### PR TITLE
feat(openai-compat): add configurable endpoint routing for providers

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -224,6 +224,7 @@ nonstream-keepalive-interval: 0
 #   - name: "openrouter" # The name of the provider; it will be used in the user agent and other places.
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
+#     endpoint-mode: "auto" # optional override: leave empty to keep provider default/legacy behavior; use auto | chat-completions | responses to force routing
 #     headers:
 #       X-Custom-Header: "custom-value"
 #     api-key-entries:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -508,6 +508,11 @@ type OpenAICompatibility struct {
 	// BaseURL is the base URL for the external OpenAI-compatible API endpoint.
 	BaseURL string `yaml:"base-url" json:"base-url"`
 
+	// EndpointMode controls which upstream endpoint family is used.
+	// Supported values: "auto", "chat-completions", "responses".
+	// When empty, it defaults to "auto".
+	EndpointMode string `yaml:"endpoint-mode,omitempty" json:"endpoint-mode,omitempty"`
+
 	// APIKeyEntries defines API keys with optional per-key proxy configuration.
 	APIKeyEntries []OpenAICompatibilityAPIKey `yaml:"api-key-entries,omitempty" json:"api-key-entries,omitempty"`
 
@@ -831,6 +836,7 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 		e.Name = strings.TrimSpace(e.Name)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.EndpointMode = normalizeOpenAICompatibilityEndpointMode(e.EndpointMode)
 		e.Headers = NormalizeHeaders(e.Headers)
 		if e.BaseURL == "" {
 			// Skip providers with no base-url; treated as removed
@@ -839,6 +845,21 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 		out = append(out, e)
 	}
 	cfg.OpenAICompatibility = out
+}
+
+func normalizeOpenAICompatibilityEndpointMode(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "default", "legacy", "provider-default", "upstream":
+		return ""
+	case "auto":
+		return "auto"
+	case "chat-completions":
+		return "chat-completions"
+	case "responses":
+		return "responses"
+	default:
+		return ""
+	}
 }
 
 // SanitizeCodexKeys removes Codex API key entries missing a BaseURL.

