### PR TITLE
fix(management): support external base url for webui oauth callbacks

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,6 +22,9 @@ remote-management:
   # Leave empty to disable the Management API entirely (404 for all /v0/management routes).
   secret-key: ""
 
+  # External base URL for remote management clients when the server is accessed behind a proxy or public domain.
+  external-base-url: ""
+
   # Disable the bundled management control panel asset download and HTTP route when true.
   disable-control-panel: false
 

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -12,6 +12,7 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -58,10 +59,16 @@ type callbackForwarder struct {
 }
 
 var (
-	callbackForwardersMu  sync.Mutex
-	callbackForwarders    = make(map[int]*callbackForwarder)
-	errAuthFileMustBeJSON = errors.New("auth file must be .json")
-	errAuthFileNotFound   = errors.New("auth file not found")
+	callbackForwardersMu               sync.Mutex
+	callbackForwarders                 = make(map[int]*callbackForwarder)
+	errAuthFileMustBeJSON              = errors.New("auth file must be .json")
+	errAuthFileNotFound                = errors.New("auth file not found")
+	webUIExternalCallbackProviderPaths = map[string]string{
+		"codex":       "/codex/callback",
+		"claude":      "/anthropic/callback",
+		"gemini":      "/google/callback",
+		"antigravity": "/antigravity/callback",
+	}
 )
 
 func extractLastRefreshTimestamp(meta map[string]any) (time.Time, bool) {
@@ -235,6 +242,49 @@ func (h *Handler) managementCallbackURL(path string) (string, error) {
 		scheme = "https"
 	}
 	return fmt.Sprintf("%s://127.0.0.1:%d%s", scheme, h.cfg.Port, path), nil
+}
+
+func replaceURLQueryValue(rawURL, key, value string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return "", fmt.Errorf("parse url: %w", err)
+	}
+	query := parsed.Query()
+	query.Set(key, value)
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}
+
+func (h *Handler) webUIExternalCallbackURL(provider string) (string, bool, error) {
+	if h == nil || h.cfg == nil {
+		return "", false, nil
+	}
+
+	baseURL := strings.TrimSpace(h.cfg.RemoteManagement.ExternalBaseURL)
+	if baseURL == "" {
+		return "", false, nil
+	}
+
+	providerPath, ok := webUIExternalCallbackProviderPaths[provider]
+	if !ok {
+		return "", false, fmt.Errorf("unsupported external callback provider %q", provider)
+	}
+
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil {
+		return "", false, fmt.Errorf("parse external base url: %w", err)
+	}
+	if !parsedBaseURL.IsAbs() || strings.TrimSpace(parsedBaseURL.Host) == "" {
+		return "", false, fmt.Errorf("external base url must be an absolute url with host")
+	}
+
+	basePath := strings.TrimRight(parsedBaseURL.Path, "/")
+	parsedBaseURL.Path = basePath + providerPath
+	parsedBaseURL.RawPath = ""
+	parsedBaseURL.RawQuery = ""
+	parsedBaseURL.Fragment = ""
+
+	return parsedBaseURL.String(), true, nil
 }
 
 func (h *Handler) ListAuthFiles(c *gin.Context) {
@@ -1412,9 +1462,22 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 
 	// Initialize Claude auth service
 	anthropicAuth := claude.NewClaudeAuth(h.cfg)
+	redirectURI := claude.RedirectURI
+	isWebUI := isWebUIRequest(c)
+	useLocalForwarder := isWebUI
+	if isWebUI {
+		if externalCallbackURL, ok, errExternal := h.webUIExternalCallbackURL("claude"); errExternal != nil {
+			log.WithError(errExternal).Error("failed to compute claude external callback url")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "callback server unavailable"})
+			return
+		} else if ok {
+			redirectURI = externalCallbackURL
+			useLocalForwarder = false
+		}
+	}
 
-	// Generate authorization URL (then override redirect_uri to reuse server port)
-	authURL, state, err := anthropicAuth.GenerateAuthURL(state, pkceCodes)
+	// Generate authorization URL
+	authURL, state, err := anthropicAuth.GenerateAuthURLWithRedirect(state, pkceCodes, redirectURI)
 	if err != nil {
 		log.Errorf("Failed to generate authorization URL: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate authorization url"})
