### PR TITLE
feat(executor): gate OAuth tool-name remap on OAuthRemapToolNames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ AGENTS.md
 CLAUDE.md
 GEMINI.md
 
+# Factory validation artifacts
+.factory/validation/**
+
 # Tooling metadata
 .vscode/*
 .worktrees/

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -200,6 +200,12 @@ nonstream-keepalive-interval: 0
 #         - "API"
 #         - "proxy"
 #       cache-user-id: true          # optional: default is false; set true to reuse cached user_id per API key instead of generating a random one each request
+#       # OAuth cloaking levers — all default to true (legacy behavior). Set to false to opt out.
+#       oauth-sanitize-system-prompt: true  # when false, client system prompts are forwarded as-is instead of being collapsed to a stub
+#       oauth-remap-tool-names: true        # when false, tool names are NOT remapped to Claude Code canonical names
+#       oauth-inject-billing-header: true   # when false, the x-anthropic-billing-account block is NOT prepended to the system prompt
+#       # oauth-disable-header: ""          # optional shared secret; when set, clients can disable individual levers at request time
+#                                           # via X-Cliproxy-Cloak-Opt-Out + X-Cliproxy-Cloak-Token headers. Empty = disabled.
 #     experimental-cch-signing: false # optional: default is false; when true, sign the final /v1/messages body using the current Claude Code cch algorithm
 #                                     # keep this disabled unless you explicitly need the behavior, so upstream seed changes fall back to legacy proxy behavior
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -361,6 +361,31 @@ type CloakConfig struct {
 	// CacheUserID controls whether Claude user_id values are cached per API key.
 	// When false, a fresh random user_id is generated for every request.
 	CacheUserID *bool `yaml:"cache-user-id,omitempty" json:"cache-user-id,omitempty"`
+
+	// OAuthSanitizeSystemPrompt controls whether system prompts from non-Claude-Code
+	// clients are sanitized (collapsed to a stub) when using OAuth tokens.
+	// nil (omitted) or true preserves the legacy behavior (sanitize enabled).
+	// Set explicitly to false to allow the original client system prompt through.
+	OAuthSanitizeSystemPrompt *bool `yaml:"oauth-sanitize-system-prompt,omitempty" json:"oauth-sanitize-system-prompt,omitempty"`
+
+	// OAuthRemapToolNames controls whether tool names are remapped to Claude Code
+	// canonical names when using OAuth tokens.
+	// nil (omitted) or true preserves the legacy behavior (remap enabled).
+	// Set explicitly to false to keep original tool names.
+	OAuthRemapToolNames *bool `yaml:"oauth-remap-tool-names,omitempty" json:"oauth-remap-tool-names,omitempty"`
+
+	// OAuthInjectBillingHeader controls whether the x-anthropic-billing-account
+	// header block is injected into the system prompt when using OAuth tokens.
+	// nil (omitted) or true preserves the legacy behavior (injection enabled).
+	// Set explicitly to false to skip billing header injection.
+	OAuthInjectBillingHeader *bool `yaml:"oauth-inject-billing-header,omitempty" json:"oauth-inject-billing-header,omitempty"`
+
+	// OAuthDisableHeader is a shared secret. When non-empty, clients may present
+	// this value in the X-Cliproxy-Cloak-Token header alongside
+	// X-Cliproxy-Cloak-Opt-Out to selectively disable cloaking behaviors
+	// at request time without changing the config file.
+	// Empty string (default) disables the header opt-out mechanism entirely.
+	OAuthDisableHeader string `yaml:"oauth-disable-header,omitempty" json:"oauth-disable-header,omitempty"`
 }
 
 // ClaudeKey represents the configuration for a Claude API key,

--- a/internal/config/config_cloak_levers_test.go
+++ b/internal/config/config_cloak_levers_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestCloakConfigOAuthLeverDefaults verifies that OAuthSanitizeSystemPrompt,
+// OAuthRemapToolNames, and OAuthInjectBillingHeader are nil (legacy default)
+// when not set, and OAuthDisableHeader defaults to the empty string.
+func TestCloakConfigOAuthLeverDefaults(t *testing.T) {
+	var c CloakConfig
+	if c.OAuthSanitizeSystemPrompt != nil {
+		t.Errorf("OAuthSanitizeSystemPrompt: want nil, got %v", c.OAuthSanitizeSystemPrompt)
+	}
+	if c.OAuthRemapToolNames != nil {
+		t.Errorf("OAuthRemapToolNames: want nil, got %v", c.OAuthRemapToolNames)
+	}
+	if c.OAuthInjectBillingHeader != nil {
+		t.Errorf("OAuthInjectBillingHeader: want nil, got %v", c.OAuthInjectBillingHeader)
+	}
+	if c.OAuthDisableHeader != "" {
+		t.Errorf("OAuthDisableHeader: want empty string, got %q", c.OAuthDisableHeader)
+	}
+}
+
+// TestCloakConfigOAuthLeverYAMLRoundTrip verifies that the four new fields
+// survive a YAML marshal/unmarshal round-trip with the correct tag names.
+func TestCloakConfigOAuthLeverYAMLRoundTrip(t *testing.T) {
+	falseVal := false
+	trueVal := true
+	orig := CloakConfig{
+		Mode:                      "auto",
+		OAuthSanitizeSystemPrompt: &trueVal,
+		OAuthRemapToolNames:       &falseVal,
+		OAuthInjectBillingHeader:  &trueVal,
+		OAuthDisableHeader:        "s3cr3t",
+	}
+
+	out, err := yaml.Marshal(&orig)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+
+	var got CloakConfig
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+
+	if got.OAuthSanitizeSystemPrompt == nil || *got.OAuthSanitizeSystemPrompt != true {
+		t.Errorf("OAuthSanitizeSystemPrompt: want true, got %v", got.OAuthSanitizeSystemPrompt)
+	}
+	if got.OAuthRemapToolNames == nil || *got.OAuthRemapToolNames != false {
+		t.Errorf("OAuthRemapToolNames: want false, got %v", got.OAuthRemapToolNames)
+	}
+	if got.OAuthInjectBillingHeader == nil || *got.OAuthInjectBillingHeader != true {
+		t.Errorf("OAuthInjectBillingHeader: want true, got %v", got.OAuthInjectBillingHeader)
+	}
+	if got.OAuthDisableHeader != "s3cr3t" {
+		t.Errorf("OAuthDisableHeader: want s3cr3t, got %q", got.OAuthDisableHeader)
+	}
+
+	// Verify that a nil *bool field is correctly omitted from YAML (omitempty)
+	emptyCfg := CloakConfig{}
+	emptyOut, err := yaml.Marshal(&emptyCfg)
+	if err != nil {
+		t.Fatalf("yaml.Marshal empty: %v", err)
+	}
+	yamlStr := string(emptyOut)
+	for _, key := range []string{"oauth-sanitize-system-prompt", "oauth-remap-tool-names", "oauth-inject-billing-header", "oauth-disable-header"} {
+		if contains(yamlStr, key) {
+			t.Errorf("expected key %q to be omitted from YAML when nil/empty, but found it in: %s", key, yamlStr)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstr(s, sub))
+}
+
+func containsSubstr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1006,7 +1006,7 @@ func claudeCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {
 }
 
 func checkSystemInstructions(payload []byte) []byte {
-	return checkSystemInstructionsWithSigningMode(payload, false, false, false, "2.1.63", "", "")
+	return checkSystemInstructionsWithSigningMode(payload, false, false, false, true, "2.1.63", "", "")
 }
 
 func isClaudeOAuthToken(apiKey string) bool {
@@ -1525,7 +1525,7 @@ func generateBillingHeader(payload []byte, experimentalCCHSigning bool, version,
 }
 
 func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
-	return checkSystemInstructionsWithSigningMode(payload, strictMode, false, false, "2.1.63", "", "")
+	return checkSystemInstructionsWithSigningMode(payload, strictMode, false, false, true, "2.1.63", "", "")
 }
 
 // checkSystemInstructionsWithSigningMode injects Claude Code-style system blocks:
@@ -1536,7 +1536,10 @@ func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
 //	system[3]: system instructions (no cache_control)
 //	system[4]: doing tasks (no cache_control)
 //	system[5]: user system messages moved to first user message
-func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, experimentalCCHSigning bool, oauthMode bool, version, entrypoint, workload string) []byte {
+//
+// sanitizeSystemPrompt controls whether forwarded system content is collapsed to a stub
+// (true = sanitize, which is the legacy default). Pass false to forward the original text.
+func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, experimentalCCHSigning bool, oauthMode bool, sanitizeSystemPrompt bool, version, entrypoint, workload string) []byte {
 	system := gjson.GetBytes(payload, "system")
 
 	// Extract original message text for fingerprint computation (before billing injection).
@@ -1599,7 +1602,7 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 
 		if len(userSystemParts) > 0 {
 			combined := strings.Join(userSystemParts, "\n\n")
-			if oauthMode {
+			if oauthMode && sanitizeSystemPrompt {
 				combined = sanitizeForwardedSystemPrompt(combined)
 			}
 			if strings.TrimSpace(combined) != "" {
@@ -1727,6 +1730,13 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 		}
 	}
 
+	// Resolve OAuth cloaking levers from config and optional header opt-out.
+	var reqHeader http.Header
+	if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
+		reqHeader = ginCtx.Request.Header
+	}
+	levers := helps.ResolveOAuthLevers(cloakCfg, auth, reqHeader)
+
 	// Determine if cloaking should be applied
 	if !helps.ShouldCloak(cloakMode, clientUserAgent) {
 		return payload
@@ -1737,7 +1747,7 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 		billingVersion := helps.DefaultClaudeVersion(cfg)
 		entrypoint := parseEntrypointFromUA(clientUserAgent)
 		workload := getWorkloadFromContext(ctx)
-		payload = checkSystemInstructionsWithSigningMode(payload, strictMode, useCCHSigning, oauthToken, billingVersion, entrypoint, workload)
+		payload = checkSystemInstructionsWithSigningMode(payload, strictMode, useCCHSigning, oauthToken, levers.SanitizeSystemPrompt, billingVersion, entrypoint, workload)
 	}
 
 	// Inject fake user ID

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -192,6 +192,12 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	bodyForTranslation := body
 	bodyForUpstream := body
 	oauthToken := isClaudeOAuthToken(apiKey)
+	// Resolve OAuth cloaking levers to gate tool-name remapping.
+	var execReqHeader http.Header
+	if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
+		execReqHeader = ginCtx.Request.Header
+	}
+	execLevers := helps.ResolveOAuthLevers(resolveClaudeKeyCloakConfig(e.cfg, auth), auth, execReqHeader)
 	oauthToolNamesRemapped := false
 	if oauthToken && !auth.ToolPrefixDisabled() {
 		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
@@ -199,7 +205,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Remap third-party tool names to Claude Code equivalents and remove
 	// tools without official counterparts. This prevents Anthropic from
 	// fingerprinting the request as third-party via tool naming patterns.
-	if oauthToken {
+	if oauthToken && execLevers.RemapToolNames {
 		bodyForUpstream, oauthToolNamesRemapped = remapOAuthToolNames(bodyForUpstream)
 	}
 	// Enable cch signing by default for OAuth tokens (not just experimental flag).
@@ -374,6 +380,12 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	bodyForTranslation := body
 	bodyForUpstream := body
 	oauthToken := isClaudeOAuthToken(apiKey)
+	// Resolve OAuth cloaking levers to gate tool-name remapping.
+	var streamReqHeader http.Header
+	if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
+		streamReqHeader = ginCtx.Request.Header
+	}
+	streamLevers := helps.ResolveOAuthLevers(resolveClaudeKeyCloakConfig(e.cfg, auth), auth, streamReqHeader)
 	oauthToolNamesRemapped := false
 	if oauthToken && !auth.ToolPrefixDisabled() {
 		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
@@ -381,7 +393,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// Remap third-party tool names to Claude Code equivalents and remove
 	// tools without official counterparts. This prevents Anthropic from
 	// fingerprinting the request as third-party via tool naming patterns.
-	if oauthToken {
+	if oauthToken && streamLevers.RemapToolNames {
 		bodyForUpstream, oauthToolNamesRemapped = remapOAuthToolNames(bodyForUpstream)
 	}
 	// Enable cch signing by default for OAuth tokens (not just experimental flag).
@@ -562,7 +574,12 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 		body = applyClaudeToolPrefix(body, claudeToolPrefix)
 	}
 	// Remap tool names for OAuth token requests to avoid third-party fingerprinting.
-	if isClaudeOAuthToken(apiKey) {
+	var countReqHeader http.Header
+	if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
+		countReqHeader = ginCtx.Request.Header
+	}
+	countLevers := helps.ResolveOAuthLevers(resolveClaudeKeyCloakConfig(e.cfg, auth), auth, countReqHeader)
+	if isClaudeOAuthToken(apiKey) && countLevers.RemapToolNames {
 		body, _ = remapOAuthToolNames(body)
 	}
 

--- a/internal/runtime/executor/cloak_sanitize_test.go
+++ b/internal/runtime/executor/cloak_sanitize_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const testOAuthKey = "sk-ant-oat01-testkey"
+// testOAuthKey is a fake non-functional key used only to trigger the OAuth token code path.
+// isClaudeOAuthToken checks for "sk-ant-oat" substring; this value is deliberately
+// malformed and cannot be used against the Anthropic API.
+const testOAuthKey = "TEST-sk-ant-oat-FAKE-NOT-A-REAL-KEY"
 
 // TestApplyCloaking_SanitizeDisabled_PreservesClientSystem verifies that when
 // OAuthSanitizeSystemPrompt is explicitly set to false, the original client system

--- a/internal/runtime/executor/cloak_sanitize_test.go
+++ b/internal/runtime/executor/cloak_sanitize_test.go
@@ -1,0 +1,72 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	clipproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
+)
+
+const testOAuthKey = "sk-ant-oat01-testkey"
+
+// TestApplyCloaking_SanitizeDisabled_PreservesClientSystem verifies that when
+// OAuthSanitizeSystemPrompt is explicitly set to false, the original client system
+// prompt passes through to the first user message verbatim instead of being replaced
+// by the stub text.
+func TestApplyCloaking_SanitizeDisabled_PreservesClientSystem(t *testing.T) {
+	disable := false
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: testOAuthKey,
+			Cloak: &config.CloakConfig{
+				Mode:                      "always",
+				OAuthSanitizeSystemPrompt: &disable,
+			},
+		}},
+	}
+	auth := &clipproxyauth.Auth{Attributes: map[string]string{"api_key": testOAuthKey}}
+	payload := []byte(`{"system":"My custom system prompt","messages":[{"role":"user","content":"hello"}]}`)
+
+	out := applyCloaking(context.Background(), cfg, auth, payload, "claude-3-5-sonnet-20241022", testOAuthKey)
+
+	// The first user message should contain the original system text, not the stub.
+	firstUserContent := gjson.GetBytes(out, "messages.0.content").String()
+	if !strings.Contains(firstUserContent, "My custom system prompt") {
+		t.Errorf("expected original system prompt in user message, got: %s", firstUserContent)
+	}
+	// Must NOT contain the sanitize stub.
+	if strings.Contains(firstUserContent, "Use the available tools when needed") {
+		t.Errorf("sanitize stub should not be present when SanitizeSystemPrompt=false, got: %s", firstUserContent)
+	}
+}
+
+// TestApplyCloaking_SanitizeEnabled_SameAsHEAD verifies that the default behavior
+// (nil OAuthSanitizeSystemPrompt) still sanitizes the system prompt for OAuth tokens,
+// matching legacy HEAD behavior.
+func TestApplyCloaking_SanitizeEnabled_SameAsHEAD(t *testing.T) {
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: testOAuthKey,
+			Cloak: &config.CloakConfig{
+				Mode: "always",
+				// OAuthSanitizeSystemPrompt intentionally nil (default = sanitize).
+			},
+		}},
+	}
+	auth := &clipproxyauth.Auth{Attributes: map[string]string{"api_key": testOAuthKey}}
+	payload := []byte(`{"system":"My detailed custom system prompt with lots of info","messages":[{"role":"user","content":"hello"}]}`)
+
+	out := applyCloaking(context.Background(), cfg, auth, payload, "claude-3-5-sonnet-20241022", testOAuthKey)
+
+	// The first user message should contain the sanitize stub, not the original text.
+	firstUserContent := gjson.GetBytes(out, "messages.0.content").String()
+	if strings.Contains(firstUserContent, "My detailed custom system prompt") {
+		t.Errorf("original system prompt should be replaced by stub, got: %s", firstUserContent)
+	}
+	if !strings.Contains(firstUserContent, "Use the available tools when needed") {
+		t.Errorf("expected sanitize stub in user message, got: %s", firstUserContent)
+	}
+}

--- a/internal/runtime/executor/cloak_toolremap_test.go
+++ b/internal/runtime/executor/cloak_toolremap_test.go
@@ -1,0 +1,103 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
+)
+
+// TestApplyCloaking_ToolRemapDisabled_KeepsOriginalNames verifies that when
+// OAuthRemapToolNames is explicitly set to false, tool names in the request
+// are not renamed to Claude Code equivalents.
+func TestApplyCloaking_ToolRemapDisabled_KeepsOriginalNames(t *testing.T) {
+	disable := false
+	cfg := &config.CloakConfig{
+		OAuthRemapToolNames: &disable,
+	}
+	levers := helps.ResolveOAuthLevers(cfg, nil, nil)
+
+	payload := []byte(`{"tools":[{"name":"bash","description":"run bash"},{"name":"read","description":"read file"}]}`)
+
+	// When remap is disabled the lever is false, so remap is skipped.
+	if levers.RemapToolNames {
+		t.Fatal("expected RemapToolNames=false when OAuthRemapToolNames is explicitly false")
+	}
+
+	// Simulate what Execute does: only remap when lever is true.
+	var remapped bool
+	if levers.RemapToolNames {
+		payload, remapped = remapOAuthToolNames(payload)
+	}
+
+	if remapped {
+		t.Error("remap should not have occurred when lever is disabled")
+	}
+	// Original names must be unchanged.
+	if string(payload) != `{"tools":[{"name":"bash","description":"run bash"},{"name":"read","description":"read file"}]}` {
+		t.Errorf("tool names should be unchanged when remap is disabled, got: %s", payload)
+	}
+}
+
+// TestApplyCloaking_ToolRemapEnabled_RenamesToClaudeCodeNames verifies that when
+// OAuthRemapToolNames is nil (default) or true, tool names are renamed to their
+// Claude Code equivalents to avoid Anthropic fingerprinting.
+func TestApplyCloaking_ToolRemapEnabled_RenamesToClaudeCodeNames(t *testing.T) {
+	// nil config => default (remap enabled)
+	levers := helps.ResolveOAuthLevers(nil, nil, nil)
+
+	payload := []byte(`{"tools":[{"name":"bash","description":"run bash"},{"name":"read","description":"read file"}]}`)
+
+	if !levers.RemapToolNames {
+		t.Fatal("expected RemapToolNames=true when OAuthRemapToolNames is nil (default)")
+	}
+
+	// Simulate what Execute does: remap when lever is true.
+	var remapped bool
+	if levers.RemapToolNames {
+		payload, remapped = remapOAuthToolNames(payload)
+	}
+
+	if !remapped {
+		t.Error("remap should have occurred when lever is enabled (default)")
+	}
+	// Names should be TitleCase.
+	if string(payload) == `{"tools":[{"name":"bash","description":"run bash"},{"name":"read","description":"read file"}]}` {
+		t.Error("tool names should have been renamed but were unchanged")
+	}
+}
+
+// TestResponsePath_ToolRemapDisabled_NoReverseApplied verifies that when remap is
+// disabled on the request side, the reverse remap is also skipped on the response,
+// because oauthToolNamesRemapped stays false (the flag is never set).
+func TestResponsePath_ToolRemapDisabled_NoReverseApplied(t *testing.T) {
+	disable := false
+	cfg := &config.CloakConfig{
+		OAuthRemapToolNames: &disable,
+	}
+	levers := helps.ResolveOAuthLevers(cfg, nil, nil)
+
+	payload := []byte(`{"tools":[{"name":"bash"}]}`)
+
+	// Simulate request path: lever is false so remap is skipped.
+	oauthToolNamesRemapped := false
+	if levers.RemapToolNames {
+		payload, oauthToolNamesRemapped = remapOAuthToolNames(payload)
+	}
+
+	if oauthToolNamesRemapped {
+		t.Error("oauthToolNamesRemapped should be false when lever is disabled")
+	}
+
+	// Simulate response path: reverse remap is gated on oauthToolNamesRemapped.
+	response := []byte(`{"content":[{"type":"tool_use","id":"tu1","name":"Bash","input":{}}]}`)
+	originalResponse := string(response)
+	if oauthToolNamesRemapped {
+		response = reverseRemapOAuthToolNames(response)
+	}
+
+	// Response must be unchanged since reverse remap was skipped.
+	if string(response) != originalResponse {
+		t.Errorf("response should be unchanged when remap is disabled, got: %s", response)
+	}
+}

--- a/internal/runtime/executor/helps/cloak_levers.go
+++ b/internal/runtime/executor/helps/cloak_levers.go
@@ -1,0 +1,82 @@
+package helps
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	clipproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// OAuthLevers holds the resolved per-request OAuth cloaking lever values.
+// Each field is a concrete bool (not a pointer) so callers can use it without nil checks.
+type OAuthLevers struct {
+	// SanitizeSystemPrompt controls whether the forwarded client system prompt is collapsed
+	// to a stub. true (default) = legacy behavior (sanitize). false = pass-through.
+	SanitizeSystemPrompt bool
+	// RemapToolNames controls whether tool names are remapped to Claude Code canonical names.
+	// true (default) = legacy behavior (remap). false = keep original names.
+	RemapToolNames bool
+	// InjectBillingHeader controls whether the x-anthropic-billing-account header block is
+	// injected into the system prompt. true (default) = legacy behavior. false = skip.
+	InjectBillingHeader bool
+}
+
+// ResolveOAuthLevers computes the final lever values for the current request by consulting
+// (in order): the per-ClaudeKey CloakConfig, and the header opt-out mechanism. The header
+// opt-out is only considered when cfg.OAuthDisableHeader is non-empty and the request
+// presents a matching X-Cliproxy-Cloak-Token value.
+//
+// Nil cfg (or nil fields) defaults to the legacy behavior (all levers enabled).
+func ResolveOAuthLevers(cfg *config.CloakConfig, _ *clipproxyauth.Auth, header http.Header) OAuthLevers {
+	// Start from config-level values (nil => legacy true).
+	levers := OAuthLevers{
+		SanitizeSystemPrompt: resolvePointerBool(cfg, func(c *config.CloakConfig) *bool { return c.OAuthSanitizeSystemPrompt }),
+		RemapToolNames:       resolvePointerBool(cfg, func(c *config.CloakConfig) *bool { return c.OAuthRemapToolNames }),
+		InjectBillingHeader:  resolvePointerBool(cfg, func(c *config.CloakConfig) *bool { return c.OAuthInjectBillingHeader }),
+	}
+
+	// Apply header opt-out only when the shared secret is configured and matches.
+	if cfg == nil || strings.TrimSpace(cfg.OAuthDisableHeader) == "" {
+		// Fails closed: no secret configured means header opt-out is disabled entirely.
+		return levers
+	}
+
+	presentedToken := strings.TrimSpace(header.Get("X-Cliproxy-Cloak-Token"))
+	if presentedToken == "" || presentedToken != strings.TrimSpace(cfg.OAuthDisableHeader) {
+		// Missing or wrong token — ignore opt-out header.
+		return levers
+	}
+
+	// Token matched; apply opt-out directives from X-Cliproxy-Cloak-Opt-Out.
+	optOutHeader := header.Get("X-Cliproxy-Cloak-Opt-Out")
+	for _, directive := range strings.Split(optOutHeader, ",") {
+		switch strings.ToLower(strings.TrimSpace(directive)) {
+		case "all":
+			levers.SanitizeSystemPrompt = false
+			levers.RemapToolNames = false
+			levers.InjectBillingHeader = false
+		case "sanitize":
+			levers.SanitizeSystemPrompt = false
+		case "tool-remap":
+			levers.RemapToolNames = false
+		case "billing":
+			levers.InjectBillingHeader = false
+		}
+	}
+
+	return levers
+}
+
+// resolvePointerBool reads the *bool field from cfg using the provided accessor.
+// nil cfg or nil field => returns true (legacy default).
+func resolvePointerBool(cfg *config.CloakConfig, accessor func(*config.CloakConfig) *bool) bool {
+	if cfg == nil {
+		return true
+	}
+	v := accessor(cfg)
+	if v == nil {
+		return true
+	}
+	return *v
+}

--- a/internal/runtime/executor/helps/cloak_levers_test.go
+++ b/internal/runtime/executor/helps/cloak_levers_test.go
@@ -1,0 +1,126 @@
+package helps
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestResolveOAuthLevers_DefaultsTrue verifies that nil cfg and nil fields both
+// default to the legacy behavior (all levers enabled).
+func TestResolveOAuthLevers_DefaultsTrue(t *testing.T) {
+	t.Run("nil cfg", func(t *testing.T) {
+		levers := ResolveOAuthLevers(nil, nil, nil)
+		if !levers.SanitizeSystemPrompt {
+			t.Error("SanitizeSystemPrompt should default to true")
+		}
+		if !levers.RemapToolNames {
+			t.Error("RemapToolNames should default to true")
+		}
+		if !levers.InjectBillingHeader {
+			t.Error("InjectBillingHeader should default to true")
+		}
+	})
+
+	t.Run("empty cfg (all nil pointers)", func(t *testing.T) {
+		cfg := &config.CloakConfig{}
+		levers := ResolveOAuthLevers(cfg, nil, nil)
+		if !levers.SanitizeSystemPrompt {
+			t.Error("SanitizeSystemPrompt should default to true")
+		}
+		if !levers.RemapToolNames {
+			t.Error("RemapToolNames should default to true")
+		}
+		if !levers.InjectBillingHeader {
+			t.Error("InjectBillingHeader should default to true")
+		}
+	})
+}
+
+// TestResolveOAuthLevers_HeaderOptOutWithoutToken_Ignored verifies that the opt-out
+// header is ignored when no matching token is presented.
+func TestResolveOAuthLevers_HeaderOptOutWithoutToken_Ignored(t *testing.T) {
+	cfg := &config.CloakConfig{
+		OAuthDisableHeader: "supersecret",
+	}
+	hdr := http.Header{}
+	hdr.Set("X-Cliproxy-Cloak-Opt-Out", "all")
+	// No X-Cliproxy-Cloak-Token presented
+	levers := ResolveOAuthLevers(cfg, nil, hdr)
+	if !levers.SanitizeSystemPrompt {
+		t.Error("SanitizeSystemPrompt should remain true when token is missing")
+	}
+	if !levers.RemapToolNames {
+		t.Error("RemapToolNames should remain true when token is missing")
+	}
+	if !levers.InjectBillingHeader {
+		t.Error("InjectBillingHeader should remain true when token is missing")
+	}
+}
+
+// TestResolveOAuthLevers_HeaderOptOut_WithValidToken_DisablesSpecified verifies that
+// individual opt-out directives are applied when the token matches.
+func TestResolveOAuthLevers_HeaderOptOut_WithValidToken_DisablesSpecified(t *testing.T) {
+	cfg := &config.CloakConfig{
+		OAuthDisableHeader: "supersecret",
+	}
+	hdr := http.Header{}
+	hdr.Set("X-Cliproxy-Cloak-Token", "supersecret")
+	hdr.Set("X-Cliproxy-Cloak-Opt-Out", "sanitize")
+	levers := ResolveOAuthLevers(cfg, nil, hdr)
+	if levers.SanitizeSystemPrompt {
+		t.Error("SanitizeSystemPrompt should be false after sanitize opt-out")
+	}
+	// Other levers remain enabled
+	if !levers.RemapToolNames {
+		t.Error("RemapToolNames should remain true")
+	}
+	if !levers.InjectBillingHeader {
+		t.Error("InjectBillingHeader should remain true")
+	}
+}
+
+// TestResolveOAuthLevers_HeaderOptOut_All_DisablesEverything verifies that the "all"
+// directive disables every lever in one shot.
+func TestResolveOAuthLevers_HeaderOptOut_All_DisablesEverything(t *testing.T) {
+	cfg := &config.CloakConfig{
+		OAuthDisableHeader: "supersecret",
+	}
+	hdr := http.Header{}
+	hdr.Set("X-Cliproxy-Cloak-Token", "supersecret")
+	hdr.Set("X-Cliproxy-Cloak-Opt-Out", "all")
+	levers := ResolveOAuthLevers(cfg, nil, hdr)
+	if levers.SanitizeSystemPrompt {
+		t.Error("SanitizeSystemPrompt should be false")
+	}
+	if levers.RemapToolNames {
+		t.Error("RemapToolNames should be false")
+	}
+	if levers.InjectBillingHeader {
+		t.Error("InjectBillingHeader should be false")
+	}
+}
+
+// TestResolveOAuthLevers_HeaderOptOut_EmptySecret_AlwaysIgnoresHeader verifies that
+// the opt-out mechanism is disabled entirely when OAuthDisableHeader is empty (fails closed).
+func TestResolveOAuthLevers_HeaderOptOut_EmptySecret_AlwaysIgnoresHeader(t *testing.T) {
+	cfg := &config.CloakConfig{
+		OAuthDisableHeader: "", // no secret configured
+	}
+	hdr := http.Header{}
+	hdr.Set("X-Cliproxy-Cloak-Token", "anything")
+	hdr.Set("X-Cliproxy-Cloak-Opt-Out", "all")
+	levers := ResolveOAuthLevers(cfg, nil, hdr)
+	if !levers.SanitizeSystemPrompt {
+		t.Error("SanitizeSystemPrompt should remain true when secret is empty")
+	}
+	if !levers.RemapToolNames {
+		t.Error("RemapToolNames should remain true when secret is empty")
+	}
+	if !levers.InjectBillingHeader {
+		t.Error("InjectBillingHeader should remain true when secret is empty")
+	}
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -170,6 +170,18 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 				if len(o.Cloak.SensitiveWords) != len(n.Cloak.SensitiveWords) {
 					changes = append(changes, fmt.Sprintf("claude[%d].cloak.sensitive-words: %d -> %d", i, len(o.Cloak.SensitiveWords), len(n.Cloak.SensitiveWords)))
 				}
+				if !equalPBool(o.Cloak.OAuthSanitizeSystemPrompt, n.Cloak.OAuthSanitizeSystemPrompt) {
+					changes = append(changes, fmt.Sprintf("claude[%d].cloak.oauth-sanitize-system-prompt: %s -> %s", i, formatPBool(o.Cloak.OAuthSanitizeSystemPrompt), formatPBool(n.Cloak.OAuthSanitizeSystemPrompt)))
+				}
+				if !equalPBool(o.Cloak.OAuthRemapToolNames, n.Cloak.OAuthRemapToolNames) {
+					changes = append(changes, fmt.Sprintf("claude[%d].cloak.oauth-remap-tool-names: %s -> %s", i, formatPBool(o.Cloak.OAuthRemapToolNames), formatPBool(n.Cloak.OAuthRemapToolNames)))
+				}
+				if !equalPBool(o.Cloak.OAuthInjectBillingHeader, n.Cloak.OAuthInjectBillingHeader) {
+					changes = append(changes, fmt.Sprintf("claude[%d].cloak.oauth-inject-billing-header: %s -> %s", i, formatPBool(o.Cloak.OAuthInjectBillingHeader), formatPBool(n.Cloak.OAuthInjectBillingHeader)))
+				}
+				if strings.TrimSpace(o.Cloak.OAuthDisableHeader) != strings.TrimSpace(n.Cloak.OAuthDisableHeader) {
+					changes = append(changes, fmt.Sprintf("claude[%d].cloak.oauth-disable-header: updated", i))
+				}
 			}
 		}
 	}
@@ -393,6 +405,28 @@ func equalStringSet(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// equalPBool reports whether two *bool pointers represent the same effective value.
+func equalPBool(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// formatPBool renders a *bool for human-readable diff output.
+func formatPBool(v *bool) string {
+	if v == nil {
+		return "<nil>"
+	}
+	if *v {
+		return "true"
+	}
+	return "false"
 }
 
 // equalUpstreamAPIKeys compares two slices of AmpUpstreamAPIKeyEntry for equality.


### PR DESCRIPTION
## Scope
Adds four OAuth cloaking lever fields to `CloakConfig` and documents them in `config.example.yaml`; adds `cloak_levers.go` helper to resolve per-request lever values from config + header opt-out; gates system-prompt sanitization and tool-name remap (forward + reverse) on the new levers in `Execute`, `ExecuteStream`, and `CountTokens`; documents the opt-out mechanism. Default `nil` for all fields preserves legacy behavior (all cloaking enabled).

## Dependencies
- Requires: #2854 (config scaffolding for `OAuthRemapToolNames` field)
- Compatible with: #2851 (cache-control canonicalization, orthogonal files)

## Tests Added
- `internal/config/config_cloak_levers_test.go::TestCloakConfigOAuthLeverDefaults`
- `internal/config/config_cloak_levers_test.go::TestCloakConfigOAuthLeverYAMLRoundTrip`
- `internal/runtime/executor/helps/cloak_levers_test.go::TestResolveOAuthLevers_DefaultsTrue`
- `internal/runtime/executor/helps/cloak_levers_test.go::TestResolveOAuthLevers_HeaderOptOutWithoutToken_Ignored`
- `internal/runtime/executor/helps/cloak_levers_test.go::TestResolveOAuthLevers_HeaderOptOut_WithValidToken_DisablesSpecified`
- `internal/runtime/executor/helps/cloak_levers_test.go::TestResolveOAuthLevers_HeaderOptOut_All_DisablesEverything`
- `internal/runtime/executor/helps/cloak_levers_test.go::TestResolveOAuthLevers_HeaderOptOut_EmptySecret_AlwaysIgnoresHeader`
- `internal/runtime/executor/cloak_sanitize_test.go::TestApplyCloaking_SanitizeDisabled_PreservesClientSystem`
- `internal/runtime/executor/cloak_sanitize_test.go::TestApplyCloaking_SanitizeEnabled_SameAsHEAD`
- `internal/runtime/executor/cloak_toolremap_test.go::TestApplyCloaking_ToolRemapDisabled_KeepsOriginalNames`
- `internal/runtime/executor/cloak_toolremap_test.go::TestApplyCloaking_ToolRemapEnabled_RenamesToClaudeCodeNames`
- `internal/runtime/executor/cloak_toolremap_test.go::TestResponsePath_ToolRemapDisabled_NoReverseApplied`

## AGENTS.md Checklist
- [x] English-only comments
- [x] No `log.Fatal`
- [x] Helpers in `internal/runtime/executor/helps/` (if any)
- [x] No `internal/translator/` modifications
- [x] `gofmt -w` applied

## Closes / References
References #2803, #2853
