### PR TITLE
docs: add ProxyPilot to community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Native macOS menu bar app that unifies Claude, Gemini, OpenAI, Qwen, and Antigra
 
 Native macOS SwiftUI app for managing CLI AI sessions (Codex, Claude Code, Gemini CLI) with unified provider management, Git review, project organization, global search, and terminal integration. Integrates CLIProxyAPI to provide OAuth authentication for Codex, Claude, Gemini, Antigravity, and Qwen Code, with built-in and third-party provider rerouting through a single proxy endpoint - no API keys needed for OAuth providers.
 
+### [ProxyPilot](https://github.com/Finesssee/ProxyPilot)
+
+Windows-native CLIProxyAPI fork with TUI, system tray, and multi-provider OAuth for AI coding tools - no API keys needed.
+
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.
 


### PR DESCRIPTION
Adds ProxyPilot to the "Who is with us?" section.

**ProxyPilot** - Windows-native CLIProxyAPI fork with TUI, system tray, and multi-provider OAuth for AI coding tools.

https://github.com/Finesssee/ProxyPilot