### PR TITLE
fix(translator): add xhigh reasoning_effort support for Codex Max models

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -202,6 +202,8 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			out, _ = sjson.Set(out, "reasoning_effort", "medium")
 		case "high":
 			out, _ = sjson.Set(out, "reasoning_effort", "high")
+		case "xhigh":
+			out, _ = sjson.Set(out, "reasoning_effort", "xhigh")
 		default:
 			out, _ = sjson.Set(out, "reasoning_effort", "auto")
 		}


### PR DESCRIPTION
https://github.com/nestharus/CLIProxyAPI/pull/new/fix/xhigh-reasoning-effort

  PR details:
  - Base: dev
  - Title: fix(translator): add xhigh reasoning_effort support for Codex Max models
  - Body:
  ## Summary
  - Adds missing `xhigh` case to the reasoning effort switch statement in the OpenAI responses translator
  - Previously, `xhigh` fell through to default and was incorrectly mapped to `"auto"`
  - Only Codex Max models (`gpt-5.1-codex-max-xhigh`) support this reasoning effort level

  Fixes #354

  ## Test plan
  - [ ] Verify requests with `reasoning.effort: "xhigh"` are correctly translated to `reasoning_effort:
  "xhigh"