### PR TITLE
docs(README): add CLIproxyAPI Quota Inspector to community projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ helping users to immersively use AI assistants across applications on controlled
 
 Cross-platform desktop app (macOS, Windows, Linux) wrapping CLIProxyAPI with a native GUI. Connects Claude, ChatGPT, Gemini, GitHub Copilot, Qwen, iFlow, and custom OpenAI-compatible endpoints with usage analytics, request monitoring, and auto-configuration for popular coding tools - no API keys needed.
 
-### [CLIproxyAPI Quota Inspector](https://github.com/AllenReder/CLIproxyAPI-Quota-Inspector)
+### [CLIProxyAPI Quota Inspector](https://github.com/AllenReder/CLIProxyAPI-Quota-Inspector)
 
 Ready-to-use cross-platform quota inspector for CLIProxyAPI, supporting per-account code 5h/7d quota windows, plan-based sorting, status coloring, and multi-account summary analytics.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Cross-platform desktop app (macOS, Windows, Linux) wrapping CLIProxyAPI with a n
 
 ### [CLIProxyAPI Quota Inspector](https://github.com/AllenReder/CLIProxyAPI-Quota-Inspector)
 
-Ready-to-use cross-platform quota inspector for CLIProxyAPI, supporting per-account code 5h/7d quota windows, plan-based sorting, status coloring, and multi-account summary analytics.
+Ready-to-use cross-platform quota inspector for CLIProxyAPI, supporting per-account codex 5h/7d quota windows, plan-based sorting, status coloring, and multi-account summary analytics.
 
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ helping users to immersively use AI assistants across applications on controlled
 
 Cross-platform desktop app (macOS, Windows, Linux) wrapping CLIProxyAPI with a native GUI. Connects Claude, ChatGPT, Gemini, GitHub Copilot, Qwen, iFlow, and custom OpenAI-compatible endpoints with usage analytics, request monitoring, and auto-configuration for popular coding tools - no API keys needed.
 
+### [CLIproxyAPI Quota Inspector](https://github.com/AllenReder/CLIproxyAPI-Quota-Inspector)
+
+Ready-to-use cross-platform quota inspector for CLIProxyAPI, supporting per-account code 5h/7d quota windows, plan-based sorting, status coloring, and multi-account summary analytics.
+
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -177,7 +177,7 @@ Shadow AI 是一款专为受限环境设计的 AI 辅助工具。提供无窗口
 
 跨平台桌面应用（macOS、Windows、Linux），以原生 GUI 封装 CLIProxyAPI。支持连接 Claude、ChatGPT、Gemini、GitHub Copilot、Qwen、iFlow 及自定义 OpenAI 兼容端点，具备使用分析、请求监控和热门编程工具自动配置功能，无需 API 密钥。
 
-### [CLIproxyAPI Quota Inspector](https://github.com/AllenReder/CLIproxyAPI-Quota-Inspector)
+### [CLIProxyAPI Quota Inspector](https://github.com/AllenReder/CLIProxyAPI-Quota-Inspector)
 
 上手即用的面向 CLIProxyAPI 跨平台配额查询工具，支持按账号展示 code 5h/7d 配额窗口、按计划排序、状态着色及多账号汇总分析。
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -179,7 +179,7 @@ Shadow AI 是一款专为受限环境设计的 AI 辅助工具。提供无窗口
 
 ### [CLIProxyAPI Quota Inspector](https://github.com/AllenReder/CLIProxyAPI-Quota-Inspector)
 
-上手即用的面向 CLIProxyAPI 跨平台配额查询工具，支持按账号展示 code 5h/7d 配额窗口、按计划排序、状态着色及多账号汇总分析。
+上手即用的面向 CLIProxyAPI 跨平台配额查询工具，支持按账号展示 codex 5h/7d 配额窗口、按计划排序、状态着色及多账号汇总分析。
 
 > [!NOTE]  
 > 如果你开发了基于 CLIProxyAPI 的项目，请提交一个 PR（拉取请求）将其添加到此列表中。

