### PR TITLE
Add Qoder provider support and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,20 @@ Get 10% OFF GLM CODING PLAN：https://z.ai/subscribe?ic=8JVLJQFSKB
 - OpenAI Codex support (GPT models) via OAuth login
 - Claude Code support via OAuth login
 - Qwen Code support via OAuth login
+- Qoder support via OAuth login
 - iFlow support via OAuth login
 - Amp CLI and IDE extensions support with provider routing
 - Streaming and non-streaming responses
 - Function calling/tools support
 - Multimodal input support (text and images)
-- Multiple accounts with round-robin load balancing (Gemini, OpenAI, Claude, Qwen and iFlow)
-- Simple CLI authentication flows (Gemini, OpenAI, Claude, Qwen and iFlow)
+- Multiple accounts with round-robin load balancing (Gemini, OpenAI, Claude, Qwen, Qoder and iFlow)
+- Simple CLI authentication flows (Gemini, OpenAI, Claude, Qwen, Qoder and iFlow)
 - Generative Language API Key support
 - AI Studio Build multi-account load balancing
 - Gemini CLI multi-account load balancing
 - Claude Code multi-account load balancing
 - Qwen Code multi-account load balancing
+- Qoder multi-account load balancing
 - iFlow multi-account load balancing
 - OpenAI Codex multi-account load balancing
 - OpenAI-compatible upstream providers via config (e.g., OpenRouter)
