### PR TITLE
feat(usage): persist statistics across restarts

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -66,6 +66,13 @@ error-logs-max-files: 10
 # When false, disable in-memory usage statistics aggregation
 usage-statistics-enabled: false
 
+# When true, automatically restore and periodically persist usage statistics snapshots.
+usage-statistics-persistence-enabled: true
+
+# Optional path override for the usage statistics snapshot file.
+# Empty uses WRITABLE_PATH/data/usage-statistics.json or <config dir>/data/usage-statistics.json.
+# usage-statistics-persistence-file: ""
+
 # Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
 # Per-entry proxy-url also supports "direct" or "none" to bypass both the global proxy-url and environment proxies explicitly.
 proxy-url: ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,10 @@ type Config struct {
 
 	// UsageStatisticsEnabled toggles in-memory usage aggregation; when false, usage data is discarded.
 	UsageStatisticsEnabled bool `yaml:"usage-statistics-enabled" json:"usage-statistics-enabled"`
+	// UsageStatisticsPersistenceEnabled toggles writing usage statistics snapshots to disk.
+	UsageStatisticsPersistenceEnabled bool `yaml:"usage-statistics-persistence-enabled" json:"usage-statistics-persistence-enabled"`
+	// UsageStatisticsPersistenceFile overrides the default usage statistics persistence file path.
+	UsageStatisticsPersistenceFile string `yaml:"usage-statistics-persistence-file" json:"usage-statistics-persistence-file"`
 
 	// DisableCooling disables quota cooldown scheduling when true.
 	DisableCooling bool `yaml:"disable-cooling" json:"disable-cooling"`
@@ -567,6 +571,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.LogsMaxTotalSizeMB = 0
 	cfg.ErrorLogsMaxFiles = 10
 	cfg.UsageStatisticsEnabled = false
+	cfg.UsageStatisticsPersistenceEnabled = true
 	cfg.DisableCooling = false
 	cfg.Pprof.Enable = false
 	cfg.Pprof.Addr = DefaultPprofAddr
@@ -619,6 +624,8 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	if cfg.Pprof.Addr == "" {
 		cfg.Pprof.Addr = DefaultPprofAddr
 	}
+
+	cfg.UsageStatisticsPersistenceFile = strings.TrimSpace(cfg.UsageStatisticsPersistenceFile)
 
 	if cfg.LogsMaxTotalSizeMB < 0 {
 		cfg.LogsMaxTotalSizeMB = 0

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -94,3 +94,21 @@ func TestRequestStatisticsMergeSnapshotDedupIgnoresLatency(t *testing.T) {
 		t.Fatalf("details len = %d, want 1", len(details))
 	}
 }
+
+func TestRequestStatisticsRecordFallsBackToProviderIdentifier(t *testing.T) {
+	stats := NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{
+		Provider:    "gemini",
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
+		Detail: coreusage.Detail{
+			InputTokens: 1,
+			TotalTokens: 1,
+		},
+	})
+
+	snapshot := stats.Snapshot()
+	if _, ok := snapshot.APIs["gemini"]; !ok {
+		t.Fatal("expected provider fallback identifier to be recorded")
+	}
+}

