### PR TITLE
refactor(kimi): move Claude Messages API compat logic into KimiExecutor

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -145,66 +145,10 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	to := sdktranslator.FromString("claude")
 	// Use streaming translation to preserve function calling, except for claude.
 	stream := from != to
-	originalPayloadSource := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayloadSource = opts.OriginalRequest
-	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, stream)
-	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
-	body, _ = sjson.SetBytes(body, "model", baseModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	bodyForTranslation, bodyForUpstream, extraBetas, oauthToolNamesRemapped, err := e.buildMessagesBody(ctx, auth, req, opts, baseModel, apiKey)
 	if err != nil {
 		return resp, err
-	}
-
-	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
-	// based on client type and configuration.
-	body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
-
-	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
-	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
-	body = ensureModelMaxTokens(body, baseModel)
-
-	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
-	body = disableThinkingIfToolChoiceForced(body)
-	body = normalizeClaudeTemperatureForThinking(body)
-
-	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
-	if countCacheControls(body) == 0 {
-		body = ensureCacheControl(body)
-	}
-
-	// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
-	// Cloaking and ensureCacheControl may push the total over 4 when the client
-	// (e.g. Amp CLI) already sends multiple cache_control blocks.
-	body = enforceCacheControlLimit(body, 4)
-
-	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
-	// A 1h-TTL block must not appear after a 5m-TTL block in evaluation order (tools→system→messages).
-	body = normalizeCacheControlTTL(body)
-
-	// Extract betas from body and convert to header
-	var extraBetas []string
-	extraBetas, body = extractAndRemoveBetas(body)
-	bodyForTranslation := body
-	bodyForUpstream := body
-	oauthToken := isClaudeOAuthToken(apiKey)
-	oauthToolNamesRemapped := false
-	if oauthToken && !auth.ToolPrefixDisabled() {
-		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
-	}
-	// Remap third-party tool names to Claude Code equivalents and remove
-	// tools without official counterparts. This prevents Anthropic from
-	// fingerprinting the request as third-party via tool naming patterns.
-	if oauthToken {
-		bodyForUpstream, oauthToolNamesRemapped = remapOAuthToolNames(bodyForUpstream)
-	}
-	// Enable cch signing by default for OAuth tokens (not just experimental flag).
-	// Claude Code always computes cch; missing or invalid cch is a detectable fingerprint.
-	if oauthToken || experimentalCCHSigningEnabled(e.cfg, auth) {
-		bodyForUpstream = signAnthropicMessagesBody(bodyForUpstream)
 	}
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
@@ -330,62 +274,10 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	defer reporter.TrackFailure(ctx, &err)
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("claude")
-	originalPayloadSource := req.Payload
-	if len(opts.OriginalRequest) > 0 {
-		originalPayloadSource = opts.OriginalRequest
-	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
-	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
-	body, _ = sjson.SetBytes(body, "model", baseModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	bodyForTranslation, bodyForUpstream, extraBetas, oauthToolNamesRemapped, err := e.buildMessagesBody(ctx, auth, req, opts, baseModel, apiKey)
 	if err != nil {
 		return nil, err
-	}
-
-	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
-	// based on client type and configuration.
-	body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
-
-	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
-	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
-	body = ensureModelMaxTokens(body, baseModel)
-
-	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
-	body = disableThinkingIfToolChoiceForced(body)
-	body = normalizeClaudeTemperatureForThinking(body)
-
-	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
-	if countCacheControls(body) == 0 {
-		body = ensureCacheControl(body)
-	}
-
-	// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
-	body = enforceCacheControlLimit(body, 4)
-
-	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
-	body = normalizeCacheControlTTL(body)
-
-	// Extract betas from body and convert to header
-	var extraBetas []string
-	extraBetas, body = extractAndRemoveBetas(body)
-	bodyForTranslation := body
-	bodyForUpstream := body
-	oauthToken := isClaudeOAuthToken(apiKey)
-	oauthToolNamesRemapped := false
-	if oauthToken && !auth.ToolPrefixDisabled() {
-		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
-	}
-	// Remap third-party tool names to Claude Code equivalents and remove
-	// tools without official counterparts. This prevents Anthropic from
-	// fingerprinting the request as third-party via tool naming patterns.
-	if oauthToken {
-		bodyForUpstream, oauthToolNamesRemapped = remapOAuthToolNames(bodyForUpstream)
-	}
-	// Enable cch signing by default for OAuth tokens (not just experimental flag).
-	if oauthToken || experimentalCCHSigningEnabled(e.cfg, auth) {
-		bodyForUpstream = signAnthropicMessagesBody(bodyForUpstream)
 	}
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
@@ -529,6 +421,75 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+// buildMessagesBody constructs the request bodies for Claude messages API.
+// Returns bodyForTranslation (used for response translation), bodyForUpstream (sent to the provider),
+// extraBetas extracted from the request, and whether OAuth tool names were remapped.
+func (e *ClaudeExecutor) buildMessagesBody(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, baseModel, apiKey string) (bodyForTranslation, bodyForUpstream []byte, extraBetas []string, oauthToolNamesRemapped bool, err error) {
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("claude")
+	stream := from != to
+	originalPayloadSource := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayloadSource = opts.OriginalRequest
+	}
+	originalPayload := originalPayloadSource
+	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, stream)
+	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
+	body, _ = sjson.SetBytes(body, "model", baseModel)
+
+	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+
+	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
+	// based on client type and configuration.
+	body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
+
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+	body = ensureModelMaxTokens(body, baseModel)
+
+	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
+	body = disableThinkingIfToolChoiceForced(body)
+	body = normalizeClaudeTemperatureForThinking(body)
+
+	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
+	if countCacheControls(body) == 0 {
+		body = ensureCacheControl(body)
+	}
+
+	// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
+	// Cloaking and ensureCacheControl may push the total over 4 when the client
+	// (e.g. Amp CLI) already sends multiple cache_control blocks.
+	body = enforceCacheControlLimit(body, 4)
+
+	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
+	// A 1h-TTL block must not appear after a 5m-TTL block in evaluation order (tools→system→messages).
+	body = normalizeCacheControlTTL(body)
+
+	// Extract betas from body and convert to header
+	extraBetas, body = extractAndRemoveBetas(body)
+	bodyForTranslation = body
+	bodyForUpstream = body
+	oauthToken := isClaudeOAuthToken(apiKey)
+	if oauthToken && !auth.ToolPrefixDisabled() {
+		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
+	}
+	// Remap third-party tool names to Claude Code equivalents and remove
+	// tools without official counterparts. This prevents Anthropic from
+	// fingerprinting the request as third-party via tool naming patterns.
+	if oauthToken {
+		bodyForUpstream, oauthToolNamesRemapped = remapOAuthToolNames(bodyForUpstream)
+	}
+	// Enable cch signing by default for OAuth tokens (not just experimental flag).
+	// Claude Code always computes cch; missing or invalid cch is a detectable fingerprint.
+	if oauthToken || experimentalCCHSigningEnabled(e.cfg, auth) {
+		bodyForUpstream = signAnthropicMessagesBody(bodyForUpstream)
+	}
+	return bodyForTranslation, bodyForUpstream, extraBetas, oauthToolNamesRemapped, nil
 }
 
 func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -75,8 +75,7 @@ func (e *KimiExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth,
 func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	from := opts.SourceFormat
 	if from.String() == "claude" {
-		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
-		return e.ClaudeExecutor.Execute(ctx, auth, req, opts)
+		return executeKimiClaudeNonStream(ctx, e.cfg, auth, req, opts, &e.ClaudeExecutor)
 	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
@@ -181,8 +180,7 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	from := opts.SourceFormat
 	if from.String() == "claude" {
-		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
-		return e.ClaudeExecutor.ExecuteStream(ctx, auth, req, opts)
+		return executeKimiClaudeStream(ctx, e.cfg, auth, req, opts, &e.ClaudeExecutor)
 	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName

--- a/internal/runtime/executor/kimi_executor_claude_compat.go
+++ b/internal/runtime/executor/kimi_executor_claude_compat.go
@@ -1,0 +1,556 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	kimiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Kimi Claude compatibility constants
+const (
+	// Thinking type constants
+	thinkingTypeAdaptive = "adaptive"
+	thinkingTypeAuto     = "auto"
+	thinkingTypeEnabled  = "enabled"
+
+	// Effort level constants
+	effortMinimal = "minimal"
+	effortNone    = "none"
+	effortLow     = "low"
+	effortMedium  = "medium"
+	effortHigh    = "high"
+	effortMax     = "max"
+	effortXHigh   = "xhigh"
+
+	// Thinking budget token constants
+	budgetMinimal = 0
+	budgetLow     = 1024
+	budgetMedium  = 4096
+	budgetHigh    = 8192
+
+	// Kimi endpoint identifier
+	kimiAPIHost = "api.kimi.com"
+
+	// Beta header values
+	betaHeaderBase = "claude-code-20250219"
+	betaHeaderFull = "claude-code-20250219,interleaved-thinking-2025-05-14"
+)
+
+// isKimiClaudeCompatBaseURL checks if the given base URL points to Kimi's Anthropic-compatible endpoint.
+func isKimiClaudeCompatBaseURL(baseURL string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(baseURL))
+	parsed, err := url.Parse(normalized)
+	if err != nil {
+		return strings.Contains(normalized, kimiAPIHost)
+	}
+	return strings.Contains(parsed.Host, kimiAPIHost)
+}
+
+// applyKimiClaudeBetaHeader sets the Anthropic-Beta header appropriate for Kimi's compatibility layer.
+func applyKimiClaudeBetaHeader(req *http.Request, strict bool) {
+	if req == nil {
+		return
+	}
+	if strict {
+		req.Header.Set("Anthropic-Beta", betaHeaderBase)
+		return
+	}
+	req.Header.Set("Anthropic-Beta", betaHeaderFull)
+}
+
+// isRetryableKimiInvalidRequest determines if a 400 response from Kimi indicates a retryable error.
+func isRetryableKimiInvalidRequest(statusCode int, responseBody []byte) bool {
+	if statusCode != http.StatusBadRequest {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(string(responseBody)))
+	if lower == "" {
+		return false
+	}
+	return strings.Contains(lower, "invalid_request_error") ||
+		strings.Contains(lower, "invalid request error")
+}
+
+// applyKimiClaudeCompatibility applies all necessary transformations to make a Claude request
+// compatible with Kimi's Anthropic-compatible endpoint.
+func applyKimiClaudeCompatibility(body []byte, strict bool) []byte {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body
+	}
+	out := stripKimiIncompatibleFields(body, strict)
+	out = stripToolReferences(out)
+	return out
+}
+
+// stripKimiIncompatibleFields removes or transforms fields that Kimi's endpoint cannot handle.
+func stripKimiIncompatibleFields(body []byte, strict bool) []byte {
+	out := body
+	out, _ = sjson.DeleteBytes(out, "metadata")
+	out, _ = sjson.DeleteBytes(out, "context_management")
+
+	thinkingType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(out, "thinking.type").String()))
+	if thinkingType == thinkingTypeAdaptive || thinkingType == thinkingTypeAuto {
+		effort := strings.ToLower(strings.TrimSpace(gjson.GetBytes(out, "output_config.effort").String()))
+		budget := budgetMedium
+		switch effort {
+		case effortMinimal, effortNone:
+			budget = budgetMinimal
+		case effortLow:
+			budget = budgetLow
+		case effortHigh, effortMax, effortXHigh:
+			budget = budgetHigh
+		}
+		if budget <= 0 {
+			out, _ = sjson.DeleteBytes(out, "thinking")
+		} else {
+			out, _ = sjson.SetBytes(out, "thinking.type", thinkingTypeEnabled)
+			out, _ = sjson.SetBytes(out, "thinking.budget_tokens", budget)
+		}
+		out, _ = sjson.DeleteBytes(out, "output_config.effort")
+	}
+	if strict {
+		out, _ = sjson.DeleteBytes(out, "output_config.effort")
+	}
+	if oc := gjson.GetBytes(out, "output_config"); oc.Exists() && oc.IsObject() && len(oc.Map()) == 0 {
+		out, _ = sjson.DeleteBytes(out, "output_config")
+	}
+	return out
+}
+
+// stripToolReferences removes tool_reference content blocks from tool_result messages.
+func stripToolReferences(body []byte) []byte {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return body
+	}
+
+	out := body
+	messages.ForEach(func(mi, msg gjson.Result) bool {
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		var modified bool
+		newBlocks := make([]interface{}, 0, len(content.Array()))
+		for _, block := range content.Array() {
+			if block.Get("type").String() != "tool_result" {
+				newBlocks = append(newBlocks, block.Value())
+				continue
+			}
+			inner := block.Get("content")
+			if !inner.IsArray() {
+				newBlocks = append(newBlocks, block.Value())
+				continue
+			}
+			innerArr := inner.Array()
+			filtered := make([]interface{}, 0, len(innerArr))
+			innerModified := false
+			for _, ib := range innerArr {
+				if ib.Get("type").String() == "tool_reference" {
+					innerModified = true
+					continue
+				}
+				filtered = append(filtered, ib.Value())
+			}
+			if !innerModified {
+				newBlocks = append(newBlocks, block.Value())
+				continue
+			}
+			modified = true
+			bm, ok := block.Value().(map[string]interface{})
+			if !ok {
+				newBlocks = append(newBlocks, block.Value())
+				continue
+			}
+			bm["content"] = filtered
+			newBlocks = append(newBlocks, bm)
+		}
+		if modified {
+			if b, err := json.Marshal(newBlocks); err == nil {
+				out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content", mi.Int()), b)
+			} else {
+				log.Warnf("failed to strip tool_reference from message %d: %v", mi.Int(), err)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// buildKimiClaudeMessagesBody constructs the request bodies for Kimi's Claude-compatible endpoint.
+// It wraps ClaudeExecutor.buildMessagesBody and then applies Kimi-specific compatibility transforms.
+func buildKimiClaudeMessagesBody(
+	e *ClaudeExecutor,
+	ctx context.Context,
+	auth *cliproxyauth.Auth,
+	req cliproxyexecutor.Request,
+	opts cliproxyexecutor.Options,
+	baseModel, apiKey string,
+) (bodyForTranslation, bodyForUpstream []byte, extraBetas []string, oauthToolNamesRemapped bool, err error) {
+	bodyForTranslation, bodyForUpstream, extraBetas, oauthToolNamesRemapped, err = e.buildMessagesBody(ctx, auth, req, opts, baseModel, apiKey)
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+	bodyForUpstream = applyKimiClaudeCompatibility(bodyForUpstream, false)
+	bodyForTranslation = applyKimiClaudeCompatibility(bodyForTranslation, false)
+	return bodyForTranslation, bodyForUpstream, extraBetas, oauthToolNamesRemapped, nil
+}
+
+// tryKimiCompatRetry encapsulates the Kimi compatibility retry logic.
+func tryKimiCompatRetry(
+	ctx context.Context,
+	statusCode int,
+	respBody []byte,
+	sendUpstream func([]byte) (*http.Response, error),
+	bodyForUpstream, bodyForTranslation *[]byte,
+) (*http.Response, error) {
+	if !isRetryableKimiInvalidRequest(statusCode, respBody) {
+		return nil, nil
+	}
+
+	log.Debugf("Kimi returned retryable 400, attempting strict-mode retry")
+	strictBody := applyKimiClaudeCompatibility(*bodyForUpstream, true)
+	*bodyForUpstream = strictBody
+	*bodyForTranslation = strictBody
+
+	retryResp, retryErr := sendUpstream(strictBody)
+	if retryErr != nil {
+		log.Warnf("Kimi strict-mode retry failed: %v", retryErr)
+		return nil, retryErr
+	}
+	return retryResp, nil
+}
+
+// executeKimiClaudeNonStream performs a non-streaming Claude-format request through Kimi's compatible endpoint.
+func executeKimiClaudeNonStream(
+	ctx context.Context,
+	cfg *config.Config,
+	auth *cliproxyauth.Auth,
+	req cliproxyexecutor.Request,
+	opts cliproxyexecutor.Options,
+	claudeExec *ClaudeExecutor,
+) (cliproxyexecutor.Response, error) {
+	var resp cliproxyexecutor.Response
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	apiKey, _ := claudeCreds(auth)
+	baseURL := kimiauth.KimiAPIBaseURL
+
+	reporter := helps.NewUsageReporter(ctx, "kimi", baseModel, auth)
+	var err error
+	defer reporter.TrackFailure(ctx, &err)
+
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("claude")
+	stream := from != to
+
+	bodyForTranslation, bodyForUpstream, extraBetas, oauthToolNamesRemapped, err := buildKimiClaudeMessagesBody(claudeExec, ctx, auth, req, opts, baseModel, apiKey)
+	if err != nil {
+		return resp, err
+	}
+
+	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	httpClient := helps.NewUtlsHTTPClient(cfg, auth, 0)
+
+	sendUpstream := func(body []byte) (*http.Response, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, cfg)
+		applyKimiClaudeBetaHeader(httpReq, false)
+		helps.RecordAPIRequest(ctx, cfg, helps.UpstreamRequestLog{
+			URL:       url,
+			Method:    http.MethodPost,
+			Headers:   httpReq.Header.Clone(),
+			Body:      body,
+			Provider:  "kimi",
+			AuthID:    authID,
+			AuthLabel: authLabel,
+			AuthType:  authType,
+			AuthValue: authValue,
+		})
+		return httpClient.Do(httpReq)
+	}
+
+	httpResp, err := sendUpstream(bodyForUpstream)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, cfg, err)
+		return resp, err
+	}
+	helps.RecordAPIResponseMetadata(ctx, cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		errBody, decErr := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
+		if decErr != nil {
+			helps.RecordAPIResponseError(ctx, cfg, decErr)
+			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
+			helps.LogWithRequestID(ctx).Warn(msg)
+			return resp, statusErr{code: httpResp.StatusCode, msg: msg}
+		}
+		b, readErr := io.ReadAll(errBody)
+		if readErr != nil {
+			helps.RecordAPIResponseError(ctx, cfg, readErr)
+			msg := fmt.Sprintf("failed to read error response body: %v", readErr)
+			helps.LogWithRequestID(ctx).Warn(msg)
+			b = []byte(msg)
+		}
+		helps.AppendAPIResponseChunk(ctx, cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		if errClose := errBody.Close(); errClose != nil {
+			log.Errorf("response body close error: %v", errClose)
+		}
+
+		retryResp, retryErr := tryKimiCompatRetry(ctx, httpResp.StatusCode, b, sendUpstream, &bodyForUpstream, &bodyForTranslation)
+		if retryErr != nil {
+			return resp, retryErr
+		}
+		if retryResp == nil {
+			return resp, statusErr{code: httpResp.StatusCode, msg: string(b)}
+		}
+		httpResp = retryResp
+	}
+	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, cfg, err)
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("response body close error: %v", errClose)
+		}
+		return resp, err
+	}
+	defer func() {
+		if errClose := decodedBody.Close(); errClose != nil {
+			log.Errorf("response body close error: %v", errClose)
+		}
+	}()
+	data, err := io.ReadAll(decodedBody)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, cfg, err)
+		return resp, err
+	}
+	helps.AppendAPIResponseChunk(ctx, cfg, data)
+	if stream {
+		lines := bytes.Split(data, []byte("\n"))
+		for _, line := range lines {
+			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
+				reporter.Publish(ctx, detail)
+			}
+		}
+	} else {
+		reporter.Publish(ctx, helps.ParseClaudeUsage(data))
+	}
+	if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
+		data = stripClaudeToolPrefixFromResponse(data, claudeToolPrefix)
+	}
+	if isClaudeOAuthToken(apiKey) && oauthToolNamesRemapped {
+		data = reverseRemapOAuthToolNames(data)
+	}
+	var param any
+	out := sdktranslator.TranslateNonStream(
+		ctx,
+		to,
+		from,
+		req.Model,
+		opts.OriginalRequest,
+		bodyForTranslation,
+		data,
+		&param,
+	)
+	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+	return resp, nil
+}
+
+// executeKimiClaudeStream performs a streaming Claude-format request through Kimi's compatible endpoint.
+func executeKimiClaudeStream(
+	ctx context.Context,
+	cfg *config.Config,
+	auth *cliproxyauth.Auth,
+	req cliproxyexecutor.Request,
+	opts cliproxyexecutor.Options,
+	claudeExec *ClaudeExecutor,
+) (*cliproxyexecutor.StreamResult, error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	apiKey, _ := claudeCreds(auth)
+	baseURL := kimiauth.KimiAPIBaseURL
+
+	reporter := helps.NewUsageReporter(ctx, "kimi", baseModel, auth)
+	var err error
+	defer reporter.TrackFailure(ctx, &err)
+
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("claude")
+
+	bodyForTranslation, bodyForUpstream, extraBetas, oauthToolNamesRemapped, err := buildKimiClaudeMessagesBody(claudeExec, ctx, auth, req, opts, baseModel, apiKey)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	httpClient := helps.NewUtlsHTTPClient(cfg, auth, 0)
+
+	sendUpstream := func(body []byte) (*http.Response, error) {
+		httpReq, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		applyClaudeHeaders(httpReq, auth, apiKey, true, extraBetas, cfg)
+		applyKimiClaudeBetaHeader(httpReq, false)
+		helps.RecordAPIRequest(ctx, cfg, helps.UpstreamRequestLog{
+			URL:       url,
+			Method:    http.MethodPost,
+			Headers:   httpReq.Header.Clone(),
+			Body:      body,
+			Provider:  "kimi",
+			AuthID:    authID,
+			AuthLabel: authLabel,
+			AuthType:  authType,
+			AuthValue: authValue,
+		})
+		return httpClient.Do(httpReq)
+	}
+
+	httpResp, err := sendUpstream(bodyForUpstream)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, cfg, err)
+		return nil, err
+	}
+	helps.RecordAPIResponseMetadata(ctx, cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		errBody, decErr := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
+		if decErr != nil {
+			helps.RecordAPIResponseError(ctx, cfg, decErr)
+			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
+			helps.LogWithRequestID(ctx).Warn(msg)
+			return nil, statusErr{code: httpResp.StatusCode, msg: msg}
+		}
+		b, readErr := io.ReadAll(errBody)
+		if readErr != nil {
+			helps.RecordAPIResponseError(ctx, cfg, readErr)
+			msg := fmt.Sprintf("failed to read error response body: %v", readErr)
+			helps.LogWithRequestID(ctx).Warn(msg)
+			b = []byte(msg)
+		}
+		helps.AppendAPIResponseChunk(ctx, cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		if errClose := errBody.Close(); errClose != nil {
+			log.Errorf("response body close error: %v", errClose)
+		}
+
+		retryResp, retryErr := tryKimiCompatRetry(ctx, httpResp.StatusCode, b, sendUpstream, &bodyForUpstream, &bodyForTranslation)
+		if retryErr != nil {
+			return nil, retryErr
+		}
+		if retryResp == nil {
+			return nil, statusErr{code: httpResp.StatusCode, msg: string(b)}
+		}
+		httpResp = retryResp
+	}
+	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, cfg, err)
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("response body close error: %v", errClose)
+		}
+		return nil, err
+	}
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		defer func() {
+			if errClose := decodedBody.Close(); errClose != nil {
+				log.Errorf("response body close error: %v", errClose)
+			}
+		}()
+
+		if from == to {
+			scanner := bufio.NewScanner(decodedBody)
+			scanner.Buffer(nil, 52_428_800)
+			for scanner.Scan() {
+				line := scanner.Bytes()
+				helps.AppendAPIResponseChunk(ctx, cfg, line)
+				if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
+					reporter.Publish(ctx, detail)
+				}
+				if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
+					line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
+				}
+				if isClaudeOAuthToken(apiKey) && oauthToolNamesRemapped {
+					line = reverseRemapOAuthToolNamesFromStreamLine(line)
+				}
+				cloned := make([]byte, len(line)+1)
+				copy(cloned, line)
+				cloned[len(line)] = '\n'
+				out <- cliproxyexecutor.StreamChunk{Payload: cloned}
+			}
+			if errScan := scanner.Err(); errScan != nil {
+				helps.RecordAPIResponseError(ctx, cfg, errScan)
+				reporter.PublishFailure(ctx)
+				out <- cliproxyexecutor.StreamChunk{Err: errScan}
+			}
+			return
+		}
+
+		scanner := bufio.NewScanner(decodedBody)
+		scanner.Buffer(nil, 52_428_800)
+		var param any
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			helps.AppendAPIResponseChunk(ctx, cfg, line)
+			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
+				reporter.Publish(ctx, detail)
+			}
+			if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
+				line = stripClaudeToolPrefixFromStreamLine(line, claudeToolPrefix)
+			}
+			if isClaudeOAuthToken(apiKey) && oauthToolNamesRemapped {
+				line = reverseRemapOAuthToolNamesFromStreamLine(line)
+			}
+			chunks := sdktranslator.TranslateStream(
+				ctx,
+				to,
+				from,
+				req.Model,
+				opts.OriginalRequest,
+				bodyForTranslation,
+				bytes.Clone(line),
+				&param,
+			)
+			for i := range chunks {
+				out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}
+			}
+		}
+		if errScan := scanner.Err(); errScan != nil {
+			helps.RecordAPIResponseError(ctx, cfg, errScan)
+			reporter.PublishFailure(ctx)
+			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+		}
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}

