### PR TITLE
fix(antigravity): 针对 gRPC 与 HTTP/2 传输层的综合修复与改进

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1564,8 +1564,9 @@ attemptLoop:
 
 				if isGRPC {
 					frameCount := 0
+					header := make([]byte, 5)
+					var msgBuf []byte
 					for {
-						header := make([]byte, 5)
 						if _, errRead := io.ReadFull(resp.Body, header); errRead != nil {
 							if errRead != io.EOF {
 								helps.RecordAPIResponseError(ctx, e.cfg, errRead)
@@ -1580,7 +1581,10 @@ attemptLoop:
 							out <- cliproxyexecutor.StreamChunk{Err: errMax}
 							break
 						}
-						msg := make([]byte, length)
+						if uint32(cap(msgBuf)) < length {
+							msgBuf = make([]byte, length)
+						}
+						msg := msgBuf[:length]
 						if _, errRead := io.ReadFull(resp.Body, msg); errRead != nil {
 							helps.RecordAPIResponseError(ctx, e.cfg, errRead)
 							out <- cliproxyexecutor.StreamChunk{Err: errRead}
@@ -2487,36 +2491,54 @@ func encodeAntigravityProtoRequest(payload []byte) []byte {
 // decodeAntigravityProtoResponse decodes a StreamGenerateContentResponse proto to JSON.
 func decodeAntigravityProtoResponse(msg []byte) []byte {
 	res := []byte(`{"response":{"candidates":[]}}`)
-	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+	err := walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
 		switch num {
 		case 1: // candidates
 			if typ == protowire.BytesType {
-				candidate := decodeCandidateProto(raw)
+				val, n := protowire.ConsumeBytes(raw)
+				if n < 0 {
+					return protowire.ParseError(n)
+				}
+				candidate := decodeCandidateProto(val)
 				res, _ = sjson.SetRawBytes(res, "response.candidates.-1", candidate)
 			}
 		case 3: // usageMetadata
 			if typ == protowire.BytesType {
-				usage := decodeUsageProto(raw)
+				val, n := protowire.ConsumeBytes(raw)
+				if n < 0 {
+					return protowire.ParseError(n)
+				}
+				usage := decodeUsageProto(val)
 				res, _ = sjson.SetRawBytes(res, "response.usageMetadata", usage)
 			}
 		}
 		return nil
 	})
+	if err != nil {
+		log.Errorf("antigravity executor: failed to decode proto response: %v", err)
+	}
 	return res
 }
 
 func decodeCandidateProto(msg []byte) []byte {
 	res := []byte(`{"content":{"parts":[]}}`)
-	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+	err := walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
 		switch num {
 		case 2: // content
 			if typ == protowire.BytesType {
-				content := decodeContentProto(raw)
+				val, n := protowire.ConsumeBytes(raw)
+				if n < 0 {
+					return protowire.ParseError(n)
+				}
+				content := decodeContentProto(val)
 				res, _ = sjson.SetRawBytes(res, "content", content)
 			}
 		case 3: // finishReason
 			if typ == protowire.VarintType {
-				val, _ := protowire.ConsumeVarint(raw)
+				val, n := protowire.ConsumeVarint(raw)
+				if n < 0 {
+					return protowire.ParseError(n)
+				}
 				reasons := []string{"FINISH_REASON_UNSPECIFIED", "STOP", "MAX_TOKENS", "SAFETY", "RECITATION", "OTHER"}
 				reason := "UNKNOWN"
 				if val < uint64(len(reasons)) {
@@ -2527,74 +2549,119 @@ func decodeCandidateProto(msg []byte) []byte {
 		}
 		return nil
 	})
+	if err != nil {
+		log.Errorf("antigravity executor: failed to decode candidate proto: %v", err)
+	}
 	return res
 }
 
 func decodeContentProto(msg []byte) []byte {
 	res := []byte(`{"parts":[]}`)
-	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+	err := walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
 		switch num {
 		case 1: // role
-			role, _ := protowire.ConsumeString(raw)
+			role, n := protowire.ConsumeString(raw)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
 			res, _ = sjson.SetBytes(res, "role", role)
 		case 2: // parts
 			if typ == protowire.BytesType {
-				part := decodePartProto(raw)
+				val, n := protowire.ConsumeBytes(raw)
+				if n < 0 {
+					return protowire.ParseError(n)
+				}
+				part := decodePartProto(val)
 				res, _ = sjson.SetRawBytes(res, "parts.-1", part)
 			}
 		}
 		return nil
 	})
+	if err != nil {
+		log.Errorf("antigravity executor: failed to decode content proto: %v", err)
+	}
 	return res
 }
 
 func decodePartProto(msg []byte) []byte {
 	res := []byte(`{}`)
-	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+	err := walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
 		switch num {
 		case 1: // text
-			text, _ := protowire.ConsumeString(raw)
+			text, n := protowire.ConsumeString(raw)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
 			res, _ = sjson.SetBytes(res, "text", text)
 		case 6: // thought (bool)
-			val, _ := protowire.ConsumeVarint(raw)
+			val, n := protowire.ConsumeVarint(raw)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
 			res, _ = sjson.SetBytes(res, "thought", val != 0)
 		case 7: // thoughtSignature
-			sig, _ := protowire.ConsumeString(raw)
+			sig, n := protowire.ConsumeString(raw)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
 			res, _ = sjson.SetBytes(res, "thoughtSignature", sig)
 		}
 		return nil
 	})
+	if err != nil {
+		log.Errorf("antigravity executor: failed to decode part proto: %v", err)
+	}
 	return res
 }
 
 func decodeUsageProto(msg []byte) []byte {
 	res := []byte(`{}`)
-	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+	err := walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
 		switch num {
 		case 1: // promptTokenCount
-			val, _ := protowire.ConsumeVarint(raw)
+			val, n := protowire.ConsumeVarint(raw)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
 			res, _ = sjson.SetBytes(res, "promptTokenCount", val)
 		case 2: // candidatesTokenCount
-			val, _ := protowire.ConsumeVarint(raw)
+			val, n := protowire.ConsumeVarint(raw)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
 			res, _ = sjson.SetBytes(res, "candidatesTokenCount", val)
 		case 3: // totalTokenCount
-			val, _ := protowire.ConsumeVarint(raw)
+			val, n := protowire.ConsumeVarint(raw)
+			if n < 0 {
+				return protowire.ParseError(n)
+			}
 			res, _ = sjson.SetBytes(res, "totalTokenCount", val)
 		}
 		return nil
 	})
