### PR TITLE
feat(auth): Add OAuth quota group suspension

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -360,6 +360,59 @@ nonstream-keepalive-interval: 0
 #   kimi:
 #     - "kimi-k2-thinking"
 
+# OAuth quota groups for Google-backed shared quota families.
+# These groups are used for per-account + per-quota-family suspension logic.
+# oauth-quota-groups:
+#   - id: "claude_45"
+#     label: "Claude"
+#     providers: ["antigravity", "gemini", "gemini-cli"]
+#     patterns:
+#       - "claude-opus-4-6*"
+#       - "claude-opus-4-5*"
+#       - "claude-sonnet-4-6*"
+#       - "claude-sonnet-4-5*"
+#       - "gpt-oss-120b-medium*"
+#     priority: 300
+#     enabled: true
+#   - id: "g3_pro"
+#     label: "Gemini Pro"
+#     providers: ["antigravity", "gemini", "gemini-cli"]
+#     patterns:
+#       - "gemini-3.1-pro-high*"
+#       - "gemini-3.1-pro-low*"
+#       - "gemini-3-pro-high*"
+#       - "gemini-3-pro-low*"
+#       - "gemini-3-pro-image*"
+#     priority: 200
+#     enabled: true
+#   - id: "g3_flash"
+#     label: "Gemini Flash"
+#     providers: ["antigravity", "gemini", "gemini-cli"]
+#     patterns:
+#       - "gemini-3-flash*"
+#       - "gemini-3.1-flash*"
+#       - "gemini-3-flash-image*"
+#       - "gemini-3.1-flash-image*"
+#       - "gemini-3-flash-lite*"
+#       - "gemini-3.1-flash-lite*"
+#     priority: 100
+#     enabled: true
+
+# CPA-owned persisted state for account + quota-group manual/auto suspension.
+# This section is normally maintained by the management API.
+# oauth-account-quota-group-state:
+#   - auth_id: "auth-123"
+#     group_id: "claude_45"
+#     manual_suspended: true
+#     manual_reason: "maintenance"
+#     auto_suspended_until: 2026-04-14T12:00:00Z
+#     auto_reason: "quota_exhausted"
+#     source_model: "claude-opus-4-6-thinking"
+#     source_provider: "antigravity"
+#     reset_time_source: "retry_after"
+#     updated_at: 2026-04-14T10:00:00Z
+#     updated_by: "management:manual"
+
 # Optional payload configuration
 # payload:
 #   default: # Default rules only set parameters when they are missing in the payload.

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -65,6 +65,10 @@ func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Man
 		allowRemoteOverride: envSecret != "",
 		envSecret:           envSecret,
 	}
+	if manager != nil {
+		manager.SetConfig(cfg)
+		manager.SetConfigFilePath(configFilePath)
+	}
 	h.startAttemptCleanup()
 	return h
 }
@@ -105,10 +109,21 @@ func NewHandlerWithoutConfigFilePath(cfg *config.Config, manager *coreauth.Manag
 }
 
 // SetConfig updates the in-memory config reference when the server hot-reloads.
-func (h *Handler) SetConfig(cfg *config.Config) { h.cfg = cfg }
+func (h *Handler) SetConfig(cfg *config.Config) {
+	h.cfg = cfg
+	if h.authManager != nil {
+		h.authManager.SetConfig(cfg)
+	}
+}
 
 // SetAuthManager updates the auth manager reference used by management endpoints.
-func (h *Handler) SetAuthManager(manager *coreauth.Manager) { h.authManager = manager }
+func (h *Handler) SetAuthManager(manager *coreauth.Manager) {
+	h.authManager = manager
+	if manager != nil {
+		manager.SetConfig(h.cfg)
+		manager.SetConfigFilePath(h.configFilePath)
+	}
+}
 
 // SetUsageStatistics allows replacing the usage statistics reference.
 func (h *Handler) SetUsageStatistics(stats *usage.RequestStatistics) { h.usageStats = stats }
@@ -280,6 +295,10 @@ func (h *Handler) persist(c *gin.Context) bool {
 	if err := config.SaveConfigPreserveComments(h.configFilePath, h.cfg); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to save config: %v", err)})
 		return false
+	}
+	if h.authManager != nil {
+		h.authManager.SetConfig(h.cfg)
+		h.authManager.SetConfigFilePath(h.configFilePath)
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	return true

--- a/internal/api/handlers/management/quota_groups.go
+++ b/internal/api/handlers/management/quota_groups.go
@@ -1,0 +1,238 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func providerSupportsOAuthQuotaGroups(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "antigravity", "gemini", "gemini-cli":
+		return true
+	default:
+		return false
+	}
+}
+
+func effectiveOAuthQuotaGroupsForProvider(groups []config.OAuthQuotaGroup, provider string) []config.OAuthQuotaGroup {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return nil
+	}
+	out := make([]config.OAuthQuotaGroup, 0, len(groups))
+	for _, group := range groups {
+		if !group.Enabled {
+			continue
+		}
+		for _, candidate := range group.Providers {
+			if strings.EqualFold(strings.TrimSpace(candidate), provider) {
+				out = append(out, group)
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Priority != out[j].Priority {
+			return out[i].Priority > out[j].Priority
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func lookupOAuthAccountQuotaGroupState(entries []config.OAuthAccountQuotaGroupState, authID, groupID string) (config.OAuthAccountQuotaGroupState, bool) {
+	authID = strings.TrimSpace(authID)
+	groupID = strings.ToLower(strings.TrimSpace(groupID))
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.AuthID) == authID && strings.EqualFold(strings.TrimSpace(entry.GroupID), groupID) {
+			return entry, true
+		}
+	}
+	return config.OAuthAccountQuotaGroupState{}, false
+}
+
+func (h *Handler) GetOAuthQuotaGroups(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"oauth-quota-groups": config.NormalizeOAuthQuotaGroups(h.cfg.OAuthQuotaGroups),
+	})
+}
+
+func (h *Handler) PutOAuthQuotaGroups(c *gin.Context) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read body"})
+		return
+	}
+	var entries []config.OAuthQuotaGroup
+	if err = json.Unmarshal(data, &entries); err != nil {
+		var wrapper struct {
+			Items []config.OAuthQuotaGroup `json:"items"`
+		}
+		if err2 := json.Unmarshal(data, &wrapper); err2 != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+			return
+		}
+		entries = wrapper.Items
+	}
+	h.cfg.OAuthQuotaGroups = config.NormalizeOAuthQuotaGroups(entries)
+	h.persist(c)
+}
+
+func (h *Handler) GetAuthFileQuotaGroups(c *gin.Context) {
+	if h.authManager == nil {
+		c.JSON(http.StatusOK, gin.H{"items": []gin.H{}})
+		return
+	}
+	h.authManager.ClearExpiredOAuthQuotaGroupAutoStates(time.Now())
+	definitions := config.NormalizeOAuthQuotaGroups(h.cfg.OAuthQuotaGroups)
+	stateEntries := config.NormalizeOAuthAccountQuotaGroupState(h.cfg.OAuthAccountQuotaGroupState)
+	groupPriority := make(map[string]int, len(definitions))
+	for _, group := range definitions {
+		groupPriority[group.ID] = group.Priority
+	}
+	now := time.Now()
+	items := make([]gin.H, 0)
+	for _, auth := range h.authManager.List() {
+		if auth == nil || !providerSupportsOAuthQuotaGroups(auth.Provider) {
+			continue
+		}
+		for _, group := range effectiveOAuthQuotaGroupsForProvider(definitions, auth.Provider) {
+			state, _ := lookupOAuthAccountQuotaGroupState(stateEntries, auth.ID, group.ID)
+			effectiveStatus := "available"
+			if auth.Disabled {
+				effectiveStatus = "auth_disabled"
+			} else if state.ManualSuspended {
+				effectiveStatus = "manual_suspended"
+			} else if !state.AutoSuspendedUntil.IsZero() && state.AutoSuspendedUntil.After(now) {
+				effectiveStatus = "auto_suspended"
+			}
+			var autoSuspendedUntil any
+			if !state.AutoSuspendedUntil.IsZero() {
+				autoSuspendedUntil = state.AutoSuspendedUntil
+			}
+			var updatedAt any
+			if !state.UpdatedAt.IsZero() {
+				updatedAt = state.UpdatedAt
+			}
+			items = append(items, gin.H{
+				"auth_id":              auth.ID,
+				"provider":             strings.ToLower(strings.TrimSpace(auth.Provider)),
+				"group_id":             group.ID,
+				"label":                group.Label,
+				"effective_status":     effectiveStatus,
+				"manual_suspended":     state.ManualSuspended,
+				"manual_reason":        state.ManualReason,
+				"auto_suspended_until": autoSuspendedUntil,
+				"auto_reason":          state.AutoReason,
+				"source_model":         state.SourceModel,
+				"source_provider":      state.SourceProvider,
+				"reset_time_source":    state.ResetTimeSource,
+				"updated_at":           updatedAt,
+				"updated_by":           state.UpdatedBy,
+			})
+		}
+	}
+	sort.Slice(items, func(i, j int) bool {
+		authLeft, _ := items[i]["auth_id"].(string)
+		authRight, _ := items[j]["auth_id"].(string)
+		if authLeft != authRight {
+			return authLeft < authRight
+		}
+		groupLeft, _ := items[i]["group_id"].(string)
+		groupRight, _ := items[j]["group_id"].(string)
+		if groupPriority[groupLeft] != groupPriority[groupRight] {
+			return groupPriority[groupLeft] > groupPriority[groupRight]
+		}
+		return groupLeft < groupRight
+	})
+	c.JSON(http.StatusOK, gin.H{"items": items})
+}
+
+func (h *Handler) PatchAuthFileQuotaGroupsManual(c *gin.Context) {
+	var body struct {
+		AuthID          string `json:"auth_id"`
+		GroupID         string `json:"group_id"`
+		ManualSuspended *bool  `json:"manual_suspended"`
+		Reason          string `json:"reason"`
+		UpdatedBy       string `json:"updated_by"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.ManualSuspended == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	authID := strings.TrimSpace(body.AuthID)
+	groupID := strings.ToLower(strings.TrimSpace(body.GroupID))
+	if authID == "" || groupID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth_id and group_id are required"})
+		return
+	}
+
+	now := time.Now().UTC()
+	current, _ := lookupOAuthAccountQuotaGroupState(h.cfg.OAuthAccountQuotaGroupState, authID, groupID)
+	current.AuthID = authID
+	current.GroupID = groupID
+	current.ManualSuspended = *body.ManualSuspended
+	current.ManualReason = strings.TrimSpace(body.Reason)
+	current.UpdatedAt = now
+	current.UpdatedBy = strings.TrimSpace(body.UpdatedBy)
+	if current.UpdatedBy == "" {
+		current.UpdatedBy = "management:manual"
+	}
+	if !current.ManualSuspended {
+		current.ManualReason = ""
+	}
+
+	if !current.ManualSuspended && current.AutoSuspendedUntil.IsZero() {
+		h.cfg.OAuthAccountQuotaGroupState = config.RemoveOAuthAccountQuotaGroupState(h.cfg.OAuthAccountQuotaGroupState, authID, groupID)
+	} else {
+		h.cfg.OAuthAccountQuotaGroupState = config.UpsertOAuthAccountQuotaGroupState(h.cfg.OAuthAccountQuotaGroupState, current)
+	}
+	h.persist(c)
+}
+
+func (h *Handler) PatchAuthFileQuotaGroupsAutoClear(c *gin.Context) {
+	var body struct {
+		AuthID    string `json:"auth_id"`
+		GroupID   string `json:"group_id"`
+		UpdatedBy string `json:"updated_by"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	authID := strings.TrimSpace(body.AuthID)
+	groupID := strings.ToLower(strings.TrimSpace(body.GroupID))
+	if authID == "" || groupID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth_id and group_id are required"})
+		return
+	}
+
+	current, ok := lookupOAuthAccountQuotaGroupState(h.cfg.OAuthAccountQuotaGroupState, authID, groupID)
+	if !ok {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		return
+	}
+	current.AutoSuspendedUntil = time.Time{}
+	current.AutoReason = ""
+	current.SourceModel = ""
+	current.SourceProvider = ""
+	current.ResetTimeSource = ""
+	current.UpdatedAt = time.Now().UTC()
+	current.UpdatedBy = strings.TrimSpace(body.UpdatedBy)
+	if current.UpdatedBy == "" {
+		current.UpdatedBy = "management:auto-clear"
+	}
+
+	if current.ManualSuspended {
+		h.cfg.OAuthAccountQuotaGroupState = config.UpsertOAuthAccountQuotaGroupState(h.cfg.OAuthAccountQuotaGroupState, current)
+	} else {
+		h.cfg.OAuthAccountQuotaGroupState = config.RemoveOAuthAccountQuotaGroupState(h.cfg.OAuthAccountQuotaGroupState, authID, groupID)
+	}
+	h.persist(c)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -259,6 +259,8 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	s.applyAccessConfig(nil, cfg)
 	if authManager != nil {
 		authManager.SetRetryConfig(cfg.RequestRetry, time.Duration(cfg.MaxRetryInterval)*time.Second, cfg.MaxRetryCredentials)
+		authManager.SetConfig(cfg)
+		authManager.SetConfigFilePath(configFilePath)
 	}
 	managementasset.SetCurrentConfig(cfg)
 	auth.SetQuotaCooldownDisabled(cfg.DisableCooling)
@@ -612,13 +614,19 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PATCH("/oauth-model-alias", s.mgmt.PatchOAuthModelAlias)
 		mgmt.DELETE("/oauth-model-alias", s.mgmt.DeleteOAuthModelAlias)
 
+		mgmt.GET("/oauth-quota-groups", s.mgmt.GetOAuthQuotaGroups)
+		mgmt.PUT("/oauth-quota-groups", s.mgmt.PutOAuthQuotaGroups)
+
 		mgmt.GET("/auth-files", s.mgmt.ListAuthFiles)
 		mgmt.GET("/auth-files/models", s.mgmt.GetAuthFileModels)
+		mgmt.GET("/auth-files/quota-groups", s.mgmt.GetAuthFileQuotaGroups)
 		mgmt.GET("/model-definitions/:channel", s.mgmt.GetStaticModelDefinitions)
 		mgmt.GET("/auth-files/download", s.mgmt.DownloadAuthFile)
 		mgmt.POST("/auth-files", s.mgmt.UploadAuthFile)
 		mgmt.DELETE("/auth-files", s.mgmt.DeleteAuthFile)
 		mgmt.PATCH("/auth-files/status", s.mgmt.PatchAuthFileStatus)
+		mgmt.PATCH("/auth-files/quota-groups/manual", s.mgmt.PatchAuthFileQuotaGroupsManual)
+		mgmt.PATCH("/auth-files/quota-groups/auto/clear", s.mgmt.PatchAuthFileQuotaGroupsAutoClear)
 		mgmt.PATCH("/auth-files/fields", s.mgmt.PatchAuthFileFields)
 		mgmt.POST("/vertex/import", s.mgmt.ImportVertexCredential)
 
@@ -907,6 +915,8 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 
 	if s.handlers != nil && s.handlers.AuthManager != nil {
 		s.handlers.AuthManager.SetRetryConfig(cfg.RequestRetry, time.Duration(cfg.MaxRetryInterval)*time.Second, cfg.MaxRetryCredentials)
+		s.handlers.AuthManager.SetConfig(cfg)
+		s.handlers.AuthManager.SetConfigFilePath(s.configFilePath)
 	}
 
 	// Update log level dynamically when debug flag changes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,6 +134,12 @@ type Config struct {
 	// gemini-api-key, codex-api-key, claude-api-key, openai-compatibility, vertex-api-key, and ampcode.
 	OAuthModelAlias map[string][]OAuthModelAlias `yaml:"oauth-model-alias,omitempty" json:"oauth-model-alias,omitempty"`
 
+	// OAuthQuotaGroups defines shared quota families used for OAuth-backed Google model routing.
+	OAuthQuotaGroups []OAuthQuotaGroup `yaml:"oauth-quota-groups,omitempty" json:"oauth-quota-groups,omitempty"`
+
+	// OAuthAccountQuotaGroupState persists manual and auto suspension state for account/group pairs.
+	OAuthAccountQuotaGroupState []OAuthAccountQuotaGroupState `yaml:"oauth-account-quota-group-state,omitempty" json:"oauth-account-quota-group-state,omitempty"`
+
 	// Payload defines default and override rules for provider payload parameters.
 	Payload PayloadConfig `yaml:"payload" json:"payload"`
 
@@ -243,6 +249,9 @@ type OAuthModelAlias struct {
 	Alias string `yaml:"alias" json:"alias"`
 	Fork  bool   `yaml:"fork,omitempty" json:"fork,omitempty"`
 }
+
+func (m OAuthModelAlias) GetName() string  { return m.Name }
+func (m OAuthModelAlias) GetAlias() string { return m.Alias }
 
 // AmpModelMapping defines a model name mapping for Amp CLI requests.
 // When Amp requests a model that isn't available locally, this mapping
@@ -695,6 +704,10 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Normalize global OAuth model name aliases.
 	cfg.SanitizeOAuthModelAlias()
 
+	// Normalize OAuth quota-group definitions and persisted quota-group runtime state.
+	cfg.OAuthQuotaGroups = NormalizeOAuthQuotaGroups(cfg.OAuthQuotaGroups)
+	cfg.OAuthAccountQuotaGroupState = NormalizeOAuthAccountQuotaGroupState(cfg.OAuthAccountQuotaGroupState)
+
 	// Validate raw payload rules and drop invalid entries.
 	cfg.SanitizePayloadRules()
 
@@ -1062,6 +1075,7 @@ func SaveConfigPreserveComments(configFile string, cfg *Config) error {
 
 	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "oauth-excluded-models")
 	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "oauth-model-alias")
