### PR TITLE
Add persistent usage statistics mode

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -63,8 +63,14 @@ logs-max-total-size-mb: 0
 # When exceeded, the oldest error log files are deleted. Default is 10. Set to 0 to disable cleanup.
 error-logs-max-files: 10
 
-# When false, disable in-memory usage statistics aggregation
+# Legacy usage statistics toggle. When true, defaults to in-memory aggregation.
+# If usage-statistics.mode is set below, it takes precedence over this boolean.
 usage-statistics-enabled: false
+
+# Usage statistics mode: off, memory, or persistent.
+# Empty/unset mode falls back to usage-statistics-enabled for compatibility.
+usage-statistics:
+  mode: "off"
 
 # Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
 # Per-entry proxy-url also supports "direct" or "none" to bypass both the global proxy-url and environment proxies explicitly.

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -187,10 +187,50 @@ func (h *Handler) PutDebug(c *gin.Context) { h.updateBoolField(c, func(v bool) {
 
 // UsageStatisticsEnabled
 func (h *Handler) GetUsageStatisticsEnabled(c *gin.Context) {
-	c.JSON(200, gin.H{"usage-statistics-enabled": h.cfg.UsageStatisticsEnabled})
+	enabled := false
+	if h != nil && h.cfg != nil {
+		enabled = h.cfg.EffectiveUsageStatisticsMode() != "off"
+	}
+	c.JSON(200, gin.H{"usage-statistics-enabled": enabled})
 }
 func (h *Handler) PutUsageStatisticsEnabled(c *gin.Context) {
-	h.updateBoolField(c, func(v bool) { h.cfg.UsageStatisticsEnabled = v })
+	h.updateBoolField(c, func(v bool) {
+		h.cfg.UsageStatisticsEnabled = v
+		if v {
+			h.cfg.UsageStatistics.Mode = "memory"
+			h.usageMode = "memory"
+			return
+		}
+		h.cfg.UsageStatistics.Mode = "off"
+		h.usageMode = "off"
+	})
+}
+
+// UsageStatisticsMode
+func (h *Handler) GetUsageStatisticsMode(c *gin.Context) {
+	if h == nil || h.cfg == nil {
+		c.JSON(http.StatusOK, gin.H{"usage-statistics-mode": "off"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"usage-statistics-mode": h.cfg.EffectiveUsageStatisticsMode()})
+}
+
+func (h *Handler) PutUsageStatisticsMode(c *gin.Context) {
+	var body struct {
+		Value *string `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	mode := strings.TrimSpace(*body.Value)
+	if mode != "off" && mode != "memory" && mode != "persistent" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid mode"})
+		return
+	}
+	h.cfg.UsageStatistics.Mode = mode
+	h.usageMode = mode
+	h.persist(c)
 }
 
 // UsageStatisticsEnabled

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -42,6 +42,9 @@ type Handler struct {
 	failedAttempts      map[string]*attemptInfo // keyed by client IP
 	authManager         *coreauth.Manager
 	usageStats          *usage.RequestStatistics
+	usageMode           string
+	snapshotStore       *usage.SnapshotStore
+	onConfigPersisted   func(*config.Config)
 	tokenStore          coreauth.Store
 	localPassword       string
 	allowRemoteOverride bool
@@ -61,6 +64,7 @@ func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Man
 		failedAttempts:      make(map[string]*attemptInfo),
 		authManager:         manager,
 		usageStats:          usage.GetRequestStatistics(),
+		usageMode:           cfg.EffectiveUsageStatisticsMode(),
 		tokenStore:          sdkAuth.GetTokenStore(),
 		allowRemoteOverride: envSecret != "",
 		envSecret:           envSecret,
@@ -126,6 +130,17 @@ func (h *Handler) SetAuthManager(manager *coreauth.Manager) {
 
 // SetUsageStatistics allows replacing the usage statistics reference.
 func (h *Handler) SetUsageStatistics(stats *usage.RequestStatistics) { h.usageStats = stats }
+
+// SetUsageStatisticsMode updates the effective usage statistics mode.
+func (h *Handler) SetUsageStatisticsMode(mode string) { h.usageMode = strings.TrimSpace(mode) }
+
+// SetUsageSnapshotStore configures the persistence store used for usage mutations.
+func (h *Handler) SetUsageSnapshotStore(store *usage.SnapshotStore) { h.snapshotStore = store }
+
+// SetConfigPersistedHook registers a callback fired after config persistence succeeds.
+func (h *Handler) SetConfigPersistedHook(callback func(*config.Config)) {
+	h.onConfigPersisted = callback
+}
 
 // SetLocalPassword configures the runtime-local password accepted for localhost requests.
 func (h *Handler) SetLocalPassword(password string) { h.localPassword = password }
@@ -226,6 +241,9 @@ func (h *Handler) AuthenticateManagementKey(clientIP string, localClient bool, p
 		return false, http.StatusForbidden, "remote management disabled"
 	}
 
+	hasLocalPassword := localClient && h.localPassword != ""
+	hasRemotePassword := secretHash != "" || envSecret != ""
+
 	fail := func() {
 		h.attemptsMu.Lock()
 		aip := h.failedAttempts[clientIP]
@@ -251,27 +269,33 @@ func (h *Handler) AuthenticateManagementKey(clientIP string, localClient bool, p
 		h.attemptsMu.Unlock()
 	}
 
-	if secretHash == "" && envSecret == "" {
-		return false, http.StatusForbidden, "remote management key not set"
-	}
-
 	if provided == "" {
+		if !hasLocalPassword && !hasRemotePassword {
+			return false, http.StatusForbidden, "remote management key not set"
+		}
 		fail()
 		return false, http.StatusUnauthorized, "missing management key"
 	}
 
-	if localClient {
-		if lp := h.localPassword; lp != "" {
-			if subtle.ConstantTimeCompare([]byte(provided), []byte(lp)) == 1 {
-				reset()
-				return true, 0, ""
-			}
+	if hasLocalPassword {
+		if subtle.ConstantTimeCompare([]byte(provided), []byte(h.localPassword)) == 1 {
+			reset()
+			return true, 0, ""
 		}
 	}
 
 	if envSecret != "" && subtle.ConstantTimeCompare([]byte(provided), []byte(envSecret)) == 1 {
 		reset()
 		return true, 0, ""
+	}
+
+	if secretHash != "" && bcrypt.CompareHashAndPassword([]byte(secretHash), []byte(provided)) == nil {
+		reset()
+		return true, 0, ""
+	}
+
+	if !hasLocalPassword && !hasRemotePassword {
+		return false, http.StatusForbidden, "remote management key not set"
 	}
 
 	if secretHash == "" || bcrypt.CompareHashAndPassword([]byte(secretHash), []byte(provided)) != nil {
@@ -287,8 +311,14 @@ func (h *Handler) AuthenticateManagementKey(clientIP string, localClient bool, p
 // persist saves the current in-memory config to disk.
 func (h *Handler) persist(c *gin.Context) bool {
 	h.mu.Lock()
-	defer h.mu.Unlock()
-	return h.persistLocked(c)
+	ok := h.persistLocked(c)
+	cfg := h.cfg
+	hook := h.onConfigPersisted
+	h.mu.Unlock()
+	if ok && hook != nil {
+		hook(cfg)
+	}
+	return ok
 }
 
 // persistLocked saves the current in-memory config to disk.

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -44,6 +44,7 @@ type Handler struct {
 	usageStats          *usage.RequestStatistics
 	usageMode           string
 	snapshotStore       *usage.SnapshotStore
+	flushUsageSnapshot  func() error
 	onConfigPersisted   func(*config.Config)
 	tokenStore          coreauth.Store
 	localPassword       string
@@ -136,6 +137,9 @@ func (h *Handler) SetUsageStatisticsMode(mode string) { h.usageMode = strings.Tr
 
 // SetUsageSnapshotStore configures the persistence store used for usage mutations.
 func (h *Handler) SetUsageSnapshotStore(store *usage.SnapshotStore) { h.snapshotStore = store }
+
+// SetUsageSnapshotFlush configures the flush hook used after explicit usage mutations.
+func (h *Handler) SetUsageSnapshotFlush(callback func() error) { h.flushUsageSnapshot = callback }
 
 // SetConfigPersistedHook registers a callback fired after config persistence succeeds.
 func (h *Handler) SetConfigPersistedHook(callback func(*config.Config)) {

--- a/internal/api/handlers/management/handler_test.go
+++ b/internal/api/handlers/management/handler_test.go
@@ -36,3 +36,22 @@ func TestAuthenticateManagementKey_LocalhostIPBan_BlocksCorrectKeyDuringBan(t *t
 		t.Fatalf("unexpected banned message: %q", errMsg)
 	}
 }
+
+func TestAuthenticateManagementKey_LocalPasswordAllowsLocalWithoutRemoteSecret(t *testing.T) {
+	h := &Handler{
+		cfg:            &config.Config{},
+		failedAttempts: make(map[string]*attemptInfo),
+		localPassword:  "local-secret",
+	}
+
+	allowed, statusCode, errMsg := h.AuthenticateManagementKey("127.0.0.1", true, "local-secret")
+	if !allowed {
+		t.Fatalf("expected local password auth to be allowed, got status=%d msg=%q", statusCode, errMsg)
+	}
+	if statusCode != 0 {
+		t.Fatalf("expected zero status code on success, got %d", statusCode)
+	}
+	if errMsg != "" {
+		t.Fatalf("expected empty error message on success, got %q", errMsg)
+	}
+}

--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	log "github.com/sirupsen/logrus"
 )
 
 type usageExportPayload struct {
@@ -75,9 +76,10 @@ func (h *Handler) ImportUsageStatistics(c *gin.Context) {
 
 	result := h.usageStats.MergeSnapshot(payload.Usage)
 	snapshot := h.usageStats.Snapshot()
-	if h.usageMode == "persistent" && h.snapshotStore != nil {
-		if err := h.snapshotStore.Save(snapshot); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if h.usageMode == "persistent" {
+		if err := h.persistUsageSnapshot(snapshot); err != nil {
+			log.WithError(err).Warn("failed to persist imported usage statistics")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to persist usage statistics"})
 			return
 		}
 	}
@@ -119,12 +121,26 @@ func (h *Handler) ResetUsageStatistics(c *gin.Context) {
 	}
 
 	snapshot := h.usageStats.Snapshot()
-	if h.usageMode == "persistent" && h.snapshotStore != nil {
-		if err := h.snapshotStore.Save(snapshot); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if h.usageMode == "persistent" {
+		if err := h.persistUsageSnapshot(snapshot); err != nil {
+			log.WithError(err).Warn("failed to persist reset usage statistics")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to persist usage statistics"})
 			return
 		}
 	}
 
 	c.JSON(http.StatusOK, gin.H{"removed": removed, "usage": snapshot})
+}
+
+func (h *Handler) persistUsageSnapshot(snapshot usage.StatisticsSnapshot) error {
+	if h == nil {
+		return nil
+	}
+	if h.flushUsageSnapshot != nil {
+		return h.flushUsageSnapshot()
+	}
+	if h.snapshotStore == nil {
+		return nil
+	}
+	return h.snapshotStore.Save(snapshot)
 }

--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -20,6 +20,11 @@ type usageImportPayload struct {
 	Usage   usage.StatisticsSnapshot `json:"usage"`
 }
 
+type usageResetRequest struct {
+	Scope string `json:"scope"`
+	Value string `json:"value,omitempty"`
+}
+
 // GetUsageStatistics returns the in-memory request statistics snapshot.
 func (h *Handler) GetUsageStatistics(c *gin.Context) {
 	var snapshot usage.StatisticsSnapshot
@@ -70,10 +75,56 @@ func (h *Handler) ImportUsageStatistics(c *gin.Context) {
 
 	result := h.usageStats.MergeSnapshot(payload.Usage)
 	snapshot := h.usageStats.Snapshot()
+	if h.usageMode == "persistent" && h.snapshotStore != nil {
+		if err := h.snapshotStore.Save(snapshot); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"added":           result.Added,
 		"skipped":         result.Skipped,
 		"total_requests":  snapshot.TotalRequests,
 		"failed_requests": snapshot.FailureCount,
 	})
+}
+
+// ResetUsageStatistics clears usage data for the requested scope.
+func (h *Handler) ResetUsageStatistics(c *gin.Context) {
+	if h == nil || h.usageStats == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "usage statistics unavailable"})
+		return
+	}
+
+	var req usageResetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var removed int
+	switch req.Scope {
+	case "all":
+		removed = int(h.usageStats.Snapshot().TotalRequests)
+		h.usageStats.ResetAll()
+	case "provider":
+		removed = h.usageStats.ResetByProvider(req.Value)
+	case "model":
+		removed = h.usageStats.ResetByModel(req.Value)
+	case "api_key":
+		removed = h.usageStats.ResetByAPIKey(req.Value)
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scope"})
+		return
+	}
+
+	snapshot := h.usageStats.Snapshot()
+	if h.usageMode == "persistent" && h.snapshotStore != nil {
+		if err := h.snapshotStore.Save(snapshot); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"removed": removed, "usage": snapshot})
 }

--- a/internal/api/handlers/management/usage_mode_test.go
+++ b/internal/api/handlers/management/usage_mode_test.go
@@ -1,0 +1,166 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+)
+
+func newUsageModeTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 8080\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	h := NewHandler(&config.Config{}, configPath, nil)
+	return h
+}
+
+func TestGetUsageStatisticsMode(t *testing.T) {
+	t.Parallel()
+	h := newUsageModeTestHandler(t)
+	h.cfg.UsageStatistics.Mode = "persistent"
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/usage-statistics-mode", nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.GetUsageStatisticsMode(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["usage-statistics-mode"] != "persistent" {
+		t.Fatalf("expected persistent, got %q", resp["usage-statistics-mode"])
+	}
+}
+
+func TestPutUsageStatisticsModeRejectsInvalidValue(t *testing.T) {
+	t.Parallel()
+	h := newUsageModeTestHandler(t)
+
+	body := []byte(`{"value":"strange"}`)
+	req := httptest.NewRequest(http.MethodPut, "/v0/management/usage-statistics-mode", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.PutUsageStatisticsMode(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGetUsageStatisticsEnabledUsesEffectiveMode(t *testing.T) {
+	t.Parallel()
+	h := newUsageModeTestHandler(t)
+	h.cfg.UsageStatisticsEnabled = false
+	h.cfg.UsageStatistics.Mode = "persistent"
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/usage-statistics-enabled", nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.GetUsageStatisticsEnabled(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]bool
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !resp["usage-statistics-enabled"] {
+		t.Fatalf("expected effective mode persistent to report enabled")
+	}
+}
+
+func TestPutUsageStatisticsEnabledOverridesExplicitMode(t *testing.T) {
+	t.Parallel()
+	h := newUsageModeTestHandler(t)
+	h.cfg.UsageStatistics.Mode = "off"
+
+	body := []byte(`{"value":true}`)
+	req := httptest.NewRequest(http.MethodPut, "/v0/management/usage-statistics-enabled", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.PutUsageStatisticsEnabled(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := h.cfg.EffectiveUsageStatisticsMode(); got != "memory" {
+		t.Fatalf("expected legacy enabled update to switch effective mode to memory, got %q", got)
+	}
+}
+
+func TestPatchUsageStatisticsModeUpdatesConfig(t *testing.T) {
+	t.Parallel()
+	h := newUsageModeTestHandler(t)
+
+	body := []byte(`{"value":"memory"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/usage-statistics-mode", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.PutUsageStatisticsMode(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := h.cfg.UsageStatistics.Mode; got != "memory" {
+		t.Fatalf("expected mode to update to memory, got %q", got)
+	}
+}
+
+func TestImportUsageStatistics_PersistentSavesSnapshot(t *testing.T) {
+	t.Parallel()
+	h := newUsageModeTestHandler(t)
+	store := usage.NewSnapshotStore(filepath.Join(t.TempDir(), "usage-statistics.json"))
+	h.SetUsageStatistics(usage.NewRequestStatistics())
+	h.SetUsageSnapshotStore(store)
+	h.SetUsageStatisticsMode("persistent")
+
+	body := []byte(`{"version":1,"usage":{"apis":{"key-a":{"total_requests":1,"total_tokens":30,"models":{"model-a":{"total_requests":1,"total_tokens":30,"details":[{"timestamp":"2026-04-28T00:00:00Z","provider":"provider-a","model":"model-a","api_key":"key-a","source":"source-a","tokens":{"total_tokens":30},"failed":false}]}}}}}}`)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/usage/import", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.ImportUsageStatistics(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("load saved snapshot: %v", err)
+	}
+	if loaded.TotalRequests != 1 {
+		t.Fatalf("expected saved snapshot to contain 1 request, got %d", loaded.TotalRequests)
+	}
+}

--- a/internal/api/handlers/management/usage_reset_test.go
+++ b/internal/api/handlers/management/usage_reset_test.go
@@ -1,0 +1,196 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+)
+
+func newUsageResetTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("port: 8080\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	h := NewHandler(&config.Config{}, configPath, nil)
+	h.SetUsageStatistics(usage.NewRequestStatistics())
+	return h
+}
+
+func seedUsageStats(t *testing.T, stats *usage.RequestStatistics) {
+	t.Helper()
+	stats.Record(nil, coreusage.Record{Provider: "provider-a", Model: "model-a", APIKey: "key-a", Detail: coreusage.Detail{TotalTokens: 10}})
+	stats.Record(nil, coreusage.Record{Provider: "provider-b", Model: "model-b", APIKey: "key-b", Detail: coreusage.Detail{TotalTokens: 20}})
+}
+
+func TestResetUsageStatistics_All(t *testing.T) {
+	t.Parallel()
+	h := newUsageResetTestHandler(t)
+	seedUsageStats(t, h.usageStats)
+
+	body := []byte(`{"scope":"all"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/usage/reset", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.ResetUsageStatistics(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := h.usageStats.Snapshot().TotalRequests; got != 0 {
+		t.Fatalf("expected reset all to clear usage, got %d requests", got)
+	}
+}
+
+func TestResetUsageStatistics_Provider(t *testing.T) {
+	t.Parallel()
+	h := newUsageResetTestHandler(t)
+	seedUsageStats(t, h.usageStats)
+
+	body := []byte(`{"scope":"provider","value":"provider-a"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/usage/reset", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.ResetUsageStatistics(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	snapshot := h.usageStats.Snapshot()
+	if _, ok := snapshot.Providers["provider-a"]; ok {
+		t.Fatalf("expected provider-a to be removed")
+	}
+	if snapshot.TotalRequests != 1 {
+		t.Fatalf("expected one remaining request, got %d", snapshot.TotalRequests)
+	}
+}
+
+func TestResetUsageStatistics_Model(t *testing.T) {
+	t.Parallel()
+	h := newUsageResetTestHandler(t)
+	seedUsageStats(t, h.usageStats)
+
+	body := []byte(`{"scope":"model","value":"model-a"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/usage/reset", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.ResetUsageStatistics(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	snapshot := h.usageStats.Snapshot()
+	if _, ok := snapshot.Models["model-a"]; ok {
+		t.Fatalf("expected model-a to be removed")
+	}
+	if snapshot.TotalRequests != 1 {
+		t.Fatalf("expected one remaining request, got %d", snapshot.TotalRequests)
+	}
+}
+
+func TestResetUsageStatistics_APIKey(t *testing.T) {
+	t.Parallel()
+	h := newUsageResetTestHandler(t)
+	seedUsageStats(t, h.usageStats)
+
+	body := []byte(`{"scope":"api_key","value":"key-a"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/usage/reset", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.ResetUsageStatistics(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	snapshot := h.usageStats.Snapshot()
+	if _, ok := snapshot.APIs["key-a"]; ok {
+		t.Fatalf("expected key-a api bucket to be removed")
+	}
+	if snapshot.TotalRequests != 1 {
+		t.Fatalf("expected one remaining request, got %d", snapshot.TotalRequests)
+	}
+}
+
+func TestResetUsageStatistics_PersistentSavesSnapshot(t *testing.T) {
+	t.Parallel()
+	h := newUsageResetTestHandler(t)
+	store := usage.NewSnapshotStore(filepath.Join(t.TempDir(), "usage-statistics.json"))
+	h.SetUsageSnapshotStore(store)
+	h.SetUsageStatisticsMode("persistent")
+	seedUsageStats(t, h.usageStats)
+
+	body := []byte(`{"scope":"provider","value":"provider-a"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/usage/reset", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.ResetUsageStatistics(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("load saved snapshot: %v", err)
+	}
+	restored := usage.NewRequestStatistics()
+	restored.MergeSnapshot(loaded)
+	snapshot := restored.Snapshot()
+	if _, ok := snapshot.Providers["provider-a"]; ok {
+		t.Fatalf("expected provider-a to remain cleared after reload")
+	}
+	if snapshot.TotalRequests != 1 {
+		t.Fatalf("expected one remaining request after reload, got %d", snapshot.TotalRequests)
+	}
+}
+
+func TestResetUsageStatistics_InvalidScope(t *testing.T) {
+	t.Parallel()
+	h := newUsageResetTestHandler(t)
+
+	body := []byte(`{"scope":"weird"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/usage/reset", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	h.ResetUsageStatistics(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["error"] == "" {
+		t.Fatalf("expected error response, got %s", w.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -178,6 +178,7 @@ type Server struct {
 	mgmt *managementHandlers.Handler
 
 	usageSnapshotStore *usage.SnapshotStore
+	usageSnapshotSaver *usage.SnapshotSaver
 
 	// ampModule is the Amp routing module for model mapping hot-reload
 	ampModule *ampmodule.AmpModule
@@ -948,6 +949,12 @@ func (s *Server) Stop(ctx context.Context) error {
 		default:
 		}
 	}
+	if s.usageSnapshotSaver != nil {
+		if err := s.usageSnapshotSaver.Close(); err != nil {
+			log.WithError(err).Warn("failed to flush usage statistics snapshot")
+		}
+		s.usageSnapshotSaver = nil
+	}
 
 	if s.muxHTTPListener != nil {
 		_ = s.muxHTTPListener.Close()
@@ -1156,6 +1163,12 @@ func (s *Server) configureUsageStatistics(oldCfg, cfg *config.Config) {
 	mode := cfg.EffectiveUsageStatisticsMode()
 	stats := usage.GetRequestStatistics()
 	stats.SetOnChange(nil)
+	if s.usageSnapshotSaver != nil {
+		if err := s.usageSnapshotSaver.Close(); err != nil {
+			log.WithError(err).Warn("failed to flush usage statistics snapshot")
+		}
+		s.usageSnapshotSaver = nil
+	}
 	usage.SetStatisticsEnabled(mode != "off")
 
 	oldMode := ""
@@ -1176,10 +1189,10 @@ func (s *Server) configureUsageStatistics(oldCfg, cfg *config.Config) {
 				}
 			}
 		}
+		saver := usage.NewSnapshotSaver(store, time.Second)
+		s.usageSnapshotSaver = saver
 		stats.SetOnChange(func(snapshot usage.StatisticsSnapshot) {
-			if err := store.Save(snapshot); err != nil {
-				log.WithError(err).Warn("failed to save usage statistics snapshot")
-			}
+			saver.SaveSoon(snapshot)
 		})
 	}
 
@@ -1187,6 +1200,11 @@ func (s *Server) configureUsageStatistics(oldCfg, cfg *config.Config) {
 		s.mgmt.SetUsageStatistics(stats)
 		s.mgmt.SetUsageStatisticsMode(mode)
 		s.mgmt.SetUsageSnapshotStore(store)
+		if s.usageSnapshotSaver != nil {
+			s.mgmt.SetUsageSnapshotFlush(s.usageSnapshotSaver.Flush)
+		} else {
+			s.mgmt.SetUsageSnapshotFlush(nil)
+		}
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -52,6 +52,7 @@ type serverOptionConfig struct {
 	engineConfigurator   func(*gin.Engine)
 	routerConfigurator   func(*gin.Engine, *handlers.BaseAPIHandler, *config.Config)
 	requestLoggerFactory func(*config.Config, string) logging.RequestLogger
+	usageSnapshotPath    string
 	localPassword        string
 	keepAliveEnabled     bool
 	keepAliveTimeout     time.Duration
@@ -115,6 +116,13 @@ func WithRequestLoggerFactory(factory func(*config.Config, string) logging.Reque
 	}
 }
 
+// WithUsageStatisticsSnapshotPath overrides the on-disk path used for persistent usage snapshots.
+func WithUsageStatisticsSnapshotPath(path string) ServerOption {
+	return func(cfg *serverOptionConfig) {
+		cfg.usageSnapshotPath = strings.TrimSpace(path)
+	}
+}
+
 // WithPostAuthHook registers a hook to be called after auth record creation.
 func WithPostAuthHook(hook auth.PostAuthHook) ServerOption {
 	return func(cfg *serverOptionConfig) {
@@ -168,6 +176,8 @@ type Server struct {
 
 	// management handler
 	mgmt *managementHandlers.Handler
+
+	usageSnapshotStore *usage.SnapshotStore
 
 	// ampModule is the Amp routing module for model mapping hot-reload
 	ampModule *ampmodule.AmpModule
@@ -263,6 +273,11 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 		envManagementSecret: envManagementSecret,
 		wsRoutes:            make(map[string]struct{}),
 	}
+	snapshotPath := optionState.usageSnapshotPath
+	if snapshotPath == "" {
+		snapshotPath = usage.DefaultSnapshotPath(configFilePath)
+	}
+	s.usageSnapshotStore = usage.NewSnapshotStore(snapshotPath)
 	s.wsAuthEnabled.Store(cfg.WebsocketAuth)
 	// Save initial YAML snapshot
 	s.oldConfigYaml, _ = yaml.Marshal(cfg)
@@ -275,6 +290,16 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	applySignatureCacheConfig(nil, cfg)
 	// Initialize management handler
 	s.mgmt = managementHandlers.NewHandler(cfg, configFilePath, authManager)
+	s.mgmt.SetConfigPersistedHook(func(updatedCfg *config.Config) {
+		var previousCfg *config.Config
+		if len(s.oldConfigYaml) > 0 {
+			_ = yaml.Unmarshal(s.oldConfigYaml, &previousCfg)
+		}
+		s.configureUsageStatistics(previousCfg, updatedCfg)
+		s.cfg = updatedCfg
+		s.oldConfigYaml, _ = yaml.Marshal(updatedCfg)
+	})
+	s.configureUsageStatistics(nil, cfg)
 	if optionState.localPassword != "" {
 		s.mgmt.SetLocalPassword(optionState.localPassword)
 	}
@@ -510,6 +535,10 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/usage", s.mgmt.GetUsageStatistics)
 		mgmt.GET("/usage/export", s.mgmt.ExportUsageStatistics)
 		mgmt.POST("/usage/import", s.mgmt.ImportUsageStatistics)
+		mgmt.POST("/usage/reset", s.mgmt.ResetUsageStatistics)
+		mgmt.GET("/usage-statistics-mode", s.mgmt.GetUsageStatisticsMode)
+		mgmt.PUT("/usage-statistics-mode", s.mgmt.PutUsageStatisticsMode)
+		mgmt.PATCH("/usage-statistics-mode", s.mgmt.PutUsageStatisticsMode)
 		mgmt.GET("/config", s.mgmt.GetConfig)
 		mgmt.GET("/config.yaml", s.mgmt.GetConfigYAML)
 		mgmt.PUT("/config.yaml", s.mgmt.PutConfigYAML)
@@ -999,9 +1028,7 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 		}
 	}
 
-	if oldCfg == nil || oldCfg.UsageStatisticsEnabled != cfg.UsageStatisticsEnabled {
-		usage.SetStatisticsEnabled(cfg.UsageStatisticsEnabled)
-	}
+	s.configureUsageStatistics(oldCfg, cfg)
 
 	if s.requestLogger != nil && (oldCfg == nil || oldCfg.ErrorLogsMaxFiles != cfg.ErrorLogsMaxFiles) {
 		if setter, ok := s.requestLogger.(interface{ SetErrorLogsMaxFiles(int) }); ok {
@@ -1120,6 +1147,47 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 		vertexAICompatCount,
 		openAICompatCount,
 	)
+}
+
+func (s *Server) configureUsageStatistics(oldCfg, cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	mode := cfg.EffectiveUsageStatisticsMode()
+	stats := usage.GetRequestStatistics()
+	stats.SetOnChange(nil)
+	usage.SetStatisticsEnabled(mode != "off")
+
+	oldMode := ""
+	if oldCfg != nil {
+		oldMode = oldCfg.EffectiveUsageStatisticsMode()
+	}
+	shouldRestore := oldCfg == nil || oldMode != mode
+	store := s.usageSnapshotStore
+	if mode == "persistent" && store != nil {
+		if shouldRestore {
+			snapshot, err := store.Load()
+			if err != nil {
+				log.WithError(err).Warn("failed to load usage statistics snapshot")
+			} else {
+				stats.MergeSnapshot(snapshot)
+				if err := store.Save(stats.Snapshot()); err != nil {
+					log.WithError(err).Warn("failed to save merged usage statistics snapshot")
+				}
+			}
+		}
+		stats.SetOnChange(func(snapshot usage.StatisticsSnapshot) {
+			if err := store.Save(snapshot); err != nil {
+				log.WithError(err).Warn("failed to save usage statistics snapshot")
+			}
+		})
+	}
+
+	if s.mgmt != nil {
+		s.mgmt.SetUsageStatistics(stats)
+		s.mgmt.SetUsageStatisticsMode(mode)
+		s.mgmt.SetUsageSnapshotStore(store)
+	}
 }
 
 func (s *Server) SetWebsocketAuthChangeHandler(fn func(bool, bool)) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -13,8 +13,10 @@ import (
 	gin "github.com/gin-gonic/gin"
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 )
 
@@ -44,7 +46,57 @@ func newTestServer(t *testing.T) *Server {
 	accessManager := sdkaccess.NewManager()
 
 	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("api-keys:\n  - test-key\n"), 0o644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
 	return NewServer(cfg, authManager, accessManager, configPath)
+}
+
+func newConfiguredTestServer(t *testing.T, mutate func(*proxyconfig.Config), opts ...ServerOption) *Server {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	tmpDir := t.TempDir()
+	authDir := filepath.Join(tmpDir, "auth")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("failed to create auth dir: %v", err)
+	}
+
+	cfg := &proxyconfig.Config{
+		SDKConfig: sdkconfig.SDKConfig{
+			APIKeys: []string{"test-key"},
+		},
+		Port:                   0,
+		AuthDir:                authDir,
+		Debug:                  true,
+		LoggingToFile:          false,
+		UsageStatisticsEnabled: false,
+	}
+	if mutate != nil {
+		mutate(cfg)
+	}
+
+	authManager := auth.NewManager(nil, nil, nil)
+	accessManager := sdkaccess.NewManager()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("api-keys:\n  - test-key\n"), 0o644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+	return NewServer(cfg, authManager, accessManager, configPath, opts...)
+}
+
+func usageTestRecord() coreusage.Record {
+	return coreusage.Record{
+		Provider: "provider-a",
+		Model:    "model-a",
+		APIKey:   "key-a",
+		Detail: coreusage.Detail{
+			InputTokens:  10,
+			OutputTokens: 20,
+			TotalTokens:  30,
+		},
+	}
 }
 
 func TestHealthz(t *testing.T) {
@@ -147,6 +199,138 @@ func TestAmpProviderModelRoutes(t *testing.T) {
 				t.Fatalf("response body for %s missing %q: %s", tc.path, tc.wantContains, body)
 			}
 		})
+	}
+}
+
+func TestNewServer_UsageStatisticsModeOffDisablesAggregation(t *testing.T) {
+	prevEnabled := usage.StatisticsEnabled()
+	usage.SetStatisticsEnabled(true)
+	t.Cleanup(func() {
+		usage.SetStatisticsEnabled(prevEnabled)
+	})
+
+	stats := usage.GetRequestStatistics()
+	stats.SetOnChange(nil)
+	stats.ResetAll()
+	t.Cleanup(func() {
+		stats.SetOnChange(nil)
+		stats.ResetAll()
+	})
+
+	_ = newConfiguredTestServer(t, func(cfg *proxyconfig.Config) {
+		cfg.UsageStatistics.Mode = "off"
+		cfg.UsageStatisticsEnabled = true
+	})
+
+	if usage.StatisticsEnabled() {
+		t.Fatalf("expected usage aggregation to be disabled when mode is off")
+	}
+}
+
+func TestNewServer_UsageStatisticsModePersistentLoadsSnapshot(t *testing.T) {
+	prevEnabled := usage.StatisticsEnabled()
+	usage.SetStatisticsEnabled(true)
+	t.Cleanup(func() {
+		usage.SetStatisticsEnabled(prevEnabled)
+	})
+
+	stats := usage.GetRequestStatistics()
+	stats.SetOnChange(nil)
+	stats.ResetAll()
+	t.Cleanup(func() {
+		stats.SetOnChange(nil)
+		stats.ResetAll()
+	})
+
+	dir := t.TempDir()
+	snapshotPath := filepath.Join(dir, "usage-statistics.json")
+	store := usage.NewSnapshotStore(snapshotPath)
+	seed := usage.NewRequestStatistics()
+	seed.Record(nil, usageTestRecord())
+	if err := store.Save(seed.Snapshot()); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+
+	_ = newConfiguredTestServer(t, func(cfg *proxyconfig.Config) {
+		cfg.UsageStatistics.Mode = "persistent"
+	}, WithUsageStatisticsSnapshotPath(snapshotPath))
+
+	snapshot := usage.GetRequestStatistics().Snapshot()
+	if snapshot.TotalRequests != 1 {
+		t.Fatalf("expected restored snapshot, got %d requests", snapshot.TotalRequests)
+	}
+}
+
+func TestNewServer_UsageStatisticsModePersistentSavesMergedInMemorySnapshotImmediately(t *testing.T) {
+	prevEnabled := usage.StatisticsEnabled()
+	usage.SetStatisticsEnabled(true)
+	t.Cleanup(func() {
+		usage.SetStatisticsEnabled(prevEnabled)
+	})
+
+	stats := usage.GetRequestStatistics()
+	stats.SetOnChange(nil)
+	stats.ResetAll()
+	t.Cleanup(func() {
+		stats.SetOnChange(nil)
+		stats.ResetAll()
+	})
+
+	stats.Record(nil, coreusage.Record{
+		Provider: "provider-memory",
+		Model:    "model-memory",
+		APIKey:   "key-memory",
+		Detail: coreusage.Detail{
+			TotalTokens: 7,
+		},
+	})
+
+	dir := t.TempDir()
+	snapshotPath := filepath.Join(dir, "usage-statistics.json")
+	store := usage.NewSnapshotStore(snapshotPath)
+	seed := usage.NewRequestStatistics()
+	seed.Record(nil, usageTestRecord())
+	if err := store.Save(seed.Snapshot()); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+
+	_ = newConfiguredTestServer(t, func(cfg *proxyconfig.Config) {
+		cfg.UsageStatistics.Mode = "persistent"
+	}, WithUsageStatisticsSnapshotPath(snapshotPath))
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("load merged snapshot: %v", err)
+	}
+	if loaded.TotalRequests != 2 {
+		t.Fatalf("expected merged snapshot to be saved with 2 requests, got %d", loaded.TotalRequests)
+	}
+}
+
+func TestUsageStatisticsModeEndpointAppliesImmediately(t *testing.T) {
+	prevEnabled := usage.StatisticsEnabled()
+	usage.SetStatisticsEnabled(false)
+	t.Cleanup(func() {
+		usage.SetStatisticsEnabled(prevEnabled)
+	})
+
+	server := newConfiguredTestServer(t, func(cfg *proxyconfig.Config) {
+		cfg.UsageStatistics.Mode = "off"
+	}, WithLocalManagementPassword("local-test-password"))
+
+	body := strings.NewReader(`{"value":"memory"}`)
+	req := httptest.NewRequest(http.MethodPut, "/v0/management/usage-statistics-mode", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Management-Key", "local-test-password")
+	req.RemoteAddr = "127.0.0.1:12345"
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !usage.StatisticsEnabled() {
+		t.Fatalf("expected usage statistics mode update to apply immediately")
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -261,6 +261,41 @@ func TestNewServer_UsageStatisticsModePersistentLoadsSnapshot(t *testing.T) {
 	}
 }
 
+func TestNewServer_UsageStatisticsModePersistentKeepsMalformedSnapshot(t *testing.T) {
+	prevEnabled := usage.StatisticsEnabled()
+	usage.SetStatisticsEnabled(true)
+	t.Cleanup(func() {
+		usage.SetStatisticsEnabled(prevEnabled)
+	})
+
+	stats := usage.GetRequestStatistics()
+	stats.SetOnChange(nil)
+	stats.ResetAll()
+	t.Cleanup(func() {
+		stats.SetOnChange(nil)
+		stats.ResetAll()
+	})
+
+	dir := t.TempDir()
+	snapshotPath := filepath.Join(dir, "usage-statistics.json")
+	malformed := []byte("{malformed")
+	if err := os.WriteFile(snapshotPath, malformed, 0o600); err != nil {
+		t.Fatalf("write malformed snapshot: %v", err)
+	}
+
+	_ = newConfiguredTestServer(t, func(cfg *proxyconfig.Config) {
+		cfg.UsageStatistics.Mode = "persistent"
+	}, WithUsageStatisticsSnapshotPath(snapshotPath))
+
+	got, err := os.ReadFile(snapshotPath)
+	if err != nil {
+		t.Fatalf("read malformed snapshot after server start: %v", err)
+	}
+	if string(got) != string(malformed) {
+		t.Fatalf("server start changed malformed snapshot to %q", string(got))
+	}
+}
+
 func TestNewServer_UsageStatisticsModePersistentSavesMergedInMemorySnapshotImmediately(t *testing.T) {
 	prevEnabled := usage.StatisticsEnabled()
 	usage.SetStatisticsEnabled(true)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,8 +62,10 @@ type Config struct {
 	// When exceeded, the oldest error log files are deleted. Default is 10. Set to 0 to disable cleanup.
 	ErrorLogsMaxFiles int `yaml:"error-logs-max-files" json:"error-logs-max-files"`
 
-	// UsageStatisticsEnabled toggles in-memory usage aggregation; when false, usage data is discarded.
+	// UsageStatisticsEnabled is the legacy usage aggregation toggle. UsageStatistics.Mode overrides it when set.
 	UsageStatisticsEnabled bool `yaml:"usage-statistics-enabled" json:"usage-statistics-enabled"`
+	// UsageStatistics controls usage aggregation mode.
+	UsageStatistics UsageStatisticsConfig `yaml:"usage-statistics" json:"usage-statistics"`
 
 	// DisableCooling disables quota cooldown scheduling when true.
 	DisableCooling bool `yaml:"disable-cooling" json:"disable-cooling"`
@@ -179,6 +181,24 @@ type PprofConfig struct {
 	Enable bool `yaml:"enable" json:"enable"`
 	// Addr is the host:port address for the pprof HTTP server.
 	Addr string `yaml:"addr" json:"addr"`
+}
+
+// UsageStatisticsConfig controls usage aggregation behavior.
+type UsageStatisticsConfig struct {
+	// Mode accepts "off", "memory", or "persistent". Empty mode falls back to UsageStatisticsEnabled.
+	Mode string `yaml:"mode" json:"mode"`
+}
+
+// EffectiveUsageStatisticsMode returns the configured usage statistics mode with legacy fallback.
+func (c *Config) EffectiveUsageStatisticsMode() string {
+	mode := strings.TrimSpace(c.UsageStatistics.Mode)
+	if mode != "" {
+		return mode
+	}
+	if c.UsageStatisticsEnabled {
+		return "memory"
+	}
+	return "off"
 }
 
 // RemoteManagement holds management API configuration under 'remote-management'.
@@ -669,6 +689,15 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	if cfg.ErrorLogsMaxFiles < 0 {
 		cfg.ErrorLogsMaxFiles = 10
+	}
+
+	cfg.UsageStatistics.Mode = strings.TrimSpace(cfg.UsageStatistics.Mode)
+	if cfg.UsageStatistics.Mode != "" {
+		switch cfg.UsageStatistics.Mode {
+		case "off", "memory", "persistent":
+		default:
+			return nil, fmt.Errorf("unknown usage-statistics mode %q", cfg.UsageStatistics.Mode)
+		}
 	}
 
 	if cfg.MaxRetryCredentials < 0 {

--- a/internal/config/usage_statistics_mode_test.go
+++ b/internal/config/usage_statistics_mode_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfigOptional_UsageStatisticsMode(t *testing.T) {
+	t.Run("explicit mode overrides legacy boolean", func(t *testing.T) {
+		cfg := loadUsageStatisticsModeConfig(t, `
+usage-statistics-enabled: true
+usage-statistics:
+  mode: "off"
+`)
+
+		if got := cfg.UsageStatistics.Mode; got != "off" {
+			t.Fatalf("UsageStatistics.Mode = %q, want %q", got, "off")
+		}
+		if got := cfg.EffectiveUsageStatisticsMode(); got != "off" {
+			t.Fatalf("EffectiveUsageStatisticsMode() = %q, want %q", got, "off")
+		}
+	})
+
+	t.Run("legacy enabled uses memory mode", func(t *testing.T) {
+		cfg := loadUsageStatisticsModeConfig(t, `
+usage-statistics-enabled: true
+`)
+
+		if got := cfg.EffectiveUsageStatisticsMode(); got != "memory" {
+			t.Fatalf("EffectiveUsageStatisticsMode() = %q, want %q", got, "memory")
+		}
+	})
+
+	t.Run("legacy disabled uses off mode", func(t *testing.T) {
+		cfg := loadUsageStatisticsModeConfig(t, `
+usage-statistics-enabled: false
+`)
+
+		if got := cfg.EffectiveUsageStatisticsMode(); got != "off" {
+			t.Fatalf("EffectiveUsageStatisticsMode() = %q, want %q", got, "off")
+		}
+	})
+
+	t.Run("rejects unknown explicit mode", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "config.yaml")
+		configYAML := []byte(`
+usage-statistics:
+  mode: "disk"
+`)
+		if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+			t.Fatalf("failed to write config: %v", err)
+		}
+
+		_, err := LoadConfigOptional(configPath, false)
+		if err == nil {
+			t.Fatal("LoadConfigOptional() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "unknown usage-statistics mode") {
+			t.Fatalf("LoadConfigOptional() error = %q, want unknown usage-statistics mode", err)
+		}
+	})
+}
+
+func loadUsageStatisticsModeConfig(t *testing.T, configYAML string) *Config {
+	t.Helper()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+	return cfg
+}

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -58,7 +58,8 @@ func StatisticsEnabled() bool { return statisticsEnabled.Load() }
 
 // RequestStatistics maintains aggregated request metrics in memory.
 type RequestStatistics struct {
-	mu sync.RWMutex
+	mu       sync.RWMutex
+	onChange func(StatisticsSnapshot)
 
 	totalRequests int64
 	successCount  int64
@@ -91,6 +92,9 @@ type modelStats struct {
 type RequestDetail struct {
 	Timestamp time.Time  `json:"timestamp"`
 	LatencyMs int64      `json:"latency_ms"`
+	Provider  string     `json:"provider,omitempty"`
+	Model     string     `json:"model,omitempty"`
+	APIKey    string     `json:"api_key,omitempty"`
 	Source    string     `json:"source"`
 	AuthIndex string     `json:"auth_index"`
 	Tokens    TokenStats `json:"tokens"`
@@ -113,12 +117,26 @@ type StatisticsSnapshot struct {
 	FailureCount  int64 `json:"failure_count"`
 	TotalTokens   int64 `json:"total_tokens"`
 
-	APIs map[string]APISnapshot `json:"apis"`
+	APIs      map[string]APISnapshot      `json:"apis"`
+	Providers map[string]ProviderSnapshot `json:"providers"`
+	Models    map[string]SummarySnapshot  `json:"models"`
 
 	RequestsByDay  map[string]int64 `json:"requests_by_day"`
 	RequestsByHour map[string]int64 `json:"requests_by_hour"`
 	TokensByDay    map[string]int64 `json:"tokens_by_day"`
 	TokensByHour   map[string]int64 `json:"tokens_by_hour"`
+}
+
+// ProviderSnapshot summarises metrics for a provider.
+type ProviderSnapshot struct {
+	TotalRequests int64 `json:"total_requests"`
+	TotalTokens   int64 `json:"total_tokens"`
+}
+
+// SummarySnapshot summarises metrics for a grouping dimension.
+type SummarySnapshot struct {
+	TotalRequests int64 `json:"total_requests"`
+	TotalTokens   int64 `json:"total_tokens"`
 }
 
 // APISnapshot summarises metrics for a single API key.
@@ -151,6 +169,16 @@ func NewRequestStatistics() *RequestStatistics {
 	}
 }
 
+// SetOnChange registers a callback invoked with a fresh snapshot after mutations.
+func (s *RequestStatistics) SetOnChange(callback func(StatisticsSnapshot)) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.onChange = callback
+	s.mu.Unlock()
+}
+
 // Record ingests a new usage record and updates the aggregates.
 func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record) {
 	if s == nil {
@@ -178,11 +206,14 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	if modelName == "" {
 		modelName = "unknown"
 	}
+	providerName := strings.TrimSpace(record.Provider)
+	if providerName == "" {
+		providerName = "unknown"
+	}
 	dayKey := timestamp.Format("2006-01-02")
 	hourKey := timestamp.Hour()
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	s.totalRequests++
 	if success {
@@ -200,6 +231,9 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	s.updateAPIStats(stats, modelName, RequestDetail{
 		Timestamp: timestamp,
 		LatencyMs: normaliseLatency(record.Latency),
+		Provider:  providerName,
+		Model:     modelName,
+		APIKey:    statsKey,
 		Source:    record.Source,
 		AuthIndex: record.AuthIndex,
 		Tokens:    detail,
@@ -210,6 +244,9 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	s.requestsByHour[hourKey]++
 	s.tokensByDay[dayKey] += totalTokens
 	s.tokensByHour[hourKey] += totalTokens
+	s.mu.Unlock()
+
+	s.notifyChange()
 }
 
 func (s *RequestStatistics) updateAPIStats(stats *apiStats, model string, detail RequestDetail) {
@@ -241,6 +278,8 @@ func (s *RequestStatistics) Snapshot() StatisticsSnapshot {
 	result.TotalTokens = s.totalTokens
 
 	result.APIs = make(map[string]APISnapshot, len(s.apis))
+	result.Providers = make(map[string]ProviderSnapshot)
+	result.Models = make(map[string]SummarySnapshot)
 	for apiName, stats := range s.apis {
 		apiSnapshot := APISnapshot{
 			TotalRequests: stats.TotalRequests,
@@ -249,12 +288,22 @@ func (s *RequestStatistics) Snapshot() StatisticsSnapshot {
 		}
 		for modelName, modelStatsValue := range stats.Models {
 			requestDetails := make([]RequestDetail, len(modelStatsValue.Details))
-			copy(requestDetails, modelStatsValue.Details)
+			for i, detail := range modelStatsValue.Details {
+				requestDetails[i] = normaliseStoredDetail(apiName, modelName, detail)
+				providerSnapshot := result.Providers[requestDetails[i].Provider]
+				providerSnapshot.TotalRequests++
+				providerSnapshot.TotalTokens += requestDetails[i].Tokens.TotalTokens
+				result.Providers[requestDetails[i].Provider] = providerSnapshot
+			}
 			apiSnapshot.Models[modelName] = ModelSnapshot{
 				TotalRequests: modelStatsValue.TotalRequests,
 				TotalTokens:   modelStatsValue.TotalTokens,
 				Details:       requestDetails,
 			}
+			modelSnapshot := result.Models[modelName]
+			modelSnapshot.TotalRequests += modelStatsValue.TotalRequests
+			modelSnapshot.TotalTokens += modelStatsValue.TotalTokens
+			result.Models[modelName] = modelSnapshot
 		}
 		result.APIs[apiName] = apiSnapshot
 	}
@@ -298,7 +347,6 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	seen := make(map[string]struct{})
 	for apiName, stats := range s.apis {
@@ -340,6 +388,7 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 				if detail.Timestamp.IsZero() {
 					detail.Timestamp = time.Now()
 				}
+				detail = normaliseStoredDetail(apiName, modelName, detail)
 				key := dedupKey(apiName, modelName, detail)
 				if _, exists := seen[key]; exists {
 					result.Skipped++
@@ -352,6 +401,10 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 		}
 	}
 
+	s.mu.Unlock()
+	if result.Added > 0 {
+		s.notifyChange()
+	}
 	return result
 }
 
@@ -378,6 +431,126 @@ func (s *RequestStatistics) recordImported(apiName, modelName string, stats *api
 	s.requestsByHour[hourKey]++
 	s.tokensByDay[dayKey] += totalTokens
 	s.tokensByHour[hourKey] += totalTokens
+}
+
+// ResetAll clears all collected statistics.
+func (s *RequestStatistics) ResetAll() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.clearLocked()
+	s.mu.Unlock()
+	s.notifyChange()
+}
+
+// ResetByProvider removes request details for a provider and rebuilds totals.
+func (s *RequestStatistics) ResetByProvider(provider string) int {
+	provider = strings.TrimSpace(provider)
+	return s.resetWhere(func(detail RequestDetail, _, _ string) bool {
+		return detail.Provider == provider
+	})
+}
+
+// ResetByModel removes request details for a model and rebuilds totals.
+func (s *RequestStatistics) ResetByModel(model string) int {
+	model = strings.TrimSpace(model)
+	return s.resetWhere(func(detail RequestDetail, _, modelName string) bool {
+		return detail.Model == model || modelName == model
+	})
+}
+
+// ResetByAPIKey removes request details for an API key and rebuilds totals.
+func (s *RequestStatistics) ResetByAPIKey(apiKey string) int {
+	apiKey = strings.TrimSpace(apiKey)
+	return s.resetWhere(func(detail RequestDetail, apiName, _ string) bool {
+		return detail.APIKey == apiKey || apiName == apiKey
+	})
+}
+
+type requestEntry struct {
+	apiName   string
+	modelName string
+	detail    RequestDetail
+}
+
+func (s *RequestStatistics) resetWhere(match func(RequestDetail, string, string) bool) int {
+	if s == nil || match == nil {
+		return 0
+	}
+	s.mu.Lock()
+	remaining := make([]requestEntry, 0)
+	removed := 0
+	for apiName, stats := range s.apis {
+		if stats == nil {
+			continue
+		}
+		for modelName, modelStatsValue := range stats.Models {
+			if modelStatsValue == nil {
+				continue
+			}
+			for _, detail := range modelStatsValue.Details {
+				detail = normaliseStoredDetail(apiName, modelName, detail)
+				if match(detail, apiName, modelName) {
+					removed++
+					continue
+				}
+				remaining = append(remaining, requestEntry{apiName: apiName, modelName: modelName, detail: detail})
+			}
+		}
+	}
+	if removed > 0 {
+		s.clearLocked()
+		for _, entry := range remaining {
+			stats, ok := s.apis[entry.apiName]
+			if !ok {
+				stats = &apiStats{Models: make(map[string]*modelStats)}
+				s.apis[entry.apiName] = stats
+			}
+			s.recordImported(entry.apiName, entry.modelName, stats, entry.detail)
+		}
+	}
+	s.mu.Unlock()
+	if removed > 0 {
+		s.notifyChange()
+	}
+	return removed
+}
+
+func (s *RequestStatistics) clearLocked() {
+	s.totalRequests = 0
+	s.successCount = 0
+	s.failureCount = 0
+	s.totalTokens = 0
+	s.apis = make(map[string]*apiStats)
+	s.requestsByDay = make(map[string]int64)
+	s.requestsByHour = make(map[int]int64)
+	s.tokensByDay = make(map[string]int64)
+	s.tokensByHour = make(map[int]int64)
+}
+
+func (s *RequestStatistics) notifyChange() {
+	s.mu.RLock()
+	callback := s.onChange
+	s.mu.RUnlock()
+	if callback == nil {
+		return
+	}
+	callback(s.Snapshot())
+}
+
+func normaliseStoredDetail(apiName, modelName string, detail RequestDetail) RequestDetail {
+	detail.Tokens = normaliseTokenStats(detail.Tokens)
+	if detail.Provider == "" {
+		detail.Provider = "unknown"
+	}
+	if detail.Model == "" {
+		detail.Model = modelName
+	}
+	if detail.APIKey == "" {
+		detail.APIKey = apiName
+	}
+	return detail
 }
 
 func dedupKey(apiName, modelName string, detail RequestDetail) string {

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -94,3 +94,154 @@ func TestRequestStatisticsMergeSnapshotDedupIgnoresLatency(t *testing.T) {
 		t.Fatalf("details len = %d, want 1", len(details))
 	}
 }
+
+func TestRequestStatisticsSnapshotIncludesProviderModelSummariesAndIdentifiers(t *testing.T) {
+	stats := NewRequestStatistics()
+	timestamp := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:      "api-key-a",
+		Provider:    "openai",
+		Model:       "gpt-5.4",
+		RequestedAt: timestamp,
+		Detail: coreusage.Detail{
+			InputTokens:  10,
+			OutputTokens: 20,
+			TotalTokens:  30,
+		},
+	})
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:      "api-key-b",
+		Provider:    "anthropic",
+		Model:       "claude-sonnet",
+		RequestedAt: timestamp.Add(time.Hour),
+		Detail: coreusage.Detail{
+			InputTokens:  7,
+			OutputTokens: 8,
+			TotalTokens:  15,
+		},
+	})
+
+	snapshot := stats.Snapshot()
+	if snapshot.Providers["openai"].TotalRequests != 1 || snapshot.Providers["openai"].TotalTokens != 30 {
+		t.Fatalf("openai summary = %+v, want requests=1 tokens=30", snapshot.Providers["openai"])
+	}
+	if snapshot.Models["claude-sonnet"].TotalRequests != 1 || snapshot.Models["claude-sonnet"].TotalTokens != 15 {
+		t.Fatalf("claude model summary = %+v, want requests=1 tokens=15", snapshot.Models["claude-sonnet"])
+	}
+
+	detail := snapshot.APIs["api-key-a"].Models["gpt-5.4"].Details[0]
+	if detail.Provider != "openai" || detail.Model != "gpt-5.4" || detail.APIKey != "api-key-a" {
+		t.Fatalf("detail identifiers = provider %q model %q api key %q", detail.Provider, detail.Model, detail.APIKey)
+	}
+}
+
+func TestRequestStatisticsOnChangeFiresAfterRecordMergeAndReset(t *testing.T) {
+	stats := NewRequestStatistics()
+	var snapshots []StatisticsSnapshot
+	stats.SetOnChange(func(snapshot StatisticsSnapshot) {
+		snapshots = append(snapshots, snapshot)
+	})
+
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:      "api-key",
+		Provider:    "openai",
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		Detail:      coreusage.Detail{TotalTokens: 10},
+	})
+	stats.MergeSnapshot(StatisticsSnapshot{APIs: map[string]APISnapshot{
+		"api-key": {
+			Models: map[string]ModelSnapshot{
+				"gpt-5.4": {Details: []RequestDetail{{
+					Timestamp: time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+					Provider:  "openai",
+					Model:     "gpt-5.4",
+					APIKey:    "api-key",
+					Tokens:    TokenStats{TotalTokens: 20},
+				}}},
+			},
+		},
+	}})
+	stats.ResetByModel("gpt-5.4")
+
+	if len(snapshots) != 3 {
+		t.Fatalf("callback count = %d, want 3", len(snapshots))
+	}
+	if snapshots[0].TotalRequests != 1 || snapshots[1].TotalRequests != 2 || snapshots[2].TotalRequests != 0 {
+		t.Fatalf("callback totals = %d, %d, %d; want 1, 2, 0", snapshots[0].TotalRequests, snapshots[1].TotalRequests, snapshots[2].TotalRequests)
+	}
+}
+
+func TestRequestStatisticsScopedResetsRebuildTotalsFromRemainingDetails(t *testing.T) {
+	stats := NewRequestStatistics()
+	record := func(apiKey, provider, model string, tokens int64, failed bool) {
+		stats.Record(context.Background(), coreusage.Record{
+			APIKey:      apiKey,
+			Provider:    provider,
+			Model:       model,
+			Failed:      failed,
+			RequestedAt: time.Date(2026, 4, 1, 10+int(tokens%3), 0, 0, 0, time.UTC),
+			Detail:      coreusage.Detail{TotalTokens: tokens},
+		})
+	}
+
+	record("api-key-a", "openai", "gpt-5.4", 10, false)
+	record("api-key-b", "openai", "gpt-4o", 20, true)
+	record("api-key-c", "anthropic", "claude-sonnet", 30, false)
+	record("api-key-d", "gemini", "gemini-pro", 40, false)
+
+	if removed := stats.ResetByProvider("openai"); removed != 2 {
+		t.Fatalf("ResetByProvider removed = %d, want 2", removed)
+	}
+	snapshot := stats.Snapshot()
+	if snapshot.TotalRequests != 2 || snapshot.SuccessCount != 2 || snapshot.FailureCount != 0 || snapshot.TotalTokens != 70 {
+		t.Fatalf("after provider reset totals = %+v, want requests=2 success=2 failure=0 tokens=70", snapshot)
+	}
+	if _, ok := snapshot.Providers["openai"]; ok {
+		t.Fatal("openai provider summary still exists after provider reset")
+	}
+
+	if removed := stats.ResetByAPIKey("api-key-c"); removed != 1 {
+		t.Fatalf("ResetByAPIKey removed = %d, want 1", removed)
+	}
+	snapshot = stats.Snapshot()
+	if snapshot.TotalRequests != 1 || snapshot.TotalTokens != 40 {
+		t.Fatalf("after api key reset totals = requests %d tokens %d, want requests=1 tokens=40", snapshot.TotalRequests, snapshot.TotalTokens)
+	}
+	if _, ok := snapshot.APIs["api-key-c"]; ok {
+		t.Fatal("api-key-c summary still exists after api key reset")
+	}
+
+	if removed := stats.ResetByModel("gemini-pro"); removed != 1 {
+		t.Fatalf("ResetByModel removed = %d, want 1", removed)
+	}
+	if snapshot = stats.Snapshot(); snapshot.TotalRequests != 0 || snapshot.TotalTokens != 0 || len(snapshot.APIs) != 0 {
+		t.Fatalf("after model reset snapshot = %+v, want empty", snapshot)
+	}
+}
+
+func TestRequestStatisticsResetAllClearsDataAndTriggersCallback(t *testing.T) {
+	stats := NewRequestStatistics()
+	var callbackSnapshot StatisticsSnapshot
+	stats.SetOnChange(func(snapshot StatisticsSnapshot) {
+		callbackSnapshot = snapshot
+	})
+
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:      "api-key",
+		Provider:    "openai",
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		Detail:      coreusage.Detail{TotalTokens: 10},
+	})
+	stats.ResetAll()
+
+	snapshot := stats.Snapshot()
+	if snapshot.TotalRequests != 0 || snapshot.TotalTokens != 0 || len(snapshot.APIs) != 0 {
+		t.Fatalf("snapshot after ResetAll = %+v, want empty", snapshot)
+	}
+	if callbackSnapshot.TotalRequests != 0 || callbackSnapshot.TotalTokens != 0 || len(callbackSnapshot.APIs) != 0 {
+		t.Fatalf("callback snapshot after ResetAll = %+v, want empty", callbackSnapshot)
+	}
+}

--- a/internal/usage/persistence.go
+++ b/internal/usage/persistence.go
@@ -3,9 +3,18 @@ package usage
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
+	"time"
 )
+
+var ErrMalformedSnapshot = errors.New("malformed usage statistics snapshot")
+
+type SnapshotWriter interface {
+	Save(StatisticsSnapshot) error
+}
 
 // SnapshotStore persists usage snapshots as JSON on disk.
 type SnapshotStore struct {
@@ -37,7 +46,7 @@ func (s *SnapshotStore) Path() string {
 	return s.path
 }
 
-// Load reads a snapshot from disk. Missing or malformed files return an empty snapshot.
+// Load reads a snapshot from disk. Missing files return an empty snapshot.
 func (s *SnapshotStore) Load() (StatisticsSnapshot, error) {
 	if s == nil || s.path == "" {
 		return StatisticsSnapshot{}, nil
@@ -51,7 +60,7 @@ func (s *SnapshotStore) Load() (StatisticsSnapshot, error) {
 	}
 	var snapshot StatisticsSnapshot
 	if err := json.Unmarshal(data, &snapshot); err != nil {
-		return StatisticsSnapshot{}, nil
+		return StatisticsSnapshot{}, fmt.Errorf("%w: %v", ErrMalformedSnapshot, err)
 	}
 	return snapshot, nil
 }
@@ -68,5 +77,112 @@ func (s *SnapshotStore) Save(snapshot StatisticsSnapshot) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.path, data, 0o600)
+	return writeFileAtomic(s.path, data, 0o600)
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	if dirFile, err := os.Open(dir); err == nil {
+		_ = dirFile.Sync()
+		_ = dirFile.Close()
+	}
+	return nil
+}
+
+type SnapshotSaver struct {
+	writer SnapshotWriter
+	delay  time.Duration
+
+	mu      sync.Mutex
+	timer   *time.Timer
+	pending *StatisticsSnapshot
+	closed  bool
+}
+
+func NewSnapshotSaver(writer SnapshotWriter, delay time.Duration) *SnapshotSaver {
+	if delay <= 0 {
+		delay = time.Second
+	}
+	return &SnapshotSaver{writer: writer, delay: delay}
+}
+
+func (s *SnapshotSaver) SaveSoon(snapshot StatisticsSnapshot) {
+	if s == nil || s.writer == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.pending = &snapshot
+	if s.timer == nil {
+		s.timer = time.AfterFunc(s.delay, s.flushPending)
+		return
+	}
+	s.timer.Reset(s.delay)
+}
+
+func (s *SnapshotSaver) Flush() error {
+	if s == nil || s.writer == nil {
+		return nil
+	}
+	snapshot, ok := s.takePending()
+	if !ok {
+		return nil
+	}
+	return s.writer.Save(snapshot)
+}
+
+func (s *SnapshotSaver) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	if s.timer != nil {
+		s.timer.Stop()
+	}
+	s.closed = true
+	s.mu.Unlock()
+	return s.Flush()
+}
+
+func (s *SnapshotSaver) takePending() (StatisticsSnapshot, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pending == nil {
+		return StatisticsSnapshot{}, false
+	}
+	snapshot := *s.pending
+	s.pending = nil
+	return snapshot, true
+}
+
+func (s *SnapshotSaver) flushPending() {
+	_ = s.Flush()
 }

--- a/internal/usage/persistence.go
+++ b/internal/usage/persistence.go
@@ -1,0 +1,72 @@
+package usage
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// SnapshotStore persists usage snapshots as JSON on disk.
+type SnapshotStore struct {
+	path string
+}
+
+// NewSnapshotStore constructs a snapshot store for path.
+func NewSnapshotStore(path string) *SnapshotStore {
+	if path == "" {
+		path = DefaultSnapshotPath("")
+	}
+	return &SnapshotStore{path: path}
+}
+
+// DefaultSnapshotPath returns the snapshot path next to the config file.
+func DefaultSnapshotPath(configFilePath string) string {
+	configDir := filepath.Dir(configFilePath)
+	if configFilePath == "" || configDir == "." {
+		configDir = "."
+	}
+	return filepath.Join(configDir, "usage-statistics.json")
+}
+
+// Path returns the configured snapshot path.
+func (s *SnapshotStore) Path() string {
+	if s == nil {
+		return ""
+	}
+	return s.path
+}
+
+// Load reads a snapshot from disk. Missing or malformed files return an empty snapshot.
+func (s *SnapshotStore) Load() (StatisticsSnapshot, error) {
+	if s == nil || s.path == "" {
+		return StatisticsSnapshot{}, nil
+	}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return StatisticsSnapshot{}, nil
+		}
+		return StatisticsSnapshot{}, err
+	}
+	var snapshot StatisticsSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return StatisticsSnapshot{}, nil
+	}
+	return snapshot, nil
+}
+
+// Save writes a snapshot to disk as JSON.
+func (s *SnapshotStore) Save(snapshot StatisticsSnapshot) error {
+	if s == nil || s.path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.path, data, 0o600)
+}

