### PR TITLE
feat(auth): add per-auth use_global_proxy configuration

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1565,8 +1565,8 @@ func (h *Handler) RequestQwenToken(c *gin.Context) {
 			return
 		}
 
-		// Create token storage
-		tokenStorage := qwenAuth.CreateTokenStorage(tokenData)
+		// Create token storage - default to false for use_global_proxy for qwen
+		tokenStorage := qwenAuth.CreateTokenStorage(tokenData, false)
 
 		tokenStorage.Email = fmt.Sprintf("qwen-%d", time.Now().UnixMilli())
 		record := &coreauth.Auth{
@@ -1742,7 +1742,8 @@ func (h *Handler) RequestIFlowCookieToken(c *gin.Context) {
 
 	tokenData.Cookie = cookieValue
 
-	tokenStorage := authSvc.CreateCookieTokenStorage(tokenData)
+	// For management API, default to false for use_global_proxy for iFlow
+	tokenStorage := authSvc.CreateCookieTokenStorage(tokenData, false)
 	email := strings.TrimSpace(tokenStorage.Email)
 	if email == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "failed to extract email from token"})

--- a/internal/auth/iflow/iflow_auth.go
+++ b/internal/auth/iflow/iflow_auth.go
@@ -489,7 +489,7 @@ func ShouldRefreshAPIKey(expireTime string) (bool, time.Duration, error) {
 }
 
 // CreateCookieTokenStorage converts cookie-based token data into persistence storage
-func (ia *IFlowAuth) CreateCookieTokenStorage(data *IFlowTokenData) *IFlowTokenStorage {
+func (ia *IFlowAuth) CreateCookieTokenStorage(data *IFlowTokenData, useGlobalProxy bool) *IFlowTokenStorage {
 	if data == nil {
 		return nil
 	}
@@ -502,12 +502,13 @@ func (ia *IFlowAuth) CreateCookieTokenStorage(data *IFlowTokenData) *IFlowTokenS
 	}
 
 	return &IFlowTokenStorage{
-		APIKey:      data.APIKey,
-		Email:       data.Email,
-		Expire:      data.Expire,
-		Cookie:      cookieToSave,
-		LastRefresh: time.Now().Format(time.RFC3339),
-		Type:        "iflow",
+		APIKey:         data.APIKey,
+		Email:          data.Email,
+		Expire:         data.Expire,
+		Cookie:         cookieToSave,
+		LastRefresh:    time.Now().Format(time.RFC3339),
+		Type:           "iflow",
+		UseGlobalProxy: useGlobalProxy,
 	}
 }
 

--- a/internal/auth/iflow/iflow_token.go
+++ b/internal/auth/iflow/iflow_token.go
@@ -11,16 +11,17 @@ import (
 
 // IFlowTokenStorage persists iFlow OAuth credentials alongside the derived API key.
 type IFlowTokenStorage struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	LastRefresh  string `json:"last_refresh"`
-	Expire       string `json:"expired"`
-	APIKey       string `json:"api_key"`
-	Email        string `json:"email"`
-	TokenType    string `json:"token_type"`
-	Scope        string `json:"scope"`
-	Cookie       string `json:"cookie"`
-	Type         string `json:"type"`
+	AccessToken    string `json:"access_token"`
+	RefreshToken   string `json:"refresh_token"`
+	LastRefresh    string `json:"last_refresh"`
+	Expire         string `json:"expired"`
+	APIKey         string `json:"api_key"`
+	Email          string `json:"email"`
+	TokenType      string `json:"token_type"`
+	Scope          string `json:"scope"`
+	Cookie         string `json:"cookie"`
+	Type           string `json:"type"`
+	UseGlobalProxy bool   `json:"use_global_proxy"`
 }
 
 // SaveTokenToFile serialises the token storage to disk.
@@ -41,4 +42,9 @@ func (ts *IFlowTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("iflow token: encode token failed: %w", err)
 	}
 	return nil
+}
+
+// SetUseGlobalProxy implements the GlobalProxySetter interface
+func (ts *IFlowTokenStorage) SetUseGlobalProxy(value bool) {
+	ts.UseGlobalProxy = value
 }

--- a/internal/auth/qwen/qwen_auth.go
+++ b/internal/auth/qwen/qwen_auth.go
@@ -337,13 +337,14 @@ func (o *QwenAuth) RefreshTokensWithRetry(ctx context.Context, refreshToken stri
 }
 
 // CreateTokenStorage creates a QwenTokenStorage object from a QwenTokenData object.
