### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -226,6 +226,21 @@ nonstream-keepalive-interval: 0
 #   user-agent: "codex_cli_rs/0.114.0 (Mac OS 14.2.0; x86_64) vscode/1.111.0"
 #   beta-features: "multi_agent"
 
+# MiniMax API keys (OpenAI-compatible endpoint at api.minimax.io/v1)
+# minimax-api-key:
+#   - api-key: "eyJhbGci..."
+#     prefix: "test" # optional: require calls like "test/MiniMax-M2.7" to target this credential
+#     base-url: "https://api.minimax.io/v1" # optional: defaults to https://api.minimax.io/v1
+#     headers:
+#       X-Custom-Header: "custom-value"
+#     proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
+#     # proxy-url: "direct" # optional: explicit direct connect for this credential
+#     models:
+#       - name: "MiniMax-M2.7"           # upstream model name
+#         alias: "minimax-latest"        # client alias mapped to the upstream model
+#     excluded-models:
+#       - "MiniMax-M2.7-highspeed"
+
 # OpenAI compatibility providers
 # openai-compatibility:
 #   - name: "openrouter" # The name of the provider; it will be used in the user agent and other places.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,9 @@ type Config struct {
 	// OpenAICompatibility defines OpenAI API compatibility configurations for external providers.
 	OpenAICompatibility []OpenAICompatibility `yaml:"openai-compatibility" json:"openai-compatibility"`
 
+	// MiniMaxKey defines a list of MiniMax API key configurations as specified in the YAML configuration file.
+	MiniMaxKey []MiniMaxKey `yaml:"minimax-api-key" json:"minimax-api-key"`
+
 	// VertexCompatAPIKey defines Vertex AI-compatible API key configurations for third-party providers.
 	// Used for services that use Vertex AI-style paths but with simple API key authentication.
 	VertexCompatAPIKey []VertexCompatKey `yaml:"vertex-api-key" json:"vertex-api-key"`
@@ -560,6 +563,51 @@ type OpenAICompatibilityModel struct {
 func (m OpenAICompatibilityModel) GetName() string  { return m.Name }
 func (m OpenAICompatibilityModel) GetAlias() string { return m.Alias }
 
+// MiniMaxKey represents the configuration for a MiniMax API key,
+// including optional overrides for the API endpoint, proxy routing, headers, and model aliases.
+type MiniMaxKey struct {
+	// APIKey is the authentication key for accessing MiniMax API services.
+	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// Priority controls selection preference when multiple credentials match.
+	// Higher values are preferred; defaults to 0.
+	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+
+	// Prefix optionally namespaces models for this credential (e.g., "teamA/MiniMax-M2.7").
+	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+
+	// BaseURL is the base URL for the MiniMax API endpoint.
+	// If empty, defaults to https://api.minimax.io/v1.
+	BaseURL string `yaml:"base-url,omitempty" json:"base-url,omitempty"`
+
+	// ProxyURL overrides the global proxy setting for this API key if provided.
+	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
+
+	// Models defines upstream model names and aliases for request routing.
+	Models []MiniMaxModel `yaml:"models,omitempty" json:"models,omitempty"`
+
+	// Headers optionally adds extra HTTP headers for requests sent with this key.
+	Headers map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+
+	// ExcludedModels lists model IDs that should be excluded for this provider.
+	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
+}
+
+func (k MiniMaxKey) GetAPIKey() string  { return k.APIKey }
+func (k MiniMaxKey) GetBaseURL() string { return k.BaseURL }
+
+// MiniMaxModel describes a mapping between an alias and the actual upstream MiniMax model name.
+type MiniMaxModel struct {
+	// Name is the upstream model identifier used when issuing requests.
+	Name string `yaml:"name" json:"name"`
+
+	// Alias is the client-facing model name that maps to Name.
+	Alias string `yaml:"alias" json:"alias"`
+}
+
+func (m MiniMaxModel) GetName() string  { return m.Name }
+func (m MiniMaxModel) GetAlias() string { return m.Alias }
+
 // LoadConfig reads a YAML configuration file from the given path,
 // unmarshals it into a Config struct, applies environment variable overrides,
 // and returns it.
@@ -688,6 +736,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	// Sanitize OpenAI compatibility providers: drop entries without base-url
 	cfg.SanitizeOpenAICompatibility()
+
+	// Sanitize MiniMax keys: drop entries without api-key
+	cfg.SanitizeMiniMaxKeys()
 
 	// Normalize OAuth provider model exclusion map.
 	cfg.OAuthExcludedModels = NormalizeOAuthExcludedModels(cfg.OAuthExcludedModels)
@@ -889,6 +940,27 @@ func (cfg *Config) SanitizeClaudeKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
 	}
