### PR TITLE
feat: support per-OAuth proxy overrides in management API

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -27,12 +27,14 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
 	geminiAuth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"golang.org/x/oauth2"
@@ -1386,9 +1388,57 @@ func (h *Handler) saveTokenRecord(ctx context.Context, record *coreauth.Auth) (s
 	return store.Save(ctx, record)
 }
 
+func (h *Handler) oauthProxyURLFromRequest(c *gin.Context) (string, error) {
+	if c == nil {
+		return "", nil
+	}
+	proxyURL := strings.TrimSpace(c.Query("proxy_url"))
+	if proxyURL == "" {
+		proxyURL = strings.TrimSpace(c.Query("proxy-url"))
+	}
+	if proxyURL == "" {
+		return "", nil
+	}
+	if _, err := proxyutil.Parse(proxyURL); err != nil {
+		return "", err
+	}
+	return proxyURL, nil
+}
+
+func (h *Handler) configWithOAuthProxy(proxyURL string) *config.Config {
+	if h == nil || h.cfg == nil {
+		return &config.Config{SDKConfig: config.SDKConfig{ProxyURL: strings.TrimSpace(proxyURL)}}
+	}
+	proxyURL = strings.TrimSpace(proxyURL)
+	if proxyURL == "" {
+		return h.cfg
+	}
+	cfgCopy := *h.cfg
+	cfgCopy.SDKConfig = h.cfg.SDKConfig
+	cfgCopy.ProxyURL = proxyURL
+	return &cfgCopy
+}
+
+func applyOAuthProxyToRecord(record *coreauth.Auth, proxyURL string) {
+	proxyURL = strings.TrimSpace(proxyURL)
+	if record == nil || proxyURL == "" {
+		return
+	}
+	record.ProxyURL = proxyURL
+	if record.Metadata == nil {
+		record.Metadata = make(map[string]any)
+	}
+	record.Metadata["proxy_url"] = proxyURL
+}
+
 func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
+	oauthProxyURL, errProxy := h.oauthProxyURLFromRequest(c)
+	if errProxy != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid proxy_url"})
+		return
+	}
 
 	fmt.Println("Initializing Claude authentication...")
 
@@ -1409,7 +1459,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	}
 
 	// Initialize Claude auth service
-	anthropicAuth := claude.NewClaudeAuth(h.cfg)
+	anthropicAuth := claude.NewClaudeAuthWithProxyURL(h.cfg, oauthProxyURL)
 
 	// Generate authorization URL (then override redirect_uri to reuse server port)
 	authURL, state, err := anthropicAuth.GenerateAuthURL(state, pkceCodes)
@@ -1512,6 +1562,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 			Storage:  tokenStorage,
 			Metadata: map[string]any{"email": tokenStorage.Email},
 		}
+		applyOAuthProxyToRecord(record, oauthProxyURL)
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {
 			log.Errorf("Failed to save authentication tokens: %v", errSave)
@@ -1534,7 +1585,13 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
-	proxyHTTPClient := util.SetProxy(&h.cfg.SDKConfig, &http.Client{})
+	oauthProxyURL, errProxy := h.oauthProxyURLFromRequest(c)
+	if errProxy != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid proxy_url"})
+		return
+	}
+	oauthCfg := h.configWithOAuthProxy(oauthProxyURL)
+	proxyHTTPClient := util.SetProxy(&oauthCfg.SDKConfig, &http.Client{})
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, proxyHTTPClient)
 
 	// Optional project ID from query
@@ -1684,7 +1741,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 
 		// Initialize authenticated HTTP client via GeminiAuth to honor proxy settings
 		gemAuth := geminiAuth.NewGeminiAuth()
