### PR TITLE
fix(codex): restore minimal continuity for prompt cache reuse

### DIFF
--- a/internal/runtime/executor/codex_continuity.go
+++ b/internal/runtime/executor/codex_continuity.go
@@ -1,0 +1,97 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+type codexContinuity struct {
+	Key string
+}
+
+func ginContextFrom(ctx context.Context) *gin.Context {
+	if ctx == nil {
+		return nil
+	}
+	ginCtx, _ := ctx.Value("gin").(*gin.Context)
+	return ginCtx
+}
+
+func principalString(raw any) string {
+	switch v := raw.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case fmt.Stringer:
+		return strings.TrimSpace(v.String())
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", raw))
+	}
+}
+
+func continuityMetadataString(meta map[string]any, key string) string {
+	if len(meta) == 0 {
+		return ""
+	}
+	raw, ok := meta[key]
+	if !ok || raw == nil {
+		return ""
+	}
+	switch v := raw.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case []byte:
+		return strings.TrimSpace(string(v))
+	default:
+		return ""
+	}
+}
+
+func resolveCodexContinuity(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) codexContinuity {
+	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(req.Payload, "prompt_cache_key").String()); promptCacheKey != "" {
+		return codexContinuity{Key: promptCacheKey}
+	}
+	if executionSession := continuityMetadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); executionSession != "" {
+		return codexContinuity{Key: executionSession}
+	}
+	if apiKey := strings.TrimSpace(helps.APIKeyFromContext(ctx)); apiKey != "" {
+		return codexContinuity{Key: uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:prompt-cache:"+apiKey)).String()}
+	}
+	if ginCtx := ginContextFrom(ctx); ginCtx != nil {
+		if v, exists := ginCtx.Get("apiKey"); exists && v != nil {
+			if trimmed := principalString(v); trimmed != "" {
+				return codexContinuity{Key: uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:prompt-cache:"+trimmed)).String()}
+			}
+		}
+	}
+	if auth != nil {
+		if authID := strings.TrimSpace(auth.ID); authID != "" {
+			return codexContinuity{Key: uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:prompt-cache:auth:"+authID)).String()}
+		}
+	}
+	return codexContinuity{}
+}
+
+func applyCodexContinuityBody(rawJSON []byte, continuity codexContinuity) []byte {
+	if continuity.Key == "" {
+		return rawJSON
+	}
+	rawJSON, _ = sjson.SetBytes(rawJSON, "prompt_cache_key", continuity.Key)
+	return rawJSON
+}
+
+func applyCodexContinuityHeaders(headers http.Header, continuity codexContinuity) {
+	if headers == nil || continuity.Key == "" {
+		return
+	}
+	headers.Set("session_id", continuity.Key)
+}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -184,7 +184,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	body = ensureImageGenerationTool(body, baseModel, auth)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
-	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
+	httpReq, err := e.cacheHelper(ctx, auth, from, url, req, opts, body)
 	if err != nil {
 		return resp, err
 	}
@@ -332,7 +332,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	body = ensureImageGenerationTool(body, baseModel, auth)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses/compact"
-	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
+	httpReq, err := e.cacheHelper(ctx, auth, from, url, req, opts, body)
 	if err != nil {
 		return resp, err
 	}
@@ -427,7 +427,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	body = ensureImageGenerationTool(body, baseModel, auth)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
-	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
+	httpReq, err := e.cacheHelper(ctx, auth, from, url, req, opts, body)
 	if err != nil {
 		return nil, err
 	}
@@ -714,8 +714,9 @@ func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 	return auth, nil
 }
 
-func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Format, url string, req cliproxyexecutor.Request, rawJSON []byte) (*http.Request, error) {
+func (e *CodexExecutor) cacheHelper(ctx context.Context, auth *cliproxyauth.Auth, from sdktranslator.Format, url string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, rawJSON []byte) (*http.Request, error) {
 	var cache helps.CodexCache
+	continuity := codexContinuity{}
 	if from == "claude" {
 		userIDResult := gjson.GetBytes(req.Payload, "metadata.user_id")
 		if userIDResult.Exists() {
@@ -728,28 +729,25 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 				}
 				helps.SetCodexCache(key, cache)
 			}
+			continuity = codexContinuity{Key: cache.ID}
 		}
 	} else if from == "openai-response" {
 		promptCacheKey := gjson.GetBytes(req.Payload, "prompt_cache_key")
 		if promptCacheKey.Exists() {
 			cache.ID = promptCacheKey.String()
+			continuity = codexContinuity{Key: cache.ID}
 		}
 	} else if from == "openai" {
-		if apiKey := strings.TrimSpace(helps.APIKeyFromContext(ctx)); apiKey != "" {
-			cache.ID = uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:prompt-cache:"+apiKey)).String()
-		}
+		continuity = resolveCodexContinuity(ctx, auth, req, opts)
+		cache.ID = continuity.Key
 	}
 
