### PR TITLE
重写之前Antigravity频繁429  完善积分失败多次策略防止报错

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -95,6 +95,9 @@ quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
   antigravity-credits: true # Whether to retry Antigravity quota_exhausted 429s once with enabledCreditTypes=["GOOGLE_ONE_AI"]
+  antigravity-credits-fail-threshold: 1 # Disable future credits attempts after this many consecutive credits failures for the same auth; 0 disables threshold-based shutdown
+  antigravity-credits-fail-strategy: "temporary" # temporary=disable credits for antigravity-credits-disable-minutes, permanent=disable credits until restart
+  antigravity-credits-disable-minutes: 300 # Only used when antigravity-credits-fail-strategy=temporary
 
 # Routing strategy for selecting credentials when multiple match.
 routing:
@@ -109,7 +112,6 @@ enable-gemini-cli-endpoint: false
 
 # When > 0, emit blank lines every N seconds for non-streaming responses to prevent idle timeouts.
 nonstream-keepalive-interval: 0
-
 # Streaming behavior (SSE keep-alives + safe bootstrap retries).
 # streaming:
 #   keepalive-seconds: 15   # Default: 0 (disabled). <= 0 disables keep-alives.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -95,9 +95,6 @@ quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
   antigravity-credits: true # Whether to retry Antigravity quota_exhausted 429s once with enabledCreditTypes=["GOOGLE_ONE_AI"]
-  antigravity-credits-fail-threshold: 1 # Disable future credits attempts after this many consecutive credits failures for the same auth; 0 disables threshold-based shutdown
-  antigravity-credits-fail-strategy: "temporary" # temporary=disable credits for antigravity-credits-disable-minutes, permanent=disable credits until restart
-  antigravity-credits-disable-minutes: 300 # Only used when antigravity-credits-fail-strategy=temporary
 
 # Routing strategy for selecting credentials when multiple match.
 routing:

--- a/docs/pr-antigravity-429-summary.md
+++ b/docs/pr-antigravity-429-summary.md
@@ -1,21 +1,26 @@
 # PR 总结（结构化版）
 
 ## 标题
-补齐 Antigravity 超细 429 状态机，并完善积分失败多次策略
+
+补齐 Antigravity 超细 429 状态机，并改成 credits 全自动处理
 
 ## 背景
+
 当前官方仓库在 Antigravity 的 429 处理上，只有基础的 fallback / retryAfter / no capacity / credits fallback 逻辑，缺少 Plus 版已经具备的超细 429 状态机能力。
 
 这会导致：
+
 - 不同类型的 429 被混成同一种处理
 - 缺少 short cooldown、soft retry、same-auth instant retry 等机制
-- 积分失败多次后没有足够灵活的配置化策略
+- 积分失败多次后仍有配置残留，行为不够收敛
 - credits 请求失败可能影响整体请求处理体验
 
 ## 目标
+
 本次改动的目标是：
+
 1. 将 Plus 版核心的超细 429 状态机补齐到官方仓库
-2. 保留并扩展 credits 失败多次策略的配置化能力
+2. 删除 credits 失败策略配置，改成代码全自动处理
 3. 避免 credits 失败直接污染主失败链
 4. 修复服务器本地编译与部署过程中暴露的语法问题
 5. 对明确余额不足错误进行更强硬、更准确的自动处理
@@ -23,24 +28,31 @@
 ## 主要改动
 
 ### 1. 补齐 Antigravity 超细 429 状态机
+
 在 `internal/runtime/executor/antigravity_executor.go` 中新增并接入：
+
 - `decideAntigravity429(...)`
 - `classifyAntigravity429(...)`
 
 支持以下状态分类：
+
 - `soft_retry`
 - `instant_retry_same_auth`
 - `short_cooldown_switch_auth`
 - `full_quota_exhausted`
 
 ### 2. 增加 same-auth instant retry
+
 当 429 被识别为极短限流时：
+
 - 不立即失败
 - 不立即切换 auth
 - 而是同 auth 短等待后重试
 
 ### 3. 增加 short cooldown 机制
+
 新增：
+
 - `antigravityShortCooldownKey(...)`
 - `antigravityIsInShortCooldown(...)`
 - `markAntigravityShortCooldown(...)`
@@ -48,81 +60,92 @@
 当某个 auth + model 命中短冷却时，会提前返回带 `retryAfter` 的 429，便于上层切换账号或等待。
 
 ### 4. 增加 soft rate limit retry
+
 新增：
+
 - `antigravityShouldRetrySoftRateLimit(...)`
 - `antigravitySoftRateLimitDelay(...)`
 
 当 429 属于 soft rate limit 时，会走短退避重试，而不是直接进入硬失败路径。
 
 ### 5. 三条执行链统一接入
+
 以下执行路径都已统一接入超细 429 状态机：
+
 - `Execute(...)`
 - `executeClaudeNonStream(...)`
 - `ExecuteStream(...)`
 
-### 6. 保留并扩展 credits 失败多次策略
-在配置中新增字段：
+### 6. credits 失败策略改成全自动
+
+移除配置字段：
+
 - `antigravity-credits-fail-threshold`
 - `antigravity-credits-fail-strategy`
 - `antigravity-credits-disable-minutes`
 
-支持两种策略：
-- `temporary`：限时尝试
-- `permanent`：永久禁止
+改为固定自动策略：
+
+- 明确的 `INSUFFICIENT_G1_CREDITS_BALANCE`：直接永久停用当前 auth 的积分尝试
+- 其他 credits 失败：自动进入固定时长停用窗口，避免持续浪费 credits 尝试
+- credits 成功后会清理失败状态，恢复正常偏好逻辑
 
 ### 7. 明确余额不足错误直接永久停用积分
+
 新增对 `INSUFFICIENT_G1_CREDITS_BALANCE` 的特殊处理：
+
 - 一旦在 429 的 `error.details[].reason` 中命中该值
 - 直接视为积分余额明确不足
-- 跳过 `antigravity-credits-fail-threshold / antigravity-credits-fail-strategy / antigravity-credits-disable-minutes` 配置判断
+- 不再依赖任何 credits 失败配置字段
 - 直接永久停用当前 auth 的积分尝试
 - 清除 `preferCredits`
 - 当前请求优先回退普通模式，不再继续浪费 credits 尝试
 
 ### 8. 优化 credits 失败后的处理方式
+
 保留并强化当前逻辑：
-- 普通 `RESOURCE_EXHAUSTED` 继续走现有 429 状态机和配置化策略
-- 明确的 `INSUFFICIENT_G1_CREDITS_BALANCE` 由代码自动硬处理，不再依赖配置
+
+- 普通 `RESOURCE_EXHAUSTED` 继续走现有 429 状态机和自动 credits 策略
+- 明确的 `INSUFFICIENT_G1_CREDITS_BALANCE` 由代码自动硬处理
 - credits 失败不直接作为主请求最终失败
 - 优先回退普通请求路径
 - 避免 credits 失败直接扩大成整体调度失败
 
 ### 9. 修复服务器编译报错
+
 修复了 `internal/runtime/executor/antigravity_executor.go` 中函数结构闭合问题，解决了服务器本地 `go build` 时报出的语法错误。
 
 ## 涉及文件
+
 - `internal/runtime/executor/antigravity_executor.go`
 - `internal/config/config.go`
 - `config.example.yaml`
 - `docs/pr-antigravity-429-summary.md`
 
-## 配置示例
+## 自动处理说明
 
-### 限时尝试
 ```yaml
 quota-exceeded:
   antigravity-credits: true
-  antigravity-credits-fail-threshold: 3
-  antigravity-credits-fail-strategy: "temporary"
-  antigravity-credits-disable-minutes: 30
 ```
 
-### 永久禁止
-```yaml
-quota-exceeded:
-  antigravity-credits: true
-  antigravity-credits-fail-threshold: 3
-  antigravity-credits-fail-strategy: "permanent"
-```
+说明：
+
+- 不再提供 temporary / permanent 的配置切换
+- 明确余额不足走永久停用
+- 其他 credits 失败由代码自动按固定策略处理
 
 ## 风险点
+
 - 超细 429 状态机引入后，执行路径变复杂，必须确保三条执行链行为一致
-- short cooldown 与 credits 失败策略并存时，要避免相互覆盖或误判
+- short cooldown 与自动 credits 策略并存时，要避免相互覆盖或误判
 - 编译部署时若源码目录不完整或函数结构有误，会直接导致 `go build` 失败
 - 明确余额不足错误被提级为硬规则后，相关 auth 的积分通道会被直接永久停用
 
 ## 验证结果
+
 已完成：
+
 - 服务器安装 Go 编译环境
 - 完整源码重新上传到服务器
 - 服务器本地成功执行 `go build -o /tmp/CLIProxyAPI.build ./cmd/server`
@@ -131,9 +154,11 @@ quota-exceeded:
 - 健康检查通过：`/healthz -> {"status":"ok"}`
 
 ## 最终效果
+
 本次 PR 合并后，官方仓库将具备：
+
 - Plus 版核心的超细 429 状态判断能力
 - 更合理的 short cooldown / soft retry / instant retry 行为
-- 可配置的 credits 失败多次策略
+- credits 全自动处理，不再暴露额外配置项
 - 对明确积分余额不足错误的自动永久停用能力
 - 已验证可在服务器端完成编译、替换与运行

--- a/docs/pr-antigravity-429-summary.md
+++ b/docs/pr-antigravity-429-summary.md
@@ -142,6 +142,24 @@ quota-exceeded:
 - 编译部署时若源码目录不完整或函数结构有误，会直接导致 `go build` 失败
 - 明确余额不足错误被提级为硬规则后，相关 auth 的积分通道会被直接永久停用
 
+### 10. 秒级 instant retry 等待规则继续收紧
+
+针对实际线上出现的秒级 `RATE_LIMIT_EXCEEDED` 边界抖动问题，进一步调整 instant retry 的等待策略：
+
+- 不再使用模糊缓冲描述
+- 明确以 `RetryInfo.retryDelay` 的原始解析值作为基准
+- 当前实际等待时间为：`retryDelay + 800ms`
+- 例如：
+  - `retryDelay = 0.467174873s` -> 实际等待 `1.267174873s`
+  - `retryDelay = 0.606037544s` -> 实际等待 `1.406037544s`
+
+这样做的原因是：
+
+- `error.message` 中的 `after 0s / 1s` 只是展示文案，不能作为准确冷却依据
+- 真正可靠的冷却值应取 `RetryInfo.retryDelay`
+- 秒级窗口边界存在轻微抖动，按原值裸等或只加较小缓冲时，仍可能偶发再次撞上 429
+- 提升到 `+800ms` 后，更适合当前线上波动场景
+
 ## 验证结果
 
 已完成：
