### PR TITLE
feat(usage): add persistence, redaction, and detail limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ config.yaml
 
 # Generated content
 bin/*
+dist/*
 logs/*
 conv/*
 temp/*
@@ -45,6 +46,11 @@ GEMINI.md
 .bmad/*
 _bmad/*
 _bmad-output/*
+
+# Local ops scripts (keep local only)
+deploy_cliproxy.sh
+patch_usage_config.sh
+check_usage_health.sh
 
 # macOS
 .DS_Store

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -62,6 +62,16 @@ error-logs-max-files: 10
 # When false, disable in-memory usage statistics aggregation
 usage-statistics-enabled: false
 
+# Usage statistics persistence settings (optional)
+usage-persistence:
+  enabled: false
+  path: "" # defaults to ${auth-dir}/usage/usage.json when empty
+  interval: 60 # seconds
+  detail-ring-size: 10000 # per-model detail history cap
+  detail-max-total: 50000 # global detail history cap
+  save-every-requests: 0 # trigger save after N requests (0 disables)
+  redact-source: false # remove source field in persisted usage details
+
 # Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
 # Per-entry proxy-url also supports "direct" or "none" to bypass both the global proxy-url and environment proxies explicitly.
 proxy-url: ""

--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -70,6 +70,7 @@ func (h *Handler) ImportUsageStatistics(c *gin.Context) {
 
 	result := h.usageStats.MergeSnapshot(payload.Usage)
 	snapshot := h.usageStats.Snapshot()
+	usage.TriggerPersistHook()
 	c.JSON(http.StatusOK, gin.H{
 		"added":           result.Added,
 		"skipped":         result.Skipped,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,8 +19,11 @@ import (
 )
 
 const (
-	DefaultPanelGitHubRepository = "https://github.com/router-for-me/Cli-Proxy-API-Management-Center"
-	DefaultPprofAddr             = "127.0.0.1:8316"
+	DefaultPanelGitHubRepository           = "https://github.com/router-for-me/Cli-Proxy-API-Management-Center"
+	DefaultPprofAddr                       = "127.0.0.1:8316"
+	DefaultUsagePersistenceIntervalSeconds = 60
+	DefaultUsageDetailRingSize             = 10000
+	DefaultUsageDetailMaxTotal             = 50000
 )
 
 // Config represents the application's configuration, loaded from a YAML file.
@@ -63,6 +66,9 @@ type Config struct {
 
 	// UsageStatisticsEnabled toggles in-memory usage aggregation; when false, usage data is discarded.
 	UsageStatisticsEnabled bool `yaml:"usage-statistics-enabled" json:"usage-statistics-enabled"`
+
+	// UsagePersistence configures usage statistics persistence to disk.
+	UsagePersistence UsagePersistenceConfig `yaml:"usage-persistence" json:"usage-persistence"`
 
 	// DisableCooling disables quota cooldown scheduling when true.
 	DisableCooling bool `yaml:"disable-cooling" json:"disable-cooling"`
@@ -126,6 +132,53 @@ type Config struct {
 	Payload PayloadConfig `yaml:"payload" json:"payload"`
 
 	legacyMigrationPending bool `yaml:"-" json:"-"`
+}
+
+// UsagePersistenceConfig controls usage statistics persistence behavior.
+type UsagePersistenceConfig struct {
+	// Enabled toggles usage persistence to disk.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+
+	// Path is the destination file for usage snapshot persistence.
+	// If empty, defaults to ${auth-dir}/usage/usage.json.
+	Path string `yaml:"path" json:"path"`
+
+	// IntervalSeconds defines how often to persist usage snapshots in seconds.
+	IntervalSeconds int `yaml:"interval" json:"interval"`
+
+	// DetailRingSize caps per-model request detail history.
+	DetailRingSize int `yaml:"detail-ring-size" json:"detail-ring-size"`
+
+	// DetailMaxTotal caps total request detail history across all models.
+	DetailMaxTotal int `yaml:"detail-max-total" json:"detail-max-total"`
+
+	// SaveEveryRequests triggers a save after N requests. Set to 0 to disable.
+	SaveEveryRequests int `yaml:"save-every-requests" json:"save-every-requests"`
+
+	// RedactSource removes request source fields from persisted usage details.
+	RedactSource bool `yaml:"redact-source" json:"redact-source"`
+}
+
+// Normalize applies defaults and ensures limits are consistent.
+func (c *UsagePersistenceConfig) Normalize() {
+	if c == nil {
+		return
+	}
+	if c.IntervalSeconds <= 0 {
+		c.IntervalSeconds = DefaultUsagePersistenceIntervalSeconds
+	}
+	if c.DetailRingSize <= 0 {
+		c.DetailRingSize = DefaultUsageDetailRingSize
+	}
+	if c.DetailMaxTotal <= 0 {
+		c.DetailMaxTotal = DefaultUsageDetailMaxTotal
+	}
+	if c.DetailMaxTotal < c.DetailRingSize {
+		c.DetailMaxTotal = c.DetailRingSize
+	}
+	if c.SaveEveryRequests < 0 {
+		c.SaveEveryRequests = 0
+	}
 }
 
 // ClaudeHeaderDefaults configures default header values injected into Claude API requests
@@ -553,6 +606,12 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.LogsMaxTotalSizeMB = 0
 	cfg.ErrorLogsMaxFiles = 10
 	cfg.UsageStatisticsEnabled = false
+	cfg.UsagePersistence.Enabled = false
+	cfg.UsagePersistence.IntervalSeconds = DefaultUsagePersistenceIntervalSeconds
+	cfg.UsagePersistence.DetailRingSize = DefaultUsageDetailRingSize
+	cfg.UsagePersistence.DetailMaxTotal = DefaultUsageDetailMaxTotal
+	cfg.UsagePersistence.SaveEveryRequests = 0
+	cfg.UsagePersistence.RedactSource = false
 	cfg.DisableCooling = false
 	cfg.Pprof.Enable = false
 	cfg.Pprof.Addr = DefaultPprofAddr
@@ -613,6 +672,8 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	if cfg.ErrorLogsMaxFiles < 0 {
 		cfg.ErrorLogsMaxFiles = 10
 	}
+
+	cfg.UsagePersistence.Normalize()
 
 	if cfg.MaxRetryCredentials < 0 {
 		cfg.MaxRetryCredentials = 0
@@ -1278,6 +1339,12 @@ func isKnownDefaultValue(path []string, node *yaml.Node) bool {
 		switch fullPath {
 		case "error-logs-max-files":
 			return node.Value == "10"
+		case "usage-persistence.interval":
+			return node.Value == fmt.Sprintf("%d", DefaultUsagePersistenceIntervalSeconds)
+		case "usage-persistence.detail-ring-size":
+			return node.Value == fmt.Sprintf("%d", DefaultUsageDetailRingSize)
+		case "usage-persistence.detail-max-total":
+			return node.Value == fmt.Sprintf("%d", DefaultUsageDetailMaxTotal)
 		}
 	}
 

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -6,6 +6,7 @@ package usage
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -56,14 +57,39 @@ func SetStatisticsEnabled(enabled bool) { statisticsEnabled.Store(enabled) }
 // StatisticsEnabled reports the current recording state.
 func StatisticsEnabled() bool { return statisticsEnabled.Load() }
 
+var persistHookMu sync.RWMutex
+var persistHook func()
+
+// SetPersistHook registers a hook for triggering persistence after usage updates.
+func SetPersistHook(hook func()) {
+	persistHookMu.Lock()
+	persistHook = hook
+	persistHookMu.Unlock()
+}
+
+// TriggerPersistHook invokes the registered persistence hook if present.
+func TriggerPersistHook() {
+	persistHookMu.RLock()
+	hook := persistHook
+	persistHookMu.RUnlock()
+	if hook != nil {
+		hook()
+	}
+}
+
 // RequestStatistics maintains aggregated request metrics in memory.
 type RequestStatistics struct {
 	mu sync.RWMutex
 
-	totalRequests int64
-	successCount  int64
-	failureCount  int64
-	totalTokens   int64
+	totalRequests        int64
+	successCount         int64
+	failureCount         int64
+	totalTokens          int64
+	detailTotal          int64
+	detailRingSize       int
+	detailMaxTotal       int
+	persistEveryRequests int64
+	persistCounter       int64
 
 	apis map[string]*apiStats
 
@@ -84,7 +110,7 @@ type apiStats struct {
 type modelStats struct {
 	TotalRequests int64
 	TotalTokens   int64
-	Details       []RequestDetail
+	Details       *RingBuffer
 }
 
 // RequestDetail stores the timestamp and token usage for a single request.
@@ -134,10 +160,39 @@ type ModelSnapshot struct {
 	Details       []RequestDetail `json:"details"`
 }
 
+const (
+	defaultDetailRingSize = 10000
+	defaultDetailMaxTotal = 50000
+)
+
 var defaultRequestStatistics = NewRequestStatistics()
 
 // GetRequestStatistics returns the shared statistics store.
 func GetRequestStatistics() *RequestStatistics { return defaultRequestStatistics }
+
+// GetSnapshot returns a snapshot from the shared statistics store.
+func GetSnapshot() StatisticsSnapshot {
+	if defaultRequestStatistics == nil {
+		return StatisticsSnapshot{}
+	}
+	return defaultRequestStatistics.Snapshot()
+}
+
+// ApplyDetailLimits updates the detail limits for the shared statistics store.
+func ApplyDetailLimits(ringSize, maxTotal int) {
+	if defaultRequestStatistics == nil {
+		return
+	}
+	defaultRequestStatistics.SetDetailLimits(ringSize, maxTotal)
+}
+
+// SetPersistEveryRequests configures how often to trigger persistence.
+func SetPersistEveryRequests(count int) {
+	if defaultRequestStatistics == nil {
+		return
+	}
+	defaultRequestStatistics.SetPersistEveryRequests(count)
+}
 
 // NewRequestStatistics constructs an empty statistics store.
 func NewRequestStatistics() *RequestStatistics {
@@ -147,6 +202,131 @@ func NewRequestStatistics() *RequestStatistics {
 		requestsByHour: make(map[int]int64),
 		tokensByDay:    make(map[string]int64),
 		tokensByHour:   make(map[int]int64),
+		detailRingSize: defaultDetailRingSize,
+		detailMaxTotal: defaultDetailMaxTotal,
+	}
+}
+
+// SetDetailLimits updates detail ring buffer limits and trims existing data as needed.
+func (s *RequestStatistics) SetDetailLimits(ringSize, maxTotal int) {
+	if s == nil {
+		return
+	}
+	if ringSize <= 0 {
+		ringSize = defaultDetailRingSize
+	}
+	if maxTotal <= 0 {
+		maxTotal = defaultDetailMaxTotal
+	}
+	if maxTotal < ringSize {
+		maxTotal = ringSize
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.detailRingSize = ringSize
+	s.detailMaxTotal = maxTotal
+
+	var total int64
+	for _, api := range s.apis {
+		if api == nil {
+			continue
+		}
+		if api.Models == nil {
+			api.Models = make(map[string]*modelStats)
+		}
+		for _, model := range api.Models {
+			if model == nil {
+				continue
+			}
+			if model.Details == nil {
+				model.Details = NewRingBuffer(ringSize)
+			} else {
+				model.Details.Resize(ringSize)
+			}
+			total += int64(model.Details.Len())
+		}
+	}
+	s.detailTotal = total
+	if s.detailMaxTotal > 0 && s.detailTotal > int64(s.detailMaxTotal) {
+		s.trimOldestDetails(int(s.detailTotal - int64(s.detailMaxTotal)))
+	}
+}
+
+// SetPersistEveryRequests sets how often persistence is triggered by request count.
+func (s *RequestStatistics) SetPersistEveryRequests(count int) {
+	if s == nil {
+		return
+	}
+	if count < 0 {
+		count = 0
+	}
+	s.mu.Lock()
+	s.persistEveryRequests = int64(count)
+	s.persistCounter = 0
+	s.mu.Unlock()
+}
+
+// RestoreSnapshot replaces the current statistics with the provided snapshot.
+// It restores totals directly rather than recalculating from request details.
+func (s *RequestStatistics) RestoreSnapshot(snapshot StatisticsSnapshot) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.totalRequests = snapshot.TotalRequests
+	s.successCount = snapshot.SuccessCount
+	s.failureCount = snapshot.FailureCount
+	s.totalTokens = snapshot.TotalTokens
+	s.persistCounter = 0
+
+	s.apis = make(map[string]*apiStats, len(snapshot.APIs))
+	s.detailTotal = 0
+	for apiName, apiSnapshot := range snapshot.APIs {
+		stats := &apiStats{
+			TotalRequests: apiSnapshot.TotalRequests,
+			TotalTokens:   apiSnapshot.TotalTokens,
+			Models:        make(map[string]*modelStats, len(apiSnapshot.Models)),
+		}
+		for modelName, modelSnapshot := range apiSnapshot.Models {
+			modelDetails := NewRingBuffer(s.detailRingSize)
+			modelDetails.Load(modelSnapshot.Details)
+			s.detailTotal += int64(modelDetails.Len())
+			stats.Models[modelName] = &modelStats{
+				TotalRequests: modelSnapshot.TotalRequests,
+				TotalTokens:   modelSnapshot.TotalTokens,
+				Details:       modelDetails,
+			}
+		}
+		s.apis[apiName] = stats
+	}
+
+	s.requestsByDay = make(map[string]int64, len(snapshot.RequestsByDay))
+	for k, v := range snapshot.RequestsByDay {
+		s.requestsByDay[k] = v
+	}
+	s.requestsByHour = make(map[int]int64, len(snapshot.RequestsByHour))
+	for k, v := range snapshot.RequestsByHour {
+		if parsed, ok := parseHourKey(k); ok {
+			s.requestsByHour[parsed] = v
+		}
+	}
+	s.tokensByDay = make(map[string]int64, len(snapshot.TokensByDay))
+	for k, v := range snapshot.TokensByDay {
+		s.tokensByDay[k] = v
+	}
+	s.tokensByHour = make(map[int]int64, len(snapshot.TokensByHour))
+	for k, v := range snapshot.TokensByHour {
+		if parsed, ok := parseHourKey(k); ok {
+			s.tokensByHour[parsed] = v
+		}
+	}
+
+	if s.detailMaxTotal > 0 && s.detailTotal > int64(s.detailMaxTotal) {
+		s.trimOldestDetails(int(s.detailTotal - int64(s.detailMaxTotal)))
 	}
 }
 
@@ -158,6 +338,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	if !statisticsEnabled.Load() {
 		return
 	}
+	triggerPersist := false
 	timestamp := record.RequestedAt
 	if timestamp.IsZero() {
 		timestamp = time.Now()
@@ -181,7 +362,6 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	hourKey := timestamp.Hour()
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	s.totalRequests++
 	if success {
@@ -208,6 +388,19 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	s.requestsByHour[hourKey]++
 	s.tokensByDay[dayKey] += totalTokens
 	s.tokensByHour[hourKey] += totalTokens
+
+	if s.persistEveryRequests > 0 {
+		s.persistCounter++
+		if s.persistCounter >= s.persistEveryRequests {
+			s.persistCounter = 0
+			triggerPersist = true
+		}
+	}
+
+	s.mu.Unlock()
+	if triggerPersist {
+		TriggerPersistHook()
+	}
 }
 
 func (s *RequestStatistics) updateAPIStats(stats *apiStats, model string, detail RequestDetail) {
@@ -215,12 +408,23 @@ func (s *RequestStatistics) updateAPIStats(stats *apiStats, model string, detail
 	stats.TotalTokens += detail.Tokens.TotalTokens
 	modelStatsValue, ok := stats.Models[model]
 	if !ok {
-		modelStatsValue = &modelStats{}
+		modelStatsValue = &modelStats{Details: NewRingBuffer(s.detailRingSize)}
 		stats.Models[model] = modelStatsValue
+	}
+	if modelStatsValue.Details == nil {
+		modelStatsValue.Details = NewRingBuffer(s.detailRingSize)
 	}
 	modelStatsValue.TotalRequests++
 	modelStatsValue.TotalTokens += detail.Tokens.TotalTokens
-	modelStatsValue.Details = append(modelStatsValue.Details, detail)
+	before := modelStatsValue.Details.Len()
+	modelStatsValue.Details.Push(detail)
+	after := modelStatsValue.Details.Len()
+	if before != after {
+		s.detailTotal += int64(after - before)
+	}
+	if s.detailMaxTotal > 0 && s.detailTotal > int64(s.detailMaxTotal) {
+		s.trimOldestDetails(int(s.detailTotal - int64(s.detailMaxTotal)))
+	}
 }
 
 // Snapshot returns a copy of the aggregated metrics for external consumption.
@@ -246,8 +450,10 @@ func (s *RequestStatistics) Snapshot() StatisticsSnapshot {
 			Models:        make(map[string]ModelSnapshot, len(stats.Models)),
 		}
 		for modelName, modelStatsValue := range stats.Models {
-			requestDetails := make([]RequestDetail, len(modelStatsValue.Details))
-			copy(requestDetails, modelStatsValue.Details)
+			var requestDetails []RequestDetail
+			if modelStatsValue.Details != nil {
+				requestDetails = modelStatsValue.Details.Snapshot()
+			}
 			apiSnapshot.Models[modelName] = ModelSnapshot{
 				TotalRequests: modelStatsValue.TotalRequests,
 				TotalTokens:   modelStatsValue.TotalTokens,
@@ -307,7 +513,10 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 			if modelStatsValue == nil {
 				continue
 			}
-			for _, detail := range modelStatsValue.Details {
+			if modelStatsValue.Details == nil {
+				continue
+			}
+			for _, detail := range modelStatsValue.Details.Snapshot() {
 				seen[dedupKey(apiName, modelName, detail)] = struct{}{}
 			}
 		}
@@ -463,10 +672,66 @@ func normaliseTokenStats(tokens TokenStats) TokenStats {
 	return tokens
 }
 
+func (s *RequestStatistics) trimOldestDetails(count int) {
+	if s == nil || count <= 0 {
+		return
+	}
+	for count > 0 {
+		var (
+			oldestDetail RequestDetail
+			oldestModel  *modelStats
+			found        bool
+		)
+		for _, api := range s.apis {
+			if api == nil {
+				continue
+			}
+			for _, model := range api.Models {
+				if model == nil || model.Details == nil || model.Details.Len() == 0 {
+					continue
+				}
+				detail, ok := model.Details.Oldest()
+				if !ok {
+					continue
+				}
+				if !found || detail.Timestamp.Before(oldestDetail.Timestamp) {
+					oldestDetail = detail
+					oldestModel = model
+					found = true
+				}
+			}
+		}
+		if !found || oldestModel == nil || oldestModel.Details == nil {
+			return
+		}
+		if _, ok := oldestModel.Details.PopOldest(); ok {
+			s.detailTotal--
+			count--
+			continue
+		}
+		return
+	}
+}
+
 func formatHour(hour int) string {
 	if hour < 0 {
 		hour = 0
 	}
 	hour = hour % 24
 	return fmt.Sprintf("%02d", hour)
+}
+
+func parseHourKey(key string) (int, bool) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return 0, false
+	}
+	value, err := strconv.Atoi(key)
+	if err != nil {
+		return 0, false
+	}
+	if value < 0 {
+		value = 0
+	}
+	return value % 24, true
 }

--- a/internal/usage/persistence.go
+++ b/internal/usage/persistence.go
@@ -1,0 +1,314 @@
+package usage
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	log "github.com/sirupsen/logrus"
+)
+
+const persistHookDebounceDelay = 3 * time.Second
+
+type persistencePayload struct {
+	Version int                `json:"version"`
+	SavedAt time.Time          `json:"saved_at"`
+	Usage   StatisticsSnapshot `json:"usage"`
+}
+
+// Persistor periodically saves usage statistics to disk.
+type Persistor struct {
+	stats        *RequestStatistics
+	path         string
+	interval     time.Duration
+	redactSource bool
+
+	saveMu sync.Mutex
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+
+	debounceMu    sync.Mutex
+	debounceTimer *time.Timer
+
+	started atomic.Bool
+}
+
+// Path returns the persistence file path.
+func (p *Persistor) Path() string {
+	if p == nil {
+		return ""
+	}
+	return p.path
+}
+
+// Interval returns the persistence interval.
+func (p *Persistor) Interval() time.Duration {
+	if p == nil {
+		return 0
+	}
+	return p.interval
+}
+
+// RedactSource indicates whether source fields are redacted on save.
+func (p *Persistor) RedactSource() bool {
+	if p == nil {
+		return false
+	}
+	return p.redactSource
+}
+
+// NewPersistor constructs a Persistor from configuration and stats.
+func NewPersistor(cfg *config.Config, stats *RequestStatistics) (*Persistor, error) {
+	if cfg == nil || stats == nil {
+		return nil, nil
+	}
+	if !cfg.UsagePersistence.Enabled {
+		return nil, nil
+	}
+	path, err := ResolveUsagePersistencePath(cfg)
+	if err != nil {
+		return nil, err
+	}
+	intervalSeconds := cfg.UsagePersistence.IntervalSeconds
+	if intervalSeconds <= 0 {
+		intervalSeconds = config.DefaultUsagePersistenceIntervalSeconds
+	}
+	p := &Persistor{
+		stats:        stats,
+		path:         path,
+		interval:     time.Duration(intervalSeconds) * time.Second,
+		redactSource: cfg.UsagePersistence.RedactSource,
+		stopCh:       make(chan struct{}),
+		doneCh:       make(chan struct{}),
+	}
+	return p, nil
+}
+
+// ResolveUsagePersistencePath derives the usage persistence file path.
+func ResolveUsagePersistencePath(cfg *config.Config) (string, error) {
+	if cfg == nil {
+		return "", errors.New("usage persistence: nil config")
+	}
+	path := strings.TrimSpace(cfg.UsagePersistence.Path)
+	if path == "" {
+		authDir := strings.TrimSpace(cfg.AuthDir)
+		if authDir == "" {
+			return "", errors.New("usage persistence: auth-dir is empty")
+		}
+		resolved, err := util.ResolveAuthDir(authDir)
+		if err != nil {
+			return "", err
+		}
+		if resolved == "" {
+			return "", errors.New("usage persistence: auth-dir is empty")
+		}
+		path = filepath.Join(resolved, "usage", "usage.json")
+	}
+	if !filepath.IsAbs(path) {
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+	}
+	return path, nil
+}
+
+// Load reads persisted usage statistics from disk.
+func (p *Persistor) Load() (StatisticsSnapshot, bool) {
+	if p == nil {
+		return StatisticsSnapshot{}, false
+	}
+	snapshot, err := p.loadFromPath(p.path)
+	if err == nil {
+		return snapshot, true
+	}
+	log.Warnf("usage persistence: failed to load %s: %v", p.path, err)
+
+	backupPath := p.path + ".bak"
+	snapshot, err = p.loadFromPath(backupPath)
+	if err == nil {
+		return snapshot, true
+	}
+	log.Errorf("usage persistence: failed to load backup %s: %v", backupPath, err)
+	return StatisticsSnapshot{}, false
+}
+
+// Start begins periodic persistence.
+func (p *Persistor) Start() {
+	if p == nil || p.interval <= 0 {
+		return
+	}
+	if !p.started.CompareAndSwap(false, true) {
+		return
+	}
+	p.persistHook(true)
+	ticker := time.NewTicker(p.interval)
+	go func() {
+		defer close(p.doneCh)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := p.Save(); err != nil {
+					log.Warnf("usage persistence: failed to save snapshot: %v", err)
+				}
+			case <-p.stopCh:
+				return
+			}
+		}
+	}()
+}
+
+// StopAndFlush stops persistence and performs a final save.
+func (p *Persistor) StopAndFlush() {
+	if p == nil {
+		return
+	}
+	p.stopOnce.Do(func() {
+		p.persistHook(false)
+		if p.started.Load() {
+			close(p.stopCh)
+			if p.doneCh != nil {
+				<-p.doneCh
+			}
+		}
+		p.stopDebounce()
+		if err := p.Save(); err != nil {
+			log.Warnf("usage persistence: failed to save final snapshot: %v", err)
+		}
+	})
+}
+
+// TriggerSaveDebounced schedules a save with debounce.
+func (p *Persistor) TriggerSaveDebounced() {
+	if p == nil {
+		return
+	}
+	p.debounceMu.Lock()
+	if p.debounceTimer != nil {
+		p.debounceTimer.Stop()
+	}
+	p.debounceTimer = time.AfterFunc(persistHookDebounceDelay, func() {
+		if err := p.Save(); err != nil {
+			log.Warnf("usage persistence: failed to save debounced snapshot: %v", err)
+		}
+		p.debounceMu.Lock()
+		p.debounceTimer = nil
+		p.debounceMu.Unlock()
+	})
+	p.debounceMu.Unlock()
+}
+
+func (p *Persistor) stopDebounce() {
+	p.debounceMu.Lock()
+	if p.debounceTimer != nil {
+		p.debounceTimer.Stop()
+		p.debounceTimer = nil
+	}
+	p.debounceMu.Unlock()
+}
+
+// Save writes the current snapshot to disk using a tmp -> backup -> rename flow.
+func (p *Persistor) Save() error {
+	if p == nil || p.stats == nil {
+		return nil
+	}
+	p.saveMu.Lock()
+	defer p.saveMu.Unlock()
+
+	snapshot := p.stats.Snapshot()
+	if p.redactSource {
+		redactSnapshotSource(&snapshot)
+	}
+	payload := persistencePayload{
+		Version: 1,
+		SavedAt: time.Now().UTC(),
+		Usage:   snapshot,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(p.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	tmpPath := filepath.Join(dir, "."+filepath.Base(p.path)+".tmp")
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return err
+	}
+
+	backupPath := p.path + ".bak"
+	_ = os.Remove(backupPath)
+	if _, err := os.Stat(p.path); err == nil {
+		if err := os.Rename(p.path, backupPath); err != nil {
+			return err
+		}
+	}
+
+	if err := os.Rename(tmpPath, p.path); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Persistor) loadFromPath(path string) (StatisticsSnapshot, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return StatisticsSnapshot{}, err
+	}
+	return decodeSnapshot(data)
+}
+
+func decodeSnapshot(data []byte) (StatisticsSnapshot, error) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return StatisticsSnapshot{}, err
+	}
+	if raw, ok := envelope["usage"]; ok && len(raw) > 0 {
+		var snapshot StatisticsSnapshot
+		if err := json.Unmarshal(raw, &snapshot); err != nil {
+			return StatisticsSnapshot{}, err
+		}
+		return snapshot, nil
+	}
+	var snapshot StatisticsSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return StatisticsSnapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func (p *Persistor) persistHook(enable bool) {
+	if enable {
+		SetPersistHook(p.TriggerSaveDebounced)
+		return
+	}
+	SetPersistHook(nil)
+}
+
+func redactSnapshotSource(snapshot *StatisticsSnapshot) {
+	if snapshot == nil {
+		return
+	}
+	for apiName, api := range snapshot.APIs {
+		for modelName, model := range api.Models {
+			for i := range model.Details {
+				model.Details[i].Source = ""
+				model.Details[i].AuthIndex = ""
+			}
+			api.Models[modelName] = model
+		}
+		snapshot.APIs[apiName] = api
+	}
+}

--- a/internal/usage/ring_buffer.go
+++ b/internal/usage/ring_buffer.go
@@ -1,0 +1,123 @@
+package usage
+
+// RingBuffer stores request details in a fixed-size ring, preserving order.
+// It is not concurrency-safe and should be guarded by an outer lock.
+type RingBuffer struct {
+	buf   []RequestDetail
+	start int
+	size  int
+	limit int
+}
+
+// NewRingBuffer creates a new ring buffer with the given limit.
+func NewRingBuffer(limit int) *RingBuffer {
+	if limit < 0 {
+		limit = 0
+	}
+	return &RingBuffer{
+		buf:   make([]RequestDetail, limit),
+		limit: limit,
+	}
+}
+
+// Push appends a detail to the buffer. If full, it evicts the oldest entry.
+func (rb *RingBuffer) Push(detail RequestDetail) {
+	if rb == nil || rb.limit == 0 {
+		return
+	}
+	if rb.size < rb.limit {
+		idx := (rb.start + rb.size) % rb.limit
+		rb.buf[idx] = detail
+		rb.size++
+		return
+	}
+	rb.buf[rb.start] = detail
+	rb.start = (rb.start + 1) % rb.limit
+	return
+}
+
+// Snapshot returns a copy of the buffer contents ordered from oldest to newest.
+func (rb *RingBuffer) Snapshot() []RequestDetail {
+	if rb == nil || rb.size == 0 || rb.limit == 0 {
+		return nil
+	}
+	out := make([]RequestDetail, rb.size)
+	for i := 0; i < rb.size; i++ {
+		idx := (rb.start + i) % rb.limit
+		out[i] = rb.buf[idx]
+	}
+	return out
+}
+
+// Load replaces the buffer contents with the provided ordered details.
+// If the input exceeds capacity, only the newest entries are retained.
+func (rb *RingBuffer) Load(details []RequestDetail) {
+	if rb == nil {
+		return
+	}
+	rb.start = 0
+	rb.size = 0
+	if rb.limit == 0 || len(details) == 0 {
+		return
+	}
+	if len(details) > rb.limit {
+		details = details[len(details)-rb.limit:]
+	}
+	for _, detail := range details {
+		rb.Push(detail)
+	}
+}
+
+// Resize changes the buffer capacity and keeps the newest entries.
+func (rb *RingBuffer) Resize(limit int) {
+	if rb == nil {
+		return
+	}
+	if limit < 0 {
+		limit = 0
+	}
+	if limit == rb.limit {
+		return
+	}
+	snapshot := rb.Snapshot()
+	rb.limit = limit
+	rb.buf = make([]RequestDetail, limit)
+	rb.start = 0
+	rb.size = 0
+	if limit == 0 {
+		return
+	}
+	if len(snapshot) > limit {
+		snapshot = snapshot[len(snapshot)-limit:]
+	}
+	for _, detail := range snapshot {
+		rb.Push(detail)
+	}
+}
+
+// Len returns the number of entries currently stored.
+func (rb *RingBuffer) Len() int {
+	if rb == nil {
+		return 0
+	}
+	return rb.size
+}
+
+// Oldest returns the oldest entry without removing it.
+func (rb *RingBuffer) Oldest() (RequestDetail, bool) {
+	if rb == nil || rb.size == 0 || rb.limit == 0 {
+		return RequestDetail{}, false
+	}
+	return rb.buf[rb.start], true
+}
+
+// PopOldest removes and returns the oldest entry.
+func (rb *RingBuffer) PopOldest() (RequestDetail, bool) {
+	if rb == nil || rb.size == 0 || rb.limit == 0 {
+		return RequestDetail{}, false
+	}
+	value := rb.buf[rb.start]
+	rb.start = (rb.start + 1) % rb.limit
+	rb.size--
+	return value, true
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
-	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/wsrelay"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
@@ -89,7 +89,12 @@ type Service struct {
 
 	// wsGateway manages websocket Gemini providers.
 	wsGateway *wsrelay.Manager
+
+	// usagePersistor persists usage statistics snapshots.
+	usagePersistor *internalusage.Persistor
 }
+
+const usageStopDrainTimeout = 5 * time.Second
 
 // RegisterUsagePlugin registers a usage plugin on the global usage manager.
 // This allows external code to monitor API usage and token consumption.
@@ -463,6 +468,54 @@ func (s *Service) rebindExecutors() {
 	}
 }
 
+func (s *Service) updateUsagePersistence(cfg *config.Config) {
+	if s == nil || cfg == nil {
+		return
+	}
+	internalusage.ApplyDetailLimits(
+		cfg.UsagePersistence.DetailRingSize,
+		cfg.UsagePersistence.DetailMaxTotal,
+	)
+	if cfg.UsagePersistence.Enabled {
+		internalusage.SetPersistEveryRequests(cfg.UsagePersistence.SaveEveryRequests)
+	} else {
+		internalusage.SetPersistEveryRequests(0)
+	}
+
+	if !cfg.UsageStatisticsEnabled || !cfg.UsagePersistence.Enabled {
+		if s.usagePersistor != nil {
+			s.usagePersistor.StopAndFlush()
+			s.usagePersistor = nil
+		}
+		return
+	}
+
+	newPersistor, err := internalusage.NewPersistor(cfg, internalusage.GetRequestStatistics())
+	if err != nil {
+		log.Warnf("usage persistence: reconfigure failed: %v", err)
+		return
+	}
+	if newPersistor == nil {
+		return
+	}
+
+	if s.usagePersistor == nil {
+		s.usagePersistor = newPersistor
+		s.usagePersistor.Start()
+		return
+	}
+
+	if s.usagePersistor.Path() == newPersistor.Path() &&
+		s.usagePersistor.Interval() == newPersistor.Interval() &&
+		s.usagePersistor.RedactSource() == newPersistor.RedactSource() {
+		return
+	}
+
+	s.usagePersistor.StopAndFlush()
+	s.usagePersistor = newPersistor
+	s.usagePersistor.Start()
+}
+
 // Run starts the service and blocks until the context is cancelled or the server stops.
 // It initializes all components including authentication, file watching, HTTP server,
 // and starts processing requests. The method blocks until the context is cancelled.
@@ -480,7 +533,34 @@ func (s *Service) Run(ctx context.Context) error {
 		ctx = context.Background()
 	}
 
+	if s.cfg != nil {
+		internalusage.ApplyDetailLimits(
+			s.cfg.UsagePersistence.DetailRingSize,
+			s.cfg.UsagePersistence.DetailMaxTotal,
+		)
+		if s.cfg.UsagePersistence.Enabled {
+			internalusage.SetPersistEveryRequests(s.cfg.UsagePersistence.SaveEveryRequests)
+		} else {
+			internalusage.SetPersistEveryRequests(0)
+		}
+	}
+
+	if s.cfg != nil && s.cfg.UsageStatisticsEnabled && s.cfg.UsagePersistence.Enabled {
+		persistor, err := internalusage.NewPersistor(s.cfg, internalusage.GetRequestStatistics())
+		if err != nil {
+			log.Warnf("usage persistence: init failed: %v", err)
+		} else if persistor != nil {
+			if snapshot, ok := persistor.Load(); ok {
+				internalusage.GetRequestStatistics().RestoreSnapshot(snapshot)
+			}
+			s.usagePersistor = persistor
+		}
+	}
+
 	usage.StartDefault(ctx)
+	if s.usagePersistor != nil {
+		s.usagePersistor.Start()
+	}
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer shutdownCancel()
@@ -661,6 +741,7 @@ func (s *Service) Run(ctx context.Context) error {
 			s.coreManager.SetOAuthModelAlias(newCfg.OAuthModelAlias)
 		}
 		s.rebindExecutors()
+		s.updateUsagePersistence(newCfg)
 	}
 
 	watcherWrapper, err = s.watcherFactory(s.configPath, s.cfg.AuthDir, reloadCallback)
@@ -716,6 +797,13 @@ func (s *Service) Shutdown(ctx context.Context) error {
 			ctx = context.Background()
 		}
 
+		if err := usage.StopDefaultAndDrain(usageStopDrainTimeout); err != nil {
+			log.Warnf("usage: stop drain timeout: %v", err)
+		}
+		if s.usagePersistor != nil {
+			s.usagePersistor.StopAndFlush()
+		}
+
 		// legacy refresh loop removed; only stopping core auth manager below
 
 		if s.watcherCancel != nil {
@@ -763,7 +851,6 @@ func (s *Service) Shutdown(ctx context.Context) error {
 			}
 		}
 
-		usage.StopDefault()
 	})
 	return shutdownErr
 }

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -45,6 +46,7 @@ type Manager struct {
 	once     sync.Once
 	stopOnce sync.Once
 	cancel   context.CancelFunc
+	done     chan struct{}
 
 	mu     sync.Mutex
 	cond   *sync.Cond
@@ -73,6 +75,7 @@ func (m *Manager) Start(ctx context.Context) {
 		}
 		var workerCtx context.Context
 		workerCtx, m.cancel = context.WithCancel(ctx)
+		m.done = make(chan struct{})
 		go m.run(workerCtx)
 	})
 }
@@ -91,6 +94,27 @@ func (m *Manager) Stop() {
 		m.mu.Unlock()
 		m.cond.Broadcast()
 	})
+}
+
+// StopAndDrain stops the dispatcher and waits for queued items to drain.
+func (m *Manager) StopAndDrain(timeout time.Duration) error {
+	if m == nil {
+		return nil
+	}
+	m.Stop()
+	if m.done == nil {
+		return nil
+	}
+	if timeout <= 0 {
+		<-m.done
+		return nil
+	}
+	select {
+	case <-m.done:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("usage: stop timeout after %s", timeout)
+	}
 }
 
 // Register appends a plugin to the delivery list.
@@ -122,6 +146,11 @@ func (m *Manager) Publish(ctx context.Context, record Record) {
 }
 
 func (m *Manager) run(ctx context.Context) {
+	defer func() {
+		if m.done != nil {
+			close(m.done)
+		}
+	}()
 	for {
 		m.mu.Lock()
 		for !m.closed && len(m.queue) == 0 {
@@ -179,3 +208,6 @@ func StartDefault(ctx context.Context) { DefaultManager().Start(ctx) }
 
 // StopDefault stops the default manager's dispatcher.
 func StopDefault() { DefaultManager().Stop() }
+
+// StopDefaultAndDrain stops the default manager and waits for queued items to drain.
+func StopDefaultAndDrain(timeout time.Duration) error { return DefaultManager().StopAndDrain(timeout) }

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -19,6 +19,7 @@ type PayloadConfig = internalconfig.PayloadConfig
 type PayloadRule = internalconfig.PayloadRule
 type PayloadFilterRule = internalconfig.PayloadFilterRule
 type PayloadModelRule = internalconfig.PayloadModelRule
+type UsagePersistenceConfig = internalconfig.UsagePersistenceConfig
 
 type GeminiKey = internalconfig.GeminiKey
 type CodexKey = internalconfig.CodexKey


### PR DESCRIPTION
这次改动主要解决 **usage 统计重启归零**，并提升 **可用性与隐私**：

**1) usage 持久化**
- 新增 `usage-persistence` 配置  
- 启动时从 `${auth-dir}/usage/usage.json` 恢复  
- 定时保存 + “每 N 次请求触发保存”  
- 优雅停机时 **drain 队列 + 最终落盘**

**2) 明细限流**
- per-model 环形明细 + 全局上限  
- 默认：`detail-ring-size=10000`，`detail-max-total=50000`

**3) 脱敏落盘**
- `redact-source: true` 时，持久化文件中 `source/auth_index` 置空  
- 管理接口返回不受影响（仍可用于排障）

**4) Import 行为保持**
- Import 仍走 `MergeSnapshot`，不影响历史逻辑  
- Merge 后触发一次去抖保存

**5) 启动/热更挂钩**
- 重载配置时会更新 detail 上限 / 保存策略  
- 不改变现有 API 行为

如需，我可以补充单测或进一步细化保存间隔与触发阈值。
