### PR TITLE
refactor(executor): dedupe thinking metadata helpers across Gemini executors

### DIFF
--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -308,13 +308,7 @@ func (e *AIStudioExecutor) translateRequest(req cliproxyexecutor.Request, opts c
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("gemini")
 	payload := sdktranslator.TranslateRequest(from, to, req.Model, bytes.Clone(req.Payload), stream)
-	if budgetOverride, includeOverride, ok := util.GeminiThinkingFromMetadata(req.Metadata); ok && util.ModelSupportsThinking(req.Model) {
-		if budgetOverride != nil {
-			norm := util.NormalizeThinkingBudget(req.Model, *budgetOverride)
-			budgetOverride = &norm
-		}
-		payload = util.ApplyGeminiThinkingConfig(payload, budgetOverride, includeOverride)
-	}
+	payload = applyThinkingMetadata(payload, req.Metadata, req.Model)
 	payload = util.ConvertThinkingLevelToBudget(payload)
 	payload = util.StripThinkingConfigIfUnsupported(req.Model, payload)
 	payload = fixGeminiImageAspectRatio(req.Model, payload)

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -79,13 +79,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("gemini")
 	body := sdktranslator.TranslateRequest(from, to, req.Model, bytes.Clone(req.Payload), false)
-	if budgetOverride, includeOverride, ok := util.GeminiThinkingFromMetadata(req.Metadata); ok && util.ModelSupportsThinking(req.Model) {
-		if budgetOverride != nil {
-			norm := util.NormalizeThinkingBudget(req.Model, *budgetOverride)
-			budgetOverride = &norm
-		}
-		body = util.ApplyGeminiThinkingConfig(body, budgetOverride, includeOverride)
-	}
+	body = applyThinkingMetadata(body, req.Metadata, req.Model)
 	body = util.StripThinkingConfigIfUnsupported(req.Model, body)
 	body = fixGeminiImageAspectRatio(req.Model, body)
 	body = applyPayloadConfig(e.cfg, req.Model, body)
@@ -174,13 +168,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("gemini")
 	body := sdktranslator.TranslateRequest(from, to, req.Model, bytes.Clone(req.Payload), true)
-	if budgetOverride, includeOverride, ok := util.GeminiThinkingFromMetadata(req.Metadata); ok && util.ModelSupportsThinking(req.Model) {
-		if budgetOverride != nil {
-			norm := util.NormalizeThinkingBudget(req.Model, *budgetOverride)
-			budgetOverride = &norm
-		}
-		body = util.ApplyGeminiThinkingConfig(body, budgetOverride, includeOverride)
-	}
+	body = applyThinkingMetadata(body, req.Metadata, req.Model)
 	body = util.StripThinkingConfigIfUnsupported(req.Model, body)
 	body = fixGeminiImageAspectRatio(req.Model, body)
 	body = applyPayloadConfig(e.cfg, req.Model, body)
@@ -288,13 +276,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("gemini")
 	translatedReq := sdktranslator.TranslateRequest(from, to, req.Model, bytes.Clone(req.Payload), false)
-	if budgetOverride, includeOverride, ok := util.GeminiThinkingFromMetadata(req.Metadata); ok && util.ModelSupportsThinking(req.Model) {
-		if budgetOverride != nil {
-			norm := util.NormalizeThinkingBudget(req.Model, *budgetOverride)
-			budgetOverride = &norm
-		}
-		translatedReq = util.ApplyGeminiThinkingConfig(translatedReq, budgetOverride, includeOverride)
-	}
+	translatedReq = applyThinkingMetadata(translatedReq, req.Metadata, req.Model)
 	translatedReq = util.StripThinkingConfigIfUnsupported(req.Model, translatedReq)
 	translatedReq = fixGeminiImageAspectRatio(req.Model, translatedReq)
 	respCtx := context.WithValue(ctx, "alt", opts.Alt)

--- a/internal/runtime/executor/payload_helpers.go
+++ b/internal/runtime/executor/payload_helpers.go
@@ -4,9 +4,41 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+// applyThinkingMetadata applies thinking config from model suffix metadata (e.g., -reasoning, -thinking-N)
+// for standard Gemini format payloads. It normalizes the budget when the model supports thinking.
+func applyThinkingMetadata(payload []byte, metadata map[string]any, model string) []byte {
+	budgetOverride, includeOverride, ok := util.GeminiThinkingFromMetadata(metadata)
+	if !ok {
+		return payload
+	}
+	if !util.ModelSupportsThinking(model) {
+		return payload
+	}
+	if budgetOverride != nil {
+		norm := util.NormalizeThinkingBudget(model, *budgetOverride)
+		budgetOverride = &norm
+	}
+	return util.ApplyGeminiThinkingConfig(payload, budgetOverride, includeOverride)
+}
+
+// applyThinkingMetadataCLI applies thinking config from model suffix metadata (e.g., -reasoning, -thinking-N)
+// for Gemini CLI format payloads (nested under "request"). It normalizes the budget when the model supports thinking.
+func applyThinkingMetadataCLI(payload []byte, metadata map[string]any, model string) []byte {
+	budgetOverride, includeOverride, ok := util.GeminiThinkingFromMetadata(metadata)
+	if !ok {
+		return payload
+	}
+	if budgetOverride != nil && util.ModelSupportsThinking(model) {
+		norm := util.NormalizeThinkingBudget(model, *budgetOverride)
+		budgetOverride = &norm
+	}
+	return util.ApplyGeminiCLIThinkingConfig(payload, budgetOverride, includeOverride)
+}
 
 // applyPayloadConfig applies payload default and override rules from configuration
 // to the given JSON payload for the specified model.


### PR DESCRIPTION
Follow-up to #376 addressing the [code review feedback](https://github.com/router-for-me/CLIProxyAPI/pull/376#pullrequestreview-3521172882) from gemini-code-assist about duplicated thinking config logic.

Extracts `applyThinkingMetadata` and `applyThinkingMetadataCLI` helpers to `payload_helpers.go` and uses them across all four Gemini-based executors. Net reduction of ~28 lines.

| Executor | Helper | Methods |
|----------|--------|---------|
| gemini | `applyThinkingMetadata` | Execute, ExecuteStream, CountTokens |
| gemini-cli | `applyThinkingMetadataCLI` | Execute, ExecuteStream, CountTokens |
| aistudio | `applyThinkingMetadata` | translateRequest |
| antigravity | `applyThinkingMetadataCLI` | Execute, ExecuteStream |

Tested manually - `-reasoning` and `-thinking-N` suffixes work across all executors.