### PR TITLE
perf(executor): reduce codex/openai proxy hot-path overhead

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -93,13 +93,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("codex")
-	originalPayloadSource := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayloadSource = opts.OriginalRequest
-	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
-	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+	originalPayload, originalTranslated, body := translateRequestPair(from, to, baseModel, req.Payload, opts.OriginalRequest, false)
 
 	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -159,35 +153,58 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		err = newCodexStatusErr(httpResp.StatusCode, b)
 		return resp, err
 	}
-	data, err := io.ReadAll(httpResp.Body)
+	completedEvent, err := readCodexCompletedEvent(httpResp.Body, func(chunk []byte) {
+		appendAPIResponseChunk(ctx, e.cfg, chunk)
+	})
 	if err != nil {
 		recordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
 	}
-	appendAPIResponseChunk(ctx, e.cfg, data)
 
-	lines := bytes.Split(data, []byte("\n"))
-	for _, line := range lines {
+	if detail, ok := parseCodexUsage(completedEvent); ok {
+		reporter.publish(ctx, detail)
+	}
+
+	var param any
+	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, completedEvent, &param)
+	resp = cliproxyexecutor.Response{Payload: []byte(out), Headers: httpResp.Header.Clone()}
+	return resp, nil
+}
+
+func readCodexCompletedEvent(body io.Reader, onChunk func([]byte)) ([]byte, error) {
+	if body == nil {
+		return nil, statusErr{code: http.StatusRequestTimeout, msg: "stream error: stream disconnected before completion: stream closed before response.completed"}
+	}
+
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(nil, 52_428_800) // 50MB
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		clonedLine := bytes.Clone(line)
+		if onChunk != nil {
+			onChunk(clonedLine)
+		}
+
 		if !bytes.HasPrefix(line, dataTag) {
 			continue
 		}
 
-		line = bytes.TrimSpace(line[5:])
-		if gjson.GetBytes(line, "type").String() != "response.completed" {
+		event := bytes.TrimSpace(line[len(dataTag):])
+		if gjson.GetBytes(event, "type").String() != "response.completed" {
 			continue
 		}
-
-		if detail, ok := parseCodexUsage(line); ok {
-			reporter.publish(ctx, detail)
-		}
-
-		var param any
-		out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, line, &param)
-		resp = cliproxyexecutor.Response{Payload: []byte(out), Headers: httpResp.Header.Clone()}
-		return resp, nil
+		return bytes.Clone(event), nil
 	}
-	err = statusErr{code: 408, msg: "stream error: stream disconnected before completion: stream closed before response.completed"}
-	return resp, err
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return nil, statusErr{code: http.StatusRequestTimeout, msg: "stream error: stream disconnected before completion: stream closed before response.completed"}
 }
 
 func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
@@ -203,13 +220,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("openai-response")
-	originalPayloadSource := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayloadSource = opts.OriginalRequest
-	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
-	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+	originalPayload, originalTranslated, body := translateRequestPair(from, to, baseModel, req.Payload, opts.OriginalRequest, false)
 
 	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -293,13 +304,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("codex")
