### PR TITLE
fix(management): harden state updates and config limits

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -426,10 +426,13 @@ func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *
 	}
 	auth.Metadata["type"] = "antigravity"
 
-	if h != nil && h.authManager != nil {
-		auth.LastRefreshedAt = now
-		auth.UpdatedAt = now
-		_, _ = h.authManager.Update(ctx, auth)
+	if h != nil {
+		state, err := h.runtimeSnapshot()
+		if err == nil && state.authManager != nil {
+			auth.LastRefreshedAt = now
+			auth.UpdatedAt = now
+			_, _ = state.authManager.Update(ctx, auth)
+		}
 	}
 
 	return strings.TrimSpace(tokenResp.AccessToken), nil
@@ -615,10 +618,14 @@ func tokenValueFromMetadata(metadata map[string]any) string {
 
 func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {
 	authIndex = strings.TrimSpace(authIndex)
-	if authIndex == "" || h == nil || h.authManager == nil {
+	if authIndex == "" || h == nil {
 		return nil
 	}
-	auths := h.authManager.List()
+	state, err := h.runtimeSnapshot()
+	if err != nil || state.authManager == nil {
+		return nil
+	}
+	auths := state.authManager.List()
 	for _, auth := range auths {
 		if auth == nil {
 			continue
@@ -638,9 +645,12 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
 			proxyCandidates = append(proxyCandidates, proxyStr)
 		}
 	}
-	if h != nil && h.cfg != nil {
-		if proxyStr := strings.TrimSpace(h.cfg.ProxyURL); proxyStr != "" {
-			proxyCandidates = append(proxyCandidates, proxyStr)
+	if h != nil {
+		state, err := h.runtimeSnapshot()
+		if err == nil && state.cfg != nil {
+			if proxyStr := strings.TrimSpace(state.cfg.ProxyURL); proxyStr != "" {
+				proxyCandidates = append(proxyCandidates, proxyStr)
+			}
 		}
 	}
 

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1026,7 +1026,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 		return
 	}
 
-	RegisterOAuthSession(state, "anthropic")
+	authDir := h.registerOAuthSession(state, "anthropic")
 
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
@@ -1051,7 +1051,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 		}
 
 		// Helper: wait for callback file
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-anthropic-%s.oauth", state))
+		waitFile := filepath.Join(authDir, fmt.Sprintf(".oauth-anthropic-%s.oauth", state))
 		waitForFile := func(path string, timeout time.Duration) (map[string]string, error) {
 			deadline := time.Now().Add(timeout)
 			for {
@@ -1162,7 +1162,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 	state := fmt.Sprintf("gem-%d", time.Now().UnixNano())
 	authURL := conf.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", "consent"))
 
-	RegisterOAuthSession(state, "gemini")
+	authDir := h.registerOAuthSession(state, "gemini")
 
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
@@ -1187,7 +1187,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 		}
 
 		// Wait for callback file written by server route
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-gemini-%s.oauth", state))
+		waitFile := filepath.Join(authDir, fmt.Sprintf(".oauth-gemini-%s.oauth", state))
 		fmt.Println("Waiting for authentication callback...")
 		deadline := time.Now().Add(5 * time.Minute)
 		var authCode string
@@ -1430,7 +1430,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		return
 	}
 
-	RegisterOAuthSession(state, "codex")
+	authDir := h.registerOAuthSession(state, "codex")
 
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
@@ -1455,7 +1455,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		}
 
 		// Wait for callback file
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-codex-%s.oauth", state))
+		waitFile := filepath.Join(authDir, fmt.Sprintf(".oauth-codex-%s.oauth", state))
 		deadline := time.Now().Add(5 * time.Minute)
 		var code string
 		for {
@@ -1561,7 +1561,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 	redirectURI := fmt.Sprintf("http://localhost:%d/oauth-callback", antigravity.CallbackPort)
 	authURL := authSvc.BuildAuthURL(state, redirectURI)
 
-	RegisterOAuthSession(state, "antigravity")
+	authDir := h.registerOAuthSession(state, "antigravity")
 
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
@@ -1585,7 +1585,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 			defer stopCallbackForwarderInstance(antigravity.CallbackPort, forwarder)
 		}
 
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-antigravity-%s.oauth", state))
+		waitFile := filepath.Join(authDir, fmt.Sprintf(".oauth-antigravity-%s.oauth", state))
 		deadline := time.Now().Add(5 * time.Minute)
 		var authCode string
 		for {
@@ -1727,7 +1727,7 @@ func (h *Handler) RequestQwenToken(c *gin.Context) {
 	}
 	authURL := deviceFlow.VerificationURIComplete
 
-	RegisterOAuthSession(state, "qwen")
+	h.registerOAuthSession(state, "qwen")
 
 	go func() {
 		fmt.Println("Waiting for authentication...")
@@ -1786,7 +1786,7 @@ func (h *Handler) RequestKimiToken(c *gin.Context) {
 		authURL = deviceFlow.VerificationURI
 	}
 
-	RegisterOAuthSession(state, "kimi")
+	h.registerOAuthSession(state, "kimi")
 
 	go func() {
 		fmt.Println("Waiting for authentication...")
@@ -1851,7 +1851,7 @@ func (h *Handler) RequestIFlowToken(c *gin.Context) {
 	authSvc := iflowauth.NewIFlowAuth(h.cfg)
 	authURL, redirectURI := authSvc.AuthorizationURL(state, iflowauth.CallbackPort)
 
-	RegisterOAuthSession(state, "iflow")
+	authDir := h.registerOAuthSession(state, "iflow")
 
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
@@ -1876,7 +1876,7 @@ func (h *Handler) RequestIFlowToken(c *gin.Context) {
 		}
 		fmt.Println("Waiting for authentication...")
 
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-iflow-%s.oauth", state))
+		waitFile := filepath.Join(authDir, fmt.Sprintf(".oauth-iflow-%s.oauth", state))
 		deadline := time.Now().Add(5 * time.Minute)
 		var resultMap map[string]string
 		for {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -221,17 +221,18 @@ func stopForwarderInstance(port int, forwarder *callbackForwarder) {
 }
 
 func (h *Handler) managementCallbackURL(path string) (string, error) {
-	if h == nil || h.cfg == nil || h.cfg.Port <= 0 {
+	snapshot, err := h.runtimeSnapshot()
+	if h == nil || err != nil || snapshot.cfg == nil || snapshot.cfg.Port <= 0 {
 		return "", fmt.Errorf("server port is not configured")
 	}
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
 	scheme := "http"
-	if h.cfg.TLS.Enable {
+	if snapshot.cfg.TLS.Enable {
 		scheme = "https"
 	}
-	return fmt.Sprintf("%s://127.0.0.1:%d%s", scheme, h.cfg.Port, path), nil
+	return fmt.Sprintf("%s://127.0.0.1:%d%s", scheme, snapshot.cfg.Port, path), nil
 }
 
 func (h *Handler) ListAuthFiles(c *gin.Context) {
@@ -239,11 +240,16 @@ func (h *Handler) ListAuthFiles(c *gin.Context) {
 		c.JSON(500, gin.H{"error": "handler not initialized"})
 		return
 	}
-	if h.authManager == nil {
+	snapshot, err := h.runtimeSnapshot()
+	if err != nil {
+		c.JSON(500, gin.H{"error": "failed to snapshot runtime state"})
+		return
+	}
+	if snapshot.authManager == nil {
 		h.listAuthFilesFromDisk(c)
 		return
 	}
-	auths := h.authManager.List()
+	auths := snapshot.authManager.List()
 	files := make([]gin.H, 0, len(auths))
 	for _, auth := range auths {
 		if entry := h.buildAuthFileEntry(auth); entry != nil {
@@ -268,8 +274,8 @@ func (h *Handler) GetAuthFileModels(c *gin.Context) {
 
 	// Try to find auth ID via authManager
 	var authID string
-	if h.authManager != nil {
-		auths := h.authManager.List()
+	if snapshot, err := h.runtimeSnapshot(); err == nil && snapshot.authManager != nil {
+		auths := snapshot.authManager.List()
 		for _, auth := range auths {
 			if auth.FileName == name || auth.ID == name {
 				authID = auth.ID
@@ -308,7 +314,12 @@ func (h *Handler) GetAuthFileModels(c *gin.Context) {
 
 // List auth files from disk when the auth manager is unavailable.
 func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
-	entries, err := os.ReadDir(h.cfg.AuthDir)
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(500, gin.H{"error": "failed to resolve auth dir"})
+		return
+	}
+	entries, err := os.ReadDir(cfg.AuthDir)
 	if err != nil {
 		c.JSON(500, gin.H{"error": fmt.Sprintf("failed to read auth dir: %v", err)})
 		return
@@ -326,7 +337,7 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 			fileData := gin.H{"name": name, "size": info.Size(), "modtime": info.ModTime()}
 
 			// Read file to get type field
-			full := filepath.Join(h.cfg.AuthDir, name)
+			full := filepath.Join(cfg.AuthDir, name)
 			if data, errRead := os.ReadFile(full); errRead == nil {
 				typeValue := gjson.GetBytes(data, "type").String()
 				emailValue := gjson.GetBytes(data, "email").String()
@@ -492,6 +503,51 @@ func isRuntimeOnlyAuth(auth *coreauth.Auth) bool {
 	return strings.EqualFold(strings.TrimSpace(auth.Attributes["runtime_only"]), "true")
 }
 
+func (h *Handler) authManagerSnapshot() (*coreauth.Manager, error) {
+	snapshot, err := h.runtimeSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	return snapshot.authManager, nil
+}
+
+func (h *Handler) authDirSnapshot() (string, error) {
+	cfg, err := h.configSnapshot()
+	if err != nil {
+		return "", err
+	}
+	if cfg == nil {
+		return "", nil
+	}
+	return cfg.AuthDir, nil
+}
+
+func findAuthByName(manager *coreauth.Manager, name string, matchPath bool) *coreauth.Auth {
+	if manager == nil {
+		return nil
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	if auth, ok := manager.GetByID(name); ok {
+		return auth
+	}
+	auths := manager.List()
+	for _, auth := range auths {
+		if auth == nil {
+			continue
+		}
+		if strings.TrimSpace(auth.FileName) == name {
+			return auth
+		}
+		if matchPath && filepath.Base(strings.TrimSpace(authAttribute(auth, "path"))) == name {
+			return auth
+		}
+	}
+	return nil
+}
+
 // Download single auth file by name
 func (h *Handler) DownloadAuthFile(c *gin.Context) {
 	name := c.Query("name")
@@ -503,7 +559,12 @@ func (h *Handler) DownloadAuthFile(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "name must end with .json"})
 		return
 	}
-	full := filepath.Join(h.cfg.AuthDir, name)
+	authDir, err := h.authDirSnapshot()
+	if err != nil || strings.TrimSpace(authDir) == "" {
+		c.JSON(500, gin.H{"error": "auth dir unavailable"})
+		return
+	}
+	full := filepath.Join(authDir, name)
 	data, err := os.ReadFile(full)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -519,7 +580,13 @@ func (h *Handler) DownloadAuthFile(c *gin.Context) {
 
 // Upload auth file: multipart or raw JSON with ?name=
 func (h *Handler) UploadAuthFile(c *gin.Context) {
-	if h.authManager == nil {
+	manager, err := h.authManagerSnapshot()
+	if err != nil || manager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
+		return
+	}
+	authDir, err := h.authDirSnapshot()
+	if err != nil || strings.TrimSpace(authDir) == "" {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
 		return
 	}
@@ -530,7 +597,7 @@ func (h *Handler) UploadAuthFile(c *gin.Context) {
 			c.JSON(400, gin.H{"error": "file must be .json"})
 			return
 		}
-		dst := filepath.Join(h.cfg.AuthDir, name)
+		dst := filepath.Join(authDir, name)
 		if !filepath.IsAbs(dst) {
 			if abs, errAbs := filepath.Abs(dst); errAbs == nil {
 				dst = abs
@@ -566,7 +633,7 @@ func (h *Handler) UploadAuthFile(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "failed to read body"})
 		return
 	}
-	dst := filepath.Join(h.cfg.AuthDir, filepath.Base(name))
+	dst := filepath.Join(authDir, filepath.Base(name))
 	if !filepath.IsAbs(dst) {
 		if abs, errAbs := filepath.Abs(dst); errAbs == nil {
 			dst = abs
@@ -585,13 +652,19 @@ func (h *Handler) UploadAuthFile(c *gin.Context) {
 
 // Delete auth files: single by name or all
 func (h *Handler) DeleteAuthFile(c *gin.Context) {
-	if h.authManager == nil {
+	manager, err := h.authManagerSnapshot()
+	if err != nil || manager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
+		return
+	}
+	authDir, err := h.authDirSnapshot()
+	if err != nil || strings.TrimSpace(authDir) == "" {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
 		return
 	}
 	ctx := c.Request.Context()
 	if all := c.Query("all"); all == "true" || all == "1" || all == "*" {
-		entries, err := os.ReadDir(h.cfg.AuthDir)
+		entries, err := os.ReadDir(authDir)
 		if err != nil {
 			c.JSON(500, gin.H{"error": fmt.Sprintf("failed to read auth dir: %v", err)})
 			return
@@ -605,7 +678,7 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 			if !strings.HasSuffix(strings.ToLower(name), ".json") {
 				continue
 			}
-			full := filepath.Join(h.cfg.AuthDir, name)
+			full := filepath.Join(authDir, name)
 			if !filepath.IsAbs(full) {
 				if abs, errAbs := filepath.Abs(full); errAbs == nil {
 					full = abs
@@ -629,9 +702,9 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 		return
 	}
 
-	targetPath := filepath.Join(h.cfg.AuthDir, filepath.Base(name))
+	targetPath := filepath.Join(authDir, filepath.Base(name))
 	targetID := ""
-	if targetAuth := h.findAuthForDelete(name); targetAuth != nil {
+	if targetAuth := findAuthByName(manager, name, true); targetAuth != nil {
 		targetID = strings.TrimSpace(targetAuth.ID)
 		if path := strings.TrimSpace(authAttribute(targetAuth, "path")); path != "" {
 			targetPath = path
@@ -663,29 +736,11 @@ func (h *Handler) DeleteAuthFile(c *gin.Context) {
 }
 
 func (h *Handler) findAuthForDelete(name string) *coreauth.Auth {
-	if h == nil || h.authManager == nil {
+	manager, err := h.authManagerSnapshot()
+	if h == nil || err != nil || manager == nil {
 		return nil
 	}
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return nil
-	}
-	if auth, ok := h.authManager.GetByID(name); ok {
-		return auth
-	}
-	auths := h.authManager.List()
-	for _, auth := range auths {
-		if auth == nil {
-			continue
-		}
-		if strings.TrimSpace(auth.FileName) == name {
-			return auth
-		}
-		if filepath.Base(strings.TrimSpace(authAttribute(auth, "path"))) == name {
-			return auth
-		}
-	}
-	return nil
+	return findAuthByName(manager, name, true)
 }
 
 func (h *Handler) authIDForPath(path string) string {
@@ -694,8 +749,8 @@ func (h *Handler) authIDForPath(path string) string {
 		return ""
 	}
 	id := path
-	if h != nil && h.cfg != nil {
-		authDir := strings.TrimSpace(h.cfg.AuthDir)
+	if authDir, err := h.authDirSnapshot(); err == nil {
+		authDir = strings.TrimSpace(authDir)
 		if authDir != "" {
 			if rel, errRel := filepath.Rel(authDir, path); errRel == nil && rel != "" {
 				id = rel
@@ -710,7 +765,8 @@ func (h *Handler) authIDForPath(path string) string {
 }
 
 func (h *Handler) registerAuthFromFile(ctx context.Context, path string, data []byte) error {
-	if h.authManager == nil {
+	manager, err := h.authManagerSnapshot()
+	if err != nil || manager == nil {
 		return nil
 	}
 	if path == "" {
@@ -759,23 +815,24 @@ func (h *Handler) registerAuthFromFile(ctx context.Context, path string, data []
 	if hasLastRefresh {
 		auth.LastRefreshedAt = lastRefresh
 	}
-	if existing, ok := h.authManager.GetByID(authID); ok {
+	if existing, ok := manager.GetByID(authID); ok {
 		auth.CreatedAt = existing.CreatedAt
 		if !hasLastRefresh {
 			auth.LastRefreshedAt = existing.LastRefreshedAt
 		}
 		auth.NextRefreshAfter = existing.NextRefreshAfter
 		auth.Runtime = existing.Runtime
-		_, err := h.authManager.Update(ctx, auth)
+		_, err := manager.Update(ctx, auth)
 		return err
 	}
-	_, err := h.authManager.Register(ctx, auth)
+	_, err = manager.Register(ctx, auth)
 	return err
 }
 
 // PatchAuthFileStatus toggles the disabled state of an auth file
 func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
-	if h.authManager == nil {
+	manager, err := h.authManagerSnapshot()
+	if err != nil || manager == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
 		return
 	}
@@ -803,17 +860,7 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 
 	// Find auth by name or ID
 	var targetAuth *coreauth.Auth
-	if auth, ok := h.authManager.GetByID(name); ok {
-		targetAuth = auth
-	} else {
-		auths := h.authManager.List()
-		for _, auth := range auths {
-			if auth.FileName == name {
-				targetAuth = auth
-				break
-			}
-		}
-	}
+	targetAuth = findAuthByName(manager, name, false)
 
 	if targetAuth == nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "auth file not found"})
@@ -831,7 +878,7 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 	}
 	targetAuth.UpdatedAt = time.Now()
 
-	if _, err := h.authManager.Update(ctx, targetAuth); err != nil {
+	if _, err := manager.Update(ctx, targetAuth); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update auth: %v", err)})
 		return
 	}
@@ -841,7 +888,8 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 
 // PatchAuthFileFields updates editable fields (prefix, proxy_url, priority) of an auth file.
 func (h *Handler) PatchAuthFileFields(c *gin.Context) {
-	if h.authManager == nil {
+	manager, err := h.authManagerSnapshot()
+	if err != nil || manager == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
 		return
 	}
@@ -867,17 +915,7 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 
 	// Find auth by name or ID
 	var targetAuth *coreauth.Auth
-	if auth, ok := h.authManager.GetByID(name); ok {
-		targetAuth = auth
-	} else {
-		auths := h.authManager.List()
-		for _, auth := range auths {
-			if auth.FileName == name {
-				targetAuth = auth
-				break
-			}
-		}
-	}
+	targetAuth = findAuthByName(manager, name, false)
 
 	if targetAuth == nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "auth file not found"})
@@ -912,7 +950,7 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 
 	targetAuth.UpdatedAt = time.Now()
 
-	if _, err := h.authManager.Update(ctx, targetAuth); err != nil {
+	if _, err := manager.Update(ctx, targetAuth); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update auth: %v", err)})
 		return
 	}
@@ -921,31 +959,32 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 }
 
 func (h *Handler) disableAuth(ctx context.Context, id string) {
-	if h == nil || h.authManager == nil {
+	manager, err := h.authManagerSnapshot()
+	if h == nil || err != nil || manager == nil {
 		return
 	}
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return
 	}
-	if auth, ok := h.authManager.GetByID(id); ok {
+	if auth, ok := manager.GetByID(id); ok {
 		auth.Disabled = true
 		auth.Status = coreauth.StatusDisabled
 		auth.StatusMessage = "removed via management API"
 		auth.UpdatedAt = time.Now()
-		_, _ = h.authManager.Update(ctx, auth)
+		_, _ = manager.Update(ctx, auth)
 		return
 	}
 	authID := h.authIDForPath(id)
 	if authID == "" {
 		return
 	}
-	if auth, ok := h.authManager.GetByID(authID); ok {
+	if auth, ok := manager.GetByID(authID); ok {
 		auth.Disabled = true
 		auth.Status = coreauth.StatusDisabled
 		auth.StatusMessage = "removed via management API"
 		auth.UpdatedAt = time.Now()
-		_, _ = h.authManager.Update(ctx, auth)
+		_, _ = manager.Update(ctx, auth)
 	}
 }
 
@@ -964,14 +1003,22 @@ func (h *Handler) tokenStoreWithBaseDir() coreauth.Store {
 	if h == nil {
 		return nil
 	}
-	store := h.tokenStore
+	snapshot, err := h.runtimeSnapshot()
+	if err != nil {
+		return nil
+	}
+	store := snapshot.tokenStore
 	if store == nil {
 		store = sdkAuth.GetTokenStore()
-		h.tokenStore = store
+		h.stateMu.Lock()
+		if h.tokenStore == nil {
+			h.tokenStore = store
+		}
+		h.stateMu.Unlock()
 	}
-	if h.cfg != nil {
+	if snapshot.cfg != nil {
 		if dirSetter, ok := store.(interface{ SetBaseDir(string) }); ok {
-			dirSetter.SetBaseDir(h.cfg.AuthDir)
+			dirSetter.SetBaseDir(snapshot.cfg.AuthDir)
 		}
 	}
 	return store
@@ -985,8 +1032,12 @@ func (h *Handler) saveTokenRecord(ctx context.Context, record *coreauth.Auth) (s
 	if store == nil {
 		return "", fmt.Errorf("token store unavailable")
 	}
-	if h.postAuthHook != nil {
-		if err := h.postAuthHook(ctx, record); err != nil {
+	snapshot, err := h.runtimeSnapshot()
+	if err != nil {
+		return "", err
+	}
+	if snapshot.postAuthHook != nil {
+		if err := snapshot.postAuthHook(ctx, record); err != nil {
 			return "", fmt.Errorf("post-auth hook failed: %w", err)
 		}
 	}
@@ -996,6 +1047,11 @@ func (h *Handler) saveTokenRecord(ctx context.Context, record *coreauth.Auth) (s
 func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return
+	}
 
 	fmt.Println("Initializing Claude authentication...")
 
@@ -1016,7 +1072,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	}
 
 	// Initialize Claude auth service
-	anthropicAuth := claude.NewClaudeAuth(h.cfg)
+	anthropicAuth := claude.NewClaudeAuth(cfg)
 
 	// Generate authorization URL (then override redirect_uri to reuse server port)
 	authURL, state, err := anthropicAuth.GenerateAuthURL(state, pkceCodes)
@@ -1141,7 +1197,12 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
-	proxyHTTPClient := util.SetProxy(&h.cfg.SDKConfig, &http.Client{})
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return
+	}
+	proxyHTTPClient := util.SetProxy(&cfg.SDKConfig, &http.Client{})
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, proxyHTTPClient)
 
 	// Optional project ID from query
@@ -1291,7 +1352,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 
 		// Initialize authenticated HTTP client via GeminiAuth to honor proxy settings
 		gemAuth := geminiAuth.NewGeminiAuth()
-		gemClient, errGetClient := gemAuth.GetAuthenticatedClient(ctx, &ts, h.cfg, &geminiAuth.WebLoginOptions{
+		gemClient, errGetClient := gemAuth.GetAuthenticatedClient(ctx, &ts, cfg, &geminiAuth.WebLoginOptions{
 			NoBrowser: true,
 		})
 		if errGetClient != nil {
@@ -1400,6 +1461,11 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 func (h *Handler) RequestCodexToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return
+	}
 
 	fmt.Println("Initializing Codex authentication...")
 
@@ -1420,7 +1486,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 	}
 
 	// Initialize Codex auth service
-	openaiAuth := codex.NewCodexAuth(h.cfg)
+	openaiAuth := codex.NewCodexAuth(cfg)
 
 	// Generate authorization URL
 	authURL, err := openaiAuth.GenerateAuthURL(state, pkceCodes)
@@ -1546,10 +1612,15 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return
+	}
 
 	fmt.Println("Initializing Antigravity authentication...")
 
-	authSvc := antigravity.NewAntigravityAuth(h.cfg, nil)
+	authSvc := antigravity.NewAntigravityAuth(cfg, nil)
 
 	state, errState := misc.GenerateRandomState()
 	if errState != nil {
@@ -1711,12 +1782,17 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 func (h *Handler) RequestQwenToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return
+	}
 
 	fmt.Println("Initializing Qwen authentication...")
 
 	state := fmt.Sprintf("gem-%d", time.Now().UnixNano())
 	// Initialize Qwen auth service
-	qwenAuth := qwen.NewQwenAuth(h.cfg)
+	qwenAuth := qwen.NewQwenAuth(cfg)
 
 	// Generate authorization URL
 	deviceFlow, err := qwenAuth.InitiateDeviceFlow(ctx)
@@ -1767,12 +1843,17 @@ func (h *Handler) RequestQwenToken(c *gin.Context) {
 func (h *Handler) RequestKimiToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return
+	}
 
 	fmt.Println("Initializing Kimi authentication...")
 
 	state := fmt.Sprintf("kmi-%d", time.Now().UnixNano())
 	// Initialize Kimi auth service
-	kimiAuth := kimi.NewKimiAuth(h.cfg)
+	kimiAuth := kimi.NewKimiAuth(cfg)
 
 	// Generate authorization URL
 	deviceFlow, errStartDeviceFlow := kimiAuth.StartDeviceFlow(ctx)
@@ -1844,11 +1925,16 @@ func (h *Handler) RequestKimiToken(c *gin.Context) {
 func (h *Handler) RequestIFlowToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "configuration unavailable"})
+		return
+	}
 
 	fmt.Println("Initializing iFlow authentication...")
 
 	state := fmt.Sprintf("ifl-%d", time.Now().UnixNano())
-	authSvc := iflowauth.NewIFlowAuth(h.cfg)
+	authSvc := iflowauth.NewIFlowAuth(cfg)
 	authURL, redirectURI := authSvc.AuthorizationURL(state, iflowauth.CallbackPort)
 
 	authDir := h.registerOAuthSession(state, "iflow")
@@ -1957,6 +2043,11 @@ func (h *Handler) RequestIFlowToken(c *gin.Context) {
 
 func (h *Handler) RequestIFlowCookieToken(c *gin.Context) {
 	ctx := context.Background()
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "configuration unavailable"})
+		return
+	}
 
 	var payload struct {
 		Cookie string `json:"cookie"`
@@ -1981,7 +2072,7 @@ func (h *Handler) RequestIFlowCookieToken(c *gin.Context) {
 
 	// Check for duplicate BXAuth before authentication
 	bxAuth := iflowauth.ExtractBXAuth(cookieValue)
-	if existingFile, err := iflowauth.CheckDuplicateBXAuth(h.cfg.AuthDir, bxAuth); err != nil {
+	if existingFile, err := iflowauth.CheckDuplicateBXAuth(cfg.AuthDir, bxAuth); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "failed to check duplicate"})
 		return
 	} else if existingFile != "" {
@@ -1990,7 +2081,7 @@ func (h *Handler) RequestIFlowCookieToken(c *gin.Context) {
 		return
 	}
 
-	authSvc := iflowauth.NewIFlowAuth(h.cfg)
+	authSvc := iflowauth.NewIFlowAuth(cfg)
 	tokenData, errAuth := authSvc.AuthenticateWithCookie(ctx, cookieValue)
 	if errAuth != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": errAuth.Error()})

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -217,6 +217,10 @@ func (h *Handler) PutLogsMaxTotalSizeMB(c *gin.Context) {
 	if value < 0 {
 		value = 0
 	}
+	if value > config.MaxLogsMaxTotalSizeMB {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "logs-max-total-size-mb exceeds allowed maximum"})
+		return
+	}
 	h.cfg.LogsMaxTotalSizeMB = value
 	h.persist(c)
 }
@@ -326,3 +330,4 @@ func (h *Handler) DeleteProxyURL(c *gin.Context) {
 	h.cfg.ProxyURL = ""
 	h.persist(c)
 }
+

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -24,11 +24,16 @@ const (
 )
 
 func (h *Handler) GetConfig(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{})
+	cfg, err := h.configSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "config snapshot failed", "message": err.Error()})
 		return
 	}
-	c.JSON(200, new(*h.cfg))
+	if cfg == nil {
+		c.JSON(http.StatusOK, gin.H{})
+		return
+	}
+	c.JSON(http.StatusOK, cfg)
 }
 
 type releaseInfo struct {
@@ -39,9 +44,14 @@ type releaseInfo struct {
 // GetLatestVersion returns the latest release version from GitHub without downloading assets.
 func (h *Handler) GetLatestVersion(c *gin.Context) {
 	client := &http.Client{Timeout: 10 * time.Second}
+	cfg, err := h.configSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "config snapshot failed", "message": err.Error()})
+		return
+	}
 	proxyURL := ""
-	if h != nil && h.cfg != nil {
-		proxyURL = strings.TrimSpace(h.cfg.ProxyURL)
+	if cfg != nil {
+		proxyURL = strings.TrimSpace(cfg.ProxyURL)
 	}
 	if proxyURL != "" {
 		sdkCfg := &sdkconfig.SDKConfig{ProxyURL: proxyURL}
@@ -93,7 +103,7 @@ func (h *Handler) GetLatestVersion(c *gin.Context) {
 
 func WriteConfig(path string, data []byte) error {
 	data = config.NormalizeCommentIndentation(data)
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}
@@ -114,13 +124,23 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_yaml", "message": "cannot read request body"})
 		return
 	}
-	var cfg config.Config
-	if err = yaml.Unmarshal(body, &cfg); err != nil {
+	var parsed config.Config
+	if err = yaml.Unmarshal(body, &parsed); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_yaml", "message": err.Error()})
 		return
 	}
-	// Validate config using LoadConfigOptional with optional=false to enforce parsing
-	tmpDir := filepath.Dir(h.configFilePath)
+	if parsed.LogsMaxTotalSizeMB > config.MaxLogsMaxTotalSizeMB {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "logs-max-total-size-mb exceeds allowed maximum"})
+		return
+	}
+
+	snapshot, err := h.runtimeSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "config snapshot failed", "message": err.Error()})
+		return
+	}
+
+	tmpDir := filepath.Dir(snapshot.configFilePath)
 	tmpFile, err := os.CreateTemp(tmpDir, "config-validate-*.yaml")
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "write_failed", "message": err.Error()})
@@ -141,31 +161,38 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 	defer func() {
 		_ = os.Remove(tempFile)
 	}()
-	_, err = config.LoadConfigOptional(tempFile, false)
-	if err != nil {
+
+	if _, err = config.LoadConfigOptional(tempFile, false); err != nil {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid_config", "message": err.Error()})
 		return
 	}
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if WriteConfig(h.configFilePath, body) != nil {
+	if err := WriteConfig(snapshot.configFilePath, body); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "write_failed", "message": "failed to write config"})
 		return
 	}
-	// Reload into handler to keep memory in sync
-	newCfg, err := config.LoadConfig(h.configFilePath)
+	newCfg, err := config.LoadConfig(snapshot.configFilePath)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "reload_failed", "message": err.Error()})
 		return
 	}
+	h.stateMu.Lock()
 	h.cfg = newCfg
+	h.stateMu.Unlock()
 	c.JSON(http.StatusOK, gin.H{"ok": true, "changed": []string{"config"}})
 }
 
 // GetConfigYAML returns the raw config.yaml file bytes without re-encoding.
 // It preserves comments and original formatting/styles.
 func (h *Handler) GetConfigYAML(c *gin.Context) {
-	data, err := os.ReadFile(h.configFilePath)
+	snapshot, err := h.runtimeSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "config snapshot failed", "message": err.Error()})
+		return
+	}
+	data, err := os.ReadFile(snapshot.configFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not_found", "message": "config file not found"})
@@ -177,110 +204,168 @@ func (h *Handler) GetConfigYAML(c *gin.Context) {
 	c.Header("Content-Type", "application/yaml; charset=utf-8")
 	c.Header("Cache-Control", "no-store")
 	c.Header("X-Content-Type-Options", "nosniff")
-	// Write raw bytes as-is
 	_, _ = c.Writer.Write(data)
 }
 
 // Debug
-func (h *Handler) GetDebug(c *gin.Context) { c.JSON(200, gin.H{"debug": h.cfg.Debug}) }
-func (h *Handler) PutDebug(c *gin.Context) { h.updateBoolField(c, func(v bool) { h.cfg.Debug = v }) }
+func (h *Handler) GetDebug(c *gin.Context) {
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"debug": false})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"debug": cfg.Debug})
+}
+
+func (h *Handler) PutDebug(c *gin.Context) {
+	h.updateBoolField(c, func(cfg *config.Config, v bool) { cfg.Debug = v })
+}
 
 // UsageStatisticsEnabled
 func (h *Handler) GetUsageStatisticsEnabled(c *gin.Context) {
-	c.JSON(200, gin.H{"usage-statistics-enabled": h.cfg.UsageStatisticsEnabled})
-}
-func (h *Handler) PutUsageStatisticsEnabled(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.UsageStatisticsEnabled = v })
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"usage-statistics-enabled": false})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"usage-statistics-enabled": cfg.UsageStatisticsEnabled})
 }
 
-// UsageStatisticsEnabled
-func (h *Handler) GetLoggingToFile(c *gin.Context) {
-	c.JSON(200, gin.H{"logging-to-file": h.cfg.LoggingToFile})
+func (h *Handler) PutUsageStatisticsEnabled(c *gin.Context) {
+	h.updateBoolField(c, func(cfg *config.Config, v bool) { cfg.UsageStatisticsEnabled = v })
 }
+
+// LoggingToFile
+func (h *Handler) GetLoggingToFile(c *gin.Context) {
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"logging-to-file": false})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"logging-to-file": cfg.LoggingToFile})
+}
+
 func (h *Handler) PutLoggingToFile(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.LoggingToFile = v })
+	h.updateBoolField(c, func(cfg *config.Config, v bool) { cfg.LoggingToFile = v })
 }
 
 // LogsMaxTotalSizeMB
 func (h *Handler) GetLogsMaxTotalSizeMB(c *gin.Context) {
-	c.JSON(200, gin.H{"logs-max-total-size-mb": h.cfg.LogsMaxTotalSizeMB})
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"logs-max-total-size-mb": 0})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"logs-max-total-size-mb": cfg.LogsMaxTotalSizeMB})
 }
+
 func (h *Handler) PutLogsMaxTotalSizeMB(c *gin.Context) {
-	var body struct {
-		Value *int `json:"value"`
-	}
-	if errBindJSON := c.ShouldBindJSON(&body); errBindJSON != nil || body.Value == nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
-		return
-	}
-	value := *body.Value
-	if value < 0 {
-		value = 0
-	}
-	if value > config.MaxLogsMaxTotalSizeMB {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "logs-max-total-size-mb exceeds allowed maximum"})
-		return
-	}
-	h.cfg.LogsMaxTotalSizeMB = value
-	h.persist(c)
+	h.updateIntField(c, func(cfg *config.Config, value int) error {
+		if value < 0 {
+			value = 0
+		}
+		if value > config.MaxLogsMaxTotalSizeMB {
+			return fmt.Errorf("logs-max-total-size-mb exceeds allowed maximum")
+		}
+		cfg.LogsMaxTotalSizeMB = value
+		return nil
+	})
 }
 
 // ErrorLogsMaxFiles
 func (h *Handler) GetErrorLogsMaxFiles(c *gin.Context) {
-	c.JSON(200, gin.H{"error-logs-max-files": h.cfg.ErrorLogsMaxFiles})
-}
-func (h *Handler) PutErrorLogsMaxFiles(c *gin.Context) {
-	var body struct {
-		Value *int `json:"value"`
-	}
-	if errBindJSON := c.ShouldBindJSON(&body); errBindJSON != nil || body.Value == nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"error-logs-max-files": 0})
 		return
 	}
