### PR TITLE
feat: add usage backup image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+unified-stats-entrypoint.sh text eol=lf

--- a/Dockerfile.stats
+++ b/Dockerfile.stats
@@ -1,0 +1,35 @@
+FROM golang:1.26-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG VERSION=dev
+ARG COMMIT=none
+ARG BUILD_DATE=unknown
+
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X 'main.Version=${VERSION}' -X 'main.Commit=${COMMIT}' -X 'main.BuildDate=${BUILD_DATE}'" -o ./CLIProxyAPI ./cmd/server/
+
+FROM alpine:3.22.0
+
+RUN apk add --no-cache postgresql-client rclone tzdata
+
+RUN mkdir /CLIProxyAPI
+
+COPY --from=builder /app/CLIProxyAPI /CLIProxyAPI/CLIProxyAPI
+COPY config.example.yaml /CLIProxyAPI/config.example.yaml
+COPY unified-stats-entrypoint.sh /CLIProxyAPI/stats-entrypoint.sh
+
+RUN chmod +x /CLIProxyAPI/stats-entrypoint.sh
+WORKDIR /CLIProxyAPI
+
+EXPOSE 8317
+
+ENV TZ=Asia/Shanghai
+
+RUN cp /usr/share/zoneinfo/${TZ} /etc/localtime && echo "${TZ}" > /etc/timezone
+
+CMD ["/CLIProxyAPI/stats-entrypoint.sh"]

--- a/Dockerfile.stats
+++ b/Dockerfile.stats
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X 'main.Version=${VERSION
 
 FROM alpine:3.22.0
 