--- a/internal/usage/persistence.go
+++ b/internal/usage/persistence.go
@@ -1,0 +1,323 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	persistenceFileName = "usage-statistics.json"
+	persistenceVersion  = 1
+	autosaveInterval    = 5 * time.Minute
+)
+
+var (
+	renameFile = os.Rename
+	removeFile = os.Remove
+)
+
+func backupPath(path string) string {
+	return path + ".bak"
+}
+
+type persistedSnapshot struct {
+	Version    int                `json:"version"`
+	ExportedAt time.Time          `json:"exported_at"`
+	Usage      StatisticsSnapshot `json:"usage"`
+}
+
+type PersistenceManager struct {
+	stats      *RequestStatistics
+	path       string
+	mu         sync.Mutex
+	cancel     context.CancelFunc
+	done       chan struct{}
+	lastSaved  StatisticsSnapshot
+	hasSaved   bool
+}
+
+func NewPersistenceManager(cfg *internalconfig.Config, configFilePath string, stats *RequestStatistics) *PersistenceManager {
+	return &PersistenceManager{
+		stats: stats,
+		path:  resolvePersistencePath(cfg, configFilePath),
+	}
+}
+
+func resolvePersistencePath(cfg *internalconfig.Config, configFilePath string) string {
+	if cfg != nil {
+		if explicit := strings.TrimSpace(cfg.UsageStatisticsPersistenceFile); explicit != "" {
+			return filepath.Clean(explicit)
+		}
+	}
+
+	if writable := util.WritablePath(); writable != "" {
+		return filepath.Join(writable, "data", persistenceFileName)
+	}
+
+	configFilePath = strings.TrimSpace(configFilePath)
+	if configFilePath == "" {
+		return ""
+	}
+
+	base := filepath.Dir(configFilePath)
+	if info, err := os.Stat(configFilePath); err == nil && info.IsDir() {
+		base = configFilePath
+	}
+	if strings.TrimSpace(base) == "" {
+		return ""
+	}
+
+	return filepath.Join(base, "data", persistenceFileName)
+}
+
+func EnabledForConfig(cfg *internalconfig.Config) bool {
+	return cfg != nil && cfg.UsageStatisticsEnabled && cfg.UsageStatisticsPersistenceEnabled
+}
+
+func ResolvePersistencePathForTesting(cfg *internalconfig.Config, configFilePath string) string {
+	return resolvePersistencePath(cfg, configFilePath)
+}
+
+func loadSnapshotFile(path string) (persistedSnapshot, bool, error) {
+	var snapshot persistedSnapshot
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return snapshot, false, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return snapshot, false, nil
+		}
+		return snapshot, false, err
+	}
+
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return persistedSnapshot{}, false, fmt.Errorf("decode usage snapshot: %w", err)
+	}
+	if snapshot.Version != persistenceVersion {
+		return persistedSnapshot{}, false, fmt.Errorf("unsupported usage snapshot version %d", snapshot.Version)
+	}
+
+	return snapshot, true, nil
+}
+
+func saveSnapshotFile(path string, snapshot StatisticsSnapshot) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+
+	payload := persistedSnapshot{
+		Version:    persistenceVersion,
+		ExportedAt: time.Now().UTC(),
+		Usage:      snapshot,
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode usage snapshot: %w", err)
+	}
+	data = append(data, '\n')
+
+	return atomicWriteJSON(path, data)
+}
+
+func snapshotsEqual(a, b StatisticsSnapshot) bool {
+	encodedA, errA := json.Marshal(a)
+	encodedB, errB := json.Marshal(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return string(encodedA) == string(encodedB)
+}
+
+func atomicWriteJSON(path string, data []byte) error {
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), "usage-*.json")
+	if err != nil {
+		return err
+	}
+
+	tmpName := tmpFile.Name()
+	defer func() {
+		_ = tmpFile.Close()
+		_ = removeFile(tmpName)
+	}()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		return err
+	}
+	if err := tmpFile.Chmod(0o600); err != nil {
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return renameFile(tmpName, path)
+		}
+		return err
+	}
+
+	return replaceFileWithBackup(path, tmpName)
+}
+
+func replaceFileWithBackup(path, replacementPath string) error {
+	backup := backupPath(path)
+	if err := removeFile(backup); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := renameFile(path, backup); err != nil {
+		return err
+	}
+	if err := renameFile(replacementPath, path); err != nil {
+		if restoreErr := renameFile(backup, path); restoreErr != nil {
+			return fmt.Errorf("replace usage snapshot: %w (restore backup: %v)", err, restoreErr)
+		}
+		return fmt.Errorf("replace usage snapshot: %w", err)
+	}
+	if err := removeFile(backup); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.WithError(err).Warnf("usage persistence backup cleanup failed: %s", backup)
+	}
+	return nil
+}
+
+func (m *PersistenceManager) Restore() error {
+	if m == nil {
+		return nil
+	}
+
+	primaryPath := strings.TrimSpace(m.path)
+	snapshot, ok, err := loadSnapshotFile(primaryPath)
+	if err != nil && primaryPath != "" {
+		backup := backupPath(primaryPath)
+		backupSnapshot, backupOK, backupErr := loadSnapshotFile(backup)
+		if backupErr == nil && backupOK {
+			snapshot = backupSnapshot
+			ok = true
+			err = nil
+			primaryPath = backup
+		}
+		if err != nil {
+			return err
+		}
+	}
+	if !ok && primaryPath != "" {
+		primaryPath = backupPath(primaryPath)
+		snapshot, ok, err = loadSnapshotFile(primaryPath)
+		if err != nil {
+			return err
+		}
+	}
+	if !ok {
+		return nil
+	}
+	if m.stats == nil {
+		log.Debug("usage persistence restore skipped: statistics store is nil")
+		return nil
+	}
+
+	result := m.stats.MergeSnapshot(snapshot.Usage)
+	m.mu.Lock()
+	m.hasSaved = false
+	m.mu.Unlock()
+	log.Infof("usage persistence restored snapshot from %s (added=%d skipped=%d)", primaryPath, result.Added, result.Skipped)
+	return nil
+}
+
+func (m *PersistenceManager) Save() error {
+	if m == nil || m.stats == nil {
+		return nil
+	}
+	snapshot := m.stats.Snapshot()
+	m.mu.Lock()
+	if m.hasSaved && snapshotsEqual(m.lastSaved, snapshot) {
+		m.mu.Unlock()
+		return nil
+	}
+	m.mu.Unlock()
+	if err := saveSnapshotFile(m.path, snapshot); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.lastSaved = snapshot
+	m.hasSaved = true
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *PersistenceManager) Start(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cancel != nil {
+		return
+	}
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	m.cancel = cancel
+	m.done = done
+
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(autosaveInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-loopCtx.Done():
+				return
+			case <-ticker.C:
+				if err := m.Save(); err != nil {
+					log.WithError(err).Warn("usage persistence autosave failed")
+				}
+			}
+		}
+	}()
+}
+
+func (m *PersistenceManager) StopAndSave() error {
+	if m == nil {
+		return nil
+	}
+
+	m.mu.Lock()
+	cancel := m.cancel
+	done := m.done
+	m.cancel = nil
+	m.done = nil
+	m.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+
+	return m.Save()
+}

