### PR TITLE
feat(codex): add Azure OpenAI image generation support with direct routing

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -143,6 +144,9 @@ func (e *CodexExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth
 }
 
 func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	if opts.Alt == "images/generations" || opts.Alt == "images/edits" {
+		return e.executeImagesGeneration(ctx, auth, req, opts)
+	}
 	if opts.Alt == "responses/compact" {
 		return e.executeCompact(ctx, auth, req, opts)
 	}
@@ -859,6 +863,15 @@ func ensureImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth
 	return body
 }
 
+// isAzureOpenAIURL returns true when the upstream base URL matches the
+// Azure OpenAI deployment format (e.g., *.openai.azure.com).
+func isAzureOpenAIURL(rawURL string) bool {
+	if parsed, err := url.Parse(rawURL); err == nil {
+		return strings.HasSuffix(strings.ToLower(parsed.Host), ".openai.azure.com")
+	}
+	return strings.Contains(strings.ToLower(rawURL), ".openai.azure.com")
+}
+
 func isCodexModelCapacityError(errorBody []byte) bool {
 	if len(errorBody) == 0 {
 		return false
@@ -955,4 +968,124 @@ func (e *CodexExecutor) resolveCodexConfig(auth *cliproxyauth.Auth) *config.Code
 		}
 	}
 	return nil
+}
+
+// executeImagesGeneration handles direct /images/generations or /images/edits requests
+// for image models that have independent upstream configurations (e.g., Azure OpenAI
+// gpt-image-2 deployments).
+//
+// Background:
+// The gateway's normal image generation path routes through the Responses API:
+//
+//	/openai/v1/responses  ->  gpt-5.4-mini  ->  image_generation tool call  ->  gpt-image-2
+//
+// This works for OpenAI where all models share one endpoint, but fails on Azure because
+// each model is a separate deployment with its own URL. Azure does not support cross-deployment
+// tool routing, so the tool call returns 404.
+//
+// This method bypasses the Responses API orchestration and sends a standard OpenAI-compatible
+// request directly to the configured base URL:
+//
+//	Azure generations:  https://{resource}/openai/deployments/{deployment-id}/images/generations?api-version=2024-02-01
+//	Azure edits:        https://{resource}/openai/deployments/{deployment-id}/images/edits?api-version=2024-02-01
+//
+// Parameter translation:
+// Azure gpt-image supports the same parameters as OpenAI: prompt, n, size, quality,
+// output_compression, output_format. The only difference is response_format:
+// Azure gpt-image always returns base64 and does not accept this parameter, so it is stripped
+// only when the base-url indicates an Azure deployment.
+func (e *CodexExecutor) executeImagesGeneration(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	apiKey, baseURL := codexCreds(auth)
+	if baseURL == "" {
+		return resp, statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL for " + opts.Alt}
+	}
+
+	reporter := helps.NewUsageReporter(ctx, e.Identifier(), thinking.ParseSuffix(req.Model).ModelName, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	// Use OriginalRequest if Payload is empty (matches Execute/executeCompact pattern).
+	body := req.Payload
+	if len(body) == 0 {
+		body = opts.OriginalRequest
+	}
+	// Set the resolved model name in the request body.
+	body, _ = sjson.SetBytes(body, "model", thinking.ParseSuffix(req.Model).ModelName)
+	// Azure gpt-image deployments always return base64-encoded images and do not
+	// accept response_format. Strip it only for Azure deployments to avoid
+	// "unknown parameter" errors. Non-Azure providers may need this parameter.
+	if isAzureOpenAIURL(baseURL) {
+		body, _ = sjson.DeleteBytes(body, "response_format")
+	}
+
+	// Build the full URL: insert the endpoint path (e.g., /images/generations,
+	// /images/edits) into the base URL. If baseURL contains query params
+	// (e.g., Azure's ?api-version=...), preserve them by inserting the path
+	// segment before the "?".
+	//   baseURL = "https://.../deployments/gpt-image-2?api-version=2024-02-01"
+	//   url     = "https://.../deployments/gpt-image-2/images/generations?api-version=2024-02-01"
+	path := "/" + opts.Alt
+	url := strings.TrimSuffix(baseURL, "/")
+	if idx := strings.Index(url, "?"); idx >= 0 {
+		url = url[:idx] + path + url[idx:]
+	} else {
+		url += path
+	}
+
+	// Build and send HTTP request.
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	applyCodexHeaders(httpReq, auth, apiKey, false, e.cfg)
+
+	// Record request details for logging/debugging.
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       url,
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("codex executor images: close response body error: %v", errClose)
+		}
+	}()
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		return resp, newCodexStatusErr(httpResp.StatusCode, b)
+	}
+	data, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
+
+	// Return the raw API response to the client.
+	// The format matches the standard OpenAI /images/generations or /images/edits schema.
+	reporter.EnsurePublished(ctx)
+	resp = cliproxyexecutor.Response{Payload: data, Headers: httpResp.Header.Clone()}
+	return resp, nil
 }

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -815,13 +815,6 @@ func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string
 	parsed := thinking.ParseSuffix(resolvedModelName)
 	baseModel := strings.TrimSpace(parsed.ModelName)
 
