### PR TITLE
fix(auth): prevent infinite token refresh loop by persisting access_token

### DIFF
--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -295,9 +295,9 @@ func metadataEqualIgnoringTimestamps(a, b []byte) bool {
 
 	// Fields to ignore: these change on every refresh but don't affect authentication logic.
 	// - timestamp, expired, expires_in, last_refresh: time-related fields that change on refresh
-	// - access_token: Google OAuth returns a new access_token on each refresh, this is expected
-	//   and shouldn't trigger file writes (the new token will be fetched again when needed)
-	ignoredFields := []string{"timestamp", "expired", "expires_in", "last_refresh", "access_token"}
+	// Note: access_token and refresh_token must NOT be ignored, as they need to be persisted
+	// to disk along with the new expiry time to prevent infinite refresh loops.
+	ignoredFields := []string{"timestamp", "expired", "expires_in", "last_refresh"}
 	for _, field := range ignoredFields {
 		delete(objA, field)
 		delete(objB, field)


### PR DESCRIPTION
## Context
Token refresh runs every 5-6 seconds instead of the expected ~55 minutes. The auth files on disk show stale `expired` timestamps (e.g., days ago), causing the refresh check to continuously trigger.

## Changes
- **FileStore**: Removed `access_token` from `ignoredFields` in `metadataEqualIgnoringTimestamps` (`sdk/auth/filestore.go`)
  - Previously, ignoring `access_token` caused the function to treat refreshed metadata as "equal" to existing data
  - This prevented writing the new `access_token` and `expired` timestamp to disk
  - On next refresh check, the stale `expired` value triggered immediate re-refresh

Verified with `go build ./cmd/server`.

Fixes #833