### PR TITLE
feat: add usage statistics persistence support

### DIFF
--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
-	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/wsrelay"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
@@ -417,6 +417,7 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 
 	usage.StartDefault(ctx)
+	internalusage.StartPersistence(ctx)
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer shutdownCancel()
@@ -652,6 +653,7 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		}
 
 		usage.StopDefault()
+		internalusage.StopPersistence()
 	})
 	return shutdownErr
 }


### PR DESCRIPTION
- Add SaveStatistics() and LoadStatistics() functions to persist/restore usage data to JSON file
- Implement background persistence goroutine with 5-minute interval
- Add SetPersistencePath() to configure the storage directory
- Integrate persistence lifecycle (start/stop) into Service.Run and Service.Shutdown
- Use atomic file writes (temp file + rename) for data safety
- Load existing statistics on startup and merge with current state