### PR TITLE
fix(management): support explicit proxy overrides in api-call

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -43,6 +43,9 @@ type apiCallRequest struct {
 	AuthIndexSnake  *string           `json:"auth_index"`
 	AuthIndexCamel  *string           `json:"authIndex"`
 	AuthIndexPascal *string           `json:"AuthIndex"`
+	ProxyURLSnake   *string           `json:"proxy_url"`
+	ProxyURLCamel   *string           `json:"proxyUrl"`
+	ProxyURLPascal  *string           `json:"ProxyURL"`
 	Method          string            `json:"method"`
 	URL             string            `json:"url"`
 	Header          map[string]string `json:"header"`
@@ -73,6 +76,9 @@ type apiCallResponse struct {
 //   - auth_index / authIndex / AuthIndex (optional):
 //     The credential "auth_index" from GET /v0/management/auth-files (or other endpoints returning it).
 //     If omitted or not found, credential-specific proxy/token substitution is skipped.
+//   - proxy_url / proxyUrl / ProxyURL (optional):
+//     Explicit proxy override for this request. Supports socks5/http/https, plus "direct"/"none"
+//     to bypass both configured and environment proxies.
 //   - method (required): HTTP method, e.g. GET, POST, PUT, PATCH, DELETE.
 //   - url (required): Absolute URL including scheme and host, e.g. "https://api.example.com/v1/ping".
 //   - header (optional): Request headers map.
@@ -85,9 +91,10 @@ type apiCallResponse struct {
 //   - data (optional): Raw request body as string (useful for POST/PUT/PATCH).
 //
 // Proxy selection (highest priority first):
-//  1. Selected credential proxy_url
-//  2. Global config proxy-url
-//  3. Direct connect (environment proxies are not used)
+//  1. Explicit request proxy_url
+//  2. Selected credential proxy_url
+//  3. Global config proxy-url
+//  4. Direct connect (environment proxies are not used)
 //
 // Response JSON (returned with HTTP 200 when the APICall itself succeeds):
 //   - status_code: Upstream HTTP status code.
@@ -130,6 +137,7 @@ func (h *Handler) APICall(c *gin.Context) {
 	}
 
 	authIndex := firstNonEmptyString(body.AuthIndexSnake, body.AuthIndexCamel, body.AuthIndexPascal)
+	proxyURL := firstNonEmptyString(body.ProxyURLSnake, body.ProxyURLCamel, body.ProxyURLPascal)
 	auth := h.authByIndex(authIndex)
 
 	reqHeaders := body.Header
@@ -188,7 +196,7 @@ func (h *Handler) APICall(c *gin.Context) {
 	httpClient := &http.Client{
 		Timeout: defaultAPICallTimeout,
 	}
-	httpClient.Transport = h.apiCallTransport(auth)
+	httpClient.Transport = h.apiCallTransport(proxyURL, auth)
 
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
@@ -317,7 +325,7 @@ func (h *Handler) refreshGeminiOAuthAccessToken(ctx context.Context, auth *corea
 	ctxToken := ctx
 	httpClient := &http.Client{
 		Timeout:   defaultAPICallTimeout,
-		Transport: h.apiCallTransport(auth),
+		Transport: h.apiCallTransport("", auth),
 	}
 	ctxToken = context.WithValue(ctxToken, oauth2.HTTPClient, httpClient)
 
@@ -376,7 +384,7 @@ func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *
 
 	httpClient := &http.Client{
 		Timeout:   defaultAPICallTimeout,
-		Transport: h.apiCallTransport(auth),
+		Transport: h.apiCallTransport("", auth),
 	}
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
@@ -630,8 +638,11 @@ func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {
 	return nil
 }
 
-func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
+func (h *Handler) apiCallTransport(explicitProxy string, auth *coreauth.Auth) http.RoundTripper {
 	var proxyCandidates []string
+	if proxyStr := strings.TrimSpace(explicitProxy); proxyStr != "" {
+		proxyCandidates = append(proxyCandidates, proxyStr)
+	}
 	if auth != nil {
 		if proxyStr := strings.TrimSpace(auth.ProxyURL); proxyStr != "" {
 			proxyCandidates = append(proxyCandidates, proxyStr)

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -19,7 +19,7 @@ func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 		},
 	}
 
-	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "direct"})
+	transport := h.apiCallTransport("", &coreauth.Auth{ProxyURL: "direct"})
 	httpTransport, ok := transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", transport)
@@ -38,7 +38,7 @@ func TestAPICallTransportInvalidAuthFallsBackToGlobalProxy(t *testing.T) {
 		},
 	}
 
-	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "bad-value"})
+	transport := h.apiCallTransport("", &coreauth.Auth{ProxyURL: "bad-value"})
 	httpTransport, ok := transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", transport)
@@ -55,6 +55,57 @@ func TestAPICallTransportInvalidAuthFallsBackToGlobalProxy(t *testing.T) {
 	}
 	if proxyURL == nil || proxyURL.String() != "http://global-proxy.example.com:8080" {
 		t.Fatalf("proxy URL = %v, want http://global-proxy.example.com:8080", proxyURL)
+	}
+}
+
+func TestAPICallTransportExplicitDirectOverridesAuthAndGlobal(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://global-proxy.example.com:8080"},
+		},
+	}
+
+	transport := h.apiCallTransport("direct", &coreauth.Auth{ProxyURL: "http://auth-proxy.example.com:8080"})
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", transport)
+	}
+	if httpTransport.Proxy != nil {
+		t.Fatal("expected explicit direct transport to disable proxy function")
+	}
+}
+
+func TestAPICallTransportExplicitProxyOverridesAuthAndGlobal(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://global-proxy.example.com:8080"},
+		},
+	}
+
+	transport := h.apiCallTransport(
+		"http://request-proxy.example.com:9090",
+		&coreauth.Auth{ProxyURL: "http://auth-proxy.example.com:8080"},
+	)
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", transport)
+	}
+
+	req, errRequest := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if errRequest != nil {
+		t.Fatalf("http.NewRequest returned error: %v", errRequest)
+	}
+
+	proxyURL, errProxy := httpTransport.Proxy(req)
+	if errProxy != nil {
+		t.Fatalf("httpTransport.Proxy returned error: %v", errProxy)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://request-proxy.example.com:9090" {
+		t.Fatalf("proxy URL = %v, want http://request-proxy.example.com:9090", proxyURL)
 	}
 }
 


### PR DESCRIPTION
## Summary
- accept `proxy_url` / `proxyUrl` / `ProxyURL` on management `/api-call` requests
- prioritize an explicit request proxy before auth-level and global proxy settings while preserving `direct` / `none` semantics
- add transport tests that cover explicit direct and explicit proxy override precedence

## Tests
- `go test ./internal/api/handlers/management -run 'TestAPICallTransport|TestAuthByIndexDistinguishesSharedAPIKeysAcrossProviders'`\n\n## Notes\n- this is the backend half of the provider proxy fix so the management UI can forward per-request provider proxies without needing an auth index\n- no existing request shape changes are required for callers that do not send a proxy override\n- pairs with router-for-me/Cli-Proxy-API-Management-Center#190 and the frontend fix in router-for-me/Cli-Proxy-API-Management-Center#194