### PR TITLE
feat(management): expose anthropic rate-limit hint on auth-files entries

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -387,6 +387,9 @@ func (h *Handler) buildAuthFileEntryLocked(auth *coreauth.Auth) gin.H {
 	if claims := extractCodexIDTokenClaims(auth); claims != nil {
 		entry["id_token"] = claims
 	}
+	if rateLimit := buildClaudeRateLimitEntry(auth); rateLimit != nil {
+		entry["rate_limit"] = rateLimit
+	}
 	// Expose priority from Attributes (set by synthesizer from JSON "priority" field).
 	// Fall back to Metadata for auths registered via UploadAuthFile (no synthesizer).
 	if p := strings.TrimSpace(authAttribute(auth, "priority")); p != "" {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -372,6 +372,9 @@ func (h *Handler) buildAuthFileEntryLocked(auth *coreauth.Auth) gin.H {
 	if claims := extractCodexIDTokenClaims(auth); claims != nil {
 		entry["id_token"] = claims
 	}
+	if rateLimit := buildClaudeRateLimitEntry(auth); rateLimit != nil {
+		entry["rate_limit"] = rateLimit
+	}
 	// Expose priority from Attributes (set by synthesizer from JSON "priority" field).
 	// Fall back to Metadata for auths registered via UploadAuthFile (no synthesizer).
 	if p := strings.TrimSpace(authAttribute(auth, "priority")); p != "" {

--- a/internal/api/handlers/management/auth_files_claude_rate_limit.go
+++ b/internal/api/handlers/management/auth_files_claude_rate_limit.go
@@ -13,6 +13,10 @@ import (
 // this auth, suitable for embedding under a `rate_limit` key on an auth-files
 // entry.
 //
+// The `windows` map is the exception to "most-recent": the store carries live
+// windows forward, so each carries its own `observed_at` (see
+// coreauth.SetAnthropicRateLimitHint).
+//
 // Returns nil when the auth is not a Claude provider, no hint has been
 // captured yet, the hint has Known=false, or the captured hint belongs to a
 // different account than this auth now holds. Mirrors extractCodexIDTokenClaims
@@ -91,6 +95,13 @@ func buildClaudeRateLimitEntry(auth *coreauth.Auth) gin.H {
 			// consumers nothing actionable and invites them to treat window
 			// presence as meaningful. The forensic signal stays in raw_headers.
 			if len(windowEntry) > 0 {
+				// Which capture this window came from; a carried one lags the
+				// top-level observed_at. After the emptiness gate on purpose:
+				// a timestamp is not a reading and must not resurrect a window
+				// with nothing to report.
+				if !window.ObservedAt.IsZero() {
+					windowEntry["observed_at"] = window.ObservedAt
+				}
 				windows[slug] = windowEntry
 			}
 		}

--- a/internal/api/handlers/management/auth_files_claude_rate_limit.go
+++ b/internal/api/handlers/management/auth_files_claude_rate_limit.go
@@ -1,0 +1,115 @@
+package management
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// buildClaudeRateLimitEntry returns a structured view of the most-recent
+// Anthropic `anthropic-ratelimit-unified-*` response-header state observed for
+// this auth, suitable for embedding under a `rate_limit` key on an auth-files
+// entry.
+//
+// Returns nil when the auth is not a Claude provider, no hint has been
+// captured yet, the hint has Known=false, or the captured hint belongs to a
+// different account than this auth now holds. Mirrors extractCodexIDTokenClaims
+// in shape and intent: provider-gated nested object, omitted entirely when
+// there's no content to surface.
+//
+// The hint store is populated by the Claude executor (see
+// internal/runtime/executor/helps/claude_rate_limit_record.go); this helper is
+// a pure read-side projection.
+func buildClaudeRateLimitEntry(auth *coreauth.Auth) gin.H {
+	if auth == nil {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "claude") {
+		return nil
+	}
+	hint, ok := coreauth.AnthropicRateLimitHintFor(auth)
+	if !ok || !hint.Known {
+		return nil
+	}
+
+	out := gin.H{}
+	if !hint.ObservedAt.IsZero() {
+		out["observed_at"] = hint.ObservedAt
+	}
+	if hint.Status != "" {
+		out["status"] = hint.Status
+	}
+	if hint.RepresentativeClaim != "" {
+		out["representative_claim"] = hint.RepresentativeClaim
+	}
+	if !hint.Reset.IsZero() {
+		out["reset_at"] = hint.Reset
+	}
+	// Gate on the presence flag, not on != 0: a legitimate explicit 0 is a real
+	// reading and must survive, while a malformed header must not surface as a
+	// healthy-looking 0. Malformed values remain visible in raw_headers.
+	if hint.HasFallbackPercentage {
+		out["fallback_percentage"] = hint.FallbackPercentage
+	}
+	if hint.OverageStatus != "" {
+		out["overage_status"] = hint.OverageStatus
+	}
+	if hint.OverageDisabledReason != "" {
+		out["overage_disabled_reason"] = hint.OverageDisabledReason
+	}
+	if hint.UpgradePaths != "" {
+		out["upgrade_paths"] = hint.UpgradePaths
+	}
+
+	if len(hint.Windows) > 0 {
+		windows := make(gin.H, len(hint.Windows))
+		for slug, window := range hint.Windows {
+			windowEntry := gin.H{}
+			if window.Status != "" {
+				windowEntry["status"] = window.Status
+			}
+			if !window.Reset.IsZero() {
+				windowEntry["reset_at"] = window.Reset
+			}
+			// Emit utilization only when the upstream actually shipped a
+			// `unified-{slug}-utilization` header for this window. Without
+			// this gate, an absent header would surface as 0.0 — indistinguishable
+			// from a real zero-utilization reading and likely to mislead alerts
+			// into treating unknown utilization as healthy usage.
+			if window.HasUtilization {
+				windowEntry["utilization"] = window.Utilization
+			}
+			if window.HasSurpassedThreshold {
+				windowEntry["surpassed_threshold"] = window.SurpassedThreshold
+			}
+			// Skip windows where no field survived omitempty gating. A slug
+			// whose only header was malformed (e.g. `unified-5h-reset: garbage`)
+			// still seeds an entry in hint.Windows on the parser side; emitting
+			// `"5h": {}` here would fabricate structured window data that tells
+			// consumers nothing actionable and invites them to treat window
+			// presence as meaningful. The forensic signal stays in raw_headers.
+			if len(windowEntry) > 0 {
+				windows[slug] = windowEntry
+			}
+		}
+		// And drop the windows key entirely if every per-slug entry got
+		// dropped — otherwise we'd surface `"windows": {}`. Mirrors the
+		// top-level `if len(out) == 0` guard one level deeper.
+		if len(windows) > 0 {
+			out["windows"] = windows
+		}
+	}
+
+	if len(hint.RawHeaders) > 0 {
+		out["raw_headers"] = hint.RawHeaders
+	}
+
+	if len(out) == 0 {
+		// No content survived omitempty gating; surface nothing rather than
+		// an empty `rate_limit: {}` block.
+		return nil
+	}
+	return out
+}

--- a/internal/api/handlers/management/auth_files_claude_rate_limit.go
+++ b/internal/api/handlers/management/auth_files_claude_rate_limit.go
@@ -1,0 +1,111 @@
+package management
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// buildClaudeRateLimitEntry returns a structured view of the most-recent
+// Anthropic `anthropic-ratelimit-unified-*` response-header state observed for
+// this auth, suitable for embedding under a `rate_limit` key on an auth-files
+// entry.
+//
+// Returns nil when the auth is not a Claude provider, no hint has been
+// captured yet, or the hint has Known=false. Mirrors extractCodexIDTokenClaims
+// in shape and intent: provider-gated nested object, omitted entirely when
+// there's no content to surface.
+//
+// The hint store is populated by the Claude executor (see
+// internal/runtime/executor/helps/claude_rate_limit_record.go); this helper is
+// a pure read-side projection.
+func buildClaudeRateLimitEntry(auth *coreauth.Auth) gin.H {
+	if auth == nil {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "claude") {
+		return nil
+	}
+	hint, ok := coreauth.GetAnthropicRateLimitHint(auth.ID)
+	if !ok || !hint.Known {
+		return nil
+	}
+
+	out := gin.H{}
+	if !hint.ObservedAt.IsZero() {
+		out["observed_at"] = hint.ObservedAt
+	}
+	if hint.Status != "" {
+		out["status"] = hint.Status
+	}
+	if hint.RepresentativeClaim != "" {
+		out["representative_claim"] = hint.RepresentativeClaim
+	}
+	if !hint.Reset.IsZero() {
+		out["reset_at"] = hint.Reset
+	}
+	if hint.FallbackPercentage != 0 {
+		out["fallback_percentage"] = hint.FallbackPercentage
+	}
+	if hint.OverageStatus != "" {
+		out["overage_status"] = hint.OverageStatus
+	}
+	if hint.OverageDisabledReason != "" {
+		out["overage_disabled_reason"] = hint.OverageDisabledReason
+	}
+	if hint.UpgradePaths != "" {
+		out["upgrade_paths"] = hint.UpgradePaths
+	}
+
+	if len(hint.Windows) > 0 {
+		windows := make(gin.H, len(hint.Windows))
+		for slug, window := range hint.Windows {
+			windowEntry := gin.H{}
+			if window.Status != "" {
+				windowEntry["status"] = window.Status
+			}
+			if !window.Reset.IsZero() {
+				windowEntry["reset_at"] = window.Reset
+			}
+			// Emit utilization only when the upstream actually shipped a
+			// `unified-{slug}-utilization` header for this window. Without
+			// this gate, an absent header would surface as 0.0 — indistinguishable
+			// from a real zero-utilization reading and likely to mislead alerts
+			// into treating unknown utilization as healthy usage.
+			if window.HasUtilization {
+				windowEntry["utilization"] = window.Utilization
+			}
+			if window.SurpassedThreshold != 0 {
+				windowEntry["surpassed_threshold"] = window.SurpassedThreshold
+			}
+			// Skip windows where no field survived omitempty gating. A slug
+			// whose only header was malformed (e.g. `unified-5h-reset: garbage`)
+			// still seeds an entry in hint.Windows on the parser side; emitting
+			// `"5h": {}` here would fabricate structured window data that tells
+			// consumers nothing actionable and invites them to treat window
+			// presence as meaningful. The forensic signal stays in raw_headers.
+			if len(windowEntry) > 0 {
+				windows[slug] = windowEntry
+			}
+		}
+		// And drop the windows key entirely if every per-slug entry got
+		// dropped — otherwise we'd surface `"windows": {}`. Mirrors the
+		// top-level `if len(out) == 0` guard one level deeper.
+		if len(windows) > 0 {
+			out["windows"] = windows
+		}
+	}
+
+	if len(hint.RawHeaders) > 0 {
+		out["raw_headers"] = hint.RawHeaders
+	}
+
+	if len(out) == 0 {
+		// No content survived omitempty gating; surface nothing rather than
+		// an empty `rate_limit: {}` block.
+		return nil
+	}
+	return out
+}

--- a/internal/api/handlers/management/auth_files_claude_rate_limit.go
+++ b/internal/api/handlers/management/auth_files_claude_rate_limit.go
@@ -14,7 +14,8 @@ import (
 // entry.
 //
 // Returns nil when the auth is not a Claude provider, no hint has been
-// captured yet, or the hint has Known=false. Mirrors extractCodexIDTokenClaims
+// captured yet, the hint has Known=false, or the captured hint belongs to a
+// different account than this auth now holds. Mirrors extractCodexIDTokenClaims
 // in shape and intent: provider-gated nested object, omitted entirely when
 // there's no content to surface.
 //
@@ -28,7 +29,7 @@ func buildClaudeRateLimitEntry(auth *coreauth.Auth) gin.H {
 	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "claude") {
 		return nil
 	}
-	hint, ok := coreauth.GetAnthropicRateLimitHint(auth.ID)
+	hint, ok := coreauth.AnthropicRateLimitHintFor(auth)
 	if !ok || !hint.Known {
 		return nil
 	}

--- a/internal/api/handlers/management/auth_files_claude_rate_limit_test.go
+++ b/internal/api/handlers/management/auth_files_claude_rate_limit_test.go
@@ -3,6 +3,7 @@ package management
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -591,4 +592,178 @@ func TestBuildClaudeRateLimitEntry_MalformedNumericsAreNotPublished(t *testing.T
 			t.Errorf("explicit zero surpassed_threshold = %v (present=%v), want 0 present", got, ok)
 		}
 	})
+}
+
+// TestBuildClaudeRateLimitEntry_SurfacesPerWindowObservedAt pins the field that
+// tells an operator which reading is live and which is inherited. The hint
+// store carries a window forward when a later response omits it — an
+// ordinary-tier response reports no premium weekly window — so `7d_oi` here
+// comes from the earlier capture and must say so, while the windows the newest
+// response did report carry the newest timestamp.
+func TestBuildClaudeRateLimitEntry_SurfacesPerWindowObservedAt(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-window-observed-at@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	premiumAt := fixedObservedAt()
+	ordinaryAt := premiumAt.Add(4 * time.Minute)
+	fingerprint := coreauth.AnthropicAccountFingerprint(auth)
+
+	coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         premiumAt,
+		Status:             "allowed_warning",
+		AccountFingerprint: fingerprint,
+		Windows: map[string]coreauth.AnthropicQuotaWindow{
+			"5h":    {Status: "allowed", Reset: premiumAt.Add(2 * time.Hour), Utilization: 0.2, HasUtilization: true},
+			"7d_oi": {Status: "allowed_warning", Reset: premiumAt.Add(30 * time.Hour), Utilization: 0.88, HasUtilization: true},
+		},
+	})
+	coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         ordinaryAt,
+		Status:             "allowed",
+		AccountFingerprint: fingerprint,
+		Windows: map[string]coreauth.AnthropicQuotaWindow{
+			"5h": {Status: "allowed", Reset: ordinaryAt.Add(2 * time.Hour), Utilization: 0.3, HasUtilization: true},
+		},
+	})
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry")
+	}
+	if !got["observed_at"].(time.Time).Equal(ordinaryAt) {
+		t.Errorf("observed_at = %v want %v", got["observed_at"], ordinaryAt)
+	}
+
+	// gin.H is a named type: asserting to map[string]any yields a nil map
+	// and every lookup below would silently report "absent".
+	windows, ok := got["windows"].(gin.H)
+	if !ok {
+		t.Fatalf("windows has type %T, want gin.H", got["windows"])
+	}
+
+	carried, ok := windows["7d_oi"].(gin.H)
+	if !ok {
+		t.Fatalf("windows[7d_oi] has type %T, want gin.H — the carried window did not reach the projection", windows["7d_oi"])
+	}
+	observedAt, present := carried["observed_at"]
+	if !present {
+		t.Fatalf("windows[7d_oi]: expected observed_at so a consumer can tell a carried reading from a live one, got %v", carried)
+	}
+	if !observedAt.(time.Time).Equal(premiumAt) {
+		t.Errorf("windows[7d_oi].observed_at = %v want %v — a carried window keeps the stamp of the capture that saw it", observedAt, premiumAt)
+	}
+	if carried["utilization"] != 0.88 {
+		t.Errorf("windows[7d_oi].utilization = %v want 0.88", carried["utilization"])
+	}
+
+	live, ok := windows["5h"].(gin.H)
+	if !ok {
+		t.Fatalf("windows[5h] has type %T, want gin.H", windows["5h"])
+	}
+	if !live["observed_at"].(time.Time).Equal(ordinaryAt) {
+		t.Errorf("windows[5h].observed_at = %v want %v", live["observed_at"], ordinaryAt)
+	}
+}
+
+// TestBuildClaudeRateLimitEntry_ObservedAtDoesNotResurrectEmptyWindow guards
+// the interaction between the per-window timestamp and the emptiness gate. The
+// store stamps every window it holds, including one whose every header was
+// malformed, so a timestamp emitted before the gate would turn `"7d": {}` into
+// `"7d": {"observed_at": ...}` and put window data in front of consumers where
+// there is none.
+func TestBuildClaudeRateLimitEntry_ObservedAtDoesNotResurrectEmptyWindow(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-observed-at-empty-window@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: fixedObservedAt(),
+		Status:     "allowed",
+		Windows: map[string]coreauth.AnthropicQuotaWindow{
+			"5h": {Status: "allowed", Reset: fixedObservedAt().Add(2 * time.Hour), Utilization: 0.4, HasUtilization: true},
+			"7d": {},
+		},
+		RawHeaders: map[string]string{
+			"anthropic-ratelimit-unified-7d-reset": "garbage",
+		},
+	})
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry")
+	}
+	windows, ok := got["windows"].(gin.H)
+	if !ok {
+		t.Fatalf("windows has type %T, want gin.H", got["windows"])
+	}
+	if _, present := windows["7d"]; present {
+		t.Errorf("windows[7d]: a window with nothing to report must stay dropped, got %v", windows["7d"])
+	}
+}
+
+// TestBuildClaudeRateLimitEntry_WindowEmptinessMatchesStore walks every
+// combination of the four fields that count as window content and asserts a
+// window is emitted exactly when at least one is set.
+//
+// The store applies the same rule on the write side to decide whether a
+// capture's entry counts as a reported window (coreauth's windowHasContent). If
+// the two drift, a window the store treats as unreported still gets published
+// as though it were a reading, or a real one silently stops being published.
+func TestBuildClaudeRateLimitEntry_WindowEmptinessMatchesStore(t *testing.T) {
+	resetAt := fixedObservedAt().Add(2 * time.Hour)
+	for combo := 0; combo < 16; combo++ {
+		hasStatus := combo&1 != 0
+		hasUtilization := combo&2 != 0
+		hasThreshold := combo&4 != 0
+		hasReset := combo&8 != 0
+		name := fmt.Sprintf("status=%v/util=%v/threshold=%v/reset=%v", hasStatus, hasUtilization, hasThreshold, hasReset)
+
+		t.Run(name, func(t *testing.T) {
+			auth := &coreauth.Auth{ID: "claude-window-emptiness-" + name, Provider: "claude"}
+			resetClaudeRateLimitHint(t, auth.ID)
+
+			window := coreauth.AnthropicQuotaWindow{}
+			if hasStatus {
+				window.Status = "allowed"
+			}
+			if hasUtilization {
+				window.HasUtilization = true
+			}
+			if hasThreshold {
+				window.HasSurpassedThreshold = true
+			}
+			if hasReset {
+				window.Reset = resetAt
+			}
+			coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+				Known:      true,
+				ObservedAt: fixedObservedAt(),
+				Status:     "allowed",
+				Windows:    map[string]coreauth.AnthropicQuotaWindow{"7d": window},
+			})
+
+			entry := buildClaudeRateLimitEntry(auth)
+			if entry == nil {
+				t.Fatal("expected an entry: the hint carries a top-level status")
+			}
+			// gin.H is a named type: asserting to map[string]any yields a nil
+			// map and the lookup below would always report "absent".
+			var published bool
+			if windows, ok := entry["windows"].(gin.H); ok {
+				_, published = windows["7d"]
+			}
+			want := hasStatus || hasUtilization || hasThreshold || hasReset
+			if published != want {
+				t.Errorf("window published = %v, want %v (%s)", published, want, name)
+			}
+		})
+	}
 }

--- a/internal/api/handlers/management/auth_files_claude_rate_limit_test.go
+++ b/internal/api/handlers/management/auth_files_claude_rate_limit_test.go
@@ -1,0 +1,594 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// fixedObservedAt pins ObservedAt for snapshot tests. Real captures use
+// time.Now(); these tests construct hints directly so we own the timestamp.
+func fixedObservedAt() time.Time {
+	return time.Date(2026, 4, 30, 12, 34, 56, 0, time.UTC)
+}
+
+// resetClaudeRateLimitHint scrubs the hint store for a given authID so each
+// test runs against a clean slate. Hint store is package-global; tests share
+// it but each test uses a unique authID.
+func resetClaudeRateLimitHint(t *testing.T, authID string) {
+	t.Helper()
+	coreauth.DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() {
+		coreauth.DeleteAnthropicRateLimitHint(authID)
+	})
+}
+
+func TestBuildClaudeRateLimitEntry_NilAuth(t *testing.T) {
+	if got := buildClaudeRateLimitEntry(nil); got != nil {
+		t.Fatalf("expected nil for nil auth, got %v", got)
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_NonClaudeProvider(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "codex-non-claude@example.com",
+		Provider: "codex",
+	}
+	coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+		Known:  true,
+		Status: "allowed",
+	})
+	t.Cleanup(func() {
+		coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{Known: false})
+	})
+
+	if got := buildClaudeRateLimitEntry(auth); got != nil {
+		t.Fatalf("expected nil for non-claude provider, got %v", got)
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_NoHintCaptured(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-no-hint@example.com",
+		Provider: "claude",
+	}
+	if got := buildClaudeRateLimitEntry(auth); got != nil {
+		t.Fatalf("expected nil when no hint captured, got %v", got)
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_HintWithKnownFalse(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-known-false@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+		Known:  false,
+		Status: "allowed", // even with content, Known=false should suppress
+	})
+
+	if got := buildClaudeRateLimitEntry(auth); got != nil {
+		t.Fatalf("expected nil when Known=false even with content, got %v", got)
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_FullHintRoundTrip(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-full-hint@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	resetTime := time.Unix(1777500000, 0).UTC()
+	weekResetTime := time.Unix(1777561200, 0).UTC()
+	hint := coreauth.AnthropicRateLimitHint{
+		Known:                 true,
+		ObservedAt:            fixedObservedAt(),
+		Status:                "allowed_warning",
+		RepresentativeClaim:   "seven_day",
+		Reset:                 weekResetTime,
+		FallbackPercentage:    0.5,
+		HasFallbackPercentage: true,
+		OverageStatus:         "rejected",
+		OverageDisabledReason: "org_level_disabled",
+		UpgradePaths:          "upgrade_plan",
+		Windows: map[string]coreauth.AnthropicQuotaWindow{
+			"5h": {
+				Status:         "allowed",
+				Reset:          resetTime,
+				Utilization:    0.35,
+				HasUtilization: true,
+			},
+			"7d": {
+				Status:                "allowed_warning",
+				Reset:                 weekResetTime,
+				Utilization:           0.85,
+				HasUtilization:        true,
+				SurpassedThreshold:    0.75,
+				HasSurpassedThreshold: true,
+			},
+		},
+		RawHeaders: map[string]string{
+			"anthropic-ratelimit-unified-status":         "allowed_warning",
+			"anthropic-ratelimit-unified-7d-utilization": "0.85",
+		},
+	}
+	coreauth.SetAnthropicRateLimitHint(auth.ID, hint)
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry for known hint with content")
+	}
+
+	checkField := func(key string, want any) {
+		t.Helper()
+		gotVal, ok := got[key]
+		if !ok {
+			t.Errorf("missing key %q", key)
+			return
+		}
+		if !reflect.DeepEqual(gotVal, want) {
+			t.Errorf("%s = %v want %v", key, gotVal, want)
+		}
+	}
+	checkField("observed_at", fixedObservedAt())
+	checkField("status", "allowed_warning")
+	checkField("representative_claim", "seven_day")
+	checkField("reset_at", weekResetTime)
+	checkField("fallback_percentage", 0.5)
+	checkField("overage_status", "rejected")
+	checkField("overage_disabled_reason", "org_level_disabled")
+	checkField("upgrade_paths", "upgrade_plan")
+
+	windows, ok := got["windows"].(gin.H)
+	if !ok {
+		t.Fatalf("windows: expected gin.H, got %T", got["windows"])
+	}
+	if len(windows) != 2 {
+		t.Fatalf("windows: expected 2 entries, got %d: %v", len(windows), windows)
+	}
+
+	w5h, ok := windows["5h"].(gin.H)
+	if !ok {
+		t.Fatalf("windows[5h]: expected gin.H, got %T", windows["5h"])
+	}
+	if w5h["status"] != "allowed" {
+		t.Errorf("windows[5h].status = %v want allowed", w5h["status"])
+	}
+	if w5h["utilization"] != 0.35 {
+		t.Errorf("windows[5h].utilization = %v want 0.35", w5h["utilization"])
+	}
+	if !w5h["reset_at"].(time.Time).Equal(resetTime) {
+		t.Errorf("windows[5h].reset_at = %v want %v", w5h["reset_at"], resetTime)
+	}
+	// 5h has no surpassed_threshold; omitempty should drop it.
+	if _, present := w5h["surpassed_threshold"]; present {
+		t.Errorf("windows[5h]: unexpected surpassed_threshold field (should be omitted when 0)")
+	}
+
+	w7d, ok := windows["7d"].(gin.H)
+	if !ok {
+		t.Fatalf("windows[7d]: expected gin.H")
+	}
+	if w7d["surpassed_threshold"] != 0.75 {
+		t.Errorf("windows[7d].surpassed_threshold = %v want 0.75", w7d["surpassed_threshold"])
+	}
+
+	rawHeaders, ok := got["raw_headers"].(map[string]string)
+	if !ok {
+		t.Fatalf("raw_headers: expected map[string]string, got %T", got["raw_headers"])
+	}
+	if rawHeaders["anthropic-ratelimit-unified-status"] != "allowed_warning" {
+		t.Errorf("raw_headers passthrough broken")
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_OmitemptyDiscipline(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-omitempty@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	// Minimum-content hint: only Known=true and Status. Everything else
+	// should drop out via omitempty gates.
+	coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: fixedObservedAt(),
+		Status:     "allowed",
+	})
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry when at least one field is set")
+	}
+	for _, shouldBeAbsent := range []string{
+		"representative_claim",
+		"reset_at",
+		"fallback_percentage",
+		"overage_status",
+		"overage_disabled_reason",
+		"upgrade_paths",
+		"windows",
+		"raw_headers",
+	} {
+		if _, present := got[shouldBeAbsent]; present {
+			t.Errorf("expected %q to be omitted from minimum-content payload, but it was present", shouldBeAbsent)
+		}
+	}
+	if got["status"] != "allowed" {
+		t.Errorf("status = %v want allowed", got["status"])
+	}
+	if !got["observed_at"].(time.Time).Equal(fixedObservedAt()) {
+		t.Errorf("observed_at = %v want %v", got["observed_at"], fixedObservedAt())
+	}
+}
+
+// TestBuildClaudeRateLimitEntry_OmitsUtilizationWhenAbsent asserts that a
+// window which never received a `unified-{slug}-utilization` header surfaces
+// without the `utilization` field — rather than emitting 0.0, which is
+// indistinguishable from a real zero-utilization reading and would mislead
+// alerts into treating unknown utilization as healthy usage.
+func TestBuildClaudeRateLimitEntry_OmitsUtilizationWhenAbsent(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-utilization-absent@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	resetTime := time.Unix(1777500000, 0).UTC()
+	hint := coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: fixedObservedAt(),
+		Status:     "allowed",
+		Windows: map[string]coreauth.AnthropicQuotaWindow{
+			// Header was present with value 0.0 — must surface explicitly.
+			"5h": {
+				Status:         "allowed",
+				Reset:          resetTime,
+				Utilization:    0.0,
+				HasUtilization: true,
+			},
+			// Header was absent — must NOT surface as 0.0.
+			"7d": {
+				Status: "allowed",
+				Reset:  resetTime,
+			},
+		},
+	}
+	coreauth.SetAnthropicRateLimitHint(auth.ID, hint)
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry")
+	}
+
+	windows, ok := got["windows"].(gin.H)
+	if !ok {
+		t.Fatalf("windows: expected gin.H, got %T", got["windows"])
+	}
+
+	w5h, ok := windows["5h"].(gin.H)
+	if !ok {
+		t.Fatalf("windows[5h]: expected gin.H, got %T", windows["5h"])
+	}
+	if util, present := w5h["utilization"]; !present {
+		t.Errorf("windows[5h]: expected utilization to be present (header was sent with value 0.0)")
+	} else if util != 0.0 {
+		t.Errorf("windows[5h].utilization = %v want 0.0", util)
+	}
+
+	w7d, ok := windows["7d"].(gin.H)
+	if !ok {
+		t.Fatalf("windows[7d]: expected gin.H, got %T", windows["7d"])
+	}
+	if _, present := w7d["utilization"]; present {
+		t.Errorf("windows[7d]: utilization must be omitted when no header was sent (got %v)", w7d["utilization"])
+	}
+}
+
+// TestBuildClaudeRateLimitEntry_OmitsEmptyWindow asserts that a slug whose
+// fields all parsed to empty/zero (e.g. only a malformed
+// `unified-5h-reset: garbage` arrived) is dropped from structured output
+// rather than surfaced as `"5h": {}`. The forensic signal — the literal
+// header value — remains accessible via raw_headers.
+func TestBuildClaudeRateLimitEntry_OmitsEmptyWindow(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-empty-window-mixed@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	resetTime := time.Unix(1777500000, 0).UTC()
+	hint := coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: fixedObservedAt(),
+		Status:     "allowed",
+		Windows: map[string]coreauth.AnthropicQuotaWindow{
+			"5h": {
+				Status:         "allowed",
+				Reset:          resetTime,
+				Utilization:    0.4,
+				HasUtilization: true,
+			},
+			// All fields zero/empty: simulates a slug that only saw a
+			// malformed header on the parser side.
+			"7d": {},
+		},
+		RawHeaders: map[string]string{
+			"anthropic-ratelimit-unified-7d-reset": "garbage",
+		},
+	}
+	coreauth.SetAnthropicRateLimitHint(auth.ID, hint)
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry")
+	}
+
+	windows, ok := got["windows"].(gin.H)
+	if !ok {
+		t.Fatalf("windows: expected gin.H, got %T", got["windows"])
+	}
+	if _, present := windows["7d"]; present {
+		t.Errorf("windows[7d]: empty window must not be emitted (got %v)", windows["7d"])
+	}
+	if _, present := windows["5h"]; !present {
+		t.Error("windows[5h]: expected populated window to survive")
+	}
+
+	rawHeaders, ok := got["raw_headers"].(map[string]string)
+	if !ok {
+		t.Fatalf("raw_headers: expected map[string]string, got %T", got["raw_headers"])
+	}
+	if rawHeaders["anthropic-ratelimit-unified-7d-reset"] != "garbage" {
+		t.Error("raw_headers must preserve the malformed header for forensic visibility")
+	}
+}
+
+// TestBuildClaudeRateLimitEntry_OmitsWindowsKeyWhenAllEmpty asserts that
+// `windows` is dropped entirely (not emitted as `{}`) when every slug got
+// gated out. Top-level fields still surface.
+func TestBuildClaudeRateLimitEntry_OmitsWindowsKeyWhenAllEmpty(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-empty-window-all@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	hint := coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: fixedObservedAt(),
+		Status:     "allowed",
+		Windows: map[string]coreauth.AnthropicQuotaWindow{
+			"5h": {},
+			"7d": {},
+		},
+	}
+	coreauth.SetAnthropicRateLimitHint(auth.ID, hint)
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry (top-level status should survive)")
+	}
+	if _, present := got["windows"]; present {
+		t.Errorf("windows: expected key to be omitted entirely when all slugs are empty, got %v", got["windows"])
+	}
+	if got["status"] != "allowed" {
+		t.Errorf("status = %v want allowed", got["status"])
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_ProviderCasingIsTolerant(t *testing.T) {
+	for _, providerCasing := range []string{"claude", "Claude", "CLAUDE", "  claude  "} {
+		auth := &coreauth.Auth{
+			ID:       "claude-test-casing-" + providerCasing + "@example.com",
+			Provider: providerCasing,
+		}
+		coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+			Known:  true,
+			Status: "allowed",
+		})
+		t.Cleanup(func() {
+			coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{Known: false})
+		})
+
+		if got := buildClaudeRateLimitEntry(auth); got == nil {
+			t.Errorf("provider %q: expected non-nil entry but got nil", providerCasing)
+		}
+	}
+}
+
+// claudeAuthWithEmail builds a Claude OAuth auth whose account fingerprint
+// resolves from the given email.
+func claudeAuthWithEmail(authID, email string) *coreauth.Auth {
+	return &coreauth.Auth{
+		ID:       authID,
+		Provider: "claude",
+		Metadata: map[string]any{"email": email},
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_RejectsHintFromDifferentAccount(t *testing.T) {
+	const authID = "claude-test-rotated@example.com"
+	resetClaudeRateLimitHint(t, authID)
+
+	previous := claudeAuthWithEmail(authID, "before-rotation@example.com")
+	coreauth.SetAnthropicRateLimitHint(authID, coreauth.AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         fixedObservedAt(),
+		Status:             "rejected",
+		AccountFingerprint: coreauth.AnthropicAccountFingerprint(previous),
+	})
+
+	// Same auth ID, different underlying account: an in-place rotation, or a
+	// capture that landed after the credential was swapped out.
+	rotated := claudeAuthWithEmail(authID, "after-rotation@example.com")
+	if got := buildClaudeRateLimitEntry(rotated); got != nil {
+		t.Fatalf("expected nil for a hint captured against a different account, got %v", got)
+	}
+
+	// The original account still reads its own capture.
+	if got := buildClaudeRateLimitEntry(previous); got == nil {
+		t.Fatal("expected the capturing account to still see its own hint")
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_ServesHintWhenAccountUnknown(t *testing.T) {
+	const authID = "claude-test-unknown-account@example.com"
+	resetClaudeRateLimitHint(t, authID)
+
+	// A capture stored without a fingerprint (auth had no identifiable
+	// account at capture time) must stay readable rather than being treated
+	// as belonging to some other account.
+	coreauth.SetAnthropicRateLimitHint(authID, coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: fixedObservedAt(),
+		Status:     "allowed",
+	})
+
+	if got := buildClaudeRateLimitEntry(claudeAuthWithEmail(authID, "someone@example.com")); got == nil {
+		t.Fatal("hint with no fingerprint should be served, not rejected")
+	}
+
+	// And the mirror case: a fingerprinted capture read back through an auth
+	// whose account is no longer identifiable (e.g. a refresh that returned
+	// no email) must not be discarded.
+	resetClaudeRateLimitHint(t, authID)
+	coreauth.SetAnthropicRateLimitHint(authID, coreauth.AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         fixedObservedAt(),
+		Status:             "allowed",
+		AccountFingerprint: coreauth.AnthropicAccountFingerprint(claudeAuthWithEmail(authID, "someone@example.com")),
+	})
+	blankAccount := &coreauth.Auth{ID: authID, Provider: "claude"}
+	if got := buildClaudeRateLimitEntry(blankAccount); got == nil {
+		t.Fatal("hint should survive an auth whose account became unidentifiable")
+	}
+}
+
+// TestBuildClaudeRateLimitEntry_OmitsAccountFingerprint pins the invariant that
+// the account fingerprint never reaches a management response. It is a hash of
+// Auth.AccountInfo(), which for an API-key auth is the API key itself, so it
+// exists to be compared in-process and must not be published — including via a
+// future field added to the hint struct and projected wholesale.
+func TestBuildClaudeRateLimitEntry_OmitsAccountFingerprint(t *testing.T) {
+	const authID = "auth-fingerprint-not-published"
+	coreauth.DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { coreauth.DeleteAnthropicRateLimitHint(authID) })
+
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: "claude",
+		Metadata: map[string]any{"email": "someone@example.com"},
+	}
+	fingerprint := coreauth.AnthropicAccountFingerprint(auth)
+	if fingerprint == "" {
+		t.Fatal("precondition: expected a non-empty fingerprint for an auth with an email")
+	}
+
+	coreauth.SetAnthropicRateLimitHint(authID, coreauth.AnthropicRateLimitHint{
+		Known:              true,
+		Status:             "allowed",
+		ObservedAt:         time.Unix(1777500000, 0).UTC(),
+		AccountFingerprint: fingerprint,
+	})
+
+	entry := buildClaudeRateLimitEntry(auth)
+	if entry == nil {
+		t.Fatal("expected a rate_limit entry for a stored hint")
+	}
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal rate_limit entry: %v", err)
+	}
+	if bytes.Contains(encoded, []byte(fingerprint)) {
+		t.Errorf("account fingerprint leaked into the management response: %s", encoded)
+	}
+	for _, banned := range []string{"fingerprint", "account_fingerprint", "AccountFingerprint"} {
+		if bytes.Contains(bytes.ToLower(encoded), bytes.ToLower([]byte(banned))) {
+			t.Errorf("management response carries a %q key: %s", banned, encoded)
+		}
+	}
+}
+
+// TestBuildClaudeRateLimitEntry_MalformedNumericsAreNotPublished pins that a
+// numeric header which failed to parse is omitted from the projection rather
+// than published as a healthy-looking 0, and that a legitimate explicit 0
+// survives. Those two cases are indistinguishable without the presence flags,
+// and 0 is exactly the reading an operator is least likely to question.
+func TestBuildClaudeRateLimitEntry_MalformedNumericsAreNotPublished(t *testing.T) {
+	auth := &coreauth.Auth{ID: "auth-malformed-numerics", Provider: "claude"}
+	t.Cleanup(func() { coreauth.DeleteAnthropicRateLimitHint(auth.ID) })
+
+	t.Run("malformed omitted", func(t *testing.T) {
+		coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+			Known: true, ObservedAt: fixedObservedAt(), Status: "allowed",
+			// Parser could not read these, so no presence flag is set.
+			FallbackPercentage: 0, HasFallbackPercentage: false,
+			Windows: map[string]coreauth.AnthropicQuotaWindow{
+				"5h": {Status: "allowed", Utilization: 0, HasUtilization: false,
+					SurpassedThreshold: 0, HasSurpassedThreshold: false},
+			},
+		})
+		entry := buildClaudeRateLimitEntry(auth)
+		if _, ok := entry["fallback_percentage"]; ok {
+			t.Error("malformed fallback_percentage was published as a real reading")
+		}
+		// gin.H is a named type: asserting to map[string]any yields a nil map
+		// and every lookup below would silently report "absent".
+		windows, ok := entry["windows"].(gin.H)
+		if !ok {
+			t.Fatalf("windows has type %T, want gin.H", entry["windows"])
+		}
+		w, ok := windows["5h"].(gin.H)
+		if !ok {
+			t.Fatalf("windows[5h] has type %T, want gin.H", windows["5h"])
+		}
+		if _, ok := w["utilization"]; ok {
+			t.Error("malformed utilization was published as a real reading")
+		}
+		if _, ok := w["surpassed_threshold"]; ok {
+			t.Error("malformed surpassed_threshold was published as a real reading")
+		}
+	})
+
+	t.Run("explicit zero survives", func(t *testing.T) {
+		coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+			Known: true, ObservedAt: fixedObservedAt().Add(time.Second), Status: "allowed",
+			FallbackPercentage: 0, HasFallbackPercentage: true,
+			Windows: map[string]coreauth.AnthropicQuotaWindow{
+				"5h": {Status: "allowed", Utilization: 0, HasUtilization: true,
+					SurpassedThreshold: 0, HasSurpassedThreshold: true},
+			},
+		})
+		entry := buildClaudeRateLimitEntry(auth)
+		if got, ok := entry["fallback_percentage"]; !ok || got != float64(0) {
+			t.Errorf("explicit zero fallback_percentage = %v (present=%v), want 0 present", got, ok)
+		}
+		// gin.H is a named type: asserting to map[string]any yields a nil map
+		// and every lookup below would silently report "absent".
+		windows, ok := entry["windows"].(gin.H)
+		if !ok {
+			t.Fatalf("windows has type %T, want gin.H", entry["windows"])
+		}
+		w, ok := windows["5h"].(gin.H)
+		if !ok {
+			t.Fatalf("windows[5h] has type %T, want gin.H", windows["5h"])
+		}
+		if got, ok := w["utilization"]; !ok || got != float64(0) {
+			t.Errorf("explicit zero utilization = %v (present=%v), want 0 present", got, ok)
+		}
+		if got, ok := w["surpassed_threshold"]; !ok || got != float64(0) {
+			t.Errorf("explicit zero surpassed_threshold = %v (present=%v), want 0 present", got, ok)
+		}
+	})
+}

