### PR TITLE
docs(config): align config.example billing header key + document X-Cliproxy-Cloak-Opt-Out directives

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -200,6 +200,13 @@ nonstream-keepalive-interval: 0
 #         - "API"
 #         - "proxy"
 #       cache-user-id: true          # optional: default is false; set true to reuse cached user_id per API key instead of generating a random one each request
+#       # OAuth cloaking levers — all default to true (legacy behavior). Set to false to opt out.
+#       oauth-sanitize-system-prompt: true  # when false, client system prompts are forwarded as-is instead of being collapsed to a stub
+#       oauth-remap-tool-names: true        # when false, tool names are NOT remapped to Claude Code canonical names
+#       oauth-inject-billing-header: true   # when false, the x-anthropic-billing-header block is NOT prepended to the system prompt
+#       # oauth-disable-header: ""          # optional shared secret; when set, clients can disable individual levers at request time
+#                                           # via X-Cliproxy-Cloak-Opt-Out + X-Cliproxy-Cloak-Token headers. Empty = opt-out disabled.
+#                                           # X-Cliproxy-Cloak-Opt-Out values (comma-separated): all, sanitize, tool-remap, billing
 #     experimental-cch-signing: false # optional: default is false; when true, sign the final /v1/messages body using the current Claude Code cch algorithm
 #                                     # keep this disabled unless you explicitly need the behavior, so upstream seed changes fall back to legacy proxy behavior
 


### PR DESCRIPTION
## Scope
Two doc-only fixes in `config.example.yaml`: (1) corrects the key name in the `oauth-inject-billing-header` comment from `x-anthropic-billing-account` to `x-anthropic-billing-header` (matching the actual implementation); adds the full OAuth cloaking lever block (sanitize, remap, billing, opt-out) with accurate inline comments. (2) Documents all `X-Cliproxy-Cloak-Opt-Out` directive values (`all`, `sanitize`, `tool-remap`, `billing`) under the opt-out comment. No code changes.

## Dependencies
This PR documents OAuth cloaking levers and `X-Cliproxy-Cloak-Opt-Out` directives that are **implemented in** (forward-looking doc PR — branch is cut from `dev` which precedes these):
- #2854 — `feat(config): scaffold OAuth cloaking levers on CloakConfig`
- #2860 — `feat(executor): gate system-prompt sanitization on OAuthSanitizeSystemPrompt`
- #2862 — `feat(executor): gate OAuth tool-name remap on OAuthRemapToolNames`
- #2863 — `feat(executor): gate x-anthropic-billing-header on OAuthInjectBillingHeader`
- #2864 — `feat(executor): header-based opt-out for OAuth cloaking levers (shared-secret)`

Reviewers: the features documented here exist in those PRs but **not yet in `dev`**. This PR is intentionally a forward-looking doc PR; it should merge after (or together with) the above five.

## Tests Added
- None (documentation only)

## AGENTS.md Checklist
- [x] English-only comments
- [x] No `log.Fatal`
- [x] No `internal/translator/` modifications
- [x] `gofmt -w` applied (no Go files changed)

## Closes / References
Closes nits from @luispater on #2860 and #2862: config.example billing key name drift and missing X-Cliproxy-Cloak-Opt-Out directive documentation.



---
_Cleanup (F-R.9): removed tracked .factory/validation/** artifacts from branch and added .factory/validation/** to .gitignore._
