### PR TITLE
fix(codex): add GPT-5.3 Codex and GPT-5.4 (including mini) entries to models registry

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1371,6 +1371,75 @@
           "xhigh"
         ]
       }
+    },
+    {
+      "id": "gpt-5.3-codex",
+      "object": "model",
+      "created": 1770307200,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.3 Codex",
+      "version": "gpt-5.3",
+      "description": "Stable version of GPT 5.3 Codex, The best model for coding and agentic tasks across domains.",
+      "context_length": 400000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.4",
+      "object": "model",
+      "created": 1772668800,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.4",
+      "version": "gpt-5.4",
+      "description": "Stable version of GPT 5.4",
+      "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "object": "model",
+      "created": 1772668800,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.4 mini",
+      "version": "gpt-5.4",
+      "description": "Our strongest mini model yet for coding, computer use, and subagents",
+      "context_length": 400000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     }
   ],
   "codex-team": [
@@ -1611,6 +1680,29 @@
       "version": "gpt-5.4",
       "description": "Stable version of GPT 5.4",
       "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "object": "model",
+      "created": 1772668800,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.4 mini",
+      "version": "gpt-5.4",
+      "description": "Our strongest mini model yet for coding, computer use, and subagents",
+      "context_length": 400000,
       "max_completion_tokens": 128000,
       "supported_parameters": [
         "tools"
@@ -1898,6 +1990,29 @@
           "xhigh"
         ]
       }
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "object": "model",
+      "created": 1772668800,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.4 mini",
+      "version": "gpt-5.4",
+      "description": "Our strongest mini model yet for coding, computer use, and subagents",
+      "context_length": 400000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     }
   ],
   "codex-pro": [
@@ -2161,6 +2276,29 @@
       "version": "gpt-5.4",
       "description": "Stable version of GPT 5.4",
       "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "object": "model",
+      "created": 1772668800,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.4 mini",
+      "version": "gpt-5.4",
+      "description": "Our strongest mini model yet for coding, computer use, and subagents",
+      "context_length": 400000,
       "max_completion_tokens": 128000,
       "supported_parameters": [
         "tools"


### PR DESCRIPTION
### TL;DR
- Added `gpt-5.4-mini` metadata to internal/registry/models/models.json
- Add `gpt-5.3-codex`, `gpt-5.4`, and `gpt-5.4-mini` to the codex-free model catalog  

### Motivation
- Populate the models registry with new GPT-5.x variants so clients and tooling can discover and use the latest Codex and 5.4 models across subscription tiers.
- Provide appropriate metadata (context length, max tokens, supported parameters, and thinking levels) for the new variants to enable correct runtime configuration.

### Description
- Updated `internal/registry/models/models.json` to add `gpt-5.3-codex` and `gpt-5.4` model objects with full metadata entries. 
- Added `gpt-5.4-mini` entries alongside `gpt-5.4` in the top-level and in the `codex-team`, `codex-plus`, and `codex-pro` collections. 
- Set `context_length`, `max_completion_tokens`, `supported_parameters`, and `thinking.levels` for each new model to match expected capabilities. 
- Normalized file ending (ensured trailing newline) for the modified JSON file.

### Testing
- Ran JSON validation against the registry schema to ensure added entries are well-formed and the validation passed. 
- Executed unit tests with `go test ./...` in the repository and all tests completed successfully.