### PR TITLE
feat: add -local-model flag to skip remote model catalog fetching

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -74,6 +74,7 @@ func main() {
 	var password string
 	var tuiMode bool
 	var standalone bool
+	var localModel bool
 
 	// Define command-line flags for different operation modes.
 	flag.BoolVar(&login, "login", false, "Login Google Account")
@@ -93,6 +94,7 @@ func main() {
 	flag.StringVar(&password, "password", "", "")
 	flag.BoolVar(&tuiMode, "tui", false, "Start with terminal management UI")
 	flag.BoolVar(&standalone, "standalone", false, "In TUI mode, start an embedded local server")
+	flag.BoolVar(&localModel, "local-model", false, "Use embedded model catalog only, skip remote model fetching")
 
 	flag.CommandLine.Usage = func() {
 		out := flag.CommandLine.Output()
@@ -491,11 +493,16 @@ func main() {
 			cmd.WaitForCloudDeploy()
 			return
 		}
+		if localModel && (!tuiMode || standalone) {
+			log.Info("Local model mode: using embedded model catalog, remote model updates disabled")
+		}
 		if tuiMode {
 			if standalone {
 				// Standalone mode: start an embedded local server and connect TUI client to it.
 				managementasset.StartAutoUpdater(context.Background(), configFilePath)
-				registry.StartModelsUpdater(context.Background())
+				if !localModel {
+					registry.StartModelsUpdater(context.Background())
+				}
 				hook := tui.NewLogHook(2000)
 				hook.SetFormatter(&logging.LogFormatter{})
 				log.AddHook(hook)
@@ -568,7 +575,9 @@ func main() {
 		} else {
 			// Start the main proxy service
 			managementasset.StartAutoUpdater(context.Background(), configFilePath)
-			registry.StartModelsUpdater(context.Background())
+			if !localModel {
+				registry.StartModelsUpdater(context.Background())
+			}
 			cmd.StartService(cfg, configFilePath, password)
 		}
 	}


### PR DESCRIPTION
## Summary

- Add `-local-model` CLI flag that disables remote model catalog fetching and 3-hour periodic refresh
- When enabled, the server uses only the embedded `models.json` loaded at package init time
- `managementasset.StartAutoUpdater` (management panel) is **not** affected

## Motivation

For environments where remote access to GitHub is restricted, unreliable, or unnecessary (e.g., air-gapped deployments, local development), users can opt into the embedded model catalog without any network calls for model data.

## Changes

**`cmd/server/main.go`** (1 file, +11/-2 lines):
- Added `var localModel bool` and `flag.BoolVar` registration
- Guarded both `registry.StartModelsUpdater()` call sites (TUI standalone + standard server mode) with `if !localModel`
- Added Info-level log message when the flag is active (only in modes that actually start a server)

## Usage

```bash
./cliproxyapi -local-model
```

Help output:
```
  -local-model
    Use embedded model catalog only, skip remote model fetching
```

## How It Works

The `registry` package already loads an embedded `models/models.json` via `//go:embed` in its `init()` function. `StartModelsUpdater()` adds remote fetching on top of that. With `-local-model`, the updater is simply not started, and the embedded data serves as the sole model catalog.