-	value := *body.Value
-	if value < 0 {
-		value = 10
-	}
-	h.cfg.ErrorLogsMaxFiles = value
-	h.persist(c)
+	c.JSON(http.StatusOK, gin.H{"error-logs-max-files": cfg.ErrorLogsMaxFiles})
+}
+
+func (h *Handler) PutErrorLogsMaxFiles(c *gin.Context) {
+	h.updateIntField(c, func(cfg *config.Config, value int) error {
+		if value < 0 {
+			value = 10
+		}
+		cfg.ErrorLogsMaxFiles = value
+		return nil
+	})
 }
 
 // Request log
-func (h *Handler) GetRequestLog(c *gin.Context) { c.JSON(200, gin.H{"request-log": h.cfg.RequestLog}) }
+func (h *Handler) GetRequestLog(c *gin.Context) {
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"request-log": false})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"request-log": cfg.RequestLog})
+}
+
 func (h *Handler) PutRequestLog(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.RequestLog = v })
+	h.updateBoolField(c, func(cfg *config.Config, v bool) { cfg.RequestLog = v })
 }
 
 // Websocket auth
 func (h *Handler) GetWebsocketAuth(c *gin.Context) {
-	c.JSON(200, gin.H{"ws-auth": h.cfg.WebsocketAuth})
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"ws-auth": false})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ws-auth": cfg.WebsocketAuth})
 }