+	if err != nil {
+		log.Errorf("antigravity executor: failed to decode usage proto: %v", err)
+	}
 	return res
 }
 
 func decodeAntigravityCountTokensResponse(msg []byte) []byte {
 	res := []byte(`{}`)
-	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+	err := walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
 		if num == 1 { // totalTokens
-			val, _ := protowire.ConsumeVarint(raw)
-			res, _ = sjson.SetBytes(res, "totalTokens", val)
+			if typ == protowire.VarintType {
+				val, n := protowire.ConsumeVarint(raw)
+				if n < 0 {
+					return protowire.ParseError(n)
+				}
+				res, _ = sjson.SetBytes(res, "totalTokens", val)
+			}
 		}
 		return nil
 	})
+	if err != nil {
+		log.Errorf("antigravity executor: failed to decode count tokens proto: %v", err)
+	}
 	return res
 }
 

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -64,6 +64,8 @@ const (
 	antigravityCreditsAutoDisableDuration  = 5 * time.Hour
 	antigravityShortQuotaCooldownThreshold = 5 * time.Minute
 	antigravityInstantRetryThreshold       = 3 * time.Second
+
+	maxGRPCMessageSize = 32 * 1024 * 1024 // 32MB safety limit
 	// systemInstruction              = "You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.**Absolute paths only****Proactiveness**"
 )
 
@@ -1572,6 +1574,12 @@ attemptLoop:
 							break
 						}
 						length := binary.BigEndian.Uint32(header[1:])