--- a/README_CN.md
+++ b/README_CN.md
@@ -177,6 +177,10 @@ Shadow AI 是一款专为受限环境设计的 AI 辅助工具。提供无窗口
 
 跨平台桌面应用（macOS、Windows、Linux），以原生 GUI 封装 CLIProxyAPI。支持连接 Claude、ChatGPT、Gemini、GitHub Copilot、Qwen、iFlow 及自定义 OpenAI 兼容端点，具备使用分析、请求监控和热门编程工具自动配置功能，无需 API 密钥。
 
+### [CLIproxyAPI Quota Inspector](https://github.com/AllenReder/CLIproxyAPI-Quota-Inspector)
+
+上手即用的面向 CLIProxyAPI 跨平台配额查询工具，支持按账号展示 code 5h/7d 配额窗口、按计划排序、状态着色及多账号汇总分析。
+
 > [!NOTE]  
 > 如果你开发了基于 CLIProxyAPI 的项目，请提交一个 PR（拉取请求）将其添加到此列表中。
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -180,7 +180,7 @@ CLIProxyAPIをネイティブGUIでラップしたクロスプラットフォー
 
 ### [CLIProxyAPI Quota Inspector](https://github.com/AllenReder/CLIProxyAPI-Quota-Inspector)
 
-CLIProxyAPI向けのすぐに使えるクロスプラットフォームのクォータ確認ツール。アカウントごとの code 5h/7d クォータ表示、プラン別ソート、ステータス色分け、複数アカウントの集計分析に対応。
+CLIProxyAPI向けのすぐに使えるクロスプラットフォームのクォータ確認ツール。アカウントごとの codex 5h/7d クォータ表示、プラン別ソート、ステータス色分け、複数アカウントの集計分析に対応。
 
 > [!NOTE]
 > CLIProxyAPIをベースにプロジェクトを開発した場合は、PRを送ってこのリストに追加してください。

--- a/README_JA.md
+++ b/README_JA.md
@@ -178,7 +178,7 @@ Shadow AIは制限された環境向けに特別に設計されたAIアシスタ
 
 CLIProxyAPIをネイティブGUIでラップしたクロスプラットフォームデスクトップアプリ（macOS、Windows、Linux）。Claude、ChatGPT、Gemini、GitHub Copilot、Qwen、iFlow、カスタムOpenAI互換エンドポイントに対応し、使用状況分析、リクエスト監視、人気コーディングツールの自動設定機能を搭載 - APIキー不要
 
-### [CLIproxyAPI Quota Inspector](https://github.com/AllenReder/CLIproxyAPI-Quota-Inspector)
+### [CLIProxyAPI Quota Inspector](https://github.com/AllenReder/CLIProxyAPI-Quota-Inspector)
 
 CLIProxyAPI向けのすぐに使えるクロスプラットフォームのクォータ確認ツール。アカウントごとの code 5h/7d クォータ表示、プラン別ソート、ステータス色分け、複数アカウントの集計分析に対応。
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -178,6 +178,10 @@ Shadow AIは制限された環境向けに特別に設計されたAIアシスタ
 
 CLIProxyAPIをネイティブGUIでラップしたクロスプラットフォームデスクトップアプリ（macOS、Windows、Linux）。Claude、ChatGPT、Gemini、GitHub Copilot、Qwen、iFlow、カスタムOpenAI互換エンドポイントに対応し、使用状況分析、リクエスト監視、人気コーディングツールの自動設定機能を搭載 - APIキー不要
 
+### [CLIproxyAPI Quota Inspector](https://github.com/AllenReder/CLIproxyAPI-Quota-Inspector)
+
+CLIProxyAPI向けのすぐに使えるクロスプラットフォームのクォータ確認ツール。アカウントごとの code 5h/7d クォータ表示、プラン別ソート、ステータス色分け、複数アカウントの集計分析に対応。
+
 > [!NOTE]
 > CLIProxyAPIをベースにプロジェクトを開発した場合は、PRを送ってこのリストに追加してください。
 


### PR DESCRIPTION
## Summary
- Added `CLIProxyAPI Quota Inspector` to the community project list.
- Updated all localized READMEs:
  - README.md (English)
  - README_CN.md (Chinese)
  - README_JA.md (Japanese)

## Project
- https://github.com/AllenReder/CLIProxyAPI-Quota-Inspector

## Notes
- Change is documentation-only.
