### PR TITLE
fix(translator): preserve Claude URL images for Codex (GPT-5.4) vision

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -131,23 +131,8 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 					case "text":
 						appendTextContent(messageContentResult.Get("text").String())
 					case "image":
-						sourceResult := messageContentResult.Get("source")
-						if sourceResult.Exists() {
-							data := sourceResult.Get("data").String()
-							if data == "" {
-								data = sourceResult.Get("base64").String()
-							}
-							if data != "" {
-								mediaType := sourceResult.Get("media_type").String()
-								if mediaType == "" {
-									mediaType = sourceResult.Get("mime_type").String()
-								}
-								if mediaType == "" {
-									mediaType = "application/octet-stream"
-								}
-								dataURL := fmt.Sprintf("data:%s;base64,%s", mediaType, data)
-								appendImageContent(dataURL)
-							}
+						if dataURL := claudeImageSourceToDataURL(messageContentResult.Get("source")); dataURL != "" {
+							appendImageContent(dataURL)
 						}
 					case "tool_use":
 						flushMessage()
@@ -178,26 +163,10 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 							for k := 0; k < len(contentResults); k++ {
 								toolResultContentType := contentResults[k].Get("type").String()
 								if toolResultContentType == "image" {
-									sourceResult := contentResults[k].Get("source")
-									if sourceResult.Exists() {
-										data := sourceResult.Get("data").String()
-										if data == "" {
-											data = sourceResult.Get("base64").String()
-										}
-										if data != "" {
-											mediaType := sourceResult.Get("media_type").String()
-											if mediaType == "" {
-												mediaType = sourceResult.Get("mime_type").String()
-											}
-											if mediaType == "" {
-												mediaType = "application/octet-stream"
-											}
-											dataURL := fmt.Sprintf("data:%s;base64,%s", mediaType, data)
-
-											toolResultContent, _ = sjson.SetBytes(toolResultContent, fmt.Sprintf("%d.type", toolResultContentIndex), "input_image")
-											toolResultContent, _ = sjson.SetBytes(toolResultContent, fmt.Sprintf("%d.image_url", toolResultContentIndex), dataURL)
-											toolResultContentIndex++
-										}
+									if dataURL := claudeImageSourceToDataURL(contentResults[k].Get("source")); dataURL != "" {
+										toolResultContent, _ = sjson.SetBytes(toolResultContent, fmt.Sprintf("%d.type", toolResultContentIndex), "input_image")
+										toolResultContent, _ = sjson.SetBytes(toolResultContent, fmt.Sprintf("%d.image_url", toolResultContentIndex), dataURL)
+										toolResultContentIndex++
 									}
 								} else if toolResultContentType == "text" {
 									toolResultContent, _ = sjson.SetBytes(toolResultContent, fmt.Sprintf("%d.type", toolResultContentIndex), "input_text")
@@ -410,6 +379,36 @@ func buildReverseMapFromClaudeOriginalToShort(original []byte) map[string]string
 		m = buildShortNameMap(names)
 	}
 	return m
+}
+
+// claudeImageSourceToDataURL converts a Claude "image" content source into a value
+// accepted by the Codex Responses input_image.image_url field. It handles both
+// base64-inlined images and URL-referenced images (source.type == "url").
+// Returns "" when the source is missing or unusable so callers can skip the part.
+func claudeImageSourceToDataURL(source gjson.Result) string {
+	if !source.Exists() {
+		return ""
+	}
+	switch source.Get("type").String() {
+	case "url":
+		return source.Get("url").String()
+	default:
+		data := source.Get("data").String()
+		if data == "" {
+			data = source.Get("base64").String()
+		}
+		if data == "" {
+			return ""
+		}
+		mediaType := source.Get("media_type").String()
+		if mediaType == "" {
+			mediaType = source.Get("mime_type").String()
+		}
+		if mediaType == "" {
+			mediaType = "application/octet-stream"
+		}
+		return fmt.Sprintf("data:%s;base64,%s", mediaType, data)
+	}
 }
 
 // normalizeToolParameters ensures object schemas contain at least an empty properties map.

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -133,3 +133,48 @@ func TestConvertClaudeRequestToCodex_ParallelToolCalls(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertClaudeRequestToCodex_ImageSources(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputJSON    string
+		wantType     string
+		wantImageURL string
+	}{
+		{
+			name: "Base64 source",
+			inputJSON: `{
+				"model": "claude-3-opus",
+				"messages": [{"role": "user", "content": [
+					{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}}
+				]}]
+			}`,
+			wantType:     "input_image",
+			wantImageURL: "data:image/png;base64,AAAA",
+		},
+		{
+			name: "URL source (fix8317)",
+			inputJSON: `{
+				"model": "claude-3-opus",
+				"messages": [{"role": "user", "content": [
+					{"type": "image", "source": {"type": "url", "url": "https://example.com/cat.png"}}
+				]}]
+			}`,
+			wantType:     "input_image",
+			wantImageURL: "https://example.com/cat.png",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertClaudeRequestToCodex("gpt-5.4", []byte(tt.inputJSON), false)
+			part := gjson.GetBytes(result, "input.0.content.0")
+			if got := part.Get("type").String(); got != tt.wantType {
+				t.Fatalf("content.0.type = %q, want %q. Output: %s", got, tt.wantType, string(result))
+			}
+			if got := part.Get("image_url").String(); got != tt.wantImageURL {
+				t.Fatalf("content.0.image_url = %q, want %q. Output: %s", got, tt.wantImageURL, string(result))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Claude→Codex translator (`internal/translator/codex/claude/codex_claude_request.go`) silently dropped Claude image content whose `source.type == "url"` because it only read `source.data` / `source.base64`. Claude clients that send URL-referenced images to `gpt-5.4` ended up with text-only context — model couldn't 睇圖.
- Extracted a `claudeImageSourceToDataURL` helper that handles both `url` and `base64` sources (matching the existing `internal/translator/openai/claude/openai_claude_request.go` behaviour), and routed the top-level user-image path and the nested `tool_result` image path through it.
- Added `TestConvertClaudeRequestToCodex_ImageSources` covering base64 + URL cases.

## Root cause

`codex_claude_request.go` handled image content at two call sites (top-level user message + `tool_result.content[]`) but only read `source.data` / `source.base64`. Anthropic's API also allows `{"type":"image","source":{"type":"url","url":"..."}}`, which was silently skipped — no error surfaced upstream, the request simply reached Codex with text only.

## Verification

- `go build ./...`
- `go vet ./internal/translator/codex/claude/...`
- `go test ./internal/translator/codex/claude/...`
- Live E2E against a local build on `127.0.0.1:8318`: Claude `/v1/messages` with `source.type="url"` image + `model: gpt-5.4` → response: `"The image shows the GitHub logo, a black Octocat silhouette in a circle."` (before the fix, the model saw text only and described no image).

## Test plan

- [x] Base64 source still produces `input_image` with a `data:<mime>;base64,...` URL
- [x] URL source produces `input_image` with the original URL
- [x] `go test ./internal/translator/codex/claude/...` passes
- [x] Live E2E via Claude-format client on `gpt-5.4`

## Out of scope (follow-ups)

Discovered during review, not addressed here to keep the fix minimal:

1. `source.type == "file"` (Anthropic file_id) still returns empty from the helper — both call sites will skip it. Requires the helper to return a structured image part (`image_url` vs `file_id`), not a string.
2. `tool_result.content` as a single image object (non-array) falls through to the string path. Sibling `openai_claude_request.go` already handles this shape.
3. `internal/translator/antigravity/claude/antigravity_claude_request.go` has the same URL-source gap (base64 only at lines 281/317/347) and its existing tests lock that behaviour.

Happy to split these into separate PRs if the project prefers.