### PR TITLE
docs: add ProxyPilot to community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Native macOS GUI for managing CLIProxyAPI: configure providers, model mappings, 
 
 Native macOS menu bar app that unifies Claude, Gemini, OpenAI, Qwen, and Antigravity subscriptions with real-time quota tracking and smart auto-failover for AI coding tools like Claude Code, OpenCode, and Droid - no API keys needed.
 
+### [ProxyPilot](https://github.com/Finesssee/ProxyPilot)
+
+vibeproxy but for Windows – use your Claude Code, Codex, Gemini, Kiro, and Qwen subscriptions with AI coding tools - no API keys needed.
+
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.
 


### PR DESCRIPTION
Adds ProxyPilot to the "Who is with us?" section.

ProxyPilot is vibeproxy but for Windows – a cross-platform API proxy server built in Go with a native Windows desktop app.