### PR TITLE
feat: add deepseek direct executor and proxy integration

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,12 @@
+{
+  "accounts": [
+    {
+      "email": "nabilasalsabilaoktavia21@gmail.com",
+      "name": "nabilasalsabilaoktavia21@gmail.com",
+      "password": "malaquena"
+    }
+  ],
+  "keys": [
+    "malaquena"
+  ]
+}

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -78,6 +78,78 @@ func GetAntigravityModels() []*ModelInfo {
 	return cloneModelInfos(getModels().Antigravity)
 }
 
+// GetDeepSeekModels returns the standard DeepSeek web model definitions.
+func GetDeepSeekModels() []*ModelInfo {
+	return cloneModelInfos([]*ModelInfo{
+		{
+			ID:                  "deepseek-v4-flash",
+			Object:              "model",
+			Created:             1767225600,
+			OwnedBy:             "deepseek",
+			Type:                "deepseek",
+			DisplayName:         "DeepSeek V4 Flash",
+			ContextLength:       128000,
+			MaxCompletionTokens: 32000,
+			Thinking:            &ThinkingSupport{Levels: []string{"low", "medium", "high"}, ZeroAllowed: true},
+		},
+		{
+			ID:                  "deepseek-v4-flash-nothinking",
+			Object:              "model",
+			Created:             1767225600,
+			OwnedBy:             "deepseek",
+			Type:                "deepseek",
+			DisplayName:         "DeepSeek V4 Flash No Thinking",
+			ContextLength:       128000,
+			MaxCompletionTokens: 32000,
+			Thinking:            &ThinkingSupport{ZeroAllowed: true},
+		},
+		{
+			ID:                  "deepseek-v4-flash-search",
+			Object:              "model",
+			Created:             1767225600,
+			OwnedBy:             "deepseek",
+			Type:                "deepseek",
+			DisplayName:         "DeepSeek V4 Flash Search",
+			ContextLength:       128000,
+			MaxCompletionTokens: 32000,
+			Thinking:            &ThinkingSupport{Levels: []string{"low", "medium", "high"}, ZeroAllowed: true},
+		},
+		{
+			ID:                  "deepseek-v4-pro",
+			Object:              "model",
+			Created:             1767225600,
+			OwnedBy:             "deepseek",
+			Type:                "deepseek",
+			DisplayName:         "DeepSeek V4 Pro",
+			ContextLength:       128000,
+			MaxCompletionTokens: 32000,
+			Thinking:            &ThinkingSupport{Levels: []string{"low", "medium", "high"}, ZeroAllowed: true},
+		},
+		{
+			ID:                  "deepseek-v4-pro-nothinking",
+			Object:              "model",
+			Created:             1767225600,
+			OwnedBy:             "deepseek",
+			Type:                "deepseek",
+			DisplayName:         "DeepSeek V4 Pro No Thinking",
+			ContextLength:       128000,
+			MaxCompletionTokens: 32000,
+			Thinking:            &ThinkingSupport{ZeroAllowed: true},
+		},
+		{
+			ID:                  "deepseek-v4-pro-search",
+			Object:              "model",
+			Created:             1767225600,
+			OwnedBy:             "deepseek",
+			Type:                "deepseek",
+			DisplayName:         "DeepSeek V4 Pro Search",
+			ContextLength:       128000,
+			MaxCompletionTokens: 32000,
+			Thinking:            &ThinkingSupport{Levels: []string{"low", "medium", "high"}, ZeroAllowed: true},
+		},
+	})
+}
+
 // WithCodexBuiltins injects hard-coded Codex-only model definitions that should
 // not depend on remote models.json updates. Built-ins replace any matching IDs
 // already present in the provided slice.