@@ -63,6 +65,11 @@ CLIProxyAPI Guides: [https://help.router-for.me/](https://help.router-for.me/)
 ## Management API
 
 see [MANAGEMENT_API.md](https://help.router-for.me/management/api)
+
+> [!NOTE]
+> The management dashboard UI is distributed as a static `management.html` asset and may lag new providers.
+> If Qoder does not appear in the UI after upgrading, delete the local `static/management.html` so the server
+> re-downloads the latest control panel bundle.
 
 ## Amp CLI Support
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -40,17 +40,19 @@ GLM CODING PLAN 是专为AI编码打造的订阅套餐，每月最低仅需20元
 - 新增 OpenAI Codex（GPT 系列）支持（OAuth 登录）
 - 新增 Claude Code 支持（OAuth 登录）
 - 新增 Qwen Code 支持（OAuth 登录）
+- 新增 Qoder 支持（OAuth 登录）
 - 新增 iFlow 支持（OAuth 登录）
 - 支持流式与非流式响应
 - 函数调用/工具支持
 - 多模态输入（文本、图片）
-- 多账户支持与轮询负载均衡（Gemini、OpenAI、Claude、Qwen 与 iFlow）
-- 简单的 CLI 身份验证流程（Gemini、OpenAI、Claude、Qwen 与 iFlow）
+- 多账户支持与轮询负载均衡（Gemini、OpenAI、Claude、Qwen、Qoder 与 iFlow）
+- 简单的 CLI 身份验证流程（Gemini、OpenAI、Claude、Qwen、Qoder 与 iFlow）
 - 支持 Gemini AIStudio API 密钥
 - 支持 AI Studio Build 多账户轮询
 - 支持 Gemini CLI 多账户轮询
 - 支持 Claude Code 多账户轮询
 - 支持 Qwen Code 多账户轮询
+- 支持 Qoder 多账户轮询
 - 支持 iFlow 多账户轮询
 - 支持 OpenAI Codex 多账户轮询
 - 通过配置接入上游 OpenAI 兼容提供商（例如 OpenRouter）

--- a/README_JA.md
+++ b/README_JA.md
@@ -39,18 +39,20 @@ GLM CODING PLANを10%割引で取得：https://z.ai/subscribe?ic=8JVLJQFSKB
 - OAuthログインによるOpenAI Codexサポート（GPTモデル）
 - OAuthログインによるClaude Codeサポート
 - OAuthログインによるQwen Codeサポート
+- OAuthログインによるQoderサポート
 - OAuthログインによるiFlowサポート
 - プロバイダールーティングによるAmp CLIおよびIDE拡張機能のサポート
 - ストリーミングおよび非ストリーミングレスポンス
 - 関数呼び出し/ツールのサポート
 - マルチモーダル入力サポート（テキストと画像）
-- ラウンドロビン負荷分散による複数アカウント対応（Gemini、OpenAI、Claude、QwenおよびiFlow）
-- シンプルなCLI認証フロー（Gemini、OpenAI、Claude、QwenおよびiFlow）
+- ラウンドロビン負荷分散による複数アカウント対応（Gemini、OpenAI、Claude、Qwen、QoderおよびiFlow）
+- シンプルなCLI認証フロー（Gemini、OpenAI、Claude、Qwen、QoderおよびiFlow）
 - Generative Language APIキーのサポート
 - AI Studioビルドのマルチアカウント負荷分散
 - Gemini CLIのマルチアカウント負荷分散
 - Claude Codeのマルチアカウント負荷分散
 - Qwen Codeのマルチアカウント負荷分散
+- Qoderのマルチアカウント負荷分散
 - iFlowのマルチアカウント負荷分散
 - OpenAI Codexのマルチアカウント負荷分散
 - 設定によるOpenAI互換アップストリームプロバイダー（例：OpenRouter）

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -68,6 +68,7 @@ func main() {
 	var oauthCallbackPort int
 	var antigravityLogin bool
 	var kimiLogin bool
+	var qoderLogin bool
 	var projectID string
 	var vertexImport string
 	var configPath string
@@ -88,6 +89,7 @@ func main() {
 	flag.IntVar(&oauthCallbackPort, "oauth-callback-port", 0, "Override OAuth callback port (defaults to provider-specific port)")
 	flag.BoolVar(&antigravityLogin, "antigravity-login", false, "Login to Antigravity using OAuth")
 	flag.BoolVar(&kimiLogin, "kimi-login", false, "Login to Kimi using OAuth")
+	flag.BoolVar(&qoderLogin, "qoder-login", false, "Login to Qoder using OAuth device flow")
 	flag.StringVar(&projectID, "project_id", "", "Project ID (Gemini only, not required)")
 	flag.StringVar(&configPath, "config", DefaultConfigPath, "Configure File Path")
 	flag.StringVar(&vertexImport, "vertex-import", "", "Import Vertex service account key JSON file")
@@ -486,6 +488,8 @@ func main() {
 		cmd.DoIFlowCookieAuth(cfg, options)
 	} else if kimiLogin {
 		cmd.DoKimiLogin(cfg, options)
+	} else if qoderLogin {
+		cmd.DoQoderLogin(cfg, options)
 	} else {
 		// In cloud deploy mode without config file, just wait for shutdown signals
 		if isCloudDeploy && !configFileExists {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -275,7 +275,7 @@ nonstream-keepalive-interval: 0
 
 # Global OAuth model name aliases (per channel)
 # These aliases rename model IDs for both model listing and request routing.
-# Supported channels: gemini-cli, vertex, aistudio, antigravity, claude, codex, qwen, iflow, kimi.
+# Supported channels: gemini-cli, vertex, aistudio, antigravity, claude, codex, qwen, iflow, kimi, qoder.
 # NOTE: Aliases do not apply to gemini-api-key, codex-api-key, claude-api-key, openai-compatibility, vertex-api-key, or ampcode.
 # You can repeat the same name with different aliases to expose multiple client model names.
 # oauth-model-alias:
@@ -307,6 +307,17 @@ nonstream-keepalive-interval: 0
 #   kimi:
 #     - name: "kimi-k2.5"
 #       alias: "k2.5"
+#   qoder:
+#     - name: "qwen-coder-qoder-1.0"
+#       alias: "qoder-coder"
+#     - name: "qwen3.5-plus"
+#       alias: "qoder-qwen35"
+#     - name: "glm-5"
+#       alias: "qoder-glm5"
+#     - name: "kimi-k2.5"
+#       alias: "qoder-kimi"
+#     - name: "minimax-m2.7"
+#       alias: "qoder-minimax"
 
 # OAuth provider excluded models
 # oauth-excluded-models:
@@ -331,6 +342,10 @@ nonstream-keepalive-interval: 0
 #     - "tstars2.0"
 #   kimi:
 #     - "kimi-k2-thinking"
+#   qoder:
+#     - "auto"
+#     - "ultimate"
+#     - "performance"
 
 # Optional payload configuration
 # payload:

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -28,6 +28,7 @@ import (
 	geminiAuth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
 	iflowauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/iflow"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
+	qoderauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qoder"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
@@ -2048,6 +2049,62 @@ func (h *Handler) RequestQwenToken(c *gin.Context) {
 	}()
 
 	c.JSON(200, gin.H{"status": "ok", "url": authURL, "state": state})
+}
+
+func (h *Handler) RequestQoderToken(c *gin.Context) {
+	ctx := context.Background()
+	ctx = PopulateAuthContext(ctx, c)
+
+	fmt.Println("Initializing Qoder authentication...")
+
+	state := fmt.Sprintf("qod-%d", time.Now().UnixNano())
+	qoderAuth := qoderauth.NewQoderAuth(h.cfg)
+
+	deviceFlow, err := qoderAuth.InitiateDeviceFlow(ctx)
+	if err != nil {
+		log.Errorf("Failed to generate authorization URL: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate authorization url"})
+		return
+	}
+
+	RegisterOAuthSession(state, "qoder")
+
+	go func() {
+		fmt.Println("Waiting for authentication...")
+		tokenData, errPollForToken := qoderAuth.PollForToken(ctx, deviceFlow)
+		if errPollForToken != nil {
+			SetOAuthSessionError(state, "Authentication failed")
+			fmt.Printf("Authentication failed: %v\n", errPollForToken)
+			return
+		}
+
+		storage := qoderAuth.CreateTokenStorage(tokenData, deviceFlow.MachineID)
+		if strings.TrimSpace(storage.Email) == "" {
+			storage.Email = fmt.Sprintf("%d", time.Now().UnixMilli())
+		}
+		fileName := fmt.Sprintf("qoder-%s.json", storage.Email)
+		record := &coreauth.Auth{
+			ID:       fileName,
+			Provider: "qoder",
+			FileName: fileName,
+			Label:    "Qoder User",
+			Storage:  storage,
+			Metadata: map[string]any{"email": storage.Email},
+		}
+		savedPath, errSave := h.saveTokenRecord(ctx, record)
+		if errSave != nil {
+			log.Errorf("Failed to save authentication tokens: %v", errSave)
+			SetOAuthSessionError(state, "Failed to save authentication tokens")
+			return
+		}
+
+		fmt.Printf("Authentication successful! Token saved to %s\n", savedPath)
+		fmt.Println("You can now use Qoder services through this CLI")
+		CompleteOAuthSession(state)
+		CompleteOAuthSessionsByProvider("qoder")
+	}()
+
+	c.JSON(200, gin.H{"status": "ok", "url": deviceFlow.VerificationURIComplete, "state": state})
 }
 
 func (h *Handler) RequestKimiToken(c *gin.Context) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -637,6 +637,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/qwen-auth-url", s.mgmt.RequestQwenToken)
 		mgmt.GET("/kimi-auth-url", s.mgmt.RequestKimiToken)
 		mgmt.GET("/iflow-auth-url", s.mgmt.RequestIFlowToken)
+		mgmt.GET("/qoder-auth-url", s.mgmt.RequestQoderToken)
 		mgmt.POST("/iflow-auth-url", s.mgmt.RequestIFlowCookieToken)
 		mgmt.POST("/oauth-callback", s.mgmt.PostOAuthCallback)
 		mgmt.GET("/get-auth-status", s.mgmt.GetAuthStatus)

--- a/internal/auth/qoder/api.go
+++ b/internal/auth/qoder/api.go
@@ -1,0 +1,312 @@
+package qoder
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+)
+
+const (
+	// QoderInferURL is the base URL for Qoder inference API
+	QoderInferURL = "https://api1.qoder.sh"
+	// QoderSigPath is the signing path for COSY authentication
+	QoderSigPath = "/api/v2/service/pro/sse/agent_chat_generation"
+	// QoderChatURL is the full URL for chat API
+	QoderChatURL = QoderInferURL + "/algo" + QoderSigPath + "?AgentId=agent_common"
+)
+
+// ModelMap maps display model names to internal Qoder model keys
+var ModelMap = map[string]string{
+	"auto":                 "auto",
+	"ultimate":             "ultimate",
+	"performance":          "performance",
+	"qwen-coder-qoder-1.0": "qmodel",
+	"qwen3.5-plus":         "q35model",
+	"glm-5":                "gmodel",
+	"kimi-k2.5":            "kmodel",
+	"minimax-m2.7":         "mmodel",
+}
+
+// ChatMessage represents a single message in the chat conversation
+type ChatMessage struct {
+	Role    string      `json:"role"`
+	Content interface{} `json:"content"`
+}
+
+// ChatRequest represents the request body for chat API
+type ChatRequest struct {
+	Messages    []ChatMessage `json:"messages"`
+	Model       string        `json:"model,omitempty"`
+	Temperature *float64      `json:"temperature,omitempty"`
+	MaxTokens   *int          `json:"max_tokens,omitempty"`
+	Stream      bool          `json:"stream"`
+}
+
+// ChatResponse represents a streaming response chunk
+type ChatResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index        int `json:"index"`
+		Delta        struct {
+			Role    string `json:"role,omitempty"`
+			Content string `json:"content,omitempty"`
+		} `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	} `json:"choices"`
+}
+
+// QoderAPI manages API calls to the Qoder cloud
+type QoderAPI struct {
+	httpClient  *http.Client
+	token       string
+	userID      string
+	name        string
+	email       string
+	machineID   string
+	cliVersion  string
+	machineOS   string
+}
+
+// NewQoderAPI creates a new QoderAPI instance
+func NewQoderAPI(cfg *config.Config, token, userID, name, email, machineID string) *QoderAPI {
+	return &QoderAPI{
+		httpClient:  util.SetProxy(&cfg.SDKConfig, &http.Client{}),
+		token:       token,
+		userID:      userID,
+		name:        name,
+		email:       email,
+		machineID:   machineID,
+		cliVersion:  QoderCLIVersion,
+		machineOS:   QoderMachineOS,
+	}
+}
+
+// UpdateCredentials updates the API credentials
+func (api *QoderAPI) UpdateCredentials(token, userID, name, email string) {
+	api.token = token
+	api.userID = userID
+	api.name = name
+	api.email = email
+}
+
+// StreamChat sends a chat request and streams the response
+func (api *QoderAPI) StreamChat(ctx context.Context, messages []ChatMessage, model string) (<-chan string, <-chan error) {
+	resultChan := make(chan string)
+	errorChan := make(chan error, 1)
+
+	go func() {
+		defer close(resultChan)
+		defer close(errorChan)
+
+		// Convert messages to prompt format
+		prompt := messagesToPrompt(messages)
+
+		// Map model name
+		qoderModel := model
+		if mapped, ok := ModelMap[model]; ok {
+			qoderModel = mapped
+		}
+
+		// Build request body
+		reqBody := map[string]interface{}{
+			"question":       prompt,
+			"model":          qoderModel,
+			"stream":         true,
+			"session_id":     uuid.New().String(),
+			"request_id":     uuid.New().String(),
+		}
+
+		bodyBytes, err := json.Marshal(reqBody)
+		if err != nil {
+			errorChan <- fmt.Errorf("failed to marshal request: %w", err)
+			return
+		}
+
+		// Build COSY auth headers
+		headers, err := BuildAuthHeaders(
+			bodyBytes,
+			QoderChatURL,
+			api.userID,
+			api.token,
+			api.name,
+			api.email,
+			api.cliVersion,
+			api.machineOS,
+		)
+		if err != nil {
+			errorChan <- fmt.Errorf("failed to build auth headers: %w", err)
+			return
+		}
+
+		// Create HTTP request
+		req, err := http.NewRequestWithContext(ctx, "POST", QoderChatURL, bytes.NewReader(bodyBytes))
+		if err != nil {
+			errorChan <- fmt.Errorf("failed to create request: %w", err)
+			return
+		}
+
+		// Set headers
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", headers.Authorization)
+		req.Header.Set("Cosy-Key", headers.CosyKey)
+		req.Header.Set("Cosy-User", headers.CosyUser)
+		req.Header.Set("Cosy-Date", headers.CosyDate)
+		req.Header.Set("X-Request-Id", headers.XRequestID)
+		req.Header.Set("X-Machine-OS", headers.XMachineOS)
+		req.Header.Set("X-IDE-Platform", headers.XIDEPlatform)
+		req.Header.Set("X-Version", headers.XVersion)
+		req.Header.Set("Accept", "text/event-stream")
+
+		// Send request
+		resp, err := api.httpClient.Do(req)
+		if err != nil {
+			errorChan <- fmt.Errorf("request failed: %w", err)
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			errorChan <- fmt.Errorf("API request failed: %d %s. Response: %s", resp.StatusCode, resp.Status, string(body))
+			return
+		}
+
+		// Read SSE stream
+		reader := bufio.NewReader(resp.Body)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				if err == io.EOF {
+					return
+				}
+				errorChan <- fmt.Errorf("failed to read stream: %w", err)
+				return
+			}
+
+			line = strings.TrimSpace(line)
+			if line == "" || !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+
+			data := strings.TrimPrefix(line, "data: ")
+			if data == "[DONE]" {
+				return
+			}
+
+			var response ChatResponse
+			if err := json.Unmarshal([]byte(data), &response); err != nil {
+				continue
+			}
+
+			if len(response.Choices) > 0 {
+				content := response.Choices[0].Delta.Content
+				if content != "" {
+					resultChan <- content
+				}
+				if response.Choices[0].FinishReason != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	return resultChan, errorChan
+}
+
+// ListModels returns the list of available models
+func (api *QoderAPI) ListModels() []string {
+	models := make([]string, 0, len(ModelMap))
+	for model := range ModelMap {
+		models = append(models, model)
+	}
+	return models
+}
+
+// messagesToPrompt converts OpenAI-style messages to Qoder prompt format
+func messagesToPrompt(messages []ChatMessage) string {
+	var parts []string
+
+	for _, msg := range messages {
+		content := contentToString(msg.Content)
+		switch msg.Role {
+		case "system":
+			parts = append(parts, fmt.Sprintf("[System Instructions]\n%s", content))
+		case "assistant":
+			parts = append(parts, fmt.Sprintf("[Previous Assistant Response]\n%s", content))
+		case "user":
+			parts = append(parts, content)
+		case "tool":
+			parts = append(parts, fmt.Sprintf("[Tool Result]\n%s", content))
+		}
+	}
+
+	return strings.Join(parts, "\n\n")
+}
+
+// contentToString converts message content to string
+func contentToString(content interface{}) string {
+	switch v := content.(type) {
+	case string:
+		return v
+	case []interface{}:
+		var parts []string
+		for _, item := range v {
+			if itemMap, ok := item.(map[string]interface{}); ok {
+				if text, ok := itemMap["text"].(string); ok {
+					parts = append(parts, text)
+				}
+			}
+		}
+		return strings.Join(parts, "\n")
+	default:
+		return fmt.Sprintf("%v", content)
+	}
+}
+
+// doRefreshToken performs token refresh and saves to storage
+func doRefreshToken(ctx context.Context, cfg *config.Config, storage *QoderTokenStorage) error {
+	auth := NewQoderAuth(cfg)
+	
+	tokenData, err := auth.RefreshTokens(ctx, storage.Token, storage.RefreshToken)
+	if err != nil {
+		return fmt.Errorf("failed to refresh token: %w", err)
+	}
+
+	auth.UpdateTokenStorage(storage, tokenData)
+	return storage.SaveTokenToFile("")
+}
+
+// RefreshTokenIfNeeded checks if token needs refresh and refreshes it
+func RefreshTokenIfNeeded(ctx context.Context, cfg *config.Config, storage *QoderTokenStorage, bufferSeconds int64) error {
+	if storage.ExpireTime == 0 {
+		return nil
+	}
+
+	now := time.Now().UnixMilli()
+	bufferMs := bufferSeconds * 1000
+	
+	if storage.ExpireTime-now-bufferMs <= 0 {
+		return doRefreshToken(ctx, cfg, storage)
+	}
+
+	return nil
+}

--- a/internal/auth/qoder/cosy.go
+++ b/internal/auth/qoder/cosy.go
@@ -1,0 +1,277 @@
+// Package qoder provides authentication and API client functionality
+// for Qoder AI services. It handles OAuth2 device flow authentication,
+// COSY hybrid-encryption signing, and direct API calls to the Qoder cloud.
+package qoder
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// RSA public key for COSY encryption (extracted from Qoder IDE v0.9)
+const qoderRSAPublicKey = `-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDA8iMH5c02LilrsERw9t6Pv5Nc
+4k6Pz1EaDicBMpdpxKduSZu5OANqUq8er4GM95omAGIOPOh+Nx0spthYA2BqGz+l
+6HRkPJ7S236FZz73In/KVuLnwI8JJ2CbuJap8kvheCCZpmAWpb/cPx/3Vr/J6I17
+XcW+ML9FoCI6AOvOzwIDAQAB
+-----END PUBLIC KEY-----`
+
+// UserInfo represents the encrypted user information payload
+type UserInfo struct {
+	UID                string `json:"uid"`
+	SecurityOAuthToken string `json:"security_oauth_token"`
+	Name               string `json:"name"`
+	AID                string `json:"aid"`
+	Email              string `json:"email"`
+}
+
+// CosyPayload represents the payload structure for COSY authentication
+type CosyPayload struct {
+	Version     string `json:"version"`
+	RequestID   string `json:"requestId"`
+	Info        string `json:"info"`
+	CosyVersion string `json:"cosyVersion"`
+	IdeVersion  string `json:"ideVersion"`
+}
+
+// CosyHeaders holds the generated COSY authentication headers
+type CosyHeaders struct {
+	Authorization string
+	CosyKey       string
+	CosyUser      string
+	CosyDate      string
+	XRequestID    string
+	XMachineOS    string
+	XIDEPlatform  string
+	XVersion      string
+}
+
+// parseRSAPublicKey parses the PEM-encoded RSA public key
+func parseRSAPublicKey(pemString string) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemString))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode RSA public key PEM")
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse RSA public key: %w", err)
+	}
+	pubKey, ok := parsed.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("not an RSA public key")
+	}
+	return pubKey, nil
+}
+
+// generateAESKey generates a random 16-character AES key (UUID hex prefix)
+func generateAESKey() ([]byte, error) {
+	id := uuid.New().String()
+	// Remove hyphens and take first 16 characters
+	hexKey := strings.ReplaceAll(id, "-", "")[:16]
+	return []byte(hexKey), nil
+}
+
+// encryptUserInfo performs AES-128-CBC encryption on user info and RSA encryption on AES key
+// Returns (cosyKey_b64, info_b64) where:
+//   - cosyKey_b64 = base64(RSA_PKCS1_encrypt(aes_key_bytes))
+//   - info_b64 = base64(AES-128-CBC_encrypt(json(user_info)))
+func encryptUserInfo(userInfo *UserInfo) (string, string, error) {
+	// Generate random 16-char AES key
+	aesKey, err := generateAESKey()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate AES key: %w", err)
+	}
+
+	// IV = key (matching JS implementation: s.slice(0,16))
+	iv := aesKey[:16]
+
+	// Serialize user info to JSON
+	plaintext, err := json.Marshal(userInfo)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to marshal user info: %w", err)
+	}
+
+	// PKCS7 padding for AES block size
+	padded, err := pkcs7Pad(plaintext, aes.BlockSize)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to pad plaintext: %w", err)
+	}
+
+	// AES-128-CBC encryption
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	ciphertext := make([]byte, len(padded))
+	mode := cipher.NewCBCEncrypter(block, iv)
+	mode.CryptBlocks(ciphertext, padded)
+
+	// Base64 encode the encrypted info
+	infoB64 := base64.StdEncoding.EncodeToString(ciphertext)
+
+	// RSA-PKCS1-v1.5 encrypt the AES key
+	pubKey, err := parseRSAPublicKey(qoderRSAPublicKey)
+	if err != nil {
+		return "", "", err
+	}
+
+	encryptedKey, err := rsa.EncryptPKCS1v15(rand.Reader, pubKey, aesKey)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to encrypt AES key: %w", err)
+	}
+
+	// Base64 encode the encrypted key
+	cosyKeyB64 := base64.StdEncoding.EncodeToString(encryptedKey)
+
+	return cosyKeyB64, infoB64, nil
+}
+
+// pkcs7Pad applies PKCS7 padding to data
+func pkcs7Pad(data []byte, blockSize int) ([]byte, error) {
+	if blockSize < 1 || blockSize > 255 {
+		return nil, fmt.Errorf("invalid block size: %d", blockSize)
+	}
+
+	padding := blockSize - len(data)%blockSize
+	padText := bytesRepeat(byte(padding), padding)
+	return append(data, padText...), nil
+}
+
+// bytesRepeat creates a byte slice with the given byte repeated count times
+func bytesRepeat(b byte, count int) []byte {
+	result := make([]byte, count)
+	for i := range result {
+		result[i] = b
+	}
+	return result
+}
+
+// buildAuthHeaders builds COSY v0.9 auth headers for one request
+// Algorithm from sharedProcessMain.js: encryptUserInfo + generateAuthToken
+func BuildAuthHeaders(body []byte, requestURL string, userID, authToken, name, email, cliVersion, machineOS string) (*CosyHeaders, error) {
+	// Build user info
+	userInfo := &UserInfo{
+		UID:                userID,
+		SecurityOAuthToken: authToken,
+		Name:               name,
+		AID:                "",
+		Email:              email,
+	}
+
+	// Encrypt user info
+	cosyKeyB64, infoB64, err := encryptUserInfo(userInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt user info: %w", err)
+	}
+
+	// Generate request ID and timestamp
+	requestID := uuid.New().String()
+	timestamp := fmt.Sprintf("%d", time.Now().Unix())
+
+	// Build payload JSON → base64
+	payload := &CosyPayload{
+		Version:     "v1",
+		RequestID:   requestID,
+		Info:        infoB64,
+		CosyVersion: cliVersion,
+		IdeVersion:  "",
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal payload: %w", err)
+	}
+	payloadB64 := base64.StdEncoding.EncodeToString(payloadJSON)
+
+	// Signing path: strip /algo prefix and query string
+	parsed, err := url.Parse(requestURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse request URL: %w", err)
+	}
+	sigPath := parsed.Path
+	if strings.HasPrefix(sigPath, "/algo") {
+		sigPath = sigPath[5:]
+	}
+
+	// Signature: MD5(payload_b64 \n cosy_key \n timestamp \n body_str \n sigpath)
+	bodyStr := string(body)
+	sigInput := fmt.Sprintf("%s\n%s\n%s\n%s\n%s", payloadB64, cosyKeyB64, timestamp, bodyStr, sigPath)
+	sig := fmt.Sprintf("%x", md5.Sum([]byte(sigInput)))
+
+	return &CosyHeaders{
+		Authorization: fmt.Sprintf("Bearer COSY.%s.%s", payloadB64, sig),
+		CosyKey:       cosyKeyB64,
+		CosyUser:      userID,
+		CosyDate:      timestamp,
+		XRequestID:    requestID,
+		XMachineOS:    machineOS,
+		XIDEPlatform:  "cli",
+		XVersion:      cliVersion,
+	}, nil
+}
+
+// generateDeviceCodeVerifier generates a PKCE code verifier
+func generateDeviceCodeVerifier() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes), nil
+}
+
+// generateDeviceCodeChallenge creates a SHA-256 hash of the code verifier
+func generateDeviceCodeChallenge(codeVerifier string) string {
+	hash := sha256.Sum256([]byte(codeVerifier))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// generateDevicePKCEPair creates a new code verifier and its corresponding code challenge
+func generateDevicePKCEPair() (string, string, error) {
+	codeVerifier, err := generateDeviceCodeVerifier()
+	if err != nil {
+		return "", "", err
+	}
+	codeChallenge := generateDeviceCodeChallenge(codeVerifier)
+	return codeVerifier, codeChallenge, nil
+}
+
+// generateMachineID generates a persistent machine UUID
+func generateMachineID() string {
+	return uuid.New().String()
+}
+
+// formatExpiresAt converts milliseconds epoch to RFC3339 format
+func formatExpiresAt(expireMs int64) string {
+	return time.Unix(0, expireMs*int64(time.Millisecond)).Format(time.RFC3339)
+}
+
+// parseExpiresAt parses RFC3339 or milliseconds to int64 milliseconds
+func parseExpiresAt(s string) int64 {
+	// Try parsing as RFC3339
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UnixMilli()
+	}
+
+	// Try parsing as Unix milliseconds
+	if ms, err := time.Parse("2006-01-02T15:04:05.999Z07:00", s); err == nil {
+		return ms.UnixMilli()
+	}
+
+	// Default to current time + 30 days
+	return time.Now().Add(30 * 24 * time.Hour).UnixMilli()
+}

--- a/internal/auth/qoder/qoder_auth.go
+++ b/internal/auth/qoder/qoder_auth.go
@@ -1,0 +1,436 @@
+package qoder
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// QoderOpenAPIBase is the base URL for Qoder OpenAPI
+	QoderOpenAPIBase = "https://openapi.qoder.sh"
+	// QoderCenterBase is the base URL for Qoder Center API
+	QoderCenterBase = "https://center.qoder.sh"
+	// QoderLoginURL is the URL for user authentication
+	QoderLoginURL = "https://qoder.com/device/selectAccounts"
+	// QoderOAuthTokenEndpoint is the URL for polling device code token
+	QoderOAuthTokenEndpoint = "https://openapi.qoder.sh/api/v1/deviceToken/poll"
+	// QoderRefreshTokenEndpoint is the URL for refreshing access tokens
+	QoderRefreshTokenEndpoint = "https://center.qoder.sh/algo/api/v3/user/refresh_token"
+	// QoderUserInfoEndpoint is the URL for fetching user information
+	QoderUserInfoEndpoint = "https://openapi.qoder.sh/api/v1/userinfo"
+	// QoderCLIVersion is the CLI version for COSY authentication
+	QoderCLIVersion = "0.9.0"
+	// QoderMachineOS is the machine OS identifier for COSY authentication
+	QoderMachineOS = "x86_64_linux"
+)
+
+// QoderTokenData represents the OAuth credentials from device flow polling
+type QoderTokenData struct {
+	AccessToken  string `json:"token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpireTime   int64  `json:"expire_time"`
+	UserID       string `json:"user_id"`
+	MachineToken string `json:"machine_token"`
+	MachineType  string `json:"machine_type"`
+}
+
+// DeviceFlowResponse represents the response from the device authorization endpoint
+type DeviceFlowResponse struct {
+	// VerificationURIComplete is the full URL with PKCE challenge for user authentication
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	// CodeVerifier is the PKCE code verifier (generated locally, not from server)
+	CodeVerifier string `json:"code_verifier"`
+	// Nonce is the random nonce for the request
+	Nonce string `json:"nonce"`
+	// MachineID is the machine identifier
+	MachineID string `json:"machine_id"`
+}
+
+// DeviceFlowPollResponse represents the token response from polling endpoint
+type DeviceFlowPollResponse struct {
+	Data struct {
+		Token         string `json:"token"`
+		RefreshToken  string `json:"refresh_token"`
+		ExpireTime    int64  `json:"expire_time"`
+		ExpireTimeStr string `json:"expireTime"`
+		UserID        string `json:"user_id"`
+		MachineToken  string `json:"machine_token"`
+		MachineType   string `json:"machineType"`
+	} `json:"data"`
+}
+
+// UserInfoResponse represents the response from user info endpoint
+type UserInfoResponse struct {
+	Data struct {
+		Name     string `json:"name"`
+		Username string `json:"username"`
+		Email    string `json:"email"`
+	} `json:"data"`
+}
+
+// RefreshTokenResponse represents the response from refresh token endpoint
+type RefreshTokenResponse struct {
+	Data struct {
+		Token         string `json:"token"`
+		RefreshToken  string `json:"refresh_token"`
+		ExpireTime    int64  `json:"expire_time"`
+		ExpireTimeStr string `json:"expireTime"`
+	} `json:"data"`
+}
+
+// QoderAuth manages authentication and token handling for the Qoder API
+type QoderAuth struct {
+	httpClient *http.Client
+}
+
+// NewQoderAuth creates a new QoderAuth instance with a proxy-configured HTTP client
+func NewQoderAuth(cfg *config.Config) *QoderAuth {
+	return &QoderAuth{
+		httpClient: util.SetProxy(&cfg.SDKConfig, &http.Client{}),
+	}
+}
+
+// generateCodeVerifier generates a cryptographically random string for PKCE
+func generateCodeVerifier() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes), nil
+}
+
+// generateCodeChallenge creates a SHA-256 hash of the code verifier
+func generateCodeChallenge(codeVerifier string) string {
+	hash := sha256.Sum256([]byte(codeVerifier))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// InitiateDeviceFlow starts the OAuth 2.0 device authorization flow
+// Qoder uses a simplified flow: generate PKCE locally and construct login URL
+func (qa *QoderAuth) InitiateDeviceFlow(ctx context.Context) (*DeviceFlowResponse, error) {
+	// Generate PKCE code verifier and challenge
+	codeVerifier, err := generateCodeVerifier()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate code verifier: %w", err)
+	}
+	codeChallenge := generateCodeChallenge(codeVerifier)
+
+	// Generate nonce and machine ID
+	nonce := uuid.New().String()
+	machineID := generateMachineID()
+
+	// Build login URL (matching Python implementation)
+	loginURL := fmt.Sprintf(
+		"%s?challenge=%s&challenge_method=S256&machine_id=%s&nonce=%s",
+		QoderLoginURL,
+		codeChallenge,
+		machineID,
+		nonce,
+	)
+
+	// Store verifier in URL for later retrieval during polling
+	verificationURIComplete := fmt.Sprintf("%s&verifier=%s", loginURL, codeVerifier)
+
+	return &DeviceFlowResponse{
+		VerificationURIComplete: verificationURIComplete,
+		CodeVerifier:            codeVerifier,
+		Nonce:                   nonce,
+		MachineID:               machineID,
+	}, nil
+}
+
+// PollForToken polls the token endpoint with the device code to obtain an access token
+func (qa *QoderAuth) PollForToken(ctx context.Context, deviceFlow *DeviceFlowResponse) (*QoderTokenData, error) {
+	// Extract code verifier from the URL
+	parsed, err := url.Parse(deviceFlow.VerificationURIComplete)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse verification URI: %w", err)
+	}
+	verifier := parsed.Query().Get("verifier")
+	if verifier == "" {
+		return nil, fmt.Errorf("code verifier not found")
+	}
+
+	nonce := parsed.Query().Get("nonce")
+	if nonce == "" {
+		nonce = deviceFlow.Nonce
+	}
+
+	pollURL := fmt.Sprintf(
+		"%s?nonce=%s&verifier=%s&challenge_method=S256",
+		QoderOAuthTokenEndpoint,
+		nonce,
+		verifier,
+	)
+
+	pollInterval := 2 * time.Second
+	maxAttempts := 90 // 3 minutes max (180 seconds / 2 seconds per poll)
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "GET", pollURL, nil)
+		if err != nil {
+			log.Warnf("Polling attempt %d/%d failed: %v", attempt+1, maxAttempts, err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "Go-http-client/2.0")
+
+		resp, err := qa.httpClient.Do(req)
+		if err != nil {
+			log.Warnf("Polling attempt %d/%d failed: %v", attempt+1, maxAttempts, err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			log.Warnf("Polling attempt %d/%d failed: %v", attempt+1, maxAttempts, err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		if resp.StatusCode == http.StatusAccepted {
+			// Still pending - continue polling
+			log.Debugf("Polling attempt %d/%d... (pending)", attempt+1, maxAttempts)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			// Token not created yet - user hasn't authenticated, continue polling
+			log.Debugf("Polling attempt %d/%d... (token not found, waiting for auth)", attempt+1, maxAttempts)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			// Parse error response
+			var errorData map[string]interface{}
+			if err = json.Unmarshal(body, &errorData); err == nil {
+				if errMsg, ok := errorData["message"].(string); ok {
+					return nil, fmt.Errorf("device token poll failed: %s", errMsg)
+				}
+			}
+			return nil, fmt.Errorf("device token poll failed: %d %s. Response: %s", resp.StatusCode, resp.Status, string(body))
+		}
+
+		// Success - parse token data
+		var response DeviceFlowPollResponse
+		if err = json.Unmarshal(body, &response); err != nil {
+			return nil, fmt.Errorf("failed to parse token response: %w", err)
+		}
+
+		tokenData := &QoderTokenData{
+			AccessToken:  response.Data.Token,
+			RefreshToken: response.Data.RefreshToken,
+			ExpireTime:   response.Data.ExpireTime,
+			UserID:       response.Data.UserID,
+			MachineToken: response.Data.MachineToken,
+			MachineType:  response.Data.MachineType,
+		}
+
+		// If expire time is 0, try parsing from string
+		if tokenData.ExpireTime == 0 && response.Data.ExpireTimeStr != "" {
+			tokenData.ExpireTime = parseExpiresAt(response.Data.ExpireTimeStr)
+		}
+
+		return tokenData, nil
+	}
+
+	return nil, fmt.Errorf("authentication timeout. Please restart the authentication process")
+}
+
+// RefreshTokens exchanges a refresh token for a new access token
+func (qa *QoderAuth) RefreshTokens(ctx context.Context, accessToken, refreshToken string) (*QoderTokenData, error) {
+	reqBody := map[string]string{
+		"refreshToken": refreshToken,
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal refresh request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", QoderRefreshTokenEndpoint, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create refresh request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := qa.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("refresh request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read refresh response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errorData map[string]interface{}
+		if err = json.Unmarshal(body, &errorData); err == nil {
+			if errMsg, ok := errorData["message"].(string); ok {
+				return nil, fmt.Errorf("token refresh failed: %s", errMsg)
+			}
+		}
+		return nil, fmt.Errorf("token refresh failed: %d %s. Response: %s", resp.StatusCode, resp.Status, string(body))
+	}
+
+	var response RefreshTokenResponse
+	if err = json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse refresh response: %w", err)
+	}
+
+	tokenData := &QoderTokenData{
+		AccessToken:  response.Data.Token,
+		RefreshToken: response.Data.RefreshToken,
+		ExpireTime:   response.Data.ExpireTime,
+	}
+
+	// If expire time is 0, try parsing from string
+	if tokenData.ExpireTime == 0 && response.Data.ExpireTimeStr != "" {
+		tokenData.ExpireTime = parseExpiresAt(response.Data.ExpireTimeStr)
+	}
+
+	return tokenData, nil
+}
+
+// FetchUserInfo fetches user information from the API
+func (qa *QoderAuth) FetchUserInfo(ctx context.Context, accessToken string) (name, email string, err error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", QoderUserInfoEndpoint, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create user info request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "Go-http-client/2.0")
+
+	resp, err := qa.httpClient.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("user info request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read user info response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("user info request failed: %d %s", resp.StatusCode, resp.Status)
+	}
+
+	var response UserInfoResponse
+	if err = json.Unmarshal(body, &response); err != nil {
+		return "", "", fmt.Errorf("failed to parse user info response: %w", err)
+	}
+
+	name = response.Data.Name
+	if name == "" {
+		name = response.Data.Username
+	}
+	email = response.Data.Email
+
+	return name, email, nil
+}
+
+// SaveUserInfo stores the user info alongside auth metadata for later use.
+// This mirrors the behavior in qoder-direct.py where user_id is persisted
+// and userinfo fields are updated if available.
+func (qa *QoderAuth) SaveUserInfo(ctx context.Context, accessToken, userID, name, email string) (string, string) {
+	if strings.TrimSpace(accessToken) == "" {
+		return name, email
+	}
+
+	if strings.TrimSpace(name) == "" || strings.TrimSpace(email) == "" {
+		if fetchedName, fetchedEmail, err := qa.FetchUserInfo(ctx, accessToken); err == nil {
+			if strings.TrimSpace(name) == "" {
+				name = fetchedName
+			}
+			if strings.TrimSpace(email) == "" {
+				email = fetchedEmail
+			}
+		}
+	}
+
+	return name, email
+}
+
+// CreateTokenStorage creates a QoderTokenStorage object from a QoderTokenData object
+func (qa *QoderAuth) CreateTokenStorage(tokenData *QoderTokenData, machineID string) *QoderTokenStorage {
+	storage := &QoderTokenStorage{
+		Token:        tokenData.AccessToken,
+		RefreshToken: tokenData.RefreshToken,
+		UserID:       tokenData.UserID,
+		ExpireTime:   tokenData.ExpireTime,
+		LastRefresh:  time.Now().Format(time.RFC3339),
+		MachineID:    machineID,
+		MachineToken: tokenData.MachineToken,
+		MachineType:  tokenData.MachineType,
+	}
+
+	return storage
+}
+
+// UpdateTokenStorage updates an existing token storage with new token data
+func (qa *QoderAuth) UpdateTokenStorage(storage *QoderTokenStorage, tokenData *QoderTokenData) {
+	storage.Token = tokenData.AccessToken
+	storage.RefreshToken = tokenData.RefreshToken
+	storage.ExpireTime = tokenData.ExpireTime
+	storage.LastRefresh = time.Now().Format(time.RFC3339)
+}
+
+// RefreshTokensWithRetry attempts to refresh tokens with a specified number of retries upon failure
+func (qa *QoderAuth) RefreshTokensWithRetry(ctx context.Context, accessToken, refreshToken string, maxRetries int) (*QoderTokenData, error) {
+	var lastErr error
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			// Wait before retry
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Duration(attempt) * time.Second):
+			}
+		}
+
+		tokenData, err := qa.RefreshTokens(ctx, accessToken, refreshToken)
+		if err == nil {
+			return tokenData, nil
+		}
+
+		lastErr = err
+		log.Warnf("Token refresh attempt %d/%d failed: %v", attempt+1, maxRetries, err)
+	}
+
+	return nil, fmt.Errorf("token refresh failed after %d attempts: %w", maxRetries, lastErr)
+}

