### PR TITLE
fix: handle non-standard 'optional' field in JSON Schema for Gemini API

### DIFF
--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -122,7 +122,9 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 			toolResult := toolsResults[i]
 			inputSchemaResult := toolResult.Get("input_schema")
 			if inputSchemaResult.Exists() && inputSchemaResult.IsObject() {
-				inputSchema := inputSchemaResult.Raw
+				// Clean the schema to handle non-standard fields like "optional"
+				// and convert them to standard JSON Schema format for Gemini
+				inputSchema := util.CleanJSONSchemaForGemini(inputSchemaResult.Raw)
 				tool, _ := sjson.Delete(toolResult.Raw, "input_schema")
 				tool, _ = sjson.SetRaw(tool, "parametersJsonSchema", inputSchema)
 				tool, _ = sjson.Delete(tool, "strict")


### PR DESCRIPTION
## Summary

Addresses issue #583 where Gemini API rejects tool parameter schemas containing non-standard `"optional"` fields.

### Problem

Some clients (reportedly Factory Droid) send tool definitions with a non-standard `"optional"` attribute in parameter schemas:

```json
{"param1": {"type": "string", "optional": false}}
```

Gemini API requires standard JSON Schema format with a `required` array:

```json
{"properties": {"param1": {"type": "string"}}, "required": ["param1"]}
```

This causes Gemini to return a 400 error: `"Unknown name 'optional' at 'request.tools[0].function_declarations[14].parameters.properties'"`

### Solution

- Added `convertOptionalToRequired()` function to `internal/util/gemini_schema.go` that:
  - Finds all properties with `"optional"` field
  - Converts `"optional": false` to entries in the parent's `"required"` array
  - Removes all `"optional"` fields from the schema
- Integrated into the existing `CleanJSONSchemaForGemini()` pipeline
- Applied `CleanJSONSchemaForGemini()` to input schemas in the Claude-to-Gemini translator (`internal/translator/gemini/claude/gemini_claude_request.go`)

### Testing

- Added 5 comprehensive unit tests covering:
  - Basic optional-to-required conversion
  - Nested properties
  - Preserving existing required arrays
  - No-op for schemas without optional fields
  - Handling all-optional-true case
- All tests pass ✅
- CI build passes ✅

## ⚠️ Why This PR is a Draft

**Unable to reproduce the issue with current Factory Droid CLI.**

During testing with Factory Droid (droid CLI) using both:
- OpenAI API format (`provider: "openai"`, `/v1/responses` endpoint)
- Claude API format (`provider: "anthropic"`, `/v1/messages` endpoint)

The `"optional"` field was **not observed** in the tool schemas sent by droid. The schemas already use standard JSON Schema format with `"required"` arrays.

Possible explanations:
1. The issue may be version-specific to an older Factory Droid release
2. The issue may only occur with specific custom tool definitions
3. The original reporter may have a different client configuration

**The fix is implemented correctly and defensively** - it will handle `"optional"` fields if any client sends them, but we couldn't confirm the fix addresses the original reporter's specific scenario.

## Request for Testing

@qq33357486 - Could you please test this branch with your setup that was producing the error? This would help confirm the fix works for your specific case.

To test:
```bash
git fetch upstream
git checkout fix-gemini-optional-schema-583
go build -o cli-proxy-api ./cmd/server
./cli-proxy-api
```

Then run your Factory Droid workflow that was triggering the `"optional"` field error.

## Files Changed

- `internal/util/gemini_schema.go` - Added `convertOptionalToRequired()` function
- `internal/util/gemini_schema_test.go` - Added tests for optional-to-required conversion
- `internal/translator/gemini/claude/gemini_claude_request.go` - Applied schema cleaning

Closes #583