### PR TITLE
fix: Implement fallback log directory for file logging on read-only system

### DIFF
--- a/internal/logging/global_logger.go
+++ b/internal/logging/global_logger.go
@@ -99,9 +99,11 @@ func ConfigureLogOutput(loggingToFile bool, logsMaxTotalSizeMB int) error {
 		// When logging to file is enabled but WRITABLE_PATH is not set,
 		// use a default writable location to avoid errors on read-only filesystems
 		// (e.g., Homebrew installations on macOS).
-		if home, err := os.UserHomeDir(); err == nil {
-			logDir = filepath.Join(home, ".cliproxyapi", "logs")
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("logging: failed to determine user home directory for fallback log path: %w", err)
 		}
+		logDir = filepath.Join(home, ".cliproxyapi", "logs")
 	}
 
 	protectedPath := ""


### PR DESCRIPTION
macOS 下面，打开 logging-to-file: true 之后，homebrew services 启动失败，排查后是日志无法写入导致的。

```
[2025-12-29 18:02:45] [--------] [error] [main.go:409] failed to configure log output: logging: failed to create log directory: mkdir logs: read-only file system
CLIProxyAPI Version: 6.6.65, Commit: Homebrew, BuiltAt: 2025-12-29T06:10:11Z
```

实现了一个日志写入错误，fallback 到 ~/.cliproxyapi/logs 的机制。

测试打开功能后，启动成功。