### PR TITLE
feat(access): per-api-key model allowlist with glob matching

### DIFF
--- a/internal/api/handlers/management/api_keys_payload_test.go
+++ b/internal/api/handlers/management/api_keys_payload_test.go
@@ -1,0 +1,120 @@
+package management
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseAPIKeysPayload(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		body         string
+		wantKeys     []string
+		wantPolicies int // count only — full equality covered below for one case
+		wantOK       bool
+	}{
+		{
+			name:     "plain string array",
+			body:     `["sk-aaa","sk-bbb"]`,
+			wantKeys: []string{"sk-aaa", "sk-bbb"},
+			wantOK:   true,
+		},
+		{
+			name:     "plain string array dedupes and trims",
+			body:     `["sk-aaa","  sk-aaa  ","sk-bbb"]`,
+			wantKeys: []string{"sk-aaa", "sk-bbb"},
+			wantOK:   true,
+		},
+		{
+			name:     "wrapped items array",
+			body:     `{"items":["sk-aaa","sk-bbb"]}`,
+			wantKeys: []string{"sk-aaa", "sk-bbb"},
+			wantOK:   true,
+		},
+		{
+			name:         "structured array camelCase",
+			body:         `[{"key":"sk-narrow","allowedModels":["gpt-4o*"]},{"key":"sk-open"}]`,
+			wantKeys:     []string{"sk-narrow", "sk-open"},
+			wantPolicies: 1,
+			wantOK:       true,
+		},
+		{
+			name:         "structured array kebab-case",
+			body:         `[{"key":"sk-narrow","allowed-models":["gpt-4o*","claude-3-*"]}]`,
+			wantKeys:     []string{"sk-narrow"},
+			wantPolicies: 1,
+			wantOK:       true,
+		},
+		{
+			name:         "structured array snake_case",
+			body:         `[{"key":"sk-narrow","allowed_models":["gpt-4o*"]}]`,
+			wantKeys:     []string{"sk-narrow"},
+			wantPolicies: 1,
+			wantOK:       true,
+		},
+		{
+			name:         "structured wrapped items",
+			body:         `{"items":[{"key":"sk-narrow","allowedModels":["gpt-4o*"]}]}`,
+			wantKeys:     []string{"sk-narrow"},
+			wantPolicies: 1,
+			wantOK:       true,
+		},
+		{
+			name:   "empty plain array fails",
+			body:   `[]`,
+			wantOK: true, // legacy plain-list path accepts empty -> clears keys
+		},
+		{
+			name:   "garbage fails",
+			body:   `not json`,
+			wantOK: false,
+		},
+		{
+			name:   "object without items fails",
+			body:   `{"foo":"bar"}`,
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			keys, policies, ok := parseAPIKeysPayload([]byte(tc.body))
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (keys=%v policies=%v)", ok, tc.wantOK, keys, policies)
+			}
+			if !ok {
+				return
+			}
+			if tc.wantKeys != nil && !reflect.DeepEqual(keys, tc.wantKeys) {
+				t.Fatalf("keys = %v, want %v", keys, tc.wantKeys)
+			}
+			if tc.wantPolicies != len(policies) {
+				t.Fatalf("policies count = %d, want %d (got %v)", len(policies), tc.wantPolicies, policies)
+			}
+		})
+	}
+}
+
+func TestParseAPIKeysPayload_StructuredPolicyShape(t *testing.T) {
+	body := `[{"key":"sk-narrow","allowedModels":["gpt-4o*","claude-3-*"]},{"key":"sk-open"}]`
+	keys, policies, ok := parseAPIKeysPayload([]byte(body))
+	if !ok {
+		t.Fatalf("expected ok")
+	}
+	if want := []string{"sk-narrow", "sk-open"}; !reflect.DeepEqual(keys, want) {
+		t.Fatalf("keys = %v, want %v", keys, want)
+	}
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+	if policies[0].Key != "sk-narrow" {
+		t.Fatalf("policy key = %q, want sk-narrow", policies[0].Key)
+	}
+	if want := []string{"gpt-4o*", "claude-3-*"}; !reflect.DeepEqual(policies[0].AllowedModels, want) {
+		t.Fatalf("policy AllowedModels = %v, want %v", policies[0].AllowedModels, want)
+	}
+}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -105,11 +105,139 @@ func (h *Handler) deleteFromStringList(c *gin.Context, target *[]string, after f
 }
 
 // api-keys
