### PR TITLE
perf(codex): replace repeated gjson/sjson path rewrites with single-pass Unmarshal/Marshal

### DIFF
--- a/internal/translator/codex/openai/chat-completions/codex_openai_request.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request.go
@@ -296,6 +296,10 @@ func rawToString(raw json.RawMessage) string {
 	if len(raw) == 0 {
 		return ""
 	}
+	// Keep behavior aligned with legacy gjson String() for null.
+	if string(raw) == "null" {
+		return ""
+	}
 	var s string
 	if err := json.Unmarshal(raw, &s); err == nil {
 		return s


### PR DESCRIPTION

The previous `ConvertOpenAIRequestToCodex()` called `gjson.GetBytes` and `sjson.Set/SetRaw` dozens of times per request. Every `sjson` write produces a full copy of the entire JSON string, so a single request with N messages, M tools, and K tool-calls triggered O(N + M + K) string copies before anything left the process. Under load this showed up in profiles as `memmove`, `appendRawPaths`, and `gjson.parseSquash` dominating CPU and GC time.

This PR rewrites `ConvertOpenAIRequestToCodex()` to decode the input exactly once into a small set of typed structs, build the output as a `map[string]any` in memory with zero intermediate string copies, then encode once with `json.Marshal`. Fields whose shape varies at runtime (`content`, `tool_choice`, parameters) are held as `json.RawMessage` and parsed only when needed. Built-in tools re-use the original raw bytes so nothing is unnecessarily re-serialised. One edge-case fix is also included: `rawToString()` now returns `""` for `null` content, matching the previous `gjson.String()` behaviour and preventing the literal string `"null"` from leaking into `function_call_output.output`.

All existing behaviour is preserved: reasoning effort defaulting, `parallel_tool_calls`, `include`, system→developer role mapping, assistant `tool_calls` expansion, tool-name shortening via `buildShortNameMap`, `response_format`/`json_schema`, `text.verbosity`, and `store: false`. The old implementation is retained as `ConvertOpenAIRequestToCodexLegacy()` in a separate file. A test suite in `codex_openai_request_test.go` compares new vs. legacy output with `reflect.DeepEqual` across 12 representative input shapes — string content, content arrays with images, assistant tool-calls, built-in tools, long MCP names, json_schema response formats, and more.

Any divergence from the legacy output fails the test before the code ships. If a regression is found, the legacy function is still compiled and callable, making rollback a single-line change. Since `json.Marshal` does not guarantee key order, any consumer that depends on field ordering in the raw bytes would be affected — however, the output is passed directly to the upstream API as a parsed JSON object, so key order is irrelevant to correctness.