### PR TITLE
fix(codex): rebuild response.output in ExecuteStream

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -168,8 +168,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 
 	lines := bytes.Split(data, []byte("\n"))
-	outputItemsByIndex := make(map[int64][]byte)
-	var outputItemsFallback [][]byte
+	outputCollector := newCodexResponseOutputCollector()
 	for _, line := range lines {
 		if !bytes.HasPrefix(line, dataTag) {
 			continue
@@ -179,16 +178,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		eventType := gjson.GetBytes(eventData, "type").String()
 
 		if eventType == "response.output_item.done" {
-			itemResult := gjson.GetBytes(eventData, "item")
-			if !itemResult.Exists() || itemResult.Type != gjson.JSON {
-				continue
-			}
-			outputIndexResult := gjson.GetBytes(eventData, "output_index")
-			if outputIndexResult.Exists() {
-				outputItemsByIndex[outputIndexResult.Int()] = []byte(itemResult.Raw)
-			} else {
-				outputItemsFallback = append(outputItemsFallback, []byte(itemResult.Raw))
-			}
+			outputCollector.AddOutputItemDone(eventData)
 			continue
 		}
 
@@ -200,29 +190,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 			reporter.Publish(ctx, detail)
 		}
 
-		completedData := eventData
-		outputResult := gjson.GetBytes(completedData, "response.output")
-		shouldPatchOutput := (!outputResult.Exists() || !outputResult.IsArray() || len(outputResult.Array()) == 0) && (len(outputItemsByIndex) > 0 || len(outputItemsFallback) > 0)
-		if shouldPatchOutput {
-			completedDataPatched := completedData
-			completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output", []byte(`[]`))
-
-			indexes := make([]int64, 0, len(outputItemsByIndex))
-			for idx := range outputItemsByIndex {
-				indexes = append(indexes, idx)
-			}
-			sort.Slice(indexes, func(i, j int) bool {
-				return indexes[i] < indexes[j]
-			})
-			for _, idx := range indexes {
-				completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", outputItemsByIndex[idx])
-			}
-			for _, item := range outputItemsFallback {
-				completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", item)
-			}
-			completedData = completedDataPatched
-		}
-
+		completedData := outputCollector.PatchCompletedOutput(eventData)
 		var param any
 		out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, completedData, &param)
 		resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
@@ -414,14 +382,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
-		// Upstream Codex (ChatGPT backend) sometimes emits `response.completed`
-		// with an empty `response.output` array, expecting clients to reconstruct
-		// the final output from preceding `response.output_item.done` events.
-		// Mirror the non-streaming Execute fix (commit c8b7e2b, fixes #2583) here
-		// so that downstream clients (e.g. Amp's lw5 reducer) receive a populated
-		// output on the streaming path as well.
-		outputItemsByIndex := make(map[int64][]byte)
-		var outputItemsFallback [][]byte
+		outputCollector := newCodexResponseOutputCollector()
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
@@ -431,47 +392,16 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				eventType := gjson.GetBytes(eventData, "type").String()
 
 				if eventType == "response.output_item.done" {
-					itemResult := gjson.GetBytes(eventData, "item")
-					if itemResult.Exists() && itemResult.Type == gjson.JSON {
-						outputIndexResult := gjson.GetBytes(eventData, "output_index")
-						if outputIndexResult.Exists() {
-							outputItemsByIndex[outputIndexResult.Int()] = []byte(itemResult.Raw)
-						} else {
-							outputItemsFallback = append(outputItemsFallback, []byte(itemResult.Raw))
-						}
-					}
+					outputCollector.AddOutputItemDone(eventData)
 				}
 
 				if eventType == "response.completed" {
 					if detail, ok := helps.ParseCodexUsage(eventData); ok {
 						reporter.Publish(ctx, detail)
 					}
-					outputResult := gjson.GetBytes(eventData, "response.output")
-					shouldPatchOutput := (!outputResult.Exists() || !outputResult.IsArray() || len(outputResult.Array()) == 0) && (len(outputItemsByIndex) > 0 || len(outputItemsFallback) > 0)
-					if shouldPatchOutput {
-						completedDataPatched := eventData
-						completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output", []byte(`[]`))
-
-						indexes := make([]int64, 0, len(outputItemsByIndex))
-						for idx := range outputItemsByIndex {
-							indexes = append(indexes, idx)
-						}
-						sort.Slice(indexes, func(i, j int) bool {
-							return indexes[i] < indexes[j]
-						})
-						for _, idx := range indexes {
-							completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", outputItemsByIndex[idx])
-						}
-						for _, item := range outputItemsFallback {
-							completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", item)
-						}
-
-						// Rebuild the SSE `data:` line with the patched JSON so
-						// downstream translators and clients see the full output.
-						rebuilt := make([]byte, 0, len(completedDataPatched)+6)
-						rebuilt = append(rebuilt, []byte("data: ")...)
-						rebuilt = append(rebuilt, completedDataPatched...)
-						line = rebuilt
+					completedData := outputCollector.PatchCompletedOutput(eventData)
+					if !bytes.Equal(completedData, eventData) {
+						line = rebuildSSEDataLine(completedData)
 					}
 				}
 			}