+						if length > maxGRPCMessageSize {
+							errMax := fmt.Errorf("gRPC frame too large: %d bytes (max %d)", length, maxGRPCMessageSize)
+							helps.RecordAPIResponseError(ctx, e.cfg, errMax)
+							out <- cliproxyexecutor.StreamChunk{Err: errMax}
+							break
+						}
 						msg := make([]byte, length)
 						if _, errRead := io.ReadFull(resp.Body, msg); errRead != nil {
 							helps.RecordAPIResponseError(ctx, e.cfg, errRead)
@@ -1583,6 +1591,10 @@ attemptLoop:
 
 						// Decode binary Protobuf to JSON for the translator
 						payload := decodeAntigravityProtoResponse(msg)
+
+						if detail, ok := helps.ParseAntigravityStreamUsage(payload); ok {
+							reporter.Publish(ctx, detail)
+						}
 
 						chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, payload, &param)
 						for i := range chunks {
@@ -2452,6 +2464,23 @@ func encodeAntigravityProtoRequest(payload []byte) []byte {
 		out = protowire.AppendTag(out, 3, protowire.BytesType)
 		out = protowire.AppendString(out, model)
 	}
+
+	// 企业外部模型配置 (tag 15)
+	if enterpriseConfig := gjson.GetBytes(payload, "enterprise_chat_model_config"); enterpriseConfig.Exists() {
+		out = protowire.AppendTag(out, 15, protowire.BytesType)
+		out = protowire.AppendString(out, enterpriseConfig.Raw)
+	}
+
+	// 启用 AI 积分计费 (tag 21)
+	if enableCredits := gjson.GetBytes(payload, "enable_ai_credits"); enableCredits.Exists() {
+		out = protowire.AppendTag(out, 21, protowire.VarintType)
+		val := uint64(0)
+		if enableCredits.Bool() {
+			val = 1
+		}
+		out = protowire.AppendVarint(out, val)
+	}
+
 	return out
 }
 

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1570,6 +1570,7 @@ attemptLoop:
 						if _, errRead := io.ReadFull(resp.Body, header); errRead != nil {
 							if errRead != io.EOF {
 								helps.RecordAPIResponseError(ctx, e.cfg, errRead)
+								reporter.PublishFailure(ctx)
 								out <- cliproxyexecutor.StreamChunk{Err: errRead}
 							}
 							break
@@ -1578,6 +1579,7 @@ attemptLoop:
 						if length > maxGRPCMessageSize {
 							errMax := fmt.Errorf("gRPC frame too large: %d bytes (max %d)", length, maxGRPCMessageSize)
 							helps.RecordAPIResponseError(ctx, e.cfg, errMax)
+							reporter.PublishFailure(ctx)
 							out <- cliproxyexecutor.StreamChunk{Err: errMax}
 							break
 						}
@@ -1587,6 +1589,7 @@ attemptLoop:
 						msg := msgBuf[:length]
 						if _, errRead := io.ReadFull(resp.Body, msg); errRead != nil {
 							helps.RecordAPIResponseError(ctx, e.cfg, errRead)
+							reporter.PublishFailure(ctx)
 							out <- cliproxyexecutor.StreamChunk{Err: errRead}
 							break
 						}
@@ -1595,6 +1598,9 @@ attemptLoop:
 
 						// Decode binary Protobuf to JSON for the translator
 						payload := decodeAntigravityProtoResponse(msg)
+
+						// Filter usage metadata to ensure we only publish terminal chunk totals
+						payload, _ = helps.StripUsageMetadataFromJSON(payload)
 
 						if detail, ok := helps.ParseAntigravityStreamUsage(payload); ok {
 							reporter.Publish(ctx, detail)
@@ -1614,6 +1620,7 @@ attemptLoop:
 						errMsg := fmt.Sprintf("gRPC upstream error (status %s): %s", grpcStatus, grpcMsg)
 						log.Errorf("antigravity executor: %s", errMsg)
 						helps.RecordAPIResponseError(ctx, e.cfg, fmt.Errorf("%s", errMsg))
+						reporter.PublishFailure(ctx)
 						out <- cliproxyexecutor.StreamChunk{Err: statusErr{code: http.StatusBadGateway, msg: errMsg}}
 					}
 				} else {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -247,16 +247,6 @@ func (e *AntigravityExecutor) HttpRequest(ctx context.Context, auth *cliproxyaut
 	}
 
 	// --- Inject Official gRPC Headers ---
-	projectID := ""
-	if auth != nil && auth.Metadata != nil {
-		if pid, ok := auth.Metadata["project_id"].(string); ok {
-			projectID = strings.TrimSpace(pid)
-		}
-	}
-	if projectID != "" {
-		httpReq.Header.Set("x-goog-user-project", projectID)
-		httpReq.Header.Set("x-goog-request-params", "project_id="+projectID)
-	}
 	httpReq.Header.Set("x-goog-api-client", antigravityAPIClientDescriptor)
 	httpReq.Header.Set("TE", "trailers")
 
@@ -2064,10 +2054,6 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	httpReq.Header.Set("User-Agent", resolveUserAgent(auth))
 
 	// --- Inject Official gRPC Headers ---
-	if projectID != "" {
-		httpReq.Header.Set("x-goog-user-project", projectID)
-		httpReq.Header.Set("x-goog-request-params", "project_id="+projectID)
-	}
 	httpReq.Header.Set("x-goog-api-client", antigravityAPIClientDescriptor)
 	httpReq.Header.Set("TE", "trailers")
 

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -37,16 +36,26 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 const (
-	antigravityBaseURLDaily                = "https://daily-cloudcode-pa.googleapis.com"
-	antigravitySandboxBaseURLDaily         = "https://daily-cloudcode-pa.sandbox.googleapis.com"
-	antigravityBaseURLProd                 = "https://cloudcode-pa.googleapis.com"
-	antigravityCountTokensPath             = "/v1internal:countTokens"
-	antigravityStreamPath                  = "/v1internal:streamGenerateContent"
-	antigravityGeneratePath                = "/v1internal:generateContent"
-	antigravityClientID                    = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
+	antigravityBaseURLDaily        = "https://daily-cloudcode-pa.googleapis.com"
+	antigravitySandboxBaseURLDaily = "https://daily-cloudcode-pa.sandbox.googleapis.com"
+	antigravityBaseURLProd         = "https://cloudcode-pa.googleapis.com"
+	antigravityCountTokensPath     = "/v1internal:countTokens"
+	antigravityStreamPath          = "/v1internal:streamGenerateContent"
+	antigravityGeneratePath        = "/v1internal:generateContent"
+	antigravityClientID            = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
+
+	// gRPC Constants
+	antigravityGRPCService      = "google.internal.cloudcode.v1.AntigravityService"
+	antigravityGRPCStreamPath   = "/" + antigravityGRPCService + "/StreamGenerateContent"
+	antigravityGRPCGeneratePath = "/" + antigravityGRPCService + "/GenerateContent"
+	antigravityGRPCCountPath    = "/" + antigravityGRPCService + "/CountTokens"
+	antigravityGRPCModelsPath   = "/" + antigravityGRPCService + "/FetchAvailableModels"
+
+	antigravityAPIClientDescriptor         = "google-cloud-sdk vscode_cloudshelleditor/0.1"
 	antigravityClientSecret                = "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"
 	defaultAntigravityAgent                = "antigravity/1.21.9 darwin/arm64" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
 	antigravityAuthType                    = "antigravity"
@@ -136,32 +145,13 @@ var (
 	antigravityTransportOnce sync.Once
 )
 
-func cloneTransportWithHTTP11(base *http.Transport) *http.Transport {
-	if base == nil {
-		return nil
-	}
-
-	clone := base.Clone()
-	clone.ForceAttemptHTTP2 = false
-	// Wipe TLSNextProto to prevent implicit HTTP/2 upgrade.
-	clone.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
-	if clone.TLSClientConfig == nil {
-		clone.TLSClientConfig = &tls.Config{}
-	} else {
-		clone.TLSClientConfig = clone.TLSClientConfig.Clone()
-	}
-	// Actively advertise only HTTP/1.1 in the ALPN handshake.
-	clone.TLSClientConfig.NextProtos = []string{"http/1.1"}
-	return clone
-}
-
 // initAntigravityTransport creates the shared HTTP/1.1 transport exactly once.
 func initAntigravityTransport() {
 	base, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
 		base = &http.Transport{}
 	}
-	antigravityTransport = cloneTransportWithHTTP11(base)
+	antigravityTransport = base.Clone()
 }
 
 // newAntigravityHTTPClient creates an HTTP client specifically for Antigravity,
@@ -177,9 +167,9 @@ func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cli
 		return client
 	}
 