--- a/internal/auth/qoder/qoder_token.go
+++ b/internal/auth/qoder/qoder_token.go
@@ -1,0 +1,95 @@
+// Package qoder provides authentication and token handling for Qoder API.
+package qoder
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
+)
+
+// QoderTokenStorage stores OAuth2 token information for Qoder API authentication.
+// It maintains compatibility with the existing auth system while adding Qoder-specific fields.
+type QoderTokenStorage struct {
+	// Token is the OAuth2 access token used for authenticating API requests.
+	Token string `json:"token"`
+	// RefreshToken is used to obtain new access tokens when the current one expires.
+	RefreshToken string `json:"refresh_token"`
+	// UserID is the unique identifier for the Qoder user.
+	UserID string `json:"user_id"`
+	// Name is the user's display name.
+	Name string `json:"name"`
+	// Email is the Qoder account email address associated with this token.
+	Email string `json:"email"`
+	// ExpireTime is the timestamp when the current access token expires (milliseconds epoch).
+	ExpireTime int64 `json:"expire_time"`
+	// Type indicates the authentication provider type, always "qoder" for this storage.
+	Type string `json:"type"`
+	// LastRefresh is the timestamp of the last token refresh operation.
+	LastRefresh string `json:"last_refresh"`
+	// MachineID is the persistent machine identifier for this installation.
+	MachineID string `json:"machine_id,omitempty"`
+	// MachineToken is the machine-specific token (if returned by auth server).
+	MachineToken string `json:"machine_token,omitempty"`
+	// MachineType is the type of machine registration.
+	MachineType string `json:"machine_type,omitempty"`
+
+	// Metadata holds arbitrary key-value pairs injected via hooks.
+	// It is not exported to JSON directly to allow flattening during serialization.
+	Metadata map[string]any `json:"-"`
+}
+
+// SetMetadata allows external callers to inject metadata into the storage before saving.
+func (ts *QoderTokenStorage) SetMetadata(meta map[string]any) {
+	ts.Metadata = meta
+}
+
+// SaveTokenToFile serializes the Qoder token storage to a JSON file.
+// This method creates the necessary directory structure and writes the token
+// data in JSON format to the specified file path for persistent storage.
+// It merges any injected metadata into the top-level JSON object.
+//
+// Parameters:
+//   - authFilePath: The full path where the token file should be saved
+//
+// Returns:
+//   - error: An error if the operation fails, nil otherwise
+func (ts *QoderTokenStorage) SaveTokenToFile(authFilePath string) error {
+	misc.LogSavingCredentials(authFilePath)
+	ts.Type = "qoder"
+
+	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+
+	f, err := os.Create(authFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to create token file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	// Merge metadata using helper
+	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)
+	if errMerge != nil {
+		return fmt.Errorf("failed to merge metadata: %w", errMerge)
+	}
+
+	if err = json.NewEncoder(f).Encode(data); err != nil {
+		return fmt.Errorf("failed to write token to file: %w", err)
+	}
+	return nil
+}
+
+// IsExpired checks if the token has expired or will expire within the given duration
+func (ts *QoderTokenStorage) IsExpired(bufferDuration int64) bool {
+	if ts.ExpireTime == 0 {
+		return true
+	}
+	now := time.Now().UnixMilli()
+	return ts.ExpireTime-now-bufferDuration <= 0
+}

