### PR TITLE
fix(claude): respect anthropic-ratelimit-unified-reset on 429

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
@@ -243,4 +244,19 @@ func (e *ClaudeExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Aut
 	}
 	httpClient := helps.NewUtlsHTTPClient(ctx, e.cfg, auth, 0)
 	return httpClient.Do(httpReq)
+}
+
+// newClaudeStatusErr builds a statusErr for an Anthropic error response,
+// populating retryAfter on 429 from the response headers. Header parsing
+// lives in helps.ParseClaudeRetryAfter so it can be tested and reused
+// without coupling to executor-package types; this thin constructor wraps
+// the result into the executor's statusErr type at the call site.
+func newClaudeStatusErr(statusCode int, headers http.Header, body []byte) statusErr {
+	err := statusErr{code: statusCode, msg: string(body)}
+	if statusCode == http.StatusTooManyRequests {
+		if d := helps.ParseClaudeRetryAfter(headers, time.Now()); d != nil {
+			err.retryAfter = d
+		}
+	}
+	return err
 }

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -145,7 +145,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 			helps.RecordAPIResponseError(ctx, e.cfg, decErr)
 			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
 			helps.LogWithRequestID(ctx).Warn(msg)
-			return resp, statusErr{code: httpResp.StatusCode, msg: msg}
+			return resp, newClaudeStatusErr(httpResp.StatusCode, httpResp.Header, []byte(msg))
 		}
 		b, readErr := io.ReadAll(errBody)
 		if readErr != nil {
@@ -156,7 +156,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newClaudeStatusErr(httpResp.StatusCode, httpResp.Header, b)
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}

--- a/internal/runtime/executor/claude_executor_retry_test.go
+++ b/internal/runtime/executor/claude_executor_retry_test.go
@@ -1,0 +1,26 @@
+package executor
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestNewClaudeStatusErrPopulatesRetryAfterOnlyOn429 asserts the only-on-429
+// gate in newClaudeStatusErr. Header-parsing correctness is covered by
+// helps.TestParseClaudeRetryAfter in the helps package; this test only
+// verifies the wrapping logic that lives alongside the executor.
+func TestNewClaudeStatusErrPopulatesRetryAfterOnlyOn429(t *testing.T) {
+	headers := http.Header{
+		"Retry-After": {"60"},
+	}
+
+	if got := newClaudeStatusErr(429, headers, []byte("rate limited")); got.retryAfter == nil {
+		t.Fatal("429: expected retryAfter to be set")
+	}
+	if got := newClaudeStatusErr(500, headers, []byte("server error")); got.retryAfter != nil {
+		t.Fatalf("500: expected retryAfter to be nil, got %v", *got.retryAfter)
+	}
+	if got := newClaudeStatusErr(401, headers, []byte("unauthorized")); got.retryAfter != nil {
+		t.Fatalf("401: expected retryAfter to be nil, got %v", *got.retryAfter)
+	}
+}

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -142,7 +142,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			helps.RecordAPIResponseError(ctx, e.cfg, decErr)
 			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
 			helps.LogWithRequestID(ctx).Warn(msg)
