### PR TITLE
fix(codex): refresh models after plan changes

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1011,6 +1011,13 @@ func (h *Handler) buildAuthFromFileData(path string, data []byte) (*coreauth.Aut
 		"path":   path,
 		"source": path,
 	}
+	if strings.EqualFold(strings.TrimSpace(provider), "codex") {
+		if idTokenRaw, ok := metadata["id_token"].(string); ok {
+			if planType := codex.PlanTypeFromIDToken(idTokenRaw); planType != "" {
+				attr["plan_type"] = planType
+			}
+		}
+	}
 	auth := &coreauth.Auth{
 		ID:         authID,
 		Provider:   provider,

--- a/internal/auth/codex/jwt_parser.go
+++ b/internal/auth/codex/jwt_parser.go
@@ -75,6 +75,15 @@ func ParseJWTToken(token string) (*JWTClaims, error) {
 	return &claims, nil
 }
 
+// PlanTypeFromIDToken extracts the ChatGPT plan type from a Codex ID token.
+func PlanTypeFromIDToken(token string) string {
+	claims, err := ParseJWTToken(strings.TrimSpace(token))
+	if err != nil || claims == nil {
+		return ""
+	}
+	return strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType)
+}
+
 // base64URLDecode decodes a Base64 URL-encoded string, adding padding if necessary.
 // JWTs use a URL-safe Base64 alphabet and omit padding, so this function ensures
 // correct decoding by re-adding the padding before decoding.

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -4,7 +4,6 @@ import "testing"
 
 func TestCodexStaticModelsIncludeGPT55(t *testing.T) {
 	tierModels := map[string][]*ModelInfo{
-		"free": GetCodexFreeModels(),
 		"team": GetCodexTeamModels(),
 		"plus": GetCodexPlusModels(),
 		"pro":  GetCodexProModels(),
@@ -84,5 +83,11 @@ func assertGPT55ModelInfo(t *testing.T, source string, model *ModelInfo) {
 		if model.Thinking.Levels[i] != level {
 			t.Fatalf("%s thinking level %d mismatch: got %q, want %q", source, i, model.Thinking.Levels[i], level)
 		}
+	}
+}
+
+func TestCodexFreeStaticModelsExcludeGPT55(t *testing.T) {
+	if model := findModelInfo(GetCodexFreeModels(), "gpt-5.5"); model != nil {
+		t.Fatal("expected codex free tier to exclude gpt-5.5")
 	}
 }

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -694,7 +694,13 @@ func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 	if auth.Metadata == nil {
 		auth.Metadata = make(map[string]any)
 	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
 	auth.Metadata["id_token"] = td.IDToken
+	if planType := codexauth.PlanTypeFromIDToken(td.IDToken); planType != "" {
+		auth.Attributes["plan_type"] = planType
+	}
 	auth.Metadata["access_token"] = td.AccessToken
 	if td.RefreshToken != "" {
 		auth.Metadata["refresh_token"] = td.RefreshToken

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -700,8 +700,6 @@ func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 	auth.Metadata["id_token"] = td.IDToken
 	if planType := codexauth.PlanTypeFromIDToken(td.IDToken); planType != "" {
 		auth.Attributes["plan_type"] = planType
-	} else {
-		delete(auth.Attributes, "plan_type")
 	}
 	auth.Metadata["access_token"] = td.AccessToken
 	if td.RefreshToken != "" {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -700,6 +700,8 @@ func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 	auth.Metadata["id_token"] = td.IDToken
 	if planType := codexauth.PlanTypeFromIDToken(td.IDToken); planType != "" {
 		auth.Attributes["plan_type"] = planType
+	} else {
+		delete(auth.Attributes, "plan_type")
 	}
 	auth.Metadata["access_token"] = td.AccessToken
 	if td.RefreshToken != "" {

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -162,10 +162,8 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 	// For codex auth files, extract plan_type from the JWT id_token.
 	if provider == "codex" {
 		if idTokenRaw, ok := metadata["id_token"].(string); ok && strings.TrimSpace(idTokenRaw) != "" {
-			if claims, errParse := codex.ParseJWTToken(idTokenRaw); errParse == nil && claims != nil {
-				if pt := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType); pt != "" {
-					a.Attributes["plan_type"] = pt
-				}
+			if pt := codex.PlanTypeFromIDToken(idTokenRaw); pt != "" {
+				a.Attributes["plan_type"] = pt
 			}
 		}
 	}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -202,6 +202,33 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	return manager
 }
 
+// SetHook replaces the lifecycle hook used for subsequent manager events.
+func (m *Manager) SetHook(hook Hook) {
+	if m == nil {
+		return
+	}
+	if hook == nil {
+		hook = NoopHook{}
+	}
+	m.mu.Lock()
+	m.hook = hook
+	m.mu.Unlock()
+}
+
+// Hook returns the currently installed lifecycle hook.
+func (m *Manager) Hook() Hook {
+	if m == nil {
+		return NoopHook{}
+	}
+	m.mu.RLock()
+	hook := m.hook
+	m.mu.RUnlock()
+	if hook == nil {
+		return NoopHook{}
+	}
+	return hook
+}
+
 func isBuiltInSelector(selector Selector) bool {
 	switch selector.(type) {
 	case *RoundRobinSelector, *FillFirstSelector:

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -127,6 +127,11 @@ type Hook interface {
 	OnResult(ctx context.Context, result Result)
 }
 
+// AuthChangeHook can be implemented by hooks that need the previous auth state.
+type AuthChangeHook interface {
+	OnAuthChanged(ctx context.Context, previous *Auth, current *Auth)
+}
+
 // NoopHook provides optional hook defaults.
 type NoopHook struct{}
 
@@ -1147,8 +1152,10 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth == nil || auth.ID == "" {
 		return nil, nil
 	}
+	var previous *Auth
 	m.mu.Lock()
 	if existing, ok := m.auths[auth.ID]; ok && existing != nil {
+		previous = existing.Clone()
 		if !auth.indexAssigned && auth.Index == "" {
 			auth.Index = existing.Index
 			auth.indexAssigned = existing.indexAssigned
@@ -1169,7 +1176,12 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	}
 	m.queueRefreshReschedule(auth.ID)
 	_ = m.persist(ctx, auth)
-	m.hook.OnAuthUpdated(ctx, auth.Clone())
+	updated := auth.Clone()
+	if changeHook, ok := m.hook.(AuthChangeHook); ok {
+		changeHook.OnAuthChanged(ctx, previous, updated)
+	} else {
+		m.hook.OnAuthUpdated(ctx, updated)
+	}
 	return auth.Clone(), nil
 }
 

--- a/sdk/cliproxy/auth/persist_policy.go
+++ b/sdk/cliproxy/auth/persist_policy.go
@@ -22,3 +22,8 @@ func shouldSkipPersist(ctx context.Context) bool {
 	enabled, ok := v.(bool)
 	return ok && enabled
 }
+
+// IsSkipPersist reports whether the context disables manager persistence.
+func IsSkipPersist(ctx context.Context) bool {
+	return shouldSkipPersist(ctx)
+}

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -256,5 +256,6 @@ func (b *Builder) Build() (*Service, error) {
 		coreManager:    coreManager,
 		serverOptions:  append([]api.ServerOption(nil), b.serverOptions...),
 	}
+	coreManager.SetHook(serviceAuthHook{service: service, next: coreManager.Hook()})
 	return service, nil
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -816,7 +816,7 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 	if a == nil || a.ID == "" {
 		return
 	}
-	if a.Disabled {
+	if authDisabledForModelRegistration(a) {
 		GlobalModelRegistry().UnregisterClient(a.ID)
 		return
 	}
@@ -1039,14 +1039,14 @@ func (s *Service) refreshModelRegistrationForAuth(current *coreauth.Auth) bool {
 		return false
 	}
 
-	if !current.Disabled {
+	if !authDisabledForModelRegistration(current) {
 		s.ensureExecutorsForAuth(current)
 	}
 	s.registerModelsForAuth(current)
 	s.coreManager.ReconcileRegistryModelStates(context.Background(), current.ID)
 
 	latest, ok := s.latestAuthForModelRegistration(current.ID)
-	if !ok || latest.Disabled {
+	if !ok || authDisabledForModelRegistration(latest) {
 		GlobalModelRegistry().UnregisterClient(current.ID)
 		s.coreManager.RefreshSchedulerEntry(current.ID)
 		return false
@@ -1078,7 +1078,20 @@ func (h serviceAuthHook) OnAuthUpdated(ctx context.Context, auth *coreauth.Auth)
 	if h.next != nil {
 		h.next.OnAuthUpdated(ctx, auth)
 	}
-	h.refreshModels(ctx, auth)
+}
+
+func (h serviceAuthHook) OnAuthChanged(ctx context.Context, previous *coreauth.Auth, current *coreauth.Auth) {
+	if h.next != nil {
+		if changeHook, ok := h.next.(coreauth.AuthChangeHook); ok {
+			changeHook.OnAuthChanged(ctx, previous, current)
+		} else {
+			h.next.OnAuthUpdated(ctx, current)
+		}
+	}
+	if !authModelRegistrationChanged(previous, current) {
+		return
+	}
+	h.refreshModels(ctx, current)
 }
 
 func (h serviceAuthHook) OnResult(ctx context.Context, result coreauth.Result) {
@@ -1094,7 +1107,7 @@ func (h serviceAuthHook) refreshModels(ctx context.Context, auth *coreauth.Auth)
 	if coreauth.IsSkipPersist(ctx) {
 		return
 	}
-	if auth.Disabled || auth.Status == coreauth.StatusDisabled {
+	if authDisabledForModelRegistration(auth) {
 		GlobalModelRegistry().UnregisterClient(auth.ID)
 		if h.service.coreManager != nil {
 			h.service.coreManager.RefreshSchedulerEntry(auth.ID)
@@ -1102,6 +1115,33 @@ func (h serviceAuthHook) refreshModels(ctx context.Context, auth *coreauth.Auth)
 		return
 	}
 	h.service.refreshModelRegistrationForAuth(auth)
+}
+
+func authDisabledForModelRegistration(auth *coreauth.Auth) bool {
+	return auth != nil && (auth.Disabled || auth.Status == coreauth.StatusDisabled)
+}
+
+func authModelRegistrationChanged(previous *coreauth.Auth, current *coreauth.Auth) bool {
+	if previous == nil || current == nil {
+		return true
+	}
+	if previous.Provider != current.Provider || previous.Prefix != current.Prefix {
+		return true
+	}
+	if authDisabledForModelRegistration(previous) != authDisabledForModelRegistration(current) {
+		return true
+	}
+	return !modelRegistrationAttributesEqual(previous.Attributes, current.Attributes)
+}
+
+func modelRegistrationAttributesEqual(a, b map[string]string) bool {
+	keys := []string{"auth_kind", "excluded_models", "gemini_virtual_primary", "plan_type", "api_key", "base_url", "compat_name", "provider_key"}
+	for _, key := range keys {
+		if strings.TrimSpace(a[key]) != strings.TrimSpace(b[key]) {
+			return false
+		}
+	}
+	return true
 }
 
 // latestAuthForModelRegistration returns the latest auth snapshot regardless of

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1062,6 +1062,48 @@ func (s *Service) refreshModelRegistrationForAuth(current *coreauth.Auth) bool {
 	return true
 }
 
+type serviceAuthHook struct {
+	service *Service
+	next    coreauth.Hook
+}
+
+func (h serviceAuthHook) OnAuthRegistered(ctx context.Context, auth *coreauth.Auth) {
+	if h.next != nil {
+		h.next.OnAuthRegistered(ctx, auth)
+	}
+	h.refreshModels(ctx, auth)
+}
+
+func (h serviceAuthHook) OnAuthUpdated(ctx context.Context, auth *coreauth.Auth) {
+	if h.next != nil {
+		h.next.OnAuthUpdated(ctx, auth)
+	}
+	h.refreshModels(ctx, auth)
+}
+
+func (h serviceAuthHook) OnResult(ctx context.Context, result coreauth.Result) {
+	if h.next != nil {
+		h.next.OnResult(ctx, result)
+	}
+}
+
+func (h serviceAuthHook) refreshModels(ctx context.Context, auth *coreauth.Auth) {
+	if h.service == nil || auth == nil || auth.ID == "" {
+		return
+	}
+	if coreauth.IsSkipPersist(ctx) {
+		return
+	}
+	if auth.Disabled || auth.Status == coreauth.StatusDisabled {
+		GlobalModelRegistry().UnregisterClient(auth.ID)
+		if h.service.coreManager != nil {
+			h.service.coreManager.RefreshSchedulerEntry(auth.ID)
+		}
+		return
+	}
+	h.service.refreshModelRegistrationForAuth(auth)
+}
+
 // latestAuthForModelRegistration returns the latest auth snapshot regardless of
 // provider membership. Callers use this after a registration attempt to restore
 // whichever state currently owns the client ID in the global registry.

--- a/sdk/cliproxy/service_codex_plan_refresh_test.go
+++ b/sdk/cliproxy/service_codex_plan_refresh_test.go
@@ -1,0 +1,57 @@
+package cliproxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+func TestServiceAuthHookRefreshesCodexModelsAfterPlanChange(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: manager,
+	}
+	manager.SetHook(serviceAuthHook{service: service, next: manager.Hook()})
+
+	auth := &coreauth.Auth{
+		ID:       "codex-plan-refresh-test",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"plan_type": "free",
+		},
+		Metadata: map[string]any{"type": "codex"},
+	}
+
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	if hasRegisteredModel(auth.ID, "gpt-5.5") {
+		t.Fatal("expected free codex auth to exclude gpt-5.5")
+	}
+
+	auth.Attributes["plan_type"] = "plus"
+	if _, err := manager.Update(context.Background(), auth); err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+	if !hasRegisteredModel(auth.ID, "gpt-5.5") {
+		t.Fatal("expected plus codex auth to include gpt-5.5 after auth update")
+	}
+}
+
+func hasRegisteredModel(authID, modelID string) bool {
+	for _, model := range registry.GetGlobalRegistry().GetModelsForClient(authID) {
+		if model != nil && model.ID == modelID {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/cliproxy/service_codex_plan_refresh_test.go
+++ b/sdk/cliproxy/service_codex_plan_refresh_test.go
@@ -94,6 +94,52 @@ func TestServiceAuthHookIgnoresTokenOnlyUpdates(t *testing.T) {
 	}
 }
 
+func TestServiceAuthHookIgnoresInvalidIDTokenWhenPlanUnchanged(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: manager,
+	}
+	manager.SetHook(serviceAuthHook{service: service, next: manager.Hook()})
+
+	auth := &coreauth.Auth{
+		ID:       "codex-invalid-id-token-test",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"plan_type": "plus",
+		},
+		Metadata: map[string]any{"type": "codex", "id_token": "valid-old-token"},
+	}
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	state := &coreauth.ModelState{
+		NextRetryAfter: time.Now().Add(time.Hour),
+	}
+	auth.ModelStates = map[string]*coreauth.ModelState{"gpt-5.5": state}
+	auth.Metadata["id_token"] = "invalid-refreshed-token"
+	if _, err := manager.Update(context.Background(), auth); err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected auth to remain registered")
+	}
+	if got := updated.Attributes["plan_type"]; got != "plus" {
+		t.Fatalf("expected plan_type to remain plus, got %q", got)
+	}
+	updatedState := updated.ModelStates["gpt-5.5"]
+	if updatedState == nil || updatedState.NextRetryAfter.IsZero() {
+		t.Fatal("expected invalid id_token update to preserve model cooldown state")
+	}
+}
+
 func TestRegisterModelsForAuthSkipsStatusDisabledAuth(t *testing.T) {
 	service := &Service{cfg: &config.Config{}}
 	auth := &coreauth.Auth{

--- a/sdk/cliproxy/service_codex_plan_refresh_test.go
+++ b/sdk/cliproxy/service_codex_plan_refresh_test.go
@@ -3,6 +3,7 @@ package cliproxy
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -44,6 +45,72 @@ func TestServiceAuthHookRefreshesCodexModelsAfterPlanChange(t *testing.T) {
 	}
 	if !hasRegisteredModel(auth.ID, "gpt-5.5") {
 		t.Fatal("expected plus codex auth to include gpt-5.5 after auth update")
+	}
+}
+
+func TestServiceAuthHookIgnoresTokenOnlyUpdates(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: manager,
+	}
+	manager.SetHook(serviceAuthHook{service: service, next: manager.Hook()})
+
+	auth := &coreauth.Auth{
+		ID:       "codex-token-refresh-test",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"plan_type": "plus",
+		},
+		Metadata: map[string]any{"type": "codex", "access_token": "old-token"},
+	}
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	state := &coreauth.ModelState{
+		NextRetryAfter: time.Now().Add(time.Hour),
+	}
+	auth.ModelStates = map[string]*coreauth.ModelState{"gpt-5.5": state}
+	auth.Metadata["access_token"] = "new-token"
+	if _, err := manager.Update(context.Background(), auth); err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected auth to remain registered")
+	}
+	updatedState := updated.ModelStates["gpt-5.5"]
+	if updatedState == nil || updatedState.NextRetryAfter.IsZero() {
+		t.Fatal("expected token-only update to preserve model cooldown state")
+	}
+	if !hasRegisteredModel(auth.ID, "gpt-5.5") {
+		t.Fatal("expected plus codex model registration to remain available")
+	}
+}
+
+func TestRegisterModelsForAuthSkipsStatusDisabledAuth(t *testing.T) {
+	service := &Service{cfg: &config.Config{}}
+	auth := &coreauth.Auth{
+		ID:       "codex-status-disabled-test",
+		Provider: "codex",
+		Status:   coreauth.StatusDisabled,
+		Attributes: map[string]string{
+			"plan_type": "plus",
+		},
+	}
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(auth)
+	if models := registry.GetGlobalRegistry().GetModelsForClient(auth.ID); len(models) != 0 {
+		t.Fatalf("expected status-disabled auth to have no registered models, got %d", len(models))
 	}
 }
 


### PR DESCRIPTION
Fix Codex model availability after account plan changes.

Previously Codex token refresh updated the stored id_token, so the UI could show the new plan, but the in-memory auth attribute used for model registration still kept the old plan_type. A Free -> Plus account could therefore continue using the Free model list until the credential file was deleted and re-imported.

Changes:
- extract Codex plan_type from refreshed id_token
- populate plan_type when importing/uploading Codex auth files
- re-register models after auth updates so plan changes update model availability
- fix GPT-5.5 tier tests: free excludes GPT-5.5, paid tiers include it

Validation:
- go test ./internal/registry ./sdk/cliproxy
- go build -o test-output ./cmd/server
