### PR TITLE
fix(claude): canonicalize cloaked cache control layout

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -162,7 +162,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
+	bodyBeforeCloaking := body
 	body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
+	cloakedByProxy := didApplyClaudeCodeCloaking(bodyBeforeCloaking, body)
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
@@ -172,8 +174,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = disableThinkingIfToolChoiceForced(body)
 	body = normalizeClaudeTemperatureForThinking(body)
 
-	// Cloaked Claude-Code-style payloads require canonical cache_control placement.
-	if isClaudeCodeCloakedPayload(body) {
+	// Only requests newly cloaked by this proxy should be canonicalized into the
+	// Claude Code-style cache_control layout.
+	if cloakedByProxy {
 		body = ensureCloakedCacheControl(body)
 	} else if countCacheControls(body) == 0 {
 		// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
@@ -350,7 +353,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
+	bodyBeforeCloaking := body
 	body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
+	cloakedByProxy := didApplyClaudeCodeCloaking(bodyBeforeCloaking, body)
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
@@ -360,8 +365,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = disableThinkingIfToolChoiceForced(body)
 	body = normalizeClaudeTemperatureForThinking(body)
 
-	// Cloaked Claude-Code-style payloads require canonical cache_control placement.
-	if isClaudeCodeCloakedPayload(body) {
+	// Only requests newly cloaked by this proxy should be canonicalized into the
+	// Claude Code-style cache_control layout.
+	if cloakedByProxy {
 		body = ensureCloakedCacheControl(body)
 	} else if countCacheControls(body) == 0 {
 		// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
@@ -1786,6 +1792,10 @@ func ensureCacheControl(payload []byte) []byte {
 
 func isClaudeCodeCloakedPayload(payload []byte) bool {
 	return strings.HasPrefix(gjson.GetBytes(payload, "system.0.text").String(), "x-anthropic-billing-header:")
+}
+
+func didApplyClaudeCodeCloaking(before, after []byte) bool {
+	return !isClaudeCodeCloakedPayload(before) && isClaudeCodeCloakedPayload(after)
 }
 
 // ensureCloakedCacheControl rewrites cache_control blocks to match Claude Code's

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -172,8 +172,11 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = disableThinkingIfToolChoiceForced(body)
 	body = normalizeClaudeTemperatureForThinking(body)
 
-	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
-	if countCacheControls(body) == 0 {
+	// Cloaked Claude-Code-style payloads require canonical cache_control placement.
+	if isClaudeCodeCloakedPayload(body) {
+		body = ensureCloakedCacheControl(body)
+	} else if countCacheControls(body) == 0 {
+		// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
 		body = ensureCacheControl(body)
 	}
 
@@ -357,8 +360,11 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = disableThinkingIfToolChoiceForced(body)
 	body = normalizeClaudeTemperatureForThinking(body)
 
-	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
-	if countCacheControls(body) == 0 {
+	// Cloaked Claude-Code-style payloads require canonical cache_control placement.
+	if isClaudeCodeCloakedPayload(body) {
+		body = ensureCloakedCacheControl(body)
+	} else if countCacheControls(body) == 0 {
+		// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
 		body = ensureCacheControl(body)
 	}
 
@@ -1778,6 +1784,74 @@ func ensureCacheControl(payload []byte) []byte {
 	return payload
 }
 
+func isClaudeCodeCloakedPayload(payload []byte) bool {
+	return strings.HasPrefix(gjson.GetBytes(payload, "system.0.text").String(), "x-anthropic-billing-header:")
+}
+
+// ensureCloakedCacheControl rewrites cache_control blocks to match Claude Code's
+// cloaked layout: system[1..N-1], tools[last], and messages[last].content[last].
+func ensureCloakedCacheControl(payload []byte) []byte {
+	payload = stripCacheControlMarkers(payload)
+	payload = injectCloakedSystemCacheControl(payload)
+	payload = injectToolsCacheControl(payload)
+	payload = injectLastMessageCacheControl(payload)
+	return payload
+}
+
+func stripCacheControlMarkers(payload []byte) []byte {
+	system := gjson.GetBytes(payload, "system")
+	if system.IsArray() {
+		system.ForEach(func(idx, _ gjson.Result) bool {
+			payload, _ = sjson.DeleteBytes(payload, fmt.Sprintf("system.%d.cache_control", int(idx.Int())))
+			return true
+		})
+	}
+
+	tools := gjson.GetBytes(payload, "tools")
+	if tools.IsArray() {
+		tools.ForEach(func(idx, _ gjson.Result) bool {
+			payload, _ = sjson.DeleteBytes(payload, fmt.Sprintf("tools.%d.cache_control", int(idx.Int())))
+			return true
+		})
+	}
+
+	messages := gjson.GetBytes(payload, "messages")
+	if messages.IsArray() {
+		messages.ForEach(func(msgIdx, msg gjson.Result) bool {
+			content := msg.Get("content")
+			if !content.IsArray() {
+				return true
+			}
+			content.ForEach(func(itemIdx, _ gjson.Result) bool {
+				payload, _ = sjson.DeleteBytes(payload, fmt.Sprintf("messages.%d.content.%d.cache_control", int(msgIdx.Int()), int(itemIdx.Int())))
+				return true
+			})
+			return true
+		})
+	}
+
+	return payload
+}
+
+func injectCloakedSystemCacheControl(payload []byte) []byte {
+	system := gjson.GetBytes(payload, "system")
+	if !system.IsArray() {
+		return payload
+	}
+
+	count := int(system.Get("#").Int())
+	for i := 1; i < count; i++ {
+		result, err := sjson.SetRawBytes(payload, fmt.Sprintf("system.%d.cache_control", i), []byte(`{"type":"ephemeral"}`))
+		if err != nil {
+			log.Warnf("failed to inject cloaked cache_control into system array: %v", err)
+			return payload
+		}
+		payload = result
+	}
+
+	return payload
+}
+
 func countCacheControls(payload []byte) int {
 	count := 0
 
@@ -2167,6 +2241,56 @@ func injectMessagesCacheControl(payload []byte) []byte {
 			return payload
 		}
 		payload = result
+	}
+
+	return payload
+}
+
+func injectLastMessageCacheControl(payload []byte) []byte {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return payload
+	}
+
+	messageCount := int(messages.Get("#").Int())
+	if messageCount == 0 {
+		return payload
+	}
+
+	contentPath := fmt.Sprintf("messages.%d.content", messageCount-1)
+	content := gjson.GetBytes(payload, contentPath)
+
+	if content.IsArray() {
+		contentCount := int(content.Get("#").Int())
+		if contentCount == 0 {
+			return payload
+		}
+		cacheControlPath := fmt.Sprintf("messages.%d.content.%d.cache_control", messageCount-1, contentCount-1)
+		result, err := sjson.SetBytes(payload, cacheControlPath, map[string]string{"type": "ephemeral"})
+		if err != nil {
+			log.Warnf("failed to inject cloaked cache_control into messages: %v", err)
+			return payload
+		}
+		return result
+	}
+
+	if content.Type == gjson.String {
+		text := content.String()
+		newContent := []map[string]interface{}{
+			{
+				"type": "text",
+				"text": text,
+				"cache_control": map[string]string{
+					"type": "ephemeral",
+				},
+			},
+		}
+		result, err := sjson.SetBytes(payload, contentPath, newContent)
+		if err != nil {
+			log.Warnf("failed to inject cloaked cache_control into message string content: %v", err)
+			return payload
+		}
+		return result
 	}
 
 	return payload

--- a/internal/runtime/executor/claude_executor_cloaked_cache_control_test.go
+++ b/internal/runtime/executor/claude_executor_cloaked_cache_control_test.go
@@ -32,10 +32,14 @@ func TestClaudeExecutorExecute_RewritesCloakedCacheControl(t *testing.T) {
 		"base_url":   server.URL,
 		"cloak_mode": "always",
 	}}
+	payload := nonCloakedCacheControlRewritePayload()
+	if isClaudeCodeCloakedPayload(payload) {
+		t.Fatal("test payload should start non-cloaked")
+	}
 
 	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "claude-3-5-sonnet-20241022",
-		Payload: cloakedCacheControlRewritePayload(),
+		Payload: payload,
 	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -60,10 +64,14 @@ func TestClaudeExecutorExecuteStream_RewritesCloakedCacheControl(t *testing.T) {
 		"base_url":   server.URL,
 		"cloak_mode": "always",
 	}}
+	payload := nonCloakedCacheControlRewritePayload()
+	if isClaudeCodeCloakedPayload(payload) {
+		t.Fatal("test payload should start non-cloaked")
+	}
 
 	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "claude-3-5-sonnet-20241022",
-		Payload: cloakedCacheControlRewritePayload(),
+		Payload: payload,
 	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
 	if err != nil {
 		t.Fatalf("ExecuteStream() error = %v", err)
@@ -77,10 +85,41 @@ func TestClaudeExecutorExecuteStream_RewritesCloakedCacheControl(t *testing.T) {
 	assertCloakedCacheControlRewrite(t, seenBody)
 }
 
-func cloakedCacheControlRewritePayload() []byte {
+func TestClaudeExecutorExecute_PreCloakedInputNotRewrittenWhenCloakingDisabled(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-3-5-sonnet","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":    "key-123",
+		"base_url":   server.URL,
+		"cloak_mode": "never",
+	}}
+	payload := preCloakedCacheControlPassThroughPayload()
+	if !isClaudeCodeCloakedPayload(payload) {
+		t.Fatal("test payload should start pre-cloaked")
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	assertPreCloakedCacheControlUnchanged(t, seenBody)
+}
+
+func nonCloakedCacheControlRewritePayload() []byte {
 	return []byte(`{
 		"system": [
-			{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.63.abcde; cc_entrypoint=cli; cch=00000;","cache_control":{"type":"ephemeral"}},
 			{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude.","cache_control":{"type":"ephemeral","ttl":"1h"}},
 			{"type":"text","text":"Follow the user's instructions closely."}
 		],
@@ -91,6 +130,24 @@ func cloakedCacheControlRewritePayload() []byte {
 		"messages": [
 			{"role":"user","content":[{"type":"text","text":"first","cache_control":{"type":"ephemeral"}}]},
 			{"role":"user","content":[{"type":"text","text":"second","cache_control":{"type":"ephemeral"}},{"type":"text","text":"third"}]}
+		]
+	}`)
+}
+
+func preCloakedCacheControlPassThroughPayload() []byte {
+	return []byte(`{
+		"system": [
+			{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.63.abcde; cc_entrypoint=cli; cch=00000;","cache_control":{"type":"ephemeral"}},
+			{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude."},
+			{"type":"text","text":"Follow the user's instructions closely."}
+		],
+		"tools": [
+			{"name":"t1","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}},
+			{"name":"t2","input_schema":{"type":"object"}}
+		],
+		"messages": [
+			{"role":"user","content":[{"type":"text","text":"first","cache_control":{"type":"ephemeral"}}]},
+			{"role":"user","content":[{"type":"text","text":"second"},{"type":"text","text":"third"}]}
 		]
 	}`)
 }
@@ -139,6 +196,41 @@ func assertCloakedCacheControlRewrite(t *testing.T, body []byte) {
 	}
 	if got := countCacheControls(body); got != 4 {
 		t.Fatalf("cache_control count = %d, want 4", got)
+	}
+}
+
+func assertPreCloakedCacheControlUnchanged(t *testing.T, body []byte) {
+	t.Helper()
+
+	if len(body) == 0 {
+		t.Fatal("expected upstream request body to be captured")
+	}
+	if !strings.HasPrefix(gjson.GetBytes(body, "system.0.text").String(), "x-anthropic-billing-header:") {
+		t.Fatalf("system.0.text = %q, want cloaked billing header", gjson.GetBytes(body, "system.0.text").String())
+	}
+	if gjson.GetBytes(body, "system.0.cache_control.type").String() != "ephemeral" {
+		t.Fatalf("system.0.cache_control.type = %q, want %q", gjson.GetBytes(body, "system.0.cache_control.type").String(), "ephemeral")
+	}
+	if gjson.GetBytes(body, "system.1.cache_control").Exists() {
+		t.Fatalf("system.1.cache_control should remain missing when cloaking is disabled")
+	}
+	if gjson.GetBytes(body, "tools.0.cache_control.type").String() != "ephemeral" {
+		t.Fatalf("tools.0.cache_control.type = %q, want %q", gjson.GetBytes(body, "tools.0.cache_control.type").String(), "ephemeral")
+	}
+	if gjson.GetBytes(body, "tools.1.cache_control").Exists() {
+		t.Fatalf("tools.1.cache_control should remain missing when cloaking is disabled")
+	}
+	if gjson.GetBytes(body, "messages.0.content.0.cache_control.type").String() != "ephemeral" {
+		t.Fatalf("messages.0.content.0.cache_control.type = %q, want %q", gjson.GetBytes(body, "messages.0.content.0.cache_control.type").String(), "ephemeral")
+	}
+	if gjson.GetBytes(body, "messages.1.content.0.cache_control").Exists() {
+		t.Fatalf("messages.1.content.0.cache_control should remain missing when cloaking is disabled")
+	}
+	if got := countMessageCacheControls(body); got != 1 {
+		t.Fatalf("message cache_control count = %d, want 1", got)
+	}
+	if got := countCacheControls(body); got != 3 {
+		t.Fatalf("cache_control count = %d, want 3", got)
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_cloaked_cache_control_test.go
+++ b/internal/runtime/executor/claude_executor_cloaked_cache_control_test.go
@@ -1,0 +1,167 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestClaudeExecutorExecute_RewritesCloakedCacheControl(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-3-5-sonnet","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":    "key-123",
+		"base_url":   server.URL,
+		"cloak_mode": "always",
+	}}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: cloakedCacheControlRewritePayload(),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	assertCloakedCacheControlRewrite(t, seenBody)
+}
+
+func TestClaudeExecutorExecuteStream_RewritesCloakedCacheControl(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":    "key-123",
+		"base_url":   server.URL,
+		"cloak_mode": "always",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: cloakedCacheControlRewritePayload(),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected stream chunk error: %v", chunk.Err)
+		}
+	}
+
+	assertCloakedCacheControlRewrite(t, seenBody)
+}
+
+func cloakedCacheControlRewritePayload() []byte {
+	return []byte(`{
+		"system": [
+			{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.63.abcde; cc_entrypoint=cli; cch=00000;","cache_control":{"type":"ephemeral"}},
+			{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude.","cache_control":{"type":"ephemeral","ttl":"1h"}},
+			{"type":"text","text":"Follow the user's instructions closely."}
+		],
+		"tools": [
+			{"name":"t1","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}},
+			{"name":"t2","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral","ttl":"1h"}}
+		],
+		"messages": [
+			{"role":"user","content":[{"type":"text","text":"first","cache_control":{"type":"ephemeral"}}]},
+			{"role":"user","content":[{"type":"text","text":"second","cache_control":{"type":"ephemeral"}},{"type":"text","text":"third"}]}
+		]
+	}`)
+}
+
+func assertCloakedCacheControlRewrite(t *testing.T, body []byte) {
+	t.Helper()
+
+	if len(body) == 0 {
+		t.Fatal("expected upstream request body to be captured")
+	}
+	if !strings.HasPrefix(gjson.GetBytes(body, "system.0.text").String(), "x-anthropic-billing-header:") {
+		t.Fatalf("system.0.text = %q, want cloaked billing header", gjson.GetBytes(body, "system.0.text").String())
+	}
+
+	system := gjson.GetBytes(body, "system").Array()
+	if len(system) < 3 {
+		t.Fatalf("expected cloaked system blocks, got %d", len(system))
+	}
+	if system[0].Get("cache_control").Exists() {
+		t.Fatalf("system.0.cache_control should be stripped for cloaked payloads")
+	}
+	for i := 1; i < len(system); i++ {
+		if system[i].Get("cache_control.type").String() != "ephemeral" {
+			t.Fatalf("system.%d.cache_control.type = %q, want %q", i, system[i].Get("cache_control.type").String(), "ephemeral")
+		}
+	}
+
+	if gjson.GetBytes(body, "tools.0.cache_control").Exists() {
+		t.Fatalf("tools.0.cache_control should be stripped during cloaked rewrite")
+	}
+	if gjson.GetBytes(body, "tools.1.cache_control.type").String() != "ephemeral" {
+		t.Fatalf("tools.1.cache_control.type = %q, want %q", gjson.GetBytes(body, "tools.1.cache_control.type").String(), "ephemeral")
+	}
+
+	if gjson.GetBytes(body, "messages.0.content.0.cache_control").Exists() {
+		t.Fatalf("messages.0.content.0.cache_control should be stripped during cloaked rewrite")
+	}
+	if gjson.GetBytes(body, "messages.1.content.0.cache_control").Exists() {
+		t.Fatalf("messages.1.content.0.cache_control should be stripped during cloaked rewrite")
+	}
+	if gjson.GetBytes(body, "messages.1.content.1.cache_control.type").String() != "ephemeral" {
+		t.Fatalf("messages.1.content.1.cache_control.type = %q, want %q", gjson.GetBytes(body, "messages.1.content.1.cache_control.type").String(), "ephemeral")
+	}
+	if got := countMessageCacheControls(body); got != 1 {
+		t.Fatalf("message cache_control count = %d, want 1", got)
+	}
+	if got := countCacheControls(body); got != 4 {
+		t.Fatalf("cache_control count = %d, want 4", got)
+	}
+}
+
+func countMessageCacheControls(payload []byte) int {
+	count := 0
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return count
+	}
+
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(_, item gjson.Result) bool {
+			if item.Get("cache_control").Exists() {
+				count++
+			}
+			return true
+		})
+		return true
+	})
+
+	return count
+}


### PR DESCRIPTION
## Summary
- canonicalize cache_control placement for cloaked Claude payloads only
- strip client-supplied cache markers before rebuilding a Claude Code-style layout
- add focused executor tests for non-streaming and streaming cloaked requests

## Why
During a compatibility review against Claude Code references, the main gap I found for Droid and Factory style cloaked traffic was cache marker placement.

Today CLIProxyAPI cloaks third-party Claude traffic, but the cache marker fallback is still generic. That means cloaked requests can preserve wasteful client-supplied message markers and miss a stable Claude Code style layout.

This patch keeps the existing non-cloaked behavior intact, but when cloaking has injected the billing header it now rewrites cache markers to a canonical layout:
- system[1..N-1]
- tools[last]
- exactly one marker on messages[last].content[last]

## Scope
This PR is intentionally narrow:
- no auth flow changes
- no beta or header negotiation changes
- no broader system-prompt refactor

## Validation
- go test focused executor coverage for cloaked rewrite behavior
- go build ./cmd/server

## Notes
I found unrelated pre-existing failures in TestCheckSystemInstructionsWithMode on the current branch baseline, so this PR adds focused regression coverage around the new cloaked cache-control behavior instead of folding unrelated fixes into the same change.