-			return nil, statusErr{code: httpResp.StatusCode, msg: msg}
+			return nil, newClaudeStatusErr(httpResp.StatusCode, httpResp.Header, []byte(msg))
 		}
 		b, readErr := io.ReadAll(errBody)
 		if readErr != nil {
@@ -156,7 +156,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newClaudeStatusErr(httpResp.StatusCode, httpResp.Header, b)
 		return nil, err
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -175,7 +175,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 			helps.RecordAPIResponseError(ctx, e.cfg, decErr)
 			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
 			helps.LogWithRequestID(ctx).Warn(msg)
-			return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: msg}
+			return cliproxyexecutor.Response{}, newClaudeStatusErr(resp.StatusCode, resp.Header, []byte(msg))
 		}
 		b, readErr := io.ReadAll(errBody)
 		if readErr != nil {
@@ -188,7 +188,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
-		return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: string(b)}
+		return cliproxyexecutor.Response{}, newClaudeStatusErr(resp.StatusCode, resp.Header, b)
 	}
 	decodedBody, err := decodeResponseBody(resp.Body, resp.Header.Get("Content-Encoding"))
 	if err != nil {

--- a/internal/runtime/executor/helps/claude_retry_after.go
+++ b/internal/runtime/executor/helps/claude_retry_after.go
@@ -1,0 +1,75 @@
+package helps
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// maxClaudeRetryAfter caps cooldown durations parsed from upstream rate-limit
+// headers at Anthropic's longest enforced quota window (7 days). A buggy or
+// malformed upstream value (e.g. an off-by-1000 ms-vs-s mistake producing a
+// year-5138 epoch) would otherwise lock out a credential effectively forever.
+const maxClaudeRetryAfter = 7 * 24 * time.Hour
+
+// ParseClaudeRetryAfter extracts a cooldown duration from Anthropic's
+// rate-limit response headers, capped at maxClaudeRetryAfter. Priority:
+//
+//  1. anthropic-ratelimit-unified-reset (epoch seconds) — Anthropic's
+//     authoritative reset moment, sent on every response.
+//  2. Retry-After (RFC 7231 seconds-or-HTTP-date) — fallback for
+//     intermediaries that inject it.
+//
+// fallbackNow is used as the reference point when the response carries no
+// parseable Date header. When Date is present the server's clock anchors
+// the calculation, so client clock skew can't distort cooldowns derived
+// from absolute-epoch headers.
+//
+// Returns a non-nil duration when a header yields a non-negative future
+// reset (zero is preserved as "retry immediately"). Past resets fall
+// through; an absent or unparseable header pair returns nil.
+func ParseClaudeRetryAfter(headers http.Header, fallbackNow time.Time) *time.Duration {
+	now := fallbackNow
+	if dateStr := headers.Get("Date"); dateStr != "" {
+		if serverTime, errParse := http.ParseTime(dateStr); errParse == nil {
+			now = serverTime
+		}
+	}
+	if v := strings.TrimSpace(headers.Get("anthropic-ratelimit-unified-reset")); v != "" {
+		if epoch, errParse := strconv.ParseInt(v, 10, 64); errParse == nil {
+			if d := clampedRetryAfter(time.Unix(epoch, 0).Sub(now)); d != nil {
+				return d
+			}
+		}
+	}
+	if v := strings.TrimSpace(headers.Get("Retry-After")); v != "" {
+		if secs, errParse := strconv.ParseInt(v, 10, 64); errParse == nil && secs >= 0 {
+			// Cap before multiplying to avoid int64 overflow into nanoseconds.
+			if maxSecs := int64(maxClaudeRetryAfter / time.Second); secs > maxSecs {
+				secs = maxSecs
+			}
+			d := time.Duration(secs) * time.Second
+			return &d
+		}
+		if t, errParse := http.ParseTime(v); errParse == nil {
+			if d := clampedRetryAfter(t.Sub(now)); d != nil {
+				return d
+			}
+		}
+	}
+	return nil
+}
+
+// clampedRetryAfter returns nil for past durations, preserves a zero
+// duration as "retry immediately", and caps future durations at
+// maxClaudeRetryAfter.
+func clampedRetryAfter(d time.Duration) *time.Duration {
+	if d < 0 {
+		return nil
+	}
+	if d > maxClaudeRetryAfter {
+		d = maxClaudeRetryAfter
+	}
+	return &d
+}

--- a/internal/runtime/executor/helps/claude_retry_after_test.go
+++ b/internal/runtime/executor/helps/claude_retry_after_test.go
@@ -1,0 +1,190 @@
+package helps
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestParseClaudeRetryAfter(t *testing.T) {
+	// Pinned to the moment of a real captured 429 (epoch 1777482352)
+	// against api.anthropic.com, with reset at 1777500000 — exactly 17648s
+	// (4h54m08s) later. Using time.Unix avoids any timezone ambiguity that
+	// time.Date would introduce.
+	now := time.Unix(1777482352, 0).UTC()
+
+	tests := []struct {
+		name    string
+		headers http.Header
+		want    *time.Duration
+	}{
+		{
+			name:    "nil headers",
+			headers: nil,
+			want:    nil,
+		},
+		{
+			name:    "empty headers",
+			headers: http.Header{},
+			want:    nil,
+		},
+		{
+			name: "anthropic-ratelimit-unified-reset future epoch — wins over Retry-After",
+			headers: http.Header{
+				"Anthropic-Ratelimit-Unified-Reset": {"1777500000"},
+				"Retry-After":                       {"30"},
+			},
+			want: durPtr(17648 * time.Second),
+		},
+		{
+			name: "anthropic-ratelimit-unified-reset past epoch — falls through to Retry-After",
+			headers: http.Header{
+				"Anthropic-Ratelimit-Unified-Reset": {"1777400000"},
+				"Retry-After":                       {"30"},
+			},
+			want: durPtr(30 * time.Second),
+		},
+		{
+			name: "anthropic-ratelimit-unified-reset year 5138 — clamped to max",
+			headers: http.Header{
+				"Anthropic-Ratelimit-Unified-Reset": {"99999999999"},
+			},
+			want: durPtr(maxClaudeRetryAfter),
+		},
+		{
+			name: "anthropic-ratelimit-unified-reset unparseable — falls through",
+			headers: http.Header{
+				"Anthropic-Ratelimit-Unified-Reset": {"not-a-number"},
+				"Retry-After":                       {"30"},
+			},
+			want: durPtr(30 * time.Second),
+		},
+		{
+			name: "Retry-After seconds",
+			headers: http.Header{
+				"Retry-After": {"60"},
+			},
+			want: durPtr(60 * time.Second),
+		},
+		{
+			name: "Retry-After zero — retry immediately (RFC 9110 §10.2.3)",
+			headers: http.Header{
+				"Retry-After": {"0"},
+			},
+			want: durPtr(0),
+		},
+		{
+			name: "Retry-After negative — treated as no hint",
+			headers: http.Header{
+				"Retry-After": {"-30"},
+			},
+			want: nil,
+		},
+		{
+			name: "Retry-After exceeds 32-bit int — parsed as int64, clamped to max",
+			headers: http.Header{
+				// Larger than math.MaxInt32 (2147483647) so strconv.Atoi
+				// would fail on 32-bit GOARCH; ParseInt(_, 10, 64) succeeds
+				// and clamping kicks in before duration multiplication.
+				"Retry-After": {"4294967296"},
+			},
+			want: durPtr(maxClaudeRetryAfter),
+		},
+		{
+			name: "Retry-After absurdly large seconds — clamped to max",
+			headers: http.Header{
+				"Retry-After": {"99999999999"},
+			},
+			want: durPtr(maxClaudeRetryAfter),
+		},
+		{
+			name: "Retry-After HTTP date in future",
+			headers: http.Header{
+				"Retry-After": {now.Add(5 * time.Minute).In(time.UTC).Format(http.TimeFormat)},
+			},
+			want: durPtr(5 * time.Minute),
+		},
+		{
+			name: "Retry-After HTTP date 10 years out — clamped to max",
+			headers: http.Header{
+				"Retry-After": {now.Add(10 * 365 * 24 * time.Hour).In(time.UTC).Format(http.TimeFormat)},
+			},
+			want: durPtr(maxClaudeRetryAfter),
+		},
+		{
+			name: "Retry-After HTTP date in past — nil",
+			headers: http.Header{
+				"Retry-After": {now.Add(-1 * time.Hour).In(time.UTC).Format(http.TimeFormat)},
+			},
+			want: nil,
+		},
+		{
+			name: "whitespace tolerated",
+			headers: http.Header{
+				"Anthropic-Ratelimit-Unified-Reset": {"  1777500000  "},
+			},
+			want: durPtr(17648 * time.Second),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseClaudeRetryAfter(tc.headers, now)
+			if (tc.want == nil) != (got == nil) {
+				t.Fatalf("want=%v got=%v", tc.want, got)
+			}
+			if tc.want != nil {
+				// 1s tolerance for HTTP-date roundtrips; everything else exact.
+				diff := *got - *tc.want
+				if diff < 0 {
+					diff = -diff
+				}
+				if diff > time.Second {
+					t.Fatalf("want=%v got=%v (diff=%v)", *tc.want, *got, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestParseClaudeRetryAfterAnchorsToServerDate(t *testing.T) {
+	// Simulate a client clock that is 1 hour ahead of the server.
+	serverNow := time.Unix(1777482352, 0).UTC()
+	clientNow := serverNow.Add(1 * time.Hour)
+	// Server says reset is 5 minutes after its own clock.
+	resetEpoch := serverNow.Add(5 * time.Minute).Unix()
+
+	headers := http.Header{
+		"Date":                              {serverNow.Format(http.TimeFormat)},
+		"Anthropic-Ratelimit-Unified-Reset": {strconv.FormatInt(resetEpoch, 10)},
+	}
+
+	got := ParseClaudeRetryAfter(headers, clientNow)
+	if got == nil {
+		t.Fatal("expected non-nil duration anchored to server Date")
+	}
+	// Without anchoring, clientNow would put the reset 55 minutes in the
+	// past, returning nil. Anchoring to Date keeps the true 5-minute
+	// cooldown — within HTTP-date 1s rounding tolerance.
+	want := 5 * time.Minute
+	diff := *got - want
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > time.Second {
+		t.Fatalf("want=%v got=%v (diff=%v)", want, *got, diff)
+	}
+
+	// Sanity check: with the same headers minus Date, the stale fallback
+	// puts the reset in the past and the function returns nil.
+	headersWithoutDate := headers.Clone()
+	headersWithoutDate.Del("Date")
+	if got := ParseClaudeRetryAfter(headersWithoutDate, clientNow); got != nil {
+		t.Fatalf("without Date anchor, expected nil (stale reset), got %v", *got)
+	}
+}
+
+func durPtr(d time.Duration) *time.Duration {
+	return &d
+}


### PR DESCRIPTION
## Summary

- On Anthropic 429s, parse `anthropic-ratelimit-unified-reset` (epoch
  seconds) and `Retry-After` from response headers and pipe through
  `statusErr.retryAfter` so the auth conductor schedules a correctly-sized
  cooldown instead of falling back to the 30m exponential cap.
- Mirrors the sibling pattern at `parseCodexRetryAfter` in
  `internal/runtime/executor/codex_executor.go:964` — same
  `(headers, now) → *time.Duration` signature, same past-reset → nil
  discipline.
- Cooldowns are clamped at 7 days (Anthropic's longest documented quota
  window) so a malformed/buggy upstream value can't lock out a credential
  permanently.

## Why

The Claude executor returned bare `statusErr{code, msg}` on errors,
leaving `result.RetryAfter` unset on 429s. The conductor then fell back
to `nextQuotaCooldown`'s exponential ladder, capped at 30 min via
`quotaBackoffMax` (`sdk/cliproxy/auth/conductor.go:73`). Anthropic's
quota windows are 5h and 7d — far longer than 30 min — so with
`routing.strategy: fill-first` an exhausted credential re-enters
selection every 30 min, immediately 429s, and loops until the actual
window resets.

Real captured 429 from `api.anthropic.com/v1/messages`:

    status: 429
    anthropic-ratelimit-unified-status: rejected
    anthropic-ratelimit-unified-representative-claim: five_hour
    anthropic-ratelimit-unified-reset: 1777500000   # epoch sec, ~5h after request
    anthropic-ratelimit-unified-7d-status: allowed
    anthropic-ratelimit-unified-7d-reset: 1777561200

## Validation

    go test -race -count=1 -run 'ParseClaude|NewClaudeStatusErr' \
      ./internal/runtime/executor/...
    go vet ./internal/runtime/executor/...
    go build -o test-output ./cmd/server && rm test-output

13 unit tests cover: epoch parsing, clamp behavior (year 5138 → 7d cap,
absurd seconds → 7d cap, 10y HTTP-date → 7d cap), Retry-After
seconds/HTTP-date fallback, past-reset → nil, only-on-429 gate, and
header priority. No `internal/translator` or `AGENTS.md` paths touched.
Falls back to the existing exponential cooldown when neither header is
present; `disable-cooling: true` continues to bypass.