### PR TITLE
feat(prompt-rules): inject/strip rules for outgoing requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ VisionCoder is also offering our users a limited-time <a href="https://coder.vis
 - Claude Code multi-account load balancing
 - OpenAI Codex multi-account load balancing
 - OpenAI-compatible upstream providers via config (e.g., OpenRouter)
+- Prompt Rules: inject standing instructions into outgoing system prompts or last user messages, or strip unwanted boilerplate (regex), scoped by model and source format and idempotent across requests
 - Reusable Go SDK for embedding the proxy (see `docs/sdk-usage.md`)
 
 ## Getting Started

--- a/README_CN.md
+++ b/README_CN.md
@@ -64,6 +64,7 @@ VisionCoder 还为我们的用户提供 <a href="https://coder.visioncoder.cn" t
 - 支持 Claude Code 多账户轮询
 - 支持 OpenAI Codex 多账户轮询
 - 通过配置接入上游 OpenAI 兼容提供商（例如 OpenRouter）
+- 提示规则：在转发到上游前向系统提示或最近的用户消息注入常驻指令，或按正则剥离不需要的样板文本；按模型与来源格式过滤，跨请求保持幂等
 - 可复用的 Go SDK（见 `docs/sdk-usage_CN.md`）
 
 ## 新手入门

--- a/README_JA.md
+++ b/README_JA.md
@@ -62,6 +62,7 @@ GLM CODING PLANを10%割引で取得：https://z.ai/subscribe?ic=8JVLJQFSKB
 - Claude Codeのマルチアカウント負荷分散
 - OpenAI Codexのマルチアカウント負荷分散
 - 設定によるOpenAI互換アップストリームプロバイダー（例：OpenRouter）
+- プロンプトルール：上流に転送する前にシステムプロンプトや最後のユーザーメッセージへ常駐の指示を注入、または不要な定型文を正規表現で除去。モデルとソース形式でスコープし、リクエスト間で冪等
 - プロキシ埋め込み用の再利用可能なGo SDK（`docs/sdk-usage.md`を参照）
 
 ## はじめに

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 	log "github.com/sirupsen/logrus"
@@ -119,6 +120,13 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_yaml", "message": err.Error()})
 		return
 	}
+	// Strict prompt-rules validation BEFORE the temp-file LoadConfigOptional dance.
+	// SanitizePromptRules (called inside LoadConfigOptional) silently drops invalid
+	// rules — we want the API caller to receive a 400 with a reason instead.
+	if err = cfg.ValidatePromptRules(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_prompt_rules", "message": err.Error()})
+		return
+	}
 	// Validate config using LoadConfigOptional with optional=false to enforce parsing
 	tmpDir := filepath.Dir(h.configFilePath)
 	tmpFile, err := os.CreateTemp(tmpDir, "config-validate-*.yaml")
@@ -159,6 +167,11 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 		return
 	}
 	h.cfg = newCfg
+	// Defensive: explicitly republish the prompt-rules snapshot from the
+	// committed config so any premature update from the temp-file validation
+	// load is overridden. LoadConfig's Sanitize already calls the hook, but
+	// belt-and-suspenders here protects against future refactors.
+	helps.UpdatePromptRulesSnapshot(h.cfg.PromptRules)
 	c.JSON(http.StatusOK, gin.H{"ok": true, "changed": []string{"config"}})
 }
 

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -149,20 +149,35 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 	defer func() {
 		_ = os.Remove(tempFile)
 	}()
-	_, err = config.LoadConfigOptional(tempFile, false)
-	if err != nil {
+	// LoadConfigOptional below side-effects the global prompt-rules snapshot
+	// via SanitizePromptRules. If any later step (WriteConfig / LoadConfig)
+	// fails we must restore the previous snapshot, otherwise live requests
+	// would be rewritten by rules that were never persisted to disk. Hold
+	// h.mu across the entire validate -> write -> reload sequence so the
+	// captured snapshot baseline can't drift under us.
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	prevPromptRules := append([]config.PromptRule(nil), h.cfg.PromptRules...)
+	rollbackPromptRules := func() {
+		helps.UpdatePromptRulesSnapshot(prevPromptRules)
+	}
+	if _, err = config.LoadConfigOptional(tempFile, false); err != nil {
+		rollbackPromptRules()
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid_config", "message": err.Error()})
 		return
 	}
-	h.mu.Lock()
-	defer h.mu.Unlock()
 	if WriteConfig(h.configFilePath, body) != nil {
+		rollbackPromptRules()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "write_failed", "message": "failed to write config"})
 		return
 	}
 	// Reload into handler to keep memory in sync
 	newCfg, err := config.LoadConfig(h.configFilePath)
 	if err != nil {
+		// Disk now holds the new YAML, but we couldn't reload it. Roll the
+		// snapshot back to match h.cfg (still the old in-memory rules) so the
+		// runtime is at least self-consistent until the operator investigates.
+		rollbackPromptRules()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "reload_failed", "message": err.Error()})
 		return
 	}