+	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "oauth-account-quota-group-state")
 
 	// Merge generated into original in-place, preserving comments/order of existing nodes.
 	mergeMappingPreserve(original.Content[0], generated.Content[0])

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -1081,12 +1082,8 @@ func SaveConfigPreserveComments(configFile string, cfg *Config) error {
 	mergeMappingPreserve(original.Content[0], generated.Content[0])
 	normalizeCollectionNodeStyles(original.Content[0])
 
-	// Write back.
-	f, err := os.Create(configFile)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
+	// Render the merged YAML into memory first so a rendering failure never
+	// leaves the on-disk file truncated.
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
@@ -1098,8 +1095,50 @@ func SaveConfigPreserveComments(configFile string, cfg *Config) error {
 		return err
 	}
 	data = NormalizeCommentIndentation(buf.Bytes())
-	_, err = f.Write(data)
-	return err
+
+	// Write atomically: temp file in the same directory, fsync, then rename.
+	// This prevents a partial write from corrupting the live config on crash
+	// or concurrent writer races.
+	return writeFileAtomic(configFile, data, 0o644)
+}
+
+// writeFileAtomic writes data to path by first writing to a sibling temp file,
+// flushing it to disk, and then renaming over the target. Rename on the same
+// filesystem is atomic on POSIX and best-effort atomic on Windows (ReplaceFile
+// semantics via os.Rename in Go).
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	tmp, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+
+	if _, err = tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err = tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err = tmp.Chmod(perm); err != nil {
+		// Non-fatal on Windows where Chmod has limited effect; ignore.
+		_ = err
+	}
+	if err = tmp.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err = os.Rename(tmpName, path); err != nil {
+		cleanup()
+		return err
+	}
+	return nil
 }
 
 // SaveConfigPreserveCommentsUpdateNestedScalar updates a nested scalar key path like ["a","b"]

