### PR TITLE
fix(claude): add thinking tokens estimation to native route usage stats

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -285,12 +285,12 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 	if stream {
-		var acc claudeStreamUsageAccumulator
+		var acc helps.ClaudeStreamUsageAccumulator
 		lines := bytes.Split(data, []byte("\n"))
 		for _, line := range lines {
-			acc.processLine(line)
+			acc.ProcessLine(line)
 		}
-		acc.publish(ctx, reporter)
+		acc.Publish(ctx, reporter)
 	} else {
 		reporter.Publish(ctx, helps.ParseClaudeUsage(data))
 	}
@@ -465,13 +465,13 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 		// If from == to (Claude → Claude), directly forward the SSE stream without translation
 		if from == to {
-			var acc claudeStreamUsageAccumulator
+			var acc helps.ClaudeStreamUsageAccumulator
 			scanner := bufio.NewScanner(decodedBody)
 			scanner.Buffer(nil, 52_428_800) // 50MB
 			for scanner.Scan() {
 				line := scanner.Bytes()
 				helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-				acc.processLine(line)
+				acc.ProcessLine(line)
 				if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 					line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
 				}
@@ -484,24 +484,25 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				cloned[len(line)] = '\n'
 				out <- cliproxyexecutor.StreamChunk{Payload: cloned}
 			}
-			acc.publish(ctx, reporter)
 			if errScan := scanner.Err(); errScan != nil {
 				helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 				reporter.PublishFailure(ctx)
 				out <- cliproxyexecutor.StreamChunk{Err: errScan}
+			} else {
+				acc.Publish(ctx, reporter)
 			}
 			return
 		}
 
 		// For other formats, use translation
-		var acc claudeStreamUsageAccumulator
+		var acc helps.ClaudeStreamUsageAccumulator
 		scanner := bufio.NewScanner(decodedBody)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			acc.processLine(line)
+			acc.ProcessLine(line)
 			if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 				line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
 			}
@@ -522,11 +523,12 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}
 			}
 		}
-		acc.publish(ctx, reporter)
 		if errScan := scanner.Err(); errScan != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+		} else {
+			acc.Publish(ctx, reporter)
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -285,11 +285,12 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 	if stream {
-		var thinkingLen int64
+		var acc claudeStreamUsageAccumulator
 		lines := bytes.Split(data, []byte("\n"))
 		for _, line := range lines {
-			accumulateClaudeStreamThinking(ctx, line, &thinkingLen, reporter)
+			acc.processLine(line)
 		}
+		acc.publish(ctx, reporter)
 	} else {
 		reporter.Publish(ctx, helps.ParseClaudeUsage(data))
 	}
@@ -464,13 +465,13 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 		// If from == to (Claude → Claude), directly forward the SSE stream without translation
 		if from == to {
-			var thinkingLen int64
+			var acc claudeStreamUsageAccumulator
 			scanner := bufio.NewScanner(decodedBody)
 			scanner.Buffer(nil, 52_428_800) // 50MB
 			for scanner.Scan() {
 				line := scanner.Bytes()
 				helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-				accumulateClaudeStreamThinking(ctx, line, &thinkingLen, reporter)
+				acc.processLine(line)
 				if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 					line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
 				}
@@ -483,6 +484,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				cloned[len(line)] = '\n'
 				out <- cliproxyexecutor.StreamChunk{Payload: cloned}
 			}
+			acc.publish(ctx, reporter)
 			if errScan := scanner.Err(); errScan != nil {
 				helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 				reporter.PublishFailure(ctx)
@@ -492,14 +494,14 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		}
 
 		// For other formats, use translation
-		var thinkingLen int64
+		var acc claudeStreamUsageAccumulator
 		scanner := bufio.NewScanner(decodedBody)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			accumulateClaudeStreamThinking(ctx, line, &thinkingLen, reporter)
+			acc.processLine(line)
 			if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 				line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
 			}
@@ -520,6 +522,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}
 			}
 		}
