### PR TITLE
feat(utls): add chatgpt.com to Cloudflare TLS fingerprint bypass

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -75,7 +75,7 @@ func (e *CodexExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth
 	if err := e.PrepareRequest(httpReq, auth); err != nil {
 		return nil, err
 	}
-	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient := helps.NewUtlsHTTPClient(e.cfg, auth, 0)
 	return httpClient.Do(httpReq)
 }
 
@@ -141,7 +141,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		AuthType:  authType,
 		AuthValue: authValue,
 	})
-	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient := helps.NewUtlsHTTPClient(e.cfg, auth, 0)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
@@ -287,7 +287,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		AuthType:  authType,
 		AuthValue: authValue,
 	})
-	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient := helps.NewUtlsHTTPClient(e.cfg, auth, 0)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
@@ -382,7 +382,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		AuthValue: authValue,
 	})
 
-	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient := helps.NewUtlsHTTPClient(e.cfg, auth, 0)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -128,9 +128,11 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	return resp, nil
 }
 
-// anthropicHosts contains the hosts that should use utls Chrome TLS fingerprint.
-var anthropicHosts = map[string]struct{}{
+// utlsProtectedHosts contains the hosts that should use utls Chrome TLS fingerprint
+// to bypass Cloudflare's TLS fingerprinting.
+var utlsProtectedHosts = map[string]struct{}{
 	"api.anthropic.com": {},
+	"chatgpt.com":       {},
 }
 
 // fallbackRoundTripper uses utls for Anthropic HTTPS hosts and falls back to
@@ -142,7 +144,7 @@ type fallbackRoundTripper struct {
 
 func (f *fallbackRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.URL.Scheme == "https" {
-		if _, ok := anthropicHosts[strings.ToLower(req.URL.Hostname())]; ok {
+		if _, ok := utlsProtectedHosts[strings.ToLower(req.URL.Hostname())]; ok {
 			return f.utls.RoundTrip(req)
 		}
 	}


### PR DESCRIPTION
## Summary

Around 2026-04-10 Cloudflare started enforcing **managed challenges** on `chatgpt.com`, returning 403 HTML challenge pages to Go's default TLS client. ChatGPT-account Codex routing (the OAuth backend at `chatgpt.com/backend-api/codex`) stopped working — every request 403'd with `auth_unavailable: no auth available`. This was not an IP block: `curl` from multiple geographic locations all hit the same wall, and JWTs were valid. The signal was purely TLS-layer (JA3 fingerprint).

The proxy already had `refraction-networking/utls` Chrome fingerprinting wired up for `api.anthropic.com` (added previously for the same Cloudflare class of problem). This PR extends that same protection to `chatgpt.com`.

## Changes

1. **`internal/runtime/executor/helps/utls_client.go`** — rename the host map from `anthropicHosts` to `utlsProtectedHosts` to reflect that it's no longer Anthropic-specific, and add `chatgpt.com` to it.
2. **`internal/runtime/executor/codex_executor.go`** — switch the four `NewProxyAwareHTTPClient` call sites (`HttpRequest`, `Execute`, `executeCompact`, `ExecuteStream`) to `NewUtlsHTTPClient`, the existing helper that uses the utls Chrome fingerprint for protected hosts and falls back to the standard transport for everything else.

Net change: **+9 / -7** across two files. No new dependencies. No behavior change for hosts outside the protected list.

## Verification

Tested after local deploy on 2026-04-10 (`cli-proxy-api:v6.9.22-cftls` image built from this patch + v6.9.22):

- Non-stream `gpt-5-codex` via `/v1/chat/completions`: **200 OK**, ~1.16 s
- Streamed `gpt-5-codex` via `/v1/chat/completions`: **200 OK**, clean SSE, ~1.87 s
- High-reasoning non-stream request: **200 OK** with reasoning + message output

Image has been running in production on two hosts (local laptop and a Contabo VPS) for 9 days serving Factory Droid traffic without regressions. Re-verified today (2026-04-19) with same image: `gpt-5.3-codex` returns expected output through the BYOK chain.

## Test plan

- [ ] Build from this branch and confirm it compiles cleanly (`go build ./...`)
- [ ] Manual: hit `chatgpt.com` from a host where Cloudflare's managed challenge is currently triggering (without this patch you should see 403 challenge HTML; with this patch you should see the normal API response)
- [ ] Regression: confirm `api.anthropic.com` traffic still uses utls (existing protection unchanged)
- [ ] Regression: confirm a non-protected HTTPS host (e.g., `api.openai.com`) still routes through the standard transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)