### PR TITLE
fix(codex): populate response.completed.response.output in streaming mode

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -179,16 +179,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		eventType := gjson.GetBytes(eventData, "type").String()
 
 		if eventType == "response.output_item.done" {
-			itemResult := gjson.GetBytes(eventData, "item")
-			if !itemResult.Exists() || itemResult.Type != gjson.JSON {
-				continue
-			}
-			outputIndexResult := gjson.GetBytes(eventData, "output_index")
-			if outputIndexResult.Exists() {
-				outputItemsByIndex[outputIndexResult.Int()] = []byte(itemResult.Raw)
-			} else {
-				outputItemsFallback = append(outputItemsFallback, []byte(itemResult.Raw))
-			}
+			collectOutputItem(eventData, outputItemsByIndex, &outputItemsFallback)
 			continue
 		}
 
@@ -200,28 +191,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 			reporter.Publish(ctx, detail)
 		}
 
-		completedData := eventData
-		outputResult := gjson.GetBytes(completedData, "response.output")
-		shouldPatchOutput := (!outputResult.Exists() || !outputResult.IsArray() || len(outputResult.Array()) == 0) && (len(outputItemsByIndex) > 0 || len(outputItemsFallback) > 0)
-		if shouldPatchOutput {
-			completedDataPatched := completedData
-			completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output", []byte(`[]`))
-
-			indexes := make([]int64, 0, len(outputItemsByIndex))
-			for idx := range outputItemsByIndex {
-				indexes = append(indexes, idx)
-			}
-			sort.Slice(indexes, func(i, j int) bool {
-				return indexes[i] < indexes[j]
-			})
-			for _, idx := range indexes {
-				completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", outputItemsByIndex[idx])
-			}
-			for _, item := range outputItemsFallback {
-				completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", item)
-			}
-			completedData = completedDataPatched
-		}
+		completedData := patchCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
 
 		var param any
 		out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, completedData, &param)
@@ -414,16 +384,29 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
+
+		// Collect output items so we can populate response.completed.response.output
+		// which the upstream Codex API may return empty during streaming.
+		outputItemsByIndex := make(map[int64][]byte)
+		var outputItemsFallback [][]byte
+
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 
 			if bytes.HasPrefix(line, dataTag) {
 				data := bytes.TrimSpace(line[5:])
-				if gjson.GetBytes(data, "type").String() == "response.completed" {
+				eventType := gjson.GetBytes(data, "type").String()
+
+				if eventType == "response.output_item.done" {
+					collectOutputItem(data, outputItemsByIndex, &outputItemsFallback)
+				}
+
+				if eventType == "response.completed" {
 					if detail, ok := helps.ParseCodexUsage(data); ok {
 						reporter.Publish(ctx, detail)
 					}
+					line = patchCompletedOutputInSSELine(line, outputItemsByIndex, outputItemsFallback)
 				}
 			}
 
@@ -846,4 +829,67 @@ func (e *CodexExecutor) resolveCodexConfig(auth *cliproxyauth.Auth) *config.Code
 		}
 	}
 	return nil
