### PR TITLE
feat: add gpt-5.4-mini codex model definitions

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1602,6 +1602,29 @@
       }
     },
     {
+      "id": "gpt-5.4-mini",
+      "object": "model",
+      "created": 1772668800,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.4 Mini",
+      "version": "gpt-5.4-mini",
+      "description": "Stable version of GPT 5.4 Mini",
+      "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
       "id": "gpt-5.4",
       "object": "model",
       "created": 1772668800,
@@ -1877,6 +1900,29 @@
       }
     },
     {
+      "id": "gpt-5.4-mini",
+      "object": "model",
+      "created": 1772668800,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.4 Mini",
+      "version": "gpt-5.4-mini",
+      "description": "Stable version of GPT 5.4 Mini",
+      "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
       "id": "gpt-5.4",
       "object": "model",
       "created": 1772668800,
@@ -2138,6 +2184,29 @@
       "version": "gpt-5.3",
       "description": "Ultra-fast coding model.",
       "context_length": 128000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "object": "model",
+      "created": 1772668800,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.4 Mini",
+      "version": "gpt-5.4-mini",
+      "description": "Stable version of GPT 5.4 Mini",
+      "context_length": 1050000,
       "max_completion_tokens": 128000,
       "supported_parameters": [
         "tools"


### PR DESCRIPTION
Summary
Add gpt-5.4-mini to the Codex model catalogs so the registry exposes it consistently.

Changes
• Added gpt-5.4-mini entries to internal/registry/models/models.json
• Included the model in codex-team, codex-plus, and codex-pro
• Reused the existing gpt-5.4 metadata shape for display name, context length, completion tokens, and thinking support

Notes
• This is a metadata-only change for registry/model listing support
• No runtime behavior changes beyond model discovery and model info lookup