### PR TITLE
feat(codex): add usage cache strategy and query api

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,6 +37,18 @@ api-keys:
   - "your-api-key-2"
   - "your-api-key-3"
 
+# Weight used for Codex plan_type=free when aggregating usage.
+# Default is 0.2 when omitted.
+codex-free-plan-weight: 0.2
+
+# Per API key available weekly quota for proxy-issued Codex OAuth auth.json files.
+# Unit is team-member weekly standard usage units (e.g. 5 means 5x team weekly quota).
+# Values align with api-keys by index; missing entries default to full system total capacity.
+# codex-oauth-available-totals:
+#   - 5
+#   - 2
+#   - 1
+
 # Enable debug logging
 debug: false
 

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -375,7 +375,7 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 		"provider":       strings.TrimSpace(auth.Provider),
 		"label":          auth.Label,
 		"status":         auth.Status,
-		"status_message": auth.StatusMessage,
+		"status_message": compactStatusMessage(auth.StatusMessage),
 		"disabled":       auth.Disabled,
 		"unavailable":    auth.Unavailable,
 		"runtime_only":   runtimeOnly,
@@ -426,6 +426,59 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 		entry["id_token"] = claims
 	}
 	return entry
+}
+
+func compactStatusMessage(raw string) string {
+	message := strings.TrimSpace(raw)
+	if message == "" {
+		return ""
+	}
+
+	if gjson.Valid(message) {
+		status := int(gjson.Get(message, "status").Int())
+		code := strings.TrimSpace(gjson.Get(message, "error.code").String())
+		errMsg := strings.TrimSpace(gjson.Get(message, "error.message").String())
+
+		switch status {
+		case 401:
+			if code != "" {
+				return "unauthorized: " + code
+			}
+			return "unauthorized"
+		case 402, 403:
+			return "payment_required"
+		case 404:
+			return "not_found"
+		case 429:
+			return "quota exhausted"
+		}
+
+		if code != "" {
+			return code
+		}
+		if errMsg != "" {
+			return clipStatusMessage(errMsg, 160)
+		}
+	}
+
+	normalized := strings.ReplaceAll(strings.ReplaceAll(message, "\r\n", "\n"), "\r", "\n")
+	if strings.Count(normalized, "\n") > 1 || len(normalized) > 240 {
+		firstLine := strings.TrimSpace(strings.SplitN(normalized, "\n", 2)[0])
+		if firstLine == "" {
+			firstLine = normalized
+		}
+		return clipStatusMessage(firstLine, 160)
+	}
+
+	return message
+}
+
+func clipStatusMessage(s string, limit int) string {
+	s = strings.TrimSpace(s)
+	if s == "" || limit <= 0 || len(s) <= limit {
+		return s
+	}
+	return strings.TrimSpace(s[:limit-3]) + "..."
 }
 
 func extractCodexIDTokenClaims(auth *coreauth.Auth) gin.H {
@@ -1483,6 +1536,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 			Metadata: map[string]any{
 				"email":      tokenStorage.Email,
 				"account_id": tokenStorage.AccountID,
+				"websockets": true,
 			},
 		}
 		savedPath, errSave := h.saveTokenRecord(ctx, record)