+}
+
+// SanitizeMiniMaxKeys normalizes headers and removes MiniMax API key entries missing an API key.
+func (cfg *Config) SanitizeMiniMaxKeys() {
+	if cfg == nil || len(cfg.MiniMaxKey) == 0 {
+		return
+	}
+	out := make([]MiniMaxKey, 0, len(cfg.MiniMaxKey))
+	for i := range cfg.MiniMaxKey {
+		e := cfg.MiniMaxKey[i]
+		e.APIKey = strings.TrimSpace(e.APIKey)
+		e.Prefix = normalizeModelPrefix(e.Prefix)
+		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.Headers = NormalizeHeaders(e.Headers)
+		e.ExcludedModels = NormalizeExcludedModels(e.ExcludedModels)
+		if e.APIKey == "" {
+			continue
+		}
+		out = append(out, e)
+	}
+	cfg.MiniMaxKey = out
 }
 
 // SanitizeGeminiKeys deduplicates and normalizes Gemini credentials.

--- a/internal/config/minimax_test.go
+++ b/internal/config/minimax_test.go
@@ -10,7 +10,7 @@ func TestSanitizeMiniMaxKeys(t *testing.T) {
 	cfg := &Config{
 		MiniMaxKey: []MiniMaxKey{
 			{APIKey: "  key1  ", BaseURL: "  https://api.minimax.io/v1  "},
-			{APIKey: ""},   // should be removed
+			{APIKey: ""}, // should be removed
 			{APIKey: "key2", Prefix: "  myprefix  "},
 		},
 	}

--- a/internal/config/minimax_test.go
+++ b/internal/config/minimax_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSanitizeMiniMaxKeys(t *testing.T) {
+	cfg := &Config{
+		MiniMaxKey: []MiniMaxKey{
+			{APIKey: "  key1  ", BaseURL: "  https://api.minimax.io/v1  "},
+			{APIKey: ""},   // should be removed
+			{APIKey: "key2", Prefix: "  myprefix  "},
+		},
+	}
+	cfg.SanitizeMiniMaxKeys()
+	if len(cfg.MiniMaxKey) != 2 {
+		t.Fatalf("expected 2 keys after sanitize, got %d", len(cfg.MiniMaxKey))
+	}
+	if cfg.MiniMaxKey[0].APIKey != "key1" {
+		t.Errorf("expected trimmed APIKey, got %q", cfg.MiniMaxKey[0].APIKey)
+	}
+	if cfg.MiniMaxKey[0].BaseURL != "https://api.minimax.io/v1" {
+		t.Errorf("expected trimmed BaseURL, got %q", cfg.MiniMaxKey[0].BaseURL)
+	}
+	if cfg.MiniMaxKey[1].Prefix != "myprefix" {
+		t.Errorf("expected trimmed prefix, got %q", cfg.MiniMaxKey[1].Prefix)
+	}
+}
+
+func TestLoadConfigOptional_MiniMaxAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	configYAML := []byte(`
+minimax-api-key:
+  - api-key: "test-minimax-key"
+    base-url: "https://api.minimax.io/v1"
+    models:
+      - name: "MiniMax-M2.7"
+        alias: "minimax-latest"
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+	if len(cfg.MiniMaxKey) != 1 {
+		t.Fatalf("expected 1 MiniMax key, got %d", len(cfg.MiniMaxKey))
+	}
+	k := cfg.MiniMaxKey[0]
+	if k.APIKey != "test-minimax-key" {
+		t.Errorf("expected api-key=test-minimax-key, got %q", k.APIKey)
+	}
+	if k.BaseURL != "https://api.minimax.io/v1" {
+		t.Errorf("expected base-url=https://api.minimax.io/v1, got %q", k.BaseURL)
+	}
+	if len(k.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(k.Models))
+	}
+	if k.Models[0].Name != "MiniMax-M2.7" {
+		t.Errorf("expected model name=MiniMax-M2.7, got %q", k.Models[0].Name)
+	}
+	if k.Models[0].Alias != "minimax-latest" {
+		t.Errorf("expected model alias=minimax-latest, got %q", k.Models[0].Alias)
+	}
+}

--- a/internal/registry/minimax_test.go
+++ b/internal/registry/minimax_test.go
@@ -1,0 +1,55 @@
+package registry
+
+import "testing"
+
+func TestGetMiniMaxModels(t *testing.T) {
+	models := GetMiniMaxModels()
+	if len(models) == 0 {
+		t.Fatal("expected at least one MiniMax model")
+	}
+
+	hasM27 := false
+	hasM27Highspeed := false
+	for _, m := range models {
+		if m.ID == "MiniMax-M2.7" {
+			hasM27 = true
+			if m.OwnedBy != "minimax" {
+				t.Errorf("expected owned_by=minimax, got %s", m.OwnedBy)
+			}
+			if m.Type != "minimax" {
+				t.Errorf("expected type=minimax, got %s", m.Type)
+			}
+		}
+		if m.ID == "MiniMax-M2.7-highspeed" {
+			hasM27Highspeed = true
+		}
+	}
+	if !hasM27 {
+		t.Error("expected MiniMax-M2.7 in model list")
+	}
+	if !hasM27Highspeed {
+		t.Error("expected MiniMax-M2.7-highspeed in model list")
+	}
+}
+
+func TestGetStaticModelDefinitionsByChannelMiniMax(t *testing.T) {
+	models := GetStaticModelDefinitionsByChannel("minimax")
+	if len(models) == 0 {
+		t.Fatal("expected models for minimax channel")
+	}
+}
+
+func TestLookupStaticModelInfoMiniMax(t *testing.T) {
+	m := LookupStaticModelInfo("MiniMax-M2.7")
+	if m == nil {
+		t.Fatal("expected to find MiniMax-M2.7 in static model info")
+	}
+	if m.ID != "MiniMax-M2.7" {
+		t.Errorf("expected ID=MiniMax-M2.7, got %s", m.ID)
+	}
+
+	m2 := LookupStaticModelInfo("MiniMax-M2.7-highspeed")
+	if m2 == nil {
+		t.Fatal("expected to find MiniMax-M2.7-highspeed in static model info")
+	}
+}

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -19,6 +19,7 @@ type staticModelsJSON struct {
 	CodexPro    []*ModelInfo `json:"codex-pro"`
 	Kimi        []*ModelInfo `json:"kimi"`
 	Antigravity []*ModelInfo `json:"antigravity"`
+	MiniMax     []*ModelInfo `json:"minimax"`
 }
 
 // GetClaudeModels returns the standard Claude model definitions.
@@ -76,6 +77,11 @@ func GetAntigravityModels() []*ModelInfo {
 	return cloneModelInfos(getModels().Antigravity)
 }
 
+// GetMiniMaxModels returns the standard MiniMax model definitions.
+func GetMiniMaxModels() []*ModelInfo {
+	return cloneModelInfos(getModels().MiniMax)
+}
+
 // cloneModelInfos returns a shallow copy of the slice with each element deep-cloned.
 func cloneModelInfos(models []*ModelInfo) []*ModelInfo {
 	if len(models) == 0 {
@@ -100,6 +106,7 @@ func cloneModelInfos(models []*ModelInfo) []*ModelInfo {
 //   - codex
 //   - kimi
 //   - antigravity
+//   - minimax
 func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	key := strings.ToLower(strings.TrimSpace(channel))
 	switch key {
@@ -119,6 +126,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		return GetKimiModels()
 	case "antigravity":
 		return GetAntigravityModels()
+	case "minimax":
+		return GetMiniMaxModels()
 	default:
 		return nil
 	}
@@ -141,6 +150,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		data.CodexPro,
 		data.Kimi,
 		data.Antigravity,
+		data.MiniMax,
 	}
 	for _, models := range allModels {
 		for _, m := range models {

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -215,6 +215,7 @@ func detectChangedProviders(oldData, newData *staticModelsJSON) []string {
 		{"codex", oldData.CodexPro, newData.CodexPro},
 		{"kimi", oldData.Kimi, newData.Kimi},
 		{"antigravity", oldData.Antigravity, newData.Antigravity},
+		{"minimax", oldData.MiniMax, newData.MiniMax},
 	}
 
 	seen := make(map[string]bool, len(sections))
@@ -335,6 +336,7 @@ func validateModelsCatalog(data *staticModelsJSON) error {
 		{name: "codex-pro", models: data.CodexPro},
 		{name: "kimi", models: data.Kimi},
 		{name: "antigravity", models: data.Antigravity},
+		{name: "minimax", models: data.MiniMax},
 	}
 
 	for _, section := range requiredSections {

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1863,5 +1863,29 @@
         ]
       }
     }
+  ],
+  "minimax": [
+    {
+      "id": "MiniMax-M2.7",
+      "object": "model",
+      "created": 1745280000,
+      "owned_by": "minimax",
+      "type": "minimax",
+      "display_name": "MiniMax M2.7",
+      "description": "Peak Performance. Ultimate Value. Master the Complex.",
+      "context_length": 1000000,
+      "max_completion_tokens": 40960
+    },
+    {
+      "id": "MiniMax-M2.7-highspeed",
+      "object": "model",
+      "created": 1745280000,
+      "owned_by": "minimax",
+      "type": "minimax",
+      "display_name": "MiniMax M2.7 Highspeed",
+      "description": "Same performance, faster and more agile.",
+      "context_length": 1000000,
+      "max_completion_tokens": 40960
+    }
   ]
 }

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -55,8 +55,8 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 		w.clientsMutex.Unlock()
 	}
 
-	geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, openAICompatCount := BuildAPIKeyClients(cfg)
-	totalAPIKeyClients := geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + openAICompatCount
+	geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, openAICompatCount, miniMaxAPIKeyCount := BuildAPIKeyClients(cfg)
+	totalAPIKeyClients := geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + openAICompatCount + miniMaxAPIKeyCount
 	log.Debugf("loaded %d API key clients", totalAPIKeyClients)
 
 	var authFileCount int
@@ -126,7 +126,7 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 		w.clientsMutex.Unlock()
 	}
 
-	totalNewClients := authFileCount + geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + openAICompatCount
+	totalNewClients := authFileCount + geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + openAICompatCount + miniMaxAPIKeyCount
 
 	if w.reloadCallback != nil {
 		log.Debugf("triggering server update callback before auth refresh")
@@ -135,7 +135,7 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 
 	w.refreshAuthState(forceAuthRefresh)
 
-	log.Infof("full client load complete - %d clients (%d auth files + %d Gemini API keys + %d Vertex API keys + %d Claude API keys + %d Codex keys + %d OpenAI-compat)",
+	log.Infof("full client load complete - %d clients (%d auth files + %d Gemini API keys + %d Vertex API keys + %d Claude API keys + %d Codex keys + %d OpenAI-compat + %d MiniMax keys)",
 		totalNewClients,
 		authFileCount,
 		geminiAPIKeyCount,
@@ -143,6 +143,7 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 		claudeAPIKeyCount,
 		codexAPIKeyCount,
 		openAICompatCount,
+		miniMaxAPIKeyCount,
 	)
 }
 
@@ -336,12 +337,13 @@ func (w *Watcher) loadFileClients(cfg *config.Config) int {
 	return authFileCount
 }
 
-func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int) {
+func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int) {
 	geminiAPIKeyCount := 0
 	vertexCompatAPIKeyCount := 0
 	claudeAPIKeyCount := 0
 	codexAPIKeyCount := 0
 	openAICompatCount := 0
+	miniMaxAPIKeyCount := 0
 
 	if len(cfg.GeminiKey) > 0 {
 		geminiAPIKeyCount += len(cfg.GeminiKey)
@@ -360,7 +362,10 @@ func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int) {
 			openAICompatCount += len(compatConfig.APIKeyEntries)
 		}
 	}
-	return geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, openAICompatCount
+	if len(cfg.MiniMaxKey) > 0 {
+		miniMaxAPIKeyCount += len(cfg.MiniMaxKey)
+	}
+	return geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, openAICompatCount, miniMaxAPIKeyCount
 }
 
 func (w *Watcher) persistConfigAsync() {

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -212,6 +212,40 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 		}
 	}
 
+	if len(oldCfg.MiniMaxKey) != len(newCfg.MiniMaxKey) {
+		changes = append(changes, fmt.Sprintf("minimax-api-key count: %d -> %d", len(oldCfg.MiniMaxKey), len(newCfg.MiniMaxKey)))
+	} else {
+		for i := range oldCfg.MiniMaxKey {
+			o := oldCfg.MiniMaxKey[i]
+			n := newCfg.MiniMaxKey[i]
+			if strings.TrimSpace(o.BaseURL) != strings.TrimSpace(n.BaseURL) {
+				changes = append(changes, fmt.Sprintf("minimax[%d].base-url: %s -> %s", i, strings.TrimSpace(o.BaseURL), strings.TrimSpace(n.BaseURL)))
+			}
+			if strings.TrimSpace(o.ProxyURL) != strings.TrimSpace(n.ProxyURL) {
+				changes = append(changes, fmt.Sprintf("minimax[%d].proxy-url: %s -> %s", i, formatProxyURL(o.ProxyURL), formatProxyURL(n.ProxyURL)))
+			}
+			if strings.TrimSpace(o.Prefix) != strings.TrimSpace(n.Prefix) {
+				changes = append(changes, fmt.Sprintf("minimax[%d].prefix: %s -> %s", i, strings.TrimSpace(o.Prefix), strings.TrimSpace(n.Prefix)))
+			}
+			if strings.TrimSpace(o.APIKey) != strings.TrimSpace(n.APIKey) {
+				changes = append(changes, fmt.Sprintf("minimax[%d].api-key: updated", i))
+			}
+			if !equalStringMap(o.Headers, n.Headers) {
+				changes = append(changes, fmt.Sprintf("minimax[%d].headers: updated", i))
+			}
+			oldModels := SummarizeMiniMaxModels(o.Models)
+			newModels := SummarizeMiniMaxModels(n.Models)
+			if oldModels.hash != newModels.hash {
+				changes = append(changes, fmt.Sprintf("minimax[%d].models: updated (%d -> %d entries)", i, oldModels.count, newModels.count))
+			}
+			oldExcluded := SummarizeExcludedModels(o.ExcludedModels)
+			newExcluded := SummarizeExcludedModels(n.ExcludedModels)
+			if oldExcluded.hash != newExcluded.hash {
+				changes = append(changes, fmt.Sprintf("minimax[%d].excluded-models: updated (%d -> %d entries)", i, oldExcluded.count, newExcluded.count))
+			}
+		}
+	}
+
 	// AmpCode settings (redacted where needed)
 	oldAmpURL := strings.TrimSpace(oldCfg.AmpCode.UpstreamURL)
 	newAmpURL := strings.TrimSpace(newCfg.AmpCode.UpstreamURL)

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -106,6 +106,21 @@ func ComputeExcludedModelsHash(excluded []string) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// ComputeMiniMaxModelsHash returns a stable hash for MiniMax model aliases.
+func ComputeMiniMaxModelsHash(models []config.MiniMaxModel) string {
+	keys := normalizeModelPairs(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+		}
+	})
+	return hashJoined(keys)
+}
+
 func normalizeModelPairs(collect func(out func(key string))) []string {
 	seen := make(map[string]struct{})
 	keys := make([]string, 0)

--- a/internal/watcher/diff/models_summary.go
+++ b/internal/watcher/diff/models_summary.go
@@ -29,6 +29,11 @@ type VertexModelsSummary struct {
 	count int
 }
 
+type MiniMaxModelsSummary struct {
+	hash  string
+	count int
+}
+
 // SummarizeGeminiModels hashes Gemini model aliases for change detection.
 func SummarizeGeminiModels(models []config.GeminiModel) GeminiModelsSummary {
 	if len(models) == 0 {
@@ -117,5 +122,26 @@ func SummarizeVertexModels(models []config.VertexCompatModel) VertexModelsSummar
 	return VertexModelsSummary{
 		hash:  hex.EncodeToString(sum[:]),
 		count: len(names),
+	}
+}
+
+// SummarizeMiniMaxModels hashes MiniMax model aliases for change detection.
+func SummarizeMiniMaxModels(models []config.MiniMaxModel) MiniMaxModelsSummary {
+	if len(models) == 0 {
+		return MiniMaxModelsSummary{}
+	}
+	keys := normalizeModelPairs(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+		}
+	})
+	return MiniMaxModelsSummary{
+		hash:  hashJoined(keys),
+		count: len(keys),
 	}
 }

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -346,8 +346,8 @@ func (s *ConfigSynthesizer) synthesizeMiniMaxKeys(ctx *SynthesisContext) []*core
 		proxyURL := strings.TrimSpace(entry.ProxyURL)
 		id, token := idGen.Next("minimax:apikey", key, base)
 		attrs := map[string]string{
-			"source":  fmt.Sprintf("config:minimax[%s]", token),
-			"api_key": key,
+			"source":   fmt.Sprintf("config:minimax[%s]", token),
+			"api_key":  key,
 			"base_url": base,
 		}
 		if entry.Priority != 0 {

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ConfigSynthesizer generates Auth entries from configuration API keys.
-// It handles Gemini, Claude, Codex, OpenAI-compat, and Vertex-compat providers.
+// It handles Gemini, Claude, Codex, OpenAI-compat, Vertex-compat, and MiniMax providers.
 type ConfigSynthesizer struct{}
 
 // NewConfigSynthesizer creates a new ConfigSynthesizer instance.
@@ -35,6 +35,8 @@ func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth,
 	out = append(out, s.synthesizeOpenAICompat(ctx)...)
 	// Vertex-compat
 	out = append(out, s.synthesizeVertexCompat(ctx)...)
+	// MiniMax API Keys
+	out = append(out, s.synthesizeMiniMaxKeys(ctx)...)
 
 	return out, nil
 }
@@ -316,6 +318,57 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, compat.ExcludedModels, "apikey")
+		out = append(out, a)
+	}
+	return out
+}
+
+// synthesizeMiniMaxKeys creates Auth entries for MiniMax API keys.
+func (s *ConfigSynthesizer) synthesizeMiniMaxKeys(ctx *SynthesisContext) []*coreauth.Auth {
+	cfg := ctx.Config
+	now := ctx.Now
+	idGen := ctx.IDGenerator
+
+	const defaultMiniMaxBaseURL = "https://api.minimax.io/v1"
+
+	out := make([]*coreauth.Auth, 0, len(cfg.MiniMaxKey))
+	for i := range cfg.MiniMaxKey {
+		entry := cfg.MiniMaxKey[i]
+		key := strings.TrimSpace(entry.APIKey)
+		if key == "" {
+			continue
+		}
+		prefix := strings.TrimSpace(entry.Prefix)
+		base := strings.TrimSpace(entry.BaseURL)
+		if base == "" {
+			base = defaultMiniMaxBaseURL
+		}
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		id, token := idGen.Next("minimax:apikey", key, base)
+		attrs := map[string]string{
+			"source":  fmt.Sprintf("config:minimax[%s]", token),
+			"api_key": key,
+			"base_url": base,
+		}
+		if entry.Priority != 0 {
+			attrs["priority"] = strconv.Itoa(entry.Priority)
+		}
+		if hash := diff.ComputeMiniMaxModelsHash(entry.Models); hash != "" {
+			attrs["models_hash"] = hash
+		}
+		addConfigHeadersToAttrs(entry.Headers, attrs)
+		a := &coreauth.Auth{
+			ID:         id,
+			Provider:   "minimax",
+			Label:      "minimax-apikey",
+			Prefix:     prefix,
+			Status:     coreauth.StatusActive,
+			ProxyURL:   proxyURL,
+			Attributes: attrs,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}
+		ApplyAuthExcludedModelsMeta(a, cfg, entry.ExcludedModels, "apikey")
 		out = append(out, a)
 	}
 	return out

--- a/sdk/cliproxy/providers.go
+++ b/sdk/cliproxy/providers.go
@@ -29,7 +29,7 @@ func NewAPIKeyClientProvider() APIKeyClientProvider {
 type apiKeyClientProvider struct{}
 
 func (p *apiKeyClientProvider) Load(ctx context.Context, cfg *config.Config) (*APIKeyClientResult, error) {
-	geminiCount, vertexCompatCount, claudeCount, codexCount, openAICompat := watcher.BuildAPIKeyClients(cfg)
+	geminiCount, vertexCompatCount, claudeCount, codexCount, openAICompat, miniMaxCount := watcher.BuildAPIKeyClients(cfg)
 	if ctx != nil {
 		select {
 		case <-ctx.Done():
@@ -43,5 +43,6 @@ func (p *apiKeyClientProvider) Load(ctx context.Context, cfg *config.Config) (*A
 		ClaudeKeyCount:       claudeCount,
 		CodexKeyCount:        codexCount,
 		OpenAICompatCount:    openAICompat,
+		MiniMaxKeyCount:      miniMaxCount,
 	}, nil
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -424,6 +424,8 @@ func (s *Service) ensureExecutorsForAuthWithMode(a *coreauth.Auth, forceReplace 
 		s.coreManager.RegisterExecutor(executor.NewClaudeExecutor(s.cfg))
 	case "kimi":
 		s.coreManager.RegisterExecutor(executor.NewKimiExecutor(s.cfg))
+	case "minimax":
+		s.coreManager.RegisterExecutor(executor.NewOpenAICompatExecutor("minimax", s.cfg))
 	default:
 		providerKey := strings.ToLower(strings.TrimSpace(a.Provider))
 		if providerKey == "" {
@@ -927,6 +929,17 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 	case "kimi":
 		models = registry.GetKimiModels()
 		models = applyExcludedModels(models, excluded)
+	case "minimax":
+		models = registry.GetMiniMaxModels()
+		if entry := s.resolveConfigMiniMaxKey(a); entry != nil {
+			if len(entry.Models) > 0 {
+				models = buildMiniMaxConfigModels(entry)
+			}
+			if authKind == "apikey" {
+				excluded = entry.ExcludedModels
+			}
+		}
+		models = applyExcludedModels(models, excluded)
 	default:
 		// Handle OpenAI-compatibility providers by name using config
 		if s.cfg != nil {
@@ -1214,6 +1227,32 @@ func (s *Service) oauthExcludedModels(provider, authKind string) []string {
 	return cfg.OAuthExcludedModels[providerKey]
 }
 
+func (s *Service) resolveConfigMiniMaxKey(auth *coreauth.Auth) *config.MiniMaxKey {
+	if auth == nil || s.cfg == nil {
+		return nil
+	}
+	var attrKey, attrBase string
+	if auth.Attributes != nil {
+		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
+		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+	}
+	for i := range s.cfg.MiniMaxKey {
+		entry := &s.cfg.MiniMaxKey[i]
+		cfgKey := strings.TrimSpace(entry.APIKey)
+		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if attrKey != "" && strings.EqualFold(cfgKey, attrKey) {
+			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
+			continue
+		}
+		if attrKey == "" && attrBase != "" && strings.EqualFold(cfgBase, attrBase) {
+			return entry
+		}
+	}
+	return nil
+}
+
 func applyExcludedModels(models []*ModelInfo, excluded []string) []*ModelInfo {
 	if len(models) == 0 || len(excluded) == 0 {
 		return models
@@ -1411,6 +1450,13 @@ func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {
 		return nil
 	}
 	return buildConfigModels(entry.Models, "openai", "openai")
+}
+
+func buildMiniMaxConfigModels(entry *config.MiniMaxKey) []*ModelInfo {
+	if entry == nil {
+		return nil
+	}
+	return buildConfigModels(entry.Models, "minimax", "minimax")
 }
 
 func rewriteModelInfoName(name, oldID, newID string) string {

--- a/sdk/cliproxy/types.go
+++ b/sdk/cliproxy/types.go
@@ -65,6 +65,9 @@ type APIKeyClientResult struct {
 
 	// OpenAICompatCount is the number of OpenAI compatibility API keys loaded
 	OpenAICompatCount int
+
+	// MiniMaxKeyCount is the number of MiniMax API keys loaded
+	MiniMaxKeyCount int
 }
 
 // WatcherFactory creates a watcher for configuration and token changes.


### PR DESCRIPTION
## Summary

- **New provider**: MiniMax (`minimax`) using the OpenAI-compatible API at `https://api.minimax.io/v1`
- **Config**: new `minimax-api-key` section in `config.yaml` (see updated `config.example.yaml`)
- **Models**: `MiniMax-M2.7` (1M context, 40960 max output) and `MiniMax-M2.7-highspeed`
- **Implementation**: reuses `OpenAICompatExecutor` — no separate executor needed since MiniMax API is fully OpenAI-compatible
- **Auth synthesis**: `watcher/synthesizer` creates auth entries with `base_url` defaulting to `https://api.minimax.io/v1`
- **Change detection**: `watcher/diff` tracks MiniMax key count, base-url, prefix, api-key, headers, and model changes
- **Tests**: unit tests for config sanitize and model registry — all 5 pass

## Config example

```yaml
minimax-api-key:
  - api-key: "your-minimax-api-key"
    base-url: "https://api.minimax.io/v1"   # optional, this is the default
    prefix: ""                               # optional model namespace
    models:
      - name: "MiniMax-M2.7"
        alias: "minimax-latest"
    excluded-models:
      - "MiniMax-M2.7-highspeed"
```

## MiniMax API reference

- Docs: https://platform.minimax.io/docs/api-reference/text-openai-api
- Models: https://platform.minimax.io/docs/guides/models