### PR TITLE
fix(translator): handle non-JSON output gracefully in function call r…

### DIFF
--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -271,7 +271,15 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 								if resp == "" {
 									resp = "{}"
 								}
-								toolNode, _ = sjson.SetBytes(toolNode, "parts."+itoa(pp)+".functionResponse.response.result", []byte(resp))
+								// Handle non-JSON output gracefully (matches dev branch approach)
+								if resp != "" && resp != "null" {
+									parsed := gjson.Parse(resp)
+									if parsed.Type == gjson.JSON {
+										toolNode, _ = sjson.SetRawBytes(toolNode, "parts."+itoa(pp)+".functionResponse.response.result", []byte(parsed.Raw))
+									} else {
+										toolNode, _ = sjson.SetBytes(toolNode, "parts."+itoa(pp)+".functionResponse.response.result", resp)
+									}
+								}
 								pp++
 							}
 						}

--- a/internal/translator/gemini-cli/openai/chat-completions/gemini-cli_openai_request.go
+++ b/internal/translator/gemini-cli/openai/chat-completions/gemini-cli_openai_request.go
@@ -271,7 +271,15 @@ func ConvertOpenAIRequestToGeminiCLI(modelName string, inputRawJSON []byte, _ bo
 								if resp == "" {
 									resp = "{}"
 								}
-								toolNode, _ = sjson.SetBytes(toolNode, "parts."+itoa(pp)+".functionResponse.response.result", []byte(resp))
+								// Handle non-JSON output gracefully (matches dev branch approach)
+								if resp != "" && resp != "null" {
+									parsed := gjson.Parse(resp)
+									if parsed.Type == gjson.JSON {
+										toolNode, _ = sjson.SetRawBytes(toolNode, "parts."+itoa(pp)+".functionResponse.response.result", []byte(parsed.Raw))
+									} else {
+										toolNode, _ = sjson.SetBytes(toolNode, "parts."+itoa(pp)+".functionResponse.response.result", resp)
+									}
+								}
 								pp++
 							}
 						}


### PR DESCRIPTION
- Parse function response output to detect JSON vs plain text
- Use SetRawBytes for valid JSON to preserve structure
- Use SetBytes for non-JSON to properly escape as string
- Prevents double-encoding of JSON responses