### PR TITLE
fix(util): forward custom Host header to upstream

### DIFF
--- a/internal/util/header_helpers.go
+++ b/internal/util/header_helpers.go
@@ -47,13 +47,13 @@ func applyCustomHeaders(r *http.Request, headers map[string]string) {
 		if k == "" || v == "" {
 			continue
 		}
-		// Host is read from req.Host (not req.Header) by net/http when
-		// writing the request; setting it via Header.Set is silently
-		// dropped on the wire. Handle it explicitly so user-configured
-		// virtual-host overrides actually take effect upstream.
+		// net/http reads Host from req.Host (not req.Header) when writing
+		// a real request, so we must mirror it there. Some callers pass
+		// synthetic requests (e.g. &http.Request{Header: ...}) and only
+		// consume r.Header afterwards, so keep the value in the header
+		// map too.
 		if http.CanonicalHeaderKey(k) == "Host" {
 			r.Host = v
-			continue
 		}
 		r.Header.Set(k, v)
 	}

--- a/internal/util/header_helpers.go
+++ b/internal/util/header_helpers.go
@@ -47,6 +47,14 @@ func applyCustomHeaders(r *http.Request, headers map[string]string) {
 		if k == "" || v == "" {
 			continue
 		}
+		// Host is read from req.Host (not req.Header) by net/http when
+		// writing the request; setting it via Header.Set is silently
+		// dropped on the wire. Handle it explicitly so user-configured
+		// virtual-host overrides actually take effect upstream.
+		if http.CanonicalHeaderKey(k) == "Host" {
+			r.Host = v
+			continue
+		}
 		r.Header.Set(k, v)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #2833.

Custom headers configured under `openai-compatibility` (and any other provider
passing through `applyCustomHeaders`) were silently dropped for the `Host` key,
because Go's `net/http` reads the wire `Host` from `req.Host`, **not** from
`req.Header["Host"]`. As a result, virtual-host routed upstreams (e.g. LiteLLM
behind an ingress) saw the `base-url`'s host instead of the user-configured
override and replied `404`.

This patch detects the `Host` key with `http.CanonicalHeaderKey` and assigns it
to `req.Host` so it is actually written on the wire. Other headers continue to
use `Header.Set` as before.

## Diff

`internal/util/header_helpers.go`:

~~~go
for k, v := range headers {
    if k == "" || v == "" {
        continue
    }
    // Host is read from req.Host (not req.Header) by net/http when
    // writing the request; setting it via Header.Set is silently
    // dropped on the wire. Handle it explicitly so user-configured
    // virtual-host overrides actually take effect upstream.
    if http.CanonicalHeaderKey(k) == "Host" {
        r.Host = v
        continue
    }
    r.Header.Set(k, v)
}
~~~

## Why this helper

`applyCustomHeaders` is the single point that processes user-configured headers
for every provider (Claude / Codex / Gemini / OpenAI-compat — all four config
structs feed into it via `ApplyCustomHeadersFromAttrs`). Fixing it here repairs
the issue everywhere consistently. The pattern (`req.Host = v`) is already used
elsewhere in the codebase (`amp/proxy.go`, `management/api_tools.go`,
`antigravity_executor.go`), so the fix is consistent with existing conventions.

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./internal/util/` — clean
- [x] Manually verified with a LiteLLM upstream that requires a specific virtual
      `Host` header. Before the patch: cliproxy got `404 {"error_msg":"404 Route Not Found"}`
      and the model was suspended via cooldown. After the patch: requests succeed
      and chat completions return correctly.

## Compat / risk

- Behavior for any non-`Host` header is unchanged.
- For `Host` specifically, the previous behavior was a no-op (the header was
  dropped). The new behavior matches what the user configured. No existing
  config is affected unless it had a `Host` entry that was already broken.
