### PR TITLE
fix(openai-compat): prevent model alias from being overwritten

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -54,13 +54,14 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("openai")
 	translated := sdktranslator.TranslateRequest(from, to, req.Model, bytes.Clone(req.Payload), opts.Stream)
-	if modelOverride := e.resolveUpstreamModel(req.Model, auth); modelOverride != "" {
+	modelOverride := e.resolveUpstreamModel(req.Model, auth)
+	if modelOverride != "" {
 		translated = e.overrideModel(translated, modelOverride)
 	}
 	translated = applyPayloadConfigWithRoot(e.cfg, req.Model, to.String(), "", translated)
 	translated = applyReasoningEffortMetadata(translated, req.Metadata, req.Model, "reasoning_effort")
 	upstreamModel := util.ResolveOriginalModel(req.Model, req.Metadata)
-	if upstreamModel != "" {
+	if upstreamModel != "" && modelOverride == "" {
 		translated, _ = sjson.SetBytes(translated, "model", upstreamModel)
 	}
 	translated = normalizeThinkingConfig(translated, upstreamModel)
@@ -148,13 +149,14 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("openai")
 	translated := sdktranslator.TranslateRequest(from, to, req.Model, bytes.Clone(req.Payload), true)
-	if modelOverride := e.resolveUpstreamModel(req.Model, auth); modelOverride != "" {
+	modelOverride := e.resolveUpstreamModel(req.Model, auth)
+	if modelOverride != "" {
 		translated = e.overrideModel(translated, modelOverride)
 	}
 	translated = applyPayloadConfigWithRoot(e.cfg, req.Model, to.String(), "", translated)
 	translated = applyReasoningEffortMetadata(translated, req.Metadata, req.Model, "reasoning_effort")
 	upstreamModel := util.ResolveOriginalModel(req.Model, req.Metadata)
-	if upstreamModel != "" {
+	if upstreamModel != "" && modelOverride == "" {
 		translated, _ = sjson.SetBytes(translated, "model", upstreamModel)
 	}
 	translated = normalizeThinkingConfig(translated, upstreamModel)


### PR DESCRIPTION
## Problem

When using OpenAI-compatible providers with model aliases, requests fail with "Unknown Model" error from the upstream API.

## Root Cause

In openai_compat_executor.go, the model alias was correctly resolved (e.g., glm-4.6-zai → glm-4.6) but then immediately overwritten by ResolveOriginalModel() back to the alias name.

## Fix

The issue was that `ResolveOriginalModel()` was unconditionally overwriting the model name, even when an alias had already been resolved. 

The fix adds a simple guard: only apply the `ResolveOriginalModel` override if no alias resolution (`modelOverride`) was performed:

```diff
- if upstreamModel != "" {
+ if upstreamModel != "" && modelOverride == "" {
```

This ensures the alias-resolved model name is preserved and sent to the upstream API correctly.

Applied to both Execute() and ExecuteStream() methods.

## Testing

- Build passes
- go vet passes
- Verified with OpenAI-compatible provider using model alias configuration