### PR TITLE
Bridge responses clients to chat-only providers

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_compact_test.go
+++ b/sdk/api/handlers/openai/openai_responses_compact_test.go
@@ -20,6 +20,7 @@ type compactCaptureExecutor struct {
 	alt          string
 	sourceFormat string
 	calls        int
+	err          error
 }
 
 func (e *compactCaptureExecutor) Identifier() string { return "test-provider" }
@@ -28,6 +29,9 @@ func (e *compactCaptureExecutor) Execute(ctx context.Context, auth *coreauth.Aut
 	e.calls++
 	e.alt = opts.Alt
 	e.sourceFormat = opts.SourceFormat.String()
+	if e.err != nil {
+		return coreexecutor.Response{}, e.err
+	}
 	return coreexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
 }
 
@@ -116,5 +120,53 @@ func TestOpenAIResponsesCompactExecute(t *testing.T) {
 	}
 	if strings.TrimSpace(resp.Body.String()) != `{"ok":true}` {
 		t.Fatalf("body = %s", resp.Body.String())
+	}
+}
+
+func TestOpenAIResponsesCompactDoesNotFallbackToChatCompletions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &compactCaptureExecutor{err: statusCodeError{code: http.StatusNotFound, msg: "404 page not found"}}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{
+		ID:       "auth-compact-fallback",
+		Provider: executor.Identifier(),
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"api_key":      "test-key",
+			"compat_name":  executor.Identifier(),
+			"provider_key": executor.Identifier(),
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses/compact", h.Compact)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(`{"model":"test-model","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d, body: %s", resp.Code, http.StatusNotFound, resp.Body.String())
+	}
+	if executor.calls != 1 {
+		t.Fatalf("executor calls = %d, want 1", executor.calls)
+	}
+	if executor.alt != "responses/compact" {
+		t.Fatalf("alt = %q, want %q", executor.alt, "responses/compact")
+	}
+	if executor.sourceFormat != "openai-response" {
+		t.Fatalf("source format = %q, want %q", executor.sourceFormat, "openai-response")
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_fallback_test.go
+++ b/sdk/api/handlers/openai/openai_responses_fallback_test.go
@@ -1,0 +1,201 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+type statusCodeError struct {
+	code int
+	msg  string
+}
+
+func (e statusCodeError) Error() string   { return e.msg }
+func (e statusCodeError) StatusCode() int { return e.code }
+
+type responsesFallbackExecutor struct {
+	calls            []string
+	payloads         [][]byte
+	originalRequests [][]byte
+	responsesErrMsg  string
+	streamPayload    []byte
+}
+
+func (e *responsesFallbackExecutor) Identifier() string { return "test-responses-fallback" }
+
+func (e *responsesFallbackExecutor) Execute(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	e.calls = append(e.calls, opts.SourceFormat.String())
+	e.payloads = append(e.payloads, append([]byte(nil), req.Payload...))
+	e.originalRequests = append(e.originalRequests, append([]byte(nil), opts.OriginalRequest...))
+	if opts.SourceFormat.String() == "openai-response" {
+		return coreexecutor.Response{}, statusCodeError{code: http.StatusNotFound, msg: e.openAIResponsesErrorMessage()}
+	}
+	return coreexecutor.Response{Payload: []byte(`{"id":"chatcmpl-test","object":"chat.completion","created":123,"model":"test-model","choices":[{"index":0,"message":{"role":"assistant","content":"fallback ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}`)}, nil
+}
+
+func (e *responsesFallbackExecutor) ExecuteStream(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	e.calls = append(e.calls, opts.SourceFormat.String())
+	e.payloads = append(e.payloads, append([]byte(nil), req.Payload...))
+	e.originalRequests = append(e.originalRequests, append([]byte(nil), opts.OriginalRequest...))
+	if opts.SourceFormat.String() == "openai-response" {
+		return nil, statusCodeError{code: http.StatusNotFound, msg: e.openAIResponsesErrorMessage()}
+	}
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	chunks <- coreexecutor.StreamChunk{Payload: e.streamPayload}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *responsesFallbackExecutor) openAIResponsesErrorMessage() string {
+	if e.responsesErrMsg != "" {
+		return e.responsesErrMsg
+	}
+	return "404 page not found"
+}
+
+func (e *responsesFallbackExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *responsesFallbackExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *responsesFallbackExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func newResponsesFallbackTestRouter(t *testing.T, executor *responsesFallbackExecutor) *gin.Engine {
+	return newResponsesFallbackTestRouterWithCompatAuth(t, executor, true)
+}
+
+func newResponsesFallbackTestRouterWithCompatAuth(t *testing.T, executor *responsesFallbackExecutor, compatAuth bool) *gin.Engine {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	authID := fmt.Sprintf("auth-%d", time.Now().UnixNano())
+	auth := &coreauth.Auth{ID: authID, Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if compatAuth {
+		auth.Attributes = map[string]string{
+			"api_key":      "test-key",
+			"compat_name":  executor.Identifier(),
+			"provider_key": executor.Identifier(),
+		}
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+	return router
+}
+
+func TestOpenAIResponsesFallbackToChatCompletionsOn404(t *testing.T) {
+	executor := &responsesFallbackExecutor{}
+	router := newResponsesFallbackTestRouter(t, executor)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"test-model","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if got := strings.Join(executor.calls, ","); got != "openai-response,openai" {
+		t.Fatalf("executor calls = %q, want openai-response,openai", got)
+	}
+	body := resp.Body.String()
+	if !strings.Contains(body, `"object":"response"`) || !strings.Contains(body, `"text":"fallback ok"`) {
+		t.Fatalf("body was not converted to responses format: %s", body)
+	}
+	if !strings.Contains(string(executor.payloads[1]), `"messages"`) {
+		t.Fatalf("fallback payload was not chat completions format: %s", string(executor.payloads[1]))
+	}
+	if string(executor.originalRequests[1]) != string(executor.payloads[1]) {
+		t.Fatalf("fallback original request did not match converted payload: original=%s payload=%s", string(executor.originalRequests[1]), string(executor.payloads[1]))
+	}
+}
+
+func TestOpenAIResponsesFallbackRequiresOpenAICompatibleAuth(t *testing.T) {
+	executor := &responsesFallbackExecutor{}
+	router := newResponsesFallbackTestRouterWithCompatAuth(t, executor, false)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"test-model","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d, body: %s", resp.Code, http.StatusNotFound, resp.Body.String())
+	}
+	if got := strings.Join(executor.calls, ","); got != "openai-response" {
+		t.Fatalf("executor calls = %q, want only openai-response", got)
+	}
+}
+
+func TestOpenAIResponsesFallbackRequiresEndpointNotFoundBody(t *testing.T) {
+	executor := &responsesFallbackExecutor{responsesErrMsg: `{"error":{"message":"model not found"}}`}
+	router := newResponsesFallbackTestRouter(t, executor)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"test-model","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d, body: %s", resp.Code, http.StatusNotFound, resp.Body.String())
+	}
+	if got := strings.Join(executor.calls, ","); got != "openai-response" {
+		t.Fatalf("executor calls = %q, want only openai-response", got)
+	}
+}
+
+func TestOpenAIResponsesStreamFallbackToChatCompletionsOn404(t *testing.T) {
+	executor := &responsesFallbackExecutor{
+		streamPayload: []byte(`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":123,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"stream ok"},"finish_reason":"stop"}]}`),
+	}
+	router := newResponsesFallbackTestRouter(t, executor)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"test-model","input":"hello","stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if got := strings.Join(executor.calls, ","); got != "openai-response,openai" {
+		t.Fatalf("executor calls = %q, want openai-response,openai", got)
+	}
+	body := resp.Body.String()
+	if !strings.Contains(body, "response.output_text.delta") || !strings.Contains(body, "stream ok") || !strings.Contains(body, "response.completed") {
+		t.Fatalf("stream was not converted to responses SSE: %s", body)
+	}
+	if string(executor.originalRequests[1]) != string(executor.payloads[1]) {
+		t.Fatalf("fallback original request did not match converted payload: original=%s payload=%s", string(executor.originalRequests[1]), string(executor.payloads[1]))
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -454,12 +454,20 @@ func convertChatCompletionsStreamToResponses(ctx context.Context, modelName stri
 		if !emit(firstChunk) {
 			return
 		}
-		for chunk := range data {
-			if !emit(chunk) {
+		for {
+			select {
+			case <-ctx.Done():
 				return
+			case chunk, ok := <-data:
+				if !ok {
+					_ = emit([]byte("data: [DONE]"))
+					return
+				}
+				if !emit(chunk) {
+					return
+				}
 			}
 		}
-		_ = emit([]byte("data: [DONE]"))
 	}()
 	return out
 }

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/router-for-me/CLIProxyAPI/v6/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	responsesconverter "github.com/router-for-me/CLIProxyAPI/v6/internal/translator/openai/openai/responses"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -331,6 +332,9 @@ func (h *OpenAIResponsesAPIHandler) handleNonStreamingResponse(c *gin.Context, r
 		return
 	}
 	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+	if isChatCompletionsResponse(resp) {
+		resp = responsesconverter.ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(cliCtx, modelName, rawJSON, rawJSON, resp, nil)
+	}
 	_, _ = c.Writer.Write(resp)
 	cliCancel()
 }
@@ -402,6 +406,12 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			// Success! Set headers.
 			setSSEHeaders()
 			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+			if isChatCompletionsStreamChunk(chunk) {
+				convertedChan := convertChatCompletionsStreamToResponses(cliCtx, modelName, rawJSON, chunk, dataChan)
+				fallbackFramer := &responsesSSEFramer{}
+				h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, convertedChan, errChan, fallbackFramer)
+				return
+			}
 
 			// Write first chunk logic (matching forwardResponsesStream)
 			framer.WriteChunk(c.Writer, chunk)