-		gemClient, errGetClient := gemAuth.GetAuthenticatedClient(ctx, &ts, h.cfg, &geminiAuth.WebLoginOptions{
+		gemClient, errGetClient := gemAuth.GetAuthenticatedClient(ctx, &ts, oauthCfg, &geminiAuth.WebLoginOptions{
 			NoBrowser: true,
 		})
 		if errGetClient != nil {
@@ -1775,6 +1832,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 			Storage:  &ts,
 			Metadata: recordMetadata,
 		}
+		applyOAuthProxyToRecord(record, oauthProxyURL)
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {
 			log.Errorf("Failed to save token to file: %v", errSave)
@@ -1793,6 +1851,11 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 func (h *Handler) RequestCodexToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
+	oauthProxyURL, errProxy := h.oauthProxyURLFromRequest(c)
+	if errProxy != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid proxy_url"})
+		return
+	}
 
 	fmt.Println("Initializing Codex authentication...")
 
@@ -1813,7 +1876,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 	}
 
 	// Initialize Codex auth service
-	openaiAuth := codex.NewCodexAuth(h.cfg)
+	openaiAuth := codex.NewCodexAuthWithProxyURL(h.cfg, oauthProxyURL)
 
 	// Generate authorization URL
 	authURL, err := openaiAuth.GenerateAuthURL(state, pkceCodes)
@@ -1918,6 +1981,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 				"account_id": tokenStorage.AccountID,
 			},
 		}
+		applyOAuthProxyToRecord(record, oauthProxyURL)
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {
 			SetOAuthSessionError(state, "Failed to save authentication tokens")
@@ -1939,10 +2003,15 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
+	oauthProxyURL, errProxy := h.oauthProxyURLFromRequest(c)
+	if errProxy != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid proxy_url"})
+		return
+	}
 
 	fmt.Println("Initializing Antigravity authentication...")
 
-	authSvc := antigravity.NewAntigravityAuth(h.cfg, nil)
+	authSvc := antigravity.NewAntigravityAuthWithProxyURL(h.cfg, oauthProxyURL)
 
 	state, errState := misc.GenerateRandomState()
 	if errState != nil {
@@ -2082,6 +2151,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 			Label:    label,
 			Metadata: metadata,
 		}