--- a/internal/api/handlers/management/auth_files_claude_rate_limit_test.go
+++ b/internal/api/handlers/management/auth_files_claude_rate_limit_test.go
@@ -21,11 +21,9 @@ func fixedObservedAt() time.Time {
 // it but each test uses a unique authID.
 func resetClaudeRateLimitHint(t *testing.T, authID string) {
 	t.Helper()
-	// SetAnthropicRateLimitHint with Known=false acts as a soft-clear for
-	// tests that check Known=false → nil entry. For full removal we'd need
-	// a Delete API; absent that, unique authIDs prevent cross-pollution.
+	coreauth.DeleteAnthropicRateLimitHint(authID)
 	t.Cleanup(func() {
-		coreauth.SetAnthropicRateLimitHint(authID, coreauth.AnthropicRateLimitHint{Known: false})
+		coreauth.DeleteAnthropicRateLimitHint(authID)
 	})
 }
 
@@ -402,5 +400,73 @@ func TestBuildClaudeRateLimitEntry_ProviderCasingIsTolerant(t *testing.T) {
 		if got := buildClaudeRateLimitEntry(auth); got == nil {
 			t.Errorf("provider %q: expected non-nil entry but got nil", providerCasing)
 		}
+	}
+}
+
+// claudeAuthWithEmail builds a Claude OAuth auth whose account fingerprint
+// resolves from the given email.
+func claudeAuthWithEmail(authID, email string) *coreauth.Auth {
+	return &coreauth.Auth{
+		ID:       authID,
+		Provider: "claude",
+		Metadata: map[string]any{"email": email},
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_RejectsHintFromDifferentAccount(t *testing.T) {
+	const authID = "claude-test-rotated@example.com"
+	resetClaudeRateLimitHint(t, authID)
+
+	previous := claudeAuthWithEmail(authID, "before-rotation@example.com")
+	coreauth.SetAnthropicRateLimitHint(authID, coreauth.AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         fixedObservedAt(),
+		Status:             "rejected",
+		AccountFingerprint: coreauth.AnthropicAccountFingerprint(previous),
+	})
+
+	// Same auth ID, different underlying account: an in-place rotation, or a
+	// capture that landed after the credential was swapped out.
+	rotated := claudeAuthWithEmail(authID, "after-rotation@example.com")
+	if got := buildClaudeRateLimitEntry(rotated); got != nil {
+		t.Fatalf("expected nil for a hint captured against a different account, got %v", got)
+	}
+
+	// The original account still reads its own capture.
+	if got := buildClaudeRateLimitEntry(previous); got == nil {
+		t.Fatal("expected the capturing account to still see its own hint")
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_ServesHintWhenAccountUnknown(t *testing.T) {
+	const authID = "claude-test-unknown-account@example.com"
+	resetClaudeRateLimitHint(t, authID)
+
+	// A capture stored without a fingerprint (auth had no identifiable
+	// account at capture time) must stay readable rather than being treated
+	// as belonging to some other account.
+	coreauth.SetAnthropicRateLimitHint(authID, coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: fixedObservedAt(),
+		Status:     "allowed",
+	})
+
+	if got := buildClaudeRateLimitEntry(claudeAuthWithEmail(authID, "someone@example.com")); got == nil {
+		t.Fatal("hint with no fingerprint should be served, not rejected")
+	}
+
+	// And the mirror case: a fingerprinted capture read back through an auth
+	// whose account is no longer identifiable (e.g. a refresh that returned
+	// no email) must not be discarded.
+	resetClaudeRateLimitHint(t, authID)
+	coreauth.SetAnthropicRateLimitHint(authID, coreauth.AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         fixedObservedAt(),
+		Status:             "allowed",
+		AccountFingerprint: coreauth.AnthropicAccountFingerprint(claudeAuthWithEmail(authID, "someone@example.com")),
+	})
+	blankAccount := &coreauth.Auth{ID: authID, Provider: "claude"}
+	if got := buildClaudeRateLimitEntry(blankAccount); got == nil {
+		t.Fatal("hint should survive an auth whose account became unidentifiable")
 	}
 }

--- a/internal/api/handlers/management/auth_files_claude_rate_limit_test.go
+++ b/internal/api/handlers/management/auth_files_claude_rate_limit_test.go
@@ -1,0 +1,406 @@
+package management
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// fixedObservedAt pins ObservedAt for snapshot tests. Real captures use
+// time.Now(); these tests construct hints directly so we own the timestamp.
+func fixedObservedAt() time.Time {
+	return time.Date(2026, 4, 30, 12, 34, 56, 0, time.UTC)
+}
+
+// resetClaudeRateLimitHint scrubs the hint store for a given authID so each
+// test runs against a clean slate. Hint store is package-global; tests share
+// it but each test uses a unique authID.
+func resetClaudeRateLimitHint(t *testing.T, authID string) {
+	t.Helper()
+	// SetAnthropicRateLimitHint with Known=false acts as a soft-clear for
+	// tests that check Known=false → nil entry. For full removal we'd need
+	// a Delete API; absent that, unique authIDs prevent cross-pollution.
+	t.Cleanup(func() {
+		coreauth.SetAnthropicRateLimitHint(authID, coreauth.AnthropicRateLimitHint{Known: false})
+	})
+}
+
+func TestBuildClaudeRateLimitEntry_NilAuth(t *testing.T) {
+	if got := buildClaudeRateLimitEntry(nil); got != nil {
+		t.Fatalf("expected nil for nil auth, got %v", got)
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_NonClaudeProvider(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "codex-non-claude@example.com",
+		Provider: "codex",
+	}
+	coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+		Known:  true,
+		Status: "allowed",
+	})
+	t.Cleanup(func() {
+		coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{Known: false})
+	})
+
+	if got := buildClaudeRateLimitEntry(auth); got != nil {
+		t.Fatalf("expected nil for non-claude provider, got %v", got)
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_NoHintCaptured(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-no-hint@example.com",
+		Provider: "claude",
+	}
+	if got := buildClaudeRateLimitEntry(auth); got != nil {
+		t.Fatalf("expected nil when no hint captured, got %v", got)
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_HintWithKnownFalse(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-known-false@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+		Known:  false,
+		Status: "allowed", // even with content, Known=false should suppress
+	})
+
+	if got := buildClaudeRateLimitEntry(auth); got != nil {
+		t.Fatalf("expected nil when Known=false even with content, got %v", got)
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_FullHintRoundTrip(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-full-hint@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	resetTime := time.Unix(1777500000, 0).UTC()
+	weekResetTime := time.Unix(1777561200, 0).UTC()
+	hint := coreauth.AnthropicRateLimitHint{
+		Known:                 true,
+		ObservedAt:            fixedObservedAt(),
+		Status:                "allowed_warning",
+		RepresentativeClaim:   "seven_day",
+		Reset:                 weekResetTime,
+		FallbackPercentage:    0.5,
+		OverageStatus:         "rejected",
+		OverageDisabledReason: "org_level_disabled",
+		UpgradePaths:          "upgrade_plan",
+		Windows: map[string]coreauth.AnthropicQuotaWindow{
+			"5h": {
+				Status:         "allowed",
+				Reset:          resetTime,
+				Utilization:    0.35,
+				HasUtilization: true,
+			},
+			"7d": {
+				Status:             "allowed_warning",
+				Reset:              weekResetTime,
+				Utilization:        0.85,
+				HasUtilization:     true,
+				SurpassedThreshold: 0.75,
+			},
+		},
+		RawHeaders: map[string]string{
+			"anthropic-ratelimit-unified-status":         "allowed_warning",
+			"anthropic-ratelimit-unified-7d-utilization": "0.85",
+		},
+	}
+	coreauth.SetAnthropicRateLimitHint(auth.ID, hint)
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry for known hint with content")
+	}
+
+	checkField := func(key string, want any) {
+		t.Helper()
+		gotVal, ok := got[key]
+		if !ok {
+			t.Errorf("missing key %q", key)
+			return
+		}
+		if !reflect.DeepEqual(gotVal, want) {
+			t.Errorf("%s = %v want %v", key, gotVal, want)
+		}
+	}
+	checkField("observed_at", fixedObservedAt())
+	checkField("status", "allowed_warning")
+	checkField("representative_claim", "seven_day")
+	checkField("reset_at", weekResetTime)
+	checkField("fallback_percentage", 0.5)
+	checkField("overage_status", "rejected")
+	checkField("overage_disabled_reason", "org_level_disabled")
+	checkField("upgrade_paths", "upgrade_plan")
+
+	windows, ok := got["windows"].(gin.H)
+	if !ok {
+		t.Fatalf("windows: expected gin.H, got %T", got["windows"])
+	}
+	if len(windows) != 2 {
+		t.Fatalf("windows: expected 2 entries, got %d: %v", len(windows), windows)
+	}
+
+	w5h, ok := windows["5h"].(gin.H)
+	if !ok {
+		t.Fatalf("windows[5h]: expected gin.H, got %T", windows["5h"])
+	}
+	if w5h["status"] != "allowed" {
+		t.Errorf("windows[5h].status = %v want allowed", w5h["status"])
+	}
+	if w5h["utilization"] != 0.35 {
+		t.Errorf("windows[5h].utilization = %v want 0.35", w5h["utilization"])
+	}
+	if !w5h["reset_at"].(time.Time).Equal(resetTime) {
+		t.Errorf("windows[5h].reset_at = %v want %v", w5h["reset_at"], resetTime)
+	}
+	// 5h has no surpassed_threshold; omitempty should drop it.
+	if _, present := w5h["surpassed_threshold"]; present {
+		t.Errorf("windows[5h]: unexpected surpassed_threshold field (should be omitted when 0)")
+	}
+
+	w7d, ok := windows["7d"].(gin.H)
+	if !ok {
+		t.Fatalf("windows[7d]: expected gin.H")
+	}
+	if w7d["surpassed_threshold"] != 0.75 {
+		t.Errorf("windows[7d].surpassed_threshold = %v want 0.75", w7d["surpassed_threshold"])
+	}
+
+	rawHeaders, ok := got["raw_headers"].(map[string]string)
+	if !ok {
+		t.Fatalf("raw_headers: expected map[string]string, got %T", got["raw_headers"])
+	}
+	if rawHeaders["anthropic-ratelimit-unified-status"] != "allowed_warning" {
+		t.Errorf("raw_headers passthrough broken")
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_OmitemptyDiscipline(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-omitempty@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	// Minimum-content hint: only Known=true and Status. Everything else
+	// should drop out via omitempty gates.
+	coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: fixedObservedAt(),
+		Status:     "allowed",
+	})
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry when at least one field is set")
+	}
+	for _, shouldBeAbsent := range []string{
+		"representative_claim",
+		"reset_at",
+		"fallback_percentage",
+		"overage_status",
+		"overage_disabled_reason",
+		"upgrade_paths",
+		"windows",
+		"raw_headers",
+	} {
+		if _, present := got[shouldBeAbsent]; present {
+			t.Errorf("expected %q to be omitted from minimum-content payload, but it was present", shouldBeAbsent)
+		}
+	}
+	if got["status"] != "allowed" {
+		t.Errorf("status = %v want allowed", got["status"])
+	}
+	if !got["observed_at"].(time.Time).Equal(fixedObservedAt()) {
+		t.Errorf("observed_at = %v want %v", got["observed_at"], fixedObservedAt())
+	}
+}
+
+// TestBuildClaudeRateLimitEntry_OmitsUtilizationWhenAbsent asserts that a
+// window which never received a `unified-{slug}-utilization` header surfaces
+// without the `utilization` field — rather than emitting 0.0, which is
+// indistinguishable from a real zero-utilization reading and would mislead
+// alerts into treating unknown utilization as healthy usage.
+func TestBuildClaudeRateLimitEntry_OmitsUtilizationWhenAbsent(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-utilization-absent@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	resetTime := time.Unix(1777500000, 0).UTC()
+	hint := coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: fixedObservedAt(),
+		Status:     "allowed",
+		Windows: map[string]coreauth.AnthropicQuotaWindow{
+			// Header was present with value 0.0 — must surface explicitly.
+			"5h": {
+				Status:         "allowed",
+				Reset:          resetTime,
+				Utilization:    0.0,
+				HasUtilization: true,
+			},
+			// Header was absent — must NOT surface as 0.0.
+			"7d": {
+				Status: "allowed",
+				Reset:  resetTime,
+			},
+		},
+	}
+	coreauth.SetAnthropicRateLimitHint(auth.ID, hint)
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry")
+	}
+
+	windows, ok := got["windows"].(gin.H)
+	if !ok {
+		t.Fatalf("windows: expected gin.H, got %T", got["windows"])
+	}
+
+	w5h, ok := windows["5h"].(gin.H)
+	if !ok {
+		t.Fatalf("windows[5h]: expected gin.H, got %T", windows["5h"])
+	}
+	if util, present := w5h["utilization"]; !present {
+		t.Errorf("windows[5h]: expected utilization to be present (header was sent with value 0.0)")
+	} else if util != 0.0 {
+		t.Errorf("windows[5h].utilization = %v want 0.0", util)
+	}
+
+	w7d, ok := windows["7d"].(gin.H)
+	if !ok {
+		t.Fatalf("windows[7d]: expected gin.H, got %T", windows["7d"])
+	}
+	if _, present := w7d["utilization"]; present {
+		t.Errorf("windows[7d]: utilization must be omitted when no header was sent (got %v)", w7d["utilization"])
+	}
+}
+
+// TestBuildClaudeRateLimitEntry_OmitsEmptyWindow asserts that a slug whose
+// fields all parsed to empty/zero (e.g. only a malformed
+// `unified-5h-reset: garbage` arrived) is dropped from structured output
+// rather than surfaced as `"5h": {}`. The forensic signal — the literal
+// header value — remains accessible via raw_headers.
+func TestBuildClaudeRateLimitEntry_OmitsEmptyWindow(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-empty-window-mixed@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	resetTime := time.Unix(1777500000, 0).UTC()
+	hint := coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: fixedObservedAt(),
+		Status:     "allowed",
+		Windows: map[string]coreauth.AnthropicQuotaWindow{
+			"5h": {
+				Status:         "allowed",
+				Reset:          resetTime,
+				Utilization:    0.4,
+				HasUtilization: true,
+			},
+			// All fields zero/empty: simulates a slug that only saw a
+			// malformed header on the parser side.
+			"7d": {},
+		},
+		RawHeaders: map[string]string{
+			"anthropic-ratelimit-unified-7d-reset": "garbage",
+		},
+	}
+	coreauth.SetAnthropicRateLimitHint(auth.ID, hint)
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry")
+	}
+
+	windows, ok := got["windows"].(gin.H)
+	if !ok {
+		t.Fatalf("windows: expected gin.H, got %T", got["windows"])
+	}
+	if _, present := windows["7d"]; present {
+		t.Errorf("windows[7d]: empty window must not be emitted (got %v)", windows["7d"])
+	}
+	if _, present := windows["5h"]; !present {
+		t.Error("windows[5h]: expected populated window to survive")
+	}
+
+	rawHeaders, ok := got["raw_headers"].(map[string]string)
+	if !ok {
+		t.Fatalf("raw_headers: expected map[string]string, got %T", got["raw_headers"])
+	}
+	if rawHeaders["anthropic-ratelimit-unified-7d-reset"] != "garbage" {
+		t.Error("raw_headers must preserve the malformed header for forensic visibility")
+	}
+}
+
+// TestBuildClaudeRateLimitEntry_OmitsWindowsKeyWhenAllEmpty asserts that
+// `windows` is dropped entirely (not emitted as `{}`) when every slug got
+// gated out. Top-level fields still surface.
+func TestBuildClaudeRateLimitEntry_OmitsWindowsKeyWhenAllEmpty(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "claude-test-empty-window-all@example.com",
+		Provider: "claude",
+	}
+	resetClaudeRateLimitHint(t, auth.ID)
+
+	hint := coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: fixedObservedAt(),
+		Status:     "allowed",
+		Windows: map[string]coreauth.AnthropicQuotaWindow{
+			"5h": {},
+			"7d": {},
+		},
+	}
+	coreauth.SetAnthropicRateLimitHint(auth.ID, hint)
+
+	got := buildClaudeRateLimitEntry(auth)
+	if got == nil {
+		t.Fatal("expected non-nil entry (top-level status should survive)")
+	}
+	if _, present := got["windows"]; present {
+		t.Errorf("windows: expected key to be omitted entirely when all slugs are empty, got %v", got["windows"])
+	}
+	if got["status"] != "allowed" {
+		t.Errorf("status = %v want allowed", got["status"])
+	}
+}
+
+func TestBuildClaudeRateLimitEntry_ProviderCasingIsTolerant(t *testing.T) {
+	for _, providerCasing := range []string{"claude", "Claude", "CLAUDE", "  claude  "} {
+		auth := &coreauth.Auth{
+			ID:       "claude-test-casing-" + providerCasing + "@example.com",
+			Provider: providerCasing,
+		}
+		coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{
+			Known:  true,
+			Status: "allowed",
+		})
+		t.Cleanup(func() {
+			coreauth.SetAnthropicRateLimitHint(auth.ID, coreauth.AnthropicRateLimitHint{Known: false})
+		})
+
+		if got := buildClaudeRateLimitEntry(auth); got == nil {
+			t.Errorf("provider %q: expected non-nil entry but got nil", providerCasing)
+		}
+	}
+}

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -174,7 +174,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		return resp, wrapClaudeFastRequestError(fastRequest, 0, err)
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-	helps.RecordAnthropicRateLimit(authID, httpResp.Header, time.Now())
+	helps.RecordAnthropicRateLimit(auth, httpResp.Header, time.Now())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -173,6 +174,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		return resp, wrapClaudeFastRequestError(fastRequest, 0, err)
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	helps.RecordAnthropicRateLimit(authID, httpResp.Header, time.Now())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -136,6 +137,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		return resp, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	helps.RecordAnthropicRateLimit(authID, httpResp.Header, time.Now())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -137,7 +137,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		return resp, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-	helps.RecordAnthropicRateLimit(authID, httpResp.Header, time.Now())
+	helps.RecordAnthropicRateLimit(auth, httpResp.Header, time.Now())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -171,6 +172,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return nil, wrapClaudeFastRequestError(fastRequest, 0, err)
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	helps.RecordAnthropicRateLimit(authID, httpResp.Header, time.Now())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -172,7 +172,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return nil, wrapClaudeFastRequestError(fastRequest, 0, err)
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-	helps.RecordAnthropicRateLimit(authID, httpResp.Header, time.Now())
+	helps.RecordAnthropicRateLimit(auth, httpResp.Header, time.Now())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -134,7 +134,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return nil, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-	helps.RecordAnthropicRateLimit(authID, httpResp.Header, time.Now())
+	helps.RecordAnthropicRateLimit(auth, httpResp.Header, time.Now())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -133,6 +134,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return nil, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	helps.RecordAnthropicRateLimit(authID, httpResp.Header, time.Now())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -244,7 +244,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 		return cliproxyexecutor.Response{}, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, resp.StatusCode, resp.Header.Clone())
-	helps.RecordAnthropicRateLimit(authID, resp.Header, time.Now())
+	helps.RecordAnthropicRateLimit(auth, resp.Header, time.Now())
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -243,6 +244,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 		return cliproxyexecutor.Response{}, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, resp.StatusCode, resp.Header.Clone())
+	helps.RecordAnthropicRateLimit(authID, resp.Header, time.Now())
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -166,6 +167,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 		return cliproxyexecutor.Response{}, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, resp.StatusCode, resp.Header.Clone())
+	helps.RecordAnthropicRateLimit(authID, resp.Header, time.Now())
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -167,7 +167,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 		return cliproxyexecutor.Response{}, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, resp.StatusCode, resp.Header.Clone())
-	helps.RecordAnthropicRateLimit(authID, resp.Header, time.Now())
+	helps.RecordAnthropicRateLimit(auth, resp.Header, time.Now())
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Decompress error responses — pass the Content-Encoding value (may be empty)
 		// and let decodeResponseBody handle both header-declared and magic-byte-detected

--- a/internal/runtime/executor/helps/claude_rate_limit_record.go
+++ b/internal/runtime/executor/helps/claude_rate_limit_record.go
@@ -1,0 +1,249 @@
+package helps
+
+import (
+	"math"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+const anthropicRateLimitHeaderPrefix = "anthropic-ratelimit-unified-"
+
+// Per-window field suffixes, ordered longest-first so that `-status` does not
+// preempt `-surpassed-threshold` during suffix matching.
+var anthropicPerWindowFieldSuffixes = []string{
+	"-surpassed-threshold",
+	"-utilization",
+	"-status",
+	"-reset",
+}
+
+// anthropicWindowSlugPattern constrains the per-window fallback to slugs that
+// actually look like quota-window identifiers: <digits><h|d> with an optional
+// `_<lowercase_word>` tier suffix (e.g. "5h", "7d", "7d_opus", "7d_sonnet").
+//
+// Without this gate, any future top-level header ending in one of the field
+// suffixes (for example `unified-overage-reset` or a hypothetical
+// `unified-foo-status`) would be misparsed into a synthetic windows[slug]
+// entry, corrupting the structured rate_limit.windows view that management
+// consumers depend on. Headers that fail this check stay raw-only — they are
+// already captured upstream into RawHeaders, which is the forward-compat
+// safety net for schema drift.
+var anthropicWindowSlugPattern = regexp.MustCompile(`^\d+[hd](?:_[a-z_]+)?$`)
+
+// Retention budget for a single capture. The hint is held per auth ID until
+// that auth's next response or a scrub, so its size is bounded here rather
+// than by the response that produced it.
+//
+// Without these, one response sizes the hint: the slug pattern's `\d+` admits
+// unboundedly many distinct windows, and neither map caps its entry count or
+// value length. Nothing in the tree sets MaxResponseHeaderBytes or
+// MaxHeaderListSize, so Go's 10 MiB defaults are the only ceiling — and a
+// context-injected RoundTripper bypasses even that. `baseURL` comes from the
+// credential and third-party Anthropic-compatible bases are explicitly
+// supported (isAnthropicUpstreamBase exists to tell them apart), so the
+// producer of these headers is not necessarily Anthropic over TLS.
+//
+// The limits sit far above real captures — observed responses carry well
+// under 20 unified headers across at most a handful of windows — so a
+// legitimate capture is never truncated. Excess is dropped rather than
+// erroring: this is passive observability, and a partial hint beats none.
+const (
+	maxAnthropicRawHeaders   = 128
+	maxAnthropicWindows      = 64
+	maxAnthropicHeaderValLen = 1024
+)
+
+// RecordAnthropicRateLimit extracts the `anthropic-ratelimit-unified-*` family
+// from an upstream Anthropic response and stashes the parsed state on the auth
+// hint store (sdk/cliproxy/auth.SetAnthropicRateLimitHint).
+//
+// Called from the Claude executor after each upstream round-trip, regardless of
+// status code. Pure passive observability — no error is returned, no routing
+// behavior changes. The conductor and selector continue to consult Auth.Quota
+// and Auth.NextRetryAfter exclusively for routing decisions.
+//
+// If the response carries no `unified-*` headers (raw API-key traffic, a
+// response from a non-subscription endpoint, or the no-headers 429 regression
+// reported in NousResearch/hermes-agent#17169), the hint store is left
+// untouched — any prior hint stays put rather than being overwritten with
+// empty state.
+func RecordAnthropicRateLimit(authID string, headers http.Header, now time.Time) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" || headers == nil {
+		return
+	}
+
+	raw := make(map[string]string)
+	windows := make(map[string]cliproxyauth.AnthropicQuotaWindow)
+	hint := cliproxyauth.AnthropicRateLimitHint{
+		ObservedAt: now,
+	}
+
+	for canonicalName, values := range headers {
+		if len(values) == 0 {
+			continue
+		}
+		lower := strings.ToLower(canonicalName)
+		if !strings.HasPrefix(lower, anthropicRateLimitHeaderPrefix) {
+			continue
+		}
+		if len(raw) >= maxAnthropicRawHeaders {
+			continue
+		}
+		value := values[0]
+		if len(value) > maxAnthropicHeaderValLen {
+			value = value[:maxAnthropicHeaderValLen]
+		}
+		raw[lower] = value
+		suffix := strings.TrimPrefix(lower, anthropicRateLimitHeaderPrefix)
+		recordAnthropicRateLimitField(&hint, windows, suffix, value)
+	}
+
+	// No `unified-*` headers seen anywhere; leave any prior hint intact.
+	// We commit a hint only when the upstream response actually carried our
+	// signal — the alternative (overwrite with empty state on every claude
+	// response) would erase prior captures whenever a non-Anthropic-shaped
+	// reply slipped through this executor or the family was stripped from a
+	// 429 response (cf. NousResearch/hermes-agent#17169).
+	if len(raw) == 0 {
+		return
+	}
+
+	hint.Known = true
+	hint.RawHeaders = raw
+	if len(windows) > 0 {
+		hint.Windows = windows
+	}
+	cliproxyauth.SetAnthropicRateLimitHint(authID, hint)
+}
+
+// recordAnthropicRateLimitField routes a single header (already stripped of
+// the `anthropic-ratelimit-unified-` prefix) into either a top-level hint slot
+// or a per-window slot. Unknown suffixes are silently ignored at this layer;
+// they remain accessible via the parent hint's RawHeaders map.
+func recordAnthropicRateLimitField(
+	hint *cliproxyauth.AnthropicRateLimitHint,
+	windows map[string]cliproxyauth.AnthropicQuotaWindow,
+	suffix, value string,
+) {
+	switch suffix {
+	case "status":
+		hint.Status = value
+		return
+	case "representative-claim":
+		hint.RepresentativeClaim = value
+		return
+	case "reset":
+		hint.Reset = parseAnthropicEpochSeconds(value)
+		return
+	case "fallback-percentage":
+		hint.FallbackPercentage = parseAnthropicFloat(value)
+		return
+	case "overage-status":
+		hint.OverageStatus = value
+		return
+	case "overage-disabled-reason":
+		hint.OverageDisabledReason = value
+		return
+	case "upgrade-paths":
+		hint.UpgradePaths = value
+		return
+	}
+
+	for _, fieldSuffix := range anthropicPerWindowFieldSuffixes {
+		if !strings.HasSuffix(suffix, fieldSuffix) {
+			continue
+		}
+		slug := strings.TrimSuffix(suffix, fieldSuffix)
+		if slug == "" || !anthropicWindowSlugPattern.MatchString(slug) {
+			// Looks like a per-window suffix but slug doesn't match the
+			// window-slug pattern — likely a future top-level field
+			// (e.g. unified-overage-reset → slug "overage"). Leave it in
+			// RawHeaders (already captured upstream) and skip structured
+			// parsing. Fail-open to RawHeaders preserves the
+			// forward-compat safety net for schema drift.
+			return
+		}
+		window, seen := windows[slug]
+		if !seen && len(windows) >= maxAnthropicWindows {
+			// Budget spent on windows already recorded; this slug stays
+			// raw-only. Fields for slugs we are already tracking still
+			// apply, so a truncated capture keeps whole windows rather
+			// than a mix of partial ones.
+			return
+		}
+		switch fieldSuffix {
+		case "-status":
+			window.Status = value
+		case "-reset":
+			window.Reset = parseAnthropicEpochSeconds(value)
+		case "-utilization":
+			window.Utilization = parseAnthropicFloat(value)
+			// Tag presence so the serializer can omit the field when the
+			// upstream response had no utilization signal at all (vs. an
+			// explicit 0.0 reading). Stays true even when parseAnthropicFloat
+			// falls back to 0 on a malformed value: the operator-visible
+			// signal is still "Anthropic shipped this header", and 0 is the
+			// safest fallback consistent with how status/reset behave on
+			// malformed input.
+			window.HasUtilization = true
+		case "-surpassed-threshold":
+			window.SurpassedThreshold = parseAnthropicFloat(value)
+		}
+		windows[slug] = window
+		return
+	}
+}
+
+// parseAnthropicEpochSeconds parses an epoch-seconds header value (Anthropic's
+// `reset` field format) into UTC time.Time. Returns the zero time on any parse
+// failure — callers should treat zero as "unknown" via .IsZero().
+//
+// Epoch values that fall outside the year range [0001, 9999] are also rejected
+// (returns zero). time.Time.MarshalJSON refuses to serialize times outside that
+// range, so a malicious upstream sending e.g. `99999999999999` would otherwise
+// stash a year-5138+ timestamp on the auth hint and crash any management
+// endpoint that JSON-marshals the AnthropicRateLimitHint.
+func parseAnthropicEpochSeconds(s string) time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	// JSON-serializable epoch range: [0001-01-01T00:00:00Z, 9999-12-31T23:59:59Z].
+	const minEpoch = -62135596800
+	const maxEpoch = 253402300799
+	if n < minEpoch || n > maxEpoch {
+		return time.Time{}
+	}
+	return time.Unix(n, 0).UTC()
+}
+
+// parseAnthropicFloat parses a float header value (utilization, threshold,
+// fallback-percentage). Returns 0 on parse failure or for non-finite values
+// (NaN, ±Inf) — strconv.ParseFloat accepts those literals, but storing them
+// breaks downstream JSON serialization and any consumer arithmetic. Callers
+// should not special-case 0 as "missing"; use the parent struct's presence
+// to disambiguate.
+func parseAnthropicFloat(s string) float64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0
+	}
+	return f
+}

