### PR TITLE
fix(claude): use api.anthropic.com for OAuth token exchange

### DIFF
--- a/internal/auth/claude/anthropic_auth.go
+++ b/internal/auth/claude/anthropic_auth.go
@@ -20,7 +20,7 @@ import (
 // OAuth configuration constants for Claude/Anthropic
 const (
 	AuthURL     = "https://claude.ai/oauth/authorize"
-	TokenURL    = "https://console.anthropic.com/v1/oauth/token"
+	TokenURL    = "https://api.anthropic.com/v1/oauth/token"
 	ClientID    = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 	RedirectURI = "http://localhost:54545/callback"
 )


### PR DESCRIPTION
## Summary

- Switch Claude OAuth token exchange URL from `console.anthropic.com` to `api.anthropic.com` to bypass Cloudflare managed challenge

## Problem

`console.anthropic.com` is now protected by a Cloudflare **managed challenge** (`cType: 'managed'`) that blocks all non-browser POST requests to `/v1/oauth/token`. This causes `-claude-login` to fail with a 403 error containing a Cloudflare "Just a moment..." challenge page.

This affects **all** programmatic HTTP clients — Go with uTLS, curl, Python requests — regardless of TLS fingerprinting or headers. The challenge requires real JavaScript execution.

## Fix

`api.anthropic.com` hosts the same OAuth token endpoint at the same path (`/v1/oauth/token`) but without the Cloudflare managed challenge. Changing the `TokenURL` constant is a one-line fix.

**Before:**
```
$ curl -s -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" \
  -d '{"grant_type":"authorization_code","client_id":"...","code":"test","state":"test","code_verifier":"test"}' \
  "https://console.anthropic.com/v1/oauth/token"
403  # Cloudflare managed challenge HTML
```

**After:**
```
$ curl -s -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" \
  -d '{"grant_type":"authorization_code","client_id":"...","code":"test","state":"test","code_verifier":"test"}' \
  "https://api.anthropic.com/v1/oauth/token"
400  # Real OAuth2 error: {"error": "invalid_grant", "error_description": "Invalid 'code' in request."}
```

## Test plan

- [x] Verified `api.anthropic.com/v1/oauth/token` returns real OAuth2 responses (not Cloudflare challenge)
- [x] Built patched binary and successfully completed `-claude-login` flow
- [x] Tokens saved and usable

Fixes #1659

🤖 Generated with [Claude Code](https://claude.com/claude-code)