@@ -488,6 +418,64 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+type codexResponseOutputCollector struct {
+	byIndex  map[int64][]byte
+	fallback [][]byte
+}
+
+func newCodexResponseOutputCollector() codexResponseOutputCollector {
+	return codexResponseOutputCollector{byIndex: make(map[int64][]byte)}
+}
+
+func (c *codexResponseOutputCollector) AddOutputItemDone(eventData []byte) {
+	itemResult := gjson.GetBytes(eventData, "item")
+	if !itemResult.Exists() || itemResult.Type != gjson.JSON {
+		return
+	}
+
+	item := []byte(itemResult.Raw)
+	outputIndexResult := gjson.GetBytes(eventData, "output_index")
+	if outputIndexResult.Exists() {
+		c.byIndex[outputIndexResult.Int()] = item
+		return
+	}
+	c.fallback = append(c.fallback, item)
+}
+
+func (c *codexResponseOutputCollector) PatchCompletedOutput(eventData []byte) []byte {
+	outputResult := gjson.GetBytes(eventData, "response.output")
+	shouldPatchOutput := (!outputResult.Exists() || !outputResult.IsArray() || len(outputResult.Array()) == 0) &&
+		(len(c.byIndex) > 0 || len(c.fallback) > 0)
+	if !shouldPatchOutput {
+		return eventData
+	}
+
+	completedDataPatched := bytes.Clone(eventData)
+	completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output", []byte(`[]`))
+
+	indexes := make([]int64, 0, len(c.byIndex))
+	for idx := range c.byIndex {
+		indexes = append(indexes, idx)
+	}
+	sort.Slice(indexes, func(i, j int) bool {
+		return indexes[i] < indexes[j]
+	})
+	for _, idx := range indexes {
+		completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", c.byIndex[idx])
+	}
+	for _, item := range c.fallback {
+		completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", item)
+	}
+	return completedDataPatched
+}
+
+func rebuildSSEDataLine(eventData []byte) []byte {
+	line := make([]byte, 0, len(eventData)+6)
+	line = append(line, []byte("data: ")...)
+	line = append(line, eventData...)
+	return line
 }
 
 func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -168,7 +168,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 
 	lines := bytes.Split(data, []byte("\n"))
-	outputCollector := newCodexResponseOutputCollector()
+	outputItems := codexOutputItems{byIndex: make(map[int64][]byte)}
 	for _, line := range lines {
 		if !bytes.HasPrefix(line, dataTag) {
 			continue
@@ -178,7 +178,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		eventType := gjson.GetBytes(eventData, "type").String()
 
 		if eventType == "response.output_item.done" {
-			outputCollector.AddOutputItemDone(eventData)
+			outputItems.addDoneEvent(eventData)
 			continue
 		}
 
@@ -190,7 +190,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 			reporter.Publish(ctx, detail)
 		}
 
-		completedData := outputCollector.PatchCompletedOutput(eventData)
+		completedData := outputItems.patchCompleted(eventData)
 		var param any
 		out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, completedData, &param)
 		resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
