### PR TITLE
feat(claude): add per-account 1M context toggle with global model whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Binaries
 cli-proxy-api
 *.exe
+server
+coverage.out
 
 # Configuration
 config.yaml

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -207,6 +207,16 @@ nonstream-keepalive-interval: 0
 #   timeout: "600"
 #   stabilize-device-profile: false  # optional, default false; set true to enable per-auth/API-key fingerprint pinning
 
+# Claude 1M context beta control.
+# When enabled, the context-1m-2025-08-07 Anthropic Beta header is added per account.
+# Each Claude auth file must also have "enable_1m_context": true to opt in.
+# Models lists which models support 1M context; leave empty to allow all.
+# claude-1m-context:
+#   enabled: true
+#   models:
+#     - claude-opus-4-6
+#     - claude-sonnet-4-6
+
 # Default headers for Codex OAuth model requests.
 # These are used only for file-backed/OAuth Codex requests when the client
 # does not send the header. `user-agent` applies to HTTP and websocket requests;

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -466,19 +466,21 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	}
 	// Expose enable_1m_context from Attributes (set by synthesizer or PatchAuthFileFields).
 	// Fall back to Metadata for auths registered via UploadAuthFile (no synthesizer).
-	if v := strings.TrimSpace(authAttribute(auth, "enable_1m_context")); strings.EqualFold(v, "true") {
-		entry["enable_1m_context"] = true
+	var is1MEnabled bool
+	if v := strings.TrimSpace(authAttribute(auth, "enable_1m_context")); v != "" {
+		is1MEnabled, _ = strconv.ParseBool(v)
 	} else if auth.Metadata != nil {
-		switch raw := auth.Metadata["enable_1m_context"].(type) {
-		case bool:
-			if raw {
-				entry["enable_1m_context"] = true
-			}
-		case string:
-			if strings.EqualFold(strings.TrimSpace(raw), "true") {
-				entry["enable_1m_context"] = true
+		if val, ok := auth.Metadata["enable_1m_context"]; ok {
+			switch v := val.(type) {
+			case bool:
+				is1MEnabled = v
+			case string:
+				is1MEnabled, _ = strconv.ParseBool(strings.TrimSpace(v))
 			}
 		}
+	}
+	if is1MEnabled {
+		entry["enable_1m_context"] = true
 	}
 	return entry
 }

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -464,6 +464,22 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 			}
 		}
 	}
+	// Expose enable_1m_context from Attributes (set by synthesizer or PatchAuthFileFields).
+	// Fall back to Metadata for auths registered via UploadAuthFile (no synthesizer).
+	if v := strings.TrimSpace(authAttribute(auth, "enable_1m_context")); strings.EqualFold(v, "true") {
+		entry["enable_1m_context"] = true
+	} else if auth.Metadata != nil {
+		switch raw := auth.Metadata["enable_1m_context"].(type) {
+		case bool:
+			if raw {
+				entry["enable_1m_context"] = true
+			}
+		case string:
+			if strings.EqualFold(strings.TrimSpace(raw), "true") {
+				entry["enable_1m_context"] = true
+			}
+		}
+	}
 	return entry
 }
 
@@ -1120,7 +1136,7 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "disabled": *req.Disabled})
 }
 
-// PatchAuthFileFields updates editable fields (prefix, proxy_url, headers, priority, note) of an auth file.
+// PatchAuthFileFields updates editable fields (prefix, proxy_url, headers, priority, note, enable_1m_context) of an auth file.
 func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 	if h.authManager == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
