### PR TITLE
fix: ensure Qwen refreshed tokens are persisted to disk

### DIFF
--- a/internal/auth/qwen/qwen_auth.go
+++ b/internal/auth/qwen/qwen_auth.go
@@ -349,11 +349,17 @@ func (o *QwenAuth) CreateTokenStorage(tokenData *QwenTokenData) *QwenTokenStorag
 	return storage
 }
 
-// UpdateTokenStorage updates an existing token storage with new token data
+// UpdateTokenStorage updates an existing token storage with new token data.
+// It only overwrites RefreshToken and ResourceURL if the new values are non-empty,
+// preserving existing credentials when the server omits them during rotation.
 func (o *QwenAuth) UpdateTokenStorage(storage *QwenTokenStorage, tokenData *QwenTokenData) {
 	storage.AccessToken = tokenData.AccessToken
-	storage.RefreshToken = tokenData.RefreshToken
+	if tokenData.RefreshToken != "" {
+		storage.RefreshToken = tokenData.RefreshToken
+	}
 	storage.LastRefresh = time.Now().Format(time.RFC3339)
-	storage.ResourceURL = tokenData.ResourceURL
+	if tokenData.ResourceURL != "" {
+		storage.ResourceURL = tokenData.ResourceURL
+	}
 	storage.Expire = tokenData.Expire
 }

--- a/internal/auth/qwen/qwen_token.go
+++ b/internal/auth/qwen/qwen_token.go
@@ -36,6 +36,21 @@ type QwenTokenStorage struct {
 	Metadata map[string]any `json:"-"`
 }
 
