### PR TITLE
fix(auth): respect configured auto-refresh interval

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1828,9 +1828,7 @@ func (m *Manager) persist(ctx context.Context, auth *Auth) error {
 // every few seconds and triggers refresh operations when required.
 // Only one loop is kept alive; starting a new one cancels the previous run.
 func (m *Manager) StartAutoRefresh(parent context.Context, interval time.Duration) {
-	if interval <= 0 || interval > refreshCheckInterval {
-		interval = refreshCheckInterval
-	} else {
+	if interval <= 0 {
 		interval = refreshCheckInterval
 	}
 	if m.refreshCancel != nil {


### PR DESCRIPTION
  Description

  - 修复 StartAutoRefresh 将传入 interval 强制覆盖为 refreshCheckInterval 的问题。
  - 变更后仅在 interval <= 0 时回退到默认 refreshCheckInterval，否则使用调用方传入值（例如 15m）。

  Why

  - 当前实现导致 auto-refresh 实际固定 5 秒检查一次。
  - 在大量 auth 文件场景下，会放大 refresh 调度频率和系统负载。

  Scope

  - 单文件、单逻辑点修改：
      - sdk/cliproxy/auth/conductor.go

  Diff summary

  - Before:
      - 无论传入什么间隔，都变成 5 秒。
  - After:
      - 仅当传入值无效时使用 5 秒默认值；有效值保留。

  Verification

  1. 容器构建通过
      - docker compose build cli-proxy-api
  2. 定向测试通过
      - go test ./sdk/cliproxy/auth（容器内）
  3. 全量测试现状
      - go test ./... 失败点在已有 thinking e2e 用例，与本 PR 无关。

  Risk

  - 低风险，未改刷新判定、重试、并发逻辑，仅修复 interval 赋值错误。