### PR TITLE
fix(antigravity): reduce bypass mode log noise

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1074,20 +1074,17 @@ func applySignatureCacheConfig(oldCfg, cfg *config.Config) {
 	if oldCfg == nil {
 		cache.SetSignatureCacheEnabled(newVal)
 		cache.SetSignatureBypassStrictMode(newStrict)
-		log.Debugf("antigravity_signature_cache_enabled toggled to %t", newVal)
 		return
 	}
 
 	oldVal := configuredSignatureCacheEnabled(oldCfg)
 	if oldVal != newVal {
 		cache.SetSignatureCacheEnabled(newVal)
-		log.Debugf("antigravity_signature_cache_enabled updated from %t to %t", oldVal, newVal)
 	}
 
 	oldStrict := configuredSignatureBypassStrict(oldCfg)
 	if oldStrict != newStrict {
 		cache.SetSignatureBypassStrictMode(newStrict)
-		log.Debugf("antigravity_signature_bypass_strict updated from %t to %t", oldStrict, newStrict)
 	}
 }
 

--- a/internal/cache/signature_cache.go
+++ b/internal/cache/signature_cache.go
@@ -207,9 +207,12 @@ func init() {
 
 // SetSignatureCacheEnabled switches Antigravity signature handling between cache mode and bypass mode.
 func SetSignatureCacheEnabled(enabled bool) {
-	signatureCacheEnabled.Store(enabled)
+	previous := signatureCacheEnabled.Swap(enabled)
+	if previous == enabled {
+		return
+	}
 	if !enabled {
-		log.Warn("antigravity signature cache DISABLED - bypass mode active, cached signatures will not be used for request translation")
+		log.Info("antigravity signature cache DISABLED - bypass mode active, cached signatures will not be used for request translation")
 	}
 }
 
@@ -220,11 +223,14 @@ func SignatureCacheEnabled() bool {
 
 // SetSignatureBypassStrictMode controls whether bypass mode uses strict protobuf-tree validation.
 func SetSignatureBypassStrictMode(strict bool) {
-	signatureBypassStrictMode.Store(strict)
+	previous := signatureBypassStrictMode.Swap(strict)
+	if previous == strict {
+		return
+	}
 	if strict {
-		log.Info("antigravity bypass signature validation: strict mode (protobuf tree)")
+		log.Debug("antigravity bypass signature validation: strict mode (protobuf tree)")
 	} else {
-		log.Info("antigravity bypass signature validation: basic mode (R/E + 0x12)")
+		log.Debug("antigravity bypass signature validation: basic mode (R/E + 0x12)")
 	}
 }
 

--- a/internal/cache/signature_cache_test.go
+++ b/internal/cache/signature_cache_test.go
@@ -1,8 +1,12 @@
 package cache
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const testModelName = "claude-sonnet-4-5"
@@ -207,4 +211,91 @@ func TestCacheSignature_ExpirationLogic(t *testing.T) {
 	// We can't easily test actual expiration without time mocking
 	// but the logic is verified by the implementation
 	_ = time.Now() // Acknowledge we're not testing time passage
+}
+
+func TestSignatureModeSetters_LogAtInfoLevel(t *testing.T) {
+	logger := log.StandardLogger()
+	previousOutput := logger.Out
+	previousLevel := logger.Level
+	previousCache := SignatureCacheEnabled()
+	previousStrict := SignatureBypassStrictMode()
+	SetSignatureCacheEnabled(true)
+	SetSignatureBypassStrictMode(false)
+	buffer := &bytes.Buffer{}
+	log.SetOutput(buffer)
+	log.SetLevel(log.InfoLevel)
+	t.Cleanup(func() {
+		log.SetOutput(previousOutput)
+		log.SetLevel(previousLevel)
+		SetSignatureCacheEnabled(previousCache)
+		SetSignatureBypassStrictMode(previousStrict)
+	})
+
+	SetSignatureCacheEnabled(false)
+	SetSignatureBypassStrictMode(true)
+	SetSignatureBypassStrictMode(false)
+
+	output := buffer.String()
+	if !strings.Contains(output, "antigravity signature cache DISABLED") {
+		t.Fatalf("expected info output for disabling signature cache, got: %q", output)
+	}
+	if strings.Contains(output, "strict mode (protobuf tree)") {
+		t.Fatalf("expected strict bypass mode log to stay below info level, got: %q", output)
+	}
+	if strings.Contains(output, "basic mode (R/E + 0x12)") {
+		t.Fatalf("expected basic bypass mode log to stay below info level, got: %q", output)
+	}
+}
+
+func TestSignatureModeSetters_DoNotRepeatSameStateLogs(t *testing.T) {
+	logger := log.StandardLogger()
+	previousOutput := logger.Out
+	previousLevel := logger.Level
+	previousCache := SignatureCacheEnabled()
+	previousStrict := SignatureBypassStrictMode()
+	SetSignatureCacheEnabled(false)
+	SetSignatureBypassStrictMode(true)
+	buffer := &bytes.Buffer{}
+	log.SetOutput(buffer)
+	log.SetLevel(log.InfoLevel)
+	t.Cleanup(func() {
+		log.SetOutput(previousOutput)
+		log.SetLevel(previousLevel)
+		SetSignatureCacheEnabled(previousCache)
+		SetSignatureBypassStrictMode(previousStrict)
+	})
+
+	SetSignatureCacheEnabled(false)
+	SetSignatureBypassStrictMode(true)
+
+	if buffer.Len() != 0 {
+		t.Fatalf("expected repeated setter calls with unchanged state to stay silent, got: %q", buffer.String())
+	}
+}
+
+func TestSignatureBypassStrictMode_LogsAtDebugLevel(t *testing.T) {
+	logger := log.StandardLogger()
+	previousOutput := logger.Out
+	previousLevel := logger.Level
+	previousStrict := SignatureBypassStrictMode()
+	SetSignatureBypassStrictMode(false)
+	buffer := &bytes.Buffer{}
+	log.SetOutput(buffer)
+	log.SetLevel(log.DebugLevel)
+	t.Cleanup(func() {
+		log.SetOutput(previousOutput)
+		log.SetLevel(previousLevel)
+		SetSignatureBypassStrictMode(previousStrict)
+	})
+
+	SetSignatureBypassStrictMode(true)
+	SetSignatureBypassStrictMode(false)
+
+	output := buffer.String()
+	if !strings.Contains(output, "strict mode (protobuf tree)") {
+		t.Fatalf("expected debug output for strict bypass mode, got: %q", output)
+	}
+	if !strings.Contains(output, "basic mode (R/E + 0x12)") {
+		t.Fatalf("expected debug output for basic bypass mode, got: %q", output)
+	}
 }


### PR DESCRIPTION
## Summary
- Use `atomic.Swap` to suppress duplicate state-change logs when the value hasn't actually changed
- Keep cache-disable visibility at info level while moving strict-mode chatter down to debug
- Remove redundant debug logs from `applySignatureCacheConfig` in server.go
- Add tests verifying log levels and deduplication behavior

## Test plan
- [x] `go test ./internal/cache/...` — new tests pass
- [x] `go build` — compiles cleanly