### PR TITLE
fix: 修复 Codex WebSocket 会话在额度耗尽后不切换账号

### DIFF
--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -82,10 +82,31 @@ type codexWebsocketRead struct {
 	err     error
 }
 
+func trySendCodexWebsocketRead(ch chan codexWebsocketRead, done <-chan struct{}, ev codexWebsocketRead) {
+	if ch == nil {
+		return
+	}
+	defer func() { _ = recover() }()
+	select {
+	case ch <- ev:
+	case <-done:
+	default:
+	}
+}
+
+func tryCloseCodexWebsocketRead(ch chan codexWebsocketRead) {
+	if ch == nil {
+		return
+	}
+	defer func() { _ = recover() }()
+	close(ch)
+}
+
 func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
 	if s == nil {
 		return
 	}
+	// 该方法仅持有 activeMu 调用避免与 connMu->activeMu 锁序冲突
 	s.activeMu.Lock()
 	if s.activeCancel != nil {
 		s.activeCancel()
@@ -105,6 +126,7 @@ func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
 	if s == nil {
 		return
 	}
+	// 该方法仅持有 activeMu 调用避免与 connMu->activeMu 锁序冲突
 	s.activeMu.Lock()
 	if s.activeCh == ch {
 		s.activeCh = nil
@@ -131,6 +153,7 @@ func (s *codexWebsocketSession) activeSnapshotForCurrentConn(conn *websocket.Con
 	if s == nil || conn == nil {
 		return nil, nil, false
 	}
+	// 锁顺序固定为 connMu -> activeMu
 	s.connMu.Lock()
 	if s.conn != conn {
 		s.connMu.Unlock()
@@ -148,6 +171,7 @@ func (s *codexWebsocketSession) clearActiveForCurrentConn(conn *websocket.Conn, 
 	if s == nil || conn == nil || ch == nil {
 		return false
 	}
+	// 锁顺序固定为 connMu -> activeMu
 	s.connMu.Lock()
 	if s.conn != conn {
 		s.connMu.Unlock()
@@ -168,6 +192,30 @@ func (s *codexWebsocketSession) clearActiveForCurrentConn(conn *websocket.Conn, 
 	s.activeMu.Unlock()
 	s.connMu.Unlock()
 	return true
+}
+
+func (s *codexWebsocketSession) failActiveForSessionClose(conn *websocket.Conn, err error) {
+	if s == nil {
+		return
+	}
+	if err == nil {
+		err = fmt.Errorf("codex websockets executor: execution session closed")
+	}
+	s.activeMu.Lock()
+	ch := s.activeCh
+	done := s.activeDone
+	if s.activeCancel != nil {
+		s.activeCancel()
+	}
+	s.activeCh = nil
+	s.activeCancel = nil
+	s.activeDone = nil
+	s.activeMu.Unlock()
+	if ch == nil {
+		return
+	}
+	trySendCodexWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: err})
+	tryCloseCodexWebsocketRead(ch)
 }
 
 func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, payload []byte) error {
@@ -1117,10 +1165,10 @@ func (e *CodexWebsocketsExecutor) getOrCreateSession(sessionID string) *codexWeb
 }
 
 func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, authID string, wsURL string, headers http.Header) (*websocket.Conn, *http.Response, error) {
+	authID = strings.TrimSpace(authID)
 	if sess == nil {
 		return e.dialCodexWebsocket(ctx, auth, wsURL, headers)
 	}
-	authID = strings.TrimSpace(authID)
 
 	sess.connMu.Lock()
 	conn := sess.conn
@@ -1190,13 +1238,9 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 				return
 			}
 			if ch != nil {
-				select {
-				case ch <- codexWebsocketRead{conn: conn, err: errRead}:
-				case <-done:
-				default:
-				}
+				trySendCodexWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: errRead})
 				if sess.clearActiveForCurrentConn(conn, ch) {
-					close(ch)
+					tryCloseCodexWebsocketRead(ch)
 				}
 			}
 			e.invalidateUpstreamConn(sess, conn, "upstream_disconnected", errRead)
@@ -1213,13 +1257,9 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 					return
 				}
 				if ch != nil {
-					select {
-					case ch <- codexWebsocketRead{conn: conn, err: errBinary}:
-					case <-done:
-					default:
-					}
+					trySendCodexWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: errBinary})
 					if sess.clearActiveForCurrentConn(conn, ch) {
-						close(ch)
+						tryCloseCodexWebsocketRead(ch)
 					}
 				}
 				e.invalidateUpstreamConn(sess, conn, "unexpected_binary", errBinary)
@@ -1329,6 +1369,9 @@ func (e *CodexWebsocketsExecutor) closeExecutionSession(sess *codexWebsocketSess
 	}
 	sessionID := sess.sessionID
 	sess.connMu.Unlock()
