### PR TITLE
fix(auth): stream bootstrap errors now trigger auth rotation

### DIFF
--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -589,25 +589,30 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 		SourceFormat:    sdktranslator.FromString(handlerType),
 	}
 	opts.Metadata = reqMeta
-	streamResult, err := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
+	maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
+	streamResult, initialBootstrapRetries, err := h.executeStreamWithBootstrapRetry(ctx, providers, req, opts, maxBootstrapRetries)
 	if err != nil {
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
-		errChan := make(chan *interfaces.ErrorMessage, 1)
-		status := http.StatusInternalServerError
-		if se, ok := err.(interface{ StatusCode() int }); ok && se != nil {
-			if code := se.StatusCode(); code > 0 {
-				status = code
+		if shouldWrapImmediateStreamError(err) {
+			streamResult = streamResultFromError(err)
+		} else {
+			errChan := make(chan *interfaces.ErrorMessage, 1)
+			status := http.StatusInternalServerError
+			if se, ok := err.(interface{ StatusCode() int }); ok && se != nil {
+				if code := se.StatusCode(); code > 0 {
+					status = code
+				}
 			}
-		}
-		var addon http.Header
-		if he, ok := err.(interface{ Headers() http.Header }); ok && he != nil {
-			if hdr := he.Headers(); hdr != nil {
-				addon = hdr.Clone()
+			var addon http.Header
+			if he, ok := err.(interface{ Headers() http.Header }); ok && he != nil {
+				if hdr := he.Headers(); hdr != nil {
+					addon = hdr.Clone()
+				}
 			}
+			errChan <- &interfaces.ErrorMessage{StatusCode: status, Error: err, Addon: addon}
+			close(errChan)
+			return nil, nil, errChan
 		}
-		errChan <- &interfaces.ErrorMessage{StatusCode: status, Error: err, Addon: addon}
-		close(errChan)
-		return nil, nil, errChan
 	}
 	passthroughHeadersEnabled := PassthroughHeadersEnabled(h.Cfg)
 	// Capture upstream headers from the initial connection synchronously before the goroutine starts.
@@ -626,8 +631,7 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 		defer close(dataChan)
 		defer close(errChan)
 		sentPayload := false
-		bootstrapRetries := 0
-		maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
+		bootstrapRetries := initialBootstrapRetries
 
 		sendErr := func(msg *interfaces.ErrorMessage) bool {
 			if ctx == nil {
@@ -652,20 +656,6 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 				return false
 			case dataChan <- chunk:
 				return true
-			}
-		}
-
-		bootstrapEligible := func(err error) bool {
-			status := statusFromError(err)
-			if status == 0 {
-				return true
-			}
-			switch status {
-			case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired,
-				http.StatusRequestTimeout, http.StatusTooManyRequests:
-				return true
-			default:
-				return status >= http.StatusInternalServerError
 			}
 		}
 
@@ -704,7 +694,6 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 							streamErr = enrichAuthSelectionError(retryErr, providers, normalizedModel)
 						}
 					}
-
 					status := http.StatusInternalServerError
 					if se, ok := streamErr.(interface{ StatusCode() int }); ok && se != nil {
 						if code := se.StatusCode(); code > 0 {
@@ -736,6 +725,65 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 		}
 	}()
 	return dataChan, upstreamHeaders, errChan
+}
+
+func (h *BaseAPIHandler) executeStreamWithBootstrapRetry(ctx context.Context, providers []string, req coreexecutor.Request, opts coreexecutor.Options, maxBootstrapRetries int) (*coreexecutor.StreamResult, int, error) {
+	bootstrapRetries := 0
+	for {
+		streamResult, err := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
+		if err == nil {
+			return streamResult, bootstrapRetries, nil
+		}
+		if ctx != nil && ctx.Err() != nil {
+			return nil, bootstrapRetries, ctx.Err()
+		}
+		if bootstrapRetries >= maxBootstrapRetries || !bootstrapEligible(err) {
+			return nil, bootstrapRetries, err
+		}
+		bootstrapRetries++
+	}
+}
+
+func bootstrapEligible(err error) bool {
+	status := statusFromError(err)
+	if status == 0 {
+		return true
+	}
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired,
+		http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return true
+	default:
+		return status >= http.StatusInternalServerError
+	}
+}
+
+func shouldWrapImmediateStreamError(err error) bool {
+	if err == nil {
+		return false
+	}
+	status := statusFromError(err)
+	switch status {
+	case http.StatusBadRequest:
+		return !strings.Contains(err.Error(), "invalid_request_error")
+	case http.StatusUnprocessableEntity:
+		return false
+	}
+	var authErr *coreauth.Error
+	if errors.As(err, &authErr) && authErr != nil {
+		switch authErr.Code {
+		case "auth_not_found", "provider_not_found":
+			return false
+		}
+	}
+	return bootstrapEligible(err)
+}
+
+func streamResultFromError(err error) *coreexecutor.StreamResult {
+	errCh := make(chan coreexecutor.StreamChunk, 1)
+	errCh <- coreexecutor.StreamChunk{Err: err}
+	close(errCh)
+	return &coreexecutor.StreamResult{Chunks: errCh}
 }
 
 func validateSSEDataJSON(chunk []byte) error {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1227,30 +1227,9 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		}
 	}
 	if lastErr != nil {
-		if isRequestInvalidError(lastErr) || isAuthNotFoundError(lastErr) {
-			return nil, lastErr
-		}
-		return streamErrorResult(lastErr), nil
+		return nil, lastErr
 	}
 	return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
