### PR TITLE
feat: add /health and /v1/health endpoints (no auth required)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/access"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/buildinfo"
 	managementHandlers "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/middleware"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api/modules"
@@ -348,6 +349,17 @@ func (s *Server) setupRoutes() {
 		})
 	})
 	s.engine.POST("/v1internal:method", geminiCLIHandlers.CLIHandler)
+
+	// Health check endpoint (no auth required)
+	healthHandler := func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"status":  "ok",
+			"service": "cliproxyapi",
+			"version": buildinfo.Version,
+		})
+	}
+	s.engine.GET("/health", healthHandler)
+	s.engine.GET("/v1/health", healthHandler)
 
 	// OAuth callback endpoints (reuse main server port)
 	// These endpoints receive provider redirects and persist


### PR DESCRIPTION
## Summary

Adds a lightweight health check endpoint to the main router so monitoring tools and launchd KeepAlive checks can probe liveness without authentication.

## What

- `GET /health` → `200 {"status":"ok","service":"cliproxyapi","version":"<buildinfo>"}`
- `GET /v1/health` → same handler (consistent with `/v1/*` namespace)
- Registered in `internal/api/server.go:setupRoutes()` alongside existing public OAuth callbacks
- No auth required — mirrors typical `/healthz` / `/readyz` conventions

## Why

Running `cliproxyapi` as a background service (launchd / systemd / Docker healthcheck) needs an unauthenticated liveness probe. Without it, harnesses default to `curl /` which hits the model-routing entrypoint and requires a valid bearer. External monitoring tools (Prometheus `blackbox_exporter`, Uptime Kuma, etc.) also expect a conventional `/health` or `/v1/health` route.

## Diff

```go
// Health check endpoint (no auth required)
healthHandler := func(c *gin.Context) {
    c.JSON(http.StatusOK, gin.H{
        "status":  "ok",
        "service": "cliproxyapi",
        "version": buildinfo.Version,
    })
}
s.engine.GET("/health", healthHandler)
s.engine.GET("/v1/health", healthHandler)
```

## Test

Built locally against 158c69d (based on master at 453aaf8). Verified:

- `curl http://localhost:8317/health` → `200 {"status":"ok",...}`
- `curl http://localhost:8317/v1/health` → same
- Other routes (OAuth callbacks, `/v1/models`, `/v1/messages`) unaffected

## Notes

Discovered while wiring a homestack health harness that treats `curl -sf /health` as the liveness contract. `/healthz` alone wasn't matched. Happy to adjust wording/placement if you'd prefer `/healthz` too or a different JSON shape.