--- a/internal/runtime/executor/kimi_executor_claude_compat_bench_test.go
+++ b/internal/runtime/executor/kimi_executor_claude_compat_bench_test.go
@@ -1,0 +1,117 @@
+package executor
+
+import (
+	"testing"
+)
+
+// BenchmarkApplyKimiClaudeCompatibility benchmarks the full compatibility transformation
+func BenchmarkApplyKimiClaudeCompatibility(b *testing.B) {
+	// Realistic request with all incompatible fields
+	input := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": "Hello"},
+			{"role": "assistant", "content": [
+				{"type": "text", "text": "Hi"},
+				{"type": "tool_use", "id": "tool_1", "name": "test_tool", "input": {"arg": "value"}}
+			]},
+			{"role": "user", "content": [
+				{"type": "text", "text": "Result"},
+				{"type": "tool_result", "tool_use_id": "tool_1", "content": "success"},
+				{"type": "tool_result", "tool_use_id": "tool_2", "content": [
+					{"type": "text", "text": "text result"},
+					{"type": "tool_reference", "tool_name": "ref_tool", "tool_use_id": "ref_1"}
+				]}
+			]}
+		],
+		"metadata": {"user_id": "{\"device_id\":\"abc\"}"},
+		"context_management": {"edits": [{"type": "x"}]},
+		"thinking": {"type": "adaptive", "budget_tokens": 2000},
+		"output_config": {"effort": "high"}
+	}`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = applyKimiClaudeCompatibility(input, false)
+	}
+}
+
+// BenchmarkApplyKimiClaudeCompatibilityStrict benchmarks strict mode transformation
+func BenchmarkApplyKimiClaudeCompatibilityStrict(b *testing.B) {
+	input := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "Hello"}],
+		"metadata": {"user_id": "user123"},
+		"thinking": {"type": "adaptive"},
+		"output_config": {"effort": "high"}
+	}`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = applyKimiClaudeCompatibility(input, true)
+	}
+}
+
+// BenchmarkStripToolReferences benchmarks the tool_reference filtering
+func BenchmarkStripToolReferences(b *testing.B) {
+	input := []byte(`{
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "text1"},
+				{"type": "tool_result", "tool_use_id": "tool_1", "content": [
+					{"type": "text", "text": "result1"},
+					{"type": "tool_reference", "tool_name": "tool_a", "tool_use_id": "ref_1"},
+					{"type": "text", "text": "result2"}
+				]}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "tool_2", "content": [
+					{"type": "tool_reference", "tool_name": "tool_b", "tool_use_id": "ref_2"},
+					{"type": "text", "text": "result3"}
+				]}
+			]}
+		]
+	}`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = stripToolReferences(input)
+	}
+}
+
+// BenchmarkStripKimiIncompatibleFields benchmarks field stripping
+func BenchmarkStripKimiIncompatibleFields(b *testing.B) {
+	input := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "Hello"}],
+		"metadata": {"user_id": "user123"},
+		"context_management": {"edits": []},
+		"thinking": {"type": "adaptive"},
+		"output_config": {"effort": "high"}
+	}`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = stripKimiIncompatibleFields(input, false)
+	}
+}
+
+// BenchmarkStripKimiIncompatibleFieldsStrict benchmarks strict mode field stripping
+func BenchmarkStripKimiIncompatibleFieldsStrict(b *testing.B) {
+	input := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "Hello"}],
+		"metadata": {"user_id": "user123"},
+		"thinking": {"type": "enabled", "budget_tokens": 4096},
+		"output_config": {"effort": "high"}
+	}`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = stripKimiIncompatibleFields(input, true)
+	}
+}

