### PR TITLE
fix: preserve Claude thinking signatures in Codex translator

### DIFF
--- a/internal/translator/codex/claude/codex_claude_response.go
+++ b/internal/translator/codex/claude/codex_claude_response.go
@@ -179,8 +179,11 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 
 			output = translatorcommon.AppendSSEEventBytes(output, "content_block_stop", template, 2)
 		} else if itemType == "reasoning" {
-			params.ThinkingSignature = itemResult.Get("encrypted_content").String()
+			if signature := itemResult.Get("encrypted_content").String(); signature != "" {
+				params.ThinkingSignature = signature
+			}
 			output = append(output, finalizeCodexThinkingBlock(params)...)
+			params.ThinkingSignature = ""
 		}
 	} else if typeStr == "response.function_call_arguments.delta" {
 		params.HasReceivedArgumentsDelta = true
@@ -389,7 +392,6 @@ func ClaudeTokenCount(_ context.Context, count int64) []byte {
 
 func finalizeCodexThinkingBlock(params *ConvertCodexResponseToClaudeParams) []byte {
 	if !params.ThinkingBlockOpen {
-		params.ThinkingSignature = ""
 		return nil
 	}
 
@@ -408,7 +410,6 @@ func finalizeCodexThinkingBlock(params *ConvertCodexResponseToClaudeParams) []by
 	params.BlockIndex++
 	params.ThinkingBlockOpen = false
 	params.ThinkingStopPending = false
-	params.ThinkingSignature = ""
 
 	return output
 }

--- a/internal/translator/codex/claude/codex_claude_response_test.go
+++ b/internal/translator/codex/claude/codex_claude_response_test.go
@@ -163,6 +163,86 @@ func TestConvertCodexResponseToClaude_StreamThinkingFinalizesPendingBlockBeforeN
 	}
 }
 
+func TestConvertCodexResponseToClaude_StreamThinkingRetainsSignatureAcrossMultipartReasoning(t *testing.T) {
+	ctx := context.Background()
+	originalRequest := []byte(`{"messages":[]}`)
+	var param any
+
+	chunks := [][]byte{
+		[]byte("data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"enc_sig_multipart\"}}"),
+		[]byte("data: {\"type\":\"response.reasoning_summary_part.added\"}"),
+		[]byte("data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"First part\"}"),
+		[]byte("data: {\"type\":\"response.reasoning_summary_part.done\"}"),
+		[]byte("data: {\"type\":\"response.reasoning_summary_part.added\"}"),
+		[]byte("data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"Second part\"}"),
+		[]byte("data: {\"type\":\"response.reasoning_summary_part.done\"}"),
+		[]byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"reasoning\"}}"),
+	}
+
+	var outputs [][]byte
+	for _, chunk := range chunks {
+		outputs = append(outputs, ConvertCodexResponseToClaude(ctx, "", originalRequest, nil, chunk, &param)...)
+	}
+
+	signatureDeltaCount := 0
+	for _, out := range outputs {
+		for _, line := range strings.Split(string(out), "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			data := gjson.Parse(strings.TrimPrefix(line, "data: "))
+			if data.Get("type").String() == "content_block_delta" && data.Get("delta.type").String() == "signature_delta" {
+				signatureDeltaCount++
+				if got := data.Get("delta.signature").String(); got != "enc_sig_multipart" {
+					t.Fatalf("unexpected signature delta: %q", got)
+				}
+			}
+		}
+	}
+
+	if signatureDeltaCount != 2 {
+		t.Fatalf("expected signature_delta for both multipart thinking blocks, got %d", signatureDeltaCount)
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamThinkingUsesEarlyCapturedSignatureWhenDoneOmitsIt(t *testing.T) {
+	ctx := context.Background()
+	originalRequest := []byte(`{"messages":[]}`)
+	var param any
+
+	chunks := [][]byte{
+		[]byte("data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"enc_sig_early\"}}"),
+		[]byte("data: {\"type\":\"response.reasoning_summary_part.added\"}"),
+		[]byte("data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"Let me think\"}"),
+		[]byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"reasoning\"}}"),
+	}
+
+	var outputs [][]byte
+	for _, chunk := range chunks {
+		outputs = append(outputs, ConvertCodexResponseToClaude(ctx, "", originalRequest, nil, chunk, &param)...)
+	}
+
+	signatureDeltaCount := 0
+	for _, out := range outputs {
+		for _, line := range strings.Split(string(out), "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			data := gjson.Parse(strings.TrimPrefix(line, "data: "))
+			if data.Get("type").String() == "content_block_delta" && data.Get("delta.type").String() == "signature_delta" {
+				signatureDeltaCount++
+				if got := data.Get("delta.signature").String(); got != "enc_sig_early" {
+					t.Fatalf("unexpected signature delta: %q", got)
+				}
+			}
+		}
+	}
+
+	if signatureDeltaCount != 1 {
+		t.Fatalf("expected signature_delta from early-captured signature, got %d", signatureDeltaCount)
+	}
+}
+
 func TestConvertCodexResponseToClaudeNonStream_ThinkingIncludesSignature(t *testing.T) {
 	ctx := context.Background()
 	originalRequest := []byte(`{"messages":[]}`)


### PR DESCRIPTION
## Summary
- retain the captured Claude thinking signature until the Codex reasoning item actually completes
- reuse an early-captured signature when `response.output_item.done` omits `encrypted_content`
- preserve `encrypted_content` as `signature` in non-stream responses
- add regressions for multipart reasoning summaries and signature-less reasoning completion

## Why
Users still hit:

```text
messages.1.content.0: Invalid `signature` in `thinking` block
```

There are already upstream reports in this bug family (#2172, #1584, #1777), and PR #1932 contains the core approach but is still open/unmerged. This branch fixes the remaining translator-side lifecycle bug where a captured signature was dropped before the reasoning item finished.

## Details
- keep thinking-block finalization separate from reasoning-item signature lifetime
- avoid clearing a captured signature when a single thinking block closes
- only overwrite the captured signature on `response.output_item.done` when Codex sends a non-empty `encrypted_content`
- clear the signature after the reasoning item has been fully finalized
- add tests covering:
  - streaming thinking blocks with signature emission
  - streaming thinking blocks that end without a signature
  - multipart streaming reasoning that reuses one captured signature across multiple thinking blocks
  - streaming reasoning finalized by `response.output_item.done` without `encrypted_content`
  - non-stream thinking blocks with signature preservation

## Verification
```bash
env GOCACHE=/tmp/CLIProxyAPI-go-build GOMODCACHE=/tmp/CLIProxyAPI-go-mod go test ./internal/translator/codex/claude -run TestConvertCodexResponseToClaude -count=1
env GOCACHE=/tmp/CLIProxyAPI-go-build GOMODCACHE=/tmp/CLIProxyAPI-go-mod go test ./internal/translator/codex/... -count=1
env GOCACHE=/tmp/CLIProxyAPI-go-build GOMODCACHE=/tmp/CLIProxyAPI-go-mod go build -o /tmp/cliproxyapi-pr2332-test ./cmd/server
```