### PR TITLE
feat: add optional persistence for usage statistics

### DIFF
--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -69,6 +69,12 @@ func (h *Handler) ImportUsageStatistics(c *gin.Context) {
 	}
 
 	result := h.usageStats.MergeSnapshot(payload.Usage)
+	if persistence := usage.GetPersistenceManager(); persistence != nil {
+		if err := persistence.Flush(c.Request.Context()); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to persist imported usage statistics"})
+			return
+		}
+	}
 	snapshot := h.usageStats.Snapshot()
 	c.JSON(http.StatusOK, gin.H{
 		"added":           result.Added,

--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -70,7 +71,10 @@ func (h *Handler) ImportUsageStatistics(c *gin.Context) {
 
 	result := h.usageStats.MergeSnapshot(payload.Usage)
 	if persistence := usage.GetPersistenceManager(); persistence != nil {
-		if err := persistence.Flush(c.Request.Context()); err != nil {
+		persistence.MarkDirty()
+		flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := persistence.Flush(flushCtx); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to persist imported usage statistics"})
 			return
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -159,6 +159,8 @@ type Server struct {
 	// management handler
 	mgmt *managementHandlers.Handler
 
+	usagePersistence *usage.PersistenceManager
+
 	// ampModule is the Amp routing module for model mapping hot-reload
 	ampModule *ampmodule.AmpModule
 
@@ -270,6 +272,16 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	}
 	logDir := logging.ResolveLogDirectory(cfg)
 	s.mgmt.SetLogDirectory(logDir)
+	if cfg.UsageStatisticsPersistenceEnabled {
+		persistPath := usage.ResolvePersistencePath(configFilePath, cfg.UsageStatisticsPersistencePath)
+		persistence := usage.NewPersistenceManager(usage.NewFileSnapshotStore(persistPath), usage.GetRequestStatistics())
+		if err := persistence.Load(context.Background()); err != nil {
+			log.WithError(err).Warnf("failed to restore usage statistics from %s", persistPath)
+		} else {
+			s.usagePersistence = persistence
+			usage.SetPersistenceManager(persistence)
+		}
+	}
 	if optionState.postAuthHook != nil {
 		s.mgmt.SetPostAuthHook(optionState.postAuthHook)
 	}
@@ -839,6 +851,15 @@ func (s *Server) Stop(ctx context.Context) error {
 	// Shutdown the HTTP server.
 	if err := s.server.Shutdown(ctx); err != nil {
 		return fmt.Errorf("failed to shutdown HTTP server: %v", err)
+	}
+
+	if s.usagePersistence != nil {
+		flushCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if err := s.usagePersistence.Close(flushCtx); err != nil {
+			return fmt.Errorf("failed to persist usage statistics during shutdown: %v", err)
+		}
+		usage.SetPersistenceManager(nil)
 	}
 
 	log.Debug("API server stopped")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -275,11 +275,10 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	if cfg.UsageStatisticsPersistenceEnabled {
 		persistPath := usage.ResolvePersistencePath(configFilePath, cfg.UsageStatisticsPersistencePath)
 		persistence := usage.NewPersistenceManager(usage.NewFileSnapshotStore(persistPath), usage.GetRequestStatistics())
+		s.usagePersistence = persistence
+		usage.SetPersistenceManager(persistence)
 		if err := persistence.Load(context.Background()); err != nil {
 			log.WithError(err).Warnf("failed to restore usage statistics from %s", persistPath)
-		} else {
-			s.usagePersistence = persistence
-			usage.SetPersistenceManager(persistence)
 		}
 	}
 	if optionState.postAuthHook != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -852,16 +852,22 @@ func (s *Server) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to shutdown HTTP server: %v", err)
 	}
 
-	if s.usagePersistence != nil {
-		flushCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
-		if err := s.usagePersistence.Close(flushCtx); err != nil {
-			return fmt.Errorf("failed to persist usage statistics during shutdown: %v", err)
-		}
-		usage.SetPersistenceManager(nil)
-	}
-
 	log.Debug("API server stopped")
+	return nil
+}
+
+// StopUsagePersistence flushes and detaches the usage persistence manager.
+func (s *Server) StopUsagePersistence(ctx context.Context) error {
+	if s == nil || s.usagePersistence == nil {
+		return nil
+	}
+	flushCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := s.usagePersistence.Close(flushCtx); err != nil {
+		return fmt.Errorf("failed to persist usage statistics during shutdown: %v", err)
+	}
+	usage.SetPersistenceManager(nil)
+	s.usagePersistence = nil
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,13 @@ type Config struct {
 	// UsageStatisticsEnabled toggles in-memory usage aggregation; when false, usage data is discarded.
 	UsageStatisticsEnabled bool `yaml:"usage-statistics-enabled" json:"usage-statistics-enabled"`
 
+	// UsageStatisticsPersistenceEnabled toggles durable local persistence for usage statistics snapshots.
+	UsageStatisticsPersistenceEnabled bool `yaml:"usage-statistics-persistence-enabled" json:"usage-statistics-persistence-enabled"`
+
+	// UsageStatisticsPersistencePath defines where usage statistics snapshots are stored.
+	// Relative paths are resolved relative to the configuration file directory.
+	UsageStatisticsPersistencePath string `yaml:"usage-statistics-persistence-path" json:"usage-statistics-persistence-path"`
+
 	// DisableCooling disables quota cooldown scheduling when true.
 	DisableCooling bool `yaml:"disable-cooling" json:"disable-cooling"`
 
@@ -583,6 +590,8 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.LogsMaxTotalSizeMB = 0
 	cfg.ErrorLogsMaxFiles = 10
 	cfg.UsageStatisticsEnabled = false
+	cfg.UsageStatisticsPersistenceEnabled = false
+	cfg.UsageStatisticsPersistencePath = "usage-statistics.json"
 	cfg.DisableCooling = false
 	cfg.Pprof.Enable = false
 	cfg.Pprof.Addr = DefaultPprofAddr

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -15,7 +15,10 @@ import (
 	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 )
 
-var statisticsEnabled atomic.Bool
+var (
+	statisticsEnabled  atomic.Bool
+	defaultPersistence atomic.Pointer[PersistenceManager]
+)
 
 func init() {
 	statisticsEnabled.Store(true)
@@ -140,6 +143,12 @@ var defaultRequestStatistics = NewRequestStatistics()
 // GetRequestStatistics returns the shared statistics store.
 func GetRequestStatistics() *RequestStatistics { return defaultRequestStatistics }
 
+// SetPersistenceManager installs the shared usage persistence manager.
+func SetPersistenceManager(manager *PersistenceManager) { defaultPersistence.Store(manager) }
+
+// GetPersistenceManager returns the shared usage persistence manager.
+func GetPersistenceManager() *PersistenceManager { return defaultPersistence.Load() }
+
 // NewRequestStatistics constructs an empty statistics store.
 func NewRequestStatistics() *RequestStatistics {
 	return &RequestStatistics{
@@ -210,6 +219,10 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	s.requestsByHour[hourKey]++
 	s.tokensByDay[dayKey] += totalTokens
 	s.tokensByHour[hourKey] += totalTokens
+
+	if persistence := defaultPersistence.Load(); persistence != nil {
+		persistence.MarkDirty()
+	}
 }
 
 func (s *RequestStatistics) updateAPIStats(stats *apiStats, model string, detail RequestDetail) {
@@ -223,6 +236,9 @@ func (s *RequestStatistics) updateAPIStats(stats *apiStats, model string, detail
 	modelStatsValue.TotalRequests++
 	modelStatsValue.TotalTokens += detail.Tokens.TotalTokens
 	modelStatsValue.Details = append(modelStatsValue.Details, detail)
+	if len(modelStatsValue.Details) > defaultMaxRequestDetails {
+		modelStatsValue.Details = append([]RequestDetail(nil), modelStatsValue.Details[len(modelStatsValue.Details)-defaultMaxRequestDetails:]...)
+	}
 }
 
 // Snapshot returns a copy of the aggregated metrics for external consumption.

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -237,9 +237,6 @@ func (s *RequestStatistics) updateAPIStats(stats *apiStats, model string, detail
 	modelStatsValue.TotalRequests++
 	modelStatsValue.TotalTokens += detail.Tokens.TotalTokens
 	modelStatsValue.Details = append(modelStatsValue.Details, detail)
-	if len(modelStatsValue.Details) > defaultMaxRequestDetails {
-		modelStatsValue.Details = modelStatsValue.Details[len(modelStatsValue.Details)-defaultMaxRequestDetails:]
-	}
 }
 
 // Snapshot returns a copy of the aggregated metrics for external consumption.

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -192,7 +192,6 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	hourKey := timestamp.Hour()
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	s.totalRequests++
 	if success {
@@ -221,6 +220,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	s.tokensByDay[dayKey] += totalTokens
 	s.tokensByHour[hourKey] += totalTokens
 
+	s.mu.Unlock()
 	if persistence := defaultPersistence.Load(); persistence != nil {
 		persistence.MarkDirty()
 	}

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -6,6 +6,7 @@ package usage
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -237,7 +238,7 @@ func (s *RequestStatistics) updateAPIStats(stats *apiStats, model string, detail
 	modelStatsValue.TotalTokens += detail.Tokens.TotalTokens
 	modelStatsValue.Details = append(modelStatsValue.Details, detail)
 	if len(modelStatsValue.Details) > defaultMaxRequestDetails {
-		modelStatsValue.Details = append([]RequestDetail(nil), modelStatsValue.Details[len(modelStatsValue.Details)-defaultMaxRequestDetails:]...)
+		modelStatsValue.Details = modelStatsValue.Details[len(modelStatsValue.Details)-defaultMaxRequestDetails:]
 	}
 }
 
@@ -396,6 +397,74 @@ func (s *RequestStatistics) recordImported(apiName, modelName string, stats *api
 	s.tokensByHour[hourKey] += totalTokens
 }
 
+// RestoreSnapshot replaces the current in-memory statistics with a persisted snapshot.
+func (s *RequestStatistics) RestoreSnapshot(snapshot StatisticsSnapshot) {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.totalRequests = snapshot.TotalRequests
+	s.successCount = snapshot.SuccessCount
+	s.failureCount = snapshot.FailureCount
+	s.totalTokens = snapshot.TotalTokens
+
+	s.apis = make(map[string]*apiStats, len(snapshot.APIs))
+	for apiName, apiSnapshot := range snapshot.APIs {
+		apiName = strings.TrimSpace(apiName)
+		if apiName == "" {
+			continue
+		}
+		stats := &apiStats{
+			TotalRequests: apiSnapshot.TotalRequests,
+			TotalTokens:   apiSnapshot.TotalTokens,
+			Models:        make(map[string]*modelStats, len(apiSnapshot.Models)),
+		}
+		for modelName, modelSnapshot := range apiSnapshot.Models {
+			modelName = strings.TrimSpace(modelName)
+			if modelName == "" {
+				modelName = "unknown"
+			}
+			details := make([]RequestDetail, len(modelSnapshot.Details))
+			copy(details, modelSnapshot.Details)
+			for i := range details {
+				details[i].Tokens = normaliseTokenStats(details[i].Tokens)
+				if details[i].LatencyMs < 0 {
+					details[i].LatencyMs = 0
+				}
+			}
+			stats.Models[modelName] = &modelStats{
+				TotalRequests: modelSnapshot.TotalRequests,
+				TotalTokens:   modelSnapshot.TotalTokens,
+				Details:       details,
+			}
+		}
+		s.apis[apiName] = stats
+	}
+
+	s.requestsByDay = make(map[string]int64, len(snapshot.RequestsByDay))
+	for day, count := range snapshot.RequestsByDay {
+		s.requestsByDay[day] = count
+	}
+
+	s.requestsByHour = make(map[int]int64, len(snapshot.RequestsByHour))
+	for hour, count := range snapshot.RequestsByHour {
+		s.requestsByHour[parseHour(hour)] = count
+	}
+
+	s.tokensByDay = make(map[string]int64, len(snapshot.TokensByDay))
+	for day, count := range snapshot.TokensByDay {
+		s.tokensByDay[day] = count
+	}
+
+	s.tokensByHour = make(map[int]int64, len(snapshot.TokensByHour))
+	for hour, count := range snapshot.TokensByHour {
+		s.tokensByHour[parseHour(hour)] = count
+	}
+}
+
 func dedupKey(apiName, modelName string, detail RequestDetail) string {
 	timestamp := detail.Timestamp.UTC().Format(time.RFC3339Nano)
 	tokens := normaliseTokenStats(detail.Tokens)
@@ -497,4 +566,12 @@ func formatHour(hour int) string {
 	}
 	hour = hour % 24
 	return fmt.Sprintf("%02d", hour)
+}
+
+func parseHour(value string) int {
+	hour, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || hour < 0 {
+		return 0
+	}
+	return hour % 24
 }

--- a/internal/usage/persistence.go
+++ b/internal/usage/persistence.go
@@ -205,8 +205,10 @@ func (m *PersistenceManager) Flush(ctx context.Context) error {
 		m.mu.Unlock()
 		return nil
 	}
-	snapshot := m.stats.Snapshot()
+	m.dirty = false
 	m.mu.Unlock()
+
+	snapshot := m.stats.Snapshot()
 	if err := m.store.Save(ctx, snapshot); err != nil {
 		m.mu.Lock()
 		if !m.closed {
@@ -215,9 +217,6 @@ func (m *PersistenceManager) Flush(ctx context.Context) error {
 		m.mu.Unlock()
 		return err
 	}
-	m.mu.Lock()
-	m.dirty = false
-	m.mu.Unlock()
 	return nil
 }
 

--- a/internal/usage/persistence.go
+++ b/internal/usage/persistence.go
@@ -1,0 +1,250 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	defaultPersistDebounce      = 2 * time.Second
+	defaultShutdownFlushTimeout = 5 * time.Second
+	defaultMaxRequestDetails    = 1000
+	statsSnapshotVersion        = 1
+)
+
+type snapshotPayload struct {
+	Version    int                `json:"version"`
+	ExportedAt time.Time          `json:"exported_at"`
+	Usage      StatisticsSnapshot `json:"usage"`
+}
+
+type SnapshotStore interface {
+	Load(ctx context.Context) (StatisticsSnapshot, error)
+	Save(ctx context.Context, snapshot StatisticsSnapshot) error
+	Path() string
+}
+
+type FileSnapshotStore struct {
+	path string
+}
+
+func NewFileSnapshotStore(path string) *FileSnapshotStore {
+	return &FileSnapshotStore{path: path}
+}
+
+func (s *FileSnapshotStore) Path() string {
+	if s == nil {
+		return ""
+	}
+	return s.path
+}
+
+func (s *FileSnapshotStore) Load(ctx context.Context) (StatisticsSnapshot, error) {
+	var empty StatisticsSnapshot
+	if s == nil || s.path == "" {
+		return empty, nil
+	}
+	if err := ctxErr(ctx); err != nil {
+		return empty, err
+	}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return empty, nil
+		}
+		return empty, err
+	}
+	if len(data) == 0 {
+		return empty, nil
+	}
+	var payload snapshotPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return empty, err
+	}
+	if payload.Version != 0 && payload.Version != statsSnapshotVersion {
+		return empty, fmt.Errorf("unsupported version %d", payload.Version)
+	}
+	return payload.Usage, nil
+}
+
+func (s *FileSnapshotStore) Save(ctx context.Context, snapshot StatisticsSnapshot) error {
+	if s == nil || s.path == "" {
+		return nil
+	}
+	if err := ctxErr(ctx); err != nil {
+		return err
+	}
+	payload := snapshotPayload{
+		Version:    statsSnapshotVersion,
+		ExportedAt: time.Now().UTC(),
+		Usage:      snapshot,
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return err
+	}
+	tmpFile, err := os.CreateTemp(filepath.Dir(s.path), ".usage-statistics-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	cleanup := true
+	defer func() {
+		_ = tmpFile.Close()
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmpFile.Write(data); err != nil {
+		return err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+type PersistenceManager struct {
+	store    SnapshotStore
+	stats    *RequestStatistics
+	debounce time.Duration
+
+	mu     sync.Mutex
+	timer  *time.Timer
+	closed bool
+	dirty  bool
+}
+
+func NewPersistenceManager(store SnapshotStore, stats *RequestStatistics) *PersistenceManager {
+	return &PersistenceManager{
+		store:    store,
+		stats:    stats,
+		debounce: defaultPersistDebounce,
+	}
+}
+
+func ResolvePersistencePath(configPath, value string) string {
+	value = filepath.Clean(value)
+	if value == "." || value == "" {
+		value = "usage-statistics.json"
+	}
+	if filepath.IsAbs(value) {
+		return value
+	}
+	base := filepath.Dir(configPath)
+	if base == "." || base == "" {
+		if abs, err := filepath.Abs(value); err == nil {
+			return abs
+		}
+		return value
+	}
+	return filepath.Join(base, value)
+}
+
+func (m *PersistenceManager) Load(ctx context.Context) error {
+	if m == nil || m.store == nil || m.stats == nil {
+		return nil
+	}
+	snapshot, err := m.store.Load(ctx)
+	if err != nil {
+		return err
+	}
+	result := m.stats.MergeSnapshot(snapshot)
+	if result.Added > 0 || result.Skipped > 0 {
+		log.Infof("usage statistics restored from %s: added=%d skipped=%d", m.store.Path(), result.Added, result.Skipped)
+	}
+	return nil
+}
+
+func (m *PersistenceManager) MarkDirty() {
+	if m == nil || m.store == nil || m.stats == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return
+	}
+	m.dirty = true
+	if m.timer == nil {
+		m.timer = time.AfterFunc(m.debounce, m.flushAsync)
+		return
+	}
+	m.timer.Reset(m.debounce)
+}
+
+func (m *PersistenceManager) Flush(ctx context.Context) error {
+	if m == nil || m.store == nil || m.stats == nil {
+		return nil
+	}
+	m.mu.Lock()
+	if m.timer != nil {
+		m.timer.Stop()
+		m.timer = nil
+	}
+	if !m.dirty {
+		m.mu.Unlock()
+		return nil
+	}
+	m.dirty = false
+	m.mu.Unlock()
+	return m.store.Save(ctx, m.stats.Snapshot())
+}
+
+func (m *PersistenceManager) Close(ctx context.Context) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	m.closed = true
+	if m.timer != nil {
+		m.timer.Stop()
+		m.timer = nil
+	}
+	m.mu.Unlock()
+	if ctx == nil {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), defaultShutdownFlushTimeout)
+		defer cancel()
+		ctx = shutdownCtx
+	}
+	return m.Flush(ctx)
+}
+
+func (m *PersistenceManager) flushAsync() {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultShutdownFlushTimeout)
+	defer cancel()
+	if err := m.Flush(ctx); err != nil {
+		log.WithError(err).Warn("failed to persist usage statistics snapshot")
+	}
+}
+
+func ctxErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return nil
+	}
+}

--- a/internal/usage/persistence.go
+++ b/internal/usage/persistence.go
@@ -168,9 +168,9 @@ func (m *PersistenceManager) Load(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	result := m.stats.MergeSnapshot(snapshot)
-	if result.Added > 0 || result.Skipped > 0 {
-		log.Infof("usage statistics restored from %s: added=%d skipped=%d", m.store.Path(), result.Added, result.Skipped)
+	m.stats.RestoreSnapshot(snapshot)
+	if snapshot.TotalRequests > 0 || snapshot.TotalTokens > 0 {
+		log.Infof("usage statistics restored from %s: total_requests=%d total_tokens=%d", m.store.Path(), snapshot.TotalRequests, snapshot.TotalTokens)
 	}
 	return nil
 }
@@ -205,9 +205,20 @@ func (m *PersistenceManager) Flush(ctx context.Context) error {
 		m.mu.Unlock()
 		return nil
 	}
+	snapshot := m.stats.Snapshot()
+	m.mu.Unlock()
+	if err := m.store.Save(ctx, snapshot); err != nil {
+		m.mu.Lock()
+		if !m.closed {
+			m.dirty = true
+		}
+		m.mu.Unlock()
+		return err
+	}
+	m.mu.Lock()
 	m.dirty = false
 	m.mu.Unlock()
-	return m.store.Save(ctx, m.stats.Snapshot())
+	return nil
 }
 
 func (m *PersistenceManager) Close(ctx context.Context) error {

--- a/internal/usage/persistence_test.go
+++ b/internal/usage/persistence_test.go
@@ -170,7 +170,7 @@ func TestRequestStatisticsRestoreSnapshotPreservesAggregates(t *testing.T) {
 func TestPersistenceManagerFlushRetainsDirtyOnSaveFailure(t *testing.T) {
 	stats := NewRequestStatistics()
 	stats.Record(context.Background(), coreusage.Record{Provider: "gemini", Model: "m", Source: "live", RequestedAt: time.Now().UTC(), Detail: coreusage.Detail{TotalTokens: 3}})
-	store := &failingSnapshotStore{path: "/tmp/failing", err: errors.New("boom")}
+	store := &failingSnapshotStore{path: "/tmp/failing", saveErr: errors.New("boom")}
 	manager := NewPersistenceManager(store, stats)
 	manager.MarkDirty()
 
@@ -204,17 +204,42 @@ func TestFileSnapshotStoreCorruptFile(t *testing.T) {
 	}
 }
 
+func TestPersistenceManagerCanPersistAfterLoadFailure(t *testing.T) {
+	stats := NewRequestStatistics()
+	store := &failingSnapshotStore{path: "/tmp/failing", loadErr: errors.New("bad snapshot")}
+	manager := NewPersistenceManager(store, stats)
+	if err := manager.Load(context.Background()); err == nil {
+		t.Fatal("expected Load() error")
+	}
+
+	stats.Record(context.Background(), coreusage.Record{Provider: "gemini", Model: "m", Source: "live", RequestedAt: time.Now().UTC(), Detail: coreusage.Detail{TotalTokens: 5}})
+	manager.MarkDirty()
+	store.loadErr = nil
+	if err := manager.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() after load failure error = %v", err)
+	}
+	if store.saves != 1 {
+		t.Fatalf("save count = %d, want 1", store.saves)
+	}
+}
+
 type failingSnapshotStore struct {
-	path string
-	err  error
+	path    string
+	loadErr error
+	saveErr error
+	saves   int
 }
 
 func (s *failingSnapshotStore) Load(ctx context.Context) (StatisticsSnapshot, error) {
+	if s.loadErr != nil {
+		return StatisticsSnapshot{}, s.loadErr
+	}
 	return StatisticsSnapshot{}, nil
 }
 
 func (s *failingSnapshotStore) Save(ctx context.Context, snapshot StatisticsSnapshot) error {
-	return s.err
+	s.saves++
+	return s.saveErr
 }
 
 func (s *failingSnapshotStore) Path() string {

--- a/internal/usage/persistence_test.go
+++ b/internal/usage/persistence_test.go
@@ -110,21 +110,6 @@ func TestPersistenceManagerLoadAndFlush(t *testing.T) {
 	}
 }
 
-func TestUpdateAPIStatsBoundsDetails(t *testing.T) {
-	stats := NewRequestStatistics()
-	bucket := &apiStats{Models: make(map[string]*modelStats)}
-	for i := 0; i < defaultMaxRequestDetails+25; i++ {
-		stats.updateAPIStats(bucket, "model", RequestDetail{Timestamp: time.Unix(int64(i), 0).UTC(), Source: "src"})
-	}
-	got := len(bucket.Models["model"].Details)
-	if got != defaultMaxRequestDetails {
-		t.Fatalf("details len = %d, want %d", got, defaultMaxRequestDetails)
-	}
-	if first := bucket.Models["model"].Details[0].Timestamp.Unix(); first != 25 {
-		t.Fatalf("first retained timestamp = %d, want 25", first)
-	}
-}
-
 func TestRequestStatisticsRestoreSnapshotPreservesAggregates(t *testing.T) {
 	stats := NewRequestStatistics()
 	snapshot := StatisticsSnapshot{
@@ -223,6 +208,30 @@ func TestPersistenceManagerCanPersistAfterLoadFailure(t *testing.T) {
 	}
 }
 
+func TestPersistenceManagerFlushPreservesConcurrentDirtyMark(t *testing.T) {
+	stats := NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{Provider: "gemini", Model: "m", Source: "seed", RequestedAt: time.Now().UTC(), Detail: coreusage.Detail{TotalTokens: 3}})
+	store := &blockingSnapshotStore{started: make(chan struct{}), release: make(chan struct{})}
+	manager := NewPersistenceManager(store, stats)
+	manager.MarkDirty()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- manager.Flush(context.Background())
+	}()
+
+	<-store.started
+	manager.MarkDirty()
+	close(store.release)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if !manager.dirty {
+		t.Fatal("expected dirty flag to remain set when new writes arrive during save")
+	}
+}
+
 type failingSnapshotStore struct {
 	path    string
 	loadErr error
@@ -244,4 +253,23 @@ func (s *failingSnapshotStore) Save(ctx context.Context, snapshot StatisticsSnap
 
 func (s *failingSnapshotStore) Path() string {
 	return s.path
+}
+
+type blockingSnapshotStore struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingSnapshotStore) Load(ctx context.Context) (StatisticsSnapshot, error) {
+	return StatisticsSnapshot{}, nil
+}
+
+func (s *blockingSnapshotStore) Save(ctx context.Context, snapshot StatisticsSnapshot) error {
+	close(s.started)
+	<-s.release
+	return nil
+}
+
+func (s *blockingSnapshotStore) Path() string {
+	return "/tmp/blocking"
 }

--- a/internal/usage/persistence_test.go
+++ b/internal/usage/persistence_test.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -124,6 +125,63 @@ func TestUpdateAPIStatsBoundsDetails(t *testing.T) {
 	}
 }
 
+func TestRequestStatisticsRestoreSnapshotPreservesAggregates(t *testing.T) {
+	stats := NewRequestStatistics()
+	snapshot := StatisticsSnapshot{
+		TotalRequests: 1500,
+		SuccessCount:  1490,
+		FailureCount:  10,
+		TotalTokens:   9000,
+		APIs: map[string]APISnapshot{
+			"gemini": {
+				TotalRequests: 1500,
+				TotalTokens:   9000,
+				Models: map[string]ModelSnapshot{
+					"gemini-2.5-pro": {
+						TotalRequests: 1500,
+						TotalTokens:   9000,
+						Details: []RequestDetail{
+							{Timestamp: time.Unix(1700000000, 0).UTC(), Source: "tail-1", Tokens: TokenStats{TotalTokens: 6}},
+							{Timestamp: time.Unix(1700000001, 0).UTC(), Source: "tail-2", Tokens: TokenStats{TotalTokens: 7}},
+						},
+					},
+				},
+			},
+		},
+		RequestsByDay:  map[string]int64{"2025-01-01": 1500},
+		RequestsByHour: map[string]int64{"10": 1500},
+		TokensByDay:    map[string]int64{"2025-01-01": 9000},
+		TokensByHour:   map[string]int64{"10": 9000},
+	}
+
+	stats.RestoreSnapshot(snapshot)
+	restored := stats.Snapshot()
+	if restored.TotalRequests != 1500 || restored.TotalTokens != 9000 || restored.FailureCount != 10 {
+		t.Fatalf("restored snapshot mismatch: got %+v", restored)
+	}
+	if got := restored.APIs["gemini"].Models["gemini-2.5-pro"].TotalRequests; got != 1500 {
+		t.Fatalf("restored model total_requests = %d, want 1500", got)
+	}
+	if got := len(restored.APIs["gemini"].Models["gemini-2.5-pro"].Details); got != 2 {
+		t.Fatalf("restored details len = %d, want 2", got)
+	}
+}
+
+func TestPersistenceManagerFlushRetainsDirtyOnSaveFailure(t *testing.T) {
+	stats := NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{Provider: "gemini", Model: "m", Source: "live", RequestedAt: time.Now().UTC(), Detail: coreusage.Detail{TotalTokens: 3}})
+	store := &failingSnapshotStore{path: "/tmp/failing", err: errors.New("boom")}
+	manager := NewPersistenceManager(store, stats)
+	manager.MarkDirty()
+
+	if err := manager.Flush(context.Background()); err == nil {
+		t.Fatal("expected Flush() error")
+	}
+	if !manager.dirty {
+		t.Fatal("expected dirty flag to remain set after save failure")
+	}
+}
+
 func TestFileSnapshotStoreMissingFile(t *testing.T) {
 	store := NewFileSnapshotStore(filepath.Join(t.TempDir(), "missing.json"))
 	snapshot, err := store.Load(context.Background())
@@ -144,4 +202,21 @@ func TestFileSnapshotStoreCorruptFile(t *testing.T) {
 	if _, err := store.Load(context.Background()); err == nil {
 		t.Fatal("expected error for corrupt snapshot file")
 	}
+}
+
+type failingSnapshotStore struct {
+	path string
+	err  error
+}
+
+func (s *failingSnapshotStore) Load(ctx context.Context) (StatisticsSnapshot, error) {
+	return StatisticsSnapshot{}, nil
+}
+
+func (s *failingSnapshotStore) Save(ctx context.Context, snapshot StatisticsSnapshot) error {
+	return s.err
+}
+
+func (s *failingSnapshotStore) Path() string {
+	return s.path
 }

--- a/internal/usage/persistence_test.go
+++ b/internal/usage/persistence_test.go
@@ -1,0 +1,147 @@
+package usage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+)
+
+func TestFileSnapshotStoreRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "usage-statistics.json")
+	store := NewFileSnapshotStore(path)
+	snapshot := StatisticsSnapshot{
+		TotalRequests: 3,
+		SuccessCount:  2,
+		FailureCount:  1,
+		TotalTokens:   42,
+		APIs: map[string]APISnapshot{
+			"gemini": {
+				TotalRequests: 3,
+				TotalTokens:   42,
+				Models: map[string]ModelSnapshot{
+					"gemini-2.5-pro": {
+						TotalRequests: 3,
+						TotalTokens:   42,
+						Details: []RequestDetail{{
+							Timestamp: time.Unix(1700000000, 0).UTC(),
+							Source:    "test@example.com",
+							Tokens:    TokenStats{InputTokens: 20, OutputTokens: 22, TotalTokens: 42},
+						}},
+					},
+				},
+			},
+		},
+	}
+	if err := store.Save(context.Background(), snapshot); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	loaded, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if loaded.TotalRequests != snapshot.TotalRequests || loaded.TotalTokens != snapshot.TotalTokens {
+		t.Fatalf("loaded snapshot mismatch: got %+v want %+v", loaded, snapshot)
+	}
+	if got := loaded.APIs["gemini"].Models["gemini-2.5-pro"].Details[0].Source; got != "test@example.com" {
+		t.Fatalf("detail source = %q", got)
+	}
+}
+
+func TestResolvePersistencePath(t *testing.T) {
+	got := ResolvePersistencePath("/tmp/config/config.yaml", "usage-statistics.json")
+	want := "/tmp/config/usage-statistics.json"
+	if got != want {
+		t.Fatalf("ResolvePersistencePath() = %q, want %q", got, want)
+	}
+}
+
+func TestPersistenceManagerLoadAndFlush(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "usage-statistics.json")
+	store := NewFileSnapshotStore(path)
+	seed := StatisticsSnapshot{
+		TotalRequests: 1,
+		SuccessCount:  1,
+		TotalTokens:   7,
+		APIs: map[string]APISnapshot{
+			"gemini": {
+				TotalRequests: 1,
+				TotalTokens:   7,
+				Models: map[string]ModelSnapshot{
+					"m": {
+						TotalRequests: 1,
+						TotalTokens:   7,
+						Details:       []RequestDetail{{Timestamp: time.Unix(1700000100, 0).UTC(), Source: "seed", Tokens: TokenStats{TotalTokens: 7}}},
+					},
+				},
+			},
+		},
+	}
+	if err := store.Save(context.Background(), seed); err != nil {
+		t.Fatalf("seed Save() error = %v", err)
+	}
+
+	stats := NewRequestStatistics()
+	manager := NewPersistenceManager(store, stats)
+	if err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := stats.Snapshot().TotalRequests; got != 1 {
+		t.Fatalf("restored total_requests = %d, want 1", got)
+	}
+
+	stats.Record(context.Background(), coreusage.Record{Provider: "gemini", Model: "m2", Source: "live", RequestedAt: time.Now().UTC(), Failed: false, Detail: coreusage.Detail{TotalTokens: 11}})
+	manager.MarkDirty()
+	if err := manager.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	loaded, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() after flush error = %v", err)
+	}
+	if loaded.TotalRequests != 2 {
+		t.Fatalf("persisted total_requests = %d, want 2", loaded.TotalRequests)
+	}
+}
+
+func TestUpdateAPIStatsBoundsDetails(t *testing.T) {
+	stats := NewRequestStatistics()
+	bucket := &apiStats{Models: make(map[string]*modelStats)}
+	for i := 0; i < defaultMaxRequestDetails+25; i++ {
+		stats.updateAPIStats(bucket, "model", RequestDetail{Timestamp: time.Unix(int64(i), 0).UTC(), Source: "src"})
+	}
+	got := len(bucket.Models["model"].Details)
+	if got != defaultMaxRequestDetails {
+		t.Fatalf("details len = %d, want %d", got, defaultMaxRequestDetails)
+	}
+	if first := bucket.Models["model"].Details[0].Timestamp.Unix(); first != 25 {
+		t.Fatalf("first retained timestamp = %d, want 25", first)
+	}
+}
+
+func TestFileSnapshotStoreMissingFile(t *testing.T) {
+	store := NewFileSnapshotStore(filepath.Join(t.TempDir(), "missing.json"))
+	snapshot, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() missing file error = %v", err)
+	}
+	if snapshot.TotalRequests != 0 {
+		t.Fatalf("expected empty snapshot, got %+v", snapshot)
+	}
+}
+
+func TestFileSnapshotStoreCorruptFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "broken.json")
+	if err := os.WriteFile(path, []byte("{"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	store := NewFileSnapshotStore(path)
+	if _, err := store.Load(context.Background()); err == nil {
+		t.Fatal("expected error for corrupt snapshot file")
+	}
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -768,6 +768,17 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		}
 
 		usage.StopDefault()
+
+		if s.server != nil {
+			flushCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			if err := s.server.StopUsagePersistence(flushCtx); err != nil {
+				log.Errorf("error persisting usage statistics during shutdown: %v", err)
+				if shutdownErr == nil {
+					shutdownErr = err
+				}
+			}
+		}
 	})
 	return shutdownErr
 }

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -46,6 +46,7 @@ type Manager struct {
 	once     sync.Once
 	stopOnce sync.Once
 	cancel   context.CancelFunc
+	done     chan struct{}
 
 	mu     sync.Mutex
 	cond   *sync.Cond
@@ -58,7 +59,7 @@ type Manager struct {
 
 // NewManager constructs a manager with a buffered queue.
 func NewManager(buffer int) *Manager {
-	m := &Manager{}
+	m := &Manager{done: make(chan struct{})}
 	m.cond = sync.NewCond(&m.mu)
 	return m
 }
@@ -92,6 +93,7 @@ func (m *Manager) Stop() {
 		m.mu.Unlock()
 		m.cond.Broadcast()
 	})
+	<-m.done
 }
 
 // Register appends a plugin to the delivery list.
