### PR TITLE
fix: custom antigravity proxy prompt & respect disable-cooling for all errors

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -285,6 +285,11 @@ oauth-model-alias:
 #   iflow:
 #     - "tstars2.0"
 
+# Custom Antigravity system instruction
+# Override the default system instruction for Antigravity API requests (Claude/Gemini-3-Pro models).
+# When empty or not set, uses the default Antigravity system instruction.
+# antigravity-system-instruction: "You are a helpful AI coding assistant..."
+
 # Optional payload configuration
 # payload:
 #   default: # Default rules only set parameters when they are missing in the payload.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,6 +111,10 @@ type Config struct {
 	// gemini-api-key, codex-api-key, claude-api-key, openai-compatibility, vertex-api-key, and ampcode.
 	OAuthModelAlias map[string][]OAuthModelAlias `yaml:"oauth-model-alias,omitempty" json:"oauth-model-alias,omitempty"`
 
+	// AntigravitySystemInstruction overrides the default system instruction for Antigravity API requests.
+	// When empty, uses the default Antigravity system instruction.
+	AntigravitySystemInstruction string `yaml:"antigravity-system-instruction,omitempty" json:"antigravity-system-instruction,omitempty"`
+
 	// Payload defines default and override rules for provider payload parameters.
 	Payload PayloadConfig `yaml:"payload" json:"payload"`
 


### PR DESCRIPTION
**Description:**

```markdown
## Summary

This PR fixes two issues:

1. **Custom Antigravity System Instruction Not Working** - Previously, the antigravity proxy system instruction was hardcoded and couldn't be customized via config.

2. **`disable-cooling: true` Only Applied to 429/5xx Errors** - Other error codes (401, 402/403, 404) still triggered cooldown periods even when `disable-cooling` was enabled.

---

## Changes

### 1. Custom Antigravity System Instruction

**Files modified:**
- `internal/config/config.go` - Added `AntigravitySystemInstruction` field
- `internal/runtime/executor/antigravity_executor.go` - Read instruction from config, renamed constant to `defaultSystemInstruction`
- `config.example.yaml` - Added example configuration

**Usage:**
```yaml
antigravity-system-instruction: "Your custom disguise prompt here..."
```

If not specified, the default instruction will be used.

---

### 2. Respect `disable-cooling` for All Error Codes

**Files modified:**
- `sdk/cliproxy/auth/conductor.go` - Modified `MarkResult()` and `applyAuthFailureState()` functions

**Behavior when `disable-cooling: true`:**

| Status Code | Before | After |
|-------------|--------|-------|
| 401 (unauthorized) | 30 min cooldown | **No cooldown** ✅ |
| 402/403 (payment_required) | 30 min cooldown | **No cooldown** ✅ |
| 404 (not_found) | 12 hour cooldown | **No cooldown** ✅ |
| 500/502/503/504 (transient) | 1 min cooldown | **No cooldown** ✅ |
| 429 (quota) | Already respected | Unchanged ✅ |

Error messages (e.g., `"unauthorized"`, `"transient upstream error"`) are still logged, but `NextRetryAfter` is set to empty and credentials won't be locked.

---

## Testing

- [ ] Tested custom antigravity system instruction
- [ ] Tested disable-cooling with various error codes
```

---

### 中文版

**标题：** `fix: 自定义 Antigravity 系统提示词 & disable-cooling 对所有错误码生效`

**描述：**

```markdown
## 概述

本 PR 修复了两个问题：

1. **自定义 Antigravity 系统提示词不生效** - 之前反重力代理的系统提示词是硬编码的，无法通过配置文件自定义。

2. **`disable-cooling: true` 仅对 429/5xx 生效** - 其他错误码（401、402/403、404）即使开启了 `disable-cooling` 仍会触发冷却。

---

## 修改内容

### 1. 自定义 Antigravity 系统提示词

**修改的文件：**
- `internal/config/config.go` - 添加 `AntigravitySystemInstruction` 字段
- `internal/runtime/executor/antigravity_executor.go` - 从配置读取提示词，常量改名为 `defaultSystemInstruction`
- `config.example.yaml` - 添加示例配置

**使用方法：**
```yaml
antigravity-system-instruction: "你的自定义伪装提示词..."
```

如未指定，将使用默认提示词。

---

### 2. `disable-cooling` 对所有错误码生效

**修改的文件：**
- `sdk/cliproxy/auth/conductor.go` - 修改 `MarkResult()` 和 `applyAuthFailureState()` 函数

**当 `disable-cooling: true` 时的行为：**

| 状态码 | 修复前 | 修复后 |
|--------|--------|--------|
| 401 (未授权) | 30 分钟冷却 | **无冷却** ✅ |
| 402/403 (需付费) | 30 分钟冷却 | **无冷却** ✅ |
| 404 (未找到) | 12 小时冷却 | **无冷却** ✅ |
| 500/502/503/504 (瞬态错误) | 1 分钟冷却 | **无冷却** ✅ |
| 429 (配额) | 已正确处理 | 不变 ✅ |

错误消息（如 `"unauthorized"`、`"transient upstream error"`）会正常记录，但 `NextRetryAfter` 设为空，凭证不会被锁定。