### PR TITLE
fix(translator): extract system messages from input in codex response…

### DIFF
--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -43,6 +43,7 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "temperature")
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "top_p")
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "service_tier")
+	rawJSON, _ = sjson.DeleteBytes(rawJSON, "metadata")
 
 	originalInstructions := ""
 	originalInstructionsText := ""


### PR DESCRIPTION
When codexInstructionsEnabled is false (default), the hasOfficialInstructions flag is set to true, causing the code to enter the 'passthrough' branch. Previously, this branch forwarded the input array directly to OpenAI Responses API without filtering out system messages.

The OpenAI Responses API (/v1/responses) does not accept messages with role: 'system' in the input array, returning:
  {"detail":"System messages are not allowed"}

This commit fixes the issue by:
1. Extracting content from any system messages in the input array
2. Removing system messages from the input before forwarding
3. Appending the extracted system content to the instructions field

This ensures compatibility with the OpenAI Responses API while preserving the system instructions for the model (e.g., Cline tool definitions).

Closes: Related to codexInstructionsEnabled behavior when false