### PR TITLE
feat(retry): detect and retry transient HTTP 400 errors from upstream

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -2051,6 +2052,17 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								shouldSuspendModel = true
 								setModelQuota = true
 							}
+						case 400:
+							if result.Error != nil && isTransientBadRequest(fmt.Errorf("%s", result.Error.Message)) {
+								if disableCooling {
+									state.NextRetryAfter = time.Time{}
+								} else {
+									next := now.Add(1 * time.Minute)
+									state.NextRetryAfter = next
+								}
+							} else {
+								state.NextRetryAfter = time.Time{}
+							}
 						case 408, 500, 502, 503, 504:
 							if disableCooling {
 								state.NextRetryAfter = time.Time{}
@@ -2386,6 +2398,9 @@ func isRequestInvalidError(err error) bool {
 	status := statusCodeFromError(err)
 	switch status {
 	case http.StatusBadRequest:
+		if isTransientBadRequest(err) {
+			return false
+		}
 		return strings.Contains(err.Error(), "invalid_request_error")
 	case http.StatusNotFound:
 		return isRequestScopedNotFoundMessage(err.Error())
@@ -2394,6 +2409,30 @@ func isRequestInvalidError(err error) bool {
 	default:
 		return false
 	}
+}
+
+// isTransientBadRequest detects HTTP 400 responses that are actually transient
+// upstream errors (e.g. model temporarily unavailable) rather than true client
+// request validation failures. These should be retried.
+func isTransientBadRequest(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	transientPatterns := []string{
+		"\u5f53\u524d\u6a21\u578b\u6682\u65f6\u65e0\u6cd5\u4f7f\u7528", // 当前模型暂时无法使用 (model temporarily unavailable)
+		"temporarily unavailable",
+		"model is currently unavailable",
+		"service is temporarily",
+		"try again later",
+		"请稍后再试", // please try again later
+	}
+	for _, p := range transientPatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
 }
 
 func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {
@@ -2454,6 +2493,19 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		}
 		auth.Quota.NextRecoverAt = next
 		auth.NextRetryAfter = next
+	case 400:
+		if resultErr != nil && isTransientBadRequest(fmt.Errorf("%s", resultErr.Message)) {
+			auth.StatusMessage = "transient upstream error"
+			if disableCooling {
+				auth.NextRetryAfter = time.Time{}
+			} else {
+				auth.NextRetryAfter = now.Add(1 * time.Minute)
+			}
+		} else {
+			if auth.StatusMessage == "" {
+				auth.StatusMessage = "bad request"
+			}
+		}
 	case 408, 500, 502, 503, 504:
 		auth.StatusMessage = "transient upstream error"
 		if disableCooling {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -2053,7 +2052,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								setModelQuota = true
 							}
 						case 400:
-							if result.Error != nil && isTransientBadRequest(fmt.Errorf("%s", result.Error.Message)) {
+							if result.Error != nil && isTransientBadRequestMessage(result.Error.Message) {
 								if disableCooling {
 									state.NextRetryAfter = time.Time{}
 								} else {
@@ -2418,9 +2417,14 @@ func isTransientBadRequest(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
+	return isTransientBadRequestMessage(err.Error())
+}
+
+// isTransientBadRequestMessage checks a raw message string for transient patterns.
+func isTransientBadRequestMessage(s string) bool {
+	msg := strings.ToLower(s)
 	transientPatterns := []string{
-		"\u5f53\u524d\u6a21\u578b\u6682\u65f6\u65e0\u6cd5\u4f7f\u7528", // 当前模型暂时无法使用 (model temporarily unavailable)
+		"当前模型暂时无法使用", // model temporarily unavailable
 		"temporarily unavailable",
 		"model is currently unavailable",
 		"service is temporarily",
@@ -2428,7 +2432,7 @@ func isTransientBadRequest(err error) bool {
 		"请稍后再试", // please try again later
 	}
 	for _, p := range transientPatterns {
-		if strings.Contains(msg, p) {
+		if strings.Contains(msg, strings.ToLower(p)) {
 			return true
 		}
 	}
@@ -2494,7 +2498,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.Quota.NextRecoverAt = next
 		auth.NextRetryAfter = next
 	case 400:
-		if resultErr != nil && isTransientBadRequest(fmt.Errorf("%s", resultErr.Message)) {
+		if resultErr != nil && isTransientBadRequestMessage(resultErr.Message) {
 			auth.StatusMessage = "transient upstream error"
 			if disableCooling {
 				auth.NextRetryAfter = time.Time{}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2421,8 +2421,47 @@ func isTransientBadRequest(err error) bool {
 }
 
 // isTransientBadRequestMessage checks a raw message string for transient patterns.
+// It handles both decoded UTF-8 text and raw JSON strings containing \uXXXX escapes.
 func isTransientBadRequestMessage(s string) bool {
 	msg := strings.ToLower(s)
+	if matchesTransientPatterns(msg) {
+		return true
+	}
+	// Some executor layers pass upstream 400 bodies as raw JSON strings with
+	// escaped Unicode (e.g. \u5f53\u524d...). Attempt to decode so that
+	// Chinese/multibyte patterns can still match.
+	if strings.Contains(msg, `\u`) {
+		decoded := unescapeUnicodeSequences(msg)
+		if decoded != msg && matchesTransientPatterns(decoded) {
+			return true
+		}
+	}
+	return false
+}
+
+// unescapeUnicodeSequences replaces \uXXXX sequences in s with their UTF-8
+// representation. This handles the common case where upstream JSON bodies are
+// passed through as raw strings without JSON-decoding.
+func unescapeUnicodeSequences(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if i+5 < len(s) && s[i] == '\\' && s[i+1] == 'u' {
+			hex := s[i+2 : i+6]
+			code, err := strconv.ParseInt(hex, 16, 32)
+			if err == nil {
+				b.WriteRune(rune(code))
+				i += 6
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+func matchesTransientPatterns(msg string) bool {
 	transientPatterns := []string{
 		"当前模型暂时无法使用", // model temporarily unavailable
 		"temporarily unavailable",

--- a/sdk/cliproxy/auth/conductor_transient_400_test.go
+++ b/sdk/cliproxy/auth/conductor_transient_400_test.go
@@ -65,3 +65,30 @@ func TestIsTransientBadRequestMessage_Direct(t *testing.T) {
 	}
 }
 
+func TestIsTransientBadRequest_RawUnicodeEscaped(t *testing.T) {
+	// Upstream 400 bodies may arrive as raw JSON with escaped Unicode.
+	// This is the exact scenario described in the review: executor passes
+	// string(body) which contains \uXXXX sequences instead of decoded UTF-8.
+	raw := `{"error":{"message":"\u5f53\u524d\u6a21\u578b\u6682\u65f6\u65e0\u6cd5\u4f7f\u7528\uff0c\u8bf7\u7a0d\u540e\u518d\u8bd5","type":"<nil>"},"requestId":"1775821625034351"}`
+	err := fmt.Errorf("%s", raw)
+	if !isTransientBadRequest(err) {
+		t.Fatal("expected raw unicode-escaped Chinese transient message to be detected")
+	}
+}
+
+func TestIsTransientBadRequestMessage_RawUnicodeOnly(t *testing.T) {
+	// Test the message-level function directly with raw escaped string.
+	raw := `\u5f53\u524d\u6a21\u578b\u6682\u65f6\u65e0\u6cd5\u4f7f\u7528`
+	if !isTransientBadRequestMessage(raw) {
+		t.Fatal("isTransientBadRequestMessage should detect raw \\uXXXX escaped Chinese pattern")
+	}
+}
+
+func TestIsTransientBadRequestMessage_RawUnicodeNonTransient(t *testing.T) {
+	// Escaped unicode that does NOT match transient patterns should return false.
+	raw := `\u0069\u006e\u0076\u0061\u006c\u0069\u0064` // "invalid"
+	if isTransientBadRequestMessage(raw) {
+		t.Fatal("non-transient escaped unicode should not match")
+	}
+}
+

--- a/sdk/cliproxy/auth/conductor_transient_400_test.go
+++ b/sdk/cliproxy/auth/conductor_transient_400_test.go
@@ -39,3 +39,29 @@ func TestIsTransientBadRequest_Nil(t *testing.T) {
 	}
 }
 
+func TestIsTransientBadRequest_CaseInsensitive(t *testing.T) {
+	err := fmt.Errorf("Model Is Temporarily Unavailable")
+	if !isTransientBadRequest(err) {
+		t.Fatal("case-insensitive match should detect mixed-case 'Temporarily Unavailable'")
+	}
+}
+
+func TestIsTransientBadRequest_UpperCase(t *testing.T) {
+	err := fmt.Errorf("TRY AGAIN LATER")
+	if !isTransientBadRequest(err) {
+		t.Fatal("case-insensitive match should detect upper-case 'TRY AGAIN LATER'")
+	}
+}
+
+func TestIsTransientBadRequestMessage_Direct(t *testing.T) {
+	if !isTransientBadRequestMessage("当前模型暂时无法使用") {
+		t.Fatal("isTransientBadRequestMessage should detect Chinese transient pattern")
+	}
+	if isTransientBadRequestMessage("invalid_request_error: bad param") {
+		t.Fatal("isTransientBadRequestMessage should not match real validation errors")
+	}
+	if isTransientBadRequestMessage("") {
+		t.Fatal("empty string should not be transient")
+	}
+}
+

--- a/sdk/cliproxy/auth/conductor_transient_400_test.go
+++ b/sdk/cliproxy/auth/conductor_transient_400_test.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsTransientBadRequest_ChineseModelUnavailable(t *testing.T) {
+	err := fmt.Errorf(`{"error":{"message":"当前模型暂时无法使用,请稍后再试","type":"<nil>"},"requestId":"1775821625034351"}`)
+	if !isTransientBadRequest(err) {
+		t.Fatal("expected Chinese 'model temporarily unavailable' message to be detected as transient")
+	}
+}
+
+func TestIsTransientBadRequest_EnglishTemporarilyUnavailable(t *testing.T) {
+	err := fmt.Errorf("model is temporarily unavailable, please try again later")
+	if !isTransientBadRequest(err) {
+		t.Fatal("expected English 'temporarily unavailable' message to be detected as transient")
+	}
+}
+
+func TestIsTransientBadRequest_TryAgainLater(t *testing.T) {
+	err := fmt.Errorf("service error: try again later")
+	if !isTransientBadRequest(err) {
+		t.Fatal("expected 'try again later' message to be detected as transient")
+	}
+}
+
+func TestIsTransientBadRequest_RealInvalidRequest(t *testing.T) {
+	err := fmt.Errorf(`{"error":{"message":"invalid_request_error: max_tokens must be positive","type":"invalid_request_error"}}`)
+	if isTransientBadRequest(err) {
+		t.Fatal("real invalid_request_error should NOT be detected as transient")
+	}
+}
+
+func TestIsTransientBadRequest_Nil(t *testing.T) {
+	if isTransientBadRequest(nil) {
+		t.Fatal("nil error should not be transient")
+	}
+}
+


### PR DESCRIPTION
## Problem

Some upstream providers (notably Chinese API endpoints) return HTTP 400 with temporary error messages like:
```json
{"error":{"message":"当前模型暂时无法使用,请稍后再试","type":"<nil>"},"requestId":"..."}
```
("The current model is temporarily unavailable, please try again later")

These are **not** true client validation errors but transient upstream failures. Currently, `request-retry` only retries 403, 408, 500, 502, 503, 504 — so these 400s are immediately returned as errors without retry.

## Solution

- Added `isTransientBadRequest()` function that detects known transient error patterns in both Chinese and English
- Updated `isRequestInvalidError()` to exclude transient 400s, allowing retry logic to handle them
- Added `case 400` in both conductor state switches to apply 1-minute cooldown for transient 400s (same as 5xx)
- Non-transient 400s (actual `invalid_request_error`) remain unaffected

### Detected patterns:
- `当前模型暂时无法使用` (model temporarily unavailable)
- `请稍后再试` (try again later) 
- `temporarily unavailable`
- `model is currently unavailable`
- `service is temporarily`
- `try again later`

## Tests

5 new tests covering transient detection, real invalid requests, and nil safety — all passing.