--- a/internal/usage/persistence_test.go
+++ b/internal/usage/persistence_test.go
@@ -1,0 +1,562 @@
+package usage
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestResolvePersistencePathPrefersExplicitConfigFile(t *testing.T) {
+	t.Setenv("WRITABLE_PATH", filepath.Join("/tmp", "writable"))
+	cfg := &internalconfig.Config{UsageStatisticsPersistenceFile: "custom/usage.json"}
+
+	got := resolvePersistencePath(cfg, filepath.Join("/tmp", "config", "config.yaml"))
+	want := filepath.Clean("custom/usage.json")
+	if got != want {
+		t.Fatalf("resolvePersistencePath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolvePersistencePathPrefersWritablePath(t *testing.T) {
+	t.Setenv("WRITABLE_PATH", filepath.Join("/tmp", "writable"))
+	cfg := &internalconfig.Config{}
+	configFile := filepath.Join("/tmp", "config", "config.yaml")
+
+	got := resolvePersistencePath(cfg, configFile)
+	want := filepath.Join(filepath.Join("/tmp", "writable"), "data", persistenceFileName)
+	if got != want {
+		t.Fatalf("resolvePersistencePath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolvePersistencePathUsesConfigDirectoryFallback(t *testing.T) {
+	t.Setenv("WRITABLE_PATH", "")
+	cfg := &internalconfig.Config{}
+	configFile := filepath.Join("/tmp", "config", "config.yaml")
+
+	got := resolvePersistencePath(cfg, configFile)
+	want := filepath.Join(filepath.Dir(configFile), "data", persistenceFileName)
+	if got != want {
+		t.Fatalf("resolvePersistencePath() = %q, want %q", got, want)
+	}
+}
+
+func TestLoadSnapshotReturnsEmptyForMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), persistenceFileName)
+
+	snapshot, ok, err := loadSnapshotFile(path)
+	if err != nil {
+		t.Fatalf("loadSnapshotFile() error = %v, want nil", err)
+	}
+	if ok {
+		t.Fatalf("loadSnapshotFile() ok = true, want false")
+	}
+	if snapshot.Version != 0 || !snapshot.ExportedAt.IsZero() || !snapshotsEqual(snapshot.Usage, StatisticsSnapshot{}) {
+		t.Fatalf("loadSnapshotFile() snapshot = %+v, want zero value", snapshot)
+	}
+}
+
+func TestSaveAndLoadSnapshotRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", persistenceFileName)
+	want := testSnapshot(
+		time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		"user@example.com",
+		"0",
+		TokenStats{InputTokens: 20, OutputTokens: 22, TotalTokens: 42},
+		false,
+	)
+
+	if err := saveSnapshotFile(path, want); err != nil {
+		t.Fatalf("saveSnapshotFile() error = %v, want nil", err)
+	}
+
+	assertSnapshotFileEquals(t, path, want)
+	assertSnapshotFilePermissions(t, path, 0o600)
+	assertSnapshotParentDirPermissions(t, path, 0o700)
+}
+
+func TestSaveSnapshotFileOverwritesExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", persistenceFileName)
+	first := testSnapshot(
+		time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		"first@example.com",
+		"0",
+		TokenStats{InputTokens: 20, OutputTokens: 22, TotalTokens: 42},
+		false,
+	)
+	second := testSnapshot(
+		time.Date(2026, 4, 2, 11, 0, 0, 0, time.UTC),
+		"second@example.com",
+		"1",
+		TokenStats{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		true,
+	)
+
+	if err := saveSnapshotFile(path, first); err != nil {
+		t.Fatalf("first saveSnapshotFile() error = %v, want nil", err)
+	}
+	if err := saveSnapshotFile(path, second); err != nil {
+		t.Fatalf("second saveSnapshotFile() error = %v, want nil", err)
+	}
+
+	assertSnapshotFileEquals(t, path, second)
+}
+
+func TestSaveSnapshotFileRestoresPreviousSnapshotWhenReplacementFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", persistenceFileName)
+	first := testSnapshot(
+		time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		"first@example.com",
+		"0",
+		TokenStats{InputTokens: 20, OutputTokens: 22, TotalTokens: 42},
+		false,
+	)
+	second := testSnapshot(
+		time.Date(2026, 4, 2, 11, 0, 0, 0, time.UTC),
+		"second@example.com",
+		"1",
+		TokenStats{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		true,
+	)
+
+	if err := saveSnapshotFile(path, first); err != nil {
+		t.Fatalf("first saveSnapshotFile() error = %v, want nil", err)
+	}
+
+	originalRename := renameFile
+	defer func() { renameFile = originalRename }()
+
+	var replacementFailed bool
+	backup := backupPath(path)
+	renameFile = func(oldPath, newPath string) error {
+		if !replacementFailed && oldPath != backup && newPath == path {
+			replacementFailed = true
+			return errors.New("injected rename failure")
+		}
+		return os.Rename(oldPath, newPath)
+	}
+
+	err := saveSnapshotFile(path, second)
+	if err == nil {
+		t.Fatal("saveSnapshotFile() error = nil, want non-nil")
+	}
+	if !replacementFailed {
+		t.Fatal("replacement rename was not exercised")
+	}
+	if !strings.Contains(err.Error(), "replace usage snapshot") {
+		t.Fatalf("saveSnapshotFile() error = %q, want replace context", err)
+	}
+
+	assertSnapshotFileEquals(t, path, first)
+	if _, statErr := os.Stat(backup); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("backup file stat error = %v, want not exists", statErr)
+	}
+}
+
+func TestSaveSnapshotFileIgnoresBackupCleanupFailureAfterSuccessfulReplace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", persistenceFileName)
+	first := testSnapshot(
+		time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		"first@example.com",
+		"0",
+		TokenStats{InputTokens: 20, OutputTokens: 22, TotalTokens: 42},
+		false,
+	)
+	second := testSnapshot(
+		time.Date(2026, 4, 2, 11, 0, 0, 0, time.UTC),
+		"second@example.com",
+		"1",
+		TokenStats{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		true,
+	)
+
+	if err := saveSnapshotFile(path, first); err != nil {
+		t.Fatalf("first saveSnapshotFile() error = %v, want nil", err)
+	}
+
+	originalRemove := removeFile
+	defer func() { removeFile = originalRemove }()
+
+	backup := backupPath(path)
+	var cleanupAttempted bool
+	removeFile = func(name string) error {
+		if name == backup {
+			if _, err := os.Stat(name); err == nil {
+				cleanupAttempted = true
+				return errors.New("injected cleanup failure")
+			}
+		}
+		return os.Remove(name)
+	}
+
+	if err := saveSnapshotFile(path, second); err != nil {
+		t.Fatalf("saveSnapshotFile() error = %v, want nil", err)
+	}
+	if !cleanupAttempted {
+		t.Fatal("backup cleanup was not exercised")
+	}
+
+	assertSnapshotFileEquals(t, path, second)
+	if _, err := os.Stat(backup); err != nil {
+		t.Fatalf("backup file stat error = %v, want backup to remain after cleanup failure", err)
+	}
+}
+
+func TestPersistenceManagerStartIsIdempotentAndStopAndSavePersistsLatestSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), persistenceFileName)
+	stats := NewRequestStatistics()
+	manager := &PersistenceManager{stats: stats, path: path}
+
+	manager.Start(nil)
+	manager.Start(nil)
+
+	latest := testSnapshot(
+		time.Date(2026, 4, 2, 12, 0, 0, 0, time.UTC),
+		"latest@example.com",
+		"2",
+		TokenStats{InputTokens: 30, OutputTokens: 12, TotalTokens: 42},
+		false,
+	)
+	stats.MergeSnapshot(latest)
+
+	if err := manager.StopAndSave(); err != nil {
+		t.Fatalf("StopAndSave() error = %v, want nil", err)
+	}
+
+	assertSnapshotFileEquals(t, path, latest)
+}
+
+func TestPersistenceManagerSaveSkipsRewriteWhenSnapshotUnchanged(t *testing.T) {
+	path := filepath.Join(t.TempDir(), persistenceFileName)
+	stats := NewRequestStatistics()
+	manager := &PersistenceManager{stats: stats, path: path}
+
+	snapshot := testSnapshot(
+		time.Date(2026, 4, 2, 12, 0, 0, 0, time.UTC),
+		"stable@example.com",
+		"2",
+		TokenStats{InputTokens: 30, OutputTokens: 12, TotalTokens: 42},
+		false,
+	)
+	stats.MergeSnapshot(snapshot)
+
+	if err := manager.Save(); err != nil {
+		t.Fatalf("first Save() error = %v, want nil", err)
+	}
+	firstData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() after first Save error = %v, want nil", err)
+	}
+
+	if err := manager.Save(); err != nil {
+		t.Fatalf("second Save() error = %v, want nil", err)
+	}
+	secondData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() after second Save error = %v, want nil", err)
+	}
+
+	if string(secondData) != string(firstData) {
+		t.Fatal("Save() rewrote snapshot despite no usage changes")
+	}
+}
+
+func TestPersistenceManagerRestoreMarksManagerDirtyAndMergesSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), persistenceFileName)
+	stats := NewRequestStatistics()
+	existingTimestamp := time.Date(2026, 4, 2, 9, 0, 0, 0, time.UTC)
+	stats.MergeSnapshot(StatisticsSnapshot{
+		APIs: map[string]APISnapshot{
+			"api-key": {
+				Models: map[string]ModelSnapshot{
+					"gpt-5.4": {
+						Details: []RequestDetail{{
+							Timestamp: existingTimestamp,
+							Source:    "existing",
+							AuthIndex: "0",
+							Tokens:    TokenStats{InputTokens: 10, TotalTokens: 10},
+						}},
+					},
+				},
+			},
+		},
+	})
+
+	importTimestamp := time.Date(2026, 4, 2, 10, 0, 0, 0, time.UTC)
+	importSnapshot := StatisticsSnapshot{
+		APIs: map[string]APISnapshot{
+			"api-key": {
+				Models: map[string]ModelSnapshot{
+					"gpt-5.4": {
+						Details: []RequestDetail{
+							{
+								Timestamp: existingTimestamp,
+								Source:    "existing",
+								AuthIndex: "0",
+								Tokens:    TokenStats{InputTokens: 10, TotalTokens: 10},
+							},
+							{
+								Timestamp: importTimestamp,
+								Source:    "imported",
+								AuthIndex: "1",
+								Tokens:    TokenStats{InputTokens: 20, TotalTokens: 20},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := saveSnapshotFile(path, importSnapshot); err != nil {
+		t.Fatalf("saveSnapshotFile() error = %v, want nil", err)
+	}
+
+	manager := &PersistenceManager{stats: stats, path: path}
+	if err := manager.Restore(); err != nil {
+		t.Fatalf("Restore() error = %v, want nil", err)
+	}
+
+	got := stats.Snapshot()
+	details := got.APIs["api-key"].Models["gpt-5.4"].Details
+	if len(details) != 2 {
+		t.Fatalf("details len = %d, want 2", len(details))
+	}
+	if got.TotalRequests != 2 {
+		t.Fatalf("TotalRequests = %d, want 2", got.TotalRequests)
+	}
+	if got.TotalTokens != 30 {
+		t.Fatalf("TotalTokens = %d, want 30", got.TotalTokens)
+	}
+
+	if err := manager.Save(); err != nil {
+		t.Fatalf("Save() after Restore error = %v, want nil", err)
+	}
+	assertSnapshotFileEquals(t, path, got)
+}
+
+func TestPersistenceManagerRestorePreservesFallbackProviderIdentifier(t *testing.T) {
+	path := filepath.Join(t.TempDir(), persistenceFileName)
+	stats := NewRequestStatistics()
+	fallbackIdentifier := "gemini"
+	importSnapshot := StatisticsSnapshot{
+		APIs: map[string]APISnapshot{
+			fallbackIdentifier: {
+				Models: map[string]ModelSnapshot{
+					"gpt-5.4": {
+						Details: []RequestDetail{{
+							Timestamp: time.Date(2026, 4, 2, 10, 0, 0, 0, time.UTC),
+							Source:    "imported",
+							AuthIndex: "1",
+							Tokens:    TokenStats{InputTokens: 20, TotalTokens: 20},
+						}},
+					},
+				},
+			},
+		},
+	}
+	if err := saveSnapshotFile(path, importSnapshot); err != nil {
+		t.Fatalf("saveSnapshotFile() error = %v, want nil", err)
+	}
+
+	manager := &PersistenceManager{stats: stats, path: path}
+	if err := manager.Restore(); err != nil {
+		t.Fatalf("Restore() error = %v, want nil", err)
+	}
+
+	got := stats.Snapshot()
+	if _, ok := got.APIs[fallbackIdentifier]; !ok {
+		t.Fatalf("Restore() changed fallback identifier %q", fallbackIdentifier)
+	}
+}
+
+func TestPersistenceManagerRestoreFallsBackToBackupWhenPrimaryMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), persistenceFileName)
+	backup := backupPath(path)
+	want := testSnapshot(
+		time.Date(2026, 4, 2, 10, 0, 0, 0, time.UTC),
+		"imported",
+		"1",
+		TokenStats{InputTokens: 20, OutputTokens: 10, TotalTokens: 30},
+		false,
+	)
+	if err := saveSnapshotFile(backup, want); err != nil {
+		t.Fatalf("saveSnapshotFile() backup error = %v, want nil", err)
+	}
+
+	stats := NewRequestStatistics()
+	manager := &PersistenceManager{stats: stats, path: path}
+	if err := manager.Restore(); err != nil {
+		t.Fatalf("Restore() error = %v, want nil", err)
+	}
+
+	got := stats.Snapshot()
+	if !snapshotsEqual(got, want) {
+		encodedGot, _ := json.Marshal(got)
+		encodedWant, _ := json.Marshal(want)
+		t.Fatalf("restored snapshot = %s, want %s", encodedGot, encodedWant)
+	}
+}
+
+func TestPersistenceManagerRestoreFallsBackToBackupWhenPrimaryIsCorrupt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), persistenceFileName)
+	backup := backupPath(path)
+	want := testSnapshot(
+		time.Date(2026, 4, 2, 10, 0, 0, 0, time.UTC),
+		"imported",
+		"1",
+		TokenStats{InputTokens: 20, OutputTokens: 10, TotalTokens: 30},
+		false,
+	)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v, want nil", err)
+	}
+	if err := os.WriteFile(path, []byte("{not-json"), 0o644); err != nil {
+		t.Fatalf("WriteFile() primary error = %v, want nil", err)
+	}
+	if err := saveSnapshotFile(backup, want); err != nil {
+		t.Fatalf("saveSnapshotFile() backup error = %v, want nil", err)
+	}
+
+	stats := NewRequestStatistics()
+	manager := &PersistenceManager{stats: stats, path: path}
+	if err := manager.Restore(); err != nil {
+		t.Fatalf("Restore() error = %v, want nil", err)
+	}
+
+	got := stats.Snapshot()
+	if !snapshotsEqual(got, want) {
+		encodedGot, _ := json.Marshal(got)
+		encodedWant, _ := json.Marshal(want)
+		t.Fatalf("restored snapshot = %s, want %s", encodedGot, encodedWant)
+	}
+}
+
+func TestPersistenceManagerRestoreReturnsErrorOnBadSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), persistenceFileName)
+	if err := os.WriteFile(path, []byte("{not-json"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v, want nil", err)
+	}
+
+	manager := &PersistenceManager{stats: NewRequestStatistics(), path: path}
+	if err := manager.Restore(); err == nil {
+		t.Fatal("Restore() error = nil, want non-nil")
+	}
+}
+
+func TestEnabledForConfigRequiresUsageCollection(t *testing.T) {
+	if EnabledForConfig(nil) {
+		t.Fatal("EnabledForConfig(nil) = true, want false")
+	}
+	if EnabledForConfig(&internalconfig.Config{UsageStatisticsEnabled: false, UsageStatisticsPersistenceEnabled: true}) {
+		t.Fatal("EnabledForConfig() = true when collection disabled, want false")
+	}
+	if EnabledForConfig(&internalconfig.Config{UsageStatisticsEnabled: true, UsageStatisticsPersistenceEnabled: false}) {
+		t.Fatal("EnabledForConfig() = true when persistence disabled, want false")
+	}
+	if !EnabledForConfig(&internalconfig.Config{UsageStatisticsEnabled: true, UsageStatisticsPersistenceEnabled: true}) {
+		t.Fatal("EnabledForConfig() = false, want true")
+	}
+}
+
+func assertSnapshotFileEquals(t *testing.T, path string, want StatisticsSnapshot) {
+	t.Helper()
+
+	got, ok, err := loadSnapshotFile(path)
+	if err != nil {
+		t.Fatalf("loadSnapshotFile() error = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatalf("loadSnapshotFile() ok = false, want true")
+	}
+	if got.Version != persistenceVersion {
+		t.Fatalf("Version = %d, want %d", got.Version, persistenceVersion)
+	}
+	if got.ExportedAt.IsZero() {
+		t.Fatal("ExportedAt = zero, want non-zero timestamp")
+	}
+	if !snapshotsEqual(got.Usage, want) {
+		encodedGot, _ := json.Marshal(got.Usage)
+		encodedWant, _ := json.Marshal(want)
+		t.Fatalf("Usage = %s, want %s", encodedGot, encodedWant)
+	}
+}
+
+func assertSnapshotFilePermissions(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode enforcement is not supported on Windows")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v, want nil", err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("file permissions = %03o, want %03o", got, want)
+	}
+}
+
+func assertSnapshotParentDirPermissions(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("directory mode enforcement is not supported on Windows")
+	}
+
+	info, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("Stat() parent dir error = %v, want nil", err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("parent dir permissions = %03o, want %03o", got, want)
+	}
+}
+
+func testSnapshot(timestamp time.Time, source, authIndex string, tokens TokenStats, failed bool) StatisticsSnapshot {
+	return StatisticsSnapshot{
+		TotalRequests: 1,
+		SuccessCount:  boolToCount(!failed),
+		FailureCount:  boolToCount(failed),
+		TotalTokens:   tokens.TotalTokens,
+		APIs: map[string]APISnapshot{
+			"api-key": {
+				TotalRequests: 1,
+				TotalTokens:   tokens.TotalTokens,
+				Models: map[string]ModelSnapshot{
+					"gpt-5.4": {
+						TotalRequests: 1,
+						TotalTokens:   tokens.TotalTokens,
+						Details: []RequestDetail{{
+							Timestamp: timestamp,
+							LatencyMs: 500,
+							Source:    source,
+							AuthIndex: authIndex,
+							Tokens:    tokens,
+							Failed:    failed,
+						}},
+					},
+				},
+			},
+		},
+		RequestsByDay:  map[string]int64{timestamp.Format("2006-01-02"): 1},
+		RequestsByHour: map[string]int64{timestamp.Format("15"): 1},
+		TokensByDay:    map[string]int64{timestamp.Format("2006-01-02"): tokens.TotalTokens},
+		TokensByHour:   map[string]int64{timestamp.Format("15"): tokens.TotalTokens},
+	}
+}
+
+func boolToCount(value bool) int64 {
+	if value {
+		return 1
+	}
+	return 0
+}
+

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
-	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/wsrelay"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
@@ -89,6 +89,9 @@ type Service struct {
 
 	// wsGateway manages websocket Gemini providers.
 	wsGateway *wsrelay.Manager
+
+	// usagePersistence persists usage statistics snapshots across service restarts.
+	usagePersistence *internalusage.PersistenceManager
 }
 
 // RegisterUsagePlugin registers a usage plugin on the global usage manager.
