### PR TITLE
feat: estimate token usage when upstream response lacks usage field

### DIFF
--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -308,6 +308,7 @@ func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth
 					break
 				}
 			case wsrelay.MessageTypeStreamEnd:
+				reporter.EnsurePublished(ctx)
 				return false
 			case wsrelay.MessageTypeHTTPResp:
 				if !metadataLogged && event.Status > 0 {
@@ -322,6 +323,7 @@ func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth
 					out <- cliproxyexecutor.StreamChunk{Payload: ensureColonSpacedJSON(lines[i])}
 				}
 				reporter.Publish(ctx, helps.ParseGeminiUsage(event.Payload))
+				reporter.EnsurePublished(ctx)
 				return false
 			case wsrelay.MessageTypeError:
 				helps.RecordAPIResponseError(ctx, e.cfg, event.Err)

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -488,6 +488,8 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 				reporter.PublishFailure(ctx)
 				out <- cliproxyexecutor.StreamChunk{Err: errScan}
+			} else {
+				reporter.EnsurePublished(ctx)
 			}
 			return
 		}
@@ -526,6 +528,8 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+		} else {
+			reporter.EnsurePublished(ctx)
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -290,6 +290,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		var param any
 		out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, completedData, &param)
 		resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+		reporter.EnsurePublished(ctx)
 		return resp, nil
 	}
 	err = statusErr{code: 408, msg: "stream error: stream disconnected before completion: stream closed before response.completed"}
@@ -510,6 +511,8 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+		} else {
+			reporter.EnsurePublished(ctx)
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -351,6 +351,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			if detail, ok := helps.ParseCodexUsage(payload); ok {
 				reporter.Publish(ctx, detail)
 			}
+			reporter.EnsurePublished(ctx)
 			var param any
 			out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, payload, &param)
 			resp = cliproxyexecutor.Response{Payload: out}
@@ -599,6 +600,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				if detail, ok := helps.ParseCodexUsage(payload); ok {
 					reporter.Publish(ctx, detail)
 				}
+				reporter.EnsurePublished(ctx)
 			}
 
 			line := encodeCodexWebsocketAsSSE(payload)

--- a/internal/runtime/executor/gemini_cli_executor.go
+++ b/internal/runtime/executor/gemini_cli_executor.go
@@ -422,6 +422,8 @@ func (e *GeminiCLIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyaut
 					helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 					reporter.PublishFailure(ctx)
 					out <- cliproxyexecutor.StreamChunk{Err: errScan}
+				} else {
+					reporter.EnsurePublished(ctx)
 				}
 				return
 			}
@@ -435,6 +437,7 @@ func (e *GeminiCLIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyaut
 			}
 			helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 			reporter.Publish(ctx, helps.ParseGeminiCLIUsage(data))