@@ -382,7 +382,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
-		outputCollector := newCodexResponseOutputCollector()
+		outputItems := codexOutputItems{byIndex: make(map[int64][]byte)}
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
@@ -392,14 +392,14 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				eventType := gjson.GetBytes(eventData, "type").String()
 
 				if eventType == "response.output_item.done" {
-					outputCollector.AddOutputItemDone(eventData)
+					outputItems.addDoneEvent(eventData)
 				}
 
 				if eventType == "response.completed" {
 					if detail, ok := helps.ParseCodexUsage(eventData); ok {
 						reporter.Publish(ctx, detail)
 					}
-					completedData := outputCollector.PatchCompletedOutput(eventData)
+					completedData := outputItems.patchCompleted(eventData)
 					if !bytes.Equal(completedData, eventData) {
 						line = rebuildSSEDataLine(completedData)
 					}
@@ -420,16 +420,12 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }
 
-type codexResponseOutputCollector struct {
+type codexOutputItems struct {
 	byIndex  map[int64][]byte
 	fallback [][]byte
 }
 
-func newCodexResponseOutputCollector() codexResponseOutputCollector {
-	return codexResponseOutputCollector{byIndex: make(map[int64][]byte)}
-}
-
-func (c *codexResponseOutputCollector) AddOutputItemDone(eventData []byte) {
+func (o *codexOutputItems) addDoneEvent(eventData []byte) {
 	itemResult := gjson.GetBytes(eventData, "item")
 	if !itemResult.Exists() || itemResult.Type != gjson.JSON {
 		return
@@ -438,16 +434,16 @@ func (c *codexResponseOutputCollector) AddOutputItemDone(eventData []byte) {
 	item := []byte(itemResult.Raw)
 	outputIndexResult := gjson.GetBytes(eventData, "output_index")
 	if outputIndexResult.Exists() {
-		c.byIndex[outputIndexResult.Int()] = item
+		o.byIndex[outputIndexResult.Int()] = item
 		return
 	}
-	c.fallback = append(c.fallback, item)
+	o.fallback = append(o.fallback, item)
 }
 
-func (c *codexResponseOutputCollector) PatchCompletedOutput(eventData []byte) []byte {
+func (o *codexOutputItems) patchCompleted(eventData []byte) []byte {
 	outputResult := gjson.GetBytes(eventData, "response.output")
 	shouldPatchOutput := (!outputResult.Exists() || !outputResult.IsArray() || len(outputResult.Array()) == 0) &&
-		(len(c.byIndex) > 0 || len(c.fallback) > 0)
+		(len(o.byIndex) > 0 || len(o.fallback) > 0)
 	if !shouldPatchOutput {
 		return eventData
 	}
@@ -455,17 +451,17 @@ func (c *codexResponseOutputCollector) PatchCompletedOutput(eventData []byte) []
 	completedDataPatched := bytes.Clone(eventData)
 	completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output", []byte(`[]`))
 
-	indexes := make([]int64, 0, len(c.byIndex))
-	for idx := range c.byIndex {
+	indexes := make([]int64, 0, len(o.byIndex))
+	for idx := range o.byIndex {
 		indexes = append(indexes, idx)
 	}
 	sort.Slice(indexes, func(i, j int) bool {
 		return indexes[i] < indexes[j]
 	})
 	for _, idx := range indexes {
-		completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", c.byIndex[idx])
+		completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", o.byIndex[idx])
 	}
-	for _, item := range c.fallback {
+	for _, item := range o.fallback {
 		completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", item)
 	}
 	return completedDataPatched

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -414,15 +414,64 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
+		// Upstream Codex (ChatGPT backend) sometimes emits `response.completed`
+		// with an empty `response.output` array, expecting clients to reconstruct
+		// the final output from preceding `response.output_item.done` events.
+		// Mirror the non-streaming Execute fix (commit c8b7e2b, fixes #2583) here
+		// so that downstream clients (e.g. Amp's lw5 reducer) receive a populated
+		// output on the streaming path as well.
+		outputItemsByIndex := make(map[int64][]byte)
+		var outputItemsFallback [][]byte
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 
 			if bytes.HasPrefix(line, dataTag) {
-				data := bytes.TrimSpace(line[5:])
-				if gjson.GetBytes(data, "type").String() == "response.completed" {
-					if detail, ok := helps.ParseCodexUsage(data); ok {
+				eventData := bytes.TrimSpace(line[5:])
+				eventType := gjson.GetBytes(eventData, "type").String()
+
+				if eventType == "response.output_item.done" {
+					itemResult := gjson.GetBytes(eventData, "item")
+					if itemResult.Exists() && itemResult.Type == gjson.JSON {
+						outputIndexResult := gjson.GetBytes(eventData, "output_index")
+						if outputIndexResult.Exists() {
+							outputItemsByIndex[outputIndexResult.Int()] = []byte(itemResult.Raw)
+						} else {
+							outputItemsFallback = append(outputItemsFallback, []byte(itemResult.Raw))
+						}
+					}
+				}
+
+				if eventType == "response.completed" {
+					if detail, ok := helps.ParseCodexUsage(eventData); ok {
 						reporter.Publish(ctx, detail)
+					}
+					outputResult := gjson.GetBytes(eventData, "response.output")
+					shouldPatchOutput := (!outputResult.Exists() || !outputResult.IsArray() || len(outputResult.Array()) == 0) && (len(outputItemsByIndex) > 0 || len(outputItemsFallback) > 0)
+					if shouldPatchOutput {
+						completedDataPatched := eventData
+						completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output", []byte(`[]`))
+
+						indexes := make([]int64, 0, len(outputItemsByIndex))
+						for idx := range outputItemsByIndex {
+							indexes = append(indexes, idx)
+						}
+						sort.Slice(indexes, func(i, j int) bool {
+							return indexes[i] < indexes[j]
+						})
+						for _, idx := range indexes {
+							completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", outputItemsByIndex[idx])
+						}
+						for _, item := range outputItemsFallback {
+							completedDataPatched, _ = sjson.SetRawBytes(completedDataPatched, "response.output.-1", item)
+						}
+
+						// Rebuild the SSE `data:` line with the patched JSON so
+						// downstream translators and clients see the full output.
+						rebuilt := make([]byte, 0, len(completedDataPatched)+6)
+						rebuilt = append(rebuilt, []byte("data: ")...)
+						rebuilt = append(rebuilt, completedDataPatched...)
+						line = rebuilt
 					}
 				}
 			}

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,31 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	"github.com/tidwall/gjson"
 )
+
+func TestCodexResponseOutputCollectorPatchCompletedOutput_SortsByOutputIndex(t *testing.T) {
+	collector := newCodexResponseOutputCollector()
+	collector.AddOutputItemDone([]byte(`{"type":"response.output_item.done","item":{"type":"message","id":"msg_2"},"output_index":2}`))
+	collector.AddOutputItemDone([]byte(`{"type":"response.output_item.done","item":{"type":"message","id":"msg_0"},"output_index":0}`))
+	collector.AddOutputItemDone([]byte(`{"type":"response.output_item.done","item":{"type":"message","id":"msg_fallback"}}`))
+
+	patched := collector.PatchCompletedOutput([]byte(`{"type":"response.completed","response":{"id":"resp_1","output":[]}}`))
+	output := gjson.GetBytes(patched, "response.output")
+	if !output.IsArray() {
+		t.Fatalf("response.output should be an array: %s", patched)
+	}
+	if len(output.Array()) != 3 {
+		t.Fatalf("response.output length = %d, want 3; payload=%s", len(output.Array()), patched)
+	}
+	if output.Array()[0].Get("id").String() != "msg_0" {
+		t.Fatalf("response.output[0].id = %q, want %q; payload=%s", output.Array()[0].Get("id").String(), "msg_0", patched)
+	}
+	if output.Array()[1].Get("id").String() != "msg_2" {
+		t.Fatalf("response.output[1].id = %q, want %q; payload=%s", output.Array()[1].Get("id").String(), "msg_2", patched)
+	}
+	if output.Array()[2].Get("id").String() != "msg_fallback" {
+		t.Fatalf("response.output[2].id = %q, want %q; payload=%s", output.Array()[2].Get("id").String(), "msg_fallback", patched)
+	}
+}
 
 func TestCodexExecutorExecute_EmptyStreamCompletionOutputUsesOutputItemDone(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42,5 +68,65 @@ func TestCodexExecutorExecute_EmptyStreamCompletionOutputUsesOutputItemDone(t *t
 	gotContent := gjson.GetBytes(resp.Payload, "choices.0.message.content").String()
 	if gotContent != "ok" {
 		t.Fatalf("choices.0.message.content = %q, want %q; payload=%s", gotContent, "ok", string(resp.Payload))
+	}
+}
+
+func TestCodexExecutorExecuteStream_EmptyStreamCompletionOutputUsesOutputItemDone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]},\"output_index\":0}\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":1775555723,\"status\":\"completed\",\"model\":\"gpt-5.4-mini-2026-03-17\",\"output\":[],\"usage\":{\"input_tokens\":8,\"output_tokens\":28,\"total_tokens\":36}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4-mini",
+		Payload: []byte(`{"model":"gpt-5.4-mini","input":"Say ok","stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var stream bytes.Buffer
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+		stream.Write(chunk.Payload)
+		stream.WriteByte('\n')
+	}
+
+	var completedData []byte
+	for _, line := range bytes.Split(stream.Bytes(), []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(line[len("data:"):])
+		if gjson.GetBytes(data, "type").String() != "response.completed" {
+			continue
+		}
+		completedData = append([]byte(nil), data...)
+	}
+	if len(completedData) == 0 {
+		t.Fatalf("missing response.completed event in stream: %s", stream.Bytes())
+	}
+
+	output := gjson.GetBytes(completedData, "response.output")
+	if !output.IsArray() || len(output.Array()) == 0 {
+		t.Fatalf("response.output should be populated: %s", completedData)
+	}
+	gotContent := output.Array()[0].Get("content.0.text").String()
+	if gotContent != "ok" {
+		t.Fatalf("response.output[0].content[0].text = %q, want %q; payload=%s", gotContent, "ok", completedData)
 	}
 }

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -15,13 +15,13 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestCodexResponseOutputCollectorPatchCompletedOutput_SortsByOutputIndex(t *testing.T) {
-	collector := newCodexResponseOutputCollector()
-	collector.AddOutputItemDone([]byte(`{"type":"response.output_item.done","item":{"type":"message","id":"msg_2"},"output_index":2}`))
-	collector.AddOutputItemDone([]byte(`{"type":"response.output_item.done","item":{"type":"message","id":"msg_0"},"output_index":0}`))
-	collector.AddOutputItemDone([]byte(`{"type":"response.output_item.done","item":{"type":"message","id":"msg_fallback"}}`))
+func TestCodexOutputItemsPatchCompleted_SortsByOutputIndex(t *testing.T) {
+	items := codexOutputItems{byIndex: make(map[int64][]byte)}
+	items.addDoneEvent([]byte(`{"type":"response.output_item.done","item":{"type":"message","id":"msg_2"},"output_index":2}`))
+	items.addDoneEvent([]byte(`{"type":"response.output_item.done","item":{"type":"message","id":"msg_0"},"output_index":0}`))
+	items.addDoneEvent([]byte(`{"type":"response.output_item.done","item":{"type":"message","id":"msg_fallback"}}`))
 
-	patched := collector.PatchCompletedOutput([]byte(`{"type":"response.completed","response":{"id":"resp_1","output":[]}}`))
+	patched := items.patchCompleted([]byte(`{"type":"response.completed","response":{"id":"resp_1","output":[]}}`))
 	output := gjson.GetBytes(patched, "response.output")
 	if !output.IsArray() {
 		t.Fatalf("response.output should be an array: %s", patched)


### PR DESCRIPTION
This fixes Codex streaming responses when the upstream backend sends an empty `response.output` in the final `response.completed` event.

After the upstream protocol change, CLIProxyAPI was updated to handle this in the non-streaming path in #2583. The streaming path was left unchanged, so `ExecuteStream` still forwarded a final `response.completed` event with empty `response.output`.

Clients that rely on `response.completed.response.output` then see no final output. In practice this broke Amp deep with `gpt-5.4`, where the stream completed but the final result was empty.

This change collects earlier `response.output_item.done` items during SSE processing and uses them to rebuild `response.completed.response.output` when needed. Usage reporting stays unchanged.

Related:
- related to #2583
- fixes #2585

Tested with a streamed `/v1/responses` request against the current backend behavior. Before the change, the final `response.completed` event had `output: []`. After the change, it contains the reconstructed assistant message and downstream clients return a non-empty result.