@@ -412,6 +422,46 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			return
 		}
 	}
+}
+
+func isChatCompletionsResponse(rawJSON []byte) bool {
+	return gjson.GetBytes(rawJSON, "object").String() == "chat.completion"
+}
+
+func isChatCompletionsStreamChunk(rawJSON []byte) bool {
+	if bytes.HasPrefix(bytes.TrimSpace(rawJSON), []byte("data:")) {
+		rawJSON = bytes.TrimSpace(bytes.TrimSpace(rawJSON)[5:])
+	}
+	return gjson.GetBytes(rawJSON, "object").String() == "chat.completion.chunk"
+}
+
+func convertChatCompletionsStreamToResponses(ctx context.Context, modelName string, rawJSON []byte, firstChunk []byte, data <-chan []byte) <-chan []byte {
+	out := make(chan []byte)
+	go func() {
+		defer close(out)
+		var param any
+		emit := func(chunk []byte) bool {
+			converted := responsesconverter.ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx, modelName, rawJSON, rawJSON, chunk, &param)
+			for i := range converted {
+				select {
+				case <-ctx.Done():
+					return false
+				case out <- converted[i]:
+				}
+			}
+			return true
+		}
+		if !emit(firstChunk) {
+			return
+		}
+		for chunk := range data {
+			if !emit(chunk) {
+				return
+			}
+		}
+		_ = emit([]byte("data: [DONE]"))
+	}()
+	return out
 }
 
 func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage, framer *responsesSSEFramer) {

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -463,6 +463,11 @@ func convertChatCompletionsStreamToResponses(ctx context.Context, modelName stri
 					_ = emit([]byte("data: [DONE]"))
 					return
 				}
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
 				if !emit(chunk) {
 					return
 				}

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -190,7 +190,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 		dataChan, _, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, requestJSON, "")
 
