### PR TITLE
Fix: payload override parameters being ignored and reasoning content being dropped

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -97,16 +97,18 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, opts.Stream)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, opts.Stream)
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+
+	// Apply thinking configuration first, then apply payload config overrides on top.
+	// This ensures payload.override params always take precedence.
+	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return resp, err
+	}
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", translated, originalTranslated, requestedModel)
 	if opts.Alt == "responses/compact" {
 		if updated, errDelete := sjson.DeleteBytes(translated, "stream"); errDelete == nil {
 			translated = updated
 		}
-	}
-
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
-	if err != nil {
-		return resp, err
 	}
 
 	url := strings.TrimSuffix(baseURL, "/") + endpoint
@@ -199,12 +201,14 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
-	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", translated, originalTranslated, requestedModel)
 
+	// Apply thinking configuration first, then apply payload config overrides on top.
+	// This ensures payload.override params always take precedence.
 	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
+	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", translated, originalTranslated, requestedModel)
 
 	// Request usage data in the final streaming chunk so that token statistics
 	// are captured even when the upstream is an OpenAI-compatible provider.

--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -158,8 +158,8 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 			// Don't send content_block_start for text here - wait for actual content
 		}
 
-		// Handle reasoning content delta
-		if reasoning := delta.Get("reasoning_content"); reasoning.Exists() {
+		// Handle reasoning content delta.
+		if reasoning := getOpenAIReasoning(delta); reasoning.Exists() {
 			for _, reasoningText := range collectOpenAIReasoningTexts(reasoning) {
 				if reasoningText == "" {
 					continue
@@ -397,7 +397,7 @@ func convertOpenAINonStreamingToAnthropic(rawJSON []byte) [][]byte {
 	if choices := root.Get("choices"); choices.Exists() && choices.IsArray() && len(choices.Array()) > 0 {
 		choice := choices.Array()[0] // Take first choice
 
-		reasoningNode := choice.Get("message.reasoning_content")
+		reasoningNode := getOpenAIReasoning(choice.Get("message"))
 		for _, reasoningText := range collectOpenAIReasoningTexts(reasoningNode) {
 			if reasoningText == "" {
 				continue
@@ -483,6 +483,16 @@ func (p *ConvertOpenAIResponseToAnthropicParams) toolContentBlockIndex(openAIToo
 	p.NextContentBlockIndex++
 	p.ToolCallBlockIndexes[openAIToolIndex] = idx
 	return idx
+}
+
+// getOpenAIReasoning returns the reasoning field from a JSON object.
+// Checks "reasoning" first (OpenAI Chat Completions standard, AWS Bedrock),
+// then fallback to "reasoning_content" (third-party compat: DeepSeek/vLLM/LiteLLM).
+func getOpenAIReasoning(obj gjson.Result) gjson.Result {
+	if r := obj.Get("reasoning"); r.Exists() {
+		return r
+	}
+	return obj.Get("reasoning_content")
 }
 
 func collectOpenAIReasoningTexts(node gjson.Result) []string {
@@ -658,7 +668,7 @@ func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, origina
 				}
 			}
 
-			if reasoning := message.Get("reasoning_content"); reasoning.Exists() {
+			if reasoning := getOpenAIReasoning(message); reasoning.Exists() {
 				for _, reasoningText := range collectOpenAIReasoningTexts(reasoning) {
 					if reasoningText == "" {
 						continue


### PR DESCRIPTION
### 🐛 payload override 参数不生效

`ApplyThinking` 在 `ApplyPayloadConfigWithRoot` 之后执行，导致 `payload.override` 注入的参数（如 `reasoning_effort: "high"`、`include_reasoning: true`）被 thinking 模块覆盖而失效。

**修复** 🔄：交换调用顺序，`ApplyThinking` 先执行，`ApplyPayloadConfigWithRoot` 后执行，确保 payload override 的参数始终生效。

---

### 🐛 OpenAI reasoning 字段未解析

OpenAI → Claude 响应转译只处理 `reasoning_content` 字段，忽略了 OpenAI Chat Completions 标准的 `reasoning` 字段，导致 AWS Bedrock 等上游返回的思考内容被静默丢弃。

**修复** 🔧：新增 `getOpenAIReasoning` 辅助函数，优先取 `reasoning` 字段（OpenAI 标准），fallback 到 `reasoning_content`（DeepSeek / vLLM / LiteLLM 兼容字段）。
