### PR TITLE
fix: validate JSON before raw-embedding function call outputs in Responses API

### DIFF
--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -1,6 +1,7 @@
 package responses
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/translator/gemini/common"
@@ -340,7 +341,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				// Set the raw JSON output directly (preserves string encoding)
 				if outputRaw != "" && outputRaw != "null" {
 					output := gjson.Parse(outputRaw)
-					if output.Type == gjson.JSON {
+					if output.Type == gjson.JSON && json.Valid([]byte(output.Raw)) {
 						functionResponse, _ = sjson.SetRaw(functionResponse, "functionResponse.response.result", output.Raw)
 					} else {
 						functionResponse, _ = sjson.Set(functionResponse, "functionResponse.response.result", outputRaw)


### PR DESCRIPTION
## Summary

- Adds `json.Valid()` check before using `sjson.SetRaw` for function call outputs in the Responses API translator, preventing non-JSON content from being embedded raw into the Gemini API request payload.

## Problem

`gjson.Parse()` marks any string starting with `{` or `[` as `gjson.JSON`, even when the content is not valid JSON. This causes `sjson.SetRaw` to embed non-JSON content directly into the Gemini request, producing 400 errors from Google's API.

Two known triggers:
1. **macOS plist output** — `defaults read` returns `{ "$archiver" = NSKeyedArchiver; ... }` which starts with `{` but uses `=` instead of `:`
2. **Truncated tool results** — clients like opencode summarize old results as `[Old tool result content cleared]` which starts with `[`

## Fix

One-line change: add `json.Valid([]byte(output.Raw))` guard before `SetRaw`. Non-JSON content falls through to `sjson.Set` which properly escapes it as a JSON string.

Fixes #2161