### PR TITLE
Proposal: Strip empty messages on translation from openai to claude

### DIFF
--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -156,8 +156,12 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 				} else if contentResult.Exists() && contentResult.IsArray() {
 					contentResult.ForEach(func(_, part gjson.Result) bool {
 						if part.Get("type").String() == "text" {
+							textContent := part.Get("text").String()
+							if textContent == "" {
+								return true
+							}
 							textPart := `{"type":"text","text":""}`
-							textPart, _ = sjson.Set(textPart, "text", part.Get("text").String())
+							textPart, _ = sjson.Set(textPart, "text", textContent)
 							out, _ = sjson.SetRaw(out, fmt.Sprintf("messages.%d.content.-1", systemMessageIndex), textPart)
 						}
 						return true
@@ -178,8 +182,12 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 
 						switch partType {
 						case "text":
+							textContent := part.Get("text").String()
+							if textContent == "" {
+								return true
+							}
 							textPart := `{"type":"text","text":""}`
-							textPart, _ = sjson.Set(textPart, "text", part.Get("text").String())
+							textPart, _ = sjson.Set(textPart, "text", textContent)
 							msg, _ = sjson.SetRaw(msg, "content.-1", textPart)
 
 						case "image_url":


### PR DESCRIPTION

Problem:  
Some vibecoding plugins sometimes generate messages with empty text.
I understand that this is not a CLIProxyAPI problem, but I still suggest considering the option of rejecting such messages.

Сhanges:
During OpenAI-to-Claude request translation, text content parts with empty strings are now filtered out instead of being forwarded. This prevents sending empty text blocks to the Claude API, which could cause unexpected behavior or validation errors.



