### PR TITLE
fix(claude): disable thinking for custom compat upstreams

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -169,6 +170,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
+	body = disableThinkingForCustomClaudeCompat(body, baseURL)
 	body = normalizeClaudeTemperatureForThinking(body)
 
 	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
@@ -354,6 +356,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
+	body = disableThinkingForCustomClaudeCompat(body, baseURL)
 	body = normalizeClaudeTemperatureForThinking(body)
 
 	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
@@ -716,6 +719,84 @@ func disableThinkingIfToolChoiceForced(body []byte) []byte {
 		}
 	}
 	return body
+}
+
+// disableThinkingForCustomClaudeCompat works around Claude-compatible upstreams that
+// reject tool-use history unless every assistant tool_call message carries reasoning.
+// Real Anthropic endpoints accept native thinking blocks, so only apply this fallback
+// for non-Anthropic base URLs when the history already contains assistant tool_use
+// messages that do not start with thinking/redacted_thinking.
+func disableThinkingForCustomClaudeCompat(body []byte, baseURL string) []byte {
+	if !customClaudeCompatNeedsThinkingDisabled(body, baseURL) {
+		return body
+	}
+	body, _ = sjson.DeleteBytes(body, "thinking")
+	body, _ = sjson.DeleteBytes(body, "output_config.effort")
+	if oc := gjson.GetBytes(body, "output_config"); oc.Exists() && oc.IsObject() && len(oc.Map()) == 0 {
+		body, _ = sjson.DeleteBytes(body, "output_config")
+	}
+	return body
+}
+
+func customClaudeCompatNeedsThinkingDisabled(body []byte, baseURL string) bool {
+	if len(body) == 0 || !gjson.ValidBytes(body) || isOfficialAnthropicBaseURL(baseURL) {
+		return false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "thinking.type").String())) {
+	case "enabled", "adaptive", "auto":
+	default:
+		return false
+	}
+
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return false
+	}
+
+	missingThinking := false
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "assistant" {
+			return true
+		}
+		content := msg.Get("content")
+		if !content.Exists() || !content.IsArray() {
+			return true
+		}
+
+		firstType := ""
+		hasToolUse := false
+		content.ForEach(func(idx, part gjson.Result) bool {
+			partType := part.Get("type").String()
+			if idx.Int() == 0 {
+				firstType = partType
+			}
+			if partType == "tool_use" {
+				hasToolUse = true
+			}
+			return true
+		})
+
+		if hasToolUse && firstType != "thinking" && firstType != "redacted_thinking" {
+			missingThinking = true
+			return false
+		}
+		return true
+	})
+
+	return missingThinking
+}
+
+func isOfficialAnthropicBaseURL(baseURL string) bool {
+	trimmed := strings.TrimSpace(baseURL)
+	if trimmed == "" {
+		return true
+	}
+	parsed, err := url.Parse(trimmed)
+	if err == nil && parsed.Hostname() != "" {
+		return strings.EqualFold(parsed.Hostname(), "api.anthropic.com")
+	}
+	return strings.EqualFold(trimmed, "https://api.anthropic.com")
 }
 
 // normalizeClaudeTemperatureForThinking keeps Anthropic message requests valid when

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1986,6 +1986,72 @@ func TestNormalizeClaudeTemperatureForThinking_AfterForcedToolChoiceKeepsOrigina
 	}
 }
 
