### PR TITLE
[codex] fix Codex server tool_search payload

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -185,6 +185,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = normalizeCodexServerToolSearch(body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -336,6 +337,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = normalizeCodexServerToolSearch(body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses/compact"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -434,6 +436,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = normalizeCodexServerToolSearch(body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -879,6 +882,33 @@ func normalizeCodexInstructions(body []byte) []byte {
 	instructions := gjson.GetBytes(body, "instructions")
 	if !instructions.Exists() || instructions.Type == gjson.Null {
 		body, _ = sjson.SetBytes(body, "instructions", "")
+	}
+	return body
+}
+
+func normalizeCodexServerToolSearch(body []byte) []byte {
+	body = normalizeCodexServerToolSearchArray(body, "tools")
+	body = normalizeCodexServerToolSearchArray(body, "tool_choice.tools")
+	return body
+}
+
+func normalizeCodexServerToolSearchArray(body []byte, path string) []byte {
+	tools := gjson.GetBytes(body, path)
+	if !tools.IsArray() {
+		return body
+	}
+
+	for i, tool := range tools.Array() {
+		if tool.Get("type").String() != "tool_search" {
+			continue
+		}
+		if tool.Get("execution").String() == "client" {
+			continue
+		}
+
+		toolPath := fmt.Sprintf("%s.%d", path, i)
+		body, _ = sjson.DeleteBytes(body, toolPath+".description")
+		body, _ = sjson.DeleteBytes(body, toolPath+".parameters")
 	}
 	return body
 }

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -907,8 +907,12 @@ func normalizeCodexServerToolSearchArray(body []byte, path string) []byte {
 		}
 
 		toolPath := fmt.Sprintf("%s.%d", path, i)
-		body, _ = sjson.DeleteBytes(body, toolPath+".description")
-		body, _ = sjson.DeleteBytes(body, toolPath+".parameters")
+		if tool.Get("description").Exists() {
+			body, _ = sjson.DeleteBytes(body, toolPath+".description")
+		}
+		if tool.Get("parameters").Exists() {
+			body, _ = sjson.DeleteBytes(body, toolPath+".parameters")
+		}
 	}
 	return body
 }