--- a/internal/api/handlers/management/prompt_rules.go
+++ b/internal/api/handlers/management/prompt_rules.go
@@ -1,0 +1,158 @@
+package management
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
+)
+
+// GetPromptRules returns the current configured prompt rules.
+func (h *Handler) GetPromptRules(c *gin.Context) {
+	h.mu.Lock()
+	out := append([]config.PromptRule(nil), h.cfg.PromptRules...)
+	h.mu.Unlock()
+	if out == nil {
+		out = []config.PromptRule{}
+	}
+	c.JSON(http.StatusOK, gin.H{"prompt-rules": out})
+}
+
+// PutPromptRules replaces the entire prompt-rules list. Validation is strict —
+// any invalid rule causes a 400 with the offending rule's name and reason.
+// This is the primary write path used by the management UI.
+func (h *Handler) PutPromptRules(c *gin.Context) {
+	rules, ok := readPromptRulesBody(c)
+	if !ok {
+		return
+	}
+	candidate := config.Config{PromptRules: rules}
+	candidate.NormalizePromptRules()
+	if err := candidate.ValidatePromptRules(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.cfg.PromptRules = candidate.PromptRules
+	helps.UpdatePromptRulesSnapshot(h.cfg.PromptRules)
+	h.persistLocked(c)
+}
+
+// PatchPromptRule upserts a single rule. The body shape mirrors other list
+// PATCH endpoints in this package:
+//
+//	{"index": <int>?, "match": "<name>"?, "value": <PromptRule>}
+//
+// If both index and match are absent (or no match found), the rule is appended.
+func (h *Handler) PatchPromptRule(c *gin.Context) {
+	var body struct {
+		Index *int               `json:"index"`
+		Match *string            `json:"match"`
+		Value *config.PromptRule `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.Value == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	cur := append([]config.PromptRule(nil), h.cfg.PromptRules...)
+	targetIdx := -1
+	if body.Index != nil && *body.Index >= 0 && *body.Index < len(cur) {
+		targetIdx = *body.Index
+	} else if body.Match != nil {
+		match := strings.TrimSpace(*body.Match)
+		if match != "" {
+			for i := range cur {
+				if cur[i].Name == match {
+					targetIdx = i
+					break
+				}
+			}
+		}
+	}
+	if targetIdx >= 0 {
+		cur[targetIdx] = *body.Value
+	} else {
+		cur = append(cur, *body.Value)
+	}
+	candidate := config.Config{PromptRules: cur}
+	candidate.NormalizePromptRules()
+	if err := candidate.ValidatePromptRules(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	h.cfg.PromptRules = candidate.PromptRules
+	helps.UpdatePromptRulesSnapshot(h.cfg.PromptRules)
+	h.persistLocked(c)
+}
+
+// DeletePromptRule removes a rule by ?name= or ?index=.
+func (h *Handler) DeletePromptRule(c *gin.Context) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if name := strings.TrimSpace(c.Query("name")); name != "" {
+		out := make([]config.PromptRule, 0, len(h.cfg.PromptRules))
+		removed := false
+		for _, r := range h.cfg.PromptRules {
+			if r.Name == name {
+				removed = true
+				continue
+			}
+			out = append(out, r)
+		}
+		if !removed {
+			c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
+			return
+		}
+		h.cfg.PromptRules = out
+		helps.UpdatePromptRulesSnapshot(h.cfg.PromptRules)
+		h.persistLocked(c)
+		return
+	}
+	if idxStr := strings.TrimSpace(c.Query("index")); idxStr != "" {
+		var idx int
+		if _, err := fmt.Sscanf(idxStr, "%d", &idx); err == nil && idx >= 0 && idx < len(h.cfg.PromptRules) {
+			h.cfg.PromptRules = append(h.cfg.PromptRules[:idx], h.cfg.PromptRules[idx+1:]...)
+			helps.UpdatePromptRulesSnapshot(h.cfg.PromptRules)
+			h.persistLocked(c)
+			return
+		}
+	}
+	c.JSON(http.StatusBadRequest, gin.H{"error": "missing name or index"})
+}
+
+func readPromptRulesBody(c *gin.Context) ([]config.PromptRule, bool) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read body"})
+		return nil, false
+	}
+	if len(data) == 0 {
+		// Empty body explicitly clears the list.
+		return []config.PromptRule{}, true
+	}
+	var arr []config.PromptRule
+	if err := json.Unmarshal(data, &arr); err == nil {
+		return arr, true
+	}
+	var obj struct {
+		Items       []config.PromptRule `json:"items"`
+		PromptRules []config.PromptRule `json:"prompt-rules"`
+	}
+	if err := json.Unmarshal(data, &obj); err == nil {
+		if obj.PromptRules != nil {
+			return obj.PromptRules, true
+		}
+		if obj.Items != nil {
+			return obj.Items, true
+		}
+	}
+	c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+	return nil, false
+}

--- a/internal/api/handlers/management/prompt_rules.go
+++ b/internal/api/handlers/management/prompt_rules.go
@@ -38,9 +38,7 @@ func (h *Handler) PutPromptRules(c *gin.Context) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.cfg.PromptRules = candidate.PromptRules
-	helps.UpdatePromptRulesSnapshot(h.cfg.PromptRules)
-	h.persistLocked(c)
+	h.applyPromptRulesAndPersist(c, candidate.PromptRules)
 }
 
 // PatchPromptRule upserts a single rule. The body shape mirrors other list
@@ -87,9 +85,7 @@ func (h *Handler) PatchPromptRule(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	h.cfg.PromptRules = candidate.PromptRules
-	helps.UpdatePromptRulesSnapshot(h.cfg.PromptRules)
-	h.persistLocked(c)
+	h.applyPromptRulesAndPersist(c, candidate.PromptRules)
 }
 
 // DeletePromptRule removes a rule by ?name= or ?index=.
@@ -110,9 +106,7 @@ func (h *Handler) DeletePromptRule(c *gin.Context) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
 			return
 		}
-		h.cfg.PromptRules = out
-		helps.UpdatePromptRulesSnapshot(h.cfg.PromptRules)
-		h.persistLocked(c)
+		h.applyPromptRulesAndPersist(c, out)
 		return
 	}
 	if idxStr := strings.TrimSpace(c.Query("index")); idxStr != "" {
@@ -121,13 +115,31 @@ func (h *Handler) DeletePromptRule(c *gin.Context) {
 		// use the parsed index to splice the slice without further bounds
 		// checking on the raw string.
 		if idx, err := strconv.Atoi(idxStr); err == nil && idx >= 0 && idx < len(h.cfg.PromptRules) {
-			h.cfg.PromptRules = append(h.cfg.PromptRules[:idx], h.cfg.PromptRules[idx+1:]...)
-			helps.UpdatePromptRulesSnapshot(h.cfg.PromptRules)
-			h.persistLocked(c)
+			next := append([]config.PromptRule(nil), h.cfg.PromptRules[:idx]...)
+			next = append(next, h.cfg.PromptRules[idx+1:]...)
+			h.applyPromptRulesAndPersist(c, next)
 			return
 		}
 	}
 	c.JSON(http.StatusBadRequest, gin.H{"error": "missing name or index"})
+}
+
+// applyPromptRulesAndPersist installs `next` into h.cfg.PromptRules, refreshes
+// the runtime snapshot, then asks persistLocked to write config.yaml. If the
+// disk write fails, both the in-memory rules and the runtime snapshot are
+// rolled back to their pre-call state — otherwise the API returning 500 would
+// leave the runtime rewriting requests with rules that were never saved
+// (Codex review pull/3178#pullrequestreview-4210925408).
+//
+// Caller MUST already hold h.mu. persistLocked writes the response body.
+func (h *Handler) applyPromptRulesAndPersist(c *gin.Context, next []config.PromptRule) {
+	prev := append([]config.PromptRule(nil), h.cfg.PromptRules...)
+	h.cfg.PromptRules = next
+	helps.UpdatePromptRulesSnapshot(h.cfg.PromptRules)
+	if !h.persistLocked(c) {
+		h.cfg.PromptRules = prev
+		helps.UpdatePromptRulesSnapshot(prev)
+	}
 }
 
 func readPromptRulesBody(c *gin.Context) ([]config.PromptRule, bool) {

--- a/internal/api/handlers/management/prompt_rules.go
+++ b/internal/api/handlers/management/prompt_rules.go
@@ -2,8 +2,8 @@ package management
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -116,8 +116,11 @@ func (h *Handler) DeletePromptRule(c *gin.Context) {
 		return
 	}
 	if idxStr := strings.TrimSpace(c.Query("index")); idxStr != "" {
-		var idx int
-		if _, err := fmt.Sscanf(idxStr, "%d", &idx); err == nil && idx >= 0 && idx < len(h.cfg.PromptRules) {
+		// strconv.Atoi rejects trailing non-digit junk ("123foo") which
+		// fmt.Sscanf silently accepts as 123 — important here because we
+		// use the parsed index to splice the slice without further bounds
+		// checking on the raw string.
+		if idx, err := strconv.Atoi(idxStr); err == nil && idx >= 0 && idx < len(h.cfg.PromptRules) {
 			h.cfg.PromptRules = append(h.cfg.PromptRules[:idx], h.cfg.PromptRules[idx+1:]...)
 			helps.UpdatePromptRulesSnapshot(h.cfg.PromptRules)
 			h.persistLocked(c)

--- a/internal/api/handlers/management/prompt_rules_test.go
+++ b/internal/api/handlers/management/prompt_rules_test.go
@@ -238,6 +238,74 @@ func TestPromptRules_API_PutEmptyBodyClears(t *testing.T) {
 	}
 }
 
+// TestPromptRules_API_Put_RollbackOnPersistFailure regression-guards the
+// prompt-rules write path: applyPromptRulesAndPersist must restore both
+// h.cfg.PromptRules and the runtime snapshot if persistLocked fails to write
+// config.yaml, otherwise the API returns 500 but live requests are rewritten
+// by rules that were never saved
+// (Codex review pull/3178#pullrequestreview-4210925408).
+func TestPromptRules_API_Put_RollbackOnPersistFailure(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	// Make the config "file" actually a directory so SaveConfigPreserveComments
+	// fails inside persistLocked. The test handler does not pre-seed the file
+	// here, since we need the path to be a directory throughout.
+	if err := os.Mkdir(configPath, 0o755); err != nil {
+		t.Fatalf("mkdir as path: %v", err)
+	}
+
+	cfg := &config.Config{
+		PromptRules: []config.PromptRule{
+			{
+				Name: "before", Enabled: true, Target: "system", Action: "inject",
+				Content: "before-content", Position: "append",
+			},
+		},
+	}
+	cfg.NormalizePromptRules()
+	manager := coreauth.NewManager(nil, nil, nil)
+	h := NewHandler(cfg, configPath, manager)
+
+	helps.UpdatePromptRulesSnapshot(cfg.PromptRules)
+	t.Cleanup(func() { helps.UpdatePromptRulesSnapshot(nil) })
+
+	body := []config.PromptRule{
+		{
+			Name: "after", Enabled: true, Target: "system", Action: "inject",
+			Content: "after-content", Position: "append",
+		},
+	}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = newJSONReq(t, http.MethodPut, "/v0/management/prompt-rules", body)
+	h.PutPromptRules(ctx)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 from persist failure; got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if got := h.cfg.PromptRules; len(got) != 1 || got[0].Name != "before" {
+		t.Fatalf("h.cfg.PromptRules must be rolled back; got %+v", got)
+	}
+
+	out := helps.ApplyPromptRules(
+		"openai",
+		"gpt-5",
+		[]byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+		"/v1/chat/completions",
+		"",
+	)
+	got := string(out)
+	if !strings.Contains(got, "before-content") {
+		t.Fatalf("rollback failed: pre-PUT rule should still fire; payload: %s", got)
+	}
+	if strings.Contains(got, "after-content") {
+		t.Fatalf("rollback failed: rejected body's rule fired anyway; payload: %s", got)
+	}
+}
+
 // TestPromptRules_API_PutConfigYAML_SnapshotRollbackOnWriteFailure regression
 // guards against a Codex P1 finding: PutConfigYAML's temp-file
 // LoadConfigOptional call mutates the global prompt-rules snapshot via

--- a/internal/api/handlers/management/prompt_rules_test.go
+++ b/internal/api/handlers/management/prompt_rules_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
@@ -233,5 +235,78 @@ func TestPromptRules_API_PutEmptyBodyClears(t *testing.T) {
 	}
 	if len(h.cfg.PromptRules) != 0 {
 		t.Fatalf("expected list cleared; got %+v", h.cfg.PromptRules)
+	}
+}
+
+// TestPromptRules_API_PutConfigYAML_SnapshotRollbackOnWriteFailure regression
+// guards against a Codex P1 finding: PutConfigYAML's temp-file
+// LoadConfigOptional call mutates the global prompt-rules snapshot via
+// SanitizePromptRules before the new YAML is committed to disk. If WriteConfig
+// then fails, the runtime would otherwise be rewriting requests with rules
+// that were never persisted. The handler must restore the previous snapshot
+// on every error path after the temp-file load.
+func TestPromptRules_API_PutConfigYAML_SnapshotRollbackOnWriteFailure(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	// Make the config "file" actually a directory so WriteConfig's
+	// os.OpenFile(..., O_WRONLY) fails with EISDIR. Temp-file creation in the
+	// same parent directory still works, so PutConfigYAML reaches
+	// LoadConfigOptional (which mutates the snapshot) before the failure.
+	if err := os.Mkdir(configPath, 0o755); err != nil {
+		t.Fatalf("mkdir as path: %v", err)
+	}
+
+	cfg := &config.Config{
+		PromptRules: []config.PromptRule{
+			{
+				Name: "before", Enabled: true, Target: "system", Action: "inject",
+				Content: "before-content", Position: "append",
+			},
+		},
+	}
+	cfg.NormalizePromptRules()
+	manager := coreauth.NewManager(nil, nil, nil)
+	h := NewHandler(cfg, configPath, manager)
+
+	helps.UpdatePromptRulesSnapshot(cfg.PromptRules)
+	t.Cleanup(func() { helps.UpdatePromptRulesSnapshot(nil) })
+
+	yamlBody := []byte(`port: 8080
+prompt-rules:
+  - name: after
+    enabled: true
+    target: system
+    action: inject
+    content: after-content
+    position: append
+`)
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPut, "/v0/management/config", bytes.NewReader(yamlBody))
+	ctx.Request.Header.Set("Content-Type", "application/yaml")
+	h.PutConfigYAML(ctx)
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("expected non-200 because configPath is a directory; got 200 body=%s", rec.Body.String())
+	}
+
+	// Apply prompt rules through the public engine using the active snapshot.
+	// If the rollback worked, the OLD rule fires and the NEW rule does not.
+	out := helps.ApplyPromptRules(
+		"openai",
+		"gpt-5",
+		[]byte(`{"messages":[{"role":"user","content":"hi"}]}`),
+		"/v1/chat/completions",
+		"",
+	)
+	got := string(out)
+	if !strings.Contains(got, "before-content") {
+		t.Fatalf("rollback failed: pre-PUT rule should still fire; payload: %s", got)
+	}
+	if strings.Contains(got, "after-content") {
+		t.Fatalf("rollback failed: rejected PUT body's rule fired anyway; payload: %s", got)
 	}
 }

--- a/internal/api/handlers/management/prompt_rules_test.go
+++ b/internal/api/handlers/management/prompt_rules_test.go
@@ -109,13 +109,15 @@ func TestPromptRules_API_PutWithInvalidRegexReturns400(t *testing.T) {
 	}
 }
 
-func TestPromptRules_API_PutWithMarkerNotInContentReturns400(t *testing.T) {
+func TestPromptRules_API_PutWithEmptyContentReturns400(t *testing.T) {
+	// v2: marker no longer needs to be inside content. Empty content remains
+	// invalid, so we test that path here.
 	t.Setenv("MANAGEMENT_PASSWORD", "")
 	h := newPromptRulesTestHandler(t, nil)
 
 	body := []config.PromptRule{{
 		Name: "bad", Enabled: true, Target: "system", Action: "inject",
-		Content: "no sentinel", Marker: "<!-- pr:none -->",
+		Content: "",
 	}}
 	rec := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(rec)
@@ -123,6 +125,25 @@ func TestPromptRules_API_PutWithMarkerNotInContentReturns400(t *testing.T) {
 	h.PutPromptRules(ctx)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPromptRules_API_PutWithMarkerNotInContent_AcceptedV2(t *testing.T) {
+	// v2 codification: PUT a rule whose marker does not appear inside content
+	// must succeed (anchor semantics, not sentinel).
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	h := newPromptRulesTestHandler(t, nil)
+
+	body := []config.PromptRule{{
+		Name: "anchor", Enabled: true, Target: "system", Action: "inject",
+		Content: " (proxy)", Marker: "qwen", Position: "append",
+	}}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = newJSONReq(t, http.MethodPut, "/v0/management/prompt-rules", body)
+	h.PutPromptRules(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 under v2; got %d body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/api/handlers/management/prompt_rules_test.go
+++ b/internal/api/handlers/management/prompt_rules_test.go
@@ -1,0 +1,216 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// newPromptRulesTestHandler returns a handler bound to a temp config.yaml so
+// persistLocked succeeds without affecting any real config file.
+//
+// Note: we deliberately do NOT call gin.SetMode here — that function is
+// not safe to call from concurrent test goroutines (Codex review §17 surface
+// area) and other tests in this package already set the mode at startup.
+func newPromptRulesTestHandler(t *testing.T, cfg *config.Config) *Handler {
+	t.Helper()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	// Seed the file so SaveConfigPreserveComments has something to round-trip.
+	if err := os.WriteFile(configPath, []byte("port: 8080\n"), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	return NewHandler(cfg, configPath, manager)
+}
+
+func newJSONReq(t *testing.T, method, path string, body any) *http.Request {
+	t.Helper()
+	var rdr *bytes.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		rdr = bytes.NewReader(raw)
+	} else {
+		rdr = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestPromptRules_API_PutGet_Roundtrip(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	h := newPromptRulesTestHandler(t, nil)
+
+	body := []config.PromptRule{
+		{
+			Name: "inject-style", Enabled: true,
+			Target: "system", Action: "inject",
+			Content: "<!-- pr:s --> Be brief.", Marker: "<!-- pr:s -->",
+		},
+	}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = newJSONReq(t, http.MethodPut, "/v0/management/prompt-rules", body)
+	h.PutPromptRules(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	ctx, _ = gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/prompt-rules", nil)
+	h.GetPromptRules(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		PromptRules []config.PromptRule `json:"prompt-rules"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.PromptRules) != 1 || got.PromptRules[0].Name != "inject-style" {
+		t.Fatalf("round-trip lost data: %+v", got.PromptRules)
+	}
+	if got.PromptRules[0].Position != "append" {
+		t.Fatalf("expected default position append; got %q", got.PromptRules[0].Position)
+	}
+}
+
+func TestPromptRules_API_PutWithInvalidRegexReturns400(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	h := newPromptRulesTestHandler(t, nil)
+
+	body := []config.PromptRule{{
+		Name: "bad", Enabled: true, Target: "system", Action: "strip",
+		Pattern: "(unclosed",
+	}}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = newJSONReq(t, http.MethodPut, "/v0/management/prompt-rules", body)
+	h.PutPromptRules(ctx)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid regex; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPromptRules_API_PutWithMarkerNotInContentReturns400(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	h := newPromptRulesTestHandler(t, nil)
+
+	body := []config.PromptRule{{
+		Name: "bad", Enabled: true, Target: "system", Action: "inject",
+		Content: "no sentinel", Marker: "<!-- pr:none -->",
+	}}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = newJSONReq(t, http.MethodPut, "/v0/management/prompt-rules", body)
+	h.PutPromptRules(ctx)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPromptRules_API_PatchByName(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	h := newPromptRulesTestHandler(t, &config.Config{
+		PromptRules: []config.PromptRule{{
+			Name: "r1", Enabled: true, Target: "system", Action: "inject",
+			Content: "<!-- pr:r1 --> a", Marker: "<!-- pr:r1 -->", Position: "append",
+		}},
+	})
+
+	match := "r1"
+	patch := struct {
+		Match *string            `json:"match"`
+		Value *config.PromptRule `json:"value"`
+	}{
+		Match: &match,
+		Value: &config.PromptRule{
+			Name: "r1", Enabled: true, Target: "system", Action: "inject",
+			Content: "<!-- pr:r1 --> NEW", Marker: "<!-- pr:r1 -->", Position: "prepend",
+		},
+	}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = newJSONReq(t, http.MethodPatch, "/v0/management/prompt-rules", patch)
+	h.PatchPromptRule(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH expected 200; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if h.cfg.PromptRules[0].Position != "prepend" {
+		t.Fatalf("expected position updated to prepend; got %+v", h.cfg.PromptRules[0])
+	}
+	if h.cfg.PromptRules[0].Content != "<!-- pr:r1 --> NEW" {
+		t.Fatalf("expected content updated; got %q", h.cfg.PromptRules[0].Content)
+	}
+}
+
+func TestPromptRules_API_DeleteByName(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	h := newPromptRulesTestHandler(t, &config.Config{
+		PromptRules: []config.PromptRule{
+			{Name: "a", Enabled: true, Target: "system", Action: "strip", Pattern: "x"},
+			{Name: "b", Enabled: true, Target: "system", Action: "strip", Pattern: "y"},
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodDelete, "/v0/management/prompt-rules?name=a", nil)
+	h.DeletePromptRule(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE expected 200; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(h.cfg.PromptRules) != 1 || h.cfg.PromptRules[0].Name != "b" {
+		t.Fatalf("expected only 'b' to remain; got %+v", h.cfg.PromptRules)
+	}
+}
+
+func TestPromptRules_API_DeleteUnknownNameReturns404(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	h := newPromptRulesTestHandler(t, nil)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodDelete, "/v0/management/prompt-rules?name=missing", nil)
+	h.DeletePromptRule(ctx)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPromptRules_API_PutEmptyBodyClears(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	h := newPromptRulesTestHandler(t, &config.Config{
+		PromptRules: []config.PromptRule{
+			{Name: "a", Enabled: true, Target: "system", Action: "strip", Pattern: "x"},
+		},
+	})
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPut, "/v0/management/prompt-rules", bytes.NewReader(nil))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PutPromptRules(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for empty body (clears); got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(h.cfg.PromptRules) != 0 {
+		t.Fatalf("expected list cleared; got %+v", h.cfg.PromptRules)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -555,6 +555,11 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PATCH("/api-keys", s.mgmt.PatchAPIKeys)
 		mgmt.DELETE("/api-keys", s.mgmt.DeleteAPIKeys)
 
+		mgmt.GET("/prompt-rules", s.mgmt.GetPromptRules)
+		mgmt.PUT("/prompt-rules", s.mgmt.PutPromptRules)
+		mgmt.PATCH("/prompt-rules", s.mgmt.PatchPromptRule)
+		mgmt.DELETE("/prompt-rules", s.mgmt.DeletePromptRule)
+
 		mgmt.GET("/gemini-api-key", s.mgmt.GetGeminiKeys)
 		mgmt.PUT("/gemini-api-key", s.mgmt.PutGeminiKeys)
 		mgmt.PATCH("/gemini-api-key", s.mgmt.PatchGeminiKey)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -369,13 +369,20 @@ const (
 // either the system prompt or the most recent natural-language user message of an
 // outgoing request, scoped by model glob and source format.
 //
-// Inject rules write Content into the target idempotently: the rule is skipped when
-// Marker is already present in the target. Marker must appear inside Content so a
-// freshly injected payload always carries its idempotency sentinel.
+// Inject rules write Content into the target idempotently. Marker is optional
+// and toggles between two semantics:
+//   - When Marker is empty (boundary mode), Position is relative to the target
+//     text boundaries (append = end, prepend = start) and idempotency is
+//     "skip when target already contains Content as a substring".
+//   - When Marker is non-empty (anchor mode), Position is relative to the
+//     marker (append = immediately after, prepend = immediately before),
+//     idempotency is "skip when Content is already directly adjacent to some
+//     marker occurrence in the configured direction", and the rule no-ops if
+//     the marker is not present in the target.
 //
-// Strip rules apply an RE2 regex to the target's text, replacing matches with empty
-// string. Strip rules run before inject rules within a single request so injected
-// content is never accidentally stripped on the same pass.
+// Strip rules apply an RE2 regex to the target's text, replacing matches with
+// empty string. Strip rules run before inject rules within a single request so
+// injected content is never accidentally stripped on the same pass.
 type PromptRule struct {
 	// Name uniquely identifies the rule for management API operations.
 	Name string `yaml:"name" json:"name"`
@@ -389,9 +396,12 @@ type PromptRule struct {
 	Target string `yaml:"target" json:"target"`
 	// Action is "inject" or "strip".
 	Action string `yaml:"action" json:"action"`
-	// Content is the literal text injected. Required for inject. Must contain Marker.
+	// Content is the literal text injected. Required for inject.
 	Content string `yaml:"content,omitempty" json:"content,omitempty"`
-	// Marker is the idempotency sentinel substring. Required for inject.
+	// Marker is optional. When non-empty it acts as an anchor: Position is
+	// relative to the marker and idempotency is checked by adjacency. When
+	// empty, Position is relative to the target's text boundaries and
+	// idempotency is checked by Content presence.
 	Marker string `yaml:"marker,omitempty" json:"marker,omitempty"`
 	// Position is "prepend" or "append" (default "append"). Used by inject.
 	Position string `yaml:"position,omitempty" json:"position,omitempty"`
@@ -941,12 +951,6 @@ func validatePromptRule(r *PromptRule) error {
 	case PromptRuleActionInject:
 		if r.Content == "" {
 			return errors.New("content is required for inject")
-		}
-		if r.Marker == "" {
-			return errors.New("marker is required for inject")
-		}
-		if !strings.Contains(r.Content, r.Marker) {
-			return errors.New("marker must appear inside content")
 		}
 		switch r.Position {
 		case PromptRulePositionAppend, PromptRulePositionPrepend:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"syscall"
 
@@ -136,6 +137,11 @@ type Config struct {
 
 	// Payload defines default and override rules for provider payload parameters.
 	Payload PayloadConfig `yaml:"payload" json:"payload"`
+
+	// PromptRules defines content-level inject/strip rules applied pre-translation
+	// to outgoing request system prompts and natural-language user messages.
+	// See helps.ApplyPromptRules for the runtime behavior.
+	PromptRules []PromptRule `yaml:"prompt-rules,omitempty" json:"prompt-rules,omitempty"`
 
 	legacyMigrationPending bool `yaml:"-" json:"-"`
 }
@@ -341,6 +347,56 @@ type PayloadModelRule struct {
 	Name string `yaml:"name" json:"name"`
 	// Protocol restricts the rule to a specific translator format (e.g., "gemini", "responses").
 	Protocol string `yaml:"protocol" json:"protocol"`
+}
+
+// PromptRule constants — exported for consumers to avoid string typos.
+const (
+	PromptRuleTargetSystem = "system"
+	PromptRuleTargetUser   = "user"
+
+	PromptRuleActionInject = "inject"
+	PromptRuleActionStrip  = "strip"
+
+	PromptRulePositionAppend  = "append"
+	PromptRulePositionPrepend = "prepend"
+
+	// PromptRulePatternMaxLen caps strip-rule regex pattern length to mitigate
+	// memory blowup risk even though Go's RE2 is linear-time.
+	PromptRulePatternMaxLen = 1024
+)
+
+// PromptRule describes a content-level transformation applied pre-translation to
+// either the system prompt or the most recent natural-language user message of an
+// outgoing request, scoped by model glob and source format.
+//
+// Inject rules write Content into the target idempotently: the rule is skipped when
+// Marker is already present in the target. Marker must appear inside Content so a
+// freshly injected payload always carries its idempotency sentinel.
+//
+// Strip rules apply an RE2 regex to the target's text, replacing matches with empty
+// string. Strip rules run before inject rules within a single request so injected
+// content is never accidentally stripped on the same pass.
+type PromptRule struct {
+	// Name uniquely identifies the rule for management API operations.
+	Name string `yaml:"name" json:"name"`
+	// Enabled toggles whether the rule fires.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Models scopes the rule. Empty list means match all models and source formats.
+	// Reuses PayloadModelRule; the Protocol field here means SOURCE format (e.g.,
+	// "openai", "openai-response", "claude", "gemini", "gemini-cli").
+	Models []PayloadModelRule `yaml:"models,omitempty" json:"models,omitempty"`
+	// Target is "system" or "user".
+	Target string `yaml:"target" json:"target"`
+	// Action is "inject" or "strip".
+	Action string `yaml:"action" json:"action"`
+	// Content is the literal text injected. Required for inject. Must contain Marker.
+	Content string `yaml:"content,omitempty" json:"content,omitempty"`
+	// Marker is the idempotency sentinel substring. Required for inject.
+	Marker string `yaml:"marker,omitempty" json:"marker,omitempty"`
+	// Position is "prepend" or "append" (default "append"). Used by inject.
+	Position string `yaml:"position,omitempty" json:"position,omitempty"`
+	// Pattern is the RE2 regex used by strip. Length capped at PromptRulePatternMaxLen.
+	Pattern string `yaml:"pattern,omitempty" json:"pattern,omitempty"`
 }
 
 // CloakConfig configures request cloaking for non-Claude-Code clients.
@@ -705,6 +761,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Validate raw payload rules and drop invalid entries.
 	cfg.SanitizePayloadRules()
 
+	// Validate prompt rules and drop invalid entries.
+	cfg.SanitizePromptRules()
+
 	// NOTE: Legacy migration persistence is intentionally disabled together with
 	// startup legacy migration to keep startup read-only for config.yaml.
 	// Re-enable the block below if automatic startup migration is needed again.
@@ -731,6 +790,189 @@ func (cfg *Config) SanitizePayloadRules() {
 	}
 	cfg.Payload.DefaultRaw = sanitizePayloadRawRules(cfg.Payload.DefaultRaw, "default-raw")
 	cfg.Payload.OverrideRaw = sanitizePayloadRawRules(cfg.Payload.OverrideRaw, "override-raw")
+}
+
+// promptRulesUpdateHook is invoked by SanitizePromptRules so the runtime cache of
+// compiled regexes stays in sync with the loaded config. Set via
+// SetPromptRulesUpdateHook from the runtime package; nil by default to keep config
+// usable in isolation (and to avoid an import cycle).
+var promptRulesUpdateHook func([]PromptRule)
+
+// promptRuleProtocolValidator is set by the runtime package to vet that
+// PromptRule.Models[].Protocol values are in the allowed source-format set.
+// Returning false rejects the rule. nil means "any protocol accepted".
+var promptRuleProtocolValidator func(string) bool
+
+// SetPromptRuleProtocolValidator registers a predicate used by ValidatePromptRule
+// to reject rules whose Models[].Protocol is not a recognized source format.
+// Wired from internal/runtime/executor/helps to keep config decoupled.
+func SetPromptRuleProtocolValidator(fn func(string) bool) {
+	promptRuleProtocolValidator = fn
+}
+
+// SetPromptRulesUpdateHook registers a callback invoked after SanitizePromptRules
+// completes. The runtime package uses this to rebuild its compiled-regex snapshot
+// without introducing a config→helps import.
+func SetPromptRulesUpdateHook(fn func([]PromptRule)) {
+	promptRulesUpdateHook = fn
+}
+
+func notifyPromptRulesUpdated(rules []PromptRule) {
+	if promptRulesUpdateHook == nil {
+		return
+	}
+	cp := append([]PromptRule(nil), rules...)
+	promptRulesUpdateHook(cp)
+}
+
+// SanitizePromptRules normalizes every prompt rule and drops any that fail
+// validation (or duplicate an earlier name), with a debug log explaining why.
+// Used at config load so a malformed YAML on disk does not block startup.
+//
+// Always invokes the registered update hook — even when the input list is empty
+// or nil — so the runtime cache is cleared when an admin removes all rules via
+// YAML upload (per Codex post-impl review BLOCKER #7).
+func (cfg *Config) SanitizePromptRules() {
+	if cfg == nil {
+		return
+	}
+	if len(cfg.PromptRules) == 0 {
+		notifyPromptRulesUpdated(nil)
+		return
+	}
+	out := make([]PromptRule, 0, len(cfg.PromptRules))
+	seen := make(map[string]struct{}, len(cfg.PromptRules))
+	for i := range cfg.PromptRules {
+		rule := normalizePromptRule(cfg.PromptRules[i])
+		if err := validatePromptRule(&rule); err != nil {
+			log.WithFields(log.Fields{
+				"section":    "prompt-rules",
+				"rule_index": i + 1,
+				"rule_name":  rule.Name,
+				"error":      err.Error(),
+			}).Warn("prompt rule dropped: invalid")
+			continue
+		}
+		if _, dup := seen[rule.Name]; dup {
+			log.WithFields(log.Fields{
+				"section":    "prompt-rules",
+				"rule_index": i + 1,
+				"rule_name":  rule.Name,
+			}).Warn("prompt rule dropped: duplicate name")
+			continue
+		}
+		seen[rule.Name] = struct{}{}
+		out = append(out, rule)
+	}
+	cfg.PromptRules = out
+	notifyPromptRulesUpdated(cfg.PromptRules)
+}
+
+// ValidatePromptRules returns the first validation error encountered, or nil when
+// every rule is well-formed. Used at API write paths so the caller receives a 400
+// with a reason instead of silently dropping rules. Names must be unique across
+// the list since they identify rules for PATCH/DELETE operations.
+func (cfg *Config) ValidatePromptRules() error {
+	if cfg == nil {
+		return nil
+	}
+	seen := make(map[string]int, len(cfg.PromptRules))
+	for i := range cfg.PromptRules {
+		rule := normalizePromptRule(cfg.PromptRules[i])
+		if err := validatePromptRule(&rule); err != nil {
+			return fmt.Errorf("prompt-rules[%d] %q: %w", i, rule.Name, err)
+		}
+		if prev, dup := seen[rule.Name]; dup {
+			return fmt.Errorf("prompt-rules[%d] %q: duplicate name (also at index %d)", i, rule.Name, prev)
+		}
+		seen[rule.Name] = i
+	}
+	return nil
+}
+
+// NormalizePromptRules applies trim/lowercase/default-position normalization in
+// place so the persisted config matches what passes validation. Call after a
+// successful ValidatePromptRules at write paths before persisting.
+func (cfg *Config) NormalizePromptRules() {
+	if cfg == nil {
+		return
+	}
+	for i := range cfg.PromptRules {
+		cfg.PromptRules[i] = normalizePromptRule(cfg.PromptRules[i])
+	}
+}
+
+func normalizePromptRule(r PromptRule) PromptRule {
+	r.Name = strings.TrimSpace(r.Name)
+	r.Target = strings.ToLower(strings.TrimSpace(r.Target))
+	r.Action = strings.ToLower(strings.TrimSpace(r.Action))
+	r.Marker = strings.TrimSpace(r.Marker)
+	if r.Action == PromptRuleActionInject {
+		pos := strings.ToLower(strings.TrimSpace(r.Position))
+		if pos == "" {
+			pos = PromptRulePositionAppend
+		}
+		r.Position = pos
+	} else {
+		r.Position = ""
+	}
+	for j := range r.Models {
+		r.Models[j].Name = strings.TrimSpace(r.Models[j].Name)
+		r.Models[j].Protocol = strings.ToLower(strings.TrimSpace(r.Models[j].Protocol))
+	}
+	return r
+}
+
+func validatePromptRule(r *PromptRule) error {
+	if r.Name == "" {
+		return errors.New("name is required")
+	}
+	for j := range r.Models {
+		if promptRuleProtocolValidator != nil && !promptRuleProtocolValidator(r.Models[j].Protocol) {
+			return fmt.Errorf("models[%d].protocol %q is not a recognized source format", j, r.Models[j].Protocol)
+		}
+	}
+	switch r.Target {
+	case PromptRuleTargetSystem, PromptRuleTargetUser:
+	default:
+		return fmt.Errorf("invalid target %q (expected %q or %q)", r.Target, PromptRuleTargetSystem, PromptRuleTargetUser)
+	}
+	switch r.Action {
+	case PromptRuleActionInject:
+		if r.Content == "" {
+			return errors.New("content is required for inject")
+		}
+		if r.Marker == "" {
+			return errors.New("marker is required for inject")
+		}
+		if !strings.Contains(r.Content, r.Marker) {
+			return errors.New("marker must appear inside content")
+		}
+		switch r.Position {
+		case PromptRulePositionAppend, PromptRulePositionPrepend:
+		default:
+			return fmt.Errorf("invalid position %q (expected %q or %q)", r.Position, PromptRulePositionAppend, PromptRulePositionPrepend)
+		}
+		if r.Pattern != "" {
+			return errors.New("pattern must be empty for inject")
+		}
+	case PromptRuleActionStrip:
+		if r.Pattern == "" {
+			return errors.New("pattern is required for strip")
+		}
+		if len(r.Pattern) > PromptRulePatternMaxLen {
+			return fmt.Errorf("pattern length %d exceeds max %d", len(r.Pattern), PromptRulePatternMaxLen)
+		}
+		if _, err := regexp.Compile(r.Pattern); err != nil {
+			return fmt.Errorf("invalid regex: %w", err)
+		}
+		if r.Content != "" || r.Marker != "" {
+			return errors.New("content and marker must be empty for strip")
+		}
+	default:
+		return fmt.Errorf("invalid action %q (expected %q or %q)", r.Action, PromptRuleActionInject, PromptRuleActionStrip)
+	}
+	return nil
 }
 
 func sanitizePayloadRawRules(rules []PayloadRule, section string) []PayloadRule {

--- a/internal/config/prompt_rules_test.go
+++ b/internal/config/prompt_rules_test.go
@@ -30,22 +30,55 @@ func TestValidatePromptRules_Valid(t *testing.T) {
 	}
 }
 
-func TestValidatePromptRules_RejectsInjectMissingMarkerInContent(t *testing.T) {
+func TestValidatePromptRules_AcceptsEmptyMarkerOnInject(t *testing.T) {
+	// v2: marker is optional. Empty marker means boundary mode.
 	cfg := &Config{
 		PromptRules: []PromptRule{{
-			Name:    "bad",
+			Name:    "boundary-inject",
 			Enabled: true,
 			Target:  "system",
 			Action:  "inject",
-			Content: "no sentinel here",
-			Marker:  "<!-- pr:none -->",
+			Content: "Always answer in JSON.",
+		}},
+	}
+	if err := cfg.ValidatePromptRules(); err != nil {
+		t.Fatalf("empty marker should be valid (boundary mode); got %v", err)
+	}
+}
+
+func TestValidatePromptRules_AcceptsMarkerNotInContent(t *testing.T) {
+	// v2: marker no longer needs to appear inside content. The marker is now
+	// an anchor against the target text, not a sentinel embedded in content.
+	cfg := &Config{
+		PromptRules: []PromptRule{{
+			Name:    "anchor-inject",
+			Enabled: true,
+			Target:  "system",
+			Action:  "inject",
+			Content: " (proxy)",
+			Marker:  "qwen",
+		}},
+	}
+	if err := cfg.ValidatePromptRules(); err != nil {
+		t.Fatalf("marker outside content should be valid; got %v", err)
+	}
+}
+
+func TestValidatePromptRules_RejectsInjectMissingContent(t *testing.T) {
+	cfg := &Config{
+		PromptRules: []PromptRule{{
+			Name:    "no-content",
+			Enabled: true,
+			Target:  "system",
+			Action:  "inject",
+			Content: "",
 		}},
 	}
 	err := cfg.ValidatePromptRules()
 	if err == nil {
-		t.Fatal("expected error when marker is not contained in content")
+		t.Fatal("expected error when content is empty")
 	}
-	if !strings.Contains(err.Error(), "marker must appear inside content") {
+	if !strings.Contains(err.Error(), "content is required") {
 		t.Fatalf("error message lacks expected reason: %v", err)
 	}
 }
@@ -168,11 +201,9 @@ func TestValidatePromptRules_RejectsBadTargetAndAction(t *testing.T) {
 func TestSanitizePromptRules_DropsInvalidAndDuplicates(t *testing.T) {
 	cfg := &Config{
 		PromptRules: []PromptRule{
-			{Name: "ok", Enabled: true, Target: "system", Action: "inject",
-				Content: "<!-- pr:o --> a", Marker: "<!-- pr:o -->"},
-			{Name: "no-marker", Enabled: true, Target: "system", Action: "inject",
-				Content: "no sentinel", Marker: "<!-- pr:x -->"}, // marker not in content
-			{Name: "ok", Enabled: true, Target: "user", Action: "strip", Pattern: "x"}, // duplicate name
+			{Name: "ok", Enabled: true, Target: "system", Action: "inject", Content: "always JSON."},
+			{Name: "no-content", Enabled: true, Target: "system", Action: "inject", Content: ""}, // missing content
+			{Name: "ok", Enabled: true, Target: "user", Action: "strip", Pattern: "x"},           // duplicate name
 			{Name: "bad-regex", Enabled: true, Target: "user", Action: "strip", Pattern: "(unclosed"},
 		},
 	}

--- a/internal/config/prompt_rules_test.go
+++ b/internal/config/prompt_rules_test.go
@@ -1,0 +1,211 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePromptRules_Valid(t *testing.T) {
+	cfg := &Config{
+		PromptRules: []PromptRule{
+			{
+				Name:    "inject-style",
+				Enabled: true,
+				Target:  "system",
+				Action:  "inject",
+				Content: "<!-- pr:s --> JSON only.",
+				Marker:  "<!-- pr:s -->",
+			},
+			{
+				Name:    "strip-buddy",
+				Enabled: true,
+				Target:  "system",
+				Action:  "strip",
+				Pattern: `Buddy[^\n]*\n?`,
+			},
+		},
+	}
+	if err := cfg.ValidatePromptRules(); err != nil {
+		t.Fatalf("expected valid; got %v", err)
+	}
+}
+
+func TestValidatePromptRules_RejectsInjectMissingMarkerInContent(t *testing.T) {
+	cfg := &Config{
+		PromptRules: []PromptRule{{
+			Name:    "bad",
+			Enabled: true,
+			Target:  "system",
+			Action:  "inject",
+			Content: "no sentinel here",
+			Marker:  "<!-- pr:none -->",
+		}},
+	}
+	err := cfg.ValidatePromptRules()
+	if err == nil {
+		t.Fatal("expected error when marker is not contained in content")
+	}
+	if !strings.Contains(err.Error(), "marker must appear inside content") {
+		t.Fatalf("error message lacks expected reason: %v", err)
+	}
+}
+
+func TestValidatePromptRules_RejectsInvalidRegex(t *testing.T) {
+	cfg := &Config{
+		PromptRules: []PromptRule{{
+			Name:    "bad-regex",
+			Enabled: true,
+			Target:  "system",
+			Action:  "strip",
+			Pattern: "(unclosed",
+		}},
+	}
+	err := cfg.ValidatePromptRules()
+	if err == nil {
+		t.Fatal("expected error for unclosed regex")
+	}
+	if !strings.Contains(err.Error(), "invalid regex") {
+		t.Fatalf("error message lacks expected reason: %v", err)
+	}
+}
+
+func TestValidatePromptRules_RejectsLongPattern(t *testing.T) {
+	cfg := &Config{
+		PromptRules: []PromptRule{{
+			Name:    "long",
+			Enabled: true,
+			Target:  "system",
+			Action:  "strip",
+			Pattern: strings.Repeat("a", PromptRulePatternMaxLen+1),
+		}},
+	}
+	err := cfg.ValidatePromptRules()
+	if err == nil {
+		t.Fatal("expected error for over-long pattern")
+	}
+	if !strings.Contains(err.Error(), "exceeds max") {
+		t.Fatalf("error message lacks expected reason: %v", err)
+	}
+}
+
+func TestValidatePromptRules_RejectsDuplicateNames(t *testing.T) {
+	cfg := &Config{
+		PromptRules: []PromptRule{
+			{
+				Name: "dup", Enabled: true, Target: "system", Action: "inject",
+				Content: "<!-- pr:d --> a", Marker: "<!-- pr:d -->",
+			},
+			{
+				Name: "dup", Enabled: true, Target: "system", Action: "inject",
+				Content: "<!-- pr:d --> b", Marker: "<!-- pr:d -->",
+			},
+		},
+	}
+	err := cfg.ValidatePromptRules()
+	if err == nil {
+		t.Fatal("expected duplicate-name rejection")
+	}
+	if !strings.Contains(err.Error(), "duplicate name") {
+		t.Fatalf("error message lacks expected reason: %v", err)
+	}
+}
+
+func TestValidatePromptRules_RejectsUnknownProtocol(t *testing.T) {
+	prev := promptRuleProtocolValidator
+	t.Cleanup(func() { promptRuleProtocolValidator = prev })
+	SetPromptRuleProtocolValidator(func(p string) bool {
+		return p == "" || p == "openai" || p == "claude" || p == "gemini"
+	})
+	cfg := &Config{
+		PromptRules: []PromptRule{{
+			Name: "rule", Enabled: true, Target: "system", Action: "inject",
+			Content: "<!-- m --> a", Marker: "<!-- m -->",
+			Models: []PayloadModelRule{{Name: "*", Protocol: "bogus"}},
+		}},
+	}
+	err := cfg.ValidatePromptRules()
+	if err == nil {
+		t.Fatal("expected error for unknown protocol")
+	}
+	if !strings.Contains(err.Error(), "not a recognized source format") {
+		t.Fatalf("error message lacks expected reason: %v", err)
+	}
+}
+
+func TestValidatePromptRules_RejectsBadTargetAndAction(t *testing.T) {
+	cases := []struct {
+		name string
+		rule PromptRule
+		want string
+	}{
+		{
+			"bad target",
+			PromptRule{Name: "x", Target: "user-prompt", Action: "inject", Content: "<!-- m --> a", Marker: "<!-- m -->"},
+			"invalid target",
+		},
+		{
+			"bad action",
+			PromptRule{Name: "x", Target: "system", Action: "replace", Content: "a", Marker: "a"},
+			"invalid action",
+		},
+		{
+			"missing name",
+			PromptRule{Target: "system", Action: "inject", Content: "<!-- m --> a", Marker: "<!-- m -->"},
+			"name is required",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{PromptRules: []PromptRule{tc.rule}}
+			err := cfg.ValidatePromptRules()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q; got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestSanitizePromptRules_DropsInvalidAndDuplicates(t *testing.T) {
+	cfg := &Config{
+		PromptRules: []PromptRule{
+			{Name: "ok", Enabled: true, Target: "system", Action: "inject",
+				Content: "<!-- pr:o --> a", Marker: "<!-- pr:o -->"},
+			{Name: "no-marker", Enabled: true, Target: "system", Action: "inject",
+				Content: "no sentinel", Marker: "<!-- pr:x -->"}, // marker not in content
+			{Name: "ok", Enabled: true, Target: "user", Action: "strip", Pattern: "x"}, // duplicate name
+			{Name: "bad-regex", Enabled: true, Target: "user", Action: "strip", Pattern: "(unclosed"},
+		},
+	}
+	cfg.SanitizePromptRules()
+	if got := len(cfg.PromptRules); got != 1 {
+		t.Fatalf("expected 1 rule to survive sanitization; got %d: %+v", got, cfg.PromptRules)
+	}
+	if cfg.PromptRules[0].Name != "ok" {
+		t.Fatalf("unexpected surviving rule: %+v", cfg.PromptRules[0])
+	}
+}
+
+func TestNormalizePromptRules_Defaults(t *testing.T) {
+	cfg := &Config{
+		PromptRules: []PromptRule{{
+			Name: "  Spaced  ", Enabled: true,
+			Target: " SYSTEM ", Action: " Inject ",
+			Content: "<!-- m --> a", Marker: "<!-- m -->",
+			Position: "", // default to "append"
+		}},
+	}
+	cfg.NormalizePromptRules()
+	r := cfg.PromptRules[0]
+	if r.Name != "Spaced" {
+		t.Fatalf("name should be trimmed: %q", r.Name)
+	}
+	if r.Target != "system" {
+		t.Fatalf("target should be lowercased: %q", r.Target)
+	}
+	if r.Action != "inject" {
+		t.Fatalf("action should be lowercased: %q", r.Action)
+	}
+	if r.Position != "append" {
+		t.Fatalf("position should default to append: %q", r.Position)
+	}
+}

--- a/internal/runtime/executor/helps/prompt_rules.go
+++ b/internal/runtime/executor/helps/prompt_rules.go
@@ -1,0 +1,294 @@
+package helps
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"sync/atomic"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/tidwall/gjson"
+)
+
+// marshalJSONNoEscape encodes v with HTML escaping disabled so injected text
+// containing <, >, or & does not appear in upstream payloads as </>/&.
+// JSON parsers handle either form, but unescaped output is more readable in logs.
+func marshalJSONNoEscape(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out, nil
+}
+
+// promptRulesSnapshot is the immutable runtime view of cfg.PromptRules with each
+// strip rule's regex pre-compiled. Concurrent readers obtain the current snapshot
+// via an atomic load — never holding a lock on the hot path.
+type promptRulesSnapshot struct {
+	rules   []config.PromptRule
+	regexes []*regexp.Regexp // parallel to rules; nil for non-strip or invalid pattern
+}
+
+var promptRulesPtr atomic.Pointer[promptRulesSnapshot]
+
+func init() {
+	// Wire SanitizePromptRules → snapshot rebuild so every config load (boot, file
+	// watcher, management API persist that re-loads) refreshes the runtime cache.
+	config.SetPromptRulesUpdateHook(updatePromptRulesSnapshotInternal)
+	// Wire validation predicate so config rejects rules scoped to unknown
+	// source formats. The set of valid protocols is owned by this package.
+	config.SetPromptRuleProtocolValidator(IsAllowedPromptRuleProtocol)
+}
+
+// UpdatePromptRulesSnapshot rebuilds the in-process compiled-regex snapshot from
+// the supplied rules. Management handlers call this after mutating cfg.PromptRules
+// in place (since those paths bypass LoadConfig).
+func UpdatePromptRulesSnapshot(rules []config.PromptRule) {
+	updatePromptRulesSnapshotInternal(rules)
+}
+
+func updatePromptRulesSnapshotInternal(rules []config.PromptRule) {
+	// Deep copy each rule's Models slice so external mutation of the source
+	// config (under management's lock) cannot race with readers iterating an
+	// older snapshot. Outer slice copy alone is insufficient — the inner
+	// Models slice is shared by default.
+	deep := make([]config.PromptRule, len(rules))
+	for i := range rules {
+		r := rules[i]
+		if len(r.Models) > 0 {
+			r.Models = append([]config.PayloadModelRule(nil), r.Models...)
+		}
+		deep[i] = r
+	}
+	snap := &promptRulesSnapshot{
+		rules:   deep,
+		regexes: make([]*regexp.Regexp, len(deep)),
+	}
+	for i := range deep {
+		if deep[i].Action == config.PromptRuleActionStrip && deep[i].Pattern != "" {
+			if re, err := regexp.Compile(deep[i].Pattern); err == nil {
+				snap.regexes[i] = re
+			}
+			// Compile failures are silently skipped at runtime — write paths
+			// already validate so this branch is defense-in-depth for SDK
+			// programmatic config users (per Codex review §14).
+		}
+	}
+	promptRulesPtr.Store(snap)
+}
+
+func loadPromptRulesSnapshot() *promptRulesSnapshot {
+	return promptRulesPtr.Load()
+}
+
+// ApplyPromptRules mutates a source-format request body according to enabled
+// prompt rules. Strip rules run first, then inject. Idempotent via per-rule
+// marker substring. Endpoint-scoped: skips /v1/images/* and the responses/compact
+// alt path.
+//
+// sourceFormat is the inbound request's protocol identifier (the value of
+// BaseAPIHandler.HandlerType()): "openai", "openai-response", "claude",
+// "gemini", or "gemini-cli". Unknown formats are pass-through.
+//
+// The function reads from a package-level atomic snapshot; callers do not need
+// to thread *config.Config through to the handler chokepoint.
+func ApplyPromptRules(sourceFormat, model string, rawJSON []byte, requestPath, alt string) []byte {
+	if len(rawJSON) == 0 {
+		return rawJSON
+	}
+	if alt == "responses/compact" || isImagesEndpointRequestPath(requestPath) {
+		return rawJSON
+	}
+	snap := loadPromptRulesSnapshot()
+	if snap == nil || len(snap.rules) == 0 {
+		return rawJSON
+	}
+	h := promptHandlerForSourceFormat(sourceFormat)
+	if h == nil {
+		return rawJSON
+	}
+	candidates := payloadModelCandidates(model, model)
+	out := rawJSON
+
+	// Strip pass first so injected content cannot be unintentionally stripped
+	// within the same request.
+	for i := range snap.rules {
+		rule := &snap.rules[i]
+		if !rule.Enabled || rule.Action != config.PromptRuleActionStrip {
+			continue
+		}
+		if !promptRuleMatch(rule, sourceFormat, candidates) {
+			continue
+		}
+		re := snap.regexes[i]
+		if re == nil {
+			continue
+		}
+		switch rule.Target {
+		case config.PromptRuleTargetSystem:
+			out = h.StripSystem(out, re)
+		case config.PromptRuleTargetUser:
+			out = h.StripLastUser(out, re)
+		}
+	}
+
+	// Inject pass.
+	for i := range snap.rules {
+		rule := &snap.rules[i]
+		if !rule.Enabled || rule.Action != config.PromptRuleActionInject {
+			continue
+		}
+		if !promptRuleMatch(rule, sourceFormat, candidates) {
+			continue
+		}
+		position := rule.Position
+		if position == "" {
+			position = config.PromptRulePositionAppend
+		}
+		switch rule.Target {
+		case config.PromptRuleTargetSystem:
+			out = h.InjectSystem(out, rule.Content, rule.Marker, position)
+		case config.PromptRuleTargetUser:
+			out = h.InjectLastUser(out, rule.Content, rule.Marker, position)
+		}
+	}
+	return out
+}
+
+// promptRuleMatch returns true when the rule's Models scope admits the given
+// source format and model. Empty Models slice means match-all — explicitly
+// different from payloadModelRulesMatch which returns false on empty.
+func promptRuleMatch(rule *config.PromptRule, sourceFormat string, models []string) bool {
+	if len(rule.Models) == 0 {
+		return true
+	}
+	if len(models) == 0 {
+		return false
+	}
+	for _, model := range models {
+		for j := range rule.Models {
+			entry := &rule.Models[j]
+			name := strings.TrimSpace(entry.Name)
+			if name == "" {
+				continue
+			}
+			if ep := strings.TrimSpace(entry.Protocol); ep != "" && sourceFormat != "" && !strings.EqualFold(ep, sourceFormat) {
+				continue
+			}
+			if matchModelPattern(name, model) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// promptHandler is the per-source-format dispatch surface. Each implementation
+// understands the JSON shape of one inbound request format and applies inject /
+// strip operations on system prompt and last natural-language user message.
+type promptHandler interface {
+	InjectSystem(payload []byte, content, marker, position string) []byte
+	StripSystem(payload []byte, re *regexp.Regexp) []byte
+	InjectLastUser(payload []byte, content, marker, position string) []byte
+	StripLastUser(payload []byte, re *regexp.Regexp) []byte
+}
+
+var (
+	openaiPromptHandler         promptHandler = &openaiPromptFmt{}
+	openaiResponsePromptHandler promptHandler = &openaiResponsePromptFmt{}
+	claudePromptHandler         promptHandler = &claudePromptFmt{}
+	geminiPromptHandler         promptHandler = newGeminiPromptFmt("")
+	geminiCLIPromptHandler      promptHandler = newGeminiPromptFmt("request")
+)
+
+// AllowedPromptRuleProtocols is the canonical set of source-format strings that
+// PromptRule.Models[].Protocol may scope to. Used by config validation and
+// kept in lockstep with the dispatch table below — no aliases.
+var AllowedPromptRuleProtocols = []string{
+	"openai", "openai-response", "claude", "gemini", "gemini-cli",
+}
+
+// IsAllowedPromptRuleProtocol returns true when p is an empty string ("any
+// source format") or matches one of the accepted source-format strings.
+func IsAllowedPromptRuleProtocol(p string) bool {
+	if p == "" {
+		return true
+	}
+	for _, allowed := range AllowedPromptRuleProtocols {
+		if allowed == p {
+			return true
+		}
+	}
+	return false
+}
+
+func promptHandlerForSourceFormat(sourceFormat string) promptHandler {
+	switch strings.ToLower(strings.TrimSpace(sourceFormat)) {
+	case "openai":
+		return openaiPromptHandler
+	case "openai-response":
+		return openaiResponsePromptHandler
+	case "claude":
+		return claudePromptHandler
+	case "gemini":
+		return geminiPromptHandler
+	case "gemini-cli":
+		return geminiCLIPromptHandler
+	default:
+		return nil
+	}
+}
+
+// applyPosition returns the result of inserting add into base at the configured
+// position. Used for inject mutations on string-shaped targets.
+func applyPosition(base, add, position string) string {
+	if position == config.PromptRulePositionPrepend {
+		return add + base
+	}
+	return base + add
+}
+
+// containsMarker returns true when marker is non-empty AND appears in text.
+// An empty marker is invalid at validation time, so this returns false to err on
+// the side of injecting (which a downstream test can flag).
+func containsMarker(text, marker string) bool {
+	if marker == "" {
+		return false
+	}
+	return strings.Contains(text, marker)
+}
+
+// hasNonEmptyText returns true when the given gjson.Result has a string-typed
+// child at field whose trimmed value is non-empty. Used by per-format locators
+// to decide whether a content block / part counts as natural-language text.
+func hasNonEmptyText(r gjson.Result, field string) bool {
+	t := r.Get(field)
+	if !t.Exists() || t.Type != gjson.String {
+		return false
+	}
+	return strings.TrimSpace(t.String()) != ""
+}
+
+// isImagesEndpointRequestPath reports whether the inbound HTTP path targets the
+// image generation/edit endpoints. Those endpoints synthesize multimodal
+// payloads internally and are excluded from prompt-rule mutations by default.
+//
+// This is a local helper to avoid coupling to the disable-image-generation
+// feature on feat/logging which is not yet on main.
+func isImagesEndpointRequestPath(path string) bool {
+	p := strings.TrimSpace(path)
+	if p == "" {
+		return false
+	}
+	return strings.HasSuffix(p, "/v1/images/generations") ||
+		strings.HasSuffix(p, "/v1/images/edits") ||
+		strings.HasSuffix(p, "/images/generations") ||
+		strings.HasSuffix(p, "/images/edits")
+}

--- a/internal/runtime/executor/helps/prompt_rules.go
+++ b/internal/runtime/executor/helps/prompt_rules.go
@@ -408,6 +408,29 @@ func blockArrayInject(payload []byte, path string, isTextBlock func(gjson.Result
 	return updated
 }
 
+// prependArrayElement inserts rawElement at index 0 of the JSON array at path.
+// sjson does not support insert-at-N natively, so we read+rebuild the array.
+// Shared across per-format handlers and blockArrayInject in this file.
+func prependArrayElement(payload []byte, path string, rawElement []byte) []byte {
+	arr := gjson.GetBytes(payload, path)
+	if !arr.IsArray() {
+		return payload
+	}
+	var b bytes.Buffer
+	b.WriteByte('[')
+	b.Write(rawElement)
+	for _, item := range arr.Array() {
+		b.WriteByte(',')
+		b.WriteString(item.Raw)
+	}
+	b.WriteByte(']')
+	updated, err := sjson.SetRawBytes(payload, path, b.Bytes())
+	if err != nil {
+		return payload
+	}
+	return updated
+}
+
 // hasNonEmptyText returns true when the given gjson.Result has a string-typed
 // child at field whose trimmed value is non-empty. Used by per-format locators
 // to decide whether a content block / part counts as natural-language text.

--- a/internal/runtime/executor/helps/prompt_rules.go
+++ b/internal/runtime/executor/helps/prompt_rules.go
@@ -3,12 +3,14 @@ package helps
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 	"sync/atomic"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 // marshalJSONNoEscape encodes v with HTML escaping disabled so injected text
@@ -89,9 +91,16 @@ func loadPromptRulesSnapshot() *promptRulesSnapshot {
 }
 
 // ApplyPromptRules mutates a source-format request body according to enabled
-// prompt rules. Strip rules run first, then inject. Idempotent via per-rule
-// marker substring. Endpoint-scoped: skips /v1/images/* and the responses/compact
-// alt path.
+// prompt rules. Strip rules run first, then inject. Idempotency is per
+// inject-rule mode:
+//   - Boundary mode (Marker == ""): skip the inject when the target already
+//     contains Content as a substring; otherwise insert at start (prepend) or
+//     end (append) of the target text.
+//   - Marker mode (Marker != ""): skip when Content is already directly
+//     adjacent to some marker occurrence in the configured direction; skip
+//     entirely when the marker is not present in the target.
+//
+// Endpoint-scoped: skips /v1/images/* and the responses/compact alt path.
 //
 // sourceFormat is the inbound request's protocol identifier (the value of
 // BaseAPIHandler.HandlerType()): "openai", "openai-response", "claude",
@@ -247,7 +256,7 @@ func promptHandlerForSourceFormat(sourceFormat string) promptHandler {
 }
 
 // applyPosition returns the result of inserting add into base at the configured
-// position. Used for inject mutations on string-shaped targets.
+// position. Used for inject mutations on string-shaped targets in boundary mode.
 func applyPosition(base, add, position string) string {
 	if position == config.PromptRulePositionPrepend {
 		return add + base
@@ -255,14 +264,148 @@ func applyPosition(base, add, position string) string {
 	return base + add
 }
 
-// containsMarker returns true when marker is non-empty AND appears in text.
-// An empty marker is invalid at validation time, so this returns false to err on
-// the side of injecting (which a downstream test can flag).
-func containsMarker(text, marker string) bool {
-	if marker == "" {
+// hasAdjacentContent reports whether content is immediately contiguous (per
+// position) to at least one occurrence of marker in text. Returns false when
+// marker or content is empty, or when marker is not present in text. Used by
+// marker-mode idempotency: walk all marker occurrences and skip the inject if
+// any of them already has content directly adjacent in the configured
+// direction.
+//
+// The scan advances by one byte after each match (not by len(marker)) so that
+// overlapping marker occurrences are visited. Without this, a target like
+// "aaab" with marker="aa" would only check index 0 and miss the adjacency at
+// index 1.
+func hasAdjacentContent(text, content, marker, position string) bool {
+	if marker == "" || content == "" {
 		return false
 	}
-	return strings.Contains(text, marker)
+	n := len(marker)
+	start := 0
+	for {
+		off := strings.Index(text[start:], marker)
+		if off < 0 {
+			return false
+		}
+		i := start + off
+		if position == config.PromptRulePositionPrepend {
+			if i >= len(content) && text[i-len(content):i] == content {
+				return true
+			}
+		} else {
+			after := i + n
+			if after+len(content) <= len(text) && text[after:after+len(content)] == content {
+				return true
+			}
+		}
+		start = i + 1
+		if start >= len(text) {
+			return false
+		}
+	}
+}
+
+// injectIntoText returns text with content inserted per the marker/position
+// rules. The bool is false (text unchanged) when the operation is a no-op:
+//   - content == ""
+//   - marker == "" and content already a substring of text (boundary
+//     idempotency)
+//   - marker != "" and marker not present in text (no anchor)
+//   - marker != "" and content already directly adjacent to some marker
+//     occurrence in the configured direction (marker idempotency)
+//
+// Otherwise the returned text contains content inserted at the first marker
+// occurrence (marker mode) or at the configured boundary (no-marker mode).
+func injectIntoText(text, content, marker, position string) (string, bool) {
+	if content == "" {
+		return text, false
+	}
+	if marker == "" {
+		if strings.Contains(text, content) {
+			return text, false
+		}
+		return applyPosition(text, content, position), true
+	}
+	firstIdx := strings.Index(text, marker)
+	if firstIdx < 0 {
+		return text, false
+	}
+	if hasAdjacentContent(text, content, marker, position) {
+		return text, false
+	}
+	if position == config.PromptRulePositionPrepend {
+		return text[:firstIdx] + content + text[firstIdx:], true
+	}
+	end := firstIdx + len(marker)
+	return text[:end] + content + text[end:], true
+}
+
+// blockArrayInject applies the v2 inject semantics to a JSON array of content
+// blocks at the given path inside payload. isTextBlock identifies which blocks
+// are text-bearing for this source format. newTextBlock builds the
+// format-specific JSON for a fresh text block carrying the provided content.
+//
+// Boundary mode (empty marker): skip if any text block already contains
+// content as a substring; otherwise insert a new text block at the array
+// boundary corresponding to position.
+//
+// Marker mode (non-empty marker): walk every text block. The whole rule is
+// suppressed if any marker-bearing block already has content directly
+// adjacent to one of its marker occurrences in the configured direction.
+// Otherwise the inject lands inside the first marker-bearing block.
+func blockArrayInject(payload []byte, path string, isTextBlock func(gjson.Result) bool, newTextBlock func(content string) ([]byte, error), content, marker, position string) []byte {
+	arr := gjson.GetBytes(payload, path)
+	if !arr.IsArray() {
+		return payload
+	}
+	blocks := arr.Array()
+	if marker == "" {
+		for _, b := range blocks {
+			if isTextBlock(b) && strings.Contains(b.Get("text").String(), content) {
+				return payload
+			}
+		}
+		newBlock, err := newTextBlock(content)
+		if err != nil {
+			return payload
+		}
+		if position == config.PromptRulePositionAppend {
+			updated, err := sjson.SetRawBytes(payload, path+".-1", newBlock)
+			if err != nil {
+				return payload
+			}
+			return updated
+		}
+		return prependArrayElement(payload, path, newBlock)
+	}
+	firstIdx := -1
+	for i, b := range blocks {
+		if !isTextBlock(b) {
+			continue
+		}
+		text := b.Get("text").String()
+		if !strings.Contains(text, marker) {
+			continue
+		}
+		if firstIdx < 0 {
+			firstIdx = i
+		}
+		if hasAdjacentContent(text, content, marker, position) {
+			return payload
+		}
+	}
+	if firstIdx < 0 {
+		return payload
+	}
+	text := blocks[firstIdx].Get("text").String()
+	newText, mutated := injectIntoText(text, content, marker, position)
+	if !mutated {
+		return payload
+	}
+	updated, err := sjson.SetBytes(payload, fmt.Sprintf("%s.%d.text", path, firstIdx), newText)
+	if err != nil {
+		return payload
+	}
+	return updated
 }
 
 // hasNonEmptyText returns true when the given gjson.Result has a string-typed

--- a/internal/runtime/executor/helps/prompt_rules.go
+++ b/internal/runtime/executor/helps/prompt_rules.go
@@ -276,19 +276,6 @@ func hasNonEmptyText(r gjson.Result, field string) bool {
 	return strings.TrimSpace(t.String()) != ""
 }
 
-// isImagesEndpointRequestPath reports whether the inbound HTTP path targets the
-// image generation/edit endpoints. Those endpoints synthesize multimodal
-// payloads internally and are excluded from prompt-rule mutations by default.
-//
-// This is a local helper to avoid coupling to the disable-image-generation
-// feature on feat/logging which is not yet on main.
-func isImagesEndpointRequestPath(path string) bool {
-	p := strings.TrimSpace(path)
-	if p == "" {
-		return false
-	}
-	return strings.HasSuffix(p, "/v1/images/generations") ||
-		strings.HasSuffix(p, "/v1/images/edits") ||
-		strings.HasSuffix(p, "/images/generations") ||
-		strings.HasSuffix(p, "/images/edits")
-}
+// isImagesEndpointRequestPath is provided by payload_helpers.go (in this same
+// package) as part of the disable-image-generation tri-state feature. We share
+// that helper rather than re-declaring it locally.

--- a/internal/runtime/executor/helps/prompt_rules_claude.go
+++ b/internal/runtime/executor/helps/prompt_rules_claude.go
@@ -1,0 +1,239 @@
+package helps
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// claudePromptFmt implements prompt-rule mutations for the Anthropic Messages
+// (Claude) source format. The system prompt lives at the top-level "system" field
+// which can be either a string or an array of content blocks ({type:"text",text}).
+// User messages live in messages[*] where role=="user"; their content can be a
+// string or an array of blocks ({type:"text"|"tool_result"|"image"|...}).
+//
+// Per Codex review §18: messages with role=="user" but content that is purely
+// tool_result blocks are NOT considered natural-language user prompts and are
+// skipped by inject/strip.
+type claudePromptFmt struct{}
+
+func (claudePromptFmt) InjectSystem(payload []byte, content, marker, position string) []byte {
+	if len(content) == 0 {
+		return payload
+	}
+	sys := gjson.GetBytes(payload, "system")
+	if !sys.Exists() {
+		// Create as plain string to match the simplest Claude shape.
+		updated, err := sjson.SetBytes(payload, "system", content)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if sys.Type == gjson.String {
+		text := sys.String()
+		if containsMarker(text, marker) {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, "system", applyPosition(text, content, position))
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if !sys.IsArray() {
+		return payload
+	}
+	// Block-array shape: skip if any text block carries the marker.
+	for _, block := range sys.Array() {
+		if block.Get("type").String() == "text" && containsMarker(block.Get("text").String(), marker) {
+			return payload
+		}
+	}
+	newBlock, err := marshalJSONNoEscape(map[string]any{"type": "text", "text": content})
+	if err != nil {
+		return payload
+	}
+	if position == "append" {
+		updated, err := sjson.SetRawBytes(payload, "system.-1", newBlock)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	return prependArrayElement(payload, "system", newBlock)
+}
+
+func (claudePromptFmt) StripSystem(payload []byte, re *regexp.Regexp) []byte {
+	sys := gjson.GetBytes(payload, "system")
+	if !sys.Exists() {
+		return payload
+	}
+	if sys.Type == gjson.String {
+		text := sys.String()
+		stripped := re.ReplaceAllString(text, "")
+		if stripped == text {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, "system", stripped)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if !sys.IsArray() {
+		return payload
+	}
+	out := payload
+	for i, block := range sys.Array() {
+		if block.Get("type").String() != "text" {
+			continue
+		}
+		tx := block.Get("text")
+		if !tx.Exists() {
+			continue
+		}
+		s := tx.String()
+		stripped := re.ReplaceAllString(s, "")
+		if stripped == s {
+			continue
+		}
+		if updated, err := sjson.SetBytes(out, fmt.Sprintf("system.%d.text", i), stripped); err == nil {
+			out = updated
+		}
+	}
+	return out
+}
+
+func (claudePromptFmt) InjectLastUser(payload []byte, content, marker, position string) []byte {
+	if len(content) == 0 {
+		return payload
+	}
+	msgs := gjson.GetBytes(payload, "messages")
+	if !msgs.IsArray() {
+		return payload
+	}
+	idx := claudeLastNaturalUserIndex(msgs)
+	if idx < 0 {
+		return payload
+	}
+	return claudeMutateUserContent(payload, idx, content, marker, position)
+}
+
+func (claudePromptFmt) StripLastUser(payload []byte, re *regexp.Regexp) []byte {
+	msgs := gjson.GetBytes(payload, "messages")
+	if !msgs.IsArray() {
+		return payload
+	}
+	idx := claudeLastNaturalUserIndex(msgs)
+	if idx < 0 {
+		return payload
+	}
+	return claudeStripUserContent(payload, idx, re)
+}
+
+// claudeLastNaturalUserIndex finds the last role=="user" message whose content is
+// a non-empty string OR an array containing at least one text block. Messages
+// whose content array is purely tool_result/image/document blocks are skipped.
+func claudeLastNaturalUserIndex(messages gjson.Result) int {
+	arr := messages.Array()
+	for i := len(arr) - 1; i >= 0; i-- {
+		m := arr[i]
+		if m.Get("role").String() != "user" {
+			continue
+		}
+		c := m.Get("content")
+		if c.Type == gjson.String {
+			if strings.TrimSpace(c.String()) != "" {
+				return i
+			}
+			continue
+		}
+		if c.IsArray() {
+			for _, block := range c.Array() {
+				if block.Get("type").String() == "text" && hasNonEmptyText(block, "text") {
+					return i
+				}
+			}
+		}
+	}
+	return -1
+}
+
+func claudeMutateUserContent(payload []byte, idx int, content, marker, position string) []byte {
+	path := fmt.Sprintf("messages.%d.content", idx)
+	c := gjson.GetBytes(payload, path)
+	if c.Type == gjson.String {
+		text := c.String()
+		if containsMarker(text, marker) {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, path, applyPosition(text, content, position))
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if !c.IsArray() {
+		return payload
+	}
+	for _, block := range c.Array() {
+		if block.Get("type").String() == "text" && containsMarker(block.Get("text").String(), marker) {
+			return payload
+		}
+	}
+	newBlock, err := marshalJSONNoEscape(map[string]any{"type": "text", "text": content})
+	if err != nil {
+		return payload
+	}
+	if position == "append" {
+		updated, err := sjson.SetRawBytes(payload, path+".-1", newBlock)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	return prependArrayElement(payload, path, newBlock)
+}
+
+func claudeStripUserContent(payload []byte, idx int, re *regexp.Regexp) []byte {
+	path := fmt.Sprintf("messages.%d.content", idx)
+	c := gjson.GetBytes(payload, path)
+	if c.Type == gjson.String {
+		text := c.String()
+		stripped := re.ReplaceAllString(text, "")
+		if stripped == text {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, path, stripped)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if !c.IsArray() {
+		return payload
+	}
+	out := payload
+	for i, block := range c.Array() {
+		if block.Get("type").String() != "text" {
+			continue
+		}
+		tx := block.Get("text")
+		if !tx.Exists() {
+			continue
+		}
+		s := tx.String()
+		stripped := re.ReplaceAllString(s, "")
+		if stripped == s {
+			continue
+		}
+		if updated, err := sjson.SetBytes(out, fmt.Sprintf("%s.%d.text", path, i), stripped); err == nil {
+			out = updated
+		}
+	}
+	return out
+}

--- a/internal/runtime/executor/helps/prompt_rules_claude.go
+++ b/internal/runtime/executor/helps/prompt_rules_claude.go
@@ -26,7 +26,11 @@ func (claudePromptFmt) InjectSystem(payload []byte, content, marker, position st
 	}
 	sys := gjson.GetBytes(payload, "system")
 	if !sys.Exists() {
-		// Create as plain string to match the simplest Claude shape.
+		// Marker mode: no anchor exists, no synthesis. Boundary mode: create as
+		// plain string to match the simplest Claude shape.
+		if marker != "" {
+			return payload
+		}
 		updated, err := sjson.SetBytes(payload, "system", content)
 		if err != nil {
 			return payload
@@ -35,10 +39,11 @@ func (claudePromptFmt) InjectSystem(payload []byte, content, marker, position st
 	}
 	if sys.Type == gjson.String {
 		text := sys.String()
-		if containsMarker(text, marker) {
+		newText, mutated := injectIntoText(text, content, marker, position)
+		if !mutated {
 			return payload
 		}
-		updated, err := sjson.SetBytes(payload, "system", applyPosition(text, content, position))
+		updated, err := sjson.SetBytes(payload, "system", newText)
 		if err != nil {
 			return payload
 		}
@@ -47,24 +52,7 @@ func (claudePromptFmt) InjectSystem(payload []byte, content, marker, position st
 	if !sys.IsArray() {
 		return payload
 	}
-	// Block-array shape: skip if any text block carries the marker.
-	for _, block := range sys.Array() {
-		if block.Get("type").String() == "text" && containsMarker(block.Get("text").String(), marker) {
-			return payload
-		}
-	}
-	newBlock, err := marshalJSONNoEscape(map[string]any{"type": "text", "text": content})
-	if err != nil {
-		return payload
-	}
-	if position == "append" {
-		updated, err := sjson.SetRawBytes(payload, "system.-1", newBlock)
-		if err != nil {
-			return payload
-		}
-		return updated
-	}
-	return prependArrayElement(payload, "system", newBlock)
+	return blockArrayInject(payload, "system", isClaudeTextBlock, newClaudeTextBlock, content, marker, position)
 }
 
 func (claudePromptFmt) StripSystem(payload []byte, re *regexp.Regexp) []byte {
@@ -168,10 +156,11 @@ func claudeMutateUserContent(payload []byte, idx int, content, marker, position 
 	c := gjson.GetBytes(payload, path)
 	if c.Type == gjson.String {
 		text := c.String()
-		if containsMarker(text, marker) {
+		newText, mutated := injectIntoText(text, content, marker, position)
+		if !mutated {
 			return payload
 		}
-		updated, err := sjson.SetBytes(payload, path, applyPosition(text, content, position))
+		updated, err := sjson.SetBytes(payload, path, newText)
 		if err != nil {
 			return payload
 		}
@@ -180,23 +169,15 @@ func claudeMutateUserContent(payload []byte, idx int, content, marker, position 
 	if !c.IsArray() {
 		return payload
 	}
-	for _, block := range c.Array() {
-		if block.Get("type").String() == "text" && containsMarker(block.Get("text").String(), marker) {
-			return payload
-		}
-	}
-	newBlock, err := marshalJSONNoEscape(map[string]any{"type": "text", "text": content})
-	if err != nil {
-		return payload
-	}
-	if position == "append" {
-		updated, err := sjson.SetRawBytes(payload, path+".-1", newBlock)
-		if err != nil {
-			return payload
-		}
-		return updated
-	}
-	return prependArrayElement(payload, path, newBlock)
+	return blockArrayInject(payload, path, isClaudeTextBlock, newClaudeTextBlock, content, marker, position)
+}
+
+func isClaudeTextBlock(b gjson.Result) bool {
+	return b.Get("type").String() == "text"
+}
+
+func newClaudeTextBlock(content string) ([]byte, error) {
+	return marshalJSONNoEscape(map[string]any{"type": "text", "text": content})
 }
 
 func claudeStripUserContent(payload []byte, idx int, re *regexp.Regexp) []byte {

--- a/internal/runtime/executor/helps/prompt_rules_gemini.go
+++ b/internal/runtime/executor/helps/prompt_rules_gemini.go
@@ -52,7 +52,11 @@ func (g *geminiPromptFmt) InjectSystem(payload []byte, content, marker, position
 	}
 	field := g.activeSystemField(payload)
 	if field == "" {
-		// Neither variant exists — create the camelCase shape under our root.
+		// Marker mode: no anchor, no synthesis. Boundary mode: create the
+		// camelCase shape under our root with a single text part.
+		if marker != "" {
+			return payload
+		}
 		instruction := map[string]any{
 			"role":  "system",
 			"parts": []map[string]any{{"text": content}},
@@ -69,7 +73,11 @@ func (g *geminiPromptFmt) InjectSystem(payload []byte, content, marker, position
 	}
 	parts := gjson.GetBytes(payload, field+".parts")
 	if !parts.IsArray() {
-		// Replace the whole field with a fresh single-part shape.
+		// Malformed shape — marker mode has no anchor here. Boundary mode
+		// replaces the field with a fresh single-part shape carrying content.
+		if marker != "" {
+			return payload
+		}
 		instruction := map[string]any{
 			"role":  "system",
 			"parts": []map[string]any{{"text": content}},
@@ -84,24 +92,7 @@ func (g *geminiPromptFmt) InjectSystem(payload []byte, content, marker, position
 		}
 		return updated
 	}
-	// Skip if any text part carries the marker.
-	for _, p := range parts.Array() {
-		if p.Get("text").Exists() && containsMarker(p.Get("text").String(), marker) {
-			return payload
-		}
-	}
-	newPart, err := marshalJSONNoEscape(map[string]any{"text": content})
-	if err != nil {
-		return payload
-	}
-	if position == "append" {
-		updated, err := sjson.SetRawBytes(payload, field+".parts.-1", newPart)
-		if err != nil {
-			return payload
-		}
-		return updated
-	}
-	return prependArrayElement(payload, field+".parts", newPart)
+	return blockArrayInject(payload, field+".parts", isGeminiTextPart, newGeminiTextPart, content, marker, position)
 }
 
 func (g *geminiPromptFmt) StripSystem(payload []byte, re *regexp.Regexp) []byte {
@@ -201,27 +192,15 @@ func geminiLastNaturalUserIndex(contents gjson.Result) int {
 
 func (g *geminiPromptFmt) mutateContentParts(payload []byte, idx int, content, marker, position string) []byte {
 	path := fmt.Sprintf("%s.%d.parts", g.prefixedPath("contents"), idx)
-	parts := gjson.GetBytes(payload, path)
-	if !parts.IsArray() {
-		return payload
-	}
-	for _, p := range parts.Array() {
-		if p.Get("text").Exists() && containsMarker(p.Get("text").String(), marker) {
-			return payload
-		}
-	}
-	newPart, err := marshalJSONNoEscape(map[string]any{"text": content})
-	if err != nil {
-		return payload
-	}
-	if position == "append" {
-		updated, err := sjson.SetRawBytes(payload, path+".-1", newPart)
-		if err != nil {
-			return payload
-		}
-		return updated
-	}
-	return prependArrayElement(payload, path, newPart)
+	return blockArrayInject(payload, path, isGeminiTextPart, newGeminiTextPart, content, marker, position)
+}
+
+func isGeminiTextPart(p gjson.Result) bool {
+	return p.Get("text").Exists()
+}
+
+func newGeminiTextPart(content string) ([]byte, error) {
+	return marshalJSONNoEscape(map[string]any{"text": content})
 }
 
 func (g *geminiPromptFmt) stripContentParts(payload []byte, idx int, re *regexp.Regexp) []byte {

--- a/internal/runtime/executor/helps/prompt_rules_gemini.go
+++ b/internal/runtime/executor/helps/prompt_rules_gemini.go
@@ -1,0 +1,249 @@
+package helps
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// geminiPromptFmt implements prompt-rule mutations for the Gemini source format.
+// rootPrefix differentiates plain "gemini" (rootPrefix="") from "gemini-cli"
+// (rootPrefix="request") — the gemini-cli source format wraps the entire Gemini
+// request shape under a top-level "request" object, which is verified at the
+// translator/gemini-cli/* and runtime/executor/gemini_cli_executor.go path
+// usages (e.g., request.systemInstruction, request.contents).
+//
+// The system prompt lives in either systemInstruction (camelCase, used by
+// OpenAI→Gemini and most clients) OR system_instruction (snake_case, used by
+// Claude→Gemini per the original Codex review §5). User messages live in
+// contents[?role=="user"] with parts that can include text, functionResponse,
+// functionCall, or inlineData blocks.
+type geminiPromptFmt struct {
+	rootPrefix string
+}
+
+func newGeminiPromptFmt(rootPrefix string) *geminiPromptFmt {
+	return &geminiPromptFmt{rootPrefix: rootPrefix}
+}
+
+const (
+	geminiSystemInstructionCamel = "systemInstruction"
+	geminiSystemInstructionSnake = "system_instruction"
+)
+
+// prefixedPath joins the format's optional root prefix with a relative path.
+// e.g., for gemini-cli with rootPrefix="request" and rel="systemInstruction",
+// returns "request.systemInstruction". For plain gemini, returns rel unchanged.
+func (g *geminiPromptFmt) prefixedPath(rel string) string {
+	if g.rootPrefix == "" {
+		return rel
+	}
+	if rel == "" {
+		return g.rootPrefix
+	}
+	return g.rootPrefix + "." + rel
+}
+
+func (g *geminiPromptFmt) InjectSystem(payload []byte, content, marker, position string) []byte {
+	if len(content) == 0 {
+		return payload
+	}
+	field := g.activeSystemField(payload)
+	if field == "" {
+		// Neither variant exists — create the camelCase shape under our root.
+		instruction := map[string]any{
+			"role":  "system",
+			"parts": []map[string]any{{"text": content}},
+		}
+		raw, err := marshalJSONNoEscape(instruction)
+		if err != nil {
+			return payload
+		}
+		updated, err := sjson.SetRawBytes(payload, g.prefixedPath(geminiSystemInstructionCamel), raw)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	parts := gjson.GetBytes(payload, field+".parts")
+	if !parts.IsArray() {
+		// Replace the whole field with a fresh single-part shape.
+		instruction := map[string]any{
+			"role":  "system",
+			"parts": []map[string]any{{"text": content}},
+		}
+		raw, err := marshalJSONNoEscape(instruction)
+		if err != nil {
+			return payload
+		}
+		updated, err := sjson.SetRawBytes(payload, field, raw)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	// Skip if any text part carries the marker.
+	for _, p := range parts.Array() {
+		if p.Get("text").Exists() && containsMarker(p.Get("text").String(), marker) {
+			return payload
+		}
+	}
+	newPart, err := marshalJSONNoEscape(map[string]any{"text": content})
+	if err != nil {
+		return payload
+	}
+	if position == "append" {
+		updated, err := sjson.SetRawBytes(payload, field+".parts.-1", newPart)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	return prependArrayElement(payload, field+".parts", newPart)
+}
+
+func (g *geminiPromptFmt) StripSystem(payload []byte, re *regexp.Regexp) []byte {
+	field := g.activeSystemField(payload)
+	if field == "" {
+		return payload
+	}
+	parts := gjson.GetBytes(payload, field+".parts")
+	if !parts.IsArray() {
+		return payload
+	}
+	out := payload
+	for i, p := range parts.Array() {
+		tx := p.Get("text")
+		if !tx.Exists() {
+			continue
+		}
+		s := tx.String()
+		stripped := re.ReplaceAllString(s, "")
+		if stripped == s {
+			continue
+		}
+		if updated, err := sjson.SetBytes(out, fmt.Sprintf("%s.parts.%d.text", field, i), stripped); err == nil {
+			out = updated
+		}
+	}
+	return out
+}
+
+func (g *geminiPromptFmt) InjectLastUser(payload []byte, content, marker, position string) []byte {
+	if len(content) == 0 {
+		return payload
+	}
+	contents := gjson.GetBytes(payload, g.prefixedPath("contents"))
+	if !contents.IsArray() {
+		return payload
+	}
+	idx := geminiLastNaturalUserIndex(contents)
+	if idx < 0 {
+		// No natural-language user message; skip rather than synthesize one. A
+		// phantom user message would change request semantics for empty / tool-only
+		// histories. Documented design choice.
+		return payload
+	}
+	return g.mutateContentParts(payload, idx, content, marker, position)
+}
+
+func (g *geminiPromptFmt) StripLastUser(payload []byte, re *regexp.Regexp) []byte {
+	contents := gjson.GetBytes(payload, g.prefixedPath("contents"))
+	if !contents.IsArray() {
+		return payload
+	}
+	idx := geminiLastNaturalUserIndex(contents)
+	if idx < 0 {
+		return payload
+	}
+	return g.stripContentParts(payload, idx, re)
+}
+
+// activeSystemField returns the prefixed field path for whichever shape exists.
+// camelCase wins when both are present (canonical form). Empty string means
+// neither exists.
+func (g *geminiPromptFmt) activeSystemField(payload []byte) string {
+	camel := g.prefixedPath(geminiSystemInstructionCamel)
+	if gjson.GetBytes(payload, camel).Exists() {
+		return camel
+	}
+	snake := g.prefixedPath(geminiSystemInstructionSnake)
+	if gjson.GetBytes(payload, snake).Exists() {
+		return snake
+	}
+	return ""
+}
+
+// geminiLastNaturalUserIndex finds the last item with role=="user" whose parts
+// contain at least one part with a non-empty text field. Skips items whose
+// parts are purely functionResponse, functionCall, or inlineData (image/file).
+func geminiLastNaturalUserIndex(contents gjson.Result) int {
+	arr := contents.Array()
+	for i := len(arr) - 1; i >= 0; i-- {
+		item := arr[i]
+		if item.Get("role").String() != "user" {
+			continue
+		}
+		parts := item.Get("parts")
+		if !parts.IsArray() {
+			continue
+		}
+		for _, p := range parts.Array() {
+			if hasNonEmptyText(p, "text") {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func (g *geminiPromptFmt) mutateContentParts(payload []byte, idx int, content, marker, position string) []byte {
+	path := fmt.Sprintf("%s.%d.parts", g.prefixedPath("contents"), idx)
+	parts := gjson.GetBytes(payload, path)
+	if !parts.IsArray() {
+		return payload
+	}
+	for _, p := range parts.Array() {
+		if p.Get("text").Exists() && containsMarker(p.Get("text").String(), marker) {
+			return payload
+		}
+	}
+	newPart, err := marshalJSONNoEscape(map[string]any{"text": content})
+	if err != nil {
+		return payload
+	}
+	if position == "append" {
+		updated, err := sjson.SetRawBytes(payload, path+".-1", newPart)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	return prependArrayElement(payload, path, newPart)
+}
+
+func (g *geminiPromptFmt) stripContentParts(payload []byte, idx int, re *regexp.Regexp) []byte {
+	path := fmt.Sprintf("%s.%d.parts", g.prefixedPath("contents"), idx)
+	parts := gjson.GetBytes(payload, path)
+	if !parts.IsArray() {
+		return payload
+	}
+	out := payload
+	for i, p := range parts.Array() {
+		tx := p.Get("text")
+		if !tx.Exists() {
+			continue
+		}
+		s := tx.String()
+		stripped := re.ReplaceAllString(s, "")
+		if stripped == s {
+			continue
+		}
+		if updated, err := sjson.SetBytes(out, fmt.Sprintf("%s.%d.text", path, i), stripped); err == nil {
+			out = updated
+		}
+	}
+	return out
+}

--- a/internal/runtime/executor/helps/prompt_rules_openai.go
+++ b/internal/runtime/executor/helps/prompt_rules_openai.go
@@ -1,0 +1,263 @@
+package helps
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// openaiPromptFmt implements prompt-rule mutations for the OpenAI Chat
+// Completions source format. System prompts live as messages with role=="system"
+// (or "developer", which OpenAI treats as system-equivalent on newer models).
+// User messages with content that is purely a tool result, an empty list, or
+// only image blocks are NOT treated as natural-language for inject/strip.
+type openaiPromptFmt struct{}
+
+func (openaiPromptFmt) InjectSystem(payload []byte, content, marker, position string) []byte {
+	if len(content) == 0 {
+		return payload
+	}
+	msgs := gjson.GetBytes(payload, "messages")
+	if msgs.IsArray() {
+		idx, role := openaiFirstSystemLikeIndex(msgs)
+		if idx >= 0 {
+			return openaiMutateMessageContent(payload, idx, role, content, marker, position, false)
+		}
+	}
+	// No system or developer message — prepend a new one.
+	newMsg := map[string]any{"role": "system", "content": content}
+	raw, err := marshalJSONNoEscape(newMsg)
+	if err != nil {
+		return payload
+	}
+	if !msgs.Exists() {
+		updated, err := sjson.SetRawBytes(payload, "messages", append(append([]byte("["), raw...), ']'))
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	return prependArrayElement(payload, "messages", raw)
+}
+
+func (openaiPromptFmt) StripSystem(payload []byte, re *regexp.Regexp) []byte {
+	msgs := gjson.GetBytes(payload, "messages")
+	if !msgs.IsArray() {
+		return payload
+	}
+	out := payload
+	for i, m := range msgs.Array() {
+		role := m.Get("role").String()
+		if role != "system" && role != "developer" {
+			continue
+		}
+		out = openaiStripMessageContent(out, i, re)
+	}
+	return out
+}
+
+func (openaiPromptFmt) InjectLastUser(payload []byte, content, marker, position string) []byte {
+	msgs := gjson.GetBytes(payload, "messages")
+	if !msgs.IsArray() {
+		return payload
+	}
+	idx := openaiLastNaturalUserIndex(msgs)
+	if idx < 0 {
+		return payload
+	}
+	return openaiMutateMessageContent(payload, idx, "user", content, marker, position, true)
+}
+
+func (openaiPromptFmt) StripLastUser(payload []byte, re *regexp.Regexp) []byte {
+	msgs := gjson.GetBytes(payload, "messages")
+	if !msgs.IsArray() {
+		return payload
+	}
+	idx := openaiLastNaturalUserIndex(msgs)
+	if idx < 0 {
+		return payload
+	}
+	return openaiStripMessageContent(payload, idx, re)
+}
+
+// openaiFirstSystemLikeIndex returns the index of the first system or developer
+// message in the array. Prefers system; falls back to developer.
+func openaiFirstSystemLikeIndex(messages gjson.Result) (int, string) {
+	devIdx := -1
+	for i, m := range messages.Array() {
+		role := m.Get("role").String()
+		switch role {
+		case "system":
+			return i, "system"
+		case "developer":
+			if devIdx < 0 {
+				devIdx = i
+			}
+		}
+	}
+	if devIdx >= 0 {
+		return devIdx, "developer"
+	}
+	return -1, ""
+}
+
+// openaiLastNaturalUserIndex finds the last role=="user" message whose content is
+// natural-language: a non-empty string, or an array containing at least one
+// {type:"text"|"input_text"} block whose text is non-empty after trim. Messages
+// with tool_call_id, role=="tool", or content that is purely image/empty are
+// skipped.
+func openaiLastNaturalUserIndex(messages gjson.Result) int {
+	arr := messages.Array()
+	for i := len(arr) - 1; i >= 0; i-- {
+		m := arr[i]
+		if m.Get("role").String() != "user" {
+			continue
+		}
+		if m.Get("tool_call_id").Exists() {
+			continue
+		}
+		c := m.Get("content")
+		if c.Type == gjson.String {
+			if strings.TrimSpace(c.String()) != "" {
+				return i
+			}
+			continue
+		}
+		if c.IsArray() {
+			for _, block := range c.Array() {
+				blockType := block.Get("type").String()
+				if blockType == "text" || blockType == "input_text" {
+					if hasNonEmptyText(block, "text") {
+						return i
+					}
+				}
+			}
+		}
+	}
+	return -1
+}
+
+// openaiMutateMessageContent injects content into messages[idx].content per the
+// given position and marker. Handles string, array, null, and missing content
+// shapes. markerScopeIsThisMessage is reserved for future use.
+func openaiMutateMessageContent(payload []byte, idx int, role, content, marker, position string, _ bool) []byte {
+	path := fmt.Sprintf("messages.%d.content", idx)
+	c := gjson.GetBytes(payload, path)
+	// Null or absent content: replace with the injected string. Some clients
+	// emit content==null as a placeholder for system / developer messages.
+	if !c.Exists() || c.Type == gjson.Null {
+		updated, err := sjson.SetBytes(payload, path, content)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if c.Type == gjson.String {
+		text := c.String()
+		if containsMarker(text, marker) {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, path, applyPosition(text, content, position))
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if c.IsArray() {
+		// Check marker presence across all text blocks first.
+		for _, block := range c.Array() {
+			t := block.Get("type").String()
+			if (t == "text" || t == "input_text") && containsMarker(block.Get("text").String(), marker) {
+				return payload
+			}
+		}
+		// We canonicalize new blocks as type="text" since OpenAI Chat
+		// Completions accepts that uniformly. Some clients use "input_text"
+		// (Responses-influenced) but mixing types in one array is also accepted
+		// by the API, and our marker-scan above handles both forms on read.
+		_ = role
+		newBlock, err := marshalJSONNoEscape(map[string]any{"type": "text", "text": content})
+		if err != nil {
+			return payload
+		}
+		if position == "append" {
+			updated, err := sjson.SetRawBytes(payload, path+".-1", newBlock)
+			if err != nil {
+				return payload
+			}
+			return updated
+		}
+		// prepend
+		return prependArrayElement(payload, path, newBlock)
+	}
+	// Unknown content shape — leave untouched.
+	return payload
+}
+
+// openaiStripMessageContent applies the regex to the content of messages[idx],
+// handling string and array shapes.
+func openaiStripMessageContent(payload []byte, idx int, re *regexp.Regexp) []byte {
+	path := fmt.Sprintf("messages.%d.content", idx)
+	c := gjson.GetBytes(payload, path)
+	if c.Type == gjson.String {
+		text := c.String()
+		stripped := re.ReplaceAllString(text, "")
+		if stripped == text {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, path, stripped)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if c.IsArray() {
+		out := payload
+		for i, block := range c.Array() {
+			t := block.Get("type").String()
+			if t != "text" && t != "input_text" {
+				continue
+			}
+			tx := block.Get("text")
+			if !tx.Exists() {
+				continue
+			}
+			s := tx.String()
+			stripped := re.ReplaceAllString(s, "")
+			if stripped == s {
+				continue
+			}
+			if updated, err := sjson.SetBytes(out, fmt.Sprintf("%s.%d.text", path, i), stripped); err == nil {
+				out = updated
+			}
+		}
+		return out
+	}
+	return payload
+}
+
+// prependArrayElement inserts rawElement at index 0 of the JSON array at path.
+// sjson does not support insert-at-N natively, so we read+rebuild the array.
+func prependArrayElement(payload []byte, path string, rawElement []byte) []byte {
+	arr := gjson.GetBytes(payload, path)
+	if !arr.IsArray() {
+		return payload
+	}
+	var b bytes.Buffer
+	b.WriteByte('[')
+	b.Write(rawElement)
+	for _, item := range arr.Array() {
+		b.WriteByte(',')
+		b.WriteString(item.Raw)
+	}
+	b.WriteByte(']')
+	updated, err := sjson.SetRawBytes(payload, path, b.Bytes())
+	if err != nil {
+		return payload
+	}
+	return updated
+}

--- a/internal/runtime/executor/helps/prompt_rules_openai.go
+++ b/internal/runtime/executor/helps/prompt_rules_openai.go
@@ -1,7 +1,6 @@
 package helps
 
 import (
-	"bytes"
 	"fmt"
 	"regexp"
 	"strings"
@@ -240,24 +239,3 @@ func openaiStripMessageContent(payload []byte, idx int, re *regexp.Regexp) []byt
 	return payload
 }
 
-// prependArrayElement inserts rawElement at index 0 of the JSON array at path.
-// sjson does not support insert-at-N natively, so we read+rebuild the array.
-func prependArrayElement(payload []byte, path string, rawElement []byte) []byte {
-	arr := gjson.GetBytes(payload, path)
-	if !arr.IsArray() {
-		return payload
-	}
-	var b bytes.Buffer
-	b.WriteByte('[')
-	b.Write(rawElement)
-	for _, item := range arr.Array() {
-		b.WriteByte(',')
-		b.WriteString(item.Raw)
-	}
-	b.WriteByte(']')
-	updated, err := sjson.SetRawBytes(payload, path, b.Bytes())
-	if err != nil {
-		return payload
-	}
-	return updated
-}

--- a/internal/runtime/executor/helps/prompt_rules_openai.go
+++ b/internal/runtime/executor/helps/prompt_rules_openai.go
@@ -28,7 +28,12 @@ func (openaiPromptFmt) InjectSystem(payload []byte, content, marker, position st
 			return openaiMutateMessageContent(payload, idx, role, content, marker, position, false)
 		}
 	}
-	// No system or developer message — prepend a new one.
+	// No system or developer message. In marker mode there is no anchor to
+	// attach to, so the rule is a no-op. In boundary mode we synthesize a fresh
+	// system message carrying just content.
+	if marker != "" {
+		return payload
+	}
 	newMsg := map[string]any{"role": "system", "content": content}
 	raw, err := marshalJSONNoEscape(newMsg)
 	if err != nil {
@@ -143,14 +148,19 @@ func openaiLastNaturalUserIndex(messages gjson.Result) int {
 
 // openaiMutateMessageContent injects content into messages[idx].content per the
 // given position and marker. Handles string, array, null, and missing content
-// shapes. markerScopeIsThisMessage is reserved for future use.
+// shapes. role is preserved for future per-role policy.
 func openaiMutateMessageContent(payload []byte, idx int, role, content, marker, position string, _ bool) []byte {
+	_ = role
 	path := fmt.Sprintf("messages.%d.content", idx)
 	c := gjson.GetBytes(payload, path)
-	// Null or absent content: replace with the injected string. Some clients
-	// emit content==null as a placeholder for system / developer messages.
+	// Null or absent content is treated as an empty target string. Boundary
+	// mode replaces it with content; marker mode no-ops (no anchor).
 	if !c.Exists() || c.Type == gjson.Null {
-		updated, err := sjson.SetBytes(payload, path, content)
+		newText, mutated := injectIntoText("", content, marker, position)
+		if !mutated {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, path, newText)
 		if err != nil {
 			return payload
 		}
@@ -158,44 +168,34 @@ func openaiMutateMessageContent(payload []byte, idx int, role, content, marker, 
 	}
 	if c.Type == gjson.String {
 		text := c.String()
-		if containsMarker(text, marker) {
+		newText, mutated := injectIntoText(text, content, marker, position)
+		if !mutated {
 			return payload
 		}
-		updated, err := sjson.SetBytes(payload, path, applyPosition(text, content, position))
+		updated, err := sjson.SetBytes(payload, path, newText)
 		if err != nil {
 			return payload
 		}
 		return updated
 	}
 	if c.IsArray() {
-		// Check marker presence across all text blocks first.
-		for _, block := range c.Array() {
-			t := block.Get("type").String()
-			if (t == "text" || t == "input_text") && containsMarker(block.Get("text").String(), marker) {
-				return payload
-			}
-		}
-		// We canonicalize new blocks as type="text" since OpenAI Chat
-		// Completions accepts that uniformly. Some clients use "input_text"
-		// (Responses-influenced) but mixing types in one array is also accepted
-		// by the API, and our marker-scan above handles both forms on read.
-		_ = role
-		newBlock, err := marshalJSONNoEscape(map[string]any{"type": "text", "text": content})
-		if err != nil {
-			return payload
-		}
-		if position == "append" {
-			updated, err := sjson.SetRawBytes(payload, path+".-1", newBlock)
-			if err != nil {
-				return payload
-			}
-			return updated
-		}
-		// prepend
-		return prependArrayElement(payload, path, newBlock)
+		// We canonicalize new blocks as type="text"; OpenAI Chat Completions
+		// accepts that uniformly. Mixed-type arrays remain valid because the
+		// scan in blockArrayInject treats both "text" and "input_text" as
+		// text-bearing on read.
+		return blockArrayInject(payload, path, isOpenAITextBlock, newOpenAITextBlock, content, marker, position)
 	}
 	// Unknown content shape — leave untouched.
 	return payload
+}
+
+func isOpenAITextBlock(b gjson.Result) bool {
+	t := b.Get("type").String()
+	return t == "text" || t == "input_text"
+}
+
+func newOpenAITextBlock(content string) ([]byte, error) {
+	return marshalJSONNoEscape(map[string]any{"type": "text", "text": content})
 }
 
 // openaiStripMessageContent applies the regex to the content of messages[idx],

--- a/internal/runtime/executor/helps/prompt_rules_responses.go
+++ b/internal/runtime/executor/helps/prompt_rules_responses.go
@@ -1,0 +1,223 @@
+package helps
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// openaiResponsePromptFmt implements prompt-rule mutations for the OpenAI
+// Responses source format. System prompt lives in the top-level "instructions"
+// string. User messages live in the "input" field, which can be either a bare
+// string or an array of input items with role and content blocks.
+type openaiResponsePromptFmt struct{}
+
+func (openaiResponsePromptFmt) InjectSystem(payload []byte, content, marker, position string) []byte {
+	if len(content) == 0 {
+		return payload
+	}
+	cur := gjson.GetBytes(payload, "instructions")
+	if cur.Exists() && cur.Type == gjson.String {
+		text := cur.String()
+		if containsMarker(text, marker) {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, "instructions", applyPosition(text, content, position))
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	// Field absent — create with content alone.
+	updated, err := sjson.SetBytes(payload, "instructions", content)
+	if err != nil {
+		return payload
+	}
+	return updated
+}
+
+func (openaiResponsePromptFmt) StripSystem(payload []byte, re *regexp.Regexp) []byte {
+	cur := gjson.GetBytes(payload, "instructions")
+	if !cur.Exists() || cur.Type != gjson.String {
+		return payload
+	}
+	text := cur.String()
+	stripped := re.ReplaceAllString(text, "")
+	if stripped == text {
+		return payload
+	}
+	updated, err := sjson.SetBytes(payload, "instructions", stripped)
+	if err != nil {
+		return payload
+	}
+	return updated
+}
+
+func (openaiResponsePromptFmt) InjectLastUser(payload []byte, content, marker, position string) []byte {
+	if len(content) == 0 {
+		return payload
+	}
+	input := gjson.GetBytes(payload, "input")
+	if !input.Exists() {
+		return payload
+	}
+	if input.Type == gjson.String {
+		text := input.String()
+		if containsMarker(text, marker) {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, "input", applyPosition(text, content, position))
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if !input.IsArray() {
+		return payload
+	}
+	idx := responsesLastNaturalUserIndex(input)
+	if idx < 0 {
+		return payload
+	}
+	return responsesMutateInputItem(payload, idx, content, marker, position)
+}
+
+func (openaiResponsePromptFmt) StripLastUser(payload []byte, re *regexp.Regexp) []byte {
+	input := gjson.GetBytes(payload, "input")
+	if !input.Exists() {
+		return payload
+	}
+	if input.Type == gjson.String {
+		text := input.String()
+		stripped := re.ReplaceAllString(text, "")
+		if stripped == text {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, "input", stripped)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if !input.IsArray() {
+		return payload
+	}
+	idx := responsesLastNaturalUserIndex(input)
+	if idx < 0 {
+		return payload
+	}
+	return responsesStripInputItem(payload, idx, re)
+}
+
+// responsesLastNaturalUserIndex finds the last input item with role=="user" that
+// has natural-language text content. Skips function_call, function_call_output,
+// reasoning, and other non-user-text item types.
+func responsesLastNaturalUserIndex(input gjson.Result) int {
+	arr := input.Array()
+	for i := len(arr) - 1; i >= 0; i-- {
+		item := arr[i]
+		if item.Get("role").String() != "user" {
+			continue
+		}
+		// Items with explicit non-message types are skipped.
+		if t := item.Get("type").String(); t != "" && t != "message" && t != "input_text" {
+			continue
+		}
+		c := item.Get("content")
+		if c.Type == gjson.String {
+			if strings.TrimSpace(c.String()) != "" {
+				return i
+			}
+			continue
+		}
+		if c.IsArray() {
+			for _, block := range c.Array() {
+				bt := block.Get("type").String()
+				if (bt == "input_text" || bt == "text") && hasNonEmptyText(block, "text") {
+					return i
+				}
+			}
+		}
+	}
+	return -1
+}
+
+func responsesMutateInputItem(payload []byte, idx int, content, marker, position string) []byte {
+	path := fmt.Sprintf("input.%d.content", idx)
+	c := gjson.GetBytes(payload, path)
+	if c.Type == gjson.String {
+		text := c.String()
+		if containsMarker(text, marker) {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, path, applyPosition(text, content, position))
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if !c.IsArray() {
+		return payload
+	}
+	for _, block := range c.Array() {
+		bt := block.Get("type").String()
+		if (bt == "input_text" || bt == "text") && containsMarker(block.Get("text").String(), marker) {
+			return payload
+		}
+	}
+	newBlock, err := marshalJSONNoEscape(map[string]any{"type": "input_text", "text": content})
+	if err != nil {
+		return payload
+	}
+	if position == "append" {
+		updated, err := sjson.SetRawBytes(payload, path+".-1", newBlock)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	return prependArrayElement(payload, path, newBlock)
+}
+
+func responsesStripInputItem(payload []byte, idx int, re *regexp.Regexp) []byte {
+	path := fmt.Sprintf("input.%d.content", idx)
+	c := gjson.GetBytes(payload, path)
+	if c.Type == gjson.String {
+		text := c.String()
+		stripped := re.ReplaceAllString(text, "")
+		if stripped == text {
+			return payload
+		}
+		updated, err := sjson.SetBytes(payload, path, stripped)
+		if err != nil {
+			return payload
+		}
+		return updated
+	}
+	if !c.IsArray() {
+		return payload
+	}
+	out := payload
+	for i, block := range c.Array() {
+		bt := block.Get("type").String()
+		if bt != "input_text" && bt != "text" {
+			continue
+		}
+		tx := block.Get("text")
+		if !tx.Exists() {
+			continue
+		}
+		s := tx.String()
+		stripped := re.ReplaceAllString(s, "")
+		if stripped == s {
+			continue
+		}
+		if updated, err := sjson.SetBytes(out, fmt.Sprintf("%s.%d.text", path, i), stripped); err == nil {
+			out = updated
+		}
+	}
+	return out
+}

--- a/internal/runtime/executor/helps/prompt_rules_responses.go
+++ b/internal/runtime/executor/helps/prompt_rules_responses.go
@@ -22,16 +22,20 @@ func (openaiResponsePromptFmt) InjectSystem(payload []byte, content, marker, pos
 	cur := gjson.GetBytes(payload, "instructions")
 	if cur.Exists() && cur.Type == gjson.String {
 		text := cur.String()
-		if containsMarker(text, marker) {
+		newText, mutated := injectIntoText(text, content, marker, position)
+		if !mutated {
 			return payload
 		}
-		updated, err := sjson.SetBytes(payload, "instructions", applyPosition(text, content, position))
+		updated, err := sjson.SetBytes(payload, "instructions", newText)
 		if err != nil {
 			return payload
 		}
 		return updated
 	}
-	// Field absent — create with content alone.
+	// Field absent. Marker mode no-ops; boundary mode creates with content alone.
+	if marker != "" {
+		return payload
+	}
 	updated, err := sjson.SetBytes(payload, "instructions", content)
 	if err != nil {
 		return payload
@@ -66,10 +70,11 @@ func (openaiResponsePromptFmt) InjectLastUser(payload []byte, content, marker, p
 	}
 	if input.Type == gjson.String {
 		text := input.String()
-		if containsMarker(text, marker) {
+		newText, mutated := injectIntoText(text, content, marker, position)
+		if !mutated {
 			return payload
 		}
-		updated, err := sjson.SetBytes(payload, "input", applyPosition(text, content, position))
+		updated, err := sjson.SetBytes(payload, "input", newText)
 		if err != nil {
 			return payload
 		}
@@ -150,10 +155,11 @@ func responsesMutateInputItem(payload []byte, idx int, content, marker, position
 	c := gjson.GetBytes(payload, path)
 	if c.Type == gjson.String {
 		text := c.String()
-		if containsMarker(text, marker) {
+		newText, mutated := injectIntoText(text, content, marker, position)
+		if !mutated {
 			return payload
 		}
-		updated, err := sjson.SetBytes(payload, path, applyPosition(text, content, position))
+		updated, err := sjson.SetBytes(payload, path, newText)
 		if err != nil {
 			return payload
 		}
@@ -162,24 +168,16 @@ func responsesMutateInputItem(payload []byte, idx int, content, marker, position
 	if !c.IsArray() {
 		return payload
 	}
-	for _, block := range c.Array() {
-		bt := block.Get("type").String()
-		if (bt == "input_text" || bt == "text") && containsMarker(block.Get("text").String(), marker) {
-			return payload
-		}
-	}
-	newBlock, err := marshalJSONNoEscape(map[string]any{"type": "input_text", "text": content})
-	if err != nil {
-		return payload
-	}
-	if position == "append" {
-		updated, err := sjson.SetRawBytes(payload, path+".-1", newBlock)
-		if err != nil {
-			return payload
-		}
-		return updated
-	}
-	return prependArrayElement(payload, path, newBlock)
+	return blockArrayInject(payload, path, isResponsesTextBlock, newResponsesTextBlock, content, marker, position)
+}
+
+func isResponsesTextBlock(b gjson.Result) bool {
+	t := b.Get("type").String()
+	return t == "input_text" || t == "text"
+}
+
+func newResponsesTextBlock(content string) ([]byte, error) {
+	return marshalJSONNoEscape(map[string]any{"type": "input_text", "text": content})
 }
 
 func responsesStripInputItem(payload []byte, idx int, re *regexp.Regexp) []byte {

--- a/internal/runtime/executor/helps/prompt_rules_test.go
+++ b/internal/runtime/executor/helps/prompt_rules_test.go
@@ -1,0 +1,649 @@
+package helps
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/tidwall/gjson"
+)
+
+// withPromptRules installs the given rules as the active snapshot for the
+// duration of the test, restoring an empty snapshot on cleanup.
+func withPromptRules(t *testing.T, rules []config.PromptRule) {
+	t.Helper()
+	// Normalize defaults so tests can pass minimal rules.
+	out := make([]config.PromptRule, 0, len(rules))
+	for _, r := range rules {
+		if r.Action == config.PromptRuleActionInject && r.Position == "" {
+			r.Position = config.PromptRulePositionAppend
+		}
+		out = append(out, r)
+	}
+	UpdatePromptRulesSnapshot(out)
+	t.Cleanup(func() { UpdatePromptRulesSnapshot(nil) })
+}
+
+// applyOpenAI is a convenience wrapper for tests targeting the OpenAI source format.
+func applyOpenAI(payload string) []byte {
+	return ApplyPromptRules("openai", "gpt-5", []byte(payload), "/v1/chat/completions", "")
+}
+func applyClaude(payload string) []byte {
+	return ApplyPromptRules("claude", "claude-sonnet-4-5", []byte(payload), "/v1/messages", "")
+}
+func applyResponses(payload string) []byte {
+	return ApplyPromptRules("openai-response", "gpt-5", []byte(payload), "/v1/responses", "")
+}
+func applyGemini(payload string) []byte {
+	return ApplyPromptRules("gemini", "gemini-3-pro", []byte(payload), "/v1beta/models/gemini-3-pro:generateContent", "")
+}
+
+// === Engine-level tests ===
+
+func TestPromptRules_NoRules_PayloadUnchanged(t *testing.T) {
+	UpdatePromptRulesSnapshot(nil)
+	in := `{"messages":[{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	if string(out) != in {
+		t.Fatalf("expected unchanged payload; got %s", string(out))
+	}
+}
+
+func TestPromptRules_DisabledRuleSkipped(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name:    "noop",
+		Enabled: false,
+		Target:  "system",
+		Action:  "inject",
+		Content: "<!-- pr:x --> hi",
+		Marker:  "<!-- pr:x -->",
+	}})
+	in := `{"messages":[{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	if strings.Contains(string(out), "<!-- pr:x -->") {
+		t.Fatalf("disabled rule should not have fired: %s", string(out))
+	}
+}
+
+func TestPromptRules_EmptyModels_MatchesAll(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name:    "match-all",
+		Enabled: true,
+		Target:  "system",
+		Action:  "inject",
+		Content: "<!-- pr:m --> code in JSON.",
+		Marker:  "<!-- pr:m -->",
+	}})
+	out := applyOpenAI(`{"messages":[{"role":"user","content":"hi"}]}`)
+	// gjson unescapes the JSON-escaped < and > so the marker substring matches.
+	if !strings.Contains(gjson.GetBytes(out, "messages.0.content").String(), "<!-- pr:m -->") {
+		t.Fatalf("empty models should match all; output: %s", string(out))
+	}
+}
+
+func TestPromptRules_ModelProtocolFilter(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name:    "claude-only",
+		Enabled: true,
+		Models: []config.PayloadModelRule{
+			{Name: "*", Protocol: "claude"},
+		},
+		Target:  "system",
+		Action:  "inject",
+		Content: "<!-- pr:c --> only claude",
+		Marker:  "<!-- pr:c -->",
+	}})
+	// openai source format does not match — rule skipped
+	out := applyOpenAI(`{"messages":[{"role":"user","content":"hi"}]}`)
+	if strings.Contains(string(out), "<!-- pr:c -->") {
+		t.Fatalf("rule scoped to claude must not fire on openai; got: %s", string(out))
+	}
+	// claude source format matches — rule fires
+	out = applyClaude(`{"messages":[{"role":"user","content":"hi"}]}`)
+	if !strings.Contains(string(out), "<!-- pr:c -->") {
+		t.Fatalf("rule scoped to claude must fire on claude; got: %s", string(out))
+	}
+}
+
+func TestPromptRules_RequestPathSkip_ImageEndpoint(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "match-all", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:i --> hi", Marker: "<!-- pr:i -->",
+	}})
+	out := ApplyPromptRules("openai", "gpt-5", []byte(`{"messages":[]}`), "/v1/images/generations", "")
+	if strings.Contains(string(out), "<!-- pr:i -->") {
+		t.Fatalf("image endpoint should be skipped; got: %s", string(out))
+	}
+}
+
+func TestPromptRules_AltSkip_Compact(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "match-all", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:c2 --> hi", Marker: "<!-- pr:c2 -->",
+	}})
+	out := ApplyPromptRules("openai-response", "gpt-5", []byte(`{"input":""}`), "/v1/responses/compact", "responses/compact")
+	if strings.Contains(string(out), "<!-- pr:c2 -->") {
+		t.Fatalf("compact alt should be skipped; got: %s", string(out))
+	}
+}
+
+// === OpenAI source format ===
+
+func TestPromptRules_OpenAI_Inject_System_String(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:s --> JSON only.", Marker: "<!-- pr:s -->",
+		Position: "append",
+	}})
+	in := `{"messages":[{"role":"system","content":"You are helpful."},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if got != "You are helpful.<!-- pr:s --> JSON only." {
+		t.Fatalf("unexpected system content: %q", got)
+	}
+}
+
+func TestPromptRules_OpenAI_Inject_System_PrependsWhenAbsent(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:s --> Be terse.", Marker: "<!-- pr:s -->",
+	}})
+	in := `{"messages":[{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	first := gjson.GetBytes(out, "messages.0")
+	if first.Get("role").String() != "system" {
+		t.Fatalf("expected first message role=system; got role=%s", first.Get("role").String())
+	}
+	if !strings.Contains(first.Get("content").String(), "<!-- pr:s -->") {
+		t.Fatalf("expected marker in first message content; got: %s", first.Get("content").String())
+	}
+	// User message preserved at index 1
+	if gjson.GetBytes(out, "messages.1.role").String() != "user" {
+		t.Fatalf("user message should be preserved at index 1: %s", string(out))
+	}
+}
+
+func TestPromptRules_OpenAI_Inject_LastUserMessage_StringContent(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "user", Enabled: true, Target: "user", Action: "inject",
+		Content: "<!-- pr:u --> Reply concisely.", Marker: "<!-- pr:u -->",
+		Position: "append",
+	}})
+	in := `{"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"ok"},{"role":"user","content":"second"}]}`
+	out := applyOpenAI(in)
+	if got := gjson.GetBytes(out, "messages.0.content").String(); got != "first" {
+		t.Fatalf("first user message must not be modified; got %q", got)
+	}
+	if got := gjson.GetBytes(out, "messages.2.content").String(); got != "second<!-- pr:u --> Reply concisely." {
+		t.Fatalf("last user message expected to be appended; got %q", got)
+	}
+}
+
+func TestPromptRules_OpenAI_Inject_LastUserMessage_ArrayContent(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "user", Enabled: true, Target: "user", Action: "inject",
+		Content: "<!-- pr:ua --> done", Marker: "<!-- pr:ua -->",
+		Position: "append",
+	}})
+	in := `{"messages":[{"role":"user","content":[{"type":"text","text":"hello"},{"type":"image_url","image_url":{"url":"x"}}]}]}`
+	out := applyOpenAI(in)
+	blocks := gjson.GetBytes(out, "messages.0.content").Array()
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 blocks after append (text, image, new-text); got %d in %s", len(blocks), string(out))
+	}
+	last := blocks[len(blocks)-1]
+	if last.Get("type").String() != "text" || last.Get("text").String() != "<!-- pr:ua --> done" {
+		t.Fatalf("last block should be inject; got %s", last.Raw)
+	}
+}
+
+func TestPromptRules_OpenAI_Skip_ToolMessage(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "user", Enabled: true, Target: "user", Action: "inject",
+		Content: "<!-- pr:nope --> x", Marker: "<!-- pr:nope -->",
+	}})
+	// Last message is a tool message — should be skipped, but the second-to-last
+	// user message is natural-language and should receive the inject.
+	in := `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","tool_calls":[{"id":"c","function":{"name":"f"}}]},{"role":"tool","tool_call_id":"c","content":"42"}]}`
+	out := applyOpenAI(in)
+	// The tool message must not contain marker
+	tool := gjson.GetBytes(out, "messages.2.content").String()
+	if strings.Contains(tool, "<!-- pr:nope -->") {
+		t.Fatalf("tool message must not be modified; got %q", tool)
+	}
+	// The user message at index 0 receives the inject
+	first := gjson.GetBytes(out, "messages.0.content").String()
+	if !strings.Contains(first, "<!-- pr:nope -->") {
+		t.Fatalf("expected last natural-language user message to receive inject; got %q", first)
+	}
+}
+
+func TestPromptRules_OpenAI_Inject_Idempotent(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:idm --> JSON only.", Marker: "<!-- pr:idm -->",
+	}})
+	// Marker already in system content — should be no-op.
+	in := `{"messages":[{"role":"system","content":"prelude <!-- pr:idm --> postlude"},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if got != "prelude <!-- pr:idm --> postlude" {
+		t.Fatalf("idempotent inject should leave content untouched; got %q", got)
+	}
+}
+
+func TestPromptRules_OpenAI_Strip_System(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "buddy", Enabled: true, Target: "system", Action: "strip",
+		Pattern: `Buddy[^\n]*\n?`,
+	}})
+	in := `{"messages":[{"role":"system","content":"Buddy is a coding assistant.\nYou are helpful."},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if got != "You are helpful." {
+		t.Fatalf("strip should remove buddy line; got %q", got)
+	}
+}
+
+// === OpenAI Responses source format ===
+
+func TestPromptRules_Responses_Inject_Instructions(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:r --> Be brief.", Marker: "<!-- pr:r -->",
+	}})
+	in := `{"instructions":"Original.","input":"hi"}`
+	out := applyResponses(in)
+	got := gjson.GetBytes(out, "instructions").String()
+	if got != "Original.<!-- pr:r --> Be brief." {
+		t.Fatalf("unexpected instructions: %q", got)
+	}
+}
+
+func TestPromptRules_Responses_Inject_Instructions_Creates(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:r --> Be brief.", Marker: "<!-- pr:r -->",
+	}})
+	in := `{"input":"hi"}`
+	out := applyResponses(in)
+	if got := gjson.GetBytes(out, "instructions").String(); got != "<!-- pr:r --> Be brief." {
+		t.Fatalf("expected instructions to be created with content; got %q", got)
+	}
+}
+
+func TestPromptRules_Responses_Inject_LastUserInputString(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "user", Enabled: true, Target: "user", Action: "inject",
+		Content: "<!-- pr:ru --> ok", Marker: "<!-- pr:ru -->",
+	}})
+	in := `{"input":"original"}`
+	out := applyResponses(in)
+	if got := gjson.GetBytes(out, "input").String(); got != "original<!-- pr:ru --> ok" {
+		t.Fatalf("unexpected input: %q", got)
+	}
+}
+
+func TestPromptRules_Responses_Inject_LastUserInputArray(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "user", Enabled: true, Target: "user", Action: "inject",
+		Content: "<!-- pr:ria --> done", Marker: "<!-- pr:ria -->",
+	}})
+	in := `{"input":[{"role":"user","content":[{"type":"input_text","text":"hello"}]}]}`
+	out := applyResponses(in)
+	blocks := gjson.GetBytes(out, "input.0.content").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks; got %d in %s", len(blocks), string(out))
+	}
+	last := blocks[len(blocks)-1]
+	if last.Get("type").String() != "input_text" || last.Get("text").String() != "<!-- pr:ria --> done" {
+		t.Fatalf("last block should be inject; got %s", last.Raw)
+	}
+}
+
+// === Claude source format ===
+
+func TestPromptRules_Claude_Inject_System_String(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:cs --> JSON.", Marker: "<!-- pr:cs -->",
+	}})
+	in := `{"system":"You are helpful.","messages":[{"role":"user","content":"hi"}]}`
+	out := applyClaude(in)
+	if got := gjson.GetBytes(out, "system").String(); got != "You are helpful.<!-- pr:cs --> JSON." {
+		t.Fatalf("unexpected system: %q", got)
+	}
+}
+
+func TestPromptRules_Claude_Inject_System_BlockArray(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:cb --> JSON.", Marker: "<!-- pr:cb -->",
+	}})
+	in := `{"system":[{"type":"text","text":"You are helpful."}],"messages":[{"role":"user","content":"hi"}]}`
+	out := applyClaude(in)
+	blocks := gjson.GetBytes(out, "system").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks after append; got %d in %s", len(blocks), string(out))
+	}
+	if blocks[1].Get("text").String() != "<!-- pr:cb --> JSON." {
+		t.Fatalf("unexpected appended block: %s", blocks[1].Raw)
+	}
+}
+
+func TestPromptRules_Claude_Inject_System_CreatesIfMissing(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:cn --> JSON.", Marker: "<!-- pr:cn -->",
+	}})
+	in := `{"messages":[{"role":"user","content":"hi"}]}`
+	out := applyClaude(in)
+	if got := gjson.GetBytes(out, "system").String(); got != "<!-- pr:cn --> JSON." {
+		t.Fatalf("expected system created with content; got %q", got)
+	}
+}
+
+func TestPromptRules_Claude_Skip_ToolResultUserMessage(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "user", Enabled: true, Target: "user", Action: "inject",
+		Content: "<!-- pr:cu --> x", Marker: "<!-- pr:cu -->",
+	}})
+	// Last user message has only tool_result blocks — should be skipped.
+	// The earlier user message (index 0) should receive the inject.
+	in := `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"tool_use","id":"c","name":"f","input":{}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"c","content":"42"}]}]}`
+	out := applyClaude(in)
+	// Last message untouched
+	last := gjson.GetBytes(out, "messages.2.content").Raw
+	if strings.Contains(last, "<!-- pr:cu -->") {
+		t.Fatalf("tool-result message should not be modified; got %s", last)
+	}
+	// First user message receives inject
+	first := gjson.GetBytes(out, "messages.0.content").String()
+	if !strings.Contains(first, "<!-- pr:cu -->") {
+		t.Fatalf("expected last natural-language user (index 0) to receive inject; got %q", first)
+	}
+}
+
+// === Gemini source format ===
+
+func TestPromptRules_Gemini_Inject_SystemInstruction_CamelCase(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:gc --> JSON.", Marker: "<!-- pr:gc -->",
+	}})
+	in := `{"systemInstruction":{"role":"system","parts":[{"text":"You are helpful."}]},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`
+	out := applyGemini(in)
+	parts := gjson.GetBytes(out, "systemInstruction.parts").Array()
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts after append; got %d in %s", len(parts), string(out))
+	}
+	if parts[1].Get("text").String() != "<!-- pr:gc --> JSON." {
+		t.Fatalf("unexpected appended part: %s", parts[1].Raw)
+	}
+}
+
+func TestPromptRules_Gemini_Inject_SystemInstruction_SnakeCase(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:gs --> JSON.", Marker: "<!-- pr:gs -->",
+	}})
+	in := `{"system_instruction":{"role":"system","parts":[{"text":"You are helpful."}]},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`
+	out := applyGemini(in)
+	parts := gjson.GetBytes(out, "system_instruction.parts").Array()
+	if len(parts) != 2 {
+		t.Fatalf("snake_case branch must mutate same field; got %d parts in %s", len(parts), string(out))
+	}
+}
+
+func TestPromptRules_Gemini_Inject_SystemInstruction_CreatesIfMissing(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:gn --> JSON.", Marker: "<!-- pr:gn -->",
+	}})
+	in := `{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`
+	out := applyGemini(in)
+	got := gjson.GetBytes(out, "systemInstruction.parts.0.text").String()
+	if got != "<!-- pr:gn --> JSON." {
+		t.Fatalf("expected camelCase systemInstruction created; got %q in %s", got, string(out))
+	}
+}
+
+func TestPromptRules_Gemini_Skip_FunctionResponseUserMessage(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "user", Enabled: true, Target: "user", Action: "inject",
+		Content: "<!-- pr:gu --> x", Marker: "<!-- pr:gu -->",
+	}})
+	in := `{"contents":[{"role":"user","parts":[{"text":"hi"}]},{"role":"model","parts":[{"functionCall":{"name":"f","args":{}}}]},{"role":"user","parts":[{"functionResponse":{"name":"f","response":{}}}]}]}`
+	out := applyGemini(in)
+	// Last contents item (functionResponse) untouched
+	last := gjson.GetBytes(out, "contents.2.parts").Raw
+	if strings.Contains(last, "<!-- pr:gu -->") {
+		t.Fatalf("functionResponse message should not be modified; got %s", last)
+	}
+	// First user contents receives inject
+	first := gjson.GetBytes(out, "contents.0.parts").Array()
+	if len(first) != 2 {
+		t.Fatalf("expected first user contents to gain a part; got %d in %s", len(first), string(out))
+	}
+}
+
+// === Ordering & idempotency ===
+
+func TestPromptRules_StripBeforeInject_PreservesNewInject(t *testing.T) {
+	// A strip that would have removed the marker if it ran AFTER inject.
+	// Strip runs first, then inject — so the new inject survives.
+	withPromptRules(t, []config.PromptRule{
+		{
+			Name: "strip-marker", Enabled: true, Target: "system", Action: "strip",
+			Pattern: `<!-- pr:keep -->[^\n]*`,
+		},
+		{
+			Name: "inject", Enabled: true, Target: "system", Action: "inject",
+			Content: "<!-- pr:keep --> stays.", Marker: "<!-- pr:keep -->",
+		},
+	})
+	in := `{"messages":[{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	sys := gjson.GetBytes(out, "messages.0.content").String()
+	if !strings.Contains(sys, "<!-- pr:keep -->") {
+		t.Fatalf("inject after strip should produce the marker; got %q", sys)
+	}
+}
+
+func TestPromptRules_StripRemovesMarker_RecreatesContent(t *testing.T) {
+	// Documents the deliberate edge-case: if a strip rule removes the marker
+	// from existing injected content (but not the rest), the next request will
+	// inject again. This codifies the "documented warning" from the plan.
+	withPromptRules(t, []config.PromptRule{
+		{
+			Name: "strip-marker", Enabled: true, Target: "system", Action: "strip",
+			Pattern: `<!-- pr:dup -->`, // strips marker only
+		},
+		{
+			Name: "inject", Enabled: true, Target: "system", Action: "inject",
+			Content: "<!-- pr:dup --> stays.", Marker: "<!-- pr:dup -->",
+		},
+	})
+	in := `{"messages":[{"role":"system","content":"<!-- pr:dup --> stays."},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	sys := gjson.GetBytes(out, "messages.0.content").String()
+	// Strip removes marker; inject finds no marker; injects again. Result:
+	// " stays.<!-- pr:dup --> stays."
+	if !strings.Contains(sys, "<!-- pr:dup --> stays.") {
+		t.Fatalf("expected duplicate content after strip-then-inject; got %q", sys)
+	}
+}
+
+func TestPromptRules_Idempotency_MarkerInOtherTargetDoesNotBlock(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:scope --> sys.", Marker: "<!-- pr:scope -->",
+	}})
+	// Marker present in user content but not in system — system inject should still fire.
+	in := `{"messages":[{"role":"user","content":"<!-- pr:scope --> embedded"}]}`
+	out := applyOpenAI(in)
+	first := gjson.GetBytes(out, "messages.0").Get("role").String()
+	if first != "system" {
+		t.Fatalf("expected new system message at index 0; got role=%s in %s", first, string(out))
+	}
+}
+
+// === gemini-cli rooted under request.* ===
+
+func applyGeminiCLI(payload string) []byte {
+	return ApplyPromptRules("gemini-cli", "gemini-3-pro", []byte(payload), "/v1internal:generateContent", "")
+}
+
+func TestPromptRules_GeminiCLI_Inject_System_NestedRequest(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:gci --> JSON.", Marker: "<!-- pr:gci -->",
+	}})
+	in := `{"request":{"systemInstruction":{"role":"system","parts":[{"text":"You are helpful."}]},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`
+	out := applyGeminiCLI(in)
+	parts := gjson.GetBytes(out, "request.systemInstruction.parts").Array()
+	if len(parts) != 2 {
+		t.Fatalf("expected systemInstruction under request.* to gain a part; got %d in %s", len(parts), string(out))
+	}
+	if parts[1].Get("text").String() != "<!-- pr:gci --> JSON." {
+		t.Fatalf("unexpected appended part: %s", parts[1].Raw)
+	}
+}
+
+func TestPromptRules_GeminiCLI_Inject_LastUser_NestedRequest(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "user", Enabled: true, Target: "user", Action: "inject",
+		Content: "<!-- pr:gcu --> done", Marker: "<!-- pr:gcu -->",
+	}})
+	in := `{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`
+	out := applyGeminiCLI(in)
+	parts := gjson.GetBytes(out, "request.contents.0.parts").Array()
+	if len(parts) != 2 {
+		t.Fatalf("expected user parts to gain a text part; got %d in %s", len(parts), string(out))
+	}
+}
+
+// Plain "gemini" must NOT match request.* paths — confirms the two formats are
+// dispatched to different handlers.
+func TestPromptRules_PlainGemini_DoesNotTouchNestedRequest(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:pg --> hi", Marker: "<!-- pr:pg -->",
+	}})
+	in := `{"request":{"systemInstruction":{"role":"system","parts":[{"text":"x"}]}}}`
+	out := applyGemini(in)
+	nestedParts := gjson.GetBytes(out, "request.systemInstruction.parts").Array()
+	if len(nestedParts) != 1 {
+		t.Fatalf("plain gemini handler must not modify request.systemInstruction; got %d parts", len(nestedParts))
+	}
+	if !gjson.GetBytes(out, "systemInstruction").Exists() {
+		t.Fatalf("plain gemini handler should have created top-level systemInstruction; got %s", string(out))
+	}
+}
+
+// === Edge: null content ===
+
+func TestPromptRules_OpenAI_Inject_System_ContentNull(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:n --> hi", Marker: "<!-- pr:n -->",
+	}})
+	in := `{"messages":[{"role":"system","content":null},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if got != "<!-- pr:n --> hi" {
+		t.Fatalf("null content should be replaced with injected string; got %q", got)
+	}
+}
+
+// === Edge: empty text in array block ===
+
+func TestPromptRules_OpenAI_LastUser_EmptyTextBlockSkipped(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "user", Enabled: true, Target: "user", Action: "inject",
+		Content: "<!-- pr:e --> ok", Marker: "<!-- pr:e -->",
+	}})
+	in := `{"messages":[{"role":"user","content":"first"},{"role":"user","content":[{"type":"text","text":""}]}]}`
+	out := applyOpenAI(in)
+	first := gjson.GetBytes(out, "messages.0.content").String()
+	if !strings.Contains(first, "<!-- pr:e -->") {
+		t.Fatalf("expected first user (only natural-language one) to receive inject; got %q", first)
+	}
+}
+
+// === Snapshot clearing on empty input ===
+
+func TestPromptRules_Sanitize_EmptyClearsSnapshot(t *testing.T) {
+	UpdatePromptRulesSnapshot([]config.PromptRule{{
+		Name: "x", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:c --> hi", Marker: "<!-- pr:c -->", Position: "append",
+	}})
+	t.Cleanup(func() { UpdatePromptRulesSnapshot(nil) })
+	cfg := &config.Config{PromptRules: nil}
+	cfg.SanitizePromptRules()
+	out := applyOpenAI(`{"messages":[{"role":"user","content":"hi"}]}`)
+	if strings.Contains(gjson.GetBytes(out, "messages.0.content").String(), "<!-- pr:c -->") {
+		t.Fatalf("empty Sanitize must clear snapshot; rule still fired in %s", string(out))
+	}
+}
+
+// === Allowed-protocol set ===
+
+func TestPromptRules_AllowedProtocols_RejectsUnknown(t *testing.T) {
+	if IsAllowedPromptRuleProtocol("bogus") {
+		t.Fatal("bogus protocol should not be allowed")
+	}
+	if !IsAllowedPromptRuleProtocol("") {
+		t.Fatal("empty protocol must be allowed (means any)")
+	}
+	for _, p := range AllowedPromptRuleProtocols {
+		if !IsAllowedPromptRuleProtocol(p) {
+			t.Fatalf("canonical protocol %q must be allowed", p)
+		}
+	}
+}
+
+// === Concurrency ===
+
+func TestPromptRules_ConcurrentSnapshotRebuild(t *testing.T) {
+	// Race-detector run: many readers calling ApplyPromptRules while a writer
+	// rebuilds the snapshot. The atomic.Pointer should make this safe.
+	rulesA := []config.PromptRule{{
+		Name: "a", Enabled: true, Target: "system", Action: "inject",
+		Content: "<!-- pr:a --> a.", Marker: "<!-- pr:a -->", Position: "append",
+	}}
+	rulesB := []config.PromptRule{{
+		Name: "b", Enabled: true, Target: "system", Action: "strip",
+		Pattern: `b+`,
+	}}
+	UpdatePromptRulesSnapshot(rulesA)
+	t.Cleanup(func() { UpdatePromptRulesSnapshot(nil) })
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			body := []byte(`{"messages":[{"role":"user","content":"bbbb"}]}`)
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = ApplyPromptRules("openai", "gpt-5", body, "/v1/chat/completions", "")
+				}
+			}
+		}()
+	}
+	for i := 0; i < 1000; i++ {
+		if i%2 == 0 {
+			UpdatePromptRulesSnapshot(rulesA)
+		} else {
+			UpdatePromptRulesSnapshot(rulesB)
+		}
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/internal/runtime/executor/helps/prompt_rules_test.go
+++ b/internal/runtime/executor/helps/prompt_rules_test.go
@@ -25,7 +25,6 @@ func withPromptRules(t *testing.T, rules []config.PromptRule) {
 	t.Cleanup(func() { UpdatePromptRulesSnapshot(nil) })
 }
 
-// applyOpenAI is a convenience wrapper for tests targeting the OpenAI source format.
 func applyOpenAI(payload string) []byte {
 	return ApplyPromptRules("openai", "gpt-5", []byte(payload), "/v1/chat/completions", "")
 }
@@ -37,6 +36,9 @@ func applyResponses(payload string) []byte {
 }
 func applyGemini(payload string) []byte {
 	return ApplyPromptRules("gemini", "gemini-3-pro", []byte(payload), "/v1beta/models/gemini-3-pro:generateContent", "")
+}
+func applyGeminiCLI(payload string) []byte {
+	return ApplyPromptRules("gemini-cli", "gemini-3-pro", []byte(payload), "/v1internal:generateContent", "")
 }
 
 // === Engine-level tests ===
@@ -56,12 +58,11 @@ func TestPromptRules_DisabledRuleSkipped(t *testing.T) {
 		Enabled: false,
 		Target:  "system",
 		Action:  "inject",
-		Content: "<!-- pr:x --> hi",
-		Marker:  "<!-- pr:x -->",
+		Content: " disabled.",
 	}})
 	in := `{"messages":[{"role":"user","content":"hi"}]}`
 	out := applyOpenAI(in)
-	if strings.Contains(string(out), "<!-- pr:x -->") {
+	if strings.Contains(string(out), "disabled.") {
 		t.Fatalf("disabled rule should not have fired: %s", string(out))
 	}
 }
@@ -72,12 +73,10 @@ func TestPromptRules_EmptyModels_MatchesAll(t *testing.T) {
 		Enabled: true,
 		Target:  "system",
 		Action:  "inject",
-		Content: "<!-- pr:m --> code in JSON.",
-		Marker:  "<!-- pr:m -->",
+		Content: "Always answer in JSON.",
 	}})
 	out := applyOpenAI(`{"messages":[{"role":"user","content":"hi"}]}`)
-	// gjson unescapes the JSON-escaped < and > so the marker substring matches.
-	if !strings.Contains(gjson.GetBytes(out, "messages.0.content").String(), "<!-- pr:m -->") {
+	if !strings.Contains(gjson.GetBytes(out, "messages.0.content").String(), "Always answer in JSON.") {
 		t.Fatalf("empty models should match all; output: %s", string(out))
 	}
 }
@@ -91,17 +90,16 @@ func TestPromptRules_ModelProtocolFilter(t *testing.T) {
 		},
 		Target:  "system",
 		Action:  "inject",
-		Content: "<!-- pr:c --> only claude",
-		Marker:  "<!-- pr:c -->",
+		Content: "claude-only marker",
 	}})
 	// openai source format does not match — rule skipped
 	out := applyOpenAI(`{"messages":[{"role":"user","content":"hi"}]}`)
-	if strings.Contains(string(out), "<!-- pr:c -->") {
+	if strings.Contains(string(out), "claude-only marker") {
 		t.Fatalf("rule scoped to claude must not fire on openai; got: %s", string(out))
 	}
 	// claude source format matches — rule fires
 	out = applyClaude(`{"messages":[{"role":"user","content":"hi"}]}`)
-	if !strings.Contains(string(out), "<!-- pr:c -->") {
+	if !strings.Contains(string(out), "claude-only marker") {
 		t.Fatalf("rule scoped to claude must fire on claude; got: %s", string(out))
 	}
 }
@@ -109,10 +107,10 @@ func TestPromptRules_ModelProtocolFilter(t *testing.T) {
 func TestPromptRules_RequestPathSkip_ImageEndpoint(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "match-all", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:i --> hi", Marker: "<!-- pr:i -->",
+		Content: "image-endpoint-skip-test",
 	}})
 	out := ApplyPromptRules("openai", "gpt-5", []byte(`{"messages":[]}`), "/v1/images/generations", "")
-	if strings.Contains(string(out), "<!-- pr:i -->") {
+	if strings.Contains(string(out), "image-endpoint-skip-test") {
 		t.Fatalf("image endpoint should be skipped; got: %s", string(out))
 	}
 }
@@ -120,26 +118,25 @@ func TestPromptRules_RequestPathSkip_ImageEndpoint(t *testing.T) {
 func TestPromptRules_AltSkip_Compact(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "match-all", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:c2 --> hi", Marker: "<!-- pr:c2 -->",
+		Content: "compact-alt-skip-test",
 	}})
 	out := ApplyPromptRules("openai-response", "gpt-5", []byte(`{"input":""}`), "/v1/responses/compact", "responses/compact")
-	if strings.Contains(string(out), "<!-- pr:c2 -->") {
+	if strings.Contains(string(out), "compact-alt-skip-test") {
 		t.Fatalf("compact alt should be skipped; got: %s", string(out))
 	}
 }
 
 // === OpenAI source format ===
 
-func TestPromptRules_OpenAI_Inject_System_String(t *testing.T) {
+func TestPromptRules_OpenAI_Inject_System_String_Boundary(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:s --> JSON only.", Marker: "<!-- pr:s -->",
-		Position: "append",
+		Content: " JSON only.", Position: "append",
 	}})
 	in := `{"messages":[{"role":"system","content":"You are helpful."},{"role":"user","content":"hi"}]}`
 	out := applyOpenAI(in)
 	got := gjson.GetBytes(out, "messages.0.content").String()
-	if got != "You are helpful.<!-- pr:s --> JSON only." {
+	if got != "You are helpful. JSON only." {
 		t.Fatalf("unexpected system content: %q", got)
 	}
 }
@@ -147,7 +144,7 @@ func TestPromptRules_OpenAI_Inject_System_String(t *testing.T) {
 func TestPromptRules_OpenAI_Inject_System_PrependsWhenAbsent(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:s --> Be terse.", Marker: "<!-- pr:s -->",
+		Content: "Be terse.",
 	}})
 	in := `{"messages":[{"role":"user","content":"hi"}]}`
 	out := applyOpenAI(in)
@@ -155,27 +152,41 @@ func TestPromptRules_OpenAI_Inject_System_PrependsWhenAbsent(t *testing.T) {
 	if first.Get("role").String() != "system" {
 		t.Fatalf("expected first message role=system; got role=%s", first.Get("role").String())
 	}
-	if !strings.Contains(first.Get("content").String(), "<!-- pr:s -->") {
-		t.Fatalf("expected marker in first message content; got: %s", first.Get("content").String())
+	if !strings.Contains(first.Get("content").String(), "Be terse.") {
+		t.Fatalf("expected synthesized system content; got: %s", first.Get("content").String())
 	}
-	// User message preserved at index 1
 	if gjson.GetBytes(out, "messages.1.role").String() != "user" {
 		t.Fatalf("user message should be preserved at index 1: %s", string(out))
+	}
+}
+
+func TestPromptRules_OpenAI_MarkerMode_NoSystem_Skips(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: " (proxy)", Marker: "helpful",
+	}})
+	// No system message exists — marker mode has no anchor, so no synthesis.
+	in := `{"messages":[{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	if first := gjson.GetBytes(out, "messages.0").Get("role").String(); first == "system" {
+		t.Fatalf("marker mode must not synthesize a system message; got role=%s in %s", first, string(out))
+	}
+	if string(out) != in {
+		t.Fatalf("expected unchanged payload; got %s", string(out))
 	}
 }
 
 func TestPromptRules_OpenAI_Inject_LastUserMessage_StringContent(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "user", Enabled: true, Target: "user", Action: "inject",
-		Content: "<!-- pr:u --> Reply concisely.", Marker: "<!-- pr:u -->",
-		Position: "append",
+		Content: " Reply concisely.", Position: "append",
 	}})
 	in := `{"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"ok"},{"role":"user","content":"second"}]}`
 	out := applyOpenAI(in)
 	if got := gjson.GetBytes(out, "messages.0.content").String(); got != "first" {
 		t.Fatalf("first user message must not be modified; got %q", got)
 	}
-	if got := gjson.GetBytes(out, "messages.2.content").String(); got != "second<!-- pr:u --> Reply concisely." {
+	if got := gjson.GetBytes(out, "messages.2.content").String(); got != "second Reply concisely." {
 		t.Fatalf("last user message expected to be appended; got %q", got)
 	}
 }
@@ -183,8 +194,7 @@ func TestPromptRules_OpenAI_Inject_LastUserMessage_StringContent(t *testing.T) {
 func TestPromptRules_OpenAI_Inject_LastUserMessage_ArrayContent(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "user", Enabled: true, Target: "user", Action: "inject",
-		Content: "<!-- pr:ua --> done", Marker: "<!-- pr:ua -->",
-		Position: "append",
+		Content: "done", Position: "append",
 	}})
 	in := `{"messages":[{"role":"user","content":[{"type":"text","text":"hello"},{"type":"image_url","image_url":{"url":"x"}}]}]}`
 	out := applyOpenAI(in)
@@ -193,7 +203,7 @@ func TestPromptRules_OpenAI_Inject_LastUserMessage_ArrayContent(t *testing.T) {
 		t.Fatalf("expected 3 blocks after append (text, image, new-text); got %d in %s", len(blocks), string(out))
 	}
 	last := blocks[len(blocks)-1]
-	if last.Get("type").String() != "text" || last.Get("text").String() != "<!-- pr:ua --> done" {
+	if last.Get("type").String() != "text" || last.Get("text").String() != "done" {
 		t.Fatalf("last block should be inject; got %s", last.Raw)
 	}
 }
@@ -201,34 +211,32 @@ func TestPromptRules_OpenAI_Inject_LastUserMessage_ArrayContent(t *testing.T) {
 func TestPromptRules_OpenAI_Skip_ToolMessage(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "user", Enabled: true, Target: "user", Action: "inject",
-		Content: "<!-- pr:nope --> x", Marker: "<!-- pr:nope -->",
+		Content: " (extra)",
 	}})
 	// Last message is a tool message — should be skipped, but the second-to-last
 	// user message is natural-language and should receive the inject.
 	in := `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","tool_calls":[{"id":"c","function":{"name":"f"}}]},{"role":"tool","tool_call_id":"c","content":"42"}]}`
 	out := applyOpenAI(in)
-	// The tool message must not contain marker
 	tool := gjson.GetBytes(out, "messages.2.content").String()
-	if strings.Contains(tool, "<!-- pr:nope -->") {
+	if strings.Contains(tool, "(extra)") {
 		t.Fatalf("tool message must not be modified; got %q", tool)
 	}
-	// The user message at index 0 receives the inject
 	first := gjson.GetBytes(out, "messages.0.content").String()
-	if !strings.Contains(first, "<!-- pr:nope -->") {
+	if !strings.Contains(first, "(extra)") {
 		t.Fatalf("expected last natural-language user message to receive inject; got %q", first)
 	}
 }
 
-func TestPromptRules_OpenAI_Inject_Idempotent(t *testing.T) {
+func TestPromptRules_OpenAI_BoundaryIdempotent(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:idm --> JSON only.", Marker: "<!-- pr:idm -->",
+		Content: "JSON only.",
 	}})
-	// Marker already in system content — should be no-op.
-	in := `{"messages":[{"role":"system","content":"prelude <!-- pr:idm --> postlude"},{"role":"user","content":"hi"}]}`
+	// Content already present in system → boundary idempotency skips.
+	in := `{"messages":[{"role":"system","content":"prelude JSON only. postlude"},{"role":"user","content":"hi"}]}`
 	out := applyOpenAI(in)
 	got := gjson.GetBytes(out, "messages.0.content").String()
-	if got != "prelude <!-- pr:idm --> postlude" {
+	if got != "prelude JSON only. postlude" {
 		t.Fatalf("idempotent inject should leave content untouched; got %q", got)
 	}
 }
@@ -251,12 +259,12 @@ func TestPromptRules_OpenAI_Strip_System(t *testing.T) {
 func TestPromptRules_Responses_Inject_Instructions(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:r --> Be brief.", Marker: "<!-- pr:r -->",
+		Content: " Be brief.",
 	}})
 	in := `{"instructions":"Original.","input":"hi"}`
 	out := applyResponses(in)
 	got := gjson.GetBytes(out, "instructions").String()
-	if got != "Original.<!-- pr:r --> Be brief." {
+	if got != "Original. Be brief." {
 		t.Fatalf("unexpected instructions: %q", got)
 	}
 }
@@ -264,23 +272,35 @@ func TestPromptRules_Responses_Inject_Instructions(t *testing.T) {
 func TestPromptRules_Responses_Inject_Instructions_Creates(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:r --> Be brief.", Marker: "<!-- pr:r -->",
+		Content: "Be brief.",
 	}})
 	in := `{"input":"hi"}`
 	out := applyResponses(in)
-	if got := gjson.GetBytes(out, "instructions").String(); got != "<!-- pr:r --> Be brief." {
+	if got := gjson.GetBytes(out, "instructions").String(); got != "Be brief." {
 		t.Fatalf("expected instructions to be created with content; got %q", got)
+	}
+}
+
+func TestPromptRules_Responses_MarkerMode_NoInstructions_Skips(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: " (proxy)", Marker: "anchor",
+	}})
+	in := `{"input":"hi"}`
+	out := applyResponses(in)
+	if gjson.GetBytes(out, "instructions").Exists() {
+		t.Fatalf("marker mode must not synthesize instructions; got %s", string(out))
 	}
 }
 
 func TestPromptRules_Responses_Inject_LastUserInputString(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "user", Enabled: true, Target: "user", Action: "inject",
-		Content: "<!-- pr:ru --> ok", Marker: "<!-- pr:ru -->",
+		Content: " ok",
 	}})
 	in := `{"input":"original"}`
 	out := applyResponses(in)
