### PR TITLE
feat(codex): add strict websocket session affinity option

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -110,6 +110,10 @@ routing:
   session-affinity: false # default: false
   # How long session-to-auth bindings are retained. Default: 1h
   session-affinity-ttl: "1h"
+  # When true, Codex downstream websocket sessions stay pinned to the currently
+  # bound auth. If that auth becomes unavailable, the request fails instead of
+  # switching to a different auth and continuing with the old previous_response_id.
+  codex-websocket-strict-affinity: false
 
 # When true, enable authentication for the WebSocket API (/v1/ws).
 ws-auth: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,6 +233,12 @@ type RoutingConfig struct {
 	// SessionAffinityTTL specifies how long session-to-auth bindings are retained.
 	// Default: 1h. Accepts duration strings like "30m", "1h", "2h30m".
 	SessionAffinityTTL string `yaml:"session-affinity-ttl,omitempty" json:"session-affinity-ttl,omitempty"`
+
+	// CodexWebsocketStrictAffinity disables automatic cross-auth failover for bound
+	// Codex downstream websocket sessions. When enabled, a bound Codex websocket
+	// session returns the bound auth's unavailability error instead of switching to
+	// another auth and continuing with the old previous_response_id.
+	CodexWebsocketStrictAffinity bool `yaml:"codex-websocket-strict-affinity,omitempty" json:"codex-websocket-strict-affinity,omitempty"`
 }
 
 // OAuthModelAlias defines a model ID alias for a specific channel.

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -437,12 +437,16 @@ var sessionPattern = regexp.MustCompile(`_session_([a-f0-9-]+)$`)
 type SessionAffinitySelector struct {
 	fallback Selector
 	cache    *SessionCache
+
+	codexWebsocketStrictAffinity bool
 }
 
 // SessionAffinityConfig configures the session affinity selector.
 type SessionAffinityConfig struct {
 	Fallback Selector
 	TTL      time.Duration
+
+	CodexWebsocketStrictAffinity bool
 }
 
 // NewSessionAffinitySelector creates a new session-aware selector.
@@ -462,9 +466,38 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 		cfg.TTL = time.Hour
 	}
 	return &SessionAffinitySelector{
-		fallback: cfg.Fallback,
-		cache:    NewSessionCache(cfg.TTL),
+		fallback:                     cfg.Fallback,
+		cache:                        NewSessionCache(cfg.TTL),
+		codexWebsocketStrictAffinity: cfg.CodexWebsocketStrictAffinity,
 	}
+}
+
+func (s *SessionAffinitySelector) strictCodexWebsocketAffinity(ctx context.Context, provider string) bool {
+	if s == nil || !s.codexWebsocketStrictAffinity {
+		return false
+	}
+	if !cliproxyexecutor.DownstreamWebsocket(ctx) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(provider), "codex")
+}
+
+func boundAuthUnavailableError(auths []*Auth, authID, provider, model string, now time.Time) error {
+	providerForError := strings.TrimSpace(provider)
+	for _, auth := range auths {
+		if auth == nil || auth.ID != authID {
+			continue
+		}
+		blocked, reason, next := isAuthBlockedForModel(auth, model, now)
+		if !blocked {
+			break
+		}
+		if reason == blockReasonCooldown {
+			return newModelCooldownError(model, providerForError, next.Sub(now))
+		}
+		break
+	}
+	return &Error{Code: "auth_unavailable", Message: "no auth available"}
 }
 
 // Pick selects an auth with session affinity when possible.
@@ -501,6 +534,10 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 				return auth, nil
 			}
 		}