+func TestDisableThinkingForCustomClaudeCompat_RemovesThinkingOnCustomBaseURL(t *testing.T) {
+	payload := []byte(`{
+		"temperature": 0,
+		"thinking": {"type":"adaptive"},
+		"output_config": {"effort":"medium"},
+		"messages": [
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"Read","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"ok"}]}
+		]
+	}`)
+
+	out := disableThinkingForCustomClaudeCompat(payload, "https://api.kimi.com/coding/")
+	out = normalizeClaudeTemperatureForThinking(out)
+
+	if gjson.GetBytes(out, "thinking").Exists() {
+		t.Fatalf("thinking should be removed for custom Claude-compatible fallback")
+	}
+	if gjson.GetBytes(out, "output_config.effort").Exists() {
+		t.Fatalf("output_config.effort should be removed for custom Claude-compatible fallback")
+	}
+	if got := gjson.GetBytes(out, "temperature").Float(); got != 0 {
+		t.Fatalf("temperature = %v, want 0 after thinking fallback removal", got)
+	}
+}
+
+func TestDisableThinkingForCustomClaudeCompat_KeepsThinkingForOfficialAnthropic(t *testing.T) {
+	payload := []byte(`{
+		"thinking": {"type":"adaptive"},
+		"output_config": {"effort":"medium"},
+		"messages": [
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"Read","input":{}}]}
+		]
+	}`)
+
+	out := disableThinkingForCustomClaudeCompat(payload, "https://api.anthropic.com")
+
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive", got)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "medium" {
+		t.Fatalf("output_config.effort = %q, want medium", got)
+	}
+}
+
+func TestDisableThinkingForCustomClaudeCompat_KeepsThinkingWhenToolUseStartsWithThinking(t *testing.T) {
+	payload := []byte(`{
+		"thinking": {"type":"adaptive"},
+		"output_config": {"effort":"medium"},
+		"messages": [
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"reasoning","signature":""},
+				{"type":"tool_use","id":"call_1","name":"Read","input":{}}
+			]}
+		]
+	}`)
+
+	out := disableThinkingForCustomClaudeCompat(payload, "https://api.kimi.com/coding/")
+
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive", got)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.type").String(); got != "thinking" {
+		t.Fatalf("messages.0.content.0.type = %q, want thinking", got)
+	}
+}
+
 func TestRemapOAuthToolNames_TitleCase_NoReverseNeeded(t *testing.T) {
 	body := []byte(`{"tools":[{"name":"Bash","description":"Run shell commands","input_schema":{"type":"object","properties":{"cmd":{"type":"string"}}}}],"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
 


### PR DESCRIPTION
## Summary
- add a narrow Claude executor fallback for non-Anthropic `/v1/messages` providers
- disable outgoing thinking only when the request history already contains assistant `tool_use` messages that do not start with `thinking` / `redacted_thinking`
- add regression tests covering custom-base fallback vs official Anthropic passthrough

## Problem
Some third-party providers expose an Anthropic-compatible Messages API at a custom base URL, but they reject thinking-enabled conversations when prior assistant tool-call messages do not carry the reasoning state they expect.

In practice this shows up as errors like:

```json
{
  "error": {
    "type": "invalid_request_error",
    "message": "thinking is enabled but reasoning_content is missing in assistant tool call message at index 53"
  }
}
```

This occurs on custom Claude-compatible endpoints even though the same request shape is not treated the same way by the official Anthropic API.

## Root Cause
`ClaudeExecutor` currently forwards `thinking` unchanged for both official Anthropic and custom Anthropic-compatible base URLs.

For some non-Anthropic providers, that becomes invalid when the existing assistant tool-use history already contains messages such as:

- `[{ "type": "tool_use", ... }]`
- `[{ "type": "text", ... }, { "type": "tool_use", ... }]`

without a leading `thinking` / `redacted_thinking` block.

Those providers then reject the request before inference begins.

## Fix
Add a narrow compatibility fallback in `internal/runtime/executor/claude_executor.go`:

- only consider **non-official Anthropic** base URLs
- only trigger when `thinking.type` is enabled/adaptive/auto
- only trigger when at least one assistant message contains `tool_use` but does **not** begin with `thinking` / `redacted_thinking`
- when triggered, remove:
  - `thinking`
  - `output_config.effort`
- leave official `https://api.anthropic.com` behavior unchanged

This keeps the existing Anthropic-native path intact while preventing hard 400 failures on custom Claude-compatible providers.

## Tests
Added executor tests for:
- removing thinking on a custom Claude-compatible base URL with tool-use history lacking leading thinking
- preserving thinking for official Anthropic base URLs
- preserving thinking when assistant tool-use history already starts with a valid thinking block

## Validation
- `go test ./internal/runtime/executor`
- `go build -o /tmp/cliproxyapi-pr-check ./cmd/server`

## Notes
This is intentionally a compatibility fallback, not a protocol reinterpretation for official Anthropic traffic.