@@ -161,4 +179,6 @@ quota-exceeded:
 - 更合理的 short cooldown / soft retry / instant retry 行为
 - credits 全自动处理，不再暴露额外配置项
 - 对明确积分余额不足错误的自动永久停用能力
+- 秒级 instant retry 已改为严格按 `retryDelay + 800ms` 等待，进一步压制秒级边界 429 外抛
+
 - 已验证可在服务器端完成编译、替换与运行

--- a/docs/pr-antigravity-429-summary.md
+++ b/docs/pr-antigravity-429-summary.md
@@ -1,0 +1,139 @@
+# PR 总结（结构化版）
+
+## 标题
+补齐 Antigravity 超细 429 状态机，并完善积分失败多次策略
+
+## 背景
+当前官方仓库在 Antigravity 的 429 处理上，只有基础的 fallback / retryAfter / no capacity / credits fallback 逻辑，缺少 Plus 版已经具备的超细 429 状态机能力。
+
+这会导致：
+- 不同类型的 429 被混成同一种处理
+- 缺少 short cooldown、soft retry、same-auth instant retry 等机制
+- 积分失败多次后没有足够灵活的配置化策略
+- credits 请求失败可能影响整体请求处理体验
+
+## 目标
+本次改动的目标是：
+1. 将 Plus 版核心的超细 429 状态机补齐到官方仓库
+2. 保留并扩展 credits 失败多次策略的配置化能力
+3. 避免 credits 失败直接污染主失败链
+4. 修复服务器本地编译与部署过程中暴露的语法问题
+5. 对明确余额不足错误进行更强硬、更准确的自动处理
+
+## 主要改动
+
+### 1. 补齐 Antigravity 超细 429 状态机
+在 `internal/runtime/executor/antigravity_executor.go` 中新增并接入：
+- `decideAntigravity429(...)`
+- `classifyAntigravity429(...)`
+
+支持以下状态分类：
+- `soft_retry`
+- `instant_retry_same_auth`
+- `short_cooldown_switch_auth`
+- `full_quota_exhausted`
+
+### 2. 增加 same-auth instant retry
+当 429 被识别为极短限流时：
+- 不立即失败
+- 不立即切换 auth
+- 而是同 auth 短等待后重试
+
+### 3. 增加 short cooldown 机制
+新增：
+- `antigravityShortCooldownKey(...)`
+- `antigravityIsInShortCooldown(...)`
+- `markAntigravityShortCooldown(...)`
+
+当某个 auth + model 命中短冷却时，会提前返回带 `retryAfter` 的 429，便于上层切换账号或等待。
+
+### 4. 增加 soft rate limit retry
+新增：
+- `antigravityShouldRetrySoftRateLimit(...)`
+- `antigravitySoftRateLimitDelay(...)`
+
+当 429 属于 soft rate limit 时，会走短退避重试，而不是直接进入硬失败路径。
+
+### 5. 三条执行链统一接入
+以下执行路径都已统一接入超细 429 状态机：
+- `Execute(...)`
+- `executeClaudeNonStream(...)`
+- `ExecuteStream(...)`
+
+### 6. 保留并扩展 credits 失败多次策略
+在配置中新增字段：
+- `antigravity-credits-fail-threshold`
+- `antigravity-credits-fail-strategy`
+- `antigravity-credits-disable-minutes`
+
+支持两种策略：
+- `temporary`：限时尝试
+- `permanent`：永久禁止
+
+### 7. 明确余额不足错误直接永久停用积分
+新增对 `INSUFFICIENT_G1_CREDITS_BALANCE` 的特殊处理：
+- 一旦在 429 的 `error.details[].reason` 中命中该值
+- 直接视为积分余额明确不足
+- 跳过 `antigravity-credits-fail-threshold / antigravity-credits-fail-strategy / antigravity-credits-disable-minutes` 配置判断
+- 直接永久停用当前 auth 的积分尝试
+- 清除 `preferCredits`
+- 当前请求优先回退普通模式，不再继续浪费 credits 尝试
+
+### 8. 优化 credits 失败后的处理方式
+保留并强化当前逻辑：
+- 普通 `RESOURCE_EXHAUSTED` 继续走现有 429 状态机和配置化策略
+- 明确的 `INSUFFICIENT_G1_CREDITS_BALANCE` 由代码自动硬处理，不再依赖配置
+- credits 失败不直接作为主请求最终失败
+- 优先回退普通请求路径
+- 避免 credits 失败直接扩大成整体调度失败
+
+### 9. 修复服务器编译报错
+修复了 `internal/runtime/executor/antigravity_executor.go` 中函数结构闭合问题，解决了服务器本地 `go build` 时报出的语法错误。
+
+## 涉及文件
+- `internal/runtime/executor/antigravity_executor.go`
+- `internal/config/config.go`
+- `config.example.yaml`
+- `docs/pr-antigravity-429-summary.md`
+
+## 配置示例
+
+### 限时尝试
+```yaml
+quota-exceeded:
+  antigravity-credits: true
+  antigravity-credits-fail-threshold: 3
+  antigravity-credits-fail-strategy: "temporary"
+  antigravity-credits-disable-minutes: 30
+```
+
+### 永久禁止
+```yaml
+quota-exceeded:
+  antigravity-credits: true
+  antigravity-credits-fail-threshold: 3
+  antigravity-credits-fail-strategy: "permanent"
+```
+
+## 风险点
+- 超细 429 状态机引入后，执行路径变复杂，必须确保三条执行链行为一致
+- short cooldown 与 credits 失败策略并存时，要避免相互覆盖或误判
+- 编译部署时若源码目录不完整或函数结构有误，会直接导致 `go build` 失败
+- 明确余额不足错误被提级为硬规则后，相关 auth 的积分通道会被直接永久停用
+
+## 验证结果
+已完成：
+- 服务器安装 Go 编译环境
+- 完整源码重新上传到服务器
+- 服务器本地成功执行 `go build -o /tmp/CLIProxyAPI.build ./cmd/server`
+- 替换 `/opt/cliproxyapi/CLIProxyAPI`
+- 重启 `cliproxyapi.service`
+- 健康检查通过：`/healthz -> {"status":"ok"}`
+
+## 最终效果
+本次 PR 合并后，官方仓库将具备：
+- Plus 版核心的超细 429 状态判断能力
+- 更合理的 short cooldown / soft retry / instant retry 行为
+- 可配置的 credits 失败多次策略
+- 对明确积分余额不足错误的自动永久停用能力
+- 已验证可在服务器端完成编译、替换与运行

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,18 +198,6 @@ type QuotaExceeded struct {
 	// AntigravityCredits indicates whether to retry Antigravity quota_exhausted 429s once
 	// on the same credential with enabledCreditTypes=["GOOGLE_ONE_AI"].
 	AntigravityCredits bool `yaml:"antigravity-credits" json:"antigravity-credits"`
-
-	// AntigravityCreditsFailThreshold controls how many consecutive credits request failures
-	// are allowed before credits attempts are disabled for the auth.
-	AntigravityCreditsFailThreshold int `yaml:"antigravity-credits-fail-threshold" json:"antigravity-credits-fail-threshold"`
-
-	// AntigravityCreditsFailStrategy controls whether credits attempts are disabled temporarily
-	// or permanently after reaching the failure threshold. Supported values: temporary, permanent.
-	AntigravityCreditsFailStrategy string `yaml:"antigravity-credits-fail-strategy" json:"antigravity-credits-fail-strategy"`
-
-	// AntigravityCreditsDisableMinutes defines the temporary disable duration after reaching
-	// the failure threshold when the strategy is temporary.
-	AntigravityCreditsDisableMinutes int `yaml:"antigravity-credits-disable-minutes" json:"antigravity-credits-disable-minutes"`
 }
 
 // RoutingConfig configures how credentials are selected for requests.
@@ -593,9 +581,6 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.Pprof.Addr = DefaultPprofAddr
 	cfg.AmpCode.RestrictManagementToLocalhost = false // Default to false: API key auth is sufficient
 	cfg.RemoteManagement.PanelGitHubRepository = DefaultPanelGitHubRepository