+
+	// 会话显式关闭时主动唤醒活跃请求避免 readCh 悬挂
+	sess.failActiveForSessionClose(conn, fmt.Errorf("codex websockets executor: execution session closed"))
 
 	if conn == nil {
 		return

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -127,6 +127,49 @@ func (s *codexWebsocketSession) isCurrentConn(conn *websocket.Conn) bool {
 	return current == conn
 }
 
+func (s *codexWebsocketSession) activeSnapshotForCurrentConn(conn *websocket.Conn) (chan codexWebsocketRead, <-chan struct{}, bool) {
+	if s == nil || conn == nil {
+		return nil, nil, false
+	}
+	s.connMu.Lock()
+	if s.conn != conn {
+		s.connMu.Unlock()
+		return nil, nil, false
+	}
+	s.activeMu.Lock()
+	ch := s.activeCh
+	done := s.activeDone
+	s.activeMu.Unlock()
+	s.connMu.Unlock()
+	return ch, done, true
+}
+
+func (s *codexWebsocketSession) clearActiveForCurrentConn(conn *websocket.Conn, ch chan codexWebsocketRead) bool {
+	if s == nil || conn == nil || ch == nil {
+		return false
+	}
+	s.connMu.Lock()
+	if s.conn != conn {
+		s.connMu.Unlock()
+		return false
+	}
+	s.activeMu.Lock()
+	if s.activeCh != ch {
+		s.activeMu.Unlock()
+		s.connMu.Unlock()
+		return false
+	}
+	s.activeCh = nil
+	if s.activeCancel != nil {
+		s.activeCancel()
+	}
+	s.activeCancel = nil
+	s.activeDone = nil
+	s.activeMu.Unlock()
+	s.connMu.Unlock()
+	return true
+}
+
 func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, payload []byte) error {
 	if s == nil {
 		return fmt.Errorf("codex websockets executor: session is nil")
@@ -1140,22 +1183,21 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		_ = conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
 		msgType, payload, errRead := conn.ReadMessage()
 		if errRead != nil {
-			if !sess.isCurrentConn(conn) {
+			// 在同一临界区做归属校验和通道快照避免检查后竞态
+			ch, done, current := sess.activeSnapshotForCurrentConn(conn)
+			if !current {
 				// 旧连接读错时不触碰当前活跃通道
 				return
 			}
-			sess.activeMu.Lock()
-			ch := sess.activeCh
-			done := sess.activeDone
-			sess.activeMu.Unlock()
 			if ch != nil {
 				select {
 				case ch <- codexWebsocketRead{conn: conn, err: errRead}:
 				case <-done:
 				default:
 				}
-				sess.clearActive(ch)
-				close(ch)
+				if sess.clearActiveForCurrentConn(conn, ch) {
+					close(ch)
+				}
 			}
 			e.invalidateUpstreamConn(sess, conn, "upstream_disconnected", errRead)
 			return
@@ -1164,37 +1206,33 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		if msgType != websocket.TextMessage {
 			if msgType == websocket.BinaryMessage {
 				errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
-				if !sess.isCurrentConn(conn) {
+				// 在同一临界区做归属校验和通道快照避免检查后竞态
+				ch, done, current := sess.activeSnapshotForCurrentConn(conn)
+				if !current {
 					// 旧连接二进制异常时不触碰当前活跃通道
 					return
 				}
-				sess.activeMu.Lock()
-				ch := sess.activeCh
-				done := sess.activeDone
-				sess.activeMu.Unlock()
 				if ch != nil {
 					select {
 					case ch <- codexWebsocketRead{conn: conn, err: errBinary}:
 					case <-done:
 					default:
 					}
-					sess.clearActive(ch)
-					close(ch)
+					if sess.clearActiveForCurrentConn(conn, ch) {
+						close(ch)
+					}
 				}
 				e.invalidateUpstreamConn(sess, conn, "unexpected_binary", errBinary)
 				return
 			}
 			continue
 		}
-		if !sess.isCurrentConn(conn) {
+		// 在同一临界区做归属校验和通道快照避免检查后竞态
+		ch, done, current := sess.activeSnapshotForCurrentConn(conn)
+		if !current {
 			// 旧连接消息不再分发给新连接请求
 			return
 		}
-
-		sess.activeMu.Lock()
-		ch := sess.activeCh
-		done := sess.activeDone
-		sess.activeMu.Unlock()
 		if ch == nil {
 			continue
 		}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -117,6 +117,16 @@ func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
 	s.activeMu.Unlock()
 }
 
+func (s *codexWebsocketSession) isCurrentConn(conn *websocket.Conn) bool {
+	if s == nil || conn == nil {
+		return false
+	}
+	s.connMu.Lock()
+	current := s.conn
+	s.connMu.Unlock()
+	return current == conn
+}
+
 func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, payload []byte) error {
 	if s == nil {
 		return fmt.Errorf("codex websockets executor: session is nil")
@@ -1123,9 +1133,17 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		return
 	}
 	for {
+		if !sess.isCurrentConn(conn) {
+			// 旧连接读循环直接退出避免误伤新请求通道
+			return
+		}
 		_ = conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
 		msgType, payload, errRead := conn.ReadMessage()
 		if errRead != nil {
+			if !sess.isCurrentConn(conn) {
+				// 旧连接读错时不触碰当前活跃通道
+				return
+			}
 			sess.activeMu.Lock()
 			ch := sess.activeCh
 			done := sess.activeDone
@@ -1146,6 +1164,10 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		if msgType != websocket.TextMessage {
 			if msgType == websocket.BinaryMessage {
 				errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
+				if !sess.isCurrentConn(conn) {
+					// 旧连接二进制异常时不触碰当前活跃通道
+					return
+				}
 				sess.activeMu.Lock()
 				ch := sess.activeCh
 				done := sess.activeDone
@@ -1163,6 +1185,10 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 				return
 			}
 			continue
+		}
+		if !sess.isCurrentConn(conn) {
+			// 旧连接消息不再分发给新连接请求
+			return
 		}
 
 		sess.activeMu.Lock()

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -1067,12 +1067,21 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	if sess == nil {
 		return e.dialCodexWebsocket(ctx, auth, wsURL, headers)
 	}
+	authID = strings.TrimSpace(authID)
 
 	sess.connMu.Lock()
 	conn := sess.conn
 	readerConn := sess.readerConn
+	currentAuthID := strings.TrimSpace(sess.authID)
 	sess.connMu.Unlock()
+	if conn != nil && currentAuthID != authID {
+		// 账号切换时先断开旧连接避免继续复用旧账号
+		e.invalidateUpstreamConn(sess, conn, "auth_switched", nil)
+		conn = nil
+		readerConn = nil
+	}
 	if conn != nil {
+		// 账号未变化时复用连接减少不必要重连
 		if readerConn != conn {
 			sess.connMu.Lock()
 			sess.readerConn = conn

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -86,7 +86,11 @@ func trySendCodexWebsocketRead(ch chan codexWebsocketRead, done <-chan struct{},
 	if ch == nil {
 		return
 	}
-	defer func() { _ = recover() }()
+	defer func() {
+		if r := recover(); r != nil {
+			log.Debugf("codex websockets executor: recover trySendCodexWebsocketRead panic=%v", r)
+		}
+	}()
 	select {
 	case ch <- ev:
 	case <-done:
@@ -98,7 +102,11 @@ func tryCloseCodexWebsocketRead(ch chan codexWebsocketRead) {
 	if ch == nil {
 		return
 	}
-	defer func() { _ = recover() }()
+	defer func() {
+		if r := recover(); r != nil {
+			log.Debugf("codex websockets executor: recover tryCloseCodexWebsocketRead panic=%v", r)
+		}
+	}()
 	close(ch)
 }
 
@@ -107,6 +115,7 @@ func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
 		return
 	}
 	// 该方法仅持有 activeMu 调用避免与 connMu->activeMu 锁序冲突
+	// 不要在持有 connMu 时调用避免未来引入反向锁序
 	s.activeMu.Lock()
 	if s.activeCancel != nil {
 		s.activeCancel()
@@ -127,6 +136,7 @@ func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
 		return
 	}
 	// 该方法仅持有 activeMu 调用避免与 connMu->activeMu 锁序冲突
+	// 不要在持有 connMu 时调用避免未来引入反向锁序
 	s.activeMu.Lock()
 	if s.activeCh == ch {
 		s.activeCh = nil
@@ -192,30 +202,6 @@ func (s *codexWebsocketSession) clearActiveForCurrentConn(conn *websocket.Conn, 
 	s.activeMu.Unlock()
 	s.connMu.Unlock()
 	return true
-}
-
-func (s *codexWebsocketSession) failActiveForSessionClose(conn *websocket.Conn, err error) {
-	if s == nil {
-		return
-	}
-	if err == nil {
-		err = fmt.Errorf("codex websockets executor: execution session closed")
-	}
-	s.activeMu.Lock()
-	ch := s.activeCh
-	done := s.activeDone
-	if s.activeCancel != nil {
-		s.activeCancel()
-	}
-	s.activeCh = nil
-	s.activeCancel = nil
-	s.activeDone = nil
-	s.activeMu.Unlock()
-	if ch == nil {
-		return
-	}
-	trySendCodexWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: err})
-	tryCloseCodexWebsocketRead(ch)
 }
 
 func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, payload []byte) error {
@@ -1359,19 +1345,33 @@ func (e *CodexWebsocketsExecutor) closeExecutionSession(sess *codexWebsocketSess
 		reason = "session_closed"
 	}
 
+	// 锁顺序固定为 connMu -> activeMu
 	sess.connMu.Lock()
 	conn := sess.conn
 	authID := sess.authID
 	wsURL := sess.wsURL
+	sessionID := sess.sessionID
 	sess.conn = nil
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}
-	sessionID := sess.sessionID
+	sess.activeMu.Lock()
+	ch := sess.activeCh
+	done := sess.activeDone
+	if sess.activeCancel != nil {
+		sess.activeCancel()
+	}
+	sess.activeCh = nil
+	sess.activeCancel = nil
+	sess.activeDone = nil
+	sess.activeMu.Unlock()
 	sess.connMu.Unlock()
 
-	// 会话显式关闭时主动唤醒活跃请求避免 readCh 悬挂
-	sess.failActiveForSessionClose(conn, fmt.Errorf("codex websockets executor: execution session closed"))
+	if ch != nil {
+		// 会话关闭时允许主动 fail active 唤醒在途 readCodexWebsocketMessage
+		trySendCodexWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: fmt.Errorf("codex websockets executor: execution session closed")})
+		tryCloseCodexWebsocketRead(ch)
+	}
 
 	if conn == nil {
 		return

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -289,3 +289,76 @@ func TestCloseExecutionSessionUnblocksActiveRead(t *testing.T) {
 		t.Fatal("read did not fail fast after closeExecutionSession")
 	}
 }
+
+func TestEnsureUpstreamConnAuthSwitchRebuildsWebsocketConn(t *testing.T) {
+	t.Parallel()
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	authHeaderCh := make(chan string, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		authHeaderCh <- strings.TrimSpace(r.Header.Get("Authorization"))
+		for {
+			_, _, errRead := conn.ReadMessage()
+			if errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	executor := NewCodexWebsocketsExecutor(&config.Config{})
+	sess := &codexWebsocketSession{sessionID: "session-auth-switch"}
+
+	headers1 := http.Header{}
+	headers1.Set("Authorization", "Bearer token-1")
+	conn1, _, errDial1 := executor.ensureUpstreamConn(context.Background(), nil, sess, "auth-1", wsURL, headers1)
+	if errDial1 != nil {
+		t.Fatalf("ensureUpstreamConn auth-1 error: %v", errDial1)
+	}
+	if conn1 == nil {
+		t.Fatal("ensureUpstreamConn auth-1 returned nil conn")
+	}
+
+	headers2 := http.Header{}
+	headers2.Set("Authorization", "Bearer token-2")
+	conn2, _, errDial2 := executor.ensureUpstreamConn(context.Background(), nil, sess, "auth-2", wsURL, headers2)
+	if errDial2 != nil {
+		t.Fatalf("ensureUpstreamConn auth-2 error: %v", errDial2)
+	}
+	if conn2 == nil {
+		t.Fatal("ensureUpstreamConn auth-2 returned nil conn")
+	}
+	if conn2 == conn1 {
+		t.Fatal("expected new websocket conn after auth switch")
+	}
+
+	defer executor.invalidateUpstreamConn(sess, conn2, "test_done", nil)
+
+	var got1, got2 string
+	select {
+	case got1 = <-authHeaderCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first websocket handshake")
+	}
+	select {
+	case got2 = <-authHeaderCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second websocket handshake")
+	}
+	if got1 != "Bearer token-1" {
+		t.Fatalf("first Authorization = %q, want %q", got1, "Bearer token-1")
+	}
+	if got2 != "Bearer token-2" {
+		t.Fatalf("second Authorization = %q, want %q", got2, "Bearer token-2")
+	}
+	if got1 == got2 {
+		t.Fatal("expected different Authorization headers after auth switch")
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gorilla/websocket"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
@@ -204,91 +200,4 @@ func TestNewProxyAwareWebsocketDialerDirectDisablesProxy(t *testing.T) {
 	if dialer.Proxy != nil {
 		t.Fatal("expected websocket proxy function to be nil for direct mode")
 	}
-}
-
-func TestEnsureUpstreamConnReconnectsWhenAuthChanges(t *testing.T) {
-	var (
-		mu             sync.Mutex
-		authorizations []string
-	)
-	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
-		mu.Lock()
-		authorizations = append(authorizations, strings.TrimSpace(r.Header.Get("Authorization")))
-		mu.Unlock()
-
-		go func() {
-			defer func() {
-				_ = conn.Close()
-			}()
-			for {
-				if _, _, errRead := conn.ReadMessage(); errRead != nil {
-					return
-				}
-			}
-		}()
-	}))
-	defer server.Close()
-
-	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-	executor := NewCodexWebsocketsExecutor(&config.Config{})
-	sess := executor.getOrCreateSession("test-session")
-	if sess == nil {
-		t.Fatal("expected session to be created")
-	}
-
-	auth1 := &cliproxyauth.Auth{ID: "auth-1"}
-	headers1 := http.Header{}
-	headers1.Set("Authorization", "Bearer token-1")
-	conn1, _, errDial1 := executor.ensureUpstreamConn(context.Background(), auth1, sess, auth1.ID, wsURL, headers1)
-	if errDial1 != nil {
-		t.Fatalf("first ensureUpstreamConn failed: %v", errDial1)
-	}
-	if conn1 == nil {
-		t.Fatal("first ensureUpstreamConn returned nil connection")
-	}
-
-	auth2 := &cliproxyauth.Auth{ID: "auth-2"}
-	headers2 := http.Header{}
-	headers2.Set("Authorization", "Bearer token-2")
-	conn2, _, errDial2 := executor.ensureUpstreamConn(context.Background(), auth2, sess, auth2.ID, wsURL, headers2)
-	if errDial2 != nil {
-		t.Fatalf("second ensureUpstreamConn failed: %v", errDial2)
-	}
-	if conn2 == nil {
-		t.Fatal("second ensureUpstreamConn returned nil connection")
-	}
-	if conn1 == conn2 {
-		t.Fatal("expected auth change to force upstream reconnect")
-	}
-
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		mu.Lock()
-		count := len(authorizations)
-		mu.Unlock()
-		if count >= 2 || time.Now().After(deadline) {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	mu.Lock()
-	got := append([]string(nil), authorizations...)
-	mu.Unlock()
-	if len(got) < 2 {
-		t.Fatalf("handshake count = %d, want at least 2", len(got))
-	}
-	if got[0] != "Bearer token-1" {
-		t.Fatalf("first Authorization = %q, want %q", got[0], "Bearer token-1")
-	}
-	if got[1] != "Bearer token-2" {
-		t.Fatalf("second Authorization = %q, want %q", got[1], "Bearer token-2")
-	}
-
-	executor.closeExecutionSession(sess, "test_done")
 }

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
@@ -199,5 +202,90 @@ func TestNewProxyAwareWebsocketDialerDirectDisablesProxy(t *testing.T) {
 
 	if dialer.Proxy != nil {
 		t.Fatal("expected websocket proxy function to be nil for direct mode")
+	}
+}
+
+func TestReadCodexWebsocketMessageReturnsWhenReadChannelClosed(t *testing.T) {
+	t.Parallel()
+
+	sess := &codexWebsocketSession{}
+	conn := &websocket.Conn{}
+	readCh := make(chan codexWebsocketRead)
+	close(readCh)
+
+	_, _, err := readCodexWebsocketMessage(context.Background(), sess, conn, readCh)
+	if err == nil {
+		t.Fatal("expected error when session read channel is closed")
+	}
+	if !strings.Contains(err.Error(), "session read channel closed") {
+		t.Fatalf("error = %v, want contains session read channel closed", err)
+	}
+}
+
+func TestCloseExecutionSessionUnblocksActiveRead(t *testing.T) {
+	t.Parallel()
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	serverConnCh := make(chan *websocket.Conn, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		serverConnCh <- conn
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		t.Fatalf("dial websocket: %v", errDial)
+	}
+	defer func() { _ = clientConn.Close() }()
+
+	var serverConn *websocket.Conn
+	select {
+	case serverConn = <-serverConnCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server websocket connection")
+	}
+
+	sess := &codexWebsocketSession{
+		sessionID:  "session-close",
+		conn:       serverConn,
+		readerConn: serverConn,
+	}
+	readCh := make(chan codexWebsocketRead, 4)
+	sess.setActive(readCh)
+
+	executor := &CodexWebsocketsExecutor{
+		CodexExecutor: &CodexExecutor{},
+		sessions: map[string]*codexWebsocketSession{
+			"session-close": sess,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	readErrCh := make(chan error, 1)
+	go func() {
+		_, _, err := readCodexWebsocketMessage(ctx, sess, serverConn, readCh)
+		readErrCh <- err
+	}()
+
+	executor.CloseExecutionSession("session-close")
+
+	select {
+	case err := <-readErrCh:
+		if err == nil {
+			t.Fatal("expected read error after closing execution session")
+		}
+		errText := err.Error()
+		if !strings.Contains(errText, "execution session closed") && !strings.Contains(errText, "session read channel closed") {
+			t.Fatalf("error = %v, want fast-fail error from session close path", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("read did not fail fast after closeExecutionSession")
 	}
 }

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
@@ -200,4 +204,91 @@ func TestNewProxyAwareWebsocketDialerDirectDisablesProxy(t *testing.T) {
 	if dialer.Proxy != nil {
 		t.Fatal("expected websocket proxy function to be nil for direct mode")
 	}
+}
+
+func TestEnsureUpstreamConnReconnectsWhenAuthChanges(t *testing.T) {
+	var (
+		mu             sync.Mutex
+		authorizations []string
+	)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		mu.Lock()
+		authorizations = append(authorizations, strings.TrimSpace(r.Header.Get("Authorization")))
+		mu.Unlock()
+
+		go func() {
+			defer func() {
+				_ = conn.Close()
+			}()
+			for {
+				if _, _, errRead := conn.ReadMessage(); errRead != nil {
+					return
+				}
+			}
+		}()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	executor := NewCodexWebsocketsExecutor(&config.Config{})
+	sess := executor.getOrCreateSession("test-session")
+	if sess == nil {
+		t.Fatal("expected session to be created")
+	}
+
+	auth1 := &cliproxyauth.Auth{ID: "auth-1"}
+	headers1 := http.Header{}
+	headers1.Set("Authorization", "Bearer token-1")
+	conn1, _, errDial1 := executor.ensureUpstreamConn(context.Background(), auth1, sess, auth1.ID, wsURL, headers1)
+	if errDial1 != nil {
+		t.Fatalf("first ensureUpstreamConn failed: %v", errDial1)
+	}
+	if conn1 == nil {
+		t.Fatal("first ensureUpstreamConn returned nil connection")
+	}
+
+	auth2 := &cliproxyauth.Auth{ID: "auth-2"}
+	headers2 := http.Header{}
+	headers2.Set("Authorization", "Bearer token-2")
+	conn2, _, errDial2 := executor.ensureUpstreamConn(context.Background(), auth2, sess, auth2.ID, wsURL, headers2)
+	if errDial2 != nil {
+		t.Fatalf("second ensureUpstreamConn failed: %v", errDial2)
+	}
+	if conn2 == nil {
+		t.Fatal("second ensureUpstreamConn returned nil connection")
+	}
+	if conn1 == conn2 {
+		t.Fatal("expected auth change to force upstream reconnect")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		count := len(authorizations)
+		mu.Unlock()
+		if count >= 2 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	got := append([]string(nil), authorizations...)
+	mu.Unlock()
+	if len(got) < 2 {
+		t.Fatalf("handshake count = %d, want at least 2", len(got))
+	}
+	if got[0] != "Bearer token-1" {
+		t.Fatalf("first Authorization = %q, want %q", got[0], "Bearer token-1")
+	}
+	if got[1] != "Bearer token-2" {
+		t.Fatalf("second Authorization = %q, want %q", got[1], "Bearer token-2")
+	}
+
+	executor.closeExecutionSession(sess, "test_done")
 }

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -154,6 +154,28 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			}
 			continue
 		}
+		nextSessionRequestSnapshot := updatedLastRequest
+		if shouldBuildResponsesWebsocketFullSnapshot(requestJSON, allowIncrementalInputWithPreviousResponseID) {
+			_, shadowLastRequest, shadowErr := normalizeResponsesWebsocketRequestWithMode(
+				payload,
+				lastRequest,
+				lastResponseOutput,
+				false,
+			)
+			if shadowErr != nil {
+				// 影子快照失败时保留旧快照避免污染会话状态
+				nextSessionRequestSnapshot = lastRequest
+				log.Warnf(
+					"responses websocket: keep previous snapshot id=%s status=%d error=%v",
+					passthroughSessionID,
+					shadowErr.StatusCode,
+					shadowErr.Error,
+				)
+			} else {
+				// 增量模式只发 delta 同时维护完整快照供切号恢复
+				nextSessionRequestSnapshot = shadowLastRequest
+			}
+		}
 		if shouldHandleResponsesWebsocketPrewarmLocally(payload, lastRequest, allowIncrementalInputWithPreviousResponseID) {
 			if updated, errDelete := sjson.DeleteBytes(requestJSON, "generate"); errDelete == nil {
 				requestJSON = updated
@@ -170,7 +192,8 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			}
 			continue
 		}
-		lastRequest = updatedLastRequest
+		// lastRequest 始终保存完整 transcript 快照
+		lastRequest = nextSessionRequestSnapshot
 
 		modelName := gjson.GetBytes(requestJSON, "model").String()
 		cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
@@ -502,6 +525,14 @@ func shouldHandleResponsesWebsocketPrewarmLocally(rawJSON []byte, lastRequest []
 	}
 	generateResult := gjson.GetBytes(rawJSON, "generate")
 	return generateResult.Exists() && !generateResult.Bool()
+}
+
+func shouldBuildResponsesWebsocketFullSnapshot(normalizedRequestJSON []byte, allowIncrementalInputWithPreviousResponseID bool) bool {
+	if !allowIncrementalInputWithPreviousResponseID {
+		return false
+	}
+	prev := strings.TrimSpace(gjson.GetBytes(normalizedRequestJSON, "previous_response_id").String())
+	return prev != ""
 }
 
 func writeResponsesWebsocketSyntheticPrewarm(

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -165,7 +165,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			if shadowErr != nil {
 				// 影子快照失败时保留旧快照避免污染会话状态
 				nextSessionRequestSnapshot = lastRequest
-				log.Warnf(
+				log.Errorf(
 					"responses websocket: keep previous snapshot id=%s status=%d error=%v",
 					passthroughSessionID,
 					shadowErr.StatusCode,
@@ -224,6 +224,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 		if shouldResetResponsesWebsocketAuthPin(terminalStatus) {
 			// 限额错误后解除 pin 让后续请求重新选可用账号
+			log.Infof("responses websocket: reset auth pin id=%s status=%d", passthroughSessionID, terminalStatus)
 			pinnedAuthID = ""
 			// 切号恢复阶段先禁用增量模式避免沿用旧账号 response id
 			forceDisableIncrementalAfterAuthReset = true
@@ -232,7 +233,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 				h.AuthManager.CloseExecutionSession(passthroughSessionID)
 			}
 		} else if forceDisableIncrementalAfterAuthReset && terminalStatus == 0 {
-			// 新账号完成一轮后恢复增量模式
+			// 仅在成功轮次恢复增量模式避免失败轮次继续透传旧 response id
 			forceDisableIncrementalAfterAuthReset = false
 		}
 		if terminalStatus == 0 {
@@ -773,7 +774,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 
 func shouldResetResponsesWebsocketAuthPin(statusCode int) bool {
 	switch statusCode {
-	case http.StatusTooManyRequests, http.StatusForbidden, http.StatusPaymentRequired:
+	case http.StatusTooManyRequests, http.StatusForbidden, http.StatusPaymentRequired, http.StatusUnauthorized:
 		return true
 	default:
 		return false

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -192,12 +192,20 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 		dataChan, _, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, requestJSON, "")
 
-		completedOutput, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, &wsBodyLog, passthroughSessionID)
+		completedOutput, terminalStatus, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, &wsBodyLog, passthroughSessionID)
 		if errForward != nil {
 			wsTerminateErr = errForward
 			appendWebsocketEvent(&wsBodyLog, "disconnect", []byte(errForward.Error()))
 			log.Warnf("responses websocket: forward failed id=%s error=%v", passthroughSessionID, errForward)
 			return
+		}
+		if shouldResetResponsesWebsocketAuthPin(terminalStatus) {
+			// 限额错误后解除 pin 让后续请求重新选可用账号
+			pinnedAuthID = ""
+			if h != nil && h.AuthManager != nil {
+				// 主动关闭旧上游会话避免继续复用旧账号连接
+				h.AuthManager.CloseExecutionSession(passthroughSessionID)
+			}
 		}
 		lastResponseOutput = completedOutput
 	}
@@ -610,21 +618,23 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 	errs <-chan *interfaces.ErrorMessage,
 	wsBodyLog *strings.Builder,
 	sessionID string,
-) ([]byte, error) {
+) ([]byte, int, error) {
 	completed := false
 	completedOutput := []byte("[]")
+	terminalStatusCode := 0
 
 	for {
 		select {
 		case <-c.Request.Context().Done():
 			cancel(c.Request.Context().Err())
-			return completedOutput, c.Request.Context().Err()
+			return completedOutput, terminalStatusCode, c.Request.Context().Err()
 		case errMsg, ok := <-errs:
 			if !ok {
 				errs = nil
 				continue
 			}
 			if errMsg != nil {
+				terminalStatusCode = errMsg.StatusCode
 				h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), errMsg)
 				markAPIResponseTimestamp(c)
 				errorPayload, errWrite := writeResponsesWebsocketError(conn, errMsg)
@@ -644,7 +654,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 					// 	errWrite,
 					// )
 					cancel(errMsg.Error)
-					return completedOutput, errWrite
+					return completedOutput, terminalStatusCode, errWrite
 				}
 			}
 			if errMsg != nil {
@@ -652,7 +662,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 			} else {
 				cancel(nil)
 			}
-			return completedOutput, nil
+			return completedOutput, terminalStatusCode, nil
 		case chunk, ok := <-data:
 			if !ok {
 				if !completed {
@@ -660,6 +670,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 						StatusCode: http.StatusRequestTimeout,
 						Error:      fmt.Errorf("stream closed before response.completed"),
 					}
+					terminalStatusCode = errMsg.StatusCode
 					h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), errMsg)
 					markAPIResponseTimestamp(c)
 					errorPayload, errWrite := writeResponsesWebsocketError(conn, errMsg)
@@ -679,13 +690,13 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 							errWrite,
 						)
 						cancel(errMsg.Error)
-						return completedOutput, errWrite
+						return completedOutput, terminalStatusCode, errWrite
 					}
 					cancel(errMsg.Error)
-					return completedOutput, nil
+					return completedOutput, terminalStatusCode, nil
 				}
 				cancel(nil)
-				return completedOutput, nil
+				return completedOutput, terminalStatusCode, nil
 			}
 
 			payloads := websocketJSONPayloadsFromChunk(chunk)
@@ -712,10 +723,19 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 						errWrite,
 					)
 					cancel(errWrite)
-					return completedOutput, errWrite
+					return completedOutput, terminalStatusCode, errWrite
 				}
 			}
 		}
+	}
+}
+
+func shouldResetResponsesWebsocketAuthPin(statusCode int) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests, http.StatusForbidden, http.StatusPaymentRequired:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -81,6 +81,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 	var lastRequest []byte
 	lastResponseOutput := []byte("[]")
 	pinnedAuthID := ""
