### PR TITLE
fix: allow remote model catalogs to omit optional sections

### DIFF
--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -322,36 +322,42 @@ func validateModelsCatalog(data *staticModelsJSON) error {
 		return fmt.Errorf("catalog is nil")
 	}
 
-	requiredSections := []struct {
-		name   string
-		models []*ModelInfo
-	}{
-		{name: "claude", models: data.Claude},
-		{name: "gemini", models: data.Gemini},
-		{name: "vertex", models: data.Vertex},
-		{name: "gemini-cli", models: data.GeminiCLI},
-		{name: "aistudio", models: data.AIStudio},
-		{name: "codex-free", models: data.CodexFree},
-		{name: "codex-team", models: data.CodexTeam},
-		{name: "codex-plus", models: data.CodexPlus},
-		{name: "codex-pro", models: data.CodexPro},
-		{name: "qwen", models: data.Qwen},
-		{name: "iflow", models: data.IFlow},
-		{name: "kimi", models: data.Kimi},
-		{name: "antigravity", models: data.Antigravity},
+	type sectionSpec struct {
+		name     string
+		models   []*ModelInfo
+		required bool
 	}
 
-	for _, section := range requiredSections {
-		if err := validateModelSection(section.name, section.models); err != nil {
+	sections := []sectionSpec{
+		{name: "claude", models: data.Claude, required: true},
+		{name: "gemini", models: data.Gemini, required: true},
+		{name: "vertex", models: data.Vertex, required: true},
+		{name: "gemini-cli", models: data.GeminiCLI, required: true},
+		{name: "aistudio", models: data.AIStudio, required: true},
+		{name: "codex-free", models: data.CodexFree, required: true},
+		{name: "codex-team", models: data.CodexTeam, required: true},
+		{name: "codex-plus", models: data.CodexPlus, required: true},
+		{name: "codex-pro", models: data.CodexPro, required: true},
+		{name: "qwen", models: data.Qwen, required: false},
+		{name: "iflow", models: data.IFlow, required: false},
+		{name: "kimi", models: data.Kimi, required: true},
+		{name: "antigravity", models: data.Antigravity, required: true},
+	}
+
+	for _, section := range sections {
+		if err := validateModelSection(section.name, section.models, section.required); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateModelSection(section string, models []*ModelInfo) error {
+func validateModelSection(section string, models []*ModelInfo, required bool) error {
 	if len(models) == 0 {
-		return fmt.Errorf("%s section is empty", section)
+		if required {
+			return fmt.Errorf("%s section is empty", section)
+		}
+		return nil
 	}
 
 	seen := make(map[string]struct{}, len(models))

--- a/internal/registry/model_updater_test.go
+++ b/internal/registry/model_updater_test.go
@@ -1,0 +1,51 @@
+package registry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateModelsCatalog_AllowsMissingOptionalSections(t *testing.T) {
+	catalog := &staticModelsJSON{
+		Claude:      []*ModelInfo{{ID: "claude-test"}},
+		Gemini:      []*ModelInfo{{ID: "gemini-test"}},
+		Vertex:      []*ModelInfo{{ID: "vertex-test"}},
+		GeminiCLI:   []*ModelInfo{{ID: "gemini-cli-test"}},
+		AIStudio:    []*ModelInfo{{ID: "aistudio-test"}},
+		CodexFree:   []*ModelInfo{{ID: "codex-free-test"}},
+		CodexTeam:   []*ModelInfo{{ID: "codex-team-test"}},
+		CodexPlus:   []*ModelInfo{{ID: "codex-plus-test"}},
+		CodexPro:    []*ModelInfo{{ID: "codex-pro-test"}},
+		Kimi:        []*ModelInfo{{ID: "kimi-test"}},
+		Antigravity: []*ModelInfo{{ID: "antigravity-test"}},
+	}
+
+	if err := validateModelsCatalog(catalog); err != nil {
+		t.Fatalf("validateModelsCatalog() error = %v, want nil", err)
+	}
+}
+
+func TestValidateModelsCatalog_RejectsDuplicateIDsInOptionalSection(t *testing.T) {
+	catalog := &staticModelsJSON{
+		Claude:      []*ModelInfo{{ID: "claude-test"}},
+		Gemini:      []*ModelInfo{{ID: "gemini-test"}},
+		Vertex:      []*ModelInfo{{ID: "vertex-test"}},
+		GeminiCLI:   []*ModelInfo{{ID: "gemini-cli-test"}},
+		AIStudio:    []*ModelInfo{{ID: "aistudio-test"}},
+		CodexFree:   []*ModelInfo{{ID: "codex-free-test"}},
+		CodexTeam:   []*ModelInfo{{ID: "codex-team-test"}},
+		CodexPlus:   []*ModelInfo{{ID: "codex-plus-test"}},
+		CodexPro:    []*ModelInfo{{ID: "codex-pro-test"}},
+		Qwen:        []*ModelInfo{{ID: "dup"}, {ID: "dup"}},
+		Kimi:        []*ModelInfo{{ID: "kimi-test"}},
+		Antigravity: []*ModelInfo{{ID: "antigravity-test"}},
+	}
+
+	err := validateModelsCatalog(catalog)
+	if err == nil {
+		t.Fatal("validateModelsCatalog() error = nil, want duplicate-id error")
+	}
+	if !strings.Contains(err.Error(), `qwen contains duplicate model id "dup"`) {
+		t.Fatalf("validateModelsCatalog() error = %v, want duplicate qwen id error", err)
+	}
+}


### PR DESCRIPTION
## Bug Description

Remote model catalog refresh is rejected even when the fetched catalog is otherwise valid.

## Root Cause

`validateModelsCatalog()` currently treats `qwen` and `iflow` as required sections. The live remote catalogs at:
- `https://raw.githubusercontent.com/router-for-me/models/refs/heads/main/models.json`
- `https://models.router-for.me/models.json`

currently omit those sections, so startup refresh fails with errors like `qwen section is empty` / `iflow section is empty`, and the service keeps using the embedded fallback catalog instead.

## Fix

- make `qwen` and `iflow` optional during remote catalog validation
- keep validating those sections when they are present
- add regression coverage for missing optional sections and duplicate IDs inside an optional section

## How to Verify

1. Run `go test ./internal/registry/...`
2. Start the server with remote model refresh enabled
3. Confirm startup refresh succeeds against the live remote catalog instead of falling back to the embedded one

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [ ] Manual verification of the fix

## Risk Assessment

Low — this only relaxes validation for provider sections that are already absent from the live remote catalog, while still validating them when they exist.
