### PR TITLE
fix(openai-compat): ignore usage:null in stream token accounting

### DIFF
--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -242,17 +242,45 @@ func ParseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {
 	}
 	usageNode := gjson.GetBytes(payload, "usage")
 	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "response.usage")
+	}
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "data.usage")
+	}
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "result.usage")
+	}
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "message.usage")
+	}
+	if !usageNode.Exists() || usageNode.Type != gjson.JSON {
 		return usage.Detail{}, false
 	}
+	inputNode := usageNode.Get("prompt_tokens")
+	if !inputNode.Exists() {
+		inputNode = usageNode.Get("input_tokens")
+	}
+	outputNode := usageNode.Get("completion_tokens")
+	if !outputNode.Exists() {
+		outputNode = usageNode.Get("output_tokens")
+	}
 	detail := usage.Detail{
-		InputTokens:  usageNode.Get("prompt_tokens").Int(),
-		OutputTokens: usageNode.Get("completion_tokens").Int(),
+		InputTokens:  inputNode.Int(),
+		OutputTokens: outputNode.Int(),
 		TotalTokens:  usageNode.Get("total_tokens").Int(),
 	}
-	if cached := usageNode.Get("prompt_tokens_details.cached_tokens"); cached.Exists() {
+	cached := usageNode.Get("prompt_tokens_details.cached_tokens")
+	if !cached.Exists() {
+		cached = usageNode.Get("input_tokens_details.cached_tokens")
+	}
+	if cached.Exists() {
 		detail.CachedTokens = cached.Int()
 	}
-	if reasoning := usageNode.Get("completion_tokens_details.reasoning_tokens"); reasoning.Exists() {
+	reasoning := usageNode.Get("completion_tokens_details.reasoning_tokens")
+	if !reasoning.Exists() {
+		reasoning = usageNode.Get("output_tokens_details.reasoning_tokens")
+	}
+	if reasoning.Exists() {
 		detail.ReasoningTokens = reasoning.Int()
 	}
 	return detail, true

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -47,6 +47,60 @@ func TestParseOpenAIUsageResponses(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIStreamUsageChatCompletions(t *testing.T) {
+	line := []byte(`data: {"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3,"prompt_tokens_details":{"cached_tokens":4},"completion_tokens_details":{"reasoning_tokens":5}}}`)
+	detail, ok := ParseOpenAIStreamUsage(line)
+	if !ok {
+		t.Fatal("expected usage to be parsed")
+	}
+	if detail.InputTokens != 1 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 1)
+	}
+	if detail.OutputTokens != 2 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 2)
+	}
+	if detail.TotalTokens != 3 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 3)
+	}
+	if detail.CachedTokens != 4 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 4)
+	}
+	if detail.ReasoningTokens != 5 {
+		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 5)
+	}
+}
+
+func TestParseOpenAIStreamUsageResponses(t *testing.T) {
+	line := []byte(`data: {"usage":{"input_tokens":10,"output_tokens":20,"total_tokens":30,"input_tokens_details":{"cached_tokens":7},"output_tokens_details":{"reasoning_tokens":9}}}`)
+	detail, ok := ParseOpenAIStreamUsage(line)
+	if !ok {
+		t.Fatal("expected usage to be parsed")
+	}
+	if detail.InputTokens != 10 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 10)
+	}
+	if detail.OutputTokens != 20 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 20)
+	}
+	if detail.TotalTokens != 30 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 30)
+	}
+	if detail.CachedTokens != 7 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 7)
+	}
+	if detail.ReasoningTokens != 9 {
+		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 9)
+	}
+}
+
+func TestParseOpenAIStreamUsageNullUsageIgnored(t *testing.T) {
+	line := []byte(`data: {"choices":[{"delta":{"content":"hi"}}],"usage":null}`)
+	_, ok := ParseOpenAIStreamUsage(line)
+	if ok {
+		t.Fatal("expected usage:null chunk to be ignored")
+	}
+}
+
 func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 	reporter := &UsageReporter{
 		provider:    "openai",


### PR DESCRIPTION
## Summary
- Fix OpenAI-compatible stream usage parsing to ignore `usage:null` chunks.
- Add stream parser fallbacks for wrapped usage paths and response-style token fields.
- Add regression tests for chat/responses usage and `usage:null` case.

## Root Cause
Upstream streaming responses often include many chunks with `usage:null` before the final chunk that contains real usage.
The previous parser treated `usage:null` as valid usage and published zero tokens early.
Because usage publishing is once-only, later real usage was ignored, so management usage stayed `0`.

## Changes
- Only parse usage when the usage node is a JSON object.
- Keep compatibility for both token field styles:
  - `prompt_tokens` / `completion_tokens`
  - `input_tokens` / `output_tokens`
- Add fallback parsing for wrapped paths:
  - `usage`
  - `response.usage`
  - `data.usage`
  - `result.usage`
  - `message.usage`

## Tests
- Added parser tests for:
  - OpenAI chat-completions style stream usage
  - OpenAI responses style stream usage
  - `usage:null` stream chunk ignored behavior

## Validation
- `go test ./internal/runtime/executor/helps -run 'ParseOpenAI(Stream)?Usage|NullUsage' -v`
- `go build -o test-output ./cmd/server && rm test-output`
- Local end-to-end reproduction (dashscope OpenAI-compatible):
  - final stream chunk contains non-zero usage
  - management usage changes from `0` to non-zero after fix