### PR TITLE
fix(codex): honor explicit image_generation tool choice

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -909,6 +909,9 @@ func shouldEnsureImageGenerationTool(body []byte, baseModel string, auth *clipro
 
 func explicitlyChoosesImageGeneration(body []byte) bool {
 	toolChoice := gjson.GetBytes(body, "tool_choice")
+	if toolChoice.Type == gjson.String && toolChoice.String() == "image_generation" {
+		return true
+	}
 	if toolChoice.Get("type").String() == "image_generation" {
 		return true
 	}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -181,7 +181,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = normalizeCodexInstructions(body)
-	body = ensureImageGenerationTool(body, baseModel, auth)
+	body = maybeEnsureImageGenerationTool(body, baseModel, auth)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -329,7 +329,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body, _ = sjson.DeleteBytes(body, "stream")
 	body = normalizeCodexInstructions(body)
-	body = ensureImageGenerationTool(body, baseModel, auth)
+	body = maybeEnsureImageGenerationTool(body, baseModel, auth)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses/compact"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -424,7 +424,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body = normalizeCodexInstructions(body)
-	body = ensureImageGenerationTool(body, baseModel, auth)
+	body = maybeEnsureImageGenerationTool(body, baseModel, auth)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -887,6 +887,46 @@ func isCodexFreePlanAuth(auth *cliproxyauth.Auth) bool {
 	return strings.EqualFold(strings.TrimSpace(auth.Attributes["plan_type"]), "free")
 }
 
+func maybeEnsureImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth.Auth) []byte {
+	if !shouldEnsureImageGenerationTool(body, baseModel, auth) {
+		return body
+	}
+	return ensureImageGenerationTool(body, baseModel, auth)
+}
+
+func shouldEnsureImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth.Auth) bool {
+	if strings.HasSuffix(baseModel, "spark") || isCodexFreePlanAuth(auth) {
+		return false
+	}
+	if hasImageGenerationTool(body) {
+		return false
+	}
+	if explicitlyChoosesImageGeneration(body) {
+		return true
+	}
+	return false
+}
+
+func explicitlyChoosesImageGeneration(body []byte) bool {
+	toolChoice := gjson.GetBytes(body, "tool_choice")
+	if toolChoice.Get("type").String() == "image_generation" {
+		return true
+	}
+	return toolsIncludeImageGeneration(toolChoice.Get("tools"))
+}
+
+func toolsIncludeImageGeneration(tools gjson.Result) bool {
+	if !tools.IsArray() {
+		return false
+	}
+	for _, tool := range tools.Array() {
+		if tool.Get("type").String() == "image_generation" {
+			return true
+		}
+	}
+	return false
+}
+
 func ensureImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth.Auth) []byte {
 	if strings.HasSuffix(baseModel, "spark") {
 		return body
@@ -900,10 +940,8 @@ func ensureImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth
 		body, _ = sjson.SetRawBytes(body, "tools", imageGenToolArrayJSON)
 		return body
 	}
-	for _, t := range tools.Array() {
-		if t.Get("type").String() == "image_generation" {
-			return body
-		}
+	if toolsIncludeImageGeneration(tools) {
+		return body
 	}
 	body, _ = sjson.SetRawBytes(body, "tools.-1", imageGenToolJSON)
 	return body
@@ -932,6 +970,10 @@ func codexImageGenerationToolModel(body []byte) string {
 		}
 	}
 	return codexDefaultImageToolModel
+}
+
+func hasImageGenerationTool(body []byte) bool {
+	return toolsIncludeImageGeneration(gjson.GetBytes(body, "tools"))
 }
 
 func isCodexModelCapacityError(errorBody []byte) bool {

--- a/internal/runtime/executor/codex_executor_imagegen_test.go
+++ b/internal/runtime/executor/codex_executor_imagegen_test.go
@@ -116,3 +116,71 @@ func TestEnsureImageGenerationTool_FreeCodexAuthDoesNotInjectTool(t *testing.T) 
 		t.Fatalf("expected no tools for free codex auth, got %s", gjson.GetBytes(result, "tools").Raw)
 	}
 }
+
+func TestMaybeEnsureImageGenerationTool_SkipsGenericClient(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"web_search"}]}`)
+	result := maybeEnsureImageGenerationTool(body, "gpt-5.4", nil)
+
+	if string(result) != string(body) {
+		t.Fatalf("expected generic client body unchanged, got %s", string(result))
+	}
+	if hasImageGenerationTool(result) {
+		t.Fatalf("expected no image_generation tool for generic client, got %s", string(result))
+	}
+}
+
+func TestMaybeEnsureImageGenerationTool_AddsForImageGenerationToolChoice(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","tool_choice":{"type":"image_generation"}}`)
+	result := maybeEnsureImageGenerationTool(body, "gpt-5.4", nil)
+
+	if !hasImageGenerationTool(result) {
+		t.Fatalf("expected image_generation tool for explicit tool_choice, got %s", string(result))
+	}
+}
+
+func TestMaybeEnsureImageGenerationTool_AppendsForImageGenerationToolChoice(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"web_search"}],"tool_choice":{"type":"image_generation"}}`)
+	result := maybeEnsureImageGenerationTool(body, "gpt-5.4", nil)
+
+	if !hasImageGenerationTool(result) {
+		t.Fatalf("expected image_generation tool for explicit tool_choice, got %s", string(result))
+	}
+	tools := gjson.GetBytes(result, "tools").Array()
+	if len(tools) != 2 {
+		t.Fatalf("expected web_search plus image_generation tools, got %s", gjson.GetBytes(result, "tools").Raw)
+	}
+}
+
+func TestMaybeEnsureImageGenerationTool_AddsForAllowedToolsImageGenerationToolChoice(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","tool_choice":{"type":"allowed_tools","tools":[{"type":"image_generation"}]}}`)
+	result := maybeEnsureImageGenerationTool(body, "gpt-5.4", nil)
+
+	if !hasImageGenerationTool(result) {
+		t.Fatalf("expected image_generation tool for allowed_tools tool_choice, got %s", string(result))
+	}
+}
+
+func TestMaybeEnsureImageGenerationTool_SkipsWhenImageGenerationToolAlreadyPresent(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"image_generation","output_format":"webp"}],"tool_choice":{"type":"image_generation"}}`)
+	result := maybeEnsureImageGenerationTool(body, "gpt-5.4", nil)
+
+	if string(result) != string(body) {
+		t.Fatalf("expected existing image_generation body unchanged, got %s", string(result))
+	}
+}
+
+func TestMaybeEnsureImageGenerationTool_FreeCodexAuthSkipsEvenWithToolChoice(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","tool_choice":{"type":"image_generation"}}`)
+	freeAuth := &cliproxyauth.Auth{
+		Provider:   "codex",
+		Attributes: map[string]string{"plan_type": "free"},
+	}
+	result := maybeEnsureImageGenerationTool(body, "gpt-5.4", freeAuth)
+
+	if string(result) != string(body) {
+		t.Fatalf("expected free auth body unchanged, got %s", string(result))
+	}
+	if hasImageGenerationTool(result) {
+		t.Fatalf("expected no image_generation tool for free auth, got %s", string(result))
+	}
+}

