### PR TITLE
docs: add CPA Usage Keeper to ecosystem list

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ Cross-platform desktop app (macOS, Windows, Linux) wrapping CLIProxyAPI with a n
 
 Ready-to-use cross-platform quota inspector for CLIProxyAPI, supporting per-account codex 5h/7d quota windows, plan-based sorting, status coloring, and multi-account summary analytics.
 
+### [CPA Usage Keeper](https://github.com/Willxup/cpa-usage-keeper)
+
+Standalone usage persistence and visualization service for CLIProxyAPI. Periodically pulls CPA data, stores normalized events in SQLite, exposes aggregate APIs, and includes a built-in web dashboard for usage, pricing, request health, and model/API statistics.
+
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Ready-to-use cross-platform quota inspector for CLIProxyAPI, supporting per-acco
 
 ### [CPA Usage Keeper](https://github.com/Willxup/cpa-usage-keeper)
 
-Standalone usage persistence and visualization service for CLIProxyAPI. Periodically pulls CPA data, stores normalized events in SQLite, exposes aggregate APIs, and includes a built-in web dashboard for usage, pricing, request health, and model/API statistics.
+Standalone persistence and visualization service for CLIProxyAPI, with periodic data sync, SQLite storage, aggregate APIs, and a built-in dashboard for usage and statistics.
 
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.

--- a/README_CN.md
+++ b/README_CN.md
@@ -183,6 +183,10 @@ Shadow AI 是一款专为受限环境设计的 AI 辅助工具。提供无窗口
 
 上手即用的面向 CLIProxyAPI 跨平台配额查询工具，支持按账号展示 codex 5h/7d 配额窗口、按计划排序、状态着色及多账号汇总分析。
 
+### [CPA Usage Keeper](https://github.com/Willxup/cpa-usage-keeper)
+
+独立的 CLIProxyAPI 使用量持久化与可视化服务。定期拉取 CPA 数据，将标准化事件持久化到 SQLite，提供聚合 API，并内置用于使用量、价格、请求健康状态以及模型/API 统计的 Web 仪表盘。
+
 > [!NOTE]  
 > 如果你开发了基于 CLIProxyAPI 的项目，请提交一个 PR（拉取请求）将其添加到此列表中。
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -185,7 +185,7 @@ Shadow AI 是一款专为受限环境设计的 AI 辅助工具。提供无窗口
 
 ### [CPA Usage Keeper](https://github.com/Willxup/cpa-usage-keeper)
 
-独立的 CLIProxyAPI 使用量持久化与可视化服务。定期拉取 CPA 数据，将标准化事件持久化到 SQLite，提供聚合 API，并内置用于使用量、价格、请求健康状态以及模型/API 统计的 Web 仪表盘。
+独立的 CLIProxyAPI 使用量持久化与可视化服务，定期同步 CPA 数据，存储到 SQLite，提供聚合 API，并内置使用量分析与统计仪表盘。
 
 > [!NOTE]  
 > 如果你开发了基于 CLIProxyAPI 的项目，请提交一个 PR（拉取请求）将其添加到此列表中。

--- a/README_JA.md
+++ b/README_JA.md
@@ -182,6 +182,10 @@ CLIProxyAPIをネイティブGUIでラップしたクロスプラットフォー
 
 CLIProxyAPI向けのすぐに使えるクロスプラットフォームのクォータ確認ツール。アカウントごとの codex 5h/7d クォータ表示、プラン別ソート、ステータス色分け、複数アカウントの集計分析に対応。
 
+### [CPA Usage Keeper](https://github.com/Willxup/cpa-usage-keeper)
+
+CLIProxyAPI向けの独立した使用量永続化・可視化サービス。CPAデータを定期的に取得し、正規化されたイベントをSQLiteに保存、集計APIを提供し、使用量、料金、リクエスト健全性、モデル/API統計を確認できる組み込みWebダッシュボードを備えています。
+
 > [!NOTE]
 > CLIProxyAPIをベースにプロジェクトを開発した場合は、PRを送ってこのリストに追加してください。
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -184,7 +184,7 @@ CLIProxyAPI向けのすぐに使えるクロスプラットフォームのクォ
 
 ### [CPA Usage Keeper](https://github.com/Willxup/cpa-usage-keeper)
 
-CLIProxyAPI向けの独立した使用量永続化・可視化サービス。CPAデータを定期的に取得し、正規化されたイベントをSQLiteに保存、集計APIを提供し、使用量、料金、リクエスト健全性、モデル/API統計を確認できる組み込みWebダッシュボードを備えています。
+CLIProxyAPI向けの独立した使用量永続化・可視化サービス。CPAデータを定期同期してSQLiteに保存し、集計APIと、使用量や各種統計を確認できる組み込みダッシュボードを提供します。
 
 > [!NOTE]
 > CLIProxyAPIをベースにプロジェクトを開発した場合は、PRを送ってこのリストに追加してください。


### PR DESCRIPTION
## Summary 
- Add CPA Usage Keeper to the ecosystem/project list
- Include localized descriptions in English, Chinese, and Japanese READMEs