-	// Preserve proxy settings from proxy-aware transports while forcing HTTP/1.1.
+	// Preserve proxy settings from proxy-aware transports while allowing HTTP/2.
 	if transport, ok := client.Transport.(*http.Transport); ok {
-		client.Transport = cloneTransportWithHTTP11(transport)
+		client.Transport = transport.Clone()
 	}
 	return client
 }
@@ -253,6 +243,20 @@ func (e *AntigravityExecutor) HttpRequest(ctx context.Context, auth *cliproxyaut
 	if err := e.PrepareRequest(httpReq, auth); err != nil {
 		return nil, err
 	}
+
+	// --- Inject Official gRPC Headers ---
+	projectID := ""
+	if auth != nil && auth.Metadata != nil {
+		if pid, ok := auth.Metadata["project_id"].(string); ok {
+			projectID = strings.TrimSpace(pid)
+		}
+	}
+	if projectID != "" {
+		httpReq.Header.Set("x-goog-user-project", projectID)
+		httpReq.Header.Set("x-goog-request-params", "project_id="+projectID)
+	}
+	httpReq.Header.Set("x-goog-api-client", antigravityAPIClientDescriptor)
+	httpReq.Header.Set("TE", "trailers")
 
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 	return httpClient.Do(httpReq)
@@ -1549,42 +1553,90 @@ attemptLoop:
 						log.Errorf("antigravity executor: close response body error: %v", errClose)
 					}
 				}()
