### PR TITLE
fix(openai): handle transcript replacement after websocket v2 compaction

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -374,7 +374,7 @@ func shouldReplaceWebsocketTranscript(rawJSON []byte, nextInput gjson.Result) bo
 			return true
 		case "message":
 			role := strings.TrimSpace(item.Get("role").String())
-			if role == "assistant" || role == "developer" {
+			if role == "assistant" {
 				return true
 			}
 		}

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -741,6 +741,32 @@ func TestNormalizeResponsesWebsocketRequestTreatsTranscriptReplacementAsReset(t 
 	}
 }
 
+func TestNormalizeResponsesWebsocketRequestDoesNotTreatDeveloperMessageAsReplacement(t *testing.T) {
+	lastRequest := []byte(`{"model":"test-model","stream":true,"input":[{"type":"message","id":"msg-1"}]}`)
+	lastResponseOutput := []byte(`[
+		{"type":"message","id":"assistant-1","role":"assistant"}
+	]`)
+	raw := []byte(`{"type":"response.create","input":[{"type":"message","id":"dev-1","role":"developer"},{"type":"message","id":"msg-2"}]}`)
+
+	normalized, next, errMsg := normalizeResponsesWebsocketRequest(raw, lastRequest, lastResponseOutput)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	items := gjson.GetBytes(normalized, "input").Array()
+	if len(items) != 4 {
+		t.Fatalf("merged input len = %d, want 4: %s", len(items), normalized)
+	}
+	if items[0].Get("id").String() != "msg-1" ||
+		items[1].Get("id").String() != "assistant-1" ||
+		items[2].Get("id").String() != "dev-1" ||
+		items[3].Get("id").String() != "msg-2" {
+		t.Fatalf("developer follow-up should preserve merge behavior: %s", normalized)
+	}
+	if !bytes.Equal(next, normalized) {
+		t.Fatalf("next request snapshot should match merged request")
+	}
+}
+
 func TestResponsesWebsocketCompactionResetsTurnStateOnTranscriptReplacement(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the WebSocket responses handler incorrectly appends input to stale turn-state after a client replaces its local history with a compacted transcript. When compaction occurs, clients may send a `response.create` request containing historical model output items (such as `function_call` or assistant messages) as a complete replacement rather than an incremental update. The previous implementation treated all incoming input as incremental, leading to duplicated stale state and orphaned `function_call` items.

The fix introduces detection logic to identify when the incoming request represents a full transcript replacement and handles it as a state reset instead of an append operation.

## Bug Fixes

- Add `shouldReplaceWebsocketTranscript()` to detect when input contains historical model output items (`function_call` or assistant/developer messages) without a `previous_response_id`
- Add `normalizeResponseTranscriptReplacement()` to process replacement requests by preserving the new input as-is while inheriting `model` and `instructions` from the last request
- Prevent duplicate turn-state accumulation when clients replace local WebSocket history post-compaction
- Avoid orphaned `function_call` items that previously resulted from incorrect incremental append handling

## Tests and Tooling

- Add `TestNormalizeResponsesWebsocketRequestTreatsTranscriptReplacementAsReset` to verify replacement detection and normalization
- Add `TestResponsesWebsocketCompactionResetsTurnStateOnTranscriptReplacement` for end-to-end validation of the compaction-to-replacement flow
- Introduce `websocketCompactionCaptureExecutor` test helper for capturing stream and compact payloads