-func (h *Handler) GetAPIKeys(c *gin.Context) { c.JSON(200, gin.H{"api-keys": h.cfg.APIKeys}) }
+func (h *Handler) GetAPIKeys(c *gin.Context) {
+	if len(h.cfg.APIKeyPolicies) == 0 {
+		c.JSON(200, gin.H{"api-keys": h.cfg.APIKeys})
+		return
+	}
+	c.JSON(200, gin.H{
+		"api-keys":         h.cfg.APIKeys,
+		"api-key-policies": h.cfg.APIKeyPolicies,
+	})
+}
+
+// PutAPIKeys accepts either:
+//
+//	["sk-aaa", "sk-bbb"]                           (legacy plain list)
+//	{"items": ["sk-aaa", "sk-bbb"]}                (legacy wrapped list)
+//	[{"key":"sk-aaa","allowedModels":["gpt-4o*"]}, {"key":"sk-bbb"}]
+//	[{"key":"sk-aaa","allowed-models":["gpt-4o*"]}]
+//
+// The structured form is unwound into APIKeys (the flat list of accepted bearer
+// values, used by the auth provider) plus APIKeyPolicies (the per-key policy
+// rows, consumed by the model-ACL middleware).
 func (h *Handler) PutAPIKeys(c *gin.Context) {
-	h.putStringList(c, func(v []string) {
-		h.cfg.APIKeys = append([]string(nil), v...)
-	}, nil)
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+
+	keys, policies, ok := parseAPIKeysPayload(data)
+	if !ok {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+
+	h.cfg.APIKeys = append([]string(nil), keys...)
+	h.cfg.APIKeyPolicies = append([]config.APIKeyPolicy(nil), policies...)
+	h.persist(c)
+}
+
+// parseAPIKeysPayload accepts both the legacy plain-string formats and the
+// structured form described on PutAPIKeys. It returns the bearer values, the
+// matching policy entries (only for keys that supplied a non-empty
+// AllowedModels list), and ok=false on parse failure.
+func parseAPIKeysPayload(data []byte) (keys []string, policies []config.APIKeyPolicy, ok bool) {
+	// Try plain []string first.
+	var plain []string
+	if err := json.Unmarshal(data, &plain); err == nil {
+		return dedupeKeyList(plain), nil, true
+	}
+
+	// Try {items: []string}.
+	var wrapped struct {
+		Items []string `json:"items"`
+	}
+	if err := json.Unmarshal(data, &wrapped); err == nil && len(wrapped.Items) > 0 {
+		return dedupeKeyList(wrapped.Items), nil, true
+	}
+
+	// Try the structured form: []{key, allowedModels|allowed-models}.
+	type structuredEntry struct {
+		Key                  string   `json:"key"`
+		AllowedModelsCamel   []string `json:"allowedModels"`
+		AllowedModelsHyphen  []string `json:"allowed-models"`
+		AllowedModelsSnake   []string `json:"allowed_models"`
+	}
+	var entries []structuredEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		// Try {items: [...]} of structured entries.
+		var wrappedStruct struct {
+			Items []structuredEntry `json:"items"`
+		}
+		if err2 := json.Unmarshal(data, &wrappedStruct); err2 != nil || len(wrappedStruct.Items) == 0 {
+			return nil, nil, false
+		}
+		entries = wrappedStruct.Items
+	}
+
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		key := strings.TrimSpace(entry.Key)
+		if key == "" {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+
+		allowed := entry.AllowedModelsCamel
+		if len(allowed) == 0 {
+			allowed = entry.AllowedModelsHyphen
+		}
+		if len(allowed) == 0 {
+			allowed = entry.AllowedModelsSnake
+		}
+		normalized := make([]string, 0, len(allowed))
+		for _, pattern := range allowed {
+			pattern = strings.TrimSpace(pattern)
+			if pattern == "" {
+				continue
+			}
+			normalized = append(normalized, pattern)
+		}
+		if len(normalized) > 0 {
+			policies = append(policies, config.APIKeyPolicy{
+				Key:           key,
+				AllowedModels: normalized,
+			})
+		}
+	}
+	if len(keys) == 0 {
+		return nil, nil, false
+	}
+	return keys, policies, true
+}
+
+// dedupeKeyList trims and de-duplicates raw key strings while preserving order.
+func dedupeKeyList(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, raw := range in {
+		key := strings.TrimSpace(raw)
+		if key == "" {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	return out
 }
 func (h *Handler) PatchAPIKeys(c *gin.Context) {
 	h.patchStringList(c, &h.cfg.APIKeys, func() {})

--- a/internal/api/model_acl.go
+++ b/internal/api/model_acl.go
@@ -1,0 +1,141 @@
+// Per-API-key model ACL enforcement.
+//
+// AuthMiddleware identifies the calling client by api key value. ModelACLMiddleware
+// then checks the model targeted by the request against that key's allowed-models
+// policy (configured via SDKConfig.APIKeyPolicies / APIKeyDefaultPolicy) and
+// rejects the request with HTTP 403 on mismatch.
+//
+// The middleware extracts the model identifier from whichever location the
+// upstream route uses:
+//
+//   - JSON body field "model" (chat completions, messages, responses, codex)
+//   - URL path segment after /v1beta/models/ (Gemini generative endpoints)
+//
+// When no model can be determined (e.g. listing endpoints, websocket upgrades),
+// the middleware allows the request through; access enforcement remains the
+// responsibility of the route's own logic in those cases.
+
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/tidwall/gjson"
+)
+
+// ModelACLMiddleware enforces SDKConfig.APIKeyPolicies for the routes it is
+// installed on. The cfgFn closure is evaluated on every request so that hot
+// config reloads take effect immediately.
+func ModelACLMiddleware(cfgFn func() *config.Config) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		cfg := cfgFn()
+		if cfg == nil {
+			c.Next()
+			return
+		}
+
+		// Skip enforcement when no policies are configured AND the default
+		// policy permits everything; the per-key check would be a no-op.
+		if len(cfg.APIKeyPolicies) == 0 && !strings.EqualFold(strings.TrimSpace(cfg.APIKeyDefaultPolicy), config.APIKeyDefaultPolicyDenyAll) {
+			c.Next()
+			return
+		}
+
+		raw, exists := c.Get("apiKey")
+		if !exists {
+			// AuthMiddleware did not run or did not identify a key. We do not
+			// enforce in that case to preserve the legacy "no auth provider =>
+			// allow" behavior of AuthMiddleware.
+			c.Next()
+			return
+		}
+		apiKey, ok := raw.(string)
+		if !ok || strings.TrimSpace(apiKey) == "" {
+			c.Next()
+			return
+		}
+
+		model, found := extractRequestedModel(c)
+		if !found {
+			// No model in this request shape (listing, ping, etc.) — allow.
+			c.Next()
+			return
+		}
+
+		if cfg.IsModelAllowedForKey(apiKey, model) {
+			c.Next()
+			return
+		}
+
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+			"error": gin.H{
+				"type":    "model_not_allowed_for_key",
+				"message": "this api key is not permitted to use the requested model",
+				"model":   model,
+			},
+		})
+	}
+}
+
+// extractRequestedModel returns the model identifier the current request is
+// targeting, or ok=false when none can be determined for the route.
+//
+// The function intentionally consumes and restores the request body so that
+// downstream handlers see an unmodified io.Reader.
+func extractRequestedModel(c *gin.Context) (model string, ok bool) {
+	if c == nil || c.Request == nil {
+		return "", false
+	}
+
+	// Gemini-style: /v1beta/models/<model>:<action>
+	if strings.HasPrefix(c.Request.URL.Path, "/v1beta/models/") {
+		rest := strings.TrimPrefix(c.Request.URL.Path, "/v1beta/models/")
+		// Drop everything from the first ':' (action) onward.
+		if idx := strings.Index(rest, ":"); idx >= 0 {
+			rest = rest[:idx]
+		}
+		// Drop everything from the first '/' onward (no nested paths today,
+		// but be defensive).
+		if idx := strings.Index(rest, "/"); idx >= 0 {
+			rest = rest[:idx]
+		}
+		rest = strings.TrimSpace(rest)
+		if rest != "" {
+			return rest, true
+		}
+	}
+
+	// JSON body: "model" field. Only POST/PUT/PATCH carry bodies we care about.
+	method := c.Request.Method
+	if method != http.MethodPost && method != http.MethodPut && method != http.MethodPatch {
+		return "", false
+	}
+	if c.Request.Body == nil {
+		return "", false
+	}
+
+	bodyBytes, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		return "", false
+	}
+	// Always restore the body so downstream handlers can re-read it.
+	c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	if len(bodyBytes) == 0 {
+		return "", false
+	}
+	res := gjson.GetBytes(bodyBytes, "model")
+	if !res.Exists() || res.Type != gjson.String {
+		return "", false
+	}
+	model = strings.TrimSpace(res.String())
+	if model == "" {
+		return "", false
+	}
+	return model, true
+}