-	cfg.QuotaExceeded.AntigravityCreditsFailThreshold = 1
-	cfg.QuotaExceeded.AntigravityCreditsFailStrategy = "temporary"
-	cfg.QuotaExceeded.AntigravityCreditsDisableMinutes = 300
 	if err = yaml.Unmarshal(data, &cfg); err != nil {
 		if optional {
 			// In cloud deploy mode, if YAML parsing fails, return empty config instead of error.
@@ -656,21 +641,6 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		cfg.MaxRetryCredentials = 0
 	}
 
-	if cfg.QuotaExceeded.AntigravityCreditsFailThreshold < 0 {
-		cfg.QuotaExceeded.AntigravityCreditsFailThreshold = 0
-	}
-	cfg.QuotaExceeded.AntigravityCreditsFailStrategy = strings.ToLower(strings.TrimSpace(cfg.QuotaExceeded.AntigravityCreditsFailStrategy))
-	if cfg.QuotaExceeded.AntigravityCreditsFailStrategy == "" {
-		cfg.QuotaExceeded.AntigravityCreditsFailStrategy = "temporary"
-	}
-	switch cfg.QuotaExceeded.AntigravityCreditsFailStrategy {
-	case "temporary", "permanent":
-	default:
-		cfg.QuotaExceeded.AntigravityCreditsFailStrategy = "temporary"
-	}
-	if cfg.QuotaExceeded.AntigravityCreditsDisableMinutes < 0 {
-		cfg.QuotaExceeded.AntigravityCreditsDisableMinutes = 0
-	}
 
 	// Sanitize Gemini API key configuration and migrate legacy entries.
 	cfg.SanitizeGeminiKeys()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,6 +198,18 @@ type QuotaExceeded struct {
 	// AntigravityCredits indicates whether to retry Antigravity quota_exhausted 429s once
 	// on the same credential with enabledCreditTypes=["GOOGLE_ONE_AI"].
 	AntigravityCredits bool `yaml:"antigravity-credits" json:"antigravity-credits"`
+
+	// AntigravityCreditsFailThreshold controls how many consecutive credits request failures
+	// are allowed before credits attempts are disabled for the auth.
+	AntigravityCreditsFailThreshold int `yaml:"antigravity-credits-fail-threshold" json:"antigravity-credits-fail-threshold"`
+
+	// AntigravityCreditsFailStrategy controls whether credits attempts are disabled temporarily
+	// or permanently after reaching the failure threshold. Supported values: temporary, permanent.
+	AntigravityCreditsFailStrategy string `yaml:"antigravity-credits-fail-strategy" json:"antigravity-credits-fail-strategy"`
+
+	// AntigravityCreditsDisableMinutes defines the temporary disable duration after reaching
+	// the failure threshold when the strategy is temporary.
+	AntigravityCreditsDisableMinutes int `yaml:"antigravity-credits-disable-minutes" json:"antigravity-credits-disable-minutes"`
 }
 
 // RoutingConfig configures how credentials are selected for requests.
@@ -581,6 +593,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.Pprof.Addr = DefaultPprofAddr
 	cfg.AmpCode.RestrictManagementToLocalhost = false // Default to false: API key auth is sufficient
 	cfg.RemoteManagement.PanelGitHubRepository = DefaultPanelGitHubRepository
+	cfg.QuotaExceeded.AntigravityCreditsFailThreshold = 1
+	cfg.QuotaExceeded.AntigravityCreditsFailStrategy = "temporary"
+	cfg.QuotaExceeded.AntigravityCreditsDisableMinutes = 300
 	if err = yaml.Unmarshal(data, &cfg); err != nil {
 		if optional {
 			// In cloud deploy mode, if YAML parsing fails, return empty config instead of error.
@@ -639,6 +654,22 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	if cfg.MaxRetryCredentials < 0 {
 		cfg.MaxRetryCredentials = 0
+	}
+
+	if cfg.QuotaExceeded.AntigravityCreditsFailThreshold < 0 {
+		cfg.QuotaExceeded.AntigravityCreditsFailThreshold = 0
+	}
+	cfg.QuotaExceeded.AntigravityCreditsFailStrategy = strings.ToLower(strings.TrimSpace(cfg.QuotaExceeded.AntigravityCreditsFailStrategy))
+	if cfg.QuotaExceeded.AntigravityCreditsFailStrategy == "" {
+		cfg.QuotaExceeded.AntigravityCreditsFailStrategy = "temporary"
+	}
+	switch cfg.QuotaExceeded.AntigravityCreditsFailStrategy {
+	case "temporary", "permanent":
+	default:
+		cfg.QuotaExceeded.AntigravityCreditsFailStrategy = "temporary"
+	}
+	if cfg.QuotaExceeded.AntigravityCreditsDisableMinutes < 0 {
+		cfg.QuotaExceeded.AntigravityCreditsDisableMinutes = 0
 	}
 
 	// Sanitize Gemini API key configuration and migrate legacy entries.

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -50,6 +50,7 @@ const (
 	antigravityAuthType                    = "antigravity"
 	refreshSkew                            = 3000 * time.Second
 	antigravityCreditsRetryTTL             = 5 * time.Hour
+	antigravityCreditsAutoDisableDuration  = 5 * time.Hour
 	antigravityShortQuotaCooldownThreshold = 5 * time.Minute
 	antigravityInstantRetryThreshold       = 1 * time.Second
 	// systemInstruction              = "You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.**Absolute paths only****Proactiveness**"
@@ -352,30 +353,6 @@ func antigravityCreditsRetryEnabled(cfg *config.Config) bool {
 	return cfg != nil && cfg.QuotaExceeded.AntigravityCredits
 }
 
-func antigravityCreditsFailureThreshold(cfg *config.Config) int {
-	if cfg == nil {
-		return 0
-	}
-	return cfg.QuotaExceeded.AntigravityCreditsFailThreshold
-}
-
-func antigravityCreditsFailureStrategy(cfg *config.Config) string {
-	if cfg == nil {
-		return "temporary"
-	}
-	strategy := strings.ToLower(strings.TrimSpace(cfg.QuotaExceeded.AntigravityCreditsFailStrategy))
-	if strategy == "permanent" {
-		return strategy
-	}
-	return "temporary"
-}
-
-func antigravityCreditsDisableDuration(cfg *config.Config) time.Duration {
-	if cfg == nil || cfg.QuotaExceeded.AntigravityCreditsDisableMinutes <= 0 {
-		return 0
-	}
-	return time.Duration(cfg.QuotaExceeded.AntigravityCreditsDisableMinutes) * time.Minute
-}
 
 func antigravityCreditsFailureStateForAuth(auth *cliproxyauth.Auth) (string, antigravityCreditsFailureState, bool) {
 	if auth == nil || strings.TrimSpace(auth.ID) == "" {
@@ -394,7 +371,7 @@ func antigravityCreditsFailureStateForAuth(auth *cliproxyauth.Auth) (string, ant
 	return authID, state, true
 }
 
-func antigravityCreditsDisabled(cfg *config.Config, auth *cliproxyauth.Auth, now time.Time) bool {
+func antigravityCreditsDisabled(auth *cliproxyauth.Auth, now time.Time) bool {
 	authID, state, ok := antigravityCreditsFailureStateForAuth(auth)
 	if !ok {
 		return false
@@ -412,27 +389,17 @@ func antigravityCreditsDisabled(cfg *config.Config, auth *cliproxyauth.Auth, now
 	return false
 }
 
-func recordAntigravityCreditsFailure(cfg *config.Config, auth *cliproxyauth.Auth, now time.Time) {
+func recordAntigravityCreditsFailure(auth *cliproxyauth.Auth, now time.Time) {
 	authID, state, ok := antigravityCreditsFailureStateForAuth(auth)
 	if !ok {
 		return
 	}
-	state.Count++
-	threshold := antigravityCreditsFailureThreshold(cfg)
-	if threshold > 0 && state.Count >= threshold {
-		switch antigravityCreditsFailureStrategy(cfg) {
-		case "permanent":
-			state.PermanentlyDisabled = true
-			state.DisabledUntil = time.Time{}
-		default:
-			disableFor := antigravityCreditsDisableDuration(cfg)
-			if disableFor > 0 {
-				state.DisabledUntil = now.Add(disableFor)
-			} else {
-				state.DisabledUntil = now
-			}
-		}
+	if state.PermanentlyDisabled {
+		antigravityCreditsFailureByAuth.Store(authID, state)
+		return
 	}
+	state.Count++
+	state.DisabledUntil = now.Add(antigravityCreditsAutoDisableDuration)
 	antigravityCreditsFailureByAuth.Store(authID, state)
 }
 
@@ -591,7 +558,7 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 		return nil, false
 	}
 
-	if antigravityCreditsDisabled(e.cfg, auth, now) {
+	if antigravityCreditsDisabled(auth, now) {
 		return nil, false
 	}
 	creditsPayload := injectEnabledCreditTypes(payload)
@@ -603,14 +570,14 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 	if errReq != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errReq)
 		clearAntigravityPreferCredits(auth, modelName)
-		recordAntigravityCreditsFailure(e.cfg, auth, now)
+		recordAntigravityCreditsFailure(auth, now)
 		return nil, true
 	}
 	httpResp, errDo := httpClient.Do(httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
 		clearAntigravityPreferCredits(auth, modelName)
-		recordAntigravityCreditsFailure(e.cfg, auth, now)
+		recordAntigravityCreditsFailure(auth, now)
 		return nil, true
 	}
 	if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
@@ -628,7 +595,7 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 	if errRead != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errRead)
 		clearAntigravityPreferCredits(auth, modelName)
-		recordAntigravityCreditsFailure(e.cfg, auth, now)
+		recordAntigravityCreditsFailure(auth, now)
 		return nil, true
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
@@ -645,7 +612,7 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 	}
 
 	clearAntigravityPreferCredits(auth, modelName)
-	recordAntigravityCreditsFailure(e.cfg, auth, now)
+	recordAntigravityCreditsFailure(auth, now)
 	return nil, true
 }
 
@@ -666,7 +633,7 @@ func (e *AntigravityExecutor) handleDirectCreditsFailure(ctx context.Context, au
 		helps.RecordAPIResponseError(ctx, e.cfg, reqErr)
 	}
 	clearAntigravityPreferCredits(auth, modelName)
-	recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
+	recordAntigravityCreditsFailure(auth, time.Now())
 }
 func reqErrBody(reqErr error) []byte {
 	if reqErr == nil {
@@ -820,7 +787,7 @@ attemptLoop:
 				case antigravity429DecisionFullQuotaExhausted:
 					if usedCreditsDirect {
 						clearAntigravityPreferCredits(auth, baseModel)
-						recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
+						recordAntigravityCreditsFailure(auth, time.Now())
 					} else {
 						creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, false, opts.Alt, baseURL, bodyBytes)
 						if creditsResp != nil {
@@ -1055,7 +1022,7 @@ attemptLoop:
 					case antigravity429DecisionFullQuotaExhausted:
 						if usedCreditsDirect {
 							clearAntigravityPreferCredits(auth, baseModel)
-							recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
+							recordAntigravityCreditsFailure(auth, time.Now())
 						} else {
 							creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
 							if creditsResp != nil {
@@ -1524,7 +1491,7 @@ attemptLoop:
 					case antigravity429DecisionFullQuotaExhausted:
 						if usedCreditsDirect {
 							clearAntigravityPreferCredits(auth, baseModel)
-							recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
+							recordAntigravityCreditsFailure(auth, time.Now())
 							httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, true, opts.Alt, baseURL)
 							if errReq != nil {
 								err = errReq

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -38,18 +38,20 @@ import (
 )
 
 const (
-	antigravityBaseURLDaily        = "https://daily-cloudcode-pa.googleapis.com"
-	antigravitySandboxBaseURLDaily = "https://daily-cloudcode-pa.sandbox.googleapis.com"
-	antigravityBaseURLProd         = "https://cloudcode-pa.googleapis.com"
-	antigravityCountTokensPath     = "/v1internal:countTokens"
-	antigravityStreamPath          = "/v1internal:streamGenerateContent"
-	antigravityGeneratePath        = "/v1internal:generateContent"
-	antigravityClientID            = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
-	antigravityClientSecret        = "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"
-	defaultAntigravityAgent        = "antigravity/1.21.9 darwin/arm64" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
-	antigravityAuthType            = "antigravity"
-	refreshSkew                    = 3000 * time.Second
-	antigravityCreditsRetryTTL = 5 * time.Hour
+	antigravityBaseURLDaily                = "https://daily-cloudcode-pa.googleapis.com"
+	antigravitySandboxBaseURLDaily         = "https://daily-cloudcode-pa.sandbox.googleapis.com"
+	antigravityBaseURLProd                 = "https://cloudcode-pa.googleapis.com"
+	antigravityCountTokensPath             = "/v1internal:countTokens"
+	antigravityStreamPath                  = "/v1internal:streamGenerateContent"
+	antigravityGeneratePath                = "/v1internal:generateContent"
+	antigravityClientID                    = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
+	antigravityClientSecret                = "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"
+	defaultAntigravityAgent                = "antigravity/1.21.9 darwin/arm64" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
+	antigravityAuthType                    = "antigravity"
+	refreshSkew                            = 3000 * time.Second
+	antigravityCreditsRetryTTL             = 5 * time.Hour
+	antigravityShortQuotaCooldownThreshold = 5 * time.Minute
+	antigravityInstantRetryThreshold       = 1 * time.Second
 	// systemInstruction              = "You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.**Absolute paths only****Proactiveness**"
 )
 
@@ -61,17 +63,31 @@ type antigravityCreditsFailureState struct {
 	PermanentlyDisabled bool
 }
 
+type antigravity429DecisionKind string
+
 const (
-	antigravity429Unknown        antigravity429Category = "unknown"
-	antigravity429RateLimited    antigravity429Category = "rate_limited"
-	antigravity429QuotaExhausted antigravity429Category = "quota_exhausted"
+	antigravity429Unknown                        antigravity429Category     = "unknown"
+	antigravity429RateLimited                    antigravity429Category     = "rate_limited"
+	antigravity429QuotaExhausted                 antigravity429Category     = "quota_exhausted"
+	antigravity429SoftRateLimit                  antigravity429Category     = "soft_rate_limit"
+	antigravity429DecisionSoftRetry              antigravity429DecisionKind = "soft_retry"
+	antigravity429DecisionInstantRetrySameAuth   antigravity429DecisionKind = "instant_retry_same_auth"
+	antigravity429DecisionShortCooldownSwitchAuth antigravity429DecisionKind = "short_cooldown_switch_auth"
+	antigravity429DecisionFullQuotaExhausted     antigravity429DecisionKind = "full_quota_exhausted"
 )
+
+type antigravity429Decision struct {
+	kind       antigravity429DecisionKind
+	retryAfter *time.Duration
+	reason     string
+}
 
 var (
 	randSource                      = rand.New(rand.NewSource(time.Now().UnixNano()))
 	randSourceMutex                 sync.Mutex
 	antigravityCreditsFailureByAuth sync.Map
 	antigravityPreferCreditsByModel sync.Map
+	antigravityShortCooldownByAuth  sync.Map
 	antigravityQuotaExhaustedKeywords = []string{
 		"quota_exhausted",
 		"quota exhausted",
@@ -235,36 +251,77 @@ func injectEnabledCreditTypes(payload []byte) []byte {
 }
 
 func classifyAntigravity429(body []byte) antigravity429Category {
-	if len(body) == 0 {
+	switch decideAntigravity429(body).kind {
+	case antigravity429DecisionInstantRetrySameAuth, antigravity429DecisionShortCooldownSwitchAuth:
+		return antigravity429RateLimited
+	case antigravity429DecisionFullQuotaExhausted:
+		return antigravity429QuotaExhausted
+	case antigravity429DecisionSoftRetry:
+		return antigravity429SoftRateLimit
+	default:
 		return antigravity429Unknown
 	}
+}
+
+func decideAntigravity429(body []byte) antigravity429Decision {
+	decision := antigravity429Decision{kind: antigravity429DecisionSoftRetry}
+	if len(body) == 0 {
+		return decision
+	}
+
+	if retryAfter, parseErr := parseRetryDelay(body); parseErr == nil && retryAfter != nil {
+		decision.retryAfter = retryAfter
+	}
+
 	lowerBody := strings.ToLower(string(body))
 	for _, keyword := range antigravityQuotaExhaustedKeywords {
 		if strings.Contains(lowerBody, keyword) {
-			return antigravity429QuotaExhausted
+			decision.kind = antigravity429DecisionFullQuotaExhausted
+			decision.reason = "quota_exhausted"
+			return decision
 		}
 	}
+
 	status := strings.TrimSpace(gjson.GetBytes(body, "error.status").String())
 	if !strings.EqualFold(status, "RESOURCE_EXHAUSTED") {
-		return antigravity429Unknown
+		return decision
 	}
+
 	details := gjson.GetBytes(body, "error.details")
 	if !details.Exists() || !details.IsArray() {
-		return antigravity429Unknown
+		decision.kind = antigravity429DecisionSoftRetry
+		return decision
 	}
+
 	for _, detail := range details.Array() {
 		if detail.Get("@type").String() != "type.googleapis.com/google.rpc.ErrorInfo" {
 			continue
 		}
 		reason := strings.TrimSpace(detail.Get("reason").String())
-		if strings.EqualFold(reason, "QUOTA_EXHAUSTED") {
-			return antigravity429QuotaExhausted
-		}
-		if strings.EqualFold(reason, "RATE_LIMIT_EXCEEDED") {
-			return antigravity429RateLimited
+		decision.reason = reason
+		switch {
+		case strings.EqualFold(reason, "QUOTA_EXHAUSTED"):
+			decision.kind = antigravity429DecisionFullQuotaExhausted
+			return decision
+		case strings.EqualFold(reason, "RATE_LIMIT_EXCEEDED"):
+			if decision.retryAfter == nil {
+				decision.kind = antigravity429DecisionSoftRetry
+				return decision
+			}
+			switch {
+			case *decision.retryAfter < antigravityInstantRetryThreshold:
+				decision.kind = antigravity429DecisionInstantRetrySameAuth
+			case *decision.retryAfter < antigravityShortQuotaCooldownThreshold:
+				decision.kind = antigravity429DecisionShortCooldownSwitchAuth
+			default:
+				decision.kind = antigravity429DecisionFullQuotaExhausted
+			}
+			return decision
 		}
 	}
-	return antigravity429Unknown
+
+	decision.kind = antigravity429DecisionSoftRetry
+	return decision
 }
 
 func antigravityHasQuotaResetDelayOrModelInfo(body []byte) bool {
@@ -484,7 +541,7 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 	if !antigravityCreditsRetryEnabled(e.cfg) {
 		return nil, false
 	}
-	if classifyAntigravity429(originalBody) != antigravity429QuotaExhausted {
+	if decideAntigravity429(originalBody).kind != antigravity429DecisionFullQuotaExhausted {
 		return nil, false
 	}
 	now := time.Now()
@@ -548,6 +605,12 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	if inCooldown, remaining := antigravityIsInShortCooldown(auth, baseModel, time.Now()); inCooldown {
+		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
+		d := remaining
+		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+	}
+
 	isClaude := strings.Contains(strings.ToLower(baseModel), "claude")
 
 	if isClaude || strings.Contains(baseModel, "gemini-3-pro") || strings.Contains(baseModel, "gemini-3.1-flash-image") {
@@ -651,61 +714,49 @@ attemptLoop:
 			helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
 
 			if httpResp.StatusCode == http.StatusTooManyRequests {
-				if usedCreditsDirect {
-					clearAntigravityPreferCredits(auth, baseModel)
-					recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
-					httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, false, opts.Alt, baseURL)
-					if errReq != nil {
-						err = errReq
-						return resp, err
-					}
-					httpResp, errDo = httpClient.Do(httpReq)
-					if errDo != nil {
-						helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-						if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
-							return resp, errDo
+				decision := decideAntigravity429(bodyBytes)
+
+				switch decision.kind {
+				case antigravity429DecisionInstantRetrySameAuth:
+					if attempt+1 < attempts {
+						if decision.retryAfter != nil && *decision.retryAfter > 0 {
+							log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, *decision.retryAfter)
+							if errWait := antigravityWait(ctx, *decision.retryAfter); errWait != nil {
+								return resp, errWait
+							}
 						}
-						lastStatus = 0
-						lastBody = nil
-						lastErr = errDo
-						if idx+1 < len(baseURLs) {
-							log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-							continue
-						}
-						err = errDo
-						return resp, err
+						continue attemptLoop
 					}
-					helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-					bodyBytes, errRead = io.ReadAll(httpResp.Body)
-					if errClose := httpResp.Body.Close(); errClose != nil {
-						log.Errorf("antigravity executor: close response body error: %v", errClose)
+				case antigravity429DecisionShortCooldownSwitchAuth:
+					if decision.retryAfter != nil && *decision.retryAfter > 0 {
+						markAntigravityShortCooldown(auth, baseModel, time.Now(), *decision.retryAfter)
+						log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown and skipping credits fallback", *decision.retryAfter, baseModel)
 					}
-					if errRead != nil {
-						helps.RecordAPIResponseError(ctx, e.cfg, errRead)
-						err = errRead
-						return resp, err
-					}
-					helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
-				} else {
-					creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, false, opts.Alt, baseURL, bodyBytes)
-					if creditsResp != nil {
-						helps.RecordAPIResponseMetadata(ctx, e.cfg, creditsResp.StatusCode, creditsResp.Header.Clone())
-						creditsBody, errCreditsRead := io.ReadAll(creditsResp.Body)
-						if errClose := creditsResp.Body.Close(); errClose != nil {
-							log.Errorf("antigravity executor: close credits success response body error: %v", errClose)
+				case antigravity429DecisionFullQuotaExhausted:
+					if usedCreditsDirect {
+						clearAntigravityPreferCredits(auth, baseModel)
+						recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
+					} else {
+						creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, false, opts.Alt, baseURL, bodyBytes)
+						if creditsResp != nil {
+							helps.RecordAPIResponseMetadata(ctx, e.cfg, creditsResp.StatusCode, creditsResp.Header.Clone())
+							creditsBody, errCreditsRead := io.ReadAll(creditsResp.Body)
+							if errClose := creditsResp.Body.Close(); errClose != nil {
+								log.Errorf("antigravity executor: close credits success response body error: %v", errClose)
+							}
+							if errCreditsRead != nil {
+								helps.RecordAPIResponseError(ctx, e.cfg, errCreditsRead)
+								err = errCreditsRead
+								return resp, err
+							}
+							helps.AppendAPIResponseChunk(ctx, e.cfg, creditsBody)
+							reporter.Publish(ctx, helps.ParseAntigravityUsage(creditsBody))
+							var param any
+							converted := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, creditsBody, &param)
+							resp = cliproxyexecutor.Response{Payload: converted, Headers: creditsResp.Header.Clone()}
+							reporter.EnsurePublished(ctx)
+							return resp, nil
 						}
-						if errCreditsRead != nil {
-							helps.RecordAPIResponseError(ctx, e.cfg, errCreditsRead)
-							err = errCreditsRead
-							return resp, err
-						}
-						helps.AppendAPIResponseChunk(ctx, e.cfg, creditsBody)
-						reporter.Publish(ctx, helps.ParseAntigravityUsage(creditsBody))
-						var param any
-						converted := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, creditsBody, &param)
-						resp = cliproxyexecutor.Response{Payload: converted, Headers: creditsResp.Header.Clone()}
-						reporter.EnsurePublished(ctx)
-						return resp, nil
 					}
 				}
 			}
@@ -741,6 +792,16 @@ attemptLoop:
 						continue attemptLoop
 					}
 				}
+				if antigravityShouldRetrySoftRateLimit(httpResp.StatusCode, bodyBytes) {
+					if attempt+1 < attempts {
+						delay := antigravitySoftRateLimitDelay(attempt)
+						log.Debugf("antigravity executor: soft rate limit for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
+						if errWait := antigravityWait(ctx, delay); errWait != nil {
+							return resp, errWait
+						}
+						continue attemptLoop
+					}
+				}
 				err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
 				return resp, err
 			}
@@ -770,6 +831,12 @@ attemptLoop:
 // executeClaudeNonStream performs a claude non-streaming request to the Antigravity API.
 func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	if inCooldown, remaining := antigravityIsInShortCooldown(auth, baseModel, time.Now()); inCooldown {
+		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
+		d := remaining
+		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+	}
+
 
 	token, updatedAuth, errToken := e.ensureAccessToken(ctx, auth)
 	if errToken != nil {
@@ -882,37 +949,34 @@ attemptLoop:
 				}
 				helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
 				if httpResp.StatusCode == http.StatusTooManyRequests {
-					if usedCreditsDirect {
-						clearAntigravityPreferCredits(auth, baseModel)
-						recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
-						httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, true, opts.Alt, baseURL)
-						if errReq != nil {
-							err = errReq
-							return resp, err
-						}
-						httpResp, errDo = httpClient.Do(httpReq)
-						if errDo != nil {
-							helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-							if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
-								return resp, errDo
+					decision := decideAntigravity429(bodyBytes)
+
+					switch decision.kind {
+					case antigravity429DecisionInstantRetrySameAuth:
+						if attempt+1 < attempts {
+							if decision.retryAfter != nil && *decision.retryAfter > 0 {
+								log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, *decision.retryAfter)
+								if errWait := antigravityWait(ctx, *decision.retryAfter); errWait != nil {
+									return resp, errWait
+								}
 							}
-							lastStatus = 0
-							lastBody = nil
-							lastErr = errDo
-							if idx+1 < len(baseURLs) {
-								log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-								continue
-							}
-							err = errDo
-							return resp, err
+							continue attemptLoop
 						}
-						helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-						goto streamSuccessClaudeNonStream
-					} else {
-						creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
-						if creditsResp != nil {
-							httpResp = creditsResp
-							helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+					case antigravity429DecisionShortCooldownSwitchAuth:
+						if decision.retryAfter != nil && *decision.retryAfter > 0 {
+							markAntigravityShortCooldown(auth, baseModel, time.Now(), *decision.retryAfter)
+							log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown and skipping credits fallback", *decision.retryAfter, baseModel)
+						}
+					case antigravity429DecisionFullQuotaExhausted:
+						if usedCreditsDirect {
+							clearAntigravityPreferCredits(auth, baseModel)
+							recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
+						} else {
+							creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
+							if creditsResp != nil {
+								httpResp = creditsResp
+								helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+							}
 						}
 					}
 				}
@@ -942,6 +1006,16 @@ attemptLoop:
 					if attempt+1 < attempts {
 						delay := antigravityNoCapacityRetryDelay(attempt)
 						log.Debugf("antigravity executor: no capacity for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
+						if errWait := antigravityWait(ctx, delay); errWait != nil {
+							return resp, errWait
+						}
+						continue attemptLoop
+					}
+				}
+				if antigravityShouldRetrySoftRateLimit(httpResp.StatusCode, bodyBytes) {
+					if attempt+1 < attempts {
+						delay := antigravitySoftRateLimitDelay(attempt)
+						log.Debugf("antigravity executor: soft rate limit for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
 						if errWait := antigravityWait(ctx, delay); errWait != nil {
 							return resp, errWait
 						}
@@ -1227,6 +1301,12 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
 	ctx = context.WithValue(ctx, "alt", "")
+	if inCooldown, remaining := antigravityIsInShortCooldown(auth, baseModel, time.Now()); inCooldown {
+		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
+		d := remaining
+		return nil, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+	}
+
 
 	token, updatedAuth, errToken := e.ensureAccessToken(ctx, auth)
 	if errToken != nil {
@@ -1338,43 +1418,62 @@ attemptLoop:
 				}
 				helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
 				if httpResp.StatusCode == http.StatusTooManyRequests {
-					if usedCreditsDirect {
-						clearAntigravityPreferCredits(auth, baseModel)
-						recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
-						httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, true, opts.Alt, baseURL)
-						if errReq != nil {
-							err = errReq
-							return nil, err
-						}
-						httpResp, errDo = httpClient.Do(httpReq)
-						if errDo != nil {
-							helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-							if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
-								return nil, errDo
+					decision := decideAntigravity429(bodyBytes)
+
+					switch decision.kind {
+					case antigravity429DecisionInstantRetrySameAuth:
+						if attempt+1 < attempts {
+							if decision.retryAfter != nil && *decision.retryAfter > 0 {
+								log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, *decision.retryAfter)
+								if errWait := antigravityWait(ctx, *decision.retryAfter); errWait != nil {
+									return nil, errWait
+								}
 							}
-							lastStatus = 0
-							lastBody = nil
-							lastErr = errDo
-							if idx+1 < len(baseURLs) {
-								log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-								continue
-							}
-							err = errDo
-							return nil, err
+							continue attemptLoop
 						}
-						helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-						goto streamSuccessExecuteStream
-					} else {
-						creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
-						if creditsResp != nil {
-							httpResp = creditsResp
+					case antigravity429DecisionShortCooldownSwitchAuth:
+						if decision.retryAfter != nil && *decision.retryAfter > 0 {
+							markAntigravityShortCooldown(auth, baseModel, time.Now(), *decision.retryAfter)
+							log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown and skipping credits fallback", *decision.retryAfter, baseModel)
+						}
+					case antigravity429DecisionFullQuotaExhausted:
+						if usedCreditsDirect {
+							clearAntigravityPreferCredits(auth, baseModel)
+							recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
+							httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, true, opts.Alt, baseURL)
+							if errReq != nil {
+								err = errReq
+								return nil, err
+							}
+							httpResp, errDo = httpClient.Do(httpReq)
+							if errDo != nil {
+								helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+								if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
+									return nil, errDo
+								}
+								lastStatus = 0
+								lastBody = nil
+								lastErr = errDo
+								if idx+1 < len(baseURLs) {
+									log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+									continue
+								}
+								err = errDo
+								return nil, err
+							}
 							helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+							goto streamSuccessExecuteStream
+						} else {
+							creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
+							if creditsResp != nil {
+								httpResp = creditsResp
+								helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+							}
 						}
 					}
 				}
 				if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
 					goto streamSuccessExecuteStream
-				}
 				}
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
@@ -1399,6 +1498,16 @@ attemptLoop:
 					if attempt+1 < attempts {
 						delay := antigravityNoCapacityRetryDelay(attempt)
 						log.Debugf("antigravity executor: no capacity for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
+						if errWait := antigravityWait(ctx, delay); errWait != nil {
+							return nil, errWait
+						}
+						continue attemptLoop
+					}
+				}
+				if antigravityShouldRetrySoftRateLimit(httpResp.StatusCode, bodyBytes) {
+					if attempt+1 < attempts {
+						delay := antigravitySoftRateLimitDelay(attempt)
+						log.Debugf("antigravity executor: soft rate limit for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
 						if errWait := antigravityWait(ctx, delay); errWait != nil {
 							return nil, errWait
 						}
@@ -2023,6 +2132,67 @@ func antigravityShouldRetryTransientResourceExhausted429(statusCode int, body []
 	}
 	msg := strings.ToLower(string(body))
 	return strings.Contains(msg, "resource has been exhausted")
+}
+
+
+func antigravityShouldRetrySoftRateLimit(statusCode int, body []byte) bool {
+	if statusCode != http.StatusTooManyRequests {
+		return false
+	}
+	return decideAntigravity429(body).kind == antigravity429DecisionSoftRetry
+}
+
+func antigravitySoftRateLimitDelay(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	base := time.Duration(attempt+1) * 500 * time.Millisecond
+	if base > 3*time.Second {
+		base = 3 * time.Second
+	}
+	return base
+}
+
+func antigravityShortCooldownKey(auth *cliproxyauth.Auth, modelName string) string {
+	if auth == nil {
+		return ""
+	}
+	authID := strings.TrimSpace(auth.ID)
+	modelName = strings.TrimSpace(modelName)
+	if authID == "" || modelName == "" {
+		return ""
+	}
+	return authID + "|" + modelName + "|sc"
+}
+
+func antigravityIsInShortCooldown(auth *cliproxyauth.Auth, modelName string, now time.Time) (bool, time.Duration) {
+	key := antigravityShortCooldownKey(auth, modelName)
+	if key == "" {
+		return false, 0
+	}
+	value, ok := antigravityShortCooldownByAuth.Load(key)
+	if !ok {
+		return false, 0
+	}
+	until, ok := value.(time.Time)
+	if !ok || until.IsZero() {
+		antigravityShortCooldownByAuth.Delete(key)
+		return false, 0
+	}
+	remaining := until.Sub(now)
+	if remaining <= 0 {
+		antigravityShortCooldownByAuth.Delete(key)
+		return false, 0
+	}
+	return true, remaining
+}
+
+func markAntigravityShortCooldown(auth *cliproxyauth.Auth, modelName string, now time.Time, duration time.Duration) {
+	key := antigravityShortCooldownKey(auth, modelName)
+	if key == "" {
+		return
+	}
+	antigravityShortCooldownByAuth.Store(key, now.Add(duration))
 }
 
 func antigravityNoCapacityRetryDelay(attempt int) time.Duration {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -664,7 +664,6 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	}
 
 	isClaude := strings.Contains(strings.ToLower(baseModel), "claude")
-
 	if isClaude || strings.Contains(baseModel, "gemini-3-pro") || strings.Contains(baseModel, "gemini-3.1-flash-image") {
 		return e.executeClaudeNonStream(ctx, auth, req, opts)
 	}
@@ -701,7 +700,6 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
-
 	attempts := antigravityRetryAttempts(auth, e.cfg)
 
 attemptLoop:
@@ -719,6 +717,7 @@ attemptLoop:
 					usedCreditsDirect = true
 				}
 			}
+
 			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, false, opts.Alt, baseURL)
 			if errReq != nil {
 				err = errReq
@@ -756,13 +755,14 @@ attemptLoop:
 
 			if httpResp.StatusCode == http.StatusTooManyRequests {
 				decision := decideAntigravity429(bodyBytes)
-
 				switch decision.kind {
 				case antigravity429DecisionInstantRetrySameAuth:
 					if attempt+1 < attempts {
 						if decision.retryAfter != nil && *decision.retryAfter > 0 {
-							log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, *decision.retryAfter)
-							if errWait := antigravityWait(ctx, *decision.retryAfter); errWait != nil {
+							wait := antigravityInstantRetryDelay(*decision.retryAfter)
+							log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, wait)
+							if errWait := antigravityWait(ctx, wait); errWait != nil {
+
 								return resp, errWait
 							}
 						}
@@ -799,6 +799,7 @@ attemptLoop:
 							return resp, nil
 						}
 					}
+				}
 			}
 
 			if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
@@ -984,8 +985,10 @@ attemptLoop:
 					case antigravity429DecisionInstantRetrySameAuth:
 						if attempt+1 < attempts {
 							if decision.retryAfter != nil && *decision.retryAfter > 0 {
-								log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, *decision.retryAfter)
-								if errWait := antigravityWait(ctx, *decision.retryAfter); errWait != nil {
+								wait := antigravityInstantRetryDelay(*decision.retryAfter)
+								log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, wait)
+								if errWait := antigravityWait(ctx, wait); errWait != nil {
+
 									return resp, errWait
 								}
 							}
@@ -1007,6 +1010,10 @@ attemptLoop:
 							helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 						}
 					}
+				}
+				}
+
+
 				if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
 					goto streamSuccessClaudeNonStream
 				}
@@ -1440,8 +1447,10 @@ attemptLoop:
 					case antigravity429DecisionInstantRetrySameAuth:
 						if attempt+1 < attempts {
 							if decision.retryAfter != nil && *decision.retryAfter > 0 {
-								log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, *decision.retryAfter)
-								if errWait := antigravityWait(ctx, *decision.retryAfter); errWait != nil {
+								wait := antigravityInstantRetryDelay(*decision.retryAfter)
+								log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, wait)
+								if errWait := antigravityWait(ctx, wait); errWait != nil {
+
 									return nil, errWait
 								}
 							}
@@ -1463,6 +1472,10 @@ attemptLoop:
 							helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 						}
 					}
+				}
+				}
+
+
 				if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
 					goto streamSuccessExecuteStream
 				}
@@ -2207,6 +2220,16 @@ func antigravityTransient429RetryDelay(attempt int) time.Duration {
 	}
 	return delay
 }
+
+func antigravityInstantRetryDelay(wait time.Duration) time.Duration {
+	if wait <= 0 {
+		return 0
+	}
+	return wait + 800*time.Millisecond
+}
+
+
+
 
 func antigravityWait(ctx context.Context, wait time.Duration) error {
 	if wait <= 0 {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -52,7 +52,7 @@ const (
 	antigravityCreditsRetryTTL             = 5 * time.Hour
 	antigravityCreditsAutoDisableDuration  = 5 * time.Hour
 	antigravityShortQuotaCooldownThreshold = 5 * time.Minute
-	antigravityInstantRetryThreshold       = 1 * time.Second
+	antigravityInstantRetryThreshold       = 3 * time.Second
 	// systemInstruction              = "You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.**Absolute paths only****Proactiveness**"
 )
 
@@ -727,30 +727,19 @@ attemptLoop:
 
 			httpResp, errDo := httpClient.Do(httpReq)
 			if errDo != nil {
-				if usedCreditsDirect {
-					e.handleDirectCreditsFailure(ctx, auth, baseModel, errDo)
-					httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, false, opts.Alt, baseURL)
-					if errReq != nil {
-						err = errReq
-						return resp, err
-					}
-					httpResp, errDo = httpClient.Do(httpReq)
+				helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+				if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
+					return resp, errDo
 				}
-				if errDo != nil {
-					helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-					if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
-						return resp, errDo
-					}
-					lastStatus = 0
-					lastBody = nil
-					lastErr = errDo
-					if idx+1 < len(baseURLs) {
-						log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-						continue
-					}
-					err = errDo
-					return resp, err
+				lastStatus = 0
+				lastBody = nil
+				lastErr = errDo
+				if idx+1 < len(baseURLs) {
+					log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+					continue
 				}
+				err = errDo
+				return resp, err
 			}
 
 			helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
@@ -810,7 +799,6 @@ attemptLoop:
 							return resp, nil
 						}
 					}
-				}
 			}
 
 			if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
