### PR TITLE
fix: strip Anthropic-specific fingerprint headers (anthropic-dangerou…

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -598,6 +598,18 @@ func (e *ClaudeExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (
 	return auth, nil
 }
 
+// removeBetaFeature removes a specific beta feature from a comma-separated beta header value.
+func removeBetaFeature(header, featureToRemove string) string {
+	parts := strings.Split(header, ",")
+	filtered := parts[:0]
+	for _, p := range parts {
+		if strings.TrimSpace(p) != featureToRemove {
+			filtered = append(filtered, p)
+		}
+	}
+	return strings.Join(filtered, ",")
+}
+
 // extractAndRemoveBetas extracts the "betas" array from the body and removes it.
 // Returns the extracted betas as a string slice and the modified body.
 func extractAndRemoveBetas(body []byte) ([]string, []byte) {
@@ -833,6 +845,13 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 		}
 	}
 
+	// Remove claude-code-20250219 for non-Anthropic upstreams: third-party providers
+	// (e.g. api.xheai.cc) do not support this beta feature and will hang or return 400
+	// when it is present. The feature is only valid on api.anthropic.com.
+	if !isAnthropicBase {
+		baseBetas = removeBetaFeature(baseBetas, "claude-code-20250219")
+	}
+
 	hasClaude1MHeader := false
 	if ginHeaders != nil {
 		if _, ok := ginHeaders[textproto.CanonicalMIMEHeaderKey("X-CPA-CLAUDE-1M")]; ok {
@@ -863,8 +882,12 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	r.Header.Set("Anthropic-Beta", baseBetas)
 
 	misc.EnsureHeader(r.Header, ginHeaders, "Anthropic-Version", "2023-06-01")
-	misc.EnsureHeader(r.Header, ginHeaders, "Anthropic-Dangerous-Direct-Browser-Access", "true")
-	misc.EnsureHeader(r.Header, ginHeaders, "X-App", "cli")
+	// Only forward Anthropic-specific fingerprint headers to api.anthropic.com.
+	// Third-party upstreams (e.g. api.xheai.cc) reject these headers with 400 or hang.
+	if isAnthropicBase {
+		misc.EnsureHeader(r.Header, ginHeaders, "Anthropic-Dangerous-Direct-Browser-Access", "true")
+		misc.EnsureHeader(r.Header, ginHeaders, "X-App", "cli")
+	}
 	// Values below match Claude Code 2.1.63 / @anthropic-ai/sdk 0.74.0 (updated 2026-02-28).
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Retry-Count", "0")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Runtime-Version", hdrDefault(hd.RuntimeVersion, "v24.3.0"))

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1064,3 +1064,63 @@ func TestCheckSystemInstructionsWithMode_StringWithSpecialChars(t *testing.T) {
 		t.Fatalf("blocks[2] text mangled, got %q", blocks[2].Get("text").String())
 	}
 }
+
+// TestApplyClaudeHeaders_NonAnthropicUpstream verifies that Anthropic-specific
+// fingerprint headers are NOT forwarded when the upstream is not api.anthropic.com.
+// These headers (Anthropic-Dangerous-Direct-Browser-Access, X-App, and the
+// claude-code-20250219 beta) cause third-party upstreams like api.xheai.cc to
+// hang or return 400. Regression test for the gateway compatibility bug.
+func TestApplyClaudeHeaders_NonAnthropicUpstream(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPost, "https://api.xheai.cc/v1/messages?beta=true", nil)
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":  "sk-test-key",
+			"base_url": "https://api.xheai.cc",
+		},
+	}
+	applyClaudeHeaders(req, auth, "sk-test-key", false, nil, nil)
+
+	// anthropic-dangerous-direct-browser-access must NOT be sent to non-Anthropic upstreams
+	if got := req.Header.Get("Anthropic-Dangerous-Direct-Browser-Access"); got != "" {
+		t.Errorf("Anthropic-Dangerous-Direct-Browser-Access = %q, want empty for non-Anthropic upstream", got)
+	}
+
+	// x-app must NOT be sent to non-Anthropic upstreams
+	if got := req.Header.Get("X-App"); got != "" {
+		t.Errorf("X-App = %q, want empty for non-Anthropic upstream", got)
+	}
+
+	// claude-code-20250219 must NOT appear in Anthropic-Beta for non-Anthropic upstreams
+	beta := req.Header.Get("Anthropic-Beta")
+	if strings.Contains(beta, "claude-code-20250219") {
+		t.Errorf("Anthropic-Beta contains claude-code-20250219 for non-Anthropic upstream: %q", beta)
+	}
+}
+
+// TestApplyClaudeHeaders_AnthropicUpstream verifies that all Anthropic-specific
+// headers ARE set when the upstream is api.anthropic.com (normal case).
+func TestApplyClaudeHeaders_AnthropicUpstream(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages?beta=true", nil)
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key": "sk-ant-test",
+		},
+	}
+	applyClaudeHeaders(req, auth, "sk-ant-test", false, nil, nil)
+
+	// anthropic-dangerous-direct-browser-access MUST be sent to api.anthropic.com
+	if got := req.Header.Get("Anthropic-Dangerous-Direct-Browser-Access"); got != "true" {
+		t.Errorf("Anthropic-Dangerous-Direct-Browser-Access = %q, want %q for Anthropic upstream", got, "true")
+	}
+
+	// x-app MUST be sent to api.anthropic.com
+	if got := req.Header.Get("X-App"); got != "cli" {
+		t.Errorf("X-App = %q, want %q for Anthropic upstream", got, "cli")
+	}
+
+	// claude-code-20250219 MUST appear in Anthropic-Beta for api.anthropic.com
+	beta := req.Header.Get("Anthropic-Beta")
+	if !strings.Contains(beta, "claude-code-20250219") {
+		t.Errorf("Anthropic-Beta missing claude-code-20250219 for Anthropic upstream: %q", beta)
+	}
+}


