### PR TITLE
feat: 升级反重力 (antigravity) UA 版本为 1.21.9

### DIFF
--- a/cmd/fetch_antigravity_models/main.go
+++ b/cmd/fetch_antigravity_models/main.go
@@ -188,7 +188,7 @@ func fetchModels(ctx context.Context, auth *coreauth.Auth) []modelEntry {
 		httpReq.Close = true
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Authorization", "Bearer "+accessToken)
-		httpReq.Header.Set("User-Agent", "antigravity/1.19.6 darwin/arm64")
+		httpReq.Header.Set("User-Agent", "antigravity/1.21.9 darwin/arm64")
 
 		httpClient := &http.Client{Timeout: 30 * time.Second}
 		if transport, _, errProxy := proxyutil.BuildHTTPTransport(auth.ProxyURL); errProxy == nil && transport != nil {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -45,7 +45,7 @@ const (
 	antigravityGeneratePath        = "/v1internal:generateContent"
 	antigravityClientID            = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
 	antigravityClientSecret        = "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"
-	defaultAntigravityAgent        = "antigravity/1.19.6 darwin/arm64"
+	defaultAntigravityAgent        = "antigravity/1.21.9 darwin/arm64"
 	antigravityAuthType            = "antigravity"
 	refreshSkew                    = 3000 * time.Second
 	antigravityCreditsRetryTTL     = 5 * time.Hour


### PR DESCRIPTION
**更新说明 (Summary)**
本次 PR 更新了反重力 (antigravity) 执行器及其相关工具的 User-Agent 版本号，从 `1.19.6` 升级至 `1.21.9`。这有助于保持与上游 API 最新的客户端标识兼容，确保请求的稳定性。

**变更清单 (Changes)**
- **`internal/runtime/executor/antigravity_executor.go`**: 
    - 更新了 `defaultAntigravityAgent` 常量中的版本号。
    - 确保所有通过该执行器发出的 `generateContent` 请求都携带新的 UA 标识。
- **`cmd/fetch_antigravity_models/main.go`**:
    - 同步更新了模型获取工具在请求上游 API 时使用的 User-Agent 字符串。

**测试情况 (Verification)**
- 验证了代码逻辑中 UA 字符串的拼接正确性。