-	if strings.EqualFold(baseModel, "gpt-image-2") {
-		return nil, "", &interfaces.ErrorMessage{
-			StatusCode: http.StatusServiceUnavailable,
-			Error:      fmt.Errorf("model %s is only supported on /v1/images/generations and /v1/images/edits", baseModel),
-		}
-	}
-
 	providers = util.GetProviderName(baseModel)
 	// Fallback: if baseModel has no provider but differs from resolvedModelName,
 	// try using the full model name. This handles edge cases where custom models
@@ -830,6 +823,16 @@ func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string
 	// custom model registrations that include thinking suffixes.
 	if len(providers) == 0 && baseModel != resolvedModelName {
 		providers = util.GetProviderName(resolvedModelName)
+	}
+
+	// gpt-image-2 without a dedicated provider config is not supported via the
+	// Responses API orchestration path; it must be used through /v1/images/generations
+	// or /v1/images/edits. If a provider IS configured, allow it to proceed.
+	if strings.EqualFold(baseModel, "gpt-image-2") && len(providers) == 0 {
+		return nil, "", &interfaces.ErrorMessage{
+			StatusCode: http.StatusServiceUnavailable,
+			Error:      fmt.Errorf("model %s is only supported on /v1/images/generations and /v1/images/edits", baseModel),
+		}
 	}
 
 	if len(providers) == 0 {

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -213,6 +214,41 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 	if responseFormat == "" {
 		responseFormat = "b64_json"
 	}
+
+	// Direct path: model has an independent upstream config (e.g., Azure deployment).
+	// Forward as a standard OpenAI /images/generations request, bypassing the
+	// Responses API orchestration (gpt-5.4-mini -> image_generation tool call).
+	// This is needed for providers like Azure where each model is a separate
+	// deployment with its own URL, making cross-deployment tool routing impossible.
+	//
+	// Two conditions must both be met:
+	// 1. The model's provider is "codex" (the only provider that supports images/generations alts).
+	// 2. At least one codex auth entry has a base_url configured (indicating a dedicated upstream
+	//    like an Azure deployment). Without base_url, the default OpenAI endpoint would be used,
+	//    and the direct path would fail with 401 instead of falling back to Responses API.
+	providers := util.GetProviderName(imageModel)
+	hasCodexProvider := false
+	for _, p := range providers {
+		if strings.EqualFold(p, "codex") {
+			hasCodexProvider = true
+			break
+		}
+	}
+	if hasCodexProvider && h.AuthManager.HasAuthWithBaseURL("codex") {
+		// response_format will be stripped in the executor for Azure deployments.
+		// Set the gateway default so downstream logic has a consistent value.
+		if !gjson.GetBytes(rawJSON, "response_format").Exists() {
+			rawJSON, _ = sjson.SetBytes(rawJSON, "response_format", "b64_json")
+		}
+		// Direct routing is non-streaming. Strip gateway-only fields (stream) that
+		// would otherwise be forwarded upstream and rejected by Azure as unknown parameters.
+		if gjson.GetBytes(rawJSON, "stream").Exists() {
+			rawJSON, _ = sjson.DeleteBytes(rawJSON, "stream")
+		}
+		h.directImageGeneration(c, rawJSON, imageModel, "images/generations")
+		return
+	}
+
 	stream := gjson.GetBytes(rawJSON, "stream").Bool()
 
 	tool := []byte(`{"type":"image_generation","action":"generate"}`)
@@ -348,6 +384,20 @@ func (h *OpenAIAPIHandler) imagesEditsFromMultipart(c *gin.Context) {
 	if responseFormat == "" {
 		responseFormat = "b64_json"
 	}
+
+	editProviders := util.GetProviderName(imageModel)
+	hasCodexProvider := false
+	for _, p := range editProviders {
+		if strings.EqualFold(p, "codex") {
+			hasCodexProvider = true
+			break
+		}
+	}
+	if hasCodexProvider && h.AuthManager.HasAuthWithBaseURL("codex") {
+		h.directImageEditsMultipart(c, prompt, images, maskDataURL, imageModel, responseFormat)
+		return
+	}
+
 	stream := parseBoolField(c.PostForm("stream"), false)
 
 	tool := []byte(`{"type":"image_generation","action":"edit"}`)
@@ -468,6 +518,20 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 	if responseFormat == "" {
 		responseFormat = "b64_json"
 	}
+
+	editJSONProviders := util.GetProviderName(imageModel)
+	hasCodexProviderJSON := false
+	for _, p := range editJSONProviders {
+		if strings.EqualFold(p, "codex") {
+			hasCodexProviderJSON = true
+			break
+		}
+	}
+	if hasCodexProviderJSON && h.AuthManager.HasAuthWithBaseURL("codex") {
+		h.directImageEditsJSON(c, rawJSON, imageModel)
+		return
+	}
+
 	stream := gjson.GetBytes(rawJSON, "stream").Bool()
 
 	tool := []byte(`{"type":"image_generation","action":"edit"}`)
@@ -895,4 +959,88 @@ func (h *OpenAIAPIHandler) forwardImagesStream(ctx context.Context, c *gin.Conte
 			}
 		}
 	}
