### PR TITLE
fix(openai): route compatible image generations natively

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -85,7 +85,10 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("openai")
 	endpoint := "/chat/completions"
-	if opts.Alt == "responses/compact" {
+	nativeImagesGenerations := strings.Trim(strings.TrimSpace(opts.Alt), "/") == "images/generations"
+	if nativeImagesGenerations {
+		endpoint = "/images/generations"
+	} else if opts.Alt == "responses/compact" {
 		to = sdktranslator.FromString("openai-response")
 		endpoint = "/responses/compact"
 	}
@@ -93,20 +96,26 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	if len(opts.OriginalRequest) > 0 {
 		originalPayloadSource = opts.OriginalRequest
 	}
-	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, opts.Stream)
-	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, opts.Stream)
+	var translated []byte
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
-	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", translated, originalTranslated, requestedModel)
-	if opts.Alt == "responses/compact" {
-		if updated, errDelete := sjson.DeleteBytes(translated, "stream"); errDelete == nil {
-			translated = updated
+	if nativeImagesGenerations {
+		translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", originalPayloadSource, originalPayloadSource, requestedModel)
+		translated = e.overrideModel(translated, baseModel)
+	} else {
+		originalPayload := originalPayloadSource
+		originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, opts.Stream)
+		translated = sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, opts.Stream)
+		translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", translated, originalTranslated, requestedModel)
+		if opts.Alt == "responses/compact" {
+			if updated, errDelete := sjson.DeleteBytes(translated, "stream"); errDelete == nil {
+				translated = updated
+			}
 		}
-	}
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
-	if err != nil {
-		return resp, err
+		translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+		if err != nil {
+			return resp, err
+		}
 	}
 
 	url := strings.TrimSuffix(baseURL, "/") + endpoint
@@ -171,8 +180,11 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	// Ensure we at least record the request even if upstream doesn't return usage
 	reporter.EnsurePublished(ctx)
 	// Translate response back to source format when needed
-	var param any
-	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, body, &param)
+	out := body
+	if !nativeImagesGenerations {
+		var param any
+		out = sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, body, &param)
+	}
 	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 	return resp, nil
 }

