### PR TITLE
fix(translator): backfill empty functionResponse.name to prevent Gemini API 400 errors

### DIFF
--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -138,20 +138,38 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 // FunctionCallGroup represents a group of function calls and their responses
 type FunctionCallGroup struct {
 	ResponsesNeeded int
+	CallNames       []string // ordered function call names for backfilling
 }
 
 // parseFunctionResponseRaw attempts to normalize a function response part into a JSON object string.
 // Falls back to a minimal "functionResponse" object when parsing fails.
-func parseFunctionResponseRaw(response gjson.Result) string {
+// If a non-empty backfillName is provided and the functionResponse.name is empty, it will be set.
+func parseFunctionResponseRaw(response gjson.Result, backfillName string) string {
 	if response.IsObject() && gjson.Valid(response.Raw) {
+		fr := response.Get("functionResponse")
+		if fr.Exists() && fr.Get("name").String() == "" {
+			nameToSet := backfillName
+			if nameToSet == "" {
+				nameToSet = "unknown"
+			}
+			patched, _ := sjson.Set(response.Raw, "functionResponse.name", nameToSet)
+			return patched
+		}
 		return response.Raw
 	}
 
 	log.Debugf("parse function response failed, using fallback")
 	funcResp := response.Get("functionResponse")
 	if funcResp.Exists() {
+		name := funcResp.Get("name").String()
+		if name == "" {
+			name = backfillName
+		}
+		if name == "" {
+			name = "unknown"
+		}
 		fr := `{"functionResponse":{"name":"","response":{"result":""}}}`
-		fr, _ = sjson.Set(fr, "functionResponse.name", funcResp.Get("name").String())
+		fr, _ = sjson.Set(fr, "functionResponse.name", name)
 		fr, _ = sjson.Set(fr, "functionResponse.response.result", funcResp.Get("response").String())
 		if id := funcResp.Get("id").String(); id != "" {
 			fr, _ = sjson.Set(fr, "functionResponse.id", id)
@@ -221,8 +239,12 @@ func fixCLIToolResponse(input string) (string, error) {
 
 					// Create merged function response content
 					functionResponseContent := `{"parts":[],"role":"function"}`
-					for _, response := range groupResponses {
-						partRaw := parseFunctionResponseRaw(response)
+					for ri, response := range groupResponses {
+						backfillName := ""
+						if ri < len(group.CallNames) {
+							backfillName = group.CallNames[ri]
+						}
+						partRaw := parseFunctionResponseRaw(response, backfillName)
 						if partRaw != "" {
 							functionResponseContent, _ = sjson.SetRaw(functionResponseContent, "parts.-1", partRaw)
 						}
@@ -243,15 +265,15 @@ func fixCLIToolResponse(input string) (string, error) {
 
 		// If this is a model with function calls, create a new group
 		if role == "model" {
-			functionCallsCount := 0
+			var callNames []string
 			parts.ForEach(func(_, part gjson.Result) bool {
-				if part.Get("functionCall").Exists() {
-					functionCallsCount++
+				if fc := part.Get("functionCall"); fc.Exists() {
+					callNames = append(callNames, fc.Get("name").String())
 				}
 				return true
 			})
 
-			if functionCallsCount > 0 {
+			if len(callNames) > 0 {
 				// Add the model content
 				if !value.IsObject() {
 					log.Warnf("failed to parse model content")
@@ -261,7 +283,8 @@ func fixCLIToolResponse(input string) (string, error) {
 
 				// Create a new group for tracking responses
 				group := &FunctionCallGroup{
-					ResponsesNeeded: functionCallsCount,
+					ResponsesNeeded: len(callNames),
+					CallNames:       callNames,
 				}
 				pendingGroups = append(pendingGroups, group)
 			} else {
@@ -291,8 +314,12 @@ func fixCLIToolResponse(input string) (string, error) {
 			collectedResponses = collectedResponses[group.ResponsesNeeded:]
 
 			functionResponseContent := `{"parts":[],"role":"function"}`
-			for _, response := range groupResponses {
-				partRaw := parseFunctionResponseRaw(response)
+			for ri, response := range groupResponses {
+				backfillName := ""
+				if ri < len(group.CallNames) {
+					backfillName = group.CallNames[ri]
+				}
+				partRaw := parseFunctionResponseRaw(response, backfillName)
 				if partRaw != "" {
 					functionResponseContent, _ = sjson.SetRaw(functionResponseContent, "parts.-1", partRaw)
 				}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -107,6 +107,18 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 			i++
 		}
 
+		// Build call_id -> name map from function_call items for resolving function_call_output names
+		callID2Name := make(map[string]string)
+		for _, item := range normalized {
+			if item.Get("type").String() == "function_call" {
+				if cid := item.Get("call_id").String(); cid != "" {
+					if name := item.Get("name").String(); name != "" {
+						callID2Name[cid] = name
+					}
+				}
+			}
+		}
+
 		for _, item := range normalized {
 			itemType := item.Get("type").String()
 			itemRole := item.Get("role").String()
@@ -318,20 +330,10 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				functionContent := `{"role":"function","parts":[]}`
 				functionResponse := `{"functionResponse":{"name":"","response":{}}}`
 
-				// We need to extract the function name from the previous function_call
-				// For now, we'll use a placeholder or extract from context if available
-				functionName := "unknown" // This should ideally be matched with the corresponding function_call
-
-				// Find the corresponding function call name by matching call_id
-				// We need to look back through the input array to find the matching call
-				if inputArray := root.Get("input"); inputArray.Exists() && inputArray.IsArray() {
-					inputArray.ForEach(func(_, prevItem gjson.Result) bool {
-						if prevItem.Get("type").String() == "function_call" && prevItem.Get("call_id").String() == callID {
-							functionName = prevItem.Get("name").String()
-							return false // Stop iteration
-						}
-						return true
-					})
+				// Resolve function name from the pre-built call_id -> name map
+				functionName := "unknown"
+				if name, ok := callID2Name[callID]; ok {
+					functionName = name
 				}
 
 				functionResponse, _ = sjson.Set(functionResponse, "functionResponse.name", functionName)


### PR DESCRIPTION
Fixes #2104

## Problem

When proxying requests to Google's Gemini API via the antigravity translator, `functionResponse` parts were sent with empty `name` fields, causing 400 errors:

```
GenerateContentRequest.contents[].parts[].function_response.name: Name cannot be empty.
```

This affected clients like Amp that send `functionResponse` parts without populating the `name` field.

## Root Cause

Incoming requests include `functionResponse` parts without a `name` field (or with an empty name). The proxy forwarded them as-is to Gemini without resolving the name from the corresponding `functionCall` in the preceding model content.

## Fix

### `antigravity_gemini_request.go`
- `fixCLIToolResponse` now collects `functionCall` names positionally from model content parts into `FunctionCallGroup.CallNames`
- `parseFunctionResponseRaw` accepts a `backfillName` parameter and guarantees a non-empty `functionResponse.name` across all code paths (backfillName → `"unknown"` fallback)

### `gemini_openai-responses_request.go`  
- Pre-builds a `callID→name` map from normalized `function_call` items instead of scanning the raw input array (matching the proven `tcID2Name` pattern from chat-completions)

## Testing
- All existing tests pass (`51 passed in 4 packages`)
- Verified end-to-end with Amp's finder subagent through the proxy — previously failing requests now succeed