### PR TITLE
fix: apply tool call reordering to HTTP /v1/responses path

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -257,7 +257,7 @@ func (h *OpenAIResponsesAPIHandler) Responses(c *gin.Context) {
 
 	// Repair tool call ordering before sending to upstream (mirrors WebSocket behavior).
 	// This fixes 2013 errors from MiniMax上游 which rejects out-of-order function_call / function_call_output.
-	rpcSessionKey := httpResponsesSessionKey(rawJSON)
+	rpcSessionKey := httpResponsesSessionKey(c.Request, rawJSON)
 	rawJSON = repairResponsesWebsocketToolCalls(rpcSessionKey, rawJSON)
 
 	// Check if the client requested a streaming response.
@@ -299,7 +299,7 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 	}
 
 	// Repair tool call ordering before sending to upstream (mirrors WebSocket behavior).
-	rpcSessionKey := httpResponsesSessionKey(rawJSON)
+	rpcSessionKey := httpResponsesSessionKey(c.Request, rawJSON)
 	rawJSON = repairResponsesWebsocketToolCalls(rpcSessionKey, rawJSON)
 
 	c.Header("Content-Type", "application/json")

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -256,7 +256,7 @@ func (h *OpenAIResponsesAPIHandler) Responses(c *gin.Context) {
 	}
 
 	// Repair tool call ordering before sending to upstream (mirrors WebSocket behavior).
-	// This fixes 2013 errors from MiniMax上游 which rejects out-of-order function_call / function_call_output.
+	// This fixes 2013 errors from MiniMax upstream which rejects out-of-order function_call / function_call_output.
 	// If no session key is available (first-turn, no prevRespID, no header), use the no-cache
 	// variant to still reorder without polluting a shared cache namespace.
 	rpcSessionKey := httpResponsesSessionKey(c.Request, rawJSON)

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -257,8 +257,14 @@ func (h *OpenAIResponsesAPIHandler) Responses(c *gin.Context) {
 
 	// Repair tool call ordering before sending to upstream (mirrors WebSocket behavior).
 	// This fixes 2013 errors from MiniMax上游 which rejects out-of-order function_call / function_call_output.
+	// If no session key is available (first-turn, no prevRespID, no header), use the no-cache
+	// variant to still reorder without polluting a shared cache namespace.
 	rpcSessionKey := httpResponsesSessionKey(c.Request, rawJSON)
-	rawJSON = repairResponsesWebsocketToolCalls(rpcSessionKey, rawJSON)
+	if rpcSessionKey != "" {
+		rawJSON = repairResponsesWebsocketToolCalls(rpcSessionKey, rawJSON)
+	} else {
+		rawJSON = repairResponsesHTTPNoCache(rawJSON)
+	}
 
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")
@@ -299,8 +305,13 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 	}
 
 	// Repair tool call ordering before sending to upstream (mirrors WebSocket behavior).
+	// If no session key is available, use the no-cache variant.
 	rpcSessionKey := httpResponsesSessionKey(c.Request, rawJSON)
-	rawJSON = repairResponsesWebsocketToolCalls(rpcSessionKey, rawJSON)
+	if rpcSessionKey != "" {
+		rawJSON = repairResponsesWebsocketToolCalls(rpcSessionKey, rawJSON)
+	} else {
+		rawJSON = repairResponsesHTTPNoCache(rawJSON)
+	}
 
 	c.Header("Content-Type", "application/json")
 	modelName := gjson.GetBytes(rawJSON, "model").String()

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -255,6 +255,11 @@ func (h *OpenAIResponsesAPIHandler) Responses(c *gin.Context) {
 		return
 	}
 
+	// Repair tool call ordering before sending to upstream (mirrors WebSocket behavior).
+	// This fixes 2013 errors from MiniMax上游 which rejects out-of-order function_call / function_call_output.
+	rpcSessionKey := httpResponsesSessionKey(rawJSON)
+	rawJSON = repairResponsesWebsocketToolCalls(rpcSessionKey, rawJSON)
+
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")
 	if streamResult.Type == gjson.True {
@@ -292,6 +297,10 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 			rawJSON = updated
 		}
 	}
+
+	// Repair tool call ordering before sending to upstream (mirrors WebSocket behavior).
+	rpcSessionKey := httpResponsesSessionKey(rawJSON)
+	rawJSON = repairResponsesWebsocketToolCalls(rpcSessionKey, rawJSON)
 
 	c.Header("Content-Type", "application/json")
 	modelName := gjson.GetBytes(rawJSON, "model").String()

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -507,8 +508,7 @@ func reorderResponsesToolCallsNoCache(rawArray string) string {
 		}
 	}
 
