### PR TITLE
feat(registry): add Claude Opus 4.5 model definition

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -26,7 +26,7 @@ func GetClaudeModels() []*ModelInfo {
 		{
 			ID:                  "claude-opus-4-5-20251101",
 			Object:              "model",
-			Created:             1730419200, // 2025-11-01
+			Created:             1761955200, // 2025-11-01
 			OwnedBy:             "anthropic",
 			Type:                "claude",
 			DisplayName:         "Claude 4.5 Opus",


### PR DESCRIPTION
## Summary
- Add support for `claude-opus-4-5-20251101` model (alias: `claude-opus-4-5`)
- Include full model specifications: 200K context window, 64K max output tokens

## Model Details
| Property | Value |
|----------|-------|
| Claude API ID | `claude-opus-4-5-20251101` |
| Claude API alias | `claude-opus-4-5` |
| Context window | 200K tokens |
| Max output | 64K tokens |
| Extended thinking | Yes |

## Test plan
- [x] Build succeeds (`go build ./...`)
- [x] Tests pass (`go test ./...`)
- [x] Verify model appears in `/v1/models` endpoint