### PR TITLE
feat: add per-credential response-header-timeout and treat 524 as transient error

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -365,6 +365,11 @@ type ClaudeKey struct {
 	// ExcludedModels lists model IDs that should be excluded for this provider.
 	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
 
+	// ResponseHeaderTimeout limits how long to wait for the upstream to start
+	// responding (in seconds). Once the first response byte arrives, this timeout
+	// no longer applies — streaming responses are not affected. 0 means no timeout.
+	ResponseHeaderTimeout int `yaml:"response-header-timeout,omitempty" json:"response-header-timeout,omitempty"`
+
 	// Cloak configures request cloaking for non-Claude-Code clients.
 	Cloak *CloakConfig `yaml:"cloak,omitempty" json:"cloak,omitempty"`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -370,6 +370,11 @@ type ClaudeKey struct {
 	// no longer applies — streaming responses are not affected. 0 means no timeout.
 	ResponseHeaderTimeout int `yaml:"response-header-timeout,omitempty" json:"response-header-timeout,omitempty"`
 
+	// TransientErrorCooldown overrides the default 1-minute cooldown applied when
+	// a transient error (408/500/502/503/504/524) is received from this upstream
+	// (in seconds). 0 means use the default (60s).
+	TransientErrorCooldown int `yaml:"transient-error-cooldown,omitempty" json:"transient-error-cooldown,omitempty"`
+
 	// Cloak configures request cloaking for non-Claude-Code clients.
 	Cloak *CloakConfig `yaml:"cloak,omitempty" json:"cloak,omitempty"`
 

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/textproto"
 	"strings"
@@ -192,6 +193,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			return resp, statusErr{code: http.StatusGatewayTimeout, msg: fmt.Sprintf("upstream timeout: %v", err)}
+		}
 		return resp, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
@@ -360,6 +364,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			return nil, statusErr{code: http.StatusGatewayTimeout, msg: fmt.Sprintf("upstream timeout: %v", err)}
+		}
 		return nil, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())

--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -3,6 +3,7 @@ package helps
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -31,6 +32,8 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		httpClient.Timeout = timeout
 	}
 
+	respHeaderTimeout := responseHeaderTimeoutFromAuth(auth)
+
 	// Priority 1: Use auth.ProxyURL if configured
 	var proxyURL string
 	if auth != nil {
@@ -46,7 +49,7 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	if proxyURL != "" {
 		transport := buildProxyTransport(proxyURL)
 		if transport != nil {
-			httpClient.Transport = transport
+			httpClient.Transport = applyResponseHeaderTimeout(transport, respHeaderTimeout)
 			return httpClient
 		}
 		// If proxy setup failed, log and fall through to context RoundTripper
@@ -58,7 +61,35 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		httpClient.Transport = rt
 	}
 
+	httpClient.Transport = applyResponseHeaderTimeout(httpClient.Transport, respHeaderTimeout)
+
 	return httpClient
+}
+
+func responseHeaderTimeoutFromAuth(auth *cliproxyauth.Auth) time.Duration {
+	if auth == nil || auth.Attributes == nil {
+		return 0
+	}
+	secs, err := strconv.Atoi(auth.Attributes["response_header_timeout"])
+	if err != nil || secs <= 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
+}
+
+func applyResponseHeaderTimeout(rt http.RoundTripper, timeout time.Duration) http.RoundTripper {
+	if timeout <= 0 {
+		return rt
+	}
+	if transport, ok := rt.(*http.Transport); ok {
+		clonedTransport := transport.Clone()
+		clonedTransport.ResponseHeaderTimeout = timeout
+		return clonedTransport
+	}
+	if rt == nil {
+		return &http.Transport{ResponseHeaderTimeout: timeout}
+	}
+	return rt
 }
 
 // buildProxyTransport creates an HTTP transport configured for the given proxy URL.

--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -87,7 +87,9 @@ func applyResponseHeaderTimeout(rt http.RoundTripper, timeout time.Duration) htt
 		return clonedTransport
 	}
 	if rt == nil {
-		return &http.Transport{ResponseHeaderTimeout: timeout}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.ResponseHeaderTimeout = timeout
+		return transport
 	}
 	return rt
 }

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -174,6 +174,7 @@ func NewUtlsHTTPClient(cfg *config.Config, auth *cliproxyauth.Auth, timeout time
 			standardTransport = transport
 		}
 	}
