### PR TITLE
fix(test): remove free tier from GPT-5.5 inclusion test

### DIFF
--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -2,9 +2,15 @@ package registry
 
 import "testing"
 
+func TestCodexFreeModelsExcludeGPT55(t *testing.T) {
+	model := findModelInfo(GetCodexFreeModels(), "gpt-5.5")
+	if model != nil {
+		t.Fatal("expected codex free tier to NOT include gpt-5.5")
+	}
+}
+
 func TestCodexStaticModelsIncludeGPT55(t *testing.T) {
 	tierModels := map[string][]*ModelInfo{
-		"free": GetCodexFreeModels(),
 		"team": GetCodexTeamModels(),
 		"plus": GetCodexPlusModels(),
 		"pro":  GetCodexProModels(),


### PR DESCRIPTION
## Summary

Fixes #3050

The test `TestCodexStaticModelsIncludeGPT55` fails because GPT-5.5 was correctly removed from `codex-free` (commit `7b89583c`) but the test was not updated.

## Changes

- Remove `free` tier from `TestCodexStaticModelsIncludeGPT55` tier map
- Add `TestCodexFreeModelsExcludeGPT55` to explicitly verify GPT-5.5 is not in the free tier

## Verification

```bash
# Tests pass
go test -v -run "TestCodex.*GPT55" ./internal/registry/
# Build succeeds
go build -o test-output ./cmd/server && rm test-output
# Formatted
gofmt -w internal/registry/model_definitions_test.go
```

All checks pass:
- `TestCodexFreeModelsExcludeGPT55` — PASS (new)
- `TestCodexStaticModelsIncludeGPT55/team` — PASS
- `TestCodexStaticModelsIncludeGPT55/plus` — PASS
- `TestCodexStaticModelsIncludeGPT55/pro` — PASS
- Build compiles cleanly