### PR TITLE
Claude+Codex compatibility: tool normalization + #2194 response translator fix

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -362,6 +362,10 @@ nonstream-keepalive-interval: 0
 #     - "kimi-k2-thinking"
 
 # Optional payload configuration
+# Query paths use gjson/sjson syntax and can include dynamic array selectors (#(...)).
+# Nested selectors are supported in override/override-raw/filter, for example:
+#   messages.#(role=="assistant").content.#(type=="tool_use").name
+# Malformed query paths are ignored (no mutation is applied).
 # payload:
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:
@@ -394,3 +398,4 @@ nonstream-keepalive-interval: 0
 #       params: # JSON paths (gjson/sjson syntax) to remove from the payload
 #         - "generationConfig.thinkingConfig.thinkingBudget"
 #         - "generationConfig.responseJsonSchema"
+#         - "messages.#(role==\"assistant\").content.#(type==\"tool_use\")"

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	antigravitythinking "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/antigravity"
 	antigravityclaude "github.com/router-for-me/CLIProxyAPI/v6/internal/translator/antigravity/claude"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
@@ -514,6 +515,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	}
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+	translated = preserveClaudeEffortForAntigravity(from, originalPayload, translated)
 
 	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -522,6 +524,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
+	translated = applyAntigravityClaudeCompatTransforms(baseModel, translated)
 
 	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
 
@@ -711,6 +714,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	}
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
+	translated = preserveClaudeEffortForAntigravity(from, originalPayload, translated)
 
 	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -719,6 +723,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
+	translated = applyAntigravityClaudeCompatTransforms(baseModel, translated)
 
 	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
 
@@ -1131,6 +1136,30 @@ func (e *AntigravityExecutor) convertStreamToNonStream(stream []byte) []byte {
 	return []byte(output)
 }
 
+func (e *AntigravityExecutor) prepareAntigravityRequestPayloads(req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) ([]byte, []byte, error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("antigravity")
+
+	originalPayload := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayload = opts.OriginalRequest
+	}
+
+	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, stream)
+	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
+
+	translated = preserveClaudeEffortForAntigravity(from, originalPayload, translated)
+
+	var err error
+	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return translated, originalTranslated, nil
+}
+
 // ExecuteStream performs a streaming request to the Antigravity API.
 func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	if opts.Alt == "responses/compact" {
@@ -1171,6 +1200,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
+	translated = preserveClaudeEffortForAntigravity(from, originalPayload, translated)
 
 	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -1179,6 +1209,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel)
+	translated = applyAntigravityClaudeCompatTransforms(baseModel, translated)
 
 	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
 
@@ -1426,13 +1457,14 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 	}
 
 	// Prepare payload once (doesn't depend on baseURL)
-	payload := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
-
-	payload, err := thinking.ApplyThinking(payload, req.Model, from.String(), to.String(), e.Identifier())
+	payload, originalTranslated, err := e.prepareAntigravityRequestPayloads(req, opts, false)
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
 
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	payload = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", payload, originalTranslated, requestedModel)
+	payload = applyAntigravityClaudeCompatTransforms(baseModel, payload)
 	payload = deleteJSONField(payload, "project")
 	payload = deleteJSONField(payload, "model")
 	payload = deleteJSONField(payload, "request.safetySettings")
@@ -2246,6 +2278,83 @@ var antigravityBaseURLFallbackOrder = func(auth *cliproxyauth.Auth) []string {
 		antigravityBaseURLDaily,
 		antigravitySandboxBaseURLDaily,
 	}