-	if got := gjson.GetBytes(out, "input").String(); got != "original<!-- pr:ru --> ok" {
+	if got := gjson.GetBytes(out, "input").String(); got != "original ok" {
 		t.Fatalf("unexpected input: %q", got)
 	}
 }
@@ -288,7 +308,7 @@ func TestPromptRules_Responses_Inject_LastUserInputString(t *testing.T) {
 func TestPromptRules_Responses_Inject_LastUserInputArray(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "user", Enabled: true, Target: "user", Action: "inject",
-		Content: "<!-- pr:ria --> done", Marker: "<!-- pr:ria -->",
+		Content: "done",
 	}})
 	in := `{"input":[{"role":"user","content":[{"type":"input_text","text":"hello"}]}]}`
 	out := applyResponses(in)
@@ -297,7 +317,7 @@ func TestPromptRules_Responses_Inject_LastUserInputArray(t *testing.T) {
 		t.Fatalf("expected 2 blocks; got %d in %s", len(blocks), string(out))
 	}
 	last := blocks[len(blocks)-1]
-	if last.Get("type").String() != "input_text" || last.Get("text").String() != "<!-- pr:ria --> done" {
+	if last.Get("type").String() != "input_text" || last.Get("text").String() != "done" {
 		t.Fatalf("last block should be inject; got %s", last.Raw)
 	}
 }