-				scanner := bufio.NewScanner(resp.Body)
-				scanner.Buffer(nil, streamScannerBuffer)
+				// If it's gRPC, we need to decode gRPC frames
+				contentType := resp.Header.Get("Content-Type")
+				isGRPC := strings.Contains(contentType, "application/grpc")
 				var param any
-				for scanner.Scan() {
-					line := scanner.Bytes()
-					helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 
-					// Filter usage metadata for all models
-					// Only retain usage statistics in the terminal chunk
-					line = helps.FilterSSEUsageMetadata(line)
+				log.Debugf("antigravity executor: stream response content-type=%q", contentType)
 
-					payload := helps.JSONPayload(line)
-					if payload == nil {
-						continue
+				if isGRPC {
+					frameCount := 0
+					for {
+						header := make([]byte, 5)
+						if _, errRead := io.ReadFull(resp.Body, header); errRead != nil {
+							if errRead != io.EOF {
+								helps.RecordAPIResponseError(ctx, e.cfg, errRead)
+								out <- cliproxyexecutor.StreamChunk{Err: errRead}
+							}
+							break
+						}
+						length := binary.BigEndian.Uint32(header[1:])
+						msg := make([]byte, length)
+						if _, errRead := io.ReadFull(resp.Body, msg); errRead != nil {
+							helps.RecordAPIResponseError(ctx, e.cfg, errRead)
+							out <- cliproxyexecutor.StreamChunk{Err: errRead}
+							break
+						}
+						frameCount++
+						log.Debugf("antigravity executor: gRPC frame flag=%d len=%d", header[0], length)
+
+						// Decode binary Protobuf to JSON for the translator
+						payload := decodeAntigravityProtoResponse(msg)
+
+						chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, payload, &param)
+						for i := range chunks {
+							out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}
+						}
 					}
 
-					if detail, ok := helps.ParseAntigravityStreamUsage(payload); ok {
-						reporter.Publish(ctx, detail)
+					// After body ends, check gRPC trailing status (HTTP/2 trailers)
+					grpcStatus := resp.Trailer.Get("grpc-status")
+					grpcMsg := resp.Trailer.Get("grpc-message")
+					log.Debugf("antigravity executor: gRPC trailer status=%q message=%q frameCount=%d", grpcStatus, grpcMsg, frameCount)
+					if grpcStatus != "" && grpcStatus != "0" {
+						errMsg := fmt.Sprintf("gRPC upstream error (status %s): %s", grpcStatus, grpcMsg)
+						log.Errorf("antigravity executor: %s", errMsg)
+						helps.RecordAPIResponseError(ctx, e.cfg, fmt.Errorf("%s", errMsg))
+						out <- cliproxyexecutor.StreamChunk{Err: statusErr{code: http.StatusBadGateway, msg: errMsg}}
 					}
+				} else {
+					// Fallback to SSE scanner
+					scanner := bufio.NewScanner(resp.Body)
+					scanner.Buffer(nil, streamScannerBuffer)
+					for scanner.Scan() {
+						line := scanner.Bytes()
+						helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 
-					chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, bytes.Clone(payload), &param)
-					for i := range chunks {
-						out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}
+						// Filter usage metadata for all models
+						// Only retain usage statistics in the terminal chunk
+						line = helps.FilterSSEUsageMetadata(line)
+
+						payload := helps.JSONPayload(line)
+						if payload == nil {
+							continue
+						}
+
+						if detail, ok := helps.ParseAntigravityStreamUsage(payload); ok {
+							reporter.Publish(ctx, detail)
+						}
+
+						chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, bytes.Clone(payload), &param)
+						for i := range chunks {
+							out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}
+						}
+					}
+					if errScan := scanner.Err(); errScan != nil {
+						helps.RecordAPIResponseError(ctx, e.cfg, errScan)
+						reporter.PublishFailure(ctx)
+						out <- cliproxyexecutor.StreamChunk{Err: errScan}
 					}
 				}
 				tail := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, []byte("[DONE]"), &param)
 				for i := range tail {
 					out <- cliproxyexecutor.StreamChunk{Payload: tail[i]}
 				}