--- a/internal/runtime/executor/helps/claude_rate_limit_record.go
+++ b/internal/runtime/executor/helps/claude_rate_limit_record.go
@@ -72,16 +72,25 @@ const (
 // reported in NousResearch/hermes-agent#17169), the hint store is left
 // untouched — any prior hint stays put rather than being overwritten with
 // empty state.
-func RecordAnthropicRateLimit(authID string, headers http.Header, now time.Time) {
-	authID = strings.TrimSpace(authID)
-	if authID == "" || headers == nil {
+//
+// Takes the auth rather than a bare ID so the capture can be tagged with the
+// account fingerprint it came from; readers use that to reject a capture that
+// belongs to a credential since rotated out from under this ID. A nil auth or
+// an auth with a blank ID is a no-op.
+func RecordAnthropicRateLimit(auth *cliproxyauth.Auth, headers http.Header, now time.Time) {
+	if auth == nil || headers == nil {
+		return
+	}
+	authID := strings.TrimSpace(auth.ID)
+	if authID == "" {
 		return
 	}
 
 	raw := make(map[string]string)
 	windows := make(map[string]cliproxyauth.AnthropicQuotaWindow)
 	hint := cliproxyauth.AnthropicRateLimitHint{
-		ObservedAt: now,
+		ObservedAt:         now,
+		AccountFingerprint: cliproxyauth.AnthropicAccountFingerprint(auth),
 	}
 
 	for canonicalName, values := range headers {
@@ -142,7 +151,10 @@ func recordAnthropicRateLimitField(
 		hint.Reset = parseAnthropicEpochSeconds(value)
 		return
 	case "fallback-percentage":
-		hint.FallbackPercentage = parseAnthropicFloat(value)
+		if f, ok := parseAnthropicFloat(value); ok {
+			hint.FallbackPercentage = f
+			hint.HasFallbackPercentage = true
+		}
 		return
 	case "overage-status":
 		hint.OverageStatus = value
@@ -183,17 +195,20 @@ func recordAnthropicRateLimitField(
 		case "-reset":
 			window.Reset = parseAnthropicEpochSeconds(value)
 		case "-utilization":
-			window.Utilization = parseAnthropicFloat(value)
-			// Tag presence so the serializer can omit the field when the
-			// upstream response had no utilization signal at all (vs. an
-			// explicit 0.0 reading). Stays true even when parseAnthropicFloat
-			// falls back to 0 on a malformed value: the operator-visible
-			// signal is still "Anthropic shipped this header", and 0 is the
-			// safest fallback consistent with how status/reset behave on
-			// malformed input.
-			window.HasUtilization = true
+			// Tag presence so a consumer can tell an explicit 0.0 reading from
+			// no utilization signal at all. Set only when the value actually
+			// parses: a malformed header would otherwise be published as a
+			// healthy 0.0, which is the reading an operator is least able to
+			// question. Malformed values stay visible in RawHeaders.
+			if f, ok := parseAnthropicFloat(value); ok {
+				window.Utilization = f
+				window.HasUtilization = true
+			}
 		case "-surpassed-threshold":
-			window.SurpassedThreshold = parseAnthropicFloat(value)
+			if f, ok := parseAnthropicFloat(value); ok {
+				window.SurpassedThreshold = f
+				window.HasSurpassedThreshold = true
+			}
 		}
 		windows[slug] = window
 		return
@@ -233,17 +248,17 @@ func parseAnthropicEpochSeconds(s string) time.Time {
 // breaks downstream JSON serialization and any consumer arithmetic. Callers
 // should not special-case 0 as "missing"; use the parent struct's presence
 // to disambiguate.
-func parseAnthropicFloat(s string) float64 {
+func parseAnthropicFloat(s string) (float64, bool) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return 0
+		return 0, false
 	}
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
-		return 0
+		return 0, false
 	}
 	if math.IsNaN(f) || math.IsInf(f, 0) {
-		return 0
+		return 0, false
 	}
-	return f
+	return f, true
 }

--- a/internal/runtime/executor/helps/claude_rate_limit_record.go
+++ b/internal/runtime/executor/helps/claude_rate_limit_record.go
@@ -49,16 +49,25 @@ var anthropicWindowSlugPattern = regexp.MustCompile(`^\d+[hd](?:_[a-z_]+)?$`)
 // reported in NousResearch/hermes-agent#17169), the hint store is left
 // untouched — any prior hint stays put rather than being overwritten with
 // empty state.
-func RecordAnthropicRateLimit(authID string, headers http.Header, now time.Time) {
-	authID = strings.TrimSpace(authID)
-	if authID == "" || headers == nil {
+//
+// Takes the auth rather than a bare ID so the capture can be tagged with the
+// account fingerprint it came from; readers use that to reject a capture that
+// belongs to a credential since rotated out from under this ID. A nil auth or
+// an auth with a blank ID is a no-op.
+func RecordAnthropicRateLimit(auth *cliproxyauth.Auth, headers http.Header, now time.Time) {
+	if auth == nil || headers == nil {
+		return
+	}
+	authID := strings.TrimSpace(auth.ID)
+	if authID == "" {
 		return
 	}
 
 	raw := make(map[string]string)
 	windows := make(map[string]cliproxyauth.AnthropicQuotaWindow)
 	hint := cliproxyauth.AnthropicRateLimitHint{
-		ObservedAt: now,
+		ObservedAt:         now,
+		AccountFingerprint: cliproxyauth.AnthropicAccountFingerprint(auth),
 	}
 
 	for canonicalName, values := range headers {

--- a/internal/runtime/executor/helps/claude_rate_limit_record.go
+++ b/internal/runtime/executor/helps/claude_rate_limit_record.go
@@ -1,0 +1,213 @@
+package helps
+
+import (
+	"math"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+const anthropicRateLimitHeaderPrefix = "anthropic-ratelimit-unified-"
+
+// Per-window field suffixes, ordered longest-first so that `-status` does not
+// preempt `-surpassed-threshold` during suffix matching.
+var anthropicPerWindowFieldSuffixes = []string{
+	"-surpassed-threshold",
+	"-utilization",
+	"-status",
+	"-reset",
+}
+
+// anthropicWindowSlugPattern constrains the per-window fallback to slugs that
+// actually look like quota-window identifiers: <digits><h|d> with an optional
+// `_<lowercase_word>` tier suffix (e.g. "5h", "7d", "7d_opus", "7d_sonnet").
+//
+// Without this gate, any future top-level header ending in one of the field
+// suffixes (for example `unified-overage-reset` or a hypothetical
+// `unified-foo-status`) would be misparsed into a synthetic windows[slug]
+// entry, corrupting the structured rate_limit.windows view that management
+// consumers depend on. Headers that fail this check stay raw-only — they are
+// already captured upstream into RawHeaders, which is the forward-compat
+// safety net for schema drift.
+var anthropicWindowSlugPattern = regexp.MustCompile(`^\d+[hd](?:_[a-z_]+)?$`)
+
+// RecordAnthropicRateLimit extracts the `anthropic-ratelimit-unified-*` family
+// from an upstream Anthropic response and stashes the parsed state on the auth
+// hint store (sdk/cliproxy/auth.SetAnthropicRateLimitHint).
+//
+// Called from the Claude executor after each upstream round-trip, regardless of
+// status code. Pure passive observability — no error is returned, no routing
+// behavior changes. The conductor and selector continue to consult Auth.Quota
+// and Auth.NextRetryAfter exclusively for routing decisions.
+//
+// If the response carries no `unified-*` headers (raw API-key traffic, a
+// response from a non-subscription endpoint, or the no-headers 429 regression
+// reported in NousResearch/hermes-agent#17169), the hint store is left
+// untouched — any prior hint stays put rather than being overwritten with
+// empty state.
+func RecordAnthropicRateLimit(authID string, headers http.Header, now time.Time) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" || headers == nil {
+		return
+	}
+
+	raw := make(map[string]string)
+	windows := make(map[string]cliproxyauth.AnthropicQuotaWindow)
+	hint := cliproxyauth.AnthropicRateLimitHint{
+		ObservedAt: now,
+	}
+
+	for canonicalName, values := range headers {
+		if len(values) == 0 {
+			continue
+		}
+		lower := strings.ToLower(canonicalName)
+		if !strings.HasPrefix(lower, anthropicRateLimitHeaderPrefix) {
+			continue
+		}
+		value := values[0]
+		raw[lower] = value
+		suffix := strings.TrimPrefix(lower, anthropicRateLimitHeaderPrefix)
+		recordAnthropicRateLimitField(&hint, windows, suffix, value)
+	}
+
+	// No `unified-*` headers seen anywhere; leave any prior hint intact.
+	// We commit a hint only when the upstream response actually carried our
+	// signal — the alternative (overwrite with empty state on every claude
+	// response) would erase prior captures whenever a non-Anthropic-shaped
+	// reply slipped through this executor or the family was stripped from a
+	// 429 response (cf. NousResearch/hermes-agent#17169).
+	if len(raw) == 0 {
+		return
+	}
+
+	hint.Known = true
+	hint.RawHeaders = raw
+	if len(windows) > 0 {
+		hint.Windows = windows
+	}
+	cliproxyauth.SetAnthropicRateLimitHint(authID, hint)
+}
+
+// recordAnthropicRateLimitField routes a single header (already stripped of
+// the `anthropic-ratelimit-unified-` prefix) into either a top-level hint slot
+// or a per-window slot. Unknown suffixes are silently ignored at this layer;
+// they remain accessible via the parent hint's RawHeaders map.
+func recordAnthropicRateLimitField(
+	hint *cliproxyauth.AnthropicRateLimitHint,
+	windows map[string]cliproxyauth.AnthropicQuotaWindow,
+	suffix, value string,
+) {
+	switch suffix {
+	case "status":
+		hint.Status = value
+		return
+	case "representative-claim":
+		hint.RepresentativeClaim = value
+		return
+	case "reset":
+		hint.Reset = parseAnthropicEpochSeconds(value)
+		return
+	case "fallback-percentage":
+		hint.FallbackPercentage = parseAnthropicFloat(value)
+		return
+	case "overage-status":
+		hint.OverageStatus = value
+		return
+	case "overage-disabled-reason":
+		hint.OverageDisabledReason = value
+		return
+	case "upgrade-paths":
+		hint.UpgradePaths = value
+		return
+	}
+
+	for _, fieldSuffix := range anthropicPerWindowFieldSuffixes {
+		if !strings.HasSuffix(suffix, fieldSuffix) {
+			continue
+		}
+		slug := strings.TrimSuffix(suffix, fieldSuffix)
+		if slug == "" || !anthropicWindowSlugPattern.MatchString(slug) {
+			// Looks like a per-window suffix but slug doesn't match the
+			// window-slug pattern — likely a future top-level field
+			// (e.g. unified-overage-reset → slug "overage"). Leave it in
+			// RawHeaders (already captured upstream) and skip structured
+			// parsing. Fail-open to RawHeaders preserves the
+			// forward-compat safety net for schema drift.
+			return
+		}
+		window := windows[slug]
+		switch fieldSuffix {
+		case "-status":
+			window.Status = value
+		case "-reset":
+			window.Reset = parseAnthropicEpochSeconds(value)
+		case "-utilization":
+			window.Utilization = parseAnthropicFloat(value)
+			// Tag presence so the serializer can omit the field when the
+			// upstream response had no utilization signal at all (vs. an
+			// explicit 0.0 reading). Stays true even when parseAnthropicFloat
+			// falls back to 0 on a malformed value: the operator-visible
+			// signal is still "Anthropic shipped this header", and 0 is the
+			// safest fallback consistent with how status/reset behave on
+			// malformed input.
+			window.HasUtilization = true
+		case "-surpassed-threshold":
+			window.SurpassedThreshold = parseAnthropicFloat(value)
+		}
+		windows[slug] = window
+		return
+	}
+}
+
+// parseAnthropicEpochSeconds parses an epoch-seconds header value (Anthropic's
+// `reset` field format) into UTC time.Time. Returns the zero time on any parse
+// failure — callers should treat zero as "unknown" via .IsZero().
+//
+// Epoch values that fall outside the year range [0001, 9999] are also rejected
+// (returns zero). time.Time.MarshalJSON refuses to serialize times outside that
+// range, so a malicious upstream sending e.g. `99999999999999` would otherwise
+// stash a year-5138+ timestamp on the auth hint and crash any management
+// endpoint that JSON-marshals the AnthropicRateLimitHint.
+func parseAnthropicEpochSeconds(s string) time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	// JSON-serializable epoch range: [0001-01-01T00:00:00Z, 9999-12-31T23:59:59Z].
+	const minEpoch = -62135596800
+	const maxEpoch = 253402300799
+	if n < minEpoch || n > maxEpoch {
+		return time.Time{}
+	}
+	return time.Unix(n, 0).UTC()
+}
+
+// parseAnthropicFloat parses a float header value (utilization, threshold,
+// fallback-percentage). Returns 0 on parse failure or for non-finite values
+// (NaN, ±Inf) — strconv.ParseFloat accepts those literals, but storing them
+// breaks downstream JSON serialization and any consumer arithmetic. Callers
+// should not special-case 0 as "missing"; use the parent struct's presence
+// to disambiguate.
+func parseAnthropicFloat(s string) float64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0
+	}
+	return f
+}

--- a/internal/runtime/executor/helps/claude_rate_limit_record_test.go
+++ b/internal/runtime/executor/helps/claude_rate_limit_record_test.go
@@ -1,6 +1,7 @@
 package helps
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,6 +19,22 @@ func resetAnthropicHint(t *testing.T, authID string) {
 	t.Cleanup(func() {
 		cliproxyauth.DeleteAnthropicRateLimitHint(authID)
 	})
+}
+
+// testAuth builds the minimal OAuth auth the capture path needs: an ID to key
+// the store by, and an email so AnthropicAccountFingerprint resolves to a
+// stable non-empty value. Tests that care about account identity pass an
+// explicit email; the rest reuse the authID.
+func testAuth(authID string) *cliproxyauth.Auth {
+	return testAuthWithEmail(authID, authID)
+}
+
+func testAuthWithEmail(authID, email string) *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{
+		ID:       authID,
+		Provider: "claude",
+		Metadata: map[string]any{"email": email},
+	}
 }
 
 // fixturePinnedNow is when the captured fixtures were observed. Pinning keeps
@@ -108,7 +125,7 @@ func TestRecordAnthropicRateLimit_Typical200(t *testing.T) {
 	resetAnthropicHint(t, authID)
 
 	now := fixturePinnedNow()
-	RecordAnthropicRateLimit(authID, realCapture200Allowed(), now)
+	RecordAnthropicRateLimit(testAuth(authID), realCapture200Allowed(), now)
 
 	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok || !hint.Known {
@@ -179,7 +196,7 @@ func TestRecordAnthropicRateLimit_GenerativeTierWindow(t *testing.T) {
 	const authID = "claude-test-tier-window@example.com"
 	resetAnthropicHint(t, authID)
 
-	RecordAnthropicRateLimit(authID, realCapture200WarningWithTierWindow(), fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), realCapture200WarningWithTierWindow(), fixturePinnedNow())
 
 	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if hint.Status != "allowed_warning" {
@@ -224,7 +241,7 @@ func TestRecordAnthropicRateLimit_429Rejected(t *testing.T) {
 	const authID = "claude-test-429-rejected@example.com"
 	resetAnthropicHint(t, authID)
 
-	RecordAnthropicRateLimit(authID, realCapture429Rejected(), fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), realCapture429Rejected(), fixturePinnedNow())
 
 	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok || !hint.Known {
@@ -266,7 +283,7 @@ func TestRecordAnthropicRateLimit_NoUnifiedHeaders(t *testing.T) {
 		"Content-Type": {"application/json"},
 		"Retry-After":  {"60"},
 	}
-	RecordAnthropicRateLimit(authID, headersWithoutFamily, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headersWithoutFamily, fixturePinnedNow())
 
 	got, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok {
@@ -295,7 +312,7 @@ func TestRecordAnthropicRateLimit_HeadersWithoutUnifiedStatus(t *testing.T) {
 		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
 		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok || !hint.Known {
@@ -320,7 +337,7 @@ func TestRecordAnthropicRateLimit_NilHeadersNoop(t *testing.T) {
 	const authID = "claude-test-nil-headers@example.com"
 	resetAnthropicHint(t, authID)
 
-	RecordAnthropicRateLimit(authID, nil, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), nil, fixturePinnedNow())
 
 	if _, ok := cliproxyauth.GetAnthropicRateLimitHint(authID); ok {
 		t.Fatal("nil headers should not create a hint")
@@ -328,9 +345,23 @@ func TestRecordAnthropicRateLimit_NilHeadersNoop(t *testing.T) {
 }
 
 func TestRecordAnthropicRateLimit_EmptyAuthIDNoop(t *testing.T) {
-	RecordAnthropicRateLimit("", realCapture200Allowed(), fixturePinnedNow())
-	RecordAnthropicRateLimit("   ", realCapture200Allowed(), fixturePinnedNow())
-	// Assertion: doesn't panic, doesn't pollute the hint store.
+	RecordAnthropicRateLimit(testAuth(""), realCapture200Allowed(), fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth("   "), realCapture200Allowed(), fixturePinnedNow())
+
+	// Assert the no-op rather than only relying on the absence of a panic:
+	// a blank ID must not seed an entry that a later blank-ID read returns.
+	for _, id := range []string{"", "   "} {
+		if _, ok := cliproxyauth.GetAnthropicRateLimitHint(id); ok {
+			t.Errorf("a blank auth ID (%q) seeded the hint store", id)
+		}
+	}
+}
+
+// The parameter is unused on purpose: the assertion here is that the call does
+// not panic, which the test framework reports without any explicit check. The
+// executor call sites nil-check auth today, but the helper must not rely on it.
+func TestRecordAnthropicRateLimit_NilAuthNoop(_ *testing.T) {
+	RecordAnthropicRateLimit(nil, realCapture200Allowed(), fixturePinnedNow())
 }
 
 func TestRecordAnthropicRateLimit_MalformedNumericsAreTolerated(t *testing.T) {
@@ -346,7 +377,7 @@ func TestRecordAnthropicRateLimit_MalformedNumericsAreTolerated(t *testing.T) {
 		"Anthropic-Ratelimit-Unified-Fallback-Percentage":  {""},
 		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if hint.Status != "allowed" {
@@ -380,8 +411,8 @@ func TestRecordAnthropicRateLimit_OverwritesPriorHint(t *testing.T) {
 	const authID = "claude-test-overwrite@example.com"
 	resetAnthropicHint(t, authID)
 
-	RecordAnthropicRateLimit(authID, realCapture200Allowed(), fixturePinnedNow())
-	RecordAnthropicRateLimit(authID, realCapture429Rejected(), fixturePinnedNow().Add(time.Minute))
+	RecordAnthropicRateLimit(testAuth(authID), realCapture200Allowed(), fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), realCapture429Rejected(), fixturePinnedNow().Add(time.Minute))
 
 	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if hint.Status != "rejected" {
@@ -402,7 +433,7 @@ func TestRecordAnthropicRateLimit_UnknownFieldGoesToRawHeadersOnly(t *testing.T)
 		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
 		"Anthropic-Ratelimit-Unified-Future-Field-Type-X":  {"someValue"}, // not a known top-level or per-window suffix
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if got := hint.RawHeaders["anthropic-ratelimit-unified-future-field-type-x"]; got != "someValue" {
@@ -438,7 +469,7 @@ func TestRecordAnthropicRateLimit_UnknownTopLevelDoesNotFabricateWindow(t *testi
 		"Anthropic-Ratelimit-Unified-Bar-Utilization":         {"0.42"},
 		"Anthropic-Ratelimit-Unified-Baz-Surpassed-Threshold": {"0.9"},
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok || !hint.Known {
@@ -494,7 +525,7 @@ func TestRecordAnthropicRateLimit_FutureTierWindowsAccepted(t *testing.T) {
 		"Anthropic-Ratelimit-Unified-7d_haiku-Utilization": {"0.8"},
 		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	wantWindows := map[string]float64{
@@ -545,7 +576,7 @@ func TestRecordAnthropicRateLimit_HasUtilizationDistinguishesAbsentFromZero(t *t
 		"Anthropic-Ratelimit-Unified-7d-Status": {"allowed"},
 		"Anthropic-Ratelimit-Unified-7d-Reset":  {"1777561200"},
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok || !hint.Known {
@@ -603,31 +634,101 @@ func TestParseAnthropicEpochSeconds(t *testing.T) {
 
 func TestParseAnthropicFloat(t *testing.T) {
 	tests := []struct {
-		in   string
-		want float64
+		in     string
+		want   float64
+		wantOK bool
 	}{
-		{"0.5", 0.5},
-		{"1.13", 1.13},
-		{"0.0", 0},
-		{"  0.5  ", 0.5},
-		{"", 0},
-		{"not-a-number", 0},
+		{"0.5", 0.5, true},
+		{"1.13", 1.13, true},
+		// An explicit zero is a real reading and must report ok, so a consumer
+		// can tell it apart from absent and from malformed.
+		{"0.0", 0, true},
+		{"  0.5  ", 0.5, true},
+		{"", 0, false},
+		{"not-a-number", 0, false},
 		// Non-finite values: strconv.ParseFloat accepts these literals
 		// without error, but they break downstream JSON serialization and
 		// any consumer arithmetic (NaN comparisons, Inf accumulation).
 		// Treat as parse failure.
-		{"NaN", 0},
-		{"nan", 0},
-		{"Inf", 0},
-		{"+Inf", 0},
-		{"-Inf", 0},
-		{"infinity", 0},
+		{"NaN", 0, false},
+		{"nan", 0, false},
+		{"Inf", 0, false},
+		{"+Inf", 0, false},
+		{"-Inf", 0, false},
+		{"infinity", 0, false},
 	}
 	for _, tc := range tests {
-		got := parseAnthropicFloat(tc.in)
-		if got != tc.want {
-			t.Errorf("parseAnthropicFloat(%q)=%v want %v", tc.in, got, tc.want)
+		got, ok := parseAnthropicFloat(tc.in)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("parseAnthropicFloat(%q)=(%v,%v) want (%v,%v)", tc.in, got, ok, tc.want, tc.wantOK)
 		}
+	}
+}
+
+// TestRecordAnthropicRateLimit_SurvivesTokenRefreshButNotRotation is the
+// end-to-end guard over the capture → lifecycle → read path, exercised through
+// a real Manager rather than by poking the store directly.
+//
+// Both halves were live defects at some point in this feature's history: an
+// unconditional scrub in Manager.Update destroyed valid quota state on every
+// routine token refresh, and before the account fingerprint existed a capture
+// could outlive the credential it described.
+func TestRecordAnthropicRateLimit_SurvivesTokenRefreshButNotRotation(t *testing.T) {
+	const authID = "claude-e2e-refresh-vs-rotation@example.com"
+	resetAnthropicHint(t, authID)
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	ctx := context.Background()
+
+	original := testAuthWithEmail(authID, "account-one@example.com")
+	if _, err := manager.Register(ctx, original); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	// A Claude response lands and is captured.
+	RecordAnthropicRateLimit(original, realCapture200WarningWithTierWindow(), fixturePinnedNow())
+	if _, ok := cliproxyauth.AnthropicRateLimitHintFor(original); !ok {
+		t.Fatal("precondition: capture should be readable")
+	}
+
+	// Routine OAuth token refresh: same account, new access token.
+	refreshed := testAuthWithEmail(authID, "account-one@example.com")
+	refreshed.Metadata["access_token"] = "refreshed-token"
+	if _, err := manager.Update(ctx, refreshed); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	hint, ok := cliproxyauth.AnthropicRateLimitHintFor(refreshed)
+	if !ok {
+		t.Fatal("quota state must survive a routine token refresh")
+	}
+	if hint.Status != "allowed_warning" {
+		t.Errorf("Status=%q want %q after refresh", hint.Status, "allowed_warning")
+	}
+
+	// Rotation to a different account under the same auth ID.
+	rotated := testAuthWithEmail(authID, "account-two@example.com")
+	if _, err := manager.Update(ctx, rotated); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if _, ok := cliproxyauth.AnthropicRateLimitHintFor(rotated); ok {
+		t.Fatal("the previous account's quota must not be served after rotation")
+	}
+
+	// A capture still in flight when the rotation happened lands late, tagged
+	// with the old account. It must not resurrect the old quota.
+	RecordAnthropicRateLimit(original, realCapture429Rejected(), fixturePinnedNow().Add(time.Second))
+	if _, ok := cliproxyauth.AnthropicRateLimitHintFor(rotated); ok {
+		t.Fatal("a late capture from the previous account must not be served to the rotated auth")
+	}
+
+	// And the rotated account's own capture is served normally.
+	RecordAnthropicRateLimit(rotated, realCapture200Allowed(), fixturePinnedNow().Add(2*time.Second))
+	hint, ok = cliproxyauth.AnthropicRateLimitHintFor(rotated)
+	if !ok {
+		t.Fatal("the rotated account must see its own capture")
+	}
+	if hint.Status != "allowed" {
+		t.Errorf("Status=%q want %q for the rotated account", hint.Status, "allowed")
 	}
 }
 
@@ -652,7 +753,7 @@ func TestRecordAnthropicRateLimit_RetentionBudget(t *testing.T) {
 	// An oversized value on a header that is within the count budget.
 	headers.Set("Anthropic-Ratelimit-Unified-Status", strings.Repeat("x", maxAnthropicHeaderValLen*3))
 
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok {
@@ -682,7 +783,7 @@ func TestRecordAnthropicRateLimit_BudgetDoesNotTruncateRealCaptures(t *testing.T
 			authID := "auth-budget-headroom-" + name
 			resetAnthropicHint(t, authID)
 
-			RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+			RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 			hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 			if !ok {

--- a/internal/runtime/executor/helps/claude_rate_limit_record_test.go
+++ b/internal/runtime/executor/helps/claude_rate_limit_record_test.go
@@ -801,3 +801,64 @@ func TestRecordAnthropicRateLimit_BudgetDoesNotTruncateRealCaptures(t *testing.T
 		})
 	}
 }
+
+// TestRecordAnthropicRateLimit_MalformedWindowDoesNotDisplaceCarried drives the
+// content-free-window case end to end, through the parser that creates it.
+//
+// A slug is seeded as soon as any header names it, so a response whose only
+// `7d_oi` header is an unparseable reset produces a zero-value entry for that
+// window. If the hint store treated that as a reported window it would both
+// destroy the rich reading captured moments earlier and — having no reset of
+// its own — be ineligible to be carried by anything afterwards, so the premium
+// window would stay gone until the next premium response.
+func TestRecordAnthropicRateLimit_MalformedWindowDoesNotDisplaceCarried(t *testing.T) {
+	const authID = "claude-malformed-window-carry@example.com"
+	resetAnthropicHint(t, authID)
+	auth := testAuth(authID)
+
+	premiumAt := fixturePinnedNow()
+	ordinaryAt := premiumAt.Add(4 * time.Minute)
+	oiReset := premiumAt.Add(30 * time.Hour)
+
+	premium := http.Header{
+		"Anthropic-Ratelimit-Unified-Status":            {"allowed_warning"},
+		"Anthropic-Ratelimit-Unified-5h-Status":         {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":          {strconv.FormatInt(premiumAt.Add(2*time.Hour).Unix(), 10)},
+		"Anthropic-Ratelimit-Unified-7d_oi-Status":      {"allowed_warning"},
+		"Anthropic-Ratelimit-Unified-7d_oi-Reset":       {strconv.FormatInt(oiReset.Unix(), 10)},
+		"Anthropic-Ratelimit-Unified-7d_oi-Utilization": {"0.88"},
+	}
+	RecordAnthropicRateLimit(auth, premium, premiumAt)
+
+	// The next response mentions 7d_oi only through a header that cannot be
+	// parsed, which is exactly how a zero-value window entry gets created.
+	ordinary := http.Header{
+		"Anthropic-Ratelimit-Unified-Status":      {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Status":   {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":    {strconv.FormatInt(ordinaryAt.Add(2*time.Hour).Unix(), 10)},
+		"Anthropic-Ratelimit-Unified-7d_oi-Reset": {"garbage"},
+	}
+	RecordAnthropicRateLimit(auth, ordinary, ordinaryAt)
+
+	hint, ok := cliproxyauth.AnthropicRateLimitHintFor(auth)
+	if !ok {
+		t.Fatal("AnthropicRateLimitHintFor() ok = false, want true")
+	}
+	oi, ok := hint.Windows["7d_oi"]
+	if !ok {
+		t.Fatal("7d_oi missing after a capture whose only 7d_oi header was malformed")
+	}
+	if oi.Utilization != 0.88 || !oi.HasUtilization || oi.Status != "allowed_warning" {
+		t.Errorf("7d_oi = %+v, want the premium capture's reading preserved", oi)
+	}
+	if !oi.Reset.Equal(oiReset) {
+		t.Errorf("7d_oi reset = %v, want %v", oi.Reset, oiReset)
+	}
+	if !oi.ObservedAt.Equal(premiumAt) {
+		t.Errorf("7d_oi ObservedAt = %v, want %v — the surviving reading is the carried one", oi.ObservedAt, premiumAt)
+	}
+	// The malformed header itself stays visible for forensics.
+	if got := hint.RawHeaders["anthropic-ratelimit-unified-7d_oi-reset"]; got != "garbage" {
+		t.Errorf("raw_headers lost the malformed value: %q", got)
+	}
+}

--- a/internal/runtime/executor/helps/claude_rate_limit_record_test.go
+++ b/internal/runtime/executor/helps/claude_rate_limit_record_test.go
@@ -1,0 +1,702 @@
+package helps
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// resetAnthropicHint clears any prior hint for an authID so each test runs
+// against a clean slate. The hint store is package-global; tests share it.
+func resetAnthropicHint(t *testing.T, authID string) {
+	t.Helper()
+	cliproxyauth.DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() {
+		cliproxyauth.DeleteAnthropicRateLimitHint(authID)
+	})
+}
+
+// fixturePinnedNow is when the captured fixtures were observed. Pinning keeps
+// time-dependent assertions deterministic.
+//
+// Captured 2026-04-29 from real api.anthropic.com /v1/messages traffic;
+// 1777408679 is the earliest sample's `ts`.
+func fixturePinnedNow() time.Time {
+	return time.Unix(1777408679, 0).UTC()
+}
+
+// realCapture200Allowed mirrors the most common /v1/messages 200 response on a
+// healthy subscription — `unified-status: allowed`, both 5h and 7d at 0.0
+// utilization, no surpassed-threshold, no upgrade-paths.
+//
+// Source: ~/.cache/claude-rate-limits.jsonl ts=1777482383.7548852.
+func realCapture200Allowed() http.Header {
+	return http.Header{
+		"Anthropic-Ratelimit-Unified-Status":                  {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":                {"1777500000"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":          {"0.0"},
+		"Anthropic-Ratelimit-Unified-7d-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-7d-Reset":                {"1777561200"},
+		"Anthropic-Ratelimit-Unified-7d-Utilization":          {"0.0"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim":    {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Fallback-Percentage":     {"0.5"},
+		"Anthropic-Ratelimit-Unified-Reset":                   {"1777500000"},
+		"Anthropic-Ratelimit-Unified-Overage-Disabled-Reason": {"org_level_disabled"},
+		"Anthropic-Ratelimit-Unified-Overage-Status":          {"rejected"},
+	}
+}
+
+// realCapture200WarningWithTierWindow mirrors a 200 response where the 7d
+// window is past the 0.75 surpassed-threshold AND a tier-specific 7d_sonnet
+// window is reported alongside the family 7d window. This is the "generative
+// windows map" load-bearing case — `7d_sonnet` is not a hard-coded enum value.
+//
+// Source: ~/.cache/claude-rate-limits.jsonl ts=1777413065.625119.
+func realCapture200WarningWithTierWindow() http.Header {
+	return http.Header{
+		"Anthropic-Ratelimit-Unified-Status":                  {"allowed_warning"},
+		"Anthropic-Ratelimit-Unified-5h-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":                {"1777420800"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":          {"0.35"},
+		"Anthropic-Ratelimit-Unified-7d-Status":               {"allowed_warning"},
+		"Anthropic-Ratelimit-Unified-7d-Reset":                {"1777575600"},
+		"Anthropic-Ratelimit-Unified-7d-Utilization":          {"0.85"},
+		"Anthropic-Ratelimit-Unified-7d-Surpassed-Threshold":  {"0.75"},
+		"Anthropic-Ratelimit-Unified-7d_sonnet-Status":        {"allowed"},
+		"Anthropic-Ratelimit-Unified-7d_sonnet-Reset":         {"1777575600"},
+		"Anthropic-Ratelimit-Unified-7d_sonnet-Utilization":   {"0.07"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim":    {"seven_day"},
+		"Anthropic-Ratelimit-Unified-Fallback-Percentage":     {"0.5"},
+		"Anthropic-Ratelimit-Unified-Reset":                   {"1777575600"},
+		"Anthropic-Ratelimit-Unified-Overage-Disabled-Reason": {"org_level_disabled_until"},
+		"Anthropic-Ratelimit-Unified-Overage-Status":          {"rejected"},
+	}
+}
+
+// realCapture429Rejected mirrors a 429 response where the 5h window is past
+// 1.0 utilization (overage is permitted but `overage-status: rejected` means
+// the org has it disabled). Includes `upgrade-paths`, which is observed only
+// at 429 / near-cap.
+//
+// Source: ~/.cache/claude-rate-limits.jsonl ts=1777482352.032908.
+func realCapture429Rejected() http.Header {
+	return http.Header{
+		"Anthropic-Ratelimit-Unified-Status":                  {"rejected"},
+		"Anthropic-Ratelimit-Unified-5h-Status":               {"rejected"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":                {"1777500000"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":          {"1.13"},
+		"Anthropic-Ratelimit-Unified-5h-Surpassed-Threshold":  {"1.0"},
+		"Anthropic-Ratelimit-Unified-7d-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-7d-Reset":                {"1777561200"},
+		"Anthropic-Ratelimit-Unified-7d-Utilization":          {"0.09"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim":    {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Fallback-Percentage":     {"0.5"},
+		"Anthropic-Ratelimit-Unified-Reset":                   {"1777500000"},
+		"Anthropic-Ratelimit-Unified-Overage-Disabled-Reason": {"org_level_disabled"},
+		"Anthropic-Ratelimit-Unified-Overage-Status":          {"rejected"},
+		"Anthropic-Ratelimit-Unified-Upgrade-Paths":           {"upgrade_plan"},
+	}
+}
+
+func TestRecordAnthropicRateLimit_Typical200(t *testing.T) {
+	const authID = "claude-test-200-allowed@example.com"
+	resetAnthropicHint(t, authID)
+
+	now := fixturePinnedNow()
+	RecordAnthropicRateLimit(authID, realCapture200Allowed(), now)
+
+	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok || !hint.Known {
+		t.Fatalf("expected hint to be set with Known=true after typical 200")
+	}
+	if hint.Status != "allowed" {
+		t.Errorf("Status=%q want %q", hint.Status, "allowed")
+	}
+	if hint.RepresentativeClaim != "five_hour" {
+		t.Errorf("RepresentativeClaim=%q want %q", hint.RepresentativeClaim, "five_hour")
+	}
+	if want := time.Unix(1777500000, 0).UTC(); !hint.Reset.Equal(want) {
+		t.Errorf("Reset=%v want %v", hint.Reset, want)
+	}
+	if hint.FallbackPercentage != 0.5 {
+		t.Errorf("FallbackPercentage=%v want 0.5", hint.FallbackPercentage)
+	}
+	if hint.OverageStatus != "rejected" {
+		t.Errorf("OverageStatus=%q want %q", hint.OverageStatus, "rejected")
+	}
+	if hint.OverageDisabledReason != "org_level_disabled" {
+		t.Errorf("OverageDisabledReason=%q want %q", hint.OverageDisabledReason, "org_level_disabled")
+	}
+	if hint.UpgradePaths != "" {
+		t.Errorf("UpgradePaths should be empty when absent, got %q", hint.UpgradePaths)
+	}
+	if !hint.ObservedAt.Equal(now) {
+		t.Errorf("ObservedAt=%v want %v", hint.ObservedAt, now)
+	}
+
+	if len(hint.Windows) != 2 {
+		t.Fatalf("expected 2 windows (5h, 7d), got %d: %v", len(hint.Windows), hint.Windows)
+	}
+	if w, ok := hint.Windows["5h"]; !ok {
+		t.Errorf("missing 5h window")
+	} else {
+		if w.Status != "allowed" {
+			t.Errorf("5h.Status=%q", w.Status)
+		}
+		if w.Utilization != 0.0 {
+			t.Errorf("5h.Utilization=%v", w.Utilization)
+		}
+		if !w.HasUtilization {
+			t.Errorf("5h.HasUtilization=false want true (header was present with value 0.0)")
+		}
+		if w.SurpassedThreshold != 0 {
+			t.Errorf("5h.SurpassedThreshold=%v want 0 (absent)", w.SurpassedThreshold)
+		}
+	}
+	if w, ok := hint.Windows["7d"]; !ok {
+		t.Errorf("missing 7d window")
+	} else {
+		if !w.Reset.Equal(time.Unix(1777561200, 0).UTC()) {
+			t.Errorf("7d.Reset=%v", w.Reset)
+		}
+	}
+
+	// raw_headers should preserve every observed unified-* header verbatim.
+	if got := hint.RawHeaders["anthropic-ratelimit-unified-5h-utilization"]; got != "0.0" {
+		t.Errorf("raw_headers[5h-utilization]=%q want %q", got, "0.0")
+	}
+	if len(hint.RawHeaders) != 12 {
+		t.Errorf("expected 12 raw headers, got %d: %v", len(hint.RawHeaders), hint.RawHeaders)
+	}
+}
+
+func TestRecordAnthropicRateLimit_GenerativeTierWindow(t *testing.T) {
+	const authID = "claude-test-tier-window@example.com"
+	resetAnthropicHint(t, authID)
+
+	RecordAnthropicRateLimit(authID, realCapture200WarningWithTierWindow(), fixturePinnedNow())
+
+	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if hint.Status != "allowed_warning" {
+		t.Fatalf("Status=%q want %q", hint.Status, "allowed_warning")
+	}
+	if hint.RepresentativeClaim != "seven_day" {
+		t.Fatalf("RepresentativeClaim=%q want %q", hint.RepresentativeClaim, "seven_day")
+	}
+	if hint.OverageDisabledReason != "org_level_disabled_until" {
+		t.Errorf("OverageDisabledReason=%q want %q", hint.OverageDisabledReason, "org_level_disabled_until")
+	}
+
+	// The load-bearing assertion: we captured a window we never declared
+	// statically. If this slug ever needs special-casing, the design has
+	// failed; it must remain pure pass-through.
+	if len(hint.Windows) != 3 {
+		t.Fatalf("expected 3 windows (5h, 7d, 7d_sonnet), got %d: %v", len(hint.Windows), hint.Windows)
+	}
+	tier, ok := hint.Windows["7d_sonnet"]
+	if !ok {
+		t.Fatalf("missing 7d_sonnet window — generative-map design broken")
+	}
+	if tier.Utilization != 0.07 {
+		t.Errorf("7d_sonnet.Utilization=%v want 0.07", tier.Utilization)
+	}
+	if tier.Status != "allowed" {
+		t.Errorf("7d_sonnet.Status=%q want %q", tier.Status, "allowed")
+	}
+
+	// Surpassed-threshold should attach to the 7d window (where it was sent),
+	// NOT to 7d_sonnet (which has no -surpassed-threshold header).
+	if hint.Windows["7d"].SurpassedThreshold != 0.75 {
+		t.Errorf("7d.SurpassedThreshold=%v want 0.75", hint.Windows["7d"].SurpassedThreshold)
+	}
+	if hint.Windows["7d_sonnet"].SurpassedThreshold != 0 {
+		t.Errorf("7d_sonnet.SurpassedThreshold should be 0 (absent), got %v",
+			hint.Windows["7d_sonnet"].SurpassedThreshold)
+	}
+}
+
+func TestRecordAnthropicRateLimit_429Rejected(t *testing.T) {
+	const authID = "claude-test-429-rejected@example.com"
+	resetAnthropicHint(t, authID)
+
+	RecordAnthropicRateLimit(authID, realCapture429Rejected(), fixturePinnedNow())
+
+	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok || !hint.Known {
+		t.Fatal("expected hint Known after 429 — capture must run on errors too")
+	}
+	if hint.Status != "rejected" {
+		t.Errorf("Status=%q want %q", hint.Status, "rejected")
+	}
+	if hint.UpgradePaths != "upgrade_plan" {
+		t.Errorf("UpgradePaths=%q want %q (only present at/near-cap)", hint.UpgradePaths, "upgrade_plan")
+	}
+	w := hint.Windows["5h"]
+	if w.Utilization != 1.13 {
+		t.Errorf("5h.Utilization=%v want 1.13 (overage)", w.Utilization)
+	}
+	if w.SurpassedThreshold != 1.0 {
+		t.Errorf("5h.SurpassedThreshold=%v want 1.0", w.SurpassedThreshold)
+	}
+	if w.Status != "rejected" {
+		t.Errorf("5h.Status=%q want %q", w.Status, "rejected")
+	}
+}
+
+func TestRecordAnthropicRateLimit_NoUnifiedHeaders(t *testing.T) {
+	// Regression case: NousResearch/hermes-agent#17169 reports that some 429
+	// paths now ship without `unified-*` headers entirely. The capture must
+	// be a no-op in that case, leaving the prior hint untouched.
+	const authID = "claude-test-no-unified@example.com"
+	resetAnthropicHint(t, authID)
+
+	priorHint := cliproxyauth.AnthropicRateLimitHint{
+		Known:               true,
+		Status:              "allowed",
+		RepresentativeClaim: "five_hour",
+	}
+	cliproxyauth.SetAnthropicRateLimitHint(authID, priorHint)
+
+	headersWithoutFamily := http.Header{
+		"Content-Type": {"application/json"},
+		"Retry-After":  {"60"},
+	}
+	RecordAnthropicRateLimit(authID, headersWithoutFamily, fixturePinnedNow())
+
+	got, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("prior hint disappeared — capture should have been a no-op")
+	}
+	if got.Status != "allowed" || got.RepresentativeClaim != "five_hour" {
+		t.Fatalf("prior hint mutated: got=%+v", got)
+	}
+}
+
+// TestRecordAnthropicRateLimit_HeadersWithoutUnifiedStatus asserts that the
+// capture still records hints when the response carries other `unified-*`
+// fields but lacks `unified-status` specifically. Earlier drafts of this
+// function used `unified-status` as a probe to early-bail, which dropped data
+// in this case (raised by chatgpt-codex-connector on PR #3170). The current
+// implementation iterates every header before deciding whether to write.
+func TestRecordAnthropicRateLimit_HeadersWithoutUnifiedStatus(t *testing.T) {
+	const authID = "claude-test-no-unified-status@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		// `unified-status` deliberately absent.
+		"Anthropic-Ratelimit-Unified-5h-Status":            {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":             {"1777500000"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":       {"0.42"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok || !hint.Known {
+		t.Fatal("expected hint to be set even without unified-status header")
+	}
+	if hint.Status != "" {
+		t.Errorf("Status should be empty when header absent, got %q", hint.Status)
+	}
+	if hint.RepresentativeClaim != "five_hour" {
+		t.Errorf("RepresentativeClaim=%q want five_hour", hint.RepresentativeClaim)
+	}
+	w := hint.Windows["5h"]
+	if w.Utilization != 0.42 {
+		t.Errorf("5h.Utilization=%v want 0.42", w.Utilization)
+	}
+	if got := hint.RawHeaders["anthropic-ratelimit-unified-5h-utilization"]; got != "0.42" {
+		t.Errorf("raw_headers[5h-utilization]=%q want %q", got, "0.42")
+	}
+}
+
+func TestRecordAnthropicRateLimit_NilHeadersNoop(t *testing.T) {
+	const authID = "claude-test-nil-headers@example.com"
+	resetAnthropicHint(t, authID)
+
+	RecordAnthropicRateLimit(authID, nil, fixturePinnedNow())
+
+	if _, ok := cliproxyauth.GetAnthropicRateLimitHint(authID); ok {
+		t.Fatal("nil headers should not create a hint")
+	}
+}
+
+func TestRecordAnthropicRateLimit_EmptyAuthIDNoop(t *testing.T) {
+	RecordAnthropicRateLimit("", realCapture200Allowed(), fixturePinnedNow())
+	RecordAnthropicRateLimit("   ", realCapture200Allowed(), fixturePinnedNow())
+	// Assertion: doesn't panic, doesn't pollute the hint store.
+}
+
+func TestRecordAnthropicRateLimit_MalformedNumericsAreTolerated(t *testing.T) {
+	const authID = "claude-test-malformed@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Status":            {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":             {"not-a-number"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":       {"???"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Fallback-Percentage":  {""},
+		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if hint.Status != "allowed" {
+		t.Errorf("Status=%q (well-formed string field should still parse)", hint.Status)
+	}
+	if !hint.Reset.Equal(time.Unix(1777500000, 0).UTC()) {
+		t.Errorf("top-level Reset=%v (well-formed epoch should still parse)", hint.Reset)
+	}
+	w := hint.Windows["5h"]
+	if w.Status != "allowed" {
+		t.Errorf("5h.Status=%q (string field unaffected by neighbor's malformed value)", w.Status)
+	}
+	if !w.Reset.IsZero() {
+		t.Errorf("5h.Reset=%v want zero (malformed epoch falls back to zero)", w.Reset)
+	}
+	if w.Utilization != 0 {
+		t.Errorf("5h.Utilization=%v want 0 (malformed float falls back to zero)", w.Utilization)
+	}
+	if hint.FallbackPercentage != 0 {
+		t.Errorf("FallbackPercentage=%v want 0 (empty string falls back to zero)", hint.FallbackPercentage)
+	}
+
+	// Raw headers preserve the malformed strings verbatim — operators reading
+	// raw_headers can recover the original payload for debugging.
+	if got := hint.RawHeaders["anthropic-ratelimit-unified-5h-reset"]; got != "not-a-number" {
+		t.Errorf("raw_headers[5h-reset]=%q want %q", got, "not-a-number")
+	}
+}
+
+func TestRecordAnthropicRateLimit_OverwritesPriorHint(t *testing.T) {
+	const authID = "claude-test-overwrite@example.com"
+	resetAnthropicHint(t, authID)
+
+	RecordAnthropicRateLimit(authID, realCapture200Allowed(), fixturePinnedNow())
+	RecordAnthropicRateLimit(authID, realCapture429Rejected(), fixturePinnedNow().Add(time.Minute))
+
+	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if hint.Status != "rejected" {
+		t.Fatalf("expected last-seen 429 to overwrite prior 200; got Status=%q", hint.Status)
+	}
+	if hint.UpgradePaths != "upgrade_plan" {
+		t.Errorf("expected last-seen UpgradePaths to be present; got %q", hint.UpgradePaths)
+	}
+}
+
+func TestRecordAnthropicRateLimit_UnknownFieldGoesToRawHeadersOnly(t *testing.T) {
+	const authID = "claude-test-unknown-field@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
+		"Anthropic-Ratelimit-Unified-Future-Field-Type-X":  {"someValue"}, // not a known top-level or per-window suffix
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if got := hint.RawHeaders["anthropic-ratelimit-unified-future-field-type-x"]; got != "someValue" {
+		t.Errorf("unknown header should round-trip via raw_headers, got %q", got)
+	}
+	if hint.Status != "allowed" {
+		t.Errorf("known fields should still parse alongside unknowns; Status=%q", hint.Status)
+	}
+}
+
+// TestRecordAnthropicRateLimit_UnknownTopLevelDoesNotFabricateWindow asserts
+// that a future top-level header ending in a per-window field suffix
+// (`...-status`, `...-reset`, `...-utilization`, `...-surpassed-threshold`) is
+// NOT misparsed into a synthetic windows[slug] entry. Without the slug-regex
+// gate, `unified-overage-reset` would create windows["overage"]; with the
+// gate, the header stays raw-only and surfaces via RawHeaders for
+// forward-compat visibility.
+func TestRecordAnthropicRateLimit_UnknownTopLevelDoesNotFabricateWindow(t *testing.T) {
+	const authID = "claude-test-future-toplevel@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Status":            {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":             {"1777500000"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":       {"0.0"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
+		// Hypothetical future top-level headers ending in known field
+		// suffixes. None of these should produce a windows[slug] entry.
+		"Anthropic-Ratelimit-Unified-Overage-Reset":           {"1777800000"},
+		"Anthropic-Ratelimit-Unified-Foo-Status":              {"someValue"},
+		"Anthropic-Ratelimit-Unified-Bar-Utilization":         {"0.42"},
+		"Anthropic-Ratelimit-Unified-Baz-Surpassed-Threshold": {"0.9"},
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok || !hint.Known {
+		t.Fatal("expected hint to be set with Known=true")
+	}
+
+	// Only the real "5h" window should be present.
+	if len(hint.Windows) != 1 {
+		t.Fatalf("expected exactly 1 window (5h), got %d: %v", len(hint.Windows), hint.Windows)
+	}
+	if _, ok := hint.Windows["5h"]; !ok {
+		t.Fatal("expected real 5h window to be parsed")
+	}
+	for _, ghost := range []string{"overage", "foo", "bar", "baz"} {
+		if _, ok := hint.Windows[ghost]; ok {
+			t.Errorf("found fabricated window %q — slug regex gate failed", ghost)
+		}
+	}
+
+	// The unknown headers must still round-trip via RawHeaders so operators
+	// can observe schema drift.
+	rawChecks := map[string]string{
+		"anthropic-ratelimit-unified-overage-reset":           "1777800000",
+		"anthropic-ratelimit-unified-foo-status":              "someValue",
+		"anthropic-ratelimit-unified-bar-utilization":         "0.42",
+		"anthropic-ratelimit-unified-baz-surpassed-threshold": "0.9",
+	}
+	for k, want := range rawChecks {
+		if got := hint.RawHeaders[k]; got != want {
+			t.Errorf("raw_headers[%s]=%q want %q", k, got, want)
+		}
+	}
+}
+
+// TestRecordAnthropicRateLimit_FutureTierWindowsAccepted asserts that the
+// slug regex doesn't reject *future* legitimate window tiers. Anthropic could
+// introduce new windows like 30d, 1h, 12h, 7d_haiku, etc.; all must continue
+// to flow through the per-window fallback.
+func TestRecordAnthropicRateLimit_FutureTierWindowsAccepted(t *testing.T) {
+	const authID = "claude-test-future-windows@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		// Existing tiers (regression check).
+		"Anthropic-Ratelimit-Unified-5h-Utilization":        {"0.1"},
+		"Anthropic-Ratelimit-Unified-7d-Utilization":        {"0.2"},
+		"Anthropic-Ratelimit-Unified-7d_opus-Utilization":   {"0.3"},
+		"Anthropic-Ratelimit-Unified-7d_sonnet-Utilization": {"0.4"},
+		// Hypothetical future tiers — same shape, different numbers/words.
+		"Anthropic-Ratelimit-Unified-30d-Utilization":      {"0.5"},
+		"Anthropic-Ratelimit-Unified-1h-Utilization":       {"0.6"},
+		"Anthropic-Ratelimit-Unified-12h-Utilization":      {"0.7"},
+		"Anthropic-Ratelimit-Unified-7d_haiku-Utilization": {"0.8"},
+		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	wantWindows := map[string]float64{
+		"5h":        0.1,
+		"7d":        0.2,
+		"7d_opus":   0.3,
+		"7d_sonnet": 0.4,
+		"30d":       0.5,
+		"1h":        0.6,
+		"12h":       0.7,
+		"7d_haiku":  0.8,
+	}
+	if len(hint.Windows) != len(wantWindows) {
+		t.Fatalf("expected %d windows, got %d: %v", len(wantWindows), len(hint.Windows), hint.Windows)
+	}
+	for slug, wantUtil := range wantWindows {
+		got, ok := hint.Windows[slug]
+		if !ok {
+			t.Errorf("missing window %q (slug regex too strict?)", slug)
+			continue
+		}
+		if got.Utilization != wantUtil {
+			t.Errorf("Windows[%q].Utilization=%v want %v", slug, got.Utilization, wantUtil)
+		}
+	}
+}
+
+// TestRecordAnthropicRateLimit_HasUtilizationDistinguishesAbsentFromZero
+// asserts that a window which lands with Status and Reset but no Utilization
+// header keeps HasUtilization=false, so downstream serializers can omit the
+// utilization field rather than emit 0.0 — which would be indistinguishable
+// from a real zero-utilization reading.
+func TestRecordAnthropicRateLimit_HasUtilizationDistinguishesAbsentFromZero(t *testing.T) {
+	const authID = "claude-test-utilization-presence@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
+		// 5h window: full triple — status, reset, AND utilization=0.0.
+		// HasUtilization should be true because the header was present.
+		"Anthropic-Ratelimit-Unified-5h-Status":      {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":       {"1777500000"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization": {"0.0"},
+		// 7d window: status + reset but NO utilization. HasUtilization
+		// should be false; the field should not surface as 0.0 to consumers.
+		"Anthropic-Ratelimit-Unified-7d-Status": {"allowed"},
+		"Anthropic-Ratelimit-Unified-7d-Reset":  {"1777561200"},
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok || !hint.Known {
+		t.Fatal("expected hint to be set with Known=true")
+	}
+
+	w5h, ok := hint.Windows["5h"]
+	if !ok {
+		t.Fatal("missing 5h window")
+	}
+	if w5h.Utilization != 0.0 {
+		t.Errorf("5h.Utilization=%v want 0.0", w5h.Utilization)
+	}
+	if !w5h.HasUtilization {
+		t.Error("5h.HasUtilization=false want true (header was present with value 0.0)")
+	}
+
+	w7d, ok := hint.Windows["7d"]
+	if !ok {
+		t.Fatal("missing 7d window")
+	}
+	if w7d.Utilization != 0 {
+		t.Errorf("7d.Utilization=%v want 0 (untouched zero value)", w7d.Utilization)
+	}
+	if w7d.HasUtilization {
+		t.Error("7d.HasUtilization=true want false (no -utilization header was sent for this window)")
+	}
+}
+
+func TestParseAnthropicEpochSeconds(t *testing.T) {
+	tests := []struct {
+		in   string
+		want time.Time
+	}{
+		{"1777500000", time.Unix(1777500000, 0).UTC()},
+		{"  1777500000  ", time.Unix(1777500000, 0).UTC()},
+		{"", time.Time{}},
+		{"   ", time.Time{}},
+		{"not-a-number", time.Time{}},
+		{"1777500000.5", time.Time{}}, // strict integer; floats rejected
+		// Out-of-range epochs are rejected: time.Time.MarshalJSON refuses
+		// to serialize years outside [0001, 9999], so a malicious upstream
+		// supplying a huge epoch would otherwise crash any management
+		// endpoint that JSON-marshals the parent hint.
+		{"99999999999999", time.Time{}},  // year 5138+
+		{"-99999999999999", time.Time{}}, // pre-year 0001
+	}
+	for _, tc := range tests {
+		got := parseAnthropicEpochSeconds(tc.in)
+		if !got.Equal(tc.want) {
+			t.Errorf("parseAnthropicEpochSeconds(%q)=%v want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseAnthropicFloat(t *testing.T) {
+	tests := []struct {
+		in   string
+		want float64
+	}{
+		{"0.5", 0.5},
+		{"1.13", 1.13},
+		{"0.0", 0},
+		{"  0.5  ", 0.5},
+		{"", 0},
+		{"not-a-number", 0},
+		// Non-finite values: strconv.ParseFloat accepts these literals
+		// without error, but they break downstream JSON serialization and
+		// any consumer arithmetic (NaN comparisons, Inf accumulation).
+		// Treat as parse failure.
+		{"NaN", 0},
+		{"nan", 0},
+		{"Inf", 0},
+		{"+Inf", 0},
+		{"-Inf", 0},
+		{"infinity", 0},
+	}
+	for _, tc := range tests {
+		got := parseAnthropicFloat(tc.in)
+		if got != tc.want {
+			t.Errorf("parseAnthropicFloat(%q)=%v want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestRecordAnthropicRateLimit_RetentionBudget pins the per-capture budget.
+// The hint is held per auth ID until that auth's next response or a scrub, so
+// a single response must not be able to size it: the window-slug pattern's
+// `\d+` admits unboundedly many distinct slugs, and nothing in the tree sets
+// MaxResponseHeaderBytes / MaxHeaderListSize, leaving Go's 10 MiB defaults as
+// the only ceiling on the producing response.
+func TestRecordAnthropicRateLimit_RetentionBudget(t *testing.T) {
+	authID := "auth-retention-budget"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{}
+	// Far more distinct windows than the budget allows, all matching the slug
+	// pattern (1h, 2h, 3h, ...), each contributing two raw headers.
+	for i := 1; i <= maxAnthropicWindows*4; i++ {
+		slug := strconv.Itoa(i) + "h"
+		headers.Set("Anthropic-Ratelimit-Unified-"+slug+"-Status", "allowed")
+		headers.Set("Anthropic-Ratelimit-Unified-"+slug+"-Utilization", "0.5")
+	}
+	// An oversized value on a header that is within the count budget.
+	headers.Set("Anthropic-Ratelimit-Unified-Status", strings.Repeat("x", maxAnthropicHeaderValLen*3))
+
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("GetAnthropicRateLimitHint() ok = false, want true")
+	}
+	if got := len(hint.RawHeaders); got > maxAnthropicRawHeaders {
+		t.Errorf("len(RawHeaders) = %d, want <= %d", got, maxAnthropicRawHeaders)
+	}
+	if got := len(hint.Windows); got > maxAnthropicWindows {
+		t.Errorf("len(Windows) = %d, want <= %d", got, maxAnthropicWindows)
+	}
+	for name, value := range hint.RawHeaders {
+		if len(value) > maxAnthropicHeaderValLen {
+			t.Errorf("RawHeaders[%q] length = %d, want <= %d", name, len(value), maxAnthropicHeaderValLen)
+		}
+	}
+}
+
+// TestRecordAnthropicRateLimit_BudgetDoesNotTruncateRealCaptures guards the
+// budget against regressing into legitimate traffic: the real fixtures must
+// round-trip completely, unaffected by the caps.
+func TestRecordAnthropicRateLimit_BudgetDoesNotTruncateRealCaptures(t *testing.T) {
+	for name, headers := range map[string]http.Header{
+		"200-allowed": realCapture200Allowed(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			authID := "auth-budget-headroom-" + name
+			resetAnthropicHint(t, authID)
+
+			RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+			hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+			if !ok {
+				t.Fatal("GetAnthropicRateLimitHint() ok = false, want true")
+			}
+			var unified int
+			for canonicalName := range headers {
+				if strings.HasPrefix(strings.ToLower(canonicalName), anthropicRateLimitHeaderPrefix) {
+					unified++
+				}
+			}
+			if len(hint.RawHeaders) != unified {
+				t.Errorf("len(RawHeaders) = %d, want %d — real capture was truncated by the budget", len(hint.RawHeaders), unified)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/helps/claude_rate_limit_record_test.go
+++ b/internal/runtime/executor/helps/claude_rate_limit_record_test.go
@@ -1,6 +1,7 @@
 package helps
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -12,12 +13,26 @@ import (
 // against a clean slate. The hint store is package-global; tests share it.
 func resetAnthropicHint(t *testing.T, authID string) {
 	t.Helper()
+	cliproxyauth.DeleteAnthropicRateLimitHint(authID)
 	t.Cleanup(func() {
-		// Best-effort cleanup. The store has no public Delete; rely on tests
-		// using unique authIDs to avoid cross-pollution. This helper exists
-		// for documentation, in case a Delete API ships later.
-		_ = authID
+		cliproxyauth.DeleteAnthropicRateLimitHint(authID)
 	})
+}
+
+// testAuth builds the minimal OAuth auth the capture path needs: an ID to key
+// the store by, and an email so AnthropicAccountFingerprint resolves to a
+// stable non-empty value. Tests that care about account identity pass an
+// explicit email; the rest reuse the authID.
+func testAuth(authID string) *cliproxyauth.Auth {
+	return testAuthWithEmail(authID, authID)
+}
+
+func testAuthWithEmail(authID, email string) *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{
+		ID:       authID,
+		Provider: "claude",
+		Metadata: map[string]any{"email": email},
+	}
 }
 
 // fixturePinnedNow is when the captured fixtures were observed. Pinning keeps
@@ -108,7 +123,7 @@ func TestRecordAnthropicRateLimit_Typical200(t *testing.T) {
 	resetAnthropicHint(t, authID)
 
 	now := fixturePinnedNow()
-	RecordAnthropicRateLimit(authID, realCapture200Allowed(), now)
+	RecordAnthropicRateLimit(testAuth(authID), realCapture200Allowed(), now)
 
 	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok || !hint.Known {
@@ -179,7 +194,7 @@ func TestRecordAnthropicRateLimit_GenerativeTierWindow(t *testing.T) {
 	const authID = "claude-test-tier-window@example.com"
 	resetAnthropicHint(t, authID)
 
-	RecordAnthropicRateLimit(authID, realCapture200WarningWithTierWindow(), fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), realCapture200WarningWithTierWindow(), fixturePinnedNow())
 
 	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if hint.Status != "allowed_warning" {
@@ -224,7 +239,7 @@ func TestRecordAnthropicRateLimit_429Rejected(t *testing.T) {
 	const authID = "claude-test-429-rejected@example.com"
 	resetAnthropicHint(t, authID)
 
-	RecordAnthropicRateLimit(authID, realCapture429Rejected(), fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), realCapture429Rejected(), fixturePinnedNow())
 
 	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok || !hint.Known {
@@ -266,7 +281,7 @@ func TestRecordAnthropicRateLimit_NoUnifiedHeaders(t *testing.T) {
 		"Content-Type": {"application/json"},
 		"Retry-After":  {"60"},
 	}
-	RecordAnthropicRateLimit(authID, headersWithoutFamily, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headersWithoutFamily, fixturePinnedNow())
 
 	got, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok {
@@ -295,7 +310,7 @@ func TestRecordAnthropicRateLimit_HeadersWithoutUnifiedStatus(t *testing.T) {
 		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
 		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok || !hint.Known {
@@ -320,7 +335,7 @@ func TestRecordAnthropicRateLimit_NilHeadersNoop(t *testing.T) {
 	const authID = "claude-test-nil-headers@example.com"
 	resetAnthropicHint(t, authID)
 
-	RecordAnthropicRateLimit(authID, nil, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), nil, fixturePinnedNow())
 
 	if _, ok := cliproxyauth.GetAnthropicRateLimitHint(authID); ok {
 		t.Fatal("nil headers should not create a hint")
@@ -328,9 +343,16 @@ func TestRecordAnthropicRateLimit_NilHeadersNoop(t *testing.T) {
 }
 
 func TestRecordAnthropicRateLimit_EmptyAuthIDNoop(t *testing.T) {
-	RecordAnthropicRateLimit("", realCapture200Allowed(), fixturePinnedNow())
-	RecordAnthropicRateLimit("   ", realCapture200Allowed(), fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(""), realCapture200Allowed(), fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth("   "), realCapture200Allowed(), fixturePinnedNow())
 	// Assertion: doesn't panic, doesn't pollute the hint store.
+}
+
+func TestRecordAnthropicRateLimit_NilAuthNoop(t *testing.T) {
+	RecordAnthropicRateLimit(nil, realCapture200Allowed(), fixturePinnedNow())
+	// Assertion: doesn't panic. The executor call sites pass auth straight
+	// through and it is nil-checked there today, but the helper must not
+	// depend on that.
 }
 
 func TestRecordAnthropicRateLimit_MalformedNumericsAreTolerated(t *testing.T) {
@@ -346,7 +368,7 @@ func TestRecordAnthropicRateLimit_MalformedNumericsAreTolerated(t *testing.T) {
 		"Anthropic-Ratelimit-Unified-Fallback-Percentage":  {""},
 		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if hint.Status != "allowed" {
@@ -380,8 +402,8 @@ func TestRecordAnthropicRateLimit_OverwritesPriorHint(t *testing.T) {
 	const authID = "claude-test-overwrite@example.com"
 	resetAnthropicHint(t, authID)
 
-	RecordAnthropicRateLimit(authID, realCapture200Allowed(), fixturePinnedNow())
-	RecordAnthropicRateLimit(authID, realCapture429Rejected(), fixturePinnedNow().Add(time.Minute))
+	RecordAnthropicRateLimit(testAuth(authID), realCapture200Allowed(), fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), realCapture429Rejected(), fixturePinnedNow().Add(time.Minute))
 
 	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if hint.Status != "rejected" {
@@ -402,7 +424,7 @@ func TestRecordAnthropicRateLimit_UnknownFieldGoesToRawHeadersOnly(t *testing.T)
 		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
 		"Anthropic-Ratelimit-Unified-Future-Field-Type-X":  {"someValue"}, // not a known top-level or per-window suffix
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if got := hint.RawHeaders["anthropic-ratelimit-unified-future-field-type-x"]; got != "someValue" {
@@ -438,7 +460,7 @@ func TestRecordAnthropicRateLimit_UnknownTopLevelDoesNotFabricateWindow(t *testi
 		"Anthropic-Ratelimit-Unified-Bar-Utilization":         {"0.42"},
 		"Anthropic-Ratelimit-Unified-Baz-Surpassed-Threshold": {"0.9"},
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok || !hint.Known {
@@ -494,7 +516,7 @@ func TestRecordAnthropicRateLimit_FutureTierWindowsAccepted(t *testing.T) {
 		"Anthropic-Ratelimit-Unified-7d_haiku-Utilization": {"0.8"},
 		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	wantWindows := map[string]float64{
@@ -545,7 +567,7 @@ func TestRecordAnthropicRateLimit_HasUtilizationDistinguishesAbsentFromZero(t *t
 		"Anthropic-Ratelimit-Unified-7d-Status": {"allowed"},
 		"Anthropic-Ratelimit-Unified-7d-Reset":  {"1777561200"},
 	}
-	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+	RecordAnthropicRateLimit(testAuth(authID), headers, fixturePinnedNow())
 
 	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
 	if !ok || !hint.Known {
@@ -628,5 +650,72 @@ func TestParseAnthropicFloat(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("parseAnthropicFloat(%q)=%v want %v", tc.in, got, tc.want)
 		}
+	}
+}
+
+// TestRecordAnthropicRateLimit_SurvivesTokenRefreshButNotRotation is the
+// end-to-end guard over the capture → lifecycle → read path, exercised through
+// a real Manager rather than by poking the store directly.
+//
+// Both halves were live defects at some point in this feature's history: an
+// unconditional scrub in Manager.Update destroyed valid quota state on every
+// routine token refresh, and before the account fingerprint existed a capture
+// could outlive the credential it described.
+func TestRecordAnthropicRateLimit_SurvivesTokenRefreshButNotRotation(t *testing.T) {
+	const authID = "claude-e2e-refresh-vs-rotation@example.com"
+	resetAnthropicHint(t, authID)
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	ctx := context.Background()
+
+	original := testAuthWithEmail(authID, "account-one@example.com")
+	if _, err := manager.Register(ctx, original); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	// A Claude response lands and is captured.
+	RecordAnthropicRateLimit(original, realCapture200WarningWithTierWindow(), fixturePinnedNow())
+	if _, ok := cliproxyauth.AnthropicRateLimitHintFor(original); !ok {
+		t.Fatal("precondition: capture should be readable")
+	}
+
+	// Routine OAuth token refresh: same account, new access token.
+	refreshed := testAuthWithEmail(authID, "account-one@example.com")
+	refreshed.Metadata["access_token"] = "refreshed-token"
+	if _, err := manager.Update(ctx, refreshed); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	hint, ok := cliproxyauth.AnthropicRateLimitHintFor(refreshed)
+	if !ok {
+		t.Fatal("quota state must survive a routine token refresh")
+	}
+	if hint.Status != "allowed_warning" {
+		t.Errorf("Status=%q want %q after refresh", hint.Status, "allowed_warning")
+	}
+
+	// Rotation to a different account under the same auth ID.
+	rotated := testAuthWithEmail(authID, "account-two@example.com")
+	if _, err := manager.Update(ctx, rotated); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if _, ok := cliproxyauth.AnthropicRateLimitHintFor(rotated); ok {
+		t.Fatal("the previous account's quota must not be served after rotation")
+	}
+
+	// A capture still in flight when the rotation happened lands late, tagged
+	// with the old account. It must not resurrect the old quota.
+	RecordAnthropicRateLimit(original, realCapture429Rejected(), fixturePinnedNow().Add(time.Second))
+	if _, ok := cliproxyauth.AnthropicRateLimitHintFor(rotated); ok {
+		t.Fatal("a late capture from the previous account must not be served to the rotated auth")
+	}
+
+	// And the rotated account's own capture is served normally.
+	RecordAnthropicRateLimit(rotated, realCapture200Allowed(), fixturePinnedNow().Add(2*time.Second))
+	hint, ok = cliproxyauth.AnthropicRateLimitHintFor(rotated)
+	if !ok {
+		t.Fatal("the rotated account must see its own capture")
+	}
+	if hint.Status != "allowed" {
+		t.Errorf("Status=%q want %q for the rotated account", hint.Status, "allowed")
 	}
 }

--- a/internal/runtime/executor/helps/claude_rate_limit_record_test.go
+++ b/internal/runtime/executor/helps/claude_rate_limit_record_test.go
@@ -1,0 +1,632 @@
+package helps
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// resetAnthropicHint clears any prior hint for an authID so each test runs
+// against a clean slate. The hint store is package-global; tests share it.
+func resetAnthropicHint(t *testing.T, authID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		// Best-effort cleanup. The store has no public Delete; rely on tests
+		// using unique authIDs to avoid cross-pollution. This helper exists
+		// for documentation, in case a Delete API ships later.
+		_ = authID
+	})
+}
+
+// fixturePinnedNow is when the captured fixtures were observed. Pinning keeps
+// time-dependent assertions deterministic.
+//
+// Captured 2026-04-29 from real api.anthropic.com /v1/messages traffic;
+// 1777408679 is the earliest sample's `ts`.
+func fixturePinnedNow() time.Time {
+	return time.Unix(1777408679, 0).UTC()
+}
+
+// realCapture200Allowed mirrors the most common /v1/messages 200 response on a
+// healthy subscription — `unified-status: allowed`, both 5h and 7d at 0.0
+// utilization, no surpassed-threshold, no upgrade-paths.
+//
+// Source: ~/.cache/claude-rate-limits.jsonl ts=1777482383.7548852.
+func realCapture200Allowed() http.Header {
+	return http.Header{
+		"Anthropic-Ratelimit-Unified-Status":                  {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":                {"1777500000"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":          {"0.0"},
+		"Anthropic-Ratelimit-Unified-7d-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-7d-Reset":                {"1777561200"},
+		"Anthropic-Ratelimit-Unified-7d-Utilization":          {"0.0"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim":    {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Fallback-Percentage":     {"0.5"},
+		"Anthropic-Ratelimit-Unified-Reset":                   {"1777500000"},
+		"Anthropic-Ratelimit-Unified-Overage-Disabled-Reason": {"org_level_disabled"},
+		"Anthropic-Ratelimit-Unified-Overage-Status":          {"rejected"},
+	}
+}
+
+// realCapture200WarningWithTierWindow mirrors a 200 response where the 7d
+// window is past the 0.75 surpassed-threshold AND a tier-specific 7d_sonnet
+// window is reported alongside the family 7d window. This is the "generative
+// windows map" load-bearing case — `7d_sonnet` is not a hard-coded enum value.
+//
+// Source: ~/.cache/claude-rate-limits.jsonl ts=1777413065.625119.
+func realCapture200WarningWithTierWindow() http.Header {
+	return http.Header{
+		"Anthropic-Ratelimit-Unified-Status":                  {"allowed_warning"},
+		"Anthropic-Ratelimit-Unified-5h-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":                {"1777420800"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":          {"0.35"},
+		"Anthropic-Ratelimit-Unified-7d-Status":               {"allowed_warning"},
+		"Anthropic-Ratelimit-Unified-7d-Reset":                {"1777575600"},
+		"Anthropic-Ratelimit-Unified-7d-Utilization":          {"0.85"},
+		"Anthropic-Ratelimit-Unified-7d-Surpassed-Threshold":  {"0.75"},
+		"Anthropic-Ratelimit-Unified-7d_sonnet-Status":        {"allowed"},
+		"Anthropic-Ratelimit-Unified-7d_sonnet-Reset":         {"1777575600"},
+		"Anthropic-Ratelimit-Unified-7d_sonnet-Utilization":   {"0.07"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim":    {"seven_day"},
+		"Anthropic-Ratelimit-Unified-Fallback-Percentage":     {"0.5"},
+		"Anthropic-Ratelimit-Unified-Reset":                   {"1777575600"},
+		"Anthropic-Ratelimit-Unified-Overage-Disabled-Reason": {"org_level_disabled_until"},
+		"Anthropic-Ratelimit-Unified-Overage-Status":          {"rejected"},
+	}
+}
+
+// realCapture429Rejected mirrors a 429 response where the 5h window is past
+// 1.0 utilization (overage is permitted but `overage-status: rejected` means
+// the org has it disabled). Includes `upgrade-paths`, which is observed only
+// at 429 / near-cap.
+//
+// Source: ~/.cache/claude-rate-limits.jsonl ts=1777482352.032908.
+func realCapture429Rejected() http.Header {
+	return http.Header{
+		"Anthropic-Ratelimit-Unified-Status":                  {"rejected"},
+		"Anthropic-Ratelimit-Unified-5h-Status":               {"rejected"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":                {"1777500000"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":          {"1.13"},
+		"Anthropic-Ratelimit-Unified-5h-Surpassed-Threshold":  {"1.0"},
+		"Anthropic-Ratelimit-Unified-7d-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-7d-Reset":                {"1777561200"},
+		"Anthropic-Ratelimit-Unified-7d-Utilization":          {"0.09"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim":    {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Fallback-Percentage":     {"0.5"},
+		"Anthropic-Ratelimit-Unified-Reset":                   {"1777500000"},
+		"Anthropic-Ratelimit-Unified-Overage-Disabled-Reason": {"org_level_disabled"},
+		"Anthropic-Ratelimit-Unified-Overage-Status":          {"rejected"},
+		"Anthropic-Ratelimit-Unified-Upgrade-Paths":           {"upgrade_plan"},
+	}
+}
+
+func TestRecordAnthropicRateLimit_Typical200(t *testing.T) {
+	const authID = "claude-test-200-allowed@example.com"
+	resetAnthropicHint(t, authID)
+
+	now := fixturePinnedNow()
+	RecordAnthropicRateLimit(authID, realCapture200Allowed(), now)
+
+	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok || !hint.Known {
+		t.Fatalf("expected hint to be set with Known=true after typical 200")
+	}
+	if hint.Status != "allowed" {
+		t.Errorf("Status=%q want %q", hint.Status, "allowed")
+	}
+	if hint.RepresentativeClaim != "five_hour" {
+		t.Errorf("RepresentativeClaim=%q want %q", hint.RepresentativeClaim, "five_hour")
+	}
+	if want := time.Unix(1777500000, 0).UTC(); !hint.Reset.Equal(want) {
+		t.Errorf("Reset=%v want %v", hint.Reset, want)
+	}
+	if hint.FallbackPercentage != 0.5 {
+		t.Errorf("FallbackPercentage=%v want 0.5", hint.FallbackPercentage)
+	}
+	if hint.OverageStatus != "rejected" {
+		t.Errorf("OverageStatus=%q want %q", hint.OverageStatus, "rejected")
+	}
+	if hint.OverageDisabledReason != "org_level_disabled" {
+		t.Errorf("OverageDisabledReason=%q want %q", hint.OverageDisabledReason, "org_level_disabled")
+	}
+	if hint.UpgradePaths != "" {
+		t.Errorf("UpgradePaths should be empty when absent, got %q", hint.UpgradePaths)
+	}
+	if !hint.ObservedAt.Equal(now) {
+		t.Errorf("ObservedAt=%v want %v", hint.ObservedAt, now)
+	}
+
+	if len(hint.Windows) != 2 {
+		t.Fatalf("expected 2 windows (5h, 7d), got %d: %v", len(hint.Windows), hint.Windows)
+	}
+	if w, ok := hint.Windows["5h"]; !ok {
+		t.Errorf("missing 5h window")
+	} else {
+		if w.Status != "allowed" {
+			t.Errorf("5h.Status=%q", w.Status)
+		}
+		if w.Utilization != 0.0 {
+			t.Errorf("5h.Utilization=%v", w.Utilization)
+		}
+		if !w.HasUtilization {
+			t.Errorf("5h.HasUtilization=false want true (header was present with value 0.0)")
+		}
+		if w.SurpassedThreshold != 0 {
+			t.Errorf("5h.SurpassedThreshold=%v want 0 (absent)", w.SurpassedThreshold)
+		}
+	}
+	if w, ok := hint.Windows["7d"]; !ok {
+		t.Errorf("missing 7d window")
+	} else {
+		if !w.Reset.Equal(time.Unix(1777561200, 0).UTC()) {
+			t.Errorf("7d.Reset=%v", w.Reset)
+		}
+	}
+
+	// raw_headers should preserve every observed unified-* header verbatim.
+	if got := hint.RawHeaders["anthropic-ratelimit-unified-5h-utilization"]; got != "0.0" {
+		t.Errorf("raw_headers[5h-utilization]=%q want %q", got, "0.0")
+	}
+	if len(hint.RawHeaders) != 12 {
+		t.Errorf("expected 12 raw headers, got %d: %v", len(hint.RawHeaders), hint.RawHeaders)
+	}
+}
+
+func TestRecordAnthropicRateLimit_GenerativeTierWindow(t *testing.T) {
+	const authID = "claude-test-tier-window@example.com"
+	resetAnthropicHint(t, authID)
+
+	RecordAnthropicRateLimit(authID, realCapture200WarningWithTierWindow(), fixturePinnedNow())
+
+	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if hint.Status != "allowed_warning" {
+		t.Fatalf("Status=%q want %q", hint.Status, "allowed_warning")
+	}
+	if hint.RepresentativeClaim != "seven_day" {
+		t.Fatalf("RepresentativeClaim=%q want %q", hint.RepresentativeClaim, "seven_day")
+	}
+	if hint.OverageDisabledReason != "org_level_disabled_until" {
+		t.Errorf("OverageDisabledReason=%q want %q", hint.OverageDisabledReason, "org_level_disabled_until")
+	}
+
+	// The load-bearing assertion: we captured a window we never declared
+	// statically. If this slug ever needs special-casing, the design has
+	// failed; it must remain pure pass-through.
+	if len(hint.Windows) != 3 {
+		t.Fatalf("expected 3 windows (5h, 7d, 7d_sonnet), got %d: %v", len(hint.Windows), hint.Windows)
+	}
+	tier, ok := hint.Windows["7d_sonnet"]
+	if !ok {
+		t.Fatalf("missing 7d_sonnet window — generative-map design broken")
+	}
+	if tier.Utilization != 0.07 {
+		t.Errorf("7d_sonnet.Utilization=%v want 0.07", tier.Utilization)
+	}
+	if tier.Status != "allowed" {
+		t.Errorf("7d_sonnet.Status=%q want %q", tier.Status, "allowed")
+	}
+
+	// Surpassed-threshold should attach to the 7d window (where it was sent),
+	// NOT to 7d_sonnet (which has no -surpassed-threshold header).
+	if hint.Windows["7d"].SurpassedThreshold != 0.75 {
+		t.Errorf("7d.SurpassedThreshold=%v want 0.75", hint.Windows["7d"].SurpassedThreshold)
+	}
+	if hint.Windows["7d_sonnet"].SurpassedThreshold != 0 {
+		t.Errorf("7d_sonnet.SurpassedThreshold should be 0 (absent), got %v",
+			hint.Windows["7d_sonnet"].SurpassedThreshold)
+	}
+}
+
+func TestRecordAnthropicRateLimit_429Rejected(t *testing.T) {
+	const authID = "claude-test-429-rejected@example.com"
+	resetAnthropicHint(t, authID)
+
+	RecordAnthropicRateLimit(authID, realCapture429Rejected(), fixturePinnedNow())
+
+	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok || !hint.Known {
+		t.Fatal("expected hint Known after 429 — capture must run on errors too")
+	}
+	if hint.Status != "rejected" {
+		t.Errorf("Status=%q want %q", hint.Status, "rejected")
+	}
+	if hint.UpgradePaths != "upgrade_plan" {
+		t.Errorf("UpgradePaths=%q want %q (only present at/near-cap)", hint.UpgradePaths, "upgrade_plan")
+	}
+	w := hint.Windows["5h"]
+	if w.Utilization != 1.13 {
+		t.Errorf("5h.Utilization=%v want 1.13 (overage)", w.Utilization)
+	}
+	if w.SurpassedThreshold != 1.0 {
+		t.Errorf("5h.SurpassedThreshold=%v want 1.0", w.SurpassedThreshold)
+	}
+	if w.Status != "rejected" {
+		t.Errorf("5h.Status=%q want %q", w.Status, "rejected")
+	}
+}
+
+func TestRecordAnthropicRateLimit_NoUnifiedHeaders(t *testing.T) {
+	// Regression case: NousResearch/hermes-agent#17169 reports that some 429
+	// paths now ship without `unified-*` headers entirely. The capture must
+	// be a no-op in that case, leaving the prior hint untouched.
+	const authID = "claude-test-no-unified@example.com"
+	resetAnthropicHint(t, authID)
+
+	priorHint := cliproxyauth.AnthropicRateLimitHint{
+		Known:               true,
+		Status:              "allowed",
+		RepresentativeClaim: "five_hour",
+	}
+	cliproxyauth.SetAnthropicRateLimitHint(authID, priorHint)
+
+	headersWithoutFamily := http.Header{
+		"Content-Type": {"application/json"},
+		"Retry-After":  {"60"},
+	}
+	RecordAnthropicRateLimit(authID, headersWithoutFamily, fixturePinnedNow())
+
+	got, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("prior hint disappeared — capture should have been a no-op")
+	}
+	if got.Status != "allowed" || got.RepresentativeClaim != "five_hour" {
+		t.Fatalf("prior hint mutated: got=%+v", got)
+	}
+}
+
+// TestRecordAnthropicRateLimit_HeadersWithoutUnifiedStatus asserts that the
+// capture still records hints when the response carries other `unified-*`
+// fields but lacks `unified-status` specifically. Earlier drafts of this
+// function used `unified-status` as a probe to early-bail, which dropped data
+// in this case (raised by chatgpt-codex-connector on PR #3170). The current
+// implementation iterates every header before deciding whether to write.
+func TestRecordAnthropicRateLimit_HeadersWithoutUnifiedStatus(t *testing.T) {
+	const authID = "claude-test-no-unified-status@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		// `unified-status` deliberately absent.
+		"Anthropic-Ratelimit-Unified-5h-Status":            {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":             {"1777500000"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":       {"0.42"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok || !hint.Known {
+		t.Fatal("expected hint to be set even without unified-status header")
+	}
+	if hint.Status != "" {
+		t.Errorf("Status should be empty when header absent, got %q", hint.Status)
+	}
+	if hint.RepresentativeClaim != "five_hour" {
+		t.Errorf("RepresentativeClaim=%q want five_hour", hint.RepresentativeClaim)
+	}
+	w := hint.Windows["5h"]
+	if w.Utilization != 0.42 {
+		t.Errorf("5h.Utilization=%v want 0.42", w.Utilization)
+	}
+	if got := hint.RawHeaders["anthropic-ratelimit-unified-5h-utilization"]; got != "0.42" {
+		t.Errorf("raw_headers[5h-utilization]=%q want %q", got, "0.42")
+	}
+}
+
+func TestRecordAnthropicRateLimit_NilHeadersNoop(t *testing.T) {
+	const authID = "claude-test-nil-headers@example.com"
+	resetAnthropicHint(t, authID)
+
+	RecordAnthropicRateLimit(authID, nil, fixturePinnedNow())
+
+	if _, ok := cliproxyauth.GetAnthropicRateLimitHint(authID); ok {
+		t.Fatal("nil headers should not create a hint")
+	}
+}
+
+func TestRecordAnthropicRateLimit_EmptyAuthIDNoop(t *testing.T) {
+	RecordAnthropicRateLimit("", realCapture200Allowed(), fixturePinnedNow())
+	RecordAnthropicRateLimit("   ", realCapture200Allowed(), fixturePinnedNow())
+	// Assertion: doesn't panic, doesn't pollute the hint store.
+}
+
+func TestRecordAnthropicRateLimit_MalformedNumericsAreTolerated(t *testing.T) {
+	const authID = "claude-test-malformed@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Status":            {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":             {"not-a-number"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":       {"???"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Fallback-Percentage":  {""},
+		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if hint.Status != "allowed" {
+		t.Errorf("Status=%q (well-formed string field should still parse)", hint.Status)
+	}
+	if !hint.Reset.Equal(time.Unix(1777500000, 0).UTC()) {
+		t.Errorf("top-level Reset=%v (well-formed epoch should still parse)", hint.Reset)
+	}
+	w := hint.Windows["5h"]
+	if w.Status != "allowed" {
+		t.Errorf("5h.Status=%q (string field unaffected by neighbor's malformed value)", w.Status)
+	}
+	if !w.Reset.IsZero() {
+		t.Errorf("5h.Reset=%v want zero (malformed epoch falls back to zero)", w.Reset)
+	}
+	if w.Utilization != 0 {
+		t.Errorf("5h.Utilization=%v want 0 (malformed float falls back to zero)", w.Utilization)
+	}
+	if hint.FallbackPercentage != 0 {
+		t.Errorf("FallbackPercentage=%v want 0 (empty string falls back to zero)", hint.FallbackPercentage)
+	}
+
+	// Raw headers preserve the malformed strings verbatim — operators reading
+	// raw_headers can recover the original payload for debugging.
+	if got := hint.RawHeaders["anthropic-ratelimit-unified-5h-reset"]; got != "not-a-number" {
+		t.Errorf("raw_headers[5h-reset]=%q want %q", got, "not-a-number")
+	}
+}
+
+func TestRecordAnthropicRateLimit_OverwritesPriorHint(t *testing.T) {
+	const authID = "claude-test-overwrite@example.com"
+	resetAnthropicHint(t, authID)
+
+	RecordAnthropicRateLimit(authID, realCapture200Allowed(), fixturePinnedNow())
+	RecordAnthropicRateLimit(authID, realCapture429Rejected(), fixturePinnedNow().Add(time.Minute))
+
+	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if hint.Status != "rejected" {
+		t.Fatalf("expected last-seen 429 to overwrite prior 200; got Status=%q", hint.Status)
+	}
+	if hint.UpgradePaths != "upgrade_plan" {
+		t.Errorf("expected last-seen UpgradePaths to be present; got %q", hint.UpgradePaths)
+	}
+}
+
+func TestRecordAnthropicRateLimit_UnknownFieldGoesToRawHeadersOnly(t *testing.T) {
+	const authID = "claude-test-unknown-field@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
+		"Anthropic-Ratelimit-Unified-Future-Field-Type-X":  {"someValue"}, // not a known top-level or per-window suffix
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if got := hint.RawHeaders["anthropic-ratelimit-unified-future-field-type-x"]; got != "someValue" {
+		t.Errorf("unknown header should round-trip via raw_headers, got %q", got)
+	}
+	if hint.Status != "allowed" {
+		t.Errorf("known fields should still parse alongside unknowns; Status=%q", hint.Status)
+	}
+}
+
+// TestRecordAnthropicRateLimit_UnknownTopLevelDoesNotFabricateWindow asserts
+// that a future top-level header ending in a per-window field suffix
+// (`...-status`, `...-reset`, `...-utilization`, `...-surpassed-threshold`) is
+// NOT misparsed into a synthetic windows[slug] entry. Without the slug-regex
+// gate, `unified-overage-reset` would create windows["overage"]; with the
+// gate, the header stays raw-only and surfaces via RawHeaders for
+// forward-compat visibility.
+func TestRecordAnthropicRateLimit_UnknownTopLevelDoesNotFabricateWindow(t *testing.T) {
+	const authID = "claude-test-future-toplevel@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Status":            {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":             {"1777500000"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization":       {"0.0"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
+		// Hypothetical future top-level headers ending in known field
+		// suffixes. None of these should produce a windows[slug] entry.
+		"Anthropic-Ratelimit-Unified-Overage-Reset":           {"1777800000"},
+		"Anthropic-Ratelimit-Unified-Foo-Status":              {"someValue"},
+		"Anthropic-Ratelimit-Unified-Bar-Utilization":         {"0.42"},
+		"Anthropic-Ratelimit-Unified-Baz-Surpassed-Threshold": {"0.9"},
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok || !hint.Known {
+		t.Fatal("expected hint to be set with Known=true")
+	}
+
+	// Only the real "5h" window should be present.
+	if len(hint.Windows) != 1 {
+		t.Fatalf("expected exactly 1 window (5h), got %d: %v", len(hint.Windows), hint.Windows)
+	}
+	if _, ok := hint.Windows["5h"]; !ok {
+		t.Fatal("expected real 5h window to be parsed")
+	}
+	for _, ghost := range []string{"overage", "foo", "bar", "baz"} {
+		if _, ok := hint.Windows[ghost]; ok {
+			t.Errorf("found fabricated window %q — slug regex gate failed", ghost)
+		}
+	}
+
+	// The unknown headers must still round-trip via RawHeaders so operators
+	// can observe schema drift.
+	rawChecks := map[string]string{
+		"anthropic-ratelimit-unified-overage-reset":           "1777800000",
+		"anthropic-ratelimit-unified-foo-status":              "someValue",
+		"anthropic-ratelimit-unified-bar-utilization":         "0.42",
+		"anthropic-ratelimit-unified-baz-surpassed-threshold": "0.9",
+	}
+	for k, want := range rawChecks {
+		if got := hint.RawHeaders[k]; got != want {
+			t.Errorf("raw_headers[%s]=%q want %q", k, got, want)
+		}
+	}
+}
+
+// TestRecordAnthropicRateLimit_FutureTierWindowsAccepted asserts that the
+// slug regex doesn't reject *future* legitimate window tiers. Anthropic could
+// introduce new windows like 30d, 1h, 12h, 7d_haiku, etc.; all must continue
+// to flow through the per-window fallback.
+func TestRecordAnthropicRateLimit_FutureTierWindowsAccepted(t *testing.T) {
+	const authID = "claude-test-future-windows@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		// Existing tiers (regression check).
+		"Anthropic-Ratelimit-Unified-5h-Utilization":        {"0.1"},
+		"Anthropic-Ratelimit-Unified-7d-Utilization":        {"0.2"},
+		"Anthropic-Ratelimit-Unified-7d_opus-Utilization":   {"0.3"},
+		"Anthropic-Ratelimit-Unified-7d_sonnet-Utilization": {"0.4"},
+		// Hypothetical future tiers — same shape, different numbers/words.
+		"Anthropic-Ratelimit-Unified-30d-Utilization":      {"0.5"},
+		"Anthropic-Ratelimit-Unified-1h-Utilization":       {"0.6"},
+		"Anthropic-Ratelimit-Unified-12h-Utilization":      {"0.7"},
+		"Anthropic-Ratelimit-Unified-7d_haiku-Utilization": {"0.8"},
+		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, _ := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	wantWindows := map[string]float64{
+		"5h":        0.1,
+		"7d":        0.2,
+		"7d_opus":   0.3,
+		"7d_sonnet": 0.4,
+		"30d":       0.5,
+		"1h":        0.6,
+		"12h":       0.7,
+		"7d_haiku":  0.8,
+	}
+	if len(hint.Windows) != len(wantWindows) {
+		t.Fatalf("expected %d windows, got %d: %v", len(wantWindows), len(hint.Windows), hint.Windows)
+	}
+	for slug, wantUtil := range wantWindows {
+		got, ok := hint.Windows[slug]
+		if !ok {
+			t.Errorf("missing window %q (slug regex too strict?)", slug)
+			continue
+		}
+		if got.Utilization != wantUtil {
+			t.Errorf("Windows[%q].Utilization=%v want %v", slug, got.Utilization, wantUtil)
+		}
+	}
+}
+
+// TestRecordAnthropicRateLimit_HasUtilizationDistinguishesAbsentFromZero
+// asserts that a window which lands with Status and Reset but no Utilization
+// header keeps HasUtilization=false, so downstream serializers can omit the
+// utilization field rather than emit 0.0 — which would be indistinguishable
+// from a real zero-utilization reading.
+func TestRecordAnthropicRateLimit_HasUtilizationDistinguishesAbsentFromZero(t *testing.T) {
+	const authID = "claude-test-utilization-presence@example.com"
+	resetAnthropicHint(t, authID)
+
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-Status":               {"allowed"},
+		"Anthropic-Ratelimit-Unified-Representative-Claim": {"five_hour"},
+		"Anthropic-Ratelimit-Unified-Reset":                {"1777500000"},
+		// 5h window: full triple — status, reset, AND utilization=0.0.
+		// HasUtilization should be true because the header was present.
+		"Anthropic-Ratelimit-Unified-5h-Status":      {"allowed"},
+		"Anthropic-Ratelimit-Unified-5h-Reset":       {"1777500000"},
+		"Anthropic-Ratelimit-Unified-5h-Utilization": {"0.0"},
+		// 7d window: status + reset but NO utilization. HasUtilization
+		// should be false; the field should not surface as 0.0 to consumers.
+		"Anthropic-Ratelimit-Unified-7d-Status": {"allowed"},
+		"Anthropic-Ratelimit-Unified-7d-Reset":  {"1777561200"},
+	}
+	RecordAnthropicRateLimit(authID, headers, fixturePinnedNow())
+
+	hint, ok := cliproxyauth.GetAnthropicRateLimitHint(authID)
+	if !ok || !hint.Known {
+		t.Fatal("expected hint to be set with Known=true")
+	}
+
+	w5h, ok := hint.Windows["5h"]
+	if !ok {
+		t.Fatal("missing 5h window")
+	}
+	if w5h.Utilization != 0.0 {
+		t.Errorf("5h.Utilization=%v want 0.0", w5h.Utilization)
+	}
+	if !w5h.HasUtilization {
+		t.Error("5h.HasUtilization=false want true (header was present with value 0.0)")
+	}
+
+	w7d, ok := hint.Windows["7d"]
+	if !ok {
+		t.Fatal("missing 7d window")
+	}
+	if w7d.Utilization != 0 {
+		t.Errorf("7d.Utilization=%v want 0 (untouched zero value)", w7d.Utilization)
+	}
+	if w7d.HasUtilization {
+		t.Error("7d.HasUtilization=true want false (no -utilization header was sent for this window)")
+	}
+}
+
+func TestParseAnthropicEpochSeconds(t *testing.T) {
+	tests := []struct {
+		in   string
+		want time.Time
+	}{
+		{"1777500000", time.Unix(1777500000, 0).UTC()},
+		{"  1777500000  ", time.Unix(1777500000, 0).UTC()},
+		{"", time.Time{}},
+		{"   ", time.Time{}},
+		{"not-a-number", time.Time{}},
+		{"1777500000.5", time.Time{}}, // strict integer; floats rejected
+		// Out-of-range epochs are rejected: time.Time.MarshalJSON refuses
+		// to serialize years outside [0001, 9999], so a malicious upstream
+		// supplying a huge epoch would otherwise crash any management
+		// endpoint that JSON-marshals the parent hint.
+		{"99999999999999", time.Time{}},  // year 5138+
+		{"-99999999999999", time.Time{}}, // pre-year 0001
+	}
+	for _, tc := range tests {
+		got := parseAnthropicEpochSeconds(tc.in)
+		if !got.Equal(tc.want) {
+			t.Errorf("parseAnthropicEpochSeconds(%q)=%v want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseAnthropicFloat(t *testing.T) {
+	tests := []struct {
+		in   string
+		want float64
+	}{
+		{"0.5", 0.5},
+		{"1.13", 1.13},
+		{"0.0", 0},
+		{"  0.5  ", 0.5},
+		{"", 0},
+		{"not-a-number", 0},
+		// Non-finite values: strconv.ParseFloat accepts these literals
+		// without error, but they break downstream JSON serialization and
+		// any consumer arithmetic (NaN comparisons, Inf accumulation).
+		// Treat as parse failure.
+		{"NaN", 0},
+		{"nan", 0},
+		{"Inf", 0},
+		{"+Inf", 0},
+		{"-Inf", 0},
+		{"infinity", 0},
+	}
+	for _, tc := range tests {
+		got := parseAnthropicFloat(tc.in)
+		if got != tc.want {
+			t.Errorf("parseAnthropicFloat(%q)=%v want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/sdk/cliproxy/auth/anthropic_rate_limit.go
+++ b/sdk/cliproxy/auth/anthropic_rate_limit.go
@@ -1,0 +1,175 @@
+package auth
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// AnthropicRateLimitHint records the most-recent Anthropic
+// `anthropic-ratelimit-unified-*` response-header state observed for one auth.
+//
+// This is passive observability state, populated by the Claude executor on every
+// upstream response. It is NOT consulted by the conductor or selector for routing
+// decisions — those continue to use Auth.Quota / Auth.NextRetryAfter. Operators
+// (management API consumers, dashboards) read this hint to surface utilization
+// and reset times before a credential is actually rate-limited.
+//
+// All fields except Known and ObservedAt are optional. Anthropic's
+// `unified-*` family is undocumented and field set has been observed to grow
+// over time (e.g. tier-specific 7d windows like `7d_opus`); the Windows map is
+// keyed by header window slug rather than predeclared fields so new windows
+// surface without code change.
+type AnthropicRateLimitHint struct {
+	// Known is true once any unified-* header has been observed for this auth.
+	Known bool
+	// ObservedAt is when the most recent capture happened (server clock).
+	ObservedAt time.Time
+	// Status mirrors `anthropic-ratelimit-unified-status`: e.g. "allowed",
+	// "allowed_warning", "rejected". Pass-through string; do not enum-tighten.
+	Status string
+	// RepresentativeClaim names the binding window
+	// (`anthropic-ratelimit-unified-representative-claim`); e.g. "five_hour",
+	// "seven_day", "seven_day_opus". Pass-through string.
+	RepresentativeClaim string
+	// Reset is the reset moment of the representative window
+	// (`anthropic-ratelimit-unified-reset`, epoch seconds → time.Time).
+	Reset time.Time
+	// Windows maps window slug → per-window state. Slugs are extracted from
+	// header names of the form `anthropic-ratelimit-unified-{slug}-{field}`,
+	// e.g. "5h", "7d", "7d_opus". The map is generative; consumers should
+	// iterate rather than assume a fixed key set.
+	Windows map[string]AnthropicQuotaWindow
+	// FallbackPercentage mirrors `anthropic-ratelimit-unified-fallback-percentage`.
+	// Optional; 0 when absent.
+	FallbackPercentage float64
+	// OverageStatus mirrors `anthropic-ratelimit-unified-overage-status`.
+	// Optional; empty when absent.
+	OverageStatus string
+	// OverageDisabledReason mirrors
+	// `anthropic-ratelimit-unified-overage-disabled-reason`. Optional.
+	OverageDisabledReason string
+	// UpgradePaths mirrors `anthropic-ratelimit-unified-upgrade-paths`. Optional.
+	UpgradePaths string
+	// RawHeaders preserves every observed `anthropic-ratelimit-unified-*` header
+	// as a lower-cased name → first value map. Forward-compat safety net for
+	// undocumented schema drift; may be nil when no headers were captured.
+	RawHeaders map[string]string
+}
+
+// AnthropicQuotaWindow records per-window state captured from
+// `anthropic-ratelimit-unified-{slug}-{field}` headers.
+type AnthropicQuotaWindow struct {
+	// Status mirrors `unified-{slug}-status`: "allowed", "allowed_warning",
+	// "rejected". Pass-through string.
+	Status string
+	// Reset mirrors `unified-{slug}-reset` (epoch seconds → time.Time).
+	Reset time.Time
+	// Utilization mirrors `unified-{slug}-utilization` as a fraction. Can
+	// exceed 1.0 when overage is in effect. Consult HasUtilization to
+	// distinguish a real 0.0 reading from "header not present".
+	Utilization float64
+	// HasUtilization is true iff a `unified-{slug}-utilization` header was
+	// observed for this window. Without this flag, a 0.0 utilization is
+	// indistinguishable from an absent header — both cases would mislead
+	// downstream alerts into treating unknown utilization as healthy usage.
+	HasUtilization bool
+	// SurpassedThreshold mirrors `unified-{slug}-surpassed-threshold`. Optional;
+	// 0 when absent. Typically populated only when Status is at warning or above.
+	SurpassedThreshold float64
+}
+
+var anthropicRateLimitHintByAuth sync.Map
+
+// SetAnthropicRateLimitHint updates the latest known Anthropic rate-limit state
+// for an auth. ObservedAt is defaulted to time.Now() if zero. Empty authID is
+// silently ignored. Concurrent-safe.
+func SetAnthropicRateLimitHint(authID string, hint AnthropicRateLimitHint) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return
+	}
+	if hint.ObservedAt.IsZero() {
+		hint.ObservedAt = time.Now()
+	}
+	// Clone map fields so the stored hint owns its own state. Without this,
+	// a caller that mutates the maps post-Set would corrupt the shared
+	// store and risk "concurrent map iteration and map write" panics under
+	// concurrent Get traffic. Pairs with the Get-side defensive copy: store
+	// owns its inner maps, callers see independent copies on both sides.
+	if hint.Windows != nil {
+		cloned := make(map[string]AnthropicQuotaWindow, len(hint.Windows))
+		for k, v := range hint.Windows {
+			cloned[k] = v
+		}
+		hint.Windows = cloned
+	}
+	if hint.RawHeaders != nil {
+		cloned := make(map[string]string, len(hint.RawHeaders))
+		for k, v := range hint.RawHeaders {
+			cloned[k] = v
+		}
+		hint.RawHeaders = cloned
+	}
+	anthropicRateLimitHintByAuth.Store(authID, hint)
+}
+
+// GetAnthropicRateLimitHint returns the latest known Anthropic rate-limit state
+// for an auth. The returned bool is true when a hint has been stored for this
+// authID at any point; the hint's Known field reflects whether the stored data
+// includes any parsed unified-* header content (a non-empty record).
+func GetAnthropicRateLimitHint(authID string) (AnthropicRateLimitHint, bool) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return AnthropicRateLimitHint{}, false
+	}
+	value, ok := anthropicRateLimitHintByAuth.Load(authID)
+	if !ok {
+		return AnthropicRateLimitHint{}, false
+	}
+	hint, ok := value.(AnthropicRateLimitHint)
+	if !ok {
+		anthropicRateLimitHintByAuth.Delete(authID)
+		return AnthropicRateLimitHint{}, false
+	}
+	// Clone map fields so callers cannot mutate internal state. Concurrent
+	// readers each get an independent view; the shared store remains stable.
+	// Without this, a caller mutating got.Windows or got.RawHeaders (even
+	// accidentally while preparing response data) would race against other
+	// readers and could trigger a `concurrent map read and map write` panic.
+	if hint.Windows != nil {
+		cloned := make(map[string]AnthropicQuotaWindow, len(hint.Windows))
+		for k, v := range hint.Windows {
+			cloned[k] = v
+		}
+		hint.Windows = cloned
+	}
+	if hint.RawHeaders != nil {
+		cloned := make(map[string]string, len(hint.RawHeaders))
+		for k, v := range hint.RawHeaders {
+			cloned[k] = v
+		}
+		hint.RawHeaders = cloned
+	}
+	return hint, true
+}
+
+// HasKnownAnthropicRateLimitHint reports whether a hint with parsed content has
+// been captured for this auth.
+func HasKnownAnthropicRateLimitHint(authID string) bool {
+	hint, ok := GetAnthropicRateLimitHint(authID)
+	return ok && hint.Known
+}
+
+// DeleteAnthropicRateLimitHint removes any stored hint for an auth. Empty
+// authID is a no-op. Concurrent-safe.
+//
+// Called from sdk/cliproxy.applyCoreAuthRemoval so a recreated auth with the
+// same ID cannot surface stale quota state via the management API.
+func DeleteAnthropicRateLimitHint(authID string) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return
+	}
+	anthropicRateLimitHintByAuth.Delete(authID)
+}

--- a/sdk/cliproxy/auth/anthropic_rate_limit.go
+++ b/sdk/cliproxy/auth/anthropic_rate_limit.go
@@ -3,10 +3,35 @@ package auth
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 )
+
+// maxCarriedAnthropicWindows bounds how many windows one merge carries forward,
+// so a hint holds at most its own capture's windows plus this many. The carried
+// side is the one needing a bound: a capture is sized by one response, while
+// merging accumulates across responses over slugs and resets the upstream
+// chooses. The capture's own count is not deducted, so a capture that fills its
+// own budget still carries.
+//
+// On the executor path the capture side is bounded by maxAnthropicWindows in
+// internal/runtime/executor/helps/claude_rate_limit_record.go. That value is
+// restated here rather than imported: sdk does not depend on that package, and
+// this entry point is exported to callers that bypass it.
+const maxCarriedAnthropicWindows = 64
+
+// maxAnthropicCarryHorizon bounds both how far ahead a carried window's reset
+// may be and how old the reading itself may be. Seven days is the longest
+// window the unified family exposes, and Reset comes from the response, so a
+// distant reset is one the age-out gate never fires on. Bounding the reading's
+// age as well keeps a beyond-horizon window from re-entering the carry set once
+// a gap in traffic moves the capture instant close enough to that reset.
+//
+// Only carrying is gated: such a window is still stored and served while the
+// capture that reported it is the current one.
+const maxAnthropicCarryHorizon = 8 * 24 * time.Hour
 
 // AnthropicRateLimitHint records the most-recent Anthropic
 // `anthropic-ratelimit-unified-*` response-header state observed for one auth.
@@ -41,6 +66,9 @@ type AnthropicRateLimitHint struct {
 	// header names of the form `anthropic-ratelimit-unified-{slug}-{field}`,
 	// e.g. "5h", "7d", "7d_opus". The map is generative; consumers should
 	// iterate rather than assume a fixed key set.
+	//
+	// Not necessarily one response's worth: SetAnthropicRateLimitHint carries
+	// live windows forward, so this can hold windows RawHeaders never mentions.
 	Windows map[string]AnthropicQuotaWindow
 	// FallbackPercentage mirrors `anthropic-ratelimit-unified-fallback-percentage`.
 	// Optional; 0 when absent.
@@ -76,6 +104,13 @@ type AnthropicRateLimitHint struct {
 // AnthropicQuotaWindow records per-window state captured from
 // `anthropic-ratelimit-unified-{slug}-{field}` headers.
 type AnthropicQuotaWindow struct {
+	// ObservedAt is when this window's state was captured, which lags the
+	// hint-level ObservedAt for a window carried forward from an earlier
+	// capture (see SetAnthropicRateLimitHint). Age a reading out against this
+	// field, not the hint-level one. The store sets it, overwriting whatever
+	// the caller supplied, and it changes on every capture — exclude it when
+	// comparing windows to detect a change in quota state.
+	ObservedAt time.Time
 	// Status mirrors `unified-{slug}-status`: "allowed", "allowed_warning",
 	// "rejected". Pass-through string.
 	Status string
@@ -111,6 +146,48 @@ var anthropicRateLimitWriteMu sync.Mutex
 // SetAnthropicRateLimitHint updates the latest known Anthropic rate-limit state
 // for an auth. ObservedAt is defaulted to time.Now() if zero. Empty authID is
 // silently ignored. Concurrent-safe.
+//
+// Windows are merged with the stored hint; everything else — Status, Reset,
+// RepresentativeClaim, RawHeaders and the rest — describes this capture alone
+// and replaces what was stored. The `unified-*` family covers only the windows
+// belonging to the responding model's tier, so an ordinary response omits a
+// premium window such as `7d_oi` whose quota is still live, and replacing
+// wholesale drops it hours before its reset.
+//
+// A window the stored hint knows and this capture omits — or names without
+// reporting a single field for — is carried over when all of:
+//
+//   - this capture has Known set. One with no unified-* content inherits
+//     nothing.
+//   - the stored capture's AccountFingerprint equals this one's. Any
+//     difference, including one side empty, leaves identity unestablished.
+//   - the window's Reset is after this capture's ObservedAt. A reset exactly at
+//     it has arrived; a zero Reset can never age out.
+//   - that Reset is at most maxAnthropicCarryHorizon ahead, and the reading is
+//     itself no older than that.
+//
+// A window this capture did report replaces the stored one whole, never field
+// by field — including one reported without a parseable reset, which is honest
+// new data that no later capture can carry.
+//
+// At most maxCarriedAnthropicWindows are carried per merge. When that binds the
+// candidates resetting soonest are dropped, since ordinary captures re-report a
+// near-reset window anyway while the long-horizon ones are what the carry
+// exists to preserve; ties break on slug.
+//
+// Carried windows keep the per-window ObservedAt of the capture that observed
+// them, and the rest are stamped with this capture's, overwriting the caller's
+// value. A hint from GetAnthropicRateLimitHint must therefore not be written
+// back through this function: the round trip re-stamps carried windows as
+// freshly observed, so it is not an identity. To assert that the window set is
+// exactly X, call DeleteAnthropicRateLimitHint first — a sequence that is not
+// atomic against a concurrent capture, since Delete does not take the writer
+// mutex.
+//
+// One limitation: a capture older than the stored one is dropped whole, windows
+// included, so a live window only it observed is lost rather than merged. Call
+// sites stamp ObservedAt and then parse the response before calling, so the
+// window for that reorder is the parse plus the wait on the writer mutex.
 func SetAnthropicRateLimitHint(authID string, hint AnthropicRateLimitHint) {
 	authID = strings.TrimSpace(authID)
 	if authID == "" {
@@ -127,6 +204,9 @@ func SetAnthropicRateLimitHint(authID string, hint AnthropicRateLimitHint) {
 	if hint.Windows != nil {
 		cloned := make(map[string]AnthropicQuotaWindow, len(hint.Windows))
 		for k, v := range hint.Windows {
+			// The store owns per-window ObservedAt; carried windows keep the
+			// stamp of the capture that saw them.
+			v.ObservedAt = hint.ObservedAt
 			cloned[k] = v
 		}
 		hint.Windows = cloned
@@ -138,11 +218,8 @@ func SetAnthropicRateLimitHint(authID string, hint AnthropicRateLimitHint) {
 		}
 		hint.RawHeaders = cloned
 	}
-	// Drop a capture that is older than what is already stored. ObservedAt is
-	// stamped by the caller before it parses the response, so two goroutines
-	// serving concurrent requests on one credential -- the normal mode for a
-	// proxy -- can stamp t1 < t2 and still reach this Store in the reverse
-	// order, leaving the older snapshot as "the most recent state observed".
+	// Drop a capture older than what is already stored; the godoc above covers
+	// how two concurrent captures on one credential arrive out of order.
 	//
 	// This orders same-credential captures only. A response already in flight
 	// when the credential rotated carries a *newer* ObservedAt than the
@@ -157,11 +234,94 @@ func SetAnthropicRateLimitHint(authID string, hint AnthropicRateLimitHint) {
 	anthropicRateLimitWriteMu.Lock()
 	defer anthropicRateLimitWriteMu.Unlock()
 	if prev, ok := anthropicRateLimitHintByAuth.Load(authID); ok {
-		if prevHint, ok := prev.(AnthropicRateLimitHint); ok && prevHint.ObservedAt.After(hint.ObservedAt) {
-			return
+		if prevHint, okPrev := prev.(AnthropicRateLimitHint); okPrev {
+			if prevHint.ObservedAt.After(hint.ObservedAt) {
+				return
+			}
+			carryLiveWindows(&hint, prevHint)
 		}
 	}
 	anthropicRateLimitHintByAuth.Store(authID, hint)
+}
+
+// windowHasContent reports whether a window says anything about quota, matching
+// the emptiness rule the management projection applies before emitting one. The
+// parser seeds a slug as soon as any header names it, so an entry whose every
+// header failed to parse records that a header arrived, not an observation.
+func windowHasContent(window AnthropicQuotaWindow) bool {
+	return window.Status != "" ||
+		window.HasUtilization ||
+		window.HasSurpassedThreshold ||
+		!window.Reset.IsZero()
+}
+
+// carryLiveWindows extends the capture's windows with the still-live windows
+// prevHint knows and this capture did not report; SetAnthropicRateLimitHint
+// documents the policy.
+//
+// prevHint is the stored hint, so its map is read-only here; its values are
+// flat structs, so copying one out shares nothing. hint.Windows is this call's
+// private clone and the only map written.
+//
+// Must be called with anthropicRateLimitWriteMu held.
+func carryLiveWindows(hint *AnthropicRateLimitHint, prevHint AnthropicRateLimitHint) {
+	// A capture stating nothing about quota inherits nothing.
+	if !hint.Known {
+		return
+	}
+	if prevHint.AccountFingerprint != hint.AccountFingerprint {
+		return
+	}
+	horizon := hint.ObservedAt.Add(maxAnthropicCarryHorizon)
+
+	type carryCandidate struct {
+		slug  string
+		reset time.Time
+	}
+	candidates := make([]carryCandidate, 0, len(prevHint.Windows))
+	for slug, window := range prevHint.Windows {
+		if reported, ok := hint.Windows[slug]; ok && windowHasContent(reported) {
+			continue
+		}
+		// Excludes a zero Reset too: a window with no known reset could never
+		// be aged out.
+		if !window.Reset.After(hint.ObservedAt) {
+			continue
+		}
+		if window.Reset.After(horizon) {
+			continue
+		}
+		// A close-enough reset is not sufficient on its own. After a gap in
+		// traffic a reset that was implausibly distant when observed comes back
+		// inside the horizon, so bound the age of the reading as well.
+		if hint.ObservedAt.Sub(window.ObservedAt) > maxAnthropicCarryHorizon {
+			continue
+		}
+		candidates = append(candidates, carryCandidate{slug: slug, reset: window.Reset})
+	}
+	if len(candidates) == 0 {
+		return
+	}
+	if len(candidates) > maxCarriedAnthropicWindows {
+		// Keep the furthest resets: those are the long-horizon windows the
+		// responding tier stopped reporting, while near-reset candidates get
+		// re-reported anyway. Slug breaks ties so eviction never depends on map
+		// iteration order.
+		sort.Slice(candidates, func(left, right int) bool {
+			if !candidates[left].reset.Equal(candidates[right].reset) {
+				return candidates[left].reset.After(candidates[right].reset)
+			}
+			return candidates[left].slug < candidates[right].slug
+		})
+		candidates = candidates[:maxCarriedAnthropicWindows]
+	}
+
+	if hint.Windows == nil {
+		hint.Windows = make(map[string]AnthropicQuotaWindow, len(candidates))
+	}
+	for _, candidate := range candidates {
+		hint.Windows[candidate.slug] = prevHint.Windows[candidate.slug]
+	}
 }
 
 // GetAnthropicRateLimitHint returns the latest known Anthropic rate-limit state

--- a/sdk/cliproxy/auth/anthropic_rate_limit.go
+++ b/sdk/cliproxy/auth/anthropic_rate_limit.go
@@ -1,0 +1,198 @@
+package auth
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// AnthropicRateLimitHint records the most-recent Anthropic
+// `anthropic-ratelimit-unified-*` response-header state observed for one auth.
+//
+// This is passive observability state, populated by the Claude executor on every
+// upstream response. It is NOT consulted by the conductor or selector for routing
+// decisions — those continue to use Auth.Quota / Auth.NextRetryAfter. Operators
+// (management API consumers, dashboards) read this hint to surface utilization
+// and reset times before a credential is actually rate-limited.
+//
+// All fields except Known and ObservedAt are optional. Anthropic's
+// `unified-*` family is undocumented and field set has been observed to grow
+// over time (e.g. tier-specific 7d windows like `7d_opus`); the Windows map is
+// keyed by header window slug rather than predeclared fields so new windows
+// surface without code change.
+type AnthropicRateLimitHint struct {
+	// Known is true once any unified-* header has been observed for this auth.
+	Known bool
+	// ObservedAt is when the most recent capture happened (server clock).
+	ObservedAt time.Time
+	// Status mirrors `anthropic-ratelimit-unified-status`: e.g. "allowed",
+	// "allowed_warning", "rejected". Pass-through string; do not enum-tighten.
+	Status string
+	// RepresentativeClaim names the binding window
+	// (`anthropic-ratelimit-unified-representative-claim`); e.g. "five_hour",
+	// "seven_day", "seven_day_opus". Pass-through string.
+	RepresentativeClaim string
+	// Reset is the reset moment of the representative window
+	// (`anthropic-ratelimit-unified-reset`, epoch seconds → time.Time).
+	Reset time.Time
+	// Windows maps window slug → per-window state. Slugs are extracted from
+	// header names of the form `anthropic-ratelimit-unified-{slug}-{field}`,
+	// e.g. "5h", "7d", "7d_opus". The map is generative; consumers should
+	// iterate rather than assume a fixed key set.
+	Windows map[string]AnthropicQuotaWindow
+	// FallbackPercentage mirrors `anthropic-ratelimit-unified-fallback-percentage`.
+	// Optional; 0 when absent.
+	FallbackPercentage float64
+	// OverageStatus mirrors `anthropic-ratelimit-unified-overage-status`.
+	// Optional; empty when absent.
+	OverageStatus string
+	// OverageDisabledReason mirrors
+	// `anthropic-ratelimit-unified-overage-disabled-reason`. Optional.
+	OverageDisabledReason string
+	// UpgradePaths mirrors `anthropic-ratelimit-unified-upgrade-paths`. Optional.
+	UpgradePaths string
+	// RawHeaders preserves every observed `anthropic-ratelimit-unified-*` header
+	// as a lower-cased name → first value map. Forward-compat safety net for
+	// undocumented schema drift; may be nil when no headers were captured.
+	RawHeaders map[string]string
+}
+
+// AnthropicQuotaWindow records per-window state captured from
+// `anthropic-ratelimit-unified-{slug}-{field}` headers.
+type AnthropicQuotaWindow struct {
+	// Status mirrors `unified-{slug}-status`: "allowed", "allowed_warning",
+	// "rejected". Pass-through string.
+	Status string
+	// Reset mirrors `unified-{slug}-reset` (epoch seconds → time.Time).
+	Reset time.Time
+	// Utilization mirrors `unified-{slug}-utilization` as a fraction. Can
+	// exceed 1.0 when overage is in effect. Consult HasUtilization to
+	// distinguish a real 0.0 reading from "header not present".
+	Utilization float64
+	// HasUtilization is true iff a `unified-{slug}-utilization` header was
+	// observed for this window. Without this flag, a 0.0 utilization is
+	// indistinguishable from an absent header — both cases would mislead
+	// downstream alerts into treating unknown utilization as healthy usage.
+	HasUtilization bool
+	// SurpassedThreshold mirrors `unified-{slug}-surpassed-threshold`. Optional;
+	// 0 when absent. Typically populated only when Status is at warning or above.
+	SurpassedThreshold float64
+}
+
+var anthropicRateLimitHintByAuth sync.Map
+
+// SetAnthropicRateLimitHint updates the latest known Anthropic rate-limit state
+// for an auth. ObservedAt is defaulted to time.Now() if zero. Empty authID is
+// silently ignored. Concurrent-safe.
+func SetAnthropicRateLimitHint(authID string, hint AnthropicRateLimitHint) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return
+	}
+	if hint.ObservedAt.IsZero() {
+		hint.ObservedAt = time.Now()
+	}
+	// Clone map fields so the stored hint owns its own state. Without this,
+	// a caller that mutates the maps post-Set would corrupt the shared
+	// store and risk "concurrent map iteration and map write" panics under
+	// concurrent Get traffic. Pairs with the Get-side defensive copy: store
+	// owns its inner maps, callers see independent copies on both sides.
+	if hint.Windows != nil {
+		cloned := make(map[string]AnthropicQuotaWindow, len(hint.Windows))
+		for k, v := range hint.Windows {
+			cloned[k] = v
+		}
+		hint.Windows = cloned
+	}
+	if hint.RawHeaders != nil {
+		cloned := make(map[string]string, len(hint.RawHeaders))
+		for k, v := range hint.RawHeaders {
+			cloned[k] = v
+		}
+		hint.RawHeaders = cloned
+	}
+	// Drop a capture that is older than what is already stored. ObservedAt is
+	// stamped by the caller before it parses the response, so two goroutines
+	// serving concurrent requests on one credential -- the normal mode for a
+	// proxy -- can stamp t1 < t2 and still reach this Store in the reverse
+	// order, leaving the older snapshot as "the most recent state observed".
+	//
+	// This orders same-credential captures only. It deliberately does NOT
+	// address a response that was already in flight when the credential
+	// rotated: that write carries a *newer* ObservedAt than the replacement
+	// credential's capture, so no ordering rule can reject it. Rejecting it
+	// needs per-capture identity (an account fingerprint or auth generation),
+	// which this PR does not carry.
+	//
+	// Load-then-Store is not atomic, so a simultaneous pair can still
+	// interleave inside this window; it narrows the race rather than closing
+	// it. sync.Map.CompareAndSwap is not an option here --
+	// AnthropicRateLimitHint holds map fields and is uncomparable, so CAS
+	// would panic.
+	if prev, ok := anthropicRateLimitHintByAuth.Load(authID); ok {
+		if prevHint, ok := prev.(AnthropicRateLimitHint); ok && prevHint.ObservedAt.After(hint.ObservedAt) {
+			return
+		}
+	}
+	anthropicRateLimitHintByAuth.Store(authID, hint)
+}
+
+// GetAnthropicRateLimitHint returns the latest known Anthropic rate-limit state
+// for an auth. The returned bool is true when a hint has been stored for this
+// authID at any point; the hint's Known field reflects whether the stored data
+// includes any parsed unified-* header content (a non-empty record).
+func GetAnthropicRateLimitHint(authID string) (AnthropicRateLimitHint, bool) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return AnthropicRateLimitHint{}, false
+	}
+	value, ok := anthropicRateLimitHintByAuth.Load(authID)
+	if !ok {
+		return AnthropicRateLimitHint{}, false
+	}
+	hint, ok := value.(AnthropicRateLimitHint)
+	if !ok {
+		anthropicRateLimitHintByAuth.Delete(authID)
+		return AnthropicRateLimitHint{}, false
+	}
+	// Clone map fields so callers cannot mutate internal state. Concurrent
+	// readers each get an independent view; the shared store remains stable.
+	// Without this, a caller mutating got.Windows or got.RawHeaders (even
+	// accidentally while preparing response data) would race against other
+	// readers and could trigger a `concurrent map read and map write` panic.
+	if hint.Windows != nil {
+		cloned := make(map[string]AnthropicQuotaWindow, len(hint.Windows))
+		for k, v := range hint.Windows {
+			cloned[k] = v
+		}
+		hint.Windows = cloned
+	}
+	if hint.RawHeaders != nil {
+		cloned := make(map[string]string, len(hint.RawHeaders))
+		for k, v := range hint.RawHeaders {
+			cloned[k] = v
+		}
+		hint.RawHeaders = cloned
+	}
+	return hint, true
+}
+
+// HasKnownAnthropicRateLimitHint reports whether a hint with parsed content has
+// been captured for this auth.
+func HasKnownAnthropicRateLimitHint(authID string) bool {
+	hint, ok := GetAnthropicRateLimitHint(authID)
+	return ok && hint.Known
+}
+
+// DeleteAnthropicRateLimitHint removes any stored hint for an auth. Empty
+// authID is a no-op. Concurrent-safe.
+//
+// Called from sdk/cliproxy.applyCoreAuthRemoval so a recreated auth with the
+// same ID cannot surface stale quota state via the management API.
+func DeleteAnthropicRateLimitHint(authID string) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return
+	}
+	anthropicRateLimitHintByAuth.Delete(authID)
+}

--- a/sdk/cliproxy/auth/anthropic_rate_limit.go
+++ b/sdk/cliproxy/auth/anthropic_rate_limit.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 	"sync"
 	"time"
@@ -43,6 +45,10 @@ type AnthropicRateLimitHint struct {
 	// FallbackPercentage mirrors `anthropic-ratelimit-unified-fallback-percentage`.
 	// Optional; 0 when absent.
 	FallbackPercentage float64
+	// HasFallbackPercentage is true iff the header was present AND parsed to a
+	// usable number. It separates an explicit 0 from both "absent" and
+	// "malformed", so a consumer never renders garbage as a real reading.
+	HasFallbackPercentage bool
 	// OverageStatus mirrors `anthropic-ratelimit-unified-overage-status`.
 	// Optional; empty when absent.
 	OverageStatus string
@@ -55,6 +61,16 @@ type AnthropicRateLimitHint struct {
 	// as a lower-cased name → first value map. Forward-compat safety net for
 	// undocumented schema drift; may be nil when no headers were captured.
 	RawHeaders map[string]string
+	// AccountFingerprint identifies the underlying account this capture came
+	// from (see AnthropicAccountFingerprint). The hint store is keyed by auth
+	// ID, but an ID can be reused across credentials — a rotation in place, or
+	// a delete-then-recreate. Tagging the capture lets readers reject a hint
+	// that demonstrably belongs to a different account instead of reporting the
+	// previous credential's quota.
+	//
+	// Empty means "account unknown" (e.g. an OAuth credential with no email in
+	// metadata) and never causes rejection; see AnthropicRateLimitHintFor.
+	AccountFingerprint string
 }
 
 // AnthropicQuotaWindow records per-window state captured from
@@ -77,9 +93,20 @@ type AnthropicQuotaWindow struct {
 	// SurpassedThreshold mirrors `unified-{slug}-surpassed-threshold`. Optional;
 	// 0 when absent. Typically populated only when Status is at warning or above.
 	SurpassedThreshold float64
+	// HasSurpassedThreshold is true iff the header was present AND parsed.
+	// Same contract as HasUtilization.
+	HasSurpassedThreshold bool
 }
 
 var anthropicRateLimitHintByAuth sync.Map
+
+// anthropicRateLimitWriteMu serializes the read-compare-write in
+// SetAnthropicRateLimitHint. sync.Map offers no compare-and-swap usable here --
+// AnthropicRateLimitHint holds map fields and is uncomparable, so CompareAndSwap
+// would panic -- and a bare Load-then-Store lets two concurrent captures for one
+// auth interleave, which is the proxy's normal load rather than an edge case.
+// Readers stay lock-free: this guards writers against each other only.
+var anthropicRateLimitWriteMu sync.Mutex
 
 // SetAnthropicRateLimitHint updates the latest known Anthropic rate-limit state
 // for an auth. ObservedAt is defaulted to time.Now() if zero. Empty authID is
@@ -117,18 +144,18 @@ func SetAnthropicRateLimitHint(authID string, hint AnthropicRateLimitHint) {
 	// proxy -- can stamp t1 < t2 and still reach this Store in the reverse
 	// order, leaving the older snapshot as "the most recent state observed".
 	//
-	// This orders same-credential captures only. It deliberately does NOT
-	// address a response that was already in flight when the credential
-	// rotated: that write carries a *newer* ObservedAt than the replacement
-	// credential's capture, so no ordering rule can reject it. Rejecting it
-	// needs per-capture identity (an account fingerprint or auth generation),
-	// which this PR does not carry.
+	// This orders same-credential captures only. A response already in flight
+	// when the credential rotated carries a *newer* ObservedAt than the
+	// replacement's capture, so no ordering rule can reject it; that case is
+	// handled on read instead, by the account fingerprint (see
+	// AnthropicRateLimitHintFor). The two are complementary: ordering settles
+	// which snapshot of one account wins, identity settles which account the
+	// stored snapshot belongs to.
 	//
-	// Load-then-Store is not atomic, so a simultaneous pair can still
-	// interleave inside this window; it narrows the race rather than closing
-	// it. sync.Map.CompareAndSwap is not an option here --
-	// AnthropicRateLimitHint holds map fields and is uncomparable, so CAS
-	// would panic.
+	// Serialized against other writers so the compare and the store cannot be
+	// split by a concurrent capture; see anthropicRateLimitWriteMu.
+	anthropicRateLimitWriteMu.Lock()
+	defer anthropicRateLimitWriteMu.Unlock()
 	if prev, ok := anthropicRateLimitHintByAuth.Load(authID); ok {
 		if prevHint, ok := prev.(AnthropicRateLimitHint); ok && prevHint.ObservedAt.After(hint.ObservedAt) {
 			return
@@ -141,6 +168,14 @@ func SetAnthropicRateLimitHint(authID string, hint AnthropicRateLimitHint) {
 // for an auth. The returned bool is true when a hint has been stored for this
 // authID at any point; the hint's Known field reflects whether the stored data
 // includes any parsed unified-* header content (a non-empty record).
+//
+// This lookup is by auth ID alone and does NOT check account identity. An auth
+// ID reused across a credential rotation can therefore return the previous
+// account's quota here. Callers that hold the *Auth — which is every caller
+// serving this data outward — should use AnthropicRateLimitHintFor instead,
+// which rejects a hint belonging to a different account. This entry point
+// remains for lookups where no *Auth is available and the ID-only semantics
+// are the intent.
 func GetAnthropicRateLimitHint(authID string) (AnthropicRateLimitHint, bool) {
 	authID = strings.TrimSpace(authID)
 	if authID == "" {
@@ -178,17 +213,71 @@ func GetAnthropicRateLimitHint(authID string) (AnthropicRateLimitHint, bool) {
 }
 
 // HasKnownAnthropicRateLimitHint reports whether a hint with parsed content has
-// been captured for this auth.
+// been captured for this auth. Like GetAnthropicRateLimitHint, this is keyed by
+// auth ID alone and does not check account identity.
 func HasKnownAnthropicRateLimitHint(authID string) bool {
 	hint, ok := GetAnthropicRateLimitHint(authID)
 	return ok && hint.Known
 }
 
+// AnthropicAccountFingerprint derives a stable, non-secret identifier for the
+// account behind an auth, used to detect that a reused auth ID now refers to a
+// different credential.
+//
+// Returns "" when the account cannot be identified (nil auth, or an OAuth
+// credential whose metadata carries no email). Callers must treat "" as
+// "unknown" rather than as a distinct account.
+//
+// The underlying AccountInfo value is hashed rather than stored: for API-key
+// auths it is the API key itself, which must not sit in a process-wide map or
+// reach a management response.
+func AnthropicAccountFingerprint(auth *Auth) string {
+	if auth == nil {
+		return ""
+	}
+	kind, value := auth.AccountInfo()
+	value = strings.TrimSpace(value)
+	if kind == "" || value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(kind + "\x00" + value))
+	return hex.EncodeToString(sum[:8])
+}
+
+// AnthropicRateLimitHintFor returns the stored hint for an auth, rejecting a
+// capture that provably belongs to a different account under the same auth ID.
+//
+// Rejection requires both fingerprints to be non-empty and different. An empty
+// fingerprint on either side means "account unknown", which resolves to serving
+// the hint: an unknown account is the pre-existing ID-only behaviour, whereas
+// rejecting on unknown would discard valid state every time an account became
+// unidentifiable — for instance a token refresh that returns no email.
+//
+// This is what makes the store safe against auth-lifecycle events without
+// hooking them. A capture still in flight when a credential rotates lands under
+// the old fingerprint and is rejected here rather than resurrecting stale quota.
+func AnthropicRateLimitHintFor(auth *Auth) (AnthropicRateLimitHint, bool) {
+	if auth == nil {
+		return AnthropicRateLimitHint{}, false
+	}
+	hint, ok := GetAnthropicRateLimitHint(auth.ID)
+	if !ok {
+		return AnthropicRateLimitHint{}, false
+	}
+	expected := AnthropicAccountFingerprint(auth)
+	if expected != "" && hint.AccountFingerprint != "" && expected != hint.AccountFingerprint {
+		return AnthropicRateLimitHint{}, false
+	}
+	return hint, true
+}
+
 // DeleteAnthropicRateLimitHint removes any stored hint for an auth. Empty
 // authID is a no-op. Concurrent-safe.
 //
-// Called from sdk/cliproxy.applyCoreAuthRemoval so a recreated auth with the
-// same ID cannot surface stale quota state via the management API.
+// Called from Manager.Remove to release the entry when a credential goes away.
+// Correctness against a reused auth ID does not depend on this running:
+// AnthropicRateLimitHintFor rejects a capture whose account fingerprint no
+// longer matches, which also covers a capture that lands after the delete.
 func DeleteAnthropicRateLimitHint(authID string) {
 	authID = strings.TrimSpace(authID)
 	if authID == "" {

--- a/sdk/cliproxy/auth/anthropic_rate_limit.go
+++ b/sdk/cliproxy/auth/anthropic_rate_limit.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 	"sync"
 	"time"
@@ -55,6 +57,16 @@ type AnthropicRateLimitHint struct {
 	// as a lower-cased name → first value map. Forward-compat safety net for
 	// undocumented schema drift; may be nil when no headers were captured.
 	RawHeaders map[string]string
+	// AccountFingerprint identifies the underlying account this capture came
+	// from (see AnthropicAccountFingerprint). The hint store is keyed by auth
+	// ID, but an ID can be reused across credentials — a rotation in place, or
+	// a delete-then-recreate. Tagging the capture lets readers reject a hint
+	// that demonstrably belongs to a different account instead of reporting the
+	// previous credential's quota.
+	//
+	// Empty means "account unknown" (e.g. an OAuth credential with no email in
+	// metadata) and never causes rejection; see AnthropicRateLimitHintFor.
+	AccountFingerprint string
 }
 
 // AnthropicQuotaWindow records per-window state captured from
@@ -161,11 +173,64 @@ func HasKnownAnthropicRateLimitHint(authID string) bool {
 	return ok && hint.Known
 }
 
+// AnthropicAccountFingerprint derives a stable, non-secret identifier for the
+// account behind an auth, used to detect that a reused auth ID now refers to a
+// different credential.
+//
+// Returns "" when the account cannot be identified (nil auth, or an OAuth
+// credential whose metadata carries no email). Callers must treat "" as
+// "unknown" rather than as a distinct account.
+//
+// The underlying AccountInfo value is hashed rather than stored: for API-key
+// auths it is the API key itself, which must not sit in a process-wide map or
+// reach a management response.
+func AnthropicAccountFingerprint(auth *Auth) string {
+	if auth == nil {
+		return ""
+	}
+	kind, value := auth.AccountInfo()
+	value = strings.TrimSpace(value)
+	if kind == "" || value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(kind + "\x00" + value))
+	return hex.EncodeToString(sum[:8])
+}
+
+// AnthropicRateLimitHintFor returns the stored hint for an auth, rejecting a
+// capture that provably belongs to a different account under the same auth ID.
+//
+// Rejection requires both fingerprints to be non-empty and different. An empty
+// fingerprint on either side means "account unknown", which resolves to serving
+// the hint: an unknown account is the pre-existing ID-only behaviour, whereas
+// rejecting on unknown would discard valid state every time an account became
+// unidentifiable — for instance a token refresh that returns no email.
+//
+// This is what makes the store safe against auth-lifecycle events without
+// hooking them. A capture still in flight when a credential rotates lands under
+// the old fingerprint and is rejected here rather than resurrecting stale quota.
+func AnthropicRateLimitHintFor(auth *Auth) (AnthropicRateLimitHint, bool) {
+	if auth == nil {
+		return AnthropicRateLimitHint{}, false
+	}
+	hint, ok := GetAnthropicRateLimitHint(auth.ID)
+	if !ok {
+		return AnthropicRateLimitHint{}, false
+	}
+	expected := AnthropicAccountFingerprint(auth)
+	if expected != "" && hint.AccountFingerprint != "" && expected != hint.AccountFingerprint {
+		return AnthropicRateLimitHint{}, false
+	}
+	return hint, true
+}
+
 // DeleteAnthropicRateLimitHint removes any stored hint for an auth. Empty
 // authID is a no-op. Concurrent-safe.
 //
-// Called from sdk/cliproxy.applyCoreAuthRemoval so a recreated auth with the
-// same ID cannot surface stale quota state via the management API.
+// Called from Manager.Remove to release the entry when a credential goes away.
+// Correctness against a reused auth ID does not depend on this running:
+// AnthropicRateLimitHintFor rejects a capture whose account fingerprint no
+// longer matches, which also covers a capture that lands after the delete.
 func DeleteAnthropicRateLimitHint(authID string) {
 	authID = strings.TrimSpace(authID)
 	if authID == "" {

--- a/sdk/cliproxy/auth/anthropic_rate_limit_test.go
+++ b/sdk/cliproxy/auth/anthropic_rate_limit_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -611,5 +613,712 @@ func TestSetAnthropicRateLimitHint_ConcurrentOrderingHolds(t *testing.T) {
 			t.Fatalf("round %d: ObservedAt = %v, want %v — an older concurrent capture won",
 				round, got.ObservedAt, base)
 		}
+	}
+}
+
+// windowSlugs lists the stored window keys in a stable order, so a failure
+// message says which windows survived rather than printing a randomized map.
+func windowSlugs(hint AnthropicRateLimitHint) []string {
+	slugs := make([]string, 0, len(hint.Windows))
+	for slug := range hint.Windows {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+	return slugs
+}
+
+// TestSetAnthropicRateLimitHint_CarriesWindowOmittedByPartialCapture pins the
+// merge. Anthropic reports only the windows belonging to the responding model's
+// tier, so the first ordinary-tier response after a premium one carries no
+// `7d_oi` header at all. Replacing the stored windows wholesale erased that
+// window while its quota was still live — observed in production as a premium
+// weekly reading that vanished minutes after appearing, hours before its reset.
+func TestSetAnthropicRateLimitHint_CarriesWindowOmittedByPartialCapture(t *testing.T) {
+	const authID = "auth-carry-premium-weekly"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	premiumAt := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	ordinaryAt := premiumAt.Add(4 * time.Minute)
+	oiReset := premiumAt.Add(30 * time.Hour)
+	// An identified account on both sides, so the carry rides the same
+	// fingerprint comparison production does rather than the both-empty branch.
+	const fingerprint = "fp-carry-premium-weekly"
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         premiumAt,
+		Status:             "allowed_warning",
+		AccountFingerprint: fingerprint,
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h":    {Status: "allowed", Reset: premiumAt.Add(2 * time.Hour), Utilization: 0.20, HasUtilization: true},
+			"7d":    {Status: "allowed", Reset: premiumAt.Add(72 * time.Hour), Utilization: 0.40, HasUtilization: true},
+			"7d_oi": {Status: "allowed_warning", Reset: oiReset, Utilization: 0.88, HasUtilization: true},
+		},
+	})
+
+	// An ordinary-tier response: same account, no premium window in the family.
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         ordinaryAt,
+		Status:             "allowed",
+		AccountFingerprint: fingerprint,
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h": {Status: "allowed", Reset: ordinaryAt.Add(2 * time.Hour), Utilization: 0.30, HasUtilization: true},
+			"7d": {Status: "allowed", Reset: ordinaryAt.Add(72 * time.Hour), Utilization: 0.45, HasUtilization: true},
+		},
+	})
+
+	got, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("GetAnthropicRateLimitHint() ok = false, want true")
+	}
+	if len(got.Windows) != 3 {
+		t.Fatalf("windows = %v, want 5h, 7d and a carried 7d_oi", windowSlugs(got))
+	}
+
+	oi, ok := got.Windows["7d_oi"]
+	if !ok {
+		t.Fatalf("7d_oi erased by a capture that never reported it; windows = %v", windowSlugs(got))
+	}
+	if oi.Utilization != 0.88 || oi.Status != "allowed_warning" || !oi.Reset.Equal(oiReset) {
+		t.Errorf("carried 7d_oi = %+v, want the premium capture's reading unchanged", oi)
+	}
+	if !oi.ObservedAt.Equal(premiumAt) {
+		t.Errorf("carried 7d_oi ObservedAt = %v, want %v — a carried window must keep the stamp of the capture that saw it", oi.ObservedAt, premiumAt)
+	}
+
+	// Windows the newest capture did report come from it, stamp included.
+	fiveHour := got.Windows["5h"]
+	if fiveHour.Utilization != 0.30 {
+		t.Errorf("5h utilization = %v, want 0.30 from the newest capture", fiveHour.Utilization)
+	}
+	if !fiveHour.ObservedAt.Equal(ordinaryAt) {
+		t.Errorf("5h ObservedAt = %v, want %v", fiveHour.ObservedAt, ordinaryAt)
+	}
+	// Everything outside Windows still describes the newest capture alone.
+	if got.Status != "allowed" || !got.ObservedAt.Equal(ordinaryAt) {
+		t.Errorf("hint-level state = (%q, %v), want the newest capture's (%q, %v)", got.Status, got.ObservedAt, "allowed", ordinaryAt)
+	}
+}
+
+// TestSetAnthropicRateLimitHint_DoesNotCarryAcrossAccounts pins the identity
+// gate. Carrying is a claim that two captures describe the same quota, so it
+// requires the same account on both sides. An unknown account on either side
+// is not a match: unlike the read path — where serving an unidentifiable hint
+// only risks showing the operator a stale reading — carrying would fabricate a
+// window the current credential may never have had.
+func TestSetAnthropicRateLimitHint_DoesNotCarryAcrossAccounts(t *testing.T) {
+	first := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+
+	cases := []struct {
+		name string
+		prev string
+		next string
+	}{
+		{name: "different accounts", prev: "fingerprint-before", next: "fingerprint-after"},
+		{name: "prior identified, capture unknown", prev: "fingerprint-before", next: ""},
+		{name: "prior unknown, capture identified", prev: "", next: "fingerprint-after"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			authID := "auth-carry-identity-" + tc.name
+			DeleteAnthropicRateLimitHint(authID)
+			t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+			SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+				Known:              true,
+				ObservedAt:         first,
+				AccountFingerprint: tc.prev,
+				Windows: map[string]AnthropicQuotaWindow{
+					"7d_oi": {Status: "allowed", Reset: first.Add(30 * time.Hour)},
+				},
+			})
+			SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+				Known:              true,
+				ObservedAt:         second,
+				AccountFingerprint: tc.next,
+				Windows: map[string]AnthropicQuotaWindow{
+					"5h": {Status: "allowed", Reset: second.Add(2 * time.Hour)},
+				},
+			})
+
+			got, _ := GetAnthropicRateLimitHint(authID)
+			if _, present := got.Windows["7d_oi"]; present {
+				t.Errorf("carried a window across unproven identity (%q → %q); windows = %v", tc.prev, tc.next, windowSlugs(got))
+			}
+		})
+	}
+}
+
+// TestSetAnthropicRateLimitHint_FreshWindowReplacesStored pins that the merge
+// works at window granularity and never at field granularity. A slug the new
+// capture reports is that capture's reading in full: a field the older capture
+// had and the newer one lacks must not survive inside it, or a cleared warning
+// would look permanent.
+func TestSetAnthropicRateLimitHint_FreshWindowReplacesStored(t *testing.T) {
+	const authID = "auth-carry-fresh-wins"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	first := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+
+	const fingerprint = "fp-fresh-wins"
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         first,
+		AccountFingerprint: fingerprint,
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h": {
+				Status:                "allowed_warning",
+				Reset:                 first.Add(2 * time.Hour),
+				Utilization:           0.91,
+				HasUtilization:        true,
+				SurpassedThreshold:    0.90,
+				HasSurpassedThreshold: true,
+			},
+		},
+	})
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         second,
+		AccountFingerprint: fingerprint,
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h": {Status: "allowed", Reset: second.Add(5 * time.Hour), Utilization: 0.05, HasUtilization: true},
+		},
+	})
+
+	got, _ := GetAnthropicRateLimitHint(authID)
+	fiveHour := got.Windows["5h"]
+	if fiveHour.Status != "allowed" || fiveHour.Utilization != 0.05 {
+		t.Errorf("5h = %+v, want the newest capture's reading", fiveHour)
+	}
+	if fiveHour.HasSurpassedThreshold || fiveHour.SurpassedThreshold != 0 {
+		t.Errorf("5h kept the stored capture's surpassed_threshold (%v) — windows merge whole, never field by field", fiveHour.SurpassedThreshold)
+	}
+	if !fiveHour.ObservedAt.Equal(second) {
+		t.Errorf("5h ObservedAt = %v, want %v", fiveHour.ObservedAt, second)
+	}
+}
+
+// TestSetAnthropicRateLimitHint_CarriesIntoCaptureWithoutWindows covers the
+// nil-map path: a capture can carry the unified-* family with no per-window
+// headers at all (RecordAnthropicRateLimit leaves Windows nil then), and the
+// carry has to allocate rather than write to a nil map.
+func TestSetAnthropicRateLimitHint_CarriesIntoCaptureWithoutWindows(t *testing.T) {
+	const authID = "auth-carry-into-nil-windows"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	first := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+	oiReset := first.Add(30 * time.Hour)
+	const fingerprint = "fp-carry-into-nil-windows"
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         first,
+		AccountFingerprint: fingerprint,
+		Windows: map[string]AnthropicQuotaWindow{
+			"7d_oi": {Status: "allowed", Reset: oiReset, Utilization: 0.88, HasUtilization: true},
+		},
+	})
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         second,
+		Status:             "allowed",
+		AccountFingerprint: fingerprint,
+	})
+
+	got, _ := GetAnthropicRateLimitHint(authID)
+	oi, ok := got.Windows["7d_oi"]
+	if !ok {
+		t.Fatalf("7d_oi lost to a capture with no windows of its own; windows = %v", windowSlugs(got))
+	}
+	if !oi.ObservedAt.Equal(first) || oi.Utilization != 0.88 {
+		t.Errorf("carried 7d_oi = %+v, want the first capture's reading and stamp", oi)
+	}
+}
+
+// TestSetAnthropicRateLimitHint_StampsWindowObservedAt pins that the store owns
+// the per-window timestamp. The field only means "which capture saw this" if no
+// caller can set it, and the carry policy reads it back as exactly that.
+func TestSetAnthropicRateLimitHint_StampsWindowObservedAt(t *testing.T) {
+	const authID = "auth-window-observed-at-stamp"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	capturedAt := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	callerSupplied := capturedAt.Add(-72 * time.Hour)
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: capturedAt,
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h": {Status: "allowed", Reset: capturedAt.Add(2 * time.Hour), ObservedAt: callerSupplied},
+		},
+	})
+
+	got, _ := GetAnthropicRateLimitHint(authID)
+	if !got.Windows["5h"].ObservedAt.Equal(capturedAt) {
+		t.Errorf("5h ObservedAt = %v, want %v — the store stamps this field, the caller does not", got.Windows["5h"].ObservedAt, capturedAt)
+	}
+}
+
+// TestSetAnthropicRateLimitHint_ConcurrentMergeKeepsCarriedWindow runs the
+// merge itself under concurrency, which the ordering tests do not: they store
+// window-less hints, so the carry loop never executes there. Premium- and
+// ordinary-tier captures race for one auth, and 7d_oi must survive whichever
+// one lands last — every capture after the seed either reports it or merges
+// from a stored hint that already carries it.
+//
+// Worth running under -race: the merge reads the store-owned window map of the
+// previous hint while other goroutines clone it on Get.
+func TestSetAnthropicRateLimitHint_ConcurrentMergeKeepsCarriedWindow(t *testing.T) {
+	const authID = "auth-concurrent-merge"
+	const writers = 64
+	const iterations = 32
+	const concurrentFingerprint = "fp-concurrent-merge"
+
+	base := time.Unix(1777500000, 0).UTC()
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	premiumWindows := func() map[string]AnthropicQuotaWindow {
+		return map[string]AnthropicQuotaWindow{
+			"5h":    {Status: "allowed", Reset: base.Add(2 * time.Hour), Utilization: 0.2, HasUtilization: true},
+			"7d":    {Status: "allowed", Reset: base.Add(72 * time.Hour), Utilization: 0.4, HasUtilization: true},
+			"7d_oi": {Status: "allowed", Reset: base.Add(96 * time.Hour), Utilization: 0.6, HasUtilization: true},
+		}
+	}
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known: true, ObservedAt: base, AccountFingerprint: concurrentFingerprint, Windows: premiumWindows(),
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				windows := premiumWindows()
+				if i%2 == 1 {
+					// Ordinary tier: the premium window is not in the family.
+					delete(windows, "7d_oi")
+				}
+				SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+					Known:              true,
+					ObservedAt:         base.Add(time.Duration(i*iterations+j+1) * time.Millisecond),
+					AccountFingerprint: concurrentFingerprint,
+					Windows:            windows,
+				})
+				_, _ = GetAnthropicRateLimitHint(authID)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	got, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("GetAnthropicRateLimitHint() ok = false, want true")
+	}
+	if _, present := got.Windows["7d_oi"]; !present {
+		t.Errorf("7d_oi lost under concurrent partial-family captures; windows = %v", windowSlugs(got))
+	}
+}
+
+// TestSetAnthropicRateLimitHint_UnknownCaptureCarriesNothing pins the Known
+// gate. A capture with no unified-* content says nothing about the account's
+// quota — it is either a scrub or a record that the auth exists — so it must
+// not inherit windows and quietly become a hint that reports quota nobody
+// observed.
+func TestSetAnthropicRateLimitHint_UnknownCaptureCarriesNothing(t *testing.T) {
+	const authID = "auth-carry-unknown-capture"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	first := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: first,
+		Windows: map[string]AnthropicQuotaWindow{
+			"7d_oi": {Status: "allowed", Reset: first.Add(30 * time.Hour), Utilization: 0.88, HasUtilization: true},
+		},
+	})
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:      false,
+		ObservedAt: second,
+	})
+
+	got, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("GetAnthropicRateLimitHint() ok = false, want true")
+	}
+	if got.Known {
+		t.Error("Known = true, want false — the scrub itself must still land")
+	}
+	if len(got.Windows) != 0 {
+		t.Errorf("a capture with no unified-* content inherited windows %v", windowSlugs(got))
+	}
+}
+
+// TestSetAnthropicRateLimitHint_CapsCarriedWindows bounds the union. Carrying
+// windows forward means the stored map is no longer sized by one response, and
+// both the slug and the reset come from upstream — so a base that rotates slug
+// names would grow one auth's map for the life of the process. The cap falls on
+// the carried side, which is the unbounded one: what this capture reported is
+// never given up, and a capture that fills its own budget still gets its carry.
+func TestSetAnthropicRateLimitHint_CapsCarriedWindows(t *testing.T) {
+	const authID = "auth-carry-cap"
+	const stored = 100
+	const fingerprint = "fp-carry-cap"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	first := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+
+	// Every window is live at `second` and inside the carry horizon, each
+	// resetting an hour later than the one before, so eviction order is
+	// unambiguous.
+	windows := make(map[string]AnthropicQuotaWindow, stored)
+	for i := 0; i < stored; i++ {
+		windows[fmt.Sprintf("w%03d", i)] = AnthropicQuotaWindow{
+			Status: "allowed",
+			Reset:  second.Add(time.Duration(i+1) * time.Hour),
+		}
+	}
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known: true, ObservedAt: first, AccountFingerprint: fingerprint, Windows: windows,
+	})
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         second,
+		AccountFingerprint: fingerprint,
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h": {Status: "allowed", Reset: second.Add(2 * time.Hour)},
+			"7d": {Status: "allowed", Reset: second.Add(72 * time.Hour)},
+		},
+	})
+
+	got, _ := GetAnthropicRateLimitHint(authID)
+	// The capture's own two windows, plus a full carry budget on top.
+	if want := 2 + maxCarriedAnthropicWindows; len(got.Windows) != want {
+		t.Fatalf("stored %d windows, want %d (2 reported + %d carried)", len(got.Windows), want, maxCarriedAnthropicWindows)
+	}
+	for _, slug := range []string{"5h", "7d"} {
+		if _, present := got.Windows[slug]; !present {
+			t.Errorf("%s: a window this capture reported was evicted to make room for a carried one", slug)
+		}
+	}
+	// Keep the furthest resets: w099 (+100h) down to w036 (+37h). Those are the
+	// long-horizon windows an ordinary capture stops re-reporting; the soonest
+	// candidates are re-reported anyway and age out on their own.
+	firstKept := stored - maxCarriedAnthropicWindows
+	for i := 0; i < stored; i++ {
+		slug := fmt.Sprintf("w%03d", i)
+		_, present := got.Windows[slug]
+		if want := i >= firstKept; present != want {
+			t.Errorf("%s (reset +%dh) present = %v, want %v — the soonest resets go first", slug, i+1, present, want)
+		}
+	}
+}
+
+// TestSetAnthropicRateLimitHint_CarryEvictionTieBreaksOnSlug contests the last
+// carry seat between two windows resetting at the same instant. Without a
+// tie-break the winner is whichever the map happened to yield first, so the
+// store would evict a different window on identical input.
+//
+// Repeated: Go randomizes map iteration per range, so one round would let an
+// order-dependent implementation through about half the time.
+func TestSetAnthropicRateLimitHint_CarryEvictionTieBreaksOnSlug(t *testing.T) {
+	const authID = "auth-carry-cap-tiebreak"
+	const rounds = 20
+	const fingerprint = "fp-carry-tiebreak"
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	first := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+
+	// One seat short of the budget goes to windows resetting far out, which
+	// eviction keeps; the two tied windows reset sooner and contest what is
+	// left.
+	sharedReset := second.Add(10 * time.Hour)
+	prior := map[string]AnthropicQuotaWindow{
+		"aaa_window": {Status: "allowed", Reset: sharedReset},
+		"bbb_window": {Status: "allowed", Reset: sharedReset},
+	}
+	for i := 0; i < maxCarriedAnthropicWindows-1; i++ {
+		prior[fmt.Sprintf("far%03d", i)] = AnthropicQuotaWindow{
+			Status: "allowed",
+			Reset:  second.Add(time.Duration(100+i) * time.Hour),
+		}
+	}
+
+	for round := 0; round < rounds; round++ {
+		DeleteAnthropicRateLimitHint(authID)
+
+		SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+			Known: true, ObservedAt: first, AccountFingerprint: fingerprint, Windows: prior,
+		})
+		SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+			Known:              true,
+			ObservedAt:         second,
+			AccountFingerprint: fingerprint,
+			Windows: map[string]AnthropicQuotaWindow{
+				"5h": {Status: "allowed", Reset: second.Add(2 * time.Hour)},
+			},
+		})
+
+		got, _ := GetAnthropicRateLimitHint(authID)
+		if want := 1 + maxCarriedAnthropicWindows; len(got.Windows) != want {
+			t.Fatalf("round %d: stored %d windows, want %d", round, len(got.Windows), want)
+		}
+		if _, present := got.Windows["aaa_window"]; !present {
+			t.Fatalf("round %d: equal resets must break toward the lower slug, kept %v", round, windowSlugs(got))
+		}
+		if _, present := got.Windows["bbb_window"]; present {
+			t.Fatalf("round %d: both tied windows were kept, so the cap did not bind", round)
+		}
+	}
+}
+
+// TestSetAnthropicRateLimitHint_ContentFreeWindowDoesNotDisplaceStored covers
+// the way a capture can name a window without observing it. The parser seeds a
+// slug as soon as any header mentions it, so a single malformed header — say
+// `unified-7d_oi-reset: garbage` — produces a zero-value entry. Treating that
+// as a reported window would be the worst of both outcomes: it destroys the
+// rich stored reading, and having no reset of its own it can never be carried
+// afterwards, so the window is gone until the next premium response.
+func TestSetAnthropicRateLimitHint_ContentFreeWindowDoesNotDisplaceStored(t *testing.T) {
+	const authID = "auth-carry-content-free-fresh"
+	const fingerprint = "fp-content-free"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	first := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+	oiReset := first.Add(30 * time.Hour)
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         first,
+		AccountFingerprint: fingerprint,
+		Windows: map[string]AnthropicQuotaWindow{
+			"7d_oi": {Status: "allowed_warning", Reset: oiReset, Utilization: 0.88, HasUtilization: true},
+		},
+	})
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         second,
+		AccountFingerprint: fingerprint,
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h":    {Status: "allowed", Reset: second.Add(2 * time.Hour)},
+			"7d_oi": {},
+		},
+	})
+
+	got, _ := GetAnthropicRateLimitHint(authID)
+	oi, ok := got.Windows["7d_oi"]
+	if !ok {
+		t.Fatalf("7d_oi missing entirely; windows = %v", windowSlugs(got))
+	}
+	if oi.Utilization != 0.88 || oi.Status != "allowed_warning" || !oi.Reset.Equal(oiReset) {
+		t.Errorf("7d_oi = %+v, want the stored reading — a slug named without content is not an observation", oi)
+	}
+	if !oi.ObservedAt.Equal(first) {
+		t.Errorf("7d_oi ObservedAt = %v, want %v — the surviving reading is the carried one", oi.ObservedAt, first)
+	}
+}
+
+// TestSetAnthropicRateLimitHint_PartiallyReportedWindowReplacesStored is the
+// other side of that line. A capture that reported even one field for the slug
+// observed something, so it replaces the stored window whole rather than being
+// treated as a gap to fill.
+func TestSetAnthropicRateLimitHint_PartiallyReportedWindowReplacesStored(t *testing.T) {
+	const authID = "auth-carry-partial-fresh"
+	const fingerprint = "fp-partial-fresh"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	first := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         first,
+		AccountFingerprint: fingerprint,
+		Windows: map[string]AnthropicQuotaWindow{
+			"7d_oi": {Status: "allowed_warning", Reset: first.Add(30 * time.Hour), Utilization: 0.88, HasUtilization: true},
+		},
+	})
+	// Status arrived, reset did not.
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		ObservedAt:         second,
+		AccountFingerprint: fingerprint,
+		Windows: map[string]AnthropicQuotaWindow{
+			"7d_oi": {Status: "rejected"},
+		},
+	})
+
+	got, _ := GetAnthropicRateLimitHint(authID)
+	oi := got.Windows["7d_oi"]
+	if oi.Status != "rejected" {
+		t.Errorf("7d_oi status = %q, want %q — a reported window replaces the stored one", oi.Status, "rejected")
+	}
+	if oi.HasUtilization || !oi.Reset.IsZero() {
+		t.Errorf("7d_oi = %+v, want no stored fields surviving inside a replaced window", oi)
+	}
+	if !oi.ObservedAt.Equal(second) {
+		t.Errorf("7d_oi ObservedAt = %v, want %v", oi.ObservedAt, second)
+	}
+}
+
+// TestSetAnthropicRateLimitHint_CarriesWhenBothAccountsUnknown keeps the
+// both-empty branch under test on purpose. Equality is the gate, so two
+// captures that both failed to identify an account match and carry. That is
+// deliberate — it mirrors the read path, which serves an unidentifiable hint
+// rather than discarding it — and it is the one case where the gate does not
+// actually prove the two captures came from the same credential.
+func TestSetAnthropicRateLimitHint_CarriesWhenBothAccountsUnknown(t *testing.T) {
+	const authID = "auth-carry-both-unknown"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	first := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: first,
+		Windows: map[string]AnthropicQuotaWindow{
+			"7d_oi": {Status: "allowed", Reset: first.Add(30 * time.Hour)},
+		},
+	})
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: second,
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h": {Status: "allowed", Reset: second.Add(2 * time.Hour)},
+		},
+	})
+
+	got, _ := GetAnthropicRateLimitHint(authID)
+	if _, present := got.Windows["7d_oi"]; !present {
+		t.Errorf("two unidentified captures must still match and carry; windows = %v", windowSlugs(got))
+	}
+}
+
+// TestSetAnthropicRateLimitHint_CarryResetGates walks the reset axis of the
+// carry policy in one place: whether a stored window survives depends on where
+// its reset sits relative to this capture, and on how old the reading is.
+func TestSetAnthropicRateLimitHint_CarryResetGates(t *testing.T) {
+	const fingerprint = "fp-reset-gates"
+	storedAt := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	soonAfter := storedAt.Add(time.Minute)
+
+	cases := []struct {
+		name        string
+		storedReset time.Time
+		captureAt   time.Time
+		wantCarried bool
+	}{
+		{"no reset known", time.Time{}, soonAfter, false},
+		{"already reset", soonAfter.Add(-30 * time.Second), soonAfter, false},
+		{"resets exactly at the capture instant", soonAfter, soonAfter, false},
+		{"live", soonAfter.Add(30 * time.Hour), soonAfter, true},
+		{"resets exactly at the horizon", soonAfter.Add(maxAnthropicCarryHorizon), soonAfter, true},
+		{"resets beyond the horizon", soonAfter.Add(maxAnthropicCarryHorizon + time.Hour), soonAfter, false},
+		// The horizon is measured from THIS capture, not the stored one. A
+		// reset nine days past the original observation is seven days out from
+		// a capture two days later, which is a window worth keeping.
+		{"outside the stored capture's horizon, inside this one's", storedAt.Add(9 * 24 * time.Hour), storedAt.Add(2 * 24 * time.Hour), true},
+		// And the age bound is what stops that from becoming a loophole: after
+		// a long gap the same distant reset falls back inside the horizon while
+		// the reading itself is weeks old.
+		{"reading older than the horizon", storedAt.Add(30 * 24 * time.Hour), storedAt.Add(25 * 24 * time.Hour), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			authID := "auth-carry-reset-gate-" + tc.name
+			DeleteAnthropicRateLimitHint(authID)
+			t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+			SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+				Known: true, ObservedAt: storedAt, AccountFingerprint: fingerprint,
+				Windows: map[string]AnthropicQuotaWindow{
+					"7d_oi": {Status: "allowed", Reset: tc.storedReset},
+				},
+			})
+			SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+				Known: true, ObservedAt: tc.captureAt, AccountFingerprint: fingerprint,
+				Windows: map[string]AnthropicQuotaWindow{
+					"5h": {Status: "allowed", Reset: tc.captureAt.Add(2 * time.Hour)},
+				},
+			})
+
+			got, _ := GetAnthropicRateLimitHint(authID)
+			_, carried := got.Windows["7d_oi"]
+			if carried != tc.wantCarried {
+				t.Errorf("7d_oi carried = %v, want %v (stored reset %v, observed %v, capture at %v); windows = %v",
+					carried, tc.wantCarried, tc.storedReset, storedAt, tc.captureAt, windowSlugs(got))
+			}
+		})
+	}
+}
+
+// TestSetAnthropicRateLimitHint_SingleReportedFieldCountsAsObservation pins each
+// clause of the content test independently. Any one of the four fields makes a
+// capture's window a real observation, so it replaces the stored reading rather
+// than being treated as a gap for the carry to fill — and dropping any single
+// clause would silently turn that field's readings into carry fodder.
+func TestSetAnthropicRateLimitHint_SingleReportedFieldCountsAsObservation(t *testing.T) {
+	const fingerprint = "fp-single-field"
+	storedAt := time.Date(2026, 5, 1, 16, 1, 0, 0, time.UTC)
+	captureAt := storedAt.Add(time.Minute)
+
+	cases := []struct {
+		name  string
+		fresh AnthropicQuotaWindow
+	}{
+		{"status only", AnthropicQuotaWindow{Status: "rejected"}},
+		{"utilization only", AnthropicQuotaWindow{HasUtilization: true}},
+		{"surpassed threshold only", AnthropicQuotaWindow{HasSurpassedThreshold: true}},
+		{"reset only", AnthropicQuotaWindow{Reset: captureAt.Add(3 * time.Hour)}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			authID := "auth-single-field-" + tc.name
+			DeleteAnthropicRateLimitHint(authID)
+			t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+			SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+				Known: true, ObservedAt: storedAt, AccountFingerprint: fingerprint,
+				Windows: map[string]AnthropicQuotaWindow{
+					"7d_oi": {Status: "allowed_warning", Reset: storedAt.Add(30 * time.Hour), Utilization: 0.88, HasUtilization: true},
+				},
+			})
+			SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+				Known: true, ObservedAt: captureAt, AccountFingerprint: fingerprint,
+				Windows: map[string]AnthropicQuotaWindow{"7d_oi": tc.fresh},
+			})
+
+			got, _ := GetAnthropicRateLimitHint(authID)
+			oi := got.Windows["7d_oi"]
+			if !oi.ObservedAt.Equal(captureAt) {
+				t.Errorf("7d_oi ObservedAt = %v, want %v — the capture reported this window, so its reading must stand",
+					oi.ObservedAt, captureAt)
+			}
+			if oi.Utilization == 0.88 && !tc.fresh.HasUtilization {
+				t.Errorf("7d_oi kept the stored utilization: the capture's window was treated as unreported")
+			}
+		})
 	}
 }

--- a/sdk/cliproxy/auth/anthropic_rate_limit_test.go
+++ b/sdk/cliproxy/auth/anthropic_rate_limit_test.go
@@ -1,0 +1,366 @@
+package auth
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSetAnthropicRateLimitHint_RoundTrip(t *testing.T) {
+	authID := "claude-test-roundtrip@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	want := AnthropicRateLimitHint{
+		Known:               true,
+		Status:              "allowed",
+		RepresentativeClaim: "five_hour",
+		Reset:               time.Unix(1777500000, 0).UTC(),
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h": {
+				Status:      "allowed",
+				Reset:       time.Unix(1777500000, 0).UTC(),
+				Utilization: 0.26,
+			},
+		},
+		FallbackPercentage: 0.5,
+	}
+	SetAnthropicRateLimitHint(authID, want)
+
+	got, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatalf("expected hint to be present after Set")
+	}
+	if got.Status != want.Status || got.RepresentativeClaim != want.RepresentativeClaim {
+		t.Fatalf("scalar mismatch: got=%+v want=%+v", got, want)
+	}
+	if !got.Reset.Equal(want.Reset) {
+		t.Fatalf("Reset mismatch: got=%v want=%v", got.Reset, want.Reset)
+	}
+	if got.Windows["5h"].Utilization != 0.26 {
+		t.Fatalf("window utilization mismatch: got=%v", got.Windows["5h"].Utilization)
+	}
+	if got.FallbackPercentage != 0.5 {
+		t.Fatalf("FallbackPercentage mismatch: got=%v", got.FallbackPercentage)
+	}
+	if got.ObservedAt.IsZero() {
+		t.Fatalf("ObservedAt should default to non-zero on Set when zero is passed")
+	}
+}
+
+func TestSetAnthropicRateLimitHint_PreservesNonZeroObservedAt(t *testing.T) {
+	authID := "claude-test-preserve-observed-at@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	pinned := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: pinned,
+	})
+
+	got, _ := GetAnthropicRateLimitHint(authID)
+	if !got.ObservedAt.Equal(pinned) {
+		t.Fatalf("ObservedAt overwritten: got=%v want=%v", got.ObservedAt, pinned)
+	}
+}
+
+func TestGetAnthropicRateLimitHint_AbsentAuth(t *testing.T) {
+	if _, ok := GetAnthropicRateLimitHint("claude-test-absent@example.com"); ok {
+		t.Fatal("expected ok=false for never-set auth")
+	}
+}
+
+func TestGetAnthropicRateLimitHint_EmptyAuthID(t *testing.T) {
+	if _, ok := GetAnthropicRateLimitHint(""); ok {
+		t.Fatal("expected ok=false for empty authID")
+	}
+	if _, ok := GetAnthropicRateLimitHint("   "); ok {
+		t.Fatal("expected ok=false for whitespace authID")
+	}
+}
+
+func TestSetAnthropicRateLimitHint_EmptyAuthIDIsNoop(t *testing.T) {
+	SetAnthropicRateLimitHint("", AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	SetAnthropicRateLimitHint("   ", AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	// No assertion needed beyond "doesn't panic"; subsequent Get with empty
+	// ID returns ok=false (covered by TestGetAnthropicRateLimitHint_EmptyAuthID).
+}
+
+func TestSetAnthropicRateLimitHint_OverwritesPriorHint(t *testing.T) {
+	authID := "claude-test-overwrite@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "rejected"})
+
+	got, _ := GetAnthropicRateLimitHint(authID)
+	if got.Status != "rejected" {
+		t.Fatalf("expected overwrite to win: got=%q", got.Status)
+	}
+}
+
+func TestHasKnownAnthropicRateLimitHint(t *testing.T) {
+	authID := "claude-test-known-flag@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	if HasKnownAnthropicRateLimitHint(authID) {
+		t.Fatal("expected false before any Set")
+	}
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: false})
+	if HasKnownAnthropicRateLimitHint(authID) {
+		t.Fatal("expected false when stored hint has Known=false")
+	}
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	if !HasKnownAnthropicRateLimitHint(authID) {
+		t.Fatal("expected true after Set with Known=true")
+	}
+}
+
+func TestAnthropicRateLimitHint_ConcurrentSafety(t *testing.T) {
+	const goroutines = 64
+	const iterations = 256
+	authIDs := []string{
+		"claude-test-concurrent-a@example.com",
+		"claude-test-concurrent-b@example.com",
+		"claude-test-concurrent-c@example.com",
+	}
+	t.Cleanup(func() {
+		for _, id := range authIDs {
+			anthropicRateLimitHintByAuth.Delete(id)
+		}
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				authID := authIDs[(idx+j)%len(authIDs)]
+				if j%2 == 0 {
+					SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+						Known:  true,
+						Status: "allowed",
+					})
+				} else {
+					_, _ = GetAnthropicRateLimitHint(authID)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Sanity: each auth has a hint with Known=true after the storm.
+	for _, id := range authIDs {
+		hint, ok := GetAnthropicRateLimitHint(id)
+		if !ok || !hint.Known {
+			t.Fatalf("expected stable hint for %s after concurrent storm", id)
+		}
+	}
+}
+
+func TestDeleteAnthropicRateLimitHint(t *testing.T) {
+	const authID = "claude-test-delete@example.com"
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	if _, ok := GetAnthropicRateLimitHint(authID); !ok {
+		t.Fatal("expected hint to be present after Set")
+	}
+	DeleteAnthropicRateLimitHint(authID)
+	if _, ok := GetAnthropicRateLimitHint(authID); ok {
+		t.Fatal("expected hint to be absent after Delete")
+	}
+}
+
+func TestSetAnthropicRateLimitHint_ClonesMapsBeforeStoring(t *testing.T) {
+	// Symmetric to the Get-side defensive copy: Set must clone caller-owned
+	// maps so post-Set mutation by the caller can't corrupt shared store
+	// state or race with concurrent Get iteration.
+	const authID = "claude-test-set-clones@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	callerWindows := map[string]AnthropicQuotaWindow{
+		"5h": {Status: "allowed", Utilization: 0.25},
+	}
+	callerRaw := map[string]string{
+		"anthropic-ratelimit-unified-status": "allowed",
+	}
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:      true,
+		Status:     "allowed",
+		Windows:    callerWindows,
+		RawHeaders: callerRaw,
+	})
+
+	// Mutate the caller's local maps after Set.
+	callerWindows["5h"] = AnthropicQuotaWindow{Status: "rejected", Utilization: 1.5}
+	callerWindows["7d"] = AnthropicQuotaWindow{Status: "rejected", Utilization: 1.0}
+	delete(callerWindows, "5h")
+	callerRaw["anthropic-ratelimit-unified-status"] = "rejected"
+	callerRaw["injected-key"] = "evil"
+	delete(callerRaw, "anthropic-ratelimit-unified-status")
+
+	// Stored copy must reflect the Set-time state, not the caller's mutations.
+	got, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("expected hint to be retrievable after Set")
+	}
+	if len(got.Windows) != 1 {
+		t.Fatalf("Windows: post-Set caller mutations leaked into store; len=%d %+v", len(got.Windows), got.Windows)
+	}
+	w, ok := got.Windows["5h"]
+	if !ok {
+		t.Fatal("Windows[5h] missing — caller's delete leaked into store")
+	}
+	if w.Status != "allowed" || w.Utilization != 0.25 {
+		t.Fatalf("Windows[5h] mutated by caller: %+v", w)
+	}
+	if len(got.RawHeaders) != 1 {
+		t.Fatalf("RawHeaders: post-Set caller mutations leaked; len=%d %+v", len(got.RawHeaders), got.RawHeaders)
+	}
+	if got.RawHeaders["anthropic-ratelimit-unified-status"] != "allowed" {
+		t.Fatalf("RawHeaders mutated by caller: got=%q", got.RawHeaders["anthropic-ratelimit-unified-status"])
+	}
+	if _, present := got.RawHeaders["injected-key"]; present {
+		t.Fatal("RawHeaders gained caller-injected key after Set")
+	}
+}
+
+func TestDeleteAnthropicRateLimitHint_AbsentAuth(t *testing.T) {
+	// Delete on never-set auth should be a no-op (no panic, no error).
+	DeleteAnthropicRateLimitHint("claude-test-delete-absent@example.com")
+}
+
+func TestGetAnthropicRateLimitHint_ReturnsDefensiveCopies(t *testing.T) {
+	// Regression: GetAnthropicRateLimitHint used to return the stored value
+	// by-value but with map fields (Windows, RawHeaders) whose underlying
+	// references were shared with the global store. A caller mutating the
+	// returned map would race against other readers and could trigger
+	// `concurrent map read and map write` panics under load. The fix clones
+	// both maps on every Get; this test pins that contract.
+	const authID = "claude-test-defensive-copy@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	original := AnthropicRateLimitHint{
+		Known:  true,
+		Status: "allowed",
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h": {Status: "allowed", Utilization: 0.26},
+		},
+		RawHeaders: map[string]string{
+			"anthropic-ratelimit-unified-status": "allowed",
+		},
+	}
+	SetAnthropicRateLimitHint(authID, original)
+
+	first, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("expected hint to be present after Set")
+	}
+
+	// Mutate the returned maps in every way a caller might:
+	//   - replace an existing key's value
+	//   - add a new key
+	//   - delete a key
+	first.Windows["5h"] = AnthropicQuotaWindow{Status: "rejected", Utilization: 9.99}
+	first.Windows["7d_FAKE"] = AnthropicQuotaWindow{Status: "fabricated"}
+	first.RawHeaders["x-fake-header"] = "injected"
+	delete(first.RawHeaders, "anthropic-ratelimit-unified-status")
+
+	// A subsequent Get must return the original, unmutated state.
+	second, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("expected hint to still be present after caller mutation")
+	}
+	if w, ok := second.Windows["5h"]; !ok {
+		t.Fatal("Windows[5h] disappeared after caller mutation")
+	} else if w.Status != "allowed" || w.Utilization != 0.26 {
+		t.Fatalf("Windows[5h] was mutated through the returned map: got=%+v", w)
+	}
+	if _, ok := second.Windows["7d_FAKE"]; ok {
+		t.Fatal("caller's fabricated window leaked into the store")
+	}
+	if got := second.RawHeaders["anthropic-ratelimit-unified-status"]; got != "allowed" {
+		t.Fatalf("RawHeaders entry mutated/deleted by caller: got=%q", got)
+	}
+	if _, ok := second.RawHeaders["x-fake-header"]; ok {
+		t.Fatal("caller's injected raw header leaked into the store")
+	}
+
+	// The two Get results must reference distinct map instances — confirm via
+	// add-then-not-leak rather than &-pointer equality (which is unstable for
+	// map headers across loads).
+	second.Windows["5h_test"] = AnthropicQuotaWindow{Status: "test"}
+	third, _ := GetAnthropicRateLimitHint(authID)
+	if _, ok := third.Windows["5h_test"]; ok {
+		t.Fatal("second Get returned the same map instance as third Get — clone is shallow")
+	}
+}
+
+func TestDeleteAnthropicRateLimitHint_EmptyAuthIDIsNoop(t *testing.T) {
+	// Set a hint under a real ID, then call Delete with empty/whitespace
+	// authIDs. The real hint must remain.
+	const realID = "claude-test-delete-noop@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(realID) })
+
+	SetAnthropicRateLimitHint(realID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	DeleteAnthropicRateLimitHint("")
+	DeleteAnthropicRateLimitHint("   ")
+	if _, ok := GetAnthropicRateLimitHint(realID); !ok {
+		t.Fatal("Delete with empty authID must not affect other entries")
+	}
+}
+
+// TestSetAnthropicRateLimitHint_OlderCaptureDoesNotOverwriteNewer pins the
+// ordering guard. ObservedAt is stamped by the caller before it parses the
+// response, so concurrent requests on one credential can stamp t1 < t2 and
+// still reach the store in the reverse order; the newer snapshot must win.
+func TestSetAnthropicRateLimitHint_OlderCaptureDoesNotOverwriteNewer(t *testing.T) {
+	const authID = "auth-ordering-guard"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	newer := time.Unix(1777500000, 0).UTC()
+	older := newer.Add(-30 * time.Second)
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known: true, Status: "rejected", ObservedAt: newer,
+	})
+	// The older capture arrives second — it must not win.
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known: true, Status: "allowed", ObservedAt: older,
+	})
+
+	got, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("GetAnthropicRateLimitHint() ok = false, want true")
+	}
+	if got.Status != "rejected" {
+		t.Errorf("Status = %q, want %q — an older capture overwrote a newer one", got.Status, "rejected")
+	}
+	if !got.ObservedAt.Equal(newer) {
+		t.Errorf("ObservedAt = %v, want %v — ObservedAt went backwards", got.ObservedAt, newer)
+	}
+}
+
+// TestSetAnthropicRateLimitHint_EqualOrNewerCaptureWins guards the boundary:
+// only a strictly older capture is dropped, so a same-instant or newer
+// observation still updates the store.
+func TestSetAnthropicRateLimitHint_EqualOrNewerCaptureWins(t *testing.T) {
+	const authID = "auth-ordering-boundary"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	base := time.Unix(1777500000, 0).UTC()
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "first", ObservedAt: base})
+
+	// Same instant must still apply — the guard drops only strictly-older.
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "same-instant", ObservedAt: base})
+	if got, _ := GetAnthropicRateLimitHint(authID); got.Status != "same-instant" {
+		t.Errorf("Status = %q, want %q — same-instant capture was wrongly dropped", got.Status, "same-instant")
+	}
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "newer", ObservedAt: base.Add(time.Second)})
+	if got, _ := GetAnthropicRateLimitHint(authID); got.Status != "newer" {
+		t.Errorf("Status = %q, want %q — newer capture did not win", got.Status, "newer")
+	}
+}

