### PR TITLE
fix(antigravity): sanitize request.contents to remove invalid metadata entries

### DIFF
--- a/internal/runtime/executor/antigravity_executor_test.go
+++ b/internal/runtime/executor/antigravity_executor_test.go
@@ -1,0 +1,140 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestSanitizeRequestContents(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedCount  int
+		shouldModify   bool
+	}{
+		{
+			name: "valid contents unchanged",
+			input: `{
+				"request": {
+					"contents": [
+						{"role": "user", "parts": [{"text": "hello"}]},
+						{"role": "model", "parts": [{"text": "hi"}]}
+					]
+				}
+			}`,
+			expectedCount: 2,
+			shouldModify:  false,
+		},
+		{
+			name: "removes entry with safetySettings",
+			input: `{
+				"request": {
+					"contents": [
+						{"role": "user", "parts": [{"text": "hello"}]},
+						{"safetySettings": [], "model": "test"}
+					]
+				}
+			}`,
+			expectedCount: 1,
+			shouldModify:  true,
+		},
+		{
+			name: "removes entry with model field",
+			input: `{
+				"request": {
+					"contents": [
+						{"role": "user", "parts": [{"text": "hello"}]},
+						{"model": "gemini-pro", "userAgent": "test"}
+					]
+				}
+			}`,
+			expectedCount: 1,
+			shouldModify:  true,
+		},
+		{
+			name: "removes entry with systemInstruction",
+			input: `{
+				"request": {
+					"contents": [
+						{"systemInstruction": {}, "toolConfig": {}}
+					]
+				}
+			}`,
+			expectedCount: 0,
+			shouldModify:  true,
+		},
+		{
+			name: "removes entry with request metadata fields",
+			input: `{
+				"request": {
+					"contents": [
+						{"role": "user", "parts": [{"text": "hello"}]},
+						{"requestId": "123", "requestType": "agent", "sessionId": "456"}
+					]
+				}
+			}`,
+			expectedCount: 1,
+			shouldModify:  true,
+		},
+		{
+			name: "keeps function call/response entries",
+			input: `{
+				"request": {
+					"contents": [
+						{"role": "user", "parts": [{"text": "hello"}]},
+						{"role": "model", "parts": [{"functionCall": {"name": "test", "args": {}}}]},
+						{"role": "function", "parts": [{"functionResponse": {"name": "test", "response": {}}}]}
+					]
+				}
+			}`,
+			expectedCount: 3,
+			shouldModify:  false,
+		},
+		{
+			name:          "handles empty contents",
+			input:         `{"request": {"contents": []}}`,
+			expectedCount: 0,
+			shouldModify:  false,
+		},
+		{
+			name:          "handles missing contents",
+			input:         `{"request": {}}`,
+			expectedCount: -1,
+			shouldModify:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeRequestContents([]byte(tt.input))
+			
+			contentsResult := gjson.GetBytes(result, "request.contents")
+			
+			if tt.expectedCount == -1 {
+				if contentsResult.Exists() {
+					t.Errorf("expected no contents field, but got one")
+				}
+				return
+			}
+
+			if !contentsResult.IsArray() {
+				t.Fatalf("expected contents to be an array")
+			}
+
+			actualCount := len(contentsResult.Array())
+			if actualCount != tt.expectedCount {
+				t.Errorf("expected %d contents, got %d", tt.expectedCount, actualCount)
+			}
+
+			for i, content := range contentsResult.Array() {
+				invalidFields := []string{"safetySettings", "model", "userAgent", "requestType", "requestId", "sessionId", "systemInstruction", "toolConfig", "generationConfig", "project", "request", "contents"}
+				for _, field := range invalidFields {
+					if content.Get(field).Exists() {
+						t.Errorf("content[%d] should not have field %q", i, field)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `sanitizeRequestContents()` function to filter invalid content entries before sending to Antigravity/Gemini API
- Prevents "Invalid JSON payload" errors when conversation history contains malformed entries

## The Problem
When conversation history is malformed or contains previous request objects as message entries, the Antigravity/Gemini API returns errors like:
```
Invalid JSON payload received. Unknown name "safetySettings" at 'request.contents[15]'
Invalid JSON payload received. Unknown name "model" at 'request.contents[15]'
Invalid JSON payload received. Unknown name "userAgent" at 'request.contents[15]'
Invalid JSON payload received. Unknown name "systemInstruction" at 'request.contents[15]'
```

## The Fix
This PR adds a sanitization step in `buildRequest()` that:
1. Iterates through all entries in `request.contents`
2. Drops any entry containing request-level metadata fields instead of proper message content
3. Logs a warning when invalid entries are dropped

**Invalid fields filtered:** `safetySettings`, `model`, `userAgent`, `requestType`, `requestId`, `sessionId`, `systemInstruction`, `toolConfig`, `generationConfig`, `project`, `request`, `contents`

**Valid content entries** should only contain: `role`, `parts`

## Testing
- Added comprehensive unit tests for `sanitizeRequestContents()`
- All existing tests pass
- Docker image rebuilt and tested locally