### PR TITLE
Fix missing streaming usage tracking for OpenAI-compatible providers

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -205,6 +205,10 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		return nil, err
 	}
 
+	// Request usage data in the final streaming chunk so that token statistics
+	// are captured even when the upstream is an OpenAI-compatible provider.
+	translated, _ = sjson.SetBytes(translated, "stream_options.include_usage", true)
+
 	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
 	if err != nil {


### PR DESCRIPTION
OpenAI-compatible upstreams don't return usage data in streaming mode unless `stream_options.include_usage` is explicitly set to `true` in the request. This was already handled in `kimi_executor` and `qwen_executor`, but missed in `openai_compat_executor`.

As a result, all streaming requests through `openai-compatibility` providers showed 0 tokens in the usage statistics panel, while non-streaming requests worked fine.

**Fix:** Add `stream_options.include_usage: true` to the translated streaming payload in `OpenAICompatExecutor.ExecuteStream()`, matching the existing pattern in kimi/qwen executors.