### PR DESCRIPTION
## Problem Description

The CLIProxyAPI gateway unconditionally forwards Anthropic-specific fingerprint headers to all upstream providers, including third-party ones like `api.xheai.cc`. This causes those upstreams to hang or return `400 Improperly formed request`, while the same request body sent directly to the upstream (without these headers) succeeds with `200 OK`.

**Failing request to gateway** (`POST /v1/messages?beta=true`, elapsed 1891ms → 400):
```
anthropic-beta: claude-code-20250219,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05,effort-2025-11-24
anthropic-dangerous-direct-browser-access: true
x-app: cli
model: claude-opus-4-6
```

**Gateway response:**
```json
{
  "error": {
    "message": "Upstream bad request: Improperly formed request.",
    "type": "invalid_request_error"
  }
}
```

**Direct upstream request (same body, succeeded with 200):**
```
Authorization: Bearer sk-sfAb5***
Content-Type: application/json
anthropic-version: 2023-06-01
# no anthropic-beta, no anthropic-dangerous-direct-browser-access, no x-app
```

Any one of the following headers is sufficient to trigger the issue:

| Header | Value | Result |
|---|---|---|
| `anthropic-beta` | contains `claude-code-20250219` + model `claude-opus-4-6` | 400 / hang |
| `anthropic-dangerous-direct-browser-access` | `true` | 400 / hang |
| `x-app` | `cli` | 400 / hang |

## Root Cause Analysis (RCA)

**Location:** `internal/runtime/executor/claude_executor.go`, function `applyClaudeHeaders()`

The function already computes `isAnthropicBase` to distinguish `api.anthropic.com` from other upstreams, but only uses it for auth header selection. The three Anthropic-specific fingerprint headers are set unconditionally:

```go
// internal/runtime/executor/claude_executor.go — BEFORE FIX

isAnthropicBase := r.URL != nil &&
    strings.EqualFold(r.URL.Scheme, "https") &&
    strings.EqualFold(r.URL.Host, "api.anthropic.com")  // computed but only used for auth

// baseBetas hardcodes claude-code-20250219 regardless of upstream
baseBetas := "claude-code-20250219,oauth-2025-04-20,..."
// ...
r.Header.Set("Anthropic-Beta", baseBetas)                              // always set
misc.EnsureHeader(..., "Anthropic-Dangerous-Direct-Browser-Access", "true")  // always set
misc.EnsureHeader(..., "X-App", "cli")                                 // always set
```

The existing configuration system (`ClaudeHeaderDefaults`, per-key `headers` map) cannot work around this: custom headers can only add or overwrite values, not conditionally suppress headers that are hardcoded earlier in the same function.

## Fix

Reuse the existing `isAnthropicBase` flag to gate the three problematic headers.

