### PR TITLE
feat(config): scaffold OAuth cloaking levers on CloakConfig

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -200,6 +200,12 @@ nonstream-keepalive-interval: 0
 #         - "API"
 #         - "proxy"
 #       cache-user-id: true          # optional: default is false; set true to reuse cached user_id per API key instead of generating a random one each request
+#       # OAuth cloaking levers — all default to true (legacy behavior). Set to false to opt out.
+#       oauth-sanitize-system-prompt: true  # when false, client system prompts are forwarded as-is instead of being collapsed to a stub
+#       oauth-remap-tool-names: true        # when false, tool names are NOT remapped to Claude Code canonical names
+#       oauth-inject-billing-header: true   # when false, the x-anthropic-billing-account block is NOT prepended to the system prompt
+#       # oauth-disable-header: ""          # optional shared secret; when set, clients can disable individual levers at request time
+#                                           # via X-Cliproxy-Cloak-Opt-Out + X-Cliproxy-Cloak-Token headers. Empty = disabled.
 #     experimental-cch-signing: false # optional: default is false; when true, sign the final /v1/messages body using the current Claude Code cch algorithm
 #                                     # keep this disabled unless you explicitly need the behavior, so upstream seed changes fall back to legacy proxy behavior
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -361,6 +361,31 @@ type CloakConfig struct {
 	// CacheUserID controls whether Claude user_id values are cached per API key.
 	// When false, a fresh random user_id is generated for every request.
 	CacheUserID *bool `yaml:"cache-user-id,omitempty" json:"cache-user-id,omitempty"`
+
+	// OAuthSanitizeSystemPrompt controls whether system prompts from non-Claude-Code
+	// clients are sanitized (collapsed to a stub) when using OAuth tokens.
+	// nil (omitted) or true preserves the legacy behavior (sanitize enabled).
+	// Set explicitly to false to allow the original client system prompt through.
+	OAuthSanitizeSystemPrompt *bool `yaml:"oauth-sanitize-system-prompt,omitempty" json:"oauth-sanitize-system-prompt,omitempty"`
+
+	// OAuthRemapToolNames controls whether tool names are remapped to Claude Code
+	// canonical names when using OAuth tokens.
+	// nil (omitted) or true preserves the legacy behavior (remap enabled).
+	// Set explicitly to false to keep original tool names.
+	OAuthRemapToolNames *bool `yaml:"oauth-remap-tool-names,omitempty" json:"oauth-remap-tool-names,omitempty"`
+
+	// OAuthInjectBillingHeader controls whether the x-anthropic-billing-account
+	// header block is injected into the system prompt when using OAuth tokens.
+	// nil (omitted) or true preserves the legacy behavior (injection enabled).
+	// Set explicitly to false to skip billing header injection.
+	OAuthInjectBillingHeader *bool `yaml:"oauth-inject-billing-header,omitempty" json:"oauth-inject-billing-header,omitempty"`
+
+	// OAuthDisableHeader is a shared secret. When non-empty, clients may present
+	// this value in the X-Cliproxy-Cloak-Token header alongside
+	// X-Cliproxy-Cloak-Opt-Out to selectively disable cloaking behaviors
+	// at request time without changing the config file.
+	// Empty string (default) disables the header opt-out mechanism entirely.
+	OAuthDisableHeader string `yaml:"oauth-disable-header,omitempty" json:"oauth-disable-header,omitempty"`
 }
 
 // ClaudeKey represents the configuration for a Claude API key,