--- a/internal/cmd/auth_manager.go
+++ b/internal/cmd/auth_manager.go
@@ -6,7 +6,7 @@ import (
 
 // newAuthManager creates a new authentication manager instance with all supported
 // authenticators and a file-based token store. It initializes authenticators for
-// Gemini, Codex, Claude, and Qwen providers.
+// Gemini, Codex, Claude, Qwen, and Qoder providers.
 //
 // Returns:
 //   - *sdkAuth.Manager: A configured authentication manager instance
@@ -20,6 +20,7 @@ func newAuthManager() *sdkAuth.Manager {
 		sdkAuth.NewIFlowAuthenticator(),
 		sdkAuth.NewAntigravityAuthenticator(),
 		sdkAuth.NewKimiAuthenticator(),
+		sdkAuth.NewQoderAuthenticator(),
 	)
 	return manager
 }

--- a/internal/cmd/qoder_login.go
+++ b/internal/cmd/qoder_login.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+// DoQoderLogin handles the Qoder device flow using the shared authentication manager.
+// It initiates the device-based authentication process for Qoder services and saves
+// the authentication tokens to the configured auth directory.
+//
+// Parameters:
+//   - cfg: The application configuration
+//   - options: Login options including browser behavior and prompts
+func DoQoderLogin(cfg *config.Config, options *LoginOptions) {
+	if options == nil {
+		options = &LoginOptions{}
+	}
+
+	manager := newAuthManager()
+
+	promptFn := options.Prompt
+	if promptFn == nil {
+		promptFn = func(prompt string) (string, error) {
+			fmt.Println()
+			fmt.Println(prompt)
+			var value string
+			_, err := fmt.Scanln(&value)
+			return value, err
+		}
+	}
+
+	authOpts := &sdkAuth.LoginOptions{
+		NoBrowser:    options.NoBrowser,
+		CallbackPort: options.CallbackPort,
+		Metadata:     map[string]string{},
+		Prompt:       promptFn,
+	}
+
+	_, savedPath, err := manager.Login(context.Background(), "qoder", cfg, authOpts)
+	if err != nil {
+		if emailErr, ok := errors.AsType[*sdkAuth.EmailRequiredError](err); ok {
+			log.Error(emailErr.Error())
+			return
+		}
+		fmt.Printf("Qoder authentication failed: %v\n", err)
+		return
+	}
+
+	if savedPath != "" {
+		fmt.Printf("Authentication saved to %s\n", savedPath)
+	}
+
+	fmt.Println("Qoder authentication successful!")
+}

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -20,6 +20,7 @@ type staticModelsJSON struct {
 	Qwen        []*ModelInfo `json:"qwen"`
 	IFlow       []*ModelInfo `json:"iflow"`
 	Kimi        []*ModelInfo `json:"kimi"`
+	Qoder       []*ModelInfo `json:"qoder"`
 	Antigravity []*ModelInfo `json:"antigravity"`
 }
 
