### PR TITLE
fix(codex): log final reasoning effort after payload overrides

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -37,6 +37,21 @@ const (
 
 var dataTag = []byte("data:")
 
+func logCodexFinalReasoningEffort(body []byte, model string) {
+	if len(body) == 0 {
+		return
+	}
+	effort := gjson.GetBytes(body, "reasoning.effort")
+	if !effort.Exists() {
+		return
+	}
+	log.WithFields(log.Fields{
+		"provider": "codex",
+		"model":    model,
+		"level":    effort.String(),
+	}).Debug("codex: final reasoning effort after payload config |")
+}
+
 // Streamed Codex responses may emit response.output_item.done events while leaving
 // response.completed.response.output empty. Keep the stream path aligned with the
 // already-patched non-stream path by reconstructing response.output from those items.
@@ -174,6 +189,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+	logCodexFinalReasoningEffort(body, baseModel)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body, _ = sjson.SetBytes(body, "stream", true)
 	body, _ = sjson.DeleteBytes(body, "previous_response_id")
@@ -326,6 +342,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+	logCodexFinalReasoningEffort(body, baseModel)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body, _ = sjson.DeleteBytes(body, "stream")
 	body = normalizeCodexInstructions(body)
@@ -418,6 +435,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+	logCodexFinalReasoningEffort(body, baseModel)
 	body, _ = sjson.DeleteBytes(body, "previous_response_id")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -38,7 +38,7 @@ const (
 var dataTag = []byte("data:")
 
 func logCodexFinalReasoningEffort(body []byte, model string) {
-	if len(body) == 0 {
+	if !log.IsLevelEnabled(log.DebugLevel) || len(body) == 0 {
 		return
 	}
 	effort := gjson.GetBytes(body, "reasoning.effort")
@@ -48,8 +48,8 @@ func logCodexFinalReasoningEffort(body []byte, model string) {
 	log.WithFields(log.Fields{
 		"provider": "codex",
 		"model":    model,
-		"level":    effort.String(),
-	}).Debug("codex: final reasoning effort after payload config |")
+		"effort":   effort.String(),
+	}).Debug("codex: final reasoning effort after payload config")
 }
 
 // Streamed Codex responses may emit response.output_item.done events while leaving

--- a/internal/runtime/executor/codex_reasoning_log_test.go
+++ b/internal/runtime/executor/codex_reasoning_log_test.go
@@ -1,32 +1,98 @@
 package executor
 
 import (
-	"bytes"
-	"strings"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/tidwall/gjson"
 )
 
 func TestLogCodexFinalReasoningEffort(t *testing.T) {
 	logger := log.StandardLogger()
-	prevOut := logger.Out
 	prevLevel := logger.GetLevel()
-	var buf bytes.Buffer
-	logger.SetOutput(&buf)
+	hook := test.NewLocal(logger)
 	logger.SetLevel(log.DebugLevel)
 	defer func() {
-		logger.SetOutput(prevOut)
+		hook.Reset()
 		logger.SetLevel(prevLevel)
 	}()
 
 	logCodexFinalReasoningEffort([]byte(`{"reasoning":{"effort":"low"}}`), "gpt-5.4-mini")
 
-	got := buf.String()
-	if !strings.Contains(got, "codex: final reasoning effort after payload config") {
-		t.Fatalf("expected final reasoning effort log, got %q", got)
+	entries := hook.AllEntries()
+	if len(entries) != 1 {
+		t.Fatalf("log entries = %d, want 1", len(entries))
 	}
-	if !strings.Contains(got, "low") {
-		t.Fatalf("expected final effort value in log, got %q", got)
+	entry := entries[0]
+	if entry.Message != "codex: final reasoning effort after payload config" {
+		t.Fatalf("log message = %q, want final reasoning effort message", entry.Message)
 	}
+	if got := entry.Data["effort"]; got != "low" {
+		t.Fatalf("effort field = %v, want low", got)
+	}
+}
+
+func TestCodexExecutorLogsPayloadOverrideReasoningEffort(t *testing.T) {
+	logger := log.StandardLogger()
+	prevLevel := logger.GetLevel()
+	hook := test.NewLocal(logger)
+	logger.SetLevel(log.DebugLevel)
+	defer func() {
+		hook.Reset()
+		logger.SetLevel(prevLevel)
+	}()
+
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":1777300000,\"status\":\"completed\",\"model\":\"gpt-5.4-mini\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "gpt-5.4-mini"}},
+					Params: map[string]any{"reasoning.effort": "low"},
+				},
+			},
+		},
+	})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4-mini",
+		Payload: []byte(`{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"Hello!"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := gjson.GetBytes(gotBody, "reasoning.effort").String(); got != "low" {
+		t.Fatalf("upstream reasoning.effort = %q, want low; body=%s", got, string(gotBody))
+	}
+
+	for _, entry := range hook.AllEntries() {
+		if entry.Message == "codex: final reasoning effort after payload config" && entry.Data["effort"] == "low" {
+			return
+		}
+	}
+	t.Fatalf("expected final reasoning effort log with effort=low, got entries=%v", hook.AllEntries())
 }

--- a/internal/runtime/executor/codex_reasoning_log_test.go
+++ b/internal/runtime/executor/codex_reasoning_log_test.go
@@ -1,0 +1,32 @@
+package executor
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestLogCodexFinalReasoningEffort(t *testing.T) {
+	logger := log.StandardLogger()
+	prevOut := logger.Out
+	prevLevel := logger.GetLevel()
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	logger.SetLevel(log.DebugLevel)
+	defer func() {
+		logger.SetOutput(prevOut)
+		logger.SetLevel(prevLevel)
+	}()
+
+	logCodexFinalReasoningEffort([]byte(`{"reasoning":{"effort":"low"}}`), "gpt-5.4-mini")
+
+	got := buf.String()
+	if !strings.Contains(got, "codex: final reasoning effort after payload config") {
+		t.Fatalf("expected final reasoning effort log, got %q", got)
+	}
+	if !strings.Contains(got, "low") {
+		t.Fatalf("expected final effort value in log, got %q", got)
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -185,6 +185,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel)
+	logCodexFinalReasoningEffort(body, baseModel)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body, _ = sjson.SetBytes(body, "stream", true)
 	body, _ = sjson.DeleteBytes(body, "previous_response_id")
@@ -388,6 +389,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, body, requestedModel)
+	logCodexFinalReasoningEffort(body, baseModel)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)


### PR DESCRIPTION
## Summary
- Add a Codex debug log after payload rules run so the final `reasoning.effort` is observable.
- Cover normal, compact, streaming, and WebSocket Codex executor paths.
- Add a regression test for the final reasoning-effort log helper.

Fixes #3097

## Test plan
- [x] `go test ./internal/runtime/executor ./internal/translator/codex/openai/chat-completions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)