### PR TITLE
fix(translator): strip defer_loading from Claude tool declarations in Codex and Gemini translators

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -255,6 +255,8 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 			tool, _ = sjson.SetRaw(tool, "parameters", normalizeToolParameters(toolResult.Get("input_schema").Raw))
 			tool, _ = sjson.Delete(tool, "input_schema")
 			tool, _ = sjson.Delete(tool, "parameters.$schema")
+			tool, _ = sjson.Delete(tool, "cache_control")
+			tool, _ = sjson.Delete(tool, "defer_loading")
 			tool, _ = sjson.Set(tool, "strict", false)
 			template, _ = sjson.SetRaw(template, "tools.-1", tool)
 		}

--- a/internal/translator/gemini-cli/claude/gemini-cli_claude_request.go
+++ b/internal/translator/gemini-cli/claude/gemini-cli_claude_request.go
@@ -156,6 +156,7 @@ func ConvertClaudeRequestToCLI(modelName string, inputRawJSON []byte, _ bool) []
 				tool, _ = sjson.Delete(tool, "input_examples")
 				tool, _ = sjson.Delete(tool, "type")
 				tool, _ = sjson.Delete(tool, "cache_control")
+				tool, _ = sjson.Delete(tool, "defer_loading")
 				if gjson.Valid(tool) && gjson.Parse(tool).IsObject() {
 					if !hasTools {
 						out, _ = sjson.SetRaw(out, "request.tools", `[{"functionDeclarations":[]}]`)

--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -137,6 +137,7 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 				tool, _ = sjson.Delete(tool, "input_examples")
 				tool, _ = sjson.Delete(tool, "type")
 				tool, _ = sjson.Delete(tool, "cache_control")
+				tool, _ = sjson.Delete(tool, "defer_loading")
 				if gjson.Valid(tool) && gjson.Parse(tool).IsObject() {
 					if !hasTools {
 						out, _ = sjson.SetRaw(out, "tools", `[{"functionDeclarations":[]}]`)


### PR DESCRIPTION
## Summary

- Strip `defer_loading` field from Claude tool definitions when translating to Codex and Gemini upstream APIs
- Also strip `cache_control` in the Codex/Claude translator (was already handled in Gemini translators)

## Problem

Claude Code CLI v2.0.70+ sends `defer_loading: true` on tool definitions when Tool Search is active (`advanced-tool-use-2025-11-20` beta). When CLIProxyAPI proxies these requests to Codex or Gemini upstreams, the unknown field causes **400 errors**:

- **Codex**: `Unknown parameter: 'tools.defer_loading'` (invalid_request_error)
- **Gemini**: `Unknown name "defer_loading" at 'request.tools[0].function_declarations[N]'` (INVALID_ARGUMENT)

## Changes

| File | Change |
|------|--------|
| `internal/translator/codex/claude/codex_claude_request.go` | Add `defer_loading` + `cache_control` deletion |
| `internal/translator/gemini-cli/claude/gemini-cli_claude_request.go` | Add `defer_loading` deletion |
| `internal/translator/gemini/claude/gemini_claude_request.go` | Add `defer_loading` deletion |

## Notes

- `defer_loading` is a Claude/Anthropic-only feature for lazy tool loading via Tool Search Tool
- Neither Codex nor Gemini APIs support this parameter — both strictly reject unknown fields
- The `antigravity/claude` translator already handles this via a whitelist approach (`allowedToolKeys`)

Fixes #1725
Fixes #1375