### PR TITLE
feat: add claude-opus-4-7-thinking and fix opus-4-6 context length

### DIFF
--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -36,7 +36,7 @@ func GetClaudeModels() []*ModelInfo {
 			Type:                "claude",
 			DisplayName:         "Claude 4.6 Opus",
 			Description:         "Premium model combining maximum intelligence with practical performance",
-			ContextLength:       1000000,
+			ContextLength:       200000,
 			MaxCompletionTokens: 128000,
 			Thinking:            &ThinkingSupport{Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: false},
 		},


### PR DESCRIPTION
## Changes

- **Add `claude-opus-4-7-thinking`** to `GetAntigravityModelConfig()` with 128K max completion tokens and full thinking support (Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: true)
- **Fix `claude-opus-4-6` context length** from `1000000` → `200000` per [Anthropic docs](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-6) (200K standard, 1M available in beta with `context-1m-2025-08-07` header)

## Known Issues / Bugs

### 1. Amp UI shows ~968K context window for thinking models
Amp uses its own internal model definitions and does **not** read `context_length` from the Claude protocol `/v1/models` response (which omits it by design in the `"claude"` handler format). This means Amp will display incorrect context window sizes regardless of what we set here. This is an Amp-side issue, not a proxy issue.

### 2. `AntigravityModelConfig` does not carry `ContextLength`
The `AntigravityModelConfig` struct only has `Thinking` and `MaxCompletionTokens`. Antigravity-channel models therefore have **no `context_length`** in the `/v1/models` response, even for OpenAI-compatible clients. A future improvement would be to add `ContextLength` to the struct and wire it through the executor and model definitions builders.

### 3. Claude protocol format omits `context_length` entirely
The `convertModelToMap` function for `handlerType == "claude"` only returns `id`, `object`, `owned_by`, `created_at`, `type`, and `display_name`. Even if we add `ContextLength` to antigravity config, clients using the Claude protocol (like Amp with `User-Agent: claude-cli`) will never see it.

## Testing
- Built and verified binary compiles cleanly
- Verified `/v1/models` endpoint returns the new model