### PR TITLE
fix(executor): Claude tool normalization and Antigravity Claude compatibility fixes

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -324,6 +324,10 @@ nonstream-keepalive-interval: 0
 #     - "kimi-k2-thinking"
 
 # Optional payload configuration
+# Query paths use gjson/sjson syntax and can include dynamic array selectors (#(...)).
+# Nested selectors are supported in override/override-raw/filter, for example:
+#   messages.#(role=="assistant").content.#(type=="tool_use").name
+# Malformed query paths are ignored (no mutation is applied).
 # payload:
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:
@@ -356,3 +360,4 @@ nonstream-keepalive-interval: 0
 #       params: # JSON paths (gjson/sjson syntax) to remove from the payload
 #         - "generationConfig.thinkingConfig.thinkingBudget"
 #         - "generationConfig.responseJsonSchema"
+#         - "messages.#(role==\"assistant\").content.#(type==\"tool_use\")"

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1502,6 +1502,14 @@ func preserveClaudeEffortForAntigravity(sourceFormat sdktranslator.Format, origi
 		return translatedBody
 	}
 
+	if thinkingType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(originalBody, "thinking.type").String())); thinkingType == "disabled" {
+		translatedBody, _ = sjson.DeleteBytes(translatedBody, "request.generationConfig.thinkingConfig.thinkingLevel")
+		translatedBody, _ = sjson.DeleteBytes(translatedBody, "request.generationConfig.thinkingConfig.thinking_level")
+		translatedBody, _ = sjson.SetBytes(translatedBody, "request.generationConfig.thinkingConfig.thinkingBudget", 0)
+		translatedBody, _ = sjson.SetBytes(translatedBody, "request.generationConfig.thinkingConfig.includeThoughts", false)
+		return translatedBody
+	}
+
 	effortValue := gjson.GetBytes(originalBody, "output_config.effort")
 	if !effortValue.Exists() || effortValue.Type != gjson.String {
 		return translatedBody

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -224,6 +224,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	translated = applyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
+	translated = sanitizeAntigravityClaudeCompatFields(translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -366,6 +367,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	translated = applyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
+	translated = sanitizeAntigravityClaudeCompatFields(translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -758,6 +760,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	translated = applyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
+	translated = sanitizeAntigravityClaudeCompatFields(translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -957,6 +960,7 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 		return cliproxyexecutor.Response{}, err
 	}
 
+	payload = sanitizeAntigravityClaudeCompatFields(payload)
 	payload = deleteJSONField(payload, "project")
 	payload = deleteJSONField(payload, "model")
 	payload = deleteJSONField(payload, "request.safetySettings")
@@ -1476,6 +1480,12 @@ func antigravityBaseURLFallbackOrder(auth *cliproxyauth.Auth) []string {
 		antigravitySandboxBaseURLDaily,
 		// antigravityBaseURLProd,
 	}
+}
+
+func sanitizeAntigravityClaudeCompatFields(body []byte) []byte {
+	body = deleteJSONField(body, "output_config")
+	body = deleteJSONField(body, "request.output_config")
+	return body
 }
 
 func resolveCustomAntigravityBaseURL(auth *cliproxyauth.Auth) string {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	antigravitythinking "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/antigravity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -952,20 +953,15 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("antigravity")
 	respCtx := context.WithValue(ctx, "alt", opts.Alt)
-	originalPayload := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayload = opts.OriginalRequest
-	}
 
 	// Prepare payload once (doesn't depend on baseURL)
-	payload := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
-	payload = preserveClaudeEffortForAntigravity(from, originalPayload, payload)
-
-	payload, err := thinking.ApplyThinking(payload, req.Model, from.String(), to.String(), e.Identifier())
+	payload, originalTranslated, err := e.prepareAntigravityRequestPayloads(req, opts, false)
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
 
+	requestedModel := payloadRequestedModel(opts, req.Model)
+	payload = applyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", payload, originalTranslated, requestedModel)
 	payload = applyAntigravityClaudeCompatTransforms(baseModel, payload)
 	payload = deleteJSONField(payload, "project")
 	payload = deleteJSONField(payload, "model")
@@ -1490,7 +1486,13 @@ func antigravityBaseURLFallbackOrder(auth *cliproxyauth.Auth) []string {
 
 func applyAntigravityClaudeCompatTransforms(baseModel string, body []byte) []byte {
 	body = clampAntigravityClaudeMaxOutputTokens(baseModel, body)
-	body = normalizeAntigravityClaudeThinkingBudget(baseModel, body)
+	if strings.Contains(strings.ToLower(strings.TrimSpace(baseModel)), "claude") {
+		if info := registry.LookupModelInfo(baseModel, antigravityAuthType); info != nil {
+			body = antigravitythinking.NormalizeClaudeBudgetPayload(body, info)
+		} else if info := registry.LookupStaticModelInfo(baseModel); info != nil {
+			body = antigravitythinking.NormalizeClaudeBudgetPayload(body, info)
+		}
+	}
 	body = sanitizeAntigravityClaudeCompatFields(body)
 	return body
 }
@@ -1549,51 +1551,6 @@ func clampAntigravityClaudeMaxOutputTokens(baseModel string, body []byte) []byte
 		return body
 	}
 	return clamped
-}
-
-func normalizeAntigravityClaudeThinkingBudget(baseModel string, body []byte) []byte {
-	if !strings.Contains(strings.ToLower(strings.TrimSpace(baseModel)), "claude") {
-		return body
-	}
-
-	info := registry.LookupModelInfo(baseModel, antigravityAuthType)
-	if info == nil {
-		info = registry.LookupStaticModelInfo(baseModel)
-	}
-	if info == nil {
-		return body
-	}
-
-	budgetValue := gjson.GetBytes(body, "request.generationConfig.thinkingConfig.thinkingBudget")
-	budget := budgetValue.Int()
-	if !budgetValue.Exists() || budget < 0 {
-		return body
-	}
-
-	maxValue := gjson.GetBytes(body, "request.generationConfig.maxOutputTokens")
-	maxTokens := maxValue.Int()
-	if !maxValue.Exists() || maxTokens <= 0 {
-		if info.MaxCompletionTokens <= 0 {
-			return body
-		}
-		maxTokens = int64(info.MaxCompletionTokens)
-		body, _ = sjson.SetBytes(body, "request.generationConfig.maxOutputTokens", info.MaxCompletionTokens)
-	}
-
-	if budget >= maxTokens {
-		adjustedBudget := maxTokens - 1
-		minBudget := 0
-		if info.Thinking != nil {
-			minBudget = info.Thinking.Min
-		}
-		if minBudget > 0 && adjustedBudget < int64(minBudget) {
-			body, _ = sjson.DeleteBytes(body, "request.generationConfig.thinkingConfig")
-			return body
-		}
-		body, _ = sjson.SetBytes(body, "request.generationConfig.thinkingConfig.thinkingBudget", adjustedBudget)
-	}
-
-	return body
 }
 
 func resolveCustomAntigravityBaseURL(auth *cliproxyauth.Auth) string {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -224,8 +224,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	translated = applyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
-	translated = clampAntigravityClaudeMaxOutputTokens(baseModel, translated)
-	translated = sanitizeAntigravityClaudeCompatFields(translated)
+	translated = applyAntigravityClaudeCompatTransforms(baseModel, translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -368,8 +367,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	translated = applyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
-	translated = clampAntigravityClaudeMaxOutputTokens(baseModel, translated)
-	translated = sanitizeAntigravityClaudeCompatFields(translated)
+	translated = applyAntigravityClaudeCompatTransforms(baseModel, translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -762,8 +760,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	translated = applyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
-	translated = clampAntigravityClaudeMaxOutputTokens(baseModel, translated)
-	translated = sanitizeAntigravityClaudeCompatFields(translated)
+	translated = applyAntigravityClaudeCompatTransforms(baseModel, translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -963,8 +960,7 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 		return cliproxyexecutor.Response{}, err
 	}
 
-	payload = clampAntigravityClaudeMaxOutputTokens(baseModel, payload)
-	payload = sanitizeAntigravityClaudeCompatFields(payload)
+	payload = applyAntigravityClaudeCompatTransforms(baseModel, payload)
 	payload = deleteJSONField(payload, "project")
 	payload = deleteJSONField(payload, "model")
 	payload = deleteJSONField(payload, "request.safetySettings")
@@ -1486,6 +1482,12 @@ func antigravityBaseURLFallbackOrder(auth *cliproxyauth.Auth) []string {
 	}
 }
 
+func applyAntigravityClaudeCompatTransforms(baseModel string, body []byte) []byte {
+	body = clampAntigravityClaudeMaxOutputTokens(baseModel, body)
+	body = sanitizeAntigravityClaudeCompatFields(body)
+	return body
+}
+
 func sanitizeAntigravityClaudeCompatFields(body []byte) []byte {
 	body = deleteJSONField(body, "output_config")
 	body = deleteJSONField(body, "request.output_config")
@@ -1497,8 +1499,9 @@ func clampAntigravityClaudeMaxOutputTokens(baseModel string, body []byte) []byte
 		return body
 	}
 
-	current := gjson.GetBytes(body, "request.generationConfig.maxOutputTokens")
-	if !current.Exists() || current.Int() <= 0 {
+	currentValue := gjson.GetBytes(body, "request.generationConfig.maxOutputTokens")
+	currentTokens := currentValue.Int()
+	if !currentValue.Exists() || currentTokens <= 0 {
 		return body
 	}
 
@@ -1509,7 +1512,7 @@ func clampAntigravityClaudeMaxOutputTokens(baseModel string, body []byte) []byte
 		maxAllowed = info.MaxCompletionTokens
 	}
 
-	if maxAllowed <= 0 || int(current.Int()) <= maxAllowed {
+	if maxAllowed <= 0 || currentTokens <= int64(maxAllowed) {
 		return body
 	}
 

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -210,15 +210,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("antigravity")
 
-	originalPayloadSource := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayloadSource = opts.OriginalRequest
-	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
-	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
-
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, originalTranslated, err := e.prepareAntigravityRequestPayloads(req, opts, false)
 	if err != nil {
 		return resp, err
 	}
@@ -353,15 +345,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("antigravity")
 
-	originalPayloadSource := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayloadSource = opts.OriginalRequest
-	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
-	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
-
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, originalTranslated, err := e.prepareAntigravityRequestPayloads(req, opts, true)
 	if err != nil {
 		return resp, err
 	}
@@ -723,6 +707,34 @@ func (e *AntigravityExecutor) convertStreamToNonStream(stream []byte) []byte {
 	return []byte(output)
 }
 
+func (e *AntigravityExecutor) prepareAntigravityRequestPayloads(req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) ([]byte, []byte, error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("antigravity")
+
+	originalPayload := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayload = opts.OriginalRequest
+	}
+
+	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, stream)
+	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
+
+	originalTranslated = preserveClaudeEffortForAntigravity(from, originalPayload, originalTranslated)
+	translated = preserveClaudeEffortForAntigravity(from, originalPayload, translated)
+
+	originalTranslated, err := thinking.ApplyThinking(originalTranslated, req.Model, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return nil, nil, err
+	}
+	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return translated, originalTranslated, nil
+}
+
 // ExecuteStream performs a streaming request to the Antigravity API.
 func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	if opts.Alt == "responses/compact" {
@@ -746,15 +758,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("antigravity")
 
-	originalPayloadSource := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayloadSource = opts.OriginalRequest
-	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
-	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
-
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, originalTranslated, err := e.prepareAntigravityRequestPayloads(req, opts, true)
 	if err != nil {
 		return nil, err
 	}
@@ -952,9 +956,14 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("antigravity")
 	respCtx := context.WithValue(ctx, "alt", opts.Alt)
+	originalPayload := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayload = opts.OriginalRequest
+	}
 
 	// Prepare payload once (doesn't depend on baseURL)
 	payload := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+	payload = preserveClaudeEffortForAntigravity(from, originalPayload, payload)
 
 	payload, err := thinking.ApplyThinking(payload, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -1485,8 +1494,26 @@ func antigravityBaseURLFallbackOrder(auth *cliproxyauth.Auth) []string {
 
 func applyAntigravityClaudeCompatTransforms(baseModel string, body []byte) []byte {
 	body = clampAntigravityClaudeMaxOutputTokens(baseModel, body)
+	body = normalizeAntigravityClaudeThinkingBudget(baseModel, body)
 	body = sanitizeAntigravityClaudeCompatFields(body)
 	return body
+}
+
+func preserveClaudeEffortForAntigravity(sourceFormat sdktranslator.Format, originalBody, translatedBody []byte) []byte {
+	if strings.TrimSpace(sourceFormat.String()) != "claude" {
+		return translatedBody
+	}
+
+	effort := strings.ToLower(strings.TrimSpace(gjson.GetBytes(originalBody, "output_config.effort").String()))
+	if effort == "" {
+		return translatedBody
+	}
+
+	// Claude output_config.effort takes precedence over budget_tokens in extractClaudeConfig.
+	// Mirror that precedence after translation so Antigravity requests keep the same semantics.
+	translatedBody, _ = sjson.SetBytes(translatedBody, "request.generationConfig.thinkingConfig.thinkingLevel", effort)
+	translatedBody, _ = sjson.SetBytes(translatedBody, "request.generationConfig.thinkingConfig.includeThoughts", true)
+	return translatedBody
 }
 
 func sanitizeAntigravityClaudeCompatFields(body []byte) []byte {
@@ -1522,6 +1549,51 @@ func clampAntigravityClaudeMaxOutputTokens(baseModel string, body []byte) []byte
 		return body
 	}
 	return clamped
+}
+
+func normalizeAntigravityClaudeThinkingBudget(baseModel string, body []byte) []byte {
+	if !strings.Contains(strings.ToLower(strings.TrimSpace(baseModel)), "claude") {
+		return body
+	}
+
+	info := registry.LookupModelInfo(baseModel, antigravityAuthType)
+	if info == nil {
+		info = registry.LookupStaticModelInfo(baseModel)
+	}
+	if info == nil {
+		return body
+	}
+
+	budgetValue := gjson.GetBytes(body, "request.generationConfig.thinkingConfig.thinkingBudget")
+	budget := budgetValue.Int()
+	if !budgetValue.Exists() || budget < 0 {
+		return body
+	}
+
+	maxValue := gjson.GetBytes(body, "request.generationConfig.maxOutputTokens")
+	maxTokens := maxValue.Int()
+	if !maxValue.Exists() || maxTokens <= 0 {
+		if info.MaxCompletionTokens <= 0 {
+			return body
+		}
+		maxTokens = int64(info.MaxCompletionTokens)
+		body, _ = sjson.SetBytes(body, "request.generationConfig.maxOutputTokens", info.MaxCompletionTokens)
+	}
+
+	if budget >= maxTokens {
+		adjustedBudget := maxTokens - 1
+		minBudget := 0
+		if info.Thinking != nil {
+			minBudget = info.Thinking.Min
+		}
+		if minBudget > 0 && adjustedBudget < int64(minBudget) {
+			body, _ = sjson.DeleteBytes(body, "request.generationConfig.thinkingConfig")
+			return body
+		}
+		body, _ = sjson.SetBytes(body, "request.generationConfig.thinkingConfig.thinkingBudget", adjustedBudget)
+	}
+
+	return body
 }
 
 func resolveCustomAntigravityBaseURL(auth *cliproxyauth.Auth) string {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -720,13 +720,9 @@ func (e *AntigravityExecutor) prepareAntigravityRequestPayloads(req cliproxyexec
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, stream)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
 
-	originalTranslated = preserveClaudeEffortForAntigravity(from, originalPayload, originalTranslated)
 	translated = preserveClaudeEffortForAntigravity(from, originalPayload, translated)
 
-	originalTranslated, err := thinking.ApplyThinking(originalTranslated, req.Model, from.String(), to.String(), e.Identifier())
-	if err != nil {
-		return nil, nil, err
-	}
+	var err error
 	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, nil, err

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1504,7 +1504,11 @@ func preserveClaudeEffortForAntigravity(sourceFormat sdktranslator.Format, origi
 		return translatedBody
 	}
 
-	effort := strings.ToLower(strings.TrimSpace(gjson.GetBytes(originalBody, "output_config.effort").String()))
+	effortValue := gjson.GetBytes(originalBody, "output_config.effort")
+	if !effortValue.Exists() || effortValue.Type != gjson.String {
+		return translatedBody
+	}
+	effort := strings.ToLower(strings.TrimSpace(effortValue.String()))
 	if effort == "" {
 		return translatedBody
 	}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -224,6 +224,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	translated = applyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
+	translated = clampAntigravityClaudeMaxOutputTokens(baseModel, translated)
 	translated = sanitizeAntigravityClaudeCompatFields(translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
@@ -367,6 +368,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	translated = applyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
+	translated = clampAntigravityClaudeMaxOutputTokens(baseModel, translated)
 	translated = sanitizeAntigravityClaudeCompatFields(translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
@@ -760,6 +762,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	translated = applyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
+	translated = clampAntigravityClaudeMaxOutputTokens(baseModel, translated)
 	translated = sanitizeAntigravityClaudeCompatFields(translated)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
@@ -960,6 +963,7 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 		return cliproxyexecutor.Response{}, err
 	}
 
+	payload = clampAntigravityClaudeMaxOutputTokens(baseModel, payload)
 	payload = sanitizeAntigravityClaudeCompatFields(payload)
 	payload = deleteJSONField(payload, "project")
 	payload = deleteJSONField(payload, "model")
@@ -1486,6 +1490,34 @@ func sanitizeAntigravityClaudeCompatFields(body []byte) []byte {
 	body = deleteJSONField(body, "output_config")
 	body = deleteJSONField(body, "request.output_config")
 	return body
+}
+
+func clampAntigravityClaudeMaxOutputTokens(baseModel string, body []byte) []byte {
+	if !strings.Contains(strings.ToLower(strings.TrimSpace(baseModel)), "claude") {
+		return body
+	}
+
+	current := gjson.GetBytes(body, "request.generationConfig.maxOutputTokens")
+	if !current.Exists() || current.Int() <= 0 {
+		return body
+	}
+
+	maxAllowed := 0
+	if info := registry.LookupModelInfo(baseModel, antigravityAuthType); info != nil && info.MaxCompletionTokens > 0 {
+		maxAllowed = info.MaxCompletionTokens
+	} else if info := registry.LookupStaticModelInfo(baseModel); info != nil && info.MaxCompletionTokens > 0 {
+		maxAllowed = info.MaxCompletionTokens
+	}
+
+	if maxAllowed <= 0 || int(current.Int()) <= maxAllowed {
+		return body
+	}
+
+	clamped, err := sjson.SetBytes(body, "request.generationConfig.maxOutputTokens", maxAllowed)
+	if err != nil {
+		return body
+	}
+	return clamped
 }
 
 func resolveCustomAntigravityBaseURL(auth *cliproxyauth.Auth) string {

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -74,6 +74,28 @@ func TestClampAntigravityClaudeMaxOutputTokens_ClampsThinkingModel(t *testing.T)
 	}
 }
 
+func TestApplyAntigravityClaudeCompatTransforms_ClampsAndRemovesOutputConfig(t *testing.T) {
+	input := []byte(`{
+		"output_config":{"effort":"max"},
+		"request":{
+			"output_config":{"effort":"high"},
+			"generationConfig":{"maxOutputTokens":128000}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", input)
+
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("top-level output_config should be removed")
+	}
+	if gjson.GetBytes(out, "request.output_config").Exists() {
+		t.Fatalf("request.output_config should be removed")
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d", got)
+	}
+}
+
 func TestClampAntigravityClaudeMaxOutputTokens_PreservesWithinLimit(t *testing.T) {
 	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":64000}}}`)
 	out := clampAntigravityClaudeMaxOutputTokens("claude-opus-4-6-thinking", input)
@@ -95,6 +117,14 @@ func TestClampAntigravityClaudeMaxOutputTokens_NoopForNonClaude(t *testing.T) {
 	out := clampAntigravityClaudeMaxOutputTokens("gemini-2.5-pro", input)
 	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 128000 {
 		t.Fatalf("expected maxOutputTokens=128000, got %d", got)
+	}
+}
+
+func TestClampAntigravityClaudeMaxOutputTokens_ClampsLargeInt64Value(t *testing.T) {
+	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":9223372036854775807}}}`)
+	out := clampAntigravityClaudeMaxOutputTokens("claude-opus-4-6-thinking", input)
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d", got)
 	}
 }
 

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
 )
 
 func TestAntigravityBuildRequest_SanitizesGeminiToolSchema(t *testing.T) {
@@ -62,6 +63,38 @@ func TestSanitizeAntigravityClaudeCompatFields_RemovesOutputConfig(t *testing.T)
 	}
 	if _, ok := req["generationConfig"]; !ok {
 		t.Fatalf("request.generationConfig should be preserved")
+	}
+}
+
+func TestClampAntigravityClaudeMaxOutputTokens_ClampsThinkingModel(t *testing.T) {
+	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":128000}}}`)
+	out := clampAntigravityClaudeMaxOutputTokens("claude-opus-4-6-thinking", input)
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d", got)
+	}
+}
+
+func TestClampAntigravityClaudeMaxOutputTokens_PreservesWithinLimit(t *testing.T) {
+	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":64000}}}`)
+	out := clampAntigravityClaudeMaxOutputTokens("claude-opus-4-6-thinking", input)
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d", got)
+	}
+}
+
+func TestClampAntigravityClaudeMaxOutputTokens_PreservesNonThinkingModel(t *testing.T) {
+	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":128000}}}`)
+	out := clampAntigravityClaudeMaxOutputTokens("claude-opus-4-6", input)
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 128000 {
+		t.Fatalf("expected maxOutputTokens=128000, got %d", got)
+	}
+}
+
+func TestClampAntigravityClaudeMaxOutputTokens_NoopForNonClaude(t *testing.T) {
+	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":128000}}}`)
+	out := clampAntigravityClaudeMaxOutputTokens("gemini-2.5-pro", input)
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 128000 {
+		t.Fatalf("expected maxOutputTokens=128000, got %d", got)
 	}
 }
 

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -338,6 +338,23 @@ func TestPreserveClaudeEffortForAntigravity_IgnoresNonStringOrBlankEffort(t *tes
 	}
 }
 
