### PR TITLE
feat: add GPT-5.5, Claude 4.7, DeepSeek support and 401-bak backup

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -114,6 +114,14 @@ routing:
 # When true, enable authentication for the WebSocket API (/v1/ws).
 ws-auth: false
 
+# Unauthorized (401) auth file auto-backup
+# When enabled, auth files that receive 401 errors are automatically moved
+# to a "401-bak" subdirectory under auth-dir.
+# A periodic scan also archives any lingering unauthorized entries.
+# unauthorized-backup:
+#   enabled: true           # default: true
+#   scan-interval: "10m"    # default: "10m"
+
 # When true, enable Gemini CLI internal endpoints (/v1internal:*).
 # Default is false for safety.
 enable-gemini-cli-endpoint: false
@@ -254,6 +262,22 @@ nonstream-keepalive-interval: 0
 #         alias: "claude-opus-4.66"
 #       - name: "kimi-k2.5"
 #         alias: "claude-opus-4.66"
+#
+#   # DeepSeek integration example — uses the OpenAI-compatible API format.
+#   # DeepSeek API is fully compatible with the OpenAI chat/completions endpoint.
+#   # Streaming, tool calling, and reasoning effort are supported natively.
+#   - name: "deepseek"
+#     base-url: "https://api.deepseek.com/v1"
+#     api-key-entries:
+#       - api-key: "sk-..."
+#     models:
+#       - name: "deepseek-chat"
+#         alias: "deepseek-v3"
+#       - name: "deepseek-reasoner"
+#         alias: "deepseek-r1"
+#         thinking:
+#           min: 1
+#           max: 131072
 
 # Vertex API keys (Vertex-compatible endpoints, base-url is optional)
 # vertex-api-key:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	log "github.com/sirupsen/logrus"
@@ -88,6 +89,9 @@ type Config struct {
 
 	// WebsocketAuth enables or disables authentication for the WebSocket API.
 	WebsocketAuth bool `yaml:"ws-auth" json:"ws-auth"`
+
+	// UnauthorizedBackup controls auto-backup of auth files that receive 401 errors.
+	UnauthorizedBackup UnauthorizedBackupConfig `yaml:"unauthorized-backup" json:"unauthorized-backup"`
 
 	// AntigravitySignatureCacheEnabled controls whether signature cache validation is enabled for thinking blocks.
 	// When true (default), cached signatures are preferred and validated.
@@ -209,6 +213,35 @@ type QuotaExceeded struct {
 	// AntigravityCredits indicates whether to retry Antigravity quota_exhausted 429s once
 	// on the same credential with enabledCreditTypes=["GOOGLE_ONE_AI"].
 	AntigravityCredits bool `yaml:"antigravity-credits" json:"antigravity-credits"`
+}
+
+// UnauthorizedBackupConfig controls automatic backup of auth files that receive 401 errors.
+type UnauthorizedBackupConfig struct {
+	// Enabled toggles the 401-bak auto-backup feature. Default: true.
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	// ScanInterval specifies how often to scan for unauthorized auth files.
+	// Default: "10m". Accepts duration strings like "5m", "30m", "1h".
+	ScanInterval string `yaml:"scan-interval,omitempty" json:"scan-interval,omitempty"`
+}
+
+// IsEnabled returns whether unauthorized backup is enabled (defaults to true).
+func (c UnauthorizedBackupConfig) IsEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// GetScanInterval parses ScanInterval or returns the default of 10 minutes.
+func (c UnauthorizedBackupConfig) GetScanInterval() time.Duration {
+	if c.ScanInterval == "" {
+		return 10 * time.Minute
+	}
+	d, err := time.ParseDuration(c.ScanInterval)
+	if err != nil || d <= 0 {
+		return 10 * time.Minute
+	}
+	return d
 }
 
 // RoutingConfig configures how credentials are selected for requests.

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -20,6 +20,7 @@ type staticModelsJSON struct {
 	IFlow       []*ModelInfo `json:"iflow"`
 	Kimi        []*ModelInfo `json:"kimi"`
 	Antigravity []*ModelInfo `json:"antigravity"`
+	DeepSeek    []*ModelInfo `json:"deepseek"`
 }
 
 // GetClaudeModels returns the standard Claude model definitions.
@@ -82,6 +83,11 @@ func GetAntigravityModels() []*ModelInfo {
 	return cloneModelInfos(getModels().Antigravity)
 }
 
+// GetDeepSeekModels returns the standard DeepSeek model definitions.
+func GetDeepSeekModels() []*ModelInfo {
+	return cloneModelInfos(getModels().DeepSeek)
+}
+
 // cloneModelInfos returns a shallow copy of the slice with each element deep-cloned.
 func cloneModelInfos(models []*ModelInfo) []*ModelInfo {
 	if len(models) == 0 {
@@ -128,6 +134,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		return GetKimiModels()
 	case "antigravity":
 		return GetAntigravityModels()
+	case "deepseek":
+		return GetDeepSeekModels()
 	default:
 		return nil
 	}
@@ -151,6 +159,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		data.IFlow,
 		data.Kimi,
 		data.Antigravity,
+		data.DeepSeek,
 	}
 	for _, models := range allModels {
 		for _, m := range models {

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -31,6 +31,48 @@
       }
     },
     {
+      "id": "claude-opus-4-7",
+      "object": "model",
+      "created": 1776988800,
+      "owned_by": "anthropic",
+      "type": "claude",
+      "display_name": "Claude 4.7 Opus",
+      "description": "Most capable Claude model with maximum intelligence and extended context",
+      "context_length": 1000000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "max"
+        ]
+      }
+    },
+    {
+      "id": "claude-sonnet-4-7",
+      "object": "model",
+      "created": 1776988800,
+      "owned_by": "anthropic",
+      "type": "claude",
+      "display_name": "Claude 4.7 Sonnet",
+      "context_length": 200000,
+      "max_completion_tokens": 64000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
       "id": "claude-sonnet-4-6",
       "object": "model",
       "created": 1771372800,
@@ -1269,6 +1311,52 @@
           "xhigh"
         ]
       }