```go
// internal/runtime/executor/claude_executor.go — AFTER FIX

// Remove claude-code-20250219 for non-Anthropic upstreams: third-party providers
// (e.g. api.xheai.cc) do not support this beta feature and will hang or return 400
// when it is present. The feature is only valid on api.anthropic.com.
if !isAnthropicBase {
    baseBetas = removeBetaFeature(baseBetas, "claude-code-20250219")
}
// ...
r.Header.Set("Anthropic-Beta", baseBetas)

misc.EnsureHeader(r.Header, ginHeaders, "Anthropic-Version", "2023-06-01")
// Only forward Anthropic-specific fingerprint headers to api.anthropic.com.
// Third-party upstreams (e.g. api.xheai.cc) reject these headers with 400 or hang.
if isAnthropicBase {
    misc.EnsureHeader(r.Header, ginHeaders, "Anthropic-Dangerous-Direct-Browser-Access", "true")
    misc.EnsureHeader(r.Header, ginHeaders, "X-App", "cli")
}
```

New helper added in the same file:

```go
func removeBetaFeature(header, featureToRemove string) string {
    parts := strings.Split(header, ",")
    filtered := parts[:0]
    for _, p := range parts {
        if strings.TrimSpace(p) != featureToRemove {
            filtered = append(filtered, p)
        }
    }
    return strings.Join(filtered, ",")
}
```

The fix applies to all three call sites of `applyClaudeHeaders` — `Execute()`, `ExecuteStream()`, and `CountTokens()` — in a single change.

**Alternative considered:** filtering at the handler or middleware layer — rejected because it would require duplicating logic across multiple paths, while `applyClaudeHeaders` is the single shared call site.

## Test Verification

New tests in `internal/runtime/executor/claude_executor_test.go`:

```go
// TestApplyClaudeHeaders_NonAnthropicUpstream verifies that Anthropic-specific
// fingerprint headers are NOT forwarded when the upstream is not api.anthropic.com.
func TestApplyClaudeHeaders_NonAnthropicUpstream(t *testing.T) {
    req, _ := http.NewRequest(http.MethodPost, "https://api.xheai.cc/v1/messages?beta=true", nil)
    auth := &cliproxyauth.Auth{
        Attributes: map[string]string{
            "api_key":  "sk-test-key",
            "base_url": "https://api.xheai.cc",
        },
    }
    applyClaudeHeaders(req, auth, "sk-test-key", false, nil, nil)

    if got := req.Header.Get("Anthropic-Dangerous-Direct-Browser-Access"); got != "" {
        t.Errorf("Anthropic-Dangerous-Direct-Browser-Access = %q, want empty", got)
    }
    if got := req.Header.Get("X-App"); got != "" {
        t.Errorf("X-App = %q, want empty", got)
    }
    if strings.Contains(req.Header.Get("Anthropic-Beta"), "claude-code-20250219") {
        t.Errorf("Anthropic-Beta contains claude-code-20250219: %q", req.Header.Get("Anthropic-Beta"))
    }
}
```

**Before fix (RED):**
```
=== RUN   TestApplyClaudeHeaders_NonAnthropicUpstream
    claude_executor_test.go:1085: Anthropic-Dangerous-Direct-Browser-Access = "true", want empty for non-Anthropic upstream
    claude_executor_test.go:1090: X-App = "cli", want empty for non-Anthropic upstream
    claude_executor_test.go:1096: Anthropic-Beta contains claude-code-20250219 for non-Anthropic upstream
--- FAIL: TestApplyClaudeHeaders_NonAnthropicUpstream (0.00s)
```

**After fix (GREEN):**
```
=== RUN   TestApplyClaudeHeaders_NonAnthropicUpstream
--- PASS: TestApplyClaudeHeaders_NonAnthropicUpstream (0.00s)
=== RUN   TestApplyClaudeHeaders_AnthropicUpstream
--- PASS: TestApplyClaudeHeaders_AnthropicUpstream (0.00s)
PASS
```

**Full test suite:**
```
go test ./...
# 35 packages — all PASS, 0 FAIL
```

## Impact Assessment

- **Affected path:** only Claude credentials configured with a non-`api.anthropic.com` `base_url`. Credentials pointing at `api.anthropic.com` are unaffected.
- **Configuration changes:** none required.
- **Deployment notes:** restart the service to apply.

## Checklist

- [x] Self-tested
- [x] New tests added covering the bug scenario (fail before fix, pass after)
- [x] Full test suite passes with no regressions
- [x] No unrelated changes included
