### PR TITLE
fix(codex): non-streaming /v1/chat/completions returns content:null

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -168,61 +169,71 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 
 	lines := bytes.Split(data, []byte("\n"))
 
-	// Collect output items from response.output_item.done events, because
-	// the response.completed event may carry an empty "output" array when the
-	// upstream uses streaming mode internally.
-	var doneOutputItems []gjson.Result
+	// Single-pass: collect output items from response.output_item.done events
+	// (keyed by output_index to preserve order) and locate the
+	// response.completed event. The completed event may carry an empty
+	// "output" array when the upstream uses streaming mode internally.
+	type indexedItem struct {
+		index int64
+		raw   string
+	}
+	var doneOutputItems []indexedItem
+	var completedLine []byte
 	for _, line := range lines {
 		if !bytes.HasPrefix(line, dataTag) {
 			continue
 		}
 		payload := bytes.TrimSpace(line[5:])
-		if gjson.GetBytes(payload, "type").String() == "response.output_item.done" {
+		eventType := gjson.GetBytes(payload, "type").String()
+		switch eventType {
+		case "response.output_item.done":
 			if item := gjson.GetBytes(payload, "item"); item.Exists() {
-				doneOutputItems = append(doneOutputItems, item)
+				idx := gjson.GetBytes(payload, "output_index").Int()
+				doneOutputItems = append(doneOutputItems, indexedItem{index: idx, raw: item.Raw})
 			}
+		case "response.completed":
+			completedLine = payload
 		}
 	}
 
-	for _, line := range lines {
-		if !bytes.HasPrefix(line, dataTag) {
-			continue
-		}
+	if completedLine == nil {
+		err = statusErr{code: 408, msg: "stream error: stream disconnected before completion: stream closed before response.completed"}
+		return resp, err
+	}
 
-		line = bytes.TrimSpace(line[5:])
-		if gjson.GetBytes(line, "type").String() != "response.completed" {
-			continue
-		}
+	if detail, ok := helps.ParseCodexUsage(completedLine); ok {
+		reporter.Publish(ctx, detail)
+	}
 
-		if detail, ok := helps.ParseCodexUsage(line); ok {
-			reporter.Publish(ctx, detail)
-		}
-
-		// If the response.completed event has an empty output array but we
-		// collected output items from earlier events, inject them so the
-		// downstream translator can extract content/tool_calls properly.
-		if len(doneOutputItems) > 0 {
-			existingOutput := gjson.GetBytes(line, "response.output")
-			if !existingOutput.IsArray() || len(existingOutput.Array()) == 0 {
-				var outputRaw []byte
-				outputRaw = append(outputRaw, '[')
-				for i, item := range doneOutputItems {
-					if i > 0 {
-						outputRaw = append(outputRaw, ',')
-					}
-					outputRaw = append(outputRaw, []byte(item.Raw)...)
+	// If the response.completed event has an empty output array but we
+	// collected output items from earlier events, inject them so the
+	// downstream translator can extract content/tool_calls properly.
+	// Items are sorted by output_index to handle parallel_tool_calls
+	// where done events may arrive out of order.
+	if len(doneOutputItems) > 0 {
+		existingOutput := gjson.GetBytes(completedLine, "response.output")
+		if !existingOutput.IsArray() || len(existingOutput.Array()) == 0 {
+			sort.Slice(doneOutputItems, func(i, j int) bool {
+				return doneOutputItems[i].index < doneOutputItems[j].index
+			})
+			var outputRaw []byte
+			outputRaw = append(outputRaw, '[')
+			for i, item := range doneOutputItems {
+				if i > 0 {
+					outputRaw = append(outputRaw, ',')
 				}
-				outputRaw = append(outputRaw, ']')
-				line, _ = sjson.SetRawBytes(line, "response.output", outputRaw)
+				outputRaw = append(outputRaw, []byte(item.raw)...)
+			}
+			outputRaw = append(outputRaw, ']')
+			if updated, setErr := sjson.SetRawBytes(completedLine, "response.output", outputRaw); setErr == nil {
+				completedLine = updated
 			}
 		}
-
-		var param any
-		out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, line, &param)
-		resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
-		return resp, nil
 	}
-	err = statusErr{code: 408, msg: "stream error: stream disconnected before completion: stream closed before response.completed"}
+
+	var param any
+	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, completedLine, &param)
+	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 	return resp, err
 }
 

--- a/internal/runtime/executor/codex_executor_nonstream_content_test.go
+++ b/internal/runtime/executor/codex_executor_nonstream_content_test.go
@@ -165,3 +165,56 @@ func TestCodexExecutorNonStreamExtractsToolCallsFromDoneEvents(t *testing.T) {
 		t.Fatalf("expected function name %q, got %q", "get_weather", funcName)
 	}
 }
+
+// TestCodexExecutorNonStreamSortsByOutputIndex verifies that when
+// response.output_item.done events arrive out of order (e.g. parallel tool
+// calls), the injected output array is sorted by output_index.
+func TestCodexExecutorNonStreamSortsByOutputIndex(t *testing.T) {
+	// Emit output_index=1 before output_index=0 to simulate out-of-order arrival
+	ssePayload := "" +
+		"event: response.output_item.done\n" +
+		`data: {"type":"response.output_item.done","output_index":1,"item":{"id":"fc_second","type":"function_call","status":"completed","call_id":"call_2","name":"get_time","arguments":"{}"}}` + "\n\n" +
+		"event: response.output_item.done\n" +
+		`data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_first","type":"function_call","status":"completed","call_id":"call_1","name":"get_weather","arguments":"{\"city\":\"NYC\"}"}}` + "\n\n" +
+		"event: response.completed\n" +
+		`data: {"type":"response.completed","response":{"id":"resp_test","object":"response","created_at":1700000000,"status":"completed","model":"gpt-5.4","output":[],"usage":{"input_tokens":10,"output_tokens":20,"total_tokens":30}}}` + "\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(ssePayload))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":[{"role":"user","content":"test"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	output := gjson.GetBytes(resp.Payload, "response.output")
+	if !output.IsArray() || len(output.Array()) != 2 {
+		t.Fatalf("expected 2 output items, got: %s", string(resp.Payload))
+	}
+
+	// output_index=0 (get_weather) should come first despite arriving second
+	firstName := gjson.GetBytes(resp.Payload, "response.output.0.name").String()
+	if firstName != "get_weather" {
+		t.Fatalf("expected first output name %q (index 0), got %q", "get_weather", firstName)
+	}
+
+	secondName := gjson.GetBytes(resp.Payload, "response.output.1.name").String()
+	if secondName != "get_time" {
+		t.Fatalf("expected second output name %q (index 1), got %q", "get_time", secondName)
+	}
+}


### PR DESCRIPTION
## Summary

Fix non-streaming `/v1/chat/completions` requests returning `content: null` when proxied through Codex OAuth. Streaming mode was unaffected.

Fixes #2582, #2583

## Root Cause

When a non-streaming request arrives, the executor forces `stream=true` upstream (since Codex OAuth requires it), reads the full SSE stream, and extracts only the `response.completed` event to pass to the translator.

However, Codex's `response.completed` event carries an **empty `output` array** — the actual message content and tool calls are delivered via earlier `response.output_item.done` events, which were being discarded.

This was a regression introduced when the non-stream path was changed from direct non-streaming requests to forced-streaming with `response.completed` extraction.

## Changes

- `internal/runtime/executor/codex_executor.go`: Add a two-pass processing of SSE lines in the `Execute` method:
  1. **First pass**: collect all `response.output_item.done` items
  2. **Second pass**: when processing `response.completed`, if its `response.output` array is empty, inject the collected items before passing to the translator

## Before / After

| Scenario | Before | After |
|---|---|---|
| Non-stream `content` | `null` (despite `completion_tokens > 0`) | Correct text content |
| Non-stream `tool_calls` | Missing | Correctly populated |
| Stream mode | Working | Unchanged |
| `response.completed` with populated output | N/A | Preserved (not overwritten) |

## Tests

New regression tests added in `codex_executor_nonstream_content_test.go`:

- `TestCodexExecutorNonStreamExtractsContentFromDoneEvents` — core bug: empty output in `response.completed`, content extracted from `output_item.done`
- `TestCodexExecutorNonStreamPreservesPopulatedOutput` — when `response.completed` already has output, it is not overwritten
- `TestCodexExecutorNonStreamExtractsToolCallsFromDoneEvents` — function_call items correctly injected

All existing tests pass (187 passed; 1 pre-existing failure in `TestEnsureQwenSystemMessage_MergeStringSystem` unrelated to this change).

## End-to-End Verification

Tested against real Codex OAuth (gpt-5.4) on a deployed instance:

```bash
# Before fix
curl -s http://127.0.0.1:8317/v1/chat/completions -d '{"model":"gpt-5.4","messages":[{"role":"user","content":"say hello"}],"stream":false}'
# → "content": null

# After fix  
curl -s http://127.0.0.1:8317/v1/chat/completions -d '{"model":"gpt-5.4","messages":[{"role":"user","content":"say hello"}],"stream":false}'
# → "content": "Hello!"
```