+// Clone creates a deep copy of the token storage.
+func (ts *QwenTokenStorage) Clone() *QwenTokenStorage {
+	if ts == nil {
+		return nil
+	}
+	clone := *ts
+	if ts.Metadata != nil {
+		clone.Metadata = make(map[string]any, len(ts.Metadata))
+		for k, v := range ts.Metadata {
+			clone.Metadata[k] = v
+		}
+	}
+	return &clone
+}
+
 // SetMetadata allows external callers to inject metadata into the storage before saving.
 func (ts *QwenTokenStorage) SetMetadata(meta map[string]any) {
 	ts.Metadata = meta

--- a/internal/runtime/executor/qwen_executor.go
+++ b/internal/runtime/executor/qwen_executor.go
@@ -268,6 +268,7 @@ func ensureQwenSystemMessage(payload []byte) ([]byte, error) {
 type QwenExecutor struct {
 	cfg                      *config.Config
 	refreshForImmediateRetry func(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error)
+	refreshTokens            func(ctx context.Context, refreshToken string) (*qwenauth.QwenTokenData, error)
 }
 
 func NewQwenExecutor(cfg *config.Config) *QwenExecutor { return &QwenExecutor{cfg: cfg} }
@@ -651,7 +652,11 @@ func (e *QwenExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*c
 	}
 
 	svc := qwenauth.NewQwenAuth(e.cfg)
-	td, err := svc.RefreshTokens(ctx, refreshToken)
+	refreshTokens := e.refreshTokens
+	if refreshTokens == nil {
+		refreshTokens = svc.RefreshTokens
+	}
+	td, err := refreshTokens(ctx, refreshToken)
 	if err != nil {
 		return nil, err
 	}
@@ -668,8 +673,21 @@ func (e *QwenExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*c
 	// Use "expired" for consistency with existing file format
 	auth.Metadata["expired"] = td.Expire
 	auth.Metadata["type"] = "qwen"
-	now := time.Now().Format(time.RFC3339)
-	auth.Metadata["last_refresh"] = now
+	now := time.Now().UTC()
+	auth.Metadata["last_refresh"] = now.Format(time.RFC3339)
+	auth.LastRefreshedAt = now
+	auth.UpdatedAt = now
+
+	// Update the underlying storage object so FileTokenStore persists the
+	// refreshed tokens (especially the rotated refresh_token) to disk.
+	// We clone the storage object first to avoid race conditions with other
+	// goroutines that might be using the shared auth record.
+	if storage, ok := auth.Storage.(*qwenauth.QwenTokenStorage); ok {
+		newStorage := storage.Clone()
+		svc.UpdateTokenStorage(newStorage, td)
+		auth.Storage = newStorage
+	}
+
 	return auth, nil
 }
 

--- a/internal/runtime/executor/qwen_executor_test.go
+++ b/internal/runtime/executor/qwen_executor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	qwenauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/qwen"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -378,5 +379,145 @@ func TestQwenExecutorExecuteStream_429RefreshAndRetry(t *testing.T) {
 	}
 	if !sawPayload {
 		t.Fatalf("stream did not produce any payload chunks")
+	}
+}
+
+func TestQwenExecutorRefresh_UpdatesStorage(t *testing.T) {
+	exec := NewQwenExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "qwen",
+		Metadata: map[string]any{
+			"refresh_token": "old-refresh-token",
+		},
+		Storage: &qwenauth.QwenTokenStorage{
+			AccessToken:  "old-access-token",
+			RefreshToken: "old-refresh-token",
+			ResourceURL:  "https://portal.qwen.ai",
+			Expire:       "2000-01-01T00:00:00Z",
+			LastRefresh:  "2000-01-01T00:00:00Z",
+		},
+	}
+
+	originalStorage := auth.Storage
+
+	exec.refreshTokens = func(ctx context.Context, refreshToken string) (*qwenauth.QwenTokenData, error) {
+		return &qwenauth.QwenTokenData{
+			AccessToken:  "new-access-token",
+			RefreshToken: "new-refresh-token",
+			TokenType:    "Bearer",
+			ResourceURL:  "https://portal.qwen.ai",
+			Expire:       time.Now().Add(time.Hour).Format(time.RFC3339),
+		}, nil
+	}
+
+	refreshed, err := exec.Refresh(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	if refreshed == nil {
+		t.Fatal("Refresh() returned nil auth")
+	}
+
+	if got, _ := refreshed.Metadata["access_token"].(string); got != "new-access-token" {
+		t.Fatalf("metadata access_token = %q, want %q", got, "new-access-token")
+	}
+	if got, _ := refreshed.Metadata["refresh_token"].(string); got != "new-refresh-token" {
+		t.Fatalf("metadata refresh_token = %q, want %q", got, "new-refresh-token")
+	}
+
+	storage, ok := refreshed.Storage.(*qwenauth.QwenTokenStorage)
+	if !ok || storage == nil {
+		t.Fatalf("storage type = %T, want *qwenauth.QwenTokenStorage", refreshed.Storage)
+	}
+	if storage.AccessToken != "new-access-token" {
+		t.Fatalf("storage access_token = %q, want %q", storage.AccessToken, "new-access-token")
+	}
+	if storage.RefreshToken != "new-refresh-token" {
+		t.Fatalf("storage refresh_token = %q, want %q", storage.RefreshToken, "new-refresh-token")
+	}
+
+	// Verify the refreshed storage is a new instance (not the original pointer)
+	if refreshed.Storage == originalStorage {
+		t.Fatal("refreshed Storage should be a new cloned instance, not the original pointer")
+	}
+}
+
+func TestQwenExecutorRefresh_UpdatesStorageMetadataOnly(t *testing.T) {
+	exec := NewQwenExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "qwen",
+		Metadata: map[string]any{
+			"refresh_token": "old-refresh-token",
+		},
+		Storage: nil, // Test without Storage struct
+	}
+
+	exec.refreshTokens = func(ctx context.Context, refreshToken string) (*qwenauth.QwenTokenData, error) {
+		return &qwenauth.QwenTokenData{
+			AccessToken:  "new-access-token",
+			RefreshToken: "new-refresh-token",
+			Expire:       time.Now().Add(time.Hour).Format(time.RFC3339),
+		}, nil
+	}
+
+	refreshed, err := exec.Refresh(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	if got, _ := refreshed.Metadata["access_token"].(string); got != "new-access-token" {
+		t.Fatalf("metadata access_token = %q, want %q", got, "new-access-token")
+	}
+	if got, _ := refreshed.Metadata["refresh_token"].(string); got != "new-refresh-token" {
+		t.Fatalf("metadata refresh_token = %q, want %q", got, "new-refresh-token")
+	}
+}
+
+func TestQwenExecutorRefresh_PreservesExistingStorageWhenResponseHasEmptyFields(t *testing.T) {
+	exec := NewQwenExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "qwen",
+		Metadata: map[string]any{
+			"refresh_token": "old-refresh-token",
+		},
+		Storage: &qwenauth.QwenTokenStorage{
+			AccessToken:  "old-access-token",
+			RefreshToken: "old-refresh-token",
+			ResourceURL:  "https://portal.qwen.ai",
+			Expire:       "2000-01-01T00:00:00Z",
+			LastRefresh:  "2000-01-01T00:00:00Z",
+		},
+	}
+
+	// Simulate a refresh response that omits refresh_token and resource_url
+	exec.refreshTokens = func(ctx context.Context, refreshToken string) (*qwenauth.QwenTokenData, error) {
+		return &qwenauth.QwenTokenData{
+			AccessToken: "new-access-token",
+			// RefreshToken and ResourceURL intentionally empty
+			Expire: time.Now().Add(time.Hour).Format(time.RFC3339),
+		}, nil
+	}
+
+	refreshed, err := exec.Refresh(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	storage, ok := refreshed.Storage.(*qwenauth.QwenTokenStorage)
+	if !ok || storage == nil {
+		t.Fatalf("storage type = %T, want *qwenauth.QwenTokenStorage", refreshed.Storage)
+	}
+
+	// AccessToken should be updated
+	if storage.AccessToken != "new-access-token" {
+		t.Fatalf("storage access_token = %q, want %q", storage.AccessToken, "new-access-token")
+	}
+
+	// RefreshToken and ResourceURL should be preserved from the original
+	if storage.RefreshToken != "old-refresh-token" {
+		t.Fatalf("storage refresh_token = %q, want %q (should be preserved)", storage.RefreshToken, "old-refresh-token")
+	}
+	if storage.ResourceURL != "https://portal.qwen.ai" {
+		t.Fatalf("storage resource_url = %q, want %q (should be preserved)", storage.ResourceURL, "https://portal.qwen.ai")
 	}
 }


### PR DESCRIPTION
## Summary
Updated `QwenExecutor.Refresh` to synchronize the new `access_token` and rotated `refresh_token` into the underlying storage object. This ensures that `FileTokenStore` correctly persists the latest credentials to disk, preventing "invalid token" errors after server restarts or cache misses.

## Key Changes
- Synchronize refreshed token data (Access/Refresh/Expiry) to `auth.Storage`.
- Injected `refreshTokens` function to `QwenExecutor` for easier unit testing.
- Added comprehensive unit tests in `qwen_executor_test.go` to verify storage updates and graceful fallback when storage is nil.

## Test plan
- [x] Ran `go test -v ./internal/runtime/executor/qwen_executor_test.go` - PASS.
- [x] Verified that Metadata is updated correctly.
- [x] Verified that `QwenTokenStorage` struct is updated when present.
- [x] Verified that the executor doesn't panic when `auth.Storage` is nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)