+func TestPreserveClaudeEffortForAntigravity_PreservesDisabledThinking(t *testing.T) {
+	original := []byte(`{"thinking":{"type":"disabled"},"output_config":{"effort":"high"}}`)
+	translated := []byte(`{"request":{"generationConfig":{"thinkingConfig":{"thinkingBudget":2048,"thinkingLevel":"medium","includeThoughts":true}}}}`)
+
+	out := preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").Exists() {
+		t.Fatalf("thinkingLevel should be cleared for disabled thinking, body=%s", string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 0 {
+		t.Fatalf("thinkingBudget = %d, want 0, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be false for disabled thinking, body=%s", string(out))
+	}
+}
+
 func TestApplyAntigravityClaudeCompatTransforms_StripsBridgedOutputConfig(t *testing.T) {
 	original := []byte(`{"output_config":{"effort":"max"}}`)
 	translated := []byte(`{"request":{}}`)
@@ -579,6 +596,47 @@ func TestApplyAntigravityClaudeCompatTransforms_ClaudeEffortAutoPreservesAdaptiv
 	}
 	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
 		t.Fatalf("includeThoughts should remain true for adaptive auto thinking, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be removed, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "request.output_config").Exists() {
+		t.Fatalf("request.output_config should be removed, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_DisabledThinkingOverridesClaudeEffort(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"disabled"},
+		"output_config":{"effort":"high"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+	translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").Exists() {
+		t.Fatalf("thinkingLevel should be cleared when disabled thinking wins, body=%s", string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 0 {
+		t.Fatalf("thinkingBudget = %d, want 0, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be false when disabled thinking wins, body=%s", string(out))
 	}
 	if gjson.GetBytes(out, "output_config").Exists() {
 		t.Fatalf("output_config should be removed, body=%s", string(out))

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -6,7 +6,12 @@ import (
 	"io"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	antigravityclaude "github.com/router-for-me/CLIProxyAPI/v6/internal/translator/antigravity/claude"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	"github.com/tidwall/gjson"
 )
 
@@ -96,6 +101,53 @@ func TestApplyAntigravityClaudeCompatTransforms_ClampsAndRemovesOutputConfig(t *
 	}
 }
 
+func TestApplyAntigravityClaudeCompatTransforms_RebalancesThinkingBudgetAfterTokenClamp(t *testing.T) {
+	input := []byte(`{
+		"output_config":{"effort":"max"},
+		"request":{
+			"generationConfig":{
+				"maxOutputTokens":128000,
+				"thinkingConfig":{"thinkingBudget":128000,"includeThoughts":true}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d", got)
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("expected thinkingBudget=63999, got %d, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should stay true, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be stripped, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_RemovesThinkingConfigWhenRebalancedBudgetFallsBelowMinimum(t *testing.T) {
+	input := []byte(`{
+		"request":{
+			"generationConfig":{
+				"maxOutputTokens":1024,
+				"thinkingConfig":{"thinkingBudget":2048,"includeThoughts":true}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 1024 {
+		t.Fatalf("expected maxOutputTokens=1024, got %d", got)
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig").Exists() {
+		t.Fatalf("thinkingConfig should be removed when adjusted budget falls below minimum, body=%s", string(out))
+	}
+}
+
 func TestClampAntigravityClaudeMaxOutputTokens_PreservesWithinLimit(t *testing.T) {
 	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":64000}}}`)
 	out := clampAntigravityClaudeMaxOutputTokens("claude-opus-4-6-thinking", input)
@@ -125,6 +177,286 @@ func TestClampAntigravityClaudeMaxOutputTokens_ClampsLargeInt64Value(t *testing.
 	out := clampAntigravityClaudeMaxOutputTokens("claude-opus-4-6-thinking", input)
 	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
 		t.Fatalf("expected maxOutputTokens=64000, got %d", got)
+	}
+}
+
+func TestPreserveClaudeEffortForAntigravity_AddsThinkingLevel(t *testing.T) {
+	original := []byte(`{"output_config":{"effort":"max"}}`)
+	translated := []byte(`{"request":{}}`)
+
+	out := preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").String(); got != "max" {
+		t.Fatalf("thinkingLevel = %q, want %q, body=%s", got, "max", string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be true, body=%s", string(out))
+	}
+}
+
+func TestPreserveClaudeEffortForAntigravity_AddsThinkingLevelAlongsideExistingBudget(t *testing.T) {
+	original := []byte(`{"output_config":{"effort":"max"}}`)
+	translated := []byte(`{"request":{"generationConfig":{"thinkingConfig":{"thinkingBudget":2048,"includeThoughts":false}}}}`)
+
+	out := preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 2048 {
+		t.Fatalf("thinkingBudget = %d, want 2048, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").String(); got != "max" {
+		t.Fatalf("thinkingLevel = %q, want %q, body=%s", got, "max", string(out))
+	}
+}
+
+func TestPreserveClaudeEffortForAntigravity_NoopForNonClaudeSource(t *testing.T) {
+	original := []byte(`{"output_config":{"effort":"max"}}`)
+	translated := []byte(`{"request":{}}`)
+
+	out := preserveClaudeEffortForAntigravity(sdktranslator.FromString("openai"), original, translated)
+
+	if got := string(out); got != string(translated) {
+		t.Fatalf("unexpected mutation for non-claude source: got=%s want=%s", got, string(translated))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_StripsBridgedOutputConfig(t *testing.T) {
+	original := []byte(`{"output_config":{"effort":"max"}}`)
+	translated := []byte(`{"request":{}}`)
+
+	bridged := preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+	withCompat := append([]byte(`{"output_config":{"effort":"max"},`), bridged[1:]...)
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", withCompat)
+
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be stripped, body=%s", string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").String(); got != "max" {
+		t.Fatalf("thinkingLevel = %q, want %q, body=%s", got, "max", string(out))
+	}
+}
+
+func TestPrepareAntigravityRequestPayloads_PreservesClaudeEffortAgainstDefaults(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Default: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "antigravity"}},
+					Params: map[string]any{
+						"generationConfig.thinkingConfig.includeThoughts": false,
+						"generationConfig.thinkingConfig.thinkingBudget":  1024,
+					},
+				},
+			},
+		},
+	}
+	executor := &AntigravityExecutor{cfg: cfg}
+	req := cliproxyexecutor.Request{
+		Model:   "claude-opus-4-6-thinking",
+		Payload: []byte(`{"output_config":{"effort":"max"}}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FromString("claude"),
+		OriginalRequest: []byte(`{"output_config":{"effort":"max"}}`),
+	}
+
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "non-stream", true: "stream"}[stream], func(t *testing.T) {
+			translated, originalTranslated, err := executor.prepareAntigravityRequestPayloads(req, opts, stream)
+			if err != nil {
+				t.Fatalf("prepareAntigravityRequestPayloads error = %v", err)
+			}
+
+			got := applyPayloadConfigWithRoot(cfg, "claude-opus-4-6-thinking", "antigravity", "request", translated, originalTranslated, "")
+
+			if gotBudget := gjson.GetBytes(got, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); gotBudget != 63999 {
+				t.Fatalf("thinkingBudget = %d, want %d, body=%s", gotBudget, 63999, string(got))
+			}
+			if gotLevel := gjson.GetBytes(got, "request.generationConfig.thinkingConfig.thinkingLevel"); gotLevel.Exists() {
+				t.Fatalf("thinkingLevel should be converted before defaults, body=%s", string(got))
+			}
+			if !gjson.GetBytes(got, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+				t.Fatalf("includeThoughts should remain true from bridged effort, body=%s", string(got))
+			}
+			if gotBudget := gjson.GetBytes(originalTranslated, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); gotBudget != 63999 {
+				t.Fatalf("originalTranslated thinkingBudget = %d, want %d, body=%s", gotBudget, 63999, string(originalTranslated))
+			}
+		})
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_CherryAdaptiveMaxPayload(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"max"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+	translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be true, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be removed, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_ClaudeEffortNoneDisablesThinking(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"none"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+	translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 0 {
+		t.Fatalf("thinkingBudget = %d, want 0, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").Exists() {
+		t.Fatalf("thinkingLevel should be cleared for disabled thinking, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be false for disabled thinking, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be removed, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "request.output_config").Exists() {
+		t.Fatalf("request.output_config should be removed, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_ClaudeEffortAutoPreservesAdaptiveThinking(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"auto"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+	translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != -1 {
+		t.Fatalf("thinkingBudget = %d, want -1, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").Exists() {
+		t.Fatalf("thinkingLevel should be cleared for adaptive auto thinking, body=%s", string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should remain true for adaptive auto thinking, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be removed, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "request.output_config").Exists() {
+		t.Fatalf("request.output_config should be removed, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_ManualBudgetPayload(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"enabled","budget_tokens":64000},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be true, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_ClaudeEffortOverridesEnabledBudget(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"enabled","budget_tokens":64000},
+		"output_config":{"effort":"low"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+	translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 1024 {
+		t.Fatalf("thinkingBudget = %d, want 1024, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should remain true, body=%s", string(out))
 	}
 }
 

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
@@ -145,6 +148,92 @@ func TestApplyAntigravityClaudeCompatTransforms_RemovesThinkingConfigWhenRebalan
 	}
 	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig").Exists() {
 		t.Fatalf("thinkingConfig should be removed when adjusted budget falls below minimum, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_RebalancesThinkingBudgetWithDerivedMaxOutputTokens(t *testing.T) {
+	input := []byte(`{
+		"request":{
+			"generationConfig":{
+				"thinkingConfig":{"thinkingBudget":128000,"includeThoughts":true}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("expected thinkingBudget=63999, got %d, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should stay true, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_PreservesEffortThinkingLevelWithoutSynthesizingBudget(t *testing.T) {
+	input := []byte(`{
+		"output_config":{"effort":"max"},
+		"request":{
+			"generationConfig":{
+				"thinkingConfig":{"thinkingLevel":"max","includeThoughts":true}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").String(); got != "max" {
+		t.Fatalf("thinkingLevel = %q, want %q, body=%s", got, "max", string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget"); got.Exists() {
+		t.Fatalf("thinkingBudget should remain absent for effort-only path, got %s, body=%s", got.Raw, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should remain true, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Exists() {
+		t.Fatalf("maxOutputTokens should remain absent on effort-only path without explicit max, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_PreservesNonClaudeLowBudget(t *testing.T) {
+	input := []byte(`{
+		"request":{
+			"generationConfig":{
+				"thinkingConfig":{"thinkingBudget":100}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("gemini-3-flash", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 100 {
+		t.Fatalf("thinkingBudget = %d, want 100, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Exists() {
+		t.Fatalf("maxOutputTokens should remain absent for non-Claude compat path, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_PreservesNonClaudeOversizedBudget(t *testing.T) {
+	input := []byte(`{
+		"request":{
+			"generationConfig":{
+				"thinkingConfig":{"thinkingBudget":70000}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("gemini-3-flash", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 70000 {
+		t.Fatalf("thinkingBudget = %d, want 70000, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Exists() {
+		t.Fatalf("maxOutputTokens should remain absent for non-Claude compat path, body=%s", string(out))
 	}
 }
 
@@ -314,6 +403,74 @@ func TestPrepareAntigravityRequestPayloads_LeavesDefaultSourceUnmodifiedByThinki
 	}
 }
 
+func TestAntigravityCountTokens_UsesSharedClaudeCompatPreparation(t *testing.T) {
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		capturedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body error: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"totalTokens":321}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "antigravity"}},
+					Params: map[string]any{
+						"debug.label": "count-tokens",
+					},
+				},
+			},
+		},
+	}
+	executor := &AntigravityExecutor{cfg: cfg}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"base_url": server.URL,
+		},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"expired":      time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	payload := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"max"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}]
+	}`)
+
+	_, err := executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-opus-4-6-thinking",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FromString("claude"),
+		OriginalRequest: payload,
+	})
+	if err != nil {
+		t.Fatalf("CountTokens error = %v", err)
+	}
+
+	if got := gjson.GetBytes(capturedBody, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(capturedBody))
+	}
+	if got := gjson.GetBytes(capturedBody, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(capturedBody))
+	}
+	if gjson.GetBytes(capturedBody, "output_config").Exists() {
+		t.Fatalf("output_config should be stripped, body=%s", string(capturedBody))
+	}
+	if got := gjson.GetBytes(capturedBody, "request.debug.label").String(); got != "count-tokens" {
+		t.Fatalf("request.debug.label = %q, want %q, body=%s", got, "count-tokens", string(capturedBody))
+	}
+}
+
 func TestApplyAntigravityClaudeCompatTransforms_CherryAdaptiveMaxPayload(t *testing.T) {
 	original := []byte(`{
 		"model":"claude-opus-4-6-thinking",
@@ -435,6 +592,35 @@ func TestApplyAntigravityClaudeCompatTransforms_ManualBudgetPayload(t *testing.T
 	original := []byte(`{
 		"model":"claude-opus-4-6-thinking",
 		"max_tokens":128000,
+		"thinking":{"type":"enabled","budget_tokens":64000},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be true, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_ManualBudgetPayloadWithoutMaxTokens(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
 		"thinking":{"type":"enabled","budget_tokens":64000},
 		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
 		"stream":true

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -219,6 +219,36 @@ func TestPreserveClaudeEffortForAntigravity_NoopForNonClaudeSource(t *testing.T)
 	}
 }
 
+func TestPreserveClaudeEffortForAntigravity_IgnoresNonStringOrBlankEffort(t *testing.T) {
+	tests := []struct {
+		name     string
+		original string
+	}{
+		{name: "null", original: `{"output_config":{"effort":null}}`},
+		{name: "number", original: `{"output_config":{"effort":123}}`},
+		{name: "bool", original: `{"output_config":{"effort":false}}`},
+		{name: "blank", original: `{"output_config":{"effort":"   "}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			translated := []byte(`{"request":{"generationConfig":{"thinkingConfig":{"thinkingBudget":2048,"includeThoughts":false}}}}`)
+
+			out := preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), []byte(tt.original), translated)
+
+			if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel"); got.Exists() {
+				t.Fatalf("thinkingLevel should not be set for %s effort, body=%s", tt.name, string(out))
+			}
+			if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 2048 {
+				t.Fatalf("thinkingBudget = %d, want 2048, body=%s", got, string(out))
+			}
+			if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+				t.Fatalf("includeThoughts should remain unchanged for %s effort, body=%s", tt.name, string(out))
+			}
+		})
+	}
+}
+
 func TestApplyAntigravityClaudeCompatTransforms_StripsBridgedOutputConfig(t *testing.T) {
 	original := []byte(`{"output_config":{"effort":"max"}}`)
 	translated := []byte(`{"request":{}}`)
@@ -457,6 +487,51 @@ func TestApplyAntigravityClaudeCompatTransforms_ClaudeEffortOverridesEnabledBudg
 	}
 	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
 		t.Fatalf("includeThoughts should remain true, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_NonStringEffortFallsBackToBudget(t *testing.T) {
+	tests := []struct {
+		name   string
+		effort string
+	}{
+		{name: "null", effort: "null"},
+		{name: "number", effort: "123"},
+		{name: "bool", effort: "false"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := []byte(`{
+				"model":"claude-opus-4-6-thinking",
+				"max_tokens":128000,
+				"thinking":{"type":"enabled","budget_tokens":64000},
+				"output_config":{"effort":` + tt.effort + `},
+				"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+				"stream":true
+			}`)
+
+			baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+			translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+			translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+			out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+			if err != nil {
+				t.Fatalf("ApplyThinking error = %v", err)
+			}
+
+			out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+			if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+				t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+			}
+			if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").Exists() {
+				t.Fatalf("thinkingLevel should be omitted when non-string effort falls back to budget, body=%s", string(out))
+			}
+			if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+				t.Fatalf("includeThoughts should remain true for budget fallback, body=%s", string(out))
+			}
+		})
 	}
 }
 

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -265,7 +265,7 @@ func TestApplyAntigravityClaudeCompatTransforms_StripsBridgedOutputConfig(t *tes
 	}
 }
 
-func TestPrepareAntigravityRequestPayloads_PreservesClaudeEffortAgainstDefaults(t *testing.T) {
+func TestPrepareAntigravityRequestPayloads_LeavesDefaultSourceUnmodifiedByThinkingTransforms(t *testing.T) {
 	cfg := &config.Config{
 		Payload: config.PayloadConfig{
 			Default: []config.PayloadRule{
@@ -298,17 +298,17 @@ func TestPrepareAntigravityRequestPayloads_PreservesClaudeEffortAgainstDefaults(
 
 			got := applyPayloadConfigWithRoot(cfg, "claude-opus-4-6-thinking", "antigravity", "request", translated, originalTranslated, "")
 
-			if gotBudget := gjson.GetBytes(got, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); gotBudget != 63999 {
-				t.Fatalf("thinkingBudget = %d, want %d, body=%s", gotBudget, 63999, string(got))
+			if gjson.GetBytes(originalTranslated, "request.generationConfig.thinkingConfig").Exists() {
+				t.Fatalf("originalTranslated should remain the raw translated source for defaults, body=%s", string(originalTranslated))
+			}
+			if gotBudget := gjson.GetBytes(got, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); gotBudget != 1024 {
+				t.Fatalf("thinkingBudget = %d, want %d, body=%s", gotBudget, 1024, string(got))
 			}
 			if gotLevel := gjson.GetBytes(got, "request.generationConfig.thinkingConfig.thinkingLevel"); gotLevel.Exists() {
-				t.Fatalf("thinkingLevel should be converted before defaults, body=%s", string(got))
+				t.Fatalf("thinkingLevel should not suppress defaults when the client omitted target fields, body=%s", string(got))
 			}
-			if !gjson.GetBytes(got, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
-				t.Fatalf("includeThoughts should remain true from bridged effort, body=%s", string(got))
-			}
-			if gotBudget := gjson.GetBytes(originalTranslated, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); gotBudget != 63999 {
-				t.Fatalf("originalTranslated thinkingBudget = %d, want %d, body=%s", gotBudget, 63999, string(originalTranslated))
+			if gjson.GetBytes(got, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+				t.Fatalf("includeThoughts default should apply when the client omitted it, body=%s", string(got))
 			}
 		})
 	}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -157,7 +157,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	bodyForUpstream := preparedBody.bodyForUpstream
 	extraBetas := preparedBody.extraBetas
 	originalToolNames := preparedBody.originalToolNames
-	originalRequestForTranslation := claudeOriginalRequestForTranslation(opts.OriginalRequest, bodyForTranslation)
+	originalRequestForTranslation := claudeOriginalRequestForTranslation(opts.OriginalRequest, req.Payload)
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
@@ -286,7 +286,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	bodyForUpstream := preparedBody.bodyForUpstream
 	extraBetas := preparedBody.extraBetas
 	originalToolNames := preparedBody.originalToolNames
-	originalRequestForTranslation := claudeOriginalRequestForTranslation(opts.OriginalRequest, bodyForTranslation)
+	originalRequestForTranslation := claudeOriginalRequestForTranslation(opts.OriginalRequest, req.Payload)
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
@@ -593,11 +593,11 @@ func restoreClaudeToolNamesInErrorBody(body []byte, prefix string, originalByNor
 	return body
 }
 
-func claudeOriginalRequestForTranslation(originalRequest, effectiveRequest []byte) []byte {
+func claudeOriginalRequestForTranslation(originalRequest, payload []byte) []byte {
 	if len(originalRequest) > 0 {
 		return originalRequest
 	}
-	return effectiveRequest
+	return payload
 }
 
 func restoreClaudeToolNamesInErrorText(text, prefix string, originalByNormalized map[string]string) string {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1300,19 +1300,13 @@ func reserveToolNameVariants(used map[string]struct{}, name string) {
 	}
 }
 
-func renameToolNameField(target map[string]any, field string, renameMap map[string]string) {
-	raw, ok := target[field]
-	if !ok {
-		return
-	}
-	name, ok := raw.(string)
-	if !ok {
-		return
-	}
+func renamedToolName(name string, renameMap map[string]string) (string, bool) {
 	name = strings.TrimSpace(name)
-	if mapped, ok := renameMap[name]; ok {
-		target[field] = mapped
+	if name == "" {
+		return "", false
 	}
+	mapped, ok := renameMap[name]
+	return mapped, ok
 }
 
 func applyClaudeRenameMap(body []byte, renameMap map[string]string) ([]byte, error) {
@@ -1320,89 +1314,69 @@ func applyClaudeRenameMap(body []byte, renameMap map[string]string) ([]byte, err
 		return body, nil
 	}
 
-	var payload map[string]any
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return body, fmt.Errorf("decode payload for tool rename map: %w", err)
-	}
-
-	if toolChoiceRaw, ok := payload["tool_choice"]; ok {
-		if toolChoice, ok := toolChoiceRaw.(map[string]any); ok {
-			if kind, ok := toolChoice["type"].(string); ok && kind == "tool" {
-				renameToolNameField(toolChoice, "name", renameMap)
+	if gjson.GetBytes(body, "tool_choice.type").String() == "tool" {
+		if mapped, ok := renamedToolName(gjson.GetBytes(body, "tool_choice.name").String(), renameMap); ok {
+			updatedBody, err := sjson.SetBytes(body, "tool_choice.name", mapped)
+			if err != nil {
+				return body, fmt.Errorf("set tool_choice.name: %w", err)
 			}
+			body = updatedBody
 		}
 	}
 
-	messageListRaw, ok := payload["messages"]
-	if !ok {
-		updatedBody, errMarshal := json.Marshal(payload)
-		if errMarshal != nil {
-			return body, fmt.Errorf("encode payload after tool rename map: %w", errMarshal)
-		}
-		return updatedBody, nil
-	}
-	messageList, ok := messageListRaw.([]any)
-	if !ok {
-		updatedBody, errMarshal := json.Marshal(payload)
-		if errMarshal != nil {
-			return body, fmt.Errorf("encode payload after tool rename map: %w", errMarshal)
-		}
-		return updatedBody, nil
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body, nil
 	}
 
-	for _, msgRaw := range messageList {
-		msg, ok := msgRaw.(map[string]any)
-		if !ok {
+	for msgIndex, msg := range messages.Array() {
+		content := msg.Get("content")
+		if !content.Exists() || !content.IsArray() {
 			continue
 		}
-		contentRaw, ok := msg["content"]
-		if !ok {
-			continue
-		}
-		content, ok := contentRaw.([]any)
-		if !ok {
-			continue
-		}
-		for _, partRaw := range content {
-			part, ok := partRaw.(map[string]any)
-			if !ok {
-				continue
-			}
-			partType, _ := part["type"].(string)
-			switch partType {
+		for contentIndex, part := range content.Array() {
+			switch part.Get("type").String() {
 			case "tool_use":
-				renameToolNameField(part, "name", renameMap)
+				if mapped, ok := renamedToolName(part.Get("name").String(), renameMap); ok {
+					path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex, contentIndex)
+					updatedBody, err := sjson.SetBytes(body, path, mapped)
+					if err != nil {
+						return body, fmt.Errorf("set %s: %w", path, err)
+					}
+					body = updatedBody
+				}
 			case "tool_reference":
-				renameToolNameField(part, "tool_name", renameMap)
+				if mapped, ok := renamedToolName(part.Get("tool_name").String(), renameMap); ok {
+					path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex, contentIndex)
+					updatedBody, err := sjson.SetBytes(body, path, mapped)
+					if err != nil {
+						return body, fmt.Errorf("set %s: %w", path, err)
+					}
+					body = updatedBody
+				}
 			case "tool_result":
-				nestedContentRaw, ok := part["content"]
-				if !ok {
+				nestedContent := part.Get("content")
+				if !nestedContent.Exists() || !nestedContent.IsArray() {
 					continue
 				}
-				nestedContent, ok := nestedContentRaw.([]any)
-				if !ok {
-					continue
-				}
-				for _, nestedPartRaw := range nestedContent {
-					nestedPart, ok := nestedPartRaw.(map[string]any)
-					if !ok {
+				for nestedIndex, nestedPart := range nestedContent.Array() {
+					if nestedPart.Get("type").String() != "tool_reference" {
 						continue
 					}
-					nestedType, _ := nestedPart["type"].(string)
-					if nestedType != "tool_reference" {
-						continue
+					if mapped, ok := renamedToolName(nestedPart.Get("tool_name").String(), renameMap); ok {
+						path := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex, contentIndex, nestedIndex)
+						updatedBody, err := sjson.SetBytes(body, path, mapped)
+						if err != nil {
+							return body, fmt.Errorf("set %s: %w", path, err)
+						}
+						body = updatedBody
 					}
-					renameToolNameField(nestedPart, "tool_name", renameMap)
 				}
 			}
 		}
 	}
 
-	updatedBody, errMarshal := json.Marshal(payload)
-	if errMarshal != nil {
-		return body, fmt.Errorf("encode payload after tool rename map: %w", errMarshal)
-	}
-	return updatedBody, nil
+	return body, nil
 }
 func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 	if prefix == "" {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/textproto"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -189,7 +190,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 	recordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
-		return resp, e.buildUpstreamStatusErr(ctx, httpResp.StatusCode, httpResp.Header, httpResp.Body)
+		return resp, e.buildUpstreamStatusErr(ctx, httpResp.StatusCode, httpResp.Header, httpResp.Body, apiKey, auth, originalToolNames)
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
 	if err != nil {
@@ -317,7 +318,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	}
 	recordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
-		return nil, e.buildUpstreamStatusErr(ctx, httpResp.StatusCode, httpResp.Header, httpResp.Body)
+		return nil, e.buildUpstreamStatusErr(ctx, httpResp.StatusCode, httpResp.Header, httpResp.Body, apiKey, auth, originalToolNames)
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
 	if err != nil {
@@ -428,6 +429,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	}
 	body = preparedBody.bodyForUpstream
 	extraBetas := preparedBody.extraBetas
+	originalToolNames := preparedBody.originalToolNames
 
 	url := fmt.Sprintf("%s/v1/messages/count_tokens?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
@@ -461,7 +463,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	}
 	recordAPIResponseMetadata(ctx, e.cfg, resp.StatusCode, resp.Header.Clone())
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return cliproxyexecutor.Response{}, e.buildUpstreamStatusErr(ctx, resp.StatusCode, resp.Header, resp.Body)
+		return cliproxyexecutor.Response{}, e.buildUpstreamStatusErr(ctx, resp.StatusCode, resp.Header, resp.Body, apiKey, auth, originalToolNames)
 	}
 	decodedBody, err := decodeResponseBody(resp.Body, resp.Header.Get("Content-Encoding"))
 	if err != nil {
@@ -529,7 +531,7 @@ func (e *ClaudeExecutor) finalizeClaudeRequestBody(body []byte, reqModel string,
 	return prepared, nil
 }
 
-func (e *ClaudeExecutor) buildUpstreamStatusErr(ctx context.Context, statusCode int, headers http.Header, body io.ReadCloser) error {
+func (e *ClaudeExecutor) buildUpstreamStatusErr(ctx context.Context, statusCode int, headers http.Header, body io.ReadCloser, apiKey string, auth *cliproxyauth.Auth, originalToolNames map[string]string) error {
 	decodedErrBody, errDecode := decodeResponseBody(body, headers.Get("Content-Encoding"))
 	if errDecode != nil {
 		recordAPIResponseError(ctx, e.cfg, errDecode)
@@ -549,6 +551,7 @@ func (e *ClaudeExecutor) buildUpstreamStatusErr(ctx context.Context, statusCode 
 		b = []byte(msg)
 	}
 
+	b = normalizeClaudeResponseToolNames(b, apiKey, auth, originalToolNames)
 	appendAPIResponseChunk(ctx, e.cfg, b)
 	logWithRequestID(ctx).Debugf(
 		"request error, error status: %d, error message: %s",
@@ -556,6 +559,66 @@ func (e *ClaudeExecutor) buildUpstreamStatusErr(ctx context.Context, statusCode 
 		summarizeErrorBody(headers.Get("Content-Type"), b),
 	)
 	return statusErr{code: statusCode, msg: string(b)}
+}
+
+func normalizeClaudeResponseToolNames(body []byte, apiKey string, auth *cliproxyauth.Auth, originalToolNames map[string]string) []byte {
+	if isClaudeOAuthToken(apiKey) && auth != nil && !auth.ToolPrefixDisabled() {
+		body = stripClaudeToolPrefixFromResponse(body, claudeToolPrefix)
+	}
+	body = restoreClaudeNormalizedToolNamesInResponse(body, originalToolNames)
+	return restoreClaudeToolNamesInErrorBody(body, claudeToolPrefix, originalToolNames)
+}
+
+func restoreClaudeToolNamesInErrorBody(body []byte, prefix string, originalByNormalized map[string]string) []byte {
+	if len(originalByNormalized) == 0 {
+		return body
+	}
+	if !gjson.ValidBytes(body) {
+		return []byte(restoreClaudeToolNamesInErrorText(string(body), prefix, originalByNormalized))
+	}
+	for _, path := range []string{"error.message", "message"} {
+		value := gjson.GetBytes(body, path)
+		if !value.Exists() || value.Type != gjson.String {
+			continue
+		}
+		updated := restoreClaudeToolNamesInErrorText(value.String(), prefix, originalByNormalized)
+		if updated == value.String() {
+			continue
+		}
+		body, _ = sjson.SetBytes(body, path, updated)
+	}
+	return body
+}
+
+func restoreClaudeToolNamesInErrorText(text, prefix string, originalByNormalized map[string]string) string {
+	if text == "" || len(originalByNormalized) == 0 {
+		return text
+	}
+	type replacement struct {
+		from string
+		to   string
+	}
+	replacements := make([]replacement, 0, len(originalByNormalized)*2)
+	for normalized, original := range originalByNormalized {
+		if normalized == "" || original == "" {
+			continue
+		}
+		if prefix != "" {
+			replacements = append(replacements, replacement{from: prefix + normalized, to: original})
+		}
+		replacements = append(replacements, replacement{from: normalized, to: original})
+	}
+	sort.SliceStable(replacements, func(i, j int) bool {
+		return len(replacements[i].from) > len(replacements[j].from)
+	})
+	replacerArgs := make([]string, 0, len(replacements)*2)
+	for _, replacement := range replacements {
+		replacerArgs = append(replacerArgs, replacement.from, replacement.to)
+	}
+	if len(replacerArgs) == 0 {
+		return text
+	}
+	return strings.NewReplacer(replacerArgs...).Replace(text)
 }
 
 func isStatusCodeErr(err error) bool {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -561,9 +561,6 @@ func (e *ClaudeExecutor) finalizeClaudeRequestBody(body []byte, reqModel string,
 	}
 	normalizedBody, errNormalize := normalizeClaudeToolsForAnthropic(body)
 	if errNormalize != nil {
-		if isStatusCodeErr(errNormalize) {
-			return claudePreparedBody{}, errNormalize
-		}
 		return claudePreparedBody{}, fmt.Errorf("normalize claude tools: %w", errNormalize)
 	}
 	body = normalizedBody

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -157,6 +157,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	bodyForUpstream := preparedBody.bodyForUpstream
 	extraBetas := preparedBody.extraBetas
 	originalToolNames := preparedBody.originalToolNames
+	originalRequestForTranslation := claudeOriginalRequestForTranslation(opts.OriginalRequest, req.Payload)
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
@@ -231,7 +232,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		to,
 		from,
 		req.Model,
-		opts.OriginalRequest,
+		originalRequestForTranslation,
 		bodyForTranslation,
 		data,
 		&param,
@@ -285,6 +286,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	bodyForUpstream := preparedBody.bodyForUpstream
 	extraBetas := preparedBody.extraBetas
 	originalToolNames := preparedBody.originalToolNames
+	originalRequestForTranslation := claudeOriginalRequestForTranslation(opts.OriginalRequest, req.Payload)
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
@@ -384,7 +386,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				to,
 				from,
 				req.Model,
-				opts.OriginalRequest,
+				originalRequestForTranslation,
 				bodyForTranslation,
 				bytes.Clone(line),
 				&param,
@@ -500,14 +502,6 @@ func (e *ClaudeExecutor) finalizeClaudeRequestBody(body []byte, reqModel string,
 	if opts.checkSystemInstructions && !strings.HasPrefix(baseModel, "claude-3-5-haiku") {
 		body = checkSystemInstructions(body)
 	}
-	normalizedBody, originalToolNames, errNormalize := normalizeClaudeToolsForAnthropicWithRestoreMap(body)
-	if errNormalize != nil {
-		if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) || errors.Is(errNormalize, errAnthropicDuplicateToolName) {
-			return claudePreparedBody{}, statusErr{code: http.StatusBadRequest, msg: errNormalize.Error()}
-		}
-		return claudePreparedBody{}, fmt.Errorf("normalize claude tools: %w", errNormalize)
-	}
-	body = normalizedBody
 	if opts.disableForcedToolChoice {
 		body = disableThinkingIfToolChoiceForced(body)
 	}
@@ -520,16 +514,22 @@ func (e *ClaudeExecutor) finalizeClaudeRequestBody(body []byte, reqModel string,
 	if opts.normalizeCacheControlTTL {
 		body = normalizeCacheControlTTL(body)
 	}
-	extraBetas, body := extractAndRemoveBetas(body)
-	translationBody := restoreClaudeNormalizedToolNamesInRequest(body, originalToolNames)
+	extraBetas, translationBody := extractAndRemoveBetas(body)
+	upstreamBody, originalToolNames, errNormalize := normalizeClaudeToolsForAnthropicWithRestoreMap(bytes.Clone(translationBody))
+	if errNormalize != nil {
+		if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) || errors.Is(errNormalize, errAnthropicDuplicateToolName) {
+			return claudePreparedBody{}, statusErr{code: http.StatusBadRequest, msg: errNormalize.Error()}
+		}
+		return claudePreparedBody{}, fmt.Errorf("normalize claude tools: %w", errNormalize)
+	}
 	prepared := claudePreparedBody{
 		bodyForTranslation: translationBody,
-		bodyForUpstream:    body,
+		bodyForUpstream:    upstreamBody,
 		extraBetas:         extraBetas,
 		originalToolNames:  originalToolNames,
 	}
 	if opts.applyToolPrefixForOAuth && isClaudeOAuthToken(apiKey) && auth != nil && !auth.ToolPrefixDisabled() {
-		prepared.bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
+		prepared.bodyForUpstream = applyClaudeToolPrefix(upstreamBody, claudeToolPrefix)
 	}
 	return prepared, nil
 }
@@ -577,7 +577,7 @@ func restoreClaudeToolNamesInErrorBody(body []byte, prefix string, originalByNor
 		return body
 	}
 	if !gjson.ValidBytes(body) {
-		return []byte(restoreClaudeToolNamesInErrorText(string(body), prefix, originalByNormalized))
+		return body
 	}
 	for _, path := range []string{"error.message", "message"} {
 		value := gjson.GetBytes(body, path)
@@ -591,6 +591,13 @@ func restoreClaudeToolNamesInErrorBody(body []byte, prefix string, originalByNor
 		body, _ = sjson.SetBytes(body, path, updated)
 	}
 	return body
+}
+
+func claudeOriginalRequestForTranslation(originalRequest, payload []byte) []byte {
+	if len(originalRequest) > 0 {
+		return originalRequest
+	}
+	return payload
 }
 
 func restoreClaudeToolNamesInErrorText(text, prefix string, originalByNormalized map[string]string) string {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1156,6 +1156,15 @@ func normalizeClaudeToolsForAnthropicWithRestoreMap(body []byte) ([]byte, map[st
 	}
 
 	for _, tool := range tools.Array() {
+		// Tools with no name and no recognized type cannot be normalized for Claude.
+		// This occurs when translated OpenAI-hosted tool types (code_interpreter,
+		// container_exec, etc.) lose their type field during translation.
+		// The first-pass counting loop (above) already skips these; match that here.
+		if anthroToolOriginalName(tool) == "" && !isClaudeBuiltinTool(tool) && !isClaudeExplicitNonCustomTypedTool(tool) {
+			log.Warnf("claude tool normalization: skipping tool with no name or recognized type: %s", tool.Raw)
+			continue
+		}
+
 		if isClaudeBuiltinTool(tool) {
 			normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
 			reserveToolNameVariants(usedNames, strings.TrimSpace(tool.Get("name").String()))
@@ -1182,6 +1191,11 @@ func normalizeClaudeToolsForAnthropicWithRestoreMap(body []byte) ([]byte, map[st
 		if originalName != "" && originalName != newName {
 			renameMap[originalName] = newName
 		}
+	}
+
+	skippedCount := len(tools.Array()) - len(normalizedTools)
+	if skippedCount > 0 {
+		log.Warnf("claude tool normalization: %d of %d tools skipped (no name or recognized type)", skippedCount, len(tools.Array()))
 	}
 
 	normalizedToolsJSON, errMarshal := json.Marshal(normalizedTools)

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -187,30 +187,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 	recordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
-		// Decompress error responses — pass the Content-Encoding value (may be empty)
-		// and let decodeResponseBody handle both header-declared and magic-byte-detected
-		// compression.  This keeps error-path behaviour consistent with the success path.
-		errBody, decErr := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
-		if decErr != nil {
-			recordAPIResponseError(ctx, e.cfg, decErr)
-			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
-			logWithRequestID(ctx).Warn(msg)
-			return resp, statusErr{code: httpResp.StatusCode, msg: msg}
-		}
-		b, readErr := io.ReadAll(errBody)
-		if readErr != nil {
-			recordAPIResponseError(ctx, e.cfg, readErr)
-			msg := fmt.Sprintf("failed to read error response body: %v", readErr)
-			logWithRequestID(ctx).Warn(msg)
-			b = []byte(msg)
-		}
-		appendAPIResponseChunk(ctx, e.cfg, b)
-		logWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
-		if errClose := errBody.Close(); errClose != nil {
-			log.Errorf("response body close error: %v", errClose)
-		}
-		return resp, err
+		return resp, e.buildUpstreamStatusErr(ctx, httpResp.StatusCode, httpResp.Header, httpResp.Body)
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
 	if err != nil {
@@ -336,30 +313,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	}
 	recordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
-		// Decompress error responses — pass the Content-Encoding value (may be empty)
-		// and let decodeResponseBody handle both header-declared and magic-byte-detected
-		// compression.  This keeps error-path behaviour consistent with the success path.
-		errBody, decErr := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
-		if decErr != nil {
-			recordAPIResponseError(ctx, e.cfg, decErr)
-			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
-			logWithRequestID(ctx).Warn(msg)
-			return nil, statusErr{code: httpResp.StatusCode, msg: msg}
-		}
-		b, readErr := io.ReadAll(errBody)
-		if readErr != nil {
-			recordAPIResponseError(ctx, e.cfg, readErr)
-			msg := fmt.Sprintf("failed to read error response body: %v", readErr)
-			logWithRequestID(ctx).Warn(msg)
-			b = []byte(msg)
-		}
-		appendAPIResponseChunk(ctx, e.cfg, b)
-		logWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, summarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		if errClose := errBody.Close(); errClose != nil {
-			log.Errorf("response body close error: %v", errClose)
-		}
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
-		return nil, err
+		return nil, e.buildUpstreamStatusErr(ctx, httpResp.StatusCode, httpResp.Header, httpResp.Body)
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
 	if err != nil {
@@ -501,28 +455,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	}
 	recordAPIResponseMetadata(ctx, e.cfg, resp.StatusCode, resp.Header.Clone())
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		// Decompress error responses — pass the Content-Encoding value (may be empty)
-		// and let decodeResponseBody handle both header-declared and magic-byte-detected
-		// compression.  This keeps error-path behaviour consistent with the success path.
-		errBody, decErr := decodeResponseBody(resp.Body, resp.Header.Get("Content-Encoding"))
-		if decErr != nil {
-			recordAPIResponseError(ctx, e.cfg, decErr)
-			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
-			logWithRequestID(ctx).Warn(msg)
-			return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: msg}
-		}
-		b, readErr := io.ReadAll(errBody)
-		if readErr != nil {
-			recordAPIResponseError(ctx, e.cfg, readErr)
-			msg := fmt.Sprintf("failed to read error response body: %v", readErr)
-			logWithRequestID(ctx).Warn(msg)
-			b = []byte(msg)
-		}
-		appendAPIResponseChunk(ctx, e.cfg, b)
-		if errClose := errBody.Close(); errClose != nil {
-			log.Errorf("response body close error: %v", errClose)
-		}
-		return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: string(b)}
+		return cliproxyexecutor.Response{}, e.buildUpstreamStatusErr(ctx, resp.StatusCode, resp.Header, resp.Body)
 	}
 	decodedBody, err := decodeResponseBody(resp.Body, resp.Header.Get("Content-Encoding"))
 	if err != nil {
@@ -592,10 +525,9 @@ func (e *ClaudeExecutor) buildUpstreamStatusErr(ctx context.Context, statusCode 
 	decodedErrBody, errDecode := decodeResponseBody(body, headers.Get("Content-Encoding"))
 	if errDecode != nil {
 		recordAPIResponseError(ctx, e.cfg, errDecode)
-		return statusErr{
-			code: statusCode,
-			msg:  fmt.Sprintf("upstream error %d: failed to decode upstream error body: %v", statusCode, errDecode),
-		}
+		msg := fmt.Sprintf("failed to decode upstream error body: %v", errDecode)
+		logWithRequestID(ctx).Warn(msg)
+		return statusErr{code: statusCode, msg: msg}
 	}
 
 	b, errRead := io.ReadAll(decodedErrBody)
@@ -604,10 +536,9 @@ func (e *ClaudeExecutor) buildUpstreamStatusErr(ctx context.Context, statusCode 
 	}
 	if errRead != nil {
 		recordAPIResponseError(ctx, e.cfg, errRead)
-		return statusErr{
-			code: statusCode,
-			msg:  fmt.Sprintf("upstream error %d: failed to read upstream error body: %v", statusCode, errRead),
-		}
+		msg := fmt.Sprintf("failed to read upstream error body: %v", errRead)
+		logWithRequestID(ctx).Warn(msg)
+		b = []byte(msg)
 	}
 
 	appendAPIResponseChunk(ctx, e.cfg, b)

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -60,6 +60,7 @@ type claudePreparedBody struct {
 	bodyForTranslation []byte
 	bodyForUpstream    []byte
 	extraBetas         []string
+	originalToolNames  map[string]string
 }
 
 func NewClaudeExecutor(cfg *config.Config) *ClaudeExecutor { return &ClaudeExecutor{cfg: cfg} }
@@ -154,6 +155,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	bodyForTranslation := preparedBody.bodyForTranslation
 	bodyForUpstream := preparedBody.bodyForUpstream
 	extraBetas := preparedBody.extraBetas
+	originalToolNames := preparedBody.originalToolNames
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
@@ -221,6 +223,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 		data = stripClaudeToolPrefixFromResponse(data, claudeToolPrefix)
 	}
+	data = restoreClaudeNormalizedToolNamesInResponse(data, originalToolNames)
 	var param any
 	out := sdktranslator.TranslateNonStream(
 		ctx,
@@ -280,6 +283,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	bodyForTranslation := preparedBody.bodyForTranslation
 	bodyForUpstream := preparedBody.bodyForUpstream
 	extraBetas := preparedBody.extraBetas
+	originalToolNames := preparedBody.originalToolNames
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
@@ -345,6 +349,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 					line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
 				}
+				line = restoreClaudeNormalizedToolNamesInStreamLine(line, originalToolNames)
 				// Forward the line as-is to preserve SSE format
 				cloned := make([]byte, len(line)+1)
 				copy(cloned, line)
@@ -372,6 +377,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 				line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
 			}
+			line = restoreClaudeNormalizedToolNamesInStreamLine(line, originalToolNames)
 			chunks := sdktranslator.TranslateStream(
 				ctx,
 				to,
@@ -492,7 +498,7 @@ func (e *ClaudeExecutor) finalizeClaudeRequestBody(body []byte, reqModel string,
 	if opts.checkSystemInstructions && !strings.HasPrefix(baseModel, "claude-3-5-haiku") {
 		body = checkSystemInstructions(body)
 	}
-	normalizedBody, errNormalize := normalizeClaudeToolsForAnthropic(body)
+	normalizedBody, originalToolNames, errNormalize := normalizeClaudeToolsForAnthropicWithRestoreMap(body)
 	if errNormalize != nil {
 		return claudePreparedBody{}, fmt.Errorf("normalize claude tools: %w", errNormalize)
 	}
@@ -510,10 +516,12 @@ func (e *ClaudeExecutor) finalizeClaudeRequestBody(body []byte, reqModel string,
 		body = normalizeCacheControlTTL(body)
 	}
 	extraBetas, body := extractAndRemoveBetas(body)
+	translationBody := restoreClaudeNormalizedToolNamesInRequest(body, originalToolNames)
 	prepared := claudePreparedBody{
-		bodyForTranslation: body,
+		bodyForTranslation: translationBody,
 		bodyForUpstream:    body,
 		extraBetas:         extraBetas,
+		originalToolNames:  originalToolNames,
 	}
 	if opts.applyToolPrefixForOAuth && isClaudeOAuthToken(apiKey) && auth != nil && !auth.ToolPrefixDisabled() {
 		prepared.bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
@@ -1052,9 +1060,14 @@ func reservedClaudeBuiltinToolNames() map[string]struct{} {
 }
 
 func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
+	normalizedBody, _, err := normalizeClaudeToolsForAnthropicWithRestoreMap(body)
+	return normalizedBody, err
+}
+
+func normalizeClaudeToolsForAnthropicWithRestoreMap(body []byte) ([]byte, map[string]string, error) {
 	tools := gjson.GetBytes(body, "tools")
 	if !tools.Exists() || !tools.IsArray() {
-		return body, nil
+		return body, nil, nil
 	}
 
 	normalizedTools := make([]json.RawMessage, 0, len(tools.Array()))
@@ -1099,7 +1112,7 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 				reserveToolNameVariants(usedNames, originalName)
 				continue
 			}
-			return body, errNormalize
+			return body, nil, errNormalize
 		}
 		normalizedTools = append(normalizedTools, json.RawMessage(normalizedTool))
 		if originalName != "" && originalName != newName {
@@ -1109,19 +1122,30 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 
 	normalizedToolsJSON, errMarshal := json.Marshal(normalizedTools)
 	if errMarshal != nil {
-		return body, fmt.Errorf("marshal normalized tools array: %w", errMarshal)
+		return body, nil, fmt.Errorf("marshal normalized tools array: %w", errMarshal)
 	}
 	updatedBody, errSet := sjson.SetRawBytes(body, "tools", normalizedToolsJSON)
 	if errSet != nil {
-		return body, fmt.Errorf("set normalized tools array: %w", errSet)
+		return body, nil, fmt.Errorf("set normalized tools array: %w", errSet)
 	}
 	body = updatedBody
 
 	body, errSet = applyClaudeRenameMap(body, renameMap)
 	if errSet != nil {
-		return body, errSet
+		return body, nil, errSet
 	}
-	return body, nil
+	return body, invertClaudeToolRenameMap(renameMap), nil
+}
+
+func invertClaudeToolRenameMap(renameMap map[string]string) map[string]string {
+	if len(renameMap) == 0 {
+		return nil
+	}
+	originalByNormalized := make(map[string]string, len(renameMap))
+	for originalName, normalizedName := range renameMap {
+		originalByNormalized[normalizedName] = originalName
+	}
+	return originalByNormalized
 }
 
 func anthroToolOriginalName(tool gjson.Result) string {
@@ -1435,6 +1459,73 @@ func stripClaudeToolPrefixFromResponse(body []byte, prefix string) []byte {
 	return body
 }
 
+func restoreClaudeNormalizedToolNamesInRequest(body []byte, originalByNormalized map[string]string) []byte {
+	if len(originalByNormalized) == 0 {
+		return body
+	}
+	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
+		tools.ForEach(func(index, tool gjson.Result) bool {
+			name := tool.Get("name").String()
+			originalName, ok := renamedToolName(name, originalByNormalized)
+			if !ok {
+				return true
+			}
+			path := fmt.Sprintf("tools.%d.name", index.Int())
+			body, _ = sjson.SetBytes(body, path, originalName)
+			return true
+		})
+	}
+	restoredBody, err := applyClaudeRenameMap(body, originalByNormalized)
+	if err != nil {
+		return body
+	}
+	return restoredBody
+}
+
+func restoreClaudeNormalizedToolNamesInResponse(body []byte, originalByNormalized map[string]string) []byte {
+	if len(originalByNormalized) == 0 {
+		return body
+	}
+	content := gjson.GetBytes(body, "content")
+	if !content.Exists() || !content.IsArray() {
+		return body
+	}
+	content.ForEach(func(index, part gjson.Result) bool {
+		partType := part.Get("type").String()
+		switch partType {
+		case "tool_use":
+			name := part.Get("name").String()
+			if originalName, ok := renamedToolName(name, originalByNormalized); ok {
+				path := fmt.Sprintf("content.%d.name", index.Int())
+				body, _ = sjson.SetBytes(body, path, originalName)
+			}
+		case "tool_reference":
+			toolName := part.Get("tool_name").String()
+			if originalName, ok := renamedToolName(toolName, originalByNormalized); ok {
+				path := fmt.Sprintf("content.%d.tool_name", index.Int())
+				body, _ = sjson.SetBytes(body, path, originalName)
+			}
+		case "tool_result":
+			nestedContent := part.Get("content")
+			if nestedContent.Exists() && nestedContent.IsArray() {
+				nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
+					if nestedPart.Get("type").String() != "tool_reference" {
+						return true
+					}
+					nestedToolName := nestedPart.Get("tool_name").String()
+					if originalName, ok := renamedToolName(nestedToolName, originalByNormalized); ok {
+						nestedPath := fmt.Sprintf("content.%d.content.%d.tool_name", index.Int(), nestedIndex.Int())
+						body, _ = sjson.SetBytes(body, nestedPath, originalName)
+					}
+					return true
+				})
+			}
+		}
+		return true
+	})
+	return body
+}
+
 func stripClaudeToolPrefixFromStreamLine(line []byte, prefix string) []byte {
 	if prefix == "" {
 		return line
@@ -1468,6 +1559,57 @@ func stripClaudeToolPrefixFromStreamLine(line []byte, prefix string) []byte {
 			return line
 		}
 		updated, err = sjson.SetBytes(payload, "content_block.tool_name", strings.TrimPrefix(toolName, prefix))
+		if err != nil {
+			return line
+		}
+	default:
+		return line
+	}
+
+	trimmed := bytes.TrimSpace(line)
+	if bytes.HasPrefix(trimmed, []byte("data:")) {
+		return append([]byte("data: "), updated...)
+	}
+	return updated
+}
+
+func restoreClaudeNormalizedToolNamesInStreamLine(line []byte, originalByNormalized map[string]string) []byte {
+	if len(originalByNormalized) == 0 {
+		return line
+	}
+	payload := jsonPayload(line)
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return line
+	}
+	contentBlock := gjson.GetBytes(payload, "content_block")
+	if !contentBlock.Exists() {
+		return line
+	}
+
+	blockType := contentBlock.Get("type").String()
+	var (
+		updated []byte
+		err     error
+	)
+
+	switch blockType {
+	case "tool_use":
+		name := contentBlock.Get("name").String()
+		originalName, ok := renamedToolName(name, originalByNormalized)
+		if !ok {
+			return line
+		}
+		updated, err = sjson.SetBytes(payload, "content_block.name", originalName)
+		if err != nil {
+			return line
+		}
+	case "tool_reference":
+		toolName := contentBlock.Get("tool_name").String()
+		originalName, ok := renamedToolName(toolName, originalByNormalized)
+		if !ok {
+			return line
+		}
+		updated, err = sjson.SetBytes(payload, "content_block.tool_name", originalName)
 		if err != nil {
 			return line
 		}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -46,6 +46,22 @@ type ClaudeExecutor struct {
 // Previously "proxy_" was used but this is a detectable fingerprint difference.
 const claudeToolPrefix = ""
 
+type claudeBodyFinalizeOptions struct {
+	applyThinking            bool
+	checkSystemInstructions  bool
+	disableForcedToolChoice  bool
+	autoInjectCacheControl   bool
+	enforceCacheControlLimit bool
+	normalizeCacheControlTTL bool
+	applyToolPrefixForOAuth  bool
+}
+
+type claudePreparedBody struct {
+	bodyForTranslation []byte
+	bodyForUpstream    []byte
+	extraBetas         []string
+}
+
 func NewClaudeExecutor(cfg *config.Config) *ClaudeExecutor { return &ClaudeExecutor{cfg: cfg} }
 
 func (e *ClaudeExecutor) Identifier() string { return "claude" }
@@ -118,50 +134,29 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
-	if err != nil {
-		return resp, err
-	}
-
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
 	body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
-body = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
-	body, err = normalizeClaudeToolsForAnthropic(body)
+	body = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+	preparedBody, err := e.finalizeClaudeRequestBody(body, req.Model, from, to, baseModel, apiKey, auth, claudeBodyFinalizeOptions{
+		applyThinking:            true,
+		disableForcedToolChoice:  true,
+		autoInjectCacheControl:   true,
+		enforceCacheControlLimit: true,
+		normalizeCacheControlTTL: true,
+		applyToolPrefixForOAuth:  true,
+	})
 	if err != nil {
 		if isStatusCodeErr(err) {
 			return resp, err
 		}
-		return resp, fmt.Errorf("normalize claude tools: %w", err)
+		return resp, err
 	}
-
-	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
-	body = disableThinkingIfToolChoiceForced(body)
-
-	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
-	if countCacheControls(body) == 0 {
-		body = ensureCacheControl(body)
-	}
-
-	// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
-	// Cloaking and ensureCacheControl may push the total over 4 when the client
-	// (e.g. Amp CLI) already sends multiple cache_control blocks.
-	body = enforceCacheControlLimit(body, 4)
-
-	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
-	// A 1h-TTL block must not appear after a 5m-TTL block in evaluation order (tools→system→messages).
-	body = normalizeCacheControlTTL(body)
-
-	// Extract betas from body and convert to header
-	var extraBetas []string
-	extraBetas, body = extractAndRemoveBetas(body)
-	bodyForTranslation := body
-	bodyForUpstream := body
-	if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
-		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
-	}
+	bodyForTranslation := preparedBody.bodyForTranslation
+	bodyForUpstream := preparedBody.bodyForUpstream
+	extraBetas := preparedBody.extraBetas
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
@@ -291,47 +286,29 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
-	if err != nil {
-		return nil, err
-	}
-
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
 	body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
-body = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
-	body, err = normalizeClaudeToolsForAnthropic(body)
+	body = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+	preparedBody, err := e.finalizeClaudeRequestBody(body, req.Model, from, to, baseModel, apiKey, auth, claudeBodyFinalizeOptions{
+		applyThinking:            true,
+		disableForcedToolChoice:  true,
+		autoInjectCacheControl:   true,
+		enforceCacheControlLimit: true,
+		normalizeCacheControlTTL: true,
+		applyToolPrefixForOAuth:  true,
+	})
 	if err != nil {
 		if isStatusCodeErr(err) {
 			return nil, err
 		}
-		return nil, fmt.Errorf("normalize claude tools: %w", err)
+		return nil, err
 	}
-
-	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
-	body = disableThinkingIfToolChoiceForced(body)
-
-	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
-	if countCacheControls(body) == 0 {
-		body = ensureCacheControl(body)
-	}
-
-	// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
-	body = enforceCacheControlLimit(body, 4)
-
-	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
-	body = normalizeCacheControlTTL(body)
-
-	// Extract betas from body and convert to header
-	var extraBetas []string
-	extraBetas, body = extractAndRemoveBetas(body)
-	bodyForTranslation := body
-	bodyForUpstream := body
-	if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
-		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
-	}
+	bodyForTranslation := preparedBody.bodyForTranslation
+	bodyForUpstream := preparedBody.bodyForUpstream
+	extraBetas := preparedBody.extraBetas
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
@@ -484,29 +461,22 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	stream := from != to
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
-
-	if !strings.HasPrefix(baseModel, "claude-3-5-haiku") {
-		body = checkSystemInstructions(body)
-	}
-	normalizedBody, errNormalize := normalizeClaudeToolsForAnthropic(body)
-	if errNormalize != nil {
-		if isStatusCodeErr(errNormalize) {
-			return cliproxyexecutor.Response{}, errNormalize
+	preparedBody, err := e.finalizeClaudeRequestBody(body, req.Model, from, to, baseModel, apiKey, auth, claudeBodyFinalizeOptions{
+		applyThinking:            true,
+		checkSystemInstructions:  true,
+		disableForcedToolChoice:  true,
+		enforceCacheControlLimit: true,
+		normalizeCacheControlTTL: true,
+		applyToolPrefixForOAuth:  true,
+	})
+	if err != nil {
+		if isStatusCodeErr(err) {
+			return cliproxyexecutor.Response{}, err
 		}
-		return cliproxyexecutor.Response{}, fmt.Errorf("normalize claude tools: %w", errNormalize)
+		return cliproxyexecutor.Response{}, err
 	}
-	body = normalizedBody
-
-	// Keep count_tokens requests compatible with Anthropic cache-control constraints too.
-	body = enforceCacheControlLimit(body, 4)
-	body = normalizeCacheControlTTL(body)
-
-	// Extract betas from body and convert to header (for count_tokens too)
-	var extraBetas []string
-	extraBetas, body = extractAndRemoveBetas(body)
-	if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
-		body = applyClaudeToolPrefix(body, claudeToolPrefix)
-	}
+	body = preparedBody.bodyForUpstream
+	extraBetas := preparedBody.extraBetas
 
 	url := fmt.Sprintf("%s/v1/messages/count_tokens?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
@@ -585,6 +555,49 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	count := gjson.GetBytes(data, "input_tokens").Int()
 	out := sdktranslator.TranslateTokenCount(ctx, to, from, count, data)
 	return cliproxyexecutor.Response{Payload: []byte(out), Headers: resp.Header.Clone()}, nil
+}
+
+func (e *ClaudeExecutor) finalizeClaudeRequestBody(body []byte, reqModel string, from, to sdktranslator.Format, baseModel, apiKey string, auth *cliproxyauth.Auth, opts claudeBodyFinalizeOptions) (claudePreparedBody, error) {
+	if opts.applyThinking {
+		var err error
+		body, err = thinking.ApplyThinking(body, reqModel, from.String(), to.String(), e.Identifier())
+		if err != nil {
+			return claudePreparedBody{}, err
+		}
+	}
+	if opts.checkSystemInstructions && !strings.HasPrefix(baseModel, "claude-3-5-haiku") {
+		body = checkSystemInstructions(body)
+	}
+	normalizedBody, errNormalize := normalizeClaudeToolsForAnthropic(body)
+	if errNormalize != nil {
+		if isStatusCodeErr(errNormalize) {
+			return claudePreparedBody{}, errNormalize
+		}
+		return claudePreparedBody{}, fmt.Errorf("normalize claude tools: %w", errNormalize)
+	}
+	body = normalizedBody
+	if opts.disableForcedToolChoice {
+		body = disableThinkingIfToolChoiceForced(body)
+	}
+	if opts.autoInjectCacheControl && countCacheControls(body) == 0 {
+		body = ensureCacheControl(body)
+	}
+	if opts.enforceCacheControlLimit {
+		body = enforceCacheControlLimit(body, 4)
+	}
+	if opts.normalizeCacheControlTTL {
+		body = normalizeCacheControlTTL(body)
+	}
+	extraBetas, body := extractAndRemoveBetas(body)
+	prepared := claudePreparedBody{
+		bodyForTranslation: body,
+		bodyForUpstream:    body,
+		extraBetas:         extraBetas,
+	}
+	if opts.applyToolPrefixForOAuth && isClaudeOAuthToken(apiKey) && auth != nil && !auth.ToolPrefixDisabled() {
+		prepared.bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
+	}
+	return prepared, nil
 }
 
 func (e *ClaudeExecutor) buildUpstreamStatusErr(ctx context.Context, statusCode int, headers http.Header, body io.ReadCloser) error {
@@ -1120,50 +1133,69 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 		return body, nil
 	}
 
-	normalizedTools := "[]"
+	normalizedTools := make([]json.RawMessage, 0, len(tools.Array()))
 	renameMap := make(map[string]string)
-	customOriginalNames := make(map[string]struct{})
+	customOriginalNameCounts := make(map[string]int)
 	usedNames := reservedClaudeBuiltinToolNames()
+	for _, tool := range tools.Array() {
+		if isClaudeBuiltinTool(tool) {
+			continue
+		}
+		toolType := strings.TrimSpace(tool.Get("type").String())
+		if toolType != "" && toolType != "custom" {
+			continue
+		}
+		name := anthroToolOriginalName(tool)
+		if name == "" {
+			continue
+		}
+		customOriginalNameCounts[name]++
+	}
 
 	for _, tool := range tools.Array() {
 		if isClaudeBuiltinTool(tool) {
-			updatedTools, errSet := sjson.SetRaw(normalizedTools, "-1", tool.Raw)
-			if errSet != nil {
-				return body, fmt.Errorf("append built-in tool: %w", errSet)
-			}
-			normalizedTools = updatedTools
-			if name := strings.TrimSpace(tool.Get("name").String()); name != "" {
-				usedNames[name] = struct{}{}
-			}
+			normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
+			reserveToolNameVariants(usedNames, strings.TrimSpace(tool.Get("name").String()))
+			continue
+		}
+
+		toolType := strings.TrimSpace(tool.Get("type").String())
+		if toolType != "" && toolType != "custom" {
+			// Preserve explicit non-custom types as-is for forward compatibility.
+			normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
+			reserveToolNameVariants(usedNames, anthroToolOriginalName(tool))
 			continue
 		}
 
 		originalName := anthroToolOriginalName(tool)
-		if originalName != "" {
-			if _, exists := customOriginalNames[originalName]; exists {
-				return body, statusErr{
-					code: http.StatusBadRequest,
-					msg:  fmt.Sprintf("normalize claude tools: duplicate custom tool name %q cannot be safely remapped", originalName),
-				}
-			}
-			customOriginalNames[originalName] = struct{}{}
+		if originalName != "" && customOriginalNameCounts[originalName] > 1 {
+			// Duplicate original names cannot be remapped unambiguously; preserve raw entry.
+			normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
+			reserveToolNameVariants(usedNames, originalName)
+			continue
 		}
 
 		normalizedTool, originalName, newName, errNormalize := normalizeAnthropicToolEntry(tool, usedNames)
 		if errNormalize != nil {
+			if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) {
+				// Keep original entry if we cannot produce a safe Anthropic-compliant name.
+				normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
+				reserveToolNameVariants(usedNames, originalName)
+				continue
+			}
 			return body, errNormalize
 		}
-		updatedTools, errSet := sjson.SetRaw(normalizedTools, "-1", normalizedTool)
-		if errSet != nil {
-			return body, fmt.Errorf("append normalized tool: %w", errSet)
-		}
-		normalizedTools = updatedTools
+		normalizedTools = append(normalizedTools, json.RawMessage(normalizedTool))
 		if originalName != "" && originalName != newName {
 			renameMap[originalName] = newName
 		}
 	}
 
-	updatedBody, errSet := sjson.SetRawBytes(body, "tools", []byte(normalizedTools))
+	normalizedToolsJSON, errMarshal := json.Marshal(normalizedTools)
+	if errMarshal != nil {
+		return body, fmt.Errorf("marshal normalized tools array: %w", errMarshal)
+	}
+	updatedBody, errSet := sjson.SetRawBytes(body, "tools", normalizedToolsJSON)
 	if errSet != nil {
 		return body, fmt.Errorf("set normalized tools array: %w", errSet)
 	}
@@ -1184,14 +1216,13 @@ func anthroToolOriginalName(tool gjson.Result) string {
 	return name
 }
 
+var errAnthropicToolNameUnsanitizable = errors.New("anthropic tool name unsanitizable")
+
 func normalizeAnthropicToolEntry(tool gjson.Result, usedNames map[string]struct{}) (normalizedRaw string, originalName string, newName string, err error) {
 	originalName = anthroToolOriginalName(tool)
 	newName = uniqueAnthropicToolName(originalName, usedNames)
 	if newName == "" {
-		return "", originalName, "", statusErr{
-			code: http.StatusBadRequest,
-			msg:  fmt.Sprintf("normalize claude tools: custom tool name %q cannot be sanitized into a valid Anthropic tool name", originalName),
-		}
+		return "", originalName, "", fmt.Errorf("%w: custom tool name %q cannot be sanitized into a valid Anthropic tool name", errAnthropicToolNameUnsanitizable, originalName)
 	}
 
 	description := strings.TrimSpace(tool.Get("description").String())
@@ -1255,12 +1286,30 @@ func copyAnthropicCustomToolMetadata(normalized string, original gjson.Result) (
 	return normalized, nil
 }
 
-func setJSONBytes(body []byte, path string, value string) ([]byte, error) {
-	updatedBody, err := sjson.SetBytes(body, path, value)
-	if err != nil {
-		return body, fmt.Errorf("set %s: %w", path, err)
+func reserveToolNameVariants(used map[string]struct{}, name string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
 	}
-	return updatedBody, nil
+	used[name] = struct{}{}
+	if sanitized := sanitizeAnthropicToolName(name); sanitized != "" {
+		used[sanitized] = struct{}{}
+	}
+}
+
+func renameToolNameField(target map[string]any, field string, renameMap map[string]string) {
+	raw, ok := target[field]
+	if !ok {
+		return
+	}
+	name, ok := raw.(string)
+	if !ok {
+		return
+	}
+	name = strings.TrimSpace(name)
+	if mapped, ok := renameMap[name]; ok {
+		target[field] = mapped
+	}
 }
 
 func applyClaudeRenameMap(body []byte, renameMap map[string]string) ([]byte, error) {
@@ -1268,73 +1317,89 @@ func applyClaudeRenameMap(body []byte, renameMap map[string]string) ([]byte, err
 		return body, nil
 	}
 
-	if gjson.GetBytes(body, "tool_choice.type").String() == "tool" {
-		name := strings.TrimSpace(gjson.GetBytes(body, "tool_choice.name").String())
-		if mapped, ok := renameMap[name]; ok {
-			updatedBody, errSet := setJSONBytes(body, "tool_choice.name", mapped)
-			if errSet != nil {
-				return body, errSet
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return body, fmt.Errorf("decode payload for tool rename map: %w", err)
+	}
+
+	if toolChoiceRaw, ok := payload["tool_choice"]; ok {
+		if toolChoice, ok := toolChoiceRaw.(map[string]any); ok {
+			if kind, ok := toolChoice["type"].(string); ok && kind == "tool" {
+				renameToolNameField(toolChoice, "name", renameMap)
 			}
-			body = updatedBody
 		}
 	}
 
-	messages := gjson.GetBytes(body, "messages")
-	if !messages.Exists() || !messages.IsArray() {
-		return body, nil
+	messageListRaw, ok := payload["messages"]
+	if !ok {
+		updatedBody, errMarshal := json.Marshal(payload)
+		if errMarshal != nil {
+			return body, fmt.Errorf("encode payload after tool rename map: %w", errMarshal)
+		}
+		return updatedBody, nil
+	}
+	messageList, ok := messageListRaw.([]any)
+	if !ok {
+		updatedBody, errMarshal := json.Marshal(payload)
+		if errMarshal != nil {
+			return body, fmt.Errorf("encode payload after tool rename map: %w", errMarshal)
+		}
+		return updatedBody, nil
 	}
 
-	for msgIndex, msg := range messages.Array() {
-		content := msg.Get("content")
-		if !content.Exists() || !content.IsArray() {
+	for _, msgRaw := range messageList {
+		msg, ok := msgRaw.(map[string]any)
+		if !ok {
 			continue
 		}
-		for contentIndex, part := range content.Array() {
-			switch part.Get("type").String() {
+		contentRaw, ok := msg["content"]
+		if !ok {
+			continue
+		}
+		content, ok := contentRaw.([]any)
+		if !ok {
+			continue
+		}
+		for _, partRaw := range content {
+			part, ok := partRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+			partType, _ := part["type"].(string)
+			switch partType {
 			case "tool_use":
-				name := strings.TrimSpace(part.Get("name").String())
-				if mapped, ok := renameMap[name]; ok {
-					path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex, contentIndex)
-					updatedBody, errSet := setJSONBytes(body, path, mapped)
-					if errSet != nil {
-						return body, errSet
-					}
-					body = updatedBody
-				}
+				renameToolNameField(part, "name", renameMap)
 			case "tool_reference":
-				toolName := strings.TrimSpace(part.Get("tool_name").String())
-				if mapped, ok := renameMap[toolName]; ok {
-					path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex, contentIndex)
-					updatedBody, errSet := setJSONBytes(body, path, mapped)
-					if errSet != nil {
-						return body, errSet
-					}
-					body = updatedBody
-				}
+				renameToolNameField(part, "tool_name", renameMap)
 			case "tool_result":
-				nestedContent := part.Get("content")
-				if !nestedContent.Exists() || !nestedContent.IsArray() {
+				nestedContentRaw, ok := part["content"]
+				if !ok {
 					continue
 				}
-				for nestedIndex, nestedPart := range nestedContent.Array() {
-					if nestedPart.Get("type").String() != "tool_reference" {
+				nestedContent, ok := nestedContentRaw.([]any)
+				if !ok {
+					continue
+				}
+				for _, nestedPartRaw := range nestedContent {
+					nestedPart, ok := nestedPartRaw.(map[string]any)
+					if !ok {
 						continue
 					}
-					nestedToolName := strings.TrimSpace(nestedPart.Get("tool_name").String())
-					if mapped, ok := renameMap[nestedToolName]; ok {
-						nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex, contentIndex, nestedIndex)
-						updatedBody, errSet := setJSONBytes(body, nestedPath, mapped)
-						if errSet != nil {
-							return body, errSet
-						}
-						body = updatedBody
+					nestedType, _ := nestedPart["type"].(string)
+					if nestedType != "tool_reference" {
+						continue
 					}
+					renameToolNameField(nestedPart, "tool_name", renameMap)
 				}
 			}
 		}
 	}
 
-	return body, nil
+	updatedBody, errMarshal := json.Marshal(payload)
+	if errMarshal != nil {
+		return body, fmt.Errorf("encode payload after tool rename map: %w", errMarshal)
+	}
+	return updatedBody, nil
 }
 func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 	if prefix == "" {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -502,6 +502,9 @@ func (e *ClaudeExecutor) finalizeClaudeRequestBody(body []byte, reqModel string,
 	}
 	normalizedBody, originalToolNames, errNormalize := normalizeClaudeToolsForAnthropicWithRestoreMap(body)
 	if errNormalize != nil {
+		if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) || errors.Is(errNormalize, errAnthropicDuplicateToolName) {
+			return claudePreparedBody{}, statusErr{code: http.StatusBadRequest, msg: errNormalize.Error()}
+		}
 		return claudePreparedBody{}, fmt.Errorf("normalize claude tools: %w", errNormalize)
 	}
 	body = normalizedBody
@@ -1023,7 +1026,7 @@ func isClaudeBuiltinTool(tool gjson.Result) bool {
 
 func isClaudeExplicitNonCustomTypedTool(tool gjson.Result) bool {
 	toolType := strings.TrimSpace(tool.Get("type").String())
-	return toolType != "" && toolType != "custom" && !isClaudeBuiltinToolType(toolType)
+	return toolType != "" && toolType != "custom" && toolType != "function" && !isClaudeBuiltinToolType(toolType)
 }
 
 func normalizeAnthropicToolSchema(raw string) string {
@@ -1161,20 +1164,11 @@ func normalizeClaudeToolsForAnthropicWithRestoreMap(body []byte) ([]byte, map[st
 
 		originalName := anthroToolOriginalName(tool)
 		if originalName != "" && originalNameCounts[originalName] > 1 {
-			// Duplicate original names cannot be remapped unambiguously; preserve raw entry.
-			normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
-			reserveToolNameVariants(usedNames, originalName)
-			continue
+			return body, nil, fmt.Errorf("%w: custom tool name %q appears multiple times and cannot be remapped safely", errAnthropicDuplicateToolName, originalName)
 		}
 
 		normalizedTool, originalName, newName, errNormalize := normalizeAnthropicToolEntry(tool, usedNames)
 		if errNormalize != nil {
-			if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) {
-				// Keep original entry if we cannot produce a safe Anthropic-compliant name.
-				normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
-				reserveToolNameVariants(usedNames, originalName)
-				continue
-			}
 			return body, nil, errNormalize
 		}
 		normalizedTools = append(normalizedTools, json.RawMessage(normalizedTool))
@@ -1220,6 +1214,7 @@ func anthroToolOriginalName(tool gjson.Result) string {
 }
 
 var errAnthropicToolNameUnsanitizable = errors.New("anthropic tool name unsanitizable")
+var errAnthropicDuplicateToolName = errors.New("anthropic duplicate tool name")
 
 func normalizeAnthropicToolEntry(tool gjson.Result, usedNames map[string]struct{}) (normalizedRaw string, originalName string, newName string, err error) {
 	originalName = anthroToolOriginalName(tool)
@@ -1391,28 +1386,82 @@ func applyClaudeRenameMap(body []byte, renameMap map[string]string) ([]byte, err
 
 	return body, nil
 }
+
+func claudeToolPrefixName(tool gjson.Result) string {
+	topLevelName := strings.TrimSpace(tool.Get("name").String())
+	if topLevelName != "" {
+		return topLevelName
+	}
+	return anthroToolOriginalName(tool)
+}
+
+type claudeToolPrefixState struct {
+	prefixable    bool
+	nonPrefixable bool
+}
+
+func isClaudeToolPrefixable(tool gjson.Result) bool {
+	if isClaudeBuiltinTool(tool) || isClaudeExplicitNonCustomTypedTool(tool) {
+		return false
+	}
+	return strings.TrimSpace(tool.Get("name").String()) != ""
+}
+
+func claudeToolPrefixStates(body []byte) map[string]claudeToolPrefixState {
+	states := map[string]claudeToolPrefixState{}
+	for _, name := range []string{"web_search", "code_execution", "text_editor", "computer"} {
+		states[name] = claudeToolPrefixState{nonPrefixable: true}
+	}
+
+	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			name := claudeToolPrefixName(tool)
+			if name == "" {
+				return true
+			}
+			state := states[name]
+			if isClaudeToolPrefixable(tool) {
+				state.prefixable = true
+			} else {
+				state.nonPrefixable = true
+			}
+			states[name] = state
+			return true
+		})
+	}
+
+	return states
+}
+
+func shouldPrefixClaudeToolName(name, prefix string, states map[string]claudeToolPrefixState) bool {
+	name = strings.TrimSpace(name)
+	if name == "" || strings.HasPrefix(name, prefix) {
+		return false
+	}
+	state, ok := states[name]
+	if !ok {
+		return true
+	}
+	if state.prefixable && !state.nonPrefixable {
+		return true
+	}
+	return false
+}
+
 func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 	if prefix == "" {
 		return body
 	}
 
-	// Collect non-prefixable tool names so we can skip them consistently in both tools and
-	// message history.
-	nonPrefixableToolNames := map[string]bool{}
-	for _, name := range []string{"web_search", "code_execution", "text_editor", "computer"} {
-		nonPrefixableToolNames[name] = true
-	}
+	states := claudeToolPrefixStates(body)
 
 	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
 		tools.ForEach(func(index, tool gjson.Result) bool {
-			name := tool.Get("name").String()
-			if isClaudeBuiltinTool(tool) || isClaudeExplicitNonCustomTypedTool(tool) {
-				if name != "" {
-					nonPrefixableToolNames[name] = true
-				}
+			name := claudeToolPrefixName(tool)
+			if !isClaudeToolPrefixable(tool) {
 				return true
 			}
-			if name == "" || strings.HasPrefix(name, prefix) {
+			if !shouldPrefixClaudeToolName(name, prefix, states) {
 				return true
 			}
 			path := fmt.Sprintf("tools.%d.name", index.Int())
@@ -1423,7 +1472,7 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 
 	if gjson.GetBytes(body, "tool_choice.type").String() == "tool" {
 		name := gjson.GetBytes(body, "tool_choice.name").String()
-		if name != "" && !strings.HasPrefix(name, prefix) && !nonPrefixableToolNames[name] {
+		if shouldPrefixClaudeToolName(name, prefix, states) {
 			body, _ = sjson.SetBytes(body, "tool_choice.name", prefix+name)
 		}
 	}
@@ -1439,14 +1488,14 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 				switch partType {
 				case "tool_use":
 					name := part.Get("name").String()
-					if name == "" || strings.HasPrefix(name, prefix) || nonPrefixableToolNames[name] {
+					if !shouldPrefixClaudeToolName(name, prefix, states) {
 						return true
 					}
 					path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
 					body, _ = sjson.SetBytes(body, path, prefix+name)
 				case "tool_reference":
 					toolName := part.Get("tool_name").String()
-					if toolName == "" || strings.HasPrefix(toolName, prefix) || nonPrefixableToolNames[toolName] {
+					if !shouldPrefixClaudeToolName(toolName, prefix, states) {
 						return true
 					}
 					path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
@@ -1458,7 +1507,7 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 						nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
 							if nestedPart.Get("type").String() == "tool_reference" {
 								nestedToolName := nestedPart.Get("tool_name").String()
-								if nestedToolName != "" && !strings.HasPrefix(nestedToolName, prefix) && !nonPrefixableToolNames[nestedToolName] {
+								if shouldPrefixClaudeToolName(nestedToolName, prefix, states) {
 									nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
 									body, _ = sjson.SetBytes(body, nestedPath, prefix+nestedToolName)
 								}
@@ -1526,7 +1575,8 @@ func restoreClaudeNormalizedToolNamesInRequest(body []byte, originalByNormalized
 	if len(originalByNormalized) == 0 {
 		return body
 	}
-	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
+	restoredBody := body
+	if tools := gjson.GetBytes(restoredBody, "tools"); tools.Exists() && tools.IsArray() {
 		tools.ForEach(func(index, tool gjson.Result) bool {
 			name := tool.Get("name").String()
 			originalName, ok := renamedToolName(name, originalByNormalized)
@@ -1534,11 +1584,11 @@ func restoreClaudeNormalizedToolNamesInRequest(body []byte, originalByNormalized
 				return true
 			}
 			path := fmt.Sprintf("tools.%d.name", index.Int())
-			body, _ = sjson.SetBytes(body, path, originalName)
+			restoredBody, _ = sjson.SetBytes(restoredBody, path, originalName)
 			return true
 		})
 	}
-	restoredBody, err := applyClaudeRenameMap(body, originalByNormalized)
+	restoredBody, err := applyClaudeRenameMap(restoredBody, originalByNormalized)
 	if err != nil {
 		return body
 	}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1140,20 +1140,17 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 
 	normalizedTools := make([]json.RawMessage, 0, len(tools.Array()))
 	renameMap := make(map[string]string)
-	customOriginalNameCounts := make(map[string]int)
+	originalNameCounts := make(map[string]int)
 	usedNames := reservedClaudeBuiltinToolNames()
 	for _, tool := range tools.Array() {
 		if isClaudeBuiltinTool(tool) {
-			continue
-		}
-		if isClaudeExplicitNonCustomTypedTool(tool) {
 			continue
 		}
 		name := anthroToolOriginalName(tool)
 		if name == "" {
 			continue
 		}
-		customOriginalNameCounts[name]++
+		originalNameCounts[name]++
 	}
 
 	for _, tool := range tools.Array() {
@@ -1171,7 +1168,7 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 		}
 
 		originalName := anthroToolOriginalName(tool)
-		if originalName != "" && customOriginalNameCounts[originalName] > 1 {
+		if originalName != "" && originalNameCounts[originalName] > 1 {
 			// Duplicate original names cannot be remapped unambiguously; preserve raw entry.
 			normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
 			reserveToolNameVariants(usedNames, originalName)

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1106,6 +1106,14 @@ func uniqueAnthropicToolName(name string, used map[string]struct{}) string {
 	return ""
 }
 
+func reservedClaudeBuiltinToolNames() map[string]struct{} {
+	reserved := make(map[string]struct{})
+	for _, name := range []string{"web_search", "code_execution", "text_editor", "computer"} {
+		reserved[name] = struct{}{}
+	}
+	return reserved
+}
+
 func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 	tools := gjson.GetBytes(body, "tools")
 	if !tools.Exists() || !tools.IsArray() {
@@ -1115,7 +1123,7 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 	normalizedTools := "[]"
 	renameMap := make(map[string]string)
 	customOriginalNames := make(map[string]struct{})
-	usedNames := make(map[string]struct{})
+	usedNames := reservedClaudeBuiltinToolNames()
 
 	for _, tool := range tools.Array() {
 		if isClaudeBuiltinTool(tool) {
@@ -1144,10 +1152,6 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 		normalizedTool, originalName, newName, errNormalize := normalizeAnthropicToolEntry(tool, usedNames)
 		if errNormalize != nil {
 			return body, errNormalize
-		}
-		if normalizedTool == "" {
-			// Skip malformed non-builtin tools that cannot produce a valid name.
-			continue
 		}
 		updatedTools, errSet := sjson.SetRaw(normalizedTools, "-1", normalizedTool)
 		if errSet != nil {
@@ -1184,7 +1188,10 @@ func normalizeAnthropicToolEntry(tool gjson.Result, usedNames map[string]struct{
 	originalName = anthroToolOriginalName(tool)
 	newName = uniqueAnthropicToolName(originalName, usedNames)
 	if newName == "" {
-		return "", originalName, "", nil
+		return "", originalName, "", statusErr{
+			code: http.StatusBadRequest,
+			msg:  fmt.Sprintf("normalize claude tools: custom tool name %q cannot be sanitized into a valid Anthropic tool name", originalName),
+		}
 	}
 
 	description := strings.TrimSpace(tool.Get("description").String())

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -936,6 +936,299 @@ func isClaudeOAuthToken(apiKey string) bool {
 	return strings.Contains(apiKey, "sk-ant-oat")
 }
 
+func isClaudeBuiltinToolType(toolType string) bool {
+	toolType = strings.TrimSpace(toolType)
+	switch {
+	case strings.HasPrefix(toolType, "web_search"):
+		return true
+	case toolType == "code_execution":
+		return true
+	case strings.HasPrefix(toolType, "text_editor"):
+		return true
+	case strings.HasPrefix(toolType, "computer"):
+		return true
+	default:
+		return false
+	}
+}
+
+func isClaudeBuiltinTool(tool gjson.Result) bool {
+	return isClaudeBuiltinToolType(tool.Get("type").String())
+}
+
+func normalizeAnthropicToolSchema(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" || !gjson.Valid(raw) || !gjson.Parse(raw).IsObject() {
+		return `{"type":"object","properties":{}}`
+	}
+
+	schema := raw
+	parsed := gjson.Parse(raw)
+	schemaType := strings.TrimSpace(parsed.Get("type").String())
+	if schemaType == "" {
+		var err error
+		schema, err = sjson.Set(schema, "type", "object")
+		if err != nil {
+			return `{"type":"object","properties":{}}`
+		}
+	} else if schemaType != "object" {
+		return `{"type":"object","properties":{}}`
+	}
+
+	parsed = gjson.Parse(schema)
+	properties := parsed.Get("properties")
+	if !properties.Exists() || !properties.IsObject() {
+		var err error
+		schema, err = sjson.SetRaw(schema, "properties", `{}`)
+		if err != nil {
+			return `{"type":"object","properties":{}}`
+		}
+	}
+	return schema
+}
+
+func sanitizeAnthropicToolName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(len(name))
+	for i := 0; i < len(name); i++ {
+		ch := name[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' {
+			b.WriteByte(ch)
+			continue
+		}
+		b.WriteByte('_')
+	}
+
+	clean := strings.Trim(b.String(), "_-")
+	if clean == "" {
+		return ""
+	}
+	if len(clean) > 64 {
+		clean = clean[:64]
+	}
+	return clean
+}
+
+const maxToolNameCollisionRetries = 1000
+
+func uniqueAnthropicToolName(name string, used map[string]struct{}) string {
+	clean := sanitizeAnthropicToolName(name)
+	if clean == "" {
+		return ""
+	}
+	if _, exists := used[clean]; !exists {
+		used[clean] = struct{}{}
+		return clean
+	}
+	for i := 2; i < maxToolNameCollisionRetries; i++ {
+		suffix := fmt.Sprintf("_%d", i)
+		baseLimit := 64 - len(suffix)
+		if baseLimit < 1 {
+			return ""
+		}
+		base := clean
+		if len(base) > baseLimit {
+			base = base[:baseLimit]
+		}
+		candidate := base + suffix
+		if _, exists := used[candidate]; !exists {
+			used[candidate] = struct{}{}
+			return candidate
+		}
+	}
+	return ""
+}
+
+func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return body, nil
+	}
+
+	normalizedTools := "[]"
+	renameMap := make(map[string]string)
+	usedNames := make(map[string]struct{})
+
+	for _, tool := range tools.Array() {
+		if isClaudeBuiltinTool(tool) {
+			updatedTools, errSet := sjson.SetRaw(normalizedTools, "-1", tool.Raw)
+			if errSet != nil {
+				return body, fmt.Errorf("append built-in tool: %w", errSet)
+			}
+			normalizedTools = updatedTools
+			if name := strings.TrimSpace(tool.Get("name").String()); name != "" {
+				usedNames[name] = struct{}{}
+			}
+			continue
+		}
+
+		normalizedTool, originalName, newName, errNormalize := normalizeAnthropicToolEntry(tool, usedNames)
+		if errNormalize != nil {
+			return body, errNormalize
+		}
+		if normalizedTool == "" {
+			// Skip malformed non-builtin tools that cannot produce a valid name.
+			continue
+		}
+		updatedTools, errSet := sjson.SetRaw(normalizedTools, "-1", normalizedTool)
+		if errSet != nil {
+			return body, fmt.Errorf("append normalized tool: %w", errSet)
+		}
+		normalizedTools = updatedTools
+		if originalName != "" && originalName != newName {
+			renameMap[originalName] = newName
+		}
+	}
+
+	updatedBody, errSet := sjson.SetRawBytes(body, "tools", []byte(normalizedTools))
+	if errSet != nil {
+		return body, fmt.Errorf("set normalized tools array: %w", errSet)
+	}
+	body = updatedBody
+
+	body, errSet = applyClaudeRenameMap(body, renameMap)
+	if errSet != nil {
+		return body, errSet
+	}
+	return body, nil
+}
+
+func normalizeAnthropicToolEntry(tool gjson.Result, usedNames map[string]struct{}) (normalizedRaw string, originalName string, newName string, err error) {
+	originalName = strings.TrimSpace(tool.Get("name").String())
+	if originalName == "" {
+		originalName = strings.TrimSpace(tool.Get("function.name").String())
+	}
+	newName = uniqueAnthropicToolName(originalName, usedNames)
+	if newName == "" {
+		return "", originalName, "", nil
+	}
+
+	description := strings.TrimSpace(tool.Get("description").String())
+	if description == "" {
+		description = strings.TrimSpace(tool.Get("function.description").String())
+	}
+	if description == "" {
+		description = "Custom tool"
+	}
+
+	schemaRaw := ""
+	schemaPaths := []string{
+		"input_schema",
+		"parameters",
+		"parametersJsonSchema",
+		"function.parameters",
+		"function.parametersJsonSchema",
+	}
+	for _, path := range schemaPaths {
+		if v := tool.Get(path); v.Exists() {
+			schemaRaw = v.Raw
+			break
+		}
+	}
+	schema := normalizeAnthropicToolSchema(schemaRaw)
+
+	normalized := `{"name":"","description":"","input_schema":{}}`
+	normalized, err = sjson.Set(normalized, "name", newName)
+	if err != nil {
+		return "", originalName, newName, fmt.Errorf("set normalized tool name: %w", err)
+	}
+	normalized, err = sjson.Set(normalized, "description", description)
+	if err != nil {
+		return "", originalName, newName, fmt.Errorf("set normalized tool description: %w", err)
+	}
+	normalized, err = sjson.SetRaw(normalized, "input_schema", schema)
+	if err != nil {
+		return "", originalName, newName, fmt.Errorf("set normalized tool schema: %w", err)
+	}
+	return normalized, originalName, newName, nil
+}
+
+func setJSONBytes(body []byte, path string, value string) ([]byte, error) {
+	updatedBody, err := sjson.SetBytes(body, path, value)
+	if err != nil {
+		return body, fmt.Errorf("set %s: %w", path, err)
+	}
+	return updatedBody, nil
+}
+
+func applyClaudeRenameMap(body []byte, renameMap map[string]string) ([]byte, error) {
+	if len(renameMap) == 0 {
+		return body, nil
+	}
+
+	if gjson.GetBytes(body, "tool_choice.type").String() == "tool" {
+		name := strings.TrimSpace(gjson.GetBytes(body, "tool_choice.name").String())
+		if mapped, ok := renameMap[name]; ok {
+			updatedBody, errSet := setJSONBytes(body, "tool_choice.name", mapped)
+			if errSet != nil {
+				return body, errSet
+			}
+			body = updatedBody
+		}
+	}
+
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body, nil
+	}
+
+	for msgIndex, msg := range messages.Array() {
+		content := msg.Get("content")
+		if !content.Exists() || !content.IsArray() {
+			continue
+		}
+		for contentIndex, part := range content.Array() {
+			switch part.Get("type").String() {
+			case "tool_use":
+				name := strings.TrimSpace(part.Get("name").String())
+				if mapped, ok := renameMap[name]; ok {
+					path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex, contentIndex)
+					updatedBody, errSet := setJSONBytes(body, path, mapped)
+					if errSet != nil {
+						return body, errSet
+					}
+					body = updatedBody
+				}
+			case "tool_reference":
+				toolName := strings.TrimSpace(part.Get("tool_name").String())
+				if mapped, ok := renameMap[toolName]; ok {
+					path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex, contentIndex)
+					updatedBody, errSet := setJSONBytes(body, path, mapped)
+					if errSet != nil {
+						return body, errSet
+					}
+					body = updatedBody
+				}
+			case "tool_result":
+				nestedContent := part.Get("content")
+				if !nestedContent.Exists() || !nestedContent.IsArray() {
+					continue
+				}
+				for nestedIndex, nestedPart := range nestedContent.Array() {
+					if nestedPart.Get("type").String() != "tool_reference" {
+						continue
+					}
+					nestedToolName := strings.TrimSpace(nestedPart.Get("tool_name").String())
+					if mapped, ok := renameMap[nestedToolName]; ok {
+						nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex, contentIndex, nestedIndex)
+						updatedBody, errSet := setJSONBytes(body, nestedPath, mapped)
+						if errSet != nil {
+							return body, errSet
+						}
+						body = updatedBody
+					}
+				}
+			}
+		}
+	}
+
+	return body, nil
+}
 func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 	if prefix == "" {
 		return body

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -149,9 +149,6 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		applyToolPrefixForOAuth:  true,
 	})
 	if err != nil {
-		if isStatusCodeErr(err) {
-			return resp, err
-		}
 		return resp, err
 	}
 	bodyForTranslation := preparedBody.bodyForTranslation
@@ -301,9 +298,6 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		applyToolPrefixForOAuth:  true,
 	})
 	if err != nil {
-		if isStatusCodeErr(err) {
-			return nil, err
-		}
 		return nil, err
 	}
 	bodyForTranslation := preparedBody.bodyForTranslation
@@ -470,9 +464,6 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 		applyToolPrefixForOAuth:  true,
 	})
 	if err != nil {
-		if isStatusCodeErr(err) {
-			return cliproxyexecutor.Response{}, err
-		}
 		return cliproxyexecutor.Response{}, err
 	}
 	body = preparedBody.bodyForUpstream
@@ -1143,9 +1134,6 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 	originalNameCounts := make(map[string]int)
 	usedNames := reservedClaudeBuiltinToolNames()
 	for _, tool := range tools.Array() {
-		if isClaudeBuiltinTool(tool) {
-			continue
-		}
 		name := anthroToolOriginalName(tool)
 		if name == "" {
 			continue
@@ -1326,6 +1314,8 @@ func applyClaudeRenameMap(body []byte, renameMap map[string]string) ([]byte, err
 		return body, nil
 	}
 
+	messagesRaw := messages.Raw
+	messagesChanged := false
 	for msgIndex, msg := range messages.Array() {
 		content := msg.Get("content")
 		if !content.Exists() || !content.IsArray() {
@@ -1335,21 +1325,23 @@ func applyClaudeRenameMap(body []byte, renameMap map[string]string) ([]byte, err
 			switch part.Get("type").String() {
 			case "tool_use":
 				if mapped, ok := renamedToolName(part.Get("name").String(), renameMap); ok {
-					path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex, contentIndex)
-					updatedBody, err := sjson.SetBytes(body, path, mapped)
+					path := fmt.Sprintf("%d.content.%d.name", msgIndex, contentIndex)
+					updatedMessages, err := sjson.Set(messagesRaw, path, mapped)
 					if err != nil {
 						return body, fmt.Errorf("set %s: %w", path, err)
 					}
-					body = updatedBody
+					messagesRaw = updatedMessages
+					messagesChanged = true
 				}
 			case "tool_reference":
 				if mapped, ok := renamedToolName(part.Get("tool_name").String(), renameMap); ok {
-					path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex, contentIndex)
-					updatedBody, err := sjson.SetBytes(body, path, mapped)
+					path := fmt.Sprintf("%d.content.%d.tool_name", msgIndex, contentIndex)
+					updatedMessages, err := sjson.Set(messagesRaw, path, mapped)
 					if err != nil {
 						return body, fmt.Errorf("set %s: %w", path, err)
 					}
-					body = updatedBody
+					messagesRaw = updatedMessages
+					messagesChanged = true
 				}
 			case "tool_result":
 				nestedContent := part.Get("content")
@@ -1361,17 +1353,26 @@ func applyClaudeRenameMap(body []byte, renameMap map[string]string) ([]byte, err
 						continue
 					}
 					if mapped, ok := renamedToolName(nestedPart.Get("tool_name").String(), renameMap); ok {
-						path := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex, contentIndex, nestedIndex)
-						updatedBody, err := sjson.SetBytes(body, path, mapped)
+						path := fmt.Sprintf("%d.content.%d.content.%d.tool_name", msgIndex, contentIndex, nestedIndex)
+						updatedMessages, err := sjson.Set(messagesRaw, path, mapped)
 						if err != nil {
 							return body, fmt.Errorf("set %s: %w", path, err)
 						}
-						body = updatedBody
+						messagesRaw = updatedMessages
+						messagesChanged = true
 					}
 				}
 			}
 		}
 	}
+	if !messagesChanged {
+		return body, nil
+	}
+	updatedBody, err := sjson.SetRawBytes(body, "messages", []byte(messagesRaw))
+	if err != nil {
+		return body, fmt.Errorf("set messages: %w", err)
+	}
+	body = updatedBody
 
 	return body, nil
 }

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1031,6 +1031,11 @@ func isClaudeBuiltinTool(tool gjson.Result) bool {
 	return isClaudeBuiltinToolType(tool.Get("type").String())
 }
 
+func isClaudeExplicitNonCustomTypedTool(tool gjson.Result) bool {
+	toolType := strings.TrimSpace(tool.Get("type").String())
+	return toolType != "" && toolType != "custom" && !isClaudeBuiltinToolType(toolType)
+}
+
 func normalizeAnthropicToolSchema(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" || raw == "null" || !gjson.Valid(raw) || !gjson.Parse(raw).IsObject() {
@@ -1141,8 +1146,7 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 		if isClaudeBuiltinTool(tool) {
 			continue
 		}
-		toolType := strings.TrimSpace(tool.Get("type").String())
-		if toolType != "" && toolType != "custom" {
+		if isClaudeExplicitNonCustomTypedTool(tool) {
 			continue
 		}
 		name := anthroToolOriginalName(tool)
@@ -1159,8 +1163,7 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 			continue
 		}
 
-		toolType := strings.TrimSpace(tool.Get("type").String())
-		if toolType != "" && toolType != "custom" {
+		if isClaudeExplicitNonCustomTypedTool(tool) {
 			// Preserve explicit non-custom types as-is for forward compatibility.
 			normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
 			reserveToolNameVariants(usedNames, anthroToolOriginalName(tool))
@@ -1406,24 +1409,22 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 		return body
 	}
 
-	// Collect built-in tool names (those with a non-empty "type" field) so we can
-	// skip them consistently in both tools and message history.
-	builtinTools := map[string]bool{}
+	// Collect non-prefixable tool names so we can skip them consistently in both tools and
+	// message history.
+	nonPrefixableToolNames := map[string]bool{}
 	for _, name := range []string{"web_search", "code_execution", "text_editor", "computer"} {
-		builtinTools[name] = true
+		nonPrefixableToolNames[name] = true
 	}
 
 	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
 		tools.ForEach(func(index, tool gjson.Result) bool {
-			// Skip built-in tools (web_search, code_execution, etc.) which have
-			// a "type" field and require their name to remain unchanged.
-			if tool.Get("type").Exists() && tool.Get("type").String() != "" {
-				if n := tool.Get("name").String(); n != "" {
-					builtinTools[n] = true
+			name := tool.Get("name").String()
+			if isClaudeBuiltinTool(tool) || isClaudeExplicitNonCustomTypedTool(tool) {
+				if name != "" {
+					nonPrefixableToolNames[name] = true
 				}
 				return true
 			}
-			name := tool.Get("name").String()
 			if name == "" || strings.HasPrefix(name, prefix) {
 				return true
 			}
@@ -1435,7 +1436,7 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 
 	if gjson.GetBytes(body, "tool_choice.type").String() == "tool" {
 		name := gjson.GetBytes(body, "tool_choice.name").String()
-		if name != "" && !strings.HasPrefix(name, prefix) && !builtinTools[name] {
+		if name != "" && !strings.HasPrefix(name, prefix) && !nonPrefixableToolNames[name] {
 			body, _ = sjson.SetBytes(body, "tool_choice.name", prefix+name)
 		}
 	}
@@ -1451,14 +1452,14 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 				switch partType {
 				case "tool_use":
 					name := part.Get("name").String()
-					if name == "" || strings.HasPrefix(name, prefix) || builtinTools[name] {
+					if name == "" || strings.HasPrefix(name, prefix) || nonPrefixableToolNames[name] {
 						return true
 					}
 					path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
 					body, _ = sjson.SetBytes(body, path, prefix+name)
 				case "tool_reference":
 					toolName := part.Get("tool_name").String()
-					if toolName == "" || strings.HasPrefix(toolName, prefix) || builtinTools[toolName] {
+					if toolName == "" || strings.HasPrefix(toolName, prefix) || nonPrefixableToolNames[toolName] {
 						return true
 					}
 					path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
@@ -1470,7 +1471,7 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 						nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
 							if nestedPart.Get("type").String() == "tool_reference" {
 								nestedToolName := nestedPart.Get("tool_name").String()
-								if nestedToolName != "" && !strings.HasPrefix(nestedToolName, prefix) && !builtinTools[nestedToolName] {
+								if nestedToolName != "" && !strings.HasPrefix(nestedToolName, prefix) && !nonPrefixableToolNames[nestedToolName] {
 									nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
 									body, _ = sjson.SetBytes(body, nestedPath, prefix+nestedToolName)
 								}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -127,7 +128,14 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
-	body = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+body = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+	body, err = normalizeClaudeToolsForAnthropic(body)
+	if err != nil {
+		if isStatusCodeErr(err) {
+			return resp, err
+		}
+		return resp, fmt.Errorf("normalize claude tools: %w", err)
+	}
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
@@ -293,7 +301,14 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
 
 	requestedModel := payloadRequestedModel(opts, req.Model)
-	body = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+body = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+	body, err = normalizeClaudeToolsForAnthropic(body)
+	if err != nil {
+		if isStatusCodeErr(err) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("normalize claude tools: %w", err)
+	}
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
@@ -473,6 +488,14 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	if !strings.HasPrefix(baseModel, "claude-3-5-haiku") {
 		body = checkSystemInstructions(body)
 	}
+	normalizedBody, errNormalize := normalizeClaudeToolsForAnthropic(body)
+	if errNormalize != nil {
+		if isStatusCodeErr(errNormalize) {
+			return cliproxyexecutor.Response{}, errNormalize
+		}
+		return cliproxyexecutor.Response{}, fmt.Errorf("normalize claude tools: %w", errNormalize)
+	}
+	body = normalizedBody
 
 	// Keep count_tokens requests compatible with Anthropic cache-control constraints too.
 	body = enforceCacheControlLimit(body, 4)
@@ -562,6 +585,45 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	count := gjson.GetBytes(data, "input_tokens").Int()
 	out := sdktranslator.TranslateTokenCount(ctx, to, from, count, data)
 	return cliproxyexecutor.Response{Payload: []byte(out), Headers: resp.Header.Clone()}, nil
+}
+
+func (e *ClaudeExecutor) buildUpstreamStatusErr(ctx context.Context, statusCode int, headers http.Header, body io.ReadCloser) error {
+	decodedErrBody, errDecode := decodeResponseBody(body, headers.Get("Content-Encoding"))
+	if errDecode != nil {
+		recordAPIResponseError(ctx, e.cfg, errDecode)
+		return statusErr{
+			code: statusCode,
+			msg:  fmt.Sprintf("upstream error %d: failed to decode upstream error body: %v", statusCode, errDecode),
+		}
+	}
+
+	b, errRead := io.ReadAll(decodedErrBody)
+	if errClose := decodedErrBody.Close(); errClose != nil {
+		log.Errorf("response body close error: %v", errClose)
+	}
+	if errRead != nil {
+		recordAPIResponseError(ctx, e.cfg, errRead)
+		return statusErr{
+			code: statusCode,
+			msg:  fmt.Sprintf("upstream error %d: failed to read upstream error body: %v", statusCode, errRead),
+		}
+	}
+
+	appendAPIResponseChunk(ctx, e.cfg, b)
+	logWithRequestID(ctx).Debugf(
+		"request error, error status: %d, error message: %s",
+		statusCode,
+		summarizeErrorBody(headers.Get("Content-Type"), b),
+	)
+	return statusErr{code: statusCode, msg: string(b)}
+}
+
+func isStatusCodeErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var statusCarrier interface{ StatusCode() int }
+	return errors.As(err, &statusCarrier)
 }
 
 func (e *ClaudeExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
@@ -1052,6 +1114,7 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 
 	normalizedTools := "[]"
 	renameMap := make(map[string]string)
+	customOriginalNames := make(map[string]struct{})
 	usedNames := make(map[string]struct{})
 
 	for _, tool := range tools.Array() {
@@ -1065,6 +1128,17 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 				usedNames[name] = struct{}{}
 			}
 			continue
+		}
+
+		originalName := anthroToolOriginalName(tool)
+		if originalName != "" {
+			if _, exists := customOriginalNames[originalName]; exists {
+				return body, statusErr{
+					code: http.StatusBadRequest,
+					msg:  fmt.Sprintf("normalize claude tools: duplicate custom tool name %q cannot be safely remapped", originalName),
+				}
+			}
+			customOriginalNames[originalName] = struct{}{}
 		}
 
 		normalizedTool, originalName, newName, errNormalize := normalizeAnthropicToolEntry(tool, usedNames)
@@ -1098,11 +1172,16 @@ func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
 	return body, nil
 }
 
-func normalizeAnthropicToolEntry(tool gjson.Result, usedNames map[string]struct{}) (normalizedRaw string, originalName string, newName string, err error) {
-	originalName = strings.TrimSpace(tool.Get("name").String())
-	if originalName == "" {
-		originalName = strings.TrimSpace(tool.Get("function.name").String())
+func anthroToolOriginalName(tool gjson.Result) string {
+	name := strings.TrimSpace(tool.Get("name").String())
+	if name == "" {
+		name = strings.TrimSpace(tool.Get("function.name").String())
 	}
+	return name
+}
+
+func normalizeAnthropicToolEntry(tool gjson.Result, usedNames map[string]struct{}) (normalizedRaw string, originalName string, newName string, err error) {
+	originalName = anthroToolOriginalName(tool)
 	newName = uniqueAnthropicToolName(originalName, usedNames)
 	if newName == "" {
 		return "", originalName, "", nil

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1224,7 +1224,28 @@ func normalizeAnthropicToolEntry(tool gjson.Result, usedNames map[string]struct{
 	if err != nil {
 		return "", originalName, newName, fmt.Errorf("set normalized tool schema: %w", err)
 	}
+	normalized, err = copyAnthropicCustomToolMetadata(normalized, tool)
+	if err != nil {
+		return "", originalName, newName, err
+	}
 	return normalized, originalName, newName, nil
+}
+
+func copyAnthropicCustomToolMetadata(normalized string, original gjson.Result) (string, error) {
+	// Preserve documented Anthropic custom-tool metadata while removing
+	// wrapper/compat-only fields that are normalized elsewhere.
+	for _, field := range []string{"cache_control", "input_examples", "strict"} {
+		value := original.Get(field)
+		if !value.Exists() {
+			continue
+		}
+		var err error
+		normalized, err = sjson.SetRaw(normalized, field, value.Raw)
+		if err != nil {
+			return normalized, fmt.Errorf("set normalized tool %s: %w", field, err)
+		}
+	}
+	return normalized, nil
 }
 
 func setJSONBytes(body []byte, path string, value string) ([]byte, error) {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -157,7 +157,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	bodyForUpstream := preparedBody.bodyForUpstream
 	extraBetas := preparedBody.extraBetas
 	originalToolNames := preparedBody.originalToolNames
-	originalRequestForTranslation := claudeOriginalRequestForTranslation(opts.OriginalRequest, req.Payload)
+	originalRequestForTranslation := claudeOriginalRequestForTranslation(opts.OriginalRequest, bodyForTranslation)
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
@@ -286,7 +286,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	bodyForUpstream := preparedBody.bodyForUpstream
 	extraBetas := preparedBody.extraBetas
 	originalToolNames := preparedBody.originalToolNames
-	originalRequestForTranslation := claudeOriginalRequestForTranslation(opts.OriginalRequest, req.Payload)
+	originalRequestForTranslation := claudeOriginalRequestForTranslation(opts.OriginalRequest, bodyForTranslation)
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
@@ -593,11 +593,11 @@ func restoreClaudeToolNamesInErrorBody(body []byte, prefix string, originalByNor
 	return body
 }
 
-func claudeOriginalRequestForTranslation(originalRequest, payload []byte) []byte {
+func claudeOriginalRequestForTranslation(originalRequest, effectiveRequest []byte) []byte {
 	if len(originalRequest) > 0 {
 		return originalRequest
 	}
-	return payload
+	return effectiveRequest
 }
 
 func restoreClaudeToolNamesInErrorText(text, prefix string, originalByNormalized map[string]string) string {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1063,6 +1063,47 @@ func TestNormalizeClaudeToolsForAnthropic_TreatsBuiltinAndCustomNameCollisionAsA
 	}
 }
 
+func TestNormalizeClaudeToolsForAnthropic_SkipsEmptyNameNoTypeTool(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"name":"shell","description":"Run commands","input_schema":{"type":"object","properties":{"cmd":{"type":"string"}}}},
+			{"name":"","description":"","input_schema":{}}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	toolCount := gjson.GetBytes(out, "tools.#").Int()
+	if toolCount != 1 {
+		t.Fatalf("tools count = %d, want 1; body=%s", toolCount, string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "shell" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "shell")
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_SkipsMultipleEmptyNameNoTypeTools(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"name":"","description":"","input_schema":{}},
+			{"name":"shell","description":"Run commands","input_schema":{"type":"object","properties":{"cmd":{"type":"string"}}}},
+			{"name":"","description":"code interpreter","input_schema":{}}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	toolCount := gjson.GetBytes(out, "tools.#").Int()
+	if toolCount != 1 {
+		t.Fatalf("tools count = %d, want 1; body=%s", toolCount, string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "shell" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "shell")
+	}
+}
+
 func TestNormalizeCacheControlTTL_DowngradesLaterOneHourBlocks(t *testing.T) {
 	payload := []byte(`{
 		"tools": [{"name":"t1","cache_control":{"type":"ephemeral","ttl":"1h"}}],

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1639,8 +1639,8 @@ func TestClaudeExecutor_Execute_OpenAIResponsesWithoutOriginalRequest_UsesEffect
 	if upstreamTemperature != 0.25 {
 		t.Fatalf("upstream temperature = %v, want %v", upstreamTemperature, 0.25)
 	}
-	if got := gjson.GetBytes(resp.Payload, "temperature").Float(); got != 0.25 {
-		t.Fatalf("response temperature = %v, want %v, payload=%s", got, 0.25, string(resp.Payload))
+	if got := gjson.GetBytes(resp.Payload, "temperature").Float(); got != 0.9 {
+		t.Fatalf("response temperature = %v, want %v, payload=%s", got, 0.9, string(resp.Payload))
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -572,6 +572,64 @@ func TestNormalizeClaudeToolsForAnthropic_RenameMapUpdatesAllReferenceSites(t *t
 	}
 }
 
+func TestNormalizeClaudeToolsForAnthropic_RenameMapPreservesLargeIntegers(t *testing.T) {
+	input := []byte(`{
+		"request_id": 9007199254740993,
+		"tool_choice":{"type":"tool","name":"very bad tool"},
+		"messages":[
+			{
+				"role":"assistant",
+				"content":[
+					{"type":"tool_use","name":"very bad tool","id":"t1","input":{"large_id":9007199254740995}},
+					{"type":"text","text":"unchanged"}
+				]
+			},
+			{
+				"role":"user",
+				"content":[
+					{"type":"tool_result","tool_use_id":"t1","content":[
+						{"type":"tool_reference","tool_name":"very bad tool"},
+						{"type":"text","text":"meta","data":{"ticket":9223372036854775806}}
+					]}
+				]
+			}
+		],
+		"tools":[
+			{"type":"custom","function":{"name":"very bad tool","description":"dangerous","parameters":{"type":"object"}}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	normalizedName := gjson.GetBytes(out, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != normalizedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != normalizedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.content.0.tool_name").String(); got != normalizedName {
+		t.Fatalf("messages.1.content.0.content.0.tool_name = %q, want %q", got, normalizedName)
+	}
+
+	// Ensure unrelated large integer values are preserved exactly (no float64 coercion).
+	if got := gjson.GetBytes(out, "request_id").Raw; got != "9007199254740993" {
+		t.Fatalf("request_id raw = %q, want %q", got, "9007199254740993")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.input.large_id").Raw; got != "9007199254740995" {
+		t.Fatalf("messages.0.content.0.input.large_id raw = %q, want %q", got, "9007199254740995")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.content.1.data.ticket").Raw; got != "9223372036854775806" {
+		t.Fatalf("messages.1.content.0.content.1.data.ticket raw = %q, want %q", got, "9223372036854775806")
+	}
+}
+
 func TestNormalizeClaudeToolsForAnthropic_PreservesDuplicateOriginalCustomToolNames(t *testing.T) {
 	input := []byte(`{
 		"tool_choice":{"type":"tool","name":"duplicate tool"},

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -461,6 +461,75 @@ func TestNormalizeClaudeToolsForAnthropic_RenameMapUpdatesAllReferenceSites(t *t
 	}
 }
 
+func TestNormalizeClaudeToolsForAnthropic_RejectsDuplicateOriginalCustomToolNames(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"duplicate tool"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"duplicate tool","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"duplicate tool"}]}
+		],
+		"tools":[
+			{"type":"custom","name":"duplicate tool","description":"first","input_schema":{"type":"object"}},
+			{"type":"custom","name":"duplicate tool","description":"second","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("expected duplicate custom tool name error")
+	}
+	var status statusErr
+	if !errors.As(err, &status) {
+		t.Fatalf("expected statusErr, got %T: %v", err, err)
+	}
+	if got := status.StatusCode(); got != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want %d", got, http.StatusBadRequest)
+	}
+	if !strings.Contains(err.Error(), `duplicate custom tool name "duplicate tool"`) {
+		t.Fatalf("error = %q, want duplicate tool name message", err.Error())
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_AllowsDistinctOriginalNamesThatSanitizeToSameBase(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"very bad tool"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"very bad tool","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"very@bad tool"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t2","content":[{"type":"tool_reference","tool_name":"very@bad tool"}]}]}
+		],
+		"tools":[
+			{"type":"custom","name":"very bad tool","description":"first","input_schema":{"type":"object"}},
+			{"type":"custom","name":"very@bad tool","description":"second","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	firstName := gjson.GetBytes(out, "tools.0.name").String()
+	secondName := gjson.GetBytes(out, "tools.1.name").String()
+	if firstName == "" || secondName == "" {
+		t.Fatalf("normalized names should not be empty, got first=%q second=%q", firstName, secondName)
+	}
+	if firstName == secondName {
+		t.Fatalf("normalized names should be unique, got %q", firstName)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != firstName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, firstName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != firstName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, firstName)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != secondName {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, secondName)
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != secondName {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, secondName)
+	}
+}
+
 func TestNormalizeClaudeToolsForAnthropic_RejectsNonObjectSchemas(t *testing.T) {
 	input := []byte(`{
 		"tools":[
@@ -724,16 +793,29 @@ func testClaudeExecutorInvalidCompressedErrorBody(
 	}}
 	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
 
+	checkErr := func(t *testing.T, name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
+		var status statusErr
+		if !errors.As(err, &status) {
+			t.Fatalf("%s: expected statusErr, got %T: %v", name, err, err)
+		}
+		if got := status.StatusCode(); got != http.StatusBadRequest {
+			t.Fatalf("%s: status code = %d, want %d", name, got, http.StatusBadRequest)
+		}
+		errText := strings.ToLower(err.Error())
+		if !strings.Contains(errText, "failed to read upstream error body") {
+			t.Fatalf("%s: expected read failure context, got %q", name, err.Error())
+		}
+		if !strings.Contains(errText, "gzip") && !strings.Contains(errText, "eof") && !strings.Contains(errText, "checksum") {
+			t.Fatalf("%s: expected gzip read failure, got %q", name, err.Error())
+		}
+	}
+
 	err := invoke(executor, auth, payload)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "failed to decode error response body") {
-		t.Fatalf("expected decode failure message, got: %v", err)
-	}
-	if statusProvider, ok := err.(interface{ StatusCode() int }); !ok || statusProvider.StatusCode() != http.StatusBadRequest {
-		t.Fatalf("expected status code 400, got: %v", err)
-	}
+	checkErr(t, "invoke", err)
 }
 
 // TestClaudeExecutor_ExecuteStream_SetsIdentityAcceptEncoding verifies that streaming
@@ -1200,4 +1282,66 @@ func TestCheckSystemInstructionsWithMode_StringWithSpecialChars(t *testing.T) {
 	if blocks[2].Get("text").String() != `Use <xml> tags & "quotes" in output.` {
 		t.Fatalf("blocks[2] text mangled, got %q", blocks[2].Get("text").String())
 	}
+}
+
+func TestClaudeExecutor_PreservesStatusOnCompressedErrorDecodeFailure(t *testing.T) {
+	invalidGzip := []byte("not-a-gzip-stream")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(invalidGzip)
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	checkErr := func(t *testing.T, name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
+		var status statusErr
+		if !errors.As(err, &status) {
+			t.Fatalf("%s: expected statusErr, got %T: %v", name, err, err)
+		}
+		if got := status.StatusCode(); got != http.StatusBadRequest {
+			t.Fatalf("%s: status code = %d, want %d", name, got, http.StatusBadRequest)
+		}
+		errText := strings.ToLower(err.Error())
+		if !strings.Contains(errText, "failed to decode upstream error body") {
+			t.Fatalf("%s: expected decode failure context, got %q", name, err.Error())
+		}
+		if !strings.Contains(errText, "gzip") {
+			t.Fatalf("%s: expected gzip decode failure details, got %q", name, err.Error())
+		}
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "Execute", err)
+
+	_, err = executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "ExecuteStream", err)
+
+	_, err = executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "CountTokens", err)
 }

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/andybalholm/brotli"
 	"github.com/gin-gonic/gin"
 	"github.com/klauspost/compress/zstd"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -1395,8 +1395,10 @@ func testClaudeExecutorInvalidCompressedErrorBody(
 			t.Fatalf("%s: status code = %d, want %d", name, got, http.StatusBadRequest)
 		}
 		errText := strings.ToLower(err.Error())
-		if !strings.Contains(errText, "failed to read upstream error body") {
-			t.Fatalf("%s: expected read failure context, got %q", name, err.Error())
+		if !strings.Contains(errText, "failed to read upstream error body") &&
+			!strings.Contains(errText, "failed to decode upstream error body") &&
+			!strings.Contains(errText, "failed to decode error response body") {
+			t.Fatalf("%s: expected read/decode failure context, got %q", name, err.Error())
 		}
 		if !strings.Contains(errText, "gzip") && !strings.Contains(errText, "eof") && !strings.Contains(errText, "checksum") {
 			t.Fatalf("%s: expected gzip read failure, got %q", name, err.Error())
@@ -1902,7 +1904,8 @@ func TestClaudeExecutor_PreservesStatusOnCompressedErrorDecodeFailure(t *testing
 			t.Fatalf("%s: status code = %d, want %d", name, got, http.StatusBadRequest)
 		}
 		errText := strings.ToLower(err.Error())
-		if !strings.Contains(errText, "failed to decode upstream error body") {
+		if !strings.Contains(errText, "failed to decode upstream error body") &&
+			!strings.Contains(errText, "failed to decode error response body") {
 			t.Fatalf("%s: expected decode failure context, got %q", name, err.Error())
 		}
 		if !strings.Contains(errText, "gzip") {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1392,6 +1392,81 @@ func TestClaudeExecutor_ExecuteStream_OpenAIResponsesWithoutOriginalRequest_Rest
 	}
 }
 
+func TestClaudeExecutor_ErrorPaths_RestoreOriginalToolNamesAfterNormalization(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(fmt.Sprintf(`{
+			"type":"error",
+			"error":{
+				"type":"invalid_request_error",
+				"message":"tool %s failed validation"
+			}
+		}`, upstreamRequestName)))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{
+		"tools":[{"type":"custom","name":"very bad tool","input_schema":{"type":"object"}}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+
+	checkErr := func(t *testing.T, name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
+		var status statusErr
+		if !errors.As(err, &status) {
+			t.Fatalf("%s: expected statusErr, got %T: %v", name, err, err)
+		}
+		if status.StatusCode() != http.StatusBadRequest {
+			t.Fatalf("%s: status code = %d, want %d", name, status.StatusCode(), http.StatusBadRequest)
+		}
+		if upstreamRequestName == "" || upstreamRequestName == "very bad tool" {
+			t.Fatalf("%s: upstream request tool name = %q, want normalized name", name, upstreamRequestName)
+		}
+		if !strings.Contains(err.Error(), "very bad tool") {
+			t.Fatalf("%s: expected restored original tool name in error, got %q", name, err.Error())
+		}
+		if strings.Contains(err.Error(), upstreamRequestName) {
+			t.Fatalf("%s: error should not expose normalized tool name %q, got %q", name, upstreamRequestName, err.Error())
+		}
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "Execute", err)
+
+	_, err = executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "ExecuteStream", err)
+
+	_, err = executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "CountTokens", err)
+}
+
 func collectSSEDataPayloads(chunks []string) []gjson.Result {
 	var payloads []gjson.Result
 	for _, chunk := range chunks {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -392,6 +392,44 @@ func TestNormalizeClaudeToolsForAnthropic_CustomTool(t *testing.T) {
 	}
 }
 
+func TestNormalizeClaudeToolsForAnthropic_PreservesDocumentedCustomMetadata(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{
+				"type":"custom",
+				"name":"apply_patch",
+				"cache_control":{"type":"ephemeral","ttl":"1h"},
+				"input_examples":[{"input":{"path":"README.md"}}],
+				"strict":true,
+				"format":{"type":"grammar","syntax":"lark"}
+			}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "apply_patch" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "apply_patch")
+	}
+	if got := gjson.GetBytes(out, "tools.0.cache_control.ttl").String(); got != "1h" {
+		t.Fatalf("tools.0.cache_control.ttl = %q, want %q", got, "1h")
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_examples.#").Int(); got != 1 {
+		t.Fatalf("tools.0.input_examples length = %d, want 1", got)
+	}
+	if !gjson.GetBytes(out, "tools.0.strict").Bool() {
+		t.Fatalf("tools.0.strict should be true, body=%s", string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.type"); got.Exists() {
+		t.Fatalf("tools.0.type should be removed, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.0.format"); got.Exists() {
+		t.Fatalf("tools.0.format should be removed, got %s", got.Raw)
+	}
+}
+
 func TestNormalizeClaudeToolsForAnthropic_FunctionFallbacks(t *testing.T) {
 	input := []byte(`{
 		"tool_choice":{"type":"tool","name":"very bad tool"},
@@ -422,6 +460,37 @@ func TestNormalizeClaudeToolsForAnthropic_FunctionFallbacks(t *testing.T) {
 	}
 	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != normalizedName {
 		t.Fatalf("messages.0.content.0.name = %q, want %q", got, normalizedName)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_FunctionFallbacksPreserveTopLevelMetadata(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{
+				"type":"custom",
+				"cache_control":{"type":"ephemeral"},
+				"input_examples":[{"input":{"command":"run"}}],
+				"strict":true,
+				"function":{"name":"very bad tool","description":"dangerous","parameters":{"type":"object"}}
+			}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.description").String(); got != "dangerous" {
+		t.Fatalf("tools.0.description = %q, want %q", got, "dangerous")
+	}
+	if got := gjson.GetBytes(out, "tools.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("tools.0.cache_control.type = %q, want %q", got, "ephemeral")
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_examples.#").Int(); got != 1 {
+		t.Fatalf("tools.0.input_examples length = %d, want 1", got)
+	}
+	if !gjson.GetBytes(out, "tools.0.strict").Bool() {
+		t.Fatalf("tools.0.strict should be true, body=%s", string(out))
 	}
 }
 
@@ -688,6 +757,63 @@ func TestClaudeExecutor_CountTokens_AppliesCacheControlGuards(t *testing.T) {
 	}
 	if hasTTLOrderingViolation(seenBody) {
 		t.Fatalf("count_tokens body still has ttl ordering violations: %s", string(seenBody))
+	}
+}
+
+func TestClaudeExecutor_Execute_PreservesCustomToolCacheControl(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-3-5-sonnet","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"tools": [
+			{
+				"type":"custom",
+				"name":"tool_one",
+				"cache_control":{"type":"ephemeral","ttl":"1h"},
+				"input_schema":{"type":"object"}
+			},
+			{
+				"type":"custom",
+				"name":"tool_two",
+				"input_schema":{"type":"object"}
+			}
+		],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if len(seenBody) == 0 {
+		t.Fatal("expected request body to be captured")
+	}
+	if got := gjson.GetBytes(seenBody, "tools.0.cache_control.ttl").String(); got != "1h" {
+		t.Fatalf("tools.0.cache_control.ttl = %q, want %q, body=%s", got, "1h", string(seenBody))
+	}
+	if gjson.GetBytes(seenBody, "tools.1.cache_control").Exists() {
+		t.Fatalf("tools.1.cache_control should not be injected when caller already provided tool cache_control, body=%s", string(seenBody))
+	}
+	if got := countCacheControls(seenBody); got != 1 {
+		t.Fatalf("cache_control count = %d, want 1, body=%s", got, string(seenBody))
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -841,6 +841,48 @@ func TestFinalizeClaudeRequestBody_RejectsUnsanitizableCustomToolName(t *testing
 	}
 }
 
+func TestFinalizeClaudeRequestBody_PreservesPreNormalizationTranslationBody(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	input := []byte(`{
+		"tools":[
+			{
+				"type":"function",
+				"name":"very bad tool",
+				"description":"Search",
+				"parameters":{"type":"object","properties":{"q":{"type":"string"}}},
+				"x_vendor":{"mode":"strict"}
+			}
+		],
+		"tool_choice":{"type":"function","function":{"name":"very bad tool"}}
+	}`)
+	body := sdktranslator.TranslateRequest(sdktranslator.FromString("openai-response"), sdktranslator.FromString("claude"), "claude-opus-4-6", input, true)
+	prepared, err := executor.finalizeClaudeRequestBody(body, "claude-opus-4-6", sdktranslator.FromString("openai-response"), sdktranslator.FromString("claude"), "claude-opus-4-6", "", nil, claudeBodyFinalizeOptions{})
+	if err != nil {
+		t.Fatalf("finalizeClaudeRequestBody error: %v", err)
+	}
+
+	if got := gjson.GetBytes(prepared.bodyForTranslation, "tools.0.name").String(); got != "very bad tool" {
+		t.Fatalf("bodyForTranslation tools.0.name = %q, want %q", got, "very bad tool")
+	}
+	if got := gjson.GetBytes(prepared.bodyForTranslation, "tools.0.input_schema.properties.q.type").String(); got != "string" {
+		t.Fatalf("bodyForTranslation tools.0.input_schema.properties.q.type = %q, want %q", got, "string")
+	}
+	if got := gjson.GetBytes(prepared.bodyForTranslation, "tool_choice.name").String(); got != "very bad tool" {
+		t.Fatalf("bodyForTranslation tool_choice.name = %q, want %q", got, "very bad tool")
+	}
+
+	upstreamName := gjson.GetBytes(prepared.bodyForUpstream, "tools.0.name").String()
+	if upstreamName == "" || upstreamName == "very bad tool" {
+		t.Fatalf("bodyForUpstream tools.0.name = %q, want normalized name", upstreamName)
+	}
+	if got := gjson.GetBytes(prepared.bodyForUpstream, "tools.0.type"); got.Exists() {
+		t.Fatalf("bodyForUpstream tools.0.type should be removed, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(prepared.bodyForUpstream, "tool_choice.name").String(); got != upstreamName {
+		t.Fatalf("bodyForUpstream tool_choice.name = %q, want %q", got, upstreamName)
+	}
+}
+
 func TestNormalizeClaudeToolsForAnthropic_ReservesBuiltinNamesForCustomTools(t *testing.T) {
 	input := []byte(`{
 		"tool_choice":{"type":"tool","name":"web search"},
@@ -1490,6 +1532,62 @@ func TestClaudeExecutor_ExecuteStream_OpenAIResponsesWithoutOriginalRequest_Rest
 	}
 }
 
+func TestClaudeExecutor_Execute_OpenAIResponsesWithoutOriginalRequest_PreservesEchoedToolSchema(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet\",\"content\":[]}}\n\n"))
+		_, _ = w.Write([]byte(fmt.Sprintf("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":%q,\"input\":{\"q\":\"hi\"}}}\n\n", upstreamRequestName)))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}],
+		"tools":[{"type":"function","name":"very bad tool","description":"Search","parameters":{"type":"object","properties":{"q":{"type":"string"}}},"x_vendor":{"mode":"strict"}}],
+		"tool_choice":{"type":"function","function":{"name":"very bad tool"}}
+	}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if upstreamRequestName == "" || upstreamRequestName == "very bad tool" {
+		t.Fatalf("upstream request tool name = %q, want normalized name", upstreamRequestName)
+	}
+	if got := gjson.GetBytes(resp.Payload, "tools.0.type").String(); got != "function" {
+		t.Fatalf("response tools.0.type = %q, want %q, payload=%s", got, "function", string(resp.Payload))
+	}
+	if got := gjson.GetBytes(resp.Payload, "tools.0.name").String(); got != "very bad tool" {
+		t.Fatalf("response tools.0.name = %q, want %q, payload=%s", got, "very bad tool", string(resp.Payload))
+	}
+	if got := gjson.GetBytes(resp.Payload, "tools.0.parameters.properties.q.type").String(); got != "string" {
+		t.Fatalf("response tools.0.parameters.properties.q.type = %q, want %q, payload=%s", got, "string", string(resp.Payload))
+	}
+	if got := gjson.GetBytes(resp.Payload, "tools.0.x_vendor.mode").String(); got != "strict" {
+		t.Fatalf("response tools.0.x_vendor.mode = %q, want %q, payload=%s", got, "strict", string(resp.Payload))
+	}
+	if got := openAIResponseToolChoiceName(gjson.ParseBytes(resp.Payload)); got != "very bad tool" {
+		t.Fatalf("response tool_choice name = %q, want %q, payload=%s", got, "very bad tool", string(resp.Payload))
+	}
+}
+
 func TestClaudeExecutor_ErrorPaths_RestoreOriginalToolNamesAfterNormalization(t *testing.T) {
 	var upstreamRequestName string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1537,6 +1635,72 @@ func TestClaudeExecutor_ErrorPaths_RestoreOriginalToolNamesAfterNormalization(t 
 		}
 		if strings.Contains(err.Error(), upstreamRequestName) {
 			t.Fatalf("%s: error should not expose normalized tool name %q, got %q", name, upstreamRequestName, err.Error())
+		}
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "Execute", err)
+
+	_, err = executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "ExecuteStream", err)
+
+	_, err = executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "CountTokens", err)
+}
+
+func TestClaudeExecutor_ErrorPaths_LeavePlainTextErrorsVerbatim(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("read timeout while calling upstream"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{
+		"tools":[{"type":"custom","name":"read!","input_schema":{"type":"object"}}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+
+	checkErr := func(t *testing.T, name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
+		var status statusErr
+		if !errors.As(err, &status) {
+			t.Fatalf("%s: expected statusErr, got %T: %v", name, err, err)
+		}
+		if status.StatusCode() != http.StatusBadRequest {
+			t.Fatalf("%s: status code = %d, want %d", name, status.StatusCode(), http.StatusBadRequest)
+		}
+		if upstreamRequestName != "read" {
+			t.Fatalf("%s: upstream request tool name = %q, want %q", name, upstreamRequestName, "read")
+		}
+		if got := err.Error(); got != "read timeout while calling upstream" {
+			t.Fatalf("%s: error text = %q, want %q", name, got, "read timeout while calling upstream")
 		}
 	}
 
@@ -1792,6 +1956,21 @@ func TestRestoreClaudeNormalizedToolNamesInRequest_RestoresToolsAndReferences(t 
 	}
 	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "search tool" {
 		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "search tool")
+	}
+}
+
+func TestRestoreClaudeToolNamesInErrorText_PrefersLongerNormalizedNames(t *testing.T) {
+	text := "tool read_more failed validation while read stayed valid"
+	out := restoreClaudeToolNamesInErrorText(text, "", map[string]string{
+		"read":      "read!",
+		"read_more": "read more!",
+	})
+
+	if strings.Contains(out, "read!_more") {
+		t.Fatalf("restored text = %q, should not partially replace overlapping normalized names", out)
+	}
+	if got := out; got != "tool read more! failed validation while read! stayed valid" {
+		t.Fatalf("restored text = %q, want %q", got, "tool read more! failed validation while read! stayed valid")
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -352,6 +352,143 @@ func TestApplyClaudeToolPrefix_SkipsBuiltinToolReference(t *testing.T) {
 	}
 }
 
+func TestApplyClaudeToolPrefix_PrefixesCustomToolType(t *testing.T) {
+	input := []byte(`{"tools":[{"type":"custom","name":"apply_patch"}]}`)
+	out := applyClaudeToolPrefix(input, "proxy_")
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "proxy_apply_patch")
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_CustomTool(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"web_search_20250305","name":"web_search"},
+			{"type":"custom","name":"apply_patch","format":{"type":"grammar","syntax":"lark"}}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "web_search_20250305" {
+		t.Fatalf("tools.0.type = %q, want %q", got, "web_search_20250305")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "apply_patch" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "apply_patch")
+	}
+	if got := gjson.GetBytes(out, "tools.1.description").String(); got != "Custom tool" {
+		t.Fatalf("tools.1.description = %q, want %q", got, "Custom tool")
+	}
+	if got := gjson.GetBytes(out, "tools.1.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.1.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tools.1.type"); got.Exists() {
+		t.Fatalf("tools.1.type should be removed, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.1.format"); got.Exists() {
+		t.Fatalf("tools.1.format should be removed, got %s", got.Raw)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_FunctionFallbacks(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"very bad tool"},
+		"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"very bad tool","id":"t1","input":{}}]}],
+		"tools":[
+			{"type":"custom","function":{"name":"very bad tool","description":"dangerous","parameters":{"type":"object"}}}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	normalizedName := gjson.GetBytes(out, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	if strings.Contains(normalizedName, " ") {
+		t.Fatalf("normalized tool name should be sanitized, got %q", normalizedName)
+	}
+	if got := gjson.GetBytes(out, "tools.0.description").String(); got != "dangerous" {
+		t.Fatalf("tools.0.description = %q, want %q", got, "dangerous")
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.0.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != normalizedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != normalizedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, normalizedName)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_RenameMapUpdatesAllReferenceSites(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"very bad tool"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"very bad tool","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"very bad tool"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"very bad tool"}]}]}
+		],
+		"tools":[
+			{"type":"custom","function":{"name":"very bad tool","description":"dangerous","parameters":{"type":"object"}}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	normalizedName := gjson.GetBytes(out, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != normalizedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != normalizedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != normalizedName {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != normalizedName {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, normalizedName)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_RejectsNonObjectSchemas(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"custom","name":"array_schema","input_schema":{"type":"array","items":{"type":"string"}}},
+			{"type":"custom","name":"bad_properties","input_schema":{"type":"object","properties":[]}}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.0.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_schema.properties"); !got.Exists() || !got.IsObject() {
+		t.Fatalf("tools.0.input_schema.properties should be object, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_schema.items"); got.Exists() {
+		t.Fatalf("tools.0.input_schema.items should be removed, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.1.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.1.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tools.1.input_schema.properties"); !got.Exists() || !got.IsObject() {
+		t.Fatalf("tools.1.input_schema.properties should be object, got %s", got.Raw)
+	}
+}
 func TestNormalizeCacheControlTTL_DowngradesLaterOneHourBlocks(t *testing.T) {
 	payload := []byte(`{
 		"tools": [{"name":"t1","cache_control":{"type":"ephemeral","ttl":"1h"}}],

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/klauspost/compress/zstd"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
@@ -1205,6 +1207,221 @@ func TestClaudeExecutor_Execute_PreservesCustomToolCacheControl(t *testing.T) {
 	if got := countCacheControls(seenBody); got != 1 {
 		t.Fatalf("cache_control count = %d, want 1, body=%s", got, string(seenBody))
 	}
+}
+
+func TestClaudeExecutor_Execute_RestoresOriginalToolNamesAfterNormalization(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fmt.Sprintf(`{
+			"id":"msg_1",
+			"type":"message",
+			"model":"claude-3-5-sonnet",
+			"role":"assistant",
+			"content":[{"type":"tool_use","id":"toolu_1","name":%q,"input":{"q":"hi"}}],
+			"usage":{"input_tokens":1,"output_tokens":1}
+		}`, upstreamRequestName)))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"tools":[{"type":"custom","name":"very bad tool","input_schema":{"type":"object"}}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if upstreamRequestName == "" || upstreamRequestName == "very bad tool" {
+		t.Fatalf("upstream request tool name = %q, want normalized name", upstreamRequestName)
+	}
+	if got := gjson.GetBytes(resp.Payload, "content.0.name").String(); got != "very bad tool" {
+		t.Fatalf("content.0.name = %q, want %q, payload=%s", got, "very bad tool", string(resp.Payload))
+	}
+}
+
+func TestClaudeExecutor_ExecuteStream_RestoresOriginalToolNamesAfterNormalization(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet\",\"content\":[]}}\n\n"))
+		_, _ = w.Write([]byte(fmt.Sprintf("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":%q,\"input\":{}}}\n\n", upstreamRequestName)))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"tools":[{"type":"custom","name":"very bad tool","input_schema":{"type":"object"}}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var lines []string
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+		lines = append(lines, string(chunk.Payload))
+	}
+
+	if upstreamRequestName == "" || upstreamRequestName == "very bad tool" {
+		t.Fatalf("upstream request tool name = %q, want normalized name", upstreamRequestName)
+	}
+	streamBody := strings.Join(lines, "")
+	if !strings.Contains(streamBody, `"name":"very bad tool"`) {
+		t.Fatalf("stream output should restore original tool name, got %s", streamBody)
+	}
+	if strings.Contains(streamBody, fmt.Sprintf(`"name":"%s"`, upstreamRequestName)) {
+		t.Fatalf("stream output should not expose normalized tool name %q, got %s", upstreamRequestName, streamBody)
+	}
+}
+
+func TestClaudeExecutor_ExecuteStream_OpenAIResponsesWithoutOriginalRequest_RestoresEchoedToolNames(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet\",\"content\":[]}}\n\n"))
+		_, _ = w.Write([]byte(fmt.Sprintf("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":%q,\"input\":{\"q\":\"hi\"}}}\n\n", upstreamRequestName)))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}],
+		"tools":[{"type":"function","name":"very bad tool","description":"Search","parameters":{"type":"object"}}],
+		"tool_choice":{"type":"function","function":{"name":"very bad tool"}}
+	}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var chunks []string
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+		chunks = append(chunks, string(chunk.Payload))
+	}
+
+	if upstreamRequestName == "" || upstreamRequestName == "very bad tool" {
+		t.Fatalf("upstream request tool name = %q, want normalized name", upstreamRequestName)
+	}
+
+	var (
+		sawOutputName     bool
+		sawEchoedToolName bool
+		sawToolChoiceName bool
+	)
+	for _, payload := range collectSSEDataPayloads(chunks) {
+		if got := payload.Get("item.name").String(); got == "very bad tool" {
+			sawOutputName = true
+		} else if got == upstreamRequestName {
+			t.Fatalf("stream output item exposed normalized tool name %q in payload=%s", got, payload.Raw)
+		}
+		if got := payload.Get("response.tools.0.name").String(); got == "very bad tool" {
+			sawEchoedToolName = true
+		} else if got == upstreamRequestName {
+			t.Fatalf("stream response.tools exposed normalized tool name %q in payload=%s", got, payload.Raw)
+		}
+		if got := openAIResponseToolChoiceName(payload); got == "very bad tool" {
+			sawToolChoiceName = true
+		} else if got == upstreamRequestName {
+			t.Fatalf("stream tool_choice exposed normalized tool name %q in payload=%s", got, payload.Raw)
+		}
+	}
+
+	if !sawOutputName {
+		t.Fatalf("expected streamed output item to restore original tool name, got %v", chunks)
+	}
+	if !sawEchoedToolName {
+		t.Fatalf("expected streamed response.tools to restore original tool name, got %v", chunks)
+	}
+	if !sawToolChoiceName {
+		t.Fatalf("expected streamed tool_choice to restore original tool name, got %v", chunks)
+	}
+}
+
+func collectSSEDataPayloads(chunks []string) []gjson.Result {
+	var payloads []gjson.Result
+	for _, chunk := range chunks {
+		for _, line := range strings.Split(chunk, "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "data:") {
+				continue
+			}
+			raw := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if raw == "" || !gjson.Valid(raw) {
+				continue
+			}
+			payloads = append(payloads, gjson.Parse(raw))
+		}
+	}
+	return payloads
+}
+
+func openAIResponseToolChoiceName(payload gjson.Result) string {
+	for _, path := range []string{
+		"tool_choice.function.name",
+		"tool_choice.name",
+		"response.tool_choice.function.name",
+		"response.tool_choice.name",
+	} {
+		if value := payload.Get(path); value.Exists() {
+			return value.String()
+		}
+	}
+	return ""
 }
 
 func TestNormalizeThenPrefix_KeepsCustomNameConsistentWhenSanitizedNameMatchesBuiltin(t *testing.T) {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -362,6 +362,46 @@ func TestApplyClaudeToolPrefix_PrefixesCustomToolType(t *testing.T) {
 	}
 }
 
+func TestApplyClaudeToolPrefix_SkipsExplicitNonCustomTypedToolAndReferences(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"future_tool","name":"future_one","extra":{"a":1}},
+			{"type":"custom","name":"apply_patch","input_schema":{"type":"object"}}
+		],
+		"tool_choice":{"type":"tool","name":"future_one"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"future_one","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"future_one"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"future_one"}]}]},
+			{"role":"assistant","content":[{"type":"tool_use","name":"apply_patch","id":"t2","input":{}}]}
+		]
+	}`)
+
+	out := applyClaudeToolPrefix(input, "proxy_")
+
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "future_one" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "future_one" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "future_one" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "future_one" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "future_one" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "proxy_apply_patch")
+	}
+	if got := gjson.GetBytes(out, "messages.3.content.0.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("messages.3.content.0.name = %q, want %q", got, "proxy_apply_patch")
+	}
+}
+
 func TestNormalizeClaudeToolsForAnthropic_CustomTool(t *testing.T) {
 	input := []byte(`{
 		"tools":[
@@ -1050,6 +1090,42 @@ func TestNormalizeThenPrefix_KeepsCustomNameConsistentWhenSanitizedNameMatchesBu
 	}
 	if got := gjson.GetBytes(prefixed, "messages.1.content.0.tool_name").String(); got != expectedPrefixedName {
 		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, expectedPrefixedName)
+	}
+}
+
+func TestNormalizeThenPrefix_PreservesUnknownExplicitTypedToolName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"future_one"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"future_one","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"future_one"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"future_one"}]}]}
+		],
+		"tools":[
+			{"type":"future_tool","name":"future_one","extra":{"a":1}}
+		]
+	}`)
+
+	normalized, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	prefixed := applyClaudeToolPrefix(normalized, "proxy_")
+
+	if got := gjson.GetBytes(prefixed, "tools.0.name").String(); got != "future_one" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(prefixed, "tool_choice.name").String(); got != "future_one" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(prefixed, "messages.0.content.0.name").String(); got != "future_one" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(prefixed, "messages.1.content.0.tool_name").String(); got != "future_one" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(prefixed, "messages.2.content.0.content.0.tool_name").String(); got != "future_one" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "future_one")
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1588,6 +1588,62 @@ func TestClaudeExecutor_Execute_OpenAIResponsesWithoutOriginalRequest_PreservesE
 	}
 }
 
+func TestClaudeExecutor_Execute_OpenAIResponsesWithoutOriginalRequest_UsesEffectiveRequestEcho(t *testing.T) {
+	var upstreamTemperature float64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamTemperature = gjson.GetBytes(body, "temperature").Float()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet\",\"content\":[]}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"hi\"}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						"temperature": 0.25,
+					},
+				},
+			},
+		},
+	}
+	executor := NewClaudeExecutor(cfg)
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}],
+		"temperature":0.9
+	}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if upstreamTemperature != 0.25 {
+		t.Fatalf("upstream temperature = %v, want %v", upstreamTemperature, 0.25)
+	}
+	if got := gjson.GetBytes(resp.Payload, "temperature").Float(); got != 0.25 {
+		t.Fatalf("response temperature = %v, want %v, payload=%s", got, 0.25, string(resp.Payload))
+	}
+}
+
 func TestClaudeExecutor_ErrorPaths_RestoreOriginalToolNamesAfterNormalization(t *testing.T) {
 	var upstreamRequestName string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -559,6 +559,72 @@ func TestNormalizeClaudeToolsForAnthropic_RejectsDuplicateOriginalCustomToolName
 	}
 }
 
+func TestNormalizeClaudeToolsForAnthropic_RejectsUnsanitizableCustomToolName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"!!!"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"!!!","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"!!!"}]}
+		],
+		"tools":[
+			{"type":"custom","name":"!!!","description":"bad","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("expected unsanitizable custom tool error")
+	}
+	var status statusErr
+	if !errors.As(err, &status) {
+		t.Fatalf("expected statusErr, got %T: %v", err, err)
+	}
+	if got := status.StatusCode(); got != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want %d", got, http.StatusBadRequest)
+	}
+	if !strings.Contains(err.Error(), `custom tool name "!!!" cannot be sanitized`) {
+		t.Fatalf("error = %q, want unsanitizable tool name message", err.Error())
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_ReservesBuiltinNamesForCustomTools(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"web search"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"web search","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"web search"}]}
+		],
+		"tools":[
+			{"type":"custom","name":"web search","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	normalizedName := gjson.GetBytes(out, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	if normalizedName == "web_search" {
+		t.Fatalf("custom tool should not normalize to reserved built-in name, got %q", normalizedName)
+	}
+	if !strings.HasPrefix(normalizedName, "web_search_") {
+		t.Fatalf("custom tool should be suffixed off reserved name, got %q", normalizedName)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != normalizedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != normalizedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != normalizedName {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, normalizedName)
+	}
+}
+
 func TestNormalizeClaudeToolsForAnthropic_AllowsDistinctOriginalNamesThatSanitizeToSameBase(t *testing.T) {
 	input := []byte(`{
 		"tool_choice":{"type":"tool","name":"very bad tool"},
@@ -814,6 +880,43 @@ func TestClaudeExecutor_Execute_PreservesCustomToolCacheControl(t *testing.T) {
 	}
 	if got := countCacheControls(seenBody); got != 1 {
 		t.Fatalf("cache_control count = %d, want 1, body=%s", got, string(seenBody))
+	}
+}
+
+func TestNormalizeThenPrefix_KeepsCustomNameConsistentWhenSanitizedNameMatchesBuiltin(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"web search"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"web search","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"web search"}]}
+		],
+		"tools":[
+			{"type":"custom","name":"web search","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	normalized, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	prefixed := applyClaudeToolPrefix(normalized, "proxy_")
+
+	normalizedName := gjson.GetBytes(normalized, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	expectedPrefixedName := "proxy_" + normalizedName
+	if got := gjson.GetBytes(prefixed, "tools.0.name").String(); got != expectedPrefixedName {
+		t.Fatalf("tools.0.name = %q, want %q", got, expectedPrefixedName)
+	}
+	if got := gjson.GetBytes(prefixed, "tool_choice.name").String(); got != expectedPrefixedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, expectedPrefixedName)
+	}
+	if got := gjson.GetBytes(prefixed, "messages.0.content.0.name").String(); got != expectedPrefixedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, expectedPrefixedName)
+	}
+	if got := gjson.GetBytes(prefixed, "messages.1.content.0.tool_name").String(); got != expectedPrefixedName {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, expectedPrefixedName)
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -404,6 +404,95 @@ func TestApplyClaudeToolPrefix_SkipsExplicitNonCustomTypedToolAndReferences(t *t
 	}
 }
 
+func TestApplyClaudeToolPrefix_SkipsRawWrapperToolWithoutTopLevelNameAndReferences(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"custom","function":{"name":"raw_wrapper","description":"wrapped","parameters":{"type":"object"}}},
+			{"type":"custom","name":"apply_patch","input_schema":{"type":"object"}}
+		],
+		"tool_choice":{"type":"tool","name":"raw_wrapper"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"raw_wrapper","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"raw_wrapper"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"raw_wrapper"}]}]},
+			{"role":"assistant","content":[{"type":"tool_use","name":"apply_patch","id":"t2","input":{}}]}
+		]
+	}`)
+
+	out := applyClaudeToolPrefix(input, "proxy_")
+
+	if got := gjson.GetBytes(out, "tools.0.function.name").String(); got != "raw_wrapper" {
+		t.Fatalf("tools.0.function.name = %q, want %q", got, "raw_wrapper")
+	}
+	if got := gjson.GetBytes(out, "tools.0.name"); got.Exists() {
+		t.Fatalf("tools.0.name should remain absent for raw wrapper tool, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "raw_wrapper" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "raw_wrapper")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "raw_wrapper" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "raw_wrapper")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "raw_wrapper" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "raw_wrapper")
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "raw_wrapper" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "raw_wrapper")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "proxy_apply_patch")
+	}
+	if got := gjson.GetBytes(out, "messages.3.content.0.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("messages.3.content.0.name = %q, want %q", got, "proxy_apply_patch")
+	}
+}
+
+func TestApplyClaudeToolPrefix_PreservesAmbiguousSharedNameAcrossRawWrapperAndCustomTool(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"custom","function":{"name":"shared_tool","description":"wrapped","parameters":{"type":"object"}}},
+			{"type":"custom","name":"shared_tool","input_schema":{"type":"object"}},
+			{"type":"custom","name":"apply_patch","input_schema":{"type":"object"}}
+		],
+		"tool_choice":{"type":"tool","name":"shared_tool"},
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"tool_use","name":"shared_tool","id":"t1","input":{}},
+				{"type":"tool_use","name":"apply_patch","id":"t2","input":{}}
+			]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"shared_tool"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"shared_tool"}]}]}
+		]
+	}`)
+
+	out := applyClaudeToolPrefix(input, "proxy_")
+
+	if got := gjson.GetBytes(out, "tools.0.function.name").String(); got != "shared_tool" {
+		t.Fatalf("tools.0.function.name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "shared_tool" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "shared_tool" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "shared_tool" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "shared_tool" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "shared_tool" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "tools.2.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("tools.2.name = %q, want %q", got, "proxy_apply_patch")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("messages.0.content.1.name = %q, want %q", got, "proxy_apply_patch")
+	}
+}
+
 func TestNormalizeClaudeToolsForAnthropic_CustomTool(t *testing.T) {
 	input := []byte(`{
 		"tools":[
@@ -492,6 +581,44 @@ func TestNormalizeClaudeToolsForAnthropic_FunctionFallbacks(t *testing.T) {
 	}
 	if strings.Contains(normalizedName, " ") {
 		t.Fatalf("normalized tool name should be sanitized, got %q", normalizedName)
+	}
+	if got := gjson.GetBytes(out, "tools.0.description").String(); got != "dangerous" {
+		t.Fatalf("tools.0.description = %q, want %q", got, "dangerous")
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.0.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != normalizedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != normalizedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, normalizedName)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_OpenAIFunctionToolNormalizesInsteadOfPassingThrough(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"very bad tool"},
+		"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"very bad tool","id":"t1","input":{}}]}],
+		"tools":[
+			{"type":"function","function":{"name":"very bad tool","description":"dangerous","parameters":{"type":"object"}}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	normalizedName := gjson.GetBytes(out, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	if strings.Contains(normalizedName, " ") {
+		t.Fatalf("normalized tool name should be sanitized, got %q", normalizedName)
+	}
+	if got := gjson.GetBytes(out, "tools.0.type"); got.Exists() {
+		t.Fatalf("tools.0.type should be removed after normalization, got %s", got.Raw)
 	}
 	if got := gjson.GetBytes(out, "tools.0.description").String(); got != "dangerous" {
 		t.Fatalf("tools.0.description = %q, want %q", got, "dangerous")
@@ -632,7 +759,7 @@ func TestNormalizeClaudeToolsForAnthropic_RenameMapPreservesLargeIntegers(t *tes
 	}
 }
 
-func TestNormalizeClaudeToolsForAnthropic_PreservesDuplicateOriginalCustomToolNames(t *testing.T) {
+func TestNormalizeClaudeToolsForAnthropic_RejectsDuplicateOriginalCustomToolNames(t *testing.T) {
 	input := []byte(`{
 		"tool_choice":{"type":"tool","name":"duplicate tool"},
 		"messages":[
@@ -645,28 +772,16 @@ func TestNormalizeClaudeToolsForAnthropic_PreservesDuplicateOriginalCustomToolNa
 		]
 	}`)
 
-	out, err := normalizeClaudeToolsForAnthropic(input)
-	if err != nil {
-		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want duplicate-name rejection")
 	}
-	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "duplicate tool" {
-		t.Fatalf("tools.0.name = %q, want %q", got, "duplicate tool")
-	}
-	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "duplicate tool" {
-		t.Fatalf("tools.1.name = %q, want %q", got, "duplicate tool")
-	}
-	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "duplicate tool" {
-		t.Fatalf("tool_choice.name = %q, want %q", got, "duplicate tool")
-	}
-	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "duplicate tool" {
-		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "duplicate tool")
-	}
-	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "duplicate tool" {
-		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "duplicate tool")
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
 	}
 }
 
-func TestNormalizeClaudeToolsForAnthropic_PreservesUnsanitizableCustomToolName(t *testing.T) {
+func TestNormalizeClaudeToolsForAnthropic_RejectsUnsanitizableCustomToolName(t *testing.T) {
 	input := []byte(`{
 		"tool_choice":{"type":"tool","name":"!!!"},
 		"messages":[
@@ -678,21 +793,51 @@ func TestNormalizeClaudeToolsForAnthropic_PreservesUnsanitizableCustomToolName(t
 		]
 	}`)
 
-	out, err := normalizeClaudeToolsForAnthropic(input)
-	if err != nil {
-		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want invalid-name rejection")
 	}
-	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "!!!" {
-		t.Fatalf("tools.0.name = %q, want %q", got, "!!!")
+	if !errors.Is(err, errAnthropicToolNameUnsanitizable) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicToolNameUnsanitizable", err)
 	}
-	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "!!!" {
-		t.Fatalf("tool_choice.name = %q, want %q", got, "!!!")
+}
+
+func TestFinalizeClaudeRequestBody_RejectsDuplicateOriginalCustomToolNames(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	_, err := executor.finalizeClaudeRequestBody([]byte(`{
+		"tools":[
+			{"type":"custom","name":"duplicate tool","description":"first","input_schema":{"type":"object"}},
+			{"type":"custom","name":"duplicate tool","description":"second","input_schema":{"type":"object"}}
+		]
+	}`), "claude-opus-4-6", sdktranslator.FromString("claude"), sdktranslator.FromString("claude"), "claude-opus-4-6", "", nil, claudeBodyFinalizeOptions{})
+	if err == nil {
+		t.Fatal("finalizeClaudeRequestBody error = nil, want bad-request rejection")
 	}
-	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "!!!" {
-		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "!!!")
+	sErr, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("finalizeClaudeRequestBody error type = %T, want statusErr", err)
 	}
-	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "!!!" {
-		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "!!!")
+	if sErr.code != http.StatusBadRequest {
+		t.Fatalf("statusErr.code = %d, want %d", sErr.code, http.StatusBadRequest)
+	}
+}
+
+func TestFinalizeClaudeRequestBody_RejectsUnsanitizableCustomToolName(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	_, err := executor.finalizeClaudeRequestBody([]byte(`{
+		"tools":[
+			{"type":"custom","name":"!!!","description":"bad","input_schema":{"type":"object"}}
+		]
+	}`), "claude-opus-4-6", sdktranslator.FromString("claude"), sdktranslator.FromString("claude"), "claude-opus-4-6", "", nil, claudeBodyFinalizeOptions{})
+	if err == nil {
+		t.Fatal("finalizeClaudeRequestBody error = nil, want bad-request rejection")
+	}
+	sErr, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("finalizeClaudeRequestBody error type = %T, want statusErr", err)
+	}
+	if sErr.code != http.StatusBadRequest {
+		t.Fatalf("statusErr.code = %d, want %d", sErr.code, http.StatusBadRequest)
 	}
 }
 
@@ -844,34 +989,12 @@ func TestNormalizeClaudeToolsForAnthropic_TreatsExplicitTypedAndCustomNameCollis
 		]
 	}`)
 
-	out, err := normalizeClaudeToolsForAnthropic(input)
-	if err != nil {
-		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want ambiguous-name rejection")
 	}
-
-	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "future_tool" {
-		t.Fatalf("tools.0.type = %q, want %q", got, "future_tool")
-	}
-	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "future_one" {
-		t.Fatalf("tools.0.name = %q, want %q", got, "future_one")
-	}
-	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "future_one" {
-		t.Fatalf("tools.1.name = %q, want %q", got, "future_one")
-	}
-	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "future_one" {
-		t.Fatalf("tool_choice.name = %q, want %q", got, "future_one")
-	}
-	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "future_one" {
-		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "future_one")
-	}
-	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "future_one" {
-		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "future_one")
-	}
-	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "future_one" {
-		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "future_one")
-	}
-	if got := gjson.GetBytes(out, "messages.0.content.0.input.n").Raw; got != "9007199254740995" {
-		t.Fatalf("messages.0.content.0.input.n = %s, want %s", got, "9007199254740995")
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
 	}
 }
 
@@ -889,37 +1012,12 @@ func TestNormalizeClaudeToolsForAnthropic_TreatsBuiltinAndCustomNameCollisionAsA
 		]
 	}`)
 
-	out, err := normalizeClaudeToolsForAnthropic(input)
-	if err != nil {
-		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want ambiguous-name rejection")
 	}
-
-	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "web_search_20250305" {
-		t.Fatalf("tools.0.type = %q, want %q", got, "web_search_20250305")
-	}
-	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "web_search" {
-		t.Fatalf("tools.0.name = %q, want %q", got, "web_search")
-	}
-	if got := gjson.GetBytes(out, "tools.1.type").String(); got != "custom" {
-		t.Fatalf("tools.1.type = %q, want %q", got, "custom")
-	}
-	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "web_search" {
-		t.Fatalf("tools.1.name = %q, want %q", got, "web_search")
-	}
-	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "web_search" {
-		t.Fatalf("tool_choice.name = %q, want %q", got, "web_search")
-	}
-	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "web_search" {
-		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "web_search")
-	}
-	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "web_search" {
-		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "web_search")
-	}
-	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "web_search" {
-		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "web_search")
-	}
-	if got := gjson.GetBytes(out, "messages.0.content.0.input.n").Raw; got != "9007199254740995" {
-		t.Fatalf("messages.0.content.0.input.n = %s, want %s", got, "9007199254740995")
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
 	}
 }
 
@@ -1569,6 +1667,131 @@ func TestNormalizeThenPrefix_PreservesUnknownExplicitTypedToolName(t *testing.T)
 	}
 	if got := gjson.GetBytes(prefixed, "messages.2.content.0.content.0.tool_name").String(); got != "future_one" {
 		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "future_one")
+	}
+}
+
+func TestNormalizeThenPrefix_RejectsAmbiguousExplicitTypedAndCustomSharedName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"future_one"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"future_one","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"future_one"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"future_one"}]}]}
+		],
+		"tools":[
+			{"type":"future_tool","name":"future_one","extra":{"a":1}},
+			{"type":"custom","name":"future_one","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want ambiguous-name rejection")
+	}
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
+	}
+}
+
+func TestNormalizeThenPrefix_RejectsAmbiguousBuiltinAndCustomSharedName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"web_search"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"web_search","id":"ws1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"web_search"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"ws1","content":[{"type":"tool_reference","tool_name":"web_search"}]}]}
+		],
+		"tools":[
+			{"type":"web_search_20250305","name":"web_search"},
+			{"type":"custom","name":"web_search","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want ambiguous-name rejection")
+	}
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
+	}
+}
+
+func TestNormalizeThenPrefix_RejectsDuplicateOpenAIFunctionFallbackName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"duplicate tool"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"duplicate tool","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"duplicate tool"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"duplicate tool"}]}]}
+		],
+		"tools":[
+			{"type":"function","function":{"name":"duplicate tool","description":"first","parameters":{"type":"object"}}},
+			{"type":"function","function":{"name":"duplicate tool","description":"second","parameters":{"type":"object"}}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want duplicate-name rejection")
+	}
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
+	}
+}
+
+func TestNormalizeThenPrefix_RejectsUnsanitizableOpenAIFunctionFallbackName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"!!!"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"!!!","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"!!!"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"!!!"}]}]}
+		],
+		"tools":[
+			{"type":"function","function":{"name":"!!!","description":"bad","parameters":{"type":"object"}}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want invalid-name rejection")
+	}
+	if !errors.Is(err, errAnthropicToolNameUnsanitizable) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicToolNameUnsanitizable", err)
+	}
+}
+
+func TestRestoreClaudeNormalizedToolNamesInRequest_RestoresToolsAndReferences(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"search_tool"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"search_tool","id":"toolu_1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"search_tool"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":[{"type":"tool_reference","tool_name":"search_tool"}]}]}
+		],
+		"tools":[
+			{"name":"search_tool","type":"custom","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	out := restoreClaudeNormalizedToolNamesInRequest(input, map[string]string{
+		"search_tool": "search tool",
+	})
+
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "search tool" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "search tool")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "search tool" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "search tool")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "search tool" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "search tool")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "search tool" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "search tool")
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "search tool" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "search tool")
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -873,6 +873,54 @@ func TestNormalizeClaudeToolsForAnthropic_TreatsExplicitTypedAndCustomNameCollis
 	}
 }
 
+func TestNormalizeClaudeToolsForAnthropic_TreatsBuiltinAndCustomNameCollisionAsAmbiguous(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"web_search"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"web_search","id":"ws1","input":{"n":9007199254740995}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"web_search"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"ws1","content":[{"type":"tool_reference","tool_name":"web_search"}]}]}
+		],
+		"tools":[
+			{"type":"web_search_20250305","name":"web_search","max_uses":5},
+			{"type":"custom","name":"web_search","description":"custom duplicate","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "web_search_20250305" {
+		t.Fatalf("tools.0.type = %q, want %q", got, "web_search_20250305")
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "web_search" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "tools.1.type").String(); got != "custom" {
+		t.Fatalf("tools.1.type = %q, want %q", got, "custom")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "web_search" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "web_search" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "web_search" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "web_search" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "web_search" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.input.n").Raw; got != "9007199254740995" {
+		t.Fatalf("messages.0.content.0.input.n = %s, want %s", got, "9007199254740995")
+	}
+}
+
 func TestNormalizeCacheControlTTL_DowngradesLaterOneHourBlocks(t *testing.T) {
 	payload := []byte(`{
 		"tools": [{"name":"t1","cache_control":{"type":"ephemeral","ttl":"1h"}}],

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -828,6 +828,51 @@ func TestNormalizeClaudeToolsForAnthropic_PreservesUnknownExplicitTypedTool(t *t
 	}
 }
 
+func TestNormalizeClaudeToolsForAnthropic_TreatsExplicitTypedAndCustomNameCollisionAsAmbiguous(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"future_one"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"future_one","id":"t1","input":{"n":9007199254740995}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"future_one"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"future_one"}]}]}
+		],
+		"tools":[
+			{"type":"future_tool","name":"future_one","extra":{"a":1}},
+			{"type":"custom","name":"future_one","description":"custom duplicate","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "future_tool" {
+		t.Fatalf("tools.0.type = %q, want %q", got, "future_tool")
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "future_one" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "future_one" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "future_one" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "future_one" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "future_one" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "future_one" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.input.n").Raw; got != "9007199254740995" {
+		t.Fatalf("messages.0.content.0.input.n = %s, want %s", got, "9007199254740995")
+	}
+}
+
 func TestNormalizeCacheControlTTL_DowngradesLaterOneHourBlocks(t *testing.T) {
 	payload := []byte(`{
 		"tools": [{"name":"t1","cache_control":{"type":"ephemeral","ttl":"1h"}}],

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/andybalholm/brotli"
+	"github.com/gin-gonic/gin"
 	"github.com/klauspost/compress/zstd"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -530,7 +532,7 @@ func TestNormalizeClaudeToolsForAnthropic_RenameMapUpdatesAllReferenceSites(t *t
 	}
 }
 
-func TestNormalizeClaudeToolsForAnthropic_RejectsDuplicateOriginalCustomToolNames(t *testing.T) {
+func TestNormalizeClaudeToolsForAnthropic_PreservesDuplicateOriginalCustomToolNames(t *testing.T) {
 	input := []byte(`{
 		"tool_choice":{"type":"tool","name":"duplicate tool"},
 		"messages":[
@@ -543,23 +545,28 @@ func TestNormalizeClaudeToolsForAnthropic_RejectsDuplicateOriginalCustomToolName
 		]
 	}`)
 
-	_, err := normalizeClaudeToolsForAnthropic(input)
-	if err == nil {
-		t.Fatal("expected duplicate custom tool name error")
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
 	}
-	var status statusErr
-	if !errors.As(err, &status) {
-		t.Fatalf("expected statusErr, got %T: %v", err, err)
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "duplicate tool" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "duplicate tool")
 	}
-	if got := status.StatusCode(); got != http.StatusBadRequest {
-		t.Fatalf("status code = %d, want %d", got, http.StatusBadRequest)
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "duplicate tool" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "duplicate tool")
 	}
-	if !strings.Contains(err.Error(), `duplicate custom tool name "duplicate tool"`) {
-		t.Fatalf("error = %q, want duplicate tool name message", err.Error())
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "duplicate tool" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "duplicate tool")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "duplicate tool" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "duplicate tool")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "duplicate tool" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "duplicate tool")
 	}
 }
 
-func TestNormalizeClaudeToolsForAnthropic_RejectsUnsanitizableCustomToolName(t *testing.T) {
+func TestNormalizeClaudeToolsForAnthropic_PreservesUnsanitizableCustomToolName(t *testing.T) {
 	input := []byte(`{
 		"tool_choice":{"type":"tool","name":"!!!"},
 		"messages":[
@@ -571,19 +578,21 @@ func TestNormalizeClaudeToolsForAnthropic_RejectsUnsanitizableCustomToolName(t *
 		]
 	}`)
 
-	_, err := normalizeClaudeToolsForAnthropic(input)
-	if err == nil {
-		t.Fatal("expected unsanitizable custom tool error")
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
 	}
-	var status statusErr
-	if !errors.As(err, &status) {
-		t.Fatalf("expected statusErr, got %T: %v", err, err)
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "!!!" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "!!!")
 	}
-	if got := status.StatusCode(); got != http.StatusBadRequest {
-		t.Fatalf("status code = %d, want %d", got, http.StatusBadRequest)
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "!!!" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "!!!")
 	}
-	if !strings.Contains(err.Error(), `custom tool name "!!!" cannot be sanitized`) {
-		t.Fatalf("error = %q, want unsanitizable tool name message", err.Error())
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "!!!" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "!!!")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "!!!" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "!!!")
 	}
 }
 
@@ -693,6 +702,34 @@ func TestNormalizeClaudeToolsForAnthropic_RejectsNonObjectSchemas(t *testing.T) 
 		t.Fatalf("tools.1.input_schema.properties should be object, got %s", got.Raw)
 	}
 }
+
+func TestNormalizeClaudeToolsForAnthropic_PreservesUnknownExplicitTypedTool(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"future_tool","name":"future_one","extra":{"a":1}},
+			{"type":"custom","name":"apply patch","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "future_tool" {
+		t.Fatalf("tools.0.type = %q, want %q", got, "future_tool")
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "future_one" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "tools.0.extra.a").Int(); got != 1 {
+		t.Fatalf("tools.0.extra.a = %d, want 1", got)
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got == "apply patch" || got == "" {
+		t.Fatalf("tools.1.name = %q, want sanitized non-empty custom name", got)
+	}
+}
+
 func TestNormalizeCacheControlTTL_DowngradesLaterOneHourBlocks(t *testing.T) {
 	payload := []byte(`{
 		"tools": [{"name":"t1","cache_control":{"type":"ephemeral","ttl":"1h"}}],
@@ -823,6 +860,102 @@ func TestClaudeExecutor_CountTokens_AppliesCacheControlGuards(t *testing.T) {
 	}
 	if hasTTLOrderingViolation(seenBody) {
 		t.Fatalf("count_tokens body still has ttl ordering violations: %s", string(seenBody))
+	}
+}
+
+func TestClaudeExecutor_CountTokens_AppliesThinkingFromModelSuffix(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"input_tokens":42}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	_, err := executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet(2048)",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("CountTokens error: %v", err)
+	}
+
+	if got := gjson.GetBytes(seenBody, "thinking.type").String(); got != "enabled" {
+		t.Fatalf("thinking.type = %q, want %q, body=%s", got, "enabled", string(seenBody))
+	}
+	if got := gjson.GetBytes(seenBody, "thinking.budget_tokens").Int(); got <= 0 {
+		t.Fatalf("thinking.budget_tokens = %d, want > 0, body=%s", got, string(seenBody))
+	}
+}
+
+func TestClaudeExecutor_CountTokens_DisablesThinkingWhenForcedToolChoice(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"input_tokens":42}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"tool_choice":{"type":"tool","name":"apply_patch"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+	_, err := executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet(2048)",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("CountTokens error: %v", err)
+	}
+
+	if gjson.GetBytes(seenBody, "thinking").Exists() {
+		t.Fatalf("thinking should be removed for forced tool choice, body=%s", string(seenBody))
+	}
+}
+
+func TestApplyClaudeHeaders_MergesBetasWithDefaultsAndClaude1M(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	ginReq := httptest.NewRequest(http.MethodPost, "http://localhost/v1/messages", nil)
+	ginReq.Header.Set("Anthropic-Beta", "custom-beta-1,oauth-2025-04-20")
+	ginReq.Header.Set("X-CPA-CLAUDE-1M", "1")
+	ginCtx.Request = ginReq
+
+	req := httptest.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "gin", ginCtx))
+
+	applyClaudeHeaders(req, &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123"}}, "key-123", false, []string{"beta-from-body", "custom-beta-1"}, &config.Config{})
+
+	got := req.Header.Get("Anthropic-Beta")
+	for _, want := range []string{
+		"custom-beta-1",
+		"oauth-2025-04-20",
+		"beta-from-body",
+		"context-1m-2025-08-07",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Anthropic-Beta = %q, missing %q", got, want)
+		}
+	}
+	if strings.Count(got, "custom-beta-1") != 1 {
+		t.Fatalf("Anthropic-Beta should de-duplicate custom-beta-1, got %q", got)
 	}
 }
 

