### PR TITLE
fix: change HTTP status code from 400 to 502 when no provider available

### DIFF
--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -615,7 +615,7 @@ func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string
 	}
 
 	if len(providers) == 0 {
-		return nil, "", &interfaces.ErrorMessage{StatusCode: http.StatusBadRequest, Error: fmt.Errorf("unknown provider for model %s", modelName)}
+		return nil, "", &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("unknown provider for model %s", modelName)}
 	}
 
 	// The thinking suffix is preserved in the model name itself, so no


### PR DESCRIPTION
## 问题描述

修复 #1082

当所有 Antigravity 账号都不可用时，CPA 之前返回 HTTP 400，但这会被 NewAPI 识别为请求错误而不进行重试，影响整体可靠性。

## 修改内容

将 `sdk/api/handlers/handlers.go` 中 `getRequestDetails` 函数的错误响应状态码从 `http.StatusBadRequest` (400) 修改为 `http.StatusBadGateway` (502)。

## 效果

HTTP 502 属于服务端错误，会触发 NewAPI 的错误重试机制，从而提高整体可靠性。

## Problem Description
Fixes #1082

When all Antigravity accounts are unavailable, CPA previously returned HTTP 400. However, this status code is interpreted by NewAPI as a client request error, which prevents retry attempts and impacts overall system reliability.

## Changes Made
Modified the error response status code in the getRequestDetails function within 
sdk/api/handlers/handlers.go
 from http.StatusBadRequest (400) to http.StatusBadGateway (502).

## Impact
HTTP 502 is categorized as a server-side error, which triggers NewAPI's error retry mechanism, thereby improving overall system reliability.