### PR TITLE
fix: update Claude masquerading headers and configurable defaults

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -156,6 +156,14 @@ nonstream-keepalive-interval: 0
 #         - "API"
 #         - "proxy"
 
+# Default headers for Claude API requests. Update when Claude Code releases new versions.
+# These are used as fallbacks when the client does not send its own headers.
+# claude-header-defaults:
+#   user-agent: "claude-cli/2.1.44 (external, sdk-cli)"
+#   package-version: "0.74.0"
+#   runtime-version: "v24.3.0"
+#   timeout: "600"
+
 # OpenAI compatibility providers
 # openai-compatibility:
 #   - name: "openrouter" # The name of the provider; it will be used in the user agent and other places.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,10 @@ type Config struct {
 	// ClaudeKey defines a list of Claude API key configurations as specified in the YAML configuration file.
 	ClaudeKey []ClaudeKey `yaml:"claude-api-key" json:"claude-api-key"`
 
+	// ClaudeHeaderDefaults configures default header values for Claude API requests.
+	// These are used as fallbacks when the client does not send its own headers.
+	ClaudeHeaderDefaults ClaudeHeaderDefaults `yaml:"claude-header-defaults" json:"claude-header-defaults"`
+
 	// OpenAICompatibility defines OpenAI API compatibility configurations for external providers.
 	OpenAICompatibility []OpenAICompatibility `yaml:"openai-compatibility" json:"openai-compatibility"`
 
@@ -115,6 +119,15 @@ type Config struct {
 	Payload PayloadConfig `yaml:"payload" json:"payload"`
 
 	legacyMigrationPending bool `yaml:"-" json:"-"`
+}
+
+// ClaudeHeaderDefaults configures default header values injected into Claude API requests
+// when the client does not send them. Update these when Claude Code releases a new version.
+type ClaudeHeaderDefaults struct {
+	UserAgent      string `yaml:"user-agent" json:"user-agent"`
+	PackageVersion string `yaml:"package-version" json:"package-version"`
+	RuntimeVersion string `yaml:"runtime-version" json:"runtime-version"`
+	Timeout        string `yaml:"timeout" json:"timeout"`
 }
 
 // TLSConfig holds HTTPS server settings.


### PR DESCRIPTION
## Summary

Updates hardcoded `X-Stainless-*` and `User-Agent` masquerading headers to match current Claude Code versions, and adds a config section so these values can be updated without recompilation.

This is part of anti-ban hardening — keeping CPA's request fingerprint consistent with legitimate Claude Code traffic.

## Problem

The hardcoded masquerading headers were outdated:
- `X-Stainless-Package-Version`: `0.55.1` (should be `0.74.0`)
- `X-Stainless-Timeout`: `60` (should be `600`)
- `User-Agent`: `claude-cli/1.0.83 (external, cli)` (should be `claude-cli/2.1.44 (external, sdk-cli)`)
- `X-Stainless-Os` / `X-Stainless-Arch`: hardcoded `Linux`/`x86_64` (should be dynamic)

These values were verified via diagnostic proxy capture against actual Claude Code 2.1.44 / @anthropic-ai/sdk 0.74.0 traffic.

## Changes

| File | Change |
|------|--------|
| `internal/runtime/executor/claude_executor.go` | Update header defaults, add dynamic OS/arch via `runtime.GOOS`/`runtime.GOARCH`, read config overrides |
| `internal/config/config.go` | New `ClaudeHeaderDefaults` config struct |
| `config.example.yaml` | Document `claude-header-defaults` config section |

## Configuration

```yaml
# Optional: override masquerading headers without recompilation
claude-header-defaults:
  user-agent: "claude-cli/2.1.44 (external, sdk-cli)"
  package-version: "0.74.0"
  runtime-version: "v24.3.0"
  timeout: "600"
```

When not configured, sensible defaults are used (matching current Claude Code versions).

## Updated defaults

| Header | Old Value | New Value |
|--------|-----------|-----------|
| `X-Stainless-Package-Version` | `0.55.1` | `0.74.0` |
| `X-Stainless-Timeout` | `60` | `600` |
| `X-Stainless-Os` | `Linux` (hardcoded) | `runtime.GOOS` (dynamic) |
| `X-Stainless-Arch` | `x86_64` (hardcoded) | `runtime.GOARCH` (dynamic) |
| `User-Agent` | `claude-cli/1.0.83 (external, cli)` | `claude-cli/2.1.44 (external, sdk-cli)` |

## Backward compatibility

Fully backward compatible. Without config, the new hardcoded defaults are used. With config, users can override any header value.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Manual testing: requests to Anthropic API carry updated headers
- [x] Config override: custom values from `claude-header-defaults` applied correctly
- [x] No config: defaults work without any config changes