@@ -167,6 +239,7 @@ func cloneModelInfos(models []*ModelInfo) []*ModelInfo {
 //   - codex
 //   - kimi
 //   - antigravity
+//   - deepseek
 func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	key := strings.ToLower(strings.TrimSpace(channel))
 	switch key {
@@ -186,6 +259,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		return GetKimiModels()
 	case "antigravity":
 		return GetAntigravityModels()
+	case "deepseek":
+		return GetDeepSeekModels()
 	default:
 		return nil
 	}
@@ -208,6 +283,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		data.CodexPro,
 		data.Kimi,
 		data.Antigravity,
+		GetDeepSeekModels(),
 	}
 	for _, models := range allModels {
 		for _, m := range models {

--- a/internal/runtime/executor/deepseek_direct_client.go
+++ b/internal/runtime/executor/deepseek_direct_client.go
@@ -1,0 +1,406 @@
+package executor
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/andybalholm/brotli"
+	utls "github.com/refraction-networking/utls"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	deepSeekLoginURL             = "https://chat.deepseek.com/api/v0/users/login"
+	deepSeekCreateSessionURL     = "https://chat.deepseek.com/api/v0/chat_session/create"
+	deepSeekCreatePowURL         = "https://chat.deepseek.com/api/v0/chat/create_pow_challenge"
+	deepSeekCompletionURL        = "https://chat.deepseek.com/api/v0/chat/completion"
+	deepSeekContinueURL          = "https://chat.deepseek.com/api/v0/chat/continue"
+	deepSeekDeleteSessionURL     = "https://chat.deepseek.com/api/v0/chat_session/delete"
+	deepSeekCompletionTargetPath = "/api/v0/chat/completion"
+	deepSeekMaxContinueRounds    = 8
+)
+
+var deepSeekBaseHeaders = map[string]string{
+	"Host":              "chat.deepseek.com",
+	"Accept":            "application/json",
+	"Content-Type":      "application/json",
+	"accept-charset":    "UTF-8",
+	"User-Agent":        "DeepSeek/2.0.1 Android/35",
+	"x-client-platform": "android",
+	"x-client-version":  "2.0.1",
+	"x-client-locale":   "zh_CN",
+}
+
+func (e *DeepSeekProxyExecutor) openCompletion(ctx context.Context, auth *cliproxyauth.Auth, dsAuth *deepSeekAuth, request deepSeekRequest, originalBody []byte) (string, *http.Response, error) {
+	sessionID, err := e.createSession(ctx, dsAuth.Token)
+	if err != nil && isDeepSeekAuthError(err) {
+		if refreshed, refreshErr := e.refreshAuthToken(ctx, auth, dsAuth); refreshErr == nil && refreshed {
+			sessionID, err = e.createSession(ctx, dsAuth.Token)
+		}
+	}
+	if err != nil {
+		return "", nil, err
+	}
+	powHeader, err := e.getPowHeader(ctx, dsAuth.Token)
+	if err != nil && isDeepSeekAuthError(err) {
+		if refreshed, refreshErr := e.refreshAuthToken(ctx, auth, dsAuth); refreshErr == nil && refreshed {
+			powHeader, err = e.getPowHeader(ctx, dsAuth.Token)
+		}
+	}
+	if err != nil {
+		return "", nil, err
+	}
+	payload := request.completionPayload(sessionID)
+	headers := e.authHeaders(dsAuth.Token)
+	headers["x-ds-pow-response"] = powHeader
+	body, _ := json.Marshal(payload)
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       deepSeekCompletionURL,
+		Method:    http.MethodPost,
+		Headers:   headersToHTTPHeader(headers),
+		Body:      originalBody,
+		Provider:  e.Identifier(),
+		AuthID:    authID(auth),
+		AuthLabel: authLabel(auth),
+		AuthType:  "deepseek",
+		AuthValue: authLabel(auth),
+	})
+	resp, err := e.postRaw(ctx, e.stream, deepSeekCompletionURL, headers, body)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return "", nil, err
+	}
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, resp.StatusCode, resp.Header.Clone())
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := readDeepSeekResponseBody(resp)
+		_ = resp.Body.Close()
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		return "", nil, statusErr{code: resp.StatusCode, msg: string(b)}
+	}
+	return sessionID, resp, nil
+}
+
+func (e *DeepSeekProxyExecutor) collectDeepSeekResponse(ctx context.Context, auth *cliproxyauth.Auth, dsAuth *deepSeekAuth, initial *http.Response, sessionID string, request deepSeekRequest) (deepSeekResult, error) {
+	var result deepSeekResult
+	state := deepSeekContinueState{SessionID: sessionID}
+	current := initial
+	for round := 0; ; round++ {
+		partial, err := consumeDeepSeekSSE(ctx, current.Body, request.Thinking, &state, func(line []byte) {
+			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+		})
+		_ = current.Body.Close()
+		result.Content += partial.Content
+		result.Reasoning += partial.Reasoning
+		if err != nil {
+			return result, err
+		}
+		if !state.shouldContinue() || round >= deepSeekMaxContinueRounds {
+			return result, nil
+		}
+		next, err := e.callContinue(ctx, auth, dsAuth, sessionID, state.ResponseMessageID)
+		if err != nil {
+			return result, err
+		}
+		current = next
+		state.prepareNext()
+	}
+}
+
+func (e *DeepSeekProxyExecutor) resolveDeepSeekAuth(ctx context.Context, auth *cliproxyauth.Auth) (*deepSeekAuth, error) {
+	if auth == nil {
+		return nil, statusErr{code: http.StatusUnauthorized, msg: "deepseek auth is missing"}
+	}
+	if token := extractDeepSeekToken(auth); token != "" {
+		return &deepSeekAuth{Token: token, AccountID: auth.ID}, nil
+	}
+	token, err := e.login(ctx, auth)
+	if err != nil {
+		return nil, err
+	}
+	setDeepSeekAuthToken(auth, token)
+	return &deepSeekAuth{Token: token, AccountID: auth.ID}, nil
+}
+
+func (e *DeepSeekProxyExecutor) refreshAuthToken(ctx context.Context, auth *cliproxyauth.Auth, dsAuth *deepSeekAuth) (bool, error) {
+	token, err := e.login(ctx, auth)
+	if err != nil {
+		return false, err
+	}
+	setDeepSeekAuthToken(auth, token)
+	dsAuth.Token = token
+	return true, nil
+}
+
+func (e *DeepSeekProxyExecutor) login(ctx context.Context, auth *cliproxyauth.Auth) (string, error) {
+	payload := map[string]any{
+		"password":  strings.TrimSpace(stringFromAuth(auth, "password")),
+		"device_id": "deepseek_to_api",
+		"os":        "android",
+	}
+	if payload["password"] == "" {
+		return "", statusErr{code: http.StatusUnauthorized, msg: "deepseek password is missing"}
+	}
+	if email := strings.TrimSpace(stringFromAuth(auth, "email")); email != "" {
+		payload["email"] = email
+	} else if mobile := strings.TrimSpace(stringFromAuth(auth, "mobile")); mobile != "" {
+		loginMobile, areaCode := normalizeDeepSeekMobile(mobile)
+		payload["mobile"] = loginMobile
+		if areaCode != nil {
+			payload["area_code"] = areaCode
+		}
+	} else {
+		return "", statusErr{code: http.StatusUnauthorized, msg: "deepseek email/mobile is missing"}
+	}
+	body, status, err := e.postJSON(ctx, e.regular, deepSeekLoginURL, deepSeekBaseHeaders, payload)
+	if err != nil {
+		return "", err
+	}
+	code, bizCode, msg, bizMsg := deepSeekResponseStatus(body)
+	if status != http.StatusOK || code != 0 || bizCode != 0 {
+		return "", statusErr{code: statusCodeOr(status, http.StatusUnauthorized), msg: failureMessage(msg, bizMsg, "deepseek login failed")}
+	}
+	token := jsonPointerString(body, "data", "biz_data", "user", "token")
+	if token == "" {
+		return "", statusErr{code: http.StatusUnauthorized, msg: "deepseek login token is missing"}
+	}
+	return token, nil
+}
+
+func (e *DeepSeekProxyExecutor) createSession(ctx context.Context, token string) (string, error) {
+	body, status, err := e.postJSON(ctx, e.regular, deepSeekCreateSessionURL, e.authHeaders(token), map[string]any{"agent": "chat"})
+	if err != nil {
+		return "", err
+	}
+	code, bizCode, msg, bizMsg := deepSeekResponseStatus(body)
+	if status == http.StatusOK && code == 0 && bizCode == 0 {
+		if sessionID := jsonPointerString(body, "data", "biz_data", "id"); sessionID != "" {
+			return sessionID, nil
+		}
+		if sessionID := jsonPointerString(body, "data", "biz_data", "chat_session", "id"); sessionID != "" {
+			return sessionID, nil
+		}
+	}
+	return "", deepSeekAPIError{status: status, code: code, bizCode: bizCode, msg: failureMessage(msg, bizMsg, "create session failed")}
+}
+
+func (e *DeepSeekProxyExecutor) getPowHeader(ctx context.Context, token string) (string, error) {
+	body, status, err := e.postJSON(ctx, e.regular, deepSeekCreatePowURL, e.authHeaders(token), map[string]any{"target_path": deepSeekCompletionTargetPath})
+	if err != nil {
+		return "", err
+	}
+	code, bizCode, msg, bizMsg := deepSeekResponseStatus(body)
+	if status != http.StatusOK || code != 0 || bizCode != 0 {
+		return "", deepSeekAPIError{status: status, code: code, bizCode: bizCode, msg: failureMessage(msg, bizMsg, "get pow failed")}
+	}
+	challenge, _ := jsonPointer(body, "data", "biz_data", "challenge").(map[string]any)
+	if challenge == nil {
+		return "", errors.New("deepseek pow challenge is missing")
+	}
+	answer, err := solveDeepSeekPow(ctx, challenge)
+	if err != nil {
+		return "", err
+	}
+	return buildDeepSeekPowHeader(challenge, answer)
+}
+
+func (e *DeepSeekProxyExecutor) callContinue(ctx context.Context, auth *cliproxyauth.Auth, dsAuth *deepSeekAuth, sessionID string, messageID int) (*http.Response, error) {
+	if sessionID == "" || messageID <= 0 {
+		return nil, errors.New("missing deepseek continue identifiers")
+	}
+	payload := map[string]any{"chat_session_id": sessionID, "message_id": messageID, "fallback_to_resume": true}
+	powHeader, err := e.getPowHeader(ctx, dsAuth.Token)
+	if err != nil {
+		return nil, err
+	}
+	headers := e.authHeaders(dsAuth.Token)
+	headers["x-ds-pow-response"] = powHeader
+	body, _ := json.Marshal(payload)
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       deepSeekContinueURL,
+		Method:    http.MethodPost,
+		Headers:   headersToHTTPHeader(headers),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID(auth),
+		AuthLabel: authLabel(auth),
+		AuthType:  "deepseek",
+		AuthValue: authLabel(auth),
+	})
+	resp, err := e.postRaw(ctx, e.stream, deepSeekContinueURL, headers, body)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return nil, err
+	}
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, resp.StatusCode, resp.Header.Clone())
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := readDeepSeekResponseBody(resp)
+		_ = resp.Body.Close()
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		return nil, statusErr{code: resp.StatusCode, msg: string(b)}
+	}
+	return resp, nil
+}
+
+func (e *DeepSeekProxyExecutor) deleteSession(ctx context.Context, token, sessionID string) {
+	if token == "" || sessionID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	_, _, err := e.postJSON(ctx, e.regular, deepSeekDeleteSessionURL, e.authHeaders(token), map[string]any{"chat_session_id": sessionID})
+	if err != nil {
+		log.Debugf("deepseek delete session failed: %v", err)
+	}
+}
+
+func (e *DeepSeekProxyExecutor) authHeaders(token string) map[string]string {
+	headers := make(map[string]string, len(deepSeekBaseHeaders)+1)
+	for key, value := range deepSeekBaseHeaders {
+		headers[key] = value
+	}
+	headers["authorization"] = "Bearer " + token
+	return headers
+}
+
+func (e *DeepSeekProxyExecutor) postJSON(ctx context.Context, client *http.Client, url string, headers map[string]string, payload any) (map[string]any, int, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, 0, err
+	}
+	resp, err := e.postRaw(ctx, client, url, headers, body)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer closeDeepSeekBody(resp.Body)
+	payloadBytes, err := readDeepSeekResponseBody(resp)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	out := map[string]any{}
+	if len(payloadBytes) > 0 {
+		if err := json.Unmarshal(payloadBytes, &out); err != nil {
+			return nil, resp.StatusCode, fmt.Errorf("deepseek json parse failed: %w", err)
+		}
+	}
+	return out, resp.StatusCode, nil
+}
+
+func (e *DeepSeekProxyExecutor) postRaw(ctx context.Context, client *http.Client, url string, headers map[string]string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	return client.Do(req)
+}
+
+func newDeepSeekHTTPClient(timeout time.Duration) *http.Client {
+	dialContext := (&net.Dialer{Timeout: 15 * time.Second, KeepAlive: 30 * time.Second}).DialContext
+	transport := &http.Transport{
+		ForceAttemptHTTP2:   false,
+		MaxIdleConns:        200,
+		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
+		Proxy:               http.ProxyFromEnvironment,
+		DialContext:         dialContext,
+		DialTLSContext:      safariTLSDialer(dialContext),
+		TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS12},
+	}
+	return &http.Client{Timeout: timeout, Transport: transport}
+}
+
+func safariTLSDialer(dialContext func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		plainConn, err := dialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		host, _, _ := net.SplitHostPort(addr)
+		uConn := utls.UClient(plainConn, &utls.Config{ServerName: host}, utls.HelloSafari_Auto)
+		if err := forceHTTP11ALPN(uConn); err != nil {
+			_ = plainConn.Close()
+			return nil, err
+		}
+		if err := uConn.HandshakeContext(ctx); err != nil {
+			_ = plainConn.Close()
+			return nil, err
+		}
+		if negotiated := uConn.ConnectionState().NegotiatedProtocol; negotiated != "" && negotiated != "http/1.1" {
+			_ = uConn.Close()
+			return nil, fmt.Errorf("unexpected ALPN protocol negotiated: %s", negotiated)
+		}
+		return uConn, nil
+	}
+}
+
+func forceHTTP11ALPN(uConn *utls.UConn) error {
+	if err := uConn.BuildHandshakeState(); err != nil {
+		return err
+	}
+	for _, ext := range uConn.Extensions {
+		alpnExt, ok := ext.(*utls.ALPNExtension)
+		if !ok {
+			continue
+		}
+		alpnExt.AlpnProtocols = []string{"http/1.1"}
+		return nil
+	}
+	return nil
+}
+
+func readDeepSeekResponseBody(resp *http.Response) ([]byte, error) {
+	encoding := strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Encoding")))
+	var reader io.Reader = resp.Body
+	switch encoding {
+	case "gzip":
+		gz, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = gz.Close() }()
+		reader = gz
+	case "br":
+		reader = brotli.NewReader(resp.Body)
+	}
+	return io.ReadAll(reader)
+}
+
+func closeDeepSeekBody(body io.Closer) {
+	if body == nil {
+		return
+	}
+	if err := body.Close(); err != nil {
+		log.Errorf("deepseek executor: close response body error: %v", err)
+	}
+}
+
+func normalizeDeepSeekMobile(raw string) (string, any) {
+	s := strings.TrimSpace(raw)
+	hasPlus := strings.HasPrefix(s, "+")
+	var b strings.Builder
+	for _, r := range s {
+		if unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	digits := b.String()
+	if (hasPlus || strings.HasPrefix(digits, "86")) && strings.HasPrefix(digits, "86") && len(digits) == 13 {
+		return digits[2:], nil
+	}
+	return digits, nil
+}

--- a/internal/runtime/executor/deepseek_direct_compat.go
+++ b/internal/runtime/executor/deepseek_direct_compat.go
@@ -1,0 +1,359 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+type deepSeekAuth struct {
+	Token     string
+	AccountID string
+}
+
+type deepSeekRequest struct {
+	RequestedModel string
+	ResolvedModel  string
+	Prompt         string
+	Stream         bool
+	Thinking       bool
+	Search         bool
+	PassThrough    map[string]any
+}
+
+func (r deepSeekRequest) completionPayload(sessionID string) map[string]any {
+	payload := map[string]any{
+		"chat_session_id":   sessionID,
+		"model_type":        deepSeekModelType(r.ResolvedModel),
+		"parent_message_id": nil,
+		"prompt":            r.Prompt,
+		"ref_file_ids":      []any{},
+		"thinking_enabled":  r.Thinking,
+		"search_enabled":    r.Search,
+	}
+	for key, value := range r.PassThrough {
+		payload[key] = value
+	}
+	return payload
+}
+
+func prepareDeepSeekRequest(body []byte, fallbackModel string) (deepSeekRequest, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return deepSeekRequest{}, err
+	}
+	model := strings.TrimSpace(asString(raw["model"]))
+	if model == "" {
+		model = fallbackModel
+	}
+	resolved := resolveDeepSeekModel(model)
+	if resolved == "" {
+		return deepSeekRequest{}, statusErr{code: http.StatusBadRequest, msg: "unsupported deepseek model: " + model}
+	}
+	thinkingEnabled, searchEnabled := deepSeekModelConfig(resolved)
+	if val, ok := raw["thinking"].(bool); ok {
+		thinkingEnabled = val
+	}
+	prompt, err := buildDeepSeekPrompt(raw)
+	if err != nil {
+		return deepSeekRequest{}, err
+	}
+	passThrough := map[string]any{}
+	for _, key := range []string{"temperature", "top_p", "max_tokens", "max_completion_tokens", "presence_penalty", "frequency_penalty", "stop"} {
+		if value, ok := raw[key]; ok {
+			passThrough[key] = value
+		}
+	}
+	return deepSeekRequest{
+		RequestedModel: model,
+		ResolvedModel:  resolved,
+		Prompt:         prompt,
+		Stream:         boolValue(raw["stream"]),
+		Thinking:       thinkingEnabled,
+		Search:         searchEnabled,
+		PassThrough:    passThrough,
+	}, nil
+}
+
+func buildDeepSeekPrompt(req map[string]any) (string, error) {
+	messages, ok := req["messages"].([]any)
+	if !ok || len(messages) == 0 {
+		return "", statusErr{code: http.StatusBadRequest, msg: "OpenAI messages array is required"}
+	}
+	var b strings.Builder
+	b.WriteString("<｜begin▁of▁sentence｜>")
+	for _, item := range messages {
+		msg, _ := item.(map[string]any)
+		role := asString(msg["role"])
+		content := normalizeDeepSeekMessageContent(msg["content"])
+		switch role {
+		case "system", "developer":
+			b.WriteString("<｜System｜>")
+			b.WriteString(content)
+			b.WriteString("<｜end▁of▁instructions｜>")
+		case "assistant":
+			b.WriteString("<｜Assistant｜>")
+			if reasoning := asString(msg["reasoning_content"]); reasoning != "" {
+				b.WriteString("[reasoning_content]\n")
+				b.WriteString(reasoning)
+				b.WriteString("\n[/reasoning_content]\n")
+			}
+			b.WriteString(content)
+			b.WriteString("<｜end▁of▁sentence｜>")
+		case "tool":
+			b.WriteString("<｜Tool｜>")
+			b.WriteString(content)
+			b.WriteString("<｜end▁of▁toolresults｜>")
+		default:
+			b.WriteString("<｜User｜>")
+			b.WriteString(content)
+		}
+	}
+	if tools, ok := req["tools"]; ok {
+		if toolPrompt := buildDeepSeekToolPrompt(tools); toolPrompt != "" {
+			b.WriteString("<｜System｜>")
+			b.WriteString(toolPrompt)
+			b.WriteString("<｜end▁of▁instructions｜>")
+		}
+	}
+	b.WriteString("<｜Assistant｜>")
+	return b.String(), nil
+}
+
+func buildDeepSeekToolPrompt(tools any) string {
+	items, ok := tools.([]any)
+	if !ok || len(items) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\nYou may call tools when needed. Return tool calls as JSON inside <tool_call>...</tool_call>. Available tools:\n")
+	for _, item := range items {
+		m, _ := item.(map[string]any)
+		fn, _ := m["function"].(map[string]any)
+		name := asString(fn["name"])
+		if name == "" {
+			continue
+		}
+		b.WriteString("- ")
+		b.WriteString(name)
+		if desc := asString(fn["description"]); desc != "" {
+			b.WriteString(": ")
+			b.WriteString(desc)
+		}
+		if params, ok := fn["parameters"]; ok {
+			encoded, _ := json.Marshal(params)
+			if len(encoded) > 0 {
+				b.WriteString(" Parameters: ")
+				b.Write(encoded)
+			}
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func normalizeDeepSeekMessageContent(content any) string {
+	switch typed := content.(type) {
+	case string:
+		return typed
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, part := range typed {
+			m, _ := part.(map[string]any)
+			if text := asString(m["text"]); text != "" {
+				parts = append(parts, text)
+				continue
+			}
+			if image, _ := m["image_url"].(map[string]any); image != nil {
+				if url := asString(image["url"]); url != "" {
+					parts = append(parts, "[image: "+url+"]")
+				}
+			}
+		}
+		return strings.Join(parts, "\n")
+	case nil:
+		return ""
+	default:
+		b, _ := json.Marshal(typed)
+		return string(b)
+	}
+}
+
+type deepSeekResult struct {
+	Content   string
+	Reasoning string
+}
+
+type deepSeekSegment struct {
+	Text string
+	Kind string
+}
+
+type deepSeekContinueState struct {
+	SessionID         string
+	ResponseMessageID int
+	LastStatus        string
+	Finished          bool
+}
+
+func (s *deepSeekContinueState) shouldContinue() bool {
+	if s == nil || s.Finished || s.SessionID == "" || s.ResponseMessageID <= 0 {
+		return false
+	}
+	switch strings.ToUpper(strings.TrimSpace(s.LastStatus)) {
+	case "WIP", "INCOMPLETE", "AUTO_CONTINUE":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *deepSeekContinueState) prepareNext() {
+	s.Finished = false
+	s.LastStatus = ""
+}
+
+func consumeDeepSeekSSE(ctx context.Context, body ioReader, thinkingEnabled bool, state *deepSeekContinueState, observeRaw func([]byte)) (deepSeekResult, error) {
+	var result deepSeekResult
+	err := scanDeepSeekSSE(ctx, body, thinkingEnabled, state, observeRaw, func(segment deepSeekSegment) bool {
+		if segment.Kind == "reasoning" {
+			result.Reasoning += segment.Text
+		} else {
+			result.Content += segment.Text
+		}
+		return true
+	})
+	return result, err
+}
+
+type ioReader interface {
+	Read([]byte) (int, error)
+}
+
+func scanDeepSeekSSE(ctx context.Context, body ioReader, thinkingEnabled bool, state *deepSeekContinueState, observeRaw func([]byte), emit func(deepSeekSegment) bool) error {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 52_428_800)
+	currentType := "text"
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		if observeRaw != nil {
+			observeRaw(bytes.Clone(line))
+		}
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := strings.TrimSpace(string(bytes.TrimPrefix(line, []byte("data:"))))
+		if data == "[DONE]" {
+			continue
+		}
+		segments, nextType := parseDeepSeekSSEPayload(data, thinkingEnabled, currentType, state)
+		currentType = nextType
+		for _, segment := range segments {
+			if !emit(segment) {
+				return ctx.Err()
+			}
+		}
+	}
+	return scanner.Err()
+}
+
+func parseDeepSeekSSEPayload(data string, thinkingEnabled bool, currentType string, state *deepSeekContinueState) ([]deepSeekSegment, string) {
+	var chunk map[string]any
+	if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+		return nil, currentType
+	}
+	observeDeepSeekContinue(chunk, state)
+	if asString(chunk["code"]) == "content_filter" {
+		return []deepSeekSegment{{Text: "[content filtered]", Kind: "content"}}, currentType
+	}
+	path := asString(chunk["p"])
+	if shouldSkipDeepSeekPath(path) {
+		return nil, currentType
+	}
+	if isDeepSeekStatusPath(path) {
+		if strings.EqualFold(asString(chunk["v"]), "FINISHED") && state != nil {
+			state.Finished = true
+		}
+		return nil, currentType
+	}
+	segments := make([]deepSeekSegment, 0, 4)
+	nextType := currentType
+	appendDeepSeekValueSegments(chunk["v"], path, thinkingEnabled, &nextType, &segments)
+	return segments, nextType
+}
+
+func appendDeepSeekValueSegments(value any, path string, thinkingEnabled bool, currentType *string, out *[]deepSeekSegment) {
+	switch typed := value.(type) {
+	case string:
+		if typed == "" || typed == "FINISHED" {
+			return
+		}
+		kind := kindForDeepSeekPath(path, *currentType)
+		if kind == "reasoning" && !thinkingEnabled {
+			*currentType = "text"
+			return
+		}
+		*out = append(*out, deepSeekSegment{Text: typed, Kind: kind})
+	case []any:
+		for _, item := range typed {
+			appendDeepSeekItemSegments(item, path, thinkingEnabled, currentType, out)
+		}
+	case map[string]any:
+		if response, ok := typed["response"]; ok {
+			appendDeepSeekValueSegments(response, "response", thinkingEnabled, currentType, out)
+			return
+		}
+		if fragments, ok := typed["fragments"]; ok {
+			appendDeepSeekValueSegments(fragments, "response/fragments", thinkingEnabled, currentType, out)
+		}
+	}
+}
+
+func appendDeepSeekItemSegments(item any, parentPath string, thinkingEnabled bool, currentType *string, out *[]deepSeekSegment) {
+	m, ok := item.(map[string]any)
+	if !ok {
+		appendDeepSeekValueSegments(item, parentPath, thinkingEnabled, currentType, out)
+		return
+	}
+	path := asString(m["p"])
+	if path == "" {
+		path = parentPath
+	}
+	if shouldSkipDeepSeekPath(path) || isDeepSeekStatusPath(path) {
+		return
+	}
+	if content := asString(m["content"]); content != "" {
+		kind := "content"
+		typeName := strings.ToUpper(firstNonEmpty(asString(m["type"]), asString(m["fragment_type"])))
+		switch typeName {
+		case "THINK", "THINKING":
+			kind = "reasoning"
+			*currentType = "reasoning"
+		case "RESPONSE":
+			kind = "content"
+			*currentType = "text"
+		default:
+			kind = kindForDeepSeekPath(path, *currentType)
+		}
+		if kind == "reasoning" && !thinkingEnabled {
+			*currentType = "text"
+			return
+		}
+		*out = append(*out, deepSeekSegment{Text: content, Kind: kind})
+		return
+	}
+	if value, ok := m["v"]; ok {
+		appendDeepSeekValueSegments(value, path, thinkingEnabled, currentType, out)
+	}
+}

--- a/internal/runtime/executor/deepseek_direct_executor.go
+++ b/internal/runtime/executor/deepseek_direct_executor.go
@@ -1,0 +1,269 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/sjson"
+)
+
+// DeepSeekProxyExecutor executes DeepSeek web models directly against chat.deepseek.com.
+type DeepSeekProxyExecutor struct {
+	cfg     *config.Config
+	regular *http.Client
+	stream  *http.Client
+}
+
+func NewDeepSeekProxyExecutor(cfg *config.Config) *DeepSeekProxyExecutor {
+	return &DeepSeekProxyExecutor{
+		cfg:     cfg,
+		regular: newDeepSeekHTTPClient(60 * time.Second),
+		stream:  newDeepSeekHTTPClient(0),
+	}
+}
+
+func (e *DeepSeekProxyExecutor) Identifier() string { return "deepseek" }
+
+func (e *DeepSeekProxyExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	reporter := helps.NewUsageReporter(ctx, e.Identifier(), baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("openai")
+	translated, err := e.prepareOpenAIRequest(baseModel, req, opts, false)
+	if err != nil {
+		return resp, err
+	}
+	request, err := prepareDeepSeekRequest(translated, baseModel)
+	if err != nil {
+		return resp, err
+	}
+	request.Stream = false
+	dsAuth, err := e.resolveDeepSeekAuth(ctx, auth)
+	if err != nil {
+		return resp, err
+	}
+	sessionID, upstream, err := e.openCompletion(ctx, auth, dsAuth, request, translated)
+	if err != nil {
+		return resp, err
+	}
+	defer closeDeepSeekBody(upstream.Body)
+	defer e.deleteSession(context.WithoutCancel(ctx), dsAuth.Token, sessionID)
+
+	result, err := e.collectDeepSeekResponse(ctx, auth, dsAuth, upstream, sessionID, request)
+	if err != nil {
+		return resp, err
+	}
+	body := buildOpenAINonStreamResponse(request.RequestedModel, result.Content, result.Reasoning)
+	reporter.Publish(ctx, helps.ParseOpenAIUsage(body))
+	reporter.EnsurePublished(ctx)
+	var param any
+	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, body, &param)
+	return cliproxyexecutor.Response{Payload: out, Headers: upstream.Header.Clone()}, nil
+}
+
+func (e *DeepSeekProxyExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	reporter := helps.NewUsageReporter(ctx, e.Identifier(), baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("openai")
+	translated, err := e.prepareOpenAIRequest(baseModel, req, opts, true)
+	if err != nil {
+		return nil, err
+	}
+	request, err := prepareDeepSeekRequest(translated, baseModel)
+	if err != nil {
+		return nil, err
+	}
+	request.Stream = true
+	dsAuth, err := e.resolveDeepSeekAuth(ctx, auth)
+	if err != nil {
+		return nil, err
+	}
+	sessionID, upstream, err := e.openCompletion(ctx, auth, dsAuth, request, translated)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		defer e.deleteSession(context.WithoutCancel(ctx), dsAuth.Token, sessionID)
+		defer reporter.EnsurePublished(ctx)
+		var param any
+		emit := func(line []byte) bool {
+			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, line, &param)
+			for i := range chunks {
+				select {
+				case <-ctx.Done():
+					out <- cliproxyexecutor.StreamChunk{Err: ctx.Err()}
+					return false
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				}
+			}
+			return true
+		}
+		if errStream := e.streamDeepSeekAsOpenAI(ctx, auth, dsAuth, upstream, sessionID, request, emit); errStream != nil {
+			helps.RecordAPIResponseError(ctx, e.cfg, errStream)
+			reporter.PublishFailure(ctx)
+			out <- cliproxyexecutor.StreamChunk{Err: errStream}
+		}
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: upstream.Header.Clone(), Chunks: out}, nil
+}
+
+func (e *DeepSeekProxyExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return (&OpenAICompatExecutor{provider: e.Identifier(), cfg: e.cfg}).CountTokens(ctx, auth, req, opts)
+}
+
+func (e *DeepSeekProxyExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	if auth == nil {
+		return nil, statusErr{code: http.StatusUnauthorized, msg: "deepseek auth is missing"}
+	}
+	clone := auth.Clone()
+	token, err := e.login(ctx, clone)
+	if err != nil {
+		return nil, err
+	}
+	setDeepSeekAuthToken(clone, token)
+	return clone, nil
+}
+
+func (e *DeepSeekProxyExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("deepseek executor: request is nil")
+	}
+	dsAuth, err := e.resolveDeepSeekAuth(ctx, auth)
+	if err != nil {
+		return nil, err
+	}
+	httpReq := req.WithContext(ctx)
+	for key, value := range e.authHeaders(dsAuth.Token) {
+		httpReq.Header.Set(key, value)
+	}
+	return e.regular.Do(httpReq)
+}
+
+func (e *DeepSeekProxyExecutor) prepareOpenAIRequest(baseModel string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) ([]byte, error) {
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("openai")
+	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
+	translated, err := sjson.SetBytes(translated, "model", baseModel)
+	if err != nil {
+		return nil, fmt.Errorf("deepseek executor: failed to set model: %w", err)
+	}
+	translated, _ = sjson.SetBytes(translated, "stream", stream)
+	if stream {
+		translated, _ = sjson.SetBytes(translated, "stream_options.include_usage", true)
+	}
+	return thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+}
+
+func (e *DeepSeekProxyExecutor) streamDeepSeekAsOpenAI(ctx context.Context, auth *cliproxyauth.Auth, dsAuth *deepSeekAuth, initial *http.Response, sessionID string, request deepSeekRequest, emit func([]byte) bool) error {
+	completionID := "chatcmpl-" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	created := time.Now().Unix()
+	state := deepSeekContinueState{SessionID: sessionID}
+	current := initial
+	sentRole := false
+	for round := 0; ; round++ {
+		err := scanDeepSeekSSE(ctx, current.Body, request.Thinking, &state, func(line []byte) {
+			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+		}, func(seg deepSeekSegment) bool {
+			if seg.Text == "" {
+				return true
+			}
+			chunk := buildOpenAIStreamChunk(completionID, request.RequestedModel, created, seg, !sentRole)
+			sentRole = true
+			return emit(chunk)
+		})
+		_ = current.Body.Close()
+		if err != nil {
+			return err
+		}
+		if !state.shouldContinue() || round >= deepSeekMaxContinueRounds {
+			break
+		}
+		next, err := e.callContinue(ctx, auth, dsAuth, sessionID, state.ResponseMessageID)
+		if err != nil {
+			return err
+		}
+		current = next
+		state.prepareNext()
+	}
+	if !emit(buildOpenAIFinishChunk(completionID, request.RequestedModel, created)) {
+		return ctx.Err()
+	}
+	if !emit([]byte("data: [DONE]\n\n")) {
+		return ctx.Err()
+	}
+	return nil
+}
+
+func buildOpenAINonStreamResponse(model, content, reasoning string) []byte {
+	message := map[string]any{"role": "assistant", "content": content}
+	if reasoning != "" {
+		message["reasoning_content"] = reasoning
+	}
+	body := map[string]any{
+		"id":      "chatcmpl-" + strconv.FormatInt(time.Now().UnixNano(), 36),
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []any{map[string]any{"index": 0, "message": message, "finish_reason": "stop"}},
+		"usage":   map[string]any{"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+	}
+	b, _ := json.Marshal(body)
+	return b
+}
+
+func buildOpenAIStreamChunk(id, model string, created int64, segment deepSeekSegment, includeRole bool) []byte {
+	delta := map[string]any{}
+	if includeRole {
+		delta["role"] = "assistant"
+	}
+	if segment.Kind == "reasoning" {
+		delta["reasoning_content"] = segment.Text
+	} else {
+		delta["content"] = segment.Text
+	}
+	body := map[string]any{
+		"id":      id,
+		"object":  "chat.completion.chunk",
+		"created": created,
+		"model":   model,
+		"choices": []any{map[string]any{"index": 0, "delta": delta, "finish_reason": nil}},
+	}
+	b, _ := json.Marshal(body)
+	return append(append([]byte("data: "), b...), []byte("\n\n")...)
+}
+
+func buildOpenAIFinishChunk(id, model string, created int64) []byte {
+	body := map[string]any{
+		"id":      id,
+		"object":  "chat.completion.chunk",
+		"created": created,
+		"model":   model,
+		"choices": []any{map[string]any{"index": 0, "delta": map[string]any{}, "finish_reason": "stop"}},
+		"usage":   map[string]any{"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+	}
+	b, _ := json.Marshal(body)
+	return append(append([]byte("data: "), b...), []byte("\n\n")...)
+}
+
+func bytesHasDataPrefix(line []byte) bool {
+	return bytes.HasPrefix(bytes.TrimSpace(line), []byte("data:"))
+}

--- a/internal/runtime/executor/deepseek_direct_helpers.go
+++ b/internal/runtime/executor/deepseek_direct_helpers.go
@@ -1,0 +1,338 @@
+package executor
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func observeDeepSeekContinue(chunk map[string]any, state *deepSeekContinueState) {
+	if state == nil {
+		return
+	}
+	if id := intFromAny(chunk["response_message_id"]); id > 0 {
+		state.ResponseMessageID = id
+	}
+	if asString(chunk["p"]) == "response/status" {
+		if status := asString(chunk["v"]); status != "" {
+			state.LastStatus = strings.TrimSpace(status)
+			if strings.EqualFold(status, "FINISHED") {
+				state.Finished = true
+			}
+		}
+	}
+	for _, rootKey := range []string{"v", "message"} {
+		root, _ := chunk[rootKey].(map[string]any)
+		response, _ := root["response"].(map[string]any)
+		if response == nil {
+			continue
+		}
+		if id := intFromAny(response["message_id"]); id > 0 {
+			state.ResponseMessageID = id
+		}
+		if status := asString(response["status"]); status != "" {
+			state.LastStatus = strings.TrimSpace(status)
+			if strings.EqualFold(status, "FINISHED") {
+				state.Finished = true
+			}
+		}
+		if autoContinue, _ := response["auto_continue"].(bool); autoContinue {
+			state.LastStatus = "AUTO_CONTINUE"
+		}
+	}
+}
+
+func kindForDeepSeekPath(path string, currentType string) string {
+	path = strings.ToLower(path)
+	if strings.Contains(path, "thinking") {
+		return "reasoning"
+	}
+	if strings.Contains(path, "content") {
+		return "content"
+	}
+	if currentType == "thinking" || currentType == "reasoning" {
+		return "reasoning"
+	}
+	return "content"
+}
+
+func shouldSkipDeepSeekPath(path string) bool {
+	if path == "response/search_status" || isDeepSeekFragmentStatusPath(path) {
+		return true
+	}
+	for _, part := range []string{"quasi_status", "elapsed_secs", "token_usage", "pending_fragment", "conversation_mode", "fragments/-1/status", "fragments/-2/status", "fragments/-3/status"} {
+		if strings.Contains(path, part) {
+			return true
+		}
+	}
+	return false
+}
+
+func isDeepSeekStatusPath(path string) bool {
+	return path == "response/status" || path == "status"
+}
+
+func isDeepSeekFragmentStatusPath(path string) bool {
+	if !strings.HasPrefix(path, "response/fragments/") || !strings.HasSuffix(path, "/status") {
+		return false
+	}
+	mid := strings.TrimSuffix(strings.TrimPrefix(path, "response/fragments/"), "/status")
+	mid = strings.TrimPrefix(mid, "-")
+	if mid == "" {
+		return false
+	}
+	for _, r := range mid {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func deepSeekModelConfig(model string) (bool, bool) {
+	model = strings.ToLower(strings.TrimSpace(model))
+	noThinking := strings.HasSuffix(model, "-nothinking")
+	base := strings.TrimSuffix(model, "-nothinking")
+	switch base {
+	case "deepseek-v4-flash", "deepseek-v4-pro", "deepseek-v4-vision":
+		return !noThinking, false
+	case "deepseek-v4-flash-search", "deepseek-v4-pro-search", "deepseek-v4-vision-search":
+		return !noThinking, true
+	default:
+		return !noThinking, false
+	}
+}
+
+func deepSeekModelType(model string) string {
+	base := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(model)), "-nothinking")
+	switch base {
+	case "deepseek-v4-pro", "deepseek-v4-pro-search":
+		return "expert"
+	case "deepseek-v4-vision", "deepseek-v4-vision-search":
+		return "vision"
+	default:
+		return "default"
+	}
+}
+
+func resolveDeepSeekModel(requested string) string {
+	model := strings.ToLower(strings.TrimSpace(requested))
+	if model == "" {
+		return ""
+	}
+	base := strings.TrimSuffix(model, "-nothinking")
+	switch base {
+	case "deepseek-v4-flash", "deepseek-v4-pro", "deepseek-v4-flash-search", "deepseek-v4-pro-search", "deepseek-v4-vision", "deepseek-v4-vision-search":
+		return model
+	case "deepseek-chat":
+		return withNoThinking(model, "deepseek-v4-flash")
+	case "deepseek-reasoner":
+		return withNoThinking(model, "deepseek-v4-pro")
+	default:
+		return ""
+	}
+}
+
+func withNoThinking(original, mapped string) string {
+	if strings.HasSuffix(original, "-nothinking") && !strings.HasSuffix(mapped, "-nothinking") {
+		return mapped + "-nothinking"
+	}
+	return mapped
+}
+
+func extractDeepSeekToken(auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	for _, key := range []string{"api_key", "token", "access_token"} {
+		if auth.Attributes != nil {
+			if value := strings.TrimSpace(auth.Attributes[key]); value != "" {
+				return value
+			}
+		}
+		if auth.Metadata != nil {
+			if value := strings.TrimSpace(asString(auth.Metadata[key])); value != "" {
+				return value
+			}
+		}
+	}
+	if auth.Metadata != nil {
+		if tokenMap, ok := auth.Metadata["token"].(map[string]any); ok {
+			return strings.TrimSpace(asString(tokenMap["access_token"]))
+		}
+	}
+	return ""
+}
+
+func setDeepSeekAuthToken(auth *cliproxyauth.Auth, token string) {
+	if auth == nil || strings.TrimSpace(token) == "" {
+		return
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = map[string]any{}
+	}
+	auth.Metadata["token"] = token
+}
+
+func stringFromAuth(auth *cliproxyauth.Auth, key string) string {
+	if auth == nil {
+		return ""
+	}
+	if auth.Attributes != nil {
+		if value := strings.TrimSpace(auth.Attributes[key]); value != "" {
+			return value
+		}
+	}
+	if auth.Metadata != nil {
+		if value := strings.TrimSpace(asString(auth.Metadata[key])); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+type deepSeekAPIError struct {
+	status  int
+	code    int
+	bizCode int
+	msg     string
+}
+
+func (e deepSeekAPIError) Error() string { return e.msg }
+
+func isDeepSeekAuthError(err error) bool {
+	apiErr, ok := err.(deepSeekAPIError)
+	if !ok {
+		return false
+	}
+	combined := strings.ToLower(apiErr.msg)
+	return apiErr.status == http.StatusUnauthorized || apiErr.status == http.StatusForbidden ||
+		apiErr.code == 40001 || apiErr.code == 40002 || apiErr.code == 40003 ||
+		apiErr.bizCode == 40001 || apiErr.bizCode == 40002 || apiErr.bizCode == 40003 ||
+		strings.Contains(combined, "token") || strings.Contains(combined, "login") ||
+		strings.Contains(combined, "unauthorized") || strings.Contains(combined, "expired") ||
+		strings.Contains(combined, "invalid jwt")
+}
+
+func deepSeekResponseStatus(resp map[string]any) (int, int, string, string) {
+	code := intFromAny(resp["code"])
+	msg := asString(resp["msg"])
+	data, _ := resp["data"].(map[string]any)
+	bizCode := intFromAny(data["biz_code"])
+	bizMsg := asString(data["biz_msg"])
+	if bizMsg == "" {
+		if bizData, _ := data["biz_data"].(map[string]any); bizData != nil {
+			bizMsg = asString(bizData["msg"])
+		}
+	}
+	return code, bizCode, msg, bizMsg
+}
+
+func failureMessage(msg, bizMsg, fallback string) string {
+	if strings.TrimSpace(bizMsg) != "" {
+		return strings.TrimSpace(bizMsg)
+	}
+	if strings.TrimSpace(msg) != "" {
+		return strings.TrimSpace(msg)
+	}
+	return fallback
+}
+
+func statusCodeOr(status, fallback int) int {
+	if status != 0 {
+		return status
+	}
+	return fallback
+}
+
+func headersToHTTPHeader(headers map[string]string) http.Header {
+	out := http.Header{}
+	for key, value := range headers {
+		out.Set(key, value)
+	}
+	return out
+}
+
+func authID(auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	return auth.ID
+}
+
+func authLabel(auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	return auth.Label
+}
+
+func asString(value any) string {
+	s, _ := value.(string)
+	return strings.TrimSpace(s)
+}
+
+func boolValue(value any) bool {
+	b, _ := value.(bool)
+	return b
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func jsonPointer(root map[string]any, path ...string) any {
+	var current any = root
+	for _, part := range path {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil
+		}
+		current = m[part]
+	}
+	return current
+}
+
+func jsonPointerString(root map[string]any, path ...string) string {
+	return asString(jsonPointer(root, path...))
+}
+
+func intFromAny(value any) int {
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case json.Number:
+		v, _ := typed.Int64()
+		return int(v)
+	default:
+		return 0
+	}
+}
+
+func int64FromAny(value any, fallback int64) int64 {
+	switch typed := value.(type) {
+	case int:
+		return int64(typed)
+	case int64:
+		return typed
+	case float64:
+		return int64(typed)
+	case json.Number:
+		v, err := typed.Int64()
+		if err == nil {
+			return v
+		}
+	}
+	return fallback
+}

--- a/internal/runtime/executor/deepseek_direct_pow.go
+++ b/internal/runtime/executor/deepseek_direct_pow.go
@@ -1,0 +1,230 @@
+package executor
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strconv"
+)
+
+func solveDeepSeekPow(ctx context.Context, challenge map[string]any) (int64, error) {
+	if asString(challenge["algorithm"]) != "DeepSeekHashV1" {
+		return 0, errors.New("unsupported deepseek pow algorithm")
+	}
+	challengeHex := asString(challenge["challenge"])
+	if len(challengeHex) != 64 {
+		return 0, errors.New("deepseek pow challenge must be 64 hex chars")
+	}
+	target, err := hex.DecodeString(challengeHex)
+	if err != nil {
+		return 0, err
+	}
+	var ta [32]byte
+	copy(ta[:], target)
+	t0 := binary.LittleEndian.Uint64(ta[0:])
+	t1 := binary.LittleEndian.Uint64(ta[8:])
+	t2 := binary.LittleEndian.Uint64(ta[16:])
+	t3 := binary.LittleEndian.Uint64(ta[24:])
+	prefix := []byte(asString(challenge["salt"]) + "_" + strconv.FormatInt(int64FromAny(challenge["expire_at"], 1680000000), 10) + "_")
+	difficulty := int64FromAny(challenge["difficulty"], 144000)
+
+	const rate = 136
+	var baseState [25]uint64
+	off := 0
+	for off+rate <= len(prefix) {
+		for i := 0; i < rate/8; i++ {
+			baseState[i] ^= binary.LittleEndian.Uint64(prefix[off+i*8:])
+		}
+		keccakF23(&baseState)
+		off += rate
+	}
+	tailLen := len(prefix) - off
+	var tail [rate]byte
+	copy(tail[:], prefix[off:])
+	var numBuf [20]byte
+	for n := int64(0); n < difficulty; n++ {
+		if n&0x3FF == 0 {
+			if err := ctx.Err(); err != nil {
+				return 0, err
+			}
+		}
+		v := uint64(n)
+		pos := 20
+		if v == 0 {
+			pos--
+			numBuf[pos] = '0'
+		} else {
+			for v > 0 {
+				pos--
+				numBuf[pos] = byte('0' + v%10)
+				v /= 10
+			}
+		}
+		numLen := 20 - pos
+		s := baseState
+		totalTail := tailLen + numLen
+		if totalTail < rate {
+			var buf [rate]byte
+			copy(buf[:tailLen], tail[:tailLen])
+			copy(buf[tailLen:totalTail], numBuf[pos:])
+			buf[totalTail] = 0x06
+			buf[rate-1] |= 0x80
+			for i := 0; i < rate/8; i++ {
+				s[i] ^= binary.LittleEndian.Uint64(buf[i*8:])
+			}
+			keccakF23(&s)
+		} else {
+			var buf [rate]byte
+			copy(buf[:tailLen], tail[:tailLen])
+			copy(buf[tailLen:rate], numBuf[pos:pos+(rate-tailLen)])
+			for i := 0; i < rate/8; i++ {
+				s[i] ^= binary.LittleEndian.Uint64(buf[i*8:])
+			}
+			keccakF23(&s)
+			var buf2 [rate]byte
+			rem := totalTail - rate
+			copy(buf2[:rem], numBuf[pos+(rate-tailLen):pos+(rate-tailLen)+rem])
+			buf2[rem] = 0x06
+			buf2[rate-1] |= 0x80
+			for i := 0; i < rate/8; i++ {
+				s[i] ^= binary.LittleEndian.Uint64(buf2[i*8:])
+			}
+			keccakF23(&s)
+		}
+		if s[0] == t0 && s[1] == t1 && s[2] == t2 && s[3] == t3 {
+			return n, nil
+		}
+	}
+	return 0, errors.New("deepseek pow solution not found")
+}
+
+func buildDeepSeekPowHeader(challenge map[string]any, answer int64) (string, error) {
+	payload := map[string]any{
+		"algorithm":   challenge["algorithm"],
+		"challenge":   challenge["challenge"],
+		"salt":        challenge["salt"],
+		"answer":      answer,
+		"signature":   challenge["signature"],
+		"target_path": challenge["target_path"],
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+var deepSeekKeccakRC = [24]uint64{
+	0x0000000000000001, 0x0000000000008082, 0x800000000000808A, 0x8000000080008000,
+	0x000000000000808B, 0x0000000080000001, 0x8000000080008081, 0x8000000000008009,
+	0x000000000000008A, 0x0000000000000088, 0x0000000080008009, 0x000000008000000A,
+	0x000000008000808B, 0x800000000000008B, 0x8000000000008089, 0x8000000000008003,
+	0x8000000000008002, 0x8000000000000080, 0x000000000000800A, 0x800000008000000A,
+	0x8000000080008081, 0x8000000000008080, 0x0000000080000001, 0x8000000080008008,
+}
+
+func rotl64(v uint64, k uint) uint64 { return v<<k | v>>(64-k) }
+
+func keccakF23(s *[25]uint64) {
+	a0, a1, a2, a3, a4 := s[0], s[1], s[2], s[3], s[4]
+	a5, a6, a7, a8, a9 := s[5], s[6], s[7], s[8], s[9]
+	a10, a11, a12, a13, a14 := s[10], s[11], s[12], s[13], s[14]
+	a15, a16, a17, a18, a19 := s[15], s[16], s[17], s[18], s[19]
+	a20, a21, a22, a23, a24 := s[20], s[21], s[22], s[23], s[24]
+	for r := 1; r < 24; r++ {
+		c0 := a0 ^ a5 ^ a10 ^ a15 ^ a20
+		c1 := a1 ^ a6 ^ a11 ^ a16 ^ a21
+		c2 := a2 ^ a7 ^ a12 ^ a17 ^ a22
+		c3 := a3 ^ a8 ^ a13 ^ a18 ^ a23
+		c4 := a4 ^ a9 ^ a14 ^ a19 ^ a24
+		d0 := c4 ^ rotl64(c1, 1)
+		d1 := c0 ^ rotl64(c2, 1)
+		d2 := c1 ^ rotl64(c3, 1)
+		d3 := c2 ^ rotl64(c4, 1)
+		d4 := c3 ^ rotl64(c0, 1)
+		a0 ^= d0
+		a5 ^= d0
+		a10 ^= d0
+		a15 ^= d0
+		a20 ^= d0
+		a1 ^= d1
+		a6 ^= d1
+		a11 ^= d1
+		a16 ^= d1
+		a21 ^= d1
+		a2 ^= d2
+		a7 ^= d2
+		a12 ^= d2
+		a17 ^= d2
+		a22 ^= d2
+		a3 ^= d3
+		a8 ^= d3
+		a13 ^= d3
+		a18 ^= d3
+		a23 ^= d3
+		a4 ^= d4
+		a9 ^= d4
+		a14 ^= d4
+		a19 ^= d4
+		a24 ^= d4
+		b0 := a0
+		b10 := rotl64(a1, 1)
+		b20 := rotl64(a2, 62)
+		b5 := rotl64(a3, 28)
+		b15 := rotl64(a4, 27)
+		b16 := rotl64(a5, 36)
+		b1 := rotl64(a6, 44)
+		b11 := rotl64(a7, 6)
+		b21 := rotl64(a8, 55)
+		b6 := rotl64(a9, 20)
+		b7 := rotl64(a10, 3)
+		b17 := rotl64(a11, 10)
+		b2 := rotl64(a12, 43)
+		b12 := rotl64(a13, 25)
+		b22 := rotl64(a14, 39)
+		b23 := rotl64(a15, 41)
+		b8 := rotl64(a16, 45)
+		b18 := rotl64(a17, 15)
+		b3 := rotl64(a18, 21)
+		b13 := rotl64(a19, 8)
+		b14 := rotl64(a20, 18)
+		b24 := rotl64(a21, 2)
+		b9 := rotl64(a22, 61)
+		b19 := rotl64(a23, 56)
+		b4 := rotl64(a24, 14)
+		a0 = b0 ^ (^b1 & b2)
+		a1 = b1 ^ (^b2 & b3)
+		a2 = b2 ^ (^b3 & b4)
+		a3 = b3 ^ (^b4 & b0)
+		a4 = b4 ^ (^b0 & b1)
+		a5 = b5 ^ (^b6 & b7)
+		a6 = b6 ^ (^b7 & b8)
+		a7 = b7 ^ (^b8 & b9)
+		a8 = b8 ^ (^b9 & b5)
+		a9 = b9 ^ (^b5 & b6)
+		a10 = b10 ^ (^b11 & b12)
+		a11 = b11 ^ (^b12 & b13)
+		a12 = b12 ^ (^b13 & b14)
+		a13 = b13 ^ (^b14 & b10)
+		a14 = b14 ^ (^b10 & b11)
+		a15 = b15 ^ (^b16 & b17)
+		a16 = b16 ^ (^b17 & b18)
+		a17 = b17 ^ (^b18 & b19)
+		a18 = b18 ^ (^b19 & b15)
+		a19 = b19 ^ (^b15 & b16)
+		a20 = b20 ^ (^b21 & b22)
+		a21 = b21 ^ (^b22 & b23)
+		a22 = b22 ^ (^b23 & b24)
+		a23 = b23 ^ (^b24 & b20)
+		a24 = b24 ^ (^b20 & b21)
+		a0 ^= deepSeekKeccakRC[r]
+	}
+	s[0], s[1], s[2], s[3], s[4] = a0, a1, a2, a3, a4
+	s[5], s[6], s[7], s[8], s[9] = a5, a6, a7, a8, a9
+	s[10], s[11], s[12], s[13], s[14] = a10, a11, a12, a13, a14
+	s[15], s[16], s[17], s[18], s[19] = a15, a16, a17, a18, a19
+	s[20], s[21], s[22], s[23], s[24] = a20, a21, a22, a23, a24
+}

--- a/internal/runtime/executor/deepseek_proxy_executor.go
+++ b/internal/runtime/executor/deepseek_proxy_executor.go
@@ -1,0 +1,3 @@
+package executor
+
+// Direct DeepSeek implementation moved to deepseek_direct_executor.go.

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -425,6 +425,8 @@ func (s *Service) ensureExecutorsForAuthWithMode(a *coreauth.Auth, forceReplace 
 		s.coreManager.RegisterExecutor(executor.NewClaudeExecutor(s.cfg))
 	case "kimi":
 		s.coreManager.RegisterExecutor(executor.NewKimiExecutor(s.cfg))
+	case "deepseek":
+		s.coreManager.RegisterExecutor(executor.NewDeepSeekProxyExecutor(s.cfg))
 	default:
 		providerKey := strings.ToLower(strings.TrimSpace(a.Provider))
 		if providerKey == "" {
@@ -927,6 +929,9 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 		models = applyExcludedModels(models, excluded)
 	case "kimi":
 		models = registry.GetKimiModels()
+		models = applyExcludedModels(models, excluded)
+	case "deepseek":
+		models = registry.GetDeepSeekModels()
 		models = applyExcludedModels(models, excluded)
 	default:
 		// Handle OpenAI-compatibility providers by name using config


### PR DESCRIPTION
### Summary
Add support for DeepSeek direct executor and proxy integration.

### Changes
- Implement DeepSeek direct executor
- Add helper, compat, and pow handling
- Integrate into runtime executor flow
- Add configuration support for DeepSeek provider

### Motivation
This enables using DeepSeek as an additional LLM source via CLIProxyAPI.

### Notes
- Does not break existing providers
- Feature is optional and configurable