### PR TITLE
fix(usage): defer retried auth failures

### DIFF
--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -72,7 +73,13 @@ func (r *UsageReporter) publishWithOutcome(ctx context.Context, detail usage.Det
 		}
 	}
 	r.once.Do(func() {
-		usage.PublishRecord(ctx, r.buildRecord(detail, failed))
+		record := r.buildRecord(detail, failed)
+		if failed && cliproxyexecutor.DeferFailure(ctx, func(ctx context.Context) {
+			usage.PublishRecord(ctx, record)
+		}) {
+			return
+		}
+		usage.PublishRecord(ctx, record)
 	})
 }
 

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -1,11 +1,59 @@
 package helps
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 )
+
+type usageReporterCapturePlugin struct {
+	provider string
+	records  chan usage.Record
+}
+
+func (p *usageReporterCapturePlugin) HandleUsage(_ context.Context, record usage.Record) {
+	if record.Provider != p.provider {
+		return
+	}
+	select {
+	case p.records <- record:
+	default:
+	}
+}
+
+func installUsageReporterCapturePlugin(t *testing.T) *usageReporterCapturePlugin {
+	t.Helper()
+	plugin := &usageReporterCapturePlugin{
+		provider: fmt.Sprintf("usage-reporter-test-%d", time.Now().UnixNano()),
+		records:  make(chan usage.Record, 4),
+	}
+	usage.RegisterPlugin(plugin)
+	return plugin
+}
+
+func readUsageReporterRecord(t *testing.T, plugin *usageReporterCapturePlugin) usage.Record {
+	t.Helper()
+	select {
+	case record := <-plugin.records:
+		return record
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for usage record")
+	}
+	return usage.Record{}
+}
+
+func assertNoUsageReporterRecord(t *testing.T, plugin *usageReporterCapturePlugin) {
+	t.Helper()
+	select {
+	case record := <-plugin.records:
+		t.Fatalf("unexpected usage record: %+v", record)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
 
 func TestParseOpenAIUsageChatCompletions(t *testing.T) {
 	data := []byte(`{"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3,"prompt_tokens_details":{"cached_tokens":4},"completion_tokens_details":{"reasoning_tokens":5}}}`)
@@ -61,4 +109,67 @@ func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 	if record.Latency > 3*time.Second {
 		t.Fatalf("latency = %v, want <= 3s", record.Latency)
 	}
+}
+
+func TestUsageReporterPublishesFailureWithoutDeferral(t *testing.T) {
+	plugin := installUsageReporterCapturePlugin(t)
+	reporter := NewUsageReporter(context.Background(), plugin.provider, "test-model", nil)
+
+	reporter.PublishFailure(context.Background())
+
+	record := readUsageReporterRecord(t, plugin)
+	if !record.Failed {
+		t.Fatalf("expected failed usage record, got success: %+v", record)
+	}
+	if record.Provider != plugin.provider {
+		t.Fatalf("provider = %q, want %q", record.Provider, plugin.provider)
+	}
+}
+
+func TestUsageReporterDefersFailureUntilFlush(t *testing.T) {
+	plugin := installUsageReporterCapturePlugin(t)
+	ctx, deferred := cliproxyexecutor.WithDeferredFailure(context.Background())
+	reporter := NewUsageReporter(ctx, plugin.provider, "test-model", nil)
+
+	reporter.PublishFailure(ctx)
+	assertNoUsageReporterRecord(t, plugin)
+
+	deferred.Flush(ctx)
+	record := readUsageReporterRecord(t, plugin)
+	if !record.Failed {
+		t.Fatalf("expected failed usage record, got success: %+v", record)
+	}
+}
+
+func TestUsageReporterDiscardedDeferredFailureIsNotPublished(t *testing.T) {
+	plugin := installUsageReporterCapturePlugin(t)
+	ctx, deferred := cliproxyexecutor.WithDeferredFailure(context.Background())
+	reporter := NewUsageReporter(ctx, plugin.provider, "test-model", nil)
+
+	reporter.PublishFailure(ctx)
+	deferred.Discard()
+	deferred.Flush(ctx)
+
+	assertNoUsageReporterRecord(t, plugin)
+}
+
+func TestUsageReporterSuccessClosesDeferredFailureScope(t *testing.T) {
+	plugin := installUsageReporterCapturePlugin(t)
+	ctx, deferred := cliproxyexecutor.WithDeferredFailure(context.Background())
+	failureReporter := NewUsageReporter(ctx, plugin.provider, "test-model", nil)
+	successReporter := NewUsageReporter(ctx, plugin.provider, "test-model", nil)
+
+	failureReporter.PublishFailure(ctx)
+	successReporter.Publish(ctx, usage.Detail{TotalTokens: 7})
+	deferred.Discard()
+	deferred.Flush(ctx)
+
+	record := readUsageReporterRecord(t, plugin)
+	if record.Failed {
+		t.Fatalf("expected successful usage record, got failed: %+v", record)
+	}
+	if record.Detail.TotalTokens != 7 {
+		t.Fatalf("total tokens = %d, want 7", record.Detail.TotalTokens)
+	}
+	assertNoUsageReporterRecord(t, plugin)
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1183,6 +1183,8 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 	if len(normalized) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
+	ctx, deferredFailure := cliproxyexecutor.WithDeferredFailure(ctx)
+	defer deferredFailure.Flush(ctx)
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
@@ -1190,6 +1192,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 	for attempt := 0; ; attempt++ {
 		resp, errExec := m.executeMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
 		if errExec == nil {
+			deferredFailure.Discard()
 			return resp, nil
 		}
 		lastErr = errExec
@@ -1204,6 +1207,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 	if lastErr != nil {
 		if shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
 			if resp, ok := m.tryAntigravityCreditsExecute(ctx, req, opts); ok {
+				deferredFailure.Discard()
 				return resp, nil
 			}
 		}
@@ -1249,6 +1253,8 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	if len(normalized) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
+	ctx, deferredFailure := cliproxyexecutor.WithDeferredFailure(ctx)
+	defer deferredFailure.Flush(ctx)
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
@@ -1256,6 +1262,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	for attempt := 0; ; attempt++ {
 		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
 		if errStream == nil {
+			deferredFailure.Discard()
 			return result, nil
 		}
 		lastErr = errStream
@@ -1270,6 +1277,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	if lastErr != nil {
 		if shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
 			if result, ok := m.tryAntigravityCreditsExecuteStream(ctx, req, opts); ok {
+				deferredFailure.Discard()
 				return result, nil
 			}
 		}

--- a/sdk/cliproxy/auth/conductor_usage_test.go
+++ b/sdk/cliproxy/auth/conductor_usage_test.go
@@ -1,0 +1,237 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+)
+
+type usageCapturePlugin struct {
+	provider string
+	records  chan usage.Record
+}
+
+func (p *usageCapturePlugin) HandleUsage(_ context.Context, record usage.Record) {
+	if record.Provider != p.provider {
+		return
+	}
+	select {
+	case p.records <- record:
+	default:
+	}
+}
+
+func installUsageCapturePlugin(t *testing.T, provider string) *usageCapturePlugin {
+	t.Helper()
+	plugin := &usageCapturePlugin{provider: provider, records: make(chan usage.Record, 8)}
+	usage.RegisterPlugin(plugin)
+	return plugin
+}
+
+type usagePublishingExecutor struct {
+	id          string
+	failAuthIDs map[string]bool
+}
+
+func (e *usagePublishingExecutor) Identifier() string { return e.id }
+
+func (e *usagePublishingExecutor) Execute(ctx context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if e.failAuthIDs[auth.ID] {
+		publishUsageRecord(ctx, usage.Record{Provider: e.id, Model: "test-model", AuthID: auth.ID, Failed: true})
+		return cliproxyexecutor.Response{}, errors.New("retryable upstream failure")
+	}
+	publishUsageRecord(ctx, usage.Record{Provider: e.id, Model: "test-model", AuthID: auth.ID, Detail: usage.Detail{TotalTokens: 3}})
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID)}, nil
+}
+
+func (e *usagePublishingExecutor) ExecuteStream(ctx context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	if e.failAuthIDs[auth.ID] {
+		publishUsageRecord(ctx, usage.Record{Provider: e.id, Model: "test-model", AuthID: auth.ID, Failed: true})
+		chunks <- cliproxyexecutor.StreamChunk{Err: errors.New("retryable upstream stream failure")}
+		close(chunks)
+		return &cliproxyexecutor.StreamResult{Headers: http.Header{}, Chunks: chunks}, nil
+	}
+	publishUsageRecord(ctx, usage.Record{Provider: e.id, Model: "test-model", AuthID: auth.ID, Detail: usage.Detail{TotalTokens: 3}})
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(auth.ID)}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Headers: http.Header{}, Chunks: chunks}, nil
+}
+
+func publishUsageRecord(ctx context.Context, record usage.Record) {
+	if record.Failed && cliproxyexecutor.DeferFailure(ctx, func(ctx context.Context) {
+		usage.PublishRecord(ctx, record)
+	}) {
+		return
+	}
+	usage.PublishRecord(ctx, record)
+}
+
+func (e *usagePublishingExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *usagePublishingExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *usagePublishingExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func newUsageRetryTestManager(t *testing.T, failAuthIDs map[string]bool) (*Manager, string, string, string, string) {
+	t.Helper()
+	manager := NewManager(nil, nil, nil)
+	provider := "usage-test-" + uuid.NewString()
+	executor := &usagePublishingExecutor{id: provider, failAuthIDs: failAuthIDs}
+	manager.RegisterExecutor(executor)
+
+	model := "test-model"
+	prefix := uuid.NewString()
+	firstAuthID := prefix + "-auth-1"
+	secondAuthID := prefix + "-auth-2"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(firstAuthID, provider, []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient(secondAuthID, provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(firstAuthID)
+		reg.UnregisterClient(secondAuthID)
+	})
+
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: firstAuthID, Provider: provider}); errRegister != nil {
+		t.Fatalf("register first auth: %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: secondAuthID, Provider: provider}); errRegister != nil {
+		t.Fatalf("register second auth: %v", errRegister)
+	}
+	return manager, provider, model, firstAuthID, secondAuthID
+}
+
+func readUsageRecord(t *testing.T, plugin *usageCapturePlugin) usage.Record {
+	t.Helper()
+	select {
+	case record := <-plugin.records:
+		return record
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for usage record")
+	}
+	return usage.Record{}
+}
+
+func assertNoUsageRecord(t *testing.T, plugin *usageCapturePlugin) {
+	t.Helper()
+	select {
+	case record := <-plugin.records:
+		t.Fatalf("unexpected usage record: %+v", record)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestManagerExecuteDiscardsRetriedFailedUsageAfterSuccess(t *testing.T) {
+	failAuthIDs := map[string]bool{}
+	manager, provider, model, firstAuthID, secondAuthID := newUsageRetryTestManager(t, failAuthIDs)
+	plugin := installUsageCapturePlugin(t, provider)
+	failAuthIDs[firstAuthID] = true
+
+	resp, errExecute := manager.Execute(context.Background(), []string{provider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("execute error = %v, want success", errExecute)
+	}
+	if string(resp.Payload) != secondAuthID {
+		t.Fatalf("payload = %q, want %q", string(resp.Payload), secondAuthID)
+	}
+
+	record := readUsageRecord(t, plugin)
+	if record.Failed {
+		t.Fatalf("expected successful usage record, got failed: %+v", record)
+	}
+	if record.AuthID != secondAuthID {
+		t.Fatalf("usage auth = %q, want %q", record.AuthID, secondAuthID)
+	}
+	assertNoUsageRecord(t, plugin)
+}
+
+func TestManagerExecuteFlushesLastFailedUsageWhenAllRetriesFail(t *testing.T) {
+	failAuthIDs := map[string]bool{}
+	manager, provider, model, firstAuthID, secondAuthID := newUsageRetryTestManager(t, failAuthIDs)
+	plugin := installUsageCapturePlugin(t, provider)
+	failAuthIDs[firstAuthID] = true
+	failAuthIDs[secondAuthID] = true
+
+	_, errExecute := manager.Execute(context.Background(), []string{provider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExecute == nil {
+		t.Fatal("expected execute error")
+	}
+
+	record := readUsageRecord(t, plugin)
+	if !record.Failed {
+		t.Fatalf("expected failed usage record, got success: %+v", record)
+	}
+	if record.AuthID != secondAuthID {
+		t.Fatalf("usage auth = %q, want last failed auth %q", record.AuthID, secondAuthID)
+	}
+	assertNoUsageRecord(t, plugin)
+}
+
+func TestManagerExecuteFlushesLastFailedUsageWhenRetryWaitIsCanceled(t *testing.T) {
+	failAuthIDs := map[string]bool{}
+	manager, provider, model, firstAuthID, _ := newUsageRetryTestManager(t, failAuthIDs)
+	plugin := installUsageCapturePlugin(t, provider)
+	failAuthIDs[firstAuthID] = true
+	manager.SetRetryConfig(1, time.Second, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, errExecute := manager.Execute(ctx, []string{provider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if !errors.Is(errExecute, context.Canceled) {
+		t.Fatalf("execute error = %v, want context canceled", errExecute)
+	}
+
+	record := readUsageRecord(t, plugin)
+	if !record.Failed {
+		t.Fatalf("expected failed usage record, got success: %+v", record)
+	}
+	if record.AuthID != firstAuthID {
+		t.Fatalf("usage auth = %q, want canceled retry auth %q", record.AuthID, firstAuthID)
+	}
+	assertNoUsageRecord(t, plugin)
+}
+
+func TestManagerExecuteStreamDiscardsRetriedFailedUsageAfterSuccess(t *testing.T) {
+	failAuthIDs := map[string]bool{}
+	manager, provider, model, firstAuthID, secondAuthID := newUsageRetryTestManager(t, failAuthIDs)
+	plugin := installUsageCapturePlugin(t, provider)
+	failAuthIDs[firstAuthID] = true
+
+	streamResult, errExecute := manager.ExecuteStream(context.Background(), []string{provider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("execute stream error = %v, want success", errExecute)
+	}
+	var payload []byte
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v, want success", chunk.Err)
+		}
+		payload = append(payload, chunk.Payload...)
+	}
+	if string(payload) != secondAuthID {
+		t.Fatalf("payload = %q, want %q", string(payload), secondAuthID)
+	}
+
+	record := readUsageRecord(t, plugin)
+	if record.Failed {
+		t.Fatalf("expected successful usage record, got failed: %+v", record)
+	}
+	if record.AuthID != secondAuthID {
+		t.Fatalf("usage auth = %q, want %q", record.AuthID, secondAuthID)
+	}
+	assertNoUsageRecord(t, plugin)
+}

--- a/sdk/cliproxy/executor/context.go
+++ b/sdk/cliproxy/executor/context.go
@@ -1,6 +1,10 @@
 package executor
 
-import "context"
+import (
+	"context"
+	"runtime"
+	"sync/atomic"
+)
 
 type downstreamWebsocketContextKey struct{}
 
@@ -20,4 +24,100 @@ func DownstreamWebsocket(ctx context.Context) bool {
 	raw := ctx.Value(downstreamWebsocketContextKey{})
 	enabled, ok := raw.(bool)
 	return ok && enabled
+}
+
+type deferredFailureContextKey struct{}
+type deferredFailurePublisher func(context.Context)
+
+const (
+	deferredFailureOpen int32 = iota
+	deferredFailureUpdating
+	deferredFailureClosed
+)
+
+// DeferredFailure holds a request-scoped failed-attempt publisher until the
+// caller knows whether the logical request ultimately succeeds or fails.
+type DeferredFailure struct {
+	state atomic.Int32
+	last  atomic.Value
+}
+
+// WithDeferredFailure returns a context that can defer failed attempt
+// publishers. It is used by retrying callers to avoid reporting intermediate
+// attempt failures as final request failures.
+func WithDeferredFailure(ctx context.Context) (context.Context, *DeferredFailure) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	deferred := &DeferredFailure{}
+	return context.WithValue(ctx, deferredFailureContextKey{}, deferred), deferred
+}
+
+// DeferFailure stores the latest failed-attempt publisher. It returns true when
+// the failure was deferred and false when callers should publish immediately.
+func DeferFailure(ctx context.Context, publish func(context.Context)) bool {
+	if ctx == nil || publish == nil {
+		return false
+	}
+	deferred, _ := ctx.Value(deferredFailureContextKey{}).(*DeferredFailure)
+	if deferred == nil {
+		return false
+	}
+	for {
+		switch deferred.state.Load() {
+		case deferredFailureClosed:
+			return false
+		case deferredFailureUpdating:
+			runtime.Gosched()
+		default:
+			if deferred.state.CompareAndSwap(deferredFailureOpen, deferredFailureUpdating) {
+				deferred.last.Store(deferredFailurePublisher(publish))
+				deferred.state.Store(deferredFailureOpen)
+				return true
+			}
+		}
+	}
+}
+
+// Discard drops any deferred failure and closes the deferral scope.
+func (d *DeferredFailure) Discard() {
+	if d == nil {
+		return
+	}
+	for {
+		switch d.state.Load() {
+		case deferredFailureClosed:
+			return
+		case deferredFailureUpdating:
+			runtime.Gosched()
+		default:
+			if d.state.CompareAndSwap(deferredFailureOpen, deferredFailureClosed) {
+				return
+			}
+		}
+	}
+}
+
+// Flush publishes the latest deferred failure, if any, and closes the scope.
+func (d *DeferredFailure) Flush(ctx context.Context) {
+	if d == nil {
+		return
+	}
+	for {
+		switch d.state.Load() {
+		case deferredFailureClosed:
+			return
+		case deferredFailureUpdating:
+			runtime.Gosched()
+		default:
+			if d.state.CompareAndSwap(deferredFailureOpen, deferredFailureClosed) {
+				if raw := d.last.Load(); raw != nil {
+					if publish, ok := raw.(deferredFailurePublisher); ok && publish != nil {
+						publish(ctx)
+					}
+				}
+				return
+			}
+		}
+	}
 }

--- a/sdk/cliproxy/executor/context_test.go
+++ b/sdk/cliproxy/executor/context_test.go
@@ -1,0 +1,88 @@
+package executor
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDeferFailureWithoutScopePublishesImmediately(t *testing.T) {
+	called := false
+	if DeferFailure(context.Background(), func(context.Context) { called = true }) {
+		t.Fatal("expected failure not to be deferred without a scope")
+	}
+	if called {
+		t.Fatal("deferred publisher should not be called by DeferFailure")
+	}
+}
+
+func TestDeferredFailureFlushPublishesLatestFailure(t *testing.T) {
+	ctx, deferred := WithDeferredFailure(context.Background())
+	var published []string
+
+	if !DeferFailure(ctx, func(context.Context) { published = append(published, "first") }) {
+		t.Fatal("expected first failure to be deferred")
+	}
+	if !DeferFailure(ctx, func(context.Context) { published = append(published, "last") }) {
+		t.Fatal("expected last failure to be deferred")
+	}
+
+	deferred.Flush(ctx)
+	if len(published) != 1 || published[0] != "last" {
+		t.Fatalf("published = %v, want [last]", published)
+	}
+}
+
+func TestDeferredFailureDiscardSuppressesFailure(t *testing.T) {
+	ctx, deferred := WithDeferredFailure(context.Background())
+	var called atomic.Bool
+
+	if !DeferFailure(ctx, func(context.Context) { called.Store(true) }) {
+		t.Fatal("expected failure to be deferred")
+	}
+	deferred.Discard()
+	deferred.Flush(ctx)
+
+	if called.Load() {
+		t.Fatal("discarded failure was published")
+	}
+}
+
+func TestDeferredFailureAfterCloseDoesNotDefer(t *testing.T) {
+	ctx, deferred := WithDeferredFailure(context.Background())
+	deferred.Flush(ctx)
+
+	if DeferFailure(ctx, func(context.Context) {}) {
+		t.Fatal("expected closed scope not to defer failures")
+	}
+}
+
+func TestDeferredFailureConcurrentFlushPublishesAtMostOnce(t *testing.T) {
+	ctx, deferred := WithDeferredFailure(context.Background())
+	var published atomic.Int32
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = DeferFailure(ctx, func(context.Context) {
+				published.Add(1)
+			})
+		}()
+	}
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			deferred.Flush(ctx)
+		}()
+	}
+	wg.Wait()
+	deferred.Flush(ctx)
+
+	if got := published.Load(); got > 1 {
+		t.Fatalf("published count = %d, want at most 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

This PR aligns usage reporting with the final logical request outcome across auth/model retries.

Executors can publish usage for each provider attempt, while the auth conductor may retry another auth/model after an intermediate failure and eventually return success to the client. Before this change, those retried internal failures could be recorded as user-visible failed usage rows even when the logical request succeeded.

The fix is request-scoped and provider-agnostic:

- Retrying callers install a request-scoped deferred-failure context.
- `UsageReporter` defers failed usage records when that context is present.
- If a later attempt succeeds, the conductor discards the deferred failure.
- If all attempts fail, the conductor flushes the latest deferred failure.

This keeps usage accounting aligned with the final request outcome while preserving retry/auth failure telemetry in the conductor, hooks, and logs.

## Implementation notes

- `auth/conductor.go` does not import or depend on `usage`.
- `sdk/cliproxy/usage/manager.go` is unchanged.
- No business-layer package, database logic, provider-specific rule, or billing logic is involved.
- The deferral helper lives in `sdk/cliproxy/executor/context.go`, next to other executor request context helpers.
- The helper does not use `sync.Mutex`; it uses a small atomic state machine to safely coordinate stream goroutines and conductor finalization.

## Why

A restored local stack with a mixed Codex auth pool reproduced the issue with real requests:

- 5 real `/v1/responses` requests to `gpt-5.4`
- Client responses: all HTTP 200
- Usage rows before the fix: 16 total
  - 11 failed rows: `provider=codex`, `model=gpt-5.4`, `failed=true`, `error_status_code=500`, `total_tokens=0`
  - 5 successful rows for the same logical requests
- App logs for the same window showed intermediate retry/auth failures:
  - `rate limited: too many requests provider=codex model=gpt-5.4`

Those failed rows represented internal retry attempts, not final client-visible request failures.

## Validation

Unit tests:

```bash
go test ./sdk/cliproxy/executor ./sdk/cliproxy/usage ./sdk/cliproxy/auth ./internal/runtime/executor/helps
go test -race ./sdk/cliproxy/executor ./sdk/cliproxy/usage ./sdk/cliproxy/auth ./internal/runtime/executor/helps
```

Added coverage:

- Deferred failure helper has no effect without a deferral scope.
- Multiple deferred failures flush only the latest failure.
- Discard suppresses deferred failure publishing.
- Closed deferral scopes no longer defer failures.
- Concurrent defer/flush publishes at most once.
- Non-stream conductor retry success publishes only successful usage.
- Non-stream conductor all-fail publishes one failed usage.
- Non-stream canceled retry wait flushes the last failed usage.
- Stream conductor retry success publishes only successful usage.

Real local stack validation after the latest changes:

- Same restored local database and mixed auth pool: 22 auth entries, including 21 Codex auths.
- 5 real `/v1/responses` requests to `gpt-5.4`.
- Client responses: all HTTP 200.
- New usage rows after the fix: 5 total.
- Failed usage rows after the fix: 0.
- Failed 500 usage rows after the fix: 0.
- Logs still showed intermediate `rate limited: too many requests provider=codex model=gpt-5.4`, confirming auth retry telemetry remains visible while usage accounting no longer records retried internal failures as final failed usage.
