### PR TITLE
feat(cloak): add fixed-device-id option to pin device_id in user_id JSON

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -205,6 +205,9 @@ nonstream-keepalive-interval: 0
 #         - "API"
 #         - "proxy"
 #       cache-user-id: true          # optional: default is false; set true to reuse cached user_id per API key instead of generating a random one each request
+#       fixed-device-id: "your-fixed-device-id-hex"  # optional: pin device_id to a fixed value for all requests
+#                                    # only takes effect when user_id is new JSON format ({"device_id":"...","account_uuid":"...","session_id":"..."})
+#                                    # leaves account_uuid and session_id intact; replaces only the device_id field
 #     experimental-cch-signing: false # optional: default is false; when true, sign the final /v1/messages body using the current Claude Code cch algorithm
 #                                     # keep this disabled unless you explicitly need the behavior, so upstream seed changes fall back to legacy proxy behavior
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -364,6 +364,12 @@ type CloakConfig struct {
 	// CacheUserID controls whether Claude user_id values are cached per API key.
 	// When false, a fresh random user_id is generated for every request.
 	CacheUserID *bool `yaml:"cache-user-id,omitempty" json:"cache-user-id,omitempty"`
+
+	// FixedDeviceID pins the device_id field to a fixed value for all requests.
+	// When set, replaces the device_id in new-format user_id JSON objects
+	// ({"device_id":"...","account_uuid":"...","session_id":"..."}) with this value.
+	// For old-format user_id strings, has no effect (whole user_id is replaced as usual).
+	FixedDeviceID string `yaml:"fixed-device-id,omitempty" json:"fixed-device-id,omitempty"`
 }
 
 // ClaudeKey represents the configuration for a Claude API key,

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1420,10 +1420,10 @@ func getWorkloadFromContext(ctx context.Context) string {
 }
 
 // getCloakConfigFromAuth extracts cloak configuration from auth attributes.