--- a/sdk/cliproxy/auth/anthropic_rate_limit_test.go
+++ b/sdk/cliproxy/auth/anthropic_rate_limit_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -310,6 +312,148 @@ func TestDeleteAnthropicRateLimitHint_EmptyAuthIDIsNoop(t *testing.T) {
 	}
 }
 
+// TestManagerUpdatePreservesHintAcrossTokenRefresh guards against scrubbing the
+// hint in Manager.Update. Update is not only the rotation path: conductor
+// refresh calls it after every routine OAuth token refresh, with the same
+// account and a new access token. Scrubbing there drops valid quota state on
+// ordinary refreshes, which — given how often Claude OAuth tokens refresh —
+// leaves /v0/management/auth-files reporting no rate_limit for much of a
+// credential's life.
+//
+// Staleness across a genuine rotation is handled on read instead, by the
+// account fingerprint (see TestAnthropicRateLimitHintFor_*).
+func TestManagerUpdatePreservesHintAcrossTokenRefresh(t *testing.T) {
+	const authID = "claude-manager-update@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	manager := NewManager(nil, nil, nil)
+	account := map[string]any{"email": "steady@example.com"}
+	if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "claude", Metadata: account}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "rejected"})
+	if _, ok := GetAnthropicRateLimitHint(authID); !ok {
+		t.Fatal("expected hint to be present before Update")
+	}
+
+	// What conductor refresh does: same account, new access token.
+	refreshed := &Auth{ID: authID, Provider: "claude", Metadata: map[string]any{
+		"email":        "steady@example.com",
+		"access_token": "rotated-token",
+	}}
+	if _, err := manager.Update(context.Background(), refreshed); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	if _, ok := GetAnthropicRateLimitHint(authID); !ok {
+		t.Fatal("hint must survive a routine token refresh for the same account")
+	}
+}
+
+// TestAnthropicRateLimitHintFor_RejectsDifferentAccount is the read-side
+// replacement for the removed Update scrub: a capture tagged with one account
+// must not be served for an auth that now holds a different one.
+func TestAnthropicRateLimitHintFor_RejectsDifferentAccount(t *testing.T) {
+	const authID = "claude-fingerprint-rotate@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	before := &Auth{ID: authID, Provider: "claude", Metadata: map[string]any{"email": "before@example.com"}}
+	after := &Auth{ID: authID, Provider: "claude", Metadata: map[string]any{"email": "after@example.com"}}
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		Status:             "rejected",
+		AccountFingerprint: AnthropicAccountFingerprint(before),
+	})
+
+	if _, ok := AnthropicRateLimitHintFor(after); ok {
+		t.Fatal("expected a capture from a different account to be rejected")
+	}
+	if _, ok := AnthropicRateLimitHintFor(before); !ok {
+		t.Fatal("expected the capturing account to still read its own hint")
+	}
+}
+
+// TestAnthropicRateLimitHintFor_UnknownAccountServes pins the deliberate
+// asymmetry: rejection requires proof of a mismatch. An empty fingerprint on
+// either side means the account is unidentifiable, which must resolve to
+// serving the hint — rejecting on unknown would re-introduce the same data
+// loss the Update scrub caused, via a narrower door (a token refresh that
+// returns no email blanks the account).
+func TestAnthropicRateLimitHintFor_UnknownAccountServes(t *testing.T) {
+	const authID = "claude-fingerprint-unknown@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	identified := &Auth{ID: authID, Provider: "claude", Metadata: map[string]any{"email": "someone@example.com"}}
+	anonymous := &Auth{ID: authID, Provider: "claude"}
+
+	if got := AnthropicAccountFingerprint(anonymous); got != "" {
+		t.Fatalf("expected empty fingerprint for an auth with no account, got %q", got)
+	}
+
+	// Stored without a fingerprint, read by an identified auth.
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	if _, ok := AnthropicRateLimitHintFor(identified); !ok {
+		t.Fatal("hint stored without a fingerprint must still be served")
+	}
+
+	// Stored with a fingerprint, read by an auth whose account went blank.
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		Status:             "allowed",
+		AccountFingerprint: AnthropicAccountFingerprint(identified),
+	})
+	if _, ok := AnthropicRateLimitHintFor(anonymous); !ok {
+		t.Fatal("hint must survive an auth whose account became unidentifiable")
+	}
+}
+
+// TestAnthropicAccountFingerprint_DoesNotLeakAPIKey pins that the fingerprint
+// is a hash: for API-key auths AccountInfo returns the key itself, which must
+// not be stored in a process-wide map or reach a management response.
+func TestAnthropicAccountFingerprint_DoesNotLeakAPIKey(t *testing.T) {
+	const secret = "sk-ant-super-secret-key"
+	auth := &Auth{
+		ID:         "claude-apikey@example.com",
+		Provider:   "claude",
+		Attributes: map[string]string{AttributeAPIKey: secret},
+	}
+
+	got := AnthropicAccountFingerprint(auth)
+	if got == "" {
+		t.Fatal("expected a fingerprint for an api-key auth")
+	}
+	if strings.Contains(got, secret) {
+		t.Fatalf("fingerprint leaks the API key: %q", got)
+	}
+}
+
+// TestManagerRemoveScrubsAnthropicRateLimitHint is the removal-side companion:
+// the management handlers call Manager.Remove directly (removeAuth), so an
+// auth recreated with the same ID must not inherit the removed credential's
+// quota state.
+func TestManagerRemoveScrubsAnthropicRateLimitHint(t *testing.T) {
+	const authID = "claude-manager-remove@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	manager := NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "claude"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	if _, ok := GetAnthropicRateLimitHint(authID); !ok {
+		t.Fatal("expected hint to be present before Remove")
+	}
+
+	manager.Remove(context.Background(), authID)
+
+	if _, ok := GetAnthropicRateLimitHint(authID); ok {
+		t.Fatal("expected hint to be scrubbed by Manager.Remove")
+	}
+}
+
 // TestSetAnthropicRateLimitHint_OlderCaptureDoesNotOverwriteNewer pins the
 // ordering guard. ObservedAt is stamped by the caller before it parses the
 // response, so concurrent requests on one credential can stamp t1 < t2 and