-	originalPayloadSource := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayloadSource = opts.OriginalRequest
-	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
-	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
+	originalPayload, originalTranslated, body := translateRequestPair(from, to, baseModel, req.Payload, opts.OriginalRequest, true)
 
 	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {

--- a/internal/runtime/executor/codex_executor_stream_parse_test.go
+++ b/internal/runtime/executor/codex_executor_stream_parse_test.go
@@ -1,0 +1,72 @@
+package executor
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadCodexCompletedEvent_FindsCompletedEvent(t *testing.T) {
+	body := strings.NewReader("data: {\"type\":\"response.created\"}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\"}}\n\n")
+	var chunks [][]byte
+
+	event, err := readCodexCompletedEvent(body, func(chunk []byte) {
+		chunks = append(chunks, append([]byte(nil), chunk...))
+	})
+	if err != nil {
+		t.Fatalf("readCodexCompletedEvent error = %v", err)
+	}
+	if got := string(event); got != `{"type":"response.completed","response":{"id":"resp_1"}}` {
+		t.Fatalf("event = %s", got)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("chunks len = %d, want 2", len(chunks))
+	}
+}
+
+func TestReadCodexCompletedEvent_ReturnsTimeoutWhenMissingCompleted(t *testing.T) {
+	body := strings.NewReader("data: {\"type\":\"response.created\"}\n")
+
+	_, err := readCodexCompletedEvent(body, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	se, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("err type = %T, want statusErr", err)
+	}
+	if se.code != 408 {
+		t.Fatalf("status code = %d, want 408", se.code)
+	}
+}
+
+type failingReader struct{}
+
+func (failingReader) Read(p []byte) (int, error) {
+	return 0, errors.New("boom")
+}
+
+func TestReadCodexCompletedEvent_PropagatesScannerError(t *testing.T) {
+	_, err := readCodexCompletedEvent(failingReader{}, nil)
+	if err == nil {
+		t.Fatal("expected scanner error, got nil")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReadCodexCompletedEvent_NilBody(t *testing.T) {
+	_, err := readCodexCompletedEvent(io.Reader(nil), nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	se, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("err type = %T, want statusErr", err)
+	}
+	if se.code != 408 {
+		t.Fatalf("status code = %d, want 408", se.code)
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -164,13 +164,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("codex")
-	originalPayloadSource := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayloadSource = opts.OriginalRequest
-	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
-	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+	originalPayload, originalTranslated, body := translateRequestPair(from, to, baseModel, req.Payload, opts.OriginalRequest, false)
 
 	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -364,7 +358,11 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 }
 
 func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
-	log.Debugf("Executing Codex Websockets stream request with auth ID: %s, model: %s", auth.ID, req.Model)
+	authIDForLog := ""
+	if auth != nil {
+		authIDForLog = auth.ID
+	}
+	log.Debugf("Executing Codex Websockets stream request with auth ID: %s, model: %s", authIDForLog, req.Model)
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -88,13 +88,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		to = sdktranslator.FromString("openai-response")
 		endpoint = "/responses/compact"
 	}
-	originalPayloadSource := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayloadSource = opts.OriginalRequest
-	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, opts.Stream)
-	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, opts.Stream)
+	originalPayload, originalTranslated, translated := translateRequestPair(from, to, baseModel, req.Payload, opts.OriginalRequest, opts.Stream)
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	translated = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", translated, originalTranslated, requestedModel)
 	if opts.Alt == "responses/compact" {
@@ -171,7 +165,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	reporter.ensurePublished(ctx)
 	// Translate response back to source format when needed
 	var param any
-	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, body, &param)
+	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, translated, body, &param)
 	resp = cliproxyexecutor.Response{Payload: []byte(out), Headers: httpResp.Header.Clone()}
 	return resp, nil
 }
@@ -190,13 +184,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("openai")
-	originalPayloadSource := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayloadSource = opts.OriginalRequest
-	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
-	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
+	originalPayload, originalTranslated, translated := translateRequestPair(from, to, baseModel, req.Payload, opts.OriginalRequest, true)
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	translated = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", translated, originalTranslated, requestedModel)
 
@@ -284,7 +272,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 			// OpenAI-compatible streams are SSE: lines typically prefixed with "data: ".
 			// Pass through translator; it yields one or more chunks for the target schema.
-			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, bytes.Clone(line), &param)
+			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, originalPayload, translated, bytes.Clone(line), &param)
 			for i := range chunks {
 				out <- cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}
 			}

--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -13,6 +14,13 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/proxy"
 )
+
+type cachedTransport struct {
+	transport *http.Transport
+	err       error
+}
+
+var proxyTransportCache sync.Map
 
 // newProxyAwareHTTPClient creates an HTTP client with proper proxy configuration priority:
 // 1. Use auth.ProxyURL if configured (highest priority)
@@ -56,8 +64,10 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	}
 
 	// Priority 3: Use RoundTripper from context (typically from RoundTripperFor)