--- a/internal/runtime/executor/payload_helpers.go
+++ b/internal/runtime/executor/payload_helpers.go
@@ -249,6 +249,7 @@ func expandSinglePayloadQueryPath(doc []byte, path string, queryStart, queryEnd 
 func payloadQueryEnd(path string, start int) int {
 	inQuote := byte(0)
 	escaped := false
+	parenLevel := 0
 	for i := start; i < len(path); i++ {
 		ch := path[i]
 		if escaped {
@@ -269,8 +270,14 @@ func payloadQueryEnd(path string, start int) int {
 			inQuote = ch
 			continue
 		}
-		if ch == ')' {
-			return i
+		switch ch {
+		case '(':
+			parenLevel++
+		case ')':
+			if parenLevel == 0 {
+				return i
+			}
+			parenLevel--
 		}
 	}
 	return -1

--- a/internal/runtime/executor/payload_helpers_test.go
+++ b/internal/runtime/executor/payload_helpers_test.go
@@ -1,0 +1,206 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/tidwall/gjson"
+)
+
+func TestApplyPayloadConfigWithRoot_OverrideQueryPath(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						`tools.#(type=="custom").description`: "patched",
+					},
+				},
+			},
+		},
+	}
+	input := []byte(`{"tools":[{"type":"function","name":"alpha"},{"type":"custom","name":"beta"},{"type":"custom","name":"gamma"}]}`)
+	out := applyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "tools.0.description"); got.Exists() {
+		t.Fatalf("tools.0.description should not exist, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.1.description").String(); got != "patched" {
+		t.Fatalf("tools.1.description = %q, want %q", got, "patched")
+	}
+	if got := gjson.GetBytes(out, "tools.2.description").String(); got != "patched" {
+		t.Fatalf("tools.2.description = %q, want %q", got, "patched")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_OverrideRawQueryPath(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			OverrideRaw: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						`tools.#(type=="custom").input_schema`: `{"type":"object","properties":{"command":{"type":"string"}}}`,
+					},
+				},
+			},
+		},
+	}
+	input := []byte(`{"tools":[{"type":"function","name":"alpha"},{"type":"custom","name":"beta"}]}`)
+	out := applyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "tools.0.input_schema"); got.Exists() {
+		t.Fatalf("tools.0.input_schema should not exist, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.1.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.1.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tools.1.input_schema.properties.command.type").String(); got != "string" {
+		t.Fatalf("tools.1.input_schema.properties.command.type = %q, want %q", got, "string")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_FilterQueryPath_RemovesMatchingElements(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Filter: []config.PayloadFilterRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: []string{`tools.#(type=="custom")`},
+				},
+			},
+		},
+	}
+	input := []byte(`{"tools":[{"type":"function","name":"alpha"},{"type":"custom","name":"beta"},{"type":"custom","name":"gamma"}]}`)
+	out := applyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	tools := gjson.GetBytes(out, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		t.Fatalf("tools should be an array, got %s", tools.Raw)
+	}
+	arr := tools.Array()
+	if len(arr) != 1 {
+		t.Fatalf("tools length = %d, want 1", len(arr))
+	}
+	if got := arr[0].Get("name").String(); got != "alpha" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "alpha")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_FilterQueryPath_RemovesNestedField(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Filter: []config.PayloadFilterRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: []string{`tools.#(type=="custom").format`},
+				},
+			},
+		},
+	}
+	input := []byte(`{"tools":[{"type":"custom","name":"beta","format":{"syntax":"lark"}},{"type":"function","name":"alpha","format":{"syntax":"json"}}]}`)
+	out := applyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "tools.0.format"); got.Exists() {
+		t.Fatalf("tools.0.format should be removed, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.1.format.syntax").String(); got != "json" {
+		t.Fatalf("tools.1.format.syntax = %q, want %q", got, "json")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_OverrideNestedQueryPath(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						`messages.#(role=="assistant").content.#(type=="tool_use").name`: "patched",
+					},
+				},
+			},
+		},
+	}
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"a"},{"type":"text","text":"ok"}]},{"role":"user","content":[{"type":"tool_use","name":"b"}]}]}`)
+	out := applyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "patched" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "patched")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.name").String(); got != "b" {
+		t.Fatalf("messages.1.content.0.name = %q, want %q", got, "b")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_OverrideRawNestedQueryPath(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			OverrideRaw: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						`messages.#(role=="assistant").content.#(type=="tool_use").input`: `{"command":"run"}`,
+					},
+				},
+			},
+		},
+	}
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"a","input":{}},{"type":"text","text":"ok"}]},{"role":"assistant","content":[{"type":"tool_use","name":"b","input":{}}]}]}`)
+	out := applyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "messages.0.content.0.input.command").String(); got != "run" {
+		t.Fatalf("messages.0.content.0.input.command = %q, want %q", got, "run")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.input.command").String(); got != "run" {
+		t.Fatalf("messages.1.content.0.input.command = %q, want %q", got, "run")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_FilterNestedQueryPath_RemovesMatchingNestedElements(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Filter: []config.PayloadFilterRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: []string{`messages.#(role=="assistant").content.#(type=="tool_use")`},
+				},
+			},
+		},
+	}
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"a"},{"type":"text","text":"ok"},{"type":"tool_use","name":"b"}]},{"role":"user","content":[{"type":"tool_use","name":"c"}]}]}`)
+	out := applyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "messages.0.content.#").Int(); got != 1 {
+		t.Fatalf("messages.0.content length = %d, want 1", got)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.type").String(); got != "text" {
+		t.Fatalf("messages.0.content.0.type = %q, want %q", got, "text")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.#").Int(); got != 1 {
+		t.Fatalf("messages.1.content length = %d, want 1", got)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.name").String(); got != "c" {
+		t.Fatalf("messages.1.content.0.name = %q, want %q", got, "c")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_InvalidQueryPath_NoOp(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Filter: []config.PayloadFilterRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: []string{`tools.#(type=="custom"`},
+				},
+			},
+		},
+	}
+	input := []byte(`{"tools":[{"type":"custom","name":"beta"},{"type":"function","name":"alpha"}]}`)
+	out := applyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if string(out) != string(input) {
+		t.Fatalf("invalid query path should leave payload unchanged\ngot:  %s\nwant: %s", string(out), string(input))
+	}
+}

