### PR TITLE
fix: add default transport timeouts to prevent indefinite hangs (#2113)

### DIFF
--- a/internal/runtime/executor/proxy_helpers.go
+++ b/internal/runtime/executor/proxy_helpers.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -10,6 +11,15 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
+)
+
+// Connection-setup timeouts. Safe for streaming — only affect dial/TLS/headers, not body reads.
+const (
+	defaultDialTimeout           = 10 * time.Second
+	defaultDialKeepAlive         = 30 * time.Second
+	defaultTLSHandshakeTimeout   = 10 * time.Second
+	defaultResponseHeaderTimeout = 30 * time.Second
+	defaultIdleConnTimeout       = 90 * time.Second
 )
 
 // newProxyAwareHTTPClient creates an HTTP client with proper proxy configuration priority:
@@ -56,24 +66,55 @@ func newProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	// Priority 3: Use RoundTripper from context (typically from RoundTripperFor)
 	if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
 		httpClient.Transport = rt
+		return httpClient
 	}
 
+	// No proxy, no context RT — use default transport with timeouts.
+	httpClient.Transport = newDefaultTransport()
 	return httpClient
 }
 
-// buildProxyTransport creates an HTTP transport configured for the given proxy URL.
-// It supports SOCKS5, HTTP, and HTTPS proxy protocols.
-//
-// Parameters:
-//   - proxyURL: The proxy URL string (e.g., "socks5://user:pass@host:port", "http://host:port")
-//
-// Returns:
-//   - *http.Transport: A configured transport, or nil if the proxy URL is invalid
+// buildProxyTransport creates a proxy-configured transport with timeouts.
+// Supports SOCKS5, HTTP, HTTPS proxies. Returns nil on invalid URL.
 func buildProxyTransport(proxyURL string) *http.Transport {
 	transport, _, errBuild := proxyutil.BuildHTTPTransport(proxyURL)
 	if errBuild != nil {
 		log.Errorf("%v", errBuild)
 		return nil
 	}
+	if transport != nil {
+		applyTransportTimeouts(transport)
+	}
 	return transport
+}
+
+// newDefaultTransport returns a transport with default timeouts.
+func newDefaultTransport() *http.Transport {
+	t := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 10,
+		ForceAttemptHTTP2:   true,
+	}
+	applyTransportTimeouts(t)
+	return t
+}
+
+// applyTransportTimeouts sets dial/TLS/header timeouts. Skips already-set fields.
+func applyTransportTimeouts(t *http.Transport) {
+	if t.DialContext == nil {
+		t.DialContext = (&net.Dialer{
+			Timeout:   defaultDialTimeout,
+			KeepAlive: defaultDialKeepAlive,
+		}).DialContext
+	}
+	if t.TLSHandshakeTimeout == 0 {
+		t.TLSHandshakeTimeout = defaultTLSHandshakeTimeout
+	}
+	if t.ResponseHeaderTimeout == 0 {
+		t.ResponseHeaderTimeout = defaultResponseHeaderTimeout
+	}
+	if t.IdleConnTimeout == 0 {
+		t.IdleConnTimeout = defaultIdleConnTimeout
+	}
 }

--- a/internal/runtime/executor/proxy_helpers_test.go
+++ b/internal/runtime/executor/proxy_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -26,5 +27,67 @@ func TestNewProxyAwareHTTPClientDirectBypassesGlobalProxy(t *testing.T) {
 	}
 	if transport.Proxy != nil {
 		t.Fatal("expected direct transport to disable proxy function")
+	}
+}
+
+func TestNewProxyAwareHTTPClientDefaultTransportTimeouts(t *testing.T) {
+	t.Parallel()
+
+	client := newProxyAwareHTTPClient(context.Background(), nil, nil, 0)
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+	}
+	if transport.TLSHandshakeTimeout != defaultTLSHandshakeTimeout {
+		t.Errorf("TLSHandshakeTimeout = %v, want %v", transport.TLSHandshakeTimeout, defaultTLSHandshakeTimeout)
+	}
+	if transport.ResponseHeaderTimeout != defaultResponseHeaderTimeout {
+		t.Errorf("ResponseHeaderTimeout = %v, want %v", transport.ResponseHeaderTimeout, defaultResponseHeaderTimeout)
+	}
+	if transport.IdleConnTimeout != defaultIdleConnTimeout {
+		t.Errorf("IdleConnTimeout = %v, want %v", transport.IdleConnTimeout, defaultIdleConnTimeout)
+	}
+	if transport.DialContext == nil {
+		t.Error("expected DialContext to be set")
+	}
+}
+
+func TestNewProxyAwareHTTPClientExplicitTimeoutPreserved(t *testing.T) {
+	t.Parallel()
+
+	explicit := 120 * time.Second
+	client := newProxyAwareHTTPClient(context.Background(), nil, nil, explicit)
+
+	if client.Timeout != explicit {
+		t.Errorf("client.Timeout = %v, want %v", client.Timeout, explicit)
+	}
+}
+
+func TestNewProxyAwareHTTPClientZeroTimeoutNoClientTimeout(t *testing.T) {
+	t.Parallel()
+
+	client := newProxyAwareHTTPClient(context.Background(), nil, nil, 0)
+
+	if client.Timeout != 0 {
+		t.Errorf("client.Timeout = %v, want 0 (safe for streaming)", client.Timeout)
+	}
+}
+
+func TestBuildProxyTransportAppliesTimeouts(t *testing.T) {
+	t.Parallel()
+
+	transport := buildProxyTransport("http://proxy.example.com:8080")
+	if transport == nil {
+		t.Fatal("expected non-nil transport for valid proxy URL")
+	}
+	if transport.TLSHandshakeTimeout != defaultTLSHandshakeTimeout {
+		t.Errorf("TLSHandshakeTimeout = %v, want %v", transport.TLSHandshakeTimeout, defaultTLSHandshakeTimeout)
+	}
+	if transport.ResponseHeaderTimeout != defaultResponseHeaderTimeout {
+		t.Errorf("ResponseHeaderTimeout = %v, want %v", transport.ResponseHeaderTimeout, defaultResponseHeaderTimeout)
+	}
+	if transport.IdleConnTimeout != defaultIdleConnTimeout {
+		t.Errorf("IdleConnTimeout = %v, want %v", transport.IdleConnTimeout, defaultIdleConnTimeout)
 	}
 }


### PR DESCRIPTION
Fixes #2113 - App freezes in offline/restricted environments due to missing timeouts in `newProxyAwareHTTPClient()`.

Changes:
- Added transport-level timeouts (10s dial/TLS, 30s header, 90s idle) to `buildProxyTransport()` and `newDefaultTransport()`.
- `newProxyAwareHTTPClient` now returns a transport with timeouts by default instead of a bare `http.Client{}`.
- `http.Client.Timeout` is kept at 0 to avoid breaking SSE/streaming.
- `applyTransportTimeouts` preserves existing fields to avoid overwriting proxy settings.

Files:
- `internal/runtime/executor/proxy_helpers.go` (logic)
- `internal/runtime/executor/proxy_helpers_test.go` (4 new tests)

All executor tests pass.