### PR TITLE
fix: recursively scan auth subdirectories for credential files / 修复：递归扫描 auth 子目录中的凭据文件

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -310,50 +311,60 @@ func (h *Handler) GetAuthFileModels(c *gin.Context) {
 }
 
 // List auth files from disk when the auth manager is unavailable.
+// It recursively walks subdirectories to discover all JSON credential files.
 func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
-	entries, err := os.ReadDir(h.cfg.AuthDir)
-	if err != nil {
-		c.JSON(500, gin.H{"error": fmt.Sprintf("failed to read auth dir: %v", err)})
-		return
-	}
 	files := make([]gin.H, 0)
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
+	errWalk := filepath.WalkDir(h.cfg.AuthDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
 		}
-		name := e.Name()
-		if !strings.HasSuffix(strings.ToLower(name), ".json") {
-			continue
+		if d.IsDir() {
+			return nil
 		}
-		if info, errInfo := e.Info(); errInfo == nil {
-			fileData := gin.H{"name": name, "size": info.Size(), "modtime": info.ModTime()}
+		if !strings.HasSuffix(strings.ToLower(d.Name()), ".json") {
+			return nil
+		}
+		// Use relative path under AuthDir as the display name so that
+		// subdirectory structure is visible (e.g. "subdir/account.json").
+		name := d.Name()
+		if rel, errRel := filepath.Rel(h.cfg.AuthDir, path); errRel == nil && rel != "" {
+			name = rel
+		}
+		info, errInfo := d.Info()
+		if errInfo != nil {
+			return nil
+		}
+		fileData := gin.H{"name": name, "size": info.Size(), "modtime": info.ModTime()}
 
-			// Read file to get type field
-			full := filepath.Join(h.cfg.AuthDir, name)
-			if data, errRead := os.ReadFile(full); errRead == nil {
-				typeValue := gjson.GetBytes(data, "type").String()
-				emailValue := gjson.GetBytes(data, "email").String()
-				fileData["type"] = typeValue
-				fileData["email"] = emailValue
-				if pv := gjson.GetBytes(data, "priority"); pv.Exists() {
-					switch pv.Type {
-					case gjson.Number:
-						fileData["priority"] = int(pv.Int())
-					case gjson.String:
-						if parsed, errAtoi := strconv.Atoi(strings.TrimSpace(pv.String())); errAtoi == nil {
-							fileData["priority"] = parsed
-						}
-					}
-				}
-				if nv := gjson.GetBytes(data, "note"); nv.Exists() && nv.Type == gjson.String {
-					if trimmed := strings.TrimSpace(nv.String()); trimmed != "" {
-						fileData["note"] = trimmed
+		// Read file to get type field
+		if data, errRead := os.ReadFile(path); errRead == nil {
+			typeValue := gjson.GetBytes(data, "type").String()
+			emailValue := gjson.GetBytes(data, "email").String()
+			fileData["type"] = typeValue
+			fileData["email"] = emailValue
+			if pv := gjson.GetBytes(data, "priority"); pv.Exists() {
+				switch pv.Type {
+				case gjson.Number:
+					fileData["priority"] = int(pv.Int())
+				case gjson.String:
+					if parsed, errAtoi := strconv.Atoi(strings.TrimSpace(pv.String())); errAtoi == nil {
+						fileData["priority"] = parsed
 					}
 				}
 			}
-
-			files = append(files, fileData)
+			if nv := gjson.GetBytes(data, "note"); nv.Exists() && nv.Type == gjson.String {
+				if trimmed := strings.TrimSpace(nv.String()); trimmed != "" {
+					fileData["note"] = trimmed
+				}
+			}
 		}
+
+		files = append(files, fileData)
+		return nil
+	})
+	if errWalk != nil {
+		c.JSON(500, gin.H{"error": fmt.Sprintf("failed to read auth dir: %v", errWalk)})
+		return
 	}
 	c.JSON(200, gin.H{"files": files})
 }

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -33,16 +34,36 @@ func (w *Watcher) start(ctx context.Context) error {
 	}
 	log.Debugf("watching config file: %s", w.configPath)
 
-	if errAddAuthDir := w.watcher.Add(w.authDir); errAddAuthDir != nil {
-		log.Errorf("failed to watch auth directory %s: %v", w.authDir, errAddAuthDir)
-		return errAddAuthDir
+	if errWatch := w.watchAuthDirRecursive(w.authDir); errWatch != nil {
+		return errWatch
 	}
-	log.Debugf("watching auth directory: %s", w.authDir)
 
 	go w.processEvents(ctx)
 
 	w.reloadClients(true, nil, false)
 	return nil
+}
+
+// watchAuthDirRecursive adds fsnotify watches on the auth directory and all its
+// subdirectories so that credential files nested in subfolders are detected.
+func (w *Watcher) watchAuthDirRecursive(root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if path == root {
+				return err // propagate root directory errors (e.g., missing dir)
+			}
+			return nil // skip inaccessible subdirectories
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if errAdd := w.watcher.Add(path); errAdd != nil {
+			log.Warnf("failed to watch auth subdirectory %s: %v", path, errAdd)
+		} else {
+			log.Debugf("watching auth directory: %s", path)
+		}
+		return nil
+	})
 }
 
 func (w *Watcher) processEvents(ctx context.Context) {
@@ -73,6 +94,19 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 	isConfigEvent := normalizedName == normalizedConfigPath && event.Op&configOps != 0
 	authOps := fsnotify.Create | fsnotify.Write | fsnotify.Remove | fsnotify.Rename
 	isAuthJSON := strings.HasPrefix(normalizedName, normalizedAuthDir) && strings.HasSuffix(normalizedName, ".json") && event.Op&authOps != 0
+
+	// When a new subdirectory is created inside the auth directory, start watching it
+	// so that credential files added later are detected.
+	if event.Op&fsnotify.Create != 0 && strings.HasPrefix(normalizedName, normalizedAuthDir) {
+		if info, errStat := os.Stat(event.Name); errStat == nil && info.IsDir() {
+			if errAdd := w.watcher.Add(event.Name); errAdd != nil {
+				log.Warnf("failed to watch new auth subdirectory %s: %v", event.Name, errAdd)
+			} else {
+				log.Debugf("watching new auth subdirectory: %s", event.Name)
+			}
+		}
+	}
+
 	if !isConfigEvent && !isAuthJSON {
 		// Ignore unrelated files (e.g., cookie snapshots *.cookie) and other noise.
 		return

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -3,6 +3,7 @@ package synthesizer
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -25,36 +26,35 @@ func NewFileSynthesizer() *FileSynthesizer {
 }
 
 // Synthesize generates Auth entries from auth files in the auth directory.
+// It recursively walks subdirectories to discover all JSON credential files.
 func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, error) {
 	out := make([]*coreauth.Auth, 0, 16)
 	if ctx == nil || ctx.AuthDir == "" {
 		return out, nil
 	}
 
-	entries, err := os.ReadDir(ctx.AuthDir)
+	err := filepath.WalkDir(ctx.AuthDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(d.Name()), ".json") {
+			return nil
+		}
+		data, errRead := os.ReadFile(path)
+		if errRead != nil || len(data) == 0 {
+			return nil
+		}
+		if auths := synthesizeFileAuths(ctx, path, data); len(auths) > 0 {
+			out = append(out, auths...)
+		}
+		return nil
+	})
 	if err != nil {
 		// Not an error if directory doesn't exist
 		return out, nil
-	}
-
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if !strings.HasSuffix(strings.ToLower(name), ".json") {
-			continue
-		}
-		full := filepath.Join(ctx.AuthDir, name)
-		data, errRead := os.ReadFile(full)
-		if errRead != nil || len(data) == 0 {
-			continue
-		}
-		auths := synthesizeFileAuths(ctx, full, data)
-		if len(auths) == 0 {
-			continue
-		}
-		out = append(out, auths...)
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Problem / 问题描述

