### PR TITLE
fix(perf): reduce p1 hot-path blocking

### DIFF
--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -271,17 +271,21 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 			}
 			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, body, bytes.Clone(line), &param)
 			for i := range chunks {
-				out <- cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}
+				if !sendChunk(ctx, out, cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}) {
+					return
+				}
 			}
 		}
 		doneChunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, body, []byte("[DONE]"), &param)
 		for i := range doneChunks {
-			out <- cliproxyexecutor.StreamChunk{Payload: []byte(doneChunks[i])}
+			if !sendChunk(ctx, out, cliproxyexecutor.StreamChunk{Payload: []byte(doneChunks[i])}) {
+				return
+			}
 		}
 		if errScan := scanner.Err(); errScan != nil {
 			recordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.publishFailure(ctx)
-			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+			_ = sendChunk(ctx, out, cliproxyexecutor.StreamChunk{Err: errScan})
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -286,13 +286,15 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			// Pass through translator; it yields one or more chunks for the target schema.
 			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, bytes.Clone(line), &param)
 			for i := range chunks {
-				out <- cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}
+				if !sendChunk(ctx, out, cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}) {
+					return
+				}
 			}
 		}
 		if errScan := scanner.Err(); errScan != nil {
 			recordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.publishFailure(ctx)
-			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+			_ = sendChunk(ctx, out, cliproxyexecutor.StreamChunk{Err: errScan})
 		}
 		// Ensure we record the request if no usage chunk was ever seen
 		reporter.ensurePublished(ctx)

