### PR TITLE
feat: add earliest-reset routing strategy for quota-aware credential selection

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -89,7 +89,7 @@ quota-exceeded:
 
 # Routing strategy for selecting credentials when multiple match.
 routing:
-  strategy: "round-robin" # round-robin (default), fill-first
+  strategy: "round-robin" # round-robin (default), fill-first, earliest-reset
 
 # When true, enable authentication for the WebSocket API (/v1/ws).
 ws-auth: false

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -286,6 +286,8 @@ func normalizeRoutingStrategy(strategy string) (string, bool) {
 		return "round-robin", true
 	case "fill-first", "fillfirst", "ff":
 		return "fill-first", true
+	case "earliest-reset", "earliestreset", "er":
+		return "earliest-reset", true
 	default:
 		return "", false
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -177,7 +177,7 @@ type QuotaExceeded struct {
 // RoutingConfig configures how credentials are selected for requests.
 type RoutingConfig struct {
 	// Strategy selects the credential selection strategy.
-	// Supported values: "round-robin" (default), "fill-first".
+	// Supported values: "round-robin" (default), "fill-first", "earliest-reset".
 	Strategy string `yaml:"strategy,omitempty" json:"strategy,omitempty"`
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -84,6 +84,18 @@ func quotaCooldownDisabledForAuth(auth *Auth) bool {
 }
 
 // Result captures execution outcome used to adjust auth state.
+// RateLimitHint carries parsed upstream rate limit metadata extracted from
+// response headers. Only the fields needed for routing are included to
+// avoid exposing raw upstream headers to hooks or logs.
+type RateLimitHint struct {
+	// Reset is when the token quota window resets.
+	Reset time.Time
+	// Remaining is the number of tokens left in the current window.
+	Remaining int64
+	// Limit is the total token budget for the current window.
+	Limit int64
+}
+
 type Result struct {
 	// AuthID references the auth that produced this result.
 	AuthID string
@@ -97,6 +109,8 @@ type Result struct {
 	RetryAfter *time.Duration
 	// Error describes the failure when Success is false.
 	Error *Error
+	// RateLimit carries parsed rate limit metadata from upstream response headers.
+	RateLimit *RateLimitHint
 }
 
 // Selector chooses an auth candidate for execution.
@@ -658,6 +672,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			lastErr = errExec
 			continue
 		}
+		result.RateLimit = parseRateLimitHint(resp.Headers)
 		m.MarkResult(execCtx, result)
 		return resp, nil
 	}
@@ -720,6 +735,14 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			lastErr = errExec
 			continue
 		}
+		if hint := parseRateLimitHint(resp.Headers); hint != nil {
+			result.RateLimit = hint
+			m.mu.Lock()
+			if a, ok := m.auths[auth.ID]; ok {
+				applyRateLimitHint(a, hint)
+			}
+			m.mu.Unlock()
+		}
 		m.hook.OnResult(execCtx, result)
 		return resp, nil
 	}
@@ -780,8 +803,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			lastErr = errStream
 			continue
 		}
+		streamRLHint := parseRateLimitHint(streamResult.Headers)
 		out := make(chan cliproxyexecutor.StreamChunk)
-		go func(streamCtx context.Context, streamAuth *Auth, streamProvider string, streamChunks <-chan cliproxyexecutor.StreamChunk) {
+		go func(streamCtx context.Context, streamAuth *Auth, streamProvider string, streamChunks <-chan cliproxyexecutor.StreamChunk, rlHint *RateLimitHint) {
 			defer close(out)
 			var failed bool
 			forward := true
@@ -808,9 +832,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				}
 			}
 			if !failed {
-				m.MarkResult(streamCtx, Result{AuthID: streamAuth.ID, Provider: streamProvider, Model: routeModel, Success: true})
+				m.MarkResult(streamCtx, Result{AuthID: streamAuth.ID, Provider: streamProvider, Model: routeModel, Success: true, RateLimit: rlHint})
 			}
-		}(execCtx, auth.Clone(), provider, streamResult.Chunks)
+		}(execCtx, auth.Clone(), provider, streamResult.Chunks, streamRLHint)
 		return &cliproxyexecutor.StreamResult{
 			Headers: streamResult.Headers,
 			Chunks:  out,
@@ -1265,6 +1289,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				clearModelQuota = true
 			} else {
 				clearAuthStateOnSuccess(auth, now)
+			}
+			if result.RateLimit != nil {
+				applyRateLimitHint(auth, result.RateLimit)
 			}
 		} else {
 			if result.Model != "" {
@@ -2415,4 +2442,60 @@ func (m *Manager) HttpRequest(ctx context.Context, auth *Auth, req *http.Request
 		return nil, &Error{Code: "provider_not_found", Message: "executor not registered for provider: " + providerKey}
 	}
 	return exec.HttpRequest(ctx, auth, req)
+}
+
+// Rate limit header constants used by Anthropic/Claude API.
+const (
+	headerRateLimitReset     = "anthropic-ratelimit-tokens-reset"
+	headerRateLimitRemaining = "anthropic-ratelimit-tokens-remaining"
+	headerRateLimitLimit     = "anthropic-ratelimit-tokens-limit"
+)
+
+// parseRateLimitHint extracts rate limit metadata from upstream response headers.
+// Returns nil if no relevant headers are present.
+func parseRateLimitHint(headers http.Header) *RateLimitHint {
+	if len(headers) == 0 {
+		return nil
+	}
+	var hint RateLimitHint
+	var found bool
+	if v := headers.Get(headerRateLimitReset); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			hint.Reset = t
+			found = true
+		}
+	}
+	if v := headers.Get(headerRateLimitRemaining); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			hint.Remaining = n
+			found = true
+		}
+	}
+	if v := headers.Get(headerRateLimitLimit); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			hint.Limit = n
+			found = true
+		}
+	}
+	if !found {
+		return nil
+	}
+	return &hint
+}
+
+// applyRateLimitHint writes parsed rate limit data into the auth's quota state.
+// Caller must hold m.mu.
+func applyRateLimitHint(auth *Auth, hint *RateLimitHint) {
+	if hint == nil || auth == nil {
+		return
+	}
+	if !hint.Reset.IsZero() {
+		auth.Quota.WindowResetAt = hint.Reset
+	}
+	if hint.Remaining > 0 {
+		auth.Quota.TokensRemaining = hint.Remaining
+	}
+	if hint.Limit > 0 {
+		auth.Quota.TokensLimit = hint.Limit
+	}
 }

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -420,3 +420,29 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	}
 	return false, blockReasonNone, time.Time{}
 }
+
+// EarliestResetSelector picks the credential whose upstream quota window resets
+// soonest ("use perishable quota first"). Credentials that have rate limit data
+// are preferred over those without. When no data is available (cold start), it
+// falls back to ID order (same as FillFirstSelector).
+type EarliestResetSelector struct{}
+
+func (s *EarliestResetSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	if len(auths) == 0 {
+		return nil, &Error{Code: "no_auth_available", Message: "no auths provided"}
+	}
+	sorted := make([]*Auth, len(auths))
+	copy(sorted, auths)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		iHas := !sorted[i].Quota.WindowResetAt.IsZero()
+		jHas := !sorted[j].Quota.WindowResetAt.IsZero()
+		if iHas != jHas {
+			return iHas
+		}
+		if iHas && jHas {
+			return sorted[i].Quota.WindowResetAt.Before(sorted[j].Quota.WindowResetAt)
+		}
+		return sorted[i].ID < sorted[j].ID
+	})
+	return sorted[0], nil
+}

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -527,3 +527,61 @@ func TestRoundRobinSelectorPick_MixedVirtualAndNonVirtualFallsBackToFlat(t *test
 		}
 	}
 }
+
+func TestEarliestResetSelectorPick_PrefersEarliestReset(t *testing.T) {
+	t.Parallel()
+
+	selector := &EarliestResetSelector{}
+	now := time.Now()
+	auths := []*Auth{
+		{ID: "a", Quota: QuotaState{WindowResetAt: now.Add(5 * time.Hour)}},
+		{ID: "b", Quota: QuotaState{WindowResetAt: now.Add(1 * time.Hour)}},
+		{ID: "c", Quota: QuotaState{WindowResetAt: now.Add(3 * time.Hour)}},
+	}
+
+	got, err := selector.Pick(context.Background(), "claude", "", cliproxyexecutor.Options{}, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if got.ID != "b" {
+		t.Fatalf("Pick() auth.ID = %q, want %q (earliest reset)", got.ID, "b")
+	}
+}
+
+func TestEarliestResetSelectorPick_ColdStartFallsBackToIDOrder(t *testing.T) {
+	t.Parallel()
+
+	selector := &EarliestResetSelector{}
+	auths := []*Auth{
+		{ID: "c"},
+		{ID: "a"},
+		{ID: "b"},
+	}
+
+	got, err := selector.Pick(context.Background(), "claude", "", cliproxyexecutor.Options{}, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if got.ID != "a" {
+		t.Fatalf("Pick() auth.ID = %q, want %q (ID order fallback)", got.ID, "a")
+	}
+}
+
+func TestEarliestResetSelectorPick_DataPreferredOverNoData(t *testing.T) {
+	t.Parallel()
+
+	selector := &EarliestResetSelector{}
+	now := time.Now()
+	auths := []*Auth{
+		{ID: "a"}, // no rate limit data
+		{ID: "b", Quota: QuotaState{WindowResetAt: now.Add(5 * time.Hour)}},
+	}
+
+	got, err := selector.Pick(context.Background(), "claude", "", cliproxyexecutor.Options{}, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if got.ID != "b" {
+		t.Fatalf("Pick() auth.ID = %q, want %q (has data should be preferred)", got.ID, "b")
+	}
+}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -105,6 +105,12 @@ type QuotaState struct {
 	NextRecoverAt time.Time `json:"next_recover_at"`
 	// BackoffLevel stores the progressive cooldown exponent used for rate limits.
 	BackoffLevel int `json:"backoff_level,omitempty"`
+	// WindowResetAt records when the upstream token quota window resets.
+	WindowResetAt time.Time `json:"window_reset_at,omitempty"`
+	// TokensRemaining is the last observed remaining token count.
+	TokensRemaining int64 `json:"tokens_remaining,omitempty"`
+	// TokensLimit is the total token budget for the current window.
+	TokensLimit int64 `json:"tokens_limit,omitempty"`
 }
 
 // ModelState captures the execution state for a specific model under an auth entry.

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -215,6 +215,8 @@ func (b *Builder) Build() (*Service, error) {
 		switch strategy {
 		case "fill-first", "fillfirst", "ff":
 			selector = &coreauth.FillFirstSelector{}
+		case "earliest-reset", "earliestreset", "er":
+			selector = &coreauth.EarliestResetSelector{}
 		default:
 			selector = &coreauth.RoundRobinSelector{}
 		}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -578,6 +578,8 @@ func (s *Service) Run(ctx context.Context) error {
 			switch strategy {
 			case "fill-first", "fillfirst", "ff":
 				return "fill-first"
+			case "earliest-reset", "earliestreset", "er":
+				return "earliest-reset"
 			default:
 				return "round-robin"
 			}
@@ -589,6 +591,8 @@ func (s *Service) Run(ctx context.Context) error {
 			switch nextStrategy {
 			case "fill-first":
 				selector = &coreauth.FillFirstSelector{}
+			case "earliest-reset":
+				selector = &coreauth.EarliestResetSelector{}
 			default:
 				selector = &coreauth.RoundRobinSelector{}
 			}


### PR DESCRIPTION
## Summary

Add a new `earliest-reset` routing strategy that prioritizes credentials whose upstream quota window resets soonest. This implements a "use perishable quota first" pattern — when multiple credentials have independent reset schedules, the one expiring soonest is used first to avoid wasting quota that would reset anyway.

Closes #1844

## Motivation

When running multiple Claude Code OAuth accounts, the existing `fill-first` and `round-robin` strategies do not consider quota reset timing. If account A resets in 1 hour and account B resets in 5 hours, it is more efficient to use A first since its remaining quota will be "wasted" (reset) sooner.

## Changes

### Layer 1: QuotaState fields (`types.go`)
- Added `WindowResetAt`, `TokensRemaining`, `TokensLimit` to track upstream rate limit data

### Layer 2: RateLimitHint struct (`conductor.go`)
- Added `RateLimitHint` struct with parsed rate limit fields (Reset, Remaining, Limit)
- Added `RateLimit *RateLimitHint` to `Result` struct — only parsed metadata, NOT raw `http.Header`, to avoid exposing sensitive upstream headers to hooks/logs

### Layer 3: Rate limit parsing (`conductor.go`)
- Added `parseRateLimitHint()` with named constants (`headerRateLimitReset`, `headerRateLimitRemaining`, `headerRateLimitLimit`) that extracts Anthropic rate limit headers
- Added `applyRateLimitHint()` that writes parsed values into `auth.Quota`
- Plumbed through all three execution paths: `executeMixedOnce`, `executeCountMixedOnce`, `executeStreamMixedOnce`
- Applied in `MarkResult` success path (inside existing lock)

### Layer 4: New selector (`selector.go`)
- `EarliestResetSelector` sorts available auths by `WindowResetAt` ascending
- Auths with rate limit data are preferred over those without
- Cold start gracefully degrades to fill-first (ID order) behavior

### Layer 5: Config wiring (`builder.go`, `service.go`, `config_basic.go`, `config.go`, `config.example.yaml`)
- Added `"earliest-reset"` (aliases: `"earliestreset"`, `"er"`) to:
  - Builder initialization (`builder.go`)
  - Hot-reload strategy switch (`service.go`)
  - Management API validation (`config_basic.go` `normalizeRoutingStrategy()`)
  - Config struct documentation (`config.go`)
  - Example config (`config.example.yaml`)

## Design Decisions

- **Auth-level quota, not model-level**: `WindowResetAt` is stored on `auth.Quota` (not `ModelState.Quota`) because Claude Code OAuth has a single token window across all models for the same credential
- **Parsed hint, not raw headers**: `RateLimitHint` struct only carries the 3 needed values, avoiding exposure of sensitive upstream headers (cookies, internal tokens) to hooks and logs
- **Cold start graceful degradation**: When no rate limit data exists yet (first requests), falls back to ID order (fill-first behavior), then auto-populates as responses arrive

## Testing

Added 3 new tests:
- `TestEarliestResetSelectorPick_PrefersEarliestReset` — verifies earliest reset time wins
- `TestEarliestResetSelectorPick_ColdStartFallsBackToIDOrder` — verifies graceful degradation
- `TestEarliestResetSelectorPick_DataPreferredOverNoData` — verifies populated data preferred over empty

All existing tests pass.

## Usage

```yaml
routing:
  strategy: "earliest-reset"
```