@@ -362,5 +506,110 @@ func TestSetAnthropicRateLimitHint_EqualOrNewerCaptureWins(t *testing.T) {
 	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "newer", ObservedAt: base.Add(time.Second)})
 	if got, _ := GetAnthropicRateLimitHint(authID); got.Status != "newer" {
 		t.Errorf("Status = %q, want %q — newer capture did not win", got.Status, "newer")
+	}
+}
+
+// TestManagerRemoveScrubsHintForAlreadyAbsentAuth pins the ordering inside
+// Manager.Remove. A response still in flight when an auth is removed lands
+// after the scrub and re-creates the entry; the operator then deletes again.
+// That second Remove finds no auth in the map and returns early, so a scrub
+// placed after that guard would never reach the resurrected hint and it would
+// outlive the process.
+func TestManagerRemoveScrubsHintForAlreadyAbsentAuth(t *testing.T) {
+	const authID = "auth-resurrected-after-removal"
+	DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	manager := NewManager(nil, nil, nil)
+	ctx := context.Background()
+
+	// The auth is not (or no longer) known to the manager, but a late capture
+	// has left a hint behind.
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:      true,
+		Status:     "allowed",
+		ObservedAt: time.Unix(1777500000, 0).UTC(),
+	})
+	if _, ok := GetAnthropicRateLimitHint(authID); !ok {
+		t.Fatal("precondition: expected a stored hint")
+	}
+
+	manager.Remove(ctx, authID)
+
+	if _, ok := GetAnthropicRateLimitHint(authID); ok {
+		t.Error("hint survived Remove for an auth the manager no longer holds; a resurrected entry would never be reclaimed")
+	}
+}
+
+// TestManagerRemoveScrubsHintForAnyProvider keeps the provider-agnostic
+// guarantee under regression protection. The scrub is keyed by auth ID and is a
+// no-op for IDs without a hint, so it must not become conditional on the auth
+// being a Claude one.
+func TestManagerRemoveScrubsHintForAnyProvider(t *testing.T) {
+	for _, provider := range []string{"claude", "gemini", "codex"} {
+		t.Run(provider, func(t *testing.T) {
+			authID := "manager-remove-provider-" + provider
+			DeleteAnthropicRateLimitHint(authID)
+			t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+			manager := NewManager(nil, nil, nil)
+			if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: provider}); err != nil {
+				t.Fatalf("Register() error = %v", err)
+			}
+			SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+
+			manager.Remove(context.Background(), authID)
+
+			if _, ok := GetAnthropicRateLimitHint(authID); ok {
+				t.Errorf("hint survived Remove for provider %q; the scrub must not be provider-conditional", provider)
+			}
+		})
+	}
+}
+
+// TestSetAnthropicRateLimitHint_ConcurrentOrderingHolds drives concurrent
+// captures for one auth and asserts the newest observation is the one left
+// standing. A bare Load-then-Store passes a single-threaded ordering check but
+// loses here: two writers interleave between the compare and the store, and the
+// older snapshot lands last.
+//
+// Repeated deliberately. One round reproduces the race only a fraction of the
+// time, so a single round would be a weak gate — a regression would pass most
+// CI runs. Rounds are independent, so the miss probability falls off
+// exponentially.
+func TestSetAnthropicRateLimitHint_ConcurrentOrderingHolds(t *testing.T) {
+	const authID = "auth-concurrent-ordering"
+	const rounds = 200
+	const writers = 64
+
+	base := time.Unix(1777500000, 0).UTC()
+	t.Cleanup(func() { DeleteAnthropicRateLimitHint(authID) })
+
+	for round := 0; round < rounds; round++ {
+		DeleteAnthropicRateLimitHint(authID)
+
+		var wg sync.WaitGroup
+		for i := 0; i < writers; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				// Newest observation is i == 0; every other writer is older.
+				SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+					Known:      true,
+					Status:     "allowed",
+					ObservedAt: base.Add(-time.Duration(i) * time.Second),
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		got, ok := GetAnthropicRateLimitHint(authID)
+		if !ok {
+			t.Fatalf("round %d: no hint stored", round)
+		}
+		if !got.ObservedAt.Equal(base) {
+			t.Fatalf("round %d: ObservedAt = %v, want %v — an older concurrent capture won",
+				round, got.ObservedAt, base)
+		}
 	}
 }