--- a/internal/runtime/executor/qwen_executor.go
+++ b/internal/runtime/executor/qwen_executor.go
@@ -421,17 +421,21 @@ func (e *QwenExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 			}
 			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, body, bytes.Clone(line), &param)
 			for i := range chunks {
-				out <- cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}
+				if !sendChunk(ctx, out, cliproxyexecutor.StreamChunk{Payload: []byte(chunks[i])}) {
+					return
+				}
 			}
 		}
 		doneChunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, body, []byte("[DONE]"), &param)
 		for i := range doneChunks {
-			out <- cliproxyexecutor.StreamChunk{Payload: []byte(doneChunks[i])}
+			if !sendChunk(ctx, out, cliproxyexecutor.StreamChunk{Payload: []byte(doneChunks[i])}) {
+				return
+			}
 		}
 		if errScan := scanner.Err(); errScan != nil {
 			recordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.publishFailure(ctx)
-			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+			_ = sendChunk(ctx, out, cliproxyexecutor.StreamChunk{Err: errScan})
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil

--- a/internal/runtime/executor/stream_cancel_test.go
+++ b/internal/runtime/executor/stream_cancel_test.go
@@ -1,0 +1,313 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+type streamCancelableExecutor interface {
+	ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error)
+}
+
+type streamExecutorCase struct {
+	name  string
+	exec  func(baseURL string) streamCancelableExecutor
+	auth  func(baseURL string) *cliproxyauth.Auth
+	model string
+}
+
+func TestStreamExecutorsCancelUpstreamBeforeFirstChunk(t *testing.T) {
+	t.Parallel()
+	for _, execCase := range streamExecutorCases() {
+		execCase := execCase
+		t.Run(execCase.name, func(t *testing.T) {
+			rt := newStreamingRoundTripper(streamScenarioBeforeFirst)
+			ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", rt)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			result := mustExecuteStream(t, execCase, "https://example.test", ctx)
+
+			select {
+			case <-rt.started:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for upstream stream start")
+			}
+
+			cancel()
+			waitForUpstreamCanceled(t, rt.upstreamCanceled)
+			waitForStreamClosed(t, result.Chunks)
+		})
+	}
+}
+
+func TestStreamExecutorsCancelUpstreamAfterFirstChunk(t *testing.T) {
+	t.Parallel()
+	for _, execCase := range streamExecutorCases() {
+		execCase := execCase
+		t.Run(execCase.name, func(t *testing.T) {
+			rt := newStreamingRoundTripper(streamScenarioAfterFirst)
+			ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", rt)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			result := mustExecuteStream(t, execCase, "https://example.test", ctx)
+
+			select {
+			case <-rt.firstChunkWritten:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for first chunk to be written")
+			}
+
+			cancel()
+			waitForUpstreamCanceled(t, rt.upstreamCanceled)
+			waitForStreamClosed(t, result.Chunks)
+		})
+	}
+}
+
+func TestStreamExecutorsCancelUpstreamMidStream(t *testing.T) {
+	t.Parallel()
+	for _, execCase := range streamExecutorCases() {
+		execCase := execCase
+		t.Run(execCase.name, func(t *testing.T) {
+			rt := newStreamingRoundTripper(streamScenarioMidStream)
+			ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", rt)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			result := mustExecuteStream(t, execCase, "https://example.test", ctx)
+
+			for index := 0; index < 2; index++ {
+				_ = readNonEmptyChunkWithTimeout(t, result.Chunks)
+			}
+
+			deadline := time.Now().Add(2 * time.Second)
+			for rt.writes.Load() < 3 {
+				if time.Now().After(deadline) {
+					t.Fatalf("expected at least 3 upstream writes before cancel, got %d", rt.writes.Load())
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+
+			cancel()
+			waitForUpstreamCanceled(t, rt.upstreamCanceled)
+			waitForStreamClosed(t, result.Chunks)
+		})
+	}
+}
+
+func streamExecutorCases() []streamExecutorCase {
+	return []streamExecutorCase{
+		{
+			name: "openai_compat",
+			exec: func(baseURL string) streamCancelableExecutor {
+				return NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+			},
+			auth: func(baseURL string) *cliproxyauth.Auth {
+				return &cliproxyauth.Auth{Attributes: map[string]string{
+					"base_url": baseURL + "/v1",
+					"api_key":  "test",
+				}}
+			},
+			model: "gpt-4o-mini",
+		},
+		{
+			name: "kimi",
+			exec: func(baseURL string) streamCancelableExecutor {
+				return NewKimiExecutor(&config.Config{})
+			},
+			auth: func(baseURL string) *cliproxyauth.Auth {
+				return &cliproxyauth.Auth{Attributes: map[string]string{
+					"access_token": "test",
+				}}
+			},
+			model: "kimi-k2",
+		},
+		{
+			name: "qwen",
+			exec: func(baseURL string) streamCancelableExecutor {
+				return NewQwenExecutor(&config.Config{})
+			},
+			auth: func(baseURL string) *cliproxyauth.Auth {
+				return &cliproxyauth.Auth{Attributes: map[string]string{
+					"base_url": baseURL + "/v1",
+					"api_key":  "test",
+				}}
+			},
+			model: "qwen-max",
+		},
+	}
+}
+
+func mustExecuteStream(t *testing.T, execCase streamExecutorCase, baseURL string, ctx context.Context) *cliproxyexecutor.StreamResult {
+	t.Helper()
+	result, err := execCase.exec(baseURL).ExecuteStream(ctx, execCase.auth(baseURL), cliproxyexecutor.Request{
+		Model:   execCase.model,
+		Payload: []byte(`{"model":"` + execCase.model + `","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	return result
+}
+
+func writeSSEChunk(t *testing.T, w http.ResponseWriter, content string) {
+	t.Helper()
+	if _, err := w.Write([]byte(`data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"content":"` + content + `"}}]}` + "\n\n")); err != nil {
+		t.Fatalf("write SSE chunk: %v", err)
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+type streamScenario string
+
+const (
+	streamScenarioBeforeFirst streamScenario = "before_first"
+	streamScenarioAfterFirst  streamScenario = "after_first"
+	streamScenarioMidStream   streamScenario = "mid_stream"
+)
+
+type streamingRoundTripper struct {
+	scenario          streamScenario
+	started           chan struct{}
+	firstChunkWritten chan struct{}
+	upstreamCanceled  chan struct{}
+	writes            atomic.Int32
+	cancelOnce        sync.Once
+	startOnce         sync.Once
+	firstOnce         sync.Once
+}
+
+func newStreamingRoundTripper(scenario streamScenario) *streamingRoundTripper {
+	return &streamingRoundTripper{
+		scenario:          scenario,
+		started:           make(chan struct{}),
+		firstChunkWritten: make(chan struct{}),
+		upstreamCanceled:  make(chan struct{}),
+	}
+}
+
+func (rt *streamingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	pr, pw := io.Pipe()
+	rt.startOnce.Do(func() { close(rt.started) })
+	go func() {
+		defer func() {
+			rt.cancelOnce.Do(func() { close(rt.upstreamCanceled) })
+			_ = pw.Close()
+		}()
+		switch rt.scenario {
+		case streamScenarioBeforeFirst:
+			<-req.Context().Done()
+			return
+		case streamScenarioAfterFirst:
+			rt.writeChunk(req.Context(), pw, "first")
+			<-req.Context().Done()
+			return
+		case streamScenarioMidStream:
+			ticker := time.NewTicker(15 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-req.Context().Done():
+					return
+				case <-ticker.C:
+					count := rt.writes.Add(1)
+					if !rt.writeChunk(req.Context(), pw, fmt.Sprintf("chunk-%d", count)) {
+						return
+					}
+				}
+			}
+		default:
+			<-req.Context().Done()
+		}
+	}()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       pr,
+		Request:    req,
+	}
+	resp.Header.Set("Content-Type", "text/event-stream")
+	return resp, nil
+}
+
+func (rt *streamingRoundTripper) writeChunk(ctx context.Context, w *io.PipeWriter, content string) bool {
+	rt.firstOnce.Do(func() { close(rt.firstChunkWritten) })
+	if _, err := io.WriteString(w, `data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"content":"`+content+`"}}]}`+"\n\n"); err != nil {
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func readNonEmptyChunkWithTimeout(t *testing.T, ch <-chan cliproxyexecutor.StreamChunk) cliproxyexecutor.StreamChunk {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		select {
+		case chunk, ok := <-ch:
+			if !ok {
+				t.Fatal("expected stream chunk, got closed channel")
+			}
+			if chunk.Err != nil {
+				t.Fatalf("unexpected stream chunk error: %v", chunk.Err)
+			}
+			if len(chunk.Payload) == 0 {
+				if time.Now().After(deadline) {
+					t.Fatal("timed out waiting for non-empty stream chunk")
+				}
+				continue
+			}
+			return chunk
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for stream chunk")
+			return cliproxyexecutor.StreamChunk{}
+		}
+	}
+}
+
+func waitForUpstreamCanceled(t *testing.T, canceled <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-canceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream cancellation")
+	}
+}
+
+func waitForStreamClosed(t *testing.T, ch <-chan cliproxyexecutor.StreamChunk) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			t.Fatal("timed out waiting for stream close")
+		}
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+		case <-time.After(remaining):
+			t.Fatal("timed out waiting for stream close")
+		}
+	}
+}

--- a/internal/runtime/executor/stream_helpers.go
+++ b/internal/runtime/executor/stream_helpers.go
@@ -1,0 +1,23 @@
+package executor
+
+import (
+	"context"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+func sendChunk(ctx context.Context, out chan<- cliproxyexecutor.StreamChunk, chunk cliproxyexecutor.StreamChunk) bool {
+	if out == nil {
+		return false
+	}
+	if ctx == nil {
+		out <- chunk
+		return true
+	}
+	select {
+	case <-ctx.Done():
+		return false
+	case out <- chunk:
+		return true
+	}
+}

--- a/internal/watcher/dispatcher.go
+++ b/internal/watcher/dispatcher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher/synthesizer"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
 )
 
 var snapshotCoreAuthsFunc = snapshotCoreAuths
@@ -153,9 +154,12 @@ func (w *Watcher) dispatchAuthUpdates(updates []AuthUpdate) {
 		key := w.authUpdateKey(update, baseTS+int64(idx))
 		if _, exists := w.pendingUpdates[key]; !exists {
 			w.pendingOrder = append(w.pendingOrder, key)
+		} else {
+			w.dispatchMerged.Add(1)
 		}
 		w.pendingUpdates[key] = update
 	}
+	w.dispatchBacklog.Store(int64(len(w.pendingOrder)))
 	if w.dispatchCond != nil {
 		w.dispatchCond.Signal()
 	}
@@ -174,6 +178,9 @@ func (w *Watcher) dispatchLoop(ctx context.Context) {
 		batch, ok := w.nextPendingBatch(ctx)
 		if !ok {
 			return
+		}
+		if backlog := w.dispatchBacklog.Load(); backlog > 0 {
+			log.Debugf("watcher dispatch backlog=%d merged=%d", backlog, w.dispatchMerged.Load())
 		}
 		queue := w.getAuthQueue()
 		if queue == nil {
@@ -211,6 +218,7 @@ func (w *Watcher) nextPendingBatch(ctx context.Context) ([]AuthUpdate, bool) {
 		delete(w.pendingUpdates, key)
 	}
 	w.pendingOrder = w.pendingOrder[:0]
+	w.dispatchBacklog.Store(0)
 	return batch, true
 }
 
@@ -228,6 +236,7 @@ func (w *Watcher) stopDispatch() {
 	w.dispatchMu.Lock()
 	w.pendingOrder = nil
 	w.pendingUpdates = nil
+	w.dispatchBacklog.Store(0)
 	if w.dispatchCond != nil {
 		w.dispatchCond.Broadcast()
 	}

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -33,13 +33,23 @@ func (w *Watcher) start(ctx context.Context) error {
 	}
 	log.Debugf("watching config file: %s", w.configPath)
 
-	if errAddAuthDir := w.watcher.Add(w.authDir); errAddAuthDir != nil {
-		log.Errorf("failed to watch auth directory %s: %v", w.authDir, errAddAuthDir)
+	authDir := w.effectiveAuthDir()
+	if errAddAuthDir := w.watcher.Add(authDir); errAddAuthDir != nil {
+		log.Errorf("failed to watch auth directory %s: %v", authDir, errAddAuthDir)
 		return errAddAuthDir
 	}
-	log.Debugf("watching auth directory: %s", w.authDir)
+	log.Debugf("watching auth directory: %s", authDir)
 
-	go w.processEvents(ctx)
+	authCtx, cancel := context.WithCancel(ctx)
+	w.authEventMu.Lock()
+	if w.authEventCancel != nil {
+		w.authEventCancel()
+	}
+	w.authEventCtx = authCtx
+	w.authEventCancel = cancel
+	w.authEventMu.Unlock()
+
+	go w.processEvents(authCtx)
 
 	w.reloadClients(true, nil, false)
 	return nil
@@ -69,7 +79,7 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 	configOps := fsnotify.Write | fsnotify.Create | fsnotify.Rename
 	normalizedName := w.normalizeAuthPath(event.Name)
 	normalizedConfigPath := w.normalizeAuthPath(w.configPath)
-	normalizedAuthDir := w.normalizeAuthPath(w.authDir)
+	normalizedAuthDir := w.normalizeAuthPath(w.effectiveAuthDir())
 	isConfigEvent := normalizedName == normalizedConfigPath && event.Op&configOps != 0
 	authOps := fsnotify.Create | fsnotify.Write | fsnotify.Remove | fsnotify.Rename
 	isAuthJSON := strings.HasPrefix(normalizedName, normalizedAuthDir) && strings.HasSuffix(normalizedName, ".json") && event.Op&authOps != 0
@@ -88,40 +98,11 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 		return
 	}
 
-	// Handle auth directory changes incrementally (.json only)
-	if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
-		if w.shouldDebounceRemove(normalizedName, now) {
-			log.Debugf("debouncing remove event for %s", filepath.Base(event.Name))
-			return
-		}
-		// Atomic replace on some platforms may surface as Rename (or Remove) before the new file is ready.
-		// Wait briefly; if the path exists again, treat as an update instead of removal.
-		time.Sleep(replaceCheckDelay)
-		if _, statErr := os.Stat(event.Name); statErr == nil {
-			if unchanged, errSame := w.authFileUnchanged(event.Name); errSame == nil && unchanged {
-				log.Debugf("auth file unchanged (hash match), skipping reload: %s", filepath.Base(event.Name))
-				return
-			}
-			log.Infof("auth file changed (%s): %s, processing incrementally", event.Op.String(), filepath.Base(event.Name))
-			w.addOrUpdateClient(event.Name)
-			return
-		}
-		if !w.isKnownAuthFile(event.Name) {
-			log.Debugf("ignoring remove for unknown auth file: %s", filepath.Base(event.Name))
-			return
-		}
-		log.Infof("auth file changed (%s): %s, processing incrementally", event.Op.String(), filepath.Base(event.Name))
-		w.removeClient(event.Name)
-		return
-	}
-	if event.Op&(fsnotify.Create|fsnotify.Write) != 0 {
-		if unchanged, errSame := w.authFileUnchanged(event.Name); errSame == nil && unchanged {
-			log.Debugf("auth file unchanged (hash match), skipping reload: %s", filepath.Base(event.Name))
-			return
-		}
-		log.Infof("auth file changed (%s): %s, processing incrementally", event.Op.String(), filepath.Base(event.Name))
-		w.addOrUpdateClient(event.Name)
-	}
+	w.enqueueAuthEvent(authPathEvent{
+		path:       event.Name,
+		normalized: normalizedName,
+		op:         event.Op & authOps,
+	})
 }
 
 func (w *Watcher) authFileUnchanged(path string) (bool, error) {
@@ -191,4 +172,138 @@ func (w *Watcher) shouldDebounceRemove(normalizedPath string, now time.Time) boo
 	}
 	w.clientsMutex.Unlock()
 	return false
+}
+
+func (w *Watcher) enqueueAuthEvent(event authPathEvent) {
+	if w == nil || event.normalized == "" {
+		return
+	}
+	w.authEventMu.Lock()
+	ctx := w.authEventCtx
+	w.authEventMu.Unlock()
+	if ctx == nil {
+		w.processAuthEvent(event)
+		return
+	}
+	worker, _ := w.getOrCreateAuthWorker(event.normalized)
+	worker.mu.Lock()
+	if worker.hasPending {
+		worker.pending.op |= event.op
+		if strings.TrimSpace(event.path) != "" {
+			worker.pending.path = event.path
+		}
+	} else {
+		worker.pending = event
+		worker.hasPending = true
+	}
+	worker.mu.Unlock()
+
+	select {
+	case worker.signal <- struct{}{}:
+	default:
+	}
+}
+
+func (w *Watcher) getOrCreateAuthWorker(normalized string) (*authEventWorker, context.Context) {
+	w.authEventMu.Lock()
+	defer w.authEventMu.Unlock()
+	if w.authEventWorkers == nil {
+		w.authEventWorkers = make(map[string]*authEventWorker)
+	}
+	if worker, ok := w.authEventWorkers[normalized]; ok && worker != nil {
+		return worker, w.authEventCtx
+	}
+	worker := &authEventWorker{signal: make(chan struct{}, 1)}
+	ctx := w.authEventCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	w.authEventWorkers[normalized] = worker
+	go w.runAuthEventWorker(ctx, normalized, worker)
+	return worker, ctx
+}
+
+func (w *Watcher) runAuthEventWorker(ctx context.Context, normalized string, worker *authEventWorker) {
+	idle := time.NewTimer(authWorkerIdleTimeout)
+	defer idle.Stop()
+	defer w.removeAuthWorker(normalized, worker)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-idle.C:
+			return
+		case <-worker.signal:
+			if !idle.Stop() {
+				select {
+				case <-idle.C:
+				default:
+				}
+			}
+			for {
+				event, ok := worker.takePending()
+				if !ok {
+					break
+				}
+				w.processAuthEvent(event)
+			}
+			idle.Reset(authWorkerIdleTimeout)
+		}
+	}
+}
+
+func (w *Watcher) removeAuthWorker(normalized string, worker *authEventWorker) {
+	w.authEventMu.Lock()
+	defer w.authEventMu.Unlock()
+	if existing, ok := w.authEventWorkers[normalized]; ok && existing == worker {
+		delete(w.authEventWorkers, normalized)
+	}
+}
+
+func (w *Watcher) processAuthEvent(event authPathEvent) {
+	now := time.Now()
+	if event.op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+		if w.shouldDebounceRemove(event.normalized, now) {
+			log.Debugf("debouncing remove event for %s", filepath.Base(event.path))
+			return
+		}
+		time.Sleep(replaceCheckDelay)
+		if _, statErr := os.Stat(event.path); statErr == nil {
+			if unchanged, errSame := w.authFileUnchanged(event.path); errSame == nil && unchanged {
+				log.Debugf("auth file unchanged (hash match), skipping reload: %s", filepath.Base(event.path))
+				return
+			}
+			log.Infof("auth file changed (%s): %s, processing incrementally", event.op.String(), filepath.Base(event.path))
+			w.addOrUpdateClient(event.path)
+			return
+		}
+		if !w.isKnownAuthFile(event.path) {
+			log.Debugf("ignoring remove for unknown auth file: %s", filepath.Base(event.path))
+			return
+		}
+		log.Infof("auth file changed (%s): %s, processing incrementally", event.op.String(), filepath.Base(event.path))
+		w.removeClient(event.path)
+		return
+	}
+	if event.op&(fsnotify.Create|fsnotify.Write) != 0 {
+		if unchanged, errSame := w.authFileUnchanged(event.path); errSame == nil && unchanged {
+			log.Debugf("auth file unchanged (hash match), skipping reload: %s", filepath.Base(event.path))
+			return
+		}
+		log.Infof("auth file changed (%s): %s, processing incrementally", event.op.String(), filepath.Base(event.path))
+		w.addOrUpdateClient(event.path)
+	}
+}
+
+func (w *authEventWorker) takePending() (authPathEvent, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.hasPending {
+		return authPathEvent{}, false
+	}
+	event := w.pending
+	w.pending = authPathEvent{}
+	w.hasPending = false
+	return event, true
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -56,9 +56,28 @@ type Watcher struct {
 	pendingUpdates    map[string]AuthUpdate
 	pendingOrder      []string
 	dispatchCancel    context.CancelFunc
+	dispatchBacklog   atomic.Int64
+	dispatchMerged    atomic.Int64
+	authEventMu       sync.Mutex
+	authEventWorkers  map[string]*authEventWorker
+	authEventCtx      context.Context
+	authEventCancel   context.CancelFunc
 	storePersister    storePersister
 	mirroredAuthDir   string
 	oldConfigYaml     []byte
+}
+
+type authPathEvent struct {
+	path       string
+	normalized string
+	op         fsnotify.Op
+}
+
+type authEventWorker struct {
+	signal     chan struct{}
+	mu         sync.Mutex
+	pending    authPathEvent
+	hasPending bool
 }
 
 // AuthUpdateAction represents the type of change detected in auth sources.
@@ -84,6 +103,7 @@ const (
 	configReloadDebounce     = 150 * time.Millisecond
 	authRemoveDebounceWindow = 1 * time.Second
 	serverUpdateDebounce     = 1 * time.Second
+	authWorkerIdleTimeout    = 2 * time.Second
 )
 
 // NewWatcher creates a new file watcher instance
@@ -93,12 +113,13 @@ func NewWatcher(configPath, authDir string, reloadCallback func(*config.Config))
 		return nil, errNewWatcher
 	}
 	w := &Watcher{
-		configPath:      configPath,
-		authDir:         authDir,
-		reloadCallback:  reloadCallback,
-		watcher:         watcher,
-		lastAuthHashes:  make(map[string]string),
-		fileAuthsByPath: make(map[string]map[string]*coreauth.Auth),
+		configPath:       configPath,
+		authDir:          authDir,
+		reloadCallback:   reloadCallback,
+		watcher:          watcher,
+		lastAuthHashes:   make(map[string]string),
+		fileAuthsByPath:  make(map[string]map[string]*coreauth.Auth),
+		authEventWorkers: make(map[string]*authEventWorker),
 	}
 	w.dispatchCond = sync.NewCond(&w.dispatchMu)
 	if store := sdkAuth.GetTokenStore(); store != nil {
@@ -124,6 +145,7 @@ func (w *Watcher) Start(ctx context.Context) error {
 // Stop stops the file watcher
 func (w *Watcher) Stop() error {
 	w.stopped.Store(true)
+	w.stopAuthEventWorkers()
 	w.stopDispatch()
 	w.stopConfigReloadTimer()
 	w.stopServerUpdateTimer()
@@ -155,5 +177,27 @@ func (w *Watcher) SnapshotCoreAuths() []*coreauth.Auth {
 	w.clientsMutex.RLock()
 	cfg := w.config
 	w.clientsMutex.RUnlock()
-	return snapshotCoreAuths(cfg, w.authDir)
+	return snapshotCoreAuths(cfg, w.effectiveAuthDir())
+}
+
+func (w *Watcher) effectiveAuthDir() string {
+	if w == nil {
+		return ""
+	}
+	if fixed := strings.TrimSpace(w.mirroredAuthDir); fixed != "" {
+		return fixed
+	}
+	return w.authDir
+}
+
+func (w *Watcher) stopAuthEventWorkers() {
+	w.authEventMu.Lock()
+	cancel := w.authEventCancel
+	w.authEventCtx = nil
+	w.authEventCancel = nil
+	w.authEventWorkers = make(map[string]*authEventWorker)
+	w.authEventMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 }

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1155,6 +1155,145 @@ func TestHandleEventRemoveKnownFileDeletes(t *testing.T) {
 	}
 }
 
+func TestHandleEventAsyncWorkerCoalescesBurstAndPreservesFinalState(t *testing.T) {
+	tmpDir := t.TempDir()
+	authDir := filepath.Join(tmpDir, "auth")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatalf("failed to create auth dir: %v", err)
+	}
+	authFile := filepath.Join(authDir, "burst.json")
+
+	queue := make(chan AuthUpdate, 16)
+	w := &Watcher{
+		authDir:         authDir,
+		configPath:      filepath.Join(tmpDir, "config.yaml"),
+		lastAuthHashes:  make(map[string]string),
+		fileAuthsByPath: make(map[string]map[string]*coreauth.Auth),
+	}
+	w.SetConfig(&config.Config{AuthDir: authDir})
+	w.SetAuthUpdateQueue(queue)
+	defer w.stopDispatch()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.authEventMu.Lock()
+	w.authEventCtx = ctx
+	w.authEventCancel = cancel
+	w.authEventMu.Unlock()
+
+	writeAuth := func(email string) {
+		payload := []byte(fmt.Sprintf(`{"type":"codex","email":"%s"}`, email))
+		if err := os.WriteFile(authFile, payload, 0o644); err != nil {
+			t.Fatalf("write auth file: %v", err)
+		}
+	}
+
+	writeAuth("one@example.com")
+	w.handleEvent(fsnotify.Event{Name: authFile, Op: fsnotify.Write})
+	first := waitForAuthUpdate(t, queue)
+	if first.Action != AuthUpdateActionAdd {
+		t.Fatalf("expected first update action %q, got %+v", AuthUpdateActionAdd, first)
+	}
+	if first.Auth == nil || first.Auth.Label != "one@example.com" {
+		t.Fatalf("expected first auth label one@example.com, got %+v", first.Auth)
+	}
+
+	writeAuth("two@example.com")
+	w.handleEvent(fsnotify.Event{Name: authFile, Op: fsnotify.Rename})
+	w.handleEvent(fsnotify.Event{Name: authFile, Op: fsnotify.Write})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		w.clientsMutex.RLock()
+		auths := w.fileAuthsByPath[w.normalizeAuthPath(authFile)]
+		var gotLabel string
+		for _, auth := range auths {
+			if auth != nil {
+				gotLabel = auth.Label
+				break
+			}
+		}
+		w.clientsMutex.RUnlock()
+		if gotLabel == "two@example.com" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for final auth state, got label=%q", gotLabel)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	second := waitForAuthUpdate(t, queue)
+	if second.Action != AuthUpdateActionModify {
+		t.Fatalf("expected second update action %q, got %+v", AuthUpdateActionModify, second)
+	}
+	if second.Auth == nil || second.Auth.Label != "two@example.com" {
+		t.Fatalf("expected second auth label two@example.com, got %+v", second.Auth)
+	}
+
+	time.Sleep(authRemoveDebounceWindow + 50*time.Millisecond)
+	if err := os.Remove(authFile); err != nil {
+		t.Fatalf("remove auth file: %v", err)
+	}
+	w.handleEvent(fsnotify.Event{Name: authFile, Op: fsnotify.Remove})
+
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		w.clientsMutex.RLock()
+		_, exists := w.fileAuthsByPath[w.normalizeAuthPath(authFile)]
+		_, hashExists := w.lastAuthHashes[w.normalizeAuthPath(authFile)]
+		w.clientsMutex.RUnlock()
+		if !exists && !hashExists {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for auth removal, exists=%v hashExists=%v", exists, hashExists)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	third := waitForAuthUpdate(t, queue)
+	if third.Action != AuthUpdateActionDelete {
+		t.Fatalf("expected third update action %q, got %+v", AuthUpdateActionDelete, third)
+	}
+	if third.ID == "" {
+		t.Fatalf("expected delete update to include auth ID, got %+v", third)
+	}
+	select {
+	case extra := <-queue:
+		t.Fatalf("unexpected extra update after delete: %+v", extra)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestDispatchAuthUpdatesTracksBacklogAndMerge(t *testing.T) {
+	w := &Watcher{
+		authQueue: make(chan AuthUpdate, 1),
+	}
+
+	w.dispatchAuthUpdates([]AuthUpdate{{Action: AuthUpdateActionModify, ID: "same"}})
+	if got := w.dispatchBacklog.Load(); got != 1 {
+		t.Fatalf("dispatch backlog = %d, want 1", got)
+	}
+
+	w.dispatchAuthUpdates([]AuthUpdate{{Action: AuthUpdateActionModify, ID: "same"}})
+	if got := w.dispatchMerged.Load(); got != 1 {
+		t.Fatalf("dispatch merged = %d, want 1", got)
+	}
+	if got := len(w.pendingOrder); got != 1 {
+		t.Fatalf("pending order len = %d, want 1", got)
+	}
+}
+
+func waitForAuthUpdate(t *testing.T, queue <-chan AuthUpdate) AuthUpdate {
+	t.Helper()
+	select {
+	case update := <-queue:
+		return update
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for auth update")
+		return AuthUpdate{}
+	}
+}
+
 func TestNormalizeAuthPathAndDebounceCleanup(t *testing.T) {
 	w := &Watcher{}
 	if got := w.normalizeAuthPath("   "); got != "" {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1684,12 +1684,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 		}
 
-		_ = m.persist(ctx, auth)
 		authSnapshot = auth.Clone()
 	}
 	m.mu.Unlock()
 	if m.scheduler != nil && authSnapshot != nil {
 		m.scheduler.upsertAuth(authSnapshot)
+	}
+	if authSnapshot != nil {
+		_ = m.persist(ctx, authSnapshot)
 	}
 
 	if clearModelQuota && result.Model != "" {

--- a/sdk/cliproxy/auth/conductor_markresult_test.go
+++ b/sdk/cliproxy/auth/conductor_markresult_test.go
@@ -1,0 +1,272 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+type blockingStore struct {
+	saveStarted chan struct{}
+	releaseSave chan struct{}
+}
+
+func (s *blockingStore) List(context.Context) ([]*Auth, error) { return nil, nil }
+
+func (s *blockingStore) Save(ctx context.Context, auth *Auth) (string, error) {
+	select {
+	case s.saveStarted <- struct{}{}:
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case <-s.releaseSave:
+		return auth.ID, nil
+	}
+}
+
+func (s *blockingStore) Delete(context.Context, string) error { return nil }
+
+func TestManagerMarkResultDoesNotBlockSchedulerOnPersist(t *testing.T) {
+	t.Parallel()
+
+	manager := newMarkResultTestManager(t)
+	store := &blockingStore{
+		saveStarted: make(chan struct{}, 1),
+		releaseSave: make(chan struct{}),
+	}
+	manager.SetStore(store)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		manager.MarkResult(context.Background(), Result{
+			AuthID:   "gemini-a",
+			Provider: "gemini",
+			Model:    "test-model",
+			Success:  false,
+			Error:    &Error{HTTPStatus: 429, Message: "quota"},
+		})
+	}()
+
+	select {
+	case <-store.saveStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for persist to start")
+	}
+
+	pickDone := make(chan *Auth, 1)
+	go func() {
+		got, _, err := manager.pickNext(context.Background(), "gemini", "test-model", cliproxyexecutor.Options{}, nil)
+		if err != nil {
+			t.Errorf("pickNext() error = %v", err)
+			pickDone <- nil
+			return
+		}
+		pickDone <- got
+	}()
+
+	select {
+	case got := <-pickDone:
+		if got == nil || got.ID != "gemini-b" {
+			t.Fatalf("pickNext() auth = %v, want gemini-b", got)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("pickNext blocked on persist")
+	}
+
+	mixedDone := make(chan struct {
+		auth     *Auth
+		provider string
+	}, 1)
+	go func() {
+		got, _, provider, err := manager.pickNextMixed(context.Background(), []string{"gemini", "claude"}, "test-model", cliproxyexecutor.Options{}, nil)
+		if err != nil {
+			t.Errorf("pickNextMixed() error = %v", err)
+			mixedDone <- struct {
+				auth     *Auth
+				provider string
+			}{}
+			return
+		}
+		mixedDone <- struct {
+			auth     *Auth
+			provider string
+		}{auth: got, provider: provider}
+	}()
+
+	select {
+	case got := <-mixedDone:
+		if got.auth == nil {
+			t.Fatal("pickNextMixed() auth = nil")
+		}
+		if got.auth.ID == "gemini-a" {
+			t.Fatalf("pickNextMixed() returned cooled auth gemini-a: provider=%s", got.provider)
+		}
+		if got.provider != "gemini" && got.provider != "claude" {
+			t.Fatalf("pickNextMixed() provider = %q, want gemini/claude", got.provider)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("pickNextMixed blocked on persist")
+	}
+
+	close(store.releaseSave)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for MarkResult to finish")
+	}
+}
+
+func TestManagerMarkResultConcurrentPickNextAndPickNextMixedPreserveCooldownAndRecovery(t *testing.T) {
+	t.Parallel()
+
+	manager := newMarkResultTestManager(t)
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   "gemini-a",
+		Provider: "gemini",
+		Model:    "test-model",
+		Success:  false,
+		Error:    &Error{HTTPStatus: 429, Message: "quota"},
+	})
+
+	errCh := make(chan error, 128)
+	var wg sync.WaitGroup
+	for worker := 0; worker < 8; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for iter := 0; iter < 20; iter++ {
+				got, _, err := manager.pickNext(context.Background(), "gemini", "test-model", cliproxyexecutor.Options{}, map[string]struct{}{})
+				if err != nil {
+					errCh <- fmt.Errorf("worker %d pickNext: %w", worker, err)
+					return
+				}
+				if got == nil || got.ID != "gemini-b" {
+					errCh <- fmt.Errorf("worker %d pickNext got %v, want gemini-b", worker, got)
+					return
+				}
+
+				gotMixed, _, provider, err := manager.pickNextMixed(context.Background(), []string{"gemini", "claude"}, "test-model", cliproxyexecutor.Options{}, map[string]struct{}{})
+				if err != nil {
+					errCh <- fmt.Errorf("worker %d pickNextMixed: %w", worker, err)
+					return
+				}
+				if gotMixed == nil {
+					errCh <- fmt.Errorf("worker %d pickNextMixed returned nil auth", worker)
+					return
+				}
+				if gotMixed.ID == "gemini-a" {
+					errCh <- fmt.Errorf("worker %d pickNextMixed returned cooled auth gemini-a", worker)
+					return
+				}
+				if provider != "gemini" && provider != "claude" {
+					errCh <- fmt.Errorf("worker %d pickNextMixed provider=%q", worker, provider)
+					return
+				}
+			}
+		}(worker)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	recoveredManager := newMarkResultTestManager(t)
+	recoveredManager.MarkResult(context.Background(), Result{
+		AuthID:   "gemini-a",
+		Provider: "gemini",
+		Model:    "test-model",
+		Success:  false,
+		Error:    &Error{HTTPStatus: 429, Message: "quota"},
+	})
+	recoveredManager.MarkResult(context.Background(), Result{
+		AuthID:   "gemini-a",
+		Provider: "gemini",
+		Model:    "test-model",
+		Success:  true,
+	})
+
+	seenSingle := make(map[string]struct{}, 2)
+	for index := 0; index < 8; index++ {
+		got, _, err := recoveredManager.pickNext(context.Background(), "gemini", "test-model", cliproxyexecutor.Options{}, map[string]struct{}{})
+		if err != nil {
+			t.Fatalf("pickNext() after recovery #%d error = %v", index, err)
+		}
+		if got == nil {
+			t.Fatalf("pickNext() after recovery #%d auth = nil", index)
+		}
+		seenSingle[got.ID] = struct{}{}
+	}
+	if len(seenSingle) != 2 {
+		t.Fatalf("after recovery pickNext seen %v, want both gemini-a and gemini-b", seenSingle)
+	}
+
+	seenMixedGemini := make(map[string]struct{}, 2)
+	seenProviders := make(map[string]struct{}, 2)
+	for index := 0; index < 12; index++ {
+		got, _, provider, err := recoveredManager.pickNextMixed(context.Background(), []string{"gemini", "claude"}, "test-model", cliproxyexecutor.Options{}, map[string]struct{}{})
+		if err != nil {
+			t.Fatalf("pickNextMixed() after recovery #%d error = %v", index, err)
+		}
+		if got == nil {
+			t.Fatalf("pickNextMixed() after recovery #%d auth = nil", index)
+		}
+		seenProviders[provider] = struct{}{}
+		if provider == "gemini" {
+			seenMixedGemini[got.ID] = struct{}{}
+		}
+	}
+	if len(seenProviders) != 2 {
+		t.Fatalf("after recovery mixed providers seen %v, want gemini and claude", seenProviders)
+	}
+	if len(seenMixedGemini) != 2 {
+		t.Fatalf("after recovery mixed gemini auths seen %v, want both gemini-a and gemini-b", seenMixedGemini)
+	}
+}
+
+func newMarkResultTestManager(t *testing.T) *Manager {
+	t.Helper()
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.executors["gemini"] = schedulerTestExecutor{}
+	manager.executors["claude"] = schedulerTestExecutor{}
+
+	reg := registry.GetGlobalRegistry()
+	for _, item := range []struct {
+		id       string
+		provider string
+	}{
+		{id: "gemini-a", provider: "gemini"},
+		{id: "gemini-b", provider: "gemini"},
+		{id: "claude-a", provider: "claude"},
+	} {
+		reg.RegisterClient(item.id, item.provider, []*registry.ModelInfo{{ID: "test-model"}})
+	}
+	t.Cleanup(func() {
+		reg.UnregisterClient("gemini-a")
+		reg.UnregisterClient("gemini-b")
+		reg.UnregisterClient("claude-a")
+	})
+
+	for _, auth := range []*Auth{
+		{ID: "gemini-a", Provider: "gemini", Metadata: map[string]any{"persist": true}},
+		{ID: "gemini-b", Provider: "gemini", Metadata: map[string]any{"persist": true}},
+		{ID: "claude-a", Provider: "claude", Metadata: map[string]any{"persist": true}},
+	} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register %s: %v", auth.ID, err)
+		}
+	}
+	return manager
+}


### PR DESCRIPTION
## Summary
- move watcher auth-file heavy I/O out of the main fsnotify loop into per-path workers while keeping dispatch serialization intact
- propagate stream cancellation through shared sendChunk helpers for OpenAI-compatible, Kimi, and Qwen executors
- shrink Manager.MarkResult hot lock scope by persisting auth snapshots after in-memory/scheduler updates
- add regression coverage for watcher burst ordering, stream cancellation timing, and concurrent MarkResult + pickNext/pickNextMixed behavior

## Impacted Areas
- internal/watcher
- internal/runtime/executor
- sdk/cliproxy/auth

## Verification
- go test ./internal/watcher ./internal/runtime/executor ./sdk/cliproxy/auth
- go test ./...
- go build -o test-output ./cmd/server
- go vet ./...

## Notes
- keeps cooldown, fair rotation, Gemini virtual parent handling, and Codex websocket preference semantics unchanged
- packaged as the P1 hot-path mitigation slice for low-risk rollback