### PR TITLE
Add Vertex prompt caching for Claude-compatible Gemini requests

### DIFF
--- a/internal/api/modules/amp/routes.go
+++ b/internal/api/modules/amp/routes.go
@@ -330,5 +330,7 @@ func (m *AmpModule) registerProviderAliases(engine *gin.Engine, baseHandler *han
 		v1betaAmp.GET("/models", geminiHandlers.GeminiModels)
 		v1betaAmp.POST("/models/*action", fallbackHandler.WrapHandler(geminiHandlers.GeminiHandler))
 		v1betaAmp.GET("/models/*action", geminiHandlers.GeminiGetHandler)
+		v1betaAmp.Any("/cachedContents", fallbackHandler.WrapHandler(geminiHandlers.GeminiCachedContentsHandler))
+		v1betaAmp.Any("/cachedContents/*name", fallbackHandler.WrapHandler(geminiHandlers.GeminiCachedContentsHandler))
 	}
 }

--- a/internal/api/modules/amp/routes_test.go
+++ b/internal/api/modules/amp/routes_test.go
@@ -211,6 +211,8 @@ func TestRegisterProviderAliases_V1BetaRoutes(t *testing.T) {
 	}{
 		{"/api/provider/google/v1beta/models", http.MethodGet},
 		{"/api/provider/google/v1beta/models/generateContent", http.MethodPost},
+		{"/api/provider/google/v1beta/cachedContents", http.MethodPost},
+		{"/api/provider/google/v1beta/cachedContents/test-cache", http.MethodGet},
 	}
 
 	for _, tc := range v1betaPaths {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -369,6 +369,8 @@ func (s *Server) setupRoutes() {
 		v1beta.GET("/models", geminiHandlers.GeminiModels)
 		v1beta.POST("/models/*action", geminiHandlers.GeminiHandler)
 		v1beta.GET("/models/*action", geminiHandlers.GeminiGetHandler)
+		v1beta.Any("/cachedContents", geminiHandlers.GeminiCachedContentsHandler)
+		v1beta.Any("/cachedContents/*name", geminiHandlers.GeminiCachedContentsHandler)
 	}
 
 	// Root endpoint

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,8 +18,53 @@ import (
 	internallogging "github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 )
+
+type cachedContentsCaptureExecutor struct {
+	provider string
+	url      string
+	method   string
+	body     string
+}
+
+func (e *cachedContentsCaptureExecutor) Identifier() string {
+	if e.provider != "" {
+		return e.provider
+	}
+	return "gemini"
+}
+
+func (e *cachedContentsCaptureExecutor) Execute(context.Context, *auth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &auth.Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (e *cachedContentsCaptureExecutor) ExecuteStream(context.Context, *auth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &auth.Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (e *cachedContentsCaptureExecutor) Refresh(_ context.Context, a *auth.Auth) (*auth.Auth, error) {
+	return a, nil
+}
+
+func (e *cachedContentsCaptureExecutor) CountTokens(context.Context, *auth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &auth.Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (e *cachedContentsCaptureExecutor) HttpRequest(_ context.Context, _ *auth.Auth, req *http.Request) (*http.Response, error) {
+	e.url = req.URL.String()
+	e.method = req.Method
+	if req.Body != nil {
+		data, _ := io.ReadAll(req.Body)
+		e.body = string(data)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBufferString(`{"name":"cachedContents/test-cache"}`)),
+	}, nil
+}
 
 func newTestServer(t *testing.T) *Server {
 	t.Helper()
@@ -147,6 +195,53 @@ func TestAmpProviderModelRoutes(t *testing.T) {
 				t.Fatalf("response body for %s missing %q: %s", tc.path, tc.wantContains, body)
 			}
 		})
+	}
+}
+
+func TestVertexCachedContentsRoutesProxyToVertexUpstream(t *testing.T) {
+	server := newTestServer(t)
+	exec := &cachedContentsCaptureExecutor{provider: "vertex"}
+	server.handlers.AuthManager.RegisterExecutor(exec)
+	if _, err := server.handlers.AuthManager.Register(context.Background(), &auth.Auth{
+		ID:       "vertex-test",
+		Provider: "vertex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{
+			"project_id":      "test-project",
+			"location":        "global",
+			"service_account": map[string]any{"project_id": "test-project", "client_email": "test@example.com", "private_key": "unused"},
+		},
+	}); err != nil {
+		t.Fatalf("register vertex auth: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/cachedContents", strings.NewReader(`{"model":"models/gemini-3-flash-preview","contents":[]}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: got %d want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if exec.url != "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/cachedContents" {
+		t.Fatalf("upstream url = %q", exec.url)
+	}
+	if !strings.Contains(exec.body, `"model":"projects/test-project/locations/global/publishers/google/models/gemini-3-flash-preview"`) {
+		t.Fatalf("upstream body missing vertex model resource: %s", exec.body)
+	}
+
+	reqGet := httptest.NewRequest(http.MethodGet, "/v1beta/cachedContents/test-cache", nil)
+	reqGet.Header.Set("Authorization", "Bearer test-key")
+	rrGet := httptest.NewRecorder()
+	server.engine.ServeHTTP(rrGet, reqGet)
+
+	if rrGet.Code != http.StatusOK {
+		t.Fatalf("GET status: got %d want %d; body=%s", rrGet.Code, http.StatusOK, rrGet.Body.String())
+	}
+	if exec.url != "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/cachedContents/test-cache" {
+		t.Fatalf("GET upstream url = %q", exec.url)
 	}
 }
 

--- a/internal/runtime/executor/gemini_vertex_cache_test.go
+++ b/internal/runtime/executor/gemini_vertex_cache_test.go
@@ -1,0 +1,56 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestVertexCacheCreateBodyUsesStablePromptFields(t *testing.T) {
+	body := []byte(`{
+		"model":"gemini-3-flash-preview",
+		"system_instruction":{"parts":[{"text":"system"}]},
+		"tools":[{"functionDeclarations":[{"name":"Read"}]}],
+		"toolConfig":{"functionCallingConfig":{"mode":"AUTO"}},
+		"contents":[{"role":"user","parts":[{"text":"dynamic"}]}]
+	}`)
+
+	createBody, ok := vertexCacheCreateBody("test-project", "global", "gemini-3-flash-preview", body)
+	if !ok {
+		t.Fatal("vertexCacheCreateBody returned ok=false")
+	}
+	if got := gjson.GetBytes(createBody, "model").String(); got != "projects/test-project/locations/global/publishers/google/models/gemini-3-flash-preview" {
+		t.Fatalf("model = %q", got)
+	}
+	if !gjson.GetBytes(createBody, "systemInstruction").Exists() {
+		t.Fatalf("systemInstruction missing: %s", string(createBody))
+	}
+	if !gjson.GetBytes(createBody, "tools").Exists() {
+		t.Fatalf("tools missing: %s", string(createBody))
+	}
+	if gjson.GetBytes(createBody, "contents").Exists() {
+		t.Fatalf("contents should not be cached: %s", string(createBody))
+	}
+}
+
+func TestApplyVertexCachedContentRemovesCachedPromptFields(t *testing.T) {
+	body := []byte(`{
+		"system_instruction":{"parts":[{"text":"system"}]},
+		"tools":[{"functionDeclarations":[{"name":"Read"}]}],
+		"toolConfig":{"functionCallingConfig":{"mode":"AUTO"}},
+		"contents":[{"role":"user","parts":[{"text":"dynamic"}]}]
+	}`)
+
+	out := applyVertexCachedContent(body, "projects/123/locations/global/cachedContents/cache-1")
+	if got := gjson.GetBytes(out, "cachedContent").String(); got != "projects/123/locations/global/cachedContents/cache-1" {
+		t.Fatalf("cachedContent = %q", got)
+	}
+	for _, path := range []string{"system_instruction", "tools", "toolConfig"} {
+		if gjson.GetBytes(out, path).Exists() {
+			t.Fatalf("%s should be removed: %s", path, string(out))
+		}
+	}
+	if !gjson.GetBytes(out, "contents").Exists() {
+		t.Fatalf("contents should remain: %s", string(out))
+	}
+}

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -7,11 +7,13 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	vertexauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/vertex"
@@ -31,8 +33,129 @@ import (
 
 const (
 	// vertexAPIVersion aligns with current public Vertex Generative AI API.
-	vertexAPIVersion = "v1"
+	vertexAPIVersion           = "v1"
+	vertexTranslatorContextKey = "cliproxy:upstream_provider"
+	vertexTranslatorProvider   = "vertex"
 )
+
+type vertexPromptCacheEntry struct {
+	name      string
+	expiresAt time.Time
+}
+
+var vertexPromptCaches sync.Map
+
+func vertexCacheModelResource(projectID, location, model string) string {
+	return fmt.Sprintf("projects/%s/locations/%s/publishers/google/models/%s", projectID, location, model)
+}
+
+func vertexPromptCacheKey(auth *cliproxyauth.Auth, projectID, location, model string, createBody []byte) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(projectID))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(location))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(model))
+	_, _ = h.Write([]byte{0})
+	if auth != nil {
+		_, _ = h.Write([]byte(auth.ID))
+		_, _ = h.Write([]byte{0})
+	}
+	_, _ = h.Write(createBody)
+	return fmt.Sprintf("%s/%s/%s/%x", projectID, location, model, h.Sum(nil))
+}
+
+func vertexCacheCreateBody(projectID, location, model string, body []byte) ([]byte, bool) {
+	out := []byte(`{"ttl":"3600s"}`)
+	out, _ = sjson.SetBytes(out, "model", vertexCacheModelResource(projectID, location, model))
+	hasCacheable := false
+	if v := gjson.GetBytes(body, "system_instruction"); v.Exists() {
+		out, _ = sjson.SetRawBytes(out, "systemInstruction", []byte(v.Raw))
+		hasCacheable = true
+	}
+	if v := gjson.GetBytes(body, "tools"); v.Exists() {
+		out, _ = sjson.SetRawBytes(out, "tools", []byte(v.Raw))
+		hasCacheable = true
+	}
+	if v := gjson.GetBytes(body, "toolConfig"); v.Exists() {
+		out, _ = sjson.SetRawBytes(out, "toolConfig", []byte(v.Raw))
+		hasCacheable = true
+	}
+	return out, hasCacheable
+}
+
+func applyVertexCachedContent(body []byte, cacheName string) []byte {
+	if strings.TrimSpace(cacheName) == "" {
+		return body
+	}
+	body, _ = sjson.SetBytes(body, "cachedContent", cacheName)
+	body, _ = sjson.DeleteBytes(body, "system_instruction")
+	body, _ = sjson.DeleteBytes(body, "tools")
+	body, _ = sjson.DeleteBytes(body, "toolConfig")
+	return body
+}
+
+func (e *GeminiVertexExecutor) maybeApplyNativePromptCache(ctx context.Context, auth *cliproxyauth.Auth, body []byte, source sdktranslator.Format, projectID, location, model, token string) []byte {
+	if source.String() != "claude" || isImagenModel(model) || gjson.GetBytes(body, "cachedContent").Exists() {
+		return body
+	}
+	createBody, ok := vertexCacheCreateBody(projectID, location, model, body)
+	if !ok {
+		return body
+	}
+	key := vertexPromptCacheKey(auth, projectID, location, model, createBody)
+	if cached, ok := vertexPromptCaches.Load(key); ok {
+		if entry, okEntry := cached.(vertexPromptCacheEntry); okEntry && entry.name != "" && time.Now().Before(entry.expiresAt) {
+			return applyVertexCachedContent(body, entry.name)
+		}
+		vertexPromptCaches.Delete(key)
+	}
+	if strings.TrimSpace(token) == "" {
+		return body
+	}
+
+	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/cachedContents", vertexBaseURL(location), vertexAPIVersion, projectID, location)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(createBody))
+	if err != nil {
+		helps.LogWithRequestID(ctx).Debugf("vertex native cache: create request error: %v", err)
+		return body
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	applyGeminiHeaders(httpReq, auth)
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.LogWithRequestID(ctx).Debugf("vertex native cache: create error: %v", err)
+		return body
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("vertex native cache: close response body error: %v", errClose)
+		}
+	}()
+	data, errRead := io.ReadAll(httpResp.Body)
+	if errRead != nil {
+		helps.LogWithRequestID(ctx).Debugf("vertex native cache: read response error: %v", errRead)
+		return body
+	}
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		helps.LogWithRequestID(ctx).Debugf("vertex native cache: create skipped, status=%d body=%s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
+		return body
+	}
+	name := strings.TrimSpace(gjson.GetBytes(data, "name").String())
+	if name == "" {
+		return body
+	}
+	vertexPromptCaches.Store(key, vertexPromptCacheEntry{name: name, expiresAt: time.Now().Add(55 * time.Minute)})
+	return applyVertexCachedContent(body, name)
+}
 
 // isImagenModel checks if the model name is an Imagen image generation model.
 // Imagen models use the :predict action instead of :generateContent.
@@ -307,6 +430,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 	defer reporter.TrackFailure(ctx, &err)
 
 	var body []byte
+	sourceFormat := opts.SourceFormat
 
 	// Handle Imagen models with special request format
 	if isImagenModel(baseModel) {
@@ -317,7 +441,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		body = imagenBody
 	} else {
 		// Standard Gemini translation flow
-		from := opts.SourceFormat
+		from := sourceFormat
 		to := sdktranslator.FromString("gemini")
 
 		originalPayloadSource := req.Payload
@@ -345,6 +469,16 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 			action = "countTokens"
 		}
 	}
+	token := ""
+	if tokenValue, errTok := vertexAccessToken(ctx, e.cfg, auth, saJSON); errTok == nil && tokenValue != "" {
+		token = tokenValue
+	} else if errTok != nil {
+		log.Errorf("vertex executor: access token error: %v", errTok)
+		return resp, statusErr{code: 500, msg: "internal server error"}
+	}
+	if action == "generateContent" {
+		body = e.maybeApplyNativePromptCache(ctx, auth, body, sourceFormat, projectID, location, baseModel, token)
+	}
 	baseURL := vertexBaseURL(location)
 	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, projectID, location, baseModel, action)
 	if opts.Alt != "" && action != "countTokens" {
@@ -357,11 +491,8 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		return resp, errNewReq
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	if token, errTok := vertexAccessToken(ctx, e.cfg, auth, saJSON); errTok == nil && token != "" {
+	if token != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+token)
-	} else if errTok != nil {
-		log.Errorf("vertex executor: access token error: %v", errTok)
-		return resp, statusErr{code: 500, msg: "internal server error"}
 	}
 	applyGeminiHeaders(httpReq, auth)
 	var attrs map[string]string
@@ -425,7 +556,8 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("gemini")
 	var param any
-	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, body, data, &param)
+	translateCtx := context.WithValue(ctx, vertexTranslatorContextKey, vertexTranslatorProvider)
+	out := sdktranslator.TranslateNonStream(translateCtx, to, from, req.Model, opts.OriginalRequest, body, data, &param)
 	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 	return resp, nil
 }
@@ -535,7 +667,8 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 	reporter.Publish(ctx, helps.ParseGeminiUsage(data))
 	var param any
-	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, body, data, &param)
+	translateCtx := context.WithValue(ctx, vertexTranslatorContextKey, vertexTranslatorProvider)
+	out := sdktranslator.TranslateNonStream(translateCtx, to, from, req.Model, opts.OriginalRequest, body, data, &param)
 	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 	return resp, nil
 }
@@ -569,6 +702,14 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 
 	action := getVertexAction(baseModel, true)
+	token := ""
+	if tokenValue, errTok := vertexAccessToken(ctx, e.cfg, auth, saJSON); errTok == nil && tokenValue != "" {
+		token = tokenValue
+	} else if errTok != nil {
+		log.Errorf("vertex executor: access token error: %v", errTok)
+		return nil, statusErr{code: 500, msg: "internal server error"}
+	}
+	body = e.maybeApplyNativePromptCache(ctx, auth, body, from, projectID, location, baseModel, token)
 	baseURL := vertexBaseURL(location)
 	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, projectID, location, baseModel, action)
 	// Imagen models don't support streaming, skip SSE params
@@ -586,11 +727,8 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 		return nil, errNewReq
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	if token, errTok := vertexAccessToken(ctx, e.cfg, auth, saJSON); errTok == nil && token != "" {
+	if token != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+token)
-	} else if errTok != nil {
-		log.Errorf("vertex executor: access token error: %v", errTok)
-		return nil, statusErr{code: 500, msg: "internal server error"}
 	}
 	applyGeminiHeaders(httpReq, auth)
 	var attrs map[string]string
@@ -648,15 +786,18 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			if detail, ok := helps.ParseGeminiStreamUsage(line); ok {
+			filtered := helps.FilterSSEUsageMetadata(line)
+			if detail, ok := helps.ParseVertexGeminiStreamUsage(filtered); ok {
 				reporter.Publish(ctx, detail)
 			}
-			lines := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, body, bytes.Clone(line), &param)
+			translateCtx := context.WithValue(ctx, vertexTranslatorContextKey, vertexTranslatorProvider)
+			lines := sdktranslator.TranslateStream(translateCtx, to, from, req.Model, opts.OriginalRequest, body, bytes.Clone(filtered), &param)
 			for i := range lines {
 				out <- cliproxyexecutor.StreamChunk{Payload: lines[i]}
 			}
 		}
-		lines := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, body, []byte("[DONE]"), &param)
+		translateCtx := context.WithValue(ctx, vertexTranslatorContextKey, vertexTranslatorProvider)
+		lines := sdktranslator.TranslateStream(translateCtx, to, from, req.Model, opts.OriginalRequest, body, []byte("[DONE]"), &param)
 		for i := range lines {
 			out <- cliproxyexecutor.StreamChunk{Payload: lines[i]}
 		}
@@ -665,6 +806,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 			reporter.PublishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
 		}
+		reporter.EnsurePublished(ctx)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }
@@ -777,15 +919,18 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			if detail, ok := helps.ParseGeminiStreamUsage(line); ok {
+			filtered := helps.FilterSSEUsageMetadata(line)
+			if detail, ok := helps.ParseVertexGeminiStreamUsage(filtered); ok {
 				reporter.Publish(ctx, detail)
 			}
-			lines := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, body, bytes.Clone(line), &param)
+			translateCtx := context.WithValue(ctx, vertexTranslatorContextKey, vertexTranslatorProvider)
+			lines := sdktranslator.TranslateStream(translateCtx, to, from, req.Model, opts.OriginalRequest, body, bytes.Clone(filtered), &param)
 			for i := range lines {
 				out <- cliproxyexecutor.StreamChunk{Payload: lines[i]}
 			}
 		}
-		lines := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, body, []byte("[DONE]"), &param)
+		translateCtx := context.WithValue(ctx, vertexTranslatorContextKey, vertexTranslatorProvider)
+		lines := sdktranslator.TranslateStream(translateCtx, to, from, req.Model, opts.OriginalRequest, body, []byte("[DONE]"), &param)
 		for i := range lines {
 			out <- cliproxyexecutor.StreamChunk{Payload: lines[i]}
 		}
@@ -794,6 +939,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 			reporter.PublishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
 		}
+		reporter.EnsurePublished(ctx)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -311,6 +311,14 @@ func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {
 	return detail
 }
 
+func hasUsageTokenSignal(detail usage.Detail) bool {
+	return detail.InputTokens != 0 ||
+		detail.OutputTokens != 0 ||
+		detail.ReasoningTokens != 0 ||
+		detail.CachedTokens != 0 ||
+		detail.TotalTokens != 0
+}
+
 func ParseGeminiCLIUsage(data []byte) usage.Detail {
 	usageNode := gjson.ParseBytes(data)
 	node := usageNode.Get("response.usageMetadata")
@@ -348,6 +356,28 @@ func ParseGeminiStreamUsage(line []byte) (usage.Detail, bool) {
 		return usage.Detail{}, false
 	}
 	return parseGeminiFamilyUsageDetail(node), true
+}
+
+func ParseVertexGeminiStreamUsage(line []byte) (usage.Detail, bool) {
+	payload := jsonPayload(line)
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return usage.Detail{}, false
+	}
+	node := gjson.GetBytes(payload, "usageMetadata")
+	if !node.Exists() {
+		node = gjson.GetBytes(payload, "response.usageMetadata")
+	}
+	if !node.Exists() {
+		node = gjson.GetBytes(payload, "usage_metadata")
+	}
+	if !node.Exists() {
+		return usage.Detail{}, false
+	}
+	detail := parseGeminiFamilyUsageDetail(node)
+	if !hasUsageTokenSignal(detail) {
+		return usage.Detail{}, false
+	}
+	return detail, true
 }
 
 func ParseGeminiCLIStreamUsage(line []byte) (usage.Detail, bool) {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -47,6 +47,35 @@ func TestParseOpenAIUsageResponses(t *testing.T) {
 	}
 }
 
+func TestParseVertexGeminiStreamUsageIgnoresEmptyMetadata(t *testing.T) {
+	if detail, ok := ParseVertexGeminiStreamUsage([]byte(`data: {"usageMetadata":{"trafficType":"ON_DEMAND"}}`)); ok {
+		t.Fatalf("ParseVertexGeminiStreamUsage returned %#v, want no usage", detail)
+	}
+}
+
+func TestParseVertexGeminiStreamUsageWrappedMetadata(t *testing.T) {
+	line := []byte(`data: {"response":{"usageMetadata":{"promptTokenCount":11,"candidatesTokenCount":2,"thoughtsTokenCount":3,"totalTokenCount":16,"cachedContentTokenCount":7}}}`)
+	detail, ok := ParseVertexGeminiStreamUsage(line)
+	if !ok {
+		t.Fatal("ParseVertexGeminiStreamUsage returned ok=false")
+	}
+	if detail.InputTokens != 11 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 11)
+	}
+	if detail.OutputTokens != 2 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 2)
+	}
+	if detail.ReasoningTokens != 3 {
+		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 3)
+	}
+	if detail.TotalTokens != 16 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 16)
+	}
+	if detail.CachedTokens != 7 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 7)
+	}
+}
+
 func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 	reporter := &UsageReporter{
 		provider:    "openai",

--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -34,6 +34,26 @@ type Params struct {
 // toolUseIDCounter provides a process-wide unique counter for tool use identifiers.
 var toolUseIDCounter uint64
 
+func vertexCacheUsageEnabled(ctx context.Context) bool {
+	v, _ := ctx.Value("cliproxy:upstream_provider").(string)
+	return v == "vertex"
+}
+
+func claudeInputAndCacheUsage(ctx context.Context, usageResult gjson.Result) (inputTokens int64, cacheReadTokens int64) {
+	inputTokens = usageResult.Get("promptTokenCount").Int()
+	if !vertexCacheUsageEnabled(ctx) {
+		return inputTokens, 0
+	}
+	cacheReadTokens = usageResult.Get("cachedContentTokenCount").Int()
+	if cacheReadTokens > 0 {
+		inputTokens -= cacheReadTokens
+		if inputTokens < 0 {
+			inputTokens = 0
+		}
+	}
+	return inputTokens, cacheReadTokens
+}
+
 // ConvertGeminiResponseToClaude performs sophisticated streaming response format conversion.
 // This function implements a complex state machine that translates backend client responses
 // into Claude-compatible Server-Sent Events (SSE) format. It manages different response types
@@ -50,7 +70,7 @@ var toolUseIDCounter uint64
 //
 // Returns:
 //   - [][]byte: A slice of bytes, each containing a Claude-compatible SSE payload.
-func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) [][]byte {
+func ConvertGeminiResponseToClaude(ctx context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) [][]byte {
 	if *param == nil {
 		*param = &Params{
 			IsGlAPIKey:       false,
@@ -238,7 +258,11 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 
 				thoughtsTokenCount := usageResult.Get("thoughtsTokenCount").Int()
 				template, _ = sjson.SetBytes(template, "usage.output_tokens", candidatesTokenCountResult.Int()+thoughtsTokenCount)
-				template, _ = sjson.SetBytes(template, "usage.input_tokens", usageResult.Get("promptTokenCount").Int())
+				inputTokens, cacheReadTokens := claudeInputAndCacheUsage(ctx, usageResult)
+				template, _ = sjson.SetBytes(template, "usage.input_tokens", inputTokens)
+				if cacheReadTokens > 0 {
+					template, _ = sjson.SetBytes(template, "usage.cache_read_input_tokens", cacheReadTokens)
+				}
 
 				appendEvent("message_delta", string(template))
 			}
@@ -258,7 +282,7 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 //
 // Returns:
 //   - []byte: A Claude-compatible JSON response.
-func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, _ *any) []byte {
+func ConvertGeminiResponseToClaudeNonStream(ctx context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, _ *any) []byte {
 	_ = requestRawJSON
 
 	root := gjson.ParseBytes(rawJSON)
@@ -269,10 +293,13 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 	out, _ = sjson.SetBytes(out, "id", root.Get("responseId").String())
 	out, _ = sjson.SetBytes(out, "model", root.Get("modelVersion").String())
 
-	inputTokens := root.Get("usageMetadata.promptTokenCount").Int()
+	inputTokens, cacheReadTokens := claudeInputAndCacheUsage(ctx, root.Get("usageMetadata"))
 	outputTokens := root.Get("usageMetadata.candidatesTokenCount").Int() + root.Get("usageMetadata.thoughtsTokenCount").Int()
 	out, _ = sjson.SetBytes(out, "usage.input_tokens", inputTokens)
 	out, _ = sjson.SetBytes(out, "usage.output_tokens", outputTokens)
+	if cacheReadTokens > 0 {
+		out, _ = sjson.SetBytes(out, "usage.cache_read_input_tokens", cacheReadTokens)
+	}
 
 	parts := root.Get("candidates.0.content.parts")
 	textBuilder := strings.Builder{}

--- a/internal/translator/gemini/claude/gemini_claude_response_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_response_test.go
@@ -1,0 +1,67 @@
+package claude
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertGeminiResponseToClaudeStreamReportsCacheReadTokens(t *testing.T) {
+	var param any
+	ctx := context.WithValue(context.Background(), "cliproxy:upstream_provider", "vertex")
+	chunks := ConvertGeminiResponseToClaude(
+		ctx,
+		"gemini-3-flash-preview",
+		[]byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+		nil,
+		[]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":105,"candidatesTokenCount":7,"totalTokenCount":112,"cachedContentTokenCount":100},"modelVersion":"gemini-3-flash-preview","responseId":"resp-1"}`),
+		&param,
+	)
+	out := string(chunks[0])
+	if !strings.Contains(out, `"cache_read_input_tokens":100`) {
+		t.Fatalf("cache_read_input_tokens missing: %s", out)
+	}
+	if !strings.Contains(out, `"input_tokens":5`) {
+		t.Fatalf("input_tokens should exclude cached tokens: %s", out)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStreamReportsCacheReadTokens(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy:upstream_provider", "vertex")
+	out := ConvertGeminiResponseToClaudeNonStream(
+		ctx,
+		"gemini-3-flash-preview",
+		[]byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+		nil,
+		[]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":105,"candidatesTokenCount":7,"totalTokenCount":112,"cachedContentTokenCount":100},"modelVersion":"gemini-3-flash-preview","responseId":"resp-1"}`),
+		nil,
+	)
+	usage := gjson.GetBytes(out, "usage")
+	if got := usage.Get("cache_read_input_tokens").Int(); got != 100 {
+		t.Fatalf("cache_read_input_tokens = %d, want 100; output=%s", got, string(out))
+	}
+	if got := usage.Get("input_tokens").Int(); got != 5 {
+		t.Fatalf("input_tokens = %d, want 5; output=%s", got, string(out))
+	}
+}
+
+func TestConvertGeminiResponseToClaudeStreamLeavesNonVertexUsageUnchanged(t *testing.T) {
+	var param any
+	chunks := ConvertGeminiResponseToClaude(
+		context.Background(),
+		"gemini-3-flash-preview",
+		[]byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+		nil,
+		[]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":105,"candidatesTokenCount":7,"totalTokenCount":112,"cachedContentTokenCount":100},"modelVersion":"gemini-3-flash-preview","responseId":"resp-1"}`),
+		&param,
+	)
+	out := string(chunks[0])
+	if strings.Contains(out, "cache_read_input_tokens") {
+		t.Fatalf("non-vertex response should not include cache_read_input_tokens: %s", out)
+	}
+	if !strings.Contains(out, `"input_tokens":105`) {
+		t.Fatalf("non-vertex input_tokens should remain promptTokenCount: %s", out)
+	}
+}

--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -6,10 +6,13 @@
 package gemini
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -17,12 +20,17 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 // GeminiAPIHandler contains the handlers for Gemini API endpoints.
 // It holds a pool of clients to interact with the backend service.
 type GeminiAPIHandler struct {
 	*handlers.BaseAPIHandler
+	cacheAuthMu sync.RWMutex
+	cacheAuthID map[string]string
 }
 
 // NewGeminiAPIHandler creates a new Gemini API handlers instance.
@@ -30,6 +38,7 @@ type GeminiAPIHandler struct {
 func NewGeminiAPIHandler(apiHandlers *handlers.BaseAPIHandler) *GeminiAPIHandler {
 	return &GeminiAPIHandler{
 		BaseAPIHandler: apiHandlers,
+		cacheAuthID:    make(map[string]string),
 	}
 }
 
@@ -161,6 +170,251 @@ func (h *GeminiAPIHandler) GeminiHandler(c *gin.Context) {
 	case "countTokens":
 		h.handleCountTokens(c, action[0], rawJSON)
 	}
+}
+
+// GeminiCachedContentsHandler proxies Gemini native cachedContents operations.
+// Cached content is not model-scoped in the URL, so this path cannot use the
+// normal model translation executor that handles generateContent/countTokens.
+func (h *GeminiAPIHandler) GeminiCachedContentsHandler(c *gin.Context) {
+	if h.AuthManager == nil {
+		c.JSON(http.StatusServiceUnavailable, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{Message: "Gemini auth manager is unavailable", Type: "server_error"},
+		})
+		return
+	}
+
+	rawJSON, errRead := c.GetRawData()
+	if errRead != nil {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{Message: fmt.Sprintf("Invalid request body: %v", errRead), Type: "invalid_request_error"},
+		})
+		return
+	}
+
+	cacheName := geminiCachedContentNameFromPath(c.Param("name"))
+	if cacheName == "" {
+		cacheName = strings.TrimSpace(gjson.GetBytes(rawJSON, "name").String())
+	}
+	auth, status, msg := h.selectGeminiCachedContentAuth(cacheName)
+	if auth == nil {
+		c.JSON(status, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{Message: msg, Type: "invalid_request_error"},
+		})
+		return
+	}
+
+	rawJSON = normalizeGeminiCachedContentBodyForAuth(rawJSON, auth)
+	targetURL := h.geminiCachedContentsURL(auth, cacheName, c.Request.URL.RawQuery)
+	var body io.Reader
+	if len(rawJSON) > 0 {
+		body = bytes.NewReader(rawJSON)
+	}
+	upstreamReq, errReq := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, targetURL, body)
+	if errReq != nil {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{Message: fmt.Sprintf("Invalid request: %v", errReq), Type: "invalid_request_error"},
+		})
+		return
+	}
+	copyGeminiCachedContentRequestHeaders(upstreamReq.Header, c.Request.Header)
+	if upstreamReq.Header.Get("Content-Type") == "" && len(rawJSON) > 0 {
+		upstreamReq.Header.Set("Content-Type", "application/json")
+	}
+
+	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	upstreamResp, errDo := h.AuthManager.HttpRequest(cliCtx, auth, upstreamReq)
+	if errDo != nil {
+		cliCancel(errDo)
+		c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{Message: errDo.Error(), Type: "server_error"},
+		})
+		return
+	}
+	defer upstreamResp.Body.Close()
+
+	data, errBody := io.ReadAll(upstreamResp.Body)
+	if errBody != nil {
+		cliCancel(errBody)
+		c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{Message: errBody.Error(), Type: "server_error"},
+		})
+		return
+	}
+	if upstreamResp.StatusCode >= 200 && upstreamResp.StatusCode < 300 && c.Request.Method == http.MethodPost {
+		if name := strings.TrimSpace(gjson.GetBytes(data, "name").String()); name != "" {
+			h.rememberCachedContentAuth(name, auth.ID)
+		}
+	}
+
+	if filtered := handlers.FilterUpstreamHeaders(upstreamResp.Header); filtered != nil {
+		handlers.WriteUpstreamHeaders(c.Writer.Header(), filtered)
+	}
+	if c.Writer.Header().Get("Content-Type") == "" {
+		c.Header("Content-Type", "application/json")
+	}
+	c.Status(upstreamResp.StatusCode)
+	_, _ = c.Writer.Write(data)
+	cliCancel(data)
+}
+
+func copyGeminiCachedContentRequestHeaders(dst, src http.Header) {
+	for _, key := range []string{
+		"Content-Type",
+		"Accept",
+		"X-Goog-Api-Client",
+		"X-Goog-Request-Params",
+		"User-Agent",
+	} {
+		if values, ok := src[key]; ok {
+			for _, value := range values {
+				dst.Add(key, value)
+			}
+		}
+	}
+}
+
+func geminiCachedContentNameFromPath(raw string) string {
+	raw = strings.TrimSpace(strings.TrimPrefix(raw, "/"))
+	if raw == "" {
+		return ""
+	}
+	if strings.HasPrefix(raw, "cachedContents/") {
+		return raw
+	}
+	return "cachedContents/" + raw
+}
+
+func (h *GeminiAPIHandler) rememberCachedContentAuth(name, authID string) {
+	name = strings.TrimSpace(name)
+	authID = strings.TrimSpace(authID)
+	if name == "" || authID == "" {
+		return
+	}
+	h.cacheAuthMu.Lock()
+	h.cacheAuthID[name] = authID
+	h.cacheAuthMu.Unlock()
+}
+
+func (h *GeminiAPIHandler) rememberedCachedContentAuth(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	h.cacheAuthMu.RLock()
+	authID := h.cacheAuthID[name]
+	h.cacheAuthMu.RUnlock()
+	return authID
+}
+
+func (h *GeminiAPIHandler) selectGeminiCachedContentAuth(cacheName string) (*cliproxyauth.Auth, int, string) {
+	if authID := h.rememberedCachedContentAuth(cacheName); authID != "" {
+		if auth, ok := h.AuthManager.GetByID(authID); ok && geminiCachedContentAuthUsable(auth) {
+			return auth, 0, ""
+		}
+	}
+
+	var vertexFallback *cliproxyauth.Auth
+	for _, auth := range h.AuthManager.List() {
+		if !geminiCachedContentAuthUsable(auth) {
+			continue
+		}
+		if !vertexCachedContentAuthHasLocation(auth) {
+			continue
+		}
+		if auth.Status == cliproxyauth.StatusActive {
+			return auth, 0, ""
+		}
+		if vertexFallback == nil {
+			vertexFallback = auth
+		}
+	}
+	if vertexFallback != nil {
+		return vertexFallback, 0, ""
+	}
+	return nil, http.StatusServiceUnavailable, "No available Vertex credential for cachedContents"
+}
+
+func geminiCachedContentAuthUsable(auth *cliproxyauth.Auth) bool {
+	return auth != nil &&
+		geminiCachedContentAuthProvider(auth) == "vertex" &&
+		!auth.Disabled &&
+		auth.Status != cliproxyauth.StatusDisabled
+}
+
+func geminiCachedContentAuthProvider(auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(auth.Provider))
+}
+
+func vertexCachedContentAuthHasLocation(auth *cliproxyauth.Auth) bool {
+	projectID, location := vertexCachedContentProjectLocation(auth)
+	return projectID != "" && location != ""
+}
+
+func vertexCachedContentProjectLocation(auth *cliproxyauth.Auth) (string, string) {
+	if auth == nil || auth.Metadata == nil {
+		return "", ""
+	}
+	projectID, _ := auth.Metadata["project_id"].(string)
+	if strings.TrimSpace(projectID) == "" {
+		projectID, _ = auth.Metadata["project"].(string)
+	}
+	location, _ := auth.Metadata["location"].(string)
+	if strings.TrimSpace(location) == "" {
+		location = "us-central1"
+	}
+	return strings.TrimSpace(projectID), strings.TrimSpace(location)
+}
+
+func (h *GeminiAPIHandler) geminiCachedContentsURL(auth *cliproxyauth.Auth, cacheName, rawQuery string) string {
+	projectID, location := vertexCachedContentProjectLocation(auth)
+	baseURL := vertexCachedContentBaseURL(location)
+	path := fmt.Sprintf("/v1/projects/%s/locations/%s/cachedContents", projectID, location)
+	if cacheName != "" {
+		if strings.HasPrefix(cacheName, "projects/") {
+			path = "/v1/" + cacheName
+		} else {
+			path += "/" + strings.TrimPrefix(cacheName, "cachedContents/")
+		}
+	}
+	if rawQuery != "" {
+		return baseURL + path + "?" + rawQuery
+	}
+	return baseURL + path
+}
+
+func vertexCachedContentBaseURL(location string) string {
+	location = strings.TrimSpace(location)
+	if location == "" {
+		location = "us-central1"
+	}
+	if location == "global" {
+		return "https://aiplatform.googleapis.com"
+	}
+	return fmt.Sprintf("https://%s-aiplatform.googleapis.com", location)
+}
+
+func normalizeGeminiCachedContentBodyForAuth(rawJSON []byte, auth *cliproxyauth.Auth) []byte {
+	if len(rawJSON) == 0 || geminiCachedContentAuthProvider(auth) != "vertex" {
+		return rawJSON
+	}
+	model := strings.TrimSpace(gjson.GetBytes(rawJSON, "model").String())
+	if model == "" || strings.HasPrefix(model, "projects/") {
+		return rawJSON
+	}
+	projectID, location := vertexCachedContentProjectLocation(auth)
+	if projectID == "" || location == "" {
+		return rawJSON
+	}
+	model = strings.TrimPrefix(model, "models/")
+	model = fmt.Sprintf("projects/%s/locations/%s/publishers/google/models/%s", projectID, location, model)
+	out, err := sjson.SetBytes(rawJSON, "model", model)
+	if err != nil {
+		return rawJSON
+	}
+	return out
 }
 
 // handleStreamGenerateContent handles streaming content generation requests for Gemini models.


