### PR TITLE
feat: Kimi Code (kimi-for-coding) support for Droid CLI via Anthropic…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ CLIProxyAPI includes integrated support for [Amp CLI](https://ampcode.com) and A
 
 **→ [Complete Amp CLI Integration Guide](https://help.router-for.me/agent-client/amp-cli.html)**
 
+## Droid CLI (Factory) and Kimi Code
+
+[Factory Droid CLI](https://docs.factory.ai/cli/getting-started/quickstart) can use CLI Proxy as a custom model endpoint (Anthropic-compatible). For [Kimi Code](https://www.kimi.com/code/docs/en/more/third-party-agents.html) (kimi-for-coding), configure `claude-api-key` with base-url `https://api.kimi.com/coding/`. The proxy sends `User-Agent: claude-code/2.0` to Kimi automatically. Set Droid’s `baseUrl` to the proxy URL (e.g. `http://localhost:8317`) and provider `anthropic` in `~/.factory/settings.json` or `~/.factory/config.json`. See [FACTORY_PROXY_CC](https://gist.github.com/chandika/c4b64c5b8f5e29f6112021d46c159fdd) and [Droid integration guide](https://help.router-for.me/agent-client/droid).
+
 ## SDK Docs
 
 - Usage: [docs/sdk-usage.md](docs/sdk-usage.md)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -150,6 +150,12 @@ codex-instructions-enabled: false
 #       sensitive-words:             # optional: words to obfuscate with zero-width characters
 #         - "API"
 #         - "proxy"
+#
+#   # Kimi Code (Anthropic-compatible). For Droid CLI (Factory) with provider "anthropic".
+#   # User-Agent "claude-code/2.0" is sent automatically; override via headers if needed.
+#   # See https://www.kimi.com/code/docs/en/more/third-party-agents.html
+#   - api-key: "sk-kimi-..."
+#     base-url: "https://api.kimi.com/coding/"
 
 # OpenAI compatibility providers
 # openai-compatibility:
@@ -165,6 +171,13 @@ codex-instructions-enabled: false
 #     models: # The models supported by the provider.
 #       - name: "moonshotai/kimi-k2:free" # The actual model name.
 #         alias: "kimi-k2" # The alias used in the API.
+#
+#
+# Droid CLI (Factory): Configure custom models in ~/.factory/settings.json or ~/.factory/config.json
+# with baseUrl = CLI Proxy URL (e.g. http://localhost:8317), apiKey, and provider "anthropic".
+# For Kimi Code, use claude-api-key (base-url https://api.kimi.com/coding/) above.
+# See https://gist.github.com/chandika/c4b64c5b8f5e29f6112021d46c159fdd
+# and https://help.router-for.me/agent-client/droid.
 
 # Vertex API keys (Vertex-compatible endpoints, use API key + base URL)
 # vertex-api-key:

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -672,7 +672,11 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Arch", "arm64")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Os", "MacOS")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Timeout", "60")
-	misc.EnsureHeader(r.Header, ginHeaders, "User-Agent", "claude-cli/1.0.83 (external, cli)")
+	userAgentDefault := "claude-cli/1.0.83 (external, cli)"
+	if _, baseURL := claudeCreds(auth); IsKimiProvider(baseURL, "claude") {
+		userAgentDefault = KimiUserAgent
+	}
+	misc.EnsureHeader(r.Header, ginHeaders, "User-Agent", userAgentDefault)
 	r.Header.Set("Connection", "keep-alive")
 	r.Header.Set("Accept-Encoding", "gzip, deflate, br, zstd")
 	if stream {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2,9 +2,11 @@ package executor
 
 import (
 	"bytes"
+	"net/http"
 	"testing"
 
 	"github.com/tidwall/gjson"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 func TestApplyClaudeToolPrefix(t *testing.T) {
@@ -59,5 +61,28 @@ func TestStripClaudeToolPrefixFromStreamLine(t *testing.T) {
 	}
 	if got := gjson.GetBytes(payload, "content_block.name").String(); got != "alpha" {
 		t.Fatalf("content_block.name = %q, want %q", got, "alpha")
+	}
+}
+
+func TestApplyClaudeHeaders_KimiUserAgent(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPost, "https://api.kimi.com/coding/v1/messages?beta=true", bytes.NewReader([]byte("{}")))
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"base_url": "https://api.kimi.com/coding/", "api_key": "sk-kimi-test"},
+	}
+	applyClaudeHeaders(req, auth, "sk-kimi-test", false, nil)
+	if got := req.Header.Get("User-Agent"); got != KimiUserAgent {
+		t.Errorf("User-Agent = %q, want %q", got, KimiUserAgent)
+	}
+}
+
+func TestApplyClaudeHeaders_NonKimiUserAgent(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages?beta=true", bytes.NewReader([]byte("{}")))
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"base_url": "https://api.anthropic.com", "api_key": "sk-ant-test"},
+	}
+	applyClaudeHeaders(req, auth, "sk-ant-test", false, nil)
+	want := "claude-cli/1.0.83 (external, cli)"
+	if got := req.Header.Get("User-Agent"); got != want {
+		t.Errorf("User-Agent = %q, want %q", got, want)
 	}
 }

