### PR TITLE
fix: use underscore suffix in short name mapping

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -289,7 +289,7 @@ func buildShortNameMap(names []string) map[string]string {
 		}
 		base := cand
 		for i := 1; ; i++ {
-			suffix := "~" + strconv.Itoa(i)
+			suffix := "_" + strconv.Itoa(i)
 			allowed := limit - len(suffix)
 			if allowed < 0 {
 				allowed = 0

--- a/internal/translator/codex/gemini/codex_gemini_request.go
+++ b/internal/translator/codex/gemini/codex_gemini_request.go
@@ -310,7 +310,7 @@ func buildShortNameMap(names []string) map[string]string {
 		}
 		base := cand
 		for i := 1; ; i++ {
-			suffix := "~" + strconv.Itoa(i)
+			suffix := "_" + strconv.Itoa(i)
 			allowed := limit - len(suffix)
 			if allowed < 0 {
 				allowed = 0

--- a/internal/translator/codex/openai/chat-completions/codex_openai_request.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request.go
@@ -361,7 +361,7 @@ func buildShortNameMap(names []string) map[string]string {
 		}
 		base := cand
 		for i := 1; ; i++ {
-			suffix := "~" + strconv.Itoa(i)
+			suffix := "_" + strconv.Itoa(i)
 			allowed := limit - len(suffix)
 			if allowed < 0 {
 				allowed = 0


### PR DESCRIPTION
Replace the "~<n>" suffix with "_<n>" when generating unique short names in codex translators (Claude, Gemini, OpenAI chat).
This avoids using a special character in identifiers, improving compatibility with downstream APIs while preserving length constraints.