+			reporter.EnsurePublished(ctx)
 			var param any
 			segments := sdktranslator.TranslateStream(respCtx, to, from, attemptModel, opts.OriginalRequest, reqBody, data, &param)
 			for i := range segments {

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -333,6 +333,8 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+		} else {
+			reporter.EnsurePublished(ctx)
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -664,6 +664,8 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+		} else {
+			reporter.EnsurePublished(ctx)
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
@@ -793,6 +795,8 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+		} else {
+			reporter.EnsurePublished(ctx)
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -24,6 +24,7 @@ const (
 	apiRequestKey           = "API_REQUEST"
 	apiResponseKey          = "API_RESPONSE"
 	apiWebsocketTimelineKey = "API_WEBSOCKET_TIMELINE"
+	usageReporterKey        = "USAGE_REPORTER"
 	creditsUsedKey          = "__antigravity_credits_used__"
 )
 
@@ -55,6 +56,7 @@ type upstreamAttempt struct {
 
 // RecordAPIRequest stores the upstream request metadata in Gin context for request logging.
 func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequestLog) {
+	captureUsageRequest(ctx, info.Body)
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}
@@ -153,6 +155,7 @@ func RecordAPIResponseError(ctx context.Context, cfg *config.Config, err error) 
 
 // AppendAPIResponseChunk appends an upstream response chunk to Gin context for request logging.
 func AppendAPIResponseChunk(ctx context.Context, cfg *config.Config, chunk []byte) {
+	captureUsageResponse(ctx, chunk)
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}
@@ -195,6 +198,7 @@ func AppendAPIResponseChunk(ctx context.Context, cfg *config.Config, chunk []byt
 
 // RecordAPIWebsocketRequest stores an upstream websocket request event in Gin context.
 func RecordAPIWebsocketRequest(ctx context.Context, cfg *config.Config, info UpstreamRequestLog) {
+	captureUsageRequest(ctx, info.Body)
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}
@@ -284,6 +288,7 @@ func WebsocketUpgradeRequestURL(rawURL string) string {
 
 // AppendAPIWebsocketResponse stores an upstream websocket response frame in Gin context.
 func AppendAPIWebsocketResponse(ctx context.Context, cfg *config.Config, payload []byte) {
+	captureUsageResponse(ctx, payload)
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}
@@ -331,6 +336,42 @@ func RecordAPIWebsocketError(ctx context.Context, cfg *config.Config, stage stri
 func ginContextFrom(ctx context.Context) *gin.Context {
 	ginCtx, _ := ctx.Value("gin").(*gin.Context)
 	return ginCtx
+}
+
+func registerUsageReporter(ctx context.Context, reporter *UsageReporter) {
+	if reporter == nil {
+		return
+	}
+	ginCtx := ginContextFrom(ctx)
+	if ginCtx == nil {
+		return
+	}
+	ginCtx.Set(usageReporterKey, reporter)
+}
+
+func usageReporterFromContext(ctx context.Context) *UsageReporter {
+	ginCtx := ginContextFrom(ctx)
+	if ginCtx == nil {
+		return nil
+	}
+	value, exists := ginCtx.Get(usageReporterKey)
+	if !exists {
+		return nil
+	}
+	reporter, _ := value.(*UsageReporter)
+	return reporter
+}
+
+func captureUsageRequest(ctx context.Context, body []byte) {
+	if reporter := usageReporterFromContext(ctx); reporter != nil {
+		reporter.captureRequestBody(body)
+	}
+}
+
+func captureUsageResponse(ctx context.Context, body []byte) {
+	if reporter := usageReporterFromContext(ctx); reporter != nil {
+		reporter.captureResponseChunk(body)
+	}
 }
 
 func getAttempts(ginCtx *gin.Context) []*upstreamAttempt {

--- a/internal/runtime/executor/helps/token_helpers.go
+++ b/internal/runtime/executor/helps/token_helpers.go
@@ -1,9 +1,11 @@
 package helps
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	"github.com/tidwall/gjson"
 	"github.com/tiktoken-go/tokenizer"
 )
@@ -49,6 +51,8 @@ func CountOpenAIChatTokens(enc tokenizer.Codec, payload []byte) (int64, error) {
 	root := gjson.ParseBytes(payload)
 	segments := make([]string, 0, 32)
 
+	collectOpenAIContent(root.Get("system"), &segments)
+	collectOpenAIContent(root.Get("instructions"), &segments)
 	collectOpenAIMessages(root.Get("messages"), &segments)
 	collectOpenAITools(root.Get("tools"), &segments)
 	collectOpenAIFunctions(root.Get("functions"), &segments)
@@ -67,6 +71,425 @@ func CountOpenAIChatTokens(enc tokenizer.Codec, payload []byte) (int64, error) {
 		return 0, err
 	}
 	return int64(count), nil
+}
+
+// EstimateUsage approximates request and response tokens when upstream usage is missing.
+func EstimateUsage(model string, requestBody []byte, responseBody []byte) usage.Detail {
+	enc, err := TokenizerForModel(model)
+	if err != nil {
+		return usage.Detail{}
+	}
+
+	inputTokens := estimateInputTokens(enc, requestBody)
+	outputTokens := countTextTokens(enc, ExtractOutputText(responseBody))
+	totalTokens := inputTokens + outputTokens
+	if totalTokens == 0 {
+		return usage.Detail{}
+	}
+	return usage.Detail{
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		TotalTokens:  totalTokens,
+	}
+}
+
+func estimateInputTokens(enc tokenizer.Codec, requestBody []byte) int64 {
+	if len(bytes.TrimSpace(requestBody)) == 0 {
+		return 0
+	}
+	if count, err := CountOpenAIChatTokens(enc, requestBody); err == nil && count > 0 {
+		return count
+	}
+	return countTextTokens(enc, ExtractInputText(requestBody))
+}
+
+func countTextTokens(enc tokenizer.Codec, text string) int64 {
+	if enc == nil {
+		return 0
+	}
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return 0
+	}
+	count, err := enc.Count(trimmed)
+	if err != nil {
+		return 0
+	}
+	return int64(count)
+}
+
+// ExtractInputText collects text-bearing request fields across supported provider schemas.
+func ExtractInputText(data []byte) string {
+	payloads := jsonPayloads(data)
+	if len(payloads) == 0 {
+		return ""
+	}
+	segments := make([]string, 0, 32)
+	for _, payload := range payloads {
+		collectInputText(gjson.ParseBytes(payload), &segments)
+	}
+	return strings.TrimSpace(strings.Join(segments, "\n"))
+}
+
+// ExtractOutputText collects visible response text across non-streaming and streaming schemas.
+func ExtractOutputText(data []byte) string {
+	payloads := jsonPayloads(data)
+	if len(payloads) == 0 {
+		return ""
+	}
+	options := detectOutputExtractionOptions(payloads)
+	segments := make([]string, 0, 32)
+	for _, payload := range payloads {
+		collectOutputText(gjson.ParseBytes(payload), options, &segments)
+	}
+	return strings.TrimSpace(strings.Join(segments, ""))
+}
+
+type outputExtractionOptions struct {
+	hasResponsesTextDelta     bool
+	hasResponsesFunctionDelta bool
+	hasResponsesOutputDone    bool
+}
+
+func detectOutputExtractionOptions(payloads [][]byte) outputExtractionOptions {
+	var options outputExtractionOptions
+	for _, payload := range payloads {
+		root := gjson.ParseBytes(payload)
+		if root.IsArray() {
+			root.ForEach(func(_, item gjson.Result) bool {
+				updateOutputExtractionOptions(item, &options)
+				return true
+			})
+			continue
+		}
+		updateOutputExtractionOptions(root, &options)
+	}
+	return options
+}
+
+func updateOutputExtractionOptions(root gjson.Result, options *outputExtractionOptions) {
+	if options == nil {
+		return
+	}
+	switch root.Get("type").String() {
+	case "response.output_text.delta", "response.reasoning_summary_text.delta":
+		options.hasResponsesTextDelta = true
+	case "response.function_call_arguments.delta":
+		options.hasResponsesFunctionDelta = true
+	case "response.output_item.done":
+		options.hasResponsesOutputDone = true
+	case "content_block_delta":
+		options.hasResponsesTextDelta = true
+	}
+}
+
+func jsonPayloads(data []byte) [][]byte {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if gjson.ValidBytes(trimmed) {
+		return [][]byte{append([]byte(nil), trimmed...)}
+	}
+
+	lines := bytes.Split(trimmed, []byte("\n"))
+	payloads := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		payload := JSONPayload(line)
+		if len(payload) == 0 {
+			line = bytes.TrimSpace(line)
+			if !gjson.ValidBytes(line) {
+				continue
+			}
+			payload = line
+		}
+		payloads = append(payloads, append([]byte(nil), payload...))
+	}
+	return payloads
+}
+
+func collectInputText(root gjson.Result, segments *[]string) {
+	if !root.Exists() {
+		return
+	}
+	if root.IsArray() {
+		root.ForEach(func(_, item gjson.Result) bool {
+			collectInputText(item, segments)
+			return true
+		})
+		return
+	}
+
+	collectOpenAIContent(root.Get("system"), segments)
+	collectOpenAIContent(root.Get("instructions"), segments)
+	collectOpenAIMessages(root.Get("messages"), segments)
+	collectOpenAIContent(root.Get("input"), segments)
+	addIfNotEmpty(segments, root.Get("prompt").String())
+
+	collectGeminiContents(root.Get("contents"), segments)
+	collectGeminiContents(root.Get("request.contents"), segments)
+	collectGeminiContent(root.Get("systemInstruction"), segments)
+	collectGeminiContent(root.Get("request.systemInstruction"), segments)
+	collectGeminiTools(root.Get("tools"), segments)
+	collectGeminiTools(root.Get("request.tools"), segments)
+	collectOpenAITools(root.Get("request.tools"), segments)
+}
+
+func collectOutputText(root gjson.Result, options outputExtractionOptions, segments *[]string) {
+	if !root.Exists() {
+		return
+	}
+	if root.IsArray() {
+		root.ForEach(func(_, item gjson.Result) bool {
+			collectOutputText(item, options, segments)
+			return true
+		})
+		return
+	}
+
+	eventType := root.Get("type").String()
+	switch eventType {
+	case "response.output_text.delta", "response.reasoning_summary_text.delta":
+		addOutputIfNotEmpty(segments, root.Get("delta").String())
+		return
+	case "response.function_call_arguments.delta":
+		addOutputIfNotEmpty(segments, root.Get("delta").String())
+		return
+	case "response.output_text.done", "response.reasoning_summary_text.done":
+		if !options.hasResponsesTextDelta {
+			addOutputIfNotEmpty(segments, root.Get("text").String())
+		}
+		return
+	case "response.function_call_arguments.done":
+		if !options.hasResponsesFunctionDelta {
+			addOutputIfNotEmpty(segments, root.Get("arguments").String())
+		}
+		return
+	case "response.output_item.done":
+		collectResponseOutputItem(root.Get("item"), options, segments)
+		return
+	case "response.completed", "response.done":
+		if !options.hasResponsesTextDelta && !options.hasResponsesFunctionDelta && !options.hasResponsesOutputDone {
+			collectResponseOutput(root.Get("response.output"), options, segments)
+			addIfNotEmpty(segments, root.Get("response.output_text").String())
+		}
+		return
+	case "content_block_delta":
+		collectClaudeDelta(root.Get("delta"), segments)
+		return
+	case "content_block_start":
+		if !options.hasResponsesTextDelta {
+			collectClaudeContentBlock(root.Get("content_block"), segments)
+		}
+		return
+	}
+
+	collectOpenAIChoices(root.Get("choices"), segments)
+	collectResponseOutput(root.Get("output"), options, segments)
+	collectResponseOutput(root.Get("response.output"), options, segments)
+	addOutputIfNotEmpty(segments, root.Get("output_text").String())
+	addOutputIfNotEmpty(segments, root.Get("response.output_text").String())
+	collectClaudeContent(root.Get("content"), segments)
+	collectGeminiCandidates(root.Get("candidates"), segments)
+	collectGeminiCandidates(root.Get("response.candidates"), segments)
+}
+
+func collectOpenAIChoices(choices gjson.Result, segments *[]string) {
+	if !choices.Exists() || !choices.IsArray() {
+		return
+	}
+	choices.ForEach(func(_, choice gjson.Result) bool {
+		message := choice.Get("message")
+		if message.Exists() {
+			collectOutputContent(message.Get("content"), segments)
+			collectOpenAIToolCalls(message.Get("tool_calls"), segments)
+			collectOpenAIFunctionCall(message.Get("function_call"), segments)
+		}
+		delta := choice.Get("delta")
+		if delta.Exists() {
+			collectOutputContent(delta.Get("content"), segments)
+			collectOpenAIToolCalls(delta.Get("tool_calls"), segments)
+			collectOpenAIFunctionCall(delta.Get("function_call"), segments)
+		}
+		return true
+	})
+}
+
+func collectResponseOutput(output gjson.Result, options outputExtractionOptions, segments *[]string) {
+	if !output.Exists() {
+		return
+	}
+	if output.IsArray() {
+		output.ForEach(func(_, item gjson.Result) bool {
+			collectResponseOutputItem(item, options, segments)
+			return true
+		})
+		return
+	}
+	collectResponseOutputItem(output, options, segments)
+}
+
+func collectResponseOutputItem(item gjson.Result, options outputExtractionOptions, segments *[]string) {
+	if !item.Exists() {
+		return
+	}
+	switch item.Get("type").String() {
+	case "message", "":
+		if options.hasResponsesTextDelta {
+			return
+		}
+		collectOutputContent(item.Get("content"), segments)
+	case "function_call":
+		if options.hasResponsesFunctionDelta {
+			return
+		}
+		addOutputIfNotEmpty(segments, item.Get("name").String())
+		addOutputIfNotEmpty(segments, item.Get("arguments").String())
+	default:
+		collectOutputContent(item.Get("content"), segments)
+		addOutputIfNotEmpty(segments, item.Get("name").String())
+		addOutputIfNotEmpty(segments, item.Get("arguments").String())
+		addOutputIfNotEmpty(segments, item.Get("text").String())
+	}
+}
+
+func collectClaudeContent(content gjson.Result, segments *[]string) {
+	collectOutputContent(content, segments)
+}
+
+func collectClaudeDelta(delta gjson.Result, segments *[]string) {
+	if !delta.Exists() {
+		return
+	}
+	addOutputIfNotEmpty(segments, delta.Get("text").String())
+	addOutputIfNotEmpty(segments, delta.Get("partial_json").String())
+}
+
+func collectClaudeContentBlock(block gjson.Result, segments *[]string) {
+	if !block.Exists() {
+		return
+	}
+	switch block.Get("type").String() {
+	case "text":
+		addOutputIfNotEmpty(segments, block.Get("text").String())
+	case "tool_use":
+		addOutputIfNotEmpty(segments, block.Get("name").String())
+		if input := block.Get("input"); input.Exists() {
+			addOutputIfNotEmpty(segments, input.Raw)
+		}
+	}
+}
+
+func collectGeminiCandidates(candidates gjson.Result, segments *[]string) {
+	if !candidates.Exists() || !candidates.IsArray() {
+		return
+	}
+	candidates.ForEach(func(_, candidate gjson.Result) bool {
+		collectGeminiContent(candidate.Get("content"), segments)
+		return true
+	})
+}
+
+func collectGeminiContents(contents gjson.Result, segments *[]string) {
+	if !contents.Exists() {
+		return
+	}
+	if contents.IsArray() {
+		contents.ForEach(func(_, content gjson.Result) bool {
+			collectGeminiContent(content, segments)
+			return true
+		})
+		return
+	}
+	collectGeminiContent(contents, segments)
+}
+
+func collectGeminiContent(content gjson.Result, segments *[]string) {
+	if !content.Exists() {
+		return
+	}
+	parts := content.Get("parts")
+	if parts.Exists() && parts.IsArray() {
+		parts.ForEach(func(_, part gjson.Result) bool {
+			addOutputIfNotEmpty(segments, part.Get("text").String())
+			if functionCall := part.Get("functionCall"); functionCall.Exists() {
+				addOutputIfNotEmpty(segments, functionCall.Get("name").String())
+				if args := functionCall.Get("args"); args.Exists() {
+					addOutputIfNotEmpty(segments, args.Raw)
+				}
+			}
+			if functionResponse := part.Get("functionResponse"); functionResponse.Exists() {
+				addOutputIfNotEmpty(segments, functionResponse.Get("name").String())
+				if response := functionResponse.Get("response"); response.Exists() {
+					addOutputIfNotEmpty(segments, response.Raw)
+				}
+			}
+			return true
+		})
+		return
+	}
+	collectOutputContent(content, segments)
+}
+
+func collectGeminiTools(tools gjson.Result, segments *[]string) {
+	if !tools.Exists() {
+		return
+	}
+	if tools.IsArray() {
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			collectGeminiTool(tool, segments)
+			return true
+		})
+		return
+	}
+	collectGeminiTool(tools, segments)
+}
+
+func collectGeminiTool(tool gjson.Result, segments *[]string) {
+	if !tool.Exists() {
+		return
+	}
+	declarations := tool.Get("functionDeclarations")
+	if declarations.Exists() && declarations.IsArray() {
+		declarations.ForEach(func(_, declaration gjson.Result) bool {
+			addIfNotEmpty(segments, declaration.Get("name").String())
+			addIfNotEmpty(segments, declaration.Get("description").String())
+			if params := declaration.Get("parameters"); params.Exists() {
+				addIfNotEmpty(segments, params.Raw)
+			}
+			return true
+		})
+	}
+}
+
+func collectOutputContent(content gjson.Result, segments *[]string) {
+	if !content.Exists() {
+		return
+	}
+	if content.Type == gjson.String {
+		addOutputIfNotEmpty(segments, content.String())
+		return
+	}
+	if content.IsArray() {
+		content.ForEach(func(_, part gjson.Result) bool {
+			collectOutputContent(part, segments)
+			return true
+		})
+		return
+	}
+	addOutputIfNotEmpty(segments, content.Get("text").String())
+	addOutputIfNotEmpty(segments, content.Get("delta").String())
+	addOutputIfNotEmpty(segments, content.Get("transcript").String())
+	if content.Get("type").String() == "tool_use" {
+		addOutputIfNotEmpty(segments, content.Get("name").String())
+		if input := content.Get("input"); input.Exists() {
+			addOutputIfNotEmpty(segments, input.Raw)
+		}
+	}
+	if content.Get("type").String() == "function_call" {
+		addOutputIfNotEmpty(segments, content.Get("name").String())
+		addOutputIfNotEmpty(segments, content.Get("arguments").String())
+	}
 }
 
 // BuildOpenAIUsageJSON returns a minimal usage structure understood by downstream translators.