@@ -948,30 +936,19 @@ attemptLoop:
 
 			httpResp, errDo := httpClient.Do(httpReq)
 			if errDo != nil {
-				if usedCreditsDirect {
-					e.handleDirectCreditsFailure(ctx, auth, baseModel, errDo)
-					httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, true, opts.Alt, baseURL)
-					if errReq != nil {
-						err = errReq
-						return resp, err
-					}
-					httpResp, errDo = httpClient.Do(httpReq)
+				helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+				if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
+					return resp, errDo
 				}
-				if errDo != nil {
-					helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-					if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
-						return resp, errDo
-					}
-					lastStatus = 0
-					lastBody = nil
-					lastErr = errDo
-					if idx+1 < len(baseURLs) {
-						log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-						continue
-					}
-					err = errDo
-					return resp, err
+				lastStatus = 0
+				lastBody = nil
+				lastErr = errDo
+				if idx+1 < len(baseURLs) {
+					log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+					continue
 				}
+				err = errDo
+				return resp, err
 			}
 			helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 			if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
@@ -1019,19 +996,17 @@ attemptLoop:
 							markAntigravityShortCooldown(auth, baseModel, time.Now(), *decision.retryAfter)
 							log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown and skipping credits fallback", *decision.retryAfter, baseModel)
 						}
