### PR TITLE
Expose Codex subscription expiry in auth files

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -505,17 +505,23 @@ func authProjectID(auth *coreauth.Auth) string {
 }
 
 func extractCodexIDTokenClaims(auth *coreauth.Auth) gin.H {
-	if auth == nil || auth.Metadata == nil {
+	if auth == nil {
 		return nil
 	}
 	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
 		return nil
 	}
-	idTokenRaw, ok := auth.Metadata["id_token"].(string)
-	if !ok {
-		return nil
+	if auth.Metadata != nil {
+		if idTokenRaw, ok := auth.Metadata["id_token"].(string); ok {
+			if claims := extractCodexIDTokenClaimsFromRaw(idTokenRaw); claims != nil {
+				return claims
+			}
+		}
 	}
-	return extractCodexIDTokenClaimsFromRaw(idTokenRaw)
+	if storage, ok := auth.Storage.(*codex.CodexTokenStorage); ok && storage != nil {
+		return extractCodexIDTokenClaimsFromRaw(storage.IDToken)
+	}
+	return nil
 }
 
 func extractCodexIDTokenClaimsFromRaw(idTokenRaw string) gin.H {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -337,6 +337,12 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 				if projectID := strings.TrimSpace(gjson.GetBytes(data, "project_id").String()); projectID != "" {
 					fileData["project_id"] = projectID
 				}
+				if strings.EqualFold(strings.TrimSpace(typeValue), "codex") {
+					if claims := extractCodexIDTokenClaimsFromRaw(gjson.GetBytes(data, "id_token").String()); claims != nil {
+						fileData["id_token"] = claims
+						applyCodexSubscriptionFields(fileData, claims)
+					}
+				}
 				if pv := gjson.GetBytes(data, "priority"); pv.Exists() {
 					switch pv.Type {
 					case gjson.Number:
@@ -440,6 +446,7 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	}
 	if claims := extractCodexIDTokenClaims(auth); claims != nil {
 		entry["id_token"] = claims
+		applyCodexSubscriptionFields(entry, claims)
 	}
 	// Expose priority from Attributes (set by synthesizer from JSON "priority" field).
 	// Fall back to Metadata for auths registered via UploadAuthFile (no synthesizer).
@@ -508,6 +515,10 @@ func extractCodexIDTokenClaims(auth *coreauth.Auth) gin.H {
 	if !ok {
 		return nil
 	}
+	return extractCodexIDTokenClaimsFromRaw(idTokenRaw)
+}
+
+func extractCodexIDTokenClaimsFromRaw(idTokenRaw string) gin.H {
 	idToken := strings.TrimSpace(idTokenRaw)
 	if idToken == "" {
 		return nil
@@ -530,11 +541,40 @@ func extractCodexIDTokenClaims(auth *coreauth.Auth) gin.H {
 	if v := claims.CodexAuthInfo.ChatgptSubscriptionActiveUntil; v != nil {
 		result["chatgpt_subscription_active_until"] = v
 	}
+	if v := claims.CodexAuthInfo.ChatgptSubscriptionLastChecked; !v.IsZero() {
+		result["chatgpt_subscription_last_checked"] = v
+	}
 
 	if len(result) == 0 {
 		return nil
 	}
 	return result
+}
+
+func applyCodexSubscriptionFields(entry gin.H, claims gin.H) {
+	if entry == nil || claims == nil {
+		return
+	}
+	if v, ok := claims["plan_type"]; ok {
+		entry["plan_type"] = v
+	}
+
+	subscription := gin.H{}
+	if v, ok := claims["chatgpt_subscription_active_start"]; ok {
+		entry["subscription_active_start"] = v
+		subscription["active_start"] = v
+	}
+	if v, ok := claims["chatgpt_subscription_active_until"]; ok {
+		entry["subscription_active_until"] = v
+		subscription["active_until"] = v
+	}
+	if v, ok := claims["chatgpt_subscription_last_checked"]; ok {
+		entry["subscription_last_checked"] = v
+		subscription["last_checked"] = v
+	}
+	if len(subscription) > 0 {
+		entry["subscription"] = subscription
+	}
 }
 
 func authEmail(auth *coreauth.Auth) string {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -535,20 +535,78 @@ func extractCodexIDTokenClaimsFromRaw(idTokenRaw string) gin.H {
 	if v := strings.TrimSpace(claims.CodexAuthInfo.ChatgptPlanType); v != "" {
 		result["plan_type"] = v
 	}
-	if v := claims.CodexAuthInfo.ChatgptSubscriptionActiveStart; v != nil {
+	if v, ok := codexSubscriptionTimestampValue(claims.CodexAuthInfo.ChatgptSubscriptionActiveStart); ok {
 		result["chatgpt_subscription_active_start"] = v
 	}
-	if v := claims.CodexAuthInfo.ChatgptSubscriptionActiveUntil; v != nil {
+	if v, ok := codexSubscriptionTimestampValue(claims.CodexAuthInfo.ChatgptSubscriptionActiveUntil); ok {
 		result["chatgpt_subscription_active_until"] = v
 	}
 	if v := claims.CodexAuthInfo.ChatgptSubscriptionLastChecked; !v.IsZero() {
-		result["chatgpt_subscription_last_checked"] = v
+		result["chatgpt_subscription_last_checked"] = v.UTC().Format(time.RFC3339)
 	}
 
 	if len(result) == 0 {
 		return nil
 	}
 	return result
+}
+
+func codexSubscriptionTimestampValue(v any) (string, bool) {
+	switch value := v.(type) {
+	case nil:
+		return "", false
+	case time.Time:
+		if value.IsZero() {
+			return "", false
+		}
+		return value.UTC().Format(time.RFC3339), true
+	case string:
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return "", false
+		}
+		if numeric, err := strconv.ParseFloat(trimmed, 64); err == nil {
+			return codexUnixTimestampString(numeric)
+		}
+		if ts, err := time.Parse(time.RFC3339, trimmed); err == nil {
+			return ts.UTC().Format(time.RFC3339), true
+		}
+		if ts, err := time.Parse(time.RFC3339Nano, trimmed); err == nil {
+			return ts.UTC().Format(time.RFC3339), true
+		}
+		return trimmed, true
+	case float64:
+		return codexUnixTimestampString(value)
+	case float32:
+		return codexUnixTimestampString(float64(value))
+	case int:
+		return codexUnixTimestampString(float64(value))
+	case int64:
+		return codexUnixTimestampString(float64(value))
+	case int32:
+		return codexUnixTimestampString(float64(value))
+	case json.Number:
+		numeric, err := value.Float64()
+		if err != nil {
+			return "", false
+		}
+		return codexUnixTimestampString(numeric)
+	default:
+		return "", false
+	}
+}
+
+func codexUnixTimestampString(value float64) (string, bool) {
+	if value <= 0 {
+		return "", false
+	}
+	// Values above this threshold are treated as millisecond Unix timestamps.
+	if value > 100000000000 {
+		value /= 1000
+	}
+	seconds := int64(value)
+	nanos := int64((value - float64(seconds)) * 1e9)
+	return time.Unix(seconds, nanos).UTC().Format(time.RFC3339), true
 }
 
 func applyCodexSubscriptionFields(entry gin.H, claims gin.H) {

--- a/internal/api/handlers/management/auth_files_subscription_test.go
+++ b/internal/api/handlers/management/auth_files_subscription_test.go
@@ -131,26 +131,28 @@ func assertCodexSubscriptionFields(t *testing.T, entry map[string]any) {
 	if got := entry["plan_type"]; got != "plus" {
 		t.Fatalf("plan_type = %#v, want plus", got)
 	}
-	if got := numberValue(entry["subscription_active_start"]); got != 1761955200 {
-		t.Fatalf("subscription_active_start = %#v, want 1761955200", entry["subscription_active_start"])
+	if got := entry["subscription_active_start"]; got != "2025-11-01T00:00:00Z" {
+		t.Fatalf("subscription_active_start = %#v, want 2025-11-01T00:00:00Z", got)
 	}
-	if got := numberValue(entry["subscription_active_until"]); got != 1764547200 {
-		t.Fatalf("subscription_active_until = %#v, want 1764547200", entry["subscription_active_until"])
+	if got := entry["subscription_active_until"]; got != "2025-12-01T00:00:00Z" {
+		t.Fatalf("subscription_active_until = %#v, want 2025-12-01T00:00:00Z", got)
 	}
-	if got, ok := entry["subscription_last_checked"].(string); ok {
-		if got != "2026-04-01T02:03:04Z" {
-			t.Fatalf("subscription_last_checked = %q, want 2026-04-01T02:03:04Z", got)
-		}
-	} else if got := entry["subscription_last_checked"]; got == nil {
-		t.Fatalf("expected subscription_last_checked")
+	if got := entry["subscription_last_checked"]; got != "2026-04-01T02:03:04Z" {
+		t.Fatalf("subscription_last_checked = %#v, want 2026-04-01T02:03:04Z", got)
 	}
 
 	subscription, ok := mapValue(entry["subscription"])
 	if !ok {
 		t.Fatalf("subscription = %T, want object", entry["subscription"])
 	}
-	if got := numberValue(subscription["active_until"]); got != 1764547200 {
-		t.Fatalf("subscription.active_until = %#v, want 1764547200", subscription["active_until"])
+	if got := subscription["active_start"]; got != "2025-11-01T00:00:00Z" {
+		t.Fatalf("subscription.active_start = %#v, want 2025-11-01T00:00:00Z", got)
+	}
+	if got := subscription["active_until"]; got != "2025-12-01T00:00:00Z" {
+		t.Fatalf("subscription.active_until = %#v, want 2025-12-01T00:00:00Z", got)
+	}
+	if got := subscription["last_checked"]; got != "2026-04-01T02:03:04Z" {
+		t.Fatalf("subscription.last_checked = %#v, want 2026-04-01T02:03:04Z", got)
 	}
 
 	idTokenClaims, ok := mapValue(entry["id_token"])
@@ -160,21 +162,8 @@ func assertCodexSubscriptionFields(t *testing.T, entry map[string]any) {
 	if got := idTokenClaims["plan_type"]; got != "plus" {
 		t.Fatalf("id_token.plan_type = %#v, want plus", got)
 	}
-}
-
-func numberValue(v any) int64 {
-	switch n := v.(type) {
-	case float64:
-		return int64(n)
-	case int64:
-		return n
-	case int:
-		return int64(n)
-	case json.Number:
-		out, _ := n.Int64()
-		return out
-	default:
-		return 0
+	if got := idTokenClaims["chatgpt_subscription_active_until"]; got != "2025-12-01T00:00:00Z" {
+		t.Fatalf("id_token.chatgpt_subscription_active_until = %#v, want 2025-12-01T00:00:00Z", got)
 	}
 }
 

--- a/internal/api/handlers/management/auth_files_subscription_test.go
+++ b/internal/api/handlers/management/auth_files_subscription_test.go
@@ -1,0 +1,190 @@
+package management
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestBuildAuthFileEntry_ExposesCodexSubscriptionFields(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	idToken := testCodexIDToken(t)
+	manager := coreauth.NewManager(nil, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "codex-user@example.com-plus.json",
+		FileName: "codex-user@example.com-plus.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"runtime_only": "true",
+		},
+		Metadata: map[string]any{
+			"type":     "codex",
+			"email":    "user@example.com",
+			"id_token": idToken,
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+	entry := h.buildAuthFileEntry(record)
+	if entry == nil {
+		t.Fatalf("expected auth entry")
+	}
+
+	assertCodexSubscriptionFields(t, entry)
+}
+
+func TestListAuthFilesFromDisk_ExposesCodexSubscriptionFields(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	idToken := testCodexIDToken(t)
+	fileData := map[string]any{
+		"type":     "codex",
+		"email":    "user@example.com",
+		"id_token": idToken,
+	}
+	data, errMarshal := json.Marshal(fileData)
+	if errMarshal != nil {
+		t.Fatalf("failed to marshal auth file: %v", errMarshal)
+	}
+	if errWrite := os.WriteFile(filepath.Join(authDir, "codex-user@example.com-plus.json"), data, 0o600); errWrite != nil {
+		t.Fatalf("failed to write auth file: %v", errWrite)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files", nil)
+
+	h.ListAuthFiles(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Files []map[string]any `json:"files"`
+	}
+	if errUnmarshal := json.Unmarshal(rec.Body.Bytes(), &payload); errUnmarshal != nil {
+		t.Fatalf("failed to decode list payload: %v", errUnmarshal)
+	}
+	if len(payload.Files) != 1 {
+		t.Fatalf("expected 1 auth file, got %d", len(payload.Files))
+	}
+
+	assertCodexSubscriptionFields(t, payload.Files[0])
+}
+
+func testCodexIDToken(t *testing.T) string {
+	t.Helper()
+
+	header := map[string]any{
+		"alg": "none",
+		"typ": "JWT",
+	}
+	payload := map[string]any{
+		"email": "user@example.com",
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id":                "acct_123",
+			"chatgpt_plan_type":                 "plus",
+			"chatgpt_subscription_active_start": float64(1761955200),
+			"chatgpt_subscription_active_until": float64(1764547200),
+			"chatgpt_subscription_last_checked": "2026-04-01T02:03:04Z",
+			"chatgpt_user_id":                   "user_123",
+			"user_id":                           "user_123",
+			"groups":                            []any{},
+			"organizations":                     []any{},
+		},
+	}
+
+	headerData, errMarshalHeader := json.Marshal(header)
+	if errMarshalHeader != nil {
+		t.Fatalf("failed to marshal jwt header: %v", errMarshalHeader)
+	}
+	payloadData, errMarshalPayload := json.Marshal(payload)
+	if errMarshalPayload != nil {
+		t.Fatalf("failed to marshal jwt payload: %v", errMarshalPayload)
+	}
+
+	encode := base64.RawURLEncoding.EncodeToString
+	return encode(headerData) + "." + encode(payloadData) + ".signature"
+}
+
+func assertCodexSubscriptionFields(t *testing.T, entry map[string]any) {
+	t.Helper()
+
+	if got := entry["plan_type"]; got != "plus" {
+		t.Fatalf("plan_type = %#v, want plus", got)
+	}
+	if got := numberValue(entry["subscription_active_start"]); got != 1761955200 {
+		t.Fatalf("subscription_active_start = %#v, want 1761955200", entry["subscription_active_start"])
+	}
+	if got := numberValue(entry["subscription_active_until"]); got != 1764547200 {
+		t.Fatalf("subscription_active_until = %#v, want 1764547200", entry["subscription_active_until"])
+	}
+	if got, ok := entry["subscription_last_checked"].(string); ok {
+		if got != "2026-04-01T02:03:04Z" {
+			t.Fatalf("subscription_last_checked = %q, want 2026-04-01T02:03:04Z", got)
+		}
+	} else if got := entry["subscription_last_checked"]; got == nil {
+		t.Fatalf("expected subscription_last_checked")
+	}
+
+	subscription, ok := mapValue(entry["subscription"])
+	if !ok {
+		t.Fatalf("subscription = %T, want object", entry["subscription"])
+	}
+	if got := numberValue(subscription["active_until"]); got != 1764547200 {
+		t.Fatalf("subscription.active_until = %#v, want 1764547200", subscription["active_until"])
+	}
+
+	idTokenClaims, ok := mapValue(entry["id_token"])
+	if !ok {
+		t.Fatalf("id_token = %T, want object", entry["id_token"])
+	}
+	if got := idTokenClaims["plan_type"]; got != "plus" {
+		t.Fatalf("id_token.plan_type = %#v, want plus", got)
+	}
+}
+
+func numberValue(v any) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	case json.Number:
+		out, _ := n.Int64()
+		return out
+	default:
+		return 0
+	}
+}
+
+func mapValue(v any) (map[string]any, bool) {
+	switch typed := v.(type) {
+	case map[string]any:
+		return typed, true
+	case gin.H:
+		return typed, true
+	default:
+		return nil, false
+	}
+}

--- a/internal/api/handlers/management/auth_files_subscription_test.go
+++ b/internal/api/handlers/management/auth_files_subscription_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
@@ -39,6 +40,36 @@ func TestBuildAuthFileEntry_ExposesCodexSubscriptionFields(t *testing.T) {
 	}
 
 	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+	entry := h.buildAuthFileEntry(record)
+	if entry == nil {
+		t.Fatalf("expected auth entry")
+	}
+
+	assertCodexSubscriptionFields(t, entry)
+}
+
+func TestBuildAuthFileEntry_ExposesCodexSubscriptionFieldsFromStorage(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	idToken := testCodexIDToken(t)
+	record := &coreauth.Auth{
+		ID:       "codex-user@example.com-plus.json",
+		FileName: "codex-user@example.com-plus.json",
+		Provider: "codex",
+		Storage: &codex.CodexTokenStorage{
+			IDToken: idToken,
+			Email:   "user@example.com",
+		},
+		Attributes: map[string]string{
+			"runtime_only": "true",
+		},
+		Metadata: map[string]any{
+			"email": "user@example.com",
+		},
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, nil)
 	entry := h.buildAuthFileEntry(record)
 	if entry == nil {
 		t.Fatalf("expected auth entry")


### PR DESCRIPTION
## Summary
- expose Codex plan type and subscription timestamps from id_token claims
- include subscription fields in both managed auth entries and disk fallback auth listing
- add tests for Codex subscription metadata in auth-files responses

## Tests
- GOCACHE=/tmp/cliproxy-go-cache go test -v ./internal/api/handlers/management
- GOCACHE=/tmp/cliproxy-go-cache go build -o test-output ./cmd/server
