### PR TITLE
Add Cookie Snapshot and fix some bugs

### DIFF
--- a/internal/auth/claude/token.go
+++ b/internal/auth/claude/token.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/luispater/CLIProxyAPI/v5/internal/misc"
 )
 
 // ClaudeTokenStorage stores OAuth2 token information for Anthropic Claude API authentication.
@@ -46,6 +48,7 @@ type ClaudeTokenStorage struct {
 // Returns:
 //   - error: An error if the operation fails, nil otherwise
 func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
+	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "claude"
 
 	// Create directory structure if it doesn't exist

--- a/internal/auth/codex/token.go
+++ b/internal/auth/codex/token.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/luispater/CLIProxyAPI/v5/internal/misc"
 )
 
 // CodexTokenStorage stores OAuth2 token information for OpenAI Codex API authentication.
@@ -42,6 +44,7 @@ type CodexTokenStorage struct {
 // Returns:
 //   - error: An error if the operation fails, nil otherwise
 func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) error {
+	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "codex"
 	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
 		return fmt.Errorf("failed to create directory: %v", err)

--- a/internal/auth/gemini/gemini-web_token.go
+++ b/internal/auth/gemini/gemini-web_token.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/luispater/CLIProxyAPI/v5/internal/misc"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -21,6 +22,7 @@ type GeminiWebTokenStorage struct {
 
 // SaveTokenToFile serializes the Gemini Web token storage to a JSON file.
 func (ts *GeminiWebTokenStorage) SaveTokenToFile(authFilePath string) error {
+	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "gemini-web"
 	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
 		return fmt.Errorf("failed to create directory: %v", err)

--- a/internal/auth/gemini/gemini_token.go
+++ b/internal/auth/gemini/gemini_token.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/luispater/CLIProxyAPI/v5/internal/misc"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -45,6 +46,7 @@ type GeminiTokenStorage struct {
 // Returns:
 //   - error: An error if the operation fails, nil otherwise
 func (ts *GeminiTokenStorage) SaveTokenToFile(authFilePath string) error {
+	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "gemini"
 	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
 		return fmt.Errorf("failed to create directory: %v", err)

--- a/internal/auth/qwen/qwen_token.go
+++ b/internal/auth/qwen/qwen_token.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/luispater/CLIProxyAPI/v5/internal/misc"
 )
 
 // QwenTokenStorage stores OAuth2 token information for Alibaba Qwen API authentication.
@@ -40,6 +42,7 @@ type QwenTokenStorage struct {
 // Returns:
 //   - error: An error if the operation fails, nil otherwise
 func (ts *QwenTokenStorage) SaveTokenToFile(authFilePath string) error {
+	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "qwen"
 	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
 		return fmt.Errorf("failed to create directory: %v", err)

--- a/internal/client/gemini-cli_client.go
+++ b/internal/client/gemini-cli_client.go
@@ -831,7 +831,6 @@ func (c *GeminiCLIClient) GetProjectList(ctx context.Context) (*interfaces.GCPPr
 //   - error: An error if the save operation fails, nil otherwise.
 func (c *GeminiCLIClient) SaveTokenToFile() error {
 	fileName := filepath.Join(c.cfg.AuthDir, fmt.Sprintf("%s-%s.json", c.tokenStorage.(*geminiAuth.GeminiTokenStorage).Email, c.tokenStorage.(*geminiAuth.GeminiTokenStorage).ProjectID))
-	log.Infof("Saving credentials to %s", fileName)
 	return c.tokenStorage.SaveTokenToFile(fileName)
 }
 

--- a/internal/client/gemini-web_client.go
+++ b/internal/client/gemini-web_client.go
@@ -80,10 +80,9 @@ func (c *GeminiWebClient) unregisterClient(reason interfaces.UnregisterReason) {
 			util.RemoveCookieSnapshots(c.tokenFilePath)
 		}
 	case interfaces.UnregisterReasonAuthFileUpdated:
-		if c.snapshotManager != nil {
-			if err := c.snapshotManager.Persist(); err != nil {
-				log.Errorf("Failed to persist Gemini Web cookies for %s: %v", filepath.Base(c.tokenFilePath), err)
-			}
+		if c.snapshotManager != nil && c.tokenFilePath != "" {
+			log.Debugf("skipping Gemini Web snapshot flush because auth file was updated: %s", filepath.Base(c.tokenFilePath))
+			util.RemoveCookieSnapshots(c.tokenFilePath)
 		}
 	default:
 		// Flush cookie snapshot to main token file and remove snapshot

--- a/internal/client/gemini-web_client.go
+++ b/internal/client/gemini-web_client.go
@@ -842,7 +842,6 @@ func (c *GeminiWebClient) SaveTokenToFile() error {
 		}
 		return ts.SaveTokenToFile(c.tokenFilePath)
 	}
-	log.Debugf("Saving Gemini Web cookie snapshot to %s", filepath.Base(util.CookieSnapshotPath(c.tokenFilePath)))
 	return c.snapshotManager.Persist()
 }
 

--- a/internal/client/gemini-web_client.go
+++ b/internal/client/gemini-web_client.go
@@ -172,6 +172,7 @@ func NewGeminiWebClient(cfg *config.Config, ts *gemini.GeminiWebTokenStorage, to
 		go client.backgroundInitRetry()
 	} else {
 		client.cookieRotationStarted = true
+		client.registerModelsOnce()
 		// Persist immediately once after successful init to capture fresh cookies
 		_ = client.SaveTokenToFile()
 		client.startCookiePersist()

--- a/internal/client/qwen_client.go
+++ b/internal/client/qwen_client.go
@@ -525,8 +525,9 @@ func (c *QwenClient) unregisterClient(reason interfaces.UnregisterReason) {
 			util.RemoveCookieSnapshots(c.tokenFilePath)
 		}
 	case interfaces.UnregisterReasonAuthFileUpdated:
-		if err := c.snapshotManager.Persist(); err != nil {
-			log.Errorf("Failed to persist Qwen cookies for %s: %v", filepath.Base(c.tokenFilePath), err)
+		if c.tokenFilePath != "" {
+			log.Debugf("skipping Qwen snapshot flush because auth file was updated: %s", filepath.Base(c.tokenFilePath))
+			util.RemoveCookieSnapshots(c.tokenFilePath)
 		}
 	case interfaces.UnregisterReasonShutdown, interfaces.UnregisterReasonReload:
 		if err := c.snapshotManager.Flush(); err != nil {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -139,7 +139,7 @@ func StartService(cfg *config.Config, configPath string) {
 				if err = json.Unmarshal(data, &ts); err == nil {
 					// For each valid Qwen token, create an authenticated client.
 					log.Info("Initializing qwen authentication for token...")
-					qwenClient := client.NewQwenClient(cfg, &ts)
+					qwenClient := client.NewQwenClient(cfg, &ts, path)
 					log.Info("Authentication successful.")
 					cliClients[path] = qwenClient
 					successfulAuthCount++

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"io/fs"
-	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -26,7 +25,7 @@ import (
 	"github.com/luispater/CLIProxyAPI/v5/internal/client"
 	"github.com/luispater/CLIProxyAPI/v5/internal/config"
 	"github.com/luispater/CLIProxyAPI/v5/internal/interfaces"
-	"github.com/luispater/CLIProxyAPI/v5/internal/util"
+	"github.com/luispater/CLIProxyAPI/v5/internal/misc"
 	"github.com/luispater/CLIProxyAPI/v5/internal/watcher"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -75,6 +74,7 @@ func StartService(cfg *config.Config, configPath string) {
 
 		// Process only JSON files in the auth directory to load authentication tokens.
 		if !info.IsDir() && strings.HasSuffix(info.Name(), ".json") {
+			misc.LogCredentialSeparator()
 			log.Debugf("Loading token from: %s", path)
 			data, errReadFile := os.ReadFile(path)
 			if errReadFile != nil {
@@ -170,7 +170,7 @@ func StartService(cfg *config.Config, configPath string) {
 		log.Fatalf("Error walking auth directory: %v", err)
 	}
 
-	apiKeyClients, glAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, openAICompatCount := buildAPIKeyClients(cfg)
+	apiKeyClients, glAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, openAICompatCount := watcher.BuildAPIKeyClients(cfg)
 
 	totalNewClients := len(cliClients) + len(apiKeyClients)
 	log.Infof("full client load complete - %d clients (%d auth files + %d GL API keys + %d Claude API keys + %d Codex keys + %d OpenAI-compat)",
@@ -376,58 +376,4 @@ func clientsToSlice(clientMap map[string]interfaces.Client) []interfaces.Client 
 		s = append(s, v)
 	}
 	return s
-}
-
-// buildAPIKeyClients creates clients from API keys in the config
-func buildAPIKeyClients(cfg *config.Config) (map[string]interfaces.Client, int, int, int, int) {
-	apiKeyClients := make(map[string]interfaces.Client)
-	glAPIKeyCount := 0
-	claudeAPIKeyCount := 0
-	codexAPIKeyCount := 0
-	openAICompatCount := 0
-
-	if len(cfg.GlAPIKey) > 0 {
-		for _, key := range cfg.GlAPIKey {
-			httpClient := util.SetProxy(cfg, &http.Client{})
-			log.Debug("Initializing with Generative Language API Key...")
-			cliClient := client.NewGeminiClient(httpClient, cfg, key)
-			apiKeyClients[cliClient.GetClientID()] = cliClient
-			glAPIKeyCount++
-		}
-	}
-
-	if len(cfg.ClaudeKey) > 0 {
-		for i := range cfg.ClaudeKey {
-			log.Debug("Initializing with Claude API Key...")
-			cliClient := client.NewClaudeClientWithKey(cfg, i)
-			apiKeyClients[cliClient.GetClientID()] = cliClient
-			claudeAPIKeyCount++
-		}
-	}
-
-	if len(cfg.CodexKey) > 0 {
-		for i := range cfg.CodexKey {
-			log.Debug("Initializing with Codex API Key...")
-			cliClient := client.NewCodexClientWithKey(cfg, i)
-			apiKeyClients[cliClient.GetClientID()] = cliClient
-			codexAPIKeyCount++
-		}
-	}
-
-	if len(cfg.OpenAICompatibility) > 0 {
-		for _, compatConfig := range cfg.OpenAICompatibility {
-			for i := 0; i < len(compatConfig.APIKeys); i++ {
-				log.Debugf("Initializing OpenAI compatibility client for provider: %s", compatConfig.Name)
-				compatClient, errClient := client.NewOpenAICompatibilityClient(cfg, &compatConfig, i)
-				if errClient != nil {
-					log.Errorf("failed to create OpenAI compatibility client for %s: %v", compatConfig.Name, errClient)
-					continue
-				}
-				apiKeyClients[compatClient.GetClientID()] = compatClient
-				openAICompatCount++
-			}
-		}
-	}
-
-	return apiKeyClients, glAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, openAICompatCount
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -346,7 +346,12 @@ func StartService(cfg *config.Config, configPath string) {
 				for _, c := range snapshot {
 					// Persist tokens/cookies then unregister/cleanup per client.
 					_ = c.SaveTokenToFile()
-					if u, ok := any(c).(interface{ UnregisterClient() }); ok {
+					switch u := any(c).(type) {
+					case interface {
+						UnregisterClientWithReason(interfaces.UnregisterReason)
+					}:
+						u.UnregisterClientWithReason(interfaces.UnregisterReasonShutdown)
+					case interface{ UnregisterClient() }:
 						u.UnregisterClient()
 					}
 				}

--- a/internal/interfaces/client.go
+++ b/internal/interfaces/client.go
@@ -72,4 +72,6 @@ const (
 	UnregisterReasonShutdown UnregisterReason = "shutdown"
 	// UnregisterReasonAuthFileRemoved indicates the underlying auth file was deleted.
 	UnregisterReasonAuthFileRemoved UnregisterReason = "auth-file-removed"
+	// UnregisterReasonAuthFileUpdated indicates the auth file content was modified.
+	UnregisterReasonAuthFileUpdated UnregisterReason = "auth-file-updated"
 )

--- a/internal/interfaces/client.go
+++ b/internal/interfaces/client.go
@@ -61,3 +61,15 @@ type Client interface {
 	// SetUnavailable sets the client to unavailable.
 	SetUnavailable()
 }
+
+// UnregisterReason describes the context for unregistering a client instance.
+type UnregisterReason string
+
+const (
+	// UnregisterReasonReload indicates a full reload is replacing the client.
+	UnregisterReasonReload UnregisterReason = "reload"
+	// UnregisterReasonShutdown indicates the service is shutting down.
+	UnregisterReasonShutdown UnregisterReason = "shutdown"
+	// UnregisterReasonAuthFileRemoved indicates the underlying auth file was deleted.
+	UnregisterReasonAuthFileRemoved UnregisterReason = "auth-file-removed"
+)

--- a/internal/misc/credentials.go
+++ b/internal/misc/credentials.go
@@ -2,9 +2,12 @@ package misc
 
 import (
 	"path/filepath"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
+
+var credentialSeparator = strings.Repeat("-", 70)
 
 // LogSavingCredentials emits a consistent log message when persisting auth material.
 func LogSavingCredentials(path string) {
@@ -13,4 +16,9 @@ func LogSavingCredentials(path string) {
 	}
 	// Use filepath.Clean so logs remain stable even if callers pass redundant separators.
 	log.Infof("Saving credentials to %s", filepath.Clean(path))
+}
+
+// LogCredentialSeparator adds a visual separator to group auth/key processing logs.
+func LogCredentialSeparator() {
+	log.Info(credentialSeparator)
 }

--- a/internal/misc/credentials.go
+++ b/internal/misc/credentials.go
@@ -1,0 +1,16 @@
+package misc
+
+import (
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// LogSavingCredentials emits a consistent log message when persisting auth material.
+func LogSavingCredentials(path string) {
+	if path == "" {
+		return
+	}
+	// Use filepath.Clean so logs remain stable even if callers pass redundant separators.
+	log.Infof("Saving credentials to %s", filepath.Clean(path))
+}

--- a/internal/util/cookie_snapshot.go
+++ b/internal/util/cookie_snapshot.go
@@ -1,0 +1,89 @@
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CookieSnapshotPath derives the cookie snapshot file path from the main token JSON path.
+// It replaces the .json suffix with .cookies, or appends .cookies if missing.
+func CookieSnapshotPath(mainPath string) string {
+	if strings.HasSuffix(mainPath, ".json") {
+		return strings.TrimSuffix(mainPath, ".json") + ".cookies"
+	}
+	return mainPath + ".cookies"
+}
+
+// IsRegularFile reports whether the given path exists and is a regular file.
+func IsRegularFile(path string) bool {
+	if path == "" {
+		return false
+	}
+	if st, err := os.Stat(path); err == nil && !st.IsDir() {
+		return true
+	}
+	return false
+}
+
+// ReadJSON reads and unmarshals a JSON file into v.
+// Returns os.ErrNotExist if the file does not exist.
+func ReadJSON(path string, v any) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return os.ErrNotExist
+		}
+		return err
+	}
+	if len(b) == 0 {
+		return nil
+	}
+	return json.Unmarshal(b, v)
+}
+
+// WriteJSON marshals v as JSON and writes to path, creating parent directories as needed.
+func WriteJSON(path string, v any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	enc := json.NewEncoder(f)
+	return enc.Encode(v)
+}
+
+// RemoveFile removes the file if it exists.
+func RemoveFile(path string) error {
+	if IsRegularFile(path) {
+		return os.Remove(path)
+	}
+	return nil
+}
+
+// TryReadCookieSnapshotInto tries to read a cookie snapshot into v.
+// It attempts the .cookies suffix; returns (true, nil) when found and decoded,
+// or (false, nil) when none exists.
+func TryReadCookieSnapshotInto(mainPath string, v any) (bool, error) {
+	snap := CookieSnapshotPath(mainPath)
+	if err := ReadJSON(snap, v); err != nil {
+		if err == os.ErrNotExist {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// WriteCookieSnapshot writes v to the snapshot path derived from mainPath using the .cookies suffix.
+func WriteCookieSnapshot(mainPath string, v any) error {
+	return WriteJSON(CookieSnapshotPath(mainPath), v)
+}
+
+// RemoveCookieSnapshots removes both modern and legacy snapshot files.
+func RemoveCookieSnapshots(mainPath string) { _ = RemoveFile(CookieSnapshotPath(mainPath)) }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -393,7 +393,7 @@ func (w *Watcher) createClientFromFile(path string, cfg *config.Config) (interfa
 	} else if tokenType == "qwen" {
 		var ts qwen.QwenTokenStorage
 		if err = json.Unmarshal(data, &ts); err == nil {
-			return client.NewQwenClient(cfg, &ts), nil
+			return client.NewQwenClient(cfg, &ts, path), nil
 		}
 	} else if tokenType == "gemini-web" {
 		var ts gemini.GeminiWebTokenStorage

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -465,7 +465,7 @@ func (w *Watcher) addOrUpdateClient(path string) {
 		if _, canUnregister := any(oldClient).(interface{ UnregisterClient() }); canUnregister {
 			log.Debugf("unregistering old client for updated file: %s", filepath.Base(path))
 		}
-		unregisterClientWithReason(oldClient, interfaces.UnregisterReasonReload)
+		unregisterClientWithReason(oldClient, interfaces.UnregisterReasonAuthFileUpdated)
 	}
 
 	// Create new client (reads the file again internally; this is acceptable as the files are small and it keeps the change minimal)


### PR DESCRIPTION
## Core Feature: Generic Cookie Snapshot Manager

- **Centralized Snapshot Logic**: A generic `Manager` for cookie snapshots has been introduced in `internal/util/cookie_snapshot.go`. This manager centralizes the logic for applying, persisting, and flushing cookie data from a temporary snapshot file to the main token file, eliminating duplicated code that was previously in each client’s implementation.
  
- **Refactored Clients**: The `GeminiWebClient` and `QwenClient` have been updated to use this new generic manager, simplifying their internal logic for handling token persistence and refresh.

## Client and Authentication Lifecycle Improvements

- **Improved Auth File Handling**: The client lifecycle logic was refactored to better manage authentication files. This includes a fix to prevent the main authentication file from being accidentally overwritten during token updates.

- **Selective Persistence**: A “reason” was added to the client unregistration process, allowing the system to selectively skip persisting tokens to disk when a client is temporarily unregistered.

- **Centralized Logging**: Logging for credential-saving operations has been centralized, improving traceability and debugging.

## Watcher and Performance Refinements

- **Watcher Refactoring**: The creation of API key-based clients has been moved into the `watcher` package, which is responsible for monitoring auth file changes.

- **Performance Optimization**: The file watcher now filters out irrelevant file system events earlier, reducing unnecessary processing and improving overall performance.