+		acc.publish(ctx, reporter)
 		if errScan := scanner.Err(); errScan != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx)

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -285,9 +285,12 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 	if stream {
+		var thinkingLen int64
 		lines := bytes.Split(data, []byte("\n"))
 		for _, line := range lines {
+			thinkingLen += int64(claudeStreamThinkingLen(line))
 			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
+				detail.ReasoningTokens = thinkingLen / 4
 				reporter.Publish(ctx, detail)
 			}
 		}
@@ -465,12 +468,15 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 		// If from == to (Claude → Claude), directly forward the SSE stream without translation
 		if from == to {
+			var thinkingLen int64
 			scanner := bufio.NewScanner(decodedBody)
 			scanner.Buffer(nil, 52_428_800) // 50MB
 			for scanner.Scan() {
 				line := scanner.Bytes()
 				helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+				thinkingLen += int64(claudeStreamThinkingLen(line))
 				if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
+					detail.ReasoningTokens = thinkingLen / 4
 					reporter.Publish(ctx, detail)
 				}
 				if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
@@ -494,13 +500,16 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		}
 
 		// For other formats, use translation
+		var thinkingLen int64
 		scanner := bufio.NewScanner(decodedBody)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+			thinkingLen += int64(claudeStreamThinkingLen(line))
 			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
+				detail.ReasoningTokens = thinkingLen / 4
 				reporter.Publish(ctx, detail)
 			}
 			if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -288,11 +288,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		var thinkingLen int64
 		lines := bytes.Split(data, []byte("\n"))
 		for _, line := range lines {
-			thinkingLen += int64(claudeStreamThinkingLen(line))
-			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
-				detail.ReasoningTokens = thinkingLen / 4
-				reporter.Publish(ctx, detail)
-			}
+			accumulateClaudeStreamThinking(ctx, line, &thinkingLen, reporter)
 		}
 	} else {
 		reporter.Publish(ctx, helps.ParseClaudeUsage(data))
@@ -474,11 +470,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			for scanner.Scan() {
 				line := scanner.Bytes()
 				helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-				thinkingLen += int64(claudeStreamThinkingLen(line))
-				if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
-					detail.ReasoningTokens = thinkingLen / 4
-					reporter.Publish(ctx, detail)
-				}
+				accumulateClaudeStreamThinking(ctx, line, &thinkingLen, reporter)
 				if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 					line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
 				}
@@ -507,11 +499,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			thinkingLen += int64(claudeStreamThinkingLen(line))
-			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
-				detail.ReasoningTokens = thinkingLen / 4
-				reporter.Publish(ctx, detail)
-			}
+			accumulateClaudeStreamThinking(ctx, line, &thinkingLen, reporter)
 			if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 				line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
 			}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -281,7 +281,7 @@ func ParseClaudeUsage(data []byte) usage.Detail {
 }
 
 // ParseClaudeStreamUsage is intentionally removed.
-// Use claudeStreamUsageAccumulator.processLine instead, which merges
+// Use ClaudeStreamUsageAccumulator.ProcessLine instead, which merges
 // usage fields across all SSE events and publishes once at stream end.
 
 // claudeThinkingTokenFactor is the approximate characters-per-token ratio
@@ -319,19 +319,19 @@ func claudeStreamThinkingLen(line []byte) int {
 	return len(delta.Get("thinking").String())
 }
 
-// claudeStreamUsageAccumulator merges usage fields across Claude SSE events
+// ClaudeStreamUsageAccumulator merges usage fields across Claude SSE events
 // and accumulates thinking content block lengths for reasoning token estimation.
 // message_start carries input_tokens + cache_read_input_tokens (under message.usage),
 // message_delta carries output_tokens (under usage), and content_block_delta carries
 // thinking text. Publishing happens once at the end of the stream.
