### PR TITLE
fix(antigravity): preserve finish_reason tool_calls across streaming chunks

### DIFF
--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response.go
@@ -21,8 +21,10 @@ import (
 
 // convertCliResponseToOpenAIChatParams holds parameters for response conversion.
 type convertCliResponseToOpenAIChatParams struct {
-	UnixTimestamp int64
-	FunctionIndex int
+	UnixTimestamp        int64
+	FunctionIndex        int
+	SawToolCall          bool   // Tracks if any tool call was seen in the entire stream
+	UpstreamFinishReason string // Caches the upstream finish reason for final chunk
 }
 
 // functionCallIDCounter provides a process-wide unique counter for function call identifiers.
@@ -78,10 +80,9 @@ func ConvertAntigravityResponseToOpenAI(_ context.Context, _ string, originalReq
 		template, _ = sjson.Set(template, "id", responseIDResult.String())
 	}
 
-	// Extract and set the finish reason.
+	// Cache the finish reason - do NOT set it in output yet (will be set on final chunk)
 	if finishReasonResult := gjson.GetBytes(rawJSON, "response.candidates.0.finishReason"); finishReasonResult.Exists() {
-		template, _ = sjson.Set(template, "choices.0.finish_reason", strings.ToLower(finishReasonResult.String()))
-		template, _ = sjson.Set(template, "choices.0.native_finish_reason", strings.ToLower(finishReasonResult.String()))
+		(*param).(*convertCliResponseToOpenAIChatParams).UpstreamFinishReason = strings.ToUpper(finishReasonResult.String())
 	}
 
 	// Extract and set usage metadata (token counts).
@@ -102,7 +103,6 @@ func ConvertAntigravityResponseToOpenAI(_ context.Context, _ string, originalReq
 
 	// Process the main content part of the response.
 	partsResult := gjson.GetBytes(rawJSON, "response.candidates.0.content.parts")
-	hasFunctionCall := false
 	if partsResult.IsArray() {
 		partResults := partsResult.Array()
 		for i := 0; i < len(partResults); i++ {
@@ -138,7 +138,7 @@ func ConvertAntigravityResponseToOpenAI(_ context.Context, _ string, originalReq
 				template, _ = sjson.Set(template, "choices.0.delta.role", "assistant")
 			} else if functionCallResult.Exists() {
 				// Handle function call content.
-				hasFunctionCall = true
+				(*param).(*convertCliResponseToOpenAIChatParams).SawToolCall = true // Persist across chunks
 				toolCallsResult := gjson.Get(template, "choices.0.delta.tool_calls")
 				functionCallIndex := (*param).(*convertCliResponseToOpenAIChatParams).FunctionIndex
 				(*param).(*convertCliResponseToOpenAIChatParams).FunctionIndex++
@@ -190,9 +190,25 @@ func ConvertAntigravityResponseToOpenAI(_ context.Context, _ string, originalReq
 		}
 	}
 
-	if hasFunctionCall {
-		template, _ = sjson.Set(template, "choices.0.finish_reason", "tool_calls")
-		template, _ = sjson.Set(template, "choices.0.native_finish_reason", "tool_calls")
+	// Determine finish_reason only on the final chunk (has both finishReason and usage metadata)
+	params := (*param).(*convertCliResponseToOpenAIChatParams)
+	upstreamFinishReason := params.UpstreamFinishReason
+	sawToolCall := params.SawToolCall
+
+	usageExists := gjson.GetBytes(rawJSON, "response.usageMetadata").Exists()
+	isFinalChunk := upstreamFinishReason != "" && usageExists
+
+	if isFinalChunk {
+		var finishReason string
+		if sawToolCall {
+			finishReason = "tool_calls"
+		} else if upstreamFinishReason == "MAX_TOKENS" {
+			finishReason = "max_tokens"
+		} else {
+			finishReason = "stop"
+		}
+		template, _ = sjson.Set(template, "choices.0.finish_reason", finishReason)
+		template, _ = sjson.Set(template, "choices.0.native_finish_reason", strings.ToLower(upstreamFinishReason))
 	}
 
 	return []string{template}

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response_test.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response_test.go
@@ -1,0 +1,128 @@
+package chat_completions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestFinishReasonToolCallsNotOverwritten(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	// Chunk 1: Contains functionCall - should set SawToolCall = true
+	chunk1 := []byte(`{"response":{"candidates":[{"content":{"parts":[{"functionCall":{"name":"list_files","args":{"path":"."}}}]}}]}}`)
+	result1 := ConvertAntigravityResponseToOpenAI(ctx, "model", nil, nil, chunk1, &param)
+
+	// Verify chunk1 has no finish_reason (null)
+	if len(result1) != 1 {
+		t.Fatalf("Expected 1 result from chunk1, got %d", len(result1))
+	}
+	fr1 := gjson.Get(result1[0], "choices.0.finish_reason")
+	if fr1.Exists() && fr1.String() != "" && fr1.Type.String() != "Null" {
+		t.Errorf("Expected finish_reason to be null in chunk1, got: %v", fr1.String())
+	}
+
+	// Chunk 2: Contains finishReason STOP + usage (final chunk, no functionCall)
+	// This simulates what the upstream sends AFTER the tool call chunk
+	chunk2 := []byte(`{"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":20,"totalTokenCount":30}}}`)
+	result2 := ConvertAntigravityResponseToOpenAI(ctx, "model", nil, nil, chunk2, &param)
+
+	// Verify chunk2 has finish_reason: "tool_calls" (not "stop")
+	if len(result2) != 1 {
+		t.Fatalf("Expected 1 result from chunk2, got %d", len(result2))
+	}
+	fr2 := gjson.Get(result2[0], "choices.0.finish_reason").String()
+	if fr2 != "tool_calls" {
+		t.Errorf("Expected finish_reason 'tool_calls', got: %s", fr2)
+	}
+
+	// Verify native_finish_reason is lowercase upstream value
+	nfr2 := gjson.Get(result2[0], "choices.0.native_finish_reason").String()
+	if nfr2 != "stop" {
+		t.Errorf("Expected native_finish_reason 'stop', got: %s", nfr2)
+	}
+}
+
+func TestFinishReasonStopForNormalText(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	// Chunk 1: Text content only
+	chunk1 := []byte(`{"response":{"candidates":[{"content":{"parts":[{"text":"Hello world"}]}}]}}`)
+	ConvertAntigravityResponseToOpenAI(ctx, "model", nil, nil, chunk1, &param)
+
+	// Chunk 2: Final chunk with STOP
+	chunk2 := []byte(`{"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}}`)
+	result2 := ConvertAntigravityResponseToOpenAI(ctx, "model", nil, nil, chunk2, &param)
+
+	// Verify finish_reason is "stop" (no tool calls were made)
+	fr := gjson.Get(result2[0], "choices.0.finish_reason").String()
+	if fr != "stop" {
+		t.Errorf("Expected finish_reason 'stop', got: %s", fr)
+	}
+}
+
+func TestFinishReasonMaxTokens(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	// Chunk 1: Text content
+	chunk1 := []byte(`{"response":{"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]}}`)
+	ConvertAntigravityResponseToOpenAI(ctx, "model", nil, nil, chunk1, &param)
+
+	// Chunk 2: Final chunk with MAX_TOKENS
+	chunk2 := []byte(`{"response":{"candidates":[{"finishReason":"MAX_TOKENS"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":100,"totalTokenCount":110}}}`)
+	result2 := ConvertAntigravityResponseToOpenAI(ctx, "model", nil, nil, chunk2, &param)
+
+	// Verify finish_reason is "max_tokens"
+	fr := gjson.Get(result2[0], "choices.0.finish_reason").String()
+	if fr != "max_tokens" {
+		t.Errorf("Expected finish_reason 'max_tokens', got: %s", fr)
+	}
+}
+
+func TestToolCallTakesPriorityOverMaxTokens(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	// Chunk 1: Contains functionCall
+	chunk1 := []byte(`{"response":{"candidates":[{"content":{"parts":[{"functionCall":{"name":"test","args":{}}}]}}]}}`)
+	ConvertAntigravityResponseToOpenAI(ctx, "model", nil, nil, chunk1, &param)
+
+	// Chunk 2: Final chunk with MAX_TOKENS (but we had a tool call, so tool_calls should win)
+	chunk2 := []byte(`{"response":{"candidates":[{"finishReason":"MAX_TOKENS"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":100,"totalTokenCount":110}}}`)
+	result2 := ConvertAntigravityResponseToOpenAI(ctx, "model", nil, nil, chunk2, &param)
+
+	// Verify finish_reason is "tool_calls" (takes priority over max_tokens)
+	fr := gjson.Get(result2[0], "choices.0.finish_reason").String()
+	if fr != "tool_calls" {
+		t.Errorf("Expected finish_reason 'tool_calls', got: %s", fr)
+	}
+}
+
+func TestNoFinishReasonOnIntermediateChunks(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	// Chunk 1: Text content (no finish reason, no usage)
+	chunk1 := []byte(`{"response":{"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]}}`)
+	result1 := ConvertAntigravityResponseToOpenAI(ctx, "model", nil, nil, chunk1, &param)
+
+	// Verify no finish_reason on intermediate chunk
+	fr1 := gjson.Get(result1[0], "choices.0.finish_reason")
+	if fr1.Exists() && fr1.String() != "" && fr1.Type.String() != "Null" {
+		t.Errorf("Expected no finish_reason on intermediate chunk, got: %v", fr1)
+	}
+
+	// Chunk 2: More text (no finish reason, no usage)
+	chunk2 := []byte(`{"response":{"candidates":[{"content":{"parts":[{"text":" world"}]}}]}}`)
+	result2 := ConvertAntigravityResponseToOpenAI(ctx, "model", nil, nil, chunk2, &param)
+
+	// Verify no finish_reason on intermediate chunk
+	fr2 := gjson.Get(result2[0], "choices.0.finish_reason")
+	if fr2.Exists() && fr2.String() != "" && fr2.Type.String() != "Null" {
+		t.Errorf("Expected no finish_reason on intermediate chunk, got: %v", fr2)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes streaming tool call detection for clients like Claude Code when using Gemini models via the antigravity translator.

**The Problem:**
When streaming responses with tool calls, the `finish_reason` was being incorrectly overwritten:
1. Chunk 1 contains `functionCall` → should set `finish_reason: "tool_calls"`
2. Chunk 2 contains `finishReason: "STOP"` + usage → overwrites to `finish_reason: "stop"` ❌

Clients like Claude Code see the final `"stop"` and think the conversation ended normally, breaking the tool call flow.

**Root Cause:**
The `hasFunctionCall` variable was local to each chunk processing - no memory across chunks. When chunk 2 has `finishReason: "STOP"` but no `functionCall`, it overwrites the previous correct value.

**The Fix:**
- Add `SawToolCall bool` to track tool calls across the entire stream
- Add `UpstreamFinishReason string` to cache the finish reason
- Only emit `finish_reason` on the final chunk (detected by presence of both `finishReason` AND `usageMetadata`)
- Apply priority: `tool_calls` > `max_tokens` > `stop`

## Changes

- `internal/translator/antigravity/openai/chat-completions/antigravity_openai_response.go`: State tracking and final chunk logic
- `internal/translator/antigravity/openai/chat-completions/antigravity_openai_response_test.go`: 5 unit tests (new file)

## Test Plan

- [x] Unit tests pass (`go test ./internal/translator/antigravity/openai/chat-completions/...`)
- [x] Manual testing with Claude Code + Gemini models via local server
- [x] Verified tool calls complete successfully
- [x] Verified normal text responses still get `finish_reason: "stop"`
- [x] Verified `MAX_TOKENS` responses get `finish_reason: "max_tokens"`

## Test Results

| Scenario | Expected | Actual |
|----------|----------|--------|
| Tool call stream | `"tool_calls"` | ✅ `"tool_calls"` |
| Normal text stream | `"stop"` | ✅ `"stop"` |
| MAX_TOKENS | `"max_tokens"` | ✅ `"max_tokens"` |
| Intermediate chunks | `null` | ✅ `null` |

## Related Issues

This addresses the streaming tool call issues reported when using Claude Code with Gemini models through CLIProxyAPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)