### PR TITLE
fix(antigravity): add web search tool support for Claude/OpenAI format requests

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -71,6 +71,7 @@ func deriveSessionID(rawJSON []byte) string {
 func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ bool) []byte {
 	enableThoughtTranslate := true
 	rawJSON := bytes.Clone(inputRawJSON)
+	hasWebSearchTool := false
 
 	// Derive session ID for signature caching
 	sessionID := deriveSessionID(rawJSON)
@@ -346,6 +347,10 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 		toolsResults := toolsResult.Array()
 		for i := 0; i < len(toolsResults); i++ {
 			toolResult := toolsResults[i]
+			if toolResult.Get("type").String() == "web_search" || toolResult.Get("name").String() == "web_search" {
+				hasWebSearchTool = true
+				continue
+			}
 			inputSchemaResult := toolResult.Get("input_schema")
 			if inputSchemaResult.Exists() && inputSchemaResult.IsObject() {
 				// Sanitize the input schema for Antigravity API compatibility
@@ -361,6 +366,13 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 				toolsJSON, _ = sjson.SetRaw(toolsJSON, "0.functionDeclarations.-1", tool)
 				toolDeclCount++
 			}
+		}
+	}
+	if hasWebSearchTool {
+		if toolsJSON == "" {
+			toolsJSON = `[{"googleSearch":{}}]`
+		} else {
+			toolsJSON, _ = sjson.SetRaw(toolsJSON, "0.googleSearch", `{}`)
 		}
 	}
 
@@ -401,6 +413,9 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 	if toolDeclCount > 0 {
 		out, _ = sjson.SetRaw(out, "request.tools", toolsJSON)
 	}
