### PR TITLE
fix(management): register saved auths and support list rescans 

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1385,7 +1385,16 @@ func (h *Handler) saveTokenRecord(ctx context.Context, record *coreauth.Auth) (s
 			return "", fmt.Errorf("post-auth hook failed: %w", err)
 		}
 	}
-	return store.Save(ctx, record)
+	savedPath, err := store.Save(ctx, record)
+	if err != nil {
+		return "", err
+	}
+	if savedPath != "" {
+		if errRegister := h.registerAuthFromFile(ctx, savedPath, nil); errRegister != nil {
+			return "", errRegister
+		}
+	}
+	return savedPath, nil
 }
 
 func (h *Handler) RequestAnthropicToken(c *gin.Context) {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -247,6 +247,9 @@ func (h *Handler) ListAuthFiles(c *gin.Context) {
 		return
 	}
 	auths := h.authManager.List()
+	if shouldRescanAuthFiles(c) {
+		auths = h.rescanAuthFiles(c.Request.Context())
+	}
 	files := make([]gin.H, 0, len(auths))
 	for _, auth := range auths {
 		if entry := h.buildAuthFileEntry(auth); entry != nil {
@@ -259,6 +262,51 @@ func (h *Handler) ListAuthFiles(c *gin.Context) {
 		return strings.ToLower(nameI) < strings.ToLower(nameJ)
 	})
 	c.JSON(200, gin.H{"files": files})
+}
+
+func shouldRescanAuthFiles(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	raw := strings.TrimSpace(c.Query("rescan"))
+	if raw == "" {
+		return false
+	}
+	switch strings.ToLower(raw) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *Handler) rescanAuthFiles(_ context.Context) []*coreauth.Auth {
+	if h == nil || h.cfg == nil {
+		return nil
+	}
+	entries, err := os.ReadDir(h.cfg.AuthDir)
+	if err != nil {
+		log.WithError(err).Warn("failed to rescan auth files from disk")
+		if h.authManager == nil {
+			return nil
+		}
+		return h.authManager.List()
+	}
+	out := make([]*coreauth.Auth, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".json") {
+			continue
+		}
+		path := filepath.Join(h.cfg.AuthDir, entry.Name())
+		auth, err := h.buildAuthFromFileData(path, nil)
+		if err != nil {
+			log.WithError(err).Warnf("failed to parse auth file during rescan: %s", entry.Name())
+			continue
+		}
+		out = append(out, auth)
+	}
+	log.Infof("rescanned auth files from disk: %d entries", len(out))
+	return out
 }
 
 // GetAuthFileModels returns the models supported by a specific auth file

--- a/internal/api/handlers/management/auth_files_delete_test.go
+++ b/internal/api/handlers/management/auth_files_delete_test.go
@@ -99,6 +99,43 @@ func TestDeleteAuthFile_UsesAuthPathFromManager(t *testing.T) {
 	}
 }
 
+func TestListAuthFiles_RescanRefreshesManagerFromDisk(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	fileName := "rescan-user.json"
+	filePath := filepath.Join(authDir, fileName)
+	if errWrite := os.WriteFile(filePath, []byte(`{"type":"codex","email":"rescan@example.com"}`), 0o600); errWrite != nil {
+		t.Fatalf("failed to write auth file: %v", errWrite)
+	}
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+
+	listRec := httptest.NewRecorder()
+	listCtx, _ := gin.CreateTestContext(listRec)
+	listReq := httptest.NewRequest(http.MethodGet, "/v0/management/auth-files?rescan=1", nil)
+	listCtx.Request = listReq
+
+	h.ListAuthFiles(listCtx)
+
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("expected list status %d, got %d with body %s", http.StatusOK, listRec.Code, listRec.Body.String())
+	}
+	var listPayload map[string]any
+	if errUnmarshal := json.Unmarshal(listRec.Body.Bytes(), &listPayload); errUnmarshal != nil {
+		t.Fatalf("failed to decode list payload: %v", errUnmarshal)
+	}
+	filesRaw, ok := listPayload["files"].([]any)
+	if !ok {
+		t.Fatalf("expected files array, payload: %#v", listPayload)
+	}
+	if len(filesRaw) != 1 {
+		t.Fatalf("expected 1 file after rescan, got %d", len(filesRaw))
+	}
+}
+
 func TestDeleteAuthFile_FallbackToAuthDirPath(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "")
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
## Background                                                                                                                                                                         
  - on macOS, Docker bind mounts may prevent auth file watcher updates from being observed reliably                                                                                     
  - this can leave auth files present on disk while the in-memory manager state lags behind                                                                                                                                                            
  ## Summary                                                                                                                                                                            
  - register saved auth files with the manager immediately after `saveTokenRecord` succeeds
  - add a `rescan=1` option for `ListAuthFiles` to read auth entries directly from disk when the manager has not caught up yet
  - add tests for the rescan listing flow    