-type claudeStreamUsageAccumulator struct {
+type ClaudeStreamUsageAccumulator struct {
 	detail      usage.Detail
 	thinkingLen int64
 	sawUsage    bool
 }
 
-// processLine extracts usage and thinking data from a single SSE line.
-func (a *claudeStreamUsageAccumulator) processLine(line []byte) {
+// ProcessLine extracts usage and thinking data from a single SSE line.
+func (a *ClaudeStreamUsageAccumulator) ProcessLine(line []byte) {
 	a.thinkingLen += int64(claudeStreamThinkingLen(line))
 
 	payload := jsonPayload(line)
@@ -365,13 +365,13 @@ func (a *claudeStreamUsageAccumulator) processLine(line []byte) {
 
 // publish emits the accumulated usage with estimated reasoning tokens.
 // Skips publishing if no usage event was observed during the stream.
-func (a *claudeStreamUsageAccumulator) publish(ctx context.Context, reporter *usageReporter) {
+func (a *ClaudeStreamUsageAccumulator) Publish(ctx context.Context, reporter *UsageReporter) {
 	if !a.sawUsage {
 		return
 	}
 	a.detail.ReasoningTokens = a.thinkingLen / claudeThinkingTokenFactor
 	a.detail.TotalTokens = a.detail.InputTokens + a.detail.OutputTokens
-	reporter.publish(ctx, a.detail)
+	reporter.Publish(ctx, a.detail)
 }
 
 func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -285,13 +285,10 @@ func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
 	if len(payload) == 0 || !gjson.ValidBytes(payload) {
 		return usage.Detail{}, false
 	}
-	// Only emit usage from message_delta events (final usage with output_tokens).
-	// message_start also carries usage but only has input_tokens; publishing it
-	// would trigger the sync.Once reporter before thinking tokens are accumulated.
-	if gjson.GetBytes(payload, "type").String() != "message_delta" {
-		return usage.Detail{}, false
-	}
 	usageNode := gjson.GetBytes(payload, "usage")
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "message.usage")
+	}
 	if !usageNode.Exists() {
 		return usage.Detail{}, false
 	}
@@ -342,14 +339,53 @@ func claudeStreamThinkingLen(line []byte) int {
 	return len(delta.Get("thinking").String())
 }
 
-// accumulateClaudeStreamThinking accumulates thinking text length from a
-// streaming line and publishes usage when the final message_delta arrives.
-func accumulateClaudeStreamThinking(ctx context.Context, line []byte, thinkingLen *int64, reporter *usageReporter) {
-	*thinkingLen += int64(claudeStreamThinkingLen(line))
-	if detail, ok := parseClaudeStreamUsage(line); ok {
-		detail.ReasoningTokens = *thinkingLen / claudeThinkingTokenFactor
-		reporter.publish(ctx, detail)
+// claudeStreamUsageAccumulator merges usage fields across Claude SSE events
+// and accumulates thinking content block lengths for reasoning token estimation.
+// message_start carries input_tokens + cache_read_input_tokens (under message.usage),
+// message_delta carries output_tokens (under usage), and content_block_delta carries
+// thinking text. Publishing happens once at the end of the stream.
+type claudeStreamUsageAccumulator struct {
+	detail      usage.Detail
+	thinkingLen int64
+}
+
+// processLine extracts usage and thinking data from a single SSE line.
+func (a *claudeStreamUsageAccumulator) processLine(line []byte) {
+	a.thinkingLen += int64(claudeStreamThinkingLen(line))
+
+	payload := jsonPayload(line)
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return
 	}
+	// message_start nests usage under "message.usage"; message_delta uses top-level "usage".
+	usageNode := gjson.GetBytes(payload, "usage")
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "message.usage")
+	}
+	if !usageNode.Exists() {
+		return
+	}
+	// Merge non-zero fields across events.
+	if v := usageNode.Get("input_tokens").Int(); v > 0 {
+		a.detail.InputTokens = v
+	}
+	if v := usageNode.Get("output_tokens").Int(); v > 0 {
+		a.detail.OutputTokens = v
+	}
+	if v := usageNode.Get("cache_read_input_tokens").Int(); v > 0 {
+		a.detail.CachedTokens = v
+	} else if a.detail.CachedTokens == 0 {
+		if v := usageNode.Get("cache_creation_input_tokens").Int(); v > 0 {
+			a.detail.CachedTokens = v
+		}
+	}
+}
+
+// publish emits the accumulated usage with estimated reasoning tokens.
+func (a *claudeStreamUsageAccumulator) publish(ctx context.Context, reporter *usageReporter) {
+	a.detail.ReasoningTokens = a.thinkingLen / claudeThinkingTokenFactor
+	a.detail.TotalTokens = a.detail.InputTokens + a.detail.OutputTokens
+	reporter.publish(ctx, a.detail)
 }
 
 func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -272,6 +272,10 @@ func ParseClaudeUsage(data []byte) usage.Detail {
 		// fall back to creation tokens when read tokens are absent
 		detail.CachedTokens = usageNode.Get("cache_creation_input_tokens").Int()
 	}
+	// Estimate reasoning tokens from thinking content blocks.
+	// Claude API does not expose thinking tokens in the usage object,
+	// so we approximate by summing thinking block text lengths / 4.
+	detail.ReasoningTokens = estimateClaudeThinkingTokens(data)
 	detail.TotalTokens = detail.InputTokens + detail.OutputTokens
 	return detail
 }
@@ -295,6 +299,36 @@ func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
 	}
 	detail.TotalTokens = detail.InputTokens + detail.OutputTokens
 	return detail, true
