### PR TITLE
feat: add first-class DeepSeek V4 provider

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -203,6 +203,28 @@ nonstream-keepalive-interval: 0
 #     experimental-cch-signing: false # optional: default is false; when true, sign the final /v1/messages body using the current Claude Code cch algorithm
 #                                     # keep this disabled unless you explicitly need the behavior, so upstream seed changes fall back to legacy proxy behavior
 
+# DeepSeek API keys
+# DeepSeek V4 uses the OpenAI-compatible API at https://api.deepseek.com.
+# deepseek-api-key:
+#   - api-key: "sk-..."
+#     prefix: "test" # optional: require calls like "test/deepseek-v4-pro" to target this credential
+#     # base-url defaults to https://api.deepseek.com
+#     base-url: "https://api.deepseek.com"
+#     headers:
+#       X-Custom-Header: "custom-value"
+#     proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
+#     # proxy-url: "direct" # optional: explicit direct connect for this credential
+#     models:
+#       - name: "deepseek-v4-pro"   # upstream model name
+#         alias: "deepseek-latest"  # client alias mapped to the upstream model
+#       - name: "deepseek-v4-flash"
+#         alias: "deepseek-fast"
+#     excluded-models:
+#       - "deepseek-chat"       # exclude specific models (exact match)
+#       - "deepseek-v4-*"       # wildcard matching prefix
+#       - "*-flash"             # wildcard matching suffix
+#       - "*reasoner*"          # wildcard matching substring
+
 # Default headers for Claude API requests. Update when Claude Code releases new versions.
 # In legacy mode, user-agent/package-version/runtime-version/timeout are used as fallbacks
 # when the client omits them, while OS/arch remain runtime-derived. When

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -23,6 +23,11 @@ type codexKeyWithAuthIndex struct {
 	AuthIndex string `json:"auth-index,omitempty"`
 }
 
