### PR TITLE
fix: Claude OAuth by prefixing tool names and merging beta headers

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -767,7 +767,7 @@ func prefixClaudeToolNames(body []byte) []byte {
 		return body
 	}
 	updated := body
-	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
+	if tools := gjson.GetBytes(updated, "tools"); tools.Exists() && tools.IsArray() {
 		tools.ForEach(func(key, tool gjson.Result) bool {
 			name := tool.Get("name").String()
 			if name != "" && !strings.HasPrefix(name, claudeToolNamePrefix) {
@@ -787,7 +787,7 @@ func stripClaudeToolNamesFromResponse(data []byte) []byte {
 		return data
 	}
 	updated := data
-	if content := gjson.GetBytes(data, "content"); content.IsArray() {
+	if content := gjson.GetBytes(updated, "content"); content.IsArray() {
 		content.ForEach(func(key, item gjson.Result) bool {
 			if item.Get("type").String() == "tool_use" {
 				name := item.Get("name").String()
@@ -813,13 +813,13 @@ func stripClaudeToolNamePrefixFromStream(line []byte) []byte {
 		return bytes.ReplaceAll(line, []byte(`"name":"`+claudeToolNamePrefix), []byte(`"name":"`))
 	}
 	updated := payload
-	if gjson.GetBytes(payload, "content_block.type").String() == "tool_use" {
-		name := gjson.GetBytes(payload, "content_block.name").String()
+	if gjson.GetBytes(updated, "content_block.type").String() == "tool_use" {
+		name := gjson.GetBytes(updated, "content_block.name").String()
 		if strings.HasPrefix(name, claudeToolNamePrefix) {
 			updated, _ = sjson.SetBytes(updated, "content_block.name", strings.TrimPrefix(name, claudeToolNamePrefix))
 		}
 	}
-	if content := gjson.GetBytes(payload, "message.content"); content.IsArray() {
+	if content := gjson.GetBytes(updated, "message.content"); content.IsArray() {
 		content.ForEach(func(key, item gjson.Result) bool {
 			if item.Get("type").String() == "tool_use" {
 				name := item.Get("name").String()


### PR DESCRIPTION
## Summary

Fixes Claude OAuth token rejection error: "This credential is only authorized for use with Claude Code and cannot be used for other API requests."

## Problem

Anthropic's OAuth tokens are restricted to Claude Code usage. The server validates requests by checking:
1. Required beta headers (specifically `claude-code-20250219`)
2. Tool names (custom tools must not conflict with reserved Claude Code tool names)

## Solution

### Tool Name Prefixing
- Prefix custom tool names with `cli_` in outbound requests to avoid conflicts with reserved Claude Code tool names
- Strip `cli_` prefix from tool names in responses (both streaming and non-streaming) for client compatibility

### Beta Header Merging
- Refactor `applyClaudeHeaders` to **merge** incoming `Anthropic-Beta` headers with base betas instead of **replacing** them
- Ensures `claude-code-20250219` and `oauth-2025-04-20` are always present in outbound requests

## Related

This fix mirrors the approach in [opencode-anthropic-auth PR #10](https://github.com/anomalyco/opencode-anthropic-auth/pull/10).

## Testing

Tested with amp CLI using Claude models - requests now succeed where they previously returned 400 errors.