### PR TITLE
fix(validate): enhance level clamping logic for provider family conversions

### DIFF
--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -53,7 +53,10 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		return &config, nil
 	}
 
-	allowClampUnsupported := isBudgetBasedProvider(fromFormat) && isLevelBasedProvider(toFormat)
+	// Allow clamping unsupported levels when converting between different provider families
+	// This handles cases like OpenAI (level-based) -> Antigravity (budget-based) where
+	// the source may request "medium" but target only supports "low"/"high"
+	allowClampUnsupported := fromFormat != "" && toFormat != "" && !isSameProviderFamily(fromFormat, toFormat)
 	strictBudget := !fromSuffix && fromFormat != "" && isSameProviderFamily(fromFormat, toFormat)
 	budgetDerivedFromLevel := false
 


### PR DESCRIPTION
# Fix: Allow clamping unsupported thinking levels in cross-provider conversions

## Problem

When using Oracle tool (or any OpenAI-compatible client) with `reasoning_effort: "medium"`, requests to Antigravity models like `gemini-3-pro-high` fail with error:

```
level "medium" not supported, valid levels: low, high
```

This happens because:
1. OpenAI format sends `reasoning_effort: "medium"`
2. Request is routed to `gemini-3-pro-high` which only supports `["low", "high"]`
3. The validation logic did not allow clamping when converting from level-based (OpenAI) to budget-based (Antigravity) providers

## Root Cause

The `allowClampUnsupported` condition in `validate.go` only allowed clamping in one direction:
- ✅ Budget-based → Level-based (e.g., Gemini → OpenAI)
- ❌ Level-based → Budget-based (e.g., OpenAI → Antigravity)

## Solution

Expand `allowClampUnsupported` to allow clamping in both directions and for any cross-provider family conversions:

```go
// Before
allowClampUnsupported := isBudgetBasedProvider(fromFormat) && isLevelBasedProvider(toFormat)

// After
allowClampUnsupported := (isBudgetBasedProvider(fromFormat) && isLevelBasedProvider(toFormat)) ||
    (isLevelBasedProvider(fromFormat) && isBudgetBasedProvider(toFormat)) ||
    (fromFormat != "" && toFormat != "" && !isSameProviderFamily(fromFormat, toFormat))
```

Now when `reasoning_effort: "medium"` is sent to a model that only supports `["low", "high"]`, the level is clamped to the nearest supported level (`"high"`) instead of returning an error.

## Files Changed

| File | Change |
|------|--------|
| `internal/thinking/validate.go` | Expand `allowClampUnsupported` condition to handle cross-provider conversions in both directions |

## Testing

**Environment:** AMP Code (ampcode.com) with CLIProxyAPI backend

**Steps to reproduce:**
1. Start CLIProxyAPI server with AMP Code configuration
2. In AMP Code, use Oracle tool to analyze a project
3. Oracle triggers request with `reasoning_effort: "medium"` 
4. Request is mapped: `gpt-5.2` → `gemini-3-pro-preview` → `gemini-3-pro-high`
5. Verify no "level not supported" error occurs
6. Verify the request succeeds with level clamped to `"high"`

**Test command in AMP Code:**
```
Oracle: Analyze the project structure and summarize main technologies used
```

## Bug Report (Before Fix)

**Issue:** Oracle tool fails with configuration error in AMP Code

**Error message:**
```
Oracle tool failed.
Reason: Backend configuration error - level "medium" not supported, valid levels: low, high
```

**Server logs:**
```
[warn ] thinking: validation failed | provider=antigravity model=gemini-3-pro-high error=level "medium" not supported, valid levels: low, high
[warn ] 400 | POST "/api/provider/openai/v1/responses"
```

## Expected Behavior (After Fix)

**Result:** Oracle tool works successfully, level is automatically clamped

**Server logs:**
```
[debug] thinking: level clamped | provider=antigravity model=gemini-3-pro-high original_value=medium clamped_to=high
[info ] 200 | POST "/api/provider/openai/v1/responses"
```
