### PR TITLE
feat(antigravity): add per-credential antigravity_credits toggle

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -464,6 +464,19 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 			}
 		}
 	}
+	// Expose per-credential antigravity_credits toggle for antigravity auths.
+	if strings.EqualFold(strings.TrimSpace(auth.Provider), "antigravity") {
+		acEnabled := strings.EqualFold(strings.TrimSpace(authAttribute(auth, "antigravity_credits")), "true")
+		if !acEnabled && auth.Metadata != nil {
+			switch v := auth.Metadata["antigravity_credits"].(type) {
+			case bool:
+				acEnabled = v
+			case string:
+				acEnabled = strings.EqualFold(strings.TrimSpace(v), "true")
+			}
+		}
+		entry["antigravity_credits"] = acEnabled
+	}
 	return entry
 }
 
@@ -1128,12 +1141,13 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 	}
 
 	var req struct {
-		Name     string            `json:"name"`
-		Prefix   *string           `json:"prefix"`
-		ProxyURL *string           `json:"proxy_url"`
-		Headers  map[string]string `json:"headers"`
-		Priority *int              `json:"priority"`
-		Note     *string           `json:"note"`
+		Name               string            `json:"name"`
+		Prefix             *string           `json:"prefix"`
+		ProxyURL           *string           `json:"proxy_url"`
+		Headers            map[string]string `json:"headers"`
+		Priority           *int              `json:"priority"`
+		Note               *string           `json:"note"`
+		AntigravityCredits *bool             `json:"antigravity_credits"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -1296,6 +1310,22 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 				targetAuth.Metadata["note"] = trimmedNote
 				targetAuth.Attributes["note"] = trimmedNote
 			}
+		}
+		changed = true
+	}
+	if req.AntigravityCredits != nil {
+		if targetAuth.Metadata == nil {
+			targetAuth.Metadata = make(map[string]any)
+		}
+		if targetAuth.Attributes == nil {
+			targetAuth.Attributes = make(map[string]string)
+		}
+		if *req.AntigravityCredits {
+			targetAuth.Metadata["antigravity_credits"] = true
+			targetAuth.Attributes["antigravity_credits"] = "true"
+		} else {
+			delete(targetAuth.Metadata, "antigravity_credits")
+			delete(targetAuth.Attributes, "antigravity_credits")
 		}
 		changed = true
 	}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -291,11 +291,26 @@ func antigravityCreditsRetryEnabled(cfg *config.Config) bool {
 // antigravity_credits toggle is on. When true, every request for this auth
 // unconditionally includes enabledCreditTypes=["GOOGLE_ONE_AI"] — no
 // prefer/exhausted state machine, no retry fallback.
+// It checks Attributes first (set by the synthesizer) and falls back to
+// Metadata (set by UploadAuthFile without synthesizer).
 func antigravityCreditsAlwaysEnabled(auth *cliproxyauth.Auth) bool {
-	if auth == nil || len(auth.Attributes) == 0 {
+	if auth == nil {
 		return false
 	}
-	return strings.EqualFold(strings.TrimSpace(auth.Attributes["antigravity_credits"]), "true")
+	if len(auth.Attributes) > 0 {
+		if strings.EqualFold(strings.TrimSpace(auth.Attributes["antigravity_credits"]), "true") {
+			return true
+		}
+	}
+	if auth.Metadata != nil {
+		switch v := auth.Metadata["antigravity_credits"].(type) {
+		case bool:
+			return v
+		case string:
+			return strings.EqualFold(strings.TrimSpace(v), "true")
+		}
+	}
+	return false
 }
 
 func antigravityCreditsExhausted(auth *cliproxyauth.Auth, now time.Time) bool {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -287,6 +287,17 @@ func antigravityCreditsRetryEnabled(cfg *config.Config) bool {
 	return cfg != nil && cfg.QuotaExceeded.AntigravityCredits
 }
 
+// antigravityCreditsAlwaysEnabled returns true when the per-credential
+// antigravity_credits toggle is on. When true, every request for this auth
+// unconditionally includes enabledCreditTypes=["GOOGLE_ONE_AI"] — no
+// prefer/exhausted state machine, no retry fallback.
+func antigravityCreditsAlwaysEnabled(auth *cliproxyauth.Auth) bool {
+	if auth == nil || len(auth.Attributes) == 0 {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(auth.Attributes["antigravity_credits"]), "true")
+}
+
 func antigravityCreditsExhausted(auth *cliproxyauth.Auth, now time.Time) bool {
 	if auth == nil || strings.TrimSpace(auth.ID) == "" {
 		return false
@@ -520,10 +531,18 @@ attemptLoop:
 		var lastBody []byte
 		var lastErr error
 
+		creditsAlwaysOn := antigravityCreditsAlwaysEnabled(auth)
+
 		for idx, baseURL := range baseURLs {
 			requestPayload := translated
 			usedCreditsDirect := false
-			if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
+			if creditsAlwaysOn {
+				// Per-credential toggle: unconditionally inject credits on every request.
+				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
+					requestPayload = creditsPayload
+					usedCreditsDirect = true
+				}
+			} else if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
 				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
 					requestPayload = creditsPayload
 					usedCreditsDirect = true
@@ -564,7 +583,7 @@ attemptLoop:
 			}
 			helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
 
-			if httpResp.StatusCode == http.StatusTooManyRequests {
+			if httpResp.StatusCode == http.StatusTooManyRequests && !creditsAlwaysOn {
 				if usedCreditsDirect {
 					if shouldMarkAntigravityCreditsExhausted(httpResp.StatusCode, bodyBytes, nil) {
 						clearAntigravityPreferCredits(auth, baseModel)
@@ -696,10 +715,17 @@ attemptLoop:
 		var lastBody []byte
 		var lastErr error
 
+		creditsAlwaysOn := antigravityCreditsAlwaysEnabled(auth)
+
 		for idx, baseURL := range baseURLs {
 			requestPayload := translated
 			usedCreditsDirect := false
-			if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
+			if creditsAlwaysOn {
+				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
+					requestPayload = creditsPayload
+					usedCreditsDirect = true
+				}
+			} else if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
 				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
 					requestPayload = creditsPayload
 					usedCreditsDirect = true
@@ -754,7 +780,7 @@ attemptLoop:
 					return resp, err
 				}
 				helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
-				if httpResp.StatusCode == http.StatusTooManyRequests {
+				if httpResp.StatusCode == http.StatusTooManyRequests && !creditsAlwaysOn {
 					if usedCreditsDirect {
 						if shouldMarkAntigravityCreditsExhausted(httpResp.StatusCode, bodyBytes, nil) {
 							clearAntigravityPreferCredits(auth, baseModel)
@@ -1121,10 +1147,17 @@ attemptLoop:
 		var lastBody []byte
 		var lastErr error
 
+		creditsAlwaysOn := antigravityCreditsAlwaysEnabled(auth)
+
 		for idx, baseURL := range baseURLs {
 			requestPayload := translated
 			usedCreditsDirect := false
-			if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
+			if creditsAlwaysOn {
+				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
+					requestPayload = creditsPayload
+					usedCreditsDirect = true
+				}
+			} else if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
 				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
 					requestPayload = creditsPayload
 					usedCreditsDirect = true
@@ -1178,7 +1211,7 @@ attemptLoop:
 					return nil, err
 				}
 				helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
-				if httpResp.StatusCode == http.StatusTooManyRequests {
+				if httpResp.StatusCode == http.StatusTooManyRequests && !creditsAlwaysOn {
 					if usedCreditsDirect {
 						if shouldMarkAntigravityCreditsExhausted(httpResp.StatusCode, bodyBytes, nil) {
 							clearAntigravityPreferCredits(auth, baseModel)

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -157,6 +157,19 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			}
 		}
 	}
+	// Read per-credential antigravity_credits toggle from auth file.
+	if rawAC, ok := metadata["antigravity_credits"]; ok {
+		switch v := rawAC.(type) {
+		case bool:
+			if v {
+				a.Attributes["antigravity_credits"] = "true"
+			}
+		case string:
+			if strings.EqualFold(strings.TrimSpace(v), "true") {
+				a.Attributes["antigravity_credits"] = "true"
+			}
+		}
+	}
 	coreauth.ApplyCustomHeadersFromMetadata(a)
 	ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, "oauth")
 	// For codex auth files, extract plan_type from the JWT id_token.
@@ -233,6 +246,10 @@ func SynthesizeGeminiVirtualAuths(primary *coreauth.Auth, metadata map[string]an
 		// Propagate note from primary auth to virtual auths
 		if noteVal, hasNote := primary.Attributes["note"]; hasNote && noteVal != "" {
 			attrs["note"] = noteVal
+		}
+		// Propagate antigravity_credits from primary auth to virtual auths
+		if acVal, hasAC := primary.Attributes["antigravity_credits"]; hasAC && acVal == "true" {
+			attrs["antigravity_credits"] = "true"
 		}
 		for k, v := range primary.Attributes {
 			if strings.HasPrefix(k, "header:") && strings.TrimSpace(v) != "" {

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -159,15 +159,15 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 	}
 	// Read per-credential antigravity_credits toggle from auth file.
 	if rawAC, ok := metadata["antigravity_credits"]; ok {
+		isTrue := false
 		switch v := rawAC.(type) {
 		case bool:
-			if v {
-				a.Attributes["antigravity_credits"] = "true"
-			}
+			isTrue = v
 		case string:
-			if strings.EqualFold(strings.TrimSpace(v), "true") {
-				a.Attributes["antigravity_credits"] = "true"
-			}
+			isTrue = strings.EqualFold(strings.TrimSpace(v), "true")
+		}
+		if isTrue {
+			a.Attributes["antigravity_credits"] = "true"
 		}
 	}
 	coreauth.ApplyCustomHeadersFromMetadata(a)


### PR DESCRIPTION
## Summary

- Add per-credential `antigravity_credits` toggle to resolve conflicts between the global `antigravity-credits` config and other 429 retry mechanisms
- When enabled on a credential, every request unconditionally includes `enabledCreditTypes=["GOOGLE_ONE_AI"]`, bypassing the prefer/exhausted state machine
- Expose `antigravity_credits` in auth file list response and support toggling via `PATCH /auth-files/fields`

## Changes

| File | Change |
|------|--------|
| `internal/watcher/synthesizer/file.go` | Extract `antigravity_credits` from auth file JSON into Attributes; propagate to virtual auths |
| `internal/runtime/executor/antigravity_executor.go` | Add `antigravityCreditsAlwaysEnabled()` helper; modify 3 execution paths to always inject credits when per-credential toggle is on |
| `internal/api/handlers/management/auth_files.go` | Expose `antigravity_credits` in list response; add to PatchAuthFileFields |

## Test plan

- [x] All existing Go tests pass
- [ ] Verify auth file with `antigravity_credits: true` always sends enabledCreditTypes
- [ ] Verify auth file without the field uses existing global retry logic
- [ ] Verify PATCH /auth-files/fields updates in-memory state

 Generated with [Claude Code](https://claude.com/claude-code)