### PR TITLE
feat: configurable oauth callback domain and unified callback route

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ Get 10% OFF GLM CODING PLAN：https://z.ai/subscribe?ic=8JVLJQFSKB
 
 CLIProxyAPI Guides: [https://help.router-for.me/](https://help.router-for.me/)
 
+## Configurable OAuth Callback Domain
+
+By default, OAuth callbacks keep the existing localhost behavior.
+
+If you want to receive OAuth callbacks through a public domain, enable `oauth-callback` in config:
+
+```yaml
+oauth-callback:
+  enabled: true
+  external-base-url: "https://cliproxy.example.com"
+  provider-paths:
+    anthropic: "/oauth/callback/anthropic"
+    codex: "/oauth/callback/codex"
+    gemini: "/oauth/callback/gemini"
+    iflow: "/oauth/callback/iflow"
+    antigravity: "/oauth/callback/antigravity"
+```
+
+Notes:
+- disabled => legacy localhost callback flow
+- enabled => callback URL uses your external domain + provider path
+- provider console redirect URI must match this config exactly
+- if using Nginx, proxy `/oauth/callback/` to CLIProxyAPI service
+
 ## Management API
 
 see [MANAGEMENT_API.md](https://help.router-for.me/management/api)

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,6 +60,30 @@ GLM CODING PLAN 是专为AI编码打造的订阅套餐，每月最低仅需20元
 
 CLIProxyAPI 用户手册： [https://help.router-for.me/](https://help.router-for.me/cn/)
 
+## 可配置 OAuth 回调域名
+
+默认情况下，OAuth 回调保持现有 localhost 行为不变。
+
+若需要通过公网域名接收 OAuth 回调，可在配置中启用 `oauth-callback`：
+
+```yaml
+oauth-callback:
+  enabled: true
+  external-base-url: "https://cliproxy.example.com"
+  provider-paths:
+    anthropic: "/oauth/callback/anthropic"
+    codex: "/oauth/callback/codex"
+    gemini: "/oauth/callback/gemini"
+    iflow: "/oauth/callback/iflow"
+    antigravity: "/oauth/callback/antigravity"
+```
+
+说明：
+- 关闭时：沿用 localhost 回调流程
+- 开启时：回调地址使用外部域名 + provider 路径
+- provider 控制台中的 redirect URI 必须与配置完全一致
+- 若使用 Nginx，请将 `/oauth/callback/` 反代到 CLIProxyAPI 服务
+
 ## 管理 API 文档
 
 请参见 [MANAGEMENT_API_CN.md](https://help.router-for.me/cn/management/api)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -31,6 +31,18 @@ remote-management:
 # Authentication directory (supports ~ for home directory)
 auth-dir: "~/.cli-proxy-api"
 
+# Optional OAuth callback domain/path override.
+# Disabled by default to preserve existing localhost callback behavior.
+# oauth-callback:
+#   enabled: true
+#   external-base-url: "https://cliproxy.example.com"
+#   provider-paths:
+#     anthropic: "/oauth/callback/anthropic"
+#     codex: "/oauth/callback/codex"
+#     gemini: "/oauth/callback/gemini"
+#     iflow: "/oauth/callback/iflow"
+#     antigravity: "/oauth/callback/antigravity"
+
 # API keys for authentication
 api-keys:
   - "your-api-key-1"

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -28,6 +29,7 @@ import (
 	iflowauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/iflow"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
@@ -125,6 +127,27 @@ func isWebUIRequest(c *gin.Context) bool {
 	default:
 		return false
 	}
+}
+
+func isExternalOAuthCallbackMode(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	if !cfg.OAuthCallback.Enabled {
+		return false
+	}
+	return strings.TrimSpace(cfg.OAuthCallback.ExternalBaseURL) != ""
+}
+
+func addOrReplaceQueryValue(rawURL, key, value string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set(key, value)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
 }
 
 func startCallbackForwarder(port int, provider, targetBase string) (*callbackForwarder, error) {
@@ -1018,17 +1041,29 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	// Initialize Claude auth service
 	anthropicAuth := claude.NewClaudeAuth(h.cfg)
 
-	// Generate authorization URL (then override redirect_uri to reuse server port)
+	redirectURI, err := BuildOAuthRedirectURI(h.cfg, "anthropic", claude.RedirectURI)
+	if err != nil {
+		log.Errorf("Failed to build redirect URI: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build redirect uri"})
+		return
+	}
+
+	// Generate authorization URL (then override redirect_uri to reuse configured callback)
 	authURL, state, err := anthropicAuth.GenerateAuthURL(state, pkceCodes)
 	if err != nil {
 		log.Errorf("Failed to generate authorization URL: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate authorization url"})
 		return
 	}
+	if authURL, err = addOrReplaceQueryValue(authURL, "redirect_uri", redirectURI); err != nil {
+		log.Errorf("Failed to apply redirect URI: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to apply redirect uri"})
+		return
+	}
 
 	RegisterOAuthSession(state, "anthropic")
 
-	isWebUI := isWebUIRequest(c)
+	isWebUI := isWebUIRequest(c) && !isExternalOAuthCallbackMode(h.cfg)
 	var forwarder *callbackForwarder
 	if isWebUI {
 		targetURL, errTarget := h.managementCallbackURL("/anthropic/callback")
@@ -1102,7 +1137,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 		code := strings.Split(rawCode, "#")[0]
 
 		// Exchange code for tokens using internal auth service
-		bundle, errExchange := anthropicAuth.ExchangeCodeForTokens(ctx, code, state, pkceCodes)
+		bundle, errExchange := anthropicAuth.ExchangeCodeForTokensWithRedirect(ctx, code, state, redirectURI, pkceCodes)
 		if errExchange != nil {
 			authErr := claude.NewAuthenticationError(claude.ErrCodeExchangeFailed, errExchange)
 			log.Errorf("Failed to exchange authorization code for tokens: %v", authErr)
@@ -1149,11 +1184,18 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 
 	fmt.Println("Initializing Google authentication...")
 
+	redirectURI, err := BuildOAuthRedirectURI(h.cfg, "gemini", fmt.Sprintf("http://localhost:%d/oauth2callback", geminiAuth.DefaultCallbackPort))
+	if err != nil {
+		log.Errorf("Failed to build redirect URI: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build redirect uri"})
+		return
+	}
+
 	// OAuth2 configuration using exported constants from internal/auth/gemini
 	conf := &oauth2.Config{
 		ClientID:     geminiAuth.ClientID,
 		ClientSecret: geminiAuth.ClientSecret,
-		RedirectURL:  fmt.Sprintf("http://localhost:%d/oauth2callback", geminiAuth.DefaultCallbackPort),
+		RedirectURL:  redirectURI,
 		Scopes:       geminiAuth.Scopes,
 		Endpoint:     google.Endpoint,
 	}
@@ -1164,7 +1206,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 
 	RegisterOAuthSession(state, "gemini")
 
-	isWebUI := isWebUIRequest(c)
+	isWebUI := isWebUIRequest(c) && !isExternalOAuthCallbackMode(h.cfg)
 	var forwarder *callbackForwarder
 	if isWebUI {
 		targetURL, errTarget := h.managementCallbackURL("/google/callback")
@@ -1422,6 +1464,13 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 	// Initialize Codex auth service
 	openaiAuth := codex.NewCodexAuth(h.cfg)
 
+	redirectURI, err := BuildOAuthRedirectURI(h.cfg, "codex", codex.RedirectURI)
+	if err != nil {
+		log.Errorf("Failed to build redirect URI: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build redirect uri"})
+		return
+	}
+
 	// Generate authorization URL
 	authURL, err := openaiAuth.GenerateAuthURL(state, pkceCodes)
 	if err != nil {
@@ -1429,10 +1478,15 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate authorization url"})
 		return
 	}
+	if authURL, err = addOrReplaceQueryValue(authURL, "redirect_uri", redirectURI); err != nil {
+		log.Errorf("Failed to apply redirect URI: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to apply redirect uri"})
+		return
+	}
 
 	RegisterOAuthSession(state, "codex")
 
-	isWebUI := isWebUIRequest(c)
+	isWebUI := isWebUIRequest(c) && !isExternalOAuthCallbackMode(h.cfg)
 	var forwarder *callbackForwarder
 	if isWebUI {
 		targetURL, errTarget := h.managementCallbackURL("/codex/callback")
@@ -1492,7 +1546,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 
 		log.Debug("Authorization code received, exchanging for tokens...")
 		// Exchange code for tokens using internal auth service
-		bundle, errExchange := openaiAuth.ExchangeCodeForTokens(ctx, code, pkceCodes)
+		bundle, errExchange := openaiAuth.ExchangeCodeForTokensWithRedirect(ctx, code, redirectURI, pkceCodes)
 		if errExchange != nil {
 			authErr := codex.NewAuthenticationError(codex.ErrCodeExchangeFailed, errExchange)
 			SetOAuthSessionError(state, "Failed to exchange authorization code for tokens")
@@ -1558,12 +1612,17 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 		return
 	}
 
-	redirectURI := fmt.Sprintf("http://localhost:%d/oauth-callback", antigravity.CallbackPort)
+	redirectURI, err := BuildOAuthRedirectURI(h.cfg, "antigravity", fmt.Sprintf("http://localhost:%d/oauth-callback", antigravity.CallbackPort))
+	if err != nil {
+		log.Errorf("Failed to build redirect URI: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build redirect uri"})
+		return
+	}
 	authURL := authSvc.BuildAuthURL(state, redirectURI)
 
 	RegisterOAuthSession(state, "antigravity")
 
-	isWebUI := isWebUIRequest(c)
+	isWebUI := isWebUIRequest(c) && !isExternalOAuthCallbackMode(h.cfg)
 	var forwarder *callbackForwarder
 	if isWebUI {
 		targetURL, errTarget := h.managementCallbackURL("/antigravity/callback")
@@ -1850,10 +1909,22 @@ func (h *Handler) RequestIFlowToken(c *gin.Context) {
 	state := fmt.Sprintf("ifl-%d", time.Now().UnixNano())
 	authSvc := iflowauth.NewIFlowAuth(h.cfg)
 	authURL, redirectURI := authSvc.AuthorizationURL(state, iflowauth.CallbackPort)
+	oauthRedirectURI, err := BuildOAuthRedirectURI(h.cfg, "iflow", redirectURI)
+	if err != nil {
+		log.Errorf("Failed to build redirect URI: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "failed to build redirect uri"})
+		return
+	}
+	if authURL, err = addOrReplaceQueryValue(authURL, "redirect", oauthRedirectURI); err != nil {
+		log.Errorf("Failed to apply redirect URI: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "failed to apply redirect uri"})
+		return
+	}
+	redirectURI = oauthRedirectURI
 
 	RegisterOAuthSession(state, "iflow")
 
-	isWebUI := isWebUIRequest(c)
+	isWebUI := isWebUIRequest(c) && !isExternalOAuthCallbackMode(h.cfg)
 	var forwarder *callbackForwarder
 	if isWebUI {
 		targetURL, errTarget := h.managementCallbackURL("/iflow/callback")

--- a/internal/api/handlers/management/auth_files_oauth_redirect_test.go
+++ b/internal/api/handlers/management/auth_files_oauth_redirect_test.go
@@ -1,0 +1,108 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func performOAuthURLRequest(t *testing.T, h *Handler, path string, call func(*gin.Context)) (string, string) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", path, nil)
+
+	call(c)
+
+	var resp struct {
+		URL   string `json:"url"`
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.URL == "" {
+		t.Fatalf("expected auth URL in response, got empty")
+	}
+	if resp.State != "" {
+		CompleteOAuthSession(resp.State)
+	}
+	return resp.URL, resp.State
+}
+
+func queryValue(t *testing.T, rawURL, key string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("failed to parse url %q: %v", rawURL, err)
+	}
+	return u.Query().Get(key)
+}
+
+func newOAuthCallbackEnabledHandler(t *testing.T) *Handler {
+	t.Helper()
+	cfg := &config.Config{
+		AuthDir: t.TempDir(),
+		OAuthCallback: config.OAuthCallbackConfig{
+			Enabled:         true,
+			ExternalBaseURL: "https://cliproxy.example.com",
+			ProviderPaths: map[string]string{
+				"anthropic":   "/oauth/callback/anthropic",
+				"codex":       "/oauth/callback/codex",
+				"gemini":      "/oauth/callback/gemini",
+				"iflow":       "/oauth/callback/iflow",
+				"antigravity": "/oauth/callback/antigravity",
+			},
+		},
+	}
+	return &Handler{cfg: cfg}
+}
+
+func TestRequestAnthropicTokenRedirectURI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newOAuthCallbackEnabledHandler(t)
+	authURL, _ := performOAuthURLRequest(t, h, "/v0/management/anthropic-auth-url", h.RequestAnthropicToken)
+	if got := queryValue(t, authURL, "redirect_uri"); got != "https://cliproxy.example.com/oauth/callback/anthropic" {
+		t.Fatalf("unexpected redirect_uri: %s", got)
+	}
+}
+
+func TestRequestCodexTokenRedirectURI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newOAuthCallbackEnabledHandler(t)
+	authURL, _ := performOAuthURLRequest(t, h, "/v0/management/codex-auth-url", h.RequestCodexToken)
+	if got := queryValue(t, authURL, "redirect_uri"); got != "https://cliproxy.example.com/oauth/callback/codex" {
+		t.Fatalf("unexpected redirect_uri: %s", got)
+	}
+}
+
+func TestRequestGeminiCLITokenRedirectURI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newOAuthCallbackEnabledHandler(t)
+	authURL, _ := performOAuthURLRequest(t, h, "/v0/management/gemini-cli-auth-url", h.RequestGeminiCLIToken)
+	if got := queryValue(t, authURL, "redirect_uri"); got != "https://cliproxy.example.com/oauth/callback/gemini" {
+		t.Fatalf("unexpected redirect_uri: %s", got)
+	}
+}
+
+func TestRequestIFlowTokenRedirectURI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newOAuthCallbackEnabledHandler(t)
+	authURL, _ := performOAuthURLRequest(t, h, "/v0/management/iflow-auth-url", h.RequestIFlowToken)
+	if got := queryValue(t, authURL, "redirect"); got != "https://cliproxy.example.com/oauth/callback/iflow" {
+		t.Fatalf("unexpected redirect: %s", got)
+	}
+}
+
+func TestRequestAntigravityTokenRedirectURI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newOAuthCallbackEnabledHandler(t)
+	authURL, _ := performOAuthURLRequest(t, h, "/v0/management/antigravity-auth-url", h.RequestAntigravityToken)
+	if got := queryValue(t, authURL, "redirect_uri"); got != "https://cliproxy.example.com/oauth/callback/antigravity" {
+		t.Fatalf("unexpected redirect_uri: %s", got)
+	}
+}

--- a/internal/api/handlers/management/oauth_callback_url.go
+++ b/internal/api/handlers/management/oauth_callback_url.go
@@ -1,0 +1,61 @@
+package management
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+var defaultOAuthCallbackProviderPaths = map[string]string{
+	"anthropic":   "/oauth/callback/anthropic",
+	"codex":       "/oauth/callback/codex",
+	"gemini":      "/oauth/callback/gemini",
+	"iflow":       "/oauth/callback/iflow",
+	"antigravity": "/oauth/callback/antigravity",
+}
+
+func BuildOAuthRedirectURI(cfg *config.Config, provider, fallback string) (string, error) {
+	if cfg == nil || !cfg.OAuthCallback.Enabled {
+		return fallback, nil
+	}
+
+	base := strings.TrimSpace(cfg.OAuthCallback.ExternalBaseURL)
+	if base == "" {
+		return fallback, nil
+	}
+
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("invalid oauth callback external base url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("invalid oauth callback external base url scheme: %s", u.Scheme)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("invalid oauth callback external base url host")
+	}
+
+	canonicalProvider, err := NormalizeOAuthProvider(provider)
+	if err != nil {
+		return "", err
+	}
+
+	path := ""
+	if cfg.OAuthCallback.ProviderPaths != nil {
+		path = strings.TrimSpace(cfg.OAuthCallback.ProviderPaths[canonicalProvider])
+	}
+	if path == "" {
+		path = defaultOAuthCallbackProviderPaths[canonicalProvider]
+	}
+	if path == "" {
+		return "", fmt.Errorf("unsupported oauth provider: %s", canonicalProvider)
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	full := strings.TrimRight(base, "/") + path
+	return full, nil
+}

--- a/internal/api/handlers/management/oauth_callback_url_test.go
+++ b/internal/api/handlers/management/oauth_callback_url_test.go
@@ -1,0 +1,33 @@
+package management
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestOAuthCallbackURLBuilder_DefaultFallback(t *testing.T) {
+	cfg := &config.Config{}
+	got, err := BuildOAuthRedirectURI(cfg, "codex", "http://localhost:1455/auth/callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "http://localhost:1455/auth/callback" {
+		t.Fatalf("got %s", got)
+	}
+}
+
+func TestOAuthCallbackURLBuilder_ExternalMode(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.OAuthCallback.Enabled = true
+	cfg.OAuthCallback.ExternalBaseURL = "https://cliproxy.example.com"
+	cfg.OAuthCallback.ProviderPaths = map[string]string{"codex": "/oauth/callback/codex"}
+
+	got, err := BuildOAuthRedirectURI(cfg, "codex", "http://localhost:1455/auth/callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://cliproxy.example.com/oauth/callback/codex" {
+		t.Fatal(got)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -363,7 +363,7 @@ func (s *Server) setupRoutes() {
 	// OAuth callback endpoints (reuse main server port)
 	// These endpoints receive provider redirects and persist
 	// the short-lived code/state for the waiting goroutine.
-	s.engine.GET("/anthropic/callback", func(c *gin.Context) {
+	handleOAuthCallback := func(provider string, c *gin.Context) {
 		code := c.Query("code")
 		state := c.Query("state")
 		errStr := c.Query("error")
@@ -371,67 +371,28 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "anthropic", state, code, errStr)
+			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, provider, state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
+	}
+
+	s.engine.GET("/oauth/callback/:provider", func(c *gin.Context) {
+		rawProvider := strings.TrimSpace(c.Param("provider"))
+		provider, err := managementHandlers.NormalizeOAuthProvider(rawProvider)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid oauth provider"})
+			return
+		}
+		handleOAuthCallback(provider, c)
 	})
 
-	s.engine.GET("/codex/callback", func(c *gin.Context) {
-		code := c.Query("code")
-		state := c.Query("state")
-		errStr := c.Query("error")
-		if errStr == "" {
-			errStr = c.Query("error_description")
-		}
-		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "codex", state, code, errStr)
-		}
-		c.Header("Content-Type", "text/html; charset=utf-8")
-		c.String(http.StatusOK, oauthCallbackSuccessHTML)
-	})
-
-	s.engine.GET("/google/callback", func(c *gin.Context) {
-		code := c.Query("code")
-		state := c.Query("state")
-		errStr := c.Query("error")
-		if errStr == "" {
-			errStr = c.Query("error_description")
-		}
-		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "gemini", state, code, errStr)
-		}
-		c.Header("Content-Type", "text/html; charset=utf-8")
-		c.String(http.StatusOK, oauthCallbackSuccessHTML)
-	})
-
-	s.engine.GET("/iflow/callback", func(c *gin.Context) {
-		code := c.Query("code")
-		state := c.Query("state")
-		errStr := c.Query("error")
-		if errStr == "" {
-			errStr = c.Query("error_description")
-		}
-		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "iflow", state, code, errStr)
-		}
-		c.Header("Content-Type", "text/html; charset=utf-8")
-		c.String(http.StatusOK, oauthCallbackSuccessHTML)
-	})
-
-	s.engine.GET("/antigravity/callback", func(c *gin.Context) {
-		code := c.Query("code")
-		state := c.Query("state")
-		errStr := c.Query("error")
-		if errStr == "" {
-			errStr = c.Query("error_description")
-		}
-		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "antigravity", state, code, errStr)
-		}
-		c.Header("Content-Type", "text/html; charset=utf-8")
-		c.String(http.StatusOK, oauthCallbackSuccessHTML)
-	})
+	// Legacy routes kept for backward compatibility and provider platform constraints.
+	s.engine.GET("/anthropic/callback", func(c *gin.Context) { handleOAuthCallback("anthropic", c) })
+	s.engine.GET("/codex/callback", func(c *gin.Context) { handleOAuthCallback("codex", c) })
+	s.engine.GET("/google/callback", func(c *gin.Context) { handleOAuthCallback("gemini", c) })
+	s.engine.GET("/iflow/callback", func(c *gin.Context) { handleOAuthCallback("iflow", c) })
+	s.engine.GET("/antigravity/callback", func(c *gin.Context) { handleOAuthCallback("antigravity", c) })
 
 	// Management routes are registered lazily by registerManagementRoutes when a secret is configured.
 }

