### PR TITLE
feat(registry): add Claude Sonnet 4.6 model definition

### DIFF
--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -29,6 +29,17 @@ func GetClaudeModels() []*ModelInfo {
 			Thinking:            &ThinkingSupport{Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: false},
 		},
 		{
+			ID:                  "claude-sonnet-4-6",
+			Object:              "model",
+			Created:             1771372800, // 2026-02-17
+			OwnedBy:             "anthropic",
+			Type:                "claude",
+			DisplayName:         "Claude 4.6 Sonnet",
+			ContextLength:       200000,
+			MaxCompletionTokens: 64000,
+			Thinking:            &ThinkingSupport{Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: false},
+		},
+		{
 			ID:                  "claude-opus-4-6",
 			Object:              "model",
 			Created:             1770318000, // 2026-02-05
@@ -897,6 +908,8 @@ func GetAntigravityModelConfig() map[string]*AntigravityModelConfig {
 		"claude-opus-4-5-thinking":   {Thinking: &ThinkingSupport{Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: true}, MaxCompletionTokens: 64000},
 		"claude-opus-4-6-thinking":   {Thinking: &ThinkingSupport{Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: true}, MaxCompletionTokens: 64000},
 		"claude-sonnet-4-5":          {MaxCompletionTokens: 64000},
+		"claude-sonnet-4-6":          {MaxCompletionTokens: 64000},
+		"claude-sonnet-4-6-thinking": {Thinking: &ThinkingSupport{Min: 1024, Max: 128000, ZeroAllowed: true, DynamicAllowed: true}, MaxCompletionTokens: 64000},
 		"gpt-oss-120b-medium":        {},
 		"tab_flash_lite_preview":     {},
 	}


### PR DESCRIPTION
## Summary

Add `claude-sonnet-4-6` to the model registry. Released by Anthropic on 2026-02-17.

## Changes

| File | Change |
|------|--------|
| `internal/registry/model_definitions_static_data.go` | Add static model definition + Antigravity config entries |

**Model definition:**
- ID: `claude-sonnet-4-6`
- Context: 200,000 tokens
- Max output: 64,000 tokens
- Thinking: Min 1024, Max 128000, ZeroAllowed: true

**Antigravity config:**
- `claude-sonnet-4-6`: 64K max completion tokens
- `claude-sonnet-4-6-thinking`: thinking support with DynamicAllowed

## Backward compatibility

Additive change only — no existing behavior affected.