+	if hasWebSearchTool && toolDeclCount == 0 {
+		out, _ = sjson.SetRaw(out, "request.tools", toolsJSON)
+	}
 
 	// Map Anthropic thinking -> Gemini thinkingBudget/include_thoughts when type==enabled
 	if t := gjson.GetBytes(rawJSON, "thinking"); enableThoughtTranslate && t.Exists() && t.IsObject() {
@@ -423,6 +438,11 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 	}
 	if v := gjson.GetBytes(rawJSON, "max_tokens"); v.Exists() && v.Type == gjson.Number {
 		out, _ = sjson.Set(out, "request.generationConfig.maxOutputTokens", v.Num)
+	}
+	if hasWebSearchTool {
+		out, _ = sjson.Set(out, "model", "gemini-2.5-flash")
+		out, _ = sjson.Set(out, "request.generationConfig.candidateCount", 1)
+		out, _ = sjson.Set(out, "requestType", "web_search")
 	}
 
 	outBytes := []byte(out)

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -34,11 +34,24 @@ import (
 //   - []byte: The transformed request data in Gemini API format
 func ConvertGeminiRequestToAntigravity(_ string, inputRawJSON []byte, _ bool) []byte {
 	rawJSON := bytes.Clone(inputRawJSON)
+	hasWebSearchTool := false
+	tools := gjson.GetBytes(rawJSON, "tools")
+	if tools.Exists() && tools.IsArray() {
+		for _, tool := range tools.Array() {
+			if tool.Get("googleSearch").Exists() {
+				hasWebSearchTool = true
+				break
+			}
+		}
+	}
 	template := ""
 	template = `{"project":"","request":{},"model":""}`
 	template, _ = sjson.SetRaw(template, "request", string(rawJSON))
 	template, _ = sjson.Set(template, "model", gjson.Get(template, "request.model").String())
 	template, _ = sjson.Delete(template, "request.model")
+	if hasWebSearchTool {
+		template, _ = sjson.Set(template, "requestType", "web_search")
+	}
 
 	template, errFixCLIToolResponse := fixCLIToolResponse(template)
 	if errFixCLIToolResponse != nil {

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -29,6 +29,7 @@ const geminiCLIFunctionThoughtSignature = "skip_thought_signature_validator"
 //   - []byte: The transformed request data in Gemini CLI API format
 func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ bool) []byte {
 	rawJSON := bytes.Clone(inputRawJSON)
+	hasWebSearchTool := false
 	// Base envelope (no default thinkingConfig)
 	out := []byte(`{"project":"","request":{"contents":[]},"model":"gemini-2.5-pro"}`)
 
@@ -361,6 +362,16 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 					hasTool = true
 				}
 			}
+			if t.Get("type").String() == "web_search" {
+				hasWebSearchTool = true
+				var errSet error
+				toolNode, errSet = sjson.SetRawBytes(toolNode, "googleSearch", []byte(`{}`))
+				if errSet != nil {
+					log.Warnf("Failed to set googleSearch tool for web_search: %v", errSet)
+					continue
+				}
+				hasTool = true
+			}
 			if gs := t.Get("google_search"); gs.Exists() {
 				var errSet error
 				toolNode, errSet = sjson.SetRawBytes(toolNode, "googleSearch", []byte(gs.Raw))
@@ -375,6 +386,12 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 			out, _ = sjson.SetRawBytes(out, "request.tools", []byte("[]"))
 			out, _ = sjson.SetRawBytes(out, "request.tools.0", toolNode)
 		}
+	}
+
+	if hasWebSearchTool {
+		out, _ = sjson.SetBytes(out, "model", "gemini-2.5-flash")
+		out, _ = sjson.SetBytes(out, "request.generationConfig.candidateCount", 1)
+		out, _ = sjson.SetBytes(out, "requestType", "web_search")
 	}
 
 	return common.AttachDefaultSafetySettings(out, "request.safetySettings")

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request.go
@@ -5,10 +5,25 @@ import (
 
 	. "github.com/router-for-me/CLIProxyAPI/v6/internal/translator/antigravity/gemini"
 	. "github.com/router-for-me/CLIProxyAPI/v6/internal/translator/gemini/openai/responses"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func ConvertOpenAIResponsesRequestToAntigravity(modelName string, inputRawJSON []byte, stream bool) []byte {
 	rawJSON := bytes.Clone(inputRawJSON)
+	hasWebSearchTool := false
+	if tools := gjson.GetBytes(rawJSON, "tools"); tools.Exists() && tools.IsArray() {
+		for _, tool := range tools.Array() {
+			if tool.Get("type").String() == "web_search" {
+				hasWebSearchTool = true
+				break
+			}
+		}
+	}
 	rawJSON = ConvertOpenAIResponsesRequestToGemini(modelName, rawJSON, stream)
+	if hasWebSearchTool {
+		rawJSON, _ = sjson.SetBytes(rawJSON, "model", "gemini-2.5-flash")
+		rawJSON, _ = sjson.SetBytes(rawJSON, "generationConfig.candidateCount", 1)
+	}
 	return ConvertGeminiRequestToAntigravity(modelName, rawJSON, stream)
 }


### PR DESCRIPTION
## Summary

This PR fixes a **critical user experience bug** where `web_search` tool requests via Claude/OpenAI API formats are silently ignored by the Antigravity backend.

## Problem

**This is a severe UX issue that completely breaks web search functionality.**

Current behavior:
- When users send `{"type": "web_search"}` tool via Claude API format → **tool is silently ignored**
- When users send `{"type": "web_search"}` tool via OpenAI API format → **also ignored**
- Even when Gemini backend returns grounding results (`groundingMetadata`) → **response data is completely lost**, client sees nothing

**From user's perspective**: They configure web search tool, but AI never searches and never returns any citations. Users assume the feature is broken or disabled.

## Solution

### Request Translation
- Detect Claude format `{"type": "web_search"}` or `{"name": "web_search"}` tool declarations
- Detect OpenAI format `{"type": "web_search"}` tool declarations
- Convert to Gemini's `{"googleSearch": {}}` format
- Auto-set `requestType: "web_search"` flag
- Force use `gemini-2.5-flash` model (currently the only model supporting grounding)

### Response Translation
- Parse `groundingMetadata.webSearchQueries` and `groundingMetadata.groundingChunks` from Gemini response
- Convert to Claude format `server_tool_use` + `web_search_tool_result` content blocks
- Support both streaming (SSE) and non-streaming responses

## Changed Files

| File | Change |
|------|--------|
| `antigravity_executor.go` | Add `requestType` detection, auto-identify web_search requests |
| `antigravity_claude_request.go` | Claude → Antigravity request conversion, detect web_search tool |
| `antigravity_claude_response.go` | Antigravity → Claude response conversion, extract and format search results |
| `antigravity_gemini_request.go` | Gemini → Antigravity request conversion, set requestType |
| `antigravity_openai_request.go` | OpenAI Chat → Antigravity request conversion |
| `antigravity_openai-responses_request.go` | OpenAI Responses → Antigravity request conversion |

## Screenshots

### Before

<img width="1189" height="204" alt="image" src="https://github.com/user-attachments/assets/8a82a3a0-5ba7-42e4-9f7f-3185bfe01dad" />


### After
<img width="1908" height="745" alt="image" src="https://github.com/user-attachments/assets/f4d382d9-3bc6-43a9-918f-d2fabf520b57" />


### Note: This PR includes commit 9c0e746 from #1126 (pending merge).



## Testing

- [x] Claude format web_search tool request → correctly converted and returns search results
- [x] OpenAI format web_search tool request → correctly converted and returns search results
- [x] Streaming response correctly outputs `server_tool_use` and `web_search_tool_result` events
- [x] Non-streaming response correctly contains search result blocks