### PR TITLE
fix(translator): fix nullable type arrays breaking Gemini/Antigravity API

### DIFF
--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -330,22 +330,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 					funcDecl, _ = sjson.Set(funcDecl, "description", desc.String())
 				}
 				if params := tool.Get("parameters"); params.Exists() {
-					// Convert parameter types from OpenAI format to Gemini format
-					cleaned := params.Raw
-					// Convert type values to uppercase for Gemini
-					paramsResult := gjson.Parse(cleaned)
-					if properties := paramsResult.Get("properties"); properties.Exists() {
-						properties.ForEach(func(key, value gjson.Result) bool {
-							if propType := value.Get("type"); propType.Exists() {
-								upperType := strings.ToUpper(propType.String())
-								cleaned, _ = sjson.Set(cleaned, "properties."+key.String()+".type", upperType)
-							}
-							return true
-						})
-					}
-					// Set the overall type to OBJECT
-					cleaned, _ = sjson.Set(cleaned, "type", "OBJECT")
-					funcDecl, _ = sjson.SetRaw(funcDecl, "parametersJsonSchema", cleaned)
+					funcDecl, _ = sjson.SetRaw(funcDecl, "parametersJsonSchema", params.Raw)
 				}
 
 				geminiTools, _ = sjson.SetRaw(geminiTools, "0.functionDeclarations.-1", funcDecl)


### PR DESCRIPTION
## Summary

- Fixed a bug in `ConvertOpenAIResponsesRequestToGemini` where nullable JSON Schema type arrays (e.g. `["string", "null"]`) were corrupted into invalid string values `"[\"STRING\",\"NULL\"]"`, causing Gemini/Antigravity API to reject requests with `400 Invalid value at '...type'`
- Removed the unnecessary type uppercasing logic entirely — downstream `CleanJSONSchemaForGemini()` in `antigravity_executor.go` already handles type flattening, nullable fields, and schema cleanup correctly
- The removed code also only processed top-level properties, missing nested schemas

## Root Cause

When a tool parameter has `"type": ["string", "null"]` (JSON array):
1. `gjson.Result.String()` returns raw text `["string","null"]`
2. `strings.ToUpper()` → `["STRING","NULL"]`
3. `sjson.Set()` stores as a JSON **string** `"[\"STRING\",\"NULL\"]"` (not an array)
4. `flattenTypeArrays()` skips it (`IsArray()` == false on a string)
5. API rejects: `400 Invalid value at '...type' (Type), "["STRING","NULL"]"`

## Verified

This fix has been tested and confirmed working with Droid Factory (Antigravity) using Gemini models, where Claude Code sends tool schemas with nullable parameters (e.g. `"type": ["string", "null"]`). The error no longer occurs after removing the broken uppercasing logic.

## Impact

- **Antigravity (Droid Factory)**: Fixed — `CleanJSONSchemaForGemini()` handles everything
- **Gemini / Vertex**: No impact — uses `parametersJsonSchema` which accepts raw JSON Schema
- **Gemini CLI**: No impact — same as Gemini
- No other executors are affected

## Test plan
- [x] Tested with Droid Factory (Antigravity) Gemini models via OpenAI Responses API
- [x] Verified nullable type arrays `["string", "null"]` are properly flattened by downstream `CleanJSONSchemaForGemini()`
- [x] Confirmed no regression for non-nullable type fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)