### PR TITLE
fix(antigravity): resolve empty functionResponse.name for toolu_* tool_use_id format

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -12,6 +12,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/translator/gemini/common"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -67,6 +68,10 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 	// contents
 	contentsJSON := "[]"
 	hasContents := false
+
+	// tool_use_id → tool_name lookup, populated incrementally during the main loop.
+	// Claude's tool_result references tool_use by ID; Gemini requires functionResponse.name.
+	toolNameByID := make(map[string]string)
 
 	messagesResult := gjson.GetBytes(rawJSON, "messages")
 	if messagesResult.IsArray() {
@@ -170,6 +175,10 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 						argsResult := contentResult.Get("input")
 						functionID := contentResult.Get("id").String()
 
+						if functionID != "" && functionName != "" {
+							toolNameByID[functionID] = functionName
+						}
+
 						// Handle both object and string input formats
 						var argsRaw string
 						if argsResult.IsObject() {
@@ -206,10 +215,19 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 					} else if contentTypeResult.Type == gjson.String && contentTypeResult.String() == "tool_result" {
 						toolCallID := contentResult.Get("tool_use_id").String()
 						if toolCallID != "" {
-							funcName := toolCallID
-							toolCallIDs := strings.Split(toolCallID, "-")
-							if len(toolCallIDs) > 1 {
-								funcName = strings.Join(toolCallIDs[0:len(toolCallIDs)-2], "-")
+							funcName, ok := toolNameByID[toolCallID]
+							if !ok {
+								// Fallback: derive a semantic name from the ID by stripping
+								// the last two dash-separated segments (e.g. "get_weather-call-123" → "get_weather").
+								// Only use the raw ID as a last resort when the heuristic produces an empty string.
+								parts := strings.Split(toolCallID, "-")
+								if len(parts) > 2 {
+									funcName = strings.Join(parts[:len(parts)-2], "-")
+								}
+								if funcName == "" {
+									funcName = toolCallID
+								}
+								log.Warnf("antigravity claude request: tool_result references unknown tool_use_id=%s, derived function name=%s", toolCallID, funcName)
 							}
 							functionResponseResult := contentResult.Get("content")
 

--- a/internal/translator/antigravity/claude/antigravity_claude_request_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request_test.go
@@ -366,6 +366,17 @@ func TestConvertClaudeRequestToAntigravity_ToolResult(t *testing.T) {
 		"model": "claude-3-5-sonnet-20240620",
 		"messages": [
 			{
+				"role": "assistant",
+				"content": [
+					{
+						"type": "tool_use",
+						"id": "get_weather-call-123",
+						"name": "get_weather",
+						"input": {"location": "Paris"}
+					}
+				]
+			},
+			{
 				"role": "user",
 				"content": [
 					{
@@ -382,12 +393,176 @@ func TestConvertClaudeRequestToAntigravity_ToolResult(t *testing.T) {
 	outputStr := string(output)
 
 	// Check function response conversion
-	funcResp := gjson.Get(outputStr, "request.contents.0.parts.0.functionResponse")
+	funcResp := gjson.Get(outputStr, "request.contents.1.parts.0.functionResponse")
 	if !funcResp.Exists() {
 		t.Error("functionResponse should exist")
 	}
 	if funcResp.Get("id").String() != "get_weather-call-123" {
 		t.Errorf("Expected function id, got '%s'", funcResp.Get("id").String())
+	}
+	if funcResp.Get("name").String() != "get_weather" {
+		t.Errorf("Expected function name 'get_weather', got '%s'", funcResp.Get("name").String())
+	}
+}
+
+func TestConvertClaudeRequestToAntigravity_ToolResultName_TouluFormat(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "claude-haiku-4-5-20251001",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{
+						"type": "tool_use",
+						"id": "toolu_tool-48fca351f12844eabf49dad8b63886d2",
+						"name": "Glob",
+						"input": {"pattern": "**/*.py"}
+					},
+					{
+						"type": "tool_use",
+						"id": "toolu_tool-cf2d061f75f845c49aacc18ee75ee708",
+						"name": "Bash",
+						"input": {"command": "ls"}
+					}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "tool_result",
+						"tool_use_id": "toolu_tool-48fca351f12844eabf49dad8b63886d2",
+						"content": "file1.py\nfile2.py"
+					},
+					{
+						"type": "tool_result",
+						"tool_use_id": "toolu_tool-cf2d061f75f845c49aacc18ee75ee708",
+						"content": "total 10"
+					}
+				]
+			}
+		]
+	}`)
+
+	output := ConvertClaudeRequestToAntigravity("claude-haiku-4-5-20251001", inputJSON, false)
+	outputStr := string(output)
+
+	funcResp0 := gjson.Get(outputStr, "request.contents.1.parts.0.functionResponse")
+	if !funcResp0.Exists() {
+		t.Fatal("first functionResponse should exist")
+	}
+	if got := funcResp0.Get("name").String(); got != "Glob" {
+		t.Errorf("Expected name 'Glob' for toolu_ format, got '%s'", got)
+	}
+
+	funcResp1 := gjson.Get(outputStr, "request.contents.1.parts.1.functionResponse")
+	if !funcResp1.Exists() {
+		t.Fatal("second functionResponse should exist")
+	}
+	if got := funcResp1.Get("name").String(); got != "Bash" {
+		t.Errorf("Expected name 'Bash' for toolu_ format, got '%s'", got)
+	}
+}
+
+func TestConvertClaudeRequestToAntigravity_ToolResultName_CustomFormat(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "claude-haiku-4-5-20251001",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{
+						"type": "tool_use",
+						"id": "Read-1773420180464065165-1327",
+						"name": "Read",
+						"input": {"file_path": "/tmp/test.py"}
+					}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "tool_result",
+						"tool_use_id": "Read-1773420180464065165-1327",
+						"content": "file content here"
+					}
+				]
+			}
+		]
+	}`)
+
+	output := ConvertClaudeRequestToAntigravity("claude-haiku-4-5-20251001", inputJSON, false)
+	outputStr := string(output)
+
+	funcResp := gjson.Get(outputStr, "request.contents.1.parts.0.functionResponse")
+	if !funcResp.Exists() {
+		t.Fatal("functionResponse should exist")
+	}
+	if got := funcResp.Get("name").String(); got != "Read" {
+		t.Errorf("Expected name 'Read', got '%s'", got)
+	}
+}
+
+func TestConvertClaudeRequestToAntigravity_ToolResultName_NoMatchingToolUse_Heuristic(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "claude-sonnet-4-5",
+		"messages": [
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "tool_result",
+						"tool_use_id": "get_weather-call-123",
+						"content": "22C sunny"
+					}
+				]
+			}
+		]
+	}`)
+
+	output := ConvertClaudeRequestToAntigravity("claude-sonnet-4-5", inputJSON, false)
+	outputStr := string(output)
+
+	funcResp := gjson.Get(outputStr, "request.contents.0.parts.0.functionResponse")
+	if !funcResp.Exists() {
+		t.Fatal("functionResponse should exist")
+	}
+	if got := funcResp.Get("name").String(); got != "get_weather" {
+		t.Errorf("Expected heuristic-derived name 'get_weather', got '%s'", got)
+	}
+}
+
+func TestConvertClaudeRequestToAntigravity_ToolResultName_NoMatchingToolUse_RawID(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "claude-sonnet-4-5",
+		"messages": [
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "tool_result",
+						"tool_use_id": "toolu_tool-48fca351f12844eabf49dad8b63886d2",
+						"content": "result data"
+					}
+				]
+			}
+		]
+	}`)
+
+	output := ConvertClaudeRequestToAntigravity("claude-sonnet-4-5", inputJSON, false)
+	outputStr := string(output)
+
+	funcResp := gjson.Get(outputStr, "request.contents.0.parts.0.functionResponse")
+	if !funcResp.Exists() {
+		t.Fatal("functionResponse should exist")
+	}
+	got := funcResp.Get("name").String()
+	if got == "" {
+		t.Error("functionResponse.name must not be empty")
+	}
+	if got != "toolu_tool-48fca351f12844eabf49dad8b63886d2" {
+		t.Errorf("Expected raw ID as last-resort name, got '%s'", got)
 	}
 }
 


