### PR TITLE
fix: prevent race condition in objectstore auth sync

### DIFF
--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -386,11 +386,12 @@ func (s *ObjectTokenStore) syncConfigFromBucket(ctx context.Context, example str
 }
 
 func (s *ObjectTokenStore) syncAuthFromBucket(ctx context.Context) error {
-	if err := os.RemoveAll(s.authDir); err != nil {
-		return fmt.Errorf("object store: reset auth directory: %w", err)
-	}
+	// NOTE: We intentionally do NOT use os.RemoveAll here.
+	// Wiping the directory triggers file watcher delete events, which then
+	// propagate deletions to the remote object store (race condition).
+	// Instead, we just ensure the directory exists and overwrite files incrementally.
 	if err := os.MkdirAll(s.authDir, 0o700); err != nil {
-		return fmt.Errorf("object store: recreate auth directory: %w", err)
+		return fmt.Errorf("object store: create auth directory: %w", err)
 	}
 
 	prefix := s.prefixedKey(objectStoreAuthPrefix + "/")


### PR DESCRIPTION
## Problem

When the objectstore bootstraps, `syncAuthFromBucket()` uses `os.RemoveAll()` to wipe the local auth directory before pulling from S3. This triggers a race condition:

1. `syncAuthFromBucket()` wipes local auth directory with `RemoveAll`
2. File watcher detects deletions and propagates them to remote store
3. `syncAuthFromBucket()` then pulls from S3, but files are now gone

This causes auth files to be permanently deleted from S3 on every service restart.

## Solution

Use incremental sync instead of delete-then-pull. Just ensure the directory exists and overwrite files as they're downloaded from S3. This prevents the watcher from seeing spurious delete events.

## Testing

- Built and verified the fix locally
- Auth files now persist correctly across service restarts