### PR TITLE
fix(auth): 统一 refresh 不可重试判定并隔离 runtime metadata，避免账号增量触发全局刷新

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -77,7 +77,8 @@ force-model-prefix: false
 # Default is false (disabled).
 passthrough-headers: false
 
-# Number of times to retry a request. Retries will occur if the HTTP response code is 403, 408, 500, 502, 503, or 504.
+# Number of times to retry a request for transient errors (for example: 408, 500, 502, 503, 504).
+# Request-level cooldown retry is skipped for 401, 402, 403, 404, 422, and 429.
 request-retry: 3
 
 # Maximum number of different credentials to try for one failed request.

--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -276,7 +276,7 @@ func (o *CodexAuth) RefreshTokensWithRetry(ctx context.Context, refreshToken str
 		if err == nil {
 			return tokenData, nil
 		}
-		if isNonRetryableRefreshErr(err) {
+		if util.IsNonRetryableRefreshError(err) {
 			log.Warnf("Token refresh attempt %d failed with non-retryable error: %v", attempt+1, err)
 			return nil, err
 		}
@@ -286,14 +286,6 @@ func (o *CodexAuth) RefreshTokensWithRetry(ctx context.Context, refreshToken str
 	}
 
 	return nil, fmt.Errorf("token refresh failed after %d attempts: %w", maxRetries, lastErr)
-}
-
-func isNonRetryableRefreshErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	raw := strings.ToLower(err.Error())
-	return strings.Contains(raw, "refresh_token_reused")
 }
 
 // UpdateTokenStorage updates an existing CodexTokenStorage with new token data.

--- a/internal/util/parse_any.go
+++ b/internal/util/parse_any.go
@@ -7,6 +7,13 @@ import (
 	"time"
 )
 
