### PR TITLE
Add CLIProxyAPI Dashboard to 'Who is with us?' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ A Windows tray application implemented using PowerShell scripts, without relying
 
 霖君 is a cross-platform desktop application for managing AI programming assistants, supporting macOS, Windows, and Linux systems. Unified management of Claude Code, Gemini CLI, OpenAI Codex, Qwen Code, and other AI coding tools, with local proxy for multi-account quota tracking and one-click configuration.
 
+### [CLIProxyAPI Dashboard](https://github.com/itsmylife44/cliproxyapi-dashboard)
+
+A modern web-based management dashboard for CLIProxyAPI built with Next.js, React, and PostgreSQL. Features real-time log streaming, structured configuration editing, API key management, OAuth provider integration for Claude/Gemini/Codex, usage analytics, container management, and config sync with OpenCode via companion plugin - no manual YAML editing needed.
+
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.
 


### PR DESCRIPTION
## Summary

Adds [CLIProxyAPI Dashboard](https://github.com/itsmylife44/cliproxyapi-dashboard) to the "Who is with us?" community section.

### What is CLIProxyAPI Dashboard?

A modern web-based management dashboard for CLIProxyAPI built with Next.js, React, and PostgreSQL. It provides:

- **Real-time Monitoring**: Live log streaming with filtering and container health status
- **Structured Configuration Editor**: Form-based configuration management instead of manual YAML editing
- **API Key Management**: Full lifecycle management for API keys
- **OAuth Provider Integration**: Connect and manage Claude, Gemini, and Codex OAuth accounts
- **Usage Analytics**: Track API usage, request patterns, and provider statistics
- **Container Management**: Start, stop, restart containers directly from the dashboard
- **Config Sync**: Auto-sync OpenCode configurations via companion plugin

Repository: https://github.com/itsmylife44/cliproxyapi-dashboard