### PR TITLE
fix: avoid data race when watching request cancellation

### DIFF
--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -339,12 +339,13 @@ func (h *BaseAPIHandler) GetContextWithCancel(handler interfaces.APIHandler, c *
 		}
 	}
 	newCtx, cancel := context.WithCancel(parentCtx)
+	cancelCtx := newCtx
 	if requestCtx != nil && requestCtx != parentCtx {
 		go func() {
 			select {
 			case <-requestCtx.Done():
 				cancel()
-			case <-newCtx.Done():
+			case <-cancelCtx.Done():
 			}
 		}()
 	}


### PR DESCRIPTION
```
[2026-03-18 23:43:57] [08a61818] [info ] [gin_logger.go:93] 200 |       11.694s |       127.0.0.1 | POST    "/v1/responses"
[2026-03-18 23:44:02] [2b7669ad] [info ] [gin_logger.go:93] 200 |        4.712s |       127.0.0.1 | POST    "/v1/responses"
panic: interface conversion: interface {} is , not chan struct {}

goroutine 2426 [running]:
context.(*cancelCtx).Done(0x0?)
        /opt/hostedtoolcache/go/1.26.1/x64/src/context/context.go:451 +0x1a5
github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers.(*BaseAPIHandler).GetContextWithCancel.func1()
        /home/runner/work/CLIProxyAPI/CLIProxyAPI/sdk/api/handlers/handlers.go:347 +0x49
created by github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers.(*BaseAPIHandler).GetContextWithCancel in goroutine 2594
        /home/runner/work/CLIProxyAPI/CLIProxyAPI/sdk/api/handlers/handlers.go:343 +0x290
```