### PR TITLE
feat(logging): make error-logs-max-files configurable

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -50,6 +50,10 @@ logging-to-file: false
 # files are deleted until within the limit. Set to 0 to disable.
 logs-max-total-size-mb: 0
 
+# Maximum number of error log files retained when request logging is disabled.
+# When exceeded, the oldest error log files are deleted. Default is 10. Set to 0 to disable cleanup.
+error-logs-max-files: 10
+
 # When false, disable in-memory usage statistics aggregation
 usage-statistics-enabled: false
 

--- a/examples/custom-provider/main.go
+++ b/examples/custom-provider/main.go
@@ -205,7 +205,7 @@ func main() {
 			// Optional: add a simple middleware + custom request logger
 			api.WithMiddleware(func(c *gin.Context) { c.Header("X-Example", "custom-provider"); c.Next() }),
 			api.WithRequestLoggerFactory(func(cfg *config.Config, cfgPath string) logging.RequestLogger {
-				return logging.NewFileRequestLogger(true, "logs", filepath.Dir(cfgPath))
+				return logging.NewFileRequestLoggerWithOptions(true, "logs", filepath.Dir(cfgPath), cfg.ErrorLogsMaxFiles)
 			}),
 		).
 		WithHooks(hooks).

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -222,6 +222,26 @@ func (h *Handler) PutLogsMaxTotalSizeMB(c *gin.Context) {
 	h.persist(c)
 }
 
+// ErrorLogsMaxFiles
+func (h *Handler) GetErrorLogsMaxFiles(c *gin.Context) {
+	c.JSON(200, gin.H{"error-logs-max-files": h.cfg.ErrorLogsMaxFiles})
+}
+func (h *Handler) PutErrorLogsMaxFiles(c *gin.Context) {
+	var body struct {
+		Value *int `json:"value"`
+	}
+	if errBindJSON := c.ShouldBindJSON(&body); errBindJSON != nil || body.Value == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	value := *body.Value
+	if value < 0 {
+		value = 10
+	}
+	h.cfg.ErrorLogsMaxFiles = value
+	h.persist(c)
+}
+
 // Request log
 func (h *Handler) GetRequestLog(c *gin.Context) { c.JSON(200, gin.H{"request-log": h.cfg.RequestLog}) }
 func (h *Handler) PutRequestLog(c *gin.Context) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -60,9 +60,9 @@ type ServerOption func(*serverOptionConfig)
 func defaultRequestLoggerFactory(cfg *config.Config, configPath string) logging.RequestLogger {
 	configDir := filepath.Dir(configPath)
 	if base := util.WritablePath(); base != "" {
-		return logging.NewFileRequestLogger(cfg.RequestLog, filepath.Join(base, "logs"), configDir)
+		return logging.NewFileRequestLogger(cfg.RequestLog, filepath.Join(base, "logs"), configDir, cfg.ErrorLogsMaxFiles)
 	}
-	return logging.NewFileRequestLogger(cfg.RequestLog, "logs", configDir)
+	return logging.NewFileRequestLogger(cfg.RequestLog, "logs", configDir, cfg.ErrorLogsMaxFiles)
 }
 
 // WithMiddleware appends additional Gin middleware during server construction.
@@ -497,6 +497,10 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PUT("/logs-max-total-size-mb", s.mgmt.PutLogsMaxTotalSizeMB)
 		mgmt.PATCH("/logs-max-total-size-mb", s.mgmt.PutLogsMaxTotalSizeMB)
 
+		mgmt.GET("/error-logs-max-files", s.mgmt.GetErrorLogsMaxFiles)
+		mgmt.PUT("/error-logs-max-files", s.mgmt.PutErrorLogsMaxFiles)
+		mgmt.PATCH("/error-logs-max-files", s.mgmt.PutErrorLogsMaxFiles)
+
 		mgmt.GET("/usage-statistics-enabled", s.mgmt.GetUsageStatisticsEnabled)
 		mgmt.PUT("/usage-statistics-enabled", s.mgmt.PutUsageStatisticsEnabled)
 		mgmt.PATCH("/usage-statistics-enabled", s.mgmt.PutUsageStatisticsEnabled)
