### PR TITLE
fix(auth): new OAuth accounts invisible to scheduler after dynamic registration

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -213,6 +213,26 @@ func (m *Manager) syncScheduler() {
 	m.syncSchedulerFromSnapshot(m.snapshotAuths())
 }
 
+// RefreshSchedulerEntry re-upserts a single auth into the scheduler so that its
+// supportedModelSet is rebuilt from the current global model registry state.
+// This must be called after models have been registered for a newly added auth,
+// because the initial scheduler.upsertAuth during Register/Update runs before
+// registerModelsForAuth and therefore snapshots an empty model set.
+func (m *Manager) RefreshSchedulerEntry(authID string) {
+	if m == nil || m.scheduler == nil || authID == "" {
+		return
+	}
+	m.mu.RLock()
+	auth, ok := m.auths[authID]
+	if !ok || auth == nil {
+		m.mu.RUnlock()
+		return
+	}
+	snapshot := auth.Clone()
+	m.mu.RUnlock()
+	m.scheduler.upsertAuth(snapshot)
+}
+
 func (m *Manager) SetSelector(selector Selector) {
 	if m == nil {
 		return
@@ -2037,6 +2057,10 @@ func (m *Manager) useSchedulerFastPath() bool {
 func shouldRetrySchedulerPick(err error) bool {
 	if err == nil {
 		return false
+	}
+	var cooldownErr *modelCooldownError
+	if errors.As(err, &cooldownErr) {
+		return true
 	}
 	var authErr *Error
 	if !errors.As(err, &authErr) || authErr == nil {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -312,6 +312,12 @@ func (s *Service) applyCoreAuthAddOrUpdate(ctx context.Context, auth *coreauth.A
 	// This operation may block on network calls, but the auth configuration
 	// is already effective at this point.
 	s.registerModelsForAuth(auth)
+
+	// Refresh the scheduler entry so that the auth's supportedModelSet is rebuilt
+	// from the now-populated global model registry. Without this, newly added auths
+	// have an empty supportedModelSet (because Register/Update upserts into the
+	// scheduler before registerModelsForAuth runs) and are invisible to the scheduler.
+	s.coreManager.RefreshSchedulerEntry(auth.ID)
 }
 
 func (s *Service) applyCoreAuthRemoval(ctx context.Context, id string) {


### PR DESCRIPTION
## Summary

- 修复动态添加 OAuth 账号时 `scheduler.upsertAuth()` 在 `registerModelsForAuth()` 之前执行，导致新账号的 `supportedModelSet` 快照为空、不进入任何 model shard 的问题
- 在 `registerModelsForAuth()` 之后调用 `RefreshSchedulerEntry()` 重建快照
- 扩展 `shouldRetrySchedulerPick()` 以匹配 `*modelCooldownError`，使安全网在所有凭据冷却时能触发 `syncScheduler()` 重建

Closes #1968

## Test plan
- [ ] 验证已有账号触发 429 后，新添加的 OAuth 账号能被调度器正常选中
- [ ] 验证 round-robin 和 fill-first 策略均正常调度新账号
- [ ] 验证 `model_cooldown` 错误触发安全网重建后能恢复服务
- [ ] 验证正常流程（无 429）下新账号注册不受影响