### PR TITLE
fix(antigravity): auto-enable thinking for Claude models when no config sent

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -190,7 +190,7 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 			out, _ = sjson.Set(out, "request.generationConfig.thinkingConfig.include_thoughts", true)
 		}
 		// type=="disabled" or other: respect explicit config
-	} else if !hasThinkingField && util.ModelSupportsThinking(modelName) {
+	} else if !t.Exists() && util.ModelSupportsThinking(modelName) {
 		// Auto-enable thinking when NO explicit thinking field was sent
 		budget := util.NormalizeThinkingBudget(modelName, defaultClaudeThinkingBudget)
 		out, _ = sjson.Set(out, "request.generationConfig.thinkingConfig.thinkingBudget", budget)


### PR DESCRIPTION
### Problem
Clients like OpenCode CLI don't send the `thinking` field in API requests even when configured for thinking models. This causes thinking blocks to not display, even though the model supports thinking.

### Solution
Auto-enable thinking for Claude models when:
- No explicit `thinking` field is present in the request
- The model has `ThinkingSupport` metadata in the registry

Uses dynamic budget (`-1`) as default, letting the backend decide the appropriate thinking budget.

### Changes
- Extract `t` and `hasThinkingField` to check for explicit thinking config
- Auto-enable thinking with dynamic budget when no config is sent
- Handle `type: "enabled"` with or without `budget_tokens`
- Respect explicit `type: "disabled"` (no override)
- Normalize all budgets through registry helper

### Testing
- Verified with OpenCode CLI (uses `@ai-sdk/anthropic`) - thinking blocks now display correctly
- Build passes: `go build ./...`

### Breaking Changes
None. This is additive behavior for clients that don't send thinking config.
