### PR TITLE
fix: Enable extended thinking support for Claude Haiku 4.5

### DIFF
--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -15,7 +15,7 @@ func GetClaudeModels() []*ModelInfo {
 			DisplayName:         "Claude 4.5 Haiku",
 			ContextLength:       200000,
 			MaxCompletionTokens: 64000,
-			// Thinking: not supported for Haiku models
+			Thinking:            &ThinkingSupport{Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: false},
 		},
 		{
 			ID:                  "claude-sonnet-4-5-20250929",


### PR DESCRIPTION
## Summary

This PR enables extended thinking support for Claude Haiku 4.5 (`claude-haiku-4-5-20251001`).

According to [Anthropic's official documentation](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking), Claude Haiku 4.5 **does support extended thinking**:

> Extended thinking is supported in the following models:
> - Claude Sonnet 4.5 (`claude-sonnet-4-5-20250929`)
> - Claude Sonnet 4 (`claude-sonnet-4-20250514`)
> - Claude Sonnet 3.7 (`claude-3-7-sonnet-20250219`) (deprecated)
> - **Claude Haiku 4.5 (`claude-haiku-4-5-20251001`)**
> - Claude Opus 4.5 (`claude-opus-4-5-20251101`)
> - Claude Opus 4.1 (`claude-opus-4-1-20250805`)
> - Claude Opus 4 (`claude-opus-4-20250514`)

## Changes

- Added `ThinkingSupport` to `claude-haiku-4-5-20251001` with the same parameters as other Claude 4.5 models:
  - `Min: 1024`
  - `Max: 128000`
  - `ZeroAllowed: true`
  - `DynamicAllowed: false`

## Testing

Tested locally by building a patched binary and verifying that Haiku 4.5 now properly returns `reasoning_content` in streaming responses when thinking is enabled via the model suffix (e.g., `claude-haiku-4-5-20251001(4096)`).