### PR TITLE
fix(codex): stabilize OpenCode prompt caching

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -880,11 +880,11 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 			}
 		}
 	} else if from == "openai-response" {
-		if promptCacheKey, _ := codexPromptCacheKeyFromClient(ctx, req, rawJSON); promptCacheKey != "" {
+		if promptCacheKey := codexPromptCacheKeyFromClient(ctx, req, rawJSON); promptCacheKey != "" {
 			cache.ID = promptCacheKey
 		}
 	} else if from == "openai" {
-		if promptCacheKey, _ := codexPromptCacheKeyFromClient(ctx, req, rawJSON); promptCacheKey != "" {
+		if promptCacheKey := codexPromptCacheKeyFromClient(ctx, req, rawJSON); promptCacheKey != "" {
 			cache.ID = promptCacheKey
 		} else if apiKey := strings.TrimSpace(helps.APIKeyFromContext(ctx)); apiKey != "" {
 			cache.ID = uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:prompt-cache:"+apiKey)).String()
@@ -906,19 +906,19 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 	return httpReq, nil
 }
 
-func codexPromptCacheKeyFromClient(ctx context.Context, req cliproxyexecutor.Request, rawJSON []byte) (string, string) {
-	if key, source := codexPromptCacheKeyFromJSON(req.Payload, "payload"); key != "" {
-		return key, source
+func codexPromptCacheKeyFromClient(ctx context.Context, req cliproxyexecutor.Request, rawJSON []byte) string {
+	if key := codexPromptCacheKeyFromJSON(req.Payload); key != "" {
+		return key
 	}
-	if key, source := codexPromptCacheKeyFromJSON(rawJSON, "body"); key != "" {
-		return key, source
+	if key := codexPromptCacheKeyFromJSON(rawJSON); key != "" {
+		return key
 	}
 	return codexPromptCacheKeyFromHeaders(ctx)
 }
 
-func codexPromptCacheKeyFromJSON(payload []byte, prefix string) (string, string) {
+func codexPromptCacheKeyFromJSON(payload []byte) string {
 	if len(payload) == 0 {
-		return "", ""
+		return ""
 	}
 	for _, path := range []string{
 		"prompt_cache_key",
@@ -928,30 +928,30 @@ func codexPromptCacheKeyFromJSON(payload []byte, prefix string) (string, string)
 		"provider_options.openai.promptCacheKey",
 	} {
 		if value := strings.TrimSpace(gjson.GetBytes(payload, path).String()); value != "" {
-			return value, prefix + "." + path
+			return value
 		}
 	}
-	return "", ""
+	return ""
 }
 
-func codexPromptCacheKeyFromHeaders(ctx context.Context) (string, string) {
+func codexPromptCacheKeyFromHeaders(ctx context.Context) string {
 	if ctx == nil {
-		return "", ""
+		return ""
 	}
 	ginCtx, ok := ctx.Value("gin").(*gin.Context)
 	if !ok || ginCtx == nil || ginCtx.Request == nil {
-		return "", ""
+		return ""
 	}
 	return codexPromptCacheKeyFromHeader(ginCtx.Request.Header)
 }
 
-func codexPromptCacheKeyFromHeader(headers http.Header) (string, string) {
-	for _, name := range []string{"X-Session-ID", "Session_id", "session_id", "Conversation_id", "conversation_id"} {
+func codexPromptCacheKeyFromHeader(headers http.Header) string {
+	for _, name := range []string{"X-Session-ID", "Session_id", "Conversation_id"} {
 		if value := strings.TrimSpace(headers.Get(name)); value != "" {
-			return value, "header." + name
+			return value
 		}
 	}
-	return "", ""
+	return ""
 }
 
 func normalizeCodexPreviousResponseIDForPromptCache(_ context.Context, from sdktranslator.Format, rawJSON []byte) []byte {
@@ -1007,6 +1007,9 @@ func normalizeCodexDeveloperCurrentTimeForPromptCache(_ context.Context, from sd
 
 	content := gjson.GetBytes(rawJSON, "input.0.content")
 	if !content.Exists() {
+		return rawJSON
+	}
+	if content.Type != gjson.String {
 		return rawJSON
 	}
 	normalized, changed := normalizeCodexCurrentTimeLine(content.String())

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -286,7 +286,6 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body, _ = sjson.SetBytes(body, "stream", true)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
@@ -546,7 +545,6 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
@@ -882,12 +880,13 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 			}
 		}
 	} else if from == "openai-response" {
-		promptCacheKey := gjson.GetBytes(req.Payload, "prompt_cache_key")
-		if promptCacheKey.Exists() {
-			cache.ID = promptCacheKey.String()
+		if promptCacheKey, _ := codexPromptCacheKeyFromClient(ctx, req, rawJSON); promptCacheKey != "" {
+			cache.ID = promptCacheKey
 		}
 	} else if from == "openai" {
-		if apiKey := strings.TrimSpace(helps.APIKeyFromContext(ctx)); apiKey != "" {
+		if promptCacheKey, _ := codexPromptCacheKeyFromClient(ctx, req, rawJSON); promptCacheKey != "" {
+			cache.ID = promptCacheKey
+		} else if apiKey := strings.TrimSpace(helps.APIKeyFromContext(ctx)); apiKey != "" {
 			cache.ID = uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:prompt-cache:"+apiKey)).String()
 		}
 	}
@@ -895,6 +894,8 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 	if cache.ID != "" {
 		rawJSON, _ = sjson.SetBytes(rawJSON, "prompt_cache_key", cache.ID)
 	}
+	rawJSON = normalizeCodexPreviousResponseIDForPromptCache(ctx, from, rawJSON)
+	rawJSON = normalizeCodexDeveloperCurrentTimeForPromptCache(ctx, from, rawJSON)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(rawJSON))
 	if err != nil {
 		return nil, err
@@ -903,6 +904,163 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 		httpReq.Header.Set("Session_id", cache.ID)
 	}
 	return httpReq, nil
+}
+
+func codexPromptCacheKeyFromClient(ctx context.Context, req cliproxyexecutor.Request, rawJSON []byte) (string, string) {
+	if key, source := codexPromptCacheKeyFromJSON(req.Payload, "payload"); key != "" {
+		return key, source
+	}
+	if key, source := codexPromptCacheKeyFromJSON(rawJSON, "body"); key != "" {
+		return key, source
+	}
+	return codexPromptCacheKeyFromHeaders(ctx)
+}
+
+func codexPromptCacheKeyFromJSON(payload []byte, prefix string) (string, string) {
+	if len(payload) == 0 {
+		return "", ""
+	}
+	for _, path := range []string{
+		"prompt_cache_key",
+		"promptCacheKey",
+		"providerOptions.openai.promptCacheKey",
+		"provider_options.openai.prompt_cache_key",
+		"provider_options.openai.promptCacheKey",
+	} {
+		if value := strings.TrimSpace(gjson.GetBytes(payload, path).String()); value != "" {
+			return value, prefix + "." + path
+		}
+	}
+	return "", ""
+}
+
+func codexPromptCacheKeyFromHeaders(ctx context.Context) (string, string) {
+	if ctx == nil {
+		return "", ""
+	}
+	ginCtx, ok := ctx.Value("gin").(*gin.Context)
+	if !ok || ginCtx == nil || ginCtx.Request == nil {
+		return "", ""
+	}
+	return codexPromptCacheKeyFromHeader(ginCtx.Request.Header)
+}
+
+func codexPromptCacheKeyFromHeader(headers http.Header) (string, string) {
+	for _, name := range []string{"X-Session-ID", "Session_id", "session_id", "Conversation_id", "conversation_id"} {
+		if value := strings.TrimSpace(headers.Get(name)); value != "" {
+			return value, "header." + name
+		}
+	}
+	return "", ""
+}
+
+func normalizeCodexPreviousResponseIDForPromptCache(_ context.Context, from sdktranslator.Format, rawJSON []byte) []byte {
+	if from != "openai-response" {
+		return rawJSON
+	}
+	if strings.TrimSpace(gjson.GetBytes(rawJSON, "previous_response_id").String()) == "" {
+		return rawJSON
+	}
+	if strings.TrimSpace(gjson.GetBytes(rawJSON, "prompt_cache_key").String()) == "" {
+		return rawJSON
+	}
+
+	input := gjson.GetBytes(rawJSON, "input")
+	if !codexInputLooksLikeFullTranscript(input) {
+		return rawJSON
+	}
+
+	updated, errDelete := sjson.DeleteBytes(rawJSON, "previous_response_id")
+	if errDelete != nil {
+		return rawJSON
+	}
+	return updated
+}
+
+func codexInputLooksLikeFullTranscript(input gjson.Result) bool {
+	if !input.Exists() || !input.IsArray() {
+		return false
+	}
+	for _, item := range input.Array() {
+		switch strings.TrimSpace(item.Get("type").String()) {
+		case "function_call", "custom_tool_call":
+			return true
+		case "message":
+			if strings.TrimSpace(item.Get("role").String()) == "assistant" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func normalizeCodexDeveloperCurrentTimeForPromptCache(_ context.Context, from sdktranslator.Format, rawJSON []byte) []byte {
+	if from != "openai-response" {
+		return rawJSON
+	}
+	if strings.TrimSpace(gjson.GetBytes(rawJSON, "prompt_cache_key").String()) == "" {
+		return rawJSON
+	}
+	if strings.TrimSpace(gjson.GetBytes(rawJSON, "input.0.role").String()) != "developer" {
+		return rawJSON
+	}
+
+	content := gjson.GetBytes(rawJSON, "input.0.content")
+	if !content.Exists() {
+		return rawJSON
+	}
+	normalized, changed := normalizeCodexCurrentTimeLine(content.String())
+	if !changed {
+		return rawJSON
+	}
+	updated, errSet := sjson.SetBytes(rawJSON, "input.0.content", normalized)
+	if errSet != nil {
+		return rawJSON
+	}
+	return updated
+}
+
+func normalizeCodexCurrentTimeLine(content string) (string, bool) {
+	const label = "Current time: "
+	index := strings.Index(content, label)
+	if index < 0 {
+		return content, false
+	}
+
+	valueStart := index + len(label)
+	valueEnd := len(content)
+	if newlineIndex := strings.IndexByte(content[valueStart:], '\n'); newlineIndex >= 0 {
+		valueEnd = valueStart + newlineIndex
+	}
+	rawValue := strings.TrimSpace(content[valueStart:valueEnd])
+	if !looksLikeISODatePrefix(rawValue) {
+		return content, false
+	}
+
+	normalizedLine := label + rawValue[:10] + "T00:00:00.000Z"
+	if content[index:valueEnd] == normalizedLine {
+		return content, false
+	}
+	return content[:index] + normalizedLine + content[valueEnd:], true
+}
+
+func looksLikeISODatePrefix(value string) bool {
+	if len(value) < len("2006-01-02") {
+		return false
+	}
+	for index := 0; index < len("2006-01-02"); index++ {
+		switch index {
+		case 4, 7:
+			if value[index] != '-' {
+				return false
+			}
+		default:
+			if value[index] < '0' || value[index] > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -986,10 +986,6 @@ func codexInputLooksLikeFullTranscript(input gjson.Result) bool {
 		if strings.TrimSpace(item.Get("role").String()) == "assistant" {
 			return true
 		}
-		switch strings.TrimSpace(item.Get("type").String()) {
-		case "function_call", "custom_tool_call":
-			return true
-		}
 	}
 	return false
 }

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -982,6 +982,7 @@ func codexInputLooksLikeFullTranscript(input gjson.Result) bool {
 		return false
 	}
 	for _, item := range input.Array() {
+		// Some Responses transcript items omit type, so assistant role alone is transcript evidence.
 		if strings.TrimSpace(item.Get("role").String()) == "assistant" {
 			return true
 		}
@@ -1060,6 +1061,7 @@ func looksLikeOpenCodeEnvBlock(block string) bool {
 		return false
 	}
 
+	// OpenCode env blocks vary by version; two secondary markers avoid matching arbitrary developer text.
 	markerCount := 0
 	for _, marker := range []string{
 		"Workspace root folder:",

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -986,6 +986,10 @@ func codexInputLooksLikeFullTranscript(input gjson.Result) bool {
 		if strings.TrimSpace(item.Get("role").String()) == "assistant" {
 			return true
 		}
+		switch strings.TrimSpace(item.Get("type").String()) {
+		case "compaction", "compaction_summary":
+			return true
+		}
 	}
 	return false
 }

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -982,13 +982,12 @@ func codexInputLooksLikeFullTranscript(input gjson.Result) bool {
 		return false
 	}
 	for _, item := range input.Array() {
+		if strings.TrimSpace(item.Get("role").String()) == "assistant" {
+			return true
+		}
 		switch strings.TrimSpace(item.Get("type").String()) {
 		case "function_call", "custom_tool_call":
 			return true
-		case "message":
-			if strings.TrimSpace(item.Get("role").String()) == "assistant" {
-				return true
-			}
 		}
 	}
 	return false
@@ -1012,7 +1011,7 @@ func normalizeCodexDeveloperCurrentTimeForPromptCache(_ context.Context, from sd
 	if content.Type != gjson.String {
 		return rawJSON
 	}
-	normalized, changed := normalizeCodexCurrentTimeLine(content.String())
+	normalized, changed := normalizeCodexOpenCodeEnvCurrentTime(content.String())
 	if !changed {
 		return rawJSON
 	}
@@ -1023,7 +1022,59 @@ func normalizeCodexDeveloperCurrentTimeForPromptCache(_ context.Context, from sd
 	return updated
 }
 
-func normalizeCodexCurrentTimeLine(content string) (string, bool) {
+func normalizeCodexOpenCodeEnvCurrentTime(content string) (string, bool) {
+	const envStartMarker = "<env>"
+	const envEndMarker = "</env>"
+
+	searchStart := 0
+	for {
+		envStart := strings.Index(content[searchStart:], envStartMarker)
+		if envStart < 0 {
+			return content, false
+		}
+		envStart += searchStart
+		blockStart := envStart + len(envStartMarker)
+		envEnd := strings.Index(content[blockStart:], envEndMarker)
+		if envEnd < 0 {
+			return content, false
+		}
+		blockEnd := blockStart + envEnd
+		block := content[blockStart:blockEnd]
+		if !looksLikeOpenCodeEnvBlock(block) {
+			searchStart = blockEnd + len(envEndMarker)
+			continue
+		}
+
+		normalizedBlock, changed := normalizeCodexCurrentTimeLineInBlock(block)
+		if !changed {
+			searchStart = blockEnd + len(envEndMarker)
+			continue
+		}
+		return content[:blockStart] + normalizedBlock + content[blockEnd:], true
+	}
+}
+
+func looksLikeOpenCodeEnvBlock(block string) bool {
+	required := strings.Contains(block, "Working directory:")
+	if !required {
+		return false
+	}
+
+	markerCount := 0
+	for _, marker := range []string{
+		"Workspace root folder:",
+		"Is directory a git repo:",
+		"Platform:",
+		"Today's date:",
+	} {
+		if strings.Contains(block, marker) {
+			markerCount++
+		}
+	}
+	return markerCount >= 2
+}
+
+func normalizeCodexCurrentTimeLineInBlock(content string) (string, bool) {
 	const label = "Current time: "
 	index := strings.Index(content, label)
 	if index < 0 {

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -186,3 +186,31 @@ func TestCodexExecutorCacheHelper_OpenAIResponses_NormalizesDeveloperCurrentTime
 		t.Fatalf("developer current time = %q, want normalized day timestamp", content)
 	}
 }
+
+func TestCodexExecutorCacheHelper_OpenAIResponses_DoesNotNormalizeStructuredDeveloperContent(t *testing.T) {
+	ctx := newCodexCacheHelperContext("", nil)
+	executor := &CodexExecutor{}
+	rawJSON := []byte(`{"model":"gpt-5.5","stream":true,"prompt_cache_key":"cpa:session","input":[{"role":"developer","content":[{"type":"input_text","text":"prefix\n  Current time: 2026-04-24T05:55:01.054Z\nsuffix"}]},{"role":"user","content":"hello"}]}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","prompt_cache_key":"cpa:session","input":[]}`),
+	}
+	url := "https://example.com/responses"
+
+	httpReq, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), url, req, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper error: %v", err)
+	}
+
+	body, errRead := io.ReadAll(httpReq.Body)
+	if errRead != nil {
+		t.Fatalf("read request body: %v", errRead)
+	}
+	content := gjson.GetBytes(body, "input.0.content")
+	if !content.IsArray() {
+		t.Fatalf("developer content type changed: %s", string(body))
+	}
+	if gotText := content.Get("0.text").String(); !strings.Contains(gotText, "2026-04-24T05:55:01.054Z") {
+		t.Fatalf("structured developer content was unexpectedly normalized: %q", gotText)
+	}
+}

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func newCodexCacheHelperContext(apiKey string, headers map[string]string) context.Context {
+	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(recorder)
 	if apiKey != "" {
@@ -162,7 +163,7 @@ func TestCodexExecutorCacheHelper_OpenAIChatCompletions_UsesSessionHeaderBeforeA
 func TestCodexExecutorCacheHelper_OpenAIResponses_NormalizesDeveloperCurrentTimeForPromptCache(t *testing.T) {
 	ctx := newCodexCacheHelperContext("", nil)
 	executor := &CodexExecutor{}
-	rawJSON := []byte(`{"model":"gpt-5.5","stream":true,"prompt_cache_key":"cpa:session","input":[{"role":"developer","content":"prefix\n  Current time: 2026-04-24T05:55:01.054Z\nsuffix"},{"role":"user","content":"hello"}]}`)
+	rawJSON := []byte(`{"model":"gpt-5.5","stream":true,"prompt_cache_key":"cpa:session","input":[{"role":"developer","content":"You are powered by the model named gpt-5.5. The exact model ID is openai/gpt-5.5\nHere is some useful information about the environment you are running in:\n<env>\n  Working directory: /repo\n  Workspace root folder: /repo\n  Is directory a git repo: yes\n  Platform: linux\n  Today's date: Fri Apr 24 2026\n  Current time: 2026-04-24T05:55:01.054Z\n</env>"},{"role":"user","content":"hello"}]}`)
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5.5",
 		Payload: []byte(`{"model":"gpt-5.5","prompt_cache_key":"cpa:session","input":[]}`),
@@ -184,6 +185,31 @@ func TestCodexExecutorCacheHelper_OpenAIResponses_NormalizesDeveloperCurrentTime
 	}
 	if !strings.Contains(content, "Current time: 2026-04-24T00:00:00.000Z") {
 		t.Fatalf("developer current time = %q, want normalized day timestamp", content)
+	}
+}
+
+func TestCodexExecutorCacheHelper_OpenAIResponses_DoesNotNormalizeUserAuthoredDeveloperCurrentTime(t *testing.T) {
+	ctx := newCodexCacheHelperContext("", nil)
+	executor := &CodexExecutor{}
+	rawJSON := []byte(`{"model":"gpt-5.5","stream":true,"prompt_cache_key":"cpa:session","input":[{"role":"developer","content":"Use this exact timestamp for the audit window.\nCurrent time: 2026-04-24T05:55:01.054Z\nDo not change it."},{"role":"user","content":"hello"}]}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","prompt_cache_key":"cpa:session","input":[]}`),
+	}
+	url := "https://example.com/responses"
+
+	httpReq, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), url, req, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper error: %v", err)
+	}
+
+	body, errRead := io.ReadAll(httpReq.Body)
+	if errRead != nil {
+		t.Fatalf("read request body: %v", errRead)
+	}
+	content := gjson.GetBytes(body, "input.0.content").String()
+	if !strings.Contains(content, "Current time: 2026-04-24T05:55:01.054Z") {
+		t.Fatalf("developer current time was unexpectedly normalized: %q", content)
 	}
 }
 

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -3,7 +3,9 @@ package executor
 import (
 	"context"
 	"io"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -12,6 +14,19 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 )
+
+func newCodexCacheHelperContext(apiKey string, headers map[string]string) context.Context {
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	if apiKey != "" {
+		ginCtx.Set("apiKey", apiKey)
+	}
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	for name, value := range headers {
+		ginCtx.Request.Header.Set(name, value)
+	}
+	return context.WithValue(context.Background(), "gin", ginCtx)
+}
 
 func TestCodexExecutorCacheHelper_OpenAIChatCompletions_StablePromptCacheKeyFromAPIKey(t *testing.T) {
 	recorder := httptest.NewRecorder()
@@ -60,5 +75,114 @@ func TestCodexExecutorCacheHelper_OpenAIChatCompletions_StablePromptCacheKeyFrom
 	gotKey2 := gjson.GetBytes(body2, "prompt_cache_key").String()
 	if gotKey2 != expectedKey {
 		t.Fatalf("prompt_cache_key (second call) = %q, want %q", gotKey2, expectedKey)
+	}
+}
+
+func TestCodexExecutorCacheHelper_OpenAIResponses_UsesSessionHeaderWhenPayloadKeyMissing(t *testing.T) {
+	ctx := newCodexCacheHelperContext("", map[string]string{"X-Session-ID": "cpa:session-123"})
+	executor := &CodexExecutor{}
+	rawJSON := []byte(`{"model":"gpt-5.5","stream":true}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":[]}`),
+	}
+	url := "https://example.com/responses"
+
+	httpReq, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), url, req, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper error: %v", err)
+	}
+
+	body, errRead := io.ReadAll(httpReq.Body)
+	if errRead != nil {
+		t.Fatalf("read request body: %v", errRead)
+	}
+	if gotKey := gjson.GetBytes(body, "prompt_cache_key").String(); gotKey != "cpa:session-123" {
+		t.Fatalf("prompt_cache_key = %q, want %q", gotKey, "cpa:session-123")
+	}
+	if gotSession := httpReq.Header.Get("Session_id"); gotSession != "cpa:session-123" {
+		t.Fatalf("Session_id = %q, want %q", gotSession, "cpa:session-123")
+	}
+}
+
+func TestCodexExecutorCacheHelper_OpenAIChatCompletions_PrefersPayloadPromptCacheKey(t *testing.T) {
+	ctx := newCodexCacheHelperContext("test-api-key", map[string]string{"X-Session-ID": "cpa:header"})
+	executor := &CodexExecutor{}
+	rawJSON := []byte(`{"model":"gpt-5.5","stream":true}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","messages":[],"prompt_cache_key":"cpa:body"}`),
+	}
+	url := "https://example.com/responses"
+
+	httpReq, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai"), url, req, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper error: %v", err)
+	}
+
+	body, errRead := io.ReadAll(httpReq.Body)
+	if errRead != nil {
+		t.Fatalf("read request body: %v", errRead)
+	}
+	if gotKey := gjson.GetBytes(body, "prompt_cache_key").String(); gotKey != "cpa:body" {
+		t.Fatalf("prompt_cache_key = %q, want %q", gotKey, "cpa:body")
+	}
+	if gotSession := httpReq.Header.Get("Session_id"); gotSession != "cpa:body" {
+		t.Fatalf("Session_id = %q, want %q", gotSession, "cpa:body")
+	}
+}
+
+func TestCodexExecutorCacheHelper_OpenAIChatCompletions_UsesSessionHeaderBeforeAPIKeyFallback(t *testing.T) {
+	ctx := newCodexCacheHelperContext("test-api-key", map[string]string{"X-Session-ID": "cpa:header"})
+	executor := &CodexExecutor{}
+	rawJSON := []byte(`{"model":"gpt-5.5","stream":true}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","messages":[]}`),
+	}
+	url := "https://example.com/responses"
+
+	httpReq, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai"), url, req, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper error: %v", err)
+	}
+
+	body, errRead := io.ReadAll(httpReq.Body)
+	if errRead != nil {
+		t.Fatalf("read request body: %v", errRead)
+	}
+	if gotKey := gjson.GetBytes(body, "prompt_cache_key").String(); gotKey != "cpa:header" {
+		t.Fatalf("prompt_cache_key = %q, want %q", gotKey, "cpa:header")
+	}
+	if gotSession := httpReq.Header.Get("Session_id"); gotSession != "cpa:header" {
+		t.Fatalf("Session_id = %q, want %q", gotSession, "cpa:header")
+	}
+}
+
+func TestCodexExecutorCacheHelper_OpenAIResponses_NormalizesDeveloperCurrentTimeForPromptCache(t *testing.T) {
+	ctx := newCodexCacheHelperContext("", nil)
+	executor := &CodexExecutor{}
+	rawJSON := []byte(`{"model":"gpt-5.5","stream":true,"prompt_cache_key":"cpa:session","input":[{"role":"developer","content":"prefix\n  Current time: 2026-04-24T05:55:01.054Z\nsuffix"},{"role":"user","content":"hello"}]}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","prompt_cache_key":"cpa:session","input":[]}`),
+	}
+	url := "https://example.com/responses"
+
+	httpReq, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), url, req, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper error: %v", err)
+	}
+
+	body, errRead := io.ReadAll(httpReq.Body)
+	if errRead != nil {
+		t.Fatalf("read request body: %v", errRead)
+	}
+	content := gjson.GetBytes(body, "input.0.content").String()
+	if strings.Contains(content, "2026-04-24T05:55:01.054Z") {
+		t.Fatalf("developer current time was not normalized: %q", content)
+	}
+	if !strings.Contains(content, "Current time: 2026-04-24T00:00:00.000Z") {
+		t.Fatalf("developer current time = %q, want normalized day timestamp", content)
 	}
 }

