### PR TITLE
fix(openai): add index field to image response for LiteLLM compatibility

### DIFF
--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response.go
@@ -8,7 +8,6 @@ package chat_completions
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -187,18 +186,11 @@ func ConvertAntigravityResponseToOpenAI(_ context.Context, _ string, originalReq
 					template, _ = sjson.SetRaw(template, "choices.0.delta.images", `[]`)
 				}
 				imageIndex := len(gjson.Get(template, "choices.0.delta.images").Array())
-				imagePayload, err := json.Marshal(map[string]any{
-					"index": imageIndex,
-					"type":  "image_url",
-					"image_url": map[string]string{
-						"url": imageURL,
-					},
-				})
-				if err != nil {
-					continue
-				}
+				imagePayload := `{"type":"image_url","image_url":{"url":""}}`
+				imagePayload, _ = sjson.Set(imagePayload, "index", imageIndex)
+				imagePayload, _ = sjson.Set(imagePayload, "image_url.url", imageURL)
 				template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
-				template, _ = sjson.SetRaw(template, "choices.0.delta.images.-1", string(imagePayload))
+				template, _ = sjson.SetRaw(template, "choices.0.delta.images.-1", imagePayload)
 			}
 		}
 	}

--- a/internal/translator/gemini-cli/openai/chat-completions/gemini-cli_openai_response.go
+++ b/internal/translator/gemini-cli/openai/chat-completions/gemini-cli_openai_response.go
@@ -8,7 +8,6 @@ package chat_completions
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -176,18 +175,11 @@ func ConvertCliResponseToOpenAI(_ context.Context, _ string, originalRequestRawJ
 					template, _ = sjson.SetRaw(template, "choices.0.delta.images", `[]`)
 				}
 				imageIndex := len(gjson.Get(template, "choices.0.delta.images").Array())
-				imagePayload, err := json.Marshal(map[string]any{
-					"index": imageIndex,
-					"type":  "image_url",
-					"image_url": map[string]string{
-						"url": imageURL,
-					},
-				})
-				if err != nil {
-					continue
-				}
+				imagePayload := `{"type":"image_url","image_url":{"url":""}}`
+				imagePayload, _ = sjson.Set(imagePayload, "index", imageIndex)
+				imagePayload, _ = sjson.Set(imagePayload, "image_url.url", imageURL)
 				template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
-				template, _ = sjson.SetRaw(template, "choices.0.delta.images.-1", string(imagePayload))
+				template, _ = sjson.SetRaw(template, "choices.0.delta.images.-1", imagePayload)
 			}
 		}
 	}

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_response.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_response.go
@@ -8,7 +8,6 @@ package chat_completions
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -188,18 +187,11 @@ func ConvertGeminiResponseToOpenAI(_ context.Context, _ string, originalRequestR
 					template, _ = sjson.SetRaw(template, "choices.0.delta.images", `[]`)
 				}
 				imageIndex := len(gjson.Get(template, "choices.0.delta.images").Array())
-				imagePayload, err := json.Marshal(map[string]any{
-					"index": imageIndex,
-					"type":  "image_url",
-					"image_url": map[string]string{
-						"url": imageURL,
-					},
-				})
-				if err != nil {
-					continue
-				}
+				imagePayload := `{"type":"image_url","image_url":{"url":""}}`
+				imagePayload, _ = sjson.Set(imagePayload, "index", imageIndex)
+				imagePayload, _ = sjson.Set(imagePayload, "image_url.url", imageURL)
 				template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
-				template, _ = sjson.SetRaw(template, "choices.0.delta.images.-1", string(imagePayload))
+				template, _ = sjson.SetRaw(template, "choices.0.delta.images.-1", imagePayload)
 			}
 		}
 	}
@@ -331,18 +323,11 @@ func ConvertGeminiResponseToOpenAINonStream(_ context.Context, _ string, origina
 					template, _ = sjson.SetRaw(template, "choices.0.message.images", `[]`)
 				}
 				imageIndex := len(gjson.Get(template, "choices.0.message.images").Array())
-				imagePayload, err := json.Marshal(map[string]any{
-					"index": imageIndex,
-					"type":  "image_url",
-					"image_url": map[string]string{
-						"url": imageURL,
-					},
-				})
-				if err != nil {
-					continue
-				}
+				imagePayload := `{"type":"image_url","image_url":{"url":""}}`
+				imagePayload, _ = sjson.Set(imagePayload, "index", imageIndex)
+				imagePayload, _ = sjson.Set(imagePayload, "image_url.url", imageURL)
 				template, _ = sjson.Set(template, "choices.0.message.role", "assistant")
-				template, _ = sjson.SetRaw(template, "choices.0.message.images.-1", string(imagePayload))
+				template, _ = sjson.SetRaw(template, "choices.0.message.images.-1", imagePayload)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Adds missing `index` field to image objects in OpenAI-compatible responses
- Fixes LiteLLM Pydantic validation error: "images.0.index Field required"

## Test plan
- [ ] Verify image generation responses include `index` field
- [ ] Test with LiteLLM client to confirm validation passes