--- a/internal/config/oauth_quota_groups.go
+++ b/internal/config/oauth_quota_groups.go
@@ -1,0 +1,383 @@
+package config
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	OAuthQuotaGroupClaude45 = "claude_45"
+	OAuthQuotaGroupG3Pro    = "g3_pro"
+	OAuthQuotaGroupG3Flash  = "g3_flash"
+)
+
+func canonicalOAuthQuotaGroupID(id string) string {
+	switch strings.ToLower(strings.TrimSpace(id)) {
+	case "google-claude", "claude", OAuthQuotaGroupClaude45:
+		return OAuthQuotaGroupClaude45
+	case "google-gemini-pro", "gemini-pro", OAuthQuotaGroupG3Pro:
+		return OAuthQuotaGroupG3Pro
+	case "google-gemini-flash", "gemini-flash", OAuthQuotaGroupG3Flash:
+		return OAuthQuotaGroupG3Flash
+	default:
+		return strings.ToLower(strings.TrimSpace(id))
+	}
+}
+
+func legacyGeminiImageGroupIDs(sourceModel string) []string {
+	sourceModel = strings.ToLower(strings.TrimSpace(sourceModel))
+	switch {
+	case sourceModel == "":
+		return []string{OAuthQuotaGroupG3Pro, OAuthQuotaGroupG3Flash}
+	case strings.Contains(sourceModel, "flash"):
+		return []string{OAuthQuotaGroupG3Flash}
+	case strings.Contains(sourceModel, "pro"), strings.Contains(sourceModel, "image"), strings.HasPrefix(sourceModel, "imagen"):
+		return []string{OAuthQuotaGroupG3Pro}
+	default:
+		return []string{OAuthQuotaGroupG3Pro, OAuthQuotaGroupG3Flash}
+	}
+}
+
+func normalizedOAuthQuotaGroupStateGroupIDs(entry OAuthAccountQuotaGroupState) []string {
+	groupID := strings.ToLower(strings.TrimSpace(entry.GroupID))
+	switch groupID {
+	case "":
+		return nil
+	case "google-gemini-image":
+		return legacyGeminiImageGroupIDs(entry.SourceModel)
+	default:
+		return []string{canonicalOAuthQuotaGroupID(groupID)}
+	}
+}
+
+func normalizedOAuthQuotaGroupIDsForRemoval(groupID string) []string {
+	switch strings.ToLower(strings.TrimSpace(groupID)) {
+	case "":
+		return nil
+	case "google-gemini-image":
+		return []string{OAuthQuotaGroupG3Pro, OAuthQuotaGroupG3Flash}
+	default:
+		return []string{canonicalOAuthQuotaGroupID(groupID)}
+	}
+}
+
+// OAuthQuotaGroup defines a logical quota family shared across OAuth-backed accounts.
+type OAuthQuotaGroup struct {
+	ID        string   `yaml:"id" json:"id"`
+	Label     string   `yaml:"label" json:"label"`
+	Providers []string `yaml:"providers,omitempty" json:"providers,omitempty"`
+	Patterns  []string `yaml:"patterns,omitempty" json:"patterns,omitempty"`
+	Priority  int      `yaml:"priority" json:"priority"`
+	Enabled   bool     `yaml:"enabled" json:"enabled"`
+
+	enabledSet bool `yaml:"-" json:"-"`
+}
+
+// OAuthAccountQuotaGroupState stores persisted manual/auto suspension state for
+// an auth account and one resolved quota group.
+type OAuthAccountQuotaGroupState struct {
+	AuthID             string    `yaml:"auth_id" json:"auth_id"`
+	GroupID            string    `yaml:"group_id" json:"group_id"`
+	ManualSuspended    bool      `yaml:"manual_suspended,omitempty" json:"manual_suspended,omitempty"`
+	ManualReason       string    `yaml:"manual_reason,omitempty" json:"manual_reason,omitempty"`
+	AutoSuspendedUntil time.Time `yaml:"auto_suspended_until,omitempty" json:"auto_suspended_until,omitempty"`
+	AutoReason         string    `yaml:"auto_reason,omitempty" json:"auto_reason,omitempty"`
+	SourceModel        string    `yaml:"source_model,omitempty" json:"source_model,omitempty"`
+	SourceProvider     string    `yaml:"source_provider,omitempty" json:"source_provider,omitempty"`
+	ResetTimeSource    string    `yaml:"reset_time_source,omitempty" json:"reset_time_source,omitempty"`
+	UpdatedAt          time.Time `yaml:"updated_at,omitempty" json:"updated_at,omitempty"`
+	UpdatedBy          string    `yaml:"updated_by,omitempty" json:"updated_by,omitempty"`
+}
+
+func DefaultOAuthQuotaGroups() []OAuthQuotaGroup {
+	return []OAuthQuotaGroup{
+		{
+			ID:        OAuthQuotaGroupClaude45,
+			Label:     "Claude",
+			Providers: []string{"antigravity", "gemini", "gemini-cli"},
+			Patterns: []string{
+				"claude-opus-4-6*",
+				"claude-opus-4-5*",
+				"claude-sonnet-4-6*",
+				"claude-sonnet-4-5*",
+				"gpt-oss-120b-medium*",
+			},
+			Priority:  300,
+			Enabled:   true,
+		},
+		{
+			ID:        OAuthQuotaGroupG3Pro,
+			Label:     "Gemini Pro",
+			Providers: []string{"antigravity", "gemini", "gemini-cli"},
+			Patterns: []string{
+				"gemini-3.1-pro-high*",
+				"gemini-3.1-pro-low*",
+				"gemini-3-pro-high*",
+				"gemini-3-pro-low*",
+				"gemini-3-pro-image*",
+			},
+			Priority:  200,
+			Enabled:   true,
+		},
+		{
+			ID:        OAuthQuotaGroupG3Flash,
+			Label:     "Gemini Flash",
+			Providers: []string{"antigravity", "gemini", "gemini-cli"},
+			Patterns: []string{
+				"gemini-3-flash*",
+				"gemini-3.1-flash*",
+				"gemini-3-flash-image*",
+				"gemini-3.1-flash-image*",
+				"gemini-3-flash-lite*",
+				"gemini-3.1-flash-lite*",
+			},
+			Priority: 100,
+			Enabled:  true,
+		},
+	}
+}
+
+func (g *OAuthQuotaGroup) UnmarshalYAML(unmarshal func(any) error) error {
+	type rawGroup struct {
+		ID        string   `yaml:"id"`
+		Label     string   `yaml:"label"`
+		Providers []string `yaml:"providers"`
+		Patterns  []string `yaml:"patterns"`
+		Priority  int      `yaml:"priority"`
+		Enabled   *bool    `yaml:"enabled"`
+	}
+
+	var raw rawGroup
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+
+	g.ID = raw.ID
+	g.Label = raw.Label
+	g.Providers = raw.Providers
+	g.Patterns = raw.Patterns
+	g.Priority = raw.Priority
+	g.Enabled = false
+	g.enabledSet = false
+	if raw.Enabled != nil {
+		g.Enabled = *raw.Enabled
+		g.enabledSet = true
+	}
+	return nil
+}
+
+func (g *OAuthQuotaGroup) UnmarshalJSON(data []byte) error {
+	type rawGroup struct {
+		ID        string   `json:"id"`
+		Label     string   `json:"label"`
+		Providers []string `json:"providers"`
+		Patterns  []string `json:"patterns"`
+		Priority  int      `json:"priority"`
+		Enabled   *bool    `json:"enabled"`
+	}
+
+	var raw rawGroup
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	g.ID = raw.ID
+	g.Label = raw.Label
+	g.Providers = raw.Providers
+	g.Patterns = raw.Patterns
+	g.Priority = raw.Priority
+	g.Enabled = false
+	g.enabledSet = false
+	if raw.Enabled != nil {
+		g.Enabled = *raw.Enabled
+		g.enabledSet = true
+	}
+	return nil
+}
+
+func defaultOAuthQuotaGroupMap() map[string]OAuthQuotaGroup {
+	defaults := DefaultOAuthQuotaGroups()
+	out := make(map[string]OAuthQuotaGroup, len(defaults))
+	for _, entry := range defaults {
+		out[entry.ID] = entry
+	}
+	return out
+}
+
+// NormalizeOAuthQuotaGroups sanitizes quota-group definitions and injects the v1 bootstrap defaults.
+func NormalizeOAuthQuotaGroups(entries []OAuthQuotaGroup) []OAuthQuotaGroup {
+	defaults := defaultOAuthQuotaGroupMap()
+	if len(entries) == 0 {
+		return append([]OAuthQuotaGroup(nil), DefaultOAuthQuotaGroups()...)
+	}
+
+	byID := make(map[string]OAuthQuotaGroup, len(defaults))
+	for id, entry := range defaults {
+		byID[id] = entry
+	}
+
+	for _, raw := range entries {
+		if strings.EqualFold(strings.TrimSpace(raw.ID), "google-gemini-image") {
+			continue
+		}
+		id := canonicalOAuthQuotaGroupID(raw.ID)
+		if id == "" {
+			continue
+		}
+		entry := raw
+		entry.ID = id
+		entry.Label = strings.TrimSpace(entry.Label)
+		entry.Providers = NormalizeExcludedModels(entry.Providers)
+		entry.Patterns = NormalizeExcludedModels(entry.Patterns)
+		if def, ok := defaults[id]; ok {
+			if entry.Label == "" {
+				entry.Label = def.Label
+			}
+			if len(entry.Providers) == 0 {
+				entry.Providers = append([]string(nil), def.Providers...)
+			}
+			if len(entry.Patterns) == 0 {
+				entry.Patterns = append([]string(nil), def.Patterns...)
+			}
+			if entry.Priority == 0 {
+				entry.Priority = def.Priority
+			}
+		}
+		if entry.Label == "" || len(entry.Providers) == 0 || len(entry.Patterns) == 0 {
+			continue
+		}
+		if raw.enabledSet {
+			entry.Enabled = raw.Enabled
+		} else if def, ok := defaults[id]; ok {
+			entry.Enabled = def.Enabled
+		} else {
+			entry.Enabled = true
+		}
+		byID[id] = entry
+	}
+
+	out := make([]OAuthQuotaGroup, 0, len(byID))
+	for _, entry := range byID {
+		if entry.ID == "" || entry.Label == "" || len(entry.Providers) == 0 || len(entry.Patterns) == 0 {
+			continue
+		}
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Priority != out[j].Priority {
+			return out[i].Priority > out[j].Priority
+		}
+		return out[i].ID < out[j].ID
+	})
+	if len(out) == 0 {
+		return append([]OAuthQuotaGroup(nil), DefaultOAuthQuotaGroups()...)
+	}
+	return out
+}
+
+// NormalizeOAuthAccountQuotaGroupState sanitizes persisted account/group suspension state.
+func NormalizeOAuthAccountQuotaGroupState(entries []OAuthAccountQuotaGroupState) []OAuthAccountQuotaGroupState {
+	if len(entries) == 0 {
+		return nil
+	}
+	byKey := make(map[string]OAuthAccountQuotaGroupState, len(entries))
+	for _, raw := range entries {
+		authID := strings.TrimSpace(raw.AuthID)
+		groupIDs := normalizedOAuthQuotaGroupStateGroupIDs(raw)
+		if authID == "" || len(groupIDs) == 0 {
+			continue
+		}
+		for _, groupID := range groupIDs {
+			entry := raw
+			entry.AuthID = authID
+			entry.GroupID = groupID
+			entry.ManualReason = strings.TrimSpace(entry.ManualReason)
+			entry.AutoReason = strings.TrimSpace(entry.AutoReason)
+			entry.SourceModel = strings.TrimSpace(entry.SourceModel)
+			entry.SourceProvider = strings.ToLower(strings.TrimSpace(entry.SourceProvider))
+			entry.ResetTimeSource = strings.TrimSpace(entry.ResetTimeSource)
+			entry.UpdatedBy = strings.TrimSpace(entry.UpdatedBy)
+
+			if !entry.ManualSuspended {
+				entry.ManualReason = ""
+			}
+			if entry.AutoSuspendedUntil.IsZero() {
+				entry.AutoReason = ""
+				entry.ResetTimeSource = ""
+			}
+			if !entry.ManualSuspended && entry.AutoSuspendedUntil.IsZero() {
+				continue
+			}
+			byKey[authID+"|"+groupID] = entry
+		}
+	}
+	if len(byKey) == 0 {
+		return nil
+	}
+	out := make([]OAuthAccountQuotaGroupState, 0, len(byKey))
+	for _, entry := range byKey {
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].AuthID != out[j].AuthID {
+			return out[i].AuthID < out[j].AuthID
+		}
+		return out[i].GroupID < out[j].GroupID
+	})
+	return out
+}
+
+// UpsertOAuthAccountQuotaGroupState replaces or inserts a normalized state entry.
+func UpsertOAuthAccountQuotaGroupState(entries []OAuthAccountQuotaGroupState, entry OAuthAccountQuotaGroupState) []OAuthAccountQuotaGroupState {
+	authID := strings.TrimSpace(entry.AuthID)
+	groupIDs := normalizedOAuthQuotaGroupStateGroupIDs(entry)
+	if authID == "" || len(groupIDs) == 0 {
+		return NormalizeOAuthAccountQuotaGroupState(entries)
+	}
+	entry.AuthID = authID
+
+	groupSet := make(map[string]struct{}, len(groupIDs))
+	for _, groupID := range groupIDs {
+		groupSet[groupID] = struct{}{}
+	}
+	filtered := make([]OAuthAccountQuotaGroupState, 0, len(entries)+len(groupIDs))
+	for _, candidate := range entries {
+		if strings.TrimSpace(candidate.AuthID) == authID {
+			if _, ok := groupSet[canonicalOAuthQuotaGroupID(candidate.GroupID)]; ok {
+				continue
+			}
+		}
+		filtered = append(filtered, candidate)
+	}
+	for _, groupID := range groupIDs {
+		next := entry
+		next.GroupID = groupID
+		filtered = append(filtered, next)
+	}
+	return NormalizeOAuthAccountQuotaGroupState(filtered)
+}
+
+// RemoveOAuthAccountQuotaGroupState removes a persisted state entry for one account/group pair.
+func RemoveOAuthAccountQuotaGroupState(entries []OAuthAccountQuotaGroupState, authID, groupID string) []OAuthAccountQuotaGroupState {
+	authID = strings.TrimSpace(authID)
+	groupIDs := normalizedOAuthQuotaGroupIDsForRemoval(groupID)
+	if authID == "" || len(groupIDs) == 0 || len(entries) == 0 {
+		return NormalizeOAuthAccountQuotaGroupState(entries)
+	}
+	groupSet := make(map[string]struct{}, len(groupIDs))
+	for _, id := range groupIDs {
+		groupSet[id] = struct{}{}
+	}
+	filtered := make([]OAuthAccountQuotaGroupState, 0, len(entries))
+	for _, candidate := range entries {
+		if strings.TrimSpace(candidate.AuthID) == authID {
+			if _, ok := groupSet[canonicalOAuthQuotaGroupID(candidate.GroupID)]; ok {
+				continue
+			}
+		}
+		filtered = append(filtered, candidate)
+	}
+	return NormalizeOAuthAccountQuotaGroupState(filtered)
+}

