### PR TITLE
fix: strip -customtools variant suffix for provider and auth lookup

### DIFF
--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -757,6 +757,16 @@ func (r *ModelRegistry) ClientSupportsModel(clientID, modelID string) bool {
 		}
 	}
 
+	// Fallback: strip known model variant suffixes (e.g. "-customtools").
+	// These variants share the same provider as the base model.
+	if stripped := StripModelVariantSuffix(modelID); stripped != modelID {
+		for _, id := range models {
+			if strings.EqualFold(strings.TrimSpace(id), stripped) {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 

--- a/internal/registry/model_variants.go
+++ b/internal/registry/model_variants.go
@@ -1,0 +1,53 @@
+// Package registry — model variant suffix normalization.
+//
+// Google's Gemini CLI appends behavioural fine-tune markers such as
+// "-customtools" to model names when it detects an API key. These variants
+// share the same upstream provider/executor as the base model, but several
+// CPA code paths — provider lookup, auth selection, OAuth /v1internal routing
+// — only know the base model name and therefore fail when the suffixed name
+// is propagated downstream.
+//
+// StripModelVariantSuffix removes these variant markers while preserving
+// thinking-budget suffixes like "(8192)" / "(high)" and chained segments like
+// "-thinking". It is the single source of truth for variant normalization
+// across the request path, auth selection path, and capability probes.
+package registry
+
+import "strings"
+
+// knownModelVariantSuffixes lists the variant markers (including the leading
+// dash) that are safe to strip for provider/auth lookup. Adding new entries
+// here automatically covers every call site through StripModelVariantSuffix.
+var knownModelVariantSuffixes = []string{"-customtools"}
+
+// StripModelVariantSuffix removes every known variant marker from model,
+// regardless of its position in the name, as long as the match falls on a
+// segment boundary ('-', '(', or end-of-string).
+//
+// Examples:
+//
+//	"gemini-3.1-pro-preview-customtools"         -> "gemini-3.1-pro-preview"
+//	"gemini-3.1-pro-preview-customtools(8192)"   -> "gemini-3.1-pro-preview(8192)"
+//	"gemini-3.1-pro-preview-customtools(high)"   -> "gemini-3.1-pro-preview(high)"
+//	"gemini-2.0-flash-customtools-thinking"      -> "gemini-2.0-flash-thinking"
+//	"gemini-2.0-flash-customtools-thinking(4096)" -> "gemini-2.0-flash-thinking(4096)"
+//	"gemini-2.5-pro"                             -> "gemini-2.5-pro" (unchanged)
+//
+// The function is idempotent and never panics on empty input.
+func StripModelVariantSuffix(model string) string {
+	if model == "" {
+		return model
+	}
+	result := model
+	for _, variant := range knownModelVariantSuffixes {
+		// Order matters: strip thinking-budget-adjacent occurrences first
+		// ("-customtools(8192)" -> "(8192)"), then chained segments
+		// ("-customtools-thinking" -> "-thinking"), then any terminal form.
+		result = strings.ReplaceAll(result, variant+"(", "(")
+		result = strings.ReplaceAll(result, variant+"-", "-")
+		if strings.HasSuffix(result, variant) {
+			result = strings.TrimSuffix(result, variant)
+		}
+	}
+	return result
+}

--- a/internal/registry/model_variants_test.go
+++ b/internal/registry/model_variants_test.go
@@ -1,0 +1,45 @@
+package registry
+
+import "testing"
+
+func TestStripModelVariantSuffix(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"empty", "", ""},
+		{"no variant", "gemini-2.5-pro", "gemini-2.5-pro"},
+		{"terminal", "gemini-3.1-pro-preview-customtools", "gemini-3.1-pro-preview"},
+		{"with thinking int", "gemini-3.1-pro-preview-customtools(8192)", "gemini-3.1-pro-preview(8192)"},
+		{"with thinking level", "gemini-3.1-pro-preview-customtools(high)", "gemini-3.1-pro-preview(high)"},
+		{"with thinking auto", "gemini-3.1-pro-preview-customtools(auto)", "gemini-3.1-pro-preview(auto)"},
+		{"chained segment", "gemini-2.0-flash-customtools-thinking", "gemini-2.0-flash-thinking"},
+		{"chained with level", "gemini-2.0-flash-customtools-thinking(4096)", "gemini-2.0-flash-thinking(4096)"},
+		{"trailing after thinking suffix order", "gemini-2.0-flash-thinking-exp-customtools", "gemini-2.0-flash-thinking-exp"},
+		{"trailing with thinking after customtools", "gemini-2.0-flash-thinking-exp-customtools(8192)", "gemini-2.0-flash-thinking-exp(8192)"},
+		{"double customtools", "gemini-foo-customtools-customtools", "gemini-foo"},
+		{"no partial match", "gemini-customtoolsextra", "gemini-customtoolsextra"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StripModelVariantSuffix(tc.in)
+			if got != tc.want {
+				t.Fatalf("StripModelVariantSuffix(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripModelVariantSuffixIdempotent(t *testing.T) {
+	inputs := []string{
+		"gemini-3.1-pro-preview-customtools(8192)",
+		"gemini-2.0-flash-customtools-thinking",
+		"gemini-2.5-pro",
+	}
+	for _, in := range inputs {
+		once := StripModelVariantSuffix(in)
+		twice := StripModelVariantSuffix(once)
+		if once != twice {
+			t.Fatalf("StripModelVariantSuffix not idempotent for %q: %q vs %q", in, once, twice)
+		}
+	}
+}

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -1492,6 +1493,25 @@ func (h *BaseAPIHandler) getRequestDetailsWithOptions(modelName string, allowIma
 	// custom model registrations that include thinking suffixes.
 	if len(providers) == 0 && baseModel != resolvedModelName {
 		providers = util.GetProviderName(resolvedModelName)
+	}
+
+	// Fallback: strip known model variant suffixes (e.g. "-customtools") for
+	// provider lookup. When a match is found, both baseModel and
+	// resolvedModelName are normalized because CPA routes gemini-cli through
+	// cloudcode-pa/v1internal (OAuth) which rejects variant suffixes with 404.
+	// The behavioral difference is minor: -customtools only changes tool
+	// selection priority (prefers custom tools over bash), not model
+	// capabilities. registry.StripModelVariantSuffix handles thinking-budget
+	// suffixes like "(8192)" and chained segments like "-thinking" so the
+	// strip is safe for resolvedModelName even when a thinking suffix is
+	// preserved.
+	if len(providers) == 0 {
+		if stripped := registry.StripModelVariantSuffix(baseModel); stripped != baseModel {
+			providers = util.GetProviderName(stripped)
+			if len(providers) > 0 {
+				resolvedModelName = registry.StripModelVariantSuffix(resolvedModelName)
+			}
+		}
 	}
 
 	if len(providers) == 0 {


### PR DESCRIPTION
## Summary
- Google's Gemini CLI appends `-customtools` to model names for a behavioral fine-tune variant. CPA doesn't recognize these suffixed names, causing **502 errors** for all Gemini CLI users when this suffix is active.
- Adds `stripModelVariantSuffix()` fallback at two points:
  1. `getRequestDetails()` in `handlers.go` — provider lookup
  2. `ClientSupportsModel()` in `model_registry.go` — auth selection
- The suffix is stripped **only** when the original name yields no matches, preserving existing behavior.

## Files changed
- `sdk/api/handlers/handlers.go` — variant suffix stripping in provider lookup
- `internal/registry/model_registry.go` — variant suffix stripping in client model support check

## Test plan
- [ ] Send request with model `gemini-2.5-pro-preview-05-06-customtools` through CPA
- [ ] Verify provider is resolved correctly (no 502)
- [ ] Verify standard model names without suffix still work as before