### PR TITLE
fix(translator): preserve built-in tools (web_search) to Responses API

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -163,6 +163,14 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 		var chatCompletionsTools []interface{}
 
 		tools.ForEach(func(_, tool gjson.Result) bool {
+			// Built-in tools (e.g. {"type":"web_search"}) are already compatible with the Chat Completions schema.
+			// Only function tools need structural conversion because Chat Completions nests details under "function".
+			toolType := tool.Get("type").String()
+			if toolType != "" && toolType != "function" && tool.IsObject() {
+				chatCompletionsTools = append(chatCompletionsTools, tool.Value())
+				return true
+			}
+
 			chatTool := `{"type":"function","function":{}}`
 
 			// Convert tool structure from responses format to chat completions format

--- a/test/builtin_tools_translation_test.go
+++ b/test/builtin_tools_translation_test.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"testing"
+
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAIToCodex_PreservesBuiltinTools(t *testing.T) {
+	in := []byte(`{
+		"model":"gpt-5",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"type":"web_search","search_context_size":"high"}],
+		"tool_choice":{"type":"web_search"}
+	}`)
+
+	out := sdktranslator.TranslateRequest(sdktranslator.FormatOpenAI, sdktranslator.FormatCodex, "gpt-5", in, false)
+
+	if got := gjson.GetBytes(out, "tools.#").Int(); got != 1 {
+		t.Fatalf("expected 1 tool, got %d: %s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "web_search" {
+		t.Fatalf("expected tools[0].type=web_search, got %q: %s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.search_context_size").String(); got != "high" {
+		t.Fatalf("expected tools[0].search_context_size=high, got %q: %s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "tool_choice.type").String(); got != "web_search" {
+		t.Fatalf("expected tool_choice.type=web_search, got %q: %s", got, string(out))
+	}
+}
+
+func TestOpenAIResponsesToOpenAI_PreservesBuiltinTools(t *testing.T) {
+	in := []byte(`{
+		"model":"gpt-5",
+		"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}],
+		"tools":[{"type":"web_search","search_context_size":"low"}]
+	}`)
+
+	out := sdktranslator.TranslateRequest(sdktranslator.FormatOpenAIResponse, sdktranslator.FormatOpenAI, "gpt-5", in, false)
+
+	if got := gjson.GetBytes(out, "tools.#").Int(); got != 1 {
+		t.Fatalf("expected 1 tool, got %d: %s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "web_search" {
+		t.Fatalf("expected tools[0].type=web_search, got %q: %s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.search_context_size").String(); got != "low" {
+		t.Fatalf("expected tools[0].search_context_size=low, got %q: %s", got, string(out))
+	}
+}


### PR DESCRIPTION
Problem
- OpenAI Chat Completions requests that include built-in tools like {"type":"web_search"} were dropped when translating to the Responses API (Codex), resulting in upstream receiving tools:[] and no web search.

Fix
- Pass through non-function tool entries unchanged during OpenAI Chat Completions -> Codex (Responses) translation.
- Preserve tool_choice for built-in tools (and flatten function tool_choice to Responses shape).
- Also preserve built-in tools when converting OpenAI Responses -> OpenAI Chat Completions.

Tests
- go test ./test -run BuiltinTools