--- a/internal/runtime/executor/codex_executor_previous_response_test.go
+++ b/internal/runtime/executor/codex_executor_previous_response_test.go
@@ -7,10 +7,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
-	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
-	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
-	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 )
 

--- a/internal/runtime/executor/codex_executor_previous_response_test.go
+++ b/internal/runtime/executor/codex_executor_previous_response_test.go
@@ -1,0 +1,79 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestCodexExecutorExecute_PreservesPreviousResponseID(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"background\":false,\"error\":null}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","previous_response_id":"resp-prev","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := gjson.GetBytes(gotBody, "previous_response_id").String(); got != "resp-prev" {
+		t.Fatalf("previous_response_id = %q, want %q; body=%s", got, "resp-prev", string(gotBody))
+	}
+}
+
+func TestCodexExecutorExecuteStream_PreservesPreviousResponseID(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"background\":false,\"error\":null}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","previous_response_id":"resp-prev","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	for range result.Chunks {
+	}
+	if got := gjson.GetBytes(gotBody, "previous_response_id").String(); got != "resp-prev" {
+		t.Fatalf("previous_response_id = %q, want %q; body=%s", got, "resp-prev", string(gotBody))
+	}
+}

--- a/internal/runtime/executor/codex_executor_previous_response_test.go
+++ b/internal/runtime/executor/codex_executor_previous_response_test.go
@@ -77,3 +77,27 @@ func TestCodexExecutorExecuteStream_PreservesPreviousResponseID(t *testing.T) {
 		t.Fatalf("previous_response_id = %q, want %q; body=%s", got, "resp-prev", string(gotBody))
 	}
 }