@@ -904,6 +908,15 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 			log.Debugf("usage_statistics_enabled updated from %t to %t", oldCfg.UsageStatisticsEnabled, cfg.UsageStatisticsEnabled)
 		} else {
 			log.Debugf("usage_statistics_enabled toggled to %t", cfg.UsageStatisticsEnabled)
+		}
+	}
+
+	if s.requestLogger != nil && (oldCfg == nil || oldCfg.ErrorLogsMaxFiles != cfg.ErrorLogsMaxFiles) {
+		if setter, ok := s.requestLogger.(interface{ SetErrorLogsMaxFiles(int) }); ok {
+			setter.SetErrorLogsMaxFiles(cfg.ErrorLogsMaxFiles)
+		}
+		if oldCfg != nil {
+			log.Debugf("error_logs_max_files updated from %d to %d", oldCfg.ErrorLogsMaxFiles, cfg.ErrorLogsMaxFiles)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,10 @@ type Config struct {
 	// When exceeded, the oldest log files are deleted until within the limit. Set to 0 to disable.
 	LogsMaxTotalSizeMB int `yaml:"logs-max-total-size-mb" json:"logs-max-total-size-mb"`
 
+	// ErrorLogsMaxFiles limits the number of error log files retained when request logging is disabled.
+	// When exceeded, the oldest error log files are deleted. Default is 10. Set to 0 to disable cleanup.
+	ErrorLogsMaxFiles int `yaml:"error-logs-max-files" json:"error-logs-max-files"`
+
 	// UsageStatisticsEnabled toggles in-memory usage aggregation; when false, usage data is discarded.
 	UsageStatisticsEnabled bool `yaml:"usage-statistics-enabled" json:"usage-statistics-enabled"`
 
@@ -502,6 +506,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
 	cfg.LoggingToFile = false
 	cfg.LogsMaxTotalSizeMB = 0
+	cfg.ErrorLogsMaxFiles = 10
 	cfg.UsageStatisticsEnabled = false
 	cfg.DisableCooling = false
 	cfg.AmpCode.RestrictManagementToLocalhost = false // Default to false: API key auth is sufficient
@@ -548,6 +553,10 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	if cfg.LogsMaxTotalSizeMB < 0 {
 		cfg.LogsMaxTotalSizeMB = 0
+	}
+
+	if cfg.ErrorLogsMaxFiles < 0 {
+		cfg.ErrorLogsMaxFiles = 10
 	}
 
 	// Sync request authentication providers with inline API keys for backwards compatibility.

--- a/sdk/logging/request_logger.go
+++ b/sdk/logging/request_logger.go
@@ -3,6 +3,8 @@ package logging
 
 import internallogging "github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 
+const defaultErrorLogsMaxFiles = 10
+
 // RequestLogger defines the interface for logging HTTP requests and responses.
 type RequestLogger = internallogging.RequestLogger
 
@@ -12,7 +14,12 @@ type StreamingLogWriter = internallogging.StreamingLogWriter
 // FileRequestLogger implements RequestLogger using file-based storage.
 type FileRequestLogger = internallogging.FileRequestLogger
 
-// NewFileRequestLogger creates a new file-based request logger.
+// NewFileRequestLogger creates a new file-based request logger with default error log retention (10 files).
 func NewFileRequestLogger(enabled bool, logsDir string, configDir string) *FileRequestLogger {
-	return internallogging.NewFileRequestLogger(enabled, logsDir, configDir)
+	return internallogging.NewFileRequestLogger(enabled, logsDir, configDir, defaultErrorLogsMaxFiles)
+}
+
+// NewFileRequestLoggerWithOptions creates a new file-based request logger with configurable error log retention.
+func NewFileRequestLoggerWithOptions(enabled bool, logsDir string, configDir string, errorLogsMaxFiles int) *FileRequestLogger {
+	return internallogging.NewFileRequestLogger(enabled, logsDir, configDir, errorLogsMaxFiles)
 }


### PR DESCRIPTION
## Summary

Make the hardcoded error log retention limit (10 files) configurable via `error-logs-max-files`.

## Changes

- Add `ErrorLogsMaxFiles` config field with default value 10
- Support hot-reload via config file changes  
- Add Management API: `GET/PUT/PATCH /v0/management/error-logs-max-files`
- Maintain SDK backward compatibility with `NewFileRequestLogger` (3 params)
- Add `NewFileRequestLoggerWithOptions` for custom error log retention

## Configuration

```yaml
# Maximum number of error log files retained when request logging is disabled.
# When exceeded, the oldest error log files are deleted. Default is 10. Set to 0 to disable cleanup.
error-logs-max-files: 10
```

## API

```bash
# Get current value
curl http://localhost:8317/v0/management/error-logs-max-files

# Update value (hot-reload supported)
curl -X PUT http://localhost:8317/v0/management/error-logs-max-files \
  -H "Content-Type: application/json" \
  -d '{"value": 20}'
```