### PR TITLE
fix(responses): strip prompt_cache_retention and prompt_cache_key before forwarding

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -82,6 +82,11 @@ func (h *OpenAIResponsesAPIHandler) Responses(c *gin.Context) {
 		return
 	}
 
+	// Strip prompt caching parameters that upstream providers do not support.
+	// These are valid OpenAI Responses API fields but cause 400 errors on
+	// providers like Codex that reject unknown parameters.
+	rawJSON = stripUnsupportedCacheParams(rawJSON)
+
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")
 	if streamResult.Type == gjson.True {
@@ -103,6 +108,8 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 		})
 		return
 	}
+
+	rawJSON = stripUnsupportedCacheParams(rawJSON)
 
 	streamResult := gjson.GetBytes(rawJSON, "stream")
 	if streamResult.Type == gjson.True {
@@ -272,4 +279,21 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flush
 			_, _ = c.Writer.Write([]byte("\n"))
 		},
 	})
+}
+
+// stripUnsupportedCacheParams removes prompt caching parameters
+// (prompt_cache_key, prompt_cache_retention) from the request payload.
+// These are valid OpenAI Responses API fields but are rejected by upstream
+// providers (e.g. Codex) that do not recognise them.
+func stripUnsupportedCacheParams(rawJSON []byte) []byte {
+	if gjson.GetBytes(rawJSON, "prompt_cache_retention").Exists() {
+		rawJSON, _ = sjson.DeleteBytes(rawJSON, "prompt_cache_retention")
+	}
+	if gjson.GetBytes(rawJSON, "prompt_cache_key").Exists() {
+		rawJSON, _ = sjson.DeleteBytes(rawJSON, "prompt_cache_key")
+	}
+	if gjson.GetBytes(rawJSON, "safety_identifier").Exists() {
+		rawJSON, _ = sjson.DeleteBytes(rawJSON, "safety_identifier")
+	}
+	return rawJSON
 }


### PR DESCRIPTION
## Summary

Strip `prompt_cache_key`, `prompt_cache_retention`, and `safety_identifier` parameters at the Responses API handler level before routing to any executor.

## Problem

Factory Droid CLI v0.90.0 (OpenAI JS SDK 6.25.0) now sends `prompt_cache_key` and `prompt_cache_retention` parameters in `/v1/responses` requests. These are valid [OpenAI Responses API parameters](https://platform.openai.com/docs/api-reference/responses/create) for prompt caching, but upstream providers (e.g. Codex) reject them:

```
400 {"detail":"Unsupported parameter: prompt_cache_retention"}
```

The Codex executor already strips `prompt_cache_retention`, but other code paths (e.g. OpenAI compat executor) do not, causing 400 errors for users whose requests are routed through those paths.

## Fix

Added `stripUnsupportedCacheParams()` helper that removes these parameters at the handler entry point (`Responses` and `Compact` endpoints), ensuring they are stripped regardless of which executor processes the request.

## Testing

- Verified the fix strips `prompt_cache_retention`, `prompt_cache_key`, and `safety_identifier` before any routing
- Pattern follows existing parameter stripping in the codex executor

Fixes #2466