### PR TITLE
fix(claude): honor disable_parallel_tool_use

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -271,9 +271,9 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 		}
 	}
 
-	// Default to parallel tool calls unless the client explicitly disables them.
+	// Default to parallel tool calls unless tool_choice explicitly disables them.
 	parallelToolCalls := true
-	if disableParallelToolUse := rootResult.Get("disable_parallel_tool_use"); disableParallelToolUse.Exists() {
+	if disableParallelToolUse := rootResult.Get("tool_choice.disable_parallel_tool_use"); disableParallelToolUse.Exists() {
 		parallelToolCalls = !disableParallelToolUse.Bool()
 	}
 

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -95,7 +95,7 @@ func TestConvertClaudeRequestToCodex_ParallelToolCalls(t *testing.T) {
 		wantParallelToolCalls bool
 	}{
 		{
-			name: "Default to true when disable_parallel_tool_use is absent",
+			name: "Default to true when tool_choice.disable_parallel_tool_use is absent",
 			inputJSON: `{
 				"model": "claude-3-opus",
 				"messages": [{"role": "user", "content": "hello"}]
@@ -106,7 +106,7 @@ func TestConvertClaudeRequestToCodex_ParallelToolCalls(t *testing.T) {
 			name: "Disable parallel tool calls when client opts out",
 			inputJSON: `{
 				"model": "claude-3-opus",
-				"disable_parallel_tool_use": true,
+				"tool_choice": {"disable_parallel_tool_use": true},
 				"messages": [{"role": "user", "content": "hello"}]
 			}`,
 			wantParallelToolCalls: false,
@@ -115,7 +115,7 @@ func TestConvertClaudeRequestToCodex_ParallelToolCalls(t *testing.T) {
 			name: "Keep parallel tool calls enabled when client explicitly allows them",
 			inputJSON: `{
 				"model": "claude-3-opus",
-				"disable_parallel_tool_use": false,
+				"tool_choice": {"disable_parallel_tool_use": false},
 				"messages": [{"role": "user", "content": "hello"}]
 			}`,
 			wantParallelToolCalls: true,


### PR DESCRIPTION
## Summary
- honor Claude's `disable_parallel_tool_use` flag when setting Codex `parallel_tool_calls`
- default `parallel_tool_calls` to `true` only when the client does not send a value
- add request translation tests for the unset, true, and false cases

## Why
Some Claude-compatible clients set `disable_parallel_tool_use` because they cannot handle a single assistant turn that emits multiple `tool_use` blocks. If we always force `parallel_tool_calls=true`, we ignore that capability signal and may return a batched tool-calling response those clients cannot consume.