### PR TITLE
feat(util): add -reasoning suffix support for Gemini models

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
@@ -58,6 +59,20 @@ func (e *AntigravityExecutor) Identifier() string { return antigravityAuthType }
 // PrepareRequest implements ProviderExecutor.
 func (e *AntigravityExecutor) PrepareRequest(_ *http.Request, _ *cliproxyauth.Auth) error { return nil }
 
+// applyThinkingMetadata applies thinking config from model suffix metadata (e.g., -reasoning, -thinking-N).
+// It trusts user intent when suffix is used, even if registry doesn't have Thinking metadata.
+func applyThinkingMetadata(translated []byte, metadata map[string]any, model string) []byte {
+	budgetOverride, includeOverride, ok := util.GeminiThinkingFromMetadata(metadata)
+	if !ok {
+		return translated
+	}
+	if budgetOverride != nil && util.ModelSupportsThinking(model) {
+		norm := util.NormalizeThinkingBudget(model, *budgetOverride)
+		budgetOverride = &norm
+	}
+	return util.ApplyGeminiCLIThinkingConfig(translated, budgetOverride, includeOverride)
+}
+
 // Execute handles non-streaming requests via the antigravity generate endpoint.
 func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	token, updatedAuth, errToken := e.ensureAccessToken(ctx, auth)
@@ -74,6 +89,8 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("antigravity")
 	translated := sdktranslator.TranslateRequest(from, to, req.Model, bytes.Clone(req.Payload), false)
+
+	translated = applyThinkingMetadata(translated, req.Metadata, req.Model)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
@@ -165,6 +182,8 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("antigravity")
 	translated := sdktranslator.TranslateRequest(from, to, req.Model, bytes.Clone(req.Payload), true)
+
+	translated = applyThinkingMetadata(translated, req.Metadata, req.Model)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0)

--- a/internal/util/gemini_thinking.go
+++ b/internal/util/gemini_thinking.go
@@ -34,6 +34,15 @@ func ParseGeminiThinkingSuffix(model string) (string, *int, *bool, bool) {
 		return base, &budgetValue, &include, true
 	}
 
+	// Handle "-reasoning" suffix: enables thinking with dynamic budget (-1)
+	// Maps: gemini-2.5-flash-reasoning -> gemini-2.5-flash with thinkingBudget=-1
+	if strings.HasSuffix(lower, "-reasoning") {
+		base := model[:len(model)-len("-reasoning")]
+		budgetValue := -1 // Dynamic budget
+		include := true
+		return base, &budgetValue, &include, true
+	}
+
 	idx := strings.LastIndex(lower, "-thinking-")
 	if idx == -1 {
 		return model, nil, nil, false


### PR DESCRIPTION
### Summary

Adds `-reasoning` suffix support for Gemini models, enabling thinking mode with dynamic budget.

### Problem

There's no easy way to enable Gemini's reasoning mode via model name. We have `-nothinking` and `-thinking-N`, but nothing for "just turn on reasoning and let the model decide the budget."

### Solution

1. **gemini_thinking.go**: Parse `-reasoning` suffix
   - `gemini-2.5-flash-reasoning` -> `gemini-2.5-flash` with `thinkingBudget=-1` and `include_thoughts=true`

2. **antigravity_executor.go**: Read and apply the thinking config from metadata
   - Same pattern used by gemini and gemini-cli executors

### Changes

- `internal/util/gemini_thinking.go`: +9 lines
- `internal/runtime/executor/antigravity_executor.go`: +21 lines

### Testing

Tested with REST calls against a local instance:

| Test | Model | Result |
|------|-------|--------|
| New suffix | `gemini-2.5-flash-reasoning` | `reasoning_content` visible |
| Variant | `gemini-2.5-flash-lite-reasoning` | `reasoning_content` visible |
| Base model | `gemini-2.5-flash` | Works as before |
| Existing suffix | `gemini-2.5-flash-nothinking` | Still works |
| Body param | `reasoning_effort: "high"` | Still works |
| Unit tests | `go test ./...` | All pass |
| Build | `go build ./...` | Clean |