-					case antigravity429DecisionFullQuotaExhausted:
-						if usedCreditsDirect {
-							clearAntigravityPreferCredits(auth, baseModel)
-							recordAntigravityCreditsFailure(auth, time.Now())
-						} else {
-							creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
-							if creditsResp != nil {
-								httpResp = creditsResp
-								helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-							}
+				case antigravity429DecisionFullQuotaExhausted:
+					if usedCreditsDirect {
+						clearAntigravityPreferCredits(auth, baseModel)
+						recordAntigravityCreditsFailure(auth, time.Now())
+					} else {
+						creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
+						if creditsResp != nil {
+							httpResp = creditsResp
+							helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 						}
 					}
-				}
 				if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
 					goto streamSuccessClaudeNonStream
 				}
@@ -1417,30 +1392,19 @@ attemptLoop:
 			}
 			httpResp, errDo := httpClient.Do(httpReq)
 			if errDo != nil {
-				if usedCreditsDirect {
-					e.handleDirectCreditsFailure(ctx, auth, baseModel, errDo)
-					httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, true, opts.Alt, baseURL)
-					if errReq != nil {
-						err = errReq
-						return nil, err
-					}
-					httpResp, errDo = httpClient.Do(httpReq)
+				helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+				if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
+					return nil, errDo
 				}
