### PR TITLE
feat: add trusted proxies config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,6 +5,13 @@ host: ""
 # Server port
 port: 8317
 
+# Trusted proxies used to resolve the real client IP from forwarded headers.
+# When omitted, Gin's default trusted proxy behavior is left unchanged.
+# Configure only local loopback proxies by default; add your reverse proxy/container subnet explicitly if needed.
+trusted-proxies:
+  - "127.0.0.0/8"
+  - "::1"
+
 # TLS settings for HTTPS. When enabled, the server listens with the provided certificate and key.
 tls:
   enable: false

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -216,9 +216,12 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 
 	// Set trusted proxies to private IP ranges to ensure correct client IP resolution in common deployment scenarios (e.g. behind a reverse proxy or in a containerized environment).
 	engine.SetTrustedProxies([]string{
+		"127.0.0.1",
+		"::1",
+		"10.0.0.0/8",
 		"172.16.0.0/12",
 		"192.168.0.0/16",
-		"10.0.0.0/8",
+		"fc00::/7",
 	})
 
 	if optionState.engineConfigurator != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -213,6 +213,14 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 
 	// Create gin engine
 	engine := gin.New()
+
+	// Set trusted proxies to private IP ranges to ensure correct client IP resolution in common deployment scenarios (e.g. behind a reverse proxy or in a containerized environment).
+	engine.SetTrustedProxies([]string{
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"10.0.0.0/8",
+	})
+
 	if optionState.engineConfigurator != nil {
 		optionState.engineConfigurator(engine)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -214,15 +214,11 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	// Create gin engine
 	engine := gin.New()
 
-	// Set trusted proxies to private IP ranges to ensure correct client IP resolution in common deployment scenarios (e.g. behind a reverse proxy or in a containerized environment).
-	engine.SetTrustedProxies([]string{
-		"127.0.0.1",
-		"::1",
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-		"fc00::/7",
-	})
+	if cfg.TrustedProxies != nil {
+		if errTrustedProxies := engine.SetTrustedProxies(cfg.TrustedProxies); errTrustedProxies != nil {
+			log.WithError(errTrustedProxies).Warn("Failed to set trusted proxies")
+		}
+	}
 
 	if optionState.engineConfigurator != nil {
 		optionState.engineConfigurator(engine)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -14,6 +14,7 @@ import (
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 )
@@ -145,6 +146,67 @@ func TestAmpProviderModelRoutes(t *testing.T) {
 			}
 			if body := rr.Body.String(); !strings.Contains(body, tc.wantContains) {
 				t.Fatalf("response body for %s missing %q: %s", tc.path, tc.wantContains, body)
+			}
+		})
+	}
+}
+
+func TestServerTrustedProxiesConfigControlsClientIP(t *testing.T) {
+	testCases := []struct {
+		name           string
+		trustedProxies []string
+		remoteAddr     string
+		wantClientIP   string
+	}{
+		{
+			name:           "omitted config keeps gin default",
+			trustedProxies: nil,
+			remoteAddr:     "10.0.0.10:12345",
+			wantClientIP:   "203.0.113.7",
+		},
+		{
+			name:           "untrusted proxy ignores forwarded header",
+			trustedProxies: []string{},
+			remoteAddr:     "10.0.0.10:12345",
+			wantClientIP:   "10.0.0.10",
+		},
+		{
+			name:           "trusted proxy uses forwarded header",
+			trustedProxies: []string{"10.0.0.0/8"},
+			remoteAddr:     "10.0.0.10:12345",
+			wantClientIP:   "203.0.113.7",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			cfg := &proxyconfig.Config{
+				TrustedProxies: tc.trustedProxies,
+				AuthDir:        t.TempDir(),
+				Debug:          true,
+			}
+			authManager := auth.NewManager(nil, nil, nil)
+			accessManager := sdkaccess.NewManager()
+			server := NewServer(cfg, authManager, accessManager, filepath.Join(t.TempDir(), "config.yaml"), WithRouterConfigurator(func(engine *gin.Engine, _ *handlers.BaseAPIHandler, _ *proxyconfig.Config) {
+				engine.GET("/client-ip", func(c *gin.Context) {
+					c.String(http.StatusOK, c.ClientIP())
+				})
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/client-ip", nil)
+			req.RemoteAddr = tc.remoteAddr
+			req.Header.Set("X-Forwarded-For", "203.0.113.7")
+			rr := httptest.NewRecorder()
+
+			server.engine.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+			}
+			if got := rr.Body.String(); got != tc.wantClientIP {
+				t.Fatalf("ClientIP = %q, want %q", got, tc.wantClientIP)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,9 @@ type Config struct {
 	Host string `yaml:"host" json:"-"`
 	// Port is the network port on which the API server will listen.
 	Port int `yaml:"port" json:"-"`
+	// TrustedProxies configures Gin trusted proxies for resolving client IPs from forwarded headers.
+	// Nil means the option was not configured and Gin defaults are left unchanged.
+	TrustedProxies []string `yaml:"trusted-proxies" json:"trusted-proxies"`
 
 	// TLS config controls HTTPS server settings.
 	TLS TLSConfig `yaml:"tls" json:"tls"`
@@ -662,6 +665,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	if cfg.Pprof.Addr == "" {
 		cfg.Pprof.Addr = DefaultPprofAddr
 	}
+	cfg.SanitizeTrustedProxies()
 
 	if cfg.LogsMaxTotalSizeMB < 0 {
 		cfg.LogsMaxTotalSizeMB = 0
@@ -722,6 +726,22 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	// Return the populated configuration struct.
 	return &cfg, nil
+}
+
+// SanitizeTrustedProxies trims configured Gin trusted proxies and drops empty entries.
+func (cfg *Config) SanitizeTrustedProxies() {
+	if cfg == nil || cfg.TrustedProxies == nil {
+		return
+	}
+	out := make([]string, 0, len(cfg.TrustedProxies))
+	for _, proxy := range cfg.TrustedProxies {
+		trimmed := strings.TrimSpace(proxy)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	cfg.TrustedProxies = out
 }
 
 // SanitizePayloadRules validates raw JSON payload rule params and drops invalid rules.

--- a/internal/config/trusted_proxies_test.go
+++ b/internal/config/trusted_proxies_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestLoadConfigOptional_TrustedProxies(t *testing.T) {
+	testCases := []struct {
+		name    string
+		yaml    string
+		want    []string
+		wantNil bool
+	}{
+		{
+			name:    "omitted",
+			yaml:    "port: 8317\n",
+			wantNil: true,
+		},
+		{
+			name: "custom trims and drops empty entries",
+			yaml: `
+trusted-proxies:
+  - "  10.0.0.0/8  "
+  - ""
+  - "  192.168.1.10  "
+`,
+			want: []string{"10.0.0.0/8", "192.168.1.10"},
+		},
+		{
+			name: "explicit empty",
+			yaml: "trusted-proxies: []\n",
+			want: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(configPath, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatalf("failed to write config: %v", err)
+			}
+
+			cfg, err := LoadConfigOptional(configPath, false)
+			if err != nil {
+				t.Fatalf("LoadConfigOptional() error = %v", err)
+			}
+
+			if tc.wantNil {
+				if cfg.TrustedProxies != nil {
+					t.Fatalf("TrustedProxies = %#v, want nil", cfg.TrustedProxies)
+				}
+				return
+			}
+			if !slices.Equal(cfg.TrustedProxies, tc.want) {
+				t.Fatalf("TrustedProxies = %#v, want %#v", cfg.TrustedProxies, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A common scenario is deploying CPA using Docker and then using nginx as a reverse proxy. In this case, the IP obtained by CPA is the internal IP of 172.16.0.0/12 instead of the real client IP. Therefore, it is recommended to add trusted proxies config.