### PR TITLE
feat: support socks5h scheme for proxy settings

### DIFF
--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -734,7 +734,7 @@ func newProxyAwareWebsocketDialer(cfg *config.Config, auth *cliproxyauth.Auth) *
 	}
 
 	switch setting.URL.Scheme {
-	case "socks5":
+	case "socks5", "socks5h":
 		var proxyAuth *proxy.Auth
 		if setting.URL.User != nil {
 			username := setting.URL.User.Username()

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -58,7 +58,7 @@ func Parse(raw string) (Setting, error) {
 	}
 
 	switch parsedURL.Scheme {
-	case "socks5", "http", "https":
+	case "socks5", "socks5h", "http", "https":
 		setting.Mode = ModeProxy
 		setting.URL = parsedURL
 		return setting, nil
@@ -95,7 +95,7 @@ func BuildHTTPTransport(raw string) (*http.Transport, Mode, error) {
 	case ModeDirect:
 		return NewDirectTransport(), setting.Mode, nil
 	case ModeProxy:
-		if setting.URL.Scheme == "socks5" {
+		if setting.URL.Scheme == "socks5" || setting.URL.Scheme == "socks5h" {
 			var proxyAuth *proxy.Auth
 			if setting.URL.User != nil {
 				username := setting.URL.User.Username()

--- a/sdk/proxyutil/proxy_test.go
+++ b/sdk/proxyutil/proxy_test.go
@@ -30,6 +30,7 @@ func TestParse(t *testing.T) {
 		{name: "http", input: "http://proxy.example.com:8080", want: ModeProxy},
 		{name: "https", input: "https://proxy.example.com:8443", want: ModeProxy},
 		{name: "socks5", input: "socks5://proxy.example.com:1080", want: ModeProxy},
+		{name: "socks5h", input: "socks5h://proxy.example.com:1080", want: ModeProxy},
 		{name: "invalid", input: "bad-value", want: ModeInvalid, wantErr: true},
 	}
 
@@ -135,5 +136,26 @@ func TestBuildHTTPTransportSOCKS5ProxyInheritsDefaultTransportSettings(t *testin
 	}
 	if transport.TLSHandshakeTimeout != defaultTransport.TLSHandshakeTimeout {
 		t.Fatalf("TLSHandshakeTimeout = %v, want %v", transport.TLSHandshakeTimeout, defaultTransport.TLSHandshakeTimeout)
+	}
+}
+
+func TestBuildHTTPTransportSOCKS5HProxy(t *testing.T) {
+	t.Parallel()
+
+	transport, mode, errBuild := BuildHTTPTransport("socks5h://proxy.example.com:1080")
+	if errBuild != nil {
+		t.Fatalf("BuildHTTPTransport returned error: %v", errBuild)
+	}
+	if mode != ModeProxy {
+		t.Fatalf("mode = %d, want %d", mode, ModeProxy)
+	}
+	if transport == nil {
+		t.Fatal("expected transport, got nil")
+	}
+	if transport.Proxy != nil {
+		t.Fatal("expected SOCKS5H transport to bypass http proxy function")
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected SOCKS5H transport to have custom DialContext")
 	}
 }


### PR DESCRIPTION
## Summary

- Add `socks5h` proxy protocol support alongside existing `http`, `https`, and `socks5` protocols
- `socks5h` delegates DNS resolution to the SOCKS5 proxy server instead of resolving locally, which is useful for accessing internal networks or bypassing DNS-based restrictions

## Changes

- `sdk/proxyutil/proxy.go`: Accept `socks5h` scheme in `Parse()` and route it through the SOCKS5 dialer in `BuildHTTPTransport()` (`BuildDialer()` already works via `proxy.FromURL` which natively supports `socks5h`)
- `internal/runtime/executor/codex_websockets_executor.go`: Handle `socks5h` in WebSocket proxy dialer
- `sdk/proxyutil/proxy_test.go`: Add `socks5h` parse and transport test cases
