### PR TITLE
fix(codex): classify context, thinking-signature, previous-response, and auth failures

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -809,11 +809,58 @@ func newCodexStatusErr(statusCode int, body []byte) statusErr {
 	if isCodexModelCapacityError(body) {
 		errCode = http.StatusTooManyRequests
 	}
+	body = classifyCodexStatusError(errCode, body)
 	err := statusErr{code: errCode, msg: string(body)}
 	if retryAfter := parseCodexRetryAfter(errCode, body, time.Now()); retryAfter != nil {
 		err.retryAfter = retryAfter
 	}
 	return err
+}
+
+func classifyCodexStatusError(statusCode int, body []byte) []byte {
+	code, errType, ok := codexStatusErrorClassification(statusCode, body)
+	if !ok {
+		return body
+	}
+	message := gjson.GetBytes(body, "error.message").String()
+	if message == "" {
+		message = gjson.GetBytes(body, "message").String()
+	}
+	if message == "" {
+		message = strings.TrimSpace(string(body))
+	}
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+	out := []byte(`{"error":{}}`)
+	out, _ = sjson.SetBytes(out, "error.message", message)
+	out, _ = sjson.SetBytes(out, "error.type", errType)
+	out, _ = sjson.SetBytes(out, "error.code", code)
+	return out
+}
+
+func codexStatusErrorClassification(statusCode int, body []byte) (code string, errType string, ok bool) {
+	errorMessage := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.message").String()))
+	if errorMessage == "" {
+		errorMessage = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "message").String()))
+	}
+	lower := strings.ToLower(strings.TrimSpace(string(body)))
+	upstreamCode := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
+	upstreamType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.type").String()))
+	isInvalidRequest := upstreamType == "" || upstreamType == "invalid_request_error"
+
+	switch {
+	case statusCode == http.StatusRequestEntityTooLarge || upstreamCode == "context_length_exceeded" || upstreamCode == "context_too_large" || isInvalidRequest && (strings.Contains(errorMessage, "context length") || strings.Contains(errorMessage, "context_length") || strings.Contains(errorMessage, "maximum context") || strings.Contains(errorMessage, "too many tokens")):
+		return "context_too_large", "invalid_request_error", true
+	case strings.Contains(lower, "invalid signature in thinking block") || strings.Contains(lower, "invalid_encrypted_content"):
+		return "thinking_signature_invalid", "invalid_request_error", true
+	case upstreamCode == "previous_response_not_found" || strings.Contains(lower, "previous_response_not_found") || strings.Contains(lower, "previous_response_id") && strings.Contains(lower, "not found"):
+		return "previous_response_not_found", "invalid_request_error", true
+	case statusCode == http.StatusUnauthorized || upstreamType == "authentication_error" || upstreamCode == "invalid_api_key" || strings.Contains(lower, "invalid or expired token") || strings.Contains(lower, "refresh_token_reused"):
+		return "auth_unavailable", "authentication_error", true
+	default:
+		return "", "", false
+	}
 }
 
 func normalizeCodexInstructions(body []byte) []byte {

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"testing"
@@ -70,6 +71,94 @@ func TestNewCodexStatusErrTreatsCapacityAsRetryableRateLimit(t *testing.T) {
 	}
 	if err.RetryAfter() != nil {
 		t.Fatalf("expected nil explicit retryAfter for capacity fallback, got %v", *err.RetryAfter())
+	}
+}
+
+func TestNewCodexStatusErrClassifiesKnownCodexFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       []byte
+		wantStatus int
+		wantType   string
+		wantCode   string
+	}{
+		{
+			name:       "context length status",
+			statusCode: http.StatusRequestEntityTooLarge,
+			body:       []byte(`{"error":{"message":"context length exceeded","type":"invalid_request_error","code":"context_length_exceeded"}}`),
+			wantStatus: http.StatusRequestEntityTooLarge,
+			wantType:   "invalid_request_error",
+			wantCode:   "context_too_large",
+		},
+		{
+			name:       "thinking signature",
+			statusCode: http.StatusBadRequest,
+			body:       []byte(`{"error":{"message":"Invalid signature in thinking block","type":"invalid_request_error","code":"invalid_request_error"}}`),
+			wantStatus: http.StatusBadRequest,
+			wantType:   "invalid_request_error",
+			wantCode:   "thinking_signature_invalid",
+		},
+		{
+			name:       "previous response missing",
+			statusCode: http.StatusBadRequest,
+			body:       []byte(`{"error":{"message":"No response found for previous_response_id resp_123","type":"invalid_request_error","code":"previous_response_not_found"}}`),
+			wantStatus: http.StatusBadRequest,
+			wantType:   "invalid_request_error",
+			wantCode:   "previous_response_not_found",
+		},
+		{
+			name:       "auth unavailable",
+			statusCode: http.StatusUnauthorized,
+			body:       []byte(`{"error":{"message":"invalid or expired token","type":"authentication_error","code":"invalid_api_key"}}`),
+			wantStatus: http.StatusUnauthorized,
+			wantType:   "authentication_error",
+			wantCode:   "auth_unavailable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := newCodexStatusErr(tc.statusCode, tc.body)
+
+			if got := err.StatusCode(); got != tc.wantStatus {
+				t.Fatalf("status code = %d, want %d", got, tc.wantStatus)
+			}
+			assertCodexErrorCode(t, err.Error(), tc.wantType, tc.wantCode)
+		})
+	}
+}
+
+func TestNewCodexStatusErrPreservesUnclassifiedErrors(t *testing.T) {
+	body := []byte(`{"error":{"message":"documentation mentions too many tokens, but this is a billing configuration failure","type":"server_error","code":"billing_config_error"}}`)
+
+	err := newCodexStatusErr(http.StatusBadGateway, body)
+
+	if got := err.StatusCode(); got != http.StatusBadGateway {
+		t.Fatalf("status code = %d, want %d", got, http.StatusBadGateway)
+	}
+	if got := err.Error(); got != string(body) {
+		t.Fatalf("error body = %s, want original %s", got, string(body))
+	}
+}
+
+func assertCodexErrorCode(t *testing.T, raw string, wantType string, wantCode string) {
+	t.Helper()
+
+	var payload struct {
+		Error struct {
+			Type string `json:"type"`
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("error body is not valid JSON: %v; body=%s", err, raw)
+	}
+	if payload.Error.Type != wantType {
+		t.Fatalf("error.type = %q, want %q; body=%s", payload.Error.Type, wantType, raw)
+	}
+	if payload.Error.Code != wantCode {
+		t.Fatalf("error.code = %q, want %q; body=%s", payload.Error.Code, wantCode, raw)
 	}
 }
 


### PR DESCRIPTION
# CLIProxyAPI Upstream PR Draft — Codex Error Classification

Date: 2026-04-24
Local fork: `/home/maetzger/Projects/cliproxyapi`
Base commit: `f1ba615`
Target upstream: `router-for-me/CLIProxyAPI`
Related issue: https://github.com/router-for-me/CLIProxyAPI/issues/2596

## PR title

```text
fix(codex): classify context, thinking-signature, previous-response, and auth failures
```

## Summary

This PR keeps successful Codex requests unchanged, but normalizes known Codex upstream failures before they are returned through CLIProxyAPI.

The goal is observability and recovery: callers should distinguish context bloat, invalid reasoning/thinking signatures, stale `previous_response_id`, and real auth failures instead of treating them as generic upstream/service failures.

## Incident data motivating the change

We investigated repeated Codex-via-Claude-Code session failures where long CLIProxyAPI sessions eventually collapsed with large request bodies and misleading generic failures.

Relevant local investigation artifacts:

- `proxy-analysis.md`: Source analysis of CLIProxyAPI request flow.
- `cli-baseline.md`: Direct Codex CLI baseline measurements.

Key measurements from `cli-baseline.md`:

| Path | Largest observed compressed request | Largest observed decoded request | Notes |
|---|---:|---:|---|
| Direct Codex CLI HTTP fallback, short turns | 18,930 B | 46,953 B | Stable across 4 turns |
| Direct Codex CLI HTTP fallback, read-only tool workload | 62,067 B | 166,473 B | Stable across 10 requests |
| CLIProxyAPI incident sessions | ~1.28–1.7 MB | not consistently captured | Sessions died under context-bloat conditions |

The baseline also confirms that direct `codex-cli 0.115.0` has a Responses-WebSocket-V2 path that can send `previous_response_id` and only incremental input:

- `codex-rs/core/src/client.rs:983-1009`: builds `ResponseCreateWsRequest` with `previous_response_id` and `incremental_items`.
- `codex-rs/core/tests/suite/client_websockets.rs:622-663`: asserts the second WebSocket request contains `previous_response_id == "resp-1"` and only the incremental suffix.

The full stateful bridge is larger than this PR. This PR only improves failure classification so orchestrators and clients can react correctly.

## Relevant CLIProxyAPI source pointers

From `proxy-analysis.md` at base commit `f1ba615`:

- `sdk/api/handlers/claude/code_handlers.go:65-85`: Claude-compatible `/v1/messages` handler reads the full request body.
- `sdk/api/handlers/claude/code_handlers.go:224-230`: streaming calls `ExecuteStreamWithAuthManager(..., h.HandlerType(), modelName, rawJSON, "")`.
- `sdk/api/handlers/handlers.go:580-589`: source format is set from handler type; for Claude Code this becomes `claude`.
- `internal/translator/codex/claude/codex_claude_request.go:77-227`: Claude message history is translated into a full Codex Responses `input` array.
- `internal/runtime/executor/codex_executor.go:145-185`: non-streaming Codex executor translates to Codex Responses and deletes `previous_response_id`.
- `internal/runtime/executor/codex_executor.go:388-427`: streaming Codex executor does the same and sends to `/responses`.
- `internal/runtime/executor/codex_executor.go:807-817`: central status error construction point.

## Proposed behavior

`newCodexStatusErr` should normalize known upstream error bodies to explicit JSON error codes:

| Condition | Returned HTTP status | `error.type` | `error.code` |
|---|---:|---|---|
| HTTP 413 or explicit context/window failure | Preserve upstream status | `invalid_request_error` | `context_too_large` |
| `Invalid signature in thinking block` or `invalid_encrypted_content` | Preserve upstream status | `invalid_request_error` | `thinking_signature_invalid` |
| `previous_response_not_found` or missing `previous_response_id` phrases | Preserve upstream status | `invalid_request_error` | `previous_response_not_found` |
| Actual auth/token failures | Preserve upstream status | `authentication_error` | `auth_unavailable` |

Existing capacity handling remains unchanged: model capacity errors still map to HTTP 429 and retain retry behavior.

Unknown upstream errors remain unchanged. The tests include a negative regression where an unrelated server error contains the phrase `too many tokens` in its message but must not be normalized.

## Patch diff

```diff
diff --git a/internal/runtime/executor/codex_executor.go b/internal/runtime/executor/codex_executor.go
index 3866723..48b3755 100644
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -809,6 +809,7 @@ func newCodexStatusErr(statusCode int, body []byte) statusErr {
 	if isCodexModelCapacityError(body) {
 		errCode = http.StatusTooManyRequests
 	}
+	body = classifyCodexStatusError(errCode, body)
 	err := statusErr{code: errCode, msg: string(body)}
 	if retryAfter := parseCodexRetryAfter(errCode, body, time.Now()); retryAfter != nil {
 		err.retryAfter = retryAfter
@@ -816,6 +817,52 @@ func newCodexStatusErr(statusCode int, body []byte) statusErr {
 	return err
 }
 
+func classifyCodexStatusError(statusCode int, body []byte) []byte {
+	code, errType, ok := codexStatusErrorClassification(statusCode, body)
+	if !ok {
+		return body
+	}
+	message := gjson.GetBytes(body, "error.message").String()
+	if message == "" {
+		message = gjson.GetBytes(body, "message").String()
+	}
+	if message == "" {
+		message = strings.TrimSpace(string(body))
+	}
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+	out := []byte(`{"error":{}}`)
+	out, _ = sjson.SetBytes(out, "error.message", message)
+	out, _ = sjson.SetBytes(out, "error.type", errType)
+	out, _ = sjson.SetBytes(out, "error.code", code)
+	return out
+}
+
+func codexStatusErrorClassification(statusCode int, body []byte) (code string, errType string, ok bool) {
+	errorMessage := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.message").String()))
+	if errorMessage == "" {
+		errorMessage = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "message").String()))
+	}
+	lower := strings.ToLower(strings.TrimSpace(string(body)))
+	upstreamCode := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
+	upstreamType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.type").String()))
+	isInvalidRequest := upstreamType == "" || upstreamType == "invalid_request_error"
+
+	switch {
+	case statusCode == http.StatusRequestEntityTooLarge || upstreamCode == "context_length_exceeded" || upstreamCode == "context_too_large" || isInvalidRequest && (strings.Contains(errorMessage, "context length") || strings.Contains(errorMessage, "context_length") || strings.Contains(errorMessage, "maximum context") || strings.Contains(errorMessage, "too many tokens")):
+		return "context_too_large", "invalid_request_error", true
+	case strings.Contains(lower, "invalid signature in thinking block") || strings.Contains(lower, "invalid_encrypted_content"):
+		return "thinking_signature_invalid", "invalid_request_error", true
+	case upstreamCode == "previous_response_not_found" || strings.Contains(lower, "previous_response_not_found") || strings.Contains(lower, "previous_response_id") && strings.Contains(lower, "not found"):
+		return "previous_response_not_found", "invalid_request_error", true
+	case statusCode == http.StatusUnauthorized || upstreamType == "authentication_error" || upstreamCode == "invalid_api_key" || strings.Contains(lower, "invalid or expired token") || strings.Contains(lower, "refresh_token_reused"):
+		return "auth_unavailable", "authentication_error", true
+	default:
+		return "", "", false
+	}
+}
+
 func normalizeCodexInstructions(body []byte) []byte {
 	instructions := gjson.GetBytes(body, "instructions")
 	if !instructions.Exists() || instructions.Type == gjson.Null {
diff --git a/internal/runtime/executor/codex_executor_retry_test.go b/internal/runtime/executor/codex_executor_retry_test.go
index 249d40d..7207d57 100644
--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"testing"
@@ -73,6 +74,94 @@ func TestNewCodexStatusErrTreatsCapacityAsRetryableRateLimit(t *testing.T) {
 	}
 }
 
+func TestNewCodexStatusErrClassifiesKnownCodexFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       []byte
+		wantStatus int
+		wantType   string
+		wantCode   string
+	}{
+		{
+			name:       "context length status",
+			statusCode: http.StatusRequestEntityTooLarge,
+			body:       []byte(`{"error":{"message":"context length exceeded","type":"invalid_request_error","code":"context_length_exceeded"}}`),
+			wantStatus: http.StatusRequestEntityTooLarge,
+			wantType:   "invalid_request_error",
+			wantCode:   "context_too_large",
+		},
+		{
+			name:       "thinking signature",
+			statusCode: http.StatusBadRequest,
+			body:       []byte(`{"error":{"message":"Invalid signature in thinking block","type":"invalid_request_error","code":"invalid_request_error"}}`),
+			wantStatus: http.StatusBadRequest,
+			wantType:   "invalid_request_error",
+			wantCode:   "thinking_signature_invalid",
+		},
+		{
+			name:       "previous response missing",
+			statusCode: http.StatusBadRequest,
+			body:       []byte(`{"error":{"message":"No response found for previous_response_id resp_123","type":"invalid_request_error","code":"previous_response_not_found"}}`),
+			wantStatus: http.StatusBadRequest,
+			wantType:   "invalid_request_error",
+			wantCode:   "previous_response_not_found",
+		},
+		{
+			name:       "auth unavailable",
+			statusCode: http.StatusUnauthorized,
+			body:       []byte(`{"error":{"message":"invalid or expired token","type":"authentication_error","code":"invalid_api_key"}}`),
+			wantStatus: http.StatusUnauthorized,
+			wantType:   "authentication_error",
+			wantCode:   "auth_unavailable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := newCodexStatusErr(tc.statusCode, tc.body)
+
+			if got := err.StatusCode(); got != tc.wantStatus {
+				t.Fatalf("status code = %d, want %d", got, tc.wantStatus)
+			}
+			assertCodexErrorCode(t, err.Error(), tc.wantType, tc.wantCode)
+		})
+	}
+}
+
+func TestNewCodexStatusErrPreservesUnclassifiedErrors(t *testing.T) {
+	body := []byte(`{"error":{"message":"documentation mentions too many tokens, but this is a billing configuration failure","type":"server_error","code":"billing_config_error"}}`)
+
+	err := newCodexStatusErr(http.StatusBadGateway, body)
+
+	if got := err.StatusCode(); got != http.StatusBadGateway {
+		t.Fatalf("status code = %d, want %d", got, http.StatusBadGateway)
+	}
+	if got := err.Error(); got != string(body) {
+		t.Fatalf("error body = %s, want original %s", got, string(body))
+	}
+}
+
+func assertCodexErrorCode(t *testing.T, raw string, wantType string, wantCode string) {
+	t.Helper()
+
+	var payload struct {
+		Error struct {
+			Type string `json:"type"`
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("error body is not valid JSON: %v; body=%s", err, raw)
+	}
+	if payload.Error.Type != wantType {
+		t.Fatalf("error.type = %q, want %q; body=%s", payload.Error.Type, wantType, raw)
+	}
+	if payload.Error.Code != wantCode {
+		t.Fatalf("error.code = %q, want %q; body=%s", payload.Error.Code, wantCode, raw)
+	}
+}
+
 func itoa(v int64) string {
 	return strconv.FormatInt(v, 10)
 }
```

## Local verification already performed

Toolchain:

```bash
/usr/local/go/bin/go version
```

Output:

```text
go version go1.26.2 linux/amd64
```

TDD RED step before the first implementation:

```bash
/usr/local/go/bin/go -C "/home/maetzger/Projects/cliproxyapi" test ./internal/runtime/executor -run TestNewCodexStatusErrClassifiesKnownCodexFailures -count=1
```

Observed failure: existing code returned upstream codes such as `context_length_exceeded`, `invalid_request_error`, and `invalid_api_key` instead of the normalized codes.

Review follow-up RED step:

```bash
/usr/local/go/bin/go -C "/home/maetzger/Projects/cliproxyapi" test ./internal/runtime/executor -run TestNewCodexStatusErrPreservesUnclassifiedErrors -count=1
```

Observed failure: broad matching incorrectly normalized an unrelated `server_error` body containing the phrase `too many tokens`. The classifier was then tightened to match parsed error fields first and only treat invalid-request context phrases as `context_too_large`.

Final targeted verification:

```bash
/usr/local/go/bin/go -C "/home/maetzger/Projects/cliproxyapi" test ./internal/runtime/executor -run 'TestNewCodexStatusErr(ClassifiesKnownCodexFailures|TreatsCapacityAsRetryableRateLimit|PreservesUnclassifiedErrors)' -count=1 -v
```

Output:

```text
=== RUN   TestNewCodexStatusErrTreatsCapacityAsRetryableRateLimit
--- PASS: TestNewCodexStatusErrTreatsCapacityAsRetryableRateLimit (0.00s)
=== RUN   TestNewCodexStatusErrClassifiesKnownCodexFailures
=== RUN   TestNewCodexStatusErrClassifiesKnownCodexFailures/context_length_status
=== RUN   TestNewCodexStatusErrClassifiesKnownCodexFailures/thinking_signature
=== RUN   TestNewCodexStatusErrClassifiesKnownCodexFailures/previous_response_missing
=== RUN   TestNewCodexStatusErrClassifiesKnownCodexFailures/auth_unavailable
--- PASS: TestNewCodexStatusErrClassifiesKnownCodexFailures (0.00s)
=== RUN   TestNewCodexStatusErrPreservesUnclassifiedErrors
--- PASS: TestNewCodexStatusErrPreservesUnclassifiedErrors (0.00s)
PASS
ok  	github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor	0.007s
```

Broader executor package verification:

```bash
/usr/local/go/bin/go -C "/home/maetzger/Projects/cliproxyapi" test ./internal/runtime/executor -count=1
```

Output:

```text
ok  	github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor	0.568s
```

Build verification:

```bash
/usr/local/go/bin/go -C "/home/maetzger/Projects/cliproxyapi" build -o "/home/maetzger/Projects/cliproxyapi/cli-proxy-api" ./cmd/server
```

Output binary:

```text
/home/maetzger/Projects/cliproxyapi/cli-proxy-api
```

## Suggested upstream test plan

1. Run targeted tests:

   ```bash
   go test ./internal/runtime/executor -run 'TestNewCodexStatusErr(ClassifiesKnownCodexFailures|TreatsCapacityAsRetryableRateLimit|PreservesUnclassifiedErrors)' -count=1
   ```

2. Run executor package tests:

   ```bash
   go test ./internal/runtime/executor -count=1
   ```

3. Build the server:

   ```bash
   go build -o cli-proxy-api ./cmd/server
   ```

4. Optional integration smoke test with a fake upstream returning each error body and asserting the downstream JSON contains the normalized `error.code`.

## Suggested Issue #2596 comment

```markdown
I ran into a related production failure mode while using Claude Code through CLIProxyAPI's Codex backend.

Short version: direct Codex CLI remained stable in a comparable read-only tool workload, while Claude-Code-via-CLIProxyAPI sessions eventually produced ~1.28–1.7 MB upstream request bodies and then failed with confusing generic errors. The immediate PR I am proposing does not attempt the full stateful Responses bridge; it only makes error classification explicit so clients/orchestrators can recover correctly.

Data points from my local investigation:

- Direct `codex-cli 0.115.0` uses Responses, not Chat Completions.
- Direct Codex CLI has a WebSocket Responses-V2 path that can send `previous_response_id` plus only incremental input. Source pointers: `codex-rs/core/src/client.rs:983-1009`; test pointer: `codex-rs/core/tests/suite/client_websockets.rs:622-663`.
- My HTTP-interceptor baseline forced direct Codex CLI into HTTPS fallback. Even in that less efficient fallback, the largest observed read-only tool-workload request was 62,067 B compressed / 166,473 B decoded across 10 requests.
- The failing CLIProxyAPI sessions reached approximately 1.28–1.7 MB request bodies.
- In CLIProxyAPI at commit `f1ba615`, the Claude `/v1/messages` path translates the full Anthropic message history into Codex Responses `input`: `internal/translator/codex/claude/codex_claude_request.go:77-227`.
- The Codex HTTP executor deletes `previous_response_id` in both non-streaming and streaming paths: `internal/runtime/executor/codex_executor.go:178` and `:419`.

The full root-cause fix likely needs a separate design: a stateful Claude-Messages-to-Codex-Responses bridge with sticky auth/session state and safe invalidation on `previous_response_not_found`.

For now, I propose a small PR around `internal/runtime/executor/codex_executor.go:newCodexStatusErr` that normalizes known upstream failures into explicit codes:

- `context_too_large`
- `thinking_signature_invalid`
- `previous_response_not_found`
- `auth_unavailable`

This lets clients distinguish context bloat and stale response IDs from actual auth outages instead of treating everything as a generic upstream/service failure.
```

## Scope intentionally not included

This PR does not preserve or synthesize `previous_response_id` for the Claude `/v1/messages` path. That remains the likely root architectural fix, but it needs a larger design around:

- downstream session key selection,
- sticky auth routing,
- per-session Codex response state,
- tool-call output continuity,
- `previous_response_not_found` invalidation/fallback,
- concurrency locks and TTL cleanup.

Keeping this PR to error classification should make it reviewable and immediately useful without changing request semantics.