+    },
+    {
+      "id": "gpt-5.5",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.5",
+      "version": "gpt-5.5",
+      "description": "Stable version of GPT 5.5, the latest frontier model.",
+      "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.5-codex",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.5 Codex",
+      "version": "gpt-5.5",
+      "description": "GPT 5.5 Codex, optimized for coding and agentic tasks.",
+      "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     }
   ],
   "codex-team": [
@@ -1352,6 +1440,52 @@
       "version": "gpt-5.4-mini",
       "description": "GPT-5.4 mini brings the strengths of GPT-5.4 to a faster, more efficient model designed for high-volume workloads.",
       "context_length": 400000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.5",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.5",
+      "version": "gpt-5.5",
+      "description": "Stable version of GPT 5.5, the latest frontier model.",
+      "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.5-codex",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.5 Codex",
+      "version": "gpt-5.5",
+      "description": "GPT 5.5 Codex, optimized for coding and agentic tasks.",
+      "context_length": 1050000,
       "max_completion_tokens": 128000,
       "supported_parameters": [
         "tools"
@@ -1482,6 +1616,52 @@
           "xhigh"
         ]
       }
+    },
+    {
+      "id": "gpt-5.5",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.5",
+      "version": "gpt-5.5",
+      "description": "Stable version of GPT 5.5, the latest frontier model.",
+      "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.5-codex",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.5 Codex",
+      "version": "gpt-5.5",
+      "description": "GPT 5.5 Codex, optimized for coding and agentic tasks.",
+      "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     }
   ],
   "codex-pro": [
@@ -1588,6 +1768,52 @@
       "version": "gpt-5.4-mini",
       "description": "GPT-5.4 mini brings the strengths of GPT-5.4 to a faster, more efficient model designed for high-volume workloads.",
       "context_length": 400000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.5",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.5",
+      "version": "gpt-5.5",
+      "description": "Stable version of GPT 5.5, the latest frontier model.",
+      "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.5-codex",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.5 Codex",
+      "version": "gpt-5.5",
+      "description": "GPT 5.5 Codex, optimized for coding and agentic tasks.",
+      "context_length": 1050000,
       "max_completion_tokens": 128000,
       "supported_parameters": [
         "tools"
@@ -2020,6 +2246,53 @@
           "high"
         ]
       }
+    }
+  ],
+  "deepseek": [
+    {
+      "id": "deepseek-chat",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "deepseek",
+      "type": "deepseek",
+      "display_name": "DeepSeek Chat",
+      "version": "v3",
+      "description": "DeepSeek V3, high-performance general-purpose model.",
+      "context_length": 1000000,
+      "max_completion_tokens": 32768,
+      "supported_parameters": [
+        "tools"
+      ]
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "deepseek",
+      "type": "deepseek",
+      "display_name": "DeepSeek V4 Flash",
+      "version": "v4-flash",
+      "description": "DeepSeek V4 Flash, fast and cost-effective for high-throughput tasks.",
+      "context_length": 1000000,
+      "max_completion_tokens": 32768,
+      "supported_parameters": [
+        "tools"
+      ]
+    },
+    {
+      "id": "deepseek-v4-pro",
+      "object": "model",
+      "created": 1776297600,
+      "owned_by": "deepseek",
+      "type": "deepseek",
+      "display_name": "DeepSeek V4 Pro",
+      "version": "v4-pro",
+      "description": "DeepSeek V4 Pro, latest generation flagship model.",
+      "context_length": 1000000,
+      "max_completion_tokens": 32768,
+      "supported_parameters": [
+        "tools"
+      ]
     }
   ]
 }

