### PR TITLE
feat(usage): 增加统计本地持久化独立开关

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -66,6 +66,11 @@ error-logs-max-files: 10
 # When false, disable in-memory usage statistics aggregation
 usage-statistics-enabled: false
 
+# When true, save usage statistics to a local JSON file and restore them on startup.
+# The snapshot file is stored next to config.yaml as usage-statistics.json.
+# When false, existing local usage snapshots are ignored and no new snapshot is written.
+usage-statistics-persistence-enabled: true
+
 # Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
 # Per-entry proxy-url also supports "direct" or "none" to bypass both the global proxy-url and environment proxies explicitly.
 proxy-url: ""

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -193,7 +193,15 @@ func (h *Handler) PutUsageStatisticsEnabled(c *gin.Context) {
 	h.updateBoolField(c, func(v bool) { h.cfg.UsageStatisticsEnabled = v })
 }
 
-// UsageStatisticsEnabled
+// UsageStatisticsPersistenceEnabled
+func (h *Handler) GetUsageStatisticsPersistenceEnabled(c *gin.Context) {
+	c.JSON(200, gin.H{"usage-statistics-persistence-enabled": h.cfg.UsageStatisticsPersistenceEnabled})
+}
+func (h *Handler) PutUsageStatisticsPersistenceEnabled(c *gin.Context) {
+	h.updateBoolField(c, func(v bool) { h.cfg.UsageStatisticsPersistenceEnabled = v })
+}
+
+// LoggingToFile
 func (h *Handler) GetLoggingToFile(c *gin.Context) {
 	c.JSON(200, gin.H{"logging-to-file": h.cfg.LoggingToFile})
 }

