### PR TITLE
fix(cliproxy): rotate auth on Anthropic 'out of extra usage' 400

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -117,6 +117,13 @@ type StoppableSelector interface {
 	Stop()
 }
 
+// AuthInvalidator is implemented by selectors that keep per-auth session
+// bindings. It lets the manager drop affinity for an auth that failed this
+// request without marking the auth itself unhealthy.
+type AuthInvalidator interface {
+	InvalidateAuth(authID string)
+}
+
 // Hook captures lifecycle callbacks for observing auth changes.
 type Hook interface {
 	// OnAuthRegistered fires when a new auth is registered.
@@ -346,6 +353,18 @@ func (m *Manager) SetSelector(selector Selector) {
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()
+	}
+}
+
+func (m *Manager) invalidateSessionAffinity(authID string) {
+	if m == nil || strings.TrimSpace(authID) == "" {
+		return
+	}
+	m.mu.RLock()
+	selector := m.selector
+	m.mu.RUnlock()
+	if invalidator, ok := selector.(AuthInvalidator); ok && invalidator != nil {
+		invalidator.InvalidateAuth(authID)
 	}
 }
 
@@ -2016,13 +2035,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	suspendReason := ""
 	clearModelQuota := false
 	setModelQuota := false
+	clearAffinityOnly := !result.Success && isClaudeOutOfExtraUsageResultError(result.Error)
 	var authSnapshot *Auth
 
 	m.mu.Lock()
 	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
 		now := time.Now()
+		if !clearAffinityOnly && result.Success {
 
-		if result.Success {
 			if result.Model != "" {
 				state := ensureModelState(auth, result.Model)
 				resetModelState(state, now)
@@ -2038,7 +2058,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			} else {
 				clearAuthStateOnSuccess(auth, now)
 			}
-		} else {
+		} else if !clearAffinityOnly {
 			if result.Model != "" {
 				if !isRequestScopedNotFoundResultError(result.Error) {
 					disableCooling := quotaCooldownDisabledForAuth(auth)
@@ -2135,8 +2155,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 		}
 
-		_ = m.persist(ctx, auth)
-		authSnapshot = auth.Clone()
+		if !clearAffinityOnly {
+			_ = m.persist(ctx, auth)
+			authSnapshot = auth.Clone()
+		}
 	}
 	m.mu.Unlock()
 	if m.scheduler != nil && authSnapshot != nil {
@@ -2154,7 +2176,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	} else if shouldSuspendModel {
 		registry.GetGlobalRegistry().SuspendClientModel(result.AuthID, result.Model, suspendReason)
 	}
-
+	if clearAffinityOnly {
+		m.invalidateSessionAffinity(result.AuthID)
+		return
+	}
 	m.hook.OnResult(ctx, result)
 }
 
@@ -2441,6 +2466,29 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 	return isRequestScopedNotFoundMessage(err.Message)
 }
 
+func isClaudeOutOfExtraUsageMessage(message string) bool {
+	lower := strings.ToLower(strings.TrimSpace(message))
+	if lower == "" {
+		return false
+	}
+	return strings.Contains(lower, "out of extra usage") ||
+		strings.Contains(lower, "claude.ai/settings/usage")
+}
+
+func isClaudeOutOfExtraUsageError(err error) bool {
+	if err == nil || statusCodeFromError(err) != http.StatusBadRequest {
+		return false
+	}
+	return isClaudeOutOfExtraUsageMessage(err.Error())
+}
+
+func isClaudeOutOfExtraUsageResultError(err *Error) bool {
+	if err == nil || statusCodeFromResult(err) != http.StatusBadRequest {
+		return false
+	}
+	return isClaudeOutOfExtraUsageMessage(err.Message)
+}
+
 // isRequestInvalidError returns true if the error represents a client request
 // error that should not be retried. Specifically, it treats 400 responses with
 // "invalid_request_error", request-scoped 404 item misses caused by `store=false`,