--- a/sdk/cliproxy/auth/anthropic_rate_limit_test.go
+++ b/sdk/cliproxy/auth/anthropic_rate_limit_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -311,18 +312,23 @@ func TestDeleteAnthropicRateLimitHint_EmptyAuthIDIsNoop(t *testing.T) {
 	}
 }
 
-// TestManagerUpdateScrubsAnthropicRateLimitHint pins the hint scrub to the
-// manager lifecycle rather than the SDK service layer. The management
-// auth-file handlers call Manager.Update directly (upsertAuthRecord), so a
-// scrub living only in Service.applyCoreAuthAddOrUpdate would let a
-// credential rotation performed through the management API keep serving the
-// previous credential's quota on /v0/management/auth-files.
-func TestManagerUpdateScrubsAnthropicRateLimitHint(t *testing.T) {
+// TestManagerUpdatePreservesHintAcrossTokenRefresh guards against scrubbing the
+// hint in Manager.Update. Update is not only the rotation path: conductor
+// refresh calls it after every routine OAuth token refresh, with the same
+// account and a new access token. Scrubbing there drops valid quota state on
+// ordinary refreshes, which — given how often Claude OAuth tokens refresh —
+// leaves /v0/management/auth-files reporting no rate_limit for much of a
+// credential's life.
+//
+// Staleness across a genuine rotation is handled on read instead, by the
+// account fingerprint (see TestAnthropicRateLimitHintFor_*).
+func TestManagerUpdatePreservesHintAcrossTokenRefresh(t *testing.T) {
 	const authID = "claude-manager-update@example.com"
 	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
 
 	manager := NewManager(nil, nil, nil)
-	if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "claude"}); err != nil {
+	account := map[string]any{"email": "steady@example.com"}
+	if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "claude", Metadata: account}); err != nil {
 		t.Fatalf("Register() error = %v", err)
 	}
 
