### PR TITLE
feat(registry): add Claude 4.5 Opus model definition

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -24,6 +24,14 @@ func GetClaudeModels() []*ModelInfo {
 			DisplayName: "Claude 4.5 Sonnet",
 		},
 		{
+			ID:          "claude-opus-4-5-20251101",
+			Object:      "model",
+			Created:     1730505600, // 2025-11-01
+			OwnedBy:     "anthropic",
+			Type:        "claude",
+			DisplayName: "Claude 4.5 Opus",
+		},
+		{
 			ID:          "claude-opus-4-1-20250805",
 			Object:      "model",
 			Created:     1722945600, // 2025-08-05


### PR DESCRIPTION
## Summary
Adds the new Claude 4.5 Opus model to the model registry.

## Changes
- Added `claude-opus-4-5-20251101` model definition with:
  - Model ID: `claude-opus-4-5-20251101`
  - Display Name: `Claude 4.5 Opus`
  - Type: `claude`
  - Created timestamp: 2025-11-01