### PR TITLE
fix: add proxy_ prefix handling for tool_reference content blocks

### DIFF
--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -126,3 +126,12 @@ func TestApplyClaudeToolPrefix_NestedToolReferenceWithStringContent(t *testing.T
 		t.Fatalf("string content should remain unchanged = %q", got)
 	}
 }
+
+func TestApplyClaudeToolPrefix_SkipsBuiltinToolReference(t *testing.T) {
+	input := []byte(`{"tools":[{"type":"web_search_20250305","name":"web_search"}],"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"web_search"}]}]}]}`)
+	out := applyClaudeToolPrefix(input, "proxy_")
+	got := gjson.GetBytes(out, "messages.0.content.0.content.0.tool_name").String()
+	if got != "web_search" {
+		t.Fatalf("built-in tool_reference should not be prefixed, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `applyClaudeToolPrefix` now prefixes `tool_name` in `tool_reference` content blocks (both top-level in `messages[].content[]` and nested inside `tool_result.content[]`)
- `stripClaudeToolPrefixFromResponse` strips prefix from `tool_reference` blocks in non-streaming responses
- `stripClaudeToolPrefixFromStreamLine` strips prefix from `tool_reference` blocks in streaming SSE lines

## Problem

When using OAuth tokens, CPA adds `proxy_` prefix to tool definitions and `tool_use`/`tool_result` names. However, `tool_reference` content blocks (from Anthropic's `advanced-tool-use` beta) were not handled — their `tool_name` field remained unprefixed while tool definitions carried the prefix.

Additionally, `tool_reference` blocks can appear **nested** inside `tool_result.content[]` arrays, not just at the top level of message content — both levels are now handled.

This caused Anthropic API 400 errors:
```
Tool reference 'mcp__nia__manage_resource' not found in available tools
```

Because the tools array had `proxy_mcp__nia__manage_resource` but history referenced `mcp__nia__manage_resource`.

## Key difference

- `tool_use` uses field `name`
- `tool_reference` uses field `tool_name`

Both are now handled in all three prefix functions.

## Test plan

- [x] `TestApplyClaudeToolPrefix_WithToolReference` — prefix applied to top-level `tool_reference`
- [x] `TestApplyClaudeToolPrefix_NestedToolReference` — prefix applied inside `tool_result.content[]`
- [x] `TestApplyClaudeToolPrefix_NestedToolReferenceWithStringContent` — string content in tool_result skipped
- [x] `TestStripClaudeToolPrefixFromResponse_WithToolReference` — prefix stripped in response
- [x] `TestStripClaudeToolPrefixFromResponse_NestedToolReference` — nested prefix stripped in response
- [x] `TestStripClaudeToolPrefixFromStreamLine_WithToolReference` — prefix stripped in SSE stream
- [x] All existing tests pass (no regressions)
- [x] Manual test: Claude Code session with eagerly-loaded MCP tools through CPA — confirmed working

> Note: This PR was originally submitted to CLIProxyAPIplus (#236). The maintainer redirected us to mainline.