### PR TITLE
fix(gemini-cli): use backend project ID from onboarding response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ _bmad-output/*
 # macOS
 .DS_Store
 ._*
+.gocache/

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -2568,10 +2568,8 @@ func performGeminiCLISetup(ctx context.Context, httpClient *http.Client, storage
 				if explicitProject && !strings.EqualFold(responseProjectID, projectID) {
 					log.Infof("Gemini onboarding: requested project %s maps to backend project %s", projectID, responseProjectID)
 					log.Infof("Using backend project ID: %s", responseProjectID)
-					finalProjectID = responseProjectID
-				} else {
-					finalProjectID = responseProjectID
 				}
+				finalProjectID = responseProjectID
 			}
 
 			storage.ProjectID = strings.TrimSpace(finalProjectID)

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -2566,20 +2566,9 @@ func performGeminiCLISetup(ctx context.Context, httpClient *http.Client, storage
 			finalProjectID := projectID
 			if responseProjectID != "" {
 				if explicitProject && !strings.EqualFold(responseProjectID, projectID) {
-					// Check if this is a free user (gen-lang-client projects or free/legacy tier)
-					isFreeUser := strings.HasPrefix(projectID, "gen-lang-client-") ||
-						strings.EqualFold(tierID, "FREE") ||
-						strings.EqualFold(tierID, "LEGACY")
-
-					if isFreeUser {
-						// For free users, use backend project ID for preview model access
-						log.Infof("Gemini onboarding: frontend project %s maps to backend project %s", projectID, responseProjectID)
-						log.Infof("Using backend project ID: %s (recommended for preview model access)", responseProjectID)
-						finalProjectID = responseProjectID
-					} else {
-						// Pro users: keep requested project ID (original behavior)
-						log.Warnf("Gemini onboarding returned project %s instead of requested %s; keeping requested project ID.", responseProjectID, projectID)
-					}
+					log.Infof("Gemini onboarding: requested project %s maps to backend project %s", projectID, responseProjectID)
+					log.Infof("Using backend project ID: %s", responseProjectID)
+					finalProjectID = responseProjectID
 				} else {
 					finalProjectID = responseProjectID
 				}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -335,10 +335,8 @@ func performGeminiCLISetup(ctx context.Context, httpClient *http.Client, storage
 				if explicitProject && !strings.EqualFold(responseProjectID, projectID) {
 					log.Infof("Gemini onboarding: requested project %s maps to backend project %s", projectID, responseProjectID)
 					log.Infof("Using backend project ID: %s", responseProjectID)
-					finalProjectID = responseProjectID
-				} else {
-					finalProjectID = responseProjectID
 				}
+				finalProjectID = responseProjectID
 			}
 
 			storage.ProjectID = strings.TrimSpace(finalProjectID)

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -333,39 +333,9 @@ func performGeminiCLISetup(ctx context.Context, httpClient *http.Client, storage
 			finalProjectID := projectID
 			if responseProjectID != "" {
 				if explicitProject && !strings.EqualFold(responseProjectID, projectID) {
-					// Check if this is a free user (gen-lang-client projects or free/legacy tier)
-					isFreeUser := strings.HasPrefix(projectID, "gen-lang-client-") ||
-						strings.EqualFold(tierID, "FREE") ||
-						strings.EqualFold(tierID, "LEGACY")
-
-					if isFreeUser {
-						// Interactive prompt for free users
-						fmt.Printf("\nGoogle returned a different project ID:\n")
-						fmt.Printf("  Requested (frontend): %s\n", projectID)
-						fmt.Printf("  Returned (backend):   %s\n\n", responseProjectID)
-						fmt.Printf("  Backend project IDs have access to preview models (gemini-3-*).\n")
-						fmt.Printf("  This is normal for free tier users.\n\n")
-						fmt.Printf("Which project ID would you like to use?\n")
-						fmt.Printf("  [1] Backend (recommended): %s\n", responseProjectID)
-						fmt.Printf("  [2] Frontend: %s\n\n", projectID)
-						fmt.Printf("Enter choice [1]: ")
-
-						reader := bufio.NewReader(os.Stdin)
-						choice, _ := reader.ReadString('\n')
-						choice = strings.TrimSpace(choice)
-
-						if choice == "2" {
-							log.Infof("Using frontend project ID: %s", projectID)
-							fmt.Println(". Warning: Frontend project IDs may not have access to preview models.")
-							finalProjectID = projectID
-						} else {
-							log.Infof("Using backend project ID: %s (recommended)", responseProjectID)
-							finalProjectID = responseProjectID
-						}
-					} else {
-						// Pro users: keep requested project ID (original behavior)
-						log.Warnf("Gemini onboarding returned project %s instead of requested %s; keeping requested project ID.", responseProjectID, projectID)
-					}
+					log.Infof("Gemini onboarding: requested project %s maps to backend project %s", projectID, responseProjectID)
+					log.Infof("Using backend project ID: %s", responseProjectID)
+					finalProjectID = responseProjectID
 				} else {
 					finalProjectID = responseProjectID
 				}

--- a/internal/misc/header_utils.go
+++ b/internal/misc/header_utils.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// GeminiCLIVersion is the version string reported in the User-Agent for upstream requests.
-	GeminiCLIVersion = "0.31.0"
+	GeminiCLIVersion = "0.34.0"
 
 	// GeminiCLIApiClientHeader is the value for the X-Goog-Api-Client header sent to the Gemini CLI upstream.
 	GeminiCLIApiClientHeader = "google-genai-sdk/1.41.0 gl-node/v22.19.0"
@@ -46,7 +46,7 @@ func GeminiCLIUserAgent(model string) string {
 	if model == "" {
 		model = "unknown"
 	}
-	return fmt.Sprintf("GeminiCLI/%s/%s (%s; %s)", GeminiCLIVersion, model, geminiCLIOS(), geminiCLIArch())
+	return fmt.Sprintf("GeminiCLI/%s/%s (%s; %s; terminal)", GeminiCLIVersion, model, geminiCLIOS(), geminiCLIArch())
 }
 
 // ScrubProxyAndFingerprintHeaders removes all headers that could reveal


### PR DESCRIPTION
## Summary
- Simplify Gemini CLI project ID selection to always use the backend project ID returned by the onboarding response, removing the free/pro user distinction that caused authentication failures for some users
- Update Gemini CLI version from 0.31.0 to 0.34.0
- Add 'terminal' to User-Agent string for better client identification

Closes #2391

## Test plan
- [x] Verify Gemini CLI login works correctly with the updated project ID handling
- [x] Confirm authentication errors ("缺少验证") are resolved
- [x] Test with both free and pro tier accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)