### PR TITLE
feat: warm up other codex oauth auths for fill-first routing

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -103,6 +103,7 @@ quota-exceeded:
 # Routing strategy for selecting credentials when multiple match.
 routing:
   strategy: "round-robin" # round-robin (default), fill-first
+  warmup: false # when true and strategy is fill-first, qualifying Codex usage events may warm up other enabled Codex OAuth auths
   # Enable universal session-sticky routing for all clients.
   # Session IDs are extracted from: X-Session-ID header, Idempotency-Key,
   # metadata.user_id, conversation_id, or first few messages hash.

--- a/internal/api/handlers/management/api_call_events.go
+++ b/internal/api/handlers/management/api_call_events.go
@@ -1,0 +1,88 @@
+package management
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// ManagementAPICallEvent is published after management /api-call returns a response.
+type ManagementAPICallEvent struct {
+	AuthIndex  string
+	Method     string
+	URL        string
+	StatusCode int
+	RespHeader http.Header
+	RespBody   []byte
+}
+
+// ManagementAPICallListener consumes management API-call events.
+type ManagementAPICallListener interface {
+	OnManagementAPICall(ctx context.Context, evt ManagementAPICallEvent)
+}
+
+// ManagementAPICallListenerFunc adapts a function to ManagementAPICallListener.
+type ManagementAPICallListenerFunc func(context.Context, ManagementAPICallEvent)
+
+// OnManagementAPICall forwards to f.
+func (f ManagementAPICallListenerFunc) OnManagementAPICall(ctx context.Context, evt ManagementAPICallEvent) {
+	f(ctx, evt)
+}
+
+type managementAPICallEventBus struct {
+	mu        sync.RWMutex
+	listeners []ManagementAPICallListener
+}
+
+func newManagementAPICallEventBus() *managementAPICallEventBus {
+	return &managementAPICallEventBus{}
+}
+
+func (b *managementAPICallEventBus) Register(listener ManagementAPICallListener) {
+	if b == nil || listener == nil {
+		return
+	}
+
+	b.mu.Lock()
+	b.listeners = append(b.listeners, listener)
+	b.mu.Unlock()
+}
+
+func (b *managementAPICallEventBus) Publish(ctx context.Context, evt ManagementAPICallEvent) {
+	if b == nil {
+		return
+	}
+
+	b.mu.RLock()
+	listeners := append([]ManagementAPICallListener(nil), b.listeners...)
+	b.mu.RUnlock()
+
+	for _, listener := range listeners {
+		if listener == nil {
+			continue
+		}
+
+		eventCopy := cloneManagementAPICallEvent(evt)
+		go func(listener ManagementAPICallListener, event ManagementAPICallEvent) {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Errorf("management api-call listener panic recovered: %v", r)
+				}
+			}()
+			listener.OnManagementAPICall(ctx, event)
+		}(listener, eventCopy)
+	}
+}
+
+func cloneManagementAPICallEvent(evt ManagementAPICallEvent) ManagementAPICallEvent {
+	copied := evt
+	if evt.RespHeader != nil {
+		copied.RespHeader = evt.RespHeader.Clone()
+	}
+	if evt.RespBody != nil {
+		copied.RespBody = append([]byte(nil), evt.RespBody...)
+	}
+	return copied
+}

