### PR TITLE
chore: ignore .sisyphus directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ docs/*
 AGENTS.md
 CLAUDE.md
 GEMINI.md
+.sisyphus
 
 # Tooling metadata
 .vscode/*


### PR DESCRIPTION
## Summary

Add `.sisyphus` directory to `.gitignore`.

将 `.sisyphus` 目录添加到 `.gitignore`。

## Why

The `.sisyphus` directory is used by AI coding assistants (OpenCode/Claude Code) to store session data and should not be committed to the repository.

`.sisyphus` 目录用于 AI 编程助手（OpenCode/Claude Code）存储会话数据，不应提交到仓库。