### PR DESCRIPTION
## 问题描述

Antigravity 的 Claude→Gemini 翻译器在处理 `tool_result` 时，通过字符串分割 `tool_use_id` 来推导 `functionResponse.name`。当 `tool_use_id` 按 `-` 分割后恰好只有 2 段时（如 Claude SDK 标准格式 `toolu_tool-<uuid>`），`[0:len-2]` 产生空切片，导致 `name` 为空字符串。Gemini API 要求 `functionResponse.name` 非空，返回 400 `REQUIRED_FIELD_MISSING`。

## 触发场景

Claude Code 客户端发送多轮对话请求，对话历史中包含两种格式的 `tool_use_id`：

| 格式 | 示例 | split(`-`) 段数 | 旧逻辑结果 |
|------|------|:-:|------|
| Claude SDK 标准格式 | `toolu_tool-48fca351f12844eabf49dad8b63886d2` | **2** | `""` → **400 错误** |
| Claude Code 自定义格式 | `Read-1773420180464065165-1327` | 3 | `"Read"` ✅ |

只有第一种格式触发 bug。第二种恰好能工作是因为 3 段去掉 2 段还剩 1 段。

## 根因分析

```go
// 旧代码 — 对 2 段 ID 失败
funcName := toolCallID
toolCallIDs := strings.Split(toolCallID, "-")
if len(toolCallIDs) > 1 {
    funcName = strings.Join(toolCallIDs[0:len(toolCallIDs)-2], "-")
    // "toolu_tool-<uuid>" → 2 段 → [0:0] → 空切片 → ""
}
```

