### PR TITLE
feat(codex): inject image_generation tool + route aliases for Codex CLI image generation

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -353,6 +353,15 @@ func (s *Server) setupRoutes() {
 		v1.POST("/responses/compact", openaiResponsesHandlers.Compact)
 	}
 
+	// Codex CLI direct route aliases (chatgpt_base_url compatible)
+	codexDirect := s.engine.Group("/backend-api/codex")
+	codexDirect.Use(AuthMiddleware(s.accessManager))
+	{
+		codexDirect.GET("/responses", openaiResponsesHandlers.ResponsesWebsocket)
+		codexDirect.POST("/responses", openaiResponsesHandlers.Responses)
+		codexDirect.POST("/responses/compact", openaiResponsesHandlers.Compact)
+	}
+
 	// Gemini compatible API routes
 	v1beta := s.engine.Group("/v1beta")
 	v1beta.Use(AuthMiddleware(s.accessManager))

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -180,6 +180,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = normalizeCodexInstructions(body)
+	body = ensureImageGenerationTool(body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -326,6 +327,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body, _ = sjson.DeleteBytes(body, "stream")
 	body = normalizeCodexInstructions(body)
+	body = ensureImageGenerationTool(body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses/compact"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -420,6 +422,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body = normalizeCodexInstructions(body)
+	body = ensureImageGenerationTool(body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -818,6 +821,24 @@ func normalizeCodexInstructions(body []byte) []byte {
 	if !instructions.Exists() || instructions.Type == gjson.Null {
 		body, _ = sjson.SetBytes(body, "instructions", "")
 	}
+	return body
+}
+
+var imageGenToolJSON = []byte(`{"type":"image_generation","output_format":"png"}`)
+var imageGenToolArrayJSON = []byte(`[{"type":"image_generation","output_format":"png"}]`)
+
+func ensureImageGenerationTool(body []byte) []byte {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		body, _ = sjson.SetRawBytes(body, "tools", imageGenToolArrayJSON)
+		return body
+	}
+	for _, t := range tools.Array() {
+		if t.Get("type").String() == "image_generation" {
+			return body
+		}
+	}
+	body, _ = sjson.SetRawBytes(body, "tools.-1", imageGenToolJSON)
 	return body
 }
 

--- a/internal/runtime/executor/codex_executor_imagegen_test.go
+++ b/internal/runtime/executor/codex_executor_imagegen_test.go
@@ -1,0 +1,89 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestEnsureImageGenerationTool_NoTools(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","input":"draw a cat"}`)
+	result := ensureImageGenerationTool(body)
+
+	tools := gjson.GetBytes(result, "tools")
+	if !tools.IsArray() {
+		t.Fatalf("expected tools array, got %v", tools.Type)
+	}
+	arr := tools.Array()
+	if len(arr) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(arr))
+	}
+	if arr[0].Get("type").String() != "image_generation" {
+		t.Fatalf("expected type=image_generation, got %s", arr[0].Get("type").String())
+	}
+	if arr[0].Get("output_format").String() != "png" {
+		t.Fatalf("expected output_format=png, got %s", arr[0].Get("output_format").String())
+	}
+}
+
+func TestEnsureImageGenerationTool_ExistingToolsWithoutImageGen(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"get_weather","parameters":{}}]}`)
+	result := ensureImageGenerationTool(body)
+
+	tools := gjson.GetBytes(result, "tools")
+	arr := tools.Array()
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(arr))
+	}
+	if arr[0].Get("type").String() != "function" {
+		t.Fatalf("expected first tool type=function, got %s", arr[0].Get("type").String())
+	}
+	if arr[1].Get("type").String() != "image_generation" {
+		t.Fatalf("expected second tool type=image_generation, got %s", arr[1].Get("type").String())
+	}
+}
+
+func TestEnsureImageGenerationTool_AlreadyPresent(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"image_generation","output_format":"webp"},{"type":"function","name":"f1"}]}`)
+	result := ensureImageGenerationTool(body)
+
+	tools := gjson.GetBytes(result, "tools")
+	arr := tools.Array()
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 tools (no duplicate), got %d", len(arr))
+	}
+	if arr[0].Get("output_format").String() != "webp" {
+		t.Fatalf("expected original output_format=webp preserved, got %s", arr[0].Get("output_format").String())
+	}
+}
+
+func TestEnsureImageGenerationTool_EmptyToolsArray(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","tools":[]}`)
+	result := ensureImageGenerationTool(body)
+
+	tools := gjson.GetBytes(result, "tools")
+	arr := tools.Array()
+	if len(arr) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(arr))
+	}
+	if arr[0].Get("type").String() != "image_generation" {
+		t.Fatalf("expected type=image_generation, got %s", arr[0].Get("type").String())
+	}
+}
+
+func TestEnsureImageGenerationTool_WebSearchAndImageGen(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"web_search"}]}`)
+	result := ensureImageGenerationTool(body)
+
+	tools := gjson.GetBytes(result, "tools")
+	arr := tools.Array()
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(arr))
+	}
+	if arr[0].Get("type").String() != "web_search" {
+		t.Fatalf("expected first tool type=web_search, got %s", arr[0].Get("type").String())
+	}
+	if arr[1].Get("type").String() != "image_generation" {
+		t.Fatalf("expected second tool type=image_generation, got %s", arr[1].Get("type").String())
+	}
+}


### PR DESCRIPTION
## Problem

When Codex CLI connects through CPA, image generation is unavailable. The root cause is a **client-side auth gate** in Codex:

```rust
// codex-rs/core/src/session/turn_context.rs
fn image_generation_tool_auth_allowed(auth_manager: Option<&AuthManager>) -> bool {
    matches!(auth_manager.and_then(AuthManager::auth_mode), Some(AuthMode::Chatgpt))
}
```

Only `AuthMode::Chatgpt` (OAuth login) enables the built-in `image_generation` tool. When using API key auth via CPA, the tool is never included in requests — the upstream never receives it, so image generation silently fails.

Additionally, Codex CLI with OAuth auth sends requests to `{chatgpt_base_url}/codex/responses`, but CPA only exposes `/v1/responses`. This path mismatch prevents using the `chatgpt_base_url` config to redirect Codex CLI traffic through CPA while keeping `AuthMode::Chatgpt`.

The recent `e935196d` (GPT-Image-2 via `/v1/images/generations`) solves the **standalone Images API** use case but does **not** address the Codex CLI integration path — Codex CLI uses the Responses API (`/responses`), not the Images API.

## Solution

Two targeted changes, no modifications to Codex CLI source code:

### 1. Tool injection in Codex executor (`codex_executor.go`)

`ensureImageGenerationTool()` appends `{"type":"image_generation","output_format":"png"}` to the `tools` array if not already present. Applied to all three execution paths: `Execute`, `executeCompact`, `ExecuteStream`.

The function is idempotent — if the client already includes `image_generation`, the existing tool config is preserved.

### 2. Route aliases for Codex CLI direct access (`server.go`)

Added `/backend-api/codex/responses` routes mapping to the same OpenAI Responses API handlers as `/v1/responses`. This allows Codex CLI to connect via `chatgpt_base_url` config while keeping `AuthMode::Chatgpt` (image_generation tool enabled client-side).

## Verified

Successfully tested end-to-end: Codex CLI (v0.122.0, gpt-5.4 xhigh) -> CPA -> upstream, `$imagegen` skill generating images through the reverse proxy.

<img width="1960" height="1128" alt="2026-04-23 013040" src="https://github.com/user-attachments/assets/24c23989-fd49-49bb-8aea-2dd54ec64e78" />

> **Note**: This PR was developed with the assistance of Claude Opus 4.6 (Anthropic), including root cause analysis of the Codex auth gating mechanism, implementation, and test coverage.

## Test plan

- [x] `TestEnsureImageGenerationTool_NoTools` — creates tools array when missing
- [x] `TestEnsureImageGenerationTool_ExistingToolsWithoutImageGen` — appends to existing tools
- [x] `TestEnsureImageGenerationTool_AlreadyPresent` — preserves existing config
- [x] `TestEnsureImageGenerationTool_EmptyToolsArray` — handles empty array
- [x] `TestEnsureImageGenerationTool_WebSearchAndImageGen` — coexists with other built-in tools
- [x] All 94 existing executor tests pass (no regressions)
- [x] Manual E2E: Codex CLI `$imagegen` through CPA proxy
