### PR TITLE
Add strict structured-output mappings for Claude, Gemini, and Codex

### DIFF
--- a/internal/translator/claude/openai/chat-completions/claude_openai_request_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request_test.go
@@ -1,0 +1,58 @@
+package chat_completions
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIRequestToClaude_MapsStructuredOutputAndStrictTool(t *testing.T) {
+	input := []byte(`{
+		"messages":[{"role":"user","content":"Return JSON"}],
+		"response_format":{
+			"type":"json_schema",
+			"json_schema":{
+				"name":"answer_schema",
+				"strict":true,
+				"schema":{
+					"type":"object",
+					"properties":{"answer":{"type":"string"}},
+					"required":["answer"],
+					"additionalProperties":false
+				}
+			}
+		},
+		"tools":[
+			{
+				"type":"function",
+				"function":{
+					"name":"save_answer",
+					"description":"save",
+					"strict":true,
+					"parameters":{
+						"type":"object",
+						"properties":{"answer":{"type":"string"}},
+						"required":["answer"],
+						"additionalProperties":false
+					}
+				}
+			}
+		]
+	}`)
+
+	output := ConvertOpenAIRequestToClaude("claude-sonnet", input, false)
+	raw := string(output)
+
+	if gjson.Get(raw, "output_config.format.type").String() != "json_schema" {
+		t.Fatalf("expected output_config.format.type=json_schema, got %s", gjson.Get(raw, "output_config.format.type").Raw)
+	}
+	if gjson.Get(raw, "output_config.format.name").String() != "answer_schema" {
+		t.Fatalf("expected output_config.format.name=answer_schema, got %s", gjson.Get(raw, "output_config.format.name").Raw)
+	}
+	if gjson.Get(raw, "output_config.format.schema.properties.answer.type").String() != "string" {
+		t.Fatalf("expected structured schema to be mapped, got %s", gjson.Get(raw, "output_config.format.schema").Raw)
+	}
+	if !gjson.Get(raw, "tools.0.strict").Bool() {
+		t.Fatalf("expected strict tool mapping, got %s", gjson.Get(raw, "tools.0").Raw)
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -1,0 +1,54 @@
+package responses
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIResponsesRequestToClaude_MapsTextFormatSchemaAndToolStrict(t *testing.T) {
+	input := []byte(`{
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"Return JSON"}]}],
+		"text":{
+			"format":{
+				"type":"json_schema",
+				"name":"result",
+				"schema":{
+					"type":"object",
+					"properties":{"ok":{"type":"boolean"}},
+					"required":["ok"],
+					"additionalProperties":false
+				}
+			}
+		},
+		"tools":[
+			{
+				"type":"function",
+				"name":"save",
+				"description":"save output",
+				"strict":true,
+				"parameters":{
+					"type":"object",
+					"properties":{"ok":{"type":"boolean"}},
+					"required":["ok"]
+				}
+			}
+		]
+	}`)
+
+	output := ConvertOpenAIResponsesRequestToClaude("claude-sonnet", input, false)
+	raw := string(output)
+
+	if gjson.Get(raw, "output_config.format.type").String() != "json_schema" {
+		t.Fatalf("expected output_config.format.type=json_schema, got %s", gjson.Get(raw, "output_config.format.type").Raw)
+	}
+	if gjson.Get(raw, "output_config.format.name").String() != "result" {
+		t.Fatalf("expected output_config.format.name=result, got %s", gjson.Get(raw, "output_config.format.name").Raw)
+	}
+	if gjson.Get(raw, "output_config.format.schema.properties.ok.type").String() != "boolean" {
+		t.Fatalf("expected structured schema to be mapped, got %s", gjson.Get(raw, "output_config.format.schema").Raw)
+	}
+	if !gjson.Get(raw, "tools.0.strict").Bool() {
+		t.Fatalf("expected tools.0.strict=true, got %s", gjson.Get(raw, "tools.0").Raw)
+	}
+}

--- a/internal/translator/codex/openai/chat-completions/codex_openai_request.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request.go
@@ -59,7 +59,7 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 	} else {
 		out, _ = sjson.Set(out, "reasoning.effort", "medium")
 	}
-	out, _ = sjson.Set(out, "parallel_tool_calls", true)
+	hasStrictStructuredOutput := false
 	out, _ = sjson.Set(out, "reasoning.summary", "auto")
 	out, _ = sjson.Set(out, "include", []string{"reasoning.encrypted_content"})
 
@@ -240,6 +240,9 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 				}
 				if v := js.Get("strict"); v.Exists() {
 					out, _ = sjson.Set(out, "text.format.strict", v.Value())
+					if v.Bool() {
+						hasStrictStructuredOutput = true
+					}
 				}
 				if v := js.Get("schema"); v.Exists() {
 					out, _ = sjson.SetRaw(out, "text.format.schema", v.Raw)
@@ -300,6 +303,9 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 					}
 					if v := fn.Get("strict"); v.Exists() {
 						item, _ = sjson.Set(item, "strict", v.Value())
+						if v.Bool() {
+							hasStrictStructuredOutput = true
+						}
 					}
 				}
 				out, _ = sjson.SetRaw(out, "tools.-1", item)