+
 func (h *Handler) PutWebsocketAuth(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.WebsocketAuth = v })
+	h.updateBoolField(c, func(cfg *config.Config, v bool) { cfg.WebsocketAuth = v })
 }
 
 // Request retry
 func (h *Handler) GetRequestRetry(c *gin.Context) {
-	c.JSON(200, gin.H{"request-retry": h.cfg.RequestRetry})
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"request-retry": 0})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"request-retry": cfg.RequestRetry})
 }
+
 func (h *Handler) PutRequestRetry(c *gin.Context) {
-	h.updateIntField(c, func(v int) { h.cfg.RequestRetry = v })
+	h.updateIntField(c, func(cfg *config.Config, v int) error {
+		cfg.RequestRetry = v
+		return nil
+	})
 }
 
 // Max retry interval
 func (h *Handler) GetMaxRetryInterval(c *gin.Context) {
-	c.JSON(200, gin.H{"max-retry-interval": h.cfg.MaxRetryInterval})
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"max-retry-interval": 0})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"max-retry-interval": cfg.MaxRetryInterval})
 }
+
 func (h *Handler) PutMaxRetryInterval(c *gin.Context) {
-	h.updateIntField(c, func(v int) { h.cfg.MaxRetryInterval = v })
+	h.updateIntField(c, func(cfg *config.Config, v int) error {
+		cfg.MaxRetryInterval = v
+		return nil
+	})
 }
 
 // ForceModelPrefix
 func (h *Handler) GetForceModelPrefix(c *gin.Context) {
-	c.JSON(200, gin.H{"force-model-prefix": h.cfg.ForceModelPrefix})
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"force-model-prefix": false})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"force-model-prefix": cfg.ForceModelPrefix})
 }
+
 func (h *Handler) PutForceModelPrefix(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.ForceModelPrefix = v })
+	h.updateBoolField(c, func(cfg *config.Config, v bool) { cfg.ForceModelPrefix = v })
 }
 
 func normalizeRoutingStrategy(strategy string) (string, bool) {
@@ -297,13 +382,19 @@ func normalizeRoutingStrategy(strategy string) (string, bool) {
 
 // RoutingStrategy
 func (h *Handler) GetRoutingStrategy(c *gin.Context) {
-	strategy, ok := normalizeRoutingStrategy(h.cfg.Routing.Strategy)
-	if !ok {
-		c.JSON(200, gin.H{"strategy": strings.TrimSpace(h.cfg.Routing.Strategy)})
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"strategy": ""})
 		return
 	}
-	c.JSON(200, gin.H{"strategy": strategy})
+	strategy, ok := normalizeRoutingStrategy(cfg.Routing.Strategy)
+	if !ok {
+		c.JSON(http.StatusOK, gin.H{"strategy": strings.TrimSpace(cfg.Routing.Strategy)})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"strategy": strategy})
 }
+
 func (h *Handler) PutRoutingStrategy(c *gin.Context) {
 	var body struct {
 		Value *string `json:"value"`
@@ -317,17 +408,29 @@ func (h *Handler) PutRoutingStrategy(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid strategy"})
 		return
 	}
-	h.cfg.Routing.Strategy = normalized
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		cfg.Routing.Strategy = normalized
+		return nil
+	})
 }
 
 // Proxy URL
-func (h *Handler) GetProxyURL(c *gin.Context) { c.JSON(200, gin.H{"proxy-url": h.cfg.ProxyURL}) }
-func (h *Handler) PutProxyURL(c *gin.Context) {
-	h.updateStringField(c, func(v string) { h.cfg.ProxyURL = v })
-}
-func (h *Handler) DeleteProxyURL(c *gin.Context) {
-	h.cfg.ProxyURL = ""
-	h.persist(c)
+func (h *Handler) GetProxyURL(c *gin.Context) {
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"proxy-url": ""})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"proxy-url": cfg.ProxyURL})
 }
 
+func (h *Handler) PutProxyURL(c *gin.Context) {
+	h.updateStringField(c, func(cfg *config.Config, v string) { cfg.ProxyURL = v })
+}
+
+func (h *Handler) DeleteProxyURL(c *gin.Context) {
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		cfg.ProxyURL = ""
+		return nil
+	})
+}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -9,32 +9,82 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 )
 
