### PR TITLE
feat(iflow): add model-specific thinking configs for GLM-4.7 and MiniMax-M2.1

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -741,7 +741,7 @@ func GetIFlowModels() []*ModelInfo {
 		{ID: "qwen3-235b-a22b-instruct", DisplayName: "Qwen3-235B-A22B-Instruct", Description: "Qwen3 235B A22B Instruct", Created: 1753401600},
 		{ID: "qwen3-235b", DisplayName: "Qwen3-235B-A22B", Description: "Qwen3 235B A22B", Created: 1753401600},
 		{ID: "minimax-m2", DisplayName: "MiniMax-M2", Description: "MiniMax M2", Created: 1758672000},
-		{ID: "minimax-m2.1", DisplayName: "MiniMax-M2.1", Description: "MiniMax M2.1", Created: 1766448000},
+		{ID: "minimax-m2.1", DisplayName: "MiniMax-M2.1", Description: "MiniMax M2.1", Created: 1766448000, Thinking: iFlowThinkingSupport},
 	}
 	models := make([]*ModelInfo, 0, len(entries))
 	for _, entry := range entries {


### PR DESCRIPTION
Adds model-specific thinking configuration support for GLM-4.7 and MiniMax-M2.1 in the iFlow executor.

**Changes:**
- GLM-4.7: Uses `extra_body` with `thinking.type: enabled` and `clear_thinking: false`
- MiniMax-M2.1: Uses `reasoning_split: true` for OpenAI-style reasoning separation
- Adds `preserveReasoningContentInMessages` to maintain reasoning history across conversation turns
- Marks MiniMax-M2.1 as supporting thinking in model definitions

This enables proper thinking/reasoning support for these models while maintaining compatibility with existing iFlow models.