--- a/internal/config/oauth_quota_groups_test.go
+++ b/internal/config/oauth_quota_groups_test.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestNormalizeOAuthQuotaGroups_InjectsDefaults(t *testing.T) {
+	groups := NormalizeOAuthQuotaGroups(nil)
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 default groups, got %d", len(groups))
+	}
+	if groups[0].ID != OAuthQuotaGroupClaude45 {
+		t.Fatalf("expected highest priority group to be %q, got %q", OAuthQuotaGroupClaude45, groups[0].ID)
+	}
+}
+
+func TestUpsertAndRemoveOAuthAccountQuotaGroupState(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	entries := UpsertOAuthAccountQuotaGroupState(nil, OAuthAccountQuotaGroupState{
+		AuthID:             "auth-1",
+		GroupID:            "Google-Claude",
+		ManualSuspended:    true,
+		ManualReason:       "maintenance",
+		AutoSuspendedUntil: now,
+	})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 state entry, got %d", len(entries))
+	}
+	if entries[0].GroupID != OAuthQuotaGroupClaude45 {
+		t.Fatalf("expected normalized group id %q, got %q", OAuthQuotaGroupClaude45, entries[0].GroupID)
+	}
+
+	entries = RemoveOAuthAccountQuotaGroupState(entries, "auth-1", OAuthQuotaGroupClaude45)
+	if len(entries) != 0 {
+		t.Fatalf("expected state entry removal, got %d entries", len(entries))
+	}
+}
+
+func TestNormalizeOAuthAccountQuotaGroupState_MigratesLegacyGeminiImageGroup(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 30, 0, 0, time.UTC)
+	entries := NormalizeOAuthAccountQuotaGroupState([]OAuthAccountQuotaGroupState{
+		{
+			AuthID:             "auth-1",
+			GroupID:            "google-gemini-image",
+			ManualSuspended:    true,
+			AutoSuspendedUntil: now,
+		},
+	})
+	if len(entries) != 2 {
+		t.Fatalf("expected legacy image group to expand into 2 groups, got %d", len(entries))
+	}
+	if entries[0].GroupID != OAuthQuotaGroupG3Flash {
+		t.Fatalf("expected first migrated group to be %q, got %q", OAuthQuotaGroupG3Flash, entries[0].GroupID)
+	}
+	if entries[1].GroupID != OAuthQuotaGroupG3Pro {
+		t.Fatalf("expected second migrated group to be %q, got %q", OAuthQuotaGroupG3Pro, entries[1].GroupID)
+	}
+}
+
+func TestNormalizeOAuthQuotaGroups_DefaultsEnabledWhenOmitted(t *testing.T) {
+	var entries []OAuthQuotaGroup
+	if err := json.Unmarshal([]byte(`[
+		{
+			"id": "custom-group",
+			"label": "Custom Group",
+			"providers": ["antigravity"],
+			"patterns": ["custom-*"],
+			"priority": 50
+		}
+	]`), &entries); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	groups := NormalizeOAuthQuotaGroups(entries)
+	found := false
+	for _, group := range groups {
+		if group.ID != "custom-group" {
+			continue
+		}
+		found = true
+		if !group.Enabled {
+			t.Fatal("custom group Enabled = false, want true when field is omitted")
+		}
+	}
+	if !found {
+		t.Fatal("custom group missing after normalization")
+	}
+}
+
+func TestNormalizeOAuthQuotaGroups_PreservesExplicitDisabledFlag(t *testing.T) {
+	var entries []OAuthQuotaGroup
+	if err := json.Unmarshal([]byte(`[
+		{
+			"id": "custom-group",
+			"label": "Custom Group",
+			"providers": ["antigravity"],
+			"patterns": ["custom-*"],
+			"priority": 50,
+			"enabled": false
+		}
+	]`), &entries); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	groups := NormalizeOAuthQuotaGroups(entries)
+	found := false
+	for _, group := range groups {
+		if group.ID != "custom-group" {
+			continue
+		}
+		found = true
+		if group.Enabled {
+			t.Fatal("custom group Enabled = true, want explicit false to be preserved")
+		}
+	}
+	if !found {
+		t.Fatal("custom group missing after normalization")
+	}
+}
+
+func TestNormalizeOAuthQuotaGroups_DropsLegacyGeminiImageDefinition(t *testing.T) {
+	var entries []OAuthQuotaGroup
+	if err := json.Unmarshal([]byte(`[
+		{
+			"id": "google-gemini-image",
+			"label": "Google Gemini Image",
+			"providers": ["antigravity"],
+			"patterns": ["*image*"],
+			"priority": 400,
+			"enabled": true
+		}
+	]`), &entries); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	groups := NormalizeOAuthQuotaGroups(entries)
+	for _, group := range groups {
+		if group.ID == "google-gemini-image" {
+			t.Fatal("legacy google-gemini-image definition should be dropped during normalization")
+		}
+	}
+}

