### PR TITLE
feat(registry): add gpt-5.3-codex-spark model definition

### DIFF
--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -749,7 +749,7 @@ func GetOpenAIModels() []*ModelInfo {
 			OwnedBy:             "openai",
 			Type:                "openai",
 			Version:             "gpt-5.3",
-			DisplayName:         "GPT-5.3-Codex-Spark",
+DisplayName:         "GPT 5.3 Codex Spark",
 			Description:         "Ultra-fast coding model.",
 			ContextLength:       128000,
 			MaxCompletionTokens: 128000,


### PR DESCRIPTION
## Summary\n- Add static OpenAI model definition for gpt-5.3-codex-spark.\n- Keep model metadata aligned to existing registry conventions and context_length semantics.\n\nRefs: https://github.com/router-for-me/CLIProxyAPI/issues/1573