### PR TITLE
fix(usage): skip null usage node in streaming response parsing

### DIFF
--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -241,7 +241,7 @@ func ParseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {
 		return usage.Detail{}, false
 	}
 	usageNode := gjson.GetBytes(payload, "usage")
-	if !usageNode.Exists() || usageNode.Type != gjson.JSON {
+	if !usageNode.Exists() || !usageNode.IsObject() {
 		return usage.Detail{}, false
 	}
 	detail := usage.Detail{
@@ -282,7 +282,7 @@ func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
 		return usage.Detail{}, false
 	}
 	usageNode := gjson.GetBytes(payload, "usage")
-	if !usageNode.Exists() || usageNode.Type != gjson.JSON {
+	if !usageNode.Exists() || !usageNode.IsObject() {
 		return usage.Detail{}, false
 	}
 	detail := usage.Detail{
@@ -344,7 +344,7 @@ func ParseGeminiStreamUsage(line []byte) (usage.Detail, bool) {
 	if !node.Exists() {
 		node = gjson.GetBytes(payload, "usage_metadata")
 	}
-	if !node.Exists() {
+	if !node.Exists() || !node.IsObject() {
 		return usage.Detail{}, false
 	}
 	return parseGeminiFamilyUsageDetail(node), true
@@ -359,7 +359,7 @@ func ParseGeminiCLIStreamUsage(line []byte) (usage.Detail, bool) {
 	if !node.Exists() {
 		node = gjson.GetBytes(payload, "usage_metadata")
 	}
-	if !node.Exists() {
+	if !node.Exists() || !node.IsObject() {
 		return usage.Detail{}, false
 	}
 	return parseGeminiFamilyUsageDetail(node), true
@@ -392,7 +392,7 @@ func ParseAntigravityStreamUsage(line []byte) (usage.Detail, bool) {
 	if !node.Exists() {
 		node = gjson.GetBytes(payload, "usage_metadata")
 	}
-	if !node.Exists() {
+	if !node.Exists() || !node.IsObject() {
 		return usage.Detail{}, false
 	}
 	return parseGeminiFamilyUsageDetail(node), true

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -241,7 +241,7 @@ func ParseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {
 		return usage.Detail{}, false
 	}
 	usageNode := gjson.GetBytes(payload, "usage")
-	if !usageNode.Exists() {
+	if !usageNode.Exists() || usageNode.Type != gjson.JSON {
 		return usage.Detail{}, false
 	}
 	detail := usage.Detail{
@@ -282,7 +282,7 @@ func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
 		return usage.Detail{}, false
 	}
 	usageNode := gjson.GetBytes(payload, "usage")
-	if !usageNode.Exists() {
+	if !usageNode.Exists() || usageNode.Type != gjson.JSON {
 		return usage.Detail{}, false
 	}
 	detail := usage.Detail{


### PR DESCRIPTION
## Summary
- Fix `ParseOpenAIStreamUsage` and `ParseClaudeStreamUsage` to skip chunks where `usage` is `null`
- Previously, chunks with `"usage": null` would pass the `Exists()` check but return 0 for all token fields
- This caused streaming requests to record zero tokens when upstream returns null usage in intermediate chunks

## Test plan
- [x] Verified fix with MiniMax-M2.7 streaming requests - tokens now recorded correctly
- [x] All existing tests pass

## Fix
```go
// Before
if !usageNode.Exists() { ... }

// After  
if !usageNode.Exists() || usageNode.Type != gjson.JSON { ... }
```