+	forceDisableIncrementalAfterAuthReset := false
 
 	for {
 		msgType, payload, errReadMessage := conn.ReadMessage()
@@ -107,16 +108,18 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		appendWebsocketEvent(&wsBodyLog, "request", payload)
 
 		allowIncrementalInputWithPreviousResponseID := false
-		if pinnedAuthID != "" && h != nil && h.AuthManager != nil {
-			if pinnedAuth, ok := h.AuthManager.GetByID(pinnedAuthID); ok && pinnedAuth != nil {
-				allowIncrementalInputWithPreviousResponseID = websocketUpstreamSupportsIncrementalInput(pinnedAuth.Attributes, pinnedAuth.Metadata)
+		if !forceDisableIncrementalAfterAuthReset {
+			if pinnedAuthID != "" && h != nil && h.AuthManager != nil {
+				if pinnedAuth, ok := h.AuthManager.GetByID(pinnedAuthID); ok && pinnedAuth != nil {
+					allowIncrementalInputWithPreviousResponseID = websocketUpstreamSupportsIncrementalInput(pinnedAuth.Attributes, pinnedAuth.Metadata)
+				}
+			} else {
+				requestModelName := strings.TrimSpace(gjson.GetBytes(payload, "model").String())
+				if requestModelName == "" {
+					requestModelName = strings.TrimSpace(gjson.GetBytes(lastRequest, "model").String())
+				}
+				allowIncrementalInputWithPreviousResponseID = h.websocketUpstreamSupportsIncrementalInputForModel(requestModelName)
 			}
-		} else {
-			requestModelName := strings.TrimSpace(gjson.GetBytes(payload, "model").String())
-			if requestModelName == "" {
-				requestModelName = strings.TrimSpace(gjson.GetBytes(lastRequest, "model").String())
-			}
-			allowIncrementalInputWithPreviousResponseID = h.websocketUpstreamSupportsIncrementalInputForModel(requestModelName)
 		}
 
 		var requestJSON []byte
@@ -202,10 +205,15 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		if shouldResetResponsesWebsocketAuthPin(terminalStatus) {
 			// 限额错误后解除 pin 让后续请求重新选可用账号
 			pinnedAuthID = ""
+			// 切号恢复阶段先禁用增量模式避免沿用旧账号 response id
+			forceDisableIncrementalAfterAuthReset = true
 			if h != nil && h.AuthManager != nil {
 				// 主动关闭旧上游会话避免继续复用旧账号连接
 				h.AuthManager.CloseExecutionSession(passthroughSessionID)
 			}
+		} else if forceDisableIncrementalAfterAuthReset && terminalStatus == 0 {
+			// 新账号完成一轮后恢复增量模式
+			forceDisableIncrementalAfterAuthReset = false
 		}
 		lastResponseOutput = completedOutput
 	}

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -192,9 +192,6 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			}
 			continue
 		}
