### PR TITLE
fix(amp): flush response buffer after each streaming chunk write

### DIFF
--- a/internal/api/modules/amp/response_rewriter.go
+++ b/internal/api/modules/amp/response_rewriter.go
@@ -40,8 +40,10 @@ func (rw *ResponseRewriter) Write(data []byte) (int, error) {
 
 	if rw.isStreaming {
 		n, err := rw.ResponseWriter.Write(rw.rewriteStreamChunk(data))
-		if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
-			flusher.Flush()
+		if err == nil {
+			if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
+				flusher.Flush()
+			}
 		}
 		return n, err
 	}


### PR DESCRIPTION
add an explicit `Flush()` call after each write to enable streaming for models instead of sending entire payload at end. fixes high TTFT.

Tested with Antigravity Oauth and `gemini-3-pro-preview`.

Fixes: #460 for other models using Amp CLI.

#498 previously only fixed for `gemini-claude-*` models