@@ -232,5 +655,14 @@ func addIfNotEmpty(segments *[]string, value string) {
 	}
 	if trimmed := strings.TrimSpace(value); trimmed != "" {
 		*segments = append(*segments, trimmed)
+	}
+}
+
+func addOutputIfNotEmpty(segments *[]string, value string) {
+	if segments == nil {
+		return
+	}
+	if strings.TrimSpace(value) != "" {
+		*segments = append(*segments, value)
 	}
 }

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -25,6 +25,9 @@ type UsageReporter struct {
 	source      string
 	requestedAt time.Time
 	once        sync.Once
+	bodyMu      sync.Mutex
+	requestBody []byte
+	responseBuf []byte
 }
 
 func NewUsageReporter(ctx context.Context, provider, model string, auth *cliproxyauth.Auth) *UsageReporter {
@@ -41,6 +44,7 @@ func NewUsageReporter(ctx context.Context, provider, model string, auth *cliprox
 		reporter.authID = auth.ID
 		reporter.authIndex = auth.EnsureIndex()
 	}
+	registerUsageReporter(ctx, reporter)
 	return reporter
 }
 
@@ -65,13 +69,8 @@ func (r *UsageReporter) publishWithOutcome(ctx context.Context, detail usage.Det
 	if r == nil {
 		return
 	}
-	if detail.TotalTokens == 0 {
-		total := detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
-		if total > 0 {
-			detail.TotalTokens = total
-		}
-	}
 	r.once.Do(func() {
+		detail = r.completeDetail(detail, failed)
 		usage.PublishRecord(ctx, r.buildRecord(detail, failed))
 	})
 }
