### PR TITLE
fix: reset Codex websocket auth pin after quota errors

### DIFF
--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -92,10 +92,40 @@ type codexWebsocketRead struct {
 	err     error
 }
 
+func trySendCodexWebsocketRead(ch chan codexWebsocketRead, done <-chan struct{}, ev codexWebsocketRead) {
+	if ch == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Debugf("codex websockets executor: recover trySendCodexWebsocketRead panic=%v", r)
+		}
+	}()
+	select {
+	case ch <- ev:
+	case <-done:
+	default:
+	}
+}
+
+func tryCloseCodexWebsocketRead(ch chan codexWebsocketRead) {
+	if ch == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Debugf("codex websockets executor: recover tryCloseCodexWebsocketRead panic=%v", r)
+		}
+	}()
+	close(ch)
+}
+
 func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
 	if s == nil {
 		return
 	}
+	// 该方法仅持有 activeMu 调用避免与 connMu->activeMu 锁序冲突
+	// 不要在持有 connMu 时调用避免未来引入反向锁序
 	s.activeMu.Lock()
 	if s.activeCancel != nil {
 		s.activeCancel()
@@ -115,6 +145,8 @@ func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
 	if s == nil {
 		return
 	}
+	// 该方法仅持有 activeMu 调用避免与 connMu->activeMu 锁序冲突
+	// 不要在持有 connMu 时调用避免未来引入反向锁序
 	s.activeMu.Lock()
 	if s.activeCh == ch {
 		s.activeCh = nil
@@ -125,6 +157,61 @@ func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
 		s.activeDone = nil
 	}
 	s.activeMu.Unlock()
+}
+
+func (s *codexWebsocketSession) isCurrentConn(conn *websocket.Conn) bool {
+	if s == nil || conn == nil {
+		return false
+	}
+	s.connMu.Lock()
+	current := s.conn
+	s.connMu.Unlock()
+	return current == conn
+}
+
+func (s *codexWebsocketSession) activeSnapshotForCurrentConn(conn *websocket.Conn) (chan codexWebsocketRead, <-chan struct{}, bool) {
+	if s == nil || conn == nil {
+		return nil, nil, false
+	}
+	// 锁顺序固定为 connMu -> activeMu
+	s.connMu.Lock()
+	if s.conn != conn {
+		s.connMu.Unlock()
+		return nil, nil, false
+	}
+	s.activeMu.Lock()
+	ch := s.activeCh
+	done := s.activeDone
+	s.activeMu.Unlock()
+	s.connMu.Unlock()
+	return ch, done, true
+}
+
+func (s *codexWebsocketSession) clearActiveForCurrentConn(conn *websocket.Conn, ch chan codexWebsocketRead) bool {
+	if s == nil || conn == nil || ch == nil {
+		return false
+	}
+	// 锁顺序固定为 connMu -> activeMu
+	s.connMu.Lock()
+	if s.conn != conn {
+		s.connMu.Unlock()
+		return false
+	}
+	s.activeMu.Lock()
+	if s.activeCh != ch {
+		s.activeMu.Unlock()
+		s.connMu.Unlock()
+		return false
+	}
+	s.activeCh = nil
+	if s.activeCancel != nil {
+		s.activeCancel()
+	}
+	s.activeCancel = nil
+	s.activeDone = nil
+	s.activeMu.Unlock()
+	s.connMu.Unlock()
+	return true
 }
 
 func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, payload []byte) error {
@@ -1118,12 +1205,21 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	if sess == nil {
 		return e.dialCodexWebsocket(ctx, auth, wsURL, headers)
 	}
+	authID = strings.TrimSpace(authID)
 
 	sess.connMu.Lock()
 	conn := sess.conn
 	readerConn := sess.readerConn
+	currentAuthID := strings.TrimSpace(sess.authID)
 	sess.connMu.Unlock()
+	if conn != nil && currentAuthID != authID {
+		// 账号切换时先断开旧连接避免继续复用旧账号
+		e.invalidateUpstreamConn(sess, conn, "auth_switched", nil)
+		conn = nil
+		readerConn = nil
+	}
 	if conn != nil {
+		// 账号未变化时复用连接减少不必要重连
 		if readerConn != conn {
 			sess.connMu.Lock()
 			sess.readerConn = conn
@@ -1165,21 +1261,24 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		return
 	}
 	for {
+		if !sess.isCurrentConn(conn) {
+			// 旧连接读循环直接退出避免误伤新请求通道
+			return
+		}
 		_ = conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
 		msgType, payload, errRead := conn.ReadMessage()
 		if errRead != nil {
-			sess.activeMu.Lock()
-			ch := sess.activeCh
-			done := sess.activeDone
-			sess.activeMu.Unlock()
+			// 在同一临界区做归属校验和通道快照避免检查后竞态
+			ch, done, current := sess.activeSnapshotForCurrentConn(conn)
+			if !current {
+				// 旧连接读错时不触碰当前活跃通道
+				return
+			}
 			if ch != nil {
-				select {
-				case ch <- codexWebsocketRead{conn: conn, err: errRead}:
-				case <-done:
-				default:
+				trySendCodexWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: errRead})
+				if sess.clearActiveForCurrentConn(conn, ch) {
+					tryCloseCodexWebsocketRead(ch)
 				}
-				sess.clearActive(ch)
-				close(ch)
 			}
 			e.invalidateUpstreamConn(sess, conn, "upstream_disconnected", errRead)
 			return
@@ -1188,29 +1287,29 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		if msgType != websocket.TextMessage {
 			if msgType == websocket.BinaryMessage {
 				errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
-				sess.activeMu.Lock()
-				ch := sess.activeCh
-				done := sess.activeDone
-				sess.activeMu.Unlock()
+				// 在同一临界区做归属校验和通道快照避免检查后竞态
+				ch, done, current := sess.activeSnapshotForCurrentConn(conn)
+				if !current {
+					// 旧连接二进制异常时不触碰当前活跃通道
+					return
+				}
 				if ch != nil {
-					select {
-					case ch <- codexWebsocketRead{conn: conn, err: errBinary}:
-					case <-done:
-					default:
+					trySendCodexWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: errBinary})
+					if sess.clearActiveForCurrentConn(conn, ch) {
+						tryCloseCodexWebsocketRead(ch)
 					}
-					sess.clearActive(ch)
-					close(ch)
 				}
 				e.invalidateUpstreamConn(sess, conn, "unexpected_binary", errBinary)
 				return
 			}
 			continue
 		}
-
-		sess.activeMu.Lock()
-		ch := sess.activeCh
-		done := sess.activeDone
-		sess.activeMu.Unlock()
+		// 在同一临界区做归属校验和通道快照避免检查后竞态
+		ch, done, current := sess.activeSnapshotForCurrentConn(conn)
+		if !current {
+			// 旧连接消息不再分发给新连接请求
+			return
+		}
 		if ch == nil {
 			continue
 		}
@@ -1311,16 +1410,33 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 		reason = "session_closed"
 	}
 
+	// 锁顺序固定为 connMu -> activeMu
 	sess.connMu.Lock()
 	conn := sess.conn
 	authID := sess.authID
 	wsURL := sess.wsURL
+	sessionID := sess.sessionID
 	sess.conn = nil
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}
-	sessionID := sess.sessionID
+	sess.activeMu.Lock()
+	ch := sess.activeCh
+	done := sess.activeDone
+	if sess.activeCancel != nil {
+		sess.activeCancel()
+	}
+	sess.activeCh = nil
+	sess.activeCancel = nil
+	sess.activeDone = nil
+	sess.activeMu.Unlock()
 	sess.connMu.Unlock()
