### PR TITLE
fix(management): 修复因 `os.PathSeparator` 导致的文件名校验错误 (Invalid name)

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -370,7 +370,7 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	}
 	name := strings.TrimSpace(auth.FileName)
 	if name == "" {
-		name = auth.ID
+		name = filepath.Base(auth.ID)
 	}
 	entry := gin.H{
 		"id":             auth.ID,


### PR DESCRIPTION
修复删除/下载/上传配置文件时因为路径分隔符检查导致的“invalid name”错误