@@ -2449,6 +2497,9 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 // routing can fall through to another auth or upstream.
 func isRequestInvalidError(err error) bool {
 	if err == nil {
+		return false
+	}
+	if isClaudeOutOfExtraUsageError(err) {
 		return false
 	}
 	if isModelSupportError(err) {

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -851,3 +851,57 @@ func TestManager_RequestScopedNotFoundStopsRetryWithoutSuspendingAuth(t *testing
 		t.Fatalf("expected request-scoped 404 to avoid bad auth model cooldown state, got %#v", state)
 	}
 }
+
+type extraUsageInvalidatingSelector struct {
+	invalidated []string
+}
+
+func (s *extraUsageInvalidatingSelector) Pick(_ context.Context, _ string, _ string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	if len(auths) == 0 {
+		return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+	}
+	return auths[0], nil
+}
+
+func (s *extraUsageInvalidatingSelector) InvalidateAuth(authID string) {
+	s.invalidated = append(s.invalidated, authID)
+}
+
+func TestMarkResult_OutOfExtraUsageClearsAffinityWithoutPoisoningAuth(t *testing.T) {
+	selector := &extraUsageInvalidatingSelector{}
+	m := NewManager(nil, selector, nil)
+	auth := &Auth{ID: "claude-auth", Provider: "claude", Status: StatusActive}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "claude-opus-4-7"
+	msg := `{"type":"error","error":{"type":"invalid_request_error","message":"You're out of extra usage. Add more at claude.ai/settings/usage and keep going."}}`
+	if isRequestInvalidError(&Error{HTTPStatus: http.StatusBadRequest, Message: msg}) {
+		t.Fatal("expected out-of-extra-usage 400 to remain credential-retryable")
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusBadRequest, Message: msg},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to remain registered")
+	}
+	if updated.Unavailable || updated.Status == StatusError {
+		t.Fatalf("expected auth to stay healthy, unavailable=%v status=%s", updated.Unavailable, updated.Status)
+	}
+	if updated.LastError != nil || updated.StatusMessage != "" {
+		t.Fatalf("expected no persisted auth error, last=%v status_message=%q", updated.LastError, updated.StatusMessage)
+	}
+	if state := updated.ModelStates[model]; state != nil {
+		t.Fatalf("expected no persisted model error, got %#v", state)
+	}
+	if len(selector.invalidated) != 1 || selector.invalidated[0] != auth.ID {
+		t.Fatalf("expected affinity invalidation for %q, got %v", auth.ID, selector.invalidated)
+	}
+}


### PR DESCRIPTION
## What

When an OAuth Claude account runs out of its extra-usage budget, Anthropic returns:

```
400 {"type":"error","error":{"type":"invalid_request_error","message":"You're out of extra usage. Add more at claude.ai/settings/usage and keep going."}}
```

Right now the conductor treats anything tagged `invalid_request_error` as a request-shape problem and bails out instead of trying the next auth, so the user just sees the 400 even when they have other healthy accounts loaded.

## Change

Treat that specific message as a quota signal rather than a malformed-request signal, scoped narrowly to the "out of extra usage" / `claude.ai/settings/usage` wording so we don't accidentally swallow real 400s.

In `sdk/cliproxy/auth/conductor.go`:

- New `isOutOfExtraUsageMessage` / `isOutOfExtraUsageError` / `isOutOfExtraUsageResultError` helpers.
- `isRequestInvalidError` returns `false` for this case so the retry loop falls through to the next eligible auth.
- `applyAuthFailureState` and the per-model branch in `MarkResult` coerce the status to 429 when this hits, so the offending auth gets `Quota.Exceeded = true` plus the normal backoff cooldown and won't be re-picked until it recovers.

Net effect: hitting this 400 now rotates accounts the same way a 429 does.

## Verification

- `go build ./...`
- `go test ./sdk/cliproxy/auth/ -count=1`

Both clean.
