### PR TITLE
feat(antigravity): prefer prod URL as first priority

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -2270,9 +2270,9 @@ var antigravityBaseURLFallbackOrder = func(auth *cliproxyauth.Auth) []string {
 		return []string{base}
 	}
 	return []string{
+		antigravityBaseURLProd,
 		antigravityBaseURLDaily,
 		antigravitySandboxBaseURLDaily,
-		// antigravityBaseURLProd,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Promote `cloudcode-pa.googleapis.com` (prod) to the first position in the antigravity base URL fallback order
- Daily and sandbox URLs remain as fallback options

## Test plan
- [ ] Verify antigravity requests hit prod URL first
- [ ] Verify fallback to daily/sandbox works if prod fails