### PR TITLE
fix: comprehensive JSON Schema sanitization for Claude to Gemini

### DIFF
--- a/internal/translator/gemini-cli/claude/gemini-cli_claude_request.go
+++ b/internal/translator/gemini-cli/claude/gemini-cli_claude_request.go
@@ -136,8 +136,14 @@ func ConvertClaudeRequestToCLI(modelName string, inputRawJSON []byte, _ bool) []
 			inputSchemaResult := toolResult.Get("input_schema")
 			if inputSchemaResult.Exists() && inputSchemaResult.IsObject() {
 				inputSchema := inputSchemaResult.Raw
-				inputSchema, _ = sjson.Delete(inputSchema, "additionalProperties")
-				inputSchema, _ = sjson.Delete(inputSchema, "$schema")
+				// Use comprehensive schema sanitization for Gemini API compatibility
+				if sanitizedSchema, sanitizeErr := util.SanitizeSchemaForGemini(inputSchema); sanitizeErr == nil {
+					inputSchema = sanitizedSchema
+				} else {
+					// Fallback to basic cleanup if sanitization fails
+					inputSchema, _ = sjson.Delete(inputSchema, "additionalProperties")
+					inputSchema, _ = sjson.Delete(inputSchema, "$schema")
+				}
 				tool, _ := sjson.Delete(toolResult.Raw, "input_schema")
 				tool, _ = sjson.SetRaw(tool, "parameters", inputSchema)
 				var toolDeclaration any

--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -129,8 +129,14 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 			inputSchemaResult := toolResult.Get("input_schema")
 			if inputSchemaResult.Exists() && inputSchemaResult.IsObject() {
 				inputSchema := inputSchemaResult.Raw
-				inputSchema, _ = sjson.Delete(inputSchema, "additionalProperties")
-				inputSchema, _ = sjson.Delete(inputSchema, "$schema")
+				// Use comprehensive schema sanitization for Gemini API compatibility
+				if sanitizedSchema, sanitizeErr := util.SanitizeSchemaForGemini(inputSchema); sanitizeErr == nil {
+					inputSchema = sanitizedSchema
+				} else {
+					// Fallback to basic cleanup if sanitization fails
+					inputSchema, _ = sjson.Delete(inputSchema, "additionalProperties")
+					inputSchema, _ = sjson.Delete(inputSchema, "$schema")
+				}
 				tool, _ := sjson.Delete(toolResult.Raw, "input_schema")
 				tool, _ = sjson.SetRaw(tool, "parameters", inputSchema)
 				var toolDeclaration any


### PR DESCRIPTION
## Problem
Claude Code CLI users experienced 400 "API Error: undefined is not an object (evaluating 'Z.map')" "... Proto field is not repeating, cannot start list..." errors when using tools with both Gemini CLI credentials and direct Gemini API keys due to incompatible JSON Schema fields.

## Root Cause
CLIProxyAPI has two independent translators (gemini-cli and gemini) that both used incomplete schema sanitization, only removing basic fields while ignoring:
- Union types: `"type": ["string", "boolean"]`
- Advanced validation: `allOf`, `exclusiveMinimum`, etc.
- Nested schema structures with Protocol Buffer incompatibilities

## Solution
- Added comprehensive `SanitizeSchemaForGemini()` utility function
- Fixed both translator pipelines:
  - Claude -> Gemini CLI (`internal/translator/gemini-cli/claude/`)
  - Claude -> Gemini API (`internal/translator/gemini/claude/`)
- Maintained backward compatibility with fallback

## Changes
- `internal/util/translator.go`: +107 lines of comprehensive schema sanitization
- `internal/translator/gemini-cli/claude/gemini-cli_claude_request.go`: Apply sanitization
- `internal/translator/gemini/claude/gemini_claude_request.go`: Apply sanitization

Fixes issues with Claude Code CLI tool compatibility across all Gemini access methods.