### PR TITLE
fix(codex): 恢复 free 账号对 gpt-5.4 的模型注册兼容性

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -23,6 +23,11 @@ type staticModelsJSON struct {
 	Antigravity []*ModelInfo `json:"antigravity"`
 }
 
+var codexFreeCompatibilityBackfillIDs = []string{
+	"gpt-5.3-codex",
+	"gpt-5.4",
+}
+
 // GetClaudeModels returns the standard Claude model definitions.
 func GetClaudeModels() []*ModelInfo {
 	return cloneModelInfos(getModels().Claude)
@@ -50,7 +55,12 @@ func GetAIStudioModels() []*ModelInfo {
 
 // GetCodexFreeModels returns model definitions for the Codex free plan tier.
 func GetCodexFreeModels() []*ModelInfo {
-	return cloneModelInfos(getModels().CodexFree)
+	data := getModels()
+	if data == nil {
+		return nil
+	}
+	models := cloneModelInfos(data.CodexFree)
+	return appendMissingModelsByID(models, codexFreeCompatibilityBackfillIDs, data.CodexPlus, data.CodexTeam, data.CodexPro)
 }
 
 // GetCodexTeamModels returns model definitions for the Codex team plan tier.
@@ -98,6 +108,53 @@ func cloneModelInfos(models []*ModelInfo) []*ModelInfo {
 		out[i] = cloneModelInfo(m)
 	}
 	return out
+}
+
+func appendMissingModelsByID(base []*ModelInfo, ids []string, sources ...[]*ModelInfo) []*ModelInfo {
+	seen := make(map[string]struct{}, len(base))
+	for _, model := range base {
+		if model == nil {
+			continue
+		}
+		id := strings.TrimSpace(model.ID)
+		if id == "" {
+			continue
+		}
+		seen[id] = struct{}{}
+	}
+
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		if model := findModelByID(id, sources...); model != nil {
+			base = append(base, cloneModelInfo(model))
+			seen[id] = struct{}{}
+		}
+	}
+
+	if len(base) == 0 {
+		return nil
+	}
+	return base
+}
+
+func findModelByID(id string, sources ...[]*ModelInfo) *ModelInfo {
+	for _, models := range sources {
+		for _, model := range models {
+			if model == nil {
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(model.ID), id) {
+				return model
+			}
+		}
+	}
+	return nil
 }
 
 // GetStaticModelDefinitionsByChannel returns static model definitions for a given channel/provider.

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -1,0 +1,58 @@
+package registry
+
+import "testing"
+
+func TestGetCodexFreeModels_BackfillsPreTierSplitModels(t *testing.T) {
+	original := getModels()
+
+	modelsCatalogStore.mu.Lock()
+	modelsCatalogStore.data = &staticModelsJSON{
+		CodexFree: []*ModelInfo{
+			{ID: "gpt-5"},
+			{ID: "gpt-5.2-codex"},
+		},
+		CodexPlus: []*ModelInfo{
+			{ID: "gpt-5.3-codex"},
+			{ID: "gpt-5.4"},
+		},
+		CodexTeam: []*ModelInfo{
+			{ID: "gpt-5.3-codex"},
+			{ID: "gpt-5.4"},
+		},
+		CodexPro: []*ModelInfo{
+			{ID: "gpt-5.3-codex"},
+			{ID: "gpt-5.4"},
+		},
+	}
+	modelsCatalogStore.mu.Unlock()
+	t.Cleanup(func() {
+		modelsCatalogStore.mu.Lock()
+		modelsCatalogStore.data = original
+		modelsCatalogStore.mu.Unlock()
+	})
+
+	models := GetCodexFreeModels()
+	if len(models) != 4 {
+		t.Fatalf("expected 4 free models after backfill, got %d", len(models))
+	}
+
+	got := make([]string, 0, len(models))
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		if model == nil {
+			t.Fatal("expected model entry, got nil")
+		}
+		got = append(got, model.ID)
+		if _, ok := seen[model.ID]; ok {
+			t.Fatalf("expected unique model IDs, got duplicate %q", model.ID)
+		}
+		seen[model.ID] = struct{}{}
+	}
+
+	want := []string{"gpt-5", "gpt-5.2-codex", "gpt-5.3-codex", "gpt-5.4"}
+	for i, id := range want {
+		if got[i] != id {
+			t.Fatalf("expected model %d to be %q, got %q", i, id, got[i])
+		}
+	}
+}


### PR DESCRIPTION
## 变更说明

3 月 10 日引入按 `plan_type` 注册 Codex 模型后，`plan_type=free` 会单独使用 `GetCodexFreeModels()`。
这让 free 账号不再继承 3 月 9 日之前统一模型表里已有的 `gpt-5.3-codex` 和 `gpt-5.4`，因此新版本里这两个模型对 free 账号变成了不可见。

这个 PR 做了两件事：

- 在 `GetCodexFreeModels()` 中为 free 账号补回 3 月 9 日之前已经可见的兼容模型：`gpt-5.3-codex` 和 `gpt-5.4`
- 增加回归测试，确保 free 账号后续不会再次丢失这两个模型

## 为什么这样改

- 这是最小修复，只恢复 3 月 9 日之前 free 账号已经具备的模型可见性，不改动现有的 `plan_type` 分流逻辑
- 修复放在运行时模型定义层，而不是只改嵌入的 `models.json`，这样即使后续模型目录自动刷新，也不会把兼容性修复覆盖掉

## 验证

- `go test ./internal/registry`
- `go test ./sdk/cliproxy`