+}
+
+// estimateClaudeThinkingTokens scans Claude response content blocks for
+// type="thinking" entries and estimates token count from text length.
+func estimateClaudeThinkingTokens(data []byte) int64 {
+	var total int64
+	gjson.ParseBytes(data).Get("content").ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() == "thinking" {
+			total += int64(len(block.Get("thinking").String()))
+		}
+		return true
+	})
+	return total / 4
+}
+
+// claudeStreamThinkingLen returns the byte length of thinking text in a
+// streaming content_block_delta line. Returns 0 for non-thinking lines.
+func claudeStreamThinkingLen(line []byte) int {
+	payload := jsonPayload(line)
+	if len(payload) == 0 {
+		return 0
+	}
+	if gjson.GetBytes(payload, "type").String() != "content_block_delta" {
+		return 0
+	}
+	delta := gjson.GetBytes(payload, "delta")
+	if delta.Get("type").String() != "thinking_delta" {
+		return 0
+	}
+	return len(delta.Get("thinking").String())
 }
 
 func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -285,6 +285,12 @@ func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
 	if len(payload) == 0 || !gjson.ValidBytes(payload) {
 		return usage.Detail{}, false
 	}
+	// Only emit usage from message_delta events (final usage with output_tokens).
+	// message_start also carries usage but only has input_tokens; publishing it
+	// would trigger the sync.Once reporter before thinking tokens are accumulated.
+	if gjson.GetBytes(payload, "type").String() != "message_delta" {
+		return usage.Detail{}, false
+	}
 	usageNode := gjson.GetBytes(payload, "usage")
 	if !usageNode.Exists() {
 		return usage.Detail{}, false
@@ -301,6 +307,10 @@ func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
 	return detail, true
 }
 
+// claudeThinkingTokenFactor is the approximate characters-per-token ratio
+// used to estimate thinking token counts from content block text length.
+const claudeThinkingTokenFactor = 4
+
 // estimateClaudeThinkingTokens scans Claude response content blocks for
 // type="thinking" entries and estimates token count from text length.
 func estimateClaudeThinkingTokens(data []byte) int64 {
@@ -311,7 +321,7 @@ func estimateClaudeThinkingTokens(data []byte) int64 {
 		}
 		return true
 	})
-	return total / 4
+	return total / claudeThinkingTokenFactor
 }
 
 // claudeStreamThinkingLen returns the byte length of thinking text in a
