### PR TITLE
fix(antigravity): use E-prefixed fake signature in strict bypass test

### DIFF
--- a/internal/runtime/executor/antigravity_executor_signature_test.go
+++ b/internal/runtime/executor/antigravity_executor_signature_test.go
@@ -21,6 +21,14 @@ func testGeminiSignaturePayload() string {
 	return base64.StdEncoding.EncodeToString(payload)
 }
 
+// testFakeClaudeSignature returns a base64 string starting with 'E' that passes
+// the lightweight hasValidClaudeSignature check but has invalid protobuf content
+// (first decoded byte 0x12 is correct, but no valid protobuf field 2 follows),
+// so it fails deep validation in strict mode.
+func testFakeClaudeSignature() string {
+	return base64.StdEncoding.EncodeToString([]byte{0x12, 0xFF, 0xFE, 0xFD})
+}
+
 func testAntigravityAuth(baseURL string) *cliproxyauth.Auth {
 	return &cliproxyauth.Auth{
 		Attributes: map[string]string{
@@ -40,7 +48,7 @@ func invalidClaudeThinkingPayload() []byte {
 			{
 				"role": "assistant",
 				"content": [
-					{"type": "thinking", "thinking": "bad", "signature": "` + testGeminiSignaturePayload() + `"},
+					{"type": "thinking", "thinking": "bad", "signature": "` + testFakeClaudeSignature() + `"},
 					{"type": "text", "text": "hello"}
 				]
 			}


### PR DESCRIPTION
## Summary
- Fix `TestAntigravityExecutor_StrictBypassRejectsInvalidSignature` test failure caused by `StripInvalidSignatureThinkingBlocks` stripping non-E/R signatures before strict mode validation runs
- Replace `testGeminiSignaturePayload()` (produces `C`-prefixed base64, stripped by lightweight check) with `testFakeClaudeSignature()` (produces `E`-prefixed base64 with invalid protobuf content) so the payload survives strip and correctly fails deep validation in strict mode

## Context
After #2715, `StripInvalidSignatureThinkingBlocks` strips all thinking blocks whose signatures don't start with `E` or `R`. The existing strict mode test used a Gemini-format signature (`C`-prefixed) which got stripped before reaching `ValidateClaudeBypassSignatures`, making the test pass the request through to upstream instead of rejecting with 400.

The three validation layers are:
1. **Strip** (unconditional): remove non-Claude-format signatures (not E/R)
2. **Normalize** (bypass mode): base64 decode + first-byte `0x12` check
3. **Inspect** (strict only): full protobuf field structure validation

The test now correctly exercises layers 1→3: the `E`-prefixed fake signature passes layer 1 but fails at layer 2 (no valid protobuf field 2).

## Test plan
- [x] `TestAntigravityExecutor_StrictBypassRejectsInvalidSignature` — now correctly rejects with 400
- [x] `TestAntigravityExecutor_NonStrictBypassSkipsPrecheck` — still passes
- [x] `TestAntigravityExecutor_CacheModeSkipsPrecheck` — still passes