--- a/internal/runtime/executor/codex_executor_tool_injection_test.go
+++ b/internal/runtime/executor/codex_executor_tool_injection_test.go
@@ -2,9 +2,11 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -15,54 +17,131 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestCodexExecutorDoesNotInjectImageGenerationToolForGenericResponsesClient(t *testing.T) {
-	capturedBody := executeCodexStreamAndCaptureBody(t, []byte(`{"model":"gpt-5.4","input":"Say ok","tools":[{"type":"web_search_preview"}]}`))
+func TestCodexExecutorImageGenerationToolInjectionAcrossRequestPaths(t *testing.T) {
+	paths := []struct {
+		name string
+		run  codexCaptureRunner
+	}{
+		{name: "execute", run: runCodexExecuteAndCaptureBody},
+		{name: "stream", run: runCodexStreamAndCaptureBody},
+		{name: "compact", run: runCodexCompactAndCaptureBody},
+	}
 
-	for _, tool := range gjson.GetBytes(capturedBody, "tools").Array() {
-		if tool.Get("type").String() == "image_generation" {
-			t.Fatalf("unexpected image_generation tool injected for generic Responses client; upstream body=%s", string(capturedBody))
+	cases := []struct {
+		name      string
+		model     string
+		payload   []byte
+		authAttrs map[string]string
+		wantImage bool
+		wantTools int
+	}{
+		{
+			name:      "generic web search client does not inject",
+			model:     "gpt-5.4",
+			payload:   []byte(`{"model":"gpt-5.4","input":"Say ok","tools":[{"type":"web_search_preview"}]}`),
+			wantImage: false,
+			wantTools: 1,
+		},
+		{
+			name:      "plain generic request does not inject",
+			model:     "gpt-5.4",
+			payload:   []byte(`{"model":"gpt-5.4","input":"Say ok"}`),
+			wantImage: false,
+			wantTools: 0,
+		},
+		{
+			name:      "explicit image generation tool choice injects",
+			model:     "gpt-5.4",
+			payload:   []byte(`{"model":"gpt-5.4","input":"Draw a cat","tool_choice":{"type":"image_generation"}}`),
+			wantImage: true,
+			wantTools: 1,
+		},
+		{
+			name:      "allowed tools image generation tool choice injects",
+			model:     "gpt-5.4",
+			payload:   []byte(`{"model":"gpt-5.4","input":"Draw a cat","tool_choice":{"type":"allowed_tools","tools":[{"type":"image_generation"}]}}`),
+			wantImage: true,
+			wantTools: 1,
+		},
+		{
+			name:      "existing image generation tool is preserved",
+			model:     "gpt-5.4",
+			payload:   []byte(`{"model":"gpt-5.4","input":"Draw a cat","tools":[{"type":"image_generation","output_format":"webp"}],"tool_choice":{"type":"image_generation"}}`),
+			wantImage: true,
+			wantTools: 1,
+		},
+		{
+			name:      "free codex auth does not inject even with explicit tool choice",
+			model:     "gpt-5.4",
+			payload:   []byte(`{"model":"gpt-5.4","input":"Draw a cat","tool_choice":{"type":"image_generation"}}`),
+			authAttrs: map[string]string{"plan_type": "free"},
+			wantImage: false,
+			wantTools: 0,
+		},
+		{
+			name:      "spark model does not inject even with explicit tool choice",
+			model:     "gpt-5.3-codex-spark",
+			payload:   []byte(`{"model":"gpt-5.3-codex-spark","input":"Draw a cat","tool_choice":{"type":"image_generation"}}`),
+			wantImage: false,
+			wantTools: 0,
+		},
+	}
+
+	for _, path := range paths {
+		for _, tc := range cases {
+			t.Run(path.name+"/"+tc.name, func(t *testing.T) {
+				capturedBody := path.run(t, tc.model, tc.payload, tc.authAttrs)
+
+				if gotImage := hasImageGenerationTool(capturedBody); gotImage != tc.wantImage {
+					t.Fatalf("hasImageGenerationTool = %v, want %v; upstream body=%s", gotImage, tc.wantImage, string(capturedBody))
+				}
+				tools := gjson.GetBytes(capturedBody, "tools")
+				if gotTools := len(tools.Array()); gotTools != tc.wantTools {
+					t.Fatalf("tools len = %d, want %d; upstream body=%s", gotTools, tc.wantTools, string(capturedBody))
+				}
+				if strings.Contains(tc.name, "existing image generation") {
+					if got := tools.Array()[0].Get("output_format").String(); got != "webp" {
+						t.Fatalf("existing image_generation output_format = %q, want webp; upstream body=%s", got, string(capturedBody))
+					}
+				}
+			})
 		}
 	}
 }
 
-func TestCodexExecutorEnsuresImageGenerationToolForExplicitToolChoice(t *testing.T) {
-	capturedBody := executeCodexStreamAndCaptureBody(t, []byte(`{"model":"gpt-5.4","input":"Draw a cat","tool_choice":{"type":"image_generation"}}`))
+type codexCaptureRunner func(t *testing.T, model string, payload []byte, authAttrs map[string]string) []byte
 
-	if !hasImageGenerationTool(capturedBody) {
-		t.Fatalf("expected image_generation tool for explicit tool_choice; upstream body=%s", string(capturedBody))
-	}
-	if got := gjson.GetBytes(capturedBody, "tool_choice.type").String(); got != "image_generation" {
-		t.Fatalf("tool_choice.type = %q, want image_generation; upstream body=%s", got, string(capturedBody))
-	}
-}
-
-func executeCodexStreamAndCaptureBody(t *testing.T, payload []byte) []byte {
+func runCodexExecuteAndCaptureBody(t *testing.T, model string, payload []byte, authAttrs map[string]string) []byte {
 	t.Helper()
-
-	bodyCh := make(chan []byte, 1)
-	errCh := make(chan error, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, errRead := io.ReadAll(r.Body)
-		if errRead != nil {
-			errCh <- errRead
-			http.Error(w, errRead.Error(), http.StatusInternalServerError)
-			return
-		}
-		bodyCh <- append([]byte(nil), body...)
-
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":1775555723,\"status\":\"completed\",\"model\":\"gpt-5.4\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
-	}))
+	server, bodyCh, errCh := newCodexCaptureServer(t, "/responses")
 	defer server.Close()
 
 	executor := NewCodexExecutor(&config.Config{})
-	auth := &cliproxyauth.Auth{Attributes: map[string]string{
-		"base_url": server.URL,
-		"api_key":  "test",
-	}}
+	auth := codexCaptureAuth(server.URL, authAttrs)
+
+	_, errExec := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   model,
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if errExec != nil {
+		t.Fatalf("Execute error: %v", errExec)
+	}
+	return receiveCapturedCodexBody(t, bodyCh, errCh)
+}
+
+func runCodexStreamAndCaptureBody(t *testing.T, model string, payload []byte, authAttrs map[string]string) []byte {
+	t.Helper()
+	server, bodyCh, errCh := newCodexCaptureServer(t, "/responses")
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := codexCaptureAuth(server.URL, authAttrs)
 
 	result, errExec := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
-		Model:   "gpt-5.4",
+		Model:   model,
 		Payload: payload,
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FromString("openai-response"),
@@ -76,9 +155,77 @@ func executeCodexStreamAndCaptureBody(t *testing.T, payload []byte) []byte {
 			t.Fatalf("stream chunk error: %v", chunk.Err)
 		}
 	}
+	return receiveCapturedCodexBody(t, bodyCh, errCh)
+}
+
+func runCodexCompactAndCaptureBody(t *testing.T, model string, payload []byte, authAttrs map[string]string) []byte {
+	t.Helper()
+	server, bodyCh, errCh := newCodexCaptureServer(t, "/responses/compact")
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := codexCaptureAuth(server.URL, authAttrs)
+
+	_, errExec := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   model,
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Alt:          "responses/compact",
+		Stream:       false,
+	})
+	if errExec != nil {
+		t.Fatalf("Execute compact error: %v", errExec)
+	}
+	return receiveCapturedCodexBody(t, bodyCh, errCh)
+}
+
+func newCodexCaptureServer(t *testing.T, wantPath string) (*httptest.Server, <-chan []byte, <-chan error) {
+	t.Helper()
+	bodyCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != wantPath {
+			errCh <- fmt.Errorf("path = %q, want %q", r.URL.Path, wantPath)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			errCh <- errRead
+			http.Error(w, errRead.Error(), http.StatusInternalServerError)
+			return
+		}
+		bodyCh <- append([]byte(nil), body...)
+
+		switch wantPath {
+		case "/responses/compact":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp_1","object":"response.compaction","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`))
+		default:
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":1775555723,\"status\":\"completed\",\"model\":\"gpt-5.4\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
+		}
+	}))
+	return server, bodyCh, errCh
+}
+
+func codexCaptureAuth(baseURL string, attrs map[string]string) *cliproxyauth.Auth {
+	authAttrs := map[string]string{
+		"base_url": baseURL,
+		"api_key":  "test",
+	}
+	for key, value := range attrs {
+		authAttrs[key] = value
+	}
+	return &cliproxyauth.Auth{Provider: "codex", Attributes: authAttrs}
+}
+
+func receiveCapturedCodexBody(t *testing.T, bodyCh <-chan []byte, errCh <-chan error) []byte {
+	t.Helper()
 	select {
 	case errRead := <-errCh:
-		t.Fatalf("read request body: %v", errRead)
+		t.Fatalf("capture request body: %v", errRead)
 	case capturedBody := <-bodyCh:
 		if len(capturedBody) == 0 {
 			t.Fatal("missing captured upstream request body")

--- a/internal/runtime/executor/codex_executor_tool_injection_test.go
+++ b/internal/runtime/executor/codex_executor_tool_injection_test.go
@@ -1,0 +1,91 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestCodexExecutorDoesNotInjectImageGenerationToolForGenericResponsesClient(t *testing.T) {
+	capturedBody := executeCodexStreamAndCaptureBody(t, []byte(`{"model":"gpt-5.4","input":"Say ok","tools":[{"type":"web_search_preview"}]}`))
+
+	for _, tool := range gjson.GetBytes(capturedBody, "tools").Array() {
+		if tool.Get("type").String() == "image_generation" {
+			t.Fatalf("unexpected image_generation tool injected for generic Responses client; upstream body=%s", string(capturedBody))
+		}
+	}
+}
+
+func TestCodexExecutorEnsuresImageGenerationToolForExplicitToolChoice(t *testing.T) {
+	capturedBody := executeCodexStreamAndCaptureBody(t, []byte(`{"model":"gpt-5.4","input":"Draw a cat","tool_choice":{"type":"image_generation"}}`))
+
+	if !hasImageGenerationTool(capturedBody) {
+		t.Fatalf("expected image_generation tool for explicit tool_choice; upstream body=%s", string(capturedBody))
+	}
+	if got := gjson.GetBytes(capturedBody, "tool_choice.type").String(); got != "image_generation" {
+		t.Fatalf("tool_choice.type = %q, want image_generation; upstream body=%s", got, string(capturedBody))
+	}
+}
+
+func executeCodexStreamAndCaptureBody(t *testing.T, payload []byte) []byte {
+	t.Helper()
+
+	bodyCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			errCh <- errRead
+			http.Error(w, errRead.Error(), http.StatusInternalServerError)
+			return
+		}
+		bodyCh <- append([]byte(nil), body...)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":1775555723,\"status\":\"completed\",\"model\":\"gpt-5.4\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, errExec := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if errExec != nil {
+		t.Fatalf("ExecuteStream error: %v", errExec)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+	select {
+	case errRead := <-errCh:
+		t.Fatalf("read request body: %v", errRead)
+	case capturedBody := <-bodyCh:
+		if len(capturedBody) == 0 {
+			t.Fatal("missing captured upstream request body")
+		}
+		return capturedBody
+	default:
+		t.Fatal("missing captured upstream request body")
+	}
+	return nil
+}

--- a/internal/runtime/executor/codex_executor_tool_injection_test.go
+++ b/internal/runtime/executor/codex_executor_tool_injection_test.go
@@ -57,6 +57,13 @@ func TestCodexExecutorImageGenerationToolInjectionAcrossRequestPaths(t *testing.
 			wantTools: 1,
 		},
 		{
+			name:      "string image generation tool choice injects",
+			model:     "gpt-5.4",
+			payload:   []byte(`{"model":"gpt-5.4","input":"Draw a cat","tool_choice":"image_generation"}`),
+			wantImage: true,
+			wantTools: 1,
+		},
+		{
 			name:      "allowed tools image generation tool choice injects",
 			model:     "gpt-5.4",
 			payload:   []byte(`{"model":"gpt-5.4","input":"Draw a cat","tool_choice":{"type":"allowed_tools","tools":[{"type":"image_generation"}]}}`),

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -37,6 +37,12 @@ func NewOpenAICompatExecutor(provider string, cfg *config.Config) *OpenAICompatE
 // Identifier implements cliproxyauth.ProviderExecutor.
 func (e *OpenAICompatExecutor) Identifier() string { return e.provider }
 
+// SupportsNativeImagesEndpoint reports whether this executor can forward an
+// OpenAI-compatible Images API request without chat/responses translation.
+func (e *OpenAICompatExecutor) SupportsNativeImagesEndpoint(endpoint string) bool {
+	return nativeImagesEndpoint(endpoint) != ""
+}
+
 // PrepareRequest injects OpenAI-compatible credentials into the outgoing HTTP request.
 func (e *OpenAICompatExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
 	if req == nil {
@@ -80,6 +86,9 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	if baseURL == "" {
 		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
 		return
+	}
+	if imageEndpoint := nativeImagesEndpoint(opts.Alt); imageEndpoint != "" {
+		return e.executeNativeImages(ctx, auth, req, opts, baseModel, baseURL, apiKey, imageEndpoint, reporter)
 	}
 
 	from := opts.SourceFormat
@@ -175,6 +184,75 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, body, &param)
 	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 	return resp, nil
+}
+
+func (e *OpenAICompatExecutor) executeNativeImages(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, baseModel, baseURL, apiKey, endpoint string, reporter *helps.UsageReporter) (resp cliproxyexecutor.Response, err error) {
+	body := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		body = opts.OriginalRequest
+	}
+	body = e.overrideModel(body, baseModel)
+
+	url := strings.TrimSuffix(baseURL, "/") + "/" + endpoint
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       url,
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("openai compat executor: close response body error: %v", errClose)
+		}
+	}()
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		return resp, statusErr{code: httpResp.StatusCode, msg: string(b)}
+	}
+	responseBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	helps.AppendAPIResponseChunk(ctx, e.cfg, responseBody)
+	reporter.Publish(ctx, helps.ParseOpenAIUsage(responseBody))
+	reporter.EnsurePublished(ctx)
+	return cliproxyexecutor.Response{Payload: responseBody, Headers: httpResp.Header.Clone()}, nil
 }
 
 func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
@@ -396,6 +474,15 @@ func (e *OpenAICompatExecutor) overrideModel(payload []byte, model string) []byt
 	}
 	payload, _ = sjson.SetBytes(payload, "model", model)
 	return payload
+}
+
+func nativeImagesEndpoint(alt string) string {
+	switch strings.Trim(strings.TrimSpace(alt), "/") {
+	case "images/generations":
+		return "images/generations"
+	default:
+		return ""
+	}
 }
 
 type statusErr struct {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -29,6 +29,8 @@ type OpenAICompatExecutor struct {
 	cfg      *config.Config
 }
 
+const openAICompatUserAgent = "cli-proxy-openai-compat"
+
 // NewOpenAICompatExecutor creates an executor bound to a provider key (e.g., "openrouter").
 func NewOpenAICompatExecutor(provider string, cfg *config.Config) *OpenAICompatExecutor {
 	return &OpenAICompatExecutor{provider: provider, cfg: cfg}
@@ -127,7 +129,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	if apiKey != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 	}
-	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
+	httpReq.Header.Set("User-Agent", openAICompatUserAgent)
 	var attrs map[string]string
 	if auth != nil {
 		attrs = auth.Attributes
@@ -191,6 +193,8 @@ func (e *OpenAICompatExecutor) executeNativeImages(ctx context.Context, auth *cl
 	if len(opts.OriginalRequest) > 0 {
 		body = opts.OriginalRequest
 	}
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "openai", "", body, body, requestedModel)
 	body = e.overrideModel(body, baseModel)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/" + endpoint
@@ -202,7 +206,7 @@ func (e *OpenAICompatExecutor) executeNativeImages(ctx context.Context, auth *cl
 	if apiKey != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 	}
-	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
+	httpReq.Header.Set("User-Agent", openAICompatUserAgent)
 	var attrs map[string]string
 	if auth != nil {
 		attrs = auth.Attributes
@@ -297,7 +301,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	if apiKey != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 	}
-	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
+	httpReq.Header.Set("User-Agent", openAICompatUserAgent)
 	var attrs map[string]string
 	if auth != nil {
 		attrs = auth.Attributes

--- a/internal/runtime/executor/openai_compat_images_test.go
+++ b/internal/runtime/executor/openai_compat_images_test.go
@@ -32,8 +32,10 @@ func TestOpenAICompatExecutorSupportsNativeImagesEndpoints(t *testing.T) {
 func TestOpenAICompatExecutorNativeImagesGenerationsUsesImagesEndpoint(t *testing.T) {
 	bodyCh := make(chan []byte, 1)
 	pathCh := make(chan string, 1)
+	userAgentCh := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		pathCh <- r.URL.Path
+		userAgentCh <- r.Header.Get("User-Agent")
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("read body: %v", err)
@@ -68,6 +70,9 @@ func TestOpenAICompatExecutorNativeImagesGenerationsUsesImagesEndpoint(t *testin
 	if path := <-pathCh; path != "/images/generations" {
 		t.Fatalf("path = %q, want /images/generations", path)
 	}
+	if userAgent := <-userAgentCh; userAgent != openAICompatUserAgent {
+		t.Fatalf("User-Agent = %q, want %q", userAgent, openAICompatUserAgent)
+	}
 	var captured map[string]any
 	if err := json.Unmarshal(<-bodyCh, &captured); err != nil {
 		t.Fatalf("unmarshal captured body: %v", err)
@@ -77,5 +82,73 @@ func TestOpenAICompatExecutorNativeImagesGenerationsUsesImagesEndpoint(t *testin
 	}
 	if got := captured["prompt"]; got != "draw" {
 		t.Fatalf("prompt = %v, want draw", got)
+	}
+}
+
+func TestOpenAICompatExecutorNativeImagesGenerationsAppliesPayloadRules(t *testing.T) {
+	bodyCh := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		bodyCh <- append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":1,"data":[{"b64_json":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{
+		Payload: config.PayloadConfig{
+			Default: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "upstream-image-model", Protocol: "openai"}},
+				Params: map[string]any{"background": "transparent"},
+			}},
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "alias-image", Protocol: "openai"}},
+				Params: map[string]any{"quality": "high"},
+			}},
+			Filter: []config.PayloadFilterRule{{
+				Models: []config.PayloadModelRule{{Name: "upstream-image-model", Protocol: "openai"}},
+				Params: []string{"temporary"},
+			}},
+		},
+	})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test-key",
+	}}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "upstream-image-model",
+		Payload: []byte(`{"model":"alias-image","prompt":"draw","quality":"low","temporary":true}`),
+	}, cliproxyexecutor.Options{
+		Alt:             "images/generations",
+		OriginalRequest: []byte(`{"model":"alias-image","prompt":"draw","quality":"low","temporary":true}`),
+		SourceFormat:    sdktranslator.FromString("openai"),
+		Metadata: map[string]any{
+			cliproxyexecutor.RequestedModelMetadataKey: "alias-image",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	var captured map[string]any
+	if err := json.Unmarshal(<-bodyCh, &captured); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+	if got := captured["model"]; got != "upstream-image-model" {
+		t.Fatalf("model = %v, want upstream-image-model", got)
+	}
+	if got := captured["background"]; got != "transparent" {
+		t.Fatalf("background = %v, want transparent", got)
+	}
+	if got := captured["quality"]; got != "high" {
+		t.Fatalf("quality = %v, want high", got)
+	}
+	if _, ok := captured["temporary"]; ok {
+		t.Fatalf("temporary field should be filtered, got %v", captured["temporary"])
 	}
 }

--- a/internal/runtime/executor/openai_compat_images_test.go
+++ b/internal/runtime/executor/openai_compat_images_test.go
@@ -1,0 +1,81 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+func TestOpenAICompatExecutorSupportsNativeImagesEndpoints(t *testing.T) {
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+
+	for _, endpoint := range []string{"images/generations", "/images/generations"} {
+		if !executor.SupportsNativeImagesEndpoint(endpoint) {
+			t.Fatalf("SupportsNativeImagesEndpoint(%q) = false, want true", endpoint)
+		}
+	}
+	for _, endpoint := range []string{"responses", "images/edits"} {
+		if executor.SupportsNativeImagesEndpoint(endpoint) {
+			t.Fatalf("SupportsNativeImagesEndpoint(%q) = true, want false", endpoint)
+		}
+	}
+}
+
+func TestOpenAICompatExecutorNativeImagesGenerationsUsesImagesEndpoint(t *testing.T) {
+	bodyCh := make(chan []byte, 1)
+	pathCh := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pathCh <- r.URL.Path
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		bodyCh <- append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":1,"data":[{"b64_json":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test-key",
+	}}
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "upstream-image-model",
+		Payload: []byte(`{"model":"alias-image","prompt":"draw"}`),
+	}, cliproxyexecutor.Options{
+		Alt:             "images/generations",
+		OriginalRequest: []byte(`{"model":"alias-image","prompt":"draw"}`),
+		SourceFormat:    sdktranslator.FromString("openai"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if string(resp.Payload) != `{"created":1,"data":[{"b64_json":"ok"}]}` {
+		t.Fatalf("payload = %s", string(resp.Payload))
+	}
+	if path := <-pathCh; path != "/images/generations" {
+		t.Fatalf("path = %q, want /images/generations", path)
+	}
+	var captured map[string]any
+	if err := json.Unmarshal(<-bodyCh, &captured); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+	if got := captured["model"]; got != "upstream-image-model" {
+		t.Fatalf("model = %v, want upstream-image-model", got)
+	}
+	if got := captured["prompt"]; got != "draw" {
+		t.Fatalf("prompt = %v, want draw", got)
+	}
+}

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -506,6 +506,28 @@ func (h *BaseAPIHandler) ExecuteWithAuthManager(ctx context.Context, handlerType
 	if errMsg != nil {
 		return nil, nil, errMsg
 	}
+	return h.executeNonStreamWithAuthManager(ctx, providers, normalizedModel, rawJSON, alt, handlerType, h.AuthManager.Execute)
+}
+
+// ExecuteImagesWithAuthManager executes an OpenAI-compatible Images API request
+// against providers whose executor explicitly supports the native Images API.
+// Codex is intentionally excluded because Codex image generation is implemented
+// through the Responses image_generation tool.
+func (h *BaseAPIHandler) ExecuteImagesWithAuthManager(ctx context.Context, modelName string, rawJSON []byte, endpoint string) ([]byte, http.Header, *interfaces.ErrorMessage) {
+	providers, normalizedModel, errMsg := h.getImagesRequestDetails(modelName)
+	if errMsg != nil {
+		return nil, nil, errMsg
+	}
+	providers = h.nativeImagesProviders(providers, endpoint)
+	if len(providers) == 0 {
+		return nil, nil, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("no native image provider for model %s", modelName)}
+	}
+	return h.executeNonStreamWithAuthManager(ctx, providers, normalizedModel, rawJSON, endpoint, "openai", h.AuthManager.Execute)
+}
+
+type nonStreamAuthExecutor func(context.Context, []string, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error)
+
+func (h *BaseAPIHandler) executeNonStreamWithAuthManager(ctx context.Context, providers []string, normalizedModel string, rawJSON []byte, alt string, sourceFormat string, execute nonStreamAuthExecutor) ([]byte, http.Header, *interfaces.ErrorMessage) {
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = normalizedModel
 	payload := rawJSON
@@ -520,31 +542,28 @@ func (h *BaseAPIHandler) ExecuteWithAuthManager(ctx context.Context, handlerType
 		Stream:          false,
 		Alt:             alt,
 		OriginalRequest: rawJSON,
-		SourceFormat:    sdktranslator.FromString(handlerType),
+		SourceFormat:    sdktranslator.FromString(sourceFormat),
 		Headers:         headersFromContext(ctx),
 	}
 	opts.Metadata = reqMeta
-	resp, err := h.AuthManager.Execute(ctx, providers, req, opts)
+	resp, err := execute(ctx, providers, req, opts)
 	if err != nil {
-		err = enrichAuthSelectionError(err, providers, normalizedModel)
-		status := http.StatusInternalServerError
-		if se, ok := err.(interface{ StatusCode() int }); ok && se != nil {
-			if code := se.StatusCode(); code > 0 {
-				status = code
-			}
-		}
-		var addon http.Header
-		if he, ok := err.(interface{ Headers() http.Header }); ok && he != nil {
-			if hdr := he.Headers(); hdr != nil {
-				addon = hdr.Clone()
-			}
-		}
-		return nil, nil, &interfaces.ErrorMessage{StatusCode: status, Error: err, Addon: addon}
+		return nil, nil, authExecutionErrorMessage(err, providers, normalizedModel)
 	}
 	if !PassthroughHeadersEnabled(h.Cfg) {
 		return resp.Payload, nil, nil
 	}
 	return resp.Payload, FilterUpstreamHeaders(resp.Headers), nil
+}
+
+// HasNativeImagesProvider reports whether a model is backed by a provider whose
+// executor can receive the requested native OpenAI-compatible Images API call.
+func (h *BaseAPIHandler) HasNativeImagesProvider(modelName string, endpoint string) bool {
+	providers, _, errMsg := h.getImagesRequestDetails(modelName)
+	if errMsg != nil {
+		return false
+	}
+	return len(h.nativeImagesProviders(providers, endpoint)) > 0
 }
 
 // ExecuteCountWithAuthManager executes a non-streaming request via the core auth manager.
@@ -554,45 +573,7 @@ func (h *BaseAPIHandler) ExecuteCountWithAuthManager(ctx context.Context, handle
 	if errMsg != nil {
 		return nil, nil, errMsg
 	}
-	reqMeta := requestExecutionMetadata(ctx)
-	reqMeta[coreexecutor.RequestedModelMetadataKey] = normalizedModel
-	payload := rawJSON
-	if len(payload) == 0 {
-		payload = nil
-	}
-	req := coreexecutor.Request{
-		Model:   normalizedModel,
-		Payload: payload,
-	}
-	opts := coreexecutor.Options{
-		Stream:          false,
-		Alt:             alt,
-		OriginalRequest: rawJSON,
-		SourceFormat:    sdktranslator.FromString(handlerType),
-		Headers:         headersFromContext(ctx),
-	}
-	opts.Metadata = reqMeta
-	resp, err := h.AuthManager.ExecuteCount(ctx, providers, req, opts)
-	if err != nil {
-		err = enrichAuthSelectionError(err, providers, normalizedModel)
-		status := http.StatusInternalServerError
-		if se, ok := err.(interface{ StatusCode() int }); ok && se != nil {
-			if code := se.StatusCode(); code > 0 {
-				status = code
-			}
-		}
-		var addon http.Header
-		if he, ok := err.(interface{ Headers() http.Header }); ok && he != nil {
-			if hdr := he.Headers(); hdr != nil {
-				addon = hdr.Clone()
-			}
-		}
-		return nil, nil, &interfaces.ErrorMessage{StatusCode: status, Error: err, Addon: addon}
-	}
-	if !PassthroughHeadersEnabled(h.Cfg) {
-		return resp.Payload, nil, nil
-	}
-	return resp.Payload, FilterUpstreamHeaders(resp.Headers), nil
+	return h.executeNonStreamWithAuthManager(ctx, providers, normalizedModel, rawJSON, alt, handlerType, h.AuthManager.ExecuteCount)
 }
 
 // ExecuteStreamWithAuthManager executes a streaming request via the core auth manager.
@@ -626,21 +607,8 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 	opts.Metadata = reqMeta
 	streamResult, err := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
 	if err != nil {
-		err = enrichAuthSelectionError(err, providers, normalizedModel)
 		errChan := make(chan *interfaces.ErrorMessage, 1)
-		status := http.StatusInternalServerError
-		if se, ok := err.(interface{ StatusCode() int }); ok && se != nil {
-			if code := se.StatusCode(); code > 0 {
-				status = code
-			}
-		}
-		var addon http.Header
-		if he, ok := err.(interface{ Headers() http.Header }); ok && he != nil {
-			if hdr := he.Headers(); hdr != nil {
-				addon = hdr.Clone()
-			}
-		}
-		errChan <- &interfaces.ErrorMessage{StatusCode: status, Error: err, Addon: addon}
+		errChan <- authExecutionErrorMessage(err, providers, normalizedModel)
 		close(errChan)
 		return nil, nil, errChan
 	}
@@ -740,19 +708,7 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 						}
 					}
 
-					status := http.StatusInternalServerError
-					if se, ok := streamErr.(interface{ StatusCode() int }); ok && se != nil {
-						if code := se.StatusCode(); code > 0 {
-							status = code
-						}
-					}
-					var addon http.Header
-					if he, ok := streamErr.(interface{ Headers() http.Header }); ok && he != nil {
-						if hdr := he.Headers(); hdr != nil {
-							addon = hdr.Clone()
-						}
-					}
-					_ = sendErr(&interfaces.ErrorMessage{StatusCode: status, Error: streamErr, Addon: addon})
+					_ = sendErr(authExecutionErrorMessage(streamErr, providers, normalizedModel))
 					return
 				}
 				if len(chunk.Payload) > 0 {
@@ -815,6 +771,14 @@ func statusFromError(err error) int {
 }
 
 func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
+	return h.getRequestDetailsForModel(modelName, false)
+}
+
+func (h *BaseAPIHandler) getImagesRequestDetails(modelName string) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
+	return h.getRequestDetailsForModel(modelName, true)
+}
+
+func (h *BaseAPIHandler) getRequestDetailsForModel(modelName string, allowImageModel bool) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
 	resolvedModelName := modelName
 	initialSuffix := thinking.ParseSuffix(modelName)
 	if initialSuffix.ModelName == "auto" {
@@ -831,7 +795,7 @@ func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string
 	parsed := thinking.ParseSuffix(resolvedModelName)
 	baseModel := strings.TrimSpace(parsed.ModelName)
 
-	if strings.EqualFold(baseModel, "gpt-image-2") {
+	if !allowImageModel && strings.EqualFold(baseModel, "gpt-image-2") {
 		return nil, "", &interfaces.ErrorMessage{
 			StatusCode: http.StatusServiceUnavailable,
 			Error:      fmt.Errorf("model %s is only supported on /v1/images/generations and /v1/images/edits", baseModel),
@@ -855,6 +819,32 @@ func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string
 	// The thinking suffix is preserved in the model name itself, so no
 	// metadata-based configuration passing is needed.
 	return providers, resolvedModelName, nil
+}
+
+func (h *BaseAPIHandler) nativeImagesProviders(providers []string, endpoint string) []string {
+	if len(providers) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		p := strings.TrimSpace(strings.ToLower(provider))
+		if p == "" || p == "codex" {
+			continue
+		}
+		if h == nil || h.AuthManager == nil {
+			continue
+		}
+		executor, ok := h.AuthManager.Executor(p)
+		if !ok {
+			continue
+		}
+		nativeExecutor, ok := executor.(coreexecutor.NativeImagesEndpointExecutor)
+		if !ok || !nativeExecutor.SupportsNativeImagesEndpoint(endpoint) {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 func cloneBytes(src []byte) []byte {
@@ -884,6 +874,23 @@ func replaceHeader(dst http.Header, src http.Header) {
 	for key, values := range src {
 		dst[key] = append([]string(nil), values...)
 	}
+}
+
+func authExecutionErrorMessage(err error, providers []string, model string) *interfaces.ErrorMessage {
+	err = enrichAuthSelectionError(err, providers, model)
+	status := http.StatusInternalServerError
+	if se, ok := err.(interface{ StatusCode() int }); ok && se != nil {
+		if code := se.StatusCode(); code > 0 {
+			status = code
+		}
+	}
+	var addon http.Header
+	if he, ok := err.(interface{ Headers() http.Header }); ok && he != nil {
+		if hdr := he.Headers(); hdr != nil {
+			addon = hdr.Clone()
+		}
+	}
+	return &interfaces.ErrorMessage{StatusCode: status, Error: err, Addon: addon}
 }
 
 func enrichAuthSelectionError(err error, providers []string, model string) error {

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -137,3 +137,24 @@ func TestGetRequestDetails_ImageModelReturns503(t *testing.T) {
 		t.Fatalf("unexpected error message: %q", msg)
 	}
 }
+
+func TestGetImagesRequestDetails_AllowsImageModel(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient("test-images-request-details", "openai-compatibility", []*registry.ModelInfo{{ID: "gpt-image-2"}})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient("test-images-request-details")
+	})
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, coreauth.NewManager(nil, nil, nil))
+
+	providers, model, errMsg := handler.getImagesRequestDetails("gpt-image-2")
+	if errMsg != nil {
+		t.Fatalf("getImagesRequestDetails() error = %v, want nil", errMsg)
+	}
+	if !reflect.DeepEqual(providers, []string{"openai-compatibility"}) {
+		t.Fatalf("providers = %v, want [openai-compatibility]", providers)
+	}
+	if model != "gpt-image-2" {
+		t.Fatalf("model = %q, want gpt-image-2", model)
+	}
+}

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -209,9 +209,25 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 	if imageModel == "" {
 		imageModel = defaultImagesToolModel
 	}
+	responseFormat := strings.TrimSpace(gjson.GetBytes(rawJSON, "response_format").String())
+	if responseFormat == "" {
+		responseFormat = "b64_json"
+	}
+	stream := gjson.GetBytes(rawJSON, "stream").Bool()
 	if h.HasNativeImagesProvider(imageModel, "images/generations") {
-		h.collectImagesFromNative(c, rawJSON, imageModel, "images/generations")
-		return
+		if !stream {
+			h.collectImagesFromNative(c, rawJSON, imageModel, "images/generations")
+			return
+		}
+		if !strings.EqualFold(imageModel, defaultImagesToolModel) {
+			c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
+				Error: handlers.ErrorDetail{
+					Message: fmt.Sprintf("no native image streaming provider for model %s", imageModel),
+					Type:    "invalid_request_error",
+				},
+			})
+			return
+		}
 	}
 	if !strings.EqualFold(imageModel, defaultImagesToolModel) {
 		c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
@@ -222,12 +238,6 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 		})
 		return
 	}
-
-	responseFormat := strings.TrimSpace(gjson.GetBytes(rawJSON, "response_format").String())
-	if responseFormat == "" {
-		responseFormat = "b64_json"
-	}
-	stream := gjson.GetBytes(rawJSON, "stream").Bool()
 
 	tool := []byte(`{"type":"image_generation","action":"generate"}`)
 	tool, _ = sjson.SetBytes(tool, "model", imageModel)

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -216,10 +216,14 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 	stream := gjson.GetBytes(rawJSON, "stream").Bool()
 	if h.HasNativeImagesProvider(imageModel, "images/generations") {
 		if !stream {
-			h.collectImagesFromNative(c, rawJSON, imageModel, "images/generations")
+			nativeJSON := rawJSON
+			if strings.TrimSpace(gjson.GetBytes(rawJSON, "response_format").String()) == "" {
+				nativeJSON, _ = sjson.SetBytes(nativeJSON, "response_format", responseFormat)
+			}
+			h.collectImagesFromNative(c, nativeJSON, imageModel, "images/generations")
 			return
 		}
-		if !strings.EqualFold(imageModel, defaultImagesToolModel) {
+		if !isDefaultImagesToolModel(imageModel) {
 			c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
 				Error: handlers.ErrorDetail{
 					Message: fmt.Sprintf("no native image streaming provider for model %s", imageModel),
@@ -229,7 +233,7 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 			return
 		}
 	}
-	if !strings.EqualFold(imageModel, defaultImagesToolModel) {
+	if !isDefaultImagesToolModel(imageModel) {
 		c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
 			Error: handlers.ErrorDetail{
 				Message: fmt.Sprintf("no native image provider for model %s", imageModel),
@@ -240,7 +244,7 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 	}
 
 	tool := []byte(`{"type":"image_generation","action":"generate"}`)
-	tool, _ = sjson.SetBytes(tool, "model", imageModel)
+	tool, _ = sjson.SetBytes(tool, "model", defaultImagesToolModel)
 
 	if v := strings.TrimSpace(gjson.GetBytes(rawJSON, "size").String()); v != "" {
 		tool, _ = sjson.SetBytes(tool, "size", v)
@@ -375,7 +379,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromMultipart(c *gin.Context) {
 	stream := parseBoolField(c.PostForm("stream"), false)
 
 	tool := []byte(`{"type":"image_generation","action":"edit"}`)
-	tool, _ = sjson.SetBytes(tool, "model", imageModel)
+	tool, _ = sjson.SetBytes(tool, "model", defaultImagesToolModel)
 
 	if v := strings.TrimSpace(c.PostForm("size")); v != "" {
 		tool, _ = sjson.SetBytes(tool, "size", v)
@@ -407,7 +411,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromMultipart(c *gin.Context) {
 		tool, _ = sjson.SetBytes(tool, "input_image_mask.image_url", strings.TrimSpace(*maskDataURL))
 	}
 
-	if !strings.EqualFold(imageModel, defaultImagesToolModel) {
+	if !isDefaultImagesToolModel(imageModel) {
 		c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
 			Error: handlers.ErrorDetail{
 				Message: fmt.Sprintf("no native image edit provider for model %s", imageModel),
@@ -505,7 +509,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 	stream := gjson.GetBytes(rawJSON, "stream").Bool()
 
 	tool := []byte(`{"type":"image_generation","action":"edit"}`)
-	tool, _ = sjson.SetBytes(tool, "model", imageModel)
+	tool, _ = sjson.SetBytes(tool, "model", defaultImagesToolModel)
 
 	for _, field := range []string{"size", "quality", "background", "output_format", "input_fidelity", "moderation"} {
 		if v := strings.TrimSpace(gjson.GetBytes(rawJSON, field).String()); v != "" {
@@ -523,7 +527,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 		tool, _ = sjson.SetBytes(tool, "input_image_mask.image_url", strings.TrimSpace(*maskDataURL))
 	}
 
-	if !strings.EqualFold(imageModel, defaultImagesToolModel) {
+	if !isDefaultImagesToolModel(imageModel) {
 		c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
 			Error: handlers.ErrorDetail{
 				Message: fmt.Sprintf("no native image edit provider for model %s", imageModel),
@@ -543,17 +547,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 
 func buildImagesResponsesRequest(prompt string, images []string, toolJSON []byte) []byte {
 	req := []byte(`{"instructions":"","stream":true,"reasoning":{"effort":"medium","summary":"auto"},"parallel_tool_calls":true,"include":["reasoning.encrypted_content"],"model":"","store":false,"tool_choice":{"type":"image_generation"}}`)
-	mainModel := defaultImagesMainModel
-	if len(toolJSON) > 0 && json.Valid(toolJSON) {
-		toolModel := strings.TrimSpace(gjson.GetBytes(toolJSON, "model").String())
-		if idx := strings.LastIndex(toolModel, "/"); idx > 0 && idx < len(toolModel)-1 {
-			prefix := strings.TrimSpace(toolModel[:idx])
-			if prefix != "" {
-				mainModel = prefix + "/" + defaultImagesMainModel
-			}
-		}
-	}
-	req, _ = sjson.SetBytes(req, "model", mainModel)
+	req, _ = sjson.SetBytes(req, "model", defaultImagesMainModel)
 
 	input := []byte(`[{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}]`)
 	input, _ = sjson.SetBytes(input, "0.content.0.text", prompt)
@@ -575,6 +569,20 @@ func buildImagesResponsesRequest(prompt string, images []string, toolJSON []byte
 		req, _ = sjson.SetRawBytes(req, "tools.-1", toolJSON)
 	}
 	return req
+}
+
+func isDefaultImagesToolModel(model string) bool {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false
+	}
+	if strings.EqualFold(model, defaultImagesToolModel) {
+		return true
+	}
+	if idx := strings.LastIndex(model, "/"); idx >= 0 && idx < len(model)-1 {
+		return strings.EqualFold(strings.TrimSpace(model[idx+1:]), defaultImagesToolModel)
+	}
+	return false
 }
 
 func (h *OpenAIAPIHandler) collectImagesFromResponses(c *gin.Context, responsesReq []byte, responseFormat string) {

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -209,6 +209,20 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 	if imageModel == "" {
 		imageModel = defaultImagesToolModel
 	}
+	if h.HasNativeImagesProvider(imageModel, "images/generations") {
+		h.collectImagesFromNative(c, rawJSON, imageModel, "images/generations")
+		return
+	}
+	if !strings.EqualFold(imageModel, defaultImagesToolModel) {
+		c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{
+				Message: fmt.Sprintf("no native image provider for model %s", imageModel),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
 	responseFormat := strings.TrimSpace(gjson.GetBytes(rawJSON, "response_format").String())
 	if responseFormat == "" {
 		responseFormat = "b64_json"
@@ -383,6 +397,16 @@ func (h *OpenAIAPIHandler) imagesEditsFromMultipart(c *gin.Context) {
 		tool, _ = sjson.SetBytes(tool, "input_image_mask.image_url", strings.TrimSpace(*maskDataURL))
 	}
 
+	if !strings.EqualFold(imageModel, defaultImagesToolModel) {
+		c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{
+				Message: fmt.Sprintf("no native image edit provider for model %s", imageModel),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
 	responsesReq := buildImagesResponsesRequest(prompt, images, tool)
 	if stream {
 		h.streamImagesFromResponses(c, responsesReq, responseFormat, "image_edit")
@@ -489,6 +513,16 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 		tool, _ = sjson.SetBytes(tool, "input_image_mask.image_url", strings.TrimSpace(*maskDataURL))
 	}
 
+	if !strings.EqualFold(imageModel, defaultImagesToolModel) {
+		c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{
+				Message: fmt.Sprintf("no native image edit provider for model %s", imageModel),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
+
 	responsesReq := buildImagesResponsesRequest(prompt, images, tool)
 	if stream {
 		h.streamImagesFromResponses(c, responsesReq, responseFormat, "image_edit")
@@ -547,6 +581,27 @@ func (h *OpenAIAPIHandler) collectImagesFromResponses(c *gin.Context, responsesR
 	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, "openai-response", mainModel, responsesReq, "")
 
 	out, errMsg := collectImagesFromResponsesStream(cliCtx, dataChan, errChan, responseFormat)
+	stopKeepAlive()
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		if errMsg.Error != nil {
+			cliCancel(errMsg.Error)
+		} else {
+			cliCancel(nil)
+		}
+		return
+	}
+	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+	_, _ = c.Writer.Write(out)
+	cliCancel()
+}
+
+func (h *OpenAIAPIHandler) collectImagesFromNative(c *gin.Context, rawJSON []byte, modelName string, endpoint string) {
+	c.Header("Content-Type", "application/json")
+
+	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
+	out, upstreamHeaders, errMsg := h.ExecuteImagesWithAuthManager(cliCtx, modelName, rawJSON, endpoint)
 	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -244,7 +245,7 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 	}
 
 	tool := []byte(`{"type":"image_generation","action":"generate"}`)
-	tool, _ = sjson.SetBytes(tool, "model", defaultImagesToolModel)
+	tool, _ = sjson.SetBytes(tool, "model", imagesResponsesToolModel(imageModel))
 
 	if v := strings.TrimSpace(gjson.GetBytes(rawJSON, "size").String()); v != "" {
 		tool, _ = sjson.SetBytes(tool, "size", v)
@@ -379,7 +380,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromMultipart(c *gin.Context) {
 	stream := parseBoolField(c.PostForm("stream"), false)
 
 	tool := []byte(`{"type":"image_generation","action":"edit"}`)
-	tool, _ = sjson.SetBytes(tool, "model", defaultImagesToolModel)
+	tool, _ = sjson.SetBytes(tool, "model", imagesResponsesToolModel(imageModel))
 
 	if v := strings.TrimSpace(c.PostForm("size")); v != "" {
 		tool, _ = sjson.SetBytes(tool, "size", v)
@@ -509,7 +510,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 	stream := gjson.GetBytes(rawJSON, "stream").Bool()
 
 	tool := []byte(`{"type":"image_generation","action":"edit"}`)
-	tool, _ = sjson.SetBytes(tool, "model", defaultImagesToolModel)
+	tool, _ = sjson.SetBytes(tool, "model", imagesResponsesToolModel(imageModel))
 
 	for _, field := range []string{"size", "quality", "background", "output_format", "input_fidelity", "moderation"} {
 		if v := strings.TrimSpace(gjson.GetBytes(rawJSON, field).String()); v != "" {
@@ -547,7 +548,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 
 func buildImagesResponsesRequest(prompt string, images []string, toolJSON []byte) []byte {
 	req := []byte(`{"instructions":"","stream":true,"reasoning":{"effort":"medium","summary":"auto"},"parallel_tool_calls":true,"include":["reasoning.encrypted_content"],"model":"","store":false,"tool_choice":{"type":"image_generation"}}`)
-	req, _ = sjson.SetBytes(req, "model", defaultImagesMainModel)
+	req, _ = sjson.SetBytes(req, "model", imagesResponsesMainModel(toolJSON))
 
 	input := []byte(`[{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}]`)
 	input, _ = sjson.SetBytes(input, "0.content.0.text", prompt)
@@ -569,6 +570,49 @@ func buildImagesResponsesRequest(prompt string, images []string, toolJSON []byte
 		req, _ = sjson.SetRawBytes(req, "tools.-1", toolJSON)
 	}
 	return req
+}
+
+func imagesResponsesToolModel(imageModel string) string {
+	imageModel = strings.TrimSpace(imageModel)
+	if imageModel == "" {
+		return defaultImagesToolModel
+	}
+	if prefixedImagesMainModel(imageModel) == "" {
+		return defaultImagesToolModel
+	}
+	return imageModel
+}
+
+func imagesResponsesMainModel(toolJSON []byte) string {
+	mainModel := defaultImagesMainModel
+	if len(toolJSON) == 0 || !json.Valid(toolJSON) {
+		return mainModel
+	}
+	toolModel := strings.TrimSpace(gjson.GetBytes(toolJSON, "model").String())
+	if prefixed := prefixedImagesMainModel(toolModel); prefixed != "" {
+		return prefixed
+	}
+	return mainModel
+}
+
+func prefixedImagesMainModel(toolModel string) string {
+	toolModel = strings.TrimSpace(toolModel)
+	if !isDefaultImagesToolModel(toolModel) {
+		return ""
+	}
+	idx := strings.LastIndex(toolModel, "/")
+	if idx <= 0 || idx >= len(toolModel)-1 {
+		return ""
+	}
+	prefix := strings.TrimSpace(toolModel[:idx])
+	if prefix == "" {
+		return ""
+	}
+	mainModel := prefix + "/" + defaultImagesMainModel
+	if len(registry.GetGlobalRegistry().GetModelProviders(mainModel)) == 0 {
+		return ""
+	}
+	return mainModel
 }
 
 func isDefaultImagesToolModel(model string) bool {

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -1,0 +1,311 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+type imagesCaptureExecutor struct {
+	provider     string
+	nativeImages bool
+	calls        int
+	model        string
+	alt          string
+	payload      string
+}
+
+func (e *imagesCaptureExecutor) Identifier() string { return e.provider }
+
+func (e *imagesCaptureExecutor) SupportsNativeImagesEndpoint(endpoint string) bool {
+	endpoint = strings.Trim(strings.TrimSpace(endpoint), "/")
+	return e.nativeImages && endpoint == "images/generations"
+}
+
+func (e *imagesCaptureExecutor) Execute(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	e.calls++
+	e.model = req.Model
+	e.alt = opts.Alt
+	e.payload = string(req.Payload)
+	return coreexecutor.Response{Payload: []byte(`{"created":1,"data":[{"b64_json":"native"}]}`)}, nil
+}
+
+func (e *imagesCaptureExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *imagesCaptureExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *imagesCaptureExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *imagesCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestImagesGenerationsRoutesNativeProviderByRequestedModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &imagesCaptureExecutor{provider: "openai-compatibility", nativeImages: true}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "images-native-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "qwen-image-test"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"qwen-image-test","prompt":"draw a cat"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if executor.calls != 1 {
+		t.Fatalf("executor calls = %d, want 1", executor.calls)
+	}
+	if executor.model != "qwen-image-test" {
+		t.Fatalf("model = %q, want qwen-image-test", executor.model)
+	}
+	if executor.alt != "images/generations" {
+		t.Fatalf("alt = %q, want images/generations", executor.alt)
+	}
+	if !strings.Contains(executor.payload, `"model":"qwen-image-test"`) {
+		t.Fatalf("payload = %s, want requested image model", executor.payload)
+	}
+}
+
+func TestImagesGenerationsPrefersNativeProviderForGPTImage2(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	nativeExecutor := &imagesCaptureExecutor{provider: "openai-compatibility", nativeImages: true}
+	codexExecutor := &imagesCaptureExecutor{provider: "codex"}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(nativeExecutor)
+	manager.RegisterExecutor(codexExecutor)
+
+	nativeAuth := &coreauth.Auth{ID: "images-gpt-image-native", Provider: nativeExecutor.Identifier(), Status: coreauth.StatusActive}
+	codexAuth := &coreauth.Auth{ID: "images-gpt-image-codex", Provider: codexExecutor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), nativeAuth); err != nil {
+		t.Fatalf("Register native auth: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), codexAuth); err != nil {
+		t.Fatalf("Register codex auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(nativeAuth.ID, nativeAuth.Provider, []*registry.ModelInfo{{ID: defaultImagesToolModel}})
+	registry.GetGlobalRegistry().RegisterClient(codexAuth.ID, codexAuth.Provider, []*registry.ModelInfo{{ID: defaultImagesToolModel}, {ID: defaultImagesMainModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(nativeAuth.ID)
+		registry.GetGlobalRegistry().UnregisterClient(codexAuth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"gpt-image-2","prompt":"draw a cat"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if nativeExecutor.calls != 1 {
+		t.Fatalf("native executor calls = %d, want 1", nativeExecutor.calls)
+	}
+	if codexExecutor.calls != 0 {
+		t.Fatalf("codex executor calls = %d, want 0", codexExecutor.calls)
+	}
+}
+
+func TestImagesGenerationsUsesOpenAICompatAliasUpstreamModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &imagesCaptureExecutor{provider: "native-images", nativeImages: true}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{
+		OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+			Name: "native-images",
+			Models: []internalconfig.OpenAICompatibilityModel{{
+				Name:  "upstream-image-model",
+				Alias: "alias-image-model",
+			}},
+		}},
+	})
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{
+		ID:       "images-native-alias-auth",
+		Provider: executor.Identifier(),
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"api_key":      "test-key",
+			"compat_name":  "native-images",
+			"provider_key": "native-images",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "alias-image-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"alias-image-model","prompt":"draw a cat"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if executor.model != "upstream-image-model" {
+		t.Fatalf("model = %q, want upstream-image-model", executor.model)
+	}
+	if !strings.Contains(executor.payload, `"model":"alias-image-model"`) {
+		t.Fatalf("payload = %s, want original requested image model", executor.payload)
+	}
+}
+
+func TestImagesGenerationsRejectsRegisteredNonNativeProvider(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &imagesCaptureExecutor{provider: "gemini"}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "images-non-native-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "imagen-test"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"imagen-test","prompt":"draw a cat"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusBadGateway, resp.Body.String())
+	}
+	if executor.calls != 0 {
+		t.Fatalf("executor calls = %d, want 0", executor.calls)
+	}
+}
+
+func TestImagesGenerationsDoesNotFallbackToCodexForCustomImageModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	imageExecutor := &imagesCaptureExecutor{provider: "gemini"}
+	codexExecutor := &imagesCaptureExecutor{provider: "codex"}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(imageExecutor)
+	manager.RegisterExecutor(codexExecutor)
+
+	imageAuth := &coreauth.Auth{ID: "images-custom-non-native-auth", Provider: imageExecutor.Identifier(), Status: coreauth.StatusActive}
+	codexAuth := &coreauth.Auth{ID: "images-custom-codex-auth", Provider: codexExecutor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), imageAuth); err != nil {
+		t.Fatalf("Register image auth: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), codexAuth); err != nil {
+		t.Fatalf("Register codex auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(imageAuth.ID, imageAuth.Provider, []*registry.ModelInfo{{ID: "imagen-test"}})
+	registry.GetGlobalRegistry().RegisterClient(codexAuth.ID, codexAuth.Provider, []*registry.ModelInfo{{ID: defaultImagesMainModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(imageAuth.ID)
+		registry.GetGlobalRegistry().UnregisterClient(codexAuth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"imagen-test","prompt":"draw a cat"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusBadGateway, resp.Body.String())
+	}
+	if imageExecutor.calls != 0 {
+		t.Fatalf("image executor calls = %d, want 0", imageExecutor.calls)
+	}
+	if codexExecutor.calls != 0 {
+		t.Fatalf("codex executor calls = %d, want 0", codexExecutor.calls)
+	}
+}
+
+func TestImagesGenerationsRejectsUnknownNonBuiltinModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	manager := coreauth.NewManager(nil, nil, nil)
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"unknown-image-model","prompt":"draw a cat"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusBadGateway, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "no native image provider") {
+		t.Fatalf("body = %s, want no native image provider error", resp.Body.String())
+	}
+}
+
+func TestImagesEditsRejectsCustomImageModelWithoutNativeEditSupport(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	codexExecutor := &imagesCaptureExecutor{provider: "codex"}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(codexExecutor)
+
+	codexAuth := &coreauth.Auth{ID: "images-edit-codex-auth", Provider: codexExecutor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), codexAuth); err != nil {
+		t.Fatalf("Register codex auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(codexAuth.ID, codexAuth.Provider, []*registry.ModelInfo{{ID: defaultImagesMainModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(codexAuth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/edits", strings.NewReader(`{"model":"imagen-test","prompt":"edit a cat","images":[{"image_url":"data:image/png;base64,aW1hZ2U="}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusBadGateway, resp.Body.String())
+	}
+	if codexExecutor.calls != 0 {
+		t.Fatalf("codex executor calls = %d, want 0", codexExecutor.calls)
+	}
+}
+
+func imagesTestRouter(manager *coreauth.Manager) *gin.Engine {
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/images/generations", h.ImagesGenerations)
+	router.POST("/v1/images/edits", h.ImagesEdits)
+	return router
+}

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -289,6 +289,44 @@ func TestImagesGenerationsAllowsProviderQualifiedGPTImage2Fallback(t *testing.T)
 	}
 }
 
