### PR TITLE
fix(antigravity): 使用真实 antigravity UA 查询积分余额

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1772,7 +1772,7 @@ func (e *AntigravityExecutor) updateAntigravityCreditsBalance(ctx context.Contex
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("User-Agent", "google-api-nodejs-client/9.15.1")
+	httpReq.Header.Set("User-Agent", resolveUserAgent(auth))
 
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 	httpResp, errDo := httpClient.Do(httpReq)


### PR DESCRIPTION
## 问题

`internal/runtime/executor/antigravity_executor.go:1775` 里的 `updateAntigravityCreditsBalance` 调用 `loadCodeAssist` 接口时，硬编码了 User-Agent：

```go
httpReq.Header.Set("User-Agent", "google-api-nodejs-client/9.15.1")
```

谷歌的 `loadCodeAssist` 对这个 UA 返回的 `paidTier` 对象**不带 `availableCredits` 数组**。导致：

- `updateAntigravityCreditsBalance` 永远把每个 auth 的 credits hint 设成 `Available=false`
- `findAllAntigravityCreditsCandidateAuths` 把所有 antigravity auth 全部从积分候选列表里过滤掉
- 在 #2971 / #2989 引入的 conductor 层积分兜底机制中，`tryAntigravityCreditsExecute` 找不到任何候选，立刻返回 `false`
- `enabledCreditTypes:["GOOGLE_ONE_AI"]` 永远不会被注入到请求里
- Google AI Ultra / Pro 订阅账号在 free tier 耗尽后只会拿到 429，**即使订阅积分余额还很充足**

这就是 #2997 报告的现象。

## 复现（任意 Google AI Ultra 账号）

```bash
TOKEN=$(jq -r .access_token < antigravity-acct.json)

# 完全相同的 body 和 endpoint，只有 User-Agent 不同：

# 1. 当前代码用的 UA — 谷歌不返回 availableCredits
curl -s -X POST "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -H "User-Agent: google-api-nodejs-client/9.15.1" \
  -d '{"metadata":{"ideType":"ANTIGRAVITY","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}}' \
  | jq '.paidTier'
# {
#   "id": "g1-ultra-tier",
#   "name": "Gemini Code Assist in Google One AI Ultra",
#   ...
#   <无 availableCredits 字段>
# }

# 2. 真实 antigravity 客户端的 UA — 谷歌正常返回积分明细
curl -s -X POST "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -H "User-Agent: antigravity/1.21.9 darwin/arm64" \
  -d '{"metadata":{"ideType":"ANTIGRAVITY","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}}' \
  | jq '.paidTier'
# {
#   "id": "g1-ultra-tier",
#   "name": "Google AI Ultra",
#   ...
#   "availableCredits": [
#     {"creditType": "GOOGLE_ONE_AI", "creditAmount": "23909", "minimumCreditAmountForUsage": "50"}
#   ]
# }
```

在多个独立的 `g1-ultra-tier` 账号上验证：用 antigravity UA 一律返回 `availableCredits`，用 nodejs UA 一律不返回。

## 修复

复用同一文件第 1952 行（`streamGenerateContent` / `generateContent` 已经在用）的 `resolveUserAgent(auth)`：

```diff
-	httpReq.Header.Set("User-Agent", "google-api-nodejs-client/9.15.1")
+	httpReq.Header.Set("User-Agent", resolveUserAgent(auth))
```

## 为什么只改一行

PR #3015 之前用了更大范围的改动来处理同一个问题（同时改了 `internal/auth/antigravity/auth.go`、`constants.go`，把 request metadata 字段名改成 snake_case，加 `X-Goog-Api-Client` header，新增 short cooldown bypass 逻辑）。该 PR 在 2026-04-25 合并到 dev（merge commit `336a3983`），之后被强推移除；当前 dev 与 main 的 HEAD（`34027da7`）已经不可达该 merge commit。

本 PR 故意把改动面缩到最小：

- 只改 runtime executor 里 `loadCodeAssist` 的 UA 一行
- 不动 `internal/auth/antigravity/`
- 不改 request metadata 字段名
- 不新增 header
- 不动 cooldown 处理

OAuth 流程里的调用方（`FetchUserInfo`、`FetchProjectID`、`OnboardUser`）继续用 `APIUserAgent`，不受影响 —— 它们本来就不读 `availableCredits`。

## 验证

- `gofmt -l internal/runtime/executor/antigravity_executor.go` — clean
- `go build -o test-output ./cmd/server && rm test-output` — OK
- `go test ./internal/runtime/executor/...` — pass
- 在一台配置 `quota-exceeded.antigravity-credits: true`、多个 antigravity 账号的生产代理上部署验证：修复前所有 `claude-opus-4-6` antigravity 请求都给客户端返回 429；修复后同样的负载持续返回 200，conductor 层积分兜底找到候选并正常生效。

Fixes #2997