### PR TITLE
fix(antigravity): allow 32MB bypass signatures

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request_test.go
@@ -468,11 +468,7 @@ func TestValidateBypassMode_HandlesWhitespace(t *testing.T) {
 
 func TestValidateBypassMode_RejectsOversizedSignature(t *testing.T) {
 	t.Parallel()
-	payload := append([]byte{0x12}, bytes.Repeat([]byte{0x34}, maxBypassSignatureLen)...)
-	sig := base64.StdEncoding.EncodeToString(payload)
-	if len(sig) <= maxBypassSignatureLen {
-		t.Fatalf("test setup: signature should exceed max length, got %d", len(sig))
-	}
+	sig := strings.Repeat("A", maxBypassSignatureLen+1)
 
 	inputJSON := []byte(`{
 		"messages": [{"role": "assistant", "content": [
@@ -486,6 +482,33 @@ func TestValidateBypassMode_RejectsOversizedSignature(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "maximum length") {
 		t.Fatalf("expected length error, got: %v", err)
+	}
+}
+
+func TestValidateBypassMode_StrictAcceptsSignatureBetween16KiBAnd32MiB(t *testing.T) {
+	previous := cache.SignatureBypassStrictMode()
+	cache.SetSignatureBypassStrictMode(true)
+	t.Cleanup(func() {
+		cache.SetSignatureBypassStrictMode(previous)
+	})
+
+	payload := buildClaudeSignaturePayload(t, 12, uint64Ptr(2), strings.Repeat("m", 20000), true)
+	sig := base64.StdEncoding.EncodeToString(payload)
+	if len(sig) <= 1<<14 {
+		t.Fatalf("test setup: signature should exceed previous 16KiB guardrail, got %d", len(sig))
+	}
+	if len(sig) > maxBypassSignatureLen {
+		t.Fatalf("test setup: signature should remain within new max length, got %d", len(sig))
+	}
+
+	inputJSON := []byte(`{
+		"messages": [{"role": "assistant", "content": [
+			{"type": "thinking", "thinking": "t", "signature": "` + sig + `"}
+		]}]
+	}`)
+
+	if err := ValidateClaudeBypassSignatures(inputJSON); err != nil {
+		t.Fatalf("expected strict mode to accept signature below 32MiB max, got: %v", err)
 	}
 }
 

--- a/internal/translator/antigravity/claude/signature_validation.go
+++ b/internal/translator/antigravity/claude/signature_validation.go
@@ -58,7 +58,7 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 )
 
-const maxBypassSignatureLen = 8192
+const maxBypassSignatureLen = 32 * 1024 * 1024
 
 type claudeSignatureTree struct {
 	EncodingLayers      int


### PR DESCRIPTION
## Summary
- raise the local Claude bypass signature length limit to 32 MiB
- keep the oversized-signature test lightweight by checking the length guard without building a huge decoded payload
- add coverage that strict mode accepts signatures above the previous 16 KiB guardrail while remaining below the new ceiling