-	if cache.ID != "" {
-		rawJSON, _ = sjson.SetBytes(rawJSON, "prompt_cache_key", cache.ID)
-	}
+	rawJSON = applyCodexContinuityBody(rawJSON, continuity)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(rawJSON))
 	if err != nil {
 		return nil, err
 	}
-	if cache.ID != "" {
-		httpReq.Header.Set("Session_id", cache.ID)
-	}
+	applyCodexContinuityHeaders(httpReq.Header, continuity)
 	return httpReq, nil
 }
 
@@ -771,9 +769,7 @@ func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, s
 	cfgUserAgent, _ := codexHeaderDefaults(cfg, auth)
 	ensureHeaderWithConfigPrecedence(r.Header, ginHeaders, "User-Agent", cfgUserAgent, codexUserAgent)
 
-	if strings.Contains(r.Header.Get("User-Agent"), "Mac OS") {
-		misc.EnsureHeader(r.Header, ginHeaders, "Session_id", uuid.NewString())
-	}
+	misc.EnsureHeader(r.Header, ginHeaders, "session_id", uuid.NewString())
 
 	if stream {
 		r.Header.Set("Accept", "text/event-stream")

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -200,7 +200,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		return resp, err
 	}
 
-	body, wsHeaders := applyCodexPromptCacheHeaders(from, req, body)
+	body, wsHeaders := applyCodexPromptCacheHeaders(ctx, auth, from, req, opts, body)
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 
 	var authID, authLabel, authType, authValue string
@@ -395,7 +395,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		return nil, err
 	}
 
-	body, wsHeaders := applyCodexPromptCacheHeaders(from, req, body)
+	body, wsHeaders := applyCodexPromptCacheHeaders(ctx, auth, from, req, opts, body)
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 
 	var authID, authLabel, authType, authValue string
@@ -773,13 +773,14 @@ func buildCodexResponsesWebsocketURL(httpURL string) (string, error) {
 	return parsed.String(), nil
 }
 
-func applyCodexPromptCacheHeaders(from sdktranslator.Format, req cliproxyexecutor.Request, rawJSON []byte) ([]byte, http.Header) {
+func applyCodexPromptCacheHeaders(ctx context.Context, auth *cliproxyauth.Auth, from sdktranslator.Format, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, rawJSON []byte) ([]byte, http.Header) {
 	headers := http.Header{}
 	if len(rawJSON) == 0 {
 		return rawJSON, headers
 	}
 
 	var cache helps.CodexCache
+	continuity := codexContinuity{}
 	if from == "claude" {
 		userIDResult := gjson.GetBytes(req.Payload, "metadata.user_id")
 		if userIDResult.Exists() {
@@ -793,17 +794,20 @@ func applyCodexPromptCacheHeaders(from sdktranslator.Format, req cliproxyexecuto
 				}
 				helps.SetCodexCache(key, cache)
 			}
+			continuity = codexContinuity{Key: cache.ID}
 		}
 	} else if from == "openai-response" {
 		if promptCacheKey := gjson.GetBytes(req.Payload, "prompt_cache_key"); promptCacheKey.Exists() {
 			cache.ID = promptCacheKey.String()
+			continuity = codexContinuity{Key: cache.ID}
 		}
+	} else if from == "openai" {
+		continuity = resolveCodexContinuity(ctx, auth, req, opts)
+		cache.ID = continuity.Key
 	}
 
-	if cache.ID != "" {
-		rawJSON, _ = sjson.SetBytes(rawJSON, "prompt_cache_key", cache.ID)
-		headers.Set("Conversation_id", cache.ID)
-	}
+	rawJSON = applyCodexContinuityBody(rawJSON, continuity)
+	applyCodexContinuityHeaders(headers, continuity)
 
 	return rawJSON, headers
 }
