### PR TITLE
feat(registry): add claude-opus-4-7 to model registry

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -68,6 +68,7 @@
           "low",
           "medium",
           "high",
+          "xhigh",
           "max"
         ]
       }
@@ -90,6 +91,7 @@
           "low",
           "medium",
           "high",
+          "xhigh",
           "max"
         ]
       }

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -51,6 +51,50 @@
       }
     },
     {
+      "id": "claude-opus-4-7",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "anthropic",
+      "type": "claude",
+      "display_name": "Claude 4.7 Opus",
+      "description": "Premium model combining maximum intelligence with practical performance",
+      "context_length": 1000000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "max"
+        ]
+      }
+    },
+    {
+      "id": "claude-opus-4-7-20260416",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "anthropic",
+      "type": "claude",
+      "display_name": "Claude 4.7 Opus",
+      "description": "Premium model combining maximum intelligence with practical performance",
+      "context_length": 1000000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "max"
+        ]
+      }
+    },
+    {
       "id": "claude-opus-4-6",
       "object": "model",
       "created": 1770318000,
@@ -1839,6 +1883,23 @@
       "display_name": "Claude Opus 4.6 (Thinking)",
       "name": "claude-opus-4-6-thinking",
       "description": "Claude Opus 4.6 (Thinking)",
+      "context_length": 200000,
+      "max_completion_tokens": 64000,
+      "thinking": {
+        "min": 1024,
+        "max": 64000,
+        "zero_allowed": true,
+        "dynamic_allowed": true
+      }
+    },
+    {
+      "id": "claude-opus-4-7-thinking",
+      "object": "model",
+      "owned_by": "antigravity",
+      "type": "antigravity",
+      "display_name": "Claude Opus 4.7 (Thinking)",
+      "name": "claude-opus-4-7-thinking",
+      "description": "Claude Opus 4.7 (Thinking)",
       "context_length": 200000,
       "max_completion_tokens": 64000,
       "thinking": {

--- a/internal/util/claude_model_test.go
+++ b/internal/util/claude_model_test.go
@@ -12,6 +12,7 @@ func TestIsClaudeThinkingModel(t *testing.T) {
 		{"claude-sonnet-4-5-thinking", "claude-sonnet-4-5-thinking", true},
 		{"claude-opus-4-5-thinking", "claude-opus-4-5-thinking", true},
 		{"claude-opus-4-6-thinking", "claude-opus-4-6-thinking", true},
+		{"claude-opus-4-7-thinking", "claude-opus-4-7-thinking", true},
 		{"Claude-Sonnet-Thinking uppercase", "Claude-Sonnet-4-5-Thinking", true},
 		{"claude thinking mixed case", "Claude-THINKING-Model", true},
 


### PR DESCRIPTION
Closes #2837

Add Claude Opus 4.7 (released 2026-04-16) to the static model registry:
- `claude-opus-4-7`
- `claude-opus-4-7-20260416` (dated alias)
- `claude-opus-4-7-thinking` (antigravity)

Model specs:
- Context window: 1M tokens
- Max completion tokens: 128000
- Thinking support: enabled with low/medium/high/max levels
- Created timestamp: 1744761600