### PR TITLE
Expands session affinity ID extraction sources

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 )
 
-const codexBuiltinImageModelID = "gpt-image-2"
+const (
+	codexBuiltinImageModelID = "gpt-image-2"
+	codexBuiltinSparkModelID = "gpt-5.3-codex-spark"
+)
 
 // staticModelsJSON mirrors the top-level structure of models.json.
 type staticModelsJSON struct {
@@ -82,7 +85,7 @@ func GetAntigravityModels() []*ModelInfo {
 // not depend on remote models.json updates. Built-ins replace any matching IDs
 // already present in the provided slice.
 func WithCodexBuiltins(models []*ModelInfo) []*ModelInfo {
-	return upsertModelInfos(models, codexBuiltinImageModelInfo())
+	return upsertModelInfos(models, codexBuiltinImageModelInfo(), codexBuiltinSparkModelInfo())
 }
 
 func codexBuiltinImageModelInfo() *ModelInfo {
@@ -94,6 +97,23 @@ func codexBuiltinImageModelInfo() *ModelInfo {
 		Type:        "openai",
 		DisplayName: "GPT Image 2",
 		Version:     codexBuiltinImageModelID,
+	}
+}
+
+func codexBuiltinSparkModelInfo() *ModelInfo {
+	return &ModelInfo{
+		ID:                  codexBuiltinSparkModelID,
+		Object:              "model",
+		Created:             1770912000,
+		OwnedBy:             "openai",
+		Type:                "openai",
+		DisplayName:         "GPT 5.3 Codex Spark",
+		Version:             "gpt-5.3",
+		Description:         "Ultra-fast coding model.",
+		ContextLength:       128000,
+		MaxCompletionTokens: 128000,
+		SupportedParameters: []string{"tools"},
+		Thinking:            &ThinkingSupport{Levels: []string{"low", "medium", "high", "xhigh"}},
 	}
 }
 

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -33,6 +33,31 @@ func TestCodexStaticModelsIncludeGPT55(t *testing.T) {
 	assertGPT55ModelInfo(t, "lookup", model)
 }
 
+func TestCodexStaticModelsIncludeSpark(t *testing.T) {
+	tierModels := map[string][]*ModelInfo{
+		"free": GetCodexFreeModels(),
+		"team": GetCodexTeamModels(),
+		"plus": GetCodexPlusModels(),
+		"pro":  GetCodexProModels(),
+	}
+
+	for tier, models := range tierModels {
+		t.Run(tier, func(t *testing.T) {
+			model := findModelInfo(models, "gpt-5.3-codex-spark")
+			if model == nil {
+				t.Fatalf("expected codex %s tier to include gpt-5.3-codex-spark", tier)
+			}
+			assertSparkModelInfo(t, tier, model)
+		})
+	}
+
+	model := LookupStaticModelInfo("gpt-5.3-codex-spark")
+	if model == nil {
+		t.Fatal("expected LookupStaticModelInfo to find gpt-5.3-codex-spark")
+	}
+	assertSparkModelInfo(t, "lookup", model)
+}
+
 func findModelInfo(models []*ModelInfo, id string) *ModelInfo {
 	for _, model := range models {
 		if model != nil && model.ID == id {
@@ -40,6 +65,57 @@ func findModelInfo(models []*ModelInfo, id string) *ModelInfo {
 		}
 	}
 	return nil
+}
+
+func assertSparkModelInfo(t *testing.T, source string, model *ModelInfo) {
+	t.Helper()
+
+	if model.ID != "gpt-5.3-codex-spark" {
+		t.Fatalf("%s id mismatch: got %q", source, model.ID)
+	}
+	if model.Object != "model" {
+		t.Fatalf("%s object mismatch: got %q", source, model.Object)
+	}
+	if model.Created != 1770912000 {
+		t.Fatalf("%s created timestamp mismatch: got %d", source, model.Created)
+	}
+	if model.OwnedBy != "openai" {
+		t.Fatalf("%s owned_by mismatch: got %q", source, model.OwnedBy)
+	}
+	if model.Type != "openai" {
+		t.Fatalf("%s type mismatch: got %q", source, model.Type)
+	}
+	if model.DisplayName != "GPT 5.3 Codex Spark" {
+		t.Fatalf("%s display name mismatch: got %q", source, model.DisplayName)
+	}
+	if model.Version != "gpt-5.3" {
+		t.Fatalf("%s version mismatch: got %q", source, model.Version)
+	}
+	if model.Description != "Ultra-fast coding model." {
+		t.Fatalf("%s description mismatch: got %q", source, model.Description)
+	}
+	if model.ContextLength != 128000 {
+		t.Fatalf("%s context length mismatch: got %d", source, model.ContextLength)
+	}
+	if model.MaxCompletionTokens != 128000 {
+		t.Fatalf("%s max completion tokens mismatch: got %d", source, model.MaxCompletionTokens)
+	}
+	if len(model.SupportedParameters) != 1 || model.SupportedParameters[0] != "tools" {
+		t.Fatalf("%s supported parameters mismatch: got %v", source, model.SupportedParameters)
+	}
+	if model.Thinking == nil {
+		t.Fatalf("%s missing thinking support", source)
+	}
+
+	want := []string{"low", "medium", "high", "xhigh"}
+	if len(model.Thinking.Levels) != len(want) {
+		t.Fatalf("%s thinking level count mismatch: got %d, want %d", source, len(model.Thinking.Levels), len(want))
+	}
+	for i, level := range want {
+		if model.Thinking.Levels[i] != level {
+			t.Fatalf("%s thinking level %d mismatch: got %q, want %q", source, i, model.Thinking.Levels[i], level)
+		}
+	}
 }
 
 func assertGPT55ModelInfo(t *testing.T, source string, model *ModelInfo) {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1619,6 +1619,30 @@ func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
 	return checkSystemInstructionsWithSigningMode(payload, strictMode, false, false, "2.1.63", "", "")
 }
 
+
+// systemContainsClaudeAgentMarker reports whether any text block in the
+// request's system field contains the "You are a Claude agent" marker used
+// by the Claude Agent SDK. Callers that already cloak via the SDK should not
+// be rewritten again.
+func systemContainsClaudeAgentMarker(system gjson.Result) bool {
+	const marker = "You are a Claude agent"
+	if system.IsArray() {
+		found := false
+		system.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").String() == "text" &&
+				strings.Contains(part.Get("text").String(), marker) {
+				found = true
+				return false
+			}
+			return true
+		})
+		return found
+	}
+	if system.Type == gjson.String {
+		return strings.Contains(system.String(), marker)
+	}
+	return false
+}
 // checkSystemInstructionsWithSigningMode injects Claude Code-style system blocks:
 //
 //	system[0]: billing header (no cache_control)
@@ -1648,6 +1672,13 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 	// Skip if already injected
 	firstText := gjson.GetBytes(payload, "system.0.text").String()
 	if strings.HasPrefix(firstText, "x-anthropic-billing-header:") {
+		return payload
+	}
+
+	// Skip if the caller has already cloaked as Claude Agent SDK
+	// (system prompt contains "You are a Claude agent"). This avoids
+	// double-rewriting and discarding the caller's real system prompt.
+	if systemContainsClaudeAgentMarker(system) {
 		return payload
 	}
 
@@ -1690,9 +1721,6 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 
 		if len(userSystemParts) > 0 {
 			combined := strings.Join(userSystemParts, "\n\n")
-			if oauthMode {
-				combined = sanitizeForwardedSystemPrompt(combined)
-			}
 			if strings.TrimSpace(combined) != "" {
 				payload = prependToFirstUserMessage(payload, combined)
 			}
@@ -1820,6 +1848,12 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 
 	// Determine if cloaking should be applied
 	if !helps.ShouldCloak(cloakMode, clientUserAgent) {
+		return payload
+	}
+	// Bypass cloaking entirely if the caller has already cloaked as Claude
+	// Agent SDK. This avoids double-rewriting the system prompt and dropping
+	// the caller's instructions when both layers try to inject markers.
+	if systemContainsClaudeAgentMarker(gjson.GetBytes(payload, "system")) {
 		return payload
 	}
 

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -953,6 +953,45 @@ func codexImageGenerationToolModel(body []byte) string {
 	return codexDefaultImageToolModel
 }
 
+func codexModelSupportsImageGeneration(model string) bool {
+	return strings.HasPrefix(strings.TrimSpace(model), "gpt-5.4")
+}
+
+func removeImageGenerationTool(body []byte) []byte {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return body
+	}
+
+	toolArray := tools.Array()
+	kept := make([]gjson.Result, 0, len(toolArray))
+	for _, tool := range toolArray {
+		if tool.Get("type").String() == "image_generation" {
+			continue
+		}
+		kept = append(kept, tool)
+	}
+	if len(kept) == len(toolArray) {
+		return body
+	}
+	if len(kept) == 0 {
+		body, _ = sjson.DeleteBytes(body, "tools")
+		return body
+	}
+
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	for i, tool := range kept {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(tool.Raw)
+	}
+	buf.WriteByte(']')
+	body, _ = sjson.SetRawBytes(body, "tools", buf.Bytes())
+	return body
+}
+
 func isCodexModelCapacityError(errorBody []byte) bool {
 	if len(errorBody) == 0 {
 		return false

--- a/internal/runtime/executor/codex_executor_imagegen_test.go
+++ b/internal/runtime/executor/codex_executor_imagegen_test.go
@@ -116,3 +116,19 @@ func TestEnsureImageGenerationTool_FreeCodexAuthDoesNotInjectTool(t *testing.T) 
 		t.Fatalf("expected no tools for free codex auth, got %s", gjson.GetBytes(result, "tools").Raw)
 	}
 }
+
+func TestCodexImageGenerationToolModel_UsesConfiguredModel(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","name":"f1"},{"type":"image_generation","model":"gpt-image-3","output_format":"webp"}]}`)
+
+	if got := codexImageGenerationToolModel(body); got != "gpt-image-3" {
+		t.Fatalf("expected configured image model, got %s", got)
+	}
+}
+
+func TestCodexImageGenerationToolModel_DefaultsWhenMissing(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"image_generation","output_format":"png"}]}`)
+
+	if got := codexImageGenerationToolModel(body); got != codexDefaultImageToolModel {
+		t.Fatalf("expected default image model %s, got %s", codexDefaultImageToolModel, got)
+	}
+}

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -26,12 +26,14 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 	modelRegistry.RegisterClient("test-request-details-claude", "claude", []*registry.ModelInfo{
 		{ID: "claude-sonnet-4-5", Created: now + 5},
 	})
+	modelRegistry.RegisterClient("test-request-details-codex", "codex", registry.GetCodexFreeModels())
 
 	// Ensure cleanup of all test registrations.
 	clientIDs := []string{
 		"test-request-details-gemini",
 		"test-request-details-openai",
 		"test-request-details-claude",
+		"test-request-details-codex",
 	}
 	for _, clientID := range clientIDs {
 		id := clientID
@@ -59,7 +61,7 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 		{
 			name:          "level suffix preserved",
 			inputModel:    "gpt-5.2(high)",
-			wantProviders: []string{"openai"},
+			wantProviders: []string{"codex", "openai"},
 			wantModel:     "gpt-5.2(high)",
 			wantErr:       false,
 		},
@@ -96,6 +98,13 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 			inputModel:    "claude-sonnet-4-5(auto)",
 			wantProviders: []string{"claude"},
 			wantModel:     "claude-sonnet-4-5(auto)",
+			wantErr:       false,
+		},
+		{
+			name:          "codex spark routes through codex",
+			inputModel:    "gpt-5.3-codex-spark",
+			wantProviders: []string{"codex"},
+			wantModel:     "gpt-5.3-codex-spark",
 			wantErr:       false,
 		},
 	}

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strings"
 	"sync"
@@ -466,7 +465,14 @@ func TestExecuteStreamWithAuthManager_DoesNotRetryAfterFirstByte(t *testing.T) {
 	}
 }
 
-func TestExecuteStreamWithAuthManager_EnrichesBootstrapRetryAuthUnavailableError(t *testing.T) {
+// TestExecuteStreamWithAuthManager_BootstrapRetrySurfacesModelCooldown verifies that
+// when the only available auth is exhausted by an upstream 401 during the
+// bootstrap retry path, the picker surfaces a `model_cooldown` error (HTTP 429
+// with retry-time hint) rather than an opaque `auth_unavailable` (HTTP 503).
+// All non-quota cooldowns (401/403/404/503) are now treated uniformly as
+// "blocked with future retry" by the selector, so the retry hint is always
+// available regardless of the underlying status code.
+func TestExecuteStreamWithAuthManager_BootstrapRetrySurfacesModelCooldown(t *testing.T) {
 	executor := &failOnceStreamExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
@@ -513,22 +519,18 @@ func TestExecuteStreamWithAuthManager_EnrichesBootstrapRetryAuthUnavailableError
 	if gotErr == nil {
 		t.Fatalf("expected terminal error")
 	}
-	if gotErr.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want %d", gotErr.StatusCode, http.StatusServiceUnavailable)
+	if gotErr.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d (model_cooldown)", gotErr.StatusCode, http.StatusTooManyRequests)
 	}
-
-	var authErr *coreauth.Error
-	if !errors.As(gotErr.Error, &authErr) || authErr == nil {
-		t.Fatalf("expected coreauth.Error, got %T", gotErr.Error)
+	body := gotErr.Error.Error()
+	if !strings.Contains(body, "\"code\":\"model_cooldown\"") {
+		t.Fatalf("body missing model_cooldown code: %q", body)
 	}
-	if authErr.Code != "auth_unavailable" {
-		t.Fatalf("code = %q, want %q", authErr.Code, "auth_unavailable")
+	if !strings.Contains(body, "test-model") {
+		t.Fatalf("body missing model context: %q", body)
 	}
-	if !strings.Contains(authErr.Message, "providers=codex") {
-		t.Fatalf("message missing provider context: %q", authErr.Message)
-	}
-	if !strings.Contains(authErr.Message, "model=test-model") {
-		t.Fatalf("message missing model context: %q", authErr.Message)
+	if !strings.Contains(body, "codex") {
+		t.Fatalf("body missing provider context: %q", body)
 	}
 
 	if executor.Calls() != 1 {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -74,6 +74,17 @@ const (
 	refreshIneffectiveBackoff = 30 * time.Second
 	quotaBackoffBase          = time.Second
 	quotaBackoffMax           = 30 * time.Minute
+	// transientBackoffBase is the initial cooldown applied for transient
+	// upstream errors (408/500/502/503/504). The ladder doubles up to
+	// transientBackoffMax. Far shorter than the quota ladder because these
+	// errors are typically transient flakes, not exhausted resources.
+	transientBackoffBase = 5 * time.Second
+	transientBackoffMax  = 5 * time.Minute
+	// allBlockedProbeWindow allows the picker to surface one blocked auth
+	// when no candidates are ready. Without this, a brief storm of upstream
+	// failures locks every auth for the configured cooldown duration with
+	// no probe budget against the same model+auth.
+	allBlockedProbeWindow = 10 * time.Second
 )
 
 var quotaCooldownDisabled atomic.Bool
@@ -118,6 +129,13 @@ type Selector interface {
 type StoppableSelector interface {
 	Selector
 	Stop()
+}
+
+// AuthInvalidator is implemented by selectors that keep per-auth session
+// bindings. It lets the manager drop affinity for an auth that failed this
+// request without marking the auth itself unhealthy.
+type AuthInvalidator interface {
+	InvalidateAuth(authID string)
 }
 
 // Hook captures lifecycle callbacks for observing auth changes.
@@ -353,6 +371,18 @@ func (m *Manager) SetSelector(selector Selector) {
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()
+	}
+}
+
+func (m *Manager) invalidateSessionAffinity(authID string) {
+	if m == nil || strings.TrimSpace(authID) == "" {
+		return
+	}
+	m.mu.RLock()
+	selector := m.selector
+	m.mu.RUnlock()
+	if invalidator, ok := selector.(AuthInvalidator); ok && invalidator != nil {
+		invalidator.InvalidateAuth(authID)
 	}
 }
 
@@ -2145,6 +2175,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	suspendReason := ""
 	clearModelQuota := false
 	setModelQuota := false
+	clearAffinityOnly := !result.Success && isClaudeOutOfExtraUsageResultError(result.Error)
 	var authSnapshot *Auth
 
 	m.mu.Lock()
@@ -2173,7 +2204,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			} else {
 				clearAuthStateOnSuccess(auth, now)
 			}
-		} else {
+		} else if !clearAffinityOnly {
 			if result.Model != "" {
 				if !isRequestScopedNotFoundResultError(result.Error) {
 					disableCooling := quotaCooldownDisabledForAuth(auth)
@@ -2250,17 +2281,33 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								setModelQuota = true
 							}
 						case 408, 500, 502, 503, 504:
-							if disableCooling {
-								state.NextRetryAfter = time.Time{}
-							} else {
-								next := now.Add(1 * time.Minute)
-								state.NextRetryAfter = next
+							var next time.Time
+							backoffLevel := state.TransientBackoffLevel
+							if !disableCooling {
+								if result.RetryAfter != nil && *result.RetryAfter > 0 {
+									next = now.Add(*result.RetryAfter)
+								} else {
+									cooldown, nextLevel := nextTransientCooldown(backoffLevel, disableCooling)
+									if cooldown > 0 {
+										next = now.Add(cooldown)
+									}
+									backoffLevel = nextLevel
+								}
 							}
+							state.NextRetryAfter = next
+							state.TransientBackoffLevel = backoffLevel
 						default:
 							state.NextRetryAfter = time.Time{}
 						}
 					}
 
+					if !state.NextRetryAfter.IsZero() && state.NextRetryAfter.After(now) {
+						if state.BlockedSince.IsZero() {
+							state.BlockedSince = now
+						}
+					} else {
+						state.BlockedSince = time.Time{}
+					}
 					auth.Status = StatusError
 					auth.UpdatedAt = now
 					updateAggregatedAvailability(auth, now)
@@ -2270,8 +2317,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 		}
 
-		_ = m.persist(ctx, auth)
-		authSnapshot = auth.Clone()
+		if !clearAffinityOnly {
+			_ = m.persist(ctx, auth)
+			authSnapshot = auth.Clone()
+		}
 	}
 	m.mu.Unlock()
 	if m.scheduler != nil && authSnapshot != nil {
@@ -2289,7 +2338,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	} else if shouldSuspendModel {
 		registry.GetGlobalRegistry().SuspendClientModel(result.AuthID, result.Model, suspendReason)
 	}
-
+	if clearAffinityOnly {
+		m.invalidateSessionAffinity(result.AuthID)
+		return
+	}
 	m.hook.OnResult(ctx, result)
 }
 
@@ -2318,6 +2370,8 @@ func resetModelState(state *ModelState, now time.Time) {
 	state.NextRetryAfter = time.Time{}
 	state.LastError = nil
 	state.Quota = QuotaState{}
+	state.BlockedSince = time.Time{}
+	state.TransientBackoffLevel = 0
 	state.UpdatedAt = now
 }
 
@@ -2332,6 +2386,9 @@ func modelStateIsClean(state *ModelState) bool {
 		return false
 	}
 	if state.Quota.Exceeded || state.Quota.Reason != "" || !state.Quota.NextRecoverAt.IsZero() || state.Quota.BackoffLevel != 0 {
+		return false
+	}
+	if !state.BlockedSince.IsZero() || state.TransientBackoffLevel != 0 {
 		return false
 	}
 	return true
@@ -2610,6 +2667,29 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 	return isRequestScopedNotFoundMessage(err.Message)
 }
 
+func isClaudeOutOfExtraUsageMessage(message string) bool {
+	lower := strings.ToLower(strings.TrimSpace(message))
+	if lower == "" {
+		return false
+	}
+	return strings.Contains(lower, "out of extra usage") ||
+		strings.Contains(lower, "claude.ai/settings/usage")
+}
+
+func isClaudeOutOfExtraUsageError(err error) bool {
+	if err == nil || statusCodeFromError(err) != http.StatusBadRequest {
+		return false
+	}
+	return isClaudeOutOfExtraUsageMessage(err.Error())
+}
+
+func isClaudeOutOfExtraUsageResultError(err *Error) bool {
+	if err == nil || statusCodeFromResult(err) != http.StatusBadRequest {
+		return false
+	}
+	return isClaudeOutOfExtraUsageMessage(err.Message)
+}
+
 // isRequestInvalidError returns true if the error represents a client request
 // error that should not be retried. Specifically, it treats 400 responses with
 // "invalid_request_error", request-scoped 404 item misses caused by `store=false`,
@@ -2618,6 +2698,9 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 // routing can fall through to another auth or upstream.
 func isRequestInvalidError(err error) bool {
 	if err == nil {
+		return false
+	}
+	if isClaudeOutOfExtraUsageError(err) {
 		return false
 	}
 	if isModelSupportError(err) {
@@ -2729,6 +2812,30 @@ func nextQuotaCooldown(prevLevel int, disableCooling bool) (time.Duration, int) 
 	}
 	if cooldown >= quotaBackoffMax {
 		return quotaBackoffMax, prevLevel
+	}
+	return cooldown, prevLevel + 1
+}
+
+// nextTransientCooldown returns the next cooldown duration and updated
+// backoff level for repeated transient upstream errors (408/500/502/503/504).
+// The level is bounded by overflow protection (1<<31) which we never approach
+// in practice given the cap, but matches the quota helper's contract.
+func nextTransientCooldown(prevLevel int, disableCooling bool) (time.Duration, int) {
+	if prevLevel < 0 {
+		prevLevel = 0
+	}
+	if disableCooling {
+		return 0, prevLevel
+	}
+	if prevLevel > 30 {
+		prevLevel = 30
+	}
+	cooldown := transientBackoffBase * time.Duration(1<<prevLevel)
+	if cooldown < transientBackoffBase {
+		cooldown = transientBackoffBase
+	}
+	if cooldown >= transientBackoffMax {
+		return transientBackoffMax, prevLevel
 	}
 	return cooldown, prevLevel + 1
 }

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -851,3 +851,57 @@ func TestManager_RequestScopedNotFoundStopsRetryWithoutSuspendingAuth(t *testing
 		t.Fatalf("expected request-scoped 404 to avoid bad auth model cooldown state, got %#v", state)
 	}
 }
+
+type extraUsageInvalidatingSelector struct {
+	invalidated []string
+}
+
+func (s *extraUsageInvalidatingSelector) Pick(_ context.Context, _ string, _ string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	if len(auths) == 0 {
+		return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+	}
+	return auths[0], nil
+}
+
+func (s *extraUsageInvalidatingSelector) InvalidateAuth(authID string) {
+	s.invalidated = append(s.invalidated, authID)
+}
+
+func TestMarkResult_OutOfExtraUsageClearsAffinityWithoutPoisoningAuth(t *testing.T) {
+	selector := &extraUsageInvalidatingSelector{}
+	m := NewManager(nil, selector, nil)
+	auth := &Auth{ID: "claude-auth", Provider: "claude", Status: StatusActive}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "claude-opus-4-7"
+	msg := `{"type":"error","error":{"type":"invalid_request_error","message":"You're out of extra usage. Add more at claude.ai/settings/usage and keep going."}}`
+	if isRequestInvalidError(&Error{HTTPStatus: http.StatusBadRequest, Message: msg}) {
+		t.Fatal("expected out-of-extra-usage 400 to remain credential-retryable")
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusBadRequest, Message: msg},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to remain registered")
+	}
+	if updated.Unavailable || updated.Status == StatusError {
+		t.Fatalf("expected auth to stay healthy, unavailable=%v status=%s", updated.Unavailable, updated.Status)
+	}
+	if updated.LastError != nil || updated.StatusMessage != "" {
+		t.Fatalf("expected no persisted auth error, last=%v status_message=%q", updated.LastError, updated.StatusMessage)
+	}
+	if state := updated.ModelStates[model]; state != nil {
+		t.Fatalf("expected no persisted model error, got %#v", state)
+	}
+	if len(selector.invalidated) != 1 || selector.invalidated[0] != auth.ID {
+		t.Fatalf("expected affinity invalidation for %q, got %v", auth.ID, selector.invalidated)
+	}
+}

--- a/sdk/cliproxy/auth/cooldown_relax_test.go
+++ b/sdk/cliproxy/auth/cooldown_relax_test.go
@@ -1,0 +1,327 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+)
+
+// TestNextTransientCooldown verifies the 5xx exponential ladder starts short
+// and caps at the configured maximum without overflow.
+func TestNextTransientCooldown(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		level int
+		want  time.Duration
+	}{
+		{0, 5 * time.Second},
+		{1, 10 * time.Second},
+		{2, 20 * time.Second},
+		{3, 40 * time.Second},
+		{4, 80 * time.Second},
+		{5, 160 * time.Second},
+		{6, transientBackoffMax}, // capped
+		{50, transientBackoffMax},
+	}
+	for _, tc := range cases {
+		got, _ := nextTransientCooldown(tc.level, false)
+		if got != tc.want {
+			t.Fatalf("nextTransientCooldown(%d) = %v, want %v", tc.level, got, tc.want)
+		}
+	}
+
+	if d, _ := nextTransientCooldown(2, true); d != 0 {
+		t.Fatalf("disableCooling should yield 0 cooldown, got %v", d)
+	}
+}
+
+// TestMarkResult_5xxUsesExpBackoff verifies repeated 503s grow the per-model
+// transient backoff level rather than parking on a fixed 1-minute cooldown.
+func TestMarkResult_5xxUsesExpBackoff(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "tx-503", Provider: "codex"}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	model := "gpt-5.3-codex-spark"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	mark := func() *ModelState {
+		t.Helper()
+		m.MarkResult(context.Background(), Result{
+			AuthID:   auth.ID,
+			Provider: "codex",
+			Model:    model,
+			Success:  false,
+			Error:    &Error{HTTPStatus: http.StatusServiceUnavailable, Message: "upstream 503"},
+		})
+		updated, ok := m.GetByID(auth.ID)
+		if !ok || updated == nil {
+			t.Fatalf("auth missing after MarkResult")
+		}
+		st := updated.ModelStates[model]
+		if st == nil {
+			t.Fatalf("model state missing")
+		}
+		return st
+	}
+
+	want := []time.Duration{
+		5 * time.Second,
+		10 * time.Second,
+		20 * time.Second,
+	}
+	wantLevels := []int{1, 2, 3}
+	for i, expected := range want {
+		st := mark()
+		got := time.Until(st.NextRetryAfter)
+		// Allow a small tolerance because NextRetryAfter is computed from now.Add(...)
+		// inside MarkResult; the assertion runs slightly after that point.
+		if got > expected || got < expected-2*time.Second {
+			t.Fatalf("attempt %d: NextRetryAfter delta = %v, want ~%v", i, got, expected)
+		}
+		if st.TransientBackoffLevel != wantLevels[i] {
+			t.Fatalf("attempt %d: TransientBackoffLevel = %d, want %d", i, st.TransientBackoffLevel, wantLevels[i])
+		}
+	}
+
+	// A success clears both the quota state and the transient backoff level.
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "codex",
+		Model:    model,
+		Success:  true,
+	})
+	updated, _ := m.GetByID(auth.ID)
+	if st := updated.ModelStates[model]; st != nil && (st.TransientBackoffLevel != 0 || !st.BlockedSince.IsZero()) {
+		t.Fatalf("success should reset transient backoff and blocked-since, got level=%d blockedSince=%v", st.TransientBackoffLevel, st.BlockedSince)
+	}
+}
+
+// TestMarkResult_BlockedSinceStableAcrossRetries verifies that BlockedSince is
+// set on first transition into a blocked state and *not* bumped on subsequent
+// failures — so the 10s probe window measures real elapsed unavailability.
+func TestMarkResult_BlockedSinceStableAcrossRetries(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "blocked-since", Provider: "codex"}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	model := "m"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: 503, Message: "x"},
+	})
+	updated, _ := m.GetByID(auth.ID)
+	first := updated.ModelStates[model].BlockedSince
+	if first.IsZero() {
+		t.Fatalf("BlockedSince must be set on first failure")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: 503, Message: "x"},
+	})
+	updated, _ = m.GetByID(auth.ID)
+	second := updated.ModelStates[model].BlockedSince
+	if !second.Equal(first) {
+		t.Fatalf("BlockedSince must remain stable across failures, was %v then %v", first, second)
+	}
+}
+
+// TestGetAvailableAuths_MixedReasonsReturnsModelCooldown verifies the legacy
+// selector path returns a cooldown-style error (with retry hint) when all
+// candidates are blocked, regardless of the underlying reason mix.
+func TestGetAvailableAuths_MixedReasonsReturnsModelCooldown(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	model := "m"
+	auths := []*Auth{
+		{
+			ID: "quota", ModelStates: map[string]*ModelState{model: {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: now.Add(2 * time.Minute),
+				BlockedSince:   now.Add(-1 * time.Second),
+				Quota:          QuotaState{Exceeded: true, NextRecoverAt: now.Add(2 * time.Minute)},
+			}},
+		},
+		{
+			ID: "transient", ModelStates: map[string]*ModelState{model: {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: now.Add(30 * time.Second),
+				BlockedSince:   now.Add(-1 * time.Second),
+			}},
+		},
+	}
+
+	_, err := getAvailableAuths(auths, "codex", model, now)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var cooldown *modelCooldownError
+	if !errors.As(err, &cooldown) {
+		t.Fatalf("expected *modelCooldownError, got %T (%v)", err, err)
+	}
+	// earliest is the 30s transient cooldown.
+	if cooldown.resetIn > 35*time.Second || cooldown.resetIn < 25*time.Second {
+		t.Fatalf("resetIn = %v, want ~30s", cooldown.resetIn)
+	}
+	if !strings.Contains(err.Error(), "cooling down") {
+		t.Fatalf("error message should describe cooldown, got %q", err.Error())
+	}
+}
+
+// TestGetAvailableAuths_AllBlockedProbeAfterWindow verifies that once every
+// candidate has been blocked at least allBlockedProbeWindow, a probe is
+// returned instead of a cooldown error so the next request can retry.
+func TestGetAvailableAuths_AllBlockedProbeAfterWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	model := "m"
+	old := now.Add(-2 * allBlockedProbeWindow)
+	auths := []*Auth{
+		{ID: "a", ModelStates: map[string]*ModelState{model: {
+			Status: StatusError, Unavailable: true,
+			NextRetryAfter: now.Add(time.Minute),
+			BlockedSince:   old,
+		}}},
+		{ID: "b", ModelStates: map[string]*ModelState{model: {
+			Status: StatusError, Unavailable: true,
+			NextRetryAfter: now.Add(time.Minute),
+			BlockedSince:   old.Add(time.Second), // slightly newer
+		}}},
+	}
+
+	probes, err := getAvailableAuths(auths, "codex", model, now)
+	if err != nil {
+		t.Fatalf("expected probe candidates, got error: %v", err)
+	}
+	if len(probes) == 0 {
+		t.Fatalf("expected at least one probe candidate")
+	}
+	if probes[0].ID != "a" {
+		t.Fatalf("probe order should put oldest blocked first, got %q", probes[0].ID)
+	}
+}
+
+// TestGetAvailableAuths_AllBlockedNoProbeBeforeWindow verifies that if every
+// candidate just got blocked, the picker still surfaces a cooldown error
+// rather than probing prematurely.
+func TestGetAvailableAuths_AllBlockedNoProbeBeforeWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	model := "m"
+	auths := []*Auth{
+		{ID: "a", ModelStates: map[string]*ModelState{model: {
+			Status: StatusError, Unavailable: true,
+			NextRetryAfter: now.Add(30 * time.Second),
+			BlockedSince:   now.Add(-1 * time.Second),
+		}}},
+	}
+
+	_, err := getAvailableAuths(auths, "codex", model, now)
+	if err == nil {
+		t.Fatalf("expected error before probe window elapses")
+	}
+	var cooldown *modelCooldownError
+	if !errors.As(err, &cooldown) {
+		t.Fatalf("expected cooldown error, got %T (%v)", err, err)
+	}
+}
+
+// TestModelSchedulerProbeAndAvailability ensures the scheduler's broadened
+// availabilitySummaryLocked counts blocked entries and pickProbeLocked picks
+// the longest-blocked entry.
+func TestModelSchedulerProbeAndAvailability(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	old := now.Add(-2 * allBlockedProbeWindow)
+	mid := now.Add(-allBlockedProbeWindow - time.Second)
+
+	authA := &Auth{ID: "a", Provider: "codex", ModelStates: map[string]*ModelState{"m": {
+		Status: StatusError, Unavailable: true,
+		NextRetryAfter: now.Add(time.Minute),
+		BlockedSince:   old,
+	}}}
+	authB := &Auth{ID: "b", Provider: "codex", ModelStates: map[string]*ModelState{"m": {
+		Status: StatusError, Unavailable: true,
+		NextRetryAfter: now.Add(time.Minute),
+		BlockedSince:   mid,
+	}}}
+
+	shard := &modelScheduler{
+		modelKey:        "m",
+		entries:         make(map[string]*scheduledAuth),
+		readyByPriority: make(map[int]*readyBucket),
+	}
+	shard.upsertEntryLocked(buildScheduledAuthMeta(authA), now)
+	shard.upsertEntryLocked(buildScheduledAuthMeta(authB), now)
+
+	total, cooldown, earliest := shard.availabilitySummaryLocked(nil)
+	if total != 2 || cooldown != 2 {
+		t.Fatalf("availabilitySummary total=%d cooldown=%d, want 2/2", total, cooldown)
+	}
+	if earliest.IsZero() {
+		t.Fatalf("expected non-zero earliest retry time")
+	}
+
+	picked := shard.pickProbeLocked(nil, now)
+	if picked == nil {
+		t.Fatalf("expected probe pick when entries are aged past the window")
+	}
+	if picked.ID != "a" {
+		t.Fatalf("probe should pick longest-blocked auth, got %q", picked.ID)
+	}
+
+	// A predicate that excludes "a" must skip it and return the next-oldest.
+	picked = shard.pickProbeLocked(func(e *scheduledAuth) bool {
+		return e != nil && e.auth != nil && e.auth.ID != "a"
+	}, now)
+	if picked == nil || picked.ID != "b" {
+		t.Fatalf("predicate-excluding-a should yield b, got %v", picked)
+	}
+
+	// If nothing is aged past the window, no probe is offered.
+	freshAuth := &Auth{ID: "c", Provider: "codex", ModelStates: map[string]*ModelState{"m": {
+		Status: StatusError, Unavailable: true,
+		NextRetryAfter: now.Add(time.Minute),
+		BlockedSince:   now.Add(-1 * time.Second),
+	}}}
+	freshShard := &modelScheduler{
+		modelKey:        "m",
+		entries:         make(map[string]*scheduledAuth),
+		readyByPriority: make(map[int]*readyBucket),
+	}
+	freshShard.upsertEntryLocked(buildScheduledAuthMeta(freshAuth), now)
+	if got := freshShard.pickProbeLocked(nil, now); got != nil {
+		t.Fatalf("expected no probe before window, got %q", got.ID)
+	}
+}

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -71,6 +71,10 @@ type scheduledAuth struct {
 	auth        *Auth
 	state       scheduledState
 	nextRetryAt time.Time
+	// blockedAt mirrors ModelState.BlockedSince so the picker can decide
+	// whether enough time has elapsed to probe a blocked auth when no
+	// ready candidates remain.
+	blockedAt time.Time
 }
 
 // readyBucket keeps the ready views for one priority level.
@@ -273,6 +277,9 @@ func (s *authScheduler) pickSingle(ctx context.Context, provider, model string, 
 	if picked := shard.pickReadyLocked(preferWebsocket, s.strategy, predicate); picked != nil {
 		return picked, nil
 	}
+	if picked := shard.pickProbeLocked(predicate, time.Now()); picked != nil {
+		return picked, nil
+	}
 	return nil, shard.unavailableErrorLocked(provider, model, predicate)
 }
 
@@ -326,6 +333,9 @@ func (s *authScheduler) pickMixed(ctx context.Context, providers []string, model
 		if picked := shard.pickReadyLocked(false, s.strategy, predicate); picked != nil {
 			return picked, providerKey, nil
 		}
+		if picked := shard.pickProbeLocked(predicate, time.Now()); picked != nil {
+			return picked, providerKey, nil
+		}
 		return nil, "", shard.unavailableErrorLocked("mixed", model, predicate)
 	}
 
@@ -354,6 +364,9 @@ func (s *authScheduler) pickMixed(ctx context.Context, providers []string, model
 		}
 	}
 	if !hasCandidate {
+		if probeAuth, probeProvider := s.mixedProbeLocked(normalized, modelKey, predicate, now); probeAuth != nil {
+			return probeAuth, probeProvider, nil
+		}
 		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
 	}
 
@@ -367,6 +380,9 @@ func (s *authScheduler) pickMixed(ctx context.Context, providers []string, model
 			if picked != nil {
 				return picked, providerKey, nil
 			}
+		}
+		if probeAuth, probeProvider := s.mixedProbeLocked(normalized, modelKey, predicate, time.Now()); probeAuth != nil {
+			return probeAuth, probeProvider, nil
 		}
 		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
 	}
@@ -385,6 +401,9 @@ func (s *authScheduler) pickMixed(ctx context.Context, providers []string, model
 		segmentEnds[providerIndex] = totalWeight
 	}
 	if totalWeight == 0 {
+		if probeAuth, probeProvider := s.mixedProbeLocked(normalized, modelKey, predicate, time.Now()); probeAuth != nil {
+			return probeAuth, probeProvider, nil
+		}
 		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
 	}
 
@@ -400,6 +419,9 @@ func (s *authScheduler) pickMixed(ctx context.Context, providers []string, model
 		}
 	}
 	if startProviderIndex < 0 {
+		if probeAuth, probeProvider := s.mixedProbeLocked(normalized, modelKey, predicate, time.Now()); probeAuth != nil {
+			return probeAuth, probeProvider, nil
+		}
 		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
 	}
 
@@ -424,7 +446,52 @@ func (s *authScheduler) pickMixed(ctx context.Context, providers []string, model
 		s.mixedCursors[cursorKey] = slot + 1
 		return picked, providerKey, nil
 	}
+	if probeAuth, probeProvider := s.mixedProbeLocked(normalized, modelKey, predicate, time.Now()); probeAuth != nil {
+		return probeAuth, probeProvider, nil
+	}
 	return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
+}
+
+// mixedProbeLocked finds the longest-blocked entry across the given providers'
+// shards for modelKey that has spent at least allBlockedProbeWindow in a
+// non-ready state. Returns nil when nothing qualifies.
+func (s *authScheduler) mixedProbeLocked(providers []string, modelKey string, predicate func(*scheduledAuth) bool, now time.Time) (*Auth, string) {
+	threshold := now.Add(-allBlockedProbeWindow)
+	var pickedAuth *Auth
+	var pickedProvider string
+	var pickedAt time.Time
+	for _, providerKey := range providers {
+		providerState := s.providers[providerKey]
+		if providerState == nil {
+			continue
+		}
+		shard := providerState.modelShards[modelKey]
+		if shard == nil {
+			continue
+		}
+		for _, entry := range shard.entries {
+			if entry == nil || entry.auth == nil {
+				continue
+			}
+			switch entry.state {
+			case scheduledStateCooldown, scheduledStateBlocked:
+			default:
+				continue
+			}
+			if entry.blockedAt.IsZero() || entry.blockedAt.After(threshold) {
+				continue
+			}
+			if predicate != nil && !predicate(entry) {
+				continue
+			}
+			if pickedAuth == nil || entry.blockedAt.Before(pickedAt) {
+				pickedAuth = entry.auth.Clone()
+				pickedProvider = providerKey
+				pickedAt = entry.blockedAt
+			}
+		}
+	}
+	return pickedAuth, pickedProvider
 }
 
 // mixedUnavailableErrorLocked synthesizes the mixed-provider cooldown or unavailable error.
@@ -572,6 +639,26 @@ func buildScheduledAuthMeta(auth *Auth) *scheduledAuthMeta {
 	}
 }
 
+// modelBlockedSince returns the BlockedSince timestamp recorded on the auth's
+// per-model state for modelKey, or fallback when none is set. The fallback
+// represents "we noticed this auth is blocked just now"; it ensures the
+// probe timer is well-defined even when state was loaded from disk without
+// the BlockedSince field populated.
+func modelBlockedSince(auth *Auth, modelKey string, fallback time.Time) time.Time {
+	if auth == nil {
+		return fallback
+	}
+	if state, ok := auth.ModelStates[modelKey]; ok && state != nil && !state.BlockedSince.IsZero() {
+		return state.BlockedSince
+	}
+	if canonical := canonicalModelKey(modelKey); canonical != modelKey {
+		if state, ok := auth.ModelStates[canonical]; ok && state != nil && !state.BlockedSince.IsZero() {
+			return state.BlockedSince
+		}
+	}
+	return fallback
+}
+
 // supportedModelSetForAuth snapshots the registry models currently registered for an auth.
 func supportedModelSetForAuth(authID string) map[string]struct{} {
 	authID = strings.TrimSpace(authID)
@@ -677,6 +764,7 @@ func (m *modelScheduler) upsertEntryLocked(meta *scheduledAuthMeta, now time.Tim
 	}
 	previousState := entry.state
 	previousNextRetryAt := entry.nextRetryAt
+	previousBlockedAt := entry.blockedAt
 	previousPriority := 0
 	previousParent := ""
 	previousWebsocketEnabled := false
@@ -689,6 +777,7 @@ func (m *modelScheduler) upsertEntryLocked(meta *scheduledAuthMeta, now time.Tim
 	entry.meta = meta
 	entry.auth = meta.auth
 	entry.nextRetryAt = time.Time{}
+	entry.blockedAt = time.Time{}
 	blocked, reason, next := isAuthBlockedForModel(meta.auth, m.modelKey, now)
 	switch {
 	case !blocked:
@@ -696,14 +785,16 @@ func (m *modelScheduler) upsertEntryLocked(meta *scheduledAuthMeta, now time.Tim
 	case reason == blockReasonCooldown:
 		entry.state = scheduledStateCooldown
 		entry.nextRetryAt = next
+		entry.blockedAt = modelBlockedSince(meta.auth, m.modelKey, now)
 	case reason == blockReasonDisabled:
 		entry.state = scheduledStateDisabled
 	default:
 		entry.state = scheduledStateBlocked
 		entry.nextRetryAt = next
+		entry.blockedAt = modelBlockedSince(meta.auth, m.modelKey, now)
 	}
 
-	if ok && previousState == entry.state && previousNextRetryAt.Equal(entry.nextRetryAt) && previousPriority == meta.priority && previousParent == meta.virtualParent && previousWebsocketEnabled == meta.websocketEnabled {
+	if ok && previousState == entry.state && previousNextRetryAt.Equal(entry.nextRetryAt) && previousBlockedAt.Equal(entry.blockedAt) && previousPriority == meta.priority && previousParent == meta.virtualParent && previousWebsocketEnabled == meta.websocketEnabled {
 		return
 	}
 	m.rebuildIndexesLocked()
@@ -739,15 +830,19 @@ func (m *modelScheduler) promoteExpiredLocked(now time.Time) {
 		case !blocked:
 			entry.state = scheduledStateReady
 			entry.nextRetryAt = time.Time{}
+			entry.blockedAt = time.Time{}
 		case reason == blockReasonCooldown:
 			entry.state = scheduledStateCooldown
 			entry.nextRetryAt = next
+			entry.blockedAt = modelBlockedSince(entry.auth, m.modelKey, now)
 		case reason == blockReasonDisabled:
 			entry.state = scheduledStateDisabled
 			entry.nextRetryAt = time.Time{}
+			entry.blockedAt = time.Time{}
 		default:
 			entry.state = scheduledStateBlocked
 			entry.nextRetryAt = next
+			entry.blockedAt = modelBlockedSince(entry.auth, m.modelKey, now)
 		}
 		changed = true
 	}
@@ -861,7 +956,11 @@ func (m *modelScheduler) unavailableErrorLocked(provider, model string, predicat
 	return &Error{Code: "auth_unavailable", Message: "no auth available"}
 }
 
-// availabilitySummaryLocked summarizes total candidates, cooldown count, and earliest retry time.
+// availabilitySummaryLocked summarizes total candidates, the count of those
+// blocked with a known retry time, and the earliest such retry time.
+// All cooldown and blocked entries with a future nextRetryAt count toward the
+// "cooldown" total — distinguishing 401/403/503 from quota 429 in the
+// user-facing error label is noise.
 func (m *modelScheduler) availabilitySummaryLocked(predicate func(*scheduledAuth) bool) (int, int, time.Time) {
 	if m == nil {
 		return 0, 0, time.Time{}
@@ -877,15 +976,56 @@ func (m *modelScheduler) availabilitySummaryLocked(predicate func(*scheduledAuth
 		if entry == nil || entry.auth == nil {
 			continue
 		}
-		if entry.state != scheduledStateCooldown {
+		switch entry.state {
+		case scheduledStateCooldown, scheduledStateBlocked:
+		default:
+			continue
+		}
+		if entry.nextRetryAt.IsZero() {
 			continue
 		}
 		cooldownCount++
-		if !entry.nextRetryAt.IsZero() && (earliest.IsZero() || entry.nextRetryAt.Before(earliest)) {
+		if earliest.IsZero() || entry.nextRetryAt.Before(earliest) {
 			earliest = entry.nextRetryAt
 		}
 	}
 	return total, cooldownCount, earliest
+}
+
+// pickProbeLocked selects the longest-blocked entry that has spent at least
+// allBlockedProbeWindow in a non-ready state. Returns nil if nothing
+// qualifies. This is the "all blocked → probe" fallback used when no ready
+// auth is available; it lets a single request retry through stale cooldowns
+// instead of surfacing the configured wait time to the caller.
+func (m *modelScheduler) pickProbeLocked(predicate func(*scheduledAuth) bool, now time.Time) *Auth {
+	if m == nil {
+		return nil
+	}
+	threshold := now.Add(-allBlockedProbeWindow)
+	var picked *scheduledAuth
+	for _, entry := range m.entries {
+		if entry == nil || entry.auth == nil {
+			continue
+		}
+		switch entry.state {
+		case scheduledStateCooldown, scheduledStateBlocked:
+		default:
+			continue
+		}
+		if entry.blockedAt.IsZero() || entry.blockedAt.After(threshold) {
+			continue
+		}
+		if predicate != nil && !predicate(entry) {
+			continue
+		}
+		if picked == nil || entry.blockedAt.Before(picked.blockedAt) {
+			picked = entry
+		}
+	}
+	if picked == nil || picked.auth == nil {
+		return nil
+	}
+	return picked.auth.Clone()
 }
 
 // rebuildIndexesLocked reconstructs ready and blocked views from the current entry map.

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -197,24 +197,49 @@ func preferCodexWebsocketAuths(ctx context.Context, provider string, available [
 	return available
 }
 
-func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (available map[int][]*Auth, cooldownCount int, earliest time.Time) {
+// collectAvailableByPriority partitions auths into ready (by priority) and
+// counts every auth that is blocked with a known future retry time. The
+// caller treats the count uniformly: 401/403/404/503 cooldowns are counted
+// alongside 429 quota cooldowns so the user-facing error remains a proper
+// `model_cooldown` with a retry hint regardless of the underlying reason.
+// probeCandidates are blocked auths whose BlockedSince timestamp is at least
+// allBlockedProbeWindow in the past, ordered by oldest BlockedSince first.
+func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (available map[int][]*Auth, cooldownCount int, earliest time.Time, probeCandidates []*Auth) {
 	available = make(map[int][]*Auth)
+	threshold := now.Add(-allBlockedProbeWindow)
+	type probeEntry struct {
+		auth      *Auth
+		blockedAt time.Time
+	}
+	var probes []probeEntry
 	for i := 0; i < len(auths); i++ {
 		candidate := auths[i]
-		blocked, reason, next := isAuthBlockedForModel(candidate, model, now)
+		blocked, _, next := isAuthBlockedForModel(candidate, model, now)
 		if !blocked {
 			priority := authPriority(candidate)
 			available[priority] = append(available[priority], candidate)
 			continue
 		}
-		if reason == blockReasonCooldown {
-			cooldownCount++
-			if !next.IsZero() && (earliest.IsZero() || next.Before(earliest)) {
-				earliest = next
-			}
+		if next.IsZero() {
+			continue
+		}
+		cooldownCount++
+		if earliest.IsZero() || next.Before(earliest) {
+			earliest = next
+		}
+		blockedAt := modelBlockedSince(candidate, model, now)
+		if !blockedAt.IsZero() && !blockedAt.After(threshold) {
+			probes = append(probes, probeEntry{auth: candidate, blockedAt: blockedAt})
 		}
 	}
-	return available, cooldownCount, earliest
+	if len(probes) > 0 {
+		sort.Slice(probes, func(i, j int) bool { return probes[i].blockedAt.Before(probes[j].blockedAt) })
+		probeCandidates = make([]*Auth, len(probes))
+		for i, p := range probes {
+			probeCandidates[i] = p.auth
+		}
+	}
+	return available, cooldownCount, earliest, probeCandidates
 }
 
 func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]*Auth, error) {
@@ -222,9 +247,12 @@ func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]
 		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
 	}
 
-	availableByPriority, cooldownCount, earliest := collectAvailableByPriority(auths, model, now)
+	availableByPriority, cooldownCount, earliest, probeCandidates := collectAvailableByPriority(auths, model, now)
 	if len(availableByPriority) == 0 {
-		if cooldownCount == len(auths) && !earliest.IsZero() {
+		if len(probeCandidates) > 0 {
+			return probeCandidates, nil
+		}
+		if cooldownCount > 0 && !earliest.IsZero() {
 			providerForError := provider
 			if providerForError == "mixed" {
 				providerForError = ""

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -147,6 +147,15 @@ type ModelState struct {
 	LastError *Error `json:"last_error,omitempty"`
 	// Quota retains quota information if this model hit rate limits.
 	Quota QuotaState `json:"quota"`
+	// BlockedSince records when this model state most recently entered an
+	// unavailable-with-future-retry condition. It is set on the transition
+	// from ready→blocked and cleared on success. Used to gate the
+	// "all-blocked → probe" fallback in selectors.
+	BlockedSince time.Time `json:"blocked_since,omitempty"`
+	// TransientBackoffLevel stores the progressive cooldown exponent used
+	// for transient upstream errors (408/500/502/503/504), mirroring the
+	// QuotaState.BackoffLevel ladder used for 429 responses.
+	TransientBackoffLevel int `json:"transient_backoff,omitempty"`
 	// UpdatedAt tracks the last update timestamp for this model state.
 	UpdatedAt time.Time `json:"updated_at"`
 }


### PR DESCRIPTION
Broadens the set of identifiers used to maintain session affinity, improving compatibility with a wider range of clients (e.g., OpenAI Codex).

- Checks additional headers (`X-Client-Request-Id`, `Session-Id`, `Conversation-Id`) alongside `X-Session-ID` when extracting a session identifier
- Adds support for the `prompt_cache_key` body field as a session source, which Codex stamps with a session ID