### PR TITLE
feat: add configurable transient-retry-interval for 408/5xx errors

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -51,6 +51,10 @@ request-retry: 3
 # Maximum wait time in seconds for a cooled-down credential before triggering a retry.
 max-retry-interval: 30
 
+# Cooldown time in seconds for transient upstream errors (408, 500, 502, 503, 504).
+# Lower this to detect backend recovery faster (default behavior is 60s when unset).
+transient-retry-interval: 60
+
 # Quota exceeded behavior
 quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -232,6 +232,14 @@ func (h *Handler) PutMaxRetryInterval(c *gin.Context) {
 	h.updateIntField(c, func(v int) { h.cfg.MaxRetryInterval = v })
 }
 
+// Transient retry interval
+func (h *Handler) GetTransientRetryInterval(c *gin.Context) {
+	c.JSON(200, gin.H{"transient-retry-interval": h.cfg.TransientRetryInterval})
+}
+func (h *Handler) PutTransientRetryInterval(c *gin.Context) {
+	h.updateIntField(c, func(v int) { h.cfg.TransientRetryInterval = v })
+}
+
 // Proxy URL
 func (h *Handler) GetProxyURL(c *gin.Context) { c.JSON(200, gin.H{"proxy-url": h.cfg.ProxyURL}) }
 func (h *Handler) PutProxyURL(c *gin.Context) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -252,6 +252,7 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	s.applyAccessConfig(nil, cfg)
 	if authManager != nil {
 		authManager.SetRetryConfig(cfg.RequestRetry, time.Duration(cfg.MaxRetryInterval)*time.Second)
+		authManager.SetTransientRetryInterval(time.Duration(cfg.TransientRetryInterval) * time.Second)
 	}
 	managementasset.SetCurrentConfig(cfg)
 	auth.SetQuotaCooldownDisabled(cfg.DisableCooling)
@@ -546,6 +547,9 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/max-retry-interval", s.mgmt.GetMaxRetryInterval)
 		mgmt.PUT("/max-retry-interval", s.mgmt.PutMaxRetryInterval)
 		mgmt.PATCH("/max-retry-interval", s.mgmt.PutMaxRetryInterval)
+		mgmt.GET("/transient-retry-interval", s.mgmt.GetTransientRetryInterval)
+		mgmt.PUT("/transient-retry-interval", s.mgmt.PutTransientRetryInterval)
+		mgmt.PATCH("/transient-retry-interval", s.mgmt.PutTransientRetryInterval)
 
 		mgmt.GET("/claude-api-key", s.mgmt.GetClaudeKeys)
 		mgmt.PUT("/claude-api-key", s.mgmt.PutClaudeKeys)
@@ -865,6 +869,7 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	}
 	if s.handlers != nil && s.handlers.AuthManager != nil {
 		s.handlers.AuthManager.SetRetryConfig(cfg.RequestRetry, time.Duration(cfg.MaxRetryInterval)*time.Second)
+		s.handlers.AuthManager.SetTransientRetryInterval(time.Duration(cfg.TransientRetryInterval) * time.Second)
 	}
 
 	// Update log level dynamically when debug flag changes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,9 @@ type Config struct {
 	// MaxRetryInterval defines the maximum wait time in seconds before retrying a cooled-down credential.
 	MaxRetryInterval int `yaml:"max-retry-interval" json:"max-retry-interval"`
 
+	// TransientRetryInterval defines the cooldown time in seconds for transient upstream errors (408, 500, 502, 503, 504).
+	TransientRetryInterval int `yaml:"transient-retry-interval" json:"transient-retry-interval"`
+
 	// QuotaExceeded defines the behavior when a quota is exceeded.
 	QuotaExceeded QuotaExceeded `yaml:"quota-exceeded" json:"quota-exceeded"`
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1736,6 +1736,9 @@ func buildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.MaxRetryInterval != newCfg.MaxRetryInterval {
 		changes = append(changes, fmt.Sprintf("max-retry-interval: %d -> %d", oldCfg.MaxRetryInterval, newCfg.MaxRetryInterval))
 	}
+	if oldCfg.TransientRetryInterval != newCfg.TransientRetryInterval {
+		changes = append(changes, fmt.Sprintf("transient-retry-interval: %d -> %d", oldCfg.TransientRetryInterval, newCfg.TransientRetryInterval))
+	}
 	if oldCfg.ProxyURL != newCfg.ProxyURL {
 		changes = append(changes, fmt.Sprintf("proxy-url: %s -> %s", oldCfg.ProxyURL, newCfg.ProxyURL))
 	}


### PR DESCRIPTION
## Summary
- Add `transient-retry-interval` config to customize cooldown for transient upstream errors (408, 500, 502, 503, 504)
- Default remains 60s when unset
- Exposes GET/PUT endpoints at `/api/internal/transient-retry-interval`

## Usage
```yaml
transient-retry-interval: 10  # seconds, lower = faster recovery detection