### PR TITLE
fix(models): add "none" reasoning effort level to gpt-5.2

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -580,7 +580,7 @@ func GetOpenAIModels() []*ModelInfo {
 			ContextLength:       400000,
 			MaxCompletionTokens: 128000,
 			SupportedParameters: []string{"tools"},
-			Thinking:            &ThinkingSupport{Levels: []string{"low", "medium", "high", "xhigh"}},
+			Thinking:            &ThinkingSupport{Levels: []string{"none", "low", "medium", "high", "xhigh"}},
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- Adds missing `"none"` reasoning effort level to the gpt-5.2 model definition

## Details

Per the [OpenAI API documentation](https://platform.openai.com/docs/api-reference/chat/create#chat_create-reasoning_effort):

> gpt-5.1 defaults to none, which does not perform reasoning. The supported reasoning values for gpt-5.1 are none, low, medium, and high.
> xhigh is supported for all models after gpt-5.1-codex-max.

This indicates gpt-5.2 should support: `none`, `low`, `medium`, `high`, `xhigh`.

Cross-referenced with the codex CLI source to confirm:
- gpt-5.1-codex, gpt-5.1-codex-mini, and gpt-5.1-codex-max do **not** support `"none"` (left unchanged)
- Only gpt-5.2 needed this addition