### PR TITLE
feat: bypass proxy for private/LAN IPs in management api-call

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -175,7 +176,7 @@ func (h *Handler) APICall(c *gin.Context) {
 	httpClient := &http.Client{
 		Timeout: defaultAPICallTimeout,
 	}
-	httpClient.Transport = h.apiCallTransport(auth)
+	httpClient.Transport = h.apiCallTransport(auth, parsedURL.Host)
 
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
@@ -283,7 +284,7 @@ func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *
 
 	httpClient := &http.Client{
 		Timeout:   defaultAPICallTimeout,
-		Transport: h.apiCallTransport(auth),
+		Transport: h.apiCallTransport(auth, ""),
 	}
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
@@ -469,7 +470,128 @@ func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {
 	return nil
 }
 
-func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
+// defaultNoProxyCIDRs are RFC 1918 / RFC 4193 private ranges, loopback,
+// and link-local. These destinations are unreachable through a typical
+// external HTTP proxy, so management requests targeting them short-circuit
+// straight to a direct transport.
+var defaultNoProxyCIDRs = []string{
+	"127.0.0.0/8",
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"169.254.0.0/16",
+	"::1/128",
+	"fc00::/7",
+	"fe80::/10",
+}
+
+// isNoProxyHost returns true when targetHost should bypass the proxy.
+// It accepts:
+//   - literal IPv4/IPv6 addresses ("10.0.0.5", "::1")
+//   - bracketed IPv6 literals ("[::1]", "[fe80::1%eth0]")
+//   - host:port forms ("nas.lan:8080", "[::1]:443")
+//   - hostnames ("localhost", "nas.lan", "printer.local")
+//
+// Hostnames are resolved via the default resolver using a short timeout.
+// Every address the hostname resolves to must fall inside the configured
+// no-proxy CIDRs; a single public address disables the bypass to avoid
+// leaking LAN DNS poisoning into external traffic. Resolution failures
+// leave the bypass disabled so the proxy still has a chance to reach the
+// target.
+func (h *Handler) isNoProxyHost(targetHost string) bool {
+	host := strings.TrimSpace(targetHost)
+	if host == "" {
+		return false
+	}
+	// Strip port if present. SplitHostPort handles "host:port" and
+	// "[ipv6]:port"; for bare hosts it errors out and we keep host as-is.
+	if stripped, _, errSplit := net.SplitHostPort(host); errSplit == nil {
+		host = stripped
+	}
+	// Strip IPv6 brackets for bare "[::1]" form (no port).
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = host[1 : len(host)-1]
+	}
+	// Trim IPv6 zone identifier ("fe80::1%eth0") before parsing.
+	if idx := strings.IndexByte(host, '%'); idx >= 0 {
+		host = host[:idx]
+	}
+	if host == "" {
+		return false
+	}
+
+	cidrs := defaultNoProxyCIDRs
+	if h != nil && h.cfg != nil && len(h.cfg.NoProxyCIDRs) > 0 {
+		cidrs = h.cfg.NoProxyCIDRs
+	}
+
+	// Case 1: literal IP.
+	if ip := net.ParseIP(host); ip != nil {
+		return ipInNoProxyRanges(ip, cidrs)
+	}
+
+	// Case 2: "localhost" is a universally understood loopback alias.
+	// Treat it as no-proxy regardless of DNS (some resolvers map it to
+	// 127.0.0.1 but CI/test environments may not).
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+
+	// Case 3: hostname. Resolve with a short timeout so a slow or missing
+	// DNS entry does not block the management request.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	ips, errResolve := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if errResolve != nil || len(ips) == 0 {
+		// Unresolvable hostname — let the proxy handle it.
+		return false
+	}
+	for _, addr := range ips {
+		if !ipInNoProxyRanges(addr.IP, cidrs) {
+			// Any public address disables the bypass.
+			return false
+		}
+	}
+	return true
+}
+
+// ipInNoProxyRanges reports whether ip matches any entry in cidrs. Entries
+// that are not valid CIDRs are compared as literal IP strings.
+func ipInNoProxyRanges(ip net.IP, cidrs []string) bool {
+	if ip == nil {
+		return false
+	}
+	for _, cidr := range cidrs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			if cidr == ip.String() {
+				return true
+			}
+			continue
+		}
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *Handler) apiCallTransport(auth *coreauth.Auth, targetHost string) http.RoundTripper {
+	// Short-circuit: any target host that falls inside the configured
+	// no-proxy ranges goes out directly, regardless of per-auth or
+	// per-API-key proxy settings. This keeps management Pick-Models
+	// requests to LAN targets (e.g. LM Studio on 172.20.0.0/12) from
+	// timing out through a global proxy that cannot reach the LAN.
+	if h.isNoProxyHost(targetHost) {
+		transport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok || transport == nil {
+			return &http.Transport{Proxy: nil}
+		}
+		clone := transport.Clone()
+		clone.Proxy = nil
+		return clone
+	}
+
 	var proxyCandidates []string
 	if auth != nil {
 		if proxyStr := strings.TrimSpace(auth.ProxyURL); proxyStr != "" {

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -19,7 +19,7 @@ func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 		},
 	}
 
-	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "direct"})
+	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "direct"}, "")
 	httpTransport, ok := transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", transport)
@@ -38,7 +38,7 @@ func TestAPICallTransportInvalidAuthFallsBackToGlobalProxy(t *testing.T) {
 		},
 	}
 
-	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "bad-value"})
+	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "bad-value"}, "")
 	httpTransport, ok := transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", transport)
