### PR TITLE
fix(translator): strip defer_loading/cache_control for Codex tools

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -255,6 +255,9 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 			tool, _ = sjson.SetRaw(tool, "parameters", normalizeToolParameters(toolResult.Get("input_schema").Raw))
 			tool, _ = sjson.Delete(tool, "input_schema")
 			tool, _ = sjson.Delete(tool, "parameters.$schema")
+			// Strip Anthropic-only fields that Codex doesn't understand
+			tool, _ = sjson.Delete(tool, "defer_loading")
+			tool, _ = sjson.Delete(tool, "cache_control")
 			tool, _ = sjson.Set(tool, "strict", false)
 			template, _ = sjson.SetRaw(template, "tools.-1", tool)
 		}

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -1,0 +1,30 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertClaudeRequestToCodex_StripsDeferLoadingAndCacheControl(t *testing.T) {
+	in := []byte(`{
+		"model":"any",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"name":"t1",
+			"description":"d",
+			"input_schema":{"type":"object","properties":{}},
+			"defer_loading":true,
+			"cache_control":{"type":"ephemeral"}
+		}]
+	}`)
+
+	out := ConvertClaudeRequestToCodex("gpt-5.3-codex", in, false)
+
+	if gjson.GetBytes(out, "tools.0.defer_loading").Exists() {
+		t.Fatalf("tools.0.defer_loading should be stripped: %s", string(out))
+	}
+	if gjson.GetBytes(out, "tools.0.cache_control").Exists() {
+		t.Fatalf("tools.0.cache_control should be stripped: %s", string(out))
+	}
+}


### PR DESCRIPTION
### What
Claude Code (>=2.x) can include Anthropic-only fields like `defer_loading` and `cache_control` inside `tools[]`. When CLIProxyAPI translates **Claude -> Codex** requests, forwarding these fields can cause upstream Codex/OpenAI-compatible backends to return 400 `unknown_parameter` (e.g. `tools.defer_loading`).

### Fix
- Strip `defer_loading` and `cache_control` from each tool in `internal/translator/codex/claude/ConvertClaudeRequestToCodex`.
- Add unit test to prevent regression.

### Testing
- `go test ./...`
