### PR TITLE
fix(auth): 400 invalid_request_error 立即返回不再重试

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -607,6 +607,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				result.RetryAfter = ra
 			}
 			m.MarkResult(execCtx, result)
+			if isRequestInvalidError(errExec) {
+				return cliproxyexecutor.Response{}, errExec
+			}
 			lastErr = errExec
 			continue
 		}
@@ -660,6 +663,9 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				result.RetryAfter = ra
 			}
 			m.MarkResult(execCtx, result)
+			if isRequestInvalidError(errExec) {
+				return cliproxyexecutor.Response{}, errExec
+			}
 			lastErr = errExec
 			continue
 		}
@@ -711,6 +717,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: rerr}
 			result.RetryAfter = retryAfterFromError(errStream)
 			m.MarkResult(execCtx, result)
+			if isRequestInvalidError(errStream) {
+				return nil, errStream
+			}
 			lastErr = errStream
 			continue
 		}
@@ -1110,6 +1119,9 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 	if status := statusCodeFromError(err); status == http.StatusOK {
 		return 0, false
 	}
+	if isRequestInvalidError(err) {
+		return 0, false
+	}
 	wait, found := m.closestCooldownWait(providers, model, attempt)
 	if !found || wait > maxWait {
 		return 0, false
@@ -1428,6 +1440,21 @@ func statusCodeFromResult(err *Error) int {
 		return 0
 	}
 	return err.StatusCode()
+}
+
+// isRequestInvalidError returns true if the error represents a client request
+// error that should not be retried. Specifically, it checks for 400 Bad Request
+// with "invalid_request_error" in the message, indicating the request itself is
+// malformed and switching to a different auth will not help.
+func isRequestInvalidError(err error) bool {
+	if err == nil {
+		return false
+	}
+	status := statusCodeFromError(err)
+	if status != http.StatusBadRequest {
+		return false
+	}
+	return strings.Contains(err.Error(), "invalid_request_error")
 }
 
 func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {


### PR DESCRIPTION
## Summary

When upstream returns 400 Bad Request with `invalid_request_error` in the message, it indicates the request itself is malformed. Switching to a different account will not help.

当上游返回 400 Bad Request 且错误消息包含 `invalid_request_error` 时，表示请求本身格式错误，切换账户不会改变结果。

## Changes

- Add `isRequestInvalidError` helper function
- Inner loop returns immediately on this error, skipping other accounts
- Outer loop (`shouldRetryAfterError`) no longer retries for this error type

---

- 添加 `isRequestInvalidError` 判定函数
- 内层循环遇到此错误立即返回，不遍历其他账户
- 外层循环（`shouldRetryAfterError`）不再对此类错误进行重试

## Why

**Before:**
1. Malformed request → 400 `invalid_request_error`
2. Inner loop continues trying all other accounts (all return the same 400)
3. If cooldown is configured, outer loop may also retry

**After:**
1. Malformed request → 400 `invalid_request_error`
2. Return error immediately, no more attempts with other accounts

---

**之前的行为：**
1. 请求格式错误 → 400 `invalid_request_error`
2. 内层循环继续尝试所有其他账户（全部返回同样的 400）
3. 如果有 cooldown 配置，外层可能还会重试

**修复后：**
1. 请求格式错误 → 400 `invalid_request_error`
2. 立即返回错误，不再尝试其他账户