+
+func TestCodexExecutorCacheHelper_OpenAIResponses_DropsPreviousResponseIDForAssistantRoleWithoutType(t *testing.T) {
+	ctx := newCodexCacheHelperContext("", nil)
+	executor := &CodexExecutor{}
+	rawJSON := []byte(`{"model":"gpt-5.5","stream":true,"prompt_cache_key":"cpa:session","previous_response_id":"resp-prev","input":[{"role":"developer","content":"instructions"},{"role":"user","content":"hello"},{"role":"assistant","content":"done"}]}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","prompt_cache_key":"cpa:session","input":[]}`),
+	}
+	url := "https://example.com/responses"
+
+	httpReq, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), url, req, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper error: %v", err)
+	}
+
+	body, errRead := io.ReadAll(httpReq.Body)
+	if errRead != nil {
+		t.Fatalf("read request body: %v", errRead)
+	}
+	if got := gjson.GetBytes(body, "previous_response_id"); got.Exists() {
+		t.Fatalf("previous_response_id was not dropped for full transcript: %s", string(body))
+	}
+}

--- a/internal/runtime/executor/codex_executor_previous_response_test.go
+++ b/internal/runtime/executor/codex_executor_previous_response_test.go
@@ -101,3 +101,43 @@ func TestCodexExecutorCacheHelper_OpenAIResponses_DropsPreviousResponseIDForAssi
 		t.Fatalf("previous_response_id was not dropped for full transcript: %s", string(body))
 	}
 }