-RUN apk add --no-cache postgresql-client rclone tzdata
+RUN apk add --no-cache curl postgresql-client rclone tzdata
 
 RUN mkdir /CLIProxyAPI
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ CLIProxyAPI Guides: [https://help.router-for.me/](https://help.router-for.me/)
 
 see [MANAGEMENT_API.md](https://help.router-for.me/management/api)
 
+## Usage Backup Image
+
+`Dockerfile.stats` provides a container entrypoint that persists Management API usage statistics across restarts using PostgreSQL/Supabase, S3-compatible object storage, or a mounted local data directory. See [docs/usage-backup.md](docs/usage-backup.md).
+
 ## Amp CLI Support
 
 CLIProxyAPI includes integrated support for [Amp CLI](https://ampcode.com) and Amp IDE extensions, enabling you to use your Google/ChatGPT/Claude OAuth subscriptions with Amp's coding tools:

--- a/docs/usage-backup.md
+++ b/docs/usage-backup.md
@@ -1,0 +1,70 @@
+# Usage Backup Image
+
+`Dockerfile.stats` builds a CLIProxyAPI image that keeps the in-memory usage statistics across container restarts. It wraps the normal server process, periodically exports `/v0/management/usage/export`, and imports the saved snapshot before serving traffic again.
+
+The image supports three backup modes:
+
+- PostgreSQL-compatible databases, including Supabase Postgres.
+- S3-compatible object storage, including Cloudflare R2 and path-style object stores.
+- Local file only, useful when `/CLIProxyAPI/data` is mounted as a persistent volume.
+
+## Build
+
+```sh
+docker build -f Dockerfile.stats -t cli-proxy-api:stats .
+```
+
+## Required Management API Key
+
+Usage import and export use the Management API, so the container must receive the same key configured in `remote-management.secret-key`:
+
+```sh
+MANAGEMENT_PASSWORD=your-management-key
+```
+
+If the key is missing, the server still starts, but usage backup import/export is disabled.
+
+## PostgreSQL / Supabase
+
+Set either `PGSTORE_DSN` or `DATABASE_URL`. `DATABASE_URL` works with the connection string provided by Supabase.
+
+```sh
+STATS_BACKEND=postgres
+DATABASE_URL=postgresql://postgres:password@db.example.supabase.co:5432/postgres
+MANAGEMENT_PASSWORD=your-management-key
+```
+
+The wrapper creates a small `usage_backup` table if it does not already exist:
+
+```sql
+CREATE TABLE IF NOT EXISTS usage_backup (
+  id INT PRIMARY KEY,
+  data JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+Set `PGSTORE_SCHEMA` to store the table in a specific schema. The schema name must contain only letters, numbers, and underscores, and it must not start with a number.
+
+## S3-Compatible Object Storage
+
+Set all object storage variables below. The wrapper stores the snapshot at `usage/usage_backup.json` in the configured bucket.
+
+```sh
+STATS_BACKEND=s3
+OBJECTSTORE_ENDPOINT=https://example.r2.cloudflarestorage.com
+OBJECTSTORE_BUCKET=cliproxyapi
+OBJECTSTORE_ACCESS_KEY=access-key
+OBJECTSTORE_SECRET_KEY=secret-key
+MANAGEMENT_PASSWORD=your-management-key
+```
+
+Cloudflare R2 endpoints use the `Cloudflare` rclone provider. Other endpoints default to the generic S3 provider with path-style access enabled.
+
+## Other Settings
+
+- `USAGE_BACKUP_INTERVAL`: export interval in seconds. Defaults to `300`.
+- `USAGE_BACKUP_PORT`: management API port override. When omitted, the wrapper uses `PORT`, then common config file paths, then `8317`.
+- `STATS_BACKEND`: optional backend override. Supported values are `postgres`, `postgresql`, `pgsql`, `s3`, `objectstore`, `local`, `none`, and `disabled`.
+
+When no database or complete object storage configuration is present, the wrapper uses local-only backups at `/CLIProxyAPI/data/usage_backup.json`.

--- a/unified-stats-entrypoint.sh
+++ b/unified-stats-entrypoint.sh
@@ -90,25 +90,31 @@ pgsql_upsert_usage_file() {
   fi
 
   prefix="$(pg_sql_prefix || true)"
-  json_data="$(tr -d '\r\n' < "${STATS_FILE}")"
+  tmp_sql="${STATS_FILE}.sql.$$"
 
-  if [ -n "${prefix}" ]; then
-    psql "${dsn}" -v ON_ERROR_STOP=1 -v usage_json="${json_data}" >/dev/null <<EOF
-${prefix}
+  {
+    if [ -n "${prefix}" ]; then
+      printf '%s\n' "${prefix}"
+    fi
+    cat <<EOF
 INSERT INTO usage_backup (id, data, updated_at)
-VALUES (1, :'usage_json'::jsonb, NOW())
+VALUES (1, \$cliproxyapi_usage\$
+EOF
+    cat "${STATS_FILE}"
+    cat <<'EOF'
+$cliproxyapi_usage$::jsonb, NOW())
 ON CONFLICT (id) DO UPDATE
 SET data = EXCLUDED.data, updated_at = NOW();
 EOF
-    return $?
+  } > "${tmp_sql}"
+
+  if psql "${dsn}" -v ON_ERROR_STOP=1 >/dev/null -f "${tmp_sql}"; then
+    status=0
+  else
+    status=$?
   fi
-
-  psql "${dsn}" -v ON_ERROR_STOP=1 -v usage_json="${json_data}" >/dev/null <<EOF
-INSERT INTO usage_backup (id, data, updated_at)
-VALUES (1, :'usage_json'::jsonb, NOW())
-ON CONFLICT (id) DO UPDATE
-SET data = EXCLUDED.data, updated_at = NOW();
-EOF
+  rm -f "${tmp_sql}"
+  return "${status}"
 }
 
 normalize_backend() {
@@ -217,6 +223,8 @@ setup_rclone() {
   esac
 
   mkdir -p "${RCLONE_CONFIG_DIR}"
+  touch "${RCLONE_CONFIG_FILE}"
+  chmod 600 "${RCLONE_CONFIG_FILE}"
   cat > "${RCLONE_CONFIG_FILE}" <<EOF
 [${RCLONE_REMOTE}]
 type = s3
@@ -343,15 +351,12 @@ export_usage_snapshot() {
   management_key="$2"
   tmp_file="${STATS_FILE}.tmp"
 
-  response="$(curl -s -w '\n%{http_code}' -H "X-Management-Key: ${management_key}" \
-    "http://localhost:${port}/v0/management/usage/export" 2>/dev/null || true)"
-  http_code="$(printf '%s\n' "${response}" | tail -n1)"
+  http_code="$(curl -s -o "${tmp_file}" -w '%{http_code}' -H "X-Management-Key: ${management_key}" \
+    "http://localhost:${port}/v0/management/usage/export" 2>/dev/null || echo '000')"
   if [ "${http_code}" != "200" ]; then
     rm -f "${tmp_file}"
     return 1
   fi
-
-  printf '%s\n' "${response}" | sed '$d' > "${tmp_file}"
   if [ ! -s "${tmp_file}" ]; then
     rm -f "${tmp_file}"
     return 1
@@ -369,12 +374,11 @@ import_usage_snapshot() {
     return 0
   fi
 
-  response="$(curl -s -w '\n%{http_code}' -X POST \
+  http_code="$(curl -s -o /dev/null -w '%{http_code}' -X POST \
     -H "X-Management-Key: ${management_key}" \
     -H "Content-Type: application/json" \
     -d @"${STATS_FILE}" \
-    "http://localhost:${port}/v0/management/usage/import" 2>/dev/null || true)"
-  http_code="$(printf '%s\n' "${response}" | tail -n1)"
+    "http://localhost:${port}/v0/management/usage/import" 2>/dev/null || echo '000')"
   if [ "${http_code}" = "200" ]; then
     log "Imported usage statistics into the running service."
     push_stats

--- a/unified-stats-entrypoint.sh
+++ b/unified-stats-entrypoint.sh
@@ -1,0 +1,462 @@
+#!/bin/sh
+set -eu
+
+DATA_DIR="/CLIProxyAPI/data"
+STATS_FILE="${DATA_DIR}/usage_backup.json"
+STATS_REMOTE_DIR="usage"
+STATS_REMOTE_KEY="${STATS_REMOTE_DIR}/usage_backup.json"
+RCLONE_REMOTE="statsremote"
+RCLONE_CONFIG_DIR="/root/.config/rclone"
+RCLONE_CONFIG_FILE="${RCLONE_CONFIG_DIR}/rclone.conf"
+BACKEND=""
+SERVER_PID=""
+
+log() {
+  echo "[stats] $*" >&2
+}
+
+get_management_key() {
+  printf '%s' "${MANAGEMENT_PASSWORD:-}"
+}
+
+get_pg_dsn() {
+  if [ -n "${PGSTORE_DSN:-}" ]; then
+    printf '%s' "${PGSTORE_DSN}"
+    return 0
+  fi
+  if [ -n "${DATABASE_URL:-}" ]; then
+    printf '%s' "${DATABASE_URL}"
+    return 0
+  fi
+  return 1
+}
+
+is_identifier() {
+  case "$1" in
+    "" | [0-9]* | *[!A-Za-z0-9_]*)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+pg_sql_prefix() {
+  if [ -n "${PGSTORE_SCHEMA:-}" ] && is_identifier "${PGSTORE_SCHEMA}"; then
+    printf 'CREATE SCHEMA IF NOT EXISTS %s; SET search_path TO %s, public;' "${PGSTORE_SCHEMA}" "${PGSTORE_SCHEMA}"
+    return 0
+  fi
+  if [ -n "${PGSTORE_SCHEMA:-}" ]; then
+    log "Ignoring unsupported PGSTORE_SCHEMA value for usage backups."
+  fi
+  return 1
+}
+
+pgsql_exec() {
+  dsn="$(get_pg_dsn || true)"
+  if [ -z "${dsn}" ]; then
+    return 1
+  fi
+
+  prefix="$(pg_sql_prefix || true)"
+  if [ -n "${prefix}" ]; then
+    psql "${dsn}" -v ON_ERROR_STOP=1 -q -c "${prefix} $1"
+    return $?
+  fi
+
+  psql "${dsn}" -v ON_ERROR_STOP=1 -q -c "$1"
+}
+
+pgsql_query_raw() {
+  dsn="$(get_pg_dsn || true)"
+  if [ -z "${dsn}" ]; then
+    return 1
+  fi
+
+  prefix="$(pg_sql_prefix || true)"
+  if [ -n "${prefix}" ]; then
+    psql "${dsn}" -v ON_ERROR_STOP=1 -q -t -A -c "${prefix} $1"
+    return $?
+  fi
+
+  psql "${dsn}" -v ON_ERROR_STOP=1 -q -t -A -c "$1"
+}
+
+pgsql_upsert_usage_file() {
+  dsn="$(get_pg_dsn || true)"
+  if [ -z "${dsn}" ] || [ ! -s "${STATS_FILE}" ]; then
+    return 1
+  fi
+
+  prefix="$(pg_sql_prefix || true)"
+  json_data="$(tr -d '\r\n' < "${STATS_FILE}")"
+
+  if [ -n "${prefix}" ]; then
+    psql "${dsn}" -v ON_ERROR_STOP=1 -v usage_json="${json_data}" >/dev/null <<EOF
+${prefix}
+INSERT INTO usage_backup (id, data, updated_at)
+VALUES (1, :'usage_json'::jsonb, NOW())
+ON CONFLICT (id) DO UPDATE
+SET data = EXCLUDED.data, updated_at = NOW();
+EOF
+    return $?
+  fi
+
+  psql "${dsn}" -v ON_ERROR_STOP=1 -v usage_json="${json_data}" >/dev/null <<EOF
+INSERT INTO usage_backup (id, data, updated_at)
+VALUES (1, :'usage_json'::jsonb, NOW())
+ON CONFLICT (id) DO UPDATE
+SET data = EXCLUDED.data, updated_at = NOW();
+EOF
+}
+
+normalize_backend() {
+  case "$1" in
+    pgsql | postgres | postgresql)
+      printf 'pgsql'
+      ;;
+    s3 | objectstore | object-storage)
+      printf 's3'
+      ;;
+    local | none | disabled)
+      printf 'local'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+read_port_from_file() {
+  if [ ! -f "$1" ]; then
+    return 1
+  fi
+
+  port="$(grep -E '^port:' "$1" 2>/dev/null | sed -E 's/^port: *["'"'"']?([0-9]+)["'"'"']?.*$/\1/' | head -n1)"
+  if [ -n "${port}" ]; then
+    printf '%s' "${port}"
+    return 0
+  fi
+  return 1
+}
+
+get_port() {
+  if [ -n "${USAGE_BACKUP_PORT:-}" ]; then
+    printf '%s' "${USAGE_BACKUP_PORT}"
+    return 0
+  fi
+  if [ -n "${PORT:-}" ]; then
+    printf '%s' "${PORT}"
+    return 0
+  fi
+
+  for file in \
+    "/CLIProxyAPI/config.yaml" \
+    "/CLIProxyAPI/objectstore/config/config.yaml" \
+    "/CLIProxyAPI/pgstore/config/config.yaml" \
+    "/CLIProxyAPI/gitstore/config/config.yaml"
+  do
+    port="$(read_port_from_file "${file}" || true)"
+    if [ -n "${port}" ]; then
+      printf '%s' "${port}"
+      return 0
+    fi
+  done
+
+  writable_root="${WRITABLE_PATH:-${writable_path:-}}"
+  if [ -n "${writable_root}" ]; then
+    for file in \
+      "${writable_root}/objectstore/config/config.yaml" \
+      "${writable_root}/pgstore/config/config.yaml" \
+      "${writable_root}/gitstore/config/config.yaml"
+    do
+      port="$(read_port_from_file "${file}" || true)"
+      if [ -n "${port}" ]; then
+        printf '%s' "${port}"
+        return 0
+      fi
+    done
+  fi
+
+  printf '8317'
+}
+
+detect_backend() {
+  if [ -n "${STATS_BACKEND:-}" ]; then
+    if backend="$(normalize_backend "${STATS_BACKEND}")"; then
+      printf '%s' "${backend}"
+      return 0
+    fi
+    log "Ignoring unsupported STATS_BACKEND value: ${STATS_BACKEND}"
+  fi
+
+  if get_pg_dsn >/dev/null 2>&1; then
+    printf 'pgsql'
+    return 0
+  fi
+
+  if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_BUCKET:-}" ] && \
+     [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ] && [ -n "${OBJECTSTORE_SECRET_KEY:-}" ]; then
+    printf 's3'
+    return 0
+  fi
+
+  printf 'local'
+}
+
+setup_rclone() {
+  provider="Other"
+  force_path_style="true"
+  endpoint="${OBJECTSTORE_ENDPOINT:-}"
+
+  case "${endpoint}" in
+    *r2.cloudflarestorage.com*)
+      provider="Cloudflare"
+      force_path_style=""
+      ;;
+  esac
+
+  mkdir -p "${RCLONE_CONFIG_DIR}"
+  cat > "${RCLONE_CONFIG_FILE}" <<EOF
+[${RCLONE_REMOTE}]
+type = s3
+provider = ${provider}
+access_key_id = ${OBJECTSTORE_ACCESS_KEY}
+secret_access_key = ${OBJECTSTORE_SECRET_KEY}
+endpoint = ${OBJECTSTORE_ENDPOINT}
+region = auto
+no_check_bucket = true
+EOF
+  if [ -n "${force_path_style}" ]; then
+    printf 'force_path_style = true\n' >> "${RCLONE_CONFIG_FILE}"
+  fi
+}
+
+pull_stats() {
+  mkdir -p "${DATA_DIR}"
+
+  case "${BACKEND}" in
+    pgsql)
+      if ! get_pg_dsn >/dev/null 2>&1; then
+        log "PostgreSQL backup requested but no PGSTORE_DSN or DATABASE_URL is configured."
+        return 0
+      fi
+      log "Initializing PostgreSQL usage backup store."
+      if ! pgsql_exec "
+        CREATE TABLE IF NOT EXISTS usage_backup (
+          id INT PRIMARY KEY,
+          data JSONB NOT NULL,
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+      " >/dev/null 2>&1; then
+        log "PostgreSQL initialization failed; continuing without a preloaded backup."
+        return 0
+      fi
+
+      tmp_file="${STATS_FILE}.tmp"
+      if pgsql_query_raw "SELECT data::text FROM usage_backup WHERE id = 1;" > "${tmp_file}" 2>/dev/null && \
+         [ -s "${tmp_file}" ] && grep -q '"usage"' "${tmp_file}"; then
+        mv "${tmp_file}" "${STATS_FILE}"
+        log "Restored usage statistics from PostgreSQL."
+      else
+        rm -f "${tmp_file}"
+        log "No PostgreSQL usage backup found."
+      fi
+      ;;
+    s3)
+      if [ -z "${OBJECTSTORE_ENDPOINT:-}" ] || [ -z "${OBJECTSTORE_BUCKET:-}" ] || \
+         [ -z "${OBJECTSTORE_ACCESS_KEY:-}" ] || [ -z "${OBJECTSTORE_SECRET_KEY:-}" ]; then
+        log "Object storage backup requested but OBJECTSTORE_* configuration is incomplete."
+        return 0
+      fi
+      log "Configuring object storage access."
+      setup_rclone
+      if rclone copyto "${RCLONE_REMOTE}:${OBJECTSTORE_BUCKET}/${STATS_REMOTE_KEY}" "${STATS_FILE}" \
+        --contimeout 5s --timeout 15s --retries 1 --s3-no-check-bucket >/dev/null 2>&1; then
+        log "Restored usage statistics from object storage."
+      else
+        rm -f "${STATS_FILE}"
+        log "No object storage usage backup found."
+      fi
+      ;;
+    local)
+      log "Using local-only usage backup mode."
+      ;;
+  esac
+}
+
+push_stats() {
+  if [ ! -s "${STATS_FILE}" ]; then
+    return 0
+  fi
+
+  case "${BACKEND}" in
+    pgsql)
+      if ! get_pg_dsn >/dev/null 2>&1; then
+        log "PostgreSQL backup requested but no PGSTORE_DSN or DATABASE_URL is configured."
+        return 0
+      fi
+      if pgsql_upsert_usage_file 2>/tmp/usage-pgsql-error.log; then
+        log "Synced usage statistics to PostgreSQL."
+      else
+        log "Failed to sync usage statistics to PostgreSQL."
+        if [ -s /tmp/usage-pgsql-error.log ]; then
+          cat /tmp/usage-pgsql-error.log >&2
+        fi
+      fi
+      rm -f /tmp/usage-pgsql-error.log
+      ;;
+    s3)
+      if [ -z "${OBJECTSTORE_ENDPOINT:-}" ] || [ -z "${OBJECTSTORE_BUCKET:-}" ] || \
+         [ -z "${OBJECTSTORE_ACCESS_KEY:-}" ] || [ -z "${OBJECTSTORE_SECRET_KEY:-}" ]; then
+        log "Object storage backup requested but OBJECTSTORE_* configuration is incomplete."
+        return 0
+      fi
+      if rclone copyto "${STATS_FILE}" "${RCLONE_REMOTE}:${OBJECTSTORE_BUCKET}/${STATS_REMOTE_KEY}" \
+        --contimeout 5s --timeout 15s --retries 2 --s3-no-check-bucket >/dev/null 2>&1; then
+        log "Synced usage statistics to object storage."
+      else
+        log "Failed to sync usage statistics to object storage."
+      fi
+      ;;
+  esac
+}
+
+wait_for_service() {
+  port="$1"
+  retry=0
+  while [ "${retry}" -lt 30 ]; do
+    if [ -n "${SERVER_PID}" ] && ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+      return 1
+    fi
+    if curl -s -o /dev/null -w "%{http_code}" "http://localhost:${port}/" 2>/dev/null | grep -q "200"; then
+      return 0
+    fi
+    retry=$((retry + 1))
+    sleep 1
+  done
+  return 1
+}
+
+export_usage_snapshot() {
+  port="$1"
+  management_key="$2"
+  tmp_file="${STATS_FILE}.tmp"
+
+  response="$(curl -s -w '\n%{http_code}' -H "X-Management-Key: ${management_key}" \
+    "http://localhost:${port}/v0/management/usage/export" 2>/dev/null || true)"
+  http_code="$(printf '%s\n' "${response}" | tail -n1)"
+  if [ "${http_code}" != "200" ]; then
+    rm -f "${tmp_file}"
+    return 1
+  fi
+
+  printf '%s\n' "${response}" | sed '$d' > "${tmp_file}"
+  if [ ! -s "${tmp_file}" ]; then
+    rm -f "${tmp_file}"
+    return 1
+  fi
+
+  mv "${tmp_file}" "${STATS_FILE}"
+  return 0
+}
+
+import_usage_snapshot() {
+  port="$1"
+  management_key="$2"
+
+  if [ ! -s "${STATS_FILE}" ]; then
+    return 0
+  fi
+
+  response="$(curl -s -w '\n%{http_code}' -X POST \
+    -H "X-Management-Key: ${management_key}" \
+    -H "Content-Type: application/json" \
+    -d @"${STATS_FILE}" \
+    "http://localhost:${port}/v0/management/usage/import" 2>/dev/null || true)"
+  http_code="$(printf '%s\n' "${response}" | tail -n1)"
+  if [ "${http_code}" = "200" ]; then
+    log "Imported usage statistics into the running service."
+    push_stats
+    return 0
+  fi
+
+  log "Usage import failed with HTTP ${http_code}."
+  return 1
+}
+
+start_periodic_export_loop() {
+  port="$1"
+  management_key="$2"
+  interval="${USAGE_BACKUP_INTERVAL:-300}"
+
+  (
+    while [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; do
+      sleep "${interval}"
+      if [ -n "${SERVER_PID}" ] && ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+        exit 0
+      fi
+      if export_usage_snapshot "${port}" "${management_key}"; then
+        push_stats
+      fi
+    done
+  ) &
+}
+
+graceful_shutdown() {
+  trap '' TERM INT
+  log "Shutting down."
+
+  port="$(get_port)"
+  management_key="$(get_management_key)"
+  if [ -n "${management_key}" ] && [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    if export_usage_snapshot "${port}" "${management_key}"; then
+      push_stats
+    fi
+  fi
+
+  if [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    kill -TERM "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+  fi
+  exit 0
+}
+
+main() {
+  mkdir -p "${DATA_DIR}"
+
+  BACKEND="$(detect_backend)"
+  log "Detected usage backup backend: ${BACKEND}"
+
+  if [ "${BACKEND}" = "local" ] && \
+     { [ -n "${OBJECTSTORE_ENDPOINT:-}" ] || [ -n "${OBJECTSTORE_BUCKET:-}" ] || [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ] || [ -n "${OBJECTSTORE_SECRET_KEY:-}" ]; }; then
+    log "Incomplete OBJECTSTORE_* configuration detected; falling back to local-only backups."
+  fi
+
+  pull_stats
+
+  trap graceful_shutdown TERM INT
+
+  log "Starting CLIProxyAPI."
+  /CLIProxyAPI/CLIProxyAPI &
+  SERVER_PID=$!
+
+  management_key="$(get_management_key)"
+  port="$(get_port)"
+  if [ -z "${management_key}" ]; then
+    log "MANAGEMENT_PASSWORD is not set; usage backup import/export is disabled."
+    wait "${SERVER_PID}"
+    return $?
+  fi
+
+  if wait_for_service "${port}"; then
+    import_usage_snapshot "${port}" "${management_key}" || true
+    start_periodic_export_loop "${port}" "${management_key}"
+  else
+    log "Service did not become ready; continuing without usage import."
+  fi
+
+  wait "${SERVER_PID}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a stats Docker image entrypoint that preserves in-memory usage statistics across container restarts
- support PostgreSQL-compatible storage, including Supabase via `DATABASE_URL` / `PGSTORE_DSN`
- support S3-compatible object storage, including Cloudflare R2, through the existing `OBJECTSTORE_*` environment variables
- document configuration, backend selection, and local-only fallback behavior

## Details
The wrapper starts CLIProxyAPI normally, imports a previously saved Management API usage snapshot on startup, periodically exports the current snapshot, and exports once more during graceful shutdown.

Supported backup modes:
- `postgres`, `postgresql`, or `pgsql` for PostgreSQL/Supabase
- `s3`, `objectstore`, or `object-storage` for S3-compatible buckets
- `local`, `none`, or `disabled` for local file-only snapshots

When `STATS_BACKEND` is not set, the wrapper auto-detects PostgreSQL first, then object storage, then falls back to local-only snapshots under `/CLIProxyAPI/data/usage_backup.json`.

## Compatibility
- The normal Dockerfile and default runtime behavior are unchanged.
- The stats image is opt-in via `Dockerfile.stats`.
- Usage import/export requires `MANAGEMENT_PASSWORD` to match `remote-management.secret-key`; without it the service still starts and logs that backup import/export is disabled.
- The new shell entrypoint is kept LF-only via `.gitattributes` so it remains executable in Linux containers when edited from Windows.

## Tests
- `git diff --check`
- `bash -n unified-stats-entrypoint.sh`

A local `go build` / Docker build was not run in this workspace because Go and Docker are not available in PATH here.