### PR TITLE
feat(fallback): add model fallback support for automatic failover

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -79,6 +79,25 @@ quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
 
+# Model fallback configuration
+# When a model fails with specific error codes (429, 503, etc.), automatically retry with a fallback model.
+# model-fallback:
+#   enabled: true
+#   max-fallback-attempts: 1  # How many fallback models to try (default: 1)
+#   mappings:
+#     - from: "claude-opus-4-5"           # Primary model (supports wildcards: "claude-*", "*-preview")
+#       to: "gpt-5.2"                     # Fallback model to use
+#       on-status-codes: [429, 502, 503]  # HTTP codes that trigger fallback (default: [429, 502, 503, 529])
+#       on-timeout: true                  # Trigger fallback on request timeout
+#     - from: "claude-sonnet-*"
+#       to: "gpt-5.2-codex"
+#     - from: "claude-haiku-*"
+#       to: "gpt-5.2"
+#       on-status-codes: [429]            # Only fallback on rate limit
+#     - from: "gemini-.*-preview"         # Regex pattern example
+#       to: "gpt-5.2"
+#       regex: true                       # Treat 'from' as regular expression
+
 # Routing strategy for selecting credentials when multiple match.
 routing:
   strategy: "round-robin" # round-robin (default), fill-first

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,9 @@ type Config struct {
 	// QuotaExceeded defines the behavior when a quota is exceeded.
 	QuotaExceeded QuotaExceeded `yaml:"quota-exceeded" json:"quota-exceeded"`
 
+	// ModelFallback configures automatic fallback to alternative models when primary fails.
+	ModelFallback ModelFallbackConfig `yaml:"model-fallback" json:"model-fallback"`
+
 	// Routing controls credential selection behavior.
 	Routing RoutingConfig `yaml:"routing" json:"routing"`
 
@@ -163,6 +166,38 @@ type RoutingConfig struct {
 	// Strategy selects the credential selection strategy.
 	// Supported values: "round-robin" (default), "fill-first".
 	Strategy string `yaml:"strategy,omitempty" json:"strategy,omitempty"`
+}
+
+// ModelFallbackConfig configures automatic model fallback when primary model fails.
+type ModelFallbackConfig struct {
+	// Enabled toggles the model fallback feature globally.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+
+	// MaxFallbackAttempts limits how many fallback models to try (default: 1).
+	MaxFallbackAttempts int `yaml:"max-fallback-attempts,omitempty" json:"max-fallback-attempts,omitempty"`
+
+	// Mappings defines model fallback chains.
+	Mappings []ModelFallbackMapping `yaml:"mappings" json:"mappings"`
+}
+
+// ModelFallbackMapping defines a single model fallback rule.
+type ModelFallbackMapping struct {
+	// From is the primary model name (supports wildcards: "claude-*", "*-preview").
+	From string `yaml:"from" json:"from"`
+
+	// To is the fallback model name to use when the primary fails.
+	To string `yaml:"to" json:"to"`
+
+	// OnStatusCodes specifies which HTTP status codes trigger fallback.
+	// Common values: 429 (rate limit), 503 (unavailable), 502 (bad gateway).
+	// If empty, defaults to [429, 502, 503, 529].
+	OnStatusCodes []int `yaml:"on-status-codes,omitempty" json:"on-status-codes,omitempty"`
+
+	// OnTimeout triggers fallback when request times out.
+	OnTimeout bool `yaml:"on-timeout,omitempty" json:"on-timeout,omitempty"`
+
+	// Regex indicates whether 'From' should be treated as a regular expression.
+	Regex bool `yaml:"regex,omitempty" json:"regex,omitempty"`
 }
 
 // OAuthModelAlias defines a model ID alias for a specific channel.


### PR DESCRIPTION
When a primary model fails with specific HTTP error codes (429, 502, 503, 529) or timeouts, the proxy can now automatically retry with a configured fallback model.

Configuration example:
  model-fallback:
    enabled: true
    max-fallback-attempts: 1
    mappings:
      - from: "claude-opus-4-5" to: "gpt-5.2" on-status-codes: [429, 503] on-timeout: true

Features:
- Wildcard pattern matching (e.g., "claude-*", "*-preview")
- Regex pattern support with `regex: true`
- Configurable trigger status codes per mapping
- Optional timeout-based fallback
- Limit on fallback chain depth to prevent loops
- Detailed logging when fallback is triggered

This enables seamless failover between different model providers, improving reliability when primary models hit rate limits or become temporarily unavailable.