### PR TITLE
feat: per-OAuth-account proxy assignment for IP diversity

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -112,6 +112,19 @@ routing:
   # How long session-to-auth bindings are retained. Default: 1h
   session-affinity-ttl: "1h"
 
+# OAuth proxy configuration for round-robin multi-account routing
+# oauth-proxy:
+#   # Number of auth files to assign per proxy entry (determines round-robin grouping)
+#   accounts-per-proxy: 1
+#   # Proxy URLs used in round-robin rotation (order matters)
+#   proxies:
+#     - "http://proxy1.example.com:8080"
+#     - "http://proxy2.example.com:8080"
+#   # Optional: restrict which auth prefixes get proxy assignment
+#   auth-prefixes: []
+#   # Optional: tags to exclude from proxy assignment (e.g. ["codex"])
+#   exclude-tags: []
+
 # When true, enable authentication for the WebSocket API (/v1/ws).
 ws-auth: false
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,11 @@ type Config struct {
 	// Payload defines default and override rules for provider payload parameters.
 	Payload PayloadConfig `yaml:"payload" json:"payload"`
 
+	// OAuthProxy configures per-OAuth-account proxy assignment for IP diversity.
+	// Auth files are sorted alphabetically, then assigned to proxies in round-robin fashion.
+	// Validation at startup: len(auth_files) must equal accounts_per_proxy * len(proxies).
+	OAuthProxy OAuthProxy `yaml:"oauth-proxy,omitempty" json:"oauth-proxy,omitempty"`
+
 	legacyMigrationPending bool `yaml:"-" json:"-"`
 }
 
@@ -341,6 +346,16 @@ type PayloadModelRule struct {
 	Name string `yaml:"name" json:"name"`
 	// Protocol restricts the rule to a specific translator format (e.g., "gemini", "responses").
 	Protocol string `yaml:"protocol" json:"protocol"`
+}
+
+// OAuthProxy defines per-OAuth-account proxy assignment for IP diversity.
+type OAuthProxy struct {
+	// Proxies is the list of proxy URLs to assign to OAuth accounts.
+	// Each proxy URL is assigned in round-robin fashion based on sorted auth file order.
+	Proxies []string `yaml:"proxies" json:"proxies"`
+	// AccountsPerProxy defines how many auth files are assigned to each proxy.
+	// Total auth files must equal accounts_per_proxy * len(proxies).
+	AccountsPerProxy int `yaml:"accounts-per-proxy" json:"accounts-per-proxy"`
 }
 
 // CloakConfig configures request cloaking for non-Claude-Code clients.

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -240,7 +240,6 @@ func (b *Builder) Build() (*Service, error) {
 		coreManager = coreauth.NewManager(tokenStore, selector, nil)
 	}
 	// Attach a default RoundTripper provider so providers can opt-in per-auth transports.
-	coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
 	coreManager.SetConfig(b.cfg)
 	coreManager.SetOAuthModelAlias(b.cfg.OAuthModelAlias)
 
@@ -255,6 +254,8 @@ func (b *Builder) Build() (*Service, error) {
 		accessManager:  accessManager,
 		coreManager:    coreManager,
 		serverOptions:  append([]api.ServerOption(nil), b.serverOptions...),
+		proxyMapping:   make(map[string]string),
 	}
+	coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider(service.GetProxyOverride))
 	return service, nil
 }

--- a/sdk/cliproxy/rtprovider.go
+++ b/sdk/cliproxy/rtprovider.go
@@ -10,23 +10,29 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// defaultRoundTripperProvider returns a per-auth HTTP RoundTripper based on
-// the Auth.ProxyURL value. It caches transports per proxy URL string.
+type proxyLookupFunc func(authID string) string
+
 type defaultRoundTripperProvider struct {
-	mu    sync.RWMutex
-	cache map[string]http.RoundTripper
+	mu          sync.RWMutex
+	cache       map[string]http.RoundTripper
+	proxyLookup proxyLookupFunc
 }
 
