### PR TITLE
Fixed incorrect function signature call to `NewBaseAPIHandlers`

### DIFF
--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -99,7 +99,7 @@ func TestExecuteStreamWithAuthManager_RetriesBeforeFirstByte(t *testing.T) {
 		Streaming: sdkconfig.StreamingConfig{
 			BootstrapRetries: &bootstrapRetries,
 		},
-	}, manager, nil)
+	}, manager)
 	dataChan, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "test-model", []byte(`{"model":"test-model"}`), "")
 	if dataChan == nil || errChan == nil {
 		t.Fatalf("expected non-nil channels")


### PR DESCRIPTION
This PR removed extra `nil` argument