+}
+
+func applyAntigravityClaudeCompatTransforms(baseModel string, body []byte) []byte {
+	body = clampAntigravityClaudeMaxOutputTokens(baseModel, body)
+	if strings.Contains(strings.ToLower(strings.TrimSpace(baseModel)), "claude") {
+		if info := registry.LookupModelInfo(baseModel, antigravityAuthType); info != nil {
+			body = antigravitythinking.NormalizeClaudeBudgetPayload(body, info)
+		} else if info := registry.LookupStaticModelInfo(baseModel); info != nil {
+			body = antigravitythinking.NormalizeClaudeBudgetPayload(body, info)
+		}
+	}
+	body = sanitizeAntigravityClaudeCompatFields(body)
+	return body
+}
+
+func preserveClaudeEffortForAntigravity(sourceFormat sdktranslator.Format, originalBody, translatedBody []byte) []byte {
+	if strings.TrimSpace(sourceFormat.String()) != "claude" {
+		return translatedBody
+	}
+
+	if thinkingType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(originalBody, "thinking.type").String())); thinkingType == "disabled" {
+		translatedBody, _ = sjson.DeleteBytes(translatedBody, "request.generationConfig.thinkingConfig.thinkingLevel")
+		translatedBody, _ = sjson.DeleteBytes(translatedBody, "request.generationConfig.thinkingConfig.thinking_level")
+		translatedBody, _ = sjson.SetBytes(translatedBody, "request.generationConfig.thinkingConfig.thinkingBudget", 0)
+		translatedBody, _ = sjson.SetBytes(translatedBody, "request.generationConfig.thinkingConfig.includeThoughts", false)
+		return translatedBody
+	}
+
+	effortValue := gjson.GetBytes(originalBody, "output_config.effort")
+	if !effortValue.Exists() || effortValue.Type != gjson.String {
+		return translatedBody
+	}
+	effort := strings.ToLower(strings.TrimSpace(effortValue.String()))
+	if effort == "" {
+		return translatedBody
+	}
+
+	// Claude output_config.effort takes precedence over budget_tokens in extractClaudeConfig.
+	// Mirror that precedence after translation so Antigravity requests keep the same semantics.
+	translatedBody, _ = sjson.SetBytes(translatedBody, "request.generationConfig.thinkingConfig.thinkingLevel", effort)
+	translatedBody, _ = sjson.SetBytes(translatedBody, "request.generationConfig.thinkingConfig.includeThoughts", true)
+	return translatedBody
+}
+
+func sanitizeAntigravityClaudeCompatFields(body []byte) []byte {
+	body = deleteJSONField(body, "output_config")
+	body = deleteJSONField(body, "request.output_config")
+	return body
+}
+
+func clampAntigravityClaudeMaxOutputTokens(baseModel string, body []byte) []byte {
+	if !strings.Contains(strings.ToLower(strings.TrimSpace(baseModel)), "claude") {
+		return body
+	}
+
+	currentValue := gjson.GetBytes(body, "request.generationConfig.maxOutputTokens")
+	currentTokens := currentValue.Int()
+	if !currentValue.Exists() || currentTokens <= 0 {
+		return body
+	}
+
+	maxAllowed := 0
+	if info := registry.LookupModelInfo(baseModel, antigravityAuthType); info != nil && info.MaxCompletionTokens > 0 {
+		maxAllowed = info.MaxCompletionTokens
+	} else if info := registry.LookupStaticModelInfo(baseModel); info != nil && info.MaxCompletionTokens > 0 {
+		maxAllowed = info.MaxCompletionTokens
+	}
+
+	if maxAllowed <= 0 || currentTokens <= int64(maxAllowed) {
+		return body
+	}
+
+	clamped, err := sjson.SetBytes(body, "request.generationConfig.maxOutputTokens", maxAllowed)
+	if err != nil {
+		return body
+	}
+	return clamped
 }
 
 func resolveCustomAntigravityBaseURL(auth *cliproxyauth.Auth) string {

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -4,9 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	antigravityclaude "github.com/router-for-me/CLIProxyAPI/v6/internal/translator/antigravity/claude"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
 )
 
 func TestAntigravityBuildRequest_SanitizesGeminiToolSchema(t *testing.T) {
@@ -88,6 +98,741 @@ func TestAntigravityBuildRequest_SkipsSchemaSanitizationWithEmptyToolsArray(t *t
 	}`))
 
 	assertNonSchemaRequestPreserved(t, body)
+}
+
+func TestSanitizeAntigravityClaudeCompatFields_RemovesOutputConfig(t *testing.T) {
+	input := []byte(`{
+		"output_config":{"effort":"max"},
+		"request":{
+			"output_config":{"effort":"high"},
+			"generationConfig":{"thinkingConfig":{"thinkingBudget":1024}}
+		}
+	}`)
+
+	out := sanitizeAntigravityClaudeCompatFields(input)
+
+	var body map[string]any
+	if err := json.Unmarshal(out, &body); err != nil {
+		t.Fatalf("unmarshal sanitized body error: %v, body=%s", err, string(out))
+	}
+	if _, ok := body["output_config"]; ok {
+		t.Fatalf("top-level output_config should be removed")
+	}
+	req, ok := body["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("request missing or invalid type")
+	}
+	if _, ok := req["output_config"]; ok {
+		t.Fatalf("request.output_config should be removed")
+	}
+	if _, ok := req["generationConfig"]; !ok {
+		t.Fatalf("request.generationConfig should be preserved")
+	}
+}
+
+func TestClampAntigravityClaudeMaxOutputTokens_ClampsThinkingModel(t *testing.T) {
+	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":128000}}}`)
+	out := clampAntigravityClaudeMaxOutputTokens("claude-opus-4-6-thinking", input)
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d", got)
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_ClampsAndRemovesOutputConfig(t *testing.T) {
+	input := []byte(`{
+		"output_config":{"effort":"max"},
+		"request":{
+			"output_config":{"effort":"high"},
+			"generationConfig":{"maxOutputTokens":128000}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", input)
+
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("top-level output_config should be removed")
+	}
+	if gjson.GetBytes(out, "request.output_config").Exists() {
+		t.Fatalf("request.output_config should be removed")
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d", got)
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_RebalancesThinkingBudgetAfterTokenClamp(t *testing.T) {
+	input := []byte(`{
+		"output_config":{"effort":"max"},
+		"request":{
+			"generationConfig":{
+				"maxOutputTokens":128000,
+				"thinkingConfig":{"thinkingBudget":128000,"includeThoughts":true}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d", got)
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("expected thinkingBudget=63999, got %d, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should stay true, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be stripped, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_RemovesThinkingConfigWhenRebalancedBudgetFallsBelowMinimum(t *testing.T) {
+	input := []byte(`{
+		"request":{
+			"generationConfig":{
+				"maxOutputTokens":1024,
+				"thinkingConfig":{"thinkingBudget":2048,"includeThoughts":true}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 1024 {
+		t.Fatalf("expected maxOutputTokens=1024, got %d", got)
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig").Exists() {
+		t.Fatalf("thinkingConfig should be removed when adjusted budget falls below minimum, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_RebalancesThinkingBudgetWithDerivedMaxOutputTokens(t *testing.T) {
+	input := []byte(`{
+		"request":{
+			"generationConfig":{
+				"thinkingConfig":{"thinkingBudget":128000,"includeThoughts":true}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("expected thinkingBudget=63999, got %d, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should stay true, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_PreservesEffortThinkingLevelWithoutSynthesizingBudget(t *testing.T) {
+	input := []byte(`{
+		"output_config":{"effort":"max"},
+		"request":{
+			"generationConfig":{
+				"thinkingConfig":{"thinkingLevel":"max","includeThoughts":true}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").String(); got != "max" {
+		t.Fatalf("thinkingLevel = %q, want %q, body=%s", got, "max", string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget"); got.Exists() {
+		t.Fatalf("thinkingBudget should remain absent for effort-only path, got %s, body=%s", got.Raw, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should remain true, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Exists() {
+		t.Fatalf("maxOutputTokens should remain absent on effort-only path without explicit max, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_PreservesNonClaudeLowBudget(t *testing.T) {
+	input := []byte(`{
+		"request":{
+			"generationConfig":{
+				"thinkingConfig":{"thinkingBudget":100}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("gemini-3-flash", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 100 {
+		t.Fatalf("thinkingBudget = %d, want 100, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Exists() {
+		t.Fatalf("maxOutputTokens should remain absent for non-Claude compat path, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_PreservesNonClaudeOversizedBudget(t *testing.T) {
+	input := []byte(`{
+		"request":{
+			"generationConfig":{
+				"thinkingConfig":{"thinkingBudget":70000}
+			}
+		}
+	}`)
+
+	out := applyAntigravityClaudeCompatTransforms("gemini-3-flash", input)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 70000 {
+		t.Fatalf("thinkingBudget = %d, want 70000, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Exists() {
+		t.Fatalf("maxOutputTokens should remain absent for non-Claude compat path, body=%s", string(out))
+	}
+}
+
+func TestClampAntigravityClaudeMaxOutputTokens_PreservesWithinLimit(t *testing.T) {
+	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":64000}}}`)
+	out := clampAntigravityClaudeMaxOutputTokens("claude-opus-4-6-thinking", input)
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d", got)
+	}
+}
+
+func TestClampAntigravityClaudeMaxOutputTokens_PreservesNonThinkingModel(t *testing.T) {
+	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":128000}}}`)
+	out := clampAntigravityClaudeMaxOutputTokens("claude-opus-4-6", input)
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 128000 {
+		t.Fatalf("expected maxOutputTokens=128000, got %d", got)
+	}
+}
+
+func TestClampAntigravityClaudeMaxOutputTokens_NoopForNonClaude(t *testing.T) {
+	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":128000}}}`)
+	out := clampAntigravityClaudeMaxOutputTokens("gemini-2.5-pro", input)
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 128000 {
+		t.Fatalf("expected maxOutputTokens=128000, got %d", got)
+	}
+}
+
+func TestClampAntigravityClaudeMaxOutputTokens_ClampsLargeInt64Value(t *testing.T) {
+	input := []byte(`{"request":{"generationConfig":{"maxOutputTokens":9223372036854775807}}}`)
+	out := clampAntigravityClaudeMaxOutputTokens("claude-opus-4-6-thinking", input)
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("expected maxOutputTokens=64000, got %d", got)
+	}
+}
+
+func TestPreserveClaudeEffortForAntigravity_AddsThinkingLevel(t *testing.T) {
+	original := []byte(`{"output_config":{"effort":"max"}}`)
+	translated := []byte(`{"request":{}}`)
+
+	out := preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").String(); got != "max" {
+		t.Fatalf("thinkingLevel = %q, want %q, body=%s", got, "max", string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be true, body=%s", string(out))
+	}
+}
+
+func TestPreserveClaudeEffortForAntigravity_AddsThinkingLevelAlongsideExistingBudget(t *testing.T) {
+	original := []byte(`{"output_config":{"effort":"max"}}`)
+	translated := []byte(`{"request":{"generationConfig":{"thinkingConfig":{"thinkingBudget":2048,"includeThoughts":false}}}}`)
+
+	out := preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 2048 {
+		t.Fatalf("thinkingBudget = %d, want 2048, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").String(); got != "max" {
+		t.Fatalf("thinkingLevel = %q, want %q, body=%s", got, "max", string(out))
+	}
+}
+
+func TestPreserveClaudeEffortForAntigravity_NoopForNonClaudeSource(t *testing.T) {
+	original := []byte(`{"output_config":{"effort":"max"}}`)
+	translated := []byte(`{"request":{}}`)
+
+	out := preserveClaudeEffortForAntigravity(sdktranslator.FromString("openai"), original, translated)
+
+	if got := string(out); got != string(translated) {
+		t.Fatalf("unexpected mutation for non-claude source: got=%s want=%s", got, string(translated))
+	}
+}
+
+func TestPreserveClaudeEffortForAntigravity_IgnoresNonStringOrBlankEffort(t *testing.T) {
+	tests := []struct {
+		name     string
+		original string
+	}{
+		{name: "null", original: `{"output_config":{"effort":null}}`},
+		{name: "number", original: `{"output_config":{"effort":123}}`},
+		{name: "bool", original: `{"output_config":{"effort":false}}`},
+		{name: "blank", original: `{"output_config":{"effort":"   "}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			translated := []byte(`{"request":{"generationConfig":{"thinkingConfig":{"thinkingBudget":2048,"includeThoughts":false}}}}`)
+
+			out := preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), []byte(tt.original), translated)
+
+			if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel"); got.Exists() {
+				t.Fatalf("thinkingLevel should not be set for %s effort, body=%s", tt.name, string(out))
+			}
+			if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 2048 {
+				t.Fatalf("thinkingBudget = %d, want 2048, body=%s", got, string(out))
+			}
+			if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+				t.Fatalf("includeThoughts should remain unchanged for %s effort, body=%s", tt.name, string(out))
+			}
+		})
+	}
+}
+
+func TestPreserveClaudeEffortForAntigravity_PreservesDisabledThinking(t *testing.T) {
+	original := []byte(`{"thinking":{"type":"disabled"},"output_config":{"effort":"high"}}`)
+	translated := []byte(`{"request":{"generationConfig":{"thinkingConfig":{"thinkingBudget":2048,"thinkingLevel":"medium","includeThoughts":true}}}}`)
+
+	out := preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").Exists() {
+		t.Fatalf("thinkingLevel should be cleared for disabled thinking, body=%s", string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 0 {
+		t.Fatalf("thinkingBudget = %d, want 0, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be false for disabled thinking, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_StripsBridgedOutputConfig(t *testing.T) {
+	original := []byte(`{"output_config":{"effort":"max"}}`)
+	translated := []byte(`{"request":{}}`)
+
+	bridged := preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+	withCompat := append([]byte(`{"output_config":{"effort":"max"},`), bridged[1:]...)
+	out := applyAntigravityClaudeCompatTransforms("claude-opus-4-6-thinking", withCompat)
+
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be stripped, body=%s", string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").String(); got != "max" {
+		t.Fatalf("thinkingLevel = %q, want %q, body=%s", got, "max", string(out))
+	}
+}
+
+func TestPrepareAntigravityRequestPayloads_LeavesDefaultSourceUnmodifiedByThinkingTransforms(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Default: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "antigravity"}},
+					Params: map[string]any{
+						"generationConfig.thinkingConfig.includeThoughts": false,
+						"generationConfig.thinkingConfig.thinkingBudget":  1024,
+					},
+				},
+			},
+		},
+	}
+	executor := &AntigravityExecutor{cfg: cfg}
+	req := cliproxyexecutor.Request{
+		Model:   "claude-opus-4-6-thinking",
+		Payload: []byte(`{"output_config":{"effort":"max"}}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FromString("claude"),
+		OriginalRequest: []byte(`{"output_config":{"effort":"max"}}`),
+	}
+
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "non-stream", true: "stream"}[stream], func(t *testing.T) {
+			translated, originalTranslated, err := executor.prepareAntigravityRequestPayloads(req, opts, stream)
+			if err != nil {
+				t.Fatalf("prepareAntigravityRequestPayloads error = %v", err)
+			}
+
+			got := helps.ApplyPayloadConfigWithRoot(cfg, "claude-opus-4-6-thinking", "antigravity", "request", translated, originalTranslated, "")
+
+			if gjson.GetBytes(originalTranslated, "request.generationConfig.thinkingConfig").Exists() {
+				t.Fatalf("originalTranslated should remain the raw translated source for defaults, body=%s", string(originalTranslated))
+			}
+			if gotBudget := gjson.GetBytes(got, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); gotBudget != 1024 {
+				t.Fatalf("thinkingBudget = %d, want %d, body=%s", gotBudget, 1024, string(got))
+			}
+			if gotLevel := gjson.GetBytes(got, "request.generationConfig.thinkingConfig.thinkingLevel"); gotLevel.Exists() {
+				t.Fatalf("thinkingLevel should not suppress defaults when the client omitted target fields, body=%s", string(got))
+			}
+			if gjson.GetBytes(got, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+				t.Fatalf("includeThoughts default should apply when the client omitted it, body=%s", string(got))
+			}
+		})
+	}
+}
+
+func TestAntigravityCountTokens_UsesSharedClaudeCompatPreparation(t *testing.T) {
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		capturedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body error: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"totalTokens":321}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "antigravity"}},
+					Params: map[string]any{
+						"debug.label": "count-tokens",
+					},
+				},
+			},
+		},
+	}
+	executor := &AntigravityExecutor{cfg: cfg}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"base_url": server.URL,
+		},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"expired":      time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	payload := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"max"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}]
+	}`)
+
+	_, err := executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-opus-4-6-thinking",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FromString("claude"),
+		OriginalRequest: payload,
+	})
+	if err != nil {
+		t.Fatalf("CountTokens error = %v", err)
+	}
+
+	if got := gjson.GetBytes(capturedBody, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(capturedBody))
+	}
+	if got := gjson.GetBytes(capturedBody, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(capturedBody))
+	}
+	if gjson.GetBytes(capturedBody, "output_config").Exists() {
+		t.Fatalf("output_config should be stripped, body=%s", string(capturedBody))
+	}
+	if got := gjson.GetBytes(capturedBody, "request.debug.label").String(); got != "count-tokens" {
+		t.Fatalf("request.debug.label = %q, want %q, body=%s", got, "count-tokens", string(capturedBody))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_CherryAdaptiveMaxPayload(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"max"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+	translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be true, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be removed, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_ClaudeEffortNoneDisablesThinking(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"none"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+	translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 0 {
+		t.Fatalf("thinkingBudget = %d, want 0, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").Exists() {
+		t.Fatalf("thinkingLevel should be cleared for disabled thinking, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be false for disabled thinking, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be removed, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "request.output_config").Exists() {
+		t.Fatalf("request.output_config should be removed, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_ClaudeEffortAutoPreservesAdaptiveThinking(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"auto"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+	translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != -1 {
+		t.Fatalf("thinkingBudget = %d, want -1, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").Exists() {
+		t.Fatalf("thinkingLevel should be cleared for adaptive auto thinking, body=%s", string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should remain true for adaptive auto thinking, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be removed, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "request.output_config").Exists() {
+		t.Fatalf("request.output_config should be removed, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_DisabledThinkingOverridesClaudeEffort(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"disabled"},
+		"output_config":{"effort":"high"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+	translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").Exists() {
+		t.Fatalf("thinkingLevel should be cleared when disabled thinking wins, body=%s", string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 0 {
+		t.Fatalf("thinkingBudget = %d, want 0, body=%s", got, string(out))
+	}
+	if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be false when disabled thinking wins, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config").Exists() {
+		t.Fatalf("output_config should be removed, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "request.output_config").Exists() {
+		t.Fatalf("request.output_config should be removed, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_ManualBudgetPayload(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"enabled","budget_tokens":64000},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be true, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_ManualBudgetPayloadWithoutMaxTokens(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"thinking":{"type":"enabled","budget_tokens":64000},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should be true, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_ClaudeEffortOverridesEnabledBudget(t *testing.T) {
+	original := []byte(`{
+		"model":"claude-opus-4-6-thinking",
+		"max_tokens":128000,
+		"thinking":{"type":"enabled","budget_tokens":64000},
+		"output_config":{"effort":"low"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+		"stream":true
+	}`)
+
+	baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+	translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+	translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+	out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+	if err != nil {
+		t.Fatalf("ApplyThinking error = %v", err)
+	}
+
+	out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 1024 {
+		t.Fatalf("thinkingBudget = %d, want 1024, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should remain true, body=%s", string(out))
+	}
+}
+
+func TestApplyAntigravityClaudeCompatTransforms_NonStringEffortFallsBackToBudget(t *testing.T) {
+	tests := []struct {
+		name   string
+		effort string
+	}{
+		{name: "null", effort: "null"},
+		{name: "number", effort: "123"},
+		{name: "bool", effort: "false"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := []byte(`{
+				"model":"claude-opus-4-6-thinking",
+				"max_tokens":128000,
+				"thinking":{"type":"enabled","budget_tokens":64000},
+				"output_config":{"effort":` + tt.effort + `},
+				"messages":[{"role":"user","content":[{"type":"text","text":"Hello!"}]}],
+				"stream":true
+			}`)
+
+			baseModel := thinking.ParseSuffix("claude-opus-4-6-thinking").ModelName
+			translated := antigravityclaude.ConvertClaudeRequestToAntigravity(baseModel, original, true)
+			translated = preserveClaudeEffortForAntigravity(sdktranslator.FromString("claude"), original, translated)
+
+			out, err := thinking.ApplyThinking(translated, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+			if err != nil {
+				t.Fatalf("ApplyThinking error = %v", err)
+			}
+
+			out = applyAntigravityClaudeCompatTransforms(baseModel, out)
+
+			if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+				t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+			}
+			if gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingLevel").Exists() {
+				t.Fatalf("thinkingLevel should be omitted when non-string effort falls back to budget, body=%s", string(out))
+			}
+			if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+				t.Fatalf("includeThoughts should remain true for budget fallback, body=%s", string(out))
+			}
+		})
+	}
 }
 
 func assertNonSchemaRequestPreserved(t *testing.T, body map[string]any) {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -8,9 +8,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -81,6 +84,23 @@ var oauthToolsToRemove = map[string]bool{}
 // Anthropic-compatible upstreams may reject or even crash when Claude models
 // omit max_tokens. Prefer registered model metadata before using a fallback.
 const defaultModelMaxTokens = 1024
+
+type claudeBodyFinalizeOptions struct {
+	applyThinking            bool
+	checkSystemInstructions  bool
+	disableForcedToolChoice  bool
+	autoInjectCacheControl   bool
+	enforceCacheControlLimit bool
+	normalizeCacheControlTTL bool
+	applyToolPrefixForOAuth  bool
+}
+
+type claudePreparedBody struct {
+	bodyForTranslation []byte
+	bodyForUpstream    []byte
+	extraBetas         []string
+	originalToolNames  map[string]string
+}
 
 func NewClaudeExecutor(cfg *config.Config) *ClaudeExecutor { return &ClaudeExecutor{cfg: cfg} }
 
@@ -154,11 +174,6 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
-	if err != nil {
-		return resp, err
-	}
-
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
 	body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
@@ -189,11 +204,20 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	var extraBetas []string
 	extraBetas, body = extractAndRemoveBetas(body)
 	bodyForTranslation := body
-	bodyForUpstream := body
+	// Normalize custom tool names/schemas to satisfy Anthropic API constraints.
+	// Returned originalToolNames lets us restore client-facing names on the response.
+	upstreamBody, originalToolNames, errNormalize := normalizeClaudeToolsForAnthropicWithRestoreMap(bytes.Clone(body))
+	if errNormalize != nil {
+		if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) || errors.Is(errNormalize, errAnthropicDuplicateToolName) {
+			return resp, statusErr{code: http.StatusBadRequest, msg: errNormalize.Error()}
+		}
+		return resp, fmt.Errorf("normalize claude tools: %w", errNormalize)
+	}
+	bodyForUpstream := upstreamBody
 	oauthToken := isClaudeOAuthToken(apiKey)
 	oauthToolNamesRemapped := false
 	if oauthToken && !auth.ToolPrefixDisabled() {
-		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
+		bodyForUpstream = applyClaudeToolPrefix(bodyForUpstream, claudeToolPrefix)
 	}
 	// Remap third-party tool names to Claude Code equivalents and remove
 	// tools without official counterparts. This prevents Anthropic from
@@ -256,6 +280,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 			helps.LogWithRequestID(ctx).Warn(msg)
 			b = []byte(msg)
 		}
+		b = restoreClaudeToolNamesInErrorBody(b, claudeToolPrefix, originalToolNames)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
 		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
@@ -300,13 +325,15 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if isClaudeOAuthToken(apiKey) && oauthToolNamesRemapped {
 		data = reverseRemapOAuthToolNames(data)
 	}
+	// Restore client-facing tool names sanitized by normalizeClaudeToolsForAnthropic.
+	data = restoreClaudeNormalizedToolNamesInResponse(data, originalToolNames)
 	var param any
 	out := sdktranslator.TranslateNonStream(
 		ctx,
 		to,
 		from,
 		req.Model,
-		opts.OriginalRequest,
+		claudeOriginalRequestForTranslation(opts.OriginalRequest, req.Payload),
 		bodyForTranslation,
 		data,
 		&param,
@@ -339,11 +366,6 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
-	if err != nil {
-		return nil, err
-	}
-
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
 	body = applyCloaking(ctx, e.cfg, auth, body, baseModel, apiKey)
@@ -371,11 +393,18 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	var extraBetas []string
 	extraBetas, body = extractAndRemoveBetas(body)
 	bodyForTranslation := body
-	bodyForUpstream := body
+	upstreamBody, originalToolNames, errNormalize := normalizeClaudeToolsForAnthropicWithRestoreMap(bytes.Clone(body))
+	if errNormalize != nil {
+		if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) || errors.Is(errNormalize, errAnthropicDuplicateToolName) {
+			return nil, statusErr{code: http.StatusBadRequest, msg: errNormalize.Error()}
+		}
+		return nil, fmt.Errorf("normalize claude tools: %w", errNormalize)
+	}
+	bodyForUpstream := upstreamBody
 	oauthToken := isClaudeOAuthToken(apiKey)
 	oauthToolNamesRemapped := false
 	if oauthToken && !auth.ToolPrefixDisabled() {
-		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
+		bodyForUpstream = applyClaudeToolPrefix(bodyForUpstream, claudeToolPrefix)
 	}
 	// Remap third-party tool names to Claude Code equivalents and remove
 	// tools without official counterparts. This prevents Anthropic from
@@ -437,6 +466,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			helps.LogWithRequestID(ctx).Warn(msg)
 			b = []byte(msg)
 		}
+		b = restoreClaudeToolNamesInErrorBody(b, claudeToolPrefix, originalToolNames)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
 		if errClose := errBody.Close(); errClose != nil {
@@ -478,6 +508,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				if isClaudeOAuthToken(apiKey) && oauthToolNamesRemapped {
 					line = reverseRemapOAuthToolNamesFromStreamLine(line)
 				}
+				line = restoreClaudeNormalizedToolNamesInStreamLine(line, originalToolNames)
 				// Forward the line as-is to preserve SSE format
 				cloned := make([]byte, len(line)+1)
 				copy(cloned, line)
@@ -508,12 +539,13 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			if isClaudeOAuthToken(apiKey) && oauthToolNamesRemapped {
 				line = reverseRemapOAuthToolNamesFromStreamLine(line)
 			}
+			line = restoreClaudeNormalizedToolNamesInStreamLine(line, originalToolNames)
 			chunks := sdktranslator.TranslateStream(
 				ctx,
 				to,
 				from,
 				req.Model,
-				opts.OriginalRequest,
+				claudeOriginalRequestForTranslation(opts.OriginalRequest, req.Payload),
 				bodyForTranslation,
 				bytes.Clone(line),
 				&param,
@@ -546,6 +578,12 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 
+	body, errThink := thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	if errThink != nil {
+		return cliproxyexecutor.Response{}, errThink
+	}
+	body = disableThinkingIfToolChoiceForced(body)
+
 	if !strings.HasPrefix(baseModel, "claude-3-5-haiku") {
 		body = checkSystemInstructions(body)
 	}
@@ -557,6 +595,13 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	// Extract betas from body and convert to header (for count_tokens too)
 	var extraBetas []string
 	extraBetas, body = extractAndRemoveBetas(body)
+	body, originalToolNames, errNormalize := normalizeClaudeToolsForAnthropicWithRestoreMap(body)
+	if errNormalize != nil {
+		if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) || errors.Is(errNormalize, errAnthropicDuplicateToolName) {
+			return cliproxyexecutor.Response{}, statusErr{code: http.StatusBadRequest, msg: errNormalize.Error()}
+		}
+		return cliproxyexecutor.Response{}, fmt.Errorf("normalize claude tools: %w", errNormalize)
+	}
 	if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 		body = applyClaudeToolPrefix(body, claudeToolPrefix)
 	}
@@ -614,6 +659,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 			helps.LogWithRequestID(ctx).Warn(msg)
 			b = []byte(msg)
 		}
+		b = restoreClaudeToolNamesInErrorBody(b, claudeToolPrefix, originalToolNames)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
@@ -642,6 +688,154 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	count := gjson.GetBytes(data, "input_tokens").Int()
 	out := sdktranslator.TranslateTokenCount(ctx, to, from, count, data)
 	return cliproxyexecutor.Response{Payload: out, Headers: resp.Header.Clone()}, nil
+}
+
+func (e *ClaudeExecutor) finalizeClaudeRequestBody(body []byte, reqModel string, from, to sdktranslator.Format, baseModel, apiKey string, auth *cliproxyauth.Auth, opts claudeBodyFinalizeOptions) (claudePreparedBody, error) {
+	if opts.applyThinking {
+		var err error
+		body, err = thinking.ApplyThinking(body, reqModel, from.String(), to.String(), e.Identifier())
+		if err != nil {
+			return claudePreparedBody{}, err
+		}
+	}
+	if opts.checkSystemInstructions && !strings.HasPrefix(baseModel, "claude-3-5-haiku") {
+		body = checkSystemInstructions(body)
+	}
+	if opts.disableForcedToolChoice {
+		body = disableThinkingIfToolChoiceForced(body)
+	}
+	if opts.autoInjectCacheControl && countCacheControls(body) == 0 {
+		body = ensureCacheControl(body)
+	}
+	if opts.enforceCacheControlLimit {
+		body = enforceCacheControlLimit(body, 4)
+	}
+	if opts.normalizeCacheControlTTL {
+		body = normalizeCacheControlTTL(body)
+	}
+	extraBetas, translationBody := extractAndRemoveBetas(body)
+	upstreamBody, originalToolNames, errNormalize := normalizeClaudeToolsForAnthropicWithRestoreMap(bytes.Clone(translationBody))
+	if errNormalize != nil {
+		if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) || errors.Is(errNormalize, errAnthropicDuplicateToolName) {
+			return claudePreparedBody{}, statusErr{code: http.StatusBadRequest, msg: errNormalize.Error()}
+		}
+		return claudePreparedBody{}, fmt.Errorf("normalize claude tools: %w", errNormalize)
+	}
+	prepared := claudePreparedBody{
+		bodyForTranslation: translationBody,
+		bodyForUpstream:    upstreamBody,
+		extraBetas:         extraBetas,
+		originalToolNames:  originalToolNames,
+	}
+	if opts.applyToolPrefixForOAuth && isClaudeOAuthToken(apiKey) && auth != nil && !auth.ToolPrefixDisabled() {
+		prepared.bodyForUpstream = applyClaudeToolPrefix(upstreamBody, claudeToolPrefix)
+	}
+	return prepared, nil
+}
+
+func (e *ClaudeExecutor) buildUpstreamStatusErr(ctx context.Context, statusCode int, headers http.Header, body io.ReadCloser, apiKey string, auth *cliproxyauth.Auth, originalToolNames map[string]string) error {
+	decodedErrBody, errDecode := decodeResponseBody(body, headers.Get("Content-Encoding"))
+	if errDecode != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, errDecode)
+		msg := fmt.Sprintf("failed to decode upstream error body: %v", errDecode)
+		helps.LogWithRequestID(ctx).Warn(msg)
+		return statusErr{code: statusCode, msg: msg}
+	}
+
+	b, errRead := io.ReadAll(decodedErrBody)
+	if errClose := decodedErrBody.Close(); errClose != nil {
+		log.Errorf("response body close error: %v", errClose)
+	}
+	if errRead != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, errRead)
+		msg := fmt.Sprintf("failed to read upstream error body: %v", errRead)
+		helps.LogWithRequestID(ctx).Warn(msg)
+		b = []byte(msg)
+	}
+
+	b = normalizeClaudeResponseToolNames(b, apiKey, auth, originalToolNames)
+	helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+	helps.LogWithRequestID(ctx).Debugf(
+		"request error, error status: %d, error message: %s",
+		statusCode,
+		helps.SummarizeErrorBody(headers.Get("Content-Type"), b),
+	)
+	return statusErr{code: statusCode, msg: string(b)}
+}
+
+func normalizeClaudeResponseToolNames(body []byte, apiKey string, auth *cliproxyauth.Auth, originalToolNames map[string]string) []byte {
+	if isClaudeOAuthToken(apiKey) && auth != nil && !auth.ToolPrefixDisabled() {
+		body = stripClaudeToolPrefixFromResponse(body, claudeToolPrefix)
+	}
+	body = restoreClaudeNormalizedToolNamesInResponse(body, originalToolNames)
+	return restoreClaudeToolNamesInErrorBody(body, claudeToolPrefix, originalToolNames)
+}
+
+func restoreClaudeToolNamesInErrorBody(body []byte, prefix string, originalByNormalized map[string]string) []byte {
+	if len(originalByNormalized) == 0 {
+		return body
+	}
+	if !gjson.ValidBytes(body) {
+		return body
+	}
+	for _, path := range []string{"error.message", "message"} {
+		value := gjson.GetBytes(body, path)
+		if !value.Exists() || value.Type != gjson.String {
+			continue
+		}
+		updated := restoreClaudeToolNamesInErrorText(value.String(), prefix, originalByNormalized)
+		if updated == value.String() {
+			continue
+		}
+		body, _ = sjson.SetBytes(body, path, updated)
+	}
+	return body
+}
+
+func claudeOriginalRequestForTranslation(originalRequest, payload []byte) []byte {
+	if len(originalRequest) > 0 {
+		return originalRequest
+	}
+	return payload
+}
+
+func restoreClaudeToolNamesInErrorText(text, prefix string, originalByNormalized map[string]string) string {
+	if text == "" || len(originalByNormalized) == 0 {
+		return text
+	}
+	type replacement struct {
+		from string
+		to   string
+	}
+	replacements := make([]replacement, 0, len(originalByNormalized)*2)
+	for normalized, original := range originalByNormalized {
+		if normalized == "" || original == "" {
+			continue
+		}
+		if prefix != "" {
+			replacements = append(replacements, replacement{from: prefix + normalized, to: original})
+		}
+		replacements = append(replacements, replacement{from: normalized, to: original})
+	}
+	sort.SliceStable(replacements, func(i, j int) bool {
+		return len(replacements[i].from) > len(replacements[j].from)
+	})
+	replacerArgs := make([]string, 0, len(replacements)*2)
+	for _, replacement := range replacements {
+		replacerArgs = append(replacerArgs, replacement.from, replacement.to)
+	}
+	if len(replacerArgs) == 0 {
+		return text
+	}
+	return strings.NewReplacer(replacerArgs...).Replace(text)
+}
+
+func isStatusCodeErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var statusCarrier interface{ StatusCode() int }
+	return errors.As(err, &statusCarrier)
 }
 
 func (e *ClaudeExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
@@ -908,6 +1102,11 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	}
 	if !strings.Contains(baseBetas, "interleaved-thinking") {
 		baseBetas += ",interleaved-thinking-2025-05-14"
+	}
+
+	// X-CPA-CLAUDE-1M opts the request into Anthropic's 1M context window beta.
+	if ginHeaders != nil && strings.TrimSpace(ginHeaders.Get("X-CPA-CLAUDE-1M")) == "1" && !strings.Contains(baseBetas, "context-1m-2025-08-07") {
+		baseBetas += ",context-1m-2025-08-07"
 	}
 
 	// Merge extra betas from request body and request flags.
@@ -1202,27 +1401,478 @@ func reverseRemapOAuthToolNamesFromStreamLine(line []byte) []byte {
 	return updated
 }
 
+func isClaudeBuiltinToolType(toolType string) bool {
+	toolType = strings.TrimSpace(toolType)
+	switch {
+	case strings.HasPrefix(toolType, "web_search"):
+		return true
+	case toolType == "code_execution":
+		return true
+	case strings.HasPrefix(toolType, "text_editor"):
+		return true
+	case strings.HasPrefix(toolType, "computer"):
+		return true
+	default:
+		return false
+	}
+}
+
+func isClaudeBuiltinTool(tool gjson.Result) bool {
+	return isClaudeBuiltinToolType(tool.Get("type").String())
+}
+
+func isClaudeExplicitNonCustomTypedTool(tool gjson.Result) bool {
+	toolType := strings.TrimSpace(tool.Get("type").String())
+	return toolType != "" && toolType != "custom" && toolType != "function" && !isClaudeBuiltinToolType(toolType)
+}
+
+func normalizeAnthropicToolSchema(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" || !gjson.Valid(raw) || !gjson.Parse(raw).IsObject() {
+		return `{"type":"object","properties":{}}`
+	}
+
+	schema := raw
+	parsed := gjson.Parse(raw)
+	schemaType := strings.TrimSpace(parsed.Get("type").String())
+	if schemaType == "" {
+		var err error
+		schema, err = sjson.Set(schema, "type", "object")
+		if err != nil {
+			return `{"type":"object","properties":{}}`
+		}
+	} else if schemaType != "object" {
+		return `{"type":"object","properties":{}}`
+	}
+
+	parsed = gjson.Parse(schema)
+	properties := parsed.Get("properties")
+	if !properties.Exists() || !properties.IsObject() {
+		var err error
+		schema, err = sjson.SetRaw(schema, "properties", `{}`)
+		if err != nil {
+			return `{"type":"object","properties":{}}`
+		}
+	}
+	return schema
+}
+
+func sanitizeAnthropicToolName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(len(name))
+	for i := 0; i < len(name); i++ {
+		ch := name[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' {
+			b.WriteByte(ch)
+			continue
+		}
+		b.WriteByte('_')
+	}
+
+	clean := strings.Trim(b.String(), "_-")
+	if clean == "" {
+		return ""
+	}
+	if len(clean) > 64 {
+		clean = clean[:64]
+	}
+	return clean
+}
+
+const maxToolNameCollisionRetries = 1000
+
+func uniqueAnthropicToolName(name string, used map[string]struct{}) string {
+	clean := sanitizeAnthropicToolName(name)
+	if clean == "" {
+		return ""
+	}
+	if _, exists := used[clean]; !exists {
+		used[clean] = struct{}{}
+		return clean
+	}
+	for i := 2; i < maxToolNameCollisionRetries; i++ {
+		suffix := fmt.Sprintf("_%d", i)
+		baseLimit := 64 - len(suffix)
+		if baseLimit < 1 {
+			return ""
+		}
+		base := clean
+		if len(base) > baseLimit {
+			base = base[:baseLimit]
+		}
+		candidate := base + suffix
+		if _, exists := used[candidate]; !exists {
+			used[candidate] = struct{}{}
+			return candidate
+		}
+	}
+	return ""
+}
+
+func reservedClaudeBuiltinToolNames() map[string]struct{} {
+	reserved := make(map[string]struct{})
+	for _, name := range []string{"web_search", "code_execution", "text_editor", "computer"} {
+		reserved[name] = struct{}{}
+	}
+	return reserved
+}
+
+func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
+	normalizedBody, _, err := normalizeClaudeToolsForAnthropicWithRestoreMap(body)
+	return normalizedBody, err
+}
+
+func normalizeClaudeToolsForAnthropicWithRestoreMap(body []byte) ([]byte, map[string]string, error) {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return body, nil, nil
+	}
+
+	normalizedTools := make([]json.RawMessage, 0, len(tools.Array()))
+	renameMap := make(map[string]string)
+	originalNameCounts := make(map[string]int)
+	usedNames := reservedClaudeBuiltinToolNames()
+	for _, tool := range tools.Array() {
+		name := anthroToolOriginalName(tool)
+		if name == "" {
+			continue
+		}
+		originalNameCounts[name]++
+	}
+
+	for _, tool := range tools.Array() {
+		// Tools with no name and no recognized type cannot be normalized for Claude.
+		// This occurs when translated OpenAI-hosted tool types (code_interpreter,
+		// container_exec, etc.) lose their type field during translation.
+		// The first-pass counting loop (above) already skips these; match that here.
+		if anthroToolOriginalName(tool) == "" && !isClaudeBuiltinTool(tool) && !isClaudeExplicitNonCustomTypedTool(tool) {
+			log.Warnf("claude tool normalization: skipping tool with no name or recognized type: %s", tool.Raw)
+			continue
+		}
+
+		if isClaudeBuiltinTool(tool) {
+			normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
+			reserveToolNameVariants(usedNames, strings.TrimSpace(tool.Get("name").String()))
+			continue
+		}
+
+		if isClaudeExplicitNonCustomTypedTool(tool) {
+			// Preserve explicit non-custom types as-is for forward compatibility.
+			normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
+			reserveToolNameVariants(usedNames, anthroToolOriginalName(tool))
+			continue
+		}
+
+		originalName := anthroToolOriginalName(tool)
+		if originalName != "" && originalNameCounts[originalName] > 1 {
+			return body, nil, fmt.Errorf("%w: custom tool name %q appears multiple times and cannot be remapped safely", errAnthropicDuplicateToolName, originalName)
+		}
+
+		normalizedTool, originalName, newName, errNormalize := normalizeAnthropicToolEntry(tool, usedNames)
+		if errNormalize != nil {
+			return body, nil, errNormalize
+		}
+		normalizedTools = append(normalizedTools, json.RawMessage(normalizedTool))
+		if originalName != "" && originalName != newName {
+			renameMap[originalName] = newName
+		}
+	}
+
+	skippedCount := len(tools.Array()) - len(normalizedTools)
+	if skippedCount > 0 {
+		log.Warnf("claude tool normalization: %d of %d tools skipped (no name or recognized type)", skippedCount, len(tools.Array()))
+	}
+
+	normalizedToolsJSON, errMarshal := json.Marshal(normalizedTools)
+	if errMarshal != nil {
+		return body, nil, fmt.Errorf("marshal normalized tools array: %w", errMarshal)
+	}
+	updatedBody, errSet := sjson.SetRawBytes(body, "tools", normalizedToolsJSON)
+	if errSet != nil {
+		return body, nil, fmt.Errorf("set normalized tools array: %w", errSet)
+	}
+	body = updatedBody
+
+	body, errSet = applyClaudeRenameMap(body, renameMap)
+	if errSet != nil {
+		return body, nil, errSet
+	}
+	return body, invertClaudeToolRenameMap(renameMap), nil
+}
+
+func invertClaudeToolRenameMap(renameMap map[string]string) map[string]string {
+	if len(renameMap) == 0 {
+		return nil
+	}
+	originalByNormalized := make(map[string]string, len(renameMap))
+	for originalName, normalizedName := range renameMap {
+		originalByNormalized[normalizedName] = originalName
+	}
+	return originalByNormalized
+}
+
+func anthroToolOriginalName(tool gjson.Result) string {
+	name := strings.TrimSpace(tool.Get("name").String())
+	if name == "" {
+		name = strings.TrimSpace(tool.Get("function.name").String())
+	}
+	return name
+}
+
+var errAnthropicToolNameUnsanitizable = errors.New("anthropic tool name unsanitizable")
+var errAnthropicDuplicateToolName = errors.New("anthropic duplicate tool name")
+
+func normalizeAnthropicToolEntry(tool gjson.Result, usedNames map[string]struct{}) (normalizedRaw string, originalName string, newName string, err error) {
+	originalName = anthroToolOriginalName(tool)
+	newName = uniqueAnthropicToolName(originalName, usedNames)
+	if newName == "" {
+		return "", originalName, "", fmt.Errorf("%w: custom tool name %q cannot be sanitized into a valid Anthropic tool name", errAnthropicToolNameUnsanitizable, originalName)
+	}
+
+	description := strings.TrimSpace(tool.Get("description").String())
+	if description == "" {
+		description = strings.TrimSpace(tool.Get("function.description").String())
+	}
+	if description == "" {
+		description = "Custom tool"
+	}
+
+	schemaRaw := ""
+	schemaPaths := []string{
+		"input_schema",
+		"parameters",
+		"parametersJsonSchema",
+		"function.parameters",
+		"function.parametersJsonSchema",
+	}
+	for _, path := range schemaPaths {
+		if v := tool.Get(path); v.Exists() {
+			schemaRaw = v.Raw
+			break
+		}
+	}
+	schema := normalizeAnthropicToolSchema(schemaRaw)
+
+	normalized := `{"name":"","description":"","input_schema":{}}`
+	normalized, err = sjson.Set(normalized, "name", newName)
+	if err != nil {
+		return "", originalName, newName, fmt.Errorf("set normalized tool name: %w", err)
+	}
+	normalized, err = sjson.Set(normalized, "description", description)
+	if err != nil {
+		return "", originalName, newName, fmt.Errorf("set normalized tool description: %w", err)
+	}
+	normalized, err = sjson.SetRaw(normalized, "input_schema", schema)
+	if err != nil {
+		return "", originalName, newName, fmt.Errorf("set normalized tool schema: %w", err)
+	}
+	normalized, err = copyAnthropicCustomToolMetadata(normalized, tool)
+	if err != nil {
+		return "", originalName, newName, err
+	}
+	return normalized, originalName, newName, nil
+}
+
+func copyAnthropicCustomToolMetadata(normalized string, original gjson.Result) (string, error) {
+	// Preserve documented Anthropic custom-tool metadata while removing
+	// wrapper/compat-only fields that are normalized elsewhere.
+	for _, field := range []string{"cache_control", "input_examples", "strict"} {
+		value := original.Get(field)
+		if !value.Exists() {
+			continue
+		}
+		var err error
+		normalized, err = sjson.SetRaw(normalized, field, value.Raw)
+		if err != nil {
+			return normalized, fmt.Errorf("set normalized tool %s: %w", field, err)
+		}
+	}
+	return normalized, nil
+}
+
+func reserveToolNameVariants(used map[string]struct{}, name string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	used[name] = struct{}{}
+	if sanitized := sanitizeAnthropicToolName(name); sanitized != "" {
+		used[sanitized] = struct{}{}
+	}
+}
+
+func renamedToolName(name string, renameMap map[string]string) (string, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false
+	}
+	mapped, ok := renameMap[name]
+	return mapped, ok
+}
+
+func applyClaudeRenameMap(body []byte, renameMap map[string]string) ([]byte, error) {
+	if len(renameMap) == 0 {
+		return body, nil
+	}
+
+	if gjson.GetBytes(body, "tool_choice.type").String() == "tool" {
+		if mapped, ok := renamedToolName(gjson.GetBytes(body, "tool_choice.name").String(), renameMap); ok {
+			updatedBody, err := sjson.SetBytes(body, "tool_choice.name", mapped)
+			if err != nil {
+				return body, fmt.Errorf("set tool_choice.name: %w", err)
+			}
+			body = updatedBody
+		}
+	}
+
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body, nil
+	}
+
+	messagesRaw := messages.Raw
+	messagesChanged := false
+	for msgIndex, msg := range messages.Array() {
+		content := msg.Get("content")
+		if !content.Exists() || !content.IsArray() {
+			continue
+		}
+		for contentIndex, part := range content.Array() {
+			switch part.Get("type").String() {
+			case "tool_use":
+				if mapped, ok := renamedToolName(part.Get("name").String(), renameMap); ok {
+					path := fmt.Sprintf("%d.content.%d.name", msgIndex, contentIndex)
+					updatedMessages, err := sjson.Set(messagesRaw, path, mapped)
+					if err != nil {
+						return body, fmt.Errorf("set %s: %w", path, err)
+					}
+					messagesRaw = updatedMessages
+					messagesChanged = true
+				}
+			case "tool_reference":
+				if mapped, ok := renamedToolName(part.Get("tool_name").String(), renameMap); ok {
+					path := fmt.Sprintf("%d.content.%d.tool_name", msgIndex, contentIndex)
+					updatedMessages, err := sjson.Set(messagesRaw, path, mapped)
+					if err != nil {
+						return body, fmt.Errorf("set %s: %w", path, err)
+					}
+					messagesRaw = updatedMessages
+					messagesChanged = true
+				}
+			case "tool_result":
+				nestedContent := part.Get("content")
+				if !nestedContent.Exists() || !nestedContent.IsArray() {
+					continue
+				}
+				for nestedIndex, nestedPart := range nestedContent.Array() {
+					if nestedPart.Get("type").String() != "tool_reference" {
+						continue
+					}
+					if mapped, ok := renamedToolName(nestedPart.Get("tool_name").String(), renameMap); ok {
+						path := fmt.Sprintf("%d.content.%d.content.%d.tool_name", msgIndex, contentIndex, nestedIndex)
+						updatedMessages, err := sjson.Set(messagesRaw, path, mapped)
+						if err != nil {
+							return body, fmt.Errorf("set %s: %w", path, err)
+						}
+						messagesRaw = updatedMessages
+						messagesChanged = true
+					}
+				}
+			}
+		}
+	}
+	if !messagesChanged {
+		return body, nil
+	}
+	updatedBody, err := sjson.SetRawBytes(body, "messages", []byte(messagesRaw))
+	if err != nil {
+		return body, fmt.Errorf("set messages: %w", err)
+	}
+	body = updatedBody
+
+	return body, nil
+}
+
+func claudeToolPrefixName(tool gjson.Result) string {
+	topLevelName := strings.TrimSpace(tool.Get("name").String())
+	if topLevelName != "" {
+		return topLevelName
+	}
+	return anthroToolOriginalName(tool)
+}
+
+type claudeToolPrefixState struct {
+	prefixable    bool
+	nonPrefixable bool
+}
+
+func isClaudeToolPrefixable(tool gjson.Result) bool {
+	if isClaudeBuiltinTool(tool) || isClaudeExplicitNonCustomTypedTool(tool) {
+		return false
+	}
+	return strings.TrimSpace(tool.Get("name").String()) != ""
+}
+
+func claudeToolPrefixStates(body []byte) map[string]claudeToolPrefixState {
+	states := map[string]claudeToolPrefixState{}
+	for _, name := range []string{"web_search", "code_execution", "text_editor", "computer"} {
+		states[name] = claudeToolPrefixState{nonPrefixable: true}
+	}
+
+	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			name := claudeToolPrefixName(tool)
+			if name == "" {
+				return true
+			}
+			state := states[name]
+			if isClaudeToolPrefixable(tool) {
+				state.prefixable = true
+			} else {
+				state.nonPrefixable = true
+			}
+			states[name] = state
+			return true
+		})
+	}
+
+	return states
+}
+
+func shouldPrefixClaudeToolName(name, prefix string, states map[string]claudeToolPrefixState) bool {
+	name = strings.TrimSpace(name)
+	if name == "" || strings.HasPrefix(name, prefix) {
+		return false
+	}
+	state, ok := states[name]
+	if !ok {
+		return true
+	}
+	if state.prefixable && !state.nonPrefixable {
+		return true
+	}
+	return false
+}
+
 func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 	if prefix == "" {
 		return body
 	}
 
-	// Collect built-in tool names from the authoritative fallback seed list and
-	// augment it with any typed built-ins present in the current request body.
-	builtinTools := helps.AugmentClaudeBuiltinToolRegistry(body, nil)
+	states := claudeToolPrefixStates(body)
 
 	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
 		tools.ForEach(func(index, tool gjson.Result) bool {
-			// Skip built-in tools (web_search, code_execution, etc.) which have
-			// a "type" field and require their name to remain unchanged.
-			if tool.Get("type").Exists() && tool.Get("type").String() != "" {
-				if n := tool.Get("name").String(); n != "" {
-					builtinTools[n] = true
-				}
+			name := claudeToolPrefixName(tool)
+			if !isClaudeToolPrefixable(tool) {
 				return true
 			}
-			name := tool.Get("name").String()
-			if name == "" || strings.HasPrefix(name, prefix) {
+			if !shouldPrefixClaudeToolName(name, prefix, states) {
 				return true
 			}
 			path := fmt.Sprintf("tools.%d.name", index.Int())
@@ -1233,7 +1883,7 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 
 	if gjson.GetBytes(body, "tool_choice.type").String() == "tool" {
 		name := gjson.GetBytes(body, "tool_choice.name").String()
-		if name != "" && !strings.HasPrefix(name, prefix) && !builtinTools[name] {
+		if shouldPrefixClaudeToolName(name, prefix, states) {
 			body, _ = sjson.SetBytes(body, "tool_choice.name", prefix+name)
 		}
 	}
@@ -1249,14 +1899,14 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 				switch partType {
 				case "tool_use":
 					name := part.Get("name").String()
-					if name == "" || strings.HasPrefix(name, prefix) || builtinTools[name] {
+					if !shouldPrefixClaudeToolName(name, prefix, states) {
 						return true
 					}
 					path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
 					body, _ = sjson.SetBytes(body, path, prefix+name)
 				case "tool_reference":
 					toolName := part.Get("tool_name").String()
-					if toolName == "" || strings.HasPrefix(toolName, prefix) || builtinTools[toolName] {
+					if !shouldPrefixClaudeToolName(toolName, prefix, states) {
 						return true
 					}
 					path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
@@ -1268,7 +1918,7 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 						nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
 							if nestedPart.Get("type").String() == "tool_reference" {
 								nestedToolName := nestedPart.Get("tool_name").String()
-								if nestedToolName != "" && !strings.HasPrefix(nestedToolName, prefix) && !builtinTools[nestedToolName] {
+								if shouldPrefixClaudeToolName(nestedToolName, prefix, states) {
 									nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
 									body, _ = sjson.SetBytes(body, nestedPath, prefix+nestedToolName)
 								}
@@ -1332,6 +1982,74 @@ func stripClaudeToolPrefixFromResponse(body []byte, prefix string) []byte {
 	return body
 }
 
+func restoreClaudeNormalizedToolNamesInRequest(body []byte, originalByNormalized map[string]string) []byte {
+	if len(originalByNormalized) == 0 {
+		return body
+	}
+	restoredBody := body
+	if tools := gjson.GetBytes(restoredBody, "tools"); tools.Exists() && tools.IsArray() {
+		tools.ForEach(func(index, tool gjson.Result) bool {
+			name := tool.Get("name").String()
+			originalName, ok := renamedToolName(name, originalByNormalized)
+			if !ok {
+				return true
+			}
+			path := fmt.Sprintf("tools.%d.name", index.Int())
+			restoredBody, _ = sjson.SetBytes(restoredBody, path, originalName)
+			return true
+		})
+	}
+	restoredBody, err := applyClaudeRenameMap(restoredBody, originalByNormalized)
+	if err != nil {
+		return body
+	}
+	return restoredBody
+}
+
+func restoreClaudeNormalizedToolNamesInResponse(body []byte, originalByNormalized map[string]string) []byte {
+	if len(originalByNormalized) == 0 {
+		return body
+	}
+	content := gjson.GetBytes(body, "content")
+	if !content.Exists() || !content.IsArray() {
+		return body
+	}
+	content.ForEach(func(index, part gjson.Result) bool {
+		partType := part.Get("type").String()
+		switch partType {
+		case "tool_use":
+			name := part.Get("name").String()
+			if originalName, ok := renamedToolName(name, originalByNormalized); ok {
+				path := fmt.Sprintf("content.%d.name", index.Int())
+				body, _ = sjson.SetBytes(body, path, originalName)
+			}
+		case "tool_reference":
+			toolName := part.Get("tool_name").String()
+			if originalName, ok := renamedToolName(toolName, originalByNormalized); ok {
+				path := fmt.Sprintf("content.%d.tool_name", index.Int())
+				body, _ = sjson.SetBytes(body, path, originalName)
+			}
+		case "tool_result":
+			nestedContent := part.Get("content")
+			if nestedContent.Exists() && nestedContent.IsArray() {
+				nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
+					if nestedPart.Get("type").String() != "tool_reference" {
+						return true
+					}
+					nestedToolName := nestedPart.Get("tool_name").String()
+					if originalName, ok := renamedToolName(nestedToolName, originalByNormalized); ok {
+						nestedPath := fmt.Sprintf("content.%d.content.%d.tool_name", index.Int(), nestedIndex.Int())
+						body, _ = sjson.SetBytes(body, nestedPath, originalName)
+					}
+					return true
+				})
+			}
+		}
+		return true
+	})
+	return body
+}
+
 func stripClaudeToolPrefixFromStreamLine(line []byte, prefix string) []byte {
 	if prefix == "" {
 		return line
@@ -1365,6 +2083,57 @@ func stripClaudeToolPrefixFromStreamLine(line []byte, prefix string) []byte {
 			return line
 		}
 		updated, err = sjson.SetBytes(payload, "content_block.tool_name", strings.TrimPrefix(toolName, prefix))
+		if err != nil {
+			return line
+		}
+	default:
+		return line
+	}
+
+	trimmed := bytes.TrimSpace(line)
+	if bytes.HasPrefix(trimmed, []byte("data:")) {
+		return append([]byte("data: "), updated...)
+	}
+	return updated
+}
+
+func restoreClaudeNormalizedToolNamesInStreamLine(line []byte, originalByNormalized map[string]string) []byte {
+	if len(originalByNormalized) == 0 {
+		return line
+	}
+	payload := helps.JSONPayload(line)
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return line
+	}
+	contentBlock := gjson.GetBytes(payload, "content_block")
+	if !contentBlock.Exists() {
+		return line
+	}
+
+	blockType := contentBlock.Get("type").String()
+	var (
+		updated []byte
+		err     error
+	)
+
+	switch blockType {
+	case "tool_use":
+		name := contentBlock.Get("name").String()
+		originalName, ok := renamedToolName(name, originalByNormalized)
+		if !ok {
+			return line
+		}
+		updated, err = sjson.SetBytes(payload, "content_block.name", originalName)
+		if err != nil {
+			return line
+		}
+	case "tool_reference":
+		toolName := contentBlock.Get("tool_name").String()
+		originalName, ok := renamedToolName(toolName, originalByNormalized)
+		if !ok {
+			return line
+		}
+		updated, err = sjson.SetBytes(payload, "content_block.tool_name", originalName)
 		if err != nil {
 			return line
 		}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,6 +21,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
@@ -964,6 +966,754 @@ func TestApplyClaudeToolPrefix_SkipsBuiltinToolReference(t *testing.T) {
 	}
 }
 
+func TestApplyClaudeToolPrefix_PrefixesCustomToolType(t *testing.T) {
+	input := []byte(`{"tools":[{"type":"custom","name":"apply_patch"}]}`)
+	out := applyClaudeToolPrefix(input, "proxy_")
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "proxy_apply_patch")
+	}
+}
+
+func TestApplyClaudeToolPrefix_SkipsExplicitNonCustomTypedToolAndReferences(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"future_tool","name":"future_one","extra":{"a":1}},
+			{"type":"custom","name":"apply_patch","input_schema":{"type":"object"}}
+		],
+		"tool_choice":{"type":"tool","name":"future_one"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"future_one","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"future_one"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"future_one"}]}]},
+			{"role":"assistant","content":[{"type":"tool_use","name":"apply_patch","id":"t2","input":{}}]}
+		]
+	}`)
+
+	out := applyClaudeToolPrefix(input, "proxy_")
+
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "future_one" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "future_one" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "future_one" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "future_one" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "future_one" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "proxy_apply_patch")
+	}
+	if got := gjson.GetBytes(out, "messages.3.content.0.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("messages.3.content.0.name = %q, want %q", got, "proxy_apply_patch")
+	}
+}
+
+func TestApplyClaudeToolPrefix_SkipsRawWrapperToolWithoutTopLevelNameAndReferences(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"custom","function":{"name":"raw_wrapper","description":"wrapped","parameters":{"type":"object"}}},
+			{"type":"custom","name":"apply_patch","input_schema":{"type":"object"}}
+		],
+		"tool_choice":{"type":"tool","name":"raw_wrapper"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"raw_wrapper","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"raw_wrapper"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"raw_wrapper"}]}]},
+			{"role":"assistant","content":[{"type":"tool_use","name":"apply_patch","id":"t2","input":{}}]}
+		]
+	}`)
+
+	out := applyClaudeToolPrefix(input, "proxy_")
+
+	if got := gjson.GetBytes(out, "tools.0.function.name").String(); got != "raw_wrapper" {
+		t.Fatalf("tools.0.function.name = %q, want %q", got, "raw_wrapper")
+	}
+	if got := gjson.GetBytes(out, "tools.0.name"); got.Exists() {
+		t.Fatalf("tools.0.name should remain absent for raw wrapper tool, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "raw_wrapper" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "raw_wrapper")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "raw_wrapper" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "raw_wrapper")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "raw_wrapper" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "raw_wrapper")
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "raw_wrapper" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "raw_wrapper")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "proxy_apply_patch")
+	}
+	if got := gjson.GetBytes(out, "messages.3.content.0.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("messages.3.content.0.name = %q, want %q", got, "proxy_apply_patch")
+	}
+}
+
+func TestApplyClaudeToolPrefix_PreservesAmbiguousSharedNameAcrossRawWrapperAndCustomTool(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"custom","function":{"name":"shared_tool","description":"wrapped","parameters":{"type":"object"}}},
+			{"type":"custom","name":"shared_tool","input_schema":{"type":"object"}},
+			{"type":"custom","name":"apply_patch","input_schema":{"type":"object"}}
+		],
+		"tool_choice":{"type":"tool","name":"shared_tool"},
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"tool_use","name":"shared_tool","id":"t1","input":{}},
+				{"type":"tool_use","name":"apply_patch","id":"t2","input":{}}
+			]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"shared_tool"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"shared_tool"}]}]}
+		]
+	}`)
+
+	out := applyClaudeToolPrefix(input, "proxy_")
+
+	if got := gjson.GetBytes(out, "tools.0.function.name").String(); got != "shared_tool" {
+		t.Fatalf("tools.0.function.name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "shared_tool" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "shared_tool" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "shared_tool" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "shared_tool" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "shared_tool" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "shared_tool")
+	}
+	if got := gjson.GetBytes(out, "tools.2.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("tools.2.name = %q, want %q", got, "proxy_apply_patch")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.name").String(); got != "proxy_apply_patch" {
+		t.Fatalf("messages.0.content.1.name = %q, want %q", got, "proxy_apply_patch")
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_CustomTool(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"web_search_20250305","name":"web_search"},
+			{"type":"custom","name":"apply_patch","format":{"type":"grammar","syntax":"lark"}}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "web_search_20250305" {
+		t.Fatalf("tools.0.type = %q, want %q", got, "web_search_20250305")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "apply_patch" {
+		t.Fatalf("tools.1.name = %q, want %q", got, "apply_patch")
+	}
+	if got := gjson.GetBytes(out, "tools.1.description").String(); got != "Custom tool" {
+		t.Fatalf("tools.1.description = %q, want %q", got, "Custom tool")
+	}
+	if got := gjson.GetBytes(out, "tools.1.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.1.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tools.1.type"); got.Exists() {
+		t.Fatalf("tools.1.type should be removed, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.1.format"); got.Exists() {
+		t.Fatalf("tools.1.format should be removed, got %s", got.Raw)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_PreservesDocumentedCustomMetadata(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{
+				"type":"custom",
+				"name":"apply_patch",
+				"cache_control":{"type":"ephemeral","ttl":"1h"},
+				"input_examples":[{"input":{"path":"README.md"}}],
+				"strict":true,
+				"format":{"type":"grammar","syntax":"lark"}
+			}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "apply_patch" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "apply_patch")
+	}
+	if got := gjson.GetBytes(out, "tools.0.cache_control.ttl").String(); got != "1h" {
+		t.Fatalf("tools.0.cache_control.ttl = %q, want %q", got, "1h")
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_examples.#").Int(); got != 1 {
+		t.Fatalf("tools.0.input_examples length = %d, want 1", got)
+	}
+	if !gjson.GetBytes(out, "tools.0.strict").Bool() {
+		t.Fatalf("tools.0.strict should be true, body=%s", string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.type"); got.Exists() {
+		t.Fatalf("tools.0.type should be removed, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.0.format"); got.Exists() {
+		t.Fatalf("tools.0.format should be removed, got %s", got.Raw)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_FunctionFallbacks(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"very bad tool"},
+		"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"very bad tool","id":"t1","input":{}}]}],
+		"tools":[
+			{"type":"custom","function":{"name":"very bad tool","description":"dangerous","parameters":{"type":"object"}}}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	normalizedName := gjson.GetBytes(out, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	if strings.Contains(normalizedName, " ") {
+		t.Fatalf("normalized tool name should be sanitized, got %q", normalizedName)
+	}
+	if got := gjson.GetBytes(out, "tools.0.description").String(); got != "dangerous" {
+		t.Fatalf("tools.0.description = %q, want %q", got, "dangerous")
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.0.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != normalizedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != normalizedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, normalizedName)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_OpenAIFunctionToolNormalizesInsteadOfPassingThrough(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"very bad tool"},
+		"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"very bad tool","id":"t1","input":{}}]}],
+		"tools":[
+			{"type":"function","function":{"name":"very bad tool","description":"dangerous","parameters":{"type":"object"}}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	normalizedName := gjson.GetBytes(out, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	if strings.Contains(normalizedName, " ") {
+		t.Fatalf("normalized tool name should be sanitized, got %q", normalizedName)
+	}
+	if got := gjson.GetBytes(out, "tools.0.type"); got.Exists() {
+		t.Fatalf("tools.0.type should be removed after normalization, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.0.description").String(); got != "dangerous" {
+		t.Fatalf("tools.0.description = %q, want %q", got, "dangerous")
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.0.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != normalizedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != normalizedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, normalizedName)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_FunctionFallbacksPreserveTopLevelMetadata(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{
+				"type":"custom",
+				"cache_control":{"type":"ephemeral"},
+				"input_examples":[{"input":{"command":"run"}}],
+				"strict":true,
+				"function":{"name":"very bad tool","description":"dangerous","parameters":{"type":"object"}}
+			}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.description").String(); got != "dangerous" {
+		t.Fatalf("tools.0.description = %q, want %q", got, "dangerous")
+	}
+	if got := gjson.GetBytes(out, "tools.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("tools.0.cache_control.type = %q, want %q", got, "ephemeral")
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_examples.#").Int(); got != 1 {
+		t.Fatalf("tools.0.input_examples length = %d, want 1", got)
+	}
+	if !gjson.GetBytes(out, "tools.0.strict").Bool() {
+		t.Fatalf("tools.0.strict should be true, body=%s", string(out))
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_RenameMapUpdatesAllReferenceSites(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"very bad tool"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"very bad tool","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"very bad tool"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"very bad tool"}]}]}
+		],
+		"tools":[
+			{"type":"custom","function":{"name":"very bad tool","description":"dangerous","parameters":{"type":"object"}}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	normalizedName := gjson.GetBytes(out, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != normalizedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != normalizedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != normalizedName {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != normalizedName {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, normalizedName)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_RenameMapPreservesLargeIntegers(t *testing.T) {
+	input := []byte(`{
+		"request_id": 9007199254740993,
+		"tool_choice":{"type":"tool","name":"very bad tool"},
+		"messages":[
+			{
+				"role":"assistant",
+				"content":[
+					{"type":"tool_use","name":"very bad tool","id":"t1","input":{"large_id":9007199254740995}},
+					{"type":"text","text":"unchanged"}
+				]
+			},
+			{
+				"role":"user",
+				"content":[
+					{"type":"tool_result","tool_use_id":"t1","content":[
+						{"type":"tool_reference","tool_name":"very bad tool"},
+						{"type":"text","text":"meta","data":{"ticket":9223372036854775806}}
+					]}
+				]
+			}
+		],
+		"tools":[
+			{"type":"custom","function":{"name":"very bad tool","description":"dangerous","parameters":{"type":"object"}}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	normalizedName := gjson.GetBytes(out, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != normalizedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != normalizedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.content.0.tool_name").String(); got != normalizedName {
+		t.Fatalf("messages.1.content.0.content.0.tool_name = %q, want %q", got, normalizedName)
+	}
+
+	// Ensure unrelated large integer values are preserved exactly (no float64 coercion).
+	if got := gjson.GetBytes(out, "request_id").Raw; got != "9007199254740993" {
+		t.Fatalf("request_id raw = %q, want %q", got, "9007199254740993")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.input.large_id").Raw; got != "9007199254740995" {
+		t.Fatalf("messages.0.content.0.input.large_id raw = %q, want %q", got, "9007199254740995")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.content.1.data.ticket").Raw; got != "9223372036854775806" {
+		t.Fatalf("messages.1.content.0.content.1.data.ticket raw = %q, want %q", got, "9223372036854775806")
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_RejectsDuplicateOriginalCustomToolNames(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"duplicate tool"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"duplicate tool","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"duplicate tool"}]}
+		],
+		"tools":[
+			{"type":"custom","name":"duplicate tool","description":"first","input_schema":{"type":"object"}},
+			{"type":"custom","name":"duplicate tool","description":"second","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want duplicate-name rejection")
+	}
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_RejectsUnsanitizableCustomToolName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"!!!"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"!!!","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"!!!"}]}
+		],
+		"tools":[
+			{"type":"custom","name":"!!!","description":"bad","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want invalid-name rejection")
+	}
+	if !errors.Is(err, errAnthropicToolNameUnsanitizable) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicToolNameUnsanitizable", err)
+	}
+}
+
+func TestFinalizeClaudeRequestBody_RejectsDuplicateOriginalCustomToolNames(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	_, err := executor.finalizeClaudeRequestBody([]byte(`{
+		"tools":[
+			{"type":"custom","name":"duplicate tool","description":"first","input_schema":{"type":"object"}},
+			{"type":"custom","name":"duplicate tool","description":"second","input_schema":{"type":"object"}}
+		]
+	}`), "claude-opus-4-6", sdktranslator.FromString("claude"), sdktranslator.FromString("claude"), "claude-opus-4-6", "", nil, claudeBodyFinalizeOptions{})
+	if err == nil {
+		t.Fatal("finalizeClaudeRequestBody error = nil, want bad-request rejection")
+	}
+	sErr, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("finalizeClaudeRequestBody error type = %T, want statusErr", err)
+	}
+	if sErr.code != http.StatusBadRequest {
+		t.Fatalf("statusErr.code = %d, want %d", sErr.code, http.StatusBadRequest)
+	}
+}
+
+func TestFinalizeClaudeRequestBody_RejectsUnsanitizableCustomToolName(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	_, err := executor.finalizeClaudeRequestBody([]byte(`{
+		"tools":[
+			{"type":"custom","name":"!!!","description":"bad","input_schema":{"type":"object"}}
+		]
+	}`), "claude-opus-4-6", sdktranslator.FromString("claude"), sdktranslator.FromString("claude"), "claude-opus-4-6", "", nil, claudeBodyFinalizeOptions{})
+	if err == nil {
+		t.Fatal("finalizeClaudeRequestBody error = nil, want bad-request rejection")
+	}
+	sErr, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("finalizeClaudeRequestBody error type = %T, want statusErr", err)
+	}
+	if sErr.code != http.StatusBadRequest {
+		t.Fatalf("statusErr.code = %d, want %d", sErr.code, http.StatusBadRequest)
+	}
+}
+
+func TestFinalizeClaudeRequestBody_PreservesPreNormalizationTranslationBody(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	input := []byte(`{
+		"tools":[
+			{
+				"type":"function",
+				"name":"very bad tool",
+				"description":"Search",
+				"parameters":{"type":"object","properties":{"q":{"type":"string"}}},
+				"x_vendor":{"mode":"strict"}
+			}
+		],
+		"tool_choice":{"type":"function","function":{"name":"very bad tool"}}
+	}`)
+	body := sdktranslator.TranslateRequest(sdktranslator.FromString("openai-response"), sdktranslator.FromString("claude"), "claude-opus-4-6", input, true)
+	prepared, err := executor.finalizeClaudeRequestBody(body, "claude-opus-4-6", sdktranslator.FromString("openai-response"), sdktranslator.FromString("claude"), "claude-opus-4-6", "", nil, claudeBodyFinalizeOptions{})
+	if err != nil {
+		t.Fatalf("finalizeClaudeRequestBody error: %v", err)
+	}
+
+	if got := gjson.GetBytes(prepared.bodyForTranslation, "tools.0.name").String(); got != "very bad tool" {
+		t.Fatalf("bodyForTranslation tools.0.name = %q, want %q", got, "very bad tool")
+	}
+	if got := gjson.GetBytes(prepared.bodyForTranslation, "tools.0.input_schema.properties.q.type").String(); got != "string" {
+		t.Fatalf("bodyForTranslation tools.0.input_schema.properties.q.type = %q, want %q", got, "string")
+	}
+	if got := gjson.GetBytes(prepared.bodyForTranslation, "tool_choice.name").String(); got != "very bad tool" {
+		t.Fatalf("bodyForTranslation tool_choice.name = %q, want %q", got, "very bad tool")
+	}
+
+	upstreamName := gjson.GetBytes(prepared.bodyForUpstream, "tools.0.name").String()
+	if upstreamName == "" || upstreamName == "very bad tool" {
+		t.Fatalf("bodyForUpstream tools.0.name = %q, want normalized name", upstreamName)
+	}
+	if got := gjson.GetBytes(prepared.bodyForUpstream, "tools.0.type"); got.Exists() {
+		t.Fatalf("bodyForUpstream tools.0.type should be removed, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(prepared.bodyForUpstream, "tool_choice.name").String(); got != upstreamName {
+		t.Fatalf("bodyForUpstream tool_choice.name = %q, want %q", got, upstreamName)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_ReservesBuiltinNamesForCustomTools(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"web search"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"web search","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"web search"}]}
+		],
+		"tools":[
+			{"type":"custom","name":"web search","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	normalizedName := gjson.GetBytes(out, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	if normalizedName == "web_search" {
+		t.Fatalf("custom tool should not normalize to reserved built-in name, got %q", normalizedName)
+	}
+	if !strings.HasPrefix(normalizedName, "web_search_") {
+		t.Fatalf("custom tool should be suffixed off reserved name, got %q", normalizedName)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != normalizedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != normalizedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, normalizedName)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != normalizedName {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, normalizedName)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_AllowsDistinctOriginalNamesThatSanitizeToSameBase(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"very bad tool"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"very bad tool","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"very@bad tool"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t2","content":[{"type":"tool_reference","tool_name":"very@bad tool"}]}]}
+		],
+		"tools":[
+			{"type":"custom","name":"very bad tool","description":"first","input_schema":{"type":"object"}},
+			{"type":"custom","name":"very@bad tool","description":"second","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	firstName := gjson.GetBytes(out, "tools.0.name").String()
+	secondName := gjson.GetBytes(out, "tools.1.name").String()
+	if firstName == "" || secondName == "" {
+		t.Fatalf("normalized names should not be empty, got first=%q second=%q", firstName, secondName)
+	}
+	if firstName == secondName {
+		t.Fatalf("normalized names should be unique, got %q", firstName)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != firstName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, firstName)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != firstName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, firstName)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != secondName {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, secondName)
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != secondName {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, secondName)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_RejectsNonObjectSchemas(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"custom","name":"array_schema","input_schema":{"type":"array","items":{"type":"string"}}},
+			{"type":"custom","name":"bad_properties","input_schema":{"type":"object","properties":[]}}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.0.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_schema.properties"); !got.Exists() || !got.IsObject() {
+		t.Fatalf("tools.0.input_schema.properties should be object, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_schema.items"); got.Exists() {
+		t.Fatalf("tools.0.input_schema.items should be removed, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.1.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.1.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tools.1.input_schema.properties"); !got.Exists() || !got.IsObject() {
+		t.Fatalf("tools.1.input_schema.properties should be object, got %s", got.Raw)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_PreservesUnknownExplicitTypedTool(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"type":"future_tool","name":"future_one","extra":{"a":1}},
+			{"type":"custom","name":"apply patch","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "future_tool" {
+		t.Fatalf("tools.0.type = %q, want %q", got, "future_tool")
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "future_one" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(out, "tools.0.extra.a").Int(); got != 1 {
+		t.Fatalf("tools.0.extra.a = %d, want 1", got)
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got == "apply patch" || got == "" {
+		t.Fatalf("tools.1.name = %q, want sanitized non-empty custom name", got)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_TreatsExplicitTypedAndCustomNameCollisionAsAmbiguous(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"future_one"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"future_one","id":"t1","input":{"n":9007199254740995}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"future_one"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"future_one"}]}]}
+		],
+		"tools":[
+			{"type":"future_tool","name":"future_one","extra":{"a":1}},
+			{"type":"custom","name":"future_one","description":"custom duplicate","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want ambiguous-name rejection")
+	}
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_TreatsBuiltinAndCustomNameCollisionAsAmbiguous(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"web_search"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"web_search","id":"ws1","input":{"n":9007199254740995}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"web_search"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"ws1","content":[{"type":"tool_reference","tool_name":"web_search"}]}]}
+		],
+		"tools":[
+			{"type":"web_search_20250305","name":"web_search","max_uses":5},
+			{"type":"custom","name":"web_search","description":"custom duplicate","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want ambiguous-name rejection")
+	}
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_SkipsEmptyNameNoTypeTool(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"name":"shell","description":"Run commands","input_schema":{"type":"object","properties":{"cmd":{"type":"string"}}}},
+			{"name":"","description":"","input_schema":{}}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	toolCount := gjson.GetBytes(out, "tools.#").Int()
+	if toolCount != 1 {
+		t.Fatalf("tools count = %d, want 1; body=%s", toolCount, string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "shell" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "shell")
+	}
+}
+
+func TestNormalizeClaudeToolsForAnthropic_SkipsMultipleEmptyNameNoTypeTools(t *testing.T) {
+	input := []byte(`{
+		"tools":[
+			{"name":"","description":"","input_schema":{}},
+			{"name":"shell","description":"Run commands","input_schema":{"type":"object","properties":{"cmd":{"type":"string"}}}},
+			{"name":"","description":"code interpreter","input_schema":{}}
+		]
+	}`)
+	out, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	toolCount := gjson.GetBytes(out, "tools.#").Int()
+	if toolCount != 1 {
+		t.Fatalf("tools count = %d, want 1; body=%s", toolCount, string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "shell" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "shell")
+	}
+}
+
 func TestNormalizeCacheControlTTL_DowngradesLaterOneHourBlocks(t *testing.T) {
 	payload := []byte(`{
 		"tools": [{"name":"t1","cache_control":{"type":"ephemeral","ttl":"1h"}}],
@@ -1144,6 +1894,840 @@ func TestClaudeExecutor_CountTokens_AppliesCacheControlGuards(t *testing.T) {
 	}
 }
 
+func TestClaudeExecutor_CountTokens_AppliesThinkingFromModelSuffix(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"input_tokens":42}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	_, err := executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet(2048)",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("CountTokens error: %v", err)
+	}
+
+	if got := gjson.GetBytes(seenBody, "thinking.type").String(); got != "enabled" {
+		t.Fatalf("thinking.type = %q, want %q, body=%s", got, "enabled", string(seenBody))
+	}
+	if got := gjson.GetBytes(seenBody, "thinking.budget_tokens").Int(); got <= 0 {
+		t.Fatalf("thinking.budget_tokens = %d, want > 0, body=%s", got, string(seenBody))
+	}
+}
+
+func TestClaudeExecutor_CountTokens_DisablesThinkingWhenForcedToolChoice(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"input_tokens":42}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"tool_choice":{"type":"tool","name":"apply_patch"},
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+	_, err := executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet(2048)",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("CountTokens error: %v", err)
+	}
+
+	if gjson.GetBytes(seenBody, "thinking").Exists() {
+		t.Fatalf("thinking should be removed for forced tool choice, body=%s", string(seenBody))
+	}
+}
+
+func TestApplyClaudeHeaders_MergesBetasWithDefaultsAndClaude1M(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	ginReq := httptest.NewRequest(http.MethodPost, "http://localhost/v1/messages", nil)
+	ginReq.Header.Set("Anthropic-Beta", "custom-beta-1,oauth-2025-04-20")
+	ginReq.Header.Set("X-CPA-CLAUDE-1M", "1")
+	ginCtx.Request = ginReq
+
+	req := httptest.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "gin", ginCtx))
+
+	applyClaudeHeaders(req, &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123"}}, "key-123", false, []string{"beta-from-body", "custom-beta-1"}, &config.Config{})
+
+	got := req.Header.Get("Anthropic-Beta")
+	for _, want := range []string{
+		"custom-beta-1",
+		"oauth-2025-04-20",
+		"beta-from-body",
+		"context-1m-2025-08-07",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Anthropic-Beta = %q, missing %q", got, want)
+		}
+	}
+	if strings.Count(got, "custom-beta-1") != 1 {
+		t.Fatalf("Anthropic-Beta should de-duplicate custom-beta-1, got %q", got)
+	}
+}
+
+func TestClaudeExecutor_Execute_PreservesCustomToolCacheControl(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-3-5-sonnet","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"tools": [
+			{
+				"type":"custom",
+				"name":"tool_one",
+				"cache_control":{"type":"ephemeral","ttl":"1h"},
+				"input_schema":{"type":"object"}
+			},
+			{
+				"type":"custom",
+				"name":"tool_two",
+				"input_schema":{"type":"object"}
+			}
+		],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if len(seenBody) == 0 {
+		t.Fatal("expected request body to be captured")
+	}
+	if got := gjson.GetBytes(seenBody, "tools.0.cache_control.ttl").String(); got != "1h" {
+		t.Fatalf("tools.0.cache_control.ttl = %q, want %q, body=%s", got, "1h", string(seenBody))
+	}
+	if gjson.GetBytes(seenBody, "tools.1.cache_control").Exists() {
+		t.Fatalf("tools.1.cache_control should not be injected when caller already provided tool cache_control, body=%s", string(seenBody))
+	}
+	if got := countCacheControls(seenBody); got != 1 {
+		t.Fatalf("cache_control count = %d, want 1, body=%s", got, string(seenBody))
+	}
+}
+
+func TestClaudeExecutor_Execute_RestoresOriginalToolNamesAfterNormalization(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fmt.Sprintf(`{
+			"id":"msg_1",
+			"type":"message",
+			"model":"claude-3-5-sonnet",
+			"role":"assistant",
+			"content":[{"type":"tool_use","id":"toolu_1","name":%q,"input":{"q":"hi"}}],
+			"usage":{"input_tokens":1,"output_tokens":1}
+		}`, upstreamRequestName)))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"tools":[{"type":"custom","name":"very bad tool","input_schema":{"type":"object"}}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if upstreamRequestName == "" || upstreamRequestName == "very bad tool" {
+		t.Fatalf("upstream request tool name = %q, want normalized name", upstreamRequestName)
+	}
+	if got := gjson.GetBytes(resp.Payload, "content.0.name").String(); got != "very bad tool" {
+		t.Fatalf("content.0.name = %q, want %q, payload=%s", got, "very bad tool", string(resp.Payload))
+	}
+}
+
+func TestClaudeExecutor_ExecuteStream_RestoresOriginalToolNamesAfterNormalization(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet\",\"content\":[]}}\n\n"))
+		_, _ = w.Write([]byte(fmt.Sprintf("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":%q,\"input\":{}}}\n\n", upstreamRequestName)))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"tools":[{"type":"custom","name":"very bad tool","input_schema":{"type":"object"}}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var lines []string
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+		lines = append(lines, string(chunk.Payload))
+	}
+
+	if upstreamRequestName == "" || upstreamRequestName == "very bad tool" {
+		t.Fatalf("upstream request tool name = %q, want normalized name", upstreamRequestName)
+	}
+	streamBody := strings.Join(lines, "")
+	if !strings.Contains(streamBody, `"name":"very bad tool"`) {
+		t.Fatalf("stream output should restore original tool name, got %s", streamBody)
+	}
+	if strings.Contains(streamBody, fmt.Sprintf(`"name":"%s"`, upstreamRequestName)) {
+		t.Fatalf("stream output should not expose normalized tool name %q, got %s", upstreamRequestName, streamBody)
+	}
+}
+
+func TestClaudeExecutor_ExecuteStream_OpenAIResponsesWithoutOriginalRequest_RestoresEchoedToolNames(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet\",\"content\":[]}}\n\n"))
+		_, _ = w.Write([]byte(fmt.Sprintf("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":%q,\"input\":{\"q\":\"hi\"}}}\n\n", upstreamRequestName)))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}],
+		"tools":[{"type":"function","name":"very bad tool","description":"Search","parameters":{"type":"object"}}],
+		"tool_choice":{"type":"function","function":{"name":"very bad tool"}}
+	}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var chunks []string
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+		chunks = append(chunks, string(chunk.Payload))
+	}
+
+	if upstreamRequestName == "" || upstreamRequestName == "very bad tool" {
+		t.Fatalf("upstream request tool name = %q, want normalized name", upstreamRequestName)
+	}
+
+	var (
+		sawOutputName     bool
+		sawEchoedToolName bool
+		sawToolChoiceName bool
+	)
+	for _, payload := range collectSSEDataPayloads(chunks) {
+		if got := payload.Get("item.name").String(); got == "very bad tool" {
+			sawOutputName = true
+		} else if got == upstreamRequestName {
+			t.Fatalf("stream output item exposed normalized tool name %q in payload=%s", got, payload.Raw)
+		}
+		if got := payload.Get("response.tools.0.name").String(); got == "very bad tool" {
+			sawEchoedToolName = true
+		} else if got == upstreamRequestName {
+			t.Fatalf("stream response.tools exposed normalized tool name %q in payload=%s", got, payload.Raw)
+		}
+		if got := openAIResponseToolChoiceName(payload); got == "very bad tool" {
+			sawToolChoiceName = true
+		} else if got == upstreamRequestName {
+			t.Fatalf("stream tool_choice exposed normalized tool name %q in payload=%s", got, payload.Raw)
+		}
+	}
+
+	if !sawOutputName {
+		t.Fatalf("expected streamed output item to restore original tool name, got %v", chunks)
+	}
+	if !sawEchoedToolName {
+		t.Fatalf("expected streamed response.tools to restore original tool name, got %v", chunks)
+	}
+	if !sawToolChoiceName {
+		t.Fatalf("expected streamed tool_choice to restore original tool name, got %v", chunks)
+	}
+}
+
+func TestClaudeExecutor_Execute_OpenAIResponsesWithoutOriginalRequest_PreservesEchoedToolSchema(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet\",\"content\":[]}}\n\n"))
+		_, _ = w.Write([]byte(fmt.Sprintf("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":%q,\"input\":{\"q\":\"hi\"}}}\n\n", upstreamRequestName)))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}],
+		"tools":[{"type":"function","name":"very bad tool","description":"Search","parameters":{"type":"object","properties":{"q":{"type":"string"}}},"x_vendor":{"mode":"strict"}}],
+		"tool_choice":{"type":"function","function":{"name":"very bad tool"}}
+	}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if upstreamRequestName == "" || upstreamRequestName == "very bad tool" {
+		t.Fatalf("upstream request tool name = %q, want normalized name", upstreamRequestName)
+	}
+	if got := gjson.GetBytes(resp.Payload, "tools.0.type").String(); got != "function" {
+		t.Fatalf("response tools.0.type = %q, want %q, payload=%s", got, "function", string(resp.Payload))
+	}
+	if got := gjson.GetBytes(resp.Payload, "tools.0.name").String(); got != "very bad tool" {
+		t.Fatalf("response tools.0.name = %q, want %q, payload=%s", got, "very bad tool", string(resp.Payload))
+	}
+	if got := gjson.GetBytes(resp.Payload, "tools.0.parameters.properties.q.type").String(); got != "string" {
+		t.Fatalf("response tools.0.parameters.properties.q.type = %q, want %q, payload=%s", got, "string", string(resp.Payload))
+	}
+	if got := gjson.GetBytes(resp.Payload, "tools.0.x_vendor.mode").String(); got != "strict" {
+		t.Fatalf("response tools.0.x_vendor.mode = %q, want %q, payload=%s", got, "strict", string(resp.Payload))
+	}
+	if got := openAIResponseToolChoiceName(gjson.ParseBytes(resp.Payload)); got != "very bad tool" {
+		t.Fatalf("response tool_choice name = %q, want %q, payload=%s", got, "very bad tool", string(resp.Payload))
+	}
+}
+
+func TestClaudeExecutor_Execute_OpenAIResponsesWithoutOriginalRequest_UsesEffectiveRequestEcho(t *testing.T) {
+	var upstreamTemperature float64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamTemperature = gjson.GetBytes(body, "temperature").Float()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet\",\"content\":[]}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"hi\"}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_stop\",\"index\":0}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						"temperature": 0.25,
+					},
+				},
+			},
+		},
+	}
+	executor := NewClaudeExecutor(cfg)
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+
+	payload := []byte(`{
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}],
+		"temperature":0.9
+	}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if upstreamTemperature != 0.25 {
+		t.Fatalf("upstream temperature = %v, want %v", upstreamTemperature, 0.25)
+	}
+	if got := gjson.GetBytes(resp.Payload, "temperature").Float(); got != 0.9 {
+		t.Fatalf("response temperature = %v, want %v, payload=%s", got, 0.9, string(resp.Payload))
+	}
+}
+
+func TestClaudeExecutor_ErrorPaths_RestoreOriginalToolNamesAfterNormalization(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(fmt.Sprintf(`{
+			"type":"error",
+			"error":{
+				"type":"invalid_request_error",
+				"message":"tool %s failed validation"
+			}
+		}`, upstreamRequestName)))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{
+		"tools":[{"type":"custom","name":"very bad tool","input_schema":{"type":"object"}}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+
+	checkErr := func(t *testing.T, name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
+		var status statusErr
+		if !errors.As(err, &status) {
+			t.Fatalf("%s: expected statusErr, got %T: %v", name, err, err)
+		}
+		if status.StatusCode() != http.StatusBadRequest {
+			t.Fatalf("%s: status code = %d, want %d", name, status.StatusCode(), http.StatusBadRequest)
+		}
+		if upstreamRequestName == "" || upstreamRequestName == "very bad tool" {
+			t.Fatalf("%s: upstream request tool name = %q, want normalized name", name, upstreamRequestName)
+		}
+		if !strings.Contains(err.Error(), "very bad tool") {
+			t.Fatalf("%s: expected restored original tool name in error, got %q", name, err.Error())
+		}
+		if strings.Contains(err.Error(), upstreamRequestName) {
+			t.Fatalf("%s: error should not expose normalized tool name %q, got %q", name, upstreamRequestName, err.Error())
+		}
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "Execute", err)
+
+	_, err = executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "ExecuteStream", err)
+
+	_, err = executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "CountTokens", err)
+}
+
+func TestClaudeExecutor_ErrorPaths_LeavePlainTextErrorsVerbatim(t *testing.T) {
+	var upstreamRequestName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamRequestName = gjson.GetBytes(body, "tools.0.name").String()
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("read timeout while calling upstream"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{
+		"tools":[{"type":"custom","name":"read!","input_schema":{"type":"object"}}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+
+	checkErr := func(t *testing.T, name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
+		var status statusErr
+		if !errors.As(err, &status) {
+			t.Fatalf("%s: expected statusErr, got %T: %v", name, err, err)
+		}
+		if status.StatusCode() != http.StatusBadRequest {
+			t.Fatalf("%s: status code = %d, want %d", name, status.StatusCode(), http.StatusBadRequest)
+		}
+		if upstreamRequestName != "read" {
+			t.Fatalf("%s: upstream request tool name = %q, want %q", name, upstreamRequestName, "read")
+		}
+		if got := err.Error(); got != "read timeout while calling upstream" {
+			t.Fatalf("%s: error text = %q, want %q", name, got, "read timeout while calling upstream")
+		}
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "Execute", err)
+
+	_, err = executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "ExecuteStream", err)
+
+	_, err = executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "CountTokens", err)
+}
+
+func collectSSEDataPayloads(chunks []string) []gjson.Result {
+	var payloads []gjson.Result
+	for _, chunk := range chunks {
+		for _, line := range strings.Split(chunk, "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "data:") {
+				continue
+			}
+			raw := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if raw == "" || !gjson.Valid(raw) {
+				continue
+			}
+			payloads = append(payloads, gjson.Parse(raw))
+		}
+	}
+	return payloads
+}
+
+func openAIResponseToolChoiceName(payload gjson.Result) string {
+	for _, path := range []string{
+		"tool_choice.function.name",
+		"tool_choice.name",
+		"response.tool_choice.function.name",
+		"response.tool_choice.name",
+	} {
+		if value := payload.Get(path); value.Exists() {
+			return value.String()
+		}
+	}
+	return ""
+}
+
+func TestNormalizeThenPrefix_KeepsCustomNameConsistentWhenSanitizedNameMatchesBuiltin(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"web search"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"web search","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"web search"}]}
+		],
+		"tools":[
+			{"type":"custom","name":"web search","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	normalized, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	prefixed := applyClaudeToolPrefix(normalized, "proxy_")
+
+	normalizedName := gjson.GetBytes(normalized, "tools.0.name").String()
+	if normalizedName == "" {
+		t.Fatal("normalized tool name should not be empty")
+	}
+	expectedPrefixedName := "proxy_" + normalizedName
+	if got := gjson.GetBytes(prefixed, "tools.0.name").String(); got != expectedPrefixedName {
+		t.Fatalf("tools.0.name = %q, want %q", got, expectedPrefixedName)
+	}
+	if got := gjson.GetBytes(prefixed, "tool_choice.name").String(); got != expectedPrefixedName {
+		t.Fatalf("tool_choice.name = %q, want %q", got, expectedPrefixedName)
+	}
+	if got := gjson.GetBytes(prefixed, "messages.0.content.0.name").String(); got != expectedPrefixedName {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, expectedPrefixedName)
+	}
+	if got := gjson.GetBytes(prefixed, "messages.1.content.0.tool_name").String(); got != expectedPrefixedName {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, expectedPrefixedName)
+	}
+}
+
+func TestNormalizeThenPrefix_PreservesUnknownExplicitTypedToolName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"future_one"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"future_one","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"future_one"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"future_one"}]}]}
+		],
+		"tools":[
+			{"type":"future_tool","name":"future_one","extra":{"a":1}}
+		]
+	}`)
+
+	normalized, err := normalizeClaudeToolsForAnthropic(input)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error: %v", err)
+	}
+	prefixed := applyClaudeToolPrefix(normalized, "proxy_")
+
+	if got := gjson.GetBytes(prefixed, "tools.0.name").String(); got != "future_one" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(prefixed, "tool_choice.name").String(); got != "future_one" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(prefixed, "messages.0.content.0.name").String(); got != "future_one" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(prefixed, "messages.1.content.0.tool_name").String(); got != "future_one" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "future_one")
+	}
+	if got := gjson.GetBytes(prefixed, "messages.2.content.0.content.0.tool_name").String(); got != "future_one" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "future_one")
+	}
+}
+
+func TestNormalizeThenPrefix_RejectsAmbiguousExplicitTypedAndCustomSharedName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"future_one"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"future_one","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"future_one"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"future_one"}]}]}
+		],
+		"tools":[
+			{"type":"future_tool","name":"future_one","extra":{"a":1}},
+			{"type":"custom","name":"future_one","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want ambiguous-name rejection")
+	}
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
+	}
+}
+
+func TestNormalizeThenPrefix_RejectsAmbiguousBuiltinAndCustomSharedName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"web_search"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"web_search","id":"ws1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"web_search"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"ws1","content":[{"type":"tool_reference","tool_name":"web_search"}]}]}
+		],
+		"tools":[
+			{"type":"web_search_20250305","name":"web_search"},
+			{"type":"custom","name":"web_search","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want ambiguous-name rejection")
+	}
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
+	}
+}
+
+func TestNormalizeThenPrefix_RejectsDuplicateOpenAIFunctionFallbackName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"duplicate tool"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"duplicate tool","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"duplicate tool"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"duplicate tool"}]}]}
+		],
+		"tools":[
+			{"type":"function","function":{"name":"duplicate tool","description":"first","parameters":{"type":"object"}}},
+			{"type":"function","function":{"name":"duplicate tool","description":"second","parameters":{"type":"object"}}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want duplicate-name rejection")
+	}
+	if !errors.Is(err, errAnthropicDuplicateToolName) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicDuplicateToolName", err)
+	}
+}
+
+func TestNormalizeThenPrefix_RejectsUnsanitizableOpenAIFunctionFallbackName(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"!!!"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"!!!","id":"t1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"!!!"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"tool_reference","tool_name":"!!!"}]}]}
+		],
+		"tools":[
+			{"type":"function","function":{"name":"!!!","description":"bad","parameters":{"type":"object"}}}
+		]
+	}`)
+
+	_, err := normalizeClaudeToolsForAnthropic(input)
+	if err == nil {
+		t.Fatal("normalizeClaudeToolsForAnthropic error = nil, want invalid-name rejection")
+	}
+	if !errors.Is(err, errAnthropicToolNameUnsanitizable) {
+		t.Fatalf("normalizeClaudeToolsForAnthropic error = %v, want errAnthropicToolNameUnsanitizable", err)
+	}
+}
+
+func TestRestoreClaudeNormalizedToolNamesInRequest_RestoresToolsAndReferences(t *testing.T) {
+	input := []byte(`{
+		"tool_choice":{"type":"tool","name":"search_tool"},
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","name":"search_tool","id":"toolu_1","input":{}}]},
+			{"role":"user","content":[{"type":"tool_reference","tool_name":"search_tool"}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":[{"type":"tool_reference","tool_name":"search_tool"}]}]}
+		],
+		"tools":[
+			{"name":"search_tool","type":"custom","input_schema":{"type":"object"}}
+		]
+	}`)
+
+	out := restoreClaudeNormalizedToolNamesInRequest(input, map[string]string{
+		"search_tool": "search tool",
+	})
+
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "search tool" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "search tool")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "search tool" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "search tool")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "search tool" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "search tool")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_name").String(); got != "search tool" {
+		t.Fatalf("messages.1.content.0.tool_name = %q, want %q", got, "search tool")
+	}
+	if got := gjson.GetBytes(out, "messages.2.content.0.content.0.tool_name").String(); got != "search tool" {
+		t.Fatalf("messages.2.content.0.content.0.tool_name = %q, want %q", got, "search tool")
+	}
+}
+
+func TestRestoreClaudeToolNamesInErrorText_PrefersLongerNormalizedNames(t *testing.T) {
+	text := "tool read_more failed validation while read stayed valid"
+	out := restoreClaudeToolNamesInErrorText(text, "", map[string]string{
+		"read":      "read!",
+		"read_more": "read more!",
+	})
+
+	if strings.Contains(out, "read!_more") {
+		t.Fatalf("restored text = %q, should not partially replace overlapping normalized names", out)
+	}
+	if got := out; got != "tool read more! failed validation while read! stayed valid" {
+		t.Fatalf("restored text = %q, want %q", got, "tool read more! failed validation while read! stayed valid")
+	}
+}
+
 func hasTTLOrderingViolation(payload []byte) bool {
 	seen5m := false
 	violates := false
@@ -1246,16 +2830,31 @@ func testClaudeExecutorInvalidCompressedErrorBody(
 	}}
 	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
 
+	checkErr := func(t *testing.T, name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
+		var status statusErr
+		if !errors.As(err, &status) {
+			t.Fatalf("%s: expected statusErr, got %T: %v", name, err, err)
+		}
+		if got := status.StatusCode(); got != http.StatusBadRequest {
+			t.Fatalf("%s: status code = %d, want %d", name, got, http.StatusBadRequest)
+		}
+		errText := strings.ToLower(err.Error())
+		if !strings.Contains(errText, "failed to read upstream error body") &&
+			!strings.Contains(errText, "failed to decode upstream error body") &&
+			!strings.Contains(errText, "failed to decode error response body") {
+			t.Fatalf("%s: expected read/decode failure context, got %q", name, err.Error())
+		}
+		if !strings.Contains(errText, "gzip") && !strings.Contains(errText, "eof") && !strings.Contains(errText, "checksum") {
+			t.Fatalf("%s: expected gzip read failure, got %q", name, err.Error())
+		}
+	}
+
 	err := invoke(executor, auth, payload)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "failed to decode error response body") {
-		t.Fatalf("expected decode failure message, got: %v", err)
-	}
-	if statusProvider, ok := err.(interface{ StatusCode() int }); !ok || statusProvider.StatusCode() != http.StatusBadRequest {
-		t.Fatalf("expected status code 400, got: %v", err)
-	}
+	checkErr(t, "invoke", err)
 }
 
 func TestEnsureModelMaxTokens_UsesRegisteredMaxCompletionTokens(t *testing.T) {
@@ -2026,4 +3625,67 @@ func TestRemapOAuthToolNames_Lowercase_ReverseApplied(t *testing.T) {
 	if got := gjson.GetBytes(reversed, "content.0.name").String(); got != "bash" {
 		t.Fatalf("content.0.name = %q, want %q", got, "bash")
 	}
+}
+
+func TestClaudeExecutor_PreservesStatusOnCompressedErrorDecodeFailure(t *testing.T) {
+	invalidGzip := []byte("not-a-gzip-stream")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(invalidGzip)
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	checkErr := func(t *testing.T, name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
+		var status statusErr
+		if !errors.As(err, &status) {
+			t.Fatalf("%s: expected statusErr, got %T: %v", name, err, err)
+		}
+		if got := status.StatusCode(); got != http.StatusBadRequest {
+			t.Fatalf("%s: status code = %d, want %d", name, got, http.StatusBadRequest)
+		}
+		errText := strings.ToLower(err.Error())
+		if !strings.Contains(errText, "failed to decode upstream error body") &&
+			!strings.Contains(errText, "failed to decode error response body") {
+			t.Fatalf("%s: expected decode failure context, got %q", name, err.Error())
+		}
+		if !strings.Contains(errText, "gzip") {
+			t.Fatalf("%s: expected gzip decode failure details, got %q", name, err.Error())
+		}
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "Execute", err)
+
+	_, err = executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "ExecuteStream", err)
+
+	_, err = executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+	})
+	checkErr(t, "CountTokens", err)
 }

--- a/internal/runtime/executor/helps/payload_helpers.go
+++ b/internal/runtime/executor/helps/payload_helpers.go
@@ -2,6 +2,7 @@ package helps
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -101,11 +102,14 @@ func ApplyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 			if fullPath == "" {
 				continue
 			}
-			updated, errSet := sjson.SetBytes(out, fullPath, value)
-			if errSet != nil {
-				continue
+			targetPaths := expandPayloadQueryPaths(out, fullPath)
+			for j := range targetPaths {
+				updated, errSet := sjson.SetBytes(out, targetPaths[j], value)
+				if errSet != nil {
+					continue
+				}
+				out = updated
 			}
-			out = updated
 		}
 	}
 	// Apply override raw rules: last write wins per field across all matching rules.
@@ -123,11 +127,14 @@ func ApplyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 			if !ok {
 				continue
 			}
-			updated, errSet := sjson.SetRawBytes(out, fullPath, rawValue)
-			if errSet != nil {
-				continue
+			targetPaths := expandPayloadQueryPaths(out, fullPath)
+			for j := range targetPaths {
+				updated, errSet := sjson.SetRawBytes(out, targetPaths[j], rawValue)
+				if errSet != nil {
+					continue
+				}
+				out = updated
 			}
-			out = updated
 		}
 	}
 	// Apply filter rules: remove matching paths from payload.
@@ -141,14 +148,149 @@ func ApplyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 			if fullPath == "" {
 				continue
 			}
-			updated, errDel := sjson.DeleteBytes(out, fullPath)
-			if errDel != nil {
-				continue
+			targetPaths := expandPayloadQueryPaths(out, fullPath)
+			// Delete in reverse to avoid array index shifts when removing elements.
+			for j := len(targetPaths) - 1; j >= 0; j-- {
+				updated, errDel := sjson.DeleteBytes(out, targetPaths[j])
+				if errDel != nil {
+					continue
+				}
+				out = updated
 			}
-			out = updated
 		}
 	}
 	return out
+}
+
+// expandPayloadQueryPaths resolves one or more gjson array query path segments
+// (#(...)) into concrete sjson mutation paths.
+// If no query segment exists, it returns fullPath.
+func expandPayloadQueryPaths(doc []byte, fullPath string) []string {
+	fullPath = strings.TrimSpace(fullPath)
+	if fullPath == "" {
+		return nil
+	}
+	paths := []string{fullPath}
+	for {
+		expandedAny := false
+		next := make([]string, 0, len(paths))
+		for i := range paths {
+			path := strings.TrimSpace(paths[i])
+			if path == "" {
+				continue
+			}
+			queryStart := strings.Index(path, "#(")
+			if queryStart == -1 {
+				next = append(next, path)
+				continue
+			}
+			queryEnd := payloadQueryEnd(path, queryStart+2)
+			if queryEnd == -1 {
+				continue
+			}
+			matches := expandSinglePayloadQueryPath(doc, path, queryStart, queryEnd)
+			if len(matches) == 0 {
+				continue
+			}
+			next = append(next, matches...)
+			expandedAny = true
+		}
+		if len(next) == 0 {
+			return nil
+		}
+		if !expandedAny {
+			return next
+		}
+		paths = next
+	}
+}
+
+func expandSinglePayloadQueryPath(doc []byte, path string, queryStart, queryEnd int) []string {
+	prefixPath := strings.TrimSuffix(path[:queryStart], ".")
+	suffixPath := ""
+	if queryEnd+1 < len(path) {
+		if path[queryEnd+1] != '.' {
+			return nil
+		}
+		suffixPath = strings.TrimPrefix(path[queryEnd+1:], ".")
+	}
+	queryExpr := strings.TrimSpace(path[queryStart+2 : queryEnd])
+	if queryExpr == "" {
+		return nil
+	}
+
+	arrayNode := gjson.ParseBytes(doc)
+	if prefixPath != "" {
+		arrayNode = gjson.GetBytes(doc, prefixPath)
+	}
+	if !arrayNode.Exists() || !arrayNode.IsArray() {
+		return nil
+	}
+
+	matches := make([]string, 0, len(arrayNode.Array()))
+	arrayNode.ForEach(func(index, item gjson.Result) bool {
+		if !payloadQueryItemMatches(item.Raw, queryExpr) {
+			return true
+		}
+		idx := strconv.FormatInt(index.Int(), 10)
+		basePath := idx
+		if prefixPath != "" {
+			basePath = prefixPath + "." + idx
+		}
+		if suffixPath != "" {
+			basePath += "." + suffixPath
+		}
+		matches = append(matches, basePath)
+		return true
+	})
+	return matches
+}
+
+func payloadQueryEnd(path string, start int) int {
+	inQuote := byte(0)
+	escaped := false
+	parenLevel := 0
+	for i := start; i < len(path); i++ {
+		ch := path[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if inQuote != 0 {
+			if ch == inQuote {
+				inQuote = 0
+			}
+			continue
+		}
+		if ch == '"' || ch == '\'' {
+			inQuote = ch
+			continue
+		}
+		switch ch {
+		case '(':
+			parenLevel++
+		case ')':
+			if parenLevel == 0 {
+				return i
+			}
+			parenLevel--
+		}
+	}
+	return -1
+}
+
+func payloadQueryItemMatches(itemRaw, expr string) bool {
+	itemRaw = strings.TrimSpace(itemRaw)
+	if itemRaw == "" || !gjson.Valid(itemRaw) {
+		return false
+	}
+	wrapped := "[" + itemRaw + "]"
+	query := "#(" + expr + ")"
+	return gjson.Get(wrapped, query).Exists()
 }
 
 func payloadModelRulesMatch(rules []config.PayloadModelRule, protocol string, models []string) bool {

--- a/internal/runtime/executor/helps/payload_helpers_test.go
+++ b/internal/runtime/executor/helps/payload_helpers_test.go
@@ -1,0 +1,230 @@
+package helps
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/tidwall/gjson"
+)
+
+func TestApplyPayloadConfigWithRoot_OverrideQueryPath(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						`tools.#(type=="custom").description`: "patched",
+					},
+				},
+			},
+		},
+	}
+	input := []byte(`{"tools":[{"type":"function","name":"alpha"},{"type":"custom","name":"beta"},{"type":"custom","name":"gamma"}]}`)
+	out := ApplyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "tools.0.description"); got.Exists() {
+		t.Fatalf("tools.0.description should not exist, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.1.description").String(); got != "patched" {
+		t.Fatalf("tools.1.description = %q, want %q", got, "patched")
+	}
+	if got := gjson.GetBytes(out, "tools.2.description").String(); got != "patched" {
+		t.Fatalf("tools.2.description = %q, want %q", got, "patched")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_OverrideRawQueryPath(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			OverrideRaw: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						`tools.#(type=="custom").input_schema`: `{"type":"object","properties":{"command":{"type":"string"}}}`,
+					},
+				},
+			},
+		},
+	}
+	input := []byte(`{"tools":[{"type":"function","name":"alpha"},{"type":"custom","name":"beta"}]}`)
+	out := ApplyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "tools.0.input_schema"); got.Exists() {
+		t.Fatalf("tools.0.input_schema should not exist, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.1.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.1.input_schema.type = %q, want %q", got, "object")
+	}
+	if got := gjson.GetBytes(out, "tools.1.input_schema.properties.command.type").String(); got != "string" {
+		t.Fatalf("tools.1.input_schema.properties.command.type = %q, want %q", got, "string")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_FilterQueryPath_RemovesMatchingElements(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Filter: []config.PayloadFilterRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: []string{`tools.#(type=="custom")`},
+				},
+			},
+		},
+	}
+	input := []byte(`{"tools":[{"type":"function","name":"alpha"},{"type":"custom","name":"beta"},{"type":"custom","name":"gamma"}]}`)
+	out := ApplyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	tools := gjson.GetBytes(out, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		t.Fatalf("tools should be an array, got %s", tools.Raw)
+	}
+	arr := tools.Array()
+	if len(arr) != 1 {
+		t.Fatalf("tools length = %d, want 1", len(arr))
+	}
+	if got := arr[0].Get("name").String(); got != "alpha" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "alpha")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_FilterQueryPath_RemovesNestedField(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Filter: []config.PayloadFilterRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: []string{`tools.#(type=="custom").format`},
+				},
+			},
+		},
+	}
+	input := []byte(`{"tools":[{"type":"custom","name":"beta","format":{"syntax":"lark"}},{"type":"function","name":"alpha","format":{"syntax":"json"}}]}`)
+	out := ApplyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "tools.0.format"); got.Exists() {
+		t.Fatalf("tools.0.format should be removed, got %s", got.Raw)
+	}
+	if got := gjson.GetBytes(out, "tools.1.format.syntax").String(); got != "json" {
+		t.Fatalf("tools.1.format.syntax = %q, want %q", got, "json")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_OverrideNestedQueryPath(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						`messages.#(role=="assistant").content.#(type=="tool_use").name`: "patched",
+					},
+				},
+			},
+		},
+	}
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"a"},{"type":"text","text":"ok"}]},{"role":"user","content":[{"type":"tool_use","name":"b"}]}]}`)
+	out := ApplyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "patched" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "patched")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.name").String(); got != "b" {
+		t.Fatalf("messages.1.content.0.name = %q, want %q", got, "b")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_OverrideNestedQueryExpressionPath(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						`messages.#(content.#(type=="tool_use")).tool_present`: true,
+					},
+				},
+			},
+		},
+	}
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"a"},{"type":"text","text":"ok"}]},{"role":"assistant","content":[{"type":"text","text":"plain"}]}]}`)
+	out := ApplyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if !gjson.GetBytes(out, "messages.0.tool_present").Bool() {
+		t.Fatalf("messages.0.tool_present = false, want true")
+	}
+	if got := gjson.GetBytes(out, "messages.1.tool_present"); got.Exists() {
+		t.Fatalf("messages.1.tool_present should not exist, got %s", got.Raw)
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_OverrideRawNestedQueryPath(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			OverrideRaw: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: map[string]any{
+						`messages.#(role=="assistant").content.#(type=="tool_use").input`: `{"command":"run"}`,
+					},
+				},
+			},
+		},
+	}
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"a","input":{}},{"type":"text","text":"ok"}]},{"role":"assistant","content":[{"type":"tool_use","name":"b","input":{}}]}]}`)
+	out := ApplyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "messages.0.content.0.input.command").String(); got != "run" {
+		t.Fatalf("messages.0.content.0.input.command = %q, want %q", got, "run")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.input.command").String(); got != "run" {
+		t.Fatalf("messages.1.content.0.input.command = %q, want %q", got, "run")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_FilterNestedQueryPath_RemovesMatchingNestedElements(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Filter: []config.PayloadFilterRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: []string{`messages.#(role=="assistant").content.#(type=="tool_use")`},
+				},
+			},
+		},
+	}
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","name":"a"},{"type":"text","text":"ok"},{"type":"tool_use","name":"b"}]},{"role":"user","content":[{"type":"tool_use","name":"c"}]}]}`)
+	out := ApplyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if got := gjson.GetBytes(out, "messages.0.content.#").Int(); got != 1 {
+		t.Fatalf("messages.0.content length = %d, want 1", got)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.type").String(); got != "text" {
+		t.Fatalf("messages.0.content.0.type = %q, want %q", got, "text")
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.#").Int(); got != 1 {
+		t.Fatalf("messages.1.content length = %d, want 1", got)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.name").String(); got != "c" {
+		t.Fatalf("messages.1.content.0.name = %q, want %q", got, "c")
+	}
+}
+
+func TestApplyPayloadConfigWithRoot_InvalidQueryPath_NoOp(t *testing.T) {
+	cfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Filter: []config.PayloadFilterRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "claude"}},
+					Params: []string{`tools.#(type=="custom"`},
+				},
+			},
+		},
+	}
+	input := []byte(`{"tools":[{"type":"custom","name":"beta"},{"type":"function","name":"alpha"}]}`)
+	out := ApplyPayloadConfigWithRoot(cfg, "claude-opus-4-6", "claude", "", input, nil, "")
+
+	if string(out) != string(input) {
+		t.Fatalf("invalid query path should leave payload unchanged\ngot:  %s\nwant: %s", string(out), string(input))
+	}
+}

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -354,8 +354,7 @@ func extractClaudeConfig(body []byte) ThinkingConfig {
 	}
 	if thinkingType == "adaptive" || thinkingType == "auto" {
 		// Claude adaptive thinking uses output_config.effort (low/medium/high/max).
-		// We only treat it as a thinking config when effort is explicitly present;
-		// otherwise we passthrough and let upstream defaults apply.
+		// Effort takes precedence when explicitly present.
 		if effort := gjson.GetBytes(body, "output_config.effort"); effort.Exists() && effort.Type == gjson.String {
 			value := strings.ToLower(strings.TrimSpace(effort.String()))
 			if value == "" {
@@ -370,7 +369,47 @@ func extractClaudeConfig(body []byte) ThinkingConfig {
 				return ThinkingConfig{Mode: ModeLevel, Level: ThinkingLevel(value)}
 			}
 		}
+		// Fallback: extract budget_tokens when effort is absent.
+		// Some clients send adaptive+budget_tokens which is invalid upstream;
+		// extracting the budget intent lets the thinking pipeline normalize the
+		// output format instead of passing through the malformed combination.
+		if budget := gjson.GetBytes(body, "thinking.budget_tokens"); budget.Exists() {
+			value := int(budget.Int())
+			switch value {
+			case 0:
+				return ThinkingConfig{Mode: ModeNone, Budget: 0}
+			case -1:
+				return ThinkingConfig{Mode: ModeAuto, Budget: -1}
+			default:
+				return ThinkingConfig{Mode: ModeBudget, Budget: value}
+			}
+		}
+		// No effort, no budget_tokens → passthrough (valid adaptive request).
 		return ThinkingConfig{}
+	}
+
+	// Check output_config.effort first for Opus 4.6+ style effort control.
+	// Ignore non-string or empty effort values so budget_tokens can still apply.
+	if effort := gjson.GetBytes(body, "output_config.effort"); effort.Exists() && effort.Type == gjson.String {
+		switch value := strings.ToLower(strings.TrimSpace(effort.String())); value {
+		case "":
+			// Treat blank effort as unset and fall back to budget_tokens handling below.
+			break
+		case "none":
+			return ThinkingConfig{Mode: ModeNone, Budget: 0}
+		case "auto":
+			return ThinkingConfig{Mode: ModeAuto, Budget: -1}
+		case "max":
+			return ThinkingConfig{Mode: ModeLevel, Level: LevelMax}
+		case "low":
+			return ThinkingConfig{Mode: ModeLevel, Level: LevelLow}
+		case "medium":
+			return ThinkingConfig{Mode: ModeLevel, Level: LevelMedium}
+		case "high":
+			return ThinkingConfig{Mode: ModeLevel, Level: LevelHigh}
+		default:
+			return ThinkingConfig{Mode: ModeLevel, Level: ThinkingLevel(value)}
+		}
 	}
 
 	// Check budget_tokens

--- a/internal/thinking/apply_test.go
+++ b/internal/thinking/apply_test.go
@@ -1,0 +1,149 @@
+package thinking
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestExtractClaudeConfig_AdaptiveBudgetTokensFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want ThinkingConfig
+	}{
+		{
+			name: "adaptive with budget_tokens falls back to budget",
+			body: `{"thinking":{"type":"adaptive","budget_tokens":10000}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 10000},
+		},
+		{
+			name: "auto with budget_tokens falls back to budget",
+			body: `{"thinking":{"type":"auto","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "adaptive with budget_tokens zero returns none",
+			body: `{"thinking":{"type":"adaptive","budget_tokens":0}}`,
+			want: ThinkingConfig{Mode: ModeNone, Budget: 0},
+		},
+		{
+			name: "adaptive with budget_tokens -1 returns auto",
+			body: `{"thinking":{"type":"adaptive","budget_tokens":-1}}`,
+			want: ThinkingConfig{Mode: ModeAuto, Budget: -1},
+		},
+		{
+			name: "adaptive with effort takes precedence over budget_tokens",
+			body: `{"thinking":{"type":"adaptive","budget_tokens":10000},"output_config":{"effort":"high"}}`,
+			want: ThinkingConfig{Mode: ModeLevel, Level: LevelHigh},
+		},
+		{
+			name: "adaptive alone returns empty config (passthrough)",
+			body: `{"thinking":{"type":"adaptive"}}`,
+			want: ThinkingConfig{},
+		},
+		{
+			name: "auto alone returns empty config (passthrough)",
+			body: `{"thinking":{"type":"auto"}}`,
+			want: ThinkingConfig{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractClaudeConfig([]byte(tt.body))
+			if got.Mode != tt.want.Mode || got.Budget != tt.want.Budget || got.Level != tt.want.Level {
+				t.Fatalf("extractClaudeConfig() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyThinking_AdaptiveBudgetTokensNormalized(t *testing.T) {
+	// End-to-end: verify that adaptive+budget_tokens input is normalized to
+	// enabled+budget_tokens (a valid Claude API combination) instead of being
+	// passed through as the invalid adaptive+budget_tokens combination.
+	body := []byte(`{"thinking":{"type":"adaptive","budget_tokens":10000},"model":"claude-sonnet-4-6","max_tokens":16384}`)
+	result, err := ApplyThinking(body, "claude-sonnet-4-6", "claude", "claude", "claude")
+	if err != nil {
+		t.Fatalf("ApplyThinking returned error: %v", err)
+	}
+	// thinking.type must be "enabled" — the budget was extracted as ModeBudget
+	// and the applier converts that to manual thinking with the given budget.
+	thinkingType := gjson.GetBytes(result, "thinking.type").String()
+	if thinkingType != "enabled" {
+		t.Fatalf("expected thinking.type=enabled, got %q in: %s", thinkingType, string(result))
+	}
+	// budget_tokens is valid with type="enabled", so it should be present.
+	if !gjson.GetBytes(result, "thinking.budget_tokens").Exists() {
+		t.Fatalf("budget_tokens should be present with type=enabled: %s", string(result))
+	}
+}
+
+func TestExtractClaudeConfig_UsesOutputConfigEffort(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want ThinkingConfig
+	}{
+		{
+			name: "preserves max effort",
+			body: `{"output_config":{"effort":"max"},"thinking":{"type":"adaptive"}}`,
+			want: ThinkingConfig{Mode: ModeLevel, Level: "max"},
+		},
+		{
+			name: "maps medium directly",
+			body: `{"output_config":{"effort":"medium"}}`,
+			want: ThinkingConfig{Mode: ModeLevel, Level: LevelMedium},
+		},
+		{
+			name: "none disables thinking",
+			body: `{"output_config":{"effort":"none"},"thinking":{"type":"enabled","budget_tokens":2048}}`,
+			want: ThinkingConfig{Mode: ModeNone, Budget: 0},
+		},
+		{
+			name: "effort takes precedence over budget tokens",
+			body: `{"output_config":{"effort":"low"},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeLevel, Level: LevelLow},
+		},
+		{
+			name: "null effort falls back to budget tokens",
+			body: `{"output_config":{"effort":null},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "empty effort falls back to budget tokens",
+			body: `{"output_config":{"effort":""},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "whitespace effort falls back to budget tokens",
+			body: `{"output_config":{"effort":"   "},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "numeric effort falls back to budget tokens",
+			body: `{"output_config":{"effort":123},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "boolean effort falls back to budget tokens",
+			body: `{"output_config":{"effort":false},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeBudget, Budget: 8192},
+		},
+		{
+			name: "unknown non-empty string still overrides budget tokens",
+			body: `{"output_config":{"effort":"bogus"},"thinking":{"type":"enabled","budget_tokens":8192}}`,
+			want: ThinkingConfig{Mode: ModeLevel, Level: "bogus"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractClaudeConfig([]byte(tt.body))
+			if got.Mode != tt.want.Mode || got.Budget != tt.want.Budget || got.Level != tt.want.Level {
+				t.Fatalf("extractClaudeConfig() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/thinking/provider/antigravity/apply.go
+++ b/internal/thinking/provider/antigravity/apply.go
@@ -184,6 +184,29 @@ func (a *Applier) applyBudgetFormat(body []byte, config thinking.ThinkingConfig,
 	return result, nil
 }
 
+// NormalizeClaudeBudgetPayload applies Claude-specific numeric thinking-budget
+// constraints to an Antigravity payload. It only mutates payloads that already
+// carry a non-negative thinkingBudget.
+func NormalizeClaudeBudgetPayload(payload []byte, modelInfo *registry.ModelInfo) []byte {
+	if modelInfo == nil {
+		return payload
+	}
+
+	budgetValue := gjson.GetBytes(payload, "request.generationConfig.thinkingConfig.thinkingBudget")
+	if !budgetValue.Exists() || budgetValue.Int() < 0 {
+		return payload
+	}
+
+	a := Applier{}
+	budget, normalized := a.normalizeClaudeBudget(int(budgetValue.Int()), payload, modelInfo)
+	if budget == -2 {
+		return normalized
+	}
+
+	normalized, _ = sjson.SetBytes(normalized, "request.generationConfig.thinkingConfig.thinkingBudget", budget)
+	return normalized
+}
+
 // normalizeClaudeBudget applies Claude-specific constraints to thinking budget.
 //
 // It handles:

--- a/internal/thinking/provider/antigravity/apply_test.go
+++ b/internal/thinking/provider/antigravity/apply_test.go
@@ -1,0 +1,65 @@
+package antigravity
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	"github.com/tidwall/gjson"
+)
+
+func TestApply_ClaudeBudgetIsReducedBelowMaxOutputTokens(t *testing.T) {
+	applier := NewApplier()
+	modelInfo := &registry.ModelInfo{
+		ID:                  "claude-opus-4-6-thinking",
+		MaxCompletionTokens: 64000,
+		Thinking: &registry.ThinkingSupport{
+			Min:            1024,
+			Max:            64000,
+			ZeroAllowed:    true,
+			DynamicAllowed: true,
+		},
+	}
+	body := []byte(`{"request":{"generationConfig":{"maxOutputTokens":64000}}}`)
+
+	out, err := applier.Apply(body, thinking.ThinkingConfig{Mode: thinking.ModeBudget, Budget: 64000}, modelInfo)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "request.generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts should remain enabled, body=%s", string(out))
+	}
+}
+
+func TestApply_ClaudeBudgetUsesModelMaxWhenRequestMaxMissing(t *testing.T) {
+	applier := NewApplier()
+	modelInfo := &registry.ModelInfo{
+		ID:                  "claude-opus-4-6-thinking",
+		MaxCompletionTokens: 64000,
+		Thinking: &registry.ThinkingSupport{
+			Min:            1024,
+			Max:            64000,
+			ZeroAllowed:    true,
+			DynamicAllowed: true,
+		},
+	}
+
+	out, err := applier.Apply([]byte(`{"request":{}}`), thinking.ThinkingConfig{Mode: thinking.ModeBudget, Budget: 64000}, modelInfo)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens").Int(); got != 64000 {
+		t.Fatalf("maxOutputTokens = %d, want 64000, body=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); got != 63999 {
+		t.Fatalf("thinkingBudget = %d, want 63999, body=%s", got, string(out))
+	}
+}

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -60,6 +60,13 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 	toHasLevelSupport := toCapability == CapabilityLevelOnly || toCapability == CapabilityHybrid
 	allowClampUnsupported := toHasLevelSupport && !isSameProviderFamily(fromFormat, toFormat)
 
+	// Claude-native effort values must retain Claude semantics even when routed to another provider.
+	// "none"/"auto" are normalized to ModeNone/ModeAuto earlier, so this guard only sees discrete effort levels.
+	// Invalid effort strings like "minimal" or "xhigh" should be rejected rather than normalized.
+	if !fromSuffix && fromFormat == "claude" && toFormat == "antigravity" && config.Mode == ModeLevel && !isValidClaudeEffortLevel(config.Level) {
+		return nil, NewThinkingError(ErrLevelNotSupported, fmt.Sprintf("level %q not supported, valid levels: low, medium, high, max", strings.ToLower(string(config.Level))))
+	}
+
 	// strictBudget determines whether to enforce strict budget range validation.
 	// This applies when: (1) config comes from request body (not suffix), (2) source format is known,
 	// and (3) source and target are in the same provider family. Cross-family or suffix-based configs
@@ -138,6 +145,12 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		}
 	}
 
+	// Claude adaptive models use ModeAuto to request upstream-default adaptive behavior,
+	// so preserve it instead of rewriting to a fixed mid-range budget.
+	if config.Mode == ModeAuto && shouldPreserveAutoMode(fromFormat, toFormat, support) {
+		return &config, nil
+	}
+
 	// Convert ModeAuto to mid-range if dynamic not allowed
 	if config.Mode == ModeAuto && !support.DynamicAllowed {
 		config = convertAutoToMidRange(config, support, toFormat, model)
@@ -162,6 +175,22 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 	}
 
 	return &config, nil
+}
+
+func isValidClaudeEffortLevel(level ThinkingLevel) bool {
+	switch strings.ToLower(strings.TrimSpace(string(level))) {
+	case "low", "medium", "high", "max":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldPreserveAutoMode(fromFormat, toFormat string, support *registry.ThinkingSupport) bool {
+	if support == nil {
+		return false
+	}
+	return fromFormat == "claude" && toFormat == "claude" && len(support.Levels) > 0
 }
 
 // convertAutoToMidRange converts ModeAuto to a mid-range value when dynamic is not allowed.

--- a/internal/thinking/validate_test.go
+++ b/internal/thinking/validate_test.go
@@ -1,0 +1,87 @@
+package thinking_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/antigravity"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/thinking/provider/claude"
+	"github.com/tidwall/gjson"
+)
+
+func TestApplyThinking_ClaudeAdaptiveAutoPreservesUpstreamDefault(t *testing.T) {
+	body := []byte(`{
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"auto"}
+	}`)
+
+	out, err := thinking.ApplyThinking(body, "claude-opus-4-6", "claude", "claude", "claude")
+	if err != nil {
+		t.Fatalf("ApplyThinking() error = %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want %q, body=%s", got, "adaptive", string(out))
+	}
+	if gjson.GetBytes(out, "thinking.budget_tokens").Exists() {
+		t.Fatalf("thinking.budget_tokens should be omitted for adaptive auto, body=%s", string(out))
+	}
+	if gjson.GetBytes(out, "output_config.effort").Exists() {
+		t.Fatalf("output_config.effort should be omitted for adaptive auto, body=%s", string(out))
+	}
+}
+
+func TestApplyThinking_ClaudeCompatAntigravityRejectsInvalidClaudeEffort(t *testing.T) {
+	tests := []struct {
+		name   string
+		effort string
+	}{
+		{name: "minimal", effort: "minimal"},
+		{name: "xhigh", effort: "xhigh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(`{"request":{"generationConfig":{"thinkingConfig":{"thinkingLevel":"` + tt.effort + `","includeThoughts":true}}}}`)
+
+			out, err := thinking.ApplyThinking(body, "claude-opus-4-6-thinking", "claude", "antigravity", "antigravity")
+			if err == nil {
+				t.Fatalf("ApplyThinking() error = nil, body=%s", string(out))
+			}
+
+			thinkingErr, ok := err.(*thinking.ThinkingError)
+			if !ok {
+				t.Fatalf("error type = %T, want *thinking.ThinkingError", err)
+			}
+			if thinkingErr.Code != thinking.ErrLevelNotSupported {
+				t.Fatalf("error code = %q, want %q", thinkingErr.Code, thinking.ErrLevelNotSupported)
+			}
+			if !strings.Contains(thinkingErr.Message, `valid levels: low, medium, high, max`) {
+				t.Fatalf("error message = %q, want valid Claude effort list", thinkingErr.Message)
+			}
+			if string(out) != string(body) {
+				t.Fatalf("returned body should remain unchanged on validation failure\ngot:  %s\nwant: %s", string(out), string(body))
+			}
+		})
+	}
+}
+
+func TestValidateConfig_NonClaudeAutoToClaudeStillClampsToConcreteLevel(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID: "claude-opus-4-6-model",
+		Thinking: &registry.ThinkingSupport{
+			Levels:         []string{"low", "medium", "high", "max"},
+			DynamicAllowed: false,
+		},
+	}
+
+	got, err := thinking.ValidateConfig(thinking.ThinkingConfig{Mode: thinking.ModeAuto, Budget: -1}, modelInfo, "gemini", "claude", false)
+	if err != nil {
+		t.Fatalf("ValidateConfig() error = %v", err)
+	}
+	if got.Mode != thinking.ModeLevel || got.Level != thinking.LevelMedium {
+		t.Fatalf("ValidateConfig() = %+v, want ModeLevel/LevelMedium", *got)
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -220,17 +220,25 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 	case "content_block_stop":
 		idx := int(root.Get("index").Int())
 		if st.InTextBlock {
+			// Replay accumulated text into the streaming `done` events.
+			// Without this, downstream Responses-API consumers (e.g. Codex CLI,
+			// `-o output-last-message`) read the empty done payload and produce
+			// blank output even though deltas carried the full text. See #2194.
+			text := st.TextBuf.String()
 			done := []byte(`{"type":"response.output_text.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"text":"","logprobs":[]}`)
 			done, _ = sjson.SetBytes(done, "sequence_number", nextSeq())
 			done, _ = sjson.SetBytes(done, "item_id", st.CurrentMsgID)
+			done, _ = sjson.SetBytes(done, "text", text)
 			out = append(out, emitEvent("response.output_text.done", done))
 			partDone := []byte(`{"type":"response.content_part.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}`)
 			partDone, _ = sjson.SetBytes(partDone, "sequence_number", nextSeq())
 			partDone, _ = sjson.SetBytes(partDone, "item_id", st.CurrentMsgID)
+			partDone, _ = sjson.SetBytes(partDone, "part.text", text)
 			out = append(out, emitEvent("response.content_part.done", partDone))
 			final := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","text":""}],"role":"assistant"}}`)
 			final, _ = sjson.SetBytes(final, "sequence_number", nextSeq())
 			final, _ = sjson.SetBytes(final, "item.id", st.CurrentMsgID)
+			final, _ = sjson.SetBytes(final, "item.content.0.text", text)
 			out = append(out, emitEvent("response.output_item.done", final))
 			st.InTextBlock = false
 		} else if st.InFuncBlock {

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
@@ -1,0 +1,90 @@
+package responses
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// Regression for #2194: streaming `done` events must replay the accumulated text
+// from prior `output_text.delta` events. Without this, downstream Responses-API
+// consumers (e.g. Codex CLI's -o output-last-message) read empty payloads and
+// produce blank output even though the deltas carried the full text.
+func TestConvertClaudeResponseToOpenAIResponses_AccumulatesTextIntoDoneEvents(t *testing.T) {
+	stream := []string{
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello "}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":2}}`,
+		`data: {"type":"message_stop"}`,
+	}
+
+	var param any
+	var allChunks [][]byte
+	for _, line := range stream {
+		chunks := ConvertClaudeResponseToOpenAIResponses(context.Background(), "claude-haiku-4-5", nil, nil, []byte(line), &param)
+		allChunks = append(allChunks, chunks...)
+	}
+
+	// Each emitted chunk is a single SSE frame: "event: <name>\ndata: <json>".
+	checked := map[string]bool{
+		"response.output_text.done":  false,
+		"response.content_part.done": false,
+		"response.output_item.done":  false,
+	}
+	for _, chunk := range allChunks {
+		text := string(chunk)
+		var eventName, payload string
+		for _, line := range strings.Split(text, "\n") {
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				eventName = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				payload = strings.TrimPrefix(line, "data: ")
+			}
+		}
+		if payload == "" {
+			continue
+		}
+		switch eventName {
+		case "response.output_text.done":
+			if got := gjson.Get(payload, "text").String(); got != "Hello world" {
+				t.Fatalf("output_text.done text = %q, want %q (payload=%s)", got, "Hello world", payload)
+			}
+			checked[eventName] = true
+		case "response.content_part.done":
+			if got := gjson.Get(payload, "part.text").String(); got != "Hello world" {
+				t.Fatalf("content_part.done part.text = %q, want %q (payload=%s)", got, "Hello world", payload)
+			}
+			checked[eventName] = true
+		case "response.output_item.done":
+			if got := gjson.Get(payload, "item.content.0.text").String(); got != "Hello world" {
+				t.Fatalf("output_item.done item.content.0.text = %q, want %q (payload=%s)", got, "Hello world", payload)
+			}
+			// Codex's ResponseItem deserializer requires `type: "message"` and
+			// `role: "assistant"`. See codex-rs/protocol/src/models.rs.
+			if got := gjson.Get(payload, "item.type").String(); got != "message" {
+				t.Fatalf("output_item.done item.type = %q, want %q (payload=%s)", got, "message", payload)
+			}
+			if got := gjson.Get(payload, "item.role").String(); got != "assistant" {
+				t.Fatalf("output_item.done item.role = %q, want %q (payload=%s)", got, "assistant", payload)
+			}
+			checked[eventName] = true
+		}
+	}
+	for name, ok := range checked {
+		if !ok {
+			var dump bytes.Buffer
+			for _, chunk := range allChunks {
+				dump.Write(chunk)
+				dump.WriteByte('\n')
+			}
+			t.Fatalf("did not see expected event %q in stream output:\n%s", name, dump.String())
+		}
+	}
+}

--- a/test/thinking_conversion_test.go
+++ b/test/thinking_conversion_test.go
@@ -2732,6 +2732,16 @@ func TestThinkingE2EClaudeAdaptive_Body(t *testing.T) {
 			inputJSON: `{"model":"claude-sonnet-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`,
 			expectErr: true,
 		},
+		{
+			name:        "C28",
+			from:        "claude",
+			to:          "claude",
+			model:       "claude-budget-model",
+			inputJSON:   `{"model":"claude-budget-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":8192},"output_config":{"effort":null}}`,
+			expectField: "thinking.budget_tokens",
+			expectValue: "8192",
+			expectErr:   false,
+		},
 	}
 
 	runThinkingTests(t, cases)


### PR DESCRIPTION
## Summary

Combines two cohesive Claude/Codex compatibility fixes that previously sat in PR #1766 (stuck on a rebase against current `dev`) and issue #2194 (no PR).

**Closes #1766. Closes #2194.**

This is a successor PR to #1766 — DevGuyRash's branch (originally fix/claude-tool-normalization, last activity 2026-03-17, 6 weeks ago) is rebased onto current `dev` as a single squashed commit, then extended with the #2194 fix. @DevGuyRash is credited as `Co-authored-by` on the commit. If you'd rather I close this and let you push your own rebase, just say the word.

## What's in here

1. **Anthropic tool name/schema normalization** (originally PR #1766). Custom tools sent to Claude are sanitized to satisfy Anthropic's name regex and schema constraints. Original client-facing names are restored on the response (and in error bodies). Wired into `Execute`, `ExecuteStream`, and `CountTokens`.

2. **Antigravity Claude compat fields** (PR #1766). `output_config` is stripped before forwarding through Antigravity; `output_config.effort` drives Claude thinking config (Opus 4.6+ effort control).

3. **Compressed error body decoding** (PR #1766). gzip/deflate/brotli/zstd error responses are decoded before logging.

4. **Dynamic payload query path expansion** (PR #1766). `override`, `overrideRaw`, and `filter` rules support `#(role=="assistant")`-style gjson array selectors.

5. **`X-CPA-CLAUDE-1M` opt-in header** (PR #1766). When set, appends `context-1m-2025-08-07` to `Anthropic-Beta`.

6. **#2194 fix — streaming `done` events replay accumulated text.** The Claude→OpenAI Responses stream translator was emitting empty `text` in `response.output_text.done`, `response.content_part.done`, and `response.output_item.done` even though deltas carried the full text. Codex CLI's `-o output-last-message` reads from the `done` payload, so Claude responses arrived empty even though tokens were billed. Now `TextBuf` is replayed into all three done events, mirroring the function-call path's `FuncArgsBuf`.

   **Root-cause note:** @DevGuyRash's #2194 report also flagged that the item type should be `agent_message`, not `message`. After cross-checking against Codex's `ResponseItem` deserializer (`codex-rs/protocol/src/models.rs`, `#[serde(tag = \"type\", rename_all = \"snake_case\")]`), `\"type\": \"message\"` is correct and already matched what the translator emits. Only the empty-text bug is fixed here. Verified with a live Codex CLI smoke test post-patch.

## Why squash, not rebase

The 30-commit branch had drifted ~370 commits behind `dev` (commit d2c7e4e9 moved executor helpers into a new `helps/` package; request prep got restructured). Conflict at every executor entry point. Squashing into one cohesive change is cleaner to review than re-replaying 30 commits with manual resolution at each step.

## Trade-offs vs the original PR

- **Dropped the `finalizeClaudeRequestBody` / `claudePreparedBody` helper refactor.** Dev's executor now inlines `ensureAccessToken` and `validateAntigravityRequestSignatures` inside each entry point, and the original helper signature couldn't carry the new arguments without a deeper rework. The *behavior* the helper centralized (apply_thinking, cache-control normalization, tool prefix, OAuth fingerprint mitigation) is preserved at every call site. The new helper functions themselves (`normalizeClaudeToolsForAnthropic`, `sanitizeAnthropicToolName`, `claudeOriginalRequestForTranslation`, `restoreClaudeToolNamesInErrorBody`, …) are all kept and used directly.

- `payload_helpers_test.go` moved into `internal/runtime/executor/helps/` to follow its production file.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (no regressions in any package)
- [x] All PR #1766 tests integrated and passing — including `TestClaudeExecutor_Execute_RestoresOriginalToolNamesAfterNormalization`, `TestClaudeExecutor_ExecuteStream_RestoresOriginalToolNamesAfterNormalization`, `TestApplyClaudeHeaders_MergesBetasWithDefaultsAndClaude1M`, and the `TestSanitizeAntigravityClaudeCompatFields_*` family
- [x] New regression test for #2194: `TestConvertClaudeResponseToOpenAIResponses_AccumulatesTextIntoDoneEvents` (fails on `dev` HEAD, passes here)
- [ ] Live smoke test against a real Claude Pro/Max OAuth subscription with Codex CLI driving `/v1/responses` (will run + post output before we ask for merge)