### PR TITLE
fix(auth): limit auto-refresh concurrency to prevent refresh storms

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -60,6 +60,7 @@ type RefreshEvaluator interface {
 
 const (
 	refreshCheckInterval  = 5 * time.Second
+	refreshMaxConcurrency = 16
 	refreshPendingBackoff = time.Minute
 	refreshFailureBackoff = 5 * time.Minute
 	quotaBackoffBase      = time.Second
@@ -155,7 +156,8 @@ type Manager struct {
 	rtProvider RoundTripperProvider
 
 	// Auto refresh state
-	refreshCancel context.CancelFunc
+	refreshCancel    context.CancelFunc
+	refreshSemaphore chan struct{}
 }
 
 // NewManager constructs a manager with optional custom selector and hook.
@@ -173,6 +175,7 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 		hook:            hook,
 		auths:           make(map[string]*Auth),
 		providerOffsets: make(map[string]int),
+		refreshSemaphore: make(chan struct{}, refreshMaxConcurrency),
 	}
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(&internalconfig.Config{})
@@ -1880,9 +1883,23 @@ func (m *Manager) checkRefreshes(ctx context.Context) {
 			if !m.markRefreshPending(a.ID, now) {
 				continue
 			}
-			go m.refreshAuth(ctx, a.ID)
+			go m.refreshAuthWithLimit(ctx, a.ID)
 		}
 	}
+}
+
+func (m *Manager) refreshAuthWithLimit(ctx context.Context, id string) {
+	if m.refreshSemaphore == nil {
+		m.refreshAuth(ctx, id)
+		return
+	}
+	select {
+	case m.refreshSemaphore <- struct{}{}:
+		defer func() { <-m.refreshSemaphore }()
+	case <-ctx.Done():
+		return
+	}
+	m.refreshAuth(ctx, id)
 }
 
 func (m *Manager) snapshotAuths() []*Auth {


### PR DESCRIPTION
## 变更摘要
  - 在 `auth conductor` 中增加自动刷新并发限流。
  - 通过信号量将并发刷新上限限制为 `16`。
  - 后台刷新任务统一走限流包装函数，避免无上限 goroutine 扇出。

  ## 背景
  当大量 auth 文件在同一时间进入可刷新状态时，原实现会直接 `go m.refreshAuth(...)`，并发不受控，容易触发刷新风暴，导致 CPU/网络瞬时升高。

  ## 具体改动
  - 文件：`sdk/cliproxy/auth/conductor.go`
  1. 新增常量：
     - `refreshMaxConcurrency = 16`
  2. `Manager` 新增字段：
     - `refreshSemaphore chan struct{}`
  3. 在 `NewManager` 中初始化信号量：
     - `make(chan struct{}, refreshMaxConcurrency)`
  4. 将 `checkRefreshes` 中的调用由：
     - `go m.refreshAuth(ctx, a.ID)`
     - 改为 `go m.refreshAuthWithLimit(ctx, a.ID)`
  5. 新增 `refreshAuthWithLimit`：
     - 先获取信号量
     - `defer` 释放
     - 再执行原有 `refreshAuth`

  ## 影响说明
  - 刷新判定逻辑不变。
  - 刷新回退/失败重试时间策略不变。
  - 仅限制同一时刻刷新并发数，降低大规模刷新时的资源冲击。

  ## 验证
  - 使用 `golang:1.26-alpine` 容器执行：
    - `go test ./sdk/cliproxy/auth`
  - 测试通过。
