### PR TITLE
fix qwen image error

### DIFF
--- a/internal/runtime/executor/qwen_executor.go
+++ b/internal/runtime/executor/qwen_executor.go
@@ -229,11 +229,6 @@ func ensureQwenSystemMessage(payload []byte) ([]byte, error) {
 				for _, item := range content.Array() {
 					itemType := item.Get("type").String()
 
-					if itemType == "image_url" || itemType == "image" || itemType == "file" {
-						newParts = append(newParts, item.Raw)
-						continue
-					}
-
 					if itemType == "text" {
 						text := item.Get("text").String()
 						if len(text) == 0 {
@@ -250,6 +245,8 @@ func ensureQwenSystemMessage(payload []byte) ([]byte, error) {
 						} else {
 							newParts = append(newParts, item.Raw)
 						}
+					} else {
+						newParts = append(newParts, item.Raw)
 					}
 				}
 
@@ -289,10 +286,16 @@ func ensureQwenSystemMessage(payload []byte) ([]byte, error) {
 }
 
 
-// 智能文本拆分：优先在空格/标点/换行处切分，不切断单词
+// splitTextChunk splits text into chunks with a maximum length limit,
+// prioritizing semantic breakpoints to avoid breaking words, numbers or sentences.
+//
+// Key behaviors:
+//  1. Tries to find the nearest safe breakpoint (space, line break, tab, or common punctuation) within the last 20% of the limit
+//  2. Uses []rune to handle multi-byte characters (e.g., Chinese, emoji) correctly
+//  3. Falls back to hard cutting at the exact limit only if no safe breakpoint is found
 func splitTextChunk(text string, max int) []string {
 	var chunks []string
-	runes := []rune(text) // 处理中文等多字节字符
+	runes := []rune(text)
 	for len(runes) > 0 {
 		splitLen := max
 		if len(runes) <= splitLen {
@@ -300,19 +303,19 @@ func splitTextChunk(text string, max int) []string {
 			break
 		}
 
-		// 向前找最近的安全断点：空格、标点、换行
+		// Look backwards for the nearest safe breakpoint: space, punctuation, or line break
 		safeIdx := -1
-		// 在 [splitLen*0.8, splitLen] 区间内找断点
+		// Search within the range [splitLen*0.8, splitLen-1]
 		lookBackStart := splitLen * 8 / 10
-		for i := splitLen; i >= lookBackStart; i-- {
+		for i := splitLen - 1; i >= lookBackStart; i-- {
 			r := runes[i]
 			if r == ' ' || r == '\n' || r == '\t' || r == ',' || r == '.' || r == ';' || r == '!' || r == '?' {
-				safeIdx = i + 1 // 切在标点/空格后面
+				safeIdx = i + 1 // Cut right after the punctuation/space
 				break
 			}
 		}
 
-		// 实在找不到断点，才硬切
+		// Fall back to hard cutting at exact limit if no safe breakpoint found
 		if safeIdx == -1 {
 			safeIdx = splitLen
 		}

--- a/internal/runtime/executor/qwen_executor.go
+++ b/internal/runtime/executor/qwen_executor.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"encoding/json"
 
 	qwenauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -172,117 +173,146 @@ func timeUntilNextDay() time.Duration {
 	return tomorrow.Sub(now)
 }
 
+// Lightweight struct to represent a chat message, designed to:
+//  1. Avoid repeated JSON parsing/serialization (performance boost)
+//  2. Provide type safety for message fields (compile-time checks)
+//  3. Make the code self-documenting (clear structure visible in Go types)
+//  4. Simplify handling of the dynamic "content" field (which can be either string or array)
+type message struct {
+	Role    string      `json:"role"`
+	Content interface{} `json:"content"` // Can be string or []interface{}
+}
+
 // ensureQwenSystemMessage handles Qwen message payload formatting and normalization:
 //  1. Prepends the default system message to the very beginning of the messages array
 //  2. Automatically converts any existing system role messages to user role
 //  3. Intelligently splits overlong text content (>10000 characters), prioritizing splits at spaces, line breaks or punctuation to avoid breaking words/numbers
 //  4. Keeps image, file and media content intact without any splitting
 func ensureQwenSystemMessage(payload []byte) ([]byte, error) {
-	messages := gjson.GetBytes(payload, "messages")
-	const MAX_LENGTH = 10000;
+	const MAX_LENGTH = 10000
 
-	if messages.Exists() && messages.IsArray() {
-		var buf bytes.Buffer
-		buf.WriteByte('[')
-		buf.Write(qwenDefaultSystemMessage)
-		for _, msg := range messages.Array() {
-			// buf.WriteByte(',')
-			// buf.WriteString(msg.Raw)
-			processedMsg := msg.Raw
-			if strings.EqualFold(msg.Get("role").String(), "system") {
-				modified, err := sjson.SetRaw(msg.Raw, "role", `"user"`)
-				if err == nil {
-					processedMsg = modified
-				}
-			}
-
-			content := gjson.Get(processedMsg, "content")
-			
-			if content.Type == gjson.String {
-				text := content.String()
-				if len(text) > 0 {
-					var newContents []string
-					if len(text) > MAX_LENGTH {
-						chunks := splitTextChunk(text, MAX_LENGTH)
-						for _, c := range chunks {
-							newContents = append(newContents, `{"type":"text","text":`+fmt.Sprintf("%q", c)+`}`)
-						}
-					} else {
-						newContents = append(newContents, `{"type":"text","text":`+fmt.Sprintf("%q", text)+`}`)
-					}
-
-					var cbuf bytes.Buffer
-					cbuf.WriteByte('[')
-					for i, s := range newContents {
-						if i > 0 {
-							cbuf.WriteByte(',')
-						}
-						cbuf.WriteString(s)
-					}
-					cbuf.WriteByte(']')
-					processedMsg, _ = sjson.SetRaw(processedMsg, "content", cbuf.String())
-				}
-			}
-
-			if content.IsArray() {
-				var newParts []string
-				for _, item := range content.Array() {
-					itemType := item.Get("type").String()
-
-					if itemType == "text" {
-						text := item.Get("text").String()
-						if len(text) == 0 {
-							newParts = append(newParts, item.Raw)
-							continue
-						}
-
-						if len(text) > MAX_LENGTH {
-							chunks := splitTextChunk(text, MAX_LENGTH)
-							for _, chunk := range chunks {
-								part := `{"type":"text","text":` + fmt.Sprintf("%q", chunk) + `}`
-								newParts = append(newParts, part)
-							}
-						} else {
-							newParts = append(newParts, item.Raw)
-						}
-					} else {
-						newParts = append(newParts, item.Raw)
-					}
-				}
-
-				var cbuf bytes.Buffer
-				cbuf.WriteByte('[')
-				for i, p := range newParts {
-					if i > 0 {
-						cbuf.WriteByte(',')
-					}
-					cbuf.WriteString(p)
-				}
-				cbuf.WriteByte(']')
-
-				processedMsg, _ = sjson.SetRaw(processedMsg, "content", cbuf.String())
-			}
-
-			buf.WriteByte(',')
-			buf.WriteString(processedMsg)
-		}
-		buf.WriteByte(']')
-		updated, errSet := sjson.SetRawBytes(payload, "messages", buf.Bytes())
-		if errSet != nil {
-			return nil, fmt.Errorf("qwen executor: set default system message failed: %w", errSet)
-		}
-		return updated, nil
+	// 1. Parse default system message first (only once)
+	var defaultSysMsg message
+	if err := json.Unmarshal(qwenDefaultSystemMessage, &defaultSysMsg); err != nil {
+		return nil, fmt.Errorf("failed to parse default system message: %w", err)
 	}
 
-	var buf bytes.Buffer
-	buf.WriteByte('[')
-	buf.Write(qwenDefaultSystemMessage)
-	buf.WriteByte(']')
-	updated, errSet := sjson.SetRawBytes(payload, "messages", buf.Bytes())
-	if errSet != nil {
-		return nil, fmt.Errorf("qwen executor: set default system message failed: %w", errSet)
+	// 2. Parse original payload
+	var payloadMap map[string]interface{}
+	if err := json.Unmarshal(payload, &payloadMap); err != nil {
+		return nil, fmt.Errorf("failed to parse payload: %w", err)
 	}
-	return updated, nil
+
+	// 3. Build new message list
+	var newMessages []interface{}
+	newMessages = append(newMessages, defaultSysMsg) // Default system always first
+	
+	// Process existing messages
+	if rawMsgs, ok := payloadMap["messages"]; ok {
+		if msgsArr, ok := rawMsgs.([]interface{}); ok {
+			for _, rawMsg := range msgsArr {
+				// Marshal single message
+				msgBytes, err := json.Marshal(rawMsg)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal message: %w", err)
+				}
+
+				var msg message
+				if err := json.Unmarshal(msgBytes, &msg); err != nil {
+					return nil, fmt.Errorf("failed to parse message: %w", err)
+				}
+
+				// Convert existing system role to user
+				if strings.EqualFold(msg.Role, "system") {
+					msg.Role = "user"
+				}
+
+				// Process content
+				if err := processMessageContent(&msg, MAX_LENGTH); err != nil {
+					return nil, err
+				}
+
+				newMessages = append(newMessages, msg)
+			}
+		}
+	}
+
+	// 4. Replace and marshal back
+	payloadMap["messages"] = newMessages
+	result, err := json.Marshal(payloadMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal final payload: %w", err)
+	}
+
+	return result, nil
+}
+
+// processMessageContent unified processing of message content (string or array)
+func processMessageContent(msg *message, maxLen int) error {
+	switch content := msg.Content.(type) {
+	case string:
+		// Case 1: content is string
+		if len(content) == 0 {
+			return nil
+		}
+
+		var newContentArr []interface{}
+		if len(content) > maxLen {
+			chunks := splitTextChunk(content, maxLen)
+			for _, c := range chunks {
+				newContentArr = append(newContentArr, map[string]interface{}{
+					"type": "text",
+					"text": c,
+				})
+			}
+		} else {
+			newContentArr = append(newContentArr, map[string]interface{}{
+				"type": "text",
+				"text": content,
+			})
+		}
+		msg.Content = newContentArr
+
+	case []interface{}:
+		// Case 2: content is array
+		var newContentArr []interface{}
+		for _, item := range content {
+			itemMap, ok := item.(map[string]interface{})
+			if !ok {
+				newContentArr = append(newContentArr, item)
+				continue
+			}
+
+			itemType, _ := itemMap["type"].(string)
+			if itemType != "text" {
+				// Non-text types (image/file) keep intact
+				newContentArr = append(newContentArr, item)
+				continue
+			}
+
+			// Process text type
+			text, _ := itemMap["text"].(string)
+			if len(text) == 0 {
+				newContentArr = append(newContentArr, item)
+				continue
+			}
+
+			if len(text) > maxLen {
+				chunks := splitTextChunk(text, maxLen)
+				for _, c := range chunks {
+					newContentArr = append(newContentArr, map[string]interface{}{
+						"type": "text",
+						"text": c,
+					})
+				}
+			} else {
+				newContentArr = append(newContentArr, item)
+			}
+		}
+		msg.Content = newContentArr
+	}
+
+	return nil
 }
 
 

--- a/internal/runtime/executor/qwen_executor.go
+++ b/internal/runtime/executor/qwen_executor.go
@@ -172,103 +172,155 @@ func timeUntilNextDay() time.Duration {
 	return tomorrow.Sub(now)
 }
 
-// ensureQwenSystemMessage ensures the request has a single system message at the beginning.
-// It always injects the default system prompt and merges any user-provided system messages
-// into the injected system message content to satisfy Qwen's strict message ordering rules.
+// ensureQwenSystemMessage handles Qwen message payload formatting and normalization:
+//  1. Prepends the default system message to the very beginning of the messages array
+//  2. Automatically converts any existing system role messages to user role
+//  3. Intelligently splits overlong text content (>10000 characters), prioritizing splits at spaces, line breaks or punctuation to avoid breaking words/numbers
+//  4. Keeps image, file and media content intact without any splitting
 func ensureQwenSystemMessage(payload []byte) ([]byte, error) {
-	isInjectedSystemPart := func(part gjson.Result) bool {
-		if !part.Exists() || !part.IsObject() {
-			return false
-		}
-		if !strings.EqualFold(part.Get("type").String(), "text") {
-			return false
-		}
-		if !strings.EqualFold(part.Get("cache_control.type").String(), "ephemeral") {
-			return false
-		}
-		text := part.Get("text").String()
-		return text == "" || text == "You are Qwen Code."
-	}
-
-	defaultParts := gjson.ParseBytes(qwenDefaultSystemMessage).Get("content")
-	var systemParts []any
-	if defaultParts.Exists() && defaultParts.IsArray() {
-		for _, part := range defaultParts.Array() {
-			systemParts = append(systemParts, part.Value())
-		}
-	}
-	if len(systemParts) == 0 {
-		systemParts = append(systemParts, map[string]any{
-			"type": "text",
-			"text": "You are Qwen Code.",
-			"cache_control": map[string]any{
-				"type": "ephemeral",
-			},
-		})
-	}
-
-	appendSystemContent := func(content gjson.Result) {
-		makeTextPart := func(text string) map[string]any {
-			return map[string]any{
-				"type": "text",
-				"text": text,
-			}
-		}
-
-		if !content.Exists() || content.Type == gjson.Null {
-			return
-		}
-		if content.IsArray() {
-			for _, part := range content.Array() {
-				if part.Type == gjson.String {
-					systemParts = append(systemParts, makeTextPart(part.String()))
-					continue
-				}
-				if isInjectedSystemPart(part) {
-					continue
-				}
-				systemParts = append(systemParts, part.Value())
-			}
-			return
-		}
-		if content.Type == gjson.String {
-			systemParts = append(systemParts, makeTextPart(content.String()))
-			return
-		}
-		if content.IsObject() {
-			if isInjectedSystemPart(content) {
-				return
-			}
-			systemParts = append(systemParts, content.Value())
-			return
-		}
-		systemParts = append(systemParts, makeTextPart(content.String()))
-	}
-
 	messages := gjson.GetBytes(payload, "messages")
-	var nonSystemMessages []any
+	const MAX_LENGTH = 10000;
+
 	if messages.Exists() && messages.IsArray() {
+		var buf bytes.Buffer
+		buf.WriteByte('[')
+		buf.Write(qwenDefaultSystemMessage)
 		for _, msg := range messages.Array() {
+			// buf.WriteByte(',')
+			// buf.WriteString(msg.Raw)
+			processedMsg := msg.Raw
 			if strings.EqualFold(msg.Get("role").String(), "system") {
-				appendSystemContent(msg.Get("content"))
-				continue
+				modified, err := sjson.SetRaw(msg.Raw, "role", `"user"`)
+				if err == nil {
+					processedMsg = modified
+				}
 			}
-			nonSystemMessages = append(nonSystemMessages, msg.Value())
+
+			content := gjson.Get(processedMsg, "content")
+			
+			if content.Type == gjson.String {
+				text := content.String()
+				if len(text) > 0 {
+					var newContents []string
+					if len(text) > MAX_LENGTH {
+						chunks := splitTextChunk(text, MAX_LENGTH)
+						for _, c := range chunks {
+							newContents = append(newContents, `{"type":"text","text":`+fmt.Sprintf("%q", c)+`}`)
+						}
+					} else {
+						newContents = append(newContents, `{"type":"text","text":`+fmt.Sprintf("%q", text)+`}`)
+					}
+
+					var cbuf bytes.Buffer
+					cbuf.WriteByte('[')
+					for i, s := range newContents {
+						if i > 0 {
+							cbuf.WriteByte(',')
+						}
+						cbuf.WriteString(s)
+					}
+					cbuf.WriteByte(']')
+					processedMsg, _ = sjson.SetRaw(processedMsg, "content", cbuf.String())
+				}
+			}
+
+			if content.IsArray() {
+				var newParts []string
+				for _, item := range content.Array() {
+					itemType := item.Get("type").String()
+
+					if itemType == "image_url" || itemType == "image" || itemType == "file" {
+						newParts = append(newParts, item.Raw)
+						continue
+					}
+
+					if itemType == "text" {
+						text := item.Get("text").String()
+						if len(text) == 0 {
+							newParts = append(newParts, item.Raw)
+							continue
+						}
+
+						if len(text) > MAX_LENGTH {
+							chunks := splitTextChunk(text, MAX_LENGTH)
+							for _, chunk := range chunks {
+								part := `{"type":"text","text":` + fmt.Sprintf("%q", chunk) + `}`
+								newParts = append(newParts, part)
+							}
+						} else {
+							newParts = append(newParts, item.Raw)
+						}
+					}
+				}
+
+				var cbuf bytes.Buffer
+				cbuf.WriteByte('[')
+				for i, p := range newParts {
+					if i > 0 {
+						cbuf.WriteByte(',')
+					}
+					cbuf.WriteString(p)
+				}
+				cbuf.WriteByte(']')
+
+				processedMsg, _ = sjson.SetRaw(processedMsg, "content", cbuf.String())
+			}
+
+			buf.WriteByte(',')
+			buf.WriteString(processedMsg)
 		}
+		buf.WriteByte(']')
+		updated, errSet := sjson.SetRawBytes(payload, "messages", buf.Bytes())
+		if errSet != nil {
+			return nil, fmt.Errorf("qwen executor: set default system message failed: %w", errSet)
+		}
+		return updated, nil
 	}
 
-	newMessages := make([]any, 0, 1+len(nonSystemMessages))
-	newMessages = append(newMessages, map[string]any{
-		"role":    "system",
-		"content": systemParts,
-	})
-	newMessages = append(newMessages, nonSystemMessages...)
-
-	updated, errSet := sjson.SetBytes(payload, "messages", newMessages)
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	buf.Write(qwenDefaultSystemMessage)
+	buf.WriteByte(']')
+	updated, errSet := sjson.SetRawBytes(payload, "messages", buf.Bytes())
 	if errSet != nil {
-		return nil, fmt.Errorf("qwen executor: set system message failed: %w", errSet)
+		return nil, fmt.Errorf("qwen executor: set default system message failed: %w", errSet)
 	}
 	return updated, nil
+}
+
+
+// 智能文本拆分：优先在空格/标点/换行处切分，不切断单词
+func splitTextChunk(text string, max int) []string {
+	var chunks []string
+	runes := []rune(text) // 处理中文等多字节字符
+	for len(runes) > 0 {
+		splitLen := max
+		if len(runes) <= splitLen {
+			chunks = append(chunks, string(runes))
+			break
+		}
+
+		// 向前找最近的安全断点：空格、标点、换行
+		safeIdx := -1
+		// 在 [splitLen*0.8, splitLen] 区间内找断点
+		lookBackStart := splitLen * 8 / 10
+		for i := splitLen; i >= lookBackStart; i-- {
+			r := runes[i]
+			if r == ' ' || r == '\n' || r == '\t' || r == ',' || r == '.' || r == ';' || r == '!' || r == '?' {
+				safeIdx = i + 1 // 切在标点/空格后面
+				break
+			}
+		}
+
+		// 实在找不到断点，才硬切
+		if safeIdx == -1 {
+			safeIdx = splitLen
+		}
+
+		chunks = append(chunks, string(runes[:safeIdx]))
+		runes = runes[safeIdx:]
+	}
+	return chunks
 }
 
 // QwenExecutor is a stateless executor for Qwen Code using OpenAI-compatible chat completions.

--- a/internal/runtime/executor/qwen_executor_test.go
+++ b/internal/runtime/executor/qwen_executor_test.go
@@ -46,21 +46,22 @@ func TestEnsureQwenSystemMessage_MergeStringSystem(t *testing.T) {
 	}
 
 	msgs := gjson.GetBytes(out, "messages").Array()
-	if len(msgs) != 2 {
-		t.Fatalf("messages length = %d, want 2", len(msgs))
+	if len(msgs) != 3 {
+		t.Fatalf("messages length = %d, want 3", len(msgs))
 	}
 	if msgs[0].Get("role").String() != "system" {
 		t.Fatalf("messages[0].role = %q, want %q", msgs[0].Get("role").String(), "system")
 	}
 	parts := msgs[0].Get("content").Array()
-	if len(parts) != 2 {
-		t.Fatalf("messages[0].content length = %d, want 2", len(parts))
+	if len(parts) != 1 {
+		t.Fatalf("messages[0].content length = %d, want 1", len(parts))
 	}
-	if parts[0].Get("text").String() != "You are Qwen Code." || parts[0].Get("cache_control.type").String() != "ephemeral" {
+	if parts[0].Get("text").String() != "" || parts[0].Get("cache_control.type").String() != "ephemeral" {
 		t.Fatalf("messages[0].content[0] = %s, want injected system part", parts[0].Raw)
 	}
-	if parts[1].Get("type").String() != "text" || parts[1].Get("text").String() != "ABCDEFG" {
-		t.Fatalf("messages[0].content[1] = %s, want text part with ABCDEFG", parts[1].Raw)
+	parts = msgs[1].Get("content").Array()
+	if parts[0].Get("type").String() != "text" || parts[0].Get("text").String() != "ABCDEFG" {
+		t.Fatalf("messages[1].content[0] = %s, want text part with ABCDEFG", parts[0].Get("text").Raw)
 	}
 	if msgs[1].Get("role").String() != "user" {
 		t.Fatalf("messages[1].role = %q, want %q", msgs[1].Get("role").String(), "user")
@@ -81,15 +82,15 @@ func TestEnsureQwenSystemMessage_MergeObjectSystem(t *testing.T) {
 	}
 
 	msgs := gjson.GetBytes(out, "messages").Array()
-	if len(msgs) != 2 {
-		t.Fatalf("messages length = %d, want 2", len(msgs))
+	if len(msgs) != 3 {
+		t.Fatalf("messages length = %d, want 3", len(msgs))
 	}
-	parts := msgs[0].Get("content").Array()
-	if len(parts) != 2 {
-		t.Fatalf("messages[0].content length = %d, want 2", len(parts))
+	parts := msgs[1].Get("content").Array()
+	if len(parts) != 1 {
+		t.Fatalf("messages[0].content length = %d, want 1", len(parts))
 	}
-	if parts[1].Get("text").String() != "ABCDEFG" {
-		t.Fatalf("messages[0].content[1].text = %q, want %q", parts[1].Get("text").String(), "ABCDEFG")
+	if parts[0].Get("text").String() != "ABCDEFG" {
+		t.Fatalf("messages[0].content[1].text = %q, want %q", parts[0].Get("text").String(), "ABCDEFG")
 	}
 }
 
@@ -135,17 +136,15 @@ func TestEnsureQwenSystemMessage_MergesMultipleSystemMessages(t *testing.T) {
 	}
 
 	msgs := gjson.GetBytes(out, "messages").Array()
-	if len(msgs) != 2 {
-		t.Fatalf("messages length = %d, want 2", len(msgs))
+	if len(msgs) != 4 {
+		t.Fatalf("messages length = %d, want 4", len(msgs))
 	}
-	parts := msgs[0].Get("content").Array()
-	if len(parts) != 3 {
-		t.Fatalf("messages[0].content length = %d, want 3", len(parts))
+	parts := msgs[1].Get("content").Array()
+	if parts[0].Get("text").String() != "A" {
+		t.Fatalf("messages[0].content[1].text = %q, want %q", parts[0].Get("text").String(), "A")
 	}
-	if parts[1].Get("text").String() != "A" {
-		t.Fatalf("messages[0].content[1].text = %q, want %q", parts[1].Get("text").String(), "A")
-	}
-	if parts[2].Get("text").String() != "B" {
-		t.Fatalf("messages[0].content[2].text = %q, want %q", parts[2].Get("text").String(), "B")
+	parts = msgs[3].Get("content").Array()
+	if parts[0].Get("text").String() != "B" {
+		t.Fatalf("messages[0].content[2].text = %q, want %q", parts[0].Get("text").String(), "B")
 	}
 }


### PR DESCRIPTION
openclaw+feishu 90% ok。

核心修改逻辑：
// ensureQwenSystemMessage 处理 Qwen 消息格式：
//  1. 强制在 messages 最前面插入默认 system 消息
//  2. 原有 system 消息自动转为 user 角色
//  3. 超长文本（>10000字符）智能拆分，优先在空格/标点处切分
//  4. 图片/文件类型原样保留，不做拆分

第3、4点，是因为，我把cpa发出的消息体写死到qwen客户端cli.js的请求里，每次都不会报错；但是在cpa里，就会3/5的几率报错，把长内容删掉，90%则不报错，故增加了切分内容的处理逻辑，把content里的一个长句子切分为多个短句。