### PR TITLE
Fix duplicate/empty tool_use blocks in OpenAI->Claude streaming translation

### DIFF
--- a/internal/translator/openai/claude/openai_claude_response_test.go
+++ b/internal/translator/openai/claude/openai_claude_response_test.go
@@ -1,0 +1,86 @@
+package claude
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIResponseToClaude_StreamToolStartEmittedOnceAndNameCanonicalized(t *testing.T) {
+	originalRequest := `{
+		"stream": true,
+		"tools": [
+			{
+				"name": "Bash",
+				"description": "run shell",
+				"input_schema": {"type":"object","properties":{"command":{"type":"string"}}}
+			}
+		]
+	}`
+
+	chunks := []string{
+		`data: {"id":"chatcmpl-1","model":"m","created":1,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"bash","arguments":""}}]}}]}`,
+		`data: {"id":"chatcmpl-1","model":"m","created":1,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":"{\"command\":\"pwd\"}"}}]}}]}`,
+		`data: {"id":"chatcmpl-1","model":"m","created":1,"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: {"id":"chatcmpl-1","model":"m","created":1,"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":2}}`,
+		`data: [DONE]`,
+	}
+
+	var param any
+	var outputs []string
+	for _, chunk := range chunks {
+		out := ConvertOpenAIResponseToClaude(context.Background(), "m", []byte(originalRequest), nil, []byte(chunk), &param)
+		outputs = append(outputs, out...)
+	}
+
+	joined := strings.Join(outputs, "")
+	if got := strings.Count(joined, `"content_block":{"type":"tool_use"`); got != 1 {
+		t.Fatalf("expected exactly 1 tool_use content_block_start, got %d\noutput:\n%s", got, joined)
+	}
+
+	if strings.Contains(joined, `"name":""`) {
+		t.Fatalf("tool_use block should not have empty name\noutput:\n%s", joined)
+	}
+
+	if !strings.Contains(joined, `"name":"Bash"`) {
+		t.Fatalf("expected canonical tool name Bash in stream output\noutput:\n%s", joined)
+	}
+}
+
+func TestConvertOpenAIResponseToClaudeNonStream_CanonicalizesToolName(t *testing.T) {
+	originalRequest := `{
+		"tools": [
+			{"name": "Bash", "input_schema": {"type":"object","properties":{"command":{"type":"string"}}}}
+		]
+	}`
+
+	openAIResponse := `{
+		"id":"chatcmpl-1",
+		"model":"m",
+		"choices":[
+			{
+				"finish_reason":"tool_calls",
+				"message":{
+					"content":"",
+					"tool_calls":[
+						{"id":"call_1","type":"function","function":{"name":"bash","arguments":"{\"command\":\"pwd\"}"}}
+					]
+				}
+			}
+		],
+		"usage":{"prompt_tokens":10,"completion_tokens":2}
+	}`
+
+	var param any
+	out := ConvertOpenAIResponseToClaudeNonStream(context.Background(), "m", []byte(originalRequest), nil, []byte(openAIResponse), &param)
+	result := gjson.Parse(out)
+
+	if got := result.Get("content.0.type").String(); got != "tool_use" {
+		t.Fatalf("expected first content block type tool_use, got %q", got)
+	}
+	if got := result.Get("content.0.name").String(); got != "Bash" {
+		t.Fatalf("expected canonical tool name %q, got %q", "Bash", got)
+	}
+}


### PR DESCRIPTION
## Summary
This fixes a response-translation bug in the OpenAI->Claude path that could break tool execution in Claude clients.

## Problem
Some OpenAI-compatible providers stream `tool_calls` in fragmented deltas:
- `function.name` appears once, then appears again as empty in later chunks
- IDs/arguments may arrive across multiple chunks

The previous translator could emit multiple `content_block_start` events for the same tool call, including an empty tool name, which can cause client-side tool execution failures.

## Changes
- Emit `tool_use` `content_block_start` exactly once per tool call in streaming mode.
- Ignore empty repeated `function.name` deltas after start.
- Canonicalize returned tool names to match request-declared tool names (case-insensitive), e.g. `bash` -> `Bash`.
- Apply the same name canonicalization to non-stream responses.
- Finalize tool-call blocks in deterministic index order.

## Testing
- Added streaming regression test:
  - verifies only one `tool_use` start is emitted
  - verifies no empty-name `tool_use` blocks
  - verifies canonical tool name output
- Added non-stream regression test for canonical tool name mapping.
- Ran full test suite: `go test ./...`

## Context / Risk
- This was validated primarily against Fireworks in an Anthropic-compatible proxy setup.
- There is potential for regressions with other OpenAI-compatible providers that emit tool call deltas differently.
- Opening this PR to get maintainer feedback on whether this behavior is the right default for broader provider compatibility.
