### PR TITLE
Mark Antigravity credits requests in access logs

### DIFF
--- a/internal/logging/gin_logger.go
+++ b/internal/logging/gin_logger.go
@@ -27,7 +27,10 @@ var aiAPIPrefixes = []string{
 	"/api/provider/",
 }
 
-const skipGinLogKey = "__gin_skip_request_logging__"
+const (
+	skipGinLogKey  = "__gin_skip_request_logging__"
+	creditsUsedKey = "__antigravity_credits_used__"
+)
 
 // GinLogrusLogger returns a Gin middleware handler that logs HTTP requests and responses
 // using logrus. It captures request details including method, path, status code, latency,
@@ -79,6 +82,9 @@ func GinLogrusLogger() gin.HandlerFunc {
 			requestID = "--------"
 		}
 		logLine := fmt.Sprintf("%3d | %13v | %15s | %-7s \"%s\"", statusCode, latency, clientIP, method, path)
+		if creditsUsed(c) {
+			logLine += " [credits]"
+		}
 		if errorMessage != "" {
 			logLine = logLine + " | " + errorMessage
 		}
@@ -143,6 +149,18 @@ func shouldSkipGinRequestLogging(c *gin.Context) bool {
 		return false
 	}
 	val, exists := c.Get(skipGinLogKey)
+	if !exists {
+		return false
+	}
+	flag, ok := val.(bool)
+	return ok && flag
+}
+
+func creditsUsed(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	val, exists := c.Get(creditsUsedKey)
 	if !exists {
 		return false
 	}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -2242,9 +2242,9 @@ var antigravityBaseURLFallbackOrder = func(auth *cliproxyauth.Auth) []string {
 		return []string{base}
 	}
 	return []string{
-		antigravityBaseURLProd,
 		antigravityBaseURLDaily,
-		antigravitySandboxBaseURLDaily,
+		antigravityBaseURLProd,
+		// antigravitySandboxBaseURLDaily,
 	}
 }
 


### PR DESCRIPTION
## Summary
- append `[credits]` to Gin access logs when Antigravity credits were used
- prefer Daily before Prod in the default Antigravity base URL fallback order and disable sandbox fallback

## Validation
- go build -o cli-proxy-api ./cmd/server
- 10 concurrent `/v1/messages` requests on debug port 8318 returned 10/10 HTTP 200
- observed access log line ending with `[credits]` for a credits-backed request