-// Returns (cloakMode, strictMode, sensitiveWords, cacheUserID).
-func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (string, bool, []string, bool) {
+// Returns (cloakMode, strictMode, sensitiveWords, cacheUserID, fixedDeviceID).
+func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (string, bool, []string, bool, string) {
 	if auth == nil || auth.Attributes == nil {
-		return "auto", false, nil, false
+		return "auto", false, nil, false, ""
 	}
 
 	cloakMode := auth.Attributes["cloak_mode"]
@@ -1442,8 +1442,22 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (string, bool, []string, bo
 	}
 
 	cacheUserID := strings.EqualFold(strings.TrimSpace(auth.Attributes["cloak_cache_user_id"]), "true")
+	fixedDeviceID := strings.TrimSpace(auth.Attributes["cloak_fixed_device_id"])
 
-	return cloakMode, strictMode, sensitiveWords, cacheUserID
+	return cloakMode, strictMode, sensitiveWords, cacheUserID, fixedDeviceID
+}
+
+// applyFixedDeviceID replaces the device_id field in a new-format user_id JSON object.
+// Only acts when user_id is a JSON object ({"device_id":"...","account_uuid":"...","session_id":"..."}).
+// Runs independently of cloaking so system prompts are never touched.
+func applyFixedDeviceID(payload []byte, fixedDeviceID string) []byte {
+	existingUserID := gjson.GetBytes(payload, "metadata.user_id").String()
+	if len(existingUserID) > 0 && existingUserID[0] == '{' {
+		if modified, err := sjson.Set(existingUserID, "device_id", fixedDeviceID); err == nil {
+			payload, _ = sjson.SetBytes(payload, "metadata.user_id", modified)
+		}
+	}
+	return payload
 }
 
 // injectFakeUserID generates and injects a fake user ID into the request metadata.
@@ -1693,13 +1707,14 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 
 	// Get cloak config from ClaudeKey configuration
 	cloakCfg := resolveClaudeKeyCloakConfig(cfg, auth)
-	attrMode, attrStrict, attrWords, attrCache := getCloakConfigFromAuth(auth)
+	attrMode, attrStrict, attrWords, attrCache, attrFixedDeviceID := getCloakConfigFromAuth(auth)
 
 	// Determine cloak settings
 	cloakMode := attrMode
 	strictMode := attrStrict
 	sensitiveWords := attrWords
 	cacheUserID := attrCache
+	fixedDeviceID := attrFixedDeviceID
 
 	if cloakCfg != nil {
 		if mode := strings.TrimSpace(cloakCfg.Mode); mode != "" {
@@ -1714,6 +1729,14 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 		if cloakCfg.CacheUserID != nil {
 			cacheUserID = *cloakCfg.CacheUserID
 		}
+		if v := strings.TrimSpace(cloakCfg.FixedDeviceID); v != "" {
+			fixedDeviceID = v
+		}
+	}
+
+	// Apply fixed device_id independently of cloaking — no system prompt changes.
+	if fixedDeviceID != "" {
+		payload = applyFixedDeviceID(payload, fixedDeviceID)
 	}
 
 	// Determine if cloaking should be applied

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1452,12 +1452,16 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (string, bool, []string, bo
 // Runs independently of cloaking so system prompts are never touched.
 func applyFixedDeviceID(payload []byte, fixedDeviceID string) []byte {
 	existingUserID := gjson.GetBytes(payload, "metadata.user_id").String()
-	if len(existingUserID) > 0 && existingUserID[0] == '{' {
-		if modified, err := sjson.Set(existingUserID, "device_id", fixedDeviceID); err == nil {
-			payload, _ = sjson.SetBytes(payload, "metadata.user_id", modified)
-		}
+	// sjson.Set errors on non-JSON strings (old-format user_id), leaving them unaffected.
+	modifiedUserID, err := sjson.Set(existingUserID, "device_id", fixedDeviceID)
+	if err != nil {
+		return payload
 	}
-	return payload
+	newPayload, err := sjson.SetBytes(payload, "metadata.user_id", modifiedUserID)
+	if err != nil {
+		return payload
+	}
+	return newPayload
 }
 
 // injectFakeUserID generates and injects a fake user ID into the request metadata.

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1451,7 +1451,11 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (string, bool, []string, bo
 // Only acts when user_id is a JSON object ({"device_id":"...","account_uuid":"...","session_id":"..."}).
 // Runs independently of cloaking so system prompts are never touched.
 func applyFixedDeviceID(payload []byte, fixedDeviceID string) []byte {
-	existingUserID := gjson.GetBytes(payload, "metadata.user_id").String()
+	result := gjson.GetBytes(payload, "metadata.user_id")
+	if !result.Exists() || result.String() == "" {
+		return payload
+	}
+	existingUserID := result.String()
 	// sjson.Set errors on non-JSON strings (old-format user_id), leaving them unaffected.
 	modifiedUserID, err := sjson.Set(existingUserID, "device_id", fixedDeviceID)
 	if err != nil {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1452,11 +1452,14 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (string, bool, []string, bo
 // Runs independently of cloaking so system prompts are never touched.
 func applyFixedDeviceID(payload []byte, fixedDeviceID string) []byte {
 	result := gjson.GetBytes(payload, "metadata.user_id")
-	if !result.Exists() || result.String() == "" {
+	if !result.Exists() {
 		return payload
 	}
 	existingUserID := result.String()
-	// sjson.Set errors on non-JSON strings (old-format user_id), leaving them unaffected.
+	// Only act on new-format JSON objects; old-format strings and empty values pass through unchanged.
+	if !gjson.Parse(existingUserID).IsObject() {
+		return payload
+	}
 	modifiedUserID, err := sjson.Set(existingUserID, "device_id", fixedDeviceID)
 	if err != nil {
 		return payload


### PR DESCRIPTION
## Summary

- Add `fixed-device-id` config field to `CloakConfig` for pinning the `device_id` in new-format `user_id` JSON objects
- New `applyFixedDeviceID()` function only replaces the `device_id` field, leaving `account_uuid` and `session_id` intact
- Runs independently of cloaking — no system prompt modifications
- Old-format `user_id` strings are unaffected

## Details

New-format user_id: `{"device_id":"...","account_uuid":"...","session_id":"..."}`
- `device_id` → replaced with configured fixed value
- `account_uuid`, `session_id` → preserved as-is

Old-format user_id (plain string): no effect

## Config

```yaml
# under cloak config:
fixed-device-id: "your-fixed-device-id-hex"
```

## Test plan

- [ ] Set `fixed-device-id` in config, send request with new-format user_id JSON → verify `device_id` replaced, other fields intact
- [ ] Send request with old-format user_id → verify no change
- [ ] Leave `fixed-device-id` unset → verify behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)