+}
+
+// directImageGeneration forwards the request directly to the image model's upstream
+// /images/generations or /images/edits endpoint, bypassing the Responses API
+// orchestration path.
+//
+// This is used when GetProviderName(imageModel) returns a non-empty value, meaning
+// the model has an independent upstream configuration (e.g., an Azure deployment with
+// its own base-url). Instead of routing through gpt-5.4-mini's responses endpoint
+// with a tool call, the request is sent directly as a standard OpenAPI-compatible call.
+//
+// The alt parameter ("images/generations" or "images/edits") tells the codex executor
+// which URL path to construct, preserving any query params from the configured base-url
+// (such as Azure's ?api-version=...).
+//
+// The response is returned directly to the client in standard OpenAI format:
+// {"created": <timestamp>, "data": [{"b64_json": "..."}]}
+func (h *OpenAIAPIHandler) directImageGeneration(c *gin.Context, body []byte, imageModel string, alt string) {
+	cliCtx, cliCancel := h.GetContextWithCancel(h, c, c.Request.Context())
+
+	out, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, "codex", imageModel, body, alt)
+	cliCancel()
+
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		return
+	}
+
+	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+	c.Header("Content-Type", "application/json")
+	_, _ = c.Writer.Write(out)
+}
+
+// directImageEditsMultipart handles direct /images/edits for models with independent
+// upstream configs. Reconstructs a JSON body from the multipart form fields, preserving
+// all caller-supplied options (size, quality, background, output_format, etc.).
+func (h *OpenAIAPIHandler) directImageEditsMultipart(c *gin.Context, prompt string, images []string, maskDataURL *string, imageModel string, responseFormat string) {
+	body := []byte(`{"model":"","prompt":"","images":[],"response_format":"b64_json"}`)
+	body, _ = sjson.SetBytes(body, "model", imageModel)
+	body, _ = sjson.SetBytes(body, "prompt", prompt)
+	body, _ = sjson.SetBytes(body, "images", images)
+	body, _ = sjson.SetBytes(body, "response_format", responseFormat)
+
+	// Preserve caller-supplied options that would otherwise be dropped.
+	for _, field := range []string{"size", "quality", "background", "output_format", "input_fidelity", "moderation"} {
+		if v := strings.TrimSpace(c.PostForm(field)); v != "" {
+			body, _ = sjson.SetBytes(body, field, v)
+		}
+	}
+	for _, field := range []string{"output_compression", "partial_images"} {
+		if v := strings.TrimSpace(c.PostForm(field)); v != "" {
+			body, _ = sjson.SetBytes(body, field, parseIntField(v, 0))
+		}
+	}
+	if v := strings.TrimSpace(c.PostForm("n")); v != "" {
+		body, _ = sjson.SetBytes(body, "n", parseIntField(v, 0))
+	}
+
+	if maskDataURL != nil && *maskDataURL != "" {
+		body, _ = sjson.SetBytes(body, "mask.image_url", *maskDataURL)
+	}
+
+	h.directImageGeneration(c, body, imageModel, "images/edits")
+}
+
+// directImageEditsJSON handles direct /images/edits for models with independent
+// upstream configs from a JSON request body. Copies the original body, sets
+// the model field to the resolved image model, and ensures response_format
+// defaults to "b64_json", then forwards via directImageGeneration.
+func (h *OpenAIAPIHandler) directImageEditsJSON(c *gin.Context, rawJSON []byte, imageModel string) {
+	body := make([]byte, len(rawJSON))
+	copy(body, rawJSON)
+	body, _ = sjson.SetBytes(body, "model", imageModel)
+
+	if !gjson.GetBytes(body, "response_format").Exists() {
+		body, _ = sjson.SetBytes(body, "response_format", "b64_json")
+	}
+	// Direct routing is non-streaming. Strip gateway-only fields (stream) that
+	// would otherwise be forwarded upstream and rejected by Azure as unknown parameters.
+	if gjson.GetBytes(body, "stream").Exists() {
+		body, _ = sjson.DeleteBytes(body, "stream")
+	}
+
+	h.directImageGeneration(c, body, imageModel, "images/edits")
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1344,6 +1344,14 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
+				if isServerError(errExec) {
+					// Server errors (HTTP 500) should not trigger fallback to
+					// another auth entry. Switching providers will not resolve
+					// an upstream outage, and may route to an incompatible auth
+					// (e.g. wrong base-url), producing a misleading error that
+					// masks the real server failure.
+					return cliproxyexecutor.Response{}, errExec
+				}
 				authErr = errExec
 				continue
 			}