@@ -307,11 +327,11 @@ func TestPromptRules_Responses_Inject_LastUserInputArray(t *testing.T) {
 func TestPromptRules_Claude_Inject_System_String(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:cs --> JSON.", Marker: "<!-- pr:cs -->",
+		Content: " JSON.",
 	}})
 	in := `{"system":"You are helpful.","messages":[{"role":"user","content":"hi"}]}`
 	out := applyClaude(in)
-	if got := gjson.GetBytes(out, "system").String(); got != "You are helpful.<!-- pr:cs --> JSON." {
+	if got := gjson.GetBytes(out, "system").String(); got != "You are helpful. JSON." {
 		t.Fatalf("unexpected system: %q", got)
 	}
 }
@@ -319,7 +339,7 @@ func TestPromptRules_Claude_Inject_System_String(t *testing.T) {
 func TestPromptRules_Claude_Inject_System_BlockArray(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:cb --> JSON.", Marker: "<!-- pr:cb -->",
+		Content: "JSON.",
 	}})
 	in := `{"system":[{"type":"text","text":"You are helpful."}],"messages":[{"role":"user","content":"hi"}]}`
 	out := applyClaude(in)
@@ -327,7 +347,7 @@ func TestPromptRules_Claude_Inject_System_BlockArray(t *testing.T) {
 	if len(blocks) != 2 {
 		t.Fatalf("expected 2 blocks after append; got %d in %s", len(blocks), string(out))
 	}
-	if blocks[1].Get("text").String() != "<!-- pr:cb --> JSON." {
+	if blocks[1].Get("text").String() != "JSON." {
 		t.Fatalf("unexpected appended block: %s", blocks[1].Raw)
 	}
 }
@@ -335,32 +355,40 @@ func TestPromptRules_Claude_Inject_System_BlockArray(t *testing.T) {
 func TestPromptRules_Claude_Inject_System_CreatesIfMissing(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:cn --> JSON.", Marker: "<!-- pr:cn -->",
+		Content: "JSON.",
 	}})
 	in := `{"messages":[{"role":"user","content":"hi"}]}`
 	out := applyClaude(in)