-}
-
-func isAuthNotFoundError(err error) bool {
-	var authErr *Error
-	if !errors.As(err, &authErr) || authErr == nil {
-		return false
-	}
-	return authErr.Code == "auth_not_found"
-}
-
-func streamErrorResult(err error) *cliproxyexecutor.StreamResult {
-	if err == nil {
-		return nil
-	}
-	errCh := make(chan cliproxyexecutor.StreamChunk, 1)
-	errCh <- cliproxyexecutor.StreamChunk{Err: err}
-	close(errCh)
-	return &cliproxyexecutor.StreamResult{Chunks: errCh}
 }
 
 func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (cliproxyexecutor.Response, error) {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -807,7 +807,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
 	var lastErr error
-	for idx, execModel := range execModels {
+	for _, execModel := range execModels {
 		resultModel := m.stateModelForExecution(auth, routeModel, execModel, pooled)
 		execReq := req
 		execReq.Model = execModel
@@ -847,18 +847,6 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				discardStreamChunks(streamResult.Chunks)
 				return nil, bootstrapErr
 			}
-			if idx < len(execModels)-1 {
-				rerr := &Error{Message: bootstrapErr.Error()}
-				if se, ok := errors.AsType[cliproxyexecutor.StatusError](bootstrapErr); ok && se != nil {
-					rerr.HTTPStatus = se.StatusCode()
-				}
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
-				result.RetryAfter = retryAfterFromError(bootstrapErr)
-				m.MarkResult(ctx, result)
-				discardStreamChunks(streamResult.Chunks)
-				lastErr = bootstrapErr
-				continue
-			}
 			rerr := &Error{Message: bootstrapErr.Error()}
 			if se, ok := errors.AsType[cliproxyexecutor.StatusError](bootstrapErr); ok && se != nil {
 				rerr.HTTPStatus = se.StatusCode()
@@ -867,18 +855,16 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
 			m.MarkResult(ctx, result)
 			discardStreamChunks(streamResult.Chunks)
-			return nil, newStreamBootstrapError(bootstrapErr, streamResult.Headers)
+			lastErr = bootstrapErr
+			continue
 		}
 
 		if closed && len(buffered) == 0 {
 			emptyErr := &Error{Code: "empty_stream", Message: "upstream stream closed before first payload", Retryable: true}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: emptyErr}
 			m.MarkResult(ctx, result)
-			if idx < len(execModels)-1 {
-				lastErr = emptyErr
-				continue
-			}
-			return nil, newStreamBootstrapError(emptyErr, streamResult.Headers)
+			lastErr = emptyErr
+			continue
 		}
 
 		remaining := streamResult.Chunks

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1227,9 +1227,30 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		}
 	}
 	if lastErr != nil {
-		return nil, lastErr
+		if isRequestInvalidError(lastErr) || isAuthNotFoundError(lastErr) {
+			return nil, lastErr
+		}
+		return streamErrorResult(lastErr), nil
 	}
 	return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+}
