### PR TITLE
fix(cloaking): string-format system prompt silently dropped, causing lost user instructions

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1269,12 +1269,8 @@ func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
 	} else if system.Type == gjson.String && system.String() != "" {
 		// Handle string-format system prompt: "system": "text"
 		// Convert to array element with cache_control.
-		escaped := strings.ReplaceAll(system.String(), `\`, `\\`)
-		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
-		escaped = strings.ReplaceAll(escaped, "\n", `\n`)
-		escaped = strings.ReplaceAll(escaped, "\r", `\r`)
-		escaped = strings.ReplaceAll(escaped, "\t", `\t`)
-		result += `,{"type":"text","text":"` + escaped + `","cache_control":{"type":"ephemeral"}}`
+		escapedBytes, _ := json.Marshal(system.String())
+		result += `,{"type":"text","text":` + string(escapedBytes) + `,"cache_control":{"type":"ephemeral"}}`
 	}
 	result += "]"
 

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1266,6 +1266,15 @@ func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
 			}
 			return true
 		})
+	} else if system.Type == gjson.String && system.String() != "" {
+		// Handle string-format system prompt: "system": "text"
+		// Convert to array element with cache_control.
+		escaped := strings.ReplaceAll(system.String(), `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+		escaped = strings.ReplaceAll(escaped, "\n", `\n`)
+		escaped = strings.ReplaceAll(escaped, "\r", `\r`)
+		escaped = strings.ReplaceAll(escaped, "\t", `\t`)
+		result += `,{"type":"text","text":"` + escaped + `","cache_control":{"type":"ephemeral"}}`
 	}
 	result += "]"
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -967,3 +967,80 @@ func TestClaudeExecutor_ExecuteStream_GzipErrorBodyNoContentEncodingHeader(t *te
 		t.Errorf("error message should contain decompressed JSON, got: %q", err.Error())
 	}
 }
+
+func TestCheckSystemInstructions_StringSystemPrompt(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":"hi"}],"system":"You are a helpful assistant"}`)
+
+	out := checkSystemInstructions(payload)
+
+	system := gjson.GetBytes(out, "system")
+	if !system.IsArray() {
+		t.Fatal("system should be converted to array")
+	}
+	items := system.Array()
+	if len(items) != 3 {
+		t.Fatalf("system array length = %d, want 3 (billing + agent + user prompt)", len(items))
+	}
+	// system[0]: billing header
+	if !strings.HasPrefix(items[0].Get("text").String(), "x-anthropic-billing-header:") {
+		t.Fatalf("system[0] should be billing header, got: %s", items[0].Get("text").String())
+	}
+	// system[2]: user's original system prompt preserved
+	if items[2].Get("text").String() != "You are a helpful assistant" {
+		t.Fatalf("system[2] should be user prompt, got: %s", items[2].Get("text").String())
+	}
+	if items[2].Get("cache_control.type").String() != "ephemeral" {
+		t.Fatal("system[2] should have cache_control.type=ephemeral")
+	}
+}
+
+func TestCheckSystemInstructions_StringSystemPromptWithSpecialChars(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":"hi"}],"system":"line1\nline2\t\"quoted\""}`)
+
+	out := checkSystemInstructions(payload)
+
+	items := gjson.GetBytes(out, "system").Array()
+	if len(items) != 3 {
+		t.Fatalf("system array length = %d, want 3", len(items))
+	}
+	got := items[2].Get("text").String()
+	if !strings.Contains(got, "line1") || !strings.Contains(got, "line2") {
+		t.Fatalf("system[2] should preserve multiline content, got: %s", got)
+	}
+}
+
+func TestCheckSystemInstructions_EmptyStringSystemPrompt(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":"hi"}],"system":""}`)
+
+	out := checkSystemInstructions(payload)
+
+	items := gjson.GetBytes(out, "system").Array()
+	if len(items) != 2 {
+		t.Fatalf("system array length = %d, want 2 (empty string should not produce a third block)", len(items))
+	}
+}
+
+func TestCheckSystemInstructions_ArraySystemPrompt(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":"hi"}],"system":[{"type":"text","text":"user prompt"}]}`)
+
+	out := checkSystemInstructions(payload)
+
+	items := gjson.GetBytes(out, "system").Array()
+	if len(items) != 3 {
+		t.Fatalf("system array length = %d, want 3", len(items))
+	}
+	if items[2].Get("text").String() != "user prompt" {
+		t.Fatalf("system[2] should be user prompt, got: %s", items[2].Get("text").String())
+	}
+}
+
+func TestCheckSystemInstructions_NoSystemField(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":"hi"}]}`)
+
+	out := checkSystemInstructions(payload)
+
+	items := gjson.GetBytes(out, "system").Array()
+	if len(items) != 2 {
+		t.Fatalf("system array length = %d, want 2 (billing + agent only)", len(items))
+	}
+}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1004,8 +1004,9 @@ func TestCheckSystemInstructions_StringSystemPromptWithSpecialChars(t *testing.T
 		t.Fatalf("system array length = %d, want 3", len(items))
 	}
 	got := items[2].Get("text").String()
-	if !strings.Contains(got, "line1") || !strings.Contains(got, "line2") {
-		t.Fatalf("system[2] should preserve multiline content, got: %s", got)
+	const want = "line1\nline2\t\"quoted\""
+	if got != want {
+		t.Fatalf("system[2] text = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Problem

`checkSystemInstructionsWithMode` only handles array-format system prompts (`"system": [...]`). The Anthropic API also accepts string-format system prompts (`"system": "text"`), which many third-party clients use (OpenAI SDK adapters, custom chat applications, etc.).

When a string-format system prompt is received, the existing code skips the `system.IsArray()` branch and the user's prompt is **silently dropped**. The resulting cloaked payload contains only 2 system blocks (billing header + agent identity), missing the user's original content.

This causes:
1. **User system prompt lost** — the AI never receives the configured assistant persona/instructions.
2. **Upstream validation failures** — some upstreams require 3+ system blocks in cloaked requests, rejecting payloads with only 2.

## Fix

Add an `else if system.Type == gjson.String` branch in `checkSystemInstructionsWithMode` to convert the string prompt into a proper array element (with `cache_control`) appended after the billing and agent blocks. Empty strings are skipped to avoid injecting a blank block.

## Tests

Added 5 test cases covering:
- String system prompt → converted to 3rd array element ✅
- String with special characters (newlines, tabs, quotes) ✅
- Empty string → no extra block injected ✅
- Array system prompt → existing behavior preserved ✅
- No system field → existing behavior preserved ✅