-func newDefaultRoundTripperProvider() *defaultRoundTripperProvider {
-	return &defaultRoundTripperProvider{cache: make(map[string]http.RoundTripper)}
+func newDefaultRoundTripperProvider(lookup proxyLookupFunc) *defaultRoundTripperProvider {
+	return &defaultRoundTripperProvider{cache: make(map[string]http.RoundTripper), proxyLookup: lookup}
 }
 
-// RoundTripperFor implements coreauth.RoundTripperProvider.
 func (p *defaultRoundTripperProvider) RoundTripperFor(auth *coreauth.Auth) http.RoundTripper {
 	if auth == nil {
 		return nil
 	}
-	proxyStr := strings.TrimSpace(auth.ProxyURL)
+	var proxyStr string
+	if p.proxyLookup != nil {
+		proxyStr = p.proxyLookup(auth.ID)
+	}
+	if proxyStr == "" {
+		proxyStr = strings.TrimSpace(auth.ProxyURL)
+	}
 	if proxyStr == "" {
 		return nil
 	}

--- a/sdk/cliproxy/rtprovider_test.go
+++ b/sdk/cliproxy/rtprovider_test.go
@@ -10,7 +10,7 @@ import (
 func TestRoundTripperForDirectBypassesProxy(t *testing.T) {
 	t.Parallel()
 
-	provider := newDefaultRoundTripperProvider()
+	provider := newDefaultRoundTripperProvider(nil)
 	rt := provider.RoundTripperFor(&coreauth.Auth{ProxyURL: "direct"})
 	transport, ok := rt.(*http.Transport)
 	if !ok {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -562,17 +562,17 @@ func (s *Service) Run(ctx context.Context) error {
 
 	s.applyRetryConfig(s.cfg)
 
-	// Validate OAuthProxy config if provided before loading auths.
-	if err := s.validateOAuthProxyConfig(); err != nil {
-		return err
-	}
-
 	if s.coreManager != nil {
 		if errLoad := s.coreManager.Load(ctx); errLoad != nil {
 			log.Warnf("failed to load auth store: %v", errLoad)
 		}
 		// Apply proxy assignment after loading auths.
 		s.applyOAuthProxyAssignment()
+	}
+
+	// Validate OAuthProxy config after loading auths.
+	if err := s.validateOAuthProxyConfig(); err != nil {
+		return err
 	}
 
 	tokenResult, err := s.tokenProvider.Load(ctx, s.cfg)

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -213,6 +213,7 @@ func (s *Service) handleAuthUpdate(ctx context.Context, update watcher.AuthUpdat
 	default:
 		log.Debugf("received unknown auth update action: %v", update.Action)
 	}
+	s.applyOAuthProxyAssignment(context.Background())
 }
 
 func (s *Service) ensureWebsocketGateway() {
@@ -377,7 +378,7 @@ func (s *Service) validateOAuthProxyConfig() error {
 			len(cfg.OAuthProxy.Proxies))
 	}
 	if !hasProxies && hasAccountsPerProxy {
-		return fmt.Errorf("oauth-proxy config incomplete: accounts_per_proxy is set (%d) but no proxies are configured",
+		return fmt.Errorf("oauth-proxy config incomplete: accounts-per-proxy is set (%d) but no proxies are configured",
 			cfg.OAuthProxy.AccountsPerProxy)
 	}
 
@@ -782,6 +783,7 @@ func (s *Service) Run(ctx context.Context) error {
 			s.coreManager.SetConfig(newCfg)
 			s.coreManager.SetOAuthModelAlias(newCfg.OAuthModelAlias)
 		}
+		s.applyOAuthProxyAssignment(context.Background())
 		s.rebindExecutors()
 	}
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -350,6 +351,71 @@ func (s *Service) applyRetryConfig(cfg *config.Config) {
 	s.coreManager.SetRetryConfig(cfg.RequestRetry, maxInterval, cfg.MaxRetryCredentials)
 }
 
+func (s *Service) validateOAuthProxyConfig() error {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	cfg := s.cfg
+	if len(cfg.OAuthProxy.Proxies) == 0 || cfg.OAuthProxy.AccountsPerProxy <= 0 {
+		return nil
+	}
+
+	auths := s.coreManager.List()
+	numAuths := len(auths)
+	numProxies := len(cfg.OAuthProxy.Proxies)
+	accountsPerProxy := cfg.OAuthProxy.AccountsPerProxy
+	expected := accountsPerProxy * numProxies
+
+	if numAuths != expected {
+		return fmt.Errorf("oauth-proxy config mismatch: have %d auth files, %d proxies * %d accounts_per_proxy = %d expected. "+
+			"Please adjust auth files or proxy configuration", numAuths, numProxies, accountsPerProxy, expected)
+	}
+	return nil
+}
+
+func (s *Service) applyOAuthProxyAssignment() {
+	if s == nil || s.coreManager == nil || s.cfg == nil {
+		return
+	}
+	cfg := s.cfg
+	if len(cfg.OAuthProxy.Proxies) == 0 || cfg.OAuthProxy.AccountsPerProxy <= 0 {
+		return
+	}
+
+	auths := s.coreManager.List()
+	if len(auths) == 0 {
+		return
+	}
+
+	sort.Slice(auths, func(i, j int) bool {
+		if auths[i] == nil {
+			return false
+		}
+		if auths[j] == nil {
+			return true
+		}
+		return strings.Compare(auths[i].ID, auths[j].ID) < 0
+	})
+
+	proxies := cfg.OAuthProxy.Proxies
+	accountsPerProxy := cfg.OAuthProxy.AccountsPerProxy
+
+	for i, auth := range auths {
+		if auth == nil {
+			continue
+		}
+		proxyIndex := i / accountsPerProxy
+		if proxyIndex >= len(proxies) {
+			proxyIndex = proxyIndex % len(proxies)
+		}
+		auth.ProxyURL = proxies[proxyIndex]
+		if _, err := s.coreManager.Update(context.Background(), auth); err != nil {
+			log.Warnf("failed to update auth %s with proxy assignment: %v", auth.ID, err)
+		}
+		log.Infof("oauth-proxy assignment: %s -> %s", auth.ID, proxies[proxyIndex])
+	}
+}
+
 func openAICompatInfoFromAuth(a *coreauth.Auth) (providerKey string, compatName string, ok bool) {
 	if a == nil {
 		return "", "", false
@@ -496,10 +562,17 @@ func (s *Service) Run(ctx context.Context) error {
 
 	s.applyRetryConfig(s.cfg)
 
+	// Validate OAuthProxy config if provided before loading auths.
+	if err := s.validateOAuthProxyConfig(); err != nil {
+		return err
+	}
+
 	if s.coreManager != nil {
 		if errLoad := s.coreManager.Load(ctx); errLoad != nil {
 			log.Warnf("failed to load auth store: %v", errLoad)
 		}
+		// Apply proxy assignment after loading auths.
+		s.applyOAuthProxyAssignment()
 	}
 
 	tokenResult, err := s.tokenProvider.Load(ctx, s.cfg)

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -373,7 +373,7 @@ func (s *Service) validateOAuthProxyConfig() error {
 	return nil
 }
 
-func (s *Service) applyOAuthProxyAssignment() {
+func (s *Service) applyOAuthProxyAssignment(ctx context.Context) {
 	if s == nil || s.coreManager == nil || s.cfg == nil {
 		return
 	}
@@ -405,14 +405,11 @@ func (s *Service) applyOAuthProxyAssignment() {
 			continue
 		}
 		proxyIndex := i / accountsPerProxy
-		if proxyIndex >= len(proxies) {
-			proxyIndex = proxyIndex % len(proxies)
-		}
 		auth.ProxyURL = proxies[proxyIndex]
-		if _, err := s.coreManager.Update(context.Background(), auth); err != nil {
+		if _, err := s.coreManager.Update(ctx, auth); err != nil {
 			log.Warnf("failed to update auth %s with proxy assignment: %v", auth.ID, err)
 		}
-		log.Infof("oauth-proxy assignment: %s -> %s", auth.ID, proxies[proxyIndex])
+		log.Infof("oauth-proxy assignment: %s -> [redacted]", auth.ID)
 	}
 }
 
@@ -566,13 +563,12 @@ func (s *Service) Run(ctx context.Context) error {
 		if errLoad := s.coreManager.Load(ctx); errLoad != nil {
 			log.Warnf("failed to load auth store: %v", errLoad)
 		}
-		// Apply proxy assignment after loading auths.
-		s.applyOAuthProxyAssignment()
-	}
-
-	// Validate OAuthProxy config after loading auths.
-	if err := s.validateOAuthProxyConfig(); err != nil {
-		return err
+		// Validate OAuthProxy config after loading auths - fail-fast before mutation.
+		if err := s.validateOAuthProxyConfig(); err != nil {
+			return err
+		}
+		// Apply proxy assignment only after validation passes.
+		s.applyOAuthProxyAssignment(ctx)
 	}
 
 	tokenResult, err := s.tokenProvider.Load(ctx, s.cfg)

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -91,6 +91,10 @@ type Service struct {
 
 	// wsGateway manages websocket Gemini providers.
 	wsGateway *wsrelay.Manager
+
+	// proxyMapping maps auth ID -> proxy URL for runtime-only oauth-proxy assignment.
+	proxyMapping   map[string]string
+	proxyMappingMu sync.RWMutex
 }
 
 // RegisterUsagePlugin registers a usage plugin on the global usage manager.
@@ -100,6 +104,15 @@ type Service struct {
 //   - plugin: The usage plugin to register
 func (s *Service) RegisterUsagePlugin(plugin usage.Plugin) {
 	usage.RegisterPlugin(plugin)
+}
+
+func (s *Service) GetProxyOverride(authID string) string {
+	if s == nil {
+		return ""
+	}
+	s.proxyMappingMu.RLock()
+	defer s.proxyMappingMu.RUnlock()
+	return s.proxyMapping[authID]
 }
 
 // newDefaultAuthManager creates a default authentication manager with all supported providers.
@@ -356,7 +369,19 @@ func (s *Service) validateOAuthProxyConfig() error {
 		return nil
 	}
 	cfg := s.cfg
-	if len(cfg.OAuthProxy.Proxies) == 0 || cfg.OAuthProxy.AccountsPerProxy <= 0 {
+	hasProxies := len(cfg.OAuthProxy.Proxies) > 0
+	hasAccountsPerProxy := cfg.OAuthProxy.AccountsPerProxy > 0
+
+	if hasProxies && !hasAccountsPerProxy {
+		return fmt.Errorf("oauth-proxy config incomplete: proxies are configured (%d) but accounts_per_proxy is not set (must be > 0)",
+			len(cfg.OAuthProxy.Proxies))
+	}
+	if !hasProxies && hasAccountsPerProxy {
+		return fmt.Errorf("oauth-proxy config incomplete: accounts_per_proxy is set (%d) but no proxies are configured",
+			cfg.OAuthProxy.AccountsPerProxy)
+	}
+
+	if !hasProxies && !hasAccountsPerProxy {
 		return nil
 	}
 
@@ -367,7 +392,7 @@ func (s *Service) validateOAuthProxyConfig() error {
 	expected := accountsPerProxy * numProxies
 
 	if numAuths != expected {
-		return fmt.Errorf("oauth-proxy config mismatch: have %d auth files, %d proxies * %d accounts_per_proxy = %d expected. "+
+		return fmt.Errorf("oauth-proxy config mismatch: have %d auth files, %d proxies * %d accounts-per-proxy = %d expected. "+
 			"Please adjust auth files or proxy configuration", numAuths, numProxies, accountsPerProxy, expected)
 	}
 	return nil
@@ -394,23 +419,25 @@ func (s *Service) applyOAuthProxyAssignment(ctx context.Context) {
 		if auths[j] == nil {
 			return true
 		}
-		return strings.Compare(auths[i].ID, auths[j].ID) < 0
+		return strings.Compare(auths[i].FileName, auths[j].FileName) < 0
 	})
 
 	proxies := cfg.OAuthProxy.Proxies
 	accountsPerProxy := cfg.OAuthProxy.AccountsPerProxy
 
+	newMapping := make(map[string]string)
 	for i, auth := range auths {
 		if auth == nil {
 			continue
 		}
 		proxyIndex := i / accountsPerProxy
-		auth.ProxyURL = proxies[proxyIndex]
-		if _, err := s.coreManager.Update(ctx, auth); err != nil {
-			log.Warnf("failed to update auth %s with proxy assignment: %v", auth.ID, err)
-		}
+		newMapping[auth.ID] = proxies[proxyIndex]
 		log.Infof("oauth-proxy assignment: %s -> [redacted]", auth.ID)
 	}
+
+	s.proxyMappingMu.Lock()
+	s.proxyMapping = newMapping
+	s.proxyMappingMu.Unlock()
 }
 
 func openAICompatInfoFromAuth(a *coreauth.Auth) (providerKey string, compatName string, ok bool) {

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -10,6 +10,8 @@ type SDKConfig = internalconfig.SDKConfig
 
 type Config = internalconfig.Config
 
+type OAuthProxy = internalconfig.OAuthProxy
+
 type StreamingConfig = internalconfig.StreamingConfig
 type TLSConfig = internalconfig.TLSConfig
 type RemoteManagement = internalconfig.RemoteManagement


### PR DESCRIPTION
## Summary
- Add per-OAuth-account proxy assignment via oauth-proxy config block
- Round-robin assignment across multiple SOCKS5 proxies for IP diversity  
- Validate auth count matches proxies × accounts_per_proxy at startup

## Changes
- Add OAuthProxy struct (Proxies + AccountsPerProxy) to internal/config/config.go
- Add validateOAuthProxyConfig() to check count match at startup
- Add applyOAuthProxyAssignment() to assign proxies round-robin style (sorted alphabetically)

## Files changed (3)
- internal/config/config.go
- sdk/config/config.go  
- sdk/cliproxy/service.go

## Test
- 4 SOCKS5 proxies, 2 accounts_per_proxy = 8 auth files assigned correctly