### PR TITLE
[codex] fix: sanitize unsigned Claude thinking blocks before upstream requests

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -152,6 +152,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
 	// A 1h-TTL block must not appear after a 5m-TTL block in evaluation order (tools→system→messages).
 	body = normalizeCacheControlTTL(body)
+	body = sanitizeClaudeRequestBody(body)
 
 	// Extract betas from body and convert to header
 	var extraBetas []string
@@ -320,6 +321,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
 	body = normalizeCacheControlTTL(body)
+	body = sanitizeClaudeRequestBody(body)
 
 	// Extract betas from body and convert to header
 	var extraBetas []string
@@ -492,6 +494,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	// Keep count_tokens requests compatible with Anthropic cache-control constraints too.
 	body = enforceCacheControlLimit(body, 4)
 	body = normalizeCacheControlTTL(body)
+	body = sanitizeClaudeRequestBody(body)
 
 	// Extract betas from body and convert to header (for count_tokens too)
 	var extraBetas []string

--- a/internal/runtime/executor/claude_request_sanitizer.go
+++ b/internal/runtime/executor/claude_request_sanitizer.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/cache"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -12,6 +13,10 @@ import (
 // valid Claude signature. Anthropic rejects unsigned thinking blocks when a mixed
 // session returns from non-Claude providers back to Claude.
 func sanitizeClaudeRequestBody(body []byte) []byte {
+	targetModel := gjson.GetBytes(body, "model").String()
+	if targetModel == "" {
+		targetModel = "claude"
+	}
 	messages := gjson.GetBytes(body, "messages")
 	if !messages.Exists() || !messages.IsArray() {
 		return body
@@ -39,7 +44,7 @@ func sanitizeClaudeRequestBody(body []byte) []byte {
 		for _, block := range blocks {
 			if block.Get("type").String() == "thinking" {
 				sig := block.Get("signature")
-				if !sig.Exists() || sig.Type != gjson.String || strings.TrimSpace(sig.String()) == "" {
+				if !sig.Exists() || sig.Type != gjson.String || !isValidClaudeThinkingSignature(targetModel, sig.String()) {
 					removedCount++
 					continue
 				}
@@ -83,4 +88,36 @@ func sanitizeClaudeRequestBody(body []byte) []byte {
 
 	log.Debug("Claude RequestSanitizer: sanitized request body")
 	return sanitizedBody
+}
+
+func isValidClaudeThinkingSignature(modelName, signature string) bool {
+	signature = strings.TrimSpace(signature)
+	if signature == "" {
+		return false
+	}
+
+	// Translator-generated signatures are prefixed with a provider/model group
+	// marker (for example "gpt#..." or "claude#..."). Those markers are useful
+	// for internal routing, but Anthropic expects the raw Claude-issued
+	// signature, so any known prefixed form must be stripped before forwarding.
+	if prefix, _, ok := splitSyntheticThinkingSignature(signature); ok {
+		log.Debugf("Claude RequestSanitizer: dropping synthetic thinking signature with prefix %q", prefix)
+		return false
+	}
+
+	return cache.HasValidSignature(modelName, signature)
+}
+
+func splitSyntheticThinkingSignature(signature string) (prefix, rawSignature string, ok bool) {
+	prefix, rawSignature, found := strings.Cut(signature, "#")
+	if !found || rawSignature == "" {
+		return "", "", false
+	}
+
+	switch prefix {
+	case "gpt", "claude", "gemini":
+		return prefix, rawSignature, true
+	default:
+		return "", "", false
+	}
 }

--- a/internal/runtime/executor/claude_request_sanitizer.go
+++ b/internal/runtime/executor/claude_request_sanitizer.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"fmt"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -19,13 +18,17 @@ func sanitizeClaudeRequestBody(body []byte) []byte {
 	}
 
 	modified := false
+	sanitizedMessages := make([]any, 0, len(messages.Array()))
 	for msgIdx, msg := range messages.Array() {
+		msgValue := msg.Value()
 		if msg.Get("role").String() != "assistant" {
+			sanitizedMessages = append(sanitizedMessages, msgValue)
 			continue
 		}
 
 		content := msg.Get("content")
 		if !content.Exists() || !content.IsArray() {
+			sanitizedMessages = append(sanitizedMessages, msgValue)
 			continue
 		}
 
@@ -45,28 +48,39 @@ func sanitizeClaudeRequestBody(body []byte) []byte {
 		}
 
 		if removedCount == 0 {
+			sanitizedMessages = append(sanitizedMessages, msgValue)
 			continue
 		}
 
-		contentPath := fmt.Sprintf("messages.%d.content", msgIdx)
-		var err error
 		if len(keepBlocks) == 0 {
-			body, err = sjson.SetBytes(body, contentPath, []any{})
-		} else {
-			body, err = sjson.SetBytes(body, contentPath, keepBlocks)
-		}
-		if err != nil {
-			log.Warnf("Claude RequestSanitizer: failed to sanitize message %d: %v", msgIdx, err)
+			modified = true
+			log.Warnf("Claude RequestSanitizer: removed assistant message %d after stripping %d invalid thinking blocks", msgIdx, removedCount)
 			continue
 		}
+
+		msgObject, ok := msgValue.(map[string]any)
+		if !ok {
+			log.Warnf("Claude RequestSanitizer: failed to sanitize message %d: unexpected message shape %T", msgIdx, msgValue)
+			sanitizedMessages = append(sanitizedMessages, msgValue)
+			continue
+		}
+		msgObject["content"] = keepBlocks
+		sanitizedMessages = append(sanitizedMessages, msgObject)
 
 		modified = true
 		log.Debugf("Claude RequestSanitizer: removed %d invalid thinking blocks from message %d", removedCount, msgIdx)
 	}
 
-	if modified {
-		log.Debug("Claude RequestSanitizer: sanitized request body")
+	if !modified {
+		return body
 	}
 
-	return body
+	sanitizedBody, err := sjson.SetBytes(body, "messages", sanitizedMessages)
+	if err != nil {
+		log.Warnf("Claude RequestSanitizer: failed to rewrite messages array: %v", err)
+		return body
+	}
+
+	log.Debug("Claude RequestSanitizer: sanitized request body")
+	return sanitizedBody
 }

--- a/internal/runtime/executor/claude_request_sanitizer.go
+++ b/internal/runtime/executor/claude_request_sanitizer.go
@@ -1,0 +1,72 @@
+package executor
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// sanitizeClaudeRequestBody removes assistant thinking blocks that do not carry a
+// valid Claude signature. Anthropic rejects unsigned thinking blocks when a mixed
+// session returns from non-Claude providers back to Claude.
+func sanitizeClaudeRequestBody(body []byte) []byte {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body
+	}
+
+	modified := false
+	for msgIdx, msg := range messages.Array() {
+		if msg.Get("role").String() != "assistant" {
+			continue
+		}
+
+		content := msg.Get("content")
+		if !content.Exists() || !content.IsArray() {
+			continue
+		}
+
+		blocks := content.Array()
+		keepBlocks := make([]any, 0, len(blocks))
+		removedCount := 0
+
+		for _, block := range blocks {
+			if block.Get("type").String() == "thinking" {
+				sig := block.Get("signature")
+				if !sig.Exists() || sig.Type != gjson.String || strings.TrimSpace(sig.String()) == "" {
+					removedCount++
+					continue
+				}
+			}
+			keepBlocks = append(keepBlocks, block.Value())
+		}
+
+		if removedCount == 0 {
+			continue
+		}
+
+		contentPath := fmt.Sprintf("messages.%d.content", msgIdx)
+		var err error
+		if len(keepBlocks) == 0 {
+			body, err = sjson.SetBytes(body, contentPath, []any{})
+		} else {
+			body, err = sjson.SetBytes(body, contentPath, keepBlocks)
+		}
+		if err != nil {
+			log.Warnf("Claude RequestSanitizer: failed to sanitize message %d: %v", msgIdx, err)
+			continue
+		}
+
+		modified = true
+		log.Debugf("Claude RequestSanitizer: removed %d invalid thinking blocks from message %d", removedCount, msgIdx)
+	}
+
+	if modified {
+		log.Debug("Claude RequestSanitizer: sanitized request body")
+	}
+
+	return body
+}

--- a/internal/runtime/executor/claude_request_sanitizer_test.go
+++ b/internal/runtime/executor/claude_request_sanitizer_test.go
@@ -15,8 +15,15 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+const (
+	validClaudeSignature     = "valid_signature_1234567890123456789012345678901234567890"
+	syntheticGPTSignature    = "gpt#valid_signature_1234567890123456789012345678901234567890"
+	syntheticClaudeSignature = "claude#valid_signature_1234567890123456789012345678901234567890"
+)
+
 func TestSanitizeClaudeRequestBody_RemovesInvalidThinkingBlocks(t *testing.T) {
 	input := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
 		"messages": [
 			{
 				"role": "assistant",
@@ -25,7 +32,8 @@ func TestSanitizeClaudeRequestBody_RemovesInvalidThinkingBlocks(t *testing.T) {
 					{"type": "text", "text": "keep text"},
 					{"type": "thinking", "thinking": "blank signature", "signature": "   "},
 					{"type": "tool_use", "id": "tool_1", "name": "search", "input": {"q": "tea"}},
-					{"type": "thinking", "thinking": "signed", "signature": "sig-123"},
+					{"type": "thinking", "thinking": "synthetic", "signature": "` + syntheticGPTSignature + `"},
+					{"type": "thinking", "thinking": "signed", "signature": "` + validClaudeSignature + `"},
 					{"type": "tool_result", "tool_use_id": "tool_1", "content": "ok"}
 				]
 			}
@@ -43,8 +51,8 @@ func TestSanitizeClaudeRequestBody_RemovesInvalidThinkingBlocks(t *testing.T) {
 	if got := content[1].Get("type").String(); got != "tool_use" {
 		t.Fatalf("content[1].type = %q, want %q", got, "tool_use")
 	}
-	if got := content[2].Get("signature").String(); got != "sig-123" {
-		t.Fatalf("content[2].signature = %q, want %q", got, "sig-123")
+	if got := content[2].Get("signature").String(); got != validClaudeSignature {
+		t.Fatalf("content[2].signature = %q, want %q", got, validClaudeSignature)
 	}
 	if got := content[3].Get("type").String(); got != "tool_result" {
 		t.Fatalf("content[3].type = %q, want %q", got, "tool_result")
@@ -53,6 +61,7 @@ func TestSanitizeClaudeRequestBody_RemovesInvalidThinkingBlocks(t *testing.T) {
 
 func TestSanitizeClaudeRequestBody_RemovesNonStringSignature(t *testing.T) {
 	input := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
 		"messages": [
 			{
 				"role": "assistant",
@@ -76,6 +85,7 @@ func TestSanitizeClaudeRequestBody_RemovesNonStringSignature(t *testing.T) {
 
 func TestSanitizeClaudeRequestBody_PreservesOtherRoles(t *testing.T) {
 	input := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
 		"messages": [
 			{
 				"role": "user",
@@ -97,8 +107,38 @@ func TestSanitizeClaudeRequestBody_PreservesOtherRoles(t *testing.T) {
 	}
 }
 
+func TestSanitizeClaudeRequestBody_RemovesSyntheticPrefixedThinkingSignatures(t *testing.T) {
+	input := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "thinking", "thinking": "gpt synthetic", "signature": "` + syntheticGPTSignature + `"},
+					{"type": "thinking", "thinking": "claude synthetic", "signature": "` + syntheticClaudeSignature + `"},
+					{"type": "thinking", "thinking": "raw claude", "signature": "` + validClaudeSignature + `"},
+					{"type": "text", "text": "keep me"}
+				]
+			}
+		]
+	}`)
+
+	out := sanitizeClaudeRequestBody(input)
+	content := gjson.GetBytes(out, "messages.0.content").Array()
+	if len(content) != 2 {
+		t.Fatalf("content block count = %d, want 2", len(content))
+	}
+	if got := content[0].Get("signature").String(); got != validClaudeSignature {
+		t.Fatalf("content[0].signature = %q, want %q", got, validClaudeSignature)
+	}
+	if got := content[1].Get("type").String(); got != "text" {
+		t.Fatalf("content[1].type = %q, want %q", got, "text")
+	}
+}
+
 func TestSanitizeClaudeRequestBody_RemovesAssistantMessagesThatBecomeEmpty(t *testing.T) {
 	input := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
 		"messages": [
 			{
 				"role": "user",
@@ -214,15 +254,17 @@ func TestClaudeExecutor_SanitizesUnsignedThinkingAcrossClaudeRequestPaths(t *tes
 			}}
 
 			payload := []byte(`{
-				"messages": [
-					{"role":"user","content":[{"type":"text","text":"hi"}]},
-					{"role":"assistant","content":[
-						{"type":"thinking","thinking":"unsigned scratchpad"},
-						{"type":"text","text":"visible reply"},
-						{"type":"thinking","thinking":"signed scratchpad","signature":"sig-123"}
-					]}
-				]
-			}`)
+					"model":"claude-3-5-sonnet-20241022",
+					"messages": [
+						{"role":"user","content":[{"type":"text","text":"hi"}]},
+						{"role":"assistant","content":[
+							{"type":"thinking","thinking":"unsigned scratchpad"},
+							{"type":"text","text":"visible reply"},
+							{"type":"thinking","thinking":"synthetic scratchpad","signature":"` + syntheticGPTSignature + `"},
+							{"type":"thinking","thinking":"signed scratchpad","signature":"` + validClaudeSignature + `"}
+						]}
+					]
+				}`)
 
 			tc.invoke(t, executor, auth, payload)
 
@@ -237,8 +279,8 @@ func TestClaudeExecutor_SanitizesUnsignedThinkingAcrossClaudeRequestPaths(t *tes
 			if got := content[0].Get("type").String(); got != "text" {
 				t.Fatalf("content[0].type = %q, want %q", got, "text")
 			}
-			if got := content[1].Get("signature").String(); got != "sig-123" {
-				t.Fatalf("content[1].signature = %q, want %q", got, "sig-123")
+			if got := content[1].Get("signature").String(); got != validClaudeSignature {
+				t.Fatalf("content[1].signature = %q, want %q", got, validClaudeSignature)
 			}
 		})
 	}

--- a/internal/runtime/executor/claude_request_sanitizer_test.go
+++ b/internal/runtime/executor/claude_request_sanitizer_test.go
@@ -97,9 +97,15 @@ func TestSanitizeClaudeRequestBody_PreservesOtherRoles(t *testing.T) {
 	}
 }
 
-func TestSanitizeClaudeRequestBody_LeavesEmptyAssistantContentArray(t *testing.T) {
+func TestSanitizeClaudeRequestBody_RemovesAssistantMessagesThatBecomeEmpty(t *testing.T) {
 	input := []byte(`{
 		"messages": [
+			{
+				"role": "user",
+				"content": [
+					{"type": "text", "text": "keep me"}
+				]
+			},
 			{
 				"role": "assistant",
 				"content": [
@@ -107,12 +113,15 @@ func TestSanitizeClaudeRequestBody_LeavesEmptyAssistantContentArray(t *testing.T
 				]
 			}
 		]
-	}`)
+		}`)
 
 	out := sanitizeClaudeRequestBody(input)
-	content := gjson.GetBytes(out, "messages.0.content").Array()
-	if len(content) != 0 {
-		t.Fatalf("content block count = %d, want 0", len(content))
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(messages))
+	}
+	if got := messages[0].Get("role").String(); got != "user" {
+		t.Fatalf("messages[0].role = %q, want %q", got, "user")
 	}
 }
 
@@ -230,6 +239,124 @@ func TestClaudeExecutor_SanitizesUnsignedThinkingAcrossClaudeRequestPaths(t *tes
 			}
 			if got := content[1].Get("signature").String(); got != "sig-123" {
 				t.Fatalf("content[1].signature = %q, want %q", got, "sig-123")
+			}
+		})
+	}
+}
+
+func TestClaudeExecutor_RemovesAssistantMessagesThatBecomeEmptyAcrossClaudeRequestPaths(t *testing.T) {
+	testCases := []struct {
+		name       string
+		invoke     func(t *testing.T, executor *ClaudeExecutor, auth *cliproxyauth.Auth, payload []byte)
+		wantPath   string
+		wantStream bool
+	}{
+		{
+			name: "execute",
+			invoke: func(t *testing.T, executor *ClaudeExecutor, auth *cliproxyauth.Auth, payload []byte) {
+				t.Helper()
+				_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+					Model:   "claude-3-5-sonnet-20241022",
+					Payload: payload,
+				}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+			},
+			wantPath: "/v1/messages",
+		},
+		{
+			name: "execute_stream",
+			invoke: func(t *testing.T, executor *ClaudeExecutor, auth *cliproxyauth.Auth, payload []byte) {
+				t.Helper()
+				result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+					Model:   "claude-3-5-sonnet-20241022",
+					Payload: payload,
+				}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+				if err != nil {
+					t.Fatalf("ExecuteStream() error = %v", err)
+				}
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						t.Fatalf("ExecuteStream() chunk error = %v", chunk.Err)
+					}
+				}
+			},
+			wantPath:   "/v1/messages",
+			wantStream: true,
+		},
+		{
+			name: "count_tokens",
+			invoke: func(t *testing.T, executor *ClaudeExecutor, auth *cliproxyauth.Auth, payload []byte) {
+				t.Helper()
+				_, err := executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+					Model:   "claude-3-5-sonnet-20241022",
+					Payload: payload,
+				}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+				if err != nil {
+					t.Fatalf("CountTokens() error = %v", err)
+				}
+			},
+			wantPath: "/v1/messages/count_tokens",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seenBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tc.wantPath {
+					t.Fatalf("request path = %q, want %q", r.URL.Path, tc.wantPath)
+				}
+				body, _ := io.ReadAll(r.Body)
+				seenBody = bytes.Clone(body)
+
+				if tc.wantStream {
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				if tc.wantPath == "/v1/messages/count_tokens" {
+					_, _ = w.Write([]byte(`{"input_tokens":42}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-3-5-sonnet-20241022","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+			}))
+			defer server.Close()
+
+			executor := NewClaudeExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{
+				"api_key":  "key-123",
+				"base_url": server.URL,
+			}}
+
+			payload := []byte(`{
+				"messages": [
+					{"role":"user","content":[{"type":"text","text":"first user"}]},
+					{"role":"assistant","content":[
+						{"type":"thinking","thinking":"unsigned scratchpad"}
+					]},
+					{"role":"user","content":[{"type":"text","text":"second user"}]}
+				]
+			}`)
+
+			tc.invoke(t, executor, auth, payload)
+
+			if len(seenBody) == 0 {
+				t.Fatal("expected request body to be captured")
+			}
+
+			messages := gjson.GetBytes(seenBody, "messages").Array()
+			if len(messages) != 2 {
+				t.Fatalf("message count = %d, want 2; body=%s", len(messages), string(seenBody))
+			}
+			if got := messages[0].Get("role").String(); got != "user" {
+				t.Fatalf("messages[0].role = %q, want %q", got, "user")
+			}
+			if got := messages[1].Get("role").String(); got != "user" {
+				t.Fatalf("messages[1].role = %q, want %q", got, "user")
 			}
 		})
 	}

--- a/internal/runtime/executor/claude_request_sanitizer_test.go
+++ b/internal/runtime/executor/claude_request_sanitizer_test.go
@@ -1,0 +1,236 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestSanitizeClaudeRequestBody_RemovesInvalidThinkingBlocks(t *testing.T) {
+	input := []byte(`{
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "thinking", "thinking": "missing signature"},
+					{"type": "text", "text": "keep text"},
+					{"type": "thinking", "thinking": "blank signature", "signature": "   "},
+					{"type": "tool_use", "id": "tool_1", "name": "search", "input": {"q": "tea"}},
+					{"type": "thinking", "thinking": "signed", "signature": "sig-123"},
+					{"type": "tool_result", "tool_use_id": "tool_1", "content": "ok"}
+				]
+			}
+		]
+	}`)
+
+	out := sanitizeClaudeRequestBody(input)
+	content := gjson.GetBytes(out, "messages.0.content").Array()
+	if len(content) != 4 {
+		t.Fatalf("content block count = %d, want 4", len(content))
+	}
+	if got := content[0].Get("type").String(); got != "text" {
+		t.Fatalf("content[0].type = %q, want %q", got, "text")
+	}
+	if got := content[1].Get("type").String(); got != "tool_use" {
+		t.Fatalf("content[1].type = %q, want %q", got, "tool_use")
+	}
+	if got := content[2].Get("signature").String(); got != "sig-123" {
+		t.Fatalf("content[2].signature = %q, want %q", got, "sig-123")
+	}
+	if got := content[3].Get("type").String(); got != "tool_result" {
+		t.Fatalf("content[3].type = %q, want %q", got, "tool_result")
+	}
+}
+
+func TestSanitizeClaudeRequestBody_RemovesNonStringSignature(t *testing.T) {
+	input := []byte(`{
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "thinking", "thinking": "bad signature type", "signature": 123},
+					{"type": "text", "text": "keep"}
+				]
+			}
+		]
+	}`)
+
+	out := sanitizeClaudeRequestBody(input)
+	content := gjson.GetBytes(out, "messages.0.content").Array()
+	if len(content) != 1 {
+		t.Fatalf("content block count = %d, want 1", len(content))
+	}
+	if got := content[0].Get("type").String(); got != "text" {
+		t.Fatalf("content[0].type = %q, want %q", got, "text")
+	}
+}
+
+func TestSanitizeClaudeRequestBody_PreservesOtherRoles(t *testing.T) {
+	input := []byte(`{
+		"messages": [
+			{
+				"role": "user",
+				"content": [
+					{"type": "thinking", "thinking": "user thinking without signature"},
+					{"type": "text", "text": "hi"}
+				]
+			}
+		]
+	}`)
+
+	out := sanitizeClaudeRequestBody(input)
+	content := gjson.GetBytes(out, "messages.0.content").Array()
+	if len(content) != 2 {
+		t.Fatalf("user content block count = %d, want 2", len(content))
+	}
+	if got := content[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("user content[0].type = %q, want %q", got, "thinking")
+	}
+}
+
+func TestSanitizeClaudeRequestBody_LeavesEmptyAssistantContentArray(t *testing.T) {
+	input := []byte(`{
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "thinking", "thinking": "missing signature"}
+				]
+			}
+		]
+	}`)
+
+	out := sanitizeClaudeRequestBody(input)
+	content := gjson.GetBytes(out, "messages.0.content").Array()
+	if len(content) != 0 {
+		t.Fatalf("content block count = %d, want 0", len(content))
+	}
+}
+
+func TestClaudeExecutor_SanitizesUnsignedThinkingAcrossClaudeRequestPaths(t *testing.T) {
+	testCases := []struct {
+		name       string
+		invoke     func(t *testing.T, executor *ClaudeExecutor, auth *cliproxyauth.Auth, payload []byte)
+		wantPath   string
+		wantStream bool
+	}{
+		{
+			name: "execute",
+			invoke: func(t *testing.T, executor *ClaudeExecutor, auth *cliproxyauth.Auth, payload []byte) {
+				t.Helper()
+				_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+					Model:   "claude-3-5-sonnet-20241022",
+					Payload: payload,
+				}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+			},
+			wantPath: "/v1/messages",
+		},
+		{
+			name: "execute_stream",
+			invoke: func(t *testing.T, executor *ClaudeExecutor, auth *cliproxyauth.Auth, payload []byte) {
+				t.Helper()
+				result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+					Model:   "claude-3-5-sonnet-20241022",
+					Payload: payload,
+				}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+				if err != nil {
+					t.Fatalf("ExecuteStream() error = %v", err)
+				}
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						t.Fatalf("ExecuteStream() chunk error = %v", chunk.Err)
+					}
+				}
+			},
+			wantPath:   "/v1/messages",
+			wantStream: true,
+		},
+		{
+			name: "count_tokens",
+			invoke: func(t *testing.T, executor *ClaudeExecutor, auth *cliproxyauth.Auth, payload []byte) {
+				t.Helper()
+				_, err := executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+					Model:   "claude-3-5-sonnet-20241022",
+					Payload: payload,
+				}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+				if err != nil {
+					t.Fatalf("CountTokens() error = %v", err)
+				}
+			},
+			wantPath: "/v1/messages/count_tokens",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seenBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tc.wantPath {
+					t.Fatalf("request path = %q, want %q", r.URL.Path, tc.wantPath)
+				}
+				body, _ := io.ReadAll(r.Body)
+				seenBody = bytes.Clone(body)
+
+				if tc.wantStream {
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				if tc.wantPath == "/v1/messages/count_tokens" {
+					_, _ = w.Write([]byte(`{"input_tokens":42}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-3-5-sonnet-20241022","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+			}))
+			defer server.Close()
+
+			executor := NewClaudeExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{
+				"api_key":  "key-123",
+				"base_url": server.URL,
+			}}
+
+			payload := []byte(`{
+				"messages": [
+					{"role":"user","content":[{"type":"text","text":"hi"}]},
+					{"role":"assistant","content":[
+						{"type":"thinking","thinking":"unsigned scratchpad"},
+						{"type":"text","text":"visible reply"},
+						{"type":"thinking","thinking":"signed scratchpad","signature":"sig-123"}
+					]}
+				]
+			}`)
+
+			tc.invoke(t, executor, auth, payload)
+
+			if len(seenBody) == 0 {
+				t.Fatal("expected request body to be captured")
+			}
+
+			content := gjson.GetBytes(seenBody, "messages.1.content").Array()
+			if len(content) != 2 {
+				t.Fatalf("assistant content block count = %d, want 2; body=%s", len(content), string(seenBody))
+			}
+			if got := content[0].Get("type").String(); got != "text" {
+				t.Fatalf("content[0].type = %q, want %q", got, "text")
+			}
+			if got := content[1].Get("signature").String(); got != "sig-123" {
+				t.Fatalf("content[1].signature = %q, want %q", got, "sig-123")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- sanitize Claude-bound request histories by removing assistant `thinking` blocks that do not carry a valid signature
- apply the sanitizer across `Execute`, `ExecuteStream`, and `CountTokens` before tool-prefix rewriting or optional body signing
- add regression tests for invalid signatures and for all Claude request paths

## Why
Mixed-provider sessions can return to Claude with unsigned `thinking` blocks synthesized by non-Claude translators. Anthropic rejects those histories with `Invalid signature in thinking block`, which breaks same-session `codex -> sonnet/opus` return.

## Impact
Visible assistant text, tool calls, and tool results are preserved. Only unsigned hidden `thinking` blocks are stripped before the request is forwarded back to Claude upstream.

## Validation
- `go test ./internal/runtime/executor`
- live proxy smoke test against `/v1/messages` with an unsigned prior assistant `thinking` block; request returned `200 OK` instead of `400 Invalid signature in thinking block`
