### PR TITLE
fix(codex): add ensurePublished to Execute and ExecuteStream for reliable usage tracking

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -180,6 +180,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		if detail, ok := parseCodexUsage(line); ok {
 			reporter.publish(ctx, detail)
 		}
+		reporter.ensurePublished(ctx)
 
 		var param any
 		out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, line, &param)
@@ -396,6 +397,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			reporter.publishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
 		}
+		reporter.ensurePublished(ctx)
 	}()
 	return stream, nil
 }


### PR DESCRIPTION
## Summary

Codex executor's `Execute` and `ExecuteStream` methods silently drop usage records when the upstream response does not include `response.usage` data (e.g., when using OAuth model aliases to proxy Claude models through the codex endpoint). This causes:

1. **Missing usage statistics** - Proxied model requests are not counted at all in the management panel
2. **Incomplete model list** - The usage statistics page only shows models that have successfully recorded usage, making aliased models invisible

## Root Cause

- `Execute` and `ExecuteStream` only call `reporter.publish()` when `parseCodexUsage()` returns `true`
- If the upstream never returns a `response.usage` field (or returns zero tokens), no usage record is emitted
- The `executeCompact` method already has `reporter.ensurePublished(ctx)` as a fallback (line 273), but `Execute` and `ExecuteStream` lack this safeguard

## Fix

Add `reporter.ensurePublished(ctx)` to both `Execute` (after the `response.completed` loop) and `ExecuteStream` (at the end of the goroutine), matching the existing pattern in `executeCompact`.

`ensurePublished` uses `sync.Once` so it is safe to call after `publish` - if usage data was already recorded, the call is a no-op. If no usage was recorded, it emits a zero-token record to ensure the request is at least counted.

## Changes

- `codex_executor.go`: Added `reporter.ensurePublished(ctx)` in `Execute` after `parseCodexUsage` block
- `codex_executor.go`: Added `reporter.ensurePublished(ctx)` in `ExecuteStream` at end of goroutine

## Testing

- Minimal change (2 lines added), follows existing `executeCompact` pattern exactly
- `ensurePublished` is idempotent via `sync.Once` - no risk of duplicate records
- No behavioral change for requests that already report usage correctly