--- a/internal/api/handlers/management/codex_usage.go
+++ b/internal/api/handlers/management/codex_usage.go
@@ -1,0 +1,1145 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	codexUsagePollInterval   = 60 * time.Second
+	codexUsageRequestTimeout = 20 * time.Second
+	codexUsageDefaultBaseURL = "https://chatgpt.com/backend-api"
+	codexFreePlanWeight      = 0.2
+	codexUsageStateFileName  = ".codex-usage-cache.json"
+)
+
+type codexUsageWindow struct {
+	UsedPercent        int   `json:"used_percent"`
+	LimitWindowSeconds int   `json:"limit_window_seconds"`
+	ResetAfterSeconds  int   `json:"reset_after_seconds"`
+	ResetAt            int64 `json:"reset_at"`
+}
+
+type codexUsageRateLimit struct {
+	Allowed         bool              `json:"allowed"`
+	LimitReached    bool              `json:"limit_reached"`
+	PrimaryWindow   *codexUsageWindow `json:"primary_window,omitempty"`
+	SecondaryWindow *codexUsageWindow `json:"secondary_window,omitempty"`
+}
+
+type codexUsageCredits struct {
+	HasCredits          bool    `json:"has_credits"`
+	Unlimited           bool    `json:"unlimited"`
+	Balance             *string `json:"balance,omitempty"`
+	ApproxLocalMessages []any   `json:"approx_local_messages,omitempty"`
+	ApproxCloudMessages []any   `json:"approx_cloud_messages,omitempty"`
+}
+
+type codexUsageAdditionalRateLimit struct {
+	LimitName      string               `json:"limit_name"`
+	MeteredFeature string               `json:"metered_feature"`
+	RateLimit      *codexUsageRateLimit `json:"rate_limit,omitempty"`
+}
+
+type codexUsagePayload struct {
+	PlanType             string                          `json:"plan_type"`
+	RateLimit            *codexUsageRateLimit            `json:"rate_limit,omitempty"`
+	Credits              *codexUsageCredits              `json:"credits,omitempty"`
+	AdditionalRateLimits []codexUsageAdditionalRateLimit `json:"additional_rate_limits,omitempty"`
+}
+
+type codexAuthUsageStatus struct {
+	AuthID        string             `json:"auth_id"`
+	FileName      string             `json:"file_name,omitempty"`
+	Email         string             `json:"email,omitempty"`
+	PlanType      string             `json:"plan_type,omitempty"`
+	AccountID     string             `json:"account_id,omitempty"`
+	BaseURL       string             `json:"base_url,omitempty"`
+	PathStyle     string             `json:"path_style,omitempty"`
+	Status        string             `json:"status"`
+	Error         string             `json:"error,omitempty"`
+	LastPolledAt  time.Time          `json:"last_polled_at,omitempty"`
+	LastSuccessAt *time.Time         `json:"last_success_at,omitempty"`
+	HasUsage      bool               `json:"has_usage"`
+	Usage         *codexUsagePayload `json:"usage,omitempty"`
+}
+
+type codexUsageWindowTotals struct {
+	AuthFiles           int     `json:"auth_files"`
+	UsedPercentSum      int     `json:"used_percent_sum"`
+	TotalPercent        int     `json:"total_percent"`
+	RemainingPercentSum int     `json:"remaining_percent_sum"`
+	AverageUsedPercent  int     `json:"average_used_percent"`
+	ProgressPercent     float64 `json:"progress_percent"`
+	MinResetAfterSecond int     `json:"min_reset_after_seconds,omitempty"`
+	MinResetAt          int64   `json:"min_reset_at,omitempty"`
+}
+
+type codexAdditionalRateLimitTotals struct {
+	LimitName       string                  `json:"limit_name"`
+	MeteredFeature  string                  `json:"metered_feature"`
+	PrimaryWindow   *codexUsageWindowTotals `json:"primary_window,omitempty"`
+	SecondaryWindow *codexUsageWindowTotals `json:"secondary_window,omitempty"`
+}
+
+type codexUsageTotalSummary struct {
+	PrimaryWindow        *codexUsageWindowTotals          `json:"primary_window,omitempty"`
+	SecondaryWindow      *codexUsageWindowTotals          `json:"secondary_window,omitempty"`
+	AdditionalRateLimits []codexAdditionalRateLimitTotals `json:"additional_rate_limits,omitempty"`
+}
+
+type codexUsageSummaryResponse struct {
+	UpdatedAt           time.Time              `json:"updated_at"`
+	PollIntervalSeconds int                    `json:"poll_interval_seconds"`
+	AuthFilesTotal      int                    `json:"auth_files_total"`
+	AuthFilesWithUsage  int                    `json:"auth_files_with_usage"`
+	AuthFilesWithErrors int                    `json:"auth_files_with_errors"`
+	SelectedAuthID      string                 `json:"selected_auth_id,omitempty"`
+	CompatPayload       codexUsagePayload      `json:"compat_payload"`
+	Total               codexUsageTotalSummary `json:"total"`
+	AuthFiles           []codexAuthUsageStatus `json:"auth_files"`
+}
+
+type codexUsagePersistentState struct {
+	UpdatedAt      time.Time                       `json:"updated_at"`
+	SelectedAuthID string                          `json:"selected_auth_id,omitempty"`
+	ByAuth         map[string]codexAuthUsageStatus `json:"by_auth"`
+	CompatPayload  codexUsagePayload               `json:"compat_payload"`
+	Summary        codexUsageSummaryResponse       `json:"summary"`
+	HasData        bool                            `json:"has_data"`
+}
+
+type codexUsageHTTPError struct {
+	StatusCode int
+	Preview    string
+}
+
+func (e *codexUsageHTTPError) Error() string {
+	if e == nil {
+		return "usage request failed"
+	}
+	if strings.TrimSpace(e.Preview) == "" {
+		return fmt.Sprintf("usage request failed: status=%d", e.StatusCode)
+	}
+	return fmt.Sprintf("usage request failed: status=%d body=%s", e.StatusCode, e.Preview)
+}
+
+type codexWindowAccumulator struct {
+	count                  int
+	denominatorCount       int
+	weightSum              float64
+	denominatorWeightSum   float64
+	usedPercentWeightedSum float64
+	limitWindowWeightedSum float64
+	minResetAfter          int
+	minResetAt             int64
+}
+
+func (a *codexWindowAccumulator) addDenominator(weight float64) {
+	if weight <= 0 {
+		weight = 1
+	}
+	a.denominatorCount++
+	a.denominatorWeightSum += weight
+}
+
+func (a *codexWindowAccumulator) add(window *codexUsageWindow, weight float64) {
+	if window == nil {
+		return
+	}
+	if weight <= 0 {
+		weight = 1
+	}
+	a.count++
+	a.weightSum += weight
+	a.usedPercentWeightedSum += float64(window.UsedPercent) * weight
+	a.limitWindowWeightedSum += float64(window.LimitWindowSeconds) * weight
+	if window.ResetAfterSeconds > 0 && (a.minResetAfter == 0 || window.ResetAfterSeconds < a.minResetAfter) {
+		a.minResetAfter = window.ResetAfterSeconds
+	}
+	if window.ResetAt > 0 && (a.minResetAt == 0 || window.ResetAt < a.minResetAt) {
+		a.minResetAt = window.ResetAt
+	}
+}
+
+func (a *codexWindowAccumulator) averageWindow() *codexUsageWindow {
+	if a == nil || a.count == 0 || a.weightSum <= 0 {
+		return nil
+	}
+	return &codexUsageWindow{
+		UsedPercent:        int(math.Round(a.usedPercentWeightedSum / a.weightSum)),
+		LimitWindowSeconds: int(math.Round(a.limitWindowWeightedSum / a.weightSum)),
+		ResetAfterSeconds:  a.minResetAfter,
+		ResetAt:            a.minResetAt,
+	}
+}
+
+func (a *codexWindowAccumulator) totals() *codexUsageWindowTotals {
+	if a == nil || a.denominatorCount == 0 || a.denominatorWeightSum <= 0 {
+		return nil
+	}
+	totalPercentFloat := a.denominatorWeightSum * 100
+	totalPercent := int(math.Round(totalPercentFloat))
+	usedPercentSum := int(math.Round(a.usedPercentWeightedSum))
+	progress := 0.0
+	if totalPercentFloat > 0 {
+		progress = (a.usedPercentWeightedSum / totalPercentFloat) * 100
+	}
+	averageUsed := 0
+	if a.denominatorWeightSum > 0 {
+		averageUsed = int(math.Round(a.usedPercentWeightedSum / a.denominatorWeightSum))
+	}
+	return &codexUsageWindowTotals{
+		AuthFiles:           a.denominatorCount,
+		UsedPercentSum:      usedPercentSum,
+		TotalPercent:        totalPercent,
+		RemainingPercentSum: totalPercent - usedPercentSum,
+		AverageUsedPercent:  averageUsed,
+		ProgressPercent:     math.Round(progress*100) / 100,
+		MinResetAfterSecond: a.minResetAfter,
+		MinResetAt:          a.minResetAt,
+	}
+}
+
+type codexRateLimitAccumulator struct {
+	hasAny          bool
+	allowedAny      bool
+	limitReachedAll bool
+	primaryWindow   codexWindowAccumulator
+	secondaryWindow codexWindowAccumulator
+}
+
+func (a *codexRateLimitAccumulator) add(rate *codexUsageRateLimit, weight float64) {
+	if rate == nil {
+		return
+	}
+	if !a.hasAny {
+		a.limitReachedAll = true
+	}
+	a.hasAny = true
+	a.allowedAny = a.allowedAny || rate.Allowed
+	if !rate.LimitReached {
+		a.limitReachedAll = false
+	}
+	a.primaryWindow.add(rate.PrimaryWindow, weight)
+	a.secondaryWindow.add(rate.SecondaryWindow, weight)
+}
+
+func (a *codexRateLimitAccumulator) addDenominator(weight float64) {
+	a.primaryWindow.addDenominator(weight)
+	a.secondaryWindow.addDenominator(weight)
+}
+
+func (a *codexRateLimitAccumulator) averageRateLimit() *codexUsageRateLimit {
+	if a == nil || !a.hasAny {
+		return nil
+	}
+	return &codexUsageRateLimit{
+		Allowed:         a.allowedAny,
+		LimitReached:    a.limitReachedAll,
+		PrimaryWindow:   a.primaryWindow.averageWindow(),
+		SecondaryWindow: a.secondaryWindow.averageWindow(),
+	}
+}
+
+type codexAdditionalAccumulator struct {
+	limitName      string
+	meteredFeature string
+	rate           codexRateLimitAccumulator
+}
+
+func defaultCodexUsagePayload() codexUsagePayload {
+	return codexUsagePayload{PlanType: "guest"}
+}
+
+// refreshCodexUsageFromCacheTTL updates codex usage cache on demand.
+// It never polls upstream unless a specific auth file cache TTL has expired.
+func (h *Handler) refreshCodexUsageFromCacheTTL(ctx context.Context) {
+	if h == nil {
+		return
+	}
+	h.codexUsagePollMu.Lock()
+	defer h.codexUsagePollMu.Unlock()
+
+	now := time.Now().UTC()
+	manager := h.authManager
+	if manager == nil {
+		return
+	}
+
+	selectedAuthID := strings.TrimSpace(manager.SelectedAuthID("codex"))
+	h.codexUsageMu.RLock()
+	selectedChanged := strings.TrimSpace(h.codexUsageSelected) != selectedAuthID
+	h.codexUsageMu.RUnlock()
+
+	previous := h.codexUsageByAuthSnapshot()
+	current := make(map[string]codexAuthUsageStatus, len(previous))
+	for key, value := range previous {
+		current[key] = value
+	}
+
+	auths := manager.List()
+	codexAuths := make(map[string]*coreauth.Auth)
+	for _, auth := range auths {
+		if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+			continue
+		}
+		codexAuths[strings.TrimSpace(auth.ID)] = auth
+	}
+	changed := false
+	for authID := range current {
+		if _, ok := codexAuths[authID]; !ok {
+			delete(current, authID)
+			changed = true
+		}
+	}
+
+	if len(codexAuths) == 0 {
+		if changed || selectedChanged {
+			h.updateCodexUsageState(current, selectedAuthID, now, true)
+		}
+		return
+	}
+
+	authIDs := make([]string, 0, len(codexAuths))
+	for authID := range codexAuths {
+		authIDs = append(authIDs, authID)
+	}
+	sort.Strings(authIDs)
+
+	for _, authID := range authIDs {
+		auth := codexAuths[authID]
+		status, ok := current[authID]
+		if !ok {
+			status = codexAuthUsageStatus{
+				AuthID: authID,
+			}
+		}
+		status.AuthID = authID
+		status.FileName = strings.TrimSpace(auth.FileName)
+		status.Email = authEmail(auth)
+		status.PlanType = inferCodexPlanType(auth, status)
+		status.AccountID = extractCodexAccountID(auth)
+		if status.Status == "" {
+			status.Status = "skipped"
+		}
+
+		shouldPoll := status.LastPolledAt.IsZero() || now.Sub(status.LastPolledAt) >= codexUsagePollInterval
+		if !shouldPoll {
+			current[authID] = status
+			continue
+		}
+
+		changed = true
+		token := extractCodexAccessToken(auth)
+		status.LastPolledAt = now
+		if token == "" {
+			status.Status = "error"
+			status.Error = "missing access_token"
+			status.Usage = nil
+			status.HasUsage = false
+			status.LastSuccessAt = nil
+			current[authID] = status
+			continue
+		}
+
+		pollCtx := ctx
+		var cancel context.CancelFunc
+		if pollCtx == nil {
+			pollCtx = context.Background()
+		}
+		pollCtx, cancel = context.WithTimeout(pollCtx, codexUsageRequestTimeout)
+		payload, baseURL, pathStyle, err := h.fetchCodexUsagePayload(pollCtx, auth, token, status.AccountID)
+		cancel()
+		status.BaseURL = baseURL
+		status.PathStyle = pathStyle
+		if err != nil {
+			status.Status = "error"
+			status.Error = err.Error()
+			if httpErr, ok := err.(*codexUsageHTTPError); ok && (httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden) {
+				// Credential is no longer valid; clear stale usage cache for this auth.
+				status.Usage = nil
+				status.HasUsage = false
+				status.LastSuccessAt = nil
+			}
+			current[authID] = status
+			log.WithError(err).Debugf("codex usage poll failed for auth %s", status.AuthID)
+			continue
+		}
+
+		status.Status = "ok"
+		status.Error = ""
+		status.PlanType = strings.TrimSpace(payload.PlanType)
+		copied := payload
+		status.Usage = &copied
+		status.HasUsage = true
+		lastSuccess := now
+		status.LastSuccessAt = &lastSuccess
+		current[authID] = status
+	}
+
+	if changed || selectedChanged {
+		h.updateCodexUsageState(current, selectedAuthID, now, true)
+	}
+}
+
+func (h *Handler) updateCodexUsageState(current map[string]codexAuthUsageStatus, selectedAuthID string, now time.Time, persist bool) {
+	if h == nil {
+		return
+	}
+	compatPayload, totalSummary, withUsage := aggregateCodexUsage(current, h.codexFreePlanWeight())
+	authErrors := 0
+	authList := make([]codexAuthUsageStatus, 0, len(current))
+	for _, item := range current {
+		if item.Status == "error" {
+			authErrors++
+		}
+		authList = append(authList, cloneCodexAuthUsageStatus(item))
+	}
+	sort.Slice(authList, func(i, j int) bool {
+		left := strings.TrimSpace(authList[i].FileName)
+		right := strings.TrimSpace(authList[j].FileName)
+		if left == right {
+			return authList[i].AuthID < authList[j].AuthID
+		}
+		if left == "" {
+			return false
+		}
+		if right == "" {
+			return true
+		}
+		return left < right
+	})
+
+	summary := codexUsageSummaryResponse{
+		UpdatedAt:           now,
+		PollIntervalSeconds: int(codexUsagePollInterval / time.Second),
+		AuthFilesTotal:      len(current),
+		AuthFilesWithUsage:  withUsage,
+		AuthFilesWithErrors: authErrors,
+		SelectedAuthID:      selectedAuthID,
+		CompatPayload:       compatPayload,
+		Total:               totalSummary,
+		AuthFiles:           authList,
+	}
+
+	h.codexUsageMu.Lock()
+	h.codexUsageByAuth = current
+	h.codexUsageCompat = compatPayload
+	h.codexUsageSummary = summary
+	h.codexUsageHasData = withUsage > 0
+	h.codexUsageSelected = selectedAuthID
+	h.codexUsageMu.Unlock()
+	if persist {
+		h.persistCodexUsageState()
+	}
+}
+
+func aggregateCodexUsage(authStatuses map[string]codexAuthUsageStatus, freePlanWeight float64) (codexUsagePayload, codexUsageTotalSummary, int) {
+	compat := defaultCodexUsagePayload()
+	var totals codexUsageTotalSummary
+
+	planCounts := map[string]int{}
+	mainRate := codexRateLimitAccumulator{}
+	additional := map[string]*codexAdditionalAccumulator{}
+	withUsage := 0
+
+	hasCreditsPayload := false
+	hasCreditsAny := false
+	unlimitedAny := false
+	balanceSum := 0.0
+	balanceCount := 0
+
+	for _, status := range authStatuses {
+		plan := strings.TrimSpace(status.PlanType)
+		if plan == "" && status.Usage != nil {
+			plan = strings.TrimSpace(status.Usage.PlanType)
+		}
+		weight := codexPlanWeight(plan, freePlanWeight)
+		mainRate.addDenominator(weight)
+
+		if status.Usage == nil {
+			continue
+		}
+		withUsage++
+		usage := status.Usage
+		usagePlan := strings.TrimSpace(usage.PlanType)
+		if usagePlan == "" {
+			usagePlan = plan
+		}
+		if usagePlan != "" {
+			planCounts[usagePlan]++
+		}
+		mainRate.add(usage.RateLimit, weight)
+
+		if usage.Credits != nil {
+			hasCreditsPayload = true
+			hasCreditsAny = hasCreditsAny || usage.Credits.HasCredits
+			unlimitedAny = unlimitedAny || usage.Credits.Unlimited
+			if usage.Credits.Balance != nil {
+				if parsed, err := strconv.ParseFloat(strings.TrimSpace(*usage.Credits.Balance), 64); err == nil {
+					balanceSum += parsed
+					balanceCount++
+				}
+			}
+		}
+
+		for i := range usage.AdditionalRateLimits {
+			item := usage.AdditionalRateLimits[i]
+			key := strings.TrimSpace(item.LimitName) + "|" + strings.TrimSpace(item.MeteredFeature)
+			acc, ok := additional[key]
+			if !ok {
+				acc = &codexAdditionalAccumulator{
+					limitName:      strings.TrimSpace(item.LimitName),
+					meteredFeature: strings.TrimSpace(item.MeteredFeature),
+				}
+				additional[key] = acc
+			}
+			acc.rate.add(item.RateLimit, weight)
+		}
+	}
+	if withUsage > 0 {
+		compat.PlanType = dominantPlanType(planCounts)
+	}
+	compat.RateLimit = mainRate.averageRateLimit()
+	totals.PrimaryWindow = mainRate.primaryWindow.totals()
+	totals.SecondaryWindow = mainRate.secondaryWindow.totals()
+
+	if hasCreditsPayload {
+		credits := &codexUsageCredits{
+			HasCredits: hasCreditsAny,
+			Unlimited:  unlimitedAny,
+		}
+		if balanceCount > 0 {
+			balance := strconv.FormatFloat(balanceSum, 'f', -1, 64)
+			credits.Balance = &balance
+		}
+		compat.Credits = credits
+	}
+
+	if len(additional) > 0 {
+		keys := make([]string, 0, len(additional))
+		for key := range additional {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		compat.AdditionalRateLimits = make([]codexUsageAdditionalRateLimit, 0, len(keys))
+		totals.AdditionalRateLimits = make([]codexAdditionalRateLimitTotals, 0, len(keys))
+		for _, key := range keys {
+			acc := additional[key]
+			compat.AdditionalRateLimits = append(compat.AdditionalRateLimits, codexUsageAdditionalRateLimit{
+				LimitName:      acc.limitName,
+				MeteredFeature: acc.meteredFeature,
+				RateLimit:      acc.rate.averageRateLimit(),
+			})
+			totals.AdditionalRateLimits = append(totals.AdditionalRateLimits, codexAdditionalRateLimitTotals{
+				LimitName:       acc.limitName,
+				MeteredFeature:  acc.meteredFeature,
+				PrimaryWindow:   acc.rate.primaryWindow.totals(),
+				SecondaryWindow: acc.rate.secondaryWindow.totals(),
+			})
+		}
+	}
+
+	return compat, totals, withUsage
+}
+
+func dominantPlanType(planCounts map[string]int) string {
+	if len(planCounts) == 0 {
+		return "guest"
+	}
+	type pair struct {
+		plan  string
+		count int
+	}
+	plans := make([]pair, 0, len(planCounts))
+	for plan, count := range planCounts {
+		plans = append(plans, pair{plan: plan, count: count})
+	}
+	sort.Slice(plans, func(i, j int) bool {
+		if plans[i].count == plans[j].count {
+			return plans[i].plan < plans[j].plan
+		}
+		return plans[i].count > plans[j].count
+	})
+	return plans[0].plan
+}
+
+func codexPlanWeight(planType string, freePlanWeight float64) float64 {
+	if freePlanWeight <= 0 {
+		freePlanWeight = codexFreePlanWeight
+	}
+	switch strings.ToLower(strings.TrimSpace(planType)) {
+	case "free":
+		return freePlanWeight
+	default:
+		return 1.0
+	}
+}
+
+func (h *Handler) codexFreePlanWeight() float64 {
+	if h == nil || h.cfg == nil || h.cfg.CodexFreePlanWeight <= 0 {
+		return codexFreePlanWeight
+	}
+	return h.cfg.CodexFreePlanWeight
+}
+
+func (h *Handler) codexOAuthAvailableTotalForAPIKey(apiKey string) (units float64, configured bool, matched bool) {
+	if h == nil || h.cfg == nil {
+		return 0, false, false
+	}
+	key := strings.TrimSpace(apiKey)
+	if key == "" {
+		return 0, false, false
+	}
+	index := -1
+	for i := range h.cfg.APIKeys {
+		if strings.TrimSpace(h.cfg.APIKeys[i]) == key {
+			index = i
+			break
+		}
+	}
+	if index < 0 {
+		return 0, false, false
+	}
+	if index >= len(h.cfg.CodexOAuthAvailableTotals) {
+		return 0, false, true
+	}
+	value := h.cfg.CodexOAuthAvailableTotals[index]
+	if value < 0 {
+		value = 0
+	}
+	return value, true, true
+}
+
+// EvaluateCodexOAuthQuota checks whether an authenticated proxy API key has exceeded
+// its configured available weekly quota for Codex traffic.
+//
+// Quota unit is "team-member weekly standard units".
+func (h *Handler) EvaluateCodexOAuthQuota(ctx context.Context, apiKey string) (exceeded bool, used float64, limit float64, checked bool) {
+	availableUnits, configured, matched := h.codexOAuthAvailableTotalForAPIKey(apiKey)
+	if !matched {
+		return false, 0, 0, false
+	}
+
+	h.refreshCodexUsageFromCacheTTL(ctx)
+	_, summary, _ := h.codexUsageSnapshot()
+	weeklyProgressPercent := 0.0
+	systemWeeklyUnits := 0.0
+	if summary.Total.SecondaryWindow != nil {
+		weeklyProgressPercent = summary.Total.SecondaryWindow.ProgressPercent
+		systemWeeklyUnits = float64(summary.Total.SecondaryWindow.TotalPercent) / 100.0
+		if systemWeeklyUnits < 0 {
+			systemWeeklyUnits = 0
+		}
+	}
+	used = (weeklyProgressPercent / 100.0) * systemWeeklyUnits
+
+	if configured {
+		limit = availableUnits
+		if limit <= 0 {
+			return true, used, 0, true
+		}
+		return used >= limit, used, limit, true
+	}
+
+	// Default behavior: full system capacity as quota.
+	if systemWeeklyUnits <= 0 {
+		return false, used, 0, false
+	}
+	limit = systemWeeklyUnits
+	return used >= limit, used, limit, true
+}
+
+func inferCodexPlanType(auth *coreauth.Auth, status codexAuthUsageStatus) string {
+	if status.Usage != nil {
+		if plan := strings.ToLower(strings.TrimSpace(status.Usage.PlanType)); plan != "" {
+			return plan
+		}
+	}
+	if plan := strings.ToLower(strings.TrimSpace(status.PlanType)); plan != "" {
+		return plan
+	}
+	if auth != nil && auth.Metadata != nil {
+		if raw, ok := auth.Metadata["plan_type"].(string); ok {
+			if plan := strings.ToLower(strings.TrimSpace(raw)); plan != "" {
+				return plan
+			}
+		}
+	}
+	if claims := extractCodexIDTokenClaims(auth); claims != nil {
+		if raw, ok := claims["plan_type"].(string); ok {
+			if plan := strings.ToLower(strings.TrimSpace(raw)); plan != "" {
+				return plan
+			}
+		}
+	}
+	name := ""
+	if auth != nil {
+		name = strings.ToLower(strings.TrimSpace(auth.FileName))
+	}
+	if name == "" {
+		name = strings.ToLower(strings.TrimSpace(status.FileName))
+	}
+	switch {
+	case strings.Contains(name, "-free"):
+		return "free"
+	case strings.Contains(name, "-team"):
+		return "team"
+	case strings.Contains(name, "-business"):
+		return "business"
+	default:
+		return "guest"
+	}
+}
+
+func (h *Handler) codexUsageStateFilePath() string {
+	if h == nil {
+		return ""
+	}
+	baseDir := ""
+	if cfgPath := strings.TrimSpace(h.configFilePath); cfgPath != "" {
+		baseDir = filepath.Dir(cfgPath)
+	} else if h.cfg != nil {
+		baseDir = strings.TrimSpace(h.cfg.AuthDir)
+	}
+	if baseDir == "" {
+		return ""
+	}
+	return filepath.Join(baseDir, codexUsageStateFileName)
+}
+
+func (h *Handler) loadCodexUsageState() {
+	if h == nil {
+		return
+	}
+	path := h.codexUsageStateFilePath()
+	if path == "" {
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var state codexUsagePersistentState
+	if err := json.Unmarshal(data, &state); err != nil {
+		log.WithError(err).Debugf("failed to load codex usage cache from %s", path)
+		return
+	}
+	if state.ByAuth == nil {
+		state.ByAuth = make(map[string]codexAuthUsageStatus)
+	}
+	compat := cloneCodexUsagePayload(&state.CompatPayload)
+	summary := state.Summary
+	summary.CompatPayload = cloneCodexUsagePayload(&summary.CompatPayload)
+	if summary.PollIntervalSeconds <= 0 {
+		summary.PollIntervalSeconds = int(codexUsagePollInterval / time.Second)
+	}
+	if summary.SelectedAuthID == "" {
+		summary.SelectedAuthID = strings.TrimSpace(state.SelectedAuthID)
+	}
+	if len(summary.AuthFiles) == 0 && len(state.ByAuth) > 0 {
+		authList := make([]codexAuthUsageStatus, 0, len(state.ByAuth))
+		for _, item := range state.ByAuth {
+			authList = append(authList, cloneCodexAuthUsageStatus(item))
+		}
+		sort.Slice(authList, func(i, j int) bool {
+			return authList[i].AuthID < authList[j].AuthID
+		})
+		summary.AuthFiles = authList
+	}
+
+	h.codexUsageMu.Lock()
+	h.codexUsageByAuth = make(map[string]codexAuthUsageStatus, len(state.ByAuth))
+	for key, value := range state.ByAuth {
+		h.codexUsageByAuth[key] = cloneCodexAuthUsageStatus(value)
+	}
+	h.codexUsageCompat = compat
+	h.codexUsageSummary = summary
+	h.codexUsageHasData = state.HasData
+	h.codexUsageSelected = strings.TrimSpace(summary.SelectedAuthID)
+	h.codexUsageMu.Unlock()
+}
+
+func (h *Handler) persistCodexUsageState() {
+	if h == nil {
+		return
+	}
+	path := h.codexUsageStateFilePath()
+	if path == "" {
+		return
+	}
+	compat, summary, hasData := h.codexUsageSnapshot()
+	byAuth := h.codexUsageByAuthSnapshot()
+	state := codexUsagePersistentState{
+		UpdatedAt:      summary.UpdatedAt,
+		SelectedAuthID: strings.TrimSpace(summary.SelectedAuthID),
+		ByAuth:         byAuth,
+		CompatPayload:  compat,
+		Summary:        summary,
+		HasData:        hasData,
+	}
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		log.WithError(err).Debug("failed to marshal codex usage cache")
+		return
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		log.WithError(err).Debugf("failed to create codex usage cache directory %s", dir)
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, encoded, 0o600); err != nil {
+		log.WithError(err).Debugf("failed to write codex usage cache temp file %s", tmp)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		log.WithError(err).Debugf("failed to commit codex usage cache file %s", path)
+		_ = os.Remove(tmp)
+	}
+}
+
+func (h *Handler) fetchCodexUsagePayload(ctx context.Context, auth *coreauth.Auth, token, accountID string) (codexUsagePayload, string, string, error) {
+	payload := defaultCodexUsagePayload()
+	baseURL, pathStyle := resolveCodexUsageBaseURL(auth)
+	usageURL := buildCodexUsageURL(baseURL, pathStyle)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, usageURL, nil)
+	if err != nil {
+		return payload, baseURL, pathStyle, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "codex-cli")
+	if strings.TrimSpace(accountID) != "" {
+		req.Header.Set("ChatGPT-Account-Id", strings.TrimSpace(accountID))
+	}
+
+	httpClient := &http.Client{
+		Timeout:   codexUsageRequestTimeout,
+		Transport: h.apiCallTransport(auth),
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return payload, baseURL, pathStyle, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return payload, baseURL, pathStyle, readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		preview := strings.TrimSpace(string(body))
+		if len(preview) > 240 {
+			preview = preview[:240]
+		}
+		return payload, baseURL, pathStyle, &codexUsageHTTPError{
+			StatusCode: resp.StatusCode,
+			Preview:    preview,
+		}
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return payload, baseURL, pathStyle, fmt.Errorf("decode usage payload: %w", err)
+	}
+	if strings.TrimSpace(payload.PlanType) == "" {
+		payload.PlanType = "guest"
+	}
+	return payload, baseURL, pathStyle, nil
+}
+
+func resolveCodexUsageBaseURL(auth *coreauth.Auth) (string, string) {
+	raw := ""
+	if auth != nil && auth.Attributes != nil {
+		raw = strings.TrimSpace(auth.Attributes["base_url"])
+	}
+	if raw == "" && auth != nil && auth.Metadata != nil {
+		if v, ok := auth.Metadata["base_url"].(string); ok {
+			raw = strings.TrimSpace(v)
+		}
+	}
+	if raw == "" {
+		raw = codexUsageDefaultBaseURL
+	}
+	raw = strings.TrimRight(raw, "/")
+	if strings.HasSuffix(raw, "/codex") {
+		raw = strings.TrimSuffix(raw, "/codex")
+	}
+	if (strings.HasPrefix(raw, "https://chatgpt.com") || strings.HasPrefix(raw, "https://chat.openai.com")) && !strings.Contains(raw, "/backend-api") {
+		raw = raw + "/backend-api"
+	}
+	raw = strings.TrimRight(raw, "/")
+	if raw == "" {
+		raw = codexUsageDefaultBaseURL
+	}
+	return raw, "wham"
+}
+
+func buildCodexUsageURL(baseURL, pathStyle string) string {
+	return strings.TrimRight(baseURL, "/") + "/wham/usage"
+}
+
+func extractCodexAccessToken(auth *coreauth.Auth) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	if token := metadataString(auth.Metadata, "access_token", "accessToken"); token != "" {
+		return token
+	}
+	if raw, ok := auth.Metadata["token"]; ok {
+		switch typed := raw.(type) {
+		case map[string]any:
+			return metadataString(typed, "access_token", "accessToken")
+		case map[string]string:
+			if token := strings.TrimSpace(typed["access_token"]); token != "" {
+				return token
+			}
+			if token := strings.TrimSpace(typed["accessToken"]); token != "" {
+				return token
+			}
+		}
+	}
+	return ""
+}
+
+func metadataString(metadata map[string]any, keys ...string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	for _, key := range keys {
+		if raw, ok := metadata[key]; ok {
+			if text, ok := raw.(string); ok {
+				if trimmed := strings.TrimSpace(text); trimmed != "" {
+					return trimmed
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func extractCodexAccountID(auth *coreauth.Auth) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	if accountID := metadataString(auth.Metadata, "account_id", "chatgpt_account_id", "chatgptAccountId"); accountID != "" {
+		return accountID
+	}
+	idToken := metadataString(auth.Metadata, "id_token")
+	if idToken == "" {
+		return ""
+	}
+	claims, err := codex.ParseJWTToken(idToken)
+	if err != nil || claims == nil {
+		return ""
+	}
+	return strings.TrimSpace(claims.GetAccountID())
+}
+
+func cloneCodexUsagePayload(payload *codexUsagePayload) codexUsagePayload {
+	if payload == nil {
+		return defaultCodexUsagePayload()
+	}
+	cloned := codexUsagePayload{
+		PlanType: strings.TrimSpace(payload.PlanType),
+	}
+	if cloned.PlanType == "" {
+		cloned.PlanType = "guest"
+	}
+	if payload.RateLimit != nil {
+		clonedRate := *payload.RateLimit
+		clonedRate.PrimaryWindow = cloneCodexUsageWindow(payload.RateLimit.PrimaryWindow)
+		clonedRate.SecondaryWindow = cloneCodexUsageWindow(payload.RateLimit.SecondaryWindow)
+		forceCodexPrimaryWindowFull(clonedRate.PrimaryWindow)
+		cloned.RateLimit = &clonedRate
+	}
+	if payload.Credits != nil {
+		clonedCredits := *payload.Credits
+		if payload.Credits.Balance != nil {
+			b := *payload.Credits.Balance
+			clonedCredits.Balance = &b
+		}
+		if len(payload.Credits.ApproxLocalMessages) > 0 {
+			clonedCredits.ApproxLocalMessages = append([]any(nil), payload.Credits.ApproxLocalMessages...)
+		}
+		if len(payload.Credits.ApproxCloudMessages) > 0 {
+			clonedCredits.ApproxCloudMessages = append([]any(nil), payload.Credits.ApproxCloudMessages...)
+		}
+		cloned.Credits = &clonedCredits
+	}
+	if len(payload.AdditionalRateLimits) > 0 {
+		cloned.AdditionalRateLimits = make([]codexUsageAdditionalRateLimit, 0, len(payload.AdditionalRateLimits))
+		for i := range payload.AdditionalRateLimits {
+			item := payload.AdditionalRateLimits[i]
+			copiedItem := codexUsageAdditionalRateLimit{
+				LimitName:      item.LimitName,
+				MeteredFeature: item.MeteredFeature,
+			}
+			if item.RateLimit != nil {
+				clonedRate := *item.RateLimit
+				clonedRate.PrimaryWindow = cloneCodexUsageWindow(item.RateLimit.PrimaryWindow)
+				clonedRate.SecondaryWindow = cloneCodexUsageWindow(item.RateLimit.SecondaryWindow)
+				forceCodexPrimaryWindowFull(clonedRate.PrimaryWindow)
+				copiedItem.RateLimit = &clonedRate
+			}
+			cloned.AdditionalRateLimits = append(cloned.AdditionalRateLimits, copiedItem)
+		}
+	}
+	return cloned
+}
+
+func cloneCodexUsageWindow(window *codexUsageWindow) *codexUsageWindow {
+	if window == nil {
+		return nil
+	}
+	cloned := *window
+	return &cloned
+}
+
+func cloneCodexUsageWindowTotals(input *codexUsageWindowTotals) *codexUsageWindowTotals {
+	if input == nil {
+		return nil
+	}
+	cloned := *input
+	return &cloned
+}
+
+func cloneCodexUsageTotalSummary(input codexUsageTotalSummary) codexUsageTotalSummary {
+	out := codexUsageTotalSummary{
+		PrimaryWindow:   cloneCodexUsageWindowTotals(input.PrimaryWindow),
+		SecondaryWindow: cloneCodexUsageWindowTotals(input.SecondaryWindow),
+	}
+	if len(input.AdditionalRateLimits) > 0 {
+		out.AdditionalRateLimits = make([]codexAdditionalRateLimitTotals, 0, len(input.AdditionalRateLimits))
+		for i := range input.AdditionalRateLimits {
+			item := input.AdditionalRateLimits[i]
+			out.AdditionalRateLimits = append(out.AdditionalRateLimits, codexAdditionalRateLimitTotals{
+				LimitName:       item.LimitName,
+				MeteredFeature:  item.MeteredFeature,
+				PrimaryWindow:   cloneCodexUsageWindowTotals(item.PrimaryWindow),
+				SecondaryWindow: cloneCodexUsageWindowTotals(item.SecondaryWindow),
+			})
+		}
+	}
+	return out
+}
+
+func forceCodexPrimaryWindowFull(window *codexUsageWindow) {
+	if window == nil {
+		return
+	}
+	window.UsedPercent = 100
+}
+
+func forceCodexPrimaryTotalsFull(window *codexUsageWindowTotals) {
+	if window == nil {
+		return
+	}
+	window.UsedPercentSum = window.TotalPercent
+	window.RemainingPercentSum = 0
+	window.AverageUsedPercent = 100
+	window.ProgressPercent = 100
+}
+
+func forceCodexPrimaryTotalsSummaryFull(summary *codexUsageTotalSummary) {
+	if summary == nil {
+		return
+	}
+	forceCodexPrimaryTotalsFull(summary.PrimaryWindow)
+	for i := range summary.AdditionalRateLimits {
+		forceCodexPrimaryTotalsFull(summary.AdditionalRateLimits[i].PrimaryWindow)
+	}
+}
+
+func cloneTimePointer(ts *time.Time) *time.Time {
+	if ts == nil {
+		return nil
+	}
+	copied := *ts
+	return &copied
+}
+
+func cloneCodexAuthUsageStatus(input codexAuthUsageStatus) codexAuthUsageStatus {
+	out := input
+	out.LastSuccessAt = cloneTimePointer(input.LastSuccessAt)
+	if input.Usage != nil {
+		cloned := cloneCodexUsagePayload(input.Usage)
+		out.Usage = &cloned
+	}
+	return out
+}
+
+func (h *Handler) codexUsageByAuthSnapshot() map[string]codexAuthUsageStatus {
+	if h == nil {
+		return nil
+	}
+	h.codexUsageMu.RLock()
+	defer h.codexUsageMu.RUnlock()
+	out := make(map[string]codexAuthUsageStatus, len(h.codexUsageByAuth))
+	for key, value := range h.codexUsageByAuth {
+		out[key] = cloneCodexAuthUsageStatus(value)
+	}
+	return out
+}
+
+func (h *Handler) codexUsageSnapshot() (codexUsagePayload, codexUsageSummaryResponse, bool) {
+	if h == nil {
+		empty := defaultCodexUsagePayload()
+		return empty, codexUsageSummaryResponse{
+			PollIntervalSeconds: int(codexUsagePollInterval / time.Second),
+			CompatPayload:       empty,
+		}, false
+	}
+	h.codexUsageMu.RLock()
+	defer h.codexUsageMu.RUnlock()
+
+	compat := cloneCodexUsagePayload(&h.codexUsageCompat)
+	summary := h.codexUsageSummary
+	summary.Total = cloneCodexUsageTotalSummary(h.codexUsageSummary.Total)
+	forceCodexPrimaryTotalsSummaryFull(&summary.Total)
+	summary.CompatPayload = cloneCodexUsagePayload(&h.codexUsageSummary.CompatPayload)
+	if len(h.codexUsageSummary.AuthFiles) > 0 {
+		summary.AuthFiles = make([]codexAuthUsageStatus, 0, len(h.codexUsageSummary.AuthFiles))
+		for i := range h.codexUsageSummary.AuthFiles {
+			summary.AuthFiles = append(summary.AuthFiles, cloneCodexAuthUsageStatus(h.codexUsageSummary.AuthFiles[i]))
+		}
+	}
+	return compat, summary, h.codexUsageHasData
+}
+
+func (h *Handler) GetCodexUsageCompat(c *gin.Context) {
+	if h == nil {
+		c.JSON(http.StatusOK, defaultCodexUsagePayload())
+		return
+	}
+	h.refreshCodexUsageFromCacheTTL(c.Request.Context())
+	compat, _, _ := h.codexUsageSnapshot()
+	c.JSON(http.StatusOK, compat)
+}
+
+func (h *Handler) GetCodexUsageSummary(c *gin.Context) {
+	if h == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "handler not initialized"})
+		return
+	}
+	h.refreshCodexUsageFromCacheTTL(c.Request.Context())
+	_, summary, _ := h.codexUsageSnapshot()
+	c.JSON(http.StatusOK, summary)
+}

--- a/internal/api/handlers/management/codex_usage_test.go
+++ b/internal/api/handlers/management/codex_usage_test.go
@@ -1,0 +1,540 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestCodexUsagePollIntervalMatchesCodexCLI(t *testing.T) {
+	if codexUsagePollInterval != 60*time.Second {
+		t.Fatalf("expected poll interval 60s, got %s", codexUsagePollInterval)
+	}
+}
+
+func TestCodexPlanWeight_FreeIsPointTwo(t *testing.T) {
+	if got := codexPlanWeight("free", 0.2); got != 0.2 {
+		t.Fatalf("expected free plan weight 0.2, got %v", got)
+	}
+	if got := codexPlanWeight("business", 0.2); got != 1.0 {
+		t.Fatalf("expected business plan weight 1.0, got %v", got)
+	}
+}
+
+func TestAggregateCodexUsage_AppliesFreeWeight(t *testing.T) {
+	statuses := map[string]codexAuthUsageStatus{
+		"free-auth": {
+			Status: "ok",
+			Usage: &codexUsagePayload{
+				PlanType: "free",
+				RateLimit: &codexUsageRateLimit{
+					PrimaryWindow: &codexUsageWindow{
+						UsedPercent:        100,
+						LimitWindowSeconds: 18000,
+					},
+				},
+			},
+		},
+		"business-auth": {
+			Status: "ok",
+			Usage: &codexUsagePayload{
+				PlanType: "business",
+				RateLimit: &codexUsageRateLimit{
+					PrimaryWindow: &codexUsageWindow{
+						UsedPercent:        0,
+						LimitWindowSeconds: 18000,
+					},
+				},
+			},
+		},
+	}
+
+	compat, totals, withUsage := aggregateCodexUsage(statuses, 0.2)
+	if withUsage != 2 {
+		t.Fatalf("expected withUsage=2, got %d", withUsage)
+	}
+	if compat.RateLimit == nil || compat.RateLimit.PrimaryWindow == nil {
+		t.Fatalf("expected primary window in compat payload")
+	}
+	if compat.RateLimit.PrimaryWindow.UsedPercent != 17 {
+		t.Fatalf("expected weighted used_percent=17, got %d", compat.RateLimit.PrimaryWindow.UsedPercent)
+	}
+	if totals.PrimaryWindow == nil {
+		t.Fatalf("expected primary totals")
+	}
+	if totals.PrimaryWindow.ProgressPercent != 16.67 {
+		t.Fatalf("expected weighted progress 16.67, got %.2f", totals.PrimaryWindow.ProgressPercent)
+	}
+}
+
+func TestAggregateCodexUsage_DenominatorIncludesAllCodexAuthFiles(t *testing.T) {
+	statuses := map[string]codexAuthUsageStatus{
+		"free-auth": {
+			PlanType: "free",
+			Status:   "ok",
+			Usage: &codexUsagePayload{
+				PlanType: "free",
+				RateLimit: &codexUsageRateLimit{
+					PrimaryWindow: &codexUsageWindow{
+						UsedPercent: 100,
+					},
+				},
+			},
+		},
+		"business-auth": {
+			PlanType: "business",
+			Status:   "ok",
+			Usage: &codexUsagePayload{
+				PlanType: "business",
+				RateLimit: &codexUsageRateLimit{
+					PrimaryWindow: &codexUsageWindow{
+						UsedPercent: 0,
+					},
+				},
+			},
+		},
+		"no-usage-auth": {
+			PlanType: "business",
+			Status:   "error",
+			Usage:    nil,
+		},
+	}
+
+	_, totals, withUsage := aggregateCodexUsage(statuses, 0.2)
+	if withUsage != 2 {
+		t.Fatalf("expected withUsage=2, got %d", withUsage)
+	}
+	if totals.PrimaryWindow == nil {
+		t.Fatalf("expected primary totals")
+	}
+	if totals.PrimaryWindow.AuthFiles != 3 {
+		t.Fatalf("expected denominator auth_files=3, got %d", totals.PrimaryWindow.AuthFiles)
+	}
+	if totals.PrimaryWindow.TotalPercent != 220 {
+		t.Fatalf("expected weighted total_percent=220, got %d", totals.PrimaryWindow.TotalPercent)
+	}
+	if totals.PrimaryWindow.UsedPercentSum != 20 {
+		t.Fatalf("expected weighted used_percent_sum=20, got %d", totals.PrimaryWindow.UsedPercentSum)
+	}
+	if totals.PrimaryWindow.ProgressPercent != 9.09 {
+		t.Fatalf("expected weighted progress 9.09, got %.2f", totals.PrimaryWindow.ProgressPercent)
+	}
+}
+
+func TestRefreshCodexUsageFromCacheTTL_PollsAllAuthsPerTTL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var whamCalls int32
+	whamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&whamCalls, 1)
+		if r.URL.Path != "/backend-api/wham/usage" && r.URL.Path != "/wham/usage" {
+			t.Fatalf("unexpected wham path: %s", r.URL.Path)
+		}
+		switch got := r.Header.Get("Authorization"); got {
+		case "Bearer token-wham", "Bearer token-api":
+		default:
+			t.Fatalf("unexpected auth header: %s", got)
+		}
+		switch got := r.Header.Get("ChatGPT-Account-Id"); got {
+		case "acc-wham", "acc-api":
+		default:
+			t.Fatalf("unexpected account id header: %s", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(codexUsagePayload{
+			PlanType: "plus",
+			RateLimit: &codexUsageRateLimit{
+				Allowed:      true,
+				LimitReached: false,
+				PrimaryWindow: &codexUsageWindow{
+					UsedPercent:        20,
+					LimitWindowSeconds: 18000,
+					ResetAfterSeconds:  1200,
+					ResetAt:            1900000000,
+				},
+				SecondaryWindow: &codexUsageWindow{
+					UsedPercent:        40,
+					LimitWindowSeconds: 604800,
+					ResetAfterSeconds:  3600,
+					ResetAt:            1900003600,
+				},
+			},
+			AdditionalRateLimits: []codexUsageAdditionalRateLimit{
+				{
+					LimitName:      "messages",
+					MeteredFeature: "cloud",
+					RateLimit: &codexUsageRateLimit{
+						Allowed:      true,
+						LimitReached: false,
+						PrimaryWindow: &codexUsageWindow{
+							UsedPercent:        10,
+							LimitWindowSeconds: 86400,
+							ResetAfterSeconds:  600,
+							ResetAt:            1900000600,
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer whamServer.Close()
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	ctx := context.Background()
+	_, _ = manager.Register(ctx, &coreauth.Auth{
+		ID:       "codex-wham",
+		Provider: "codex",
+		FileName: "codex-wham.json",
+		Attributes: map[string]string{
+			"base_url": whamServer.URL + "/backend-api",
+		},
+		Metadata: map[string]any{
+			"access_token": "token-wham",
+			"account_id":   "acc-wham",
+			"email":        "wham@example.com",
+		},
+	})
+	_, _ = manager.Register(ctx, &coreauth.Auth{
+		ID:       "codex-api",
+		Provider: "codex",
+		FileName: "codex-api.json",
+		Attributes: map[string]string{
+			"base_url": whamServer.URL,
+		},
+		Metadata: map[string]any{
+			"access_token": "token-api",
+			"account_id":   "acc-api",
+			"email":        "api@example.com",
+		},
+	})
+	_, _ = manager.Register(ctx, &coreauth.Auth{
+		ID:       "codex-apikey",
+		Provider: "codex",
+		FileName: "codex-apikey.json",
+		Attributes: map[string]string{
+			"api_key": "sk-test",
+		},
+	})
+
+	h := &Handler{
+		cfg:              &config.Config{},
+		authManager:      manager,
+		configFilePath:   t.TempDir() + "/config.yaml",
+		codexUsageByAuth: make(map[string]codexAuthUsageStatus),
+		codexUsageCompat: defaultCodexUsagePayload(),
+	}
+
+	manager.SetSelectedAuthID("codex", "codex-wham")
+	h.refreshCodexUsageFromCacheTTL(context.Background())
+	compat, summary, hasData := h.codexUsageSnapshot()
+
+	if !hasData {
+		t.Fatal("expected usage data after polling")
+	}
+	if atomic.LoadInt32(&whamCalls) != 2 {
+		t.Fatalf("expected 2 usage calls routed to wham path, got %d", whamCalls)
+	}
+	if summary.SelectedAuthID != "codex-wham" {
+		t.Fatalf("expected selected auth codex-wham, got %q", summary.SelectedAuthID)
+	}
+	if compat.PlanType != "plus" {
+		t.Fatalf("expected plan_type plus, got %q", compat.PlanType)
+	}
+	if compat.RateLimit == nil || compat.RateLimit.PrimaryWindow == nil {
+		t.Fatalf("expected aggregated primary window")
+	}
+	if compat.RateLimit.PrimaryWindow.UsedPercent != 100 {
+		t.Fatalf("expected 5h used_percent forced to 100, got %d", compat.RateLimit.PrimaryWindow.UsedPercent)
+	}
+	if summary.AuthFilesTotal != 3 {
+		t.Fatalf("expected all codex auth files cached, got %d", summary.AuthFilesTotal)
+	}
+	if summary.AuthFilesWithUsage != 2 {
+		t.Fatalf("expected 2 auth with usage, got %d", summary.AuthFilesWithUsage)
+	}
+
+	// Within TTL no upstream calls should be issued.
+	h.refreshCodexUsageFromCacheTTL(context.Background())
+	if atomic.LoadInt32(&whamCalls) != 2 {
+		t.Fatalf("expected still 2 usage calls due to TTL, got %d", whamCalls)
+	}
+
+	// Selection changes should not trigger upstream requests when TTL is still valid.
+	manager.SetSelectedAuthID("codex", "codex-api")
+	h.refreshCodexUsageFromCacheTTL(context.Background())
+	if atomic.LoadInt32(&whamCalls) != 2 {
+		t.Fatalf("expected usage call count unchanged on selection change, got %d", whamCalls)
+	}
+	_, summary, _ = h.codexUsageSnapshot()
+	if summary.SelectedAuthID != "codex-api" {
+		t.Fatalf("expected selected auth codex-api, got %q", summary.SelectedAuthID)
+	}
+
+	// Force only wham auth TTL to expire; only wham should be refreshed.
+	h.codexUsageMu.Lock()
+	st := h.codexUsageByAuth["codex-wham"]
+	st.LastPolledAt = time.Now().Add(-61 * time.Second).UTC()
+	h.codexUsageByAuth["codex-wham"] = st
+	h.codexUsageMu.Unlock()
+	h.refreshCodexUsageFromCacheTTL(context.Background())
+	if atomic.LoadInt32(&whamCalls) != 3 {
+		t.Fatalf("expected one additional wham poll after ttl expiry, got %d", whamCalls)
+	}
+}
+
+func TestCodexUsageStatePersistence(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := tmp + "/config.yaml"
+	h := &Handler{
+		configFilePath:   configPath,
+		codexUsageByAuth: make(map[string]codexAuthUsageStatus),
+		codexUsageCompat: defaultCodexUsagePayload(),
+	}
+	now := time.Now().UTC()
+	h.updateCodexUsageState(map[string]codexAuthUsageStatus{
+		"codex-a": {
+			AuthID:       "codex-a",
+			Status:       "ok",
+			LastPolledAt: now,
+			HasUsage:     true,
+			Usage: &codexUsagePayload{
+				PlanType: "plus",
+				RateLimit: &codexUsageRateLimit{
+					PrimaryWindow: &codexUsageWindow{
+						UsedPercent:        33,
+						LimitWindowSeconds: 18000,
+					},
+				},
+			},
+		},
+	}, "codex-a", now, true)
+
+	h2 := &Handler{
+		configFilePath:   configPath,
+		codexUsageByAuth: make(map[string]codexAuthUsageStatus),
+		codexUsageCompat: defaultCodexUsagePayload(),
+	}
+	h2.loadCodexUsageState()
+	compat, summary, hasData := h2.codexUsageSnapshot()
+	if !hasData {
+		t.Fatal("expected persisted usage data after reload")
+	}
+	if summary.SelectedAuthID != "codex-a" {
+		t.Fatalf("expected selected auth codex-a, got %q", summary.SelectedAuthID)
+	}
+	if compat.RateLimit == nil || compat.RateLimit.PrimaryWindow == nil || compat.RateLimit.PrimaryWindow.UsedPercent != 100 {
+		t.Fatalf("unexpected persisted compat payload: %+v", compat)
+	}
+}
+
+func TestGetCodexUsageCompatDefaultsToGuest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &Handler{}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/codex/usage", nil)
+
+	h.GetCodexUsageCompat(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var payload codexUsagePayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.PlanType != "guest" {
+		t.Fatalf("expected plan_type guest, got %q", payload.PlanType)
+	}
+}
+
+func TestEvaluateCodexOAuthQuota_UsesConfiguredAvailableTotal(t *testing.T) {
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: config.SDKConfig{
+				APIKeys:                   []string{"k1", "k2"},
+				CodexOAuthAvailableTotals: []float64{3.0},
+			},
+		},
+		codexUsageByAuth: make(map[string]codexAuthUsageStatus),
+		codexUsageCompat: defaultCodexUsagePayload(),
+		codexUsageSummary: codexUsageSummaryResponse{
+			Total: codexUsageTotalSummary{
+				PrimaryWindow:   &codexUsageWindowTotals{ProgressPercent: 90},
+				SecondaryWindow: &codexUsageWindowTotals{ProgressPercent: 60, TotalPercent: 600},
+			},
+		},
+	}
+
+	exceeded, progress, limit, checked := h.EvaluateCodexOAuthQuota(context.Background(), "k1")
+	if !checked {
+		t.Fatal("expected checked=true for configured api key")
+	}
+	if !exceeded {
+		t.Fatal("expected exceeded=true when progress exceeds configured limit")
+	}
+	if math.Abs(progress-3.6) > 1e-9 {
+		t.Fatalf("expected used weekly units=3.6, got %v", progress)
+	}
+	if limit != 3 {
+		t.Fatalf("expected configured limit units=3, got %v", limit)
+	}
+
+	exceeded, progress, limit, checked = h.EvaluateCodexOAuthQuota(context.Background(), "k2")
+	if !checked {
+		t.Fatal("expected checked=true for second api key")
+	}
+	if exceeded {
+		t.Fatal("expected exceeded=false with default full quota")
+	}
+	if math.Abs(progress-3.6) > 1e-9 {
+		t.Fatalf("expected used weekly units=3.6, got %v", progress)
+	}
+	if limit != 6 {
+		t.Fatalf("expected default full-system units limit=6, got %v", limit)
+	}
+
+	_, _, _, checked = h.EvaluateCodexOAuthQuota(context.Background(), "k-not-found")
+	if checked {
+		t.Fatal("expected checked=false for unknown api key")
+	}
+}
+
+func TestEvaluateCodexOAuthQuota_IgnoresPrimaryWindow(t *testing.T) {
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: config.SDKConfig{
+				APIKeys:                   []string{"k1"},
+				CodexOAuthAvailableTotals: []float64{2},
+			},
+		},
+		codexUsageByAuth: make(map[string]codexAuthUsageStatus),
+		codexUsageCompat: defaultCodexUsagePayload(),
+		codexUsageSummary: codexUsageSummaryResponse{
+			Total: codexUsageTotalSummary{
+				PrimaryWindow:   &codexUsageWindowTotals{ProgressPercent: 95},
+				SecondaryWindow: &codexUsageWindowTotals{ProgressPercent: 40, TotalPercent: 300},
+			},
+		},
+	}
+
+	exceeded, progress, limit, checked := h.EvaluateCodexOAuthQuota(context.Background(), "k1")
+	if !checked {
+		t.Fatal("expected checked=true")
+	}
+	if exceeded {
+		t.Fatal("expected exceeded=false when only primary(5h) exceeds limit")
+	}
+	if math.Abs(progress-1.2) > 1e-9 {
+		t.Fatalf("expected weekly used units=1.2, got %v", progress)
+	}
+	if limit != 2 {
+		t.Fatalf("expected limit units=2, got %v", limit)
+	}
+}
+
+func TestRefreshCodexUsageFromCacheTTL_ClearsUsageOnUnauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var statusCode int32 = http.StatusOK
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/backend-api/wham/usage" {
+			t.Fatalf("unexpected wham path: %s", r.URL.Path)
+		}
+		if code := int(atomic.LoadInt32(&statusCode)); code != http.StatusOK {
+			w.WriteHeader(code)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(codexUsagePayload{
+			PlanType: "plus",
+			RateLimit: &codexUsageRateLimit{
+				PrimaryWindow: &codexUsageWindow{
+					UsedPercent:        25,
+					LimitWindowSeconds: 18000,
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	ctx := context.Background()
+	_, _ = manager.Register(ctx, &coreauth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		FileName: "codex-auth.json",
+		Attributes: map[string]string{
+			"base_url": server.URL + "/backend-api",
+		},
+		Metadata: map[string]any{
+			"access_token": "token-auth",
+			"account_id":   "acc-auth",
+		},
+	})
+
+	h := &Handler{
+		cfg:              &config.Config{},
+		authManager:      manager,
+		configFilePath:   t.TempDir() + "/config.yaml",
+		codexUsageByAuth: make(map[string]codexAuthUsageStatus),
+		codexUsageCompat: defaultCodexUsagePayload(),
+	}
+
+	manager.SetSelectedAuthID("codex", "codex-auth")
+	h.refreshCodexUsageFromCacheTTL(context.Background())
+	compat, summary, hasData := h.codexUsageSnapshot()
+	if !hasData {
+		t.Fatal("expected hasData=true after successful poll")
+	}
+	if summary.AuthFilesWithUsage != 1 {
+		t.Fatalf("expected withUsage=1 after success, got %d", summary.AuthFilesWithUsage)
+	}
+	if compat.PlanType != "plus" {
+		t.Fatalf("expected plan_type plus after success, got %q", compat.PlanType)
+	}
+
+	atomic.StoreInt32(&statusCode, http.StatusUnauthorized)
+	h.codexUsageMu.Lock()
+	st := h.codexUsageByAuth["codex-auth"]
+	st.LastPolledAt = time.Now().Add(-61 * time.Second).UTC()
+	h.codexUsageByAuth["codex-auth"] = st
+	h.codexUsageMu.Unlock()
+
+	h.refreshCodexUsageFromCacheTTL(context.Background())
+	compat, summary, hasData = h.codexUsageSnapshot()
+	if hasData {
+		t.Fatal("expected hasData=false after unauthorized response clears usage")
+	}
+	if summary.AuthFilesWithUsage != 0 {
+		t.Fatalf("expected withUsage=0 after unauthorized response, got %d", summary.AuthFilesWithUsage)
+	}
+	if compat.PlanType != "guest" {
+		t.Fatalf("expected plan_type guest after usage clear, got %q", compat.PlanType)
+	}
+	authStatus, ok := h.codexUsageByAuthSnapshot()["codex-auth"]
+	if !ok {
+		t.Fatal("expected auth status to remain present")
+	}
+	if authStatus.Status != "error" {
+		t.Fatalf("expected auth status error, got %q", authStatus.Status)
+	}
+	if authStatus.Usage != nil {
+		t.Fatal("expected usage to be nil after unauthorized response")
+	}
+	if authStatus.HasUsage {
+		t.Fatal("expected has_usage=false after unauthorized response")
+	}
+}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -104,6 +104,66 @@ func (h *Handler) deleteFromStringList(c *gin.Context, target *[]string, after f
 	c.JSON(400, gin.H{"error": "missing index or value"})
 }
 
+func (h *Handler) putFloat64List(c *gin.Context, set func([]float64), after func()) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+	var arr []float64
+	if err = json.Unmarshal(data, &arr); err != nil {
+		var obj struct {
+			Items []float64 `json:"items"`
+		}
+		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		arr = obj.Items
+	}
+	set(arr)
+	if after != nil {
+		after()
+	}
+	h.persist(c)
+}
+
+func (h *Handler) patchFloat64List(c *gin.Context, target *[]float64, after func()) {
+	var body struct {
+		Index *int     `json:"index"`
+		Value *float64 `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.Index == nil || body.Value == nil {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+	if *body.Index < 0 || *body.Index >= len(*target) {
+		c.JSON(400, gin.H{"error": "index out of range"})
+		return
+	}
+	(*target)[*body.Index] = *body.Value
+	if after != nil {
+		after()
+	}
+	h.persist(c)
+}
+
+func (h *Handler) deleteFromFloat64List(c *gin.Context, target *[]float64, after func()) {
+	if idxStr := c.Query("index"); idxStr != "" {
+		var idx int
+		_, err := fmt.Sscanf(idxStr, "%d", &idx)
+		if err == nil && idx >= 0 && idx < len(*target) {
+			*target = append((*target)[:idx], (*target)[idx+1:]...)
+			if after != nil {
+				after()
+			}
+			h.persist(c)
+			return
+		}
+	}
+	c.JSON(400, gin.H{"error": "missing or invalid index"})
+}
+
 // api-keys
 func (h *Handler) GetAPIKeys(c *gin.Context) { c.JSON(200, gin.H{"api-keys": h.cfg.APIKeys}) }
 func (h *Handler) PutAPIKeys(c *gin.Context) {
@@ -116,6 +176,41 @@ func (h *Handler) PatchAPIKeys(c *gin.Context) {
 }
 func (h *Handler) DeleteAPIKeys(c *gin.Context) {
 	h.deleteFromStringList(c, &h.cfg.APIKeys, func() {})
+}
+
+func (h *Handler) GetCodexFreePlanWeight(c *gin.Context) {
+	c.JSON(200, gin.H{"codex-free-plan-weight": h.cfg.CodexFreePlanWeight})
+}
+
+func (h *Handler) PutCodexFreePlanWeight(c *gin.Context) {
+	h.updateFloatField(c, func(v float64) {
+		h.cfg.CodexFreePlanWeight = v
+		h.cfg.NormalizeCodexUsageControls()
+	})
+}
+
+func (h *Handler) GetCodexOAuthAvailableTotals(c *gin.Context) {
+	c.JSON(200, gin.H{"codex-oauth-available-totals": h.cfg.CodexOAuthAvailableTotals})
+}
+
+func (h *Handler) PutCodexOAuthAvailableTotals(c *gin.Context) {
+	h.putFloat64List(c, func(v []float64) {
+		h.cfg.CodexOAuthAvailableTotals = append([]float64(nil), v...)
+	}, func() {
+		h.cfg.NormalizeCodexUsageControls()
+	})
+}
+
+func (h *Handler) PatchCodexOAuthAvailableTotals(c *gin.Context) {
+	h.patchFloat64List(c, &h.cfg.CodexOAuthAvailableTotals, func() {
+		h.cfg.NormalizeCodexUsageControls()
+	})
+}
+
+func (h *Handler) DeleteCodexOAuthAvailableTotals(c *gin.Context) {
+	h.deleteFromFloat64List(c, &h.cfg.CodexOAuthAvailableTotals, func() {
+		h.cfg.NormalizeCodexUsageControls()
+	})
 }
 
 // gemini-api-key: []GeminiKey

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -48,6 +48,13 @@ type Handler struct {
 	envSecret           string
 	logDir              string
 	postAuthHook        coreauth.PostAuthHook
+	codexUsageMu        sync.RWMutex
+	codexUsagePollMu    sync.Mutex
+	codexUsageByAuth    map[string]codexAuthUsageStatus
+	codexUsageCompat    codexUsagePayload
+	codexUsageSummary   codexUsageSummaryResponse
+	codexUsageHasData   bool
+	codexUsageSelected  string
 }
 
 // NewHandler creates a new management handler instance.
@@ -64,7 +71,10 @@ func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Man
 		tokenStore:          sdkAuth.GetTokenStore(),
 		allowRemoteOverride: envSecret != "",
 		envSecret:           envSecret,
+		codexUsageByAuth:    make(map[string]codexAuthUsageStatus),
+		codexUsageCompat:    defaultCodexUsagePayload(),
 	}
+	h.loadCodexUsageState()
 	h.startAttemptCleanup()
 	return h
 }
@@ -313,6 +323,18 @@ func (h *Handler) updateIntField(c *gin.Context, set func(int)) {
 func (h *Handler) updateStringField(c *gin.Context, set func(string)) {
 	var body struct {
 		Value *string `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	set(*body.Value)
+	h.persist(c)
+}
+
+func (h *Handler) updateFloatField(c *gin.Context, set func(float64)) {
+	var body struct {
+		Value *float64 `json:"value"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -329,6 +329,7 @@ func (s *Server) setupRoutes() {
 	v1.Use(AuthMiddleware(s.accessManager))
 	{
 		v1.GET("/models", s.unifiedModelsHandler(openaiHandlers, claudeCodeHandlers))
+		v1.GET("/backend-api/wham/usage", s.mgmt.GetCodexUsageCompat)
 		v1.POST("/chat/completions", openaiHandlers.ChatCompletions)
 		v1.POST("/completions", openaiHandlers.Completions)
 		v1.POST("/messages", claudeCodeHandlers.ClaudeMessages)
@@ -358,6 +359,9 @@ func (s *Server) setupRoutes() {
 			},
 		})
 	})
+	s.engine.GET("/api/codex/usage", AuthMiddleware(s.accessManager), s.mgmt.GetCodexUsageCompat)
+	s.engine.GET("/wham/usage", AuthMiddleware(s.accessManager), s.mgmt.GetCodexUsageCompat)
+	s.engine.GET("/backend-api/wham/usage", AuthMiddleware(s.accessManager), s.mgmt.GetCodexUsageCompat)
 	s.engine.POST("/v1internal:method", geminiCLIHandlers.CLIHandler)
 
 	// OAuth callback endpoints (reuse main server port)
@@ -487,6 +491,7 @@ func (s *Server) registerManagementRoutes() {
 	mgmt.Use(s.managementAvailabilityMiddleware(), s.mgmt.Middleware())
 	{
 		mgmt.GET("/usage", s.mgmt.GetUsageStatistics)
+		mgmt.GET("/codex-usage-summary", s.mgmt.GetCodexUsageSummary)
 		mgmt.GET("/usage/export", s.mgmt.ExportUsageStatistics)
 		mgmt.POST("/usage/import", s.mgmt.ImportUsageStatistics)
 		mgmt.GET("/config", s.mgmt.GetConfig)
@@ -533,6 +538,9 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PUT("/api-keys", s.mgmt.PutAPIKeys)
 		mgmt.PATCH("/api-keys", s.mgmt.PatchAPIKeys)
 		mgmt.DELETE("/api-keys", s.mgmt.DeleteAPIKeys)
+		mgmt.GET("/codex-free-plan-weight", s.mgmt.GetCodexFreePlanWeight)
+		mgmt.PUT("/codex-free-plan-weight", s.mgmt.PutCodexFreePlanWeight)
+		mgmt.PATCH("/codex-free-plan-weight", s.mgmt.PutCodexFreePlanWeight)
 
 		mgmt.GET("/gemini-api-key", s.mgmt.GetGeminiKeys)
 		mgmt.PUT("/gemini-api-key", s.mgmt.PutGeminiKeys)
@@ -680,7 +688,13 @@ func (s *Server) serveManagementControlPanel(c *gin.Context) {
 		}
 	}
 
-	c.File(filePath)
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		log.WithError(err).Error("failed to read management control panel asset")
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+	c.Data(http.StatusOK, "text/html; charset=utf-8", data)
 }
 
 func (s *Server) enableKeepAlive(timeout time.Duration, onTimeout func()) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -112,6 +112,25 @@ func TestAmpProviderModelRoutes(t *testing.T) {
 	}
 }
 
+func TestCodexUsageCompatRoutes(t *testing.T) {
+	server := newTestServer(t)
+	paths := []string{"/api/codex/usage", "/wham/usage", "/backend-api/wham/usage", "/v1/backend-api/wham/usage"}
+
+	for _, path := range paths {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("Authorization", "Bearer test-key")
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("unexpected status for %s: got %d, body=%s", path, rr.Code, rr.Body.String())
+		}
+		if !strings.Contains(rr.Body.String(), `"plan_type":"guest"`) {
+			t.Fatalf("expected guest payload for %s, got %s", path, rr.Body.String())
+		}
+	}
+}
+
 func TestDefaultRequestLoggerFactory_UsesResolvedLogDirectory(t *testing.T) {
 	t.Setenv("WRITABLE_PATH", "")
 	t.Setenv("writable_path", "")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -627,6 +627,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Normalize global OAuth model name aliases.
 	cfg.SanitizeOAuthModelAlias()
 
+	// Normalize Codex usage weighting/available-total controls.
+	cfg.NormalizeCodexUsageControls()
+
 	// Validate raw payload rules and drop invalid entries.
 	cfg.SanitizePayloadRules()
 
@@ -647,6 +650,28 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	// Return the populated configuration struct.
 	return &cfg, nil
+}
+
+// NormalizeCodexUsageControls clamps and defaults Codex usage control settings.
+func (cfg *Config) NormalizeCodexUsageControls() {
+	if cfg == nil {
+		return
+	}
+	if cfg.CodexFreePlanWeight <= 0 {
+		cfg.CodexFreePlanWeight = 0.2
+	}
+	if len(cfg.CodexOAuthAvailableTotals) == 0 {
+		return
+	}
+	normalized := make([]float64, len(cfg.CodexOAuthAvailableTotals))
+	for i := range cfg.CodexOAuthAvailableTotals {
+		value := cfg.CodexOAuthAvailableTotals[i]
+		if value < 0 {
+			value = 0
+		}
+		normalized[i] = value
+	}
+	cfg.CodexOAuthAvailableTotals = normalized
 }
 
 // SanitizePayloadRules validates raw JSON payload rule params and drops invalid rules.

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -20,6 +20,16 @@ type SDKConfig struct {
 	// APIKeys is a list of keys for authenticating clients to this proxy server.
 	APIKeys []string `yaml:"api-keys" json:"api-keys"`
 
+	// CodexFreePlanWeight controls the relative weight used when aggregating Codex usage
+	// for accounts reported as plan_type=free. Default is 0.2 when unset or invalid.
+	CodexFreePlanWeight float64 `yaml:"codex-free-plan-weight,omitempty" json:"codex-free-plan-weight,omitempty"`
+
+	// CodexOAuthAvailableTotals configures per-API-key available weekly quota for proxy-issued
+	// Codex CLI OAuth auth.json files. The value at index i applies to api-keys[i].
+	// Unit is team-member weekly standard usage units (for example 5 means 5x team weekly quota).
+	// Missing entries default to the full system total weekly capacity.
+	CodexOAuthAvailableTotals []float64 `yaml:"codex-oauth-available-totals,omitempty" json:"codex-oauth-available-totals,omitempty"`
+
 	// PassthroughHeaders controls whether upstream response headers are forwarded to downstream clients.
 	// Default is false (disabled).
 	PassthroughHeaders bool `yaml:"passthrough-headers" json:"passthrough-headers"`

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -50,6 +50,9 @@ func (e *CodexExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Aut
 		return nil
 	}
 	apiKey, _ := codexCreds(auth)
+	if err := ensureCodexOAuthToken(auth, apiKey); err != nil {
+		return err
+	}
 	if strings.TrimSpace(apiKey) != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
@@ -84,6 +87,9 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
 	apiKey, baseURL := codexCreds(auth)
+	if err = ensureCodexOAuthToken(auth, apiKey); err != nil {
+		return resp, err
+	}
 	if baseURL == "" {
 		baseURL = "https://chatgpt.com/backend-api/codex"
 	}
@@ -194,6 +200,9 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
 	apiKey, baseURL := codexCreds(auth)
+	if err = ensureCodexOAuthToken(auth, apiKey); err != nil {
+		return resp, err
+	}
 	if baseURL == "" {
 		baseURL = "https://chatgpt.com/backend-api/codex"
 	}
@@ -284,6 +293,9 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
 	apiKey, baseURL := codexCreds(auth)
+	if err = ensureCodexOAuthToken(auth, apiKey); err != nil {
+		return nil, err
+	}
 	if baseURL == "" {
 		baseURL = "https://chatgpt.com/backend-api/codex"
 	}
@@ -652,12 +664,7 @@ func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, s
 	}
 	r.Header.Set("Connection", "Keep-Alive")
 
-	isAPIKey := false
-	if auth != nil && auth.Attributes != nil {
-		if v := strings.TrimSpace(auth.Attributes["api_key"]); v != "" {
-			isAPIKey = true
-		}
-	}
+	isAPIKey := codexIsAPIKeyAuth(auth)
 	if !isAPIKey {
 		r.Header.Set("Originator", "codex_cli_rs")
 		if auth != nil && auth.Metadata != nil {
@@ -707,15 +714,64 @@ func codexCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {
 		return "", ""
 	}
 	if a.Attributes != nil {
-		apiKey = a.Attributes["api_key"]
+		apiKey = strings.TrimSpace(a.Attributes["api_key"])
 		baseURL = a.Attributes["base_url"]
 	}
-	if apiKey == "" && a.Metadata != nil {
-		if v, ok := a.Metadata["access_token"].(string); ok {
-			apiKey = v
-		}
+	if codexIsOAuthAuth(a) {
+		return codexMetadataAccessToken(a), strings.TrimSpace(baseURL)
 	}
-	return
+	if apiKey == "" {
+		apiKey = codexMetadataAccessToken(a)
+	}
+	return strings.TrimSpace(apiKey), strings.TrimSpace(baseURL)
+}
+
+func codexMetadataAccessToken(a *cliproxyauth.Auth) string {
+	if a == nil || a.Metadata == nil {
+		return ""
+	}
+	if v, ok := a.Metadata["access_token"].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	if v, ok := a.Metadata["accessToken"].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}
+
+func codexAuthKind(a *cliproxyauth.Auth) string {
+	if a == nil || a.Attributes == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(a.Attributes["auth_kind"]))
+}
+
+func codexIsOAuthAuth(a *cliproxyauth.Auth) bool {
+	return codexAuthKind(a) == "oauth"
+}
+
+func codexIsAPIKeyAuth(a *cliproxyauth.Auth) bool {
+	kind := codexAuthKind(a)
+	switch kind {
+	case "oauth":
+		return false
+	case "apikey":
+		return true
+	}
+	if a != nil && a.Attributes != nil {
+		return strings.TrimSpace(a.Attributes["api_key"]) != ""
+	}
+	return false
+}
+
+func ensureCodexOAuthToken(a *cliproxyauth.Auth, token string) error {
+	if !codexIsOAuthAuth(a) {
+		return nil
+	}
+	if strings.TrimSpace(token) != "" {
+		return nil
+	}
+	return statusErr{code: http.StatusUnauthorized, msg: "codex oauth access_token missing"}
 }
 
 func (e *CodexExecutor) resolveCodexConfig(auth *cliproxyauth.Auth) *config.CodexKey {

--- a/internal/runtime/executor/codex_executor_auth_test.go
+++ b/internal/runtime/executor/codex_executor_auth_test.go
@@ -1,0 +1,134 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestCodexCredsOAuthIgnoresAPIKeyAttribute(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+			"api_key":   "fake-api-key",
+			"base_url":  "https://chatgpt.com/backend-api/codex",
+		},
+		Metadata: map[string]any{
+			"access_token": "real-oauth-token",
+		},
+	}
+
+	token, baseURL := codexCreds(auth)
+	if token != "real-oauth-token" {
+		t.Fatalf("expected oauth access token, got %q", token)
+	}
+	if baseURL != "https://chatgpt.com/backend-api/codex" {
+		t.Fatalf("unexpected baseURL: %q", baseURL)
+	}
+}
+
+func TestCodexCredsOAuthMissingTokenDoesNotFallbackToAPIKey(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+			"api_key":   "fake-api-key",
+		},
+	}
+
+	token, _ := codexCreds(auth)
+	if token != "" {
+		t.Fatalf("expected empty token for oauth without access_token, got %q", token)
+	}
+	if err := ensureCodexOAuthToken(auth, token); err == nil {
+		t.Fatal("expected missing oauth token error")
+	}
+}
+
+func TestCodexCredsAPIKeyAuthPrefersAPIKey(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"api_key":   "config-api-key",
+		},
+		Metadata: map[string]any{
+			"access_token": "oauth-token",
+		},
+	}
+
+	token, _ := codexCreds(auth)
+	if token != "config-api-key" {
+		t.Fatalf("expected config api_key, got %q", token)
+	}
+}
+
+func TestApplyCodexHeadersOAuthAddsAccountHeaders(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+			"api_key":   "fake-api-key",
+		},
+		Metadata: map[string]any{
+			"account_id": "acct_123",
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	applyCodexHeaders(req, auth, "real-oauth-token", true)
+
+	if got := req.Header.Get("Originator"); got != "codex_cli_rs" {
+		t.Fatalf("expected oauth Originator header, got %q", got)
+	}
+	if got := req.Header.Get("Chatgpt-Account-Id"); got != "acct_123" {
+		t.Fatalf("expected oauth account header, got %q", got)
+	}
+}
+
+func TestApplyCodexHeadersAPIKeySkipsAccountHeaders(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"api_key":   "config-api-key",
+		},
+		Metadata: map[string]any{
+			"account_id": "acct_123",
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	applyCodexHeaders(req, auth, "config-api-key", true)
+
+	if got := req.Header.Get("Originator"); got != "" {
+		t.Fatalf("expected no Originator header for api key auth, got %q", got)
+	}
+	if got := req.Header.Get("Chatgpt-Account-Id"); got != "" {
+		t.Fatalf("expected no account header for api key auth, got %q", got)
+	}
+}
+
+func TestApplyCodexWebsocketHeadersOAuthAddsAccountHeaders(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+			"api_key":   "fake-api-key",
+		},
+		Metadata: map[string]any{
+			"account_id": "acct_456",
+		},
+	}
+
+	headers := applyCodexWebsocketHeaders(context.Background(), http.Header{}, auth, "real-oauth-token")
+	if got := headers.Get("Originator"); got != "codex_cli_rs" {
+		t.Fatalf("expected websocket Originator header, got %q", got)
+	}
+	if got := headers.Get("Chatgpt-Account-Id"); got != "acct_456" {
+		t.Fatalf("expected websocket account header, got %q", got)
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -155,6 +155,9 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	apiKey, baseURL := codexCreds(auth)
+	if err = ensureCodexOAuthToken(auth, apiKey); err != nil {
+		return resp, err
+	}
 	if baseURL == "" {
 		baseURL = "https://chatgpt.com/backend-api/codex"
 	}
@@ -374,6 +377,9 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	apiKey, baseURL := codexCreds(auth)
+	if err = ensureCodexOAuthToken(auth, apiKey); err != nil {
+		return nil, err
+	}
 	if baseURL == "" {
 		baseURL = "https://chatgpt.com/backend-api/codex"
 	}
@@ -874,12 +880,7 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 	misc.EnsureHeader(headers, ginHeaders, "Session_id", uuid.NewString())
 	misc.EnsureHeader(headers, ginHeaders, "User-Agent", codexUserAgent)
 
-	isAPIKey := false
-	if auth != nil && auth.Attributes != nil {
-		if v := strings.TrimSpace(auth.Attributes["api_key"]); v != "" {
-			isAPIKey = true
-		}
-	}
+	isAPIKey := codexIsAPIKeyAuth(auth)
 	if !isAPIKey {
 		headers.Set("Originator", "codex_cli_rs")
 		if auth != nil && auth.Metadata != nil {

--- a/sdk/auth/codex_device.go
+++ b/sdk/auth/codex_device.go
@@ -273,7 +273,8 @@ func (a *CodexAuthenticator) buildAuthRecord(authSvc *codex.CodexAuth, authBundl
 
 	fileName := codex.CredentialFileName(tokenStorage.Email, planType, hashAccountID, true)
 	metadata := map[string]any{
-		"email": tokenStorage.Email,
+		"email":      tokenStorage.Email,
+		"websockets": true,
 	}
 
 	fmt.Println("Codex authentication successful")

--- a/sdk/auth/codex_device_test.go
+++ b/sdk/auth/codex_device_test.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+)
+
+func TestBuildAuthRecord_DefaultWebsocketsEnabled(t *testing.T) {
+	a := NewCodexAuthenticator()
+	authSvc := &codex.CodexAuth{}
+	authBundle := &codex.CodexAuthBundle{
+		TokenData: codex.CodexTokenData{
+			Email: "codex-user@example.com",
+		},
+	}
+
+	record, err := a.buildAuthRecord(authSvc, authBundle)
+	if err != nil {
+		t.Fatalf("buildAuthRecord returned error: %v", err)
+	}
+	if record == nil {
+		t.Fatal("buildAuthRecord returned nil record")
+	}
+	if record.Metadata == nil {
+		t.Fatal("record metadata is nil")
+	}
+	raw, ok := record.Metadata["websockets"]
+	if !ok {
+		t.Fatal("expected metadata.websockets to be present")
+	}
+	enabled, ok := raw.(bool)
+	if !ok {
+		t.Fatalf("expected metadata.websockets to be bool, got %T", raw)
+	}
+	if !enabled {
+		t.Fatal("expected metadata.websockets to default to true")
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -134,6 +134,8 @@ type Manager struct {
 	hook      Hook
 	mu        sync.RWMutex
 	auths     map[string]*Auth
+	// selectedAuthByProvider stores the last auth ID selected by scheduler per provider.
+	selectedAuthByProvider map[string]string
 	// providerOffsets tracks per-model provider rotation state for multi-provider routing.
 	providerOffsets map[string]int
 
@@ -170,13 +172,14 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 		hook = NoopHook{}
 	}
 	manager := &Manager{
-		store:            store,
-		executors:        make(map[string]ProviderExecutor),
-		selector:         selector,
-		hook:             hook,
-		auths:            make(map[string]*Auth),
-		providerOffsets:  make(map[string]int),
-		refreshSemaphore: make(chan struct{}, refreshMaxConcurrency),
+		store:                  store,
+		executors:              make(map[string]ProviderExecutor),
+		selector:               selector,
+		hook:                   hook,
+		auths:                  make(map[string]*Auth),
+		selectedAuthByProvider: make(map[string]string),
+		providerOffsets:        make(map[string]int),
+		refreshSemaphore:       make(chan struct{}, refreshMaxConcurrency),
 	}
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(&internalconfig.Config{})
@@ -193,6 +196,43 @@ func (m *Manager) SetSelector(selector Selector) {
 	}
 	m.mu.Lock()
 	m.selector = selector
+	m.mu.Unlock()
+}
+
+// SelectedAuthID returns the last scheduler-selected auth ID for the given provider.
+func (m *Manager) SelectedAuthID(provider string) string {
+	if m == nil {
+		return ""
+	}
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return ""
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return strings.TrimSpace(m.selectedAuthByProvider[provider])
+}
+
+// SetSelectedAuthID updates the last scheduler-selected auth ID for a provider.
+// This is primarily intended for integrations that need to pin external state to a specific auth.
+func (m *Manager) SetSelectedAuthID(provider, authID string) {
+	m.setSelectedAuthID(provider, authID)
+}
+
+func (m *Manager) setSelectedAuthID(provider, authID string) {
+	if m == nil {
+		return
+	}
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	authID = strings.TrimSpace(authID)
+	if provider == "" || authID == "" {
+		return
+	}
+	m.mu.Lock()
+	if m.selectedAuthByProvider == nil {
+		m.selectedAuthByProvider = make(map[string]string)
+	}
+	m.selectedAuthByProvider[provider] = authID
 	m.mu.Unlock()
 }
 
@@ -622,6 +662,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, provider, req.Model)
 		publishSelectedAuthMetadata(opts.Metadata, auth.ID)
+		m.setSelectedAuthID(provider, auth.ID)
 
 		tried[auth.ID] = struct{}{}
 		execCtx := ctx
@@ -684,6 +725,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, provider, req.Model)
 		publishSelectedAuthMetadata(opts.Metadata, auth.ID)
+		m.setSelectedAuthID(provider, auth.ID)
 
 		tried[auth.ID] = struct{}{}
 		execCtx := ctx
@@ -746,6 +788,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, provider, req.Model)
 		publishSelectedAuthMetadata(opts.Metadata, auth.ID)
+		m.setSelectedAuthID(provider, auth.ID)
 
 		tried[auth.ID] = struct{}{}
 		execCtx := ctx

--- a/sdk/cliproxy/auth/selected_auth_test.go
+++ b/sdk/cliproxy/auth/selected_auth_test.go
@@ -1,0 +1,15 @@
+package auth
+
+import "testing"
+
+func TestSelectedAuthIDRoundTrip(t *testing.T) {
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetSelectedAuthID("Codex", "auth-1")
+
+	if got := mgr.SelectedAuthID("codex"); got != "auth-1" {
+		t.Fatalf("expected selected auth auth-1, got %q", got)
+	}
+	if got := mgr.SelectedAuthID("CODEX"); got != "auth-1" {
+		t.Fatalf("expected provider lookup to be case-insensitive, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- keep Codex usage cache/TTL/aggregation/persistence strategy
- add ChatGPT-style usage path compatibility via `/backend-api/wham/usage`

## Details=
- kept usage behaviors:
  - cache-first usage reads
  - per-auth TTL refresh
  - weighted aggregation and persisted usage state

## Validation
- `go test ./internal/api/... ./internal/runtime/executor/...` passed
- online A/B smoke verified:
  - `/v1/models`
  - `/backend-api/wham/usage`
  - `/v1/backend-api/wham/usage`