+func TestImagesGenerationsPreservesRoutableProviderQualifiedGPTImage2Fallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	codexExecutor := &imagesCaptureExecutor{provider: "codex"}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(codexExecutor)
+
+	codexAuth := &coreauth.Auth{ID: "images-qualified-codex-generate-auth", Provider: codexExecutor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), codexAuth); err != nil {
+		t.Fatalf("Register codex auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(codexAuth.ID, codexAuth.Provider, []*registry.ModelInfo{{ID: "codex/" + defaultImagesMainModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(codexAuth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"codex/gpt-image-2","prompt":"draw a cat"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if codexExecutor.calls != 1 {
+		t.Fatalf("codex executor calls = %d, want 1", codexExecutor.calls)
+	}
+	if codexExecutor.model != "codex/"+defaultImagesMainModel {
+		t.Fatalf("model = %q, want codex/%s", codexExecutor.model, defaultImagesMainModel)
+	}
+	if got := gjson.Get(codexExecutor.payload, "model").String(); got != "codex/"+defaultImagesMainModel {
+		t.Fatalf("payload model = %q, want codex/%s; payload=%s", got, defaultImagesMainModel, codexExecutor.payload)
+	}
+	if got := gjson.Get(codexExecutor.payload, "tools.0.model").String(); got != "codex/"+defaultImagesToolModel {
+		t.Fatalf("tool model = %q, want codex/%s; payload=%s", got, defaultImagesToolModel, codexExecutor.payload)
+	}
+}
+
 func TestImagesGenerationsDoesNotFallbackToCodexForCustomImageModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	imageExecutor := &imagesCaptureExecutor{provider: "gemini"}
