### PR TITLE
fix: suppress token refresh write-back loop and reduce log noise

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -993,7 +993,7 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	}
 
 	total := authEntries + geminiAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + vertexAICompatCount + openAICompatCount
-	fmt.Printf("server clients and configuration updated: %d clients (%d auth entries + %d Gemini API keys + %d Claude API keys + %d Codex keys + %d Vertex-compat + %d OpenAI-compat)\n",
+	log.Debugf("server clients and configuration updated: %d clients (%d auth entries + %d Gemini API keys + %d Claude API keys + %d Codex keys + %d Vertex-compat + %d OpenAI-compat)",
 		total,
 		authEntries,
 		geminiAPIKeyCount,

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2159,7 +2159,12 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	updated.NextRefreshAfter = time.Time{}
 	updated.LastError = nil
 	updated.UpdatedAt = now
-	_, _ = m.Update(ctx, updated)
+	// Use WithSkipPersist to avoid writing the refreshed token back to disk.
+	// The in-memory state is already updated; persisting here would trigger
+	// the file watcher, which calls reloadCallback -> UpdateClients, creating
+	// a write-back feedback loop that spams the log with "configuration updated"
+	// messages every ~1 minute per token.
+	_, _ = m.Update(WithSkipPersist(ctx), updated)
 }
 
 func (m *Manager) executorFor(provider string) ProviderExecutor {


### PR DESCRIPTION
## Summary

- **conductor.go**: Use `WithSkipPersist` in `refreshAuth` to prevent disk write-back after auto-refresh. The refresh cycle writes the updated token to the JSON file, triggering the fsnotify watcher → `reloadCallback` → `UpdateClients`, logging "server clients and configuration updated" every ~1 minute per token. Since the in-memory state is already current, persisting is unnecessary and creates a feedback loop.

- **server.go**: Change `UpdateClients` `fmt.Printf` to `log.Debugf` so configuration reload messages respect the debug flag and don't unconditionally fill stdout logs.

## Problem

With 2+ OAuth tokens (e.g., Claude Max accounts), each refreshing within a 4-hour lead window with a 1-minute backoff, the log accumulates ~2 messages/minute continuously. Over 12 days this produced 438 redundant "configuration updated" lines — pure noise that obscures meaningful log entries and contributes to log file growth.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./sdk/cliproxy/auth/... -run "SkipPersist|Refresh"` passes
- [ ] Verify no "configuration updated" messages in stdout when `debug: false`
- [ ] Verify messages appear when `debug: true`
- [ ] Confirm token refresh still works (check token expiry updates in auth JSON files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)