-		// lastRequest 始终保存完整 transcript 快照
-		lastRequest = nextSessionRequestSnapshot
-
 		modelName := gjson.GetBytes(requestJSON, "model").String()
 		cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
 		cliCtx = cliproxyexecutor.WithDownstreamWebsocket(cliCtx)
@@ -238,7 +235,12 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			// 新账号完成一轮后恢复增量模式
 			forceDisableIncrementalAfterAuthReset = false
 		}
-		lastResponseOutput = completedOutput
+		if terminalStatus == 0 {
+			// 仅在本轮成功后提交快照避免失败轮次污染会话历史
+			lastRequest = nextSessionRequestSnapshot
+			// 仅在本轮成功后提交输出避免失败把状态推进到空输出
+			lastResponseOutput = completedOutput
+		}
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -62,6 +62,27 @@ type websocketAuthCaptureExecutor struct {
 	authIDs []string
 }
 
+type websocketStatusError struct {
+	code int
+	msg  string
+}
+
+func (e websocketStatusError) Error() string {
+	if strings.TrimSpace(e.msg) != "" {
+		return e.msg
+	}
+	return fmt.Sprintf("status %d", e.code)
+}
+
+func (e websocketStatusError) StatusCode() int {
+	return e.code
+}
+
+type websocketQuotaSwitchExecutor struct {
+	mu      sync.Mutex
+	authIDs []string
+}
+
 func (e *websocketAuthCaptureExecutor) Identifier() string { return "test-provider" }
 
 func (e *websocketAuthCaptureExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
@@ -94,6 +115,47 @@ func (e *websocketAuthCaptureExecutor) HttpRequest(context.Context, *coreauth.Au
 }
 
 func (e *websocketAuthCaptureExecutor) AuthIDs() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.authIDs...)