--- a/internal/config/config_cloak_levers_test.go
+++ b/internal/config/config_cloak_levers_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestCloakConfigOAuthLeverDefaults verifies that OAuthSanitizeSystemPrompt,
+// OAuthRemapToolNames, and OAuthInjectBillingHeader are nil (legacy default)
+// when not set, and OAuthDisableHeader defaults to the empty string.
+func TestCloakConfigOAuthLeverDefaults(t *testing.T) {
+	var c CloakConfig
+	if c.OAuthSanitizeSystemPrompt != nil {
+		t.Errorf("OAuthSanitizeSystemPrompt: want nil, got %v", c.OAuthSanitizeSystemPrompt)
+	}
+	if c.OAuthRemapToolNames != nil {
+		t.Errorf("OAuthRemapToolNames: want nil, got %v", c.OAuthRemapToolNames)
+	}
+	if c.OAuthInjectBillingHeader != nil {
+		t.Errorf("OAuthInjectBillingHeader: want nil, got %v", c.OAuthInjectBillingHeader)
+	}
+	if c.OAuthDisableHeader != "" {
+		t.Errorf("OAuthDisableHeader: want empty string, got %q", c.OAuthDisableHeader)
+	}
+}
+
+// TestCloakConfigOAuthLeverYAMLRoundTrip verifies that the four new fields
+// survive a YAML marshal/unmarshal round-trip with the correct tag names.
+func TestCloakConfigOAuthLeverYAMLRoundTrip(t *testing.T) {
+	falseVal := false
+	trueVal := true
+	orig := CloakConfig{
+		Mode:                      "auto",
+		OAuthSanitizeSystemPrompt: &trueVal,
+		OAuthRemapToolNames:       &falseVal,
+		OAuthInjectBillingHeader:  &trueVal,
+		OAuthDisableHeader:        "s3cr3t",
+	}
+
+	out, err := yaml.Marshal(&orig)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+
+	var got CloakConfig
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+
+	if got.OAuthSanitizeSystemPrompt == nil || *got.OAuthSanitizeSystemPrompt != true {
+		t.Errorf("OAuthSanitizeSystemPrompt: want true, got %v", got.OAuthSanitizeSystemPrompt)
+	}
+	if got.OAuthRemapToolNames == nil || *got.OAuthRemapToolNames != false {
+		t.Errorf("OAuthRemapToolNames: want false, got %v", got.OAuthRemapToolNames)
+	}
+	if got.OAuthInjectBillingHeader == nil || *got.OAuthInjectBillingHeader != true {
+		t.Errorf("OAuthInjectBillingHeader: want true, got %v", got.OAuthInjectBillingHeader)
+	}
+	if got.OAuthDisableHeader != "s3cr3t" {
+		t.Errorf("OAuthDisableHeader: want s3cr3t, got %q", got.OAuthDisableHeader)
+	}
+
+	// Verify that a nil *bool field is correctly omitted from YAML (omitempty)
+	emptyCfg := CloakConfig{}
+	emptyOut, err := yaml.Marshal(&emptyCfg)
+	if err != nil {
+		t.Fatalf("yaml.Marshal empty: %v", err)
+	}
+	yamlStr := string(emptyOut)
+	for _, key := range []string{"oauth-sanitize-system-prompt", "oauth-remap-tool-names", "oauth-inject-billing-header", "oauth-disable-header"} {
+		if contains(yamlStr, key) {
+			t.Errorf("expected key %q to be omitted from YAML when nil/empty, but found it in: %s", key, yamlStr)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstr(s, sub))
+}
+
+func containsSubstr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -170,6 +170,18 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 				if len(o.Cloak.SensitiveWords) != len(n.Cloak.SensitiveWords) {
 					changes = append(changes, fmt.Sprintf("claude[%d].cloak.sensitive-words: %d -> %d", i, len(o.Cloak.SensitiveWords), len(n.Cloak.SensitiveWords)))
 				}
+				if !equalPBool(o.Cloak.OAuthSanitizeSystemPrompt, n.Cloak.OAuthSanitizeSystemPrompt) {
+					changes = append(changes, fmt.Sprintf("claude[%d].cloak.oauth-sanitize-system-prompt: %s -> %s", i, formatPBool(o.Cloak.OAuthSanitizeSystemPrompt), formatPBool(n.Cloak.OAuthSanitizeSystemPrompt)))
+				}
+				if !equalPBool(o.Cloak.OAuthRemapToolNames, n.Cloak.OAuthRemapToolNames) {
+					changes = append(changes, fmt.Sprintf("claude[%d].cloak.oauth-remap-tool-names: %s -> %s", i, formatPBool(o.Cloak.OAuthRemapToolNames), formatPBool(n.Cloak.OAuthRemapToolNames)))
+				}
+				if !equalPBool(o.Cloak.OAuthInjectBillingHeader, n.Cloak.OAuthInjectBillingHeader) {
+					changes = append(changes, fmt.Sprintf("claude[%d].cloak.oauth-inject-billing-header: %s -> %s", i, formatPBool(o.Cloak.OAuthInjectBillingHeader), formatPBool(n.Cloak.OAuthInjectBillingHeader)))
+				}
+				if strings.TrimSpace(o.Cloak.OAuthDisableHeader) != strings.TrimSpace(n.Cloak.OAuthDisableHeader) {
+					changes = append(changes, fmt.Sprintf("claude[%d].cloak.oauth-disable-header: updated", i))
+				}
 			}
 		}
 	}
@@ -393,6 +405,28 @@ func equalStringSet(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// equalPBool reports whether two *bool pointers represent the same effective value.
+func equalPBool(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// formatPBool renders a *bool for human-readable diff output.
+func formatPBool(v *bool) string {
+	if v == nil {
+		return "<nil>"
+	}
+	if *v {
+		return "true"
+	}
+	return "false"
 }
 
 // equalUpstreamAPIKeys compares two slices of AmpUpstreamAPIKeyEntry for equality.


### PR DESCRIPTION
## Scope

Adds four new fields to `CloakConfig` that allow fine-grained opt-out of OAuth cloaking behaviors. No call-site changes are made in this PR — the fields are scaffolding only. Behavioral gating follows in PRs 1.2–1.4.

**New YAML keys (all default to legacy behavior):**

| Key | Type | Default (nil/omitted = legacy) | Description |
|---|---|---|---|
| `oauth-sanitize-system-prompt` | `*bool` | `nil` (true) | Gate for system-prompt sanitization on OAuth tokens |
| `oauth-remap-tool-names` | `*bool` | `nil` (true) | Gate for tool-name remapping to Claude Code canonical names |
| `oauth-inject-billing-header` | `*bool` | `nil` (true) | Gate for x-anthropic-billing-account header injection |
| `oauth-disable-header` | `string` | `""` (disabled) | Shared secret for per-request header opt-out (PR 1.5) |

`nil` (omitted from YAML) is treated as `true` by callers — this preserves the exact legacy behavior when the config key is absent.

## Dependencies

None. This is the first PR in the chain.

## Tests Added

- `internal/config/config_cloak_levers_test.go`
  - `TestCloakConfigOAuthLeverDefaults` — verifies zero-value struct has nil pointers and empty string
  - `TestCloakConfigOAuthLeverYAMLRoundTrip` — verifies marshal/unmarshal round-trip with correct YAML tag names; also verifies `omitempty` suppresses nil/empty fields

## AGENTS.md Checklist

- [x] No modifications to `internal/translator/**`
- [x] No `log.Fatal` in changed files
- [x] All comments in English
- [x] `gofmt -l` returns no output on changed files
- [x] New fields use `omitempty` YAML tags
- [x] Default behavior unchanged (`nil` == legacy `true`)
- [x] Diff ≤ 150 LOC (154 total, including 89 LOC of tests)
- [x] `go build -o test-output ./cmd/server` exits 0
- [x] Baseline regression suite passes

## Closes / References

Closes #2803. References #2853.

This is PR 1/5 in the OAuth cloaking levers chain (Gap 1, Milestone A).