--- a/internal/runtime/executor/openai_compat_executor_images_test.go
+++ b/internal/runtime/executor/openai_compat_executor_images_test.go
@@ -1,0 +1,90 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+type nativeImagesRequestCapture struct {
+	path          string
+	authorization string
+	userAgent     string
+	body          []byte
+	readErr       error
+}
+
+func TestOpenAICompatExecutorNativeImagesGenerations(t *testing.T) {
+	captured := make(chan nativeImagesRequestCapture, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		captured <- nativeImagesRequestCapture{
+			path:          r.URL.Path,
+			authorization: r.Header.Get("Authorization"),
+			userAgent:     r.Header.Get("User-Agent"),
+			body:          body,
+			readErr:       err,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Upstream-Test", "native-images")
+		_, _ = w.Write([]byte(`{"created":123,"data":[{"b64_json":"img"}],"usage":{"total_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test-key",
+	}}
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "upstream-image-model",
+		Payload: []byte(`{"model":"client-image-model","prompt":"draw a cat","response_format":"b64_json"}`),
+	}, cliproxyexecutor.Options{
+		Alt:             "images/generations",
+		OriginalRequest: []byte(`{"model":"client-image-model","prompt":"draw a cat","response_format":"b64_json"}`),
+		SourceFormat:    sdktranslator.FromString("openai"),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if string(resp.Payload) != `{"created":123,"data":[{"b64_json":"img"}],"usage":{"total_tokens":1}}` {
+		t.Fatalf("payload = %s", string(resp.Payload))
+	}
+	if resp.Headers.Get("X-Upstream-Test") != "native-images" {
+		t.Fatalf("missing upstream header")
+	}
+
+	var got nativeImagesRequestCapture
+	select {
+	case got = <-captured:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for upstream request")
+	}
+	if got.readErr != nil {
+		t.Fatalf("read request body: %v", got.readErr)
+	}
+	if got.path != "/v1/images/generations" {
+		t.Fatalf("path = %q, want %q", got.path, "/v1/images/generations")
+	}
+	if got.authorization != "Bearer test-key" {
+		t.Fatalf("authorization = %q", got.authorization)
+	}
+	if got.userAgent != "cli-proxy-openai-compat" {
+		t.Fatalf("user agent = %q", got.userAgent)
+	}
+	if model := gjson.GetBytes(got.body, "model").String(); model != "upstream-image-model" {
+		t.Fatalf("model = %q, want %q; body=%s", model, "upstream-image-model", string(got.body))
+	}
+	if prompt := gjson.GetBytes(got.body, "prompt").String(); prompt != "draw a cat" {
+		t.Fatalf("prompt = %q", prompt)
+	}
+}

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -242,6 +243,14 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 		responseFormat = "b64_json"
 	}
 	stream := gjson.GetBytes(rawJSON, "stream").Bool()
+	if openAICompatibleImageModel(imageModel) {
+		nativeJSON := rawJSON
+		if strings.TrimSpace(gjson.GetBytes(rawJSON, "response_format").String()) == "" {
+			nativeJSON, _ = sjson.SetBytes(nativeJSON, "response_format", responseFormat)
+		}
+		h.collectImagesFromNative(c, nativeJSON, imageModel)
+		return
+	}
 
 	tool := []byte(`{"type":"image_generation","action":"generate"}`)
 	tool, _ = sjson.SetBytes(tool, "model", imageModel)
@@ -583,6 +592,42 @@ func (h *OpenAIAPIHandler) collectImagesFromResponses(c *gin.Context, responsesR
 	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, "openai-response", mainModel, responsesReq, "")
 
 	out, errMsg := collectImagesFromResponsesStream(cliCtx, dataChan, errChan, responseFormat)
+	stopKeepAlive()
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		if errMsg.Error != nil {
+			cliCancel(errMsg.Error)
+		} else {
+			cliCancel(nil)
+		}
+		return
+	}
+	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+	_, _ = c.Writer.Write(out)
+	cliCancel()
+}
+
+func openAICompatibleImageModel(modelName string) bool {
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" || !strings.Contains(modelName, "/") {
+		return false
+	}
+	registryRef := registry.GetGlobalRegistry()
+	for _, provider := range registryRef.GetModelProviders(modelName) {
+		info := registryRef.GetModelInfo(modelName, provider)
+		if info != nil && strings.EqualFold(strings.TrimSpace(info.Type), "openai-compatibility") {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *OpenAIAPIHandler) collectImagesFromNative(c *gin.Context, rawJSON []byte, modelName string) {
+	c.Header("Content-Type", "application/json")
+
+	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
+	out, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, "openai", modelName, rawJSON, "images/generations")
 	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -2,6 +2,8 @@ package openai
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -10,6 +12,11 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 	"github.com/tidwall/gjson"
 )
 
@@ -92,4 +99,120 @@ func TestImagesEditsMultipartRejectsUnsupportedModel(t *testing.T) {
 	resp := performImagesEndpointRequest(t, imagesEditsPath, writer.FormDataContentType(), &body, handler.ImagesEdits)
 
 	assertUnsupportedImagesModelResponse(t, resp, "gpt-5.4-mini")
+}
+
+type imageNativeCaptureExecutor struct {
+	calls        int
+	alt          string
+	sourceFormat string
+	model        string
+	payload      []byte
+}
+
+func (e *imageNativeCaptureExecutor) Identifier() string { return "test-native-images-provider" }
+
+func (e *imageNativeCaptureExecutor) Execute(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	e.calls++
+	e.alt = opts.Alt
+	e.sourceFormat = opts.SourceFormat.String()
+	e.model = req.Model
+	e.payload = append(e.payload[:0], req.Payload...)
+	return coreexecutor.Response{
+		Payload: []byte(`{"created":123,"data":[{"b64_json":"native-image"}]}`),
+		Headers: http.Header{"X-Native-Test": []string{"ok"}},
+	}, nil
+}
+
+func (e *imageNativeCaptureExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *imageNativeCaptureExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *imageNativeCaptureExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *imageNativeCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestImagesGenerationsUsesOpenAICompatibleImageModelNatively(t *testing.T) {
+	executor := &imageNativeCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "test-native-images-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{
+		ID:   "test-native/gpt-image-2",
+		Type: "openai-compatibility",
+	}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+	manager.RefreshSchedulerEntry(auth.ID)
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{PassthroughHeaders: true}, manager)
+	handler := NewOpenAIAPIHandler(base)
+	body := strings.NewReader(`{"model":"test-native/gpt-image-2","prompt":"draw a fox"}`)
+
+	resp := performImagesEndpointRequest(t, imagesGenerationsPath, "application/json", body, handler.ImagesGenerations)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.Code, resp.Body.String())
+	}
+	if executor.calls != 1 {
+		t.Fatalf("executor calls = %d, want 1", executor.calls)
+	}
+	if executor.alt != "images/generations" {
+		t.Fatalf("alt = %q, want images/generations", executor.alt)
+	}
+	if executor.sourceFormat != "openai" {
+		t.Fatalf("source format = %q, want openai", executor.sourceFormat)
+	}
+	if executor.model != "test-native/gpt-image-2" {
+		t.Fatalf("model = %q", executor.model)
+	}
+	if gjson.GetBytes(executor.payload, "response_format").String() != "b64_json" {
+		t.Fatalf("expected default response_format in native payload, got %s", string(executor.payload))
+	}
+	if strings.TrimSpace(resp.Body.String()) != `{"created":123,"data":[{"b64_json":"native-image"}]}` {
+		t.Fatalf("body = %s", resp.Body.String())
+	}
+}
+
+func TestOpenAICompatibleImageModelUsesRegistryType(t *testing.T) {
+	registryRef := registry.GetGlobalRegistry()
+	registryRef.RegisterClient("test-image-model-openai-compat", "openai-compat-provider", []*registry.ModelInfo{{
+		ID:   "registry-native/gpt-image-2",
+		Type: "openai-compatibility",
+	}})
+	registryRef.RegisterClient("test-image-model-bare-openai-compat", "openai-compat-provider", []*registry.ModelInfo{{
+		ID:   "gpt-image-2",
+		Type: "openai-compatibility",
+	}})
+	registryRef.RegisterClient("test-image-model-codex", "codex", []*registry.ModelInfo{{
+		ID:   "registry-codex/gpt-image-2",
+		Type: "codex",
+	}})
+	t.Cleanup(func() {
+		registryRef.UnregisterClient("test-image-model-openai-compat")
+		registryRef.UnregisterClient("test-image-model-bare-openai-compat")
+		registryRef.UnregisterClient("test-image-model-codex")
+	})
+
+	if !openAICompatibleImageModel("registry-native/gpt-image-2") {
+		t.Fatalf("expected openai-compatible image model")
+	}
+	if openAICompatibleImageModel("registry-codex/gpt-image-2") {
+		t.Fatalf("did not expect codex image model to be treated as openai-compatible")
+	}
+	if openAICompatibleImageModel("gpt-image-2") {
+		t.Fatalf("did not expect bare gpt-image-2 to be routed through native OpenAI-compatible path")
+	}
 }


### PR DESCRIPTION
## Summary
- Route OpenAI-compatible image generation models through the native `/images/generations` endpoint instead of converting them into Codex Responses fallback requests.
- Preserve the existing `AuthManager` execution path by passing `alt=images/generations`; no handler-side auth/provider selection is added.
- Return native OpenAI Images responses directly for OpenAI-compatible image models registered in the model registry.

Fixes #3075
Related to #2991

## Validation
- `go test -count=1 ./...`
- `go test -race -count=1 -run 'TestOpenAICompatExecutorNativeImagesGenerations|TestImagesGenerationsUsesOpenAICompatibleImageModelNatively|TestOpenAICompatibleImageModelUsesRegistryType|TestImagesModelValidationAllowsGPTImage2WithOptionalPrefix' ./internal/runtime/executor ./sdk/api/handlers/openai`
- `go build -o test-output ./cmd/server && rm test-output`
- Local stack smoke test: `POST /v1/images/generations` with an OpenAI-compatible `local-image/gpt-image-2` model returned `200`; the mock upstream received `/v1/images/generations` with body model `gpt-image-2`, and the app logs did not contain `local-image/gpt-5.4-mini`.
