### PR TITLE
fix: handle tools conversion for gemini-claude-sonnet-4-5-thinking model

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -683,7 +683,7 @@ func geminiToAntigravity(modelName string, payload []byte) []byte {
 		}
 	}
 
-	if strings.HasPrefix(modelName, "claude-sonnet-") {
+	if strings.HasPrefix(modelName, "claude-sonnet-") || modelName == "claude-sonnet-4-5-thinking" {
 		gjson.Get(template, "request.tools").ForEach(func(key, tool gjson.Result) bool {
 			tool.Get("functionDeclarations").ForEach(func(funKey, funcDecl gjson.Result) bool {
 				if funcDecl.Get("parametersJsonSchema").Exists() {


### PR DESCRIPTION
The gemini-claude-sonnet-4-5-thinking model was not being properly processed
for tools conversion from Claude format (parametersJsonSchema) to Gemini format
(parameters), causing "input_schema: Field required" errors.

The model name 'claude-sonnet-4-5-thinking' does not match the prefix check
'strings.HasPrefix(modelName, "claude-sonnet-")', so the tools conversion
logic was never executed.

This fix adds an explicit check for the 'claude-sonnet-4-5-thinking' model
name to ensure tools are properly converted before sending to the antigravity
backend.

Fixes input_schema validation errors when using gemini-claude-sonnet-4-5-thinking
model with function calling enabled.