### PR TITLE
fix: prevent Event Loop with ExpectedWriteTracker (Issue #833 Part 2)

### DIFF
--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -78,6 +78,8 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 			if metadataEqualIgnoringTimestamps(existing, raw, auth.Provider) {
 				return path, nil
 			}
+			// Record expected write to prevent fsnotify loop (Issue #833)
+			GetExpectedWriteTracker().ExpectWrite(path, raw)
 			file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600)
 			if errOpen != nil {
 				return "", fmt.Errorf("auth filestore: open existing failed: %w", errOpen)
@@ -93,6 +95,8 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 		} else if !os.IsNotExist(errRead) {
 			return "", fmt.Errorf("auth filestore: read existing failed: %w", errRead)
 		}
+		// Record expected write to prevent fsnotify loop (Issue #833)
+		GetExpectedWriteTracker().ExpectWrite(path, raw)
 		if errWrite := os.WriteFile(path, raw, 0o600); errWrite != nil {
 			return "", fmt.Errorf("auth filestore: write file failed: %w", errWrite)
 		}
@@ -317,9 +321,12 @@ func jsonEqual(a, b []byte) bool {
 // ignoring fields that change on every refresh but don't affect functionality.
 // This prevents unnecessary file writes that would trigger watcher events and
 // create refresh loops.
-// The provider parameter controls whether access_token is ignored: providers like
-// Google OAuth (gemini, gemini-cli) can re-fetch tokens when needed, while others
-// like iFlow require the refreshed token to be persisted.
+//
+// NOTE: access_token is NOT ignored for Google OAuth providers (gemini, gemini-cli, antigravity).
+// Access tokens have a 1-hour lifespan and MUST be persisted after refresh, otherwise
+// the token will remain expired on disk while being refreshed in memory, causing
+// a refresh loop and authentication failures.
+// See: GitHub Issue #833
 func metadataEqualIgnoringTimestamps(a, b []byte, provider string) bool {
 	var objA, objB map[string]any
 	if err := json.Unmarshal(a, &objA); err != nil {
@@ -331,14 +338,8 @@ func metadataEqualIgnoringTimestamps(a, b []byte, provider string) bool {
 
 	// Fields to ignore: these change on every refresh but don't affect authentication logic.
 	// - timestamp, expired, expires_in, last_refresh: time-related fields that change on refresh
+	// NOTE: access_token is NOT ignored because it MUST be persisted to disk after refresh.
 	ignoredFields := []string{"timestamp", "expired", "expires_in", "last_refresh"}
-
-	// For providers that can re-fetch tokens when needed (e.g., Google OAuth),
-	// we ignore access_token to avoid unnecessary file writes.
-	switch provider {
-	case "gemini", "gemini-cli", "antigravity":
-		ignoredFields = append(ignoredFields, "access_token")
-	}
 
 	for _, field := range ignoredFields {
 		delete(objA, field)

--- a/sdk/auth/store_registry.go
+++ b/sdk/auth/store_registry.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"crypto/sha256"
 	"sync"
 
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -10,6 +11,73 @@ var (
 	storeMu         sync.RWMutex
 	registeredStore coreauth.Store
 )
+
+// expectedWriteTracker provides a global mechanism to prevent self-triggered fsnotify loops.
+// When the token store writes to an auth file, it records the expected content hash.
+// When the watcher receives fsnotify events, it checks if the event matches an expected write
+// and ignores it if so. This prevents the infinite loop described in Issue #833.
+var expectedWriteTracker struct {
+	mu    sync.RWMutex
+	track *tracker
+}
+
+type tracker struct {
+	expected map[string]string // path -> hash
+}
+
+// GetExpectedWriteTracker returns the global expected write tracker.
+// This is used by both the token store (to record writes) and the watcher (to filter events).
+func GetExpectedWriteTracker() *tracker {
+	expectedWriteTracker.mu.RLock()
+	if expectedWriteTracker.track != nil {
+		expectedWriteTracker.mu.RUnlock()
+		return expectedWriteTracker.track
+	}
+	expectedWriteTracker.mu.RUnlock()
+
+	expectedWriteTracker.mu.Lock()
+	defer expectedWriteTracker.mu.Unlock()
+	if expectedWriteTracker.track == nil {
+		expectedWriteTracker.track = &tracker{
+			expected: make(map[string]string),
+		}
+	}
+	return expectedWriteTracker.track
+}
+
+// ExpectWrite records that we expect to write to the given path with the given content.
+// This should be called before writing to the file.
+func (t *tracker) ExpectWrite(path string, content []byte) {
+	if t == nil || path == "" || len(content) == 0 {
+		return
+	}
+	hash := computeContentHash(content)
+	t.expected[path] = hash
+}
+
+// ConsumeIfExpected checks if the given path and content match an expected write.
+// If it matches, the expectation is consumed (removed) and returns true.
+// Returns false if no matching expectation exists.
+func (t *tracker) ConsumeIfExpected(path string, content []byte) bool {
+	if t == nil || path == "" {
+		return false
+	}
+	hash := computeContentHash(content)
+	if expected, ok := t.expected[path]; ok && expected == hash {
+		delete(t.expected, path)
+		return true
+	}
+	return false
+}
+
+// computeContentHash computes SHA256 hash for content comparison.
+func computeContentHash(content []byte) string {
+	if len(content) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(content)
+	return string(sum[:]) // Use first 32 bytes as key
+}
 
 // RegisterTokenStore sets the global token store used by the authentication helpers.
 func RegisterTokenStore(store coreauth.Store) {


### PR DESCRIPTION
## Event Loop 问题修复 - PR (Issue #833 Part 2)

这是 Issue #833 的第二个修复，专注于解决 **Token 刷新后无限循环** 的问题。

### 问题背景

PR #1232 修复了 "Token 不保存" 的问题，但修复后的代码仍然可能触发无限循环：

1. Token 刷新 → `Save()` 写入文件
2. fsnotify 检测到文件变化
3. `Watcher.handleEvent()` 被调用
4. `addOrUpdateClient()` 重新加载认证信息
5. `persistAuthAsync()` 再次调用 `Save()`
6. 回到步骤 1 → **无限循环** ♻️

### 解决方案

实现 **Global ExpectedWriteTracker** 机制，通过内容哈希区分 "自触发" 和 "外部触发" 的文件变化。

### 核心修改

#### 1. `sdk/auth/store_registry.go`
新增全局追踪器：
- `GetExpectedWriteTracker()`: 获取全局单例
- `ExpectWrite(path, content)`: 写入前记录预期内容哈希
- `ConsumeIfExpected(path, content)`: 读取时检查是否是自触发事件

#### 2. `sdk/auth/filestore.go`
在 `Save()` 方法中：
- 在实际写入文件前调用 `ExpectWrite()` 记录预期内容

#### 3. `internal/watcher/events.go`
在 `handleEvent()` 方法中：
- 检测到 fsnotify 事件时，先调用 `ConsumeIfExpected()` 检查
- 如果是自触发的写入，忽略该事件，避免循环
- 如果是外部修改（如用户手动编辑），正常处理

### 工作流程

```
Token 刷新 → Save() 写入前:
  ├─ 调用 ExpectWrite() 记录预期哈希
  └─ 写入文件

fsnotify 事件触发 → handleEvent():
  ├─ 调用 ConsumeIfExpected() 检查
  ├─ 如果匹配 → 忽略 (self-triggered)
  └─ 如果不匹配 → 正常处理 (external change)
```

### 测试

已创建单元测试验证：
- 预期写入记录和消费机制
- SHA256 内容哈希计算
- 空值和边界情况处理

运行测试：
```bash
go test -v ./sdk/auth/
```

### 与 PR #1232 的关系

| PR | 修复内容 | 状态 |
|----|---------|------|
| #1232 | Token 持久化 (access_token 保存) | ✅ 已合并 |
| 本 PR | Event Loop (防止无限循环) | 🔄 待审查 |

两个修复相辅相成，建议在合并本 PR 后同时关闭 Issue #833。

### 相关文档

- [Event Loop 修复技术文档](docs/EVENT_LOOP_FIX.md)
- 测试代码: `sdk/auth/store_registry_test.go`