### PR TITLE
fix(translator): preserve tool_use blocks on args parse failure

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -13,6 +13,7 @@ import (
 	client "github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/translator/gemini/common"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -105,20 +106,19 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 							functionArgs = functionArgsResult.String()
 						}
 						if err := json.Unmarshal([]byte(functionArgs), &args); err != nil {
+							log.Warnf("failed to unmarshal tool_use input args: %v", err)
 							// Preserve tool_use block with empty args on parse failure
 							// to maintain tool_use/tool_result pairing required by Claude API
 							args = make(map[string]any)
 						}
-						if strings.Contains(modelName, "claude") {
-							clientContent.Parts = append(clientContent.Parts, client.Part{
-								FunctionCall: &client.FunctionCall{ID: functionID, Name: functionName, Args: args},
-							})
-						} else {
-							clientContent.Parts = append(clientContent.Parts, client.Part{
-								FunctionCall:     &client.FunctionCall{ID: functionID, Name: functionName, Args: args},
-								ThoughtSignature: geminiCLIClaudeThoughtSignature,
-							})
+						part := client.Part{
+							FunctionCall: &client.FunctionCall{ID: functionID, Name: functionName, Args: args},
 						}
+						if !strings.Contains(modelName, "claude") {
+							part.ThoughtSignature = geminiCLIClaudeThoughtSignature
+						}
+						clientContent.Parts = append(clientContent.Parts, part)
+
 					} else if contentTypeResult.Type == gjson.String && contentTypeResult.String() == "tool_result" {
 						toolCallID := contentResult.Get("tool_use_id").String()
 						if toolCallID != "" {

--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -13,6 +13,7 @@ import (
 	client "github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/translator/gemini/common"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -89,10 +90,12 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 							functionArgs = functionArgsResult.String()
 						}
 						if err := json.Unmarshal([]byte(functionArgs), &args); err != nil {
+							log.Warnf("failed to unmarshal tool_use input args: %v", err)
 							// Preserve tool_use block with empty args on parse failure
 							// to maintain tool_use/tool_result pairing required by Claude API
 							args = make(map[string]any)
 						}
+
 						clientContent.Parts = append(clientContent.Parts, client.Part{
 							FunctionCall:     &client.FunctionCall{Name: functionName, Args: args},
 							ThoughtSignature: geminiClaudeThoughtSignature,


### PR DESCRIPTION
## Summary
- Fix silent dropping of `tool_use` blocks when JSON unmarshaling of input args fails
- Initialize empty args map on parse failure instead of discarding the block

## Problem
When `json.Unmarshal` failed on tool_use input arguments, the entire `tool_use` block was silently dropped. This broke the required tool_use/tool_result pairing, causing Claude API errors:
```
tool_use ids were found without tool_result blocks immediately after: toolu_xxx
```

## Solution
Changed from `if err == nil { append }` to `if err != nil { args = empty }; append` to always preserve the tool_use block.

## Files Changed
- `internal/translator/antigravity/claude/antigravity_claude_request.go`
- `internal/translator/gemini/claude/gemini_claude_request.go`