+
+	if ch != nil {
+		// 会话关闭时允许主动 fail active 唤醒在途 readCodexWebsocketMessage
+		trySendCodexWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: fmt.Errorf("codex websockets executor: execution session closed")})
+		tryCloseCodexWebsocketRead(ch)
+	}
 
 	if conn == nil {
 		return

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -106,8 +106,9 @@ func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) <-chan str
 	if s == nil {
 		return nil
 	}
-	// 该方法仅持有 activeMu 调用避免与 connMu->activeMu 锁序冲突
-	// 不要在持有 connMu 时调用避免未来引入反向锁序
+	// This helper only takes activeMu to avoid conflicting with the
+	// connMu -> activeMu lock ordering used elsewhere.
+	// Do not call it while holding connMu to avoid future lock inversion.
 	s.activeMu.Lock()
 	if s.activeCancel != nil {
 		s.activeCancel()
@@ -129,8 +130,9 @@ func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
 	if s == nil {
 		return
 	}
-	// 该方法仅持有 activeMu 调用避免与 connMu->activeMu 锁序冲突
-	// 不要在持有 connMu 时调用避免未来引入反向锁序
+	// This helper only takes activeMu to avoid conflicting with the
+	// connMu -> activeMu lock ordering used elsewhere.
+	// Do not call it while holding connMu to avoid future lock inversion.
 	s.activeMu.Lock()
 	if s.activeCh == ch {
 		s.activeCh = nil
@@ -157,7 +159,7 @@ func (s *codexWebsocketSession) activeSnapshotForCurrentConn(conn *websocket.Con
 	if s == nil || conn == nil {
 		return nil, nil, false
 	}
-	// 锁顺序固定为 connMu -> activeMu
+	// Keep the lock order fixed as connMu -> activeMu.
 	s.connMu.Lock()
 	if s.conn != conn {
 		s.connMu.Unlock()
@@ -1191,13 +1193,15 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	currentAuthID := strings.TrimSpace(sess.authID)
 	sess.connMu.Unlock()
 	if conn != nil && currentAuthID != authID {
-		// 账号切换时先断开旧连接避免继续复用旧账号
+		// Drop the old upstream connection before switching auths so the next
+		// request cannot keep using the previous auth.
 		e.invalidateUpstreamConn(sess, conn, "auth_switched", nil)
 		conn = nil
 		readerConn = nil
 	}
 	if conn != nil {
-		// 账号未变化时复用连接减少不必要重连
+		// Reuse the existing connection when the auth is unchanged to avoid
+		// unnecessary reconnects.
 		if readerConn != conn {
 			sess.connMu.Lock()
 			sess.readerConn = conn
@@ -1240,16 +1244,19 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 	}
 	for {
 		if !sess.isCurrentConn(conn) {
-			// 旧连接读循环直接退出避免误伤新请求通道
+			// Stop stale reader loops immediately so they cannot interfere with
+			// the current request channel.
 			return
 		}
 		_ = conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
 		msgType, payload, errRead := conn.ReadMessage()
 		if errRead != nil {
-			// 在同一临界区做归属校验和通道快照避免检查后竞态
+			// Snapshot ownership and the active channel inside one critical
+			// section to avoid check-then-use races.
 			ch, done, current := sess.activeSnapshotForCurrentConn(conn)
 			if !current {
-				// 旧连接读错时不触碰当前活跃通道
+				// A stale connection read error must not touch the current
+				// active request channel.
 				return
 			}
 			if ch != nil {
@@ -1262,10 +1269,12 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		if msgType != websocket.TextMessage {
 			if msgType == websocket.BinaryMessage {
 				errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
-				// 在同一临界区做归属校验和通道快照避免检查后竞态
+				// Snapshot ownership and the active channel inside one critical
+				// section to avoid check-then-use races.
 				ch, done, current := sess.activeSnapshotForCurrentConn(conn)
 				if !current {
-					// 旧连接二进制异常时不触碰当前活跃通道
+					// A stale connection binary error must not touch the current
+					// active request channel.
 					return
 				}
 				if ch != nil {
@@ -1276,10 +1285,11 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 			}
 			continue
 		}
-		// 在同一临界区做归属校验和通道快照避免检查后竞态
+		// Snapshot ownership and the active channel inside one critical
+		// section to avoid check-then-use races.
 		ch, done, current := sess.activeSnapshotForCurrentConn(conn)
 		if !current {
-			// 旧连接消息不再分发给新连接请求
+			// Do not forward stale connection messages to the current request.
 			return
 		}
 		if ch == nil {
@@ -1382,7 +1392,7 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 		reason = "session_closed"
 	}
 
-	// 锁顺序固定为 connMu -> activeMu
+	// Keep the lock order fixed as connMu -> activeMu.
 	sess.connMu.Lock()
 	conn := sess.conn
 	authID := sess.authID

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -96,33 +96,15 @@ func trySendCodexWebsocketRead(ch chan codexWebsocketRead, done <-chan struct{},
 	if ch == nil {
 		return
 	}
-	defer func() {
-		if r := recover(); r != nil {
-			log.Debugf("codex websockets executor: recover trySendCodexWebsocketRead panic=%v", r)
-		}
-	}()
 	select {
 	case ch <- ev:
 	case <-done:
-	default:
 	}
 }
 
-func tryCloseCodexWebsocketRead(ch chan codexWebsocketRead) {
-	if ch == nil {
-		return
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			log.Debugf("codex websockets executor: recover tryCloseCodexWebsocketRead panic=%v", r)
-		}
-	}()
-	close(ch)
-}
-
-func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
+func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) <-chan struct{} {
 	if s == nil {
-		return
+		return nil
 	}
 	// 该方法仅持有 activeMu 调用避免与 connMu->activeMu 锁序冲突
 	// 不要在持有 connMu 时调用避免未来引入反向锁序
@@ -138,7 +120,9 @@ func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
 		s.activeDone = activeCtx.Done()
 		s.activeCancel = activeCancel
 	}
+	done := s.activeDone
 	s.activeMu.Unlock()
+	return done
 }
 
 func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
@@ -185,33 +169,6 @@ func (s *codexWebsocketSession) activeSnapshotForCurrentConn(conn *websocket.Con
 	s.activeMu.Unlock()
 	s.connMu.Unlock()
 	return ch, done, true
-}
-
-func (s *codexWebsocketSession) clearActiveForCurrentConn(conn *websocket.Conn, ch chan codexWebsocketRead) bool {
-	if s == nil || conn == nil || ch == nil {
-		return false
-	}
-	// 锁顺序固定为 connMu -> activeMu
-	s.connMu.Lock()
-	if s.conn != conn {
-		s.connMu.Unlock()
-		return false
-	}
-	s.activeMu.Lock()
-	if s.activeCh != ch {
-		s.activeMu.Unlock()
-		s.connMu.Unlock()
-		return false
-	}
-	s.activeCh = nil
-	if s.activeCancel != nil {
-		s.activeCancel()
-	}
-	s.activeCancel = nil
-	s.activeDone = nil
-	s.activeMu.Unlock()
-	s.connMu.Unlock()
-	return true
 }
 
 func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, payload []byte) error {
@@ -350,9 +307,10 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 
 	var readCh chan codexWebsocketRead
+	var activeDone <-chan struct{}
 	if sess != nil {
 		readCh = make(chan codexWebsocketRead, 4096)
-		sess.setActive(readCh)
+		activeDone = sess.setActive(readCh)
 		defer sess.clearActive(readCh)
 	}
 
@@ -401,7 +359,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		if ctx != nil && ctx.Err() != nil {
 			return resp, ctx.Err()
 		}
-		msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh)
+		msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh, activeDone)
 		if errRead != nil {
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "read", errRead)
 			return resp, errRead
@@ -542,9 +500,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 
 	var readCh chan codexWebsocketRead
+	var activeDone <-chan struct{}
 	if sess != nil {
 		readCh = make(chan codexWebsocketRead, 4096)
-		sess.setActive(readCh)
+		activeDone = sess.setActive(readCh)
 	}
 
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
@@ -631,7 +590,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				_ = send(cliproxyexecutor.StreamChunk{Err: ctx.Err()})
 				return
 			}
-			msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh)
+			msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh, activeDone)
 			if errRead != nil {
 				if sess != nil && ctx != nil && ctx.Err() != nil {
 					terminateReason = "context_done"
@@ -749,7 +708,7 @@ func buildCodexWebsocketRequestBody(body []byte) []byte {
 	return fallback
 }
 
-func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession, conn *websocket.Conn, readCh chan codexWebsocketRead) (int, []byte, error) {
+func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession, conn *websocket.Conn, readCh chan codexWebsocketRead, activeDone <-chan struct{}) (int, []byte, error) {
 	if sess == nil {
 		if conn == nil {
 			return 0, nil, fmt.Errorf("codex websockets executor: websocket conn is nil")
@@ -764,10 +723,29 @@ func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession,
 	if readCh == nil {
 		return 0, nil, fmt.Errorf("codex websockets executor: session read channel is nil")
 	}
+	if activeDone == nil {
+		return 0, nil, fmt.Errorf("codex websockets executor: session read signal is nil")
+	}
 	for {
 		select {
 		case <-ctx.Done():
 			return 0, nil, ctx.Err()
+		case <-activeDone:
+			select {
+			case ev, ok := <-readCh:
+				if !ok {
+					return 0, nil, fmt.Errorf("codex websockets executor: session read channel closed")
+				}
+				if ev.conn != conn {
+					return 0, nil, fmt.Errorf("codex websockets executor: execution session closed")
+				}
+				if ev.err != nil {
+					return 0, nil, ev.err
+				}
+				return ev.msgType, ev.payload, nil
+			default:
+			}
+			return 0, nil, fmt.Errorf("codex websockets executor: execution session closed")
 		case ev, ok := <-readCh:
 			if !ok {
 				return 0, nil, fmt.Errorf("codex websockets executor: session read channel closed")
@@ -1276,9 +1254,6 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 			}
 			if ch != nil {
 				trySendCodexWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: errRead})
-				if sess.clearActiveForCurrentConn(conn, ch) {
-					tryCloseCodexWebsocketRead(ch)
-				}
 			}
 			e.invalidateUpstreamConn(sess, conn, "upstream_disconnected", errRead)
 			return
@@ -1295,9 +1270,6 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 				}
 				if ch != nil {
 					trySendCodexWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: errBinary})
-					if sess.clearActiveForCurrentConn(conn, ch) {
-						tryCloseCodexWebsocketRead(ch)
-					}
 				}
 				e.invalidateUpstreamConn(sess, conn, "unexpected_binary", errBinary)
 				return
@@ -1421,8 +1393,6 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 		sess.readerConn = nil
 	}
 	sess.activeMu.Lock()
-	ch := sess.activeCh
-	done := sess.activeDone
 	if sess.activeCancel != nil {
 		sess.activeCancel()
 	}
@@ -1431,12 +1401,6 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 	sess.activeDone = nil
 	sess.activeMu.Unlock()
 	sess.connMu.Unlock()
-
-	if ch != nil {
-		// 会话关闭时允许主动 fail active 唤醒在途 readCodexWebsocketMessage
-		trySendCodexWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: fmt.Errorf("codex websockets executor: execution session closed")})
-		tryCloseCodexWebsocketRead(ch)
-	}
 
 	if conn == nil {
 		return

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -299,14 +299,54 @@ func TestReadCodexWebsocketMessageReturnsWhenReadChannelClosed(t *testing.T) {
 	sess := &codexWebsocketSession{}
 	conn := &websocket.Conn{}
 	readCh := make(chan codexWebsocketRead)
+	activeCtx, activeCancel := context.WithCancel(context.Background())
+	defer activeCancel()
 	close(readCh)
 
-	_, _, err := readCodexWebsocketMessage(context.Background(), sess, conn, readCh)
+	_, _, err := readCodexWebsocketMessage(context.Background(), sess, conn, readCh, activeCtx.Done())
 	if err == nil {
 		t.Fatal("expected error when session read channel is closed")
 	}
 	if !strings.Contains(err.Error(), "session read channel closed") {
 		t.Fatalf("error = %v, want contains session read channel closed", err)
+	}
+}
+
+func TestTrySendCodexWebsocketReadWaitsForBufferDrain(t *testing.T) {
+	t.Parallel()
+
+	activeCtx, activeCancel := context.WithCancel(context.Background())
+	defer activeCancel()
+
+	readCh := make(chan codexWebsocketRead, 1)
+	readCh <- codexWebsocketRead{msgType: websocket.TextMessage, payload: []byte("first")}
+
+	sendDone := make(chan struct{})
+	go func() {
+		trySendCodexWebsocketRead(readCh, activeCtx.Done(), codexWebsocketRead{msgType: websocket.TextMessage, payload: []byte("second")})
+		close(sendDone)
+	}()
+
+	select {
+	case <-sendDone:
+		t.Fatal("trySendCodexWebsocketRead returned before buffer drained")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	first := <-readCh
+	if string(first.payload) != "first" {
+		t.Fatalf("first payload = %q, want first", string(first.payload))
+	}
+
+	select {
+	case <-sendDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("trySendCodexWebsocketRead did not complete after buffer drain")
+	}
+
+	second := <-readCh
+	if string(second.payload) != "second" {
+		t.Fatalf("second payload = %q, want second", string(second.payload))
 	}
 }
 
@@ -345,7 +385,7 @@ func TestCloseExecutionSessionUnblocksActiveRead(t *testing.T) {
 		readerConn: serverConn,
 	}
 	readCh := make(chan codexWebsocketRead, 4)
-	sess.setActive(readCh)
+	activeDone := sess.setActive(readCh)
 
 	executor := NewCodexWebsocketsExecutor(&config.Config{})
 	executor.store.sessions["session-close"] = sess
@@ -354,7 +394,7 @@ func TestCloseExecutionSessionUnblocksActiveRead(t *testing.T) {
 	defer cancel()
 	readErrCh := make(chan error, 1)
 	go func() {
-		_, _, err := readCodexWebsocketMessage(ctx, sess, serverConn, readCh)
+		_, _, err := readCodexWebsocketMessage(ctx, sess, serverConn, readCh, activeDone)
 		readErrCh <- err
 	}()
 

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
@@ -287,5 +290,159 @@ func TestNewProxyAwareWebsocketDialerDirectDisablesProxy(t *testing.T) {
 
 	if dialer.Proxy != nil {
 		t.Fatal("expected websocket proxy function to be nil for direct mode")
+	}
+}
+
+func TestReadCodexWebsocketMessageReturnsWhenReadChannelClosed(t *testing.T) {
+	t.Parallel()
+
+	sess := &codexWebsocketSession{}
+	conn := &websocket.Conn{}
+	readCh := make(chan codexWebsocketRead)
+	close(readCh)
+
+	_, _, err := readCodexWebsocketMessage(context.Background(), sess, conn, readCh)
+	if err == nil {
+		t.Fatal("expected error when session read channel is closed")
+	}
+	if !strings.Contains(err.Error(), "session read channel closed") {
+		t.Fatalf("error = %v, want contains session read channel closed", err)
+	}
+}
+
+func TestCloseExecutionSessionUnblocksActiveRead(t *testing.T) {
+	t.Parallel()
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	serverConnCh := make(chan *websocket.Conn, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		serverConnCh <- conn
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		t.Fatalf("dial websocket: %v", errDial)
+	}
+	defer func() { _ = clientConn.Close() }()
+
+	var serverConn *websocket.Conn
+	select {
+	case serverConn = <-serverConnCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server websocket connection")
+	}
+
+	sess := &codexWebsocketSession{
+		sessionID:  "session-close",
+		conn:       serverConn,
+		readerConn: serverConn,
+	}
+	readCh := make(chan codexWebsocketRead, 4)
+	sess.setActive(readCh)
+
+	executor := NewCodexWebsocketsExecutor(&config.Config{})
+	executor.store.sessions["session-close"] = sess
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	readErrCh := make(chan error, 1)
+	go func() {
+		_, _, err := readCodexWebsocketMessage(ctx, sess, serverConn, readCh)
+		readErrCh <- err
+	}()
+
+	executor.CloseExecutionSession("session-close")
+
+	select {
+	case err := <-readErrCh:
+		if err == nil {
+			t.Fatal("expected read error after closing execution session")
+		}
+		errText := err.Error()
+		if !strings.Contains(errText, "execution session closed") && !strings.Contains(errText, "session read channel closed") {
+			t.Fatalf("error = %v, want fast-fail error from session close path", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("read did not fail fast after closeExecutionSession")
+	}
+}
+
+func TestEnsureUpstreamConnAuthSwitchRebuildsWebsocketConn(t *testing.T) {
+	t.Parallel()
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	authHeaderCh := make(chan string, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		authHeaderCh <- strings.TrimSpace(r.Header.Get("Authorization"))
+		for {
+			_, _, errRead := conn.ReadMessage()
+			if errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	executor := NewCodexWebsocketsExecutor(&config.Config{})
+	sess := &codexWebsocketSession{sessionID: "session-auth-switch"}
+
+	headers1 := http.Header{}
+	headers1.Set("Authorization", "Bearer token-1")
+	conn1, _, errDial1 := executor.ensureUpstreamConn(context.Background(), nil, sess, "auth-1", wsURL, headers1)
+	if errDial1 != nil {
+		t.Fatalf("ensureUpstreamConn auth-1 error: %v", errDial1)
+	}
+	if conn1 == nil {
+		t.Fatal("ensureUpstreamConn auth-1 returned nil conn")
+	}
+
+	headers2 := http.Header{}
+	headers2.Set("Authorization", "Bearer token-2")
+	conn2, _, errDial2 := executor.ensureUpstreamConn(context.Background(), nil, sess, "auth-2", wsURL, headers2)
+	if errDial2 != nil {
+		t.Fatalf("ensureUpstreamConn auth-2 error: %v", errDial2)
+	}
+	if conn2 == nil {
+		t.Fatal("ensureUpstreamConn auth-2 returned nil conn")
+	}
+	if conn2 == conn1 {
+		t.Fatal("expected new websocket conn after auth switch")
+	}
+
+	defer executor.invalidateUpstreamConn(sess, conn2, "test_done", nil)
+
+	var got1, got2 string
+	select {
+	case got1 = <-authHeaderCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first websocket handshake")
+	}
+	select {
+	case got2 = <-authHeaderCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second websocket handshake")
+	}
+	if got1 != "Bearer token-1" {
+		t.Fatalf("first Authorization = %q, want %q", got1, "Bearer token-1")
+	}
+	if got2 != "Bearer token-2" {
+		t.Fatalf("second Authorization = %q, want %q", got2, "Bearer token-2")
+	}
+	if got1 == got2 {
+		t.Fatal("expected different Authorization headers after auth switch")
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -79,6 +79,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 	var lastRequest []byte
 	lastResponseOutput := []byte("[]")
 	pinnedAuthID := ""
+	forceDisableIncrementalAfterAuthReset := false
 
 	for {
 		msgType, payload, errReadMessage := conn.ReadMessage()
@@ -104,16 +105,18 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		appendWebsocketTimelineEvent(&wsTimelineLog, "request", payload, time.Now())
 
 		allowIncrementalInputWithPreviousResponseID := false
-		if pinnedAuthID != "" && h != nil && h.AuthManager != nil {
-			if pinnedAuth, ok := h.AuthManager.GetByID(pinnedAuthID); ok && pinnedAuth != nil {
-				allowIncrementalInputWithPreviousResponseID = websocketUpstreamSupportsIncrementalInput(pinnedAuth.Attributes, pinnedAuth.Metadata)
+		if !forceDisableIncrementalAfterAuthReset {
+			if pinnedAuthID != "" && h != nil && h.AuthManager != nil {
+				if pinnedAuth, ok := h.AuthManager.GetByID(pinnedAuthID); ok && pinnedAuth != nil {
+					allowIncrementalInputWithPreviousResponseID = websocketUpstreamSupportsIncrementalInput(pinnedAuth.Attributes, pinnedAuth.Metadata)
+				}
+			} else {
+				requestModelName := strings.TrimSpace(gjson.GetBytes(payload, "model").String())
+				if requestModelName == "" {
+					requestModelName = strings.TrimSpace(gjson.GetBytes(lastRequest, "model").String())
+				}
+				allowIncrementalInputWithPreviousResponseID = h.websocketUpstreamSupportsIncrementalInputForModel(requestModelName)
 			}
-		} else {
-			requestModelName := strings.TrimSpace(gjson.GetBytes(payload, "model").String())
-			if requestModelName == "" {
-				requestModelName = strings.TrimSpace(gjson.GetBytes(lastRequest, "model").String())
-			}
-			allowIncrementalInputWithPreviousResponseID = h.websocketUpstreamSupportsIncrementalInputForModel(requestModelName)
 		}
 
 		var requestJSON []byte
@@ -147,6 +150,26 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			}
 			continue
 		}
+		nextSessionRequestSnapshot := updatedLastRequest
+		if shouldBuildResponsesWebsocketFullSnapshot(requestJSON, allowIncrementalInputWithPreviousResponseID) {
+			_, shadowLastRequest, shadowErr := normalizeResponsesWebsocketRequestWithMode(
+				payload,
+				lastRequest,
+				lastResponseOutput,
+				false,
+			)
+			if shadowErr != nil {
+				nextSessionRequestSnapshot = lastRequest
+				log.Errorf(
+					"responses websocket: keep previous snapshot id=%s status=%d error=%v",
+					passthroughSessionID,
+					shadowErr.StatusCode,
+					shadowErr.Error,
+				)
+			} else {
+				nextSessionRequestSnapshot = repairResponsesWebsocketToolCalls(downstreamSessionKey, shadowLastRequest)
+			}
+		}
 		if shouldHandleResponsesWebsocketPrewarmLocally(payload, lastRequest, allowIncrementalInputWithPreviousResponseID) {
 			if updated, errDelete := sjson.DeleteBytes(requestJSON, "generate"); errDelete == nil {
 				requestJSON = updated
@@ -164,8 +187,9 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 
 		requestJSON = repairResponsesWebsocketToolCalls(downstreamSessionKey, requestJSON)
-		updatedLastRequest = bytes.Clone(requestJSON)
-		lastRequest = updatedLastRequest
+		if !shouldBuildResponsesWebsocketFullSnapshot(requestJSON, allowIncrementalInputWithPreviousResponseID) {
+			nextSessionRequestSnapshot = bytes.Clone(requestJSON)
+		}
 
 		modelName := gjson.GetBytes(requestJSON, "model").String()
 		cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
@@ -190,13 +214,26 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 		dataChan, _, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, requestJSON, "")
 
-		completedOutput, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, &wsTimelineLog, passthroughSessionID)
+		completedOutput, terminalStatus, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, &wsTimelineLog, passthroughSessionID)
 		if errForward != nil {
 			wsTerminateErr = errForward
 			log.Warnf("responses websocket: forward failed id=%s error=%v", passthroughSessionID, errForward)
 			return
 		}
-		lastResponseOutput = completedOutput
+		if shouldResetResponsesWebsocketAuthPin(terminalStatus) {
+			log.Infof("responses websocket: reset auth pin id=%s status=%d", passthroughSessionID, terminalStatus)
+			pinnedAuthID = ""
+			forceDisableIncrementalAfterAuthReset = true
+			if h != nil && h.AuthManager != nil {
+				h.AuthManager.CloseExecutionSession(passthroughSessionID)
+			}
+		} else if forceDisableIncrementalAfterAuthReset && terminalStatus == 0 {
+			forceDisableIncrementalAfterAuthReset = false
+		}
+		if terminalStatus == 0 {
+			lastRequest = nextSessionRequestSnapshot
+			lastResponseOutput = completedOutput
+		}
 	}
 }
 
@@ -590,6 +627,14 @@ func shouldHandleResponsesWebsocketPrewarmLocally(rawJSON []byte, lastRequest []
 	return generateResult.Exists() && !generateResult.Bool()
 }
 
+func shouldBuildResponsesWebsocketFullSnapshot(normalizedRequestJSON []byte, allowIncrementalInputWithPreviousResponseID bool) bool {
+	if !allowIncrementalInputWithPreviousResponseID {
+		return false
+	}
+	prev := strings.TrimSpace(gjson.GetBytes(normalizedRequestJSON, "previous_response_id").String())
+	return prev != ""
+}
+
 func writeResponsesWebsocketSyntheticPrewarm(
 	c *gin.Context,
 	conn *websocket.Conn,
@@ -711,9 +756,10 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 	errs <-chan *interfaces.ErrorMessage,
 	wsTimelineLog *strings.Builder,
 	sessionID string,
-) ([]byte, error) {
+) ([]byte, int, error) {
 	completed := false
 	completedOutput := []byte("[]")
+	terminalStatusCode := 0
 	downstreamSessionKey := ""
 	if c != nil && c.Request != nil {
 		downstreamSessionKey = websocketDownstreamSessionKey(c.Request)
@@ -723,13 +769,14 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 		select {
 		case <-c.Request.Context().Done():
 			cancel(c.Request.Context().Err())
-			return completedOutput, c.Request.Context().Err()
+			return completedOutput, terminalStatusCode, c.Request.Context().Err()
 		case errMsg, ok := <-errs:
 			if !ok {
 				errs = nil
 				continue
 			}
 			if errMsg != nil {
+				terminalStatusCode = errMsg.StatusCode
 				h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), errMsg)
 				markAPIResponseTimestamp(c)
 				errorPayload, errWrite := writeResponsesWebsocketError(conn, wsTimelineLog, errMsg)
@@ -748,7 +795,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 					// 	errWrite,
 					// )
 					cancel(errMsg.Error)
-					return completedOutput, errWrite
+					return completedOutput, terminalStatusCode, errWrite
 				}
 			}
 			if errMsg != nil {
@@ -756,7 +803,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 			} else {
 				cancel(nil)
 			}
-			return completedOutput, nil
+			return completedOutput, terminalStatusCode, nil
 		case chunk, ok := <-data:
 			if !ok {
 				if !completed {
@@ -764,6 +811,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 						StatusCode: http.StatusRequestTimeout,
 						Error:      fmt.Errorf("stream closed before response.completed"),
 					}
+					terminalStatusCode = errMsg.StatusCode
 					h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), errMsg)
 					markAPIResponseTimestamp(c)
 					errorPayload, errWrite := writeResponsesWebsocketError(conn, wsTimelineLog, errMsg)
@@ -782,13 +830,13 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 							errWrite,
 						)
 						cancel(errMsg.Error)
-						return completedOutput, errWrite
+						return completedOutput, terminalStatusCode, errWrite
 					}
 					cancel(errMsg.Error)
-					return completedOutput, nil
+					return completedOutput, terminalStatusCode, nil
 				}
 				cancel(nil)
-				return completedOutput, nil
+				return completedOutput, terminalStatusCode, nil
 			}
 
 			payloads := websocketJSONPayloadsFromChunk(chunk)
@@ -815,10 +863,19 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 						errWrite,
 					)
 					cancel(errWrite)
-					return completedOutput, errWrite
+					return completedOutput, terminalStatusCode, errWrite
 				}
 			}
 		}