+		applyOAuthProxyToRecord(record, oauthProxyURL)
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {
 			log.Errorf("Failed to save token to file: %v", errSave)
@@ -2104,12 +2174,17 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 func (h *Handler) RequestKimiToken(c *gin.Context) {
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
+	oauthProxyURL, errProxy := h.oauthProxyURLFromRequest(c)
+	if errProxy != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid proxy_url"})
+		return
+	}
 
 	fmt.Println("Initializing Kimi authentication...")
 
 	state := fmt.Sprintf("kmi-%d", time.Now().UnixNano())
 	// Initialize Kimi auth service
-	kimiAuth := kimi.NewKimiAuth(h.cfg)
+	kimiAuth := kimi.NewKimiAuthWithProxyURL(h.cfg, oauthProxyURL)
 
 	// Generate authorization URL
 	deviceFlow, errStartDeviceFlow := kimiAuth.StartDeviceFlow(ctx)
@@ -2162,6 +2237,7 @@ func (h *Handler) RequestKimiToken(c *gin.Context) {
 			Storage:  tokenStorage,
 			Metadata: metadata,
 		}
+		applyOAuthProxyToRecord(record, oauthProxyURL)
 		savedPath, errSave := h.saveTokenRecord(ctx, record)
 		if errSave != nil {
 			log.Errorf("Failed to save authentication tokens: %v", errSave)

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -12,6 +12,7 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1405,6 +1406,16 @@ func (h *Handler) oauthProxyURLFromRequest(c *gin.Context) (string, error) {
 	return proxyURL, nil
 }
 
+func (h *Handler) oauthConfig(c *gin.Context) (*config.Config, bool) {
+	if h == nil || h.cfg == nil {
+		if c != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "configuration unavailable"})
+		}
+		return nil, false
+	}
+	return h.cfg, true
+}
+
 func (h *Handler) configWithOAuthProxy(proxyURL string) *config.Config {
 	if h == nil || h.cfg == nil {
 		return &config.Config{SDKConfig: config.SDKConfig{ProxyURL: strings.TrimSpace(proxyURL)}}
@@ -1414,8 +1425,7 @@ func (h *Handler) configWithOAuthProxy(proxyURL string) *config.Config {
 		return h.cfg
 	}
 	cfgCopy := *h.cfg
-	cfgCopy.SDKConfig = h.cfg.SDKConfig
-	cfgCopy.ProxyURL = proxyURL
+	cfgCopy.SDKConfig.ProxyURL = proxyURL
 	return &cfgCopy
 }
 
@@ -1432,6 +1442,10 @@ func applyOAuthProxyToRecord(record *coreauth.Auth, proxyURL string) {
 }
 
 func (h *Handler) RequestAnthropicToken(c *gin.Context) {
+	cfg, okCfg := h.oauthConfig(c)
+	if !okCfg {
+		return
+	}
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
 	oauthProxyURL, errProxy := h.oauthProxyURLFromRequest(c)
@@ -1459,7 +1473,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 	}
 
 	// Initialize Claude auth service
-	anthropicAuth := claude.NewClaudeAuthWithProxyURL(h.cfg, oauthProxyURL)
+	anthropicAuth := claude.NewClaudeAuthWithProxyURL(cfg, oauthProxyURL)
 
 	// Generate authorization URL (then override redirect_uri to reuse server port)
 	authURL, state, err := anthropicAuth.GenerateAuthURL(state, pkceCodes)
@@ -1494,7 +1508,7 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 		}
 
 		// Helper: wait for callback file
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-anthropic-%s.oauth", state))
+		waitFile := filepath.Join(cfg.AuthDir, fmt.Sprintf(".oauth-anthropic-%s.oauth", state))
 		waitForFile := func(path string, timeout time.Duration) (map[string]string, error) {
 			deadline := time.Now().Add(timeout)
 			for {
@@ -1583,6 +1597,10 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 }
 
 func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
+	cfg, okCfg := h.oauthConfig(c)
+	if !okCfg {
+		return
+	}
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
 	oauthProxyURL, errProxy := h.oauthProxyURLFromRequest(c)
@@ -1637,7 +1655,7 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 		}
 
 		// Wait for callback file written by server route
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-gemini-%s.oauth", state))
+		waitFile := filepath.Join(cfg.AuthDir, fmt.Sprintf(".oauth-gemini-%s.oauth", state))
 		fmt.Println("Waiting for authentication callback...")
 		deadline := time.Now().Add(5 * time.Minute)
 		var authCode string
@@ -1849,6 +1867,10 @@ func (h *Handler) RequestGeminiCLIToken(c *gin.Context) {
 }
 
 func (h *Handler) RequestCodexToken(c *gin.Context) {
+	cfg, okCfg := h.oauthConfig(c)
+	if !okCfg {
+		return
+	}
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
 	oauthProxyURL, errProxy := h.oauthProxyURLFromRequest(c)
@@ -1876,7 +1898,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 	}
 
 	// Initialize Codex auth service
-	openaiAuth := codex.NewCodexAuthWithProxyURL(h.cfg, oauthProxyURL)
+	openaiAuth := codex.NewCodexAuthWithProxyURL(cfg, oauthProxyURL)
 
 	// Generate authorization URL
 	authURL, err := openaiAuth.GenerateAuthURL(state, pkceCodes)
