### PR TITLE
fix: prioritize model mappings over local providers for Amp CLI

### DIFF
--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -241,3 +241,11 @@ func (h *Handler) DeleteProxyURL(c *gin.Context) {
 	h.cfg.ProxyURL = ""
 	h.persist(c)
 }
+
+// Prioritize Model Mappings (for Amp CLI)
+func (h *Handler) GetPrioritizeModelMappings(c *gin.Context) {
+	c.JSON(200, gin.H{"prioritize-model-mappings": h.cfg.AmpCode.PrioritizeModelMappings})
+}
+func (h *Handler) PutPrioritizeModelMappings(c *gin.Context) {
+	h.updateBoolField(c, func(v bool) { h.cfg.AmpCode.PrioritizeModelMappings = v })
+}

--- a/internal/api/modules/amp/amp.go
+++ b/internal/api/modules/amp/amp.go
@@ -100,6 +100,16 @@ func (m *AmpModule) Name() string {
 	return "amp-routing"
 }
 
+// getPrioritizeModelMappings returns whether model mappings should take precedence over local API keys
+func (m *AmpModule) getPrioritizeModelMappings() bool {
+	m.configMu.RLock()
+	defer m.configMu.RUnlock()
+	if m.lastConfig == nil {
+		return false
+	}
+	return m.lastConfig.PrioritizeModelMappings
+}
+
 // Register sets up Amp routes if configured.
 // This implements the RouteModuleV2 interface with Context.
 // Routes are registered only once via sync.Once for idempotent behavior.

--- a/internal/api/modules/amp/routes.go
+++ b/internal/api/modules/amp/routes.go
@@ -171,7 +171,7 @@ func (m *AmpModule) registerManagementRoutes(engine *gin.Engine, baseHandler *ha
 	geminiBridge := createGeminiBridgeHandler(geminiHandlers.GeminiHandler)
 	geminiV1Beta1Fallback := NewFallbackHandlerWithMapper(func() *httputil.ReverseProxy {
 		return m.getProxy()
-	}, m.modelMapper)
+	}, m.modelMapper, m.getPrioritizeModelMappings)
 	geminiV1Beta1Handler := geminiV1Beta1Fallback.WrapHandler(geminiBridge)
 
 	// Route POST model calls through Gemini bridge with FallbackHandler.
@@ -209,7 +209,7 @@ func (m *AmpModule) registerProviderAliases(engine *gin.Engine, baseHandler *han
 	// Also includes model mapping support for routing unavailable models to alternatives
 	fallbackHandler := NewFallbackHandlerWithMapper(func() *httputil.ReverseProxy {
 		return m.getProxy()
-	}, m.modelMapper)
+	}, m.modelMapper, m.getPrioritizeModelMappings)
 
 	// Provider-specific routes under /api/provider/:provider
 	ampProviders := engine.Group("/api/provider")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -520,6 +520,10 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PUT("/ws-auth", s.mgmt.PutWebsocketAuth)
 		mgmt.PATCH("/ws-auth", s.mgmt.PutWebsocketAuth)
 
+		mgmt.GET("/prioritize-model-mappings", s.mgmt.GetPrioritizeModelMappings)
+		mgmt.PUT("/prioritize-model-mappings", s.mgmt.PutPrioritizeModelMappings)
+		mgmt.PATCH("/prioritize-model-mappings", s.mgmt.PutPrioritizeModelMappings)
+
 		mgmt.GET("/request-retry", s.mgmt.GetRequestRetry)
 		mgmt.PUT("/request-retry", s.mgmt.PutRequestRetry)
 		mgmt.PATCH("/request-retry", s.mgmt.PutRequestRetry)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,6 +143,10 @@ type AmpCode struct {
 	// When Amp requests a model that isn't available locally, these mappings
 	// allow routing to an alternative model that IS available.
 	ModelMappings []AmpModelMapping `yaml:"model-mappings" json:"model-mappings"`
+
+	// PrioritizeModelMappings when true, model mappings take precedence over local API keys.
+	// When false (default), local API keys are used first if available.
+	PrioritizeModelMappings bool `yaml:"prioritize-model-mappings" json:"prioritize-model-mappings"`
 }
 
 // PayloadConfig defines default and override parameter rules applied to provider payloads.


### PR DESCRIPTION
## Summary
- Model mappings now take precedence over local API keys when routing Amp CLI requests
- This allows users to route requests (e.g., `claude-opus-4-5`) to their preferred target models (e.g., `gemini-claude-opus-4-5-thinking`) via OAuth, even when local API keys are configured

## Problem
Previously, if a user had a local Anthropic API key configured, Amp CLI requests for models like `claude-opus-4-5-20251101` would bypass model mappings and go directly to Anthropic. Users couldn't override this behavior to use their preferred OAuth-based providers.

## Solution
Changed the routing priority in `fallback_handlers.go`:
1. **Before**: Check local providers first → model mappings only if no local provider
2. **After**: Check model mappings first → local providers as fallback

This gives users full control over request routing through their configured model mappings.