### PR TITLE
Add thinking intensity to usage request details

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1886,6 +1886,8 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 		}
 	}
 
+	helps.CaptureUsageThinkingFromRequest(ctx, payload)
+
 	useAntigravitySchema := strings.Contains(modelName, "claude") || strings.Contains(modelName, "gemini-3-pro") || strings.Contains(modelName, "gemini-3.1-pro")
 	var (
 		bodyReader io.Reader

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -88,6 +92,42 @@ func TestAntigravityBuildRequest_SkipsSchemaSanitizationWithEmptyToolsArray(t *t
 	}`))
 
 	assertNonSchemaRequestPreserved(t, body)
+}
+
+func TestAntigravityBuildRequest_CapturesThinkingWhenRequestLogDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+
+	executor := &AntigravityExecutor{cfg: &config.Config{}}
+	auth := &cliproxyauth.Auth{}
+	payload := []byte(`{
+		"request": {
+			"contents": [
+				{"role": "user", "parts": [{"text": "hello"}]}
+			],
+			"generationConfig": {
+				"thinkingConfig": {
+					"thinkingBudget": 8192
+				}
+			}
+		}
+	}`)
+
+	if _, err := executor.buildRequest(ctx, auth, "token", "gemini-3.1-flash-image", payload, false, "", "https://example.com"); err != nil {
+		t.Fatalf("buildRequest error: %v", err)
+	}
+
+	thinking := helps.UsageThinkingFromContext(ctx)
+	if thinking == nil {
+		t.Fatal("thinking metadata is nil, want captured metadata")
+	}
+	if thinking.Intensity != "medium" {
+		t.Fatalf("thinking intensity = %q, want medium", thinking.Intensity)
+	}
+	if thinking.Budget != 8192 {
+		t.Fatalf("thinking budget = %d, want 8192", thinking.Budget)
+	}
 }
 
 func assertNonSchemaRequestPreserved(t *testing.T, body map[string]any) {

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -24,6 +24,7 @@ const (
 	apiRequestKey           = "API_REQUEST"
 	apiResponseKey          = "API_RESPONSE"
 	apiWebsocketTimelineKey = "API_WEBSOCKET_TIMELINE"
+	usageThinkingKey        = "USAGE_THINKING"
 	creditsUsedKey          = "__antigravity_credits_used__"
 )
 
@@ -55,6 +56,7 @@ type upstreamAttempt struct {
 
 // RecordAPIRequest stores the upstream request metadata in Gin context for request logging.
 func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequestLog) {
+	CaptureUsageThinkingFromRequest(ctx, info.Body)
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}
@@ -195,6 +197,7 @@ func AppendAPIResponseChunk(ctx context.Context, cfg *config.Config, chunk []byt
 
 // RecordAPIWebsocketRequest stores an upstream websocket request event in Gin context.
 func RecordAPIWebsocketRequest(ctx context.Context, cfg *config.Config, info UpstreamRequestLog) {
+	CaptureUsageThinkingFromRequest(ctx, info.Body)
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	"github.com/tidwall/gjson"
@@ -24,6 +25,7 @@ type UsageReporter struct {
 	apiKey      string
 	source      string
 	requestedAt time.Time
+	thinking    *usage.Thinking
 	once        sync.Once
 }
 
@@ -72,6 +74,7 @@ func (r *UsageReporter) publishWithOutcome(ctx context.Context, detail usage.Det
 		}
 	}
 	r.once.Do(func() {
+		r.captureThinkingFromContext(ctx)
 		usage.PublishRecord(ctx, r.buildRecord(detail, failed))
 	})
 }
@@ -85,6 +88,7 @@ func (r *UsageReporter) EnsurePublished(ctx context.Context) {
 		return
 	}
 	r.once.Do(func() {
+		r.captureThinkingFromContext(ctx)
 		usage.PublishRecord(ctx, r.buildRecord(usage.Detail{}, false))
 	})
 }
@@ -105,7 +109,15 @@ func (r *UsageReporter) buildRecord(detail usage.Detail, failed bool) usage.Reco
 		Latency:     r.latency(),
 		Failed:      failed,
 		Detail:      detail,
+		Thinking:    cloneUsageThinking(r.thinking),
 	}
+}
+
+func (r *UsageReporter) captureThinkingFromContext(ctx context.Context) {
+	if r == nil || r.thinking != nil {
+		return
+	}
+	r.thinking = UsageThinkingFromContext(ctx)
 }
 
 func (r *UsageReporter) latency() time.Duration {
@@ -194,6 +206,146 @@ func resolveUsageAuthType(auth *cliproxyauth.Auth) string {
 		return "apikey"
 	}
 	return kind
+}
+
+func CaptureUsageThinkingFromRequest(ctx context.Context, body []byte) {
+	ginCtx := ginContextFrom(ctx)
+	if ginCtx == nil {
+		return
+	}
+	thinkingDetail := ParseUsageThinkingFromRequest(body)
+	if isUsageThinkingZero(thinkingDetail) {
+		return
+	}
+	ginCtx.Set(usageThinkingKey, thinkingDetail)
+}
+
+func UsageThinkingFromContext(ctx context.Context) *usage.Thinking {
+	ginCtx := ginContextFrom(ctx)
+	if ginCtx == nil {
+		return nil
+	}
+	value, exists := ginCtx.Get(usageThinkingKey)
+	if !exists {
+		return nil
+	}
+	switch v := value.(type) {
+	case usage.Thinking:
+		return cloneUsageThinking(&v)
+	case *usage.Thinking:
+		return cloneUsageThinking(v)
+	default:
+		return nil
+	}
+}
+
+func ParseUsageThinkingFromRequest(body []byte) usage.Thinking {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return usage.Thinking{}
+	}
+
+	if parsed := parseUsageThinkingLevel(body, "reasoning.effort"); !isUsageThinkingZero(parsed) {
+		return parsed
+	}
+	if parsed := parseUsageThinkingLevel(body, "reasoning_effort"); !isUsageThinkingZero(parsed) {
+		return parsed
+	}
+	if parsed := parseUsageThinkingLevel(body, "output_config.effort"); !isUsageThinkingZero(parsed) {
+		return parsed
+	}
+
+	for _, path := range []string{
+		"request.generationConfig.thinkingConfig.thinkingLevel",
+		"request.generationConfig.thinkingConfig.thinking_level",
+		"generationConfig.thinkingConfig.thinkingLevel",
+		"generationConfig.thinkingConfig.thinking_level",
+	} {
+		if parsed := parseUsageThinkingLevel(body, path); !isUsageThinkingZero(parsed) {
+			return parsed
+		}
+	}
+
+	for _, path := range []string{
+		"request.generationConfig.thinkingConfig.thinkingBudget",
+		"request.generationConfig.thinkingConfig.thinking_budget",
+		"generationConfig.thinkingConfig.thinkingBudget",
+		"generationConfig.thinkingConfig.thinking_budget",
+		"thinking.budget_tokens",
+	} {
+		if parsed := parseUsageThinkingBudget(body, path); !isUsageThinkingZero(parsed) {
+			return parsed
+		}
+	}
+
+	if thinkingType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "thinking.type").String())); thinkingType != "" {
+		switch thinkingType {
+		case "disabled":
+			return usage.Thinking{Intensity: string(thinking.LevelNone), Mode: thinking.ModeNone.String(), Level: string(thinking.LevelNone)}
+		case "adaptive", "auto", "enabled":
+			return usage.Thinking{Intensity: string(thinking.LevelAuto), Mode: thinking.ModeAuto.String(), Level: string(thinking.LevelAuto)}
+		}
+	}
+
+	return usage.Thinking{}
+}
+
+func parseUsageThinkingLevel(body []byte, path string) usage.Thinking {
+	node := gjson.GetBytes(body, path)
+	if !node.Exists() {
+		return usage.Thinking{}
+	}
+	level := strings.ToLower(strings.TrimSpace(node.String()))
+	if level == "" {
+		return usage.Thinking{}
+	}
+	switch level {
+	case string(thinking.LevelNone):
+		return usage.Thinking{Intensity: level, Mode: thinking.ModeNone.String(), Level: level}
+	case string(thinking.LevelAuto):
+		return usage.Thinking{Intensity: level, Mode: thinking.ModeAuto.String(), Level: level}
+	default:
+		return usage.Thinking{Intensity: level, Mode: thinking.ModeLevel.String(), Level: level}
+	}
+}
+
+func parseUsageThinkingBudget(body []byte, path string) usage.Thinking {
+	node := gjson.GetBytes(body, path)
+	if !node.Exists() {
+		return usage.Thinking{}
+	}
+	budget := int(node.Int())
+	switch budget {
+	case 0:
+		return usage.Thinking{Intensity: string(thinking.LevelNone), Mode: thinking.ModeNone.String(), Level: string(thinking.LevelNone), Budget: 0}
+	case -1:
+		return usage.Thinking{Intensity: string(thinking.LevelAuto), Mode: thinking.ModeAuto.String(), Level: string(thinking.LevelAuto), Budget: -1}
+	default:
+		level, _ := thinking.ConvertBudgetToLevel(budget)
+		return usage.Thinking{Intensity: level, Mode: thinking.ModeBudget.String(), Level: level, Budget: budget}
+	}
+}
+
+func cloneUsageThinking(thinkingDetail *usage.Thinking) *usage.Thinking {
+	if thinkingDetail == nil {
+		return nil
+	}
+	clone := usage.Thinking{
+		Intensity: strings.TrimSpace(thinkingDetail.Intensity),
+		Mode:      strings.TrimSpace(thinkingDetail.Mode),
+		Level:     strings.TrimSpace(thinkingDetail.Level),
+		Budget:    thinkingDetail.Budget,
+	}
+	if isUsageThinkingZero(clone) {
+		return nil
+	}
+	return &clone
+}
+
+func isUsageThinkingZero(thinkingDetail usage.Thinking) bool {
+	return strings.TrimSpace(thinkingDetail.Intensity) == "" &&
+		strings.TrimSpace(thinkingDetail.Mode) == "" &&
+		strings.TrimSpace(thinkingDetail.Level) == "" &&
+		thinkingDetail.Budget == 0
 }
 
 func ParseCodexUsage(data []byte) (usage.Detail, bool) {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -1,9 +1,12 @@
 package helps
 
 import (
+	"context"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 )
 
@@ -60,5 +63,132 @@ func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 	}
 	if record.Latency > 3*time.Second {
 		t.Fatalf("latency = %v, want <= 3s", record.Latency)
+	}
+}
+
+func TestParseUsageThinkingFromRequest(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		wantIntensity string
+		wantMode      string
+		wantLevel     string
+		wantBudget    int
+	}{
+		{
+			name:          "codex effort",
+			body:          `{"reasoning":{"effort":"high"}}`,
+			wantIntensity: "high",
+			wantMode:      "level",
+			wantLevel:     "high",
+		},
+		{
+			name:          "gemini budget",
+			body:          `{"generationConfig":{"thinkingConfig":{"thinkingBudget":8192}}}`,
+			wantIntensity: "medium",
+			wantMode:      "budget",
+			wantLevel:     "medium",
+			wantBudget:    8192,
+		},
+		{
+			name:          "gemini cli auto",
+			body:          `{"request":{"generationConfig":{"thinkingConfig":{"thinkingBudget":-1}}}}`,
+			wantIntensity: "auto",
+			wantMode:      "auto",
+			wantLevel:     "auto",
+			wantBudget:    -1,
+		},
+		{
+			name:          "gemini custom budget",
+			body:          `{"generationConfig":{"thinkingConfig":{"thinkingBudget":-2}}}`,
+			wantIntensity: "",
+			wantMode:      "budget",
+			wantLevel:     "",
+			wantBudget:    -2,
+		},
+		{
+			name:          "claude disabled",
+			body:          `{"thinking":{"type":"disabled"}}`,
+			wantIntensity: "none",
+			wantMode:      "none",
+			wantLevel:     "none",
+		},
+		{
+			name:          "claude adaptive effort",
+			body:          `{"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`,
+			wantIntensity: "max",
+			wantMode:      "level",
+			wantLevel:     "max",
+		},
+		{
+			name:          "claude adaptive",
+			body:          `{"thinking":{"type":"adaptive"}}`,
+			wantIntensity: "auto",
+			wantMode:      "auto",
+			wantLevel:     "auto",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseUsageThinkingFromRequest([]byte(tt.body))
+			if got.Intensity != tt.wantIntensity {
+				t.Fatalf("intensity = %q, want %q", got.Intensity, tt.wantIntensity)
+			}
+			if got.Mode != tt.wantMode {
+				t.Fatalf("mode = %q, want %q", got.Mode, tt.wantMode)
+			}
+			if got.Level != tt.wantLevel {
+				t.Fatalf("level = %q, want %q", got.Level, tt.wantLevel)
+			}
+			if got.Budget != tt.wantBudget {
+				t.Fatalf("budget = %d, want %d", got.Budget, tt.wantBudget)
+			}
+		})
+	}
+}
+
+func TestUsageReporterBuildRecordIncludesThinkingFromContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+	CaptureUsageThinkingFromRequest(ctx, []byte(`{"reasoning_effort":"medium"}`))
+
+	reporter := &UsageReporter{
+		provider:    "openai",
+		model:       "gpt-5.4",
+		requestedAt: time.Now(),
+	}
+	reporter.captureThinkingFromContext(ctx)
+
+	record := reporter.buildRecord(usage.Detail{TotalTokens: 3}, false)
+	if record.Thinking == nil {
+		t.Fatal("thinking metadata is nil, want populated")
+	}
+	if record.Thinking.Intensity != "medium" {
+		t.Fatalf("intensity = %q, want medium", record.Thinking.Intensity)
+	}
+	if record.Thinking.Mode != "level" {
+		t.Fatalf("mode = %q, want level", record.Thinking.Mode)
+	}
+	if record.Thinking.Level != "medium" {
+		t.Fatalf("level = %q, want medium", record.Thinking.Level)
+	}
+}
+
+func TestCaptureUsageThinkingFromRequestKeepsExistingOnEmptyBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+
+	CaptureUsageThinkingFromRequest(ctx, []byte(`{"reasoning_effort":"high"}`))
+	CaptureUsageThinkingFromRequest(ctx, nil)
+
+	got := UsageThinkingFromContext(ctx)
+	if got == nil {
+		t.Fatal("thinking metadata is nil, want existing metadata")
+	}
+	if got.Intensity != "high" {
+		t.Fatalf("intensity = %q, want high", got.Intensity)
 	}
 }

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -89,12 +89,13 @@ type modelStats struct {
 
 // RequestDetail stores the timestamp, latency, and token usage for a single request.
 type RequestDetail struct {
-	Timestamp time.Time  `json:"timestamp"`
-	LatencyMs int64      `json:"latency_ms"`
-	Source    string     `json:"source"`
-	AuthIndex string     `json:"auth_index"`
-	Tokens    TokenStats `json:"tokens"`
-	Failed    bool       `json:"failed"`
+	Timestamp time.Time           `json:"timestamp"`
+	LatencyMs int64               `json:"latency_ms"`
+	Source    string              `json:"source"`
+	AuthIndex string              `json:"auth_index"`
+	Thinking  *coreusage.Thinking `json:"thinking,omitempty"`
+	Tokens    TokenStats          `json:"tokens"`
+	Failed    bool                `json:"failed"`
 }
 
 // TokenStats captures the token usage breakdown for a request.
@@ -202,6 +203,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 		LatencyMs: normaliseLatency(record.Latency),
 		Source:    record.Source,
 		AuthIndex: record.AuthIndex,
+		Thinking:  cloneThinking(record.Thinking),
 		Tokens:    detail,
 		Failed:    failed,
 	})