@@ -1911,7 +1933,7 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 		}
 
 		// Wait for callback file
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-codex-%s.oauth", state))
+		waitFile := filepath.Join(cfg.AuthDir, fmt.Sprintf(".oauth-codex-%s.oauth", state))
 		deadline := time.Now().Add(5 * time.Minute)
 		var code string
 		for {
@@ -2001,6 +2023,10 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 }
 
 func (h *Handler) RequestAntigravityToken(c *gin.Context) {
+	cfg, okCfg := h.oauthConfig(c)
+	if !okCfg {
+		return
+	}
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
 	oauthProxyURL, errProxy := h.oauthProxyURLFromRequest(c)
@@ -2011,7 +2037,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 
 	fmt.Println("Initializing Antigravity authentication...")
 
-	authSvc := antigravity.NewAntigravityAuthWithProxyURL(h.cfg, oauthProxyURL)
+	authSvc := antigravity.NewAntigravityAuthWithProxyURL(cfg, oauthProxyURL)
 
 	state, errState := misc.GenerateRandomState()
 	if errState != nil {
@@ -2047,7 +2073,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 			defer stopCallbackForwarderInstance(antigravity.CallbackPort, forwarder)
 		}
 
-		waitFile := filepath.Join(h.cfg.AuthDir, fmt.Sprintf(".oauth-antigravity-%s.oauth", state))
+		waitFile := filepath.Join(cfg.AuthDir, fmt.Sprintf(".oauth-antigravity-%s.oauth", state))
 		deadline := time.Now().Add(5 * time.Minute)
 		var authCode string
 		for {
@@ -2172,6 +2198,10 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 }
 
 func (h *Handler) RequestKimiToken(c *gin.Context) {
+	cfg, okCfg := h.oauthConfig(c)
+	if !okCfg {
+		return
+	}
 	ctx := context.Background()
 	ctx = PopulateAuthContext(ctx, c)
 	oauthProxyURL, errProxy := h.oauthProxyURLFromRequest(c)
@@ -2184,7 +2214,7 @@ func (h *Handler) RequestKimiToken(c *gin.Context) {
 
 	state := fmt.Sprintf("kmi-%d", time.Now().UnixNano())
 	// Initialize Kimi auth service
-	kimiAuth := kimi.NewKimiAuthWithProxyURL(h.cfg, oauthProxyURL)
+	kimiAuth := kimi.NewKimiAuthWithProxyURL(cfg, oauthProxyURL)
 
 	// Generate authorization URL
 	deviceFlow, errStartDeviceFlow := kimiAuth.StartDeviceFlow(ctx)
@@ -2669,9 +2699,19 @@ func (h *Handler) GetAuthStatus(c *gin.Context) {
 
 // PopulateAuthContext extracts request info and adds it to the context
 func PopulateAuthContext(ctx context.Context, c *gin.Context) context.Context {
+	if c == nil || c.Request == nil {
+		return ctx
+	}
+	var query url.Values
+	if c.Request.URL != nil {
+		query = make(url.Values, len(c.Request.URL.Query()))
+		for key, values := range c.Request.URL.Query() {
+			query[key] = append([]string(nil), values...)
+		}
+	}
 	info := &coreauth.RequestInfo{
-		Query:   c.Request.URL.Query(),
-		Headers: c.Request.Header,
+		Query:   query,
+		Headers: c.Request.Header.Clone(),
 	}
 	return coreauth.WithRequestInfo(ctx, info)
 }

--- a/internal/api/handlers/management/oauth_proxy_test.go
+++ b/internal/api/handlers/management/oauth_proxy_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -66,6 +67,9 @@ func TestConfigWithOAuthProxyDoesNotMutateGlobalConfig(t *testing.T) {
 	if override.ProxyURL != "direct" {
 		t.Fatalf("override proxy-url = %q, want direct", override.ProxyURL)
 	}
+	if override.SDKConfig.ProxyURL != "direct" {
+		t.Fatalf("override sdk-proxy-url = %q, want direct", override.SDKConfig.ProxyURL)
+	}
 	if override.AuthDir != cfg.AuthDir {
 		t.Fatalf("auth-dir = %q, want %q", override.AuthDir, cfg.AuthDir)
 	}
@@ -107,5 +111,26 @@ func TestApplyOAuthProxyToRecordEmptyIsNoop(t *testing.T) {
 	}
 	if record.Metadata != nil {
 		t.Fatalf("metadata = %#v, want nil", record.Metadata)
+	}
+}
+
+func TestPopulateAuthContextCopiesRequestMetadata(t *testing.T) {
+	ctx := newOAuthProxyTestContext("/v0/management/codex-auth-url?source=original")
+	ctx.Request.Header.Set("X-Test", "original")
+
+	authCtx := PopulateAuthContext(context.Background(), ctx)
+
+	ctx.Request.URL.RawQuery = "source=mutated"
+	ctx.Request.Header.Set("X-Test", "mutated")
+
+	info := coreauth.GetRequestInfo(authCtx)
+	if info == nil {
+		t.Fatal("expected request info")
+	}
+	if got := info.Query.Get("source"); got != "original" {
+		t.Fatalf("query source = %q, want original", got)
+	}
+	if got := info.Headers.Get("X-Test"); got != "original" {
+		t.Fatalf("header X-Test = %q, want original", got)
 	}
 }

--- a/internal/api/handlers/management/oauth_proxy_test.go
+++ b/internal/api/handlers/management/oauth_proxy_test.go
@@ -1,0 +1,111 @@
+package management
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func newOAuthProxyTestContext(rawURL string) *gin.Context {
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, rawURL, nil)
+	return ctx
+}
+
+func TestOAuthProxyURLFromRequest(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	h := &Handler{}
+	tests := []struct {
+		name    string
+		rawURL  string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty", rawURL: "/v0/management/codex-auth-url", want: ""},
+		{name: "snake query", rawURL: "/v0/management/codex-auth-url?proxy_url=direct", want: "direct"},
+		{name: "dash query", rawURL: "/v0/management/codex-auth-url?proxy-url=none", want: "none"},
+		{name: "http proxy", rawURL: "/v0/management/codex-auth-url?proxy_url=http%3A%2F%2Fproxy.example.com%3A8080", want: "http://proxy.example.com:8080"},
+		{name: "socks5 proxy", rawURL: "/v0/management/codex-auth-url?proxy_url=socks5%3A%2F%2F127.0.0.1%3A1080", want: "socks5://127.0.0.1:1080"},
+		{name: "invalid", rawURL: "/v0/management/codex-auth-url?proxy_url=bad-value", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := h.oauthProxyURLFromRequest(newOAuthProxyTestContext(tt.rawURL))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("proxy_url = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigWithOAuthProxyDoesNotMutateGlobalConfig(t *testing.T) {
+	cfg := &config.Config{SDKConfig: config.SDKConfig{ProxyURL: "http://global.example.com:8080"}, AuthDir: "/auth"}
+	h := &Handler{cfg: cfg}
+
+	override := h.configWithOAuthProxy("direct")
+	if override == cfg {
+		t.Fatal("expected copied config when proxy override is provided")
+	}
+	if override.ProxyURL != "direct" {
+		t.Fatalf("override proxy-url = %q, want direct", override.ProxyURL)
+	}
+	if override.AuthDir != cfg.AuthDir {
+		t.Fatalf("auth-dir = %q, want %q", override.AuthDir, cfg.AuthDir)
+	}
+	if cfg.ProxyURL != "http://global.example.com:8080" {
+		t.Fatalf("global proxy-url mutated to %q", cfg.ProxyURL)
+	}
+
+	inherited := h.configWithOAuthProxy("")
+	if inherited != cfg {
+		t.Fatal("expected original config when no proxy override is provided")
+	}
+}
+
+func TestApplyOAuthProxyToRecord(t *testing.T) {
+	record := &coreauth.Auth{
+		Metadata: map[string]any{"email": "user@example.com"},
+	}
+
+	applyOAuthProxyToRecord(record, "direct")
+
+	if record.ProxyURL != "direct" {
+		t.Fatalf("record.ProxyURL = %q, want direct", record.ProxyURL)
+	}
+	if got, _ := record.Metadata["proxy_url"].(string); got != "direct" {
+		t.Fatalf("metadata.proxy_url = %q, want direct", got)
+	}
+	if got, _ := record.Metadata["email"].(string); got != "user@example.com" {
+		t.Fatalf("metadata.email = %q, want user@example.com", got)
+	}
+}
+
+func TestApplyOAuthProxyToRecordEmptyIsNoop(t *testing.T) {
+	record := &coreauth.Auth{}
+
+	applyOAuthProxyToRecord(record, "")
+
+	if record.ProxyURL != "" {
+		t.Fatalf("record.ProxyURL = %q, want empty", record.ProxyURL)
+	}
+	if record.Metadata != nil {
+		t.Fatalf("metadata = %#v, want nil", record.Metadata)
+	}
+}

--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -46,15 +46,13 @@ func NewAntigravityAuth(cfg *config.Config, httpClient *http.Client) *Antigravit
 // NewAntigravityAuthWithProxyURL creates a new Antigravity auth service with a proxy override.
 // proxyURL takes precedence over cfg.ProxyURL when non-empty.
 func NewAntigravityAuthWithProxyURL(cfg *config.Config, proxyURL string) *AntigravityAuth {
-	if cfg == nil {
-		cfg = &config.Config{}
+	var sdkCfg config.SDKConfig
+	if cfg != nil {
+		sdkCfg = cfg.SDKConfig
 	}
-	effectiveProxyURL := strings.TrimSpace(proxyURL)
-	sdkCfg := cfg.SDKConfig
-	if effectiveProxyURL == "" {
-		effectiveProxyURL = strings.TrimSpace(cfg.ProxyURL)
+	if trimmedProxyURL := strings.TrimSpace(proxyURL); trimmedProxyURL != "" {
+		sdkCfg.ProxyURL = trimmedProxyURL
 	}
-	sdkCfg.ProxyURL = effectiveProxyURL
 	return &AntigravityAuth{
 		httpClient: util.SetProxy(&sdkCfg, &http.Client{}),
 	}

--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -37,14 +37,26 @@ type AntigravityAuth struct {
 
 // NewAntigravityAuth creates a new Antigravity auth service.
 func NewAntigravityAuth(cfg *config.Config, httpClient *http.Client) *AntigravityAuth {
-	if cfg == nil {
-		cfg = &config.Config{}
-	}
 	if httpClient != nil {
 		return &AntigravityAuth{httpClient: httpClient}
 	}
+	return NewAntigravityAuthWithProxyURL(cfg, "")
+}
+
+// NewAntigravityAuthWithProxyURL creates a new Antigravity auth service with a proxy override.
+// proxyURL takes precedence over cfg.ProxyURL when non-empty.
+func NewAntigravityAuthWithProxyURL(cfg *config.Config, proxyURL string) *AntigravityAuth {
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	effectiveProxyURL := strings.TrimSpace(proxyURL)
+	sdkCfg := cfg.SDKConfig
+	if effectiveProxyURL == "" {
+		effectiveProxyURL = strings.TrimSpace(cfg.ProxyURL)
+	}
+	sdkCfg.ProxyURL = effectiveProxyURL
 	return &AntigravityAuth{
-		httpClient: util.SetProxy(&cfg.SDKConfig, &http.Client{}),
+		httpClient: util.SetProxy(&sdkCfg, &http.Client{}),
 	}
 }
 

--- a/internal/auth/antigravity/auth_proxy_test.go
+++ b/internal/auth/antigravity/auth_proxy_test.go
@@ -1,0 +1,42 @@
+package antigravity
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestNewAntigravityAuthWithProxyURL_OverrideDirectDisablesProxy(t *testing.T) {
+	cfg := &config.Config{SDKConfig: config.SDKConfig{ProxyURL: "http://proxy.example.com:8080"}}
+	auth := NewAntigravityAuthWithProxyURL(cfg, "direct")
+
+	transport, ok := auth.httpClient.Transport.(*http.Transport)
+	if !ok || transport == nil {
+		t.Fatalf("expected http.Transport, got %T", auth.httpClient.Transport)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("expected direct transport to disable proxy function")
+	}
+}
+
+func TestNewAntigravityAuthWithProxyURL_OverrideProxyTakesPrecedence(t *testing.T) {
+	cfg := &config.Config{SDKConfig: config.SDKConfig{ProxyURL: "http://global.example.com:8080"}}
+	auth := NewAntigravityAuthWithProxyURL(cfg, "http://override.example.com:8081")
+
+	transport, ok := auth.httpClient.Transport.(*http.Transport)
+	if !ok || transport == nil {
+		t.Fatalf("expected http.Transport, got %T", auth.httpClient.Transport)
+	}
+	req, errReq := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if errReq != nil {
+		t.Fatalf("new request: %v", errReq)
+	}
+	proxyURL, errProxy := transport.Proxy(req)
+	if errProxy != nil {
+		t.Fatalf("proxy func: %v", errProxy)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://override.example.com:8081" {
+		t.Fatalf("proxy URL = %v, want http://override.example.com:8081", proxyURL)
+	}
+}

--- a/internal/auth/kimi/kimi.go
+++ b/internal/auth/kimi/kimi.go
@@ -47,8 +47,14 @@ type KimiAuth struct {
 
 // NewKimiAuth creates a new KimiAuth service instance.
 func NewKimiAuth(cfg *config.Config) *KimiAuth {
+	return NewKimiAuthWithProxyURL(cfg, "")
+}
+
+// NewKimiAuthWithProxyURL creates a new KimiAuth service instance with a proxy override.
+// proxyURL takes precedence over cfg.ProxyURL when non-empty.
+func NewKimiAuthWithProxyURL(cfg *config.Config, proxyURL string) *KimiAuth {
 	return &KimiAuth{
-		deviceClient: NewDeviceFlowClient(cfg),
+		deviceClient: NewDeviceFlowClientWithDeviceIDAndProxyURL(cfg, "", proxyURL),
 		cfg:          cfg,
 	}
 }

--- a/internal/auth/kimi/kimi_proxy_test.go
+++ b/internal/auth/kimi/kimi_proxy_test.go
@@ -40,3 +40,24 @@ func TestNewDeviceFlowClientWithDeviceIDAndProxyURL_OverrideProxyTakesPrecedence
 		t.Fatalf("proxy URL = %v, want http://override.example.com:8081", proxyURL)
 	}
 }
+
+func TestNewKimiAuthWithProxyURL_OverrideProxyTakesPrecedence(t *testing.T) {
+	cfg := &config.Config{SDKConfig: config.SDKConfig{ProxyURL: "http://global.example.com:8080"}}
+	auth := NewKimiAuthWithProxyURL(cfg, "http://override.example.com:8081")
+
+	transport, ok := auth.deviceClient.httpClient.Transport.(*http.Transport)
+	if !ok || transport == nil {
+		t.Fatalf("expected http.Transport, got %T", auth.deviceClient.httpClient.Transport)
+	}
+	req, errReq := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if errReq != nil {
+		t.Fatalf("new request: %v", errReq)
+	}
+	proxyURL, errProxy := transport.Proxy(req)
+	if errProxy != nil {
+		t.Fatalf("proxy func: %v", errProxy)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://override.example.com:8081" {
+		t.Fatalf("proxy URL = %v, want http://override.example.com:8081", proxyURL)
+	}
+}


### PR DESCRIPTION
## Summary

Adds per-OAuth proxy overrides for Management API OAuth flows and persists explicit proxy choices into generated auth files.

Closes #3130

## Key changes

- Adds optional `proxy_url` handling for Codex, Claude/Anthropic, Antigravity, Gemini CLI, and Kimi OAuth start endpoints.
- Validates explicit proxy values and rejects malformed values with `400 invalid proxy_url`.
- Keeps empty `proxy_url` behavior as global proxy inheritance without persisting the global proxy into auth files.
- Persists explicit OAuth proxy values into both `Auth.ProxyURL` and `metadata.proxy_url`.
- Adds proxy override constructors/tests for Antigravity and Kimi.

## Testing

- `go test ./internal/api/handlers/management ./internal/auth/... ./internal/watcher/...`
- `go test ./...`