-// Generic helpers for list[string]
-func (h *Handler) putStringList(c *gin.Context, set func([]string), after func()) {
+func (h *Handler) configSnapshotOrEmpty() *config.Config {
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		return &config.Config{}
+	}
+	return cfg
+}
+
+func decodeJSONItems[T any](c *gin.Context) ([]T, bool) {
 	data, err := c.GetRawData()
 	if err != nil {
 		c.JSON(400, gin.H{"error": "failed to read body"})
-		return
+		return nil, false
 	}
-	var arr []string
-	if err = json.Unmarshal(data, &arr); err != nil {
-		var obj struct {
-			Items []string `json:"items"`
-		}
-		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
-			c.JSON(400, gin.H{"error": "invalid body"})
-			return
-		}
-		arr = obj.Items
+
+	var items []T
+	if err = json.Unmarshal(data, &items); err == nil {
+		return items, true
 	}
-	set(arr)
-	if after != nil {
-		after()
+
+	var wrapped struct {
+		Items []T `json:"items"`
 	}
-	h.persist(c)
+	if err = json.Unmarshal(data, &wrapped); err != nil || len(wrapped.Items) == 0 {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return nil, false
+	}
+	return wrapped.Items, true
 }
 
-func (h *Handler) patchStringList(c *gin.Context, target *[]string, after func()) {
+func findIndexByIndexOrMatch[T any](items []T, index *int, match *string, matches func(T, string) bool) int {
+	if index != nil && *index >= 0 && *index < len(items) {
+		return *index
+	}
+	if match == nil {
+		return -1
+	}
+
+	needle := strings.TrimSpace(*match)
+	if needle == "" {
+		return -1
+	}
+	for i := range items {
+		if matches(items[i], needle) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (h *Handler) ampCodeSnapshot() config.AmpCode {
+	return h.configSnapshotOrEmpty().AmpCode
+}
+
+func (h *Handler) mutateAmpCode(c *gin.Context, mutate func(*config.AmpCode) error) {
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		return mutate(&cfg.AmpCode)
+	})
+}
+
+// Generic helpers for list[string]
+func (h *Handler) putStringList(c *gin.Context, set func(*config.Config, []string), after func(*config.Config)) {
+	arr, ok := decodeJSONItems[string](c)
+	if !ok {
+		return
+	}
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		set(cfg, arr)
+		if after != nil {
+			after(cfg)
+		}
+		return nil
+	})
+}
+
+func (h *Handler) patchStringList(c *gin.Context, target func(*config.Config) *[]string, after func(*config.Config)) {
 	var body struct {
 		Old   *string `json:"old"`
 		New   *string `json:"new"`
@@ -45,103 +95,106 @@ func (h *Handler) patchStringList(c *gin.Context, target *[]string, after func()
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	if body.Index != nil && body.Value != nil && *body.Index >= 0 && *body.Index < len(*target) {
-		(*target)[*body.Index] = *body.Value
-		if after != nil {
-			after()
-		}
-		h.persist(c)
-		return
-	}
-	if body.Old != nil && body.New != nil {
-		for i := range *target {
-			if (*target)[i] == *body.Old {
-				(*target)[i] = *body.New
-				if after != nil {
-					after()
-				}
-				h.persist(c)
-				return
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		items := target(cfg)
+		if body.Index != nil && body.Value != nil && *body.Index >= 0 && *body.Index < len(*items) {
+			(*items)[*body.Index] = *body.Value
+			if after != nil {
+				after(cfg)
 			}
+			return nil
 		}
-		*target = append(*target, *body.New)
-		if after != nil {
-			after()
+		if body.Old != nil && body.New != nil {
+			for i := range *items {
+				if (*items)[i] == *body.Old {
+					(*items)[i] = *body.New
+					if after != nil {
+						after(cfg)
+					}
+					return nil
+				}
+			}
+			*items = append(*items, *body.New)
+			if after != nil {
+				after(cfg)
+			}
+			return nil
 		}
-		h.persist(c)
-		return
-	}
-	c.JSON(400, gin.H{"error": "missing fields"})
+		return fmt.Errorf("missing fields")
+	})
 }
 
-func (h *Handler) deleteFromStringList(c *gin.Context, target *[]string, after func()) {
+func (h *Handler) deleteFromStringList(c *gin.Context, target func(*config.Config) *[]string, after func(*config.Config)) {
 	if idxStr := c.Query("index"); idxStr != "" {
 		var idx int
 		_, err := fmt.Sscanf(idxStr, "%d", &idx)
-		if err == nil && idx >= 0 && idx < len(*target) {
-			*target = append((*target)[:idx], (*target)[idx+1:]...)
-			if after != nil {
-				after()
-			}
-			h.persist(c)
+		if err == nil {
+			h.applyConfigMutation(c, func(cfg *config.Config) error {
+				items := target(cfg)
+				if idx < 0 || idx >= len(*items) {
+					return fmt.Errorf("missing index or value")
+				}
+				*items = append((*items)[:idx], (*items)[idx+1:]...)
+				if after != nil {
+					after(cfg)
+				}
+				return nil
+			})
 			return
 		}
 	}
 	if val := strings.TrimSpace(c.Query("value")); val != "" {
-		out := make([]string, 0, len(*target))
-		for _, v := range *target {
-			if strings.TrimSpace(v) != val {
-				out = append(out, v)
+		h.applyConfigMutation(c, func(cfg *config.Config) error {
+			items := target(cfg)
+			out := make([]string, 0, len(*items))
+			for _, v := range *items {
+				if strings.TrimSpace(v) != val {
+					out = append(out, v)
+				}
 			}
-		}
-		*target = out
-		if after != nil {
-			after()
-		}
-		h.persist(c)
+			*items = out
+			if after != nil {
+				after(cfg)
+			}
+			return nil
+		})
 		return
 	}
 	c.JSON(400, gin.H{"error": "missing index or value"})
 }
 
 // api-keys
-func (h *Handler) GetAPIKeys(c *gin.Context) { c.JSON(200, gin.H{"api-keys": h.cfg.APIKeys}) }
+func (h *Handler) GetAPIKeys(c *gin.Context) {
+	cfg := h.configSnapshotOrEmpty()
+	c.JSON(200, gin.H{"api-keys": cfg.APIKeys})
+}
 func (h *Handler) PutAPIKeys(c *gin.Context) {
-	h.putStringList(c, func(v []string) {
-		h.cfg.APIKeys = append([]string(nil), v...)
+	h.putStringList(c, func(cfg *config.Config, v []string) {
+		cfg.APIKeys = append([]string(nil), v...)
 	}, nil)
 }
 func (h *Handler) PatchAPIKeys(c *gin.Context) {
-	h.patchStringList(c, &h.cfg.APIKeys, func() {})
+	h.patchStringList(c, func(cfg *config.Config) *[]string { return &cfg.APIKeys }, nil)
 }
 func (h *Handler) DeleteAPIKeys(c *gin.Context) {
-	h.deleteFromStringList(c, &h.cfg.APIKeys, func() {})
+	h.deleteFromStringList(c, func(cfg *config.Config) *[]string { return &cfg.APIKeys }, nil)
 }
 
 // gemini-api-key: []GeminiKey
 func (h *Handler) GetGeminiKeys(c *gin.Context) {
-	c.JSON(200, gin.H{"gemini-api-key": h.cfg.GeminiKey})
+	cfg := h.configSnapshotOrEmpty()
+	c.JSON(200, gin.H{"gemini-api-key": cfg.GeminiKey})
 }
 func (h *Handler) PutGeminiKeys(c *gin.Context) {
-	data, err := c.GetRawData()
-	if err != nil {
-		c.JSON(400, gin.H{"error": "failed to read body"})
+	arr, ok := decodeJSONItems[config.GeminiKey](c)
+	if !ok {
 		return
 	}
-	var arr []config.GeminiKey
-	if err = json.Unmarshal(data, &arr); err != nil {
-		var obj struct {
-			Items []config.GeminiKey `json:"items"`
-		}
-		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
-			c.JSON(400, gin.H{"error": "invalid body"})
-			return
-		}
-		arr = obj.Items
-	}
-	h.cfg.GeminiKey = append([]config.GeminiKey(nil), arr...)
-	h.cfg.SanitizeGeminiKeys()
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		cfg.GeminiKey = append([]config.GeminiKey(nil), arr...)
+		cfg.SanitizeGeminiKeys()
+		return nil
+	})
 }
 func (h *Handler) PatchGeminiKey(c *gin.Context) {
 	type geminiKeyPatch struct {
@@ -161,80 +214,73 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	targetIndex := -1
-	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.GeminiKey) {
-		targetIndex = *body.Index
-	}
-	if targetIndex == -1 && body.Match != nil {
-		match := strings.TrimSpace(*body.Match)
-		if match != "" {
-			for i := range h.cfg.GeminiKey {
-				if h.cfg.GeminiKey[i].APIKey == match {
-					targetIndex = i
-					break
-				}
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		targetIndex := findIndexByIndexOrMatch(cfg.GeminiKey, body.Index, body.Match, func(item config.GeminiKey, match string) bool {
+			return item.APIKey == match
+		})
+		if targetIndex == -1 {
+			return fmt.Errorf("item not found")
+		}
+		entry := cfg.GeminiKey[targetIndex]
+		if body.Value.APIKey != nil {
+			trimmed := strings.TrimSpace(*body.Value.APIKey)
+			if trimmed == "" {
+				cfg.GeminiKey = append(cfg.GeminiKey[:targetIndex], cfg.GeminiKey[targetIndex+1:]...)
+				cfg.SanitizeGeminiKeys()
+				return nil
 			}
+			entry.APIKey = trimmed
 		}
-	}
-	if targetIndex == -1 {
-		c.JSON(404, gin.H{"error": "item not found"})
-		return
-	}
-
-	entry := h.cfg.GeminiKey[targetIndex]
-	if body.Value.APIKey != nil {
-		trimmed := strings.TrimSpace(*body.Value.APIKey)
-		if trimmed == "" {
-			h.cfg.GeminiKey = append(h.cfg.GeminiKey[:targetIndex], h.cfg.GeminiKey[targetIndex+1:]...)
-			h.cfg.SanitizeGeminiKeys()
-			h.persist(c)
-			return
+		if body.Value.Prefix != nil {
+			entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
 		}
-		entry.APIKey = trimmed
-	}
-	if body.Value.Prefix != nil {
-		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
-	}
-	if body.Value.BaseURL != nil {
-		entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
-	}
-	if body.Value.ProxyURL != nil {
-		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
-	}
-	if body.Value.Headers != nil {
-		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
-	}
-	if body.Value.ExcludedModels != nil {
-		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
-	}
-	h.cfg.GeminiKey[targetIndex] = entry
-	h.cfg.SanitizeGeminiKeys()
-	h.persist(c)
+		if body.Value.BaseURL != nil {
+			entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
+		}
+		if body.Value.ProxyURL != nil {
+			entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
+		}
+		if body.Value.Headers != nil {
+			entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
+		}
+		if body.Value.ExcludedModels != nil {
+			entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
+		}
+		cfg.GeminiKey[targetIndex] = entry
+		cfg.SanitizeGeminiKeys()
+		return nil
+	})
 }
 
 func (h *Handler) DeleteGeminiKey(c *gin.Context) {
 	if val := strings.TrimSpace(c.Query("api-key")); val != "" {
-		out := make([]config.GeminiKey, 0, len(h.cfg.GeminiKey))
-		for _, v := range h.cfg.GeminiKey {
-			if v.APIKey != val {
-				out = append(out, v)
+		h.applyConfigMutation(c, func(cfg *config.Config) error {
+			out := make([]config.GeminiKey, 0, len(cfg.GeminiKey))
+			for _, v := range cfg.GeminiKey {
+				if v.APIKey != val {
+					out = append(out, v)
+				}
 			}
-		}
-		if len(out) != len(h.cfg.GeminiKey) {
-			h.cfg.GeminiKey = out
-			h.cfg.SanitizeGeminiKeys()
-			h.persist(c)
-		} else {
-			c.JSON(404, gin.H{"error": "item not found"})
-		}
+			if len(out) == len(cfg.GeminiKey) {
+				return fmt.Errorf("item not found")
+			}
+			cfg.GeminiKey = out
+			cfg.SanitizeGeminiKeys()
+			return nil
+		})
 		return
 	}
 	if idxStr := c.Query("index"); idxStr != "" {
 		var idx int
-		if _, err := fmt.Sscanf(idxStr, "%d", &idx); err == nil && idx >= 0 && idx < len(h.cfg.GeminiKey) {
-			h.cfg.GeminiKey = append(h.cfg.GeminiKey[:idx], h.cfg.GeminiKey[idx+1:]...)
-			h.cfg.SanitizeGeminiKeys()
-			h.persist(c)
+		if _, err := fmt.Sscanf(idxStr, "%d", &idx); err == nil {
+			h.applyConfigMutation(c, func(cfg *config.Config) error {
+				if idx < 0 || idx >= len(cfg.GeminiKey) {
+					return fmt.Errorf("missing api-key or index")
+				}
+				cfg.GeminiKey = append(cfg.GeminiKey[:idx], cfg.GeminiKey[idx+1:]...)
+				cfg.SanitizeGeminiKeys()
+				return nil
+			})
 			return
 		}
 	}
@@ -243,31 +289,22 @@ func (h *Handler) DeleteGeminiKey(c *gin.Context) {
 
 // claude-api-key: []ClaudeKey
 func (h *Handler) GetClaudeKeys(c *gin.Context) {
-	c.JSON(200, gin.H{"claude-api-key": h.cfg.ClaudeKey})
+	cfg := h.configSnapshotOrEmpty()
+	c.JSON(200, gin.H{"claude-api-key": cfg.ClaudeKey})
 }
 func (h *Handler) PutClaudeKeys(c *gin.Context) {
-	data, err := c.GetRawData()
-	if err != nil {
-		c.JSON(400, gin.H{"error": "failed to read body"})
+	arr, ok := decodeJSONItems[config.ClaudeKey](c)
+	if !ok {
 		return
-	}
-	var arr []config.ClaudeKey
-	if err = json.Unmarshal(data, &arr); err != nil {
-		var obj struct {
-			Items []config.ClaudeKey `json:"items"`
-		}
-		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
-			c.JSON(400, gin.H{"error": "invalid body"})
-			return
-		}
-		arr = obj.Items
 	}
 	for i := range arr {
 		normalizeClaudeKey(&arr[i])
 	}
-	h.cfg.ClaudeKey = arr
-	h.cfg.SanitizeClaudeKeys()
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		cfg.ClaudeKey = arr
+		cfg.SanitizeClaudeKeys()
+		return nil
+	})
 }
 func (h *Handler) PatchClaudeKey(c *gin.Context) {
 	type claudeKeyPatch struct {
@@ -288,72 +325,69 @@ func (h *Handler) PatchClaudeKey(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	targetIndex := -1
-	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.ClaudeKey) {
-		targetIndex = *body.Index
-	}
-	if targetIndex == -1 && body.Match != nil {
-		match := strings.TrimSpace(*body.Match)
-		for i := range h.cfg.ClaudeKey {
-			if h.cfg.ClaudeKey[i].APIKey == match {
-				targetIndex = i
-				break
-			}
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		targetIndex := findIndexByIndexOrMatch(cfg.ClaudeKey, body.Index, body.Match, func(item config.ClaudeKey, match string) bool {
+			return item.APIKey == match
+		})
+		if targetIndex == -1 {
+			return fmt.Errorf("item not found")
 		}
-	}
-	if targetIndex == -1 {
-		c.JSON(404, gin.H{"error": "item not found"})
-		return
-	}
-
-	entry := h.cfg.ClaudeKey[targetIndex]
-	if body.Value.APIKey != nil {
-		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
-	}
-	if body.Value.Prefix != nil {
-		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
-	}
-	if body.Value.BaseURL != nil {
-		entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
-	}
-	if body.Value.ProxyURL != nil {
-		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
-	}
-	if body.Value.Models != nil {
-		entry.Models = append([]config.ClaudeModel(nil), (*body.Value.Models)...)
-	}
-	if body.Value.Headers != nil {
-		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
-	}
-	if body.Value.ExcludedModels != nil {
-		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
-	}
-	normalizeClaudeKey(&entry)
-	h.cfg.ClaudeKey[targetIndex] = entry
-	h.cfg.SanitizeClaudeKeys()
-	h.persist(c)
+		entry := cfg.ClaudeKey[targetIndex]
+		if body.Value.APIKey != nil {
+			entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+		}
+		if body.Value.Prefix != nil {
+			entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
+		}
+		if body.Value.BaseURL != nil {
+			entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
+		}
+		if body.Value.ProxyURL != nil {
+			entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
+		}
+		if body.Value.Models != nil {
+			entry.Models = append([]config.ClaudeModel(nil), (*body.Value.Models)...)
+		}
+		if body.Value.Headers != nil {
+			entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
+		}
+		if body.Value.ExcludedModels != nil {
+			entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
+		}
+		normalizeClaudeKey(&entry)
+		cfg.ClaudeKey[targetIndex] = entry
+		cfg.SanitizeClaudeKeys()
+		return nil
+	})
 }
 
 func (h *Handler) DeleteClaudeKey(c *gin.Context) {
 	if val := c.Query("api-key"); val != "" {
-		out := make([]config.ClaudeKey, 0, len(h.cfg.ClaudeKey))
-		for _, v := range h.cfg.ClaudeKey {
-			if v.APIKey != val {
-				out = append(out, v)
+		h.applyConfigMutation(c, func(cfg *config.Config) error {
+			out := make([]config.ClaudeKey, 0, len(cfg.ClaudeKey))
+			for _, v := range cfg.ClaudeKey {
+				if v.APIKey != val {
+					out = append(out, v)
+				}
 			}
-		}
-		h.cfg.ClaudeKey = out
-		h.cfg.SanitizeClaudeKeys()
-		h.persist(c)
+			cfg.ClaudeKey = out
+			cfg.SanitizeClaudeKeys()
+			return nil
+		})
 		return
 	}
 	if idxStr := c.Query("index"); idxStr != "" {
 		var idx int
 		_, err := fmt.Sscanf(idxStr, "%d", &idx)
-		if err == nil && idx >= 0 && idx < len(h.cfg.ClaudeKey) {
-			h.cfg.ClaudeKey = append(h.cfg.ClaudeKey[:idx], h.cfg.ClaudeKey[idx+1:]...)
-			h.cfg.SanitizeClaudeKeys()
-			h.persist(c)
+		if err == nil {
+			h.applyConfigMutation(c, func(cfg *config.Config) error {
+				if idx < 0 || idx >= len(cfg.ClaudeKey) {
+					return fmt.Errorf("missing api-key or index")
+				}
+				cfg.ClaudeKey = append(cfg.ClaudeKey[:idx], cfg.ClaudeKey[idx+1:]...)
+				cfg.SanitizeClaudeKeys()
+				return nil
+			})
 			return
 		}
 	}
@@ -362,24 +396,13 @@ func (h *Handler) DeleteClaudeKey(c *gin.Context) {
 
 // openai-compatibility: []OpenAICompatibility
 func (h *Handler) GetOpenAICompat(c *gin.Context) {
-	c.JSON(200, gin.H{"openai-compatibility": normalizedOpenAICompatibilityEntries(h.cfg.OpenAICompatibility)})
+	cfg := h.configSnapshotOrEmpty()
+	c.JSON(200, gin.H{"openai-compatibility": normalizedOpenAICompatibilityEntries(cfg.OpenAICompatibility)})
 }
 func (h *Handler) PutOpenAICompat(c *gin.Context) {
-	data, err := c.GetRawData()
-	if err != nil {
-		c.JSON(400, gin.H{"error": "failed to read body"})
+	arr, ok := decodeJSONItems[config.OpenAICompatibility](c)
+	if !ok {
 		return
-	}
-	var arr []config.OpenAICompatibility
-	if err = json.Unmarshal(data, &arr); err != nil {
-		var obj struct {
-			Items []config.OpenAICompatibility `json:"items"`
-		}
-		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
-			c.JSON(400, gin.H{"error": "invalid body"})
-			return
-		}
-		arr = obj.Items
 	}
 	filtered := make([]config.OpenAICompatibility, 0, len(arr))
 	for i := range arr {
@@ -388,9 +411,11 @@ func (h *Handler) PutOpenAICompat(c *gin.Context) {
 			filtered = append(filtered, arr[i])
 		}
 	}
-	h.cfg.OpenAICompatibility = filtered
-	h.cfg.SanitizeOpenAICompatibility()
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		cfg.OpenAICompatibility = filtered
+		cfg.SanitizeOpenAICompatibility()
+		return nil
+	})
 }
 func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	type openAICompatPatch struct {
@@ -410,76 +435,72 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	targetIndex := -1
-	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.OpenAICompatibility) {
-		targetIndex = *body.Index
-	}
-	if targetIndex == -1 && body.Name != nil {
-		match := strings.TrimSpace(*body.Name)
-		for i := range h.cfg.OpenAICompatibility {
-			if h.cfg.OpenAICompatibility[i].Name == match {
-				targetIndex = i
-				break
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		targetIndex := findIndexByIndexOrMatch(cfg.OpenAICompatibility, body.Index, body.Name, func(item config.OpenAICompatibility, match string) bool {
+			return item.Name == match
+		})
+		if targetIndex == -1 {
+			return fmt.Errorf("item not found")
+		}
+		entry := cfg.OpenAICompatibility[targetIndex]
+		if body.Value.Name != nil {
+			entry.Name = strings.TrimSpace(*body.Value.Name)
+		}
+		if body.Value.Prefix != nil {
+			entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
+		}
+		if body.Value.BaseURL != nil {
+			trimmed := strings.TrimSpace(*body.Value.BaseURL)
+			if trimmed == "" {
+				cfg.OpenAICompatibility = append(cfg.OpenAICompatibility[:targetIndex], cfg.OpenAICompatibility[targetIndex+1:]...)
+				cfg.SanitizeOpenAICompatibility()
+				return nil
 			}
+			entry.BaseURL = trimmed
 		}
-	}
-	if targetIndex == -1 {
-		c.JSON(404, gin.H{"error": "item not found"})
-		return
-	}
-
-	entry := h.cfg.OpenAICompatibility[targetIndex]
-	if body.Value.Name != nil {
-		entry.Name = strings.TrimSpace(*body.Value.Name)
-	}
-	if body.Value.Prefix != nil {
-		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
-	}
-	if body.Value.BaseURL != nil {
-		trimmed := strings.TrimSpace(*body.Value.BaseURL)
-		if trimmed == "" {
-			h.cfg.OpenAICompatibility = append(h.cfg.OpenAICompatibility[:targetIndex], h.cfg.OpenAICompatibility[targetIndex+1:]...)
-			h.cfg.SanitizeOpenAICompatibility()
-			h.persist(c)
-			return
+		if body.Value.APIKeyEntries != nil {
+			entry.APIKeyEntries = append([]config.OpenAICompatibilityAPIKey(nil), (*body.Value.APIKeyEntries)...)
 		}
-		entry.BaseURL = trimmed
-	}
-	if body.Value.APIKeyEntries != nil {
-		entry.APIKeyEntries = append([]config.OpenAICompatibilityAPIKey(nil), (*body.Value.APIKeyEntries)...)
-	}
-	if body.Value.Models != nil {
-		entry.Models = append([]config.OpenAICompatibilityModel(nil), (*body.Value.Models)...)
-	}
-	if body.Value.Headers != nil {
-		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
-	}
-	normalizeOpenAICompatibilityEntry(&entry)
-	h.cfg.OpenAICompatibility[targetIndex] = entry
-	h.cfg.SanitizeOpenAICompatibility()
-	h.persist(c)
+		if body.Value.Models != nil {
+			entry.Models = append([]config.OpenAICompatibilityModel(nil), (*body.Value.Models)...)
+		}
+		if body.Value.Headers != nil {
+			entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
+		}
+		normalizeOpenAICompatibilityEntry(&entry)
+		cfg.OpenAICompatibility[targetIndex] = entry
+		cfg.SanitizeOpenAICompatibility()
+		return nil
+	})
 }
 
 func (h *Handler) DeleteOpenAICompat(c *gin.Context) {
 	if name := c.Query("name"); name != "" {
-		out := make([]config.OpenAICompatibility, 0, len(h.cfg.OpenAICompatibility))
-		for _, v := range h.cfg.OpenAICompatibility {
-			if v.Name != name {
-				out = append(out, v)
+		h.applyConfigMutation(c, func(cfg *config.Config) error {
+			out := make([]config.OpenAICompatibility, 0, len(cfg.OpenAICompatibility))
+			for _, v := range cfg.OpenAICompatibility {
+				if v.Name != name {
+					out = append(out, v)
+				}
 			}
-		}
-		h.cfg.OpenAICompatibility = out
-		h.cfg.SanitizeOpenAICompatibility()
-		h.persist(c)
+			cfg.OpenAICompatibility = out
+			cfg.SanitizeOpenAICompatibility()
+			return nil
+		})
 		return
 	}
 	if idxStr := c.Query("index"); idxStr != "" {
 		var idx int
 		_, err := fmt.Sscanf(idxStr, "%d", &idx)
-		if err == nil && idx >= 0 && idx < len(h.cfg.OpenAICompatibility) {
-			h.cfg.OpenAICompatibility = append(h.cfg.OpenAICompatibility[:idx], h.cfg.OpenAICompatibility[idx+1:]...)
-			h.cfg.SanitizeOpenAICompatibility()
-			h.persist(c)
+		if err == nil {
+			h.applyConfigMutation(c, func(cfg *config.Config) error {
+				if idx < 0 || idx >= len(cfg.OpenAICompatibility) {
+					return fmt.Errorf("missing name or index")
+				}
+				cfg.OpenAICompatibility = append(cfg.OpenAICompatibility[:idx], cfg.OpenAICompatibility[idx+1:]...)
+				cfg.SanitizeOpenAICompatibility()
+				return nil
+			})
 			return
 		}
 	}
@@ -488,31 +509,22 @@ func (h *Handler) DeleteOpenAICompat(c *gin.Context) {
 
 // vertex-api-key: []VertexCompatKey
 func (h *Handler) GetVertexCompatKeys(c *gin.Context) {
-	c.JSON(200, gin.H{"vertex-api-key": h.cfg.VertexCompatAPIKey})
+	cfg := h.configSnapshotOrEmpty()
+	c.JSON(200, gin.H{"vertex-api-key": cfg.VertexCompatAPIKey})
 }
 func (h *Handler) PutVertexCompatKeys(c *gin.Context) {
-	data, err := c.GetRawData()
-	if err != nil {
-		c.JSON(400, gin.H{"error": "failed to read body"})
+	arr, ok := decodeJSONItems[config.VertexCompatKey](c)
+	if !ok {
 		return
-	}
-	var arr []config.VertexCompatKey
-	if err = json.Unmarshal(data, &arr); err != nil {
-		var obj struct {
-			Items []config.VertexCompatKey `json:"items"`
-		}
-		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
-			c.JSON(400, gin.H{"error": "invalid body"})
-			return
-		}
-		arr = obj.Items
 	}
 	for i := range arr {
 		normalizeVertexCompatKey(&arr[i])
 	}
-	h.cfg.VertexCompatAPIKey = arr
-	h.cfg.SanitizeVertexCompatKeys()
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		cfg.VertexCompatAPIKey = arr
+		cfg.SanitizeVertexCompatKeys()
+		return nil
+	})
 }
 func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 	type vertexCompatPatch struct {
@@ -533,88 +545,81 @@ func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	targetIndex := -1
-	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.VertexCompatAPIKey) {
-		targetIndex = *body.Index
-	}
-	if targetIndex == -1 && body.Match != nil {
-		match := strings.TrimSpace(*body.Match)
-		if match != "" {
-			for i := range h.cfg.VertexCompatAPIKey {
-				if h.cfg.VertexCompatAPIKey[i].APIKey == match {
-					targetIndex = i
-					break
-				}
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		targetIndex := findIndexByIndexOrMatch(cfg.VertexCompatAPIKey, body.Index, body.Match, func(item config.VertexCompatKey, match string) bool {
+			return item.APIKey == match
+		})
+		if targetIndex == -1 {
+			return fmt.Errorf("item not found")
+		}
+		entry := cfg.VertexCompatAPIKey[targetIndex]
+		if body.Value.APIKey != nil {
+			trimmed := strings.TrimSpace(*body.Value.APIKey)
+			if trimmed == "" {
+				cfg.VertexCompatAPIKey = append(cfg.VertexCompatAPIKey[:targetIndex], cfg.VertexCompatAPIKey[targetIndex+1:]...)
+				cfg.SanitizeVertexCompatKeys()
+				return nil
 			}
+			entry.APIKey = trimmed
 		}
-	}
-	if targetIndex == -1 {
-		c.JSON(404, gin.H{"error": "item not found"})
-		return
-	}
-
-	entry := h.cfg.VertexCompatAPIKey[targetIndex]
-	if body.Value.APIKey != nil {
-		trimmed := strings.TrimSpace(*body.Value.APIKey)
-		if trimmed == "" {
-			h.cfg.VertexCompatAPIKey = append(h.cfg.VertexCompatAPIKey[:targetIndex], h.cfg.VertexCompatAPIKey[targetIndex+1:]...)
-			h.cfg.SanitizeVertexCompatKeys()
-			h.persist(c)
-			return
+		if body.Value.Prefix != nil {
+			entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
 		}
-		entry.APIKey = trimmed
-	}
-	if body.Value.Prefix != nil {
-		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
-	}
-	if body.Value.BaseURL != nil {
-		trimmed := strings.TrimSpace(*body.Value.BaseURL)
-		if trimmed == "" {
-			h.cfg.VertexCompatAPIKey = append(h.cfg.VertexCompatAPIKey[:targetIndex], h.cfg.VertexCompatAPIKey[targetIndex+1:]...)
-			h.cfg.SanitizeVertexCompatKeys()
-			h.persist(c)
-			return
+		if body.Value.BaseURL != nil {
+			trimmed := strings.TrimSpace(*body.Value.BaseURL)
+			if trimmed == "" {
+				cfg.VertexCompatAPIKey = append(cfg.VertexCompatAPIKey[:targetIndex], cfg.VertexCompatAPIKey[targetIndex+1:]...)
+				cfg.SanitizeVertexCompatKeys()
+				return nil
+			}
+			entry.BaseURL = trimmed
 		}
-		entry.BaseURL = trimmed
-	}
-	if body.Value.ProxyURL != nil {
-		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
-	}
-	if body.Value.Headers != nil {
-		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
-	}
-	if body.Value.Models != nil {
-		entry.Models = append([]config.VertexCompatModel(nil), (*body.Value.Models)...)
-	}
-	if body.Value.ExcludedModels != nil {
-		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
-	}
-	normalizeVertexCompatKey(&entry)
-	h.cfg.VertexCompatAPIKey[targetIndex] = entry
-	h.cfg.SanitizeVertexCompatKeys()
-	h.persist(c)
+		if body.Value.ProxyURL != nil {
+			entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
+		}
+		if body.Value.Headers != nil {
+			entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
+		}
+		if body.Value.Models != nil {
+			entry.Models = append([]config.VertexCompatModel(nil), (*body.Value.Models)...)
+		}
+		if body.Value.ExcludedModels != nil {
+			entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
+		}
+		normalizeVertexCompatKey(&entry)
+		cfg.VertexCompatAPIKey[targetIndex] = entry
+		cfg.SanitizeVertexCompatKeys()
+		return nil
+	})
 }
 
 func (h *Handler) DeleteVertexCompatKey(c *gin.Context) {
 	if val := strings.TrimSpace(c.Query("api-key")); val != "" {
-		out := make([]config.VertexCompatKey, 0, len(h.cfg.VertexCompatAPIKey))
-		for _, v := range h.cfg.VertexCompatAPIKey {
-			if v.APIKey != val {
-				out = append(out, v)
+		h.applyConfigMutation(c, func(cfg *config.Config) error {
+			out := make([]config.VertexCompatKey, 0, len(cfg.VertexCompatAPIKey))
+			for _, v := range cfg.VertexCompatAPIKey {
+				if v.APIKey != val {
+					out = append(out, v)
+				}
 			}
-		}
-		h.cfg.VertexCompatAPIKey = out
-		h.cfg.SanitizeVertexCompatKeys()
-		h.persist(c)
+			cfg.VertexCompatAPIKey = out
+			cfg.SanitizeVertexCompatKeys()
+			return nil
+		})
 		return
 	}
 	if idxStr := c.Query("index"); idxStr != "" {
 		var idx int
 		_, errScan := fmt.Sscanf(idxStr, "%d", &idx)
-		if errScan == nil && idx >= 0 && idx < len(h.cfg.VertexCompatAPIKey) {
-			h.cfg.VertexCompatAPIKey = append(h.cfg.VertexCompatAPIKey[:idx], h.cfg.VertexCompatAPIKey[idx+1:]...)
-			h.cfg.SanitizeVertexCompatKeys()
-			h.persist(c)
+		if errScan == nil {
+			h.applyConfigMutation(c, func(cfg *config.Config) error {
+				if idx < 0 || idx >= len(cfg.VertexCompatAPIKey) {
+					return fmt.Errorf("missing api-key or index")
+				}
+				cfg.VertexCompatAPIKey = append(cfg.VertexCompatAPIKey[:idx], cfg.VertexCompatAPIKey[idx+1:]...)
+				cfg.SanitizeVertexCompatKeys()
+				return nil
+			})
 			return
 		}
 	}
@@ -623,7 +628,8 @@ func (h *Handler) DeleteVertexCompatKey(c *gin.Context) {
 
 // oauth-excluded-models: map[string][]string
 func (h *Handler) GetOAuthExcludedModels(c *gin.Context) {
-	c.JSON(200, gin.H{"oauth-excluded-models": config.NormalizeOAuthExcludedModels(h.cfg.OAuthExcludedModels)})
+	cfg := h.configSnapshotOrEmpty()
+	c.JSON(200, gin.H{"oauth-excluded-models": config.NormalizeOAuthExcludedModels(cfg.OAuthExcludedModels)})
 }
 
 func (h *Handler) PutOAuthExcludedModels(c *gin.Context) {
@@ -643,8 +649,10 @@ func (h *Handler) PutOAuthExcludedModels(c *gin.Context) {
 		}
 		entries = wrapper.Items
 	}
-	h.cfg.OAuthExcludedModels = config.NormalizeOAuthExcludedModels(entries)
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		cfg.OAuthExcludedModels = config.NormalizeOAuthExcludedModels(entries)
+		return nil
+	})
 }
 
 func (h *Handler) PatchOAuthExcludedModels(c *gin.Context) {
@@ -662,27 +670,26 @@ func (h *Handler) PatchOAuthExcludedModels(c *gin.Context) {
 		return
 	}
 	normalized := config.NormalizeExcludedModels(body.Models)
-	if len(normalized) == 0 {
-		if h.cfg.OAuthExcludedModels == nil {
-			c.JSON(404, gin.H{"error": "provider not found"})
-			return
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		if len(normalized) == 0 {
+			if cfg.OAuthExcludedModels == nil {
+				return fmt.Errorf("provider not found")
+			}
+			if _, ok := cfg.OAuthExcludedModels[provider]; !ok {
+				return fmt.Errorf("provider not found")
+			}
+			delete(cfg.OAuthExcludedModels, provider)
+			if len(cfg.OAuthExcludedModels) == 0 {
+				cfg.OAuthExcludedModels = nil
+			}
+			return nil
 		}
-		if _, ok := h.cfg.OAuthExcludedModels[provider]; !ok {
-			c.JSON(404, gin.H{"error": "provider not found"})
-			return
+		if cfg.OAuthExcludedModels == nil {
+			cfg.OAuthExcludedModels = make(map[string][]string)
 		}
-		delete(h.cfg.OAuthExcludedModels, provider)
-		if len(h.cfg.OAuthExcludedModels) == 0 {
-			h.cfg.OAuthExcludedModels = nil
-		}
-		h.persist(c)
-		return
-	}
-	if h.cfg.OAuthExcludedModels == nil {
-		h.cfg.OAuthExcludedModels = make(map[string][]string)
-	}
-	h.cfg.OAuthExcludedModels[provider] = normalized
-	h.persist(c)
+		cfg.OAuthExcludedModels[provider] = normalized
+		return nil
+	})
 }
 
 func (h *Handler) DeleteOAuthExcludedModels(c *gin.Context) {
@@ -691,24 +698,25 @@ func (h *Handler) DeleteOAuthExcludedModels(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "missing provider"})
 		return
 	}
-	if h.cfg.OAuthExcludedModels == nil {
-		c.JSON(404, gin.H{"error": "provider not found"})
-		return
-	}
-	if _, ok := h.cfg.OAuthExcludedModels[provider]; !ok {
-		c.JSON(404, gin.H{"error": "provider not found"})
-		return
-	}
-	delete(h.cfg.OAuthExcludedModels, provider)
-	if len(h.cfg.OAuthExcludedModels) == 0 {
-		h.cfg.OAuthExcludedModels = nil
-	}
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		if cfg.OAuthExcludedModels == nil {
+			return fmt.Errorf("provider not found")
+		}
+		if _, ok := cfg.OAuthExcludedModels[provider]; !ok {
+			return fmt.Errorf("provider not found")
+		}
+		delete(cfg.OAuthExcludedModels, provider)
+		if len(cfg.OAuthExcludedModels) == 0 {
+			cfg.OAuthExcludedModels = nil
+		}
+		return nil
+	})
 }
 
 // oauth-model-alias: map[string][]OAuthModelAlias
 func (h *Handler) GetOAuthModelAlias(c *gin.Context) {
-	c.JSON(200, gin.H{"oauth-model-alias": sanitizedOAuthModelAlias(h.cfg.OAuthModelAlias)})
+	cfg := h.configSnapshotOrEmpty()
+	c.JSON(200, gin.H{"oauth-model-alias": sanitizedOAuthModelAlias(cfg.OAuthModelAlias)})
 }
 
 func (h *Handler) PutOAuthModelAlias(c *gin.Context) {
@@ -728,8 +736,10 @@ func (h *Handler) PutOAuthModelAlias(c *gin.Context) {
 		}
 		entries = wrapper.Items
 	}
-	h.cfg.OAuthModelAlias = sanitizedOAuthModelAlias(entries)
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		cfg.OAuthModelAlias = sanitizedOAuthModelAlias(entries)
+		return nil
+	})
 }
 
 func (h *Handler) PatchOAuthModelAlias(c *gin.Context) {
@@ -756,27 +766,26 @@ func (h *Handler) PatchOAuthModelAlias(c *gin.Context) {
 
 	normalizedMap := sanitizedOAuthModelAlias(map[string][]config.OAuthModelAlias{channel: body.Aliases})
 	normalized := normalizedMap[channel]
-	if len(normalized) == 0 {
-		if h.cfg.OAuthModelAlias == nil {
-			c.JSON(404, gin.H{"error": "channel not found"})
-			return
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		if len(normalized) == 0 {
+			if cfg.OAuthModelAlias == nil {
+				return fmt.Errorf("channel not found")
+			}
+			if _, ok := cfg.OAuthModelAlias[channel]; !ok {
+				return fmt.Errorf("channel not found")
+			}
+			delete(cfg.OAuthModelAlias, channel)
+			if len(cfg.OAuthModelAlias) == 0 {
+				cfg.OAuthModelAlias = nil
+			}
+			return nil
 		}
-		if _, ok := h.cfg.OAuthModelAlias[channel]; !ok {
-			c.JSON(404, gin.H{"error": "channel not found"})
-			return
+		if cfg.OAuthModelAlias == nil {
+			cfg.OAuthModelAlias = make(map[string][]config.OAuthModelAlias)
 		}
-		delete(h.cfg.OAuthModelAlias, channel)
-		if len(h.cfg.OAuthModelAlias) == 0 {
-			h.cfg.OAuthModelAlias = nil
-		}
-		h.persist(c)
-		return
-	}
-	if h.cfg.OAuthModelAlias == nil {
-		h.cfg.OAuthModelAlias = make(map[string][]config.OAuthModelAlias)
-	}
-	h.cfg.OAuthModelAlias[channel] = normalized
-	h.persist(c)
+		cfg.OAuthModelAlias[channel] = normalized
+		return nil
+	})
 }
 
 func (h *Handler) DeleteOAuthModelAlias(c *gin.Context) {
@@ -788,41 +797,30 @@ func (h *Handler) DeleteOAuthModelAlias(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "missing channel"})
 		return
 	}
-	if h.cfg.OAuthModelAlias == nil {
-		c.JSON(404, gin.H{"error": "channel not found"})
-		return
-	}
-	if _, ok := h.cfg.OAuthModelAlias[channel]; !ok {
-		c.JSON(404, gin.H{"error": "channel not found"})
-		return
-	}
-	delete(h.cfg.OAuthModelAlias, channel)
-	if len(h.cfg.OAuthModelAlias) == 0 {
-		h.cfg.OAuthModelAlias = nil
-	}
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		if cfg.OAuthModelAlias == nil {
+			return fmt.Errorf("channel not found")
+		}
+		if _, ok := cfg.OAuthModelAlias[channel]; !ok {
+			return fmt.Errorf("channel not found")
+		}
+		delete(cfg.OAuthModelAlias, channel)
+		if len(cfg.OAuthModelAlias) == 0 {
+			cfg.OAuthModelAlias = nil
+		}
+		return nil
+	})
 }
 
 // codex-api-key: []CodexKey
 func (h *Handler) GetCodexKeys(c *gin.Context) {
-	c.JSON(200, gin.H{"codex-api-key": h.cfg.CodexKey})
+	cfg := h.configSnapshotOrEmpty()
+	c.JSON(200, gin.H{"codex-api-key": cfg.CodexKey})
 }
 func (h *Handler) PutCodexKeys(c *gin.Context) {
-	data, err := c.GetRawData()
-	if err != nil {
-		c.JSON(400, gin.H{"error": "failed to read body"})
+	arr, ok := decodeJSONItems[config.CodexKey](c)
+	if !ok {
 		return
-	}
-	var arr []config.CodexKey
-	if err = json.Unmarshal(data, &arr); err != nil {
-		var obj struct {
-			Items []config.CodexKey `json:"items"`
-		}
-		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
-			c.JSON(400, gin.H{"error": "invalid body"})
-			return
-		}
-		arr = obj.Items
 	}
 	// Filter out codex entries with empty base-url (treat as removed)
 	filtered := make([]config.CodexKey, 0, len(arr))
@@ -834,9 +832,11 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 		}
 		filtered = append(filtered, entry)
 	}
-	h.cfg.CodexKey = filtered
-	h.cfg.SanitizeCodexKeys()
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		cfg.CodexKey = filtered
+		cfg.SanitizeCodexKeys()
+		return nil
+	})
 }
 func (h *Handler) PatchCodexKey(c *gin.Context) {
 	type codexKeyPatch struct {
@@ -857,79 +857,75 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	targetIndex := -1
-	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.CodexKey) {
-		targetIndex = *body.Index
-	}
-	if targetIndex == -1 && body.Match != nil {
-		match := strings.TrimSpace(*body.Match)
-		for i := range h.cfg.CodexKey {
-			if h.cfg.CodexKey[i].APIKey == match {
-				targetIndex = i
-				break
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		targetIndex := findIndexByIndexOrMatch(cfg.CodexKey, body.Index, body.Match, func(item config.CodexKey, match string) bool {
+			return item.APIKey == match
+		})
+		if targetIndex == -1 {
+			return fmt.Errorf("item not found")
+		}
+		entry := cfg.CodexKey[targetIndex]
+		if body.Value.APIKey != nil {
+			entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+		}
+		if body.Value.Prefix != nil {
+			entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
+		}
+		if body.Value.BaseURL != nil {
+			trimmed := strings.TrimSpace(*body.Value.BaseURL)
+			if trimmed == "" {
+				cfg.CodexKey = append(cfg.CodexKey[:targetIndex], cfg.CodexKey[targetIndex+1:]...)
+				cfg.SanitizeCodexKeys()
+				return nil
 			}
+			entry.BaseURL = trimmed
 		}
-	}
-	if targetIndex == -1 {
-		c.JSON(404, gin.H{"error": "item not found"})
-		return
-	}
-
-	entry := h.cfg.CodexKey[targetIndex]
-	if body.Value.APIKey != nil {
-		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
-	}
-	if body.Value.Prefix != nil {
-		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
-	}
-	if body.Value.BaseURL != nil {
-		trimmed := strings.TrimSpace(*body.Value.BaseURL)
-		if trimmed == "" {
-			h.cfg.CodexKey = append(h.cfg.CodexKey[:targetIndex], h.cfg.CodexKey[targetIndex+1:]...)
-			h.cfg.SanitizeCodexKeys()
-			h.persist(c)
-			return
+		if body.Value.ProxyURL != nil {
+			entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
 		}
-		entry.BaseURL = trimmed
-	}
-	if body.Value.ProxyURL != nil {
-		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
-	}
-	if body.Value.Models != nil {
-		entry.Models = append([]config.CodexModel(nil), (*body.Value.Models)...)
-	}
-	if body.Value.Headers != nil {
-		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
-	}
-	if body.Value.ExcludedModels != nil {
-		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
-	}
-	normalizeCodexKey(&entry)
-	h.cfg.CodexKey[targetIndex] = entry
-	h.cfg.SanitizeCodexKeys()
-	h.persist(c)
+		if body.Value.Models != nil {
+			entry.Models = append([]config.CodexModel(nil), (*body.Value.Models)...)
+		}
+		if body.Value.Headers != nil {
+			entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
+		}
+		if body.Value.ExcludedModels != nil {
+			entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
+		}
+		normalizeCodexKey(&entry)
+		cfg.CodexKey[targetIndex] = entry
+		cfg.SanitizeCodexKeys()
+		return nil
+	})
 }
 
 func (h *Handler) DeleteCodexKey(c *gin.Context) {
 	if val := c.Query("api-key"); val != "" {
-		out := make([]config.CodexKey, 0, len(h.cfg.CodexKey))
-		for _, v := range h.cfg.CodexKey {
-			if v.APIKey != val {
-				out = append(out, v)
+		h.applyConfigMutation(c, func(cfg *config.Config) error {
+			out := make([]config.CodexKey, 0, len(cfg.CodexKey))
+			for _, v := range cfg.CodexKey {
+				if v.APIKey != val {
+					out = append(out, v)
+				}
 			}
-		}
-		h.cfg.CodexKey = out
-		h.cfg.SanitizeCodexKeys()
-		h.persist(c)
+			cfg.CodexKey = out
+			cfg.SanitizeCodexKeys()
+			return nil
+		})
 		return
 	}
 	if idxStr := c.Query("index"); idxStr != "" {
 		var idx int
 		_, err := fmt.Sscanf(idxStr, "%d", &idx)
-		if err == nil && idx >= 0 && idx < len(h.cfg.CodexKey) {
-			h.cfg.CodexKey = append(h.cfg.CodexKey[:idx], h.cfg.CodexKey[idx+1:]...)
-			h.cfg.SanitizeCodexKeys()
-			h.persist(c)
+		if err == nil {
+			h.applyConfigMutation(c, func(cfg *config.Config) error {
+				if idx < 0 || idx >= len(cfg.CodexKey) {
+					return fmt.Errorf("missing api-key or index")
+				}
+				cfg.CodexKey = append(cfg.CodexKey[:idx], cfg.CodexKey[idx+1:]...)
+				cfg.SanitizeCodexKeys()
+				return nil
+			})
 			return
 		}
 	}
@@ -1070,74 +1066,58 @@ func sanitizedOAuthModelAlias(entries map[string][]config.OAuthModelAlias) map[s
 
 // GetAmpCode returns the complete ampcode configuration.
 func (h *Handler) GetAmpCode(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"ampcode": config.AmpCode{}})
-		return
-	}
-	c.JSON(200, gin.H{"ampcode": h.cfg.AmpCode})
+	c.JSON(200, gin.H{"ampcode": h.ampCodeSnapshot()})
 }
 
 // GetAmpUpstreamURL returns the ampcode upstream URL.
 func (h *Handler) GetAmpUpstreamURL(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"upstream-url": ""})
-		return
-	}
-	c.JSON(200, gin.H{"upstream-url": h.cfg.AmpCode.UpstreamURL})
+	c.JSON(200, gin.H{"upstream-url": h.ampCodeSnapshot().UpstreamURL})
 }
 
 // PutAmpUpstreamURL updates the ampcode upstream URL.
 func (h *Handler) PutAmpUpstreamURL(c *gin.Context) {
-	h.updateStringField(c, func(v string) { h.cfg.AmpCode.UpstreamURL = strings.TrimSpace(v) })
+	h.updateStringField(c, func(cfg *config.Config, v string) { cfg.AmpCode.UpstreamURL = strings.TrimSpace(v) })
 }
 
 // DeleteAmpUpstreamURL clears the ampcode upstream URL.
 func (h *Handler) DeleteAmpUpstreamURL(c *gin.Context) {
-	h.cfg.AmpCode.UpstreamURL = ""
-	h.persist(c)
+	h.mutateAmpCode(c, func(amp *config.AmpCode) error {
+		amp.UpstreamURL = ""
+		return nil
+	})
 }
 
 // GetAmpUpstreamAPIKey returns the ampcode upstream API key.
 func (h *Handler) GetAmpUpstreamAPIKey(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"upstream-api-key": ""})
