### PR TITLE
.1616750161180714:2fb665accdd718b4eb14a70501355dff_69e6d82a59f68fc20e58829f.69e6ddf559f68fc20e5882e1.69e6ddf590f0ee6098651891:Trae CN.T(2026/4/21 10:16:21)

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -193,8 +193,8 @@ func (h *Handler) APICall(c *gin.Context) {
 
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
-		log.WithError(errDo).Debug("management APICall request failed")
-		c.JSON(http.StatusBadGateway, gin.H{"error": "request failed"})
+		log.WithError(errDo).Error("management APICall request failed")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "request failed: " + errDo.Error()})
 		return
 	}
 	defer func() {

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -48,6 +49,7 @@ type apiCallRequest struct {
 	URL             string            `json:"url"`
 	Header          map[string]string `json:"header"`
 	Data            string            `json:"data"`
+	Insecure        bool              `json:"insecure"`
 }
 
 type apiCallResponse struct {
@@ -189,7 +191,7 @@ func (h *Handler) APICall(c *gin.Context) {
 	httpClient := &http.Client{
 		Timeout: defaultAPICallTimeout,
 	}
-	httpClient.Transport = h.apiCallTransport(auth)
+	httpClient.Transport = h.apiCallTransport(auth, body.Insecure)
 
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
@@ -318,7 +320,7 @@ func (h *Handler) refreshGeminiOAuthAccessToken(ctx context.Context, auth *corea
 	ctxToken := ctx
 	httpClient := &http.Client{
 		Timeout:   defaultAPICallTimeout,
-		Transport: h.apiCallTransport(auth),
+		Transport: h.apiCallTransport(auth, false),
 	}
 	ctxToken = context.WithValue(ctxToken, oauth2.HTTPClient, httpClient)
 
@@ -377,7 +379,7 @@ func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *
 
 	httpClient := &http.Client{
 		Timeout:   defaultAPICallTimeout,
-		Transport: h.apiCallTransport(auth),
+		Transport: h.apiCallTransport(auth, false),
 	}
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
@@ -631,7 +633,7 @@ func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {
 	return nil
 }
 
-func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
+func (h *Handler) apiCallTransport(auth *coreauth.Auth, insecure bool) http.RoundTripper {
 	var proxyCandidates []string
 	if auth != nil {
 		if proxyStr := strings.TrimSpace(auth.ProxyURL); proxyStr != "" {
@@ -651,16 +653,32 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
 
 	for _, proxyStr := range proxyCandidates {
 		if transport := buildProxyTransport(proxyStr); transport != nil {
+			if insecure {
+				if transport.TLSClientConfig == nil {
+					transport.TLSClientConfig = &tls.Config{}
+				}
+				transport.TLSClientConfig.InsecureSkipVerify = true
+			}
 			return transport
 		}
 	}
 
 	transport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok || transport == nil {
-		return &http.Transport{Proxy: nil}
+		t := &http.Transport{Proxy: nil}
+		if insecure {
+			t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		}
+		return t
 	}
 	clone := transport.Clone()
 	clone.Proxy = nil
+	if insecure {
+		if clone.TLSClientConfig == nil {
+			clone.TLSClientConfig = &tls.Config{}
+		}
+		clone.TLSClientConfig.InsecureSkipVerify = true
+	}
 	return clone
 }
 

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -19,7 +19,7 @@ func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 		},
 	}
 
-	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "direct"})
+	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "direct"}, false)
 	httpTransport, ok := transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", transport)
@@ -38,7 +38,7 @@ func TestAPICallTransportInvalidAuthFallsBackToGlobalProxy(t *testing.T) {
 		},
 	}
 
-	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "bad-value"})
+	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "bad-value"}, false)
 	httpTransport, ok := transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", transport)
@@ -135,7 +135,7 @@ func TestAPICallTransportAPIKeyAuthFallsBackToConfigProxyURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			transport := h.apiCallTransport(tc.auth)
+			transport := h.apiCallTransport(tc.auth, false)
 			httpTransport, ok := transport.(*http.Transport)
 			if !ok {
 				t.Fatalf("transport type = %T, want *http.Transport", transport)


### PR DESCRIPTION
修改API调用失败时的日志级别以更准确反映问题严重性，同时在返回给客户端的错误信息中包含具体错误原因，便于问题排查