### PR TITLE
fix(management): revive codex auth after quota refresh

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -209,6 +209,8 @@ func (h *Handler) APICall(c *gin.Context) {
 		return
 	}
 
+	h.reviveAuthFromOfficialUsage(c.Request.Context(), auth, parsedURL, resp.StatusCode, respBody)
+
 	c.JSON(http.StatusOK, apiCallResponse{
 		StatusCode: resp.StatusCode,
 		Header:     resp.Header,
@@ -611,6 +613,94 @@ func tokenValueFromMetadata(metadata map[string]any) string {
 		return strings.TrimSpace(v)
 	}
 	return ""
+}
+
+func (h *Handler) reviveAuthFromOfficialUsage(ctx context.Context, auth *coreauth.Auth, target *url.URL, statusCode int, body []byte) {
+	if h == nil || h.authManager == nil || auth == nil || target == nil {
+		return
+	}
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return
+	}
+
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	switch provider {
+	case "codex":
+		h.reviveCodexAuthFromUsage(ctx, auth, target, body)
+	}
+}
+
+func (h *Handler) reviveCodexAuthFromUsage(ctx context.Context, auth *coreauth.Auth, target *url.URL, body []byte) {
+	if auth == nil || target == nil {
+		return
+	}
+	if !strings.HasSuffix(strings.TrimSpace(target.Path), "/wham/usage") {
+		return
+	}
+
+	var payload codexOfficialUsagePayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return
+	}
+	if !codexUsagePayloadAllowsScheduling(time.Now().UTC(), &payload) {
+		return
+	}
+	_, _ = h.authManager.ClearQuotaExhaustion(ctx, auth.ID)
+}
+
+type codexOfficialUsagePayload struct {
+	RateLimit *codexOfficialRateLimit `json:"rate_limit"`
+}
+
+type codexOfficialRateLimit struct {
+	Allowed         bool                       `json:"allowed"`
+	LimitReached    bool                       `json:"limit_reached"`
+	PrimaryWindow   *codexOfficialUsageWindow  `json:"primary_window"`
+	SecondaryWindow *codexOfficialUsageWindow  `json:"secondary_window"`
+}
+
+type codexOfficialUsageWindow struct {
+	UsedPercent       float64 `json:"used_percent"`
+	ResetAt           int64   `json:"reset_at"`
+	ResetAfterSeconds int64   `json:"reset_after_seconds"`
+}
+
+func codexUsagePayloadAllowsScheduling(now time.Time, payload *codexOfficialUsagePayload) bool {
+	if payload == nil {
+		return false
+	}
+	rateLimit := payload.RateLimit
+	if rateLimit == nil {
+		return false
+	}
+
+	// Only revive when the official usage response clearly indicates that the
+	// credential is schedulable again. This keeps the management refresh path
+	// conservative and avoids clearing non-quota failures.
+	if rateLimit.Allowed && !rateLimit.LimitReached {
+		return true
+	}
+
+	// Fallback: if the weekly window is no longer exhausted because its reset
+	// timestamp is already in the past, allow revival even if the top-level flags
+	// have not been recomputed yet.
+	if rateLimit.SecondaryWindow != nil && codexOfficialWindowExhausted(now, rateLimit.SecondaryWindow) {
+		return false
+	}
+	return !rateLimit.LimitReached
+}
+
+func codexOfficialWindowExhausted(now time.Time, window *codexOfficialUsageWindow) bool {
+	if window == nil {
+		return false
+	}
+	if window.ResetAt > 0 && time.Unix(window.ResetAt, 0).UTC().After(now) {
+		return window.UsedPercent >= 100
+	}
+	if window.ResetAfterSeconds > 0 {
+		return window.UsedPercent >= 100
+	}
+	return false
 }
 
 func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -169,5 +171,206 @@ func TestResolveTokenForAuth_Antigravity_SkipsRefreshWhenTokenValid(t *testing.T
 	}
 	if callCount != 0 {
 		t.Fatalf("expected no refresh calls, got %d", callCount)
+	}
+}
+
+func TestAPICall_RevivesCodexQuotaStateFromOfficialUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	now := time.Now().UTC()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/backend-api/wham/usage" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer token-123" {
+			t.Fatalf("unexpected authorization header: %s", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"plan_type": "team",
+			"rate_limit": map[string]any{
+				"allowed":       true,
+				"limit_reached": false,
+				"primary_window": map[string]any{
+					"used_percent":         0,
+					"limit_window_seconds": 18000,
+					"reset_after_seconds":  120,
+					"reset_at":             now.Add(2 * time.Minute).Unix(),
+				},
+				"secondary_window": map[string]any{
+					"used_percent":         0,
+					"limit_window_seconds": 604800,
+					"reset_after_seconds":  3600,
+					"reset_at":             now.Add(time.Hour).Unix(),
+				},
+			},
+		})
+	}))
+	t.Cleanup(upstream.Close)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth := &coreauth.Auth{
+		ID:       "codex-revive.json",
+		FileName: filepath.Base("codex-revive.json"),
+		Provider: "codex",
+		Status:   coreauth.StatusError,
+		Metadata: map[string]any{
+			"access_token": "token-123",
+			"email":        "revive@example.com",
+		},
+		Unavailable:    true,
+		NextRetryAfter: now.Add(24 * time.Hour),
+		Quota: coreauth.QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: now.Add(24 * time.Hour),
+		},
+		StatusMessage: `{"error":{"type":"usage_limit_reached"}}`,
+		ModelStates: map[string]*coreauth.ModelState{
+			"gpt-5.4": {
+				Status:         coreauth.StatusError,
+				StatusMessage:  `{"error":{"type":"usage_limit_reached"}}`,
+				Unavailable:    true,
+				NextRetryAfter: now.Add(24 * time.Hour),
+				LastError:      &coreauth.Error{HTTPStatus: http.StatusTooManyRequests, Message: `{"error":{"type":"usage_limit_reached"}}`},
+				Quota: coreauth.QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: now.Add(24 * time.Hour),
+				},
+			},
+		},
+	}
+	registered, err := manager.Register(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	h := &Handler{authManager: manager}
+	reqBody := map[string]any{
+		"auth_index": registered.Index,
+		"method":     "GET",
+		"url":        upstream.URL + "/backend-api/wham/usage",
+		"header": map[string]string{
+			"Authorization": "Bearer $TOKEN$",
+		},
+	}
+	bodyBytes, _ := json.Marshal(reqBody)
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/api-call", strings.NewReader(string(bodyBytes)))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.APICall(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d with body %s", rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	if updated.Unavailable {
+		t.Fatalf("expected auth to be available after usage refresh")
+	}
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected next_retry_after cleared, got %v", updated.NextRetryAfter)
+	}
+	if updated.Quota.Exceeded {
+		t.Fatalf("expected auth quota to be cleared")
+	}
+	if updated.Status != coreauth.StatusActive {
+		t.Fatalf("expected auth status active, got %s", updated.Status)
+	}
+	state := updated.ModelStates["gpt-5.4"]
+	if state == nil {
+		t.Fatal("expected model state to exist")
+	}
+	if state.Unavailable || state.Quota.Exceeded || !state.NextRetryAfter.IsZero() || state.Status != coreauth.StatusActive {
+		t.Fatalf("expected model quota state cleared, got %#v", state)
+	}
+}
+
+func TestAPICall_DoesNotReviveCodexQuotaStateWhenOfficialUsageStillBlocked(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	now := time.Now().UTC()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"plan_type": "team",
+			"rate_limit": map[string]any{
+				"allowed":       false,
+				"limit_reached": true,
+				"secondary_window": map[string]any{
+					"used_percent":         100,
+					"limit_window_seconds": 604800,
+					"reset_after_seconds":  3600,
+					"reset_at":             now.Add(time.Hour).Unix(),
+				},
+			},
+		})
+	}))
+	t.Cleanup(upstream.Close)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth := &coreauth.Auth{
+		ID:             "codex-still-blocked.json",
+		FileName:       filepath.Base("codex-still-blocked.json"),
+		Provider:       "codex",
+		Status:         coreauth.StatusError,
+		Metadata:       map[string]any{"access_token": "token-123"},
+		Unavailable:    true,
+		NextRetryAfter: now.Add(24 * time.Hour),
+		Quota: coreauth.QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: now.Add(24 * time.Hour),
+		},
+		StatusMessage: `{"error":{"type":"usage_limit_reached"}}`,
+	}
+	registered, err := manager.Register(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	h := &Handler{authManager: manager}
+	reqBody := map[string]any{
+		"auth_index": registered.Index,
+		"method":     "GET",
+		"url":        upstream.URL + "/backend-api/wham/usage",
+		"header": map[string]string{
+			"Authorization": "Bearer $TOKEN$",
+		},
+	}
+	bodyBytes, _ := json.Marshal(reqBody)
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/api-call", strings.NewReader(string(bodyBytes)))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.APICall(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d with body %s", rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	if !updated.Unavailable {
+		t.Fatalf("expected auth to remain unavailable")
+	}
+	if updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected next_retry_after to remain set")
+	}
+	if !updated.Quota.Exceeded {
+		t.Fatalf("expected auth quota to remain exceeded")
 	}
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1832,6 +1832,109 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.UpdatedAt = now
 }
 
