### PR TITLE
fix(antigravity): prevent invalid JSON when tool_result has no content

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -231,8 +231,12 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 
 							} else if functionResponseResult.IsObject() {
 								functionResponseJSON, _ = sjson.SetRaw(functionResponseJSON, "response.result", functionResponseResult.Raw)
-							} else {
+							} else if functionResponseResult.Raw != "" {
 								functionResponseJSON, _ = sjson.SetRaw(functionResponseJSON, "response.result", functionResponseResult.Raw)
+							} else {
+								// Content field is missing entirely — .Raw is empty which
+								// causes sjson.SetRaw to produce invalid JSON (e.g. "result":}).
+								functionResponseJSON, _ = sjson.Set(functionResponseJSON, "response.result", "")
 							}
 
 							partJSON := `{}`


### PR DESCRIPTION
## Summary
- Fix invalid JSON payload error when a Claude `tool_result` block has no `content` field
- `sjson.SetRaw` with an empty string (from missing `.Raw`) produces malformed JSON like `"result":}`
- Guard against empty `.Raw` by falling back to `sjson.Set` with `""`, preserving `null` and other valid raw values

Fix #1646  

## Test plan
- [x] Reproduced bug with simple JSON (missing content field → invalid JSON)
- [x] Verified fix produces valid JSON for missing, null, string, and array content
- [x] Verified with original payload end-to-end via curl
- [x] Added regression tests for missing and null content cases