+}
+
+// collectOutputItem extracts an output item from a response.output_item.done event
+// and stores it by index (or in the fallback slice when no index is present).
+func collectOutputItem(eventData []byte, itemsByIndex map[int64][]byte, itemsFallback *[][]byte) {
+	itemResult := gjson.GetBytes(eventData, "item")
+	if !itemResult.Exists() || itemResult.Type != gjson.JSON {
+		return
+	}
+	outputIndexResult := gjson.GetBytes(eventData, "output_index")
+	if outputIndexResult.Exists() {
+		itemsByIndex[outputIndexResult.Int()] = []byte(itemResult.Raw)
+	} else {
+		*itemsFallback = append(*itemsFallback, []byte(itemResult.Raw))
+	}
+}
+
+// patchCompletedOutput injects collected output items into a response.completed JSON
+// payload when the upstream returned an empty response.output array. Returns the
+// original data unchanged if output is already populated or no items were collected.
+func patchCompletedOutput(data []byte, itemsByIndex map[int64][]byte, itemsFallback [][]byte) []byte {
+	if len(itemsByIndex) == 0 && len(itemsFallback) == 0 {
+		return data
+	}
+	outputResult := gjson.GetBytes(data, "response.output")
+	if outputResult.Exists() && outputResult.IsArray() && len(outputResult.Array()) > 0 {
+		return data
+	}
+
+	patched, err := sjson.SetRawBytes(data, "response.output", []byte(`[]`))
+	if err != nil {
+		return data
+	}
+
+	indexes := make([]int64, 0, len(itemsByIndex))
+	for idx := range itemsByIndex {
+		indexes = append(indexes, idx)
+	}
+	sort.Slice(indexes, func(i, j int) bool { return indexes[i] < indexes[j] })
+	for _, idx := range indexes {
+		patched, _ = sjson.SetRawBytes(patched, "response.output.-1", itemsByIndex[idx])
+	}
+	for _, item := range itemsFallback {
+		patched, _ = sjson.SetRawBytes(patched, "response.output.-1", item)
+	}
+
+	return patched
+}
+
+// patchCompletedOutputInSSELine wraps patchCompletedOutput for SSE "data:" framed lines.
+func patchCompletedOutputInSSELine(line []byte, itemsByIndex map[int64][]byte, itemsFallback [][]byte) []byte {
+	if len(itemsByIndex) == 0 && len(itemsFallback) == 0 {
+		return line
+	}
+	if !bytes.HasPrefix(line, dataTag) {
+		return line
+	}
+	data := bytes.TrimSpace(line[5:])
+	patched := patchCompletedOutput(data, itemsByIndex, itemsFallback)
+	if bytes.Equal(patched, data) {
+		return line
+	}
+	return append([]byte("data: "), patched...)
 }

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -869,10 +869,16 @@ func patchCompletedOutput(data []byte, itemsByIndex map[int64][]byte, itemsFallb
 	}
 	sort.Slice(indexes, func(i, j int) bool { return indexes[i] < indexes[j] })
 	for _, idx := range indexes {
-		patched, _ = sjson.SetRawBytes(patched, "response.output.-1", itemsByIndex[idx])
+		patched, err = sjson.SetRawBytes(patched, "response.output.-1", itemsByIndex[idx])
+		if err != nil {
+			return data
+		}
 	}
 	for _, item := range itemsFallback {
-		patched, _ = sjson.SetRawBytes(patched, "response.output.-1", item)
+		patched, err = sjson.SetRawBytes(patched, "response.output.-1", item)
+		if err != nil {
+			return data
+		}
 	}
 
 	return patched

