### PR TITLE
feat: add portless-style local routing

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -74,6 +74,14 @@ func main() {
 	var password string
 	var tuiMode bool
 	var standalone bool
+	var localRouting bool
+	var localName string
+	var localTLD string
+	var localEdgePort int
+	var localHTTPS bool
+	var localAppPort int
+	var localStateDir string
+	var localForce bool
 
 	// Define command-line flags for different operation modes.
 	flag.BoolVar(&login, "login", false, "Login Google Account")
@@ -93,6 +101,14 @@ func main() {
 	flag.StringVar(&password, "password", "", "")
 	flag.BoolVar(&tuiMode, "tui", false, "Start with terminal management UI")
 	flag.BoolVar(&standalone, "standalone", false, "In TUI mode, start an embedded local server")
+	flag.BoolVar(&localRouting, "local-routing", false, "Enable named local routing mode")
+	flag.StringVar(&localName, "local-name", "", "Override local route name in named local routing mode")
+	flag.StringVar(&localTLD, "local-tld", "", "Override local route TLD in named local routing mode")
+	flag.IntVar(&localEdgePort, "local-edge-port", 0, "Override edge proxy port in named local routing mode")
+	flag.BoolVar(&localHTTPS, "local-https", false, "Enable HTTPS URL mode for named local routing")
+	flag.IntVar(&localAppPort, "local-app-port", 0, "Pin backend app port in named local routing mode")
+	flag.StringVar(&localStateDir, "local-state-dir", "", "Override local routing state directory")
+	flag.BoolVar(&localForce, "local-force", false, "Force takeover when a local route is already owned")
 
 	flag.CommandLine.Usage = func() {
 		out := flag.CommandLine.Output()
@@ -394,6 +410,32 @@ func main() {
 	if cfg == nil {
 		cfg = &config.Config{}
 	}
+	cfg.SanitizeLocalRouting()
+	if localRouting {
+		cfg.LocalRouting.Enabled = true
+	}
+	if trimmed := strings.TrimSpace(localName); trimmed != "" {
+		cfg.LocalRouting.Name = trimmed
+	}
+	if trimmed := strings.TrimSpace(localTLD); trimmed != "" {
+		cfg.LocalRouting.TLD = trimmed
+	}
+	if localEdgePort > 0 {
+		cfg.LocalRouting.EdgePort = localEdgePort
+	}
+	if localHTTPS {
+		cfg.LocalRouting.HTTPS = true
+	}
+	if localAppPort > 0 {
+		cfg.LocalRouting.AppPort = localAppPort
+	}
+	if trimmed := strings.TrimSpace(localStateDir); trimmed != "" {
+		cfg.LocalRouting.StateDir = trimmed
+	}
+	if localForce {
+		cfg.LocalRouting.Force = true
+	}
+	cfg.SanitizeLocalRouting()
 
 	// In cloud deploy mode, check if we have a valid configuration
 	var configFileExists bool

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,6 +5,20 @@ host: ""
 # Server port
 port: 8317
 
+# Optional named local routing mode (portless-style).
+# When enabled, CLIProxyAPI binds to a local backend port and registers a stable
+# host like "<name>.localhost" on an edge proxy port.
+local-routing:
+  enabled: false
+  name: "" # optional explicit name; defaults to folder name (worktree branch prefix when detected)
+  tld: "localhost"
+  edge-port: 1355
+  https: false
+  app-port: 0 # 0 = auto-assign in 4000-4999 range
+  state-dir: "" # default: ~/.cliproxyapi/portless (or /tmp fallback)
+  force: false # overwrite routes registered by another running process
+  display-oauth-url: false # optional UX hint for OAuth flows
+
 # TLS settings for HTTPS. When enabled, the server listens with the provided certificate and key.
 tls:
   enable: false

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -29,6 +29,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/localrouting"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -231,7 +232,26 @@ func (h *Handler) managementCallbackURL(path string) (string, error) {
 	if h.cfg.TLS.Enable {
 		scheme = "https"
 	}
-	return fmt.Sprintf("%s://127.0.0.1:%d%s", scheme, h.cfg.Port, path), nil
+	target := fmt.Sprintf("%s://127.0.0.1:%d%s", scheme, h.cfg.Port, path)
+	if h.cfg.LocalRouting.Enabled && h.cfg.LocalRouting.DisplayOAuthURL {
+		lrCfg := localrouting.BuildConfig(
+			h.cfg.LocalRouting.Enabled,
+			h.cfg.LocalRouting.Name,
+			h.cfg.LocalRouting.TLD,
+			h.cfg.LocalRouting.EdgePort,
+			h.cfg.LocalRouting.HTTPS,
+			h.cfg.LocalRouting.AppPort,
+			h.cfg.LocalRouting.StateDir,
+			h.cfg.LocalRouting.Force,
+			h.cfg.LocalRouting.DisplayOAuthURL,
+		)
+		status := localrouting.LoadStatusFromConfig(lrCfg)
+		if status.Host != "" && status.EdgePort > 0 {
+			displayBase := localrouting.BuildURL(status.HTTPS, status.Host, status.EdgePort)
+			log.Infof("oauth callback named URL hint: %s%s", strings.TrimSuffix(displayBase, "/"), path)
+		}
+	}
+	return target, nil
 }
 
 func (h *Handler) ListAuthFiles(c *gin.Context) {

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/localrouting"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -48,6 +49,7 @@ type Handler struct {
 	envSecret           string
 	logDir              string
 	postAuthHook        coreauth.PostAuthHook
+	localRouting        *localrouting.Runtime
 }
 
 // NewHandler creates a new management handler instance.
@@ -132,6 +134,11 @@ func (h *Handler) SetLogDirectory(dir string) {
 // SetPostAuthHook registers a hook to be called after auth record creation but before persistence.
 func (h *Handler) SetPostAuthHook(hook coreauth.PostAuthHook) {
 	h.postAuthHook = hook
+}
+
+// SetLocalRoutingRuntime binds local routing runtime for management status inspection.
+func (h *Handler) SetLocalRoutingRuntime(runtime *localrouting.Runtime) {
+	h.localRouting = runtime
 }
 
 // Middleware enforces access control for management endpoints.

--- a/internal/api/handlers/management/local_routing.go
+++ b/internal/api/handlers/management/local_routing.go
@@ -1,0 +1,111 @@
+package management
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/localrouting"
+)
+
+func (h *Handler) localRoutingConfig() localrouting.Config {
+	if h == nil || h.cfg == nil {
+		return localrouting.BuildConfig(false, "", "localhost", localrouting.DefaultEdgePort, false, 0, "", false, false)
+	}
+	cfg := h.cfg.LocalRouting
+	return localrouting.BuildConfig(
+		cfg.Enabled,
+		cfg.Name,
+		cfg.TLD,
+		cfg.EdgePort,
+		cfg.HTTPS,
+		cfg.AppPort,
+		cfg.StateDir,
+		cfg.Force,
+		cfg.DisplayOAuthURL,
+	)
+}
+
+// GetLocalRoutingStatus returns runtime status for local named routing.
+func (h *Handler) GetLocalRoutingStatus(c *gin.Context) {
+	cfg := h.localRoutingConfig()
+	status := localrouting.LoadStatusFromConfig(cfg)
+	if h != nil && h.localRouting != nil {
+		status = h.localRouting.Status()
+	}
+	if status.StateDir != "" {
+		if pid := localrouting.ReadEdgePID(status.StateDir); pid > 0 {
+			status.EdgeOwnerPID = pid
+		}
+	}
+	c.JSON(http.StatusOK, status)
+}
+
+// GetLocalRoutingRoutes lists persisted local routes.
+func (h *Handler) GetLocalRoutingRoutes(c *gin.Context) {
+	cfg := h.localRoutingConfig()
+	stateDir := localrouting.ResolveStateDir(cfg.StateDir, cfg.EdgePort)
+	store := localrouting.NewRouteStore(stateDir, cfg.EdgePort)
+	routes, errList := store.List()
+	if errList != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": errList.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"routes": routes})
+}
+
+// PostLocalRoutingSyncHosts optionally adds current routes to /etc/hosts.
+func (h *Handler) PostLocalRoutingSyncHosts(c *gin.Context) {
+	cfg := h.localRoutingConfig()
+	if strings.EqualFold(localrouting.NormalizeTLD(cfg.TLD), "localhost") {
+		c.JSON(http.StatusOK, gin.H{"status": "skipped", "message": "tld localhost does not require hosts sync"})
+		return
+	}
+	stateDir := localrouting.ResolveStateDir(cfg.StateDir, cfg.EdgePort)
+	store := localrouting.NewRouteStore(stateDir, cfg.EdgePort)
+	routes, errList := store.List()
+	if errList != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": errList.Error()})
+		return
+	}
+	if errSync := syncHostsFile(routes); errSync != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": errSync.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "routes": len(routes)})
+}
+
+func syncHostsFile(routes []localrouting.RouteInfo) error {
+	const beginMarker = "# BEGIN cliproxyapi-local-routing"
+	const endMarker = "# END cliproxyapi-local-routing"
+	const hostsPath = "/etc/hosts"
+
+	payload, errRead := os.ReadFile(hostsPath)
+	if errRead != nil {
+		return errRead
+	}
+	content := string(payload)
+	start := strings.Index(content, beginMarker)
+	end := strings.Index(content, endMarker)
+	if start >= 0 && end > start {
+		end += len(endMarker)
+		content = strings.TrimSpace(content[:start]) + "\n"
+	}
+	var b strings.Builder
+	b.WriteString(strings.TrimSpace(content))
+	b.WriteString("\n\n")
+	b.WriteString(beginMarker)
+	b.WriteString("\n")
+	for _, route := range routes {
+		if strings.TrimSpace(route.Host) == "" {
+			continue
+		}
+		b.WriteString("127.0.0.1\t")
+		b.WriteString(route.Host)
+		b.WriteString("\n")
+	}
+	b.WriteString(endMarker)
+	b.WriteString("\n")
+	return os.WriteFile(hostsPath, []byte(b.String()), 0o644)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/modules"
 	ampmodule "github.com/router-for-me/CLIProxyAPI/v6/internal/api/modules/amp"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/localrouting"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/managementasset"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -176,6 +177,8 @@ type Server struct {
 	keepAliveOnTimeout func()
 	keepAliveHeartbeat chan struct{}
 	keepAliveStop      chan struct{}
+
+	localRouting *localrouting.Runtime
 }
 
 // NewServer creates and initializes a new API server instance.
@@ -272,6 +275,7 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 		s.mgmt.SetPostAuthHook(optionState.postAuthHook)
 	}
 	s.localPassword = optionState.localPassword
+	s.mgmt.SetLocalRoutingRuntime(nil)
 
 	// Setup routes
 	s.setupRoutes()
@@ -312,6 +316,17 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	}
 
 	return s
+}
+
+// SetLocalRoutingRuntime binds local routing runtime data for management endpoints.
+func (s *Server) SetLocalRoutingRuntime(runtime *localrouting.Runtime) {
+	if s == nil {
+		return
+	}
+	s.localRouting = runtime
+	if s.mgmt != nil {
+		s.mgmt.SetLocalRoutingRuntime(runtime)
+	}
 }
 
 // setupRoutes configures the API routes for the server.
