### PR TITLE
fix(codex): improve OAuth websocket parity for fast/priority responses

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	codexUserAgent  = "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)"
-	codexOriginator = "codex-tui"
+	codexOriginator = "codex-toy-app-server"
 )
 
 var dataTag = []byte("data:")

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -190,9 +190,10 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
-	if !gjson.GetBytes(body, "instructions").Exists() {
-		body, _ = sjson.SetBytes(body, "instructions", "")
-	}
+	body = normalizeCodexWebsocketInstructions(body)
+	executionSessionID := executionSessionIDFromOptions(opts)
+	var turnMeta string
+	body, turnMeta = enrichCodexWebsocketSessionMetadata(body, executionSessionID)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
@@ -201,6 +202,13 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 
 	body, wsHeaders := applyCodexPromptCacheHeaders(from, req, body)
+	if strings.TrimSpace(executionSessionID) != "" {
+		wsHeaders.Set("Session_id", executionSessionID)
+		wsHeaders.Set("x-client-request-id", executionSessionID)
+	}
+	if strings.TrimSpace(turnMeta) != "" {
+		wsHeaders.Set("x-codex-turn-metadata", turnMeta)
+	}
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 
 	var authID, authLabel, authType, authValue string
@@ -210,7 +218,6 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		authType, authValue = auth.AccountInfo()
 	}
 
-	executionSessionID := executionSessionIDFromOptions(opts)
 	var sess *codexWebsocketSession
 	if executionSessionID != "" {
 		sess = e.getOrCreateSession(executionSessionID)
@@ -388,6 +395,15 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, body, requestedModel)
+	body, _ = sjson.SetBytes(body, "model", baseModel)
+	body, _ = sjson.SetBytes(body, "stream", true)
+	body, _ = sjson.DeleteBytes(body, "previous_response_id")
+	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
+	body, _ = sjson.DeleteBytes(body, "safety_identifier")
+	body = normalizeCodexWebsocketInstructions(body)
+	executionSessionID := executionSessionIDFromOptions(opts)
+	var turnMeta string
+	body, turnMeta = enrichCodexWebsocketSessionMetadata(body, executionSessionID)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
@@ -396,6 +412,13 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 
 	body, wsHeaders := applyCodexPromptCacheHeaders(from, req, body)
+	if strings.TrimSpace(executionSessionID) != "" {
+		wsHeaders.Set("Session_id", executionSessionID)
+		wsHeaders.Set("x-client-request-id", executionSessionID)
+	}
+	if strings.TrimSpace(turnMeta) != "" {
+		wsHeaders.Set("x-codex-turn-metadata", turnMeta)
+	}
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 
 	var authID, authLabel, authType, authValue string
@@ -403,7 +426,6 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	authLabel = auth.Label
 	authType, authValue = auth.AccountInfo()
 