-		return
-	}
-	c.JSON(200, gin.H{"upstream-api-key": h.cfg.AmpCode.UpstreamAPIKey})
+	c.JSON(200, gin.H{"upstream-api-key": h.ampCodeSnapshot().UpstreamAPIKey})
 }
 
 // PutAmpUpstreamAPIKey updates the ampcode upstream API key.
 func (h *Handler) PutAmpUpstreamAPIKey(c *gin.Context) {
-	h.updateStringField(c, func(v string) { h.cfg.AmpCode.UpstreamAPIKey = strings.TrimSpace(v) })
+	h.updateStringField(c, func(cfg *config.Config, v string) { cfg.AmpCode.UpstreamAPIKey = strings.TrimSpace(v) })
 }
 
 // DeleteAmpUpstreamAPIKey clears the ampcode upstream API key.
 func (h *Handler) DeleteAmpUpstreamAPIKey(c *gin.Context) {
-	h.cfg.AmpCode.UpstreamAPIKey = ""
-	h.persist(c)
+	h.mutateAmpCode(c, func(amp *config.AmpCode) error {
+		amp.UpstreamAPIKey = ""
+		return nil
+	})
 }
 
 // GetAmpRestrictManagementToLocalhost returns the localhost restriction setting.
 func (h *Handler) GetAmpRestrictManagementToLocalhost(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"restrict-management-to-localhost": true})
