### PR TITLE
fix(kimi): drop orphan empty assistant messages

### DIFF
--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -478,13 +478,30 @@ func isKimiAssistantContentEmpty(content gjson.Result) bool {
 	if !content.Exists() || content.Type == gjson.Null {
 		return true
 	}
-	if content.Type == gjson.String {
-		return strings.TrimSpace(content.String()) == ""
-	}
-	if content.IsArray() {
-		return len(content.Array()) == 0
+	if content.Type == gjson.String || content.IsArray() {
+		return strings.TrimSpace(kimiAssistantContentText(content)) == ""
 	}
 	return false
+}
+
+func kimiAssistantContentText(content gjson.Result) string {
+	if content.Type == gjson.String {
+		return strings.TrimSpace(content.String())
+	}
+	if !content.IsArray() {
+		return ""
+	}
+
+	parts := make([]string, 0, len(content.Array()))
+	for _, item := range content.Array() {
+		text := strings.TrimSpace(item.Get("text").String())
+		if text == "" {
+			continue
+		}
+		parts = append(parts, text)
+	}
+
+	return strings.Join(parts, "\n")
 }
 
 func fallbackAssistantReasoning(msg gjson.Result, hasLatest bool, latest string) string {
@@ -492,24 +509,8 @@ func fallbackAssistantReasoning(msg gjson.Result, hasLatest bool, latest string)
 		return latest
 	}
 
-	content := msg.Get("content")
-	if content.Type == gjson.String {
-		if text := strings.TrimSpace(content.String()); text != "" {
-			return text
-		}
-	}
-	if content.IsArray() {
-		parts := make([]string, 0, len(content.Array()))
-		for _, item := range content.Array() {
-			text := strings.TrimSpace(item.Get("text").String())
-			if text == "" {
-				continue
-			}
-			parts = append(parts, text)
-		}
-		if len(parts) > 0 {
-			return strings.Join(parts, "\n")
-		}
+	if text := kimiAssistantContentText(msg.Get("content")); text != "" {
+		return text
 	}
 
 	return "[reasoning unavailable]"

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -203,3 +203,63 @@ func TestNormalizeKimiToolMessageLinks_RepairsIDsAndReasoningTogether(t *testing
 		t.Fatalf("messages.2.reasoning_content = %q, want %q", got, "r1")
 	}
 }
+
+func TestNormalizeKimiToolMessageLinks_DropsEffectivelyEmptyAssistantMessages(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"user","content":"hello"},
+			{"role":"assistant","content":""},
+			{"role":"assistant","content":[{"type":"text","text":"   "}],"reasoning_content":"   "},
+			{"role":"assistant","tool_calls":null,"content":"   "},
+			{"role":"assistant","content":"kept"}
+		]
+	}`)
+
+	out, err := normalizeKimiToolMessageLinks(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiToolMessageLinks() error = %v", err)
+	}
+
+	msgs := gjson.GetBytes(out, "messages").Array()
+	if len(msgs) != 2 {
+		t.Fatalf("len(messages) = %d, want 2; output=%s", len(msgs), string(out))
+	}
+	if got := msgs[0].Get("role").String(); got != "user" {
+		t.Fatalf("messages[0].role = %q, want %q", got, "user")
+	}
+	if got := msgs[1].Get("content").String(); got != "kept" {
+		t.Fatalf("messages[1].content = %q, want %q", got, "kept")
+	}
+}
+
+func TestNormalizeKimiToolMessageLinks_PreservesAssistantMessagesWithToolMetadata(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"list_directory","arguments":"{}"}}]},
+			{"role":"assistant","content":"   ","function_call":{"name":"legacy_call","arguments":"{}"}},
+			{"role":"assistant","content":[{"type":"text","text":"   "}],"reasoning_content":"keep me"}
+		]
+	}`)
+
+	out, err := normalizeKimiToolMessageLinks(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiToolMessageLinks() error = %v", err)
+	}
+
+	msgs := gjson.GetBytes(out, "messages").Array()
+	if len(msgs) != 3 {
+		t.Fatalf("len(messages) = %d, want 3; output=%s", len(msgs), string(out))
+	}
+	if !msgs[0].Get("tool_calls").Exists() {
+		t.Fatalf("messages[0].tool_calls should exist")
+	}
+	if got := msgs[0].Get("reasoning_content").String(); got != "[reasoning unavailable]" {
+		t.Fatalf("messages[0].reasoning_content = %q, want %q", got, "[reasoning unavailable]")
+	}
+	if !msgs[1].Get("function_call").Exists() {
+		t.Fatalf("messages[1].function_call should exist")
+	}
+	if got := msgs[2].Get("reasoning_content").String(); got != "keep me" {
+		t.Fatalf("messages[2].reasoning_content = %q, want %q", got, "keep me")
+	}
+}


### PR DESCRIPTION
## Summary
- drop assistant messages that are truly orphan/empty before forwarding to Kimi
- preserve assistant turns that carry tool linkage (`tool_calls` or legacy `function_call`) or non-empty `reasoning_content`
- keep existing Kimi tool-call id and reasoning normalization flow intact

## Why
Kimi rejects requests containing empty assistant turns with no tool linkage (`the message at position X with role 'assistant' must not be empty`).

Fixes #1730
