### PR TITLE
fix(translator): use string content for assistant messages in OpenAI format

### DIFF
--- a/internal/translator/openai/claude/openai_claude_request.go
+++ b/internal/translator/openai/claude/openai_claude_request.go
@@ -218,13 +218,17 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 					if hasContent || hasReasoning || hasToolCalls {
 						msgJSON := []byte(`{"role":"assistant"}`)
 
-						// Add content (as array if we have items, empty string if reasoning-only)
+						// OpenAI spec: assistant content must be string (not array).
+						// Concatenate text parts; skip non-text items (images not valid in assistant content).
 						if hasContent {
-							contentArrayJSON := []byte(`[]`)
+							var textParts []string
 							for _, contentItem := range contentItems {
-								contentArrayJSON, _ = sjson.SetRawBytes(contentArrayJSON, "-1", contentItem)
+								item := gjson.ParseBytes(contentItem)
+								if item.Get("type").String() == "text" {
+									textParts = append(textParts, item.Get("text").String())
+								}
 							}
-							msgJSON, _ = sjson.SetRawBytes(msgJSON, "content", contentArrayJSON)
+							msgJSON, _ = sjson.SetBytes(msgJSON, "content", strings.Join(textParts, "\n"))
 						} else {
 							// Ensure content field exists for OpenAI compatibility
 							msgJSON, _ = sjson.SetBytes(msgJSON, "content", "")

--- a/internal/translator/openai/claude/openai_claude_request_test.go
+++ b/internal/translator/openai/claude/openai_claude_request_test.go
@@ -228,9 +228,10 @@ func TestConvertClaudeRequestToOpenAI_ThinkingToReasoningContent(t *testing.T) {
 				t.Errorf("content existence = %v, want %v", gotHasContent, tt.wantHasContent)
 			}
 
-			if tt.wantHasContent && tt.wantContentText != "" {
-				// Find text content
-				var foundText string
+			// For assistant messages, content is a string (OpenAI spec).
+			var foundText string
+			switch {
+			case content.IsArray():
 				content.ForEach(func(_, v gjson.Result) bool {
 					if v.Get("type").String() == "text" {
 						foundText = v.Get("text").String()
@@ -238,9 +239,11 @@ func TestConvertClaudeRequestToOpenAI_ThinkingToReasoningContent(t *testing.T) {
 					}
 					return true
 				})
-				if foundText != tt.wantContentText {
-					t.Errorf("content text = %q, want %q", foundText, tt.wantContentText)
-				}
+			case content.Type == gjson.String:
+				foundText = content.String()
+			}
+			if foundText != tt.wantContentText {
+				t.Errorf("content text = %q, want %q", foundText, tt.wantContentText)
 			}
 		})
 	}
@@ -637,14 +640,16 @@ func TestConvertClaudeRequestToOpenAI_AssistantTextToolUseTextOrder(t *testing.T
 		t.Fatalf("Expected tool_call name %q, got %q", "do_work", got)
 	}
 
-	// Content should have both pre and post text
-	if got := assistantMsg.Get("content.0.text").String(); got != "pre" {
-		t.Fatalf("Expected content[0] text %q, got %q", "pre", got)
+	// Content should be a string with both pre and post text (OpenAI spec: assistant content is string)
+	if assistantMsg.Get("content").Type != gjson.String {
+		t.Fatalf("Expected assistant content to be string, got %s", assistantMsg.Get("content").Type)
 	}
-	if got := assistantMsg.Get("content.1.text").String(); got != "post" {
-		t.Fatalf("Expected content[1] text %q, got %q", "post", got)
+	// Both "pre" and "post" should be in the content string
+	contentStr := assistantMsg.Get("content").String()
+	if contentStr != "pre\npost" {
+		t.Fatalf("Expected content %q, got %q", "pre\npost", contentStr)
 	}
-}
+	}
 
 func TestConvertClaudeRequestToOpenAI_AssistantThinkingToolUseThinkingSplit(t *testing.T) {
 	inputJSON := `{
@@ -678,12 +683,12 @@ func TestConvertClaudeRequestToOpenAI_AssistantThinkingToolUseThinkingSplit(t *t
 		t.Fatalf("Expected messages[0] to be assistant, got %s", assistantMsg.Get("role").String())
 	}
 
-	// Should have content with both pre and post
-	if got := assistantMsg.Get("content.0.text").String(); got != "pre" {
-		t.Fatalf("Expected content[0] text %q, got %q", "pre", got)
+	// Content should be a string with both pre and post (OpenAI spec: assistant content is string)
+	if assistantMsg.Get("content").Type != gjson.String {
+		t.Fatalf("Expected assistant content to be string, got %s", assistantMsg.Get("content").Type)
 	}
-	if got := assistantMsg.Get("content.1.text").String(); got != "post" {
-		t.Fatalf("Expected content[1] text %q, got %q", "post", got)
+	if got := assistantMsg.Get("content").String(); got != "pre\npost" {
+		t.Fatalf("Expected content %q, got %q", "pre\npost", got)
 	}
 
 	// Should have tool_calls


### PR DESCRIPTION
## Problem
  The Claude→OpenAI translator was outputting assistant message `content` as an array (`[{"type":"text","text":"..."}]`), but the OpenAI Chat Completions API spec requires assistant content
  to be a **string**.

  This caused some upstream providers (notably New API / One API based relay stations) to reject requests mid-stream with `HTTP/2 INTERNAL_ERROR`, resulting in `unexpected EOF` or `stream
  error` disconnections visible as `500` errors with "Headers were already written" warnings in the proxy log.

  ## Fix
  For assistant messages, extract text from content items and concatenate into a single string. Non-assistant roles (user, etc.) keep the array format since OpenAI allows array content for
  user messages.

  ## Testing
  - All 11 existing tests in `internal/translator/openai/claude/` pass
  - All translator package tests pass (0 failures)