### PR TITLE
feat(antigravity): deferred credits activation with pool-based gating

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -99,6 +99,7 @@ quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
   antigravity-credits: true # Whether to retry Antigravity quota_exhausted 429s once with enabledCreditTypes=["GOOGLE_ONE_AI"]
+  antigravity-credits-threshold: 0 # Pool exhaustion ratio before activating credits (0=immediate, 0.8=80% exhausted, 1.0=all exhausted)
 
 # Routing strategy for selecting credentials when multiple match.
 routing:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,15 @@ type Config struct {
 	// MaxRetryInterval defines the maximum wait time in seconds before retrying a cooled-down credential.
 	MaxRetryInterval int `yaml:"max-retry-interval" json:"max-retry-interval"`
 
+	// TTFTTimeout defines the global Time-To-First-Token timeout for streaming requests, in seconds.
+	// If no first token (including thinking tokens) is received within this duration, the request
+	// is aborted and retried with a different credential/model. 0 = disabled (default).
+	TTFTTimeout int `yaml:"ttft-timeout" json:"ttft-timeout"`
+	// TTFTTimeoutModels provides per-model TTFT timeout overrides, in seconds.
+	// Keys are client-facing model names (the model name in the request, before alias resolution).
+	// Values override the global ttft-timeout for that specific model.
+	TTFTTimeoutModels map[string]int `yaml:"ttft-timeout-models,omitempty" json:"ttft-timeout-models,omitempty"`
+
 	// QuotaExceeded defines the behavior when a quota is exceeded.
 	QuotaExceeded QuotaExceeded `yaml:"quota-exceeded" json:"quota-exceeded"`
 
@@ -209,6 +218,12 @@ type QuotaExceeded struct {
 	// AntigravityCredits indicates whether to retry Antigravity quota_exhausted 429s once
 	// on the same credential with enabledCreditTypes=["GOOGLE_ONE_AI"].
 	AntigravityCredits bool `yaml:"antigravity-credits" json:"antigravity-credits"`
+
+	// AntigravityCreditsThreshold controls when credits are activated based on pool exhaustion ratio.
+	// 0 (default): activate credits on first QUOTA_EXHAUSTED (backward compatible).
+	// 0.8: only activate when 80% of known auths for the model are exhausted.
+	// 1.0: only activate when all known auths are exhausted.
+	AntigravityCreditsThreshold float64 `yaml:"antigravity-credits-threshold" json:"antigravity-credits-threshold"`
 }
 
 // RoutingConfig configures how credentials are selected for requests.

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -582,6 +582,13 @@ func markAntigravityCreditsPermanentlyDisabled(auth *cliproxyauth.Auth) {
 	auth.Metadata["min_credit_amount"] = "1"
 }
 
+func clearAntigravityCreditsPermanentlyDisabled(auth *cliproxyauth.Auth) {
+	if auth == nil || strings.TrimSpace(auth.ID) == "" {
+		return
+	}
+	antigravityCreditsFailureByAuth.Delete(strings.TrimSpace(auth.ID))
+}
+
 func antigravityHasExplicitCreditsBalanceExhaustedReason(body []byte) bool {
 	if len(body) == 0 {
 		return false
@@ -2125,6 +2132,9 @@ func (e *AntigravityExecutor) updateAntigravityCreditsBalance(ctx context.Contex
 		}
 		auth.Metadata["credit_amount"] = credit.Get("creditAmount").String()
 		auth.Metadata["min_credit_amount"] = credit.Get("minimumCreditAmountForUsage").String()
+		if antigravityAuthHasCredits(auth) {
+			clearAntigravityCreditsPermanentlyDisabled(auth)
+		}
 		return
 	}
 }

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -93,25 +94,178 @@ var (
 	antigravityCreditsFailureByAuth   sync.Map
 	antigravityPreferCreditsByModel   sync.Map
 	antigravityShortCooldownByAuth    sync.Map
+	antigravityModelPools             sync.Map // baseModel → *antigravityModelQuotaPool
 	antigravityQuotaExhaustedKeywords = []string{
 		"quota_exhausted",
 		"quota exhausted",
 	}
-	antigravityCreditsExhaustedKeywords = []string{
-		"google_one_ai",
-		"insufficient credit",
-		"insufficient credits",
-		"not enough credit",
-		"not enough credits",
-		"credit exhausted",
-		"credits exhausted",
-		"credit balance",
-		"minimumcreditamountforusage",
-		"minimum credit amount for usage",
-		"minimum credit",
-		"resource has been exhausted",
-	}
 )
+
+// antigravityModelQuotaPool tracks per-model quota exhaustion across auths.
+type antigravityModelQuotaPool struct {
+	mu          sync.RWMutex
+	seen        map[string]time.Time // auth.ID → last request time
+	exhausted   map[string]time.Time // auth.ID → quotaResetTimeStamp
+	cleanupMu   sync.Mutex
+	lastCleanup time.Time
+}
+
+func getAntigravityModelPool(baseModel string) *antigravityModelQuotaPool {
+	val, _ := antigravityModelPools.LoadOrStore(baseModel, &antigravityModelQuotaPool{
+		seen:      make(map[string]time.Time),
+		exhausted: make(map[string]time.Time),
+	})
+	return val.(*antigravityModelQuotaPool)
+}
+
+func (p *antigravityModelQuotaPool) markSeen(authID string, now time.Time) {
+	p.mu.Lock()
+	p.seen[authID] = now
+	p.mu.Unlock()
+}
+
+func (p *antigravityModelQuotaPool) markExhausted(authID string, quotaResetAt time.Time) {
+	p.mu.Lock()
+	p.exhausted[authID] = quotaResetAt
+	p.mu.Unlock()
+}
+
+func (p *antigravityModelQuotaPool) clearExhausted(authID string) {
+	p.mu.Lock()
+	delete(p.exhausted, authID)
+	p.mu.Unlock()
+}
+
+func (p *antigravityModelQuotaPool) shouldActivateCredits(threshold float64, minSampleSize int, now time.Time) bool {
+	p.maybeCleanup(now)
+	if threshold <= 0 || math.IsNaN(threshold) {
+		return true // threshold=0/NaN → backward compatible (current behavior)
+	}
+	if threshold > 1 {
+		threshold = 1
+	}
+	if minSampleSize < 3 {
+		minSampleSize = 3
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	var activeSeen, activeExhausted int
+	for authID, lastSeen := range p.seen {
+		if now.Sub(lastSeen) >= 12*time.Hour {
+			continue // stale entry
+		}
+		activeSeen++
+		if resetAt, ok := p.exhausted[authID]; ok && now.Before(resetAt) {
+			activeExhausted++
+		}
+	}
+	// Small pool exception: if all known auths are exhausted, activate credits
+	// even if sample size is below minimum (avoids dead-end with 1-2 auths).
+	if activeSeen > 0 && activeExhausted == activeSeen {
+		return true
+	}
+	if activeSeen < minSampleSize {
+		return false // insufficient sample
+	}
+	return float64(activeExhausted)/float64(activeSeen) >= threshold
+}
+
+func (p *antigravityModelQuotaPool) maybeCleanup(now time.Time) {
+	if !p.cleanupMu.TryLock() {
+		return
+	}
+	defer p.cleanupMu.Unlock()
+	if now.Sub(p.lastCleanup) < 5*time.Minute {
+		return
+	}
+	p.lastCleanup = now
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for authID, lastSeen := range p.seen {
+		if now.Sub(lastSeen) >= 12*time.Hour {
+			delete(p.seen, authID)
+			delete(p.exhausted, authID)
+		} else if resetAt, ok := p.exhausted[authID]; ok && now.After(resetAt) {
+			delete(p.exhausted, authID)
+		}
+	}
+}
+
+// parseQuotaResetTimestamp extracts the precise quotaResetTimeStamp from a 429 response body.
+func parseQuotaResetTimestamp(body []byte) (time.Time, bool) {
+	details := gjson.GetBytes(body, "error.details")
+	if !details.Exists() || !details.IsArray() {
+		return time.Time{}, false
+	}
+	for _, detail := range details.Array() {
+		if detail.Get("@type").String() != "type.googleapis.com/google.rpc.ErrorInfo" {
+			continue
+		}
+		ts := strings.TrimSpace(detail.Get("metadata.quotaResetTimeStamp").String())
+		if ts == "" {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// antigravityQuotaResetTime returns the best available quota reset time.
+// Fallback chain: quotaResetTimeStamp → now+retryDelay → now+5h.
+func antigravityQuotaResetTime(body []byte, retryAfter *time.Duration, now time.Time) time.Time {
+	if resetAt, ok := parseQuotaResetTimestamp(body); ok {
+		return resetAt
+	}
+	if retryAfter != nil && *retryAfter > 0 {
+		return now.Add(*retryAfter)
+	}
+	return now.Add(antigravityCreditsRetryTTL)
+}
+
+// antigravityAuthHasCredits checks whether the auth has sufficient credits balance.
+func antigravityAuthHasCredits(auth *cliproxyauth.Auth) bool {
+	if auth == nil || auth.Metadata == nil {
+		return true // no data → conservative pass (backward compatible)
+	}
+	creditAmount, ok1 := parseMetaFloat(auth.Metadata, "credit_amount")
+	minAmount, ok2 := parseMetaFloat(auth.Metadata, "min_credit_amount")
+	if !ok1 || !ok2 {
+		return true // missing fields → pass
+	}
+	return creditAmount >= minAmount
+}
+
+// parseMetaFloat extracts a float64 from auth.Metadata (handles string and numeric types).
+func parseMetaFloat(metadata map[string]any, key string) (float64, bool) {
+	v, ok := metadata[key]
+	if !ok {
+		return 0, false
+	}
+	switch typed := v.(type) {
+	case float64:
+		return typed, true
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case uint64:
+		return float64(typed), true
+	case json.Number:
+		if f, err := typed.Float64(); err == nil {
+			return f, true
+		}
+	case string:
+		if f, err := strconv.ParseFloat(strings.TrimSpace(typed), 64); err == nil {
+			return f, true
+		}
+	}
+	return 0, false
+}
 
 // AntigravityExecutor proxies requests to the antigravity upstream.
 type AntigravityExecutor struct {
@@ -349,28 +503,6 @@ func decideAntigravity429(body []byte) antigravity429Decision {
 	return decision
 }
 
-func antigravityHasQuotaResetDelayOrModelInfo(body []byte) bool {
-	if len(body) == 0 {
-		return false
-	}
-	details := gjson.GetBytes(body, "error.details")
-	if !details.Exists() || !details.IsArray() {
-		return false
-	}
-	for _, detail := range details.Array() {
-		if detail.Get("@type").String() != "type.googleapis.com/google.rpc.ErrorInfo" {
-			continue
-		}
-		if strings.TrimSpace(detail.Get("metadata.quotaResetDelay").String()) != "" {
-			return true
-		}
-		if strings.TrimSpace(detail.Get("metadata.model").String()) != "" {
-			return true
-		}
-	}
-	return false
-}
-
 func antigravityCreditsRetryEnabled(cfg *config.Config) bool {
 	return cfg != nil && cfg.QuotaExceeded.AntigravityCredits
 }
@@ -440,6 +572,14 @@ func markAntigravityCreditsPermanentlyDisabled(auth *cliproxyauth.Auth) {
 		ExplicitBalanceExhausted: true,
 	}
 	antigravityCreditsFailureByAuth.Store(authID, state)
+	// Update auth.Metadata so antigravityAuthHasCredits returns false immediately.
+	// Set both fields to ensure the ok1/ok2 check in antigravityAuthHasCredits passes
+	// even if min_credit_amount was never populated by updateAntigravityCreditsBalance.
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["credit_amount"] = "0"
+	auth.Metadata["min_credit_amount"] = "1"
 }
 
 func antigravityHasExplicitCreditsBalanceExhaustedReason(body []byte) bool {
@@ -495,14 +635,19 @@ func antigravityShouldPreferCredits(auth *cliproxyauth.Auth, modelName string, n
 	return true
 }
 
-func markAntigravityPreferCredits(auth *cliproxyauth.Auth, modelName string, now time.Time, retryAfter *time.Duration) {
+func markAntigravityPreferCredits(auth *cliproxyauth.Auth, modelName string, now time.Time, retryAfter *time.Duration, quotaResetAt time.Time) {
 	key := antigravityPreferCreditsKey(auth, modelName)
 	if key == "" {
 		return
 	}
-	until := now.Add(antigravityCreditsRetryTTL)
-	if retryAfter != nil && *retryAfter > 0 {
+	var until time.Time
+	switch {
+	case !quotaResetAt.IsZero():
+		until = quotaResetAt
+	case retryAfter != nil && *retryAfter > 0:
 		until = now.Add(*retryAfter)
+	default:
+		until = now.Add(antigravityCreditsRetryTTL)
 	}
 	antigravityPreferCreditsByModel.Store(key, until)
 }
@@ -513,28 +658,6 @@ func clearAntigravityPreferCredits(auth *cliproxyauth.Auth, modelName string) {
 		return
 	}
 	antigravityPreferCreditsByModel.Delete(key)
-}
-
-func shouldMarkAntigravityCreditsExhausted(statusCode int, body []byte, reqErr error) bool {
-	if reqErr != nil || statusCode == 0 {
-		return false
-	}
-	if statusCode >= http.StatusInternalServerError || statusCode == http.StatusRequestTimeout {
-		return false
-	}
-	lowerBody := strings.ToLower(string(body))
-	for _, keyword := range antigravityCreditsExhaustedKeywords {
-		if strings.Contains(lowerBody, keyword) {
-			if keyword == "resource has been exhausted" &&
-				statusCode == http.StatusTooManyRequests &&
-				decideAntigravity429(body).kind == antigravity429DecisionSoftRetry &&
-				!antigravityHasQuotaResetDelayOrModelInfo(body) {
-				return false
-			}
-			return true
-		}
-	}
-	return false
 }
 
 func newAntigravityStatusErr(statusCode int, body []byte) statusErr {
@@ -602,7 +725,8 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 	}
 	if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
 		retryAfter, _ := parseRetryDelay(originalBody)
-		markAntigravityPreferCredits(auth, modelName, now, retryAfter)
+		quotaResetAt := antigravityQuotaResetTime(originalBody, retryAfter, now)
+		markAntigravityPreferCredits(auth, modelName, now, retryAfter, quotaResetAt)
 		clearAntigravityCreditsFailureState(auth)
 		return httpResp, true
 	}
@@ -636,36 +760,6 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 	return nil, true
 }
 
-func (e *AntigravityExecutor) handleDirectCreditsFailure(ctx context.Context, auth *cliproxyauth.Auth, modelName string, reqErr error) {
-	if reqErr != nil {
-		if shouldForcePermanentDisableCredits(reqErrBody(reqErr)) {
-			clearAntigravityPreferCredits(auth, modelName)
-			markAntigravityCreditsPermanentlyDisabled(auth)
-			return
-		}
-
-		if antigravityHasExplicitCreditsBalanceExhaustedReason(reqErrBody(reqErr)) {
-			clearAntigravityPreferCredits(auth, modelName)
-			markAntigravityCreditsPermanentlyDisabled(auth)
-			return
-		}
-
-		helps.RecordAPIResponseError(ctx, e.cfg, reqErr)
-	}
-	clearAntigravityPreferCredits(auth, modelName)
-	recordAntigravityCreditsFailure(auth, time.Now())
-}
-func reqErrBody(reqErr error) []byte {
-	if reqErr == nil {
-		return nil
-	}
-	msg := reqErr.Error()
-	if strings.TrimSpace(msg) == "" {
-		return nil
-	}
-	return []byte(msg)
-}
-
 func shouldForcePermanentDisableCredits(body []byte) bool {
 	return antigravityHasExplicitCreditsBalanceExhaustedReason(body)
 }
@@ -676,6 +770,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	getAntigravityModelPool(baseModel).markSeen(auth.ID, time.Now())
 	if inCooldown, remaining := antigravityIsInShortCooldown(auth, baseModel, time.Now()); inCooldown {
 		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
@@ -724,6 +819,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 	attempts := antigravityRetryAttempts(auth, e.cfg)
+	pool := getAntigravityModelPool(baseModel)
 
 attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {
@@ -731,10 +827,14 @@ attemptLoop:
 		var lastBody []byte
 		var lastErr error
 
+		pool.markSeen(auth.ID, time.Now())
 		for idx, baseURL := range baseURLs {
 			requestPayload := translated
 			usedCreditsDirect := false
-			if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
+			if antigravityCreditsRetryEnabled(e.cfg) &&
+				antigravityShouldPreferCredits(auth, baseModel, time.Now()) &&
+				antigravityAuthHasCredits(auth) &&
+				pool.shouldActivateCredits(e.cfg.QuotaExceeded.AntigravityCreditsThreshold, e.cfg.MaxRetryCredentials, time.Now()) {
 				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
 					requestPayload = creditsPayload
 					usedCreditsDirect = true
@@ -797,10 +897,18 @@ attemptLoop:
 						log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown and skipping credits fallback", *decision.retryAfter, baseModel)
 					}
 				case antigravity429DecisionFullQuotaExhausted:
+					quotaResetAt := antigravityQuotaResetTime(bodyBytes, decision.retryAfter, time.Now())
+					pool.markExhausted(auth.ID, quotaResetAt)
 					if usedCreditsDirect {
 						clearAntigravityPreferCredits(auth, baseModel)
-						recordAntigravityCreditsFailure(auth, time.Now())
-					} else {
+						if antigravityHasExplicitCreditsBalanceExhaustedReason(bodyBytes) {
+							markAntigravityCreditsPermanentlyDisabled(auth)
+						} else {
+							recordAntigravityCreditsFailure(auth, time.Now())
+						}
+					} else if antigravityCreditsRetryEnabled(e.cfg) &&
+						antigravityAuthHasCredits(auth) &&
+						pool.shouldActivateCredits(e.cfg.QuotaExceeded.AntigravityCreditsThreshold, e.cfg.MaxRetryCredentials, time.Now()) {
 						creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, false, opts.Alt, baseURL, bodyBytes)
 						if creditsResp != nil {
 							helps.RecordAPIResponseMetadata(ctx, e.cfg, creditsResp.StatusCode, creditsResp.Header.Clone())
@@ -871,6 +979,9 @@ attemptLoop:
 			}
 
 			reporter.Publish(ctx, helps.ParseAntigravityUsage(bodyBytes))
+			if !usedCreditsDirect {
+				pool.clearExhausted(auth.ID)
+			}
 			var param any
 			converted := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, bodyBytes, &param)
 			resp = cliproxyexecutor.Response{Payload: converted, Headers: httpResp.Header.Clone()}
@@ -895,6 +1006,7 @@ attemptLoop:
 // executeClaudeNonStream performs a claude non-streaming request to the Antigravity API.
 func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	getAntigravityModelPool(baseModel).markSeen(auth.ID, time.Now())
 	if inCooldown, remaining := antigravityIsInShortCooldown(auth, baseModel, time.Now()); inCooldown {
 		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
@@ -939,6 +1051,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 
 	attempts := antigravityRetryAttempts(auth, e.cfg)
+	pool := getAntigravityModelPool(baseModel)
 
 attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {
@@ -946,10 +1059,14 @@ attemptLoop:
 		var lastBody []byte
 		var lastErr error
 
+		pool.markSeen(auth.ID, time.Now())
 		for idx, baseURL := range baseURLs {
 			requestPayload := translated
 			usedCreditsDirect := false
-			if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
+			if antigravityCreditsRetryEnabled(e.cfg) &&
+				antigravityShouldPreferCredits(auth, baseModel, time.Now()) &&
+				antigravityAuthHasCredits(auth) &&
+				pool.shouldActivateCredits(e.cfg.QuotaExceeded.AntigravityCreditsThreshold, e.cfg.MaxRetryCredentials, time.Now()) {
 				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
 					requestPayload = creditsPayload
 					usedCreditsDirect = true
@@ -1026,10 +1143,18 @@ attemptLoop:
 							log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown and skipping credits fallback", *decision.retryAfter, baseModel)
 						}
 					case antigravity429DecisionFullQuotaExhausted:
+						quotaResetAt := antigravityQuotaResetTime(bodyBytes, decision.retryAfter, time.Now())
+						pool.markExhausted(auth.ID, quotaResetAt)
 						if usedCreditsDirect {
 							clearAntigravityPreferCredits(auth, baseModel)
-							recordAntigravityCreditsFailure(auth, time.Now())
-						} else {
+							if antigravityHasExplicitCreditsBalanceExhaustedReason(bodyBytes) {
+								markAntigravityCreditsPermanentlyDisabled(auth)
+							} else {
+								recordAntigravityCreditsFailure(auth, time.Now())
+							}
+						} else if antigravityCreditsRetryEnabled(e.cfg) &&
+							antigravityAuthHasCredits(auth) &&
+							pool.shouldActivateCredits(e.cfg.QuotaExceeded.AntigravityCreditsThreshold, e.cfg.MaxRetryCredentials, time.Now()) {
 							creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
 							if creditsResp != nil {
 								httpResp = creditsResp
@@ -1086,6 +1211,9 @@ attemptLoop:
 			}
 
 		streamSuccessClaudeNonStream:
+			if !usedCreditsDirect {
+				pool.clearExhausted(auth.ID)
+			}
 			out := make(chan cliproxyexecutor.StreamChunk)
 			go func(resp *http.Response) {
 				defer close(out)
@@ -1360,6 +1488,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
 	ctx = context.WithValue(ctx, "alt", "")
+	getAntigravityModelPool(baseModel).markSeen(auth.ID, time.Now())
 	if inCooldown, remaining := antigravityIsInShortCooldown(auth, baseModel, time.Now()); inCooldown {
 		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
@@ -1404,6 +1533,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 
 	attempts := antigravityRetryAttempts(auth, e.cfg)
+	pool := getAntigravityModelPool(baseModel)
 
 attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {
@@ -1411,10 +1541,14 @@ attemptLoop:
 		var lastBody []byte
 		var lastErr error
 
+		pool.markSeen(auth.ID, time.Now())
 		for idx, baseURL := range baseURLs {
 			requestPayload := translated
 			usedCreditsDirect := false
-			if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
+			if antigravityCreditsRetryEnabled(e.cfg) &&
+				antigravityShouldPreferCredits(auth, baseModel, time.Now()) &&
+				antigravityAuthHasCredits(auth) &&
+				pool.shouldActivateCredits(e.cfg.QuotaExceeded.AntigravityCreditsThreshold, e.cfg.MaxRetryCredentials, time.Now()) {
 				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
 					requestPayload = creditsPayload
 					usedCreditsDirect = true
@@ -1490,10 +1624,18 @@ attemptLoop:
 							log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown and skipping credits fallback", *decision.retryAfter, baseModel)
 						}
 					case antigravity429DecisionFullQuotaExhausted:
+						quotaResetAt := antigravityQuotaResetTime(bodyBytes, decision.retryAfter, time.Now())
+						pool.markExhausted(auth.ID, quotaResetAt)
 						if usedCreditsDirect {
 							clearAntigravityPreferCredits(auth, baseModel)
-							recordAntigravityCreditsFailure(auth, time.Now())
-						} else {
+							if antigravityHasExplicitCreditsBalanceExhaustedReason(bodyBytes) {
+								markAntigravityCreditsPermanentlyDisabled(auth)
+							} else {
+								recordAntigravityCreditsFailure(auth, time.Now())
+							}
+						} else if antigravityCreditsRetryEnabled(e.cfg) &&
+							antigravityAuthHasCredits(auth) &&
+							pool.shouldActivateCredits(e.cfg.QuotaExceeded.AntigravityCreditsThreshold, e.cfg.MaxRetryCredentials, time.Now()) {
 							creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
 							if creditsResp != nil {
 								httpResp = creditsResp
@@ -1550,6 +1692,9 @@ attemptLoop:
 			}
 
 		streamSuccessExecuteStream:
+			if !usedCreditsDirect {
+				pool.clearExhausted(auth.ID)
+			}
 			out := make(chan cliproxyexecutor.StreamChunk)
 			go func(resp *http.Response) {
 				defer close(out)
@@ -1882,6 +2027,7 @@ func (e *AntigravityExecutor) refreshToken(ctx context.Context, auth *cliproxyau
 	if errProject := e.ensureAntigravityProjectID(ctx, auth, tokenResp.AccessToken); errProject != nil {
 		log.Warnf("antigravity executor: ensure project id failed: %v", errProject)
 	}
+	e.updateAntigravityCreditsBalance(ctx, auth, tokenResp.AccessToken)
 	return auth, nil
 }
 
@@ -1916,6 +2062,71 @@ func (e *AntigravityExecutor) ensureAntigravityProjectID(ctx context.Context, au
 	auth.Metadata["project_id"] = strings.TrimSpace(projectID)
 
 	return nil
+}
+
+// updateAntigravityCreditsBalance calls loadCodeAssist to fetch the latest credits balance
+// and stores it in auth.Metadata for use by antigravityAuthHasCredits.
+func (e *AntigravityExecutor) updateAntigravityCreditsBalance(ctx context.Context, auth *cliproxyauth.Auth, accessToken string) {
+	if auth == nil {
+		return
+	}
+	token := strings.TrimSpace(accessToken)
+	if token == "" {
+		token = metaStringValue(auth.Metadata, "access_token")
+	}
+	if token == "" {
+		return
+	}
+
+	loadReqBody := `{"metadata":{"ideType":"ANTIGRAVITY","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}}`
+	endpointURL := "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist"
+	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, strings.NewReader(loadReqBody))
+	if errReq != nil {
+		log.Debugf("antigravity executor: create loadCodeAssist request error: %v", errReq)
+		return
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("User-Agent", "google-api-nodejs-client/9.15.1")
+
+	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
+	httpResp, errDo := httpClient.Do(httpReq)
+	if errDo != nil {
+		log.Debugf("antigravity executor: loadCodeAssist request error: %v", errDo)
+		return
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("antigravity executor: close loadCodeAssist response body error: %v", errClose)
+		}
+	}()
+
+	bodyBytes, errRead := io.ReadAll(httpResp.Body)
+	if errRead != nil || httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
+		log.Debugf("antigravity executor: loadCodeAssist returned status %d, err=%v", httpResp.StatusCode, errRead)
+		return
+	}
+
+	// Extract paidTier subscription status and credits balance.
+	// paidTier.id: "g1-pro-tier" (Pro), "g1-ultra-tier" (Ultra), absent (Free).
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	paidTierID := strings.TrimSpace(gjson.GetBytes(bodyBytes, "paidTier.id").String())
+	auth.Metadata["paid_tier_id"] = paidTierID
+
+	credits := gjson.GetBytes(bodyBytes, "paidTier.availableCredits")
+	if !credits.IsArray() {
+		return
+	}
+	for _, credit := range credits.Array() {
+		if !strings.EqualFold(credit.Get("creditType").String(), "GOOGLE_ONE_AI") {
+			continue
+		}
+		auth.Metadata["credit_amount"] = credit.Get("creditAmount").String()
+		auth.Metadata["min_credit_amount"] = credit.Get("minimumCreditAmountForUsage").String()
+		return
+	}
 }
 
 func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyauth.Auth, token, modelName string, payload []byte, stream bool, alt, baseURL string) (*http.Request, error) {

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +21,7 @@ func resetAntigravityCreditsRetryState() {
 	antigravityCreditsFailureByAuth = sync.Map{}
 	antigravityPreferCreditsByModel = sync.Map{}
 	antigravityShortCooldownByAuth = sync.Map{}
+	antigravityModelPools = sync.Map{}
 }
 
 func TestClassifyAntigravity429(t *testing.T) {
@@ -79,37 +81,6 @@ func TestInjectEnabledCreditTypes(t *testing.T) {
 
 	if got := injectEnabledCreditTypes([]byte(`not json`)); got != nil {
 		t.Fatalf("injectEnabledCreditTypes() for invalid json = %s, want nil", string(got))
-	}
-}
-
-func TestShouldMarkAntigravityCreditsExhausted(t *testing.T) {
-	t.Run("credit errors are marked", func(t *testing.T) {
-		for _, body := range [][]byte{
-			[]byte(`{"error":{"message":"Insufficient GOOGLE_ONE_AI credits"}}`),
-			[]byte(`{"error":{"message":"minimumCreditAmountForUsage requirement not met"}}`),
-		} {
-			if !shouldMarkAntigravityCreditsExhausted(http.StatusForbidden, body, nil) {
-				t.Fatalf("shouldMarkAntigravityCreditsExhausted(%s) = false, want true", string(body))
-			}
-		}
-	})
-
-	t.Run("transient 429 resource exhausted is not marked", func(t *testing.T) {
-		body := []byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`)
-		if shouldMarkAntigravityCreditsExhausted(http.StatusTooManyRequests, body, nil) {
-			t.Fatalf("shouldMarkAntigravityCreditsExhausted(%s) = true, want false", string(body))
-		}
-	})
-
-	t.Run("resource exhausted with quota metadata is still marked", func(t *testing.T) {
-		body := []byte(`{"error":{"code":429,"message":"Resource has been exhausted","status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","metadata":{"quotaResetDelay":"1h","model":"claude-sonnet-4-6"}}]}}`)
-		if !shouldMarkAntigravityCreditsExhausted(http.StatusTooManyRequests, body, nil) {
-			t.Fatalf("shouldMarkAntigravityCreditsExhausted(%s) = false, want true", string(body))
-		}
-	})
-
-	if shouldMarkAntigravityCreditsExhausted(http.StatusServiceUnavailable, []byte(`{"error":{"message":"credits exhausted"}}`), nil) {
-		t.Fatal("shouldMarkAntigravityCreditsExhausted() = true for 5xx, want false")
 	}
 }
 
@@ -470,7 +441,7 @@ func TestAntigravityExecute_DoesNotDirectInjectCreditsWhenFlagDisabled(t *testin
 			"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
 		},
 	}
-	markAntigravityPreferCredits(auth, "gemini-2.5-flash", time.Now(), nil)
+	markAntigravityPreferCredits(auth, "gemini-2.5-flash", time.Now(), nil, time.Time{})
 
 	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "gemini-2.5-flash",
@@ -486,5 +457,541 @@ func TestAntigravityExecute_DoesNotDirectInjectCreditsWhenFlagDisabled(t *testin
 	}
 	if strings.Contains(requestBodies[0], `"enabledCreditTypes":["GOOGLE_ONE_AI"]`) {
 		t.Fatalf("request unexpectedly used enabledCreditTypes with flag disabled: %s", requestBodies[0])
+	}
+}
+
+// --- Pool tracking unit tests ---
+
+func TestAntigravityModelQuotaPool_ShouldActivateCredits(t *testing.T) {
+	t.Run("threshold=0 always activates", func(t *testing.T) {
+		pool := &antigravityModelQuotaPool{
+			seen:      make(map[string]time.Time),
+			exhausted: make(map[string]time.Time),
+		}
+		now := time.Now()
+		pool.seen["a1"] = now
+		if !pool.shouldActivateCredits(0, 3, now) {
+			t.Fatal("threshold=0 should always return true")
+		}
+	})
+
+	t.Run("insufficient sample returns false", func(t *testing.T) {
+		pool := &antigravityModelQuotaPool{
+			seen:      make(map[string]time.Time),
+			exhausted: make(map[string]time.Time),
+		}
+		now := time.Now()
+		pool.seen["a1"] = now
+		pool.exhausted["a1"] = now.Add(1 * time.Hour)
+		pool.seen["a2"] = now
+		// a2 is NOT exhausted → not all exhausted, so small pool exception doesn't apply
+		// 2 seen, minSample=3 → false
+		if pool.shouldActivateCredits(0.8, 3, now) {
+			t.Fatal("should return false when sample < minSampleSize")
+		}
+	})
+
+	t.Run("small pool all exhausted activates credits", func(t *testing.T) {
+		pool := &antigravityModelQuotaPool{
+			seen:      make(map[string]time.Time),
+			exhausted: make(map[string]time.Time),
+		}
+		now := time.Now()
+		pool.seen["a1"] = now
+		pool.exhausted["a1"] = now.Add(1 * time.Hour)
+		pool.seen["a2"] = now
+		pool.exhausted["a2"] = now.Add(1 * time.Hour)
+		// 2 seen, 2 exhausted (all exhausted) → small pool exception → true
+		if !pool.shouldActivateCredits(0.8, 3, now) {
+			t.Fatal("should return true when all auths are exhausted (small pool exception)")
+		}
+	})
+
+	t.Run("below threshold returns false", func(t *testing.T) {
+		pool := &antigravityModelQuotaPool{
+			seen:      make(map[string]time.Time),
+			exhausted: make(map[string]time.Time),
+		}
+		now := time.Now()
+		for i := 0; i < 10; i++ {
+			id := "auth-" + strings.Repeat("x", i+1)
+			pool.seen[id] = now
+		}
+		// Only 5 out of 10 exhausted = 50% < 80%
+		for i := 0; i < 5; i++ {
+			id := "auth-" + strings.Repeat("x", i+1)
+			pool.exhausted[id] = now.Add(1 * time.Hour)
+		}
+		if pool.shouldActivateCredits(0.8, 3, now) {
+			t.Fatal("50% exhausted should not activate at 80% threshold")
+		}
+	})
+
+	t.Run("at threshold returns true", func(t *testing.T) {
+		pool := &antigravityModelQuotaPool{
+			seen:      make(map[string]time.Time),
+			exhausted: make(map[string]time.Time),
+		}
+		now := time.Now()
+		for i := 0; i < 10; i++ {
+			id := "auth-" + strings.Repeat("x", i+1)
+			pool.seen[id] = now
+		}
+		// 8 out of 10 exhausted = 80% >= 80%
+		for i := 0; i < 8; i++ {
+			id := "auth-" + strings.Repeat("x", i+1)
+			pool.exhausted[id] = now.Add(1 * time.Hour)
+		}
+		if !pool.shouldActivateCredits(0.8, 3, now) {
+			t.Fatal("80% exhausted should activate at 80% threshold")
+		}
+	})
+
+	t.Run("expired exhausted entries are not counted", func(t *testing.T) {
+		pool := &antigravityModelQuotaPool{
+			seen:      make(map[string]time.Time),
+			exhausted: make(map[string]time.Time),
+		}
+		now := time.Now()
+		for i := 0; i < 5; i++ {
+			id := "auth-" + strings.Repeat("x", i+1)
+			pool.seen[id] = now
+			// Reset time is in the past
+			pool.exhausted[id] = now.Add(-1 * time.Minute)
+		}
+		if pool.shouldActivateCredits(0.8, 3, now) {
+			t.Fatal("expired exhausted entries should not count")
+		}
+	})
+
+	t.Run("stale seen entries are not counted", func(t *testing.T) {
+		pool := &antigravityModelQuotaPool{
+			seen:      make(map[string]time.Time),
+			exhausted: make(map[string]time.Time),
+		}
+		now := time.Now()
+		// All entries are stale (>12h)
+		for i := 0; i < 5; i++ {
+			id := "auth-" + strings.Repeat("x", i+1)
+			pool.seen[id] = now.Add(-13 * time.Hour)
+			pool.exhausted[id] = now.Add(1 * time.Hour)
+		}
+		if pool.shouldActivateCredits(0.8, 3, now) {
+			t.Fatal("stale seen entries should not count")
+		}
+	})
+}
+
+func TestParseQuotaResetTimestamp(t *testing.T) {
+	t.Run("valid timestamp", func(t *testing.T) {
+		body := []byte(`{"error":{"details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","metadata":{"quotaResetTimeStamp":"2026-04-15T06:32:14Z"}}]}}`)
+		ts, ok := parseQuotaResetTimestamp(body)
+		if !ok {
+			t.Fatal("parseQuotaResetTimestamp() returned false, want true")
+		}
+		expected, _ := time.Parse(time.RFC3339, "2026-04-15T06:32:14Z")
+		if !ts.Equal(expected) {
+			t.Fatalf("parseQuotaResetTimestamp() = %v, want %v", ts, expected)
+		}
+	})
+
+	t.Run("missing metadata", func(t *testing.T) {
+		body := []byte(`{"error":{"details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo"}]}}`)
+		_, ok := parseQuotaResetTimestamp(body)
+		if ok {
+			t.Fatal("parseQuotaResetTimestamp() returned true for missing metadata")
+		}
+	})
+
+	t.Run("missing details", func(t *testing.T) {
+		body := []byte(`{"error":{"message":"quota exhausted"}}`)
+		_, ok := parseQuotaResetTimestamp(body)
+		if ok {
+			t.Fatal("parseQuotaResetTimestamp() returned true for missing details")
+		}
+	})
+
+	t.Run("malformed timestamp", func(t *testing.T) {
+		body := []byte(`{"error":{"details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","metadata":{"quotaResetTimeStamp":"not-a-date"}}]}}`)
+		_, ok := parseQuotaResetTimestamp(body)
+		if ok {
+			t.Fatal("parseQuotaResetTimestamp() returned true for malformed timestamp")
+		}
+	})
+}
+
+func TestAntigravityAuthHasCredits(t *testing.T) {
+	t.Run("sufficient balance", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Metadata: map[string]any{
+				"credit_amount":     "25000",
+				"min_credit_amount": "50",
+			},
+		}
+		if !antigravityAuthHasCredits(auth) {
+			t.Fatal("antigravityAuthHasCredits() = false, want true")
+		}
+	})
+
+	t.Run("insufficient balance", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Metadata: map[string]any{
+				"credit_amount":     "30",
+				"min_credit_amount": "50",
+			},
+		}
+		if antigravityAuthHasCredits(auth) {
+			t.Fatal("antigravityAuthHasCredits() = true, want false")
+		}
+	})
+
+	t.Run("no credits fields is backward compatible", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Metadata: map[string]any{
+				"access_token": "token",
+			},
+		}
+		if !antigravityAuthHasCredits(auth) {
+			t.Fatal("antigravityAuthHasCredits() = false with no credits fields, want true (backward compat)")
+		}
+	})
+
+	t.Run("nil auth returns true", func(t *testing.T) {
+		if !antigravityAuthHasCredits(nil) {
+			t.Fatal("antigravityAuthHasCredits(nil) = false, want true")
+		}
+	})
+
+	t.Run("nil metadata returns true", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{}
+		if !antigravityAuthHasCredits(auth) {
+			t.Fatal("antigravityAuthHasCredits(nil metadata) = false, want true")
+		}
+	})
+}
+
+func TestAntigravityQuotaResetTime(t *testing.T) {
+	now := time.Now()
+
+	t.Run("prefers quotaResetTimeStamp", func(t *testing.T) {
+		expected, _ := time.Parse(time.RFC3339, "2026-04-15T06:32:14Z")
+		body := []byte(`{"error":{"details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","metadata":{"quotaResetTimeStamp":"2026-04-15T06:32:14Z"}}]}}`)
+		d := 10 * time.Minute
+		got := antigravityQuotaResetTime(body, &d, now)
+		if !got.Equal(expected) {
+			t.Fatalf("antigravityQuotaResetTime() = %v, want %v", got, expected)
+		}
+	})
+
+	t.Run("falls back to retryAfter", func(t *testing.T) {
+		body := []byte(`{"error":{"message":"quota exhausted"}}`)
+		d := 30 * time.Minute
+		got := antigravityQuotaResetTime(body, &d, now)
+		expected := now.Add(30 * time.Minute)
+		if got.Sub(expected) > time.Second {
+			t.Fatalf("antigravityQuotaResetTime() = %v, want ~%v", got, expected)
+		}
+	})
+
+	t.Run("falls back to 5h default", func(t *testing.T) {
+		body := []byte(`{"error":{"message":"quota exhausted"}}`)
+		got := antigravityQuotaResetTime(body, nil, now)
+		expected := now.Add(5 * time.Hour)
+		if got.Sub(expected) > time.Second {
+			t.Fatalf("antigravityQuotaResetTime() = %v, want ~%v", got, expected)
+		}
+	})
+}
+
+func TestAntigravityExecute_RetriesQuotaExhaustedWithCredits_ThresholdZeroBackwardCompat(t *testing.T) {
+	resetAntigravityCreditsRetryState()
+	t.Cleanup(resetAntigravityCreditsRetryState)
+
+	var (
+		mu            sync.Mutex
+		requestBodies []string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+
+		mu.Lock()
+		requestBodies = append(requestBodies, string(body))
+		reqNum := len(requestBodies)
+		mu.Unlock()
+
+		if reqNum == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"QUOTA_EXHAUSTED"}}`))
+			return
+		}
+
+		if !strings.Contains(string(body), `"enabledCreditTypes":["GOOGLE_ONE_AI"]`) {
+			t.Fatalf("second request body missing enabledCreditTypes: %s", string(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}}`))
+	}))
+	defer server.Close()
+
+	// threshold=0 (default) → backward compatible: credits on first QUOTA_EXHAUSTED
+	exec := NewAntigravityExecutor(&config.Config{
+		QuotaExceeded: config.QuotaExceeded{
+			AntigravityCredits:          true,
+			AntigravityCreditsThreshold: 0,
+		},
+	})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-threshold-zero",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+		},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"project_id":   "project-1",
+			"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gemini-2.5-flash",
+		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatAntigravity,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(resp.Payload) == 0 {
+		t.Fatal("Execute() returned empty payload")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requestBodies))
+	}
+}
+
+func TestAntigravityExecute_PoolGatesCreditsActivation(t *testing.T) {
+	resetAntigravityCreditsRetryState()
+	t.Cleanup(resetAntigravityCreditsRetryState)
+
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"QUOTA_EXHAUSTED"}}`))
+	}))
+	defer server.Close()
+
+	// threshold=0.8, MaxRetryCredentials=8 (minSampleSize)
+	// Pre-populate pool with non-exhausted auths so small pool exception doesn't apply.
+	// 1 exhausted / 4 seen = 25% < 80% and 4 < minSample(8) → credits should NOT activate.
+	baseModel := "gemini-2.5-flash"
+	pool := getAntigravityModelPool(baseModel)
+	now := time.Now()
+	for i := range 3 {
+		pool.markSeen(fmt.Sprintf("auth-healthy-%d", i), now)
+	}
+
+	exec := NewAntigravityExecutor(&config.Config{
+		QuotaExceeded: config.QuotaExceeded{
+			AntigravityCredits:          true,
+			AntigravityCreditsThreshold: 0.8,
+		},
+		MaxRetryCredentials: 8,
+	})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-pool-gated",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+		},
+		Metadata: map[string]any{
+			"access_token":      "token",
+			"project_id":        "project-1",
+			"expired":           time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+			"credit_amount":     "25000",
+			"min_credit_amount": "50",
+		},
+	}
+
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gemini-2.5-flash",
+		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatAntigravity,
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want 429 (credits should not activate)")
+	}
+	// Only 1 request (no credits fallback attempt)
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1 (no credits fallback due to pool gating)", requestCount)
+	}
+}
+
+func TestAntigravityExecute_PoolActivatesCreditsWhenThresholdMet(t *testing.T) {
+	resetAntigravityCreditsRetryState()
+	t.Cleanup(resetAntigravityCreditsRetryState)
+
+	var (
+		mu            sync.Mutex
+		requestBodies []string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+
+		mu.Lock()
+		requestBodies = append(requestBodies, string(body))
+		reqNum := len(requestBodies)
+		mu.Unlock()
+
+		if reqNum == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"QUOTA_EXHAUSTED"}}`))
+			return
+		}
+
+		// Second request should have credits injected
+		if !strings.Contains(string(body), `"enabledCreditTypes":["GOOGLE_ONE_AI"]`) {
+			t.Fatalf("second request body missing enabledCreditTypes: %s", string(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}}`))
+	}))
+	defer server.Close()
+
+	// threshold=0.8, minSampleSize=5
+	// Pre-populate pool so 4/5 auths are exhausted (80% >= 80%)
+	baseModel := "gemini-2.5-flash"
+	pool := getAntigravityModelPool(baseModel)
+	now := time.Now()
+	for i := range 5 {
+		id := fmt.Sprintf("auth-pool-%d", i)
+		pool.markSeen(id, now)
+		if i < 4 {
+			pool.markExhausted(id, now.Add(1*time.Hour))
+		}
+	}
+
+	exec := NewAntigravityExecutor(&config.Config{
+		QuotaExceeded: config.QuotaExceeded{
+			AntigravityCredits:          true,
+			AntigravityCreditsThreshold: 0.8,
+		},
+		MaxRetryCredentials: 5,
+	})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-pool-4", // This auth is already in the pool as seen but not exhausted
+		Attributes: map[string]string{
+			"base_url": server.URL,
+		},
+		Metadata: map[string]any{
+			"access_token":      "token",
+			"project_id":        "project-1",
+			"expired":           time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+			"credit_amount":     "25000",
+			"min_credit_amount": "50",
+		},
+	}
+
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   baseModel,
+		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatAntigravity,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(resp.Payload) == 0 {
+		t.Fatal("Execute() returned empty payload")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("request count = %d, want 2 (credits fallback should activate when pool threshold met)", len(requestBodies))
+	}
+}
+
+func TestAntigravityExecute_AuthWithoutCreditsSkipsFallback(t *testing.T) {
+	resetAntigravityCreditsRetryState()
+	t.Cleanup(resetAntigravityCreditsRetryState)
+
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"QUOTA_EXHAUSTED"}}`))
+	}))
+	defer server.Close()
+
+	// threshold=0 → would normally activate credits immediately
+	// But auth has insufficient credits balance
+	exec := NewAntigravityExecutor(&config.Config{
+		QuotaExceeded: config.QuotaExceeded{
+			AntigravityCredits:          true,
+			AntigravityCreditsThreshold: 0,
+		},
+	})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-no-credits",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+		},
+		Metadata: map[string]any{
+			"access_token":      "token",
+			"project_id":        "project-1",
+			"expired":           time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+			"credit_amount":     "30",
+			"min_credit_amount": "50",
+		},
+	}
+
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gemini-2.5-flash",
+		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatAntigravity,
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want 429 (credits should be skipped due to low balance)")
+	}
+	// Only 1 request (no credits fallback because auth has insufficient credits)
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1 (no credits fallback for low balance auth)", requestCount)
+	}
+}
+
+func TestParseMetaFloat(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   any
+		wantVal float64
+		wantOK  bool
+	}{
+		{"string", "25000", 25000, true},
+		{"float64", float64(100), 100, true},
+		{"int", int(50), 50, true},
+		{"int64", int64(75), 75, true},
+		{"empty string", "", 0, false},
+		{"invalid string", "abc", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := map[string]any{"key": tt.value}
+			got, ok := parseMetaFloat(meta, "key")
+			if ok != tt.wantOK {
+				t.Fatalf("parseMetaFloat() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && got != tt.wantVal {
+				t.Fatalf("parseMetaFloat() = %f, want %f", got, tt.wantVal)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Delay paid credits activation until a configurable ratio of free-quota auths are exhausted, preventing credit waste in large pools
- Track per-auth credits balance via `loadCodeAssist` metadata and gate credits on actual balance
- Fix `PermanentlyDisabled` flag never clearing — now auto-recovers when balance is replenished

## Design: Two-Layer Gating

**Layer 1: Per-Auth Credits Balance** — checks `credit_amount >= min_credit_amount` from auth.Metadata (populated via `loadCodeAssist` during token refresh every ~10min).

**Layer 2: Per-Model Pool Exhaustion** — `antigravityModelQuotaPool` tracks seen/exhausted auths per model. Credits activate only when `exhausted/seen >= threshold` AND `seen >= minSampleSize`.

## Changes

| File | Change |
|------|--------|
| `config.example.yaml` | Add `antigravity-credits-threshold` config |
| `internal/config/config.go` | Add `AntigravityCreditsThreshold` field |
| `internal/runtime/executor/antigravity_executor.go` | Pool tracking, balance gate, 6 gate points, PermanentlyDisabled recovery |
| `antigravity_executor_credits_test.go` | Pool unit tests, integration tests, edge cases |

## Key behaviors

- `threshold=0` (default): backward compatible, credits activate immediately on 429
- `threshold=0.8`: credits activate when 80% of seen auths are exhausted
- Small pool exception: if ALL seen auths are exhausted, credits activate regardless of minSampleSize
- `threshold` clamped to `[0, 1]`, NaN treated as 0
- `INSUFFICIENT_G1_CREDITS_BALANCE` in direct credits path now triggers permanent disable
- `PermanentlyDisabled` auto-clears when `updateAntigravityCreditsBalance` detects balance recovery

## Related

- Complements #2628 (per-credential toggle) — coexists as escape hatch
- Addresses #2836 problem 1 (PermanentlyDisabled no TTL)
- Addresses #2831 community feedback