@@ -137,6 +138,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		return GetKimiModels()
 	case "antigravity":
 		return GetAntigravityModels()
+	case "qoder":
+		return GetQoderModels()
 	default:
 		return nil
 	}
@@ -161,6 +164,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		data.IFlow,
 		data.Kimi,
 		data.Antigravity,
+		data.Qoder,
 	}
 	for _, models := range allModels {
 		for _, m := range models {
@@ -171,4 +175,9 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 	}
 
 	return nil
+}
+
+// GetQoderModels returns the Qoder model definitions.
+func GetQoderModels() []*ModelInfo {
+	return cloneModelInfos(getModels().Qoder)
 }

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -338,6 +338,7 @@ func validateModelsCatalog(data *staticModelsJSON) error {
 		{name: "qwen", models: data.Qwen},
 		{name: "iflow", models: data.IFlow},
 		{name: "kimi", models: data.Kimi},
+		{name: "qoder", models: data.Qoder},
 		{name: "antigravity", models: data.Antigravity},
 	}
 

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2679,5 +2679,37 @@
       "context_length": 114000,
       "max_completion_tokens": 32768
     }
+  ],
+  "qoder": [
+    {
+      "id": "qwen-coder-qoder-1.0",
+      "name": "Qwen Coder Qoder 1.0",
+      "owned_by": "qoder",
+      "description": "Qoder-tuned Qwen coder model"
+    },
+    {
+      "id": "qwen3.5-plus",
+      "name": "Qwen3.5 Plus",
+      "owned_by": "qoder",
+      "description": "Qwen 3.5 Plus via Qoder"
+    },
+    {
+      "id": "glm-5",
+      "name": "GLM-5",
+      "owned_by": "qoder",
+      "description": "GLM-5 via Qoder"
+    },
+    {
+      "id": "kimi-k2.5",
+      "name": "Kimi K2.5",
+      "owned_by": "qoder",
+      "description": "Kimi K2.5 via Qoder"
+    },
+    {
+      "id": "minimax-m2.7",
+      "name": "MiniMax M2.7",
+      "owned_by": "qoder",
+      "description": "MiniMax M2.7 via Qoder"
+    }
   ]
 }