-		completedOutput, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, &wsTimelineLog, passthroughSessionID)
+		completedOutput, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, &wsTimelineLog, passthroughSessionID, modelName, requestJSON)
 		if errForward != nil {
 			wsTerminateErr = errForward
 			log.Warnf("responses websocket: forward failed id=%s error=%v", passthroughSessionID, errForward)
@@ -711,9 +711,12 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 	errs <-chan *interfaces.ErrorMessage,
 	wsTimelineLog *strings.Builder,
 	sessionID string,
+	modelName string,
+	requestJSON []byte,
 ) ([]byte, error) {
 	completed := false
 	completedOutput := []byte("[]")
+	chatCompletionsFallback := false
 	downstreamSessionKey := ""
 	if c != nil && c.Request != nil {
 		downstreamSessionKey = websocketDownstreamSessionKey(c.Request)
@@ -789,6 +792,12 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 				}
 				cancel(nil)
 				return completedOutput, nil
+			}
+
+			if !chatCompletionsFallback && isChatCompletionsStreamChunk(chunk) {
+				chatCompletionsFallback = true
+				data = convertChatCompletionsStreamToResponses(c.Request.Context(), modelName, requestJSON, chunk, data)
+				continue
 			}
 
 			payloads := websocketJSONPayloadsFromChunk(chunk)

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -190,7 +190,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 		dataChan, _, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, requestJSON, "")
 