@@ -550,6 +565,9 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/ws-auth", s.mgmt.GetWebsocketAuth)
 		mgmt.PUT("/ws-auth", s.mgmt.PutWebsocketAuth)
 		mgmt.PATCH("/ws-auth", s.mgmt.PutWebsocketAuth)
+		mgmt.GET("/local-routing/status", s.mgmt.GetLocalRoutingStatus)
+		mgmt.GET("/local-routing/routes", s.mgmt.GetLocalRoutingRoutes)
+		mgmt.POST("/local-routing/sync-hosts", s.mgmt.PostLocalRoutingSyncHosts)
 
 		mgmt.GET("/ampcode", s.mgmt.GetAmpCode)
 		mgmt.GET("/ampcode/upstream-url", s.mgmt.GetAmpUpstreamURL)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,9 @@ type Config struct {
 	// Port is the network port on which the API server will listen.
 	Port int `yaml:"port" json:"-"`
 
+	// LocalRouting controls optional named local routing mode.
+	LocalRouting LocalRoutingConfig `yaml:"local-routing" json:"local-routing"`
+
 	// TLS config controls HTTPS server settings.
 	TLS TLSConfig `yaml:"tls" json:"tls"`
 
@@ -153,6 +156,19 @@ type TLSConfig struct {
 	Cert string `yaml:"cert" json:"cert"`
 	// Key is the path to the TLS private key file.
 	Key string `yaml:"key" json:"key"`
+}
+
+// LocalRoutingConfig controls optional local named routing mode.
+type LocalRoutingConfig struct {
+	Enabled         bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Name            string `yaml:"name,omitempty" json:"name,omitempty"`
+	TLD             string `yaml:"tld,omitempty" json:"tld,omitempty"`
+	EdgePort        int    `yaml:"edge-port,omitempty" json:"edge-port,omitempty"`
+	HTTPS           bool   `yaml:"https,omitempty" json:"https,omitempty"`
+	AppPort         int    `yaml:"app-port,omitempty" json:"app-port,omitempty"`
+	StateDir        string `yaml:"state-dir,omitempty" json:"state-dir,omitempty"`
+	Force           bool   `yaml:"force,omitempty" json:"force,omitempty"`
+	DisplayOAuthURL bool   `yaml:"display-oauth-url,omitempty" json:"display-oauth-url,omitempty"`
 }
 
 // PprofConfig holds pprof HTTP server settings.
@@ -549,6 +565,8 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	var cfg Config
 	// Set defaults before unmarshal so that absent keys keep defaults.
 	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
+	cfg.LocalRouting.TLD = "localhost"
+	cfg.LocalRouting.EdgePort = 1355
 	cfg.LoggingToFile = false
 	cfg.LogsMaxTotalSizeMB = 0
 	cfg.ErrorLogsMaxFiles = 10
@@ -645,6 +663,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Validate raw payload rules and drop invalid entries.
 	cfg.SanitizePayloadRules()
 
+	// Normalize local routing settings.
+	cfg.SanitizeLocalRouting()
+
 	// NOTE: Legacy migration persistence is intentionally disabled together with
 	// startup legacy migration to keep startup read-only for config.yaml.
 	// Re-enable the block below if automatic startup migration is needed again.
@@ -662,6 +683,25 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	// Return the populated configuration struct.
 	return &cfg, nil
+}
+
+// SanitizeLocalRouting normalizes local routing config values.
+func (cfg *Config) SanitizeLocalRouting() {
+	if cfg == nil {
+		return
+	}
+	cfg.LocalRouting.Name = strings.TrimSpace(cfg.LocalRouting.Name)
+	cfg.LocalRouting.TLD = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(cfg.LocalRouting.TLD)), ".")
+	if cfg.LocalRouting.TLD == "" {
+		cfg.LocalRouting.TLD = "localhost"
+	}
+	cfg.LocalRouting.StateDir = strings.TrimSpace(cfg.LocalRouting.StateDir)
+	if cfg.LocalRouting.EdgePort <= 0 {
+		cfg.LocalRouting.EdgePort = 1355
+	}
+	if cfg.LocalRouting.AppPort < 0 {
+		cfg.LocalRouting.AppPort = 0
+	}
 }
 
 // SanitizePayloadRules validates raw JSON payload rule params and drops invalid rules.