--- a/internal/runtime/executor/qoder_executor.go
+++ b/internal/runtime/executor/qoder_executor.go
@@ -1,0 +1,734 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	qoderauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qoder"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+)
+
+// QoderExecutor executes requests against the Qoder API with COSY authentication
+type QoderExecutor struct {
+	cfg        *config.Config
+	httpClient *http.Client
+}
+
+// NewQoderExecutor creates a new Qoder executor
+func NewQoderExecutor(cfg *config.Config) *QoderExecutor {
+	return &QoderExecutor{
+		cfg: cfg,
+		httpClient: &http.Client{
+			Timeout: 180 * time.Second,
+		},
+	}
+}
+
+// Identifier returns the provider identifier
+func (e *QoderExecutor) Identifier() string {
+	return "qoder"
+}
+
+// ExecuteStream executes a streaming request against Qoder API
+func (e *QoderExecutor) ExecuteStream(ctx context.Context, authRecord *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	// Get token storage from auth record
+	storage, ok := authRecord.Storage.(*qoderauth.QoderTokenStorage)
+	if !ok {
+		return nil, fmt.Errorf("invalid auth storage type for qoder: %T", authRecord.Storage)
+	}
+
+	// Check if token needs refresh
+	bufferSeconds := int64(600) // 10 minutes
+	if err := qoderauth.RefreshTokenIfNeeded(ctx, e.cfg, storage, bufferSeconds); err != nil {
+		log.Warnf("Qoder token refresh failed: %v", err)
+	}
+
+	// Parse request to get model and messages
+	var chatReq map[string]interface{}
+	if err := json.Unmarshal(req.Payload, &chatReq); err != nil {
+		return nil, fmt.Errorf("failed to parse request: %w", err)
+	}
+
+	// Map model name
+	model, _ := chatReq["model"].(string)
+	qoderModel := model
+	if mapped, ok := qoderauth.ModelMap[model]; ok {
+		qoderModel = mapped
+	}
+
+	// Convert messages to prompt format and normalize tool history
+	messagesRaw, _ := chatReq["messages"].([]interface{})
+	toolsRaw := chatReq["tools"]
+	normalized := normalizeQoderMessages(messagesRaw)
+	useNormalized := hasToolHistory(messagesRaw)
+	prompt := messagesToPromptGeneric(normalized, toolsRaw)
+
+	requestID := uuid.New().String()
+	sessionID := uuid.New().String()
+
+	// Build request body for Qoder API (agent router payload)
+	reqBody := map[string]interface{}{
+		"requestId":           requestID,
+		"sessionId":           sessionID,
+		"questionText":        prompt,
+		"references":          []interface{}{},
+		"mode":                "agent",
+		"sessionType":         "ASSISTANT",
+		"chatTask":            "FREE_INPUT",
+		"stream":              true,
+		"source":              1,
+		"isReply":             false,
+		"taskDefinitionType":  "system",
+		"codeLanguage":        "",
+		"preferredLanguage":   "English",
+		"closeTypewriter":     true,
+		"pluginPayloadConfig": map[string]interface{}{},
+		"chatContext": map[string]interface{}{
+			"text":              prompt,
+			"localeLang":        "English",
+			"preferredLanguage": "English",
+		},
+		"extra": map[string]interface{}{
+			"modelConfig": map[string]interface{}{
+				"key": qoderModel,
+			},
+		},
+		"request_id":       requestID,
+		"request_set_id":   requestID,
+		"chat_record_id":   requestID,
+		"session_id":       sessionID,
+		"agent_id":         "agent_common",
+		"task_id":          "common",
+		"chat_task":        "FREE_INPUT",
+		"version":          "3",
+		"aliyun_user_type": "personal_standard",
+		"session_type":     "ASSISTANT",
+		"parameters": map[string]interface{}{
+			"max_new_tokens": 16384,
+			"max_tokens":     16384,
+		},
+		"model_config": map[string]interface{}{
+			"key":                   qoderModel,
+			"display_name":          qoderModel,
+			"model":                 "",
+			"format":                "",
+			"is_vl":                 false,
+			"is_reasoning":          false,
+			"api_key":               "",
+			"url":                   "",
+			"source":                "",
+			"max_input_tokens":      0,
+			"enable":                false,
+			"price_factor":          0,
+			"original_price_factor": 0,
+			"is_default":            false,
+			"is_new":                false,
+			"exclude_tags":          nil,
+			"tags":                  nil,
+			"icon":                  nil,
+			"strategies":            nil,
+		},
+		"messages": func() []interface{} {
+			if useNormalized {
+				return normalized
+			}
+			return messagesRaw
+		}(),
+	}
+	if toolsRaw != nil {
+		reqBody["tools"] = toolsRaw
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Build COSY auth headers
+	headers, err := qoderauth.BuildAuthHeaders(
+		bodyBytes,
+		qoderauth.QoderChatURL,
+		storage.UserID,
+		storage.Token,
+		storage.Name,
+		storage.Email,
+		qoderauth.QoderCLIVersion,
+		qoderauth.QoderMachineOS,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build COSY auth: %w", err)
+	}
+
+	// Create HTTP request
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", qoderauth.QoderChatURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", headers.Authorization)
+	httpReq.Header.Set("Cosy-Key", headers.CosyKey)
+	httpReq.Header.Set("Cosy-User", headers.CosyUser)
+	httpReq.Header.Set("Cosy-Date", headers.CosyDate)
+	httpReq.Header.Set("X-Request-Id", headers.XRequestID)
+	httpReq.Header.Set("X-Machine-OS", headers.XMachineOS)
+	httpReq.Header.Set("X-IDE-Platform", headers.XIDEPlatform)
+	httpReq.Header.Set("X-Version", headers.XVersion)
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	// Send request
+	httpResp, err := e.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		defer func() { _ = httpResp.Body.Close() }()
+		body, _ := io.ReadAll(httpResp.Body)
+		return nil, newQoderStatusError(httpResp.StatusCode, string(body))
+	}
+
+	// Create streaming channel
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		defer func() { _ = httpResp.Body.Close() }()
+
+		var debugFile *os.File
+		if debugPath := strings.TrimSpace(os.Getenv("QODER_DEBUG_SSE")); debugPath != "" {
+			if f, err := os.OpenFile(debugPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil {
+				debugFile = f
+				defer func() { _ = f.Close() }()
+			}
+		}
+
+		scanner := bufio.NewScanner(httpResp.Body)
+		scanner.Buffer(nil, 52_428_800) // 50MB max line
+
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+			if debugFile != nil {
+				_, _ = debugFile.Write(append([]byte("[raw] "), append(line, '\n')...))
+			}
+
+			// Skip non-data lines
+			if !bytes.HasPrefix(line, []byte("data:")) {
+				continue
+			}
+
+			data := bytes.TrimPrefix(line, []byte("data:"))
+			data = bytes.TrimPrefix(data, []byte(" "))
+			if bytes.Equal(data, []byte("[DONE]")) {
+				return
+			}
+			if debugFile != nil {
+				_, _ = debugFile.Write(append([]byte("[data] "), append(data, '\n')...))
+			}
+
+			// Parse Qoder response envelope
+			var event map[string]interface{}
+			if err := json.Unmarshal(data, &event); err != nil {
+				continue
+			}
+			statusVal := 200
+			if rawStatus, ok := event["statusCodeValue"]; ok {
+				switch v := rawStatus.(type) {
+				case float64:
+					statusVal = int(v)
+				case int:
+					statusVal = v
+				}
+			}
+			innerStr, _ := event["body"].(string)
+			if statusVal != http.StatusOK {
+				msg := innerStr
+				if msg == "" {
+					msg = fmt.Sprintf("upstream status %d", statusVal)
+				}
+				out <- cliproxyexecutor.StreamChunk{Err: newQoderStatusError(statusVal, msg)}
+				return
+			}
+			if innerStr == "" {
+				continue
+			}
+			if innerStr == "[DONE]" {
+				return
+			}
+			var inner map[string]interface{}
+			if err := json.Unmarshal([]byte(innerStr), &inner); err != nil {
+				continue
+			}
+			chunkBytes, err := buildOpenAIChunk(inner, model)
+			if err != nil {
+				continue
+			}
+			out <- cliproxyexecutor.StreamChunk{Payload: chunkBytes}
+		}
+	}()
+
+	return &cliproxyexecutor.StreamResult{
+		Headers: httpResp.Header.Clone(),
+		Chunks:  out,
+	}, nil
+}
+
+// messagesToPromptGeneric converts generic messages to Qoder prompt format
+
+const qoderToolCallInstructions = "[TOOL CALL INSTRUCTIONS]\nWhen you need to use a tool, output EXACTLY this on its own line and stop:\n\nCalled tool: tool_name({\"arg\": \"value\"})\n\nRules — no exceptions:\n- ONLY use the format above. No JSON-only blocks. No ```bash blocks.\n- If a tool is needed, call it IMMEDIATELY — do not describe what you are about to do, just do it.\n- Do NOT say \"I'll run...\", \"Let me check...\", \"Running now\", \"On it\" — output the Called tool line and stop.\n- To run a shell command: Called tool: exec({\"command\":\"your command here\"})\n- Do NOT invent or fabricate tool results. No results until the system returns them.\n- After receiving a tool result, call another tool or write your final answer.\n- Do NOT offer to perform tasks that require tools you do not have access to.\n- If no tool is needed, respond normally."
+
+const qoderBehaviorInstructions = "[BEHAVIOR INSTRUCTIONS]\nPlan before a multi-step task:\n- If completing the task will require more than 2 tool calls, state your plan in one sentence before the first call.\n- Then execute — do not re-explain the plan on each step.\n\nNarrate progress between calls:\n- After every 2-3 tool calls, emit one short status line so the user can follow along (e.g. \"Found the file, now checking contents...\").\n- Keep it to one line — then immediately make the next tool call.\n\nPersist until the task is done:\n- Do NOT give up after one failed attempt. Try at least 2-5 different approaches before concluding something is impossible.\n- If a command fails, read the error message and fix it — wrong flags, wrong path, wrong syntax. Adjust and retry.\n- Only report failure after genuinely exhausting options. Describe what you tried and what each attempt returned.\n\nVerify before you state:\n- Do NOT state facts about emails, files, data, or system state from memory. If you can check it with a tool, check it first.\n- If you are unsure whether something exists or is true, run a tool to find out before answering.\n- Be honest about things you failed to do or are not sure about — do not make claims not supported by what the tools returned.\n\nRead the help before using an unfamiliar command:\n- If you are unsure what flags or arguments a CLI tool accepts, run it with --help first.\n- Example: Called tool: exec({\"command\":\"gog gmail --help\"})\n- The help output will tell you exactly what to do. Use it — do not guess."
+
+func messagesToPromptGeneric(messages []interface{}, tools interface{}) string {
+	parts := make([]string, 0, len(messages)+2)
+	if tools != nil {
+		parts = append(parts, qoderToolCallInstructions)
+		parts = append(parts, qoderBehaviorInstructions)
+	}
+
+	for _, msg := range messages {
+		msgMap, ok := msg.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		role, _ := msgMap["role"].(string)
+		content := extractContentGeneric(msgMap["content"])
+
+		switch role {
+		case "system":
+			parts = append(parts, "[System Instructions]\n"+content)
+		case "assistant":
+			parts = append(parts, "[Previous Assistant Response]\n"+content)
+		case "user":
+			parts = append(parts, content)
+		case "tool":
+			name, _ := msgMap["name"].(string)
+			if name == "" {
+				name = "tool"
+			}
+			parts = append(parts, fmt.Sprintf("[Tool Result for %s]\n%s", name, content))
+		}
+	}
+
+	return strings.Join(parts, "\n\n")
+}
+
+// extractContentGeneric extracts text content from message content field
+func extractContentGeneric(content interface{}) string {
+	switch v := content.(type) {
+	case string:
+		return v
+	case []interface{}:
+		var parts []string
+		for _, item := range v {
+			if itemMap, ok := item.(map[string]interface{}); ok {
+				if itemMap["type"] == "text" {
+					if text, ok := itemMap["text"].(string); ok {
+						parts = append(parts, text)
+					}
+					continue
+				}
+				if text, ok := itemMap["text"].(string); ok {
+					parts = append(parts, text)
+				}
+			}
+		}
+		return strings.Join(parts, "\n")
+	default:
+		return fmt.Sprintf("%v", content)
+	}
+}
+
+func normalizeQoderMessages(messages []interface{}) []interface{} {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]interface{}, 0, len(messages))
+	for _, msg := range messages {
+		msgMap, ok := msg.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		role, _ := msgMap["role"].(string)
+		switch role {
+		case "tool":
+			name, _ := msgMap["name"].(string)
+			if name == "" {
+				name = "tool"
+			}
+			content := extractContentGeneric(msgMap["content"])
+			out = append(out, map[string]interface{}{
+				"role":    "user",
+				"content": fmt.Sprintf("[Tool Result for %s]\n%s", name, content),
+			})
+		case "assistant":
+			if toolCalls, ok := msgMap["tool_calls"].([]interface{}); ok && len(toolCalls) > 0 {
+				parts := make([]string, 0, len(toolCalls))
+				for _, call := range toolCalls {
+					callMap, ok := call.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					fn, _ := callMap["function"].(map[string]interface{})
+					name, _ := fn["name"].(string)
+					args, _ := fn["arguments"].(string)
+					if name == "" {
+						name = "?"
+					}
+					if args == "" {
+						args = "{}"
+					}
+					parts = append(parts, fmt.Sprintf("Called tool: %s(%s)", name, args))
+				}
+				content := extractContentGeneric(msgMap["content"])
+				text := strings.Join(parts, "\n")
+				if content != "" {
+					text = content + "\n" + text
+				}
+				out = append(out, map[string]interface{}{
+					"role":    "assistant",
+					"content": text,
+				})
+				continue
+			}
+			out = append(out, msgMap)
+		default:
+			out = append(out, msgMap)
+		}
+	}
+	return out
+}
+
+func hasToolHistory(messages []interface{}) bool {
+	for _, msg := range messages {
+		msgMap, ok := msg.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		role, _ := msgMap["role"].(string)
+		if role == "tool" {
+			return true
+		}
+		if role == "assistant" {
+			if toolCalls, ok := msgMap["tool_calls"].([]interface{}); ok && len(toolCalls) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func buildOpenAIChunk(inner map[string]interface{}, model string) ([]byte, error) {
+	if inner == nil {
+		return nil, fmt.Errorf("empty inner payload")
+	}
+	if _, ok := inner["model"]; !ok || inner["model"] == "" {
+		inner["model"] = model
+	}
+	if choices, ok := inner["choices"].([]interface{}); ok {
+		if len(choices) == 0 {
+			if inner["finish_reason"] != nil || inner["stop"] != nil {
+				inner["choices"] = []map[string]interface{}{{
+					"index":         0,
+					"delta":         map[string]interface{}{},
+					"finish_reason": "stop",
+				}}
+			}
+		}
+	}
+	return json.Marshal(inner)
+}
+
+// convertToOpenAIChunk converts Qoder response chunk to OpenAI format
+func convertToOpenAIChunk(qoderChunk map[string]interface{}, model string) map[string]interface{} {
+	choices, _ := qoderChunk["choices"].([]interface{})
+	if len(choices) == 0 {
+		return map[string]interface{}{
+			"id":      fmt.Sprintf("qoder-%d", time.Now().UnixNano()),
+			"object":  "chat.completion.chunk",
+			"created": time.Now().Unix(),
+			"model":   model,
+			"choices": []map[string]interface{}{{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "stop"}},
+		}
+	}
+
+	choice, _ := choices[0].(map[string]interface{})
+	delta, _ := choice["delta"].(map[string]interface{})
+	finishReasonRaw, _ := choice["finish_reason"].(interface{})
+
+	var finishReason *string
+	if finishReasonRaw != nil {
+		fr := fmt.Sprintf("%v", finishReasonRaw)
+		finishReason = &fr
+	}
+
+	return map[string]interface{}{
+		"id":      fmt.Sprintf("qoder-%d", time.Now().UnixNano()),
+		"object":  "chat.completion.chunk",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []map[string]interface{}{
+			{
+				"index": 0,
+				"delta": map[string]interface{}{
+					"content": delta["content"],
+				},
+				"finish_reason": finishReason,
+			},
+		},
+	}
+}
+
+// qoderStatusError implements StatusError for Qoder API errors
+type qoderStatusError struct {
+	status  int
+	message string
+}
+
+func newQoderStatusError(status int, message string) *qoderStatusError {
+	return &qoderStatusError{status: status, message: message}
+}
+
+func (e *qoderStatusError) Error() string {
+	return fmt.Sprintf("Qoder API error %d: %s", e.status, e.message)
+}
+
+func (e *qoderStatusError) StatusCode() int {
+	return e.status
+}
+
+// CountTokens estimates token count for the request (placeholder implementation)
+func (e *QoderExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	// Simple estimation: 1 token ≈ 4 characters
+	var chatReq map[string]interface{}
+	if err := json.Unmarshal(req.Payload, &chatReq); err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+
+	messagesRaw, _ := chatReq["messages"].([]interface{})
+	totalChars := 0
+	for _, msg := range messagesRaw {
+		if msgMap, ok := msg.(map[string]interface{}); ok {
+			content := extractContentGeneric(msgMap["content"])
+			totalChars += len(content)
+		}
+	}
+
+	estimatedTokens := totalChars / 4
+	if estimatedTokens < 1 {
+		estimatedTokens = 1
+	}
+
+	response := map[string]interface{}{
+		"usage": map[string]int{
+			"prompt_tokens":     estimatedTokens,
+			"completion_tokens": 0,
+			"total_tokens":      estimatedTokens,
+		},
+	}
+
+	responseBytes, _ := json.Marshal(response)
+	return cliproxyexecutor.Response{
+		Payload: responseBytes,
+	}, nil
+}
+
+// Execute executes a non-streaming request against Qoder API
+func (e *QoderExecutor) Execute(ctx context.Context, authRecord *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	// Use streaming executor and accumulate
+	streamResult, err := e.ExecuteStream(ctx, authRecord, req, opts)
+	if err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+
+	// Accumulate all chunks
+	var content strings.Builder
+	var finishReason string
+	type pendingToolCall struct {
+		ID        string
+		Name      string
+		Arguments string
+	}
+	pendingToolCalls := make(map[int]*pendingToolCall)
+
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			return cliproxyexecutor.Response{}, chunk.Err
+		}
+
+		var oiChunk map[string]interface{}
+		if err := json.Unmarshal(chunk.Payload, &oiChunk); err == nil {
+			if choices, ok := oiChunk["choices"].([]interface{}); ok && len(choices) > 0 {
+				if choice, ok := choices[0].(map[string]interface{}); ok {
+					if delta, ok := choice["delta"].(map[string]interface{}); ok {
+						if toolCalls, ok := delta["tool_calls"].([]interface{}); ok {
+							for _, call := range toolCalls {
+								callMap, ok := call.(map[string]interface{})
+								if !ok {
+									continue
+								}
+								idx := 0
+								if rawIdx, ok := callMap["index"].(float64); ok {
+									idx = int(rawIdx)
+								}
+								entry := pendingToolCalls[idx]
+								if entry == nil {
+									entry = &pendingToolCall{}
+									pendingToolCalls[idx] = entry
+								}
+								if id, ok := callMap["id"].(string); ok && id != "" {
+									entry.ID = id
+								}
+								if fn, ok := callMap["function"].(map[string]interface{}); ok {
+									if name, ok := fn["name"].(string); ok && name != "" {
+										entry.Name = name
+									}
+									if args, ok := fn["arguments"].(string); ok && args != "" {
+										entry.Arguments += args
+									}
+								}
+							}
+						}
+						if contentStr, ok := delta["content"].(string); ok {
+							content.WriteString(contentStr)
+						}
+					}
+					if fr, ok := choice["finish_reason"].(string); ok && fr != "" {
+						finishReason = fr
+					}
+				}
+			}
+		}
+	}
+
+	var toolCalls []map[string]interface{}
+	if finishReason == "tool_calls" && len(pendingToolCalls) > 0 {
+		for i := 0; i < len(pendingToolCalls); i++ {
+			entry, ok := pendingToolCalls[i]
+			if !ok || entry == nil {
+				continue
+			}
+			id := entry.ID
+			if id == "" {
+				id = fmt.Sprintf("call_%d", time.Now().UnixNano())
+			}
+			args := entry.Arguments
+			if strings.TrimSpace(args) == "" {
+				args = "{}"
+			}
+			toolCalls = append(toolCalls, map[string]interface{}{
+				"id":   id,
+				"type": "function",
+				"function": map[string]interface{}{
+					"name":      entry.Name,
+					"arguments": args,
+				},
+			})
+		}
+	}
+
+	// Build final response
+	message := map[string]interface{}{
+		"role":    "assistant",
+		"content": content.String(),
+	}
+	if len(toolCalls) > 0 {
+		message["tool_calls"] = toolCalls
+	}
+	response := map[string]interface{}{
+		"id":      fmt.Sprintf("qoder-%d", time.Now().UnixNano()),
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   req.Model,
+		"choices": []map[string]interface{}{
+			{
+				"index":         0,
+				"message":       message,
+				"finish_reason": finishReason,
+			},
+		},
+	}
+
+	responseBytes, _ := json.Marshal(response)
+	return cliproxyexecutor.Response{
+		Payload: responseBytes,
+		Headers: streamResult.Headers,
+	}, nil
+}
+
+// Refresh attempts to refresh Qoder credentials
+func (e *QoderExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	storage, ok := auth.Storage.(*qoderauth.QoderTokenStorage)
+	if !ok {
+		return nil, fmt.Errorf("invalid auth storage type for qoder")
+	}
+
+	qoderAuth := qoderauth.NewQoderAuth(e.cfg)
+	tokenData, err := qoderAuth.RefreshTokens(ctx, storage.Token, storage.RefreshToken)
+	if err != nil {
+		return nil, err
+	}
+
+	qoderAuth.UpdateTokenStorage(storage, tokenData)
+	return auth, nil
+}
+
+// HttpRequest injects Qoder COSY authentication into the HTTP request and executes it
+func (e *QoderExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
+	storage, ok := auth.Storage.(*qoderauth.QoderTokenStorage)
+	if !ok {
+		return nil, fmt.Errorf("invalid auth storage type for qoder")
+	}
+
+	// Read request body for COSY signing
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	// Build COSY auth headers
+	headers, err := qoderauth.BuildAuthHeaders(
+		bodyBytes,
+		req.URL.String(),
+		storage.UserID,
+		storage.Token,
+		storage.Name,
+		storage.Email,
+		qoderauth.QoderCLIVersion,
+		qoderauth.QoderMachineOS,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build COSY auth: %w", err)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", headers.Authorization)
+	req.Header.Set("Cosy-Key", headers.CosyKey)
+	req.Header.Set("Cosy-User", headers.CosyUser)
+	req.Header.Set("Cosy-Date", headers.CosyDate)
+	req.Header.Set("X-Request-Id", headers.XRequestID)
+	req.Header.Set("X-Machine-OS", headers.XMachineOS)
+	req.Header.Set("X-IDE-Platform", headers.XIDEPlatform)
+	req.Header.Set("X-Version", headers.XVersion)
+
+	// Execute request
+	req = req.WithContext(ctx)
+	return e.httpClient.Do(req)
+}

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	qoderauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qoder"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/geminicli"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -165,6 +166,17 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 				if pt := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType); pt != "" {
 					a.Attributes["plan_type"] = pt
 				}