--- a/internal/api/server_oauth_callback_route_test.go
+++ b/internal/api/server_oauth_callback_route_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
+)
+
+func TestOAuthUnifiedCallbackRoute_WritesPendingSessionFile(t *testing.T) {
+	server := newTestServer(t)
+	state := "state-unified-callback-test"
+	management.RegisterOAuthSession(state, "codex")
+	defer management.CompleteOAuthSession(state)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback/codex?code=abc&state="+state, nil)
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	callbackFile := filepath.Join(server.cfg.AuthDir, ".oauth-codex-"+state+".oauth")
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(callbackFile); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected callback file to be created: %s", callbackFile)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/auth/claude/anthropic_auth.go
+++ b/internal/auth/claude/anthropic_auth.go
@@ -130,8 +130,15 @@ func (c *ClaudeAuth) parseCodeAndState(code string) (parsedCode, parsedState str
 //   - *ClaudeAuthBundle: The complete authentication bundle with tokens
 //   - error: An error if token exchange fails
 func (o *ClaudeAuth) ExchangeCodeForTokens(ctx context.Context, code, state string, pkceCodes *PKCECodes) (*ClaudeAuthBundle, error) {
+	return o.ExchangeCodeForTokensWithRedirect(ctx, code, state, RedirectURI, pkceCodes)
+}
+
+func (o *ClaudeAuth) ExchangeCodeForTokensWithRedirect(ctx context.Context, code, state, redirectURI string, pkceCodes *PKCECodes) (*ClaudeAuthBundle, error) {
 	if pkceCodes == nil {
 		return nil, fmt.Errorf("PKCE codes are required for token exchange")
+	}
+	if strings.TrimSpace(redirectURI) == "" {
+		return nil, fmt.Errorf("redirect URI is required for token exchange")
 	}
 	newCode, newState := o.parseCodeAndState(code)
 
@@ -141,7 +148,7 @@ func (o *ClaudeAuth) ExchangeCodeForTokens(ctx context.Context, code, state stri
 		"state":         state,
 		"grant_type":    "authorization_code",
 		"client_id":     ClientID,
-		"redirect_uri":  RedirectURI,
+		"redirect_uri":  redirectURI,
 		"code_verifier": pkceCodes.CodeVerifier,
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,8 @@ const (
 // Config represents the application's configuration, loaded from a YAML file.
 type Config struct {
 	SDKConfig `yaml:",inline"`
+	// OAuthCallback configures optional external OAuth callback URLs and provider paths.
+	OAuthCallback OAuthCallbackConfig `yaml:"oauth-callback" json:"oauth-callback"`
 	// Host is the network host/interface on which the API server will bind.
 	// Default is empty ("") to bind all interfaces (IPv4 + IPv6). Use "127.0.0.1" or "localhost" for local-only access.
 	Host string `yaml:"host" json:"-"`
@@ -162,6 +164,13 @@ type RemoteManagement struct {
 	// PanelGitHubRepository overrides the GitHub repository used to fetch the management panel asset.
 	// Accepts either a repository URL (https://github.com/org/repo) or an API releases endpoint.
 	PanelGitHubRepository string `yaml:"panel-github-repository"`
+}
+
+// OAuthCallbackConfig defines optional external OAuth callback settings.
+type OAuthCallbackConfig struct {
+	Enabled         bool              `yaml:"enabled" json:"enabled"`
+	ExternalBaseURL string            `yaml:"external-base-url" json:"external-base-url"`
+	ProviderPaths   map[string]string `yaml:"provider-paths" json:"provider-paths"`
 }
 
 // QuotaExceeded defines the behavior when API quota limits are exceeded.

--- a/internal/config/oauth_callback_config_test.go
+++ b/internal/config/oauth_callback_config_test.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+	return path
+}
+
+func TestLoadConfig_DefaultOAuthCallbackDisabled(t *testing.T) {
+	path := writeTempConfigFile(t, "host: \"\"\nport: 8317\nauth-dir: \"~/.cli-proxy-api\"\n")
+	cfg, err := LoadConfigOptional(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.OAuthCallback.Enabled {
+		t.Fatal("expected oauth-callback.enabled default false")
+	}
+}
+
+func TestLoadConfig_OAuthCallbackCustomValues(t *testing.T) {
+	path := writeTempConfigFile(t, "host: \"\"\nport: 8317\nauth-dir: \"~/.cli-proxy-api\"\noauth-callback:\n  enabled: true\n  external-base-url: \"https://cliproxy.example.com\"\n  provider-paths:\n    codex: \"/oauth/callback/codex\"\n")
+	cfg, err := LoadConfigOptional(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.OAuthCallback.ExternalBaseURL != "https://cliproxy.example.com" {
+		t.Fatalf("unexpected base url: %s", cfg.OAuthCallback.ExternalBaseURL)
+	}
+}


### PR DESCRIPTION
## Summary
- add optional `oauth-callback` config block to support external callback domain + provider paths while preserving localhost behavior by default
- wire management OAuth flows (Anthropic/Codex/Gemini/iFlow/Antigravity) to use one redirect URI source for both auth URL generation and token exchange
- add unified callback route `/oauth/callback/:provider` and keep legacy callback routes for compatibility; update README and README_CN examples

## Test Plan
- [x] `go test ./internal/config -run OAuthCallback -v`
- [x] `go test ./internal/api/handlers/management -run "Request.*RedirectURI|OAuthCallbackURLBuilder" -v`
- [x] `go test ./internal/api -run OAuthUnifiedCallbackRoute -v`
- [x] `go test ./internal/config ./internal/api ./internal/api/handlers/management -v`
- [x] `go test ./...`