### PR TITLE
fix(translator): remove unsupported token limit fields for Codex Responses API

### DIFF
--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -17,6 +17,9 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 	rawJSON, _ = sjson.SetBytes(rawJSON, "store", false)
 	rawJSON, _ = sjson.SetBytes(rawJSON, "parallel_tool_calls", true)
 	rawJSON, _ = sjson.SetBytes(rawJSON, "include", []string{"reasoning.encrypted_content"})
+	// Codex Responses rejects token limit fields, so strip them out before forwarding.
+	rawJSON, _ = sjson.DeleteBytes(rawJSON, "max_output_tokens")
+	rawJSON, _ = sjson.DeleteBytes(rawJSON, "max_completion_tokens")
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "temperature")
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "top_p")
 


### PR DESCRIPTION
## Summary
- Fixes Factory CLI compatibility issue with OpenAI Codex Responses API
- Removes `max_output_tokens` and `max_completion_tokens` fields that cause "Unsupported parameter" errors
- Allows Factory CLI to work properly through CLIProxyAPI with ChatGPT Plus/Pro OAuth

## Problem
The OpenAI Codex Responses API (`chatgpt.com/backend-api/codex/responses`) rejects requests containing `max_output_tokens` and `max_completion_tokens` fields. When Factory CLI sends these parameters, it fails with:
```json
{"detail":"Unsupported parameter: max_output_tokens"}
```

## Solution
Strip these incompatible fields during request translation, similar to how `temperature` and `top_p` are already being removed.

## Test Plan
- [x] Tested with Factory CLI using custom model configuration
- [x] Verified requests successfully reach Codex API after field removal
- [x] Confirmed no impact on other translation flows
- [x] Follows existing pattern for field removal in the codebase