-	if got := gjson.GetBytes(out, "system").String(); got != "<!-- pr:cn --> JSON." {
+	if got := gjson.GetBytes(out, "system").String(); got != "JSON." {
 		t.Fatalf("expected system created with content; got %q", got)
+	}
+}
+
+func TestPromptRules_Claude_MarkerMode_NoSystem_Skips(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: " (proxy)", Marker: "helpful",
+	}})
+	in := `{"messages":[{"role":"user","content":"hi"}]}`
+	out := applyClaude(in)
+	if gjson.GetBytes(out, "system").Exists() {
+		t.Fatalf("marker mode must not synthesize claude system; got %s", string(out))
 	}
 }
 
 func TestPromptRules_Claude_Skip_ToolResultUserMessage(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "user", Enabled: true, Target: "user", Action: "inject",
-		Content: "<!-- pr:cu --> x", Marker: "<!-- pr:cu -->",
+		Content: " x",
 	}})
-	// Last user message has only tool_result blocks — should be skipped.
-	// The earlier user message (index 0) should receive the inject.
 	in := `{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"tool_use","id":"c","name":"f","input":{}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"c","content":"42"}]}]}`
 	out := applyClaude(in)
-	// Last message untouched
 	last := gjson.GetBytes(out, "messages.2.content").Raw