--- a/internal/runtime/executor/kimi_executor_claude_compat_test.go
+++ b/internal/runtime/executor/kimi_executor_claude_compat_test.go
@@ -1,0 +1,152 @@
+package executor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestIsKimiClaudeCompatBaseURL(t *testing.T) {
+	t.Parallel()
+
+	if !isKimiClaudeCompatBaseURL("https://api.kimi.com/coding") {
+		t.Fatal("expected kimi base url to be recognized")
+	}
+	if isKimiClaudeCompatBaseURL("https://api.anthropic.com") {
+		t.Fatal("did not expect anthropic base url to be recognized as kimi")
+	}
+}
+
+func TestApplyKimiClaudeCompatibility_NormalizeAdaptiveThinking(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"high"},"context_management":{"edits":[{"type":"x"}]},"metadata":{"user_id":"{\"device_id\":\"abc\"}"}}`)
+	out := applyKimiClaudeCompatibility(input, false)
+
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "enabled" {
+		t.Fatalf("thinking.type = %q, want enabled", got)
+	}
+	if got := gjson.GetBytes(out, "thinking.budget_tokens").Int(); got != 8192 {
+		t.Fatalf("thinking.budget_tokens = %d, want 8192", got)
+	}
+	if gjson.GetBytes(out, "output_config.effort").Exists() {
+		t.Fatal("output_config.effort should be removed")
+	}
+	if gjson.GetBytes(out, "context_management").Exists() {
+		t.Fatal("context_management should be removed")
+	}
+	if gjson.GetBytes(out, "metadata").Exists() {
+		t.Fatal("metadata should be removed")
+	}
+}
+
+func TestApplyKimiClaudeBetaHeader(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "https://api.kimi.com/coding/v1/messages?beta=true", nil)
+	applyKimiClaudeBetaHeader(req, false)
+	if got := req.Header.Get("Anthropic-Beta"); got != "claude-code-20250219,interleaved-thinking-2025-05-14" {
+		t.Fatalf("beta header = %q", got)
+	}
+	applyKimiClaudeBetaHeader(req, true)
+	if got := req.Header.Get("Anthropic-Beta"); got != "claude-code-20250219" {
+		t.Fatalf("strict beta header = %q", got)
+	}
+}
+
+func TestIsRetryableKimiInvalidRequest(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"error":{"type":"invalid_request_error","message":"Invalid request Error"}}`)
+	if !isRetryableKimiInvalidRequest(http.StatusBadRequest, body) {
+		t.Fatal("expected invalid_request_error to be retryable")
+	}
+	if isRetryableKimiInvalidRequest(http.StatusInternalServerError, body) {
+		t.Fatal("status 500 should not be retryable")
+	}
+}
+
+func TestApplyKimiClaudeCompatibility_StripToolReference(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"1","content":[{"type":"text","text":"result"},{"type":"tool_reference","tool_name":"WebSearch"}]}]}]}`)
+	out := applyKimiClaudeCompatibility(input, false)
+
+	arr := gjson.GetBytes(out, "messages.0.content.0.content")
+	if !arr.IsArray() {
+		t.Fatal("expected inner content to remain an array")
+	}
+	for _, v := range arr.Array() {
+		if v.Get("type").String() == "tool_reference" {
+			t.Fatalf("tool_reference should be removed, got %s", v.Raw)
+		}
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.content.0.type").String(); got != "text" {
+		t.Fatalf("first inner block type = %q, want text", got)
+	}
+	if gjson.GetBytes(out, "messages.0.content.0.content.1").Exists() {
+		t.Fatal("expected only one inner block after stripping tool_reference")
+	}
+}
+
+func TestApplyKimiClaudeCompatibility_NoToolReferenceNoOp(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"1","content":[{"type":"text","text":"ok"}]}]}]}`)
+	out := applyKimiClaudeCompatibility(input, false)
+
+	if got := gjson.GetBytes(out, "messages.0.content.0.content.0.text").String(); got != "ok" {
+		t.Fatalf("inner text = %q, want ok", got)
+	}
+}
+
+func TestApplyKimiClaudeCompatibility_MultipleToolReferences(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"1","content":[{"type":"tool_reference","tool_name":"A"},{"type":"text","text":"middle"},{"type":"tool_reference","tool_name":"B"}]}]}]}`)
+	out := applyKimiClaudeCompatibility(input, false)
+
+	arr := gjson.GetBytes(out, "messages.0.content.0.content")
+	if len(arr.Array()) != 1 {
+		t.Fatalf("expected 1 inner block, got %d", len(arr.Array()))
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.content.0.type").String(); got != "text" {
+		t.Fatalf("expected text block, got %q", got)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.content.0.text").String(); got != "middle" {
+		t.Fatalf("expected middle text, got %q", got)
+	}
+}
+
+func TestApplyKimiClaudeCompatibility_MultipleMessages(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"1","content":[{"type":"tool_reference","tool_name":"A"}]}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"2","content":[{"type":"tool_reference","tool_name":"B"},{"type":"text","text":"ok"}]}]}]}`)
+	out := applyKimiClaudeCompatibility(input, false)
+
+	if gjson.GetBytes(out, "messages.0.content.0.content.0.type").String() == "tool_reference" {
+		t.Fatal("msg0 tool_reference should be removed")
+	}
+	if gjson.GetBytes(out, "messages.1.content.0.content.0.type").String() == "tool_reference" {
+		t.Fatal("msg1 tool_reference should be removed")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.content.0.text").String(); got != "ok" {
+		t.Fatalf("msg1 inner text = %q, want ok", got)
+	}
+}
+
+func TestStripKimiIncompatibleFields_StrictMode(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"thinking":{"type":"enabled","budget_tokens":4096},"output_config":{"effort":"high"}}`)
+	out := stripKimiIncompatibleFields(input, true)
+
+	if gjson.GetBytes(out, "output_config.effort").Exists() {
+		t.Fatal("output_config.effort should be removed in strict mode")
+	}
+	if !gjson.GetBytes(out, "thinking.budget_tokens").Exists() {
+		t.Fatal("thinking.budget_tokens should be preserved in strict mode")
+	}
+}


### PR DESCRIPTION
## Summary

Per maintainer feedback on #3058: Kimi is a first-class provider, so Claude Messages API compatibility handling should live in the dedicated `KimiExecutor` rather than the generic `ClaudeExecutor`.

This PR migrates all Kimi-specific compatibility logic into `kimi_executor.go` and its new companion file `kimi_executor_claude_compat.go`, making `ClaudeExecutor` provider-agnostic again.

## Changes

- **Extract `buildMessagesBody` on `ClaudeExecutor`**: a reusable helper that constructs translation/upstream bodies, applies thinking, cloaking, cache control, beta extraction, and OAuth tool remapping. Both `Execute` and `ExecuteStream` now call this instead of inlining the logic.

- **Add `kimi_executor_claude_compat.go`** with Kimi-specific transforms:
  - `applyKimiClaudeCompatibility` — strips `metadata`, `context_management`, normalizes adaptive thinking to enabled+budget_tokens, and removes `tool_reference` blocks.
  - `applyKimiClaudeBetaHeader` — sets the appropriate `Anthropic-Beta` header (`claude-code-20250219` base, or with `interleaved-thinking-2025-05-14` in non-strict mode).
  - `isRetryableKimiInvalidRequest` + `tryKimiCompatRetry` — strict-mode fallback when Kimi returns a retryable 400.

- **Update `KimiExecutor`**:
  - `HttpRequest` and `Execute` now call `executeKimiClaudeNonStream`
  - `ExecuteStream` now calls `executeKimiClaudeStream`
  - Both apply Kimi compatibility transforms before sending upstream.

- **Add tests and benchmarks**:
  - `kimi_executor_claude_compat_test.go`
  - `kimi_executor_claude_compat_bench_test.go`

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./internal/runtime/executor/...`
- [ ] Manual: route a Claude-format request through Kimi endpoint and verify response

## Related

- Closes the approach taken in #3058 (now superseded)