### PR TITLE
Change GLM CODING PLAN subscription price

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ So you can use local or multi-account CLI access with OpenAI(include Responses)/
 
 This project is sponsored by Z.ai, supporting us with their GLM CODING PLAN.
 
-GLM CODING PLAN is a subscription service designed for AI coding, starting at just $3/month. It provides access to their flagship GLM-4.7 model across 10+ popular AI coding tools (Claude Code, Cline, Roo Code, etc.), offering developers top-tier, fast, and stable coding experiences.
+GLM CODING PLAN is a subscription service designed for AI coding, starting at just $10/month. It provides access to their flagship GLM-4.7 model across 10+ popular AI coding tools (Claude Code, Cline, Roo Code, etc.), offering developers top-tier, fast, and stable coding experiences.
 
 Get 10% OFF GLM CODING PLAN：https://z.ai/subscribe?ic=8JVLJQFSKB
 


### PR DESCRIPTION
Updated the subscription price for GLM CODING PLAN from $3/month to $10/month.

I cant find 3$ one, looks like they removed