-	if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
-		httpClient.Transport = rt
+	if ctx != nil {
+		if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
+			httpClient.Transport = rt
+		}
 	}
 
 	return httpClient
@@ -75,10 +85,23 @@ func buildProxyTransport(proxyURL string) *http.Transport {
 	if proxyURL == "" {
 		return nil
 	}
+	cacheKey := strings.TrimSpace(proxyURL)
+	if cacheKey == "" {
+		return nil
+	}
+	if cached, ok := proxyTransportCache.Load(cacheKey); ok {
+		if typed, okType := cached.(*cachedTransport); okType {
+			if typed == nil || typed.err != nil {
+				return nil
+			}
+			return typed.transport
+		}
+	}
 
 	parsedURL, errParse := url.Parse(proxyURL)
 	if errParse != nil {
 		log.Errorf("parse proxy URL failed: %v", errParse)
+		proxyTransportCache.Store(cacheKey, &cachedTransport{err: errParse})
 		return nil
 	}
 
@@ -96,21 +119,40 @@ func buildProxyTransport(proxyURL string) *http.Transport {
 		dialer, errSOCKS5 := proxy.SOCKS5("tcp", parsedURL.Host, proxyAuth, proxy.Direct)
 		if errSOCKS5 != nil {
 			log.Errorf("create SOCKS5 dialer failed: %v", errSOCKS5)
+			proxyTransportCache.Store(cacheKey, &cachedTransport{err: errSOCKS5})
 			return nil
 		}
 		// Set up a custom transport using the SOCKS5 dialer
 		transport = &http.Transport{
+			Proxy:                 nil,
+			MaxIdleConns:          100,
+			MaxIdleConnsPerHost:   100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+			ForceAttemptHTTP2:     true,
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return dialer.Dial(network, addr)
 			},
 		}
 	} else if parsedURL.Scheme == "http" || parsedURL.Scheme == "https" {
 		// Configure HTTP or HTTPS proxy
-		transport = &http.Transport{Proxy: http.ProxyURL(parsedURL)}
+		transport = &http.Transport{
+			Proxy:                 http.ProxyURL(parsedURL),
+			MaxIdleConns:          100,
+			MaxIdleConnsPerHost:   100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+			ForceAttemptHTTP2:     true,
+		}
 	} else {
 		log.Errorf("unsupported proxy scheme: %s", parsedURL.Scheme)
+		proxyTransportCache.Store(cacheKey, &cachedTransport{err: url.InvalidHostError(parsedURL.Scheme)})
 		return nil
 	}
+
+	proxyTransportCache.Store(cacheKey, &cachedTransport{transport: transport})
 
 	return transport
 }

--- a/internal/runtime/executor/proxy_helpers_test.go
+++ b/internal/runtime/executor/proxy_helpers_test.go
@@ -1,0 +1,31 @@
+package executor
+
+import (
+	"testing"
+)
+
+func TestBuildProxyTransport_CachesByURL(t *testing.T) {
+	proxyURL := "http://127.0.0.1:8080"
+
+	first := buildProxyTransport(proxyURL)
+	if first == nil {
+		t.Fatal("expected first transport, got nil")
+	}
+	second := buildProxyTransport(proxyURL)
+	if second == nil {
+		t.Fatal("expected second transport, got nil")
+	}
+	if first != second {
+		t.Fatal("expected cached transport pointer to be reused")
+	}
+}
+
+func TestBuildProxyTransport_InvalidURLCachedAsFailure(t *testing.T) {
+	proxyURL := "://bad url"
+	if got := buildProxyTransport(proxyURL); got != nil {
+		t.Fatalf("expected nil transport for invalid proxy, got %#v", got)
+	}
+	if got := buildProxyTransport(proxyURL); got != nil {
+		t.Fatalf("expected nil transport for cached invalid proxy, got %#v", got)
+	}
+}