--- a/internal/runtime/executor/codex_executor_stream_output_patch_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_patch_test.go
@@ -1,0 +1,150 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestCollectOutputItem_WithIndex(t *testing.T) {
+	eventData := []byte(`{"type":"response.output_item.done","item":{"type":"message","content":[{"type":"output_text","text":"hi"}]},"output_index":0}`)
+	itemsByIndex := make(map[int64][]byte)
+	var fallback [][]byte
+
+	collectOutputItem(eventData, itemsByIndex, &fallback)
+
+	if len(itemsByIndex) != 1 {
+		t.Fatalf("expected 1 indexed item, got %d", len(itemsByIndex))
+	}
+	if len(fallback) != 0 {
+		t.Fatalf("expected 0 fallback items, got %d", len(fallback))
+	}
+	if gjson.GetBytes(itemsByIndex[0], "type").String() != "message" {
+		t.Fatalf("expected message type, got %s", gjson.GetBytes(itemsByIndex[0], "type").String())
+	}
+}
+
+func TestCollectOutputItem_WithoutIndex(t *testing.T) {
+	eventData := []byte(`{"type":"response.output_item.done","item":{"type":"message"}}`)
+	itemsByIndex := make(map[int64][]byte)
+	var fallback [][]byte
+
+	collectOutputItem(eventData, itemsByIndex, &fallback)
+
+	if len(itemsByIndex) != 0 {
+		t.Fatalf("expected 0 indexed items, got %d", len(itemsByIndex))
+	}
+	if len(fallback) != 1 {
+		t.Fatalf("expected 1 fallback item, got %d", len(fallback))
+	}
+}
+
+func TestCollectOutputItem_NoItem(t *testing.T) {
+	eventData := []byte(`{"type":"response.output_item.done"}`)
+	itemsByIndex := make(map[int64][]byte)
+	var fallback [][]byte
+
+	collectOutputItem(eventData, itemsByIndex, &fallback)
+
+	if len(itemsByIndex) != 0 || len(fallback) != 0 {
+		t.Fatalf("expected no items collected for missing item field")
+	}
+}
+
+func TestPatchCompletedOutput_EmptyOutput(t *testing.T) {
+	data := []byte(`{"type":"response.completed","response":{"id":"resp_1","output":[]}}`)
+	item := []byte(`{"type":"message","content":[{"type":"output_text","text":"hello"}]}`)
+	itemsByIndex := map[int64][]byte{0: item}
+
+	patched := patchCompletedOutput(data, itemsByIndex, nil)
+
+	text := gjson.GetBytes(patched, "response.output.0.content.0.text").String()
+	if text != "hello" {
+		t.Fatalf("output text = %q, want %q", text, "hello")
+	}
+}
+
+func TestPatchCompletedOutput_AlreadyPopulated(t *testing.T) {
+	data := []byte(`{"type":"response.completed","response":{"output":[{"type":"message"}]}}`)
+	item := []byte(`{"type":"message","content":[{"type":"output_text","text":"new"}]}`)
+
+	patched := patchCompletedOutput(data, map[int64][]byte{0: item}, nil)
+
+	if string(patched) != string(data) {
+		t.Fatalf("expected no change for already-populated output")
+	}
+}
+
+func TestPatchCompletedOutput_NoItems(t *testing.T) {
+	data := []byte(`{"type":"response.completed","response":{"output":[]}}`)
+
+	patched := patchCompletedOutput(data, nil, nil)
+
+	if string(patched) != string(data) {
+		t.Fatalf("expected no change when no items collected")
+	}
+}
+
+func TestPatchCompletedOutput_MultipleItemsSorted(t *testing.T) {
+	data := []byte(`{"type":"response.completed","response":{"output":[]}}`)
+	itemsByIndex := map[int64][]byte{
+		1: []byte(`{"type":"function_call","name":"search"}`),
+		0: []byte(`{"type":"message","content":[{"type":"output_text","text":"hi"}]}`),
+	}
+
+	patched := patchCompletedOutput(data, itemsByIndex, nil)
+
+	output := gjson.GetBytes(patched, "response.output")
+	if len(output.Array()) != 2 {
+		t.Fatalf("expected 2 output items, got %d", len(output.Array()))
+	}
+	if gjson.GetBytes(patched, "response.output.0.type").String() != "message" {
+		t.Fatalf("expected first item to be message")
+	}
+	if gjson.GetBytes(patched, "response.output.1.type").String() != "function_call" {
+		t.Fatalf("expected second item to be function_call")
+	}
+}
+
+func TestPatchCompletedOutputInSSELine_EmptyOutput(t *testing.T) {
+	line := []byte(`data: {"type":"response.completed","response":{"output":[]}}`)
+	item := []byte(`{"type":"message","content":[{"type":"output_text","text":"hello"}]}`)
+
+	patched := patchCompletedOutputInSSELine(line, map[int64][]byte{0: item}, nil)
+
+	data := patched[6:] // strip "data: "
+	text := gjson.GetBytes(data, "response.output.0.content.0.text").String()
+	if text != "hello" {
+		t.Fatalf("output text = %q, want %q", text, "hello")
+	}
+}
+
+func TestPatchCompletedOutputInSSELine_AlreadyPopulated(t *testing.T) {
+	line := []byte(`data: {"type":"response.completed","response":{"output":[{"type":"message"}]}}`)
+
+	patched := patchCompletedOutputInSSELine(line, map[int64][]byte{0: []byte(`{"type":"new"}`)}, nil)
+
+	if string(patched) != string(line) {
+		t.Fatalf("expected no change for already-populated output")
+	}
+}
+
+func TestPatchCompletedOutputInSSELine_NonDataLine(t *testing.T) {
+	line := []byte(`event: response.completed`)
+
+	patched := patchCompletedOutputInSSELine(line, map[int64][]byte{0: []byte(`{}`)}, nil)
+
+	if string(patched) != string(line) {
+		t.Fatalf("expected no change for non-data line")
+	}
+}
+
+func TestPatchCompletedOutputInSSELine_NoItems(t *testing.T) {
+	line := []byte(`data: {"type":"response.completed","response":{"output":[]}}`)
+
+	patched := patchCompletedOutputInSSELine(line, nil, nil)
+
+	if string(patched) != string(line) {
+		t.Fatalf("expected no change when no items collected")
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -310,6 +310,9 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		}
 	}
 
