### PR TITLE
feat(models): add gemini-3.1-flash-lite to antigravity and remove deprecated 2.5 models

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2607,38 +2607,6 @@
       }
     },
     {
-      "id": "gemini-2.5-flash",
-      "object": "model",
-      "owned_by": "antigravity",
-      "type": "antigravity",
-      "display_name": "Gemini 2.5 Flash",
-      "name": "gemini-2.5-flash",
-      "description": "Gemini 2.5 Flash",
-      "context_length": 1048576,
-      "max_completion_tokens": 65535,
-      "thinking": {
-        "max": 24576,
-        "zero_allowed": true,
-        "dynamic_allowed": true
-      }
-    },
-    {
-      "id": "gemini-2.5-flash-lite",
-      "object": "model",
-      "owned_by": "antigravity",
-      "type": "antigravity",
-      "display_name": "Gemini 2.5 Flash Lite",
-      "name": "gemini-2.5-flash-lite",
-      "description": "Gemini 2.5 Flash Lite",
-      "context_length": 1048576,
-      "max_completion_tokens": 65535,
-      "thinking": {
-        "max": 24576,
-        "zero_allowed": true,
-        "dynamic_allowed": true
-      }
-    },
-    {
       "id": "gemini-3-flash",
       "object": "model",
       "owned_by": "antigravity",
@@ -2714,6 +2682,29 @@
         "dynamic_allowed": true,
         "levels": [
           "minimal",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "gemini-3.1-flash-lite",
+      "object": "model",
+      "owned_by": "antigravity",
+      "type": "antigravity",
+      "display_name": "Gemini 3.1 Flash Lite",
+      "name": "gemini-3.1-flash-lite",
+      "description": "Gemini 3.1 Flash Lite",
+      "context_length": 1048576,
+      "max_completion_tokens": 65535,
+      "thinking": {
+        "min": 1,
+        "max": 65535,
+        "zero_allowed": true,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
           "high"
         ]
       }


### PR DESCRIPTION
## Summary
- Add `gemini-3.1-flash-lite` to antigravity provider with verified thinking config (`min=1, max=65535, levels: minimal/low/medium/high`), tested against upstream API
- Remove deprecated `gemini-2.5-flash` and `gemini-2.5-flash-lite` from antigravity (upstream returns 429 quota exhausted, replaced by `gemini-3.1-flash-lite`)

## Test plan
- [x] Thinking budget boundary test via Gemini API: confirmed upstream range `[-1, 65535]`
- [x] Thinking levels test: `none`, `minimal`, `low`, `medium`, `high` all working
- [x] Context length test: 128K/256K/512K/900K tokens input all pass
- [x] E2E non-stream request via proxy: `gemini-3.1-flash-lite-preview` alias routes correctly
- [x] Compilation and unit tests pass