### PR DESCRIPTION
## Summary

- add Vertex native `cachedContents` proxy routes for `/v1beta/cachedContents` and the Amp Google provider alias
- add automatic Vertex prompt cache creation/reuse for Claude-compatible requests translated to Gemini
- report Vertex cache reads back to Claude-compatible clients as `cache_read_input_tokens`, with `input_tokens` excluding cached prompt tokens
- keep the new stream usage parser and Claude cache accounting scoped to Vertex so the regular Gemini path remains unchanged

## Root Cause

Claude-compatible Agent requests were translated to Gemini/Vertex generateContent calls, but Anthropic `cache_control` hints were not bridged to Vertex native context caching. Separately, Vertex stream responses can carry empty or wrapped `usageMetadata`; the previous shared Gemini parser could publish an empty usage record before the terminal usage chunk. Finally, Gemini `cachedContentTokenCount` was not mapped back to Claude `cache_read_input_tokens`, so Agent clients could not see cache hits even when Vertex returned them.

## Implementation Notes

- For Vertex service-account requests, stable prompt fields (`system_instruction`, `tools`, `toolConfig`) are used to create a Vertex cachedContent resource with a 1 hour TTL.
- The generated request then references `cachedContent` and removes the cached prompt fields from the live request to avoid duplicating context.
- Cache reuse is keyed by the actual Vertex cache create body plus project/location/model/auth, avoiding repeated cache creation for identical stable prompts.
- The `/v1beta/cachedContents` proxy is Vertex-only and normalizes `models/<model>` into the full Vertex publisher model resource.
- Claude-compatible usage mapping is gated by a Vertex context marker: `input_tokens = promptTokenCount - cachedContentTokenCount`, `cache_read_input_tokens = cachedContentTokenCount`.

## Validation

- `go test ./internal/translator/gemini/claude ./internal/runtime/executor/helps ./internal/runtime/executor ./internal/api ./internal/api/modules/amp ./sdk/api/handlers/gemini`

Manual Vertex validation against a live Vertex service-account credential:

```text
5 identical /v1/messages?beta=true Agent requests
cachedContents before: 8
cachedContents after: 9
new Vertex cache: projects/710749625912/locations/global/cachedContents/6999339392896598016
new cache totalTokenCount: 40902

round1 usage: input_tokens=20, output_tokens=588, cache_read_input_tokens=40902
round2 usage: input_tokens=20, output_tokens=212, cache_read_input_tokens=40902
round3 usage: input_tokens=20, output_tokens=109, cache_read_input_tokens=40902
round4 usage: input_tokens=20, output_tokens=223, cache_read_input_tokens=40902
round5 usage: input_tokens=20, output_tokens=183, cache_read_input_tokens=40902
```

This confirms the cache resource is created by Vertex, later requests reuse the same resource without creating additional caches, and the Claude-compatible Agent response receives the cache-read token count returned by Vertex.
