### PR TITLE
docs: add ProxyPal to "Who is with us?" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Browser-based tool to translate SRT subtitles using your Gemini subscription via
 
 CLI wrapper for instant switching between multiple Claude accounts and alternative models (Gemini, Codex, Antigravity) via CLIProxyAPI OAuth - no API keys needed
 
+### [ProxyPal](https://github.com/buddingnewinsights/proxypal)
+
+Cross-platform desktop app (macOS, Windows, Linux) wrapping CLIProxyAPI with a native GUI. Connects Claude, ChatGPT, Gemini, GitHub Copilot, Qwen, iFlow, and custom OpenAI-compatible endpoints with usage analytics, request monitoring, and auto-configuration for popular coding tools - no API keys needed.
+
 ### [Quotio](https://github.com/nguyenphutrong/quotio)
 
 Native macOS menu bar app that unifies Claude, Gemini, OpenAI, Qwen, and Antigravity subscriptions with real-time quota tracking and smart auto-failover for AI coding tools like Claude Code, OpenCode, and Droid - no API keys needed.

--- a/README_CN.md
+++ b/README_CN.md
@@ -125,6 +125,10 @@ CLIProxyAPI 已内置对 [Amp CLI](https://ampcode.com) 和 Amp IDE 扩展的支
 
 CLI 封装器，用于通过 CLIProxyAPI OAuth 即时切换多个 Claude 账户和替代模型（Gemini, Codex, Antigravity），无需 API 密钥。
 
+### [ProxyPal](https://github.com/buddingnewinsights/proxypal)
+
+跨平台桌面应用（macOS、Windows、Linux），以原生 GUI 封装 CLIProxyAPI。支持连接 Claude、ChatGPT、Gemini、GitHub Copilot、Qwen、iFlow 及自定义 OpenAI 兼容端点，具备使用分析、请求监控和热门编程工具自动配置功能，无需 API 密钥。
+
 ### [Quotio](https://github.com/nguyenphutrong/quotio)
 
 原生 macOS 菜单栏应用，统一管理 Claude、Gemini、OpenAI、Qwen 和 Antigravity 订阅，提供实时配额追踪和智能自动故障转移，支持 Claude Code、OpenCode 和 Droid 等 AI 编程工具，无需 API 密钥。

--- a/README_JA.md
+++ b/README_JA.md
@@ -126,6 +126,10 @@ CLIProxyAPI経由でGeminiサブスクリプションを使用してSRT字幕を
 
 CLIProxyAPI OAuthを使用して複数のClaudeアカウントや代替モデル（Gemini、Codex、Antigravity）を即座に切り替えるCLIラッパー - APIキー不要
 
+### [ProxyPal](https://github.com/buddingnewinsights/proxypal)
+
+CLIProxyAPIをネイティブGUIでラップしたクロスプラットフォームデスクトップアプリ（macOS、Windows、Linux）。Claude、ChatGPT、Gemini、GitHub Copilot、Qwen、iFlow、カスタムOpenAI互換エンドポイントに対応し、使用状況分析、リクエスト監視、人気コーディングツールの自動設定機能を搭載 - APIキー不要
+
 ### [Quotio](https://github.com/nguyenphutrong/quotio)
 
 Claude、Gemini、OpenAI、Qwen、Antigravityのサブスクリプションを統合し、リアルタイムのクォータ追跡とスマート自動フェイルオーバーを備えたmacOSネイティブのメニューバーアプリ。Claude Code、OpenCode、Droidなどのコーディングツール向け - APIキー不要


### PR DESCRIPTION
## Summary

Add [ProxyPal](https://github.com/buddingnewinsights/proxypal) to the community projects list in all three README files (EN, CN, JA).

Closes #2420
Closes #2453

## What is ProxyPal?

ProxyPal is a cross-platform desktop app (macOS, Windows, Linux) wrapping CLIProxyAPI with a native Tauri v2 GUI. It supports multiple AI providers (Claude, ChatGPT, Gemini, GitHub Copilot, Qwen, iFlow), usage analytics, request monitoring, and auto-configuration for popular coding tools.

**Repo**: https://github.com/buddingnewinsights/proxypal

## Changes

- **README.md** — Added ProxyPal entry (English)
- **README_CN.md** — Added ProxyPal entry (Chinese)
- **README_JA.md** — Added ProxyPal entry (Japanese)