+	}
+}
+
+func shouldResetResponsesWebsocketAuthPin(statusCode int) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests, http.StatusForbidden, http.StatusPaymentRequired, http.StatusUnauthorized:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -69,6 +69,27 @@ type websocketAuthCaptureExecutor struct {
 	authIDs []string
 }
 
+type websocketStatusError struct {
+	code int
+	msg  string
+}
+
+func (e websocketStatusError) Error() string {
+	if strings.TrimSpace(e.msg) != "" {
+		return e.msg
+	}
+	return fmt.Sprintf("status %d", e.code)
+}
+
+func (e websocketStatusError) StatusCode() int {
+	return e.code
+}
+
+type websocketQuotaSwitchExecutor struct {
+	mu      sync.Mutex
+	authIDs []string
+}
+
 func (e *websocketAuthCaptureExecutor) Identifier() string { return "test-provider" }
 
 func (e *websocketAuthCaptureExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
@@ -101,6 +122,47 @@ func (e *websocketAuthCaptureExecutor) HttpRequest(context.Context, *coreauth.Au
 }
 
 func (e *websocketAuthCaptureExecutor) AuthIDs() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.authIDs...)
+}
+
+func (e *websocketQuotaSwitchExecutor) Identifier() string { return "test-provider" }
+
+func (e *websocketQuotaSwitchExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *websocketQuotaSwitchExecutor) ExecuteStream(_ context.Context, auth *coreauth.Auth, _ coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	e.mu.Lock()
+	if auth != nil {
+		e.authIDs = append(e.authIDs, auth.ID)
+	}
+	e.mu.Unlock()
+
+	if auth != nil && auth.ID == "auth-1" {
+		return nil, websocketStatusError{code: http.StatusTooManyRequests, msg: "quota exhausted"}
+	}
+
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed","response":{"id":"resp-upstream","output":[{"type":"message","id":"out-1"}]}}`)}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *websocketQuotaSwitchExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *websocketQuotaSwitchExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *websocketQuotaSwitchExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *websocketQuotaSwitchExecutor) AuthIDs() []string {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return append([]string(nil), e.authIDs...)
@@ -681,7 +743,7 @@ func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 		close(errCh)
 
 		var timelineLog strings.Builder
-		completedOutput, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+		completedOutput, statusCode, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
 			ctx,
 			conn,
 			func(...interface{}) {},
@@ -692,6 +754,10 @@ func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 		)
 		if err != nil {
 			serverErrCh <- err
+			return
+		}
+		if statusCode != 0 {
+			serverErrCh <- fmt.Errorf("status code = %d, want 0", statusCode)
 			return
 		}
 		if gjson.GetBytes(completedOutput, "0.id").String() != "out-1" {
@@ -760,7 +826,7 @@ func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing
 			return
 		}
 