@@ -837,9 +841,7 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 		betaHeader = codexResponsesWebsocketBetaHeaderValue
 	}
 	headers.Set("OpenAI-Beta", betaHeader)
-	if strings.Contains(headers.Get("User-Agent"), "Mac OS") {
-		misc.EnsureHeader(headers, ginHeaders, "Session_id", uuid.NewString())
-	}
+	misc.EnsureHeader(headers, ginHeaders, "session_id", uuid.NewString())
 	headers.Del("User-Agent")
 
 	isAPIKey := false


### PR DESCRIPTION
Fixes prompt-cache continuity regressions for Codex requests by restoring the smallest executor-level behavior needed to keep repeated requests on one stable upstream cache identity.

## Summary

This PR restores minimal Codex continuity handling on top of the current `origin/main` tip so repeated Codex requests can reuse upstream prompt cache again.

The key change is intentionally small:

- resolve one stable continuity key for Codex requests
- apply that same key to outgoing `prompt_cache_key`
- apply that same key to outgoing `session_id`
- keep HTTP and websocket Codex paths aligned

No auth-affinity routing, scheduler changes, or `internal/translator` changes are included.

## Why this is needed

I previously opened PR #2374 to restore Codex cache continuity. That approach was later reverted by @luispater in PR #2400.

After that revert, repeated Codex requests again stopped sharing a stable continuity identity, which caused cache hits to disappear in my real OpenCode -> CLIProxyAPI -> Codex usage.

The regression came from losing the executor-level continuity behavior that ensured repeated requests reused one stable cache/session identity instead of falling back to narrower or inconsistent request identity handling.

## Before this change

In the regressed state:

- repeated Codex requests could lose a stable continuity identity
- OpenAI-style Codex requests could fall back too narrowly when deriving continuity
- HTTP and websocket paths did not preserve the same effective continuity model
- prompt cache reads stopped occurring again in repeated OpenCode sessions

## After this change

CLIProxyAPI restores one minimal continuity rule for Codex executors:

- prefer explicit incoming `prompt_cache_key`
- otherwise use execution session metadata if available
- otherwise use a stable client-principal-derived hash
- otherwise use a stable auth-ID-derived hash

That chosen continuity key is then applied to both:

- request body `prompt_cache_key`
- request header `session_id`

This keeps repeated Codex requests on one stable upstream continuity identity without changing routing policy.

## Scope

This PR is intentionally narrow.

Included:

- `internal/runtime/executor/codex_continuity.go`
- `internal/runtime/executor/codex_executor.go`
- `internal/runtime/executor/codex_websockets_executor.go`

Not included:

- auth-affinity or sticky-routing changes
- scheduler or conductor changes
- `internal/translator` changes
- broader cache policy redesign

## Manual validation

This change was manually validated in OpenCode sessions.

Confirmed behavior:

- `gpt-5.4` works
- `gpt-5.4-mini` works
- repeated OpenCode requests through CLIProxyAPI regain prompt cache hits

I am only explicitly claiming manual validation with OpenCode, but the fix is implemented as a generic Codex continuity improvement rather than an OpenCode-specific special case.

## Relationship to previous PRs

- prior attempt: #2374
- revert of that attempt: #2400

This PR is the minimal reapplication of the executor-level continuity behavior needed to restore prompt cache reuse while avoiding the broader review surface that the earlier attempt accumulated.