--- a/internal/api/handlers/management/config_usage_statistics_persistence_test.go
+++ b/internal/api/handlers/management/config_usage_statistics_persistence_test.go
@@ -1,0 +1,73 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestGetUsageStatisticsPersistenceEnabled(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/usage-statistics-persistence-enabled", nil)
+
+	h := &Handler{cfg: &config.Config{UsageStatisticsPersistenceEnabled: true}}
+	h.GetUsageStatisticsPersistenceEnabled(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var body map[string]bool
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	if !body["usage-statistics-persistence-enabled"] {
+		t.Fatal("usage-statistics-persistence-enabled = false, want true")
+	}
+}
+
+func TestPutUsageStatisticsPersistenceEnabled(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("usage-statistics-persistence-enabled: true\n"), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	body := bytes.NewBufferString(`{"value":false}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/usage-statistics-persistence-enabled", body)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h := NewHandler(&config.Config{UsageStatisticsPersistenceEnabled: true}, configPath, nil)
+	h.PutUsageStatisticsPersistenceEnabled(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if h.cfg.UsageStatisticsPersistenceEnabled {
+		t.Fatal("UsageStatisticsPersistenceEnabled = true, want false")
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile returned error: %v", err)
+	}
+	if !bytes.Contains(data, []byte("usage-statistics-persistence-enabled: false")) {
+		t.Fatalf("config file missing updated persistence setting: %s", string(data))
+	}
+}

--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -69,6 +69,14 @@ func (h *Handler) ImportUsageStatistics(c *gin.Context) {
 	}
 
 	result := h.usageStats.MergeSnapshot(payload.Usage)
+	if err := h.usageStats.FlushPersistence(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "failed to persist usage statistics",
+			"added":   result.Added,
+			"skipped": result.Skipped,
+		})
+		return
+	}
 	snapshot := h.usageStats.Snapshot()
 	c.JSON(http.StatusOK, gin.H{
 		"added":           result.Added,

--- a/internal/api/handlers/management/usage_persistence_test.go
+++ b/internal/api/handlers/management/usage_persistence_test.go
@@ -1,0 +1,71 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func TestImportUsageStatisticsPersistsSnapshotImmediately(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+
+	path := filepath.Join(t.TempDir(), "usage-statistics.json")
+	stats := usage.NewRequestStatistics()
+	if err := stats.EnablePersistence(path); err != nil {
+		t.Fatalf("EnablePersistence returned error: %v", err)
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"version": 1,
+		"usage": usage.StatisticsSnapshot{
+			APIs: map[string]usage.APISnapshot{
+				"test-key": {
+					Models: map[string]usage.ModelSnapshot{
+						"gpt-5.4": {
+							Details: []usage.RequestDetail{{
+								Timestamp: time.Date(2026, 4, 8, 8, 0, 0, 0, time.UTC),
+								Tokens: usage.TokenStats{
+									InputTokens:  10,
+									OutputTokens: 20,
+									TotalTokens:  30,
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/usage/import", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h := &Handler{usageStats: stats}
+	h.ImportUsageStatistics(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	snapshot, err := usage.LoadSnapshotFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadSnapshotFromFile returned error: %v", err)
+	}
+	if snapshot.TotalRequests != 1 {
+		t.Fatalf("total_requests = %d, want 1", snapshot.TotalRequests)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -63,6 +63,14 @@ func defaultRequestLoggerFactory(cfg *config.Config, configPath string) logging.
 	return logging.NewFileRequestLogger(cfg.RequestLog, logsDir, configDir, cfg.ErrorLogsMaxFiles)
 }
 
+func usageStatisticsPersistencePath(configFilePath string) string {
+	configDir := strings.TrimSpace(filepath.Dir(configFilePath))
+	if configDir == "" {
+		configDir = "."
+	}
+	return filepath.Join(configDir, "usage-statistics.json")
+}
+
 // WithMiddleware appends additional Gin middleware during server construction.
 func WithMiddleware(mw ...gin.HandlerFunc) ServerOption {
 	return func(cfg *serverOptionConfig) {
@@ -261,6 +269,7 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	}
 	managementasset.SetCurrentConfig(cfg)
 	auth.SetQuotaCooldownDisabled(cfg.DisableCooling)
+	s.syncUsageStatisticsPersistence(cfg)
 	// Initialize management handler
 	s.mgmt = managementHandlers.NewHandler(cfg, configFilePath, authManager)
 	if optionState.localPassword != "" {
@@ -517,6 +526,9 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/usage-statistics-enabled", s.mgmt.GetUsageStatisticsEnabled)
 		mgmt.PUT("/usage-statistics-enabled", s.mgmt.PutUsageStatisticsEnabled)
 		mgmt.PATCH("/usage-statistics-enabled", s.mgmt.PutUsageStatisticsEnabled)
+		mgmt.GET("/usage-statistics-persistence-enabled", s.mgmt.GetUsageStatisticsPersistenceEnabled)
+		mgmt.PUT("/usage-statistics-persistence-enabled", s.mgmt.PutUsageStatisticsPersistenceEnabled)
+		mgmt.PATCH("/usage-statistics-persistence-enabled", s.mgmt.PutUsageStatisticsPersistenceEnabled)
 
 		mgmt.GET("/proxy-url", s.mgmt.GetProxyURL)
 		mgmt.PUT("/proxy-url", s.mgmt.PutProxyURL)
@@ -826,6 +838,7 @@ func (s *Server) Start() error {
 //   - error: An error if the server fails to stop
 func (s *Server) Stop(ctx context.Context) error {
 	log.Debug("Stopping API server...")
+	var stopErrs []error
 
 	if s.keepAliveEnabled {
 		select {
@@ -834,9 +847,17 @@ func (s *Server) Stop(ctx context.Context) error {
 		}
 	}
 
+	if err := s.flushUsageStatisticsPersistence(); err != nil {
+		stopErrs = append(stopErrs, fmt.Errorf("failed to persist usage statistics: %w", err))
+	}
+
 	// Shutdown the HTTP server.
 	if err := s.server.Shutdown(ctx); err != nil {
-		return fmt.Errorf("failed to shutdown HTTP server: %v", err)
+		stopErrs = append(stopErrs, fmt.Errorf("failed to shutdown HTTP server: %v", err))
+	}
+
+	if len(stopErrs) > 0 {
+		return errors.Join(stopErrs...)
 	}
 
 	log.Debug("API server stopped")
@@ -906,6 +927,11 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 
 	if oldCfg == nil || oldCfg.UsageStatisticsEnabled != cfg.UsageStatisticsEnabled {
 		usage.SetStatisticsEnabled(cfg.UsageStatisticsEnabled)
+	}
+	if oldCfg == nil ||
+		oldCfg.UsageStatisticsEnabled != cfg.UsageStatisticsEnabled ||
+		oldCfg.UsageStatisticsPersistenceEnabled != cfg.UsageStatisticsPersistenceEnabled {
+		s.syncUsageStatisticsPersistence(cfg)
 	}
 
 	if s.requestLogger != nil && (oldCfg == nil || oldCfg.ErrorLogsMaxFiles != cfg.ErrorLogsMaxFiles) {
@@ -1022,6 +1048,29 @@ func (s *Server) SetWebsocketAuthChangeHandler(fn func(bool, bool)) {
 		return
 	}
 	s.wsAuthChanged = fn
+}
+
+func (s *Server) syncUsageStatisticsPersistence(cfg *config.Config) {
+	if s == nil {
+		return
+	}
+
+	if cfg == nil || !cfg.UsageStatisticsEnabled || !cfg.UsageStatisticsPersistenceEnabled {
+		usage.GetRequestStatistics().DisablePersistence()
+		return
+	}
+
+	persistencePath := usageStatisticsPersistencePath(s.configFilePath)
+	if err := usage.GetRequestStatistics().EnablePersistence(persistencePath); err != nil {
+		log.WithError(err).Warnf("failed to enable usage statistics persistence at %s", persistencePath)
+	}
+}
+
+func (s *Server) flushUsageStatisticsPersistence() error {
+	if s == nil {
+		return nil
+	}
+	return usage.GetRequestStatistics().FlushPersistence()
 }
 
 // (management handlers moved to internal/api/handlers/management)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +16,7 @@ import (
 	gin "github.com/gin-gonic/gin"
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
@@ -24,6 +28,16 @@ func newTestServer(t *testing.T) *Server {
 	gin.SetMode(gin.TestMode)
 
 	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	return newTestServerWithConfigPath(t, configPath)
+}
+
+func newTestServerWithConfigPath(t *testing.T, configPath string) *Server {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := filepath.Dir(configPath)
 	authDir := filepath.Join(tmpDir, "auth")
 	if err := os.MkdirAll(authDir, 0o700); err != nil {
 		t.Fatalf("failed to create auth dir: %v", err)
@@ -33,17 +47,17 @@ func newTestServer(t *testing.T) *Server {
 		SDKConfig: sdkconfig.SDKConfig{
 			APIKeys: []string{"test-key"},
 		},
-		Port:                   0,
-		AuthDir:                authDir,
-		Debug:                  true,
-		LoggingToFile:          false,
-		UsageStatisticsEnabled: false,
+		Port:                              0,
+		AuthDir:                           authDir,
+		Debug:                             true,
+		LoggingToFile:                     false,
+		UsageStatisticsEnabled:            true,
+		UsageStatisticsPersistenceEnabled: true,
 	}
 
 	authManager := auth.NewManager(nil, nil, nil)
 	accessManager := sdkaccess.NewManager()
 
-	configPath := filepath.Join(tmpDir, "config.yaml")
 	return NewServer(cfg, authManager, accessManager, configPath)
 }
 
@@ -231,5 +245,148 @@ func TestDefaultRequestLoggerFactory_UsesResolvedLogDirectory(t *testing.T) {
 		if strings.HasPrefix(entry.Name(), "error-") && strings.HasSuffix(entry.Name(), ".log") {
 			t.Fatalf("unexpected forced error log in config dir %s", configLogsDir)
 		}
+	}
+}
+
+func TestNewServerRestoresPersistedUsageStatistics(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	usagePath := filepath.Join(tmpDir, "usage-statistics.json")
+	if err := usage.SaveSnapshotToFile(usagePath, usage.StatisticsSnapshot{
+		APIs: map[string]usage.APISnapshot{
+			"persisted-key": {
+				Models: map[string]usage.ModelSnapshot{
+					"gpt-5.4": {
+						Details: []usage.RequestDetail{{
+							Timestamp: time.Date(2026, 4, 8, 10, 0, 0, 0, time.UTC),
+							Tokens: usage.TokenStats{
+								InputTokens:  10,
+								OutputTokens: 20,
+								TotalTokens:  30,
+							},
+						}},
+					},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("SaveSnapshotToFile returned error: %v", err)
+	}
+
+	_ = newTestServerWithConfigPath(t, configPath)
+
+	snapshot := usage.GetRequestStatistics().Snapshot()
+	modelSnapshot, ok := snapshot.APIs["persisted-key"].Models["gpt-5.4"]
+	if !ok || len(modelSnapshot.Details) == 0 {
+		t.Fatalf("expected persisted usage statistics to be restored, snapshot=%+v", snapshot.APIs["persisted-key"])
+	}
+}
+
+func TestServerStopFlushesUsageStatisticsPersistence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	server := newTestServerWithConfigPath(t, configPath)
+	usage.GetRequestStatistics().MergeSnapshot(usage.StatisticsSnapshot{
+		APIs: map[string]usage.APISnapshot{
+			"stop-flush-key": {
+				Models: map[string]usage.ModelSnapshot{
+					"gpt-5.4": {
+						Details: []usage.RequestDetail{{
+							Timestamp: time.Date(2026, 4, 8, 11, 0, 0, 0, time.UTC),
+							Tokens: usage.TokenStats{
+								InputTokens:  11,
+								OutputTokens: 19,
+								TotalTokens:  30,
+							},
+						}},
+					},
+				},
+			},
+		},
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen returned error: %v", err)
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.server.Serve(listener)
+	}()
+
+	if err := server.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+
+	serveErr := <-errCh
+	if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+		t.Fatalf("Serve returned error: %v", serveErr)
+	}
+
+	usagePath := filepath.Join(filepath.Dir(configPath), "usage-statistics.json")
+	snapshot, err := usage.LoadSnapshotFromFile(usagePath)
+	if err != nil {
+		t.Fatalf("LoadSnapshotFromFile returned error: %v", err)
+	}
+	modelSnapshot, ok := snapshot.APIs["stop-flush-key"].Models["gpt-5.4"]
+	if !ok || len(modelSnapshot.Details) == 0 {
+		t.Fatalf("expected stop to flush usage statistics, snapshot=%+v", snapshot.APIs["stop-flush-key"])
+	}
+}
+
+func TestNewServerSkipsUsageStatisticsRestoreWhenPersistenceDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	usagePath := filepath.Join(tmpDir, "usage-statistics.json")
+	if err := usage.SaveSnapshotToFile(usagePath, usage.StatisticsSnapshot{
+		APIs: map[string]usage.APISnapshot{
+			"disabled-restore-key": {
+				Models: map[string]usage.ModelSnapshot{
+					"gpt-5.4": {
+						Details: []usage.RequestDetail{{
+							Timestamp: time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC),
+							Tokens: usage.TokenStats{
+								InputTokens:  10,
+								OutputTokens: 20,
+								TotalTokens:  30,
+							},
+						}},
+					},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("SaveSnapshotToFile returned error: %v", err)
+	}
+
+	authDir := filepath.Join(tmpDir, "auth")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("failed to create auth dir: %v", err)
+	}
+	cfg := &proxyconfig.Config{
+		SDKConfig: sdkconfig.SDKConfig{
+			APIKeys: []string{"test-key"},
+		},
+		Port:                              0,
+		AuthDir:                           authDir,
+		Debug:                             true,
+		LoggingToFile:                     false,
+		UsageStatisticsEnabled:            true,
+		UsageStatisticsPersistenceEnabled: false,
+	}
+
+	authManager := auth.NewManager(nil, nil, nil)
+	accessManager := sdkaccess.NewManager()
+	_ = NewServer(cfg, authManager, accessManager, configPath)
+
+	snapshot := usage.GetRequestStatistics().Snapshot()
+	if _, ok := snapshot.APIs["disabled-restore-key"]; ok {
+		t.Fatalf("expected persisted usage statistics restore to stay disabled, snapshot=%+v", snapshot.APIs["disabled-restore-key"])
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,10 @@ type Config struct {
 	// UsageStatisticsEnabled toggles in-memory usage aggregation; when false, usage data is discarded.
 	UsageStatisticsEnabled bool `yaml:"usage-statistics-enabled" json:"usage-statistics-enabled"`
 
+	// UsageStatisticsPersistenceEnabled controls whether usage statistics are restored from disk on startup
+	// and persisted back to disk during runtime. When false, local usage snapshot files are ignored.
+	UsageStatisticsPersistenceEnabled bool `yaml:"usage-statistics-persistence-enabled" json:"usage-statistics-persistence-enabled"`
+
 	// DisableCooling disables quota cooldown scheduling when true.
 	DisableCooling bool `yaml:"disable-cooling" json:"disable-cooling"`
 
@@ -576,6 +580,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.LogsMaxTotalSizeMB = 0
 	cfg.ErrorLogsMaxFiles = 10
 	cfg.UsageStatisticsEnabled = false
+	cfg.UsageStatisticsPersistenceEnabled = true
 	cfg.DisableCooling = false
 	cfg.Pprof.Enable = false
 	cfg.Pprof.Addr = DefaultPprofAddr

--- a/internal/config/usage_statistics_persistence_test.go
+++ b/internal/config/usage_statistics_persistence_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfigOptional_UsageStatisticsPersistenceEnabledDefaultsToTrue(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("debug: false\n"), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+
+	if !cfg.UsageStatisticsPersistenceEnabled {
+		t.Fatal("UsageStatisticsPersistenceEnabled = false, want true")
+	}
+}
+
+func TestLoadConfigOptional_UsageStatisticsPersistenceEnabledHonorsFalse(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("usage-statistics-persistence-enabled: false\n"), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+
+	if cfg.UsageStatisticsPersistenceEnabled {
+		t.Fatal("UsageStatisticsPersistenceEnabled = true, want false")
+	}
+}

--- a/internal/tui/config_tab.go
+++ b/internal/tui/config_tab.go
@@ -340,6 +340,7 @@ func (m configTabModel) parseConfig(cfg map[string]any) []configField {
 	fields = append(fields, configField{"Logs Max Total Size (MB)", "logs-max-total-size-mb", "int", fmt.Sprintf("%.0f", getFloat(cfg, "logs-max-total-size-mb")), nil})
 	fields = append(fields, configField{"Error Logs Max Files", "error-logs-max-files", "int", fmt.Sprintf("%.0f", getFloat(cfg, "error-logs-max-files")), nil})
 	fields = append(fields, configField{"Usage Stats Enabled", "usage-statistics-enabled", "bool", fmt.Sprintf("%v", getBool(cfg, "usage-statistics-enabled")), nil})
+	fields = append(fields, configField{"Usage Stats Local Save", "usage-statistics-persistence-enabled", "bool", fmt.Sprintf("%v", getBool(cfg, "usage-statistics-persistence-enabled")), nil})
 	fields = append(fields, configField{"Request Log", "request-log", "bool", fmt.Sprintf("%v", getBool(cfg, "request-log")), nil})
 
 	// Quota exceeded
@@ -381,7 +382,7 @@ func fieldSection(apiPath string) string {
 	switch apiPath {
 	case "port", "host", "debug", "proxy-url", "request-retry", "max-retry-interval", "force-model-prefix":
 		return T("section_server")
-	case "logging-to-file", "logs-max-total-size-mb", "error-logs-max-files", "usage-statistics-enabled", "request-log":
+	case "logging-to-file", "logs-max-total-size-mb", "error-logs-max-files", "usage-statistics-enabled", "usage-statistics-persistence-enabled", "request-log":
 		return T("section_logging")
 	case "ws-auth":
 		return T("section_websocket")

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -215,9 +215,15 @@ func (m dashboardModel) renderDashboard(cfg, usage map[string]any, authFiles []m
 		proxyURL := getString(cfg, "proxy-url")
 		loggingToFile := getBool(cfg, "logging-to-file")
 		usageEnabled := true
+		usagePersistenceEnabled := true
 		if v, ok := cfg["usage-statistics-enabled"]; ok {
 			if b, ok2 := v.(bool); ok2 {
 				usageEnabled = b
+			}
+		}
+		if v, ok := cfg["usage-statistics-persistence-enabled"]; ok {
+			if b, ok2 := v.(bool); ok2 {
+				usagePersistenceEnabled = b
 			}
 		}
 
@@ -227,6 +233,7 @@ func (m dashboardModel) renderDashboard(cfg, usage map[string]any, authFiles []m
 		}{
 			{T("debug_mode"), boolEmoji(debug)},
 			{T("usage_stats"), boolEmoji(usageEnabled)},
+			{"Usage Stats Local Save", boolEmoji(usagePersistenceEnabled)},
 			{T("log_to_file"), boolEmoji(loggingToFile)},
 			{T("retry_count"), fmt.Sprintf("%.0f", retry)},
 		}

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -64,6 +64,7 @@ type RequestStatistics struct {
 	successCount  int64
 	failureCount  int64
 	totalTokens   int64
+	persistence   *statisticsPersistence
 
 	apis map[string]*apiStats
 
@@ -182,7 +183,6 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	hourKey := timestamp.Hour()
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	s.totalRequests++
 	if success {
@@ -210,6 +210,10 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	s.requestsByHour[hourKey]++
 	s.tokensByDay[dayKey] += totalTokens
 	s.tokensByHour[hourKey] += totalTokens
+
+	persistence := s.persistence
+	s.mu.Unlock()
+	s.schedulePersistenceSave(persistence)
 }
 
 func (s *RequestStatistics) updateAPIStats(stats *apiStats, model string, detail RequestDetail) {
@@ -298,7 +302,6 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	seen := make(map[string]struct{})
 	for apiName, stats := range s.apis {
@@ -352,6 +355,11 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 		}
 	}
 
+	persistence := s.persistence
+	s.mu.Unlock()
+	if result.Added > 0 {
+		s.schedulePersistenceSave(persistence)
+	}
 	return result
 }
 

--- a/internal/usage/persistence.go
+++ b/internal/usage/persistence.go
@@ -1,0 +1,263 @@
+package usage
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const defaultPersistenceFlushInterval = 200 * time.Millisecond
+
+type statisticsPersistence struct {
+	path          string
+	flushInterval time.Duration
+	triggerCh     chan struct{}
+	flushCh       chan chan error
+	stopCh        chan struct{}
+	stopOnce      sync.Once
+}
+
+func newStatisticsPersistence(path string) *statisticsPersistence {
+	return &statisticsPersistence{
+		path:          path,
+		flushInterval: defaultPersistenceFlushInterval,
+		triggerCh:     make(chan struct{}, 1),
+		flushCh:       make(chan chan error),
+		stopCh:        make(chan struct{}),
+	}
+}
+
+// SaveSnapshotToFile writes a statistics snapshot to disk using an atomic replace.
+func SaveSnapshotToFile(path string, snapshot StatisticsSnapshot) error {
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" {
+		return fmt.Errorf("usage statistics persistence path is empty")
+	}
+
+	dir := filepath.Dir(trimmedPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create usage statistics directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal usage statistics snapshot: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmpFile, err := os.CreateTemp(dir, "usage-statistics-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary usage statistics file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("write temporary usage statistics file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("close temporary usage statistics file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, trimmedPath); err != nil {
+		if removeErr := os.Remove(trimmedPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return fmt.Errorf("replace usage statistics file: %w", err)
+		}
+		if retryErr := os.Rename(tmpPath, trimmedPath); retryErr != nil {
+			return fmt.Errorf("replace usage statistics file: %w", retryErr)
+		}
+	}
+
+	return nil
+}
+
+// LoadSnapshotFromFile loads a statistics snapshot from disk.
+func LoadSnapshotFromFile(path string) (StatisticsSnapshot, error) {
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" {
+		return StatisticsSnapshot{}, fmt.Errorf("usage statistics persistence path is empty")
+	}
+
+	data, err := os.ReadFile(trimmedPath)
+	if err != nil {
+		return StatisticsSnapshot{}, err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return StatisticsSnapshot{}, nil
+	}
+
+	var snapshot StatisticsSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return StatisticsSnapshot{}, fmt.Errorf("unmarshal usage statistics snapshot: %w", err)
+	}
+
+	return snapshot, nil
+}
+
+// EnablePersistence configures automatic statistics persistence and restores any existing snapshot.
+func (s *RequestStatistics) EnablePersistence(path string) error {
+	if s == nil {
+		return nil
+	}
+
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" {
+		return fmt.Errorf("usage statistics persistence path is empty")
+	}
+	if !filepath.IsAbs(trimmedPath) {
+		absPath, err := filepath.Abs(trimmedPath)
+		if err != nil {
+			return fmt.Errorf("resolve usage statistics persistence path: %w", err)
+		}
+		trimmedPath = absPath
+	}
+
+	persistence := newStatisticsPersistence(trimmedPath)
+	go persistence.run(s)
+
+	s.mu.Lock()
+	previousPersistence := s.persistence
+	s.persistence = persistence
+	s.mu.Unlock()
+
+	if previousPersistence != nil {
+		previousPersistence.stop()
+	}
+
+	snapshot, err := LoadSnapshotFromFile(trimmedPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	s.MergeSnapshot(snapshot)
+	return nil
+}
+
+// FlushPersistence writes the current statistics snapshot to disk immediately.
+func (s *RequestStatistics) FlushPersistence() error {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.RLock()
+	persistence := s.persistence
+	s.mu.RUnlock()
+	if persistence == nil {
+		return nil
+	}
+
+	return persistence.flushNow(s.Snapshot())
+}
+
+// DisablePersistence detaches local statistics persistence immediately.
+func (s *RequestStatistics) DisablePersistence() {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	persistence := s.persistence
+	s.persistence = nil
+	s.mu.Unlock()
+
+	if persistence != nil {
+		persistence.stop()
+	}
+}
+
+func (s *RequestStatistics) schedulePersistenceSave(persistence *statisticsPersistence) {
+	if s == nil || persistence == nil {
+		return
+	}
+	persistence.schedule()
+}
+
+func (p *statisticsPersistence) run(stats *RequestStatistics) {
+	var (
+		timer  *time.Timer
+		timerC <-chan time.Time
+	)
+
+	for {
+		select {
+		case <-p.triggerCh:
+			if timer == nil {
+				timer = time.NewTimer(p.flushInterval)
+				timerC = timer.C
+				continue
+			}
+			if !timer.Stop() {
+				select {
+				case <-timerC:
+				default:
+				}
+			}
+			timer.Reset(p.flushInterval)
+		case done := <-p.flushCh:
+			if timer != nil {
+				if !timer.Stop() {
+					select {
+					case <-timerC:
+					default:
+					}
+				}
+				timer = nil
+				timerC = nil
+			}
+			done <- SaveSnapshotToFile(p.path, stats.Snapshot())
+		case <-timerC:
+			if err := SaveSnapshotToFile(p.path, stats.Snapshot()); err != nil {
+				log.WithError(err).Warn("failed to persist usage statistics snapshot")
+			}
+			timer = nil
+			timerC = nil
+		case <-p.stopCh:
+			if timer != nil {
+				if !timer.Stop() {
+					select {
+					case <-timerC:
+					default:
+					}
+				}
+			}
+			return
+		}
+	}
+}
+
+func (p *statisticsPersistence) schedule() {
+	select {
+	case p.triggerCh <- struct{}{}:
+	default:
+	}
+}
+
+func (p *statisticsPersistence) flushNow(snapshot StatisticsSnapshot) error {
+	done := make(chan error, 1)
+	select {
+	case p.flushCh <- done:
+		return <-done
+	case <-p.stopCh:
+		return SaveSnapshotToFile(p.path, snapshot)
+	}
+}
+
+func (p *statisticsPersistence) stop() {
+	p.stopOnce.Do(func() {
+		close(p.stopCh)
+	})
+}

--- a/internal/usage/persistence_test.go
+++ b/internal/usage/persistence_test.go
@@ -1,0 +1,229 @@
+package usage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+)
+
+func TestSaveSnapshotToFileAndLoadSnapshotFromFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "usage-statistics.json")
+	want := StatisticsSnapshot{
+		TotalRequests: 1,
+		SuccessCount:  1,
+		FailureCount:  0,
+		TotalTokens:   30,
+		APIs: map[string]APISnapshot{
+			"test-key": {
+				TotalRequests: 1,
+				TotalTokens:   30,
+				Models: map[string]ModelSnapshot{
+					"gpt-5.4": {
+						TotalRequests: 1,
+						TotalTokens:   30,
+						Details: []RequestDetail{{
+							Timestamp: time.Date(2026, 4, 8, 8, 0, 0, 0, time.UTC),
+							LatencyMs: 1200,
+							Source:    "codex",
+							AuthIndex: "codex:0",
+							Tokens: TokenStats{
+								InputTokens:  10,
+								OutputTokens: 20,
+								TotalTokens:  30,
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	if err := SaveSnapshotToFile(path, want); err != nil {
+		t.Fatalf("SaveSnapshotToFile returned error: %v", err)
+	}
+
+	got, err := LoadSnapshotFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadSnapshotFromFile returned error: %v", err)
+	}
+
+	if got.TotalRequests != want.TotalRequests {
+		t.Fatalf("total_requests = %d, want %d", got.TotalRequests, want.TotalRequests)
+	}
+	if got.TotalTokens != want.TotalTokens {
+		t.Fatalf("total_tokens = %d, want %d", got.TotalTokens, want.TotalTokens)
+	}
+	if len(got.APIs["test-key"].Models["gpt-5.4"].Details) != 1 {
+		t.Fatalf("details len = %d, want 1", len(got.APIs["test-key"].Models["gpt-5.4"].Details))
+	}
+}
+
+func TestRequestStatisticsEnablePersistenceRestoresExistingSnapshot(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "usage-statistics.json")
+	want := StatisticsSnapshot{
+		TotalRequests: 1,
+		SuccessCount:  1,
+		TotalTokens:   30,
+		APIs: map[string]APISnapshot{
+			"test-key": {
+				Models: map[string]ModelSnapshot{
+					"gpt-5.4": {
+						Details: []RequestDetail{{
+							Timestamp: time.Date(2026, 4, 8, 8, 0, 0, 0, time.UTC),
+							Tokens: TokenStats{
+								InputTokens:  10,
+								OutputTokens: 20,
+								TotalTokens:  30,
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+	if err := SaveSnapshotToFile(path, want); err != nil {
+		t.Fatalf("SaveSnapshotToFile returned error: %v", err)
+	}
+
+	stats := NewRequestStatistics()
+	if err := stats.EnablePersistence(path); err != nil {
+		t.Fatalf("EnablePersistence returned error: %v", err)
+	}
+
+	got := stats.Snapshot()
+	if got.TotalRequests != want.TotalRequests {
+		t.Fatalf("total_requests = %d, want %d", got.TotalRequests, want.TotalRequests)
+	}
+	if got.TotalTokens != want.TotalTokens {
+		t.Fatalf("total_tokens = %d, want %d", got.TotalTokens, want.TotalTokens)
+	}
+}
+
+func TestRequestStatisticsFlushPersistenceWritesMergedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "usage-statistics.json")
+	stats := NewRequestStatistics()
+	if err := stats.EnablePersistence(path); err != nil {
+		t.Fatalf("EnablePersistence returned error: %v", err)
+	}
+
+	result := stats.MergeSnapshot(StatisticsSnapshot{
+		APIs: map[string]APISnapshot{
+			"test-key": {
+				Models: map[string]ModelSnapshot{
+					"gpt-5.4": {
+						Details: []RequestDetail{{
+							Timestamp: time.Date(2026, 4, 8, 8, 0, 0, 0, time.UTC),
+							Tokens: TokenStats{
+								InputTokens:  10,
+								OutputTokens: 20,
+								TotalTokens:  30,
+							},
+						}},
+					},
+				},
+			},
+		},
+	})
+	if result.Added != 1 {
+		t.Fatalf("added = %d, want 1", result.Added)
+	}
+
+	if err := stats.FlushPersistence(); err != nil {
+		t.Fatalf("FlushPersistence returned error: %v", err)
+	}
+
+	got, err := LoadSnapshotFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadSnapshotFromFile returned error: %v", err)
+	}
+	if got.TotalRequests != 1 {
+		t.Fatalf("total_requests = %d, want 1", got.TotalRequests)
+	}
+}
+
+func TestRequestStatisticsRecordPersistsSnapshotAsync(t *testing.T) {
+	t.Parallel()
+
+	previousEnabled := StatisticsEnabled()
+	SetStatisticsEnabled(true)
+	t.Cleanup(func() {
+		SetStatisticsEnabled(previousEnabled)
+	})
+
+	path := filepath.Join(t.TempDir(), "usage-statistics.json")
+	stats := NewRequestStatistics()
+	if err := stats.EnablePersistence(path); err != nil {
+		t.Fatalf("EnablePersistence returned error: %v", err)
+	}
+
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:      "persisted-key",
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 4, 8, 9, 0, 0, 0, time.UTC),
+		Detail: coreusage.Detail{
+			InputTokens:  12,
+			OutputTokens: 18,
+			TotalTokens:  30,
+		},
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		snapshot, err := LoadSnapshotFromFile(path)
+		if err == nil {
+			modelSnapshot := snapshot.APIs["persisted-key"].Models["gpt-5.4"]
+			if snapshot.TotalRequests >= 1 && len(modelSnapshot.Details) >= 1 {
+				return
+			}
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for persisted snapshot at %s", path)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestRequestStatisticsDisablePersistenceStopsWritingToDisk(t *testing.T) {
+	t.Parallel()
+
+	previousEnabled := StatisticsEnabled()
+	SetStatisticsEnabled(true)
+	t.Cleanup(func() {
+		SetStatisticsEnabled(previousEnabled)
+	})
+
+	path := filepath.Join(t.TempDir(), "usage-statistics.json")
+	stats := NewRequestStatistics()
+	if err := stats.EnablePersistence(path); err != nil {
+		t.Fatalf("EnablePersistence returned error: %v", err)
+	}
+	stats.DisablePersistence()
+
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:      "disabled-key",
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 4, 8, 9, 30, 0, 0, time.UTC),
+		Detail: coreusage.Detail{
+			InputTokens:  12,
+			OutputTokens: 18,
+			TotalTokens:  30,
+		},
+	})
+
+	time.Sleep(300 * time.Millisecond)
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected persistence to stay disabled, stat err = %v", err)
+	}
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -39,6 +39,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.UsageStatisticsEnabled != newCfg.UsageStatisticsEnabled {
 		changes = append(changes, fmt.Sprintf("usage-statistics-enabled: %t -> %t", oldCfg.UsageStatisticsEnabled, newCfg.UsageStatisticsEnabled))
 	}
+	if oldCfg.UsageStatisticsPersistenceEnabled != newCfg.UsageStatisticsPersistenceEnabled {
+		changes = append(changes, fmt.Sprintf("usage-statistics-persistence-enabled: %t -> %t", oldCfg.UsageStatisticsPersistenceEnabled, newCfg.UsageStatisticsPersistenceEnabled))
+	}
 	if oldCfg.DisableCooling != newCfg.DisableCooling {
 		changes = append(changes, fmt.Sprintf("disable-cooling: %t -> %t", oldCfg.DisableCooling, newCfg.DisableCooling))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -219,21 +219,22 @@ func TestBuildConfigChangeDetails_SecretsAndCounts(t *testing.T) {
 
 func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 	oldCfg := &config.Config{
-		Port:                   1000,
-		AuthDir:                "/old",
-		Debug:                  false,
-		LoggingToFile:          false,
-		UsageStatisticsEnabled: false,
-		DisableCooling:         false,
-		RequestRetry:           1,
-		MaxRetryCredentials:    1,
-		MaxRetryInterval:       1,
-		WebsocketAuth:          false,
-		QuotaExceeded:          config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
-		ClaudeKey:              []config.ClaudeKey{{APIKey: "c1"}},
-		CodexKey:               []config.CodexKey{{APIKey: "x1"}},
-		AmpCode:                config.AmpCode{UpstreamAPIKey: "keep", RestrictManagementToLocalhost: false},
-		RemoteManagement:       config.RemoteManagement{DisableControlPanel: false, PanelGitHubRepository: "old/repo", SecretKey: "keep"},
+		Port:                              1000,
+		AuthDir:                           "/old",
+		Debug:                             false,
+		LoggingToFile:                     false,
+		UsageStatisticsEnabled:            false,
+		UsageStatisticsPersistenceEnabled: true,
+		DisableCooling:                    false,
+		RequestRetry:                      1,
+		MaxRetryCredentials:               1,
+		MaxRetryInterval:                  1,
+		WebsocketAuth:                     false,
+		QuotaExceeded:                     config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
+		ClaudeKey:                         []config.ClaudeKey{{APIKey: "c1"}},
+		CodexKey:                          []config.CodexKey{{APIKey: "x1"}},
+		AmpCode:                           config.AmpCode{UpstreamAPIKey: "keep", RestrictManagementToLocalhost: false},
+		RemoteManagement:                  config.RemoteManagement{DisableControlPanel: false, PanelGitHubRepository: "old/repo", SecretKey: "keep"},
 		SDKConfig: sdkconfig.SDKConfig{
 			RequestLog:                 false,
 			ProxyURL:                   "http://old-proxy",
@@ -243,17 +244,18 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 		},
 	}
 	newCfg := &config.Config{
-		Port:                   2000,
-		AuthDir:                "/new",
-		Debug:                  true,
-		LoggingToFile:          true,
-		UsageStatisticsEnabled: true,
-		DisableCooling:         true,
-		RequestRetry:           2,
-		MaxRetryCredentials:    3,
-		MaxRetryInterval:       3,
-		WebsocketAuth:          true,
-		QuotaExceeded:          config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
+		Port:                              2000,
+		AuthDir:                           "/new",
+		Debug:                             true,
+		LoggingToFile:                     true,
+		UsageStatisticsEnabled:            true,
+		UsageStatisticsPersistenceEnabled: false,
+		DisableCooling:                    true,
+		RequestRetry:                      2,
+		MaxRetryCredentials:               3,
+		MaxRetryInterval:                  3,
+		WebsocketAuth:                     true,
+		QuotaExceeded:                     config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
 		ClaudeKey: []config.ClaudeKey{
 			{APIKey: "c1", BaseURL: "http://new", ProxyURL: "http://p", Headers: map[string]string{"H": "1"}, ExcludedModels: []string{"a"}},
 			{APIKey: "c2"},
@@ -286,6 +288,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 	expectContains(t, details, "debug: false -> true")
 	expectContains(t, details, "logging-to-file: false -> true")
 	expectContains(t, details, "usage-statistics-enabled: false -> true")
+	expectContains(t, details, "usage-statistics-persistence-enabled: true -> false")
 	expectContains(t, details, "disable-cooling: false -> true")
 	expectContains(t, details, "request-log: false -> true")
 	expectContains(t, details, "request-retry: 1 -> 2")
@@ -311,17 +314,18 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 
 func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 	oldCfg := &config.Config{
-		Port:                   1,
-		AuthDir:                "/a",
-		Debug:                  false,
-		LoggingToFile:          false,
-		UsageStatisticsEnabled: false,
-		DisableCooling:         false,
-		RequestRetry:           1,
-		MaxRetryCredentials:    1,
-		MaxRetryInterval:       1,
-		WebsocketAuth:          false,
-		QuotaExceeded:          config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
+		Port:                              1,
+		AuthDir:                           "/a",
+		Debug:                             false,
+		LoggingToFile:                     false,
+		UsageStatisticsEnabled:            false,
+		UsageStatisticsPersistenceEnabled: false,
+		DisableCooling:                    false,
+		RequestRetry:                      1,
+		MaxRetryCredentials:               1,
+		MaxRetryInterval:                  1,
+		WebsocketAuth:                     false,
+		QuotaExceeded:                     config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
 		GeminiKey: []config.GeminiKey{
 			{APIKey: "g-old", BaseURL: "http://g-old", ProxyURL: "http://gp-old", Headers: map[string]string{"A": "1"}},
 		},
@@ -365,17 +369,18 @@ func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 		},
 	}
 	newCfg := &config.Config{
-		Port:                   2,
-		AuthDir:                "/b",
-		Debug:                  true,
-		LoggingToFile:          true,
-		UsageStatisticsEnabled: true,
-		DisableCooling:         true,
-		RequestRetry:           2,
-		MaxRetryCredentials:    3,
-		MaxRetryInterval:       3,
-		WebsocketAuth:          true,
-		QuotaExceeded:          config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
+		Port:                              2,
+		AuthDir:                           "/b",
+		Debug:                             true,
+		LoggingToFile:                     true,
+		UsageStatisticsEnabled:            true,
+		UsageStatisticsPersistenceEnabled: true,
+		DisableCooling:                    true,
+		RequestRetry:                      2,
+		MaxRetryCredentials:               3,
+		MaxRetryInterval:                  3,
+		WebsocketAuth:                     true,
+		QuotaExceeded:                     config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
 		GeminiKey: []config.GeminiKey{
 			{APIKey: "g-new", BaseURL: "http://g-new", ProxyURL: "http://gp-new", Headers: map[string]string{"A": "2"}, ExcludedModels: []string{"x", "y"}},
 		},
@@ -430,6 +435,7 @@ func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 	expectContains(t, changes, "debug: false -> true")
 	expectContains(t, changes, "logging-to-file: false -> true")
 	expectContains(t, changes, "usage-statistics-enabled: false -> true")
+	expectContains(t, changes, "usage-statistics-persistence-enabled: false -> true")
 	expectContains(t, changes, "disable-cooling: false -> true")
 	expectContains(t, changes, "request-retry: 1 -> 2")
 	expectContains(t, changes, "max-retry-credentials: 1 -> 3")


### PR DESCRIPTION
- 为使用统计新增本地持久化能力，支持自动落盘、启动恢复与停止刷盘

- 新增 usage-statistics-persistence-enabled 配置与管理接口，默认开启且可单独关闭本地保存

- 补充配置说明、TUI 展示与回归测试，覆盖持久化开关、导入落盘和重启恢复链路