+			}
+		}
+	}
+	if provider == "qoder" {
+		var storage qoderauth.QoderTokenStorage
+		if raw, errMarshal := json.Marshal(metadata); errMarshal == nil {
+			if errUnmarshal := json.Unmarshal(raw, &storage); errUnmarshal == nil {
+				if strings.TrimSpace(storage.Type) == "" {
+					storage.Type = "qoder"
+				}
+				a.Storage = &storage
 			}
 		}
 	}

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	qoderauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qoder"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -253,6 +254,17 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 	}
 	if email, ok := metadata["email"].(string); ok && email != "" {
 		auth.Attributes["email"] = email
+	}
+	if provider == "qoder" {
+		var storage qoderauth.QoderTokenStorage
+		if raw, errMarshal := json.Marshal(metadata); errMarshal == nil {
+			if errUnmarshal := json.Unmarshal(raw, &storage); errUnmarshal == nil {
+				if strings.TrimSpace(storage.Type) == "" {
+					storage.Type = "qoder"
+				}
+				auth.Storage = &storage
+			}
+		}
 	}
 	return auth, nil
 }

--- a/sdk/auth/qoder.go
+++ b/sdk/auth/qoder.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qoder"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/browser"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+// QoderAuthenticator implements the device flow login for Qoder accounts.
+type QoderAuthenticator struct{}
+
+// NewQoderAuthenticator constructs a Qoder authenticator.
+func NewQoderAuthenticator() *QoderAuthenticator {
+	return &QoderAuthenticator{}
+}
+
+func (a *QoderAuthenticator) Provider() string {
+	return "qoder"
+}
+
+func (a *QoderAuthenticator) RefreshLead() *time.Duration {
+	// Refresh 10 minutes before expiry (matching Python implementation)
+	d := 10 * time.Minute
+	return &d
+}
+
+func (a *QoderAuthenticator) Login(ctx context.Context, cfg *config.Config, opts *LoginOptions) (*coreauth.Auth, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("cliproxy auth: configuration is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if opts == nil {
+		opts = &LoginOptions{}
+	}
+
+	authSvc := qoder.NewQoderAuth(cfg)
+
+	// Initiate device flow
+	deviceFlow, err := authSvc.InitiateDeviceFlow(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("qoder device flow initiation failed: %w", err)
+	}
+
+	authURL := deviceFlow.VerificationURIComplete
+
+	// Open browser or display URL
+	if !opts.NoBrowser {
+		fmt.Println("Opening browser for Qoder authentication")
+		if !browser.IsAvailable() {
+			log.Warn("No browser available; please open the URL manually")
+			fmt.Printf("Visit the following URL to continue authentication:\n%s\n", authURL)
+		} else if err = browser.OpenURL(authURL); err != nil {
+			log.Warnf("Failed to open browser automatically: %v", err)
+			fmt.Printf("Visit the following URL to continue authentication:\n%s\n", authURL)
+		}
+	} else {
+		fmt.Printf("Visit the following URL to continue authentication:\n%s\n", authURL)
+	}
+
+	fmt.Println("Waiting for Qoder authentication...")
+
+	// Poll for token
+	tokenData, err := authSvc.PollForToken(ctx, deviceFlow)
+	if err != nil {
+		return nil, fmt.Errorf("qoder authentication failed: %w", err)
+	}
+
+	// Fetch user info (best effort)
+	name, email, err := authSvc.FetchUserInfo(ctx, tokenData.AccessToken)
+	if err != nil {
+		log.Warnf("Failed to fetch user info: %v", err)
+	}
+
+	// Create token storage
+	tokenStorage := authSvc.CreateTokenStorage(tokenData, deviceFlow.MachineID)
+	if tokenData.UserID != "" {
+		_, _ = authSvc.SaveUserInfo(ctx, tokenData.AccessToken, tokenData.UserID, name, email)
+	}
+
+	// Get email from options if not fetched
+	if email == "" && opts.Metadata != nil {
+		email = opts.Metadata["email"]
+		if email == "" {
+			email = opts.Metadata["alias"]
+		}
+	}
+
+	if email == "" && opts.Prompt != nil {
+		email, err = opts.Prompt("Please input your email address or alias for Qoder:")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return nil, &EmailRequiredError{Prompt: "Please provide an email address or alias for Qoder."}
+	}
+
+	tokenStorage.Email = email
+	tokenStorage.Name = name
+
+	// Generate file name
+	fileName := fmt.Sprintf("qoder-%s.json", tokenStorage.Email)
+	metadata := map[string]any{
+		"email":   tokenStorage.Email,
+		"name":    tokenStorage.Name,
+		"user_id": tokenData.UserID,
+	}
+
+	fmt.Println("Qoder authentication successful")
+	if name != "" {
+		fmt.Printf("Logged in as %s <%s>\n", name, email)
+	}
+
+	return &coreauth.Auth{
+		ID:       fileName,
+		Provider: a.Provider(),
+		FileName: fileName,
+		Storage:  tokenStorage,
+		Metadata: metadata,
+	}, nil
+}

