### PR TITLE
feat: add OpenAI-compatible Gemini embeddings endpoint

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -323,6 +323,7 @@ func (s *Server) setupRoutes() {
 		v1.GET("/models", s.unifiedModelsHandler(openaiHandlers, claudeCodeHandlers))
 		v1.POST("/chat/completions", openaiHandlers.ChatCompletions)
 		v1.POST("/completions", openaiHandlers.Completions)
+		v1.POST("/embeddings", openaiHandlers.Embeddings)
 		v1.POST("/messages", claudeCodeHandlers.ClaudeMessages)
 		v1.POST("/messages/count_tokens", claudeCodeHandlers.ClaudeCountTokens)
 		v1.POST("/responses", openaiResponsesHandlers.Responses)
@@ -345,6 +346,7 @@ func (s *Server) setupRoutes() {
 			"endpoints": []string{
 				"POST /v1/chat/completions",
 				"POST /v1/completions",
+				"POST /v1/embeddings",
 				"GET /v1/models",
 			},
 		})

--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -147,6 +147,18 @@ func GetGeminiModels() []*ModelInfo {
 			Thinking:                   &ThinkingSupport{Min: 0, Max: 24576, ZeroAllowed: true, DynamicAllowed: true},
 		},
 		{
+			ID:                         "gemini-embedding-001",
+			Object:                     "model",
+			Created:                    1740787200,
+			OwnedBy:                    "google",
+			Type:                       "gemini",
+			Name:                       "models/gemini-embedding-001",
+			Version:                    "001",
+			DisplayName:                "Gemini Embedding 001",
+			Description:                "Google Gemini text embedding model.",
+			SupportedGenerationMethods: []string{"embedContent", "batchEmbedContents"},
+		},
+		{
 			ID:                         "gemini-3-pro-preview",
 			Object:                     "model",
 			Created:                    1737158400,

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -659,6 +659,11 @@ func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string
 	return providers, resolvedModelName, nil
 }
 
