### PR TITLE
解决大量codex账号进行健康扫描时候巨量内存分配以及高CPU占用

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -613,21 +613,15 @@ func tokenValueFromMetadata(metadata map[string]any) string {
 }
 
 func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {
-	authIndex = strings.TrimSpace(authIndex)
-	if authIndex == "" || h == nil || h.authManager == nil {
-		return nil
-	}
-	auths := h.authManager.List()
-	for _, auth := range auths {
-		if auth == nil {
-			continue
-		}
-		auth.EnsureIndex()
-		if auth.Index == authIndex {
-			return auth
-		}
-	}
-	return nil
+    authIndex = strings.TrimSpace(authIndex)
+    if authIndex == "" || h == nil || h.authManager == nil {
+        return nil
+    }
+    // 使用直接查找替代 List() 全量拷贝
+    if auth, ok := h.authManager.GetByIndex(authIndex); ok {
+        return auth
+    }
+    return nil
 }
 
 func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2879,3 +2879,22 @@ func (m *Manager) HttpRequest(ctx context.Context, auth *Auth, req *http.Request
 	}
 	return exec.HttpRequest(ctx, auth, req)
 }
+
+func (m *Manager) GetByIndex(index string) (*Auth, bool) {
+    index = strings.TrimSpace(index)
+    if index == "" {
+        return nil, false
+    }
+    m.mu.RLock()
+    defer m.mu.RUnlock()
+    for _, auth := range m.auths {
+        if auth == nil {
+            continue
+        }
+        auth.EnsureIndex()
+        if auth.Index == index {
+            return auth.Clone(), true
+        }
+    }
+    return nil, false
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2885,8 +2885,8 @@ func (m *Manager) GetByIndex(index string) (*Auth, bool) {
     if index == "" {
         return nil, false
     }
-    m.mu.RLock()
-    defer m.mu.RUnlock()
+    m.mu.Lock()
+    defer m.mu.Unlock()
     for _, auth := range m.auths {
         if auth == nil {
             continue


### PR DESCRIPTION

内存泄漏分析报告
问题概述
从 heap profile 来看，主要内存占用集中在以下几个热点：

热点 1：auth.(*Manager).List - 最大内存消费者（~13.4MB 当前，历史累计 5.6GB）
<TEXT>
40: 13434880 [16790: 5639290880] @ auth.(*Manager).List
3369: 1940544 [1607287: 925797312] @ auth.(*Auth).Clone (called from List)
2435: 1012960 [1160282: 482677312] @ auth.(*Auth).Clone
1662: 478656 [801513: 230835744] @ auth.(*Auth).Clone
根因分析：

在 conductor.go:1981 的 List() 方法中，每次调用都会对所有 auth 进行深拷贝（Clone）。当频繁扫描大量 codex 账号健康度时，这会产生巨大的内存分配压力。

关键调用路径：

<TEXT>
management.(*Handler).authByIndex → auth.(*Manager).List → Clone every auth
authByIndex 在 api_tools.go:620 被调用，它遍历所有 auth 只是为了找到一个匹配的索引。每次 API 调用都执行完整的 List+Clone。


修复建议
修复 1（关键）：authByIndex 应使用索引查找而非全量 List
<GO>
// 在 conductor.go 中添加方法
func (m *Manager) GetByIndex(index string) (*Auth, bool) {
    index = strings.TrimSpace(index)
    if index == "" {
        return nil, false
    }
    m.mu.RLock()
    defer m.mu.RUnlock()
    for _, auth := range m.auths {
        if auth == nil {
            continue
        }
        auth.EnsureIndex()
        if auth.Index == index {
            return auth.Clone(), true
        }
    }
    return nil, false
}
然后修改 api_tools.go:620：

<GO>
func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {
    authIndex = strings.TrimSpace(authIndex)
    if authIndex == "" || h == nil || h.authManager == nil {
        return nil
    }
    // 使用直接查找替代 List() 全量拷贝
    if auth, ok := h.authManager.GetByIndex(authIndex); ok {
        return auth
    }
    return nil
}
预期效果： 将每次 API 调用的内存分配从 O(N×auth_size) 降低到 O(1×auth_size)。对于 1000 个账号，每次请求节省约 800KB~1MB 分配。