### PR TITLE
fix(antigravity): strip billing header from system instruction before upstream call

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -101,6 +101,9 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 			systemTypePromptResult := systemPromptResult.Get("type")
 			if systemTypePromptResult.Type == gjson.String && systemTypePromptResult.String() == "text" {
 				systemPrompt := systemPromptResult.Get("text").String()
+				if strings.HasPrefix(systemPrompt, "x-anthropic-billing-header:") {
+					continue
+				}
 				partJSON := []byte(`{}`)
 				if systemPrompt != "" {
 					partJSON, _ = sjson.SetBytes(partJSON, "text", systemPrompt)


### PR DESCRIPTION
## Summary
- Strip `x-anthropic-billing-header` block from the Claude system array before forwarding to Gemini upstream
- This block is client-internal metadata and should not be included in `systemInstruction.parts`

## Test plan
- [ ] Verify requests with billing header in system instruction no longer forward it upstream
- [ ] Verify normal system instructions are unaffected