### PR TITLE
fix(amp): enforce auth on root management routes

### DIFF
--- a/internal/api/modules/amp/routes.go
+++ b/internal/api/modules/amp/routes.go
@@ -127,20 +127,6 @@ func (m *AmpModule) managementAvailabilityMiddleware() gin.HandlerFunc {
 	}
 }
 
-// wrapManagementAuth skips auth for selected management paths while keeping authentication elsewhere.
-func wrapManagementAuth(auth gin.HandlerFunc, prefixes ...string) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		path := c.Request.URL.Path
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(path, prefix) && (len(path) == len(prefix) || path[len(prefix)] == '/') {
-				c.Next()
-				return
-			}
-		}
-		auth(c)
-	}
-}
-
 // registerManagementRoutes registers Amp management proxy routes
 // These routes proxy through to the Amp control plane for OAuth, user management, etc.
 // Uses dynamic middleware and proxy getter for hot-reload support.
@@ -155,10 +141,8 @@ func (m *AmpModule) registerManagementRoutes(engine *gin.Engine, baseHandler *ha
 	ampAPI.Use(m.localhostOnlyMiddleware())
 
 	// Apply authentication middleware - requires valid API key in Authorization header
-	var authWithBypass gin.HandlerFunc
 	if auth != nil {
 		ampAPI.Use(auth)
-		authWithBypass = wrapManagementAuth(auth, "/threads", "/auth", "/docs", "/settings")
 	}
 
 	// Inject client API key into request context for per-client upstream routing
@@ -207,8 +191,8 @@ func (m *AmpModule) registerManagementRoutes(engine *gin.Engine, baseHandler *ha
 	// Root-level routes that AMP CLI expects without /api prefix
 	// These need the same security middleware as the /api/* routes (dynamic for hot-reload)
 	rootMiddleware := []gin.HandlerFunc{m.managementAvailabilityMiddleware(), noCORSMiddleware(), m.localhostOnlyMiddleware()}
-	if authWithBypass != nil {
-		rootMiddleware = append(rootMiddleware, authWithBypass)
+	if auth != nil {
+		rootMiddleware = append(rootMiddleware, auth)
 	}
 	// Add clientAPIKeyMiddleware after auth for per-client upstream routing
 	rootMiddleware = append(rootMiddleware, clientAPIKeyMiddleware())


### PR DESCRIPTION
### Motivation

- Close an authentication bypass where root-level Amp management routes (e.g., `/threads`, `/auth`) could be accessed without the configured API-key auth, which allowed privileged upstream proxying.

### Description

- Remove the `wrapManagementAuth` bypass helper that selectively skipped auth for certain root prefixes.
- Apply the configured `auth` middleware directly to root-level management routes when present so root routes receive the same API-key checks as `/api/*` routes.
- Preserve existing management middlewares (`managementAvailabilityMiddleware`, `noCORSMiddleware`, `localhostOnlyMiddleware`) and keep `clientAPIKeyMiddleware` applied after auth for per-client upstream routing.

### Testing

- Ran `go test ./internal/api/modules/amp` and the package tests passed successfully.
- Built the server with `go build -o test-output ./cmd/server && rm test-output` and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81ecbf1f4832fbcc461ae7baa592a)