### PR TITLE
fix: skip proxy_ prefix for built-in tools in message history

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -753,11 +753,21 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 		return body
 	}
 
+	// Collect built-in tool names (those with a non-empty "type" field) so we can
+	// skip them consistently in both tools and message history.
+	builtinTools := map[string]bool{}
+	for _, name := range []string{"web_search", "code_execution", "text_editor", "computer"} {
+		builtinTools[name] = true
+	}
+
 	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
 		tools.ForEach(func(index, tool gjson.Result) bool {
 			// Skip built-in tools (web_search, code_execution, etc.) which have
 			// a "type" field and require their name to remain unchanged.
 			if tool.Get("type").Exists() && tool.Get("type").String() != "" {
+				if n := tool.Get("name").String(); n != "" {
+					builtinTools[n] = true
+				}
 				return true
 			}
 			name := tool.Get("name").String()
@@ -772,7 +782,7 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 
 	if gjson.GetBytes(body, "tool_choice.type").String() == "tool" {
 		name := gjson.GetBytes(body, "tool_choice.name").String()
-		if name != "" && !strings.HasPrefix(name, prefix) {
+		if name != "" && !strings.HasPrefix(name, prefix) && !builtinTools[name] {
 			body, _ = sjson.SetBytes(body, "tool_choice.name", prefix+name)
 		}
 	}
@@ -788,7 +798,7 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 					return true
 				}
 				name := part.Get("name").String()
-				if name == "" || strings.HasPrefix(name, prefix) {
+				if name == "" || strings.HasPrefix(name, prefix) || builtinTools[name] {
 					return true
 				}
 				path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -25,15 +25,94 @@ func TestApplyClaudeToolPrefix(t *testing.T) {
 	}
 }
 
-func TestApplyClaudeToolPrefix_SkipsBuiltinTools(t *testing.T) {
-	input := []byte(`{"tools":[{"type":"web_search_20250305","name":"web_search"},{"name":"my_custom_tool","input_schema":{"type":"object"}}]}`)
-	out := applyClaudeToolPrefix(input, "proxy_")
+func TestApplyClaudeToolPrefix_BuiltinToolSkipped(t *testing.T) {
+	body := []byte(`{
+		"tools": [
+			{"type": "web_search_20250305", "name": "web_search", "max_uses": 5},
+			{"name": "Read"}
+		],
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "tool_use", "name": "web_search", "id": "ws1", "input": {}},
+				{"type": "tool_use", "name": "Read", "id": "r1", "input": {}}
+			]}
+		]
+	}`)
+	out := applyClaudeToolPrefix(body, "proxy_")
 
 	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "web_search" {
-		t.Fatalf("built-in tool name should not be prefixed: tools.0.name = %q, want %q", got, "web_search")
+		t.Fatalf("tools.0.name = %q, want %q", got, "web_search")
 	}
-	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "proxy_my_custom_tool" {
-		t.Fatalf("custom tool should be prefixed: tools.1.name = %q, want %q", got, "proxy_my_custom_tool")
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "web_search" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "proxy_Read" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "proxy_Read")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.name").String(); got != "proxy_Read" {
+		t.Fatalf("messages.0.content.1.name = %q, want %q", got, "proxy_Read")
+	}
+}
+
+func TestApplyClaudeToolPrefix_KnownBuiltinInHistoryOnly(t *testing.T) {
+	body := []byte(`{
+		"tools": [
+			{"name": "Read"}
+		],
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "tool_use", "name": "web_search", "id": "ws1", "input": {}}
+			]}
+		]
+	}`)
+	out := applyClaudeToolPrefix(body, "proxy_")
+
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "web_search" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "proxy_Read" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "proxy_Read")
+	}
+}
+
+func TestApplyClaudeToolPrefix_CustomToolsPrefixed(t *testing.T) {
+	body := []byte(`{
+		"tools": [{"name": "Read"}, {"name": "Write"}],
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "tool_use", "name": "Read", "id": "r1", "input": {}},
+				{"type": "tool_use", "name": "Write", "id": "w1", "input": {}}
+			]}
+		]
+	}`)
+	out := applyClaudeToolPrefix(body, "proxy_")
+
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "proxy_Read" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "proxy_Read")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "proxy_Write" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "proxy_Write")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "proxy_Read" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "proxy_Read")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.name").String(); got != "proxy_Write" {
+		t.Fatalf("messages.0.content.1.name = %q, want %q", got, "proxy_Write")
+	}
+}
+
+func TestApplyClaudeToolPrefix_ToolChoiceBuiltin(t *testing.T) {
+	body := []byte(`{
+		"tools": [
+			{"type": "web_search_20250305", "name": "web_search"},
+			{"name": "Read"}
+		],
+		"tool_choice": {"type": "tool", "name": "web_search"}
+	}`)
+	out := applyClaudeToolPrefix(body, "proxy_")
+
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "web_search" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "web_search")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes an inconsistency in the Claude tool prefix logic where built-in tools (e.g. `web_search`, `code_execution`, `text_editor`, `computer`) were correctly skipped in the `tools[]` definitions but incorrectly prefixed in `messages[].content[]` (conversation history) and `tool_choice`.

This caused Anthropic API rejections when built-in tool references appeared in conversation history as `proxy_web_search` instead of `web_search`.

**Related:** Companion fix to #1608 (tool_reference prefix handling). Both address different aspects of the same anti-ban hardening effort — ensuring tool names sent to Anthropic match exactly what the API expects.

## Problem

The `applyClaudeToolPrefix()` function applies the `proxy_` prefix to tool names as part of the masquerading strategy. However, it only checked for built-in tools in the `tools[]` array definition, not in:

1. `messages[].content[].name` — tool_use blocks in conversation history
2. `tool_choice.name` — when the client specifies a specific tool

This meant multi-turn conversations with built-in tool calls would fail on subsequent messages because the prefixed names (`proxy_web_search`) don't match Anthropic's built-in tool definitions.

## Changes

| File | Change |
|------|--------|
| `internal/runtime/executor/claude_executor.go` | Build a built-in tools map at prefix application time; skip prefixing in `tool_choice.name` and `messages[].content[].name` for built-in tools |
| `internal/runtime/executor/claude_executor_test.go` | 4 new test cases covering built-in tools in history, mixed tools, history-only built-ins, and tool_choice |

## How it works

1. At the start of `applyClaudeToolPrefix()`, collect known built-in tool names:
   - Hardcoded set: `web_search`, `code_execution`, `text_editor`, `computer`
   - Dynamically: any tool from `tools[]` with a non-empty `type` field
2. When iterating `messages[].content[]` and `tool_choice`, check the built-in map before applying prefix
3. No behavior change for custom (non-built-in) tools — they continue to be prefixed normally

## Backward compatibility

Fully backward compatible. Only changes behavior for built-in tool names that were being incorrectly prefixed.

## Test plan

- [x] Unit tests for built-in tools in message history
- [x] Unit tests for mixed built-in + custom tools
- [x] Unit tests for built-in tools appearing only in history (not in current tools array)
- [x] Unit tests for tool_choice with built-in names
- [x] `go test ./internal/runtime/executor/...` passes
- [x] Manual testing with Claude Code sessions using web_search tool