@@ -135,7 +135,7 @@ func TestAPICallTransportAPIKeyAuthFallsBackToConfigProxyURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			transport := h.apiCallTransport(tc.auth)
+			transport := h.apiCallTransport(tc.auth, "")
 			httpTransport, ok := transport.(*http.Transport)
 			if !ok {
 				t.Fatalf("transport type = %T, want *http.Transport", transport)
@@ -208,5 +208,96 @@ func TestAuthByIndexDistinguishesSharedAPIKeysAcrossProviders(t *testing.T) {
 	}
 	if gotCompat.ID != compatAuth.ID {
 		t.Fatalf("authByIndex(compat) returned %q, want %q", gotCompat.ID, compatAuth.ID)
+	}
+}
+
+func TestIsNoProxyHost(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{cfg: &config.Config{}}
+
+	cases := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{"empty host", "", false},
+		{"ipv4 private /8", "10.0.0.5", true},
+		{"ipv4 private /12", "172.20.23.32", true},
+		{"ipv4 private /16", "192.168.1.50", true},
+		{"ipv4 loopback", "127.0.0.1", true},
+		{"ipv4 link-local", "169.254.1.1", true},
+		{"ipv4 public", "8.8.8.8", false},
+		{"ipv4 with port", "10.0.0.5:8080", true},
+		{"ipv6 loopback bare", "::1", true},
+		{"ipv6 loopback bracketed", "[::1]", true},
+		{"ipv6 loopback with port", "[::1]:443", true},
+		{"ipv6 link-local with zone", "fe80::1%eth0", true},
+		{"ipv6 ula", "fd00::1", true},
+		{"ipv6 public", "2001:4860:4860::8888", false},
+		{"localhost literal", "localhost", true},
+		{"localhost with port", "localhost:1234", true},
+		{"localhost case", "LOCALHOST", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := h.isNoProxyHost(tc.host)
+			if got != tc.want {
+				t.Fatalf("isNoProxyHost(%q) = %v, want %v", tc.host, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAPICallTransportBypassesProxyForPrivateIP(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://global-proxy.example.com:8080"},
+		},
+	}
+
+	// LAN IP (LM Studio on local network) must bypass the global proxy so
+	// the management Pick-Models request can reach it directly.
+	transport := h.apiCallTransport(&coreauth.Auth{}, "172.20.23.32:1234")
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", transport)
+	}
+	if httpTransport.Proxy != nil {
+		req, _ := http.NewRequest(http.MethodGet, "http://172.20.23.32:1234/", nil)
+		if proxyURL, _ := httpTransport.Proxy(req); proxyURL != nil {
+			t.Fatalf("expected no proxy for LAN IP, got %v", proxyURL)
+		}
+	}
+}
+
+func TestAPICallTransportUsesProxyForPublicIP(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://global-proxy.example.com:8080"},
+		},
+	}
+
+	transport := h.apiCallTransport(&coreauth.Auth{}, "api.openai.com:443")
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", transport)
+	}
+	req, errRequest := http.NewRequest(http.MethodGet, "https://api.openai.com", nil)
+	if errRequest != nil {
+		t.Fatalf("http.NewRequest returned error: %v", errRequest)
+	}
+	proxyURL, errProxy := httpTransport.Proxy(req)
+	if errProxy != nil {
+		t.Fatalf("httpTransport.Proxy returned error: %v", errProxy)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://global-proxy.example.com:8080" {
+		t.Fatalf("proxy URL = %v, want http://global-proxy.example.com:8080", proxyURL)
 	}
 }

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -34,6 +34,17 @@ type SDKConfig struct {
 	// Empty or invalid values use the default 3h.
 	VideoResultAuthCacheTTL string `yaml:"video-result-auth-cache-ttl,omitempty" json:"video-result-auth-cache-ttl,omitempty"`
 
+	// NoProxyCIDRs lists CIDRs or literal IPs whose targets should bypass the
+	// configured ProxyURL. Management api-call requests to hosts falling
+	// inside these ranges are sent directly instead of being routed through
+	// the proxy. Applies to literal IPs and hostnames that resolve to IPs
+	// inside the list.
+	//
+	// Defaults (used when this field is empty): 127.0.0.0/8, 10.0.0.0/8,
+	// 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, ::1/128, fc00::/7,
+	// fe80::/10. Specifying any value here REPLACES the defaults.
+	NoProxyCIDRs []string `yaml:"no-proxy-cidrs,omitempty" json:"no-proxy-cidrs,omitempty"`
+
 	// ForceModelPrefix requires explicit model prefixes (e.g., "teamA/gemini-3-pro-preview")
 	// to target prefixed credentials. When false, unprefixed model requests may use prefixed
 	// credentials as well.


### PR DESCRIPTION
## Summary
- When a global proxy is configured, the management `api-call` handler routes **all** requests through it — including requests to LAN targets (e.g. LM Studio at `172.x.x.x`). Since proxies typically cannot reach private networks, these requests **time out**.
- The Management UI "Pick Models from /models" feature becomes unusable for any LAN-hosted provider when a proxy is configured.
- Adds `isNoProxyHost()` that detects RFC 1918, loopback, and link-local addresses and skips the proxy for them.
- Only affects the management api-call handler; executor proxy logic is unchanged.

## Default bypass ranges
`127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `::1/128`, `fc00::/7`, `fe80::/10`

## Files changed
- `internal/api/handlers/management/api_tools.go`

## Test plan
- [ ] Configure global proxy in config.yaml
- [ ] Use Management UI "Pick Models" with a LAN target (e.g. `http://192.168.1.100:1234/v1/models`)
- [ ] Verify models are fetched successfully (no timeout)
- [ ] Verify external targets still route through proxy