-				if errScan := scanner.Err(); errScan != nil {
-					helps.RecordAPIResponseError(ctx, e.cfg, errScan)
-					reporter.PublishFailure(ctx)
-					out <- cliproxyexecutor.StreamChunk{Err: errScan}
-				} else {
-					reporter.EnsurePublished(ctx)
-				}
+				reporter.EnsurePublished(ctx)
 			}(httpResp)
 			return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 		}
@@ -2374,4 +2426,165 @@ func generateProjectID() string {
 	randSourceMutex.Unlock()
 	randomPart := strings.ToLower(uuid.NewString())[:5]
 	return adj + "-" + noun + "-" + randomPart
+}
+
+// encodeGRPCMessage adds the 5-byte gRPC framing header (0 for uncompressed + 4-byte length).
+func encodeGRPCMessage(data []byte) []byte {
+	out := make([]byte, 5+len(data))
+	out[0] = 0 // uncompressed
+	binary.BigEndian.PutUint32(out[1:5], uint32(len(data)))
+	copy(out[5:], data)
+	return out
+}
+
+// encodeAntigravityProtoRequest builds a binary protobuf message for the Antigravity request.
+func encodeAntigravityProtoRequest(payload []byte) []byte {
+	var out []byte
+	if project := gjson.GetBytes(payload, "project").String(); project != "" {
+		out = protowire.AppendTag(out, 1, protowire.BytesType)
+		out = protowire.AppendString(out, project)
+	}
+	if req := gjson.GetBytes(payload, "request"); req.Exists() {
+		out = protowire.AppendTag(out, 2, protowire.BytesType)
+		out = protowire.AppendString(out, req.Raw)
+	}
+	if model := gjson.GetBytes(payload, "model").String(); model != "" {
+		out = protowire.AppendTag(out, 3, protowire.BytesType)
+		out = protowire.AppendString(out, model)
+	}
+	return out
+}
+
+// decodeAntigravityProtoResponse decodes a StreamGenerateContentResponse proto to JSON.
+func decodeAntigravityProtoResponse(msg []byte) []byte {
+	res := []byte(`{"response":{"candidates":[]}}`)
+	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		switch num {
+		case 1: // candidates
+			if typ == protowire.BytesType {
+				candidate := decodeCandidateProto(raw)
+				res, _ = sjson.SetRawBytes(res, "response.candidates.-1", candidate)
+			}
+		case 3: // usageMetadata
+			if typ == protowire.BytesType {
+				usage := decodeUsageProto(raw)
+				res, _ = sjson.SetRawBytes(res, "response.usageMetadata", usage)
+			}
+		}
+		return nil
+	})
+	return res
+}
+
+func decodeCandidateProto(msg []byte) []byte {
+	res := []byte(`{"content":{"parts":[]}}`)
+	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		switch num {
+		case 2: // content
+			if typ == protowire.BytesType {
+				content := decodeContentProto(raw)
+				res, _ = sjson.SetRawBytes(res, "content", content)
+			}
+		case 3: // finishReason
+			if typ == protowire.VarintType {
+				val, _ := protowire.ConsumeVarint(raw)
+				reasons := []string{"FINISH_REASON_UNSPECIFIED", "STOP", "MAX_TOKENS", "SAFETY", "RECITATION", "OTHER"}
+				reason := "UNKNOWN"
+				if val < uint64(len(reasons)) {
+					reason = reasons[val]
+				}
+				res, _ = sjson.SetBytes(res, "finishReason", reason)
+			}
+		}
+		return nil
+	})
+	return res
+}
+
+func decodeContentProto(msg []byte) []byte {
+	res := []byte(`{"parts":[]}`)
+	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		switch num {
+		case 1: // role
+			role, _ := protowire.ConsumeString(raw)
+			res, _ = sjson.SetBytes(res, "role", role)
+		case 2: // parts
+			if typ == protowire.BytesType {
+				part := decodePartProto(raw)
+				res, _ = sjson.SetRawBytes(res, "parts.-1", part)
+			}
+		}
+		return nil
+	})
+	return res
+}
+
+func decodePartProto(msg []byte) []byte {
+	res := []byte(`{}`)
+	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		switch num {
+		case 1: // text
+			text, _ := protowire.ConsumeString(raw)
+			res, _ = sjson.SetBytes(res, "text", text)
+		case 6: // thought (bool)
+			val, _ := protowire.ConsumeVarint(raw)
+			res, _ = sjson.SetBytes(res, "thought", val != 0)
+		case 7: // thoughtSignature
+			sig, _ := protowire.ConsumeString(raw)
+			res, _ = sjson.SetBytes(res, "thoughtSignature", sig)
+		}
+		return nil
+	})
+	return res
+}
+
+func decodeUsageProto(msg []byte) []byte {
+	res := []byte(`{}`)
+	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		switch num {
+		case 1: // promptTokenCount
+			val, _ := protowire.ConsumeVarint(raw)
+			res, _ = sjson.SetBytes(res, "promptTokenCount", val)
+		case 2: // candidatesTokenCount
+			val, _ := protowire.ConsumeVarint(raw)
+			res, _ = sjson.SetBytes(res, "candidatesTokenCount", val)
+		case 3: // totalTokenCount
+			val, _ := protowire.ConsumeVarint(raw)
+			res, _ = sjson.SetBytes(res, "totalTokenCount", val)
+		}
+		return nil
+	})
+	return res
+}
+
+func decodeAntigravityCountTokensResponse(msg []byte) []byte {
+	res := []byte(`{}`)
+	_ = walkProtobufFields(msg, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		if num == 1 { // totalTokens
+			val, _ := protowire.ConsumeVarint(raw)
+			res, _ = sjson.SetBytes(res, "totalTokens", val)
+		}
+		return nil
+	})
+	return res
+}
+
+func walkProtobufFields(msg []byte, visit func(num protowire.Number, typ protowire.Type, raw []byte) error) error {
+	for offset := 0; offset < len(msg); {
+		num, typ, n := protowire.ConsumeTag(msg[offset:])
+		if n < 0 {
+			return fmt.Errorf("malformed protobuf tag: %w", protowire.ParseError(n))
+		}
+		offset += n
+		valueLen := protowire.ConsumeFieldValue(num, typ, msg[offset:])
+		if valueLen < 0 {
+			return fmt.Errorf("malformed protobuf field %d: %w", num, protowire.ParseError(valueLen))
+		}
+		fieldRaw := msg[offset : offset+valueLen]
+		if err := visit(num, typ, fieldRaw); err != nil {
+			return err
+		}
+		offset += valueLen
+	}
+	return nil
 }

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -2062,6 +2062,15 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("User-Agent", resolveUserAgent(auth))
+
+	// --- Inject Official gRPC Headers ---
+	if projectID != "" {
+		httpReq.Header.Set("x-goog-user-project", projectID)
+		httpReq.Header.Set("x-goog-request-params", "project_id="+projectID)
+	}
+	httpReq.Header.Set("x-goog-api-client", antigravityAPIClientDescriptor)
+	httpReq.Header.Set("TE", "trailers")
+
 	if host := resolveHost(base); host != "" {
 		httpReq.Host = host
 	}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -2465,13 +2465,13 @@ func encodeAntigravityProtoRequest(payload []byte) []byte {
 		out = protowire.AppendString(out, model)
 	}
 
