### PR TITLE
fix(antigravity): apply schema cleaning to Gemini 3 models

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1026,7 +1026,7 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	payload = geminiToAntigravity(modelName, payload, projectID)
 	payload, _ = sjson.SetBytes(payload, "model", alias2ModelName(modelName))
 
-	if strings.Contains(modelName, "claude") {
+	if strings.Contains(modelName, "claude") || util.IsGemini3Model(modelName) {
 		strJSON := string(payload)
 		paths := make([]string, 0)
 		util.Walk(gjson.ParseBytes(payload), "", "parametersJsonSchema", &paths)


### PR DESCRIPTION
## Problem

`gemini-3-pro-preview` model fails to execute tool calls in Codex, returning empty responses. The upstream Antigravity API returns `MALFORMED_FUNCTION_CALL` error:

```json
{
  "response": {
    "candidates": [{
      "content": {},
      "finishReason": "MALFORMED_FUNCTION_CALL",
      "finishMessage": "Malformed function call: call:default_api:shell{command:[\"pwd\"],workdir:\"{masked}/z/CLIProxyAPI\"}"
    }],
    "usageMetadata": {...},
    "modelVersion": "gemini-3-pro-high"
  }
}
```

Meanwhile, `gemini-claude-opus-4-5-thinking` works correctly for the same tool calls.

## Fix

Related to #739. Just extend `CleanJSONSchemaForAntigravity` to include Gemini 3 models, applying the same schema normalization that already works for Claude models. This adds required parameters to tools that lack them, preventing the malformed function call error.


Tested with `gemini-3-pro-preview` in Codex - tool calls now execute correctly. Screenshot:

<img width="678" height="1327" alt="SCR-20260102-rhkx-3" src="https://github.com/user-attachments/assets/02fef21a-fd8d-461a-bb08-2d17badfd174" />