-	if strings.Contains(last, "<!-- pr:cu -->") {
+	if strings.Contains(last, " x") {
 		t.Fatalf("tool-result message should not be modified; got %s", last)
 	}
-	// First user message receives inject
 	first := gjson.GetBytes(out, "messages.0.content").String()
-	if !strings.Contains(first, "<!-- pr:cu -->") {
+	if first != "hi x" {
 		t.Fatalf("expected last natural-language user (index 0) to receive inject; got %q", first)
 	}
 }
@@ -370,7 +398,7 @@ func TestPromptRules_Claude_Skip_ToolResultUserMessage(t *testing.T) {
 func TestPromptRules_Gemini_Inject_SystemInstruction_CamelCase(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:gc --> JSON.", Marker: "<!-- pr:gc -->",
+		Content: "JSON.",
 	}})
 	in := `{"systemInstruction":{"role":"system","parts":[{"text":"You are helpful."}]},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`
 	out := applyGemini(in)
@@ -378,7 +406,7 @@ func TestPromptRules_Gemini_Inject_SystemInstruction_CamelCase(t *testing.T) {
 	if len(parts) != 2 {
 		t.Fatalf("expected 2 parts after append; got %d in %s", len(parts), string(out))
 	}
-	if parts[1].Get("text").String() != "<!-- pr:gc --> JSON." {
+	if parts[1].Get("text").String() != "JSON." {
 		t.Fatalf("unexpected appended part: %s", parts[1].Raw)
 	}
 }
@@ -386,7 +414,7 @@ func TestPromptRules_Gemini_Inject_SystemInstruction_CamelCase(t *testing.T) {
 func TestPromptRules_Gemini_Inject_SystemInstruction_SnakeCase(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:gs --> JSON.", Marker: "<!-- pr:gs -->",
+		Content: "JSON.",
 	}})
 	in := `{"system_instruction":{"role":"system","parts":[{"text":"You are helpful."}]},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`
 	out := applyGemini(in)
