### PR TITLE
fix: preserve ModelStates during auth reload/refresh and parse Antigravity retryDelay

### DIFF
--- a/internal/runtime/executor/antigravity_executor_test.go
+++ b/internal/runtime/executor/antigravity_executor_test.go
@@ -1,0 +1,249 @@
+package executor
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseAntigravityRetryDelay_Valid429Response(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"message": "Resource exhausted",
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "10.5s"}
+			]
+		}
+	}`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result == nil {
+		t.Fatal("Expected non-nil duration")
+	}
+	expected := 10*time.Second + 500*time.Millisecond
+	if *result != expected {
+		t.Errorf("Expected %v, got %v", expected, *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_LargeDuration(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "10627.493230411s"}
+			]
+		}
+	}`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result == nil {
+		t.Fatal("Expected non-nil duration")
+	}
+	// Verify it's roughly 2.95 hours
+	if result.Hours() < 2.9 || result.Hours() > 3.0 {
+		t.Errorf("Expected ~2.95 hours, got %v", *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_EmptyBody(t *testing.T) {
+	result := parseAntigravityRetryDelay(nil)
+	if result != nil {
+		t.Errorf("Expected nil for empty body, got %v", *result)
+	}
+
+	result = parseAntigravityRetryDelay([]byte{})
+	if result != nil {
+		t.Errorf("Expected nil for empty byte slice, got %v", *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_NoErrorDetails(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"message": "Resource exhausted"
+		}
+	}`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result != nil {
+		t.Errorf("Expected nil when no details field, got %v", *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_EmptyDetails(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"details": []
+		}
+	}`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result != nil {
+		t.Errorf("Expected nil for empty details array, got %v", *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_WrongType(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "RATE_LIMIT"}
+			]
+		}
+	}`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result != nil {
+		t.Errorf("Expected nil when @type doesn't match RetryInfo, got %v", *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_EmptyRetryDelay(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": ""}
+			]
+		}
+	}`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result != nil {
+		t.Errorf("Expected nil for empty retryDelay, got %v", *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_InvalidDurationFormat(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "invalid"}
+			]
+		}
+	}`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result != nil {
+		t.Errorf("Expected nil for invalid duration format, got %v", *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_ZeroDuration(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "0s"}
+			]
+		}
+	}`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result != nil {
+		t.Errorf("Expected nil for zero duration, got %v", *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_NegativeDuration(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "-5s"}
+			]
+		}
+	}`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result != nil {
+		t.Errorf("Expected nil for negative duration, got %v", *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_MultipleDetails(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "RATE_LIMIT"},
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "30s"},
+				{"@type": "type.googleapis.com/google.rpc.Help", "links": []}
+			]
+		}
+	}`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result == nil {
+		t.Fatal("Expected non-nil duration")
+	}
+	expected := 30 * time.Second
+	if *result != expected {
+		t.Errorf("Expected %v, got %v", expected, *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_InvalidJSON(t *testing.T) {
+	body := []byte(`{invalid json`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result != nil {
+		t.Errorf("Expected nil for invalid JSON, got %v", *result)
+	}
+}
+
+func TestParseAntigravityRetryDelay_DetailsNotArray(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"details": "not an array"
+		}
+	}`)
+
+	result := parseAntigravityRetryDelay(body)
+	if result != nil {
+		t.Errorf("Expected nil when details is not an array, got %v", *result)
+	}
+}
+
+func TestNewAntigravityStatusErr_429WithRetryDelay(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "60s"}
+			]
+		}
+	}`)
+
+	err := newAntigravityStatusErr(429, body)
+	if err.code != 429 {
+		t.Errorf("Expected code 429, got %d", err.code)
+	}
+	if err.retryAfter == nil {
+		t.Fatal("Expected non-nil retryAfter for 429")
+	}
+	expected := 60 * time.Second
+	if *err.retryAfter != expected {
+		t.Errorf("Expected retryAfter %v, got %v", expected, *err.retryAfter)
+	}
+}
+
+func TestNewAntigravityStatusErr_Non429(t *testing.T) {
+	body := []byte(`{"error": {"message": "Internal error"}}`)
+
+	err := newAntigravityStatusErr(500, body)
+	if err.code != 500 {
+		t.Errorf("Expected code 500, got %d", err.code)
+	}
+	if err.retryAfter != nil {
+		t.Errorf("Expected nil retryAfter for non-429, got %v", *err.retryAfter)
+	}
+}
+
+func TestNewAntigravityStatusErr_429WithoutRetryInfo(t *testing.T) {
+	body := []byte(`{"error": {"message": "Rate limit exceeded"}}`)
+
+	err := newAntigravityStatusErr(429, body)
+	if err.code != 429 {
+		t.Errorf("Expected code 429, got %d", err.code)
+	}
+	if err.retryAfter != nil {
+		t.Errorf("Expected nil retryAfter when no RetryInfo, got %v", *err.retryAfter)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -224,9 +224,19 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 		return nil, nil
 	}
 	m.mu.Lock()
-	if existing, ok := m.auths[auth.ID]; ok && existing != nil && !auth.indexAssigned && auth.Index == "" {
-		auth.Index = existing.Index
-		auth.indexAssigned = existing.indexAssigned
+	if existing, ok := m.auths[auth.ID]; ok && existing != nil {
+		if !auth.indexAssigned && auth.Index == "" {
+			auth.Index = existing.Index
+			auth.indexAssigned = existing.indexAssigned
+		}
+		// Preserve runtime state that is not persisted (deep copy)
+		if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
+			copiedStates := make(map[string]*ModelState, len(existing.ModelStates))
+			for k, v := range existing.ModelStates {
+				copiedStates[k] = v.Clone()
+			}
+			auth.ModelStates = copiedStates
+		}
 	}
 	auth.EnsureIndex()
 	m.auths[auth.ID] = auth.Clone()

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -282,6 +282,14 @@ func (s *Service) applyCoreAuthAddOrUpdate(ctx context.Context, auth *coreauth.A
 		auth.CreatedAt = existing.CreatedAt
 		auth.LastRefreshedAt = existing.LastRefreshedAt
 		auth.NextRefreshAfter = existing.NextRefreshAfter
+		// Preserve runtime state that is not persisted to file (deep copy)
+		if len(existing.ModelStates) > 0 {
+			copiedStates := make(map[string]*coreauth.ModelState, len(existing.ModelStates))
+			for k, v := range existing.ModelStates {
+				copiedStates[k] = v.Clone()
+			}
+			auth.ModelStates = copiedStates
+		}
 		if _, err := s.coreManager.Update(ctx, auth); err != nil {
 			log.Errorf("failed to update auth %s: %v", auth.ID, err)
 		}


### PR DESCRIPTION
## Summary

- Fix `ModelStates` (containing `BackoffLevel`) being lost when auth is reloaded or refreshed
- Parse upstream `retryDelay` from Antigravity 429 responses for accurate cooldown

Fixes #797

## Changes

### 1. Preserve ModelStates in `service.go:applyCoreAuthAddOrUpdate`

```go
if len(existing.ModelStates) > 0 {
    auth.ModelStates = existing.ModelStates
}
```

### 2. Preserve ModelStates in `conductor.go:Manager.Update`

```go
if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
    auth.ModelStates = existing.ModelStates
}
```

### 3. Parse Antigravity retryDelay in `antigravity_executor.go`

- Added `parseAntigravityRetryDelay()` to extract `retryDelay` from 429 responses
- Added `newAntigravityStatusErr()` to create errors with `retryAfter` field
- Updated all 429 error returns to use the new function

## Problem

When auth file changes (after 429) or token refresh occurs:
1. `ModelStates` was not preserved during update
2. `BackoffLevel` reset to 0
3. Cooldown always started at 1s instead of accumulating

Additionally, Antigravity returns `retryDelay: "10627.493230411s"` (~3 hours) but it was ignored, using default exponential backoff instead.

## Test plan

- [ ] Trigger 429 errors and verify cooldown times accumulate properly
- [ ] Verify auth file changes don't reset `BackoffLevel`
- [ ] Verify token refresh doesn't reset `BackoffLevel`
- [ ] Verify Antigravity `retryDelay` is parsed and used for cooldown