### PR TITLE
fix(executor): recover empty codex stream completions

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -36,6 +36,220 @@ const (
 
 var dataTag = []byte("data:")
 
+type codexStreamFunctionCallState struct {
+	ItemID      string
+	CallID      string
+	Name        string
+	Arguments   string
+	OutputIndex int64
+}
+
+type codexStreamCompletionState struct {
+	outputItemsByIndex  map[int64][]byte
+	outputItemsFallback [][]byte
+	functionCallsByItem map[string]*codexStreamFunctionCallState
+}
+
+func newCodexStreamCompletionState() *codexStreamCompletionState {
+	return &codexStreamCompletionState{
+		outputItemsByIndex:  make(map[int64][]byte),
+		functionCallsByItem: make(map[string]*codexStreamFunctionCallState),
+	}
+}
+
+func (s *codexStreamCompletionState) functionCallByItem(itemID string, outputIndex int64) *codexStreamFunctionCallState {
+	if s == nil {
+		return nil
+	}
+	itemID = strings.TrimSpace(itemID)
+	if itemID != "" {
+		if state, ok := s.functionCallsByItem[itemID]; ok && state != nil {
+			return state
+		}
+	}
+	if outputIndex < 0 {
+		return nil
+	}
+	for _, state := range s.functionCallsByItem {
+		if state != nil && state.OutputIndex == outputIndex {
+			return state
+		}
+	}
+	return nil
+}
+
+func (s *codexStreamCompletionState) recordEvent(eventData []byte) {
+	if s == nil || len(eventData) == 0 {
+		return
+	}
+
+	eventType := gjson.GetBytes(eventData, "type").String()
+	switch eventType {
+	case "response.output_item.done":
+		itemResult := gjson.GetBytes(eventData, "item")
+		if !itemResult.Exists() || itemResult.Type != gjson.JSON {
+			return
+		}
+		outputIndexResult := gjson.GetBytes(eventData, "output_index")
+		if outputIndexResult.Exists() {
+			s.outputItemsByIndex[outputIndexResult.Int()] = []byte(itemResult.Raw)
+			return
+		}
+		s.outputItemsFallback = append(s.outputItemsFallback, []byte(itemResult.Raw))
+	case "response.output_item.added":
+		item := gjson.GetBytes(eventData, "item")
+		if !item.Exists() || item.Get("type").String() != "function_call" {
+			return
+		}
+		itemID := strings.TrimSpace(item.Get("id").String())
+		if itemID == "" {
+			return
+		}
+		state := s.functionCallByItem(itemID, gjson.GetBytes(eventData, "output_index").Int())
+		if state == nil {
+			state = &codexStreamFunctionCallState{
+				ItemID:      itemID,
+				OutputIndex: gjson.GetBytes(eventData, "output_index").Int(),
+			}
+			s.functionCallsByItem[itemID] = state
+		}
+		if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
+			state.CallID = callID
+		}
+		if name := strings.TrimSpace(item.Get("name").String()); name != "" {
+			state.Name = name
+		}
+	case "response.function_call_arguments.delta":
+		itemID := strings.TrimSpace(gjson.GetBytes(eventData, "item_id").String())
+		outputIndex := gjson.GetBytes(eventData, "output_index").Int()
+		state := s.functionCallByItem(itemID, outputIndex)
+		if state == nil {
+			return
+		}
+		if delta := gjson.GetBytes(eventData, "delta").String(); delta != "" {
+			state.Arguments += delta
+		}
+	case "response.function_call_arguments.done":
+		itemID := strings.TrimSpace(gjson.GetBytes(eventData, "item_id").String())
+		outputIndex := gjson.GetBytes(eventData, "output_index").Int()
+		state := s.functionCallByItem(itemID, outputIndex)
+		if state == nil {
+			return
+		}
+		if arguments := gjson.GetBytes(eventData, "arguments").String(); arguments != "" {
+			state.Arguments = arguments
+		}
+	}
+}
+
+func (s *codexStreamCompletionState) patchCompletedOutputIfEmpty(completedData []byte) ([]byte, int) {
+	if s == nil || len(completedData) == 0 {
+		return completedData, 0
+	}
+
+	outputResult := gjson.GetBytes(completedData, "response.output")
+	if outputResult.Exists() && outputResult.IsArray() && len(outputResult.Array()) > 0 {
+		return completedData, 0
+	}
+
+	type recoveredItem struct {
+		outputIndex int64
+		raw         []byte
+	}
+
+	recovered := make([]recoveredItem, 0, len(s.outputItemsByIndex)+len(s.outputItemsFallback)+len(s.functionCallsByItem))
+	seenCallIDs := make(map[string]struct{}, len(s.functionCallsByItem))
+	seenItemIDs := make(map[string]struct{}, len(s.functionCallsByItem))
+
+	indexes := make([]int64, 0, len(s.outputItemsByIndex))
+	for idx := range s.outputItemsByIndex {
+		indexes = append(indexes, idx)
+	}
+	sort.Slice(indexes, func(i, j int) bool { return indexes[i] < indexes[j] })
+	for _, idx := range indexes {
+		raw := s.outputItemsByIndex[idx]
+		recovered = append(recovered, recoveredItem{outputIndex: idx, raw: raw})
+		if callID := strings.TrimSpace(gjson.GetBytes(raw, "call_id").String()); callID != "" {
+			seenCallIDs[callID] = struct{}{}
+		}
+		if itemID := strings.TrimSpace(gjson.GetBytes(raw, "id").String()); itemID != "" {
+			seenItemIDs[itemID] = struct{}{}
+		}
+	}
+	for _, raw := range s.outputItemsFallback {
+		recovered = append(recovered, recoveredItem{outputIndex: int64(len(indexes) + len(recovered)), raw: raw})
+		if callID := strings.TrimSpace(gjson.GetBytes(raw, "call_id").String()); callID != "" {
+			seenCallIDs[callID] = struct{}{}
+		}
+		if itemID := strings.TrimSpace(gjson.GetBytes(raw, "id").String()); itemID != "" {
+			seenItemIDs[itemID] = struct{}{}
+		}
+	}
+
+	if len(s.functionCallsByItem) > 0 {
+		keys := make([]string, 0, len(s.functionCallsByItem))
+		for key := range s.functionCallsByItem {
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			left := s.functionCallsByItem[keys[i]]
+			right := s.functionCallsByItem[keys[j]]
+			if left == nil || right == nil {
+				return keys[i] < keys[j]
+			}
+			if left.OutputIndex != right.OutputIndex {
+				return left.OutputIndex < right.OutputIndex
+			}
+			return keys[i] < keys[j]
+		})
+		for _, key := range keys {
+			state := s.functionCallsByItem[key]
+			if state == nil || strings.TrimSpace(state.CallID) == "" {
+				continue
+			}
+			if _, ok := seenCallIDs[state.CallID]; ok {
+				continue
+			}
+			if _, ok := seenItemIDs[state.ItemID]; ok {
+				continue
+			}
+
+			args := state.Arguments
+			if strings.TrimSpace(args) == "" {
+				args = "{}"
+			}
+			itemID := state.ItemID
+			if strings.TrimSpace(itemID) == "" {
+				itemID = fmt.Sprintf("fc_%s", state.CallID)
+			}
+
+			item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
+			item, _ = sjson.SetBytes(item, "id", itemID)
+			item, _ = sjson.SetBytes(item, "arguments", args)
+			item, _ = sjson.SetBytes(item, "call_id", state.CallID)
+			item, _ = sjson.SetBytes(item, "name", state.Name)
+			recovered = append(recovered, recoveredItem{outputIndex: state.OutputIndex, raw: item})
+			seenCallIDs[state.CallID] = struct{}{}
+			seenItemIDs[itemID] = struct{}{}
+		}
+	}
+
+	if len(recovered) == 0 {
+		return completedData, 0
+	}
+
+	sort.SliceStable(recovered, func(i, j int) bool {
+		return recovered[i].outputIndex < recovered[j].outputIndex
+	})
+
+	patched := completedData
+	patched, _ = sjson.SetRawBytes(patched, "response.output", []byte(`[]`))
+	for _, item := range recovered {
+		patched, _ = sjson.SetRawBytes(patched, "response.output.-1", item.raw)
+	}
+	return patched, len(recovered)
+}
+
 // CodexExecutor is a stateless executor for Codex (OpenAI Responses API entrypoint).
 // If api_key is unavailable on auth, it falls back to legacy via ClientAdapter.
 type CodexExecutor struct {
@@ -414,16 +628,35 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
+		streamState := newCodexStreamCompletionState()
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 
 			if bytes.HasPrefix(line, dataTag) {
 				data := bytes.TrimSpace(line[5:])
+				streamState.recordEvent(data)
 				if gjson.GetBytes(data, "type").String() == "response.completed" {
 					if detail, ok := helps.ParseCodexUsage(data); ok {
 						reporter.Publish(ctx, detail)
 					}
+					if patched, recoveredCount := streamState.patchCompletedOutputIfEmpty(data); recoveredCount > 0 {
+						log.Warnf(
+							"codex stream completed with empty response.output; recovered_items=%d cached_done_items=%d cached_function_calls=%d",
+							recoveredCount,
+							len(streamState.outputItemsByIndex)+len(streamState.outputItemsFallback),
+							len(streamState.functionCallsByItem),
+						)
+						data = patched
+					} else {
+						log.Warnf(
+							"codex stream completed with empty response.output and no recoverable items; cached_done_items=%d cached_function_calls=%d",
+							len(streamState.outputItemsByIndex)+len(streamState.outputItemsFallback),
+							len(streamState.functionCallsByItem),
+						)
+					}
+					line = append(append([]byte{}, dataTag...), ' ')
+					line = append(line, data...)
 				}
 			}
 

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -42,5 +43,129 @@ func TestCodexExecutorExecute_EmptyStreamCompletionOutputUsesOutputItemDone(t *t
 	gotContent := gjson.GetBytes(resp.Payload, "choices.0.message.content").String()
 	if gotContent != "ok" {
 		t.Fatalf("choices.0.message.content = %q, want %q; payload=%s", gotContent, "ok", string(resp.Payload))
+	}
+}
+
+func TestCodexExecutorExecuteStream_EmptyCompletionOutputUsesOutputItemDone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]},\"output_index\":0}\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":1775555723,\"status\":\"completed\",\"model\":\"gpt-5.4-mini-2026-03-17\",\"output\":[],\"usage\":{\"input_tokens\":8,\"output_tokens\":28,\"total_tokens\":36}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":"Say ok","stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var chunks [][]byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		chunks = append(chunks, chunk.Payload)
+	}
+
+	var completedPayload []byte
+	for _, chunk := range chunks {
+		text := strings.TrimSpace(string(chunk))
+		if !strings.HasPrefix(text, "data: ") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(text, "data: "))
+		if gjson.Get(payload, "type").String() != "response.completed" {
+			continue
+		}
+		completedPayload = []byte(payload)
+		break
+	}
+	if len(completedPayload) == 0 {
+		t.Fatalf("missing response.completed chunk in stream: %q", chunks)
+	}
+
+	output := gjson.GetBytes(completedPayload, "response.output")
+	if !output.Exists() || len(output.Array()) != 1 {
+		t.Fatalf("response.output = %s, want 1 recovered item; completed=%s", output.Raw, string(completedPayload))
+	}
+	if got := output.Array()[0].Get("content.0.text").String(); got != "ok" {
+		t.Fatalf("response.output[0].content[0].text = %q, want %q; completed=%s", got, "ok", string(completedPayload))
+	}
+}
+
+func TestCodexExecutorExecuteStream_EmptyCompletionOutputUsesFunctionCallState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"id\":\"fc_call_1\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_1\",\"name\":\"skill\"}}\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_call_1\",\"output_index\":1,\"delta\":\"{\\\"path\\\":\\\"README.md\\\"}\"}\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc_call_1\",\"output_index\":1,\"arguments\":\"{\\\"path\\\":\\\"README.md\\\"}\"}\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_2\",\"object\":\"response\",\"created_at\":1775555723,\"status\":\"completed\",\"model\":\"gpt-5.4-2026-03-05\",\"output\":[],\"usage\":{\"input_tokens\":8,\"output_tokens\":28,\"total_tokens\":36}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":"Use a tool","stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var completedPayload []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		text := strings.TrimSpace(string(chunk.Payload))
+		if !strings.HasPrefix(text, "data: ") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(text, "data: "))
+		if gjson.Get(payload, "type").String() != "response.completed" {
+			continue
+		}
+		completedPayload = []byte(payload)
+	}
+	if len(completedPayload) == 0 {
+		t.Fatal("missing response.completed chunk")
+	}
+
+	output := gjson.GetBytes(completedPayload, "response.output")
+	if !output.Exists() || len(output.Array()) != 1 {
+		t.Fatalf("response.output = %s, want 1 recovered function_call; completed=%s", output.Raw, string(completedPayload))
+	}
+	item := output.Array()[0]
+	if got := item.Get("type").String(); got != "function_call" {
+		t.Fatalf("response.output[0].type = %q, want %q; completed=%s", got, "function_call", string(completedPayload))
+	}
+	if got := item.Get("call_id").String(); got != "call_1" {
+		t.Fatalf("response.output[0].call_id = %q, want %q; completed=%s", got, "call_1", string(completedPayload))
+	}
+	if got := item.Get("name").String(); got != "skill" {
+		t.Fatalf("response.output[0].name = %q, want %q; completed=%s", got, "skill", string(completedPayload))
+	}
+	if got := item.Get("arguments").String(); got != "{\"path\":\"README.md\"}" {
+		t.Fatalf("response.output[0].arguments = %q, want %q; completed=%s", got, "{\"path\":\"README.md\"}", string(completedPayload))
 	}
 }


### PR DESCRIPTION
## Summary
- cache Codex stream output items and function call state while consuming SSE events
- recover `response.output` when `response.completed` arrives with an empty output array
- add regression coverage for message output recovery and function call recovery in stream mode

## Background
Some Codex/OpenAI Responses streams emit `response.output_item.done` or function call argument events, but end with `response.completed.response.output=[]`.

The non-stream path already had recovery logic for empty completed output, while `ExecuteStream` did not. That mismatch can leave downstream clients with an empty final response even though the stream already carried recoverable output state.

## Testing
- `go test ./internal/runtime/executor -run 'TestCodexExecutorExecute(Stream)?_Empty' -count=1`
- `go test ./internal/runtime/executor -count=1`
