### PR TITLE
fix: preserve responses continuation state for openai-compatible upstreams

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -25,6 +25,7 @@ import (
 // It holds a pool of clients to interact with the backend service.
 type OpenAIResponsesAPIHandler struct {
 	*handlers.BaseAPIHandler
+	turnState responsesTurnStateCache
 }
 
 // NewOpenAIResponsesAPIHandler creates a new OpenAIResponses API handlers instance.
@@ -82,6 +83,12 @@ func (h *OpenAIResponsesAPIHandler) Responses(c *gin.Context) {
 		return
 	}
 
+	rawJSON, errMsg := h.normalizeContinuationRequest(rawJSON)
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		return
+	}
+
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")
 	if streamResult.Type == gjson.True {
@@ -131,6 +138,7 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 		cliCancel(errMsg.Error)
 		return
 	}
+	h.rememberCompletedResponse(rawJSON, resp)
 	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 	_, _ = c.Writer.Write(resp)
 	cliCancel()
@@ -157,6 +165,7 @@ func (h *OpenAIResponsesAPIHandler) handleNonStreamingResponse(c *gin.Context, r
 		cliCancel(errMsg.Error)
 		return
 	}
+	h.rememberCompletedResponse(rawJSON, resp)
 	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 	_, _ = c.Writer.Write(resp)
 	cliCancel()
@@ -230,6 +239,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 
 			// Write first chunk logic (matching forwardResponsesStream)
+			h.rememberCompletedResponseFromChunk(rawJSON, chunk)
 			if bytes.HasPrefix(chunk, []byte("event:")) {
 				_, _ = c.Writer.Write([]byte("\n"))
 			}
@@ -238,15 +248,16 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			flusher.Flush()
 
 			// Continue
-			h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan)
+			h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, rawJSON, dataChan, errChan)
 			return
 		}
 	}
 }
 