@@ -1423,9 +1486,8 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 
 	RegisterOAuthSession(state, "anthropic")
 
-	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
-	if isWebUI {
+	if useLocalForwarder {
 		targetURL, errTarget := h.managementCallbackURL("/anthropic/callback")
 		if errTarget != nil {
 			log.WithError(errTarget).Error("failed to compute anthropic callback target")
@@ -1441,7 +1503,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	}
 
 	go func() {
-		if isWebUI {
+		if useLocalForwarder {
 			defer stopCallbackForwarderInstance(anthropicCallbackPort, forwarder)
 		}
 
@@ -1497,7 +1559,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 		code := strings.Split(rawCode, "#")[0]
 
 		// Exchange code for tokens using internal auth service
-		bundle, errExchange := anthropicAuth.ExchangeCodeForTokens(ctx, code, state, pkceCodes)
+		bundle, errExchange := anthropicAuth.ExchangeCodeForTokensWithRedirect(ctx, code, state, redirectURI, pkceCodes)
 		if errExchange != nil {
 			authErr := claude.NewAuthenticationError(claude.ErrCodeExchangeFailed, errExchange)
 			log.Errorf("Failed to exchange authorization code for tokens: %v", authErr)
@@ -1543,12 +1605,25 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 	projectID := c.Query("project_id")
 
 	fmt.Println("Initializing Google authentication...")
+	redirectURI := fmt.Sprintf("http://localhost:%d/oauth2callback", geminiAuth.DefaultCallbackPort)
+	isWebUI := isWebUIRequest(c)
+	useLocalForwarder := isWebUI
+	if isWebUI {
+		if externalCallbackURL, ok, errExternal := h.webUIExternalCallbackURL("gemini"); errExternal != nil {
+			log.WithError(errExternal).Error("failed to compute gemini external callback url")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "callback server unavailable"})
+			return
+		} else if ok {
+			redirectURI = externalCallbackURL
+			useLocalForwarder = false
+		}
+	}
 
 	// OAuth2 configuration using exported constants from internal/auth/gemini
 	conf := &oauth2.Config{
 		ClientID:     geminiAuth.ClientID,
 		ClientSecret: geminiAuth.ClientSecret,
-		RedirectURL:  fmt.Sprintf("http://localhost:%d/oauth2callback", geminiAuth.DefaultCallbackPort),
+		RedirectURL:  redirectURI,
 		Scopes:       geminiAuth.Scopes,
 		Endpoint:     google.Endpoint,
 	}
@@ -1559,9 +1634,8 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 
 	RegisterOAuthSession(state, "gemini")
 
-	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
-	if isWebUI {
+	if useLocalForwarder {
 		targetURL, errTarget := h.managementCallbackURL("/google/callback")
 		if errTarget != nil {
 			log.WithError(errTarget).Error("failed to compute gemini callback target")
@@ -1577,7 +1651,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 	}
 
 	go func() {
-		if isWebUI {
+		if useLocalForwarder {
 			defer stopCallbackForwarderInstance(geminiCallbackPort, forwarder)
 		}
 
@@ -1829,23 +1903,41 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 
 	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
+	redirectURI := codex.RedirectURI
+	useLocalForwarder := isWebUI
 	if isWebUI {
-		targetURL, errTarget := h.managementCallbackURL("/codex/callback")
-		if errTarget != nil {
-			log.WithError(errTarget).Error("failed to compute codex callback target")
+		if externalCallbackURL, ok, errExternal := h.webUIExternalCallbackURL("codex"); errExternal != nil {
+			log.WithError(errExternal).Error("failed to compute codex external callback url")
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "callback server unavailable"})
 			return
-		}
-		var errStart error
-		if forwarder, errStart = startCallbackForwarder(codexCallbackPort, "codex", targetURL); errStart != nil {
-			log.WithError(errStart).Error("failed to start codex callback forwarder")
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to start callback server"})
-			return
+		} else if ok {
+			redirectURI = externalCallbackURL
+			useLocalForwarder = false
+			updatedURL, errReplace := replaceURLQueryValue(authURL, "redirect_uri", redirectURI)
+			if errReplace != nil {
+				log.WithError(errReplace).Error("failed to rewrite codex redirect uri")
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate authorization url"})
+				return
+			}
+			authURL = updatedURL
+		} else {
+			targetURL, errTarget := h.managementCallbackURL("/codex/callback")
+			if errTarget != nil {
+				log.WithError(errTarget).Error("failed to compute codex callback target")
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "callback server unavailable"})
+				return
+			}
+			var errStart error
+			if forwarder, errStart = startCallbackForwarder(codexCallbackPort, "codex", targetURL); errStart != nil {
+				log.WithError(errStart).Error("failed to start codex callback forwarder")
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to start callback server"})
+				return
+			}
 		}
 	}
 
 	go func() {
-		if isWebUI {
+		if useLocalForwarder {
 			defer stopCallbackForwarderInstance(codexCallbackPort, forwarder)
 		}
 
@@ -1887,7 +1979,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 
 		log.Debug("Authorization code received, exchanging for tokens...")
 		// Exchange code for tokens using internal auth service
-		bundle, errExchange := openaiAuth.ExchangeCodeForTokens(ctx, code, pkceCodes)
+		bundle, errExchange := openaiAuth.ExchangeCodeForTokensWithRedirect(ctx, code, redirectURI, pkceCodes)
 		if errExchange != nil {
 			authErr := codex.NewAuthenticationError(codex.ErrCodeExchangeFailed, errExchange)
 			SetOAuthSessionError(state, "Failed to exchange authorization code for tokens")
@@ -1954,13 +2046,24 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 	}
 
 	redirectURI := fmt.Sprintf("http://localhost:%d/oauth-callback", antigravity.CallbackPort)
+	isWebUI := isWebUIRequest(c)
+	useLocalForwarder := isWebUI
+	if isWebUI {
+		if externalCallbackURL, ok, errExternal := h.webUIExternalCallbackURL("antigravity"); errExternal != nil {
+			log.WithError(errExternal).Error("failed to compute antigravity external callback url")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "callback server unavailable"})
+			return
+		} else if ok {
+			redirectURI = externalCallbackURL
+			useLocalForwarder = false
+		}
+	}
 	authURL := authSvc.BuildAuthURL(state, redirectURI)
 
 	RegisterOAuthSession(state, "antigravity")
 
-	isWebUI := isWebUIRequest(c)
 	var forwarder *callbackForwarder
-	if isWebUI {
+	if useLocalForwarder {
 		targetURL, errTarget := h.managementCallbackURL("/antigravity/callback")
 		if errTarget != nil {
 			log.WithError(errTarget).Error("failed to compute antigravity callback target")
@@ -1976,7 +2079,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 	}
 
 	go func() {
-		if isWebUI {
+		if useLocalForwarder {
 			defer stopCallbackForwarderInstance(antigravity.CallbackPort, forwarder)
 		}
 

--- a/internal/api/handlers/management/auth_files_codex_oauth_test.go
+++ b/internal/api/handlers/management/auth_files_codex_oauth_test.go
@@ -1,0 +1,141 @@
+package management
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestRequestCodexToken_WebUIExternalCallbackSkipsLocalForwarder(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{
+		AuthDir: t.TempDir(),
+		Port:    49794,
+		RemoteManagement: config.RemoteManagement{
+			ExternalBaseURL: "https://cpa.example.com",
+		},
+	}, nil)
+	h.tokenStore = &memoryAuthStore{}
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/v0/management/codex-auth-url?is_webui=true", nil)
+	req.Host = "cpa.example.com"
+	ctx.Request = req
+
+	h.RequestCodexToken(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Status string `json:"status"`
+		URL    string `json:"url"`
+		State  string `json:"state"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status != "ok" {
+		t.Fatalf("status = %q, want %q", resp.Status, "ok")
+	}
+	if resp.State == "" {
+		t.Fatalf("expected non-empty oauth state")
+	}
+
+	parsed, err := url.Parse(resp.URL)
+	if err != nil {
+		t.Fatalf("failed to parse auth url: %v", err)
+	}
+	if got := parsed.Query().Get("redirect_uri"); got != "https://cpa.example.com/codex/callback" {
+		t.Fatalf("redirect_uri = %q, want %q", got, "https://cpa.example.com/codex/callback")
+	}
+
+	callbackForwardersMu.Lock()
+	_, exists := callbackForwarders[codexCallbackPort]
+	callbackForwardersMu.Unlock()
+	if exists {
+		t.Fatalf("expected no local codex callback forwarder for external webui requests")
+	}
+
+	CompleteOAuthSession(resp.State)
+	time.Sleep(600 * time.Millisecond)
+}
+
+func TestRequestCodexToken_WebUILocalhostKeepsLocalForwarder(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	if callbackForwarderPortUnavailable(codexCallbackPort) {
+		t.Skipf("skipping localhost forwarder test because 127.0.0.1:%d is unavailable in this environment", codexCallbackPort)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir(), Port: 49794}, nil)
+	h.tokenStore = &memoryAuthStore{}
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/v0/management/codex-auth-url?is_webui=true", nil)
+	req.Host = "127.0.0.1:49794"
+	ctx.Request = req
+
+	h.RequestCodexToken(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Status string `json:"status"`
+		URL    string `json:"url"`
+		State  string `json:"state"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	parsed, err := url.Parse(resp.URL)
+	if err != nil {
+		t.Fatalf("failed to parse auth url: %v", err)
+	}
+	if got := parsed.Query().Get("redirect_uri"); got != "http://localhost:1455/auth/callback" {
+		t.Fatalf("redirect_uri = %q, want %q", got, "http://localhost:1455/auth/callback")
+	}
+
+	callbackForwardersMu.Lock()
+	_, exists := callbackForwarders[codexCallbackPort]
+	callbackForwardersMu.Unlock()
+	if !exists {
+		t.Fatalf("expected local codex callback forwarder for localhost webui requests")
+	}
+
+	CompleteOAuthSession(resp.State)
+	time.Sleep(600 * time.Millisecond)
+
+	callbackForwardersMu.Lock()
+	_, exists = callbackForwarders[codexCallbackPort]
+	callbackForwardersMu.Unlock()
+	if exists {
+		t.Fatalf("expected local codex callback forwarder to stop after session completion")
+	}
+}
+
+func callbackForwarderPortUnavailable(port int) bool {
+	ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		return true
+	}
+	_ = ln.Close()
+	return false
+}

--- a/internal/api/handlers/management/auth_files_external_base_url_oauth_test.go
+++ b/internal/api/handlers/management/auth_files_external_base_url_oauth_test.go
@@ -1,0 +1,179 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/antigravity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestWebUIExternalCallbackURL_UsesConfiguredBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		wantURL  string
+	}{
+		{
+			name:     "codex",
+			provider: "codex",
+			wantURL:  "https://example.com/base/codex/callback",
+		},
+		{
+			name:     "claude",
+			provider: "claude",
+			wantURL:  "https://example.com/base/anthropic/callback",
+		},
+		{
+			name:     "gemini",
+			provider: "gemini",
+			wantURL:  "https://example.com/base/google/callback",
+		},
+		{
+			name:     "antigravity",
+			provider: "antigravity",
+			wantURL:  "https://example.com/base/antigravity/callback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewHandlerWithoutConfigFilePath(&config.Config{
+				RemoteManagement: config.RemoteManagement{ExternalBaseURL: " https://example.com/base/?foo=bar#fragment "},
+			}, nil)
+
+			gotURL, ok, err := h.webUIExternalCallbackURL(tt.provider)
+			if err != nil {
+				t.Fatalf("webUIExternalCallbackURL(%q) error = %v", tt.provider, err)
+			}
+			if !ok {
+				t.Fatalf("webUIExternalCallbackURL(%q) ok = false, want true", tt.provider)
+			}
+			if gotURL != tt.wantURL {
+				t.Fatalf("webUIExternalCallbackURL(%q) = %q, want %q", tt.provider, gotURL, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestWebUIExternalCallbackURL_InvalidBaseURL(t *testing.T) {
+	h := NewHandlerWithoutConfigFilePath(&config.Config{
+		RemoteManagement: config.RemoteManagement{ExternalBaseURL: "not-a-valid-url"},
+	}, nil)
+
+	gotURL, ok, err := h.webUIExternalCallbackURL("codex")
+	if err == nil {
+		t.Fatalf("webUIExternalCallbackURL returned nil error, want error")
+	}
+	if ok {
+		t.Fatalf("webUIExternalCallbackURL ok = true, want false")
+	}
+	if gotURL != "" {
+		t.Fatalf("webUIExternalCallbackURL url = %q, want empty", gotURL)
+	}
+}
+
+func TestRequestOAuthToken_ExternalBaseURL_UsesPublicCallback(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		requestURL   string
+		providerPath string
+		callbackPort int
+		call         func(h *Handler, c *gin.Context)
+	}{
+		{
+			name:         "codex",
+			requestURL:   "http://cpa.example.com/v0/management/codex-auth-url?is_webui=true",
+			providerPath: "/codex/callback",
+			callbackPort: codexCallbackPort,
+			call:         (*Handler).RequestCodexToken,
+		},
+		{
+			name:         "claude",
+			requestURL:   "http://cpa.example.com/v0/management/anthropic-auth-url?is_webui=true",
+			providerPath: "/anthropic/callback",
+			callbackPort: anthropicCallbackPort,
+			call:         (*Handler).RequestAnthropicToken,
+		},
+		{
+			name:         "gemini",
+			requestURL:   "http://cpa.example.com/v0/management/gemini-cli-auth-url?is_webui=true",
+			providerPath: "/google/callback",
+			callbackPort: geminiCallbackPort,
+			call:         (*Handler).RequestGeminiCLIToken,
+		},
+		{
+			name:         "antigravity",
+			requestURL:   "http://cpa.example.com/v0/management/antigravity-auth-url?is_webui=true",
+			providerPath: "/antigravity/callback",
+			callbackPort: antigravity.CallbackPort,
+			call:         (*Handler).RequestAntigravityToken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewHandlerWithoutConfigFilePath(&config.Config{
+				AuthDir: t.TempDir(),
+				Port:    49794,
+				RemoteManagement: config.RemoteManagement{
+					ExternalBaseURL: "https://cpa.example.com/base/",
+				},
+			}, nil)
+			h.tokenStore = &memoryAuthStore{}
+
+			rec := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(rec)
+			req := httptest.NewRequest(http.MethodGet, tt.requestURL, nil)
+			req.Host = "cpa.example.com"
+			ctx.Request = req
+
+			tt.call(h, ctx)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+			}
+
+			var resp struct {
+				Status string `json:"status"`
+				URL    string `json:"url"`
+				State  string `json:"state"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if resp.Status != "ok" {
+				t.Fatalf("status = %q, want %q", resp.Status, "ok")
+			}
+			if resp.State == "" {
+				t.Fatalf("expected non-empty oauth state")
+			}
+
+			parsed, err := url.Parse(resp.URL)
+			if err != nil {
+				t.Fatalf("failed to parse auth url: %v", err)
+			}
+			if got := parsed.Query().Get("redirect_uri"); got != "https://cpa.example.com/base"+tt.providerPath {
+				t.Fatalf("redirect_uri = %q, want %q", got, "https://cpa.example.com/base"+tt.providerPath)
+			}
+
+			callbackForwardersMu.Lock()
+			_, exists := callbackForwarders[tt.callbackPort]
+			callbackForwardersMu.Unlock()
+			if exists {
+				t.Fatalf("expected no local callback forwarder for %s external webui request", tt.name)
+			}
+
+			CompleteOAuthSession(resp.State)
+			time.Sleep(600 * time.Millisecond)
+		})
+	}
+}

--- a/internal/auth/claude/anthropic_auth.go
+++ b/internal/auth/claude/anthropic_auth.go
@@ -79,15 +79,23 @@ func NewClaudeAuth(cfg *config.Config) *ClaudeAuth {
 //   - string: The state parameter for verification
 //   - error: An error if PKCE codes are missing or URL generation fails
 func (o *ClaudeAuth) GenerateAuthURL(state string, pkceCodes *PKCECodes) (string, string, error) {
+	return o.GenerateAuthURLWithRedirect(state, pkceCodes, RedirectURI)
+}
+
+// GenerateAuthURLWithRedirect creates the OAuth authorization URL with a caller-provided redirect URI.
+func (o *ClaudeAuth) GenerateAuthURLWithRedirect(state string, pkceCodes *PKCECodes, redirectURI string) (string, string, error) {
 	if pkceCodes == nil {
 		return "", "", fmt.Errorf("PKCE codes are required")
+	}
+	if strings.TrimSpace(redirectURI) == "" {
+		return "", "", fmt.Errorf("redirect URI is required")
 	}
 
 	params := url.Values{
 		"code":                  {"true"},
 		"client_id":             {ClientID},
 		"response_type":         {"code"},
-		"redirect_uri":          {RedirectURI},
+		"redirect_uri":          {strings.TrimSpace(redirectURI)},
 		"scope":                 {"user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"},
 		"code_challenge":        {pkceCodes.CodeChallenge},
 		"code_challenge_method": {"S256"},
@@ -130,8 +138,16 @@ func (c *ClaudeAuth) parseCodeAndState(code string) (parsedCode, parsedState str
 //   - *ClaudeAuthBundle: The complete authentication bundle with tokens
 //   - error: An error if token exchange fails
 func (o *ClaudeAuth) ExchangeCodeForTokens(ctx context.Context, code, state string, pkceCodes *PKCECodes) (*ClaudeAuthBundle, error) {
+	return o.ExchangeCodeForTokensWithRedirect(ctx, code, state, RedirectURI, pkceCodes)
+}
+
+// ExchangeCodeForTokensWithRedirect exchanges authorization code for tokens using a caller-provided redirect URI.
+func (o *ClaudeAuth) ExchangeCodeForTokensWithRedirect(ctx context.Context, code, state, redirectURI string, pkceCodes *PKCECodes) (*ClaudeAuthBundle, error) {
 	if pkceCodes == nil {
 		return nil, fmt.Errorf("PKCE codes are required for token exchange")
+	}
+	if strings.TrimSpace(redirectURI) == "" {
+		return nil, fmt.Errorf("redirect URI is required for token exchange")
 	}
 	newCode, newState := o.parseCodeAndState(code)
 
@@ -141,7 +157,7 @@ func (o *ClaudeAuth) ExchangeCodeForTokens(ctx context.Context, code, state stri
 		"state":         state,
 		"grant_type":    "authorization_code",
 		"client_id":     ClientID,
-		"redirect_uri":  RedirectURI,
+		"redirect_uri":  strings.TrimSpace(redirectURI),
 		"code_verifier": pkceCodes.CodeVerifier,
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,6 +176,8 @@ type RemoteManagement struct {
 	AllowRemote bool `yaml:"allow-remote"`
 	// SecretKey is the management key (plaintext or bcrypt hashed). YAML key intentionally 'secret-key'.
 	SecretKey string `yaml:"secret-key"`
+	// ExternalBaseURL is the externally reachable base URL used by remote management clients.
+	ExternalBaseURL string `yaml:"external-base-url"`
 	// DisableControlPanel skips serving and syncing the bundled management UI when true.
 	DisableControlPanel bool `yaml:"disable-control-panel"`
 	// DisableAutoUpdatePanel disables automatic periodic background updates of the management panel asset from GitHub.
@@ -619,6 +621,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		_ = SaveConfigPreserveCommentsUpdateNestedScalar(configFile, []string{"remote-management", "secret-key"}, hashed)
 	}
 
+	cfg.RemoteManagement.ExternalBaseURL = strings.TrimSpace(cfg.RemoteManagement.ExternalBaseURL)
 	cfg.RemoteManagement.PanelGitHubRepository = strings.TrimSpace(cfg.RemoteManagement.PanelGitHubRepository)
 	if cfg.RemoteManagement.PanelGitHubRepository == "" {
 		cfg.RemoteManagement.PanelGitHubRepository = DefaultPanelGitHubRepository

--- a/internal/config/remote_management_external_base_url_test.go
+++ b/internal/config/remote_management_external_base_url_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfigOptional_RemoteManagementExternalBaseURL(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	configYAML := []byte(`
+remote-management:
+  external-base-url: "  https://example.com/base/  "
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+
+	if got := cfg.RemoteManagement.ExternalBaseURL; got != "https://example.com/base/" {
+		t.Fatalf("ExternalBaseURL = %q, want %q", got, "https://example.com/base/")
+	}
+}


### PR DESCRIPTION
## Summary
- add `remote-management.external-base-url` so webui oauth callbacks can use a configured public base URL
- route Codex, Claude, Gemini CLI, and Antigravity webui oauth flows through provider-specific external callback paths when configured
- add config and management handler tests to cover external callback resolution and preserve localhost fallback behavior