### PR TITLE
fix(translator): emit message_start on first chunk regardless of role field

### DIFF
--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -128,9 +128,10 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 		param.CreatedAt = root.Get("created").Int()
 	}
 
-	// Check if this is the first chunk (has role)
+	// Emit message_start on the very first chunk, regardless of whether it has a role field.
+	// Some providers (like Copilot) may send tool_calls in the first chunk without a role field.
 	if delta := root.Get("choices.0.delta"); delta.Exists() {
-		if role := delta.Get("role"); role.Exists() && role.String() == "assistant" && !param.MessageStarted {
+		if !param.MessageStarted {
 			// Send message_start event
 			messageStart := map[string]interface{}{
 				"type": "message_start",


### PR DESCRIPTION
## Summary

Fix Anthropic protocol violation when translating OpenAI streaming responses that contain tool calls in the first chunk.

**Closes #563**

## Problem

When using CLIProxyAPI to translate OpenAI-compatible responses to Anthropic format, clients like **amp** (Anthropic's CLI) would fail with:

```
Error: Unexpected event order, got content_block_start before "message_start"
```

This happened specifically with complex requests that triggered tool calls (e.g., codebase exploration), while simple text responses worked fine.

## Root Cause

The OpenAI→Anthropic stream translator at `internal/translator/openai/claude/openai_claude_response.go` only emitted `message_start` when the first chunk contained `delta.role = "assistant"`:

```go
// Before (line 131-133)
if role := delta.Get("role"); role.Exists() && role.String() == "assistant" && !param.MessageStarted {
```

**The issue:** Some OpenAI-compatible providers (notably GitHub Copilot) send tool calls in the **first** streaming chunk **without** a `role` field:

| Response Type | First Chunk | Has role? | message_start sent? |
|---------------|-------------|-----------|---------------------|
| Simple text | `{"delta":{"content":"Hi","role":"assistant"}}` | Yes | Yes |
| Tool call | `{"delta":{"content":null,"tool_calls":[...]}}` | No | **No** |

When `message_start` was not sent, the subsequent `content_block_start` event violated the Anthropic SSE protocol, which requires `message_start` to come first.

## Solution

Emit `message_start` unconditionally on the first chunk:

```go
// After
if !param.MessageStarted {
```

This ensures proper event ordering regardless of whether the first chunk contains a `role` field.

## Testing

Tested with:
- **Simple requests** (text responses): Still works
- **Complex requests** (tool calls via GitHub Copilot): Now works

Example that was failing before:
```bash
amp -x "Explore this codebase to understand the project structure and purpose"
# Before: Error: Unexpected event order, got content_block_start before "message_start"
# After: Works correctly, returns full codebase analysis
```

## Impact

- **Low risk**: The change only affects when `message_start` is emitted, not its content
- **Backward compatible**: Responses that already worked will continue to work identically
- **Fixes**: GitHub Copilot and potentially other OpenAI-compatible providers that do not include `role` in tool-call-first responses