### PR TITLE
fix(config): enable gemini-3-pro-preview by removing forced alias

### DIFF
--- a/internal/config/oauth_model_alias_migration.go
+++ b/internal/config/oauth_model_alias_migration.go
@@ -12,7 +12,6 @@ import (
 var antigravityModelConversionTable = map[string]string{
 	"gemini-2.5-computer-use-preview-10-2025": "rev19-uic3-1p",
 	"gemini-3-pro-image-preview":              "gemini-3-pro-image",
-	"gemini-3-pro-preview":                    "gemini-3-pro-high",
 	"gemini-3-flash-preview":                  "gemini-3-flash",
 	"gemini-claude-sonnet-4-5":                "claude-sonnet-4-5",
 	"gemini-claude-sonnet-4-5-thinking":       "claude-sonnet-4-5-thinking",
@@ -25,7 +24,6 @@ func defaultAntigravityAliases() []OAuthModelAlias {
 	return []OAuthModelAlias{
 		{Name: "rev19-uic3-1p", Alias: "gemini-2.5-computer-use-preview-10-2025"},
 		{Name: "gemini-3-pro-image", Alias: "gemini-3-pro-image-preview"},
-		{Name: "gemini-3-pro-high", Alias: "gemini-3-pro-preview"},
 		{Name: "gemini-3-flash", Alias: "gemini-3-flash-preview"},
 		{Name: "claude-sonnet-4-5", Alias: "gemini-claude-sonnet-4-5"},
 		{Name: "claude-sonnet-4-5-thinking", Alias: "gemini-claude-sonnet-4-5-thinking"},

--- a/internal/config/oauth_model_alias_migration_test.go
+++ b/internal/config/oauth_model_alias_migration_test.go
@@ -111,8 +111,11 @@ func TestMigrateOAuthModelAlias_ConvertsAntigravityModels(t *testing.T) {
 	if !strings.Contains(content, "rev19-uic3-1p") {
 		t.Fatal("expected gemini-2.5-computer-use-preview-10-2025 to be converted to rev19-uic3-1p")
 	}
-	if !strings.Contains(content, "gemini-3-pro-high") {
-		t.Fatal("expected gemini-3-pro-preview to be converted to gemini-3-pro-high")
+	if !strings.Contains(content, "gemini-3-pro-preview") {
+		t.Fatal("expected gemini-3-pro-preview to be preserved")
+	}
+	if strings.Contains(content, "gemini-3-pro-high") {
+		t.Fatal("expected gemini-3-pro-preview NOT to be converted to gemini-3-pro-high")
 	}
 
 	// Verify missing default aliases were supplemented


### PR DESCRIPTION
## Description
This PR fixes an issue where  was unavailable because it was being forcibly aliased to  in the configuration migration logic.

## Changes
- Removed `"gemini-3-pro-preview": "gemini-3-pro-high"` mapping from `antigravityModelConversionTable` in `internal/config/oauth_model_alias_migration.go`.
- Removed the corresponding default alias from `defaultAntigravityAliases`.
- Updated unit tests in `internal/config/oauth_model_alias_migration_test.go` to assert that `gemini-3-pro-preview` is preserved and not aliased.

## Impact
This change allows users to explicitly select and use the `gemini-3-pro-preview` model via the CLI.