### PR TITLE
fix(auth): align file auth ids and callback auth directory handling

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -244,9 +243,11 @@ func (h *Handler) ListAuthFiles(c *gin.Context) {
 		return
 	}
 	auths := h.authManager.List()
+	authDir := h.effectiveAuthDir()
+	fileInfoIndex := buildAuthDirFileInfoIndex(authDir)
 	files := make([]gin.H, 0, len(auths))
 	for _, auth := range auths {
-		if entry := h.buildAuthFileEntry(auth); entry != nil {
+		if entry := h.buildAuthFileEntry(auth, authDir, fileInfoIndex); entry != nil {
 			files = append(files, entry)
 		}
 	}
@@ -308,7 +309,8 @@ func (h *Handler) GetAuthFileModels(c *gin.Context) {
 
 // List auth files from disk when the auth manager is unavailable.
 func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
-	entries, err := os.ReadDir(h.cfg.AuthDir)
+	authDir := h.effectiveAuthDir()
+	entries, err := os.ReadDir(authDir)
 	if err != nil {
 		c.JSON(500, gin.H{"error": fmt.Sprintf("failed to read auth dir: %v", err)})
 		return
@@ -326,7 +328,7 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 			fileData := gin.H{"name": name, "size": info.Size(), "modtime": info.ModTime()}
 
 			// Read file to get type field
-			full := filepath.Join(h.cfg.AuthDir, name)
+			full := filepath.Join(authDir, name)
 			if data, errRead := os.ReadFile(full); errRead == nil {
 				typeValue := gjson.GetBytes(data, "type").String()
 				emailValue := gjson.GetBytes(data, "email").String()
@@ -340,7 +342,7 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 	c.JSON(200, gin.H{"files": files})
 }
 
-func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
+func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth, authDir string, fileInfoIndex map[string]os.FileInfo) gin.H {
 	if auth == nil {
 		return nil
 	}
@@ -399,10 +401,10 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	if path != "" {
 		entry["path"] = path
 		entry["source"] = "file"
-		if info, err := os.Stat(path); err == nil {
+		if info, exists, err := resolveAuthFileInfo(authDir, fileInfoIndex, path); err == nil && exists {
 			entry["size"] = info.Size()
 			entry["modtime"] = info.ModTime()
-		} else if os.IsNotExist(err) {
+		} else if err == nil && !exists {
 			// Hide credentials removed from disk but still lingering in memory.
 			if !runtimeOnly && (auth.Disabled || auth.Status == coreauth.StatusDisabled || strings.EqualFold(strings.TrimSpace(auth.StatusMessage), "removed via management api")) {
 				return nil
@@ -478,6 +480,56 @@ func authEmail(auth *coreauth.Auth) string {
 	return ""
 }
 
+func buildAuthDirFileInfoIndex(authDir string) map[string]os.FileInfo {
+	authDir = strings.TrimSpace(authDir)
+	if authDir == "" {
+		return nil
+	}
+	cleanAuthDir := filepath.Clean(authDir)
+	index := make(map[string]os.FileInfo)
+	err := filepath.Walk(cleanAuthDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if info == nil || info.IsDir() {
+			return nil
+		}
+		rel, errRel := filepath.Rel(cleanAuthDir, path)
+		if errRel != nil || rel == "" || rel == "." {
+			return nil
+		}
+		index[sdkAuth.NormalizeFileAuthID(path, cleanAuthDir)] = info
+		return nil
+	})
+	if err != nil {
+		return nil
+	}
+	return index
+}
+
+func resolveAuthFileInfo(authDir string, fileInfoIndex map[string]os.FileInfo, path string) (os.FileInfo, bool, error) {
+	cleanPath := filepath.Clean(strings.TrimSpace(path))
+	if cleanPath == "" || cleanPath == "." {
+		return nil, false, nil
+	}
+	cleanAuthDir := filepath.Clean(strings.TrimSpace(authDir))
+	if cleanAuthDir != "" && cleanAuthDir != "." {
+		if rel, err := filepath.Rel(cleanAuthDir, cleanPath); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			if info, ok := fileInfoIndex[sdkAuth.NormalizeFileAuthID(cleanPath, cleanAuthDir)]; ok {
+				return info, true, nil
+			}
+		}
+	}
+	info, err := os.Stat(cleanPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return info, true, nil
+}
+
 func authAttribute(auth *coreauth.Auth, key string) string {
 	if auth == nil || len(auth.Attributes) == 0 {
 		return ""
@@ -503,7 +555,7 @@ func (h *Handler) DownloadAuthFile(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "name must end with .json"})
 		return
 	}
-	full := filepath.Join(h.cfg.AuthDir, name)
+	full := filepath.Join(h.effectiveAuthDir(), name)
 	data, err := os.ReadFile(full)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -530,7 +582,7 @@ func (h *Handler) UploadAuthFile(c *gin.Context) {
 			c.JSON(400, gin.H{"error": "file must be .json"})
 			return
 		}
-		dst := filepath.Join(h.cfg.AuthDir, name)
+		dst := filepath.Join(h.effectiveAuthDir(), name)
 		if !filepath.IsAbs(dst) {
 			if abs, errAbs := filepath.Abs(dst); errAbs == nil {
 				dst = abs
@@ -566,7 +618,7 @@ func (h *Handler) UploadAuthFile(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "failed to read body"})
 		return
 	}
-	dst := filepath.Join(h.cfg.AuthDir, filepath.Base(name))
+	dst := filepath.Join(h.effectiveAuthDir(), filepath.Base(name))
 	if !filepath.IsAbs(dst) {
 		if abs, errAbs := filepath.Abs(dst); errAbs == nil {
 			dst = abs
@@ -591,7 +643,7 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 	}
 	ctx := c.Request.Context()
 	if all := c.Query("all"); all == "true" || all == "1" || all == "*" {
-		entries, err := os.ReadDir(h.cfg.AuthDir)
+		entries, err := os.ReadDir(h.effectiveAuthDir())
 		if err != nil {
 			c.JSON(500, gin.H{"error": fmt.Sprintf("failed to read auth dir: %v", err)})
 			return
@@ -605,7 +657,7 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 			if !strings.HasSuffix(strings.ToLower(name), ".json") {
 				continue
 			}
-			full := filepath.Join(h.cfg.AuthDir, name)
+			full := filepath.Join(h.effectiveAuthDir(), name)
 			if !filepath.IsAbs(full) {
 				if abs, errAbs := filepath.Abs(full); errAbs == nil {
 					full = abs
@@ -629,7 +681,7 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		return
 	}
 
-	targetPath := filepath.Join(h.cfg.AuthDir, filepath.Base(name))
+	targetPath := filepath.Join(h.effectiveAuthDir(), filepath.Base(name))
 	targetID := ""
 	if targetAuth := h.findAuthForDelete(name); targetAuth != nil {
 		targetID = strings.TrimSpace(targetAuth.ID)
@@ -689,24 +741,10 @@ func (h *Handler) findAuthForDelete(name string) *coreauth.Auth {
 }
 
 func (h *Handler) authIDForPath(path string) string {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return ""
+	if h == nil || h.cfg == nil {
+		return sdkAuth.NormalizeFileAuthID(path, "")
 	}
-	id := path
-	if h != nil && h.cfg != nil {
-		authDir := strings.TrimSpace(h.cfg.AuthDir)
-		if authDir != "" {
-			if rel, errRel := filepath.Rel(authDir, path); errRel == nil && rel != "" {
-				id = rel
-			}
-		}
-	}
-	// On Windows, normalize ID casing to avoid duplicate auth entries caused by case-insensitive paths.
-	if runtime.GOOS == "windows" {
-		id = strings.ToLower(id)
-	}
-	return id
+	return sdkAuth.NormalizeFileAuthID(path, h.effectiveAuthDir())
 }
 
 func (h *Handler) registerAuthFromFile(ctx context.Context, path string, data []byte) error {
@@ -1051,7 +1089,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 		}
 
 		// Helper: wait for callback file
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-anthropic-%s.oauth", state))
+		waitFile := filepath.Join(h.effectiveAuthDir(), fmt.Sprintf(".oauth-anthropic-%s.oauth", state))
 		waitForFile := func(path string, timeout time.Duration) (map[string]string, error) {
 			deadline := time.Now().Add(timeout)
 			for {
@@ -1187,7 +1225,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 		}
 
 		// Wait for callback file written by server route
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-gemini-%s.oauth", state))
+		waitFile := filepath.Join(h.effectiveAuthDir(), fmt.Sprintf(".oauth-gemini-%s.oauth", state))
 		fmt.Println("Waiting for authentication callback...")
 		deadline := time.Now().Add(5 * time.Minute)
 		var authCode string
@@ -1455,7 +1493,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		}
 
 		// Wait for callback file
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-codex-%s.oauth", state))
+		waitFile := filepath.Join(h.effectiveAuthDir(), fmt.Sprintf(".oauth-codex-%s.oauth", state))
 		deadline := time.Now().Add(5 * time.Minute)
 		var code string
 		for {
@@ -1585,7 +1623,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 			defer stopCallbackForwarderInstance(antigravity.CallbackPort, forwarder)
 		}
 
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-antigravity-%s.oauth", state))
+		waitFile := filepath.Join(h.effectiveAuthDir(), fmt.Sprintf(".oauth-antigravity-%s.oauth", state))
 		deadline := time.Now().Add(5 * time.Minute)
 		var authCode string
 		for {
@@ -1876,7 +1914,7 @@ func (h *Handler) RequestIFlowToken(c *gin.Context) {
 		}
 		fmt.Println("Waiting for authentication...")
 
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-iflow-%s.oauth", state))
+		waitFile := filepath.Join(h.effectiveAuthDir(), fmt.Sprintf(".oauth-iflow-%s.oauth", state))
 		deadline := time.Now().Add(5 * time.Minute)
 		var resultMap map[string]string
 		for {
@@ -1981,7 +2019,7 @@ func (h *Handler) RequestIFlowCookieToken(c *gin.Context) {
 
 	// Check for duplicate BXAuth before authentication
 	bxAuth := iflowauth.ExtractBXAuth(cookieValue)
-	if existingFile, err := iflowauth.CheckDuplicateBXAuth(h.cfg.AuthDir, bxAuth); err != nil {
+	if existingFile, err := iflowauth.CheckDuplicateBXAuth(h.effectiveAuthDir(), bxAuth); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "failed to check duplicate"})
 		return
 	} else if existingFile != "" {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -568,7 +568,7 @@ func (h *Handler) DownloadAuthFile(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "name must end with .json"})
 		return
 	}
-	full := filepath.Join(h.effectiveAuthDir(), name)
+	full := filepath.Join(h.effectiveAuthDir(), filepath.Base(name))
 	data, err := os.ReadFile(full)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -489,6 +489,7 @@ func buildAuthDirFileInfoIndex(authDir string) map[string]os.FileInfo {
 	index := make(map[string]os.FileInfo)
 	err := filepath.Walk(cleanAuthDir, func(path string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
+			log.WithError(walkErr).Warnf("management: walk auth directory entry failed: %s", path)
 			return nil
 		}
 		if info == nil || info.IsDir() {
@@ -502,9 +503,21 @@ func buildAuthDirFileInfoIndex(authDir string) map[string]os.FileInfo {
 		return nil
 	})
 	if err != nil {
+		log.WithError(err).Warn("management: failed to walk auth directory for file index")
 		return nil
 	}
 	return index
+}
+
+func isSimpleAuthFileName(name string) bool {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" || filepath.VolumeName(trimmed) != "" {
+		return false
+	}
+	if strings.ContainsAny(trimmed, `/\\`) {
+		return false
+	}
+	return filepath.Base(trimmed) == trimmed
 }
 
 func resolveAuthFileInfo(authDir string, fileInfoIndex map[string]os.FileInfo, path string) (os.FileInfo, bool, error) {
@@ -547,7 +560,7 @@ func isRuntimeOnlyAuth(auth *coreauth.Auth) bool {
 // Download single auth file by name
 func (h *Handler) DownloadAuthFile(c *gin.Context) {
 	name := c.Query("name")
-	if name == "" || strings.Contains(name, string(os.PathSeparator)) {
+	if !isSimpleAuthFileName(name) {
 		c.JSON(400, gin.H{"error": "invalid name"})
 		return
 	}
@@ -605,7 +618,7 @@ func (h *Handler) UploadAuthFile(c *gin.Context) {
 		return
 	}
 	name := c.Query("name")
-	if name == "" || strings.Contains(name, string(os.PathSeparator)) {
+	if !isSimpleAuthFileName(name) {
 		c.JSON(400, gin.H{"error": "invalid name"})
 		return
 	}
@@ -676,7 +689,7 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		return
 	}
 	name := c.Query("name")
-	if name == "" || strings.Contains(name, string(os.PathSeparator)) {
+	if !isSimpleAuthFileName(name) {
 		c.JSON(400, gin.H{"error": "invalid name"})
 		return
 	}

--- a/internal/api/handlers/management/auth_files_list_test.go
+++ b/internal/api/handlers/management/auth_files_list_test.go
@@ -1,0 +1,223 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestListAuthFiles_UsesAuthDirSnapshotForManagedFiles(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	fileName := "codex-user@example.com-plus.json"
+	filePath := filepath.Join(authDir, fileName)
+	content := []byte(`{"type":"codex","email":"user@example.com"}`)
+	if err := os.WriteFile(filePath, content, 0o600); err != nil {
+		t.Fatalf("failed to write auth file: %v", err)
+	}
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("failed to stat auth file: %v", err)
+	}
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	record := &coreauth.Auth{
+		ID:       fileName,
+		FileName: fileName,
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"path": filePath,
+		},
+		Metadata: map[string]any{
+			"email": "user@example.com",
+		},
+	}
+	if _, err := manager.Register(context.Background(), record); err != nil {
+		t.Fatalf("failed to register auth record: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	resp := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(resp)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files", nil)
+
+	h.ListAuthFiles(ctx)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected list status %d, got %d with body %s", http.StatusOK, resp.Code, resp.Body.String())
+	}
+
+	var payload struct {
+		Files []map[string]any `json:"files"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode payload: %v", err)
+	}
+	if len(payload.Files) != 1 {
+		t.Fatalf("expected 1 auth file, got %d", len(payload.Files))
+	}
+	if got := payload.Files[0]["name"]; got != fileName {
+		t.Fatalf("expected file name %q, got %v", fileName, got)
+	}
+	if got := int64(payload.Files[0]["size"].(float64)); got != info.Size() {
+		t.Fatalf("expected size %d, got %d", info.Size(), got)
+	}
+	if got := payload.Files[0]["source"]; got != "file" {
+		t.Fatalf("expected source file, got %v", got)
+	}
+}
+
+func TestListAuthFiles_UsesNestedRelativePathSnapshot(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	firstPath := filepath.Join(authDir, "a", "foo.json")
+	secondPath := filepath.Join(authDir, "b", "foo.json")
+	if err := os.MkdirAll(filepath.Dir(firstPath), 0o700); err != nil {
+		t.Fatalf("failed to create first dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(secondPath), 0o700); err != nil {
+		t.Fatalf("failed to create second dir: %v", err)
+	}
+	firstContent := []byte(`{"type":"codex","email":"a@example.com"}`)
+	secondContent := []byte(`{"type":"codex","email":"nested-longer@example.com","note":"this file is intentionally longer"}`)
+	if err := os.WriteFile(firstPath, firstContent, 0o600); err != nil {
+		t.Fatalf("failed to write first auth file: %v", err)
+	}
+	if err := os.WriteFile(secondPath, secondContent, 0o600); err != nil {
+		t.Fatalf("failed to write second auth file: %v", err)
+	}
+	firstInfo, err := os.Stat(firstPath)
+	if err != nil {
+		t.Fatalf("failed to stat first auth file: %v", err)
+	}
+	secondInfo, err := os.Stat(secondPath)
+	if err != nil {
+		t.Fatalf("failed to stat second auth file: %v", err)
+	}
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	for _, record := range []*coreauth.Auth{
+		{
+			ID:       filepath.Join("a", "foo.json"),
+			FileName: filepath.Join("a", "foo.json"),
+			Provider: "codex",
+			Status:   coreauth.StatusActive,
+			Attributes: map[string]string{
+				"path": firstPath,
+			},
+		},
+		{
+			ID:       filepath.Join("b", "foo.json"),
+			FileName: filepath.Join("b", "foo.json"),
+			Provider: "codex",
+			Status:   coreauth.StatusActive,
+			Attributes: map[string]string{
+				"path": secondPath,
+			},
+		},
+	} {
+		if _, err := manager.Register(context.Background(), record); err != nil {
+			t.Fatalf("failed to register auth record %s: %v", record.ID, err)
+		}
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	resp := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(resp)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files", nil)
+
+	h.ListAuthFiles(ctx)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected list status %d, got %d with body %s", http.StatusOK, resp.Code, resp.Body.String())
+	}
+
+	var payload struct {
+		Files []map[string]any `json:"files"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode payload: %v", err)
+	}
+	if len(payload.Files) != 2 {
+		t.Fatalf("expected 2 auth files, got %d", len(payload.Files))
+	}
+
+	entriesByPath := make(map[string]map[string]any, len(payload.Files))
+	for _, file := range payload.Files {
+		path, _ := file["path"].(string)
+		entriesByPath[path] = file
+	}
+	if got := int64(entriesByPath[firstPath]["size"].(float64)); got != firstInfo.Size() {
+		t.Fatalf("expected first size %d, got %d", firstInfo.Size(), got)
+	}
+	if got := int64(entriesByPath[secondPath]["size"].(float64)); got != secondInfo.Size() {
+		t.Fatalf("expected second size %d, got %d", secondInfo.Size(), got)
+	}
+}
+
+func TestListAuthFiles_HidesDeletedNestedManagedFile(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	rootPath := filepath.Join(authDir, "foo.json")
+	nestedPath := filepath.Join(authDir, "nested", "foo.json")
+	if err := os.MkdirAll(filepath.Dir(nestedPath), 0o700); err != nil {
+		t.Fatalf("failed to create nested dir: %v", err)
+	}
+	if err := os.WriteFile(rootPath, []byte(`{"type":"codex"}`), 0o600); err != nil {
+		t.Fatalf("failed to write root auth file: %v", err)
+	}
+	if err := os.WriteFile(nestedPath, []byte(`{"type":"codex"}`), 0o600); err != nil {
+		t.Fatalf("failed to write nested auth file: %v", err)
+	}
+	if err := os.Remove(nestedPath); err != nil {
+		t.Fatalf("failed to remove nested auth file: %v", err)
+	}
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	record := &coreauth.Auth{
+		ID:       filepath.Join("nested", "foo.json"),
+		FileName: filepath.Join("nested", "foo.json"),
+		Provider: "codex",
+		Status:   coreauth.StatusDisabled,
+		Disabled: true,
+		Attributes: map[string]string{
+			"path": nestedPath,
+		},
+	}
+	if _, err := manager.Register(context.Background(), record); err != nil {
+		t.Fatalf("failed to register auth record: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	resp := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(resp)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files", nil)
+
+	h.ListAuthFiles(ctx)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected list status %d, got %d with body %s", http.StatusOK, resp.Code, resp.Body.String())
+	}
+
+	var payload struct {
+		Files []map[string]any `json:"files"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode payload: %v", err)
+	}
+	if len(payload.Files) != 0 {
+		t.Fatalf("expected deleted nested auth to be hidden, got %d entries", len(payload.Files))
+	}
+}

--- a/internal/api/handlers/management/auth_files_test.go
+++ b/internal/api/handlers/management/auth_files_test.go
@@ -1,9 +1,13 @@
 package management
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 )
@@ -15,5 +19,31 @@ func TestAuthIDForPath_UsesSharedFileAuthNormalization(t *testing.T) {
 
 	if got, want := h.authIDForPath(path), sdkAuth.NormalizeFileAuthID(path, authDir); got != want {
 		t.Fatalf("auth ID = %q, want %q", got, want)
+	}
+}
+
+func TestDownloadAuthFile_RejectsPathTraversalSeparators(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, nil)
+	tests := []string{
+		"nested/file.json",
+		`nested\\file.json`,
+		`C:\\temp\\file.json`,
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(rec)
+			ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files/download?name="+url.QueryEscape(name), nil)
+
+			h.DownloadAuthFile(ctx)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+		})
 	}
 }

--- a/internal/api/handlers/management/auth_files_test.go
+++ b/internal/api/handlers/management/auth_files_test.go
@@ -29,6 +29,7 @@ func TestDownloadAuthFile_RejectsPathTraversalSeparators(t *testing.T) {
 	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, nil)
 	tests := []string{
 		"nested/file.json",
+		"../outside.json",
 		`nested\\file.json`,
 		`C:\\temp\\file.json`,
 	}

--- a/internal/api/handlers/management/auth_files_test.go
+++ b/internal/api/handlers/management/auth_files_test.go
@@ -1,0 +1,19 @@
+package management
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
+)
+
+func TestAuthIDForPath_UsesSharedFileAuthNormalization(t *testing.T) {
+	authDir := filepath.Join(`C:\`, "Auths")
+	path := filepath.Join(authDir, "Nested", "Foo.json")
+	h := &Handler{cfg: &config.Config{AuthDir: authDir}}
+
+	if got, want := h.authIDForPath(path), sdkAuth.NormalizeFileAuthID(path, authDir); got != want {
+		t.Fatalf("auth ID = %q, want %q", got, want)
+	}
+}

--- a/internal/api/handlers/management/effective_auth_dir_test.go
+++ b/internal/api/handlers/management/effective_auth_dir_test.go
@@ -1,0 +1,81 @@
+package management
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type mirroredAuthDirStore struct {
+	authDir string
+}
+
+func (s *mirroredAuthDirStore) List(context.Context) ([]*coreauth.Auth, error)       { return nil, nil }
+func (s *mirroredAuthDirStore) Save(context.Context, *coreauth.Auth) (string, error) { return "", nil }
+func (s *mirroredAuthDirStore) Delete(context.Context, string) error                 { return nil }
+func (s *mirroredAuthDirStore) AuthDir() string                                      { return s.authDir }
+
+func TestPostOAuthCallbackUsesEffectiveAuthDir(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	configuredAuthDir := t.TempDir()
+	mirroredAuthDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: configuredAuthDir}, nil)
+	h.tokenStore = &mirroredAuthDirStore{authDir: mirroredAuthDir}
+
+	state := "codex-state-1"
+	RegisterOAuthSession(state, "codex")
+
+	body, err := json.Marshal(map[string]string{
+		"provider": "codex",
+		"state":    state,
+		"code":     "test-code",
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	resp := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(resp)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/oauth/callback", bytes.NewReader(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.PostOAuthCallback(ctx)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, resp.Code, resp.Body.String())
+	}
+
+	callbackPath := filepath.Join(mirroredAuthDir, ".oauth-codex-"+state+".oauth")
+	if _, err := os.Stat(callbackPath); err != nil {
+		t.Fatalf("expected callback file in mirrored auth dir: %v", err)
+	}
+	configuredPath := filepath.Join(configuredAuthDir, ".oauth-codex-"+state+".oauth")
+	if _, err := os.Stat(configuredPath); !os.IsNotExist(err) {
+		t.Fatalf("expected configured auth dir to remain untouched, stat err=%v", err)
+	}
+}
+
+func TestAuthIDForPathUsesEffectiveAuthDir(t *testing.T) {
+	configuredAuthDir := t.TempDir()
+	mirroredAuthDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: configuredAuthDir}, nil)
+	h.tokenStore = &mirroredAuthDirStore{authDir: mirroredAuthDir}
+
+	path := filepath.Join(mirroredAuthDir, "nested", "demo.json")
+	got := h.authIDForPath(path)
+	want := sdkAuth.NormalizeFileAuthID(path, mirroredAuthDir)
+	if got != want {
+		t.Fatalf("authIDForPath = %q, want %q", got, want)
+	}
+}

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -38,6 +38,7 @@ type Handler struct {
 	cfg                 *config.Config
 	configFilePath      string
 	mu                  sync.Mutex
+	stateMu             sync.RWMutex
 	attemptsMu          sync.Mutex
 	failedAttempts      map[string]*attemptInfo // keyed by client IP
 	authManager         *coreauth.Manager
@@ -48,6 +49,21 @@ type Handler struct {
 	envSecret           string
 	logDir              string
 	postAuthHook        coreauth.PostAuthHook
+}
+
+type authDirProvider interface {
+	AuthDir() string
+}
+
+// ResolveEffectiveAuthDir returns the runtime auth directory used by file-based flows.
+// Stores with mirrored workspaces may override the configured auth dir.
+func ResolveEffectiveAuthDir(configAuthDir string, store coreauth.Store) string {
+	if provider, ok := store.(authDirProvider); ok {
+		if dir := strings.TrimSpace(provider.AuthDir()); dir != "" {
+			return dir
+		}
+	}
+	return strings.TrimSpace(configAuthDir)
 }
 
 // NewHandler creates a new management handler instance.
@@ -104,17 +120,43 @@ func NewHandlerWithoutConfigFilePath(cfg *config.Config, manager *coreauth.Manag
 	return NewHandler(cfg, "", manager)
 }
 
+// StateMiddleware serializes management runtime state access so request handlers,
+// hot-reload updates and persistence do not observe partially-updated in-memory state.
+func (h *Handler) StateMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		h.stateMu.Lock()
+		defer h.stateMu.Unlock()
+		c.Next()
+	}
+}
+
 // SetConfig updates the in-memory config reference when the server hot-reloads.
-func (h *Handler) SetConfig(cfg *config.Config) { h.cfg = cfg }
+func (h *Handler) SetConfig(cfg *config.Config) {
+	h.stateMu.Lock()
+	h.cfg = cfg
+	h.stateMu.Unlock()
+}
 
 // SetAuthManager updates the auth manager reference used by management endpoints.
-func (h *Handler) SetAuthManager(manager *coreauth.Manager) { h.authManager = manager }
+func (h *Handler) SetAuthManager(manager *coreauth.Manager) {
+	h.stateMu.Lock()
+	h.authManager = manager
+	h.stateMu.Unlock()
+}
 
 // SetUsageStatistics allows replacing the usage statistics reference.
-func (h *Handler) SetUsageStatistics(stats *usage.RequestStatistics) { h.usageStats = stats }
+func (h *Handler) SetUsageStatistics(stats *usage.RequestStatistics) {
+	h.stateMu.Lock()
+	h.usageStats = stats
+	h.stateMu.Unlock()
+}
 
 // SetLocalPassword configures the runtime-local password accepted for localhost requests.
-func (h *Handler) SetLocalPassword(password string) { h.localPassword = password }
+func (h *Handler) SetLocalPassword(password string) {
+	h.stateMu.Lock()
+	h.localPassword = password
+	h.stateMu.Unlock()
+}
 
 // SetLogDirectory updates the directory where main.log should be looked up.
 func (h *Handler) SetLogDirectory(dir string) {
@@ -126,12 +168,27 @@ func (h *Handler) SetLogDirectory(dir string) {
 			dir = abs
 		}
 	}
+	h.stateMu.Lock()
 	h.logDir = dir
+	h.stateMu.Unlock()
 }
 
 // SetPostAuthHook registers a hook to be called after auth record creation but before persistence.
 func (h *Handler) SetPostAuthHook(hook coreauth.PostAuthHook) {
+	h.stateMu.Lock()
 	h.postAuthHook = hook
+	h.stateMu.Unlock()
+}
+
+func (h *Handler) effectiveAuthDir() string {
+	if h == nil {
+		return ""
+	}
+	store := h.tokenStoreWithBaseDir()
+	if h.cfg == nil {
+		return ResolveEffectiveAuthDir("", store)
+	}
+	return ResolveEffectiveAuthDir(h.cfg.AuthDir, store)
 }
 
 // Middleware enforces access control for management endpoints.

--- a/internal/api/handlers/management/oauth_callback.go
+++ b/internal/api/handlers/management/oauth_callback.go
@@ -87,7 +87,7 @@ func (h *Handler) PostOAuthCallback(c *gin.Context) {
 		return
 	}
 
-	if _, errWrite := WriteOAuthCallbackFileForPendingSession(h.cfg.AuthDir, canonicalProvider, state, code, errMsg); errWrite != nil {
+	if _, errWrite := WriteOAuthCallbackFileForPendingSession(h.effectiveAuthDir(), canonicalProvider, state, code, errMsg); errWrite != nil {
 		if errors.Is(errWrite, errOAuthSessionNotPending) {
 			c.JSON(http.StatusConflict, gin.H{"status": "error", "error": "oauth flow is not pending"})
 			return

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/access"
+	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	managementHandlers "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/middleware"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/modules"
@@ -41,6 +42,11 @@ import (
 )
 
 const oauthCallbackSuccessHTML = `<html><head><meta charset="utf-8"><title>Authentication successful</title><script>setTimeout(function(){window.close();},5000);</script></head><body><h1>Authentication successful!</h1><p>You can close this window.</p><p>This window will close automatically in 5 seconds.</p></body></html>`
+
+func writePendingOAuthCallbackFile(configAuthDir, provider, state, code, errStr string) {
+	authDir := managementHandlers.ResolveEffectiveAuthDir(configAuthDir, sdkAuth.GetTokenStore())
+	_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(authDir, provider, state, code, errStr)
+}
 
 type serverOptionConfig struct {
 	extraMiddleware      []gin.HandlerFunc
@@ -195,6 +201,13 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	for i := range opts {
 		opts[i](optionState)
 	}
+	if accessManager == nil {
+		log.Warn("access manager was nil, creating a default manager")
+		accessManager = sdkaccess.NewManager()
+		configaccess.Register(&cfg.SDKConfig)
+		accessManager.SetProviders(sdkaccess.RegisteredProviders())
+	}
+
 	// Set gin mode
 	if !cfg.Debug {
 		gin.SetMode(gin.ReleaseMode)
@@ -371,7 +384,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "anthropic", state, code, errStr)
+			writePendingOAuthCallbackFile(s.cfg.AuthDir, "anthropic", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -385,7 +398,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "codex", state, code, errStr)
+			writePendingOAuthCallbackFile(s.cfg.AuthDir, "codex", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -399,7 +412,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "gemini", state, code, errStr)
+			writePendingOAuthCallbackFile(s.cfg.AuthDir, "gemini", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -413,7 +426,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "iflow", state, code, errStr)
+			writePendingOAuthCallbackFile(s.cfg.AuthDir, "iflow", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -427,7 +440,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "antigravity", state, code, errStr)
+			writePendingOAuthCallbackFile(s.cfg.AuthDir, "antigravity", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -484,7 +497,7 @@ func (s *Server) registerManagementRoutes() {
 	log.Info("management routes registered after secret key configuration")
 
 	mgmt := s.engine.Group("/v0/management")
-	mgmt.Use(s.managementAvailabilityMiddleware(), s.mgmt.Middleware())
+	mgmt.Use(s.managementAvailabilityMiddleware(), s.mgmt.StateMiddleware(), s.mgmt.Middleware())
 	{
 		mgmt.GET("/usage", s.mgmt.GetUsageStatistics)
 		mgmt.GET("/usage/export", s.mgmt.ExportUsageStatistics)
@@ -1028,7 +1041,8 @@ func (s *Server) SetWebsocketAuthChangeHandler(fn func(bool, bool)) {
 func AuthMiddleware(manager *sdkaccess.Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if manager == nil {
-			c.Next()
+			log.Error("authentication middleware misconfigured: access manager is nil")
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authentication unavailable"})
 			return
 		}
 

--- a/internal/api/server_oauth_callback_test.go
+++ b/internal/api/server_oauth_callback_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	managementHandlers "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type oauthCallbackMirrorStore struct {
+	authDir string
+}
+
+func (s *oauthCallbackMirrorStore) List(context.Context) ([]*coreauth.Auth, error) { return nil, nil }
+func (s *oauthCallbackMirrorStore) Save(context.Context, *coreauth.Auth) (string, error) {
+	return "", nil
+}
+func (s *oauthCallbackMirrorStore) Delete(context.Context, string) error { return nil }
+func (s *oauthCallbackMirrorStore) AuthDir() string                      { return s.authDir }
+
+func TestWritePendingOAuthCallbackFileUsesEffectiveAuthDir(t *testing.T) {
+	configuredAuthDir := t.TempDir()
+	mirroredAuthDir := t.TempDir()
+	previousStore := sdkAuth.GetTokenStore()
+	sdkAuth.RegisterTokenStore(&oauthCallbackMirrorStore{authDir: mirroredAuthDir})
+	t.Cleanup(func() {
+		sdkAuth.RegisterTokenStore(previousStore)
+	})
+
+	state := "anthropic-state-1"
+	managementHandlers.RegisterOAuthSession(state, "anthropic")
+
+	writePendingOAuthCallbackFile(configuredAuthDir, "anthropic", state, "test-code", "")
+
+	callbackPath := filepath.Join(mirroredAuthDir, ".oauth-anthropic-"+state+".oauth")
+	if _, err := os.Stat(callbackPath); err != nil {
+		t.Fatalf("expected callback file in mirrored auth dir: %v", err)
+	}
+	configuredPath := filepath.Join(configuredAuthDir, ".oauth-anthropic-"+state+".oauth")
+	if _, err := os.Stat(configuredPath); !os.IsNotExist(err) {
+		t.Fatalf("expected configured auth dir to remain untouched, stat err=%v", err)
+	}
+}

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/geminicli"
+	sdkauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -36,9 +36,6 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 		return out, nil
 	}
 
-	now := ctx.Now
-	cfg := ctx.Config
-
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -52,97 +49,110 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 		if errRead != nil || len(data) == 0 {
 			continue
 		}
-		var metadata map[string]any
-		if errUnmarshal := json.Unmarshal(data, &metadata); errUnmarshal != nil {
+		auths := synthesizeFileAuths(ctx, full, data)
+		if len(auths) == 0 {
 			continue
 		}
-		t, _ := metadata["type"].(string)
-		if t == "" {
-			continue
-		}
-		provider := strings.ToLower(t)
-		if provider == "gemini" {
-			provider = "gemini-cli"
-		}
-		label := provider
-		if email, _ := metadata["email"].(string); email != "" {
-			label = email
-		}
-		// Use relative path under authDir as ID to stay consistent with the file-based token store
-		id := full
-		if rel, errRel := filepath.Rel(ctx.AuthDir, full); errRel == nil && rel != "" {
-			id = rel
-		}
-		// On Windows, normalize ID casing to avoid duplicate auth entries caused by case-insensitive paths.
-		if runtime.GOOS == "windows" {
-			id = strings.ToLower(id)
-		}
-
-		proxyURL := ""
-		if p, ok := metadata["proxy_url"].(string); ok {
-			proxyURL = p
-		}
-
-		prefix := ""
-		if rawPrefix, ok := metadata["prefix"].(string); ok {
-			trimmed := strings.TrimSpace(rawPrefix)
-			trimmed = strings.Trim(trimmed, "/")
-			if trimmed != "" && !strings.Contains(trimmed, "/") {
-				prefix = trimmed
-			}
-		}
-
-		disabled, _ := metadata["disabled"].(bool)
-		status := coreauth.StatusActive
-		if disabled {
-			status = coreauth.StatusDisabled
-		}
-
-		// Read per-account excluded models from the OAuth JSON file
-		perAccountExcluded := extractExcludedModelsFromMetadata(metadata)
-
-		a := &coreauth.Auth{
-			ID:       id,
-			Provider: provider,
-			Label:    label,
-			Prefix:   prefix,
-			Status:   status,
-			Disabled: disabled,
-			Attributes: map[string]string{
-				"source": full,
-				"path":   full,
-			},
-			ProxyURL:  proxyURL,
-			Metadata:  metadata,
-			CreatedAt: now,
-			UpdatedAt: now,
-		}
-		// Read priority from auth file
-		if rawPriority, ok := metadata["priority"]; ok {
-			switch v := rawPriority.(type) {
-			case float64:
-				a.Attributes["priority"] = strconv.Itoa(int(v))
-			case string:
-				priority := strings.TrimSpace(v)
-				if _, errAtoi := strconv.Atoi(priority); errAtoi == nil {
-					a.Attributes["priority"] = priority
-				}
-			}
-		}
-		ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, "oauth")
-		if provider == "gemini-cli" {
-			if virtuals := SynthesizeGeminiVirtualAuths(a, metadata, now); len(virtuals) > 0 {
-				for _, v := range virtuals {
-					ApplyAuthExcludedModelsMeta(v, cfg, perAccountExcluded, "oauth")
-				}
-				out = append(out, a)
-				out = append(out, virtuals...)
-				continue
-			}
-		}
-		out = append(out, a)
+		out = append(out, auths...)
 	}
 	return out, nil
+}
+
+// SynthesizeAuthFile generates Auth entries for one auth JSON file payload.
+// It shares exactly the same mapping behavior as FileSynthesizer.Synthesize.
+func SynthesizeAuthFile(ctx *SynthesisContext, fullPath string, data []byte) []*coreauth.Auth {
+	return synthesizeFileAuths(ctx, fullPath, data)
+}
+
+func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []*coreauth.Auth {
+	if ctx == nil || len(data) == 0 {
+		return nil
+	}
+	now := ctx.Now
+	cfg := ctx.Config
+	var metadata map[string]any
+	if errUnmarshal := json.Unmarshal(data, &metadata); errUnmarshal != nil {
+		return nil
+	}
+	t, _ := metadata["type"].(string)
+	if t == "" {
+		return nil
+	}
+	provider := strings.ToLower(t)
+	if provider == "gemini" {
+		provider = "gemini-cli"
+	}
+	label := provider
+	if email, _ := metadata["email"].(string); email != "" {
+		label = email
+	}
+	// Keep watcher IDs aligned with file-store and management handlers.
+	id := sdkauth.NormalizeFileAuthID(fullPath, ctx.AuthDir)
+
+	proxyURL := ""
+	if p, ok := metadata["proxy_url"].(string); ok {
+		proxyURL = p
+	}
+
+	prefix := ""
+	if rawPrefix, ok := metadata["prefix"].(string); ok {
+		trimmed := strings.TrimSpace(rawPrefix)
+		trimmed = strings.Trim(trimmed, "/")
+		if trimmed != "" && !strings.Contains(trimmed, "/") {
+			prefix = trimmed
+		}
+	}
+
+	disabled, _ := metadata["disabled"].(bool)
+	status := coreauth.StatusActive
+	if disabled {
+		status = coreauth.StatusDisabled
+	}
+
+	// Read per-account excluded models from the OAuth JSON file.
+	perAccountExcluded := extractExcludedModelsFromMetadata(metadata)
+
+	a := &coreauth.Auth{
+		ID:       id,
+		Provider: provider,
+		Label:    label,
+		Prefix:   prefix,
+		Status:   status,
+		Disabled: disabled,
+		Attributes: map[string]string{
+			"source": fullPath,
+			"path":   fullPath,
+		},
+		ProxyURL:  proxyURL,
+		Metadata:  metadata,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	// Read priority from auth file.
+	if rawPriority, ok := metadata["priority"]; ok {
+		switch v := rawPriority.(type) {
+		case float64:
+			a.Attributes["priority"] = strconv.Itoa(int(v))
+		case string:
+			priority := strings.TrimSpace(v)
+			if _, errAtoi := strconv.Atoi(priority); errAtoi == nil {
+				a.Attributes["priority"] = priority
+			}
+		}
+	}
+	ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, "oauth")
+	if provider == "gemini-cli" {
+		if virtuals := SynthesizeGeminiVirtualAuths(a, metadata, now); len(virtuals) > 0 {
+			for _, v := range virtuals {
+				ApplyAuthExcludedModelsMeta(v, cfg, perAccountExcluded, "oauth")
+			}
+			out := make([]*coreauth.Auth, 0, 1+len(virtuals))
+			out = append(out, a)
+			out = append(out, virtuals...)
+			return out
+		}
+	}
+	return []*coreauth.Auth{a}
 }
 
 // SynthesizeGeminiVirtualAuths creates virtual Auth entries for multi-project Gemini credentials.

--- a/internal/watcher/synthesizer/file_test.go
+++ b/internal/watcher/synthesizer/file_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	sdkauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -121,6 +122,25 @@ func TestFileSynthesizer_Synthesize_ValidAuthFile(t *testing.T) {
 	}
 }
 
+func TestSynthesizeAuthFile_UsesNormalizedWindowsAuthID(t *testing.T) {
+	ctx := &SynthesisContext{
+		Config:      &config.Config{},
+		AuthDir:     `C:\Auths`,
+		Now:         time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		IDGenerator: NewStableIDGenerator(),
+	}
+	data := []byte(`{"type":"claude","email":"test@example.com"}`)
+	fullPath := filepath.Join(ctx.AuthDir, `Nested`, `Foo.json`)
+
+	auths := SynthesizeAuthFile(ctx, fullPath, data)
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth, got %d", len(auths))
+	}
+	want := sdkauth.NormalizeFileAuthID(fullPath, ctx.AuthDir)
+	if got := auths[0].ID; got != want {
+		t.Fatalf("auth ID = %q, want %q", got, want)
+	}
+}
 func TestFileSynthesizer_Synthesize_GeminiProviderMapping(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/sdk/auth/file_id.go
+++ b/sdk/auth/file_id.go
@@ -1,0 +1,29 @@
+package auth
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// NormalizeFileAuthID returns the canonical auth ID for a file-backed auth entry.
+func NormalizeFileAuthID(path, baseDir string) string {
+	return normalizeFileAuthIDForOS(path, baseDir, runtime.GOOS)
+}
+
+func normalizeFileAuthIDForOS(path, baseDir, goos string) string {
+	id := strings.TrimSpace(path)
+	baseDir = strings.TrimSpace(baseDir)
+	if id == "" {
+		return ""
+	}
+	if baseDir != "" {
+		if rel, errRel := filepath.Rel(baseDir, id); errRel == nil && rel != "" {
+			id = rel
+		}
+	}
+	if goos == "windows" {
+		id = strings.ToLower(id)
+	}
+	return id
+}

--- a/sdk/auth/file_id.go
+++ b/sdk/auth/file_id.go
@@ -18,7 +18,7 @@ func normalizeFileAuthIDForOS(path, baseDir, goos string) string {
 		return ""
 	}
 	if baseDir != "" {
-		if rel, errRel := filepath.Rel(baseDir, id); errRel == nil && rel != "" {
+		if rel, errRel := filepath.Rel(baseDir, id); errRel == nil && rel != "" && rel != "." {
 			id = rel
 		}
 	}

--- a/sdk/auth/file_id_test.go
+++ b/sdk/auth/file_id_test.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeFileAuthIDForOS(t *testing.T) {
+	baseDir := filepath.Join("auths")
+	path := filepath.Join(baseDir, "Sub", "My-Auth.JSON")
+	rel, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		t.Fatalf("failed to build relative path: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		goos string
+		want string
+	}{
+		{name: "windows lowercases id", goos: "windows", want: strings.ToLower(rel)},
+		{name: "linux preserves case", goos: "linux", want: rel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeFileAuthIDForOS(path, baseDir, tt.goos)
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestNormalizeFileAuthIDForOSEmptyPath(t *testing.T) {
+	if got := normalizeFileAuthIDForOS("   ", "auths", "windows"); got != "" {
+		t.Fatalf("expected empty id, got %q", got)
+	}
+}

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -258,17 +257,7 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 }
 
 func (s *FileTokenStore) idFor(path, baseDir string) string {
-	id := path
-	if baseDir != "" {
-		if rel, errRel := filepath.Rel(baseDir, path); errRel == nil && rel != "" {
-			id = rel
-		}
-	}
-	// On Windows, normalize ID casing to avoid duplicate auth entries caused by case-insensitive paths.
-	if runtime.GOOS == "windows" {
-		id = strings.ToLower(id)
-	}
-	return id
+	return NormalizeFileAuthID(path, baseDir)
 }
 
 func (s *FileTokenStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, error) {


### PR DESCRIPTION
## Summary
- normalize file-backed auth ids through a shared helper
- align management callback files with the effective runtime auth directory
- keep management auth file listing and watcher synthesizer behavior consistent

## Business value
- avoids duplicate or mismatched file auth records, especially on Windows and nested auth paths
- reduces support issues where callback files land in the configured directory while runtime uses a mirrored directory
- isolates auth-dir consistency work from broader watcher and executor changes

## Tests
- go test ./internal/api/handlers/management ./internal/api ./internal/watcher/synthesizer ./sdk/auth