-				if errDo != nil {
-					helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-					if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
-						return nil, errDo
-					}
-					lastStatus = 0
-					lastBody = nil
-					lastErr = errDo
-					if idx+1 < len(baseURLs) {
-						log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-						continue
-					}
-					err = errDo
-					return nil, err
+				lastStatus = 0
+				lastBody = nil
+				lastErr = errDo
+				if idx+1 < len(baseURLs) {
+					log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+					continue
 				}
+				err = errDo
+				return nil, err
 			}
 			helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 			if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
@@ -1488,42 +1452,17 @@ attemptLoop:
 							markAntigravityShortCooldown(auth, baseModel, time.Now(), *decision.retryAfter)
 							log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown and skipping credits fallback", *decision.retryAfter, baseModel)
 						}
-					case antigravity429DecisionFullQuotaExhausted:
-						if usedCreditsDirect {
-							clearAntigravityPreferCredits(auth, baseModel)
-							recordAntigravityCreditsFailure(auth, time.Now())
-							httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, true, opts.Alt, baseURL)
-							if errReq != nil {
-								err = errReq
-								return nil, err
-							}
-							httpResp, errDo = httpClient.Do(httpReq)
-							if errDo != nil {
-								helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-								if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
-									return nil, errDo
-								}
-								lastStatus = 0
-								lastBody = nil
-								lastErr = errDo
-								if idx+1 < len(baseURLs) {
-									log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-									continue
-								}
-								err = errDo
-								return nil, err
-							}
+				case antigravity429DecisionFullQuotaExhausted:
+					if usedCreditsDirect {
+						clearAntigravityPreferCredits(auth, baseModel)
+						recordAntigravityCreditsFailure(auth, time.Now())
+					} else {
+						creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
+						if creditsResp != nil {
+							httpResp = creditsResp
 							helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-							goto streamSuccessExecuteStream
-						} else {
-							creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
-							if creditsResp != nil {
-								httpResp = creditsResp
-								helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-							}
 						}
 					}
-				}
 				if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
 					goto streamSuccessExecuteStream
 				}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -49,11 +49,17 @@ const (
 	defaultAntigravityAgent        = "antigravity/1.21.9 darwin/arm64" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
 	antigravityAuthType            = "antigravity"
 	refreshSkew                    = 3000 * time.Second
-	antigravityCreditsRetryTTL     = 5 * time.Hour
+	antigravityCreditsRetryTTL = 5 * time.Hour
 	// systemInstruction              = "You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.**Absolute paths only****Proactiveness**"
 )
 
 type antigravity429Category string