@@ -213,6 +215,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 }
 
 func (s *RequestStatistics) updateAPIStats(stats *apiStats, model string, detail RequestDetail) {
+	detail = cloneRequestDetail(detail)
 	stats.TotalRequests++
 	stats.TotalTokens += detail.Tokens.TotalTokens
 	modelStatsValue, ok := stats.Models[model]
@@ -248,8 +251,7 @@ func (s *RequestStatistics) Snapshot() StatisticsSnapshot {
 			Models:        make(map[string]ModelSnapshot, len(stats.Models)),
 		}
 		for modelName, modelStatsValue := range stats.Models {
-			requestDetails := make([]RequestDetail, len(modelStatsValue.Details))
-			copy(requestDetails, modelStatsValue.Details)
+			requestDetails := cloneRequestDetails(modelStatsValue.Details)
 			apiSnapshot.Models[modelName] = ModelSnapshot{
 				TotalRequests: modelStatsValue.TotalRequests,
 				TotalTokens:   modelStatsValue.TotalTokens,
@@ -333,6 +335,7 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 				modelName = "unknown"
 			}
 			for _, detail := range modelSnapshot.Details {
+				detail = cloneRequestDetail(detail)
 				detail.Tokens = normaliseTokenStats(detail.Tokens)
 				if detail.LatencyMs < 0 {
 					detail.LatencyMs = 0
@@ -466,6 +469,39 @@ func normaliseTokenStats(tokens TokenStats) TokenStats {
 		tokens.TotalTokens = tokens.InputTokens + tokens.OutputTokens + tokens.ReasoningTokens + tokens.CachedTokens
 	}
 	return tokens
+}
+
+func normaliseThinking(thinking *coreusage.Thinking) coreusage.Thinking {
+	if thinking == nil {
+		return coreusage.Thinking{}
+	}
+	return coreusage.Thinking{
+		Intensity: strings.TrimSpace(thinking.Intensity),
+		Mode:      strings.TrimSpace(thinking.Mode),
+		Level:     strings.TrimSpace(thinking.Level),
+		Budget:    thinking.Budget,
+	}
+}
+
+func cloneThinking(thinking *coreusage.Thinking) *coreusage.Thinking {
+	normalized := normaliseThinking(thinking)
+	if normalized.Intensity == "" && normalized.Mode == "" && normalized.Level == "" && normalized.Budget == 0 {
+		return nil
+	}
+	return &normalized
+}
+
+func cloneRequestDetail(detail RequestDetail) RequestDetail {
+	detail.Thinking = cloneThinking(detail.Thinking)
+	return detail
+}
+
+func cloneRequestDetails(details []RequestDetail) []RequestDetail {
+	cloned := make([]RequestDetail, len(details))
+	for i, detail := range details {
+		cloned[i] = cloneRequestDetail(detail)
+	}
+	return cloned
 }
 
 func normaliseLatency(latency time.Duration) int64 {

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -10,6 +10,11 @@ import (
 
 func TestRequestStatisticsRecordIncludesLatency(t *testing.T) {
 	stats := NewRequestStatistics()
+	thinkingDetail := &coreusage.Thinking{
+		Intensity: "high",
+		Mode:      "level",
+		Level:     "high",
+	}
 	stats.Record(context.Background(), coreusage.Record{
 		APIKey:      "test-key",
 		Model:       "gpt-5.4",
@@ -20,7 +25,9 @@ func TestRequestStatisticsRecordIncludesLatency(t *testing.T) {
 			OutputTokens: 20,
 			TotalTokens:  30,
 		},
+		Thinking: thinkingDetail,
 	})
+	thinkingDetail.Intensity = "mutated"
 
 	snapshot := stats.Snapshot()
 	details := snapshot.APIs["test-key"].Models["gpt-5.4"].Details
@@ -29,6 +36,72 @@ func TestRequestStatisticsRecordIncludesLatency(t *testing.T) {
 	}
 	if details[0].LatencyMs != 1500 {
 		t.Fatalf("latency_ms = %d, want 1500", details[0].LatencyMs)
+	}
+	if details[0].Thinking == nil {
+		t.Fatal("thinking metadata is nil, want populated")
+	}
+	if details[0].Thinking.Intensity != "high" {
+		t.Fatalf("thinking intensity = %q, want high", details[0].Thinking.Intensity)
+	}
+}
+
+func TestRequestStatisticsSnapshotDeepCopiesThinking(t *testing.T) {
+	stats := NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:      "test-key",
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
+		Thinking: &coreusage.Thinking{
+			Intensity: "medium",
+			Mode:      "level",
+			Level:     "medium",
+		},
+		Detail: coreusage.Detail{TotalTokens: 1},
+	})
+
+	snapshot := stats.Snapshot()
+	snapshot.APIs["test-key"].Models["gpt-5.4"].Details[0].Thinking.Intensity = "mutated"
+
+	nextSnapshot := stats.Snapshot()
+	got := nextSnapshot.APIs["test-key"].Models["gpt-5.4"].Details[0].Thinking.Intensity
+	if got != "medium" {
+		t.Fatalf("thinking intensity = %q after snapshot mutation, want medium", got)
+	}
+}
+
+func TestRequestStatisticsMergeSnapshotDeepCopiesThinking(t *testing.T) {
+	stats := NewRequestStatistics()
+	thinkingDetail := &coreusage.Thinking{
+		Intensity: "medium",
+		Mode:      "level",
+		Level:     "medium",
+	}
+	snapshot := StatisticsSnapshot{
+		APIs: map[string]APISnapshot{
+			"test-key": {
+				Models: map[string]ModelSnapshot{
+					"gpt-5.4": {
+						Details: []RequestDetail{{
+							Timestamp: time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
+							Thinking:  thinkingDetail,
+							Tokens:    TokenStats{TotalTokens: 1},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := stats.MergeSnapshot(snapshot)
+	if result.Added != 1 || result.Skipped != 0 {
+		t.Fatalf("merge = %+v, want added=1 skipped=0", result)
+	}
+	thinkingDetail.Intensity = "mutated"
+
+	nextSnapshot := stats.Snapshot()
+	got := nextSnapshot.APIs["test-key"].Models["gpt-5.4"].Details[0].Thinking.Intensity
+	if got != "medium" {
+		t.Fatalf("thinking intensity = %q after source snapshot mutation, want medium", got)
 	}
 }
 
@@ -72,6 +145,65 @@ func TestRequestStatisticsMergeSnapshotDedupIgnoresLatency(t *testing.T) {
 								TotalTokens:  30,
 							},
 						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := stats.MergeSnapshot(first)
+	if result.Added != 1 || result.Skipped != 0 {
+		t.Fatalf("first merge = %+v, want added=1 skipped=0", result)
+	}
+
+	result = stats.MergeSnapshot(second)
+	if result.Added != 0 || result.Skipped != 1 {
+		t.Fatalf("second merge = %+v, want added=0 skipped=1", result)
+	}
+
+	snapshot := stats.Snapshot()
+	details := snapshot.APIs["test-key"].Models["gpt-5.4"].Details
+	if len(details) != 1 {
+		t.Fatalf("details len = %d, want 1", len(details))
+	}
+}
+
+func TestRequestStatisticsMergeSnapshotDedupIgnoresThinking(t *testing.T) {
+	stats := NewRequestStatistics()
+	timestamp := time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC)
+	baseDetail := RequestDetail{
+		Timestamp: timestamp,
+		Source:    "user@example.com",
+		AuthIndex: "0",
+		Tokens: TokenStats{
+			InputTokens:  10,
+			OutputTokens: 20,
+			TotalTokens:  30,
+		},
+	}
+	first := StatisticsSnapshot{
+		APIs: map[string]APISnapshot{
+			"test-key": {
+				Models: map[string]ModelSnapshot{
+					"gpt-5.4": {
+						Details: []RequestDetail{baseDetail},
+					},
+				},
+			},
+		},
+	}
+	withThinking := baseDetail
+	withThinking.Thinking = &coreusage.Thinking{
+		Intensity: "high",
+		Mode:      "level",
+		Level:     "high",
+	}
+	second := StatisticsSnapshot{
+		APIs: map[string]APISnapshot{
+			"test-key": {
+				Models: map[string]ModelSnapshot{
+					"gpt-5.4": {
+						Details: []RequestDetail{withThinking},
 					},
 				},
 			},

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -21,6 +21,7 @@ type Record struct {
 	Latency     time.Duration
 	Failed      bool
 	Detail      Detail
+	Thinking    *Thinking
 }
 
 // Detail holds the token usage breakdown.
@@ -30,6 +31,14 @@ type Detail struct {
 	ReasoningTokens int64
 	CachedTokens    int64
 	TotalTokens     int64
+}
+
+// Thinking captures the request's configured thinking/reasoning intensity.
+type Thinking struct {
+	Intensity string `json:"intensity,omitempty"`
+	Mode      string `json:"mode,omitempty"`
+	Level     string `json:"level,omitempty"`
+	Budget    int    `json:"budget,omitempty"`
 }
 
 // Plugin consumes usage records emitted by the proxy runtime.


### PR DESCRIPTION
## Summary
- Capture thinking/reasoning settings from upstream request bodies for usage reporting.
- Add optional `thinking` metadata to usage records and request details.
- Support OpenAI/Codex reasoning effort, Claude thinking settings, and Gemini thinkingConfig levels/budgets.

## Related
- Management UI support: https://github.com/router-for-me/Cli-Proxy-API-Management-Center/pull/234

## Testing
- `go test ./internal/runtime/executor/helps ./internal/usage ./sdk/cliproxy/usage`
- `go build ./cmd/server`
