### PR TITLE
fix: Fixes Bash tool command parameter name mismatch

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_response.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_response.go
@@ -233,8 +233,14 @@ func ConvertAntigravityResponseToClaude(_ context.Context, _ string, originalReq
 				output = output + fmt.Sprintf("data: %s\n\n\n", data)
 
 				if fcArgsResult := functionCallResult.Get("args"); fcArgsResult.Exists() {
+					argsRaw := fcArgsResult.Raw
+					// Amp expects "cmd" for Bash tool, but Gemini sends "command"
+					// Convert command → cmd for Bash tools using proper JSON parsing
+					if fcName == "Bash" || fcName == "bash" || fcName == "bash_20241022" {
+						argsRaw = convertBashCommandToCmdField(argsRaw)
+					}
 					output = output + "event: content_block_delta\n"
-					data, _ = sjson.Set(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"input_json_delta","partial_json":""}}`, params.ResponseIndex), "delta.partial_json", fcArgsResult.Raw)
+					data, _ = sjson.Set(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"input_json_delta","partial_json":""}}`, params.ResponseIndex), "delta.partial_json", argsRaw)
 					output = output + fmt.Sprintf("data: %s\n\n\n", data)
 				}
 				params.ResponseType = 3
@@ -320,6 +326,36 @@ func resolveStopReason(params *Params) string {
 	}
 
 	return "end_turn"
+}
+
+// convertBashCommandToCmdField converts "command" field to "cmd" field for Bash tools.
+// Amp expects "cmd" but Gemini sends "command". This uses proper JSON parsing
+// to avoid accidentally replacing "command" that appears in values.
+func convertBashCommandToCmdField(argsRaw string) string {
+	// Only process valid JSON
+	if !gjson.Valid(argsRaw) {
+		return argsRaw
+	}
+
+	// Check if "command" key exists and "cmd" doesn't
+	commandVal := gjson.Get(argsRaw, "command")
+	cmdVal := gjson.Get(argsRaw, "cmd")
+
+	if commandVal.Exists() && !cmdVal.Exists() {
+		// Set "cmd" to the value of "command", preserve the raw value type
+		result, err := sjson.SetRaw(argsRaw, "cmd", commandVal.Raw)
+		if err != nil {
+			return argsRaw
+		}
+		// Delete "command" key
+		result, err = sjson.Delete(result, "command")
+		if err != nil {
+			return argsRaw
+		}
+		return result
+	}
+
+	return argsRaw
 }
 
 // ConvertAntigravityResponseToClaudeNonStream converts a non-streaming Gemini CLI response to a non-streaming Claude response.

--- a/internal/translator/antigravity/claude/antigravity_claude_response_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_response_test.go
@@ -1,0 +1,78 @@
+package claude
+
+import (
+	"testing"
+)
+
+func TestConvertBashCommandToCmdField(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "basic command to cmd conversion",
+			input:    `{"command": "git diff"}`,
+			expected: `{"cmd":"git diff"}`,
+		},
+		{
+			name:     "already has cmd field - no change",
+			input:    `{"cmd": "git diff"}`,
+			expected: `{"cmd": "git diff"}`,
+		},
+		{
+			name:     "both cmd and command - keep cmd only",
+			input:    `{"command": "git diff", "cmd": "ls"}`,
+			expected: `{"command": "git diff", "cmd": "ls"}`, // no change when cmd exists
+		},
+		{
+			name:     "command with special characters in value",
+			input:    `{"command": "echo \"command\": test"}`,
+			expected: `{"cmd":"echo \"command\": test"}`,
+		},
+		{
+			name:     "command with nested quotes",
+			input:    `{"command": "bash -c 'echo \"hello\"'"}`,
+			expected: `{"cmd":"bash -c 'echo \"hello\"'"}`,
+		},
+		{
+			name:     "command with newlines",
+			input:    `{"command": "echo hello\necho world"}`,
+			expected: `{"cmd":"echo hello\necho world"}`,
+		},
+		{
+			name:     "empty command value",
+			input:    `{"command": ""}`,
+			expected: `{"cmd":""}`,
+		},
+		{
+			name:     "command with other fields - preserves them",
+			input:    `{"command": "git diff", "timeout": 30}`,
+			expected: `{ "timeout": 30,"cmd":"git diff"}`,
+		},
+		{
+			name:     "invalid JSON - returns unchanged",
+			input:    `{invalid json`,
+			expected: `{invalid json`,
+		},
+		{
+			name:     "empty object",
+			input:    `{}`,
+			expected: `{}`,
+		},
+		{
+			name:     "no command field",
+			input:    `{"restart": true}`,
+			expected: `{"restart": true}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertBashCommandToCmdField(tt.input)
+			if result != tt.expected {
+				t.Errorf("convertBashCommandToCmdField(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Addresses an issue where the Bash tool expects the "cmd" parameter, but Gemini sends "command".

This commit introduces a function that converts the "command" field to "cmd" for Bash tools. It uses proper JSON parsing to avoid accidental replacements of "command" that appear in values.

Also, adds tests to verify that the conversion works correctly in different scenarios.

## Summary
Gemini returns `command` field for Bash tool arguments, but Amp clients expect `cmd`. 
This converts `command` → `cmd` using proper JSON parsing.

## References
- Anthropic Bash Tool docs: https://docs.anthropic.com/en/docs/build-with-claude/computer-use#bash-tool
- Tool naming convention: Anthropic uses versioned tool names like `bash_20241022`