### PR TITLE
fix(management): make antigravity webui callback ports configurable

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -32,6 +32,13 @@ remote-management:
   # GitHub repository for the management control panel. Accepts a repository URL or releases API URL.
   panel-github-repository: "https://github.com/router-for-me/Cli-Proxy-API-Management-Center"
 
+  # Optional: override the localhost callback port used by the web UI Antigravity OAuth flow on standard instances.
+  # Useful when the provider default callback port conflicts with another listener.
+  antigravity-webui-callback-port: 55121
+
+  # Optional: separate callback port override for premium instances.
+  antigravity-webui-callback-port-premium: 55122
+
 # Authentication directory (supports ~ for home directory)
 auth-dir: "~/.cli-proxy-api"
 

--- a/internal/api/handlers/management/antigravity_callback_port_test.go
+++ b/internal/api/handlers/management/antigravity_callback_port_test.go
@@ -1,0 +1,63 @@
+package management
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestResolveAntigravityWebUICallbackPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		apiPort int
+		cfg     *config.Config
+		want    int
+	}{
+		{
+			name:    "defaults standard instance",
+			apiPort: 8317,
+			cfg:     &config.Config{},
+			want:    defaultAntigravityStandardPort,
+		},
+		{
+			name:    "defaults premium instance",
+			apiPort: 8318,
+			cfg:     &config.Config{},
+			want:    defaultAntigravityPremiumPort,
+		},
+		{
+			name:    "custom standard port from config",
+			apiPort: 8317,
+			cfg: &config.Config{RemoteManagement: config.RemoteManagement{
+				AntigravityWebUICallbackPort: 60121,
+				AntigravityWebUICallbackPortPremium: 60122,
+			}},
+			want: 60121,
+		},
+		{
+			name:    "custom premium port from config",
+			apiPort: 8318,
+			cfg: &config.Config{RemoteManagement: config.RemoteManagement{
+				AntigravityWebUICallbackPort: 60121,
+				AntigravityWebUICallbackPortPremium: 60122,
+			}},
+			want: 60122,
+		},
+		{
+			name:    "fallback to standard default when config is nil",
+			apiPort: 8317,
+			cfg:     nil,
+			want:    defaultAntigravityStandardPort,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Handler{cfg: tt.cfg}
+			got := h.resolveAntigravityWebUICallbackPort(tt.apiPort)
+			if got != tt.want {
+				t.Fatalf("resolveAntigravityWebUICallbackPort(%d) = %d, want %d", tt.apiPort, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -44,11 +44,13 @@ import (
 var lastRefreshKeys = []string{"last_refresh", "lastRefresh", "last_refreshed_at", "lastRefreshedAt"}
 
 const (
-	anthropicCallbackPort = 54545
-	geminiCallbackPort    = 8085
-	codexCallbackPort     = 1455
-	geminiCLIEndpoint     = "https://cloudcode-pa.googleapis.com"
-	geminiCLIVersion      = "v1internal"
+	anthropicCallbackPort       = 54545
+	geminiCallbackPort          = 8085
+	codexCallbackPort           = 1455
+	defaultAntigravityStandardPort = 55121
+	defaultAntigravityPremiumPort  = 55122
+	geminiCLIEndpoint           = "https://cloudcode-pa.googleapis.com"
+	geminiCLIVersion            = "v1internal"
 )
 
 type callbackForwarder struct {
@@ -128,6 +130,24 @@ func isWebUIRequest(c *gin.Context) bool {
 	default:
 		return false
 	}
+}
+
+func (h *Handler) resolveAntigravityWebUICallbackPort(apiPort int) int {
+	if h != nil && h.cfg != nil {
+		if apiPort == 8318 {
+			if port := h.cfg.RemoteManagement.AntigravityWebUICallbackPortPremium; port > 0 {
+				return port
+			}
+			return defaultAntigravityPremiumPort
+		}
+		if port := h.cfg.RemoteManagement.AntigravityWebUICallbackPort; port > 0 {
+			return port
+		}
+	}
+	if apiPort == 8318 {
+		return defaultAntigravityPremiumPort
+	}
+	return defaultAntigravityStandardPort
 }
 
 func startCallbackForwarder(port int, provider, targetBase string) (*callbackForwarder, error) {
@@ -1953,12 +1973,17 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 		return
 	}
 
-	redirectURI := fmt.Sprintf("http://localhost:%d/oauth-callback", antigravity.CallbackPort)
+	isWebUI := isWebUIRequest(c)
+	callbackPort := antigravity.CallbackPort
+	if isWebUI {
+		callbackPort = h.resolveAntigravityWebUICallbackPort(h.cfg.Port)
+	}
+
+	redirectURI := fmt.Sprintf("http://localhost:%d/oauth-callback", callbackPort)
 	authURL := authSvc.BuildAuthURL(state, redirectURI)
 
 	RegisterOAuthSession(state, "antigravity")
 
-	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
 	if isWebUI {
 		targetURL, errTarget := h.managementCallbackURL("/antigravity/callback")
@@ -1968,7 +1993,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 			return
 		}
 		var errStart error
-		if forwarder, errStart = startCallbackForwarder(antigravity.CallbackPort, "antigravity", targetURL); errStart != nil {
+		if forwarder, errStart = startCallbackForwarder(callbackPort, "antigravity", targetURL); errStart != nil {
 			log.WithError(errStart).Error("failed to start antigravity callback forwarder")
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to start callback server"})
 			return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -184,6 +184,10 @@ type RemoteManagement struct {
 	// PanelGitHubRepository overrides the GitHub repository used to fetch the management panel asset.
 	// Accepts either a repository URL (https://github.com/org/repo) or an API releases endpoint.
 	PanelGitHubRepository string `yaml:"panel-github-repository"`
+	// AntigravityWebUICallbackPort overrides the localhost callback port used by the web UI flow on standard instances.
+	AntigravityWebUICallbackPort int `yaml:"antigravity-webui-callback-port"`
+	// AntigravityWebUICallbackPortPremium overrides the localhost callback port used by the web UI flow on premium instances.
+	AntigravityWebUICallbackPortPremium int `yaml:"antigravity-webui-callback-port-premium"`
 }
 
 // QuotaExceeded defines the behavior when API quota limits are exceeded.


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> This PR fixes the Antigravity web UI OAuth callback port conflict in CLIProxyAPI. The web UI callback ports should be configurable so standard and premium instances can run safely side by side without colliding with the default provider callback port.

_The rest of this PR was written by gpt-5.4-adaptive, running in the OpenClaw harness. Full environment + prompt history appear at the end._

# Changes
- add `remote-management.antigravity-webui-callback-port` and `remote-management.antigravity-webui-callback-port-premium` config fields,
- replace the previous web UI Antigravity callback port selection with config-backed resolution plus safe defaults,
- keep the standard and premium web UI flows isolated so they no longer contend for the provider default callback port,
- add a focused management handler test covering default and overridden callback port resolution,
- document the new config knobs in `config.example.yaml`.

# Tests
- `GOTMPDIR=<exec-enabled-temp-dir> GOCACHE=<local-go-cache> go test ./internal/api/handlers/management/... ./internal/config/...` -> passed,
- production verification on two separate local instances -> service health remained `active` and HTTP health checks returned `200`,
- web UI Antigravity auth start returns distinct localhost callback URLs for the standard and premium instances,
- listener verification confirmed that the standard and premium flows bind to separate callback ports and no longer collide with the provider default callback port.

# Risks
- low: introduces two new optional config fields under `remote-management`,
- low: default behavior changes only for the Antigravity web UI flow, not for the CLI login path,
- medium: downstream environments that depend on the old implicit web UI callback port may need to set explicit overrides if they use a custom topology.

# Follow-ups
- consider extending the same config pattern to other management-side OAuth providers if callback port collisions show up elsewhere,
- consider documenting the relationship between provider default callback ports and web UI callback forwarders in the main docs.

# Prompt History

## Environment
Harness: OpenClaw
Model: gpt-5.4
Thinking level: adaptive
Terminal: bash
System: Linux x64

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-04-03T01:54:00+02:00 | `Request to avoid a hardcoded fix and prepare the change properly for PR.` |
| 2026-04-03T01:56:00+02:00 | `Request to continue autonomously until the implementation was complete.` |
| 2026-04-03T02:00:00+02:00 | `Request to open a polished PR in English.` |
| 2026-04-03T02:03:00+02:00 | `Request to override the workflow rule and have the assistant write the summary.` |
| 2026-04-03T02:04:00+02:00 | `This PR fixes the Antigravity web UI OAuth callback port conflict in CLIProxyAPI. The web UI callback ports should be configurable so standard and premium instances can run safely side by side without colliding with the default provider callback port.` |
