### PR TITLE
fix(gemini-cli): fix token usage statistics not being recorded

### DIFF
--- a/internal/runtime/executor/gemini_cli_executor.go
+++ b/internal/runtime/executor/gemini_cli_executor.go
@@ -423,6 +423,7 @@ func (e *GeminiCLIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyaut
 					reporter.PublishFailure(ctx)
 					out <- cliproxyexecutor.StreamChunk{Err: errScan}
 				}
+				reporter.EnsurePublished(ctx)
 				return
 			}
 

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -318,6 +318,12 @@ func ParseGeminiCLIUsage(data []byte) usage.Detail {
 		node = usageNode.Get("response.usage_metadata")
 	}
 	if !node.Exists() {
+		node = usageNode.Get("usageMetadata")
+	}
+	if !node.Exists() {
+		node = usageNode.Get("usage_metadata")
+	}
+	if !node.Exists() {
 		return usage.Detail{}
 	}
 	return parseGeminiFamilyUsageDetail(node)
@@ -356,6 +362,12 @@ func ParseGeminiCLIStreamUsage(line []byte) (usage.Detail, bool) {
 		return usage.Detail{}, false
 	}
 	node := gjson.GetBytes(payload, "response.usageMetadata")
+	if !node.Exists() {
+		node = gjson.GetBytes(payload, "response.usage_metadata")
+	}
+	if !node.Exists() {
+		node = gjson.GetBytes(payload, "usageMetadata")
+	}
 	if !node.Exists() {
 		node = gjson.GetBytes(payload, "usage_metadata")
 	}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -311,18 +311,25 @@ func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {
 	return detail
 }
 
+// findGeminiCLIUsageNode searches for the usageMetadata node in a parsed
+// Gemini CLI JSON result, checking both the response-wrapped and root-level
+// paths with camelCase and snake_case variants.
+func findGeminiCLIUsageNode(root gjson.Result) gjson.Result {
+	for _, path := range []string{
+		"response.usageMetadata",
+		"response.usage_metadata",
+		"usageMetadata",
+		"usage_metadata",
+	} {
+		if node := root.Get(path); node.Exists() {
+			return node
+		}
+	}
+	return gjson.Result{}
+}
+
 func ParseGeminiCLIUsage(data []byte) usage.Detail {
-	usageNode := gjson.ParseBytes(data)
-	node := usageNode.Get("response.usageMetadata")
-	if !node.Exists() {
-		node = usageNode.Get("response.usage_metadata")
-	}
-	if !node.Exists() {
-		node = usageNode.Get("usageMetadata")
-	}
-	if !node.Exists() {
-		node = usageNode.Get("usage_metadata")
-	}
+	node := findGeminiCLIUsageNode(gjson.ParseBytes(data))
 	if !node.Exists() {
 		return usage.Detail{}
 	}
@@ -361,16 +368,7 @@ func ParseGeminiCLIStreamUsage(line []byte) (usage.Detail, bool) {
 	if len(payload) == 0 || !gjson.ValidBytes(payload) {
 		return usage.Detail{}, false
 	}
-	node := gjson.GetBytes(payload, "response.usageMetadata")
-	if !node.Exists() {
-		node = gjson.GetBytes(payload, "response.usage_metadata")
-	}
-	if !node.Exists() {
-		node = gjson.GetBytes(payload, "usageMetadata")
-	}
-	if !node.Exists() {
-		node = gjson.GetBytes(payload, "usage_metadata")
-	}
+	node := findGeminiCLIUsageNode(gjson.ParseBytes(payload))
 	if !node.Exists() {
 		return usage.Detail{}, false
 	}


### PR DESCRIPTION
This PR fixes an issue where token usage statistics (input, output, reasoning, cached) were appearing as 0 in the management interface when using the gemini-cli provider, especially in streaming mode.

Key changes:
1. Updated `ParseGeminiCLIUsage` and `ParseGeminiCLIStreamUsage` to check for `usageMetadata` and `usage_metadata` at the root level, in addition to within the `response` object. 
2. Added a call to `EnsurePublished` in the gemini-cli streaming path to guarantee that at least a zero-usage record is published if no usage chunks are found, matching the behavior of other executors. This ensures that streaming requests are correctly counted even if token metadata is missing from the stream chunks.