Auth credential files placed in subdirectories under the auth directory (e.g., erified/once/account.json) are correctly discovered on Windows but **completely invisible on Linux/Docker deployments**.

auth 目录下子目录中的凭据文件（例如 已验/一次/account.json）在 Windows 上可以正确识别，但在 **Linux/Docker 环境下完全不可见**。

## Root Cause / 根因分析

Three places in the codebase only read the top-level auth directory without recursing into subdirectories:

代码中有三处只读取 auth 根目录，不递归进入子目录：

1. **synthesizer/file.go** - FileSynthesizer.Synthesize() used os.ReadDir() which only lists direct children, and explicitly skipped directories with if e.IsDir() { continue }. This is the core auth state refresh path called by snapshotCoreAuths().

   FileSynthesizer.Synthesize() 使用 os.ReadDir() 只读取一级目录，并用 if e.IsDir() { continue } 直接跳过了所有子目录。这是 snapshotCoreAuths() 调用的核心凭据状态刷新路径。

2. **events.go** - snotify.Watcher.Add() was only called on the root auth directory. Since fsnotify does not recursively watch subdirectories, file changes in subfolders were never detected.

   snotify.Watcher.Add() 只对 auth 根目录添加了监听。由于 fsnotify 不会递归监听子目录，子文件夹中的文件变更永远不会被检测到。

3. **uth_files.go** - The listAuthFilesFromDisk() fallback handler also used os.ReadDir() without recursion.

   listAuthFilesFromDisk() 备用处理器同样使用 os.ReadDir() 而没有递归。

### Why it partially worked on Windows / 为什么在 Windows 上部分可用

The eloadClients() and loadFileClients() methods in clients.go already use ilepath.Walk() for recursive scanning. On Windows, the initial load picked up subdirectory files through these paths, but the Synthesize() path (which builds the actual auth entries for the auth manager) did not.

clients.go 中的 eloadClients() 和 loadFileClients() 已经使用了 ilepath.Walk() 进行递归扫描。在 Windows 上，初始加载通过这些路径发现了子目录文件，但真正构建 auth entries 的 Synthesize() 路径并没有。

## Changes / 修改内容

- **synthesizer/file.go**: Replace os.ReadDir with ilepath.WalkDir to recursively discover all .json credential files in subdirectories

  将 os.ReadDir 替换为 ilepath.WalkDir，递归发现子目录中所有 .json 凭据文件

- **events.go**: Add watchAuthDirRecursive() to register fsnotify watches on all existing subdirectories at startup, and automatically watch newly created subdirectories via Create events

  新增 watchAuthDirRecursive() 方法，在启动时对所有现有子目录注册 fsnotify 监听，并在检测到新子目录创建时自动添加监听

- **uth_files.go**: Update listAuthFilesFromDisk() fallback handler to recursively walk subdirectories and use relative paths as display names

  更新 listAuthFilesFromDisk() 备用处理器，递归遍历子目录并使用相对路径作为显示名称

## Testing / 测试

All existing unit tests pass without modification:

所有现有单元测试均通过，无需修改：

- internal/watcher/... ✅ PASS
- internal/watcher/synthesizer/... ✅ PASS
- internal/api/... ✅ PASS