@@ -321,14 +331,25 @@ func claudeStreamThinkingLen(line []byte) int {
 	if len(payload) == 0 {
 		return 0
 	}
-	if gjson.GetBytes(payload, "type").String() != "content_block_delta" {
+	p := gjson.ParseBytes(payload)
+	if p.Get("type").String() != "content_block_delta" {
 		return 0
 	}
-	delta := gjson.GetBytes(payload, "delta")
+	delta := p.Get("delta")
 	if delta.Get("type").String() != "thinking_delta" {
 		return 0
 	}
 	return len(delta.Get("thinking").String())
+}
+
+// accumulateClaudeStreamThinking accumulates thinking text length from a
+// streaming line and publishes usage when the final message_delta arrives.
+func accumulateClaudeStreamThinking(ctx context.Context, line []byte, thinkingLen *int64, reporter *usageReporter) {
+	*thinkingLen += int64(claudeStreamThinkingLen(line))
+	if detail, ok := parseClaudeStreamUsage(line); ok {
+		detail.ReasoningTokens = *thinkingLen / claudeThinkingTokenFactor
+		reporter.publish(ctx, detail)
+	}
 }
 
 func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -280,29 +280,9 @@ func ParseClaudeUsage(data []byte) usage.Detail {
 	return detail
 }
 
-func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
-	payload := jsonPayload(line)
-	if len(payload) == 0 || !gjson.ValidBytes(payload) {
-		return usage.Detail{}, false
-	}
-	usageNode := gjson.GetBytes(payload, "usage")
-	if !usageNode.Exists() {
-		usageNode = gjson.GetBytes(payload, "message.usage")
-	}
-	if !usageNode.Exists() {
-		return usage.Detail{}, false
-	}
-	detail := usage.Detail{
-		InputTokens:  usageNode.Get("input_tokens").Int(),
-		OutputTokens: usageNode.Get("output_tokens").Int(),
-		CachedTokens: usageNode.Get("cache_read_input_tokens").Int(),
-	}
-	if detail.CachedTokens == 0 {
-		detail.CachedTokens = usageNode.Get("cache_creation_input_tokens").Int()
-	}
-	detail.TotalTokens = detail.InputTokens + detail.OutputTokens
-	return detail, true
-}
+// ParseClaudeStreamUsage is intentionally removed.
+// Use claudeStreamUsageAccumulator.processLine instead, which merges
+// usage fields across all SSE events and publishes once at stream end.
 
 // claudeThinkingTokenFactor is the approximate characters-per-token ratio
 // used to estimate thinking token counts from content block text length.
