### PR TITLE
fix(responses): keep tool-call/result chains contiguous when converting to chat/completions

### DIFF
--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -117,6 +117,7 @@ func (h *OpenAIAPIHandler) ChatCompletions(c *gin.Context) {
 	if shouldTreatAsResponsesFormat(rawJSON) {
 		modelName := gjson.GetBytes(rawJSON, "model").String()
 		rawJSON = responsesconverter.ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName, rawJSON, stream)
+		rawJSON = sanitizeConvertedResponsesChatCompletions(rawJSON)
 		stream = gjson.GetBytes(rawJSON, "stream").Bool()
 	}
 

--- a/sdk/api/handlers/openai/openai_responses_chatcompletions_sanitizer.go
+++ b/sdk/api/handlers/openai/openai_responses_chatcompletions_sanitizer.go
@@ -1,0 +1,258 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// sanitizeConvertedResponsesChatCompletions normalizes chat-completions payloads
+// produced from /v1/responses-style inputs before they are forwarded upstream.
+//
+// Some Responses conversations can contain non-tool messages between an
+// assistant tool call and the matching tool result. OpenAI-compatible
+// chat-completions backends expect every pending tool call to be satisfied by
+// tool messages before any other role appears. This sanitizer keeps tool-call
+// chains contiguous by buffering interleaved non-tool messages until all
+// pending tool results arrive. It also merges consecutive assistant tool-call
+// messages into a single assistant turn so parallel calls stay valid for strict
+// chat-completions executors.
+func sanitizeConvertedResponsesChatCompletions(rawJSON []byte) []byte {
+	decoder := json.NewDecoder(bytes.NewReader(rawJSON))
+	decoder.UseNumber()
+
+	var payload map[string]any
+	if err := decoder.Decode(&payload); err != nil {
+		return rawJSON
+	}
+
+	rawMessages, ok := payload["messages"].([]any)
+	if !ok || len(rawMessages) == 0 {
+		return rawJSON
+	}
+
+	messages, changed := normalizeChatCompletionsToolMessageOrder(rawMessages)
+	if !changed {
+		return rawJSON
+	}
+
+	payload["messages"] = messages
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return rawJSON
+	}
+	return out
+}
+
+func normalizeChatCompletionsToolMessageOrder(messages []any) ([]any, bool) {
+	remaining := append([]any(nil), messages...)
+	normalized := make([]any, 0, len(messages))
+	buffered := make([]any, 0)
+	pendingToolCalls := make(map[string]struct{})
+	lastAssistantToolIndex := -1
+	changed := false
+
+	prependBuffered := func() {
+		if len(buffered) == 0 {
+			return
+		}
+		remaining = append(append(make([]any, 0, len(buffered)+len(remaining)), buffered...), remaining...)
+		buffered = buffered[:0]
+		lastAssistantToolIndex = -1
+	}
+
+	for len(remaining) > 0 {
+		if len(pendingToolCalls) == 0 && len(buffered) > 0 {
+			prependBuffered()
+		}
+
+		rawMessage := remaining[0]
+		remaining = remaining[1:]
+
+		message, ok := rawMessage.(map[string]any)
+		if !ok {
+			if len(pendingToolCalls) > 0 {
+				buffered = append(buffered, rawMessage)
+				changed = true
+			} else {
+				normalized = append(normalized, rawMessage)
+				lastAssistantToolIndex = -1
+			}
+			continue
+		}
+
+		role, _ := message["role"].(string)
+		toolCalls := messageToolCalls(message)
+
+		if role == "assistant" && len(toolCalls) > 0 {
+			if canMergeAdjacentAssistantToolCalls(pendingToolCalls, lastAssistantToolIndex, normalized) {
+				if previous, ok := normalized[lastAssistantToolIndex].(map[string]any); ok {
+					previous["tool_calls"] = append(messageToolCalls(previous), toolCalls...)
+					mergeAssistantContent(previous, message)
+					addPendingToolCallIDs(pendingToolCalls, toolCalls)
+					changed = true
+					continue
+				}
+			}
+			if len(pendingToolCalls) > 0 {
+				buffered = append(buffered, rawMessage)
+				changed = true
+				continue
+			}
+
+			normalized = append(normalized, message)
+			lastAssistantToolIndex = len(normalized) - 1
+			addPendingToolCallIDs(pendingToolCalls, toolCalls)
+			continue
+		}
+
+		if role == "tool" {
+			toolCallID, _ := message["tool_call_id"].(string)
+			if len(pendingToolCalls) > 0 && len(buffered) > 0 {
+				if toolCallID == "" {
+					buffered = append(buffered, rawMessage)
+					changed = true
+					continue
+				}
+				if _, ok := pendingToolCalls[toolCallID]; !ok {
+					buffered = append(buffered, rawMessage)
+					changed = true
+					continue
+				}
+			}
+
+			normalized = append(normalized, message)
+			if toolCallID != "" {
+				delete(pendingToolCalls, toolCallID)
+			}
+			if len(pendingToolCalls) == 0 {
+				lastAssistantToolIndex = -1
+			}
+			continue
+		}
+
+		if len(pendingToolCalls) > 0 {
+			buffered = append(buffered, message)
+			changed = true
+			continue
+		}
+
+		normalized = append(normalized, message)
+		lastAssistantToolIndex = -1
+	}
+
+	if len(buffered) > 0 {
+		normalized = append(normalized, buffered...)
+	}
+
+	return normalized, changed
+}
+
+func messageToolCalls(message map[string]any) []any {
+	raw, ok := message["tool_calls"].([]any)
+	if !ok {
+		return nil
+	}
+	return raw
+}
+
+func canMergeAdjacentAssistantToolCalls(pendingToolCalls map[string]struct{}, lastAssistantToolIndex int, normalized []any) bool {
+	if len(pendingToolCalls) == 0 || lastAssistantToolIndex < 0 || lastAssistantToolIndex >= len(normalized) {
+		return false
+	}
+	return lastAssistantToolIndex == len(normalized)-1
+}
+
+func addPendingToolCallIDs(pending map[string]struct{}, toolCalls []any) {
+	for _, rawToolCall := range toolCalls {
+		toolCall, ok := rawToolCall.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, _ := toolCall["id"].(string)
+		if id == "" {
+			continue
+		}
+		pending[id] = struct{}{}
+	}
+}
+
+func mergeAssistantContent(dst, src map[string]any) {
+	srcContent, srcExists := src["content"]
+	if !srcExists || isEmptyMessageContent(srcContent) {
+		return
+	}
+
+	dstContent, dstExists := dst["content"]
+	if !dstExists || isEmptyMessageContent(dstContent) {
+		dst["content"] = srcContent
+		return
+	}
+
+	dstParts, dstPartsOK := dstContent.([]any)
+	srcParts, srcPartsOK := srcContent.([]any)
+	if dstPartsOK && srcPartsOK {
+		dst["content"] = append(dstParts, srcParts...)
+		return
+	}
+
+	dstText, dstTextOK := dstContent.(string)
+	srcText, srcTextOK := srcContent.(string)
+	if dstTextOK && srcTextOK {
+		switch {
+		case dstText == "":
+			dst["content"] = srcText
+		case srcText == "":
+			// Keep dst unchanged.
+		default:
+			dst["content"] = dstText + "\n" + srcText
+		}
+		return
+	}
+
+	if mergedParts, ok := mergeMessageContentAsParts(dstContent, srcContent); ok {
+		dst["content"] = mergedParts
+	}
+}
+
+func mergeMessageContentAsParts(dstContent, srcContent any) ([]any, bool) {
+	dstParts, dstOK := messageContentAsParts(dstContent)
+	srcParts, srcOK := messageContentAsParts(srcContent)
+	if !dstOK || !srcOK {
+		return nil, false
+	}
+	return append(dstParts, srcParts...), true
+}
+
+func messageContentAsParts(content any) ([]any, bool) {
+	switch v := content.(type) {
+	case nil:
+		return nil, false
+	case string:
+		if v == "" {
+			return []any{}, true
+		}
+		return []any{
+			map[string]any{
+				"type": "text",
+				"text": v,
+			},
+		}, true
+	case []any:
+		return append([]any{}, v...), true
+	default:
+		return nil, false
+	}
+}
+
+func isEmptyMessageContent(content any) bool {
+	switch v := content.(type) {
+	case nil:
+		return true
+	case string:
+		return v == ""
+	case []any:
+		return len(v) == 0
+	default:
+		return false
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_chatcompletions_sanitizer_test.go
+++ b/sdk/api/handlers/openai/openai_responses_chatcompletions_sanitizer_test.go
@@ -1,0 +1,446 @@
+package openai
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	responsesconverter "github.com/router-for-me/CLIProxyAPI/v6/internal/translator/openai/openai/responses"
+	"github.com/tidwall/gjson"
+)
+
+func TestSanitizeConvertedResponsesChatCompletions_ReordersInterleavedMessagesFromResponsesInput(t *testing.T) {
+	input := []byte(`{
+		"model": "skd/gpt5.4",
+		"instructions": "system instructions",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]},
+			{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"bad\"}","call_id":"call_1"},
+			{"type":"message","role":"developer","content":[{"type":"input_text","text":"Bash reported command-not-found; verify PATH before retrying."}]},
+			{"type":"function_call_output","call_id":"call_1","output":"The Bash output indicates a command/setup failure that should be fixed before retrying."}
+		],
+		"stream": true
+	}`)
+
+	converted := responsesconverter.ConvertOpenAIResponsesRequestToOpenAIChatCompletions("skd/gpt5.4", input, true)
+	sanitized := sanitizeConvertedResponsesChatCompletions(converted)
+
+	messages := gjson.GetBytes(sanitized, "messages").Array()
+	if len(messages) != 5 {
+		t.Fatalf("expected 5 messages, got %d: %s", len(messages), gjson.GetBytes(sanitized, "messages").Raw)
+	}
+
+	if got := messages[0].Get("role").String(); got != "system" {
+		t.Fatalf("message[0] role = %q, want system", got)
+	}
+	if got := messages[1].Get("role").String(); got != "user" {
+		t.Fatalf("message[1] role = %q, want user", got)
+	}
+	if got := messages[2].Get("role").String(); got != "assistant" {
+		t.Fatalf("message[2] role = %q, want assistant", got)
+	}
+	if got := messages[3].Get("role").String(); got != "tool" {
+		t.Fatalf("message[3] role = %q, want tool", got)
+	}
+	if got := messages[4].Get("role").String(); got != "user" {
+		t.Fatalf("message[4] role = %q, want user", got)
+	}
+
+	if got := messages[3].Get("tool_call_id").String(); got != "call_1" {
+		t.Fatalf("tool_call_id = %q, want call_1", got)
+	}
+
+	assertToolCallChainsAreContiguous(t, sanitized)
+}
+
+func TestSanitizeConvertedResponsesChatCompletions_MergesConsecutiveAssistantToolCallMessages(t *testing.T) {
+	input := []byte(`{
+		"model": "skd/gpt5.4",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"compare weather"}]},
+			{"type":"function_call","name":"get_weather","arguments":"{\"city\":\"Paris\"}","call_id":"call_paris"},
+			{"type":"function_call","name":"get_weather","arguments":"{\"city\":\"London\"}","call_id":"call_london"},
+			{"type":"function_call_output","call_id":"call_paris","output":"sunny"},
+			{"type":"function_call_output","call_id":"call_london","output":"rainy"}
+		],
+		"stream": true
+	}`)
+
+	converted := responsesconverter.ConvertOpenAIResponsesRequestToOpenAIChatCompletions("skd/gpt5.4", input, true)
+	sanitized := sanitizeConvertedResponsesChatCompletions(converted)
+
+	messages := gjson.GetBytes(sanitized, "messages").Array()
+	if len(messages) != 4 {
+		t.Fatalf("expected 4 messages, got %d: %s", len(messages), gjson.GetBytes(sanitized, "messages").Raw)
+	}
+
+	assistant := messages[1]
+	if got := assistant.Get("role").String(); got != "assistant" {
+		t.Fatalf("message[1] role = %q, want assistant", got)
+	}
+	if got := len(assistant.Get("tool_calls").Array()); got != 2 {
+		t.Fatalf("assistant tool_calls len = %d, want 2", got)
+	}
+
+	assertToolCallChainsAreContiguous(t, sanitized)
+}
+
+func TestSanitizeConvertedResponsesChatCompletions_PreservesAlreadyValidSequences(t *testing.T) {
+	payload := []byte(`{
+		"model":"skd/gpt5.4",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"ping","arguments":"{}"}}]},
+			{"role":"tool","tool_call_id":"call_1","content":"ok"},
+			{"role":"assistant","content":"done"}
+		],
+		"stream":true
+	}`)
+
+	sanitized := sanitizeConvertedResponsesChatCompletions(payload)
+	if string(sanitized) != string(payload) {
+		t.Fatalf("expected valid sequence to remain unchanged.\nGot:  %s\nWant: %s", sanitized, payload)
+	}
+}
+
+func TestSanitizeConvertedResponsesChatCompletions_FixesCapturedFixtureShape(t *testing.T) {
+	input := mustReadFixture(t, "responses_interleaved_tool_chain_fixture.json")
+
+	converted := responsesconverter.ConvertOpenAIResponsesRequestToOpenAIChatCompletions("skd/gpt5.4", input, true)
+	if idx := firstToolCallOrderingViolation(converted); idx == -1 {
+		t.Fatalf("expected fixture to reproduce an ordering violation before sanitization: %s", gjson.GetBytes(converted, "messages").Raw)
+	}
+
+	sanitized := sanitizeConvertedResponsesChatCompletions(converted)
+	if idx := firstToolCallOrderingViolation(sanitized); idx != -1 {
+		t.Fatalf("expected sanitizer to remove ordering violation, first invalid message index=%d: %s", idx, gjson.GetBytes(sanitized, "messages").Raw)
+	}
+
+	messages := gjson.GetBytes(sanitized, "messages").Array()
+	lastToolIdx := len(messages) - 2
+	if got := messages[lastToolIdx].Get("role").String(); got != "tool" {
+		t.Fatalf("message[%d] role = %q, want tool", lastToolIdx, got)
+	}
+	if got := messages[lastToolIdx+1].Get("role").String(); got != "user" {
+		t.Fatalf("message[%d] role = %q, want user", lastToolIdx+1, got)
+	}
+}
+
+func TestSanitizeConvertedResponsesChatCompletions_PreservesLargeNumericLiterals(t *testing.T) {
+	payload := []byte(`{
+		"model":"skd/gpt5.4",
+		"seed":9007199254740993,
+		"tools":[
+			{
+				"type":"function",
+				"function":{
+					"name":"ping",
+					"parameters":{
+						"type":"object",
+						"properties":{
+							"limit":{"type":"integer","maximum":9007199254740995}
+						}
+					}
+				}
+			}
+		],
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"ping","arguments":"{}"}}]},
+			{"role":"user","content":"interleaved"},
+			{"role":"tool","tool_call_id":"call_1","content":"ok"}
+		],
+		"stream":true
+	}`)
+
+	sanitized := sanitizeConvertedResponsesChatCompletions(payload)
+	if !bytes.Contains(sanitized, []byte(`"seed":9007199254740993`)) {
+		t.Fatalf("expected large top-level numeric literal to be preserved, got: %s", sanitized)
+	}
+	if !bytes.Contains(sanitized, []byte(`"maximum":9007199254740995`)) {
+		t.Fatalf("expected nested tool-schema numeric literal to be preserved, got: %s", sanitized)
+	}
+}
+
+func TestSanitizeConvertedResponsesChatCompletions_DoesNotMergeAssistantToolCallsAcrossToolResults(t *testing.T) {
+	payload := []byte(`{
+		"model":"skd/gpt5.4",
+		"messages":[
+			{"role":"user","content":"compare"},
+			{"role":"assistant","tool_calls":[
+				{"id":"call_a","type":"function","function":{"name":"weather","arguments":"{\"city\":\"Paris\"}"}},
+				{"id":"call_b","type":"function","function":{"name":"weather","arguments":"{\"city\":\"London\"}"}}
+			]},
+			{"role":"tool","tool_call_id":"call_a","content":"sunny"},
+			{"role":"assistant","tool_calls":[
+				{"id":"call_c","type":"function","function":{"name":"weather","arguments":"{\"city\":\"Tokyo\"}"}}
+			]},
+			{"role":"tool","tool_call_id":"call_b","content":"rainy"},
+			{"role":"tool","tool_call_id":"call_c","content":"humid"}
+		],
+		"stream":true
+	}`)
+
+	sanitized := sanitizeConvertedResponsesChatCompletions(payload)
+	messages := gjson.GetBytes(sanitized, "messages").Array()
+	if len(messages) != 6 {
+		t.Fatalf("expected 6 messages, got %d: %s", len(messages), gjson.GetBytes(sanitized, "messages").Raw)
+	}
+
+	roleSequence := []string{
+		messages[0].Get("role").String(),
+		messages[1].Get("role").String(),
+		messages[2].Get("role").String(),
+		messages[3].Get("role").String(),
+		messages[4].Get("role").String(),
+		messages[5].Get("role").String(),
+	}
+	wantRoles := []string{"user", "assistant", "tool", "tool", "assistant", "tool"}
+	if !reflect.DeepEqual(roleSequence, wantRoles) {
+		t.Fatalf("role sequence = %#v, want %#v. messages=%s", roleSequence, wantRoles, gjson.GetBytes(sanitized, "messages").Raw)
+	}
+
+	firstAssistant := messages[1]
+	secondAssistant := messages[4]
+	if got := len(firstAssistant.Get("tool_calls").Array()); got != 2 {
+		t.Fatalf("first assistant tool_calls len = %d, want 2", got)
+	}
+	if got := len(secondAssistant.Get("tool_calls").Array()); got != 1 {
+		t.Fatalf("second assistant tool_calls len = %d, want 1", got)
+	}
+	if got := secondAssistant.Get("tool_calls.0.id").String(); got != "call_c" {
+		t.Fatalf("second assistant tool_call id = %q, want call_c", got)
+	}
+	if idx := firstToolCallOrderingViolation(sanitized); idx != -1 {
+		t.Fatalf("expected no ordering violation after delaying later assistant tool calls, got first invalid index=%d: %s", idx, gjson.GetBytes(sanitized, "messages").Raw)
+	}
+}
+
+func TestSanitizeConvertedResponsesChatCompletions_MergesAssistantToolCallsAcrossBufferedMessagesBeforeToolResults(t *testing.T) {
+	input := []byte(`{
+		"model":"skd/gpt5.4",
+		"instructions":"system instructions",
+		"input":[
+			{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"a\"}","call_id":"call_a"},
+			{"type":"message","role":"developer","content":[{"type":"input_text","text":"diagnostic before another tool call"}]},
+			{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"b\"}","call_id":"call_b"},
+			{"type":"function_call_output","call_id":"call_a","output":"A done"},
+			{"type":"function_call_output","call_id":"call_b","output":"B done"}
+		],
+		"stream":true
+	}`)
+
+	converted := responsesconverter.ConvertOpenAIResponsesRequestToOpenAIChatCompletions("skd/gpt5.4", input, true)
+	sanitized := sanitizeConvertedResponsesChatCompletions(converted)
+	messages := gjson.GetBytes(sanitized, "messages").Array()
+
+	var assistantToolCallCounts []int
+	for _, message := range messages {
+		if message.Get("role").String() == "assistant" && message.Get("tool_calls").Exists() {
+			assistantToolCallCounts = append(assistantToolCallCounts, len(message.Get("tool_calls").Array()))
+		}
+	}
+
+	if !reflect.DeepEqual(assistantToolCallCounts, []int{2}) {
+		t.Fatalf("assistant tool call grouping = %#v, want []int{2}. messages=%s", assistantToolCallCounts, gjson.GetBytes(sanitized, "messages").Raw)
+	}
+	if idx := firstToolCallOrderingViolation(sanitized); idx != -1 {
+		t.Fatalf("expected no ordering violation after merging across buffered message, got first invalid index=%d: %s", idx, gjson.GetBytes(sanitized, "messages").Raw)
+	}
+
+	lastMessage := messages[len(messages)-1]
+	if got := lastMessage.Get("role").String(); got != "user" {
+		t.Fatalf("last message role = %q, want user. messages=%s", got, gjson.GetBytes(sanitized, "messages").Raw)
+	}
+	if got := lastMessage.Get("content.0.text").String(); got != "diagnostic before another tool call" {
+		t.Fatalf("last buffered message text = %q, want diagnostic message", got)
+	}
+}
+
+func TestSanitizeConvertedResponsesChatCompletions_BuffersToolResultsForDeferredAssistantToolCalls(t *testing.T) {
+	payload := []byte(`{
+		"model":"skd/gpt5.4",
+		"messages":[
+			{"role":"user","content":"compare"},
+			{"role":"assistant","tool_calls":[
+				{"id":"call_a","type":"function","function":{"name":"weather","arguments":"{\"city\":\"Paris\"}"}},
+				{"id":"call_b","type":"function","function":{"name":"weather","arguments":"{\"city\":\"London\"}"}}
+			]},
+			{"role":"tool","tool_call_id":"call_a","content":"sunny"},
+			{"role":"assistant","tool_calls":[
+				{"id":"call_c","type":"function","function":{"name":"weather","arguments":"{\"city\":\"Tokyo\"}"}}
+			]},
+			{"role":"tool","tool_call_id":"call_c","content":"humid"},
+			{"role":"tool","tool_call_id":"call_b","content":"rainy"}
+		],
+		"stream":true
+	}`)
+
+	sanitized := sanitizeConvertedResponsesChatCompletions(payload)
+	messages := gjson.GetBytes(sanitized, "messages").Array()
+	roleSequence := []string{
+		messages[0].Get("role").String(),
+		messages[1].Get("role").String(),
+		messages[2].Get("role").String(),
+		messages[3].Get("role").String(),
+		messages[4].Get("role").String(),
+		messages[5].Get("role").String(),
+	}
+	wantRoles := []string{"user", "assistant", "tool", "tool", "assistant", "tool"}
+	if !reflect.DeepEqual(roleSequence, wantRoles) {
+		t.Fatalf("role sequence = %#v, want %#v. messages=%s", roleSequence, wantRoles, gjson.GetBytes(sanitized, "messages").Raw)
+	}
+	if got := messages[3].Get("tool_call_id").String(); got != "call_b" {
+		t.Fatalf("message[3] tool_call_id = %q, want call_b", got)
+	}
+	if got := messages[4].Get("tool_calls.0.id").String(); got != "call_c" {
+		t.Fatalf("message[4] tool_call id = %q, want call_c", got)
+	}
+	if got := messages[5].Get("tool_call_id").String(); got != "call_c" {
+		t.Fatalf("message[5] tool_call_id = %q, want call_c", got)
+	}
+	if idx := firstToolCallOrderingViolation(sanitized); idx != -1 {
+		t.Fatalf("expected no ordering violation after buffering deferred tool result, got first invalid index=%d: %s", idx, gjson.GetBytes(sanitized, "messages").Raw)
+	}
+}
+
+func TestMergeAssistantContent_StringString(t *testing.T) {
+	dst := map[string]any{"content": "first"}
+	src := map[string]any{"content": "second"}
+
+	mergeAssistantContent(dst, src)
+
+	if got := dst["content"]; got != "first\nsecond" {
+		t.Fatalf("merged content = %#v, want %q", got, "first\nsecond")
+	}
+}
+
+func TestMergeAssistantContent_ArrayArray(t *testing.T) {
+	dst := map[string]any{
+		"content": []any{
+			map[string]any{"type": "text", "text": "first"},
+		},
+	}
+	src := map[string]any{
+		"content": []any{
+			map[string]any{"type": "text", "text": "second"},
+		},
+	}
+
+	mergeAssistantContent(dst, src)
+
+	want := []any{
+		map[string]any{"type": "text", "text": "first"},
+		map[string]any{"type": "text", "text": "second"},
+	}
+	if !reflect.DeepEqual(dst["content"], want) {
+		t.Fatalf("merged content = %#v, want %#v", dst["content"], want)
+	}
+}
+
+func TestMergeAssistantContent_MixedStringAndArray(t *testing.T) {
+	tests := []struct {
+		name string
+		dst  any
+		src  any
+		want []any
+	}{
+		{
+			name: "string_then_array",
+			dst:  "first",
+			src: []any{
+				map[string]any{"type": "text", "text": "second"},
+			},
+			want: []any{
+				map[string]any{"type": "text", "text": "first"},
+				map[string]any{"type": "text", "text": "second"},
+			},
+		},
+		{
+			name: "array_then_string",
+			dst: []any{
+				map[string]any{"type": "text", "text": "first"},
+			},
+			src: "second",
+			want: []any{
+				map[string]any{"type": "text", "text": "first"},
+				map[string]any{"type": "text", "text": "second"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := map[string]any{"content": tt.dst}
+			src := map[string]any{"content": tt.src}
+
+			mergeAssistantContent(dst, src)
+
+			if !reflect.DeepEqual(dst["content"], tt.want) {
+				t.Fatalf("merged content = %#v, want %#v", dst["content"], tt.want)
+			}
+		})
+	}
+}
+
+func assertToolCallChainsAreContiguous(t *testing.T, rawJSON []byte) {
+	t.Helper()
+
+	pending := make(map[string]struct{})
+	messages := gjson.GetBytes(rawJSON, "messages").Array()
+	for idx, message := range messages {
+		role := message.Get("role").String()
+		if len(pending) > 0 && role != "tool" {
+			t.Fatalf("message[%d] role=%s interrupted pending tool calls: %s", idx, role, gjson.GetBytes(rawJSON, "messages").Raw)
+		}
+
+		if role == "assistant" {
+			for _, toolCall := range message.Get("tool_calls").Array() {
+				if id := toolCall.Get("id").String(); id != "" {
+					pending[id] = struct{}{}
+				}
+			}
+		}
+
+		if role == "tool" {
+			delete(pending, message.Get("tool_call_id").String())
+		}
+	}
+}
+
+func firstToolCallOrderingViolation(rawJSON []byte) int {
+	pending := make(map[string]struct{})
+	messages := gjson.GetBytes(rawJSON, "messages").Array()
+	for idx, message := range messages {
+		role := message.Get("role").String()
+		if len(pending) > 0 && role != "tool" {
+			return idx
+		}
+
+		if role == "assistant" {
+			for _, toolCall := range message.Get("tool_calls").Array() {
+				if id := toolCall.Get("id").String(); id != "" {
+					pending[id] = struct{}{}
+				}
+			}
+		}
+
+		if role == "tool" {
+			delete(pending, message.Get("tool_call_id").String())
+		}
+	}
+	return -1
+}
+
+func mustReadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+
+	path := filepath.Join("..", "..", "..", "..", "test", "testdata", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	return data
+}

--- a/test/testdata/responses_interleaved_tool_chain_fixture.json
+++ b/test/testdata/responses_interleaved_tool_chain_fixture.json
@@ -1,0 +1,174 @@
+{
+  "model": "skd/gpt5.4",
+  "instructions": "<!-- AUTONOMY DIRECTIVE -->\nYou are an autonomous coding agent.\nFollow AGENTS.md, restore runtime context, and continue execution without waiting for confirmation on obvious next steps.\n\n# oh-my-codex\n- Prefer evidence over assumption.\n- Use tools when correctness depends on retrieval or verification.\n- Keep responses concise but complete.\n",
+  "stream": true,
+  "tool_choice": "auto",
+  "parallel_tool_calls": false,
+  "service_tier": "priority",
+  "include": [],
+  "tools": [
+    {
+      "type": "function",
+      "name": "exec_command",
+      "description": "Runs a shell command and returns stdout/stderr.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "cmd": {
+            "type": "string"
+          },
+          "workdir": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cmd"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "type": "function",
+      "name": "write_stdin",
+      "description": "Writes stdin to a running command session.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "session_id": {
+            "type": "number"
+          },
+          "chars": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "type": "function",
+      "name": "update_plan",
+      "description": "Updates the visible execution plan.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "explanation": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  ],
+  "input": [
+    {
+      "type": "message",
+      "role": "developer",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "<permissions instructions>\nFilesystem sandboxing defines which files can be read or written. sandbox_mode is danger-full-access.\nApproval policy is never.\n</permissions instructions>"
+        },
+        {
+          "type": "input_text",
+          "text": "<collaboration_mode>Default</collaboration_mode>\nUse skills when explicitly invoked."
+        }
+      ]
+    },
+    {
+      "type": "message",
+      "role": "user",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "# AGENTS.md instructions for /Users/example/Downloads\n\n<INSTRUCTIONS>\nLoad workspace conventions from AGENTS.md before making changes.\n</INSTRUCTIONS>"
+        }
+      ]
+    },
+    {
+      "type": "message",
+      "role": "developer",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "OMX native SessionStart detected. Restore notepad context and continue from existing mode state."
+        }
+      ]
+    },
+    {
+      "type": "message",
+      "role": "user",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "hi"
+        }
+      ]
+    },
+    {
+      "type": "function_call",
+      "name": "exec_command",
+      "arguments": "{\"cmd\":\"pwd && ls -la && find .. -name AGENTS.md -print\"}",
+      "call_id": "call_NqAlJDqSV7UX9D2G1SarNR2s"
+    },
+    {
+      "type": "function_call_output",
+      "call_id": "call_NqAlJDqSV7UX9D2G1SarNR2s",
+      "output": "Command: /bin/zsh -lc 'pwd && ls -la && find .. -name AGENTS.md -print'\nOutput:\n/Users/example/Downloads\n../CLIProxyAPI/AGENTS.md"
+    },
+    {
+      "type": "function_call",
+      "name": "exec_command",
+      "arguments": "{\"cmd\":\"find . -maxdepth 2 -name AGENTS.md -print && echo state\"}",
+      "call_id": "call_lU06AP96RGPFliueYafiAbQ2"
+    },
+    {
+      "type": "function_call_output",
+      "call_id": "call_lU06AP96RGPFliueYafiAbQ2",
+      "output": "Command: /bin/zsh -lc 'find . -maxdepth 2 -name AGENTS.md -print && echo state'\nOutput:\n.omx/context/request-7593537e-500-investigation.md\nstate"
+    },
+    {
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "Hi — I restored the local OMX context and resumed the prior investigation state."
+        }
+      ]
+    },
+    {
+      "type": "message",
+      "role": "user",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "<hook_prompt hook_run_id=\"stop:4:/Users/example/.codex/hooks.json\">yes, proceed</hook_prompt>"
+        }
+      ]
+    },
+    {
+      "type": "function_call",
+      "name": "exec_command",
+      "arguments": "{\"cmd\":\"sed -n '1,220p' request-f79a035c.log && sed -n '1,220p' request-body.json && cat request-headers.json\"}",
+      "call_id": "call_GgABCmWvPYuP5ds9a4Fp0XST"
+    },
+    {
+      "type": "message",
+      "role": "developer",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "Bash reported command not found, permission denied, or a missing file/path. Verify the command, dependency installation, PATH, file permissions, and referenced paths before retrying."
+        }
+      ]
+    },
+    {
+      "type": "function_call_output",
+      "call_id": "call_GgABCmWvPYuP5ds9a4Fp0XST",
+      "output": "The Bash output indicates a command/setup failure that should be fixed before retrying."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Buffer interleaved non-tool messages while Responses-originated tool calls are still pending, then flush them only after the matching tool results are emitted downstream to `/v1/chat/completions`.

## Problem

The current `/v1/responses` compatibility path can generate an invalid upstream chat-completions transcript when a non-tool message is inserted between:

- an `assistant` message with `tool_calls`
- the matching `tool` message(s)

This was reproduced from the captured request artifacts:

Example of the malformed sequence:

```text
assistant(tool_calls=[call_GgABCmWvPYuP5ds9a4Fp0XST])
user("Bash reported `command not found`...")
tool(tool_call_id=call_GgABCmWvPYuP5ds9a4Fp0XST)
```

Strict OpenAI-compatible chat-completions executors can reject that transcript and return `500 Internal Server Error`.

## Root Cause

The Responses compatibility flow preserved item order too literally when converting Responses `input` items into upstream chat-completions `messages`.

That allowed injected diagnostic messages to land between pending tool calls and their matching tool outputs, violating the chat-completions tool-call contract.

## Fix

Added a small sanitizer in the OpenAI handler layer for chat-completions payloads produced from Responses-style input.

It now:

- buffers interleaved non-tool messages while tool results are pending
- flushes buffered messages only after all pending tool call IDs are satisfied
- merges consecutive assistant tool-call messages into a single assistant turn
- leaves already-valid transcripts unchanged

## Testing

Verified locally with:

```bash
gofmt -w sdk/api/handlers/openai/openai_handlers.go sdk/api/handlers/openai/openai_responses_chatcompletions_sanitizer.go sdk/api/handlers/openai/openai_responses_chatcompletions_sanitizer_test.go
go test ./sdk/api/handlers/openai -count=1
go build -o test-output ./cmd/server && rm test-output
```

Regression coverage added for:

- interleaved developer/user messages between `assistant.tool_calls` and matching `tool`
- consecutive assistant tool-call messages that should become one assistant turn
- already-valid transcripts remaining unchanged

---

# Incident Report: Responses-to-Chat-Completions Tool Call Ordering Bug

## Summary

A `/v1/responses` conversation could be converted into an invalid upstream `/v1/chat/completions` transcript when a non-tool message appeared between an assistant tool call and the matching tool result.

This was reproduced with the following captured artifacts:

- `request-742c1251.log`
- `request-f79a035c.log`
- `request-body-gid___axonhub_Request_104.json`
- `request-headers-gid___axonhub_Request_104.json`

The failing upstream request used the correct model (`skd/gpt5.4` on the local side, rewritten to `GPT-5.4` upstream), so this incident is **not** the earlier model-alias mismatch issue (`skd/gpt-5.4`).

## Impact

OpenAI-compatible upstream executors that strictly validate tool-call sequencing can reject the malformed transcript and return `500 Internal Server Error` instead of generating a model response.

## Symptoms

The replayed request in `request-f79a035c.log` failed with:

- local endpoint: `/v1/responses`
- upstream endpoint: `/v1/chat/completions`
- status: `500`
- body: `{"error":{"message":"Internal Server Error","type":"api_error"}}`

## Concrete Reproduction Evidence

The exported upstream payload in `request-body-gid___axonhub_Request_104.json` contains this invalid order near the end of the `messages` array:

1. `messages[19]`: `assistant` with `tool_calls = ["call_GgABCmWvPYuP5ds9a4Fp0XST"]`
2. `messages[20]`: `user` message beginning with `Bash reported \`command not found\``
3. `messages[21]`: `tool` message with `tool_call_id = "call_GgABCmWvPYuP5ds9a4Fp0XST"`

That sequence violates the chat-completions tool-call contract: once an assistant emits `tool_calls`, the transcript must provide the matching `tool` messages before any `user`, `system`, or additional `assistant` turns.

## Root Cause

The `/v1/responses` compatibility flow converted Responses input items to chat-completions messages in strict linear order.

That behavior was insufficient for tool-call chains because Responses payloads can contain intermediate non-tool messages (for example injected diagnostics such as:

- `Bash reported \`command not found\`, \`permission denied\`, or a missing file/path...`

) between a `function_call` item and the eventual `function_call_output` item.

The converter forwarded that intermediate message directly into the upstream `messages` array, which broke the required adjacency between:

- `assistant.tool_calls`
- matching `tool` messages

## Reproduction Procedure

1. Capture or replay a Responses-originated request that is routed into the OpenAI-compatibility `/v1/chat/completions` executor path.
2. Confirm the replay fails, as shown in `request-f79a035c.log`.
3. Inspect the exported upstream request body (`request-body-gid___axonhub_Request_104.json`).
4. Validate the message ordering with a simple pending-tool-call checker:

```python
import json
from pathlib import Path

body = json.loads(Path("request-body-gid___axonhub_Request_104.json").read_text())
pending = set()
for i, message in enumerate(body["messages"]):
    role = message.get("role")
    if pending and role != "tool":
        print("invalid order at", i, "role=", role, "pending=", sorted(pending))
        break
    if role == "assistant":
        for tool_call in message.get("tool_calls", []):
            if tool_call.get("id"):
                pending.add(tool_call["id"])
    if role == "tool":
        pending.discard(message.get("tool_call_id"))
```

Expected result before the fix: the checker reports the interleaved `user` message that appears before the pending tool result is supplied.

## Why This Was Hard to Spot

Large payload size, long AGENTS/system prompts, and many tool definitions were initially suspicious. Direct replay experiments showed those factors were not sufficient on their own to cause the failure. The decisive issue was the malformed message ordering inside the converted upstream chat-completions transcript.

## Fix

The handler now sanitizes chat-completions payloads produced from Responses-style input before forwarding them upstream.

The sanitizer does two things:

1. **Buffers interleaved non-tool messages** while tool calls are still pending.
2. **Flushes buffered messages only after all pending tool results arrive**, restoring a valid tool-call chain.
3. **Merges consecutive assistant tool-call messages** into a single assistant turn so parallel tool calls remain valid for strict chat-completions backends.

## Files Changed

- `sdk/api/handlers/openai/openai_handlers.go`
- `sdk/api/handlers/openai/openai_responses_chatcompletions_sanitizer.go`
- `sdk/api/handlers/openai/openai_responses_chatcompletions_sanitizer_test.go`

## Regression Coverage

Added tests for:

- interleaved developer/user messages between tool call and tool result
- consecutive assistant tool-call messages that should become a single assistant turn
- no-op behavior for already-valid transcripts

## Verification

Recommended verification commands:

```bash
gofmt -w sdk/api/handlers/openai/openai_handlers.go sdk/api/handlers/openai/openai_responses_chatcompletions_sanitizer.go sdk/api/handlers/openai/openai_responses_chatcompletions_sanitizer_test.go
go test ./sdk/api/handlers/openai -count=1
go build -o test-output ./cmd/server && rm test-output
```

## Remaining Risk

This fix preserves interleaved non-tool messages by reordering them after the pending tool-result chain. That is the safest chat-completions-compatible behavior, but it still changes transcript order relative to the original Responses payload. If a future backend supports richer mixed tool/message sequencing natively, the sanitizer may become unnecessary for that backend.