### PR TITLE
fix(usage): defer failed records until request outcome

### DIFF
--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -90,7 +90,7 @@ func (r *UsageReporter) publishWithOutcome(ctx context.Context, detail usage.Det
 	}
 	detail = normalizeUsageDetailTotal(detail)
 	r.once.Do(func() {
-		usage.PublishRecord(ctx, r.buildRecord(detail, failed))
+		usage.PublishRecordOrDefer(ctx, r.buildRecord(detail, failed))
 	})
 }
 

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	"golang.org/x/net/context"
@@ -512,6 +513,7 @@ func (h *BaseAPIHandler) ExecuteWithAuthManager(ctx context.Context, handlerType
 	if len(payload) == 0 {
 		payload = nil
 	}
+	ctx, finishUsageFailures := coreusage.WithDeferredFailures(ctx)
 	req := coreexecutor.Request{
 		Model:   normalizedModel,
 		Payload: payload,
@@ -526,6 +528,7 @@ func (h *BaseAPIHandler) ExecuteWithAuthManager(ctx context.Context, handlerType
 	opts.Metadata = reqMeta
 	resp, err := h.AuthManager.Execute(ctx, providers, req, opts)
 	if err != nil {
+		finishUsageFailures(true)
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
 		status := http.StatusInternalServerError
 		if se, ok := err.(interface{ StatusCode() int }); ok && se != nil {
@@ -541,6 +544,7 @@ func (h *BaseAPIHandler) ExecuteWithAuthManager(ctx context.Context, handlerType
 		}
 		return nil, nil, &interfaces.ErrorMessage{StatusCode: status, Error: err, Addon: addon}
 	}
+	finishUsageFailures(false)
 	if !PassthroughHeadersEnabled(h.Cfg) {
 		return resp.Payload, nil, nil
 	}
@@ -560,6 +564,7 @@ func (h *BaseAPIHandler) ExecuteCountWithAuthManager(ctx context.Context, handle
 	if len(payload) == 0 {
 		payload = nil
 	}
+	ctx, finishUsageFailures := coreusage.WithDeferredFailures(ctx)
 	req := coreexecutor.Request{
 		Model:   normalizedModel,
 		Payload: payload,
@@ -574,6 +579,7 @@ func (h *BaseAPIHandler) ExecuteCountWithAuthManager(ctx context.Context, handle
 	opts.Metadata = reqMeta
 	resp, err := h.AuthManager.ExecuteCount(ctx, providers, req, opts)
 	if err != nil {
+		finishUsageFailures(true)
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
 		status := http.StatusInternalServerError
 		if se, ok := err.(interface{ StatusCode() int }); ok && se != nil {
@@ -589,6 +595,7 @@ func (h *BaseAPIHandler) ExecuteCountWithAuthManager(ctx context.Context, handle
 		}
 		return nil, nil, &interfaces.ErrorMessage{StatusCode: status, Error: err, Addon: addon}
 	}
+	finishUsageFailures(false)
 	if !PassthroughHeadersEnabled(h.Cfg) {
 		return resp.Payload, nil, nil
 	}
@@ -612,6 +619,7 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 	if len(payload) == 0 {
 		payload = nil
 	}
+	ctx, finishUsageFailures := coreusage.WithDeferredFailures(ctx)
 	req := coreexecutor.Request{
 		Model:   normalizedModel,
 		Payload: payload,
@@ -626,6 +634,7 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 	opts.Metadata = reqMeta
 	streamResult, err := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
 	if err != nil {
+		finishUsageFailures(true)
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
 		errChan := make(chan *interfaces.ErrorMessage, 1)
 		status := http.StatusInternalServerError
@@ -658,6 +667,8 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 	dataChan := make(chan []byte)
 	errChan := make(chan *interfaces.ErrorMessage, 1)
 	go func() {
+		usageFailed := false
+		defer func() { finishUsageFailures(usageFailed) }()
 		defer close(dataChan)
 		defer close(errChan)
 		sentPayload := false
@@ -752,12 +763,14 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 							addon = hdr.Clone()
 						}
 					}
+					usageFailed = true
 					_ = sendErr(&interfaces.ErrorMessage{StatusCode: status, Error: streamErr, Addon: addon})
 					return
 				}
 				if len(chunk.Payload) > 0 {
 					if handlerType == "openai-response" {
 						if err := validateSSEDataJSON(chunk.Payload); err != nil {
+							usageFailed = true
 							_ = sendErr(&interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: err})
 							return
 						}

--- a/sdk/api/handlers/handlers_usage_deferred_test.go
+++ b/sdk/api/handlers/handlers_usage_deferred_test.go
@@ -1,0 +1,304 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	runtimehelps "github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+type deferredUsageRecorder struct {
+	authPrefix string
+	records    chan coreusage.Record
+	closed     atomic.Bool
+}
+
+func (r *deferredUsageRecorder) HandleUsage(_ context.Context, record coreusage.Record) {
+	if r.closed.Load() {
+		return
+	}
+	if strings.HasPrefix(record.AuthID, r.authPrefix) {
+		r.records <- record
+	}
+}
+
+type deferredUsageExecutor struct {
+	fail       map[string]bool
+	streamFail map[string]bool
+}
+
+func (e *deferredUsageExecutor) Identifier() string { return "codex" }
+
+func (e *deferredUsageExecutor) Execute(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (resp coreexecutor.Response, err error) {
+	reporter := runtimehelps.NewUsageReporter(ctx, e.Identifier(), req.Model, auth)
+	defer reporter.TrackFailure(ctx, &err)
+	if e.fail[auth.ID] {
+		err = &coreauth.Error{Code: "upstream_error", Message: "upstream failed", HTTPStatus: http.StatusInternalServerError}
+		return coreexecutor.Response{}, err
+	}
+	reporter.Publish(ctx, coreusage.Detail{InputTokens: 1, OutputTokens: 1})
+	return coreexecutor.Response{Payload: []byte(auth.ID)}, nil
+}
+
+func (e *deferredUsageExecutor) CountTokens(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (resp coreexecutor.Response, err error) {
+	return e.Execute(ctx, auth, req, coreexecutor.Options{})
+}
+
+func (e *deferredUsageExecutor) ExecuteStream(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (result *coreexecutor.StreamResult, err error) {
+	reporter := runtimehelps.NewUsageReporter(ctx, e.Identifier(), req.Model, auth)
+	defer reporter.TrackFailure(ctx, &err)
+	if e.fail[auth.ID] {
+		err = &coreauth.Error{Code: "upstream_error", Message: "upstream failed", HTTPStatus: http.StatusInternalServerError}
+		return nil, err
+	}
+	if e.streamFail[auth.ID] {
+		chunks := make(chan coreexecutor.StreamChunk, 1)
+		go func() {
+			reporter.PublishFailure(ctx)
+			chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{Code: "stream_error", Message: "stream failed", HTTPStatus: http.StatusInternalServerError}}
+			close(chunks)
+		}()
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	reporter.Publish(ctx, coreusage.Detail{InputTokens: 1, OutputTokens: 1})
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {}\n\n")}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *deferredUsageExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *deferredUsageExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, &coreauth.Error{Code: "not_implemented", Message: "HttpRequest not implemented", HTTPStatus: http.StatusNotImplemented}
+}
+
+func newDeferredUsageHandler(t *testing.T, model string, fail map[string]bool, authIDs ...string) (*BaseAPIHandler, *deferredUsageRecorder) {
+	return newDeferredUsageHandlerWithStreamFailures(t, model, fail, nil, authIDs...)
+}
+
+func newDeferredUsageHandlerWithStreamFailures(t *testing.T, model string, fail, streamFail map[string]bool, authIDs ...string) (*BaseAPIHandler, *deferredUsageRecorder) {
+	t.Helper()
+	manager := coreauth.NewManager(nil, nil, nil)
+	if fail == nil {
+		fail = make(map[string]bool)
+	}
+	if streamFail == nil {
+		streamFail = make(map[string]bool)
+	}
+	executor := &deferredUsageExecutor{fail: fail, streamFail: streamFail}
+	manager.RegisterExecutor(executor)
+
+	recorder := &deferredUsageRecorder{
+		authPrefix: "usage-deferred-" + uuid.NewString(),
+		records:    make(chan coreusage.Record, 8),
+	}
+	coreusage.RegisterPlugin(recorder)
+	t.Cleanup(func() { recorder.closed.Store(true) })
+
+	modelRegistry := registry.GetGlobalRegistry()
+	for i, authID := range authIDs {
+		priority := "0"
+		if i == 0 {
+			priority = "10"
+		}
+		fullID := recorder.authPrefix + "-" + authID
+		auth := &coreauth.Auth{
+			ID:       fullID,
+			Provider: "codex",
+			Attributes: map[string]string{
+				"api_key":  fullID,
+				"priority": priority,
+			},
+		}
+		modelRegistry.RegisterClient(fullID, "codex", []*registry.ModelInfo{{ID: model}})
+		t.Cleanup(func() { modelRegistry.UnregisterClient(fullID) })
+		if fail[authID] {
+			fail[fullID] = true
+		}
+		if streamFail[authID] {
+			streamFail[fullID] = true
+		}
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register auth %s: %v", fullID, err)
+		}
+	}
+
+	return NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager), recorder
+}
+
+func readDeferredUsageRecord(t *testing.T, recorder *deferredUsageRecorder) coreusage.Record {
+	t.Helper()
+	select {
+	case record := <-recorder.records:
+		return record
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for usage record")
+		return coreusage.Record{}
+	}
+}
+
+func assertNoDeferredUsageRecord(t *testing.T, recorder *deferredUsageRecorder) {
+	t.Helper()
+	select {
+	case record := <-recorder.records:
+		t.Fatalf("unexpected usage record: auth=%s failed=%v", record.AuthID, record.Failed)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestExecuteWithAuthManagerDropsRetriedFailedUsageOnSuccess(t *testing.T) {
+	model := "usage-deferred-model-" + uuid.NewString()
+	handler, recorder := newDeferredUsageHandler(t, model, map[string]bool{"bad": true}, "bad", "good")
+
+	payload, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai-response", model, []byte(`{"input":"hello"}`), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteWithAuthManager error: %v", errMsg.Error)
+	}
+	if !strings.Contains(string(payload), "good") {
+		t.Fatalf("expected good auth payload, got %q", payload)
+	}
+
+	record := readDeferredUsageRecord(t, recorder)
+	if record.Failed {
+		t.Fatalf("expected only success usage, got failed record for %s", record.AuthID)
+	}
+	if !strings.Contains(record.AuthID, "good") {
+		t.Fatalf("expected success record for good auth, got %s", record.AuthID)
+	}
+	assertNoDeferredUsageRecord(t, recorder)
+}
+
+func TestExecuteWithAuthManagerFlushesFinalFailedUsage(t *testing.T) {
+	model := "usage-deferred-model-" + uuid.NewString()
+	handler, recorder := newDeferredUsageHandler(t, model, map[string]bool{"bad": true}, "bad")
+
+	_, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai-response", model, []byte(`{"input":"hello"}`), "")
+	if errMsg == nil {
+		t.Fatal("expected ExecuteWithAuthManager error")
+	}
+
+	record := readDeferredUsageRecord(t, recorder)
+	if !record.Failed {
+		t.Fatalf("expected failed usage, got success record for %s", record.AuthID)
+	}
+	assertNoDeferredUsageRecord(t, recorder)
+}
+
+func TestExecuteCountWithAuthManagerDropsRetriedFailedUsageOnSuccess(t *testing.T) {
+	model := "usage-deferred-model-" + uuid.NewString()
+	handler, recorder := newDeferredUsageHandler(t, model, map[string]bool{"bad": true}, "bad", "good")
+
+	payload, _, errMsg := handler.ExecuteCountWithAuthManager(context.Background(), "openai-response", model, []byte(`{"input":"hello"}`), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteCountWithAuthManager error: %v", errMsg.Error)
+	}
+	if !strings.Contains(string(payload), "good") {
+		t.Fatalf("expected good auth payload, got %q", payload)
+	}
+
+	record := readDeferredUsageRecord(t, recorder)
+	if record.Failed {
+		t.Fatalf("expected only success usage, got failed record for %s", record.AuthID)
+	}
+	if !strings.Contains(record.AuthID, "good") {
+		t.Fatalf("expected success record for good auth, got %s", record.AuthID)
+	}
+	assertNoDeferredUsageRecord(t, recorder)
+}
+
+func TestExecuteCountWithAuthManagerFlushesFinalFailedUsage(t *testing.T) {
+	model := "usage-deferred-model-" + uuid.NewString()
+	handler, recorder := newDeferredUsageHandler(t, model, map[string]bool{"bad": true}, "bad")
+
+	_, _, errMsg := handler.ExecuteCountWithAuthManager(context.Background(), "openai-response", model, []byte(`{"input":"hello"}`), "")
+	if errMsg == nil {
+		t.Fatal("expected ExecuteCountWithAuthManager error")
+	}
+
+	record := readDeferredUsageRecord(t, recorder)
+	if !record.Failed {
+		t.Fatalf("expected failed usage, got success record for %s", record.AuthID)
+	}
+	assertNoDeferredUsageRecord(t, recorder)
+}
+
+func TestExecuteStreamWithAuthManagerDropsRetriedFailedUsageOnSuccess(t *testing.T) {
+	model := "usage-deferred-model-" + uuid.NewString()
+	handler, recorder := newDeferredUsageHandler(t, model, map[string]bool{"bad": true}, "bad", "good")
+
+	data, _, errs := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(`{"input":"hello"}`), "")
+	var chunks [][]byte
+	for chunk := range data {
+		chunks = append(chunks, chunk)
+	}
+	for errMsg := range errs {
+		if errMsg != nil {
+			t.Fatalf("unexpected stream error: %v", errMsg.Error)
+		}
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected stream payload")
+	}
+
+	record := readDeferredUsageRecord(t, recorder)
+	if record.Failed {
+		t.Fatalf("expected only success usage, got failed record for %s", record.AuthID)
+	}
+	if !strings.Contains(record.AuthID, "good") {
+		t.Fatalf("expected success record for good auth, got %s", record.AuthID)
+	}
+	assertNoDeferredUsageRecord(t, recorder)
+}
+
+func TestExecuteStreamWithAuthManagerFlushesInitialFailedUsage(t *testing.T) {
+	model := "usage-deferred-model-" + uuid.NewString()
+	handler, recorder := newDeferredUsageHandler(t, model, map[string]bool{"bad": true}, "bad")
+
+	data, _, errs := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(`{"input":"hello"}`), "")
+	if data != nil {
+		t.Fatal("expected no stream data channel")
+	}
+	errMsg, ok := <-errs
+	if !ok || errMsg == nil {
+		t.Fatal("expected stream error")
+	}
+
+	record := readDeferredUsageRecord(t, recorder)
+	if !record.Failed {
+		t.Fatalf("expected failed usage, got success record for %s", record.AuthID)
+	}
+	assertNoDeferredUsageRecord(t, recorder)
+}
+
+func TestExecuteStreamWithAuthManagerFlushesStreamFailedUsage(t *testing.T) {
+	model := "usage-deferred-model-" + uuid.NewString()
+	handler, recorder := newDeferredUsageHandlerWithStreamFailures(t, model, nil, map[string]bool{"bad": true}, "bad")
+
+	data, _, errs := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(`{"input":"hello"}`), "")
+	for range data {
+		t.Fatal("expected no stream payload")
+	}
+	errMsg, ok := <-errs
+	if !ok || errMsg == nil {
+		t.Fatal("expected stream error")
+	}
+
+	record := readDeferredUsageRecord(t, recorder)
+	if !record.Failed {
+		t.Fatalf("expected failed usage, got success record for %s", record.AuthID)
+	}
+	assertNoDeferredUsageRecord(t, recorder)
+}

--- a/sdk/cliproxy/usage/deferred.go
+++ b/sdk/cliproxy/usage/deferred.go
@@ -1,0 +1,63 @@
+package usage
+
+import (
+	"context"
+	"sync"
+)
+
+type deferredFailuresContextKey struct{}
+
+type deferredFailureScope struct {
+	mu        sync.Mutex
+	active    bool
+	last      Record
+	hasRecord bool
+}
+
+// WithDeferredFailures buffers failed usage records until finish is called.
+func WithDeferredFailures(ctx context.Context) (context.Context, func(bool)) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	scope := &deferredFailureScope{active: true}
+	ctx = context.WithValue(ctx, deferredFailuresContextKey{}, scope)
+	return ctx, func(flush bool) {
+		var record Record
+		hasRecord := false
+
+		scope.mu.Lock()
+		if !scope.active {
+			scope.mu.Unlock()
+			return
+		}
+		if flush && scope.hasRecord {
+			record = scope.last
+			hasRecord = true
+		}
+		scope.active = false
+		scope.hasRecord = false
+		scope.mu.Unlock()
+
+		if hasRecord {
+			PublishRecord(ctx, record)
+		}
+	}
+}
+
+// PublishRecordOrDefer publishes immediately unless the request is buffering failures.
+func PublishRecordOrDefer(ctx context.Context, record Record) {
+	if record.Failed && ctx != nil {
+		scope, _ := ctx.Value(deferredFailuresContextKey{}).(*deferredFailureScope)
+		if scope != nil {
+			scope.mu.Lock()
+			if scope.active {
+				scope.last = record
+				scope.hasRecord = true
+				scope.mu.Unlock()
+				return
+			}
+			scope.mu.Unlock()
+		}
+	}
+	PublishRecord(ctx, record)
+}

--- a/sdk/cliproxy/usage/deferred_test.go
+++ b/sdk/cliproxy/usage/deferred_test.go
@@ -1,0 +1,103 @@
+package usage
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type deferredFailureRecorder struct {
+	authPrefix string
+	records    chan Record
+	closed     atomic.Bool
+}
+
+func (r *deferredFailureRecorder) HandleUsage(_ context.Context, record Record) {
+	if r.closed.Load() {
+		return
+	}
+	if strings.HasPrefix(record.AuthID, r.authPrefix) {
+		r.records <- record
+	}
+}
+
+func newDeferredFailureRecorder(t *testing.T) *deferredFailureRecorder {
+	t.Helper()
+	recorder := &deferredFailureRecorder{
+		authPrefix: "usage-deferred-" + uuid.NewString(),
+		records:    make(chan Record, 8),
+	}
+	RegisterPlugin(recorder)
+	t.Cleanup(func() { recorder.closed.Store(true) })
+	return recorder
+}
+
+func readDeferredFailureRecord(t *testing.T, recorder *deferredFailureRecorder) Record {
+	t.Helper()
+	select {
+	case record := <-recorder.records:
+		return record
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for usage record")
+		return Record{}
+	}
+}
+
+func assertNoDeferredFailureRecord(t *testing.T, recorder *deferredFailureRecorder) {
+	t.Helper()
+	select {
+	case record := <-recorder.records:
+		t.Fatalf("unexpected usage record: auth=%s failed=%v", record.AuthID, record.Failed)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestPublishRecordOrDeferDropsFailedRecordOnSuccess(t *testing.T) {
+	recorder := newDeferredFailureRecorder(t)
+	ctx, finish := WithDeferredFailures(context.Background())
+
+	PublishRecordOrDefer(ctx, Record{AuthID: recorder.authPrefix + "-failed", Failed: true})
+	finish(false)
+
+	assertNoDeferredFailureRecord(t, recorder)
+}
+
+func TestPublishRecordOrDeferFlushesLatestFailedRecordOnFailure(t *testing.T) {
+	recorder := newDeferredFailureRecorder(t)
+	ctx, finish := WithDeferredFailures(context.Background())
+
+	PublishRecordOrDefer(ctx, Record{AuthID: recorder.authPrefix + "-first", Failed: true})
+	PublishRecordOrDefer(ctx, Record{AuthID: recorder.authPrefix + "-last", Failed: true})
+	finish(true)
+	finish(true)
+
+	record := readDeferredFailureRecord(t, recorder)
+	if record.AuthID != recorder.authPrefix+"-last" {
+		t.Fatalf("flushed auth = %s, want latest failed record", record.AuthID)
+	}
+	if !record.Failed {
+		t.Fatal("expected failed record")
+	}
+	assertNoDeferredFailureRecord(t, recorder)
+}
+
+func TestPublishRecordOrDeferPublishesSuccessImmediately(t *testing.T) {
+	recorder := newDeferredFailureRecorder(t)
+	ctx, finish := WithDeferredFailures(context.Background())
+
+	PublishRecordOrDefer(ctx, Record{AuthID: recorder.authPrefix + "-success", Failed: false})
+
+	record := readDeferredFailureRecord(t, recorder)
+	if record.AuthID != recorder.authPrefix+"-success" {
+		t.Fatalf("published auth = %s, want success record", record.AuthID)
+	}
+	if record.Failed {
+		t.Fatal("expected success record")
+	}
+	finish(false)
+	assertNoDeferredFailureRecord(t, recorder)
+}


### PR DESCRIPTION
## Summary

This is a smaller replacement for #3042.

It fixes request-scoped usage pollution from retry attempts: failed intermediate provider/auth attempts are now buffered until the top-level request outcome is known.

- If a later retry succeeds, intermediate failed usage records are dropped.
- If the request ultimately fails, the latest failed usage record is published.
- Successful usage records are still published immediately.

The change intentionally avoids modifying the auth retry conductor or the usage manager queue/dispatcher.

## Implementation

- Adds a request-scoped failed-usage deferral helper in `sdk/cliproxy/usage`.
- Routes `UsageReporter` through the helper so only failed records are buffered.
- Wraps the SDK handler execution paths so final request outcome decides whether to flush or discard deferred failures.
- Covers non-stream, token-count, and stream execution paths.

## Validation

Unit / build validation:

```bash
go test -race -count=1 ./sdk/cliproxy/usage ./internal/runtime/executor/helps ./sdk/api/handlers ./sdk/cliproxy/auth
go build -o test-output ./cmd/server && rm test-output
go test -count=1 ./...
```

Local deploy stack validation with the patched kernel linked into the app and a mock Codex upstream:

```text
final failure: HTTP 500, usage = 1 total / 1 failed / 0 success / 500:codex:gpt-5.4-mini
retry success: HTTP 200, usage = 1 total / 0 failed / 1 success / ok:codex:gpt-5.4-mini
```

## Notes

CodeRabbit was run once before final cleanup and reported one minor test-cleanup concern. The tests now self-disable registered test usage plugins during cleanup without changing the usage manager API.