-	// 企业外部模型配置 (tag 15)
+	// Enterprise external model config (tag 15)
 	if enterpriseConfig := gjson.GetBytes(payload, "enterprise_chat_model_config"); enterpriseConfig.Exists() {
 		out = protowire.AppendTag(out, 15, protowire.BytesType)
 		out = protowire.AppendString(out, enterpriseConfig.Raw)
 	}
 
-	// 启用 AI 积分计费 (tag 21)
+	// Enable AI credits billing (tag 21)
 	if enableCredits := gjson.GetBytes(payload, "enable_ai_credits"); enableCredits.Exists() {
 		out = protowire.AppendTag(out, 21, protowire.VarintType)
 		val := uint64(0)


### PR DESCRIPTION
## 描述 (Description)
这个 PR 为 Antigravity 执行器引入了几个关键的修复和改进，主要确保了与上游 gRPC 接口基于 HTTP/2 协议的交互稳定性，同时正确处理了流式传输错误，并修复了 Protobuf 解析过程中可能导致的异常问题。

### 主要更改 (Key Changes)
- **HTTP/2 与元数据头增强**: 启用了标准的 HTTP/2 协议协商，并为普通请求和流式请求正确注入了必要的 `x-goog-*` 元数据请求头（后续移除了 `x-goog-user-project` 以解决下游返回 `403 Authorization Failed` 的问题）。
- **gRPC 流式传输稳定性**: 解决了 gRPC 处理路径中潜在的内存溢出（OOM）风险。增加了流错误检测机制以正确解析和抛出 gRPC Stream Trailer 中的错误状态，避免了之前发生错误却被当作 `empty_stream` 默默吞掉的现象。
- **Protobuf 解析修复**: 正确解包了 `BytesType` 类型中的 Protobuf 长度前缀，并且加入了对解析报错的安全拦截处理，避免进程或流意外奔溃。
- **监控与统计**: 新增了用量统计 (Usage Reporting) 的上报机制，并且更新了相关请求的 Tags 以便更好的追踪日志。
- **代码规范**: 根据项目的设定规则，已将作用域内的代码注释全部翻译为了英文。

### 包含的 Commit
- 修复 `x-goog-user-project` 导致的 403 权限验证失败的问题
- 修复流式请求中未能正确注入 `x-goog` 元数据请求头的问题
- 正确捕获并抛出请求错误，过滤掉 gRPC 路径中的非终端流状态
- 修复因 `BytesType` protobuf 长度前缀未被正确剥离引起的解析错误并捕获解码异常
- 将相关注释翻译为英文以符合代码库规范
- 修复 gRPC 的 OOM 风险，增加 usage 用量上报，并更新 request tags
- 注入强制的 `x-goog-*` 元数据 headers 并启用 HTTP/2 连接

## 测试指导 (Testing Instructions)
- 无错误地编译并成功运行网关。
- 发起 Antigravity 的流式对话请求，验证 403 错误已被成功解决。
- 确认当触发外部错误时能够通过 Stream 返回具体的错误信息，而不是静默退出。
- 确认网关是否正常进行了 Token 用量等各项指标的上报统计。