-		completedOutput, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, &wsTimelineLog, passthroughSessionID, modelName, requestJSON)
+		completedOutput, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, &wsTimelineLog, passthroughSessionID, modelName, requestJSON, cliCtx)
 		if errForward != nil {
 			wsTerminateErr = errForward
 			log.Warnf("responses websocket: forward failed id=%s error=%v", passthroughSessionID, errForward)
@@ -713,6 +713,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 	sessionID string,
 	modelName string,
 	requestJSON []byte,
+	turnCtx context.Context,
 ) ([]byte, error) {
 	completed := false
 	completedOutput := []byte("[]")
@@ -720,6 +721,9 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 	downstreamSessionKey := ""
 	if c != nil && c.Request != nil {
 		downstreamSessionKey = websocketDownstreamSessionKey(c.Request)
+	}
+	if turnCtx == nil {
+		turnCtx = c.Request.Context()
 	}
 
 	for {
@@ -796,7 +800,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 
 			if !chatCompletionsFallback && isChatCompletionsStreamChunk(chunk) {
 				chatCompletionsFallback = true
-				data = convertChatCompletionsStreamToResponses(c.Request.Context(), modelName, requestJSON, chunk, data)
+				data = convertChatCompletionsStreamToResponses(turnCtx, modelName, requestJSON, chunk, data)
 				continue
 			}
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -691,6 +691,7 @@ func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 			"session-1",
 			"test-model",
 			[]byte(`{"model":"test-model","input":"hello","stream":true}`),
+			ctx.Request.Context(),
 		)
 		if err != nil {
 			serverErrCh <- err
@@ -773,6 +774,7 @@ func TestForwardResponsesWebsocketConvertsChatCompletionsFallback(t *testing.T) 
 			"session-1",
 			"test-model",
 			[]byte(`{"model":"test-model","input":"hello","stream":true}`),
+			ctx.Request.Context(),
 		)
 		if err != nil {
 			serverErrCh <- err
@@ -832,6 +834,88 @@ func TestForwardResponsesWebsocketConvertsChatCompletionsFallback(t *testing.T) 
 	}
 }
 
+func TestForwardResponsesWebsocketCancelsFallbackConverterWithTurnContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() {
+			errClose := conn.Close()
+			if errClose != nil {
+				serverErrCh <- errClose
+			}
+		}()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte, 1)
+		errCh := make(chan *interfaces.ErrorMessage, 1)
+		data <- []byte(`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":123,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}`)
+		errCh <- &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errors.New("upstream stopped")}
+		close(errCh)
+
+		turnCtx, turnCancel := context.WithCancel(ctx.Request.Context())
+		defer turnCancel()
+		h := &OpenAIResponsesAPIHandler{BaseAPIHandler: handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)}
+		_, err = h.forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(args ...interface{}) { turnCancel() },
+			data,
+			errCh,
+			&strings.Builder{},
+			"session-1",
+			"test-model",
+			[]byte(`{"model":"test-model","input":"hello","stream":true}`),
+			turnCtx,
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+
+		select {
+		case data <- []byte(`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":123,"model":"test-model","choices":[{"index":0,"delta":{"content":"blocked if converter leaked"},"finish_reason":"stop"}]}`):
+			serverErrCh <- errors.New("fallback converter still consumed data after turn cancellation")
+		case <-time.After(100 * time.Millisecond):
+			serverErrCh <- nil
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		errClose := conn.Close()
+		if errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	for {
+		_, payload, errReadMessage := conn.ReadMessage()
+		if errReadMessage != nil {
+			t.Fatalf("read websocket message: %v", errReadMessage)
+		}
+		if gjson.GetBytes(payload, "type").String() == "error" {
+			break
+		}
+	}
+
+	if errServer := <-serverErrCh; errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
 func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -868,6 +952,7 @@ func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing
 			"session-1",
 			"test-model",
 			[]byte(`{"model":"test-model","input":"hello","stream":true}`),
+			ctx.Request.Context(),
 		)
 		if err == nil {
 			serverErrCh <- errors.New("expected websocket write failure")

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -689,6 +689,8 @@ func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 			errCh,
 			&timelineLog,
 			"session-1",
+			"test-model",
+			[]byte(`{"model":"test-model","input":"hello","stream":true}`),
 		)
 		if err != nil {
 			serverErrCh <- err
@@ -734,6 +736,102 @@ func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 	}
 }
 