--- a/sdk/cliproxy/auth/antigravity_quota_groups_behavior_test.go
+++ b/sdk/cliproxy/auth/antigravity_quota_groups_behavior_test.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+func TestManagerExecute_AntigravityClaudeQuotaGroupDoesNotBlockGemini(t *testing.T) {
+	now := time.Now().UTC()
+
+	manager := NewManager(nil, nil, nil)
+	executor := &aliasRoutingExecutor{id: "antigravity"}
+	manager.RegisterExecutor(executor)
+
+	cfg := &internalconfig.Config{
+		OAuthQuotaGroups: internalconfig.DefaultOAuthQuotaGroups(),
+		OAuthAccountQuotaGroupState: []internalconfig.OAuthAccountQuotaGroupState{
+			{
+				AuthID:             "ag-auth",
+				GroupID:            internalconfig.OAuthQuotaGroupClaude45,
+				AutoSuspendedUntil: now.Add(30 * time.Minute),
+				AutoReason:         "quota_exhausted",
+				SourceModel:        "claude-sonnet-4-6",
+				SourceProvider:     "antigravity",
+				ResetTimeSource:    "retry_after",
+			},
+		},
+	}
+	manager.SetConfig(cfg)
+	t.Cleanup(func() {
+		manager.SetConfig(&internalconfig.Config{})
+	})
+
+	auth := &Auth{
+		ID:       "ag-auth",
+		Provider: "antigravity",
+		Status:   StatusActive,
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{
+		{ID: "claude-sonnet-4-6"},
+		{ID: "gemini-3.1-flash-lite"},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+	manager.RefreshSchedulerEntry(auth.ID)
+
+	updatedAuth, ok := manager.GetByID(auth.ID)
+	if !ok || updatedAuth == nil {
+		t.Fatal("updated auth missing")
+	}
+	updateAggregatedAvailability(updatedAuth, now)
+	if updatedAuth.Unavailable {
+		t.Fatal("auth.Unavailable = true, want false while Gemini quota-group is still available")
+	}
+
+	geminiResp, err := manager.Execute(
+		context.Background(),
+		[]string{"antigravity"},
+		cliproxyexecutor.Request{Model: "gemini-3.1-flash-lite"},
+		cliproxyexecutor.Options{},
+	)
+	if err != nil {
+		t.Fatalf("execute Gemini error = %v, want success", err)
+	}
+	if string(geminiResp.Payload) != "gemini-3.1-flash-lite" {
+		t.Fatalf("execute Gemini payload = %q, want %q", string(geminiResp.Payload), "gemini-3.1-flash-lite")
+	}
+
+	_, err = manager.Execute(
+		context.Background(),
+		[]string{"antigravity"},
+		cliproxyexecutor.Request{Model: "claude-sonnet-4-6"},
+		cliproxyexecutor.Options{},
+	)
+	if err == nil {
+		t.Fatal("execute Claude error = nil, want cooldown error")
+	}
+	if _, ok := err.(*modelCooldownError); !ok {
+		t.Fatalf("execute Claude error = %T, want *modelCooldownError", err)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -174,6 +174,11 @@ type Manager struct {
 	// Auto refresh state
 	refreshCancel context.CancelFunc
 	refreshLoop   *authAutoRefreshLoop
+
+	// quotaGroupCleanupCancel cancels the background OAuth quota-group
+	// expired-state cleanup loop. nil when no loop is running. See
+	// StartOAuthQuotaGroupCleanup.
+	quotaGroupCleanupCancel context.CancelFunc
 }
 
 // NewManager constructs a manager with optional custom selector and hook.
@@ -1231,7 +1236,10 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 	if len(normalized) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
-	m.ClearExpiredOAuthQuotaGroupAutoStates(time.Now())
+	// Expired quota-group auto suspensions are reaped by the background loop
+	// started via StartOAuthQuotaGroupCleanup (see oauth_quota_groups_manager.go).
+	// The per-request lock-free check in oauthQuotaGroupBlock already skips
+	// entries whose AutoSuspendedUntil is in the past.
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
@@ -1263,7 +1271,10 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 	if len(normalized) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
-	m.ClearExpiredOAuthQuotaGroupAutoStates(time.Now())
+	// Expired quota-group auto suspensions are reaped by the background loop
+	// started via StartOAuthQuotaGroupCleanup (see oauth_quota_groups_manager.go).
+	// The per-request lock-free check in oauthQuotaGroupBlock already skips
+	// entries whose AutoSuspendedUntil is in the past.
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
@@ -1295,7 +1306,10 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	if len(normalized) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
-	m.ClearExpiredOAuthQuotaGroupAutoStates(time.Now())
+	// Expired quota-group auto suspensions are reaped by the background loop
+	// started via StartOAuthQuotaGroupCleanup (see oauth_quota_groups_manager.go).
+	// The per-request lock-free check in oauthQuotaGroupBlock already skips
+	// entries whose AutoSuspendedUntil is in the past.
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
@@ -3053,6 +3067,12 @@ func (m *Manager) StartAutoRefresh(parent context.Context, interval time.Duratio
 
 	loop.rebuild(time.Now())
 	go loop.run(ctx)
+
+	// Piggy-back the quota-group cleanup loop on the refresh lifecycle so hosts
+	// that already call StartAutoRefresh/StopAutoRefresh get background reaping
+	// for free. Cancelling the refresh context also cancels this one because
+	// StartOAuthQuotaGroupCleanup derives its context from the supplied parent.
+	m.StartOAuthQuotaGroupCleanup(ctx, 0)
 }
 
 // StopAutoRefresh cancels the background refresh loop, if running.
@@ -3066,6 +3086,7 @@ func (m *Manager) StopAutoRefresh() {
 	if cancel != nil {
 		cancel()
 	}
+	m.StopOAuthQuotaGroupCleanup()
 	// Stop selector if it implements StoppableSelector (e.g., SessionAffinitySelector)
 	if stoppable, ok := m.selector.(StoppableSelector); ok {
 		stoppable.Stop()

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -165,6 +165,9 @@ type Manager struct {
 	// It is initialized in NewManager; never Load() before first Store().
 	runtimeConfig atomic.Value
 
+	// configFilePath stores the active config.yaml path used to persist CPA-owned runtime state.
+	configFilePath atomic.Value
+
 	// Optional HTTP RoundTripper provider injected by host.
 	rtProvider RoundTripperProvider
 
@@ -192,6 +195,7 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	}
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(&internalconfig.Config{})
+	manager.configFilePath.Store("")
 	manager.apiKeyModelAlias.Store(apiKeyModelAliasTable(nil))
 	manager.scheduler = newAuthScheduler(selector)
 	return manager
@@ -344,6 +348,45 @@ func (m *Manager) SetSelector(selector Selector) {
 	}
 }
 
+func selectorForRoutingStrategy(strategy string) Selector {
+	switch strings.ToLower(strings.TrimSpace(strategy)) {
+	case "fill-first", "fillfirst", "ff":
+		return &FillFirstSelector{}
+	default:
+		return &RoundRobinSelector{}
+	}
+}
+
+func sameSelectorKind(current Selector, next Selector) bool {
+	switch current.(type) {
+	case *FillFirstSelector:
+		_, ok := next.(*FillFirstSelector)
+		return ok
+	case *RoundRobinSelector:
+		_, ok := next.(*RoundRobinSelector)
+		return ok
+	default:
+		return false
+	}
+}
+
+func (m *Manager) applyBuiltInSelectorForConfig(cfg *internalconfig.Config) {
+	if m == nil || cfg == nil {
+		return
+	}
+	m.mu.RLock()
+	current := m.selector
+	m.mu.RUnlock()
+	if !isBuiltInSelector(current) {
+		return
+	}
+	next := selectorForRoutingStrategy(cfg.Routing.Strategy)
+	if sameSelectorKind(current, next) {
+		return
+	}
+	m.SetSelector(next)
+}
+
 // SetStore swaps the underlying persistence store.
 func (m *Manager) SetStore(store Store) {
 	m.mu.Lock()
@@ -368,7 +411,17 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 		cfg = &internalconfig.Config{}
 	}
 	m.runtimeConfig.Store(cfg)
+	m.applyBuiltInSelectorForConfig(cfg)
+	SetOAuthQuotaRuntimeConfig(cfg)
 	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
+}
+
+// SetConfigFilePath updates the config.yaml path used when persisting quota-group runtime state.
+func (m *Manager) SetConfigFilePath(path string) {
+	if m == nil {
+		return
+	}
+	m.configFilePath.Store(strings.TrimSpace(path))
 }
 
 func (m *Manager) lookupAPIKeyUpstreamModel(authID, requestedModel string) string {
@@ -1178,6 +1231,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 	if len(normalized) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
+	m.ClearExpiredOAuthQuotaGroupAutoStates(time.Now())
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
@@ -1209,6 +1263,7 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 	if len(normalized) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
+	m.ClearExpiredOAuthQuotaGroupAutoStates(time.Now())
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
@@ -1240,6 +1295,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	if len(normalized) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
+	m.ClearExpiredOAuthQuotaGroupAutoStates(time.Now())
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
@@ -1972,6 +2028,8 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	clearModelQuota := false
 	setModelQuota := false
 	var authSnapshot *Auth
+	var runtimeCfgToPublish *internalconfig.Config
+	persistRuntimeConfig := false
 
 	m.mu.Lock()
 	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
@@ -1979,6 +2037,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 
 		if result.Success {
 			if result.Model != "" {
+				if cfg, changed := m.clearOAuthQuotaGroupAutoStateLocked(auth, result.Model, now); changed {
+					runtimeCfgToPublish = cfg
+					persistRuntimeConfig = true
+				}
 				state := ensureModelState(auth, result.Model)
 				resetModelState(state, now)
 				updateAggregatedAvailability(auth, now)
@@ -2046,6 +2108,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						case 429:
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
+							_, matchedQuotaGroup := resolveOAuthQuotaGroup(auth, result.Model)
 							if !disableCooling {
 								if result.RetryAfter != nil {
 									next = now.Add(*result.RetryAfter)
@@ -2057,14 +2120,28 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 									backoffLevel = nextLevel
 								}
 							}
-							state.NextRetryAfter = next
-							state.Quota = QuotaState{
-								Exceeded:      true,
-								Reason:        "quota",
-								NextRecoverAt: next,
-								BackoffLevel:  backoffLevel,
+							if matchedQuotaGroup {
+								state.Unavailable = false
+								state.NextRetryAfter = time.Time{}
+								state.Quota = QuotaState{}
 							}
-							if !disableCooling {
+							if !disableCooling && !next.IsZero() && matchedQuotaGroup {
+								resetSource := "computed_backoff"
+								if result.RetryAfter != nil {
+									resetSource = "retry_after"
+								}
+								if cfg, changed := m.setOAuthQuotaGroupAutoStateLocked(auth, result.Model, result.Provider, next, resetSource, now); changed {
+									runtimeCfgToPublish = cfg
+									persistRuntimeConfig = true
+								}
+							} else if !disableCooling && !next.IsZero() {
+								state.NextRetryAfter = next
+								state.Quota = QuotaState{
+									Exceeded:      true,
+									Reason:        "quota",
+									NextRecoverAt: next,
+									BackoffLevel:  backoffLevel,
+								}
 								suspendReason = "quota"
 								shouldSuspendModel = true
 								setModelQuota = true
@@ -2094,6 +2171,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 		authSnapshot = auth.Clone()
 	}
 	m.mu.Unlock()
+	if runtimeCfgToPublish != nil {
+		m.SetConfig(runtimeCfgToPublish)
+		if persistRuntimeConfig {
+			if err := m.persistRuntimeConfigSnapshot(runtimeCfgToPublish); err != nil {
+				log.WithError(err).Warn("failed to persist oauth-account-quota-group-state")
+			}
+		}
+	}
 	if m.scheduler != nil && authSnapshot != nil {
 		m.scheduler.upsertAuth(authSnapshot)
 	}
@@ -2161,16 +2246,12 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	if auth == nil {
 		return
 	}
-	if len(auth.ModelStates) == 0 {
-		clearAggregatedAvailability(auth)
-		return
-	}
-	allUnavailable := true
+	hasState := false
+	modelAllUnavailable := true
 	earliestRetry := time.Time{}
 	quotaExceeded := false
 	quotaRecover := time.Time{}
 	maxBackoffLevel := 0
-	hasState := false
 	for _, state := range auth.ModelStates {
 		if state == nil {
 			continue
@@ -2193,7 +2274,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 			}
 		}
 		if !stateUnavailable {
-			allUnavailable = false
+			modelAllUnavailable = false
 		}
 		if state.Quota.Exceeded {
 			quotaExceeded = true
@@ -2205,17 +2286,57 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 			}
 		}
 	}
-	if !hasState {
+
+	supportedModels := registry.GetGlobalRegistry().GetModelsForClient(auth.ID)
+	modelIDs := make([]string, 0, len(supportedModels))
+	for _, model := range supportedModels {
+		if model == nil {
+			continue
+		}
+		modelIDs = append(modelIDs, model.ID)
+	}
+	effectiveGroups := collectOAuthQuotaGroupsForModels(auth, modelIDs)
+	hasEffectiveGroups := len(effectiveGroups) > 0
+	groupAllUnavailable := hasEffectiveGroups
+	groupQuotaRecover := time.Time{}
+	groupQuotaExceeded := false
+	for _, group := range effectiveGroups {
+		state, ok := oauthQuotaGroupState(auth.ID, group.ID)
+		if !ok {
+			groupAllUnavailable = false
+			continue
+		}
+		if state.ManualSuspended {
+			continue
+		}
+		if !state.AutoSuspendedUntil.IsZero() && state.AutoSuspendedUntil.After(now) {
+			groupQuotaExceeded = true
+			if groupQuotaRecover.IsZero() || state.AutoSuspendedUntil.Before(groupQuotaRecover) {
+				groupQuotaRecover = state.AutoSuspendedUntil
+			}
+			continue
+		}
+		groupAllUnavailable = false
+	}
+
+	if !hasState && !hasEffectiveGroups {
 		clearAggregatedAvailability(auth)
 		return
 	}
-	auth.Unavailable = allUnavailable
-	if allUnavailable {
+
+	auth.Unavailable = (hasState && modelAllUnavailable) || groupAllUnavailable
+	if auth.Unavailable {
+		if groupAllUnavailable && (!groupQuotaRecover.IsZero() && (earliestRetry.IsZero() || groupQuotaRecover.Before(earliestRetry))) {
+			earliestRetry = groupQuotaRecover
+		}
 		auth.NextRetryAfter = earliestRetry
 	} else {
 		auth.NextRetryAfter = time.Time{}
 	}
-	if quotaExceeded {
+	if groupQuotaExceeded && (quotaRecover.IsZero() || (!groupQuotaRecover.IsZero() && groupQuotaRecover.Before(quotaRecover))) {
+		quotaRecover = groupQuotaRecover
+	}
+	if quotaExceeded || groupQuotaExceeded {
 		auth.Quota.Exceeded = true
 		auth.Quota.Reason = "quota"
 		auth.Quota.NextRecoverAt = quotaRecover

--- a/sdk/cliproxy/auth/oauth_quota_groups.go
+++ b/sdk/cliproxy/auth/oauth_quota_groups.go
@@ -1,0 +1,269 @@
+package auth
+
+import (
+	"path"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+type oauthQuotaRuntimeSnapshot struct {
+	groups          []internalconfig.OAuthQuotaGroup
+	oauthModelAlias map[string][]internalconfig.OAuthModelAlias
+	states          map[string]map[string]internalconfig.OAuthAccountQuotaGroupState
+}
+
+var oauthQuotaRuntime atomic.Value
+
+func init() {
+	oauthQuotaRuntime.Store(buildOAuthQuotaRuntimeSnapshot(&internalconfig.Config{}))
+}
+
+func buildOAuthQuotaRuntimeSnapshot(cfg *internalconfig.Config) oauthQuotaRuntimeSnapshot {
+	if cfg == nil {
+		cfg = &internalconfig.Config{}
+	}
+	groups := internalconfig.NormalizeOAuthQuotaGroups(cfg.OAuthQuotaGroups)
+	stateSlice := internalconfig.NormalizeOAuthAccountQuotaGroupState(cfg.OAuthAccountQuotaGroupState)
+
+	groupCopy := make([]internalconfig.OAuthQuotaGroup, 0, len(groups))
+	for _, group := range groups {
+		groupCopy = append(groupCopy, internalconfig.OAuthQuotaGroup{
+			ID:        strings.ToLower(strings.TrimSpace(group.ID)),
+			Label:     strings.TrimSpace(group.Label),
+			Providers: append([]string(nil), group.Providers...),
+			Patterns:  append([]string(nil), group.Patterns...),
+			Priority:  group.Priority,
+			Enabled:   group.Enabled,
+		})
+	}
+	sort.Slice(groupCopy, func(i, j int) bool {
+		if groupCopy[i].Priority != groupCopy[j].Priority {
+			return groupCopy[i].Priority > groupCopy[j].Priority
+		}
+		return groupCopy[i].ID < groupCopy[j].ID
+	})
+
+	aliasCopy := make(map[string][]internalconfig.OAuthModelAlias, len(cfg.OAuthModelAlias))
+	for channel, entries := range cfg.OAuthModelAlias {
+		key := strings.ToLower(strings.TrimSpace(channel))
+		if key == "" || len(entries) == 0 {
+			continue
+		}
+		copied := make([]internalconfig.OAuthModelAlias, 0, len(entries))
+		for _, entry := range entries {
+			copied = append(copied, internalconfig.OAuthModelAlias{
+				Name:  strings.TrimSpace(entry.Name),
+				Alias: strings.TrimSpace(entry.Alias),
+				Fork:  entry.Fork,
+			})
+		}
+		aliasCopy[key] = copied
+	}
+
+	stateCopy := make(map[string]map[string]internalconfig.OAuthAccountQuotaGroupState)
+	for _, entry := range stateSlice {
+		authID := strings.TrimSpace(entry.AuthID)
+		groupID := strings.ToLower(strings.TrimSpace(entry.GroupID))
+		if authID == "" || groupID == "" {
+			continue
+		}
+		if stateCopy[authID] == nil {
+			stateCopy[authID] = make(map[string]internalconfig.OAuthAccountQuotaGroupState)
+		}
+		stateCopy[authID][groupID] = entry
+	}
+
+	return oauthQuotaRuntimeSnapshot{
+		groups:          groupCopy,
+		oauthModelAlias: aliasCopy,
+		states:          stateCopy,
+	}
+}
+
+// SetOAuthQuotaRuntimeConfig updates the global quota-group routing snapshot.
+func SetOAuthQuotaRuntimeConfig(cfg *internalconfig.Config) {
+	oauthQuotaRuntime.Store(buildOAuthQuotaRuntimeSnapshot(cfg))
+}
+
+func currentOAuthQuotaRuntimeSnapshot() oauthQuotaRuntimeSnapshot {
+	if snapshot, ok := oauthQuotaRuntime.Load().(oauthQuotaRuntimeSnapshot); ok {
+		return snapshot
+	}
+	return buildOAuthQuotaRuntimeSnapshot(nil)
+}
+
+func oauthQuotaProviderSupported(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "antigravity", "gemini", "gemini-cli":
+		return true
+	default:
+		return false
+	}
+}
+
+func wildcardMatchCI(pattern, value string) bool {
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	value = strings.ToLower(strings.TrimSpace(value))
+	if pattern == "" || value == "" {
+		return false
+	}
+	matched, err := path.Match(pattern, value)
+	if err == nil && matched {
+		return true
+	}
+	return pattern == value
+}
+
+func oauthQuotaGroupCandidates(auth *Auth, model string, snapshot oauthQuotaRuntimeSnapshot) []string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return nil
+	}
+	seen := make(map[string]struct{}, 4)
+	out := make([]string, 0, 4)
+	appendCandidate := func(value string) {
+		value = strings.ToLower(strings.TrimSpace(canonicalModelKey(value)))
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+
+	channel := modelAliasChannel(auth)
+	if channel != "" && len(snapshot.oauthModelAlias) > 0 {
+		if aliases := snapshot.oauthModelAlias[channel]; len(aliases) > 0 {
+			entries := make([]modelAliasEntry, 0, len(aliases))
+			for i := range aliases {
+				entries = append(entries, aliases[i])
+			}
+			if resolved := resolveModelAliasFromConfigModels(model, entries); resolved != "" {
+				appendCandidate(resolved)
+			}
+		}
+	}
+	appendCandidate(model)
+	return out
+}
+
+func resolveOAuthQuotaGroup(auth *Auth, model string) (internalconfig.OAuthQuotaGroup, bool) {
+	if auth == nil || !oauthQuotaProviderSupported(auth.Provider) {
+		return internalconfig.OAuthQuotaGroup{}, false
+	}
+	snapshot := currentOAuthQuotaRuntimeSnapshot()
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	candidates := oauthQuotaGroupCandidates(auth, model, snapshot)
+	if len(candidates) == 0 {
+		return internalconfig.OAuthQuotaGroup{}, false
+	}
+
+	for _, group := range snapshot.groups {
+		if !group.Enabled {
+			continue
+		}
+		supported := false
+		for _, candidateProvider := range group.Providers {
+			if strings.EqualFold(strings.TrimSpace(candidateProvider), provider) {
+				supported = true
+				break
+			}
+		}
+		if !supported {
+			continue
+		}
+		for _, candidate := range candidates {
+			for _, pattern := range group.Patterns {
+				if wildcardMatchCI(pattern, candidate) {
+					return group, true
+				}
+			}
+		}
+	}
+	return internalconfig.OAuthQuotaGroup{}, false
+}
+
+func oauthQuotaGroupState(authID, groupID string) (internalconfig.OAuthAccountQuotaGroupState, bool) {
+	authID = strings.TrimSpace(authID)
+	groupID = strings.ToLower(strings.TrimSpace(groupID))
+	if authID == "" || groupID == "" {
+		return internalconfig.OAuthAccountQuotaGroupState{}, false
+	}
+	snapshot := currentOAuthQuotaRuntimeSnapshot()
+	byAuth := snapshot.states[authID]
+	if len(byAuth) == 0 {
+		return internalconfig.OAuthAccountQuotaGroupState{}, false
+	}
+	state, ok := byAuth[groupID]
+	return state, ok
+}
+
+func oauthQuotaGroupBlock(auth *Auth, model string, now time.Time) (bool, bool, time.Time) {
+	if auth == nil {
+		return false, false, time.Time{}
+	}
+	group, ok := resolveOAuthQuotaGroup(auth, model)
+	if !ok {
+		return false, false, time.Time{}
+	}
+	state, ok := oauthQuotaGroupState(auth.ID, group.ID)
+	if !ok {
+		return false, false, time.Time{}
+	}
+	if state.ManualSuspended {
+		return true, false, time.Time{}
+	}
+	if !state.AutoSuspendedUntil.IsZero() && state.AutoSuspendedUntil.After(now) {
+		return true, true, state.AutoSuspendedUntil
+	}
+	return false, false, time.Time{}
+}
+
+func collectOAuthQuotaGroupsForModels(auth *Auth, models []string) []internalconfig.OAuthQuotaGroup {
+	if auth == nil || !oauthQuotaProviderSupported(auth.Provider) {
+		return nil
+	}
+	snapshot := currentOAuthQuotaRuntimeSnapshot()
+	seen := make(map[string]internalconfig.OAuthQuotaGroup)
+	for _, model := range models {
+		group, ok := resolveOAuthQuotaGroup(auth, model)
+		if !ok {
+			continue
+		}
+		seen[group.ID] = group
+	}
+	if len(seen) == 0 {
+		provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+		for _, group := range snapshot.groups {
+			if !group.Enabled {
+				continue
+			}
+			for _, candidateProvider := range group.Providers {
+				if strings.EqualFold(strings.TrimSpace(candidateProvider), provider) {
+					seen[group.ID] = group
+					break
+				}
+			}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]internalconfig.OAuthQuotaGroup, 0, len(seen))
+	for _, group := range seen {
+		out = append(out, group)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Priority != out[j].Priority {
+			return out[i].Priority > out[j].Priority
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}

--- a/sdk/cliproxy/auth/oauth_quota_groups_manager.go
+++ b/sdk/cliproxy/auth/oauth_quota_groups_manager.go
@@ -1,14 +1,29 @@
 package auth
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	log "github.com/sirupsen/logrus"
 )
+
+// oauthQuotaGroupPersistMu serializes config.yaml writes triggered by quota-
+// group state changes so concurrent goroutines never race on the same file.
+// The actual write is still atomic (temp+rename) in SaveConfigPreserveComments,
+// but this lock ensures a deterministic ordering and avoids unnecessary
+// re-entrant load/merge work piling up.
+var oauthQuotaGroupPersistMu sync.Mutex
+
+// defaultOAuthQuotaGroupCleanupInterval is the cadence at which expired auto
+// suspensions are reaped in the background. Chosen to be short enough that
+// users rarely observe a stale cooldown banner yet large enough that the
+// cleanup never dominates CPU or I/O.
+const defaultOAuthQuotaGroupCleanupInterval = 30 * time.Second
 
 func (m *Manager) configFilePathValue() string {
 	if m == nil {
@@ -34,7 +49,35 @@ func (m *Manager) persistRuntimeConfigSnapshot(cfg *internalconfig.Config) error
 	if path == "" {
 		return nil
 	}
+	oauthQuotaGroupPersistMu.Lock()
+	defer oauthQuotaGroupPersistMu.Unlock()
 	return internalconfig.SaveConfigPreserveComments(path, cfg)
+}
+
+// cloneRuntimeConfigForQuotaGroups returns a shallow copy of the currently
+// published runtime config that is safe to mutate without affecting readers
+// that already hold the previous pointer. Only the slice headers that the
+// quota-group code actually writes to are re-aliased; every other field
+// aliases the previous snapshot, which is acceptable because the publisher
+// replaces the whole struct via SetConfig once mutation completes.
+func (m *Manager) cloneRuntimeConfigForQuotaGroups() *internalconfig.Config {
+	var prev *internalconfig.Config
+	if m != nil {
+		prev, _ = m.runtimeConfig.Load().(*internalconfig.Config)
+	}
+	if prev == nil {
+		return &internalconfig.Config{}
+	}
+	next := *prev
+	if len(prev.OAuthAccountQuotaGroupState) > 0 {
+		next.OAuthAccountQuotaGroupState = append(
+			make([]internalconfig.OAuthAccountQuotaGroupState, 0, len(prev.OAuthAccountQuotaGroupState)),
+			prev.OAuthAccountQuotaGroupState...,
+		)
+	} else {
+		next.OAuthAccountQuotaGroupState = nil
+	}
+	return &next
 }
 
 func findOAuthQuotaGroupState(entries []internalconfig.OAuthAccountQuotaGroupState, authID, groupID string) (internalconfig.OAuthAccountQuotaGroupState, bool) {
@@ -56,10 +99,7 @@ func (m *Manager) setOAuthQuotaGroupAutoStateLocked(auth *Auth, model, provider 
 	if !ok {
 		return nil, false
 	}
-	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
-	if cfg == nil {
-		cfg = &internalconfig.Config{}
-	}
+	cfg := m.cloneRuntimeConfigForQuotaGroups()
 
 	current, _ := findOAuthQuotaGroupState(cfg.OAuthAccountQuotaGroupState, auth.ID, group.ID)
 	next := current
@@ -95,10 +135,7 @@ func (m *Manager) clearOAuthQuotaGroupAutoStateLocked(auth *Auth, model string, 
 	if !ok {
 		return nil, false
 	}
-	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
-	if cfg == nil {
-		cfg = &internalconfig.Config{}
-	}
+	cfg := m.cloneRuntimeConfigForQuotaGroups()
 	current, ok := findOAuthQuotaGroupState(cfg.OAuthAccountQuotaGroupState, auth.ID, group.ID)
 	if !ok || current.AutoSuspendedUntil.IsZero() {
 		return nil, false
@@ -137,10 +174,7 @@ func (m *Manager) ClearExpiredOAuthQuotaGroupAutoStates(now time.Time) bool {
 	)
 
 	m.mu.Lock()
-	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
-	if cfg == nil {
-		cfg = &internalconfig.Config{}
-	}
+	cfg := m.cloneRuntimeConfigForQuotaGroups()
 
 	entries := internalconfig.NormalizeOAuthAccountQuotaGroupState(cfg.OAuthAccountQuotaGroupState)
 	if len(entries) == 0 {
@@ -207,4 +241,66 @@ func (m *Manager) ClearExpiredOAuthQuotaGroupAutoStates(now time.Time) bool {
 		}
 	}
 	return true
+}
+
+// StartOAuthQuotaGroupCleanup launches a background goroutine that periodically
+// reaps expired auto cooldowns. Keeping cleanup off the request path avoids the
+// original implementation's issue where every Execute/ExecuteStream/CountTokens
+// call took the global Manager lock and potentially re-wrote config.yaml.
+//
+// Only one loop is kept alive; starting a new one cancels the previous run.
+// Pass a non-positive interval to use the default cadence.
+func (m *Manager) StartOAuthQuotaGroupCleanup(parent context.Context, interval time.Duration) {
+	if m == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = defaultOAuthQuotaGroupCleanupInterval
+	}
+
+	m.mu.Lock()
+	if m.quotaGroupCleanupCancel != nil {
+		m.quotaGroupCleanupCancel()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	m.quotaGroupCleanupCancel = cancel
+	m.mu.Unlock()
+
+	go func() {
+		// Run once shortly after start so any expired entries loaded from disk
+		// are reaped without waiting for the first tick.
+		primer := time.NewTimer(time.Second)
+		defer primer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-primer.C:
+			m.ClearExpiredOAuthQuotaGroupAutoStates(time.Now())
+		}
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				m.ClearExpiredOAuthQuotaGroupAutoStates(time.Now())
+			}
+		}
+	}()
+}
+
+// StopOAuthQuotaGroupCleanup cancels any running background cleanup loop.
+func (m *Manager) StopOAuthQuotaGroupCleanup() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	cancel := m.quotaGroupCleanupCancel
+	m.quotaGroupCleanupCancel = nil
+	m.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 }

--- a/sdk/cliproxy/auth/oauth_quota_groups_manager.go
+++ b/sdk/cliproxy/auth/oauth_quota_groups_manager.go
@@ -1,0 +1,210 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	log "github.com/sirupsen/logrus"
+)
+
+func (m *Manager) configFilePathValue() string {
+	if m == nil {
+		return ""
+	}
+	if raw, ok := m.configFilePath.Load().(string); ok {
+		if trimmed := strings.TrimSpace(raw); trimmed != "" {
+			return trimmed
+		}
+	}
+	wd, err := os.Getwd()
+	if err != nil || strings.TrimSpace(wd) == "" {
+		return ""
+	}
+	return filepath.Join(wd, "config.yaml")
+}
+
+func (m *Manager) persistRuntimeConfigSnapshot(cfg *internalconfig.Config) error {
+	if m == nil || cfg == nil {
+		return nil
+	}
+	path := m.configFilePathValue()
+	if path == "" {
+		return nil
+	}
+	return internalconfig.SaveConfigPreserveComments(path, cfg)
+}
+
+func findOAuthQuotaGroupState(entries []internalconfig.OAuthAccountQuotaGroupState, authID, groupID string) (internalconfig.OAuthAccountQuotaGroupState, bool) {
+	authID = strings.TrimSpace(authID)
+	groupID = strings.ToLower(strings.TrimSpace(groupID))
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.AuthID) == authID && strings.EqualFold(strings.TrimSpace(entry.GroupID), groupID) {
+			return entry, true
+		}
+	}
+	return internalconfig.OAuthAccountQuotaGroupState{}, false
+}
+
+func (m *Manager) setOAuthQuotaGroupAutoStateLocked(auth *Auth, model, provider string, until time.Time, resetTimeSource string, now time.Time) (*internalconfig.Config, bool) {
+	if m == nil || auth == nil || until.IsZero() {
+		return nil, false
+	}
+	group, ok := resolveOAuthQuotaGroup(auth, model)
+	if !ok {
+		return nil, false
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil {
+		cfg = &internalconfig.Config{}
+	}
+
+	current, _ := findOAuthQuotaGroupState(cfg.OAuthAccountQuotaGroupState, auth.ID, group.ID)
+	next := current
+	next.AuthID = auth.ID
+	next.GroupID = group.ID
+	next.AutoSuspendedUntil = until.UTC()
+	next.AutoReason = "quota_exhausted"
+	next.SourceModel = strings.TrimSpace(model)
+	next.SourceProvider = strings.ToLower(strings.TrimSpace(provider))
+	next.ResetTimeSource = strings.TrimSpace(resetTimeSource)
+	next.UpdatedAt = now.UTC()
+	next.UpdatedBy = "system:auto"
+
+	if current.ManualSuspended == next.ManualSuspended &&
+		current.ManualReason == next.ManualReason &&
+		current.AutoSuspendedUntil.Equal(next.AutoSuspendedUntil) &&
+		current.AutoReason == next.AutoReason &&
+		current.SourceModel == next.SourceModel &&
+		current.SourceProvider == next.SourceProvider &&
+		current.ResetTimeSource == next.ResetTimeSource {
+		return nil, false
+	}
+
+	cfg.OAuthAccountQuotaGroupState = internalconfig.UpsertOAuthAccountQuotaGroupState(cfg.OAuthAccountQuotaGroupState, next)
+	return cfg, true
+}
+
+func (m *Manager) clearOAuthQuotaGroupAutoStateLocked(auth *Auth, model string, now time.Time) (*internalconfig.Config, bool) {
+	if m == nil || auth == nil {
+		return nil, false
+	}
+	group, ok := resolveOAuthQuotaGroup(auth, model)
+	if !ok {
+		return nil, false
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil {
+		cfg = &internalconfig.Config{}
+	}
+	current, ok := findOAuthQuotaGroupState(cfg.OAuthAccountQuotaGroupState, auth.ID, group.ID)
+	if !ok || current.AutoSuspendedUntil.IsZero() {
+		return nil, false
+	}
+
+	current.AutoSuspendedUntil = time.Time{}
+	current.AutoReason = ""
+	current.SourceModel = ""
+	current.SourceProvider = ""
+	current.ResetTimeSource = ""
+	current.UpdatedAt = now.UTC()
+	current.UpdatedBy = "system:auto-clear"
+
+	if current.ManualSuspended {
+		cfg.OAuthAccountQuotaGroupState = internalconfig.UpsertOAuthAccountQuotaGroupState(cfg.OAuthAccountQuotaGroupState, current)
+	} else {
+		cfg.OAuthAccountQuotaGroupState = internalconfig.RemoveOAuthAccountQuotaGroupState(cfg.OAuthAccountQuotaGroupState, auth.ID, group.ID)
+	}
+	return cfg, true
+}
+
+// ClearExpiredOAuthQuotaGroupAutoStates removes auto cooldown state that has
+// already passed its reset time while preserving manual suspensions.
+func (m *Manager) ClearExpiredOAuthQuotaGroupAutoStates(now time.Time) bool {
+	if m == nil {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	now = now.UTC()
+
+	var (
+		cfgToPublish  *internalconfig.Config
+		authSnapshots []*Auth
+	)
+
+	m.mu.Lock()
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil {
+		cfg = &internalconfig.Config{}
+	}
+
+	entries := internalconfig.NormalizeOAuthAccountQuotaGroupState(cfg.OAuthAccountQuotaGroupState)
+	if len(entries) == 0 {
+		m.mu.Unlock()
+		return false
+	}
+
+	nextEntries := make([]internalconfig.OAuthAccountQuotaGroupState, 0, len(entries))
+	affectedAuthIDs := make(map[string]struct{})
+	changed := false
+
+	for _, entry := range entries {
+		if entry.AutoSuspendedUntil.IsZero() || entry.AutoSuspendedUntil.After(now) {
+			nextEntries = append(nextEntries, entry)
+			continue
+		}
+
+		changed = true
+		if authID := strings.TrimSpace(entry.AuthID); authID != "" {
+			affectedAuthIDs[authID] = struct{}{}
+		}
+
+		entry.AutoSuspendedUntil = time.Time{}
+		entry.AutoReason = ""
+		entry.SourceModel = ""
+		entry.SourceProvider = ""
+		entry.ResetTimeSource = ""
+		entry.UpdatedAt = now
+		entry.UpdatedBy = "system:auto-expire"
+
+		if entry.ManualSuspended {
+			nextEntries = append(nextEntries, entry)
+		}
+	}
+
+	if changed {
+		cfg.OAuthAccountQuotaGroupState = internalconfig.NormalizeOAuthAccountQuotaGroupState(nextEntries)
+		cfgToPublish = cfg
+		for authID := range affectedAuthIDs {
+			auth := m.auths[authID]
+			if auth == nil {
+				continue
+			}
+			updateAggregatedAvailability(auth, now)
+			auth.UpdatedAt = now
+			authSnapshots = append(authSnapshots, auth.Clone())
+		}
+	}
+	m.mu.Unlock()
+
+	if cfgToPublish == nil {
+		return false
+	}
+
+	m.SetConfig(cfgToPublish)
+	if err := m.persistRuntimeConfigSnapshot(cfgToPublish); err != nil {
+		log.WithError(err).Warn("failed to persist expired oauth-account-quota-group-state cleanup")
+	}
+	if m.scheduler != nil {
+		for _, authSnapshot := range authSnapshots {
+			if authSnapshot != nil {
+				m.scheduler.upsertAuth(authSnapshot)
+			}
+		}
+	}
+	return true
+}

--- a/sdk/cliproxy/auth/oauth_quota_groups_test.go
+++ b/sdk/cliproxy/auth/oauth_quota_groups_test.go
@@ -1,0 +1,366 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+)
+
+func testOAuthQuotaConfig() *internalconfig.Config {
+	return &internalconfig.Config{
+		OAuthQuotaGroups: internalconfig.DefaultOAuthQuotaGroups(),
+		OAuthModelAlias: map[string][]internalconfig.OAuthModelAlias{
+			"antigravity": {{
+				Name:  "gemini-3.1-flash-lite",
+				Alias: "gpt-4o",
+			}},
+		},
+	}
+}
+
+func TestResolveOAuthQuotaGroup_UsesAliasAndPriority(t *testing.T) {
+	cfg := testOAuthQuotaConfig()
+	SetOAuthQuotaRuntimeConfig(cfg)
+	t.Cleanup(func() {
+		SetOAuthQuotaRuntimeConfig(&internalconfig.Config{})
+	})
+
+	auth := &Auth{ID: "auth-1", Provider: "antigravity"}
+
+	imageGroup, ok := resolveOAuthQuotaGroup(auth, "gemini-3.1-flash-image-4k")
+	if !ok {
+		t.Fatal("resolveOAuthQuotaGroup(image) = no match, want g3_flash")
+	}
+	if imageGroup.ID != internalconfig.OAuthQuotaGroupG3Flash {
+		t.Fatalf("resolveOAuthQuotaGroup(image) = %q, want %q", imageGroup.ID, internalconfig.OAuthQuotaGroupG3Flash)
+	}
+
+	aliasGroup, ok := resolveOAuthQuotaGroup(auth, "gpt-4o")
+	if !ok {
+		t.Fatal("resolveOAuthQuotaGroup(alias) = no match, want g3_flash")
+	}
+	if aliasGroup.ID != internalconfig.OAuthQuotaGroupG3Flash {
+		t.Fatalf("resolveOAuthQuotaGroup(alias) = %q, want %q", aliasGroup.ID, internalconfig.OAuthQuotaGroupG3Flash)
+	}
+
+	claudeGroup, ok := resolveOAuthQuotaGroup(auth, "Claude-Opus-4-6-Thinking")
+	if !ok {
+		t.Fatal("resolveOAuthQuotaGroup(claude) = no match, want claude_45")
+	}
+	if claudeGroup.ID != internalconfig.OAuthQuotaGroupClaude45 {
+		t.Fatalf("resolveOAuthQuotaGroup(claude) = %q, want %q", claudeGroup.ID, internalconfig.OAuthQuotaGroupClaude45)
+	}
+
+	if _, ok := resolveOAuthQuotaGroup(auth, "gemini-2.5-pro"); ok {
+		t.Fatal("resolveOAuthQuotaGroup(gemini-2.5-pro) matched, want no match")
+	}
+
+	if _, ok := resolveOAuthQuotaGroup(auth, "unclassified-model"); ok {
+		t.Fatal("resolveOAuthQuotaGroup(unclassified) matched, want no match")
+	}
+}
+
+func TestIsAuthBlockedForModel_UsesQuotaGroupState(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := testOAuthQuotaConfig()
+	cfg.OAuthAccountQuotaGroupState = []internalconfig.OAuthAccountQuotaGroupState{
+		{
+			AuthID:          "manual-auth",
+			GroupID:         internalconfig.OAuthQuotaGroupClaude45,
+			ManualSuspended: true,
+			ManualReason:    "maintenance",
+		},
+		{
+			AuthID:             "auto-auth",
+			GroupID:            internalconfig.OAuthQuotaGroupG3Pro,
+			AutoSuspendedUntil: now.Add(5 * time.Minute),
+			AutoReason:         "quota_exhausted",
+		},
+	}
+	SetOAuthQuotaRuntimeConfig(cfg)
+	t.Cleanup(func() {
+		SetOAuthQuotaRuntimeConfig(&internalconfig.Config{})
+	})
+
+	manualAuth := &Auth{ID: "manual-auth", Provider: "antigravity"}
+	blocked, reason, next := isAuthBlockedForModel(manualAuth, "claude-sonnet-4-6", now)
+	if !blocked {
+		t.Fatal("manual quota-group block = false, want true")
+	}
+	if reason != blockReasonDisabled {
+		t.Fatalf("manual quota-group reason = %v, want %v", reason, blockReasonDisabled)
+	}
+	if !next.IsZero() {
+		t.Fatalf("manual quota-group next = %v, want zero", next)
+	}
+
+	autoAuth := &Auth{ID: "auto-auth", Provider: "antigravity"}
+	blocked, reason, next = isAuthBlockedForModel(autoAuth, "gemini-3.1-pro-high", now)
+	if !blocked {
+		t.Fatal("auto quota-group block = false, want true")
+	}
+	if reason != blockReasonCooldown {
+		t.Fatalf("auto quota-group reason = %v, want %v", reason, blockReasonCooldown)
+	}
+	if next.IsZero() || !next.After(now) {
+		t.Fatalf("auto quota-group next = %v, want future timestamp", next)
+	}
+
+	blocked, reason, next = isAuthBlockedForModel(autoAuth, "gemini-3.1-flash-lite", now)
+	if blocked {
+		t.Fatal("flash group unexpectedly blocked by pro cooldown")
+	}
+	if reason != blockReasonNone {
+		t.Fatalf("flash group reason = %v, want %v", reason, blockReasonNone)
+	}
+	if !next.IsZero() {
+		t.Fatalf("flash group next = %v, want zero", next)
+	}
+}
+
+func TestUpdateAggregatedAvailability_UsesEffectiveQuotaGroups(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := testOAuthQuotaConfig()
+	cfg.OAuthAccountQuotaGroupState = []internalconfig.OAuthAccountQuotaGroupState{
+		{
+			AuthID:          "agg-auth",
+			GroupID:         internalconfig.OAuthQuotaGroupClaude45,
+			ManualSuspended: true,
+		},
+	}
+	SetOAuthQuotaRuntimeConfig(cfg)
+	t.Cleanup(func() {
+		SetOAuthQuotaRuntimeConfig(&internalconfig.Config{})
+	})
+
+	auth := &Auth{ID: "agg-auth", Provider: "antigravity"}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{
+		{ID: "claude-sonnet-4-6"},
+		{ID: "gemini-3.1-flash-lite"},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+
+	updateAggregatedAvailability(auth, now)
+	if auth.Unavailable {
+		t.Fatal("auth.Unavailable = true, want false when one effective group is still available")
+	}
+
+	cfg.OAuthAccountQuotaGroupState = append(cfg.OAuthAccountQuotaGroupState, internalconfig.OAuthAccountQuotaGroupState{
+		AuthID:             "agg-auth",
+		GroupID:            internalconfig.OAuthQuotaGroupG3Flash,
+		AutoSuspendedUntil: now.Add(10 * time.Minute),
+		AutoReason:         "quota_exhausted",
+	})
+	SetOAuthQuotaRuntimeConfig(cfg)
+
+	updateAggregatedAvailability(auth, now)
+	if !auth.Unavailable {
+		t.Fatal("auth.Unavailable = false, want true when all effective groups are blocked")
+	}
+	if auth.NextRetryAfter.IsZero() || !auth.NextRetryAfter.After(now) {
+		t.Fatalf("auth.NextRetryAfter = %v, want future timestamp", auth.NextRetryAfter)
+	}
+	if !auth.Quota.Exceeded {
+		t.Fatal("auth.Quota.Exceeded = false, want true")
+	}
+}
+
+func TestManagerMarkResult_QuotaGroupCooldownLifecycle(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	cfg := testOAuthQuotaConfig()
+	manager.SetConfig(cfg)
+	t.Cleanup(func() {
+		manager.SetConfig(&internalconfig.Config{})
+	})
+
+	auth := &Auth{
+		ID:       "quota-auth",
+		Provider: "antigravity",
+		Status:   StatusActive,
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	model := "gemini-3.1-flash-lite"
+	retryAfter := 3 * time.Minute
+	manager.MarkResult(context.Background(), Result{
+		AuthID:     auth.ID,
+		Provider:   auth.Provider,
+		Model:      model,
+		Success:    false,
+		RetryAfter: &retryAfter,
+		Error: &Error{
+			Message:    "quota exhausted",
+			HTTPStatus: 429,
+		},
+	})
+
+	runtimeCfg, _ := manager.runtimeConfig.Load().(*internalconfig.Config)
+	if runtimeCfg == nil {
+		t.Fatal("runtime config = nil")
+	}
+	state, ok := findOAuthQuotaGroupState(runtimeCfg.OAuthAccountQuotaGroupState, auth.ID, internalconfig.OAuthQuotaGroupG3Flash)
+	if !ok {
+		t.Fatal("quota-group state missing after 429")
+	}
+	if state.AutoReason != "quota_exhausted" {
+		t.Fatalf("state.AutoReason = %q, want %q", state.AutoReason, "quota_exhausted")
+	}
+	if state.ResetTimeSource != "retry_after" {
+		t.Fatalf("state.ResetTimeSource = %q, want %q", state.ResetTimeSource, "retry_after")
+	}
+	if state.SourceModel != model {
+		t.Fatalf("state.SourceModel = %q, want %q", state.SourceModel, model)
+	}
+
+	updatedAuth, ok := manager.GetByID(auth.ID)
+	if !ok || updatedAuth == nil {
+		t.Fatal("updated auth missing")
+	}
+	modelState := updatedAuth.ModelStates[model]
+	if modelState == nil {
+		t.Fatal("model state missing after 429")
+	}
+	if modelState.Unavailable {
+		t.Fatal("modelState.Unavailable = true, want false for quota-group cooldown")
+	}
+	if !modelState.NextRetryAfter.IsZero() {
+		t.Fatalf("modelState.NextRetryAfter = %v, want zero", modelState.NextRetryAfter)
+	}
+	if modelState.Quota.Exceeded {
+		t.Fatal("modelState.Quota.Exceeded = true, want false")
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  true,
+	})
+
+	runtimeCfg, _ = manager.runtimeConfig.Load().(*internalconfig.Config)
+	if runtimeCfg == nil {
+		t.Fatal("runtime config after success = nil")
+	}
+	if _, ok := findOAuthQuotaGroupState(runtimeCfg.OAuthAccountQuotaGroupState, auth.ID, internalconfig.OAuthQuotaGroupG3Flash); ok {
+		t.Fatal("quota-group state still present after success")
+	}
+}
+
+func TestManagerMarkResult_503DoesNotPersistQuotaGroupCooldown(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	cfg := testOAuthQuotaConfig()
+	manager.SetConfig(cfg)
+	t.Cleanup(func() {
+		manager.SetConfig(&internalconfig.Config{})
+	})
+
+	auth := &Auth{
+		ID:       "capacity-auth",
+		Provider: "antigravity",
+		Status:   StatusActive,
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	model := "claude-opus-4-6-thinking"
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error: &Error{
+			Message:    "No capacity available",
+			HTTPStatus: 503,
+		},
+	})
+
+	runtimeCfg, _ := manager.runtimeConfig.Load().(*internalconfig.Config)
+	if runtimeCfg == nil {
+		t.Fatal("runtime config = nil")
+	}
+	if _, ok := findOAuthQuotaGroupState(runtimeCfg.OAuthAccountQuotaGroupState, auth.ID, internalconfig.OAuthQuotaGroupClaude45); ok {
+		t.Fatal("quota-group state unexpectedly persisted for 503")
+	}
+
+	updatedAuth, ok := manager.GetByID(auth.ID)
+	if !ok || updatedAuth == nil {
+		t.Fatal("updated auth missing")
+	}
+	modelState := updatedAuth.ModelStates[model]
+	if modelState == nil {
+		t.Fatal("model state missing after 503")
+	}
+	if !modelState.Unavailable {
+		t.Fatal("modelState.Unavailable = false, want true for transient 503 cooldown")
+	}
+	if modelState.NextRetryAfter.IsZero() {
+		t.Fatal("modelState.NextRetryAfter = zero, want transient retry window")
+	}
+}
+
+func TestManagerClearExpiredOAuthQuotaGroupAutoStates_RemovesExpiredState(t *testing.T) {
+	now := time.Now().UTC()
+	manager := NewManager(nil, nil, nil)
+	cfg := testOAuthQuotaConfig()
+	cfg.OAuthAccountQuotaGroupState = []internalconfig.OAuthAccountQuotaGroupState{
+		{
+			AuthID:             "auto-expired",
+			GroupID:            internalconfig.OAuthQuotaGroupG3Pro,
+			AutoSuspendedUntil: now.Add(-1 * time.Minute),
+			AutoReason:         "quota_exhausted",
+			SourceModel:        "gemini-3.1-pro-high",
+			SourceProvider:     "antigravity",
+			ResetTimeSource:    "retry_after",
+		},
+		{
+			AuthID:             "manual-auth",
+			GroupID:            internalconfig.OAuthQuotaGroupG3Flash,
+			ManualSuspended:    true,
+			ManualReason:       "manual override",
+			AutoSuspendedUntil: now.Add(-2 * time.Minute),
+			AutoReason:         "quota_exhausted",
+			SourceModel:        "gemini-3.1-flash-lite",
+			SourceProvider:     "antigravity",
+			ResetTimeSource:    "retry_after",
+		},
+	}
+	manager.SetConfig(cfg)
+	t.Cleanup(func() {
+		manager.SetConfig(&internalconfig.Config{})
+	})
+
+	if changed := manager.ClearExpiredOAuthQuotaGroupAutoStates(now); !changed {
+		t.Fatal("ClearExpiredOAuthQuotaGroupAutoStates = false, want true")
+	}
+
+	runtimeCfg, _ := manager.runtimeConfig.Load().(*internalconfig.Config)
+	if runtimeCfg == nil {
+		t.Fatal("runtime config = nil")
+	}
+	if _, ok := findOAuthQuotaGroupState(runtimeCfg.OAuthAccountQuotaGroupState, "auto-expired", internalconfig.OAuthQuotaGroupG3Pro); ok {
+		t.Fatal("expired auto cooldown state still present")
+	}
+
+	state, ok := findOAuthQuotaGroupState(runtimeCfg.OAuthAccountQuotaGroupState, "manual-auth", internalconfig.OAuthQuotaGroupG3Flash)
+	if !ok {
+		t.Fatal("manual state missing after cleanup")
+	}
+	if !state.ManualSuspended {
+		t.Fatal("manual state lost manual suspension flag")
+	}
+	if !state.AutoSuspendedUntil.IsZero() {
+		t.Fatalf("manual state auto cooldown still present: %v", state.AutoSuspendedUntil)
+	}
+	if state.AutoReason != "" || state.SourceModel != "" || state.SourceProvider != "" || state.ResetTimeSource != "" {
+		t.Fatalf("manual state still has stale auto metadata: %#v", state)
+	}
+}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -376,6 +376,17 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 		return true, blockReasonDisabled, time.Time{}
 	}
 	if model != "" {
+		if blocked, cooldown, next := oauthQuotaGroupBlock(auth, model, now); blocked {
+			if cooldown {
+				if next.Before(now) {
+					next = now
+				}
+				return true, blockReasonCooldown, next
+			}
+			return true, blockReasonDisabled, time.Time{}
+		}
+	}
+	if model != "" {
 		if len(auth.ModelStates) > 0 {
 			state, ok := auth.ModelStates[model]
 			if (!ok || state == nil) && model != "" {


### PR DESCRIPTION
## Summary

Add configurable OAuth quota-group suspension for OAuth-backed providers (`antigravity`, `gemini`, `gemini-cli`).

This introduces a generic quota-group layer that can persist manual and automatic suspension state, route model-scoped 429 quota exhaustion into group-level cooldowns, and keep transient capacity failures model-scoped. The main motivation is to make provider behavior match real OAuth quota semantics for accounts that share quota across model families. In the current implementation a 429 usually freezes only the exact model that tripped it, which means a burned Claude family can still be retried through adjacent Claude models until they fail individually.

### What this change adds

- Config-driven quota groups (`oauth-quota-groups`) with provider + wildcard pattern matching.
- Selector enforcement of group-level suspension (both manual and automatic cooldown).
- Persistence of suspension state in `config.yaml` under `oauth-account-quota-group-state`, preserving comments.
- Management endpoints for admin-controlled suspend / lift / clear-cooldown.
- Focused tests including the Antigravity case where Claude can be suspended while Gemini Flash remains available.

## History

This was originally submitted against the downstream Plus repository as router-for-me/CLIProxyAPIPlus#524 and closed by the maintainer with the note that the Plus project only accepts third-party-provider PRs; core `AuthManager` changes belong in this mainline repo. The companion dashboard side has already been merged as itsmylife44/cliproxyapi-dashboard#192 and shipped in dashboard `v0.1.77`.

## Code review feedback from the previous submission

The automated review on the closed PR flagged three concerns. This resubmission addresses all of them in a follow-up commit (`fix(quota-groups): address PR #524 code review feedback`):

1. **Thread-safety when mutating shared config.** The previous version loaded the shared `*internalconfig.Config` pointer from `atomic.Value` and then mutated the `OAuthAccountQuotaGroupState` slice header in place. Any reader that still held the previous pointer could observe a torn slice header.
   - Now `cloneRuntimeConfigForQuotaGroups()` returns a shallow copy of the current snapshot with an independently owned state slice. All three mutation sites (`setOAuthQuotaGroupAutoStateLocked`, `clearOAuthQuotaGroupAutoStateLocked`, `ClearExpiredOAuthQuotaGroupAutoStates`) now mutate the copy and publish it via `SetConfig`. No in-place mutation of the shared snapshot remains.

2. **File corruption from concurrent writes of `config.yaml`.** The previous version used `os.Create` + `Write`, which truncates the live file before the new bytes are written and leaves the file in an inconsistent state on crash or concurrent writer.
   - `SaveConfigPreserveComments` now renders the merged YAML fully in memory first, then calls the new `writeFileAtomic` helper: `CreateTemp` sibling → `Write` → `Sync` → `Chmod` → `Rename`. Rename is atomic on POSIX and best-effort atomic on Windows.
   - A package-level `oauthQuotaGroupPersistMu` serializes quota-group-initiated writes so the merge/render step is not performed concurrently on the same file even though the final rename is atomic.

3. **Synchronous expired-state cleanup on the hot path.** The previous version called `ClearExpiredOAuthQuotaGroupAutoStates` at the top of `Execute`, `ExecuteCount`, and `ExecuteStream`. That call took the global `Manager` mutex and, on any expiry, synchronously rewrote `config.yaml` — inside the request path.
   - All three hot-path calls are removed. The lock-free `oauthQuotaGroupBlock` read already ignores entries whose `AutoSuspendedUntil` is in the past, so the request path stays correct without cleanup.
   - A new `StartOAuthQuotaGroupCleanup` / `StopOAuthQuotaGroupCleanup` pair runs the reaper in a single background goroutine (30s ticker + 1s primer), tracked by `Manager.quotaGroupCleanupCancel` so only one loop is alive at a time. It is auto-wired into the existing `StartAutoRefresh` / `StopAutoRefresh` lifecycle so hosts get it for free.

## Verification

- `go build ./...` — OK on `golang:1.26-alpine`.
- `go test -race -count=1 ./sdk/cliproxy/auth/... ./internal/config/...` — OK, no data races reported.
- Existing `conductor_oauth_alias_suspension_test.go`, `antigravity_quota_groups_behavior_test.go`, `oauth_quota_groups_test.go`, `oauth_quota_groups_manager` (via `auth` package tests), and `internal/config` tests pass.

## Commits

1. `feat(auth): Add OAuth quota group suspension` — the feature itself (ported from the closed PR).
2. `fix(quota-groups): address PR #524 code review feedback` — the three review fixes above.

## Related

- Dashboard counterpart (already merged): itsmylife44/cliproxyapi-dashboard#192
- Previous closed PR: router-for-me/CLIProxyAPIPlus#524