+	standardTransport = applyResponseHeaderTimeout(standardTransport, responseHeaderTimeoutFromAuth(auth))
 
 	client := &http.Client{
 		Transport: &fallbackRoundTripper{

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -119,6 +119,9 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 		if ck.ResponseHeaderTimeout > 0 {
 			attrs["response_header_timeout"] = strconv.Itoa(ck.ResponseHeaderTimeout)
 		}
+		if ck.TransientErrorCooldown > 0 {
+			attrs["transient_error_cooldown"] = strconv.Itoa(ck.TransientErrorCooldown)
+		}
 		addConfigHeadersToAttrs(ck.Headers, attrs)
 		proxyURL := strings.TrimSpace(ck.ProxyURL)
 		a := &coreauth.Auth{

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -116,6 +116,9 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 		if hash := diff.ComputeClaudeModelsHash(ck.Models); hash != "" {
 			attrs["models_hash"] = hash
 		}
+		if ck.ResponseHeaderTimeout > 0 {
+			attrs["response_header_timeout"] = strconv.Itoa(ck.ResponseHeaderTimeout)
+		}
 		addConfigHeadersToAttrs(ck.Headers, attrs)
 		proxyURL := strings.TrimSpace(ck.ProxyURL)
 		a := &coreauth.Auth{

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2252,7 +2252,15 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		if quotaCooldownDisabledForAuth(auth) {
 			auth.NextRetryAfter = time.Time{}
 		} else {
-			auth.NextRetryAfter = now.Add(1 * time.Minute)
+			cooldown := 1 * time.Minute
+			if auth.Attributes != nil {
+				if v, ok := auth.Attributes["transient_error_cooldown"]; ok {
+					if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+						cooldown = time.Duration(secs) * time.Second
+					}
+				}
+			}
+			auth.NextRetryAfter = now.Add(cooldown)
 		}
 	default:
 		if auth.StatusMessage == "" {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2247,7 +2247,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		}
 		auth.Quota.NextRecoverAt = next
 		auth.NextRetryAfter = next
-	case 408, 500, 502, 503, 504:
+	case 408, 500, 502, 503, 504, 524:
 		auth.StatusMessage = "transient upstream error"
 		if quotaCooldownDisabledForAuth(auth) {
 			auth.NextRetryAfter = time.Time{}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1894,11 +1894,19 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							suspendReason = "quota"
 							shouldSuspendModel = true
 							setModelQuota = true
-						case 408, 500, 502, 503, 504:
+						case 408, 500, 502, 503, 504, 524:
 							if quotaCooldownDisabledForAuth(auth) {
 								state.NextRetryAfter = time.Time{}
 							} else {
-								next := now.Add(1 * time.Minute)
+								cooldown := 1 * time.Minute
+								if auth.Attributes != nil {
+									if v, ok := auth.Attributes["transient_error_cooldown"]; ok {
+										if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+											cooldown = time.Duration(secs) * time.Second
+										}
+									}
+								}
+								next := now.Add(cooldown)
 								state.NextRetryAfter = next
 							}
 						default:


### PR DESCRIPTION
## Summary

- Add `response-header-timeout` config field to `claude-api-key` entries (per-credential, in seconds)
- Only limits wait time for the upstream to start responding — streaming responses are **not** affected
- Add HTTP 524 (Cloudflare timeout) to the transient error list in conductor
- Wrap Go `net.Error` timeout as `statusErr{code: 504}` so conductor properly applies 1-minute cooldown on timeout failures

## Motivation

Upstreams behind Cloudflare CDN have a ~100s default 524 timeout. Without per-credential timeout control, each failing credential wastes 2+ minutes before failover triggers. With `response-header-timeout: 15`, failover triggers within ~15 seconds. The 504 wrapping ensures the failing credential enters cooldown, so subsequent requests skip it immediately.

## Config example

```yaml
claude-api-key:
  - api-key: sk-xxx
    base-url: https://example.com
    response-header-timeout: 15  # 15s to start responding, then no limit
```

## Files changed

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `ResponseHeaderTimeout` field to `ClaudeKey` |
| `internal/watcher/synthesizer/config.go` | Pass timeout to `Auth.Attributes` |
| `internal/runtime/executor/proxy_helpers.go` | Apply `ResponseHeaderTimeout` to `http.Transport` |
| `sdk/cliproxy/auth/conductor.go` | Add 524 to transient error list |
| `internal/runtime/executor/claude_executor.go` | Wrap `net.Error` timeout as `statusErr{code: 504}` |

## Test plan

- [ ] Configure `response-header-timeout: 15` on an upstream behind Cloudflare
- [ ] Verify failover triggers at ~15s instead of ~100s when upstream is unresponsive
- [ ] Verify the timed-out credential enters 1-minute cooldown (next request skips it)
- [ ] Verify streaming responses are not interrupted by this timeout
- [ ] Verify upstreams without `response-header-timeout` behave as before (no timeout)