--- a/internal/api/handlers/management/api_call_events_test.go
+++ b/internal/api/handlers/management/api_call_events_test.go
@@ -1,0 +1,96 @@
+package management
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type recordingAPICallListener struct {
+	ch chan ManagementAPICallEvent
+}
+
+func (l *recordingAPICallListener) OnManagementAPICall(_ context.Context, evt ManagementAPICallEvent) {
+	l.ch <- evt
+}
+
+func TestManagementAPICallEventBusDispatchesAsync(t *testing.T) {
+	t.Parallel()
+
+	bus := newManagementAPICallEventBus()
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	bus.Register(ManagementAPICallListenerFunc(func(context.Context, ManagementAPICallEvent) {
+		entered <- struct{}{}
+		<-release
+	}))
+
+	done := make(chan struct{})
+	go func() {
+		bus.Publish(context.Background(), ManagementAPICallEvent{AuthIndex: "a1", StatusCode: 200})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("publish blocked by listener")
+	}
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("listener did not receive event")
+	}
+	close(release)
+}
+
+func TestManagementAPICallEventBusDeliversToAllListeners(t *testing.T) {
+	t.Parallel()
+
+	bus := newManagementAPICallEventBus()
+	first := &recordingAPICallListener{ch: make(chan ManagementAPICallEvent, 1)}
+	second := &recordingAPICallListener{ch: make(chan ManagementAPICallEvent, 1)}
+	bus.Register(first)
+	bus.Register(second)
+
+	want := ManagementAPICallEvent{AuthIndex: "a-multi", StatusCode: 201}
+	bus.Publish(context.Background(), want)
+
+	select {
+	case got := <-first.ch:
+		if got.AuthIndex != want.AuthIndex || got.StatusCode != want.StatusCode {
+			t.Fatalf("first listener got %+v, want %+v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first listener missing event")
+	}
+
+	select {
+	case got := <-second.ch:
+		if got.AuthIndex != want.AuthIndex || got.StatusCode != want.StatusCode {
+			t.Fatalf("second listener got %+v, want %+v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second listener missing event")
+	}
+}
+
+func TestManagementAPICallEventBusRecoversPanics(t *testing.T) {
+	t.Parallel()
+
+	bus := newManagementAPICallEventBus()
+	bus.Register(ManagementAPICallListenerFunc(func(context.Context, ManagementAPICallEvent) {
+		panic("boom")
+	}))
+	listener := &recordingAPICallListener{ch: make(chan ManagementAPICallEvent, 1)}
+	bus.Register(listener)
+
+	bus.Publish(context.Background(), ManagementAPICallEvent{AuthIndex: "a2"})
+
+	select {
+	case <-listener.ch:
+	case <-time.After(time.Second):
+		t.Fatal("expected non-panicking listener to still receive event")
+	}
+}

--- a/internal/api/handlers/management/api_call_warmup.go
+++ b/internal/api/handlers/management/api_call_warmup.go
@@ -1,0 +1,439 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	log "github.com/sirupsen/logrus"
+)
+
+const warmupCooldown = 20 * time.Second
+
+var warmupMiniModelPatterns = []string{"*mini*"}
+
+type WarmupQuotaSnapshot struct {
+	HasFiveHourWindow      bool
+	FiveHourResetRemaining time.Duration
+	HasWeeklyWindow        bool
+	WeeklyResetRemaining   time.Duration
+}
+
+type usageWindow struct {
+	LimitWindowSeconds int64 `json:"limit_window_seconds"`
+	ResetAfterSeconds  int64 `json:"reset_after_seconds"`
+	ResetAt            int64 `json:"reset_at"`
+}
+
+type usageRateLimit struct {
+	PrimaryWindow   *usageWindow `json:"primary_window"`
+	SecondaryWindow *usageWindow `json:"secondary_window"`
+}
+
+type usageResponse struct {
+	RateLimit usageRateLimit `json:"rate_limit"`
+}
+
+type WarmupListener struct {
+	cfg               *config.Config
+	authManager       *coreauth.Manager
+	mu                sync.Mutex
+	lastAcceptedAt    map[string]time.Time
+	warmedAuthIndexes map[string]struct{}
+	now               func() time.Time
+	execute           func(context.Context, []string, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error)
+}
+
+func NewWarmupListener(cfg *config.Config, manager *coreauth.Manager) *WarmupListener {
+	listener := &WarmupListener{
+		cfg:               cfg,
+		authManager:       manager,
+		lastAcceptedAt:    map[string]time.Time{},
+		warmedAuthIndexes: map[string]struct{}{},
+	}
+	if manager != nil {
+		listener.execute = manager.Execute
+	}
+	return listener
+}
+
+func (l *WarmupListener) setConfig(cfg *config.Config) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	l.cfg = cfg
+	l.mu.Unlock()
+}
+
+func (l *WarmupListener) currentConfig() *config.Config {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.cfg
+}
+
+func (l *WarmupListener) setAuthManager(manager *coreauth.Manager) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	l.authManager = manager
+	if manager != nil {
+		l.execute = manager.Execute
+	}
+	l.mu.Unlock()
+}
+
+func (l *WarmupListener) currentAuthManager() *coreauth.Manager {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.authManager
+}
+
+func parseWarmupQuotaSnapshot(body []byte) (WarmupQuotaSnapshot, bool) {
+	var resp usageResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return WarmupQuotaSnapshot{}, false
+	}
+
+	snapshot := WarmupQuotaSnapshot{}
+	for _, window := range []*usageWindow{resp.RateLimit.PrimaryWindow, resp.RateLimit.SecondaryWindow} {
+		if window == nil {
+			continue
+		}
+		remaining := time.Duration(window.ResetAfterSeconds) * time.Second
+		switch window.LimitWindowSeconds {
+		case 5 * 60 * 60:
+			snapshot.HasFiveHourWindow = true
+			snapshot.FiveHourResetRemaining = remaining
+		case 7 * 24 * 60 * 60:
+			snapshot.HasWeeklyWindow = true
+			snapshot.WeeklyResetRemaining = remaining
+		}
+	}
+
+	return snapshot, true
+}
+
+func warmupAllowed(snapshot WarmupQuotaSnapshot) bool {
+	if !snapshot.HasFiveHourWindow || !snapshot.HasWeeklyWindow {
+		return false
+	}
+	return snapshot.FiveHourResetRemaining >= 5*time.Hour &&
+		snapshot.WeeklyResetRemaining >= 7*24*time.Hour
+}
+
+func (l *WarmupListener) isWarmupEnabled() bool {
+	cfg := l.currentConfig()
+	if cfg == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(cfg.Routing.Strategy), "fill-first") && cfg.Routing.Warmup
+}
+
+func (l *WarmupListener) shouldSkipSource(authIndex string) bool {
+	if l == nil {
+		return true
+	}
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return true
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.warmedAuthIndexes == nil {
+		return false
+	}
+	_, ok := l.warmedAuthIndexes[authIndex]
+	return ok
+}
+
+func (l *WarmupListener) markSourceWarmed(authIndex string) {
+	if l == nil {
+		return
+	}
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.warmedAuthIndexes == nil {
+		l.warmedAuthIndexes = map[string]struct{}{}
+	}
+	l.warmedAuthIndexes[authIndex] = struct{}{}
+}
+
+func (l *WarmupListener) shouldIgnoreByCooldown(authIndex string, now time.Time) bool {
+	if l == nil {
+		return true
+	}
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return true
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.lastAcceptedAt == nil {
+		l.lastAcceptedAt = map[string]time.Time{}
+	}
+	last, ok := l.lastAcceptedAt[authIndex]
+	if ok && now.Sub(last) < warmupCooldown {
+		return true
+	}
+	l.lastAcceptedAt[authIndex] = now
+	return false
+}
+
+func hasNegativeModelState(auth *coreauth.Auth) bool {
+	if auth == nil {
+		return false
+	}
+	for _, state := range auth.ModelStates {
+		if state == nil {
+			continue
+		}
+		if state.Status == coreauth.StatusDisabled || state.Status == coreauth.StatusError || state.Unavailable || state.Quota.Exceeded {
+			return true
+		}
+		if !state.NextRetryAfter.IsZero() || state.LastError != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *WarmupListener) collectWarmupTargets(auths []*coreauth.Auth, sourceID string) []*coreauth.Auth {
+	out := make([]*coreauth.Auth, 0)
+	for _, auth := range auths {
+		if auth == nil || auth.ID == sourceID {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+			continue
+		}
+		accountType, _ := auth.AccountInfo()
+		if accountType != "oauth" {
+			continue
+		}
+		if auth.Disabled || auth.Status == coreauth.StatusDisabled || auth.Status == coreauth.StatusError || auth.Unavailable || auth.Quota.Exceeded || !auth.NextRetryAfter.IsZero() || auth.LastError != nil || hasNegativeModelState(auth) {
+			continue
+		}
+		out = append(out, auth)
+	}
+	return out
+}
+
+func selectWarmupModel(authID string) string {
+	models := registry.GetGlobalRegistry().GetModelsForClient(authID)
+	for _, pattern := range warmupMiniModelPatterns {
+		for _, model := range models {
+			if model == nil {
+				continue
+			}
+			id := strings.TrimSpace(model.ID)
+			if id == "" {
+				continue
+			}
+			if matchWarmupModelPattern(pattern, id) {
+				return id
+			}
+		}
+	}
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		id := strings.TrimSpace(model.ID)
+		if id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+func matchWarmupModelPattern(pattern, model string) bool {
+	pattern = strings.TrimSpace(pattern)
+	model = strings.TrimSpace(model)
+	if pattern == "" {
+		return false
+	}
+	if pattern == "*" {
+		return true
+	}
+
+	pi, si := 0, 0
+	starIdx := -1
+	matchIdx := 0
+	for si < len(model) {
+		if pi < len(pattern) && pattern[pi] == model[si] {
+			pi++
+			si++
+			continue
+		}
+		if pi < len(pattern) && pattern[pi] == '*' {
+			starIdx = pi
+			matchIdx = si
+			pi++
+			continue
+		}
+		if starIdx != -1 {
+			pi = starIdx + 1
+			matchIdx++
+			si = matchIdx
+			continue
+		}
+		return false
+	}
+	for pi < len(pattern) && pattern[pi] == '*' {
+		pi++
+	}
+	return pi == len(pattern)
+}
+
+func (l *WarmupListener) authByIndex(authIndex string) *coreauth.Auth {
+	authIndex = strings.TrimSpace(authIndex)
+	manager := l.currentAuthManager()
+	if authIndex == "" || manager == nil {
+		return nil
+	}
+
+	auths := manager.List()
+	for _, auth := range auths {
+		if auth == nil {
+			continue
+		}
+		auth.EnsureIndex()
+		if auth.Index == authIndex {
+			return auth
+		}
+	}
+	return nil
+}
+
+func isSourceCodexOAuthCandidate(auth *coreauth.Auth) bool {
+	if auth == nil || strings.TrimSpace(auth.ID) == "" {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return false
+	}
+	accountType, _ := auth.AccountInfo()
+	return accountType == "oauth"
+}
+
+func (l *WarmupListener) executeWarmup(ctx context.Context, target *coreauth.Auth, model string) error {
+	if target == nil {
+		return fmt.Errorf("warmup target is nil")
+	}
+	targetID := strings.TrimSpace(target.ID)
+	model = strings.TrimSpace(model)
+	if targetID == "" {
+		return fmt.Errorf("warmup target id is empty")
+	}
+	if model == "" {
+		return fmt.Errorf("warmup model is empty")
+	}
+
+	execFn := l.execute
+	if execFn == nil {
+		if manager := l.currentAuthManager(); manager != nil {
+			execFn = manager.Execute
+		}
+	}
+	if execFn == nil {
+		return fmt.Errorf("warmup execute function unavailable")
+	}
+
+	payload, err := json.Marshal(map[string]string{
+		"model": model,
+		"input": "hello",
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = execFn(ctx, []string{"codex"}, cliproxyexecutor.Request{
+		Model:   model,
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+		Alt:          "",
+		Metadata: map[string]any{
+			cliproxyexecutor.PinnedAuthMetadataKey: targetID,
+		},
+	})
+	return err
+}
+
+func (l *WarmupListener) OnManagementAPICall(ctx context.Context, evt ManagementAPICallEvent) {
+	manager := l.currentAuthManager()
+	if l == nil || !l.isWarmupEnabled() || manager == nil {
+		return
+	}
+	if evt.StatusCode < 200 || evt.StatusCode >= 300 {
+		return
+	}
+
+	sourceAuthIndex := strings.TrimSpace(evt.AuthIndex)
+	if sourceAuthIndex == "" || l.shouldSkipSource(sourceAuthIndex) {
+		return
+	}
+
+	source := l.authByIndex(sourceAuthIndex)
+	if !isSourceCodexOAuthCandidate(source) {
+		return
+	}
+
+	snapshot, ok := parseWarmupQuotaSnapshot(evt.RespBody)
+	if !ok || !warmupAllowed(snapshot) {
+		return
+	}
+
+	now := time.Now()
+	if l.now != nil {
+		now = l.now()
+	}
+	if l.shouldIgnoreByCooldown(sourceAuthIndex, now) {
+		return
+	}
+
+	targets := l.collectWarmupTargets(manager.List(), source.ID)
+	if len(targets) == 0 {
+		return
+	}
+
+	hasSuccess := false
+	for _, target := range targets {
+		model := selectWarmupModel(target.ID)
+		if strings.TrimSpace(model) == "" {
+			continue
+		}
+		if err := l.executeWarmup(ctx, target, model); err != nil {
+			log.WithError(err).Warnf("management api-call warmup failed for auth %s", target.ID)
+			continue
+		}
+		hasSuccess = true
+	}
+	if hasSuccess {
+		l.markSourceWarmed(sourceAuthIndex)
+	}
+}

--- a/internal/api/handlers/management/api_call_warmup.go
+++ b/internal/api/handlers/management/api_call_warmup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -91,6 +92,8 @@ func (l *WarmupListener) setAuthManager(manager *coreauth.Manager) {
 	l.authManager = manager
 	if manager != nil {
 		l.execute = manager.Execute
+	} else {
+		l.execute = nil
 	}
 	l.mu.Unlock()
 }
@@ -102,6 +105,15 @@ func (l *WarmupListener) currentAuthManager() *coreauth.Manager {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.authManager
+}
+
+func (l *WarmupListener) currentExecute() func(context.Context, []string, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.execute
 }
 
 func parseWarmupQuotaSnapshot(body []byte) (WarmupQuotaSnapshot, bool) {
@@ -314,18 +326,7 @@ func (l *WarmupListener) authByIndex(authIndex string) *coreauth.Auth {
 	if authIndex == "" || manager == nil {
 		return nil
 	}
-
-	auths := manager.List()
-	for _, auth := range auths {
-		if auth == nil {
-			continue
-		}
-		auth.EnsureIndex()
-		if auth.Index == authIndex {
-			return auth
-		}
-	}
-	return nil
+	return findAuthByStableIndex(manager.List(), authIndex)
 }
 
 func isSourceCodexOAuthCandidate(auth *coreauth.Auth) bool {
@@ -337,6 +338,25 @@ func isSourceCodexOAuthCandidate(auth *coreauth.Auth) bool {
 	}
 	accountType, _ := auth.AccountInfo()
 	return accountType == "oauth"
+}
+
+func isWarmupUsageURL(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return false
+	}
+	if !strings.EqualFold(parsed.Hostname(), "api.openai.com") {
+		return false
+	}
+	return parsed.Path == "/v1/usage"
 }
 
 func (l *WarmupListener) executeWarmup(ctx context.Context, target *coreauth.Auth, model string) error {
@@ -352,7 +372,7 @@ func (l *WarmupListener) executeWarmup(ctx context.Context, target *coreauth.Aut
 		return fmt.Errorf("warmup model is empty")
 	}
 
-	execFn := l.execute
+	execFn := l.currentExecute()
 	if execFn == nil {
 		if manager := l.currentAuthManager(); manager != nil {
 			execFn = manager.Execute
@@ -400,6 +420,10 @@ func (l *WarmupListener) OnManagementAPICall(ctx context.Context, evt Management
 
 	source := l.authByIndex(sourceAuthIndex)
 	if !isSourceCodexOAuthCandidate(source) {
+		return
+	}
+
+	if !isWarmupUsageURL(evt.URL) {
 		return
 	}
 

--- a/internal/api/handlers/management/api_call_warmup.go
+++ b/internal/api/handlers/management/api_call_warmup.go
@@ -142,11 +142,14 @@ func parseWarmupQuotaSnapshot(body []byte) (WarmupQuotaSnapshot, bool) {
 }
 
 func warmupAllowed(snapshot WarmupQuotaSnapshot) bool {
-	if !snapshot.HasFiveHourWindow || !snapshot.HasWeeklyWindow {
-		return false
+	if snapshot.HasFiveHourWindow && snapshot.HasWeeklyWindow {
+		return snapshot.FiveHourResetRemaining >= 5*time.Hour &&
+			snapshot.WeeklyResetRemaining >= 7*24*time.Hour
 	}
-	return snapshot.FiveHourResetRemaining >= 5*time.Hour &&
-		snapshot.WeeklyResetRemaining >= 7*24*time.Hour
+	if snapshot.HasWeeklyWindow {
+		return snapshot.WeeklyResetRemaining >= 7*24*time.Hour
+	}
+	return false
 }
 
 func (l *WarmupListener) isWarmupEnabled() bool {

--- a/internal/api/handlers/management/api_call_warmup_test.go
+++ b/internal/api/handlers/management/api_call_warmup_test.go
@@ -1,0 +1,355 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+func TestParseWarmupQuotaSnapshotRequiresBothWindows(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"rate_limit":{
+			"primary_window":{"limit_window_seconds":604800,"reset_after_seconds":604800,"reset_at":1777149808},
+			"secondary_window":null
+		}
+	}`)
+
+	snapshot, ok := parseWarmupQuotaSnapshot(body)
+	if !ok {
+		t.Fatal("expected parse success")
+	}
+	if snapshot.HasFiveHourWindow {
+		t.Fatal("did not expect five-hour window")
+	}
+	if !snapshot.HasWeeklyWindow {
+		t.Fatal("expected weekly window")
+	}
+	if warmupAllowed(snapshot) {
+		t.Fatal("warmup should require both windows")
+	}
+}
+
+func TestWarmupListenerSkipsAlreadyWarmedSource(t *testing.T) {
+	t.Parallel()
+
+	listener := &WarmupListener{
+		warmedAuthIndexes: map[string]struct{}{"source-1": {}},
+		lastAcceptedAt:    map[string]time.Time{},
+	}
+
+	if !listener.shouldSkipSource("source-1") {
+		t.Fatal("expected warmed source to be skipped")
+	}
+}
+
+func TestWarmupListenerCooldownBlocksDuplicateSource(t *testing.T) {
+	t.Parallel()
+
+	listener := &WarmupListener{
+		warmedAuthIndexes: map[string]struct{}{},
+		lastAcceptedAt:    map[string]time.Time{},
+	}
+	now := time.Now()
+
+	if listener.shouldIgnoreByCooldown("source-1", now) {
+		t.Fatal("first event should not be ignored")
+	}
+	if !listener.shouldIgnoreByCooldown("source-1", now.Add(5*time.Second)) {
+		t.Fatal("second event should be ignored during cooldown")
+	}
+}
+
+func TestWarmupTargetsExcludeNegativeStateAndCurrentAuth(t *testing.T) {
+	t.Parallel()
+
+	listener := &WarmupListener{}
+	auths := []*coreauth.Auth{
+		{ID: "source", Provider: "codex", Metadata: map[string]any{"email": "source@example.com"}},
+		{ID: "good", Provider: "codex", Metadata: map[string]any{"email": "good@example.com"}},
+		{ID: "disabled", Provider: "codex", Disabled: true, Metadata: map[string]any{"email": "disabled@example.com"}},
+		{ID: "quota", Provider: "codex", Metadata: map[string]any{"email": "quota@example.com"}, Quota: coreauth.QuotaState{Exceeded: true}},
+		{ID: "model-error", Provider: "codex", Metadata: map[string]any{"email": "model-error@example.com"}, ModelStates: map[string]*coreauth.ModelState{"gpt-5": {Status: coreauth.StatusError}}},
+	}
+
+	got := listener.collectWarmupTargets(auths, "source")
+	if len(got) != 1 || got[0].ID != "good" {
+		t.Fatalf("targets = %#v", got)
+	}
+}
+
+func TestSelectWarmupModelPrefersMiniPattern(t *testing.T) {
+	authID := "warmup-mini-" + strings.ReplaceAll(strings.ToLower(t.Name()), "/", "-")
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: "gpt-5.4"}, {ID: "gpt-5.4-mini"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(authID)
+	})
+
+	model := selectWarmupModel(authID)
+	if model != "gpt-5.4-mini" {
+		t.Fatalf("model = %q, want %q", model, "gpt-5.4-mini")
+	}
+}
+
+func TestHandlerSetConfigUpdatesWarmupListener(t *testing.T) {
+	t.Parallel()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	h := NewHandler(&config.Config{Routing: config.RoutingConfig{Strategy: "fill-first", Warmup: true}}, "", manager)
+	if h.warmupListener == nil {
+		t.Fatal("expected warmup listener")
+	}
+	if !h.warmupListener.isWarmupEnabled() {
+		t.Fatal("expected warmup enabled before config update")
+	}
+
+	h.SetConfig(&config.Config{Routing: config.RoutingConfig{Strategy: "round-robin", Warmup: false}})
+	if h.warmupListener.isWarmupEnabled() {
+		t.Fatal("expected warmup disabled after config update")
+	}
+}
+
+func TestWarmupListenerExecutesDefaultResponsesForEachTarget(t *testing.T) {
+	t.Parallel()
+
+	testID := strings.ReplaceAll(strings.ToLower(t.Name()), "/", "-")
+	manager := coreauth.NewManager(nil, nil, nil)
+	source := &coreauth.Auth{ID: "source-" + testID, Provider: "codex", Metadata: map[string]any{"email": "source@example.com"}}
+	targetA := &coreauth.Auth{ID: "target-a-" + testID, Provider: "codex", Metadata: map[string]any{"email": "target-a@example.com"}}
+	targetB := &coreauth.Auth{ID: "target-b-" + testID, Provider: "codex", Metadata: map[string]any{"email": "target-b@example.com"}}
+	if _, err := manager.Register(context.Background(), source); err != nil {
+		t.Fatalf("register source: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), targetA); err != nil {
+		t.Fatalf("register targetA: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), targetB); err != nil {
+		t.Fatalf("register targetB: %v", err)
+	}
+
+	sourceAuth, ok := manager.GetByID(source.ID)
+	if !ok {
+		t.Fatal("source auth missing")
+	}
+	sourceIndex := sourceAuth.EnsureIndex()
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(targetA.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.4-mini"}})
+	reg.RegisterClient(targetB.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.4-nano"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(targetA.ID)
+		reg.UnregisterClient(targetB.ID)
+	})
+
+	type executeCall struct {
+		providers []string
+		req       cliproxyexecutor.Request
+		opts      cliproxyexecutor.Options
+	}
+	calls := make([]executeCall, 0, 2)
+	listener := &WarmupListener{
+		cfg:               &config.Config{Routing: config.RoutingConfig{Strategy: "fill-first", Warmup: true}},
+		authManager:       manager,
+		lastAcceptedAt:    map[string]time.Time{},
+		warmedAuthIndexes: map[string]struct{}{},
+		now:               func() time.Time { return time.Unix(1000, 0) },
+		execute: func(_ context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			calls = append(calls, executeCall{providers: append([]string(nil), providers...), req: req, opts: opts})
+			return cliproxyexecutor.Response{}, nil
+		},
+	}
+
+	listener.OnManagementAPICall(context.Background(), ManagementAPICallEvent{
+		AuthIndex:  sourceIndex,
+		Method:     "GET",
+		URL:        "https://api.openai.com/v1/usage",
+		StatusCode: 200,
+		RespBody: []byte(`{
+			"rate_limit":{
+				"primary_window":{"limit_window_seconds":18000,"reset_after_seconds":18000,"reset_at":1777149808},
+				"secondary_window":{"limit_window_seconds":604800,"reset_after_seconds":604800,"reset_at":1777149808}
+			}
+		}`),
+	})
+
+	if len(calls) != 2 {
+		t.Fatalf("execute calls = %d, want 2", len(calls))
+	}
+
+	seenTargetIDs := map[string]bool{}
+	for _, call := range calls {
+		if len(call.providers) != 1 || call.providers[0] != "codex" {
+			t.Fatalf("providers = %#v", call.providers)
+		}
+		if call.opts.SourceFormat.String() != "openai-response" {
+			t.Fatalf("source format = %q", call.opts.SourceFormat.String())
+		}
+		if call.opts.Stream {
+			t.Fatal("stream should be false")
+		}
+		if call.opts.Alt != "" {
+			t.Fatalf("alt = %q, want empty", call.opts.Alt)
+		}
+		pinnedID, _ := call.opts.Metadata[cliproxyexecutor.PinnedAuthMetadataKey].(string)
+		if pinnedID == "" {
+			t.Fatalf("missing %q metadata", cliproxyexecutor.PinnedAuthMetadataKey)
+		}
+		seenTargetIDs[pinnedID] = true
+
+		var payload map[string]any
+		if err := json.Unmarshal(call.req.Payload, &payload); err != nil {
+			t.Fatalf("payload json: %v", err)
+		}
+		if payload["input"] != "hello" {
+			t.Fatalf("payload input = %#v", payload["input"])
+		}
+		if payload["model"] != call.req.Model {
+			t.Fatalf("payload model = %#v, req model = %q", payload["model"], call.req.Model)
+		}
+	}
+	if !seenTargetIDs[targetA.ID] || !seenTargetIDs[targetB.ID] {
+		t.Fatalf("seen pinned auths = %#v", seenTargetIDs)
+	}
+}
+
+func TestWarmupListenerNonQuotaEventDoesNotConsumeCooldown(t *testing.T) {
+	t.Parallel()
+
+	testID := strings.ReplaceAll(strings.ToLower(t.Name()), "/", "-")
+	manager := coreauth.NewManager(nil, nil, nil)
+	source := &coreauth.Auth{ID: "source-" + testID, Provider: "codex", Metadata: map[string]any{"email": "source@example.com"}}
+	target := &coreauth.Auth{ID: "target-" + testID, Provider: "codex", Metadata: map[string]any{"email": "target@example.com"}}
+	if _, err := manager.Register(context.Background(), source); err != nil {
+		t.Fatalf("register source: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), target); err != nil {
+		t.Fatalf("register target: %v", err)
+	}
+
+	sourceAuth, ok := manager.GetByID(source.ID)
+	if !ok {
+		t.Fatal("source auth missing")
+	}
+	sourceIndex := sourceAuth.EnsureIndex()
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(target.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.4-mini"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(target.ID)
+	})
+
+	calls := 0
+	now := time.Unix(1000, 0)
+	listener := &WarmupListener{
+		cfg:               &config.Config{Routing: config.RoutingConfig{Strategy: "fill-first", Warmup: true}},
+		authManager:       manager,
+		lastAcceptedAt:    map[string]time.Time{},
+		warmedAuthIndexes: map[string]struct{}{},
+		now:               func() time.Time { return now },
+		execute: func(context.Context, []string, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			calls++
+			return cliproxyexecutor.Response{}, nil
+		},
+	}
+
+	listener.OnManagementAPICall(context.Background(), ManagementAPICallEvent{
+		AuthIndex:  sourceIndex,
+		Method:     "GET",
+		URL:        "https://api.openai.com/v1/usage",
+		StatusCode: 200,
+		RespBody:   []byte(`{"ok":true}`),
+	})
+
+	listener.OnManagementAPICall(context.Background(), ManagementAPICallEvent{
+		AuthIndex:  sourceIndex,
+		Method:     "GET",
+		URL:        "https://api.openai.com/v1/usage",
+		StatusCode: 200,
+		RespBody: []byte(`{
+			"rate_limit":{
+				"primary_window":{"limit_window_seconds":18000,"reset_after_seconds":18000,"reset_at":1777149808},
+				"secondary_window":{"limit_window_seconds":604800,"reset_after_seconds":604800,"reset_at":1777149808}
+			}
+		}`),
+	})
+
+	if calls != 1 {
+		t.Fatalf("execute calls = %d, want 1", calls)
+	}
+}
+
+func TestWarmupListenerMarksSourceOnlyAfterSuccess(t *testing.T) {
+	t.Parallel()
+
+	testID := strings.ReplaceAll(strings.ToLower(t.Name()), "/", "-")
+	manager := coreauth.NewManager(nil, nil, nil)
+	source := &coreauth.Auth{ID: "source-" + testID, Provider: "codex", Metadata: map[string]any{"email": "source@example.com"}}
+	target := &coreauth.Auth{ID: "target-" + testID, Provider: "codex", Metadata: map[string]any{"email": "target@example.com"}}
+	if _, err := manager.Register(context.Background(), source); err != nil {
+		t.Fatalf("register source: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), target); err != nil {
+		t.Fatalf("register target: %v", err)
+	}
+
+	sourceAuth, ok := manager.GetByID(source.ID)
+	if !ok {
+		t.Fatal("source auth missing")
+	}
+	sourceIndex := sourceAuth.EnsureIndex()
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(target.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.4-mini"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(target.ID)
+	})
+
+	now := time.Unix(1000, 0)
+	listener := &WarmupListener{
+		cfg:               &config.Config{Routing: config.RoutingConfig{Strategy: "fill-first", Warmup: true}},
+		authManager:       manager,
+		lastAcceptedAt:    map[string]time.Time{},
+		warmedAuthIndexes: map[string]struct{}{},
+		now:               func() time.Time { return now },
+		execute: func(context.Context, []string, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			return cliproxyexecutor.Response{}, errors.New("warmup failed")
+		},
+	}
+
+	evt := ManagementAPICallEvent{
+		AuthIndex:  sourceIndex,
+		Method:     "GET",
+		URL:        "https://api.openai.com/v1/usage",
+		StatusCode: 200,
+		RespBody: []byte(`{
+			"rate_limit":{
+				"primary_window":{"limit_window_seconds":18000,"reset_after_seconds":18000,"reset_at":1777149808},
+				"secondary_window":{"limit_window_seconds":604800,"reset_after_seconds":604800,"reset_at":1777149808}
+			}
+		}`),
+	}
+
+	listener.OnManagementAPICall(context.Background(), evt)
+	if listener.shouldSkipSource(sourceIndex) {
+		t.Fatal("source should stay eligible when all warmups fail")
+	}
+
+	now = now.Add(warmupCooldown + time.Second)
+	listener.execute = func(context.Context, []string, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+		return cliproxyexecutor.Response{}, nil
+	}
+	listener.OnManagementAPICall(context.Background(), evt)
+	if !listener.shouldSkipSource(sourceIndex) {
+		t.Fatal("source should be marked only after warmup success")
+	}
+}

--- a/internal/api/handlers/management/api_call_warmup_test.go
+++ b/internal/api/handlers/management/api_call_warmup_test.go
@@ -14,7 +14,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 )
 
-func TestParseWarmupQuotaSnapshotRequiresBothWindows(t *testing.T) {
+func TestWarmupAllowedWeeklyOnlyWindowFromRateLimit(t *testing.T) {
 	t.Parallel()
 
 	body := []byte(`{
@@ -34,8 +34,113 @@ func TestParseWarmupQuotaSnapshotRequiresBothWindows(t *testing.T) {
 	if !snapshot.HasWeeklyWindow {
 		t.Fatal("expected weekly window")
 	}
+	if !warmupAllowed(snapshot) {
+		t.Fatal("weekly-only window should allow warmup when weekly threshold is met")
+	}
+}
+
+func TestWarmupAllowedDualWindowsRequireBothThresholds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "both windows meet threshold",
+			body: `{
+				"rate_limit":{
+					"primary_window":{"limit_window_seconds":18000,"reset_after_seconds":18000,"reset_at":1777149808},
+					"secondary_window":{"limit_window_seconds":604800,"reset_after_seconds":604800,"reset_at":1777149808}
+				}
+			}`,
+			want: true,
+		},
+		{
+			name: "five-hour below threshold",
+			body: `{
+				"rate_limit":{
+					"primary_window":{"limit_window_seconds":18000,"reset_after_seconds":17999,"reset_at":1777149808},
+					"secondary_window":{"limit_window_seconds":604800,"reset_after_seconds":604800,"reset_at":1777149808}
+				}
+			}`,
+			want: false,
+		},
+		{
+			name: "weekly below threshold",
+			body: `{
+				"rate_limit":{
+					"primary_window":{"limit_window_seconds":18000,"reset_after_seconds":18000,"reset_at":1777149808},
+					"secondary_window":{"limit_window_seconds":604800,"reset_after_seconds":604799,"reset_at":1777149808}
+				}
+			}`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot, ok := parseWarmupQuotaSnapshot([]byte(tt.body))
+			if !ok {
+				t.Fatal("expected parse success")
+			}
+			if got := warmupAllowed(snapshot); got != tt.want {
+				t.Fatalf("warmupAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWarmupAllowedRejectsSingleFiveHourWindow(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"rate_limit":{
+			"primary_window":{"limit_window_seconds":18000,"reset_after_seconds":18000,"reset_at":1777149808},
+			"secondary_window":null
+		}
+	}`)
+
+	snapshot, ok := parseWarmupQuotaSnapshot(body)
+	if !ok {
+		t.Fatal("expected parse success")
+	}
+	if !snapshot.HasFiveHourWindow {
+		t.Fatal("expected five-hour window")
+	}
+	if snapshot.HasWeeklyWindow {
+		t.Fatal("did not expect weekly window")
+	}
 	if warmupAllowed(snapshot) {
-		t.Fatal("warmup should require both windows")
+		t.Fatal("five-hour-only window should not allow warmup")
+	}
+}
+
+func TestWarmupAllowedIgnoresCodeReviewRateLimit(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"rate_limit":{
+			"primary_window":{"limit_window_seconds":18000,"reset_after_seconds":18000,"reset_at":1777149808},
+			"secondary_window":null
+		},
+		"code_review_rate_limit":{
+			"primary_window":{"limit_window_seconds":604800,"reset_after_seconds":604800,"reset_at":1777149808},
+			"secondary_window":null
+		}
+	}`)
+
+	snapshot, ok := parseWarmupQuotaSnapshot(body)
+	if !ok {
+		t.Fatal("expected parse success")
+	}
+	if snapshot.HasWeeklyWindow {
+		t.Fatal("did not expect weekly window from code_review_rate_limit")
+	}
+	if warmupAllowed(snapshot) {
+		t.Fatal("code_review_rate_limit should not affect warmup decision")
 	}
 }
 

--- a/internal/api/handlers/management/api_call_warmup_test.go
+++ b/internal/api/handlers/management/api_call_warmup_test.go
@@ -288,6 +288,93 @@ func TestWarmupListenerNonQuotaEventDoesNotConsumeCooldown(t *testing.T) {
 	}
 }
 
+func TestWarmupListenerSkipsNonUsageURLEvenWhenBodyLooksLikeQuota(t *testing.T) {
+	t.Parallel()
+
+	testID := strings.ReplaceAll(strings.ToLower(t.Name()), "/", "-")
+	manager := coreauth.NewManager(nil, nil, nil)
+	source := &coreauth.Auth{ID: "source-" + testID, Provider: "codex", Metadata: map[string]any{"email": "source@example.com"}}
+	target := &coreauth.Auth{ID: "target-" + testID, Provider: "codex", Metadata: map[string]any{"email": "target@example.com"}}
+	if _, err := manager.Register(context.Background(), source); err != nil {
+		t.Fatalf("register source: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), target); err != nil {
+		t.Fatalf("register target: %v", err)
+	}
+
+	sourceAuth, ok := manager.GetByID(source.ID)
+	if !ok {
+		t.Fatal("source auth missing")
+	}
+	sourceIndex := sourceAuth.EnsureIndex()
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(target.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.4-mini"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(target.ID)
+	})
+
+	calls := 0
+	listener := &WarmupListener{
+		cfg:               &config.Config{Routing: config.RoutingConfig{Strategy: "fill-first", Warmup: true}},
+		authManager:       manager,
+		lastAcceptedAt:    map[string]time.Time{},
+		warmedAuthIndexes: map[string]struct{}{},
+		now:               func() time.Time { return time.Unix(1000, 0) },
+		execute: func(context.Context, []string, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			calls++
+			return cliproxyexecutor.Response{}, nil
+		},
+	}
+
+	listener.OnManagementAPICall(context.Background(), ManagementAPICallEvent{
+		AuthIndex:  sourceIndex,
+		Method:     "GET",
+		URL:        "https://api.openai.com/v1/models",
+		StatusCode: 200,
+		RespBody: []byte(`{
+			"rate_limit":{
+				"primary_window":{"limit_window_seconds":18000,"reset_after_seconds":18000,"reset_at":1777149808},
+				"secondary_window":{"limit_window_seconds":604800,"reset_after_seconds":604800,"reset_at":1777149808}
+			}
+		}`),
+	})
+
+	if calls != 0 {
+		t.Fatalf("execute calls = %d, want 0", calls)
+	}
+}
+
+func TestWarmupListenerCurrentExecuteTracksManagerHotUpdate(t *testing.T) {
+	t.Parallel()
+
+	oldErr := errors.New("old execute")
+	listener := &WarmupListener{
+		execute: func(context.Context, []string, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			return cliproxyexecutor.Response{}, oldErr
+		},
+	}
+
+	execBefore := listener.currentExecute()
+	if execBefore == nil {
+		t.Fatal("expected current execute before update")
+	}
+	if _, err := execBefore(context.Background(), []string{"codex"}, cliproxyexecutor.Request{}, cliproxyexecutor.Options{}); !errors.Is(err, oldErr) {
+		t.Fatalf("before update error = %v, want old execute error", err)
+	}
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	listener.setAuthManager(manager)
+
+	execAfter := listener.currentExecute()
+	if execAfter == nil {
+		t.Fatal("expected current execute after update")
+	}
+	if _, err := execAfter(context.Background(), []string{"codex"}, cliproxyexecutor.Request{}, cliproxyexecutor.Options{}); errors.Is(err, oldErr) {
+		t.Fatalf("after update still used old execute: %v", err)
+	}
+}
+
 func TestWarmupListenerMarksSourceOnlyAfterSuccess(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -633,17 +633,7 @@ func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {
 	if authIndex == "" || h == nil || h.authManager == nil {
 		return nil
 	}
-	auths := h.authManager.List()
-	for _, auth := range auths {
-		if auth == nil {
-			continue
-		}
-		auth.EnsureIndex()
-		if auth.Index == authIndex {
-			return auth
-		}
-	}
-	return nil
+	return findAuthByStableIndex(h.authManager.List(), authIndex)
 }
 
 func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -209,11 +209,26 @@ func (h *Handler) APICall(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, apiCallResponse{
+	responseHeader := resp.Header.Clone()
+	responseBody := append([]byte(nil), respBody...)
+	response := apiCallResponse{
 		StatusCode: resp.StatusCode,
-		Header:     resp.Header,
-		Body:       string(respBody),
-	})
+		Header:     responseHeader,
+		Body:       string(responseBody),
+	}
+	c.JSON(http.StatusOK, response)
+
+	if h != nil && h.apiCallEvents != nil {
+		eventCtx := context.WithoutCancel(c.Request.Context())
+		h.apiCallEvents.Publish(eventCtx, ManagementAPICallEvent{
+			AuthIndex:  authIndex,
+			Method:     method,
+			URL:        urlStr,
+			StatusCode: resp.StatusCode,
+			RespHeader: responseHeader.Clone(),
+			RespBody:   append([]byte(nil), responseBody...),
+		})
+	}
 }
 
 func firstNonEmptyString(values ...*string) string {

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -2,9 +2,14 @@ package management
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
@@ -208,5 +213,141 @@ func TestAuthByIndexDistinguishesSharedAPIKeysAcrossProviders(t *testing.T) {
 	}
 	if gotCompat.ID != compatAuth.ID {
 		t.Fatalf("authByIndex(compat) returned %q, want %q", gotCompat.ID, compatAuth.ID)
+	}
+}
+
+func TestAPICallPublishesEventAfterSuccessResponse(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Upstream", "ready")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	h := &Handler{apiCallEvents: newManagementAPICallEventBus()}
+	events := make(chan ManagementAPICallEvent, 1)
+	h.RegisterManagementAPICallListener(ManagementAPICallListenerFunc(func(_ context.Context, evt ManagementAPICallEvent) {
+		events <- evt
+	}))
+
+	r := gin.New()
+	r.POST("/api-call", h.APICall)
+
+	targetURL := upstream.URL + "/v1/warmup"
+	reqBody := `{"method":"GET","url":"` + targetURL + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api-call", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var gotResp apiCallResponse
+	if errUnmarshal := json.Unmarshal(rec.Body.Bytes(), &gotResp); errUnmarshal != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", errUnmarshal)
+	}
+	if gotResp.StatusCode != http.StatusCreated {
+		t.Fatalf("response status_code = %d, want %d", gotResp.StatusCode, http.StatusCreated)
+	}
+	if gotResp.Body != `{"ok":true}` {
+		t.Fatalf("response body = %q, want %q", gotResp.Body, `{"ok":true}`)
+	}
+	if got := gotResp.Header["X-Upstream"]; len(got) != 1 || got[0] != "ready" {
+		t.Fatalf("response header X-Upstream = %v, want [ready]", got)
+	}
+
+	select {
+	case evt := <-events:
+		if evt.AuthIndex != "" {
+			t.Fatalf("event auth_index = %q, want empty", evt.AuthIndex)
+		}
+		if evt.Method != http.MethodGet {
+			t.Fatalf("event method = %q, want %q", evt.Method, http.MethodGet)
+		}
+		if evt.URL != targetURL {
+			t.Fatalf("event url = %q, want %q", evt.URL, targetURL)
+		}
+		if evt.StatusCode != http.StatusCreated {
+			t.Fatalf("event status_code = %d, want %d", evt.StatusCode, http.StatusCreated)
+		}
+		if evt.RespHeader.Get("X-Upstream") != "ready" {
+			t.Fatalf("event header X-Upstream = %q, want %q", evt.RespHeader.Get("X-Upstream"), "ready")
+		}
+		if string(evt.RespBody) != `{"ok":true}` {
+			t.Fatalf("event body = %q, want %q", string(evt.RespBody), `{"ok":true}`)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected APICall event after success response")
+	}
+}
+
+func TestAPICallPublishesEventWithDetachedContext(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	h := &Handler{apiCallEvents: newManagementAPICallEventBus()}
+	ctxErrs := make(chan error, 1)
+	h.RegisterManagementAPICallListener(ManagementAPICallListenerFunc(func(ctx context.Context, evt ManagementAPICallEvent) {
+		time.Sleep(50 * time.Millisecond)
+		ctxErrs <- ctx.Err()
+	}))
+
+	r := gin.New()
+	r.POST("/api-call", h.APICall)
+
+	reqBody := `{"method":"GET","url":"` + upstream.URL + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api-call", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	select {
+	case err := <-ctxErrs:
+		if err != nil {
+			t.Fatalf("listener context err = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected listener context result")
+	}
+}
+
+func TestAPICallDoesNotPublishEventOnRequestFailure(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{apiCallEvents: newManagementAPICallEventBus()}
+	events := make(chan ManagementAPICallEvent, 1)
+	h.RegisterManagementAPICallListener(ManagementAPICallListenerFunc(func(_ context.Context, evt ManagementAPICallEvent) {
+		events <- evt
+	}))
+
+	r := gin.New()
+	r.POST("/api-call", h.APICall)
+
+	reqBody := `{"method":"GET","url":"http://127.0.0.1:1/unreachable"}`
+	req := httptest.NewRequest(http.MethodPost, "/api-call", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+
+	select {
+	case evt := <-events:
+		t.Fatalf("unexpected event published: %+v", evt)
+	case <-time.After(200 * time.Millisecond):
 	}
 }

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -216,6 +216,37 @@ func TestAuthByIndexDistinguishesSharedAPIKeysAcrossProviders(t *testing.T) {
 	}
 }
 
+func TestFindAuthByStableIndexWorksWithoutEnsureIndex(t *testing.T) {
+	t.Parallel()
+
+	auth := &coreauth.Auth{
+		ID:       "gemini-no-index",
+		Provider: "gemini",
+		Attributes: map[string]string{
+			"api_key": "shared-key",
+		},
+	}
+	if auth.Index != "" {
+		t.Fatalf("expected empty initial index, got %q", auth.Index)
+	}
+
+	wantIndex := auth.StableIndex()
+	if wantIndex == "" {
+		t.Fatal("expected stable index")
+	}
+
+	got := findAuthByStableIndex([]*coreauth.Auth{auth}, wantIndex)
+	if got == nil {
+		t.Fatal("expected auth by stable index")
+	}
+	if got != auth {
+		t.Fatal("helper should return original auth pointer")
+	}
+	if auth.Index != "" {
+		t.Fatalf("helper should not assign index, got %q", auth.Index)
+	}
+}
+
 func TestAPICallPublishesEventAfterSuccessResponse(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/management/auth_index_lookup.go
+++ b/internal/api/handlers/management/auth_index_lookup.go
@@ -1,0 +1,24 @@
+package management
+
+import (
+	"strings"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func findAuthByStableIndex(auths []*coreauth.Auth, authIndex string) *coreauth.Auth {
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return nil
+	}
+
+	for _, auth := range auths {
+		if auth == nil {
+			continue
+		}
+		if auth.StableIndex() == authIndex {
+			return auth
+		}
+	}
+	return nil
+}

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -317,6 +317,14 @@ func (h *Handler) PutRoutingStrategy(c *gin.Context) {
 	h.persist(c)
 }
 
+// RoutingWarmup
+func (h *Handler) GetRoutingWarmup(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"warmup": h.cfg.Routing.Warmup})
+}
+func (h *Handler) PutRoutingWarmup(c *gin.Context) {
+	h.updateBoolField(c, func(v bool) { h.cfg.Routing.Warmup = v })
+}
+
 // Proxy URL
 func (h *Handler) GetProxyURL(c *gin.Context) { c.JSON(200, gin.H{"proxy-url": h.cfg.ProxyURL}) }
 func (h *Handler) PutProxyURL(c *gin.Context) {

--- a/internal/api/handlers/management/config_routing_warmup_test.go
+++ b/internal/api/handlers/management/config_routing_warmup_test.go
@@ -1,0 +1,55 @@
+package management
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestRoutingWarmupHandlers(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	cfg := &config.Config{}
+	h := &Handler{cfg: cfg, configFilePath: writeTestConfigFile(t)}
+	r := gin.New()
+	r.GET("/routing/warmup", h.GetRoutingWarmup)
+	r.PUT("/routing/warmup", h.PutRoutingWarmup)
+	r.PATCH("/routing/warmup", h.PutRoutingWarmup)
+
+	getReq := httptest.NewRequest(http.MethodGet, "/routing/warmup", nil)
+	getRec := httptest.NewRecorder()
+	r.ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d", getRec.Code, http.StatusOK)
+	}
+	if strings.TrimSpace(getRec.Body.String()) != `{"warmup":false}` {
+		t.Fatalf("GET body = %s", getRec.Body.String())
+	}
+
+	putReq := httptest.NewRequest(http.MethodPut, "/routing/warmup", strings.NewReader(`{"value":true}`))
+	putReq.Header.Set("Content-Type", "application/json")
+	putRec := httptest.NewRecorder()
+	r.ServeHTTP(putRec, putReq)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want %d; body=%s", putRec.Code, http.StatusOK, putRec.Body.String())
+	}
+	if !cfg.Routing.Warmup {
+		t.Fatal("expected routing.warmup to become true")
+	}
+
+	patchReq := httptest.NewRequest(http.MethodPatch, "/routing/warmup", strings.NewReader(`{"value":false}`))
+	patchReq.Header.Set("Content-Type", "application/json")
+	patchRec := httptest.NewRecorder()
+	r.ServeHTTP(patchRec, patchReq)
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, want %d; body=%s", patchRec.Code, http.StatusOK, patchRec.Body.String())
+	}
+	if cfg.Routing.Warmup {
+		t.Fatal("expected routing.warmup to become false")
+	}
+}

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -48,6 +48,8 @@ type Handler struct {
 	envSecret           string
 	logDir              string
 	postAuthHook        coreauth.PostAuthHook
+	apiCallEvents       *managementAPICallEventBus
+	warmupListener      *WarmupListener
 }
 
 // NewHandler creates a new management handler instance.
@@ -64,6 +66,11 @@ func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Man
 		tokenStore:          sdkAuth.GetTokenStore(),
 		allowRemoteOverride: envSecret != "",
 		envSecret:           envSecret,
+		apiCallEvents:       newManagementAPICallEventBus(),
+	}
+	if manager != nil {
+		h.warmupListener = NewWarmupListener(cfg, manager)
+		h.RegisterManagementAPICallListener(h.warmupListener)
 	}
 	h.startAttemptCleanup()
 	return h
@@ -111,7 +118,11 @@ func (h *Handler) SetConfig(cfg *config.Config) {
 	}
 	h.mu.Lock()
 	h.cfg = cfg
+	warmupListener := h.warmupListener
 	h.mu.Unlock()
+	if warmupListener != nil {
+		warmupListener.setConfig(cfg)
+	}
 }
 
 // SetAuthManager updates the auth manager reference used by management endpoints.
@@ -119,9 +130,24 @@ func (h *Handler) SetAuthManager(manager *coreauth.Manager) {
 	if h == nil {
 		return
 	}
+	createdWarmupListener := false
 	h.mu.Lock()
 	h.authManager = manager
+	warmupListener := h.warmupListener
+	cfg := h.cfg
+	if warmupListener == nil && manager != nil {
+		warmupListener = NewWarmupListener(cfg, manager)
+		h.warmupListener = warmupListener
+		createdWarmupListener = true
+	}
 	h.mu.Unlock()
+	if warmupListener == nil {
+		return
+	}
+	warmupListener.setAuthManager(manager)
+	if createdWarmupListener {
+		h.RegisterManagementAPICallListener(warmupListener)
+	}
 }
 
 // SetUsageStatistics allows replacing the usage statistics reference.
@@ -146,6 +172,14 @@ func (h *Handler) SetLogDirectory(dir string) {
 // SetPostAuthHook registers a hook to be called after auth record creation but before persistence.
 func (h *Handler) SetPostAuthHook(hook coreauth.PostAuthHook) {
 	h.postAuthHook = hook
+}
+
+// RegisterManagementAPICallListener registers a listener for management /api-call events.
+func (h *Handler) RegisterManagementAPICallListener(listener ManagementAPICallListener) {
+	if h == nil || h.apiCallEvents == nil {
+		return
+	}
+	h.apiCallEvents.Register(listener)
 }
 
 // Middleware enforces access control for management endpoints.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -581,6 +581,9 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/routing/strategy", s.mgmt.GetRoutingStrategy)
 		mgmt.PUT("/routing/strategy", s.mgmt.PutRoutingStrategy)
 		mgmt.PATCH("/routing/strategy", s.mgmt.PutRoutingStrategy)
+		mgmt.GET("/routing/warmup", s.mgmt.GetRoutingWarmup)
+		mgmt.PUT("/routing/warmup", s.mgmt.PutRoutingWarmup)
+		mgmt.PATCH("/routing/warmup", s.mgmt.PutRoutingWarmup)
 
 		mgmt.GET("/claude-api-key", s.mgmt.GetClaudeKeys)
 		mgmt.PUT("/claude-api-key", s.mgmt.PutClaudeKeys)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -217,6 +217,9 @@ type RoutingConfig struct {
 	// Supported values: "round-robin" (default), "fill-first".
 	Strategy string `yaml:"strategy,omitempty" json:"strategy,omitempty"`
 
+	// Warmup enables management-triggered fill-first Codex OAuth warmup.
+	Warmup bool `yaml:"warmup,omitempty" json:"warmup,omitempty"`
+
 	// ClaudeCodeSessionAffinity enables session-sticky routing for Claude Code clients.
 	// When enabled, requests with the same session ID (extracted from metadata.user_id)
 	// are routed to the same auth credential when available.
@@ -1339,6 +1342,14 @@ func isKnownDefaultValue(path []string, node *yaml.Node) bool {
 			return node.Value == DefaultPanelGitHubRepository
 		case "routing.strategy":
 			return node.Value == "round-robin"
+		}
+	}
+
+	// Check bool defaults
+	if node.Kind == yaml.ScalarNode && node.Tag == "!!bool" {
+		switch fullPath {
+		case "routing.warmup":
+			return node.Value == "false"
 		}
 	}
 

--- a/internal/tui/config_tab.go
+++ b/internal/tui/config_tab.go
@@ -349,8 +349,10 @@ func (m configTabModel) parseConfig(cfg map[string]any) []configField {
 	// Routing
 	if routing, ok := cfg["routing"].(map[string]any); ok {
 		fields = append(fields, configField{"Routing Strategy", "routing/strategy", "string", getString(routing, "strategy"), nil})
+		fields = append(fields, configField{"Routing Warmup", "routing/warmup", "bool", fmt.Sprintf("%v", getBool(routing, "warmup")), nil})
 	} else {
 		fields = append(fields, configField{"Routing Strategy", "routing/strategy", "string", "", nil})
+		fields = append(fields, configField{"Routing Warmup", "routing/warmup", "bool", "false", nil})
 	}
 
 	// WebSocket auth

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -87,6 +87,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.Routing.Strategy != newCfg.Routing.Strategy {
 		changes = append(changes, fmt.Sprintf("routing.strategy: %s -> %s", oldCfg.Routing.Strategy, newCfg.Routing.Strategy))
 	}
+	if oldCfg.Routing.Warmup != newCfg.Routing.Warmup {
+		changes = append(changes, fmt.Sprintf("routing.warmup: %t -> %t", oldCfg.Routing.Warmup, newCfg.Routing.Warmup))
+	}
 
 	// API keys (redacted) and counts
 	if len(oldCfg.APIKeys) != len(newCfg.APIKeys) {

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -540,6 +540,15 @@ func TestBuildConfigChangeDetails_CountBranches(t *testing.T) {
 	expectContains(t, changes, "vertex-api-key count: 0 -> 1")
 }
 
+func TestConfigDiffIncludesRoutingWarmupChange(t *testing.T) {
+	oldCfg := &config.Config{}
+	newCfg := &config.Config{}
+	newCfg.Routing.Warmup = true
+
+	changes := BuildConfigChangeDetails(oldCfg, newCfg)
+	expectContains(t, changes, "routing.warmup: false -> true")
+}
+
 func TestTrimStrings(t *testing.T) {
 	out := trimStrings([]string{" a ", "b", "  c"})
 	if len(out) != 3 || out[0] != "a" || out[1] != "b" || out[2] != "c" {

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -215,6 +215,21 @@ func (a *Auth) indexSeed() string {
 	return ""
 }
 
+// StableIndex computes the deterministic auth index without mutating Auth fields.
+func (a *Auth) StableIndex() string {
+	if a == nil {
+		return ""
+	}
+	if idx := strings.TrimSpace(a.Index); idx != "" {
+		return idx
+	}
+	seed := a.indexSeed()
+	if seed == "" {
+		return ""
+	}
+	return stableAuthIndex(seed)
+}
+
 // EnsureIndex returns a stable index derived from the auth file name or credential identity.
 func (a *Auth) EnsureIndex() string {
 	if a == nil {
@@ -224,12 +239,10 @@ func (a *Auth) EnsureIndex() string {
 		return a.Index
 	}
 
-	seed := a.indexSeed()
-	if seed == "" {
+	idx := a.StableIndex()
+	if idx == "" {
 		return ""
 	}
-
-	idx := stableAuthIndex(seed)
 	a.Index = idx
 	a.indexAssigned = true
 	return idx

--- a/sdk/cliproxy/auth/types_test.go
+++ b/sdk/cliproxy/auth/types_test.go
@@ -96,3 +96,28 @@ func TestEnsureIndexUsesCredentialIdentity(t *testing.T) {
 		t.Fatalf("duplicate config entries should be separated by source-derived seed, got %q", geminiIndex)
 	}
 }
+
+func TestStableIndexDoesNotAssignIndex(t *testing.T) {
+	t.Parallel()
+
+	auth := &Auth{
+		Provider: "gemini",
+		Attributes: map[string]string{
+			"api_key": "stable-key",
+			"source":  "config:gemini[stable-index-no-write]",
+		},
+	}
+
+	index := auth.StableIndex()
+	if index == "" {
+		t.Fatal("stable index should not be empty")
+	}
+	if auth.Index != "" {
+		t.Fatalf("StableIndex should not assign Index, got %q", auth.Index)
+	}
+
+	assigned := auth.EnsureIndex()
+	if assigned != index {
+		t.Fatalf("EnsureIndex = %q, want %q", assigned, index)
+	}
+}


### PR DESCRIPTION
## Summary
- add `routing.warmup` config support for fill-first routing
- publish async management `api-call` events after the original response is returned
- warm up other enabled Codex OAuth auths from qualifying Codex usage payloads

## What changed
- add a management-local async `api-call` event bus with multi-listener fan-out and panic recovery
- publish `ManagementAPICallEvent` after `/v0/management/api-call` success responses
- add `WarmupListener` for Codex-only quota parsing, source cooldown, success-only source tracking, target filtering, and model selection
- execute warmup through the existing Codex `/responses` path with pinned auth metadata
- expose `routing.warmup` in config, management config surface, TUI config view, and watcher diff output

## Flow

```mermaid
%% mermaid-hash: en-7b8f0d8d
flowchart TD
    A[Management client calls /v0/management/api-call] --> B[APICall forwards request upstream]
    B --> C[Read full upstream response body]
    C --> D[Return original management response to caller]
    D --> E[Publish ManagementAPICallEvent asynchronously]

    E --> F{routing.strategy == fill-first<br/>and routing.warmup == true}
    F -- No --> Z[Stop]
    F -- Yes --> G{Source auth exists<br/>and is Codex OAuth}
    G -- No --> Z
    G -- Yes --> H{Source auth already warmed successfully?}
    H -- Yes --> Z
    H -- No --> I{Response status is 2xx?}
    I -- No --> Z
    I -- Yes --> J{Body contains both 5h and 7d windows?}
    J -- No --> Z
    J -- Yes --> K{Both windows satisfy threshold?}
    K -- No --> Z
    K -- Yes --> L{Same authIndex seen within 20 seconds?}
    L -- Yes --> Z
    L -- No --> M[Collect other enabled Codex OAuth auths]

    M --> N[Exclude current auth]
    N --> O[Exclude Disabled, StatusDisabled, Unavailable, QuotaExceeded, or negative ModelState]
    O --> P{Any warmup targets left?}
    P -- No --> Z
    P -- Yes --> Q[Select model for each target auth]
    Q --> R[Prefer first model matching *mini*]
    R --> S[Otherwise use first available model]
    S --> T[Call default Codex /responses with pinned auth]
    T --> U[Request body: model plus input=hello]

    U --> V{At least one target warmup succeeded?}
    V -- No --> Z
    V -- Yes --> W[Mark source authIndex as warmed]
    W --> Z
```

## Test plan
- `GOPROXY=https://proxy.golang.org,direct go test ./...`
- `GOPROXY=https://proxy.golang.org,direct go build -o test-output ./cmd/server && rm test-output`

