### PR TITLE
build: add freebsd support for releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ builds:
       - linux
       - windows
       - darwin
+      - freebsd
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
## Description
This PR adds FreeBSD support to Goreleaser so CLIProxyAPI can natively run on FreeBSD servers.

- Added `freebsd` to `goos`
- Ignored unsupported freebsd architectures (`arm`, `s390x`, `loong64`)

Closes no issues, generated to help a user deploy on FreeBSD environments (e.g. Serv00).