### PR TITLE
fix(antigravity): pass through adaptive thinking effort level instead of always mapping to high

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -441,9 +441,22 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 				out, _ = sjson.Set(out, "request.generationConfig.thinkingConfig.includeThoughts", true)
 			}
 		case "adaptive", "auto":
-			// Keep adaptive/auto as a high level sentinel; ApplyThinking resolves it
-			// to model-specific max capability.
-			out, _ = sjson.Set(out, "request.generationConfig.thinkingConfig.thinkingLevel", "high")
+			// For adaptive thinking:
+			// - If output_config.effort is explicitly present, pass through as thinkingLevel.
+			// - Otherwise, treat it as "enabled with target-model maximum" and emit high.
+			// ApplyThinking handles clamping to target model's supported levels.
+			effort := ""
+			if v := gjson.GetBytes(rawJSON, "output_config.effort"); v.Exists() && v.Type == gjson.String {
+				effort = strings.ToLower(strings.TrimSpace(v.String()))
+			}
+			if effort != "" {
+				if effort == "max" {
+					effort = "high"
+				}
+				out, _ = sjson.Set(out, "request.generationConfig.thinkingConfig.thinkingLevel", effort)
+			} else {
+				out, _ = sjson.Set(out, "request.generationConfig.thinkingConfig.thinkingLevel", "high")
+			}
 			out, _ = sjson.Set(out, "request.generationConfig.thinkingConfig.includeThoughts", true)
 		}
 	}

--- a/internal/translator/antigravity/claude/antigravity_claude_request_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request_test.go
@@ -1199,3 +1199,64 @@ func TestConvertClaudeRequestToAntigravity_ToolAndThinking_NoExistingSystem(t *t
 		t.Errorf("Interleaved thinking hint should be in created systemInstruction, got: %v", sysInstruction.Raw)
 	}
 }
+
+func TestConvertClaudeRequestToAntigravity_AdaptiveThinking_EffortLevels(t *testing.T) {
+	tests := []struct {
+		name     string
+		effort   string
+		expected string
+	}{
+		{"low", "low", "low"},
+		{"medium", "medium", "medium"},
+		{"high", "high", "high"},
+		{"max", "max", "high"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			inputJSON := []byte(`{
+				"model": "claude-opus-4-6-thinking",
+				"messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}],
+				"thinking": {"type": "adaptive"},
+				"output_config": {"effort": "` + tt.effort + `"}
+			}`)
+
+			output := ConvertClaudeRequestToAntigravity("claude-opus-4-6-thinking", inputJSON, false)
+			outputStr := string(output)
+
+			thinkingConfig := gjson.Get(outputStr, "request.generationConfig.thinkingConfig")
+			if !thinkingConfig.Exists() {
+				t.Fatal("thinkingConfig should exist for adaptive thinking")
+			}
+			if thinkingConfig.Get("thinkingLevel").String() != tt.expected {
+				t.Errorf("Expected thinkingLevel %q, got %q", tt.expected, thinkingConfig.Get("thinkingLevel").String())
+			}
+			if !thinkingConfig.Get("includeThoughts").Bool() {
+				t.Error("includeThoughts should be true")
+			}
+		})
+	}
+}
+
+func TestConvertClaudeRequestToAntigravity_AdaptiveThinking_NoEffort(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "claude-opus-4-6-thinking",
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}],
+		"thinking": {"type": "adaptive"}
+	}`)
+
+	output := ConvertClaudeRequestToAntigravity("claude-opus-4-6-thinking", inputJSON, false)
+	outputStr := string(output)
+
+	thinkingConfig := gjson.Get(outputStr, "request.generationConfig.thinkingConfig")
+	if !thinkingConfig.Exists() {
+		t.Fatal("thinkingConfig should exist for adaptive thinking without effort")
+	}
+	if thinkingConfig.Get("thinkingLevel").String() != "high" {
+		t.Errorf("Expected default thinkingLevel \"high\", got %q", thinkingConfig.Get("thinkingLevel").String())
+	}
+	if !thinkingConfig.Get("includeThoughts").Bool() {
+		t.Error("includeThoughts should be true")
+	}
+}


### PR DESCRIPTION
## Summary

- Antigravity Claude translator now passes through `output_config.effort` (low/medium/high) as `thinkingLevel` for adaptive thinking requests, instead of always mapping to `high`.
- `max` effort is mapped to `high` since Gemini backend does not support `max` as a thinking level.
- When no explicit effort is provided, defaults to `high` (preserves existing behavior).

## Changes

- `antigravity_claude_request.go`: Read `output_config.effort` in the `adaptive`/`auto` case and pass through to `thinkingConfig.thinkingLevel`
- `antigravity_claude_request_test.go`: Add table-driven tests covering low/medium/high/max effort levels and no-effort fallback