-func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
+func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flusher http.Flusher, cancel func(error), requestJSON []byte, data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{
 		WriteChunk: func(chunk []byte) {
+			h.rememberCompletedResponseFromChunk(requestJSON, chunk)
 			if bytes.HasPrefix(chunk, []byte("event:")) {
 				_, _ = c.Writer.Write([]byte("\n"))
 			}

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
@@ -32,7 +32,7 @@ func TestForwardResponsesStreamTerminalErrorUsesResponsesErrorChunk(t *testing.T
 	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: errors.New("unexpected EOF")}
 	close(errs)
 
-	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs)
+	h.forwardResponsesStream(c, flusher, func(error) {}, nil, data, errs)
 	body := recorder.Body.String()
 	if !strings.Contains(body, `"type":"error"`) {
 		t.Fatalf("expected responses error chunk, got: %q", body)

--- a/sdk/api/handlers/openai/openai_responses_http_continuation_test.go
+++ b/sdk/api/handlers/openai/openai_responses_http_continuation_test.go
@@ -1,0 +1,149 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	"github.com/tidwall/gjson"
+)
+
+type responsesContinuationCaptureExecutor struct {
+	calls    int
+	payloads [][]byte
+}
+
+func (e *responsesContinuationCaptureExecutor) Identifier() string { return "test-provider" }
+
+func (e *responsesContinuationCaptureExecutor) Execute(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	e.calls++
+	e.payloads = append(e.payloads, append([]byte(nil), req.Payload...))
+	if e.calls == 1 {
+		return coreexecutor.Response{Payload: []byte(`{"id":"resp-1","output":[{"type":"function_call","id":"fc-1","call_id":"call-1"},{"type":"message","id":"assistant-1"}]}`)}, nil
+	}
+	return coreexecutor.Response{Payload: []byte(`{"id":"resp-2","output":[{"type":"message","id":"assistant-2"}]}`)}, nil
+}
+
+func (e *responsesContinuationCaptureExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *responsesContinuationCaptureExecutor) Refresh(ctx context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *responsesContinuationCaptureExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *responsesContinuationCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestOpenAIResponsesHTTPContinuationMergesCachedTurn(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &responsesContinuationCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "auth-http-cont", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+
+	firstReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"test-model","input":[{"type":"message","id":"msg-1"}]}`))
+	firstReq.Header.Set("Content-Type", "application/json")
+	firstResp := httptest.NewRecorder()
+	router.ServeHTTP(firstResp, firstReq)
+	if firstResp.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want %d", firstResp.Code, http.StatusOK)
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"test-model","previous_response_id":"resp-1","input":[{"type":"function_call_output","call_id":"call-1","id":"tool-out-1"}]}`))
+	secondReq.Header.Set("Content-Type", "application/json")
+	secondResp := httptest.NewRecorder()
+	router.ServeHTTP(secondResp, secondReq)
+	if secondResp.Code != http.StatusOK {
+		t.Fatalf("second status = %d, want %d body=%s", secondResp.Code, http.StatusOK, secondResp.Body.String())
+	}
+
+	if executor.calls != 2 {
+		t.Fatalf("executor calls = %d, want 2", executor.calls)
+	}
+	if gjson.GetBytes(executor.payloads[1], "previous_response_id").Exists() {
+		t.Fatalf("second payload must not include previous_response_id: %s", executor.payloads[1])
+	}
+	input := gjson.GetBytes(executor.payloads[1], "input").Array()
+	if len(input) != 4 {
+		t.Fatalf("merged input len = %d, want 4: %s", len(input), executor.payloads[1])
+	}
+	if input[0].Get("id").String() != "msg-1" ||
+		input[1].Get("id").String() != "fc-1" ||
+		input[2].Get("id").String() != "assistant-1" ||
+		input[3].Get("id").String() != "tool-out-1" {
+		t.Fatalf("unexpected merged input order: %s", executor.payloads[1])
+	}
+}
+
+func TestNormalizeContinuationRequestSupportsStringInputShorthand(t *testing.T) {
+	h := &OpenAIResponsesAPIHandler{}
+	h.rememberCompletedResponse(
+		[]byte(`{"model":"test-model","input":"Use the weather tool for Paris."}`),
+		[]byte(`{"id":"resp-str-1","output":[{"type":"function_call","id":"fc-1","call_id":"call-1"},{"type":"message","id":"assistant-1"}]}`),
+	)
+
+	normalized, errMsg := h.normalizeContinuationRequest([]byte(`{"previous_response_id":"resp-str-1","input":[{"type":"function_call_output","call_id":"call-1","id":"tool-out-1"}]}`))
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 4 {
+		t.Fatalf("merged input len = %d, want 4: %s", len(input), normalized)
+	}
+	if input[0].Get("role").String() != "user" {
+		t.Fatalf("expected normalized first item to be user message: %s", normalized)
+	}
+	if input[0].Get("content").String() != "Use the weather tool for Paris." {
+		t.Fatalf("unexpected normalized first item content: %s", normalized)
+	}
+}
+
+func TestRememberCompletedResponseFromChunkCachesStreamingTurn(t *testing.T) {
+	h := &OpenAIResponsesAPIHandler{}
+	requestJSON := []byte(`{"model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)
+	chunk := []byte(`event: response.completed
+data: {"type":"response.completed","response":{"id":"resp-stream-1","output":[{"type":"function_call","id":"fc-1","call_id":"call-1"},{"type":"message","id":"assistant-1"}]}}
+
+`)
+	h.rememberCompletedResponseFromChunk(requestJSON, chunk)
+
+	normalized, errMsg := h.normalizeContinuationRequest([]byte(`{"previous_response_id":"resp-stream-1","input":[{"type":"function_call_output","call_id":"call-1","id":"tool-out-1"}]}`))
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 4 {
+		t.Fatalf("merged input len = %d, want 4: %s", len(input), normalized)
+	}
+	if input[3].Get("id").String() != "tool-out-1" {
+		t.Fatalf("unexpected merged payload: %s", normalized)
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_turn_state.go
+++ b/sdk/api/handlers/openai/openai_responses_turn_state.go
@@ -1,0 +1,185 @@
+package openai
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const responsesTurnStateTTL = 30 * time.Minute
+
+type responsesTurnStateEntry struct {
+	request []byte
+	output  []byte
+	expire  time.Time
+}
+
+type responsesTurnStateCache struct {
+	entries sync.Map
+}
+
+func (c *responsesTurnStateCache) load(responseID string) ([]byte, []byte, bool) {
+	responseID = strings.TrimSpace(responseID)
+	if responseID == "" {
+		return nil, nil, false
+	}
+	raw, ok := c.entries.Load(responseID)
+	if !ok {
+		return nil, nil, false
+	}
+	entry, ok := raw.(responsesTurnStateEntry)
+	if !ok {
+		c.entries.Delete(responseID)
+		return nil, nil, false
+	}
+	if !entry.expire.After(time.Now()) {
+		c.entries.Delete(responseID)
+		return nil, nil, false
+	}
+	return bytes.Clone(entry.request), bytes.Clone(entry.output), true
+}
+
+func (c *responsesTurnStateCache) store(responseID string, requestJSON []byte, outputJSON []byte) {
+	responseID = strings.TrimSpace(responseID)
+	if responseID == "" || len(requestJSON) == 0 || len(outputJSON) == 0 {
+		return
+	}
+	c.entries.Store(responseID, responsesTurnStateEntry{
+		request: bytes.Clone(requestJSON),
+		output:  bytes.Clone(outputJSON),
+		expire:  time.Now().Add(responsesTurnStateTTL),
+	})
+}
+
+func normalizeResponsesRequestInputRaw(rawJSON []byte) (string, *interfaces.ErrorMessage) {
+	input := gjson.GetBytes(rawJSON, "input")
+	if !input.Exists() {
+		return "[]", nil
+	}
+	if input.IsArray() {
+		return input.Raw, nil
+	}
+	if input.Type == gjson.String {
+		message := []byte(`{"type":"message","role":"user","content":""}`)
+		message, _ = sjson.SetBytes(message, "content", input.String())
+		return fmt.Sprintf("[%s]", message), nil
+	}
+	return "", &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadRequest,
+		Error:      fmt.Errorf("responses request requires array or string field: input"),
+	}
+}
+
+func normalizeResponsesHTTPContinuationRequest(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte) ([]byte, *interfaces.ErrorMessage) {
+	if len(lastRequest) == 0 {
+		return rawJSON, nil
+	}
+
+	nextInput := gjson.GetBytes(rawJSON, "input")
+	if !nextInput.Exists() || !nextInput.IsArray() {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadRequest,
+			Error:      fmt.Errorf("responses request requires array field: input"),
+		}
+	}
+
+	existingInputRaw, errMsg := normalizeResponsesRequestInputRaw(lastRequest)
+	if errMsg != nil {
+		return nil, errMsg
+	}
+	mergedInput, errMerge := mergeJSONArrayRaw(existingInputRaw, normalizeJSONArrayRaw(lastResponseOutput))
+	if errMerge != nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadRequest,
+			Error:      fmt.Errorf("invalid previous response output: %w", errMerge),
+		}
+	}
+	mergedInput, errMerge = mergeJSONArrayRaw(mergedInput, nextInput.Raw)
+	if errMerge != nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadRequest,
+			Error:      fmt.Errorf("invalid request input: %w", errMerge),
+		}
+	}
+
+	normalized, errDelete := sjson.DeleteBytes(rawJSON, "previous_response_id")
+	if errDelete != nil {
+		normalized = bytes.Clone(rawJSON)
+	}
+	var errSet error
+	normalized, errSet = sjson.SetRawBytes(normalized, "input", []byte(mergedInput))
+	if errSet != nil {
+		return nil, &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadRequest,
+			Error:      fmt.Errorf("failed to merge responses input: %w", errSet),
+		}
+	}
+	if !gjson.GetBytes(normalized, "model").Exists() {
+		modelName := strings.TrimSpace(gjson.GetBytes(lastRequest, "model").String())
+		if modelName != "" {
+			normalized, _ = sjson.SetBytes(normalized, "model", modelName)
+		}
+	}
+	if !gjson.GetBytes(normalized, "instructions").Exists() {
+		instructions := gjson.GetBytes(lastRequest, "instructions")
+		if instructions.Exists() {
+			normalized, _ = sjson.SetRawBytes(normalized, "instructions", []byte(instructions.Raw))
+		}
+	}
+	return normalized, nil
+}
+
+func (h *OpenAIResponsesAPIHandler) normalizeContinuationRequest(rawJSON []byte) ([]byte, *interfaces.ErrorMessage) {
+	if h == nil {
+		return rawJSON, nil
+	}
+	previousResponseID := strings.TrimSpace(gjson.GetBytes(rawJSON, "previous_response_id").String())
+	if previousResponseID == "" {
+		return rawJSON, nil
+	}
+	lastRequest, lastResponseOutput, ok := h.turnState.load(previousResponseID)
+	if !ok {
+		return rawJSON, nil
+	}
+	return normalizeResponsesHTTPContinuationRequest(rawJSON, lastRequest, lastResponseOutput)
+}
+
+func (h *OpenAIResponsesAPIHandler) rememberCompletedResponse(requestJSON []byte, responseJSON []byte) {
+	if h == nil {
+		return
+	}
+	responseID := strings.TrimSpace(gjson.GetBytes(responseJSON, "id").String())
+	if responseID == "" {
+		responseID = strings.TrimSpace(gjson.GetBytes(responseJSON, "response.id").String())
+	}
+	if responseID == "" {
+		return
+	}
+	output := gjson.GetBytes(responseJSON, "output")
+	if !output.Exists() || !output.IsArray() {
+		output = gjson.GetBytes(responseJSON, "response.output")
+	}
+	if !output.Exists() || !output.IsArray() {
+		return
+	}
+	h.turnState.store(responseID, requestJSON, []byte(output.Raw))
+}
+
+func (h *OpenAIResponsesAPIHandler) rememberCompletedResponseFromChunk(requestJSON []byte, chunk []byte) {
+	if h == nil || len(chunk) == 0 {
+		return
+	}
+	for _, payload := range websocketJSONPayloadsFromChunk(chunk) {
+		if gjson.GetBytes(payload, "type").String() != wsEventTypeCompleted {
+			continue
+		}
+		h.rememberCompletedResponse(requestJSON, payload)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve HTTP `/v1/responses` continuation state for openai-compatible upstreams that do not support `previous_response_id`
- cache completed response turns for both non-streaming and streaming responses
- normalize string shorthand `input` into a user message before merging continuation input
- add regression coverage for HTTP continuation and streaming completion caching

## Testing
- `go test ./sdk/api/handlers/openai -count=1`
- verified `/v1/responses` continuation against a live `gpt-5.4` openai-compatible upstream for both non-streaming and streaming flows
