### PR TITLE
fix: handle nested text format and reasoning_content field

### DIFF
--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -212,7 +212,15 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 					for _, item := range items {
 						switch item.Get("type").String() {
 						case "text":
-							node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".text", item.Get("text").String())
+							// Handle nested text format: {"type": "text", "text": {"text": "content"}}
+							textResult := item.Get("text")
+							var textContent string
+							if textResult.IsObject() {
+								textContent = textResult.Get("text").String()
+							} else {
+								textContent = textResult.String()
+							}
+							node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".text", textContent)
 							p++
 						case "image_url":
 							imageURL := item.Get("image_url.url").String()
@@ -255,6 +263,15 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 					for _, item := range content.Array() {
 						switch item.Get("type").String() {
 						case "text":
+							// Handle nested text format: {"type": "text", "text": {"text": "content"}}
+							textResult := item.Get("text")
+							var textContent string
+							if textResult.IsObject() {
+								textContent = textResult.Get("text").String()
+							} else {
+								textContent = textResult.String()
+							}
+							node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".text", textContent)
 							p++
 						case "image_url":
 							// If the assistant returned an inline data URL, preserve it for history fidelity.

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -163,7 +163,15 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 						switch partType {
 						case "text":
 							textPart := `{"type":"text","text":""}`
-							textPart, _ = sjson.Set(textPart, "text", part.Get("text").String())
+							// Handle nested text format: {"type": "text", "text": {"text": "content"}}
+							textResult := part.Get("text")
+							var textContent string
+							if textResult.IsObject() {
+								textContent = textResult.Get("text").String()
+							} else {
+								textContent = textResult.String()
+							}
+							textPart, _ = sjson.Set(textPart, "text", textContent)
 							msg, _ = sjson.SetRaw(msg, "content.-1", textPart)
 
 						case "image_url":

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -117,7 +117,15 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 
 					switch contentType {
 					case "text":
-						appendTextContent(messageContentResult.Get("text").String())
+						// Handle nested text format: {"type": "text", "text": {"text": "content"}}
+						textResult := messageContentResult.Get("text")
+						var textContent string
+						if textResult.IsObject() {
+							textContent = textResult.Get("text").String()
+						} else {
+							textContent = textResult.String()
+						}
+						appendTextContent(textContent)
 					case "image":
 						sourceResult := messageContentResult.Get("source")
 						if sourceResult.Exists() {

--- a/internal/translator/gemini-cli/claude/gemini-cli_claude_request.go
+++ b/internal/translator/gemini-cli/claude/gemini-cli_claude_request.go
@@ -87,7 +87,15 @@ func ConvertClaudeRequestToCLI(modelName string, inputRawJSON []byte, _ bool) []
 					switch contentResult.Get("type").String() {
 					case "text":
 						part := `{"text":""}`
-						part, _ = sjson.Set(part, "text", contentResult.Get("text").String())
+						// Handle nested text format: {"type": "text", "text": {"text": "content"}}
+						textResult := contentResult.Get("text")
+						var textContent string
+						if textResult.IsObject() {
+							textContent = textResult.Get("text").String()
+						} else {
+							textContent = textResult.String()
+						}
+						part, _ = sjson.Set(part, "text", textContent)
 						contentJSON, _ = sjson.SetRaw(contentJSON, "parts.-1", part)
 
 					case "tool_use":

--- a/internal/translator/gemini-cli/openai/chat-completions/gemini-cli_openai_request.go
+++ b/internal/translator/gemini-cli/openai/chat-completions/gemini-cli_openai_request.go
@@ -180,7 +180,15 @@ func ConvertOpenAIRequestToGeminiCLI(modelName string, inputRawJSON []byte, _ bo
 					for _, item := range items {
 						switch item.Get("type").String() {
 						case "text":
-							node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".text", item.Get("text").String())
+							// Handle nested text format: {"type": "text", "text": {"text": "content"}}
+							textResult := item.Get("text")
+							var textContent string
+							if textResult.IsObject() {
+								textContent = textResult.Get("text").String()
+							} else {
+								textContent = textResult.String()
+							}
+							node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".text", textContent)
 							p++
 						case "image_url":
 							imageURL := item.Get("image_url.url").String()
@@ -224,7 +232,15 @@ func ConvertOpenAIRequestToGeminiCLI(modelName string, inputRawJSON []byte, _ bo
 					for _, item := range content.Array() {
 						switch item.Get("type").String() {
 						case "text":
-							node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".text", item.Get("text").String())
+							// Handle nested text format: {"type": "text", "text": {"text": "content"}}
+							textResult := item.Get("text")
+							var textContent string
+							if textResult.IsObject() {
+								textContent = textResult.Get("text").String()
+							} else {
+								textContent = textResult.String()
+							}
+							node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".text", textContent)
 							p++
 						case "image_url":
 							// If the assistant returned an inline data URL, preserve it for history fidelity.

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
@@ -198,7 +198,15 @@ func ConvertOpenAIRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 					for _, item := range items {
 						switch item.Get("type").String() {
 						case "text":
-							node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".text", item.Get("text").String())
+							// Handle nested text format: {"type": "text", "text": {"text": "content"}}
+							textResult := item.Get("text")
+							var textContent string
+							if textResult.IsObject() {
+								textContent = textResult.Get("text").String()
+							} else {
+								textContent = textResult.String()
+							}
+							node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".text", textContent)
 							p++
 						case "image_url":
 							imageURL := item.Get("image_url.url").String()

--- a/internal/translator/openai/claude/openai_claude_request.go
+++ b/internal/translator/openai/claude/openai_claude_request.go
@@ -262,7 +262,12 @@ func convertClaudeContentPart(part gjson.Result) (string, bool) {
 
 	switch partType {
 	case "text":
-		text := part.Get("text").String()
+		textValue := part.Get("text")
+		// Handle potentially nested text format from some SDKs, e.g., {"text": {"text": "..."}}
+		for textValue.IsObject() {
+			textValue = textValue.Get("text")
+		}
+		text := textValue.String()
 		if strings.TrimSpace(text) == "" {
 			return "", false
 		}


### PR DESCRIPTION
## Summary

This PR fixes three issues related to extended thinking support:

### Fix #730 - Handle nested text format
OpenAI-compatible SDKs (like the official OpenAI SDK) send content in nested format:
```json
{"type": "text", "text": {"text": "actual content"}}
```

The current code only handles the flat format, causing the content to be lost.

### Fix #731 - Use `reasoning_content` instead of `reasoning`
The streaming response uses `reasoning_content` field, but the non-streaming response was using `reasoning`. This inconsistency breaks clients that expect the same field name.

### Fix #732 - Remove inaccurate token estimation
The hardcoded `reasoning_tokens` estimation was inaccurate and misleading. Removed it since we don't have access to actual token counts.

## Testing

- Tested with ProxyPal app using Claude extended thinking
- Verified both streaming and non-streaming responses work correctly
- Confirmed OpenAI SDK nested format is properly handled

## Related Issues

Fixes #730
Fixes #731
Fixes #732

## Note

These fixes are currently deployed via a fork ([heyhuynhgiabuu/CLIProxyAPI](https://github.com/heyhuynhgiabuu/CLIProxyAPI/releases/tag/v6.6.56-patched)) for ProxyPal users. Once merged, ProxyPal will switch back to the official releases.