--- a/sdk/auth/backup.go
+++ b/sdk/auth/backup.go
@@ -1,0 +1,158 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+const backupSubDir = "401-bak"
+
+// MoveToBackup moves the auth file for the given auth record into the 401-bak
+// subdirectory under the configured auth directory. The operation is idempotent:
+// if the file is already in 401-bak or does not exist, it returns nil.
+func (s *FileTokenStore) MoveToBackup(ctx context.Context, auth *cliproxyauth.Auth) error {
+	if auth == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	srcPath, err := s.resolveAuthPath(auth)
+	if err != nil {
+		return fmt.Errorf("resolve auth path: %w", err)
+	}
+	if srcPath == "" {
+		log.Debugf("401-bak: skipping %s — no resolvable path", maskSensitiveID(auth.ID))
+		return nil
+	}
+
+	if _, statErr := os.Stat(srcPath); os.IsNotExist(statErr) {
+		return nil
+	}
+
+	dir := filepath.Dir(srcPath)
+	if filepath.Base(dir) == backupSubDir {
+		return nil
+	}
+
+	backupDir := filepath.Join(dir, backupSubDir)
+	if err = os.MkdirAll(backupDir, 0o700); err != nil {
+		return fmt.Errorf("create 401-bak dir: %w", err)
+	}
+
+	baseName := filepath.Base(srcPath)
+	dstPath := filepath.Join(backupDir, baseName)
+
+	if _, statErr := os.Stat(dstPath); statErr == nil {
+		dstPath = deduplicatePath(backupDir, baseName)
+	}
+
+	maskedID := maskSensitiveID(auth.ID)
+	log.Infof("401-bak: moving auth %s to %s", maskedID, backupSubDir)
+
+	if err = os.Rename(srcPath, dstPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		log.Errorf("401-bak: failed to move %s: %v", maskedID, err)
+		return fmt.Errorf("move to 401-bak: %w", err)
+	}
+
+	log.Infof("401-bak: successfully moved %s -> %s", maskedID, filepath.Base(dstPath))
+	return nil
+}
+
+// BackupScanner periodically queries the Manager for auth entries that are
+// in unauthorized (401) state and moves their backing files to 401-bak.
+type BackupScanner struct {
+	store    *FileTokenStore
+	manager  *cliproxyauth.Manager
+	interval time.Duration
+	stopCh   chan struct{}
+	once     sync.Once
+}
+
+// NewBackupScanner creates a scanner that runs at the specified interval.
+func NewBackupScanner(store *FileTokenStore, manager *cliproxyauth.Manager, interval time.Duration) *BackupScanner {
+	if interval <= 0 {
+		interval = 10 * time.Minute
+	}
+	return &BackupScanner{
+		store:    store,
+		manager:  manager,
+		interval: interval,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start begins the periodic scan loop in a background goroutine.
+func (bs *BackupScanner) Start() {
+	go bs.run()
+}
+
+// Stop terminates the background scan loop.
+func (bs *BackupScanner) Stop() {
+	bs.once.Do(func() { close(bs.stopCh) })
+}
+
+func (bs *BackupScanner) run() {
+	ticker := time.NewTicker(bs.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-bs.stopCh:
+			return
+		case <-ticker.C:
+			bs.scan()
+		}
+	}
+}
+
+func (bs *BackupScanner) scan() {
+	if bs.manager == nil || bs.store == nil {
+		return
+	}
+
+	auths := bs.manager.List()
+
+	moved := 0
+	ctx := context.Background()
+	for _, auth := range auths {
+		if auth == nil || auth.StatusMessage != "unauthorized" {
+			continue
+		}
+		if moveErr := bs.store.MoveToBackup(ctx, auth); moveErr != nil {
+			log.Warnf("401-bak scan: move failed for %s: %v", maskSensitiveID(auth.ID), moveErr)
+		} else {
+			moved++
+		}
+	}
+
+	if moved > 0 {
+		log.Infof("401-bak scan: moved %d unauthorized auth file(s)", moved)
+	}
+}
+
+func deduplicatePath(dir, baseName string) string {
+	ext := filepath.Ext(baseName)
+	nameOnly := strings.TrimSuffix(baseName, ext)
+	ts := time.Now().Format("20060102-150405.000000000")
+	return filepath.Join(dir, fmt.Sprintf("%s_%s%s", nameOnly, ts, ext))
+}
+
+func maskSensitiveID(id string) string {
+	if len(id) <= 8 {
+		return "***"
+	}
+	return id[:4] + "***" + id[len(id)-3:]
+}

--- a/sdk/auth/backup_hook.go
+++ b/sdk/auth/backup_hook.go
@@ -1,0 +1,66 @@
+package auth
+
+import (
+	"context"
+	"sync/atomic"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+// BackupOnUnauthorizedHook wraps an existing Hook and triggers 401-bak
+// file movement when execution results indicate a 401 unauthorized error.
+type BackupOnUnauthorizedHook struct {
+	inner   cliproxyauth.Hook
+	store   *FileTokenStore
+	enabled atomic.Bool
+}
+
+// NewBackupOnUnauthorizedHook creates a hook that delegates to inner and
+// additionally moves auth files to 401-bak on 401 errors.
+func NewBackupOnUnauthorizedHook(inner cliproxyauth.Hook, store *FileTokenStore, enabled bool) *BackupOnUnauthorizedHook {
+	if inner == nil {
+		inner = cliproxyauth.NoopHook{}
+	}
+	h := &BackupOnUnauthorizedHook{inner: inner, store: store}
+	h.enabled.Store(enabled)
+	return h
+}
+
+// SetEnabled dynamically toggles the 401-bak backup feature.
+func (h *BackupOnUnauthorizedHook) SetEnabled(v bool) {
+	h.enabled.Store(v)
+}
+
+func (h *BackupOnUnauthorizedHook) OnAuthRegistered(ctx context.Context, auth *cliproxyauth.Auth) {
+	h.inner.OnAuthRegistered(ctx, auth)
+}
+
+func (h *BackupOnUnauthorizedHook) OnAuthUpdated(ctx context.Context, auth *cliproxyauth.Auth) {
+	h.inner.OnAuthUpdated(ctx, auth)
+}
+
+func (h *BackupOnUnauthorizedHook) OnResult(ctx context.Context, result cliproxyauth.Result) {
+	h.inner.OnResult(ctx, result)
+
+	if !h.enabled.Load() {
+		return
+	}
+	if result.Error == nil || result.Success {
+		return
+	}
+	if result.Error.HTTPStatus != 401 {
+		return
+	}
+	if h.store == nil || result.AuthID == "" {
+		return
+	}
+
+	auth := &cliproxyauth.Auth{
+		ID:       result.AuthID,
+		FileName: result.AuthID,
+	}
+	if err := h.store.MoveToBackup(ctx, auth); err != nil {
+		log.Warnf("401-bak hook: move failed for %s: %v", maskSensitiveID(result.AuthID), err)
+	}
+}

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -237,7 +237,22 @@ func (b *Builder) Build() (*Service, error) {
 			})
 		}
 