@@ -449,6 +487,44 @@ func TestImagesEditsAllowsProviderQualifiedGPTImage2Fallback(t *testing.T) {
 	}
 	if got := gjson.Get(codexExecutor.payload, "input.0.content.1.type").String(); got != "input_image" {
 		t.Fatalf("input image type = %q, want input_image; payload=%s", got, codexExecutor.payload)
+	}
+}
+
+func TestImagesEditsPreservesRoutableProviderQualifiedGPTImage2Fallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	codexExecutor := &imagesCaptureExecutor{provider: "codex"}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(codexExecutor)
+
+	codexAuth := &coreauth.Auth{ID: "images-qualified-codex-edit-auth", Provider: codexExecutor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), codexAuth); err != nil {
+		t.Fatalf("Register codex auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(codexAuth.ID, codexAuth.Provider, []*registry.ModelInfo{{ID: "codex/" + defaultImagesMainModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(codexAuth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/edits", strings.NewReader(`{"model":"codex/gpt-image-2","prompt":"edit a cat","images":[{"image_url":"data:image/png;base64,aW1hZ2U="}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if codexExecutor.calls != 1 {
+		t.Fatalf("codex executor calls = %d, want 1", codexExecutor.calls)
+	}
+	if codexExecutor.model != "codex/"+defaultImagesMainModel {
+		t.Fatalf("model = %q, want codex/%s", codexExecutor.model, defaultImagesMainModel)
+	}
+	if got := gjson.Get(codexExecutor.payload, "model").String(); got != "codex/"+defaultImagesMainModel {
+		t.Fatalf("payload model = %q, want codex/%s; payload=%s", got, defaultImagesMainModel, codexExecutor.payload)
+	}
+	if got := gjson.Get(codexExecutor.payload, "tools.0.model").String(); got != "codex/"+defaultImagesToolModel {
+		t.Fatalf("tool model = %q, want codex/%s; payload=%s", got, defaultImagesToolModel, codexExecutor.payload)
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -15,6 +15,7 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	"github.com/tidwall/gjson"
 )
 
 type imagesCaptureExecutor struct {
@@ -41,8 +42,15 @@ func (e *imagesCaptureExecutor) Execute(_ context.Context, _ *coreauth.Auth, req
 	return coreexecutor.Response{Payload: []byte(`{"created":1,"data":[{"b64_json":"native"}]}`)}, nil
 }
 
-func (e *imagesCaptureExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
-	return nil, errors.New("not implemented")
+func (e *imagesCaptureExecutor) ExecuteStream(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	e.calls++
+	e.model = req.Model
+	e.alt = opts.Alt
+	e.payload = string(req.Payload)
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.completed","response":{"created_at":1,"output":[{"type":"image_generation_call","result":"aW1hZ2U=","output_format":"png"}],"tool_usage":{"image_gen":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}}` + "\n\n")}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
 }
 
 func (e *imagesCaptureExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
@@ -92,6 +100,38 @@ func TestImagesGenerationsRoutesNativeProviderByRequestedModel(t *testing.T) {
 	}
 	if !strings.Contains(executor.payload, `"model":"qwen-image-test"`) {
 		t.Fatalf("payload = %s, want requested image model", executor.payload)
+	}
+	if !strings.Contains(executor.payload, `"response_format":"b64_json"`) {
+		t.Fatalf("payload = %s, want default response_format=b64_json", executor.payload)
+	}
+}
+
+func TestImagesGenerationsPreservesExplicitNativeResponseFormat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &imagesCaptureExecutor{provider: "openai-compatibility", nativeImages: true}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "images-native-format-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "qwen-image-test"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"qwen-image-test","prompt":"draw a cat","response_format":"url"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if !strings.Contains(executor.payload, `"response_format":"url"`) {
+		t.Fatalf("payload = %s, want explicit response_format=url", executor.payload)
 	}
 }
 
