### PR TITLE
feat(claude,codex): add scope:global to cache_control + preserve previous_response_id

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1318,6 +1318,7 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 				partJSON := part.Raw
 				if !part.Get("cache_control").Exists() {
 					updated, _ := sjson.SetBytes([]byte(partJSON), "cache_control.type", "ephemeral")
+					updated, _ = sjson.SetBytes(updated, "cache_control.scope", "global")
 					partJSON = string(updated)
 				}
 				result += "," + partJSON
@@ -1325,7 +1326,7 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 			return true
 		})
 	} else if system.Type == gjson.String && system.String() != "" {
-		partJSON := `{"type":"text","cache_control":{"type":"ephemeral"}}`
+		partJSON := `{"type":"text","cache_control":{"type":"ephemeral","scope":"global"}}`
 		updated, _ := sjson.SetBytes([]byte(partJSON), "text", system.String())
 		partJSON = string(updated)
 		result += "," + partJSON
@@ -1839,7 +1840,7 @@ func injectMessagesCacheControl(payload []byte) []byte {
 		contentCount := int(content.Get("#").Int())
 		if contentCount > 0 {
 			cacheControlPath := fmt.Sprintf("messages.%d.content.%d.cache_control", secondToLastUserIdx, contentCount-1)
-			result, err := sjson.SetBytes(payload, cacheControlPath, map[string]string{"type": "ephemeral"})
+			result, err := sjson.SetBytes(payload, cacheControlPath, map[string]string{"type": "ephemeral", "scope": "global"})
 			if err != nil {
 				log.Warnf("failed to inject cache_control into messages: %v", err)
 				return payload
@@ -1854,7 +1855,8 @@ func injectMessagesCacheControl(payload []byte) []byte {
 				"type": "text",
 				"text": text,
 				"cache_control": map[string]string{
-					"type": "ephemeral",
+					"type":  "ephemeral",
+					"scope": "global",
 				},
 			},
 		}
@@ -1898,7 +1900,7 @@ func injectToolsCacheControl(payload []byte) []byte {
 
 	// Add cache_control to the last tool
 	lastToolPath := fmt.Sprintf("tools.%d.cache_control", toolCount-1)
-	result, err := sjson.SetBytes(payload, lastToolPath, map[string]string{"type": "ephemeral"})
+	result, err := sjson.SetBytes(payload, lastToolPath, map[string]string{"type": "ephemeral", "scope": "global"})
 	if err != nil {
 		log.Warnf("failed to inject cache_control into tools array: %v", err)
 		return payload
@@ -1937,7 +1939,7 @@ func injectSystemCacheControl(payload []byte) []byte {
 
 		// Add cache_control to the last system element
 		lastSystemPath := fmt.Sprintf("system.%d.cache_control", count-1)
-		result, err := sjson.SetBytes(payload, lastSystemPath, map[string]string{"type": "ephemeral"})
+		result, err := sjson.SetBytes(payload, lastSystemPath, map[string]string{"type": "ephemeral", "scope": "global"})
 		if err != nil {
 			log.Warnf("failed to inject cache_control into system array: %v", err)
 			return payload
@@ -1952,7 +1954,8 @@ func injectSystemCacheControl(payload []byte) []byte {
 				"type": "text",
 				"text": text,
 				"cache_control": map[string]string{
-					"type": "ephemeral",
+					"type":  "ephemeral",
+					"scope": "global",
 				},
 			},
 		}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -111,7 +111,6 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body, _ = sjson.SetBytes(body, "stream", true)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
@@ -309,7 +308,6 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
@@ -412,7 +410,6 @@ func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth
 	}
 
 	body, _ = sjson.SetBytes(body, "model", baseModel)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -187,7 +187,6 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body, _ = sjson.SetBytes(body, "stream", true)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	if !gjson.GetBytes(body, "instructions").Exists() {

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -18,7 +18,13 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 	}
 
 	rawJSON, _ = sjson.SetBytes(rawJSON, "stream", true)
-	rawJSON, _ = sjson.SetBytes(rawJSON, "store", false)
+	// When previous_response_id is a non-empty string, enable store so OpenAI
+	// can chain responses. Otherwise keep store=false to avoid data retention.
+	if prev := gjson.GetBytes(rawJSON, "previous_response_id"); prev.Type == gjson.String && prev.Str != "" {
+		rawJSON, _ = sjson.SetBytes(rawJSON, "store", true)
+	} else {
+		rawJSON, _ = sjson.SetBytes(rawJSON, "store", false)
+	}
 	rawJSON, _ = sjson.SetBytes(rawJSON, "parallel_tool_calls", true)
 	rawJSON, _ = sjson.SetBytes(rawJSON, "include", []string{"reasoning.encrypted_content"})
 	// Codex Responses rejects token limit fields, so strip them out before forwarding.


### PR DESCRIPTION
## Problem

Multi-agent workflows (missions, squads, subagents) that route through the proxy create isolated sessions. Each session builds its own prompt cache independently, paying full price for the same system prompt, tools, and context across every worker.

Additionally, the proxy unconditionally strips `previous_response_id` from Codex requests, breaking incremental turn chaining for clients that support it (e.g., Codex CLI).

## What this PR does

### 1. Claude: inject `scope:"global"` on all cache_control breakpoints

7 injection points in `claude_executor.go` now set `scope:"global"` alongside `type:"ephemeral"`:
- `checkSystemInstructionsWithSigningMode` — array system parts and string fallback
- `injectMessagesCacheControl` — array content and string-to-array conversion
- `injectToolsCacheControl` — last tool
- `injectSystemCacheControl` — array last element and string-to-array conversion

The `prompt-caching-scope-2026-01-05` beta header is already in the default `baseBetas` string (line 837). This change makes it effective by actually setting `scope` on the cache_control objects.

### 2. Codex: stop stripping `previous_response_id`

Removed `sjson.DeleteBytes(body, "previous_response_id")` from 4 locations:
- `codex_executor.go` Execute, ExecuteStream, CountTokens
- `codex_websockets_executor.go` Execute

The proxy should not silently strip client-sent caching fields. If the upstream rejects `previous_response_id`, that's between the client and upstream.

### 3. Codex translator: conditional `store` based on chaining

`codex_openai-responses_request.go` now checks for `previous_response_id` before setting `store`:
- Present and non-empty string → `store: true` (required for OpenAI to persist responses for chaining)
- Absent or empty → `store: false` (default, no data retention)

`prompt_cache_retention` stripping is intentionally kept — the Codex backend rejects it with `{"detail":"Unsupported parameter: prompt_cache_retention"}`.

## Impact

### Claude (`scope:"global"`)

Without scope:global, each worker's cached system prompt is isolated to its own session. With it, all requests using the same API key share one prompt cache.

| Scenario (5 workers, 60K system prompt) | Before | After |
|---|---|---|
| Worker A turn 1 | 60K full price | 60K full price |
| Worker B turn 1 | 60K full price | 6K (90% cached) |
| Worker C turn 1 | 60K full price | 6K (90% cached) |
| Worker D turn 1 | 60K full price | 6K (90% cached) |
| Worker E turn 1 | 60K full price | 6K (90% cached) |
| **Total** | **300K tokens** | **84K tokens (72% savings)** |

### Codex (`previous_response_id` passthrough)

Clients using `previous_response_id` (e.g., Codex CLI) send only delta input on subsequent turns instead of full conversation history. A 20-turn session sends ~160K tokens with chaining vs ~2.3M without — 14x reduction.

Clients that don't send `previous_response_id` (e.g., Factory Droid) see zero behavior change — the field simply isn't in the request body, so there's nothing to strip or pass through.

## Files changed

| File | Lines | Change |
|---|---|---|
| `claude_executor.go` | +8 | `scope:"global"` on 7 injection points |
| `codex_executor.go` | -3 | removed `previous_response_id` stripping |
| `codex_websockets_executor.go` | -1 | removed `previous_response_id` stripping |
| `codex_openai-responses_request.go` | +7/-1 | conditional `store` based on `previous_response_id` |

## Risk

Low.

- `scope:"global"` is additive. The beta header `prompt-caching-scope-2026-01-05` is already in the default `baseBetas` (line 837). Anthropic ignores `scope` if the beta isn't set, and it is.
- `previous_response_id` passthrough only affects clients that explicitly send the field. Existing clients that don't send it see zero behavior change.
- The `store` conditional is a strict superset of the previous behavior — `store: false` is still the default when no chaining is requested.
- `prompt_cache_retention` is still stripped to avoid Codex backend 400 errors.

## Test plan

- [ ] Claude requests include `scope:"global"` in all injected `cache_control` blocks
- [ ] Claude requests with existing `cache_control` are not modified (preserves client-sent values)
- [ ] Codex requests preserve `previous_response_id` when client sends it
- [ ] Codex requests without `previous_response_id` still have `store:false`
- [ ] `prompt_cache_retention` is still stripped (no 400 from Codex backend)
- [ ] Existing SSE streaming, WebSocket, and non-streaming paths unaffected