--- a/internal/usage/persistence_test.go
+++ b/internal/usage/persistence_test.go
@@ -1,8 +1,10 @@
 package usage
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -93,11 +95,61 @@ func TestSnapshotStoreLoadSaveAndMalformedFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte("{malformed"), 0o600); err != nil {
 		t.Fatalf("write malformed file: %v", err)
 	}
-	malformed, err := store.Load()
-	if err != nil {
-		t.Fatalf("Load() malformed file error = %v, want nil", err)
+	if _, err := store.Load(); err == nil {
+		t.Fatalf("Load() malformed file error = nil, want error")
+	} else if !errors.Is(err, ErrMalformedSnapshot) {
+		t.Fatalf("Load() malformed file error = %v, want ErrMalformedSnapshot", err)
 	}
-	if malformed.TotalRequests != 0 || len(malformed.APIs) != 0 {
-		t.Fatalf("malformed snapshot = %+v, want empty", malformed)
+
+	afterMalformed, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read malformed file after Load: %v", err)
+	}
+	if string(afterMalformed) != "{malformed" {
+		t.Fatalf("Load() changed malformed file to %q", string(afterMalformed))
+	}
+}
+
+type countingSnapshotWriter struct {
+	mu       sync.Mutex
+	count    int
+	snapshot StatisticsSnapshot
+}
+
+func (w *countingSnapshotWriter) Save(snapshot StatisticsSnapshot) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.count++
+	w.snapshot = snapshot
+	return nil
+}
+
+func (w *countingSnapshotWriter) state() (int, StatisticsSnapshot) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.count, w.snapshot
+}
+
+func TestSnapshotSaverCoalescesWrites(t *testing.T) {
+	writer := &countingSnapshotWriter{}
+	saver := NewSnapshotSaver(writer, 10*time.Millisecond)
+	t.Cleanup(func() {
+		if err := saver.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	saver.SaveSoon(StatisticsSnapshot{TotalRequests: 1})
+	saver.SaveSoon(StatisticsSnapshot{TotalRequests: 2})
+	saver.SaveSoon(StatisticsSnapshot{TotalRequests: 3})
+
+	time.Sleep(50 * time.Millisecond)
+
+	count, snapshot := writer.state()
+	if count != 1 {
+		t.Fatalf("SaveSoon() wrote %d snapshots, want 1", count)
+	}
+	if snapshot.TotalRequests != 3 {
+		t.Fatalf("SaveSoon() saved total requests %d, want latest snapshot with 3", snapshot.TotalRequests)
 	}
 }

--- a/internal/usage/persistence_test.go
+++ b/internal/usage/persistence_test.go
@@ -1,0 +1,103 @@
+package usage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSnapshotStoreLoadSaveAndMalformedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "usage.json")
+	store := NewSnapshotStore(path)
+
+	if store.Path() != path {
+		t.Fatalf("Path() = %q, want %q", store.Path(), path)
+	}
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	defaultPath := DefaultSnapshotPath(configPath)
+	wantDefaultPath := filepath.Join(filepath.Dir(configPath), "usage-statistics.json")
+	if defaultPath != wantDefaultPath {
+		t.Fatalf("DefaultSnapshotPath() = %q, want %q", defaultPath, wantDefaultPath)
+	}
+	defaultStore := NewSnapshotStore("")
+	if defaultStore.Path() != DefaultSnapshotPath("") {
+		t.Fatalf("NewSnapshotStore empty path = %q, want %q", defaultStore.Path(), DefaultSnapshotPath(""))
+	}
+
+	missing, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() missing file error = %v, want nil", err)
+	}
+	if missing.TotalRequests != 0 || len(missing.APIs) != 0 {
+		t.Fatalf("missing snapshot = %+v, want empty", missing)
+	}
+
+	timestamp := time.Date(2026, 4, 1, 9, 30, 0, 0, time.UTC)
+	want := StatisticsSnapshot{
+		TotalRequests: 1,
+		SuccessCount:  1,
+		TotalTokens:   42,
+		APIs: map[string]APISnapshot{
+			"api-key": {
+				TotalRequests: 1,
+				TotalTokens:   42,
+				Models: map[string]ModelSnapshot{
+					"gpt-5.4": {
+						TotalRequests: 1,
+						TotalTokens:   42,
+						Details: []RequestDetail{{
+							Timestamp: timestamp,
+							Provider:  "openai",
+							Model:     "gpt-5.4",
+							APIKey:    "api-key",
+							Tokens: TokenStats{
+								InputTokens:  12,
+								OutputTokens: 30,
+								TotalTokens:  42,
+							},
+						}},
+					},
+				},
+			},
+		},
+		Providers: map[string]ProviderSnapshot{
+			"openai": {TotalRequests: 1, TotalTokens: 42},
+		},
+		Models: map[string]SummarySnapshot{
+			"gpt-5.4": {TotalRequests: 1, TotalTokens: 42},
+		},
+		RequestsByDay:  map[string]int64{"2026-04-01": 1},
+		RequestsByHour: map[string]int64{"09": 1},
+		TokensByDay:    map[string]int64{"2026-04-01": 42},
+		TokensByHour:   map[string]int64{"09": 42},
+	}
+
+	if err := store.Save(want); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	got, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() saved file error = %v", err)
+	}
+	if got.TotalRequests != want.TotalRequests || got.TotalTokens != want.TotalTokens {
+		t.Fatalf("loaded totals = requests %d tokens %d, want requests %d tokens %d", got.TotalRequests, got.TotalTokens, want.TotalRequests, want.TotalTokens)
+	}
+	if got.APIs["api-key"].Models["gpt-5.4"].Details[0].Provider != "openai" {
+		t.Fatalf("loaded provider = %q, want openai", got.APIs["api-key"].Models["gpt-5.4"].Details[0].Provider)
+	}
+	if got.Providers["openai"].TotalTokens != 42 {
+		t.Fatalf("loaded provider tokens = %d, want 42", got.Providers["openai"].TotalTokens)
+	}
+
+	if err := os.WriteFile(path, []byte("{malformed"), 0o600); err != nil {
+		t.Fatalf("write malformed file: %v", err)
+	}
+	malformed, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() malformed file error = %v, want nil", err)
+	}
+	if malformed.TotalRequests != 0 || len(malformed.APIs) != 0 {
+		t.Fatalf("malformed snapshot = %+v, want empty", malformed)
+	}
+}

