### PR TITLE
feat(antigravity): add payload config support to Antigravity executor

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -93,6 +93,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	translated = util.ApplyGemini3ThinkingLevelFromMetadataCLI(req.Model, req.Metadata, translated)
 	translated = util.ApplyDefaultThinkingIfNeededCLI(req.Model, translated)
 	translated = normalizeAntigravityThinking(req.Model, translated)
+	translated = applyPayloadConfigWithRoot(e.cfg, req.Model, "antigravity", "request", translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
@@ -187,6 +188,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	translated = util.ApplyGemini3ThinkingLevelFromMetadataCLI(req.Model, req.Metadata, translated)
 	translated = util.ApplyDefaultThinkingIfNeededCLI(req.Model, translated)
 	translated = normalizeAntigravityThinking(req.Model, translated)
+	translated = applyPayloadConfigWithRoot(e.cfg, req.Model, "antigravity", "request", translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
@@ -520,6 +522,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	translated = util.ApplyGemini3ThinkingLevelFromMetadataCLI(req.Model, req.Metadata, translated)
 	translated = util.ApplyDefaultThinkingIfNeededCLI(req.Model, translated)
 	translated = normalizeAntigravityThinking(req.Model, translated)
+	translated = applyPayloadConfigWithRoot(e.cfg, req.Model, "antigravity", "request", translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0)


### PR DESCRIPTION
## Summary
- Adds `applyPayloadConfig` calls to the Antigravity executor, enabling `config.yaml` payload overrides for Antigravity/Gemini-Claude models

## Problem
The Antigravity executor was missing support for `payload.override` configuration, unlike other executors (Claude, Gemini, Codex, etc.). This meant config like:

```yaml
payload:
  override:
    - models:
        - name: "gemini-claude-opus-4-5*"
      params:
        generationConfig.thinkingConfig.thinkingBudget: 31999
```

had no effect on Antigravity requests.

## Solution
Added `applyPayloadConfig(e.cfg, req.Model, translated)` to all three Antigravity executor paths:
- `Execute` (non-streaming)
- `executeClaudeNonStream`
- `ExecuteStream` (streaming)

## Test plan
- [x] Verified build passes
- [x] Tested with `gemini-claude-opus-4-5-thinking` model
- [x] Confirmed `thinkingBudget: 31999` appears in upstream API request after fix