@@ -123,6 +125,7 @@ func (m *Manager) Publish(ctx context.Context, record Record) {
 }
 
 func (m *Manager) run(ctx context.Context) {
+	defer close(m.done)
 	for {
 		m.mu.Lock()
 		for !m.closed && len(m.queue) == 0 {

--- a/sdk/cliproxy/usage/manager_test.go
+++ b/sdk/cliproxy/usage/manager_test.go
@@ -1,0 +1,71 @@
+package usage
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+type recordingPlugin struct {
+	mu      sync.Mutex
+	records []Record
+	release chan struct{}
+	started chan struct{}
+}
+
+func (p *recordingPlugin) HandleUsage(ctx context.Context, record Record) {
+	if p.started != nil {
+		select {
+		case <-p.started:
+		default:
+			close(p.started)
+		}
+	}
+	if p.release != nil {
+		<-p.release
+	}
+	p.mu.Lock()
+	p.records = append(p.records, record)
+	p.mu.Unlock()
+}
+
+func TestManagerStopDrainsQueueBeforeReturn(t *testing.T) {
+	m := NewManager(4)
+	plugin := &recordingPlugin{
+		release: make(chan struct{}),
+		started: make(chan struct{}),
+	}
+	m.Register(plugin)
+
+	m.Publish(context.Background(), Record{Provider: "gemini", Model: "m1"})
+	m.Publish(context.Background(), Record{Provider: "gemini", Model: "m2"})
+
+	<-plugin.started
+
+	stopDone := make(chan struct{})
+	go func() {
+		m.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned before queued records were drained")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(plugin.release)
+
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return after draining queued records")
+	}
+
+	plugin.mu.Lock()
+	defer plugin.mu.Unlock()
+	if len(plugin.records) != 2 {
+		t.Fatalf("records processed = %d, want 2", len(plugin.records))
+	}
+}


### PR DESCRIPTION
## Summary

Usage statistics are currently in-memory only, so they are lost on restart or redeploy.

This PR adds optional file-backed persistence for usage statistics snapshots. The feature is disabled by default, so existing behavior does not change unless it is explicitly enabled in config.

Closes #2671

## What this adds

- `usage-statistics-persistence-enabled`
- `usage-statistics-persistence-path`
- snapshot restore during server startup
- debounced snapshot writes while usage is being recorded
- snapshot flush after `POST /usage/import`
- final snapshot flush during shutdown after the async usage queue has been drained
- persistence remains active even if snapshot restore fails at startup
- persistence flush logic preserves dirty state across save failures and concurrent writes during save

## Scope

This PR is intentionally narrow:

- no UI changes
- no request-log persistence
- no database backend
- no default behavior change
- no change to usage export/import snapshot semantics beyond making them durable when persistence is enabled

## Implementation notes

The persisted file uses the existing usage snapshot structure with a small versioned wrapper. That keeps the format easy to inspect and avoids introducing a separate persistence-specific schema.

## Validation

- `gofmt -w internal/config/config.go internal/usage/logger_plugin.go internal/usage/persistence.go internal/usage/persistence_test.go internal/api/handlers/management/usage.go internal/api/server.go sdk/cliproxy/service.go sdk/cliproxy/usage/manager.go sdk/cliproxy/usage/manager_test.go`
- `go build -o /tmp/cli-proxy-api-test ./cmd/server`
- `go test ./sdk/cliproxy/usage ./internal/usage ./internal/api/handlers/management ./internal/api/... ./sdk/cliproxy/... ./test/...`