@@ -1128,12 +1144,13 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 	}
 
 	var req struct {
-		Name     string            `json:"name"`
-		Prefix   *string           `json:"prefix"`
-		ProxyURL *string           `json:"proxy_url"`
-		Headers  map[string]string `json:"headers"`
-		Priority *int              `json:"priority"`
-		Note     *string           `json:"note"`
+		Name            string            `json:"name"`
+		Prefix          *string           `json:"prefix"`
+		ProxyURL        *string           `json:"proxy_url"`
+		Headers         map[string]string `json:"headers"`
+		Priority        *int              `json:"priority"`
+		Note            *string           `json:"note"`
+		Enable1MContext *bool             `json:"enable_1m_context"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -1296,6 +1313,22 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 				targetAuth.Metadata["note"] = trimmedNote
 				targetAuth.Attributes["note"] = trimmedNote
 			}
+		}
+		changed = true
+	}
+	if req.Enable1MContext != nil {
+		if targetAuth.Metadata == nil {
+			targetAuth.Metadata = make(map[string]any)
+		}
+		if targetAuth.Attributes == nil {
+			targetAuth.Attributes = make(map[string]string)
+		}
+		if *req.Enable1MContext {
+			targetAuth.Metadata["enable_1m_context"] = true
+			targetAuth.Attributes["enable_1m_context"] = "true"
+		} else {
+			delete(targetAuth.Metadata, "enable_1m_context")
+			delete(targetAuth.Attributes, "enable_1m_context")
 		}
 		changed = true
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,10 @@ type Config struct {
 	// Payload defines default and override rules for provider payload parameters.
 	Payload PayloadConfig `yaml:"payload" json:"payload"`
 
+	// Claude1MContext controls the context-1m-2025-08-07 Anthropic Beta feature.
+	// When enabled, the 1M context beta header is added to requests for accounts
+	// that have enable_1m_context set in their auth file, limited to the listed models.
+	Claude1MContext Claude1MContext `yaml:"claude-1m-context" json:"claude-1m-context"`
 	legacyMigrationPending bool `yaml:"-" json:"-"`
 }
 
@@ -149,6 +153,18 @@ type ClaudeHeaderDefaults struct {
 	Arch                   string `yaml:"arch" json:"arch"`
 	Timeout                string `yaml:"timeout" json:"timeout"`
 	StabilizeDeviceProfile *bool  `yaml:"stabilize-device-profile,omitempty" json:"stabilize-device-profile,omitempty"`
+}
+
+// Claude1MContext controls the context-1m-2025-08-07 Anthropic Beta feature.
+// When Enabled is true and a per-account toggle is on, the 1M context beta header
+// is added to matching requests. Models lists the model names that support 1M context;
+// an empty list means all models are allowed.
+type Claude1MContext struct {
+	// Enabled is the global toggle. When false, 1M context is never applied.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Models lists model names that support 1M context (e.g. claude-opus-4-6, claude-sonnet-4-6).
+	// An empty list means all models are allowed when the per-account toggle is on.
+	Models []string `yaml:"models" json:"models"`
 }
 
 // CodexHeaderDefaults configures fallback header values injected into Codex

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http"
 	"net/textproto"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -869,36 +868,6 @@ func decodeResponseBody(body io.ReadCloser, contentEncoding string) (io.ReadClos
 	return body, nil
 }
 
-// mapStainlessOS maps runtime.GOOS to Stainless SDK OS names.
-func mapStainlessOS() string {
-	switch runtime.GOOS {
-	case "darwin":
-		return "MacOS"
-	case "windows":
-		return "Windows"
-	case "linux":
-		return "Linux"
-	case "freebsd":
-		return "FreeBSD"
-	default:
-		return "Other::" + runtime.GOOS
-	}
-}
-
-// mapStainlessArch maps runtime.GOARCH to Stainless SDK architecture names.
-func mapStainlessArch() string {
-	switch runtime.GOARCH {
-	case "amd64":
-		return "x64"
-	case "arm64":
-		return "arm64"
-	case "386":
-		return "x86"
-	default:
-		return "other::" + runtime.GOARCH
-	}
-}
-
 func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string, stream bool, extraBetas []string, cfg *config.Config, model string) {
 	hdrDefault := func(cfgVal, fallback string) string {
 		if cfgVal != "" {
@@ -1036,12 +1005,22 @@ func should1MContext(auth *cliproxyauth.Auth, cfg *config.Config, model string) 
 		return false
 	}
 	// Check Attributes first (set by synthesizer / PatchAuthFileFields),
-	// then fall back to Metadata (set by UploadAuthFile / registerAuthFromFile).
+	// then fall back to Metadata only when the attribute key is absent
+	// (set by UploadAuthFile / registerAuthFromFile).
+	// An explicit Attributes value (including "false") is authoritative.
 	enabled := false
 	if auth.Attributes != nil {
-		enabled, _ = strconv.ParseBool(strings.TrimSpace(auth.Attributes["enable_1m_context"]))
-	}
-	if !enabled && auth.Metadata != nil {
+		if attrVal, hasAttr := auth.Attributes["enable_1m_context"]; hasAttr {
+			enabled, _ = strconv.ParseBool(strings.TrimSpace(attrVal))
+		} else if auth.Metadata != nil {
+			switch v := auth.Metadata["enable_1m_context"].(type) {
+			case bool:
+				enabled = v
+			case string:
+				enabled, _ = strconv.ParseBool(strings.TrimSpace(v))
+			}
+		}
+	} else if auth.Metadata != nil {
 		switch v := auth.Metadata["enable_1m_context"].(type) {
 		case bool:
 			enabled = v

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1041,12 +1041,12 @@ func should1MContext(auth *cliproxyauth.Auth, cfg *config.Config, model string) 
 		return true
 	}
 	// Check if the request model is in the whitelist.
+	modelsMap := make(map[string]struct{}, len(cfg.Claude1MContext.Models))
 	for _, m := range cfg.Claude1MContext.Models {
-		if strings.EqualFold(strings.TrimSpace(m), model) {
-			return true
-		}
+		modelsMap[strings.ToLower(strings.TrimSpace(m))] = struct{}{}
 	}
-	return false
+	_, ok := modelsMap[strings.ToLower(model)]
+	return ok
 }
 
 func claudeCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -12,6 +12,8 @@ import (
 	"io"
 	"net/http"
 	"net/textproto"
+	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1030,10 +1032,24 @@ func should1MContext(auth *cliproxyauth.Auth, cfg *config.Config, model string) 
 	if cfg == nil || !cfg.Claude1MContext.Enabled {
 		return false
 	}
-	if auth == nil || auth.Attributes == nil {
+	if auth == nil {
 		return false
 	}
-	if !strings.EqualFold(strings.TrimSpace(auth.Attributes["enable_1m_context"]), "true") {
+	// Check Attributes first (set by synthesizer / PatchAuthFileFields),
+	// then fall back to Metadata (set by UploadAuthFile / registerAuthFromFile).
+	enabled := false
+	if auth.Attributes != nil {
+		enabled, _ = strconv.ParseBool(strings.TrimSpace(auth.Attributes["enable_1m_context"]))
+	}
+	if !enabled && auth.Metadata != nil {
+		switch v := auth.Metadata["enable_1m_context"].(type) {
+		case bool:
+			enabled = v
+		case string:
+			enabled, _ = strconv.ParseBool(strings.TrimSpace(v))
+		}
+	}
+	if !enabled {
 		return false
 	}
 	// If models whitelist is empty, allow all models.

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1005,22 +1005,22 @@ func should1MContext(auth *cliproxyauth.Auth, cfg *config.Config, model string) 
 		return false
 	}
 	// Check Attributes first (set by synthesizer / PatchAuthFileFields),
-	// then fall back to Metadata only when the attribute key is absent
-	// (set by UploadAuthFile / registerAuthFromFile).
-	// An explicit Attributes value (including "false") is authoritative.
+	// then fall back to Metadata only when the attribute key is absent or
+	// the value is unparseable (set by UploadAuthFile / registerAuthFromFile).
+	// An explicit Attributes value that parses cleanly (including "false")
+	// is authoritative; a malformed attribute should not silently disable
+	// 1M context, so it falls back to Metadata as if absent.
 	enabled := false
+	useMetadataFallback := true
 	if auth.Attributes != nil {
 		if attrVal, hasAttr := auth.Attributes["enable_1m_context"]; hasAttr {
-			enabled, _ = strconv.ParseBool(strings.TrimSpace(attrVal))
-		} else if auth.Metadata != nil {
-			switch v := auth.Metadata["enable_1m_context"].(type) {
-			case bool:
-				enabled = v
-			case string:
-				enabled, _ = strconv.ParseBool(strings.TrimSpace(v))
+			if parsed, err := strconv.ParseBool(strings.TrimSpace(attrVal)); err == nil {
+				enabled = parsed
+				useMetadataFallback = false
 			}
 		}
-	} else if auth.Metadata != nil {
+	}
+	if useMetadataFallback && auth.Metadata != nil {
 		switch v := auth.Metadata["enable_1m_context"].(type) {
 		case bool:
 			enabled = v

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -213,7 +213,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if err != nil {
 		return resp, err
 	}
-	applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg)
+	applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg, baseModel)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -394,7 +394,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if err != nil {
 		return nil, err
 	}
-	applyClaudeHeaders(httpReq, auth, apiKey, true, extraBetas, e.cfg)
+	applyClaudeHeaders(httpReq, auth, apiKey, true, extraBetas, e.cfg, baseModel)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -571,7 +571,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
-	applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg)
+	applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg, baseModel)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -867,7 +867,37 @@ func decodeResponseBody(body io.ReadCloser, contentEncoding string) (io.ReadClos
 	return body, nil
 }
 
-func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string, stream bool, extraBetas []string, cfg *config.Config) {
+// mapStainlessOS maps runtime.GOOS to Stainless SDK OS names.
+func mapStainlessOS() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "MacOS"
+	case "windows":
+		return "Windows"
+	case "linux":
+		return "Linux"
+	case "freebsd":
+		return "FreeBSD"
+	default:
+		return "Other::" + runtime.GOOS
+	}
+}
+
+// mapStainlessArch maps runtime.GOARCH to Stainless SDK architecture names.
+func mapStainlessArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	case "386":
+		return "x86"
+	default:
+		return "other::" + runtime.GOARCH
+	}
+}
+
+func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string, stream bool, extraBetas []string, cfg *config.Config, model string) {
 	hdrDefault := func(cfgVal, fallback string) string {
 		if cfgVal != "" {
 			return cfgVal
@@ -911,15 +941,20 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 		baseBetas += ",interleaved-thinking-2025-05-14"
 	}
 
+	// Determine whether to include the 1M context beta.
+	// Three ways to enable:
+	//   1. Client sends X-CPA-CLAUDE-1M header (explicit override)
+	//   2. Config claude-1m-context.enabled + per-account enable_1m_context attribute + model whitelist
 	hasClaude1MHeader := false
 	if ginHeaders != nil {
 		if _, ok := ginHeaders[textproto.CanonicalMIMEHeaderKey("X-CPA-CLAUDE-1M")]; ok {
 			hasClaude1MHeader = true
 		}
 	}
+	want1M := hasClaude1MHeader || should1MContext(auth, cfg, model)
 
 	// Merge extra betas from request body and request flags.
-	if len(extraBetas) > 0 || hasClaude1MHeader {
+	if len(extraBetas) > 0 || want1M {
 		existingSet := make(map[string]bool)
 		for _, b := range strings.Split(baseBetas, ",") {
 			betaName := strings.TrimSpace(b)
@@ -934,7 +969,7 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 				existingSet[beta] = true
 			}
 		}
-		if hasClaude1MHeader && !existingSet["context-1m-2025-08-07"] {
+		if want1M && !existingSet["context-1m-2025-08-07"] {
 			baseBetas += ",context-1m-2025-08-07"
 		}
 	}
@@ -987,6 +1022,31 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	if stream {
 		r.Header.Set("Accept-Encoding", "identity")
 	}
+}
+
+// should1MContext checks whether the 1M context beta should be enabled for this
+// auth + model combination based on config and per-account settings.
+func should1MContext(auth *cliproxyauth.Auth, cfg *config.Config, model string) bool {
+	if cfg == nil || !cfg.Claude1MContext.Enabled {
+		return false
+	}
+	if auth == nil || auth.Attributes == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Attributes["enable_1m_context"]), "true") {
+		return false
+	}
+	// If models whitelist is empty, allow all models.
+	if len(cfg.Claude1MContext.Models) == 0 {
+		return true
+	}
+	// Check if the request model is in the whitelist.
+	for _, m := range cfg.Claude1MContext.Models {
+		if strings.EqualFold(strings.TrimSpace(m), model) {
+			return true
+		}
+	}
+	return false
 }
 
 func claudeCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -99,7 +99,7 @@ func TestApplyClaudeHeaders_UsesConfiguredBaselineFingerprint(t *testing.T) {
 	}
 
 	req := newClaudeHeaderTestRequest(t, incoming)
-	applyClaudeHeaders(req, auth, "key-baseline", false, nil, cfg)
+	applyClaudeHeaders(req, auth, "key-baseline", false, nil, cfg, "claude-opus-4-6")
 
 	assertClaudeFingerprint(t, req.Header, "evil-client/9.9", "9.9.9", "v24.5.0", "Linux", "x64")
 	if got := req.Header.Get("X-Stainless-Timeout"); got != "900" {
@@ -135,7 +135,7 @@ func TestApplyClaudeHeaders_TracksHighestClaudeCLIFingerprint(t *testing.T) {
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(firstReq, auth, "key-upgrade", false, nil, cfg)
+	applyClaudeHeaders(firstReq, auth, "key-upgrade", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, firstReq.Header, "claude-cli/2.1.62 (external, cli)", "0.74.0", "v24.3.0", "MacOS", "arm64")
 
 	thirdPartyReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -145,7 +145,7 @@ func TestApplyClaudeHeaders_TracksHighestClaudeCLIFingerprint(t *testing.T) {
 		"X-Stainless-Os":              []string{"Windows"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(thirdPartyReq, auth, "key-upgrade", false, nil, cfg)
+	applyClaudeHeaders(thirdPartyReq, auth, "key-upgrade", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.62 (external, cli)", "0.74.0", "v24.3.0", "MacOS", "arm64")
 
 	higherReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -155,7 +155,7 @@ func TestApplyClaudeHeaders_TracksHighestClaudeCLIFingerprint(t *testing.T) {
 		"X-Stainless-Os":              []string{"MacOS"},
 		"X-Stainless-Arch":            []string{"arm64"},
 	})
-	applyClaudeHeaders(higherReq, auth, "key-upgrade", false, nil, cfg)
+	applyClaudeHeaders(higherReq, auth, "key-upgrade", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, higherReq.Header, "claude-cli/2.1.63 (external, cli)", "0.75.0", "v24.4.0", "MacOS", "arm64")
 
 	lowerReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -165,7 +165,7 @@ func TestApplyClaudeHeaders_TracksHighestClaudeCLIFingerprint(t *testing.T) {
 		"X-Stainless-Os":              []string{"Windows"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(lowerReq, auth, "key-upgrade", false, nil, cfg)
+	applyClaudeHeaders(lowerReq, auth, "key-upgrade", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, lowerReq.Header, "claude-cli/2.1.63 (external, cli)", "0.75.0", "v24.4.0", "MacOS", "arm64")
 }
 
@@ -197,7 +197,7 @@ func TestApplyClaudeHeaders_DoesNotDowngradeConfiguredBaselineOnFirstClaudeClien
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(olderClaudeReq, auth, "key-baseline-floor", false, nil, cfg)
+	applyClaudeHeaders(olderClaudeReq, auth, "key-baseline-floor", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, olderClaudeReq.Header, "claude-cli/2.1.70 (external, cli)", "0.80.0", "v24.5.0", "MacOS", "arm64")
 
 	newerClaudeReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -207,7 +207,7 @@ func TestApplyClaudeHeaders_DoesNotDowngradeConfiguredBaselineOnFirstClaudeClien
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(newerClaudeReq, auth, "key-baseline-floor", false, nil, cfg)
+	applyClaudeHeaders(newerClaudeReq, auth, "key-baseline-floor", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, newerClaudeReq.Header, "claude-cli/2.1.71 (external, cli)", "0.81.0", "v24.6.0", "MacOS", "arm64")
 }
 
@@ -249,7 +249,7 @@ func TestApplyClaudeHeaders_UpgradesCachedSoftwareFingerprintWhenBaselineAdvance
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(officialReq, auth, "key-baseline-reload", false, nil, oldCfg)
+	applyClaudeHeaders(officialReq, auth, "key-baseline-reload", false, nil, oldCfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, officialReq.Header, "claude-cli/2.1.71 (external, cli)", "0.81.0", "v24.6.0", "MacOS", "arm64")
 
 	thirdPartyReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -259,7 +259,7 @@ func TestApplyClaudeHeaders_UpgradesCachedSoftwareFingerprintWhenBaselineAdvance
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(thirdPartyReq, auth, "key-baseline-reload", false, nil, newCfg)
+	applyClaudeHeaders(thirdPartyReq, auth, "key-baseline-reload", false, nil, newCfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.77 (external, cli)", "0.87.0", "v24.8.0", "MacOS", "arm64")
 }
 
@@ -291,7 +291,7 @@ func TestApplyClaudeHeaders_LearnsOfficialFingerprintAfterCustomBaselineFallback
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(thirdPartyReq, auth, "key-custom-baseline-learning", false, nil, cfg)
+	applyClaudeHeaders(thirdPartyReq, auth, "key-custom-baseline-learning", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, thirdPartyReq.Header, "my-gateway/1.0", "custom-pkg", "custom-runtime", "MacOS", "arm64")
 
 	officialReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -301,7 +301,7 @@ func TestApplyClaudeHeaders_LearnsOfficialFingerprintAfterCustomBaselineFallback
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(officialReq, auth, "key-custom-baseline-learning", false, nil, cfg)
+	applyClaudeHeaders(officialReq, auth, "key-custom-baseline-learning", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, officialReq.Header, "claude-cli/2.1.77 (external, cli)", "0.87.0", "v24.8.0", "MacOS", "arm64")
 
 	postLearningThirdPartyReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -311,7 +311,7 @@ func TestApplyClaudeHeaders_LearnsOfficialFingerprintAfterCustomBaselineFallback
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(postLearningThirdPartyReq, auth, "key-custom-baseline-learning", false, nil, cfg)
+	applyClaudeHeaders(postLearningThirdPartyReq, auth, "key-custom-baseline-learning", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, postLearningThirdPartyReq.Header, "claude-cli/2.1.77 (external, cli)", "0.87.0", "v24.8.0", "MacOS", "arm64")
 }
 
@@ -443,7 +443,7 @@ func TestApplyClaudeHeaders_ThirdPartyBaselineThenOfficialUpgradeKeepsPinnedPlat
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(thirdPartyReq, auth, "key-third-party-then-official", false, nil, cfg)
+	applyClaudeHeaders(thirdPartyReq, auth, "key-third-party-then-official", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.70 (external, cli)", "0.80.0", "v24.5.0", "MacOS", "arm64")
 
 	officialReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -453,7 +453,7 @@ func TestApplyClaudeHeaders_ThirdPartyBaselineThenOfficialUpgradeKeepsPinnedPlat
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(officialReq, auth, "key-third-party-then-official", false, nil, cfg)
+	applyClaudeHeaders(officialReq, auth, "key-third-party-then-official", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, officialReq.Header, "claude-cli/2.1.77 (external, cli)", "0.87.0", "v24.8.0", "MacOS", "arm64")
 }
 
@@ -485,7 +485,7 @@ func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(firstReq, auth, "key-disable-stability", false, nil, cfg)
+	applyClaudeHeaders(firstReq, auth, "key-disable-stability", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, firstReq.Header, "claude-cli/2.1.62 (external, cli)", "0.74.0", "v24.3.0", "Linux", "x64")
 
 	thirdPartyReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -495,7 +495,7 @@ func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
 		"X-Stainless-Os":              []string{"Windows"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(thirdPartyReq, auth, "key-disable-stability", false, nil, cfg)
+	applyClaudeHeaders(thirdPartyReq, auth, "key-disable-stability", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.60 (external, cli)", "0.10.0", "v18.0.0", "Windows", "x64")
 
 	lowerReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -505,7 +505,7 @@ func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
 		"X-Stainless-Os":              []string{"Windows"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(lowerReq, auth, "key-disable-stability", false, nil, cfg)
+	applyClaudeHeaders(lowerReq, auth, "key-disable-stability", false, nil, cfg, "claude-opus-4-6")
 	assertClaudeFingerprint(t, lowerReq.Header, "claude-cli/2.1.61 (external, cli)", "0.73.0", "v24.2.0", "Windows", "x64")
 }
 
@@ -536,7 +536,7 @@ func TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForCla
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(req, auth, "key-legacy-ua-override", false, nil, cfg)
+	applyClaudeHeaders(req, auth, "key-legacy-ua-override", false, nil, cfg, "claude-opus-4-6")
 
 	assertClaudeFingerprint(t, req.Header, "config-ua/1.0", "0.74.0", "v24.3.0", "Linux", "x64")
 }
@@ -565,7 +565,7 @@ func TestApplyClaudeHeaders_LegacyModeFallsBackToRuntimeOSArchWhenMissing(t *tes
 	req := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent": []string{"curl/8.7.1"},
 	})
-	applyClaudeHeaders(req, auth, "key-legacy-runtime-os-arch", false, nil, cfg)
+	applyClaudeHeaders(req, auth, "key-legacy-runtime-os-arch", false, nil, cfg, "claude-opus-4-6")
 
 	assertClaudeFingerprint(t, req.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", helps.MapStainlessOS(), helps.MapStainlessArch())
 }
@@ -592,7 +592,7 @@ func TestApplyClaudeHeaders_UnsetStabilizationAlsoUsesLegacyRuntimeOSArchFallbac
 	req := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent": []string{"curl/8.7.1"},
 	})
-	applyClaudeHeaders(req, auth, "key-unset-runtime-os-arch", false, nil, cfg)
+	applyClaudeHeaders(req, auth, "key-unset-runtime-os-arch", false, nil, cfg, "claude-opus-4-6")
 
 	assertClaudeFingerprint(t, req.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", helps.MapStainlessOS(), helps.MapStainlessArch())
 }

--- a/internal/runtime/executor/should_1m_context_test.go
+++ b/internal/runtime/executor/should_1m_context_test.go
@@ -1,0 +1,180 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestShould1MContext_GlobalEnabledAccountEnabledWhitelistedModel(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+			Models:  []string{"claude-opus-4-6", "claude-sonnet-4-6"},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"enable_1m_context": "true"},
+	}
+	if !should1MContext(auth, cfg, "claude-opus-4-6") {
+		t.Fatal("expected true for enabled config + enabled account + whitelisted model")
+	}
+}
+
+func TestShould1MContext_AccountDisabled(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+			Models:  []string{"claude-opus-4-6"},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+	}
+	if should1MContext(auth, cfg, "claude-opus-4-6") {
+		t.Fatal("expected false when account does not have enable_1m_context")
+	}
+}
+
+func TestShould1MContext_GlobalDisabled(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: false,
+			Models:  []string{"claude-opus-4-6"},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"enable_1m_context": "true"},
+	}
+	if should1MContext(auth, cfg, "claude-opus-4-6") {
+		t.Fatal("expected false when global config is disabled")
+	}
+}
+
+func TestShould1MContext_NonWhitelistedModel(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+			Models:  []string{"claude-opus-4-6"},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"enable_1m_context": "true"},
+	}
+	if should1MContext(auth, cfg, "claude-sonnet-4-5-20250929") {
+		t.Fatal("expected false for model not in whitelist")
+	}
+}
+
+func TestShould1MContext_EmptyWhitelistAllowsAll(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+			Models:  nil,
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"enable_1m_context": "true"},
+	}
+	if !should1MContext(auth, cfg, "any-model-name") {
+		t.Fatal("expected true when models whitelist is empty (allow all)")
+	}
+}
+
+func TestShould1MContext_MetadataFallback_Bool(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+		},
+	}
+	// UploadAuthFile path: Attributes is empty, Metadata has the value
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"enable_1m_context": true},
+	}
+	if !should1MContext(auth, cfg, "claude-opus-4-6") {
+		t.Fatal("expected true when enable_1m_context is in Metadata as bool")
+	}
+}
+
+func TestShould1MContext_MetadataFallback_String(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"enable_1m_context": "true"},
+	}
+	if !should1MContext(auth, cfg, "claude-opus-4-6") {
+		t.Fatal("expected true when enable_1m_context is in Metadata as string")
+	}
+}
+
+func TestShould1MContext_MetadataFalse(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"enable_1m_context": false},
+	}
+	if should1MContext(auth, cfg, "claude-opus-4-6") {
+		t.Fatal("expected false when Metadata enable_1m_context is false")
+	}
+}
+
+func TestShould1MContext_NilAuth(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+		},
+	}
+	if should1MContext(nil, cfg, "claude-opus-4-6") {
+		t.Fatal("expected false for nil auth")
+	}
+}
+
+func TestShould1MContext_NilConfig(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"enable_1m_context": "true"},
+	}
+	if should1MContext(auth, nil, "claude-opus-4-6") {
+		t.Fatal("expected false for nil config")
+	}
+}
+
+func TestShould1MContext_AttributesTakesPrecedenceOverMetadata(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+		},
+	}
+	// Attributes says true, Metadata says false — Attributes wins
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"enable_1m_context": "true"},
+		Metadata:   map[string]any{"enable_1m_context": false},
+	}
+	if !should1MContext(auth, cfg, "claude-opus-4-6") {
+		t.Fatal("expected true: Attributes should take precedence over Metadata")
+	}
+}
+
+func TestShould1MContext_CaseInsensitiveModel(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+			Models:  []string{"Claude-Opus-4-6"},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"enable_1m_context": "true"},
+	}
+	if !should1MContext(auth, cfg, "claude-opus-4-6") {
+		t.Fatal("expected true: model whitelist matching should be case-insensitive")
+	}
+}

--- a/internal/runtime/executor/should_1m_context_test.go
+++ b/internal/runtime/executor/should_1m_context_test.go
@@ -178,3 +178,38 @@ func TestShould1MContext_CaseInsensitiveModel(t *testing.T) {
 		t.Fatal("expected true: model whitelist matching should be case-insensitive")
 	}
 }
+
+func TestShould1MContext_AttributeFalseOverridesMetadataTrue(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+		},
+	}
+	// Attributes explicitly says false; Metadata says true.
+	// The account-level explicit off must win — Metadata is only a fallback.
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"enable_1m_context": "false"},
+		Metadata:   map[string]any{"enable_1m_context": true},
+	}
+	if should1MContext(auth, cfg, "claude-opus-4-6") {
+		t.Fatal("expected false: explicit Attribute=false must override Metadata=true")
+	}
+}
+
+func TestShould1MContext_AttributeParseFailureFallsBackToMetadata(t *testing.T) {
+	cfg := &config.Config{
+		Claude1MContext: config.Claude1MContext{
+			Enabled: true,
+		},
+	}
+	// Attribute value is unparseable as bool ("yes" is not accepted by
+	// strconv.ParseBool); the broken attribute should be treated as absent
+	// so the Metadata value remains authoritative.
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"enable_1m_context": "yes"},
+		Metadata:   map[string]any{"enable_1m_context": true},
+	}
+	if !should1MContext(auth, cfg, "claude-opus-4-6") {
+		t.Fatal("expected true: unparseable Attribute should fall back to Metadata")
+	}
+}

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -158,6 +158,19 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 		}
 	}
 	coreauth.ApplyCustomHeadersFromMetadata(a)
+	// Read enable_1m_context from auth file (Claude 1M context beta toggle).
+	if raw1M, ok := metadata["enable_1m_context"]; ok {
+		switch v := raw1M.(type) {
+		case bool:
+			if v {
+				a.Attributes["enable_1m_context"] = "true"
+			}
+		case string:
+			if strings.EqualFold(strings.TrimSpace(v), "true") {
+				a.Attributes["enable_1m_context"] = "true"
+			}
+		}
+	}
 	ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, "oauth")
 	// For codex auth files, extract plan_type from the JWT id_token.
 	if provider == "codex" {

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -160,15 +160,15 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 	coreauth.ApplyCustomHeadersFromMetadata(a)
 	// Read enable_1m_context from auth file (Claude 1M context beta toggle).
 	if raw1M, ok := metadata["enable_1m_context"]; ok {
+		var isTrue bool
 		switch v := raw1M.(type) {
 		case bool:
-			if v {
-				a.Attributes["enable_1m_context"] = "true"
-			}
+			isTrue = v
 		case string:
-			if strings.EqualFold(strings.TrimSpace(v), "true") {
-				a.Attributes["enable_1m_context"] = "true"
-			}
+			isTrue, _ = strconv.ParseBool(strings.TrimSpace(v))
+		}
+		if isTrue {
+			a.Attributes["enable_1m_context"] = "true"
 		}
 	}
 	ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, "oauth")


### PR DESCRIPTION
## 概述 / Summary

新增 Claude 1M context beta（`context-1m-2025-08-07`）的可控開關，支援全局設定 + 每帳號獨立切換，讓使用者可以精確控制哪些帳號和哪些模型啟用 1M context。

Adds configurable control for Claude's 1M context beta (`context-1m-2025-08-07`) with a two-layer mechanism: global config toggle with model whitelist + per-account opt-in. This gives operators precise control over which accounts and models use 1M context, avoiding errors on models that don't support the feature.

## 改動詳情 / Changes

### 1. `internal/config/config.go` — 新增設定結構 / New config struct
- 新增 `Claude1MContext` struct（`Enabled bool` + `Models []string`）
- 加入 Config 的 `claude-1m-context` YAML 欄位
- Adds `Claude1MContext` struct with global toggle and model whitelist

### 2. `internal/runtime/executor/claude_executor.go` — 核心邏輯 / Core logic
- `applyClaudeHeaders` 新增 `model` 參數，3 個呼叫點同步更新
- 新增 `should1MContext()` 判斷函數：config enabled + auth attribute + model whitelist
- 滿足條件時自動在 `Anthropic-Beta` header 中加入 `context-1m-2025-08-07`
- `X-CPA-CLAUDE-1M` header 覆蓋機制保留（向後相容）

### 3. `internal/watcher/synthesizer/file.go` — 合成階段 / Synthesis
- 從 auth JSON 的 `enable_1m_context` 欄位讀取（支援 bool/string 格式）
- 寫入 `auth.Attributes["enable_1m_context"]`，模式與 `priority`/`note` 一致

### 4. `internal/api/handlers/management/auth_files.go` — 管理 API / Management API
- `buildAuthFileEntry` 回傳 `enable_1m_context` 欄位（Attributes 優先，Metadata 回退）
- `PatchAuthFileFields` 新增 `Enable1MContext *bool` 請求欄位

### 5. `config.example.yaml` / `.gitignore`
- 新增 `claude-1m-context` 設定範例
- `.gitignore` 加入 `server` 和 `coverage.out`

## 改動文件 / Changed files

| 文件 / File | 改動 / Change |
|---|---|
| `internal/config/config.go` | 新增 `Claude1MContext` struct 和 Config 欄位 |
| `internal/runtime/executor/claude_executor.go` | 新增 1M context 條件判斷邏輯 |
| `internal/watcher/synthesizer/file.go` | 合成階段讀取 `enable_1m_context` 到 Attributes |
| `internal/api/handlers/management/auth_files.go` | 列表回傳 + PATCH 寫入 `enable_1m_context` |
| `config.example.yaml` | 新增設定範例 |
| `.gitignore` | 加入建置產物 |

## 使用方式 / Usage

**config.yaml：**
```yaml
claude-1m-context:
  enabled: true
  models:
    - claude-opus-4-6
    - claude-sonnet-4-6
```

**Auth JSON 檔案：**
```json
{ "type": "claude", "enable_1m_context": true }
```

**Management API：**
```bash
# 啟用
curl -X PATCH /v0/management/auth-files/fields \
  -d '{"name": "claude-xxx@gmail.com.json", "enable_1m_context": true}'

# 停用
curl -X PATCH /v0/management/auth-files/fields \
  -d '{"name": "claude-xxx@gmail.com.json", "enable_1m_context": false}'
```

**啟用條件（AND）：**
1. `claude-1m-context.enabled = true`（全局開關）
2. auth file `enable_1m_context = true`（帳號開關）
3. 模型在 `claude-1m-context.models` 白名單中（空 = 全部允許）

或：客戶端發送 `X-CPA-CLAUDE-1M` header（直接覆蓋，向後相容）

## 測試計劃 / Test plan

- [x] `go build ./cmd/server/` 編譯通過
- [x] `go test ./internal/runtime/executor/...` 通過
- [x] `go test ./internal/watcher/...` 通過
- [x] `go test ./internal/api/handlers/management/...` 通過
- [x] `go test ./internal/config/...` 通過
- [x] `go test ./sdk/...` 通過
- [x] `go test ./test/...` 整合測試通過
- [x] 設定 `claude-1m-context.enabled: true` + auth JSON `enable_1m_context: true`，白名單模型請求帶 1M beta header
- [x] 未設定的帳號/模型不帶 1M beta header
- [x] `X-CPA-CLAUDE-1M` header 覆蓋機制正常運作
- [x] 管理面板 PATCH API 可正確讀寫 `enable_1m_context`

## 前端配套（待做）/ Frontend follow-up

管理面板 UI（[Cli-Proxy-API-Management-Center](https://github.com/router-for-me/Cli-Proxy-API-Management-Center)）需要在 Claude 卡片操作列新增 1M toggle，調用本 PR 新增的 API。