-		return
-	}
-	c.JSON(200, gin.H{"restrict-management-to-localhost": h.cfg.AmpCode.RestrictManagementToLocalhost})
+	c.JSON(200, gin.H{"restrict-management-to-localhost": h.ampCodeSnapshot().RestrictManagementToLocalhost})
 }
 
 // PutAmpRestrictManagementToLocalhost updates the localhost restriction setting.
 func (h *Handler) PutAmpRestrictManagementToLocalhost(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.AmpCode.RestrictManagementToLocalhost = v })
+	h.updateBoolField(c, func(cfg *config.Config, v bool) { cfg.AmpCode.RestrictManagementToLocalhost = v })
 }
 
 // GetAmpModelMappings returns the ampcode model mappings.
 func (h *Handler) GetAmpModelMappings(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"model-mappings": []config.AmpModelMapping{}})
-		return
-	}
-	c.JSON(200, gin.H{"model-mappings": h.cfg.AmpCode.ModelMappings})
+	c.JSON(200, gin.H{"model-mappings": h.ampCodeSnapshot().ModelMappings})
 }
 
 // PutAmpModelMappings replaces all ampcode model mappings.
@@ -1149,8 +1129,10 @@ func (h *Handler) PutAmpModelMappings(c *gin.Context) {
 		c.JSON(400, gin.H{"error": "invalid body"})
 		return
 	}
-	h.cfg.AmpCode.ModelMappings = body.Value
-	h.persist(c)
+	h.mutateAmpCode(c, func(amp *config.AmpCode) error {
+		amp.ModelMappings = body.Value
+		return nil
+	})
 }
 
 // PatchAmpModelMappings adds or updates model mappings.
@@ -1163,21 +1145,22 @@ func (h *Handler) PatchAmpModelMappings(c *gin.Context) {
 		return
 	}
 
-	existing := make(map[string]int)
-	for i, m := range h.cfg.AmpCode.ModelMappings {
-		existing[strings.TrimSpace(m.From)] = i
-	}
-
-	for _, newMapping := range body.Value {
-		from := strings.TrimSpace(newMapping.From)
-		if idx, ok := existing[from]; ok {
-			h.cfg.AmpCode.ModelMappings[idx] = newMapping
-		} else {
-			h.cfg.AmpCode.ModelMappings = append(h.cfg.AmpCode.ModelMappings, newMapping)
-			existing[from] = len(h.cfg.AmpCode.ModelMappings) - 1
+	h.mutateAmpCode(c, func(amp *config.AmpCode) error {
+		existing := make(map[string]int)
+		for i, m := range amp.ModelMappings {
+			existing[strings.TrimSpace(m.From)] = i
 		}
-	}
-	h.persist(c)
+		for _, newMapping := range body.Value {
+			from := strings.TrimSpace(newMapping.From)
+			if idx, ok := existing[from]; ok {
+				amp.ModelMappings[idx] = newMapping
+			} else {
+				amp.ModelMappings = append(amp.ModelMappings, newMapping)
+				existing[from] = len(amp.ModelMappings) - 1
+			}
+		}
+		return nil
+	})
 }
 
 // DeleteAmpModelMappings removes specified model mappings by "from" field.