@@ -84,9 +83,64 @@ func (r *UsageReporter) EnsurePublished(ctx context.Context) {
 	if r == nil {
 		return
 	}
-	r.once.Do(func() {
-		usage.PublishRecord(ctx, r.buildRecord(usage.Detail{}, false))
-	})
+	r.publishWithOutcome(ctx, usage.Detail{}, false)
+}
+
+func (r *UsageReporter) captureRequestBody(body []byte) {
+	if r == nil {
+		return
+	}
+	r.bodyMu.Lock()
+	defer r.bodyMu.Unlock()
+	r.requestBody = append(r.requestBody[:0], body...)
+	r.responseBuf = r.responseBuf[:0]
+}
+
+func (r *UsageReporter) captureResponseChunk(chunk []byte) {
+	if r == nil {
+		return
+	}
+	data := bytes.TrimSpace(chunk)
+	if len(data) == 0 {
+		return
+	}
+	r.bodyMu.Lock()
+	defer r.bodyMu.Unlock()
+	if len(r.responseBuf) > 0 {
+		r.responseBuf = append(r.responseBuf, '\n')
+	}
+	r.responseBuf = append(r.responseBuf, data...)
+}
+
+func (r *UsageReporter) completeDetail(detail usage.Detail, failed bool) usage.Detail {
+	if detail.TotalTokens == 0 {
+		total := detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
+		if total > 0 {
+			detail.TotalTokens = total
+		}
+	}
+	if failed || !isMissingUsageDetail(detail) {
+		return detail
+	}
+	if estimated := r.estimateUsage(); !isMissingUsageDetail(estimated) {
+		return estimated
+	}
+	return detail
+}
+
+func (r *UsageReporter) estimateUsage() usage.Detail {
+	if r == nil {
+		return usage.Detail{}
+	}
+	r.bodyMu.Lock()
+	requestBody := append([]byte(nil), r.requestBody...)
+	responseBody := append([]byte(nil), r.responseBuf...)
+	r.bodyMu.Unlock()
+	return EstimateUsage(r.model, requestBody, responseBody)
+}
+
+func isMissingUsageDetail(detail usage.Detail) bool {
+	return detail.TotalTokens == 0 && detail.InputTokens == 0 && detail.OutputTokens == 0
 }
 
 func (r *UsageReporter) buildRecord(detail usage.Detail, failed bool) usage.Record {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -62,3 +62,94 @@ func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 		t.Fatalf("latency = %v, want <= 3s", record.Latency)
 	}
 }