-	// Iterate in original order: add calls + their outputs, skip lone outputs
-	// (they will be re-added at the end as orphaned).
+	// Iterate: add non-outputs as-is, add calls + their outputs.
 	result := make([]json.RawMessage, 0, len(items))
 	for _, item := range items {
 		if len(item) == 0 {
@@ -516,31 +516,34 @@ func reorderResponsesToolCallsNoCache(rawArray string) string {
 		}
 		itemType := strings.TrimSpace(gjson.GetBytes(item, "type").String())
 		if isResponsesToolCallOutputType(itemType) {
-			// Skip lone outputs here; they will be added as orphaned at the end.
-			continue
+			continue // outputs handled when we hit their call
 		}
 		if isResponsesToolCallType(itemType) {
 			callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
-			result = append(result, item)
-			if callID != "" {
-				outputs := outputsByCallID[callID]
-				for i := range outputs {
-					result = append(result, outputs[i])
-				}
-				// Remove so these outputs are not appended again as orphaned.
-				delete(outputsByCallID, callID)
+			if callID == "" {
+				// Drop tool calls without call_id (upstream rejects them).
+				continue
 			}
+			result = append(result, item)
+			outputs := outputsByCallID[callID]
+			for i := range outputs {
+				result = append(result, outputs[i])
+			}
+			delete(outputsByCallID, callID)
 			continue
 		}
 		// Non-tool items: add as-is.
 		result = append(result, item)
 	}
 
-	// Append orphaned outputs at the end.
-	for _, outputs := range outputsByCallID {
-		for i := range outputs {
-			result = append(result, outputs[i])
-		}
+	// Append orphaned outputs in sorted order for stable output.
+	orphanOrder := make([]string, 0, len(outputsByCallID))
+	for callID := range outputsByCallID {
+		orphanOrder = append(orphanOrder, callID)
+	}
+	sort.Strings(orphanOrder)
+	for _, callID := range orphanOrder {
+		result = append(result, outputsByCallID[callID]...)
 	}
 
 	out, err := json.Marshal(result)

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -424,9 +424,13 @@ func isResponsesToolCallOutputType(itemType string) bool {
 // httpResponsesSessionKey derives a session key for HTTP requests.
 // It mirrors the WebSocket session key derivation by preferring request-level
 // identity headers (X-Client-Request-Id), then falling back to a hash of
-// model + previous_response_id. Using only the payload fields would cause
-// cache collisions between different users on first-turn requests (where
-// previous_response_id is empty).
+// model + previous_response_id.
+//
+// SECURITY: When no request-level identity is available (no headers and no
+// previous_response_id), we return an empty string so callers skip the shared
+// cache entirely. Without this, all first-turn requests for the same model
+// would share one cache namespace, enabling cross-user cache pollution and
+// tool-output leakage in multi-tenant deployments.
 func httpResponsesSessionKey(req *http.Request, payload []byte) string {
 	// Prefer an explicit request ID header if present (mirrors WebSocket behavior).
 	if sessionKey := websocketDownstreamSessionKey(req); sessionKey != "" {
@@ -435,6 +439,12 @@ func httpResponsesSessionKey(req *http.Request, payload []byte) string {
 	// Fall back to a hash of model + previous_response_id.
 	model := strings.TrimSpace(gjson.GetBytes(payload, "model").String())
 	prevRespID := strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String())
+	// If previous_response_id is empty AND no request header is present,
+	// skip caching entirely to avoid cross-user namespace pollution on
+	// first-turn requests (where all users share the same model key).
+	if prevRespID == "" {
+		return ""
+	}
 	composite := model + "|" + prevRespID
 	hash := sha256.Sum256([]byte(composite))
 	return "http:" + hex.EncodeToString(hash[:16])

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -460,9 +460,8 @@ func repairResponsesHTTPNoCache(payload []byte) []byte {
 	if !input.Exists() || !input.IsArray() {
 		return payload
 	}
-	// allowOrphanOutputs=true: don't drop outputs without matching calls
-	updatedRaw, errRepair := repairResponsesToolCallsArray(nil, nil, "", input.Raw, true)
-	if errRepair != nil || updatedRaw == "" || updatedRaw == input.Raw {
+	updatedRaw := reorderResponsesToolCallsNoCache(input.Raw)
+	if updatedRaw == "" || updatedRaw == input.Raw {
 		return payload
 	}
 	updated, errSet := sjson.SetRawBytes(payload, "input", []byte(updatedRaw))
@@ -470,4 +469,83 @@ func repairResponsesHTTPNoCache(payload []byte) []byte {
 		return payload
 	}
 	return updated
+}
+
+// reorderResponsesToolCallsNoCache reorders function_call / function_call_output items
+// so that each output immediately follows its corresponding call, without using any
+// shared session cache.
+// Algorithm:
+//  1. Collect all output items keyed by call_id.
+//  2. Iterate original items in order; add non-output items directly.
+//     For each call, add the call then immediately append its outputs from the map.
+//     Remove appended outputs from the map so they are not processed again.
+//  3. Append any orphaned outputs (those whose call_id was not found) at the end.
+//
+// This handles both correct-order and reversed-order (output before call) cases.
+func reorderResponsesToolCallsNoCache(rawArray string) string {
+	rawArray = strings.TrimSpace(rawArray)
+	if rawArray == "" {
+		return "[]"
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal([]byte(rawArray), &items); err != nil {
+		return ""
+	}
+
+	// Collect all output items keyed by call_id.
+	outputsByCallID := make(map[string][]json.RawMessage, len(items))
+	for _, item := range items {
+		if len(item) == 0 {
+			continue
+		}
+		itemType := strings.TrimSpace(gjson.GetBytes(item, "type").String())
+		if isResponsesToolCallOutputType(itemType) {
+			callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
+			if callID != "" {
+				outputsByCallID[callID] = append(outputsByCallID[callID], item)
+			}
+		}
+	}
+
+	// Iterate in original order: add calls + their outputs, skip lone outputs
+	// (they will be re-added at the end as orphaned).
+	result := make([]json.RawMessage, 0, len(items))
+	for _, item := range items {
+		if len(item) == 0 {
+			continue
+		}
+		itemType := strings.TrimSpace(gjson.GetBytes(item, "type").String())
+		if isResponsesToolCallOutputType(itemType) {
+			// Skip lone outputs here; they will be added as orphaned at the end.
+			continue
+		}
+		if isResponsesToolCallType(itemType) {
+			callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
+			result = append(result, item)
+			if callID != "" {
+				outputs := outputsByCallID[callID]
+				for i := range outputs {
+					result = append(result, outputs[i])
+				}
+				// Remove so these outputs are not appended again as orphaned.
+				delete(outputsByCallID, callID)
+			}
+			continue
+		}
+		// Non-tool items: add as-is.
+		result = append(result, item)
+	}
+
+	// Append orphaned outputs at the end.
+	for _, outputs := range outputsByCallID {
+		for i := range outputs {
+			result = append(result, outputs[i])
+		}
+	}
+
+	out, err := json.Marshal(result)
+	if err != nil {
+		return ""
+	}
+	return string(out)
 }

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -1,7 +1,9 @@
 package openai
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"encoding/hex"
 	"net/http"
 	"strings"
 	"sync"
@@ -417,4 +419,17 @@ func isResponsesToolCallOutputType(itemType string) bool {
 	default:
 		return false
 	}
+}
+
+// httpResponsesSessionKey derives a deterministic session key from the HTTP request payload
+// for tool call cache lookups. Mirrors the WebSocket session key derivation logic.
+func httpResponsesSessionKey(payload []byte) string {
+	model := strings.TrimSpace(gjson.GetBytes(payload, "model").String())
+	prevRespID := strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String())
+	// Build a composite key from model + previous_response_id.
+	// This is deterministic per request, matching the WebSocket behavior where
+	// the same session sees cached tool calls across multiple message exchanges.
+	composite := model + "|" + prevRespID
+	hash := sha256.Sum256([]byte(composite))
+	return "http:" + hex.EncodeToString(hash[:16])
 }

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -2,8 +2,8 @@ package openai
 
 import (
 	"crypto/sha256"
-	"encoding/json"
 	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"sync"
@@ -421,14 +421,20 @@ func isResponsesToolCallOutputType(itemType string) bool {
 	}
 }
 
-// httpResponsesSessionKey derives a deterministic session key from the HTTP request payload
-// for tool call cache lookups. Mirrors the WebSocket session key derivation logic.
-func httpResponsesSessionKey(payload []byte) string {
+// httpResponsesSessionKey derives a session key for HTTP requests.
+// It mirrors the WebSocket session key derivation by preferring request-level
+// identity headers (X-Client-Request-Id), then falling back to a hash of
+// model + previous_response_id. Using only the payload fields would cause
+// cache collisions between different users on first-turn requests (where
+// previous_response_id is empty).
+func httpResponsesSessionKey(req *http.Request, payload []byte) string {
+	// Prefer an explicit request ID header if present (mirrors WebSocket behavior).
+	if sessionKey := websocketDownstreamSessionKey(req); sessionKey != "" {
+		return "http:" + sessionKey
+	}
+	// Fall back to a hash of model + previous_response_id.
 	model := strings.TrimSpace(gjson.GetBytes(payload, "model").String())
 	prevRespID := strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String())
-	// Build a composite key from model + previous_response_id.
-	// This is deterministic per request, matching the WebSocket behavior where
-	// the same session sees cached tool calls across multiple message exchanges.
 	composite := model + "|" + prevRespID
 	hash := sha256.Sum256([]byte(composite))
 	return "http:" + hex.EncodeToString(hash[:16])

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -427,10 +427,8 @@ func isResponsesToolCallOutputType(itemType string) bool {
 // model + previous_response_id.
 //
 // SECURITY: When no request-level identity is available (no headers and no
-// previous_response_id), we return an empty string so callers skip the shared
-// cache entirely. Without this, all first-turn requests for the same model
-// would share one cache namespace, enabling cross-user cache pollution and
-// tool-output leakage in multi-tenant deployments.
+// previous_response_id), we call repairResponsesHTTPNoCache which performs
+// reordering without any shared cache to avoid cross-user cache pollution.
 func httpResponsesSessionKey(req *http.Request, payload []byte) string {
 	// Prefer an explicit request ID header if present (mirrors WebSocket behavior).
 	if sessionKey := websocketDownstreamSessionKey(req); sessionKey != "" {
@@ -440,12 +438,36 @@ func httpResponsesSessionKey(req *http.Request, payload []byte) string {
 	model := strings.TrimSpace(gjson.GetBytes(payload, "model").String())
 	prevRespID := strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String())
 	// If previous_response_id is empty AND no request header is present,
-	// skip caching entirely to avoid cross-user namespace pollution on
-	// first-turn requests (where all users share the same model key).
+	// return empty so callers fall back to repairResponsesHTTPNoCache
+	// (no shared cache to prevent cross-user pollution on first-turn requests).
 	if prevRespID == "" {
 		return ""
 	}
 	composite := model + "|" + prevRespID
 	hash := sha256.Sum256([]byte(composite))
 	return "http:" + hex.EncodeToString(hash[:16])
+}
+
+// repairResponsesHTTPNoCache performs tool call reordering without using any session
+// cache. Use this when sessionKey is empty (no request-level identity available
+// and previous_response_id is absent) to still fix out-of-order tool calls while
+// avoiding cross-user cache pollution.
+func repairResponsesHTTPNoCache(payload []byte) []byte {
+	if len(payload) == 0 {
+		return payload
+	}
+	input := gjson.GetBytes(payload, "input")
+	if !input.Exists() || !input.IsArray() {
+		return payload
+	}
+	// allowOrphanOutputs=true: don't drop outputs without matching calls
+	updatedRaw, errRepair := repairResponsesToolCallsArray(nil, nil, "", input.Raw, true)
+	if errRepair != nil || updatedRaw == "" || updatedRaw == input.Raw {
+		return payload
+	}
+	updated, errSet := sjson.SetRawBytes(payload, "input", []byte(updatedRaw))
+	if errSet != nil {
+		return payload
+	}
+	return updated
 }


### PR DESCRIPTION
## Summary

Apply the same `repairResponsesToolCallsArray` logic to the HTTP `/v1/responses` path that already exists for WebSocket.

MiniMax upstream rejects requests where `function_call_output` items appear before their corresponding `function_call` items in the `input` array (2013 error). The WebSocket handler already fixes this via `repairResponsesWebsocketToolCalls()`, but the HTTP path was missing the fix entirely.

## Changes

### `sdk/api/handlers/openai/openai_responses_handlers.go`
- `Responses()`: call `repairResponsesWebsocketToolCalls()` at the top before dispatching to streaming/non-streaming handlers
- `Compact()`: same fix applied before executing the compact request

### `sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go`
- Add `httpResponsesSessionKey()` to derive a deterministic session key from `model`+`previous_response_id` for per-session tool call cache lookups in HTTP context

## Behavior

After this change, the HTTP `/v1/responses` path behaves identically to WebSocket: the `input` array is reordered so each `function_call_output` immediately follows its `function_call` before the request is forwarded to upstream.

This fixes the 2013 error when using MiniMax models via the HTTP path through cc-switch or direct API calls.