+var parseTimeLayouts = []string{
+	time.RFC3339,
+	time.RFC3339Nano,
+	"2006-01-02 15:04:05",
+	"2006-01-02 15:04",
+}
+
 // ParseBoolAny parses common bool encodings from JSON-decoded values.
 func ParseBoolAny(val any) (bool, bool) {
 	switch typed := val.(type) {
@@ -75,13 +82,7 @@ func ParseTimeAny(v any) (time.Time, bool) {
 		if s == "" {
 			return time.Time{}, false
 		}
-		layouts := []string{
-			time.RFC3339,
-			time.RFC3339Nano,
-			"2006-01-02 15:04:05",
-			"2006-01-02 15:04",
-		}
-		for _, layout := range layouts {
+		for _, layout := range parseTimeLayouts {
 			if ts, err := time.Parse(layout, s); err == nil {
 				return ts, true
 			}

--- a/internal/util/parse_any.go
+++ b/internal/util/parse_any.go
@@ -80,7 +80,6 @@ func ParseTimeAny(v any) (time.Time, bool) {
 			time.RFC3339Nano,
 			"2006-01-02 15:04:05",
 			"2006-01-02 15:04",
-			"2006-01-02T15:04:05Z07:00",
 		}
 		for _, layout := range layouts {
 			if ts, err := time.Parse(layout, s); err == nil {
@@ -91,6 +90,8 @@ func ParseTimeAny(v any) (time.Time, bool) {
 			return normaliseUnix(unix), true
 		}
 	case float64:
+		return normaliseUnix(int64(value)), true
+	case int:
 		return normaliseUnix(int64(value)), true
 	case int64:
 		return normaliseUnix(value), true

--- a/internal/util/parse_any.go
+++ b/internal/util/parse_any.go
@@ -1,0 +1,116 @@
+package util
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ParseBoolAny parses common bool encodings from JSON-decoded values.
+func ParseBoolAny(val any) (bool, bool) {
+	switch typed := val.(type) {
+	case bool:
+		return typed, true
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return false, false
+		}
+		parsed, err := strconv.ParseBool(trimmed)
+		if err != nil {
+			return false, false
+		}
+		return parsed, true
+	case float64:
+		return typed != 0, true
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return false, false
+		}
+		return parsed != 0, true
+	default:
+		return false, false
+	}
+}
+
+// ParseIntAny parses common int encodings from JSON-decoded values.
+func ParseIntAny(val any) (int, bool) {
+	switch typed := val.(type) {
+	case int:
+		return typed, true
+	case int32:
+		return int(typed), true
+	case int64:
+		return int(typed), true
+	case float64:
+		return int(typed), true
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(parsed), true
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return 0, false
+		}
+		parsed, err := strconv.Atoi(trimmed)
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	default:
+		return 0, false
+	}
+}
+
+// ParseTimeAny parses common time encodings from JSON-decoded values.
+func ParseTimeAny(v any) (time.Time, bool) {
+	switch value := v.(type) {
+	case string:
+		s := strings.TrimSpace(value)
+		if s == "" {
+			return time.Time{}, false
+		}
+		layouts := []string{
+			time.RFC3339,
+			time.RFC3339Nano,
+			"2006-01-02 15:04:05",
+			"2006-01-02 15:04",
+			"2006-01-02T15:04:05Z07:00",
+		}
+		for _, layout := range layouts {
+			if ts, err := time.Parse(layout, s); err == nil {
+				return ts, true
+			}
+		}
+		if unix, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return normaliseUnix(unix), true
+		}
+	case float64:
+		return normaliseUnix(int64(value)), true
+	case int64:
+		return normaliseUnix(value), true
+	case json.Number:
+		if i, err := value.Int64(); err == nil {
+			return normaliseUnix(i), true
+		}
+		if f, err := value.Float64(); err == nil {
+			return normaliseUnix(int64(f)), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func normaliseUnix(raw int64) time.Time {
+	if raw <= 0 {
+		return time.Time{}
+	}
+	if raw > 1_000_000_000_000 {
+		return time.UnixMilli(raw)
+	}
+	return time.Unix(raw, 0)
+}

--- a/internal/util/parse_any_test.go
+++ b/internal/util/parse_any_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 func TestParseBoolAny(t *testing.T) {
@@ -64,26 +65,38 @@ func TestParseIntAny(t *testing.T) {
 func TestParseTimeAny(t *testing.T) {
 	t.Parallel()
 
+	base := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	baseUnix := base.Unix()
+	baseMillis := base.UnixMilli()
+
 	tests := []struct {
 		name string
 		in   any
+		want time.Time
 		ok   bool
 	}{
-		{name: "rfc3339", in: "2026-03-01T00:00:00Z", ok: true},
-		{name: "unix string", in: "1700000000", ok: true},
-		{name: "float unix", in: 1700000000.0, ok: true},
-		{name: "json number unix", in: json.Number("1700000000"), ok: true},
-		{name: "empty", in: "", ok: false},
-		{name: "invalid", in: "not-time", ok: false},
+		{name: "rfc3339", in: "2023-01-01T00:00:00Z", want: base, ok: true},
+		{name: "unix string seconds", in: "1672531200", want: base, ok: true},
+		{name: "unix string millis", in: "1672531200000", want: base, ok: true},
+		{name: "float unix", in: float64(baseUnix), want: base, ok: true},
+		{name: "int unix", in: int(baseUnix), want: base, ok: true},
+		{name: "int64 unix", in: baseUnix, want: base, ok: true},
+		{name: "json number unix", in: json.Number("1672531200"), want: base, ok: true},
+		{name: "json number millis", in: json.Number("1672531200000"), want: time.UnixMilli(baseMillis), ok: true},
+		{name: "empty", in: "", want: time.Time{}, ok: false},
+		{name: "invalid", in: "not-time", want: time.Time{}, ok: false},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, ok := ParseTimeAny(tt.in)
+			got, ok := ParseTimeAny(tt.in)
 			if ok != tt.ok {
 				t.Fatalf("ParseTimeAny(%v) ok=%v, want %v", tt.in, ok, tt.ok)
+			}
+			if tt.ok && !got.Equal(tt.want) {
+				t.Fatalf("ParseTimeAny(%v) got=%v, want=%v", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/internal/util/parse_any_test.go
+++ b/internal/util/parse_any_test.go
@@ -1,0 +1,90 @@
+package util
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseBoolAny(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   any
+		want bool
+		ok   bool
+	}{
+		{name: "bool true", in: true, want: true, ok: true},
+		{name: "string false", in: "false", want: false, ok: true},
+		{name: "float one", in: 1.0, want: true, ok: true},
+		{name: "json number zero", in: json.Number("0"), want: false, ok: true},
+		{name: "invalid string", in: "x", want: false, ok: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := ParseBoolAny(tt.in)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("ParseBoolAny(%v) = (%v,%v), want (%v,%v)", tt.in, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestParseIntAny(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   any
+		want int
+		ok   bool
+	}{
+		{name: "int", in: 7, want: 7, ok: true},
+		{name: "float", in: 7.9, want: 7, ok: true},
+		{name: "json number", in: json.Number("12"), want: 12, ok: true},
+		{name: "string", in: "42", want: 42, ok: true},
+		{name: "invalid", in: "x", want: 0, ok: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := ParseIntAny(tt.in)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("ParseIntAny(%v) = (%v,%v), want (%v,%v)", tt.in, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestParseTimeAny(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   any
+		ok   bool
+	}{
+		{name: "rfc3339", in: "2026-03-01T00:00:00Z", ok: true},
+		{name: "unix string", in: "1700000000", ok: true},
+		{name: "float unix", in: 1700000000.0, ok: true},
+		{name: "json number unix", in: json.Number("1700000000"), ok: true},
+		{name: "empty", in: "", ok: false},
+		{name: "invalid", in: "not-time", ok: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, ok := ParseTimeAny(tt.in)
+			if ok != tt.ok {
+				t.Fatalf("ParseTimeAny(%v) ok=%v, want %v", tt.in, ok, tt.ok)
+			}
+		})
+	}
+}

--- a/internal/util/retry_classify.go
+++ b/internal/util/retry_classify.go
@@ -1,0 +1,15 @@
+package util
+
+import "strings"
+
+// IsNonRetryableRefreshError reports whether a token refresh error is terminal
+// and should not be retried immediately.
+func IsNonRetryableRefreshError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "refresh_token_reused") ||
+		strings.Contains(msg, "invalid_grant") ||
+		strings.Contains(msg, "token_invalidated")
+}

--- a/internal/util/retry_classify_test.go
+++ b/internal/util/retry_classify_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsNonRetryableRefreshError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "refresh token reused", err: errors.New("refresh_token_reused"), want: true},
+		{name: "invalid grant", err: errors.New("oauth INVALID_GRANT"), want: true},
+		{name: "token invalidated", err: errors.New("Token_Invalidated by server"), want: true},
+		{name: "other", err: errors.New("temporary network error"), want: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsNonRetryableRefreshError(tc.err); got != tc.want {
+				t.Fatalf("IsNonRetryableRefreshError()=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -202,7 +202,6 @@ func (w *Watcher) addOrUpdateClient(path string) {
 		}
 		w.lastAuthContents[normalized] = &newAuth
 	}
-
 	oldByID := make(map[string]*coreauth.Auth, len(w.fileAuthsByPath[normalized]))
 	for id, a := range w.fileAuthsByPath[normalized] {
 		oldByID[id] = a
@@ -224,7 +223,6 @@ func (w *Watcher) addOrUpdateClient(path string) {
 	}
 	updates := w.computePerPathUpdatesLocked(oldByID, newByID)
 	w.clientsMutex.Unlock()
-
 	w.persistAuthAsync(fmt.Sprintf("Sync auth %s", filepath.Base(path)), path)
 	w.dispatchAuthUpdates(updates)
 }
@@ -239,10 +237,8 @@ func (w *Watcher) removeClient(path string) {
 	delete(w.lastAuthHashes, normalized)
 	delete(w.lastAuthContents, normalized)
 	delete(w.fileAuthsByPath, normalized)
-
 	updates := w.computePerPathUpdatesLocked(oldByID, map[string]*coreauth.Auth{})
 	w.clientsMutex.Unlock()
-
 	w.persistAuthAsync(fmt.Sprintf("Remove auth %s", filepath.Base(path)), path)
 	w.dispatchAuthUpdates(updates)
 }

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -132,11 +132,12 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			"source": fullPath,
 			"path":   fullPath,
 		},
-		ProxyURL:  proxyURL,
-		Metadata:  metadata,
-		CreatedAt: now,
-		UpdatedAt: now,
+	ProxyURL:  proxyURL,
+	Metadata:  metadata,
+	CreatedAt: now,
+	UpdatedAt: now,
 	}
+	coreauth.RestoreRuntimeStateFromMetadata(a, metadata)
 	// Read priority from auth file.
 	if rawPriority, ok := metadata["priority"]; ok {
 		switch v := rawPriority.(type) {

--- a/internal/watcher/synthesizer/file_test.go
+++ b/internal/watcher/synthesizer/file_test.go
@@ -131,6 +131,57 @@ func TestFileSynthesizer_Synthesize_ValidAuthFile(t *testing.T) {
 	}
 }
 
+func TestFileSynthesizer_Synthesize_RestoresRuntimeStateFromMetadata(t *testing.T) {
+	tempDir := t.TempDir()
+	nextRetry := time.Now().UTC().Add(20 * time.Minute).Round(time.Second)
+
+	authData := map[string]any{
+		"type":                     "claude",
+		"email":                    "runtime@example.com",
+		"runtime_status":           string(coreauth.StatusError),
+		"runtime_status_message":   "cooldown",
+		"runtime_unavailable":      true,
+		"runtime_next_retry_after": nextRetry.Format(time.RFC3339Nano),
+		"runtime_last_error": map[string]any{
+			"code":        "rate_limit",
+			"message":     "too many requests",
+			"http_status": 429,
+		},
+	}
+	data, _ := json.Marshal(authData)
+	if err := os.WriteFile(filepath.Join(tempDir, "runtime.json"), data, 0o644); err != nil {
+		t.Fatalf("failed to write auth file: %v", err)
+	}
+
+	synth := NewFileSynthesizer()
+	ctx := &SynthesisContext{
+		Config:      &config.Config{},
+		AuthDir:     tempDir,
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth, got %d", len(auths))
+	}
+	got := auths[0]
+	if got.Status != coreauth.StatusError {
+		t.Fatalf("status=%s, want %s", got.Status, coreauth.StatusError)
+	}
+	if got.StatusMessage != "cooldown" {
+		t.Fatalf("status message=%q, want %q", got.StatusMessage, "cooldown")
+	}
+	if !got.Unavailable {
+		t.Fatalf("unavailable=false, want true")
+	}
+	if got.LastError == nil || got.LastError.HTTPStatus != 429 {
+		t.Fatalf("last error=%+v, want http_status=429", got.LastError)
+	}
+}
+
 func TestFileSynthesizer_Synthesize_GeminiProviderMapping(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -387,7 +387,7 @@ func TestAddOrUpdateClientSkipsUnchanged(t *testing.T) {
 	}
 }
 
-func TestAddOrUpdateClientTriggersReloadAndHash(t *testing.T) {
+func TestAddOrUpdateClientUpdatesHashWithoutReload(t *testing.T) {
 	tmpDir := t.TempDir()
 	authFile := filepath.Join(tmpDir, "sample.json")
 	if err := os.WriteFile(authFile, []byte(`{"type":"demo","api_key":"k"}`), 0o644); err != nil {
@@ -416,7 +416,7 @@ func TestAddOrUpdateClientTriggersReloadAndHash(t *testing.T) {
 	}
 }
 
-func TestRemoveClientRemovesHash(t *testing.T) {
+func TestRemoveClientRemovesHashWithoutReload(t *testing.T) {
 	tmpDir := t.TempDir()
 	authFile := filepath.Join(tmpDir, "sample.json")
 	var reloads int32
@@ -773,7 +773,7 @@ func TestStopConfigReloadTimerSafeWhenNil(t *testing.T) {
 	w.stopConfigReloadTimer()
 }
 
-func TestHandleEventRemovesAuthFile(t *testing.T) {
+func TestHandleEventRemovesAuthFileWithoutReload(t *testing.T) {
 	tmpDir := t.TempDir()
 	authFile := filepath.Join(tmpDir, "remove.json")
 	if err := os.WriteFile(authFile, []byte(`{"type":"demo"}`), 0o644); err != nil {
@@ -1063,7 +1063,7 @@ func TestHandleEventAtomicReplaceUnchangedSkips(t *testing.T) {
 	}
 }
 
-func TestHandleEventAtomicReplaceChangedTriggersUpdate(t *testing.T) {
+func TestHandleEventAtomicReplaceChangedTriggersIncrementalUpdateOnly(t *testing.T) {
 	tmpDir := t.TempDir()
 	authDir := filepath.Join(tmpDir, "auth")
 	if err := os.MkdirAll(authDir, 0o755); err != nil {
@@ -1124,7 +1124,7 @@ func TestHandleEventRemoveUnknownFileIgnored(t *testing.T) {
 	}
 }
 
-func TestHandleEventRemoveKnownFileDeletes(t *testing.T) {
+func TestHandleEventRemoveKnownFileDeletesWithoutReload(t *testing.T) {
 	tmpDir := t.TempDir()
 	authDir := filepath.Join(tmpDir, "auth")
 	if err := os.MkdirAll(authDir, 0o755); err != nil {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -25,18 +24,6 @@ type FileTokenStore struct {
 	dirLock sync.RWMutex
 	baseDir string
 }
-
-const (
-	// runtime metadata keys persist transient execution state to disk so that
-	// cooldown/error decisions survive process restarts.
-	metadataKeyStatus      = "runtime_status"
-	metadataKeyStatusMsg   = "runtime_status_message"
-	metadataKeyUnavailable = "runtime_unavailable"
-	metadataKeyQuota       = "runtime_quota"
-	metadataKeyLastError   = "runtime_last_error"
-	metadataKeyNextRetry   = "runtime_next_retry_after"
-	metadataKeyModelStates = "runtime_model_states"
-)
 
 // NewFileTokenStore creates a token store that saves credentials to disk through the
 // TokenStorage implementation embedded in the token record.
@@ -83,18 +70,19 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 		SetMetadata(map[string]any)
 	}
 
+	metadata := cliproxyauth.CloneMetadata(auth.Metadata)
+	metadata["disabled"] = auth.Disabled
+	cliproxyauth.ApplyRuntimeStateToMetadata(metadata, auth)
+
 	switch {
 	case auth.Storage != nil:
 		if setter, ok := auth.Storage.(metadataSetter); ok {
-			setter.SetMetadata(auth.Metadata)
+			setter.SetMetadata(metadata)
 		}
 		if err = auth.Storage.SaveTokenToFile(path); err != nil {
 			return "", err
 		}
 	case auth.Metadata != nil:
-		metadata := cloneMetadata(auth.Metadata)
-		metadata["disabled"] = auth.Disabled
-		applyRuntimeStateToMetadata(metadata, auth)
 		raw, errMarshal := json.Marshal(metadata)
 		if errMarshal != nil {
 			return "", fmt.Errorf("auth filestore: marshal metadata failed: %w", errMarshal)
@@ -269,7 +257,7 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 	if email, ok := metadata["email"].(string); ok && email != "" {
 		auth.Attributes["email"] = email
 	}
-	restoreRuntimeStateFromMetadata(auth, metadata)
+	cliproxyauth.RestoreRuntimeStateFromMetadata(auth, metadata)
 	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
 	return auth, nil
 }
@@ -463,131 +451,4 @@ func deepEqualJSON(a, b any) bool {
 	default:
 		return false
 	}
-}
-
-func cloneMetadata(src map[string]any) map[string]any {
-	if len(src) == 0 {
-		return map[string]any{}
-	}
-	dst := make(map[string]any, len(src))
-	for key, value := range src {
-		dst[key] = value
-	}
-	return dst
-}
-
-// applyRuntimeStateToMetadata stores runtime-only account/model health state into
-// namespaced metadata fields so state can be restored after restart.
-func applyRuntimeStateToMetadata(metadata map[string]any, auth *cliproxyauth.Auth) {
-	if metadata == nil || auth == nil {
-		return
-	}
-
-	metadata[metadataKeyStatus] = string(auth.Status)
-	if msg := strings.TrimSpace(auth.StatusMessage); msg != "" {
-		metadata[metadataKeyStatusMsg] = msg
-	} else {
-		delete(metadata, metadataKeyStatusMsg)
-	}
-	metadata[metadataKeyUnavailable] = auth.Unavailable
-
-	if !auth.NextRetryAfter.IsZero() {
-		metadata[metadataKeyNextRetry] = auth.NextRetryAfter.UTC().Format(time.RFC3339Nano)
-	} else {
-		delete(metadata, metadataKeyNextRetry)
-	}
-
-	if !isQuotaStateZero(auth.Quota) {
-		metadata[metadataKeyQuota] = auth.Quota
-	} else {
-		delete(metadata, metadataKeyQuota)
-	}
-
-	if auth.LastError != nil {
-		metadata[metadataKeyLastError] = auth.LastError
-	} else {
-		delete(metadata, metadataKeyLastError)
-	}
-
-	if len(auth.ModelStates) > 0 {
-		metadata[metadataKeyModelStates] = auth.ModelStates
-	} else {
-		delete(metadata, metadataKeyModelStates)
-	}
-}
-
-// restoreRuntimeStateFromMetadata restores runtime-only state written by
-// applyRuntimeStateToMetadata to avoid relearning cooldown/error state on startup.
-func restoreRuntimeStateFromMetadata(auth *cliproxyauth.Auth, metadata map[string]any) {
-	if auth == nil || metadata == nil {
-		return
-	}
-
-	if persistedStatus := parseStatusAny(metadata[metadataKeyStatus]); persistedStatus != "" && !auth.Disabled {
-		auth.Status = persistedStatus
-	}
-	if msg, ok := metadata[metadataKeyStatusMsg].(string); ok {
-		auth.StatusMessage = strings.TrimSpace(msg)
-	}
-	if unavailable, okUnavailable := util.ParseBoolAny(metadata[metadataKeyUnavailable]); okUnavailable {
-		auth.Unavailable = unavailable
-	}
-	if nextRetry, okNextRetry := util.ParseTimeAny(metadata[metadataKeyNextRetry]); okNextRetry {
-		auth.NextRetryAfter = nextRetry
-	}
-
-	if quotaRaw, okQuota := metadata[metadataKeyQuota]; okQuota {
-		var quota cliproxyauth.QuotaState
-		if decodeAnyToStruct(quotaRaw, &quota) == nil {
-			auth.Quota = quota
-		}
-	}
-	if errRaw, okLastErr := metadata[metadataKeyLastError]; okLastErr {
-		var lastErr cliproxyauth.Error
-		if decodeAnyToStruct(errRaw, &lastErr) == nil && (lastErr.Message != "" || lastErr.Code != "" || lastErr.HTTPStatus > 0) {
-			auth.LastError = &lastErr
-		}
-	}
-	if statesRaw, okStates := metadata[metadataKeyModelStates]; okStates {
-		var states map[string]*cliproxyauth.ModelState
-		if decodeAnyToStruct(statesRaw, &states) == nil && len(states) > 0 {
-			auth.ModelStates = states
-		}
-	}
-
-	if auth.Disabled {
-		auth.Status = cliproxyauth.StatusDisabled
-	}
-}
-
-func decodeAnyToStruct(raw any, target any) error {
-	if raw == nil || target == nil {
-		return fmt.Errorf("decode any: nil input")
-	}
-	blob, errMarshal := json.Marshal(raw)
-	if errMarshal != nil {
-		return errMarshal
-	}
-	return json.Unmarshal(blob, target)
-}
-
-func parseStatusAny(raw any) cliproxyauth.Status {
-	s, ok := raw.(string)
-	if !ok {
-		return ""
-	}
-	status := cliproxyauth.Status(strings.TrimSpace(s))
-	switch status {
-	case cliproxyauth.StatusUnknown, cliproxyauth.StatusActive, cliproxyauth.StatusPending,
-		cliproxyauth.StatusRefreshing, cliproxyauth.StatusError, cliproxyauth.StatusDisabled:
-		return status
-	}
-	return ""
-}
-
-func isQuotaStateZero(state cliproxyauth.QuotaState) bool {
-	return !state.Exceeded &&
-		strings.TrimSpace(state.Reason) == "" &&
-		state.NextRecoverAt.IsZero() &&
-		state.BackoffLevel == 0
 }

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -11,11 +11,11 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -529,10 +529,10 @@ func restoreRuntimeStateFromMetadata(auth *cliproxyauth.Auth, metadata map[strin
 	if msg, ok := metadata[metadataKeyStatusMsg].(string); ok {
 		auth.StatusMessage = strings.TrimSpace(msg)
 	}
-	if unavailable, okUnavailable := parseBoolAny(metadata[metadataKeyUnavailable]); okUnavailable {
+	if unavailable, okUnavailable := util.ParseBoolAny(metadata[metadataKeyUnavailable]); okUnavailable {
 		auth.Unavailable = unavailable
 	}
-	if nextRetry, okNextRetry := parseTimeAny(metadata[metadataKeyNextRetry]); okNextRetry {
+	if nextRetry, okNextRetry := util.ParseTimeAny(metadata[metadataKeyNextRetry]); okNextRetry {
 		auth.NextRetryAfter = nextRetry
 	}
 
@@ -583,41 +583,6 @@ func parseStatusAny(raw any) cliproxyauth.Status {
 		return status
 	}
 	return ""
-}
-
-func parseBoolAny(raw any) (bool, bool) {
-	switch v := raw.(type) {
-	case bool:
-		return v, true
-	case string:
-		parsed, err := strconv.ParseBool(strings.TrimSpace(v))
-		if err != nil {
-			return false, false
-		}
-		return parsed, true
-	case float64:
-		return v != 0, true
-	case int:
-		return v != 0, true
-	default:
-		return false, false
-	}
-}
-
-func parseTimeAny(raw any) (time.Time, bool) {
-	switch v := raw.(type) {
-	case string:
-		trimmed := strings.TrimSpace(v)
-		if trimmed == "" {
-			return time.Time{}, false
-		}
-		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
-			if parsed, err := time.Parse(layout, trimmed); err == nil {
-				return parsed, true
-			}
-		}
-	}
-	return time.Time{}, false
 }
 
 func isQuotaStateZero(state cliproxyauth.QuotaState) bool {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -616,8 +616,6 @@ func parseTimeAny(raw any) (time.Time, bool) {
 				return parsed, true
 			}
 		}
-	case time.Time:
-		return v, true
 	}
 	return time.Time{}, false
 }

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -24,6 +25,16 @@ type FileTokenStore struct {
 	dirLock sync.RWMutex
 	baseDir string
 }
+
+const (
+	metadataKeyStatus       = "status"
+	metadataKeyStatusMsg    = "status_message"
+	metadataKeyUnavailable  = "unavailable"
+	metadataKeyQuota        = "quota"
+	metadataKeyLastError    = "last_error"
+	metadataKeyNextRetry    = "next_retry_after"
+	metadataKeyModelStates  = "model_states"
+)
 
 // NewFileTokenStore creates a token store that saves credentials to disk through the
 // TokenStorage implementation embedded in the token record.
@@ -79,8 +90,10 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 			return "", err
 		}
 	case auth.Metadata != nil:
-		auth.Metadata["disabled"] = auth.Disabled
-		raw, errMarshal := json.Marshal(auth.Metadata)
+		metadata := cloneMetadata(auth.Metadata)
+		metadata["disabled"] = auth.Disabled
+		applyRuntimeStateToMetadata(metadata, auth)
+		raw, errMarshal := json.Marshal(metadata)
 		if errMarshal != nil {
 			return "", fmt.Errorf("auth filestore: marshal metadata failed: %w", errMarshal)
 		}
@@ -254,6 +267,7 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 	if email, ok := metadata["email"].(string); ok && email != "" {
 		auth.Attributes["email"] = email
 	}
+	restoreRuntimeStateFromMetadata(auth, metadata)
 	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
 	return auth, nil
 }
@@ -447,4 +461,163 @@ func deepEqualJSON(a, b any) bool {
 	default:
 		return false
 	}
+}
+
+func cloneMetadata(src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return map[string]any{}
+	}
+	dst := make(map[string]any, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}
+
+func applyRuntimeStateToMetadata(metadata map[string]any, auth *cliproxyauth.Auth) {
+	if metadata == nil || auth == nil {
+		return
+	}
+
+	metadata[metadataKeyStatus] = string(auth.Status)
+	if msg := strings.TrimSpace(auth.StatusMessage); msg != "" {
+		metadata[metadataKeyStatusMsg] = msg
+	} else {
+		delete(metadata, metadataKeyStatusMsg)
+	}
+	metadata[metadataKeyUnavailable] = auth.Unavailable
+
+	if !auth.NextRetryAfter.IsZero() {
+		metadata[metadataKeyNextRetry] = auth.NextRetryAfter.UTC().Format(time.RFC3339Nano)
+	} else {
+		delete(metadata, metadataKeyNextRetry)
+	}
+
+	if !isQuotaStateZero(auth.Quota) {
+		metadata[metadataKeyQuota] = auth.Quota
+	} else {
+		delete(metadata, metadataKeyQuota)
+	}
+
+	if auth.LastError != nil {
+		metadata[metadataKeyLastError] = auth.LastError
+	} else {
+		delete(metadata, metadataKeyLastError)
+	}
+
+	if len(auth.ModelStates) > 0 {
+		metadata[metadataKeyModelStates] = auth.ModelStates
+	} else {
+		delete(metadata, metadataKeyModelStates)
+	}
+}
+
+func restoreRuntimeStateFromMetadata(auth *cliproxyauth.Auth, metadata map[string]any) {
+	if auth == nil || metadata == nil {
+		return
+	}
+
+	if persistedStatus := parseStatusAny(metadata[metadataKeyStatus]); persistedStatus != "" && !auth.Disabled {
+		auth.Status = persistedStatus
+	}
+	if msg, ok := metadata[metadataKeyStatusMsg].(string); ok {
+		auth.StatusMessage = strings.TrimSpace(msg)
+	}
+	if unavailable, okUnavailable := parseBoolAny(metadata[metadataKeyUnavailable]); okUnavailable {
+		auth.Unavailable = unavailable
+	}
+	if nextRetry, okNextRetry := parseTimeAny(metadata[metadataKeyNextRetry]); okNextRetry {
+		auth.NextRetryAfter = nextRetry
+	}
+
+	if quotaRaw, okQuota := metadata[metadataKeyQuota]; okQuota {
+		var quota cliproxyauth.QuotaState
+		if decodeAnyToStruct(quotaRaw, &quota) == nil {
+			auth.Quota = quota
+		}
+	}
+	if errRaw, okLastErr := metadata[metadataKeyLastError]; okLastErr {
+		var lastErr cliproxyauth.Error
+		if decodeAnyToStruct(errRaw, &lastErr) == nil && (lastErr.Message != "" || lastErr.Code != "" || lastErr.HTTPStatus > 0) {
+			auth.LastError = &lastErr
+		}
+	}
+	if statesRaw, okStates := metadata[metadataKeyModelStates]; okStates {
+		var states map[string]*cliproxyauth.ModelState
+		if decodeAnyToStruct(statesRaw, &states) == nil && len(states) > 0 {
+			auth.ModelStates = states
+		}
+	}
+
+	if auth.Disabled {
+		auth.Status = cliproxyauth.StatusDisabled
+	}
+}
+
+func decodeAnyToStruct(raw any, target any) error {
+	if raw == nil || target == nil {
+		return fmt.Errorf("decode any: nil input")
+	}
+	blob, errMarshal := json.Marshal(raw)
+	if errMarshal != nil {
+		return errMarshal
+	}
+	return json.Unmarshal(blob, target)
+}
+
+func parseStatusAny(raw any) cliproxyauth.Status {
+	switch v := raw.(type) {
+	case string:
+		switch cliproxyauth.Status(strings.TrimSpace(v)) {
+		case cliproxyauth.StatusUnknown, cliproxyauth.StatusActive, cliproxyauth.StatusPending,
+			cliproxyauth.StatusRefreshing, cliproxyauth.StatusError, cliproxyauth.StatusDisabled:
+			return cliproxyauth.Status(strings.TrimSpace(v))
+		}
+	}
+	return ""
+}
+
+func parseBoolAny(raw any) (bool, bool) {
+	switch v := raw.(type) {
+	case bool:
+		return v, true
+	case string:
+		parsed, err := strconv.ParseBool(strings.TrimSpace(v))
+		if err != nil {
+			return false, false
+		}
+		return parsed, true
+	case float64:
+		return v != 0, true
+	case int:
+		return v != 0, true
+	default:
+		return false, false
+	}
+}
+
+func parseTimeAny(raw any) (time.Time, bool) {
+	switch v := raw.(type) {
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return time.Time{}, false
+		}
+		if parsed, err := time.Parse(time.RFC3339Nano, trimmed); err == nil {
+			return parsed, true
+		}
+		if parsed, err := time.Parse(time.RFC3339, trimmed); err == nil {
+			return parsed, true
+		}
+	case time.Time:
+		return v, true
+	}
+	return time.Time{}, false
+}
+
+func isQuotaStateZero(state cliproxyauth.QuotaState) bool {
+	return !state.Exceeded &&
+		strings.TrimSpace(state.Reason) == "" &&
+		state.NextRecoverAt.IsZero() &&
+		state.BackoffLevel == 0
 }

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -566,13 +566,15 @@ func decodeAnyToStruct(raw any, target any) error {
 }
 
 func parseStatusAny(raw any) cliproxyauth.Status {
-	switch v := raw.(type) {
-	case string:
-		switch cliproxyauth.Status(strings.TrimSpace(v)) {
-		case cliproxyauth.StatusUnknown, cliproxyauth.StatusActive, cliproxyauth.StatusPending,
-			cliproxyauth.StatusRefreshing, cliproxyauth.StatusError, cliproxyauth.StatusDisabled:
-			return cliproxyauth.Status(strings.TrimSpace(v))
-		}
+	s, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	status := cliproxyauth.Status(strings.TrimSpace(s))
+	switch status {
+	case cliproxyauth.StatusUnknown, cliproxyauth.StatusActive, cliproxyauth.StatusPending,
+		cliproxyauth.StatusRefreshing, cliproxyauth.StatusError, cliproxyauth.StatusDisabled:
+		return status
 	}
 	return ""
 }
@@ -603,11 +605,10 @@ func parseTimeAny(raw any) (time.Time, bool) {
 		if trimmed == "" {
 			return time.Time{}, false
 		}
-		if parsed, err := time.Parse(time.RFC3339Nano, trimmed); err == nil {
-			return parsed, true
-		}
-		if parsed, err := time.Parse(time.RFC3339, trimmed); err == nil {
-			return parsed, true
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+			if parsed, err := time.Parse(layout, trimmed); err == nil {
+				return parsed, true
+			}
 		}
 	case time.Time:
 		return v, true

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -27,13 +27,15 @@ type FileTokenStore struct {
 }
 
 const (
-	metadataKeyStatus       = "status"
-	metadataKeyStatusMsg    = "status_message"
-	metadataKeyUnavailable  = "unavailable"
-	metadataKeyQuota        = "quota"
-	metadataKeyLastError    = "last_error"
-	metadataKeyNextRetry    = "next_retry_after"
-	metadataKeyModelStates  = "model_states"
+	// runtime metadata keys persist transient execution state to disk so that
+	// cooldown/error decisions survive process restarts.
+	metadataKeyStatus      = "runtime_status"
+	metadataKeyStatusMsg   = "runtime_status_message"
+	metadataKeyUnavailable = "runtime_unavailable"
+	metadataKeyQuota       = "runtime_quota"
+	metadataKeyLastError   = "runtime_last_error"
+	metadataKeyNextRetry   = "runtime_next_retry_after"
+	metadataKeyModelStates = "runtime_model_states"
 )
 
 // NewFileTokenStore creates a token store that saves credentials to disk through the
@@ -474,6 +476,8 @@ func cloneMetadata(src map[string]any) map[string]any {
 	return dst
 }
 
+// applyRuntimeStateToMetadata stores runtime-only account/model health state into
+// namespaced metadata fields so state can be restored after restart.
 func applyRuntimeStateToMetadata(metadata map[string]any, auth *cliproxyauth.Auth) {
 	if metadata == nil || auth == nil {
 		return
@@ -512,6 +516,8 @@ func applyRuntimeStateToMetadata(metadata map[string]any, auth *cliproxyauth.Aut
 	}
 }
 
+// restoreRuntimeStateFromMetadata restores runtime-only state written by
+// applyRuntimeStateToMetadata to avoid relearning cooldown/error state on startup.
 func restoreRuntimeStateFromMetadata(auth *cliproxyauth.Auth, metadata map[string]any) {
 	if auth == nil || metadata == nil {
 		return

--- a/sdk/auth/filestore_runtime_state_test.go
+++ b/sdk/auth/filestore_runtime_state_test.go
@@ -82,14 +82,14 @@ func TestFileTokenStore_PersistsAndRestoresRuntimeState(t *testing.T) {
 	if errUnmarshal := json.Unmarshal(raw, &persisted); errUnmarshal != nil {
 		t.Fatalf("unmarshal persisted JSON: %v", errUnmarshal)
 	}
-	if _, ok := persisted["model_states"]; !ok {
-		t.Fatalf("persisted metadata missing model_states")
+	if _, ok := persisted["runtime_model_states"]; !ok {
+		t.Fatalf("persisted metadata missing runtime_model_states")
 	}
-	if _, ok := persisted["next_retry_after"]; !ok {
-		t.Fatalf("persisted metadata missing next_retry_after")
+	if _, ok := persisted["runtime_next_retry_after"]; !ok {
+		t.Fatalf("persisted metadata missing runtime_next_retry_after")
 	}
-	if _, ok := persisted["quota"]; !ok {
-		t.Fatalf("persisted metadata missing quota")
+	if _, ok := persisted["runtime_quota"]; !ok {
+		t.Fatalf("persisted metadata missing runtime_quota")
 	}
 
 	entries, errList := store.List(context.Background())
@@ -127,4 +127,3 @@ func TestFileTokenStore_PersistsAndRestoresRuntimeState(t *testing.T) {
 		t.Fatalf("model state quota=%+v, want exceeded quota", state.Quota)
 	}
 }
-

--- a/sdk/auth/filestore_runtime_state_test.go
+++ b/sdk/auth/filestore_runtime_state_test.go
@@ -1,0 +1,130 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestFileTokenStore_PersistsAndRestoresRuntimeState(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+
+	nextRetry := time.Now().UTC().Add(15 * time.Minute).Round(time.Second)
+	nextRecover := nextRetry.Add(30 * time.Second)
+
+	auth := &cliproxyauth.Auth{
+		ID:          "sample.json",
+		FileName:    "sample.json",
+		Provider:    "codex",
+		Status:      cliproxyauth.StatusError,
+		Unavailable: true,
+		Quota: cliproxyauth.QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: nextRecover,
+			BackoffLevel:  2,
+		},
+		LastError: &cliproxyauth.Error{
+			Code:       "rate_limit",
+			Message:    "usage_limit_reached",
+			HTTPStatus: 429,
+		},
+		NextRetryAfter: nextRetry,
+		ModelStates: map[string]*cliproxyauth.ModelState{
+			"gpt-5.3-codex": {
+				Status:         cliproxyauth.StatusError,
+				StatusMessage:  "quota exhausted",
+				Unavailable:    true,
+				NextRetryAfter: nextRetry,
+				LastError: &cliproxyauth.Error{
+					Code:       "rate_limit",
+					Message:    "usage_limit_reached",
+					HTTPStatus: 429,
+				},
+				Quota: cliproxyauth.QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: nextRecover,
+					BackoffLevel:  3,
+				},
+				UpdatedAt: time.Now().UTC().Round(time.Second),
+			},
+		},
+		Metadata: map[string]any{
+			"type":  "codex",
+			"email": "example@example.com",
+		},
+		Attributes: map[string]string{"path": filepath.Join(dir, "sample.json")},
+	}
+
+	savedPath, errSave := store.Save(context.Background(), auth)
+	if errSave != nil {
+		t.Fatalf("Save() error: %v", errSave)
+	}
+	if savedPath == "" {
+		t.Fatalf("Save() returned empty path")
+	}
+
+	raw, errRead := os.ReadFile(savedPath)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error: %v", errRead)
+	}
+	var persisted map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &persisted); errUnmarshal != nil {
+		t.Fatalf("unmarshal persisted JSON: %v", errUnmarshal)
+	}
+	if _, ok := persisted["model_states"]; !ok {
+		t.Fatalf("persisted metadata missing model_states")
+	}
+	if _, ok := persisted["next_retry_after"]; !ok {
+		t.Fatalf("persisted metadata missing next_retry_after")
+	}
+	if _, ok := persisted["quota"]; !ok {
+		t.Fatalf("persisted metadata missing quota")
+	}
+
+	entries, errList := store.List(context.Background())
+	if errList != nil {
+		t.Fatalf("List() error: %v", errList)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("List() entries=%d, want 1", len(entries))
+	}
+
+	got := entries[0]
+	if got.Status != cliproxyauth.StatusError {
+		t.Fatalf("Status=%q, want %q", got.Status, cliproxyauth.StatusError)
+	}
+	if !got.Unavailable {
+		t.Fatalf("Unavailable=false, want true")
+	}
+	if got.NextRetryAfter.IsZero() {
+		t.Fatalf("NextRetryAfter is zero, want persisted value")
+	}
+	if !got.Quota.Exceeded || got.Quota.Reason != "quota" {
+		t.Fatalf("Quota=%+v, want exceeded quota", got.Quota)
+	}
+	state := got.ModelStates["gpt-5.3-codex"]
+	if state == nil {
+		t.Fatalf("model state missing")
+	}
+	if !state.Unavailable {
+		t.Fatalf("model state unavailable=false, want true")
+	}
+	if state.NextRetryAfter.IsZero() {
+		t.Fatalf("model state NextRetryAfter is zero")
+	}
+	if state.Quota.Reason != "quota" || !state.Quota.Exceeded {
+		t.Fatalf("model state quota=%+v, want exceeded quota", state.Quota)
+	}
+}
+

--- a/sdk/auth/filestore_runtime_state_test.go
+++ b/sdk/auth/filestore_runtime_state_test.go
@@ -11,6 +11,25 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
+type captureStorage struct {
+	metadata map[string]any
+}
+
+func (s *captureStorage) SetMetadata(meta map[string]any) {
+	s.metadata = meta
+}
+
+func (s *captureStorage) SaveTokenToFile(authFilePath string) error {
+	if s.metadata == nil {
+		s.metadata = map[string]any{}
+	}
+	raw, err := json.Marshal(s.metadata)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(authFilePath, raw, 0o600)
+}
+
 func TestFileTokenStore_PersistsAndRestoresRuntimeState(t *testing.T) {
 	t.Parallel()
 
@@ -125,5 +144,45 @@ func TestFileTokenStore_PersistsAndRestoresRuntimeState(t *testing.T) {
 	}
 	if state.Quota.Reason != "quota" || !state.Quota.Exceeded {
 		t.Fatalf("model state quota=%+v, want exceeded quota", state.Quota)
+	}
+}
+
+func TestFileTokenStore_StorageBackedSaveIncludesRuntimeMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "storage.json")
+	store := NewFileTokenStore()
+	nextRetry := time.Now().UTC().Add(10 * time.Minute).Round(time.Second)
+	storage := &captureStorage{}
+
+	auth := &cliproxyauth.Auth{
+		ID:             "storage.json",
+		Provider:       "codex",
+		Status:         cliproxyauth.StatusError,
+		Unavailable:    true,
+		NextRetryAfter: nextRetry,
+		Metadata: map[string]any{
+			"type":  "codex",
+			"email": "storage@example.com",
+		},
+		Attributes: map[string]string{"path": path},
+		Storage:    storage,
+	}
+
+	if _, err := store.Save(context.Background(), auth); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	if got, ok := storage.metadata["runtime_status"].(string); !ok || got != string(cliproxyauth.StatusError) {
+		t.Fatalf("runtime_status=%v, want %q", storage.metadata["runtime_status"], cliproxyauth.StatusError)
+	}
+	if got, ok := storage.metadata["runtime_unavailable"].(bool); !ok || !got {
+		t.Fatalf("runtime_unavailable=%v, want true", storage.metadata["runtime_unavailable"])
+	}
+	if _, ok := storage.metadata["runtime_next_retry_after"]; !ok {
+		t.Fatalf("runtime_next_retry_after missing in storage metadata")
+	}
+	if _, ok := auth.Metadata["runtime_status"]; ok {
+		t.Fatalf("auth.Metadata mutated with runtime keys")
 	}
 }

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -1,6 +1,9 @@
 package auth
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestExtractAccessToken(t *testing.T) {
 	t.Parallel()
@@ -74,6 +77,34 @@ func TestExtractAccessToken(t *testing.T) {
 			got := extractAccessToken(tt.metadata)
 			if got != tt.expected {
 				t.Errorf("extractAccessToken() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseTimeAny(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  any
+		want bool
+	}{
+		{name: "rfc3339nano", raw: "2026-03-01T00:00:00.123456789Z", want: true},
+		{name: "rfc3339", raw: "2026-03-01T00:00:00Z", want: true},
+		{name: "empty", raw: "", want: false},
+		{name: "invalid", raw: "not-time", want: false},
+		{name: "time type", raw: time.Now(), want: false},
+		{name: "int type", raw: 123, want: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, ok := parseTimeAny(tc.raw)
+			if ok != tc.want {
+				t.Fatalf("parseTimeAny(%T) ok=%v, want %v", tc.raw, ok, tc.want)
 			}
 		})
 	}

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -97,7 +97,7 @@ func TestParseTimeAny(t *testing.T) {
 		{name: "empty", raw: "", want: false},
 		{name: "invalid", raw: "not-time", want: false},
 		{name: "time type", raw: time.Now(), want: false},
-		{name: "int type", raw: 123, want: false},
+		{name: "int type", raw: 123, want: true},
 	}
 
 	for _, tc := range tests {

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"testing"
 	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 )
 
 func TestExtractAccessToken(t *testing.T) {
@@ -102,9 +104,9 @@ func TestParseTimeAny(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, ok := parseTimeAny(tc.raw)
+			_, ok := util.ParseTimeAny(tc.raw)
 			if ok != tc.want {
-				t.Fatalf("parseTimeAny(%T) ok=%v, want %v", tc.raw, ok, tc.want)
+				t.Fatalf("util.ParseTimeAny(%T) ok=%v, want %v", tc.raw, ok, tc.want)
 			}
 		})
 	}

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -2,9 +2,6 @@ package auth
 
 import (
 	"testing"
-	"time"
-
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 )
 
 func TestExtractAccessToken(t *testing.T) {
@@ -79,34 +76,6 @@ func TestExtractAccessToken(t *testing.T) {
 			got := extractAccessToken(tt.metadata)
 			if got != tt.expected {
 				t.Errorf("extractAccessToken() = %q, want %q", got, tt.expected)
-			}
-		})
-	}
-}
-
-func TestParseTimeAny(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		raw  any
-		want bool
-	}{
-		{name: "rfc3339nano", raw: "2026-03-01T00:00:00.123456789Z", want: true},
-		{name: "rfc3339", raw: "2026-03-01T00:00:00Z", want: true},
-		{name: "empty", raw: "", want: false},
-		{name: "invalid", raw: "not-time", want: false},
-		{name: "time type", raw: time.Now(), want: false},
-		{name: "int type", raw: 123, want: true},
-	}
-
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			_, ok := util.ParseTimeAny(tc.raw)
-			if ok != tc.want {
-				t.Fatalf("util.ParseTimeAny(%T) ok=%v, want %v", tc.raw, ok, tc.want)
 			}
 		})
 	}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -314,6 +314,68 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 }
 
+// PruneUnsupportedModelStates removes runtime state for models that no longer
+// exist in the registry snapshot while preserving supported-model runtime state.
+func (m *Manager) PruneUnsupportedModelStates(ctx context.Context, authID string) {
+	if m == nil || authID == "" {
+		return
+	}
+
+	supportedModels := registry.GetGlobalRegistry().GetModelsForClient(authID)
+	supported := make(map[string]struct{}, len(supportedModels))
+	for _, model := range supportedModels {
+		if model == nil {
+			continue
+		}
+		modelKey := canonicalModelKey(model.ID)
+		if modelKey == "" {
+			continue
+		}
+		supported[modelKey] = struct{}{}
+	}
+
+	var snapshot *Auth
+	now := time.Now()
+
+	m.mu.Lock()
+	auth, ok := m.auths[authID]
+	if ok && auth != nil && len(auth.ModelStates) > 0 {
+		changed := false
+		for modelKey := range auth.ModelStates {
+			baseModel := canonicalModelKey(modelKey)
+			if baseModel == "" {
+				baseModel = strings.TrimSpace(modelKey)
+			}
+			if _, supportedModel := supported[baseModel]; supportedModel {
+				continue
+			}
+			delete(auth.ModelStates, modelKey)
+			changed = true
+		}
+		if len(auth.ModelStates) == 0 {
+			auth.ModelStates = nil
+		}
+		if changed {
+			updateAggregatedAvailability(auth, now)
+			if !hasModelError(auth, now) {
+				auth.LastError = nil
+				auth.StatusMessage = ""
+				auth.Status = StatusActive
+			}
+			auth.UpdatedAt = now
+			if errPersist := m.persist(ctx, auth); errPersist != nil {
+				logEntryWithRequestID(ctx).WithField("auth_id", auth.ID).Warnf("failed to persist auth changes during model state pruning: %v", errPersist)
+			}
+			snapshot = auth.Clone()
+		}
+	}
+	m.mu.Unlock()
+
+	if m.scheduler != nil && snapshot != nil {
+		m.scheduler.upsertAuth(snapshot)
+	}
+}
+
 func (m *Manager) SetSelector(selector Selector) {
 	if m == nil {
 		return

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1899,6 +1900,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 
 	m.mu.Lock()
 	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
+		beforePersistState := persistStateSnapshot(auth)
 		now := time.Now()
 
 		if result.Success {
@@ -2014,7 +2016,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 		}
 
-		_ = m.persist(ctx, auth)
+		afterPersistState := persistStateSnapshot(auth)
+		if !reflect.DeepEqual(beforePersistState, afterPersistState) {
+			_ = m.persist(ctx, auth)
+		}
 		authSnapshot = auth.Clone()
 	}
 	m.mu.Unlock()
@@ -2207,6 +2212,57 @@ func cloneError(err *Error) *Error {
 		Retryable:  err.Retryable,
 		HTTPStatus: err.HTTPStatus,
 	}
+}
+
+type modelPersistState struct {
+	Status         Status
+	StatusMessage  string
+	Unavailable    bool
+	NextRetryAfter time.Time
+	LastError      *Error
+	Quota          QuotaState
+}
+
+type authPersistState struct {
+	Status         Status
+	StatusMessage  string
+	Unavailable    bool
+	NextRetryAfter time.Time
+	Quota          QuotaState
+	LastError      *Error
+	ModelStates    map[string]modelPersistState
+}
+
+func persistStateSnapshot(auth *Auth) authPersistState {
+	if auth == nil {
+		return authPersistState{}
+	}
+	snapshot := authPersistState{
+		Status:         auth.Status,
+		StatusMessage:  auth.StatusMessage,
+		Unavailable:    auth.Unavailable,
+		NextRetryAfter: auth.NextRetryAfter,
+		Quota:          auth.Quota,
+		LastError:      cloneError(auth.LastError),
+	}
+	if len(auth.ModelStates) == 0 {
+		return snapshot
+	}
+	snapshot.ModelStates = make(map[string]modelPersistState, len(auth.ModelStates))
+	for model, state := range auth.ModelStates {
+		if state == nil {
+			continue
+		}
+		snapshot.ModelStates[model] = modelPersistState{
+			Status:         state.Status,
+			StatusMessage:  state.StatusMessage,
+			Unavailable:    state.Unavailable,
+			NextRetryAfter: state.NextRetryAfter,
+			LastError:      cloneError(state.LastError),
+			Quota:          state.Quota,
+		}
+	}
+	return snapshot
 }
 
 func statusCodeFromError(err error) int {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -61,12 +61,13 @@ type RefreshEvaluator interface {
 }
 
 const (
-	refreshCheckInterval  = 5 * time.Second
-	refreshMaxConcurrency = 16
-	refreshPendingBackoff = time.Minute
-	refreshFailureBackoff = 5 * time.Minute
-	quotaBackoffBase      = time.Second
-	quotaBackoffMax       = 30 * time.Minute
+	refreshCheckInterval       = 5 * time.Second
+	refreshMaxConcurrency      = 16
+	refreshPendingBackoff      = time.Minute
+	refreshFailureBackoff      = 5 * time.Minute
+	refreshNonRetryableBackoff = 24 * time.Hour
+	quotaBackoffBase           = time.Second
+	quotaBackoffMax            = 30 * time.Minute
 )
 
 var quotaCooldownDisabled atomic.Bool
@@ -2307,11 +2308,11 @@ func statusCodeFromResult(err *Error) int {
 func isNonRetryableRequestRetryStatus(status int) bool {
 	switch status {
 	case http.StatusUnauthorized, // 401
-		http.StatusPaymentRequired, // 402
-		http.StatusForbidden, // 403
-		http.StatusNotFound, // 404
+		http.StatusPaymentRequired,     // 402
+		http.StatusForbidden,           // 403
+		http.StatusNotFound,            // 404
 		http.StatusUnprocessableEntity, // 422
-		http.StatusTooManyRequests: // 429
+		http.StatusTooManyRequests:     // 429
 		return true
 	default:
 		return false
@@ -3223,7 +3224,7 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	if err != nil {
 		m.mu.Lock()
 		if current := m.auths[id]; current != nil {
-			current.NextRefreshAfter = now.Add(refreshFailureBackoff)
+			current.NextRefreshAfter = now.Add(refreshBackoffForError(err))
 			current.LastError = &Error{Message: err.Error()}
 			m.auths[id] = current
 			if m.scheduler != nil {
@@ -3246,6 +3247,13 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	updated.LastError = nil
 	updated.UpdatedAt = now
 	_, _ = m.Update(ctx, updated)
+}
+
+func refreshBackoffForError(err error) time.Duration {
+	if util.IsNonRetryableRefreshError(err) {
+		return refreshNonRetryableBackoff
+	}
+	return refreshFailureBackoff
 }
 
 func (m *Manager) executorFor(provider string) ProviderExecutor {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1853,7 +1853,11 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 	if maxWait <= 0 {
 		return 0, false
 	}
-	if status := statusCodeFromError(err); status == http.StatusOK {
+	status := statusCodeFromError(err)
+	if status == http.StatusOK {
+		return 0, false
+	}
+	if isNonRetryableRequestRetryStatus(status) {
 		return 0, false
 	}
 	if isRequestInvalidError(err) {
@@ -2242,6 +2246,20 @@ func statusCodeFromResult(err *Error) int {
 		return 0
 	}
 	return err.StatusCode()
+}
+
+func isNonRetryableRequestRetryStatus(status int) bool {
+	switch status {
+	case http.StatusUnauthorized, // 401
+		http.StatusPaymentRequired, // 402
+		http.StatusForbidden, // 403
+		http.StatusNotFound, // 404
+		http.StatusUnprocessableEntity, // 422
+		http.StatusTooManyRequests: // 429
+		return true
+	default:
+		return false
+	}
 }
 
 func isModelSupportErrorMessage(message string) bool {

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -646,6 +646,73 @@ func TestManager_Execute_DisableCooling_DoesNotBlackoutAfter429RetryAfter(t *tes
 	}
 }
 
+func TestManager_ShouldRetryAfterError_NonRetryableStatuses(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(3, 30*time.Second, 0)
+
+	model := "test-model"
+	next := time.Now().Add(5 * time.Second)
+
+	auth := &Auth{
+		ID:       "auth-429",
+		Provider: "claude",
+		ModelStates: map[string]*ModelState{
+			model: {
+				Unavailable:    true,
+				Status:         StatusError,
+				NextRetryAfter: next,
+			},
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	_, _, maxWait := m.retrySettings()
+	testCases := []int{401, 402, 403, 404, 422, 429}
+	for _, status := range testCases {
+		wait, shouldRetry := m.shouldRetryAfterError(&Error{HTTPStatus: status, Message: "non-retryable"}, 0, []string{"claude"}, model, maxWait)
+		if shouldRetry {
+			t.Fatalf("expected shouldRetry=false for status=%d, got true (wait=%v)", status, wait)
+		}
+		if wait != 0 {
+			t.Fatalf("expected wait=0 for status=%d, got %v", status, wait)
+		}
+	}
+}
+
+func TestManager_ShouldRetryAfterError_RetriesOn408(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(3, 30*time.Second, 0)
+
+	model := "test-model"
+	next := time.Now().Add(5 * time.Second)
+
+	auth := &Auth{
+		ID:       "auth-408",
+		Provider: "claude",
+		ModelStates: map[string]*ModelState{
+			model: {
+				Unavailable:    true,
+				Status:         StatusError,
+				NextRetryAfter: next,
+			},
+		},
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	_, _, maxWait := m.retrySettings()
+	wait, shouldRetry := m.shouldRetryAfterError(&Error{HTTPStatus: 408, Message: "timeout"}, 0, []string{"claude"}, model, maxWait)
+	if !shouldRetry {
+		t.Fatalf("expected shouldRetry=true for 408")
+	}
+	if wait <= 0 {
+		t.Fatalf("expected wait>0 for 408, got %v", wait)
+	}
+}
+
 func TestManager_MarkResult_RequestScopedNotFoundDoesNotCooldownAuth(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 

--- a/sdk/cliproxy/auth/persist_policy_test.go
+++ b/sdk/cliproxy/auth/persist_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type countingStore struct {
@@ -58,5 +59,111 @@ func TestWithSkipPersist_DisablesRegisterPersistence(t *testing.T) {
 	}
 	if got := store.saveCount.Load(); got != 0 {
 		t.Fatalf("expected 0 Save calls, got %d", got)
+	}
+}
+
+func TestMarkResult_DoesNotPersistOnSteadySuccess(t *testing.T) {
+	store := &countingStore{}
+	mgr := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "auth-1",
+		Provider: "antigravity",
+		Metadata: map[string]any{"type": "antigravity"},
+	}
+
+	if _, err := mgr.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	mgr.MarkResult(context.Background(), Result{
+		AuthID:   "auth-1",
+		Provider: "antigravity",
+		Model:    "m1",
+		Success:  true,
+	})
+	first := store.saveCount.Load()
+
+	mgr.MarkResult(context.Background(), Result{
+		AuthID:   "auth-1",
+		Provider: "antigravity",
+		Model:    "m1",
+		Success:  true,
+	})
+	second := store.saveCount.Load()
+
+	if second != first {
+		t.Fatalf("expected no extra Save on steady success, got first=%d second=%d", first, second)
+	}
+}
+
+func TestMarkResult_PersistsOnFailureTransition(t *testing.T) {
+	store := &countingStore{}
+	mgr := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "auth-1",
+		Provider: "antigravity",
+		Metadata: map[string]any{"type": "antigravity"},
+	}
+
+	if _, err := mgr.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	mgr.MarkResult(context.Background(), Result{
+		AuthID:   "auth-1",
+		Provider: "antigravity",
+		Model:    "m1",
+		Success:  true,
+	})
+	beforeFail := store.saveCount.Load()
+
+	retryAfter := 2 * time.Minute
+	mgr.MarkResult(context.Background(), Result{
+		AuthID:     "auth-1",
+		Provider:   "antigravity",
+		Model:      "m1",
+		Success:    false,
+		RetryAfter: &retryAfter,
+		Error:      &Error{HTTPStatus: 429, Message: "usage_limit_reached"},
+	})
+	afterFail := store.saveCount.Load()
+
+	if afterFail <= beforeFail {
+		t.Fatalf("expected Save on failure transition, got before=%d after=%d", beforeFail, afterFail)
+	}
+}
+
+func TestMarkResult_PersistsOnRecoveryTransition(t *testing.T) {
+	store := &countingStore{}
+	mgr := NewManager(store, nil, nil)
+	auth := &Auth{
+		ID:       "auth-1",
+		Provider: "antigravity",
+		Metadata: map[string]any{"type": "antigravity"},
+	}
+
+	if _, err := mgr.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	mgr.MarkResult(context.Background(), Result{
+		AuthID:   "auth-1",
+		Provider: "antigravity",
+		Model:    "m1",
+		Success:  false,
+		Error:    &Error{HTTPStatus: 401, Message: "unauthorized"},
+	})
+	beforeRecovery := store.saveCount.Load()
+
+	mgr.MarkResult(context.Background(), Result{
+		AuthID:   "auth-1",
+		Provider: "antigravity",
+		Model:    "m1",
+		Success:  true,
+	})
+	afterRecovery := store.saveCount.Load()
+
+	if afterRecovery <= beforeRecovery {
+		t.Fatalf("expected Save on recovery transition, got before=%d after=%d", beforeRecovery, afterRecovery)
 	}
 }

--- a/sdk/cliproxy/auth/runtime_metadata.go
+++ b/sdk/cliproxy/auth/runtime_metadata.go
@@ -1,0 +1,170 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+const (
+	// Runtime metadata keys persisted in auth JSON files.
+	MetadataKeyRuntimeStatus      = "runtime_status"
+	MetadataKeyRuntimeStatusMsg   = "runtime_status_message"
+	MetadataKeyRuntimeUnavailable = "runtime_unavailable"
+	MetadataKeyRuntimeQuota       = "runtime_quota"
+	MetadataKeyRuntimeLastError   = "runtime_last_error"
+	MetadataKeyRuntimeNextRetry   = "runtime_next_retry_after"
+	MetadataKeyRuntimeModelStates = "runtime_model_states"
+)
+
+var runtimeMetadataKeys = [...]string{
+	MetadataKeyRuntimeStatus,
+	MetadataKeyRuntimeStatusMsg,
+	MetadataKeyRuntimeUnavailable,
+	MetadataKeyRuntimeQuota,
+	MetadataKeyRuntimeLastError,
+	MetadataKeyRuntimeNextRetry,
+	MetadataKeyRuntimeModelStates,
+}
+
+// CloneMetadata returns a shallow copy of metadata to avoid mutating caller-owned maps.
+func CloneMetadata(src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return map[string]any{}
+	}
+	dst := make(map[string]any, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}
+
+// HasRuntimeStateMetadata reports whether metadata contains any persisted runtime state key.
+func HasRuntimeStateMetadata(metadata map[string]any) bool {
+	if len(metadata) == 0 {
+		return false
+	}
+	for _, key := range runtimeMetadataKeys {
+		if _, ok := metadata[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ApplyRuntimeStateToMetadata stores runtime-only account/model state in namespaced metadata fields.
+func ApplyRuntimeStateToMetadata(metadata map[string]any, auth *Auth) {
+	if metadata == nil || auth == nil {
+		return
+	}
+
+	metadata[MetadataKeyRuntimeStatus] = string(auth.Status)
+	if msg := strings.TrimSpace(auth.StatusMessage); msg != "" {
+		metadata[MetadataKeyRuntimeStatusMsg] = msg
+	} else {
+		delete(metadata, MetadataKeyRuntimeStatusMsg)
+	}
+	metadata[MetadataKeyRuntimeUnavailable] = auth.Unavailable
+
+	if !auth.NextRetryAfter.IsZero() {
+		metadata[MetadataKeyRuntimeNextRetry] = auth.NextRetryAfter.UTC().Format(time.RFC3339Nano)
+	} else {
+		delete(metadata, MetadataKeyRuntimeNextRetry)
+	}
+
+	if !isQuotaStateZero(auth.Quota) {
+		metadata[MetadataKeyRuntimeQuota] = auth.Quota
+	} else {
+		delete(metadata, MetadataKeyRuntimeQuota)
+	}
+
+	if auth.LastError != nil {
+		metadata[MetadataKeyRuntimeLastError] = auth.LastError
+	} else {
+		delete(metadata, MetadataKeyRuntimeLastError)
+	}
+
+	if len(auth.ModelStates) > 0 {
+		metadata[MetadataKeyRuntimeModelStates] = auth.ModelStates
+	} else {
+		delete(metadata, MetadataKeyRuntimeModelStates)
+	}
+}
+
+// RestoreRuntimeStateFromMetadata restores runtime-only state from namespaced metadata fields.
+func RestoreRuntimeStateFromMetadata(auth *Auth, metadata map[string]any) {
+	if auth == nil || metadata == nil {
+		return
+	}
+
+	if persistedStatus := parseStatusAny(metadata[MetadataKeyRuntimeStatus]); persistedStatus != "" && !auth.Disabled {
+		auth.Status = persistedStatus
+	}
+	if msg, ok := metadata[MetadataKeyRuntimeStatusMsg].(string); ok {
+		auth.StatusMessage = strings.TrimSpace(msg)
+	}
+	if unavailable, okUnavailable := parseBoolAny(metadata[MetadataKeyRuntimeUnavailable]); okUnavailable {
+		auth.Unavailable = unavailable
+	}
+	if nextRetry, okNextRetry := parseTimeValue(metadata[MetadataKeyRuntimeNextRetry]); okNextRetry {
+		auth.NextRetryAfter = nextRetry
+	}
+
+	if quotaRaw, okQuota := metadata[MetadataKeyRuntimeQuota]; okQuota {
+		var quota QuotaState
+		if decodeAnyToStruct(quotaRaw, &quota) == nil {
+			auth.Quota = quota
+		}
+	}
+	if errRaw, okLastErr := metadata[MetadataKeyRuntimeLastError]; okLastErr {
+		var lastErr Error
+		if decodeAnyToStruct(errRaw, &lastErr) == nil && (lastErr.Message != "" || lastErr.Code != "" || lastErr.HTTPStatus > 0) {
+			auth.LastError = &lastErr
+		}
+	}
+	if statesRaw, okStates := metadata[MetadataKeyRuntimeModelStates]; okStates {
+		var states map[string]*ModelState
+		if decodeAnyToStruct(statesRaw, &states) == nil && len(states) > 0 {
+			auth.ModelStates = states
+		}
+	}
+
+	if auth.Disabled {
+		auth.Status = StatusDisabled
+	}
+}
+
+func parseStatusAny(raw any) Status {
+	s, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	status := Status(strings.TrimSpace(s))
+	switch status {
+	case StatusUnknown, StatusActive, StatusPending, StatusRefreshing, StatusError, StatusDisabled:
+		return status
+	default:
+		return ""
+	}
+}
+
+func decodeAnyToStruct(raw any, target any) error {
+	if raw == nil || target == nil {
+		return errDecodeAnyNilInput
+	}
+	blob, errMarshal := json.Marshal(raw)
+	if errMarshal != nil {
+		return errMarshal
+	}
+	return json.Unmarshal(blob, target)
+}
+
+var errDecodeAnyNilInput = errors.New("decode any: nil input")
+
+func isQuotaStateZero(state QuotaState) bool {
+	return !state.Exceeded &&
+		strings.TrimSpace(state.Reason) == "" &&
+		state.NextRecoverAt.IsZero() &&
+		state.BackoffLevel == 0
+}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	baseauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 )
 
 // PostAuthHook defines a function that is called after an Auth record is created
@@ -328,61 +327,11 @@ func (a *Auth) RequestRetryOverride() (int, bool) {
 }
 
 func parseBoolAny(val any) (bool, bool) {
-	switch typed := val.(type) {
-	case bool:
-		return typed, true
-	case string:
-		trimmed := strings.TrimSpace(typed)
-		if trimmed == "" {
-			return false, false
-		}
-		parsed, err := strconv.ParseBool(trimmed)
-		if err != nil {
-			return false, false
-		}
-		return parsed, true
-	case float64:
-		return typed != 0, true
-	case json.Number:
-		parsed, err := typed.Int64()
-		if err != nil {
-			return false, false
-		}
-		return parsed != 0, true
-	default:
-		return false, false
-	}
+	return util.ParseBoolAny(val)
 }
 
 func parseIntAny(val any) (int, bool) {
-	switch typed := val.(type) {
-	case int:
-		return typed, true
-	case int32:
-		return int(typed), true
-	case int64:
-		return int(typed), true
-	case float64:
-		return int(typed), true
-	case json.Number:
-		parsed, err := typed.Int64()
-		if err != nil {
-			return 0, false
-		}
-		return int(parsed), true
-	case string:
-		trimmed := strings.TrimSpace(typed)
-		if trimmed == "" {
-			return 0, false
-		}
-		parsed, err := strconv.Atoi(trimmed)
-		if err != nil {
-			return 0, false
-		}
-		return parsed, true
-	default:
-		return 0, false
-	}
+	return util.ParseIntAny(val)
 }
 
 func (a *Auth) AccountInfo() (string, string) {
@@ -520,49 +469,5 @@ func ProviderRefreshLead(provider string, runtime any) *time.Duration {
 }
 
 func parseTimeValue(v any) (time.Time, bool) {
-	switch value := v.(type) {
-	case string:
-		s := strings.TrimSpace(value)
-		if s == "" {
-			return time.Time{}, false
-		}
-		layouts := []string{
-			time.RFC3339,
-			time.RFC3339Nano,
-			"2006-01-02 15:04:05",
-			"2006-01-02 15:04",
-			"2006-01-02T15:04:05Z07:00",
-		}
-		for _, layout := range layouts {
-			if ts, err := time.Parse(layout, s); err == nil {
-				return ts, true
-			}
-		}
-		if unix, err := strconv.ParseInt(s, 10, 64); err == nil {
-			return normaliseUnix(unix), true
-		}
-	case float64:
-		return normaliseUnix(int64(value)), true
-	case int64:
-		return normaliseUnix(value), true
-	case json.Number:
-		if i, err := value.Int64(); err == nil {
-			return normaliseUnix(i), true
-		}
-		if f, err := value.Float64(); err == nil {
-			return normaliseUnix(int64(f)), true
-		}
-	}
-	return time.Time{}, false
-}
-
-func normaliseUnix(raw int64) time.Time {
-	if raw <= 0 {
-		return time.Time{}
-	}
-	// Heuristic: treat values with millisecond precision (>1e12) accordingly.
-	if raw > 1_000_000_000_000 {
-		return time.UnixMilli(raw)
-	}
-	return time.Unix(raw, 0)
+	return util.ParseTimeAny(v)
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -284,13 +284,18 @@ func (s *Service) applyCoreAuthAddOrUpdate(ctx context.Context, auth *coreauth.A
 	// immediately for API calls, rather than waiting for model registration to complete.
 	op := "register"
 	var err error
+	hasRuntimeMetadata := coreauth.HasRuntimeStateMetadata(auth.Metadata)
+	keepRuntimeState := hasRuntimeMetadata && !auth.Disabled && auth.Status != coreauth.StatusDisabled
 	if existing, ok := s.coreManager.GetByID(auth.ID); ok {
 		auth.CreatedAt = existing.CreatedAt
 		if !existing.Disabled && existing.Status != coreauth.StatusDisabled && !auth.Disabled && auth.Status != coreauth.StatusDisabled {
 			auth.LastRefreshedAt = existing.LastRefreshedAt
 			auth.NextRefreshAfter = existing.NextRefreshAfter
+			if !hasRuntimeMetadata {
+				preserveRuntimeStateFromExistingIfMetadataMissing(auth, existing)
+				keepRuntimeState = true
+			}
 		}
-		preserveRuntimeStateFromExistingIfMetadataMissing(auth, existing)
 		op = "update"
 		_, err = s.coreManager.Update(ctx, auth)
 	} else {
@@ -310,7 +315,11 @@ func (s *Service) applyCoreAuthAddOrUpdate(ctx context.Context, auth *coreauth.A
 	// This operation may block on network calls, but the auth configuration
 	// is already effective at this point.
 	s.registerModelsForAuth(auth)
-	s.coreManager.ReconcileRegistryModelStates(ctx, auth.ID)
+	if keepRuntimeState {
+		s.coreManager.PruneUnsupportedModelStates(ctx, auth.ID)
+	} else {
+		s.coreManager.ReconcileRegistryModelStates(ctx, auth.ID)
+	}
 
 	// Refresh the scheduler entry so that the auth's supportedModelSet is rebuilt
 	// from the now-populated global model registry. Without this, newly added auths
@@ -326,11 +335,14 @@ func preserveRuntimeStateFromExistingIfMetadataMissing(incoming, existing *corea
 	if coreauth.HasRuntimeStateMetadata(incoming.Metadata) {
 		return
 	}
-
-	if incoming.Disabled == existing.Disabled {
-		incoming.Status = existing.Status
-		incoming.StatusMessage = existing.StatusMessage
+	if existing.Disabled || existing.Status == coreauth.StatusDisabled || incoming.Disabled || incoming.Status == coreauth.StatusDisabled {
+		if incoming.Disabled || incoming.Status == coreauth.StatusDisabled {
+			incoming.Status = coreauth.StatusDisabled
+		}
+		return
 	}
+	incoming.Status = existing.Status
+	incoming.StatusMessage = existing.StatusMessage
 	incoming.Unavailable = existing.Unavailable
 	incoming.NextRetryAfter = existing.NextRetryAfter
 	incoming.Quota = existing.Quota
@@ -349,10 +361,6 @@ func preserveRuntimeStateFromExistingIfMetadataMissing(incoming, existing *corea
 		}
 	} else {
 		incoming.ModelStates = nil
-	}
-
-	if incoming.Disabled {
-		incoming.Status = coreauth.StatusDisabled
 	}
 }
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -289,10 +289,8 @@ func (s *Service) applyCoreAuthAddOrUpdate(ctx context.Context, auth *coreauth.A
 		if !existing.Disabled && existing.Status != coreauth.StatusDisabled && !auth.Disabled && auth.Status != coreauth.StatusDisabled {
 			auth.LastRefreshedAt = existing.LastRefreshedAt
 			auth.NextRefreshAfter = existing.NextRefreshAfter
-			if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
-				auth.ModelStates = existing.ModelStates
-			}
 		}
+		preserveRuntimeStateFromExistingIfMetadataMissing(auth, existing)
 		op = "update"
 		_, err = s.coreManager.Update(ctx, auth)
 	} else {
@@ -319,6 +317,43 @@ func (s *Service) applyCoreAuthAddOrUpdate(ctx context.Context, auth *coreauth.A
 	// have an empty supportedModelSet (because Register/Update upserts into the
 	// scheduler before registerModelsForAuth runs) and are invisible to the scheduler.
 	s.coreManager.RefreshSchedulerEntry(auth.ID)
+}
+
+func preserveRuntimeStateFromExistingIfMetadataMissing(incoming, existing *coreauth.Auth) {
+	if incoming == nil || existing == nil {
+		return
+	}
+	if coreauth.HasRuntimeStateMetadata(incoming.Metadata) {
+		return
+	}
+
+	if incoming.Disabled == existing.Disabled {
+		incoming.Status = existing.Status
+		incoming.StatusMessage = existing.StatusMessage
+	}
+	incoming.Unavailable = existing.Unavailable
+	incoming.NextRetryAfter = existing.NextRetryAfter
+	incoming.Quota = existing.Quota
+
+	if existing.LastError != nil {
+		copyErr := *existing.LastError
+		incoming.LastError = &copyErr
+	} else {
+		incoming.LastError = nil
+	}
+
+	if len(existing.ModelStates) > 0 {
+		incoming.ModelStates = make(map[string]*coreauth.ModelState, len(existing.ModelStates))
+		for model, state := range existing.ModelStates {
+			incoming.ModelStates[model] = state.Clone()
+		}
+	} else {
+		incoming.ModelStates = nil
+	}
+
+	if incoming.Disabled {
+		incoming.Status = coreauth.StatusDisabled
+	}
 }
 
 func (s *Service) applyCoreAuthRemoval(ctx context.Context, id string) {

--- a/sdk/cliproxy/service_runtime_state_test.go
+++ b/sdk/cliproxy/service_runtime_state_test.go
@@ -1,0 +1,129 @@
+package cliproxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestApplyCoreAuthAddOrUpdate_PreservesRuntimeStateWhenRuntimeMetadataMissing(t *testing.T) {
+	t.Parallel()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{coreManager: manager}
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	existing := &coreauth.Auth{
+		ID:               "a1",
+		Provider:         "claude",
+		Status:           coreauth.StatusError,
+		StatusMessage:    "cooling",
+		Unavailable:      true,
+		LastRefreshedAt:  now.Add(-2 * time.Hour),
+		NextRefreshAfter: now.Add(30 * time.Minute),
+		NextRetryAfter:   now.Add(10 * time.Minute),
+		Quota: coreauth.QuotaState{
+			Exceeded: true,
+			Reason:   "rate_limited",
+		},
+		LastError: &coreauth.Error{
+			Code:       "rate_limit",
+			Message:    "too many requests",
+			HTTPStatus: 429,
+		},
+		ModelStates: map[string]*coreauth.ModelState{
+			"claude-3-7-sonnet": {
+				Status:      coreauth.StatusError,
+				Unavailable: true,
+			},
+		},
+		Metadata: map[string]any{"type": "claude", "email": "u@example.com"},
+	}
+	if _, err := manager.Register(context.Background(), existing); err != nil {
+		t.Fatalf("register existing auth: %v", err)
+	}
+
+	incoming := &coreauth.Auth{
+		ID:       "a1",
+		Provider: "claude",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"type": "claude", "email": "u@example.com"},
+	}
+	service.applyCoreAuthAddOrUpdate(context.Background(), incoming)
+
+	got, ok := manager.GetByID("a1")
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	if got.Status != coreauth.StatusError {
+		t.Fatalf("status = %s, want %s", got.Status, coreauth.StatusError)
+	}
+	if got.StatusMessage != "cooling" {
+		t.Fatalf("status message = %q, want %q", got.StatusMessage, "cooling")
+	}
+	if !got.Unavailable {
+		t.Fatal("unavailable = false, want true")
+	}
+	if got.NextRetryAfter.IsZero() {
+		t.Fatal("next retry cleared, want preserved")
+	}
+	if got.LastError == nil || got.LastError.HTTPStatus != 429 {
+		t.Fatalf("last error = %#v, want HTTPStatus=429", got.LastError)
+	}
+	if len(got.ModelStates) != 1 {
+		t.Fatalf("model states len = %d, want 1", len(got.ModelStates))
+	}
+	if !got.LastRefreshedAt.Equal(existing.LastRefreshedAt) {
+		t.Fatalf("last refreshed = %v, want %v", got.LastRefreshedAt, existing.LastRefreshedAt)
+	}
+	if !got.NextRefreshAfter.Equal(existing.NextRefreshAfter) {
+		t.Fatalf("next refresh after = %v, want %v", got.NextRefreshAfter, existing.NextRefreshAfter)
+	}
+}
+
+func TestApplyCoreAuthAddOrUpdate_RuntimeMetadataTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{coreManager: manager}
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+
+	existing := &coreauth.Auth{
+		ID:            "a2",
+		Provider:      "claude",
+		Status:        coreauth.StatusError,
+		StatusMessage: "old-state",
+		Unavailable:   true,
+		Metadata:      map[string]any{"type": "claude", "email": "u@example.com"},
+	}
+	if _, err := manager.Register(context.Background(), existing); err != nil {
+		t.Fatalf("register existing auth: %v", err)
+	}
+
+	incoming := &coreauth.Auth{
+		ID:       "a2",
+		Provider: "claude",
+		Metadata: map[string]any{
+			"type":                                 "claude",
+			"email":                                "u@example.com",
+			coreauth.MetadataKeyRuntimeStatus:      string(coreauth.StatusActive),
+			coreauth.MetadataKeyRuntimeStatusMsg:   "",
+			coreauth.MetadataKeyRuntimeUnavailable: false,
+			coreauth.MetadataKeyRuntimeNextRetry:   now.Format(time.RFC3339Nano),
+		},
+	}
+	coreauth.RestoreRuntimeStateFromMetadata(incoming, incoming.Metadata)
+	service.applyCoreAuthAddOrUpdate(context.Background(), incoming)
+
+	got, ok := manager.GetByID("a2")
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	if got.Status != coreauth.StatusActive {
+		t.Fatalf("status = %s, want %s", got.Status, coreauth.StatusActive)
+	}
+	if got.Unavailable {
+		t.Fatal("unavailable = true, want false")
+	}
+}

--- a/sdk/cliproxy/service_runtime_state_test.go
+++ b/sdk/cliproxy/service_runtime_state_test.go
@@ -33,7 +33,7 @@ func TestApplyCoreAuthAddOrUpdate_PreservesRuntimeStateWhenRuntimeMetadataMissin
 			HTTPStatus: 429,
 		},
 		ModelStates: map[string]*coreauth.ModelState{
-			"claude-3-7-sonnet": {
+			"claude-3-7-sonnet-20250219": {
 				Status:      coreauth.StatusError,
 				Unavailable: true,
 			},

--- a/sdk/cliproxy/service_stale_state_test.go
+++ b/sdk/cliproxy/service_stale_state_test.go
@@ -17,7 +17,7 @@ func TestServiceApplyCoreAuthAddOrUpdate_DeleteReAddDoesNotInheritStaleRuntimeSt
 	}
 
 	authID := "service-stale-state-auth"
-	modelID := "stale-model"
+	modelID := "claude-3-7-sonnet-20250219"
 	lastRefreshedAt := time.Date(2026, time.March, 1, 8, 0, 0, 0, time.UTC)
 	nextRefreshAfter := lastRefreshedAt.Add(30 * time.Minute)
 


### PR DESCRIPTION
  ## 变更内容

  1. 统一 refresh 不可重试判定逻辑

  - 新增 internal/util/IsNonRetryableRefreshError
  - codex refresh 与 manager refresh 共用同一判定，避免规则分叉

  2. runtime 状态 metadata 命名空间化

  - 将运行态持久化字段改为 runtime_*（如 runtime_status/runtime_model_states）
  - 明确注释用途：用于运行态持久化与重启恢复，避免与业务 metadata 冲突

  3. watcher 增量更新语义修正

  - auth 文件增量变更仅走账号级 refreshAuthState 增量链路
  - 不再触发全局 reloadCallback（配置级全量刷新路径保持不变）

  ## 结果

  - 降低无效 refresh 重试噪音（非可重试错误单次即返回）
  - 避免 auth 增量写入触发全局 clients/configuration 更新
  - 保持重启后冷却/错误状态可恢复

  ## 测试

  - 容器内执行：
    go test ./internal/util ./internal/auth/codex ./sdk/auth ./sdk/cliproxy/auth ./internal/watcher -count=1
  - 全部通过（internal/auth/codex 为 no test files）
