### PR TITLE
fix(codex): strip stream_options from Responses API requests

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -113,6 +113,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
+	body, _ = sjson.DeleteBytes(body, "stream_options")
 	if !gjson.GetBytes(body, "instructions").Exists() {
 		body, _ = sjson.SetBytes(body, "instructions", "")
 	}
@@ -311,6 +312,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
+	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	if !gjson.GetBytes(body, "instructions").Exists() {
 		body, _ = sjson.SetBytes(body, "instructions", "")
@@ -415,6 +417,7 @@ func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth
 	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
+	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body, _ = sjson.SetBytes(body, "stream", false)
 	if !gjson.GetBytes(body, "instructions").Exists() {
 		body, _ = sjson.SetBytes(body, "instructions", "")


### PR DESCRIPTION
## Problem

The Codex/OpenAI Responses API does not support the `stream_options` parameter. When clients such as Amp CLI include `stream_options` in their requests, CLIProxyAPI forwards it verbatim to the upstream `/responses` endpoint, resulting in a **400** error:

```json
{"detail":"Unsupported parameter: stream_options"}
```

Both OAuth accounts are tried and both fail, so the request is never fulfilled.

**Log evidence:**

```
[codex_executor.go:360] request error, error status: 400, error message: {"detail":"Unsupported parameter: stream_options"}
```

## Fix

Strip `stream_options` from the request body before forwarding to the Codex Responses API, consistent with how `previous_response_id`, `prompt_cache_retention`, and `safety_identifier` are already stripped.

Applied in all three code paths:
- `Execute` (non-streaming fetch)
- `ExecuteStream` (streaming)
- `CountTokens` (token counting)

## Testing

- Confirmed the fix compiles cleanly (`go build ./internal/runtime/executor/`).
- The change is a single `sjson.DeleteBytes` call per method, following the identical pattern used for the adjacent parameter deletions.