### PR TITLE
fix(auth): preserve API key enforcement for legacy auth.providers configs

### DIFF
--- a/internal/config/access_legacy_auth_test.go
+++ b/internal/config/access_legacy_auth_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoadConfigOptional_MigratesLegacyAuthProviders(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	configYAML := []byte(`
+auth:
+  providers:
+    - type: config-api-key
+      api-keys:
+        - legacy-key-1
+        - legacy-key-2
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+
+	want := []string{"legacy-key-1", "legacy-key-2"}
+	if !reflect.DeepEqual(cfg.APIKeys, want) {
+		t.Fatalf("APIKeys = %v, want %v", cfg.APIKeys, want)
+	}
+}
+
+func TestLoadConfigOptional_MergesTopLevelAndLegacyAuthProviders(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	configYAML := []byte(`
+api-keys:
+  - current-key-1
+auth:
+  providers:
+    - type: config-api-key
+      api-keys:
+        - current-key-1
+        - legacy-key-2
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+
+	want := []string{"current-key-1", "legacy-key-2"}
+	if !reflect.DeepEqual(cfg.APIKeys, want) {
+		t.Fatalf("APIKeys = %v, want %v", cfg.APIKeys, want)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -589,6 +589,13 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 
+	var legacy legacyConfigData
+	if errLegacy := yaml.Unmarshal(data, &legacy); errLegacy == nil {
+		if cfg.migrateLegacyAuthProviders(legacy.Auth.Providers) {
+			cfg.legacyMigrationPending = true
+		}
+	}
+
 	// NOTE: Startup legacy key migration is intentionally disabled.
 	// Reason: avoid mutating config.yaml during server startup.
 	// Re-enable the block below if automatic startup migration is needed again.
@@ -1708,6 +1715,7 @@ func normalizeCollectionNodeStyles(node *yaml.Node) {
 type legacyConfigData struct {
 	LegacyGeminiKeys      []string                    `yaml:"generative-language-api-key"`
 	OpenAICompat          []legacyOpenAICompatibility `yaml:"openai-compatibility"`
+	Auth                  legacyAuthConfig            `yaml:"auth"`
 	AmpUpstreamURL        string                      `yaml:"amp-upstream-url"`
 	AmpUpstreamAPIKey     string                      `yaml:"amp-upstream-api-key"`
 	AmpRestrictManagement *bool                       `yaml:"amp-restrict-management-to-localhost"`
@@ -1718,6 +1726,49 @@ type legacyOpenAICompatibility struct {
 	Name    string   `yaml:"name"`
 	BaseURL string   `yaml:"base-url"`
 	APIKeys []string `yaml:"api-keys"`
+}
+
+type legacyAuthConfig struct {
+	Providers []legacyAccessProvider `yaml:"providers"`
+}
+
+type legacyAccessProvider struct {
+	Type    string   `yaml:"type"`
+	APIKeys []string `yaml:"api-keys"`
+}
+
+func (cfg *Config) migrateLegacyAuthProviders(providers []legacyAccessProvider) bool {
+	if cfg == nil || len(providers) == 0 {
+		return false
+	}
+	changed := false
+	seen := make(map[string]struct{}, len(cfg.APIKeys))
+	for i := range cfg.APIKeys {
+		key := strings.TrimSpace(cfg.APIKeys[i])
+		if key == "" {
+			continue
+		}
+		seen[key] = struct{}{}
+	}
+	for i := range providers {
+		providerType := strings.ToLower(strings.TrimSpace(providers[i].Type))
+		if providerType != "" && providerType != "config-api-key" {
+			continue
+		}
+		for _, raw := range providers[i].APIKeys {
+			key := strings.TrimSpace(raw)
+			if key == "" {
+				continue
+			}
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			cfg.APIKeys = append(cfg.APIKeys, key)
+			seen[key] = struct{}{}
+			changed = true
+		}
+	}
+	return changed
 }
 
 func (cfg *Config) migrateLegacyGeminiKeys(legacy []string) bool {


### PR DESCRIPTION
### Motivation
- A refactor removed support for legacy `auth.providers` API key entries which could leave the runtime with zero access providers and allow unauthenticated requests.
- The change restores compatibility for deployments that still define API keys under the legacy `auth.providers` block so authentication is not silently disabled after upgrades.
- The fix migrates legacy `config-api-key` provider keys into the in-memory `APIKeys` list during config loading without changing global auth manager semantics.

### Description
- Parse a legacy `auth.providers` section in the YAML via the existing `legacyConfigData` and add `Auth`/provider structs to recognize `api-keys` entries for legacy providers. (`internal/config/config.go`)
- Implement `migrateLegacyAuthProviders` to trim, deduplicate, and merge `auth.providers[*].api-keys` for `config-api-key` providers into the top-level `cfg.APIKeys` slice in-memory. (`internal/config/config.go`)
- Hook the migration into `LoadConfigOptional` immediately after YAML unmarshal and mark `cfg.legacyMigrationPending = true` when keys were migrated to preserve the existing non-mutating startup behavior. (`internal/config/config.go`)
- Add regression tests covering a legacy-only `auth.providers` config and a config that merges top-level `api-keys` with legacy `auth.providers` keys. (`internal/config/access_legacy_auth_test.go`)

### Testing
- Ran `gofmt -w` on modified files to satisfy formatting requirements and ensure import/format hygiene.
- Ran `go test ./internal/config` and the test suite passed successfully.
- Built the server with `go build -o test-output ./cmd/server && rm test-output` to verify the change compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80b889ffc832f9b25696f9272f5d0)