### PR TITLE
Add official Homebrew formula

### DIFF
--- a/Formula/cliproxyapi.rb
+++ b/Formula/cliproxyapi.rb
@@ -1,4 +1,4 @@
-class CliProxyApi < Formula
+class Cliproxyapi < Formula
   desc "CLI API proxy service for OpenAI, Gemini, Claude, and Codex-compatible clients"
   homepage "https://github.com/router-for-me/CLIProxyAPI"
   version "6.8.49"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Because this repository is not named `homebrew-cliproxyapi`, use a custom tap co
 
 ```bash
 brew tap router-for-me/cliproxyapi https://github.com/router-for-me/CLIProxyAPI
-brew install router-for-me/cliproxyapi/cli-proxy-api
+brew install cliproxyapi
 ```
 
 After installation, you can start with:

--- a/README_CN.md
+++ b/README_CN.md
@@ -68,7 +68,7 @@ CLIProxyAPI 用户手册： [https://help.router-for.me/](https://help.router-fo
 
 ```bash
 brew tap router-for-me/cliproxyapi https://github.com/router-for-me/CLIProxyAPI
-brew install router-for-me/cliproxyapi/cli-proxy-api
+brew install cliproxyapi
 ```
 
 安装完成后，可以先运行：


### PR DESCRIPTION
## Summary
- add an official Formula/cliproxyapi.rb that installs the prebuilt GitHub release archives for macOS and Linux
- document the Homebrew install flow in both README.md and README_CN.md
- keep the formula aligned with the existing Goreleaser release artifacts and checksums

## Verification
- brew style Formula/cliproxyapi.rb
- brew info router-for-me/cliproxyapi/cliproxyapi
- brew audit --strict --tap router-for-me/cliproxyapi