@@ -399,29 +427,39 @@ func TestPromptRules_Gemini_Inject_SystemInstruction_SnakeCase(t *testing.T) {
 func TestPromptRules_Gemini_Inject_SystemInstruction_CreatesIfMissing(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:gn --> JSON.", Marker: "<!-- pr:gn -->",
+		Content: "JSON.",
 	}})
 	in := `{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`
 	out := applyGemini(in)
 	got := gjson.GetBytes(out, "systemInstruction.parts.0.text").String()
-	if got != "<!-- pr:gn --> JSON." {
+	if got != "JSON." {
 		t.Fatalf("expected camelCase systemInstruction created; got %q in %s", got, string(out))
+	}
+}
+
+func TestPromptRules_Gemini_MarkerMode_NoSystem_Skips(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: " (proxy)", Marker: "helpful",
+	}})
+	in := `{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`
+	out := applyGemini(in)
+	if gjson.GetBytes(out, "systemInstruction").Exists() || gjson.GetBytes(out, "system_instruction").Exists() {
+		t.Fatalf("marker mode must not synthesize gemini systemInstruction; got %s", string(out))
 	}
 }
 
 func TestPromptRules_Gemini_Skip_FunctionResponseUserMessage(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "user", Enabled: true, Target: "user", Action: "inject",
-		Content: "<!-- pr:gu --> x", Marker: "<!-- pr:gu -->",
+		Content: " x",
 	}})
 	in := `{"contents":[{"role":"user","parts":[{"text":"hi"}]},{"role":"model","parts":[{"functionCall":{"name":"f","args":{}}}]},{"role":"user","parts":[{"functionResponse":{"name":"f","response":{}}}]}]}`
 	out := applyGemini(in)
-	// Last contents item (functionResponse) untouched
 	last := gjson.GetBytes(out, "contents.2.parts").Raw
-	if strings.Contains(last, "<!-- pr:gu -->") {
+	if strings.Contains(last, " x") {
 		t.Fatalf("functionResponse message should not be modified; got %s", last)
 	}
-	// First user contents receives inject
 	first := gjson.GetBytes(out, "contents.0.parts").Array()
 	if len(first) != 2 {
 		t.Fatalf("expected first user contents to gain a part; got %d in %s", len(first), string(out))
@@ -431,74 +469,262 @@ func TestPromptRules_Gemini_Skip_FunctionResponseUserMessage(t *testing.T) {
 // === Ordering & idempotency ===
 
 func TestPromptRules_StripBeforeInject_PreservesNewInject(t *testing.T) {
-	// A strip that would have removed the marker if it ran AFTER inject.
-	// Strip runs first, then inject — so the new inject survives.
+	// Strip removes the to-be-injected content if it pre-exists; inject runs
+	// after strip and re-creates content. Verifies pass ordering.
 	withPromptRules(t, []config.PromptRule{
 		{
-			Name: "strip-marker", Enabled: true, Target: "system", Action: "strip",
-			Pattern: `<!-- pr:keep -->[^\n]*`,
+			Name: "strip-keep", Enabled: true, Target: "system", Action: "strip",
+			Pattern: `keep[^\n]*`,
 		},
 		{
 			Name: "inject", Enabled: true, Target: "system", Action: "inject",
-			Content: "<!-- pr:keep --> stays.", Marker: "<!-- pr:keep -->",
+			Content: "keep this.",
 		},
 	})
-	in := `{"messages":[{"role":"user","content":"hi"}]}`
+	in := `{"messages":[{"role":"system","content":"keep prior"},{"role":"user","content":"hi"}]}`
 	out := applyOpenAI(in)
 	sys := gjson.GetBytes(out, "messages.0.content").String()
-	if !strings.Contains(sys, "<!-- pr:keep -->") {
-		t.Fatalf("inject after strip should produce the marker; got %q", sys)
+	if !strings.Contains(sys, "keep this.") {
+		t.Fatalf("inject after strip should produce content; got %q", sys)
 	}
 }
 
-func TestPromptRules_StripRemovesMarker_RecreatesContent(t *testing.T) {
-	// Documents the deliberate edge-case: if a strip rule removes the marker
-	// from existing injected content (but not the rest), the next request will
-	// inject again. This codifies the "documented warning" from the plan.
+func TestPromptRules_StripBeforeInject_BoundaryReinjects(t *testing.T) {
+	// In v2 boundary mode, if a prior inject's content gets fully stripped,
+	// the next request re-injects (boundary idempotency is content-based).
 	withPromptRules(t, []config.PromptRule{
 		{
-			Name: "strip-marker", Enabled: true, Target: "system", Action: "strip",
-			Pattern: `<!-- pr:dup -->`, // strips marker only
+			Name: "strip-content", Enabled: true, Target: "system", Action: "strip",
+			Pattern: `keep this\.`,
 		},
 		{
 			Name: "inject", Enabled: true, Target: "system", Action: "inject",
-			Content: "<!-- pr:dup --> stays.", Marker: "<!-- pr:dup -->",
+			Content: "keep this.",
 		},
 	})
-	in := `{"messages":[{"role":"system","content":"<!-- pr:dup --> stays."},{"role":"user","content":"hi"}]}`
+	in := `{"messages":[{"role":"system","content":"prelude keep this. postlude"},{"role":"user","content":"hi"}]}`
 	out := applyOpenAI(in)
 	sys := gjson.GetBytes(out, "messages.0.content").String()
-	// Strip removes marker; inject finds no marker; injects again. Result:
-	// " stays.<!-- pr:dup --> stays."
-	if !strings.Contains(sys, "<!-- pr:dup --> stays.") {
-		t.Fatalf("expected duplicate content after strip-then-inject; got %q", sys)
+	if !strings.Contains(sys, "keep this.") {
+		t.Fatalf("expected reinject after strip removed prior content; got %q", sys)
 	}
 }
 
-func TestPromptRules_Idempotency_MarkerInOtherTargetDoesNotBlock(t *testing.T) {
+// === v2 marker-anchor mode ===
+
+func TestPromptRules_MarkerMode_Adjacent_Skip(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:scope --> sys.", Marker: "<!-- pr:scope -->",
+		Content: " (proxy)", Marker: "qwen", Position: "append",
 	}})
-	// Marker present in user content but not in system — system inject should still fire.
-	in := `{"messages":[{"role":"user","content":"<!-- pr:scope --> embedded"}]}`
+	// Content already directly after the marker — idempotent skip.
+	in := `{"messages":[{"role":"system","content":"You are qwen (proxy)-99."},{"role":"user","content":"hi"}]}`
 	out := applyOpenAI(in)
-	first := gjson.GetBytes(out, "messages.0").Get("role").String()
-	if first != "system" {
-		t.Fatalf("expected new system message at index 0; got role=%s in %s", first, string(out))
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if got != "You are qwen (proxy)-99." {
+		t.Fatalf("adjacent content must be idempotent; got %q", got)
+	}
+}
+
+func TestPromptRules_MarkerMode_NotAdjacent_InjectsAtFirst(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: " (proxy)", Marker: "qwen", Position: "append",
+	}})
+	in := `{"messages":[{"role":"system","content":"You are qwen-99."},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if got != "You are qwen (proxy)-99." {
+		t.Fatalf("first run should inject after marker; got %q", got)
+	}
+	out2 := applyOpenAI(string(out))
+	got2 := gjson.GetBytes(out2, "messages.0.content").String()
+	if got2 != got {
+		t.Fatalf("second run must be idempotent; got %q vs %q", got, got2)
+	}
+}
+
+func TestPromptRules_MarkerMode_PrependBefore_Adjacent(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "[proxy] ", Marker: "qwen", Position: "prepend",
+	}})
+	// Content already directly before marker — skip.
+	in := `{"messages":[{"role":"system","content":"You are [proxy] qwen."},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if got != "You are [proxy] qwen." {
+		t.Fatalf("prepend adjacency must be idempotent; got %q", got)
+	}
+}
+
+func TestPromptRules_MarkerMode_PrependBefore_NotAdjacent(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "[proxy] ", Marker: "qwen", Position: "prepend",
+	}})
+	in := `{"messages":[{"role":"system","content":"You are qwen."},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if got != "You are [proxy] qwen." {
+		t.Fatalf("prepend should land immediately before marker; got %q", got)
+	}
+}
+
+func TestPromptRules_MarkerMode_AbsentMarker_Skip(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: " (proxy)", Marker: "qwen",
+	}})
+	in := `{"messages":[{"role":"system","content":"You are something else."},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	if string(out) != in {
+		t.Fatalf("marker mode without anchor must skip; got %s", string(out))
+	}
+}
+
+func TestPromptRules_MarkerMode_MultiOccurrence_InjectsAtFirst(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "*", Marker: "X", Position: "append",
+	}})
+	in := `{"messages":[{"role":"system","content":"X.X.X"},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if got != "X*.X.X" {
+		t.Fatalf("expected inject after FIRST occurrence only; got %q", got)
+	}
+	// Re-run: first occurrence now has content adjacent → skip
+	out2 := applyOpenAI(string(out))
+	if gjson.GetBytes(out2, "messages.0.content").String() != got {
+		t.Fatalf("multi-occurrence run must be idempotent")
+	}
+}
+
+func TestPromptRules_MarkerMode_MultiOccurrence_AnyAdjacencySuppresses(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "*", Marker: "X", Position: "append",
+	}})
+	// Last occurrence already has content adjacent — whole rule no-ops.
+	in := `{"messages":[{"role":"system","content":"X.X.X*"},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if got != "X.X.X*" {
+		t.Fatalf("any adjacency must suppress whole rule; got %q", got)
+	}
+}
+
+func TestPromptRules_MarkerMode_OverlapWithContent_StableAcrossRuns(t *testing.T) {
+	// marker="foo", content="foofoo": after first inject, the inserted text
+	// itself contains marker substrings, so subsequent runs see adjacency and
+	// skip. Documents the runaway-inject mitigation.
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "foofoo", Marker: "foo", Position: "append",
+	}})
+	in := `{"messages":[{"role":"system","content":"X foo Y"},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if got != "X foofoofoo Y" {
+		t.Fatalf("first run unexpected: %q", got)
+	}
+	out2 := applyOpenAI(string(out))
+	got2 := gjson.GetBytes(out2, "messages.0.content").String()
+	if got2 != got {
+		t.Fatalf("overlap inject must be stable across runs; got %q vs %q", got, got2)
+	}
+	out3 := applyOpenAI(string(out2))
+	if gjson.GetBytes(out3, "messages.0.content").String() != got {
+		t.Fatalf("overlap inject must remain stable on the third run too")
+	}
+}
+
+func TestPromptRules_BlockArray_Marker_AdjacencyInOtherBlock_Suppresses(t *testing.T) {
+	// Marker present in two text blocks. Block 1 already has content adjacent
+	// → whole rule no-ops, block 0 stays untouched.
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "*", Marker: "anchor", Position: "append",
+	}})
+	in := `{"system":[{"type":"text","text":"anchor here"},{"type":"text","text":"anchor*"}],"messages":[{"role":"user","content":"hi"}]}`
+	out := applyClaude(in)
+	if string(out) != in {
+		t.Fatalf("block-array adjacency in any block must suppress whole rule; got %s", string(out))
+	}
+}
+
+func TestPromptRules_BlockArray_Marker_FirstBlockHasMarker_InjectsThere(t *testing.T) {
+	// Marker in block 1 only. Inject lands inside that block.
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "*", Marker: "anchor", Position: "append",
+	}})
+	in := `{"system":[{"type":"text","text":"no marker here"},{"type":"text","text":"anchor X"}],"messages":[{"role":"user","content":"hi"}]}`
+	out := applyClaude(in)
+	blocks := gjson.GetBytes(out, "system").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("inject must mutate existing block, not add a new one; got %d", len(blocks))
+	}
+	if blocks[0].Get("text").String() != "no marker here" {
+		t.Fatalf("block 0 must be untouched; got %s", blocks[0].Raw)
+	}
+	if blocks[1].Get("text").String() != "anchor* X" {
+		t.Fatalf("block 1 should have inject after marker; got %s", blocks[1].Raw)
+	}
+}
+
+func TestPromptRules_BoundaryMode_BlockArrayContentPresent_Skip(t *testing.T) {
+	// Boundary mode, content already in some block → skip.
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "JSON only.",
+	}})
+	in := `{"system":[{"type":"text","text":"prelude"},{"type":"text","text":"... JSON only. ..."}],"messages":[{"role":"user","content":"hi"}]}`
+	out := applyClaude(in)
+	if string(out) != in {
+		t.Fatalf("boundary block-array idempotency: content present must skip; got %s", string(out))
+	}
+}
+
+func TestPromptRules_BoundaryMode_BlockArrayContentAbsent_AppendsBlock(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "JSON only.",
+	}})
+	in := `{"system":[{"type":"text","text":"prelude"}],"messages":[{"role":"user","content":"hi"}]}`
+	out := applyClaude(in)
+	blocks := gjson.GetBytes(out, "system").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("expected new text block appended; got %d in %s", len(blocks), string(out))
+	}
+	if blocks[1].Get("text").String() != "JSON only." {
+		t.Fatalf("appended block content mismatch: %s", blocks[1].Raw)
+	}
+}
+
+func TestPromptRules_BoundaryMode_BlockArrayContentAbsent_PrependsBlock(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "JSON only.", Position: "prepend",
+	}})
+	in := `{"system":[{"type":"text","text":"prelude"}],"messages":[{"role":"user","content":"hi"}]}`
+	out := applyClaude(in)
+	blocks := gjson.GetBytes(out, "system").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("expected new text block prepended; got %d in %s", len(blocks), string(out))
+	}
+	if blocks[0].Get("text").String() != "JSON only." {
+		t.Fatalf("prepended block content mismatch: %s", blocks[0].Raw)
 	}
 }
 
 // === gemini-cli rooted under request.* ===
 
-func applyGeminiCLI(payload string) []byte {
-	return ApplyPromptRules("gemini-cli", "gemini-3-pro", []byte(payload), "/v1internal:generateContent", "")
-}
-
 func TestPromptRules_GeminiCLI_Inject_System_NestedRequest(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:gci --> JSON.", Marker: "<!-- pr:gci -->",
+		Content: "JSON.",
 	}})
 	in := `{"request":{"systemInstruction":{"role":"system","parts":[{"text":"You are helpful."}]},"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`
 	out := applyGeminiCLI(in)
@@ -506,7 +732,7 @@ func TestPromptRules_GeminiCLI_Inject_System_NestedRequest(t *testing.T) {
 	if len(parts) != 2 {
 		t.Fatalf("expected systemInstruction under request.* to gain a part; got %d in %s", len(parts), string(out))
 	}
-	if parts[1].Get("text").String() != "<!-- pr:gci --> JSON." {
+	if parts[1].Get("text").String() != "JSON." {
 		t.Fatalf("unexpected appended part: %s", parts[1].Raw)
 	}
 }
@@ -514,7 +740,7 @@ func TestPromptRules_GeminiCLI_Inject_System_NestedRequest(t *testing.T) {
 func TestPromptRules_GeminiCLI_Inject_LastUser_NestedRequest(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "user", Enabled: true, Target: "user", Action: "inject",
-		Content: "<!-- pr:gcu --> done", Marker: "<!-- pr:gcu -->",
+		Content: "done",
 	}})
 	in := `{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`
 	out := applyGeminiCLI(in)
@@ -524,12 +750,12 @@ func TestPromptRules_GeminiCLI_Inject_LastUser_NestedRequest(t *testing.T) {
 	}
 }
 
-// Plain "gemini" must NOT match request.* paths — confirms the two formats are
+// Plain "gemini" must NOT touch request.* — confirms the two formats are
 // dispatched to different handlers.
 func TestPromptRules_PlainGemini_DoesNotTouchNestedRequest(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:pg --> hi", Marker: "<!-- pr:pg -->",
+		Content: "hi",
 	}})
 	in := `{"request":{"systemInstruction":{"role":"system","parts":[{"text":"x"}]}}}`
 	out := applyGemini(in)
