### PR TITLE
fix: remove propertyNames from JSON schema for Gemini compatibility

### DIFF
--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -296,6 +296,7 @@ func flattenTypeArrays(jsonStr string) string {
 func removeUnsupportedKeywords(jsonStr string) string {
 	keywords := append(unsupportedConstraints,
 		"$schema", "$defs", "definitions", "const", "$ref", "additionalProperties",
+		"propertyNames", // Gemini doesn't support property name validation
 	)
 	for _, key := range keywords {
 		for _, p := range findPaths(jsonStr, key) {


### PR DESCRIPTION
## Summary
- Add `propertyNames` to the list of unsupported JSON Schema keywords removed when translating Claude tool schemas for the Antigravity provider
- Add test coverage for `propertyNames` removal in both simple and nested schema structures

## Problem
When using the Antigravity provider to proxy Claude models, requests fail with 400 errors:

```
Invalid JSON payload received. Unknown name "propertyNames" at 
'request.tools[0].function_declarations[14].parameters.properties[1].value.items.properties[2].value': Cannot find field.
```

Gemini's API does not support the JSON Schema `propertyNames` keyword, which is used by Claude tool schemas to validate object property names.

### Reproduction
Issue was observed and replicated using [Factory AI's Droid CLI](https://github.com/factory-ai/droid) with CLIProxyAPI, configured as:

```json
{
  "model_display_name": "Claude Opus 4.5 [Antigravity]",
  "model": "gemini-claude-opus-4-5-thinking",
  "base_url": "http://localhost:8317",
  "api_key": "<redacted>",
  "provider": "anthropic"
}
```

## Solution
Added `propertyNames` to the unsupported keywords list in `CleanJSONSchemaForGemini()`, which already handles similar incompatibilities like `$ref`, `definitions`, and `additionalProperties`.

## Test plan
- [x] Added `TestCleanJSONSchemaForGemini_PropertyNamesRemoval` - verifies basic removal
- [x] Added `TestCleanJSONSchemaForGemini_PropertyNamesRemoval_Nested` - verifies deeply nested removal
- [x] All 23 existing tests continue to pass
- [x] Manual testing with Factory Droid CLI confirmed fix resolves the issue