--- a/internal/localrouting/certs.go
+++ b/internal/localrouting/certs.go
@@ -1,0 +1,280 @@
+package localrouting
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+type CertAssets struct {
+	CACertPath string
+	CertPath   string
+	KeyPath    string
+}
+
+type CertManager struct {
+	stateDir string
+	store    *RouteStore
+	mu       sync.Mutex
+}
+
+func NewCertManager(stateDir string, store *RouteStore) *CertManager {
+	return &CertManager{stateDir: stateDir, store: store}
+}
+
+func (m *CertManager) EnsureRouteCert(host string) (CertAssets, error) {
+	if m == nil {
+		return CertAssets{}, fmt.Errorf("cert manager is nil")
+	}
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return CertAssets{}, fmt.Errorf("host is required")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := os.MkdirAll(m.certDir(), 0o755); err != nil {
+		return CertAssets{}, fmt.Errorf("create cert dir: %w", err)
+	}
+	caCert, caKey, caAssets, err := m.ensureCA()
+	if err != nil {
+		return CertAssets{}, err
+	}
+	assets := m.routeAssets(host)
+	if certValidForHost(assets.CertPath, host) {
+		assets.CACertPath = caAssets.CACertPath
+		return assets, nil
+	}
+	leafDER, keyPEM, certPEM, err := issueLeafCert(host, caCert, caKey)
+	if err != nil {
+		return CertAssets{}, err
+	}
+	_ = leafDER
+	if err := os.WriteFile(assets.KeyPath, keyPEM, 0o600); err != nil {
+		return CertAssets{}, fmt.Errorf("write leaf key: %w", err)
+	}
+	if err := os.WriteFile(assets.CertPath, certPEM, 0o644); err != nil {
+		return CertAssets{}, fmt.Errorf("write leaf cert: %w", err)
+	}
+	assets.CACertPath = caAssets.CACertPath
+	return assets, nil
+}
+
+func (m *CertManager) TLSConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			host := normalizeRequestHost(chi.ServerName)
+			if host == "" && chi.Conn != nil {
+				host = normalizeRequestHost(chi.Conn.LocalAddr().String())
+			}
+			if host == "" {
+				routes, err := m.store.List()
+				if err == nil && len(routes) > 0 {
+					host = routes[0].Host
+				}
+			}
+			if host == "" {
+				return nil, fmt.Errorf("missing server name")
+			}
+			routes, err := m.store.List()
+			if err == nil {
+				if route, ok := findRoute(host, routes); ok {
+					host = route.Host
+				}
+			}
+			assets, err := m.EnsureRouteCert(host)
+			if err != nil {
+				return nil, err
+			}
+			cert, err := tls.LoadX509KeyPair(assets.CertPath, assets.KeyPath)
+			if err != nil {
+				return nil, fmt.Errorf("load key pair: %w", err)
+			}
+			return &cert, nil
+		},
+	}
+}
+
+func (m *CertManager) CAPath() string {
+	return filepath.Join(m.certDir(), "ca.pem")
+}
+
+func (m *CertManager) certDir() string {
+	return filepath.Join(m.stateDir, "certs")
+}
+
+func (m *CertManager) ensureCA() (*x509.Certificate, *rsa.PrivateKey, CertAssets, error) {
+	caCertPath := filepath.Join(m.certDir(), "ca.pem")
+	caKeyPath := filepath.Join(m.certDir(), "ca.key")
+	if cert, key, ok := loadCA(caCertPath, caKeyPath); ok {
+		return cert, key, CertAssets{CACertPath: caCertPath}, nil
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, CertAssets{}, fmt.Errorf("generate ca key: %w", err)
+	}
+	serial, err := randSerial()
+	if err != nil {
+		return nil, nil, CertAssets{}, err
+	}
+	tpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "CLIProxyAPI Local Routing CA", Organization: []string{"CLIProxyAPI"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(3650 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            1,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, CertAssets{}, fmt.Errorf("create ca cert: %w", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	if err := os.WriteFile(caCertPath, certPEM, 0o644); err != nil {
+		return nil, nil, CertAssets{}, fmt.Errorf("write ca cert: %w", err)
+	}
+	if err := os.WriteFile(caKeyPath, keyPEM, 0o600); err != nil {
+		return nil, nil, CertAssets{}, fmt.Errorf("write ca key: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, CertAssets{}, fmt.Errorf("parse ca cert: %w", err)
+	}
+	return cert, key, CertAssets{CACertPath: caCertPath}, nil
+}
+
+func (m *CertManager) routeAssets(host string) CertAssets {
+	sum := sha1.Sum([]byte(host))
+	token := hex.EncodeToString(sum[:8])
+	base := fmt.Sprintf("%s-%s", SanitizeLabel(strings.ReplaceAll(host, ".", "-")), token)
+	return CertAssets{
+		CertPath: filepath.Join(m.certDir(), base+".pem"),
+		KeyPath:  filepath.Join(m.certDir(), base+".key"),
+	}
+}
+
+func loadCA(certPath, keyPath string) (*x509.Certificate, *rsa.PrivateKey, bool) {
+	certPEM, errCert := os.ReadFile(certPath)
+	keyPEM, errKey := os.ReadFile(keyPath)
+	if errCert != nil || errKey != nil {
+		return nil, nil, false
+	}
+	certBlock, _ := pem.Decode(certPEM)
+	keyBlock, _ := pem.Decode(keyPEM)
+	if certBlock == nil || keyBlock == nil {
+		return nil, nil, false
+	}
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, nil, false
+	}
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, nil, false
+	}
+	return cert, key, true
+}
+
+func issueLeafCert(host string, caCert *x509.Certificate, caKey *rsa.PrivateKey) ([]byte, []byte, []byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("generate leaf key: %w", err)
+	}
+	serial, err := randSerial()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	names := []string{host}
+	if !strings.HasPrefix(host, "*.") {
+		names = append(names, "*."+host)
+	}
+	tpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: host,
+		},
+		NotBefore:   time.Now().Add(-time.Hour),
+		NotAfter:    time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:    names,
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		tpl.IPAddresses = []net.IP{ip}
+		tpl.DNSNames = nil
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("create leaf cert: %w", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	certPEM = append(certPEM, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw})...)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return der, keyPEM, certPEM, nil
+}
+
+func certValidForHost(certPath, host string) bool {
+	payload, err := os.ReadFile(certPath)
+	if err != nil {
+		return false
+	}
+	block, _ := pem.Decode(payload)
+	if block == nil {
+		return false
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false
+	}
+	if cert.VerifyHostname(host) != nil {
+		return false
+	}
+	wantWildcard := "*." + host
+	for _, name := range cert.DNSNames {
+		if strings.EqualFold(name, wantWildcard) {
+			return true
+		}
+	}
+	return false
+}
+
+func randSerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, fmt.Errorf("generate serial: %w", err)
+	}
+	return serial, nil
+}
+
+func TrustInstallCommand(caCertPath string) string {
+	switch runtime.GOOS {
+	case "darwin":
+		return fmt.Sprintf("sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain %q", caCertPath)
+	case "linux":
+		return fmt.Sprintf("sudo cp %q /usr/local/share/ca-certificates/cliproxyapi-local-routing.crt && sudo update-ca-certificates", caCertPath)
+	case "windows":
+		return fmt.Sprintf("certutil -addstore Root %q", caCertPath)
+	default:
+		return ""
+	}
+}