--- a/internal/runtime/executor/kimi.go
+++ b/internal/runtime/executor/kimi.go
@@ -1,0 +1,18 @@
+package executor
+
+import "strings"
+
+// KimiUserAgent is sent to Kimi API when the provider is Kimi, so requests are not rejected.
+// See https://www.kimi.com/code/docs/en/more/third-party-agents.html
+const KimiUserAgent = "claude-code/2.0"
+
+// IsKimiProvider reports whether the provider is Kimi (base URL or provider key).
+// When true, requests should use KimiUserAgent.
+func IsKimiProvider(baseURL, providerKey string) bool {
+	base := strings.ToLower(strings.TrimSpace(baseURL))
+	if strings.Contains(base, "api.kimi.com") {
+		return true
+	}
+	key := strings.ToLower(strings.TrimSpace(providerKey))
+	return key == "kimi" || key == "kimi-for-coding"
+}

--- a/internal/runtime/executor/kimi_test.go
+++ b/internal/runtime/executor/kimi_test.go
@@ -1,0 +1,39 @@
+package executor
+
+import "testing"
+
+func TestIsKimiProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseURL     string
+		providerKey string
+		want        bool
+	}{
+		{"kimi base url coding", "https://api.kimi.com/coding/", "openrouter", true},
+		{"kimi base url v1", "https://api.kimi.com/coding/v1", "other", true},
+		{"kimi base url no slash", "https://api.kimi.com/coding", "x", true},
+		{"provider kimi", "https://example.com/v1", "kimi", true},
+		{"provider kimi-for-coding", "https://example.com", "kimi-for-coding", true},
+		{"provider kimi case", "https://example.com", "KIMI", true},
+		{"provider kimi-for-coding case", "https://example.com", "Kimi-For-Coding", true},
+		{"openrouter", "https://openrouter.ai/api/v1", "openrouter", false},
+		{"other host", "https://api.openai.com/v1", "openai", false},
+		{"empty", "", "", false},
+		{"empty base kimi key", "", "kimi", true},
+		{"empty key kimi base", "https://api.kimi.com/coding/", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsKimiProvider(tt.baseURL, tt.providerKey)
+			if got != tt.want {
+				t.Errorf("IsKimiProvider(%q, %q) = %v, want %v", tt.baseURL, tt.providerKey, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKimiUserAgent(t *testing.T) {
+	if KimiUserAgent != "claude-code/2.0" {
+		t.Errorf("KimiUserAgent = %q, want %q", KimiUserAgent, "claude-code/2.0")
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor_test.go
+++ b/internal/runtime/executor/openai_compat_executor_test.go
@@ -1,0 +1,171 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+const minimalOpenAIResponse = `{"id":"gen-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+
+func TestOpenAICompatExecutor_KimiUserAgent(t *testing.T) {
+	var gotUA string
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(minimalOpenAIResponse))
+	}))
+	defer stub.Close()
+
+	cfg := &config.Config{}
+	e := NewOpenAICompatExecutor("kimi", cfg)
+	auth := &cliproxyauth.Auth{
+		Provider:   "kimi",
+		Attributes: map[string]string{"base_url": stub.URL, "api_key": "sk-test"},
+	}
+	payload := []byte(`{"model":"kimi-for-coding","messages":[{"role":"user","content":"hi"}]}`)
+	req := cliproxyexecutor.Request{Model: "kimi-for-coding", Payload: payload}
+	opts := cliproxyexecutor.Options{
+		Stream:       false,
+		SourceFormat: sdktranslator.FormatOpenAI,
+	}
+
+	resp, err := e.Execute(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(resp.Payload) == 0 {
+		t.Fatal("empty response payload")
+	}
+	if gotUA != KimiUserAgent {
+		t.Errorf("User-Agent = %q, want %q", gotUA, KimiUserAgent)
+	}
+}
+
+func TestOpenAICompatExecutor_NonKimiUserAgent(t *testing.T) {
+	var gotUA string
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(minimalOpenAIResponse))
+	}))
+	defer stub.Close()
+
+	cfg := &config.Config{}
+	e := NewOpenAICompatExecutor("openrouter", cfg)
+	auth := &cliproxyauth.Auth{
+		Provider:   "openrouter",
+		Attributes: map[string]string{"base_url": stub.URL, "api_key": "sk-or-xxx"},
+	}
+	payload := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	req := cliproxyexecutor.Request{Model: "gpt-4", Payload: payload}
+	opts := cliproxyexecutor.Options{
+		Stream:       false,
+		SourceFormat: sdktranslator.FormatOpenAI,
+	}
+
+	_, err := e.Execute(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	want := "cli-proxy-openai-compat"
+	if gotUA != want {
+		t.Errorf("User-Agent = %q, want %q", gotUA, want)
+	}
+}
+
+func TestOpenAICompatExecutor_PrepareRequest_KimiUserAgent(t *testing.T) {
+	var gotUA string
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer stub.Close()
+
+	cfg := &config.Config{}
+	e := NewOpenAICompatExecutor("kimi", cfg)
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"base_url": stub.URL, "api_key": "sk-kimi"},
+	}
+	body := bytes.NewReader([]byte(`{}`))
+	req, err := http.NewRequest(http.MethodPost, stub.URL+"/chat/completions", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.PrepareRequest(req, auth); err != nil {
+		t.Fatal(err)
+	}
+	client := stub.Client()
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if gotUA != KimiUserAgent {
+		t.Errorf("User-Agent = %q, want %q", gotUA, KimiUserAgent)
+	}
+}
+
+func TestNormalizeKimiOpenAIResponse(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []byte
+		output string // gjson path to check, or "unchanged" to expect input equality
+		want   string
+	}{
+		{
+			name:  "reasoning_content only (message)",
+			input: []byte(`{"choices":[{"message":{"role":"assistant","content":"","reasoning_content":"hello"}}]}`),
+			output: "choices.0.message.content",
+			want:   "hello",
+		},
+		{
+			name:  "reasoning_content only (delta)",
+			input: []byte(`{"choices":[{"delta":{"content":null,"reasoning_content":"hi"}}]}`),
+			output: "choices.0.delta.content",
+			want:   "hi",
+		},
+		{
+			name:   "content already set",
+			input:  []byte(`{"choices":[{"message":{"content":"ok","reasoning_content":"skip"}}]}`),
+			output: "choices.0.message.content",
+			want:   "ok",
+		},
+		{
+			name:   "DONE unchanged",
+			input:  []byte("[DONE]"),
+			output: "unchanged",
+			want:   "[DONE]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeKimiOpenAIResponse(tt.input)
+			if tt.output == "unchanged" {
+				if string(got) != tt.want {
+					t.Errorf("got %q, want %q", got, tt.want)
+				}
+				return
+			}
+			v := string(got)
+			if len(v) < 2 {
+				t.Fatalf("normalize returned too short: %q", v)
+			}
+			c := gjson.Get(v, tt.output)
+			if c.String() != tt.want {
+				t.Errorf("%s = %q, want %q", tt.output, c.String(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -45,6 +45,9 @@ type oaiToResponsesState struct {
 	TotalTokens      int64
 	ReasoningTokens  int64
 	UsageSeen        bool
+	// Completed is set when response.completed has been emitted (e.g. from finish_reason or [DONE]).
+	// Used to avoid emitting completion twice when [DONE] follows a finish_reason chunk.
+	Completed bool
 }
 
 // responseIDCounter provides a process-wide unique counter for synthesized response identifiers.
@@ -52,6 +55,268 @@ var responseIDCounter uint64
 
 func emitRespEvent(event string, payload string) string {
 	return fmt.Sprintf("event: %s\ndata: %s", event, payload)
+}
+
+// emitStreamCompletion runs finalization (message/reasoning/fn done events + response.completed)
+// using accumulated stream state. Call when finish_reason is seen or when [DONE] is received
+// and completion has not yet been emitted. Mutates st; caller must set st.Completed = true.
+func emitStreamCompletion(st *oaiToResponsesState, requestRawJSON []byte) []string {
+	var out []string
+	nextSeq := func() int { st.Seq++; return st.Seq }
+
+	// Emit reasoning done events if we have pending reasoning
+	if st.ReasoningID != "" {
+		text := st.ReasoningBuf.String()
+		textDone := `{"type":"response.reasoning_summary_text.done","sequence_number":0,"item_id":"","output_index":0,"summary_index":0,"text":""}`
+		textDone, _ = sjson.Set(textDone, "sequence_number", nextSeq())
+		textDone, _ = sjson.Set(textDone, "item_id", st.ReasoningID)
+		textDone, _ = sjson.Set(textDone, "output_index", st.ReasoningIndex)
+		textDone, _ = sjson.Set(textDone, "text", text)
+		out = append(out, emitRespEvent("response.reasoning_summary_text.done", textDone))
+		partDone := `{"type":"response.reasoning_summary_part.done","sequence_number":0,"item_id":"","output_index":0,"summary_index":0,"part":{"type":"summary_text","text":""}}`
+		partDone, _ = sjson.Set(partDone, "sequence_number", nextSeq())
+		partDone, _ = sjson.Set(partDone, "item_id", st.ReasoningID)
+		partDone, _ = sjson.Set(partDone, "output_index", st.ReasoningIndex)
+		partDone, _ = sjson.Set(partDone, "part.text", text)
+		out = append(out, emitRespEvent("response.reasoning_summary_part.done", partDone))
+		outputItemDone := `{"type":"response.output_item.done","item":{"id":"","type":"reasoning","encrypted_content":"","summary":[{"type":"summary_text","text":""}]},"output_index":0,"sequence_number":0}`
+		outputItemDone, _ = sjson.Set(outputItemDone, "sequence_number", nextSeq())
+		outputItemDone, _ = sjson.Set(outputItemDone, "item.id", st.ReasoningID)
+		outputItemDone, _ = sjson.Set(outputItemDone, "output_index", st.ReasoningIndex)
+		outputItemDone, _ = sjson.Set(outputItemDone, "item.summary.text", text)
+		out = append(out, emitRespEvent("response.output_item.done", outputItemDone))
+		st.Reasonings = append(st.Reasonings, oaiToResponsesStateReasoning{ReasoningID: st.ReasoningID, ReasoningData: text})
+		st.ReasoningID = ""
+		st.ReasoningBuf.Reset()
+	}
+
+	// Emit message done events for all indices that started a message
+	if len(st.MsgItemAdded) > 0 {
+		idxs := make([]int, 0, len(st.MsgItemAdded))
+		for i := range st.MsgItemAdded {
+			idxs = append(idxs, i)
+		}
+		for i := 0; i < len(idxs); i++ {
+			for j := i + 1; j < len(idxs); j++ {
+				if idxs[j] < idxs[i] {
+					idxs[i], idxs[j] = idxs[j], idxs[i]
+				}
+			}
+		}
+		for _, i := range idxs {
+			if st.MsgItemAdded[i] && !st.MsgItemDone[i] {
+				fullText := ""
+				if b := st.MsgTextBuf[i]; b != nil {
+					fullText = b.String()
+				}
+				done := `{"type":"response.output_text.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"text":"","logprobs":[]}`
+				done, _ = sjson.Set(done, "sequence_number", nextSeq())
+				done, _ = sjson.Set(done, "item_id", fmt.Sprintf("msg_%s_%d", st.ResponseID, i))
+				done, _ = sjson.Set(done, "output_index", i)
+				done, _ = sjson.Set(done, "content_index", 0)
+				done, _ = sjson.Set(done, "text", fullText)
+				out = append(out, emitRespEvent("response.output_text.done", done))
+				partDone := `{"type":"response.content_part.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}`
+				partDone, _ = sjson.Set(partDone, "sequence_number", nextSeq())
+				partDone, _ = sjson.Set(partDone, "item_id", fmt.Sprintf("msg_%s_%d", st.ResponseID, i))
+				partDone, _ = sjson.Set(partDone, "output_index", i)
+				partDone, _ = sjson.Set(partDone, "content_index", 0)
+				partDone, _ = sjson.Set(partDone, "part.text", fullText)
+				out = append(out, emitRespEvent("response.content_part.done", partDone))
+				itemDone := `{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}}`
+				itemDone, _ = sjson.Set(itemDone, "sequence_number", nextSeq())
+				itemDone, _ = sjson.Set(itemDone, "output_index", i)
+				itemDone, _ = sjson.Set(itemDone, "item.id", fmt.Sprintf("msg_%s_%d", st.ResponseID, i))
+				itemDone, _ = sjson.Set(itemDone, "item.content.0.text", fullText)
+				out = append(out, emitRespEvent("response.output_item.done", itemDone))
+				st.MsgItemDone[i] = true
+			}
+		}
+	}
+
+	// Emit function call done events for any active function calls
+	if len(st.FuncCallIDs) > 0 {
+		idxs := make([]int, 0, len(st.FuncCallIDs))
+		for i := range st.FuncCallIDs {
+			idxs = append(idxs, i)
+		}
+		for i := 0; i < len(idxs); i++ {
+			for j := i + 1; j < len(idxs); j++ {
+				if idxs[j] < idxs[i] {
+					idxs[i], idxs[j] = idxs[j], idxs[i]
+				}
+			}
+		}
+		for _, i := range idxs {
+			callID := st.FuncCallIDs[i]
+			if callID == "" || st.FuncItemDone[i] {
+				continue
+			}
+			args := "{}"
+			if b := st.FuncArgsBuf[i]; b != nil && b.Len() > 0 {
+				args = b.String()
+			}
+			fcDone := `{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`
+			fcDone, _ = sjson.Set(fcDone, "sequence_number", nextSeq())
+			fcDone, _ = sjson.Set(fcDone, "item_id", fmt.Sprintf("fc_%s", callID))
+			fcDone, _ = sjson.Set(fcDone, "output_index", i)
+			fcDone, _ = sjson.Set(fcDone, "arguments", args)
+			out = append(out, emitRespEvent("response.function_call_arguments.done", fcDone))
+			itemDone := `{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`
+			itemDone, _ = sjson.Set(itemDone, "sequence_number", nextSeq())
+			itemDone, _ = sjson.Set(itemDone, "output_index", i)
+			itemDone, _ = sjson.Set(itemDone, "item.id", fmt.Sprintf("fc_%s", callID))
+			itemDone, _ = sjson.Set(itemDone, "item.arguments", args)
+			itemDone, _ = sjson.Set(itemDone, "item.call_id", callID)
+			itemDone, _ = sjson.Set(itemDone, "item.name", st.FuncNames[i])
+			out = append(out, emitRespEvent("response.output_item.done", itemDone))
+			st.FuncItemDone[i] = true
+			st.FuncArgsDone[i] = true
+		}
+	}
+
+	completed := `{"type":"response.completed","sequence_number":0,"response":{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null}}`
+	completed, _ = sjson.Set(completed, "sequence_number", nextSeq())
+	completed, _ = sjson.Set(completed, "response.id", st.ResponseID)
+	completed, _ = sjson.Set(completed, "response.created_at", st.Created)
+	if len(requestRawJSON) > 0 {
+		req := gjson.ParseBytes(requestRawJSON)
+		if v := req.Get("instructions"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.instructions", v.String())
+		}
+		if v := req.Get("max_output_tokens"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.max_output_tokens", v.Int())
+		}
+		if v := req.Get("max_tool_calls"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.max_tool_calls", v.Int())
+		}
+		if v := req.Get("model"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.model", v.String())
+		}
+		if v := req.Get("parallel_tool_calls"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.parallel_tool_calls", v.Bool())
+		}
+		if v := req.Get("previous_response_id"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.previous_response_id", v.String())
+		}
+		if v := req.Get("prompt_cache_key"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.prompt_cache_key", v.String())
+		}
+		if v := req.Get("reasoning"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.reasoning", v.Value())
+		}
+		if v := req.Get("safety_identifier"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.safety_identifier", v.String())
+		}
+		if v := req.Get("service_tier"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.service_tier", v.String())
+		}
+		if v := req.Get("store"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.store", v.Bool())
+		}
+		if v := req.Get("temperature"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.temperature", v.Float())
+		}
+		if v := req.Get("text"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.text", v.Value())
+		}
+		if v := req.Get("tool_choice"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.tool_choice", v.Value())
+		}
+		if v := req.Get("tools"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.tools", v.Value())
+		}
+		if v := req.Get("top_logprobs"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.top_logprobs", v.Int())
+		}
+		if v := req.Get("top_p"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.top_p", v.Float())
+		}
+		if v := req.Get("truncation"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.truncation", v.String())
+		}
+		if v := req.Get("user"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.user", v.Value())
+		}
+		if v := req.Get("metadata"); v.Exists() {
+			completed, _ = sjson.Set(completed, "response.metadata", v.Value())
+		}
+	}
+	outputsWrapper := `{"arr":[]}`
+	for _, r := range st.Reasonings {
+		item := `{"id":"","type":"reasoning","summary":[{"type":"summary_text","text":""}]}`
+		item, _ = sjson.Set(item, "id", r.ReasoningID)
+		item, _ = sjson.Set(item, "summary.0.text", r.ReasoningData)
+		outputsWrapper, _ = sjson.SetRaw(outputsWrapper, "arr.-1", item)
+	}
+	if len(st.MsgItemAdded) > 0 {
+		midxs := make([]int, 0, len(st.MsgItemAdded))
+		for i := range st.MsgItemAdded {
+			midxs = append(midxs, i)
+		}
+		for i := 0; i < len(midxs); i++ {
+			for j := i + 1; j < len(midxs); j++ {
+				if midxs[j] < midxs[i] {
+					midxs[i], midxs[j] = midxs[j], midxs[i]
+				}
+			}
+		}
+		for _, i := range midxs {
+			txt := ""
+			if b := st.MsgTextBuf[i]; b != nil {
+				txt = b.String()
+			}
+			item := `{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`
+			item, _ = sjson.Set(item, "id", fmt.Sprintf("msg_%s_%d", st.ResponseID, i))
+			item, _ = sjson.Set(item, "content.0.text", txt)
+			outputsWrapper, _ = sjson.SetRaw(outputsWrapper, "arr.-1", item)
+		}
+	}
+	if len(st.FuncArgsBuf) > 0 {
+		idxs := make([]int, 0, len(st.FuncArgsBuf))
+		for i := range st.FuncArgsBuf {
+			idxs = append(idxs, i)
+		}
+		for i := 0; i < len(idxs); i++ {
+			for j := i + 1; j < len(idxs); j++ {
+				if idxs[j] < idxs[i] {
+					idxs[i], idxs[j] = idxs[j], idxs[i]
+				}
+			}
+		}
+		for _, i := range idxs {
+			args := ""
+			if b := st.FuncArgsBuf[i]; b != nil {
+				args = b.String()
+			}
+			callID := st.FuncCallIDs[i]
+			name := st.FuncNames[i]
+			item := `{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`
+			item, _ = sjson.Set(item, "id", fmt.Sprintf("fc_%s", callID))
+			item, _ = sjson.Set(item, "arguments", args)
+			item, _ = sjson.Set(item, "call_id", callID)
+			item, _ = sjson.Set(item, "name", name)
+			outputsWrapper, _ = sjson.SetRaw(outputsWrapper, "arr.-1", item)
+		}
+	}
+	if gjson.Get(outputsWrapper, "arr.#").Int() > 0 {
+		completed, _ = sjson.SetRaw(completed, "response.output", gjson.Get(outputsWrapper, "arr").Raw)
+	}
+	if st.UsageSeen {
+		completed, _ = sjson.Set(completed, "response.usage.input_tokens", st.PromptTokens)
+		completed, _ = sjson.Set(completed, "response.usage.input_tokens_details.cached_tokens", st.CachedTokens)
+		completed, _ = sjson.Set(completed, "response.usage.output_tokens", st.CompletionTokens)
+		if st.ReasoningTokens > 0 {
+			completed, _ = sjson.Set(completed, "response.usage.output_tokens_details.reasoning_tokens", st.ReasoningTokens)
+		}
+		total := st.TotalTokens
+		if total == 0 {
+			total = st.PromptTokens + st.CompletionTokens
+		}
+		completed, _ = sjson.Set(completed, "response.usage.total_tokens", total)
+	}
+	out = append(out, emitRespEvent("response.completed", completed))
+	return out
 }
 
 // ConvertOpenAIChatCompletionsResponseToOpenAIResponses converts OpenAI Chat Completions streaming chunks
@@ -82,7 +347,12 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 		return []string{}
 	}
 	if bytes.Equal(rawJSON, []byte("[DONE]")) {
-		return []string{}
+		if st.Completed {
+			return []string{}
+		}
+		out := emitStreamCompletion(st, requestRawJSON)
+		st.Completed = true
+		return out
 	}
 
 	root := gjson.ParseBytes(rawJSON)
@@ -349,249 +619,10 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 				}
 			}
 