+		if s.strictCodexWebsocketAffinity(ctx, provider) {
+			entry.Infof("session-affinity: cache hit but bound auth unavailable; strict codex websocket affinity blocks failover | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), cachedAuthID, provider, model)
+			return nil, boundAuthUnavailableError(auths, cachedAuthID, provider, model, now)
+		}
 		// Cached auth not available, reselect via fallback selector for even distribution
 		auth, err := s.fallback.Pick(ctx, provider, model, opts, auths)
 		if err != nil {
@@ -520,6 +557,10 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 					entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
 					return auth, nil
 				}
+			}
+			if s.strictCodexWebsocketAffinity(ctx, provider) {
+				entry.Infof("session-affinity: fallback cache hit but bound auth unavailable; strict codex websocket affinity blocks failover | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), cachedAuthID, provider, model)
+				return nil, boundAuthUnavailableError(auths, cachedAuthID, provider, model, now)
 			}
 		}
 	}

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -700,6 +700,110 @@ func TestSessionAffinitySelector_FailoverWhenAuthUnavailable(t *testing.T) {
 	}
 }
 
+func TestSessionAffinitySelector_CodexWebsocketStrictAffinity_NoFailoverWhenBoundAuthUnavailable(t *testing.T) {
+	t.Parallel()
+
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback:                     fallback,
+		TTL:                          time.Minute,
+		CodexWebsocketStrictAffinity: true,
+	})
+	defer selector.Stop()
+
+	now := time.Now()
+	auths := []*Auth{
+		{ID: "auth-a", Metadata: map[string]any{"websockets": true}},
+		{ID: "auth-b", Metadata: map[string]any{"websockets": true}},
+	}
+
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_codex-ws-strict-test"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+
+	first, err := selector.Pick(ctx, "codex", "gpt-5.4", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if first == nil {
+		t.Fatal("Pick() returned nil auth")
+	}
+
+	first.ModelStates = map[string]*ModelState{
+		"gpt-5.4": {
+			Unavailable:    true,
+			NextRetryAfter: now.Add(30 * time.Minute),
+			Quota: QuotaState{
+				Exceeded:      true,
+				NextRecoverAt: now.Add(30 * time.Minute),
+			},
+		},
+	}
+
+	second, err := selector.Pick(ctx, "codex", "gpt-5.4", opts, auths)
+	if err == nil {
+		t.Fatalf("Pick() after bound auth becomes unavailable = %v, want error", second)
+	}
+	if second != nil {
+		t.Fatalf("Pick() after bound auth becomes unavailable returned auth %q, want nil", second.ID)
+	}
+	var cooldownErr *modelCooldownError
+	if !errors.As(err, &cooldownErr) {
+		t.Fatalf("Pick() error = %T %v, want *modelCooldownError", err, err)
+	}
+}
+
+func TestSessionAffinitySelector_CodexWebsocketStrictAffinity_HTTPStillFailsOver(t *testing.T) {
+	t.Parallel()
+
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback:                     fallback,
+		TTL:                          time.Minute,
+		CodexWebsocketStrictAffinity: true,
+	})
+	defer selector.Stop()
+
+	now := time.Now()
+	auths := []*Auth{
+		{ID: "auth-a", Metadata: map[string]any{"websockets": true}},
+		{ID: "auth-b", Metadata: map[string]any{"websockets": true}},
+	}
+
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_codex-http-failover-test"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+
+	first, err := selector.Pick(context.Background(), "codex", "gpt-5.4", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if first == nil {
+		t.Fatal("Pick() returned nil auth")
+	}
+
+	first.ModelStates = map[string]*ModelState{
+		"gpt-5.4": {
+			Unavailable:    true,
+			NextRetryAfter: now.Add(30 * time.Minute),
+			Quota: QuotaState{
+				Exceeded:      true,
+				NextRecoverAt: now.Add(30 * time.Minute),
+			},
+		},
+	}
+
+	second, err := selector.Pick(context.Background(), "codex", "gpt-5.4", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() after failover error = %v", err)
+	}
+	if second == nil {
+		t.Fatal("Pick() after failover returned nil auth")
+	}
+	if second.ID == first.ID {
+		t.Fatalf("Pick() after failover returned same auth %q, expected different", first.ID)
+	}
+}
+
 func TestRoundRobinSelectorPick_MixedVirtualAndNonVirtualFallsBackToFlat(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -211,10 +211,12 @@ func (b *Builder) Build() (*Service, error) {
 		strategy := ""
 		sessionAffinity := false
 		sessionAffinityTTL := time.Hour
+		codexWebsocketStrictAffinity := false
 		if b.cfg != nil {
 			strategy = strings.ToLower(strings.TrimSpace(b.cfg.Routing.Strategy))
 			// Support both legacy ClaudeCodeSessionAffinity and new universal SessionAffinity
 			sessionAffinity = b.cfg.Routing.ClaudeCodeSessionAffinity || b.cfg.Routing.SessionAffinity
+			codexWebsocketStrictAffinity = b.cfg.Routing.CodexWebsocketStrictAffinity
 			if ttlStr := strings.TrimSpace(b.cfg.Routing.SessionAffinityTTL); ttlStr != "" {
 				if parsed, err := time.ParseDuration(ttlStr); err == nil && parsed > 0 {
 					sessionAffinityTTL = parsed
@@ -232,8 +234,9 @@ func (b *Builder) Build() (*Service, error) {
 		// Wrap with session affinity if enabled (failover is always on)
 		if sessionAffinity {
 			selector = coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
-				Fallback: selector,
-				TTL:      sessionAffinityTTL,
+				Fallback:                     selector,
+				TTL:                          sessionAffinityTTL,
+				CodexWebsocketStrictAffinity: codexWebsocketStrictAffinity,
 			})
 		}
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -612,11 +612,13 @@ func (s *Service) Run(ctx context.Context) error {
 		previousStrategy := ""
 		var previousSessionAffinity bool
 		var previousSessionAffinityTTL string
+		var previousCodexWebsocketStrictAffinity bool
 		s.cfgMu.RLock()
 		if s.cfg != nil {
 			previousStrategy = strings.ToLower(strings.TrimSpace(s.cfg.Routing.Strategy))
 			previousSessionAffinity = s.cfg.Routing.ClaudeCodeSessionAffinity || s.cfg.Routing.SessionAffinity
 			previousSessionAffinityTTL = s.cfg.Routing.SessionAffinityTTL
+			previousCodexWebsocketStrictAffinity = s.cfg.Routing.CodexWebsocketStrictAffinity
 		}
 		s.cfgMu.RUnlock()
 
@@ -643,10 +645,12 @@ func (s *Service) Run(ctx context.Context) error {
 
 		nextSessionAffinity := newCfg.Routing.ClaudeCodeSessionAffinity || newCfg.Routing.SessionAffinity
 		nextSessionAffinityTTL := newCfg.Routing.SessionAffinityTTL
+		nextCodexWebsocketStrictAffinity := newCfg.Routing.CodexWebsocketStrictAffinity
 
 		selectorChanged := previousStrategy != nextStrategy ||
 			previousSessionAffinity != nextSessionAffinity ||
-			previousSessionAffinityTTL != nextSessionAffinityTTL
+			previousSessionAffinityTTL != nextSessionAffinityTTL ||
+			previousCodexWebsocketStrictAffinity != nextCodexWebsocketStrictAffinity
 
 		if s.coreManager != nil && selectorChanged {
 			var selector coreauth.Selector
@@ -665,8 +669,9 @@ func (s *Service) Run(ctx context.Context) error {
 					}
 				}
 				selector = coreauth.NewSessionAffinitySelectorWithConfig(coreauth.SessionAffinityConfig{
-					Fallback: selector,
-					TTL:      ttl,
+					Fallback:                     selector,
+					TTL:                          ttl,
+					CodexWebsocketStrictAffinity: nextCodexWebsocketStrictAffinity,
 				})
 			}
 


### PR DESCRIPTION
## Summary
- add a routing config flag codex-websocket-strict-affinity
- when enabled, bound Codex downstream websocket sessions no longer fail over to a different auth if the bound auth becomes unavailable
- preserve existing failover behavior for HTTP requests and for other providers

## Why
Codex websocket follow-up turns can carry a previous_response_id. If a session-affinity binding is silently reselected onto a different auth after the original auth becomes unavailable, the upstream may reject that old previous_response_id with previous_response_not_found.

This change keeps the current global behavior by default, but provides a safer opt-in mode for Codex websocket sessions that prefer continuity over automatic cross-auth failover.

## Tests
- go test ./sdk/cliproxy/auth
- go build -o test-output.exe ./cmd/server
