### PR TITLE
fix(auth): respect disable-cooling for 401/402/403/404 errors

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1752,20 +1752,32 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				} else {
 					switch statusCode {
 					case 401:
-						next := now.Add(30 * time.Minute)
-						state.NextRetryAfter = next
-						suspendReason = "unauthorized"
-						shouldSuspendModel = true
+						if quotaCooldownDisabledForAuth(auth) {
+							state.NextRetryAfter = time.Time{}
+						} else {
+							next := now.Add(30 * time.Minute)
+							state.NextRetryAfter = next
+							suspendReason = "unauthorized"
+							shouldSuspendModel = true
+						}
 					case 402, 403:
-						next := now.Add(30 * time.Minute)
-						state.NextRetryAfter = next
-						suspendReason = "payment_required"
-						shouldSuspendModel = true
+						if quotaCooldownDisabledForAuth(auth) {
+							state.NextRetryAfter = time.Time{}
+						} else {
+							next := now.Add(30 * time.Minute)
+							state.NextRetryAfter = next
+							suspendReason = "payment_required"
+							shouldSuspendModel = true
+						}
 					case 404:
-						next := now.Add(12 * time.Hour)
-						state.NextRetryAfter = next
-						suspendReason = "not_found"
-						shouldSuspendModel = true
+						if quotaCooldownDisabledForAuth(auth) {
+							state.NextRetryAfter = time.Time{}
+						} else {
+							next := now.Add(12 * time.Hour)
+							state.NextRetryAfter = next
+							suspendReason = "not_found"
+							shouldSuspendModel = true
+						}
 					case 429:
 						var next time.Time
 						backoffLevel := state.Quota.BackoffLevel
@@ -2094,13 +2106,25 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	switch statusCode {
 	case 401:
 		auth.StatusMessage = "unauthorized"
-		auth.NextRetryAfter = now.Add(30 * time.Minute)
+		if quotaCooldownDisabledForAuth(auth) {
+			auth.NextRetryAfter = time.Time{}
+		} else {
+			auth.NextRetryAfter = now.Add(30 * time.Minute)
+		}
 	case 402, 403:
 		auth.StatusMessage = "payment_required"
-		auth.NextRetryAfter = now.Add(30 * time.Minute)
+		if quotaCooldownDisabledForAuth(auth) {
+			auth.NextRetryAfter = time.Time{}
+		} else {
+			auth.NextRetryAfter = now.Add(30 * time.Minute)
+		}
 	case 404:
 		auth.StatusMessage = "not_found"
-		auth.NextRetryAfter = now.Add(12 * time.Hour)
+		if quotaCooldownDisabledForAuth(auth) {
+			auth.NextRetryAfter = time.Time{}
+		} else {
+			auth.NextRetryAfter = now.Add(12 * time.Hour)
+		}
 	case 429:
 		auth.StatusMessage = "quota exhausted"
 		auth.Quota.Exceeded = true


### PR DESCRIPTION
## Summary
- `disable-cooling` previously only suppressed cooldown for 429 and 5xx errors
- Third-party API providers returning 401/403/404 transiently would block auths for 30min~12h, eventually      
causing `auth_unavailable` for all credentials
- Polluted `ModelStates` survived config hot-reloads (inherited in `applyCoreAuthAddOrUpdate`), requiring a    
full restart to recover
- Now `disable-cooling` also clears `NextRetryAfter` and skips model suspension for 401/402/403/404
## Test plan
- [x] Configure 3 Claude API keys with third-party provider and `disable-cooling: true`
- [x] Simulate 401/403/404 upstream errors
- [x] Verify auths remain available and are not blocked
- [x] Verify existing cooldown behavior is preserved when `disable-cooling: false`

Fixes #2261