### PR TITLE
feat: add per-auth tool_prefix_disabled option

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -134,7 +134,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	extraBetas, body = extractAndRemoveBetas(body)
 	bodyForTranslation := body
 	bodyForUpstream := body
-	if isClaudeOAuthToken(apiKey) {
+	if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
 	}
 
@@ -208,7 +208,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	} else {
 		reporter.publish(ctx, parseClaudeUsage(data))
 	}
-	if isClaudeOAuthToken(apiKey) {
+	if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 		data = stripClaudeToolPrefixFromResponse(data, claudeToolPrefix)
 	}
 	var param any
@@ -275,7 +275,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	extraBetas, body = extractAndRemoveBetas(body)
 	bodyForTranslation := body
 	bodyForUpstream := body
-	if isClaudeOAuthToken(apiKey) {
+	if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
 	}
 
@@ -348,7 +348,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				if detail, ok := parseClaudeStreamUsage(line); ok {
 					reporter.publish(ctx, detail)
 				}
-				if isClaudeOAuthToken(apiKey) {
+				if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 					line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
 				}
 				// Forward the line as-is to preserve SSE format
@@ -375,7 +375,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			if detail, ok := parseClaudeStreamUsage(line); ok {
 				reporter.publish(ctx, detail)
 			}
-			if isClaudeOAuthToken(apiKey) {
+			if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 				line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
 			}
 			chunks := sdktranslator.TranslateStream(
@@ -423,7 +423,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	// Extract betas from body and convert to header (for count_tokens too)
 	var extraBetas []string
 	extraBetas, body = extractAndRemoveBetas(body)
-	if isClaudeOAuthToken(apiKey) {
+	if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 		body = applyClaudeToolPrefix(body, claudeToolPrefix)
 	}
 

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -213,6 +213,23 @@ func (a *Auth) DisableCoolingOverride() (bool, bool) {
 	return false, false
 }
 
+// ToolPrefixDisabled returns whether the proxy_ tool name prefix should be
+// skipped for this auth. When true, tool names are sent to Anthropic unchanged.
+// The value is read from metadata key "tool_prefix_disabled" (or "tool-prefix-disabled").
+func (a *Auth) ToolPrefixDisabled() bool {
+	if a == nil || a.Metadata == nil {
+		return false
+	}
+	for _, key := range []string{"tool_prefix_disabled", "tool-prefix-disabled"} {
+		if val, ok := a.Metadata[key]; ok {
+			if parsed, okParse := parseBoolAny(val); okParse {
+				return parsed
+			}
+		}
+	}
+	return false
+}
+
 // RequestRetryOverride returns the auth-file scoped request_retry override when present.
 // The value is read from metadata key "request_retry" (or legacy "request-retry").
 func (a *Auth) RequestRetryOverride() (int, bool) {

--- a/sdk/cliproxy/auth/types_test.go
+++ b/sdk/cliproxy/auth/types_test.go
@@ -1,0 +1,35 @@
+package auth
+
+import "testing"
+
+func TestToolPrefixDisabled(t *testing.T) {
+	var a *Auth
+	if a.ToolPrefixDisabled() {
+		t.Error("nil auth should return false")
+	}
+
+	a = &Auth{}
+	if a.ToolPrefixDisabled() {
+		t.Error("empty auth should return false")
+	}
+
+	a = &Auth{Metadata: map[string]any{"tool_prefix_disabled": true}}
+	if !a.ToolPrefixDisabled() {
+		t.Error("should return true when set to true")
+	}
+
+	a = &Auth{Metadata: map[string]any{"tool_prefix_disabled": "true"}}
+	if !a.ToolPrefixDisabled() {
+		t.Error("should return true when set to string 'true'")
+	}
+
+	a = &Auth{Metadata: map[string]any{"tool-prefix-disabled": true}}
+	if !a.ToolPrefixDisabled() {
+		t.Error("should return true with kebab-case key")
+	}
+
+	a = &Auth{Metadata: map[string]any{"tool_prefix_disabled": false}}
+	if a.ToolPrefixDisabled() {
+		t.Error("should return false when set to false")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a per-authentication configuration option `tool_prefix_disabled` that allows users to disable the `proxy_` tool name prefix on individual auth entries.

This is useful for users who route their own Anthropic account through CPA and want tool names sent unchanged — while still using the prefix for other (shared/pooled) accounts that benefit from the anti-ban hardening.

## Problem

Currently, the `proxy_` prefix is applied globally for all Claude OAuth-type credentials. There's no way to disable it selectively per account. Users running their own personal API keys through CPA don't need the prefix (since their usage patterns are natural), but they're forced to have it applied anyway.

## Changes

| File | Change |
|------|--------|
| `sdk/cliproxy/auth/types.go` | New `ToolPrefixDisabled()` accessor that reads `tool_prefix_disabled` or `tool-prefix-disabled` from auth metadata |
| `internal/runtime/executor/claude_executor.go` | 6 conditional points updated to check `!auth.ToolPrefixDisabled()` before applying/stripping prefix |
| `sdk/cliproxy/auth/types_test.go` | 5 test cases for nil auth, empty auth, boolean, string, and kebab-case key |

## Configuration

```yaml
auths:
  - credential: "sk-ant-xxx"
    metadata:
      tool_prefix_disabled: true  # or tool-prefix-disabled: true
```

Both underscore (`tool_prefix_disabled`) and kebab-case (`tool-prefix-disabled`) keys are supported for consistency with other metadata conventions.

## How it works

1. `ToolPrefixDisabled()` reads from the auth entry's metadata map
2. At each point where the prefix is applied or stripped, the condition becomes:
   `isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled()`
3. If `tool_prefix_disabled: true`, the prefix is neither added to requests nor stripped from responses
4. Default behavior is preserved — prefix is applied unless explicitly disabled

## Backward compatibility

Fully backward compatible. Default behavior (prefix enabled) is unchanged. The new option is opt-in via metadata.

## Test plan

- [x] Unit tests for `ToolPrefixDisabled()` accessor (nil, empty, true, false, string, kebab-case)
- [x] `go test ./sdk/cliproxy/auth/...` passes
- [x] `go test ./internal/runtime/executor/...` passes
- [x] Manual testing: auth with `tool_prefix_disabled: true` sends unprefixed tool names
- [x] Manual testing: auth without the flag continues to prefix tools normally