### PR TITLE
Recover responses stream disconnects

### DIFF
--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -77,6 +77,10 @@ func (w *ResponseWriterWrapper) Write(data []byte) (int, error) {
 
 	// CRITICAL: Write to client first (zero latency)
 	n, err := w.ResponseWriter.Write(data)
+	if n <= 0 {
+		return n, err
+	}
+	written := data[:n]
 
 	// THEN: Handle logging based on response type
 	if w.isStreaming && w.chunkChannel != nil {
@@ -86,14 +90,14 @@ func (w *ResponseWriterWrapper) Write(data []byte) (int, error) {
 		}
 		// For streaming responses: Send to async logging channel (non-blocking)
 		select {
-		case w.chunkChannel <- append([]byte(nil), data...): // Non-blocking send with copy
+		case w.chunkChannel <- append([]byte(nil), written...): // Non-blocking send with copy
 		default: // Channel full, skip logging to avoid blocking
 		}
 		return n, err
 	}
 
 	if w.shouldBufferResponseBody() {
-		w.body.Write(data)
+		w.body.Write(written)
 	}
 
 	return n, err
@@ -125,6 +129,10 @@ func (w *ResponseWriterWrapper) WriteString(data string) (int, error) {
 
 	// CRITICAL: Write to client first (zero latency)
 	n, err := w.ResponseWriter.WriteString(data)
+	if n <= 0 {
+		return n, err
+	}
+	written := data[:n]
 
 	// THEN: Capture for logging
 	if w.isStreaming && w.chunkChannel != nil {
@@ -133,14 +141,14 @@ func (w *ResponseWriterWrapper) WriteString(data string) (int, error) {
 			w.firstChunkTimestamp = time.Now()
 		}
 		select {
-		case w.chunkChannel <- []byte(data):
+		case w.chunkChannel <- []byte(written):
 		default:
 		}
 		return n, err
 	}
 
 	if w.shouldBufferResponseBody() {
-		w.body.WriteString(data)
+		w.body.WriteString(written)
 	}
 	return n, err
 }

--- a/internal/api/middleware/response_writer_test.go
+++ b/internal/api/middleware/response_writer_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bytes"
+	"errors"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -154,6 +155,75 @@ func TestFinalizeStreamingWritesAPIWebsocketTimeline(t *testing.T) {
 	}
 }
 
+func TestWriteBuffersOnlySuccessfulPrefixWhenClientWriteFails(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+
+	writeErr := errors.New("write failed")
+	underlying := &partialWriteResponseWriter{
+		ResponseWriter: c.Writer,
+		writeN:         3,
+		err:            writeErr,
+	}
+
+	wrapper := &ResponseWriterWrapper{
+		ResponseWriter: underlying,
+		body:           &bytes.Buffer{},
+		logger:         &testRequestLogger{enabled: true},
+		requestInfo:    &RequestInfo{},
+	}
+
+	n, err := wrapper.Write([]byte("abcdef"))
+	if n != 3 {
+		t.Fatalf("Write returned n=%d, want 3", n)
+	}
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("Write returned err=%v, want %v", err, writeErr)
+	}
+	if got := wrapper.body.String(); got != "abc" {
+		t.Fatalf("buffered body = %q, want %q", got, "abc")
+	}
+}
+
+func TestWriteStreamingLogsOnlySuccessfulPrefixWhenClientWriteFails(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+
+	writeErr := errors.New("write failed")
+	underlying := &partialWriteResponseWriter{
+		ResponseWriter: c.Writer,
+		writeN:         4,
+		err:            writeErr,
+	}
+
+	wrapper := &ResponseWriterWrapper{
+		ResponseWriter: underlying,
+		logger:         &testRequestLogger{enabled: true},
+		requestInfo:    &RequestInfo{},
+		isStreaming:    true,
+		chunkChannel:   make(chan []byte, 1),
+	}
+
+	n, err := wrapper.Write([]byte("abcdefgh"))
+	if n != 4 {
+		t.Fatalf("Write returned n=%d, want 4", n)
+	}
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("Write returned err=%v, want %v", err, writeErr)
+	}
+
+	select {
+	case chunk := <-wrapper.chunkChannel:
+		if string(chunk) != "abcd" {
+			t.Fatalf("logged chunk = %q, want %q", string(chunk), "abcd")
+		}
+	default:
+		t.Fatal("expected streaming write to enqueue successful prefix")
+	}
+}
+
 type testRequestLogger struct {
 	enabled bool
 }
