### PR TITLE
fix(translator): handle tool call arguments in codex→claude streaming translator

### DIFF
--- a/internal/translator/codex/claude/codex_claude_response.go
+++ b/internal/translator/codex/claude/codex_claude_response.go
@@ -22,8 +22,9 @@ var (
 
 // ConvertCodexResponseToClaudeParams holds parameters for response conversion.
 type ConvertCodexResponseToClaudeParams struct {
-	HasToolCall bool
-	BlockIndex  int
+	HasToolCall              bool
+	BlockIndex               int
+	HasReceivedArgumentsDelta bool
 }
 
 // ConvertCodexResponseToClaude performs sophisticated streaming response format conversion.
@@ -137,6 +138,7 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		itemType := itemResult.Get("type").String()
 		if itemType == "function_call" {
 			(*param).(*ConvertCodexResponseToClaudeParams).HasToolCall = true
+			(*param).(*ConvertCodexResponseToClaudeParams).HasReceivedArgumentsDelta = false
 			template = `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"","name":"","input":{}}}`
 			template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
 			template, _ = sjson.Set(template, "content_block.id", itemResult.Get("call_id").String())
@@ -171,6 +173,7 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 			output += fmt.Sprintf("data: %s\n\n", template)
 		}
 	} else if typeStr == "response.function_call_arguments.delta" {
+		(*param).(*ConvertCodexResponseToClaudeParams).HasReceivedArgumentsDelta = true
 		template = `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`
 		template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
 		template, _ = sjson.Set(template, "delta.partial_json", rootResult.Get("delta").String())
@@ -182,13 +185,16 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		// in a single "done" event without preceding "delta" events.
 		// Emit the full arguments as a single input_json_delta so the
 		// downstream Claude client receives the complete tool input.
-		if args := rootResult.Get("arguments").String(); args != "" {
-			template = `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`
-			template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
-			template, _ = sjson.Set(template, "delta.partial_json", args)
+		// When delta events were already received, skip to avoid duplicating arguments.
+		if !(*param).(*ConvertCodexResponseToClaudeParams).HasReceivedArgumentsDelta {
+			if args := rootResult.Get("arguments").String(); args != "" {
+				template = `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`
+				template, _ = sjson.Set(template, "index", (*param).(*ConvertCodexResponseToClaudeParams).BlockIndex)
+				template, _ = sjson.Set(template, "delta.partial_json", args)
 
-			output += "event: content_block_delta\n"
-			output += fmt.Sprintf("data: %s\n\n", template)
+				output += "event: content_block_delta\n"
+				output += fmt.Sprintf("data: %s\n\n", template)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

The codex→claude streaming translator (`internal/translator/codex/claude/codex_claude_response.go`) has two related bugs with `response.function_call_arguments` events:

### Bug 1: Spark models — arguments lost entirely

Spark models (e.g. `gpt-5.3-codex-spark`) send function call arguments **only** in a single `response.function_call_arguments.done` event, without preceding `delta` events. The translator didn't handle `done`, so arguments were silently dropped. Downstream Claude clients received `input: {}`, causing "required field missing" errors and infinite tool-call retry loops.

### Bug 2: Non-spark models — arguments duplicated

Non-spark models (e.g. `gpt-5.3-codex`, `gpt-5.2-codex`) stream arguments via multiple `delta` events, then a final `done` with the complete arguments. A naive `done` handler that always emits duplicates what deltas already streamed — producing invalid double-JSON like `{"file_path":"..."}{"file_path":"..."}`, causing parse failures and retry loops.

## Fix

Two commits:

1. **Add `done` handler** — emits arguments from `done` event (for spark models that send no deltas)
2. **Add `HasReceivedArgumentsDelta` flag** — `done` handler only emits when no deltas preceded it; skips for non-spark models that already streamed via deltas

This is the same pattern applied to the OpenAI translator in PR #1635 (merged).

## Changes

`internal/translator/codex/claude/codex_claude_response.go`:
- Add `HasReceivedArgumentsDelta bool` field to `ConvertCodexResponseToClaudeParams`
- Reset flag on each new `response.output_item.added` (function_call)
- Set flag to `true` in `response.function_call_arguments.delta` handler
- Add `response.function_call_arguments.done` handler that emits only when `HasReceivedArgumentsDelta == false`

## Tested

- `gpt-5.3-codex-spark` — Read, Grep, Glob tools ✅
- `gpt-5.3-codex` medium — Read, Grep, Glob tools ✅  
- `gpt-5.2-codex` — Read, Grep, Glob tools ✅

## Related

- Issue #1609 (same fix, submitted as issue per prior pr-path-guard guidance)
- PR #1635 (same pattern applied to OpenAI translator — merged)

## Test plan

- [ ] Test with spark model (`gpt-5.3-codex-spark`) — tool calls return correct arguments
- [ ] Test with non-spark model (`gpt-5.3-codex`) — no argument duplication
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes