### PR TITLE
cleanup(translator): remove leftover instructions restore in codex responses

### DIFF
--- a/internal/translator/codex/openai/responses/codex_openai-responses_response.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_response.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
 )
 
 // ConvertCodexResponseToOpenAIResponses converts OpenAI Chat Completions streaming chunks
@@ -15,15 +14,6 @@ import (
 func ConvertCodexResponseToOpenAIResponses(ctx context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) []string {
 	if bytes.HasPrefix(rawJSON, []byte("data:")) {
 		rawJSON = bytes.TrimSpace(rawJSON[5:])
-		if typeResult := gjson.GetBytes(rawJSON, "type"); typeResult.Exists() {
-			typeStr := typeResult.String()
-			if typeStr == "response.created" || typeStr == "response.in_progress" || typeStr == "response.completed" {
-				if gjson.GetBytes(rawJSON, "response.instructions").Exists() {
-					instructions := gjson.GetBytes(originalRequestRawJSON, "instructions").String()
-					rawJSON, _ = sjson.SetBytes(rawJSON, "response.instructions", instructions)
-				}
-			}
-		}
 		out := fmt.Sprintf("data: %s", string(rawJSON))
 		return []string{out}
 	}
@@ -39,10 +29,5 @@ func ConvertCodexResponseToOpenAIResponsesNonStream(_ context.Context, modelName
 		return ""
 	}
 	responseResult := rootResult.Get("response")
-	template := responseResult.Raw
-	if responseResult.Get("instructions").Exists() {
-		instructions := gjson.GetBytes(originalRequestRawJSON, "instructions").String()
-		template, _ = sjson.Set(template, "instructions", instructions)
-	}
-	return template
+	return responseResult.Raw
 }

--- a/internal/translator/codex/openai/responses/codex_openai-responses_response.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_response.go
@@ -11,7 +11,7 @@ import (
 // ConvertCodexResponseToOpenAIResponses converts OpenAI Chat Completions streaming chunks
 // to OpenAI Responses SSE events (response.*).
 
-func ConvertCodexResponseToOpenAIResponses(ctx context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) []string {
+func ConvertCodexResponseToOpenAIResponses(_ context.Context, _ string, _, _, rawJSON []byte, _ *any) []string {
 	if bytes.HasPrefix(rawJSON, []byte("data:")) {
 		rawJSON = bytes.TrimSpace(rawJSON[5:])
 		out := fmt.Sprintf("data: %s", string(rawJSON))
@@ -22,7 +22,7 @@ func ConvertCodexResponseToOpenAIResponses(ctx context.Context, modelName string
 
 // ConvertCodexResponseToOpenAIResponsesNonStream builds a single Responses JSON
 // from a non-streaming OpenAI Chat Completions response.
-func ConvertCodexResponseToOpenAIResponsesNonStream(_ context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, _ *any) string {
+func ConvertCodexResponseToOpenAIResponsesNonStream(_ context.Context, _ string, _, _, rawJSON []byte, _ *any) string {
 	rootResult := gjson.ParseBytes(rawJSON)
 	// Verify this is a response.completed event
 	if rootResult.Get("type").String() != "response.completed" {


### PR DESCRIPTION
## Summary

- Remove dead code: instructions restore logic in codex responses translator that became a no-op after `ac802a46` removed the instructions injection system
- Remove unused `sjson` import

## Context

The instructions restore was originally needed when CPA injected custom per-model system prompts into Codex requests. The response translator would then "restore" the client's original instructions so injected content was hidden from the client.

Since `ac802a46` removed all injection logic, the proxy no longer modifies instructions before forwarding. The upstream's `response.instructions` already matches the client's original value, making the restore a no-op.

## Changes

**`internal/translator/codex/openai/responses/codex_openai-responses_response.go`**

- Streaming path: removed the `response.created`/`response.in_progress`/`response.completed` instructions override block
- Non-streaming path: removed the `response.instructions` override and return `responseResult.Raw` directly
- Removed unused `sjson` import

Closes #1868