### PR TITLE
fix: surface upstream error details in Gemini CLI OAuth onboarding UI

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1306,12 +1306,12 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 			projects, errAll := onboardAllGeminiProjects(ctx, gemClient, &ts)
 			if errAll != nil {
 				log.Errorf("Failed to complete Gemini CLI onboarding: %v", errAll)
-				SetOAuthSessionError(state, "Failed to complete Gemini CLI onboarding")
+				SetOAuthSessionError(state, fmt.Sprintf("Failed to complete Gemini CLI onboarding: %v", errAll))
 				return
 			}
 			if errVerify := ensureGeminiProjectsEnabled(ctx, gemClient, projects); errVerify != nil {
 				log.Errorf("Failed to verify Cloud AI API status: %v", errVerify)
-				SetOAuthSessionError(state, "Failed to verify Cloud AI API status")
+				SetOAuthSessionError(state, fmt.Sprintf("Failed to verify Cloud AI API status: %v", errVerify))
 				return
 			}
 			ts.ProjectID = strings.Join(projects, ",")
@@ -1320,7 +1320,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 			ts.Auto = false
 			if errSetup := performGeminiCLISetup(ctx, gemClient, &ts, ""); errSetup != nil {
 				log.Errorf("Google One auto-discovery failed: %v", errSetup)
-				SetOAuthSessionError(state, "Google One auto-discovery failed")
+				SetOAuthSessionError(state, fmt.Sprintf("Google One auto-discovery failed: %v", errSetup))
 				return
 			}
 			if strings.TrimSpace(ts.ProjectID) == "" {
@@ -1331,19 +1331,19 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 			isChecked, errCheck := checkCloudAPIIsEnabled(ctx, gemClient, ts.ProjectID)
 			if errCheck != nil {
 				log.Errorf("Failed to verify Cloud AI API status: %v", errCheck)
-				SetOAuthSessionError(state, "Failed to verify Cloud AI API status")
+				SetOAuthSessionError(state, fmt.Sprintf("Failed to verify Cloud AI API status: %v", errCheck))
 				return
 			}
 			ts.Checked = isChecked
 			if !isChecked {
 				log.Error("Cloud AI API is not enabled for the auto-discovered project")
-				SetOAuthSessionError(state, "Cloud AI API not enabled")
+				SetOAuthSessionError(state, fmt.Sprintf("Cloud AI API not enabled for project %s", ts.ProjectID))
 				return
 			}
 		} else {
 			if errEnsure := ensureGeminiProjectAndOnboard(ctx, gemClient, &ts, requestedProjectID); errEnsure != nil {
 				log.Errorf("Failed to complete Gemini CLI onboarding: %v", errEnsure)
-				SetOAuthSessionError(state, "Failed to complete Gemini CLI onboarding")
+				SetOAuthSessionError(state, fmt.Sprintf("Failed to complete Gemini CLI onboarding: %v", errEnsure))
 				return
 			}
 
@@ -1356,13 +1356,13 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 			isChecked, errCheck := checkCloudAPIIsEnabled(ctx, gemClient, ts.ProjectID)
 			if errCheck != nil {
 				log.Errorf("Failed to verify Cloud AI API status: %v", errCheck)
-				SetOAuthSessionError(state, "Failed to verify Cloud AI API status")
+				SetOAuthSessionError(state, fmt.Sprintf("Failed to verify Cloud AI API status: %v", errCheck))
 				return
 			}
 			ts.Checked = isChecked
 			if !isChecked {
 				log.Error("Cloud AI API is not enabled for the selected project")
-				SetOAuthSessionError(state, "Cloud AI API not enabled")
+				SetOAuthSessionError(state, fmt.Sprintf("Cloud AI API not enabled for project %s", ts.ProjectID))
 				return
 			}
 		}


### PR DESCRIPTION
## Summary

- `SetOAuthSessionError` in `RequestGeminiCLIToken` previously sent generic messages to the management panel (e.g. *"Failed to complete Gemini CLI onboarding"*), hiding the actual error returned by Google APIs
- The specific error was only written to the server log via `log.Errorf`, which is often inaccessible in headless/Docker deployments
- Now all 8 error paths include the upstream error message via `fmt.Sprintf`, so the management panel shows actionable messages like *"no Google Cloud projects available for this account"* instead of a generic failure

## Changes

**File:** `internal/api/handlers/management/auth_files.go`

| Error path | Before | After |
|---|---|---|
| `onboardAllGeminiProjects` fail | `"Failed to complete Gemini CLI onboarding"` | `fmt.Sprintf("...onboarding: %v", errAll)` |
| `ensureGeminiProjectsEnabled` fail | `"Failed to verify Cloud AI API status"` | `fmt.Sprintf("...status: %v", errVerify)` |
| Google One auto-discovery fail | `"Google One auto-discovery failed"` | `fmt.Sprintf("...failed: %v", errSetup)` |
| Cloud AI check fail (Google One) | `"Failed to verify Cloud AI API status"` | `fmt.Sprintf("...status: %v", errCheck)` |
| Cloud AI not enabled (Google One) | `"Cloud AI API not enabled"` | `fmt.Sprintf("...not enabled for project %s", ts.ProjectID)` |
| `ensureGeminiProjectAndOnboard` fail | `"Failed to complete Gemini CLI onboarding"` | `fmt.Sprintf("...onboarding: %v", errEnsure)` |
| Cloud AI check fail (default) | `"Failed to verify Cloud AI API status"` | `fmt.Sprintf("...status: %v", errCheck)` |
| Cloud AI not enabled (default) | `"Cloud AI API not enabled"` | `fmt.Sprintf("...not enabled for project %s", ts.ProjectID)` |

## Test plan

- [x] `go build ./...` passes
- [x] Deployed to private instance, triggered Gemini CLI OAuth with a fresh Google account (no GCP projects)
- [x] Management panel now shows: *"Failed to complete Gemini CLI onboarding: no Google Cloud projects available for this account"* instead of the generic message