-		coreManager = coreauth.NewManager(tokenStore, selector, nil)
+		backupEnabled := b.cfg != nil && b.cfg.UnauthorizedBackup.IsEnabled()
+
+		var authHook coreauth.Hook
+		var backupFileStore *sdkAuth.FileTokenStore
+		if fileStore, ok := tokenStore.(*sdkAuth.FileTokenStore); ok {
+			backupFileStore = fileStore
+			authHook = sdkAuth.NewBackupOnUnauthorizedHook(nil, fileStore, backupEnabled)
+		}
+
+		coreManager = coreauth.NewManager(tokenStore, selector, authHook)
+
+		if backupEnabled && backupFileStore != nil {
+			scanInterval := b.cfg.UnauthorizedBackup.GetScanInterval()
+			scanner := sdkAuth.NewBackupScanner(backupFileStore, coreManager, scanInterval)
+			scanner.Start()
+		}
 	}
 	// Attach a default RoundTripper provider so providers can opt-in per-auth transports.
 	coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())


### PR DESCRIPTION
- models: add gpt-5.5 and gpt-5.5-codex to all codex tiers (free/team/plus/pro)
- models: add claude-opus-4-7 and claude-sonnet-4-7 to claude section
- models: add deepseek section (deepseek-chat, deepseek-v4-flash, deepseek-v4-pro)
- feat(401-bak): auto-move unauthorized auth files to 401-bak on 401 errors
- feat(401-bak): periodic scanner via Manager.List() runtime state
- feat(401-bak): BackupOnUnauthorizedHook wired into builder with config gating
- config: add UnauthorizedBackupConfig (enabled/scan-interval)
- config: add DeepSeek example in config.example.yaml