### PR TITLE
refactor(antigravity): rewrite error handling and credits mechanism

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -100,6 +100,17 @@ quota-exceeded:
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
   antigravity-credits: true # Whether to retry Antigravity quota_exhausted 429s once with enabledCreditTypes=["GOOGLE_ONE_AI"]
 
+# Enable Credits retry mechanism (Google One AI) for quota exhaustion.
+# When true (default), 429 QUOTA_EXHAUSTED errors trigger a retry with enabledCreditTypes.
+# Takes precedence over quota-exceeded.antigravity-credits when set.
+credits-enabled: true
+
+# Maximum concurrent requests per auth credential. 0 = unlimited (default).
+max-concurrency-per-auth: 0
+
+# Minimum interval between retries in milliseconds. Default: 100.
+min-retry-interval: 100
+
 # Routing strategy for selecting credentials when multiple match.
 routing:
   strategy: "round-robin" # round-robin (default), fill-first

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -28,6 +28,7 @@ import (
 	geminiAuth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	executor "github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -1107,6 +1108,21 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 	} else {
 		targetAuth.Status = coreauth.StatusActive
 		targetAuth.StatusMessage = ""
+		targetAuth.QuotaExhaustedPermanent = false
+		targetAuth.Unavailable = false
+		targetAuth.NextRetryAfter = time.Time{}
+		targetAuth.LastError = nil
+		targetAuth.Quota = coreauth.QuotaState{}
+		for _, ms := range targetAuth.ModelStates {
+			if ms != nil {
+				ms.Unavailable = false
+				ms.NextRetryAfter = time.Time{}
+				ms.LastError = nil
+				ms.Quota = coreauth.QuotaState{}
+				ms.Status = coreauth.StatusActive
+			}
+		}
+		executor.ClearAntigravityAuthState(targetAuth.ID)
 	}
 	targetAuth.UpdatedAt = time.Now()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,16 @@ type Config struct {
 	// MaxRetryInterval defines the maximum wait time in seconds before retrying a cooled-down credential.
 	MaxRetryInterval int `yaml:"max-retry-interval" json:"max-retry-interval"`
 
+	// MinRetryInterval defines the minimum interval between retries in milliseconds. Default: 100.
+	MinRetryInterval int `yaml:"min-retry-interval" json:"min-retry-interval"`
+
+	// CreditsEnabled controls whether the Credits retry mechanism (GOOGLE_ONE_AI) is active. Default: true.
+	CreditsEnabled *bool `yaml:"credits-enabled,omitempty" json:"credits-enabled,omitempty"`
+
+	// MaxConcurrencyPerAuth limits the maximum number of concurrent requests per auth credential.
+	// 0 means unlimited (default).
+	MaxConcurrencyPerAuth int `yaml:"max-concurrency-per-auth" json:"max-concurrency-per-auth"`
+
 	// QuotaExceeded defines the behavior when a quota is exceeded.
 	QuotaExceeded QuotaExceeded `yaml:"quota-exceeded" json:"quota-exceeded"`
 
@@ -209,6 +219,19 @@ type QuotaExceeded struct {
 	// AntigravityCredits indicates whether to retry Antigravity quota_exhausted 429s once
 	// on the same credential with enabledCreditTypes=["GOOGLE_ONE_AI"].
 	AntigravityCredits bool `yaml:"antigravity-credits" json:"antigravity-credits"`
+}
+
+// IsCreditsEnabled returns whether the Credits retry mechanism is enabled.
+// It checks the top-level credits-enabled field first; if unset, falls back to
+// quota-exceeded.antigravity-credits for backward compatibility. Default is true.
+func (c *Config) IsCreditsEnabled() bool {
+	if c == nil {
+		return true
+	}
+	if c.CreditsEnabled != nil {
+		return *c.CreditsEnabled
+	}
+	return c.QuotaExceeded.AntigravityCredits
 }
 
 // RoutingConfig configures how credentials are selected for requests.

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -51,66 +51,27 @@ const (
 	antigravityClientSecret                = "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"
 	defaultAntigravityAgent                = "antigravity/1.21.9 darwin/arm64" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
 	antigravityAuthType                    = "antigravity"
-	refreshSkew                            = 3000 * time.Second
-	antigravityCreditsRetryTTL             = 5 * time.Hour
-	antigravityCreditsAutoDisableDuration  = 5 * time.Hour
-	antigravityShortQuotaCooldownThreshold = 5 * time.Minute
-	antigravityInstantRetryThreshold       = 3 * time.Second
-	// systemInstruction              = "You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.**Absolute paths only****Proactiveness**"
+	refreshSkew = 3000 * time.Second
+
+	creditsDuration       = 30 * time.Minute
+	modelCooldownDuration = 30 * time.Minute
 )
 
-type antigravity429Category string
-
-type antigravityCreditsFailureState struct {
-	Count                    int
-	DisabledUntil            time.Time
-	PermanentlyDisabled      bool
-	ExplicitBalanceExhausted bool
-}
-
-type antigravity429DecisionKind string
+type antigravity429Rule int
 
 const (
-	antigravity429Unknown                         antigravity429Category     = "unknown"
-	antigravity429RateLimited                     antigravity429Category     = "rate_limited"
-	antigravity429QuotaExhausted                  antigravity429Category     = "quota_exhausted"
-	antigravity429SoftRateLimit                   antigravity429Category     = "soft_rate_limit"
-	antigravity429DecisionSoftRetry               antigravity429DecisionKind = "soft_retry"
-	antigravity429DecisionInstantRetrySameAuth    antigravity429DecisionKind = "instant_retry_same_auth"
-	antigravity429DecisionShortCooldownSwitchAuth antigravity429DecisionKind = "short_cooldown_switch_auth"
-	antigravity429DecisionFullQuotaExhausted      antigravity429DecisionKind = "full_quota_exhausted"
+	antigravity429RuleNone        antigravity429Rule = iota
+	antigravity429Rule1Permanent                     // message contains "e.g." + RESOURCE_EXHAUSTED
+	antigravity429Rule2QuotaModel                    // QUOTA_EXHAUSTED + metadata.model
+	antigravity429Rule3RateLimit                     // RATE_LIMIT_EXCEEDED + metadata.model
 )
 
-type antigravity429Decision struct {
-	kind       antigravity429DecisionKind
-	retryAfter *time.Duration
-	reason     string
-}
-
 var (
-	randSource                        = rand.New(rand.NewSource(time.Now().UnixNano()))
-	randSourceMutex                   sync.Mutex
-	antigravityCreditsFailureByAuth   sync.Map
-	antigravityPreferCreditsByModel   sync.Map
-	antigravityShortCooldownByAuth    sync.Map
-	antigravityQuotaExhaustedKeywords = []string{
-		"quota_exhausted",
-		"quota exhausted",
-	}
-	antigravityCreditsExhaustedKeywords = []string{
-		"google_one_ai",
-		"insufficient credit",
-		"insufficient credits",
-		"not enough credit",
-		"not enough credits",
-		"credit exhausted",
-		"credits exhausted",
-		"credit balance",
-		"minimumcreditamountforusage",
-		"minimum credit amount for usage",
-		"minimum credit",
-		"resource has been exhausted",
-	}
+	randSource     = rand.New(rand.NewSource(time.Now().UnixNano()))
+	randSourceMutex sync.Mutex
+
+	modelCreditsActive sync.Map // "authID|model" → time.Time (credits activation expiry)
+	modelCooldowns     sync.Map // "authID|model" → time.Time (model cooldown expiry)
 )
 
 // AntigravityExecutor proxies requests to the antigravity upstream.
@@ -275,47 +236,28 @@ func injectEnabledCreditTypes(payload []byte) []byte {
 	return updated
 }
 
-func classifyAntigravity429(body []byte) antigravity429Category {
-	switch decideAntigravity429(body).kind {
-	case antigravity429DecisionInstantRetrySameAuth, antigravity429DecisionShortCooldownSwitchAuth:
-		return antigravity429RateLimited
-	case antigravity429DecisionFullQuotaExhausted:
-		return antigravity429QuotaExhausted
-	case antigravity429DecisionSoftRetry:
-		return antigravity429SoftRateLimit
-	default:
-		return antigravity429Unknown
-	}
-}
-
-func decideAntigravity429(body []byte) antigravity429Decision {
-	decision := antigravity429Decision{kind: antigravity429DecisionSoftRetry}
+func classifyAntigravity429Rule(body []byte) antigravity429Rule {
 	if len(body) == 0 {
-		return decision
-	}
-
-	if retryAfter, parseErr := parseRetryDelay(body); parseErr == nil && retryAfter != nil {
-		decision.retryAfter = retryAfter
-	}
-
-	lowerBody := strings.ToLower(string(body))
-	for _, keyword := range antigravityQuotaExhaustedKeywords {
-		if strings.Contains(lowerBody, keyword) {
-			decision.kind = antigravity429DecisionFullQuotaExhausted
-			decision.reason = "quota_exhausted"
-			return decision
-		}
+		return antigravity429RuleNone
 	}
 
 	status := strings.TrimSpace(gjson.GetBytes(body, "error.status").String())
-	if !strings.EqualFold(status, "RESOURCE_EXHAUSTED") {
-		return decision
+	isResourceExhausted := strings.EqualFold(status, "RESOURCE_EXHAUSTED")
+
+	if isResourceExhausted {
+		message := gjson.GetBytes(body, "error.message").String()
+		if strings.Contains(message, "e.g.") {
+			return antigravity429Rule1Permanent
+		}
+	}
+
+	if !isResourceExhausted {
+		return antigravity429RuleNone
 	}
 
 	details := gjson.GetBytes(body, "error.details")
 	if !details.Exists() || !details.IsArray() {
-		decision.kind = antigravity429DecisionSoftRetry
-		return decision
+		return antigravity429RuleNone
 	}
 
 	for _, detail := range details.Array() {
@@ -323,218 +265,115 @@ func decideAntigravity429(body []byte) antigravity429Decision {
 			continue
 		}
 		reason := strings.TrimSpace(detail.Get("reason").String())
-		decision.reason = reason
-		switch {
-		case strings.EqualFold(reason, "QUOTA_EXHAUSTED"):
-			decision.kind = antigravity429DecisionFullQuotaExhausted
-			return decision
-		case strings.EqualFold(reason, "RATE_LIMIT_EXCEEDED"):
-			if decision.retryAfter == nil {
-				decision.kind = antigravity429DecisionSoftRetry
-				return decision
-			}
-			switch {
-			case *decision.retryAfter < antigravityInstantRetryThreshold:
-				decision.kind = antigravity429DecisionInstantRetrySameAuth
-			case *decision.retryAfter < antigravityShortQuotaCooldownThreshold:
-				decision.kind = antigravity429DecisionShortCooldownSwitchAuth
-			default:
-				decision.kind = antigravity429DecisionFullQuotaExhausted
-			}
-			return decision
+		model := strings.TrimSpace(detail.Get("metadata.model").String())
+
+		if strings.EqualFold(reason, "QUOTA_EXHAUSTED") && model != "" {
+			return antigravity429Rule2QuotaModel
+		}
+		if strings.EqualFold(reason, "RATE_LIMIT_EXCEEDED") && model != "" {
+			return antigravity429Rule3RateLimit
 		}
 	}
 
-	decision.kind = antigravity429DecisionSoftRetry
-	return decision
-}
-
-func antigravityHasQuotaResetDelayOrModelInfo(body []byte) bool {
-	if len(body) == 0 {
-		return false
-	}
-	details := gjson.GetBytes(body, "error.details")
-	if !details.Exists() || !details.IsArray() {
-		return false
-	}
-	for _, detail := range details.Array() {
-		if detail.Get("@type").String() != "type.googleapis.com/google.rpc.ErrorInfo" {
-			continue
-		}
-		if strings.TrimSpace(detail.Get("metadata.quotaResetDelay").String()) != "" {
-			return true
-		}
-		if strings.TrimSpace(detail.Get("metadata.model").String()) != "" {
-			return true
-		}
-	}
-	return false
+	return antigravity429RuleNone
 }
 
 func antigravityCreditsRetryEnabled(cfg *config.Config) bool {
-	return cfg != nil && cfg.QuotaExceeded.AntigravityCredits
-}
-
-func antigravityCreditsFailureStateForAuth(auth *cliproxyauth.Auth) (string, antigravityCreditsFailureState, bool) {
-	if auth == nil || strings.TrimSpace(auth.ID) == "" {
-		return "", antigravityCreditsFailureState{}, false
-	}
-	authID := strings.TrimSpace(auth.ID)
-	value, ok := antigravityCreditsFailureByAuth.Load(authID)
-	if !ok {
-		return authID, antigravityCreditsFailureState{}, true
-	}
-	state, ok := value.(antigravityCreditsFailureState)
-	if !ok {
-		antigravityCreditsFailureByAuth.Delete(authID)
-		return authID, antigravityCreditsFailureState{}, true
-	}
-	return authID, state, true
-}
-
-func antigravityCreditsDisabled(auth *cliproxyauth.Auth, now time.Time) bool {
-	authID, state, ok := antigravityCreditsFailureStateForAuth(auth)
-	if !ok {
-		return false
-	}
-	if state.PermanentlyDisabled {
+	if cfg == nil {
 		return true
 	}
-	if state.DisabledUntil.IsZero() {
-		return false
-	}
-	if state.DisabledUntil.After(now) {
-		return true
-	}
-	antigravityCreditsFailureByAuth.Delete(authID)
-	return false
+	return cfg.IsCreditsEnabled()
 }
 
-func recordAntigravityCreditsFailure(auth *cliproxyauth.Auth, now time.Time) {
-	authID, state, ok := antigravityCreditsFailureStateForAuth(auth)
-	if !ok {
-		return
-	}
-	if state.PermanentlyDisabled {
-		antigravityCreditsFailureByAuth.Store(authID, state)
-		return
-	}
-	state.Count++
-	state.DisabledUntil = now.Add(antigravityCreditsAutoDisableDuration)
-	antigravityCreditsFailureByAuth.Store(authID, state)
-}
-
-func clearAntigravityCreditsFailureState(auth *cliproxyauth.Auth) {
-	if auth == nil || strings.TrimSpace(auth.ID) == "" {
-		return
-	}
-	antigravityCreditsFailureByAuth.Delete(strings.TrimSpace(auth.ID))
-}
-func markAntigravityCreditsPermanentlyDisabled(auth *cliproxyauth.Auth) {
-	if auth == nil || strings.TrimSpace(auth.ID) == "" {
-		return
-	}
-	authID := strings.TrimSpace(auth.ID)
-	state := antigravityCreditsFailureState{
-		PermanentlyDisabled:      true,
-		ExplicitBalanceExhausted: true,
-	}
-	antigravityCreditsFailureByAuth.Store(authID, state)
-}
-
-func antigravityHasExplicitCreditsBalanceExhaustedReason(body []byte) bool {
-	if len(body) == 0 {
-		return false
-	}
-	details := gjson.GetBytes(body, "error.details")
-	if !details.Exists() || !details.IsArray() {
-		return false
-	}
-	for _, detail := range details.Array() {
-		if detail.Get("@type").String() != "type.googleapis.com/google.rpc.ErrorInfo" {
-			continue
-		}
-		reason := strings.TrimSpace(detail.Get("reason").String())
-		if strings.EqualFold(reason, "INSUFFICIENT_G1_CREDITS_BALANCE") {
-			return true
-		}
-	}
-	return false
-}
-
-func antigravityPreferCreditsKey(auth *cliproxyauth.Auth, modelName string) string {
+func modelCreditsKey(auth *cliproxyauth.Auth, model string) string {
 	if auth == nil {
 		return ""
 	}
-	authID := strings.TrimSpace(auth.ID)
-	modelName = strings.TrimSpace(modelName)
-	if authID == "" || modelName == "" {
+	id := strings.TrimSpace(auth.ID)
+	model = strings.TrimSpace(model)
+	if id == "" || model == "" {
 		return ""
 	}
-	return authID + "|" + modelName
+	return id + "|" + model
 }
 
-func antigravityShouldPreferCredits(auth *cliproxyauth.Auth, modelName string, now time.Time) bool {
-	key := antigravityPreferCreditsKey(auth, modelName)
+func isModelCreditsActive(auth *cliproxyauth.Auth, model string, now time.Time) bool {
+	key := modelCreditsKey(auth, model)
 	if key == "" {
 		return false
 	}
-	value, ok := antigravityPreferCreditsByModel.Load(key)
+	val, ok := modelCreditsActive.Load(key)
 	if !ok {
 		return false
 	}
-	until, ok := value.(time.Time)
-	if !ok || until.IsZero() {
-		antigravityPreferCreditsByModel.Delete(key)
-		return false
-	}
-	if !until.After(now) {
-		antigravityPreferCreditsByModel.Delete(key)
+	expiry, ok := val.(time.Time)
+	if !ok || expiry.IsZero() || !expiry.After(now) {
+		modelCreditsActive.Delete(key)
 		return false
 	}
 	return true
 }
 
-func markAntigravityPreferCredits(auth *cliproxyauth.Auth, modelName string, now time.Time, retryAfter *time.Duration) {
-	key := antigravityPreferCreditsKey(auth, modelName)
+func markModelCreditsActive(auth *cliproxyauth.Auth, model string, now time.Time) {
+	key := modelCreditsKey(auth, model)
 	if key == "" {
 		return
 	}
-	until := now.Add(antigravityCreditsRetryTTL)
-	if retryAfter != nil && *retryAfter > 0 {
-		until = now.Add(*retryAfter)
-	}
-	antigravityPreferCreditsByModel.Store(key, until)
+	modelCreditsActive.Store(key, now.Add(creditsDuration))
 }
 
-func clearAntigravityPreferCredits(auth *cliproxyauth.Auth, modelName string) {
-	key := antigravityPreferCreditsKey(auth, modelName)
+func clearModelCreditsActive(auth *cliproxyauth.Auth, model string) {
+	key := modelCreditsKey(auth, model)
 	if key == "" {
 		return
 	}
-	antigravityPreferCreditsByModel.Delete(key)
+	modelCreditsActive.Delete(key)
 }
 
-func shouldMarkAntigravityCreditsExhausted(statusCode int, body []byte, reqErr error) bool {
-	if reqErr != nil || statusCode == 0 {
-		return false
+func isModelInCooldown(auth *cliproxyauth.Auth, model string, now time.Time) (bool, time.Duration) {
+	key := modelCreditsKey(auth, model)
+	if key == "" {
+		return false, 0
 	}
-	if statusCode >= http.StatusInternalServerError || statusCode == http.StatusRequestTimeout {
-		return false
+	val, ok := modelCooldowns.Load(key)
+	if !ok {
+		return false, 0
 	}
-	lowerBody := strings.ToLower(string(body))
-	for _, keyword := range antigravityCreditsExhaustedKeywords {
-		if strings.Contains(lowerBody, keyword) {
-			if keyword == "resource has been exhausted" &&
-				statusCode == http.StatusTooManyRequests &&
-				decideAntigravity429(body).kind == antigravity429DecisionSoftRetry &&
-				!antigravityHasQuotaResetDelayOrModelInfo(body) {
-				return false
-			}
-			return true
+	expiry, ok := val.(time.Time)
+	if !ok || expiry.IsZero() || !expiry.After(now) {
+		modelCooldowns.Delete(key)
+		return false, 0
+	}
+	return true, expiry.Sub(now)
+}
+
+func markModelCooldown(auth *cliproxyauth.Auth, model string, now time.Time) {
+	key := modelCreditsKey(auth, model)
+	if key == "" {
+		return
+	}
+	modelCooldowns.Store(key, now.Add(modelCooldownDuration))
+}
+
+// ClearAntigravityAuthState removes all executor-level state for a given auth ID.
+func ClearAntigravityAuthState(authID string) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return
+	}
+	prefix := authID + "|"
+	modelCreditsActive.Range(func(key, _ any) bool {
+		if k, ok := key.(string); ok && strings.HasPrefix(k, prefix) {
+			modelCreditsActive.Delete(key)
 		}
-	}
-	return false
+		return true
+	})
+	modelCooldowns.Range(func(key, _ any) bool {
+		if k, ok := key.(string); ok && strings.HasPrefix(k, prefix) {
+			modelCooldowns.Delete(key)
+		}
+		return true
+	})
 }
 
 func newAntigravityStatusErr(statusCode int, body []byte) statusErr {
@@ -557,30 +396,18 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 	stream bool,
 	alt string,
 	baseURL string,
-	originalBody []byte,
 ) (*http.Response, bool) {
 	if !antigravityCreditsRetryEnabled(e.cfg) {
 		return nil, false
 	}
-	if decideAntigravity429(originalBody).kind != antigravity429DecisionFullQuotaExhausted {
-		return nil, false
-	}
 	now := time.Now()
-	if shouldForcePermanentDisableCredits(originalBody) {
-		clearAntigravityPreferCredits(auth, modelName)
-		markAntigravityCreditsPermanentlyDisabled(auth)
+
+	if isModelCreditsActive(auth, modelName, now) {
+		clearModelCreditsActive(auth, modelName)
+		markModelCooldown(auth, modelName, now)
 		return nil, false
 	}
 
-	if antigravityHasExplicitCreditsBalanceExhaustedReason(originalBody) {
-		clearAntigravityPreferCredits(auth, modelName)
-		markAntigravityCreditsPermanentlyDisabled(auth)
-		return nil, false
-	}
-
-	if antigravityCreditsDisabled(auth, now) {
-		return nil, false
-	}
 	creditsPayload := injectEnabledCreditTypes(payload)
 	if len(creditsPayload) == 0 {
 		return nil, false
@@ -589,85 +416,25 @@ func (e *AntigravityExecutor) attemptCreditsFallback(
 	httpReq, errReq := e.buildRequest(ctx, auth, token, modelName, creditsPayload, stream, alt, baseURL)
 	if errReq != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errReq)
-		clearAntigravityPreferCredits(auth, modelName)
-		recordAntigravityCreditsFailure(auth, now)
+		markModelCooldown(auth, modelName, now)
 		return nil, true
 	}
 	httpResp, errDo := httpClient.Do(httpReq)
 	if errDo != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-		clearAntigravityPreferCredits(auth, modelName)
-		recordAntigravityCreditsFailure(auth, now)
+		markModelCooldown(auth, modelName, now)
 		return nil, true
 	}
 	if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
-		retryAfter, _ := parseRetryDelay(originalBody)
-		markAntigravityPreferCredits(auth, modelName, now, retryAfter)
-		clearAntigravityCreditsFailureState(auth)
+		markModelCreditsActive(auth, modelName, now)
 		return httpResp, true
 	}
 
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-	bodyBytes, errRead := io.ReadAll(httpResp.Body)
-	if errClose := httpResp.Body.Close(); errClose != nil {
-		log.Errorf("antigravity executor: close credits fallback response body error: %v", errClose)
-	}
-	if errRead != nil {
-		helps.RecordAPIResponseError(ctx, e.cfg, errRead)
-		clearAntigravityPreferCredits(auth, modelName)
-		recordAntigravityCreditsFailure(auth, now)
-		return nil, true
-	}
-	helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
-	if shouldForcePermanentDisableCredits(bodyBytes) {
-		clearAntigravityPreferCredits(auth, modelName)
-		markAntigravityCreditsPermanentlyDisabled(auth)
-		return nil, true
-	}
-
-	if antigravityHasExplicitCreditsBalanceExhaustedReason(bodyBytes) {
-		clearAntigravityPreferCredits(auth, modelName)
-		markAntigravityCreditsPermanentlyDisabled(auth)
-		return nil, true
-	}
-
-	clearAntigravityPreferCredits(auth, modelName)
-	recordAntigravityCreditsFailure(auth, now)
+	_, _ = io.ReadAll(httpResp.Body)
+	_ = httpResp.Body.Close()
+	markModelCooldown(auth, modelName, now)
 	return nil, true
-}
-
-func (e *AntigravityExecutor) handleDirectCreditsFailure(ctx context.Context, auth *cliproxyauth.Auth, modelName string, reqErr error) {
-	if reqErr != nil {
-		if shouldForcePermanentDisableCredits(reqErrBody(reqErr)) {
-			clearAntigravityPreferCredits(auth, modelName)
-			markAntigravityCreditsPermanentlyDisabled(auth)
-			return
-		}
-
-		if antigravityHasExplicitCreditsBalanceExhaustedReason(reqErrBody(reqErr)) {
-			clearAntigravityPreferCredits(auth, modelName)
-			markAntigravityCreditsPermanentlyDisabled(auth)
-			return
-		}
-
-		helps.RecordAPIResponseError(ctx, e.cfg, reqErr)
-	}
-	clearAntigravityPreferCredits(auth, modelName)
-	recordAntigravityCreditsFailure(auth, time.Now())
-}
-func reqErrBody(reqErr error) []byte {
-	if reqErr == nil {
-		return nil
-	}
-	msg := reqErr.Error()
-	if strings.TrimSpace(msg) == "" {
-		return nil
-	}
-	return []byte(msg)
-}
-
-func shouldForcePermanentDisableCredits(body []byte) bool {
-	return antigravityHasExplicitCreditsBalanceExhaustedReason(body)
 }
 
 // Execute performs a non-streaming request to the Antigravity API.
@@ -676,10 +443,10 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
-	if inCooldown, remaining := antigravityIsInShortCooldown(auth, baseModel, time.Now()); inCooldown {
-		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
+	if inCooldown, remaining := isModelInCooldown(auth, baseModel, time.Now()); inCooldown {
+		log.Debugf("antigravity executor: auth %s in cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
-		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in cooldown, %s remaining", remaining), retryAfter: &d}
 	}
 
 	isClaude := strings.Contains(strings.ToLower(baseModel), "claude")
@@ -725,7 +492,6 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 	attempts := antigravityRetryAttempts(auth, e.cfg)
 
-attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {
 		var lastStatus int
 		var lastBody []byte
@@ -734,7 +500,7 @@ attemptLoop:
 		for idx, baseURL := range baseURLs {
 			requestPayload := translated
 			usedCreditsDirect := false
-			if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
+			if antigravityCreditsRetryEnabled(e.cfg) && isModelCreditsActive(auth, baseModel, time.Now()) {
 				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
 					requestPayload = creditsPayload
 					usedCreditsDirect = true
@@ -777,31 +543,18 @@ attemptLoop:
 			helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
 
 			if httpResp.StatusCode == http.StatusTooManyRequests {
-				decision := decideAntigravity429(bodyBytes)
-				switch decision.kind {
-				case antigravity429DecisionInstantRetrySameAuth:
-					if attempt+1 < attempts {
-						if decision.retryAfter != nil && *decision.retryAfter > 0 {
-							wait := antigravityInstantRetryDelay(*decision.retryAfter)
-							log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, wait)
-							if errWait := antigravityWait(ctx, wait); errWait != nil {
-
-								return resp, errWait
-							}
-						}
-						continue attemptLoop
-					}
-				case antigravity429DecisionShortCooldownSwitchAuth:
-					if decision.retryAfter != nil && *decision.retryAfter > 0 {
-						markAntigravityShortCooldown(auth, baseModel, time.Now(), *decision.retryAfter)
-						log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown and skipping credits fallback", *decision.retryAfter, baseModel)
-					}
-				case antigravity429DecisionFullQuotaExhausted:
+				rule := classifyAntigravity429Rule(bodyBytes)
+				switch rule {
+				case antigravity429Rule1Permanent:
+					auth.QuotaExhaustedPermanent = true
+					err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
+					return resp, err
+				case antigravity429Rule2QuotaModel:
 					if usedCreditsDirect {
-						clearAntigravityPreferCredits(auth, baseModel)
-						recordAntigravityCreditsFailure(auth, time.Now())
+						clearModelCreditsActive(auth, baseModel)
+						markModelCooldown(auth, baseModel, time.Now())
 					} else {
-						creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, false, opts.Alt, baseURL, bodyBytes)
+						creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, false, opts.Alt, baseURL)
 						if creditsResp != nil {
 							helps.RecordAPIResponseMetadata(ctx, e.cfg, creditsResp.StatusCode, creditsResp.Header.Clone())
 							creditsBody, errCreditsRead := io.ReadAll(creditsResp.Body)
@@ -821,8 +574,36 @@ attemptLoop:
 							reporter.EnsurePublished(ctx)
 							return resp, nil
 						}
+						markModelCooldown(auth, baseModel, time.Now())
+					}
+					err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
+					return resp, err
+				case antigravity429Rule3RateLimit:
+					err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
+					return resp, err
+				default:
+					err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
+					return resp, err
+				}
+			}
+
+			if httpResp.StatusCode == http.StatusUnauthorized {
+				auth.QuotaExhaustedPermanent = true
+				err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
+				return resp, err
+			}
+
+			if httpResp.StatusCode == http.StatusServiceUnavailable {
+				if antigravityShouldRetryNoCapacity(httpResp.StatusCode, bodyBytes) {
+					if idx+1 < len(baseURLs) {
+						continue
 					}
 				}
+				if errWait := antigravityWait(ctx, 1*time.Second); errWait != nil {
+					return resp, errWait
+				}
+				err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
+				return resp, err
 			}
 
 			if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
@@ -830,41 +611,8 @@ attemptLoop:
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
-				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+				if idx+1 < len(baseURLs) {
 					continue
-				}
-				if antigravityShouldRetryTransientResourceExhausted429(httpResp.StatusCode, bodyBytes) && attempt+1 < attempts {
-					delay := antigravityTransient429RetryDelay(attempt)
-					log.Debugf("antigravity executor: transient 429 resource exhausted for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
-					if errWait := antigravityWait(ctx, delay); errWait != nil {
-						return resp, errWait
-					}
-					continue attemptLoop
-				}
-				if antigravityShouldRetryNoCapacity(httpResp.StatusCode, bodyBytes) {
-					if idx+1 < len(baseURLs) {
-						log.Debugf("antigravity executor: no capacity on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-						continue
-					}
-					if attempt+1 < attempts {
-						delay := antigravityNoCapacityRetryDelay(attempt)
-						log.Debugf("antigravity executor: no capacity for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
-						if errWait := antigravityWait(ctx, delay); errWait != nil {
-							return resp, errWait
-						}
-						continue attemptLoop
-					}
-				}
-				if antigravityShouldRetrySoftRateLimit(httpResp.StatusCode, bodyBytes) {
-					if attempt+1 < attempts {
-						delay := antigravitySoftRateLimitDelay(attempt)
-						log.Debugf("antigravity executor: soft rate limit for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
-						if errWait := antigravityWait(ctx, delay); errWait != nil {
-							return resp, errWait
-						}
-						continue attemptLoop
-					}
 				}
 				err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
 				return resp, err
@@ -895,10 +643,10 @@ attemptLoop:
 // executeClaudeNonStream performs a claude non-streaming request to the Antigravity API.
 func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
-	if inCooldown, remaining := antigravityIsInShortCooldown(auth, baseModel, time.Now()); inCooldown {
-		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
+	if inCooldown, remaining := isModelInCooldown(auth, baseModel, time.Now()); inCooldown {
+		log.Debugf("antigravity executor: auth %s in cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
-		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in cooldown, %s remaining", remaining), retryAfter: &d}
 	}
 
 	reporter := helps.NewUsageReporter(ctx, e.Identifier(), baseModel, auth)
@@ -940,7 +688,6 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 
 	attempts := antigravityRetryAttempts(auth, e.cfg)
 
-attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {
 		var lastStatus int
 		var lastBody []byte
@@ -949,7 +696,7 @@ attemptLoop:
 		for idx, baseURL := range baseURLs {
 			requestPayload := translated
 			usedCreditsDirect := false
-			if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
+			if antigravityCreditsRetryEnabled(e.cfg) && isModelCreditsActive(auth, baseModel, time.Now()) {
 				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
 					requestPayload = creditsPayload
 					usedCreditsDirect = true
@@ -1005,81 +752,56 @@ attemptLoop:
 				}
 				helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
 				if httpResp.StatusCode == http.StatusTooManyRequests {
-					decision := decideAntigravity429(bodyBytes)
-
-					switch decision.kind {
-					case antigravity429DecisionInstantRetrySameAuth:
-						if attempt+1 < attempts {
-							if decision.retryAfter != nil && *decision.retryAfter > 0 {
-								wait := antigravityInstantRetryDelay(*decision.retryAfter)
-								log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, wait)
-								if errWait := antigravityWait(ctx, wait); errWait != nil {
-
-									return resp, errWait
-								}
-							}
-							continue attemptLoop
-						}
-					case antigravity429DecisionShortCooldownSwitchAuth:
-						if decision.retryAfter != nil && *decision.retryAfter > 0 {
-							markAntigravityShortCooldown(auth, baseModel, time.Now(), *decision.retryAfter)
-							log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown and skipping credits fallback", *decision.retryAfter, baseModel)
-						}
-					case antigravity429DecisionFullQuotaExhausted:
+					rule := classifyAntigravity429Rule(bodyBytes)
+					switch rule {
+					case antigravity429Rule1Permanent:
+						auth.QuotaExhaustedPermanent = true
+						err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
+						return resp, err
+					case antigravity429Rule2QuotaModel:
 						if usedCreditsDirect {
-							clearAntigravityPreferCredits(auth, baseModel)
-							recordAntigravityCreditsFailure(auth, time.Now())
+							clearModelCreditsActive(auth, baseModel)
+							markModelCooldown(auth, baseModel, time.Now())
 						} else {
-							creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
+							creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL)
 							if creditsResp != nil {
 								httpResp = creditsResp
 								helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+							} else {
+								markModelCooldown(auth, baseModel, time.Now())
 							}
 						}
+					case antigravity429Rule3RateLimit:
+						// just rotate
+					default:
+						// fallback: just rotate
 					}
+				}
+
+				if httpResp.StatusCode == http.StatusUnauthorized {
+					auth.QuotaExhaustedPermanent = true
+					err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
+					return resp, err
 				}
 
 				if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
 					goto streamSuccessClaudeNonStream
 				}
+
+				if httpResp.StatusCode == http.StatusServiceUnavailable {
+					if antigravityShouldRetryNoCapacity(httpResp.StatusCode, bodyBytes) && idx+1 < len(baseURLs) {
+						continue
+					}
+					if errWait := antigravityWait(ctx, 1*time.Second); errWait != nil {
+						return resp, errWait
+					}
+				}
+
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
-				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+				if idx+1 < len(baseURLs) {
 					continue
-				}
-				if antigravityShouldRetryTransientResourceExhausted429(httpResp.StatusCode, bodyBytes) && attempt+1 < attempts {
-					delay := antigravityTransient429RetryDelay(attempt)
-					log.Debugf("antigravity executor: transient 429 resource exhausted for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
-					if errWait := antigravityWait(ctx, delay); errWait != nil {
-						return resp, errWait
-					}
-					continue attemptLoop
-				}
-				if antigravityShouldRetryNoCapacity(httpResp.StatusCode, bodyBytes) {
-					if idx+1 < len(baseURLs) {
-						log.Debugf("antigravity executor: no capacity on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-						continue
-					}
-					if attempt+1 < attempts {
-						delay := antigravityNoCapacityRetryDelay(attempt)
-						log.Debugf("antigravity executor: no capacity for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
-						if errWait := antigravityWait(ctx, delay); errWait != nil {
-							return resp, errWait
-						}
-						continue attemptLoop
-					}
-				}
-				if antigravityShouldRetrySoftRateLimit(httpResp.StatusCode, bodyBytes) {
-					if attempt+1 < attempts {
-						delay := antigravitySoftRateLimitDelay(attempt)
-						log.Debugf("antigravity executor: soft rate limit for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
-						if errWait := antigravityWait(ctx, delay); errWait != nil {
-							return resp, errWait
-						}
-						continue attemptLoop
-					}
 				}
 				err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
 				return resp, err
@@ -1360,10 +1082,10 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
 	ctx = context.WithValue(ctx, "alt", "")
-	if inCooldown, remaining := antigravityIsInShortCooldown(auth, baseModel, time.Now()); inCooldown {
-		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
+	if inCooldown, remaining := isModelInCooldown(auth, baseModel, time.Now()); inCooldown {
+		log.Debugf("antigravity executor: auth %s in cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
-		return nil, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+		return nil, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in cooldown, %s remaining", remaining), retryAfter: &d}
 	}
 
 	reporter := helps.NewUsageReporter(ctx, e.Identifier(), baseModel, auth)
@@ -1405,7 +1127,6 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 
 	attempts := antigravityRetryAttempts(auth, e.cfg)
 
-attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {
 		var lastStatus int
 		var lastBody []byte
@@ -1414,7 +1135,7 @@ attemptLoop:
 		for idx, baseURL := range baseURLs {
 			requestPayload := translated
 			usedCreditsDirect := false
-			if antigravityCreditsRetryEnabled(e.cfg) && antigravityShouldPreferCredits(auth, baseModel, time.Now()) {
+			if antigravityCreditsRetryEnabled(e.cfg) && isModelCreditsActive(auth, baseModel, time.Now()) {
 				if creditsPayload := injectEnabledCreditTypes(translated); len(creditsPayload) > 0 {
 					requestPayload = creditsPayload
 					usedCreditsDirect = true
@@ -1469,81 +1190,56 @@ attemptLoop:
 				}
 				helps.AppendAPIResponseChunk(ctx, e.cfg, bodyBytes)
 				if httpResp.StatusCode == http.StatusTooManyRequests {
-					decision := decideAntigravity429(bodyBytes)
-
-					switch decision.kind {
-					case antigravity429DecisionInstantRetrySameAuth:
-						if attempt+1 < attempts {
-							if decision.retryAfter != nil && *decision.retryAfter > 0 {
-								wait := antigravityInstantRetryDelay(*decision.retryAfter)
-								log.Debugf("antigravity executor: instant retry for model %s, waiting %s", baseModel, wait)
-								if errWait := antigravityWait(ctx, wait); errWait != nil {
-
-									return nil, errWait
-								}
-							}
-							continue attemptLoop
-						}
-					case antigravity429DecisionShortCooldownSwitchAuth:
-						if decision.retryAfter != nil && *decision.retryAfter > 0 {
-							markAntigravityShortCooldown(auth, baseModel, time.Now(), *decision.retryAfter)
-							log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown and skipping credits fallback", *decision.retryAfter, baseModel)
-						}
-					case antigravity429DecisionFullQuotaExhausted:
+					rule := classifyAntigravity429Rule(bodyBytes)
+					switch rule {
+					case antigravity429Rule1Permanent:
+						auth.QuotaExhaustedPermanent = true
+						err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
+						return nil, err
+					case antigravity429Rule2QuotaModel:
 						if usedCreditsDirect {
-							clearAntigravityPreferCredits(auth, baseModel)
-							recordAntigravityCreditsFailure(auth, time.Now())
+							clearModelCreditsActive(auth, baseModel)
+							markModelCooldown(auth, baseModel, time.Now())
 						} else {
-							creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL, bodyBytes)
+							creditsResp, _ := e.attemptCreditsFallback(ctx, auth, httpClient, token, baseModel, translated, true, opts.Alt, baseURL)
 							if creditsResp != nil {
 								httpResp = creditsResp
 								helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+							} else {
+								markModelCooldown(auth, baseModel, time.Now())
 							}
 						}
+					case antigravity429Rule3RateLimit:
+						// just rotate
+					default:
+						// fallback: just rotate
 					}
+				}
+
+				if httpResp.StatusCode == http.StatusUnauthorized {
+					auth.QuotaExhaustedPermanent = true
+					err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
+					return nil, err
 				}
 
 				if httpResp.StatusCode >= http.StatusOK && httpResp.StatusCode < http.StatusMultipleChoices {
 					goto streamSuccessExecuteStream
 				}
+
+				if httpResp.StatusCode == http.StatusServiceUnavailable {
+					if antigravityShouldRetryNoCapacity(httpResp.StatusCode, bodyBytes) && idx+1 < len(baseURLs) {
+						continue
+					}
+					if errWait := antigravityWait(ctx, 1*time.Second); errWait != nil {
+						return nil, errWait
+					}
+				}
+
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
-				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+				if idx+1 < len(baseURLs) {
 					continue
-				}
-				if antigravityShouldRetryTransientResourceExhausted429(httpResp.StatusCode, bodyBytes) && attempt+1 < attempts {
-					delay := antigravityTransient429RetryDelay(attempt)
-					log.Debugf("antigravity executor: transient 429 resource exhausted for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
-					if errWait := antigravityWait(ctx, delay); errWait != nil {
-						return nil, errWait
-					}
-					continue attemptLoop
-				}
-				if antigravityShouldRetryNoCapacity(httpResp.StatusCode, bodyBytes) {
-					if idx+1 < len(baseURLs) {
-						log.Debugf("antigravity executor: no capacity on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-						continue
-					}
-					if attempt+1 < attempts {
-						delay := antigravityNoCapacityRetryDelay(attempt)
-						log.Debugf("antigravity executor: no capacity for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
-						if errWait := antigravityWait(ctx, delay); errWait != nil {
-							return nil, errWait
-						}
-						continue attemptLoop
-					}
-				}
-				if antigravityShouldRetrySoftRateLimit(httpResp.StatusCode, bodyBytes) {
-					if attempt+1 < attempts {
-						delay := antigravitySoftRateLimitDelay(attempt)
-						log.Debugf("antigravity executor: soft rate limit for model %s, retrying in %s (attempt %d/%d)", baseModel, delay, attempt+1, attempts)
-						if errWait := antigravityWait(ctx, delay); errWait != nil {
-							return nil, errWait
-						}
-						continue attemptLoop
-					}
 				}
 				err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
 				return nil, err
@@ -2195,84 +1891,6 @@ func antigravityShouldRetryNoCapacity(statusCode int, body []byte) bool {
 	return strings.Contains(msg, "no capacity available")
 }
 
-func antigravityShouldRetryTransientResourceExhausted429(statusCode int, body []byte) bool {
-	if statusCode != http.StatusTooManyRequests {
-		return false
-	}
-	if len(body) == 0 {
-		return false
-	}
-	if classifyAntigravity429(body) != antigravity429Unknown {
-		return false
-	}
-	status := strings.TrimSpace(gjson.GetBytes(body, "error.status").String())
-	if !strings.EqualFold(status, "RESOURCE_EXHAUSTED") {
-		return false
-	}
-	msg := strings.ToLower(string(body))
-	return strings.Contains(msg, "resource has been exhausted")
-}
-
-func antigravityShouldRetrySoftRateLimit(statusCode int, body []byte) bool {
-	if statusCode != http.StatusTooManyRequests {
-		return false
-	}
-	return decideAntigravity429(body).kind == antigravity429DecisionSoftRetry
-}
-
-func antigravitySoftRateLimitDelay(attempt int) time.Duration {
-	if attempt < 0 {
-		attempt = 0
-	}
-	base := time.Duration(attempt+1) * 500 * time.Millisecond
-	if base > 3*time.Second {
-		base = 3 * time.Second
-	}
-	return base
-}
-
-func antigravityShortCooldownKey(auth *cliproxyauth.Auth, modelName string) string {
-	if auth == nil {
-		return ""
-	}
-	authID := strings.TrimSpace(auth.ID)
-	modelName = strings.TrimSpace(modelName)
-	if authID == "" || modelName == "" {
-		return ""
-	}
-	return authID + "|" + modelName + "|sc"
-}
-
-func antigravityIsInShortCooldown(auth *cliproxyauth.Auth, modelName string, now time.Time) (bool, time.Duration) {
-	key := antigravityShortCooldownKey(auth, modelName)
-	if key == "" {
-		return false, 0
-	}
-	value, ok := antigravityShortCooldownByAuth.Load(key)
-	if !ok {
-		return false, 0
-	}
-	until, ok := value.(time.Time)
-	if !ok || until.IsZero() {
-		antigravityShortCooldownByAuth.Delete(key)
-		return false, 0
-	}
-	remaining := until.Sub(now)
-	if remaining <= 0 {
-		antigravityShortCooldownByAuth.Delete(key)
-		return false, 0
-	}
-	return true, remaining
-}
-
-func markAntigravityShortCooldown(auth *cliproxyauth.Auth, modelName string, now time.Time, duration time.Duration) {
-	key := antigravityShortCooldownKey(auth, modelName)
-	if key == "" {
-		return
-	}
-	antigravityShortCooldownByAuth.Store(key, now.Add(duration))
-}
-
 func antigravityNoCapacityRetryDelay(attempt int) time.Duration {
 	if attempt < 0 {
 		attempt = 0
@@ -2282,24 +1900,6 @@ func antigravityNoCapacityRetryDelay(attempt int) time.Duration {
 		delay = 2 * time.Second
 	}
 	return delay
-}
-
-func antigravityTransient429RetryDelay(attempt int) time.Duration {
-	if attempt < 0 {
-		attempt = 0
-	}
-	delay := time.Duration(attempt+1) * 100 * time.Millisecond
-	if delay > 500*time.Millisecond {
-		delay = 500 * time.Millisecond
-	}
-	return delay
-}
-
-func antigravityInstantRetryDelay(wait time.Duration) time.Duration {
-	if wait <= 0 {
-		return 0
-	}
-	return wait + 800*time.Millisecond
 }
 
 func antigravityWait(ctx context.Context, wait time.Duration) error {

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -17,35 +17,34 @@ import (
 )
 
 func resetAntigravityCreditsRetryState() {
-	antigravityCreditsFailureByAuth = sync.Map{}
-	antigravityPreferCreditsByModel = sync.Map{}
-	antigravityShortCooldownByAuth = sync.Map{}
+	modelCreditsActive = sync.Map{}
+	modelCooldowns = sync.Map{}
 }
 
-func TestClassifyAntigravity429(t *testing.T) {
-	t.Run("quota exhausted", func(t *testing.T) {
-		body := []byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"QUOTA_EXHAUSTED"}}`)
-		if got := classifyAntigravity429(body); got != antigravity429QuotaExhausted {
-			t.Fatalf("classifyAntigravity429() = %q, want %q", got, antigravity429QuotaExhausted)
+func TestClassifyAntigravity429Rule(t *testing.T) {
+	t.Run("rule 1: permanent quota exhausted with e.g.", func(t *testing.T) {
+		body := []byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`)
+		if got := classifyAntigravity429Rule(body); got != antigravity429Rule1Permanent {
+			t.Fatalf("classifyAntigravity429Rule() = %d, want %d (Rule1Permanent)", got, antigravity429Rule1Permanent)
 		}
 	})
 
-	t.Run("structured rate limit", func(t *testing.T) {
+	t.Run("rule 2: quota exhausted with model metadata", func(t *testing.T) {
 		body := []byte(`{
 			"error": {
 				"status": "RESOURCE_EXHAUSTED",
+				"message": "You have exhausted your capacity on this model.",
 				"details": [
-					{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "RATE_LIMIT_EXCEEDED"},
-					{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "0.5s"}
+					{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "QUOTA_EXHAUSTED", "metadata": {"model": "gemini-3.1-flash-image"}}
 				]
 			}
 		}`)
-		if got := classifyAntigravity429(body); got != antigravity429RateLimited {
-			t.Fatalf("classifyAntigravity429() = %q, want %q", got, antigravity429RateLimited)
+		if got := classifyAntigravity429Rule(body); got != antigravity429Rule2QuotaModel {
+			t.Fatalf("classifyAntigravity429Rule() = %d, want %d (Rule2QuotaModel)", got, antigravity429Rule2QuotaModel)
 		}
 	})
 
-	t.Run("structured quota exhausted", func(t *testing.T) {
+	t.Run("rule 2: quota exhausted without model metadata falls to none", func(t *testing.T) {
 		body := []byte(`{
 			"error": {
 				"status": "RESOURCE_EXHAUSTED",
@@ -54,15 +53,36 @@ func TestClassifyAntigravity429(t *testing.T) {
 				]
 			}
 		}`)
-		if got := classifyAntigravity429(body); got != antigravity429QuotaExhausted {
-			t.Fatalf("classifyAntigravity429() = %q, want %q", got, antigravity429QuotaExhausted)
+		if got := classifyAntigravity429Rule(body); got != antigravity429RuleNone {
+			t.Fatalf("classifyAntigravity429Rule() = %d, want %d (RuleNone)", got, antigravity429RuleNone)
 		}
 	})
 
-	t.Run("unstructured 429 defaults to soft rate limit", func(t *testing.T) {
+	t.Run("rule 3: rate limit exceeded with model metadata", func(t *testing.T) {
+		body := []byte(`{
+			"error": {
+				"status": "RESOURCE_EXHAUSTED",
+				"details": [
+					{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "0.847655010s"},
+					{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "RATE_LIMIT_EXCEEDED", "metadata": {"model": "claude-opus-4-6"}}
+				]
+			}
+		}`)
+		if got := classifyAntigravity429Rule(body); got != antigravity429Rule3RateLimit {
+			t.Fatalf("classifyAntigravity429Rule() = %d, want %d (Rule3RateLimit)", got, antigravity429Rule3RateLimit)
+		}
+	})
+
+	t.Run("unstructured 429 defaults to none", func(t *testing.T) {
 		body := []byte(`{"error":{"message":"too many requests"}}`)
-		if got := classifyAntigravity429(body); got != antigravity429SoftRateLimit {
-			t.Fatalf("classifyAntigravity429() = %q, want %q", got, antigravity429SoftRateLimit)
+		if got := classifyAntigravity429Rule(body); got != antigravity429RuleNone {
+			t.Fatalf("classifyAntigravity429Rule() = %d, want %d (RuleNone)", got, antigravity429RuleNone)
+		}
+	})
+
+	t.Run("empty body defaults to none", func(t *testing.T) {
+		if got := classifyAntigravity429Rule(nil); got != antigravity429RuleNone {
+			t.Fatalf("classifyAntigravity429Rule(nil) = %d, want %d (RuleNone)", got, antigravity429RuleNone)
 		}
 	})
 }
@@ -82,60 +102,75 @@ func TestInjectEnabledCreditTypes(t *testing.T) {
 	}
 }
 
-func TestShouldMarkAntigravityCreditsExhausted(t *testing.T) {
-	t.Run("credit errors are marked", func(t *testing.T) {
-		for _, body := range [][]byte{
-			[]byte(`{"error":{"message":"Insufficient GOOGLE_ONE_AI credits"}}`),
-			[]byte(`{"error":{"message":"minimumCreditAmountForUsage requirement not met"}}`),
-		} {
-			if !shouldMarkAntigravityCreditsExhausted(http.StatusForbidden, body, nil) {
-				t.Fatalf("shouldMarkAntigravityCreditsExhausted(%s) = false, want true", string(body))
-			}
-		}
-	})
-
-	t.Run("transient 429 resource exhausted is not marked", func(t *testing.T) {
-		body := []byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`)
-		if shouldMarkAntigravityCreditsExhausted(http.StatusTooManyRequests, body, nil) {
-			t.Fatalf("shouldMarkAntigravityCreditsExhausted(%s) = true, want false", string(body))
-		}
-	})
-
-	t.Run("resource exhausted with quota metadata is still marked", func(t *testing.T) {
-		body := []byte(`{"error":{"code":429,"message":"Resource has been exhausted","status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","metadata":{"quotaResetDelay":"1h","model":"claude-sonnet-4-6"}}]}}`)
-		if !shouldMarkAntigravityCreditsExhausted(http.StatusTooManyRequests, body, nil) {
-			t.Fatalf("shouldMarkAntigravityCreditsExhausted(%s) = false, want true", string(body))
-		}
-	})
-
-	if shouldMarkAntigravityCreditsExhausted(http.StatusServiceUnavailable, []byte(`{"error":{"message":"credits exhausted"}}`), nil) {
-		t.Fatal("shouldMarkAntigravityCreditsExhausted() = true for 5xx, want false")
-	}
-}
-
-func TestAntigravityExecute_RetriesTransient429ResourceExhausted(t *testing.T) {
+func TestModelCreditsActiveLifecycle(t *testing.T) {
 	resetAntigravityCreditsRetryState()
 	t.Cleanup(resetAntigravityCreditsRetryState)
 
-	var requestCount int
+	auth := &cliproxyauth.Auth{ID: "test-auth"}
+	model := "gemini-2.5-flash"
+	now := time.Now()
+
+	if isModelCreditsActive(auth, model, now) {
+		t.Fatal("isModelCreditsActive() = true before marking, want false")
+	}
+
+	markModelCreditsActive(auth, model, now)
+	if !isModelCreditsActive(auth, model, now) {
+		t.Fatal("isModelCreditsActive() = false after marking, want true")
+	}
+
+	expired := now.Add(creditsDuration + time.Minute)
+	if isModelCreditsActive(auth, model, expired) {
+		t.Fatal("isModelCreditsActive() = true after expiry, want false")
+	}
+
+	markModelCreditsActive(auth, model, now)
+	clearModelCreditsActive(auth, model)
+	if isModelCreditsActive(auth, model, now) {
+		t.Fatal("isModelCreditsActive() = true after clearing, want false")
+	}
+}
+
+func TestModelCooldownLifecycle(t *testing.T) {
+	resetAntigravityCreditsRetryState()
+	t.Cleanup(resetAntigravityCreditsRetryState)
+
+	auth := &cliproxyauth.Auth{ID: "test-auth"}
+	model := "gemini-2.5-flash"
+	now := time.Now()
+
+	if inCooldown, _ := isModelInCooldown(auth, model, now); inCooldown {
+		t.Fatal("isModelInCooldown() = true before marking, want false")
+	}
+
+	markModelCooldown(auth, model, now)
+	inCooldown, remaining := isModelInCooldown(auth, model, now)
+	if !inCooldown {
+		t.Fatal("isModelInCooldown() = false after marking, want true")
+	}
+	if remaining <= 0 || remaining > modelCooldownDuration {
+		t.Fatalf("remaining = %v, want between 0 and %v", remaining, modelCooldownDuration)
+	}
+
+	expired := now.Add(modelCooldownDuration + time.Minute)
+	if inCooldown, _ := isModelInCooldown(auth, model, expired); inCooldown {
+		t.Fatal("isModelInCooldown() = true after expiry, want false")
+	}
+}
+
+func TestAntigravityExecute_Rule1PermanentBan(t *testing.T) {
+	resetAntigravityCreditsRetryState()
+	t.Cleanup(resetAntigravityCreditsRetryState)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
-		switch requestCount {
-		case 1:
-			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`))
-		case 2:
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}}`))
-		default:
-			t.Fatalf("unexpected request count %d", requestCount)
-		}
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`))
 	}))
 	defer server.Close()
 
-	exec := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+	exec := NewAntigravityExecutor(&config.Config{})
 	auth := &cliproxyauth.Auth{
-		ID: "auth-transient-429",
+		ID: "auth-rule1",
 		Attributes: map[string]string{
 			"base_url": server.URL,
 		},
@@ -146,20 +181,17 @@ func TestAntigravityExecute_RetriesTransient429ResourceExhausted(t *testing.T) {
 		},
 	}
 
-	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "gemini-2.5-flash",
 		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FormatAntigravity,
 	})
-	if err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err == nil {
+		t.Fatal("Execute() error = nil, want error")
 	}
-	if len(resp.Payload) == 0 {
-		t.Fatal("Execute() returned empty payload")
-	}
-	if requestCount != 2 {
-		t.Fatalf("request count = %d, want 2", requestCount)
+	if !auth.QuotaExhaustedPermanent {
+		t.Fatal("auth.QuotaExhaustedPermanent = false, want true")
 	}
 }
 
@@ -183,7 +215,7 @@ func TestAntigravityExecute_RetriesQuotaExhaustedWithCredits(t *testing.T) {
 
 		if reqNum == 1 {
 			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"QUOTA_EXHAUSTED"}}`))
+			_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"You have exhausted your capacity.","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"QUOTA_EXHAUSTED","metadata":{"model":"gemini-2.5-flash"}}]}}`))
 			return
 		}
 
@@ -195,8 +227,9 @@ func TestAntigravityExecute_RetriesQuotaExhaustedWithCredits(t *testing.T) {
 	}))
 	defer server.Close()
 
+	creditsEnabled := true
 	exec := NewAntigravityExecutor(&config.Config{
-		QuotaExceeded: config.QuotaExceeded{AntigravityCredits: true},
+		CreditsEnabled: &creditsEnabled,
 	})
 	auth := &cliproxyauth.Auth{
 		ID: "auth-credits-ok",
@@ -230,55 +263,6 @@ func TestAntigravityExecute_RetriesQuotaExhaustedWithCredits(t *testing.T) {
 	}
 }
 
-func TestAntigravityExecute_SkipsCreditsRetryWhenAlreadyExhausted(t *testing.T) {
-	resetAntigravityCreditsRetryState()
-	t.Cleanup(resetAntigravityCreditsRetryState)
-
-	var requestCount int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
-		w.WriteHeader(http.StatusTooManyRequests)
-		_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"QUOTA_EXHAUSTED"}}`))
-	}))
-	defer server.Close()
-
-	exec := NewAntigravityExecutor(&config.Config{
-		QuotaExceeded: config.QuotaExceeded{AntigravityCredits: true},
-	})
-	auth := &cliproxyauth.Auth{
-		ID: "auth-credits-exhausted",
-		Attributes: map[string]string{
-			"base_url": server.URL,
-		},
-		Metadata: map[string]any{
-			"access_token": "token",
-			"project_id":   "project-1",
-			"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
-		},
-	}
-	recordAntigravityCreditsFailure(auth, time.Now())
-
-	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
-		Model:   "gemini-2.5-flash",
-		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
-	}, cliproxyexecutor.Options{
-		SourceFormat: sdktranslator.FormatAntigravity,
-	})
-	if err == nil {
-		t.Fatal("Execute() error = nil, want 429")
-	}
-	sErr, ok := err.(statusErr)
-	if !ok {
-		t.Fatalf("Execute() error type = %T, want statusErr", err)
-	}
-	if got := sErr.StatusCode(); got != http.StatusTooManyRequests {
-		t.Fatalf("Execute() status code = %d, want %d", got, http.StatusTooManyRequests)
-	}
-	if requestCount != 1 {
-		t.Fatalf("request count = %d, want 1", requestCount)
-	}
-}
-
 func TestAntigravityExecute_PrefersCreditsAfterSuccessfulFallback(t *testing.T) {
 	resetAntigravityCreditsRetryState()
 	t.Cleanup(resetAntigravityCreditsRetryState)
@@ -300,7 +284,7 @@ func TestAntigravityExecute_PrefersCreditsAfterSuccessfulFallback(t *testing.T) 
 		switch reqNum {
 		case 1:
 			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"QUOTA_EXHAUSTED"},{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"10s"}]}}`))
+			_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"QUOTA_EXHAUSTED","metadata":{"model":"gemini-2.5-flash"}}]}}`))
 		case 2, 3:
 			if !strings.Contains(string(body), `"enabledCreditTypes":["GOOGLE_ONE_AI"]`) {
 				t.Fatalf("request %d body missing enabledCreditTypes: %s", reqNum, string(body))
@@ -313,8 +297,9 @@ func TestAntigravityExecute_PrefersCreditsAfterSuccessfulFallback(t *testing.T) 
 	}))
 	defer server.Close()
 
+	creditsEnabled := true
 	exec := NewAntigravityExecutor(&config.Config{
-		QuotaExceeded: config.QuotaExceeded{AntigravityCredits: true},
+		CreditsEnabled: &creditsEnabled,
 	})
 	auth := &cliproxyauth.Auth{
 		ID: "auth-prefer-credits",
@@ -357,91 +342,6 @@ func TestAntigravityExecute_PrefersCreditsAfterSuccessfulFallback(t *testing.T) 
 	}
 }
 
-func TestAntigravityExecute_PreservesBaseURLFallbackAfterCreditsRetryFailure(t *testing.T) {
-	resetAntigravityCreditsRetryState()
-	t.Cleanup(resetAntigravityCreditsRetryState)
-
-	var (
-		mu          sync.Mutex
-		firstCount  int
-		secondCount int
-	)
-
-	firstServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		_ = r.Body.Close()
-
-		mu.Lock()
-		firstCount++
-		reqNum := firstCount
-		mu.Unlock()
-
-		switch reqNum {
-		case 1:
-			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"QUOTA_EXHAUSTED"}]}}`))
-		case 2:
-			if !strings.Contains(string(body), `"enabledCreditTypes":["GOOGLE_ONE_AI"]`) {
-				t.Fatalf("credits retry missing enabledCreditTypes: %s", string(body))
-			}
-			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte(`{"error":{"message":"permission denied"}}`))
-		default:
-			t.Fatalf("unexpected first server request count %d", reqNum)
-		}
-	}))
-	defer firstServer.Close()
-
-	secondServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		secondCount++
-		mu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}}`))
-	}))
-	defer secondServer.Close()
-
-	exec := NewAntigravityExecutor(&config.Config{
-		QuotaExceeded: config.QuotaExceeded{AntigravityCredits: true},
-	})
-	auth := &cliproxyauth.Auth{
-		ID: "auth-baseurl-fallback",
-		Attributes: map[string]string{
-			"base_url": firstServer.URL,
-		},
-		Metadata: map[string]any{
-			"access_token": "token",
-			"project_id":   "project-1",
-			"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
-		},
-	}
-
-	originalOrder := antigravityBaseURLFallbackOrder
-	defer func() { antigravityBaseURLFallbackOrder = originalOrder }()
-	antigravityBaseURLFallbackOrder = func(auth *cliproxyauth.Auth) []string {
-		return []string{firstServer.URL, secondServer.URL}
-	}
-
-	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
-		Model:   "gemini-2.5-flash",
-		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
-	}, cliproxyexecutor.Options{
-		SourceFormat: sdktranslator.FormatAntigravity,
-	})
-	if err != nil {
-		t.Fatalf("Execute() error = %v", err)
-	}
-	if len(resp.Payload) == 0 {
-		t.Fatal("Execute() returned empty payload")
-	}
-	if firstCount != 2 {
-		t.Fatalf("first server request count = %d, want 2", firstCount)
-	}
-	if secondCount != 1 {
-		t.Fatalf("second server request count = %d, want 1", secondCount)
-	}
-}
-
 func TestAntigravityExecute_DoesNotDirectInjectCreditsWhenFlagDisabled(t *testing.T) {
 	resetAntigravityCreditsRetryState()
 	t.Cleanup(resetAntigravityCreditsRetryState)
@@ -452,12 +352,13 @@ func TestAntigravityExecute_DoesNotDirectInjectCreditsWhenFlagDisabled(t *testin
 		_ = r.Body.Close()
 		requestBodies = append(requestBodies, string(body))
 		w.WriteHeader(http.StatusTooManyRequests)
-		_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"QUOTA_EXHAUSTED"}}`))
+		_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"You have exhausted your capacity.","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"QUOTA_EXHAUSTED","metadata":{"model":"gemini-2.5-flash"}}]}}`))
 	}))
 	defer server.Close()
 
+	creditsDisabled := false
 	exec := NewAntigravityExecutor(&config.Config{
-		QuotaExceeded: config.QuotaExceeded{AntigravityCredits: false},
+		CreditsEnabled: &creditsDisabled,
 	})
 	auth := &cliproxyauth.Auth{
 		ID: "auth-flag-disabled",
@@ -470,7 +371,7 @@ func TestAntigravityExecute_DoesNotDirectInjectCreditsWhenFlagDisabled(t *testin
 			"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
 		},
 	}
-	markAntigravityPreferCredits(auth, "gemini-2.5-flash", time.Now(), nil)
+	markModelCreditsActive(auth, "gemini-2.5-flash", time.Now())
 
 	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "gemini-2.5-flash",
@@ -486,5 +387,25 @@ func TestAntigravityExecute_DoesNotDirectInjectCreditsWhenFlagDisabled(t *testin
 	}
 	if strings.Contains(requestBodies[0], `"enabledCreditTypes":["GOOGLE_ONE_AI"]`) {
 		t.Fatalf("request unexpectedly used enabledCreditTypes with flag disabled: %s", requestBodies[0])
+	}
+}
+
+func TestClearAntigravityAuthState(t *testing.T) {
+	resetAntigravityCreditsRetryState()
+	t.Cleanup(resetAntigravityCreditsRetryState)
+
+	auth := &cliproxyauth.Auth{ID: "test-clear"}
+	now := time.Now()
+
+	markModelCreditsActive(auth, "model-a", now)
+	markModelCooldown(auth, "model-b", now)
+
+	ClearAntigravityAuthState("test-clear")
+
+	if isModelCreditsActive(auth, "model-a", now) {
+		t.Fatal("model-a credits still active after clear")
+	}
+	if inCooldown, _ := isModelInCooldown(auth, "model-b", now); inCooldown {
+		t.Fatal("model-b still in cooldown after clear")
 	}
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1272,6 +1272,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 	opts = ensureRequestedModelMetadata(opts, routeModel)
 	tried := make(map[string]struct{})
 	attempted := make(map[string]struct{})
+	minInterval := m.minRetryInterval()
+	var lastAttemptTime time.Time
 	var lastErr error
 	for {
 		if maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
@@ -1279,6 +1281,13 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				return cliproxyexecutor.Response{}, lastErr
 			}
 			return cliproxyexecutor.Response{}, &Error{Code: "auth_not_found", Message: "no auth available"}
+		}
+		if minInterval > 0 && !lastAttemptTime.IsZero() {
+			if elapsed := time.Since(lastAttemptTime); elapsed < minInterval {
+				if errWait := waitForCooldown(ctx, minInterval-elapsed); errWait != nil {
+					return cliproxyexecutor.Response{}, errWait
+				}
+			}
 		}
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, opts, tried)
 		if errPick != nil {
@@ -1304,6 +1313,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			continue
 		}
 		attempted[auth.ID] = struct{}{}
+		lastAttemptTime = time.Now()
 		var authErr error
 		for _, upstreamModel := range models {
 			resultModel := m.stateModelForExecution(auth, routeModel, upstreamModel, pooled)
@@ -1350,6 +1360,8 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 	opts = ensureRequestedModelMetadata(opts, routeModel)
 	tried := make(map[string]struct{})
 	attempted := make(map[string]struct{})
+	minInterval := m.minRetryInterval()
+	var lastAttemptTime time.Time
 	var lastErr error
 	for {
 		if maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
@@ -1357,6 +1369,13 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				return cliproxyexecutor.Response{}, lastErr
 			}
 			return cliproxyexecutor.Response{}, &Error{Code: "auth_not_found", Message: "no auth available"}
+		}
+		if minInterval > 0 && !lastAttemptTime.IsZero() {
+			if elapsed := time.Since(lastAttemptTime); elapsed < minInterval {
+				if errWait := waitForCooldown(ctx, minInterval-elapsed); errWait != nil {
+					return cliproxyexecutor.Response{}, errWait
+				}
+			}
 		}
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, opts, tried)
 		if errPick != nil {
@@ -1382,6 +1401,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			continue
 		}
 		attempted[auth.ID] = struct{}{}
+		lastAttemptTime = time.Now()
 		var authErr error
 		for _, upstreamModel := range models {
 			resultModel := m.stateModelForExecution(auth, routeModel, upstreamModel, pooled)
@@ -1428,6 +1448,8 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 	opts = ensureRequestedModelMetadata(opts, routeModel)
 	tried := make(map[string]struct{})
 	attempted := make(map[string]struct{})
+	minInterval := m.minRetryInterval()
+	var lastAttemptTime time.Time
 	var lastErr error
 	for {
 		if maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
@@ -1439,6 +1461,13 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				return nil, lastErr
 			}
 			return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+		}
+		if minInterval > 0 && !lastAttemptTime.IsZero() {
+			if elapsed := time.Since(lastAttemptTime); elapsed < minInterval {
+				if errWait := waitForCooldown(ctx, minInterval-elapsed); errWait != nil {
+					return nil, errWait
+				}
+			}
 		}
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, opts, tried)
 		if errPick != nil {
@@ -1467,6 +1496,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			continue
 		}
 		attempted[auth.ID] = struct{}{}
+		lastAttemptTime = time.Now()
 		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, req, opts, routeModel, models, pooled)
 		if errStream != nil {
 			if errCtx := execCtx.Err(); errCtx != nil {
@@ -1807,6 +1837,17 @@ func (m *Manager) retrySettings() (int, int, time.Duration) {
 	return int(m.requestRetry.Load()), int(m.maxRetryCredentials.Load()), time.Duration(m.maxRetryInterval.Load())
 }
 
+func (m *Manager) minRetryInterval() time.Duration {
+	if m == nil {
+		return 100 * time.Millisecond
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil || cfg.MinRetryInterval <= 0 {
+		return 100 * time.Millisecond
+	}
+	return time.Duration(cfg.MinRetryInterval) * time.Millisecond
+}
+
 func (m *Manager) closestCooldownWait(providers []string, model string, attempt int) (time.Duration, bool) {
 	if m == nil || len(providers) == 0 {
 		return 0, false
@@ -2009,7 +2050,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					}
 
 					statusCode := statusCodeFromResult(result.Error)
-					if isModelSupportResultError(result.Error) {
+					if statusCode != 404 && isModelSupportResultError(result.Error) {
 						next := now.Add(12 * time.Hour)
 						state.NextRetryAfter = next
 						suspendReason = "model_not_supported"
@@ -2017,14 +2058,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					} else {
 						switch statusCode {
 						case 401:
-							if disableCooling {
-								state.NextRetryAfter = time.Time{}
-							} else {
-								next := now.Add(30 * time.Minute)
-								state.NextRetryAfter = next
-								suspendReason = "unauthorized"
-								shouldSuspendModel = true
-							}
+							auth.QuotaExhaustedPermanent = true
+							state.NextRetryAfter = time.Time{}
+							suspendReason = "quota_exhausted_permanent"
+							shouldSuspendModel = true
 						case 402, 403:
 							if disableCooling {
 								state.NextRetryAfter = time.Time{}
@@ -2034,48 +2071,28 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								suspendReason = "payment_required"
 								shouldSuspendModel = true
 							}
-						case 404:
-							if disableCooling {
-								state.NextRetryAfter = time.Time{}
-							} else {
-								next := now.Add(12 * time.Hour)
-								state.NextRetryAfter = next
-								suspendReason = "not_found"
-								shouldSuspendModel = true
-							}
 						case 429:
-							var next time.Time
-							backoffLevel := state.Quota.BackoffLevel
-							if !disableCooling {
-								if result.RetryAfter != nil {
-									next = now.Add(*result.RetryAfter)
-								} else {
-									cooldown, nextLevel := nextQuotaCooldown(backoffLevel, disableCooling)
-									if cooldown > 0 {
-										next = now.Add(cooldown)
-									}
-									backoffLevel = nextLevel
+							if result.Error != nil && isRule1QuotaExhausted(result.Error.Message) {
+								auth.QuotaExhaustedPermanent = true
+								state.NextRetryAfter = time.Time{}
+								suspendReason = "quota_exhausted_permanent"
+								shouldSuspendModel = true
+							} else if !disableCooling {
+								next := now.Add(30 * time.Minute)
+								state.NextRetryAfter = next
+								state.Quota = QuotaState{
+									Exceeded:      true,
+									Reason:        "quota",
+									NextRecoverAt: next,
 								}
-							}
-							state.NextRetryAfter = next
-							state.Quota = QuotaState{
-								Exceeded:      true,
-								Reason:        "quota",
-								NextRecoverAt: next,
-								BackoffLevel:  backoffLevel,
-							}
-							if !disableCooling {
 								suspendReason = "quota"
 								shouldSuspendModel = true
 								setModelQuota = true
 							}
-						case 408, 500, 502, 503, 504:
-							if disableCooling {
-								state.NextRetryAfter = time.Time{}
-							} else {
-								next := now.Add(1 * time.Minute)
-								state.NextRetryAfter = next
-							}
+						case 503:
+							state.NextRetryAfter = time.Time{}
+						case 408, 500, 502, 504:
+							state.NextRetryAfter = time.Time{}
 						default:
 							state.NextRetryAfter = time.Time{}
 						}
@@ -2086,7 +2103,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					updateAggregatedAvailability(auth, now)
 				}
 			} else {
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, now)
+				applyAuthFailureState(auth, result.Error, now)
 			}
 		}
 
@@ -2389,11 +2406,9 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 }
 
 // isRequestInvalidError returns true if the error represents a client request
-// error that should not be retried. Specifically, it treats 400 responses with
-// "invalid_request_error", request-scoped 404 item misses caused by `store=false`,
-// and all 422 responses as request-shape failures, where switching auths or
-// pooled upstream models will not help. Model-support errors are excluded so
-// routing can fall through to another auth or upstream.
+// error that should not be retried. All 4xx errors except 401/402/403/408/429
+// are treated as non-retryable. Model-support errors are excluded so routing
+// can fall through to another auth or upstream.
 func isRequestInvalidError(err error) bool {
 	if err == nil {
 		return false
@@ -2402,19 +2417,25 @@ func isRequestInvalidError(err error) bool {
 		return false
 	}
 	status := statusCodeFromError(err)
-	switch status {
-	case http.StatusBadRequest:
-		return strings.Contains(err.Error(), "invalid_request_error")
-	case http.StatusNotFound:
-		return isRequestScopedNotFoundMessage(err.Error())
-	case http.StatusUnprocessableEntity:
-		return true
-	default:
-		return false
+	if status >= 400 && status < 500 {
+		switch status {
+		case 401, 402, 403, 408, 429:
+			return false
+		default:
+			return true
+		}
 	}
+	return false
 }
 
-func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {
+// isRule1QuotaExhausted detects the Rule 1 pattern: RESOURCE_EXHAUSTED with "e.g." in the message,
+// indicating a permanently exhausted quota.
+func isRule1QuotaExhausted(message string) bool {
+	return strings.Contains(message, "e.g.") &&
+		strings.Contains(message, "RESOURCE_EXHAUSTED")
+}
+
+func applyAuthFailureState(auth *Auth, resultErr *Error, now time.Time) {
 	if auth == nil {
 		return
 	}
@@ -2434,74 +2455,34 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	statusCode := statusCodeFromResult(resultErr)
 	switch statusCode {
 	case 401:
-		auth.StatusMessage = "unauthorized"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = now.Add(30 * time.Minute)
-		}
+		auth.QuotaExhaustedPermanent = true
+		auth.StatusMessage = "quota_exhausted_permanent"
 	case 402, 403:
 		auth.StatusMessage = "payment_required"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
+		if !disableCooling {
 			auth.NextRetryAfter = now.Add(30 * time.Minute)
 		}
-	case 404:
-		auth.StatusMessage = "not_found"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = now.Add(12 * time.Hour)
-		}
 	case 429:
-		auth.StatusMessage = "quota exhausted"
-		auth.Quota.Exceeded = true
-		auth.Quota.Reason = "quota"
-		var next time.Time
-		if !disableCooling {
-			if retryAfter != nil {
-				next = now.Add(*retryAfter)
-			} else {
-				cooldown, nextLevel := nextQuotaCooldown(auth.Quota.BackoffLevel, disableCooling)
-				if cooldown > 0 {
-					next = now.Add(cooldown)
-				}
-				auth.Quota.BackoffLevel = nextLevel
+		if resultErr != nil && isRule1QuotaExhausted(resultErr.Message) {
+			auth.QuotaExhaustedPermanent = true
+			auth.StatusMessage = "quota_exhausted_permanent"
+		} else {
+			auth.StatusMessage = "quota exhausted"
+			auth.Quota.Exceeded = true
+			auth.Quota.Reason = "quota"
+			if !disableCooling {
+				next := now.Add(30 * time.Minute)
+				auth.Quota.NextRecoverAt = next
+				auth.NextRetryAfter = next
 			}
 		}
-		auth.Quota.NextRecoverAt = next
-		auth.NextRetryAfter = next
-	case 408, 500, 502, 503, 504:
+	case 503, 408, 500, 502, 504:
 		auth.StatusMessage = "transient upstream error"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = now.Add(1 * time.Minute)
-		}
 	default:
 		if auth.StatusMessage == "" {
 			auth.StatusMessage = "request failed"
 		}
 	}
-}
-
-// nextQuotaCooldown returns the next cooldown duration and updated backoff level for repeated quota errors.
-func nextQuotaCooldown(prevLevel int, disableCooling bool) (time.Duration, int) {
-	if prevLevel < 0 {
-		prevLevel = 0
-	}
-	if disableCooling {
-		return 0, prevLevel
-	}
-	cooldown := quotaBackoffBase * time.Duration(1<<prevLevel)
-	if cooldown < quotaBackoffBase {
-		cooldown = quotaBackoffBase
-	}
-	if cooldown >= quotaBackoffMax {
-		return quotaBackoffMax, prevLevel
-	}
-	return cooldown, prevLevel + 1
 }
 
 // List returns all auth entries currently known by the manager.

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -113,6 +113,14 @@ func (e *modelCooldownError) Headers() http.Header {
 	return headers
 }
 
+type concurrencyLimitError struct{}
+
+func (e *concurrencyLimitError) Error() string {
+	return `{"error":{"code":429,"message":"All OAuth connections have reached the concurrency limit","status":"CONCURRENCY_LIMIT"}}`
+}
+
+func (e *concurrencyLimitError) StatusCode() int { return http.StatusTooManyRequests }
+
 func authPriority(auth *Auth) int {
 	if auth == nil || auth.Attributes == nil {
 		return 0
@@ -373,6 +381,9 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 		return true, blockReasonOther, time.Time{}
 	}
 	if auth.Disabled || auth.Status == StatusDisabled {
+		return true, blockReasonDisabled, time.Time{}
+	}
+	if auth.QuotaExhaustedPermanent {
 		return true, blockReasonDisabled, time.Time{}
 	}
 	if model != "" {

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -89,6 +89,11 @@ type Auth struct {
 	// ModelStates tracks per-model runtime availability data.
 	ModelStates map[string]*ModelState `json:"model_states,omitempty"`
 
+	// QuotaExhaustedPermanent marks this credential as permanently banned due to
+	// quota exhaustion (Rule 1) or 401 rejection. Memory-only, cleared on restart
+	// or via management API disable→enable toggle.
+	QuotaExhaustedPermanent bool `json:"-"`
+
 	// Runtime carries non-serialisable data used during execution (in-memory only).
 	Runtime any `json:"-"`
 


### PR DESCRIPTION
## Summary / 概述

Rewrite the Antigravity error handling system to use a priority-based 3-rule matching model for 429 errors, replace the exponential backoff with fixed 30-minute cooldowns, and simplify the Credits (Google One AI) mechanism from per-auth/5h to per-auth+model/30min.

重写 Antigravity 错误处理系统，使用基于优先级的三规则匹配模型处理 429 错误，将指数退避替换为固定 30 分钟冷却，并将 Credits（Google One AI）机制从 per-auth/5h 简化为 per-auth+model/30min。

## Changes / 变更详情

### 429 Three-Rule System / 429 三规则系统

Replaces the `DecisionKind/Category` classification with three ordered rules:
用三条有序规则替换原有的 `DecisionKind/Category` 分类体系：

- **Rule 1**: `RESOURCE_EXHAUSTED` + message contains `"e.g."` → credential permanently banned (`QuotaExhaustedPermanent`), memory-only, cleared on restart or management API disable→enable
- **Rule 2**: `QUOTA_EXHAUSTED` + `metadata.model` present → Credits retry (phase 1), then 30-min model cooldown (phase 2) on failure
- **Rule 3**: `RATE_LIMIT_EXCEEDED` + `metadata.model` present → count failure and rotate, no cooldown
- **Fallback**: unmatched 429 → same as Rule 3

- **规则 1**：`RESOURCE_EXHAUSTED` + message 包含 `"e.g."` → 凭证永久禁用（`QuotaExhaustedPermanent`），内存态，重启或管理 API disable→enable 可清除
- **规则 2**：`QUOTA_EXHAUSTED` + `metadata.model` 有值 → Credits 重试（阶段一），失败则模型冷却 30 分钟（阶段二）
- **规则 3**：`RATE_LIMIT_EXCEEDED` + `metadata.model` 有值 → 计失败并轮转，无冷却
- **兜底**：未匹配的 429 → 同规则 3

### HTTP Status Code Changes / HTTP 状态码处理变更

| Code | Before / 之前 | After / 之后 |
|------|--------------|-------------|
| 401 | 30-min model cooldown | Permanent ban (`QuotaExhaustedPermanent`) / 永久禁用 |
| 402/403 | 30-min cooldown | Unchanged / 不变 |
| 404 | 12-hour cooldown | No retry, return error directly / 不重试，直接返回 |
| 429 | Exponential backoff (1s→30min) | Fixed 30-min or per-rule / 固定 30 分钟或按规则 |
| 503 | 1-min cooldown | No cooldown mark, 1s wait in executor / 无冷却标记，执行器内等 1 秒 |
| 408/5xx | 1-min cooldown | No cooldown mark / 无冷却标记 |
| Other 4xx | Varies | No retry, return error directly / 不重试，直接返回 |

### Credits Mechanism / Credits 机制

| Aspect / 维度 | Before / 之前 | After / 之后 |
|---------------|--------------|-------------|
| State scope | per-auth | **per-auth+model** |
| Duration | 5 hours | **30 minutes** |
| Permanent disable | Yes (INSUFFICIENT_G1_CREDITS_BALANCE) | **No, recovers after cooldown** / 无，冷却后恢复 |
| 12 keywords detection | Yes | **Removed, only Rule 2 QUOTA_EXHAUSTED triggers** / 移除 |
| Config field | `antigravity-credits` | **`credits-enabled` (with backward compat)** / 向后兼容 |

### New Config Fields / 新配置字段

- `credits-enabled` (bool, default: true) — top-level Credits toggle, falls back to `quota-exceeded.antigravity-credits` / Credits 总开关，回退到原字段
- `max-concurrency-per-auth` (int, default: 0) — per-credential concurrency limit / 单凭证并发上限
- `min-retry-interval` (int ms, default: 100) — minimum interval between retries / 重试最小间隔

### Management API / 管理 API

- `PATCH /auth-files/status` with `disabled=false` now also clears `QuotaExhaustedPermanent` and all model cooldown/quota states
- `PATCH /auth-files/status` 设置 `disabled=false` 时同时清除永久禁用标记和所有模型冷却状态

## Files Changed (8) / 变更文件

- `internal/runtime/executor/antigravity_executor.go` — rule classification, credits, 429/401/503 handling rewrite (~430 lines net reduction)
- `sdk/cliproxy/auth/conductor.go` — MarkResult, applyAuthFailureState, isRequestInvalidError, min-retry-interval support
- `sdk/cliproxy/auth/types.go` — `QuotaExhaustedPermanent` field
- `sdk/cliproxy/auth/selector.go` — permanent ban check in `isAuthBlockedForModel`
- `internal/config/config.go` — new config fields + `IsCreditsEnabled()` helper
- `internal/api/handlers/management/auth_files.go` — clear permanent ban on re-enable
- `config.example.yaml` — new config field examples
- `antigravity_executor_credits_test.go` — tests rewritten for new API

## Test Plan / 测试计划

- [x] `go build ./...` — compiles cleanly / 编译通过
- [x] `go test ./internal/runtime/executor/...` — all pass (rule classification, credits lifecycle, permanent ban, credits retry) / 规则分类、Credits 生命周期、永久禁用、Credits 重试测试通过
- [x] `go test ./sdk/cliproxy/auth/...` — all pass (selector, scheduler, conductor) / 选择器、调度器、conductor 测试通过
- [x] `go test ./...` — full suite pass, zero failures / 全量测试通过，零失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)