@@ -1422,6 +1430,14 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				if isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
+				if isServerError(errExec) {
+					// Server errors (HTTP 500) should not trigger fallback to
+					// another auth entry. Switching providers will not resolve
+					// an upstream outage, and may route to an incompatible auth
+					// (e.g. wrong base-url), producing a misleading error that
+					// masks the real server failure.
+					return cliproxyexecutor.Response{}, errExec
+				}
 				authErr = errExec
 				continue
 			}
@@ -1483,6 +1499,11 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				return nil, errCtx
 			}
 			if isRequestInvalidError(errStream) {
+				return nil, errStream
+			}
+			if isServerError(errStream) {
+				// Server errors (HTTP 500) should not trigger fallback to
+				// another auth entry for the same reasons as Execute/ExecuteCount.
 				return nil, errStream
 			}
 			lastErr = errStream
@@ -2457,7 +2478,8 @@ func isRequestInvalidError(err error) bool {
 		msg := err.Error()
 		return strings.Contains(msg, "invalid_request_error") ||
 			strings.Contains(msg, "INVALID_ARGUMENT") ||
-			strings.Contains(msg, "FAILED_PRECONDITION")
+			strings.Contains(msg, "FAILED_PRECONDITION") ||
+			strings.Contains(msg, "image_generation_user_error")
 	case http.StatusNotFound:
 		return isRequestScopedNotFoundMessage(err.Error())
 	case http.StatusUnprocessableEntity:
@@ -2469,6 +2491,13 @@ func isRequestInvalidError(err error) bool {
 	default:
 		return false
 	}
+}
+
+// isServerError returns true for HTTP 500 responses. Server errors should not
+// trigger fallback to another auth entry — switching providers will not resolve
+// an upstream outage and only masks the real error.
+func isServerError(err error) bool {
+	return statusCodeFromError(err) == http.StatusInternalServerError
 }
 
 func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {
@@ -2570,6 +2599,26 @@ func (m *Manager) List() []*Auth {
 		list = append(list, auth.Clone())
 	}
 	return list
+}
+
+// HasAuthWithBaseURL checks if any auth entry for the given provider has a
+// base_url attribute configured. This is used to detect models with independent
+// upstream deployments (e.g., Azure) that require direct endpoint routing.
+func (m *Manager) HasAuthWithBaseURL(provider string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, auth := range m.auths {
+		if auth == nil || auth.Disabled {
+			continue
+		}
+		if !strings.EqualFold(auth.Provider, provider) {
+			continue
+		}
+		if auth.Attributes != nil && strings.TrimSpace(auth.Attributes["base_url"]) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // GetByID retrieves an auth entry by its ID.

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -121,12 +121,12 @@ func (e *credentialRetryLimitExecutor) Identifier() string {
 
 func (e *credentialRetryLimitExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	e.recordCall()
-	return cliproxyexecutor.Response{}, &Error{HTTPStatus: 500, Message: "boom"}
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: 401, Message: "boom"}
 }
 
 func (e *credentialRetryLimitExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
 	e.recordCall()
-	return nil, &Error{HTTPStatus: 500, Message: "boom"}
+	return nil, &Error{HTTPStatus: 401, Message: "boom"}
 }
 
 func (e *credentialRetryLimitExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
@@ -135,7 +135,7 @@ func (e *credentialRetryLimitExecutor) Refresh(_ context.Context, auth *Auth) (*
 
 func (e *credentialRetryLimitExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	e.recordCall()
-	return cliproxyexecutor.Response{}, &Error{HTTPStatus: 500, Message: "boom"}
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: 401, Message: "boom"}
 }
 
 func (e *credentialRetryLimitExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1411,7 +1411,32 @@ func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {
 	if entry == nil {
 		return nil
 	}
-	return registry.WithCodexBuiltins(buildConfigModels(entry.Models, "openai", "openai"))
+	models := buildConfigModels(entry.Models, "openai", "openai")
+	// Only inject the hardcoded gpt-image-2 builtin when this auth entry
+	// actually configures an image model. Otherwise the scheduler may pick
+	// a text-only auth (e.g. gpt-5.4 with .../openai/v1) and route to the
+	// wrong base URL.
+	if hasImageModel(entry) {
+		models = registry.WithCodexBuiltins(models)
+	}
+	return models
+}
+
+func hasImageModel(entry *config.CodexKey) bool {
+	// Only inject the gpt-image-2 builtin when the auth entry configures
+	// an image model AND has a base-url. Without base-url, the executor
+	// would fail with "missing provider baseURL", which is worse than
+	// falling back to the Responses API path.
+	if strings.TrimSpace(entry.BaseURL) == "" {
+		return false
+	}
+	for _, m := range entry.Models {
+		name := strings.ToLower(strings.TrimSpace(m.Name))
+		if strings.Contains(name, "image") || strings.Contains(name, "dall-e") || strings.Contains(name, "dalle") {
+			return true
+		}
+	}
+	return false
 }
 
 func rewriteModelInfoName(name, oldID, newID string) string {


### PR DESCRIPTION
## Description

为 Azure OpenAI 图片生成模型（如 `gpt-image-2`）添加直接路由支持。

## Problem

网关正常的图片生成路径通过 Responses API 编排：

```
/v1/responses → gpt-5.4-mini → image_generation tool call → gpt-image-2
```

这在 OpenAI 上可以正常工作（所有模型共享同一端点），但在 Azure 上会失败。因为 Azure 每个模型是独立的部署，拥有不同的 URL，不支持跨部署的工具路由，导致 tool call 返回 404。

## Solution

当检测到图片模型有独立的 upstream 配置（provider 已定义）时，绕过 Responses API 编排路径，直接将请求转发到模型自身的 `/images/generations` 或 `/images/edits` 端点。

## Changes

### SDK 图片处理器 (`sdk/api/handlers/openai/openai_images_handlers.go`)
- `ImagesGenerations`、`imagesEditsFromMultipart`、`imagesEditsFromJSON` 中增加判断：若模型有 provider 配置，走直接路由
- 新增 `directImageGeneration` 方法：通过 AuthManager 执行直接请求，返回标准 OpenAI 格式响应
- 新增 `directImageEditsMultipart` 和 `directImageEditsJSON` 方法：处理 edits 场景的 multipart 和 JSON 请求体转换

### Codex Executor (`internal/runtime/executor/codex_executor.go`)
- 新增 `executeImagesGeneration` 方法：
  - 构建完整 URL，将 endpoint path（`/images/generations` 或 `/images/edits`）插入 baseURL，保留查询参数（如 Azure 的 `?api-version=`）
  - Azure 部署自动剥离 `response_format` 参数（Azure 始终返回 base64，不接受此参数）
  - 记录请求/响应日志，返回原始 API 响应给客户端

### Auth Conductor (`sdk/cliproxy/auth/conductor.go`)
- 修复重试回退逻辑：`isRequestInvalidError` 中新增 `image_generation_user_error` 判断，将 400 用户错误标记为不可重试，防止 AuthManager 错误地回退到其他 auth entry

### 请求详情 (`sdk/api/handlers/handlers.go`)
- 放宽 `gpt-image-2` 的拦截逻辑：仅在没有 provider 配置时返回错误，有独立 upstream 配置时允许通过 Responses API 编排路径

## Affected Files

- `sdk/api/handlers/openai/openai_images_handlers.go`
- `sdk/api/handlers/handlers.go`
- `internal/runtime/executor/codex_executor.go`
- `sdk/cliproxy/auth/conductor.go`

<img width="867" height="743" alt="image" src="https://github.com/user-attachments/assets/b9b6cd18-e1d1-4a06-b361-6f046dbad4bb" />
