### PR TITLE
fix(auth): prevent Kimi token expiry by increasing refresh frequency and reducing 401 cooldown

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1240,6 +1240,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	suspendReason := ""
 	clearModelQuota := false
 	setModelQuota := false
+	triggerRefreshAuthID := ""
 
 	m.mu.Lock()
 	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
@@ -1277,10 +1278,13 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				statusCode := statusCodeFromResult(result.Error)
 				switch statusCode {
 				case 401:
-					next := now.Add(30 * time.Minute)
+					// Use a short cooldown so the credential becomes available again
+					// quickly after a background refresh succeeds.
+					next := now.Add(30 * time.Second)
 					state.NextRetryAfter = next
 					suspendReason = "unauthorized"
 					shouldSuspendModel = true
+					triggerRefreshAuthID = result.AuthID
 				case 402, 403:
 					next := now.Add(30 * time.Minute)
 					state.NextRetryAfter = next
@@ -1349,6 +1353,12 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	}
 
 	m.hook.OnResult(ctx, result)
+
+	// On 401 trigger an immediate background refresh so the credential
+	// is renewed before the short cooldown expires.
+	if triggerRefreshAuthID != "" {
+		go m.refreshAuthWithLimit(context.Background(), triggerRefreshAuthID)
+	}
 }
 
 func ensureModelState(auth *Auth, model string) *ModelState {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -627,7 +627,7 @@ func (s *Service) Run(ctx context.Context) error {
 
 	// Prefer core auth manager auto refresh if available.
 	if s.coreManager != nil {
-		interval := 15 * time.Minute
+		interval := 30 * time.Second
 		s.coreManager.StartAutoRefresh(context.Background(), interval)
 		log.Infof("core auth auto-refresh started (interval=%s)", interval)
 	}


### PR DESCRIPTION
## Summary

Fixes intermittent Kimi K-2.5 failures where requests work initially but fail after ~10-15 minutes with 401 errors, followed by prolonged "no available credentials" 500 errors.

## Root Cause

The auto-refresh check interval in `service.go` was set to **15 minutes** — exactly matching Kimi's token lifetime (`expires_in=900`). Despite Kimi having a 5-minute `RefreshLead`, the refresh check never ran within that window, causing tokens to expire before renewal.

**The failure chain:**
```
T=0:00   → Token refreshed, valid until T+15:00
T+10:00  → Token SHOULD be refreshed (5min RefreshLead), but next check isn't until T+15:00
T+14:xx  → API request hits expired token → 401 from Kimi API
T+14:xx  → MarkResult: Auth suspended for 30 MINUTES (case 401 cooldown)
T+14:xx  → All subsequent requests → 500 "no available credentials" (1ms responses)
T+15:00  → Auto-refresh finally runs, gets new token — but auth still suspended for 29 more min
T+44:xx  → 30-min cooldown expires → requests work again
```

**Evidence from production logs:**
```
00:44:04 → Request 200 OK (token still valid)
00:45:48 → Request 401 (836ms) — token expired
00:45:51-00:47:57 → 7 consecutive 500 errors (1-52ms) — auth suspended
00:49:48 → Kimi token finally refreshed (next 15-min tick)
```

## Changes

### 1. `sdk/cliproxy/service.go` — Reduce auto-refresh check interval
```go
// BEFORE:
interval := 15 * time.Minute
// AFTER:
interval := 30 * time.Second
```
This ensures `checkRefreshes()` runs frequently enough for the 5-minute `RefreshLead` to actually trigger proactive token renewal before expiry. The check itself is lightweight (iterates auths under RLock, only refreshes when needed).

### 2. `sdk/cliproxy/auth/conductor.go` — Reduce 401 cooldown + trigger immediate refresh
```go
// BEFORE (case 401):
next := now.Add(30 * time.Minute)

// AFTER:
next := now.Add(30 * time.Second)
triggerRefreshAuthID = result.AuthID
// ... after lock release:
go m.refreshAuthWithLimit(context.Background(), triggerRefreshAuthID)
```
- **30-second cooldown** instead of 30 minutes — credential becomes available again promptly after refresh succeeds
- **Immediate background refresh** on 401 — don't wait for the next periodic check
- Uses `context.Background()` so the refresh outlives the request context
- `refreshAuthWithLimit` uses an existing semaphore to prevent thundering herd

## Impact on Other Providers

- **Kimi**: Directly fixed — tokens refreshed well before expiry, 401 recovery in ~30s instead of ~30min
- **Claude/Codex/Gemini**: No negative impact — their tokens have much longer lifetimes (hours/days), so the more frequent check is a no-op (exits early via `shouldRefresh()` returning false). The reduced 401 cooldown benefits all providers equally.
- **CPU overhead**: Negligible — `checkRefreshes()` acquires RLock, iterates auths, checks `ExpirationTime()` vs `RefreshLead`, skips if not needed. No network calls unless a refresh is actually due.

## Verification

- [x] `go build ./...` — compiles cleanly
- [x] `go test ./...` — all tests pass (1 pre-existing failure in `TestManager_MaxRetryCredentials_LimitsCrossCredentialRetries` unrelated to this change, also fails on `main`)