--- a/sdk/auth/refresh_registry.go
+++ b/sdk/auth/refresh_registry.go
@@ -15,6 +15,7 @@ func init() {
 	registerRefreshLead("gemini-cli", func() Authenticator { return NewGeminiAuthenticator() })
 	registerRefreshLead("antigravity", func() Authenticator { return NewAntigravityAuthenticator() })
 	registerRefreshLead("kimi", func() Authenticator { return NewKimiAuthenticator() })
+	registerRefreshLead("qoder", func() Authenticator { return NewQoderAuthenticator() })
 }
 
 func registerRefreshLead(provider string, factory func() Authenticator) {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -425,6 +425,8 @@ func (s *Service) ensureExecutorsForAuthWithMode(a *coreauth.Auth, forceReplace 
 		s.coreManager.RegisterExecutor(executor.NewIFlowExecutor(s.cfg))
 	case "kimi":
 		s.coreManager.RegisterExecutor(executor.NewKimiExecutor(s.cfg))
+	case "qoder":
+		s.coreManager.RegisterExecutor(executor.NewQoderExecutor(s.cfg))
 	default:
 		providerKey := strings.ToLower(strings.TrimSpace(a.Provider))
 		if providerKey == "" {
@@ -907,6 +909,9 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 		models = applyExcludedModels(models, excluded)
 	case "kimi":
 		models = registry.GetKimiModels()
+		models = applyExcludedModels(models, excluded)
+	case "qoder":
+		models = registry.GetQoderModels()
 		models = applyExcludedModels(models, excluded)
 	default:
 		// Handle OpenAI-compatibility providers by name using config


### PR DESCRIPTION
- Add Qoder provider support across auth, registry, watcher, and executor wiring
- Expose Qoder OAuth device-flow login via CLI flag and management endpoint
- Add Qoder model catalog entries and config examples
- Update docs (EN/CN/JA) and note management UI asset refresh