### PR TITLE
feat: 动态获取 Antigravity User-Agent 版本号

### DIFF
--- a/cmd/fetch_antigravity_models/main.go
+++ b/cmd/fetch_antigravity_models/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	sdkauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/proxyutil"
@@ -188,7 +189,7 @@ func fetchModels(ctx context.Context, auth *coreauth.Auth) []modelEntry {
 		httpReq.Close = true
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Authorization", "Bearer "+accessToken)
-		httpReq.Header.Set("User-Agent", "antigravity/1.21.9 darwin/arm64")
+		httpReq.Header.Set("User-Agent", misc.AntigravityUserAgent())
 
 		httpClient := &http.Client{Timeout: 30 * time.Second}
 		if transport, _, errProxy := proxyutil.BuildHTTPTransport(auth.ProxyURL); errProxy == nil && transport != nil {

--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -1,0 +1,97 @@
+// Package misc provides miscellaneous utility functions for the CLI Proxy API server.
+package misc
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	antigravityReleasesURL     = "https://antigravity-auto-updater-974169037036.us-central1.run.app/releases"
+	antigravityFallbackVersion = "1.21.9"
+	antigravityVersionCacheTTL = 6 * time.Hour
+	antigravityFetchTimeout    = 10 * time.Second
+)
+
+type antigravityRelease struct {
+	Version     string `json:"version"`
+	ExecutionID string `json:"execution_id"`
+}
+
+var (
+	cachedAntigravityVersion string
+	antigravityVersionMu     sync.RWMutex
+	antigravityVersionExpiry time.Time
+)
+
+// AntigravityLatestVersion returns the latest antigravity version from the releases API.
+// It caches the result for antigravityVersionCacheTTL and falls back to antigravityFallbackVersion
+// if the fetch fails.
+func AntigravityLatestVersion() string {
+	antigravityVersionMu.RLock()
+	if cachedAntigravityVersion != "" && time.Now().Before(antigravityVersionExpiry) {
+		v := cachedAntigravityVersion
+		antigravityVersionMu.RUnlock()
+		return v
+	}
+	antigravityVersionMu.RUnlock()
+
+	antigravityVersionMu.Lock()
+	defer antigravityVersionMu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if cachedAntigravityVersion != "" && time.Now().Before(antigravityVersionExpiry) {
+		return cachedAntigravityVersion
+	}
+
+	version := fetchAntigravityLatestVersion()
+	cachedAntigravityVersion = version
+	antigravityVersionExpiry = time.Now().Add(antigravityVersionCacheTTL)
+	return version
+}
+
+// AntigravityUserAgent returns the User-Agent string for antigravity requests
+// using the latest version fetched from the releases API.
+func AntigravityUserAgent() string {
+	return fmt.Sprintf("antigravity/%s darwin/arm64", AntigravityLatestVersion())
+}
+
+func fetchAntigravityLatestVersion() string {
+	client := &http.Client{Timeout: antigravityFetchTimeout}
+	resp, err := client.Get(antigravityReleasesURL)
+	if err != nil {
+		log.WithError(err).Warn("failed to fetch antigravity releases, using fallback version")
+		return antigravityFallbackVersion
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.WithField("status", resp.StatusCode).Warn("antigravity releases API returned non-200, using fallback version")
+		return antigravityFallbackVersion
+	}
+
+	var releases []antigravityRelease
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		log.WithError(err).Warn("failed to decode antigravity releases response, using fallback version")
+		return antigravityFallbackVersion
+	}
+
+	if len(releases) == 0 {
+		log.Warn("antigravity releases API returned empty list, using fallback version")
+		return antigravityFallbackVersion
+	}
+
+	version := releases[0].Version
+	if version == "" {
+		log.Warn("antigravity releases API returned empty version, using fallback version")
+		return antigravityFallbackVersion
+	}
+
+	log.WithField("version", version).Info("fetched latest antigravity version")
+	return version
+}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -45,7 +46,7 @@ const (
 	antigravityGeneratePath        = "/v1internal:generateContent"
 	antigravityClientID            = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
 	antigravityClientSecret        = "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"
-	defaultAntigravityAgent        = "antigravity/1.21.9 darwin/arm64"
+	defaultAntigravityAgent        = "antigravity/1.21.9 darwin/arm64" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
 	antigravityAuthType            = "antigravity"
 	refreshSkew                    = 3000 * time.Second
 	antigravityCreditsRetryTTL     = 5 * time.Hour
@@ -1739,7 +1740,7 @@ func resolveUserAgent(auth *cliproxyauth.Auth) string {
 			}
 		}
 	}
-	return defaultAntigravityAgent
+	return misc.AntigravityUserAgent()
 }
 
 func antigravityRetryAttempts(auth *cliproxyauth.Auth, cfg *config.Config) int {


### PR DESCRIPTION
#### 1.主要改动 (What)
- **新增工具函数** (`internal/misc/antigravity_version.go`):
    - 实现了 `AntigravityLatestVersion()`：通过 HTTP 请求访问 `antigravity-auto-updater` 接口。
    - 引入了 **6 小时缓存机制**，使用 `sync.RWMutex` 保证并发安全，避免频繁请求 API。
    - 提供了 **降级方案 (Fallback)**：如果远程 API 请求失败或数据格式异常，将自动回退到默认版本 `1.21.9`。
- **更新执行器** (`internal/runtime/executor/antigravity_executor.go`):
    - 修改了 `resolveUserAgent` 函数，由原来的直接返回常量改为调用 `misc.AntigravityUserAgent()`。
    - 将原有的 `defaultAntigravityAgent` 标记为仅作为 Fallback 使用。

#### 2.测试验证 (Testing)
- [x] **API 连通性测试**：验证能够正确从远程接口解析出版本号。
- [x] **缓存逻辑测试**：验证在 6 小时内多次调用时，不会触发重复的 HTTP 请求。
- [x] **错误处理测试**：验证在断网或 API 返回 500 时，系统能正确回退到 `1.21.9`。