+
+func TestCodexExecutorCacheHelper_OpenAIResponses_PreservesPreviousResponseIDForToolCallIncrementalInput(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		item string
+	}{
+		{
+			name: "function_call",
+			item: `{"type":"function_call","id":"fc-1","call_id":"call-1","name":"tool"}`,
+		},
+		{
+			name: "custom_tool_call",
+			item: `{"type":"custom_tool_call","id":"ctc-1","call_id":"call-1","name":"apply_patch"}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newCodexCacheHelperContext("", nil)
+			executor := &CodexExecutor{}
+			rawJSON := []byte(`{"model":"gpt-5.5","stream":true,"prompt_cache_key":"cpa:session","previous_response_id":"resp-prev","input":[` + tc.item + `,{"type":"message","id":"msg-1"}]}`)
+			req := cliproxyexecutor.Request{
+				Model:   "gpt-5.5",
+				Payload: []byte(`{"model":"gpt-5.5","prompt_cache_key":"cpa:session","input":[]}`),
+			}
+			url := "https://example.com/responses"
+
+			httpReq, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), url, req, rawJSON)
+			if err != nil {
+				t.Fatalf("cacheHelper error: %v", err)
+			}
+
+			body, errRead := io.ReadAll(httpReq.Body)
+			if errRead != nil {
+				t.Fatalf("read request body: %v", errRead)
+			}
+			if got := gjson.GetBytes(body, "previous_response_id").String(); got != "resp-prev" {
+				t.Fatalf("previous_response_id = %q, want resp-prev; body=%s", got, string(body))
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/codex_executor_previous_response_test.go
+++ b/internal/runtime/executor/codex_executor_previous_response_test.go
@@ -102,6 +102,34 @@ func TestCodexExecutorCacheHelper_OpenAIResponses_DropsPreviousResponseIDForAssi
 	}
 }
 
+func TestCodexExecutorCacheHelper_OpenAIResponses_DropsPreviousResponseIDForCompactionTranscript(t *testing.T) {
+	for _, typ := range []string{"compaction", "compaction_summary"} {
+		t.Run(typ, func(t *testing.T) {
+			ctx := newCodexCacheHelperContext("", nil)
+			executor := &CodexExecutor{}
+			rawJSON := []byte(`{"model":"gpt-5.5","stream":true,"prompt_cache_key":"cpa:session","previous_response_id":"resp-prev","input":[{"type":"message","role":"user","content":"hello"},{"type":"` + typ + `","encrypted_content":"summary"}]}`)
+			req := cliproxyexecutor.Request{
+				Model:   "gpt-5.5",
+				Payload: []byte(`{"model":"gpt-5.5","prompt_cache_key":"cpa:session","input":[]}`),
+			}
+			url := "https://example.com/responses"
+
+			httpReq, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), url, req, rawJSON)
+			if err != nil {
+				t.Fatalf("cacheHelper error: %v", err)
+			}
+
+			body, errRead := io.ReadAll(httpReq.Body)
+			if errRead != nil {
+				t.Fatalf("read request body: %v", errRead)
+			}
+			if got := gjson.GetBytes(body, "previous_response_id"); got.Exists() {
+				t.Fatalf("previous_response_id was not dropped for compaction transcript: %s", string(body))
+			}
+		})
+	}
+}
+
 func TestCodexExecutorCacheHelper_OpenAIResponses_PreservesPreviousResponseIDForToolCallIncrementalInput(t *testing.T) {
 	for _, tc := range []struct {
 		name string


### PR DESCRIPTION
## Summary
- Prefer client supplied Codex prompt cache keys from payload, translated body, provider options, or session headers before falling back to the API key derived key.
- Normalize the volatile OpenCode developer Current time value to a stable day-level timestamp for OpenAI Responses prompt-cache stability.
- Preserve previous_response_id for incremental Responses requests while still dropping it for full-transcript prompt-cache requests.

## Why
OpenCode includes environment metadata in the first developer input item. The Current time field changes on every turn, which breaks exact-prefix prompt cache reuse shortly after the stable prefix. Keeping the date but normalizing the time removes that per-request jitter without changing user/task content.

## Tests
- docker run --rm -v "/root/project/cpa":/app -w /app golang:1.26-alpine go test -run 'TestCodexExecutorCacheHelper|TestCodexExecutorExecute.*PreviousResponseID' ./internal/runtime/executor
- docker build -t cli-proxy-api:pr-check .