-			// finish_reason triggers finalization, including text done/content done/item done,
-			// reasoning done/part.done, function args done/item done, and completed
+			// finish_reason triggers finalization; use shared helper and mark completed
 			if fr := choice.Get("finish_reason"); fr.Exists() && fr.String() != "" {
-				// Emit message done events for all indices that started a message
-				if len(st.MsgItemAdded) > 0 {
-					// sort indices for deterministic order
-					idxs := make([]int, 0, len(st.MsgItemAdded))
-					for i := range st.MsgItemAdded {
-						idxs = append(idxs, i)
-					}
-					for i := 0; i < len(idxs); i++ {
-						for j := i + 1; j < len(idxs); j++ {
-							if idxs[j] < idxs[i] {
-								idxs[i], idxs[j] = idxs[j], idxs[i]
-							}
-						}
-					}
-					for _, i := range idxs {
-						if st.MsgItemAdded[i] && !st.MsgItemDone[i] {
-							fullText := ""
-							if b := st.MsgTextBuf[i]; b != nil {
-								fullText = b.String()
-							}
-							done := `{"type":"response.output_text.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"text":"","logprobs":[]}`
-							done, _ = sjson.Set(done, "sequence_number", nextSeq())
-							done, _ = sjson.Set(done, "item_id", fmt.Sprintf("msg_%s_%d", st.ResponseID, i))
-							done, _ = sjson.Set(done, "output_index", i)
-							done, _ = sjson.Set(done, "content_index", 0)
-							done, _ = sjson.Set(done, "text", fullText)
-							out = append(out, emitRespEvent("response.output_text.done", done))
-
-							partDone := `{"type":"response.content_part.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}`
-							partDone, _ = sjson.Set(partDone, "sequence_number", nextSeq())
-							partDone, _ = sjson.Set(partDone, "item_id", fmt.Sprintf("msg_%s_%d", st.ResponseID, i))
-							partDone, _ = sjson.Set(partDone, "output_index", i)
-							partDone, _ = sjson.Set(partDone, "content_index", 0)
-							partDone, _ = sjson.Set(partDone, "part.text", fullText)
-							out = append(out, emitRespEvent("response.content_part.done", partDone))
-
-							itemDone := `{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}}`
-							itemDone, _ = sjson.Set(itemDone, "sequence_number", nextSeq())
-							itemDone, _ = sjson.Set(itemDone, "output_index", i)
-							itemDone, _ = sjson.Set(itemDone, "item.id", fmt.Sprintf("msg_%s_%d", st.ResponseID, i))
-							itemDone, _ = sjson.Set(itemDone, "item.content.0.text", fullText)
-							out = append(out, emitRespEvent("response.output_item.done", itemDone))
-							st.MsgItemDone[i] = true
-						}
-					}
-				}
-
-				if st.ReasoningID != "" {
-					stopReasoning(st.ReasoningBuf.String())
-					st.ReasoningBuf.Reset()
-				}
-
-				// Emit function call done events for any active function calls
-				if len(st.FuncCallIDs) > 0 {
-					idxs := make([]int, 0, len(st.FuncCallIDs))
-					for i := range st.FuncCallIDs {
-						idxs = append(idxs, i)
-					}
-					for i := 0; i < len(idxs); i++ {
-						for j := i + 1; j < len(idxs); j++ {
-							if idxs[j] < idxs[i] {
-								idxs[i], idxs[j] = idxs[j], idxs[i]
-							}
-						}
-					}
-					for _, i := range idxs {
-						callID := st.FuncCallIDs[i]
-						if callID == "" || st.FuncItemDone[i] {
-							continue
-						}
-						args := "{}"
-						if b := st.FuncArgsBuf[i]; b != nil && b.Len() > 0 {
-							args = b.String()
-						}
-						fcDone := `{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`
-						fcDone, _ = sjson.Set(fcDone, "sequence_number", nextSeq())
-						fcDone, _ = sjson.Set(fcDone, "item_id", fmt.Sprintf("fc_%s", callID))
-						fcDone, _ = sjson.Set(fcDone, "output_index", i)
-						fcDone, _ = sjson.Set(fcDone, "arguments", args)
-						out = append(out, emitRespEvent("response.function_call_arguments.done", fcDone))
-
-						itemDone := `{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`
-						itemDone, _ = sjson.Set(itemDone, "sequence_number", nextSeq())
-						itemDone, _ = sjson.Set(itemDone, "output_index", i)
-						itemDone, _ = sjson.Set(itemDone, "item.id", fmt.Sprintf("fc_%s", callID))
-						itemDone, _ = sjson.Set(itemDone, "item.arguments", args)
-						itemDone, _ = sjson.Set(itemDone, "item.call_id", callID)
-						itemDone, _ = sjson.Set(itemDone, "item.name", st.FuncNames[i])
-						out = append(out, emitRespEvent("response.output_item.done", itemDone))
-						st.FuncItemDone[i] = true
-						st.FuncArgsDone[i] = true
-					}
-				}
-				completed := `{"type":"response.completed","sequence_number":0,"response":{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null}}`
-				completed, _ = sjson.Set(completed, "sequence_number", nextSeq())
-				completed, _ = sjson.Set(completed, "response.id", st.ResponseID)
-				completed, _ = sjson.Set(completed, "response.created_at", st.Created)
-				// Inject original request fields into response as per docs/response.completed.json
-				if requestRawJSON != nil {
-					req := gjson.ParseBytes(requestRawJSON)
-					if v := req.Get("instructions"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.instructions", v.String())
-					}
-					if v := req.Get("max_output_tokens"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.max_output_tokens", v.Int())
-					}
-					if v := req.Get("max_tool_calls"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.max_tool_calls", v.Int())
-					}
-					if v := req.Get("model"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.model", v.String())
-					}
-					if v := req.Get("parallel_tool_calls"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.parallel_tool_calls", v.Bool())
-					}
-					if v := req.Get("previous_response_id"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.previous_response_id", v.String())
-					}
-					if v := req.Get("prompt_cache_key"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.prompt_cache_key", v.String())
-					}
-					if v := req.Get("reasoning"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.reasoning", v.Value())
-					}
-					if v := req.Get("safety_identifier"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.safety_identifier", v.String())
-					}
-					if v := req.Get("service_tier"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.service_tier", v.String())
-					}
-					if v := req.Get("store"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.store", v.Bool())
-					}
-					if v := req.Get("temperature"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.temperature", v.Float())
-					}
-					if v := req.Get("text"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.text", v.Value())
-					}
-					if v := req.Get("tool_choice"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.tool_choice", v.Value())
-					}
-					if v := req.Get("tools"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.tools", v.Value())
-					}
-					if v := req.Get("top_logprobs"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.top_logprobs", v.Int())
-					}
-					if v := req.Get("top_p"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.top_p", v.Float())
-					}
-					if v := req.Get("truncation"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.truncation", v.String())
-					}
-					if v := req.Get("user"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.user", v.Value())
-					}
-					if v := req.Get("metadata"); v.Exists() {
-						completed, _ = sjson.Set(completed, "response.metadata", v.Value())
-					}
-				}
-				// Build response.output using aggregated buffers
-				outputsWrapper := `{"arr":[]}`
-				if len(st.Reasonings) > 0 {
-					for _, r := range st.Reasonings {
-						item := `{"id":"","type":"reasoning","summary":[{"type":"summary_text","text":""}]}`
-						item, _ = sjson.Set(item, "id", r.ReasoningID)
-						item, _ = sjson.Set(item, "summary.0.text", r.ReasoningData)
-						outputsWrapper, _ = sjson.SetRaw(outputsWrapper, "arr.-1", item)
-					}
-				}
-				// Append message items in ascending index order
-				if len(st.MsgItemAdded) > 0 {
-					midxs := make([]int, 0, len(st.MsgItemAdded))
-					for i := range st.MsgItemAdded {
-						midxs = append(midxs, i)
-					}
-					for i := 0; i < len(midxs); i++ {
-						for j := i + 1; j < len(midxs); j++ {
-							if midxs[j] < midxs[i] {
-								midxs[i], midxs[j] = midxs[j], midxs[i]
-							}
-						}
-					}
-					for _, i := range midxs {
-						txt := ""
-						if b := st.MsgTextBuf[i]; b != nil {
-							txt = b.String()
-						}
-						item := `{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`
-						item, _ = sjson.Set(item, "id", fmt.Sprintf("msg_%s_%d", st.ResponseID, i))
-						item, _ = sjson.Set(item, "content.0.text", txt)
-						outputsWrapper, _ = sjson.SetRaw(outputsWrapper, "arr.-1", item)
-					}
-				}
-				if len(st.FuncArgsBuf) > 0 {
-					idxs := make([]int, 0, len(st.FuncArgsBuf))
-					for i := range st.FuncArgsBuf {
-						idxs = append(idxs, i)
-					}
-					// small-N sort without extra imports
-					for i := 0; i < len(idxs); i++ {
-						for j := i + 1; j < len(idxs); j++ {
-							if idxs[j] < idxs[i] {
-								idxs[i], idxs[j] = idxs[j], idxs[i]
-							}
-						}
-					}
-					for _, i := range idxs {
-						args := ""
-						if b := st.FuncArgsBuf[i]; b != nil {
-							args = b.String()
-						}
-						callID := st.FuncCallIDs[i]
-						name := st.FuncNames[i]
-						item := `{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`
-						item, _ = sjson.Set(item, "id", fmt.Sprintf("fc_%s", callID))
-						item, _ = sjson.Set(item, "arguments", args)
-						item, _ = sjson.Set(item, "call_id", callID)
-						item, _ = sjson.Set(item, "name", name)
-						outputsWrapper, _ = sjson.SetRaw(outputsWrapper, "arr.-1", item)
-					}
-				}
-				if gjson.Get(outputsWrapper, "arr.#").Int() > 0 {
-					completed, _ = sjson.SetRaw(completed, "response.output", gjson.Get(outputsWrapper, "arr").Raw)
-				}
-				if st.UsageSeen {
-					completed, _ = sjson.Set(completed, "response.usage.input_tokens", st.PromptTokens)
-					completed, _ = sjson.Set(completed, "response.usage.input_tokens_details.cached_tokens", st.CachedTokens)
-					completed, _ = sjson.Set(completed, "response.usage.output_tokens", st.CompletionTokens)
-					if st.ReasoningTokens > 0 {
-						completed, _ = sjson.Set(completed, "response.usage.output_tokens_details.reasoning_tokens", st.ReasoningTokens)
-					}
-					total := st.TotalTokens
-					if total == 0 {
-						total = st.PromptTokens + st.CompletionTokens
-					}
-					completed, _ = sjson.Set(completed, "response.usage.total_tokens", total)
-				}
-				out = append(out, emitRespEvent("response.completed", completed))
+				out = append(out, emitStreamCompletion(st, requestRawJSON)...)
+				st.Completed = true
 			}
 
 			return true

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -1,0 +1,82 @@
+package responses
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestConvertOpenAIStream_DONEOnly_EmitsCompletion(t *testing.T) {
+	ctx := context.Background()
+	var param any
+	req := []byte(`{"model":"kimi-for-coding"}`)
+
+	// No prior chunks; only [DONE]. Should emit response.completed (possibly with empty output).
+	out := ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx, "kimi", nil, req, []byte("[DONE]"), &param)
+	var hasCompleted bool
+	for _, s := range out {
+		if strings.Contains(s, "response.completed") {
+			hasCompleted = true
+			break
+		}
+	}
+	if !hasCompleted {
+		t.Errorf("stream with only [DONE]: expected at least one response.completed event, got %d events", len(out))
+	}
+}
+
+func TestConvertOpenAIStream_DeltasThenDONE_EmitsCompletionWithOutput(t *testing.T) {
+	ctx := context.Background()
+	var param any
+	req := []byte(`{"model":"kimi-for-coding"}`)
+
+	// Chunk 1: create + content delta (no finish_reason)
+	ch1 := []byte(`data: {"id":"ch-1","object":"chat.completion.chunk","created":1,"choices":[{"index":0,"delta":{"content":"hi"}}]}`)
+	out1 := ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx, "kimi", nil, req, ch1, &param)
+	if len(out1) == 0 {
+		t.Fatal("expected events from content delta chunk")
+	}
+
+	// Chunk 2: [DONE] only. Should emit completion (we never saw finish_reason).
+	out2 := ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx, "kimi", nil, req, []byte("[DONE]"), &param)
+	var hasCompleted bool
+	var completedData string
+	for _, s := range out2 {
+		if strings.Contains(s, "response.completed") {
+			hasCompleted = true
+			completedData = s
+			break
+		}
+	}
+	if !hasCompleted {
+		t.Fatalf("stream [deltas then DONE]: expected response.completed, got %d events", len(out2))
+	}
+	if !strings.Contains(completedData, "hi") {
+		t.Errorf("response.completed should contain accumulated content %q", "hi")
+	}
+}
+
+func TestConvertOpenAIStream_FinishReasonThenDONE_OneCompletionOnly(t *testing.T) {
+	ctx := context.Background()
+	var param any
+	req := []byte(`{"model":"kimi-for-coding"}`)
+
+	// Chunk 1: content + finish_reason
+	ch1 := []byte(`data: {"id":"ch-1","object":"chat.completion.chunk","created":1,"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}`)
+	out1 := ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx, "kimi", nil, req, ch1, &param)
+	n1 := 0
+	for _, s := range out1 {
+		if strings.Contains(s, "response.completed") {
+			n1++
+		}
+	}
+	if n1 != 1 {
+		t.Fatalf("after finish_reason chunk: expected exactly 1 response.completed, got %d", n1)
+	}
+
+	// Chunk 2: [DONE]. Should emit nothing (already completed).
+	out2 := ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx, "kimi", nil, req, []byte("[DONE]"), &param)
+	if len(out2) != 0 {
+		t.Fatalf("after [DONE] when already completed: expected 0 events, got %d", len(out2))
+	}
+}


### PR DESCRIPTION
… API

Add IsKimiProvider/KimiUserAgent helpers; inject User-Agent in OpenAI-compat and Claude executors when upstream is Kimi. Normalize reasoning_content to content for Kimi responses before translation. Emit response.completed on [DONE] when upstream omits finish_reason (openai->responses). Pass [DONE] through to translator; add unit tests. Document Anthropic-only Kimi setup in config.example.yaml and README.