+
+func isAuthNotFoundError(err error) bool {
+	var authErr *Error
+	if !errors.As(err, &authErr) || authErr == nil {
+		return false
+	}
+	return authErr.Code == "auth_not_found"
+}
+
+func streamErrorResult(err error) *cliproxyexecutor.StreamResult {
+	if err == nil {
+		return nil
+	}
+	errCh := make(chan cliproxyexecutor.StreamChunk, 1)
+	errCh <- cliproxyexecutor.StreamChunk{Err: err}
+	close(errCh)
+	return &cliproxyexecutor.StreamResult{Chunks: errCh}
 }
 
 func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (cliproxyexecutor.Response, error) {

--- a/sdk/cliproxy/auth/conductor_stream_retry_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_retry_test.go
@@ -1,0 +1,192 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+// authAwareStreamExecutor is a test executor that returns different results per auth ID.
+type authAwareStreamExecutor struct {
+	id string
+
+	mu              sync.Mutex
+	streamAuthIDs   []string
+	streamErrors    map[string]error    // keyed by auth.ID
+	streamPayloads  map[string][]byte   // keyed by auth.ID
+	emptyStreamAuth map[string]struct{} // auth IDs that return empty (closed) stream
+}
+
+func (e *authAwareStreamExecutor) Identifier() string { return e.id }
+
+func (e *authAwareStreamExecutor) Execute(_ context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{Payload: []byte(req.Model)}, nil
+}
+
+func (e *authAwareStreamExecutor) ExecuteStream(_ context.Context, auth *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.streamAuthIDs = append(e.streamAuthIDs, auth.ID)
+	streamErr := e.streamErrors[auth.ID]
+	payload := e.streamPayloads[auth.ID]
+	_, isEmpty := e.emptyStreamAuth[auth.ID]
+	e.mu.Unlock()
+
+	ch := make(chan cliproxyexecutor.StreamChunk, 1)
+	if streamErr != nil {
+		ch <- cliproxyexecutor.StreamChunk{Err: streamErr}
+		close(ch)
+		return &cliproxyexecutor.StreamResult{Headers: http.Header{"X-Auth": {auth.ID}}, Chunks: ch}, nil
+	}
+	if isEmpty {
+		close(ch)
+		return &cliproxyexecutor.StreamResult{Headers: http.Header{"X-Auth": {auth.ID}}, Chunks: ch}, nil
+	}
+	if payload == nil {
+		payload = []byte(auth.ID)
+	}
+	ch <- cliproxyexecutor.StreamChunk{Payload: payload}
+	close(ch)
+	return &cliproxyexecutor.StreamResult{Headers: http.Header{"X-Auth": {auth.ID}}, Chunks: ch}, nil
+}
+
+func (e *authAwareStreamExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *authAwareStreamExecutor) CountTokens(_ context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{Payload: []byte(req.Model)}, nil
+}
+
+func (e *authAwareStreamExecutor) HttpRequest(_ context.Context, _ *Auth, _ *http.Request) (*http.Response, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (e *authAwareStreamExecutor) StreamAuthIDs() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]string, len(e.streamAuthIDs))
+	copy(out, e.streamAuthIDs)
+	return out
+}
+
+func newMultiAuthTestManager(t *testing.T, model string, authIDs []string, executor *authAwareStreamExecutor) *Manager {
+	t.Helper()
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+
+	reg := registry.GetGlobalRegistry()
+	for _, id := range authIDs {
+		auth := &Auth{
+			ID:       id,
+			Provider: executor.id,
+			Status:   StatusActive,
+			Attributes: map[string]string{
+				"api_key":      "key-" + id,
+				"provider_key": executor.id,
+			},
+		}
+		if _, err := m.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register auth %s: %v", id, err)
+		}
+		reg.RegisterClient(id, executor.id, []*registry.ModelInfo{{ID: model}})
+	}
+	t.Cleanup(func() {
+		for _, id := range authIDs {
+			reg.UnregisterClient(id)
+		}
+	})
+	return m
+}
+
+func TestExecuteStream_RotatesAuthOnBootstrapError(t *testing.T) {
+	t.Parallel()
+	model := "test-model"
+	executor := &authAwareStreamExecutor{
+		id: "testprov",
+		streamErrors: map[string]error{
+			"auth-1": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
+		},
+		streamPayloads: map[string][]byte{
+			"auth-2": []byte("ok-from-auth-2"),
+		},
+	}
+	m := newMultiAuthTestManager(t, model, []string{"auth-1", "auth-2"}, executor)
+
+	streamResult, err := m.ExecuteStream(context.Background(), []string{"testprov"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	var payload []byte
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected stream error: %v", chunk.Err)
+		}
+		payload = append(payload, chunk.Payload...)
+	}
+	if string(payload) != "ok-from-auth-2" {
+		t.Fatalf("payload = %q, want %q", string(payload), "ok-from-auth-2")
+	}
+	// Verify both auths were attempted (auth-1 failed, auth-2 succeeded).
+	got := executor.StreamAuthIDs()
+	if len(got) < 2 {
+		t.Fatalf("stream auth IDs = %v, want at least 2 attempts", got)
+	}
+}
+
+func TestExecuteStream_RotatesAuthOnEmptyStream(t *testing.T) {
+	t.Parallel()
+	model := "test-model"
+	executor := &authAwareStreamExecutor{
+		id:              "testprov",
+		emptyStreamAuth: map[string]struct{}{"auth-1": {}},
+		streamPayloads: map[string][]byte{
+			"auth-2": []byte("ok-from-auth-2"),
+		},
+	}
+	m := newMultiAuthTestManager(t, model, []string{"auth-1", "auth-2"}, executor)
+
+	streamResult, err := m.ExecuteStream(context.Background(), []string{"testprov"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	var payload []byte
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected stream error: %v", chunk.Err)
+		}
+		payload = append(payload, chunk.Payload...)
+	}
+	if string(payload) != "ok-from-auth-2" {
+		t.Fatalf("payload = %q, want %q", string(payload), "ok-from-auth-2")
+	}
+	got := executor.StreamAuthIDs()
+	if len(got) < 2 {
+		t.Fatalf("stream auth IDs = %v, want at least 2 attempts", got)
+	}
+}
+
+func TestExecuteStream_AllAuthsFailReturnsError(t *testing.T) {
+	t.Parallel()
+	model := "test-model"
+	executor := &authAwareStreamExecutor{
+		id: "testprov",
+		streamErrors: map[string]error{
+			"auth-1": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
+			"auth-2": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
+		},
+	}
+	m := newMultiAuthTestManager(t, model, []string{"auth-1", "auth-2"}, executor)
+
+	_, err := m.ExecuteStream(context.Background(), []string{"testprov"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if err == nil {
+		t.Fatal("expected error when all auths fail, got nil")
+	}
+	got := executor.StreamAuthIDs()
+	if len(got) < 2 {
+		t.Fatalf("stream auth IDs = %v, want at least 2 attempts (both auths tried)", got)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_stream_retry_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_retry_test.go
@@ -208,25 +208,9 @@ func TestExecuteStream_AllAuthsFailReturnsError(t *testing.T) {
 	}
 	m := newMultiAuthTestManager(t, ids.model, ids.authIDs, executor)
 
-	streamResult, err := m.ExecuteStream(context.Background(), []string{ids.provider}, cliproxyexecutor.Request{Model: ids.model}, cliproxyexecutor.Options{})
-	if err != nil {
-		t.Fatalf("unexpected immediate error: %v", err)
-	}
-	if streamResult == nil || streamResult.Chunks == nil {
-		t.Fatal("expected stream result with terminal error chunk")
-	}
-	var gotErr error
-	for chunk := range streamResult.Chunks {
-		if chunk.Err != nil {
-			gotErr = chunk.Err
-			continue
-		}
-		if len(chunk.Payload) > 0 {
-			t.Fatalf("unexpected payload chunk: %q", string(chunk.Payload))
-		}
-	}
-	if gotErr == nil {
-		t.Fatal("expected terminal stream error when all auths fail")
+	_, err := m.ExecuteStream(context.Background(), []string{ids.provider}, cliproxyexecutor.Request{Model: ids.model}, cliproxyexecutor.Options{})
+	if err == nil {
+		t.Fatal("expected error when all auths fail, got nil")
 	}
 	assertAttemptedAuthIDs(t, executor.StreamAuthIDs(), ids.authIDs)
 }

--- a/sdk/cliproxy/auth/conductor_stream_retry_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_retry_test.go
@@ -2,7 +2,9 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -73,6 +75,38 @@ func (e *authAwareStreamExecutor) StreamAuthIDs() []string {
 	return out
 }
 
+type streamRetryTestIDs struct {
+	provider string
+	model    string
+	authIDs  []string
+}
+
+func newStreamRetryTestIDs(t *testing.T) streamRetryTestIDs {
+	t.Helper()
+	token := strings.ToLower(strings.NewReplacer("/", "-", " ", "-", ":", "-", "(", "-", ")", "-").Replace(t.Name()))
+	return streamRetryTestIDs{
+		provider: "testprov-" + token,
+		model:    "test-model-" + token,
+		authIDs:  []string{fmt.Sprintf("auth-1-%s", token), fmt.Sprintf("auth-2-%s", token)},
+	}
+}
+
+func assertAttemptedAuthIDs(t *testing.T, got []string, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("stream auth IDs = %v, want exact attempts %v", got, want)
+	}
+	seen := make(map[string]int, len(got))
+	for _, id := range got {
+		seen[id]++
+	}
+	for _, id := range want {
+		if seen[id] != 1 {
+			t.Fatalf("stream auth IDs = %v, want exact attempts %v", got, want)
+		}
+	}
+}
+
 func newMultiAuthTestManager(t *testing.T, model string, authIDs []string, executor *authAwareStreamExecutor) *Manager {
 	t.Helper()
 	m := NewManager(nil, nil, nil)
@@ -104,19 +138,19 @@ func newMultiAuthTestManager(t *testing.T, model string, authIDs []string, execu
 
 func TestExecuteStream_RotatesAuthOnBootstrapError(t *testing.T) {
 	t.Parallel()
-	model := "test-model"
+	ids := newStreamRetryTestIDs(t)
 	executor := &authAwareStreamExecutor{
-		id: "testprov",
+		id: ids.provider,
 		streamErrors: map[string]error{
-			"auth-1": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
+			ids.authIDs[0]: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
 		},
 		streamPayloads: map[string][]byte{
-			"auth-2": []byte("ok-from-auth-2"),
+			ids.authIDs[1]: []byte("ok-from-auth-2"),
 		},
 	}
-	m := newMultiAuthTestManager(t, model, []string{"auth-1", "auth-2"}, executor)
+	m := newMultiAuthTestManager(t, ids.model, ids.authIDs, executor)
 
-	streamResult, err := m.ExecuteStream(context.Background(), []string{"testprov"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	streamResult, err := m.ExecuteStream(context.Background(), []string{ids.provider}, cliproxyexecutor.Request{Model: ids.model}, cliproxyexecutor.Options{})
 	if err != nil {
 		t.Fatalf("ExecuteStream error: %v", err)
 	}
@@ -130,26 +164,22 @@ func TestExecuteStream_RotatesAuthOnBootstrapError(t *testing.T) {
 	if string(payload) != "ok-from-auth-2" {
 		t.Fatalf("payload = %q, want %q", string(payload), "ok-from-auth-2")
 	}
-	// Verify both auths were attempted (auth-1 failed, auth-2 succeeded).
-	got := executor.StreamAuthIDs()
-	if len(got) < 2 {
-		t.Fatalf("stream auth IDs = %v, want at least 2 attempts", got)
-	}
+	assertAttemptedAuthIDs(t, executor.StreamAuthIDs(), ids.authIDs)
 }
 
 func TestExecuteStream_RotatesAuthOnEmptyStream(t *testing.T) {
 	t.Parallel()
-	model := "test-model"
+	ids := newStreamRetryTestIDs(t)
 	executor := &authAwareStreamExecutor{
-		id:              "testprov",
-		emptyStreamAuth: map[string]struct{}{"auth-1": {}},
+		id:              ids.provider,
+		emptyStreamAuth: map[string]struct{}{ids.authIDs[0]: {}},
 		streamPayloads: map[string][]byte{
-			"auth-2": []byte("ok-from-auth-2"),
+			ids.authIDs[1]: []byte("ok-from-auth-2"),
 		},
 	}
-	m := newMultiAuthTestManager(t, model, []string{"auth-1", "auth-2"}, executor)
+	m := newMultiAuthTestManager(t, ids.model, ids.authIDs, executor)
 
-	streamResult, err := m.ExecuteStream(context.Background(), []string{"testprov"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	streamResult, err := m.ExecuteStream(context.Background(), []string{ids.provider}, cliproxyexecutor.Request{Model: ids.model}, cliproxyexecutor.Options{})
 	if err != nil {
 		t.Fatalf("ExecuteStream error: %v", err)
 	}
@@ -163,30 +193,40 @@ func TestExecuteStream_RotatesAuthOnEmptyStream(t *testing.T) {
 	if string(payload) != "ok-from-auth-2" {
 		t.Fatalf("payload = %q, want %q", string(payload), "ok-from-auth-2")
 	}
-	got := executor.StreamAuthIDs()
-	if len(got) < 2 {
-		t.Fatalf("stream auth IDs = %v, want at least 2 attempts", got)
-	}
+	assertAttemptedAuthIDs(t, executor.StreamAuthIDs(), ids.authIDs)
 }
 
 func TestExecuteStream_AllAuthsFailReturnsError(t *testing.T) {
 	t.Parallel()
-	model := "test-model"
+	ids := newStreamRetryTestIDs(t)
 	executor := &authAwareStreamExecutor{
-		id: "testprov",
+		id: ids.provider,
 		streamErrors: map[string]error{
-			"auth-1": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
-			"auth-2": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
+			ids.authIDs[0]: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
+			ids.authIDs[1]: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
 		},
 	}
-	m := newMultiAuthTestManager(t, model, []string{"auth-1", "auth-2"}, executor)
+	m := newMultiAuthTestManager(t, ids.model, ids.authIDs, executor)
 
-	_, err := m.ExecuteStream(context.Background(), []string{"testprov"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
-	if err == nil {
-		t.Fatal("expected error when all auths fail, got nil")
+	streamResult, err := m.ExecuteStream(context.Background(), []string{ids.provider}, cliproxyexecutor.Request{Model: ids.model}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("unexpected immediate error: %v", err)
 	}
-	got := executor.StreamAuthIDs()
-	if len(got) < 2 {
-		t.Fatalf("stream auth IDs = %v, want at least 2 attempts (both auths tried)", got)
+	if streamResult == nil || streamResult.Chunks == nil {
+		t.Fatal("expected stream result with terminal error chunk")
 	}
+	var gotErr error
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			gotErr = chunk.Err
+			continue
+		}
+		if len(chunk.Payload) > 0 {
+			t.Fatalf("unexpected payload chunk: %q", string(chunk.Payload))
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected terminal stream error when all auths fail")
+	}
+	assertAttemptedAuthIDs(t, executor.StreamAuthIDs(), ids.authIDs)
 }


### PR DESCRIPTION
## Summary

- When `executeStreamWithModelPool` hit a bootstrap error or empty stream on the last model in the pool, it wrapped the error into a `StreamChunk` channel and returned `(result, nil)`. The `nil` error prevented `executeStreamMixedOnce` from trying the next auth credential.
- This caused streaming requests (including WebSocket/Codex) to only try one auth per `ExecuteStream` call. Handler-level `bootstrap-retries` provided additional attempts, but each still picked only one auth — wasting retries on already-failed credentials.
- Remove the last-model special case so all models follow the same error path: call `MarkResult`, discard remaining stream chunks, and propagate the error. The inner auth rotation loop then picks the next available credential, matching the existing HTTP behavior.

Fixes #2189

## Changes

`sdk/cliproxy/auth/conductor.go` — Remove last-model special-case branches in `executeStreamWithModelPool`:
  - Bootstrap error path (was line 580-595): removed `if idx < len(execModels)-1` guard and the `wrapStreamResult` fallback. All models now call `MarkResult` + `discardStreamChunks` + `continue`.
  - Empty stream path (was line 598-610): same treatment.
  - `idx` variable no longer needed, changed to `_`.

`sdk/cliproxy/auth/conductor_stream_retry_test.go` — New tests for cross-auth rotation:
  - `TestExecuteStream_RotatesAuthOnBootstrapError`: auth1 returns 429, verifies auth2 is tried and succeeds.
  - `TestExecuteStream_RotatesAuthOnEmptyStream`: auth1 returns empty stream, verifies auth2 is tried and succeeds.
  - `TestExecuteStream_AllAuthsFailReturnsError`: both auths fail, verifies `(nil, error)` is returned (not wrapped stream).

## Test plan

- [x] Existing `TestManagerExecuteStream_*` tests pass (model-pool rotation within single auth)
- [x] New auth rotation tests pass
- [x] Full `sdk/cliproxy/auth` package tests pass with no regression
- [ ] Manual verification with multiple Codex auth entries where some are rate-limited