@@ -337,6 +343,7 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 			}
 		}
 	}
+	out, _ = sjson.Set(out, "parallel_tool_calls", !hasStrictStructuredOutput)
 
 	out, _ = sjson.Set(out, "store", false)
 	return []byte(out)

--- a/internal/translator/codex/openai/chat-completions/codex_openai_request_test.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request_test.go
@@ -1,0 +1,71 @@
+package chat_completions
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIRequestToCodex_DisablesParallelToolCallsWhenStrict(t *testing.T) {
+	input := []byte(`{
+		"messages":[{"role":"user","content":"Return JSON"}],
+		"response_format":{
+			"type":"json_schema",
+			"json_schema":{
+				"name":"result",
+				"strict":true,
+				"schema":{
+					"type":"object",
+					"properties":{"answer":{"type":"string"}},
+					"required":["answer"],
+					"additionalProperties":false
+				}
+			}
+		},
+		"tools":[
+			{
+				"type":"function",
+				"function":{
+					"name":"save_answer",
+					"description":"save",
+					"strict":true,
+					"parameters":{"type":"object","properties":{}}
+				}
+			}
+		]
+	}`)
+
+	output := ConvertOpenAIRequestToCodex("gpt-5", input, false)
+	raw := string(output)
+
+	if !gjson.Get(raw, "text.format.strict").Bool() {
+		t.Fatalf("expected text.format.strict=true, got %s", gjson.Get(raw, "text.format.strict").Raw)
+	}
+	if gjson.Get(raw, "parallel_tool_calls").Bool() {
+		t.Fatalf("expected parallel_tool_calls=false when strict is enabled, got %s", gjson.Get(raw, "parallel_tool_calls").Raw)
+	}
+}
+
+func TestConvertOpenAIRequestToCodex_UsesParallelToolCallsWhenNotStrict(t *testing.T) {
+	input := []byte(`{
+		"messages":[{"role":"user","content":"Hello"}],
+		"tools":[
+			{
+				"type":"function",
+				"function":{
+					"name":"save_answer",
+					"description":"save",
+					"strict":false,
+					"parameters":{"type":"object","properties":{}}
+				}
+			}
+		]
+	}`)
+
+	output := ConvertOpenAIRequestToCodex("gpt-5", input, false)
+	raw := string(output)
+
+	if !gjson.Get(raw, "parallel_tool_calls").Bool() {
+		t.Fatalf("expected parallel_tool_calls=true when strict is not enabled, got %s", gjson.Get(raw, "parallel_tool_calls").Raw)
+	}
+}

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_request_test.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_request_test.go
@@ -1,0 +1,53 @@
+package chat_completions
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIRequestToGemini_MapsResponseFormatJSONSchema(t *testing.T) {
+	input := []byte(`{
+		"messages":[{"role":"user","content":"Return JSON"}],
+		"response_format":{
+			"type":"json_schema",
+			"json_schema":{
+				"name":"result",
+				"strict":true,
+				"schema":{
+					"type":"object",
+					"properties":{"x":{"type":"string"}},
+					"required":["x"],
+					"additionalProperties":false
+				}
+			}
+		}
+	}`)
+
+	output := ConvertOpenAIRequestToGemini("gemini-2.5-pro", input, false)
+	raw := string(output)
+
+	if gjson.Get(raw, "generationConfig.responseMimeType").String() != "application/json" {
+		t.Fatalf("expected responseMimeType=application/json, got %s", gjson.Get(raw, "generationConfig.responseMimeType").Raw)
+	}
+	if !gjson.Get(raw, "generationConfig.responseJsonSchema").Exists() {
+		t.Fatalf("expected responseJsonSchema to exist, got %s", gjson.Get(raw, "generationConfig").Raw)
+	}
+	if gjson.Get(raw, "generationConfig.responseJsonSchema.additionalProperties").Exists() {
+		t.Fatalf("expected Gemini-cleaned schema without additionalProperties, got %s", gjson.Get(raw, "generationConfig.responseJsonSchema").Raw)
+	}
+}
+
+func TestConvertOpenAIRequestToGemini_MapsResponseFormatJSONObject(t *testing.T) {
+	input := []byte(`{
+		"messages":[{"role":"user","content":"Return JSON"}],
+		"response_format":{"type":"json_object"}
+	}`)
+
+	output := ConvertOpenAIRequestToGemini("gemini-2.5-pro", input, false)
+	raw := string(output)
+
+	if gjson.Get(raw, "generationConfig.responseMimeType").String() != "application/json" {
+		t.Fatalf("expected responseMimeType=application/json, got %s", gjson.Get(raw, "generationConfig.responseMimeType").Raw)
+	}
+}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -1,0 +1,42 @@
+package responses
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIResponsesRequestToGemini_MapsTextFormatSchema(t *testing.T) {
+	input := []byte(`{
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"Return JSON"}]}],
+		"max_output_tokens":128,
+		"text":{
+			"format":{
+				"type":"json_schema",
+				"name":"result",
+				"schema":{
+					"type":"object",
+					"properties":{"status":{"type":"string"}},
+					"required":["status"],
+					"additionalProperties":false
+				}
+			}
+		}
+	}`)
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-2.5-pro", input, false)
+	raw := string(output)
+
+	if gjson.Get(raw, "generationConfig.responseMimeType").String() != "application/json" {
+		t.Fatalf("expected responseMimeType=application/json, got %s", gjson.Get(raw, "generationConfig.responseMimeType").Raw)
+	}
+	if !gjson.Get(raw, "generationConfig.responseJsonSchema").Exists() {
+		t.Fatalf("expected responseJsonSchema to exist, got %s", gjson.Get(raw, "generationConfig").Raw)
+	}
+	if gjson.Get(raw, "generationConfig.responseJsonSchema.additionalProperties").Exists() {
+		t.Fatalf("expected Gemini-cleaned schema without additionalProperties, got %s", gjson.Get(raw, "generationConfig.responseJsonSchema").Raw)
+	}
+	if gjson.Get(raw, "generationConfig.maxOutputTokens").Int() != 128 {
+		t.Fatalf("expected maxOutputTokens=128, got %s", gjson.Get(raw, "generationConfig.maxOutputTokens").Raw)
+	}
+}


### PR DESCRIPTION
## Summary
- map OpenAI response_format/text.format JSON Schema requests to provider-native structured output fields for Claude and Gemini
- propagate strict tool flags to Claude tool definitions
- preserve Gemini structured-output fields through AI Studio executor translation
- disable Codex parallel_tool_calls when strict structured output/tool schemas are requested
- add focused unit tests for new mappings in Claude/Gemini/Codex translators

## Notes
- Go toolchain is not available in this environment, so gofmt/go test could not be executed locally.