### PR TITLE
fix: handle plain string content in OpenAI Responses → Gemini translation

### DIFF
--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -1,0 +1,74 @@
+package responses
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIResponsesRequestToGemini_ContentStringAndArrayFormats(t *testing.T) {
+	t.Run("string content", func(t *testing.T) {
+		inputJSON := []byte(`{
+			"model": "gpt-5",
+			"input": [
+				{"role": "system", "content": "You are helpful"},
+				{"role": "user", "content": "Hello"}
+			]
+		}`)
+
+		output := ConvertOpenAIResponsesRequestToGemini("gemini-2.5-flash", inputJSON, false)
+		outputStr := string(output)
+
+		if got := gjson.Get(outputStr, "system_instruction.parts.0.text").String(); got != "You are helpful" {
+			t.Fatalf("unexpected system instruction text: got %q", got)
+		}
+
+		contents := gjson.Get(outputStr, "contents")
+		if !contents.Exists() || !contents.IsArray() {
+			t.Fatalf("contents should be an array")
+		}
+		if len(contents.Array()) != 1 {
+			t.Fatalf("expected 1 content item, got %d", len(contents.Array()))
+		}
+		if got := gjson.Get(outputStr, "contents.0.role").String(); got != "user" {
+			t.Fatalf("unexpected role for string message: got %q", got)
+		}
+		if got := gjson.Get(outputStr, "contents.0.parts.0.text").String(); got != "Hello" {
+			t.Fatalf("unexpected text for string message: got %q", got)
+		}
+	})
+
+	t.Run("array content", func(t *testing.T) {
+		inputJSON := []byte(`{
+			"model": "gpt-5",
+			"input": [
+				{
+					"role": "system",
+					"content": [
+						{"type": "input_text", "text": "You are helpful"},
+						{"type": "input_text", "text": "Be concise"}
+					]
+				},
+				{
+					"role": "user",
+					"content": [
+						{"type": "input_text", "text": "Hello"}
+					]
+				}
+			]
+		}`)
+
+		output := ConvertOpenAIResponsesRequestToGemini("gemini-2.5-flash", inputJSON, false)
+		outputStr := string(output)
+
+		if got := gjson.Get(outputStr, "system_instruction.parts.0.text").String(); got != "You are helpful\nBe concise" {
+			t.Fatalf("unexpected array system instruction text: got %q", got)
+		}
+		if got := gjson.Get(outputStr, "contents.0.role").String(); got != "user" {
+			t.Fatalf("unexpected role for array message: got %q", got)
+		}
+		if got := gjson.Get(outputStr, "contents.0.parts.0.text").String(); got != "Hello" {
+			t.Fatalf("unexpected text for array message: got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fix OpenAI Responses → Gemini request translation when message `content` is sent as a plain string (common in OpenAI SDKs, including Python), not just as an array.

## Bug

`ConvertOpenAIResponsesRequestToGemini` only processed message content when `content` was an array.
For inputs like:

```json
{"role":"system","content":"You are helpful"}
{"role":"user","content":"Hello"}
```

content was skipped, producing `contents: []` in the Gemini payload and causing:

```
at least one contents field is required
```

## Fix

### 1) System message handling
- Added support for string `content` in system messages (in addition to array handling).
- When `content` is a string, it now populates `system_instruction.parts[0].text`.

### 2) Regular message handling
- Added non-array `content` handling before existing array logic.
- When `content` is a string, it now creates a Gemini `contents` item directly with mapped role and a text part.

### 3) Tests
- Added `gemini_openai-responses_request_test.go` with coverage for both formats:
  - string `content` (`system` + `user`)
  - array `content` (existing structured format)

## Reproduction

1. Send OpenAI Responses request with plain string message content:
   ```json
   {
     "model": "gpt-5",
     "input": [
       {"role": "system", "content": "You are helpful"},
       {"role": "user", "content": "Hello"}
     ]
   }
   ```
2. Before this fix: translated Gemini request has empty `contents` and request fails.
3. After this fix: translated Gemini request includes `system_instruction` and `contents` with user text, and succeeds.

## Notes

- Followed existing style and preserved tab-indented Go formatting.