@@ -173,6 +243,26 @@ func (l *testRequestLogger) IsEnabled() bool {
 type testStreamingLogWriter struct {
 	apiWebsocketTimeline []byte
 	closed               bool
+}
+
+type partialWriteResponseWriter struct {
+	gin.ResponseWriter
+	writeN int
+	err    error
+}
+
+func (w *partialWriteResponseWriter) Write(data []byte) (int, error) {
+	if w.writeN >= len(data) {
+		return w.ResponseWriter.Write(data)
+	}
+	return w.writeN, w.err
+}
+
+func (w *partialWriteResponseWriter) WriteString(data string) (int, error) {
+	if w.writeN >= len(data) {
+		return w.ResponseWriter.WriteString(data)
+	}
+	return w.writeN, w.err
 }
 
 func (w *testStreamingLogWriter) WriteChunkAsync([]byte) {}

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -271,7 +271,10 @@ func (h *ClaudeCodeAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON [
 
 			// Write the first chunk
 			if len(chunk) > 0 {
-				_, _ = c.Writer.Write(chunk)
+				if _, err := c.Writer.Write(chunk); err != nil {
+					cliCancel(err)
+					return
+				}
 				flusher.Flush()
 			}
 
@@ -284,15 +287,16 @@ func (h *ClaudeCodeAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON [
 
 func (h *ClaudeCodeAPIHandler) forwardClaudeStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{
-		WriteChunk: func(chunk []byte) {
+		WriteChunk: func(chunk []byte) error {
 			if len(chunk) == 0 {
-				return
+				return nil
 			}
-			_, _ = c.Writer.Write(chunk)
+			_, err := c.Writer.Write(chunk)
+			return err
 		},
-		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
+		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) error {
 			if errMsg == nil {
-				return
+				return nil
 			}
 			status := http.StatusInternalServerError
 			if errMsg.StatusCode > 0 {
@@ -301,7 +305,8 @@ func (h *ClaudeCodeAPIHandler) forwardClaudeStream(c *gin.Context, flusher http.
 			c.Status(status)
 
 			errorBytes, _ := json.Marshal(h.toClaudeError(errMsg))
-			_, _ = fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", errorBytes)
+			_, err := fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", errorBytes)
+			return err
 		},
 	})
 }

--- a/sdk/api/handlers/gemini/gemini-cli_handlers.go
+++ b/sdk/api/handlers/gemini/gemini-cli_handlers.go
@@ -209,25 +209,31 @@ func (h *GeminiCLIAPIHandler) forwardCLIStream(c *gin.Context, flusher http.Flus
 
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{
 		KeepAliveInterval: keepAliveInterval,
-		WriteChunk: func(chunk []byte) {
+		WriteChunk: func(chunk []byte) error {
 			if alt == "" {
 				if bytes.Equal(chunk, []byte("data: [DONE]")) || bytes.Equal(chunk, []byte("[DONE]")) {
-					return
+					return nil
 				}
 
 				if !bytes.HasPrefix(chunk, []byte("data:")) {
-					_, _ = c.Writer.Write([]byte("data: "))
+					if _, err := c.Writer.Write([]byte("data: ")); err != nil {
+						return err
+					}
 				}
 
-				_, _ = c.Writer.Write(chunk)
-				_, _ = c.Writer.Write([]byte("\n\n"))
+				if _, err := c.Writer.Write(chunk); err != nil {
+					return err
+				}
+				_, err := c.Writer.Write([]byte("\n\n"))
+				return err
 			} else {
-				_, _ = c.Writer.Write(chunk)
+				_, err := c.Writer.Write(chunk)
+				return err
 			}
 		},
-		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
+		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) error {
 			if errMsg == nil {
-				return
+				return nil
 			}
 			status := http.StatusInternalServerError
 			if errMsg.StatusCode > 0 {
@@ -239,9 +245,11 @@ func (h *GeminiCLIAPIHandler) forwardCLIStream(c *gin.Context, flusher http.Flus
 			}
 			body := handlers.BuildErrorResponseBody(status, errText)
 			if alt == "" {
-				_, _ = fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", string(body))
+				_, err := fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", string(body))
+				return err
 			} else {
-				_, _ = c.Writer.Write(body)
+				_, err := c.Writer.Write(body)
+				return err
 			}
 		},
 	})

--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -237,11 +237,23 @@ func (h *GeminiAPIHandler) handleStreamGenerateContent(c *gin.Context, modelName
 
 			// Write first chunk
 			if alt == "" {
-				_, _ = c.Writer.Write([]byte("data: "))
-				_, _ = c.Writer.Write(chunk)
-				_, _ = c.Writer.Write([]byte("\n\n"))
+				if _, err := c.Writer.Write([]byte("data: ")); err != nil {
+					cliCancel(err)
+					return
+				}
+				if _, err := c.Writer.Write(chunk); err != nil {
+					cliCancel(err)
+					return
+				}
+				if _, err := c.Writer.Write([]byte("\n\n")); err != nil {
+					cliCancel(err)
+					return
+				}
 			} else {
-				_, _ = c.Writer.Write(chunk)
+				if _, err := c.Writer.Write(chunk); err != nil {
+					cliCancel(err)
+					return
+				}
 			}
 			flusher.Flush()
 
@@ -309,18 +321,24 @@ func (h *GeminiAPIHandler) forwardGeminiStream(c *gin.Context, flusher http.Flus
 
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{
 		KeepAliveInterval: keepAliveInterval,
-		WriteChunk: func(chunk []byte) {
+		WriteChunk: func(chunk []byte) error {
 			if alt == "" {
-				_, _ = c.Writer.Write([]byte("data: "))
-				_, _ = c.Writer.Write(chunk)
-				_, _ = c.Writer.Write([]byte("\n\n"))
+				if _, err := c.Writer.Write([]byte("data: ")); err != nil {
+					return err
+				}
+				if _, err := c.Writer.Write(chunk); err != nil {
+					return err
+				}
+				_, err := c.Writer.Write([]byte("\n\n"))
+				return err
 			} else {
-				_, _ = c.Writer.Write(chunk)
+				_, err := c.Writer.Write(chunk)
+				return err
 			}
 		},
-		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
+		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) error {
 			if errMsg == nil {
-				return
+				return nil
 			}
 			status := http.StatusInternalServerError
 			if errMsg.StatusCode > 0 {
@@ -332,9 +350,11 @@ func (h *GeminiAPIHandler) forwardGeminiStream(c *gin.Context, flusher http.Flus
 			}
 			body := handlers.BuildErrorResponseBody(status, errText)
 			if alt == "" {
-				_, _ = fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", string(body))
+				_, err := fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", string(body))
+				return err
 			} else {
-				_, _ = c.Writer.Write(body)
+				_, err := c.Writer.Write(body)
+				return err
 			}
 		},
 	})

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -498,7 +498,10 @@ func (h *OpenAIAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON []byt
 				// Stream closed without data? Send DONE or just headers.
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-				_, _ = fmt.Fprintf(c.Writer, "data: [DONE]\n\n")
+				if _, err := fmt.Fprintf(c.Writer, "data: [DONE]\n\n"); err != nil {
+					cliCancel(err)
+					return
+				}
 				flusher.Flush()
 				cliCancel(nil)
 				return
@@ -508,7 +511,10 @@ func (h *OpenAIAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON []byt
 			setSSEHeaders()
 			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 
-			_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(chunk))
+			if _, err := fmt.Fprintf(c.Writer, "data: %s\n\n", string(chunk)); err != nil {
+				cliCancel(err)
+				return
+			}
 			flusher.Flush()
 
 			// Continue streaming the rest
@@ -604,7 +610,10 @@ func (h *OpenAIAPIHandler) handleCompletionsStreamingResponse(c *gin.Context, ra
 			if !ok {
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-				_, _ = fmt.Fprintf(c.Writer, "data: [DONE]\n\n")
+				if _, err := fmt.Fprintf(c.Writer, "data: [DONE]\n\n"); err != nil {
+					cliCancel(err)
+					return
+				}
 				flusher.Flush()
 				cliCancel(nil)
 				return
@@ -617,7 +626,10 @@ func (h *OpenAIAPIHandler) handleCompletionsStreamingResponse(c *gin.Context, ra
 			// Write the first chunk
 			converted := convertChatCompletionsStreamChunkToCompletions(chunk)
 			if converted != nil {
-				_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(converted))
+				if _, err := fmt.Fprintf(c.Writer, "data: %s\n\n", string(converted)); err != nil {
+					cliCancel(err)
+					return
+				}
 				flusher.Flush()
 			}
 
@@ -659,12 +671,13 @@ func (h *OpenAIAPIHandler) handleCompletionsStreamingResponse(c *gin.Context, ra
 }
 func (h *OpenAIAPIHandler) handleStreamResult(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{
-		WriteChunk: func(chunk []byte) {
-			_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(chunk))
+		WriteChunk: func(chunk []byte) error {
+			_, err := fmt.Fprintf(c.Writer, "data: %s\n\n", string(chunk))
+			return err
 		},
-		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
+		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) error {
 			if errMsg == nil {
-				return
+				return nil
 			}
 			status := http.StatusInternalServerError
 			if errMsg.StatusCode > 0 {
@@ -675,10 +688,12 @@ func (h *OpenAIAPIHandler) handleStreamResult(c *gin.Context, flusher http.Flush
 				errText = errMsg.Error.Error()
 			}
 			body := handlers.BuildErrorResponseBody(status, errText)
-			_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(body))
+			_, err := fmt.Fprintf(c.Writer, "data: %s\n\n", string(body))
+			return err
 		},
-		WriteDone: func() {
-			_, _ = fmt.Fprint(c.Writer, "data: [DONE]\n\n")
+		WriteDone: func() error {
+			_, err := fmt.Fprint(c.Writer, "data: [DONE]\n\n")
+			return err
 		},
 	})
 }

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -23,15 +23,15 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-func writeResponsesSSEChunk(w io.Writer, chunk []byte) {
+func writeResponsesSSEChunk(w io.Writer, chunk []byte) error {
 	if w == nil || len(chunk) == 0 {
-		return
+		return nil
 	}
 	if _, err := w.Write(chunk); err != nil {
-		return
+		return err
 	}
 	if bytes.HasSuffix(chunk, []byte("\n\n")) || bytes.HasSuffix(chunk, []byte("\r\n\r\n")) {
-		return
+		return nil
 	}
 	suffix := []byte("\n\n")
 	if bytes.HasSuffix(chunk, []byte("\r\n")) {
@@ -40,8 +40,9 @@ func writeResponsesSSEChunk(w io.Writer, chunk []byte) {
 		suffix = []byte("\n")
 	}
 	if _, err := w.Write(suffix); err != nil {
-		return
+		return err
 	}
+	return nil
 }
 
 type responsesSSEFramer struct {
@@ -49,9 +50,9 @@ type responsesSSEFramer struct {
 	transformFrame func([]byte) []byte
 }
 
-func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) {
+func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) error {
 	if len(chunk) == 0 {
-		return
+		return nil
 	}
 	if responsesSSENeedsLineBreak(f.pending, chunk) {
 		f.pending = append(f.pending, '\n')
@@ -66,39 +67,47 @@ func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) {
 		if f.transformFrame != nil {
 			frame = f.transformFrame(frame)
 		}
-		writeResponsesSSEChunk(w, frame)
+		if err := writeResponsesSSEChunk(w, frame); err != nil {
+			return err
+		}
 		copy(f.pending, f.pending[frameLen:])
 		f.pending = f.pending[:len(f.pending)-frameLen]
 	}
 	if len(bytes.TrimSpace(f.pending)) == 0 {
 		f.pending = f.pending[:0]
-		return
+		return nil
 	}
 	if len(f.pending) == 0 || !responsesSSECanEmitWithoutDelimiter(f.pending) {
-		return
+		return nil
 	}
 	frame := f.pending
 	if f.transformFrame != nil {
 		frame = f.transformFrame(frame)
 	}
-	writeResponsesSSEChunk(w, frame)
+	if err := writeResponsesSSEChunk(w, frame); err != nil {
+		return err
+	}
 	f.pending = f.pending[:0]
+	return nil
 }
 
-func (f *responsesSSEFramer) Flush(w io.Writer) {
+func (f *responsesSSEFramer) Flush(w io.Writer) error {
 	if len(f.pending) == 0 {
-		return
+		return nil
 	}
 	if len(bytes.TrimSpace(f.pending)) == 0 {
 		f.pending = f.pending[:0]
-		return
+		return nil
 	}
 	if !responsesSSECanEmitWithoutDelimiter(f.pending) {
 		f.pending = f.pending[:0]
-		return
+		return nil
 	}
-	writeResponsesSSEChunk(w, f.pending)
+	if err := writeResponsesSSEChunk(w, f.pending); err != nil {
+		return err
+	}
 	f.pending = f.pending[:0]
+	return nil
 }
 
 func responsesSSEFrameLen(chunk []byte) int {
@@ -403,7 +412,10 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 				// Stream closed without data? Send headers and done.
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-				_, _ = c.Writer.Write([]byte("\n"))
+				if _, err := c.Writer.Write([]byte("\n")); err != nil {
+					cliCancel(err)
+					return
+				}
 				flusher.Flush()
 				cliCancel(nil)
 				return
@@ -414,7 +426,10 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 
 			// Write first chunk logic (matching forwardResponsesStream)
-			framer.WriteChunk(c.Writer, recovery.normalizeChunk(chunk))
+			if err := framer.WriteChunk(c.Writer, recovery.normalizeChunk(chunk)); err != nil {
+				cliCancel(err)
+				return
+			}
 			flusher.Flush()
 
 			// Continue
@@ -435,13 +450,15 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flush
 		framer.transformFrame = recovery.normalizeFrame
 	}
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{
-		WriteChunk: func(chunk []byte) {
-			framer.WriteChunk(c.Writer, recovery.normalizeChunk(chunk))
+		WriteChunk: func(chunk []byte) error {
+			return framer.WriteChunk(c.Writer, recovery.normalizeChunk(chunk))
 		},
-		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
-			framer.Flush(c.Writer)
+		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) error {
+			if err := framer.Flush(c.Writer); err != nil {
+				return err
+			}
 			if errMsg == nil {
-				return
+				return nil
 			}
 			status := http.StatusInternalServerError
 			if errMsg.StatusCode > 0 {
@@ -452,15 +469,18 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flush
 				errText = errMsg.Error.Error()
 			}
 			chunk := handlers.BuildOpenAIResponsesStreamErrorChunk(status, errText, 0)
-			_, _ = fmt.Fprintf(c.Writer, "\nevent: error\ndata: %s\n\n", string(chunk))
+			_, err := fmt.Fprintf(c.Writer, "\nevent: error\ndata: %s\n\n", string(chunk))
+			return err
 		},
-		WriteDone: func() {
-			framer.Flush(c.Writer)
-			if payload := recovery.synthesizeCompletedPayload(); len(payload) > 0 {
-				writeResponsesSSEChunk(c.Writer, append([]byte("data: "), payload...))
-				return
+		WriteDone: func() error {
+			if err := framer.Flush(c.Writer); err != nil {
+				return err
 			}
-			_, _ = c.Writer.Write([]byte("\n"))
+			if payload := recovery.synthesizeCompletedPayload(); len(payload) > 0 {
+				return writeResponsesSSEChunk(c.Writer, append([]byte("data: "), payload...))
+			}
+			_, err := c.Writer.Write([]byte("\n"))
+			return err
 		},
 	})
 }

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -460,6 +460,9 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flush
 			if errMsg == nil {
 				return nil
 			}
+			if payload := recovery.recoverTerminalErrorPayload(errMsg); len(payload) > 0 {
+				return writeResponsesSSEChunk(c.Writer, append([]byte("data: "), payload...))
+			}
 			status := http.StatusInternalServerError
 			if errMsg.StatusCode > 0 {
 				status = errMsg.StatusCode

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -45,7 +45,8 @@ func writeResponsesSSEChunk(w io.Writer, chunk []byte) {
 }
 
 type responsesSSEFramer struct {
-	pending []byte
+	pending        []byte
+	transformFrame func([]byte) []byte
 }
 
 func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) {
@@ -61,7 +62,11 @@ func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) {
 		if frameLen == 0 {
 			break
 		}
-		writeResponsesSSEChunk(w, f.pending[:frameLen])
+		frame := f.pending[:frameLen]
+		if f.transformFrame != nil {
+			frame = f.transformFrame(frame)
+		}
+		writeResponsesSSEChunk(w, frame)
 		copy(f.pending, f.pending[frameLen:])
 		f.pending = f.pending[:len(f.pending)-frameLen]
 	}
@@ -72,7 +77,11 @@ func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) {
 	if len(f.pending) == 0 || !responsesSSECanEmitWithoutDelimiter(f.pending) {
 		return
 	}
-	writeResponsesSSEChunk(w, f.pending)
+	frame := f.pending
+	if f.transformFrame != nil {
+		frame = f.transformFrame(frame)
+	}
+	writeResponsesSSEChunk(w, frame)
 	f.pending = f.pending[:0]
 }
 
@@ -366,7 +375,8 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		c.Header("Connection", "keep-alive")
 		c.Header("Access-Control-Allow-Origin", "*")
 	}
-	framer := &responsesSSEFramer{}
+	recovery := newResponsesStreamRecovery()
+	framer := &responsesSSEFramer{transformFrame: recovery.normalizeFrame}
 
 	// Peek at the first chunk
 	for {
@@ -404,21 +414,26 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 
 			// Write first chunk logic (matching forwardResponsesStream)
-			framer.WriteChunk(c.Writer, chunk)
+			framer.WriteChunk(c.Writer, recovery.normalizeChunk(chunk))
 			flusher.Flush()
 
 			// Continue
-			h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan, framer)
+			h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan, framer, recovery)
 			return
 		}
 	}
 }
 
-func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage, framer *responsesSSEFramer) {
+func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage, framer *responsesSSEFramer, recovery *responsesStreamRecovery) {
 	if framer == nil {
 		framer = &responsesSSEFramer{}
 	}
-	recovery := newResponsesStreamRecovery()
+	if recovery == nil {
+		recovery = newResponsesStreamRecovery()
+	}
+	if framer.transformFrame == nil {
+		framer.transformFrame = recovery.normalizeFrame
+	}
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{
 		WriteChunk: func(chunk []byte) {
 			framer.WriteChunk(c.Writer, recovery.normalizeChunk(chunk))

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -418,9 +418,10 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flush
 	if framer == nil {
 		framer = &responsesSSEFramer{}
 	}
+	recovery := newResponsesStreamRecovery()
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{
 		WriteChunk: func(chunk []byte) {
-			framer.WriteChunk(c.Writer, chunk)
+			framer.WriteChunk(c.Writer, recovery.normalizeChunk(chunk))
 		},
 		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
 			framer.Flush(c.Writer)
@@ -440,6 +441,10 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flush
 		},
 		WriteDone: func() {
 			framer.Flush(c.Writer)
+			if payload := recovery.synthesizeCompletedPayload(); len(payload) > 0 {
+				writeResponsesSSEChunk(c.Writer, append([]byte("data: "), payload...))
+				return
+			}
 			_, _ = c.Writer.Write([]byte("\n"))
 		},
 	})

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
@@ -32,7 +32,7 @@ func TestForwardResponsesStreamTerminalErrorUsesResponsesErrorChunk(t *testing.T
 	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: errors.New("unexpected EOF")}
 	close(errs)
 
-	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil, nil)
 	body := recorder.Body.String()
 	if !strings.Contains(body, `"type":"error"`) {
 		t.Fatalf("expected responses error chunk, got: %q", body)

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
@@ -260,6 +261,50 @@ func TestForwardResponsesStreamRecoversTransportErrorDuringCustomToolCall(t *tes
 		t.Fatalf("recovered tool name = %q, want %q", gjson.Get(payload, "response.output.0.name").String(), "apply_patch")
 	}
 	expectedInput := "*** Begin Patch\n*** Add File: /tmp/fix.txt\n+hello\n"
+	if gjson.Get(payload, "response.output.0.input").String() != expectedInput {
+		t.Fatalf("recovered tool input = %q, want %q", gjson.Get(payload, "response.output.0.input").String(), expectedInput)
+	}
+}
+
+func TestForwardResponsesStreamRecoversTerminalErrorChannelDuringCustomToolCall(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	data := make(chan []byte, 3)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	data <- []byte("data: {\"type\":\"response.created\",\"sequence_number\":1,\"response\":{\"id\":\"resp-1\",\"created_at\":123,\"model\":\"gpt-5.4\"}}")
+	data <- []byte("data: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"item\":{\"id\":\"ctc-1\",\"type\":\"custom_tool_call\",\"status\":\"in_progress\",\"call_id\":\"call-1\",\"input\":\"\",\"name\":\"apply_patch\"},\"output_index\":2}")
+	data <- []byte("data: {\"type\":\"response.custom_tool_call_input.delta\",\"sequence_number\":3,\"item_id\":\"ctc-1\",\"output_index\":2,\"delta\":\"*** Begin Patch\\n*** Add File: /tmp/fix.txt\\n\"}")
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		errs <- &interfaces.ErrorMessage{
+			StatusCode: http.StatusInternalServerError,
+			Error:      errors.New("stream error: stream ID 23; INTERNAL_ERROR; received from peer"),
+		}
+		close(errs)
+		close(data)
+	}()
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil, nil)
+
+	body := recorder.Body.String()
+	if strings.Contains(body, "event: error") {
+		t.Fatalf("expected terminal error to be replaced by completion. Body: %q", body)
+	}
+	if strings.Contains(body, "\"type\":\"error\"") {
+		t.Fatalf("expected terminal error payload to be suppressed. Body: %q", body)
+	}
+	if !strings.Contains(body, "\"type\":\"response.completed\"") {
+		t.Fatalf("expected synthesized response.completed event. Body: %q", body)
+	}
+
+	parts := strings.Split(strings.TrimSpace(body), "\n\n")
+	last := parts[len(parts)-1]
+	payload := strings.TrimSpace(strings.TrimPrefix(last, "data:"))
+	if gjson.Get(payload, "response.output.0.type").String() != "custom_tool_call" {
+		t.Fatalf("recovered output type = %q, want custom_tool_call", gjson.Get(payload, "response.output.0.type").String())
+	}
+	expectedInput := "*** Begin Patch\n*** Add File: /tmp/fix.txt\n"
 	if gjson.Get(payload, "response.output.0.input").String() != expectedInput {
 		t.Fatalf("recovered tool input = %q, want %q", gjson.Get(payload, "response.output.0.input").String(), expectedInput)
 	}

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	"github.com/tidwall/gjson"
 )
 
 func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *httptest.ResponseRecorder, *gin.Context, http.Flusher) {
@@ -53,7 +54,7 @@ func TestForwardResponsesStreamSeparatesDataOnlySSEChunks(t *testing.T) {
 		t.Errorf("unexpected first event.\nGot: %q\nWant: %q", parts[0], expectedPart1)
 	}
 
-	expectedPart2 := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"output\":[]}}"
+	expectedPart2 := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"output\":[{\"type\":\"function_call\",\"arguments\":\"{}\"}]}}"
 	if parts[1] != expectedPart2 {
 		t.Errorf("unexpected second event.\nGot: %q\nWant: %q", parts[1], expectedPart2)
 	}
@@ -138,5 +139,62 @@ func TestForwardResponsesStreamDropsIncompleteTrailingDataChunkOnFlush(t *testin
 
 	if got := recorder.Body.String(); got != "\n" {
 		t.Fatalf("expected incomplete trailing data to be dropped on flush.\nGot: %q", got)
+	}
+}
+
+func TestForwardResponsesStreamSynthesizesMissingCompletedEvent(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	data := make(chan []byte, 4)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte("data: {\"type\":\"response.created\",\"sequence_number\":1,\"response\":{\"id\":\"resp-1\",\"created_at\":123,\"model\":\"gpt-5.4\"}}")
+	data <- []byte("data: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"item\":{\"id\":\"msg-1\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0}")
+	data <- []byte("data: {\"type\":\"response.output_text.delta\",\"sequence_number\":3,\"item_id\":\"msg-1\",\"output_index\":0,\"delta\":\"hello world\"}")
+	data <- []byte("data: {\"type\":\"response.output_text.done\",\"sequence_number\":4,\"item_id\":\"msg-1\",\"output_index\":0,\"text\":\"hello world\"}")
+	close(data)
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+
+	body := recorder.Body.String()
+	if !strings.Contains(body, "\"type\":\"response.completed\"") {
+		t.Fatalf("expected synthesized response.completed event. Body: %q", body)
+	}
+	if !strings.Contains(body, "\"hello world\"") {
+		t.Fatalf("expected synthesized completion to preserve assistant text. Body: %q", body)
+	}
+
+	parts := strings.Split(strings.TrimSpace(body), "\n\n")
+	last := parts[len(parts)-1]
+	if !strings.HasPrefix(last, "data: ") {
+		t.Fatalf("expected last SSE frame to be data-only completion, got %q", last)
+	}
+	payload := strings.TrimSpace(strings.TrimPrefix(last, "data:"))
+	if gjson.Get(payload, "type").String() != "response.completed" {
+		t.Fatalf("last payload type = %q, want response.completed", gjson.Get(payload, "type").String())
+	}
+	if gjson.Get(payload, "response.output.0.content.0.text").String() != "hello world" {
+		t.Fatalf("synthetic response.output text = %q, want %q", gjson.Get(payload, "response.output.0.content.0.text").String(), "hello world")
+	}
+}
+
+func TestForwardResponsesStreamPatchesEmptyCompletedOutput(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	data := make(chan []byte, 2)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte("data: {\"type\":\"response.output_item.done\",\"sequence_number\":1,\"item\":{\"id\":\"msg-1\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\",\"annotations\":[],\"logprobs\":[]}],\"role\":\"assistant\"},\"output_index\":0}")
+	data <- []byte("data: {\"type\":\"response.completed\",\"sequence_number\":2,\"response\":{\"id\":\"resp-1\",\"created_at\":123,\"model\":\"gpt-5.4\",\"output\":[]}}")
+	close(data)
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+
+	body := recorder.Body.String()
+	parts := strings.Split(strings.TrimSpace(body), "\n\n")
+	last := parts[len(parts)-1]
+	payload := strings.TrimSpace(strings.TrimPrefix(last, "data:"))
+	if gjson.Get(payload, "response.output.0.content.0.text").String() != "ok" {
+		t.Fatalf("patched response.output text = %q, want %q. Body: %q", gjson.Get(payload, "response.output.0.content.0.text").String(), "ok", body)
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -234,4 +235,59 @@ func TestForwardResponsesStreamPatchesEmptyCompletedOutput(t *testing.T) {
 	if gjson.Get(payload, "response.output.0.content.0.text").String() != "ok" {
 		t.Fatalf("patched response.output text = %q, want %q. Body: %q", gjson.Get(payload, "response.output.0.content.0.text").String(), "ok", body)
 	}
+}
+
+func TestForwardResponsesStreamCancelsOnDownstreamWriteError(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	writeErr := errors.New("broken pipe")
+	c.Writer = &failingResponsesWriter{
+		ResponseWriter: c.Writer,
+		failAfter:      1,
+		err:            writeErr,
+	}
+	flusher = c.Writer.(http.Flusher)
+
+	data := make(chan []byte, 2)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n")
+	data <- []byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"later\"}\n\n")
+	close(data)
+	close(errs)
+
+	var cancelErr error
+	h.forwardResponsesStream(c, flusher, func(err error) { cancelErr = err }, data, errs, nil, nil)
+
+	if !errors.Is(cancelErr, writeErr) {
+		t.Fatalf("cancel error = %v, want %v", cancelErr, writeErr)
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, "\"type\":\"response.created\"") {
+		t.Fatalf("expected first chunk to be written before failure. Body: %q", body)
+	}
+	if strings.Contains(body, "later") {
+		t.Fatalf("expected stream to stop after downstream write failure. Body: %q", body)
+	}
+}
+
+type failingResponsesWriter struct {
+	gin.ResponseWriter
+	failAfter int
+	err       error
+}
+
+func (w *failingResponsesWriter) Write(data []byte) (int, error) {
+	if w.failAfter == 0 {
+		return 0, w.err
+	}
+	w.failAfter--
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *failingResponsesWriter) WriteString(data string) (int, error) {
+	if w.failAfter == 0 {
+		return 0, w.err
+	}
+	w.failAfter--
+	return w.ResponseWriter.WriteString(data)
 }

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -42,7 +42,7 @@ func TestForwardResponsesStreamSeparatesDataOnlySSEChunks(t *testing.T) {
 	close(data)
 	close(errs)
 
-	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil, nil)
 	body := recorder.Body.String()
 	parts := strings.Split(strings.TrimSpace(body), "\n\n")
 	if len(parts) != 2 {
@@ -71,7 +71,7 @@ func TestForwardResponsesStreamReassemblesSplitSSEEventChunks(t *testing.T) {
 	close(data)
 	close(errs)
 
-	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil, nil)
 
 	got := strings.TrimSuffix(recorder.Body.String(), "\n")
 	want := "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n"
@@ -90,7 +90,7 @@ func TestForwardResponsesStreamPreservesValidFullSSEEventChunks(t *testing.T) {
 	close(data)
 	close(errs)
 
-	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil, nil)
 
 	got := strings.TrimSuffix(recorder.Body.String(), "\n")
 	if got != string(chunk) {
@@ -108,7 +108,7 @@ func TestForwardResponsesStreamBuffersSplitDataPayloadChunks(t *testing.T) {
 	close(data)
 	close(errs)
 
-	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil, nil)
 
 	got := recorder.Body.String()
 	want := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n\n"
@@ -135,7 +135,7 @@ func TestForwardResponsesStreamDropsIncompleteTrailingDataChunkOnFlush(t *testin
 	close(data)
 	close(errs)
 
-	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil, nil)
 
 	if got := recorder.Body.String(); got != "\n" {
 		t.Fatalf("expected incomplete trailing data to be dropped on flush.\nGot: %q", got)
@@ -154,7 +154,7 @@ func TestForwardResponsesStreamSynthesizesMissingCompletedEvent(t *testing.T) {
 	close(data)
 	close(errs)
 
-	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil, nil)
 
 	body := recorder.Body.String()
 	if !strings.Contains(body, "\"type\":\"response.completed\"") {
@@ -178,6 +178,43 @@ func TestForwardResponsesStreamSynthesizesMissingCompletedEvent(t *testing.T) {
 	}
 }
 
+func TestForwardResponsesStreamRecoversTransportErrorFrame(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	data := make(chan []byte, 5)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte("data: {\"type\":\"response.created\",\"sequence_number\":1,\"response\":{\"id\":\"resp-1\",\"created_at\":123,\"model\":\"gpt-5.4\"}}")
+	data <- []byte("data: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"item\":{\"id\":\"msg-1\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0}")
+	data <- []byte("data: {\"type\":\"response.output_text.delta\",\"sequence_number\":3,\"item_id\":\"msg-1\",\"output_index\":0,\"delta\":\"partial answer\"}")
+	data <- []byte("event: error\n")
+	data <- []byte("data: {\"type\":\"error\",\"code\":\"internal_server_error\",\"message\":\"stream error: stream ID 219; INTERNAL_ERROR; received from peer\",\"sequence_number\":4}\n\n")
+	close(data)
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil, nil)
+
+	body := recorder.Body.String()
+	if strings.Contains(body, "event: error") {
+		t.Fatalf("expected error event to be replaced by completion. Body: %q", body)
+	}
+	if strings.Contains(body, "\"type\":\"error\"") {
+		t.Fatalf("expected upstream transport error to be suppressed. Body: %q", body)
+	}
+	if !strings.Contains(body, "\"type\":\"response.completed\"") {
+		t.Fatalf("expected recovered response.completed event. Body: %q", body)
+	}
+
+	parts := strings.Split(strings.TrimSpace(body), "\n\n")
+	last := parts[len(parts)-1]
+	payload := strings.TrimSpace(strings.TrimPrefix(last, "data:"))
+	if gjson.Get(payload, "type").String() != "response.completed" {
+		t.Fatalf("last payload type = %q, want response.completed", gjson.Get(payload, "type").String())
+	}
+	if gjson.Get(payload, "response.output.0.content.0.text").String() != "partial answer" {
+		t.Fatalf("recovered response.output text = %q, want %q", gjson.Get(payload, "response.output.0.content.0.text").String(), "partial answer")
+	}
+}
+
 func TestForwardResponsesStreamPatchesEmptyCompletedOutput(t *testing.T) {
 	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
 
@@ -188,7 +225,7 @@ func TestForwardResponsesStreamPatchesEmptyCompletedOutput(t *testing.T) {
 	close(data)
 	close(errs)
 
-	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil, nil)
 
 	body := recorder.Body.String()
 	parts := strings.Split(strings.TrimSpace(body), "\n\n")

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -216,6 +216,55 @@ func TestForwardResponsesStreamRecoversTransportErrorFrame(t *testing.T) {
 	}
 }
 
+func TestForwardResponsesStreamRecoversTransportErrorDuringCustomToolCall(t *testing.T) {
+	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
+
+	data := make(chan []byte, 7)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte("data: {\"type\":\"response.created\",\"sequence_number\":1,\"response\":{\"id\":\"resp-1\",\"created_at\":123,\"model\":\"gpt-5.4\"}}")
+	data <- []byte("data: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"item\":{\"id\":\"ctc-1\",\"type\":\"custom_tool_call\",\"status\":\"in_progress\",\"call_id\":\"call-1\",\"input\":\"\",\"name\":\"apply_patch\"},\"output_index\":2}")
+	data <- []byte("data: {\"type\":\"response.custom_tool_call_input.delta\",\"sequence_number\":3,\"item_id\":\"ctc-1\",\"output_index\":2,\"delta\":\"*** Begin Patch\\n\"}")
+	data <- []byte(": keep-alive\n\n")
+	data <- []byte("data: {\"type\":\"response.custom_tool_call_input.delta\",\"sequence_number\":4,\"item_id\":\"ctc-1\",\"output_index\":2,\"delta\":\"*** Add File: /tmp/fix.txt\\n+hello\\n\"}")
+	data <- []byte("event: error\n")
+	data <- []byte("data: {\"type\":\"error\",\"code\":\"internal_server_error\",\"message\":\"stream error: stream ID 27; INTERNAL_ERROR; received from peer\",\"sequence_number\":0}\n\n")
+	close(data)
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil, nil)
+
+	body := recorder.Body.String()
+	if strings.Contains(body, "event: error") {
+		t.Fatalf("expected error event to be replaced by completion. Body: %q", body)
+	}
+	if strings.Contains(body, "\"type\":\"error\"") {
+		t.Fatalf("expected upstream transport error to be suppressed. Body: %q", body)
+	}
+	if !strings.Contains(body, "\"type\":\"response.completed\"") {
+		t.Fatalf("expected recovered response.completed event. Body: %q", body)
+	}
+
+	parts := strings.Split(strings.TrimSpace(body), "\n\n")
+	last := parts[len(parts)-1]
+	payload := strings.TrimSpace(strings.TrimPrefix(last, "data:"))
+	if gjson.Get(payload, "type").String() != "response.completed" {
+		t.Fatalf("last payload type = %q, want response.completed", gjson.Get(payload, "type").String())
+	}
+	if gjson.Get(payload, "response.output.0.type").String() != "custom_tool_call" {
+		t.Fatalf("recovered output type = %q, want custom_tool_call", gjson.Get(payload, "response.output.0.type").String())
+	}
+	if gjson.Get(payload, "response.output.0.call_id").String() != "call-1" {
+		t.Fatalf("recovered call_id = %q, want %q", gjson.Get(payload, "response.output.0.call_id").String(), "call-1")
+	}
+	if gjson.Get(payload, "response.output.0.name").String() != "apply_patch" {
+		t.Fatalf("recovered tool name = %q, want %q", gjson.Get(payload, "response.output.0.name").String(), "apply_patch")
+	}
+	expectedInput := "*** Begin Patch\n*** Add File: /tmp/fix.txt\n+hello\n"
+	if gjson.Get(payload, "response.output.0.input").String() != expectedInput {
+		t.Fatalf("recovered tool input = %q, want %q", gjson.Get(payload, "response.output.0.input").String(), expectedInput)
+	}
+}
+
 func TestForwardResponsesStreamPatchesEmptyCompletedOutput(t *testing.T) {
 	h, recorder, c, flusher := newResponsesStreamTestHandler(t)
 

--- a/sdk/api/handlers/openai/openai_responses_stream_recovery.go
+++ b/sdk/api/handlers/openai/openai_responses_stream_recovery.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -264,6 +266,25 @@ func (r *responsesStreamRecovery) recoverErrorPayload(payload []byte) []byte {
 		return nil
 	}
 	return r.synthesizeCompletedPayload()
+}
+
+func (r *responsesStreamRecovery) recoverTerminalErrorPayload(errMsg *interfaces.ErrorMessage) []byte {
+	if r == nil || errMsg == nil {
+		return nil
+	}
+
+	status := errMsg.StatusCode
+	if status <= 0 {
+		status = 500
+	}
+
+	errText := ""
+	if errMsg.Error != nil {
+		errText = errMsg.Error.Error()
+	}
+
+	payload := handlers.BuildOpenAIResponsesStreamErrorChunk(status, errText, 0)
+	return r.recoverErrorPayload(payload)
 }
 
 func (r *responsesStreamRecovery) captureMeta(payload []byte) {

--- a/sdk/api/handlers/openai/openai_responses_stream_recovery.go
+++ b/sdk/api/handlers/openai/openai_responses_stream_recovery.go
@@ -177,6 +177,28 @@ func (r *responsesStreamRecovery) synthesizeCompletedPayload() []byte {
 	return payload
 }
 
+func (r *responsesStreamRecovery) normalizeFrame(frame []byte) []byte {
+	if r == nil || len(frame) == 0 {
+		return frame
+	}
+
+	eventName, payload := responsesSSEFrameEventAndPayload(frame)
+	if eventName != "error" || len(payload) == 0 || !json.Valid(payload) {
+		return frame
+	}
+
+	normalized := r.normalizePayload(payload)
+	if gjson.GetBytes(normalized, "type").String() != "response.completed" {
+		return frame
+	}
+
+	rebuilt := append([]byte("data: "), normalized...)
+	if bytes.HasSuffix(frame, []byte("\r\n\r\n")) {
+		return append(rebuilt, []byte("\r\n\r\n")...)
+	}
+	return append(rebuilt, []byte("\n\n")...)
+}
+
 func (r *responsesStreamRecovery) normalizePayload(payload []byte) []byte {
 	if r == nil {
 		return payload
@@ -214,9 +236,28 @@ func (r *responsesStreamRecovery) normalizePayload(payload []byte) []byte {
 		payload = r.patchCompletedPayload(payload)
 		r.captureMeta(payload)
 		r.completedSeen = true
+	case "error":
+		if recovered := r.recoverErrorPayload(payload); len(recovered) > 0 {
+			payload = recovered
+		}
 	}
 
 	return payload
+}
+
+func (r *responsesStreamRecovery) recoverErrorPayload(payload []byte) []byte {
+	if r == nil || r.completedSeen || len(payload) == 0 || !json.Valid(payload) {
+		return nil
+	}
+	if strings.TrimSpace(gjson.GetBytes(payload, "type").String()) != "error" {
+		return nil
+	}
+	code := strings.TrimSpace(gjson.GetBytes(payload, "code").String())
+	message := strings.TrimSpace(gjson.GetBytes(payload, "message").String())
+	if !responsesErrorLooksRecoverable(code, message) {
+		return nil
+	}
+	return r.synthesizeCompletedPayload()
 }
 
 func (r *responsesStreamRecovery) captureMeta(payload []byte) {
@@ -601,4 +642,45 @@ func lineEndingBytes(line []byte) []byte {
 	default:
 		return nil
 	}
+}
+
+func responsesSSEFrameEventAndPayload(frame []byte) (string, []byte) {
+	lines := bytes.Split(frame, []byte("\n"))
+	eventName := ""
+	dataLines := make([][]byte, 0, 1)
+	for i := range lines {
+		line := bytes.TrimSpace(lines[i])
+		if len(line) == 0 {
+			continue
+		}
+		switch {
+		case bytes.HasPrefix(line, []byte("event:")):
+			eventName = strings.TrimSpace(string(line[len("event:"):]))
+		case bytes.HasPrefix(line, []byte("data:")):
+			data := bytes.TrimSpace(line[len("data:"):])
+			if len(data) > 0 {
+				dataLines = append(dataLines, bytes.Clone(data))
+			}
+		}
+	}
+	if len(dataLines) == 0 {
+		return eventName, nil
+	}
+	return eventName, bytes.Join(dataLines, []byte("\n"))
+}
+
+func responsesErrorLooksRecoverable(code, message string) bool {
+	code = strings.ToLower(strings.TrimSpace(code))
+	message = strings.ToLower(strings.TrimSpace(message))
+	if message == "" {
+		return false
+	}
+	if code != "internal_server_error" && code != "server_error" {
+		return false
+	}
+	return strings.Contains(message, "stream error:") ||
+		strings.Contains(message, "received from peer") ||
+		strings.Contains(message, "unexpected eof") ||
+		strings.Contains(message, "stream closed") ||
+		strings.Contains(message, "response.completed")
 }

--- a/sdk/api/handlers/openai/openai_responses_stream_recovery.go
+++ b/sdk/api/handlers/openai/openai_responses_stream_recovery.go
@@ -1,0 +1,604 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+type responsesRecoveredMessage struct {
+	ItemID      string
+	OutputIndex int64
+	Text        strings.Builder
+}
+
+type responsesRecoveredFunctionCall struct {
+	ItemID      string
+	OutputIndex int64
+	CallID      string
+	Name        string
+	Arguments   strings.Builder
+}
+
+type responsesRecoveredOutput struct {
+	OutputIndex int64
+	Raw         []byte
+}
+
+type responsesStreamRecovery struct {
+	responseID    string
+	createdAt     int64
+	model         string
+	lastSequence  int64
+	sequenceSeen  bool
+	completedSeen bool
+	usageRaw      []byte
+
+	outputItemsByIndex  map[int64][]byte
+	outputItemsFallback [][]byte
+
+	messagesByID    map[string]*responsesRecoveredMessage
+	messagesByIndex map[int64]*responsesRecoveredMessage
+
+	functionCallsByID    map[string]*responsesRecoveredFunctionCall
+	functionCallsByIndex map[int64]*responsesRecoveredFunctionCall
+}
+
+func newResponsesStreamRecovery() *responsesStreamRecovery {
+	return &responsesStreamRecovery{
+		outputItemsByIndex:   make(map[int64][]byte),
+		messagesByID:         make(map[string]*responsesRecoveredMessage),
+		messagesByIndex:      make(map[int64]*responsesRecoveredMessage),
+		functionCallsByID:    make(map[string]*responsesRecoveredFunctionCall),
+		functionCallsByIndex: make(map[int64]*responsesRecoveredFunctionCall),
+		outputItemsFallback:  make([][]byte, 0),
+	}
+}
+
+func (r *responsesStreamRecovery) normalizeChunk(chunk []byte) []byte {
+	if len(chunk) == 0 {
+		return chunk
+	}
+
+	lines := bytes.SplitAfter(chunk, []byte("\n"))
+	if len(lines) == 0 {
+		lines = [][]byte{chunk}
+	}
+
+	sawStructuredLine := false
+	changed := false
+	var rebuilt bytes.Buffer
+
+	for i := range lines {
+		line := lines[i]
+		if len(line) == 0 {
+			continue
+		}
+		lineEnding := lineEndingBytes(line)
+		content := bytes.TrimRight(line, "\r\n")
+		trimmed := bytes.TrimSpace(content)
+		if len(trimmed) == 0 {
+			rebuilt.Write(line)
+			continue
+		}
+
+		switch {
+		case bytes.HasPrefix(trimmed, []byte("event:")):
+			sawStructuredLine = true
+			eventName := strings.TrimSpace(string(trimmed[len("event:"):]))
+			if eventName == "response.done" {
+				rebuilt.WriteString("event: response.completed")
+				rebuilt.Write(lineEnding)
+				changed = true
+				continue
+			}
+		case bytes.HasPrefix(trimmed, []byte("data:")):
+			sawStructuredLine = true
+			payload := bytes.TrimSpace(trimmed[len("data:"):])
+			if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) || !json.Valid(payload) {
+				rebuilt.Write(line)
+				continue
+			}
+
+			normalized := r.normalizePayload(payload)
+			if !bytes.Equal(normalized, payload) {
+				changed = true
+			}
+			rebuilt.WriteString("data: ")
+			rebuilt.Write(normalized)
+			rebuilt.Write(lineEnding)
+			continue
+		}
+
+		rebuilt.Write(line)
+	}
+
+	if sawStructuredLine {
+		if changed {
+			return rebuilt.Bytes()
+		}
+		return chunk
+	}
+
+	trimmed := bytes.TrimSpace(chunk)
+	if len(trimmed) == 0 || !json.Valid(trimmed) {
+		return chunk
+	}
+
+	normalized := r.normalizePayload(trimmed)
+	if bytes.Equal(normalized, trimmed) {
+		return chunk
+	}
+	return normalized
+}
+
+func (r *responsesStreamRecovery) synthesizeCompletedPayload() []byte {
+	if r == nil || r.completedSeen {
+		return nil
+	}
+
+	recoveredOutput := r.buildRecoveredOutput()
+	if len(recoveredOutput) == 0 {
+		return nil
+	}
+
+	responseID := strings.TrimSpace(r.responseID)
+	if responseID == "" {
+		responseID = fmt.Sprintf("resp_recovered_%d", time.Now().UnixNano())
+	}
+	createdAt := r.createdAt
+	if createdAt == 0 {
+		createdAt = time.Now().Unix()
+	}
+
+	payload := []byte(`{"type":"response.completed","sequence_number":0,"response":{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null,"output":[]}}`)
+	payload, _ = sjson.SetBytes(payload, "response.id", responseID)
+	payload, _ = sjson.SetBytes(payload, "response.created_at", createdAt)
+	if strings.TrimSpace(r.model) != "" {
+		payload, _ = sjson.SetBytes(payload, "response.model", r.model)
+	}
+	if r.sequenceSeen {
+		payload, _ = sjson.SetBytes(payload, "sequence_number", r.lastSequence+1)
+	}
+	if len(r.usageRaw) > 0 && json.Valid(r.usageRaw) {
+		payload, _ = sjson.SetRawBytes(payload, "response.usage", r.usageRaw)
+	}
+	for i := range recoveredOutput {
+		payload, _ = sjson.SetRawBytes(payload, "response.output.-1", recoveredOutput[i].Raw)
+	}
+
+	r.completedSeen = true
+	return payload
+}
+
+func (r *responsesStreamRecovery) normalizePayload(payload []byte) []byte {
+	if r == nil {
+		return payload
+	}
+
+	payload = bytes.TrimSpace(bytes.Clone(payload))
+	if len(payload) == 0 || !json.Valid(payload) {
+		return payload
+	}
+
+	eventType := strings.TrimSpace(gjson.GetBytes(payload, "type").String())
+	if eventType == "response.done" {
+		if updated, err := sjson.SetBytes(payload, "type", "response.completed"); err == nil && len(updated) > 0 {
+			payload = updated
+			eventType = "response.completed"
+		}
+	}
+
+	r.captureMeta(payload)
+
+	switch eventType {
+	case "response.output_item.added":
+		r.recordOutputItemAdded(payload)
+	case "response.output_item.done":
+		r.recordOutputItemDone(payload)
+	case "response.output_text.delta":
+		r.recordOutputTextDelta(payload)
+	case "response.output_text.done":
+		r.recordOutputTextDone(payload)
+	case "response.function_call_arguments.delta":
+		r.recordFunctionCallArgumentsDelta(payload)
+	case "response.function_call_arguments.done":
+		r.recordFunctionCallArgumentsDone(payload)
+	case "response.completed":
+		payload = r.patchCompletedPayload(payload)
+		r.captureMeta(payload)
+		r.completedSeen = true
+	}
+
+	return payload
+}
+
+func (r *responsesStreamRecovery) captureMeta(payload []byte) {
+	if r == nil || len(payload) == 0 {
+		return
+	}
+
+	if seq := gjson.GetBytes(payload, "sequence_number"); seq.Exists() {
+		r.sequenceSeen = true
+		r.lastSequence = seq.Int()
+	}
+
+	response := gjson.GetBytes(payload, "response")
+	if response.Exists() {
+		if id := strings.TrimSpace(response.Get("id").String()); id != "" {
+			r.responseID = id
+		}
+		if createdAt := response.Get("created_at").Int(); createdAt > 0 {
+			r.createdAt = createdAt
+		}
+		if model := strings.TrimSpace(response.Get("model").String()); model != "" {
+			r.model = model
+		}
+		if usage := response.Get("usage"); usage.Exists() && usage.Type == gjson.JSON && json.Valid([]byte(usage.Raw)) {
+			r.usageRaw = []byte(usage.Raw)
+		}
+	}
+}
+
+func (r *responsesStreamRecovery) recordOutputItemAdded(payload []byte) {
+	item := gjson.GetBytes(payload, "item")
+	if !item.Exists() || item.Type != gjson.JSON {
+		return
+	}
+
+	outputIndex := gjson.GetBytes(payload, "output_index").Int()
+	switch item.Get("type").String() {
+	case "message":
+		message := r.ensureMessage(strings.TrimSpace(item.Get("id").String()), outputIndex)
+		if message != nil && message.ItemID == "" {
+			message.ItemID = strings.TrimSpace(item.Get("id").String())
+		}
+	case "function_call":
+		call := r.ensureFunctionCall(strings.TrimSpace(item.Get("id").String()), outputIndex)
+		if call == nil {
+			return
+		}
+		if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
+			call.CallID = callID
+		}
+		if name := strings.TrimSpace(item.Get("name").String()); name != "" {
+			call.Name = name
+		}
+	}
+}
+
+func (r *responsesStreamRecovery) recordOutputItemDone(payload []byte) {
+	item := gjson.GetBytes(payload, "item")
+	if !item.Exists() || item.Type != gjson.JSON || !json.Valid([]byte(item.Raw)) {
+		return
+	}
+
+	raw := []byte(item.Raw)
+	if outputIndex := gjson.GetBytes(payload, "output_index"); outputIndex.Exists() {
+		r.outputItemsByIndex[outputIndex.Int()] = raw
+		return
+	}
+	r.outputItemsFallback = append(r.outputItemsFallback, raw)
+}
+
+func (r *responsesStreamRecovery) recordOutputTextDelta(payload []byte) {
+	message := r.ensureMessage(
+		strings.TrimSpace(gjson.GetBytes(payload, "item_id").String()),
+		gjson.GetBytes(payload, "output_index").Int(),
+	)
+	if message == nil {
+		return
+	}
+	if delta := gjson.GetBytes(payload, "delta").String(); delta != "" {
+		message.Text.WriteString(delta)
+	}
+}
+
+func (r *responsesStreamRecovery) recordOutputTextDone(payload []byte) {
+	message := r.ensureMessage(
+		strings.TrimSpace(gjson.GetBytes(payload, "item_id").String()),
+		gjson.GetBytes(payload, "output_index").Int(),
+	)
+	if message == nil {
+		return
+	}
+	if text := gjson.GetBytes(payload, "text").String(); text != "" {
+		message.Text.Reset()
+		message.Text.WriteString(text)
+	}
+}
+
+func (r *responsesStreamRecovery) recordFunctionCallArgumentsDelta(payload []byte) {
+	call := r.ensureFunctionCall(
+		strings.TrimSpace(gjson.GetBytes(payload, "item_id").String()),
+		gjson.GetBytes(payload, "output_index").Int(),
+	)
+	if call == nil {
+		return
+	}
+	if delta := gjson.GetBytes(payload, "delta").String(); delta != "" {
+		call.Arguments.WriteString(delta)
+	}
+}
+
+func (r *responsesStreamRecovery) recordFunctionCallArgumentsDone(payload []byte) {
+	call := r.ensureFunctionCall(
+		strings.TrimSpace(gjson.GetBytes(payload, "item_id").String()),
+		gjson.GetBytes(payload, "output_index").Int(),
+	)
+	if call == nil {
+		return
+	}
+	if args := gjson.GetBytes(payload, "arguments").String(); args != "" {
+		call.Arguments.Reset()
+		call.Arguments.WriteString(args)
+	}
+}
+
+func (r *responsesStreamRecovery) patchCompletedPayload(payload []byte) []byte {
+	output := gjson.GetBytes(payload, "response.output")
+	if output.Exists() && output.IsArray() && len(output.Array()) > 0 {
+		return payload
+	}
+
+	recoveredOutput := r.buildRecoveredOutput()
+	if len(recoveredOutput) == 0 {
+		return payload
+	}
+
+	patched := payload
+	patched, _ = sjson.SetRawBytes(patched, "response.output", []byte(`[]`))
+	for i := range recoveredOutput {
+		patched, _ = sjson.SetRawBytes(patched, "response.output.-1", recoveredOutput[i].Raw)
+	}
+	if gjson.GetBytes(patched, "response.id").String() == "" && strings.TrimSpace(r.responseID) != "" {
+		patched, _ = sjson.SetBytes(patched, "response.id", r.responseID)
+	}
+	if gjson.GetBytes(patched, "response.created_at").Int() == 0 && r.createdAt > 0 {
+		patched, _ = sjson.SetBytes(patched, "response.created_at", r.createdAt)
+	}
+	if gjson.GetBytes(patched, "response.model").String() == "" && strings.TrimSpace(r.model) != "" {
+		patched, _ = sjson.SetBytes(patched, "response.model", r.model)
+	}
+	return patched
+}
+
+func (r *responsesStreamRecovery) buildRecoveredOutput() []responsesRecoveredOutput {
+	recovered := make([]responsesRecoveredOutput, 0, len(r.outputItemsByIndex)+len(r.outputItemsFallback)+len(r.messagesByID)+len(r.functionCallsByID))
+	seenItemIDs := make(map[string]struct{})
+	seenCallIDs := make(map[string]struct{})
+
+	indexes := make([]int64, 0, len(r.outputItemsByIndex))
+	for idx := range r.outputItemsByIndex {
+		indexes = append(indexes, idx)
+	}
+	sort.Slice(indexes, func(i, j int) bool { return indexes[i] < indexes[j] })
+	for _, idx := range indexes {
+		raw := r.outputItemsByIndex[idx]
+		recovered = append(recovered, responsesRecoveredOutput{OutputIndex: idx, Raw: raw})
+		recordRecoveredIdentifiers(raw, seenItemIDs, seenCallIDs)
+	}
+
+	nextFallbackIndex := r.maxKnownOutputIndex() + 1
+	for i := range r.outputItemsFallback {
+		raw := r.outputItemsFallback[i]
+		recovered = append(recovered, responsesRecoveredOutput{OutputIndex: nextFallbackIndex, Raw: raw})
+		nextFallbackIndex++
+		recordRecoveredIdentifiers(raw, seenItemIDs, seenCallIDs)
+	}
+
+	messageIndexes := make([]int64, 0, len(r.messagesByIndex))
+	for idx := range r.messagesByIndex {
+		messageIndexes = append(messageIndexes, idx)
+	}
+	sort.Slice(messageIndexes, func(i, j int) bool { return messageIndexes[i] < messageIndexes[j] })
+
+	functionIndexes := make([]int64, 0, len(r.functionCallsByIndex))
+	for idx := range r.functionCallsByIndex {
+		functionIndexes = append(functionIndexes, idx)
+	}
+	sort.Slice(functionIndexes, func(i, j int) bool { return functionIndexes[i] < functionIndexes[j] })
+
+	for _, idx := range functionIndexes {
+		call := r.functionCallsByIndex[idx]
+		if call == nil {
+			continue
+		}
+		itemID := strings.TrimSpace(call.ItemID)
+		callID := strings.TrimSpace(call.CallID)
+		if itemID != "" {
+			if _, exists := seenItemIDs[itemID]; exists {
+				continue
+			}
+		}
+		if callID != "" {
+			if _, exists := seenCallIDs[callID]; exists {
+				continue
+			}
+		}
+		raw := buildRecoveredFunctionCallRaw(call)
+		if len(raw) == 0 {
+			continue
+		}
+		recovered = append(recovered, responsesRecoveredOutput{OutputIndex: idx, Raw: raw})
+		recordRecoveredIdentifiers(raw, seenItemIDs, seenCallIDs)
+	}
+
+	for _, idx := range messageIndexes {
+		message := r.messagesByIndex[idx]
+		if message == nil {
+			continue
+		}
+		itemID := strings.TrimSpace(message.ItemID)
+		if itemID != "" {
+			if _, exists := seenItemIDs[itemID]; exists {
+				continue
+			}
+		}
+		raw := buildRecoveredMessageRaw(r.responseID, message)
+		if len(raw) == 0 {
+			continue
+		}
+		recovered = append(recovered, responsesRecoveredOutput{OutputIndex: idx, Raw: raw})
+		recordRecoveredIdentifiers(raw, seenItemIDs, seenCallIDs)
+	}
+
+	sort.SliceStable(recovered, func(i, j int) bool {
+		return recovered[i].OutputIndex < recovered[j].OutputIndex
+	})
+	return recovered
+}
+
+func (r *responsesStreamRecovery) ensureMessage(itemID string, outputIndex int64) *responsesRecoveredMessage {
+	itemID = strings.TrimSpace(itemID)
+	if itemID != "" {
+		if message, ok := r.messagesByID[itemID]; ok {
+			if message.OutputIndex < 0 && outputIndex >= 0 {
+				message.OutputIndex = outputIndex
+				r.messagesByIndex[outputIndex] = message
+			}
+			return message
+		}
+	}
+	if outputIndex >= 0 {
+		if message, ok := r.messagesByIndex[outputIndex]; ok {
+			if message.ItemID == "" && itemID != "" {
+				message.ItemID = itemID
+				r.messagesByID[itemID] = message
+			}
+			return message
+		}
+	}
+
+	message := &responsesRecoveredMessage{ItemID: itemID, OutputIndex: outputIndex}
+	if itemID != "" {
+		r.messagesByID[itemID] = message
+	}
+	if outputIndex >= 0 {
+		r.messagesByIndex[outputIndex] = message
+	}
+	return message
+}
+
+func (r *responsesStreamRecovery) ensureFunctionCall(itemID string, outputIndex int64) *responsesRecoveredFunctionCall {
+	itemID = strings.TrimSpace(itemID)
+	if itemID != "" {
+		if call, ok := r.functionCallsByID[itemID]; ok {
+			if call.OutputIndex < 0 && outputIndex >= 0 {
+				call.OutputIndex = outputIndex
+				r.functionCallsByIndex[outputIndex] = call
+			}
+			return call
+		}
+	}
+	if outputIndex >= 0 {
+		if call, ok := r.functionCallsByIndex[outputIndex]; ok {
+			if call.ItemID == "" && itemID != "" {
+				call.ItemID = itemID
+				r.functionCallsByID[itemID] = call
+			}
+			return call
+		}
+	}
+
+	call := &responsesRecoveredFunctionCall{ItemID: itemID, OutputIndex: outputIndex}
+	if itemID != "" {
+		r.functionCallsByID[itemID] = call
+	}
+	if outputIndex >= 0 {
+		r.functionCallsByIndex[outputIndex] = call
+	}
+	return call
+}
+
+func (r *responsesStreamRecovery) maxKnownOutputIndex() int64 {
+	maxIndex := int64(-1)
+	for idx := range r.outputItemsByIndex {
+		if idx > maxIndex {
+			maxIndex = idx
+		}
+	}
+	for idx := range r.messagesByIndex {
+		if idx > maxIndex {
+			maxIndex = idx
+		}
+	}
+	for idx := range r.functionCallsByIndex {
+		if idx > maxIndex {
+			maxIndex = idx
+		}
+	}
+	return maxIndex
+}
+
+func buildRecoveredMessageRaw(responseID string, message *responsesRecoveredMessage) []byte {
+	if message == nil {
+		return nil
+	}
+	text := message.Text.String()
+	if text == "" {
+		return nil
+	}
+	item := []byte(`{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`)
+	itemID := strings.TrimSpace(message.ItemID)
+	if itemID == "" {
+		itemID = fmt.Sprintf("msg_%s_%d", strings.TrimSpace(responseID), message.OutputIndex)
+	}
+	item, _ = sjson.SetBytes(item, "id", itemID)
+	item, _ = sjson.SetBytes(item, "content.0.text", text)
+	return item
+}
+
+func buildRecoveredFunctionCallRaw(call *responsesRecoveredFunctionCall) []byte {
+	if call == nil {
+		return nil
+	}
+	callID := strings.TrimSpace(call.CallID)
+	name := strings.TrimSpace(call.Name)
+	if callID == "" && name == "" {
+		return nil
+	}
+	arguments := call.Arguments.String()
+	if strings.TrimSpace(arguments) == "" {
+		arguments = "{}"
+	}
+	item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
+	itemID := strings.TrimSpace(call.ItemID)
+	if itemID == "" {
+		itemID = fmt.Sprintf("fc_%s", callID)
+	}
+	item, _ = sjson.SetBytes(item, "id", itemID)
+	item, _ = sjson.SetBytes(item, "arguments", arguments)
+	item, _ = sjson.SetBytes(item, "call_id", callID)
+	item, _ = sjson.SetBytes(item, "name", name)
+	return item
+}
+
+func recordRecoveredIdentifiers(raw []byte, seenItemIDs, seenCallIDs map[string]struct{}) {
+	if len(raw) == 0 {
+		return
+	}
+	if itemID := strings.TrimSpace(gjson.GetBytes(raw, "id").String()); itemID != "" {
+		seenItemIDs[itemID] = struct{}{}
+	}
+	if callID := strings.TrimSpace(gjson.GetBytes(raw, "call_id").String()); callID != "" {
+		seenCallIDs[callID] = struct{}{}
+	}
+}
+
+func lineEndingBytes(line []byte) []byte {
+	switch {
+	case bytes.HasSuffix(line, []byte("\r\n")):
+		return []byte("\r\n")
+	case bytes.HasSuffix(line, []byte("\n")):
+		return []byte("\n")
+	default:
+		return nil
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_stream_recovery.go
+++ b/sdk/api/handlers/openai/openai_responses_stream_recovery.go
@@ -21,9 +21,11 @@ type responsesRecoveredMessage struct {
 type responsesRecoveredFunctionCall struct {
 	ItemID      string
 	OutputIndex int64
+	ItemType    string
 	CallID      string
 	Name        string
 	Arguments   strings.Builder
+	Input       strings.Builder
 }
 
 type responsesRecoveredOutput struct {
@@ -232,6 +234,10 @@ func (r *responsesStreamRecovery) normalizePayload(payload []byte) []byte {
 		r.recordFunctionCallArgumentsDelta(payload)
 	case "response.function_call_arguments.done":
 		r.recordFunctionCallArgumentsDone(payload)
+	case "response.custom_tool_call_input.delta":
+		r.recordCustomToolCallInputDelta(payload)
+	case "response.custom_tool_call_input.done":
+		r.recordCustomToolCallInputDone(payload)
 	case "response.completed":
 		payload = r.patchCompletedPayload(payload)
 		r.captureMeta(payload)
@@ -300,10 +306,13 @@ func (r *responsesStreamRecovery) recordOutputItemAdded(payload []byte) {
 		if message != nil && message.ItemID == "" {
 			message.ItemID = strings.TrimSpace(item.Get("id").String())
 		}
-	case "function_call":
+	case "function_call", "custom_tool_call":
 		call := r.ensureFunctionCall(strings.TrimSpace(item.Get("id").String()), outputIndex)
 		if call == nil {
 			return
+		}
+		if itemType := strings.TrimSpace(item.Get("type").String()); itemType != "" {
+			call.ItemType = itemType
 		}
 		if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
 			call.CallID = callID
@@ -363,6 +372,7 @@ func (r *responsesStreamRecovery) recordFunctionCallArgumentsDelta(payload []byt
 	if call == nil {
 		return
 	}
+	call.ItemType = "function_call"
 	if delta := gjson.GetBytes(payload, "delta").String(); delta != "" {
 		call.Arguments.WriteString(delta)
 	}
@@ -376,9 +386,39 @@ func (r *responsesStreamRecovery) recordFunctionCallArgumentsDone(payload []byte
 	if call == nil {
 		return
 	}
+	call.ItemType = "function_call"
 	if args := gjson.GetBytes(payload, "arguments").String(); args != "" {
 		call.Arguments.Reset()
 		call.Arguments.WriteString(args)
+	}
+}
+
+func (r *responsesStreamRecovery) recordCustomToolCallInputDelta(payload []byte) {
+	call := r.ensureFunctionCall(
+		strings.TrimSpace(gjson.GetBytes(payload, "item_id").String()),
+		gjson.GetBytes(payload, "output_index").Int(),
+	)
+	if call == nil {
+		return
+	}
+	call.ItemType = "custom_tool_call"
+	if delta := gjson.GetBytes(payload, "delta").String(); delta != "" {
+		call.Input.WriteString(delta)
+	}
+}
+
+func (r *responsesStreamRecovery) recordCustomToolCallInputDone(payload []byte) {
+	call := r.ensureFunctionCall(
+		strings.TrimSpace(gjson.GetBytes(payload, "item_id").String()),
+		gjson.GetBytes(payload, "output_index").Int(),
+	)
+	if call == nil {
+		return
+	}
+	call.ItemType = "custom_tool_call"
+	if input := gjson.GetBytes(payload, "input").String(); input != "" {
+		call.Input.Reset()
+		call.Input.WriteString(input)
 	}
 }
 
@@ -600,25 +640,55 @@ func buildRecoveredFunctionCallRaw(call *responsesRecoveredFunctionCall) []byte 
 	if call == nil {
 		return nil
 	}
+	itemType := strings.TrimSpace(call.ItemType)
+	if itemType == "" {
+		itemType = "function_call"
+	}
 	callID := strings.TrimSpace(call.CallID)
 	name := strings.TrimSpace(call.Name)
 	if callID == "" && name == "" {
 		return nil
 	}
-	arguments := call.Arguments.String()
-	if strings.TrimSpace(arguments) == "" {
-		arguments = "{}"
-	}
-	item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
+
 	itemID := strings.TrimSpace(call.ItemID)
 	if itemID == "" {
-		itemID = fmt.Sprintf("fc_%s", callID)
+		switch itemType {
+		case "custom_tool_call":
+			if callID != "" {
+				itemID = fmt.Sprintf("ctc_%s", callID)
+			} else {
+				itemID = fmt.Sprintf("ctc_%d", call.OutputIndex)
+			}
+		default:
+			if callID != "" {
+				itemID = fmt.Sprintf("fc_%s", callID)
+			} else {
+				itemID = fmt.Sprintf("fc_%d", call.OutputIndex)
+			}
+		}
 	}
-	item, _ = sjson.SetBytes(item, "id", itemID)
-	item, _ = sjson.SetBytes(item, "arguments", arguments)
-	item, _ = sjson.SetBytes(item, "call_id", callID)
-	item, _ = sjson.SetBytes(item, "name", name)
-	return item
+
+	switch itemType {
+	case "custom_tool_call":
+		input := call.Input.String()
+		item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)
+		item, _ = sjson.SetBytes(item, "id", itemID)
+		item, _ = sjson.SetBytes(item, "input", input)
+		item, _ = sjson.SetBytes(item, "call_id", callID)
+		item, _ = sjson.SetBytes(item, "name", name)
+		return item
+	default:
+		arguments := call.Arguments.String()
+		if strings.TrimSpace(arguments) == "" {
+			arguments = "{}"
+		}
+		item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
+		item, _ = sjson.SetBytes(item, "id", itemID)
+		item, _ = sjson.SetBytes(item, "arguments", arguments)
+		item, _ = sjson.SetBytes(item, "call_id", callID)
+		item, _ = sjson.SetBytes(item, "name", name)
+		return item
+	}
 }
 
 func recordRecoveredIdentifiers(raw []byte, seenItemIDs, seenCallIDs map[string]struct{}) {

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -714,6 +714,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 ) ([]byte, error) {
 	completed := false
 	completedOutput := []byte("[]")
+	recovery := newResponsesStreamRecovery()
 	downstreamSessionKey := ""
 	if c != nil && c.Request != nil {
 		downstreamSessionKey = websocketDownstreamSessionKey(c.Request)
@@ -760,6 +761,23 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 		case chunk, ok := <-data:
 			if !ok {
 				if !completed {
+					if payload := recovery.synthesizeCompletedPayload(); len(payload) > 0 {
+						completed = true
+						completedOutput = responseCompletedOutputFromPayload(payload)
+						markAPIResponseTimestamp(c)
+						if errWrite := writeResponsesWebsocketPayload(conn, wsTimelineLog, payload, time.Now()); errWrite != nil {
+							log.Warnf(
+								"responses websocket: downstream_out write failed id=%s event=%s error=%v",
+								sessionID,
+								websocketPayloadEventType(payload),
+								errWrite,
+							)
+							cancel(errWrite)
+							return completedOutput, errWrite
+						}
+						cancel(nil)
+						return completedOutput, nil
+					}
 					errMsg := &interfaces.ErrorMessage{
 						StatusCode: http.StatusRequestTimeout,
 						Error:      fmt.Errorf("stream closed before response.completed"),
@@ -791,7 +809,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 				return completedOutput, nil
 			}
 
-			payloads := websocketJSONPayloadsFromChunk(chunk)
+			payloads := websocketJSONPayloadsFromChunk(recovery.normalizeChunk(chunk))
 			for i := range payloads {
 				recordResponsesWebsocketToolCallsFromPayload(downstreamSessionKey, payloads[i])
 				eventType := gjson.GetBytes(payloads[i], "type").String()

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -731,6 +731,23 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 				continue
 			}
 			if errMsg != nil {
+				if payload := recovery.recoverTerminalErrorPayload(errMsg); len(payload) > 0 {
+					completed = true
+					completedOutput = responseCompletedOutputFromPayload(payload)
+					markAPIResponseTimestamp(c)
+					if errWrite := writeResponsesWebsocketPayload(conn, wsTimelineLog, payload, time.Now()); errWrite != nil {
+						log.Warnf(
+							"responses websocket: downstream_out write failed id=%s event=%s error=%v",
+							sessionID,
+							websocketPayloadEventType(payload),
+							errWrite,
+						)
+						cancel(errWrite)
+						return completedOutput, errWrite
+					}
+					cancel(nil)
+					return completedOutput, nil
+				}
 				h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), errMsg)
 				markAPIResponseTimestamp(c)
 				errorPayload, errWrite := writeResponsesWebsocketError(conn, wsTimelineLog, errMsg)

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -974,6 +974,107 @@ func TestForwardResponsesWebsocketRecoversTransportErrorPayload(t *testing.T) {
 	}
 }
 
+func TestForwardResponsesWebsocketRecoversTransportErrorDuringCustomToolCall(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte, 5)
+		errCh := make(chan *interfaces.ErrorMessage)
+		data <- []byte("data: {\"type\":\"response.created\",\"sequence_number\":1,\"response\":{\"id\":\"resp-1\",\"created_at\":123,\"model\":\"gpt-5.4\"}}")
+		data <- []byte("data: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"item\":{\"id\":\"ctc-1\",\"type\":\"custom_tool_call\",\"status\":\"in_progress\",\"call_id\":\"call-1\",\"input\":\"\",\"name\":\"apply_patch\"},\"output_index\":2}")
+		data <- []byte("data: {\"type\":\"response.custom_tool_call_input.delta\",\"sequence_number\":3,\"item_id\":\"ctc-1\",\"output_index\":2,\"delta\":\"*** Begin Patch\\n*** Add File: /tmp/fix.txt\\n\"}")
+		data <- []byte(": keep-alive\n\n")
+		data <- []byte("event: error\ndata: {\"type\":\"error\",\"code\":\"internal_server_error\",\"message\":\"stream error: stream ID 27; INTERNAL_ERROR; received from peer\",\"sequence_number\":0}\n\n")
+		close(data)
+		close(errCh)
+
+		var timelineLog strings.Builder
+		completedOutput, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			&timelineLog,
+			"session-custom-tool-recover",
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		if gjson.GetBytes(completedOutput, "0.type").String() != "custom_tool_call" {
+			serverErrCh <- errors.New("completed output type not recovered from transport error")
+			return
+		}
+		expectedInput := "*** Begin Patch\n*** Add File: /tmp/fix.txt\n"
+		if gjson.GetBytes(completedOutput, "0.input").String() != expectedInput {
+			serverErrCh <- errors.New("completed output input not recovered from transport error")
+			return
+		}
+		if strings.Contains(timelineLog.String(), "\"type\":\"error\"") && !strings.Contains(timelineLog.String(), "\"type\":\"response.completed\"") {
+			serverErrCh <- errors.New("timeline retained error without recovered completion")
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	if errSetDeadline := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); errSetDeadline != nil {
+		t.Fatalf("set read deadline: %v", errSetDeadline)
+	}
+
+	var completedPayload []byte
+	for i := 0; i < 5; i++ {
+		_, payload, errReadMessage := conn.ReadMessage()
+		if errReadMessage != nil {
+			t.Fatalf("read websocket message: %v", errReadMessage)
+		}
+		if gjson.GetBytes(payload, "type").String() == wsEventTypeCompleted {
+			completedPayload = payload
+			break
+		}
+		if gjson.GetBytes(payload, "type").String() == wsEventTypeError {
+			t.Fatalf("unexpected websocket error payload: %s", string(payload))
+		}
+	}
+	if len(completedPayload) == 0 {
+		t.Fatal("expected recovered response.completed payload")
+	}
+	if gjson.GetBytes(completedPayload, "response.output.0.type").String() != "custom_tool_call" {
+		t.Fatalf("response.output type = %q, want %q", gjson.GetBytes(completedPayload, "response.output.0.type").String(), "custom_tool_call")
+	}
+	expectedInput := "*** Begin Patch\n*** Add File: /tmp/fix.txt\n"
+	if gjson.GetBytes(completedPayload, "response.output.0.input").String() != expectedInput {
+		t.Fatalf("response.output input = %q, want %q", gjson.GetBytes(completedPayload, "response.output.0.input").String(), expectedInput)
+	}
+
+	if errServer := <-serverErrCh; errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
 func TestResponsesWebsocketTimelineRecordsDisconnectEvent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -883,6 +883,97 @@ func TestForwardResponsesWebsocketSynthesizesMissingCompletedEvent(t *testing.T)
 	}
 }
 
+func TestForwardResponsesWebsocketRecoversTransportErrorPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte, 4)
+		errCh := make(chan *interfaces.ErrorMessage)
+		data <- []byte("data: {\"type\":\"response.created\",\"sequence_number\":1,\"response\":{\"id\":\"resp-1\",\"created_at\":123,\"model\":\"gpt-5.4\"}}")
+		data <- []byte("data: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"item\":{\"id\":\"msg-1\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0}")
+		data <- []byte("data: {\"type\":\"response.output_text.delta\",\"sequence_number\":3,\"item_id\":\"msg-1\",\"output_index\":0,\"delta\":\"partial websocket answer\"}")
+		data <- []byte("event: error\ndata: {\"type\":\"error\",\"code\":\"internal_server_error\",\"message\":\"stream error: stream ID 219; INTERNAL_ERROR; received from peer\",\"sequence_number\":4}\n\n")
+		close(data)
+		close(errCh)
+
+		var timelineLog strings.Builder
+		completedOutput, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			&timelineLog,
+			"session-transport-recover",
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		if gjson.GetBytes(completedOutput, "0.content.0.text").String() != "partial websocket answer" {
+			serverErrCh <- errors.New("completed output not recovered from transport error")
+			return
+		}
+		if strings.Contains(timelineLog.String(), "\"type\":\"error\"") && !strings.Contains(timelineLog.String(), "\"type\":\"response.completed\"") {
+			serverErrCh <- errors.New("timeline retained error without recovered completion")
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	if errSetDeadline := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); errSetDeadline != nil {
+		t.Fatalf("set read deadline: %v", errSetDeadline)
+	}
+
+	var completedPayload []byte
+	for i := 0; i < 5; i++ {
+		_, payload, errReadMessage := conn.ReadMessage()
+		if errReadMessage != nil {
+			t.Fatalf("read websocket message: %v", errReadMessage)
+		}
+		if gjson.GetBytes(payload, "type").String() == wsEventTypeCompleted {
+			completedPayload = payload
+			break
+		}
+		if gjson.GetBytes(payload, "type").String() == wsEventTypeError {
+			t.Fatalf("unexpected websocket error payload: %s", string(payload))
+		}
+	}
+	if len(completedPayload) == 0 {
+		t.Fatal("expected recovered response.completed payload")
+	}
+	if gjson.GetBytes(completedPayload, "response.output.0.content.0.text").String() != "partial websocket answer" {
+		t.Fatalf("response.output text = %q, want %q", gjson.GetBytes(completedPayload, "response.output.0.content.0.text").String(), "partial websocket answer")
+	}
+
+	if errServer := <-serverErrCh; errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
 func TestResponsesWebsocketTimelineRecordsDisconnectEvent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -799,6 +799,90 @@ func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing
 	}
 }
 
+func TestForwardResponsesWebsocketSynthesizesMissingCompletedEvent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte, 4)
+		errCh := make(chan *interfaces.ErrorMessage)
+		data <- []byte("data: {\"type\":\"response.created\",\"sequence_number\":1,\"response\":{\"id\":\"resp-1\",\"created_at\":123,\"model\":\"gpt-5.4\"}}")
+		data <- []byte("data: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"item\":{\"id\":\"msg-1\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0}")
+		data <- []byte("data: {\"type\":\"response.output_text.delta\",\"sequence_number\":3,\"item_id\":\"msg-1\",\"output_index\":0,\"delta\":\"hello websocket\"}")
+		data <- []byte("data: {\"type\":\"response.output_text.done\",\"sequence_number\":4,\"item_id\":\"msg-1\",\"output_index\":0,\"text\":\"hello websocket\"}")
+		close(data)
+		close(errCh)
+
+		var timelineLog strings.Builder
+		completedOutput, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			&timelineLog,
+			"session-recover",
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		if gjson.GetBytes(completedOutput, "0.content.0.text").String() != "hello websocket" {
+			serverErrCh <- errors.New("completed output not synthesized correctly")
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	if errSetDeadline := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); errSetDeadline != nil {
+		t.Fatalf("set read deadline: %v", errSetDeadline)
+	}
+
+	var completedPayload []byte
+	for i := 0; i < 5; i++ {
+		_, payload, errReadMessage := conn.ReadMessage()
+		if errReadMessage != nil {
+			t.Fatalf("read websocket message: %v", errReadMessage)
+		}
+		if gjson.GetBytes(payload, "type").String() == wsEventTypeCompleted {
+			completedPayload = payload
+			break
+		}
+	}
+	if len(completedPayload) == 0 {
+		t.Fatal("expected synthesized response.completed payload")
+	}
+	if gjson.GetBytes(completedPayload, "response.output.0.content.0.text").String() != "hello websocket" {
+		t.Fatalf("response.output text = %q, want %q", gjson.GetBytes(completedPayload, "response.output.0.content.0.text").String(), "hello websocket")
+	}
+
+	if errServer := <-serverErrCh; errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
 func TestResponsesWebsocketTimelineRecordsDisconnectEvent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -1075,6 +1075,113 @@ func TestForwardResponsesWebsocketRecoversTransportErrorDuringCustomToolCall(t *
 	}
 }
 
+func TestForwardResponsesWebsocketRecoversTerminalErrorChannelDuringCustomToolCall(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte, 3)
+		errCh := make(chan *interfaces.ErrorMessage, 1)
+		data <- []byte("data: {\"type\":\"response.created\",\"sequence_number\":1,\"response\":{\"id\":\"resp-1\",\"created_at\":123,\"model\":\"gpt-5.4\"}}")
+		data <- []byte("data: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"item\":{\"id\":\"ctc-1\",\"type\":\"custom_tool_call\",\"status\":\"in_progress\",\"call_id\":\"call-1\",\"input\":\"\",\"name\":\"apply_patch\"},\"output_index\":2}")
+		data <- []byte("data: {\"type\":\"response.custom_tool_call_input.delta\",\"sequence_number\":3,\"item_id\":\"ctc-1\",\"output_index\":2,\"delta\":\"*** Begin Patch\\n*** Add File: /tmp/fix.txt\\n\"}")
+
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			errCh <- &interfaces.ErrorMessage{
+				StatusCode: http.StatusInternalServerError,
+				Error:      errors.New("stream error: stream ID 23; INTERNAL_ERROR; received from peer"),
+			}
+			close(errCh)
+			close(data)
+		}()
+
+		var timelineLog strings.Builder
+		completedOutput, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			&timelineLog,
+			"session-custom-tool-terminal-recover",
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		if gjson.GetBytes(completedOutput, "0.type").String() != "custom_tool_call" {
+			serverErrCh <- errors.New("completed output type not recovered from terminal error")
+			return
+		}
+		expectedInput := "*** Begin Patch\n*** Add File: /tmp/fix.txt\n"
+		if gjson.GetBytes(completedOutput, "0.input").String() != expectedInput {
+			serverErrCh <- errors.New("completed output input not recovered from terminal error")
+			return
+		}
+		if strings.Contains(timelineLog.String(), "\"type\":\"error\"") && !strings.Contains(timelineLog.String(), "\"type\":\"response.completed\"") {
+			serverErrCh <- errors.New("timeline retained terminal error without recovered completion")
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	if errSetDeadline := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); errSetDeadline != nil {
+		t.Fatalf("set read deadline: %v", errSetDeadline)
+	}
+
+	var completedPayload []byte
+	for i := 0; i < 5; i++ {
+		_, payload, errReadMessage := conn.ReadMessage()
+		if errReadMessage != nil {
+			t.Fatalf("read websocket message: %v", errReadMessage)
+		}
+		if gjson.GetBytes(payload, "type").String() == wsEventTypeCompleted {
+			completedPayload = payload
+			break
+		}
+		if gjson.GetBytes(payload, "type").String() == wsEventTypeError {
+			t.Fatalf("unexpected websocket error payload: %s", string(payload))
+		}
+	}
+	if len(completedPayload) == 0 {
+		t.Fatal("expected recovered response.completed payload")
+	}
+	if gjson.GetBytes(completedPayload, "response.output.0.type").String() != "custom_tool_call" {
+		t.Fatalf("response.output type = %q, want %q", gjson.GetBytes(completedPayload, "response.output.0.type").String(), "custom_tool_call")
+	}
+	expectedInput := "*** Begin Patch\n*** Add File: /tmp/fix.txt\n"
+	if gjson.GetBytes(completedPayload, "response.output.0.input").String() != expectedInput {
+		t.Fatalf("response.output input = %q, want %q", gjson.GetBytes(completedPayload, "response.output.0.input").String(), expectedInput)
+	}
+
+	if errServer := <-serverErrCh; errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
 func TestResponsesWebsocketTimelineRecordsDisconnectEvent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/sdk/api/handlers/stream_forwarder.go
+++ b/sdk/api/handlers/stream_forwarder.go
@@ -14,19 +14,19 @@ type StreamForwardOptions struct {
 	KeepAliveInterval *time.Duration
 
 	// WriteChunk writes a single data chunk to the response body. It should not flush.
-	WriteChunk func(chunk []byte)
+	WriteChunk func(chunk []byte) error
 
 	// WriteTerminalError writes an error payload to the response body when streaming fails
 	// after headers have already been committed. It should not flush.
-	WriteTerminalError func(errMsg *interfaces.ErrorMessage)
+	WriteTerminalError func(errMsg *interfaces.ErrorMessage) error
 
 	// WriteDone optionally writes a terminal marker when the upstream data channel closes
 	// without an error (e.g. OpenAI's `[DONE]`). It should not flush.
-	WriteDone func()
+	WriteDone func() error
 
 	// WriteKeepAlive optionally writes a keep-alive heartbeat. It should not flush.
 	// When nil, a standard SSE comment heartbeat is used.
-	WriteKeepAlive func()
+	WriteKeepAlive func() error
 }
 
 func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage, opts StreamForwardOptions) {
@@ -39,13 +39,14 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 
 	writeChunk := opts.WriteChunk
 	if writeChunk == nil {
-		writeChunk = func([]byte) {}
+		writeChunk = func([]byte) error { return nil }
 	}
 
 	writeKeepAlive := opts.WriteKeepAlive
 	if writeKeepAlive == nil {
-		writeKeepAlive = func() {
-			_, _ = c.Writer.Write([]byte(": keep-alive\n\n"))
+		writeKeepAlive = func() error {
+			_, err := c.Writer.Write([]byte(": keep-alive\n\n"))
+			return err
 		}
 	}
 
@@ -81,20 +82,29 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 				}
 				if terminalErr != nil {
 					if opts.WriteTerminalError != nil {
-						opts.WriteTerminalError(terminalErr)
+						if err := opts.WriteTerminalError(terminalErr); err != nil {
+							cancel(err)
+							return
+						}
 					}
 					flusher.Flush()
 					cancel(terminalErr.Error)
 					return
 				}
 				if opts.WriteDone != nil {
-					opts.WriteDone()
+					if err := opts.WriteDone(); err != nil {
+						cancel(err)
+						return
+					}
 				}
 				flusher.Flush()
 				cancel(nil)
 				return
 			}
-			writeChunk(chunk)
+			if err := writeChunk(chunk); err != nil {
+				cancel(err)
+				return
+			}
 			flusher.Flush()
 		case errMsg, ok := <-errs:
 			if !ok {
@@ -103,7 +113,10 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 			if errMsg != nil {
 				terminalErr = errMsg
 				if opts.WriteTerminalError != nil {
-					opts.WriteTerminalError(errMsg)
+					if err := opts.WriteTerminalError(errMsg); err != nil {
+						cancel(err)
+						return
+					}
 					flusher.Flush()
 				}
 			}
@@ -114,7 +127,10 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 			cancel(execErr)
 			return
 		case <-keepAliveC:
-			writeKeepAlive()
+			if err := writeKeepAlive(); err != nil {
+				cancel(err)
+				return
+			}
 			flusher.Flush()
 		}
 	}


### PR DESCRIPTION
## Summary
- recover upstream Responses transport errors by rewriting recoverable terminal `event: error` frames into synthetic `response.completed`
- recover late transport breaks even when the stream is inside an in-progress `custom_tool_call` edit, by rebuilding `custom_tool_call.input` from incremental deltas
- recover terminal stream failures that surface through the proxy error channel instead of the data channel, so long streams no longer leak `event:error` just because the upstream parser promoted the failure into `errChan`
- stop downstream streaming immediately when writing to the client fails instead of silently continuing to drain upstream output
- make streaming request logs record only bytes that were actually written to the client so debug logs stop overstating delivery success
- add regression coverage for message streams, tool-call streams, terminal-error recovery, and downstream write-failure cancellation across SSE and websocket outputs

## Root Cause
There turned out to be four separate failure modes behind `stream closed before response.completed`:
- some upstream Responses streams ended with transport-level `event: error` frames after useful content had already been emitted
- downstream write failures were still swallowed locally, so the proxy could keep draining upstream output after the desktop client had already lost the connection
- the stream recovery state tracked assistant text and `function_call.arguments`, but not `custom_tool_call.input`, so long Codex edit streams could still fail recovery if the transport broke during an in-progress tool edit
- even after that state fix, not every late transport failure arrived as a stream chunk; some were promoted into the proxy's terminal `errChan` path, which previously bypassed recovery entirely and wrote `event:error` straight to the client

That last gap exactly matches the newest reproduced trace from April 12, 2026 around 16:09 local time: the stream had already emitted `response.output_item.added` for a `custom_tool_call`, then thousands of `response.custom_tool_call_input.delta` events, then a late recoverable upstream transport failure. The proxy now attempts completion recovery in both the chunk path and the terminal error path.

## Impact
Responses streaming is now resilient across the full long-edit path:
- recoverable upstream transport breaks are normalized into a final completion event when enough state exists to rebuild it
- in-progress `custom_tool_call` edits now survive late transport errors because their partial input is preserved and emitted in the synthetic completion
- terminal upstream failures routed through `errChan` are now treated the same way as recoverable `event:error` chunks instead of leaking straight through to the desktop client
- downstream disconnects now terminate the stream promptly instead of ghost-writing more SSE frames into logs after the client is gone
- request logs are now trustworthy for partial-write cases because they only capture the successfully written prefix

## Validation
- `go test ./sdk/api/handlers/openai`
- `go test ./sdk/api/handlers`
- `go test ./internal/api/middleware`
- `go test ./...` still has pre-existing failures in `internal/runtime/executor` unrelated to this change