--- a/internal/runtime/executor/request_translate_helpers.go
+++ b/internal/runtime/executor/request_translate_helpers.go
@@ -1,0 +1,31 @@
+package executor
+
+import (
+	"bytes"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+// translateRequestPair translates both runtime and original payloads while avoiding
+// duplicate work when they are identical.
+func translateRequestPair(
+	from sdktranslator.Format,
+	to sdktranslator.Format,
+	baseModel string,
+	payload []byte,
+	original []byte,
+	stream bool,
+) (originalPayload []byte, originalTranslated []byte, translated []byte) {
+	originalPayload = payload
+	if len(original) > 0 {
+		originalPayload = original
+	}
+
+	translated = sdktranslator.TranslateRequest(from, to, baseModel, payload, stream)
+	if bytes.Equal(originalPayload, payload) {
+		return originalPayload, bytes.Clone(translated), translated
+	}
+
+	originalTranslated = sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, stream)
+	return originalPayload, originalTranslated, translated
+}

--- a/internal/runtime/executor/request_translate_helpers_test.go
+++ b/internal/runtime/executor/request_translate_helpers_test.go
@@ -1,0 +1,49 @@
+package executor
+
+import (
+	"bytes"
+	"testing"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+func TestTranslateRequestPair_UsesSingleTranslationForSameOriginal(t *testing.T) {
+	from := sdktranslator.FromString("openai")
+	to := sdktranslator.FromString("codex")
+	payload := []byte(`{"model":"gpt-5","messages":[{"role":"user","content":"hi"}]}`)
+
+	originalPayload, originalTranslated, translated := translateRequestPair(from, to, "gpt-5", payload, nil, false)
+	want := sdktranslator.TranslateRequest(from, to, "gpt-5", payload, false)
+
+	if !bytes.Equal(originalPayload, payload) {
+		t.Fatalf("original payload mismatch\n got: %s\nwant: %s", string(originalPayload), string(payload))
+	}
+	if !bytes.Equal(translated, want) {
+		t.Fatalf("translated payload mismatch\n got: %s\nwant: %s", string(translated), string(want))
+	}
+	if !bytes.Equal(originalTranslated, want) {
+		t.Fatalf("original translated payload mismatch\n got: %s\nwant: %s", string(originalTranslated), string(want))
+	}
+}
+
+func TestTranslateRequestPair_TranslatesOriginalAndRuntimeSeparately(t *testing.T) {
+	from := sdktranslator.FromString("openai")
+	to := sdktranslator.FromString("codex")
+	runtimePayload := []byte(`{"model":"gpt-5","messages":[{"role":"user","content":"runtime"}]}`)
+	originalPayloadInput := []byte(`{"model":"gpt-5","messages":[{"role":"user","content":"original"}]}`)
+
+	originalPayload, originalTranslated, translated := translateRequestPair(from, to, "gpt-5", runtimePayload, originalPayloadInput, false)
+
+	wantRuntime := sdktranslator.TranslateRequest(from, to, "gpt-5", runtimePayload, false)
+	wantOriginal := sdktranslator.TranslateRequest(from, to, "gpt-5", originalPayloadInput, false)
+
+	if !bytes.Equal(originalPayload, originalPayloadInput) {
+		t.Fatalf("original payload mismatch\n got: %s\nwant: %s", string(originalPayload), string(originalPayloadInput))
+	}
+	if !bytes.Equal(translated, wantRuntime) {
+		t.Fatalf("runtime translated payload mismatch\n got: %s\nwant: %s", string(translated), string(wantRuntime))
+	}
+	if !bytes.Equal(originalTranslated, wantOriginal) {
+		t.Fatalf("original translated payload mismatch\n got: %s\nwant: %s", string(originalTranslated), string(wantOriginal))
+	}
+}


### PR DESCRIPTION
## Summary
- reduce duplicate request translation work across Codex, Codex WebSocket, and OpenAI-compat executors by introducing a shared translateRequestPair helper
- optimize non-stream Codex execution to parse SSE incrementally until response.completed instead of buffering the full upstream body
- add cached proxy transport reuse with pooling defaults and nil-safe websocket auth logging to improve throughput and stability

## Validation
- go test ./internal/runtime/executor ./sdk/api/handlers/openai
- go test ./...

## Notes
- includes unit tests for translation helper behavior, Codex completed-event parsing, and proxy transport cache behavior