### PR TITLE
feat(cmd): add detached background mode and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ cli-proxy-api.exe --background
 
 If startup succeeds, the command prints the detached PID and exits immediately, and the proxy keeps running after the terminal is closed.
 
+`--background` is only intended for normal service startup. Do not combine it with interactive/login/import/TUI modes (for example: `--login`, `--codex-login`, `--codex-device-login`, `--claude-login`, `--antigravity-login`, `--kimi-login`, `--vertex-import`, `--tui`).
+
 ## Management API
 
 see [MANAGEMENT_API.md](https://help.router-for.me/management/api)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ VisionCoder is also offering our users a limited-time <a href="https://coder.vis
 
 CLIProxyAPI Guides: [https://help.router-for.me/](https://help.router-for.me/)
 
+### Windows Background Mode
+
+When running `cli-proxy-api.exe` directly in a terminal, closing that terminal also closes the process.
+
+Use `--background` to relaunch the server as a detached process:
+
+```bash
+cli-proxy-api.exe --background
+```
+
+If startup succeeds, the command prints the detached PID and exits immediately, and the proxy keeps running after the terminal is closed.
+
 ## Management API
 
 see [MANAGEMENT_API.md](https://help.router-for.me/management/api)

--- a/README_CN.md
+++ b/README_CN.md
@@ -86,6 +86,8 @@ cli-proxy-api.exe --background
 
 启动成功后会打印后台进程 PID 并立即返回。之后即使关闭终端，代理服务也会继续运行。
 
+`--background` 仅用于常规服务启动，请勿与交互/登录/导入/TUI 模式组合使用（例如：`--login`、`--codex-login`、`--codex-device-login`、`--claude-login`、`--antigravity-login`、`--kimi-login`、`--vertex-import`、`--tui`）。
+
 ## 管理 API 文档
 
 请参见 [MANAGEMENT_API_CN.md](https://help.router-for.me/cn/management/api)

--- a/README_CN.md
+++ b/README_CN.md
@@ -74,6 +74,18 @@ VisionCoder 还为我们的用户提供 <a href="https://coder.visioncoder.cn" t
 
 CLIProxyAPI 用户手册： [https://help.router-for.me/](https://help.router-for.me/cn/)
 
+### Windows 后台运行
+
+如果直接在终端中运行 `cli-proxy-api.exe`，关闭终端时该进程会一起退出。
+
+可使用 `--background` 参数将服务重新拉起为脱离终端的后台进程：
+
+```bash
+cli-proxy-api.exe --background
+```
+
+启动成功后会打印后台进程 PID 并立即返回。之后即使关闭终端，代理服务也会继续运行。
+
 ## 管理 API 文档
 
 请参见 [MANAGEMENT_API_CN.md](https://help.router-for.me/cn/management/api)

--- a/README_JA.md
+++ b/README_JA.md
@@ -51,7 +51,7 @@ GLM CODING PLANを10%割引で取得：https://z.ai/subscribe?ic=8JVLJQFSKB
 
 ## 概要
 
-- CLIモデル向けのOpenAI/Gemini/Claude互換APIエンドポイント
+- CLIモデル向けのOpenAI/Gemini/Claude/Codex互換APIエンドポイント
 - OAuthログインによるOpenAI Codexサポート（GPTモデル）
 - OAuthログインによるClaude Codeサポート
 - プロバイダールーティングによるAmp CLIおよびIDE拡張機能のサポート
@@ -71,6 +71,18 @@ GLM CODING PLANを10%割引で取得：https://z.ai/subscribe?ic=8JVLJQFSKB
 ## はじめに
 
 CLIProxyAPIガイド：[https://help.router-for.me/](https://help.router-for.me/)
+
+### Windows バックグラウンド実行
+
+`cli-proxy-api.exe` をターミナルで直接実行すると、そのターミナルを閉じた時点でプロセスも終了します。
+
+`--background` を使うと、サーバーをターミナルから切り離したバックグラウンドプロセスとして再起動できます。
+
+```bash
+cli-proxy-api.exe --background
+```
+
+起動に成功すると、デタッチされた PID を表示してコマンドはすぐ終了します。以後はターミナルを閉じてもプロキシは動作し続けます。
 
 ## 管理API
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -84,6 +84,8 @@ cli-proxy-api.exe --background
 
 起動に成功すると、デタッチされた PID を表示してコマンドはすぐ終了します。以後はターミナルを閉じてもプロキシは動作し続けます。
 
+`--background` は通常のサービス起動専用です。対話/ログイン/インポート/TUI モード（例：`--login`、`--codex-login`、`--codex-device-login`、`--claude-login`、`--antigravity-login`、`--kimi-login`、`--vertex-import`、`--tui`）と組み合わせないでください。
+
 ## 管理API
 
 [MANAGEMENT_API.md](https://help.router-for.me/management/api)を参照

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -73,6 +73,7 @@ func main() {
 	var tuiMode bool
 	var standalone bool
 	var localModel bool
+	var background bool
 
 	// Define command-line flags for different operation modes.
 	flag.BoolVar(&login, "login", false, "Login Google Account")
@@ -91,6 +92,7 @@ func main() {
 	flag.BoolVar(&tuiMode, "tui", false, "Start with terminal management UI")
 	flag.BoolVar(&standalone, "standalone", false, "In TUI mode, start an embedded local server")
 	flag.BoolVar(&localModel, "local-model", false, "Use embedded model catalog only, skip remote model fetching")
+	flag.BoolVar(&background, "background", false, "Run as detached background process on Windows")
 
 	flag.CommandLine.Usage = func() {
 		out := flag.CommandLine.Output()
@@ -121,6 +123,25 @@ func main() {
 
 	// Parse the command-line flags.
 	flag.Parse()
+
+	if background {
+		filteredArgs := make([]string, 0, len(os.Args)-1)
+		for _, arg := range os.Args[1:] {
+			if arg == "--background" || arg == "-background" ||
+				strings.HasPrefix(arg, "--background=") || strings.HasPrefix(arg, "-background=") {
+				continue
+			}
+			filteredArgs = append(filteredArgs, arg)
+		}
+		exited, errStartDetached := cmd.StartDetachedIfRequested(true, filteredArgs)
+		if errStartDetached != nil {
+			log.Errorf("failed to start detached background process: %v", errStartDetached)
+			return
+		}
+		if exited {
+			return
+		}
+	}
 
 	// Core application variables.
 	var err error

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -124,23 +124,9 @@ func main() {
 	// Parse the command-line flags.
 	flag.Parse()
 
-	if background {
-		filteredArgs := make([]string, 0, len(os.Args)-1)
-		for _, arg := range os.Args[1:] {
-			if arg == "--background" || arg == "-background" ||
-				strings.HasPrefix(arg, "--background=") || strings.HasPrefix(arg, "-background=") {
-				continue
-			}
-			filteredArgs = append(filteredArgs, arg)
-		}
-		exited, errStartDetached := cmd.StartDetachedIfRequested(true, filteredArgs)
-		if errStartDetached != nil {
-			log.Errorf("failed to start detached background process: %v", errStartDetached)
-			return
-		}
-		if exited {
-			return
-		}
+	if background && (login || codexLogin || codexDeviceLogin || claudeLogin || antigravityLogin || kimiLogin || vertexImport != "" || tuiMode) {
+		log.Error("--background cannot be combined with interactive/login/import/tui modes")
+		return
 	}
 
 	// Core application variables.
@@ -502,6 +488,24 @@ func main() {
 	} else if kimiLogin {
 		cmd.DoKimiLogin(cfg, options)
 	} else {
+		if background {
+			filteredArgs := make([]string, 0, len(os.Args)-1)
+			for _, arg := range os.Args[1:] {
+				if arg == "--background" || arg == "-background" ||
+					strings.HasPrefix(arg, "--background=") || strings.HasPrefix(arg, "-background=") {
+					continue
+				}
+				filteredArgs = append(filteredArgs, arg)
+			}
+			exited, errStartDetached := cmd.StartDetachedIfRequested(true, filteredArgs)
+			if errStartDetached != nil {
+				log.Errorf("failed to start detached background process: %v", errStartDetached)
+				return
+			}
+			if exited {
+				return
+			}
+		}
 		// In cloud deploy mode without config file, just wait for shutdown signals
 		if isCloudDeploy && !configFileExists {
 			// No config file available, just wait for shutdown

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -56,6 +56,11 @@ func init() {
 func main() {
 	fmt.Printf("CLIProxyAPI Version: %s, Commit: %s, BuiltAt: %s\n", buildinfo.Version, buildinfo.Commit, buildinfo.BuildDate)
 
+	if hasSplitBackgroundBoolValue(os.Args[1:]) {
+		log.Error("invalid --background usage: split bool form is not supported, use --background or --background=true/false")
+		return
+	}
+
 	// Command-line flags to control the application's behavior.
 	var login bool
 	var codexLogin bool
@@ -602,9 +607,6 @@ func filterBackgroundArgs(args []string) []string {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "--background" || arg == "-background" {
-			if i+1 < len(args) && isBoolLikeFlagValue(args[i+1]) {
-				i++
-			}
 			continue
 		}
 		if strings.HasPrefix(arg, "--background=") || strings.HasPrefix(arg, "-background=") {
@@ -622,4 +624,15 @@ func isBoolLikeFlagValue(v string) bool {
 	default:
 		return false
 	}
+}
+
+func hasSplitBackgroundBoolValue(args []string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--background" || args[i] == "-background" {
+			if isBoolLikeFlagValue(args[i+1]) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -489,14 +489,7 @@ func main() {
 		cmd.DoKimiLogin(cfg, options)
 	} else {
 		if background {
-			filteredArgs := make([]string, 0, len(os.Args)-1)
-			for _, arg := range os.Args[1:] {
-				if arg == "--background" || arg == "-background" ||
-					strings.HasPrefix(arg, "--background=") || strings.HasPrefix(arg, "-background=") {
-					continue
-				}
-				filteredArgs = append(filteredArgs, arg)
-			}
+			filteredArgs := filterBackgroundArgs(os.Args[1:])
 			exited, errStartDetached := cmd.StartDetachedIfRequested(true, filteredArgs)
 			if errStartDetached != nil {
 				log.Errorf("failed to start detached background process: %v", errStartDetached)
@@ -601,5 +594,32 @@ func main() {
 			}
 			cmd.StartService(cfg, configFilePath, password)
 		}
+	}
+}
+
+func filterBackgroundArgs(args []string) []string {
+	filtered := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--background" || arg == "-background" {
+			if i+1 < len(args) && isBoolLikeFlagValue(args[i+1]) {
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(arg, "--background=") || strings.HasPrefix(arg, "-background=") {
+			continue
+		}
+		filtered = append(filtered, arg)
+	}
+	return filtered
+}
+
+func isBoolLikeFlagValue(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "0", "t", "f", "true", "false":
+		return true
+	default:
+		return false
 	}
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -19,14 +19,14 @@ func TestFilterBackgroundArgs(t *testing.T) {
 			want: []string{"--config", "config.yaml"},
 		},
 		{
-			name: "remove background value true",
+			name: "do not consume split bool token",
 			args: []string{"--background", "true", "--config", "config.yaml"},
-			want: []string{"--config", "config.yaml"},
+			want: []string{"true", "--config", "config.yaml"},
 		},
 		{
-			name: "remove background value false short form",
+			name: "do not consume split bool token short form",
 			args: []string{"-background", "f", "--config", "config.yaml"},
-			want: []string{"--config", "config.yaml"},
+			want: []string{"f", "--config", "config.yaml"},
 		},
 		{
 			name: "remove background equals syntax",
@@ -52,6 +52,53 @@ func TestFilterBackgroundArgs(t *testing.T) {
 			got := filterBackgroundArgs(tt.args)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("filterBackgroundArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasSplitBackgroundBoolValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "detect split true",
+			args: []string{"--background", "true", "--config", "config.yaml"},
+			want: true,
+		},
+		{
+			name: "detect split short false",
+			args: []string{"-background", "f"},
+			want: true,
+		},
+		{
+			name: "no split when equals syntax",
+			args: []string{"--background=true", "--config", "config.yaml"},
+			want: false,
+		},
+		{
+			name: "no split when standalone flag",
+			args: []string{"--background", "--config", "config.yaml"},
+			want: false,
+		},
+		{
+			name: "no background",
+			args: []string{"--config", "config.yaml"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := hasSplitBackgroundBoolValue(tt.args)
+			if got != tt.want {
+				t.Fatalf("hasSplitBackgroundBoolValue() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilterBackgroundArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "remove background flag only",
+			args: []string{"--background", "--config", "config.yaml"},
+			want: []string{"--config", "config.yaml"},
+		},
+		{
+			name: "remove background value true",
+			args: []string{"--background", "true", "--config", "config.yaml"},
+			want: []string{"--config", "config.yaml"},
+		},
+		{
+			name: "remove background value false short form",
+			args: []string{"-background", "f", "--config", "config.yaml"},
+			want: []string{"--config", "config.yaml"},
+		},
+		{
+			name: "remove background equals syntax",
+			args: []string{"--background=1", "--config", "config.yaml"},
+			want: []string{"--config", "config.yaml"},
+		},
+		{
+			name: "keep non bool next token",
+			args: []string{"--background", "--config", "config.yaml"},
+			want: []string{"--config", "config.yaml"},
+		},
+		{
+			name: "keep other flags",
+			args: []string{"--local-model", "--config", "config.yaml"},
+			want: []string{"--local-model", "--config", "config.yaml"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterBackgroundArgs(tt.args)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("filterBackgroundArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+

--- a/internal/cmd/background_nonwindows.go
+++ b/internal/cmd/background_nonwindows.go
@@ -2,9 +2,14 @@
 
 package cmd
 
+import "fmt"
+
 // StartDetachedIfRequested relaunches the current process in detached mode when requested.
-// Non-Windows platforms currently do not relaunch.
+// Non-Windows platforms do not support this relaunch mode.
 func StartDetachedIfRequested(enabled bool, args []string) (bool, error) {
 	_ = args
+	if enabled {
+		return false, fmt.Errorf("--background is currently supported on Windows only")
+	}
 	return false, nil
 }

--- a/internal/cmd/background_nonwindows.go
+++ b/internal/cmd/background_nonwindows.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package cmd
+
+// StartDetachedIfRequested relaunches the current process in detached mode when requested.
+// Non-Windows platforms currently do not relaunch.
+func StartDetachedIfRequested(enabled bool, args []string) (bool, error) {
+	_ = args
+	return false, nil
+}

--- a/internal/cmd/background_windows.go
+++ b/internal/cmd/background_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+const backgroundCreationFlags = 0x00000008 | 0x00000200
+
+// StartDetachedIfRequested relaunches the current process in detached mode when requested.
+// It returns true when parent process should exit immediately.
+func StartDetachedIfRequested(enabled bool, args []string) (bool, error) {
+	if !enabled {
+		return false, nil
+	}
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return false, fmt.Errorf("open dev null: %w", err)
+	}
+	defer func() {
+		_ = devNull.Close()
+	}()
+
+	child := exec.Command(os.Args[0], args...)
+	child.Stdin = devNull
+	child.Stdout = devNull
+	child.Stderr = devNull
+	child.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: backgroundCreationFlags,
+	}
+
+	if err := child.Start(); err != nil {
+		return false, fmt.Errorf("start detached child process: %w", err)
+	}
+	if child.Process == nil {
+		return false, fmt.Errorf("detached process started without pid")
+	}
+
+	fmt.Printf("CLIProxyAPI detached successfully (pid: %d)\n", child.Process.Pid)
+	return true, nil
+}

--- a/internal/cmd/background_windows.go
+++ b/internal/cmd/background_windows.go
@@ -9,7 +9,8 @@ import (
 	"syscall"
 )
 
-const backgroundCreationFlags = 0x00000008 | 0x00000200
+const detachedProcess = 0x00000008
+const backgroundCreationFlags = detachedProcess | syscall.CREATE_NEW_PROCESS_GROUP
 
 // StartDetachedIfRequested relaunches the current process in detached mode when requested.
 // It returns true when parent process should exit immediately.
@@ -26,7 +27,12 @@ func StartDetachedIfRequested(enabled bool, args []string) (bool, error) {
 		_ = devNull.Close()
 	}()
 
-	child := exec.Command(os.Args[0], args...)
+	executablePath, err := os.Executable()
+	if err != nil {
+		return false, fmt.Errorf("resolve executable path: %w", err)
+	}
+
+	child := exec.Command(executablePath, args...)
 	child.Stdin = devNull
 	child.Stdout = devNull
 	child.Stderr = devNull
@@ -36,9 +42,6 @@ func StartDetachedIfRequested(enabled bool, args []string) (bool, error) {
 
 	if err := child.Start(); err != nil {
 		return false, fmt.Errorf("start detached child process: %w", err)
-	}
-	if child.Process == nil {
-		return false, fmt.Errorf("detached process started without pid")
 	}
 
 	fmt.Printf("CLIProxyAPI detached successfully (pid: %d)\n", child.Process.Pid)


### PR DESCRIPTION
## Summary

This PR adds a Windows-only detached background startup mode so `cli-proxy-api.exe` can keep running after the launching terminal is closed.

Previously, when starting the server from a terminal on Windows, closing the terminal would terminate the server process. This change introduces a `--background` flag that relaunches the process in detached mode and exits the parent process immediately after successful spawn. It also keeps behavior unchanged on non-Windows platforms and updates multilingual docs for discoverability.

## Key Changes

- Add new CLI flag in `cmd/server/main.go`:
  - `--background` / `-background`
  - filter the flag before relaunch to avoid recursive respawn
  - support filtering both plain and assignment forms (`--background`, `-background`, `--background=true`, `-background=true`)
  - call `cmd.StartDetachedIfRequested(...)` and return early in the parent process
- Add Windows implementation:
  - `internal/cmd/background_windows.go`
  - start child process with detached creation flags
  - redirect stdio to `os.DevNull`
  - print detached child PID on success
- Add non-Windows no-op implementation:
  - `internal/cmd/background_nonwindows.go`
  - keep cross-platform build compatibility without changing current non-Windows behavior
- Update docs:
  - `README.md`: add **Windows Background Mode** section with usage and behavior
  - `README_CN.md`: add **Windows 后台运行** section
  - `README_JA.md`: add **Windows バックグラウンド実行** section and align feature wording with Codex support

## Files Changed

- `cmd/server/main.go`
- `internal/cmd/background_windows.go` (new)
- `internal/cmd/background_nonwindows.go` (new)
- `README.md`
- `README_CN.md`
- `README_JA.md`

## Behavior Notes

- `--background` is effective on Windows (detached relaunch).
- On non-Windows, current behavior remains unchanged (no relaunch).
- Detached child suppresses terminal IO by design (`stdin/stdout/stderr` -> null device).
- Other startup flags (for example `--config`) are preserved and passed through to the detached child process.

## Test Plan

- [x] Build verification: `go build -o cli-proxy-api.exe ./cmd/server`
- [x] On Windows, run `cli-proxy-api.exe --background`
- [x] Confirm command exits quickly and prints detached PID
- [x] Close terminal and verify proxy process remains alive
- [x] Call health/API endpoint to confirm service is reachable after terminal close
- [x] Run normal startup (without `--background`) to confirm no regression