@@ -474,7 +477,7 @@ func (s *Service) rebindExecutors() {
 //
 // Returns:
 //   - error: An error if the service fails to start or run
-func (s *Service) Run(ctx context.Context) error {
+func (s *Service) Run(ctx context.Context) (runErr error) {
 	if s == nil {
 		return fmt.Errorf("cliproxy: service is nil")
 	}
@@ -483,12 +486,24 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 
 	usage.StartDefault(ctx)
+	if internalusage.EnabledForConfig(s.cfg) {
+		s.usagePersistence = internalusage.NewPersistenceManager(s.cfg, s.configPath, internalusage.GetRequestStatistics())
+		if err := s.usagePersistence.Restore(); err != nil {
+			log.WithError(err).Warn("failed to restore usage statistics snapshot")
+		}
+		s.usagePersistence.Start(ctx)
+	}
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer shutdownCancel()
 	defer func() {
 		if err := s.Shutdown(shutdownCtx); err != nil {
 			log.Errorf("service shutdown returned error: %v", err)
+			if runErr == nil {
+				runErr = err
+				return
+			}
+			runErr = errors.Join(runErr, err)
 		}
 	}()
 
@@ -650,6 +665,9 @@ func (s *Service) Run(ctx context.Context) error {
 			s.coreManager.SetSelector(selector)
 		}
 
+		oldPersistenceEnabled := internalusage.EnabledForConfig(s.cfg)
+		oldPersistencePath := internalusage.ResolvePersistencePathForTesting(s.cfg, s.configPath)
+
 		s.applyRetryConfig(newCfg)
 		s.applyPprofConfig(newCfg)
 		if s.server != nil {
@@ -661,6 +679,26 @@ func (s *Service) Run(ctx context.Context) error {
 		if s.coreManager != nil {
 			s.coreManager.SetConfig(newCfg)
 			s.coreManager.SetOAuthModelAlias(newCfg.OAuthModelAlias)
+		}
+		newPersistenceEnabled := internalusage.EnabledForConfig(newCfg)
+		newPersistencePath := internalusage.ResolvePersistencePathForTesting(newCfg, s.configPath)
+		if oldPersistenceEnabled != newPersistenceEnabled || oldPersistencePath != newPersistencePath {
+			if s.usagePersistence != nil {
+				if err := s.usagePersistence.StopAndSave(); err != nil {
+					log.WithError(err).Warn("failed to persist usage statistics snapshot before config reload")
+				}
+				s.usagePersistence = nil
+			}
+			if newPersistenceEnabled {
+				s.usagePersistence = internalusage.NewPersistenceManager(newCfg, s.configPath, internalusage.GetRequestStatistics())
+				if err := s.usagePersistence.Restore(); err != nil {
+					log.WithError(err).Warn("failed to restore usage statistics snapshot after config reload")
+				}
+				if err := s.usagePersistence.Save(); err != nil {
+					log.WithError(err).Warn("failed to seed usage statistics snapshot after config reload")
+				}
+				s.usagePersistence.Start(ctx)
+			}
 		}
 		s.rebindExecutors()
 	}
@@ -763,6 +801,16 @@ func (s *Service) Shutdown(ctx context.Context) error {
 					shutdownErr = err
 				}
 			}
+		}
+
+		if s.usagePersistence != nil {
+			if err := s.usagePersistence.StopAndSave(); err != nil {
+				log.WithError(err).Warn("failed to persist usage statistics snapshot during shutdown")
+				if shutdownErr == nil {
+					shutdownErr = err
+				}
+			}
+			s.usagePersistence = nil
 		}
 
 		usage.StopDefault()

--- a/sdk/cliproxy/service_usage_persistence_test.go
+++ b/sdk/cliproxy/service_usage_persistence_test.go
@@ -1,0 +1,417 @@
+package cliproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+type stubTokenClientProvider struct{}
+
+func (stubTokenClientProvider) Load(context.Context, *config.Config) (*TokenClientResult, error) {
+	return &TokenClientResult{}, nil
+}
+
+type stubAPIKeyClientProvider struct{}
+
+func (stubAPIKeyClientProvider) Load(context.Context, *config.Config) (*APIKeyClientResult, error) {
+	return &APIKeyClientResult{}, nil
+}
+
+func replaceUsageStatisticsSnapshot(snapshot internalusage.StatisticsSnapshot) {
+	stats := internalusage.GetRequestStatistics()
+	*stats = *internalusage.NewRequestStatistics()
+	stats.MergeSnapshot(snapshot)
+}
+
+func TestServiceShutdownPersistsUsageSnapshot(t *testing.T) {
+	tempDir := t.TempDir()
+	snapshotPath := filepath.Join(tempDir, "usage-statistics.json")
+
+	cfg := &config.Config{
+		UsageStatisticsEnabled:            true,
+		UsageStatisticsPersistenceEnabled: true,
+		UsageStatisticsPersistenceFile:    snapshotPath,
+	}
+
+	originalStatisticsEnabled := internalusage.StatisticsEnabled()
+	internalusage.SetStatisticsEnabled(true)
+	defer internalusage.SetStatisticsEnabled(originalStatisticsEnabled)
+
+	stats := internalusage.NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:      "api-key",
+		Model:       "gpt-5.4",
+		Source:      "test",
+		AuthIndex:   "0",
+		RequestedAt: time.Date(2026, time.April, 2, 12, 0, 0, 0, time.UTC),
+		Latency:     500 * time.Millisecond,
+		Detail: coreusage.Detail{
+			InputTokens:  3,
+			OutputTokens: 2,
+			TotalTokens:  5,
+		},
+	})
+
+	service := &Service{
+		cfg:              cfg,
+		configPath:       filepath.Join(tempDir, "config.yaml"),
+		usagePersistence: internalusage.NewPersistenceManager(cfg, filepath.Join(tempDir, "config.yaml"), stats),
+	}
+
+	if err := service.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v, want nil", err)
+	}
+
+	data, err := os.ReadFile(snapshotPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v, want nil", err)
+	}
+
+	var snapshot struct {
+		Version int `json:"version"`
+		Usage   struct {
+			TotalRequests int64 `json:"total_requests"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		t.Fatalf("Unmarshal() error = %v, want nil", err)
+	}
+	if snapshot.Version != 1 {
+		t.Fatalf("version = %d, want 1", snapshot.Version)
+	}
+	if snapshot.Usage.TotalRequests != 1 {
+		t.Fatalf("usage.total_requests = %d, want 1", snapshot.Usage.TotalRequests)
+	}
+}
+
+func TestServiceRunInitializesUsagePersistenceWhenEnabled(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+	authDir := filepath.Join(tempDir, "auth")
+	snapshotPath := filepath.Join(tempDir, "usage-statistics.json")
+
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v, want nil", err)
+	}
+	if err := os.WriteFile(configPath, []byte("host: 127.0.0.1\nport: 0\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v, want nil", err)
+	}
+
+	cfg := &config.Config{
+		Host:                              "127.0.0.1",
+		Port:                              0,
+		AuthDir:                           authDir,
+		UsageStatisticsEnabled:            true,
+		UsageStatisticsPersistenceEnabled: true,
+		UsageStatisticsPersistenceFile:    snapshotPath,
+		CommercialMode:                    true,
+	}
+
+	originalStatisticsEnabled := internalusage.StatisticsEnabled()
+	internalusage.SetStatisticsEnabled(true)
+	defer internalusage.SetStatisticsEnabled(originalStatisticsEnabled)
+
+	originalSnapshot := internalusage.GetRequestStatistics().Snapshot()
+	replaceUsageStatisticsSnapshot(internalusage.StatisticsSnapshot{})
+	defer replaceUsageStatisticsSnapshot(originalSnapshot)
+
+	uniqueSuffix := strconv.FormatInt(time.Now().UnixNano(), 10)
+	apiKey := "startup-api-key-" + uniqueSuffix
+	model := "gpt-5.4-" + uniqueSuffix
+
+	seedStats := internalusage.NewRequestStatistics()
+	seedStats.Record(context.Background(), coreusage.Record{
+		APIKey:      apiKey,
+		Model:       model,
+		Source:      "startup-test",
+		AuthIndex:   "startup-auth-" + uniqueSuffix,
+		RequestedAt: time.Date(2026, time.April, 2, 13, 0, 0, 0, time.UTC),
+		Latency:     250 * time.Millisecond,
+		Detail: coreusage.Detail{
+			InputTokens:  3,
+			OutputTokens: 2,
+			TotalTokens:  5,
+		},
+	})
+	seedManager := internalusage.NewPersistenceManager(cfg, configPath, seedStats)
+	if err := seedManager.Save(); err != nil {
+		t.Fatalf("Save() error = %v, want nil", err)
+	}
+
+	var hookErr error
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	service, err := NewBuilder().
+		WithConfig(cfg).
+		WithConfigPath(configPath).
+		WithTokenClientProvider(stubTokenClientProvider{}).
+		WithAPIKeyClientProvider(stubAPIKeyClientProvider{}).
+		WithWatcherFactory(func(configPath, authDir string, reload func(*config.Config)) (*WatcherWrapper, error) {
+			return &WatcherWrapper{}, nil
+		}).
+		WithHooks(Hooks{OnAfterStart: func(s *Service) {
+			if s.usagePersistence == nil {
+				hookErr = fmt.Errorf("usagePersistence = nil, want initialized manager")
+				cancel()
+				return
+			}
+
+			snapshot := internalusage.GetRequestStatistics().Snapshot()
+			statsKey := apiKey
+			apiSnapshot, ok := snapshot.APIs[statsKey]
+			if !ok {
+				hookErr = fmt.Errorf("restored snapshot missing API key entry")
+				cancel()
+				return
+			}
+			modelSnapshot, ok := apiSnapshot.Models[model]
+			if !ok || modelSnapshot.TotalRequests == 0 {
+				hookErr = fmt.Errorf("restored snapshot missing model entry")
+			}
+			cancel()
+		}}).
+		Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v, want nil", err)
+	}
+
+	if err := service.Run(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want %v", err, context.Canceled)
+	}
+	if hookErr != nil {
+		t.Fatal(hookErr)
+	}
+}
+
+func TestServiceReloadRestoresUsageSnapshotBeforeSavingNewPersistenceTarget(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+	authDir := filepath.Join(tempDir, "auth")
+	oldSnapshotPath := filepath.Join(tempDir, "usage-old.json")
+	newSnapshotPath := filepath.Join(tempDir, "usage-new.json")
+
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v, want nil", err)
+	}
+	if err := os.WriteFile(configPath, []byte("host: 127.0.0.1\nport: 0\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v, want nil", err)
+	}
+
+	baseCfg := &config.Config{
+		Host:                              "127.0.0.1",
+		Port:                              0,
+		AuthDir:                           authDir,
+		UsageStatisticsEnabled:            true,
+		UsageStatisticsPersistenceEnabled: true,
+		UsageStatisticsPersistenceFile:    oldSnapshotPath,
+		CommercialMode:                    true,
+	}
+
+	originalStatisticsEnabled := internalusage.StatisticsEnabled()
+	internalusage.SetStatisticsEnabled(true)
+	defer internalusage.SetStatisticsEnabled(originalStatisticsEnabled)
+
+	originalSnapshot := internalusage.GetRequestStatistics().Snapshot()
+	replaceUsageStatisticsSnapshot(internalusage.StatisticsSnapshot{})
+	defer replaceUsageStatisticsSnapshot(originalSnapshot)
+
+	liveStats := internalusage.GetRequestStatistics()
+	liveKey := "reload-live-api-key"
+	liveModel := "gpt-live"
+	liveStats.Record(context.Background(), coreusage.Record{
+		APIKey:      liveKey,
+		Model:       liveModel,
+		Source:      "reload-live",
+		AuthIndex:   "live-auth",
+		RequestedAt: time.Date(2026, time.April, 2, 14, 0, 0, 0, time.UTC),
+		Latency:     200 * time.Millisecond,
+		Detail: coreusage.Detail{
+			InputTokens:  2,
+			OutputTokens: 3,
+			TotalTokens:  5,
+		},
+	})
+
+	persistedStats := internalusage.NewRequestStatistics()
+	persistedKey := "reload-persisted-api-key"
+	persistedModel := "gpt-persisted"
+	persistedStats.Record(context.Background(), coreusage.Record{
+		APIKey:      persistedKey,
+		Model:       persistedModel,
+		Source:      "reload-persisted",
+		AuthIndex:   "persisted-auth",
+		RequestedAt: time.Date(2026, time.April, 2, 15, 0, 0, 0, time.UTC),
+		Latency:     300 * time.Millisecond,
+		Detail: coreusage.Detail{
+			InputTokens:  4,
+			OutputTokens: 5,
+			TotalTokens:  9,
+		},
+	})
+	persistedManager := internalusage.NewPersistenceManager(&config.Config{UsageStatisticsPersistenceFile: newSnapshotPath}, configPath, persistedStats)
+	if err := persistedManager.Save(); err != nil {
+		t.Fatalf("Save() persisted snapshot error = %v, want nil", err)
+	}
+
+	started := make(chan struct{})
+	var reloadFunc func(*config.Config)
+	service := &Service{
+		cfg:              baseCfg,
+		configPath:       configPath,
+		usagePersistence: internalusage.NewPersistenceManager(baseCfg, configPath, liveStats),
+		watcherFactory: func(configPath, authDir string, reload func(*config.Config)) (*WatcherWrapper, error) {
+			reloadFunc = reload
+			return &WatcherWrapper{}, nil
+		},
+		tokenProvider:  stubTokenClientProvider{},
+		apiKeyProvider: stubAPIKeyClientProvider{},
+		hooks: Hooks{OnAfterStart: func(*Service) {
+			close(started)
+		}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- service.Run(ctx)
+	}()
+
+	<-started
+	deadline := time.Now().Add(2 * time.Second)
+	for reloadFunc == nil && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if reloadFunc == nil {
+		t.Fatal("reload callback = nil, want initialized watcher callback")
+	}
+
+	reloadCfg := *baseCfg
+	reloadCfg.UsageStatisticsPersistenceFile = newSnapshotPath
+	reloadFunc(&reloadCfg)
+	cancel()
+
+	if err := <-runErrCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want %v", err, context.Canceled)
+	}
+
+	restoredStats := internalusage.NewRequestStatistics()
+	snapshotManager := internalusage.NewPersistenceManager(&config.Config{UsageStatisticsPersistenceFile: newSnapshotPath}, configPath, restoredStats)
+	if err := snapshotManager.Restore(); err != nil {
+		t.Fatalf("Restore() reloaded snapshot error = %v, want nil", err)
+	}
+
+	snapshot := restoredStats.Snapshot()
+	liveAPISnapshot, ok := snapshot.APIs[liveKey]
+	if !ok {
+		t.Fatal("reloaded snapshot missing live in-memory API key entry")
+	}
+	if modelSnapshot, ok := liveAPISnapshot.Models[liveModel]; !ok || modelSnapshot.TotalRequests == 0 {
+		t.Fatal("reloaded snapshot missing live in-memory model entry")
+	}
+
+	persistedAPISnapshot, ok := snapshot.APIs[persistedKey]
+	if !ok {
+		t.Fatal("reloaded snapshot missing pre-existing persisted API key entry")
+	}
+	if modelSnapshot, ok := persistedAPISnapshot.Models[persistedModel]; !ok || modelSnapshot.TotalRequests == 0 {
+		t.Fatal("reloaded snapshot missing pre-existing persisted model entry")
+	}
+}
+
+func TestServiceReloadKeepsExistingUsagePersistenceWhenRelevantSettingsUnchanged(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+	authDir := filepath.Join(tempDir, "auth")
+	snapshotPath := filepath.Join(tempDir, "usage-statistics.json")
+
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v, want nil", err)
+	}
+	if err := os.WriteFile(configPath, []byte("host: 127.0.0.1\nport: 0\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v, want nil", err)
+	}
+
+	baseCfg := &config.Config{
+		Host:                              "127.0.0.1",
+		Port:                              0,
+		AuthDir:                           authDir,
+		UsageStatisticsEnabled:            true,
+		UsageStatisticsPersistenceEnabled: true,
+		UsageStatisticsPersistenceFile:    snapshotPath,
+		CommercialMode:                    true,
+	}
+
+	originalStatisticsEnabled := internalusage.StatisticsEnabled()
+	internalusage.SetStatisticsEnabled(true)
+	defer internalusage.SetStatisticsEnabled(originalStatisticsEnabled)
+
+	originalSnapshot := internalusage.GetRequestStatistics().Snapshot()
+	replaceUsageStatisticsSnapshot(internalusage.StatisticsSnapshot{})
+	defer replaceUsageStatisticsSnapshot(originalSnapshot)
+
+	started := make(chan struct{})
+	var reloadFunc func(*config.Config)
+	service := &Service{
+		cfg:              baseCfg,
+		configPath:       configPath,
+		usagePersistence: internalusage.NewPersistenceManager(baseCfg, configPath, internalusage.GetRequestStatistics()),
+		watcherFactory: func(configPath, authDir string, reload func(*config.Config)) (*WatcherWrapper, error) {
+			reloadFunc = reload
+			return &WatcherWrapper{}, nil
+		},
+		tokenProvider:  stubTokenClientProvider{},
+		apiKeyProvider: stubAPIKeyClientProvider{},
+		hooks: Hooks{OnAfterStart: func(*Service) {
+			close(started)
+		}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- service.Run(ctx)
+	}()
+
+	<-started
+	deadline := time.Now().Add(2 * time.Second)
+	for reloadFunc == nil && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if reloadFunc == nil {
+		t.Fatal("reload callback = nil, want initialized watcher callback")
+	}
+
+	originalManager := service.usagePersistence
+	if originalManager == nil {
+		t.Fatal("usagePersistence = nil, want initialized manager")
+	}
+
+	reloadCfg := *baseCfg
+	reloadCfg.Routing.Strategy = "fill-first"
+	reloadFunc(&reloadCfg)
+
+	if service.usagePersistence != originalManager {
+		t.Fatal("reload replaced usagePersistence despite unchanged persistence settings")
+	}
+
+	cancel()
+	if err := <-runErrCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want %v", err, context.Canceled)
+	}
+}


### PR DESCRIPTION
## Summary

Automatically restore and save usage statistics snapshots so history survives service restarts.

## Changes

- Add `PersistenceManager` in `internal/usage/persistence.go` to handle snapshot save/restore/autosave lifecycle
- Add two new config fields: `usage-statistics-persistence-enabled` (default: `true`) and `usage-statistics-persistence-file` (optional path override)
- Integrate persistence into `sdk/cliproxy/service.go`: restore on startup, autosave every 5 minutes, save on shutdown and config reload
- Use atomic write with `.bak` fallback to prevent data corruption
- Dedup-safe merge via existing `MergeSnapshot` logic

## Testing

- `internal/usage/persistence_test.go`: 562 lines covering save/restore/autosave/backup/atomic write
- `sdk/cliproxy/service_usage_persistence_test.go`: 417 lines covering full service lifecycle (startup restore, shutdown persist, config reload)
- `internal/usage/logger_plugin_test.go`: added provider fallback identifier test

## Notes

Persistence is only active when both `usage-statistics-enabled: true` and `usage-statistics-persistence-enabled: true` are set. No behavior change for users who don't opt in.