@@ -214,6 +254,41 @@ func TestImagesGenerationsRejectsRegisteredNonNativeProvider(t *testing.T) {
 	}
 }
 
+func TestImagesGenerationsAllowsProviderQualifiedGPTImage2Fallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	codexExecutor := &imagesCaptureExecutor{provider: "codex"}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(codexExecutor)
+
+	codexAuth := &coreauth.Auth{ID: "images-qualified-generate-codex-auth", Provider: codexExecutor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), codexAuth); err != nil {
+		t.Fatalf("Register codex auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(codexAuth.ID, codexAuth.Provider, []*registry.ModelInfo{{ID: defaultImagesMainModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(codexAuth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"openai/gpt-image-2","prompt":"draw a cat"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if codexExecutor.calls != 1 {
+		t.Fatalf("codex executor calls = %d, want 1", codexExecutor.calls)
+	}
+	if codexExecutor.model != defaultImagesMainModel {
+		t.Fatalf("model = %q, want %s", codexExecutor.model, defaultImagesMainModel)
+	}
+	if got := gjson.Get(codexExecutor.payload, "tools.0.model").String(); got != defaultImagesToolModel {
+		t.Fatalf("tool model = %q, want %s; payload=%s", got, defaultImagesToolModel, codexExecutor.payload)
+	}
+}
+
 func TestImagesGenerationsDoesNotFallbackToCodexForCustomImageModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	imageExecutor := &imagesCaptureExecutor{provider: "gemini"}
