### PR TITLE
refactor(gemini-web): Remove auto-refresh, auto-close, and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,6 @@ The server uses a YAML configuration file (`config.yaml`) located in the project
 | `gemini-web.code-mode`                  | boolean  | false              | Enables code mode for optimized responses in coding-related tasks.                                                                                                                        |
 | `gemini-web.max-chars-per-request`      | integer  | 1,000,000          | The maximum number of characters to send to Gemini Web in a single request.                                                                                                               |
 | `gemini-web.disable-continuation-hint`  | boolean  | false              | Disables the continuation hint for split prompts.                                                                                                                                         |
-| `gemini-web.token-refresh-seconds`      | integer  | 540                | The interval in seconds for background cookie auto-refresh.                                                                                                                               |
 
 ### Example Configuration File
 
@@ -337,7 +336,6 @@ gemini-web:
   context: true # Enable conversation context reuse
   code-mode: false # Enable code mode
   max-chars-per-request: 1000000 # Max characters per request
-  token-refresh-seconds: 540 # Cookie refresh interval in seconds
 
 # Request authentication providers
 auth:

--- a/README_CN.md
+++ b/README_CN.md
@@ -308,7 +308,6 @@ console.log(await claudeResponse.json());
 | `gemini-web.code-mode`                  | boolean  | false              | 是否启用代码模式，优化代码相关任务的响应。                                      |
 | `gemini-web.max-chars-per-request`      | integer  | 1,000,000          | 单次请求发送给 Gemini Web 的最大字符数。                                        |
 | `gemini-web.disable-continuation-hint`  | boolean  | false              | 当提示被拆分时，是否禁用连续提示的暗示。                                        |
-| `gemini-web.token-refresh-seconds`      | integer  | 540                | 后台 Cookie 自动刷新的间隔（秒）。                                            |
 
 ### 配置文件示例
 
@@ -349,7 +348,6 @@ gemini-web:
   context: true # 启用会话上下文重用
   code-mode: false # 启用代码模式
   max-chars-per-request: 1000000 # 单次请求最大字符数
-  token-refresh-seconds: 540 # Cookie 刷新间隔（秒）
 
 # 请求鉴权提供方
 auth:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -71,21 +71,19 @@ openai-compatibility:
         alias: "kimi-k2" # The alias used in the API.
 
 # Gemini Web settings
-# gemini-web:
-#     # Conversation reuse: set to true to enable (default), false to disable.
-#     context: true
-#     # Maximum characters per single request to Gemini Web. Requests exceeding this
-#     # size split into chunks. Only the last chunk carries files and yields the final answer.
-#     max-chars-per-request: 1000000
-#     # Disable the short continuation hint appended to intermediate chunks
-#     # when splitting long prompts. Default is false (hint enabled by default).
-#     disable-continuation-hint: false
-#     # Background token auto-refresh interval seconds (defaults to 540 if unset or <= 0)
-#     token-refresh-seconds: 540
-#     # Code mode:
-#     #   - true: enable XML wrapping hint and attach the coding-partner Gem.
-#     #           Thought merging (<think> into visible content) applies to STREAMING only;
-#     #           non-stream responses keep reasoning/thought parts separate for clients
-#     #           that expect explicit reasoning fields.
-#     #   - false: disable XML hint and keep <think> separate
-#     code-mode: false
+gemini-web:
+    # Conversation reuse: set to true to enable (default), false to disable.
+    context: true
+    # Maximum characters per single request to Gemini Web. Requests exceeding this
+    # size split into chunks. Only the last chunk carries files and yields the final answer.
+    max-chars-per-request: 1000000
+    # Disable the short continuation hint appended to intermediate chunks
+    # when splitting long prompts. Default is false (hint enabled by default).
+    disable-continuation-hint: false
+    # Code mode:
+    #   - true: enable XML wrapping hint and attach the coding-partner Gem.
+    #           Thought merging (<think> into visible content) applies to STREAMING only;
+    #           non-stream responses keep reasoning/thought parts separate for clients
+    #           that expect explicit reasoning fields.
+    #   - false: disable XML hint and keep <think> separate
+    code-mode: false