-		_, err = (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+		_, _, err = (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
 			ctx,
 			conn,
 			func(...interface{}) {},
@@ -1063,6 +1129,118 @@ func TestResponsesWebsocketPinsOnlyWebsocketCapableAuth(t *testing.T) {
 
 	if got := executor.AuthIDs(); len(got) != 2 || got[0] != "auth-sse" || got[1] != "auth-ws" {
 		t.Fatalf("selected auth IDs = %v, want [auth-sse auth-ws]", got)
+	}
+}
+
+func TestShouldResetResponsesWebsocketAuthPin(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		statusCode int
+		want       bool
+	}{
+		{name: "too_many_requests", statusCode: http.StatusTooManyRequests, want: true},
+		{name: "forbidden", statusCode: http.StatusForbidden, want: true},
+		{name: "payment_required", statusCode: http.StatusPaymentRequired, want: true},
+		{name: "unauthorized", statusCode: http.StatusUnauthorized, want: true},
+		{name: "internal_error", statusCode: http.StatusInternalServerError, want: false},
+		{name: "zero", statusCode: 0, want: false},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldResetResponsesWebsocketAuthPin(tc.statusCode)
+			if got != tc.want {
+				t.Fatalf("shouldResetResponsesWebsocketAuthPin(%d) = %v, want %v", tc.statusCode, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResponsesWebsocketClearsPinAndSwitchesAuthAfterQuotaError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	selector := &orderedWebsocketSelector{order: []string{"auth-1", "auth-2"}}
+	executor := &websocketQuotaSwitchExecutor{}
+	manager := coreauth.NewManager(nil, selector, nil)
+	manager.SetRetryConfig(0, 0, 1)
+	manager.RegisterExecutor(executor)
+
+	auth1 := &coreauth.Auth{
+		ID:         "auth-1",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("Register auth-1: %v", err)
+	}
+	auth2 := &coreauth.Auth{
+		ID:         "auth-2",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth2); err != nil {
+		t.Fatalf("Register auth-2: %v", err)
+	}
+
+	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	registry.GetGlobalRegistry().RegisterClient(auth2.ID, auth2.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
+		registry.GetGlobalRegistry().UnregisterClient(auth2.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
+		t.Fatalf("write first websocket message: %v", errWrite)
+	}
+	_, firstPayload, errReadFirst := conn.ReadMessage()
+	if errReadFirst != nil {
+		t.Fatalf("read first websocket message: %v", errReadFirst)
+	}
+	if got := gjson.GetBytes(firstPayload, "type").String(); got != wsEventTypeError {
+		t.Fatalf("first payload type = %s, want %s", got, wsEventTypeError)
+	}
+	if got := gjson.GetBytes(firstPayload, "error.code").String(); got != "rate_limit_exceeded" {
+		t.Fatalf("first payload code = %s, want rate_limit_exceeded", got)
+	}
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
+		t.Fatalf("write second websocket message: %v", errWrite)
+	}
+	_, secondPayload, errReadSecond := conn.ReadMessage()
+	if errReadSecond != nil {
+		t.Fatalf("read second websocket message: %v", errReadSecond)
+	}
+	if got := gjson.GetBytes(secondPayload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("second payload type = %s, want %s", got, wsEventTypeCompleted)
+	}
+
+	if got := executor.AuthIDs(); len(got) != 2 || got[0] != "auth-1" || got[1] != "auth-2" {
+		t.Fatalf("selected auth IDs = %v, want [auth-1 auth-2]", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- clear pinned Codex websocket auth after terminal quota/auth errors so the next turn can reselect credentials
- rebuild the upstream websocket when the selected auth changes instead of reusing the old connection
- preserve a full downstream snapshot after auth reset and add regression coverage for auth switch/session close behavior

## Why
Same-team multi-account Codex setups can look like round-robin is broken after one credential hits 429, because the downstream websocket session keeps reusing the previously pinned auth and its upstream websocket connection. This patch forces a clean auth re-selection path after terminal quota/auth failures.

## Test
- go test ./sdk/api/handlers/openai
- go test ./internal/runtime/executor
- go build ./...