+
+type antigravityCreditsFailureState struct {
+	Count               int
+	DisabledUntil       time.Time
+	PermanentlyDisabled bool
+}
 
 const (
 	antigravity429Unknown        antigravity429Category = "unknown"
@@ -62,10 +68,10 @@ const (
 )
 
 var (
-	randSource                        = rand.New(rand.NewSource(time.Now().UnixNano()))
-	randSourceMutex                   sync.Mutex
-	antigravityCreditsExhaustedByAuth sync.Map
-	antigravityPreferCreditsByModel   sync.Map
+	randSource                      = rand.New(rand.NewSource(time.Now().UnixNano()))
+	randSourceMutex                 sync.Mutex
+	antigravityCreditsFailureByAuth sync.Map
+	antigravityPreferCreditsByModel sync.Map
 	antigravityQuotaExhaustedKeywords = []string{
 		"quota_exhausted",
 		"quota exhausted",
@@ -287,38 +293,95 @@ func antigravityCreditsRetryEnabled(cfg *config.Config) bool {
 	return cfg != nil && cfg.QuotaExceeded.AntigravityCredits
 }
 
-func antigravityCreditsExhausted(auth *cliproxyauth.Auth, now time.Time) bool {
-	if auth == nil || strings.TrimSpace(auth.ID) == "" {
-		return false
+func antigravityCreditsFailureThreshold(cfg *config.Config) int {
+	if cfg == nil {
+		return 0
 	}
-	value, ok := antigravityCreditsExhaustedByAuth.Load(auth.ID)
+	return cfg.QuotaExceeded.AntigravityCreditsFailThreshold
+}
+
+func antigravityCreditsFailureStrategy(cfg *config.Config) string {
+	if cfg == nil {
+		return "temporary"
+	}
+	strategy := strings.ToLower(strings.TrimSpace(cfg.QuotaExceeded.AntigravityCreditsFailStrategy))
+	if strategy == "permanent" {
+		return strategy
+	}
+	return "temporary"
+}
+
+func antigravityCreditsDisableDuration(cfg *config.Config) time.Duration {
+	if cfg == nil || cfg.QuotaExceeded.AntigravityCreditsDisableMinutes <= 0 {
+		return 0
+	}
+	return time.Duration(cfg.QuotaExceeded.AntigravityCreditsDisableMinutes) * time.Minute
+}
+
+func antigravityCreditsFailureStateForAuth(auth *cliproxyauth.Auth) (string, antigravityCreditsFailureState, bool) {
+	if auth == nil || strings.TrimSpace(auth.ID) == "" {
+		return "", antigravityCreditsFailureState{}, false
+	}
+	authID := strings.TrimSpace(auth.ID)
+	value, ok := antigravityCreditsFailureByAuth.Load(authID)
+	if !ok {
+		return authID, antigravityCreditsFailureState{}, true
+	}
+	state, ok := value.(antigravityCreditsFailureState)
+	if !ok {
+		antigravityCreditsFailureByAuth.Delete(authID)
+		return authID, antigravityCreditsFailureState{}, true
+	}
+	return authID, state, true
+}
+
+func antigravityCreditsDisabled(cfg *config.Config, auth *cliproxyauth.Auth, now time.Time) bool {
+	authID, state, ok := antigravityCreditsFailureStateForAuth(auth)
 	if !ok {
 		return false
 	}
-	until, ok := value.(time.Time)
-	if !ok || until.IsZero() {
-		antigravityCreditsExhaustedByAuth.Delete(auth.ID)
+	if state.PermanentlyDisabled {
+		return true
+	}
+	if state.DisabledUntil.IsZero() {
 		return false
 	}
-	if !until.After(now) {
-		antigravityCreditsExhaustedByAuth.Delete(auth.ID)
-		return false
+	if state.DisabledUntil.After(now) {
+		return true
 	}
-	return true
+	antigravityCreditsFailureByAuth.Delete(authID)
+	return false
 }
 
-func markAntigravityCreditsExhausted(auth *cliproxyauth.Auth, now time.Time) {
+func recordAntigravityCreditsFailure(cfg *config.Config, auth *cliproxyauth.Auth, now time.Time) {
+	authID, state, ok := antigravityCreditsFailureStateForAuth(auth)
+	if !ok {
+		return
+	}
+	state.Count++
+	threshold := antigravityCreditsFailureThreshold(cfg)
+	if threshold > 0 && state.Count >= threshold {
+		switch antigravityCreditsFailureStrategy(cfg) {
+		case "permanent":
+			state.PermanentlyDisabled = true
+			state.DisabledUntil = time.Time{}
+		default:
+			disableFor := antigravityCreditsDisableDuration(cfg)
+			if disableFor > 0 {
+				state.DisabledUntil = now.Add(disableFor)
+			} else {
+				state.DisabledUntil = now
+			}
+		}
+	}
+	antigravityCreditsFailureByAuth.Store(authID, state)
+}
+
+func clearAntigravityCreditsFailureState(auth *cliproxyauth.Auth) {
 	if auth == nil || strings.TrimSpace(auth.ID) == "" {
 		return
 	}
-	antigravityCreditsExhaustedByAuth.Store(auth.ID, now.Add(antigravityCreditsRetryTTL))
-}
-
-func clearAntigravityCreditsExhausted(auth *cliproxyauth.Auth) {
-	if auth == nil || strings.TrimSpace(auth.ID) == "" {
-		return
-	}
-	antigravityCreditsExhaustedByAuth.Delete(auth.ID)
+	antigravityCreditsFailureByAuth.Delete(strings.TrimSpace(auth.ID))
 }
 
 func antigravityPreferCreditsKey(auth *cliproxyauth.Auth, modelName string) string {
@@ -425,7 +488,7 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 		return nil, false
 	}
 	now := time.Now()
-	if antigravityCreditsExhausted(auth, now) {
+	if antigravityCreditsDisabled(e.cfg, auth, now) {
 		return nil, false
 	}
 	creditsPayload := injectEnabledCreditTypes(payload)
@@ -436,17 +499,21 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 	httpReq, errReq := e.buildRequest(ctx, auth, token, modelName, creditsPayload, stream, alt, baseURL)
 	if errReq != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errReq)
+		clearAntigravityPreferCredits(auth, modelName)
+		recordAntigravityCreditsFailure(e.cfg, auth, now)
 		return nil, true
 	}
 	httpResp, errDo := httpClient.Do(httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+		clearAntigravityPreferCredits(auth, modelName)
+		recordAntigravityCreditsFailure(e.cfg, auth, now)
 		return nil, true
 	}
 	if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
 		retryAfter, _ := parseRetryDelay(originalBody)
 		markAntigravityPreferCredits(auth, modelName, now, retryAfter)
-		clearAntigravityCreditsExhausted(auth)
+		clearAntigravityCreditsFailureState(auth)
 		return httpResp, true
 	}
 
@@ -457,14 +524,22 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 	}
 	if errRead != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errRead)
+		clearAntigravityPreferCredits(auth, modelName)
+		recordAntigravityCreditsFailure(e.cfg, auth, now)
 		return nil, true
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
-	if shouldMarkAntigravityCreditsExhausted(httpResp.StatusCode, bodyBytes, nil) {
-		clearAntigravityPreferCredits(auth, modelName)
-		markAntigravityCreditsExhausted(auth, now)
-	}
+	clearAntigravityPreferCredits(auth, modelName)
+	recordAntigravityCreditsFailure(e.cfg, auth, now)
 	return nil, true
+}
+
+func (e *AntigravityExecutor) handleDirectCreditsFailure(ctx context.Context, auth *cliproxyauth.Auth, modelName string, reqErr error) {
+	if reqErr != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, reqErr)
+	}
+	clearAntigravityPreferCredits(auth, modelName)
+	recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
 }
 
 // Execute performs a non-streaming request to the Antigravity API.
@@ -537,19 +612,30 @@ attemptLoop:
 
 			httpResp, errDo := httpClient.Do(httpReq)
 			if errDo != nil {
-				helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-				if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
-					return resp, errDo
+				if usedCreditsDirect {
+					e.handleDirectCreditsFailure(ctx, auth, baseModel, errDo)
+					httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, false, opts.Alt, baseURL)
+					if errReq != nil {
+						err = errReq
+						return resp, err
+					}
+					httpResp, errDo = httpClient.Do(httpReq)
 				}
-				lastStatus = 0
-				lastBody = nil
-				lastErr = errDo
-				if idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
+				if errDo != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+					if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
+						return resp, errDo
+					}
+					lastStatus = 0
+					lastBody = nil
+					lastErr = errDo
+					if idx+1 < len(baseURLs) {
+						log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+						continue
+					}
+					err = errDo
+					return resp, err
 				}
-				err = errDo
-				return resp, err
 			}
 
 			helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
@@ -566,10 +652,40 @@ attemptLoop:
 
 			if httpResp.StatusCode == http.StatusTooManyRequests {
 				if usedCreditsDirect {
-					if shouldMarkAntigravityCreditsExhausted(httpResp.StatusCode, bodyBytes, nil) {
-						clearAntigravityPreferCredits(auth, baseModel)
-						markAntigravityCreditsExhausted(auth, time.Now())
+					clearAntigravityPreferCredits(auth, baseModel)
+					recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
+					httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, false, opts.Alt, baseURL)
+					if errReq != nil {
+						err = errReq
+						return resp, err
 					}
+					httpResp, errDo = httpClient.Do(httpReq)
+					if errDo != nil {
+						helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+						if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
+							return resp, errDo
+						}
+						lastStatus = 0
+						lastBody = nil
+						lastErr = errDo
+						if idx+1 < len(baseURLs) {
+							log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+							continue
+						}
+						err = errDo
+						return resp, err
+					}
+					helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+					bodyBytes, errRead = io.ReadAll(httpResp.Body)
+					if errClose := httpResp.Body.Close(); errClose != nil {
+						log.Errorf("antigravity executor: close response body error: %v", errClose)
+					}
+					if errRead != nil {
+						helps.RecordAPIResponseError(ctx, e.cfg, errRead)
+						err = errRead
+						return resp, err
+					}
+					helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
 				} else {
 					creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, false, opts.Alt, baseURL, bodyBytes)
 					if creditsResp != nil {
@@ -713,19 +829,30 @@ attemptLoop:
 
 			httpResp, errDo := httpClient.Do(httpReq)
 			if errDo != nil {
-				helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-				if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
-					return resp, errDo
+				if usedCreditsDirect {
+					e.handleDirectCreditsFailure(ctx, auth, baseModel, errDo)
+					httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, true, opts.Alt, baseURL)
+					if errReq != nil {
+						err = errReq
+						return resp, err
+					}
+					httpResp, errDo = httpClient.Do(httpReq)
 				}
-				lastStatus = 0
-				lastBody = nil
-				lastErr = errDo
-				if idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
+				if errDo != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+					if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
+						return resp, errDo
+					}
+					lastStatus = 0
+					lastBody = nil
+					lastErr = errDo
+					if idx+1 < len(baseURLs) {
+						log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+						continue
+					}
+					err = errDo
+					return resp, err
 				}
-				err = errDo
-				return resp, err
 			}
 			helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 			if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
