### PR TITLE
fix(claude): flush Claude SSE chunks immediately

### DIFF
--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -250,10 +250,7 @@ func (h *ClaudeCodeAPIHandler) forwardClaudeStream(c *gin.Context, flusher http.
 
 				// An error occurred: emit as a proper SSE error event
 				errorBytes, _ := json.Marshal(h.toClaudeError(errMsg))
-				_, _ = c.Writer.Write([]byte("event: error\n"))
-				_, _ = c.Writer.Write([]byte("data: "))
-				_, _ = c.Writer.Write(errorBytes)
-				_, _ = c.Writer.Write([]byte("\n\n"))
+				_, _ = fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", errorBytes)
 				flusher.Flush()
 			}
 


### PR DESCRIPTION
- Write each SSE chunk directly to c.Writer and flush immediately
- Remove buffered writer and ticker-based flushing that failed to stream SSE and only sent at the end of the response
- 500ms timeout case for consistency with OpenAI/Gemini handlers
- Matches OpenAI behavior

Fixes #460 .

Tested with Antigravity Oauth with AmpCode CLI.