### PR TITLE
feat: add adaptive thinking type and output_config.effort support

### DIFF
--- a/internal/thinking/strip.go
+++ b/internal/thinking/strip.go
@@ -30,7 +30,7 @@ func StripThinkingConfig(body []byte, provider string) []byte {
 	var paths []string
 	switch provider {
 	case "claude":
-		paths = []string{"thinking"}
+		paths = []string{"thinking", "output_config"}
 	case "gemini":
 		paths = []string{"generationConfig.thinkingConfig"}
 	case "gemini-cli", "antigravity":


### PR DESCRIPTION
## Summary
- Add support for Claude's `thinking.type = "adaptive"` and `output_config.effort` parameter across all translators (Gemini, Gemini CLI, Antigravity, OpenAI, Codex)
- `adaptive` without `effort` defaults to level `"high"`; `enabled` without `budget_tokens` preserves backward-compatible behavior per translator
- Gemini-family translators use `thinkingLevel` instead of hardcoded budget (`24576`), letting `ApplyThinking` resolve actual budget from model config / user payload config
- `effort = "max"` capped to `"high"` for OpenAI/Codex (only support `low/medium/high`)
- Strip `output_config` when model doesn't support thinking

## Changes
| File | Change |
|------|--------|
| `thinking/apply.go` | `extractClaudeConfig` handles `adaptive` + `output_config.effort`; added `MapClaudeEffortToLevel` helper |
| `thinking/strip.go` | Strip `output_config` for Claude provider |
| `antigravity_claude_request.go` | `adaptive` support + `thinkingLevel` instead of hardcoded budget |
| `gemini_claude_request.go` | Same as antigravity (without `request.` prefix) |
| `gemini-cli_claude_request.go` | Same as antigravity |
| `openai_claude_request.go` | `adaptive` → `"high"`, `enabled` → auto; `effort` mapped + xhigh capped |
| `codex_claude_request.go` | `adaptive` → `"high"`, `enabled` → `"medium"`; `effort` mapped + xhigh capped |

## Test plan
- [ ] Verify `thinking.type = "adaptive"` without `effort` defaults to `high` across all providers
- [ ] Verify `thinking.type = "enabled"` without `budget_tokens` preserves existing behavior
- [ ] Verify `output_config.effort = "max"` maps to `xhigh` for Gemini, capped to `high` for OpenAI/Codex
- [ ] Verify `output_config.effort` overrides adaptive default when both present
- [ ] Verify models that don't support thinking strip both `thinking` and `output_config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)