--- a/test/usage_logging_test.go
+++ b/test/usage_logging_test.go
@@ -48,6 +48,8 @@ func TestGeminiExecutorRecordsSuccessfulZeroUsageInStatistics(t *testing.T) {
 		internalusage.SetStatisticsEnabled(prevStatsEnabled)
 	})
 
+	before := internalusage.GetRequestStatistics().Snapshot().TotalRequests
+
 	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   model,
 		Payload: []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`),
@@ -59,6 +61,12 @@ func TestGeminiExecutorRecordsSuccessfulZeroUsageInStatistics(t *testing.T) {
 		t.Fatalf("Execute error: %v", err)
 	}
 
+	waitForStatisticsTotalRequests(t, before+1)
+	after := internalusage.GetRequestStatistics().Snapshot().TotalRequests
+	if after != before+1 {
+		t.Fatalf("expected total requests to increment by 1, got before=%d after=%d", before, after)
+	}
+
 	detail := waitForStatisticsDetail(t, "gemini", model, source)
 	if detail.Failed {
 		t.Fatalf("detail failed = true, want false")
@@ -66,6 +74,21 @@ func TestGeminiExecutorRecordsSuccessfulZeroUsageInStatistics(t *testing.T) {
 	if detail.Tokens.TotalTokens != 0 {
 		t.Fatalf("total tokens = %d, want 0", detail.Tokens.TotalTokens)
 	}
+}
+
+func waitForStatisticsTotalRequests(t *testing.T, want int64) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot := internalusage.GetRequestStatistics().Snapshot()
+		if snapshot.TotalRequests >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for total request count %d", want)
 }
 
 func waitForStatisticsDetail(t *testing.T, apiName, model, source string) internalusage.RequestDetail {


### PR DESCRIPTION
## Summary
- Add configurable usage statistics modes: `off`, `memory`, and `persistent`, while preserving the legacy `usage-statistics-enabled` fallback.
- Persist usage snapshots across restarts with atomic writes, malformed snapshot protection, and coalesced background saves.
- Add management APIs for usage mode updates and scoped usage resets by all/provider/model/api_key.

## Testing
- `go test ./internal/config ./internal/usage ./internal/api/handlers/management ./internal/api ./test`
- `go build -o /data/data/com.termux/files/usr/tmp/cli-proxy-api-review ./cmd/server`