### PR TITLE
fix(watcher): 合并 auth 事件风暴下的回调触发，降低高 CPU

### DIFF
--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -318,6 +318,9 @@ func (w *Watcher) triggerServerUpdate(cfg *config.Config) {
 	if w == nil || w.reloadCallback == nil || cfg == nil {
 		return
 	}
+	if w.stopped.Load() {
+		return
+	}
 
 	now := time.Now()
 
@@ -343,10 +346,13 @@ func (w *Watcher) triggerServerUpdate(cfg *config.Config) {
 		w.serverUpdateTimer.Stop()
 	}
 	w.serverUpdateTimer = time.AfterFunc(delay, func() {
+		if w.stopped.Load() {
+			return
+		}
 		w.clientsMutex.RLock()
 		latestCfg := w.config
 		w.clientsMutex.RUnlock()
-		if latestCfg == nil || w.reloadCallback == nil {
+		if latestCfg == nil || w.reloadCallback == nil || w.stopped.Load() {
 			w.serverUpdateMu.Lock()
 			w.serverUpdatePend = false
 			w.serverUpdateMu.Unlock()

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -39,6 +40,7 @@ type Watcher struct {
 	serverUpdateTimer *time.Timer
 	serverUpdateLast  time.Time
 	serverUpdatePend  bool
+	stopped           atomic.Bool
 	reloadCallback    func(*config.Config)
 	watcher           *fsnotify.Watcher
 	lastAuthHashes    map[string]string
@@ -119,6 +121,7 @@ func (w *Watcher) Start(ctx context.Context) error {
 
 // Stop stops the file watcher
 func (w *Watcher) Stop() error {
+	w.stopped.Store(true)
 	w.stopDispatch()
 	w.stopConfigReloadTimer()
 	w.stopServerUpdateTimer()


### PR DESCRIPTION
## 背景
在大量 auth 文件（例如数千）被批量写入时，watcher 会对每个 `CREATE/WRITE/REMOVE` 事件都立即触发一次 `reloadCallback`。这会导致回调风暴，CPU 明显升高，且日志重复刷 `server clients and configuration updated`。

关联 Issue：#1873

## 改动
本 PR 仅针对**增量 auth 更新路径**做回调防抖（不改全量 reload 语义）：

1. 在 `Watcher` 增加服务更新防抖状态：
- `serverUpdateMu`
- `serverUpdateTimer`
- `serverUpdateLast`
- `serverUpdatePend`

2. 新增 `serverUpdateDebounce = 1s`
- 首个事件立即回调
- 窗口内后续事件合并成一次延迟回调

3. 将以下路径的回调从“每次立即触发”改为“触发防抖器”
- `addOrUpdateClient`
- `removeClient`

4. `Stop()` 中增加 `stopServerUpdateTimer()`，避免遗留 timer。

## 结果
在 auth 文件事件风暴场景下，回调次数显著下降，避免重复重建相同客户端配置，降低 CPU 峰值。

## 兼容性
- 全量 `reloadClients(...)` 的回调行为保持不变（仍立即触发）
- 仅限增量 auth 事件路径做抑制

## 验证
已通过：
- `go test ./internal/watcher -run Test -count=1`