@@ -331,12 +337,95 @@ func TestManagerUpdateScrubsAnthropicRateLimitHint(t *testing.T) {
 		t.Fatal("expected hint to be present before Update")
 	}
 
-	if _, err := manager.Update(context.Background(), &Auth{ID: authID, Provider: "claude"}); err != nil {
+	// What conductor refresh does: same account, new access token.
+	refreshed := &Auth{ID: authID, Provider: "claude", Metadata: map[string]any{
+		"email":        "steady@example.com",
+		"access_token": "rotated-token",
+	}}
+	if _, err := manager.Update(context.Background(), refreshed); err != nil {
 		t.Fatalf("Update() error = %v", err)
 	}
 
-	if _, ok := GetAnthropicRateLimitHint(authID); ok {
-		t.Fatal("expected hint to be scrubbed by Manager.Update")
+	if _, ok := GetAnthropicRateLimitHint(authID); !ok {
+		t.Fatal("hint must survive a routine token refresh for the same account")
+	}
+}
+
+// TestAnthropicRateLimitHintFor_RejectsDifferentAccount is the read-side
+// replacement for the removed Update scrub: a capture tagged with one account
+// must not be served for an auth that now holds a different one.
+func TestAnthropicRateLimitHintFor_RejectsDifferentAccount(t *testing.T) {
+	const authID = "claude-fingerprint-rotate@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	before := &Auth{ID: authID, Provider: "claude", Metadata: map[string]any{"email": "before@example.com"}}
+	after := &Auth{ID: authID, Provider: "claude", Metadata: map[string]any{"email": "after@example.com"}}
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		Status:             "rejected",
+		AccountFingerprint: AnthropicAccountFingerprint(before),
+	})
+
+	if _, ok := AnthropicRateLimitHintFor(after); ok {
+		t.Fatal("expected a capture from a different account to be rejected")
+	}
+	if _, ok := AnthropicRateLimitHintFor(before); !ok {
+		t.Fatal("expected the capturing account to still read its own hint")
+	}
+}
+
+// TestAnthropicRateLimitHintFor_UnknownAccountServes pins the deliberate
+// asymmetry: rejection requires proof of a mismatch. An empty fingerprint on
+// either side means the account is unidentifiable, which must resolve to
+// serving the hint — rejecting on unknown would re-introduce the same data
+// loss the Update scrub caused, via a narrower door (a token refresh that
+// returns no email blanks the account).
+func TestAnthropicRateLimitHintFor_UnknownAccountServes(t *testing.T) {
+	const authID = "claude-fingerprint-unknown@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	identified := &Auth{ID: authID, Provider: "claude", Metadata: map[string]any{"email": "someone@example.com"}}
+	anonymous := &Auth{ID: authID, Provider: "claude"}
+
+	if got := AnthropicAccountFingerprint(anonymous); got != "" {
+		t.Fatalf("expected empty fingerprint for an auth with no account, got %q", got)
+	}
+
+	// Stored without a fingerprint, read by an identified auth.
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	if _, ok := AnthropicRateLimitHintFor(identified); !ok {
+		t.Fatal("hint stored without a fingerprint must still be served")
+	}
+
+	// Stored with a fingerprint, read by an auth whose account went blank.
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:              true,
+		Status:             "allowed",
+		AccountFingerprint: AnthropicAccountFingerprint(identified),
+	})
+	if _, ok := AnthropicRateLimitHintFor(anonymous); !ok {
+		t.Fatal("hint must survive an auth whose account became unidentifiable")
+	}
+}
+
+// TestAnthropicAccountFingerprint_DoesNotLeakAPIKey pins that the fingerprint
+// is a hash: for API-key auths AccountInfo returns the key itself, which must
+// not be stored in a process-wide map or reach a management response.
+func TestAnthropicAccountFingerprint_DoesNotLeakAPIKey(t *testing.T) {
+	const secret = "sk-ant-super-secret-key"
+	auth := &Auth{
+		ID:         "claude-apikey@example.com",
+		Provider:   "claude",
+		Attributes: map[string]string{AttributeAPIKey: secret},
+	}
+
+	got := AnthropicAccountFingerprint(auth)
+	if got == "" {
+		t.Fatal("expected a fingerprint for an api-key auth")
+	}
+	if strings.Contains(got, secret) {
+		t.Fatalf("fingerprint leaks the API key: %q", got)
 	}
 }
 
@@ -362,24 +451,5 @@ func TestManagerRemoveScrubsAnthropicRateLimitHint(t *testing.T) {
 
 	if _, ok := GetAnthropicRateLimitHint(authID); ok {
 		t.Fatal("expected hint to be scrubbed by Manager.Remove")
-	}
-}
-
-// TestManagerUpdateUnknownAuthLeavesHintIntact guards the placement of the
-// scrub relative to Update's existence check: Update returns early for an
-// unregistered ID, and must not scrub in that case.
-func TestManagerUpdateUnknownAuthLeavesHintIntact(t *testing.T) {
-	const authID = "claude-manager-update-unknown@example.com"
-	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
-
-	manager := NewManager(nil, nil, nil)
-	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
-
-	if _, err := manager.Update(context.Background(), &Auth{ID: authID, Provider: "claude"}); err != nil {
-		t.Fatalf("Update() error = %v", err)
-	}
-
-	if _, ok := GetAnthropicRateLimitHint(authID); !ok {
-		t.Fatal("expected hint to survive Update of an unregistered auth")
 	}
 }

