### PR TITLE
fix(translator): map OpenAI Responses developer-role input to Gemini legally

### DIFF
--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -118,7 +118,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 
 			switch itemType {
 			case "message":
-				if strings.EqualFold(itemRole, "system") {
+				if strings.EqualFold(itemRole, "system") || strings.EqualFold(itemRole, "developer"){
 					if contentArray := item.Get("content"); contentArray.Exists() {
 						systemInstr := []byte(`{"parts":[]}`)
 						if systemInstructionResult := gjson.GetBytes(out, "systemInstruction"); systemInstructionResult.Exists() {

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -118,7 +118,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 
 			switch itemType {
 			case "message":
-				if strings.EqualFold(itemRole, "system") || strings.EqualFold(itemRole, "developer"){
+				if strings.EqualFold(itemRole, "system") || strings.EqualFold(itemRole, "developer") {
 					if contentArray := item.Get("content"); contentArray.Exists() {
 						systemInstr := []byte(`{"parts":[]}`)
 						if systemInstructionResult := gjson.GetBytes(out, "systemInstruction"); systemInstructionResult.Exists() {


### PR DESCRIPTION
## What Changed

- map OpenAI Responses `input[].role == "developer"` to Gemini `systemInstruction`
- keep regular user input in `contents`

## Why

Gemini request messages only support `user` and `model` roles.
The Responses translator previously treated `system` as instruction-level input but let `developer` fall through as a normal message role, which could produce invalid Gemini payloads and fail requests.

## Impact

Resolve Issue #2791.
OpenAI-compatible clients that send `developer` messages through the Responses API path can now be translated to Gemini reliably, with developer guidance preserved in `systemInstruction`.

## Validation

Run a simple test with no error.
```bash
curl --noproxy '*' --http1.1 -i http://127.0.0.1:8317/v1/responses \
    -H 'Content-Type: application/json' \
    -H 'Authorization: Bearer $KEY' \ 
    -d '{
      "stream": true,
      "temperature": 1,
      "top_p": 1,
      "model": "gpt-5.4",
      "input": [
        {
          "content": "You are Lobe, an AI Agent will help users.\n\nCurrent model: gpt-5.4\nToday's date: 2026/4/15\n\nYour role is to:\n- Answer questions accurately and helpfully\n- Assist with a wide variety of tasks\n- Provide clear and concise explanations\n- Be friendly and professional in your responses\n\nRespond in the same language the user is using.\n\nPreferred reply language: zh-CN. Use this language unless the user explicitly asks to switch.",
          "role": "developer"
        },
        {
          "content": "Hello! Who are you?",
          "role": "user"
        }
      ],
      "store": false
      ]
    }'
```
