### PR TITLE
Show Codex account plan and quota windows in Auth Files

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -431,6 +431,7 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	if claims := extractCodexIDTokenClaims(auth); claims != nil {
 		entry["id_token"] = claims
 	}
+	addCodexAccountEntryFields(entry, auth)
 	// Expose priority from Attributes (set by synthesizer from JSON "priority" field).
 	// Fall back to Metadata for auths registered via UploadAuthFile (no synthesizer).
 	if p := strings.TrimSpace(authAttribute(auth, "priority")); p != "" {
@@ -463,6 +464,311 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 		}
 	}
 	return entry
+}
+
+func addCodexAccountEntryFields(entry gin.H, auth *coreauth.Auth) {
+	if entry == nil || auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return
+	}
+
+	planType := strings.TrimSpace(authAttribute(auth, "plan_type"))
+	if claims := extractCodexIDTokenClaims(auth); claims != nil {
+		if planType == "" {
+			if v, ok := claims["plan_type"].(string); ok {
+				planType = strings.TrimSpace(v)
+			}
+		}
+		if v, ok := claims["chatgpt_subscription_active_start"]; ok {
+			entry["subscription_start"] = v
+			entry["chatgpt_subscription_active_start"] = v
+		}
+		if v, ok := claims["chatgpt_subscription_active_until"]; ok {
+			entry["subscription_until"] = v
+			entry["chatgpt_subscription_active_until"] = v
+		}
+	}
+	if planType != "" {
+		entry["plan_type"] = strings.ToLower(planType)
+	}
+
+	now := time.Now()
+	addQuotaEntryFields(entry, auth.Quota, now)
+	addCodexQuotaWindowEntryFields(entry, auth, now)
+}
+
+func addQuotaEntryFields(entry gin.H, quota coreauth.QuotaState, now time.Time) {
+	entry["quota_exceeded"] = quota.Exceeded
+	entry["quota_status"] = quotaEntryStatus(quota, now)
+	if reason := strings.TrimSpace(quota.Reason); reason != "" {
+		entry["quota_reason"] = reason
+	}
+	if !quota.NextRecoverAt.IsZero() {
+		recoverAt := quota.NextRecoverAt.UTC()
+		entry["quota_next_recover_at"] = recoverAt
+		if recoverAt.After(now) {
+			recoverAfter := recoverAt.Sub(now)
+			entry["quota_recover_after_seconds"] = int64(recoverAfter.Seconds())
+			entry["quota_recover_in"] = recoverAfter.Round(time.Second).String()
+		}
+	}
+	if quota.BackoffLevel > 0 {
+		entry["quota_backoff_level"] = quota.BackoffLevel
+	}
+}
+
+func quotaEntryStatus(quota coreauth.QuotaState, now time.Time) string {
+	if quota.Exceeded {
+		if quota.NextRecoverAt.After(now) {
+			return "recovering"
+		}
+		return "exceeded"
+	}
+	if quota.Reason != "" || !quota.NextRecoverAt.IsZero() || quota.BackoffLevel > 0 {
+		return "limited"
+	}
+	return "available"
+}
+
+type codexQuotaWindow struct {
+	prefix   string
+	aliases  []string
+	keyBases []string
+}
+
+var codexQuotaWindows = []codexQuotaWindow{
+	{
+		prefix:  "quota_5h",
+		aliases: []string{"5h", "5_hour", "5_hours", "five_hour", "five_hours", "short"},
+		keyBases: []string{
+			"codex_quota_5h",
+			"codex_quota_5_hour",
+			"codex_quota_five_hour",
+			"quota_5h",
+			"quota_5_hour",
+			"usage_5h",
+			"usage_limit_5h",
+		},
+	},
+	{
+		prefix:  "quota_weekly",
+		aliases: []string{"weekly", "week", "7d", "seven_day", "seven_days"},
+		keyBases: []string{
+			"codex_quota_weekly",
+			"codex_quota_week",
+			"quota_weekly",
+			"quota_week",
+			"usage_weekly",
+			"usage_week",
+			"usage_limit_weekly",
+		},
+	},
+}
+
+func addCodexQuotaWindowEntryFields(entry gin.H, auth *coreauth.Auth, now time.Time) {
+	for _, window := range codexQuotaWindows {
+		addCodexQuotaWindowFromMetadata(entry, auth, window, now)
+	}
+	addCodexQuotaRuntimeFallback(entry, auth.Quota, now)
+}
+
+func addCodexQuotaWindowFromMetadata(entry gin.H, auth *coreauth.Auth, window codexQuotaWindow, now time.Time) bool {
+	limit, hasLimit := codexQuotaFieldString(auth, window, "limit", "max", "total")
+	remaining, hasRemaining := codexQuotaFieldString(auth, window, "remaining", "available", "left")
+	used, hasUsed := codexQuotaFieldString(auth, window, "used", "consumed")
+	status, hasStatus := codexQuotaFieldString(auth, window, "status", "state")
+	recoverAt, hasRecoverAt := codexQuotaFieldTime(auth, window, "reset_at", "resets_at", "recover_at", "next_recover_at")
+
+	if !hasLimit && !hasRemaining && !hasUsed && !hasStatus && !hasRecoverAt {
+		return false
+	}
+
+	if hasLimit {
+		entry[window.prefix+"_limit"] = limit
+	}
+	if hasRemaining {
+		entry[window.prefix+"_remaining"] = remaining
+	}
+	if hasUsed {
+		entry[window.prefix+"_used"] = used
+	}
+	if amount := formatCodexQuotaAmount(remaining, hasRemaining, limit, hasLimit, used, hasUsed); amount != "" {
+		entry[window.prefix+"_amount"] = amount
+	}
+	if hasStatus {
+		entry[window.prefix+"_status"] = strings.ToLower(status)
+	} else if hasRecoverAt && recoverAt.After(now) {
+		entry[window.prefix+"_status"] = "recovering"
+	} else {
+		entry[window.prefix+"_status"] = "available"
+	}
+	if hasRecoverAt {
+		setQuotaRecoverFields(entry, window.prefix, recoverAt, now)
+	}
+	return true
+}
+
+func addCodexQuotaRuntimeFallback(entry gin.H, quota coreauth.QuotaState, now time.Time) {
+	if !quotaHasState(quota) {
+		return
+	}
+	prefix := codexQuotaFallbackPrefix(quota, now)
+	if _, exists := entry[prefix+"_status"]; exists {
+		return
+	}
+	entry[prefix+"_status"] = quotaEntryStatus(quota, now)
+	if !quota.NextRecoverAt.IsZero() {
+		setQuotaRecoverFields(entry, prefix, quota.NextRecoverAt.UTC(), now)
+	}
+	if quota.BackoffLevel > 0 {
+		entry[prefix+"_backoff_level"] = quota.BackoffLevel
+	}
+}
+
+func quotaHasState(quota coreauth.QuotaState) bool {
+	return quota.Exceeded || strings.TrimSpace(quota.Reason) != "" || !quota.NextRecoverAt.IsZero() || quota.BackoffLevel > 0
+}
+
+func codexQuotaFallbackPrefix(quota coreauth.QuotaState, now time.Time) string {
+	reason := strings.ToLower(strings.TrimSpace(quota.Reason))
+	if strings.Contains(reason, "week") {
+		return "quota_weekly"
+	}
+	if strings.Contains(reason, "5h") || strings.Contains(reason, "5 hour") || strings.Contains(reason, "five hour") {
+		return "quota_5h"
+	}
+	if !quota.NextRecoverAt.IsZero() && quota.NextRecoverAt.Sub(now) > 5*time.Hour {
+		return "quota_weekly"
+	}
+	return "quota_5h"
+}
+
+func setQuotaRecoverFields(entry gin.H, prefix string, recoverAt, now time.Time) {
+	recoverAt = recoverAt.UTC()
+	entry[prefix+"_next_recover_at"] = recoverAt
+	if recoverAt.After(now) {
+		recoverAfter := recoverAt.Sub(now)
+		entry[prefix+"_recover_after_seconds"] = int64(recoverAfter.Seconds())
+		entry[prefix+"_recover_in"] = recoverAfter.Round(time.Second).String()
+	}
+}
+
+func codexQuotaFieldString(auth *coreauth.Auth, window codexQuotaWindow, suffixes ...string) (string, bool) {
+	raw, ok := codexQuotaFieldValue(auth, window, suffixes...)
+	if !ok {
+		return "", false
+	}
+	return codexQuotaString(raw)
+}
+
+func codexQuotaFieldTime(auth *coreauth.Auth, window codexQuotaWindow, suffixes ...string) (time.Time, bool) {
+	raw, ok := codexQuotaFieldValue(auth, window, suffixes...)
+	if !ok {
+		return time.Time{}, false
+	}
+	return parseCodexQuotaTime(raw)
+}
+
+func codexQuotaFieldValue(auth *coreauth.Auth, window codexQuotaWindow, suffixes ...string) (any, bool) {
+	if auth == nil {
+		return nil, false
+	}
+	for _, key := range codexQuotaFlatKeys(window, suffixes...) {
+		if auth.Metadata != nil {
+			if raw, ok := auth.Metadata[key]; ok {
+				return raw, true
+			}
+		}
+		if auth.Attributes != nil {
+			if raw, ok := auth.Attributes[key]; ok {
+				return raw, true
+			}
+		}
+	}
+	if raw, ok := codexQuotaNestedValue(auth.Metadata, window, suffixes...); ok {
+		return raw, true
+	}
+	return nil, false
+}
+
+func codexQuotaFlatKeys(window codexQuotaWindow, suffixes ...string) []string {
+	keys := make([]string, 0, len(window.keyBases)*len(suffixes))
+	for _, base := range window.keyBases {
+		for _, suffix := range suffixes {
+			keys = append(keys, base+"_"+suffix)
+		}
+	}
+	return keys
+}
+
+func codexQuotaNestedValue(metadata map[string]any, window codexQuotaWindow, suffixes ...string) (any, bool) {
+	if metadata == nil {
+		return nil, false
+	}
+	containerKeys := []string{"codex_quota", "codex_quotas", "quota", "quotas", "usage_limits", "usage"}
+	for _, containerKey := range containerKeys {
+		container, ok := metadata[containerKey].(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, alias := range window.aliases {
+			nested, ok := container[alias].(map[string]any)
+			if !ok {
+				continue
+			}
+			for _, suffix := range suffixes {
+				if raw, ok := nested[suffix]; ok {
+					return raw, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
+func codexQuotaString(raw any) (string, bool) {
+	switch v := raw.(type) {
+	case string:
+		s := strings.TrimSpace(v)
+		return s, s != ""
+	case int:
+		return strconv.Itoa(v), true
+	case int64:
+		return strconv.FormatInt(v, 10), true
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64), true
+	case json.Number:
+		return v.String(), true
+	default:
+		if raw == nil {
+			return "", false
+		}
+		s := strings.TrimSpace(fmt.Sprintf("%v", raw))
+		return s, s != ""
+	}
+}
+
+func parseCodexQuotaTime(raw any) (time.Time, bool) {
+	if ts, ok := raw.(time.Time); ok {
+		return ts.UTC(), !ts.IsZero()
+	}
+	return parseLastRefreshValue(raw)
+}
+
+func formatCodexQuotaAmount(remaining string, hasRemaining bool, limit string, hasLimit bool, used string, hasUsed bool) string {
+	switch {
+	case hasRemaining && hasLimit:
+		return fmt.Sprintf("%s / %s remaining", remaining, limit)
+	case hasUsed && hasLimit:
+		return fmt.Sprintf("%s / %s used", used, limit)
+	case hasRemaining:
+		return remaining + " remaining"
+	case hasUsed:
+		return used + " used"
+	case hasLimit:
+		return "limit " + limit
+	default:
+		return ""
+	}
 }
 
 func extractCodexIDTokenClaims(auth *coreauth.Auth) gin.H {
@@ -1024,6 +1330,15 @@ func (h *Handler) buildAuthFromFileData(path string, data []byte) (*coreauth.Aut
 	}
 	if hasLastRefresh {
 		auth.LastRefreshedAt = lastRefresh
+	}
+	if strings.EqualFold(provider, "codex") {
+		if idTokenRaw, ok := metadata["id_token"].(string); ok && strings.TrimSpace(idTokenRaw) != "" {
+			if claims, errParse := codex.ParseJWTToken(idTokenRaw); errParse == nil && claims != nil {
+				if planType := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType); planType != "" {
+					auth.Attributes["plan_type"] = planType
+				}
+			}
+		}
 	}
 	if h != nil && h.authManager != nil {
 		if existing, ok := h.authManager.GetByID(authID); ok {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -428,10 +428,11 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 			log.WithError(err).Warnf("failed to stat auth file %s", path)
 		}
 	}
-	if claims := extractCodexIDTokenClaims(auth); claims != nil {
+	claims := extractCodexIDTokenClaims(auth)
+	if claims != nil {
 		entry["id_token"] = claims
 	}
-	addCodexAccountEntryFields(entry, auth)
+	addCodexAccountEntryFields(entry, auth, claims)
 	// Expose priority from Attributes (set by synthesizer from JSON "priority" field).
 	// Fall back to Metadata for auths registered via UploadAuthFile (no synthesizer).
 	if p := strings.TrimSpace(authAttribute(auth, "priority")); p != "" {
@@ -466,13 +467,13 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	return entry
 }
 
-func addCodexAccountEntryFields(entry gin.H, auth *coreauth.Auth) {
+func addCodexAccountEntryFields(entry gin.H, auth *coreauth.Auth, claims gin.H) {
 	if entry == nil || auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
 		return
 	}
 
 	planType := strings.TrimSpace(authAttribute(auth, "plan_type"))
-	if claims := extractCodexIDTokenClaims(auth); claims != nil {
+	if claims != nil {
 		if planType == "" {
 			if v, ok := claims["plan_type"].(string); ok {
 				planType = strings.TrimSpace(v)
@@ -598,7 +599,7 @@ func addCodexQuotaWindowFromMetadata(entry gin.H, auth *coreauth.Auth, window co
 		entry[window.prefix+"_status"] = strings.ToLower(status)
 	} else if hasRecoverAt && recoverAt.After(now) {
 		entry[window.prefix+"_status"] = "recovering"
-	} else {
+	} else if hasRecoverAt {
 		entry[window.prefix+"_status"] = "available"
 	}
 	if hasRecoverAt {
@@ -612,7 +613,7 @@ func addCodexQuotaRuntimeFallback(entry gin.H, quota coreauth.QuotaState, now ti
 		return
 	}
 	prefix := codexQuotaFallbackPrefix(quota, now)
-	if _, exists := entry[prefix+"_status"]; exists {
+	if existingStatus, exists := entry[prefix+"_status"]; exists && !strings.EqualFold(strings.TrimSpace(fmt.Sprintf("%v", existingStatus)), "available") {
 		return
 	}
 	entry[prefix+"_status"] = quotaEntryStatus(quota, now)

--- a/internal/api/handlers/management/auth_files_codex_account_test.go
+++ b/internal/api/handlers/management/auth_files_codex_account_test.go
@@ -1,0 +1,82 @@
+package management
+
+import (
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestBuildAuthFileEntry_ExposesCodexPlanAndQuota(t *testing.T) {
+	recoverAt := time.Now().Add(90 * time.Minute).UTC().Truncate(time.Second)
+	weeklyRecoverAt := time.Now().Add(72 * time.Hour).UTC().Truncate(time.Second)
+	auth := &coreauth.Auth{
+		ID:       "codex-user.json",
+		FileName: "codex-user.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path":      "/tmp/codex-user.json",
+			"plan_type": "pro",
+		},
+		Metadata: map[string]any{
+			"codex_quota_5h_limit":         float64(100),
+			"codex_quota_5h_remaining":     float64(12),
+			"codex_quota_5h_reset_at":      recoverAt.Format(time.RFC3339),
+			"codex_quota_weekly_limit":     "1000",
+			"codex_quota_weekly_remaining": "700",
+			"codex_quota_weekly_reset_at":  weeklyRecoverAt.Unix(),
+		},
+		Quota: coreauth.QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: recoverAt,
+			BackoffLevel:  2,
+		},
+	}
+
+	entry := (&Handler{}).buildAuthFileEntry(auth)
+	if entry == nil {
+		t.Fatal("expected auth entry")
+	}
+
+	if got := entry["plan_type"]; got != "pro" {
+		t.Fatalf("plan_type = %#v, want %q", got, "pro")
+	}
+	if got := entry["quota_5h_amount"]; got != "12 / 100 remaining" {
+		t.Fatalf("quota_5h_amount = %#v, want %q", got, "12 / 100 remaining")
+	}
+	if got := entry["quota_5h_remaining"]; got != "12" {
+		t.Fatalf("quota_5h_remaining = %#v, want %q", got, "12")
+	}
+	if got := entry["quota_5h_limit"]; got != "100" {
+		t.Fatalf("quota_5h_limit = %#v, want %q", got, "100")
+	}
+	if got := entry["quota_5h_next_recover_at"]; got != recoverAt {
+		t.Fatalf("quota_5h_next_recover_at = %#v, want %#v", got, recoverAt)
+	}
+	if got := entry["quota_weekly_amount"]; got != "700 / 1000 remaining" {
+		t.Fatalf("quota_weekly_amount = %#v, want %q", got, "700 / 1000 remaining")
+	}
+	if got := entry["quota_weekly_next_recover_at"]; got != weeklyRecoverAt {
+		t.Fatalf("quota_weekly_next_recover_at = %#v, want %#v", got, weeklyRecoverAt)
+	}
+	if got := entry["quota_status"]; got != "recovering" {
+		t.Fatalf("quota_status = %#v, want %q", got, "recovering")
+	}
+	if got := entry["quota_reason"]; got != "quota" {
+		t.Fatalf("quota_reason = %#v, want %q", got, "quota")
+	}
+	if got := entry["quota_next_recover_at"]; got != recoverAt {
+		t.Fatalf("quota_next_recover_at = %#v, want %#v", got, recoverAt)
+	}
+	seconds, ok := entry["quota_recover_after_seconds"].(int64)
+	if !ok || seconds <= 0 {
+		t.Fatalf("quota_recover_after_seconds = %#v, want positive int64", entry["quota_recover_after_seconds"])
+	}
+	if got, ok := entry["quota_recover_in"].(string); !ok || got == "" {
+		t.Fatalf("quota_recover_in = %#v, want non-empty string", entry["quota_recover_in"])
+	}
+	if got := entry["quota_backoff_level"]; got != 2 {
+		t.Fatalf("quota_backoff_level = %#v, want %d", got, 2)
+	}
+}

--- a/internal/api/handlers/management/auth_files_codex_account_test.go
+++ b/internal/api/handlers/management/auth_files_codex_account_test.go
@@ -80,3 +80,39 @@ func TestBuildAuthFileEntry_ExposesCodexPlanAndQuota(t *testing.T) {
 		t.Fatalf("quota_backoff_level = %#v, want %d", got, 2)
 	}
 }
+
+func TestBuildAuthFileEntry_PreservesCooldownWhenQuotaWindowMetadataIsPartial(t *testing.T) {
+	recoverAt := time.Now().Add(90 * time.Minute).UTC().Truncate(time.Second)
+	auth := &coreauth.Auth{
+		ID:       "codex-user.json",
+		FileName: "codex-user.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path":      "/tmp/codex-user.json",
+			"plan_type": "plus",
+		},
+		Metadata: map[string]any{
+			"codex_quota_5h_limit":     float64(100),
+			"codex_quota_5h_remaining": float64(0),
+		},
+		Quota: coreauth.QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: recoverAt,
+		},
+	}
+
+	entry := (&Handler{}).buildAuthFileEntry(auth)
+	if got := entry["quota_5h_amount"]; got != "0 / 100 remaining" {
+		t.Fatalf("quota_5h_amount = %#v, want %q", got, "0 / 100 remaining")
+	}
+	if got := entry["quota_5h_status"]; got != "recovering" {
+		t.Fatalf("quota_5h_status = %#v, want %q", got, "recovering")
+	}
+	if got := entry["quota_5h_next_recover_at"]; got != recoverAt {
+		t.Fatalf("quota_5h_next_recover_at = %#v, want %#v", got, recoverAt)
+	}
+	if got, ok := entry["quota_5h_recover_in"].(string); !ok || got == "" {
+		t.Fatalf("quota_5h_recover_in = %#v, want non-empty string", entry["quota_5h_recover_in"])
+	}
+}

--- a/internal/tui/auth_tab.go
+++ b/internal/tui/auth_tab.go
@@ -23,6 +23,17 @@ var authEditableFields = []editableField{
 	{label: "Priority", key: "priority"},
 }
 
+const (
+	authRowNameWidth          = 24
+	authRowChannelWidth       = 12
+	authRowEmailWidth         = 28
+	authRowCursorWidth        = 2
+	authRowStatusIconWidth    = 2
+	authRowStatusTextMinWidth = 8
+	authRowSummaryMinWidth    = 12
+	authRowInterColumnSpaces  = 5
+)
+
 // authTabModel displays auth credential files with interactive management.
 type authTabModel struct {
 	client   *Client
@@ -212,16 +223,16 @@ func (m authTabModel) renderContent() string {
 		}
 
 		displayName := name
-		if len(displayName) > 24 {
-			displayName = displayName[:21] + "..."
+		if len(displayName) > authRowNameWidth {
+			displayName = displayName[:authRowNameWidth-3] + "..."
 		}
 		displayEmail := email
-		if len(displayEmail) > 28 {
-			displayEmail = displayEmail[:25] + "..."
+		if len(displayEmail) > authRowEmailWidth {
+			displayEmail = displayEmail[:authRowEmailWidth-3] + "..."
 		}
 
-		row := fmt.Sprintf("%s%s %-24s %-12s %-28s %s",
-			cursor, statusIcon, displayName, channel, displayEmail, statusText)
+		row := fmt.Sprintf("%s%s %-*s %-*s %-*s %s",
+			cursor, statusIcon, authRowNameWidth, displayName, authRowChannelWidth, channel, authRowEmailWidth, displayEmail, statusText)
 		if summary := authFileRowSummary(f, m.width); summary != "" {
 			row += "  " + summary
 		}
@@ -287,12 +298,22 @@ func authFileRowSummary(f map[string]any, width int) string {
 
 	summary := strings.Join(parts, " ")
 	if width > 0 {
-		maxSummaryWidth := width - 82
-		if maxSummaryWidth >= 12 && len(summary) > maxSummaryWidth {
+		maxSummaryWidth := width - authRowPrefixWidth()
+		if maxSummaryWidth >= authRowSummaryMinWidth && len(summary) > maxSummaryWidth {
 			summary = truncate(summary, maxSummaryWidth)
 		}
 	}
 	return summary
+}
+
+func authRowPrefixWidth() int {
+	return authRowCursorWidth +
+		authRowStatusIconWidth +
+		authRowNameWidth +
+		authRowChannelWidth +
+		authRowEmailWidth +
+		authRowStatusTextMinWidth +
+		authRowInterColumnSpaces
 }
 
 func formatCodexPlanForRow(plan string) string {

--- a/internal/tui/auth_tab.go
+++ b/internal/tui/auth_tab.go
@@ -191,6 +191,9 @@ func (m authTabModel) renderContent() string {
 	for i, f := range m.files {
 		name := getString(f, "name")
 		channel := getString(f, "channel")
+		if channel == "" {
+			channel = getString(f, "type")
+		}
 		email := getString(f, "email")
 		disabled := getBool(f, "disabled")
 
@@ -219,6 +222,9 @@ func (m authTabModel) renderContent() string {
 
 		row := fmt.Sprintf("%s%s %-24s %-12s %-28s %s",
 			cursor, statusIcon, displayName, channel, displayEmail, statusText)
+		if summary := authFileRowSummary(f, m.width); summary != "" {
+			row += "  " + summary
+		}
 		sb.WriteString(rowStyle.Render(row))
 		sb.WriteString("\n")
 
@@ -251,6 +257,95 @@ func (m authTabModel) renderContent() string {
 	return sb.String()
 }
 
+func authFileRowSummary(f map[string]any, width int) string {
+	provider := getString(f, "provider")
+	if provider == "" {
+		provider = getString(f, "type")
+	}
+	if !strings.EqualFold(provider, "codex") && getAnyString(f, "plan_type") == "" {
+		return ""
+	}
+
+	parts := make([]string, 0, 3)
+	if plan := formatCodexPlanForRow(getAnyString(f, "plan_type")); plan != "" {
+		parts = append(parts, plan)
+	}
+	if quota := compactQuotaWindowSummary(f, "quota_5h", "5h"); quota != "" {
+		parts = append(parts, quota)
+	}
+	if quota := compactQuotaWindowSummary(f, "quota_weekly", "wk"); quota != "" {
+		parts = append(parts, quota)
+	}
+	if len(parts) == 1 {
+		if quota := compactQuotaWindowSummary(f, "quota", "quota"); quota != "" {
+			parts = append(parts, quota)
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	summary := strings.Join(parts, " ")
+	if width > 0 {
+		maxSummaryWidth := width - 82
+		if maxSummaryWidth >= 12 && len(summary) > maxSummaryWidth {
+			summary = truncate(summary, maxSummaryWidth)
+		}
+	}
+	return summary
+}
+
+func formatCodexPlanForRow(plan string) string {
+	plan = strings.ToLower(strings.TrimSpace(plan))
+	switch plan {
+	case "":
+		return ""
+	case "free":
+		return "Free"
+	case "plus":
+		return "Plus"
+	case "pro":
+		return "Pro"
+	default:
+		return strings.ToUpper(plan[:1]) + plan[1:]
+	}
+}
+
+func compactQuotaWindowSummary(f map[string]any, prefix, label string) string {
+	if amount := compactQuotaAmount(getAnyString(f, prefix+"_amount")); amount != "" {
+		return label + ":" + amount
+	}
+	remaining := strings.TrimSpace(getAnyString(f, prefix+"_remaining"))
+	limit := strings.TrimSpace(getAnyString(f, prefix+"_limit"))
+	if remaining != "" && limit != "" {
+		return label + ":" + remaining + "/" + limit
+	}
+	status := strings.ToLower(strings.TrimSpace(getAnyString(f, prefix+"_status")))
+	recoverIn := strings.TrimSpace(getAnyString(f, prefix+"_recover_in"))
+	if status != "" && status != "available" {
+		if recoverIn != "" {
+			return label + ":" + status + " " + recoverIn
+		}
+		return label + ":" + status
+	}
+	if recoverIn != "" {
+		return label + ":reset " + recoverIn
+	}
+	return ""
+}
+
+func compactQuotaAmount(amount string) string {
+	amount = strings.TrimSpace(amount)
+	if amount == "" {
+		return ""
+	}
+	lower := strings.ToLower(amount)
+	if strings.HasSuffix(lower, " remaining") {
+		amount = strings.TrimSpace(amount[:len(amount)-len(" remaining")])
+	}
+	return strings.ReplaceAll(amount, " ", "")
+}
+
 func (m authTabModel) renderDetail(f map[string]any) string {
 	var sb strings.Builder
 
@@ -277,6 +372,20 @@ func (m authTabModel) renderDetail(f map[string]any) string {
 		{"Status Msg", "status_message", false},
 		{"File Name", "file_name", false},
 		{"Auth Type", "auth_type", false},
+		{"Plan Type", "plan_type", false},
+		{"Subscription Until", "subscription_until", false},
+		{"Quota Status", "quota_status", false},
+		{"5h Quota", "quota_5h_amount", false},
+		{"5h Status", "quota_5h_status", false},
+		{"5h Recover", "quota_5h_recover_in", false},
+		{"5h Recover At", "quota_5h_next_recover_at", false},
+		{"Weekly Quota", "quota_weekly_amount", false},
+		{"Weekly Status", "quota_weekly_status", false},
+		{"Weekly Recover", "quota_weekly_recover_in", false},
+		{"Weekly Recover At", "quota_weekly_next_recover_at", false},
+		{"Last Recover", "quota_recover_in", false},
+		{"Recover At", "quota_next_recover_at", false},
+		{"Quota Backoff", "quota_backoff_level", false},
 		{"Prefix", "prefix", true},
 		{"Proxy URL", "proxy_url", true},
 		{"Priority", "priority", true},

--- a/internal/tui/auth_tab_test.go
+++ b/internal/tui/auth_tab_test.go
@@ -1,0 +1,74 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAuthTabRenderDetailShowsCodexPlanAndQuota(t *testing.T) {
+	m := authTabModel{}
+	out := m.renderDetail(map[string]any{
+		"name":                    "codex-user.json",
+		"type":                    "codex",
+		"email":                   "user@example.com",
+		"plan_type":               "plus",
+		"quota_status":            "recovering",
+		"quota_5h_amount":         "12 / 100 remaining",
+		"quota_5h_recover_in":     "1h30m0s",
+		"quota_weekly_amount":     "700 / 1000 remaining",
+		"quota_weekly_recover_in": "72h0m0s",
+		"quota_recover_in":        "1h30m0s",
+		"quota_next_recover_at":   "2026-04-26T12:00:00Z",
+		"quota_backoff_level":     2,
+		"subscription_until":      "2026-05-01T00:00:00Z",
+	})
+
+	for _, want := range []string{
+		"Plan Type",
+		"plus",
+		"Quota Status",
+		"recovering",
+		"5h Quota",
+		"12 / 100 remaining",
+		"5h Recover",
+		"Weekly Quota",
+		"700 / 1000 remaining",
+		"Weekly Recover",
+		"72h0m0s",
+		"Last Recover",
+		"1h30m0s",
+		"Recover At",
+		"2026-04-26T12:00:00Z",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("renderDetail() missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestAuthTabRenderContentShowsCodexQuotaSummaryInRows(t *testing.T) {
+	m := authTabModel{
+		width: 120,
+		files: []map[string]any{
+			{
+				"name":                "codex-plus.json",
+				"type":                "codex",
+				"email":               "plus@example.com",
+				"plan_type":           "plus",
+				"quota_5h_amount":     "12 / 100 remaining",
+				"quota_weekly_amount": "700 / 1000 remaining",
+			},
+		},
+	}
+
+	out := m.renderContent()
+	for _, want := range []string{
+		"Plus",
+		"5h:12/100",
+		"wk:700/1000",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("renderContent() missing %q in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Expose Codex plan, subscription, and quota window fields from management auth-file entries.
- Show Codex plan plus 5h and weekly quota summaries directly in TUI Auth Files rows for multi-account selection.
- Keep expanded Auth Files details with per-window quota amount and recovery timestamps.

## Test Plan
- [x] go test ./internal/api/handlers/management ./internal/tui -count=1
- [x] go build -o test-output ./cmd/server && rm test-output
- [x] git diff --check
- [ ] go test ./... (known unrelated failure tracked in #3067: internal/registry TestCodexStaticModelsIncludeGPT55/free)

## Notes
This PR displays available quota metadata when present and runtime cooldown information when recorded. It does not invent remaining quota values when upstream/account metadata does not provide them.