### PR TITLE
fix: strip markdown code fences from non-streaming Claude responses

### DIFF
--- a/internal/translator/claude/openai/chat-completions/claude_openai_response.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -380,7 +381,7 @@ func ConvertClaudeResponseToOpenAINonStream(_ context.Context, _ string, origina
 	out, _ = sjson.Set(out, "model", model)
 
 	// Set message content by combining all text parts
-	messageContent := strings.Join(contentParts, "")
+	messageContent := util.StripMarkdownCodeFences(strings.Join(contentParts, ""))
 	out, _ = sjson.Set(out, "choices.0.message.content", messageContent)
 
 	// Add reasoning content if available (following OpenAI reasoning format)

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -368,7 +369,7 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 		if st.TextBuf.Len() > 0 || st.InTextBlock || st.CurrentMsgID != "" {
 			item := `{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`
 			item, _ = sjson.Set(item, "id", st.CurrentMsgID)
-			item, _ = sjson.Set(item, "content.0.text", st.TextBuf.String())
+			item, _ = sjson.Set(item, "content.0.text", util.StripMarkdownCodeFences(st.TextBuf.String()))
 			outputsWrapper, _ = sjson.SetRaw(outputsWrapper, "arr.-1", item)
 		}
 		// function_call items (in ascending index order for determinism)
@@ -637,7 +638,7 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 	if currentMsgID != "" || textBuf.Len() > 0 {
 		item := `{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`
 		item, _ = sjson.Set(item, "id", currentMsgID)
-		item, _ = sjson.Set(item, "content.0.text", textBuf.String())
+		item, _ = sjson.Set(item, "content.0.text", util.StripMarkdownCodeFences(textBuf.String()))
 		outputsWrapper, _ = sjson.SetRaw(outputsWrapper, "arr.-1", item)
 	}
 	if len(toolCalls) > 0 {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -112,6 +112,33 @@ func CountAuthFiles[T any](ctx context.Context, store interface {
 	return len(entries)
 }
 
+// StripMarkdownCodeFences removes markdown code fences that LLMs sometimes wrap
+// around JSON or XML responses. If text starts with ```<optional-tag> and ends
+// with ```, the fence lines are removed and the inner content is returned.
+// Otherwise text is returned unchanged.
+func StripMarkdownCodeFences(text string) string {
+	trimmed := strings.TrimSpace(text)
+	if !strings.HasPrefix(trimmed, "```") {
+		return text
+	}
+
+	// Find the end of the opening fence line.
+	firstNewline := strings.Index(trimmed, "\n")
+	if firstNewline == -1 {
+		// Single line like "```something```" -- not a real fence block.
+		return text
+	}
+
+	// The closing fence must be the last non-blank line.
+	if !strings.HasSuffix(trimmed, "```") {
+		return text
+	}
+
+	// Strip the opening fence line and the closing "```".
+	inner := trimmed[firstNewline+1 : len(trimmed)-3]
+	return strings.TrimSpace(inner)
+}
+
 // WritablePath returns the cleaned WRITABLE_PATH environment variable when it is set.
 // It accepts both uppercase and lowercase variants for compatibility with existing conventions.
 func WritablePath() string {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,76 @@
+package util
+
+import "testing"
+
+func TestStripMarkdownCodeFences(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "json fence",
+			in:   "```json\n{\"facts\": [1, 2, 3]}\n```",
+			want: "{\"facts\": [1, 2, 3]}",
+		},
+		{
+			name: "xml fence",
+			in:   "```xml\n<root><item>hello</item></root>\n```",
+			want: "<root><item>hello</item></root>",
+		},
+		{
+			name: "fence without language tag",
+			in:   "```\n{\"key\": \"value\"}\n```",
+			want: "{\"key\": \"value\"}",
+		},
+		{
+			name: "plain text unchanged",
+			in:   "{\"key\": \"value\"}",
+			want: "{\"key\": \"value\"}",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "trailing newlines after closing fence",
+			in:   "```json\n{\"a\": 1}\n```\n\n\n",
+			want: "{\"a\": 1}",
+		},
+		{
+			name: "leading whitespace before fence",
+			in:   "  \n```json\n{\"a\": 1}\n```\n",
+			want: "{\"a\": 1}",
+		},
+		{
+			name: "multiline content",
+			in:   "```json\n{\n  \"a\": 1,\n  \"b\": 2\n}\n```",
+			want: "{\n  \"a\": 1,\n  \"b\": 2\n}",
+		},
+		{
+			name: "backticks inside content not stripped",
+			in:   "some text with ``` in the middle",
+			want: "some text with ``` in the middle",
+		},
+		{
+			name: "only opening fence no closing",
+			in:   "```json\n{\"a\": 1}",
+			want: "```json\n{\"a\": 1}",
+		},
+		{
+			name: "single line backticks",
+			in:   "```something```",
+			want: "```something```",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripMarkdownCodeFences(tt.in)
+			if got != tt.want {
+				t.Errorf("StripMarkdownCodeFences(%q)\n got: %q\nwant: %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Claude models sometimes wrap JSON responses in markdown code fences (` ```json ... ``` `) when accessed through the OpenAI-compatible translation layer
- Downstream apps that expect raw JSON (e.g. [Hindsight](https://github.com/vectorize-io/hindsight)) fail to parse the response and must retry, wasting tokens and adding latency
- Adds `StripMarkdownCodeFences()` to `internal/util` that detects when the entire response is a single fenced block and strips the fence lines
- Applied to the non-streaming paths in both chat completions (`/v1/chat/completions`) and OpenResponses (`/v1/responses`) translators

## Test plan
- [x] Unit tests for `StripMarkdownCodeFences` covering: json/xml fences, no language tag, plain text passthrough, empty string, trailing/leading whitespace, multiline content, inline backticks, missing closing fence, single-line backticks
- [x] Full project builds cleanly
- [x] Existing translator tests pass
- [x] End-to-end tested with Hindsight via Docker — retain calls succeed without JSON parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)