+// ClearQuotaExhaustion clears runtime quota/cooldown state for an auth when an
+// external signal (for example a management usage refresh) confirms the
+// credential is available again. Non-quota errors are preserved.
+func (m *Manager) ClearQuotaExhaustion(ctx context.Context, authID string) (*Auth, bool) {
+	if m == nil || strings.TrimSpace(authID) == "" {
+		return nil, false
+	}
+
+	var (
+		authSnapshot  *Auth
+		clearedModels []string
+		cleared       bool
+	)
+
+	m.mu.Lock()
+	auth, ok := m.auths[authID]
+	if ok && auth != nil {
+		now := time.Now()
+		cleared = clearQuotaStateForAuth(auth, now, &clearedModels)
+		if cleared {
+			_ = m.persist(ctx, auth)
+		}
+		authSnapshot = auth.Clone()
+	}
+	m.mu.Unlock()
+
+	if !cleared || authSnapshot == nil {
+		return authSnapshot, false
+	}
+	if m.scheduler != nil {
+		m.scheduler.upsertAuth(authSnapshot)
+	}
+	for _, model := range clearedModels {
+		registry.GetGlobalRegistry().ClearModelQuotaExceeded(authID, model)
+		registry.GetGlobalRegistry().ResumeClientModel(authID, model)
+	}
+	return authSnapshot, true
+}
+
+func clearQuotaStateForAuth(auth *Auth, now time.Time, clearedModels *[]string) bool {
+	if auth == nil {
+		return false
+	}
+
+	clearedAny := false
+	for model, state := range auth.ModelStates {
+		if state == nil || !isQuotaRuntimeState(state.StatusMessage, state.LastError, state.Quota.Exceeded) {
+			continue
+		}
+		resetModelState(state, now)
+		clearedAny = true
+		if clearedModels != nil {
+			*clearedModels = append(*clearedModels, model)
+		}
+	}
+
+	authQuotaState := isQuotaRuntimeState(auth.StatusMessage, auth.LastError, auth.Quota.Exceeded)
+	if authQuotaState {
+		auth.Quota = QuotaState{}
+		auth.LastError = nil
+		auth.StatusMessage = ""
+		auth.NextRetryAfter = time.Time{}
+		auth.UpdatedAt = now
+		clearedAny = true
+	}
+
+	if !clearedAny {
+		return false
+	}
+
+	updateAggregatedAvailability(auth, now)
+	if authQuotaState && !hasModelError(auth, now) {
+		clearAuthStateOnSuccess(auth, now)
+	}
+	return true
+}
+
+func isQuotaRuntimeState(statusMessage string, lastError *Error, exceeded bool) bool {
+	if exceeded {
+		return true
+	}
+	if lastError != nil {
+		if lastError.HTTPStatus == http.StatusTooManyRequests {
+			return true
+		}
+		if quotaErrorSignal(lastError.Message) {
+			return true
+		}
+	}
+	return quotaErrorSignal(statusMessage)
+}
+
+func quotaErrorSignal(text string) bool {
+	signal := strings.ToLower(strings.TrimSpace(text))
+	if signal == "" {
+		return false
+	}
+	return strings.Contains(signal, "usage_limit_reached") ||
+		strings.Contains(signal, "quota exhausted") ||
+		strings.Contains(signal, "\"quota\"") ||
+		strings.Contains(signal, "\"rate_limit\"")
+}
+
 func cloneError(err *Error) *Error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
Fixes #2065

## Summary

When the management quota page refreshes Codex usage successfully and the official `wham/usage` response shows the credential is available again, the runtime auth state should be cleared immediately instead of waiting for the old cooldown to expire.

## What this changes

- detect successful Codex `wham/usage` refreshes in management `api-call`
- conservatively revive the auth only when the official response clearly indicates the credential is schedulable again
- clear runtime quota/cooldown state and refresh the scheduler snapshot
- add regression tests for both revive and still-blocked cases

## Notes

This does not change normal request-time quota handling. It only lets the management quota refresh path bring runtime state back in sync after official usage has already recovered.