--- a/internal/runtime/executor/codex_executor_tool_search_test.go
+++ b/internal/runtime/executor/codex_executor_tool_search_test.go
@@ -20,7 +20,9 @@ func TestNormalizeCodexServerToolSearchStripsServerOnlyFields(t *testing.T) {
 			{"type":"tool_search","description":"search local tools","parameters":{"type":"object"}},
 			{"type":"tool_search","execution":"server","description":"search server tools","parameters":{"type":"object"}},
 			{"type":"tool_search","execution":"client","description":"search client tools","parameters":{"type":"object"}},
-			{"type":"function","name":"lookup","description":"keep me","parameters":{"type":"object"}}
+			{"type":"function","name":"lookup","description":"keep me","parameters":{"type":"object"}},
+			{"type":"tool_search","execution":"server","description":null,"parameters":null},
+			{"type":"tool_search","execution":"server","name":"metadata-only"}
 		],
 		"tool_choice": {
 			"type": "allowed_tools",
@@ -55,6 +57,15 @@ func TestNormalizeCodexServerToolSearchStripsServerOnlyFields(t *testing.T) {
 	}
 	if !gjson.GetBytes(out, "tools.3.parameters").Exists() {
 		t.Fatalf("function parameters should be preserved: %s", string(out))
+	}
+	if gjson.GetBytes(out, "tools.4.description").Exists() {
+		t.Fatalf("null server tool_search description should be removed: %s", string(out))
+	}
+	if gjson.GetBytes(out, "tools.4.parameters").Exists() {
+		t.Fatalf("null server tool_search parameters should be removed: %s", string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.5.name").String(); got != "metadata-only" {
+		t.Fatalf("server tool_search without removable fields name = %q, want preserved: %s", got, string(out))
 	}
 	if gjson.GetBytes(out, "tool_choice.tools.0.description").Exists() {
 		t.Fatalf("tool_choice.tools.0.description should be removed: %s", string(out))

--- a/internal/runtime/executor/codex_executor_tool_search_test.go
+++ b/internal/runtime/executor/codex_executor_tool_search_test.go
@@ -1,0 +1,117 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestNormalizeCodexServerToolSearchStripsServerOnlyFields(t *testing.T) {
+	body := []byte(`{
+		"tools": [
+			{"type":"tool_search","description":"search local tools","parameters":{"type":"object"}},
+			{"type":"tool_search","execution":"server","description":"search server tools","parameters":{"type":"object"}},
+			{"type":"tool_search","execution":"client","description":"search client tools","parameters":{"type":"object"}},
+			{"type":"function","name":"lookup","description":"keep me","parameters":{"type":"object"}}
+		],
+		"tool_choice": {
+			"type": "allowed_tools",
+			"tools": [
+				{"type":"tool_search","description":"search allowed tools","parameters":{"type":"object"}}
+			]
+		}
+	}`)
+
+	out := normalizeCodexServerToolSearch(body)
+
+	if gjson.GetBytes(out, "tools.0.description").Exists() {
+		t.Fatalf("tools.0.description should be removed: %s", string(out))
+	}
+	if gjson.GetBytes(out, "tools.0.parameters").Exists() {
+		t.Fatalf("tools.0.parameters should be removed: %s", string(out))
+	}
+	if gjson.GetBytes(out, "tools.1.description").Exists() {
+		t.Fatalf("tools.1.description should be removed: %s", string(out))
+	}
+	if gjson.GetBytes(out, "tools.1.parameters").Exists() {
+		t.Fatalf("tools.1.parameters should be removed: %s", string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.2.description").String(); got != "search client tools" {
+		t.Fatalf("client tool_search description = %q, want preserved: %s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "tools.2.parameters").Exists() {
+		t.Fatalf("client tool_search parameters should be preserved: %s", string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.3.description").String(); got != "keep me" {
+		t.Fatalf("function description = %q, want preserved: %s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "tools.3.parameters").Exists() {
+		t.Fatalf("function parameters should be preserved: %s", string(out))
+	}
+	if gjson.GetBytes(out, "tool_choice.tools.0.description").Exists() {
+		t.Fatalf("tool_choice.tools.0.description should be removed: %s", string(out))
+	}
+	if gjson.GetBytes(out, "tool_choice.tools.0.parameters").Exists() {
+		t.Fatalf("tool_choice.tools.0.parameters should be removed: %s", string(out))
+	}
+}
+
+func TestCodexExecutorExecuteNormalizesServerToolSearch(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"background\":false,\"error\":null}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{
+		SDKConfig: config.SDKConfig{
+			DisableImageGeneration: config.DisableImageGenerationAll,
+		},
+	})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model: "gpt-5.4",
+		Payload: []byte(`{
+			"model":"gpt-5.4",
+			"input":"hello",
+			"tools":[
+				{"type":"tool_search","description":"server search","parameters":{"type":"object"}},
+				{"type":"tool_search","execution":"client","description":"client search","parameters":{"type":"object"}}
+			]
+		}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if gjson.GetBytes(gotBody, "tools.0.description").Exists() {
+		t.Fatalf("server tool_search description should be removed: %s", string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "tools.0.parameters").Exists() {
+		t.Fatalf("server tool_search parameters should be removed: %s", string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "tools.1.description").String(); got != "client search" {
+		t.Fatalf("client tool_search description = %q, want preserved: %s", got, string(gotBody))
+	}
+	if !gjson.GetBytes(gotBody, "tools.1.parameters").Exists() {
+		t.Fatalf("client tool_search parameters should be preserved: %s", string(gotBody))
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -195,6 +195,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = normalizeCodexServerToolSearch(body)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
@@ -395,6 +396,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = normalizeCodexServerToolSearch(body)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)


### PR DESCRIPTION
﻿## Summary

Fix Codex Responses requests that include server-executed `tool_search` tools with client-only fields.

Codex upstream rejects payloads like `{"type":"tool_search","description":"..."}` with `Invalid Value: 'tools.tool_search.description'. Server-executed tool_search does not accept a description.` For server/default `tool_search`, this strips `description` and `parameters` before forwarding while preserving those fields for `execution: "client"` and regular function tools.

The normalization is applied to HTTP Responses, compact Responses, and WebSocket Responses paths.

## Validation

- `go test ./internal/runtime/executor -run 'TestNormalizeCodexServerToolSearch|TestCodexExecutorExecuteNormalizesServerToolSearch'`
- `go build -o <temp> ./cmd/server`

`go test ./internal/runtime/executor` still has unrelated existing Antigravity credits test failures around `v1internal:loadCodeAssist`; the new targeted tests pass.