--- a/internal/auth/gemini/gemini-web_token.go
+++ b/internal/auth/gemini/gemini-web_token.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	log "github.com/sirupsen/logrus"
@@ -18,12 +19,16 @@ type GeminiWebTokenStorage struct {
 	Secure1PSID   string `json:"secure_1psid"`
 	Secure1PSIDTS string `json:"secure_1psidts"`
 	Type          string `json:"type"`
+	LastRefresh   string `json:"last_refresh,omitempty"`
 }
 
 // SaveTokenToFile serializes the Gemini Web token storage to a JSON file.
 func (ts *GeminiWebTokenStorage) SaveTokenToFile(authFilePath string) error {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "gemini-web"
+	if ts.LastRefresh == "" {
+		ts.LastRefresh = time.Now().Format(time.RFC3339)
+	}
 	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}

--- a/internal/client/gemini-web/auth.go
+++ b/internal/client/gemini-web/auth.go
@@ -151,26 +151,11 @@ func getAccessToken(baseCookies map[string]string, proxy string, verbose bool, i
 	return "", nil, &AuthError{Msg: "Failed to retrieve token."}
 }
 
-// rotate1psidts refreshes __Secure-1PSIDTS and caches it locally.
-func rotate1psidts(cookies map[string]string, proxy string, insecure bool) (string, error) {
-	psid, ok := cookies["__Secure-1PSID"]
+// rotate1PSIDTS refreshes __Secure-1PSIDTS
+func rotate1PSIDTS(cookies map[string]string, proxy string, insecure bool) (string, error) {
+	_, ok := cookies["__Secure-1PSID"]
 	if !ok {
 		return "", &AuthError{Msg: "__Secure-1PSID missing"}
-	}
-
-	cacheDir := "temp"
-	_ = os.MkdirAll(cacheDir, 0o755)
-	cacheFile := filepath.Join(cacheDir, ".cached_1psidts_"+psid+".txt")
-
-	if st, err := os.Stat(cacheFile); err == nil {
-		if time.Since(st.ModTime()) <= time.Minute {
-			if b, errReadFile := os.ReadFile(cacheFile); errReadFile == nil {
-				v := strings.TrimSpace(string(b))
-				if v != "" {
-					return v, nil
-				}
-			}
-		}
 	}
 
 	tr := &http.Transport{}
@@ -205,7 +190,6 @@ func rotate1psidts(cookies map[string]string, proxy string, insecure bool) (stri
 
 	for _, c := range resp.Cookies() {
 		if c.Name == "__Secure-1PSIDTS" {
-			_ = os.WriteFile(cacheFile, []byte(c.Value), 0o644)
 			return c.Value, nil
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,10 +120,6 @@ type GeminiWebConfig struct {
 	// DisableContinuationHint, when true, disables the continuation hint for split prompts.
 	// The hint is enabled by default.
 	DisableContinuationHint bool `yaml:"disable-continuation-hint,omitempty" json:"disable-continuation-hint,omitempty"`
-
-	// TokenRefreshSeconds controls the background cookie auto-refresh interval in seconds.
-	// When unset or <= 0, defaults to 540 seconds.
-	TokenRefreshSeconds int `yaml:"token-refresh-seconds" json:"token-refresh-seconds"`
 }
 
 // RemoteManagement holds management API configuration under 'remote-management'.

--- a/internal/runtime/executor/gemini_web_state.go
+++ b/internal/runtime/executor/gemini_web_state.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -18,15 +16,13 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/translator/translator"
-	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
 const (
-	geminiWebDefaultTimeoutSec         = 300
-	geminiWebDefaultRefreshIntervalSec = 540
+	geminiWebDefaultTimeoutSec = 300
 )
 
 type geminiWebState struct {
@@ -48,15 +44,7 @@ type geminiWebState struct {
 	convData  map[string]geminiwebapi.ConversationRecord
 	convIndex map[string]string
 
-	refreshInterval time.Duration
-	lastRefresh     time.Time
-}
-
-func (s *geminiWebState) RefreshLead() time.Duration {
-	if s.refreshInterval > 0 {
-		return s.refreshInterval
-	}
-	return 9 * time.Minute
+	lastRefresh time.Time
 }
 
 func newGeminiWebState(cfg *config.Config, token *gemini.GeminiWebTokenStorage, storagePath string) *geminiWebState {
@@ -84,11 +72,6 @@ func newGeminiWebState(cfg *config.Config, token *gemini.GeminiWebTokenStorage, 
 		state.accountID = suffix
 	}
 	state.loadConversationCaches()
-	intervalSec := geminiWebDefaultRefreshIntervalSec
-	if cfg != nil && cfg.GeminiWeb.TokenRefreshSeconds > 0 {
-		intervalSec = cfg.GeminiWeb.TokenRefreshSeconds
-	}
-	state.refreshInterval = time.Duration(intervalSec) * time.Second
 	return state
 }
 
@@ -136,15 +119,9 @@ func (s *geminiWebState) ensureClient() error {
 		s.token.Secure1PSID,
 		s.token.Secure1PSIDTS,
 		proxyURL,
-		geminiwebapi.WithOnCookiesRefreshed(s.onCookiesRefreshed),
 	)
 	timeout := geminiWebDefaultTimeoutSec
-	refresh := geminiWebDefaultRefreshIntervalSec
-	if s.cfg != nil && s.cfg.GeminiWeb.TokenRefreshSeconds > 0 {
-		refresh = s.cfg.GeminiWeb.TokenRefreshSeconds
-	}
-	// Use explicit refresh; background auto-refresh disabled here
-	if err := s.client.Init(float64(timeout), false, 300, false, float64(refresh), false); err != nil {
+	if err := s.client.Init(float64(timeout), false); err != nil {
 		s.client = nil
 		return err
 	}
@@ -162,36 +139,23 @@ func (s *geminiWebState) refresh(ctx context.Context) error {
 		s.token.Secure1PSID,
 		s.token.Secure1PSIDTS,
 		proxyURL,
-		geminiwebapi.WithOnCookiesRefreshed(s.onCookiesRefreshed),
 	)
 	timeout := geminiWebDefaultTimeoutSec
-	refresh := geminiWebDefaultRefreshIntervalSec
-	if s.cfg != nil && s.cfg.GeminiWeb.TokenRefreshSeconds > 0 {
-		refresh = s.cfg.GeminiWeb.TokenRefreshSeconds
-	}
-	// Use explicit refresh; background auto-refresh disabled here
-	if err := s.client.Init(float64(timeout), false, 300, false, float64(refresh), false); err != nil {
+	if err := s.client.Init(float64(timeout), false); err != nil {
 		return err
 	}
 	// Attempt rotation proactively to persist new TS sooner
-	_ = s.tryRotatePSIDTS(proxyURL)
+	if newTS, err := s.client.RotateTS(); err == nil && newTS != "" && newTS != s.token.Secure1PSIDTS {
+		s.tokenMu.Lock()
+		s.token.Secure1PSIDTS = newTS
+		s.tokenDirty = true
+		if s.client != nil && s.client.Cookies != nil {
+			s.client.Cookies["__Secure-1PSIDTS"] = newTS
+		}
+		s.tokenMu.Unlock()
+	}
 	s.lastRefresh = time.Now()
 	return nil
-}
-
-func (s *geminiWebState) onCookiesRefreshed() {
-	s.tokenMu.Lock()
-	defer s.tokenMu.Unlock()
-	if s.client == nil || s.client.Cookies == nil {
-		return
-	}
-	if v := s.client.Cookies["__Secure-1PSID"]; v != "" {
-		s.token.Secure1PSID = v
-	}
-	if v := s.client.Cookies["__Secure-1PSIDTS"]; v != "" {
-		s.token.Secure1PSIDTS = v
-	}
-	s.tokenDirty = true
 }
 
 func (s *geminiWebState) tokenSnapshot() *gemini.GeminiWebTokenStorage {
@@ -199,70 +163,6 @@ func (s *geminiWebState) tokenSnapshot() *gemini.GeminiWebTokenStorage {
 	defer s.tokenMu.Unlock()
 	c := *s.token
 	return &c
-}
-
-// tryRotatePSIDTS performs a best-effort rotation of __Secure-1PSIDTS using
-// the public RotateCookies endpoint. On success it updates both the in-memory
-// token and the live client's cookie jar so that subsequent requests adopt the
-// new value. Any error is ignored by the caller to avoid disrupting refresh.
-func (s *geminiWebState) tryRotatePSIDTS(proxy string) error {
-	cookies := map[string]string{
-		"__Secure-1PSID":   s.token.Secure1PSID,
-		"__Secure-1PSIDTS": s.token.Secure1PSIDTS,
-	}
-
-	tr := &http.Transport{}
-	if proxy != "" {
-		if pu, err := url.Parse(proxy); err == nil {
-			tr.Proxy = http.ProxyURL(pu)
-		}
-	}
-	client := &http.Client{Transport: tr, Timeout: 60 * time.Second}
-
-	req, _ := http.NewRequest(http.MethodPost, geminiwebapi.EndpointRotateCookies, bytes.NewReader([]byte("[000,\"-0000000000000000000\"]")))
-	for k, vs := range geminiwebapi.HeadersRotateCookies {
-		for _, v := range vs {
-			req.Header.Add(k, v)
-		}
-	}
-	for k, v := range cookies {
-		req.AddCookie(&http.Cookie{Name: k, Value: v})
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		for _, c := range resp.Cookies() {
-			if c == nil {
-				continue
-			}
-			if c.Name == "__Secure-1PSIDTS" && c.Value != "" && c.Value != s.token.Secure1PSIDTS {
-				s.tokenMu.Lock()
-				s.token.Secure1PSIDTS = c.Value
-				s.tokenDirty = true
-				if s.client != nil && s.client.Cookies != nil {
-					s.client.Cookies["__Secure-1PSIDTS"] = c.Value
-				}
-				s.tokenMu.Unlock()
-				break
-			}
-		}
-	}
-	return nil
-}
-
-func (s *geminiWebState) ShouldRefresh(now time.Time, _ *cliproxyauth.Auth) bool {
-	interval := s.refreshInterval
-	if interval <= 0 {
-		interval = time.Duration(geminiWebDefaultRefreshIntervalSec) * time.Second
-	}
-	if s.lastRefresh.IsZero() {
-		return true
-	}
-	return now.Sub(s.lastRefresh) >= interval
 }
 
 type geminiWebPrepared struct {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -461,9 +461,6 @@ func (w *Watcher) reloadConfig() bool {
 		if oldConfig.GeminiWeb.DisableContinuationHint != newConfig.GeminiWeb.DisableContinuationHint {
 			log.Debugf("  gemini-web.disable-continuation-hint: %t -> %t", oldConfig.GeminiWeb.DisableContinuationHint, newConfig.GeminiWeb.DisableContinuationHint)
 		}
-		if oldConfig.GeminiWeb.TokenRefreshSeconds != newConfig.GeminiWeb.TokenRefreshSeconds {
-			log.Debugf("  gemini-web.token-refresh-seconds: %d -> %d", oldConfig.GeminiWeb.TokenRefreshSeconds, newConfig.GeminiWeb.TokenRefreshSeconds)
-		}
 		if oldConfig.GeminiWeb.CodeMode != newConfig.GeminiWeb.CodeMode {
 			log.Debugf("  gemini-web.code-mode: %t -> %t", oldConfig.GeminiWeb.CodeMode, newConfig.GeminiWeb.CodeMode)
 		}

--- a/sdk/auth/gemini-web.go
+++ b/sdk/auth/gemini-web.go
@@ -24,6 +24,6 @@ func (a *GeminiWebAuthenticator) Login(ctx context.Context, cfg *config.Config, 
 }
 
 func (a *GeminiWebAuthenticator) RefreshLead() *time.Duration {
-	d := 9 * time.Minute
+	d := 3 * time.Hour
 	return &d
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -322,9 +322,6 @@ func (s *Service) Run(ctx context.Context) error {
 	// Prefer core auth manager auto refresh if available.
 	if s.coreManager != nil {
 		interval := 15 * time.Minute
-		if sec := s.cfg.GeminiWeb.TokenRefreshSeconds; sec > 0 {
-			interval = time.Duration(sec) * time.Second
-		}
 		s.coreManager.StartAutoRefresh(context.Background(), interval)
 		log.Infof("core auth auto-refresh started (interval=%s)", interval)
 	}


### PR DESCRIPTION
This commit simplifies the Gemini web client by removing several complex, stateful features. The previous implementation for auto-refreshing cookies and auto-closing the client involved background goroutines, timers, and file system caching, which made the client's lifecycle difficult to manage.

The following features have been removed:
- The cookie auto-refresh mechanism, including the background goroutine (`rotateCookies`) and related configuration fields.
- The file-based caching for the `__Secure-1PSIDTS` token. The `rotate1PSIDTS` function now fetches a new token on every call.
- The auto-close functionality, which used timers to close the client after a period of inactivity.
- Associated configuration options and methods (`WithAccountLabel`, `WithOnCookiesRefreshed`, `Close`, etc.).

By removing this logic, the client becomes more stateless and predictable. The responsibility for managing the client's lifecycle and handling token expiration is now shifted to the caller, leading to a simpler and more robust integration.