### PR TITLE
feat(sdk): add D2 guard pattern to prevent custom antigravity executor overwrite

### DIFF
--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -409,6 +409,14 @@ func (s *Service) ensureExecutorsForAuthWithMode(a *coreauth.Auth, forceReplace 
 		}
 		return
 	case "antigravity":
+		existingExecutor, hasExecutor := s.coreManager.Executor("antigravity")
+		if hasExecutor {
+			_, isSDKAntigravity := existingExecutor.(*executor.AntigravityExecutor)
+			if !isSDKAntigravity {
+				// Custom executor already registered — do not overwrite
+				return
+			}
+		}
 		s.coreManager.RegisterExecutor(executor.NewAntigravityExecutor(s.cfg))
 	case "claude":
 		s.coreManager.RegisterExecutor(executor.NewClaudeExecutor(s.cfg))


### PR DESCRIPTION
## Summary
- Add D2 guard pattern in `sdk/cliproxy/service.go` to prevent custom antigravity executor from being overwritten by default values during initialization.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)