### PR TITLE
fix(codex): set finish_reason to "tool_calls" in non-streaming response when tool calls are present

### DIFF
--- a/internal/translator/codex/openai/chat-completions/codex_openai_response.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_response.go
@@ -284,12 +284,12 @@ func ConvertCodexResponseToOpenAINonStream(_ context.Context, _ string, original
 	}
 
 	// Process the output array for content and function calls
+	var toolCalls [][]byte
 	outputResult := responseResult.Get("output")
 	if outputResult.IsArray() {
 		outputArray := outputResult.Array()
 		var contentText string
 		var reasoningText string
-		var toolCalls [][]byte
 
 		for _, outputItem := range outputArray {
 			outputType := outputItem.Get("type").String()
@@ -367,8 +367,12 @@ func ConvertCodexResponseToOpenAINonStream(_ context.Context, _ string, original
 	if statusResult := responseResult.Get("status"); statusResult.Exists() {
 		status := statusResult.String()
 		if status == "completed" {
-			template, _ = sjson.SetBytes(template, "choices.0.finish_reason", "stop")
-			template, _ = sjson.SetBytes(template, "choices.0.native_finish_reason", "stop")
+			finishReason := "stop"
+			if len(toolCalls) > 0 {
+				finishReason = "tool_calls"
+			}
+			template, _ = sjson.SetBytes(template, "choices.0.finish_reason", finishReason)
+			template, _ = sjson.SetBytes(template, "choices.0.native_finish_reason", finishReason)
 		}
 	}
 


### PR DESCRIPTION
Fixes router-for-me/CLIProxyAPI#2443

## Problem

`ConvertCodexResponseToOpenAINonStream` unconditionally sets `finish_reason = "stop"` when the Codex response status is `"completed"`, even when the response contains `tool_calls`. This causes any OpenAI-compatible client that inspects `finish_reason` to incorrectly terminate its agentic loop.

The streaming path (`ConvertCodexResponseToOpenAI`) already handles this correctly by checking `FunctionCallIndex != -1`.

## Fix

Check whether `toolCalls` is non-empty before deciding `finish_reason`, mirroring the streaming path:

```go
// Before
template, _ = sjson.SetBytes(template, "choices.0.finish_reason", "stop")
template, _ = sjson.SetBytes(template, "choices.0.native_finish_reason", "stop")

// After
finishReason := "stop"
if len(toolCalls) > 0 {
    finishReason = "tool_calls"
}
template, _ = sjson.SetBytes(template, "choices.0.finish_reason", finishReason)
template, _ = sjson.SetBytes(template, "choices.0.native_finish_reason", finishReason)
```

## Testing

```bash
# Non-streaming with tool use — now returns "tool_calls"
curl -s '.../v1/chat/completions' \
  -d '{"model":"gpt-5.3-codex","stream":false,"tools":[...],"messages":[...]}' \
  | jq '.choices[0].finish_reason'
# "tool_calls"

# Non-streaming without tools — still returns "stop"
curl -s '.../v1/chat/completions' \
  -d '{"model":"gpt-5.3-codex","stream":false,"messages":[{"role":"user","content":"hi"}]}' \
  | jq '.choices[0].finish_reason'
# "stop"
```
