### PR TITLE
fix(antigravity): cap maxOutputTokens using registry max_completion_tokens

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	antigravityclaude "github.com/router-for-me/CLIProxyAPI/v6/internal/translator/antigravity/claude"
@@ -1954,6 +1955,15 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	}
 	payload = geminiToAntigravity(modelName, payload, projectID)
 	payload, _ = sjson.SetBytes(payload, "model", modelName)
+
+	// Cap maxOutputTokens to model's max_completion_tokens from registry
+	if maxOut := gjson.GetBytes(payload, "request.generationConfig.maxOutputTokens"); maxOut.Exists() && maxOut.Type == gjson.Number {
+		if modelInfo := registry.LookupModelInfo(modelName, "antigravity"); modelInfo != nil && modelInfo.MaxCompletionTokens > 0 {
+			if int(maxOut.Int()) > modelInfo.MaxCompletionTokens {
+				payload, _ = sjson.SetBytes(payload, "request.generationConfig.maxOutputTokens", modelInfo.MaxCompletionTokens)
+			}
+		}
+	}
 
 	useAntigravitySchema := strings.Contains(modelName, "claude") || strings.Contains(modelName, "gemini-3-pro") || strings.Contains(modelName, "gemini-3.1-pro")
 	var (


### PR DESCRIPTION
## Summary
- Claude models on antigravity have a 64000 token output limit (`max_completion_tokens` in models.json), but `max_tokens` from downstream Anthropic API requests was passed through to `maxOutputTokens` uncapped
- When clients (e.g. Cherry Studio) send `max_tokens: 128000`, Google returns `400 INVALID_ARGUMENT`
- Added a cap in `buildRequest` that checks the model's `MaxCompletionTokens` from the registry and clamps `maxOutputTokens` accordingly

## Test plan
- [x] Send a Claude request via antigravity with `max_tokens: 128000` — should be capped to 64000
- [x] Send a Claude request with `max_tokens: 32000` — should pass through unchanged
- [x] Non-Claude models should be unaffected (their `maxOutputTokens` is already deleted in `buildRequest`)