--- a/internal/config/openai_compat_endpoint_mode_test.go
+++ b/internal/config/openai_compat_endpoint_mode_test.go
@@ -1,0 +1,37 @@
+package config
+
+import "testing"
+
+func TestSanitizeOpenAICompatibility_NormalizesEndpointMode(t *testing.T) {
+	cfg := &Config{
+		OpenAICompatibility: []OpenAICompatibility{
+			{
+				Name:         "provider-a",
+				BaseURL:      "https://example.com/v1",
+				EndpointMode: " RESPONSES ",
+			},
+			{
+				Name:         "provider-b",
+				BaseURL:      "https://example.com/v2",
+				EndpointMode: "unexpected",
+			},
+			{
+				Name:         "provider-c",
+				BaseURL:      "https://example.com/v3",
+				EndpointMode: " upstream ",
+			},
+		},
+	}
+
+	cfg.SanitizeOpenAICompatibility()
+
+	if got := cfg.OpenAICompatibility[0].EndpointMode; got != "responses" {
+		t.Fatalf("endpoint mode = %q, want %q", got, "responses")
+	}
+	if got := cfg.OpenAICompatibility[1].EndpointMode; got != "" {
+		t.Fatalf("endpoint mode = %q, want empty default mode", got)
+	}
+	if got := cfg.OpenAICompatibility[2].EndpointMode; got != "" {
+		t.Fatalf("endpoint mode = %q, want empty default mode", got)
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -29,6 +29,18 @@ type OpenAICompatExecutor struct {
 	cfg      *config.Config
 }
 
+const (
+	openAICompatEndpointModeDefault         = ""
+	openAICompatEndpointModeAuto            = "auto"
+	openAICompatEndpointModeChatCompletions = "chat-completions"
+	openAICompatEndpointModeResponses       = "responses"
+)
+
+type openAICompatEndpoint struct {
+	format sdktranslator.Format
+	path   string
+}
+
 // NewOpenAICompatExecutor creates an executor bound to a provider key (e.g., "openrouter").
 func NewOpenAICompatExecutor(provider string, cfg *config.Config) *OpenAICompatExecutor {
 	return &OpenAICompatExecutor{provider: provider, cfg: cfg}
@@ -83,12 +95,9 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	}
 
 	from := opts.SourceFormat
-	to := sdktranslator.FromString("openai")
-	endpoint := "/chat/completions"
-	if opts.Alt == "responses/compact" {
-		to = sdktranslator.FromString("openai-response")
-		endpoint = "/responses/compact"
-	}
+	upstream := e.resolveUpstreamEndpoint(auth, from, opts.Alt)
+	to := upstream.format
+	endpoint := upstream.path
 	originalPayloadSource := req.Payload
 	if len(opts.OriginalRequest) > 0 {
 		originalPayloadSource = opts.OriginalRequest
@@ -190,7 +199,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	}
 
 	from := opts.SourceFormat
-	to := sdktranslator.FromString("openai")
+	upstream := e.resolveUpstreamEndpoint(auth, from, opts.Alt)
+	to := upstream.format
+	endpoint := upstream.path
 	originalPayloadSource := req.Payload
 	if len(opts.OriginalRequest) > 0 {
 		originalPayloadSource = opts.OriginalRequest
@@ -206,11 +217,12 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		return nil, err
 	}
 
-	// Request usage data in the final streaming chunk so that token statistics
-	// are captured even when the upstream is an OpenAI-compatible provider.
-	translated, _ = sjson.SetBytes(translated, "stream_options.include_usage", true)
+	// Request usage data in the final streaming chunk for chat completions upstreams.
+	if endpoint == "/chat/completions" {
+		translated, _ = sjson.SetBytes(translated, "stream_options.include_usage", true)
+	}
 
-	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	url := strings.TrimSuffix(baseURL, "/") + endpoint
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
 	if err != nil {
 		return nil, err
@@ -273,11 +285,28 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
+		passthroughResponses := to == sdktranslator.FormatOpenAIResponse && from == sdktranslator.FormatOpenAIResponse && endpoint == "/responses"
+		var frame []byte
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			if detail, ok := helps.ParseOpenAIStreamUsage(line); ok {
 				reporter.Publish(ctx, detail)
+			}
+			if passthroughResponses {
+				line = bytes.TrimRight(line, "\r")
+				if len(line) == 0 {
+					if len(frame) > 0 {
+						out <- cliproxyexecutor.StreamChunk{Payload: bytes.Clone(frame)}
+						frame = frame[:0]
+					}
+					continue
+				}
+				if len(frame) > 0 {
+					frame = append(frame, '\n')
+				}
+				frame = append(frame, line...)
+				continue
 			}
 			if len(line) == 0 {
 				continue
@@ -293,6 +322,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			for i := range chunks {
 				out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}
 			}
+		}
+		if passthroughResponses && len(frame) > 0 {
+			out <- cliproxyexecutor.StreamChunk{Payload: bytes.Clone(frame)}
 		}
 		if errScan := scanner.Err(); errScan != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
@@ -385,6 +417,61 @@ func (e *OpenAICompatExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *con
 		}
 	}
 	return nil
+}
+
+func (e *OpenAICompatExecutor) resolveUpstreamEndpoint(auth *cliproxyauth.Auth, from sdktranslator.Format, alt string) openAICompatEndpoint {
+	if alt == "responses/compact" {
+		return openAICompatEndpoint{
+			format: sdktranslator.FormatOpenAIResponse,
+			path:   "/responses/compact",
+		}
+	}
+
+	mode := openAICompatEndpointModeAuto
+	if compat := e.resolveCompatConfig(auth); compat != nil {
+		mode = normalizeOpenAICompatEndpointMode(compat.EndpointMode)
+	}
+	if mode == openAICompatEndpointModeDefault {
+		return openAICompatEndpoint{
+			format: sdktranslator.FormatOpenAI,
+			path:   "/chat/completions",
+		}
+	}
+
+	switch mode {
+	case openAICompatEndpointModeResponses:
+		return openAICompatEndpoint{
+			format: sdktranslator.FormatOpenAIResponse,
+			path:   "/responses",
+		}
+	case openAICompatEndpointModeAuto:
+		if from == sdktranslator.FormatOpenAIResponse {
+			return openAICompatEndpoint{
+				format: sdktranslator.FormatOpenAIResponse,
+				path:   "/responses",
+			}
+		}
+	}
+
+	return openAICompatEndpoint{
+		format: sdktranslator.FormatOpenAI,
+		path:   "/chat/completions",
+	}
+}
+
+func normalizeOpenAICompatEndpointMode(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "default", "legacy", "provider-default", "upstream":
+		return openAICompatEndpointModeDefault
+	case openAICompatEndpointModeAuto:
+		return openAICompatEndpointModeAuto
+	case openAICompatEndpointModeChatCompletions:
+		return openAICompatEndpointModeChatCompletions
+	case openAICompatEndpointModeResponses:
+		return openAICompatEndpointModeResponses
+	default:
+		return openAICompatEndpointModeDefault
+	}
 }
 
 func (e *OpenAICompatExecutor) overrideModel(payload []byte, model string) []byte {

--- a/internal/runtime/executor/openai_compat_executor_endpoint_test.go
+++ b/internal/runtime/executor/openai_compat_executor_endpoint_test.go
@@ -1,0 +1,287 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAICompatExecutor_AutoUsesResponsesEndpointForResponsesRequests(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openrouter", &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:         "openrouter",
+			BaseURL:      server.URL + "/v1",
+			EndpointMode: "auto",
+		}},
+	})
+	auth := &cliproxyauth.Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"base_url":     server.URL + "/v1",
+			"api_key":      "test",
+			"compat_name":  "openrouter",
+			"provider_key": "openrouter",
+		},
+	}
+	payload := []byte(`{"model":"gpt-5","input":[{"role":"user","content":"hi"}]}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want %q", gotPath, "/v1/responses")
+	}
+	if !gjson.GetBytes(gotBody, "input").Exists() {
+		t.Fatalf("expected responses payload to keep input field")
+	}
+	if gjson.GetBytes(gotBody, "messages").Exists() {
+		t.Fatalf("unexpected chat completions messages field in responses payload")
+	}
+	if string(resp.Payload) != `{"id":"resp_1","object":"response","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}` {
+		t.Fatalf("payload = %s", string(resp.Payload))
+	}
+}
+
+func TestOpenAICompatExecutor_DefaultModeKeepsLegacyChatCompletionsRouting(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","created":1,"model":"gpt-5","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openrouter", &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:    "openrouter",
+			BaseURL: server.URL + "/v1",
+		}},
+	})
+	auth := &cliproxyauth.Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"base_url":     server.URL + "/v1",
+			"api_key":      "test",
+			"compat_name":  "openrouter",
+			"provider_key": "openrouter",
+		},
+	}
+	payload := []byte(`{"model":"gpt-5","input":[{"role":"user","content":"hi"}]}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Fatalf("path = %q, want %q", gotPath, "/v1/chat/completions")
+	}
+	if !gjson.GetBytes(gotBody, "messages").Exists() {
+		t.Fatalf("expected legacy chat completions payload to include messages")
+	}
+	if gotObject := gjson.GetBytes(resp.Payload, "object").String(); gotObject != "response" {
+		t.Fatalf("response object = %q, want %q", gotObject, "response")
+	}
+}
+
+func TestOpenAICompatExecutor_ChatCompletionsOverrideTranslatesResponsesRequests(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","created":1,"model":"gpt-5","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openrouter", &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:         "openrouter",
+			BaseURL:      server.URL + "/v1",
+			EndpointMode: "chat-completions",
+		}},
+	})
+	auth := &cliproxyauth.Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"base_url":     server.URL + "/v1",
+			"api_key":      "test",
+			"compat_name":  "openrouter",
+			"provider_key": "openrouter",
+		},
+	}
+	payload := []byte(`{"model":"gpt-5","input":[{"role":"user","content":"hi"}]}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Fatalf("path = %q, want %q", gotPath, "/v1/chat/completions")
+	}
+	if !gjson.GetBytes(gotBody, "messages").Exists() {
+		t.Fatalf("expected chat completions payload to include messages")
+	}
+	if gjson.GetBytes(gotBody, "input").Exists() {
+		t.Fatalf("unexpected responses input field in chat completions payload")
+	}
+	if gotObject := gjson.GetBytes(resp.Payload, "object").String(); gotObject != "response" {
+		t.Fatalf("response object = %q, want %q", gotObject, "response")
+	}
+}
+
+func TestOpenAICompatExecutor_ResponsesOverrideTranslatesChatRequests(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","output":[{"type":"message","id":"msg_1","status":"completed","role":"assistant","content":[{"type":"output_text","text":"ok","annotations":[]}]}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openrouter", &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:         "openrouter",
+			BaseURL:      server.URL + "/v1",
+			EndpointMode: "responses",
+		}},
+	})
+	auth := &cliproxyauth.Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"base_url":     server.URL + "/v1",
+			"api_key":      "test",
+			"compat_name":  "openrouter",
+			"provider_key": "openrouter",
+		},
+	}
+	payload := []byte(`{"model":"gpt-5","messages":[{"role":"user","content":"hi"}]}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAI,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want %q", gotPath, "/v1/responses")
+	}
+	if !gjson.GetBytes(gotBody, "input").Exists() {
+		t.Fatalf("expected responses payload to include input")
+	}
+	if gjson.GetBytes(gotBody, "messages").Exists() {
+		t.Fatalf("unexpected chat completions messages field in responses payload")
+	}
+	if gotObject := gjson.GetBytes(resp.Payload, "object").String(); gotObject != "chat.completion" {
+		t.Fatalf("response object = %q, want %q", gotObject, "chat.completion")
+	}
+}
+
+func TestOpenAICompatExecutor_StreamResponsesPassthroughPreservesEvents(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.created\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.completed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\"},\"usage\":{\"input_tokens\":1,\"output_tokens\":2,\"total_tokens\":3}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openrouter", &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:         "openrouter",
+			BaseURL:      server.URL + "/v1",
+			EndpointMode: "auto",
+		}},
+	})
+	auth := &cliproxyauth.Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"base_url":     server.URL + "/v1",
+			"api_key":      "test",
+			"compat_name":  "openrouter",
+			"provider_key": "openrouter",
+		},
+	}
+	payload := []byte(`{"model":"gpt-5","input":[{"role":"user","content":"hi"}],"stream":true}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want %q", gotPath, "/v1/responses")
+	}
+	if strings.Contains(string(gotBody), "stream_options") {
+		t.Fatalf("responses upstream request unexpectedly added chat-completions stream_options: %s", string(gotBody))
+	}
+
+	var chunks [][]byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		chunks = append(chunks, chunk.Payload)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("chunk count = %d, want %d", len(chunks), 2)
+	}
+	if got := string(chunks[0]); got != "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}" {
+		t.Fatalf("first chunk = %q", got)
+	}
+	if got := string(chunks[1]); got != "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\"},\"usage\":{\"input_tokens\":1,\"output_tokens\":2,\"total_tokens\":3}}" {
+		t.Fatalf("second chunk = %q", got)
+	}
+}

