### PR TITLE
fix(models): correct GPT-5.5 Codex context length

### DIFF
--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -4,7 +4,6 @@ import "testing"
 
 func TestCodexStaticModelsIncludeGPT55(t *testing.T) {
 	tierModels := map[string][]*ModelInfo{
-		"free": GetCodexFreeModels(),
 		"team": GetCodexTeamModels(),
 		"plus": GetCodexPlusModels(),
 		"pro":  GetCodexProModels(),
@@ -63,7 +62,7 @@ func assertGPT55ModelInfo(t *testing.T, source string, model *ModelInfo) {
 	if model.Description != "Frontier model for complex coding, research, and real-world work." {
 		t.Fatalf("%s description mismatch: got %q", source, model.Description)
 	}
-	if model.ContextLength != 272000 {
+	if model.ContextLength != 1050000 {
 		t.Fatalf("%s context length mismatch: got %d", source, model.ContextLength)
 	}
 	if model.MaxCompletionTokens != 128000 {

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1397,7 +1397,7 @@
       "display_name": "GPT 5.5",
       "version": "gpt-5.5",
       "description": "Frontier model for complex coding, research, and real-world work.",
-      "context_length": 272000,
+      "context_length": 1050000,
       "max_completion_tokens": 128000,
       "supported_parameters": [
         "tools"
@@ -1538,7 +1538,7 @@
       "display_name": "GPT 5.5",
       "version": "gpt-5.5",
       "description": "Frontier model for complex coding, research, and real-world work.",
-      "context_length": 272000,
+      "context_length": 1050000,
       "max_completion_tokens": 128000,
       "supported_parameters": [
         "tools"
@@ -1679,7 +1679,7 @@
       "display_name": "GPT 5.5",
       "version": "gpt-5.5",
       "description": "Frontier model for complex coding, research, and real-world work.",
-      "context_length": 272000,
+      "context_length": 1050000,
       "max_completion_tokens": 128000,
       "supported_parameters": [
         "tools"


### PR DESCRIPTION
## Summary

- Update Codex GPT-5.5 static registry metadata from `272000` to the official `1050000` context window.
- Keep GPT-5.5 max completion tokens at `128000` and preserve existing model/tier metadata.
- Align the GPT-5.5 registry test with the tiers that currently expose GPT-5.5 (`team`, `plus`, `pro`) and assert the corrected context length.

## Context

`context_length` represents the total model context window in the registry. GPT-5.5 follows the same long-context pattern already used by the Codex GPT-5.4 entries, while the previous `272000` value corresponded to an input-side threshold rather than the total context window.

## Test Plan

- [x] `go test ./internal/registry -run TestCodexStaticModelsIncludeGPT55 -v`
- [x] `go test ./...`
- [x] `go build -o test-output ./cmd/server && rm test-output`