--- a/sdk/cliproxy/auth/anthropic_rate_limit_test.go
+++ b/sdk/cliproxy/auth/anthropic_rate_limit_test.go
@@ -1,0 +1,385 @@
+package auth
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSetAnthropicRateLimitHint_RoundTrip(t *testing.T) {
+	authID := "claude-test-roundtrip@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	want := AnthropicRateLimitHint{
+		Known:               true,
+		Status:              "allowed",
+		RepresentativeClaim: "five_hour",
+		Reset:               time.Unix(1777500000, 0).UTC(),
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h": {
+				Status:      "allowed",
+				Reset:       time.Unix(1777500000, 0).UTC(),
+				Utilization: 0.26,
+			},
+		},
+		FallbackPercentage: 0.5,
+	}
+	SetAnthropicRateLimitHint(authID, want)
+
+	got, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatalf("expected hint to be present after Set")
+	}
+	if got.Status != want.Status || got.RepresentativeClaim != want.RepresentativeClaim {
+		t.Fatalf("scalar mismatch: got=%+v want=%+v", got, want)
+	}
+	if !got.Reset.Equal(want.Reset) {
+		t.Fatalf("Reset mismatch: got=%v want=%v", got.Reset, want.Reset)
+	}
+	if got.Windows["5h"].Utilization != 0.26 {
+		t.Fatalf("window utilization mismatch: got=%v", got.Windows["5h"].Utilization)
+	}
+	if got.FallbackPercentage != 0.5 {
+		t.Fatalf("FallbackPercentage mismatch: got=%v", got.FallbackPercentage)
+	}
+	if got.ObservedAt.IsZero() {
+		t.Fatalf("ObservedAt should default to non-zero on Set when zero is passed")
+	}
+}
+
+func TestSetAnthropicRateLimitHint_PreservesNonZeroObservedAt(t *testing.T) {
+	authID := "claude-test-preserve-observed-at@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	pinned := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:      true,
+		ObservedAt: pinned,
+	})
+
+	got, _ := GetAnthropicRateLimitHint(authID)
+	if !got.ObservedAt.Equal(pinned) {
+		t.Fatalf("ObservedAt overwritten: got=%v want=%v", got.ObservedAt, pinned)
+	}
+}
+
+func TestGetAnthropicRateLimitHint_AbsentAuth(t *testing.T) {
+	if _, ok := GetAnthropicRateLimitHint("claude-test-absent@example.com"); ok {
+		t.Fatal("expected ok=false for never-set auth")
+	}
+}
+
+func TestGetAnthropicRateLimitHint_EmptyAuthID(t *testing.T) {
+	if _, ok := GetAnthropicRateLimitHint(""); ok {
+		t.Fatal("expected ok=false for empty authID")
+	}
+	if _, ok := GetAnthropicRateLimitHint("   "); ok {
+		t.Fatal("expected ok=false for whitespace authID")
+	}
+}
+
+func TestSetAnthropicRateLimitHint_EmptyAuthIDIsNoop(t *testing.T) {
+	SetAnthropicRateLimitHint("", AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	SetAnthropicRateLimitHint("   ", AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	// No assertion needed beyond "doesn't panic"; subsequent Get with empty
+	// ID returns ok=false (covered by TestGetAnthropicRateLimitHint_EmptyAuthID).
+}
+
+func TestSetAnthropicRateLimitHint_OverwritesPriorHint(t *testing.T) {
+	authID := "claude-test-overwrite@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "rejected"})
+
+	got, _ := GetAnthropicRateLimitHint(authID)
+	if got.Status != "rejected" {
+		t.Fatalf("expected overwrite to win: got=%q", got.Status)
+	}
+}
+
+func TestHasKnownAnthropicRateLimitHint(t *testing.T) {
+	authID := "claude-test-known-flag@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	if HasKnownAnthropicRateLimitHint(authID) {
+		t.Fatal("expected false before any Set")
+	}
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: false})
+	if HasKnownAnthropicRateLimitHint(authID) {
+		t.Fatal("expected false when stored hint has Known=false")
+	}
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	if !HasKnownAnthropicRateLimitHint(authID) {
+		t.Fatal("expected true after Set with Known=true")
+	}
+}
+
+func TestAnthropicRateLimitHint_ConcurrentSafety(t *testing.T) {
+	const goroutines = 64
+	const iterations = 256
+	authIDs := []string{
+		"claude-test-concurrent-a@example.com",
+		"claude-test-concurrent-b@example.com",
+		"claude-test-concurrent-c@example.com",
+	}
+	t.Cleanup(func() {
+		for _, id := range authIDs {
+			anthropicRateLimitHintByAuth.Delete(id)
+		}
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				authID := authIDs[(idx+j)%len(authIDs)]
+				if j%2 == 0 {
+					SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+						Known:  true,
+						Status: "allowed",
+					})
+				} else {
+					_, _ = GetAnthropicRateLimitHint(authID)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Sanity: each auth has a hint with Known=true after the storm.
+	for _, id := range authIDs {
+		hint, ok := GetAnthropicRateLimitHint(id)
+		if !ok || !hint.Known {
+			t.Fatalf("expected stable hint for %s after concurrent storm", id)
+		}
+	}
+}
+
+func TestDeleteAnthropicRateLimitHint(t *testing.T) {
+	const authID = "claude-test-delete@example.com"
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	if _, ok := GetAnthropicRateLimitHint(authID); !ok {
+		t.Fatal("expected hint to be present after Set")
+	}
+	DeleteAnthropicRateLimitHint(authID)
+	if _, ok := GetAnthropicRateLimitHint(authID); ok {
+		t.Fatal("expected hint to be absent after Delete")
+	}
+}
+
+func TestSetAnthropicRateLimitHint_ClonesMapsBeforeStoring(t *testing.T) {
+	// Symmetric to the Get-side defensive copy: Set must clone caller-owned
+	// maps so post-Set mutation by the caller can't corrupt shared store
+	// state or race with concurrent Get iteration.
+	const authID = "claude-test-set-clones@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	callerWindows := map[string]AnthropicQuotaWindow{
+		"5h": {Status: "allowed", Utilization: 0.25},
+	}
+	callerRaw := map[string]string{
+		"anthropic-ratelimit-unified-status": "allowed",
+	}
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{
+		Known:      true,
+		Status:     "allowed",
+		Windows:    callerWindows,
+		RawHeaders: callerRaw,
+	})
+
+	// Mutate the caller's local maps after Set.
+	callerWindows["5h"] = AnthropicQuotaWindow{Status: "rejected", Utilization: 1.5}
+	callerWindows["7d"] = AnthropicQuotaWindow{Status: "rejected", Utilization: 1.0}
+	delete(callerWindows, "5h")
+	callerRaw["anthropic-ratelimit-unified-status"] = "rejected"
+	callerRaw["injected-key"] = "evil"
+	delete(callerRaw, "anthropic-ratelimit-unified-status")
+
+	// Stored copy must reflect the Set-time state, not the caller's mutations.
+	got, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("expected hint to be retrievable after Set")
+	}
+	if len(got.Windows) != 1 {
+		t.Fatalf("Windows: post-Set caller mutations leaked into store; len=%d %+v", len(got.Windows), got.Windows)
+	}
+	w, ok := got.Windows["5h"]
+	if !ok {
+		t.Fatal("Windows[5h] missing — caller's delete leaked into store")
+	}
+	if w.Status != "allowed" || w.Utilization != 0.25 {
+		t.Fatalf("Windows[5h] mutated by caller: %+v", w)
+	}
+	if len(got.RawHeaders) != 1 {
+		t.Fatalf("RawHeaders: post-Set caller mutations leaked; len=%d %+v", len(got.RawHeaders), got.RawHeaders)
+	}
+	if got.RawHeaders["anthropic-ratelimit-unified-status"] != "allowed" {
+		t.Fatalf("RawHeaders mutated by caller: got=%q", got.RawHeaders["anthropic-ratelimit-unified-status"])
+	}
+	if _, present := got.RawHeaders["injected-key"]; present {
+		t.Fatal("RawHeaders gained caller-injected key after Set")
+	}
+}
+
+func TestDeleteAnthropicRateLimitHint_AbsentAuth(t *testing.T) {
+	// Delete on never-set auth should be a no-op (no panic, no error).
+	DeleteAnthropicRateLimitHint("claude-test-delete-absent@example.com")
+}
+
+func TestGetAnthropicRateLimitHint_ReturnsDefensiveCopies(t *testing.T) {
+	// Regression: GetAnthropicRateLimitHint used to return the stored value
+	// by-value but with map fields (Windows, RawHeaders) whose underlying
+	// references were shared with the global store. A caller mutating the
+	// returned map would race against other readers and could trigger
+	// `concurrent map read and map write` panics under load. The fix clones
+	// both maps on every Get; this test pins that contract.
+	const authID = "claude-test-defensive-copy@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	original := AnthropicRateLimitHint{
+		Known:  true,
+		Status: "allowed",
+		Windows: map[string]AnthropicQuotaWindow{
+			"5h": {Status: "allowed", Utilization: 0.26},
+		},
+		RawHeaders: map[string]string{
+			"anthropic-ratelimit-unified-status": "allowed",
+		},
+	}
+	SetAnthropicRateLimitHint(authID, original)
+
+	first, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("expected hint to be present after Set")
+	}
+
+	// Mutate the returned maps in every way a caller might:
+	//   - replace an existing key's value
+	//   - add a new key
+	//   - delete a key
+	first.Windows["5h"] = AnthropicQuotaWindow{Status: "rejected", Utilization: 9.99}
+	first.Windows["7d_FAKE"] = AnthropicQuotaWindow{Status: "fabricated"}
+	first.RawHeaders["x-fake-header"] = "injected"
+	delete(first.RawHeaders, "anthropic-ratelimit-unified-status")
+
+	// A subsequent Get must return the original, unmutated state.
+	second, ok := GetAnthropicRateLimitHint(authID)
+	if !ok {
+		t.Fatal("expected hint to still be present after caller mutation")
+	}
+	if w, ok := second.Windows["5h"]; !ok {
+		t.Fatal("Windows[5h] disappeared after caller mutation")
+	} else if w.Status != "allowed" || w.Utilization != 0.26 {
+		t.Fatalf("Windows[5h] was mutated through the returned map: got=%+v", w)
+	}
+	if _, ok := second.Windows["7d_FAKE"]; ok {
+		t.Fatal("caller's fabricated window leaked into the store")
+	}
+	if got := second.RawHeaders["anthropic-ratelimit-unified-status"]; got != "allowed" {
+		t.Fatalf("RawHeaders entry mutated/deleted by caller: got=%q", got)
+	}
+	if _, ok := second.RawHeaders["x-fake-header"]; ok {
+		t.Fatal("caller's injected raw header leaked into the store")
+	}
+
+	// The two Get results must reference distinct map instances — confirm via
+	// add-then-not-leak rather than &-pointer equality (which is unstable for
+	// map headers across loads).
+	second.Windows["5h_test"] = AnthropicQuotaWindow{Status: "test"}
+	third, _ := GetAnthropicRateLimitHint(authID)
+	if _, ok := third.Windows["5h_test"]; ok {
+		t.Fatal("second Get returned the same map instance as third Get — clone is shallow")
+	}
+}
+
+func TestDeleteAnthropicRateLimitHint_EmptyAuthIDIsNoop(t *testing.T) {
+	// Set a hint under a real ID, then call Delete with empty/whitespace
+	// authIDs. The real hint must remain.
+	const realID = "claude-test-delete-noop@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(realID) })
+
+	SetAnthropicRateLimitHint(realID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	DeleteAnthropicRateLimitHint("")
+	DeleteAnthropicRateLimitHint("   ")
+	if _, ok := GetAnthropicRateLimitHint(realID); !ok {
+		t.Fatal("Delete with empty authID must not affect other entries")
+	}
+}
+
+// TestManagerUpdateScrubsAnthropicRateLimitHint pins the hint scrub to the
+// manager lifecycle rather than the SDK service layer. The management
+// auth-file handlers call Manager.Update directly (upsertAuthRecord), so a
+// scrub living only in Service.applyCoreAuthAddOrUpdate would let a
+// credential rotation performed through the management API keep serving the
+// previous credential's quota on /v0/management/auth-files.
+func TestManagerUpdateScrubsAnthropicRateLimitHint(t *testing.T) {
+	const authID = "claude-manager-update@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	manager := NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "claude"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "rejected"})
+	if _, ok := GetAnthropicRateLimitHint(authID); !ok {
+		t.Fatal("expected hint to be present before Update")
+	}
+
+	if _, err := manager.Update(context.Background(), &Auth{ID: authID, Provider: "claude"}); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	if _, ok := GetAnthropicRateLimitHint(authID); ok {
+		t.Fatal("expected hint to be scrubbed by Manager.Update")
+	}
+}
+
+// TestManagerRemoveScrubsAnthropicRateLimitHint is the removal-side companion:
+// the management handlers call Manager.Remove directly (removeAuth), so an
+// auth recreated with the same ID must not inherit the removed credential's
+// quota state.
+func TestManagerRemoveScrubsAnthropicRateLimitHint(t *testing.T) {
+	const authID = "claude-manager-remove@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	manager := NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "claude"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+	if _, ok := GetAnthropicRateLimitHint(authID); !ok {
+		t.Fatal("expected hint to be present before Remove")
+	}
+
+	manager.Remove(context.Background(), authID)
+
+	if _, ok := GetAnthropicRateLimitHint(authID); ok {
+		t.Fatal("expected hint to be scrubbed by Manager.Remove")
+	}
+}
+
+// TestManagerUpdateUnknownAuthLeavesHintIntact guards the placement of the
+// scrub relative to Update's existence check: Update returns early for an
+// unregistered ID, and must not scrub in that case.
+func TestManagerUpdateUnknownAuthLeavesHintIntact(t *testing.T) {
+	const authID = "claude-manager-update-unknown@example.com"
+	t.Cleanup(func() { anthropicRateLimitHintByAuth.Delete(authID) })
+
+	manager := NewManager(nil, nil, nil)
+	SetAnthropicRateLimitHint(authID, AnthropicRateLimitHint{Known: true, Status: "allowed"})
+
+	if _, err := manager.Update(context.Background(), &Auth{ID: authID, Provider: "claude"}); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	if _, ok := GetAnthropicRateLimitHint(authID); !ok {
+		t.Fatal("expected hint to survive Update of an unregistered auth")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -142,6 +142,12 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 		m.scheduler.upsertAuth(authClone)
 	}
 	m.queueRefreshReschedule(auth.ID)
+	// No Anthropic rate-limit scrub here on purpose. Update is the routine
+	// token-refresh path (conductor_refresh.go calls it after every OAuth
+	// refresh), not just the rotation path, so clearing the hint would drop
+	// valid quota state for the same account on an ordinary refresh. A
+	// rotation to a different account is handled on read instead, by the
+	// account fingerprint on the hint.
 	_ = m.persist(ctx, auth)
 	m.hook.OnAuthUpdated(ctx, auth.Clone())
 	if clearedCooldown {
@@ -160,6 +166,14 @@ func (m *Manager) Remove(ctx context.Context, id string) {
 	if id == "" {
 		return
 	}
+	// Release the Anthropic rate-limit hint before the already-absent early
+	// return below, not after it. A response still in flight when an auth is
+	// removed lands after the scrub and re-creates the entry; the delete that
+	// follows finds no auth in the map and returns, so a scrub placed later
+	// would never reach the resurrected hint and it would outlive the process.
+	// Unconditional is safe: the store is keyed by authID and this is a no-op
+	// for IDs without one.
+	DeleteAnthropicRateLimitHint(id)
 	_ = ctx
 
 	m.mu.Lock()

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -142,6 +142,14 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 		m.scheduler.upsertAuth(authClone)
 	}
 	m.queueRefreshReschedule(auth.ID)
+	// An in-place update of an existing auth.ID may be a credential
+	// rotation (same ID, new underlying account), so drop the Anthropic
+	// rate-limit hint rather than let the management API report the
+	// previous credential's quota. Centralised here, in the manager
+	// lifecycle, so direct callers (the management auth-file handlers
+	// upsert via Manager.Update without going through the SDK service
+	// path) are covered too. No-op for IDs without a stored hint.
+	DeleteAnthropicRateLimitHint(auth.ID)
 	_ = m.persist(ctx, auth)
 	m.hook.OnAuthUpdated(ctx, auth.Clone())
 	if clearedCooldown {
@@ -192,6 +200,11 @@ func (m *Manager) Remove(ctx context.Context, id string) {
 	}
 	m.queueRefreshUnschedule(id)
 	m.invalidateSessionAffinity(id)
+	// Scrub the Anthropic rate-limit hint so an auth recreated with the
+	// same ID cannot surface the removed credential's quota. Provider-
+	// agnostic: the hint store is keyed by authID and this is a no-op for
+	// IDs without a stored hint.
+	DeleteAnthropicRateLimitHint(id)
 
 	if provider != "" {
 		if exec, ok := m.Executor(provider); ok && exec != nil {

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -142,14 +142,12 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 		m.scheduler.upsertAuth(authClone)
 	}
 	m.queueRefreshReschedule(auth.ID)
-	// An in-place update of an existing auth.ID may be a credential
-	// rotation (same ID, new underlying account), so drop the Anthropic
-	// rate-limit hint rather than let the management API report the
-	// previous credential's quota. Centralised here, in the manager
-	// lifecycle, so direct callers (the management auth-file handlers
-	// upsert via Manager.Update without going through the SDK service
-	// path) are covered too. No-op for IDs without a stored hint.
-	DeleteAnthropicRateLimitHint(auth.ID)
+	// No Anthropic rate-limit scrub here on purpose. Update is the routine
+	// token-refresh path (conductor_refresh.go calls it after every OAuth
+	// refresh), not just the rotation path, so clearing the hint would drop
+	// valid quota state for the same account on an ordinary refresh. A
+	// rotation to a different account is handled on read instead, by the
+	// account fingerprint on the hint.
 	_ = m.persist(ctx, auth)
 	m.hook.OnAuthUpdated(ctx, auth.Clone())
 	if clearedCooldown {
@@ -200,10 +198,11 @@ func (m *Manager) Remove(ctx context.Context, id string) {
 	}
 	m.queueRefreshUnschedule(id)
 	m.invalidateSessionAffinity(id)
-	// Scrub the Anthropic rate-limit hint so an auth recreated with the
-	// same ID cannot surface the removed credential's quota. Provider-
-	// agnostic: the hint store is keyed by authID and this is a no-op for
-	// IDs without a stored hint.
+	// Release the Anthropic rate-limit hint along with the credential.
+	// Provider-agnostic: the hint store is keyed by authID and this is a
+	// no-op for IDs without a stored hint. Staleness against an auth later
+	// recreated under this ID is handled on read via the account
+	// fingerprint; this keeps the store from retaining dead entries.
 	DeleteAnthropicRateLimitHint(id)
 
 	if provider != "" {

--- a/sdk/cliproxy/service_auth.go
+++ b/sdk/cliproxy/service_auth.go
@@ -292,19 +292,6 @@ func (s *Service) prepareCoreAuthForModelRegistration(ctx context.Context, auth 
 		}
 		op = "update"
 		_, err = s.coreManager.Update(ctx, auth)
-		// Conservative invalidation, success-gated: an in-place upsert of
-		// an existing auth.ID could be a credential rotation (same ID, new
-		// underlying account/token), so clear the Anthropic rate-limit
-		// hint to prevent /management/auth-files from surfacing the
-		// pre-update credential's quota state. Only on success — a failed
-		// Update leaves the previous auth active in coreManager, and
-		// dropping its hint would lose still-valid observability state
-		// until the next Claude response repopulates. The next response
-		// after a successful update repopulates within seconds. No-op
-		// for IDs without a stored hint.
-		if err == nil {
-			coreauth.DeleteAnthropicRateLimitHint(auth.ID)
-		}
 	} else {
 		_, err = s.coreManager.Register(ctx, auth)
 	}
@@ -357,12 +344,6 @@ func (s *Service) applyCoreAuthRemoval(ctx context.Context, id string) {
 		provider = strings.TrimSpace(existing.Provider)
 	}
 	GlobalModelRegistry().UnregisterClient(id)
-	// Scrub the Anthropic rate-limit hint so a recreated auth with the same
-	// ID can't surface stale quota state via the management API. Provider-
-	// agnostic call: hint store lookup is keyed by authID and a no-op for
-	// IDs without a stored hint, so this is safe regardless of the removed
-	// auth's provider.
-	coreauth.DeleteAnthropicRateLimitHint(id)
 	s.coreManager.Remove(ctx, id)
 	if strings.EqualFold(provider, "codex") {
 		executor.CloseCodexWebsocketSessionsForAuthID(id, "auth_removed")

--- a/sdk/cliproxy/service_auth.go
+++ b/sdk/cliproxy/service_auth.go
@@ -292,6 +292,19 @@ func (s *Service) prepareCoreAuthForModelRegistration(ctx context.Context, auth 
 		}
 		op = "update"
 		_, err = s.coreManager.Update(ctx, auth)
+		// Conservative invalidation, success-gated: an in-place upsert of
+		// an existing auth.ID could be a credential rotation (same ID, new
+		// underlying account/token), so clear the Anthropic rate-limit
+		// hint to prevent /management/auth-files from surfacing the
+		// pre-update credential's quota state. Only on success — a failed
+		// Update leaves the previous auth active in coreManager, and
+		// dropping its hint would lose still-valid observability state
+		// until the next Claude response repopulates. The next response
+		// after a successful update repopulates within seconds. No-op
+		// for IDs without a stored hint.
+		if err == nil {
+			coreauth.DeleteAnthropicRateLimitHint(auth.ID)
+		}
 	} else {
 		_, err = s.coreManager.Register(ctx, auth)
 	}
@@ -344,6 +357,12 @@ func (s *Service) applyCoreAuthRemoval(ctx context.Context, id string) {
 		provider = strings.TrimSpace(existing.Provider)
 	}
 	GlobalModelRegistry().UnregisterClient(id)
+	// Scrub the Anthropic rate-limit hint so a recreated auth with the same
+	// ID can't surface stale quota state via the management API. Provider-
+	// agnostic call: hint store lookup is keyed by authID and a no-op for
+	// IDs without a stored hint, so this is safe regardless of the removed
+	// auth's provider.
+	coreauth.DeleteAnthropicRateLimitHint(id)
 	s.coreManager.Remove(ctx, id)
 	if strings.EqualFold(provider, "codex") {
 		executor.CloseCodexWebsocketSessionsForAuthID(id, "auth_removed")

--- a/sdk/cliproxy/service_auth_rate_limit_hint_test.go
+++ b/sdk/cliproxy/service_auth_rate_limit_hint_test.go
@@ -9,99 +9,91 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
 
-// seedAnthropicHint stores a hint for authID and registers cleanup. The hint
-// store is package-global, so every test here uses a distinct auth ID.
-func seedAnthropicHint(t *testing.T, authID string) {
+// These cover the hint through the Service entry point a config-file credential
+// swap actually takes — the watcher raises Modify and
+// Service.applyCoreAuthAddOrUpdate upserts through coreManager.Update. The
+// Manager-level tests drive Update directly with hand-built structs, so without
+// these nothing exercises the production path.
+//
+// Invalidation lives on the Manager now, so what is asserted here is the
+// behaviour that path must produce, not the presence of a Service-level hook.
+
+func seedHint(t *testing.T, authID, email string) {
 	t.Helper()
 	coreauth.DeleteAnthropicRateLimitHint(authID)
 	t.Cleanup(func() {
 		coreauth.DeleteAnthropicRateLimitHint(authID)
 		GlobalModelRegistry().UnregisterClient(authID)
 	})
+	fp := coreauth.AnthropicAccountFingerprint(claudeAuth(authID, email))
 	coreauth.SetAnthropicRateLimitHint(authID, coreauth.AnthropicRateLimitHint{
-		Known:      true,
-		Status:     "allowed",
-		ObservedAt: time.Date(2026, time.March, 1, 8, 0, 0, 0, time.UTC),
+		Known:              true,
+		Status:             "allowed",
+		ObservedAt:         time.Unix(1777500000, 0).UTC(),
+		AccountFingerprint: fp,
 	})
-	if _, ok := coreauth.GetAnthropicRateLimitHint(authID); !ok {
-		t.Fatalf("seed failed: no hint stored for %q", authID)
+}
+
+func claudeAuth(authID, email string) *coreauth.Auth {
+	return &coreauth.Auth{
+		ID:       authID,
+		Provider: "claude",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"email": email},
 	}
 }
 
-// TestApplyCoreAuthAddOrUpdate_ScrubsHintOnSuccessfulUpdate covers the
-// success-gated scrub. An in-place upsert of an existing auth ID can be a
-// credential rotation (same ID, new underlying account), so the hint must not
-// survive it and report the previous credential's quota.
-func TestApplyCoreAuthAddOrUpdate_ScrubsHintOnSuccessfulUpdate(t *testing.T) {
+// A token refresh rewrites the auth file with the same account; the quota state
+// must survive it. Scrubbing on update was the original defect here.
+func TestServiceUpsert_TokenRefreshKeepsHint(t *testing.T) {
 	service := &Service{cfg: &config.Config{}, coreManager: coreauth.NewManager(nil, nil, nil)}
-	const authID = "hint-scrub-on-update"
+	const authID = "svc-refresh@example.com"
 	ctx := context.Background()
 
-	// Register first: the scrub is on the update branch, not the register one.
-	service.applyCoreAuthAddOrUpdate(ctx, &coreauth.Auth{
-		ID: authID, Provider: "claude", Status: coreauth.StatusActive,
-	})
-	if _, ok := service.coreManager.GetByID(authID); !ok {
-		t.Fatalf("expected auth %q to be registered", authID)
+	service.applyCoreAuthAddOrUpdate(ctx, claudeAuth(authID, "same@example.com"))
+	seedHint(t, authID, "same@example.com")
+
+	// Same account, new token — the routine refresh shape.
+	refreshed := claudeAuth(authID, "same@example.com")
+	refreshed.Metadata["access_token"] = "rotated-token"
+	service.applyCoreAuthAddOrUpdate(ctx, refreshed)
+
+	// Read back what the manager actually stored, not a hand-built Auth —
+	// otherwise the assertion holds even if the upsert did nothing.
+	stored, ok := service.coreManager.GetByID(authID)
+	if !ok || stored == nil {
+		t.Fatal("auth missing from the manager after update")
 	}
-
-	seedAnthropicHint(t, authID)
-
-	// Second upsert takes the update branch.
-	service.applyCoreAuthAddOrUpdate(ctx, &coreauth.Auth{
-		ID: authID, Provider: "claude", Status: coreauth.StatusActive,
-	})
-
-	if _, ok := coreauth.GetAnthropicRateLimitHint(authID); ok {
-		t.Error("hint survived a successful in-place update; a rotated credential's quota would still be served")
+	if got := stored.Metadata["access_token"]; got != "rotated-token" {
+		t.Fatalf("update did not reach the manager: access_token = %v", got)
+	}
+	if _, ok := coreauth.AnthropicRateLimitHintFor(stored); !ok {
+		t.Error("hint was lost across a same-account update; an ordinary token refresh must not drop quota state")
 	}
 }
 
-// TestApplyCoreAuthAddOrUpdate_KeepsHintWhenRegisteringNewAuth guards the
-// other side of the branch: registering an auth that is not already present
-// is not a rotation, so an unrelated seeded hint must not be disturbed.
-func TestApplyCoreAuthAddOrUpdate_KeepsHintWhenRegisteringNewAuth(t *testing.T) {
+// The same entry point with a different account behind the ID must not serve
+// the previous account's quota.
+func TestServiceUpsert_RotationToNewAccountIsRejectedOnRead(t *testing.T) {
 	service := &Service{cfg: &config.Config{}, coreManager: coreauth.NewManager(nil, nil, nil)}
-	const authID = "hint-kept-on-register"
-	seedAnthropicHint(t, authID)
+	const authID = "svc-rotation@example.com"
+	ctx := context.Background()
 
-	service.applyCoreAuthAddOrUpdate(context.Background(), &coreauth.Auth{
-		ID: authID, Provider: "claude", Status: coreauth.StatusActive,
-	})
+	service.applyCoreAuthAddOrUpdate(ctx, claudeAuth(authID, "old@example.com"))
+	seedHint(t, authID, "old@example.com")
 
-	if _, ok := coreauth.GetAnthropicRateLimitHint(authID); !ok {
-		t.Error("hint was scrubbed on the register branch; only a successful in-place update should scrub")
+	service.applyCoreAuthAddOrUpdate(ctx, claudeAuth(authID, "new@example.com"))
+
+	// Read back the manager's Auth so the rejection is proven against the
+	// credential the upsert actually installed.
+	stored, ok := service.coreManager.GetByID(authID)
+	if !ok || stored == nil {
+		t.Fatal("auth missing from the manager after update")
 	}
-}
-
-// TestApplyCoreAuthRemoval_ScrubsHint covers the removal hook. The scrub is
-// deliberately provider-agnostic — the store is keyed by auth ID and the call
-// is a no-op for IDs without a hint.
-func TestApplyCoreAuthRemoval_ScrubsHint(t *testing.T) {
-	for _, provider := range []string{"claude", "gemini"} {
-		t.Run(provider, func(t *testing.T) {
-			service := &Service{cfg: &config.Config{}, coreManager: coreauth.NewManager(nil, nil, nil)}
-			authID := "hint-scrub-on-removal-" + provider
-			ctx := context.Background()
-
-			service.applyCoreAuthAddOrUpdate(ctx, &coreauth.Auth{
-				ID: authID, Provider: provider, Status: coreauth.StatusActive,
-			})
-			seedAnthropicHint(t, authID)
-
-			service.applyCoreAuthRemoval(ctx, authID)
-
-			if _, ok := coreauth.GetAnthropicRateLimitHint(authID); ok {
-				t.Error("hint survived auth removal; a recreated auth with the same ID would inherit it")
-			}
-		})
+	if got := stored.Metadata["email"]; got != "new@example.com" {
+		t.Fatalf("rotation did not reach the manager: email = %v", got)
 	}
-}
-
-// TestApplyCoreAuthRemoval_ScrubIsNoOpForUnknownID pins that the scrub
-// tolerates IDs it has never seen, which is the common case for non-Claude
-// providers flowing through the same removal path.
-func TestApplyCoreAuthRemoval_ScrubIsNoOpForUnknownID(t *testing.T) {
-	service := &Service{cfg: &config.Config{}, coreManager: coreauth.NewManager(nil, nil, nil)}
-	service.applyCoreAuthRemoval(context.Background(), "hint-never-seen")
+	if _, ok := coreauth.AnthropicRateLimitHintFor(stored); ok {
+		t.Error("the previous account's quota is served under the rotated credential")
+	}
 }

--- a/sdk/cliproxy/service_auth_rate_limit_hint_test.go
+++ b/sdk/cliproxy/service_auth_rate_limit_hint_test.go
@@ -1,0 +1,107 @@
+package cliproxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+// seedAnthropicHint stores a hint for authID and registers cleanup. The hint
+// store is package-global, so every test here uses a distinct auth ID.
+func seedAnthropicHint(t *testing.T, authID string) {
+	t.Helper()
+	coreauth.DeleteAnthropicRateLimitHint(authID)
+	t.Cleanup(func() {
+		coreauth.DeleteAnthropicRateLimitHint(authID)
+		GlobalModelRegistry().UnregisterClient(authID)
+	})
+	coreauth.SetAnthropicRateLimitHint(authID, coreauth.AnthropicRateLimitHint{
+		Known:      true,
+		Status:     "allowed",
+		ObservedAt: time.Date(2026, time.March, 1, 8, 0, 0, 0, time.UTC),
+	})
+	if _, ok := coreauth.GetAnthropicRateLimitHint(authID); !ok {
+		t.Fatalf("seed failed: no hint stored for %q", authID)
+	}
+}
+
+// TestApplyCoreAuthAddOrUpdate_ScrubsHintOnSuccessfulUpdate covers the
+// success-gated scrub. An in-place upsert of an existing auth ID can be a
+// credential rotation (same ID, new underlying account), so the hint must not
+// survive it and report the previous credential's quota.
+func TestApplyCoreAuthAddOrUpdate_ScrubsHintOnSuccessfulUpdate(t *testing.T) {
+	service := &Service{cfg: &config.Config{}, coreManager: coreauth.NewManager(nil, nil, nil)}
+	const authID = "hint-scrub-on-update"
+	ctx := context.Background()
+
+	// Register first: the scrub is on the update branch, not the register one.
+	service.applyCoreAuthAddOrUpdate(ctx, &coreauth.Auth{
+		ID: authID, Provider: "claude", Status: coreauth.StatusActive,
+	})
+	if _, ok := service.coreManager.GetByID(authID); !ok {
+		t.Fatalf("expected auth %q to be registered", authID)
+	}
+
+	seedAnthropicHint(t, authID)
+
+	// Second upsert takes the update branch.
+	service.applyCoreAuthAddOrUpdate(ctx, &coreauth.Auth{
+		ID: authID, Provider: "claude", Status: coreauth.StatusActive,
+	})
+
+	if _, ok := coreauth.GetAnthropicRateLimitHint(authID); ok {
+		t.Error("hint survived a successful in-place update; a rotated credential's quota would still be served")
+	}
+}
+
+// TestApplyCoreAuthAddOrUpdate_KeepsHintWhenRegisteringNewAuth guards the
+// other side of the branch: registering an auth that is not already present
+// is not a rotation, so an unrelated seeded hint must not be disturbed.
+func TestApplyCoreAuthAddOrUpdate_KeepsHintWhenRegisteringNewAuth(t *testing.T) {
+	service := &Service{cfg: &config.Config{}, coreManager: coreauth.NewManager(nil, nil, nil)}
+	const authID = "hint-kept-on-register"
+	seedAnthropicHint(t, authID)
+
+	service.applyCoreAuthAddOrUpdate(context.Background(), &coreauth.Auth{
+		ID: authID, Provider: "claude", Status: coreauth.StatusActive,
+	})
+
+	if _, ok := coreauth.GetAnthropicRateLimitHint(authID); !ok {
+		t.Error("hint was scrubbed on the register branch; only a successful in-place update should scrub")
+	}
+}
+
+// TestApplyCoreAuthRemoval_ScrubsHint covers the removal hook. The scrub is
+// deliberately provider-agnostic — the store is keyed by auth ID and the call
+// is a no-op for IDs without a hint.
+func TestApplyCoreAuthRemoval_ScrubsHint(t *testing.T) {
+	for _, provider := range []string{"claude", "gemini"} {
+		t.Run(provider, func(t *testing.T) {
+			service := &Service{cfg: &config.Config{}, coreManager: coreauth.NewManager(nil, nil, nil)}
+			authID := "hint-scrub-on-removal-" + provider
+			ctx := context.Background()
+
+			service.applyCoreAuthAddOrUpdate(ctx, &coreauth.Auth{
+				ID: authID, Provider: provider, Status: coreauth.StatusActive,
+			})
+			seedAnthropicHint(t, authID)
+
+			service.applyCoreAuthRemoval(ctx, authID)
+
+			if _, ok := coreauth.GetAnthropicRateLimitHint(authID); ok {
+				t.Error("hint survived auth removal; a recreated auth with the same ID would inherit it")
+			}
+		})
+	}
+}
+
+// TestApplyCoreAuthRemoval_ScrubIsNoOpForUnknownID pins that the scrub
+// tolerates IDs it has never seen, which is the common case for non-Claude
+// providers flowing through the same removal path.
+func TestApplyCoreAuthRemoval_ScrubIsNoOpForUnknownID(t *testing.T) {
+	service := &Service{cfg: &config.Config{}, coreManager: coreauth.NewManager(nil, nil, nil)}
+	service.applyCoreAuthRemoval(context.Background(), "hint-never-seen")
+}


### PR DESCRIPTION
## Summary

Adds a provider-gated `rate_limit` block to each Claude entry returned by `/v0/management/auth-files`, surfacing the most-recent `anthropic-ratelimit-unified-*` header state captured by the executor. Operators (dashboards, status-line indicators, alerting hooks) can now see per-window utilization, reset times, and overage state directly from the management API instead of having to inspect upstream traffic out-of-band.

**Depends on #3169** (capture infrastructure). This PR adds the read-side projection and keys the hint to the account rather than the auth lifecycle; merge order is `#3169` then this PR.

## Why

The capture in #3169 makes the data available internally. This PR exposes it on the surface that already powers the Management Center UI. Without it, the captured state is dead-end data — present in memory, useful to nobody.

## Design

**Mirrors the codex `id_token` precedent at `internal/api/handlers/management/auth_files.go:431-433`** verbatim:

- Provider-gated (`auth.Provider == \"claude\"`, case-tolerant via `EqualFold` + `TrimSpace`)
- Single nested object on the existing entry
- Returns nil (key omitted) when there's no content to surface
- Snake_case throughout
- Timestamps as RFC3339Nano (Go default `time.Time` MarshalJSON; consistent with neighboring `created_at`, `last_refresh`, `next_retry_after`)
- Strict `omitempty` discipline — every optional field is gated before the gin.H key is set

**Generative `windows` map keyed by header slug.** Real production captures already include `7d_sonnet` alongside `5h` and `7d`; iterating a map rather than declaring fixed fields means new tier-specific windows surface without schema changes.

**`raw_headers` forward-compat safety net.** The `anthropic-ratelimit-unified-*` family is undocumented; the raw map preserves every observed header verbatim so operators can recover schema drift from logs even before the structured parser learns about a new field.

## Sample payload

Real-captured 200 response (the `allowed_warning` + `7d_sonnet` case from `#3169`'s test fixtures):

```json
{
  \"id\": \"claude-akirby@example.com.json\",
  \"provider\": \"claude\",
  \"status\": \"active\",
  \"...\": \"...\",
  \"rate_limit\": {
    \"observed_at\": \"2026-04-30T13:14:22.123456789Z\",
    \"status\": \"allowed_warning\",
    \"representative_claim\": \"seven_day\",
    \"reset_at\": \"2026-04-30T18:00:00Z\",
    \"fallback_percentage\": 0.5,
    \"overage_status\": \"rejected\",
    \"overage_disabled_reason\": \"org_level_disabled_until\",
    \"windows\": {
      \"5h\":        {\"status\": \"allowed\",         \"reset_at\": \"...\", \"utilization\": 0.35},
      \"7d\":        {\"status\": \"allowed_warning\", \"reset_at\": \"...\", \"utilization\": 0.85, \"surpassed_threshold\": 0.75},
      \"7d_sonnet\": {\"status\": \"allowed\",         \"reset_at\": \"...\", \"utilization\": 0.07}
    },
    \"raw_headers\": { /* every observed unified-* header, verbatim */ }
  }
}
```

For credentials with no captures yet (no Claude calls have been made through them since startup), `rate_limit` is omitted entirely. For non-Claude credentials, the field is never emitted.

## Alternatives considered

- **New endpoint** (e.g. `/v0/management/rate-limits`). Rejected: doesn't match how this codebase has historically handled per-credential metadata. The `id_token` precedent — a nested object alongside other entry fields, populated by a small helper — is the established pattern.
- **Flat fields** (`rate_limit_5h_utilization`, `rate_limit_7d_utilization`, etc.). Rejected: forces a code change every time Anthropic adds a new tier-specific window. `7d_sonnet` is in the wild already.
- **Per-window array `[{name: \"5h\", ...}, {name: \"7d\", ...}]`**. Considered. Map keyed by slug is more idiomatic for this codebase (cf. `usage.requests_by_day` in `internal/usage/logger_plugin.go`, which uses `map[string]int64` for time-bucketed data — same shape).
- **Bundling with #3169 into one PR**. Split deliberately — capture is pure infrastructure with no surface change; exposure is the surface decision. Reviewers can engage with each independently.

## Differs from #3068

#3068 proposed surfacing Codex plan + 5h/weekly windows on this same handler and was closed. This PR is intentionally narrower:

- **Single source** — the in-memory hint store populated by passive capture in #3169. No multi-source priority logic, no alias resolution, no claim/metadata/attribute fallback chains.
- **One field per concept** — no triplicates like `quota_recover_after_seconds` + `quota_recover_in` + `quota_next_recover_at` for the same recovery time.
- **No behavior changes elsewhere** — no `buildAuthFromFileData` touches, no TUI changes, no auth-loading-path additions. Just one helper + one call site in `buildAuthFileEntry`.
- **Scope** — 3 files, 347 lines total (95 LOC of helper, 249 LOC of tests, 3-line wire-up).

## Backwards compatibility

The `rate_limit` key is new and absent on credentials without captures, so existing consumers of the auth-files payload see no field changes and new consumers opt in by reading the new key. The Go surface is additive rather than unchanged: `AnthropicRateLimitHint` gains an `AccountFingerprint` field, `sdk/cliproxy/auth` gains `AnthropicAccountFingerprint` and `AnthropicRateLimitHintFor`, and `RecordAnthropicRateLimit` takes the auth instead of a bare ID. That last one lives under `internal/`, so it is not reachable by external consumers.

## Test coverage

`internal/api/handlers/management/auth_files_claude_rate_limit_test.go` (249 LOC, 7 tests):

- nil-auth guard
- non-Claude provider gate (codex auth with hint set should return nil)
- no-hint case (Claude auth, no capture observed yet)
- `Known=false` case (hint present but content-less)
- full-hint round-trip with field-by-field assertion on every output key
- omitempty discipline (minimum-content hint produces minimum-key payload — only fields with values appear)
- provider-name casing tolerance (`Claude`, `CLAUDE`, `  claude  ` all match)

All pass under `-race`.

## Validation

```
go vet ./...
go test -race -count=1 -run 'BuildClaudeRateLimitEntry' \
  ./internal/api/handlers/management/...
go build -o test-output ./cmd/server && rm test-output
```

The 8 pre-existing `internal/api/handlers/management/` test failures (`TestAPICallTransport*`, `TestDelete*Key_*`, `TestAuthByIndex*`) reproduce on stock `upstream/dev` and are unrelated. No `internal/translator/` or `AGENTS.md` paths touched.