-	executionSessionID := executionSessionIDFromOptions(opts)
 	var sess *codexWebsocketSession
 	if executionSessionID != "" {
 		sess = e.getOrCreateSession(executionSessionID)
@@ -802,7 +824,6 @@ func applyCodexPromptCacheHeaders(from sdktranslator.Format, req cliproxyexecuto
 
 	if cache.ID != "" {
 		rawJSON, _ = sjson.SetBytes(rawJSON, "prompt_cache_key", cache.ID)
-		headers.Set("Conversation_id", cache.ID)
 	}
 
 	return rawJSON, headers
@@ -1060,6 +1081,30 @@ func websocketHandshakeBody(resp *http.Response) []byte {
 		return nil
 	}
 	return body
+}
+
+func normalizeCodexWebsocketInstructions(body []byte) []byte {
+	instructions := gjson.GetBytes(body, "instructions")
+	if !instructions.Exists() || instructions.Type == gjson.Null || strings.TrimSpace(instructions.String()) == "" {
+		body, _ = sjson.SetBytes(body, "instructions", "You are a helpful assistant.")
+	}
+	return body
+}
+
+func enrichCodexWebsocketSessionMetadata(body []byte, sessionID string) ([]byte, string) {
+	if strings.TrimSpace(sessionID) == "" {
+		sessionID = uuid.NewString()
+	}
+	if promptCacheKey := gjson.GetBytes(body, "prompt_cache_key"); !promptCacheKey.Exists() || strings.TrimSpace(promptCacheKey.String()) == "" {
+		body, _ = sjson.SetBytes(body, "prompt_cache_key", sessionID)
+	}
+	clientMetadata := gjson.GetBytes(body, "client_metadata")
+	if !clientMetadata.Exists() || clientMetadata.Type == gjson.Null {
+		body, _ = sjson.SetRawBytes(body, "client_metadata", []byte(`{}`))
+	}
+	turnMeta := fmt.Sprintf(`{"session_id":"%s","turn_id":"","workspaces":{},"sandbox":"seccomp"}`, sessionID)
+	body, _ = sjson.SetBytes(body, "client_metadata.x-codex-turn-metadata", turnMeta)
+	return body, turnMeta
 }
 
 func closeHTTPResponseBody(resp *http.Response, logPrefix string) {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -1072,11 +1072,7 @@ func websocketHandshakeBody(resp *http.Response) []byte {
 }
 
 func normalizeCodexWebsocketInstructions(body []byte) []byte {
-	instructions := gjson.GetBytes(body, "instructions")
-	if !instructions.Exists() || instructions.Type == gjson.Null || strings.TrimSpace(instructions.String()) == "" {
-		body, _ = sjson.SetBytes(body, "instructions", "You are a helpful assistant.")
-	}
-	return body
+	return normalizeCodexInstructions(body)
 }
 
 func enrichCodexWebsocketSessionMetadata(body []byte, sessionID string) ([]byte, string, string) {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -185,15 +185,9 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
-	body, _ = sjson.SetBytes(body, "model", baseModel)
-	body, _ = sjson.SetBytes(body, "stream", true)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
-	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
-	body, _ = sjson.DeleteBytes(body, "safety_identifier")
-	body = normalizeCodexWebsocketInstructions(body)
-	executionSessionID := executionSessionIDFromOptions(opts)
-	var turnMeta string
-	body, turnMeta = enrichCodexWebsocketSessionMetadata(body, executionSessionID)
+	originalExecutionSessionID := executionSessionIDFromOptions(opts)
+	var effectiveSessionID, turnMeta string
+	body, effectiveSessionID, turnMeta = prepareCodexWebsocketRequestBody(body, baseModel, originalExecutionSessionID, true)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
@@ -202,9 +196,9 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 
 	body, wsHeaders := applyCodexPromptCacheHeaders(from, req, body)
-	if strings.TrimSpace(executionSessionID) != "" {
-		wsHeaders.Set("Session_id", executionSessionID)
-		wsHeaders.Set("x-client-request-id", executionSessionID)
+	if strings.TrimSpace(effectiveSessionID) != "" {
+		wsHeaders.Set("Session_id", effectiveSessionID)
+		wsHeaders.Set("x-client-request-id", effectiveSessionID)
 	}
 	if strings.TrimSpace(turnMeta) != "" {
 		wsHeaders.Set("x-codex-turn-metadata", turnMeta)
@@ -219,8 +213,8 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 
 	var sess *codexWebsocketSession
-	if executionSessionID != "" {
-		sess = e.getOrCreateSession(executionSessionID)
+	if originalExecutionSessionID != "" {
+		sess = e.getOrCreateSession(originalExecutionSessionID)
 		sess.reqMu.Lock()
 		defer sess.reqMu.Unlock()
 	}
@@ -256,13 +250,13 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 	recordAPIWebsocketHandshake(ctx, e.cfg, respHS)
 	if sess == nil {
-		logCodexWebsocketConnected(executionSessionID, authID, wsURL)
+		logCodexWebsocketConnected(effectiveSessionID, authID, wsURL)
 		defer func() {
 			reason := "completed"
 			if err != nil {
 				reason = "error"
 			}
-			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, reason, err)
+			logCodexWebsocketDisconnected(effectiveSessionID, authID, wsURL, reason, err)
 			if errClose := conn.Close(); errClose != nil {
 				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 			}
@@ -395,15 +389,9 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, body, requestedModel)
-	body, _ = sjson.SetBytes(body, "model", baseModel)
-	body, _ = sjson.SetBytes(body, "stream", true)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
-	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
-	body, _ = sjson.DeleteBytes(body, "safety_identifier")
-	body = normalizeCodexWebsocketInstructions(body)
-	executionSessionID := executionSessionIDFromOptions(opts)
-	var turnMeta string
-	body, turnMeta = enrichCodexWebsocketSessionMetadata(body, executionSessionID)
+	originalExecutionSessionID := executionSessionIDFromOptions(opts)
+	var effectiveSessionID, turnMeta string
+	body, effectiveSessionID, turnMeta = prepareCodexWebsocketRequestBody(body, baseModel, originalExecutionSessionID, true)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
@@ -412,9 +400,9 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 
 	body, wsHeaders := applyCodexPromptCacheHeaders(from, req, body)
-	if strings.TrimSpace(executionSessionID) != "" {
-		wsHeaders.Set("Session_id", executionSessionID)
-		wsHeaders.Set("x-client-request-id", executionSessionID)
+	if strings.TrimSpace(effectiveSessionID) != "" {
+		wsHeaders.Set("Session_id", effectiveSessionID)
+		wsHeaders.Set("x-client-request-id", effectiveSessionID)
 	}
 	if strings.TrimSpace(turnMeta) != "" {
 		wsHeaders.Set("x-codex-turn-metadata", turnMeta)
@@ -427,8 +415,8 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	authType, authValue = auth.AccountInfo()
 
 	var sess *codexWebsocketSession
-	if executionSessionID != "" {
-		sess = e.getOrCreateSession(executionSessionID)
+	if originalExecutionSessionID != "" {
+		sess = e.getOrCreateSession(originalExecutionSessionID)
 		if sess != nil {
 			sess.reqMu.Lock()
 		}
@@ -473,7 +461,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	recordAPIWebsocketHandshake(ctx, e.cfg, respHS)
 
 	if sess == nil {
-		logCodexWebsocketConnected(executionSessionID, authID, wsURL)
+		logCodexWebsocketConnected(effectiveSessionID, authID, wsURL)
 	}
 
 	var readCh chan codexWebsocketRead
@@ -519,7 +507,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			conn = connRetry
 			wsReqBody = wsReqBodyRetry
 		} else {
-			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "send_error", errSend)
+			logCodexWebsocketDisconnected(effectiveSessionID, authID, wsURL, "send_error", errSend)
 			if errClose := conn.Close(); errClose != nil {
 				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 			}
@@ -539,7 +527,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				sess.reqMu.Unlock()
 				return
 			}
-			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, terminateReason, terminateErr)
+			logCodexWebsocketDisconnected(effectiveSessionID, authID, wsURL, terminateReason, terminateErr)
 			if errClose := conn.Close(); errClose != nil {
 				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 			}
@@ -1091,20 +1079,31 @@ func normalizeCodexWebsocketInstructions(body []byte) []byte {
 	return body
 }
 
-func enrichCodexWebsocketSessionMetadata(body []byte, sessionID string) ([]byte, string) {
-	if strings.TrimSpace(sessionID) == "" {
-		sessionID = uuid.NewString()
+func enrichCodexWebsocketSessionMetadata(body []byte, sessionID string) ([]byte, string, string) {
+	effectiveSessionID := strings.TrimSpace(sessionID)
+	if effectiveSessionID == "" {
+		effectiveSessionID = uuid.NewString()
 	}
 	if promptCacheKey := gjson.GetBytes(body, "prompt_cache_key"); !promptCacheKey.Exists() || strings.TrimSpace(promptCacheKey.String()) == "" {
-		body, _ = sjson.SetBytes(body, "prompt_cache_key", sessionID)
+		body, _ = sjson.SetBytes(body, "prompt_cache_key", effectiveSessionID)
 	}
 	clientMetadata := gjson.GetBytes(body, "client_metadata")
 	if !clientMetadata.Exists() || clientMetadata.Type == gjson.Null {
 		body, _ = sjson.SetRawBytes(body, "client_metadata", []byte(`{}`))
 	}
-	turnMeta := fmt.Sprintf(`{"session_id":"%s","turn_id":"","workspaces":{},"sandbox":"seccomp"}`, sessionID)
+	turnMeta := fmt.Sprintf(`{"session_id":"%s","turn_id":"","workspaces":{},"sandbox":"seccomp"}`, effectiveSessionID)
 	body, _ = sjson.SetBytes(body, "client_metadata.x-codex-turn-metadata", turnMeta)
-	return body, turnMeta
+	return body, effectiveSessionID, turnMeta
+}
+
+func prepareCodexWebsocketRequestBody(body []byte, baseModel string, sessionID string, stream bool) ([]byte, string, string) {
+	body, _ = sjson.SetBytes(body, "model", baseModel)
+	body, _ = sjson.SetBytes(body, "stream", stream)
+	body, _ = sjson.DeleteBytes(body, "previous_response_id")
+	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
+	body, _ = sjson.DeleteBytes(body, "safety_identifier")
+	body = normalizeCodexWebsocketInstructions(body)
+	return enrichCodexWebsocketSessionMetadata(body, sessionID)
 }
 
 func closeHTTPResponseBody(resp *http.Response, logPrefix string) {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -1099,7 +1099,6 @@ func enrichCodexWebsocketSessionMetadata(body []byte, sessionID string) ([]byte,
 func prepareCodexWebsocketRequestBody(body []byte, baseModel string, sessionID string, stream bool) ([]byte, string, string) {
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body, _ = sjson.SetBytes(body, "stream", stream)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body = normalizeCodexWebsocketInstructions(body)

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -32,6 +32,58 @@ func TestBuildCodexWebsocketRequestBodyPreservesPreviousResponseID(t *testing.T)
 	}
 }
 
+func TestPrepareCodexWebsocketRequestBodyNormalizesMissingInstructionsToEmptyString(t *testing.T) {
+	body, effectiveSessionID, turnMeta := prepareCodexWebsocketRequestBody([]byte(`{"input":[]}`), "gpt-5-codex", "session-123", true)
+
+	if got := gjson.GetBytes(body, "instructions").String(); got != "" {
+		t.Fatalf("instructions = %q, want empty string", got)
+	}
+	if got := gjson.GetBytes(body, "model").String(); got != "gpt-5-codex" {
+		t.Fatalf("model = %q, want gpt-5-codex", got)
+	}
+	if !gjson.GetBytes(body, "stream").Bool() {
+		t.Fatal("stream = false, want true")
+	}
+	if effectiveSessionID != "session-123" {
+		t.Fatalf("effectiveSessionID = %q, want session-123", effectiveSessionID)
+	}
+	if got := gjson.Get(turnMeta, "session_id").String(); got != "session-123" {
+		t.Fatalf("turnMeta.session_id = %q, want session-123", got)
+	}
+	if got := gjson.GetBytes(body, "prompt_cache_key").String(); got != "session-123" {
+		t.Fatalf("prompt_cache_key = %q, want session-123", got)
+	}
+	if got := gjson.GetBytes(body, "client_metadata.x-codex-turn-metadata").String(); got != turnMeta {
+		t.Fatalf("embedded turn metadata mismatch: got %q want %q", got, turnMeta)
+	}
+}
+
+func TestPrepareCodexWebsocketRequestBodyPreservesBlankInstructionsAndGeneratedSessionMetadata(t *testing.T) {
+	body, effectiveSessionID, turnMeta := prepareCodexWebsocketRequestBody([]byte(`{"instructions":"   ","prompt_cache_retention":"ephemeral","safety_identifier":"sid"}`), "gpt-5-codex", "", true)
+
+	if got := gjson.GetBytes(body, "instructions").String(); got != "   " {
+		t.Fatalf("instructions = %q, want blank string preserved", got)
+	}
+	if effectiveSessionID == "" {
+		t.Fatal("effectiveSessionID is empty")
+	}
+	if got := gjson.Get(turnMeta, "session_id").String(); got != effectiveSessionID {
+		t.Fatalf("turnMeta.session_id = %q, want %q", got, effectiveSessionID)
+	}
+	if got := gjson.GetBytes(body, "prompt_cache_key").String(); got != effectiveSessionID {
+		t.Fatalf("prompt_cache_key = %q, want %q", got, effectiveSessionID)
+	}
+	if got := gjson.GetBytes(body, "client_metadata.x-codex-turn-metadata").String(); got != turnMeta {
+		t.Fatalf("embedded turn metadata mismatch: got %q want %q", got, turnMeta)
+	}
+	if gjson.GetBytes(body, "prompt_cache_retention").Exists() {
+		t.Fatalf("prompt_cache_retention should be removed: %s", body)
+	}
+	if gjson.GetBytes(body, "safety_identifier").Exists() {
+		t.Fatalf("safety_identifier should be removed: %s", body)
+	}
+}
+
 func TestApplyCodexWebsocketHeadersDefaultsToCurrentResponsesBeta(t *testing.T) {
 	headers := applyCodexWebsocketHeaders(context.Background(), http.Header{}, nil, "", nil)
 

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -159,8 +159,24 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 	}
 	coreauth.ApplyCustomHeadersFromMetadata(a)
 	ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, "oauth")
-	// For codex auth files, extract plan_type from the JWT id_token.
+	// For codex auth files, extract plan_type from the JWT id_token and default websocket support on.
 	if provider == "codex" {
+		if raw, ok := metadata["websockets"]; ok && raw != nil {
+			switch v := raw.(type) {
+			case bool:
+				if v {
+					a.Attributes["websockets"] = "true"
+				} else {
+					a.Attributes["websockets"] = "false"
+				}
+			case string:
+				if trimmed := strings.TrimSpace(v); trimmed != "" {
+					a.Attributes["websockets"] = trimmed
+				}
+			}
+		} else {
+			a.Attributes["websockets"] = "true"
+		}
 		if idTokenRaw, ok := metadata["id_token"].(string); ok && strings.TrimSpace(idTokenRaw) != "" {
 			if claims, errParse := codex.ParseJWTToken(idTokenRaw); errParse == nil && claims != nil {
 				if pt := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType); pt != "" {

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/geminicli"
+	sdkauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -161,21 +162,8 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 	ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, "oauth")
 	// For codex auth files, extract plan_type from the JWT id_token and default websocket support on.
 	if provider == "codex" {
-		if raw, ok := metadata["websockets"]; ok && raw != nil {
-			switch v := raw.(type) {
-			case bool:
-				if v {
-					a.Attributes["websockets"] = "true"
-				} else {
-					a.Attributes["websockets"] = "false"
-				}
-			case string:
-				if trimmed := strings.TrimSpace(v); trimmed != "" {
-					a.Attributes["websockets"] = trimmed
-				}
-			}
-		} else {
-			a.Attributes["websockets"] = "true"
+		if websockets, ok := sdkauth.CodexWebsocketsAttributeValue(metadata); ok {
+			a.Attributes["websockets"] = websockets
 		}
 		if idTokenRaw, ok := metadata["id_token"].(string); ok && strings.TrimSpace(idTokenRaw) != "" {
 			if claims, errParse := codex.ParseJWTToken(idTokenRaw); errParse == nil && claims != nil {

--- a/internal/watcher/synthesizer/file_test.go
+++ b/internal/watcher/synthesizer/file_test.go
@@ -131,6 +131,65 @@ func TestFileSynthesizer_Synthesize_ValidAuthFile(t *testing.T) {
 	}
 }
 
+func TestFileSynthesizer_Synthesize_CodexAuthDefaultsWebsocketsTrue(t *testing.T) {
+	tempDir := t.TempDir()
+
+	authData := map[string]any{
+		"type":  "codex",
+		"email": "codex@example.com",
+	}
+	data, _ := json.Marshal(authData)
+	if err := os.WriteFile(filepath.Join(tempDir, "codex-auth.json"), data, 0644); err != nil {
+		t.Fatalf("failed to write auth file: %v", err)
+	}
+
+	auths, err := NewFileSynthesizer().Synthesize(&SynthesisContext{
+		Config:      &config.Config{},
+		AuthDir:     tempDir,
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth, got %d", len(auths))
+	}
+	if got := auths[0].Attributes["websockets"]; got != "true" {
+		t.Fatalf("websockets = %q, want true", got)
+	}
+}
+
+func TestFileSynthesizer_Synthesize_CodexAuthHonorsExplicitWebsocketsOverride(t *testing.T) {
+	tempDir := t.TempDir()
+
+	authData := map[string]any{
+		"type":       "codex",
+		"email":      "codex@example.com",
+		"websockets": false,
+	}
+	data, _ := json.Marshal(authData)
+	if err := os.WriteFile(filepath.Join(tempDir, "codex-auth.json"), data, 0644); err != nil {
+		t.Fatalf("failed to write auth file: %v", err)
+	}
+
+	auths, err := NewFileSynthesizer().Synthesize(&SynthesisContext{
+		Config:      &config.Config{},
+		AuthDir:     tempDir,
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth, got %d", len(auths))
+	}
+	if got := auths[0].Attributes["websockets"]; got != "false" {
+		t.Fatalf("websockets = %q, want false", got)
+	}
+}
+
 func TestFileSynthesizer_Synthesize_GeminiProviderMapping(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/sdk/auth/codex.go
+++ b/sdk/auth/codex.go
@@ -27,6 +27,28 @@ func NewCodexAuthenticator() *CodexAuthenticator {
 	return &CodexAuthenticator{CallbackPort: 1455}
 }
 
+func CodexWebsocketsAttributeValue(metadata map[string]any) (string, bool) {
+	if metadata == nil {
+		return "true", true
+	}
+	raw, ok := metadata["websockets"]
+	if !ok || raw == nil {
+		return "true", true
+	}
+	switch v := raw.(type) {
+	case bool:
+		if v {
+			return "true", true
+		}
+		return "false", true
+	case string:
+		if trimmed := strings.TrimSpace(v); trimmed != "" {
+			return trimmed, true
+		}
+	}
+	return "", false
+}
+
 func (a *CodexAuthenticator) Provider() string {
 	return "codex"
 }

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -251,6 +251,24 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		LastRefreshedAt:  time.Time{},
 		NextRefreshAfter: time.Time{},
 	}
+	if provider == "codex" {
+		if raw, ok := metadata["websockets"]; ok && raw != nil {
+			switch v := raw.(type) {
+			case bool:
+				if v {
+					auth.Attributes["websockets"] = "true"
+				} else {
+					auth.Attributes["websockets"] = "false"
+				}
+			case string:
+				if trimmed := strings.TrimSpace(v); trimmed != "" {
+					auth.Attributes["websockets"] = trimmed
+				}
+			}
+		} else {
+			auth.Attributes["websockets"] = "true"
+		}
+	}
 	if email, ok := metadata["email"].(string); ok && email != "" {
 		auth.Attributes["email"] = email
 	}

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -252,21 +252,8 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		NextRefreshAfter: time.Time{},
 	}
 	if provider == "codex" {
-		if raw, ok := metadata["websockets"]; ok && raw != nil {
-			switch v := raw.(type) {
-			case bool:
-				if v {
-					auth.Attributes["websockets"] = "true"
-				} else {
-					auth.Attributes["websockets"] = "false"
-				}
-			case string:
-				if trimmed := strings.TrimSpace(v); trimmed != "" {
-					auth.Attributes["websockets"] = trimmed
-				}
-			}
-		} else {
-			auth.Attributes["websockets"] = "true"
+		if websockets, ok := CodexWebsocketsAttributeValue(metadata); ok {
+			auth.Attributes["websockets"] = websockets
 		}
 	}
 	if email, ok := metadata["email"].(string); ok && email != "" {


### PR DESCRIPTION
## Summary

Improve Codex OAuth websocket parity so `service_tier=priority` behaves closer to official Codex `/fast` behavior.

This patch focuses on Codex OAuth websocket routing and request-shape parity, and is related to the same Codex websocket transport area touched by #2230 / #2256, but addresses a different problem:

- #2230 / #2256 focused on websocket session pinning and auth switching after quota failures.
- This patch focuses on **Codex OAuth websocket eligibility + request/header/session parity for fast/priority behavior**.

## What this changes

### 1) Default file-backed Codex OAuth auths to websocket-capable

Files:
- `internal/watcher/synthesizer/file.go`
- `sdk/auth/filestore.go`

Behavior:
- Preserve explicit `websockets` metadata when present.
- Otherwise synthesize `Attributes["websockets"] = "true"` for provider `codex`.

Why:
- File-backed Codex OAuth auths were otherwise routed through HTTP fallback instead of the Codex websocket path.

### 2) Normalize Codex websocket request bodies in both execute paths

File:
- `internal/runtime/executor/codex_websockets_executor.go`

Behavior:
- For both `Execute` and `ExecuteStream`:
  - ensure `model`
  - ensure `stream=true` in streaming path
  - drop unsupported carryover fields
  - ensure non-empty `instructions`

Why:
- Codex websocket upstream is stricter than generic OpenAI Responses handling and rejects some under-normalized payloads.

### 3) Add session-aligned websocket metadata/header parity

Files:
- `internal/runtime/executor/codex_websockets_executor.go`
- `internal/runtime/executor/codex_executor.go`

Behavior:
- Populate `prompt_cache_key` from the execution/session id when absent.
- Populate `client_metadata.x-codex-turn-metadata`.
- Mirror the same execution/session identity into websocket headers:
  - `Session_id`
  - `x-client-request-id`
  - `x-codex-turn-metadata`
- Stop forcing `Conversation_id` on Codex websocket requests.
- Use an originator closer to the official app-server/debug path.

Why:
- Official Codex websocket requests carry request/session metadata that was missing or mismatched in the proxy path.
- This metadata appears to matter for Codex OAuth websocket behavior, especially when using `service_tier=priority`.

## Investigation summary

During investigation, the following concrete issues were confirmed:

1. Official Codex `/fast` sends `service_tier: "priority"` over websocket.
2. Official default behavior omits the tier field rather than sending `"default"`.
3. File-backed Codex OAuth auths in CLIProxyAPI were not websocket-enabled by default.
4. Proxy websocket requests were missing Codex-like session metadata and header parity.
5. Sending literal `service_tier: "default"` can be rejected upstream on the Codex websocket path.

## Validation

### Official Codex baseline
Using traced official Codex websocket requests:
- default/no tier -> request omits `service_tier`
- fast -> request sends `service_tier: "priority"`

### Proxy behavior after this patch
The proxy websocket path:
- routes Codex OAuth auths over websocket instead of HTTP fallback
- sends `service_tier: "priority"` upstream
- includes prompt cache + turn metadata + request/session headers
- avoids invalid default-tier semantics by using omitted tier as baseline

### Latency benchmark
Short websocket prompt:
`Reply with exactly: OK and nothing else.`

Patched proxy, comparing **omitted tier** vs **priority**:

**omit(null)**
- total median: **1.94s**
- first-token median: **1.28s**

**priority**
- total median: **1.81s**
- first-token median: **1.12s**

This is not a dramatic improvement, but it is measurable and consistently in the expected direction after the websocket parity fixes.

## Notes / scope

- Upstream still returns `response.completed.service_tier = default`, so that field alone does not appear reliable for verifying Codex fast behavior on this route.
- This PR does **not** claim perfect 1:1 parity with official Codex internals.
- It does provide validated transport/session/request-shape fixes that move Codex OAuth websocket behavior materially closer to official `/fast` behavior.

## Related

- Related to #2230
- Related transport area: #2256
