### PR TITLE
fix(amp): add /threads.rss root-level route for AMP CLI

### DIFF
--- a/internal/api/modules/amp/routes.go
+++ b/internal/api/modules/amp/routes.go
@@ -111,6 +111,14 @@ func (m *AmpModule) registerManagementRoutes(engine *gin.Engine, baseHandler *ha
 	ampAPI.Any("/otel", proxyHandler)
 	ampAPI.Any("/otel/*path", proxyHandler)
 
+	// Root-level routes that AMP CLI expects without /api prefix
+	// These need the same security middleware as the /api/* routes
+	rootMiddleware := []gin.HandlerFunc{noCORSMiddleware()}
+	if restrictToLocalhost {
+		rootMiddleware = append(rootMiddleware, localhostOnlyMiddleware())
+	}
+	engine.GET("/threads.rss", append(rootMiddleware, proxyHandler)...)
+
 	// Google v1beta1 passthrough with OAuth fallback
 	// AMP CLI uses non-standard paths like /publishers/google/models/...
 	// We bridge these to our standard Gemini handler to enable local OAuth.

--- a/internal/api/modules/amp/routes_test.go
+++ b/internal/api/modules/amp/routes_test.go
@@ -37,6 +37,7 @@ func TestRegisterManagementRoutes(t *testing.T) {
 		{"/api/meta", http.MethodGet},
 		{"/api/telemetry", http.MethodGet},
 		{"/api/threads", http.MethodGet},
+		{"/threads.rss", http.MethodGet}, // Root-level route (no /api prefix)
 		{"/api/otel", http.MethodGet},
 		// Google v1beta1 bridge should still proxy non-model requests (GET) and allow POST
 		{"/api/provider/google/v1beta1/models", http.MethodGet},


### PR DESCRIPTION
### Problem

During AMP CLI startup, the proxy server returns a 404 error for `/threads.rss`:

```
[GIN] 2025/11/29 - 04:20:44 | 404 |            0s |             ::1 | GET     "/threads.rss"
```

The AMP CLI requests `/threads.rss` directly at the root level, but the AMP module only registers thread-related routes under `/api/*`:
- `/api/threads`
- `/api/threads/*path`

Issue noted when investigating/testing Issue #370 

### Solution

Add a root-level route for `/threads.rss` that proxies to the AMP upstream, using the same security middleware as other management routes:
- `noCORSMiddleware()` - always applied
- `localhostOnlyMiddleware()` - applied when `amp-restrict-management-to-localhost: true`

### Changes

- `internal/api/modules/amp/routes.go`: Added `/threads.rss` GET route with appropriate middleware

### Testing

Verified the fix by starting the AMP CLI client - the 404 error is no longer present and requests to `/threads.rss` are properly proxied to the AMP upstream.