### PR TITLE
fix(openai): improve Claude compatibility translation

### DIFF
--- a/internal/translator/openai/claude/openai_claude_request.go
+++ b/internal/translator/openai/claude/openai_claude_request.go
@@ -13,6 +13,10 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+func isClaudeCodeBillingHeaderText(text string) bool {
+	return strings.HasPrefix(text, "x-anthropic-billing-header:")
+}
+
 // ConvertClaudeRequestToOpenAI parses and transforms an Anthropic API request into OpenAI Chat Completions API format.
 // It extracts the model name, system instruction, message contents, and tool declarations
 // from the raw JSON request and returns them in the format expected by the OpenAI API.
@@ -103,7 +107,7 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 	hasSystemContent := false
 	if system := root.Get("system"); system.Exists() {
 		if system.Type == gjson.String {
-			if system.String() != "" {
+			if system.String() != "" && !isClaudeCodeBillingHeaderText(system.String()) {
 				oldSystem := []byte(`{"type":"text","text":""}`)
 				oldSystem, _ = sjson.SetBytes(oldSystem, "text", system.String())
 				systemMsgJSON, _ = sjson.SetRawBytes(systemMsgJSON, "content.-1", oldSystem)
@@ -113,6 +117,9 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 			if system.IsArray() {
 				systemResults := system.Array()
 				for i := 0; i < len(systemResults); i++ {
+					if systemResults[i].Get("type").String() == "text" && isClaudeCodeBillingHeaderText(systemResults[i].Get("text").String()) {
+						continue
+					}
 					if contentItem, ok := convertClaudeContentPart(systemResults[i]); ok {
 						systemMsgJSON, _ = sjson.SetRawBytes(systemMsgJSON, "content.-1", []byte(contentItem))
 						hasSystemContent = true
@@ -188,6 +195,9 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 							toolResultJSON, _ = sjson.SetRawBytes(toolResultJSON, "content", []byte(toolResultContent))
 						} else {
 							toolResultJSON, _ = sjson.SetBytes(toolResultJSON, "content", toolResultContent)
+						}
+						if cacheControl := part.Get("cache_control"); cacheControl.Exists() {
+							toolResultJSON, _ = sjson.SetRawBytes(toolResultJSON, "cache_control", []byte(cacheControl.Raw))
 						}
 						toolResults = append(toolResults, toolResultJSON)
 					}
@@ -286,10 +296,13 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 			openAIToolJSON := []byte(`{"type":"function","function":{"name":"","description":""}}`)
 			openAIToolJSON, _ = sjson.SetBytes(openAIToolJSON, "function.name", tool.Get("name").String())
 			openAIToolJSON, _ = sjson.SetBytes(openAIToolJSON, "function.description", tool.Get("description").String())
+			if cacheControl := tool.Get("cache_control"); cacheControl.Exists() {
+				openAIToolJSON, _ = sjson.SetRawBytes(openAIToolJSON, "cache_control", []byte(cacheControl.Raw))
+			}
 
 			// Convert Anthropic input_schema to OpenAI function parameters
 			if inputSchema := tool.Get("input_schema"); inputSchema.Exists() {
-				openAIToolJSON, _ = sjson.SetBytes(openAIToolJSON, "function.parameters", inputSchema.Value())
+				openAIToolJSON, _ = sjson.SetBytes(openAIToolJSON, "function.parameters", normalizeObjectSchemaProperties(inputSchema.Value()))
 			}
 
 			toolsJSON, _ = sjson.SetRawBytes(toolsJSON, "-1", openAIToolJSON)
@@ -328,6 +341,28 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 	return out
 }
 
+func normalizeObjectSchemaProperties(schema any) any {
+	switch value := schema.(type) {
+	case map[string]any:
+		if value["type"] == "object" {
+			if _, ok := value["properties"]; !ok {
+				value["properties"] = map[string]any{}
+			}
+		}
+		for key, child := range value {
+			value[key] = normalizeObjectSchemaProperties(child)
+		}
+		return value
+	case []any:
+		for i, child := range value {
+			value[i] = normalizeObjectSchemaProperties(child)
+		}
+		return value
+	default:
+		return schema
+	}
+}
+
 func convertClaudeContentPart(part gjson.Result) (string, bool) {
 	partType := part.Get("type").String()
 
@@ -339,6 +374,9 @@ func convertClaudeContentPart(part gjson.Result) (string, bool) {
 		}
 		textContent := []byte(`{"type":"text","text":""}`)
 		textContent, _ = sjson.SetBytes(textContent, "text", text)
+		if cacheControl := part.Get("cache_control"); cacheControl.Exists() {
+			textContent, _ = sjson.SetRawBytes(textContent, "cache_control", []byte(cacheControl.Raw))
+		}
 		return string(textContent), true
 
 	case "image":
@@ -371,6 +409,9 @@ func convertClaudeContentPart(part gjson.Result) (string, bool) {
 
 		imageContent := []byte(`{"type":"image_url","image_url":{"url":""}}`)
 		imageContent, _ = sjson.SetBytes(imageContent, "image_url.url", imageURL)
+		if cacheControl := part.Get("cache_control"); cacheControl.Exists() {
+			imageContent, _ = sjson.SetRawBytes(imageContent, "cache_control", []byte(cacheControl.Raw))
+		}
 
 		return string(imageContent), true
 

--- a/internal/translator/openai/claude/openai_claude_request_test.go
+++ b/internal/translator/openai/claude/openai_claude_request_test.go
@@ -390,6 +390,47 @@ func TestConvertClaudeRequestToOpenAI_SystemMessageScenarios(t *testing.T) {
 	}
 }
 
+func TestConvertClaudeRequestToOpenAI_ToolSchemaAddsMissingObjectProperties(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-3-opus",
+		"tools": [
+			{
+				"name": "empty_params",
+				"description": "No args",
+				"input_schema": {"type": "object"}
+			},
+			{
+				"name": "nested_params",
+				"description": "Nested args",
+				"input_schema": {
+					"type": "object",
+					"properties": {
+						"nested": {"type": "object"},
+						"items": {
+							"type": "array",
+							"items": {"type": "object"}
+						}
+					}
+				}
+			}
+		],
+		"messages": [{"role": "user", "content": "hello"}]
+	}`
+
+	result := ConvertClaudeRequestToOpenAI("test-model", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+
+	if got := resultJSON.Get("tools.0.function.parameters.properties"); !got.Exists() || !got.IsObject() {
+		t.Fatalf("root object properties missing or invalid: %s", resultJSON.Get("tools.0.function.parameters").Raw)
+	}
+	if got := resultJSON.Get("tools.1.function.parameters.properties.nested.properties"); !got.Exists() || !got.IsObject() {
+		t.Fatalf("nested object properties missing or invalid: %s", resultJSON.Get("tools.1.function.parameters").Raw)
+	}
+	if got := resultJSON.Get("tools.1.function.parameters.properties.items.items.properties"); !got.Exists() || !got.IsObject() {
+		t.Fatalf("array item object properties missing or invalid: %s", resultJSON.Get("tools.1.function.parameters").Raw)
+	}
+}
+
 func TestConvertClaudeRequestToOpenAI_ToolResultOrderAndContent(t *testing.T) {
 	inputJSON := `{
 		"model": "claude-3-opus",
@@ -694,5 +735,74 @@ func TestConvertClaudeRequestToOpenAI_AssistantThinkingToolUseThinkingSplit(t *t
 	// Should have combined reasoning_content from both thinking blocks
 	if got := assistantMsg.Get("reasoning_content").String(); got != "t1\n\nt2" {
 		t.Fatalf("Expected reasoning_content %q, got %q", "t1\n\nt2", got)
+	}
+}
+
+func TestConvertClaudeRequestToOpenAI_PreservesToolResultCacheControl(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-3-opus",
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"do_work","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"tool output","cache_control":{"type":"ephemeral","ttl":"1h"}}]}
+		]
+	}`)
+
+	out := ConvertClaudeRequestToOpenAI("gpt-test", input, false)
+
+	if got := gjson.GetBytes(out, "messages.1.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("tool_result cache_control.type = %q, want ephemeral; output=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "messages.1.cache_control.ttl").String(); got != "1h" {
+		t.Fatalf("tool_result cache_control.ttl = %q, want 1h; output=%s", got, string(out))
+	}
+}
+
+func TestConvertClaudeRequestToOpenAI_PreservesCacheControl(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-3-opus",
+		"system":[{"type":"text","text":"stable system","cache_control":{"type":"ephemeral","ttl":"1h"}}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],
+		"tools":[{"name":"probe_tool","description":"probe","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral","ttl":"1h"}}]
+	}`)
+
+	out := ConvertClaudeRequestToOpenAI("gpt-test", input, false)
+
+	if got := gjson.GetBytes(out, "messages.0.content.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("system cache_control.type = %q, want ephemeral; output=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.cache_control.ttl").String(); got != "1h" {
+		t.Fatalf("system cache_control.ttl = %q, want 1h; output=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("message cache_control.type = %q, want ephemeral; output=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("tool cache_control.type = %q, want ephemeral; output=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "tools.0.cache_control.ttl").String(); got != "1h" {
+		t.Fatalf("tool cache_control.ttl = %q, want 1h; output=%s", got, string(out))
+	}
+}
+
+func TestConvertClaudeRequestToOpenAI_SkipsBillingHeaderSystemBlock(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-3-opus",
+		"system":[
+			{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.114.e2a; cc_entrypoint=cli; cch=abcde;"},
+			{"type":"text","text":"stable instructions","cache_control":{"type":"ephemeral","ttl":"1h"}}
+		],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]
+	}`)
+
+	out := ConvertClaudeRequestToOpenAI("gpt-test", input, false)
+
+	if got := gjson.GetBytes(out, "messages.0.content.#").Int(); got != 1 {
+		t.Fatalf("system content count = %d, want 1; output=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.text").String(); got != "stable instructions" {
+		t.Fatalf("system content text = %q, want stable instructions; output=%s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("system cache_control.type = %q, want ephemeral; output=%s", got, string(out))
 	}
 }

--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -57,9 +57,10 @@ type ConvertOpenAIResponseToAnthropicParams struct {
 
 // ToolCallAccumulator holds the state for accumulating tool call data
 type ToolCallAccumulator struct {
-	ID        string
-	Name      string
-	Arguments strings.Builder
+	ID                  string
+	Name                string
+	Arguments           strings.Builder
+	ContentBlockStarted bool
 }
 
 // ConvertOpenAIResponseToClaude converts OpenAI streaming response format to Anthropic API format.
@@ -236,8 +237,8 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 
 				// Handle function name
 				if function := toolCall.Get("function"); function.Exists() {
-					if name := function.Get("name"); name.Exists() {
-						accumulator.Name = util.MapToolName(param.ToolNameMap, name.String())
+					if name := function.Get("name"); name.Exists() && strings.TrimSpace(name.String()) != "" && !accumulator.ContentBlockStarted {
+						accumulator.Name = util.MapToolName(param.ToolNameMap, strings.TrimSpace(name.String()))
 
 						stopThinkingContentBlock(param, &results)
 
@@ -250,6 +251,7 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 						contentBlockStartJSONBytes, _ = sjson.SetBytes(contentBlockStartJSONBytes, "content_block.id", util.SanitizeClaudeToolID(accumulator.ID))
 						contentBlockStartJSONBytes, _ = sjson.SetBytes(contentBlockStartJSONBytes, "content_block.name", accumulator.Name)
 						results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_start", contentBlockStartJSONBytes, 2))
+						accumulator.ContentBlockStarted = true
 					}
 
 					// Handle function arguments
@@ -291,6 +293,9 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 		if !param.ContentBlocksStopped {
 			for index := range param.ToolCallsAccumulator {
 				accumulator := param.ToolCallsAccumulator[index]
+				if !accumulator.ContentBlockStarted {
+					continue
+				}
 				blockIndex := param.toolContentBlockIndex(index)
 
 				// Send complete input_json_delta with all accumulated arguments
@@ -355,6 +360,9 @@ func convertOpenAIDoneToAnthropic(param *ConvertOpenAIResponseToAnthropicParams)
 	if !param.ContentBlocksStopped {
 		for index := range param.ToolCallsAccumulator {
 			accumulator := param.ToolCallsAccumulator[index]
+			if !accumulator.ContentBlockStarted {
+				continue
+			}
 			blockIndex := param.toolContentBlockIndex(index)
 
 			if accumulator.Arguments.Len() > 0 {

--- a/internal/translator/openai/claude/openai_claude_response_test.go
+++ b/internal/translator/openai/claude/openai_claude_response_test.go
@@ -1,0 +1,114 @@
+package claude
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIResponseToClaude_StreamToolCallIgnoresEmptyNameDeltas(t *testing.T) {
+	events := convertOpenAIStreamTestEvents(t, []string{
+		`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"Bash","arguments":""}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":"{\""}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":"command"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":"\":\"pwd\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	})
+
+	assertSingleBashToolUse(t, events)
+	assertToolArgsAndStopReason(t, events)
+}
+
+func TestConvertOpenAIResponseToClaude_StreamToolCallSuppressesRepeatedNameStart(t *testing.T) {
+	events := convertOpenAIStreamTestEvents(t, []string{
+		`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"Bash","arguments":""}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"Bash","arguments":"{\"command\":\"pwd\"}"}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+	})
+
+	assertSingleBashToolUse(t, events)
+	assertToolArgsAndStopReason(t, events)
+}
+
+func convertOpenAIStreamTestEvents(t *testing.T, chunks []string) []gjson.Result {
+	t.Helper()
+
+	originalRequest := []byte(`{"stream":true,"tools":[{"name":"Bash"}]}`)
+	var param any
+	var events []gjson.Result
+
+	for _, chunk := range chunks {
+		out := ConvertOpenAIResponseToClaude(context.Background(), "gpt-test", originalRequest, nil, []byte(chunk), &param)
+		for _, raw := range out {
+			event := parseSSEDataJSON(t, string(raw))
+			events = append(events, event)
+		}
+	}
+
+	return events
+}
+
+func parseSSEDataJSON(t *testing.T, raw string) gjson.Result {
+	t.Helper()
+
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		parsed := gjson.Parse(payload)
+		if !parsed.Exists() {
+			t.Fatalf("invalid SSE JSON payload: %q", payload)
+		}
+		return parsed
+	}
+
+	t.Fatalf("missing SSE data line: %q", raw)
+	return gjson.Result{}
+}
+
+func assertSingleBashToolUse(t *testing.T, events []gjson.Result) {
+	t.Helper()
+
+	var toolStarts []gjson.Result
+	for _, event := range events {
+		if event.Get("type").String() == "content_block_start" && event.Get("content_block.type").String() == "tool_use" {
+			toolStarts = append(toolStarts, event)
+		}
+	}
+
+	if len(toolStarts) != 1 {
+		t.Fatalf("tool_use content_block_start count = %d, want 1; starts=%v", len(toolStarts), toolStarts)
+	}
+	if got := toolStarts[0].Get("content_block.name").String(); got != "Bash" {
+		t.Fatalf("tool name = %q, want Bash", got)
+	}
+}
+
+func assertToolArgsAndStopReason(t *testing.T, events []gjson.Result) {
+	t.Helper()
+
+	var gotArgs, gotStopReason string
+	for _, event := range events {
+		switch event.Get("type").String() {
+		case "content_block_delta":
+			if event.Get("delta.type").String() == "input_json_delta" {
+				gotArgs += event.Get("delta.partial_json").String()
+			}
+		case "message_delta":
+			gotStopReason = event.Get("delta.stop_reason").String()
+		}
+	}
+
+	if !strings.Contains(gotArgs, `"command":"pwd"`) {
+		t.Fatalf("tool arguments = %q, want command pwd", gotArgs)
+	}
+	if gotStopReason != "tool_use" {
+		t.Fatalf("stop_reason = %q, want tool_use", gotStopReason)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix OpenAI streaming tool call translation when later deltas omit or repeat function names.
- Normalize Anthropic tool schemas for OpenAI-compatible providers by adding missing object properties.
- Preserve cache_control metadata and skip Claude Code billing headers in OpenAI-compatible request translation.

## Test plan
- [x] GOROOT=/usr/local/Cellar/go/1.26.2/libexec GOPROXY=https://goproxy.cn,direct go test ./internal/translator/openai/claude