+
+func TestEstimateUsageCountsRequestAndResponse(t *testing.T) {
+	request := []byte(`{"messages":[{"role":"user","content":"Hello there"}]}`)
+	response := []byte(`{"choices":[{"message":{"role":"assistant","content":"General Kenobi"}}]}`)
+
+	detail := EstimateUsage("gpt-4o", request, response)
+	if detail.InputTokens <= 0 {
+		t.Fatalf("input tokens = %d, want > 0", detail.InputTokens)
+	}
+	if detail.OutputTokens <= 0 {
+		t.Fatalf("output tokens = %d, want > 0", detail.OutputTokens)
+	}
+	if detail.TotalTokens != detail.InputTokens+detail.OutputTokens {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, detail.InputTokens+detail.OutputTokens)
+	}
+	if detail.ReasoningTokens != 0 {
+		t.Fatalf("reasoning tokens = %d, want 0", detail.ReasoningTokens)
+	}
+	if detail.CachedTokens != 0 {
+		t.Fatalf("cached tokens = %d, want 0", detail.CachedTokens)
+	}
+}
+
+func TestExtractOutputTextProviderFormats(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want string
+	}{
+		{
+			name: "openai chat",
+			data: []byte(`{"choices":[{"message":{"role":"assistant","content":"OpenAI output"}}]}`),
+			want: "OpenAI output",
+		},
+		{
+			name: "claude message",
+			data: []byte(`{"content":[{"type":"text","text":"Claude output"}]}`),
+			want: "Claude output",
+		},
+		{
+			name: "gemini candidate",
+			data: []byte(`{"candidates":[{"content":{"parts":[{"text":"Gemini output"}]}}]}`),
+			want: "Gemini output",
+		},
+		{
+			name: "openai stream",
+			data: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"stream \"}}]}\n\ndata: {\"choices\":[{\"delta\":{\"content\":\"output\"}}]}\n\n"),
+			want: "stream output",
+		},
+		{
+			name: "codex response",
+			data: []byte(`{"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"Codex output"}]}]}}`),
+			want: "Codex output",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractOutputText(tt.data); got != tt.want {
+				t.Fatalf("ExtractOutputText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEstimateUsageEmptyResponseOutput(t *testing.T) {
+	request := []byte(`{"messages":[{"role":"user","content":"Hello there"}]}`)
+	response := []byte(`{"choices":[{"message":{"role":"assistant","content":""}}]}`)
+
+	detail := EstimateUsage("gpt-4o", request, response)
+	if detail.InputTokens <= 0 {
+		t.Fatalf("input tokens = %d, want > 0", detail.InputTokens)
+	}
+	if detail.OutputTokens != 0 {
+		t.Fatalf("output tokens = %d, want 0", detail.OutputTokens)
+	}
+	if detail.TotalTokens != detail.InputTokens {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, detail.InputTokens)
+	}
+}
+
+func TestUsageReporterDoesNotEstimateWhenUsageExists(t *testing.T) {
+	reporter := &UsageReporter{model: "gpt-4o"}
+	reporter.captureRequestBody([]byte(`{"messages":[{"role":"user","content":"Hello there"}]}`))
+	reporter.captureResponseChunk([]byte(`{"choices":[{"message":{"role":"assistant","content":"General Kenobi"}}]}`))
+
+	detail := reporter.completeDetail(usage.Detail{InputTokens: 1, OutputTokens: 2, TotalTokens: 3}, false)
+	if detail.InputTokens != 1 || detail.OutputTokens != 2 || detail.TotalTokens != 3 {
+		t.Fatalf("detail = %+v, want original usage values", detail)
+	}
+}

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -299,6 +299,8 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+		} else {
+			reporter.EnsurePublished(ctx)
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil


### PR DESCRIPTION
## Summary

When LLM API responses omit the `usage` field, the proxy previously recorded zero tokens for all fields. This PR introduces tiktoken-based token estimation that fills in `InputTokens`, `OutputTokens`, and `TotalTokens` from the actual request/response content when usage is missing.

## Changes

### Core: Estimation logic
- `EstimateUsage(model, requestBody, responseBody)` in `token_helpers.go`: Uses existing `tiktoken-go/tokenizer` to estimate tokens when upstream usage is absent
- `ExtractInputText()`: Extracts text content from request bodies across OpenAI, Claude, Gemini, Codex formats
- `ExtractOutputText()`: Extracts text content from response bodies (non-streaming and streaming) across all provider formats
- `countTextTokens()`: Helper that tokenizes a plain string with a model-appropriate codec

### Core: UsageReporter integration
- `UsageReporter.captureRequestBody()` / `captureResponseChunk()`: Captures raw payloads during logging, enabling estimation at publish time
- `UsageReporter.completeDetail()`: When `detail` is all-zero (no usage from upstream), automatically invokes `EstimateUsage()` to fill in values
- `publishWithOutcome()` now calls `completeDetail()` before publishing, so all executors benefit automatically
- `EnsurePublished()` now delegates to `publishWithOutcome()`, ensuring streaming paths also get estimation

### Executors: EnsurePublished coverage
Added `reporter.EnsurePublished(ctx)` to all streaming executor paths that previously only called `Publish` on usage chunks (which may never arrive):
- `aistudio_executor.go`
- `claude_executor.go`
- `codex_executor.go`
- `codex_websockets_executor.go`
- `gemini_cli_executor.go`
- `gemini_executor.go`
- `gemini_vertex_executor.go`
- `kimi_executor.go`

### Tests
- `TestEstimateUsageCountsRequestAndResponse`: Verifies both input and output tokens are estimated
- `TestExtractOutputTextProviderFormats`: Covers OpenAI, Claude, Gemini, Codex response formats
- `TestEstimateUsageEmptyResponseOutput`: Empty response content yields OutputTokens=0
- `TestUsageReporterDoesNotEstimateWhenUsageExists`: Real usage is never overwritten

## Design decisions

- **No marking**: Estimated values are not tagged as `estimated`; they fill `usage.Detail` transparently
- **Centralized**: Estimation happens in `publishWithOutcome()`, so every executor benefits without per-executor changes
- **Lazy capture**: Request/response bodies are captured as a side-effect of existing logging calls (zero overhead when logging is disabled)
- **Fallback only**: Estimation only triggers when `TotalTokens == 0 && InputTokens == 0 && OutputTokens == 0`; real usage is always preferred
- **Empty content**: If response content is empty (abnormal response), `OutputTokens` stays 0 per requirement

## Testing

```
go test ./internal/runtime/executor/helps/... — PASS
```