--- a/internal/api/model_acl_test.go
+++ b/internal/api/model_acl_test.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func newTestRouter(cfg *config.Config, apiKey string) *gin.Engine {
+	router := gin.New()
+	// Stand-in for AuthMiddleware: install the api key directly into context.
+	router.Use(func(c *gin.Context) {
+		if apiKey != "" {
+			c.Set("apiKey", apiKey)
+		}
+		c.Next()
+	})
+	router.Use(ModelACLMiddleware(func() *config.Config { return cfg }))
+
+	router.POST("/v1/chat/completions", func(c *gin.Context) {
+		body, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		// Echo the body back so the test can verify the downstream handler
+		// was able to read it after the middleware peeked.
+		c.Data(http.StatusOK, "application/json", body)
+	})
+	router.POST("/v1beta/models/*action", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true, "path": c.Request.URL.Path})
+	})
+	router.GET("/v1/models", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": []string{}})
+	})
+	return router
+}
+
+func TestModelACLMiddleware_NoPoliciesAllowsAllByDefault(t *testing.T) {
+	cfg := &config.Config{}
+	router := newTestRouter(cfg, "sk-anything")
+
+	body, _ := json.Marshal(map[string]any{"model": "gpt-5"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "gpt-5") {
+		t.Fatalf("downstream handler did not see body: %s", w.Body.String())
+	}
+}
+
+func TestModelACLMiddleware_AllowedModelPasses(t *testing.T) {
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{
+			APIKeys: []string{"sk-narrow"},
+			APIKeyPolicies: []config.APIKeyPolicy{
+				{Key: "sk-narrow", AllowedModels: []string{"gpt-4o*"}},
+			},
+		},
+	}
+	router := newTestRouter(cfg, "sk-narrow")
+
+	body, _ := json.Marshal(map[string]any{"model": "gpt-4o-mini", "messages": []any{}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestModelACLMiddleware_DisallowedModelRejected(t *testing.T) {
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{
+			APIKeys: []string{"sk-narrow"},
+			APIKeyPolicies: []config.APIKeyPolicy{
+				{Key: "sk-narrow", AllowedModels: []string{"gpt-4o*"}},
+			},
+		},
+	}
+	router := newTestRouter(cfg, "sk-narrow")
+
+	body, _ := json.Marshal(map[string]any{"model": "claude-3-5-sonnet-20241022"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "model_not_allowed_for_key") {
+		t.Fatalf("expected error code in body, got %s", w.Body.String())
+	}
+}
+
+func TestModelACLMiddleware_DenyAllDefaultRejectsUnknownKey(t *testing.T) {
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{
+			APIKeyDefaultPolicy: config.APIKeyDefaultPolicyDenyAll,
+		},
+	}
+	router := newTestRouter(cfg, "sk-anything")
+	body, _ := json.Marshal(map[string]any{"model": "gpt-5"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestModelACLMiddleware_GeminiPathExtraction(t *testing.T) {
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{
+			APIKeys: []string{"sk-gemini"},
+			APIKeyPolicies: []config.APIKeyPolicy{
+				{Key: "sk-gemini", AllowedModels: []string{"gemini-2.0-flash"}},
+			},
+		},
+	}
+	router := newTestRouter(cfg, "sk-gemini")
+
+	// Allowed model
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.0-flash:generateContent", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("allowed gemini model: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	// Disallowed model
+	req = httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-1.5-pro:generateContent", strings.NewReader("{}"))
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("disallowed gemini model: expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestModelACLMiddleware_ListEndpointAlwaysAllowed(t *testing.T) {
+	// /v1/models has no body and no model in path; the middleware must
+	// permit it regardless of policy so clients can still discover models.
+	cfg := &config.Config{
+		SDKConfig: config.SDKConfig{
+			APIKeyDefaultPolicy: config.APIKeyDefaultPolicyDenyAll,
+		},
+	}
+	router := newTestRouter(cfg, "sk-anything")
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 on listing endpoint, got %d", w.Code)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -330,9 +330,12 @@ func (s *Server) setupRoutes() {
 	claudeCodeHandlers := claude.NewClaudeCodeAPIHandler(s.handlers)
 	openaiResponsesHandlers := openai.NewOpenAIResponsesAPIHandler(s.handlers)
 
+	cfgFn := func() *config.Config { return s.cfg }
+
 	// OpenAI compatible API routes
 	v1 := s.engine.Group("/v1")
 	v1.Use(AuthMiddleware(s.accessManager))
+	v1.Use(ModelACLMiddleware(cfgFn))
 	{
 		v1.GET("/models", s.unifiedModelsHandler(openaiHandlers, claudeCodeHandlers))
 		v1.POST("/chat/completions", openaiHandlers.ChatCompletions)
@@ -347,6 +350,7 @@ func (s *Server) setupRoutes() {
 	// Gemini compatible API routes
 	v1beta := s.engine.Group("/v1beta")
 	v1beta.Use(AuthMiddleware(s.accessManager))
+	v1beta.Use(ModelACLMiddleware(cfgFn))
 	{
 		v1beta.GET("/models", geminiHandlers.GeminiModels)
 		v1beta.POST("/models/*action", geminiHandlers.GeminiHandler)

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -4,6 +4,28 @@
 // debug settings, proxy configuration, and API keys.
 package config
 
+import (
+	"path"
+	"strings"
+)
+
+// APIKeyDefaultPolicyAllowAll permits any model when a key has no explicit AllowedModels list.
+const APIKeyDefaultPolicyAllowAll = "allow-all"
+
+// APIKeyDefaultPolicyDenyAll forbids every model when a key has no explicit AllowedModels list.
+const APIKeyDefaultPolicyDenyAll = "deny-all"
+
+// APIKeyPolicy describes per-client-key access controls. AllowedModels supports
+// path.Match-style globs (e.g. "claude-3-*", "gpt-4o*"). An empty AllowedModels
+// list defers to APIKeyDefaultPolicy on the parent SDKConfig.
+type APIKeyPolicy struct {
+	// Key is the bearer/api key value this policy applies to.
+	Key string `yaml:"key" json:"key"`
+
+	// AllowedModels lists glob patterns of model identifiers this key may target.
+	AllowedModels []string `yaml:"allowed-models,omitempty" json:"allowed-models,omitempty"`
+}
+
 // SDKConfig represents the application's configuration, loaded from a YAML file.
 type SDKConfig struct {
 	// ProxyURL is the URL of an optional proxy server to use for outbound requests.
@@ -24,6 +46,16 @@ type SDKConfig struct {
 	// APIKeys is a list of keys for authenticating clients to this proxy server.
 	APIKeys []string `yaml:"api-keys" json:"api-keys"`
 
+	// APIKeyPolicies stores per-key access policies (allowed model globs).
+	// Keys present here must also exist in APIKeys to be accepted by the auth
+	// provider; entries without a matching APIKeys row are ignored.
+	APIKeyPolicies []APIKeyPolicy `yaml:"api-key-policies,omitempty" json:"api-key-policies,omitempty"`
+
+	// APIKeyDefaultPolicy controls behavior for keys with no entry in
+	// APIKeyPolicies, or whose entry has an empty AllowedModels list. Valid
+	// values are "allow-all" (default, backward compatible) and "deny-all".
+	APIKeyDefaultPolicy string `yaml:"api-key-default-policy,omitempty" json:"api-key-default-policy,omitempty"`
+
 	// PassthroughHeaders controls whether upstream response headers are forwarded to downstream clients.
 	// Default is false (disabled).
 	PassthroughHeaders bool `yaml:"passthrough-headers" json:"passthrough-headers"`
@@ -34,6 +66,66 @@ type SDKConfig struct {
 	// NonStreamKeepAliveInterval controls how often blank lines are emitted for non-streaming responses.
 	// <= 0 disables keep-alives. Value is in seconds.
 	NonStreamKeepAliveInterval int `yaml:"nonstream-keepalive-interval,omitempty" json:"nonstream-keepalive-interval,omitempty"`
+}
+
+// IsModelAllowedForKey reports whether the given client api key may target the
+// given model. Matching uses path.Match glob semantics. An unknown key, or a
+// key whose AllowedModels list is empty, falls back to APIKeyDefaultPolicy:
+// "deny-all" rejects, anything else (including the default empty value) allows.
+//
+// The model argument is matched after stripping any provider prefix of the form
+// "<prefix>/<model>" so that policies stay portable across prefixed credentials.
+func (c *SDKConfig) IsModelAllowedForKey(key, model string) bool {
+	if c == nil {
+		return true
+	}
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedKey == "" {
+		return c.defaultAllows()
+	}
+
+	// Strip a single leading "<prefix>/" segment if present so glob authors do
+	// not have to anticipate every prefixed credential.
+	candidate := model
+	if idx := strings.Index(candidate, "/"); idx >= 0 && idx < len(candidate)-1 {
+		candidate = candidate[idx+1:]
+	}
+
+	for i := range c.APIKeyPolicies {
+		if c.APIKeyPolicies[i].Key != trimmedKey {
+			continue
+		}
+		patterns := c.APIKeyPolicies[i].AllowedModels
+		if len(patterns) == 0 {
+			return c.defaultAllows()
+		}
+		for _, pattern := range patterns {
+			pattern = strings.TrimSpace(pattern)
+			if pattern == "" {
+				continue
+			}
+			if pattern == candidate {
+				return true
+			}
+			if matched, err := path.Match(pattern, candidate); err == nil && matched {
+				return true
+			}
+			// Also try the unstripped form for keys whose policies were
+			// authored against the prefixed model name verbatim.
+			if matched, err := path.Match(pattern, model); err == nil && matched {
+				return true
+			}
+		}
+		return false
+	}
+	return c.defaultAllows()
+}
+
+func (c *SDKConfig) defaultAllows() bool {
+	if c == nil {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(c.APIKeyDefaultPolicy), APIKeyDefaultPolicyDenyAll) == false
 }
 
 // StreamingConfig holds server streaming behavior configuration.

--- a/internal/config/sdk_config_test.go
+++ b/internal/config/sdk_config_test.go
@@ -1,0 +1,167 @@
+package config
+
+import "testing"
+
+func TestIsModelAllowedForKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		cfg     SDKConfig
+		key     string
+		model   string
+		want    bool
+	}{
+		{
+			name:  "no policies allow-all default permits any model",
+			cfg:   SDKConfig{},
+			key:   "sk-anything",
+			model: "gpt-5",
+			want:  true,
+		},
+		{
+			name: "no policies deny-all default rejects any model",
+			cfg: SDKConfig{
+				APIKeyDefaultPolicy: APIKeyDefaultPolicyDenyAll,
+			},
+			key:   "sk-anything",
+			model: "gpt-5",
+			want:  false,
+		},
+		{
+			name: "matching key with empty allowed list defers to default allow",
+			cfg: SDKConfig{
+				APIKeyPolicies: []APIKeyPolicy{
+					{Key: "sk-empty", AllowedModels: nil},
+				},
+			},
+			key:   "sk-empty",
+			model: "gpt-4o-mini",
+			want:  true,
+		},
+		{
+			name: "matching key with empty allowed list and deny-all default rejects",
+			cfg: SDKConfig{
+				APIKeyDefaultPolicy: APIKeyDefaultPolicyDenyAll,
+				APIKeyPolicies: []APIKeyPolicy{
+					{Key: "sk-empty", AllowedModels: nil},
+				},
+			},
+			key:   "sk-empty",
+			model: "gpt-4o-mini",
+			want:  false,
+		},
+		{
+			name: "exact model match wins",
+			cfg: SDKConfig{
+				APIKeyPolicies: []APIKeyPolicy{
+					{Key: "sk-strict", AllowedModels: []string{"claude-3-5-sonnet-20241022"}},
+				},
+			},
+			key:   "sk-strict",
+			model: "claude-3-5-sonnet-20241022",
+			want:  true,
+		},
+		{
+			name: "non-matching exact model rejects when policy is non-empty",
+			cfg: SDKConfig{
+				APIKeyPolicies: []APIKeyPolicy{
+					{Key: "sk-strict", AllowedModels: []string{"claude-3-5-sonnet-20241022"}},
+				},
+			},
+			key:   "sk-strict",
+			model: "gpt-5",
+			want:  false,
+		},
+		{
+			name: "glob star matches family",
+			cfg: SDKConfig{
+				APIKeyPolicies: []APIKeyPolicy{
+					{Key: "sk-glob", AllowedModels: []string{"gpt-4o*"}},
+				},
+			},
+			key:   "sk-glob",
+			model: "gpt-4o-mini",
+			want:  true,
+		},
+		{
+			name: "glob does not match unrelated family",
+			cfg: SDKConfig{
+				APIKeyPolicies: []APIKeyPolicy{
+					{Key: "sk-glob", AllowedModels: []string{"gpt-4o*"}},
+				},
+			},
+			key:   "sk-glob",
+			model: "claude-3-5-sonnet-20241022",
+			want:  false,
+		},
+		{
+			name: "prefix-stripped model matches glob",
+			cfg: SDKConfig{
+				APIKeyPolicies: []APIKeyPolicy{
+					{Key: "sk-prefix", AllowedModels: []string{"gemini-3-pro*"}},
+				},
+			},
+			key:   "sk-prefix",
+			model: "teamA/gemini-3-pro-preview",
+			want:  true,
+		},
+		{
+			name: "policy authored against the prefixed form still matches",
+			cfg: SDKConfig{
+				APIKeyPolicies: []APIKeyPolicy{
+					{Key: "sk-prefix-literal", AllowedModels: []string{"teamA/gemini-3-pro*"}},
+				},
+			},
+			key:   "sk-prefix-literal",
+			model: "teamA/gemini-3-pro-preview",
+			want:  true,
+		},
+		{
+			name: "unknown key falls back to allow-all default",
+			cfg: SDKConfig{
+				APIKeyPolicies: []APIKeyPolicy{
+					{Key: "sk-known", AllowedModels: []string{"gpt-4o*"}},
+				},
+			},
+			key:   "sk-unknown",
+			model: "gpt-4o",
+			want:  true,
+		},
+		{
+			name: "unknown key with deny-all default rejects",
+			cfg: SDKConfig{
+				APIKeyDefaultPolicy: APIKeyDefaultPolicyDenyAll,
+				APIKeyPolicies: []APIKeyPolicy{
+					{Key: "sk-known", AllowedModels: []string{"gpt-4o*"}},
+				},
+			},
+			key:   "sk-unknown",
+			model: "gpt-4o",
+			want:  false,
+		},
+		{
+			name: "blank key falls back to default",
+			cfg: SDKConfig{
+				APIKeyDefaultPolicy: APIKeyDefaultPolicyDenyAll,
+				APIKeyPolicies: []APIKeyPolicy{
+					{Key: "sk-known", AllowedModels: []string{"gpt-4o*"}},
+				},
+			},
+			key:   "   ",
+			model: "gpt-4o",
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.cfg.IsModelAllowedForKey(tc.key, tc.model)
+			if got != tc.want {
+				t.Fatalf("IsModelAllowedForKey(%q, %q) = %v, want %v", tc.key, tc.model, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds enforcement for per-client-key model ACLs at the request middleware layer. The companion dashboard already stores `allowedModels` per UserApiKey and attempts to push them to `PUT /v0/management/api-keys`, but until now there was nowhere upstream for them to land — the structured payload was rejected and dashboards silently fell back to the legacy plain-array form, so no key was ever actually restricted.

This change adds:

**Config**
- `APIKeyPolicy{Key, AllowedModels}` and `SDKConfig.APIKeyPolicies`
- `SDKConfig.APIKeyDefaultPolicy` (`"allow-all"` | `"deny-all"`; defaults to `allow-all` so existing deployments are unaffected)
- `IsModelAllowedForKey` supports `path.Match` globs and tolerates a single leading `<prefix>/` segment so policies stay portable across prefixed credentials

**Management API**
- `PutAPIKeys` accepts both the legacy string list and the structured `[{key, allowedModels}]` form, with `allowedModels` / `allowed-models` / `allowed_models` all recognized so existing dashboard payloads work unchanged
- `GetAPIKeys` exposes `api-key-policies` when any are configured

**Middleware**
- New `ModelACLMiddleware` extracts the targeted model from the JSON body (`model` field) or the Gemini-style `/v1beta/models/<model>:<action>` path, then enforces the per-key policy
- The body is read once and restored via `io.NopCloser` so downstream handlers still see the original request bytes
- Wired into both `/v1` and `/v1beta` groups directly after `AuthMiddleware`
- Bypasses any request that has no identified api key (preserving the legacy "no auth provider configured => allow" behavior) and any shape with no extractable model (listings, websocket upgrades) so discovery endpoints keep working

## Test plan

- [x] Unit tests for `IsModelAllowedForKey` covering allow-all, deny-all, empty allowed list semantics, exact matches, glob matches, and the prefixed-credential case
- [x] Middleware tests covering the allow / deny / unknown-key / Gemini path / list-endpoint / body-pass-through paths
- [x] Parser tests for `PutAPIKeys` covering the legacy plain list, the wrapped items form, and the structured form in all three case styles (`allowedModels` / `allowed-models` / `allowed_models`)

## Backwards compatibility

Default policy is `allow-all`; deployments that do not opt in by setting `APIKeyPolicies` or flipping `APIKeyDefaultPolicy` to `deny-all` see no behavior change. Existing dashboards that `PUT` a plain string list continue to work — the new structured form is additive.