-func (o *QwenAuth) CreateTokenStorage(tokenData *QwenTokenData) *QwenTokenStorage {
+func (o *QwenAuth) CreateTokenStorage(tokenData *QwenTokenData, useGlobalProxy bool) *QwenTokenStorage {
 	storage := &QwenTokenStorage{
-		AccessToken:  tokenData.AccessToken,
-		RefreshToken: tokenData.RefreshToken,
-		LastRefresh:  time.Now().Format(time.RFC3339),
-		ResourceURL:  tokenData.ResourceURL,
-		Expire:       tokenData.Expire,
+		AccessToken:    tokenData.AccessToken,
+		RefreshToken:   tokenData.RefreshToken,
+		LastRefresh:    time.Now().Format(time.RFC3339),
+		ResourceURL:    tokenData.ResourceURL,
+		Expire:         tokenData.Expire,
+		UseGlobalProxy: useGlobalProxy,
 	}
 
 	return storage

--- a/internal/auth/qwen/qwen_token.go
+++ b/internal/auth/qwen/qwen_token.go
@@ -30,6 +30,8 @@ type QwenTokenStorage struct {
 	Type string `json:"type"`
 	// Expire is the timestamp when the current access token expires.
 	Expire string `json:"expired"`
+	// UseGlobalProxy indicates whether to use the global proxy from config.yaml.
+	UseGlobalProxy bool `json:"use_global_proxy"`
 }
 
 // SaveTokenToFile serializes the Qwen token storage to a JSON file.
@@ -60,4 +62,9 @@ func (ts *QwenTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to write token to file: %w", err)
 	}
 	return nil
+}
+
+// SetUseGlobalProxy implements the GlobalProxySetter interface
+func (ts *QwenTokenStorage) SetUseGlobalProxy(value bool) {
+	ts.UseGlobalProxy = value
 }

--- a/internal/cmd/iflow_cookie.go
+++ b/internal/cmd/iflow_cookie.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/iflow"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 )
 
 // DoIFlowCookieAuth performs the iFlow cookie-based authentication.
@@ -49,6 +50,16 @@ func DoIFlowCookieAuth(cfg *config.Config, options *LoginOptions) {
 		return
 	}
 
+	// Ask if user wants to use global proxy
+	useGlobalProxy := false // Default to false for iFlow
+	if options != nil && options.Prompt != nil {
+		// Create sdk auth LoginOptions from cmd LoginOptions to use AskUseGlobalProxy
+		sdkOpts := &auth.LoginOptions{
+			Prompt: options.Prompt,
+		}
+		useGlobalProxy = auth.AskUseGlobalProxy(sdkOpts, false)
+	}
+
 	// Authenticate with cookie
 	auth := iflow.NewIFlowAuth(cfg)
 	ctx := context.Background()
@@ -60,7 +71,7 @@ func DoIFlowCookieAuth(cfg *config.Config, options *LoginOptions) {
 	}
 
 	// Create token storage
-	tokenStorage := auth.CreateCookieTokenStorage(tokenData)
+	tokenStorage := auth.CreateCookieTokenStorage(tokenData, useGlobalProxy)
 
 	// Get auth file path using email in filename
 	authFilePath := getAuthFilePath(cfg, "iflow", tokenData.Email)

--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -16,8 +16,8 @@ import (
 
 // newProxyAwareHTTPClient creates an HTTP client with proper proxy configuration priority:
 // 1. Use auth.ProxyURL if configured (highest priority)
-// 2. Use cfg.ProxyURL if auth proxy is not configured
-// 3. Use RoundTripper from context if neither are configured
+// 2. Use cfg.ProxyURL if auth.UseGlobalProxy is true and auth.ProxyURL is not configured
+// 3. Use RoundTripper from context if no proxy is configured
 //
 // Parameters:
 //   - ctx: The context containing optional RoundTripper
@@ -33,14 +33,14 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		httpClient.Timeout = timeout
 	}
 
-	// Priority 1: Use auth.ProxyURL if configured
+	// Priority 1: Use auth.ProxyURL if configured (highest priority)
 	var proxyURL string
 	if auth != nil {
 		proxyURL = strings.TrimSpace(auth.ProxyURL)
 	}
 
-	// Priority 2: Use cfg.ProxyURL if auth proxy is not configured
-	if proxyURL == "" && cfg != nil {
+	// Priority 2: Use cfg.ProxyURL if auth.UseGlobalProxy is true and no auth proxy is set
+	if proxyURL == "" && auth != nil && auth.UseGlobalProxy && cfg != nil {
 		proxyURL = strings.TrimSpace(cfg.ProxyURL)
 	}
 

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -197,6 +197,12 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 	if email, ok := metadata["email"].(string); ok && email != "" {
 		auth.Attributes["email"] = email
 	}
+	// Load use_global_proxy from metadata, default to true if not set
+	// This maintains backward compatibility for existing auth files
+	auth.UseGlobalProxy = true // Default to true
+	if useGlobalProxy, ok := metadata["use_global_proxy"].(bool); ok {
+		auth.UseGlobalProxy = useGlobalProxy
+	}
 	return auth, nil
 }
 

--- a/sdk/auth/qwen.go
+++ b/sdk/auth/qwen.go
@@ -71,7 +71,9 @@ func (a *QwenAuthenticator) Login(ctx context.Context, cfg *config.Config, opts 
 		return nil, fmt.Errorf("qwen authentication failed: %w", err)
 	}
 
-	tokenStorage := authSvc.CreateTokenStorage(tokenData)
+	// Note: use_global_proxy will be set by manager.go's Login method
+	// Default to false for qwen
+	tokenStorage := authSvc.CreateTokenStorage(tokenData, false)
 
 	email := ""
 	if opts.Metadata != nil {

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -35,6 +35,8 @@ type Auth struct {
 	Unavailable bool `json:"unavailable"`
 	// ProxyURL overrides the global proxy setting for this auth if provided.
 	ProxyURL string `json:"proxy_url,omitempty"`
+	// UseGlobalProxy indicates whether to use the global proxy from config.yaml.
+	UseGlobalProxy bool `json:"use_global_proxy"`
 	// Attributes stores provider specific metadata needed by executors (immutable configuration).
 	Attributes map[string]string `json:"attributes,omitempty"`
 	// Metadata stores runtime mutable provider state (e.g. tokens, cookies).


### PR DESCRIPTION
#304 
- Add use_global_proxy field to Auth struct and auth files
- Prompt users for proxy preference during login flows
- Use provider-specific defaults (iFlow/Qwen: false, others: true)
- Maintain backward compatibility by defaulting to true for existing files
- Implement GlobalProxySetter interface for token storage
- Update proxy selection logic to respect use_global_proxy flag

This allows users to control proxy usage on a per-auth basis while maintaining backward compatibility with existing auth files.

Generated with [Claude Code](https://claude.com/claude-code)