+func TestForwardResponsesWebsocketConvertsChatCompletionsFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() {
+			errClose := conn.Close()
+			if errClose != nil {
+				serverErrCh <- errClose
+			}
+		}()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte, 1)
+		errCh := make(chan *interfaces.ErrorMessage)
+		data <- []byte(`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":123,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"websocket fallback ok"},"finish_reason":"stop"}]}`)
+		close(data)
+		close(errCh)
+
+		var timelineLog strings.Builder
+		completedOutput, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			&timelineLog,
+			"session-1",
+			"test-model",
+			[]byte(`{"model":"test-model","input":"hello","stream":true}`),
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		if !strings.Contains(string(completedOutput), "websocket fallback ok") {
+			serverErrCh <- fmt.Errorf("completed output did not include fallback text: %s", completedOutput)
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		errClose := conn.Close()
+		if errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	seenDelta := false
+	seenCompleted := false
+	deadline := time.After(2 * time.Second)
+	for !seenCompleted {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for converted websocket response")
+		default:
+		}
+		_, payload, errReadMessage := conn.ReadMessage()
+		if errReadMessage != nil {
+			t.Fatalf("read websocket message: %v", errReadMessage)
+		}
+		eventType := gjson.GetBytes(payload, "type").String()
+		switch eventType {
+		case "response.output_text.delta":
+			if strings.Contains(string(payload), "websocket fallback ok") {
+				seenDelta = true
+			}
+		case wsEventTypeCompleted:
+			seenCompleted = true
+		case "error":
+			t.Fatalf("unexpected websocket error payload: %s", payload)
+		}
+	}
+	if !seenDelta {
+		t.Fatal("did not receive converted output text delta")
+	}
+
+	if errServer := <-serverErrCh; errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
 func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -768,6 +866,8 @@ func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing
 			errCh,
 			&timelineLog,
 			"session-1",
+			"test-model",
+			[]byte(`{"model":"test-model","input":"hello","stream":true}`),
 		)
 		if err == nil {
 			serverErrCh <- errors.New("expected websocket write failure")

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -834,13 +834,19 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		execReq := req
 		execReq.Model = execModel
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, opts)
+		fallbackAttempted := false
 		if shouldFallbackOpenAIResponsesToChatCompletions(auth, opts, errStream) {
+			fallbackAttempted = true
+			responsesErr := errStream
 			fallbackOpts := opts
 			fallbackOpts.SourceFormat = sdktranslator.FormatOpenAI
 			fallbackPayload := sdktranslator.TranslateRequest(sdktranslator.FormatOpenAIResponse, sdktranslator.FormatOpenAI, execModel, execReq.Payload, fallbackOpts.Stream)
 			execReq.Payload = fallbackPayload
 			fallbackOpts.OriginalRequest = fallbackPayload
 			streamResult, errStream = executor.ExecuteStream(ctx, auth, execReq, fallbackOpts)
+			if errStream != nil {
+				errStream = fallbackAttemptError{fallback: errStream, original: responsesErr}
+			}
 		}
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
@@ -853,7 +859,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 			result.RetryAfter = retryAfterFromError(errStream)
 			m.MarkResult(ctx, result)