从 ID 字符串猜测工具名本身就是错误的设计。Claude API 中 `tool_result` 通过 `tool_use_id` 引用前面 `tool_use` 块的 `id`，工具名应从对应的 `tool_use.name` 获取。

## 修复方案

用 `tool_use.id → tool_use.name` 的 lookup map 替代字符串分割启发式：

1. **在主循环中增量构建映射**：处理 `tool_use` 块时，记录 `id → name` 到 `toolNameByID` map
2. **处理 `tool_result` 时查表**：从 map 中查找对应的工具名
3. **Fallback**：查不到时退回使用完整 `tool_use_id` 作为 name（保证非空），并输出 warn 日志

```go
// 新代码
toolNameByID := make(map[string]string)

// 处理 tool_use 时记录映射
if functionID != "" && functionName != "" {
    toolNameByID[functionID] = functionName
}

// 处理 tool_result 时查找
funcName := toolNameByID[toolCallID]
if funcName == "" {
    funcName = toolCallID
    log.Warnf("antigravity claude request: tool_result references unknown tool_use_id=%s, using ID as function name", toolCallID)
}
```

这个方案是语义正确的：`tool_result` 的名字就应该来自对应 `tool_use.name`，而不是从 ID 字符串猜。

## 测试覆盖

- `TestToolResult` — 更新为包含前置 `tool_use` 块，验证 name 正确解析
- `TestToolResultName_TouluFormat` — 新增，覆盖原始 bug 场景（`toolu_tool-*` 格式，多工具并行）
- `TestToolResultName_CustomFormat` — 新增，覆盖 `Read-timestamp-seq` 格式
- 所有既有测试通过，无回归

## 影响范围

- 仅修改 `internal/translator/antigravity/claude/antigravity_claude_request.go`
- 所有走 antigravity + Claude API 格式的模型受益（claude-sonnet-4-5, claude-opus-4-6, claude-haiku-4-5 等）