+// GetRequestDetails resolves the provider set and normalized model name for an incoming request.
+func (h *BaseAPIHandler) GetRequestDetails(modelName string) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
+	return h.getRequestDetails(modelName)
+}
+
 func cloneBytes(src []byte) []byte {
 	if len(src) == 0 {
 		return nil

--- a/sdk/api/handlers/openai/openai_embeddings.go
+++ b/sdk/api/handlers/openai/openai_embeddings.go
@@ -1,0 +1,498 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+const geminiGenerativeLanguageBaseURL = "https://generativelanguage.googleapis.com"
+
+type openAIEmbeddingsRequest struct {
+	Model          string          `json:"model"`
+	Input          json.RawMessage `json:"input"`
+	EncodingFormat string          `json:"encoding_format,omitempty"`
+	Dimensions     int             `json:"dimensions,omitempty"`
+}
+
+type openAIEmbeddingsResponse struct {
+	Object string                  `json:"object"`
+	Data   []openAIEmbeddingRecord `json:"data"`
+	Model  string                  `json:"model"`
+	Usage  openAIEmbeddingsUsage   `json:"usage"`
+}
+
+type openAIEmbeddingRecord struct {
+	Object    string    `json:"object"`
+	Embedding []float64 `json:"embedding"`
+	Index     int       `json:"index"`
+}
+
+type openAIEmbeddingsUsage struct {
+	PromptTokens int `json:"prompt_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}
+
+// Embeddings handles the OpenAI-compatible /v1/embeddings endpoint.
+// It currently translates Gemini embedding requests into the OpenAI embeddings shape.
+func (h *OpenAIAPIHandler) Embeddings(c *gin.Context) {
+	rawJSON, err := c.GetRawData()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{
+				Message: fmt.Sprintf("Invalid request: %v", err),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
+	req, errMsg := parseOpenAIEmbeddingsRequest(rawJSON)
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		return
+	}
+
+	c.Header("Content-Type", "application/json")
+	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
+	resp, execErr := h.executeEmbeddings(cliCtx, req)
+	stopKeepAlive()
+	if execErr != nil {
+		h.WriteErrorResponse(c, execErr)
+		cliCancel(execErr.Error)
+		return
+	}
+
+	_, _ = c.Writer.Write(resp)
+	cliCancel()
+}
+
+func parseOpenAIEmbeddingsRequest(rawJSON []byte) (*openAIEmbeddingsRequest, *interfaces.ErrorMessage) {
+	var req openAIEmbeddingsRequest
+	if err := json.Unmarshal(rawJSON, &req); err != nil {
+		return nil, invalidEmbeddingsRequest(fmt.Sprintf("invalid JSON: %v", err))
+	}
+
+	req.Model = normalizeEmbeddingModelName(req.Model)
+	if req.Model == "" {
+		return nil, invalidEmbeddingsRequest("model is required")
+	}
+
+	encodingFormat := strings.ToLower(strings.TrimSpace(req.EncodingFormat))
+	switch encodingFormat {
+	case "", "float":
+		req.EncodingFormat = "float"
+	case "base64":
+		// The OpenAI SDK can request base64 by default for embeddings.
+		// We still return float vectors so existing downstream callers keep working.
+		req.EncodingFormat = encodingFormat
+	default:
+		return nil, invalidEmbeddingsRequest("only encoding_format=float or base64 is supported")
+	}
+
+	if len(bytes.TrimSpace(req.Input)) == 0 {
+		return nil, invalidEmbeddingsRequest("input is required")
+	}
+
+	inputs, err := parseEmbeddingInputs(req.Input)
+	if err != nil {
+		return nil, invalidEmbeddingsRequest(err.Error())
+	}
+	if len(inputs) == 0 {
+		return nil, invalidEmbeddingsRequest("input must not be empty")
+	}
+
+	return &req, nil
+}
+
+func parseEmbeddingInputs(raw json.RawMessage) ([]string, error) {
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return []string{single}, nil
+	}
+
+	var many []string
+	if err := json.Unmarshal(raw, &many); err == nil {
+		if len(many) == 0 {
+			return nil, fmt.Errorf("input array must not be empty")
+		}
+		return many, nil
+	}
+
+	return nil, fmt.Errorf("input must be a string or an array of strings")
+}
+
+func invalidEmbeddingsRequest(message string) *interfaces.ErrorMessage {
+	return &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadRequest,
+		Error:      errors.New(message),
+	}
+}
+
+func normalizeEmbeddingModelName(model string) string {
+	model = strings.TrimSpace(model)
+	return strings.TrimPrefix(model, "models/")
+}
+
+func (h *OpenAIAPIHandler) executeEmbeddings(ctx context.Context, req *openAIEmbeddingsRequest) ([]byte, *interfaces.ErrorMessage) {
+	if h == nil || h.AuthManager == nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusInternalServerError,
+			Error:      fmt.Errorf("auth manager is unavailable"),
+		}
+	}
+
+	auth, normalizedModel, errMsg := h.selectEmbeddingAuth(ctx, req.Model)
+	if errMsg != nil {
+		return nil, errMsg
+	}
+
+	switch strings.ToLower(strings.TrimSpace(auth.Provider)) {
+	case "gemini":
+		return h.executeGeminiEmbeddings(ctx, auth, normalizedModel, req)
+	case "gemini-cli":
+		return h.executeGeminiCLIEmbeddingsViaVertex(ctx, auth, normalizedModel, req)
+	default:
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadRequest,
+			Error:      fmt.Errorf("provider %s does not support /v1/embeddings", auth.Provider),
+		}
+	}
+}
+
+func (h *OpenAIAPIHandler) selectEmbeddingAuth(ctx context.Context, model string) (*coreauth.Auth, string, *interfaces.ErrorMessage) {
+	providers, normalizedModel, errMsg := h.GetRequestDetails(model)
+	if errMsg == nil {
+		auth, err := h.AuthManager.SelectAuthForModel(ctx, providers, normalizedModel, coreexecutor.Options{})
+		if err == nil {
+			return auth, normalizedModel, nil
+		}
+		status := http.StatusInternalServerError
+		if se, ok := err.(interface{ StatusCode() int }); ok && se != nil && se.StatusCode() > 0 {
+			status = se.StatusCode()
+		}
+		return nil, "", &interfaces.ErrorMessage{StatusCode: status, Error: err}
+	}
+
+	normalizedModel = normalizeEmbeddingModelName(model)
+	if normalizedModel == "gemini-embedding-001" {
+		for _, auth := range h.AuthManager.List() {
+			if auth == nil || auth.Disabled {
+				continue
+			}
+			provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+			if provider == "gemini" || provider == "gemini-cli" {
+				return auth, normalizedModel, nil
+			}
+		}
+	}
+
+	return nil, "", errMsg
+}
+
+func (h *OpenAIAPIHandler) executeGeminiEmbeddings(ctx context.Context, auth *coreauth.Auth, model string, req *openAIEmbeddingsRequest) ([]byte, *interfaces.ErrorMessage) {
+	inputs, err := parseEmbeddingInputs(req.Input)
+	if err != nil {
+		return nil, invalidEmbeddingsRequest(err.Error())
+	}
+
+	endpointURL, payload, err := buildGeminiEmbeddingRequest(auth, model, inputs, req.Dimensions)
+	if err != nil {
+		return nil, invalidEmbeddingsRequest(err.Error())
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusInternalServerError,
+			Error:      err,
+		}
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusInternalServerError,
+			Error:      err,
+		}
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := h.AuthManager.HttpRequest(ctx, auth, httpReq)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if se, ok := err.(interface{ StatusCode() int }); ok && se != nil && se.StatusCode() > 0 {
+			status = se.StatusCode()
+		}
+		return nil, &interfaces.ErrorMessage{StatusCode: status, Error: err}
+	}
+	defer func() {
+		_ = httpResp.Body.Close()
+	}()
+
+	respBody, readErr := io.ReadAll(httpResp.Body)
+	if readErr != nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusInternalServerError,
+			Error:      readErr,
+		}
+	}
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: httpResp.StatusCode,
+			Error:      errors.New(string(respBody)),
+		}
+	}
+
+	translated, err := convertGeminiEmbeddingResponseToOpenAI(model, respBody)
+	if err != nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadGateway,
+			Error:      fmt.Errorf("invalid Gemini embeddings response: %w", err),
+		}
+	}
+	return translated, nil
+}
+
+func (h *OpenAIAPIHandler) executeGeminiCLIEmbeddingsViaVertex(ctx context.Context, auth *coreauth.Auth, model string, req *openAIEmbeddingsRequest) ([]byte, *interfaces.ErrorMessage) {
+	inputs, err := parseEmbeddingInputs(req.Input)
+	if err != nil {
+		return nil, invalidEmbeddingsRequest(err.Error())
+	}
+
+	endpointURL, payload, err := buildVertexEmbeddingRequest(auth, model, inputs, req.Dimensions)
+	if err != nil {
+		return nil, invalidEmbeddingsRequest(err.Error())
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusInternalServerError,
+			Error:      err,
+		}
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusInternalServerError,
+			Error:      err,
+		}
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := h.AuthManager.HttpRequest(ctx, auth, httpReq)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if se, ok := err.(interface{ StatusCode() int }); ok && se != nil && se.StatusCode() > 0 {
+			status = se.StatusCode()
+		}
+		return nil, &interfaces.ErrorMessage{StatusCode: status, Error: err}
+	}
+	defer func() {
+		_ = httpResp.Body.Close()
+	}()
+
+	respBody, readErr := io.ReadAll(httpResp.Body)
+	if readErr != nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusInternalServerError,
+			Error:      readErr,
+		}
+	}
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: httpResp.StatusCode,
+			Error:      errors.New(string(respBody)),
+		}
+	}
+
+	translated, err := convertVertexEmbeddingResponseToOpenAI(model, respBody)
+	if err != nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadGateway,
+			Error:      fmt.Errorf("invalid Vertex embeddings response: %w", err),
+		}
+	}
+	return translated, nil
+}
+
+func buildGeminiEmbeddingRequest(auth *coreauth.Auth, model string, inputs []string, dimensions int) (string, any, error) {
+	model = normalizeEmbeddingModelName(model)
+	if model == "" {
+		return "", nil, fmt.Errorf("model is required")
+	}
+	baseURL := resolveGeminiEmbeddingBaseURL(auth)
+
+	escapedModel := url.PathEscape(model)
+	if len(inputs) == 1 {
+		payload := map[string]any{
+			"content": map[string]any{
+				"parts": []map[string]string{{"text": inputs[0]}},
+			},
+		}
+		if dimensions > 0 {
+			payload["outputDimensionality"] = dimensions
+		}
+		return fmt.Sprintf("%s/v1beta/models/%s:embedContent", baseURL, escapedModel), payload, nil
+	}
+
+	requests := make([]map[string]any, 0, len(inputs))
+	for _, input := range inputs {
+		entry := map[string]any{
+			"model": "models/" + model,
+			"content": map[string]any{
+				"parts": []map[string]string{{"text": input}},
+			},
+		}
+		if dimensions > 0 {
+			entry["outputDimensionality"] = dimensions
+		}
+		requests = append(requests, entry)
+	}
+
+	return fmt.Sprintf("%s/v1beta/models/%s:batchEmbedContents", baseURL, escapedModel), map[string]any{
+		"requests": requests,
+	}, nil
+}
+
+func resolveGeminiEmbeddingBaseURL(auth *coreauth.Auth) string {
+	baseURL := geminiGenerativeLanguageBaseURL
+	if auth != nil && auth.Attributes != nil {
+		if custom := strings.TrimSpace(auth.Attributes["base_url"]); custom != "" {
+			baseURL = strings.TrimRight(custom, "/")
+		}
+	}
+	if baseURL == "" {
+		return geminiGenerativeLanguageBaseURL
+	}
+	return baseURL
+}
+
+func buildVertexEmbeddingRequest(auth *coreauth.Auth, model string, inputs []string, dimensions int) (string, any, error) {
+	projectID := resolveGeminiCLIProjectID(auth)
+	if projectID == "" {
+		return "", nil, fmt.Errorf("missing Gemini project_id for Vertex embeddings")
+	}
+
+	// Vertex exposes text embedding models through PredictionService.
+	upstreamModel := "text-embedding-005"
+	instances := make([]map[string]any, 0, len(inputs))
+	for _, input := range inputs {
+		instances = append(instances, map[string]any{"content": input})
+	}
+	payload := map[string]any{
+		"instances": instances,
+	}
+	if dimensions > 0 {
+		payload["parameters"] = map[string]any{"outputDimensionality": dimensions}
+	}
+
+	url := fmt.Sprintf(
+		"https://us-central1-aiplatform.googleapis.com/v1/projects/%s/locations/us-central1/publishers/google/models/%s:predict",
+		url.PathEscape(projectID),
+		upstreamModel,
+	)
+	return url, payload, nil
+}
+
+func resolveGeminiCLIProjectID(auth *coreauth.Auth) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	if value, ok := auth.Metadata["project_id"].(string); ok {
+		return strings.TrimSpace(value)
+	}
+	return ""
+}
+
+func convertGeminiEmbeddingResponseToOpenAI(model string, rawJSON []byte) ([]byte, error) {
+	type geminiEmbeddingValues struct {
+		Values []float64 `json:"values"`
+	}
+	type geminiSingleEmbeddingResponse struct {
+		Embedding geminiEmbeddingValues `json:"embedding"`
+	}
+	type geminiBatchEmbeddingResponse struct {
+		Embeddings []geminiEmbeddingValues `json:"embeddings"`
+	}
+
+	var out openAIEmbeddingsResponse
+	out.Object = "list"
+	out.Model = normalizeEmbeddingModelName(model)
+
+	var single geminiSingleEmbeddingResponse
+	if err := json.Unmarshal(rawJSON, &single); err == nil && len(single.Embedding.Values) > 0 {
+		out.Data = []openAIEmbeddingRecord{{
+			Object:    "embedding",
+			Embedding: single.Embedding.Values,
+			Index:     0,
+		}}
+		return json.Marshal(out)
+	}
+
+	var batch geminiBatchEmbeddingResponse
+	if err := json.Unmarshal(rawJSON, &batch); err == nil && len(batch.Embeddings) > 0 {
+		out.Data = make([]openAIEmbeddingRecord, 0, len(batch.Embeddings))
+		for i, embedding := range batch.Embeddings {
+			out.Data = append(out.Data, openAIEmbeddingRecord{
+				Object:    "embedding",
+				Embedding: embedding.Values,
+				Index:     i,
+			})
+		}
+		return json.Marshal(out)
+	}
+
+	return nil, fmt.Errorf("missing embedding values")
+}
+
+func convertVertexEmbeddingResponseToOpenAI(model string, rawJSON []byte) ([]byte, error) {
+	type vertexEmbedding struct {
+		Embeddings struct {
+			Values []float64 `json:"values"`
+		} `json:"embeddings"`
+	}
+	type vertexResponse struct {
+		Predictions []vertexEmbedding `json:"predictions"`
+	}
+
+	var response vertexResponse
+	if err := json.Unmarshal(rawJSON, &response); err != nil {
+		return nil, err
+	}
+	if len(response.Predictions) == 0 {
+		return nil, fmt.Errorf("missing predictions")
+	}
+
+	out := openAIEmbeddingsResponse{
+		Object: "list",
+		Model:  normalizeEmbeddingModelName(model),
+	}
+	out.Data = make([]openAIEmbeddingRecord, 0, len(response.Predictions))
+	for i, prediction := range response.Predictions {
+		if len(prediction.Embeddings.Values) == 0 {
+			return nil, fmt.Errorf("missing embedding values")
+		}
+		out.Data = append(out.Data, openAIEmbeddingRecord{
+			Object:    "embedding",
+			Embedding: prediction.Embeddings.Values,
+			Index:     i,
+		})
+	}
+	return json.Marshal(out)
+}

--- a/sdk/api/handlers/openai/openai_embeddings_test.go
+++ b/sdk/api/handlers/openai/openai_embeddings_test.go
@@ -1,0 +1,197 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	"github.com/tidwall/gjson"
+)
+
+type embeddingCaptureExecutor struct {
+	lastURL    string
+	lastMethod string
+	lastBody   string
+	respBody   string
+}
+
+func (e *embeddingCaptureExecutor) Identifier() string { return "gemini" }
+
+func (e *embeddingCaptureExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *embeddingCaptureExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (<-chan coreexecutor.StreamChunk, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *embeddingCaptureExecutor) Refresh(ctx context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *embeddingCaptureExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *embeddingCaptureExecutor) HttpRequest(_ context.Context, _ *coreauth.Auth, req *http.Request) (*http.Response, error) {
+	body, _ := io.ReadAll(req.Body)
+	e.lastURL = req.URL.String()
+	e.lastMethod = req.Method
+	e.lastBody = string(body)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(e.respBody)),
+	}, nil
+}
+
+func registerEmbeddingTestAuth(t *testing.T, executor *embeddingCaptureExecutor) (*coreauth.Manager, string) {
+	t.Helper()
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "gemini-embed-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{
+		{ID: "gemini-embedding-001"},
+	})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+	return manager, auth.ID
+}
+
+func TestOpenAIEmbeddingsSingleInputUsesGeminiEmbedContent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &embeddingCaptureExecutor{
+		respBody: `{"embedding":{"values":[0.1,0.2,0.3]}}`,
+	}
+	manager, _ := registerEmbeddingTestAuth(t, executor)
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/embeddings", h.Embeddings)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", strings.NewReader(`{"model":"gemini-embedding-001","input":"hello","dimensions":3}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusOK)
+	}
+	if executor.lastMethod != http.MethodPost {
+		t.Fatalf("method = %q, want %q", executor.lastMethod, http.MethodPost)
+	}
+	if !strings.Contains(executor.lastURL, "/v1beta/models/gemini-embedding-001:embedContent") {
+		t.Fatalf("url = %q, want embedContent route", executor.lastURL)
+	}
+	if got := gjson.Get(executor.lastBody, "content.parts.0.text").String(); got != "hello" {
+		t.Fatalf("request text = %q, want %q", got, "hello")
+	}
+	if got := gjson.Get(executor.lastBody, "outputDimensionality").Int(); got != 3 {
+		t.Fatalf("outputDimensionality = %d, want 3", got)
+	}
+	if got := gjson.Get(resp.Body.String(), "data.0.embedding.1").Float(); got != 0.2 {
+		t.Fatalf("response embedding = %v, want 0.2 at index 1", got)
+	}
+}
+
+func TestOpenAIEmbeddingsBatchInputUsesGeminiBatchEmbedContents(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &embeddingCaptureExecutor{
+		respBody: `{"embeddings":[{"values":[1,2]},{"values":[3,4]}]}`,
+	}
+	manager, _ := registerEmbeddingTestAuth(t, executor)
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/embeddings", h.Embeddings)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", strings.NewReader(`{"model":"gemini-embedding-001","input":["alpha","beta"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusOK)
+	}
+	if !strings.Contains(executor.lastURL, "/v1beta/models/gemini-embedding-001:batchEmbedContents") {
+		t.Fatalf("url = %q, want batchEmbedContents route", executor.lastURL)
+	}
+	if got := gjson.Get(executor.lastBody, "requests.0.content.parts.0.text").String(); got != "alpha" {
+		t.Fatalf("first request text = %q, want %q", got, "alpha")
+	}
+	if got := gjson.Get(executor.lastBody, "requests.1.content.parts.0.text").String(); got != "beta" {
+		t.Fatalf("second request text = %q, want %q", got, "beta")
+	}
+	if got := len(gjson.Get(resp.Body.String(), "data").Array()); got != 2 {
+		t.Fatalf("response embeddings count = %d, want 2", got)
+	}
+}
+
+func TestOpenAIEmbeddingsAcceptsBase64EncodingFormat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &embeddingCaptureExecutor{
+		respBody: `{"embedding":{"values":[0.5,0.25]}}`,
+	}
+	manager, _ := registerEmbeddingTestAuth(t, executor)
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/embeddings", h.Embeddings)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", strings.NewReader(`{"model":"gemini-embedding-001","input":"hello","encoding_format":"base64"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusOK)
+	}
+	if got := gjson.Get(resp.Body.String(), "data.0.embedding.0").Float(); got != 0.5 {
+		t.Fatalf("response embedding = %v, want 0.5 at index 0", got)
+	}
+}
+
+func TestOpenAIModelsIncludesGeminiEmbeddingWhenGeminiAuthExists(t *testing.T) {
+	executor := &embeddingCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "gemini-model-list-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIAPIHandler(base)
+	models := h.Models()
+
+	found := false
+	for _, model := range models {
+		if id, _ := model["id"].(string); id == "gemini-embedding-001" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("gemini-embedding-001 not found in models list")
+	}
+}

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin"
@@ -52,7 +53,53 @@ func (h *OpenAIAPIHandler) HandlerType() string {
 func (h *OpenAIAPIHandler) Models() []map[string]any {
 	// Get dynamic models from the global registry
 	modelRegistry := registry.GetGlobalRegistry()
-	return modelRegistry.GetAvailableModels("openai")
+	models := modelRegistry.GetAvailableModels("openai")
+	if h.hasProviderAuth("gemini", "gemini-cli") && !containsModelID(models, "gemini-embedding-001") {
+		if info := registry.LookupStaticModelInfo("gemini-embedding-001"); info != nil {
+			models = append(models, map[string]any{
+				"id":       info.ID,
+				"object":   info.Object,
+				"created":  info.Created,
+				"owned_by": info.OwnedBy,
+			})
+		}
+	}
+	return models
+}
+
+func (h *OpenAIAPIHandler) hasProviderAuth(providers ...string) bool {
+	if h == nil || h.AuthManager == nil {
+		return false
+	}
+	allowed := make(map[string]struct{}, len(providers))
+	for _, provider := range providers {
+		key := strings.ToLower(strings.TrimSpace(provider))
+		if key == "" {
+			continue
+		}
+		allowed[key] = struct{}{}
+	}
+	if len(allowed) == 0 {
+		return false
+	}
+	for _, auth := range h.AuthManager.List() {
+		if auth == nil || auth.Disabled {
+			continue
+		}
+		if _, ok := allowed[strings.ToLower(strings.TrimSpace(auth.Provider))]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func containsModelID(models []map[string]any, modelID string) bool {
+	for _, model := range models {
+		if id, _ := model["id"].(string); id == modelID {
+			return true
+		}
+	}
+	return false
 }
 
 // OpenAIModels handles the /v1/models endpoint.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1528,6 +1528,40 @@ func (m *Manager) GetByID(id string) (*Auth, bool) {
 	return auth.Clone(), true
 }
 
+// SelectAuthForModel resolves the next available auth for the supplied model and provider set
+// using the manager's normal selection logic without executing a translated request.
+func (m *Manager) SelectAuthForModel(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options) (*Auth, error) {
+	if m == nil {
+		return nil, &Error{Code: "provider_not_found", Message: "manager is nil"}
+	}
+
+	normalized := make([]string, 0, len(providers))
+	seen := make(map[string]struct{}, len(providers))
+	for _, provider := range providers {
+		key := strings.ToLower(strings.TrimSpace(provider))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, key)
+	}
+	if len(normalized) == 0 {
+		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
+	}
+
+	tried := make(map[string]struct{})
+	if len(normalized) == 1 {
+		auth, _, err := m.pickNext(ctx, normalized[0], model, opts, tried)
+		return auth, err
+	}
+
+	auth, _, _, err := m.pickNextMixed(ctx, normalized, model, opts, tried)
+	return auth, err
+}
+
 func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
 	m.mu.RLock()
 	executor, okExecutor := m.executors[provider]


### PR DESCRIPTION
## Summary
- add an OpenAI-compatible `/v1/embeddings` endpoint for Gemini and Gemini CLI auth flows
- expose `gemini-embedding-001` in `/v1/models` when Gemini auth is available
- add request parsing, dimensionality passthrough, and tests for single, batch, and base64-style embedding requests

## Testing
- `go test ./sdk/api/handlers/openai ./internal/api`