--- a/internal/localrouting/certs_test.go
+++ b/internal/localrouting/certs_test.go
@@ -1,0 +1,50 @@
+package localrouting
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"testing"
+)
+
+func TestEnsureRouteCertCreatesCAAndLeaf(t *testing.T) {
+	store := NewRouteStore(t.TempDir(), 1355)
+	manager := NewCertManager(store.StateDir(), store)
+
+	assets, err := manager.EnsureRouteCert("app.localhost")
+	if err != nil {
+		t.Fatalf("EnsureRouteCert: %v", err)
+	}
+	if assets.CACertPath == "" || assets.CertPath == "" || assets.KeyPath == "" {
+		t.Fatal("expected cert asset paths")
+	}
+	if _, err := os.Stat(assets.CACertPath); err != nil {
+		t.Fatalf("stat ca cert: %v", err)
+	}
+
+	payload, err := os.ReadFile(assets.CertPath)
+	if err != nil {
+		t.Fatalf("read leaf cert: %v", err)
+	}
+	block, _ := pem.Decode(payload)
+	if block == nil {
+		t.Fatal("decode pem leaf cert")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse leaf cert: %v", err)
+	}
+	if err := cert.VerifyHostname("app.localhost"); err != nil {
+		t.Fatalf("verify exact host: %v", err)
+	}
+	if err := cert.VerifyHostname("tenant.app.localhost"); err != nil {
+		t.Fatalf("verify wildcard host: %v", err)
+	}
+}
+
+func TestTrustInstallCommand(t *testing.T) {
+	cmd := TrustInstallCommand("/tmp/ca.pem")
+	if cmd == "" {
+		t.Fatal("expected trust install command")
+	}
+}

--- a/internal/localrouting/pid_other.go
+++ b/internal/localrouting/pid_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package localrouting
+
+func processAlive(pid int) bool {
+	return pid > 0
+}

--- a/internal/localrouting/pid_unix.go
+++ b/internal/localrouting/pid_unix.go
@@ -1,0 +1,16 @@
+//go:build darwin || linux
+
+package localrouting
+
+import (
+	"errors"
+	"syscall"
+)
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/internal/localrouting/ports.go
+++ b/internal/localrouting/ports.go
@@ -1,0 +1,27 @@
+package localrouting
+
+import (
+	"fmt"
+	"net"
+)
+
+func FindFreePort(minPort, maxPort int) (int, error) {
+	if minPort <= 0 {
+		minPort = MinAppPort
+	}
+	if maxPort <= 0 {
+		maxPort = MaxAppPort
+	}
+	if minPort > maxPort {
+		return 0, fmt.Errorf("invalid port range: %d-%d", minPort, maxPort)
+	}
+	for port := minPort; port <= maxPort; port++ {
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			continue
+		}
+		_ = ln.Close()
+		return port, nil
+	}
+	return 0, fmt.Errorf("no available port in range %d-%d", minPort, maxPort)
+}

--- a/internal/localrouting/ports_test.go
+++ b/internal/localrouting/ports_test.go
@@ -1,0 +1,13 @@
+package localrouting
+
+import "testing"
+
+func TestFindFreePort(t *testing.T) {
+	port, errFind := FindFreePort(4900, 4910)
+	if errFind != nil {
+		t.Fatalf("find free port: %v", errFind)
+	}
+	if port < 4900 || port > 4910 {
+		t.Fatalf("port = %d, out of range", port)
+	}
+}

