### PR TITLE
feat(executor): 为 openai-compat 添加 wire-api 配置支持

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -133,6 +133,7 @@ ws-auth: false
 #   - name: "openrouter" # The name of the provider; it will be used in the user agent and other places.
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
+#     wire-api: "responses" # optional: use "responses" to send /responses payloads instead of /chat/completions
 #     headers:
 #       X-Custom-Header: "custom-value"
 #     api-key-entries:

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -710,6 +710,7 @@ func normalizeOpenAICompatibilityEntry(entry *config.OpenAICompatibility) {
 	}
 	// Trim base-url; empty base-url indicates provider should be removed by sanitization
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.WireAPI = strings.TrimSpace(entry.WireAPI)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	existing := make(map[string]struct{}, len(entry.APIKeyEntries))
 	for i := range entry.APIKeyEntries {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -294,6 +294,9 @@ type OpenAICompatibility struct {
 	// BaseURL is the base URL for the external OpenAI-compatible API endpoint.
 	BaseURL string `yaml:"base-url" json:"base-url"`
 
+	// WireAPI selects the upstream OpenAI wire protocol (chat-completions or responses).
+	WireAPI string `yaml:"wire-api,omitempty" json:"wire-api,omitempty"`
+
 	// APIKeyEntries defines API keys with optional per-key proxy configuration.
 	APIKeyEntries []OpenAICompatibilityAPIKey `yaml:"api-key-entries,omitempty" json:"api-key-entries,omitempty"`
 
@@ -462,6 +465,7 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 		e.Name = strings.TrimSpace(e.Name)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.WireAPI = strings.TrimSpace(e.WireAPI)
 		e.Headers = NormalizeHeaders(e.Headers)
 		if e.BaseURL == "" {
 			// Skip providers with no base-url; treated as removed

--- a/internal/runtime/executor/openai_compat_executor_test.go
+++ b/internal/runtime/executor/openai_compat_executor_test.go
@@ -1,0 +1,123 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestBuildRequestURL(t *testing.T) {
+	e := &OpenAICompatExecutor{}
+
+	tests := []struct {
+		baseURL  string
+		wireAPI  string
+		expected string
+	}{
+		{"https://api.example.com/v1", "chat", "https://api.example.com/v1/chat/completions"},
+		{"https://api.example.com/v1/", "chat", "https://api.example.com/v1/chat/completions"},
+		{"https://api.example.com/v1", "responses", "https://api.example.com/v1/responses"},
+		{"https://api.example.com/v1/", "responses", "https://api.example.com/v1/responses"},
+		{"https://api.example.com", "", "https://api.example.com/chat/completions"},
+	}
+
+	for _, tt := range tests {
+		got := e.buildRequestURL(tt.baseURL, tt.wireAPI)
+		if got != tt.expected {
+			t.Errorf("buildRequestURL(%q, %q) = %q, want %q", tt.baseURL, tt.wireAPI, got, tt.expected)
+		}
+	}
+}
+
+func TestResolveWireAPI(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		auth     *cliproxyauth.Auth
+		expected string
+	}{
+		{
+			name:     "nil auth returns chat",
+			cfg:      nil,
+			auth:     nil,
+			expected: "chat",
+		},
+		{
+			name:     "nil config returns chat",
+			cfg:      nil,
+			auth:     &cliproxyauth.Auth{Provider: "test"},
+			expected: "chat",
+		},
+		{
+			name: "config with responses wire-api",
+			cfg: &config.Config{
+				OpenAICompatibility: []config.OpenAICompatibility{
+					{
+						Name:    "test-provider",
+						WireAPI: "responses",
+					},
+				},
+			},
+			auth: &cliproxyauth.Auth{
+				Provider: "test-provider",
+			},
+			expected: "responses",
+		},
+		{
+			name: "config with chat wire-api",
+			cfg: &config.Config{
+				OpenAICompatibility: []config.OpenAICompatibility{
+					{
+						Name:    "test-provider",
+						WireAPI: "chat",
+					},
+				},
+			},
+			auth: &cliproxyauth.Auth{
+				Provider: "test-provider",
+			},
+			expected: "chat",
+		},
+		{
+			name: "config with empty wire-api defaults to chat",
+			cfg: &config.Config{
+				OpenAICompatibility: []config.OpenAICompatibility{
+					{
+						Name:    "test-provider",
+						WireAPI: "",
+					},
+				},
+			},
+			auth: &cliproxyauth.Auth{
+				Provider: "test-provider",
+			},
+			expected: "chat",
+		},
+		{
+			name: "provider not found defaults to chat",
+			cfg: &config.Config{
+				OpenAICompatibility: []config.OpenAICompatibility{
+					{
+						Name:    "other-provider",
+						WireAPI: "responses",
+					},
+				},
+			},
+			auth: &cliproxyauth.Auth{
+				Provider: "test-provider",
+			},
+			expected: "chat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &OpenAICompatExecutor{cfg: tt.cfg}
+			got := e.resolveWireAPI(tt.auth)
+			if got != tt.expected {
+				t.Errorf("resolveWireAPI() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/watcher/diff/openai_compat.go
+++ b/internal/watcher/diff/openai_compat.go
@@ -75,6 +75,17 @@ func describeOpenAICompatibilityUpdate(oldEntry, newEntry config.OpenAICompatibi
 	if !equalStringMap(oldEntry.Headers, newEntry.Headers) {
 		details = append(details, "headers updated")
 	}
+	if trimmedOld, trimmedNew := strings.TrimSpace(oldEntry.WireAPI), strings.TrimSpace(newEntry.WireAPI); !strings.EqualFold(trimmedOld, trimmedNew) {
+		oldValue := trimmedOld
+		if oldValue == "" {
+			oldValue = "chat"
+		}
+		newValue := trimmedNew
+		if newValue == "" {
+			newValue = "chat"
+		}
+		details = append(details, fmt.Sprintf("wire-api %s -> %s", oldValue, newValue))
+	}
 	if len(details) == 0 {
 		return ""
 	}

--- a/internal/watcher/diff/openai_compat_test.go
+++ b/internal/watcher/diff/openai_compat_test.go
@@ -185,3 +185,50 @@ func TestOpenAICompatKeyUsesModelNameWhenAliasEmpty(t *testing.T) {
 		t.Fatalf("expected model-name fallback, got %s/%s", key, label)
 	}
 }
+
+func TestDiffOpenAICompatibility_WireAPIChange(t *testing.T) {
+	oldList := []config.OpenAICompatibility{
+		{
+			Name:    "provider-a",
+			WireAPI: "",
+		},
+	}
+	newList := []config.OpenAICompatibility{
+		{
+			Name:    "provider-a",
+			WireAPI: "responses",
+		},
+	}
+
+	changes := DiffOpenAICompatibility(oldList, newList)
+	found := false
+	for _, c := range changes {
+		if strings.Contains(c, "wire-api chat -> responses") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected changes to contain wire-api change, got %v", changes)
+	}
+}
+
+func TestDiffOpenAICompatibility_WireAPINoChange(t *testing.T) {
+	oldList := []config.OpenAICompatibility{
+		{
+			Name:    "provider-a",
+			WireAPI: "responses",
+		},
+	}
+	newList := []config.OpenAICompatibility{
+		{
+			Name:    "provider-a",
+			WireAPI: "responses",
+		},
+	}
+
+	changes := DiffOpenAICompatibility(oldList, newList)
+	if len(changes) != 0 {
+		t.Fatalf("expected no changes, got %v", changes)
+	}
+}


### PR DESCRIPTION
## 问题背景

我使用的中转站（KFC）的模型名称（如 `gpt-5.2-low`）不满足 Codex CLI 的标准模型名格式，无法使用 `codex-api-key` 配置。因此只能使用 `openai-compatibility` 配置。

但该中转站仅支持 `/v1/responses` 端点，不支持 `/v1/chat/completions`。

## 解决方案

新增 `wire-api` 配置选项：

```yaml
openai-compatibility:
  - name: my-provider
    base-url: https://api.example.com/v1
    wire-api: responses  # 新增选项
```

- `wire-api: responses` → 使用 `/responses` 端点
- `wire-api: chat` 或不配置 → 使用 `/chat/completions`（默认，向后兼容）

## 相关信息

- **Related**: #401 (已关闭)
- @unstableneutron 在 #401 中提出了类似的实现思路，并在其 fork 中提交了 [commit 20bef0c](https://github.com/unstableneutron/CLIProxyAPI/commit/20bef0cfb8280d820c0eab7e9ac978f482db48fe)，但未重新提交 PR。感谢他的先驱工作！

## 变更内容

- 在 `OpenAICompatibility` 结构体添加 `WireAPI` 字段
- 添加 `resolveWireAPI()` 从配置读取 wire-api
- 添加 `buildRequestURL()` 动态选择端点
- 支持配置热更新时检测 wire-api 变更
- 添加单元测试

## 测试

- [x] `go build ./...` 编译通过
- [x] `go test ./...` 单元测试通过
- [x] Codex CLI 集成测试通过
- [x] curl 测试 `/v1/responses` 端点通过