### PR TITLE
fix(logging): add API response timestamp and fix request timestamp timing

### DIFF
--- a/internal/api/middleware/request_logging.go
+++ b/internal/api/middleware/request_logging.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
@@ -103,6 +104,7 @@ func captureRequestInfo(c *gin.Context) (*RequestInfo, error) {
 		Headers:   headers,
 		Body:      body,
 		RequestID: logging.GetGinRequestID(c),
+		Timestamp: time.Now(),
 	}, nil
 }
 

--- a/sdk/api/handlers/gemini/gemini-cli_handlers.go
+++ b/sdk/api/handlers/gemini/gemini-cli_handlers.go
@@ -124,8 +124,8 @@ func (h *GeminiCLIAPIHandler) CLIHandler(c *gin.Context) {
 			log.Errorf("Failed to read response body: %v", err)
 			return
 		}
-		_, _ = c.Writer.Write(output)
 		c.Set("API_RESPONSE_TIMESTAMP", time.Now())
+		_, _ = c.Writer.Write(output)
 		c.Set("API_RESPONSE", output)
 	}
 }

--- a/sdk/api/handlers/gemini/gemini-cli_handlers.go
+++ b/sdk/api/handlers/gemini/gemini-cli_handlers.go
@@ -125,6 +125,7 @@ func (h *GeminiCLIAPIHandler) CLIHandler(c *gin.Context) {
 			return
 		}
 		_, _ = c.Writer.Write(output)
+		c.Set("API_RESPONSE_TIMESTAMP", time.Now())
 		c.Set("API_RESPONSE", output)
 	}
 }

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -361,6 +361,11 @@ func appendAPIResponse(c *gin.Context, data []byte) {
 		return
 	}
 
+	// Capture timestamp on first API response
+	if _, exists := c.Get("API_RESPONSE_TIMESTAMP"); !exists {
+		c.Set("API_RESPONSE_TIMESTAMP", time.Now())
+	}
+
 	if existing, exists := c.Get("API_RESPONSE"); exists {
 		if existingBytes, ok := existing.([]byte); ok && len(existingBytes) > 0 {
 			combined := make([]byte, 0, len(existingBytes)+len(data)+1)


### PR DESCRIPTION
## Summary

- Fix REQUEST INFO timestamp to capture when request first arrives (not at log write time)
- Add API RESPONSE timestamp when upstream response arrives
- Enable accurate measurement of backend response latency in error logs

Fixes #1299

## Changes

| File | Change |
|------|--------|
| `request_logging.go` | Add `Timestamp` field to `RequestInfo`, set at middleware initialization |
| `response_writer.go` | Add `extractAPIResponseTimestamp()`, pass timestamps through logging chain |
| `request_logger.go` | Update `LogRequestWithOptions()` and `writeAPISection()` to accept/output timestamps |
| `handlers.go` | Set `API_RESPONSE_TIMESTAMP` in `appendAPIResponse()` on first response |
| `gemini-cli_handlers.go` | Set `API_RESPONSE_TIMESTAMP` in Gemini CLI handler |

## Example Output

```
=== REQUEST INFO ===
Timestamp: 2026-01-27T18:18:30.366575728+08:00
...

=== API RESPONSE ===
Timestamp: 2026-01-27T18:19:45.123456789+08:00
{...response...}
```