-			if isRequestInvalidError(errStream) {
+			if !fallbackAttempted && isRequestInvalidError(errStream) {
 				return nil, errStream
 			}
 			lastErr = errStream
@@ -1202,7 +1208,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 			return resp, nil
 		}
 		lastErr = errExec
-		wait, shouldRetry := m.shouldRetryAfterError(errExec, attempt, normalized, req.Model, maxWait)
+		wait, shouldRetry := m.shouldRetryAfterError(retryBasisError(errExec), attempt, normalized, req.Model, maxWait)
 		if !shouldRetry {
 			break
 		}
@@ -1268,7 +1274,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 			return result, nil
 		}
 		lastErr = errStream
-		wait, shouldRetry := m.shouldRetryAfterError(errStream, attempt, normalized, req.Model, maxWait)
+		wait, shouldRetry := m.shouldRetryAfterError(retryBasisError(errStream), attempt, normalized, req.Model, maxWait)
 		if !shouldRetry {
 			break
 		}
@@ -1337,13 +1343,19 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			execReq := req
 			execReq.Model = upstreamModel
 			resp, errExec := executor.Execute(execCtx, auth, execReq, opts)
+			fallbackAttempted := false
 			if shouldFallbackOpenAIResponsesToChatCompletions(auth, opts, errExec) {
+				fallbackAttempted = true
+				responsesErr := errExec
 				fallbackOpts := opts
 				fallbackOpts.SourceFormat = sdktranslator.FormatOpenAI
 				fallbackPayload := sdktranslator.TranslateRequest(sdktranslator.FormatOpenAIResponse, sdktranslator.FormatOpenAI, upstreamModel, execReq.Payload, fallbackOpts.Stream)
 				execReq.Payload = fallbackPayload
 				fallbackOpts.OriginalRequest = fallbackPayload
 				resp, errExec = executor.Execute(execCtx, auth, execReq, fallbackOpts)
+				if errExec != nil {
+					errExec = fallbackAttemptError{fallback: errExec, original: responsesErr}
+				}
 			}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
@@ -1358,7 +1370,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 					result.RetryAfter = ra
 				}
 				m.MarkResult(execCtx, result)