@@ -1186,8 +1169,10 @@ func (h *Handler) DeleteAmpModelMappings(c *gin.Context) {
 		Value []string `json:"value"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil || len(body.Value) == 0 {
-		h.cfg.AmpCode.ModelMappings = nil
-		h.persist(c)
+		h.mutateAmpCode(c, func(amp *config.AmpCode) error {
+			amp.ModelMappings = nil
+			return nil
+		})
 		return
 	}
 
@@ -1196,37 +1181,31 @@ func (h *Handler) DeleteAmpModelMappings(c *gin.Context) {
 		toRemove[strings.TrimSpace(from)] = true
 	}
 
-	newMappings := make([]config.AmpModelMapping, 0, len(h.cfg.AmpCode.ModelMappings))
-	for _, m := range h.cfg.AmpCode.ModelMappings {
-		if !toRemove[strings.TrimSpace(m.From)] {
-			newMappings = append(newMappings, m)
+	h.mutateAmpCode(c, func(amp *config.AmpCode) error {
+		newMappings := make([]config.AmpModelMapping, 0, len(amp.ModelMappings))
+		for _, m := range amp.ModelMappings {
+			if !toRemove[strings.TrimSpace(m.From)] {
+				newMappings = append(newMappings, m)
+			}
 		}
-	}
-	h.cfg.AmpCode.ModelMappings = newMappings
-	h.persist(c)
+		amp.ModelMappings = newMappings
+		return nil
+	})
 }
 
 // GetAmpForceModelMappings returns whether model mappings are forced.
 func (h *Handler) GetAmpForceModelMappings(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"force-model-mappings": false})
-		return
-	}
-	c.JSON(200, gin.H{"force-model-mappings": h.cfg.AmpCode.ForceModelMappings})
+	c.JSON(200, gin.H{"force-model-mappings": h.ampCodeSnapshot().ForceModelMappings})
 }
 
 // PutAmpForceModelMappings updates the force model mappings setting.
 func (h *Handler) PutAmpForceModelMappings(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.AmpCode.ForceModelMappings = v })
+	h.updateBoolField(c, func(cfg *config.Config, v bool) { cfg.AmpCode.ForceModelMappings = v })
 }
 
 // GetAmpUpstreamAPIKeys returns the ampcode upstream API keys mapping.
 func (h *Handler) GetAmpUpstreamAPIKeys(c *gin.Context) {
-	if h == nil || h.cfg == nil {
-		c.JSON(200, gin.H{"upstream-api-keys": []config.AmpUpstreamAPIKeyEntry{}})
-		return
-	}
-	c.JSON(200, gin.H{"upstream-api-keys": h.cfg.AmpCode.UpstreamAPIKeys})
+	c.JSON(200, gin.H{"upstream-api-keys": h.ampCodeSnapshot().UpstreamAPIKeys})
 }
 
 // PutAmpUpstreamAPIKeys replaces all ampcode upstream API keys mappings.
@@ -1240,8 +1219,10 @@ func (h *Handler) PutAmpUpstreamAPIKeys(c *gin.Context) {
 	}
 	// Normalize entries: trim whitespace, filter empty
 	normalized := normalizeAmpUpstreamAPIKeyEntries(body.Value)
-	h.cfg.AmpCode.UpstreamAPIKeys = normalized
-	h.persist(c)
+	h.mutateAmpCode(c, func(amp *config.AmpCode) error {
+		amp.UpstreamAPIKeys = normalized
+		return nil
+	})
 }
 
 // PatchAmpUpstreamAPIKeys adds or updates upstream API keys entries.
@@ -1255,28 +1236,29 @@ func (h *Handler) PatchAmpUpstreamAPIKeys(c *gin.Context) {
 		return
 	}
 
-	existing := make(map[string]int)
-	for i, entry := range h.cfg.AmpCode.UpstreamAPIKeys {
-		existing[strings.TrimSpace(entry.UpstreamAPIKey)] = i
-	}
-
-	for _, newEntry := range body.Value {
-		upstreamKey := strings.TrimSpace(newEntry.UpstreamAPIKey)
-		if upstreamKey == "" {
-			continue
+	h.mutateAmpCode(c, func(amp *config.AmpCode) error {
+		existing := make(map[string]int)
+		for i, entry := range amp.UpstreamAPIKeys {
+			existing[strings.TrimSpace(entry.UpstreamAPIKey)] = i
 		}
-		normalizedEntry := config.AmpUpstreamAPIKeyEntry{
-			UpstreamAPIKey: upstreamKey,
-			APIKeys:        normalizeAPIKeysList(newEntry.APIKeys),
+		for _, newEntry := range body.Value {
+			upstreamKey := strings.TrimSpace(newEntry.UpstreamAPIKey)
+			if upstreamKey == "" {
+				continue
+			}
+			normalizedEntry := config.AmpUpstreamAPIKeyEntry{
+				UpstreamAPIKey: upstreamKey,
+				APIKeys:        normalizeAPIKeysList(newEntry.APIKeys),
+			}
+			if idx, ok := existing[upstreamKey]; ok {
+				amp.UpstreamAPIKeys[idx] = normalizedEntry
+			} else {
+				amp.UpstreamAPIKeys = append(amp.UpstreamAPIKeys, normalizedEntry)
+				existing[upstreamKey] = len(amp.UpstreamAPIKeys) - 1
+			}
 		}
-		if idx, ok := existing[upstreamKey]; ok {
-			h.cfg.AmpCode.UpstreamAPIKeys[idx] = normalizedEntry
-		} else {
-			h.cfg.AmpCode.UpstreamAPIKeys = append(h.cfg.AmpCode.UpstreamAPIKeys, normalizedEntry)
-			existing[upstreamKey] = len(h.cfg.AmpCode.UpstreamAPIKeys) - 1
-		}
-	}
-	h.persist(c)
+		return nil
+	})
 }
 
 // DeleteAmpUpstreamAPIKeys removes specified upstream API keys entries.
@@ -1299,8 +1281,10 @@ func (h *Handler) DeleteAmpUpstreamAPIKeys(c *gin.Context) {
 
 	// Empty array means clear all
 	if len(body.Value) == 0 {
-		h.cfg.AmpCode.UpstreamAPIKeys = nil
-		h.persist(c)
+		h.mutateAmpCode(c, func(amp *config.AmpCode) error {
+			amp.UpstreamAPIKeys = nil
+			return nil
+		})
 		return
 	}
 
@@ -1317,14 +1301,16 @@ func (h *Handler) DeleteAmpUpstreamAPIKeys(c *gin.Context) {
 		return
 	}
 
-	newEntries := make([]config.AmpUpstreamAPIKeyEntry, 0, len(h.cfg.AmpCode.UpstreamAPIKeys))
-	for _, entry := range h.cfg.AmpCode.UpstreamAPIKeys {
-		if !toRemove[strings.TrimSpace(entry.UpstreamAPIKey)] {
-			newEntries = append(newEntries, entry)
+	h.mutateAmpCode(c, func(amp *config.AmpCode) error {
+		newEntries := make([]config.AmpUpstreamAPIKeyEntry, 0, len(amp.UpstreamAPIKeys))
+		for _, entry := range amp.UpstreamAPIKeys {
+			if !toRemove[strings.TrimSpace(entry.UpstreamAPIKey)] {
+				newEntries = append(newEntries, entry)
+			}
 		}
-	}
-	h.cfg.AmpCode.UpstreamAPIKeys = newEntries
-	h.persist(c)
+		amp.UpstreamAPIKeys = newEntries
+		return nil
+	})
 }
 
 // normalizeAmpUpstreamAPIKeyEntries normalizes a list of upstream API key entries.

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -193,6 +193,12 @@ func (h *Handler) effectiveAuthDir() string {
 	return ResolveEffectiveAuthDir(h.cfg.AuthDir, store)
 }
 
+func (h *Handler) registerOAuthSession(state, provider string) string {
+	authDir := h.effectiveAuthDir()
+	RegisterOAuthSession(state, provider, authDir)
+	return authDir
+}
+
 // Middleware enforces access control for management endpoints.
 // All requests (local and remote) require a valid management key.
 // Additionally, remote access requires allow-remote-management=true.

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -184,6 +184,8 @@ func (h *Handler) effectiveAuthDir() string {
 	if h == nil {
 		return ""
 	}
+	h.stateMu.RLock()
+	defer h.stateMu.RUnlock()
 	store := h.tokenStoreWithBaseDir()
 	if h.cfg == nil {
 		return ResolveEffectiveAuthDir("", store)
@@ -205,7 +207,12 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 
 		clientIP := c.ClientIP()
 		localClient := clientIP == "127.0.0.1" || clientIP == "::1"
+		h.stateMu.RLock()
 		cfg := h.cfg
+		localPassword := h.localPassword
+		allowRemoteOverride := h.allowRemoteOverride
+		envSecret := h.envSecret
+		h.stateMu.RUnlock()
 		var (
 			allowRemote bool
 			secretHash  string
@@ -214,10 +221,9 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 			allowRemote = cfg.RemoteManagement.AllowRemote
 			secretHash = cfg.RemoteManagement.SecretKey
 		}
-		if h.allowRemoteOverride {
+		if allowRemoteOverride {
 			allowRemote = true
 		}
-		envSecret := h.envSecret
 
 		fail := func() {}
 		if !localClient {
@@ -287,8 +293,8 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		}
 
 		if localClient {
-			if lp := h.localPassword; lp != "" {
-				if subtle.ConstantTimeCompare([]byte(provided), []byte(lp)) == 1 {
+			if localPassword != "" {
+				if subtle.ConstantTimeCompare([]byte(provided), []byte(localPassword)) == 1 {
 					c.Next()
 					return
 				}

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -19,6 +19,7 @@ import (
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"golang.org/x/crypto/bcrypt"
+	"gopkg.in/yaml.v3"
 )
 
 type attemptInfo struct {
@@ -41,6 +42,19 @@ type Handler struct {
 	stateMu             sync.RWMutex
 	attemptsMu          sync.Mutex
 	failedAttempts      map[string]*attemptInfo // keyed by client IP
+	authManager         *coreauth.Manager
+	usageStats          *usage.RequestStatistics
+	tokenStore          coreauth.Store
+	localPassword       string
+	allowRemoteOverride bool
+	envSecret           string
+	logDir              string
+	postAuthHook        coreauth.PostAuthHook
+}
+
+type runtimeStateSnapshot struct {
+	cfg                 *config.Config
+	configFilePath      string
 	authManager         *coreauth.Manager
 	usageStats          *usage.RequestStatistics
 	tokenStore          coreauth.Store
@@ -120,12 +134,10 @@ func NewHandlerWithoutConfigFilePath(cfg *config.Config, manager *coreauth.Manag
 	return NewHandler(cfg, "", manager)
 }
 
-// StateMiddleware serializes management runtime state access so request handlers,
-// hot-reload updates and persistence do not observe partially-updated in-memory state.
+// StateMiddleware is kept for compatibility but no longer serializes the entire
+// request lifecycle. Handlers should use short-lived snapshots and mutation helpers instead.
 func (h *Handler) StateMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		h.stateMu.Lock()
-		defer h.stateMu.Unlock()
 		c.Next()
 	}
 }
@@ -180,21 +192,78 @@ func (h *Handler) SetPostAuthHook(hook coreauth.PostAuthHook) {
 	h.stateMu.Unlock()
 }
 
-func (h *Handler) effectiveAuthDir() string {
+func cloneConfig(cfg *config.Config) (*config.Config, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	raw, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	var cloned config.Config
+	if err := yaml.Unmarshal(raw, &cloned); err != nil {
+		return nil, err
+	}
+	return &cloned, nil
+}
+
+func (h *Handler) runtimeSnapshot() (*runtimeStateSnapshot, error) {
 	if h == nil {
-		return ""
+		return &runtimeStateSnapshot{}, nil
 	}
 	h.stateMu.RLock()
-	defer h.stateMu.RUnlock()
-	store := h.tokenStoreWithBaseDir()
-	if h.cfg == nil {
+	cfg, err := cloneConfig(h.cfg)
+	snapshot := &runtimeStateSnapshot{
+		cfg:                 cfg,
+		configFilePath:      h.configFilePath,
+		authManager:         h.authManager,
+		usageStats:          h.usageStats,
+		tokenStore:          h.tokenStore,
+		localPassword:       h.localPassword,
+		allowRemoteOverride: h.allowRemoteOverride,
+		envSecret:           h.envSecret,
+		logDir:              h.logDir,
+		postAuthHook:        h.postAuthHook,
+	}
+	h.stateMu.RUnlock()
+	if snapshot.tokenStore == nil {
+		snapshot.tokenStore = sdkAuth.GetTokenStore()
+	}
+	if err != nil {
+		return snapshot, err
+	}
+	return snapshot, nil
+}
+
+func (h *Handler) configSnapshot() (*config.Config, error) {
+	snapshot, err := h.runtimeSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	return snapshot.cfg, nil
+}
+
+func effectiveAuthDirFromSnapshot(cfg *config.Config, store coreauth.Store) string {
+	if cfg == nil {
 		return ResolveEffectiveAuthDir("", store)
 	}
-	return ResolveEffectiveAuthDir(h.cfg.AuthDir, store)
+	return ResolveEffectiveAuthDir(cfg.AuthDir, store)
+}
+
+func (h *Handler) effectiveAuthDir() string {
+	snapshot, err := h.runtimeSnapshot()
+	if err != nil {
+		return ""
+	}
+	return effectiveAuthDirFromSnapshot(snapshot.cfg, snapshot.tokenStore)
 }
 
 func (h *Handler) registerOAuthSession(state, provider string) string {
-	authDir := h.effectiveAuthDir()
+	snapshot, err := h.runtimeSnapshot()
+	if err != nil {
+		return ""
+	}
+	authDir := effectiveAuthDirFromSnapshot(snapshot.cfg, snapshot.tokenStore)
 	RegisterOAuthSession(state, provider, authDir)
 	return authDir
 }
@@ -341,12 +410,18 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 	}
 }
 
-// persist saves the current in-memory config to disk.
-func (h *Handler) persist(c *gin.Context) bool {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+func (h *Handler) persistConfig(c *gin.Context, cfg *config.Config) bool {
+	if cfg == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return false
+	}
 	// Preserve comments when writing
-	if err := config.SaveConfigPreserveComments(h.configFilePath, h.cfg); err != nil {
+	snapshot, err := h.runtimeSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to snapshot config: %v", err)})
+		return false
+	}
+	if err := config.SaveConfigPreserveComments(snapshot.configFilePath, cfg); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to save config: %v", err)})
 		return false
 	}
@@ -354,8 +429,50 @@ func (h *Handler) persist(c *gin.Context) bool {
 	return true
 }
 
+// persist saves the current in-memory config to disk.
+func (h *Handler) persist(c *gin.Context) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	cfg, err := h.configSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to snapshot config: %v", err)})
+		return false
+	}
+	return h.persistConfig(c, cfg)
+}
+
+func (h *Handler) applyConfigMutation(c *gin.Context, mutate func(*config.Config) error) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	current, err := h.configSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to snapshot config: %v", err)})
+		return false
+	}
+	if current == nil {
+		current = &config.Config{}
+	}
+	nextCfg, err := cloneConfig(current)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to clone config: %v", err)})
+		return false
+	}
+	if err := mutate(nextCfg); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return false
+	}
+	if !h.persistConfig(c, nextCfg) {
+		return false
+	}
+	h.stateMu.Lock()
+	h.cfg = nextCfg
+	h.stateMu.Unlock()
+	return true
+}
+
 // Helper methods for simple types
-func (h *Handler) updateBoolField(c *gin.Context, set func(bool)) {
+func (h *Handler) updateBoolField(c *gin.Context, set func(*config.Config, bool)) {
 	var body struct {
 		Value *bool `json:"value"`
 	}
@@ -363,11 +480,13 @@ func (h *Handler) updateBoolField(c *gin.Context, set func(bool)) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
-	set(*body.Value)
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		set(cfg, *body.Value)
+		return nil
+	})
 }
 
-func (h *Handler) updateIntField(c *gin.Context, set func(int)) {
+func (h *Handler) updateIntField(c *gin.Context, set func(*config.Config, int) error) {
 	var body struct {
 		Value *int `json:"value"`
 	}
@@ -375,11 +494,12 @@ func (h *Handler) updateIntField(c *gin.Context, set func(int)) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
-	set(*body.Value)
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		return set(cfg, *body.Value)
+	})
 }
 
-func (h *Handler) updateStringField(c *gin.Context, set func(string)) {
+func (h *Handler) updateStringField(c *gin.Context, set func(*config.Config, string)) {
 	var body struct {
 		Value *string `json:"value"`
 	}
@@ -387,6 +507,8 @@ func (h *Handler) updateStringField(c *gin.Context, set func(string)) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
-	set(*body.Value)
-	h.persist(c)
+	h.applyConfigMutation(c, func(cfg *config.Config) error {
+		set(cfg, *body.Value)
+		return nil
+	})
 }

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -38,6 +38,7 @@ type Handler struct {
 	cfg                 *config.Config
 	configFilePath      string
 	mu                  sync.Mutex
+	stateMu             sync.RWMutex
 	attemptsMu          sync.Mutex
 	failedAttempts      map[string]*attemptInfo // keyed by client IP
 	authManager         *coreauth.Manager
@@ -48,6 +49,21 @@ type Handler struct {
 	envSecret           string
 	logDir              string
 	postAuthHook        coreauth.PostAuthHook
+}
+
+type authDirProvider interface {
+	AuthDir() string
+}
+
+// ResolveEffectiveAuthDir returns the runtime auth directory used by file-based flows.
+// Stores with mirrored workspaces may override the configured auth dir.
+func ResolveEffectiveAuthDir(configAuthDir string, store coreauth.Store) string {
+	if provider, ok := store.(authDirProvider); ok {
+		if dir := strings.TrimSpace(provider.AuthDir()); dir != "" {
+			return dir
+		}
+	}
+	return strings.TrimSpace(configAuthDir)
 }
 
 // NewHandler creates a new management handler instance.
@@ -104,17 +120,43 @@ func NewHandlerWithoutConfigFilePath(cfg *config.Config, manager *coreauth.Manag
 	return NewHandler(cfg, "", manager)
 }
 
+// StateMiddleware serializes management runtime state access so request handlers,
+// hot-reload updates and persistence do not observe partially-updated in-memory state.
+func (h *Handler) StateMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		h.stateMu.Lock()
+		defer h.stateMu.Unlock()
+		c.Next()
+	}
+}
+
 // SetConfig updates the in-memory config reference when the server hot-reloads.
-func (h *Handler) SetConfig(cfg *config.Config) { h.cfg = cfg }
+func (h *Handler) SetConfig(cfg *config.Config) {
+	h.stateMu.Lock()
+	h.cfg = cfg
+	h.stateMu.Unlock()
+}
 
 // SetAuthManager updates the auth manager reference used by management endpoints.
-func (h *Handler) SetAuthManager(manager *coreauth.Manager) { h.authManager = manager }
+func (h *Handler) SetAuthManager(manager *coreauth.Manager) {
+	h.stateMu.Lock()
+	h.authManager = manager
+	h.stateMu.Unlock()
+}
 
 // SetUsageStatistics allows replacing the usage statistics reference.
-func (h *Handler) SetUsageStatistics(stats *usage.RequestStatistics) { h.usageStats = stats }
+func (h *Handler) SetUsageStatistics(stats *usage.RequestStatistics) {
+	h.stateMu.Lock()
+	h.usageStats = stats
+	h.stateMu.Unlock()
+}
 
 // SetLocalPassword configures the runtime-local password accepted for localhost requests.
-func (h *Handler) SetLocalPassword(password string) { h.localPassword = password }
+func (h *Handler) SetLocalPassword(password string) {
+	h.stateMu.Lock()
+	h.localPassword = password
+	h.stateMu.Unlock()
+}
 
 // SetLogDirectory updates the directory where main.log should be looked up.
 func (h *Handler) SetLogDirectory(dir string) {
@@ -126,12 +168,27 @@ func (h *Handler) SetLogDirectory(dir string) {
 			dir = abs
 		}
 	}
+	h.stateMu.Lock()
 	h.logDir = dir
+	h.stateMu.Unlock()
 }
 
 // SetPostAuthHook registers a hook to be called after auth record creation but before persistence.
 func (h *Handler) SetPostAuthHook(hook coreauth.PostAuthHook) {
+	h.stateMu.Lock()
 	h.postAuthHook = hook
+	h.stateMu.Unlock()
+}
+
+func (h *Handler) effectiveAuthDir() string {
+	if h == nil {
+		return ""
+	}
+	store := h.tokenStoreWithBaseDir()
+	if h.cfg == nil {
+		return ResolveEffectiveAuthDir("", store)
+	}
+	return ResolveEffectiveAuthDir(h.cfg.AuthDir, store)
 }
 
 // Middleware enforces access control for management endpoints.

--- a/internal/api/handlers/management/handler_state_test.go
+++ b/internal/api/handlers/management/handler_state_test.go
@@ -1,0 +1,97 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestStateMiddleware_BlocksConcurrentSetConfig(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("generate hash: %v", err)
+	}
+
+	h := NewHandler(&config.Config{RemoteManagement: config.RemoteManagement{SecretKey: string(hash)}}, filepath.Join(t.TempDir(), "config.yaml"), nil)
+	r := gin.New()
+	release := make(chan struct{})
+	reached := make(chan struct{})
+	r.GET("/guarded", h.StateMiddleware(), func(c *gin.Context) {
+		close(reached)
+		<-release
+		c.Status(http.StatusNoContent)
+	})
+
+	go func() {
+		req := httptest.NewRequest(http.MethodGet, "/guarded", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+	}()
+
+	select {
+	case <-reached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request did not enter guarded handler")
+	}
+
+	updated := make(chan struct{})
+	go func() {
+		h.SetConfig(&config.Config{})
+		close(updated)
+	}()
+
+	select {
+	case <-updated:
+		t.Fatal("SetConfig should wait for in-flight management request")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-updated:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SetConfig did not complete after request finished")
+	}
+}
+
+func TestPutLogsMaxTotalSizeMB_RejectsOversizedValue(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("logging-to-file: false\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	h := NewHandler(&config.Config{}, configPath, nil)
+	r := gin.New()
+	r.PUT("/logs-max-total-size-mb", h.StateMiddleware(), h.PutLogsMaxTotalSizeMB)
+
+	body := strings.NewReader(`{"value":1048577}`)
+	req := httptest.NewRequest(http.MethodPut, "/logs-max-total-size-mb", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("unexpected status: got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !strings.Contains(resp["error"], "exceeds allowed maximum") {
+		t.Fatalf("unexpected error response: %v", resp)
+	}
+}

--- a/internal/api/handlers/management/handler_state_test.go
+++ b/internal/api/handlers/management/handler_state_test.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-func TestStateMiddleware_BlocksConcurrentSetConfig(t *testing.T) {
+func TestStateMiddleware_DoesNotBlockConcurrentSetConfig(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.DefaultCost)
@@ -53,8 +53,8 @@ func TestStateMiddleware_BlocksConcurrentSetConfig(t *testing.T) {
 
 	select {
 	case <-updated:
-		t.Fatal("SetConfig should wait for in-flight management request")
 	case <-time.After(150 * time.Millisecond):
+		t.Fatal("SetConfig should not wait for in-flight management request")
 	}
 
 	close(release)
@@ -93,5 +93,53 @@ func TestPutLogsMaxTotalSizeMB_RejectsOversizedValue(t *testing.T) {
 	}
 	if !strings.Contains(resp["error"], "exceeds allowed maximum") {
 		t.Fatalf("unexpected error response: %v", resp)
+	}
+}
+
+func TestStateMiddleware_DoesNotDeadlockRegisterOAuthSession(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewHandler(&config.Config{AuthDir: t.TempDir()}, filepath.Join(t.TempDir(), "config.yaml"), nil)
+	r := gin.New()
+	r.GET("/oauth", h.StateMiddleware(), func(c *gin.Context) {
+		h.registerOAuthSession("state-for-deadlock-check", "codex")
+		c.Status(http.StatusNoContent)
+	})
+
+	done := make(chan struct{})
+	go func() {
+		req := httptest.NewRequest(http.MethodGet, "/oauth", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("registerOAuthSession should not block while management request is in flight")
+	}
+}
+
+func TestPutConfigYAML_RejectsOversizedLogLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("logging-to-file: false\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	h := NewHandler(&config.Config{}, configPath, nil)
+	r := gin.New()
+	r.PUT("/config.yaml", h.PutConfigYAML)
+
+	req := httptest.NewRequest(http.MethodPut, "/config.yaml", strings.NewReader("logs-max-total-size-mb: 1048577\n"))
+	req.Header.Set("Content-Type", "application/yaml")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest && w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected oversized config to be rejected, got %d body=%s", w.Code, w.Body.String())
 	}
 }

--- a/internal/api/handlers/management/logs.go
+++ b/internal/api/handlers/management/logs.go
@@ -28,11 +28,16 @@ func (h *Handler) GetLogs(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler unavailable"})
 		return
 	}
-	if h.cfg == nil {
+	cfg, err := h.configSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return
+	}
+	if cfg == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "configuration unavailable"})
 		return
 	}
-	if !h.cfg.LoggingToFile {
+	if !cfg.LoggingToFile {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "logging to file disabled"})
 		return
 	}
@@ -90,11 +95,16 @@ func (h *Handler) DeleteLogs(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler unavailable"})
 		return
 	}
-	if h.cfg == nil {
+	cfg, err := h.configSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return
+	}
+	if cfg == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "configuration unavailable"})
 		return
 	}
-	if !h.cfg.LoggingToFile {
+	if !cfg.LoggingToFile {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "logging to file disabled"})
 		return
 	}
@@ -152,11 +162,16 @@ func (h *Handler) GetRequestErrorLogs(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler unavailable"})
 		return
 	}
-	if h.cfg == nil {
+	cfg, err := h.configSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return
+	}
+	if cfg == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "configuration unavailable"})
 		return
 	}
-	if h.cfg.RequestLog {
+	if cfg.RequestLog {
 		c.JSON(http.StatusOK, gin.H{"files": []any{}})
 		return
 	}
@@ -216,7 +231,12 @@ func (h *Handler) GetRequestLogByID(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler unavailable"})
 		return
 	}
-	if h.cfg == nil {
+	cfg, err := h.configSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return
+	}
+	if cfg == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "configuration unavailable"})
 		return
 	}
@@ -303,7 +323,12 @@ func (h *Handler) DownloadRequestErrorLog(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler unavailable"})
 		return
 	}
-	if h.cfg == nil {
+	cfg, err := h.configSnapshot()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "configuration unavailable"})
+		return
+	}
+	if cfg == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "configuration unavailable"})
 		return
 	}
@@ -357,10 +382,14 @@ func (h *Handler) logDirectory() string {
 	if h == nil {
 		return ""
 	}
-	if h.logDir != "" {
-		return h.logDir
+	snapshot, err := h.runtimeSnapshot()
+	if err == nil {
+		if strings.TrimSpace(snapshot.logDir) != "" {
+			return snapshot.logDir
+		}
+		return logging.ResolveLogDirectory(snapshot.cfg)
 	}
-	return logging.ResolveLogDirectory(h.cfg)
+	return ""
 }
 
 func (h *Handler) collectLogFiles(dir string) ([]string, error) {

--- a/internal/api/handlers/management/oauth_callback.go
+++ b/internal/api/handlers/management/oauth_callback.go
@@ -87,7 +87,7 @@ func (h *Handler) PostOAuthCallback(c *gin.Context) {
 		return
 	}
 
-	if _, errWrite := WriteOAuthCallbackFileForPendingSession(h.cfg.AuthDir, canonicalProvider, state, code, errMsg); errWrite != nil {
+	if _, errWrite := WriteOAuthCallbackFileForPendingSession(canonicalProvider, state, code, errMsg); errWrite != nil {
 		if errors.Is(errWrite, errOAuthSessionNotPending) {
 			c.JSON(http.StatusConflict, gin.H{"status": "error", "error": "oauth flow is not pending"})
 			return

--- a/internal/api/handlers/management/oauth_callback.go
+++ b/internal/api/handlers/management/oauth_callback.go
@@ -18,7 +18,7 @@ type oauthCallbackRequest struct {
 }
 
 func (h *Handler) PostOAuthCallback(c *gin.Context) {
-	if h == nil || h.cfg == nil {
+	if h == nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "handler not initialized"})
 		return
 	}

--- a/internal/api/handlers/management/oauth_callback_test.go
+++ b/internal/api/handlers/management/oauth_callback_test.go
@@ -1,0 +1,67 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestPostOAuthCallback_UsesSessionAuthDir(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	tempDir := t.TempDir()
+	configAuthDir := filepath.Join(tempDir, "config-auth")
+	sessionAuthDir := filepath.Join(tempDir, "session-auth")
+	if err := os.MkdirAll(configAuthDir, 0o700); err != nil {
+		t.Fatalf("failed to create config auth dir: %v", err)
+	}
+	if err := os.MkdirAll(sessionAuthDir, 0o700); err != nil {
+		t.Fatalf("failed to create session auth dir: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: configAuthDir}, coreauth.NewManager(nil, nil, nil))
+	state := "codex-session-bound-state"
+	RegisterOAuthSession(state, "codex", sessionAuthDir)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/oauth/callback", strings.NewReader(`{"provider":"codex","state":"`+state+`","code":"auth-code"}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+
+	h.PostOAuthCallback(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, recorder.Code, recorder.Body.String())
+	}
+
+	sessionPath := filepath.Join(sessionAuthDir, ".oauth-codex-"+state+".oauth")
+	configPath := filepath.Join(configAuthDir, ".oauth-codex-"+state+".oauth")
+	if _, err := os.Stat(sessionPath); err != nil {
+		t.Fatalf("expected callback file in session auth dir, stat err: %v", err)
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no callback file in config auth dir, stat err: %v", err)
+	}
+
+	var payload map[string]string
+	raw, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("failed to read callback file: %v", err)
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("failed to decode callback file: %v", err)
+	}
+	if payload["code"] != "auth-code" {
+		t.Fatalf("expected code to be persisted, got %q", payload["code"])
+	}
+}

--- a/internal/api/handlers/management/oauth_sessions.go
+++ b/internal/api/handlers/management/oauth_sessions.go
@@ -25,6 +25,7 @@ var (
 type oauthSession struct {
 	Provider  string
 	Status    string
+	AuthDir   string
 	CreatedAt time.Time
 	ExpiresAt time.Time
 }
@@ -53,9 +54,10 @@ func (s *oauthSessionStore) purgeExpiredLocked(now time.Time) {
 	}
 }
 
