### PR TITLE
fix(logging): expand tilde in auth-dir path for log directory

### DIFF
--- a/internal/logging/global_logger.go
+++ b/internal/logging/global_logger.go
@@ -131,7 +131,10 @@ func ResolveLogDirectory(cfg *config.Config) string {
 		return logDir
 	}
 	if !isDirWritable(logDir) {
-		authDir := strings.TrimSpace(cfg.AuthDir)
+		authDir, err := util.ResolveAuthDir(cfg.AuthDir)
+		if err != nil {
+			log.Warnf("Failed to resolve auth-dir %q for log directory: %v", cfg.AuthDir, err)
+		}
 		if authDir != "" {
 			logDir = filepath.Join(authDir, "logs")
 		}


### PR DESCRIPTION
## Summary
- Use `util.ResolveAuthDir` to properly expand `~` to user home directory when resolving log directory path
- Add warning log when auth-dir resolution fails, providing useful debugging information

## Problem
When `auth-dir` is configured as `~/.cli-proxy-api`, the code used `strings.TrimSpace()` which only removes whitespace but keeps the literal `~` character. This caused logs to be created in a directory literally named `~` instead of the actual home directory.

Bug introduced in 62e2b67 (refactor(logging): centralize log directory resolution logic).

## Changes
- Replace `strings.TrimSpace(cfg.AuthDir)` with `util.ResolveAuthDir(cfg.AuthDir)` to properly expand tilde
- Log a warning when `ResolveAuthDir` returns an error to aid debugging