+type deepSeekKeyWithAuthIndex struct {
+	config.DeepSeekKey
+	AuthIndex string `json:"auth-index,omitempty"`
+}
+
 type vertexCompatKeyWithAuthIndex struct {
 	config.VertexCompatKey
 	AuthIndex string `json:"auth-index,omitempty"`
@@ -158,6 +163,39 @@ func (h *Handler) codexKeysWithAuthIndex() []codexKeyWithAuthIndex {
 		out[i] = codexKeyWithAuthIndex{
 			CodexKey:  entry,
 			AuthIndex: authIndex,
+		}
+	}
+	return out
+}
+
+func (h *Handler) deepSeekKeysWithAuthIndex() []deepSeekKeyWithAuthIndex {
+	if h == nil {
+		return nil
+	}
+	liveIndexByID := h.liveAuthIndexByID()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.cfg == nil {
+		return nil
+	}
+
+	idGen := synthesizer.NewStableIDGenerator()
+	out := make([]deepSeekKeyWithAuthIndex, len(h.cfg.DeepSeekKey))
+	for i := range h.cfg.DeepSeekKey {
+		entry := h.cfg.DeepSeekKey[i]
+		authIndex := ""
+		if key := strings.TrimSpace(entry.APIKey); key != "" {
+			base := strings.TrimSpace(entry.BaseURL)
+			if base == "" {
+				base = config.DefaultDeepSeekBaseURL
+			}
+			id, _ := idGen.Next("deepseek:apikey", key, base)
+			authIndex = liveIndexByID[id]
+		}
+		out[i] = deepSeekKeyWithAuthIndex{
+			DeepSeekKey: entry,
+			AuthIndex:   authIndex,
 		}
 	}
 	return out

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -426,6 +426,189 @@ func (h *Handler) DeleteClaudeKey(c *gin.Context) {
 	c.JSON(400, gin.H{"error": "missing api-key or index"})
 }
 
+// deepseek-api-key: []DeepSeekKey
+func (h *Handler) GetDeepSeekKeys(c *gin.Context) {
+	c.JSON(200, gin.H{"deepseek-api-key": h.deepSeekKeysWithAuthIndex()})
+}
+
+func (h *Handler) PutDeepSeekKeys(c *gin.Context) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+	var arr []config.DeepSeekKey
+	if err = json.Unmarshal(data, &arr); err != nil {
+		var obj struct {
+			Items []config.DeepSeekKey `json:"items"`
+		}
+		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		arr = obj.Items
+	}
+	normalized := make([]config.DeepSeekKey, 0, len(arr))
+	for i := range arr {
+		entry := arr[i]
+		normalizeDeepSeekKey(&entry)
+		if entry.APIKey == "" {
+			continue
+		}
+		normalized = append(normalized, entry)
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.cfg.DeepSeekKey = normalized
+	h.cfg.SanitizeDeepSeekKeys()
+	h.persistLocked(c)
+}
+
+func (h *Handler) PatchDeepSeekKey(c *gin.Context) {
+	type deepSeekKeyPatch struct {
+		APIKey         *string                 `json:"api-key"`
+		Priority       *int                    `json:"priority"`
+		Prefix         *string                 `json:"prefix"`
+		BaseURL        *string                 `json:"base-url"`
+		ProxyURL       *string                 `json:"proxy-url"`
+		Models         *[]config.DeepSeekModel `json:"models"`
+		Headers        *map[string]string      `json:"headers"`
+		ExcludedModels *[]string               `json:"excluded-models"`
+	}
+	var body struct {
+		Index *int              `json:"index"`
+		Match *string           `json:"match"`
+		Value *deepSeekKeyPatch `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	targetIndex := -1
+	if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.DeepSeekKey) {
+		targetIndex = *body.Index
+	}
+	if targetIndex == -1 && body.Match != nil {
+		match := strings.TrimSpace(*body.Match)
+		for i := range h.cfg.DeepSeekKey {
+			if h.cfg.DeepSeekKey[i].APIKey == match {
+				targetIndex = i
+				break
+			}
+		}
+	}
+	if targetIndex == -1 {
+		c.JSON(404, gin.H{"error": "item not found"})
+		return
+	}
+
+	entry := h.cfg.DeepSeekKey[targetIndex]
+	if body.Value.APIKey != nil {
+		trimmed := strings.TrimSpace(*body.Value.APIKey)
+		if trimmed == "" {
+			h.cfg.DeepSeekKey = append(h.cfg.DeepSeekKey[:targetIndex], h.cfg.DeepSeekKey[targetIndex+1:]...)
+			h.cfg.SanitizeDeepSeekKeys()
+			h.persistLocked(c)
+			return
+		}
+		entry.APIKey = trimmed
+	}
+	if body.Value.Priority != nil {
+		entry.Priority = *body.Value.Priority
+	}
+	if body.Value.Prefix != nil {
+		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
+	}
+	if body.Value.BaseURL != nil {
+		entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
+	}
+	if body.Value.ProxyURL != nil {
+		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
+	}
+	if body.Value.Models != nil {
+		entry.Models = append([]config.DeepSeekModel(nil), (*body.Value.Models)...)
+	}
+	if body.Value.Headers != nil {
+		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
+	}
+	if body.Value.ExcludedModels != nil {
+		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
+	}
+	normalizeDeepSeekKey(&entry)
+	h.cfg.DeepSeekKey[targetIndex] = entry
+	h.cfg.SanitizeDeepSeekKeys()
+	h.persistLocked(c)
+}
+
+func (h *Handler) DeleteDeepSeekKey(c *gin.Context) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if val := strings.TrimSpace(c.Query("api-key")); val != "" {
+		if baseRaw, okBase := c.GetQuery("base-url"); okBase {
+			base := strings.TrimSpace(baseRaw)
+			if base == "" {
+				base = config.DefaultDeepSeekBaseURL
+			}
+			out := make([]config.DeepSeekKey, 0, len(h.cfg.DeepSeekKey))
+			for _, v := range h.cfg.DeepSeekKey {
+				entryBase := strings.TrimSpace(v.BaseURL)
+				if entryBase == "" {
+					entryBase = config.DefaultDeepSeekBaseURL
+				}
+				if strings.TrimSpace(v.APIKey) == val && entryBase == base {
+					continue
+				}
+				out = append(out, v)
+			}
+			if len(out) != len(h.cfg.DeepSeekKey) {
+				h.cfg.DeepSeekKey = out
+				h.cfg.SanitizeDeepSeekKeys()
+				h.persistLocked(c)
+			} else {
+				c.JSON(404, gin.H{"error": "item not found"})
+			}
+			return
+		}
+
+		matchIndex := -1
+		matchCount := 0
+		for i := range h.cfg.DeepSeekKey {
+			if strings.TrimSpace(h.cfg.DeepSeekKey[i].APIKey) == val {
+				matchCount++
+				if matchIndex == -1 {
+					matchIndex = i
+				}
+			}
+		}
+		if matchCount > 1 {
+			c.JSON(400, gin.H{"error": "multiple items match api-key; base-url is required"})
+			return
+		}
+		if matchIndex != -1 {
+			h.cfg.DeepSeekKey = append(h.cfg.DeepSeekKey[:matchIndex], h.cfg.DeepSeekKey[matchIndex+1:]...)
+			h.cfg.SanitizeDeepSeekKeys()
+			h.persistLocked(c)
+			return
+		}
+		c.JSON(404, gin.H{"error": "item not found"})
+		return
+	}
+	if idxStr := c.Query("index"); idxStr != "" {
+		var idx int
+		_, err := fmt.Sscanf(idxStr, "%d", &idx)
+		if err == nil && idx >= 0 && idx < len(h.cfg.DeepSeekKey) {
+			h.cfg.DeepSeekKey = append(h.cfg.DeepSeekKey[:idx], h.cfg.DeepSeekKey[idx+1:]...)
+			h.cfg.SanitizeDeepSeekKeys()
+			h.persistLocked(c)
+			return
+		}
+	}
+	c.JSON(400, gin.H{"error": "missing api-key or index"})
+}
+
 // openai-compatibility: []OpenAICompatibility
 func (h *Handler) GetOpenAICompat(c *gin.Context) {
 	c.JSON(200, gin.H{"openai-compatibility": h.openAICompatibilityWithAuthIndex()})
@@ -1149,6 +1332,32 @@ func normalizeCodexKey(entry *config.CodexKey) {
 		return
 	}
 	normalized := make([]config.CodexModel, 0, len(entry.Models))
+	for i := range entry.Models {
+		model := entry.Models[i]
+		model.Name = strings.TrimSpace(model.Name)
+		model.Alias = strings.TrimSpace(model.Alias)
+		if model.Name == "" && model.Alias == "" {
+			continue
+		}
+		normalized = append(normalized, model)
+	}
+	entry.Models = normalized
+}
+
+func normalizeDeepSeekKey(entry *config.DeepSeekKey) {
+	if entry == nil {
+		return
+	}
+	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.Prefix = strings.TrimSpace(entry.Prefix)
+	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	if len(entry.Models) == 0 {
+		return
+	}
+	normalized := make([]config.DeepSeekModel, 0, len(entry.Models))
 	for i := range entry.Models {
 		model := entry.Models[i]
 		model.Name = strings.TrimSpace(model.Name)

--- a/internal/api/handlers/management/config_lists_deepseek_test.go
+++ b/internal/api/handlers/management/config_lists_deepseek_test.go
@@ -1,0 +1,99 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestDeepSeekKeysManagementCRUD(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &Handler{cfg: &config.Config{}, configFilePath: writeTestConfigFile(t)}
+
+	putBody := []config.DeepSeekKey{{
+		APIKey:   " ds-key ",
+		Priority: 7,
+		Prefix:   " team ",
+		Models:   []config.DeepSeekModel{{Name: " deepseek-v4-pro ", Alias: " latest "}},
+	}}
+	putPayload, err := json.Marshal(putBody)
+	if err != nil {
+		t.Fatalf("marshal put body: %v", err)
+	}
+	putResp := performDeepSeekManagementRequest(http.MethodPut, "/v0/management/deepseek-api-key", putPayload, h.PutDeepSeekKeys)
+	if putResp.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, body=%s", putResp.Code, putResp.Body.String())
+	}
+	if len(h.cfg.DeepSeekKey) != 1 {
+		t.Fatalf("DeepSeekKey length = %d, want 1", len(h.cfg.DeepSeekKey))
+	}
+	entry := h.cfg.DeepSeekKey[0]
+	if entry.APIKey != "ds-key" {
+		t.Fatalf("api key = %q", entry.APIKey)
+	}
+	if entry.BaseURL != config.DefaultDeepSeekBaseURL {
+		t.Fatalf("base url = %q, want default", entry.BaseURL)
+	}
+	if entry.Prefix != "team" {
+		t.Fatalf("prefix = %q", entry.Prefix)
+	}
+	if len(entry.Models) != 1 || entry.Models[0].Name != "deepseek-v4-pro" || entry.Models[0].Alias != "latest" {
+		t.Fatalf("models not normalized: %#v", entry.Models)
+	}
+
+	patchPayload := []byte(`{"index":0,"value":{"priority":9,"base-url":"https://api.deepseek.com","models":[{"name":"deepseek-v4-flash","alias":"fast"}],"headers":{"X-Test":"ok"}}}`)
+	patchResp := performDeepSeekManagementRequest(http.MethodPatch, "/v0/management/deepseek-api-key", patchPayload, h.PatchDeepSeekKey)
+	if patchResp.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, body=%s", patchResp.Code, patchResp.Body.String())
+	}
+	entry = h.cfg.DeepSeekKey[0]
+	if entry.Priority != 9 {
+		t.Fatalf("priority = %d, want 9", entry.Priority)
+	}
+	if len(entry.Models) != 1 || entry.Models[0].Name != "deepseek-v4-flash" || entry.Models[0].Alias != "fast" {
+		t.Fatalf("models after patch = %#v", entry.Models)
+	}
+	if entry.Headers["X-Test"] != "ok" {
+		t.Fatalf("headers after patch = %#v", entry.Headers)
+	}
+
+	getResp := performDeepSeekManagementRequest(http.MethodGet, "/v0/management/deepseek-api-key", nil, h.GetDeepSeekKeys)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, body=%s", getResp.Code, getResp.Body.String())
+	}
+	var got map[string][]map[string]any
+	if err := json.Unmarshal(getResp.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal GET body: %v", err)
+	}
+	if len(got["deepseek-api-key"]) != 1 {
+		t.Fatalf("GET returned %#v", got)
+	}
+
+	deleteResp := performDeepSeekManagementRequest(http.MethodDelete, "/v0/management/deepseek-api-key?api-key=ds-key&base-url=https://api.deepseek.com", nil, h.DeleteDeepSeekKey)
+	if deleteResp.Code != http.StatusOK {
+		t.Fatalf("DELETE status = %d, body=%s", deleteResp.Code, deleteResp.Body.String())
+	}
+	if len(h.cfg.DeepSeekKey) != 0 {
+		t.Fatalf("DeepSeekKey length after delete = %d, want 0", len(h.cfg.DeepSeekKey))
+	}
+}
+
+func performDeepSeekManagementRequest(method, target string, body []byte, handler gin.HandlerFunc) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	var reader *bytes.Reader
+	if body == nil {
+		reader = bytes.NewReader(nil)
+	} else {
+		reader = bytes.NewReader(body)
+	}
+	c.Request = httptest.NewRequest(method, target, reader)
+	c.Request.Header.Set("Content-Type", "application/json")
+	handler(c)
+	return w
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -621,6 +621,11 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PATCH("/codex-api-key", s.mgmt.PatchCodexKey)
 		mgmt.DELETE("/codex-api-key", s.mgmt.DeleteCodexKey)
 
+		mgmt.GET("/deepseek-api-key", s.mgmt.GetDeepSeekKeys)
+		mgmt.PUT("/deepseek-api-key", s.mgmt.PutDeepSeekKeys)
+		mgmt.PATCH("/deepseek-api-key", s.mgmt.PatchDeepSeekKey)
+		mgmt.DELETE("/deepseek-api-key", s.mgmt.DeleteDeepSeekKey)
+
 		mgmt.GET("/openai-compatibility", s.mgmt.GetOpenAICompat)
 		mgmt.PUT("/openai-compatibility", s.mgmt.PutOpenAICompat)
 		mgmt.PATCH("/openai-compatibility", s.mgmt.PatchOpenAICompat)
@@ -1096,6 +1101,7 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	geminiAPIKeyCount := len(cfg.GeminiKey)
 	claudeAPIKeyCount := len(cfg.ClaudeKey)
 	codexAPIKeyCount := len(cfg.CodexKey)
+	deepSeekAPIKeyCount := len(cfg.DeepSeekKey)
 	vertexAICompatCount := len(cfg.VertexCompatAPIKey)
 	openAICompatCount := 0
 	for i := range cfg.OpenAICompatibility {
@@ -1103,13 +1109,14 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 		openAICompatCount += len(entry.APIKeyEntries)
 	}
 
-	total := authEntries + geminiAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + vertexAICompatCount + openAICompatCount
-	fmt.Printf("server clients and configuration updated: %d clients (%d auth entries + %d Gemini API keys + %d Claude API keys + %d Codex keys + %d Vertex-compat + %d OpenAI-compat)\n",
+	total := authEntries + geminiAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + deepSeekAPIKeyCount + vertexAICompatCount + openAICompatCount
+	fmt.Printf("server clients and configuration updated: %d clients (%d auth entries + %d Gemini API keys + %d Claude API keys + %d Codex keys + %d DeepSeek keys + %d Vertex-compat + %d OpenAI-compat)\n",
 		total,
 		authEntries,
 		geminiAPIKeyCount,
 		claudeAPIKeyCount,
 		codexAPIKeyCount,
+		deepSeekAPIKeyCount,
 		vertexAICompatCount,
 		openAICompatCount,
 	)

--- a/internal/auth/deepseek_constants.go
+++ b/internal/auth/deepseek_constants.go
@@ -1,0 +1,6 @@
+package auth
+
+import "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+
+// DeepSeekAPIBaseURL is the default OpenAI-compatible DeepSeek API endpoint.
+const DeepSeekAPIBaseURL = config.DefaultDeepSeekBaseURL

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	DefaultPanelGitHubRepository = "https://github.com/router-for-me/Cli-Proxy-API-Management-Center"
+	DefaultDeepSeekBaseURL       = "https://api.deepseek.com"
 	DefaultPprofAddr             = "127.0.0.1:8316"
 )
 
@@ -108,6 +109,9 @@ type Config struct {
 
 	// ClaudeKey defines a list of Claude API key configurations as specified in the YAML configuration file.
 	ClaudeKey []ClaudeKey `yaml:"claude-api-key" json:"claude-api-key"`
+
+	// DeepSeekKey defines DeepSeek API key configurations.
+	DeepSeekKey []DeepSeekKey `yaml:"deepseek-api-key" json:"deepseek-api-key"`
 
 	// ClaudeHeaderDefaults configures default header values for Claude API requests.
 	// These are used as fallbacks when the client does not send its own headers.
@@ -417,6 +421,50 @@ type ClaudeModel struct {
 func (m ClaudeModel) GetName() string  { return m.Name }
 func (m ClaudeModel) GetAlias() string { return m.Alias }
 
+// DeepSeekKey represents the configuration for a DeepSeek API key.
+type DeepSeekKey struct {
+	// APIKey is the authentication key for DeepSeek API services.
+	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// Priority controls selection preference when multiple credentials match.
+	// Higher values are preferred; defaults to 0.
+	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+
+	// Prefix optionally namespaces models for this credential (e.g., "teamA/deepseek-v4-pro").
+	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+
+	// BaseURL is the base URL for the DeepSeek API endpoint.
+	// If empty, https://api.deepseek.com is used.
+	BaseURL string `yaml:"base-url,omitempty" json:"base-url,omitempty"`
+
+	// ProxyURL overrides the global proxy setting for this API key if provided.
+	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
+
+	// Models defines upstream model names and aliases for request routing.
+	Models []DeepSeekModel `yaml:"models,omitempty" json:"models,omitempty"`
+
+	// Headers optionally adds extra HTTP headers for requests sent with this key.
+	Headers map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+
+	// ExcludedModels lists model IDs that should be excluded for this provider.
+	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
+}
+
+func (k DeepSeekKey) GetAPIKey() string  { return k.APIKey }
+func (k DeepSeekKey) GetBaseURL() string { return k.BaseURL }
+
+// DeepSeekModel describes a mapping between an alias and the actual upstream model name.
+type DeepSeekModel struct {
+	// Name is the upstream model identifier used when issuing requests.
+	Name string `yaml:"name" json:"name"`
+
+	// Alias is the client-facing model name that maps to Name.
+	Alias string `yaml:"alias" json:"alias"`
+}
+
+func (m DeepSeekModel) GetName() string  { return m.Name }
+func (m DeepSeekModel) GetAlias() string { return m.Alias }
+
 // CodexKey represents the configuration for a Codex API key,
 // including the API key itself and an optional base URL for the API endpoint.
 type CodexKey struct {
@@ -687,6 +735,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Sanitize Claude key headers
 	cfg.SanitizeClaudeKeys()
 
+	// Sanitize DeepSeek API keys and defaults.
+	cfg.SanitizeDeepSeekKeys()
+
 	// Sanitize OpenAI compatibility providers: drop entries without base-url
 	cfg.SanitizeOpenAICompatibility()
 
@@ -890,6 +941,39 @@ func (cfg *Config) SanitizeClaudeKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
 	}
+}
+
+// SanitizeDeepSeekKeys deduplicates and normalizes DeepSeek credentials.
+// It defaults empty base URLs to the official DeepSeek API endpoint.
+func (cfg *Config) SanitizeDeepSeekKeys() {
+	if cfg == nil || len(cfg.DeepSeekKey) == 0 {
+		return
+	}
+
+	seen := make(map[string]struct{}, len(cfg.DeepSeekKey))
+	out := cfg.DeepSeekKey[:0]
+	for i := range cfg.DeepSeekKey {
+		entry := cfg.DeepSeekKey[i]
+		entry.APIKey = strings.TrimSpace(entry.APIKey)
+		if entry.APIKey == "" {
+			continue
+		}
+		entry.Prefix = normalizeModelPrefix(entry.Prefix)
+		entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+		if entry.BaseURL == "" {
+			entry.BaseURL = DefaultDeepSeekBaseURL
+		}
+		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+		entry.Headers = NormalizeHeaders(entry.Headers)
+		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
+		uniqueKey := entry.APIKey + "|" + entry.BaseURL
+		if _, exists := seen[uniqueKey]; exists {
+			continue
+		}
+		seen[uniqueKey] = struct{}{}
+		out = append(out, entry)
+	}
+	cfg.DeepSeekKey = out
 }
 
 // SanitizeGeminiKeys deduplicates and normalizes Gemini credentials.

--- a/internal/registry/deepseek_models_test.go
+++ b/internal/registry/deepseek_models_test.go
@@ -1,0 +1,44 @@
+package registry
+
+import "testing"
+
+func TestDeepSeekStaticModelsIncludeV4(t *testing.T) {
+	models := GetDeepSeekModels()
+	for _, id := range []string{"deepseek-v4-pro", "deepseek-v4-flash"} {
+		model := findModelInfo(models, id)
+		if model == nil {
+			t.Fatalf("expected DeepSeek models to include %s", id)
+		}
+		if model.OwnedBy != "deepseek" {
+			t.Fatalf("%s owned_by = %q, want deepseek", id, model.OwnedBy)
+		}
+		if model.Type != "deepseek" {
+			t.Fatalf("%s type = %q, want deepseek", id, model.Type)
+		}
+		if model.ContextLength != 1000000 {
+			t.Fatalf("%s context length = %d, want 1000000", id, model.ContextLength)
+		}
+		if model.MaxCompletionTokens != 384000 {
+			t.Fatalf("%s max completion tokens = %d, want 384000", id, model.MaxCompletionTokens)
+		}
+		if model.Thinking == nil {
+			t.Fatalf("%s missing thinking support", id)
+		}
+		wantLevels := []string{"high", "max"}
+		if len(model.Thinking.Levels) != len(wantLevels) {
+			t.Fatalf("%s thinking level count = %d, want %d", id, len(model.Thinking.Levels), len(wantLevels))
+		}
+		for i := range wantLevels {
+			if model.Thinking.Levels[i] != wantLevels[i] {
+				t.Fatalf("%s thinking level[%d] = %q, want %q", id, i, model.Thinking.Levels[i], wantLevels[i])
+			}
+		}
+	}
+
+	if got := GetStaticModelDefinitionsByChannel("deepseek"); findModelInfo(got, "deepseek-v4-pro") == nil {
+		t.Fatal("expected channel lookup to include deepseek-v4-pro")
+	}
+	if got := LookupStaticModelInfo("deepseek-v4-flash"); got == nil {
+		t.Fatal("expected LookupStaticModelInfo to find deepseek-v4-flash")
+	}
+}

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -20,6 +20,7 @@ type staticModelsJSON struct {
 	CodexPlus   []*ModelInfo `json:"codex-plus"`
 	CodexPro    []*ModelInfo `json:"codex-pro"`
 	Kimi        []*ModelInfo `json:"kimi"`
+	DeepSeek    []*ModelInfo `json:"deepseek"`
 	Antigravity []*ModelInfo `json:"antigravity"`
 }
 
@@ -71,6 +72,11 @@ func GetCodexProModels() []*ModelInfo {
 // GetKimiModels returns the standard Kimi (Moonshot AI) model definitions.
 func GetKimiModels() []*ModelInfo {
 	return cloneModelInfos(getModels().Kimi)
+}
+
+// GetDeepSeekModels returns the standard DeepSeek model definitions.
+func GetDeepSeekModels() []*ModelInfo {
+	return cloneModelInfos(getModels().DeepSeek)
 }
 
 // GetAntigravityModels returns the standard Antigravity model definitions.
@@ -166,6 +172,7 @@ func cloneModelInfos(models []*ModelInfo) []*ModelInfo {
 //   - aistudio
 //   - codex
 //   - kimi
+//   - deepseek
 //   - antigravity
 func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	key := strings.ToLower(strings.TrimSpace(channel))
@@ -184,6 +191,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		return GetCodexProModels()
 	case "kimi":
 		return GetKimiModels()
+	case "deepseek":
+		return GetDeepSeekModels()
 	case "antigravity":
 		return GetAntigravityModels()
 	default:
@@ -207,6 +216,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		data.AIStudio,
 		data.CodexPro,
 		data.Kimi,
+		data.DeepSeek,
 		data.Antigravity,
 	}
 	for _, models := range allModels {

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -6,7 +6,15 @@ import (
 	"strings"
 )
 
-const codexBuiltinImageModelID = "gpt-image-2"
+const (
+	codexBuiltinImageModelID = "gpt-image-2"
+
+	deepSeekV4FlashModelID   = "deepseek-v4-flash"
+	deepSeekV4ProModelID     = "deepseek-v4-pro"
+	deepSeekChatModelID      = "deepseek-chat"
+	deepSeekReasonerModelID  = "deepseek-reasoner"
+	deepSeekModelCreatedTime = 1777161600 // 2026-04-26
+)
 
 // staticModelsJSON mirrors the top-level structure of models.json.
 type staticModelsJSON struct {
@@ -75,8 +83,12 @@ func GetKimiModels() []*ModelInfo {
 }
 
 // GetDeepSeekModels returns the standard DeepSeek model definitions.
+//
+// DeepSeek is also supplied as a built-in overlay so existing remote models.json
+// catalogs that predate the deepseek section do not erase first-class provider
+// support during startup/periodic refresh.
 func GetDeepSeekModels() []*ModelInfo {
-	return cloneModelInfos(getModels().DeepSeek)
+	return WithDeepSeekBuiltins(cloneModelInfos(getModels().DeepSeek))
 }
 
 // GetAntigravityModels returns the standard Antigravity model definitions.
@@ -91,6 +103,18 @@ func WithCodexBuiltins(models []*ModelInfo) []*ModelInfo {
 	return upsertModelInfos(models, codexBuiltinImageModelInfo())
 }
 
+// WithDeepSeekBuiltins injects hard-coded DeepSeek model definitions that should
+// not depend on remote models.json updates. Built-ins replace any matching IDs
+// already present in the provided slice.
+func WithDeepSeekBuiltins(models []*ModelInfo) []*ModelInfo {
+	return upsertModelInfos(models,
+		deepSeekV4FlashModelInfo(),
+		deepSeekV4ProModelInfo(),
+		deepSeekChatModelInfo(),
+		deepSeekReasonerModelInfo(),
+	)
+}
+
 func codexBuiltinImageModelInfo() *ModelInfo {
 	return &ModelInfo{
 		ID:          codexBuiltinImageModelID,
@@ -100,6 +124,67 @@ func codexBuiltinImageModelInfo() *ModelInfo {
 		Type:        "openai",
 		DisplayName: "GPT Image 2",
 		Version:     codexBuiltinImageModelID,
+	}
+}
+
+func deepSeekV4FlashModelInfo() *ModelInfo {
+	return deepSeekThinkingModelInfo(
+		deepSeekV4FlashModelID,
+		"DeepSeek V4 Flash",
+		"DeepSeek-V4-Flash: fast DeepSeek V4 model with 1M context and thinking/non-thinking modes.",
+	)
+}
+
+func deepSeekV4ProModelInfo() *ModelInfo {
+	return deepSeekThinkingModelInfo(
+		deepSeekV4ProModelID,
+		"DeepSeek V4 Pro",
+		"DeepSeek-V4-Pro: flagship DeepSeek V4 model with 1M context and thinking/non-thinking modes.",
+	)
+}
+
+func deepSeekChatModelInfo() *ModelInfo {
+	return &ModelInfo{
+		ID:                  deepSeekChatModelID,
+		Object:              "model",
+		Created:             deepSeekModelCreatedTime,
+		OwnedBy:             "deepseek",
+		Type:                "deepseek",
+		DisplayName:         "DeepSeek Chat (legacy)",
+		Version:             deepSeekChatModelID,
+		Description:         "Legacy compatibility alias for deepseek-v4-flash non-thinking mode; scheduled for DeepSeek deprecation on 2026-07-24.",
+		ContextLength:       1000000,
+		MaxCompletionTokens: 384000,
+		SupportedParameters: []string{"tools", "json_mode"},
+	}
+}
+
+func deepSeekReasonerModelInfo() *ModelInfo {
+	return deepSeekThinkingModelInfo(
+		deepSeekReasonerModelID,
+		"DeepSeek Reasoner (legacy)",
+		"Legacy compatibility alias for deepseek-v4-flash thinking mode; scheduled for DeepSeek deprecation on 2026-07-24.",
+	)
+}
+
+func deepSeekThinkingModelInfo(id, displayName, description string) *ModelInfo {
+	return &ModelInfo{
+		ID:                  id,
+		Object:              "model",
+		Created:             deepSeekModelCreatedTime,
+		OwnedBy:             "deepseek",
+		Type:                "deepseek",
+		DisplayName:         displayName,
+		Version:             id,
+		Description:         description,
+		ContextLength:       1000000,
+		MaxCompletionTokens: 384000,
+		SupportedParameters: []string{"tools", "json_mode", "reasoning_effort"},
+		Thinking: &ThinkingSupport{
+			ZeroAllowed:    true,
+			DynamicAllowed: true,
+			Levels:         []string{"high", "max"},
+		},
 	}
 }
 
@@ -214,9 +299,12 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		data.Vertex,
 		data.GeminiCLI,
 		data.AIStudio,
-		data.CodexPro,
+		WithCodexBuiltins(data.CodexFree),
+		WithCodexBuiltins(data.CodexTeam),
+		WithCodexBuiltins(data.CodexPlus),
+		WithCodexBuiltins(data.CodexPro),
 		data.Kimi,
-		data.DeepSeek,
+		WithDeepSeekBuiltins(data.DeepSeek),
 		data.Antigravity,
 	}
 	for _, models := range allModels {

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -335,7 +335,9 @@ func validateModelsCatalog(data *staticModelsJSON) error {
 		{name: "codex-plus", models: data.CodexPlus},
 		{name: "codex-pro", models: data.CodexPro},
 		{name: "kimi", models: data.Kimi},
-		{name: "deepseek", models: data.DeepSeek},
+		// DeepSeek may be absent from older remote catalogs. The application
+		// supplies DeepSeek models as built-ins, so do not reject otherwise valid
+		// catalogs while the shared upstream model source catches up.
 		{name: "antigravity", models: data.Antigravity},
 	}
 

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -214,6 +214,7 @@ func detectChangedProviders(oldData, newData *staticModelsJSON) []string {
 		{"codex", oldData.CodexPlus, newData.CodexPlus},
 		{"codex", oldData.CodexPro, newData.CodexPro},
 		{"kimi", oldData.Kimi, newData.Kimi},
+		{"deepseek", oldData.DeepSeek, newData.DeepSeek},
 		{"antigravity", oldData.Antigravity, newData.Antigravity},
 	}
 
@@ -334,6 +335,7 @@ func validateModelsCatalog(data *staticModelsJSON) error {
 		{name: "codex-plus", models: data.CodexPlus},
 		{name: "codex-pro", models: data.CodexPro},
 		{name: "kimi", models: data.Kimi},
+		{name: "deepseek", models: data.DeepSeek},
 		{name: "antigravity", models: data.Antigravity},
 	}
 

--- a/internal/registry/model_updater_deepseek_test.go
+++ b/internal/registry/model_updater_deepseek_test.go
@@ -1,0 +1,41 @@
+package registry
+
+import "testing"
+
+func TestValidateModelsCatalogAllowsMissingDeepSeekSection(t *testing.T) {
+	data := cloneModelsCatalogForTest(getModels())
+	data.DeepSeek = nil
+
+	if err := validateModelsCatalog(data); err != nil {
+		t.Fatalf("validateModelsCatalog() error = %v, want nil for missing deepseek section", err)
+	}
+}
+
+func TestDeepSeekBuiltinsSurviveMissingCatalogSection(t *testing.T) {
+	models := WithDeepSeekBuiltins(nil)
+	for _, id := range []string{deepSeekV4FlashModelID, deepSeekV4ProModelID, deepSeekChatModelID, deepSeekReasonerModelID} {
+		if findModelInfo(models, id) == nil {
+			t.Fatalf("expected DeepSeek builtins to include %s", id)
+		}
+	}
+}
+
+func cloneModelsCatalogForTest(in *staticModelsJSON) *staticModelsJSON {
+	if in == nil {
+		return &staticModelsJSON{}
+	}
+	return &staticModelsJSON{
+		Claude:      cloneModelInfos(in.Claude),
+		Gemini:      cloneModelInfos(in.Gemini),
+		Vertex:      cloneModelInfos(in.Vertex),
+		GeminiCLI:   cloneModelInfos(in.GeminiCLI),
+		AIStudio:    cloneModelInfos(in.AIStudio),
+		CodexFree:   cloneModelInfos(in.CodexFree),
+		CodexTeam:   cloneModelInfos(in.CodexTeam),
+		CodexPlus:   cloneModelInfos(in.CodexPlus),
+		CodexPro:    cloneModelInfos(in.CodexPro),
+		Kimi:        cloneModelInfos(in.Kimi),
+		DeepSeek:    cloneModelInfos(in.DeepSeek),
+		Antigravity: cloneModelInfos(in.Antigravity),
+	}
+}

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1292,6 +1292,31 @@
           "xhigh"
         ]
       }
+    },
+    {
+      "id": "gpt-5.5",
+      "object": "model",
+      "created": 1776902400,
+      "owned_by": "openai",
+      "type": "openai",
+      "display_name": "GPT 5.5",
+      "version": "gpt-5.5",
+      "description": "Frontier model for complex coding, research, and real-world work.",
+      "context_length": 272000,
+      "max_completion_tokens": 128000,
+      "supported_parameters": [
+        "tools"
+      ],
+      "thinking": {
+        "zero_allowed": true,
+        "dynamic_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
     }
   ],
   "codex-team": [
@@ -1946,6 +1971,95 @@
           "low",
           "medium",
           "high"
+        ]
+      }
+    }
+  ],
+  "deepseek": [
+    {
+      "id": "deepseek-v4-flash",
+      "object": "model",
+      "created": 1777161600,
+      "owned_by": "deepseek",
+      "type": "deepseek",
+      "display_name": "DeepSeek V4 Flash",
+      "description": "DeepSeek-V4-Flash: fast DeepSeek V4 model with 1M context and thinking/non-thinking modes.",
+      "context_length": 1000000,
+      "max_completion_tokens": 384000,
+      "supported_parameters": [
+        "tools",
+        "json_mode",
+        "reasoning_effort"
+      ],
+      "thinking": {
+        "zero_allowed": true,
+        "dynamic_allowed": true,
+        "levels": [
+          "high",
+          "max"
+        ]
+      }
+    },
+    {
+      "id": "deepseek-v4-pro",
+      "object": "model",
+      "created": 1777161600,
+      "owned_by": "deepseek",
+      "type": "deepseek",
+      "display_name": "DeepSeek V4 Pro",
+      "description": "DeepSeek-V4-Pro: flagship DeepSeek V4 model with 1M context and thinking/non-thinking modes.",
+      "context_length": 1000000,
+      "max_completion_tokens": 384000,
+      "supported_parameters": [
+        "tools",
+        "json_mode",
+        "reasoning_effort"
+      ],
+      "thinking": {
+        "zero_allowed": true,
+        "dynamic_allowed": true,
+        "levels": [
+          "high",
+          "max"
+        ]
+      }
+    },
+    {
+      "id": "deepseek-chat",
+      "object": "model",
+      "created": 1777161600,
+      "owned_by": "deepseek",
+      "type": "deepseek",
+      "display_name": "DeepSeek Chat (legacy)",
+      "description": "Legacy compatibility alias for deepseek-v4-flash non-thinking mode; scheduled for DeepSeek deprecation on 2026-07-24.",
+      "context_length": 1000000,
+      "max_completion_tokens": 384000,
+      "supported_parameters": [
+        "tools",
+        "json_mode"
+      ]
+    },
+    {
+      "id": "deepseek-reasoner",
+      "object": "model",
+      "created": 1777161600,
+      "owned_by": "deepseek",
+      "type": "deepseek",
+      "display_name": "DeepSeek Reasoner (legacy)",
+      "description": "Legacy compatibility alias for deepseek-v4-flash thinking mode; scheduled for DeepSeek deprecation on 2026-07-24.",
+      "context_length": 1000000,
+      "max_completion_tokens": 384000,
+      "supported_parameters": [
+        "tools",
+        "json_mode",
+        "reasoning_effort"
+      ],
+      "thinking": {
+        "zero_allowed": true,
+        "dynamic_allowed": true,
+        "levels": [
+          "high",
+          "max"
         ]
       }
     }

--- a/internal/runtime/executor/deepseek_executor.go
+++ b/internal/runtime/executor/deepseek_executor.go
@@ -1,0 +1,328 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	deepseekauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/sjson"
+)
+
+// DeepSeekExecutor is a stateless executor for DeepSeek's OpenAI-compatible Chat Completions API.
+type DeepSeekExecutor struct {
+	cfg *config.Config
+}
+
+// NewDeepSeekExecutor creates a new DeepSeek executor.
+func NewDeepSeekExecutor(cfg *config.Config) *DeepSeekExecutor { return &DeepSeekExecutor{cfg: cfg} }
+
+// Identifier returns the executor identifier.
+func (e *DeepSeekExecutor) Identifier() string { return "deepseek" }
+
+// PrepareRequest injects DeepSeek credentials into the outgoing HTTP request.
+func (e *DeepSeekExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
+	if req == nil {
+		return nil
+	}
+	if _, apiKey := deepSeekCredentials(auth); strings.TrimSpace(apiKey) != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(req, attrs)
+	return nil
+}
+
+// HttpRequest injects DeepSeek credentials into the request and executes it.
+func (e *DeepSeekExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("deepseek executor: request is nil")
+	}
+	if ctx == nil {
+		ctx = req.Context()
+	}
+	httpReq := req.WithContext(ctx)
+	if err := e.PrepareRequest(httpReq, auth); err != nil {
+		return nil, err
+	}
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	return httpClient.Do(httpReq)
+}
+
+// Execute performs a non-streaming chat completion request to DeepSeek.
+func (e *DeepSeekExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseURL, apiKey := deepSeekCredentials(auth)
+	if baseURL == "" {
+		err = statusErr{code: http.StatusUnauthorized, msg: "missing DeepSeek baseURL"}
+		return resp, err
+	}
+
+	reporter := helps.NewUsageReporter(ctx, e.Identifier(), baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("openai")
+	originalPayloadSource := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayloadSource = opts.OriginalRequest
+	}
+	originalPayload := bytes.Clone(originalPayloadSource)
+	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
+	body := sdktranslator.TranslateRequest(from, to, baseModel, bytes.Clone(req.Payload), false)
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+
+	body, err = thinking.ApplyThinking(body, req.Model, from.String(), "deepseek", e.Identifier())
+	if err != nil {
+		return resp, err
+	}
+
+	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	applyDeepSeekHeaders(httpReq, apiKey, false, auth)
+
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       url,
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("deepseek executor: close response body error: %v", errClose)
+		}
+	}()
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return resp, err
+	}
+	data, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
+	reporter.Publish(ctx, helps.ParseOpenAIUsage(data))
+	reporter.EnsurePublished(ctx)
+
+	var param any
+	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, body, data, &param)
+	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+	return resp, nil
+}
+
+// ExecuteStream performs a streaming chat completion request to DeepSeek.
+func (e *DeepSeekExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseURL, apiKey := deepSeekCredentials(auth)
+	if baseURL == "" {
+		err = statusErr{code: http.StatusUnauthorized, msg: "missing DeepSeek baseURL"}
+		return nil, err
+	}
+
+	reporter := helps.NewUsageReporter(ctx, e.Identifier(), baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("openai")
+	originalPayloadSource := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayloadSource = opts.OriginalRequest
+	}
+	originalPayload := bytes.Clone(originalPayloadSource)
+	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
+	body := sdktranslator.TranslateRequest(from, to, baseModel, bytes.Clone(req.Payload), true)
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+
+	body, err = thinking.ApplyThinking(body, req.Model, from.String(), "deepseek", e.Identifier())
+	if err != nil {
+		return nil, err
+	}
+	body, _ = sjson.SetBytes(body, "stream_options.include_usage", true)
+
+	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	applyDeepSeekHeaders(httpReq, apiKey, true, auth)
+
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       url,
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return nil, err
+	}
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("deepseek executor: close response body error: %v", errClose)
+		}
+		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return nil, err
+	}
+
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("deepseek executor: close response body error: %v", errClose)
+			}
+		}()
+		scanner := bufio.NewScanner(httpResp.Body)
+		scanner.Buffer(nil, 52_428_800)
+		var param any
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+			if detail, ok := helps.ParseOpenAIStreamUsage(line); ok {
+				reporter.Publish(ctx, detail)
+			}
+			if len(line) == 0 || !bytes.HasPrefix(line, []byte("data:")) {
+				continue
+			}
+			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, body, bytes.Clone(line), &param)
+			for i := range chunks {
+				out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}
+			}
+		}
+		if errScan := scanner.Err(); errScan != nil {
+			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
+			reporter.PublishFailure(ctx)
+			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+		} else {
+			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, body, []byte("data: [DONE]"), &param)
+			for i := range chunks {
+				out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}
+			}
+		}
+		reporter.EnsurePublished(ctx)
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+// CountTokens estimates token count for DeepSeek requests using the OpenAI chat tokenizer path.
+func (e *DeepSeekExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("openai")
+	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+
+	translated, err := thinking.ApplyThinking(translated, req.Model, from.String(), "deepseek", e.Identifier())
+	if err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+
+	enc, err := helps.TokenizerForModel(baseModel)
+	if err != nil {
+		return cliproxyexecutor.Response{}, fmt.Errorf("deepseek executor: tokenizer init failed: %w", err)
+	}
+	count, err := helps.CountOpenAIChatTokens(enc, translated)
+	if err != nil {
+		return cliproxyexecutor.Response{}, fmt.Errorf("deepseek executor: token counting failed: %w", err)
+	}
+	usageJSON := helps.BuildOpenAIUsageJSON(count)
+	translatedUsage := sdktranslator.TranslateTokenCount(ctx, to, from, count, usageJSON)
+	return cliproxyexecutor.Response{Payload: translatedUsage}, nil
+}
+
+// Refresh is a no-op for DeepSeek API-key credentials.
+func (e *DeepSeekExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	_ = ctx
+	return auth, nil
+}
+
+func deepSeekCredentials(auth *cliproxyauth.Auth) (baseURL, apiKey string) {
+	baseURL = deepseekauth.DeepSeekAPIBaseURL
+	if auth == nil {
+		return baseURL, ""
+	}
+	if auth.Attributes != nil {
+		if v := strings.TrimSpace(auth.Attributes["base_url"]); v != "" {
+			baseURL = v
+		}
+		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
+	}
+	return baseURL, apiKey
+}
+
+func applyDeepSeekHeaders(req *http.Request, apiKey string, stream bool, auth *cliproxyauth.Auth) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "cli-proxy-deepseek")
+	if stream {
+		req.Header.Set("Accept", "text/event-stream")
+		req.Header.Set("Cache-Control", "no-cache")
+	}
+	if strings.TrimSpace(apiKey) != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(req, attrs)
+}

--- a/internal/runtime/executor/deepseek_executor_test.go
+++ b/internal/runtime/executor/deepseek_executor_test.go
@@ -1,0 +1,93 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+func TestDeepSeekExecutorAppliesV4Thinking(t *testing.T) {
+	var gotAuth string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("path = %s, want /chat/completions", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-test","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL, "api_key": "ds-test-key"}}
+	exec := NewDeepSeekExecutor(&config.Config{})
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-pro(max)",
+		Payload: []byte(`{"model":"deepseek-v4-pro","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if gotAuth != "Bearer ds-test-key" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	thinkingObj, ok := gotBody["thinking"].(map[string]any)
+	if !ok || thinkingObj["type"] != "enabled" {
+		t.Fatalf("thinking object = %#v, want enabled", gotBody["thinking"])
+	}
+	if got := gotBody["reasoning_effort"]; got != "max" {
+		t.Fatalf("reasoning_effort = %#v, want max; body=%#v", got, gotBody)
+	}
+}
+
+func TestDeepSeekExecutorDisablesThinking(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-test","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL, "api_key": "ds-test-key"}}
+	exec := NewDeepSeekExecutor(&config.Config{})
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash(none)",
+		Payload: []byte(`{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"high"}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	thinkingObj, ok := gotBody["thinking"].(map[string]any)
+	if !ok || thinkingObj["type"] != "disabled" {
+		t.Fatalf("thinking object = %#v, want disabled", gotBody["thinking"])
+	}
+	if _, exists := gotBody["reasoning_effort"]; exists {
+		t.Fatalf("reasoning_effort should be removed when disabled; body=%#v", gotBody)
+	}
+}
+
+func TestDeepSeekPrepareRequestUsesDefaultBaseURLCredential(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/models", nil)
+	exec := NewDeepSeekExecutor(&config.Config{})
+	err := exec.PrepareRequest(req, &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "ds-key"}})
+	if err != nil {
+		t.Fatalf("PrepareRequest returned error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); !strings.EqualFold(got, "Bearer ds-key") {
+		t.Fatalf("Authorization = %q", got)
+	}
+}

--- a/internal/runtime/executor/helps/thinking_providers.go
+++ b/internal/runtime/executor/helps/thinking_providers.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/antigravity"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/claude"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/codex"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/deepseek"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/gemini"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/geminicli"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/kimi"

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -18,6 +18,7 @@ var providerAppliers = map[string]ProviderApplier{
 	"codex":       nil,
 	"antigravity": nil,
 	"kimi":        nil,
+	"deepseek":    nil,
 }
 
 // GetProviderApplier returns the ProviderApplier for the given provider name.
@@ -62,7 +63,7 @@ func IsUserDefinedModel(modelInfo *registry.ModelInfo) bool {
 //   - body: Original request body JSON
 //   - model: Model name, optionally with thinking suffix (e.g., "claude-sonnet-4-5(16384)")
 //   - fromFormat: Source request format (e.g., openai, codex, gemini)
-//   - toFormat: Target provider format for the request body (gemini, gemini-cli, antigravity, claude, openai, codex, kimi)
+//   - toFormat: Target provider format for the request body (gemini, gemini-cli, antigravity, claude, openai, codex, kimi, deepseek)
 //   - providerKey: Provider identifier used for registry model lookups (may differ from toFormat, e.g., openrouter -> openai)
 //
 // Returns:
@@ -329,6 +330,8 @@ func extractThinkingConfig(body []byte, provider string) ThinkingConfig {
 	case "kimi":
 		// Kimi uses OpenAI-compatible reasoning_effort format
 		return extractOpenAIConfig(body)
+	case "deepseek":
+		return extractDeepSeekConfig(body)
 	default:
 		return ThinkingConfig{}
 	}
@@ -483,6 +486,34 @@ func extractCodexConfig(body []byte) ThinkingConfig {
 			return ThinkingConfig{Mode: ModeNone, Budget: 0}
 		}
 		return ThinkingConfig{Mode: ModeLevel, Level: ThinkingLevel(value)}
+	}
+
+	return ThinkingConfig{}
+}
+
+// extractDeepSeekConfig extracts DeepSeek thinking controls from an OpenAI-compatible request body.
+func extractDeepSeekConfig(body []byte) ThinkingConfig {
+	thinkingType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "thinking.type").String()))
+	if thinkingType == "disabled" {
+		return ThinkingConfig{Mode: ModeNone, Budget: 0}
+	}
+
+	if effort := gjson.GetBytes(body, "reasoning_effort"); effort.Exists() {
+		value := strings.ToLower(strings.TrimSpace(effort.String()))
+		switch value {
+		case "none":
+			return ThinkingConfig{Mode: ModeNone, Budget: 0}
+		case "auto":
+			return ThinkingConfig{Mode: ModeAuto, Budget: -1}
+		case "":
+			return ThinkingConfig{}
+		default:
+			return ThinkingConfig{Mode: ModeLevel, Level: ThinkingLevel(value)}
+		}
+	}
+
+	if thinkingType == "enabled" {
+		return ThinkingConfig{Mode: ModeAuto, Budget: -1}
 	}
 
 	return ThinkingConfig{}

--- a/internal/thinking/provider/deepseek/apply.go
+++ b/internal/thinking/provider/deepseek/apply.go
@@ -1,0 +1,101 @@
+// Package deepseek implements thinking configuration for DeepSeek models.
+//
+// DeepSeek V4 uses an OpenAI-compatible Chat Completions surface with two
+// controls: thinking.type toggles thinking, and reasoning_effort controls effort.
+package deepseek
+
+import (
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Applier implements thinking.ProviderApplier for DeepSeek models.
+type Applier struct{}
+
+var _ thinking.ProviderApplier = (*Applier)(nil)
+
+// NewApplier creates a new DeepSeek thinking applier.
+func NewApplier() *Applier { return &Applier{} }
+
+func init() {
+	thinking.RegisterProvider("deepseek", NewApplier())
+}
+
+// Apply applies DeepSeek thinking configuration to an OpenAI-compatible body.
+func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *registry.ModelInfo) ([]byte, error) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		body = []byte(`{}`)
+	}
+
+	var effort string
+	enabled := true
+	switch config.Mode {
+	case thinking.ModeLevel:
+		if config.Level == "" {
+			return body, nil
+		}
+		effort = normalizeEffort(config.Level)
+	case thinking.ModeNone:
+		enabled = false
+	case thinking.ModeAuto:
+		// DeepSeek defaults to high/max automatically. Keep thinking enabled and
+		// avoid forcing a specific effort when the caller asks for auto.
+	case thinking.ModeBudget:
+		level, ok := thinking.ConvertBudgetToLevel(config.Budget)
+		if !ok {
+			return body, nil
+		}
+		effort = normalizeEffort(thinking.ThinkingLevel(level))
+	default:
+		return body, nil
+	}
+
+	if !thinking.IsUserDefinedModel(modelInfo) && modelInfo != nil && modelInfo.Thinking == nil && enabled {
+		return body, nil
+	}
+
+	return applyDeepSeekThinking(body, enabled, effort)
+}
+
+func normalizeEffort(level thinking.ThinkingLevel) string {
+	switch level {
+	case thinking.LevelMinimal, thinking.LevelLow, thinking.LevelMedium, thinking.LevelHigh:
+		return string(thinking.LevelHigh)
+	case thinking.LevelXHigh, thinking.LevelMax:
+		return string(thinking.LevelMax)
+	default:
+		return string(level)
+	}
+}
+
+func applyDeepSeekThinking(body []byte, enabled bool, effort string) ([]byte, error) {
+	result, errSetType := sjson.SetBytes(body, "thinking.type", thinkingType(enabled))
+	if errSetType != nil {
+		return body, fmt.Errorf("deepseek thinking: failed to set thinking.type: %w", errSetType)
+	}
+
+	if !enabled || effort == "" {
+		result, errDeleteEffort := sjson.DeleteBytes(result, "reasoning_effort")
+		if errDeleteEffort != nil {
+			return body, fmt.Errorf("deepseek thinking: failed to clear reasoning_effort: %w", errDeleteEffort)
+		}
+		return result, nil
+	}
+
+	result, errSetEffort := sjson.SetBytes(result, "reasoning_effort", effort)
+	if errSetEffort != nil {
+		return body, fmt.Errorf("deepseek thinking: failed to set reasoning_effort: %w", errSetEffort)
+	}
+	return result, nil
+}
+
+func thinkingType(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}

--- a/internal/thinking/strip.go
+++ b/internal/thinking/strip.go
@@ -37,7 +37,7 @@ func StripThinkingConfig(body []byte, provider string) []byte {
 		paths = []string{"request.generationConfig.thinkingConfig"}
 	case "openai":
 		paths = []string{"reasoning_effort"}
-	case "kimi":
+	case "kimi", "deepseek":
 		paths = []string{
 			"reasoning_effort",
 			"thinking",

--- a/internal/thinking/types.go
+++ b/internal/thinking/types.go
@@ -1,7 +1,7 @@
 // Package thinking provides unified thinking configuration processing.
 //
 // This package offers a unified interface for parsing, validating, and applying
-// thinking configurations across various AI providers (Claude, Gemini, OpenAI, Codex, Antigravity, Kimi).
+// thinking configurations across various AI providers (Claude, Gemini, OpenAI, Codex, Antigravity, Kimi, DeepSeek).
 package thinking
 
 import "github.com/router-for-me/CLIProxyAPI/v6/internal/registry"

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -55,8 +55,8 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 		w.clientsMutex.Unlock()
 	}
 
-	geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, openAICompatCount := BuildAPIKeyClients(cfg)
-	totalAPIKeyClients := geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + openAICompatCount
+	geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, deepSeekAPIKeyCount, openAICompatCount := BuildAPIKeyClients(cfg)
+	totalAPIKeyClients := geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + deepSeekAPIKeyCount + openAICompatCount
 	log.Debugf("loaded %d API key clients", totalAPIKeyClients)
 
 	var authFileCount int
@@ -126,7 +126,7 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 		w.clientsMutex.Unlock()
 	}
 
-	totalNewClients := authFileCount + geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + openAICompatCount
+	totalNewClients := authFileCount + geminiAPIKeyCount + vertexCompatAPIKeyCount + claudeAPIKeyCount + codexAPIKeyCount + deepSeekAPIKeyCount + openAICompatCount
 
 	if w.reloadCallback != nil {
 		log.Debugf("triggering server update callback before auth refresh")
@@ -135,13 +135,14 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 
 	w.refreshAuthState(forceAuthRefresh)
 
-	log.Infof("full client load complete - %d clients (%d auth files + %d Gemini API keys + %d Vertex API keys + %d Claude API keys + %d Codex keys + %d OpenAI-compat)",
+	log.Infof("full client load complete - %d clients (%d auth files + %d Gemini API keys + %d Vertex API keys + %d Claude API keys + %d Codex keys + %d DeepSeek keys + %d OpenAI-compat)",
 		totalNewClients,
 		authFileCount,
 		geminiAPIKeyCount,
 		vertexCompatAPIKeyCount,
 		claudeAPIKeyCount,
 		codexAPIKeyCount,
+		deepSeekAPIKeyCount,
 		openAICompatCount,
 	)
 }
@@ -336,11 +337,12 @@ func (w *Watcher) loadFileClients(cfg *config.Config) int {
 	return authFileCount
 }
 
-func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int) {
+func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int, int) {
 	geminiAPIKeyCount := 0
 	vertexCompatAPIKeyCount := 0
 	claudeAPIKeyCount := 0
 	codexAPIKeyCount := 0
+	deepSeekAPIKeyCount := 0
 	openAICompatCount := 0
 
 	if len(cfg.GeminiKey) > 0 {
@@ -355,12 +357,15 @@ func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int) {
 	if len(cfg.CodexKey) > 0 {
 		codexAPIKeyCount += len(cfg.CodexKey)
 	}
+	if len(cfg.DeepSeekKey) > 0 {
+		deepSeekAPIKeyCount += len(cfg.DeepSeekKey)
+	}
 	if len(cfg.OpenAICompatibility) > 0 {
 		for _, compatConfig := range cfg.OpenAICompatibility {
 			openAICompatCount += len(compatConfig.APIKeyEntries)
 		}
 	}
-	return geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, openAICompatCount
+	return geminiAPIKeyCount, vertexCompatAPIKeyCount, claudeAPIKeyCount, codexAPIKeyCount, deepSeekAPIKeyCount, openAICompatCount
 }
 
 func (w *Watcher) persistConfigAsync() {

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -56,6 +56,21 @@ func ComputeClaudeModelsHash(models []config.ClaudeModel) string {
 	return hashJoined(keys)
 }
 
+// ComputeDeepSeekModelsHash returns a stable hash for DeepSeek model aliases.
+func ComputeDeepSeekModelsHash(models []config.DeepSeekModel) string {
+	keys := normalizeModelPairs(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+		}
+	})
+	return hashJoined(keys)
+}
+
 // ComputeCodexModelsHash returns a stable hash for Codex model aliases.
 func ComputeCodexModelsHash(models []config.CodexModel) string {
 	keys := normalizeModelPairs(func(out func(key string)) {

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -5,12 +5,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher/diff"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 // ConfigSynthesizer generates Auth entries from configuration API keys.
-// It handles Gemini, Claude, Codex, OpenAI-compat, and Vertex-compat providers.
+// It handles Gemini, Claude, Codex, DeepSeek, OpenAI-compat, and Vertex-compat providers.
 type ConfigSynthesizer struct{}
 
 // NewConfigSynthesizer creates a new ConfigSynthesizer instance.
@@ -31,6 +32,8 @@ func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth,
 	out = append(out, s.synthesizeClaudeKeys(ctx)...)
 	// Codex API Keys
 	out = append(out, s.synthesizeCodexKeys(ctx)...)
+	// DeepSeek API Keys
+	out = append(out, s.synthesizeDeepSeekKeys(ctx)...)
 	// OpenAI-compat
 	out = append(out, s.synthesizeOpenAICompat(ctx)...)
 	// Vertex-compat
@@ -180,6 +183,57 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, ck.ExcludedModels, "apikey")
+		out = append(out, a)
+	}
+	return out
+}
+
+// synthesizeDeepSeekKeys creates Auth entries for DeepSeek API keys.
+func (s *ConfigSynthesizer) synthesizeDeepSeekKeys(ctx *SynthesisContext) []*coreauth.Auth {
+	cfg := ctx.Config
+	now := ctx.Now
+	idGen := ctx.IDGenerator
+
+	out := make([]*coreauth.Auth, 0, len(cfg.DeepSeekKey))
+	for i := range cfg.DeepSeekKey {
+		entry := cfg.DeepSeekKey[i]
+		key := strings.TrimSpace(entry.APIKey)
+		if key == "" {
+			continue
+		}
+		prefix := strings.TrimSpace(entry.Prefix)
+		base := strings.TrimSpace(entry.BaseURL)
+		if base == "" {
+			base = config.DefaultDeepSeekBaseURL
+		}
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		id, token := idGen.Next("deepseek:apikey", key, base)
+		attrs := map[string]string{
+			"source":  fmt.Sprintf("config:deepseek[%s]", token),
+			"api_key": key,
+		}
+		if entry.Priority != 0 {
+			attrs["priority"] = strconv.Itoa(entry.Priority)
+		}
+		if base != "" {
+			attrs["base_url"] = base
+		}
+		if hash := diff.ComputeDeepSeekModelsHash(entry.Models); hash != "" {
+			attrs["models_hash"] = hash
+		}
+		addConfigHeadersToAttrs(entry.Headers, attrs)
+		a := &coreauth.Auth{
+			ID:         id,
+			Provider:   "deepseek",
+			Label:      "deepseek-apikey",
+			Prefix:     prefix,
+			Status:     coreauth.StatusActive,
+			ProxyURL:   proxyURL,
+			Attributes: attrs,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}
+		ApplyAuthExcludedModelsMeta(a, cfg, entry.ExcludedModels, "apikey")
 		out = append(out, a)
 	}
 	return out

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -615,3 +615,40 @@ func TestConfigSynthesizer_AllProviders(t *testing.T) {
 		}
 	}
 }
+
+func TestConfigSynthesizer_DeepSeekKeys(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			DeepSeekKey: []config.DeepSeekKey{
+				{APIKey: "ds-1", BaseURL: "https://api.deepseek.com", Prefix: "team", Priority: 5, Models: []config.DeepSeekModel{{Name: "deepseek-v4-pro", Alias: "deepseek-latest"}}},
+			},
+		},
+		Now:         now,
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths := NewConfigSynthesizer().synthesizeDeepSeekKeys(ctx)
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 DeepSeek auth, got %d", len(auths))
+	}
+	auth := auths[0]
+	if auth.Provider != "deepseek" {
+		t.Fatalf("provider = %q, want deepseek", auth.Provider)
+	}
+	if auth.Prefix != "team" {
+		t.Fatalf("prefix = %q, want team", auth.Prefix)
+	}
+	if got := auth.Attributes["base_url"]; got != "https://api.deepseek.com" {
+		t.Fatalf("base_url = %q", got)
+	}
+	if got := auth.Attributes["api_key"]; got != "ds-1" {
+		t.Fatalf("api_key = %q", got)
+	}
+	if got := auth.Attributes["priority"]; got != "5" {
+		t.Fatalf("priority = %q", got)
+	}
+	if got := auth.Attributes["models_hash"]; got == "" {
+		t.Fatal("expected models_hash to be set")
+	}
+}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -66,16 +66,17 @@ func TestBuildAPIKeyClientsCounts(t *testing.T) {
 		VertexCompatAPIKey: []config.VertexCompatKey{
 			{APIKey: "v1"},
 		},
-		ClaudeKey: []config.ClaudeKey{{APIKey: "c1"}},
-		CodexKey:  []config.CodexKey{{APIKey: "x1"}, {APIKey: "x2"}},
+		ClaudeKey:   []config.ClaudeKey{{APIKey: "c1"}},
+		CodexKey:    []config.CodexKey{{APIKey: "x1"}, {APIKey: "x2"}},
+		DeepSeekKey: []config.DeepSeekKey{{APIKey: "d1"}, {APIKey: "d2"}, {APIKey: "d3"}},
 		OpenAICompatibility: []config.OpenAICompatibility{
 			{APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "o1"}, {APIKey: "o2"}}},
 		},
 	}
 
-	gemini, vertex, claude, codex, compat := BuildAPIKeyClients(cfg)
-	if gemini != 2 || vertex != 1 || claude != 1 || codex != 2 || compat != 2 {
-		t.Fatalf("unexpected counts: %d %d %d %d %d", gemini, vertex, claude, codex, compat)
+	gemini, vertex, claude, codex, deepseek, compat := BuildAPIKeyClients(cfg)
+	if gemini != 2 || vertex != 1 || claude != 1 || codex != 2 || deepseek != 3 || compat != 2 {
+		t.Fatalf("unexpected counts: %d %d %d %d %d %d", gemini, vertex, claude, codex, deepseek, compat)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -965,6 +965,10 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *internalconfig.Config) {
 			if entry := resolveCodexAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
 			}
+		case "deepseek":
+			if entry := resolveDeepSeekAPIKeyConfig(cfg, auth); entry != nil {
+				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
+			}
 		case "vertex":
 			if entry := resolveVertexAPIKeyConfig(cfg, auth); entry != nil {
 				compileAPIKeyModelAliasForModels(byAlias, entry.Models)
@@ -1646,6 +1650,8 @@ func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) strin
 		upstreamModel = resolveUpstreamModelForClaudeAPIKey(cfg, auth, requestedModel)
 	case "codex":
 		upstreamModel = resolveUpstreamModelForCodexAPIKey(cfg, auth, requestedModel)
+	case "deepseek":
+		upstreamModel = resolveUpstreamModelForDeepSeekAPIKey(cfg, auth, requestedModel)
 	case "vertex":
 		upstreamModel = resolveUpstreamModelForVertexAPIKey(cfg, auth, requestedModel)
 	default:
@@ -1725,6 +1731,13 @@ func resolveCodexAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internalc
 	return resolveAPIKeyConfig(cfg.CodexKey, auth)
 }
 
+func resolveDeepSeekAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internalconfig.DeepSeekKey {
+	if cfg == nil {
+		return nil
+	}
+	return resolveAPIKeyConfig(cfg.DeepSeekKey, auth)
+}
+
 func resolveVertexAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internalconfig.VertexCompatKey {
 	if cfg == nil {
 		return nil
@@ -1750,6 +1763,14 @@ func resolveUpstreamModelForClaudeAPIKey(cfg *internalconfig.Config, auth *Auth,
 
 func resolveUpstreamModelForCodexAPIKey(cfg *internalconfig.Config, auth *Auth, requestedModel string) string {
 	entry := resolveCodexAPIKeyConfig(cfg, auth)
+	if entry == nil {
+		return ""
+	}
+	return resolveModelAliasFromConfigModels(requestedModel, asModelAliasEntries(entry.Models))
+}
+
+func resolveUpstreamModelForDeepSeekAPIKey(cfg *internalconfig.Config, auth *Auth, requestedModel string) string {
+	entry := resolveDeepSeekAPIKeyConfig(cfg, auth)
 	if entry == nil {
 		return ""
 	}

--- a/sdk/cliproxy/providers.go
+++ b/sdk/cliproxy/providers.go
@@ -29,7 +29,7 @@ func NewAPIKeyClientProvider() APIKeyClientProvider {
 type apiKeyClientProvider struct{}
 
 func (p *apiKeyClientProvider) Load(ctx context.Context, cfg *config.Config) (*APIKeyClientResult, error) {
-	geminiCount, vertexCompatCount, claudeCount, codexCount, openAICompat := watcher.BuildAPIKeyClients(cfg)
+	geminiCount, vertexCompatCount, claudeCount, codexCount, deepSeekCount, openAICompat := watcher.BuildAPIKeyClients(cfg)
 	if ctx != nil {
 		select {
 		case <-ctx.Done():
@@ -42,6 +42,7 @@ func (p *apiKeyClientProvider) Load(ctx context.Context, cfg *config.Config) (*A
 		VertexCompatKeyCount: vertexCompatCount,
 		ClaudeKeyCount:       claudeCount,
 		CodexKeyCount:        codexCount,
+		DeepSeekKeyCount:     deepSeekCount,
 		OpenAICompatCount:    openAICompat,
 	}, nil
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -423,6 +423,8 @@ func (s *Service) ensureExecutorsForAuthWithMode(a *coreauth.Auth, forceReplace 
 		s.coreManager.RegisterExecutor(executor.NewAntigravityExecutor(s.cfg))
 	case "claude":
 		s.coreManager.RegisterExecutor(executor.NewClaudeExecutor(s.cfg))
+	case "deepseek":
+		s.coreManager.RegisterExecutor(executor.NewDeepSeekExecutor(s.cfg))
 	case "kimi":
 		s.coreManager.RegisterExecutor(executor.NewKimiExecutor(s.cfg))
 	default:
@@ -899,6 +901,17 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 			}
 		}
 		models = applyExcludedModels(models, excluded)
+	case "deepseek":
+		models = registry.GetDeepSeekModels()
+		if entry := s.resolveConfigDeepSeekKey(a); entry != nil {
+			if len(entry.Models) > 0 {
+				models = buildDeepSeekConfigModels(entry)
+			}
+			if authKind == "apikey" {
+				excluded = entry.ExcludedModels
+			}
+		}
+		models = applyExcludedModels(models, excluded)
 	case "codex":
 		codexPlanType := ""
 		if a.Attributes != nil {
@@ -1111,6 +1124,32 @@ func (s *Service) resolveConfigClaudeKey(auth *coreauth.Auth) *config.ClaudeKey 
 			if strings.EqualFold(strings.TrimSpace(entry.APIKey), attrKey) {
 				return entry
 			}
+		}
+	}
+	return nil
+}
+
+func (s *Service) resolveConfigDeepSeekKey(auth *coreauth.Auth) *config.DeepSeekKey {
+	if auth == nil || s.cfg == nil {
+		return nil
+	}
+	var attrKey, attrBase string
+	if auth.Attributes != nil {
+		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
+		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+	}
+	for i := range s.cfg.DeepSeekKey {
+		entry := &s.cfg.DeepSeekKey[i]
+		cfgKey := strings.TrimSpace(entry.APIKey)
+		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if attrKey != "" && strings.EqualFold(cfgKey, attrKey) {
+			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
+			continue
+		}
+		if attrKey == "" && attrBase != "" && strings.EqualFold(cfgBase, attrBase) {
+			return entry
 		}
 	}
 	return nil
@@ -1405,6 +1444,13 @@ func buildClaudeConfigModels(entry *config.ClaudeKey) []*ModelInfo {
 		return nil
 	}
 	return buildConfigModels(entry.Models, "anthropic", "claude")
+}
+
+func buildDeepSeekConfigModels(entry *config.DeepSeekKey) []*ModelInfo {
+	if entry == nil {
+		return nil
+	}
+	return buildConfigModels(entry.Models, "deepseek", "deepseek")
 }
 
 func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {

--- a/sdk/cliproxy/types.go
+++ b/sdk/cliproxy/types.go
@@ -63,6 +63,9 @@ type APIKeyClientResult struct {
 	// CodexKeyCount is the number of Codex API keys loaded
 	CodexKeyCount int
 
+	// DeepSeekKeyCount is the number of DeepSeek API keys loaded
+	DeepSeekKeyCount int
+
 	// OpenAICompatCount is the number of OpenAI compatibility API keys loaded
 	OpenAICompatCount int
 }

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -23,6 +23,8 @@ type PayloadModelRule = internalconfig.PayloadModelRule
 type GeminiKey = internalconfig.GeminiKey
 type CodexKey = internalconfig.CodexKey
 type ClaudeKey = internalconfig.ClaudeKey
+type DeepSeekKey = internalconfig.DeepSeekKey
+type DeepSeekModel = internalconfig.DeepSeekModel
 type VertexCompatKey = internalconfig.VertexCompatKey
 type VertexCompatModel = internalconfig.VertexCompatModel
 type OpenAICompatibility = internalconfig.OpenAICompatibility
@@ -33,6 +35,7 @@ type TLS = internalconfig.TLSConfig
 
 const (
 	DefaultPanelGitHubRepository = internalconfig.DefaultPanelGitHubRepository
+	DefaultDeepSeekBaseURL       = internalconfig.DefaultDeepSeekBaseURL
 )
 
 func LoadConfig(configFile string) (*Config, error) { return internalconfig.LoadConfig(configFile) }


### PR DESCRIPTION
## Summary

Adds first-class DeepSeek provider support to CLIProxyAPI.

## Changes

- Add `deepseek-api-key` configuration support.
- Add DeepSeek auth synthesis and provider registration.
- Add dedicated DeepSeek executor using the OpenAI-compatible Chat Completions API.
- Add DeepSeek thinking support with `thinking.type` and `reasoning_effort`.
- Add static DeepSeek V4 model definitions.
- Add management API endpoints for DeepSeek API keys.
- Add model refresh compatibility so DeepSeek models survive remote catalog refreshes while upstream model catalogs catch up.

## Validation

- `gofmt -w .`
- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`