--- a/internal/watcher/diff/openai_compat.go
+++ b/internal/watcher/diff/openai_compat.go
@@ -142,6 +142,9 @@ func openAICompatSignature(entry config.OpenAICompatibility) string {
 	if v := strings.TrimSpace(entry.BaseURL); v != "" {
 		parts = append(parts, "base="+v)
 	}
+	if v := strings.TrimSpace(entry.EndpointMode); v != "" {
+		parts = append(parts, "endpoint_mode="+strings.ToLower(v))
+	}
 
 	models := make([]string, 0, len(entry.Models))
 	for _, model := range entry.Models {


### PR DESCRIPTION
## Summary
Adds support for configuring the upstream endpoint mode for OpenAI-compatible providers. This allows dynamic routing between `/chat/completions` and `/responses` based on configuration.

## Motivation
Some upstream providers use different endpoint families, such as OpenAI Responses API (`/v1/responses`) versus the standard Chat Completions API (`/v1/chat/completions`). Previously, the endpoint was hardcoded or determined solely by the incoming request format. This change gives users explicit control over which endpoint family to use.

## Changes
- **New `endpoint-mode` config field**: Added to the `openai-compatibility` section to specify the upstream endpoint type.
- **Supported modes**:
  - `auto` (default): Selects the endpoint based on the incoming request format.
  - `chat-completions`: Forces routing to `/chat/completions`.
  - `responses`: Forces routing to `/responses`.
  - Empty: Falls back to legacy behavior.
- **Watcher support**: Added `endpoint-mode` to the config signature calculation so changes trigger a hot-reload.
- **Tests**: Added unit tests for configuration parsing and endpoint resolution logic.

## Configuration Example
```yaml
openai-compatibility:
  - name: my-provider
    base-url: https://api.example.com
    # Supported values: auto, chat-completions, responses
    endpoint-mode: auto
    api-key-entries:
      - key: sk-xxx
```