### PR TITLE
fix(gemini): force type to string for enum fields to fix Antigravity Gemini API error

### DIFF
--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -175,7 +175,7 @@ func convertConstToEnum(jsonStr string) string {
 	return jsonStr
 }
 
-// convertEnumValuesToStrings ensures all enum values are strings.
+// convertEnumValuesToStrings ensures all enum values are strings and the schema type is set to string.
 // Gemini API requires enum values to be of type string, not numbers or booleans.
 func convertEnumValuesToStrings(jsonStr string) string {
 	for _, p := range findPaths(jsonStr, "enum") {
@@ -185,19 +185,15 @@ func convertEnumValuesToStrings(jsonStr string) string {
 		}
 
 		var stringVals []string
-		needsConversion := false
 		for _, item := range arr.Array() {
-			// Check if any value is not a string
-			if item.Type != gjson.String {
-				needsConversion = true
-			}
 			stringVals = append(stringVals, item.String())
 		}
 
-		// Only update if we found non-string values
-		if needsConversion {
-			jsonStr, _ = sjson.Set(jsonStr, p, stringVals)
-		}
+		// Always update enum values to strings and set type to "string"
+		// This ensures compatibility with Antigravity Gemini which only allows enum for STRING type
+		jsonStr, _ = sjson.Set(jsonStr, p, stringVals)
+		parentPath := trimSuffix(p, ".enum")
+		jsonStr, _ = sjson.Set(jsonStr, joinPath(parentPath, "type"), "string")
 	}
 	return jsonStr
 }


### PR DESCRIPTION
关联 issue #1260

### 问题描述
在使用 Anthropic API 路由到 Antigravity Gemini 模型时，如果 tool 的 parameters 中包含 `enum` 字段，且该字段的 `type` 不是 `string`（例如是 `integer` 或 `boolean`），Antigravity Gemini API 会报错：
`GenerateContentRequest.tools[0].function_declarations[x].parameters.properties[y].enum: only allowed for STRING`

### 解决方案
修改了 `internal/util/gemini_schema.go` 中的 `convertEnumValuesToStrings` 函数：
1. 在处理 `enum` 字段时，不仅将 enum 的值转换为字符串数组，还强制将其所属 schema 的 `type` 属性设置为 `"string"`。
2. 确保所有包含枚举值的字段都符合 Gemini API 对于枚举值只能用于字符串类型的要求。

### 验证结果
- 运行了 `internal/util` 下的相关测试，确认修复后能正确处理非字符串类型的枚举字段。