+}
+
+func (e *websocketQuotaSwitchExecutor) Identifier() string { return "test-provider" }
+
+func (e *websocketQuotaSwitchExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *websocketQuotaSwitchExecutor) ExecuteStream(_ context.Context, auth *coreauth.Auth, _ coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	e.mu.Lock()
+	if auth != nil {
+		e.authIDs = append(e.authIDs, auth.ID)
+	}
+	e.mu.Unlock()
+
+	if auth != nil && auth.ID == "auth-1" {
+		return nil, websocketStatusError{code: http.StatusTooManyRequests, msg: "quota exhausted"}
+	}
+
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed","response":{"id":"resp-upstream","output":[{"type":"message","id":"out-1"}]}}`)}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *websocketQuotaSwitchExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *websocketQuotaSwitchExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *websocketQuotaSwitchExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *websocketQuotaSwitchExecutor) AuthIDs() []string {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return append([]string(nil), e.authIDs...)
@@ -417,7 +479,7 @@ func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 		close(errCh)
 
 		var bodyLog strings.Builder
-		completedOutput, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+		completedOutput, statusCode, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
 			ctx,
 			conn,
 			func(...interface{}) {},
@@ -428,6 +490,10 @@ func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 		)
 		if err != nil {
 			serverErrCh <- err
+			return
+		}
+		if statusCode != 0 {
+			serverErrCh <- fmt.Errorf("status code = %d, want 0", statusCode)
 			return
 		}
 		if gjson.GetBytes(completedOutput, "0.id").String() != "out-1" {
@@ -660,5 +726,89 @@ func TestResponsesWebsocketPinsOnlyWebsocketCapableAuth(t *testing.T) {
 
 	if got := executor.AuthIDs(); len(got) != 2 || got[0] != "auth-sse" || got[1] != "auth-ws" {
 		t.Fatalf("selected auth IDs = %v, want [auth-sse auth-ws]", got)
+	}
+}
+
+func TestResponsesWebsocketClearsPinAndSwitchesAuthAfterQuotaError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	selector := &orderedWebsocketSelector{order: []string{"auth-1", "auth-2"}}
+	executor := &websocketQuotaSwitchExecutor{}
+	manager := coreauth.NewManager(nil, selector, nil)
+	manager.SetRetryConfig(0, 0, 1)
+	manager.RegisterExecutor(executor)
+
+	auth1 := &coreauth.Auth{
+		ID:         "auth-1",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("Register auth-1: %v", err)
+	}
+	auth2 := &coreauth.Auth{
+		ID:         "auth-2",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth2); err != nil {
+		t.Fatalf("Register auth-2: %v", err)
+	}
+
+	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	registry.GetGlobalRegistry().RegisterClient(auth2.ID, auth2.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
+		registry.GetGlobalRegistry().UnregisterClient(auth2.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
+		t.Fatalf("write first websocket message: %v", errWrite)
+	}
+	_, firstPayload, errReadFirst := conn.ReadMessage()
+	if errReadFirst != nil {
+		t.Fatalf("read first websocket message: %v", errReadFirst)
+	}
+	if got := gjson.GetBytes(firstPayload, "type").String(); got != wsEventTypeError {
+		t.Fatalf("first payload type = %s, want %s", got, wsEventTypeError)
+	}
+	if got := gjson.GetBytes(firstPayload, "error.code").String(); got != "rate_limit_exceeded" {
+		t.Fatalf("first payload code = %s, want rate_limit_exceeded", got)
+	}
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
+		t.Fatalf("write second websocket message: %v", errWrite)
+	}
+	_, secondPayload, errReadSecond := conn.ReadMessage()
+	if errReadSecond != nil {
+		t.Fatalf("read second websocket message: %v", errReadSecond)
+	}
+	if got := gjson.GetBytes(secondPayload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("second payload type = %s, want %s", got, wsEventTypeCompleted)
+	}
+
+	if got := executor.AuthIDs(); len(got) != 2 || got[0] != "auth-1" || got[1] != "auth-2" {
+		t.Fatalf("selected auth IDs = %v, want [auth-1 auth-2]", got)
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -390,6 +390,34 @@ func TestSetWebsocketRequestBody(t *testing.T) {
 	}
 }
 
+func TestShouldResetResponsesWebsocketAuthPin(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		statusCode int
+		want       bool
+	}{
+		{name: "too_many_requests", statusCode: http.StatusTooManyRequests, want: true},
+		{name: "forbidden", statusCode: http.StatusForbidden, want: true},
+		{name: "payment_required", statusCode: http.StatusPaymentRequired, want: true},
+		{name: "unauthorized", statusCode: http.StatusUnauthorized, want: false},
+		{name: "internal_error", statusCode: http.StatusInternalServerError, want: false},
+		{name: "zero", statusCode: 0, want: false},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldResetResponsesWebsocketAuthPin(tc.statusCode)
+			if got != tc.want {
+				t.Fatalf("shouldResetResponsesWebsocketAuthPin(%d) = %v, want %v", tc.statusCode, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -62,27 +62,6 @@ type websocketAuthCaptureExecutor struct {
 	authIDs []string
 }
 
-type websocketStatusError struct {
-	code int
-	msg  string
-}
-
-func (e websocketStatusError) Error() string {
-	if strings.TrimSpace(e.msg) != "" {
-		return e.msg
-	}
-	return fmt.Sprintf("status %d", e.code)
-}
-
-func (e websocketStatusError) StatusCode() int {
-	return e.code
-}
-
-type websocketQuotaSwitchExecutor struct {
-	mu      sync.Mutex
-	authIDs []string
-}
-
 func (e *websocketAuthCaptureExecutor) Identifier() string { return "test-provider" }
 
 func (e *websocketAuthCaptureExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
@@ -115,47 +94,6 @@ func (e *websocketAuthCaptureExecutor) HttpRequest(context.Context, *coreauth.Au
 }
 
 func (e *websocketAuthCaptureExecutor) AuthIDs() []string {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	return append([]string(nil), e.authIDs...)
-}
-
-func (e *websocketQuotaSwitchExecutor) Identifier() string { return "test-provider" }
-
-func (e *websocketQuotaSwitchExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
-	return coreexecutor.Response{}, errors.New("not implemented")
-}
-
-func (e *websocketQuotaSwitchExecutor) ExecuteStream(_ context.Context, auth *coreauth.Auth, _ coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
-	e.mu.Lock()
-	if auth != nil {
-		e.authIDs = append(e.authIDs, auth.ID)
-	}
-	e.mu.Unlock()
-
-	if auth != nil && auth.ID == "auth-1" {
-		return nil, websocketStatusError{code: http.StatusTooManyRequests, msg: "quota exhausted"}
-	}
-
-	chunks := make(chan coreexecutor.StreamChunk, 1)
-	chunks <- coreexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed","response":{"id":"resp-upstream","output":[{"type":"message","id":"out-1"}]}}`)}
-	close(chunks)
-	return &coreexecutor.StreamResult{Chunks: chunks}, nil
-}
-
-func (e *websocketQuotaSwitchExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
-	return auth, nil
-}
-
-func (e *websocketQuotaSwitchExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
-	return coreexecutor.Response{}, errors.New("not implemented")
-}
-
-func (e *websocketQuotaSwitchExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (e *websocketQuotaSwitchExecutor) AuthIDs() []string {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return append([]string(nil), e.authIDs...)
@@ -726,89 +664,5 @@ func TestResponsesWebsocketPinsOnlyWebsocketCapableAuth(t *testing.T) {
 
 	if got := executor.AuthIDs(); len(got) != 2 || got[0] != "auth-sse" || got[1] != "auth-ws" {
 		t.Fatalf("selected auth IDs = %v, want [auth-sse auth-ws]", got)
-	}
-}
-
-func TestResponsesWebsocketClearsPinAndSwitchesAuthAfterQuotaError(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	selector := &orderedWebsocketSelector{order: []string{"auth-1", "auth-2"}}
-	executor := &websocketQuotaSwitchExecutor{}
-	manager := coreauth.NewManager(nil, selector, nil)
-	manager.SetRetryConfig(0, 0, 1)
-	manager.RegisterExecutor(executor)
-
-	auth1 := &coreauth.Auth{
-		ID:         "auth-1",
-		Provider:   executor.Identifier(),
-		Status:     coreauth.StatusActive,
-		Attributes: map[string]string{"websockets": "true"},
-	}
-	if _, err := manager.Register(context.Background(), auth1); err != nil {
-		t.Fatalf("Register auth-1: %v", err)
-	}
-	auth2 := &coreauth.Auth{
-		ID:         "auth-2",
-		Provider:   executor.Identifier(),
-		Status:     coreauth.StatusActive,
-		Attributes: map[string]string{"websockets": "true"},
-	}
-	if _, err := manager.Register(context.Background(), auth2); err != nil {
-		t.Fatalf("Register auth-2: %v", err)
-	}
-
-	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: "test-model"}})
-	registry.GetGlobalRegistry().RegisterClient(auth2.ID, auth2.Provider, []*registry.ModelInfo{{ID: "test-model"}})
-	t.Cleanup(func() {
-		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
-		registry.GetGlobalRegistry().UnregisterClient(auth2.ID)
-	})
-
-	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
-	h := NewOpenAIResponsesAPIHandler(base)
-	router := gin.New()
-	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
-
-	server := httptest.NewServer(router)
-	defer server.Close()
-
-	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
-	if err != nil {
-		t.Fatalf("dial websocket: %v", err)
-	}
-	defer func() {
-		if errClose := conn.Close(); errClose != nil {
-			t.Fatalf("close websocket: %v", errClose)
-		}
-	}()
-
-	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
-		t.Fatalf("write first websocket message: %v", errWrite)
-	}
-	_, firstPayload, errReadFirst := conn.ReadMessage()
-	if errReadFirst != nil {
-		t.Fatalf("read first websocket message: %v", errReadFirst)
-	}
-	if got := gjson.GetBytes(firstPayload, "type").String(); got != wsEventTypeError {
-		t.Fatalf("first payload type = %s, want %s", got, wsEventTypeError)
-	}
-	if got := gjson.GetBytes(firstPayload, "error.code").String(); got != "rate_limit_exceeded" {
-		t.Fatalf("first payload code = %s, want rate_limit_exceeded", got)
-	}
-
-	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
-		t.Fatalf("write second websocket message: %v", errWrite)
-	}
-	_, secondPayload, errReadSecond := conn.ReadMessage()
-	if errReadSecond != nil {
-		t.Fatalf("read second websocket message: %v", errReadSecond)
-	}
-	if got := gjson.GetBytes(secondPayload, "type").String(); got != wsEventTypeCompleted {
-		t.Fatalf("second payload type = %s, want %s", got, wsEventTypeCompleted)
-	}
-
-	if got := executor.AuthIDs(); len(got) != 2 || got[0] != "auth-1" || got[1] != "auth-2" {
-		t.Fatalf("selected auth IDs = %v, want [auth-1 auth-2]", got)
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -401,7 +401,7 @@ func TestShouldResetResponsesWebsocketAuthPin(t *testing.T) {
 		{name: "too_many_requests", statusCode: http.StatusTooManyRequests, want: true},
 		{name: "forbidden", statusCode: http.StatusForbidden, want: true},
 		{name: "payment_required", statusCode: http.StatusPaymentRequired, want: true},
-		{name: "unauthorized", statusCode: http.StatusUnauthorized, want: false},
+		{name: "unauthorized", statusCode: http.StatusUnauthorized, want: true},
 		{name: "internal_error", statusCode: http.StatusInternalServerError, want: false},
 		{name: "zero", statusCode: 0, want: false},
 	}


### PR DESCRIPTION
## 问题
- Codex WebSocket 会话中账号被固定
- 账号额度耗尽后后续请求仍反复命中同一账号

## 修复
- 限额类错误后解除会话 pin 并关闭旧 execution session
- execution session 内 auth 变化时强制重建上游 websocket 连接

## 验证
- 新增会话内 429 后切号回归测试
- 新增 auth 切换触发重连回归测试
- 相关包测试通过

## 关联
- Closes #2230