@@ -330,6 +405,50 @@ func TestImagesEditsRejectsCustomImageModelWithoutNativeEditSupport(t *testing.T
 	}
 	if codexExecutor.calls != 0 {
 		t.Fatalf("codex executor calls = %d, want 0", codexExecutor.calls)
+	}
+}
+
+func TestImagesEditsAllowsProviderQualifiedGPTImage2Fallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	codexExecutor := &imagesCaptureExecutor{provider: "codex"}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(codexExecutor)
+
+	codexAuth := &coreauth.Auth{ID: "images-qualified-edit-codex-auth", Provider: codexExecutor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), codexAuth); err != nil {
+		t.Fatalf("Register codex auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(codexAuth.ID, codexAuth.Provider, []*registry.ModelInfo{{ID: defaultImagesMainModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(codexAuth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/edits", strings.NewReader(`{"model":"openai/gpt-image-2","prompt":"edit a cat","images":[{"image_url":"data:image/png;base64,aW1hZ2U="}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if codexExecutor.calls != 1 {
+		t.Fatalf("codex executor calls = %d, want 1", codexExecutor.calls)
+	}
+	if codexExecutor.model != defaultImagesMainModel {
+		t.Fatalf("model = %q, want %s", codexExecutor.model, defaultImagesMainModel)
+	}
+	if got := gjson.Get(codexExecutor.payload, "tools.0.type").String(); got != "image_generation" {
+		t.Fatalf("tool type = %q, want image_generation; payload=%s", got, codexExecutor.payload)
+	}
+	if got := gjson.Get(codexExecutor.payload, "tools.0.action").String(); got != "edit" {
+		t.Fatalf("tool action = %q, want edit; payload=%s", got, codexExecutor.payload)
+	}
+	if got := gjson.Get(codexExecutor.payload, "tools.0.model").String(); got != defaultImagesToolModel {
+		t.Fatalf("tool model = %q, want %s; payload=%s", got, defaultImagesToolModel, codexExecutor.payload)
+	}
+	if got := gjson.Get(codexExecutor.payload, "input.0.content.1.type").String(); got != "input_image" {
+		t.Fatalf("input image type = %q, want input_image; payload=%s", got, codexExecutor.payload)
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -254,6 +254,38 @@ func TestImagesGenerationsDoesNotFallbackToCodexForCustomImageModel(t *testing.T
 	}
 }
 
+func TestImagesGenerationsRejectsNativeProviderStreamWithoutStreamingSupport(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	nativeExecutor := &imagesCaptureExecutor{provider: "openai-compatibility", nativeImages: true}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(nativeExecutor)
+
+	auth := &coreauth.Auth{ID: "images-native-stream-auth", Provider: nativeExecutor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "qwen-image-test"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	router := imagesTestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"qwen-image-test","prompt":"draw a cat","stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body=%s", resp.Code, http.StatusBadGateway, resp.Body.String())
+	}
+	if nativeExecutor.calls != 0 {
+		t.Fatalf("native executor calls = %d, want 0", nativeExecutor.calls)
+	}
+	if !strings.Contains(resp.Body.String(), "no native image streaming provider") {
+		t.Fatalf("body = %s, want native image streaming provider error", resp.Body.String())
+	}
+}
+
 func TestImagesGenerationsRejectsUnknownNonBuiltinModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	manager := coreauth.NewManager(nil, nil, nil)

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -88,3 +88,9 @@ type StatusError interface {
 	error
 	StatusCode() int
 }
+
+// NativeImagesEndpointExecutor is an optional executor capability for providers
+// that can receive OpenAI-compatible Images API requests without translation.
+type NativeImagesEndpointExecutor interface {
+	SupportsNativeImagesEndpoint(endpoint string) bool
+}


### PR DESCRIPTION
Fixes #3018.
Fixes #3023.
Related to #3036.
Related to #2991.

Separate from usage retry accounting in #3042.

## Summary
- stops unconditional Codex `image_generation` tool injection for generic Responses requests
- ensures `tools` contains `image_generation` only when the request explicitly selects the image generation tool
- preserves existing client-provided `image_generation` tool definitions without duplicating or overwriting them
- keeps existing safeguards for `spark` models and free Codex auth
- routes native OpenAI-compatible `/v1/images/generations` requests through providers that explicitly support the native Images endpoint
- prevents custom/native image models from falling back to Codex `gpt-5.4-mini` when no native Images provider is available
- keeps `stream:true` native image requests from being silently downgraded to non-streaming responses
- applies configured payload rules and the existing OpenAI-compatible User-Agent behavior on native Images requests

## Why
Codex clients can expose the native `image_generation` tool in their own tool registry. The proxy should not infer image generation from headers or generic chat text. It should only repair explicit structured image-tool intent, such as a frontend/client selecting the image generation tool.

This avoids the upstream error shape reported in related issues where `tool_choice` selects `image_generation` but the `tools` array does not contain the matching tool.

The OpenAI-compatible Images API is a separate native endpoint family. Provider image models such as Qwen/native Images API models should be routed by the requested image model to a native Images provider, not translated through the Codex Responses image tool fallback.

## Notes on related issues
- #3018 is the core Codex regression: `image_generation` was injected into generic Responses traffic.
- #3023 is covered by adding the missing `image_generation` tool when the request explicitly selects it.
- #3036 is related because it reports the same missing-tool error, but free-account image generation limits are not changed here.
- #2991 is related because this PR fixes the native Images routing side where custom/provider image models could end up requesting Codex `gpt-5.4-mini`; provider/account support limitations are not changed here.

## Local validation
- `go test -count=1 ./internal/runtime/executor -run 'TestOpenAICompatExecutorNativeImages|TestOpenAICompatExecutorSupportsNativeImages'`
- `go test -count=1 ./sdk/api/handlers/openai -run 'TestImages(Generations|Edits)'`
- `go test -count=1 ./internal/runtime/executor ./sdk/api/handlers ./sdk/api/handlers/openai ./sdk/cliproxy/auth ./sdk/cliproxy/executor`
- `go test -race -count=1 ./internal/runtime/executor -run 'TestOpenAICompatExecutorNativeImages|TestOpenAICompatExecutorSupportsNativeImages'`
- `go test -race -count=1 ./sdk/api/handlers/openai -run 'TestImages(Generations|Edits)'`
- `go build -o test-output ./cmd/server && rm test-output`

I also rebuilt a downstream local deploy stack with this patched kernel and verified:
- native image model requests are routed as the requested provider/model instead of `codex/gpt-5.4-mini`
- `gpt-image-2` still works through the Codex image tool fallback and returns a real `b64_json` image payload