+	outputItemsByIndex := make(map[int64][]byte)
+	var outputItemsFallback [][]byte
+
 	for {
 		if ctx != nil && ctx.Err() != nil {
 			return resp, ctx.Err()
@@ -347,10 +350,16 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 
 		payload = normalizeCodexWebsocketCompletion(payload)
 		eventType := gjson.GetBytes(payload, "type").String()
+
+		if eventType == "response.output_item.done" {
+			collectOutputItem(payload, outputItemsByIndex, &outputItemsFallback)
+		}
+
 		if eventType == "response.completed" {
 			if detail, ok := helps.ParseCodexUsage(payload); ok {
 				reporter.Publish(ctx, detail)
 			}
+			payload = patchCompletedOutput(payload, outputItemsByIndex, outputItemsFallback)
 			var param any
 			out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, payload, &param)
 			resp = cliproxyexecutor.Response{Payload: out}
@@ -537,6 +546,12 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		}
 
 		var param any
+
+		// Collect output items to populate response.completed.response.output
+		// which the upstream Codex API may return empty during streaming.
+		outputItemsByIndex := make(map[int64][]byte)
+		var outputItemsFallback [][]byte
+
 		for {
 			if ctx != nil && ctx.Err() != nil {
 				terminateReason = "context_done"
@@ -595,6 +610,11 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 
 			payload = normalizeCodexWebsocketCompletion(payload)
 			eventType := gjson.GetBytes(payload, "type").String()
+
+			if eventType == "response.output_item.done" {
+				collectOutputItem(payload, outputItemsByIndex, &outputItemsFallback)
+			}
+
 			if eventType == "response.completed" || eventType == "response.done" {
 				if detail, ok := helps.ParseCodexUsage(payload); ok {
 					reporter.Publish(ctx, detail)
@@ -602,6 +622,9 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 
 			line := encodeCodexWebsocketAsSSE(payload)
+			if eventType == "response.completed" || eventType == "response.done" {
+				line = patchCompletedOutputInSSELine(line, outputItemsByIndex, outputItemsFallback)
+			}
 			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, body, body, line, &param)
 			for i := range chunks {
 				if !send(cliproxyexecutor.StreamChunk{Payload: chunks[i]}) {


### PR DESCRIPTION
## Summary

- The Codex upstream API returns `response.completed` with an empty `output[]` array during streaming, despite correctly emitting `response.output_item.done` events with full content earlier in the stream
- Clients like Amp CLI use the completed response's output as the source of truth, causing streamed text to disappear when the stream finishes
- The non-streaming HTTP executor already patched this inline — this PR extracts the pattern into shared helpers and applies the fix to all four code paths

## Changes

**Shared helpers** (in `codex_executor.go`):
- `collectOutputItem` — extracts item from `output_item.done` event by index
- `patchCompletedOutput` — injects collected items into completed JSON payload (transport-agnostic)
- `patchCompletedOutputInSSELine` — SSE-framed wrapper

**Fixed code paths:**
| Path | Transport | Status |
|---|---|---|
| `CodexExecutor.Execute` | HTTP non-streaming | Refactored to shared helpers |
| `CodexExecutor.ExecuteStream` | HTTP SSE | **Newly fixed** |
| `CodexWebsocketsExecutor.Execute` | WS non-streaming | **Newly fixed** |
| `CodexWebsocketsExecutor.ExecuteStream` | WS streaming | **Newly fixed** |

## Behavior

- If `response.completed.response.output` is empty and `response.output_item.done` events were seen, injects the collected items sorted by `output_index`
- If output is already populated (upstream fixes this), patching is a no-op
- If no items were collected, returns data unchanged
- On `sjson` error, returns original data unchanged (fail-safe)

## Test plan

- [x] 12 new unit tests covering `collectOutputItem`, `patchCompletedOutput`, and `patchCompletedOutputInSSELine`
- [x] Existing `TestCodexExecutorExecute_EmptyStreamCompletionOutputUsesOutputItemDone` passes
- [x] Full executor test suite passes (only pre-existing Qwen test failure, unrelated)
- [x] `go build ./...` clean
- [x] Verified end-to-end with Amp CLI via CLIProxyAPI — streamed text persists after stream completion