@@ -544,16 +770,28 @@ func TestPromptRules_PlainGemini_DoesNotTouchNestedRequest(t *testing.T) {
 
 // === Edge: null content ===
 
-func TestPromptRules_OpenAI_Inject_System_ContentNull(t *testing.T) {
+func TestPromptRules_OpenAI_Inject_System_ContentNull_Boundary(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "sys", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:n --> hi", Marker: "<!-- pr:n -->",
+		Content: "hi",
 	}})
 	in := `{"messages":[{"role":"system","content":null},{"role":"user","content":"hi"}]}`
 	out := applyOpenAI(in)
 	got := gjson.GetBytes(out, "messages.0.content").String()
-	if got != "<!-- pr:n --> hi" {
+	if got != "hi" {
 		t.Fatalf("null content should be replaced with injected string; got %q", got)
+	}
+}
+
+func TestPromptRules_OpenAI_Inject_System_ContentNull_MarkerSkips(t *testing.T) {
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: " hi", Marker: "anchor",
+	}})
+	in := `{"messages":[{"role":"system","content":null},{"role":"user","content":"hi"}]}`
+	out := applyOpenAI(in)
+	if got := gjson.GetBytes(out, "messages.0.content").Type; got != gjson.Null {
+		t.Fatalf("null content under marker mode must remain null; got type=%v in %s", got, string(out))
 	}
 }
 
@@ -562,12 +800,12 @@ func TestPromptRules_OpenAI_Inject_System_ContentNull(t *testing.T) {
 func TestPromptRules_OpenAI_LastUser_EmptyTextBlockSkipped(t *testing.T) {
 	withPromptRules(t, []config.PromptRule{{
 		Name: "user", Enabled: true, Target: "user", Action: "inject",
-		Content: "<!-- pr:e --> ok", Marker: "<!-- pr:e -->",
+		Content: " ok",
 	}})
 	in := `{"messages":[{"role":"user","content":"first"},{"role":"user","content":[{"type":"text","text":""}]}]}`
 	out := applyOpenAI(in)
 	first := gjson.GetBytes(out, "messages.0.content").String()
-	if !strings.Contains(first, "<!-- pr:e -->") {
+	if first != "first ok" {
 		t.Fatalf("expected first user (only natural-language one) to receive inject; got %q", first)
 	}
 }
@@ -577,13 +815,16 @@ func TestPromptRules_OpenAI_LastUser_EmptyTextBlockSkipped(t *testing.T) {
 func TestPromptRules_Sanitize_EmptyClearsSnapshot(t *testing.T) {
 	UpdatePromptRulesSnapshot([]config.PromptRule{{
 		Name: "x", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:c --> hi", Marker: "<!-- pr:c -->", Position: "append",
+		Content: "hi", Position: "append",
 	}})
 	t.Cleanup(func() { UpdatePromptRulesSnapshot(nil) })
 	cfg := &config.Config{PromptRules: nil}
 	cfg.SanitizePromptRules()
 	out := applyOpenAI(`{"messages":[{"role":"user","content":"hi"}]}`)
-	if strings.Contains(gjson.GetBytes(out, "messages.0.content").String(), "<!-- pr:c -->") {
+	// After Sanitize wipes snapshot, the rule should not fire — the only
+	// content the user message has is "hi", which the system would have
+	// injected as well. Verify there is no role=system message.
+	if gjson.GetBytes(out, "messages.0.role").String() == "system" {
 		t.Fatalf("empty Sanitize must clear snapshot; rule still fired in %s", string(out))
 	}
 }
@@ -607,11 +848,9 @@ func TestPromptRules_AllowedProtocols_RejectsUnknown(t *testing.T) {
 // === Concurrency ===
 
 func TestPromptRules_ConcurrentSnapshotRebuild(t *testing.T) {
-	// Race-detector run: many readers calling ApplyPromptRules while a writer
-	// rebuilds the snapshot. The atomic.Pointer should make this safe.
 	rulesA := []config.PromptRule{{
 		Name: "a", Enabled: true, Target: "system", Action: "inject",
-		Content: "<!-- pr:a --> a.", Marker: "<!-- pr:a -->", Position: "append",
+		Content: "a.", Position: "append",
 	}}
 	rulesB := []config.PromptRule{{
 		Name: "b", Enabled: true, Target: "system", Action: "strip",
@@ -646,4 +885,190 @@ func TestPromptRules_ConcurrentSnapshotRebuild(t *testing.T) {
 	}
 	close(stop)
 	wg.Wait()
+}
+
+// === Pure-helper tests for hasAdjacentContent / injectIntoText ===
+
+func TestInjectIntoText_BoundaryMode_Append(t *testing.T) {
+	out, mut := injectIntoText("base", "X", "", "append")
+	if !mut || out != "baseX" {
+		t.Fatalf("append boundary: got (%q, %v)", out, mut)
+	}
+}
+
+func TestInjectIntoText_BoundaryMode_Prepend(t *testing.T) {
+	out, mut := injectIntoText("base", "X", "", "prepend")
+	if !mut || out != "Xbase" {
+		t.Fatalf("prepend boundary: got (%q, %v)", out, mut)
+	}
+}
+
+func TestInjectIntoText_BoundaryMode_ContentPresent_Skip(t *testing.T) {
+	out, mut := injectIntoText("preX-suf", "X", "", "append")
+	if mut || out != "preX-suf" {
+		t.Fatalf("expected skip; got (%q, %v)", out, mut)
+	}
+}
+
+func TestInjectIntoText_MarkerMode_Append_FirstOccurrence(t *testing.T) {
+	out, mut := injectIntoText("X.X.X", "*", "X", "append")
+	if !mut || out != "X*.X.X" {
+		t.Fatalf("expected first-occurrence append; got (%q, %v)", out, mut)
+	}
+}
+
+func TestInjectIntoText_MarkerMode_AdjacentAtAnyOccurrence_Skip(t *testing.T) {
+	// Last X has content "*" adjacent → whole op skips.
+	out, mut := injectIntoText("X.X.X*", "*", "X", "append")
+	if mut || out != "X.X.X*" {
+		t.Fatalf("expected adjacency skip; got (%q, %v)", out, mut)
+	}
+}
+
+func TestInjectIntoText_MarkerMode_NotInText_Skip(t *testing.T) {
+	out, mut := injectIntoText("nothing here", "*", "X", "append")
+	if mut || out != "nothing here" {
+		t.Fatalf("expected no-anchor skip; got (%q, %v)", out, mut)
+	}
+}
+
+func TestInjectIntoText_EmptyContent_Skip(t *testing.T) {
+	out, mut := injectIntoText("base", "", "", "append")
+	if mut || out != "base" {
+		t.Fatalf("empty content must be skip; got (%q, %v)", out, mut)
+	}
+}
+
+func TestInjectIntoText_EmptyTarget_Boundary(t *testing.T) {
+	out, mut := injectIntoText("", "X", "", "append")
+	if !mut || out != "X" {
+		t.Fatalf("empty target boundary append: got (%q, %v)", out, mut)
+	}
+}
+
+func TestInjectIntoText_EmptyTarget_MarkerMode_Skip(t *testing.T) {
+	out, mut := injectIntoText("", "X", "anchor", "append")
+	if mut || out != "" {
+		t.Fatalf("empty target marker mode: got (%q, %v)", out, mut)
+	}
+}
+
+func TestInjectIntoText_PrependMarker_NotEnoughRoom_Inserts(t *testing.T) {
+	// content " bar" length 4; marker "foo" at index 2; not enough room before
+	// (only "X " = 2 chars). hasAdjacentContent must return false.
+	out, mut := injectIntoText("X foo Y", " bar", "foo", "prepend")
+	if !mut || out != "X  barfoo Y" {
+		t.Fatalf("prepend with insufficient prior room: got (%q, %v)", out, mut)
+	}
+}
+
+func TestHasAdjacentContent_Append_DirectlyAfter(t *testing.T) {
+	if !hasAdjacentContent("X foobar Y", "bar", "foo", "append") {
+		t.Fatal("expected adjacent (foo|bar)")
+	}
+	if hasAdjacentContent("X foo bar Y", "bar", "foo", "append") {
+		t.Fatal("space between marker and content must NOT be adjacent")
+	}
+}
+
+func TestHasAdjacentContent_Prepend_DirectlyBefore(t *testing.T) {
+	if !hasAdjacentContent("X barfoo Y", "bar", "foo", "prepend") {
+		t.Fatal("expected adjacent (bar|foo)")
+	}
+	if hasAdjacentContent("X bar foo Y", "bar", "foo", "prepend") {
+		t.Fatal("space between content and marker must NOT be adjacent")
+	}
+}
+
+func TestHasAdjacentContent_EmptyArgs(t *testing.T) {
+	if hasAdjacentContent("text", "", "marker", "append") {
+		t.Fatal("empty content must be non-adjacent")
+	}
+	if hasAdjacentContent("text", "x", "", "append") {
+		t.Fatal("empty marker must be non-adjacent")
+	}
+}
+
+func TestHasAdjacentContent_OverlappingMarker_Append(t *testing.T) {
+	// marker="aa" appears at indices 0 AND 1 inside "aaab". The byte-level scan
+	// must visit both, otherwise it misses the adjacency at index 1.
+	if !hasAdjacentContent("aaab", "b", "aa", "append") {
+		t.Fatal("scan must detect overlapping marker occurrences (append)")
+	}
+}
+
+func TestHasAdjacentContent_OverlappingMarker_Prepend(t *testing.T) {
+	// "baa" with marker="aa": occurrences at indices 1 and 2 (overlap of one).
+	// Content "b" precedes the FIRST occurrence at index 1.
+	if !hasAdjacentContent("baa", "b", "aa", "prepend") {
+		t.Fatal("scan must detect overlapping marker occurrences (prepend)")
+	}
+}
+
+func TestHasAdjacentContent_MultiByteUTF8(t *testing.T) {
+	// "X 日本 hello Y": marker is the multi-byte CJK string, content is ASCII.
+	// strings.Index works on bytes, and the adjacency check must respect that
+	// length math without truncating in the middle of a code point.
+	const marker = "日本"      // 6 bytes
+	const text = "X 日本hello Y" // marker followed immediately by "hello"
+	if !hasAdjacentContent(text, "hello", marker, "append") {
+		t.Fatalf("multi-byte marker adjacency: expected match")
+	}
+	if hasAdjacentContent("X 日本 hello Y", "hello", marker, "append") {
+		t.Fatalf("multi-byte marker adjacency: space between must be non-adjacent")
+	}
+}
+
+func TestInjectIntoText_MarkerMode_OverlappingMarker_FirstRunSkips(t *testing.T) {
+	// "aaab" with marker="aa" has occurrences at indices 0 AND 1. Content "b"
+	// is adjacent at index 1. Without the byte-by-byte scan the adjacency at
+	// index 1 would be missed and the rule would (incorrectly) inject. With
+	// the fix the rule correctly skips on the FIRST run.
+	out, mut := injectIntoText("aaab", "b", "aa", "append")
+	if mut || out != "aaab" {
+		t.Fatalf("overlap adjacency must skip on first run; got (%q, %v)", out, mut)
+	}
+}
+
+func TestInjectIntoText_MarkerMode_NoOverlapAdjacency_StableAcrossRuns(t *testing.T) {
+	// "aaa" with marker="aa": occurrences at 0 and 1; content "X" is adjacent
+	// to neither initially. First run inserts at index 0; second run sees
+	// adjacency at index 0 and skips.
+	out, mut := injectIntoText("aaa", "X", "aa", "append")
+	if !mut || out != "aaXa" {
+		t.Fatalf("first run should inject after first marker; got (%q, %v)", out, mut)
+	}
+	out2, mut2 := injectIntoText(out, "X", "aa", "append")
+	if mut2 || out2 != out {
+		t.Fatalf("second run must be idempotent; got (%q, %v)", out2, mut2)
+	}
+}
+
+func TestInjectIntoText_BoundaryMode_AbAbContentPresent(t *testing.T) {
+	// content="ab" already present in target — boundary mode skips.
+	out, mut := injectIntoText("abab", "ab", "", "append")
+	if mut || out != "abab" {
+		t.Fatalf("boundary content present must skip; got (%q, %v)", out, mut)
+	}
+}
+
+func TestPromptRules_BlockArray_Marker_TwoMarkerBlocks_InjectsBlock0Only(t *testing.T) {
+	// Two text blocks each contain the marker; neither has content adjacent.
+	// Inject must land in block 0 only; block 2 keeps the marker untouched.
+	withPromptRules(t, []config.PromptRule{{
+		Name: "sys", Enabled: true, Target: "system", Action: "inject",
+		Content: "*", Marker: "anchor", Position: "append",
+	}})
+	in := `{"system":[{"type":"text","text":"anchor first"},{"type":"text","text":"anchor second"}],"messages":[{"role":"user","content":"hi"}]}`
+	out := applyClaude(in)
+	blocks := gjson.GetBytes(out, "system").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks; got %d in %s", len(blocks), string(out))
+	}
+	if blocks[0].Get("text").String() != "anchor* first" {
+		t.Fatalf("block 0 should have inject after marker; got %s", blocks[0].Raw)
+	}
+	if blocks[1].Get("text").String() != "anchor second" {
+		t.Fatalf("block 1 must be untouched; got %s", blocks[1].Raw)
+	}
 }

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -56,6 +57,18 @@ type pinnedAuthContextKey struct{}
 type selectedAuthCallbackContextKey struct{}
 type executionSessionContextKey struct{}
 type disallowFreeAuthContextKey struct{}
+type requestPathContextKey struct{}
+
+// requestPathFromContext extracts the inbound HTTP request path stashed by
+// GetContextWithCancel. Used by Execute*WithAuthManager to drive endpoint-
+// scoped pre-translation rules without altering the public method signatures.
+func requestPathFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	v, _ := ctx.Value(requestPathContextKey{}).(string)
+	return v
+}
 
 // WithPinnedAuthID returns a child context that requests execution on a specific auth ID.
 func WithPinnedAuthID(ctx context.Context, authID string) context.Context {
@@ -384,6 +397,9 @@ func (h *BaseAPIHandler) GetContextWithCancel(handler interfaces.APIHandler, c *
 	}
 	newCtx = context.WithValue(newCtx, "gin", c)
 	newCtx = context.WithValue(newCtx, "handler", handler)
+	if c != nil && c.Request != nil && c.Request.URL != nil {
+		newCtx = context.WithValue(newCtx, requestPathContextKey{}, c.Request.URL.Path)
+	}
 	return newCtx, func(params ...interface{}) {
 		if h.Cfg.RequestLog && len(params) == 1 {
 			if existing, exists := c.Get("API_RESPONSE"); exists {
@@ -508,7 +524,14 @@ func (h *BaseAPIHandler) ExecuteWithAuthManager(ctx context.Context, handlerType
 	}
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = normalizedModel
+	// Apply pre-translation prompt rules (inject/strip on system + last user
+	// natural-language message) before any executor sees the request body.
+	// OriginalRequest stays the un-mutated rawJSON so payload-rule semantics
+	// (default-when-missing checks) compare against what the client sent.
 	payload := rawJSON
+	if len(payload) > 0 {
+		payload = helps.ApplyPromptRules(handlerType, normalizedModel, payload, requestPathFromContext(ctx), alt)
+	}
 	if len(payload) == 0 {
 		payload = nil
 	}
@@ -556,7 +579,14 @@ func (h *BaseAPIHandler) ExecuteCountWithAuthManager(ctx context.Context, handle
 	}
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = normalizedModel
+	// Apply pre-translation prompt rules (inject/strip on system + last user
+	// natural-language message) before any executor sees the request body.
+	// OriginalRequest stays the un-mutated rawJSON so payload-rule semantics
+	// (default-when-missing checks) compare against what the client sent.
 	payload := rawJSON
+	if len(payload) > 0 {
+		payload = helps.ApplyPromptRules(handlerType, normalizedModel, payload, requestPathFromContext(ctx), alt)
+	}
 	if len(payload) == 0 {
 		payload = nil
 	}
@@ -608,7 +638,14 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 	}
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = normalizedModel
+	// Apply pre-translation prompt rules (inject/strip on system + last user
+	// natural-language message) before any executor sees the request body.
+	// OriginalRequest stays the un-mutated rawJSON so payload-rule semantics
+	// (default-when-missing checks) compare against what the client sent.
 	payload := rawJSON
+	if len(payload) > 0 {
+		payload = helps.ApplyPromptRules(handlerType, normalizedModel, payload, requestPathFromContext(ctx), alt)
+	}
 	if len(payload) == 0 {
 		payload = nil
 	}


### PR DESCRIPTION
## Summary

Adds a "Prompt Rules" feature that lets operators configure content-level mutations on outgoing requests, applied at a single chokepoint pre-translation. Two operations:

- **Inject** standing instructions (style guides, persona, project context) into the system prompt or last natural-language user message. Survives client-side compaction (Claude Code `/compact`, etc.) because every request runs through the pipeline — the rule re-fires idempotently.
- **Strip** unwanted boilerplate via RE2 regex (e.g., a "Buddy" preamble some clients inject every turn).

Inject has two modes:

- **Boundary mode** (`Marker` empty): append at end / prepend at start of the target. Idempotent via `strings.Contains(target, content)`.
- **Anchor mode** (`Marker` non-empty): inject immediately after / before the marker. Idempotent via "content already directly adjacent to some marker occurrence in the configured direction". If the marker isn't present in the target, the rule no-ops.

Multi-occurrence markers in a single string are walked for idempotency; the inject lands at the first only. Block-array targets (Claude `system` blocks, OpenAI/Responses content blocks, Gemini parts) walk every text-bearing block — any block with content adjacent suppresses the whole rule, otherwise the inject lands inside the first marker-bearing block.

## Where it runs

A single chokepoint at `BaseAPIHandler.ExecuteWithAuthManager` (covers `Execute`, `ExecuteCount`, `ExecuteStream` — count-token and retry paths included). Source-format–keyed dispatch: `openai`, `openai-response`, `claude`, `gemini`, `gemini-cli`. Skips ` /v1/images/*` and `alt=responses/compact` requests by default.

Reads from a package-level `atomic.Pointer[promptRulesSnapshot]` populated by config sanitize and management-API persist hooks; no lock contention on the hot path. Race-tested via `TestPromptRules_ConcurrentSnapshotRebuild`.

Strip pass runs first within a single request, then inject — so an inject can safely re-create what strip just removed.

## Configuration

YAML schema:

```yaml
prompt-rules:
  - name: always-json
    enabled: true
    target: system        # system | user
    action: inject        # inject | strip
    content: "Always answer in JSON."
    # marker: ""          # optional anchor
    # position: append    # append | prepend (default: append)
    # models:
    #   - { name: "gpt-*", protocol: "openai" }
  - name: drop-buddy-preamble
    enabled: true
    target: system
    action: strip
    pattern: 'Buddy[^\n]*\n?'
```

`models` empty means match all models and source formats. Per-entry `protocol` scopes by inbound source format.

## Management API

```
GET    /v0/management/prompt-rules
PUT    /v0/management/prompt-rules
PATCH  /v0/management/prompt-rules        (upsert by index or name)
DELETE /v0/management/prompt-rules?name=... | ?index=...
```

All write paths run `ValidatePromptRules` and return 400 with the offending rule's name + reason on failure. The same validator runs on the management YAML upload path so a bad rule cannot sneak in via `PutConfigYAML`.

## Paired frontend PR

The management UI for editing these rules ships in router-for-me/Cli-Proxy-API-Management-Center#251. The two should be reviewed and merged together — the backend works standalone via the management API or YAML, but the operator experience depends on the UI.

## Test plan

- [ ] `go test -race ./internal/runtime/executor/helps/... ./internal/config/... ./internal/api/handlers/management/... ./sdk/api/handlers/...`
- [ ] `go build ./...`
- [ ] Boundary inject: synthesizes / appends / is idempotent across `openai`, `openai-response`, `claude`, `gemini`, `gemini-cli`.
- [ ] Anchor inject: lands adjacent to marker; second run skips; rule no-ops when marker absent.
- [ ] Strip removes regex matches; naturally idempotent.
- [ ] `/v1/images/generations` and `alt=responses/compact` skip the pipeline.
- [ ] Block-array targets (Claude system blocks, OpenAI text/input_text content blocks, Gemini parts): boundary mode appends a fresh text block at the boundary; anchor mode injects inside the first marker-bearing block; adjacency in any block suppresses the whole rule.
- [ ] Live smoke: PUT a rule via management API, send a chat completion, verify the upstream payload carries the expected text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)