### PR TITLE
test(codex): cover fast mode service tier forwarding

### DIFF
--- a/internal/runtime/executor/codex_executor_service_tier_test.go
+++ b/internal/runtime/executor/codex_executor_service_tier_test.go
@@ -1,0 +1,62 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestCodexExecutorExecute_ForwardsPriorityServiceTier(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":1700000000,\"model\":\"gpt-5.3-codex\",\"output\":[],\"parallel_tool_calls\":true,\"store\":false}}\n"))
+	}))
+	defer server.Close()
+
+	executor := &CodexExecutor{}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test-access-token",
+	}}
+	payload := []byte(`{"model":"gpt-5.3-codex","service_tier":"priority","reasoning":{"effort":"high"},"input":[{"role":"user","content":"hi"}]}`)
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.3-codex",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/responses" {
+		t.Fatalf("path = %q, want %q", gotPath, "/responses")
+	}
+	if got := gjson.GetBytes(gotBody, "service_tier").String(); got != "priority" {
+		t.Fatalf("service_tier = %q, want %q, body=%s", got, "priority", string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "reasoning.effort").String(); got != "high" {
+		t.Fatalf("reasoning.effort = %q, want %q, body=%s", got, "high", string(gotBody))
+	}
+	if !gjson.GetBytes(gotBody, "stream").Bool() {
+		t.Fatalf("expected stream=true, body=%s", string(gotBody))
+	}
+	if gjson.GetBytes(resp.Payload, "type").String() != "response.completed" {
+		t.Fatalf("unexpected response payload: %s", string(resp.Payload))
+	}
+	if gjson.GetBytes(resp.Payload, "response.object").String() != "response" {
+		t.Fatalf("unexpected response object in payload: %s", string(resp.Payload))
+	}
+}

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
@@ -318,3 +318,29 @@ func TestTruncationRemovedForCodexCompatibility(t *testing.T) {
 		t.Fatalf("truncation should be removed for Codex compatibility")
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToCodex_PreservesPriorityServiceTier(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gpt-5.3-codex",
+		"service_tier": "priority",
+		"input": [{"role":"user","content":"hello"}]
+	}`)
+
+	output := ConvertOpenAIResponsesRequestToCodex("gpt-5.3-codex", inputJSON, false)
+	if got := gjson.GetBytes(output, "service_tier").String(); got != "priority" {
+		t.Fatalf("service_tier = %q, want %q", got, "priority")
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToCodex_StripsNonPriorityServiceTier(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gpt-5.3-codex",
+		"service_tier": "fast",
+		"input": [{"role":"user","content":"hello"}]
+	}`)
+
+	output := ConvertOpenAIResponsesRequestToCodex("gpt-5.3-codex", inputJSON, false)
+	if gjson.GetBytes(output, "service_tier").Exists() {
+		t.Fatalf("service_tier should be removed when not priority, body=%s", string(output))
+	}
+}


### PR DESCRIPTION
## Summary
- add translator coverage to ensure `service_tier: "priority"` is preserved for Codex requests
- add translator coverage to ensure non-priority `service_tier` values are still stripped
- add executor coverage to ensure the translated `priority` tier is actually forwarded to Codex upstream

## Why these tests matter
This PR is intentionally test-only.

The purpose is to lock an existing behavior that is easy to regress:
- real Codex CLI fast mode is not sent as `fast_mode=true`
- the CLI maps local `service_tier = "fast"` to request payload `service_tier: "priority"`
- Codex forwarding needs to preserve that `priority` value all the way through translation and executor forwarding

Without explicit coverage here, a future cleanup that removes or normalizes `service_tier` too aggressively could silently disable fast mode forwarding while requests still appear to work.

These tests make that contract explicit at both layers:
- translator layer: `priority` must survive translation, other unsupported tiers must not
- executor layer: the preserved `priority` tier must actually reach Codex upstream

## Tests
- `go test ./internal/translator/codex/openai/responses -count=1`
- `go test ./internal/runtime/executor -count=1`