@@ -756,10 +883,31 @@ attemptLoop:
 				helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
 				if httpResp.StatusCode == http.StatusTooManyRequests {
 					if usedCreditsDirect {
-						if shouldMarkAntigravityCreditsExhausted(httpResp.StatusCode, bodyBytes, nil) {
-							clearAntigravityPreferCredits(auth, baseModel)
-							markAntigravityCreditsExhausted(auth, time.Now())
+						clearAntigravityPreferCredits(auth, baseModel)
+						recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
+						httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, true, opts.Alt, baseURL)
+						if errReq != nil {
+							err = errReq
+							return resp, err
 						}
+						httpResp, errDo = httpClient.Do(httpReq)
+						if errDo != nil {
+							helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+							if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
+								return resp, errDo
+							}
+							lastStatus = 0
+							lastBody = nil
+							lastErr = errDo
+							if idx+1 < len(baseURLs) {
+								log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+								continue
+							}
+							err = errDo
+							return resp, err
+						}
+						helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+						goto streamSuccessClaudeNonStream
 					} else {
 						creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
 						if creditsResp != nil {
@@ -1137,19 +1285,30 @@ attemptLoop:
 			}
 			httpResp, errDo := httpClient.Do(httpReq)
 			if errDo != nil {
-				helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-				if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
-					return nil, errDo
+				if usedCreditsDirect {
+					e.handleDirectCreditsFailure(ctx, auth, baseModel, errDo)
+					httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, true, opts.Alt, baseURL)
+					if errReq != nil {
+						err = errReq
+						return nil, err
+					}
+					httpResp, errDo = httpClient.Do(httpReq)
 				}
-				lastStatus = 0
-				lastBody = nil
-				lastErr = errDo
-				if idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
+				if errDo != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+					if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
+						return nil, errDo
+					}
+					lastStatus = 0
+					lastBody = nil
+					lastErr = errDo
+					if idx+1 < len(baseURLs) {
+						log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+						continue
+					}
+					err = errDo
+					return nil, err
 				}
-				err = errDo
-				return nil, err
 			}
 			helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 			if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
@@ -1180,10 +1339,31 @@ attemptLoop:
 				helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
 				if httpResp.StatusCode == http.StatusTooManyRequests {
 					if usedCreditsDirect {
-						if shouldMarkAntigravityCreditsExhausted(httpResp.StatusCode, bodyBytes, nil) {
-							clearAntigravityPreferCredits(auth, baseModel)
-							markAntigravityCreditsExhausted(auth, time.Now())
+						clearAntigravityPreferCredits(auth, baseModel)
+						recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
+						httpReq, errReq = e.buildRequest(ctx, auth, token, baseModel, translated, true, opts.Alt, baseURL)
+						if errReq != nil {
+							err = errReq
+							return nil, err
 						}
+						httpResp, errDo = httpClient.Do(httpReq)
+						if errDo != nil {
+							helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+							if errors.Is(errDo, context.Canceled) || errors.Is(errDo, context.DeadlineExceeded) {
+								return nil, errDo
+							}
+							lastStatus = 0
+							lastBody = nil
+							lastErr = errDo
+							if idx+1 < len(baseURLs) {
+								log.Debugf("antigravity executor: request error on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+								continue
+							}
+							err = errDo
+							return nil, err
+						}
+						helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+						goto streamSuccessExecuteStream
 					} else {
 						creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
 						if creditsResp != nil {
@@ -1194,6 +1374,7 @@ attemptLoop:
 				}
 				if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
 					goto streamSuccessExecuteStream
+				}
 				}
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -61,7 +61,9 @@ type antigravityCreditsFailureState struct {
 	Count               int
 	DisabledUntil       time.Time
 	PermanentlyDisabled bool
+	ExplicitBalanceExhausted bool
 }
+
 
 type antigravity429DecisionKind string
 
@@ -440,6 +442,38 @@ func clearAntigravityCreditsFailureState(auth *cliproxyauth.Auth) {
 	}
 	antigravityCreditsFailureByAuth.Delete(strings.TrimSpace(auth.ID))
 }
+func markAntigravityCreditsPermanentlyDisabled(auth *cliproxyauth.Auth) {
+	if auth == nil || strings.TrimSpace(auth.ID) == "" {
+		return
+	}
+	authID := strings.TrimSpace(auth.ID)
+	state := antigravityCreditsFailureState{
+		PermanentlyDisabled:   true,
+		ExplicitBalanceExhausted: true,
+	}
+	antigravityCreditsFailureByAuth.Store(authID, state)
+}
+
+func antigravityHasExplicitCreditsBalanceExhaustedReason(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	details := gjson.GetBytes(body, "error.details")
+	if !details.Exists() || !details.IsArray() {
+		return false
+	}
+	for _, detail := range details.Array() {
+		if detail.Get("@type").String() != "type.googleapis.com/google.rpc.ErrorInfo" {
+			continue
+		}
+		reason := strings.TrimSpace(detail.Get("reason").String())
+		if strings.EqualFold(reason, "INSUFFICIENT_G1_CREDITS_BALANCE") {
+			return true
+		}
+	}
+	return false
+}
+
 
 func antigravityPreferCreditsKey(auth *cliproxyauth.Auth, modelName string) string {
 	if auth == nil {
@@ -545,6 +579,18 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 		return nil, false
 	}
 	now := time.Now()
+	if shouldForcePermanentDisableCredits(originalBody) {
+		clearAntigravityPreferCredits(auth, modelName)
+		markAntigravityCreditsPermanentlyDisabled(auth)
+		return nil, false
+	}
+
+	if antigravityHasExplicitCreditsBalanceExhaustedReason(originalBody) {
+		clearAntigravityPreferCredits(auth, modelName)
+		markAntigravityCreditsPermanentlyDisabled(auth)
+		return nil, false
+	}
+
 	if antigravityCreditsDisabled(e.cfg, auth, now) {
 		return nil, false
 	}
@@ -586,6 +632,18 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 		return nil, true
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
+	if shouldForcePermanentDisableCredits(bodyBytes) {
+		clearAntigravityPreferCredits(auth, modelName)
+		markAntigravityCreditsPermanentlyDisabled(auth)
+		return nil, true
+	}
+
+	if antigravityHasExplicitCreditsBalanceExhaustedReason(bodyBytes) {
+		clearAntigravityPreferCredits(auth, modelName)
+		markAntigravityCreditsPermanentlyDisabled(auth)
+		return nil, true
+	}
+
 	clearAntigravityPreferCredits(auth, modelName)
 	recordAntigravityCreditsFailure(e.cfg, auth, now)
 	return nil, true
@@ -593,11 +651,38 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 
 func (e *AntigravityExecutor) handleDirectCreditsFailure(ctx context.Context, auth *cliproxyauth.Auth, modelName string, reqErr error) {
 	if reqErr != nil {
+		if shouldForcePermanentDisableCredits(reqErrBody(reqErr)) {
+			clearAntigravityPreferCredits(auth, modelName)
+			markAntigravityCreditsPermanentlyDisabled(auth)
+			return
+		}
+
+	if antigravityHasExplicitCreditsBalanceExhaustedReason(reqErrBody(reqErr)) {
+		clearAntigravityPreferCredits(auth, modelName)
+		markAntigravityCreditsPermanentlyDisabled(auth)
+		return
+	}
+
 		helps.RecordAPIResponseError(ctx, e.cfg, reqErr)
 	}
 	clearAntigravityPreferCredits(auth, modelName)
 	recordAntigravityCreditsFailure(e.cfg, auth, time.Now())
 }
+func reqErrBody(reqErr error) []byte {
+	if reqErr == nil {
+		return nil
+	}
+	msg := reqErr.Error()
+	if strings.TrimSpace(msg) == "" {
+		return nil
+	}
+	return []byte(msg)
+}
+
+func shouldForcePermanentDisableCredits(body []byte) bool {
+	return antigravityHasExplicitCreditsBalanceExhaustedReason(body)
+}
+
 
 // Execute performs a non-streaming request to the Antigravity API.
 func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {


### PR DESCRIPTION
### 1. 补齐 Antigravity 超细 429 状态机
在 `internal/runtime/executor/antigravity_executor.go` 中新增并接入：
- `decideAntigravity429(...)`
- `classifyAntigravity429(...)`

支持以下状态分类：
- `soft_retry`
- `instant_retry_same_auth`
- `short_cooldown_switch_auth`
- `full_quota_exhausted`

### 2. 增加 same-auth instant retry
当 429 被识别为极短限流时：
- 不立即失败
- 不立即切换 auth
- 而是同 auth 短等待后重试

### 3. 增加 short cooldown 机制
新增：
- `antigravityShortCooldownKey(...)`
- `antigravityIsInShortCooldown(...)`
- `markAntigravityShortCooldown(...)`

当某个 auth + model 命中短冷却时，会提前返回带 `retryAfter` 的 429，便于上层切换账号或等待。

### 4. 增加 soft rate limit retry
新增：
- `antigravityShouldRetrySoftRateLimit(...)`
- `antigravitySoftRateLimitDelay(...)`

当 429 属于 soft rate limit 时，会走短退避重试，而不是直接进入硬失败路径。

### 5. 三条执行链统一接入
以下执行路径都已统一接入超细 429 状态机：
- `Execute(...)`
- `executeClaudeNonStream(...)`
- `ExecuteStream(...)`

### 6. 保留并扩展 credits 失败多次策略
在配置中新增字段：
- `antigravity-credits-fail-threshold`
- `antigravity-credits-fail-strategy`
- `antigravity-credits-disable-minutes`

支持两种策略：
- `temporary`：限时尝试
- `permanent`：永久禁止

### 7. 优化 credits 失败后的处理方式
保留并强化当前逻辑：
- credits 失败不直接作为主请求最终失败
- 优先回退普通请求路径
- 避免 credits 失败直接扩大成整体调度失败




## 配置示例

### 限时尝试
```yaml
quota-exceeded:
  antigravity-credits: true
  antigravity-credits-fail-threshold: 3
  antigravity-credits-fail-strategy: "temporary"
  antigravity-credits-disable-minutes: 30
```

### 永久禁止
```yaml
quota-exceeded:
  antigravity-credits: true
  antigravity-credits-fail-threshold: 3
  antigravity-credits-fail-strategy: "permanent"
```

## 验证结果
已完成：
- 服务器安装 Go 编译环境
- 完整源码重新上传到服务器
- 服务器本地成功执行 `go build -o /tmp/CLIProxyAPI.build ./cmd/server`
- 替换 `/opt/cliproxyapi/CLIProxyAPI`
- 重启 `cliproxyapi.service`
- 健康检查通过：`/healthz -> {"status":"ok"}`