-func (s *oauthSessionStore) Register(state, provider string) {
+func (s *oauthSessionStore) Register(state, provider, authDir string) {
 	state = strings.TrimSpace(state)
 	provider = strings.ToLower(strings.TrimSpace(provider))
+	authDir = strings.TrimSpace(authDir)
 	if state == "" || provider == "" {
 		return
 	}
@@ -68,6 +70,7 @@ func (s *oauthSessionStore) Register(state, provider string) {
 	s.sessions[state] = oauthSession{
 		Provider:  provider,
 		Status:    "",
+		AuthDir:   authDir,
 		CreatedAt: now,
 		ExpiresAt: now.Add(s.ttl),
 	}
@@ -168,7 +171,9 @@ func (s *oauthSessionStore) IsPending(state, provider string) bool {
 
 var oauthSessions = newOAuthSessionStore(oauthSessionTTL)
 
-func RegisterOAuthSession(state, provider string) { oauthSessions.Register(state, provider) }
+func RegisterOAuthSession(state, provider, authDir string) {
+	oauthSessions.Register(state, provider, authDir)
+}
 
 func SetOAuthSessionError(state, message string) { oauthSessions.SetError(state, message) }
 
@@ -265,19 +270,26 @@ func WriteOAuthCallbackFile(authDir, provider, state, code, errorMessage string)
 	if err != nil {
 		return "", fmt.Errorf("marshal oauth callback payload: %w", err)
 	}
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		return "", fmt.Errorf("create oauth callback dir: %w", err)
+	}
 	if err := os.WriteFile(filePath, data, 0o600); err != nil {
 		return "", fmt.Errorf("write oauth callback file: %w", err)
 	}
 	return filePath, nil
 }
 
-func WriteOAuthCallbackFileForPendingSession(authDir, provider, state, code, errorMessage string) (string, error) {
+func WriteOAuthCallbackFileForPendingSession(provider, state, code, errorMessage string) (string, error) {
 	canonicalProvider, err := NormalizeOAuthProvider(provider)
 	if err != nil {
 		return "", err
 	}
-	if !IsOAuthSessionPending(state, canonicalProvider) {
+	session, ok := oauthSessions.Get(state)
+	if !ok || session.Status != "" || !strings.EqualFold(session.Provider, canonicalProvider) {
 		return "", errOAuthSessionNotPending
 	}
-	return WriteOAuthCallbackFile(authDir, canonicalProvider, state, code, errorMessage)
+	if strings.TrimSpace(session.AuthDir) == "" {
+		return "", fmt.Errorf("oauth session auth dir is empty")
+	}
+	return WriteOAuthCallbackFile(session.AuthDir, canonicalProvider, state, code, errorMessage)
 }

--- a/internal/api/handlers/management/quota.go
+++ b/internal/api/handlers/management/quota.go
@@ -1,18 +1,31 @@
 package management
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
 
 // Quota exceeded toggles
 func (h *Handler) GetSwitchProject(c *gin.Context) {
-	c.JSON(200, gin.H{"switch-project": h.cfg.QuotaExceeded.SwitchProject})
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(200, gin.H{"switch-project": false})
+		return
+	}
+	c.JSON(200, gin.H{"switch-project": cfg.QuotaExceeded.SwitchProject})
 }
 func (h *Handler) PutSwitchProject(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.QuotaExceeded.SwitchProject = v })
+	h.updateBoolField(c, func(cfg *config.Config, v bool) { cfg.QuotaExceeded.SwitchProject = v })
 }
 
 func (h *Handler) GetSwitchPreviewModel(c *gin.Context) {
-	c.JSON(200, gin.H{"switch-preview-model": h.cfg.QuotaExceeded.SwitchPreviewModel})
+	cfg, err := h.configSnapshot()
+	if err != nil || cfg == nil {
+		c.JSON(200, gin.H{"switch-preview-model": false})
+		return
+	}
+	c.JSON(200, gin.H{"switch-preview-model": cfg.QuotaExceeded.SwitchPreviewModel})
 }
 func (h *Handler) PutSwitchPreviewModel(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.QuotaExceeded.SwitchPreviewModel = v })
+	h.updateBoolField(c, func(cfg *config.Config, v bool) { cfg.QuotaExceeded.SwitchPreviewModel = v })
 }

--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -23,8 +23,11 @@ type usageImportPayload struct {
 // GetUsageStatistics returns the in-memory request statistics snapshot.
 func (h *Handler) GetUsageStatistics(c *gin.Context) {
 	var snapshot usage.StatisticsSnapshot
-	if h != nil && h.usageStats != nil {
-		snapshot = h.usageStats.Snapshot()
+	if h != nil {
+		state, err := h.runtimeSnapshot()
+		if err == nil && state.usageStats != nil {
+			snapshot = state.usageStats.Snapshot()
+		}
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"usage":           snapshot,
@@ -35,8 +38,11 @@ func (h *Handler) GetUsageStatistics(c *gin.Context) {
 // ExportUsageStatistics returns a complete usage snapshot for backup/migration.
 func (h *Handler) ExportUsageStatistics(c *gin.Context) {
 	var snapshot usage.StatisticsSnapshot
-	if h != nil && h.usageStats != nil {
-		snapshot = h.usageStats.Snapshot()
+	if h != nil {
+		state, err := h.runtimeSnapshot()
+		if err == nil && state.usageStats != nil {
+			snapshot = state.usageStats.Snapshot()
+		}
 	}
 	c.JSON(http.StatusOK, usageExportPayload{
 		Version:    1,
@@ -47,7 +53,12 @@ func (h *Handler) ExportUsageStatistics(c *gin.Context) {
 
 // ImportUsageStatistics merges a previously exported usage snapshot into memory.
 func (h *Handler) ImportUsageStatistics(c *gin.Context) {
-	if h == nil || h.usageStats == nil {
+	if h == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "usage statistics unavailable"})
+		return
+	}
+	state, err := h.runtimeSnapshot()
+	if err != nil || state.usageStats == nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "usage statistics unavailable"})
 		return
 	}
@@ -68,8 +79,8 @@ func (h *Handler) ImportUsageStatistics(c *gin.Context) {
 		return
 	}
 
-	result := h.usageStats.MergeSnapshot(payload.Usage)
-	snapshot := h.usageStats.Snapshot()
+	result := state.usageStats.MergeSnapshot(payload.Usage)
+	snapshot := state.usageStats.Snapshot()
 	c.JSON(http.StatusOK, gin.H{
 		"added":           result.Added,
 		"skipped":         result.Skipped,

--- a/internal/api/handlers/management/vertex_import.go
+++ b/internal/api/handlers/management/vertex_import.go
@@ -15,11 +15,12 @@ import (
 
 // ImportVertexCredential handles uploading a Vertex service account JSON and saving it as an auth record.
 func (h *Handler) ImportVertexCredential(c *gin.Context) {
-	if h == nil || h.cfg == nil {
+	cfg, err := h.configSnapshot()
+	if h == nil || err != nil || cfg == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "config unavailable"})
 		return
 	}
-	if h.cfg.AuthDir == "" {
+	if cfg.AuthDir == "" {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth directory not configured"})
 		return
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -497,7 +497,7 @@ func (s *Server) registerManagementRoutes() {
 	log.Info("management routes registered after secret key configuration")
 
 	mgmt := s.engine.Group("/v0/management")
-	mgmt.Use(s.managementAvailabilityMiddleware(), s.mgmt.StateMiddleware(), s.mgmt.Middleware())
+	mgmt.Use(s.managementAvailabilityMiddleware(), s.mgmt.Middleware(), s.mgmt.StateMiddleware())
 	{
 		mgmt.GET("/usage", s.mgmt.GetUsageStatistics)
 		mgmt.GET("/usage/export", s.mgmt.ExportUsageStatistics)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -43,9 +43,8 @@ import (
 
 const oauthCallbackSuccessHTML = `<html><head><meta charset="utf-8"><title>Authentication successful</title><script>setTimeout(function(){window.close();},5000);</script></head><body><h1>Authentication successful!</h1><p>You can close this window.</p><p>This window will close automatically in 5 seconds.</p></body></html>`
 
-func writePendingOAuthCallbackFile(configAuthDir, provider, state, code, errStr string) {
-	authDir := managementHandlers.ResolveEffectiveAuthDir(configAuthDir, sdkAuth.GetTokenStore())
-	_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(authDir, provider, state, code, errStr)
+func writePendingOAuthCallbackFile(provider, state, code, errStr string) {
+	_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(provider, state, code, errStr)
 }
 
 type serverOptionConfig struct {
@@ -384,7 +383,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			writePendingOAuthCallbackFile(s.cfg.AuthDir, "anthropic", state, code, errStr)
+			writePendingOAuthCallbackFile("anthropic", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -398,7 +397,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			writePendingOAuthCallbackFile(s.cfg.AuthDir, "codex", state, code, errStr)
+			writePendingOAuthCallbackFile("codex", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -412,7 +411,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			writePendingOAuthCallbackFile(s.cfg.AuthDir, "gemini", state, code, errStr)
+			writePendingOAuthCallbackFile("gemini", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -426,7 +425,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			writePendingOAuthCallbackFile(s.cfg.AuthDir, "iflow", state, code, errStr)
+			writePendingOAuthCallbackFile("iflow", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -440,7 +439,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			writePendingOAuthCallbackFile(s.cfg.AuthDir, "antigravity", state, code, errStr)
+			writePendingOAuthCallbackFile("antigravity", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/access"
+	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	managementHandlers "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/middleware"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/modules"
@@ -41,6 +42,11 @@ import (
 )
 
 const oauthCallbackSuccessHTML = `<html><head><meta charset="utf-8"><title>Authentication successful</title><script>setTimeout(function(){window.close();},5000);</script></head><body><h1>Authentication successful!</h1><p>You can close this window.</p><p>This window will close automatically in 5 seconds.</p></body></html>`
+
+func writePendingOAuthCallbackFile(configAuthDir, provider, state, code, errStr string) {
+	authDir := managementHandlers.ResolveEffectiveAuthDir(configAuthDir, sdkAuth.GetTokenStore())
+	_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(authDir, provider, state, code, errStr)
+}
 
 type serverOptionConfig struct {
 	extraMiddleware      []gin.HandlerFunc
@@ -195,6 +201,13 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	for i := range opts {
 		opts[i](optionState)
 	}
+	if accessManager == nil {
+		log.Warn("access manager was nil, creating a default manager")
+		accessManager = sdkaccess.NewManager()
+		configaccess.Register(&cfg.SDKConfig)
+		accessManager.SetProviders(sdkaccess.RegisteredProviders())
+	}
+
 	// Set gin mode
 	if !cfg.Debug {
 		gin.SetMode(gin.ReleaseMode)
@@ -371,7 +384,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "anthropic", state, code, errStr)
+			writePendingOAuthCallbackFile(s.cfg.AuthDir, "anthropic", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -385,7 +398,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "codex", state, code, errStr)
+			writePendingOAuthCallbackFile(s.cfg.AuthDir, "codex", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -399,7 +412,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "gemini", state, code, errStr)
+			writePendingOAuthCallbackFile(s.cfg.AuthDir, "gemini", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -413,7 +426,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "iflow", state, code, errStr)
+			writePendingOAuthCallbackFile(s.cfg.AuthDir, "iflow", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -427,7 +440,7 @@ func (s *Server) setupRoutes() {
 			errStr = c.Query("error_description")
 		}
 		if state != "" {
-			_, _ = managementHandlers.WriteOAuthCallbackFileForPendingSession(s.cfg.AuthDir, "antigravity", state, code, errStr)
+			writePendingOAuthCallbackFile(s.cfg.AuthDir, "antigravity", state, code, errStr)
 		}
 		c.Header("Content-Type", "text/html; charset=utf-8")
 		c.String(http.StatusOK, oauthCallbackSuccessHTML)
@@ -484,7 +497,7 @@ func (s *Server) registerManagementRoutes() {
 	log.Info("management routes registered after secret key configuration")
 
 	mgmt := s.engine.Group("/v0/management")
-	mgmt.Use(s.managementAvailabilityMiddleware(), s.mgmt.Middleware())
+	mgmt.Use(s.managementAvailabilityMiddleware(), s.mgmt.StateMiddleware(), s.mgmt.Middleware())
 	{
 		mgmt.GET("/usage", s.mgmt.GetUsageStatistics)
 		mgmt.GET("/usage/export", s.mgmt.ExportUsageStatistics)
@@ -1028,7 +1041,8 @@ func (s *Server) SetWebsocketAuthChangeHandler(fn func(bool, bool)) {
 func AuthMiddleware(manager *sdkaccess.Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if manager == nil {
-			c.Next()
+			log.Error("authentication middleware misconfigured: access manager is nil")
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "authentication unavailable"})
 			return
 		}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -496,7 +496,7 @@ func (s *Server) registerManagementRoutes() {
 	log.Info("management routes registered after secret key configuration")
 
 	mgmt := s.engine.Group("/v0/management")
-	mgmt.Use(s.managementAvailabilityMiddleware(), s.mgmt.Middleware(), s.mgmt.StateMiddleware())
+	mgmt.Use(s.managementAvailabilityMiddleware(), s.mgmt.Middleware())
 	{
 		mgmt.GET("/usage", s.mgmt.GetUsageStatistics)
 		mgmt.GET("/usage/export", s.mgmt.ExportUsageStatistics)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	gin "github.com/gin-gonic/gin"
+	managementHandlers "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
@@ -256,3 +257,31 @@ func TestDefaultRequestLoggerFactory_UsesResolvedLogDirectory(t *testing.T) {
 	}
 }
 
+func TestOAuthCallbackRoute_UsesSessionAuthDir(t *testing.T) {
+	server := newTestServer(t)
+
+	sessionAuthDir := filepath.Join(t.TempDir(), "session-auth")
+	if err := os.MkdirAll(sessionAuthDir, 0o700); err != nil {
+		t.Fatalf("failed to create session auth dir: %v", err)
+	}
+
+	state := "codex-route-session-state"
+	managementHandlers.RegisterOAuthSession(state, "codex", sessionAuthDir)
+
+	req := httptest.NewRequest(http.MethodGet, "/codex/callback?state="+state+"&code=route-code", nil)
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	sessionPath := filepath.Join(sessionAuthDir, ".oauth-codex-"+state+".oauth")
+	configPath := filepath.Join(server.cfg.AuthDir, ".oauth-codex-"+state+".oauth")
+	if _, err := os.Stat(sessionPath); err != nil {
+		t.Fatalf("expected callback file in session auth dir, stat err: %v", err)
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no callback file in config auth dir, stat err: %v", err)
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -46,6 +46,53 @@ func newTestServer(t *testing.T) *Server {
 	return NewServer(cfg, authManager, accessManager, configPath)
 }
 
+func TestAuthMiddleware_NilManagerRejectsRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(AuthMiddleware(nil))
+	r.GET("/protected", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("unexpected status: got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestNewServer_CreatesAccessManagerWhenNil(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tmpDir := t.TempDir()
+	authDir := filepath.Join(tmpDir, "auth")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("failed to create auth dir: %v", err)
+	}
+
+	cfg := &proxyconfig.Config{
+		SDKConfig: sdkconfig.SDKConfig{APIKeys: []string{"test-key"}},
+		Port:      0,
+		AuthDir:   authDir,
+	}
+
+	server := NewServer(cfg, auth.NewManager(nil, nil, nil), nil, filepath.Join(tmpDir, "config.yaml"))
+
+	unauthorized := httptest.NewRecorder()
+	server.engine.ServeHTTP(unauthorized, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized without credentials, got %d body=%s", unauthorized.Code, unauthorized.Body.String())
+	}
+
+	authorizedReq := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	authorizedReq.Header.Set("Authorization", "Bearer test-key")
+	authorized := httptest.NewRecorder()
+	server.engine.ServeHTTP(authorized, authorizedReq)
+	if authorized.Code != http.StatusOK {
+		t.Fatalf("expected authorized request to succeed, got %d body=%s", authorized.Code, authorized.Body.String())
+	}
+}
 func TestAmpProviderModelRoutes(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -208,3 +255,4 @@ func TestDefaultRequestLoggerFactory_UsesResolvedLogDirectory(t *testing.T) {
 		}
 	}
 }
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,7 @@ import (
 const (
 	DefaultPanelGitHubRepository = "https://github.com/router-for-me/Cli-Proxy-API-Management-Center"
 	DefaultPprofAddr             = "127.0.0.1:8316"
-	MaxLogsMaxTotalSizeMB        = 1024 * 1024
+	MaxLogsMaxTotalSizeMB        = 1024
 )
 
 // Config represents the application's configuration, loaded from a YAML file.
@@ -1830,5 +1830,3 @@ func removeLegacyAuthBlock(root *yaml.Node) {
 	}
 	removeMapKey(root, "auth")
 }
-
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ import (
 const (
 	DefaultPanelGitHubRepository = "https://github.com/router-for-me/Cli-Proxy-API-Management-Center"
 	DefaultPprofAddr             = "127.0.0.1:8316"
+	MaxLogsMaxTotalSizeMB        = 1024 * 1024
 )
 
 // Config represents the application's configuration, loaded from a YAML file.
@@ -596,6 +597,8 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	if cfg.LogsMaxTotalSizeMB < 0 {
 		cfg.LogsMaxTotalSizeMB = 0
+	} else if cfg.LogsMaxTotalSizeMB > MaxLogsMaxTotalSizeMB {
+		cfg.LogsMaxTotalSizeMB = MaxLogsMaxTotalSizeMB
 	}
 
 	if cfg.ErrorLogsMaxFiles < 0 {
@@ -1827,3 +1830,5 @@ func removeLegacyAuthBlock(root *yaml.Node) {
 	}
 	removeMapKey(root, "auth")
 }
+
+

--- a/internal/config/config_limits_test.go
+++ b/internal/config/config_limits_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_ClampsLogsMaxTotalSizeMB(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("logs-max-total-size-mb: 1048577\n"), 0o600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if cfg.LogsMaxTotalSizeMB != MaxLogsMaxTotalSizeMB {
+		t.Fatalf("expected logs-max-total-size-mb to be clamped to %d, got %d", MaxLogsMaxTotalSizeMB, cfg.LogsMaxTotalSizeMB)
+	}
+}


### PR DESCRIPTION
## Summary
- harden management state mutation paths
- enforce and test configuration limits in management/server flows
- add regression coverage for handler state and server config boundaries

## Business value
- reduces management-side state corruption risk
- gives maintainers a self-contained PR for config safety instead of mixing it with auth/watcher changes
- improves rollback safety because the scope stays within management/config handling

## Tests
- go test ./internal/api/handlers/management ./internal/api ./internal/config