-				if isRequestInvalidError(errExec) {
+				if !fallbackAttempted && isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
 				authErr = errExec
@@ -1368,7 +1380,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			return resp, nil
 		}
 		if authErr != nil {
-			if isRequestInvalidError(authErr) {
+			if _, isFallbackErr := authErr.(fallbackAttemptError); !isFallbackErr && isRequestInvalidError(authErr) {
 				return cliproxyexecutor.Response{}, authErr
 			}
 			lastErr = authErr
@@ -1499,7 +1511,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			if errCtx := execCtx.Err(); errCtx != nil {
 				return nil, errCtx
 			}
-			if isRequestInvalidError(errStream) {
+			if _, isFallbackErr := errStream.(fallbackAttemptError); !isFallbackErr && isRequestInvalidError(errStream) {
 				return nil, errStream
 			}
 			lastErr = errStream
@@ -2512,6 +2524,45 @@ func isOpenAIResponsesEndpointNotFoundError(err error) bool {
 		return false
 	}
 	return strings.EqualFold(strings.TrimSpace(err.Error()), "404 page not found")
+}
+
+type fallbackAttemptError struct {
+	fallback error
+	original error
+}
+
+func (e fallbackAttemptError) Error() string {
+	if e.fallback != nil {
+		return e.fallback.Error()
+	}
+	if e.original != nil {
+		return e.original.Error()
+	}
+	return ""
+}
+
+func (e fallbackAttemptError) Unwrap() error {
+	return e.fallback
+}
+
+func (e fallbackAttemptError) StatusCode() int {
+	if se, ok := e.fallback.(interface{ StatusCode() int }); ok && se != nil {
+		if code := se.StatusCode(); code > 0 {
+			return code
+		}
+	}
+	if se, ok := e.original.(interface{ StatusCode() int }); ok && se != nil {
+		return se.StatusCode()
+	}
+	return 0
+}
+
+func retryBasisError(err error) error {
+	var fallbackErr fallbackAttemptError
+	if errors.As(err, &fallbackErr) && fallbackErr.original != nil {
+		return fallbackErr.original
+	}
+	return err
 }
 
 func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2498,6 +2498,9 @@ func shouldFallbackOpenAIResponsesToChatCompletions(auth *Auth, opts cliproxyexe
 	if opts.SourceFormat != sdktranslator.FormatOpenAIResponse {
 		return false
 	}
+	if strings.TrimSpace(opts.Alt) != "" {
+		return false
+	}
 	if !isOpenAICompatAPIKeyAuth(auth) {
 		return false
 	}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -833,6 +834,14 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		execReq := req
 		execReq.Model = execModel
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, opts)
+		if shouldFallbackOpenAIResponsesToChatCompletions(auth, opts, errStream) {
+			fallbackOpts := opts
+			fallbackOpts.SourceFormat = sdktranslator.FormatOpenAI
+			fallbackPayload := sdktranslator.TranslateRequest(sdktranslator.FormatOpenAIResponse, sdktranslator.FormatOpenAI, execModel, execReq.Payload, fallbackOpts.Stream)
+			execReq.Payload = fallbackPayload
+			fallbackOpts.OriginalRequest = fallbackPayload
+			streamResult, errStream = executor.ExecuteStream(ctx, auth, execReq, fallbackOpts)
+		}
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
 				return nil, errCtx
@@ -1328,6 +1337,14 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			execReq := req
 			execReq.Model = upstreamModel
 			resp, errExec := executor.Execute(execCtx, auth, execReq, opts)
+			if shouldFallbackOpenAIResponsesToChatCompletions(auth, opts, errExec) {
+				fallbackOpts := opts
+				fallbackOpts.SourceFormat = sdktranslator.FormatOpenAI
+				fallbackPayload := sdktranslator.TranslateRequest(sdktranslator.FormatOpenAIResponse, sdktranslator.FormatOpenAI, upstreamModel, execReq.Payload, fallbackOpts.Stream)
+				execReq.Payload = fallbackPayload
+				fallbackOpts.OriginalRequest = fallbackPayload
+				resp, errExec = executor.Execute(execCtx, auth, execReq, fallbackOpts)
+			}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -2474,6 +2491,26 @@ func isRequestInvalidError(err error) bool {
 	}
 }
 
+func shouldFallbackOpenAIResponsesToChatCompletions(auth *Auth, opts cliproxyexecutor.Options, err error) bool {
+	if err == nil {
+		return false
+	}
+	if opts.SourceFormat != sdktranslator.FormatOpenAIResponse {
+		return false
+	}
+	if !isOpenAICompatAPIKeyAuth(auth) {
+		return false
+	}
+	return statusCodeFromError(err) == http.StatusNotFound && isOpenAIResponsesEndpointNotFoundError(err)
+}
+
+func isOpenAIResponsesEndpointNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(err.Error()), "404 page not found")
+}
+
 func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {
 	if auth == nil {
 		return
@@ -2886,6 +2923,9 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 
 func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, string, error) {
 	if !m.useSchedulerFastPath() {
+		return m.pickNextMixedLegacy(ctx, providers, model, opts, tried)
+	}
+	if pinnedAuthIDFromMetadata(opts.Metadata) != "" {
 		return m.pickNextMixedLegacy(ctx, providers, model, opts, tried)
 	}
 

--- a/sdk/cliproxy/auth/openai_compat_pool_test.go
+++ b/sdk/cliproxy/auth/openai_compat_pool_test.go
@@ -158,6 +158,54 @@ func (e *authScopedOpenAICompatPoolExecutor) ExecuteCalls() []string {
 	return out
 }
 
+type responsesFallbackInvalidExecutor struct {
+	id string
+
+	mu    sync.Mutex
+	calls []string
+}
+
+func (e *responsesFallbackInvalidExecutor) Identifier() string { return e.id }
+
+func (e *responsesFallbackInvalidExecutor) Execute(_ context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	call := auth.ID + "|" + req.Model + "|" + opts.SourceFormat.String()
+	e.mu.Lock()
+	e.calls = append(e.calls, call)
+	e.mu.Unlock()
+
+	if auth.ID == "chat-only" && opts.SourceFormat.String() == "openai-response" {
+		return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotFound, Message: "404 page not found"}
+	}
+	if auth.ID == "chat-only" && opts.SourceFormat.String() == "openai" {
+		return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusBadRequest, Message: "invalid_request_error: malformed fallback payload"}
+	}
+	return cliproxyexecutor.Response{Payload: []byte(call)}, nil
+}
+
+func (e *responsesFallbackInvalidExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "ExecuteStream not implemented"}
+}
+
+func (e *responsesFallbackInvalidExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *responsesFallbackInvalidExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "CountTokens not implemented"}
+}
+
+func (e *responsesFallbackInvalidExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "HttpRequest not implemented"}
+}
+
+func (e *responsesFallbackInvalidExecutor) Calls() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]string, len(e.calls))
+	copy(out, e.calls)
+	return out
+}
+
 func newOpenAICompatPoolTestManager(t *testing.T, alias string, models []internalconfig.OpenAICompatibilityModel, executor *openAICompatPoolExecutor) *Manager {
 	t.Helper()
 	cfg := &internalconfig.Config{
@@ -208,6 +256,70 @@ func readOpenAICompatStreamPayload(t *testing.T, streamResult *cliproxyexecutor.
 		payload = append(payload, chunk.Payload...)
 	}
 	return string(payload)
+}
+
+func TestManagerExecute_ResponsesFallbackInvalidErrorTriesNextAuth(t *testing.T) {
+	provider := "responses-fallback-invalid"
+	executor := &responsesFallbackInvalidExecutor{id: provider}
+	m := NewManager(nil, &FillFirstSelector{}, nil)
+	m.RegisterExecutor(executor)
+
+	for _, auth := range []*Auth{
+		{
+			ID:       "chat-only",
+			Provider: provider,
+			Status:   StatusActive,
+			Attributes: map[string]string{
+				"api_key":      "test-key-1",
+				"compat_name":  provider,
+				"provider_key": provider,
+			},
+		},
+		{
+			ID:       "native-responses",
+			Provider: provider,
+			Status:   StatusActive,
+			Attributes: map[string]string{
+				"api_key":      "test-key-2",
+				"compat_name":  provider,
+				"provider_key": provider,
+			},
+		},
+	} {
+		if _, err := m.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register auth %s: %v", auth.ID, err)
+		}
+		registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+		defer registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	}
+
+	resp, err := m.Execute(
+		context.Background(),
+		[]string{provider},
+		cliproxyexecutor.Request{Model: "test-model", Payload: []byte(`{"model":"test-model","input":"hello"}`)},
+		cliproxyexecutor.Options{SourceFormat: "openai-response", OriginalRequest: []byte(`{"model":"test-model","input":"hello"}`)},
+	)
+	if err != nil {
+		t.Fatalf("execute error = %v, want success via next auth", err)
+	}
+	if string(resp.Payload) != "native-responses|test-model|openai-response" {
+		t.Fatalf("payload = %q, want native responses auth", string(resp.Payload))
+	}
+
+	got := executor.Calls()
+	want := []string{
+		"chat-only|test-model|openai-response",
+		"chat-only|test-model|openai",
+		"native-responses|test-model|openai-response",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("execute calls = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("execute call %d = %q, want %q (all calls: %v)", i, got[i], want[i], got)
+		}
+	}
 }
 
 func TestManagerExecuteCount_OpenAICompatAliasPoolStopsOnInvalidRequest(t *testing.T) {


### PR DESCRIPTION
Some OpenAI-compatible providers expose /chat/completions but return a plain 404 for /responses. The responses handler now accepts chat completion fallback output and converts it back to Responses API shape, while the auth manager retries only OpenAI-compatible API-key auths for the observed endpoint-missing body.

Constraint: NVIDIA integrate returns HTTP 404 with body '404 page not found' for /v1/responses while /v1/chat/completions is available.

Tested: go test ./sdk/api/handlers/openai ./sdk/cliproxy/auth
Tested: go build -o test-output ./cmd/server