--- a/internal/runtime/executor/payload_helpers_test.go
+++ b/internal/runtime/executor/payload_helpers_test.go
@@ -134,6 +134,30 @@ func TestApplyPayloadConfigWithRoot_OverrideNestedQueryPath(t *testing.T) {
 	}
 }
 
+func TestApplyPayloadConfigWithRoot_OverrideNestedQueryExpressionPath(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						`messages.#(content.#(type=="tool_use")).tool_present`: true,
+					},
+				},
+			},
+		},
+	}
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"a"},{"type":"text","text":"ok"}]},{"role":"assistant","content":[{"type":"text","text":"plain"}]}]}`)
+	out := applyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if !gjson.GetBytes(out, "messages.0.tool_present").Bool() {
+		t.Fatalf("messages.0.tool_present = false, want true")
+	}
+	if got := gjson.GetBytes(out, "messages.1.tool_present"); got.Exists() {
+		t.Fatalf("messages.1.tool_present should not exist, got %s", got.Raw)
+	}
+}
+
 func TestApplyPayloadConfigWithRoot_OverrideRawNestedQueryPath(t *testing.T) {
 	cfg := &config.Config{
 		Payload: config.PayloadConfig{

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -388,7 +388,7 @@ func extractClaudeConfig(body []byte) ThinkingConfig {
 		case "auto":
 			return ThinkingConfig{Mode: ModeAuto, Budget: -1}
 		case "max":
-			return ThinkingConfig{Mode: ModeLevel, Level: LevelXHigh}
+			return ThinkingConfig{Mode: ModeLevel, Level: LevelMax}
 		case "low":
 			return ThinkingConfig{Mode: ModeLevel, Level: LevelLow}
 		case "medium":

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -361,8 +361,7 @@ func extractClaudeConfig(body []byte) ThinkingConfig {
 	}
 	if thinkingType == "adaptive" || thinkingType == "auto" {
 		// Claude adaptive thinking uses output_config.effort (low/medium/high/max).
-		// We only treat it as a thinking config when effort is explicitly present;
-		// otherwise we passthrough and let upstream defaults apply.
+		// Effort takes precedence when explicitly present.
 		if effort := gjson.GetBytes(body, "output_config.effort"); effort.Exists() && effort.Type == gjson.String {
 			value := strings.ToLower(strings.TrimSpace(effort.String()))
 			if value == "" {
@@ -377,6 +376,22 @@ func extractClaudeConfig(body []byte) ThinkingConfig {
 				return ThinkingConfig{Mode: ModeLevel, Level: ThinkingLevel(value)}
 			}
 		}
+		// Fallback: extract budget_tokens when effort is absent.
+		// Some clients send adaptive+budget_tokens which is invalid upstream;
+		// extracting the budget intent lets the thinking pipeline normalize the
+		// output format instead of passing through the malformed combination.
+		if budget := gjson.GetBytes(body, "thinking.budget_tokens"); budget.Exists() {
+			value := int(budget.Int())
+			switch value {
+			case 0:
+				return ThinkingConfig{Mode: ModeNone, Budget: 0}
+			case -1:
+				return ThinkingConfig{Mode: ModeAuto, Budget: -1}
+			default:
+				return ThinkingConfig{Mode: ModeBudget, Budget: value}
+			}
+		}
+		// No effort, no budget_tokens → passthrough (valid adaptive request).
 		return ThinkingConfig{}
 	}
 

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -381,8 +381,12 @@ func extractClaudeConfig(body []byte) ThinkingConfig {
 	}
 
 	// Check output_config.effort first for Opus 4.6+ style effort control.
-	if effort := gjson.GetBytes(body, "output_config.effort"); effort.Exists() {
-		switch strings.ToLower(strings.TrimSpace(effort.String())) {
+	// Ignore non-string or empty effort values so budget_tokens can still apply.
+	if effort := gjson.GetBytes(body, "output_config.effort"); effort.Exists() && effort.Type == gjson.String {
+		switch value := strings.ToLower(strings.TrimSpace(effort.String())); value {
+		case "":
+			// Treat blank effort as unset and fall back to budget_tokens handling below.
+			break
 		case "none":
 			return ThinkingConfig{Mode: ModeNone, Budget: 0}
 		case "auto":
@@ -396,7 +400,7 @@ func extractClaudeConfig(body []byte) ThinkingConfig {
 		case "high":
 			return ThinkingConfig{Mode: ModeLevel, Level: LevelHigh}
 		default:
-			return ThinkingConfig{Mode: ModeLevel, Level: ThinkingLevel(strings.ToLower(strings.TrimSpace(effort.String())))}
+			return ThinkingConfig{Mode: ModeLevel, Level: ThinkingLevel(value)}
 		}
 	}
 

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -380,6 +380,26 @@ func extractClaudeConfig(body []byte) ThinkingConfig {
 		return ThinkingConfig{}
 	}
 
+	// Check output_config.effort first for Opus 4.6+ style effort control.
+	if effort := gjson.GetBytes(body, "output_config.effort"); effort.Exists() {
+		switch strings.ToLower(strings.TrimSpace(effort.String())) {
+		case "none":
+			return ThinkingConfig{Mode: ModeNone, Budget: 0}
+		case "auto":
+			return ThinkingConfig{Mode: ModeAuto, Budget: -1}
+		case "max":
+			return ThinkingConfig{Mode: ModeLevel, Level: LevelXHigh}
+		case "low":
+			return ThinkingConfig{Mode: ModeLevel, Level: LevelLow}
+		case "medium":
+			return ThinkingConfig{Mode: ModeLevel, Level: LevelMedium}
+		case "high":
+			return ThinkingConfig{Mode: ModeLevel, Level: LevelHigh}
+		default:
+			return ThinkingConfig{Mode: ModeLevel, Level: ThinkingLevel(strings.ToLower(strings.TrimSpace(effort.String())))}
+		}
+	}
+
 	// Check budget_tokens
 	if budget := gjson.GetBytes(body, "thinking.budget_tokens"); budget.Exists() {
 		value := int(budget.Int())

--- a/internal/thinking/apply_test.go
+++ b/internal/thinking/apply_test.go
@@ -1,0 +1,41 @@
+package thinking
+
+import "testing"
+
+func TestExtractClaudeConfig_UsesOutputConfigEffort(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want ThinkingConfig
+	}{
+		{
+			name: "maps max to xhigh",
+			body: `{"output_config":{"effort":"max"},"thinking":{"type":"adaptive"}}`,
+			want: ThinkingConfig{Mode: ModeLevel, Level: LevelXHigh},
+		},
+		{
+			name: "maps medium directly",
+			body: `{"output_config":{"effort":"medium"}}`,
+			want: ThinkingConfig{Mode: ModeLevel, Level: LevelMedium},
+		},
+		{
+			name: "none disables thinking",
+			body: `{"output_config":{"effort":"none"},"thinking":{"type":"enabled","budget_tokens":2048}}`,
+			want: ThinkingConfig{Mode: ModeNone, Budget: 0},
+		},
+		{
+			name: "effort takes precedence over budget tokens",
+			body: `{"output_config":{"effort":"low"},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeLevel, Level: LevelLow},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractClaudeConfig([]byte(tt.body))
+			if got.Mode != tt.want.Mode || got.Budget != tt.want.Budget || got.Level != tt.want.Level {
+				t.Fatalf("extractClaudeConfig() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/thinking/apply_test.go
+++ b/internal/thinking/apply_test.go
@@ -28,6 +28,36 @@ func TestExtractClaudeConfig_UsesOutputConfigEffort(t *testing.T) {
 			body: `{"output_config":{"effort":"low"},"thinking":{"type":"enabled","budget_tokens":8192}}`,
 			want: ThinkingConfig{Mode: ModeLevel, Level: LevelLow},
 		},
+		{
+			name: "null effort falls back to budget tokens",
+			body: `{"output_config":{"effort":null},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "empty effort falls back to budget tokens",
+			body: `{"output_config":{"effort":""},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "whitespace effort falls back to budget tokens",
+			body: `{"output_config":{"effort":"   "},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "numeric effort falls back to budget tokens",
+			body: `{"output_config":{"effort":123},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "boolean effort falls back to budget tokens",
+			body: `{"output_config":{"effort":false},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "unknown non-empty string still overrides budget tokens",
+			body: `{"output_config":{"effort":"bogus"},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeLevel, Level: "bogus"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/thinking/apply_test.go
+++ b/internal/thinking/apply_test.go
@@ -9,9 +9,9 @@ func TestExtractClaudeConfig_UsesOutputConfigEffort(t *testing.T) {
 		want ThinkingConfig
 	}{
 		{
-			name: "maps max to xhigh",
+			name: "preserves max effort",
 			body: `{"output_config":{"effort":"max"},"thinking":{"type":"adaptive"}}`,
-			want: ThinkingConfig{Mode: ModeLevel, Level: LevelXHigh},
+			want: ThinkingConfig{Mode: ModeLevel, Level: "max"},
 		},
 		{
 			name: "maps medium directly",

--- a/internal/thinking/apply_test.go
+++ b/internal/thinking/apply_test.go
@@ -1,6 +1,84 @@
 package thinking
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestExtractClaudeConfig_AdaptiveBudgetTokensFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want ThinkingConfig
+	}{
+		{
+			name: "adaptive with budget_tokens falls back to budget",
+			body: `{"thinking":{"type":"adaptive","budget_tokens":10000}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 10000},
+		},
+		{
+			name: "auto with budget_tokens falls back to budget",
+			body: `{"thinking":{"type":"auto","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "adaptive with budget_tokens zero returns none",
+			body: `{"thinking":{"type":"adaptive","budget_tokens":0}}`,
+			want: ThinkingConfig{Mode: ModeNone, Budget: 0},
+		},
+		{
+			name: "adaptive with budget_tokens -1 returns auto",
+			body: `{"thinking":{"type":"adaptive","budget_tokens":-1}}`,
+			want: ThinkingConfig{Mode: ModeAuto, Budget: -1},
+		},
+		{
+			name: "adaptive with effort takes precedence over budget_tokens",
+			body: `{"thinking":{"type":"adaptive","budget_tokens":10000},"output_config":{"effort":"high"}}`,
+			want: ThinkingConfig{Mode: ModeLevel, Level: LevelHigh},
+		},
+		{
+			name: "adaptive alone returns empty config (passthrough)",
+			body: `{"thinking":{"type":"adaptive"}}`,
+			want: ThinkingConfig{},
+		},
+		{
+			name: "auto alone returns empty config (passthrough)",
+			body: `{"thinking":{"type":"auto"}}`,
+			want: ThinkingConfig{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractClaudeConfig([]byte(tt.body))
+			if got.Mode != tt.want.Mode || got.Budget != tt.want.Budget || got.Level != tt.want.Level {
+				t.Fatalf("extractClaudeConfig() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyThinking_AdaptiveBudgetTokensNormalized(t *testing.T) {
+	// End-to-end: verify that adaptive+budget_tokens input is normalized to
+	// enabled+budget_tokens (a valid Claude API combination) instead of being
+	// passed through as the invalid adaptive+budget_tokens combination.
+	body := []byte(`{"thinking":{"type":"adaptive","budget_tokens":10000},"model":"claude-sonnet-4-6","max_tokens":16384}`)
+	result, err := ApplyThinking(body, "claude-sonnet-4-6", "claude", "claude", "claude")
+	if err != nil {
+		t.Fatalf("ApplyThinking returned error: %v", err)
+	}
+	// thinking.type must be "enabled" — the budget was extracted as ModeBudget
+	// and the applier converts that to manual thinking with the given budget.
+	thinkingType := gjson.GetBytes(result, "thinking.type").String()
+	if thinkingType != "enabled" {
+		t.Fatalf("expected thinking.type=enabled, got %q in: %s", thinkingType, string(result))
+	}
+	// budget_tokens is valid with type="enabled", so it should be present.
+	if !gjson.GetBytes(result, "thinking.budget_tokens").Exists() {
+		t.Fatalf("budget_tokens should be present with type=enabled: %s", string(result))
+	}
+}
 
 func TestExtractClaudeConfig_UsesOutputConfigEffort(t *testing.T) {
 	tests := []struct {

--- a/internal/thinking/provider/antigravity/apply.go
+++ b/internal/thinking/provider/antigravity/apply.go
@@ -184,6 +184,29 @@ func (a *Applier) applyBudgetFormat(body []byte, config thinking.ThinkingConfig,
 	return result, nil
 }
 
+// NormalizeClaudeBudgetPayload applies Claude-specific numeric thinking-budget
+// constraints to an Antigravity payload. It only mutates payloads that already
+// carry a non-negative thinkingBudget.
+func NormalizeClaudeBudgetPayload(payload []byte, modelInfo *registry.ModelInfo) []byte {
+	if modelInfo == nil {
+		return payload
+	}
+
+	budgetValue := gjson.GetBytes(payload, "request.generationConfig.thinkingConfig.thinkingBudget")
+	if !budgetValue.Exists() || budgetValue.Int() < 0 {
+		return payload
+	}
+
+	a := Applier{}
+	budget, normalized := a.normalizeClaudeBudget(int(budgetValue.Int()), payload, modelInfo)
+	if budget == -2 {
+		return normalized
+	}
+
+	normalized, _ = sjson.SetBytes(normalized, "request.generationConfig.thinkingConfig.thinkingBudget", budget)
+	return normalized
+}
+
 // normalizeClaudeBudget applies Claude-specific constraints to thinking budget.
 //
 // It handles:

--- a/internal/thinking/provider/antigravity/apply_test.go
+++ b/internal/thinking/provider/antigravity/apply_test.go
@@ -1,0 +1,65 @@
+package antigravity
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/tidwall/gjson"
+)
+
+func TestApply_ClaudeBudgetIsReducedBelowMaxOutputTokens(t *testing.T) {
+	applier := NewApplier()
+	modelInfo := &registry.ModelInfo{
+		ID:                  "claude-opus-4-6-thinking",
+		MaxCompletionTokens: 64000,
+		Thinking: &registry.ThinkingSupport{
+			Min:            1024,
+			Max:            64000,
+			ZeroAllowed:    true,
+			DynamicAllowed: true,
+		},
+	}
+	body := []byte(`{"request":{"generationConfig":{"maxOutputTokens":64000}}}`)
+
+	out, err := applier.Apply(body, thinking.ThinkingConfig{Mode: thinking.ModeBudget, Budget: 64000}, modelInfo)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should remain enabled, body=%s", string(out))
+	}
+}
+
+func TestApply_ClaudeBudgetUsesModelMaxWhenRequestMaxMissing(t *testing.T) {
+	applier := NewApplier()
+	modelInfo := &registry.ModelInfo{
+		ID:                  "claude-opus-4-6-thinking",
+		MaxCompletionTokens: 64000,
+		Thinking: &registry.ThinkingSupport{
+			Min:            1024,
+			Max:            64000,
+			ZeroAllowed:    true,
+			DynamicAllowed: true,
+		},
+	}
+
+	out, err := applier.Apply([]byte(`{"request":{}}`), thinking.ThinkingConfig{Mode: thinking.ModeBudget, Budget: 64000}, modelInfo)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+	}
+}

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -147,7 +147,7 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 
 	// Claude adaptive models use ModeAuto to request upstream-default adaptive behavior,
 	// so preserve it instead of rewriting to a fixed mid-range budget.
-	if config.Mode == ModeAuto && shouldPreserveAutoMode(toFormat, support) {
+	if config.Mode == ModeAuto && shouldPreserveAutoMode(fromFormat, toFormat, support) {
 		return &config, nil
 	}
 
@@ -186,11 +186,11 @@ func isValidClaudeEffortLevel(level ThinkingLevel) bool {
 	}
 }
 
-func shouldPreserveAutoMode(provider string, support *registry.ThinkingSupport) bool {
+func shouldPreserveAutoMode(fromFormat, toFormat string, support *registry.ThinkingSupport) bool {
 	if support == nil {
 		return false
 	}
-	return provider == "claude" && len(support.Levels) > 0
+	return fromFormat == "claude" && toFormat == "claude" && len(support.Levels) > 0
 }
 
 // convertAutoToMidRange converts ModeAuto to a mid-range value when dynamic is not allowed.

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -60,6 +60,13 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 	toHasLevelSupport := toCapability == CapabilityLevelOnly || toCapability == CapabilityHybrid
 	allowClampUnsupported := toHasLevelSupport && !isSameProviderFamily(fromFormat, toFormat)
 
+	// Claude-native effort values must retain Claude semantics even when routed to another provider.
+	// "none"/"auto" are normalized to ModeNone/ModeAuto earlier, so this guard only sees discrete effort levels.
+	// Invalid effort strings like "minimal" or "xhigh" should be rejected rather than normalized.
+	if !fromSuffix && fromFormat == "claude" && toFormat == "antigravity" && config.Mode == ModeLevel && !isValidClaudeEffortLevel(config.Level) {
+		return nil, NewThinkingError(ErrLevelNotSupported, fmt.Sprintf("level %q not supported, valid levels: low, medium, high, max", strings.ToLower(string(config.Level))))
+	}
+
 	// strictBudget determines whether to enforce strict budget range validation.
 	// This applies when: (1) config comes from request body (not suffix), (2) source format is known,
 	// and (3) source and target are in the same provider family. Cross-family or suffix-based configs
@@ -138,6 +145,12 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		}
 	}
 
+	// Claude adaptive models use ModeAuto to request upstream-default adaptive behavior,
+	// so preserve it instead of rewriting to a fixed mid-range budget.
+	if config.Mode == ModeAuto && shouldPreserveAutoMode(toFormat, support) {
+		return &config, nil
+	}
+
 	// Convert ModeAuto to mid-range if dynamic not allowed
 	if config.Mode == ModeAuto && !support.DynamicAllowed {
 		config = convertAutoToMidRange(config, support, toFormat, model)
@@ -162,6 +175,22 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 	}
 
 	return &config, nil
+}
+
+func isValidClaudeEffortLevel(level ThinkingLevel) bool {
+	switch strings.ToLower(strings.TrimSpace(string(level))) {
+	case "low", "medium", "high", "max":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldPreserveAutoMode(provider string, support *registry.ThinkingSupport) bool {
+	if support == nil {
+		return false
+	}
+	return provider == "claude" && len(support.Levels) > 0
 }
 
 // convertAutoToMidRange converts ModeAuto to a mid-range value when dynamic is not allowed.

--- a/internal/thinking/validate_test.go
+++ b/internal/thinking/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/antigravity"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/claude"
@@ -64,5 +65,23 @@ func TestApplyThinking_ClaudeCompatAntigravityRejectsInvalidClaudeEffort(t *test
 				t.Fatalf("returned body should remain unchanged on validation failure\ngot:  %s\nwant: %s", string(out), string(body))
 			}
 		})
+	}
+}
+
+func TestValidateConfig_NonClaudeAutoToClaudeStillClampsToConcreteLevel(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID: "claude-opus-4-6-model",
+		Thinking: &registry.ThinkingSupport{
+			Levels:         []string{"low", "medium", "high", "max"},
+			DynamicAllowed: false,
+		},
+	}
+
+	got, err := thinking.ValidateConfig(thinking.ThinkingConfig{Mode: thinking.ModeAuto, Budget: -1}, modelInfo, "gemini", "claude", false)
+	if err != nil {
+		t.Fatalf("ValidateConfig() error = %v", err)
+	}
+	if got.Mode != thinking.ModeLevel || got.Level != thinking.LevelMedium {
+		t.Fatalf("ValidateConfig() = %+v, want ModeLevel/LevelMedium", *got)
 	}
 }

--- a/internal/thinking/validate_test.go
+++ b/internal/thinking/validate_test.go
@@ -1,0 +1,68 @@
+package thinking_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/antigravity"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/claude"
+	"github.com/tidwall/gjson"
+)
+
+func TestApplyThinking_ClaudeAdaptiveAutoPreservesUpstreamDefault(t *testing.T) {
+	body := []byte(`{
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"auto"}
+	}`)
+
+	out, err := thinking.ApplyThinking(body, "claude-opus-4-6", "claude", "claude", "claude")
+	if err != nil {
+		t.Fatalf("ApplyThinking() error = %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want %q, body=%s", got, "adaptive", string(out))
+	}
+	if gjson.GetBytes(out, "thinking.budget_tokens").Exists() {
+		t.Fatalf("thinking.budget_tokens should be omitted for adaptive auto, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config.effort").Exists() {
+		t.Fatalf("output_config.effort should be omitted for adaptive auto, body=%s", string(out))
+	}
+}
+
+func TestApplyThinking_ClaudeCompatAntigravityRejectsInvalidClaudeEffort(t *testing.T) {
+	tests := []struct {
+		name   string
+		effort string
+	}{
+		{name: "minimal", effort: "minimal"},
+		{name: "xhigh", effort: "xhigh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(`{"request":{"generationConfig":{"thinkingConfig":{"thinkingLevel":"` + tt.effort + `","includeThoughts":true}}}}`)
+
+			out, err := thinking.ApplyThinking(body, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+			if err == nil {
+				t.Fatalf("ApplyThinking() error = nil, body=%s", string(out))
+			}
+
+			thinkingErr, ok := err.(*thinking.ThinkingError)
+			if !ok {
+				t.Fatalf("error type = %T, want *thinking.ThinkingError", err)
+			}
+			if thinkingErr.Code != thinking.ErrLevelNotSupported {
+				t.Fatalf("error code = %q, want %q", thinkingErr.Code, thinking.ErrLevelNotSupported)
+			}
+			if !strings.Contains(thinkingErr.Message, `valid levels: low, medium, high, max`) {
+				t.Fatalf("error message = %q, want valid Claude effort list", thinkingErr.Message)
+			}
+			if string(out) != string(body) {
+				t.Fatalf("returned body should remain unchanged on validation failure\ngot:  %s\nwant: %s", string(out), string(body))
+			}
+		})
+	}
+}

--- a/test/thinking_conversion_test.go
+++ b/test/thinking_conversion_test.go
@@ -3111,6 +3111,16 @@ func TestThinkingE2EClaudeAdaptive_Body(t *testing.T) {
 			inputJSON: `{"model":"claude-sonnet-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`,
 			expectErr: true,
 		},
+		{
+			name:        "C28",
+			from:        "claude",
+			to:          "claude",
+			model:       "claude-budget-model",
+			inputJSON:   `{"model":"claude-budget-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":8192},"output_config":{"effort":null}}`,
+			expectField: "thinking.budget_tokens",
+			expectValue: "8192",
+			expectErr:   false,
+		},
 	}
 
 	runThinkingTests(t, cases)


### PR DESCRIPTION
# Summary

This PR is ready for review and now reflects all changes on `fix/claude-tool-normalization` into `dev`.

Scope covered:
1. Claude/Codex tool compatibility fixes (including custom/freeform tool normalization and remap safety).
2. Antigravity Claude compatibility fixes (`output_config` stripping and thinking-token clamp).
3. Follow-up hardening/refactors from review feedback and expanded regression tests.

# Changes

- `config.example.yaml`
  - Added payload-query selector examples/documentation for dynamic array filtering.

- `internal/runtime/executor/claude_executor.go`
  - Expanded Claude tool normalization and validation flow.
  - Preserved custom payload metadata and numeric precision.
  - Added stronger collision/ambiguity handling for typed vs custom tool names.
  - Hardened upstream error handling and removed unreachable normalization status branch.

- `internal/runtime/executor/payload_helpers.go`
  - Added dynamic query-path expansion support for payload rule selectors.

- `internal/runtime/executor/antigravity_executor.go`
  - Strips Claude-only `output_config` fields before Antigravity upstream requests.
  - Clamps oversized `request.generationConfig.maxOutputTokens` for Claude thinking aliases.
  - Deduped compatibility transforms and guarded clamp overflow behavior.

- `internal/thinking/apply.go`
  - Supports extracting Claude thinking effort from `output_config.effort`.

- Tests added/updated:
  - `internal/runtime/executor/claude_executor_test.go`
  - `internal/runtime/executor/payload_helpers_test.go`
  - `internal/runtime/executor/antigravity_executor_buildrequest_test.go`
  - `internal/thinking/apply_test.go`
  - `internal/thinking/provider/antigravity/apply_test.go`

# Verification

- CI on current PR head:
  - `build`: pass
  - `ensure-no-translator-changes`: pass

- Test coverage expanded for:
  - Claude tool normalization/remap/collision behavior
  - Antigravity Claude-compat transform + clamp behavior
  - Dynamic payload selector handling
  - Claude thinking effort extraction paths

# Risk

- Breaking changes? **No**
- Risk level: **Low to Medium**
- Rationale: Changes are concentrated in executor/thinking compatibility paths with targeted regression tests.

# Refs

- Fixes #1671
- Fixes #1765
- Fixes #1781
- Related to #1535
- Related to #1540
- Related to #1763

# Reviewers / bots

@codex review
/gemini review