--- a/internal/localrouting/proxy.go
+++ b/internal/localrouting/proxy.go
@@ -1,0 +1,190 @@
+package localrouting
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type EdgeProxy struct {
+	store    *RouteStore
+	edgePort int
+	https    bool
+	certs    *CertManager
+
+	mu       sync.Mutex
+	server   *http.Server
+	listener net.Listener
+	owner    bool
+}
+
+func NewEdgeProxy(store *RouteStore, edgePort int, https bool) *EdgeProxy {
+	if edgePort <= 0 {
+		edgePort = DefaultEdgePort
+	}
+	stateDir := ""
+	if store != nil {
+		stateDir = store.StateDir()
+	}
+	return &EdgeProxy{
+		store:    store,
+		edgePort: edgePort,
+		https:    https,
+		certs:    NewCertManager(stateDir, store),
+	}
+}
+
+func (p *EdgeProxy) StartOrReuse() (bool, error) {
+	if p == nil {
+		return false, fmt.Errorf("edge proxy is nil")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.server != nil {
+		return p.owner, nil
+	}
+	ln, errListen := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", p.edgePort))
+	if errListen != nil {
+		if strings.Contains(strings.ToLower(errListen.Error()), "address already in use") {
+			p.owner = false
+			return false, nil
+		}
+		return false, errListen
+	}
+	handler := &edgeHandler{store: p.store, edgePort: p.edgePort}
+	server := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	if p.https {
+		server.TLSConfig = p.certs.TLSConfig()
+	}
+	p.server = server
+	p.listener = ln
+	p.owner = true
+	_ = os.WriteFile(filepathJoin(p.store.StateDir(), "edge.pid"), []byte(strconv.Itoa(os.Getpid())), 0o644)
+	go func() {
+		if p.https {
+			tlsListener := tls.NewListener(ln, server.TLSConfig)
+			_ = server.Serve(tlsListener)
+			return
+		}
+		_ = server.Serve(ln)
+	}()
+	return true, nil
+}
+
+func (p *EdgeProxy) Stop(ctx context.Context) error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	server := p.server
+	owner := p.owner
+	p.server = nil
+	p.listener = nil
+	p.owner = false
+	p.mu.Unlock()
+	if server == nil || !owner {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_ = os.Remove(filepathJoin(p.store.StateDir(), "edge.pid"))
+	return server.Shutdown(ctx)
+}
+
+type edgeHandler struct {
+	store    *RouteStore
+	edgePort int
+}
+
+func (h *edgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.store == nil {
+		http.Error(w, "local routing is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if strings.EqualFold(strings.TrimSpace(r.Header.Get("X-CLIProxyAPI-Local-Routing-Hop")), "1") {
+		w.WriteHeader(http.StatusLoopDetected)
+		_, _ = w.Write([]byte("loop detected: your proxy target likely preserved the original host header; enable host rewrite/changeOrigin"))
+		return
+	}
+	host := normalizeRequestHost(r.Host)
+	routes, errList := h.store.List()
+	if errList != nil {
+		http.Error(w, "failed to load local routes", http.StatusBadGateway)
+		return
+	}
+	route, ok := findRoute(host, routes)
+	if !ok {
+		http.Error(w, "unknown local route", http.StatusNotFound)
+		return
+	}
+	if route.TargetPort == h.edgePort && strings.EqualFold(route.TargetHost, "127.0.0.1") {
+		w.WriteHeader(http.StatusLoopDetected)
+		_, _ = w.Write([]byte("loop detected: route points back to edge proxy"))
+		return
+	}
+	targetURL := &url.URL{Scheme: "http", Host: net.JoinHostPort(route.TargetHost, strconv.Itoa(route.TargetPort))}
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		req.Host = route.TargetHost + ":" + strconv.Itoa(route.TargetPort)
+		req.Header.Set("X-CLIProxyAPI-Local-Routing-Hop", "1")
+	}
+	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, _ error) {
+		http.Error(w, "route backend unavailable", http.StatusBadGateway)
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+func normalizeRequestHost(raw string) string {
+	host := strings.ToLower(strings.TrimSpace(raw))
+	if host == "" {
+		return ""
+	}
+	if strings.Contains(host, ":") {
+		if parsedHost, _, errSplit := net.SplitHostPort(host); errSplit == nil {
+			host = parsedHost
+		} else {
+			host = strings.Split(host, ":")[0]
+		}
+	}
+	return strings.Trim(host, ".")
+}
+
+func findRoute(host string, routes []RouteInfo) (RouteInfo, bool) {
+	for i := range routes {
+		if strings.EqualFold(host, routes[i].Host) {
+			return routes[i], true
+		}
+	}
+	for i := range routes {
+		h := strings.ToLower(strings.TrimSpace(routes[i].Host))
+		if h == "" {
+			continue
+		}
+		if strings.HasSuffix(host, "."+h) {
+			return routes[i], true
+		}
+	}
+	return RouteInfo{}, false
+}
+
+func filepathJoin(base, name string) string {
+	if strings.TrimSpace(base) == "" {
+		return name
+	}
+	return base + string(os.PathSeparator) + name
+}

--- a/internal/localrouting/proxy_test.go
+++ b/internal/localrouting/proxy_test.go
@@ -1,0 +1,23 @@
+package localrouting
+
+import "testing"
+
+func TestFindRouteWildcard(t *testing.T) {
+	routes := []RouteInfo{{Host: "myapp.localhost", TargetHost: "127.0.0.1", TargetPort: 4100}}
+	if _, ok := findRoute("myapp.localhost", routes); !ok {
+		t.Fatal("expected exact route")
+	}
+	route, ok := findRoute("tenant1.myapp.localhost", routes)
+	if !ok {
+		t.Fatal("expected wildcard route")
+	}
+	if route.TargetPort != 4100 {
+		t.Fatalf("target_port = %d, want 4100", route.TargetPort)
+	}
+}
+
+func TestNormalizeRequestHost(t *testing.T) {
+	if got := normalizeRequestHost("MyApp.Localhost:1355"); got != "myapp.localhost" {
+		t.Fatalf("normalizeRequestHost = %q", got)
+	}
+}

--- a/internal/localrouting/runtime.go
+++ b/internal/localrouting/runtime.go
@@ -1,0 +1,266 @@
+package localrouting
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Runtime struct {
+	store  *RouteStore
+	edge   *EdgeProxy
+	route  RouteInfo
+	status Status
+	owner  bool
+	closed bool
+	mu     sync.Mutex
+}
+
+var (
+	activeMu     sync.RWMutex
+	activeStatus Status
+)
+
+func ActiveStatus() Status {
+	activeMu.RLock()
+	defer activeMu.RUnlock()
+	return activeStatus
+}
+
+func setActiveStatus(status Status) {
+	activeMu.Lock()
+	activeStatus = status
+	activeMu.Unlock()
+}
+
+func BuildConfig(enabled bool, name, tld string, edgePort int, https bool, appPort int, stateDir string, force bool, displayOAuth bool) Config {
+	if edgePort <= 0 {
+		edgePort = DefaultEdgePort
+	}
+	if tld == "" {
+		tld = "localhost"
+	}
+	return Config{
+		Enabled:      enabled,
+		Name:         name,
+		TLD:          tld,
+		EdgePort:     edgePort,
+		HTTPS:        https,
+		AppPort:      appPort,
+		StateDir:     stateDir,
+		Force:        force,
+		DisplayOAuth: displayOAuth,
+	}
+}
+
+func Start(cfg Config, backendHost string, backendPort int) (*Runtime, error) {
+	if !cfg.Enabled {
+		setActiveStatus(Status{Enabled: false, UpdatedAt: time.Now().UTC()})
+		return nil, nil
+	}
+	if backendPort <= 0 {
+		return nil, fmt.Errorf("local routing backend port is invalid")
+	}
+	if strings.TrimSpace(backendHost) == "" {
+		backendHost = "127.0.0.1"
+	}
+	name := InferRouteName(cfg.Name)
+	tld := NormalizeTLD(cfg.TLD)
+	host := BuildHost(name, tld)
+	store := NewRouteStore(cfg.StateDir, cfg.EdgePort)
+	edge := NewEdgeProxy(store, cfg.EdgePort, cfg.HTTPS)
+	owner, errStart := edge.StartOrReuse()
+	if errStart != nil {
+		return nil, errStart
+	}
+	route, errRegister := store.Register(RouteInfo{
+		Name:       name,
+		BaseName:   name,
+		Host:       host,
+		TargetHost: backendHost,
+		TargetPort: backendPort,
+		PID:        os.Getpid(),
+		Command:    strings.Join(os.Args, " "),
+	}, cfg.Force)
+	if errRegister != nil {
+		if owner {
+			_ = edge.Stop(context.Background())
+		}
+		return nil, errRegister
+	}
+	status := Status{
+		Enabled:      true,
+		URL:          BuildURL(cfg.HTTPS, host, cfg.EdgePort),
+		Name:         name,
+		Host:         host,
+		TLD:          tld,
+		EdgePort:     cfg.EdgePort,
+		BackendHost:  backendHost,
+		BackendPort:  backendPort,
+		HTTPS:        cfg.HTTPS,
+		StateDir:     store.StateDir(),
+		UpdatedAt:    time.Now().UTC(),
+		EdgeOwnerPID: 0,
+	}
+	if cfg.HTTPS {
+		status.CACertPath = edge.certs.CAPath()
+		status.TrustCommand = TrustInstallCommand(status.CACertPath)
+	}
+	if owner {
+		status.EdgeOwnerPID = os.Getpid()
+	}
+	setActiveStatus(status)
+	return &Runtime{store: store, edge: edge, route: route, status: status, owner: owner}, nil
+}
+
+func (r *Runtime) Status() Status {
+	if r == nil {
+		return ActiveStatus()
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.status
+}
+
+func (r *Runtime) ListRoutes() ([]RouteInfo, error) {
+	if r == nil || r.store == nil {
+		status := ActiveStatus()
+		store := NewRouteStore(status.StateDir, status.EdgePort)
+		return store.List()
+	}
+	return r.store.List()
+}
+
+func (r *Runtime) Close(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closed = true
+	store := r.store
+	edge := r.edge
+	route := r.route
+	owner := r.owner
+	r.mu.Unlock()
+
+	if store != nil {
+		_ = store.Unregister(route.Host, os.Getpid())
+	}
+	if owner && edge != nil {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		_ = edge.Stop(ctx)
+	}
+	setActiveStatus(Status{Enabled: false, UpdatedAt: time.Now().UTC()})
+	return nil
+}
+
+func InferRouteName(override string) string {
+	if trimmed := SanitizeLabel(override); strings.TrimSpace(override) != "" {
+		return trimmed
+	}
+	cwd, errCwd := os.Getwd()
+	base := "cliproxyapi"
+	if errCwd == nil {
+		base = SanitizeLabel(filepath.Base(cwd))
+	}
+	prefix := inferWorktreePrefix()
+	if prefix == "" {
+		return base
+	}
+	return SanitizeLabel(prefix + "-" + base)
+}
+
+func inferWorktreePrefix() string {
+	gitDir := strings.TrimSpace(runGit("rev-parse", "--git-dir"))
+	commonDir := strings.TrimSpace(runGit("rev-parse", "--git-common-dir"))
+	if gitDir == "" || commonDir == "" {
+		return ""
+	}
+	absGitDir, errGitDir := filepath.Abs(gitDir)
+	absCommonDir, errCommon := filepath.Abs(commonDir)
+	if errGitDir != nil || errCommon != nil {
+		return ""
+	}
+	if absGitDir == absCommonDir {
+		return ""
+	}
+	if !strings.Contains(absGitDir, string(filepath.Separator)+"worktrees"+string(filepath.Separator)) {
+		return ""
+	}
+	branch := strings.TrimSpace(runGit("rev-parse", "--abbrev-ref", "HEAD"))
+	if branch == "" || branch == "HEAD" {
+		return ""
+	}
+	return SanitizeLabel(branch)
+}
+
+func runGit(args ...string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+func LoadStatusFromConfig(cfg Config) Status {
+	status := ActiveStatus()
+	if status.Enabled {
+		return status
+	}
+	edgePort := cfg.EdgePort
+	if edgePort <= 0 {
+		edgePort = DefaultEdgePort
+	}
+	stateDir := ResolveStateDir(cfg.StateDir, edgePort)
+	host := BuildHost(InferRouteName(cfg.Name), cfg.TLD)
+	return Status{
+		Enabled:     cfg.Enabled,
+		Name:        InferRouteName(cfg.Name),
+		Host:        host,
+		TLD:         NormalizeTLD(cfg.TLD),
+		EdgePort:    edgePort,
+		HTTPS:       cfg.HTTPS,
+		StateDir:    stateDir,
+		URL:         BuildURL(cfg.HTTPS, host, edgePort),
+		BackendHost: "127.0.0.1",
+		BackendPort: cfg.AppPort,
+		UpdatedAt:   time.Now().UTC(),
+		CACertPath:  filepath.Join(stateDir, "certs", "ca.pem"),
+		TrustCommand: func() string {
+			if !cfg.HTTPS {
+				return ""
+			}
+			return TrustInstallCommand(filepath.Join(stateDir, "certs", "ca.pem"))
+		}(),
+	}
+}
+
+func ReadEdgePID(stateDir string) int {
+	payload, errRead := os.ReadFile(filepath.Join(stateDir, "edge.pid"))
+	if errRead != nil {
+		return 0
+	}
+	pid, errAtoi := strconv.Atoi(strings.TrimSpace(string(payload)))
+	if errAtoi != nil || pid <= 0 {
+		return 0
+	}
+	if !processAlive(pid) {
+		return 0
+	}
+	return pid
+}

--- a/internal/localrouting/sanitize.go
+++ b/internal/localrouting/sanitize.go
@@ -1,0 +1,58 @@
+package localrouting
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var invalidLabelChars = regexp.MustCompile(`[^a-z0-9-]+`)
+
+func NormalizeTLD(raw string) string {
+	tld := strings.ToLower(strings.TrimSpace(raw))
+	tld = strings.TrimPrefix(tld, ".")
+	if tld == "" {
+		return "localhost"
+	}
+	return invalidLabelChars.ReplaceAllString(tld, "")
+}
+
+func SanitizeLabel(raw string) string {
+	v := strings.ToLower(strings.TrimSpace(raw))
+	v = strings.ReplaceAll(v, "_", "-")
+	v = invalidLabelChars.ReplaceAllString(v, "-")
+	v = strings.Trim(v, "-")
+	if v == "" {
+		return "cliproxyapi"
+	}
+	if len(v) > 63 {
+		v = strings.Trim(v[:63], "-")
+		if v == "" {
+			v = "cliproxyapi"
+		}
+	}
+	return v
+}
+
+func BuildHost(name, tld string) string {
+	name = SanitizeLabel(name)
+	tld = NormalizeTLD(tld)
+	if tld == "" {
+		return name
+	}
+	return name + "." + tld
+}
+
+func BuildURL(https bool, host string, edgePort int) string {
+	scheme := "http"
+	if https {
+		scheme = "https"
+	}
+	if edgePort <= 0 {
+		edgePort = DefaultEdgePort
+	}
+	if (https && edgePort == 443) || (!https && edgePort == 80) {
+		return scheme + "://" + host
+	}
+	return scheme + "://" + host + ":" + strconv.Itoa(edgePort)
+}

--- a/internal/localrouting/sanitize_test.go
+++ b/internal/localrouting/sanitize_test.go
@@ -1,0 +1,14 @@
+package localrouting
+
+import "testing"
+
+func TestBuildHostAndURL(t *testing.T) {
+	host := BuildHost("My_App", ".LOCALHOST")
+	if host != "my-app.localhost" {
+		t.Fatalf("host = %q, want my-app.localhost", host)
+	}
+	url := BuildURL(false, host, 1355)
+	if url != "http://my-app.localhost:1355" {
+		t.Fatalf("url = %q", url)
+	}
+}

--- a/internal/localrouting/store.go
+++ b/internal/localrouting/store.go
@@ -1,0 +1,252 @@
+package localrouting
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type RouteStore struct {
+	stateDir   string
+	routesPath string
+	lockPath   string
+	mu         sync.Mutex
+}
+
+type routeFile struct {
+	Routes map[string]RouteInfo `json:"routes"`
+}
+
+func ResolveStateDir(raw string, edgePort int) string {
+	if trimmed := strings.TrimSpace(raw); trimmed != "" {
+		return trimmed
+	}
+	if home, errHome := os.UserHomeDir(); errHome == nil && strings.TrimSpace(home) != "" && edgePort >= 1024 {
+		return filepath.Join(home, ".cliproxyapi", "portless")
+	}
+	return filepath.Join(os.TempDir(), "cliproxyapi-portless")
+}
+
+func NewRouteStore(stateDir string, edgePort int) *RouteStore {
+	resolved := ResolveStateDir(stateDir, edgePort)
+	return &RouteStore{
+		stateDir:   resolved,
+		routesPath: filepath.Join(resolved, "routes.json"),
+		lockPath:   filepath.Join(resolved, "routes.lock"),
+	}
+}
+
+func (s *RouteStore) StateDir() string {
+	if s == nil {
+		return ""
+	}
+	return s.stateDir
+}
+
+func (s *RouteStore) List() ([]RouteInfo, error) {
+	if s == nil {
+		return nil, fmt.Errorf("route store is nil")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var out []RouteInfo
+	err := s.withLock(func() error {
+		rf, errRead := s.readRoutesLocked()
+		if errRead != nil {
+			return errRead
+		}
+		now := time.Now().UTC()
+		changed := false
+		for host, route := range rf.Routes {
+			if route.PID > 0 && !processAlive(route.PID) {
+				delete(rf.Routes, host)
+				changed = true
+				continue
+			}
+			if route.UpdatedAt.IsZero() {
+				route.UpdatedAt = now
+				rf.Routes[host] = route
+				changed = true
+			}
+		}
+		if changed {
+			if errWrite := s.writeRoutesLocked(rf); errWrite != nil {
+				return errWrite
+			}
+		}
+		out = make([]RouteInfo, 0, len(rf.Routes))
+		for _, route := range rf.Routes {
+			out = append(out, route)
+		}
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].Host < out[j].Host
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *RouteStore) Register(route RouteInfo, force bool) (RouteInfo, error) {
+	if s == nil {
+		return RouteInfo{}, fmt.Errorf("route store is nil")
+	}
+	if route.Host == "" || route.TargetHost == "" || route.TargetPort <= 0 {
+		return RouteInfo{}, fmt.Errorf("invalid route registration")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	route.Host = strings.ToLower(strings.TrimSpace(route.Host))
+	route.Name = SanitizeLabel(route.Name)
+	if route.BaseName == "" {
+		route.BaseName = route.Name
+	}
+	now := time.Now().UTC()
+
+	var final RouteInfo
+	err := s.withLock(func() error {
+		rf, errRead := s.readRoutesLocked()
+		if errRead != nil {
+			return errRead
+		}
+		if existing, ok := rf.Routes[route.Host]; ok {
+			if existing.PID > 0 && existing.PID != route.PID && processAlive(existing.PID) && !force {
+				return fmt.Errorf("route %s is owned by pid %d", route.Host, existing.PID)
+			}
+			route.CreatedAt = existing.CreatedAt
+			if route.CreatedAt.IsZero() {
+				route.CreatedAt = now
+			}
+		} else if route.CreatedAt.IsZero() {
+			route.CreatedAt = now
+		}
+		route.UpdatedAt = now
+		rf.Routes[route.Host] = route
+		if errWrite := s.writeRoutesLocked(rf); errWrite != nil {
+			return errWrite
+		}
+		final = route
+		return nil
+	})
+	if err != nil {
+		return RouteInfo{}, err
+	}
+	return final, nil
+}
+
+func (s *RouteStore) Unregister(host string, pid int) error {
+	if s == nil {
+		return nil
+	}
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.withLock(func() error {
+		rf, errRead := s.readRoutesLocked()
+		if errRead != nil {
+			return errRead
+		}
+		existing, ok := rf.Routes[host]
+		if !ok {
+			return nil
+		}
+		if pid > 0 && existing.PID > 0 && existing.PID != pid && processAlive(existing.PID) {
+			return nil
+		}
+		delete(rf.Routes, host)
+		return s.writeRoutesLocked(rf)
+	})
+}
+
+func (s *RouteStore) withLock(fn func() error) error {
+	if errMk := os.MkdirAll(s.stateDir, 0o755); errMk != nil {
+		return fmt.Errorf("create state dir: %w", errMk)
+	}
+	unlock, errLock := s.acquireFileLock(10 * time.Second)
+	if errLock != nil {
+		return errLock
+	}
+	defer unlock()
+	return fn()
+}
+
+func (s *RouteStore) readRoutesLocked() (*routeFile, error) {
+	rf := &routeFile{Routes: map[string]RouteInfo{}}
+	payload, errRead := os.ReadFile(s.routesPath)
+	if errRead != nil {
+		if os.IsNotExist(errRead) {
+			return rf, nil
+		}
+		return nil, fmt.Errorf("read routes: %w", errRead)
+	}
+	if len(payload) == 0 {
+		return rf, nil
+	}
+	if errUnmarshal := json.Unmarshal(payload, rf); errUnmarshal != nil {
+		return nil, fmt.Errorf("parse routes: %w", errUnmarshal)
+	}
+	if rf.Routes == nil {
+		rf.Routes = map[string]RouteInfo{}
+	}
+	return rf, nil
+}
+
+func (s *RouteStore) writeRoutesLocked(rf *routeFile) error {
+	if rf == nil {
+		rf = &routeFile{Routes: map[string]RouteInfo{}}
+	}
+	if rf.Routes == nil {
+		rf.Routes = map[string]RouteInfo{}
+	}
+	payload, errMarshal := json.MarshalIndent(rf, "", "  ")
+	if errMarshal != nil {
+		return fmt.Errorf("marshal routes: %w", errMarshal)
+	}
+	tmpPath := s.routesPath + ".tmp"
+	if errWrite := os.WriteFile(tmpPath, payload, 0o644); errWrite != nil {
+		return fmt.Errorf("write temp routes: %w", errWrite)
+	}
+	if errRename := os.Rename(tmpPath, s.routesPath); errRename != nil {
+		return fmt.Errorf("replace routes: %w", errRename)
+	}
+	return nil
+}
+
+func (s *RouteStore) acquireFileLock(timeout time.Duration) (func(), error) {
+	start := time.Now()
+	for {
+		f, errOpen := os.OpenFile(s.lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if errOpen == nil {
+			_, _ = fmt.Fprintf(f, "%d\n", os.Getpid())
+			_ = f.Close()
+			return func() {
+				_ = os.Remove(s.lockPath)
+			}, nil
+		}
+		if !os.IsExist(errOpen) {
+			return nil, fmt.Errorf("acquire lock: %w", errOpen)
+		}
+		info, errStat := os.Stat(s.lockPath)
+		if errStat == nil && time.Since(info.ModTime()) > 30*time.Second {
+			_ = os.Remove(s.lockPath)
+			continue
+		}
+		if time.Since(start) >= timeout {
+			return nil, fmt.Errorf("acquire lock timeout: %s", s.lockPath)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/internal/localrouting/store_test.go
+++ b/internal/localrouting/store_test.go
@@ -1,0 +1,70 @@
+package localrouting
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRouteStoreRegisterListAndUnregister(t *testing.T) {
+	stateDir := t.TempDir()
+	store := NewRouteStore(stateDir, 1355)
+
+	registered, errRegister := store.Register(RouteInfo{
+		Name:       "app",
+		Host:       "app.localhost",
+		TargetHost: "127.0.0.1",
+		TargetPort: 4101,
+		PID:        os.Getpid(),
+	}, false)
+	if errRegister != nil {
+		t.Fatalf("register route: %v", errRegister)
+	}
+	if registered.Host != "app.localhost" {
+		t.Fatalf("registered host = %q", registered.Host)
+	}
+
+	routes, errList := store.List()
+	if errList != nil {
+		t.Fatalf("list routes: %v", errList)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("routes len = %d, want 1", len(routes))
+	}
+
+	if errUnregister := store.Unregister("app.localhost", os.Getpid()); errUnregister != nil {
+		t.Fatalf("unregister route: %v", errUnregister)
+	}
+	routes, errList = store.List()
+	if errList != nil {
+		t.Fatalf("list routes after unregister: %v", errList)
+	}
+	if len(routes) != 0 {
+		t.Fatalf("routes len after unregister = %d, want 0", len(routes))
+	}
+}
+
+func TestRouteStorePrunesDeadPID(t *testing.T) {
+	stateDir := t.TempDir()
+	store := NewRouteStore(stateDir, 1355)
+	_, errRegister := store.Register(RouteInfo{
+		Name:       "dead",
+		Host:       "dead.localhost",
+		TargetHost: "127.0.0.1",
+		TargetPort: 4102,
+		PID:        999999,
+	}, true)
+	if errRegister != nil {
+		t.Fatalf("register dead route: %v", errRegister)
+	}
+	routes, errList := store.List()
+	if errList != nil {
+		t.Fatalf("list routes: %v", errList)
+	}
+	if len(routes) != 0 {
+		t.Fatalf("expected dead route to be pruned, got %d", len(routes))
+	}
+	if _, errStat := os.Stat(filepath.Join(stateDir, "routes.json")); errStat != nil {
+		t.Fatalf("routes file missing: %v", errStat)
+	}
+}

--- a/internal/localrouting/types.go
+++ b/internal/localrouting/types.go
@@ -1,0 +1,53 @@
+package localrouting
+
+import "time"
+
+const (
+	DefaultEdgePort = 1355
+	MinAppPort      = 4000
+	MaxAppPort      = 4999
+)
+
+// Config controls named local routing behavior.
+type Config struct {
+	Enabled      bool
+	Name         string
+	TLD          string
+	EdgePort     int
+	HTTPS        bool
+	AppPort      int
+	StateDir     string
+	Force        bool
+	DisplayOAuth bool
+}
+
+// RouteInfo describes one named route entry.
+type RouteInfo struct {
+	Name       string    `json:"name"`
+	BaseName   string    `json:"base_name,omitempty"`
+	Host       string    `json:"host"`
+	TargetHost string    `json:"target_host"`
+	TargetPort int       `json:"target_port"`
+	PID        int       `json:"pid"`
+	Command    string    `json:"command,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// Status reports runtime local-routing state.
+type Status struct {
+	Enabled      bool      `json:"enabled"`
+	URL          string    `json:"url,omitempty"`
+	Name         string    `json:"name,omitempty"`
+	Host         string    `json:"host,omitempty"`
+	TLD          string    `json:"tld,omitempty"`
+	EdgePort     int       `json:"edge_port,omitempty"`
+	BackendHost  string    `json:"backend_host,omitempty"`
+	BackendPort  int       `json:"backend_port,omitempty"`
+	HTTPS        bool      `json:"https"`
+	StateDir     string    `json:"state_dir,omitempty"`
+	CACertPath   string    `json:"ca_cert_path,omitempty"`
+	TrustCommand string    `json:"trust_command,omitempty"`
+	EdgeOwnerPID int       `json:"edge_owner_pid,omitempty"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/localrouting"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
@@ -89,6 +90,9 @@ type Service struct {
 
 	// wsGateway manages websocket Gemini providers.
 	wsGateway *wsrelay.Manager
+
+	// localRouting controls optional named local routing lifecycle.
+	localRouting *localrouting.Runtime
 }
 
 // RegisterUsagePlugin registers a usage plugin on the global usage manager.
@@ -495,6 +499,9 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 
 	s.applyRetryConfig(s.cfg)
+	if errLocalRouting := s.applyLocalRouting(); errLocalRouting != nil {
+		return errLocalRouting
+	}
 
 	if s.coreManager != nil {
 		if errLoad := s.coreManager.Load(ctx); errLoad != nil {
@@ -522,6 +529,9 @@ func (s *Service) Run(ctx context.Context) error {
 
 	// handlers no longer depend on legacy clients; pass nil slice initially
 	s.server = api.NewServer(s.cfg, s.coreManager, s.accessManager, s.configPath, s.serverOptions...)
+	if s.server != nil {
+		s.server.SetLocalRoutingRuntime(s.localRouting)
+	}
 
 	if s.authManager == nil {
 		s.authManager = newDefaultAuthManager()
@@ -600,7 +610,13 @@ func (s *Service) Run(ctx context.Context) error {
 	}()
 
 	time.Sleep(100 * time.Millisecond)
-	fmt.Printf("API server started successfully on: %s:%d\n", s.cfg.Host, s.cfg.Port)
+	if s.localRouting != nil {
+		status := s.localRouting.Status()
+		fmt.Printf("API server started successfully on backend %s:%d\n", s.cfg.Host, s.cfg.Port)
+		fmt.Printf("Local routing URL: %s\n", status.URL)
+	} else {
+		fmt.Printf("API server started successfully on: %s:%d\n", s.cfg.Host, s.cfg.Port)
+	}
 
 	s.applyPprofConfig(s.cfg)
 
@@ -742,6 +758,15 @@ func (s *Service) Shutdown(ctx context.Context) error {
 			s.authQueueStop()
 			s.authQueueStop = nil
 		}
+		if s.localRouting != nil {
+			if errLocal := s.localRouting.Close(ctx); errLocal != nil {
+				log.Errorf("failed to stop local routing: %v", errLocal)
+				if shutdownErr == nil {
+					shutdownErr = errLocal
+				}
+			}
+			s.localRouting = nil
+		}
 
 		if errShutdownPprof := s.shutdownPprof(ctx); errShutdownPprof != nil {
 			log.Errorf("failed to stop pprof server: %v", errShutdownPprof)
@@ -766,6 +791,48 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		usage.StopDefault()
 	})
 	return shutdownErr
+}
+
+func (s *Service) applyLocalRouting() error {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	s.cfg.SanitizeLocalRouting()
+	if !s.cfg.LocalRouting.Enabled {
+		return nil
+	}
+	backendPort := s.cfg.LocalRouting.AppPort
+	if backendPort <= 0 {
+		allocated, errFindPort := localrouting.FindFreePort(localrouting.MinAppPort, localrouting.MaxAppPort)
+		if errFindPort != nil {
+			return fmt.Errorf("cliproxy: local routing failed to allocate backend port: %w", errFindPort)
+		}
+		backendPort = allocated
+		s.cfg.LocalRouting.AppPort = backendPort
+	}
+	s.cfg.Host = "127.0.0.1"
+	s.cfg.Port = backendPort
+	runtimeCfg := localrouting.BuildConfig(
+		true,
+		s.cfg.LocalRouting.Name,
+		s.cfg.LocalRouting.TLD,
+		s.cfg.LocalRouting.EdgePort,
+		s.cfg.LocalRouting.HTTPS,
+		s.cfg.LocalRouting.AppPort,
+		s.cfg.LocalRouting.StateDir,
+		s.cfg.LocalRouting.Force,
+		s.cfg.LocalRouting.DisplayOAuthURL,
+	)
+	runtimeInst, errStart := localrouting.Start(runtimeCfg, s.cfg.Host, s.cfg.Port)
+	if errStart != nil {
+		return fmt.Errorf("cliproxy: local routing setup failed: %w", errStart)
+	}
+	s.localRouting = runtimeInst
+	if runtimeInst != nil {
+		status := runtimeInst.Status()
+		log.Infof("local routing enabled: %s -> %s:%d (edge:%d owner:%v)", status.URL, status.BackendHost, status.BackendPort, status.EdgePort, status.EdgeOwnerPID == os.Getpid())
+	}
+	return nil
 }
 
 func (s *Service) ensureAuthDir() error {

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -12,6 +12,7 @@ type Config = internalconfig.Config
 
 type StreamingConfig = internalconfig.StreamingConfig
 type TLSConfig = internalconfig.TLSConfig
+type LocalRoutingConfig = internalconfig.LocalRoutingConfig
 type RemoteManagement = internalconfig.RemoteManagement
 type AmpCode = internalconfig.AmpCode
 type OAuthModelAlias = internalconfig.OAuthModelAlias


### PR DESCRIPTION
## Summary
- add native portless-style local routing with a shared edge proxy and persistent route store
- support stable named local URLs, automatic backend port allocation, management endpoints, and OAuth URL hints
- add local HTTPS certificate generation with trust command exposure and tests

## Testing
- go test ./...