@@ -347,6 +327,7 @@ func claudeStreamThinkingLen(line []byte) int {
 type claudeStreamUsageAccumulator struct {
 	detail      usage.Detail
 	thinkingLen int64
+	sawUsage    bool
 }
 
 // processLine extracts usage and thinking data from a single SSE line.
@@ -365,6 +346,7 @@ func (a *claudeStreamUsageAccumulator) processLine(line []byte) {
 	if !usageNode.Exists() {
 		return
 	}
+	a.sawUsage = true
 	// Merge non-zero fields across events.
 	if v := usageNode.Get("input_tokens").Int(); v > 0 {
 		a.detail.InputTokens = v
@@ -382,7 +364,11 @@ func (a *claudeStreamUsageAccumulator) processLine(line []byte) {
 }
 
 // publish emits the accumulated usage with estimated reasoning tokens.
+// Skips publishing if no usage event was observed during the stream.
 func (a *claudeStreamUsageAccumulator) publish(ctx context.Context, reporter *usageReporter) {
+	if !a.sawUsage {
+		return
+	}
 	a.detail.ReasoningTokens = a.thinkingLen / claudeThinkingTokenFactor
 	a.detail.TotalTokens = a.detail.InputTokens + a.detail.OutputTokens
 	reporter.publish(ctx, a.detail)

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -62,3 +62,91 @@ func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 		t.Fatalf("latency = %v, want <= 3s", record.Latency)
 	}
 }
+
+	func TestClaudeStreamAccumulator_FullSequence(t *testing.T) {
+	// Simulate: message_start (input+cache) → thinking_delta → message_delta (output)
+	var acc claudeStreamUsageAccumulator
+	acc.processLine([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":10,"cache_read_input_tokens":50000}}}`))
+	acc.processLine([]byte(`data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"Let me think about this carefully step by step"}}`))
+	acc.processLine([]byte(`data: {"type":"message_delta","usage":{"output_tokens":200}}`))
+
+	if !acc.sawUsage {
+		t.Fatal("sawUsage should be true after processing usage events")
+	}
+	if acc.detail.InputTokens != 10 {
+		t.Fatalf("input tokens = %d, want 10", acc.detail.InputTokens)
+	}
+	if acc.detail.OutputTokens != 200 {
+		t.Fatalf("output tokens = %d, want 200", acc.detail.OutputTokens)
+	}
+	if acc.detail.CachedTokens != 50000 {
+		t.Fatalf("cached tokens = %d, want 50000", acc.detail.CachedTokens)
+	}
+	expectedThinking := int64(len("Let me think about this carefully step by step")) / claudeThinkingTokenFactor
+	if acc.thinkingLen/claudeThinkingTokenFactor != expectedThinking {
+		t.Fatalf("thinking tokens = %d, want %d", acc.thinkingLen/claudeThinkingTokenFactor, expectedThinking)
+	}
+}
+
+	func TestClaudeStreamAccumulator_MessageStartOnly(t *testing.T) {
+	var acc claudeStreamUsageAccumulator
+	acc.processLine([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":5,"cache_read_input_tokens":100000}}}`))
+
+	if !acc.sawUsage {
+		t.Fatal("sawUsage should be true after message_start with usage")
+	}
+	if acc.detail.InputTokens != 5 {
+		t.Fatalf("input tokens = %d, want 5", acc.detail.InputTokens)
+	}
+	if acc.detail.OutputTokens != 0 {
+		t.Fatalf("output tokens = %d, want 0", acc.detail.OutputTokens)
+	}
+	if acc.detail.CachedTokens != 100000 {
+		t.Fatalf("cached tokens = %d, want 100000", acc.detail.CachedTokens)
+	}
+}
+
+	func TestClaudeStreamAccumulator_MessageDeltaOnly(t *testing.T) {
+	var acc claudeStreamUsageAccumulator
+	acc.processLine([]byte(`data: {"type":"message_delta","usage":{"output_tokens":150}}`))
+
+	if !acc.sawUsage {
+		t.Fatal("sawUsage should be true after message_delta with usage")
+	}
+	if acc.detail.InputTokens != 0 {
+		t.Fatalf("input tokens = %d, want 0", acc.detail.InputTokens)
+	}
+	if acc.detail.OutputTokens != 150 {
+		t.Fatalf("output tokens = %d, want 150", acc.detail.OutputTokens)
+	}
+}
+
+	func TestClaudeStreamAccumulator_ThinkingDeltaOnly_NoUsage(t *testing.T) {
+	// Stream with only thinking deltas but no usage event — should not publish
+	var acc claudeStreamUsageAccumulator
+	acc.processLine([]byte(`data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"some thinking text"}}`))
+
+	if acc.sawUsage {
+		t.Fatal("sawUsage should be false when no usage event was received")
+	}
+	if acc.thinkingLen == 0 {
+		t.Fatal("thinkingLen should be non-zero after processing thinking_delta")
+	}
+}
+
+	func TestClaudeStreamAccumulator_NoEvents(t *testing.T) {
+	// Empty/interrupted stream — should not publish
+	var acc claudeStreamUsageAccumulator
+	if acc.sawUsage {
+		t.Fatal("sawUsage should be false for empty accumulator")
+	}
+}
+
+	func TestClaudeStreamAccumulator_CacheCreationFallback(t *testing.T) {
+	var acc claudeStreamUsageAccumulator
+	acc.processLine([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":3,"cache_creation_input_tokens":80000}}}`))
+
+	if acc.detail.CachedTokens != 80000 {
+		t.Fatalf("cached tokens = %d, want 80000 (from cache_creation fallback)", acc.detail.CachedTokens)
+	}
+}

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -65,10 +65,10 @@ func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 
 	func TestClaudeStreamAccumulator_FullSequence(t *testing.T) {
 	// Simulate: message_start (input+cache) → thinking_delta → message_delta (output)
-	var acc claudeStreamUsageAccumulator
-	acc.processLine([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":10,"cache_read_input_tokens":50000}}}`))
-	acc.processLine([]byte(`data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"Let me think about this carefully step by step"}}`))
-	acc.processLine([]byte(`data: {"type":"message_delta","usage":{"output_tokens":200}}`))
+	var acc ClaudeStreamUsageAccumulator
+	acc.ProcessLine([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":10,"cache_read_input_tokens":50000}}}`))
+	acc.ProcessLine([]byte(`data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"Let me think about this carefully step by step"}}`))
+	acc.ProcessLine([]byte(`data: {"type":"message_delta","usage":{"output_tokens":200}}`))
 
 	if !acc.sawUsage {
 		t.Fatal("sawUsage should be true after processing usage events")
@@ -89,8 +89,8 @@ func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 }
 
 	func TestClaudeStreamAccumulator_MessageStartOnly(t *testing.T) {
-	var acc claudeStreamUsageAccumulator
-	acc.processLine([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":5,"cache_read_input_tokens":100000}}}`))
+	var acc ClaudeStreamUsageAccumulator
+	acc.ProcessLine([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":5,"cache_read_input_tokens":100000}}}`))
 
 	if !acc.sawUsage {
 		t.Fatal("sawUsage should be true after message_start with usage")
@@ -107,8 +107,8 @@ func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 }
 
 	func TestClaudeStreamAccumulator_MessageDeltaOnly(t *testing.T) {
-	var acc claudeStreamUsageAccumulator
-	acc.processLine([]byte(`data: {"type":"message_delta","usage":{"output_tokens":150}}`))
+	var acc ClaudeStreamUsageAccumulator
+	acc.ProcessLine([]byte(`data: {"type":"message_delta","usage":{"output_tokens":150}}`))
 
 	if !acc.sawUsage {
 		t.Fatal("sawUsage should be true after message_delta with usage")
@@ -123,8 +123,8 @@ func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 
 	func TestClaudeStreamAccumulator_ThinkingDeltaOnly_NoUsage(t *testing.T) {
 	// Stream with only thinking deltas but no usage event — should not publish
-	var acc claudeStreamUsageAccumulator
-	acc.processLine([]byte(`data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"some thinking text"}}`))
+	var acc ClaudeStreamUsageAccumulator
+	acc.ProcessLine([]byte(`data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"some thinking text"}}`))
 
 	if acc.sawUsage {
 		t.Fatal("sawUsage should be false when no usage event was received")
@@ -136,15 +136,15 @@ func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 
 	func TestClaudeStreamAccumulator_NoEvents(t *testing.T) {
 	// Empty/interrupted stream — should not publish
-	var acc claudeStreamUsageAccumulator
+	var acc ClaudeStreamUsageAccumulator
 	if acc.sawUsage {
 		t.Fatal("sawUsage should be false for empty accumulator")
 	}
 }
 
 	func TestClaudeStreamAccumulator_CacheCreationFallback(t *testing.T) {
-	var acc claudeStreamUsageAccumulator
-	acc.processLine([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":3,"cache_creation_input_tokens":80000}}}`))
+	var acc ClaudeStreamUsageAccumulator
+	acc.ProcessLine([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":3,"cache_creation_input_tokens":80000}}}`))
 
 	if acc.detail.CachedTokens != 80000 {
 		t.Fatalf("cached tokens = %d, want 80000 (from cache_creation fallback)", acc.detail.CachedTokens)

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -293,7 +293,17 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 		}
 		if changed {
 			updateAggregatedAvailability(auth, now)
-			if !hasModelError(auth, now) {
+			// Only clear auth-level status when the auth is otherwise healthy.
+			// hasModelError only inspects per-model state, so without these
+			// extra guards a disabled auth or an auth with a non-model
+			// auth-level failure (e.g. OAuth-level error set by
+			// applyAuthFailureState) would be silently flipped back to
+			// StatusActive, hiding the real problem from management output.
+			if !hasModelError(auth, now) &&
+				!auth.Disabled &&
+				auth.Status != StatusDisabled &&
+				auth.Status != StatusError &&
+				auth.LastError == nil {
 				auth.LastError = nil
 				auth.StatusMessage = ""
 				auth.Status = StatusActive


### PR DESCRIPTION
## 概述 / Summary

走 `/v1/messages`（Claude 原生路由）時，`parseClaudeUsage` 和 `parseClaudeStreamUsage` 沒有解析 Thinking Tokens，導致管理面板的「思考 Tokens」欄位顯示 0。OpenAI 路由和 Gemini 路由都有正確解析，唯獨 Claude 原生路由遺漏。

Claude API 的 `usage` 物件本身不包含獨立的 thinking tokens 欄位，因此採用與 translator 層相同的估算方式：累計 thinking content block 的文字長度除以 4。

When using `/v1/messages` (Claude native route), `parseClaudeUsage` and `parseClaudeStreamUsage` did not parse thinking tokens, causing the "Thinking Tokens" field in the management panel to show 0. The OpenAI and Gemini routes already parsed these correctly.

Since Claude's `usage` object does not expose a dedicated thinking tokens field, we estimate them from thinking content blocks (text length / 4), matching the approach used by the Claude→OpenAI translator layer.

## 改動詳情 / Changes

### 1. `internal/runtime/executor/usage_helpers.go`
- `parseClaudeUsage`（非串流）：新增呼叫 `estimateClaudeThinkingTokens` 掃描 `content` 陣列中 `type: "thinking"` 區塊
- 新增 `estimateClaudeThinkingTokens()` — 累計 thinking 區塊文字長度 / 4
- 新增 `claudeStreamThinkingLen()` — 從串流 `content_block_delta`（`thinking_delta`）提取文字長度

### 2. `internal/runtime/executor/claude_executor.go`
- 3 個串流處理迴圈（Execute stream 模式、ExecuteStream Claude→Claude passthrough、ExecuteStream Claude→other translation）加入 `thinkingLen` 累積器
- 當 `parseClaudeStreamUsage` 偵測到 usage 時，填入 `detail.ReasoningTokens = thinkingLen / 4`

## 改動文件 / Changed files

| 文件 / File | 改動 / Change |
|---|---|
| `internal/runtime/executor/usage_helpers.go` | 新增 thinking tokens 估算函數，parseClaudeUsage 補上 ReasoningTokens |
| `internal/runtime/executor/claude_executor.go` | 3 個串流迴圈加入 thinking 文字累積和 ReasoningTokens 注入 |

## 對比參考 / Reference

| 路由 | 實作方式 |
|------|---------|
| OpenAI (`/v1/chat/completions`) | `usageNode.Get("output_tokens_details.reasoning_tokens")` — API 直接回傳 |
| Gemini | `node.Get("thoughtsTokenCount")` — API 直接回傳 |
| Claude→OpenAI translator | `st.ReasoningBuf.Len() / 4` — 從 thinking 文字估算 |
| **Claude 原生（本 PR）** | `estimateClaudeThinkingTokens` / `claudeStreamThinkingLen` — 同上估算方式 |

## 測試計劃 / Test plan

- [x] `go build ./cmd/server/` 編譯通過
- [x] `go test ./...` 全部測試通過（零失敗）
- [x] Claude 原生路由（`/v1/messages`）帶 thinking 的請求，管理面板顯示非零的 Thinking Tokens
- [x] 串流和非串流模式都正確統計
- [x] 不帶 thinking 的請求，ReasoningTokens 保持 0