### PR TITLE
[codex] normalize Claude OAuth tool handling

### DIFF
--- a/internal/logging/global_logger.go
+++ b/internal/logging/global_logger.go
@@ -30,7 +30,39 @@ var (
 type LogFormatter struct{}
 
 // logFieldOrder defines the display order for common log fields.
-var logFieldOrder = []string{"provider", "model", "mode", "budget", "level", "original_mode", "original_value", "min", "max", "clamped_to", "error"}
+var logFieldOrder = []string{
+	"provider",
+	"model",
+	"mode",
+	"budget",
+	"level",
+	"original_mode",
+	"original_value",
+	"min",
+	"max",
+	"clamped_to",
+	"endpoint",
+	"body_bytes",
+	"json_valid",
+	"messages",
+	"system_bytes",
+	"tools",
+	"tool_bytes",
+	"max_tool_bytes",
+	"tool_schema_bytes",
+	"max_tool_schema_bytes",
+	"text_blocks",
+	"text_bytes",
+	"max_text_bytes",
+	"image_blocks",
+	"base64_image_blocks",
+	"image_data_bytes",
+	"max_image_data_bytes",
+	"data_image_refs",
+	"base64_markers",
+	"cache_control_nodes",
+	"error",
+}
 
 // Format renders a single log entry with custom formatting.
 func (m *LogFormatter) Format(entry *log.Entry) ([]byte, error) {

--- a/internal/logging/global_logger_test.go
+++ b/internal/logging/global_logger_test.go
@@ -1,0 +1,63 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestLogFormatterIncludesClaudePayloadDiagnosticsFields(t *testing.T) {
+	entry := &log.Entry{
+		Time:    time.Date(2026, 4, 30, 22, 40, 0, 0, time.UTC),
+		Level:   log.WarnLevel,
+		Message: "claude payload diagnostics: large or image-containing upstream request",
+		Data: log.Fields{
+			"request_id":            "abc12345",
+			"model":                 "claude-opus-4-7",
+			"endpoint":              "messages",
+			"body_bytes":            2836981,
+			"json_valid":            true,
+			"messages":              4,
+			"tools":                 12,
+			"tool_schema_bytes":     98765,
+			"max_tool_schema_bytes": 45678,
+			"text_bytes":            123456,
+			"max_text_bytes":        100000,
+			"image_blocks":          2,
+			"base64_image_blocks":   2,
+			"image_data_bytes":      2000000,
+			"data_image_refs":       0,
+			"cache_control_nodes":   4,
+		},
+	}
+
+	formatted, err := (&LogFormatter{}).Format(entry)
+	if err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+	line := string(formatted)
+
+	for _, want := range []string{
+		"model=claude-opus-4-7",
+		"endpoint=messages",
+		"body_bytes=2836981",
+		"json_valid=true",
+		"messages=4",
+		"tools=12",
+		"tool_schema_bytes=98765",
+		"max_tool_schema_bytes=45678",
+		"text_bytes=123456",
+		"max_text_bytes=100000",
+		"image_blocks=2",
+		"base64_image_blocks=2",
+		"image_data_bytes=2000000",
+		"data_image_refs=0",
+		"cache_control_nodes=4",
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("formatted log missing %q:\n%s", want, line)
+		}
+	}
+}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1855,13 +1855,13 @@ func restoreClaudeNormalizedToolNamesInResponse(body []byte, originalByNormalize
 			name := part.Get("name").String()
 			if originalName, ok := renamedToolName(name, originalByNormalized); ok {
 				path := fmt.Sprintf("content.%d.name", index.Int())
-				body, _ = sjson.SetBytes(body, path, originalName)
+				body = setClaudeRestoredToolName(body, path, originalName)
 			}
 		case "tool_reference":
 			toolName := part.Get("tool_name").String()
 			if originalName, ok := renamedToolName(toolName, originalByNormalized); ok {
 				path := fmt.Sprintf("content.%d.tool_name", index.Int())
-				body, _ = sjson.SetBytes(body, path, originalName)
+				body = setClaudeRestoredToolName(body, path, originalName)
 			}
 		case "tool_result":
 			nestedContent := part.Get("content")
@@ -1873,7 +1873,7 @@ func restoreClaudeNormalizedToolNamesInResponse(body []byte, originalByNormalize
 					nestedToolName := nestedPart.Get("tool_name").String()
 					if originalName, ok := renamedToolName(nestedToolName, originalByNormalized); ok {
 						nestedPath := fmt.Sprintf("content.%d.content.%d.tool_name", index.Int(), nestedIndex.Int())
-						body, _ = sjson.SetBytes(body, nestedPath, originalName)
+						body = setClaudeRestoredToolName(body, nestedPath, originalName)
 					}
 					return true
 				})
@@ -1882,6 +1882,15 @@ func restoreClaudeNormalizedToolNamesInResponse(body []byte, originalByNormalize
 		return true
 	})
 	return body
+}
+
+func setClaudeRestoredToolName(body []byte, path, originalName string) []byte {
+	updatedBody, err := sjson.SetBytes(body, path, originalName)
+	if err != nil {
+		log.WithError(err).WithField("path", path).Warn("failed to restore Claude tool name")
+		return body
+	}
+	return updatedBody
 }
 
 func restoreClaudeNormalizedToolNamesInStreamLine(line []byte, originalByNormalized map[string]string) []byte {
@@ -1943,7 +1952,12 @@ func restoreClaudeToolNamesInErrorBody(body []byte, prefix string, originalByNor
 		}
 		updated := restoreClaudeToolNamesInErrorText(value.String(), prefix, originalByNormalized)
 		if updated != value.String() {
-			body, _ = sjson.SetBytes(body, path, updated)
+			updatedBody, err := sjson.SetBytes(body, path, updated)
+			if err != nil {
+				log.WithError(err).WithField("path", path).Warn("failed to restore Claude tool name in error body")
+				continue
+			}
+			body = updatedBody
 		}
 	}
 	return body

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -8,9 +8,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -190,11 +193,17 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	var extraBetas []string
 	extraBetas, body = extractAndRemoveBetas(body)
 	bodyForTranslation := body
-	bodyForUpstream := body
+	bodyForUpstream, originalToolNames, errNormalize := normalizeClaudeToolsForAnthropicWithRestoreMap(bytes.Clone(body))
+	if errNormalize != nil {
+		if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) || errors.Is(errNormalize, errAnthropicDuplicateToolName) {
+			return resp, statusErr{code: http.StatusBadRequest, msg: errNormalize.Error()}
+		}
+		return resp, fmt.Errorf("normalize claude tools: %w", errNormalize)
+	}
 	oauthToken := isClaudeOAuthToken(apiKey)
 	oauthToolNamesRemapped := false
 	if oauthToken && !auth.ToolPrefixDisabled() {
-		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
+		bodyForUpstream = applyClaudeToolPrefix(bodyForUpstream, claudeToolPrefix)
 	}
 	// Remap third-party tool names to Claude Code equivalents and remove
 	// tools without official counterparts. This prevents Anthropic from
@@ -209,6 +218,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
+	logClaudePayloadDiagnostics(ctx, "messages", baseModel, bodyForUpstream)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
 	if err != nil {
 		return resp, err
@@ -257,6 +267,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 			helps.LogWithRequestID(ctx).Warn(msg)
 			b = []byte(msg)
 		}
+		b = restoreClaudeToolNamesInErrorBody(b, claudeToolPrefix, originalToolNames)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
 		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
@@ -301,13 +312,14 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if isClaudeOAuthToken(apiKey) && oauthToolNamesRemapped {
 		data = reverseRemapOAuthToolNames(data)
 	}
+	data = restoreClaudeNormalizedToolNamesInResponse(data, originalToolNames)
 	var param any
 	out := sdktranslator.TranslateNonStream(
 		ctx,
 		to,
 		from,
 		req.Model,
-		opts.OriginalRequest,
+		claudeOriginalRequestForTranslation(opts.OriginalRequest, req.Payload),
 		bodyForTranslation,
 		data,
 		&param,
@@ -373,11 +385,17 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	var extraBetas []string
 	extraBetas, body = extractAndRemoveBetas(body)
 	bodyForTranslation := body
-	bodyForUpstream := body
+	bodyForUpstream, originalToolNames, errNormalize := normalizeClaudeToolsForAnthropicWithRestoreMap(bytes.Clone(body))
+	if errNormalize != nil {
+		if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) || errors.Is(errNormalize, errAnthropicDuplicateToolName) {
+			return nil, statusErr{code: http.StatusBadRequest, msg: errNormalize.Error()}
+		}
+		return nil, fmt.Errorf("normalize claude tools: %w", errNormalize)
+	}
 	oauthToken := isClaudeOAuthToken(apiKey)
 	oauthToolNamesRemapped := false
 	if oauthToken && !auth.ToolPrefixDisabled() {
-		bodyForUpstream = applyClaudeToolPrefix(body, claudeToolPrefix)
+		bodyForUpstream = applyClaudeToolPrefix(bodyForUpstream, claudeToolPrefix)
 	}
 	// Remap third-party tool names to Claude Code equivalents and remove
 	// tools without official counterparts. This prevents Anthropic from
@@ -391,6 +409,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	}
 
 	url := fmt.Sprintf("%s/v1/messages?beta=true", baseURL)
+	logClaudePayloadDiagnostics(ctx, "messages_stream", baseModel, bodyForUpstream)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyForUpstream))
 	if err != nil {
 		return nil, err
@@ -439,6 +458,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			helps.LogWithRequestID(ctx).Warn(msg)
 			b = []byte(msg)
 		}
+		b = restoreClaudeToolNamesInErrorBody(b, claudeToolPrefix, originalToolNames)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
 		if errClose := errBody.Close(); errClose != nil {
@@ -480,6 +500,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				if isClaudeOAuthToken(apiKey) && oauthToolNamesRemapped {
 					line = reverseRemapOAuthToolNamesFromStreamLine(line)
 				}
+				line = restoreClaudeNormalizedToolNamesInStreamLine(line, originalToolNames)
 				// Forward the line as-is to preserve SSE format
 				cloned := make([]byte, len(line)+1)
 				copy(cloned, line)
@@ -510,12 +531,13 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			if isClaudeOAuthToken(apiKey) && oauthToolNamesRemapped {
 				line = reverseRemapOAuthToolNamesFromStreamLine(line)
 			}
+			line = restoreClaudeNormalizedToolNamesInStreamLine(line, originalToolNames)
 			chunks := sdktranslator.TranslateStream(
 				ctx,
 				to,
 				from,
 				req.Model,
-				opts.OriginalRequest,
+				claudeOriginalRequestForTranslation(opts.OriginalRequest, req.Payload),
 				bodyForTranslation,
 				bytes.Clone(line),
 				&param,
@@ -548,6 +570,12 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 
+	body, errThink := thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	if errThink != nil {
+		return cliproxyexecutor.Response{}, errThink
+	}
+	body = disableThinkingIfToolChoiceForced(body)
+
 	if !strings.HasPrefix(baseModel, "claude-3-5-haiku") {
 		body = checkSystemInstructions(body)
 	}
@@ -559,6 +587,13 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	// Extract betas from body and convert to header (for count_tokens too)
 	var extraBetas []string
 	extraBetas, body = extractAndRemoveBetas(body)
+	body, originalToolNames, errNormalize := normalizeClaudeToolsForAnthropicWithRestoreMap(body)
+	if errNormalize != nil {
+		if errors.Is(errNormalize, errAnthropicToolNameUnsanitizable) || errors.Is(errNormalize, errAnthropicDuplicateToolName) {
+			return cliproxyexecutor.Response{}, statusErr{code: http.StatusBadRequest, msg: errNormalize.Error()}
+		}
+		return cliproxyexecutor.Response{}, fmt.Errorf("normalize claude tools: %w", errNormalize)
+	}
 	if isClaudeOAuthToken(apiKey) && !auth.ToolPrefixDisabled() {
 		body = applyClaudeToolPrefix(body, claudeToolPrefix)
 	}
@@ -566,8 +601,10 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	if isClaudeOAuthToken(apiKey) {
 		body, _ = remapOAuthToolNames(body)
 	}
+	body = sanitizeClaudeCountTokensPayload(body)
 
 	url := fmt.Sprintf("%s/v1/messages/count_tokens?beta=true", baseURL)
+	logClaudePayloadDiagnostics(ctx, "count_tokens", baseModel, body)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
@@ -616,6 +653,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 			helps.LogWithRequestID(ctx).Warn(msg)
 			b = []byte(msg)
 		}
+		b = restoreClaudeToolNamesInErrorBody(b, claudeToolPrefix, originalToolNames)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
@@ -1202,6 +1240,746 @@ func reverseRemapOAuthToolNamesFromStreamLine(line []byte) []byte {
 		return append([]byte("data: "), updated...)
 	}
 	return updated
+}
+
+const (
+	claudePayloadDiagnosticsLargeBodyBytes  = 512 * 1024
+	claudePayloadDiagnosticsLargeImageBytes = 128 * 1024
+)
+
+type claudePayloadDiagnostics struct {
+	BodyBytes         int
+	JSONValid         bool
+	Messages          int
+	SystemBytes       int
+	Tools             int
+	ToolBytes         int
+	MaxToolBytes      int
+	ToolSchemaBytes   int
+	MaxToolSchemaSize int
+	TextBlocks        int
+	TextBytes         int
+	MaxTextBytes      int
+	ImageBlocks       int
+	Base64ImageBlocks int
+	ImageDataBytes    int
+	MaxImageDataBytes int
+	DataImageRefs     int
+	Base64Markers     int
+	CacheControlNodes int
+}
+
+func sanitizeClaudeCountTokensPayload(body []byte) []byte {
+	for _, path := range []string{"max_tokens", "maxTokens", "stream"} {
+		var err error
+		body, err = sjson.DeleteBytes(body, path)
+		if err != nil {
+			continue
+		}
+	}
+	return body
+}
+
+func logClaudePayloadDiagnostics(ctx context.Context, endpoint, model string, body []byte) {
+	diagnostics := buildClaudePayloadDiagnostics(body)
+	if !diagnostics.ShouldLog() {
+		return
+	}
+
+	helps.LogWithRequestID(ctx).WithFields(log.Fields{
+		"endpoint":              endpoint,
+		"model":                 model,
+		"body_bytes":            diagnostics.BodyBytes,
+		"json_valid":            diagnostics.JSONValid,
+		"messages":              diagnostics.Messages,
+		"system_bytes":          diagnostics.SystemBytes,
+		"tools":                 diagnostics.Tools,
+		"tool_bytes":            diagnostics.ToolBytes,
+		"max_tool_bytes":        diagnostics.MaxToolBytes,
+		"tool_schema_bytes":     diagnostics.ToolSchemaBytes,
+		"max_tool_schema_bytes": diagnostics.MaxToolSchemaSize,
+		"text_blocks":           diagnostics.TextBlocks,
+		"text_bytes":            diagnostics.TextBytes,
+		"max_text_bytes":        diagnostics.MaxTextBytes,
+		"image_blocks":          diagnostics.ImageBlocks,
+		"base64_image_blocks":   diagnostics.Base64ImageBlocks,
+		"image_data_bytes":      diagnostics.ImageDataBytes,
+		"max_image_data_bytes":  diagnostics.MaxImageDataBytes,
+		"data_image_refs":       diagnostics.DataImageRefs,
+		"base64_markers":        diagnostics.Base64Markers,
+		"cache_control_nodes":   diagnostics.CacheControlNodes,
+	}).Warn("claude payload diagnostics: large or image-containing upstream request")
+}
+
+func (d claudePayloadDiagnostics) ShouldLog() bool {
+	return d.BodyBytes >= claudePayloadDiagnosticsLargeBodyBytes ||
+		d.ImageBlocks > 0 ||
+		d.DataImageRefs > 0 ||
+		d.ImageDataBytes >= claudePayloadDiagnosticsLargeImageBytes ||
+		d.MaxTextBytes >= claudePayloadDiagnosticsLargeBodyBytes ||
+		d.MaxToolBytes >= claudePayloadDiagnosticsLargeBodyBytes
+}
+
+func buildClaudePayloadDiagnostics(body []byte) claudePayloadDiagnostics {
+	diagnostics := claudePayloadDiagnostics{
+		BodyBytes:         len(body),
+		DataImageRefs:     bytes.Count(body, []byte("data:image")),
+		Base64Markers:     bytes.Count(body, []byte("base64")),
+		CacheControlNodes: bytes.Count(body, []byte(`"cache_control"`)),
+	}
+	if !gjson.ValidBytes(body) {
+		return diagnostics
+	}
+
+	diagnostics.JSONValid = true
+	root := gjson.ParseBytes(body)
+	if system := root.Get("system"); system.Exists() {
+		diagnostics.SystemBytes = len(system.Raw)
+	}
+
+	messages := root.Get("messages")
+	if messages.IsArray() {
+		messageItems := messages.Array()
+		diagnostics.Messages = len(messageItems)
+		for _, message := range messageItems {
+			addClaudeContentDiagnostics(message.Get("content"), &diagnostics)
+		}
+	}
+
+	tools := root.Get("tools")
+	if tools.IsArray() {
+		toolItems := tools.Array()
+		diagnostics.Tools = len(toolItems)
+		for _, tool := range toolItems {
+			toolBytes := len(tool.Raw)
+			diagnostics.ToolBytes += toolBytes
+			if toolBytes > diagnostics.MaxToolBytes {
+				diagnostics.MaxToolBytes = toolBytes
+			}
+			addClaudeToolSchemaDiagnostics(tool, &diagnostics)
+		}
+	}
+
+	return diagnostics
+}
+
+func addClaudeToolSchemaDiagnostics(tool gjson.Result, diagnostics *claudePayloadDiagnostics) {
+	for _, path := range []string{
+		"input_schema",
+		"parameters",
+		"parametersJsonSchema",
+		"function.parameters",
+		"function.parametersJsonSchema",
+	} {
+		schema := tool.Get(path)
+		if !schema.Exists() {
+			continue
+		}
+		schemaBytes := len(schema.Raw)
+		diagnostics.ToolSchemaBytes += schemaBytes
+		if schemaBytes > diagnostics.MaxToolSchemaSize {
+			diagnostics.MaxToolSchemaSize = schemaBytes
+		}
+		return
+	}
+}
+
+func addClaudeContentDiagnostics(content gjson.Result, diagnostics *claudePayloadDiagnostics) {
+	if !content.Exists() {
+		return
+	}
+	if content.Type == gjson.String {
+		addClaudeTextDiagnostics(content.String(), diagnostics)
+		return
+	}
+	if content.IsArray() {
+		for _, part := range content.Array() {
+			addClaudeContentPartDiagnostics(part, diagnostics)
+		}
+		return
+	}
+	if content.IsObject() {
+		addClaudeContentPartDiagnostics(content, diagnostics)
+	}
+}
+
+func addClaudeContentPartDiagnostics(part gjson.Result, diagnostics *claudePayloadDiagnostics) {
+	switch strings.TrimSpace(part.Get("type").String()) {
+	case "text":
+		addClaudeTextDiagnostics(part.Get("text").String(), diagnostics)
+	case "image":
+		diagnostics.ImageBlocks++
+		source := part.Get("source")
+		if strings.EqualFold(strings.TrimSpace(source.Get("type").String()), "base64") {
+			diagnostics.Base64ImageBlocks++
+		}
+		imageData := source.Get("data")
+		if imageData.Exists() && imageData.Type == gjson.String {
+			imageBytes := len(imageData.String())
+			diagnostics.ImageDataBytes += imageBytes
+			if imageBytes > diagnostics.MaxImageDataBytes {
+				diagnostics.MaxImageDataBytes = imageBytes
+			}
+		}
+	default:
+		if text := part.Get("text"); text.Exists() && text.Type == gjson.String {
+			addClaudeTextDiagnostics(text.String(), diagnostics)
+		}
+	}
+
+	if nested := part.Get("content"); nested.Exists() {
+		addClaudeContentDiagnostics(nested, diagnostics)
+	}
+	if url := part.Get("image_url.url"); url.Exists() && strings.HasPrefix(url.String(), "data:image") {
+		diagnostics.DataImageRefs++
+	}
+}
+
+func addClaudeTextDiagnostics(text string, diagnostics *claudePayloadDiagnostics) {
+	if text == "" {
+		return
+	}
+	textBytes := len(text)
+	diagnostics.TextBlocks++
+	diagnostics.TextBytes += textBytes
+	if textBytes > diagnostics.MaxTextBytes {
+		diagnostics.MaxTextBytes = textBytes
+	}
+}
+
+func isClaudeBuiltinToolType(toolType string) bool {
+	toolType = strings.TrimSpace(toolType)
+	switch {
+	case strings.HasPrefix(toolType, "web_search"):
+		return true
+	case toolType == "code_execution":
+		return true
+	case strings.HasPrefix(toolType, "text_editor"):
+		return true
+	case strings.HasPrefix(toolType, "computer"):
+		return true
+	default:
+		return false
+	}
+}
+
+func isClaudeBuiltinTool(tool gjson.Result) bool {
+	return isClaudeBuiltinToolType(tool.Get("type").String())
+}
+
+func isClaudeExplicitNonCustomTypedTool(tool gjson.Result) bool {
+	toolType := strings.TrimSpace(tool.Get("type").String())
+	return toolType != "" && toolType != "custom" && toolType != "function" && !isClaudeBuiltinToolType(toolType)
+}
+
+func normalizeAnthropicToolSchema(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" || !gjson.Valid(raw) || !gjson.Parse(raw).IsObject() {
+		return `{"type":"object","properties":{}}`
+	}
+
+	schema := raw
+	parsed := gjson.Parse(raw)
+	schemaType := strings.TrimSpace(parsed.Get("type").String())
+	if schemaType == "" {
+		var err error
+		schema, err = sjson.Set(schema, "type", "object")
+		if err != nil {
+			return `{"type":"object","properties":{}}`
+		}
+	} else if schemaType != "object" {
+		return `{"type":"object","properties":{}}`
+	}
+
+	parsed = gjson.Parse(schema)
+	properties := parsed.Get("properties")
+	if !properties.Exists() || !properties.IsObject() {
+		var err error
+		schema, err = sjson.SetRaw(schema, "properties", `{}`)
+		if err != nil {
+			return `{"type":"object","properties":{}}`
+		}
+	}
+	return schema
+}
+
+func sanitizeAnthropicToolName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(len(name))
+	for i := 0; i < len(name); i++ {
+		ch := name[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' {
+			b.WriteByte(ch)
+			continue
+		}
+		b.WriteByte('_')
+	}
+
+	clean := strings.Trim(b.String(), "_-")
+	if clean == "" {
+		return ""
+	}
+	if len(clean) > 64 {
+		clean = clean[:64]
+	}
+	return clean
+}
+
+const maxToolNameCollisionRetries = 1000
+
+func uniqueAnthropicToolName(name string, used map[string]struct{}) string {
+	clean := sanitizeAnthropicToolName(name)
+	if clean == "" {
+		return ""
+	}
+	if _, exists := used[clean]; !exists {
+		used[clean] = struct{}{}
+		return clean
+	}
+	for i := 2; i < maxToolNameCollisionRetries; i++ {
+		suffix := fmt.Sprintf("_%d", i)
+		baseLimit := 64 - len(suffix)
+		if baseLimit < 1 {
+			return ""
+		}
+		base := clean
+		if len(base) > baseLimit {
+			base = base[:baseLimit]
+		}
+		candidate := base + suffix
+		if _, exists := used[candidate]; !exists {
+			used[candidate] = struct{}{}
+			return candidate
+		}
+	}
+	return ""
+}
+
+func reservedClaudeBuiltinToolNames() map[string]struct{} {
+	reserved := make(map[string]struct{})
+	for _, name := range []string{"web_search", "code_execution", "text_editor", "computer"} {
+		reserved[name] = struct{}{}
+	}
+	return reserved
+}
+
+func normalizeClaudeToolsForAnthropic(body []byte) ([]byte, error) {
+	normalizedBody, _, err := normalizeClaudeToolsForAnthropicWithRestoreMap(body)
+	return normalizedBody, err
+}
+
+func normalizeClaudeToolsForAnthropicWithRestoreMap(body []byte) ([]byte, map[string]string, error) {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return body, nil, nil
+	}
+
+	normalizedTools := make([]json.RawMessage, 0, len(tools.Array()))
+	renameMap := make(map[string]string)
+	originalNameCounts := make(map[string]int)
+	usedNames := reservedClaudeBuiltinToolNames()
+	for _, tool := range tools.Array() {
+		name := anthroToolOriginalName(tool)
+		if name == "" {
+			continue
+		}
+		originalNameCounts[name]++
+	}
+
+	for _, tool := range tools.Array() {
+		if anthroToolOriginalName(tool) == "" && !isClaudeBuiltinTool(tool) && !isClaudeExplicitNonCustomTypedTool(tool) {
+			log.Warnf("claude tool normalization: skipping tool with no name or recognized type: %s", tool.Raw)
+			continue
+		}
+
+		if isClaudeBuiltinTool(tool) {
+			normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
+			reserveToolNameVariants(usedNames, strings.TrimSpace(tool.Get("name").String()))
+			continue
+		}
+
+		if isClaudeExplicitNonCustomTypedTool(tool) {
+			normalizedTools = append(normalizedTools, json.RawMessage(tool.Raw))
+			reserveToolNameVariants(usedNames, anthroToolOriginalName(tool))
+			continue
+		}
+
+		originalName := anthroToolOriginalName(tool)
+		if originalName != "" && originalNameCounts[originalName] > 1 {
+			return body, nil, fmt.Errorf("%w: custom tool name %q appears multiple times and cannot be remapped safely", errAnthropicDuplicateToolName, originalName)
+		}
+
+		normalizedTool, originalName, newName, errNormalize := normalizeAnthropicToolEntry(tool, usedNames)
+		if errNormalize != nil {
+			return body, nil, errNormalize
+		}
+		normalizedTools = append(normalizedTools, json.RawMessage(normalizedTool))
+		if originalName != "" && originalName != newName {
+			renameMap[originalName] = newName
+		}
+	}
+
+	skippedCount := len(tools.Array()) - len(normalizedTools)
+	if skippedCount > 0 {
+		log.Warnf("claude tool normalization: %d of %d tools skipped (no name or recognized type)", skippedCount, len(tools.Array()))
+	}
+
+	normalizedToolsJSON, errMarshal := json.Marshal(normalizedTools)
+	if errMarshal != nil {
+		return body, nil, fmt.Errorf("marshal normalized tools array: %w", errMarshal)
+	}
+	updatedBody, errSet := sjson.SetRawBytes(body, "tools", normalizedToolsJSON)
+	if errSet != nil {
+		return body, nil, fmt.Errorf("set normalized tools array: %w", errSet)
+	}
+	body = updatedBody
+
+	body, errSet = applyClaudeRenameMap(body, renameMap)
+	if errSet != nil {
+		return body, nil, errSet
+	}
+	return body, invertClaudeToolRenameMap(renameMap), nil
+}
+
+func invertClaudeToolRenameMap(renameMap map[string]string) map[string]string {
+	if len(renameMap) == 0 {
+		return nil
+	}
+	originalByNormalized := make(map[string]string, len(renameMap))
+	for originalName, normalizedName := range renameMap {
+		originalByNormalized[normalizedName] = originalName
+	}
+	return originalByNormalized
+}
+
+func anthroToolOriginalName(tool gjson.Result) string {
+	name := strings.TrimSpace(tool.Get("name").String())
+	if name == "" {
+		name = strings.TrimSpace(tool.Get("function.name").String())
+	}
+	return name
+}
+
+var errAnthropicToolNameUnsanitizable = errors.New("anthropic tool name unsanitizable")
+var errAnthropicDuplicateToolName = errors.New("anthropic duplicate tool name")
+
+func normalizeAnthropicToolEntry(tool gjson.Result, usedNames map[string]struct{}) (normalizedRaw string, originalName string, newName string, err error) {
+	originalName = anthroToolOriginalName(tool)
+	newName = uniqueAnthropicToolName(originalName, usedNames)
+	if newName == "" {
+		return "", originalName, "", fmt.Errorf("%w: custom tool name %q cannot be sanitized into a valid Anthropic tool name", errAnthropicToolNameUnsanitizable, originalName)
+	}
+
+	description := strings.TrimSpace(tool.Get("description").String())
+	if description == "" {
+		description = strings.TrimSpace(tool.Get("function.description").String())
+	}
+	if description == "" {
+		description = "Custom tool"
+	}
+
+	schemaRaw := ""
+	schemaPaths := []string{
+		"input_schema",
+		"parameters",
+		"parametersJsonSchema",
+		"function.parameters",
+		"function.parametersJsonSchema",
+	}
+	for _, path := range schemaPaths {
+		if v := tool.Get(path); v.Exists() {
+			schemaRaw = v.Raw
+			break
+		}
+	}
+	schema := normalizeAnthropicToolSchema(schemaRaw)
+
+	normalized := `{"name":"","description":"","input_schema":{}}`
+	normalized, err = sjson.Set(normalized, "name", newName)
+	if err != nil {
+		return "", originalName, newName, fmt.Errorf("set normalized tool name: %w", err)
+	}
+	normalized, err = sjson.Set(normalized, "description", description)
+	if err != nil {
+		return "", originalName, newName, fmt.Errorf("set normalized tool description: %w", err)
+	}
+	normalized, err = sjson.SetRaw(normalized, "input_schema", schema)
+	if err != nil {
+		return "", originalName, newName, fmt.Errorf("set normalized tool schema: %w", err)
+	}
+	normalized, err = copyAnthropicCustomToolMetadata(normalized, tool)
+	if err != nil {
+		return "", originalName, newName, err
+	}
+	return normalized, originalName, newName, nil
+}
+
+func copyAnthropicCustomToolMetadata(normalized string, original gjson.Result) (string, error) {
+	for _, field := range []string{"cache_control", "input_examples", "strict"} {
+		value := original.Get(field)
+		if !value.Exists() {
+			continue
+		}
+		var err error
+		normalized, err = sjson.SetRaw(normalized, field, value.Raw)
+		if err != nil {
+			return normalized, fmt.Errorf("set normalized tool %s: %w", field, err)
+		}
+	}
+	return normalized, nil
+}
+
+func reserveToolNameVariants(used map[string]struct{}, name string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	used[name] = struct{}{}
+	if sanitized := sanitizeAnthropicToolName(name); sanitized != "" {
+		used[sanitized] = struct{}{}
+	}
+}
+
+func renamedToolName(name string, renameMap map[string]string) (string, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false
+	}
+	mapped, ok := renameMap[name]
+	return mapped, ok
+}
+
+func applyClaudeRenameMap(body []byte, renameMap map[string]string) ([]byte, error) {
+	if len(renameMap) == 0 {
+		return body, nil
+	}
+
+	if gjson.GetBytes(body, "tool_choice.type").String() == "tool" {
+		if mapped, ok := renamedToolName(gjson.GetBytes(body, "tool_choice.name").String(), renameMap); ok {
+			updatedBody, err := sjson.SetBytes(body, "tool_choice.name", mapped)
+			if err != nil {
+				return body, fmt.Errorf("set tool_choice.name: %w", err)
+			}
+			body = updatedBody
+		}
+	}
+
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body, nil
+	}
+
+	messagesRaw := messages.Raw
+	messagesChanged := false
+	for msgIndex, msg := range messages.Array() {
+		content := msg.Get("content")
+		if !content.Exists() || !content.IsArray() {
+			continue
+		}
+		for contentIndex, part := range content.Array() {
+			switch part.Get("type").String() {
+			case "tool_use":
+				if mapped, ok := renamedToolName(part.Get("name").String(), renameMap); ok {
+					path := fmt.Sprintf("%d.content.%d.name", msgIndex, contentIndex)
+					updatedMessages, err := sjson.Set(messagesRaw, path, mapped)
+					if err != nil {
+						return body, fmt.Errorf("set %s: %w", path, err)
+					}
+					messagesRaw = updatedMessages
+					messagesChanged = true
+				}
+			case "tool_reference":
+				if mapped, ok := renamedToolName(part.Get("tool_name").String(), renameMap); ok {
+					path := fmt.Sprintf("%d.content.%d.tool_name", msgIndex, contentIndex)
+					updatedMessages, err := sjson.Set(messagesRaw, path, mapped)
+					if err != nil {
+						return body, fmt.Errorf("set %s: %w", path, err)
+					}
+					messagesRaw = updatedMessages
+					messagesChanged = true
+				}
+			case "tool_result":
+				nestedContent := part.Get("content")
+				if !nestedContent.Exists() || !nestedContent.IsArray() {
+					continue
+				}
+				for nestedIndex, nestedPart := range nestedContent.Array() {
+					if nestedPart.Get("type").String() != "tool_reference" {
+						continue
+					}
+					if mapped, ok := renamedToolName(nestedPart.Get("tool_name").String(), renameMap); ok {
+						path := fmt.Sprintf("%d.content.%d.content.%d.tool_name", msgIndex, contentIndex, nestedIndex)
+						updatedMessages, err := sjson.Set(messagesRaw, path, mapped)
+						if err != nil {
+							return body, fmt.Errorf("set %s: %w", path, err)
+						}
+						messagesRaw = updatedMessages
+						messagesChanged = true
+					}
+				}
+			}
+		}
+	}
+	if !messagesChanged {
+		return body, nil
+	}
+	updatedBody, err := sjson.SetRawBytes(body, "messages", []byte(messagesRaw))
+	if err != nil {
+		return body, fmt.Errorf("set messages: %w", err)
+	}
+	return updatedBody, nil
+}
+
+func restoreClaudeNormalizedToolNamesInResponse(body []byte, originalByNormalized map[string]string) []byte {
+	if len(originalByNormalized) == 0 {
+		return body
+	}
+	content := gjson.GetBytes(body, "content")
+	if !content.Exists() || !content.IsArray() {
+		return body
+	}
+	content.ForEach(func(index, part gjson.Result) bool {
+		partType := part.Get("type").String()
+		switch partType {
+		case "tool_use":
+			name := part.Get("name").String()
+			if originalName, ok := renamedToolName(name, originalByNormalized); ok {
+				path := fmt.Sprintf("content.%d.name", index.Int())
+				body, _ = sjson.SetBytes(body, path, originalName)
+			}
+		case "tool_reference":
+			toolName := part.Get("tool_name").String()
+			if originalName, ok := renamedToolName(toolName, originalByNormalized); ok {
+				path := fmt.Sprintf("content.%d.tool_name", index.Int())
+				body, _ = sjson.SetBytes(body, path, originalName)
+			}
+		case "tool_result":
+			nestedContent := part.Get("content")
+			if nestedContent.Exists() && nestedContent.IsArray() {
+				nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
+					if nestedPart.Get("type").String() != "tool_reference" {
+						return true
+					}
+					nestedToolName := nestedPart.Get("tool_name").String()
+					if originalName, ok := renamedToolName(nestedToolName, originalByNormalized); ok {
+						nestedPath := fmt.Sprintf("content.%d.content.%d.tool_name", index.Int(), nestedIndex.Int())
+						body, _ = sjson.SetBytes(body, nestedPath, originalName)
+					}
+					return true
+				})
+			}
+		}
+		return true
+	})
+	return body
+}
+
+func restoreClaudeNormalizedToolNamesInStreamLine(line []byte, originalByNormalized map[string]string) []byte {
+	if len(originalByNormalized) == 0 {
+		return line
+	}
+	payload := helps.JSONPayload(line)
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return line
+	}
+	contentBlock := gjson.GetBytes(payload, "content_block")
+	if !contentBlock.Exists() {
+		return line
+	}
+
+	blockType := contentBlock.Get("type").String()
+	var updated []byte
+	var err error
+	switch blockType {
+	case "tool_use":
+		name := contentBlock.Get("name").String()
+		originalName, ok := renamedToolName(name, originalByNormalized)
+		if !ok {
+			return line
+		}
+		updated, err = sjson.SetBytes(payload, "content_block.name", originalName)
+		if err != nil {
+			return line
+		}
+	case "tool_reference":
+		toolName := contentBlock.Get("tool_name").String()
+		originalName, ok := renamedToolName(toolName, originalByNormalized)
+		if !ok {
+			return line
+		}
+		updated, err = sjson.SetBytes(payload, "content_block.tool_name", originalName)
+		if err != nil {
+			return line
+		}
+	default:
+		return line
+	}
+
+	trimmed := bytes.TrimSpace(line)
+	if bytes.HasPrefix(trimmed, []byte("data:")) {
+		return append([]byte("data: "), updated...)
+	}
+	return updated
+}
+
+func restoreClaudeToolNamesInErrorBody(body []byte, prefix string, originalByNormalized map[string]string) []byte {
+	if len(originalByNormalized) == 0 || !gjson.ValidBytes(body) {
+		return body
+	}
+	for _, path := range []string{"error.message", "message"} {
+		value := gjson.GetBytes(body, path)
+		if !value.Exists() || value.Type != gjson.String {
+			continue
+		}
+		updated := restoreClaudeToolNamesInErrorText(value.String(), prefix, originalByNormalized)
+		if updated != value.String() {
+			body, _ = sjson.SetBytes(body, path, updated)
+		}
+	}
+	return body
+}
+
+func restoreClaudeToolNamesInErrorText(text, prefix string, originalByNormalized map[string]string) string {
+	if text == "" || len(originalByNormalized) == 0 {
+		return text
+	}
+	type replacement struct {
+		from string
+		to   string
+	}
+	replacements := make([]replacement, 0, len(originalByNormalized)*2)
+	for normalized, original := range originalByNormalized {
+		if normalized == "" || original == "" {
+			continue
+		}
+		if prefix != "" {
+			replacements = append(replacements, replacement{from: prefix + normalized, to: original})
+		}
+		replacements = append(replacements, replacement{from: normalized, to: original})
+	}
+	sort.SliceStable(replacements, func(i, j int) bool {
+		return len(replacements[i].from) > len(replacements[j].from)
+	})
+	replacerArgs := make([]string, 0, len(replacements)*2)
+	for _, replacement := range replacements {
+		replacerArgs = append(replacerArgs, replacement.from, replacement.to)
+	}
+	if len(replacerArgs) == 0 {
+		return text
+	}
+	return strings.NewReplacer(replacerArgs...).Replace(text)
+}
+
+func claudeOriginalRequestForTranslation(originalRequest, payload []byte) []byte {
+	if len(originalRequest) > 0 {
+		return originalRequest
+	}
+	return payload
 }
 
 func applyClaudeToolPrefix(body []byte, prefix string) []byte {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1591,9 +1591,14 @@ func normalizeClaudeToolsForAnthropicWithRestoreMap(body []byte) ([]byte, map[st
 		originalNameCounts[name]++
 	}
 
-	for _, tool := range tools.Array() {
+	for toolIndex, tool := range tools.Array() {
 		if anthroToolOriginalName(tool) == "" && !isClaudeBuiltinTool(tool) && !isClaudeExplicitNonCustomTypedTool(tool) {
-			log.Warnf("claude tool normalization: skipping tool with no name or recognized type: %s", tool.Raw)
+			log.Warnf(
+				"claude tool normalization: skipping tool with no name or recognized type (index=%d type=%q has_function_name=%t)",
+				toolIndex,
+				strings.TrimSpace(tool.Get("type").String()),
+				strings.TrimSpace(tool.Get("function.name").String()) != "",
+			)
 			continue
 		}
 
@@ -1720,7 +1725,7 @@ func normalizeAnthropicToolEntry(tool gjson.Result, usedNames map[string]struct{
 }
 
 func copyAnthropicCustomToolMetadata(normalized string, original gjson.Result) (string, error) {
-	for _, field := range []string{"cache_control", "input_examples", "strict"} {
+	for _, field := range []string{"cache_control", "input_examples"} {
 		value := original.Get(field)
 		if !value.Exists() {
 			continue

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2029,7 +2029,7 @@ func TestRemapOAuthToolNames_Lowercase_ReverseApplied(t *testing.T) {
 }
 
 func TestNormalizeClaudeToolsForAnthropic_CustomToolDefaultSchema(t *testing.T) {
-	body := []byte(`{"tools":[{"type":"custom","name":"apply.patch","description":"Patch edit","format":{"type":"grammar"}},{"type":"web_search_20250305","name":"web_search"}],"tool_choice":{"type":"tool","name":"apply.patch"},"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"apply.patch","input":{}}]}]}`)
+	body := []byte(`{"tools":[{"type":"custom","name":"apply.patch","description":"Patch edit","format":{"type":"grammar"},"strict":true},{"type":"web_search_20250305","name":"web_search"}],"tool_choice":{"type":"tool","name":"apply.patch"},"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"apply.patch","input":{}}]}]}`)
 
 	out, restoreMap, err := normalizeClaudeToolsForAnthropicWithRestoreMap(body)
 	if err != nil {
@@ -2043,6 +2043,9 @@ func TestNormalizeClaudeToolsForAnthropic_CustomToolDefaultSchema(t *testing.T) 
 	}
 	if gjson.GetBytes(out, "tools.0.format").Exists() {
 		t.Fatalf("tools.0.format should be removed for custom tools")
+	}
+	if gjson.GetBytes(out, "tools.0.strict").Exists() {
+		t.Fatalf("tools.0.strict should be removed for custom tools")
 	}
 	if got := gjson.GetBytes(out, "tools.0.input_schema.type").String(); got != "object" {
 		t.Fatalf("tools.0.input_schema.type = %q, want object", got)

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2027,3 +2027,173 @@ func TestRemapOAuthToolNames_Lowercase_ReverseApplied(t *testing.T) {
 		t.Fatalf("content.0.name = %q, want %q", got, "bash")
 	}
 }
+
+func TestNormalizeClaudeToolsForAnthropic_CustomToolDefaultSchema(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"custom","name":"apply.patch","description":"Patch edit","format":{"type":"grammar"}},{"type":"web_search_20250305","name":"web_search"}],"tool_choice":{"type":"tool","name":"apply.patch"},"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"apply.patch","input":{}}]}]}`)
+
+	out, restoreMap, err := normalizeClaudeToolsForAnthropicWithRestoreMap(body)
+	if err != nil {
+		t.Fatalf("normalizeClaudeToolsForAnthropicWithRestoreMap() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "apply_patch" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "apply_patch")
+	}
+	if gjson.GetBytes(out, "tools.0.type").Exists() {
+		t.Fatalf("tools.0.type should be removed for custom tools")
+	}
+	if gjson.GetBytes(out, "tools.0.format").Exists() {
+		t.Fatalf("tools.0.format should be removed for custom tools")
+	}
+	if got := gjson.GetBytes(out, "tools.0.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.0.input_schema.type = %q, want object", got)
+	}
+	if !gjson.GetBytes(out, "tools.0.input_schema.properties").IsObject() {
+		t.Fatalf("tools.0.input_schema.properties should be an object")
+	}
+	if got := gjson.GetBytes(out, "tools.1.type").String(); got != "web_search_20250305" {
+		t.Fatalf("tools.1.type = %q, want web_search_20250305", got)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "apply_patch" {
+		t.Fatalf("tool_choice.name = %q, want apply_patch", got)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "apply_patch" {
+		t.Fatalf("message tool name = %q, want apply_patch", got)
+	}
+	if got := restoreMap["apply_patch"]; got != "apply.patch" {
+		t.Fatalf("restoreMap[apply_patch] = %q, want apply.patch", got)
+	}
+}
+
+func TestRestoreClaudeNormalizedToolNames(t *testing.T) {
+	restoreMap := map[string]string{"apply_patch": "apply.patch"}
+	body := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"apply_patch","input":{}},{"type":"tool_reference","tool_name":"apply_patch"},{"type":"tool_result","content":[{"type":"tool_reference","tool_name":"apply_patch"}]}]}`)
+
+	out := restoreClaudeNormalizedToolNamesInResponse(body, restoreMap)
+	if got := gjson.GetBytes(out, "content.0.name").String(); got != "apply.patch" {
+		t.Fatalf("content.0.name = %q, want apply.patch", got)
+	}
+	if got := gjson.GetBytes(out, "content.1.tool_name").String(); got != "apply.patch" {
+		t.Fatalf("content.1.tool_name = %q, want apply.patch", got)
+	}
+	if got := gjson.GetBytes(out, "content.2.content.0.tool_name").String(); got != "apply.patch" {
+		t.Fatalf("nested tool_name = %q, want apply.patch", got)
+	}
+
+	line := []byte(`data: {"type":"content_block_start","content_block":{"type":"tool_use","name":"apply_patch"}}`)
+	restoredLine := restoreClaudeNormalizedToolNamesInStreamLine(line, restoreMap)
+	if got := gjson.GetBytes(helps.JSONPayload(restoredLine), "content_block.name").String(); got != "apply.patch" {
+		t.Fatalf("stream content_block.name = %q, want apply.patch", got)
+	}
+}
+
+func TestRestoreClaudeToolNamesInErrorBody(t *testing.T) {
+	restoreMap := map[string]string{"apply_patch": "apply.patch"}
+	body := []byte(`{"error":{"message":"tools.0.name apply_patch is invalid"},"message":"apply_patch failed"}`)
+
+	out := restoreClaudeToolNamesInErrorBody(body, "", restoreMap)
+	if got := gjson.GetBytes(out, "error.message").String(); got != "tools.0.name apply.patch is invalid" {
+		t.Fatalf("error.message = %q, want original tool name", got)
+	}
+	if got := gjson.GetBytes(out, "message").String(); got != "apply.patch failed" {
+		t.Fatalf("message = %q, want original tool name", got)
+	}
+}
+
+func TestBuildClaudePayloadDiagnosticsCountsImagesAndLargeFields(t *testing.T) {
+	body := []byte(`{"system":"sys","messages":[{"role":"user","content":[{"type":"text","text":"hello"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"abcd"}},{"type":"tool_result","content":[{"type":"text","text":"nested"}]}]}],"tools":[{"name":"apply_patch","input_schema":{"type":"object","properties":{"patch":{"type":"string"}}}}]}`)
+
+	diagnostics := buildClaudePayloadDiagnostics(body)
+	if !diagnostics.JSONValid {
+		t.Fatal("expected payload to be valid JSON")
+	}
+	if diagnostics.Messages != 1 {
+		t.Fatalf("Messages = %d, want 1", diagnostics.Messages)
+	}
+	if diagnostics.TextBlocks != 2 {
+		t.Fatalf("TextBlocks = %d, want 2", diagnostics.TextBlocks)
+	}
+	if diagnostics.TextBytes != len("hello")+len("nested") {
+		t.Fatalf("TextBytes = %d, want %d", diagnostics.TextBytes, len("hello")+len("nested"))
+	}
+	if diagnostics.ImageBlocks != 1 {
+		t.Fatalf("ImageBlocks = %d, want 1", diagnostics.ImageBlocks)
+	}
+	if diagnostics.Base64ImageBlocks != 1 {
+		t.Fatalf("Base64ImageBlocks = %d, want 1", diagnostics.Base64ImageBlocks)
+	}
+	if diagnostics.ImageDataBytes != len("abcd") {
+		t.Fatalf("ImageDataBytes = %d, want %d", diagnostics.ImageDataBytes, len("abcd"))
+	}
+	if diagnostics.Tools != 1 {
+		t.Fatalf("Tools = %d, want 1", diagnostics.Tools)
+	}
+	if diagnostics.ToolSchemaBytes == 0 {
+		t.Fatal("expected tool schema bytes to be counted")
+	}
+	if !diagnostics.ShouldLog() {
+		t.Fatal("expected image payload diagnostics to be logged")
+	}
+}
+
+func TestSanitizeClaudeCountTokensPayloadRemovesUnsupportedFields(t *testing.T) {
+	body := []byte(`{"model":"claude","messages":[],"max_tokens":1000,"maxTokens":2000,"stream":true}`)
+
+	out := sanitizeClaudeCountTokensPayload(body)
+	for _, path := range []string{"max_tokens", "maxTokens", "stream"} {
+		if gjson.GetBytes(out, path).Exists() {
+			t.Fatalf("%s should be removed from count_tokens payload: %s", path, string(out))
+		}
+	}
+	if got := gjson.GetBytes(out, "model").String(); got != "claude" {
+		t.Fatalf("model = %q, want claude", got)
+	}
+}
+
+func TestClaudeExecutor_CountTokensNormalizesCustomToolSchema(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages/count_tokens" {
+			t.Fatalf("path = %q, want /v1/messages/count_tokens", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"input_tokens":7}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}],"tools":[{"name":"apply.patch","description":"Patch edit","input_schema":{}}],"tool_choice":{"type":"tool","name":"apply.patch"},"max_tokens":1000,"stream":true}`)
+
+	_, err := executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("CountTokens() error = %v", err)
+	}
+	if len(seenBody) == 0 {
+		t.Fatal("expected request body to be captured")
+	}
+	if got := gjson.GetBytes(seenBody, "tools.0.name").String(); got != "apply_patch" {
+		t.Fatalf("tools.0.name = %q, want apply_patch", got)
+	}
+	if got := gjson.GetBytes(seenBody, "tools.0.input_schema.type").String(); got != "object" {
+		t.Fatalf("tools.0.input_schema.type = %q, want object", got)
+	}
+	if !gjson.GetBytes(seenBody, "tools.0.input_schema.properties").IsObject() {
+		t.Fatalf("tools.0.input_schema.properties should be an object")
+	}
+	if got := gjson.GetBytes(seenBody, "tool_choice.name").String(); got != "apply_patch" {
+		t.Fatalf("tool_choice.name = %q, want apply_patch", got)
+	}
+	for _, path := range []string{"max_tokens", "stream"} {
+		if gjson.GetBytes(seenBody, path).Exists() {
+			t.Fatalf("%s should be removed from count_tokens request: %s", path, string(seenBody))
+		}
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
@@ -20,6 +21,102 @@ var (
 	account = ""
 	session = ""
 )
+
+const minEmbeddedImageDataBytes = 512
+
+var embeddedImageDataURLPattern = regexp.MustCompile(`(?i)data:(image/[a-z0-9.+-]+);base64,([A-Za-z0-9+/=_-]+)`)
+
+func makeClaudeTextPart(text string) string {
+	contentPart := []byte(`{"type":"text","text":""}`)
+	contentPart, _ = sjson.SetBytes(contentPart, "text", text)
+	return string(contentPart)
+}
+
+func makeClaudeImagePart(mediaType, data string) string {
+	contentPart := []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
+	contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
+	contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
+	return string(contentPart)
+}
+
+func claudeTextPartsWithEmbeddedImages(text string) ([]string, bool) {
+	if text == "" || !strings.Contains(strings.ToLower(text), "data:image/") {
+		return nil, false
+	}
+
+	var parts []string
+	cursor := 0
+	searchStart := 0
+	extractedImage := false
+	for searchStart < len(text) {
+		match := embeddedImageDataURLPattern.FindStringSubmatchIndex(text[searchStart:])
+		if match == nil {
+			break
+		}
+
+		start := searchStart + match[0]
+		end := searchStart + match[1]
+		mediaType := text[searchStart+match[2] : searchStart+match[3]]
+		data := text[searchStart+match[4] : searchStart+match[5]]
+		if !shouldExtractEmbeddedImageData(mediaType, data) {
+			searchStart = end
+			continue
+		}
+
+		textEnd := start
+		imageEnd := end
+		if wrapperStart, wrapperEnd, ok := markdownImageWrapperBounds(text, cursor, start, end); ok {
+			textEnd = wrapperStart
+			imageEnd = wrapperEnd
+		}
+
+		appendClaudeTextPart(&parts, text[cursor:textEnd])
+		parts = append(parts, makeClaudeImagePart(mediaType, data))
+		cursor = imageEnd
+		searchStart = imageEnd
+		extractedImage = true
+	}
+
+	if !extractedImage {
+		return nil, false
+	}
+	appendClaudeTextPart(&parts, text[cursor:])
+	return parts, true
+}
+
+func shouldExtractEmbeddedImageData(mediaType, data string) bool {
+	if !strings.HasPrefix(strings.ToLower(mediaType), "image/") {
+		return false
+	}
+	if len(data) < minEmbeddedImageDataBytes {
+		return false
+	}
+	return len(data)%4 != 1
+}
+
+func markdownImageWrapperBounds(text string, cursor, start, end int) (int, int, bool) {
+	prefix := text[cursor:start]
+	openRelative := strings.LastIndex(prefix, "![")
+	if openRelative < 0 {
+		return start, end, false
+	}
+	open := cursor + openRelative
+	wrapperPrefix := text[open:start]
+	if strings.ContainsAny(wrapperPrefix, "\r\n") || !strings.HasSuffix(wrapperPrefix, "](") {
+		return start, end, false
+	}
+	if end >= len(text) || text[end] != ')' {
+		return start, end, false
+	}
+	return open, end + 1, true
+}
+
+func appendClaudeTextPart(parts *[]string, text string) {
+	if text == "" {
+		return
+	}
+	*parts = append(*parts, makeClaudeTextPart(text))
+}
 
 // ConvertOpenAIResponsesRequestToClaude transforms an OpenAI Responses API request
 // into a Claude Messages API request using only gjson/sjson for JSON handling.
@@ -62,7 +159,7 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 			supportsMax := supportsAdaptive && thinking.HasLevel(mi.Thinking.Levels, string(thinking.LevelMax))
 
 			// Claude 4.6 supports adaptive thinking with output_config.effort.
-			// MapToClaudeEffort normalizes levels (e.g. minimal→low, xhigh→high) to avoid
+			// MapToClaudeEffort normalizes levels (e.g. minimal -> low, xhigh -> high) to avoid
 			// validation errors since validate treats same-provider unsupported levels as errors.
 			if supportsAdaptive {
 				switch effort {
@@ -192,10 +289,19 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 						case "input_text", "output_text":
 							if t := part.Get("text"); t.Exists() {
 								txt := t.String()
-								textAggregate.WriteString(txt)
-								contentPart := []byte(`{"type":"text","text":""}`)
-								contentPart, _ = sjson.SetBytes(contentPart, "text", txt)
-								partsJSON = append(partsJSON, string(contentPart))
+								if ptype == "input_text" {
+									textParts, extractedImage := claudeTextPartsWithEmbeddedImages(txt)
+									if extractedImage {
+										partsJSON = append(partsJSON, textParts...)
+										hasImage = true
+									} else {
+										textAggregate.WriteString(txt)
+										partsJSON = append(partsJSON, makeClaudeTextPart(txt))
+									}
+								} else {
+									textAggregate.WriteString(txt)
+									partsJSON = append(partsJSON, makeClaudeTextPart(txt))
+								}
 							}
 							if ptype == "input_text" {
 								role = "user"
@@ -265,7 +371,18 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 						return true
 					})
 				} else if parts.Type == gjson.String {
-					textAggregate.WriteString(parts.String())
+					txt := parts.String()
+					if strings.EqualFold(item.Get("role").String(), "user") {
+						textParts, extractedImage := claudeTextPartsWithEmbeddedImages(txt)
+						if extractedImage {
+							partsJSON = append(partsJSON, textParts...)
+							hasImage = true
+						} else {
+							textAggregate.WriteString(txt)
+						}
+					} else {
+						textAggregate.WriteString(txt)
+					}
 				}
 
 				// Fallback to given role if content types not decisive
@@ -327,9 +444,17 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 				// Map to user tool_result
 				callID := item.Get("call_id").String()
 				outputStr := item.Get("output").String()
+				textParts, extractedImage := claudeTextPartsWithEmbeddedImages(outputStr)
 				toolResult := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
 				toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", callID)
-				toolResult, _ = sjson.SetBytes(toolResult, "content", outputStr)
+				if extractedImage {
+					toolResult, _ = sjson.SetRawBytes(toolResult, "content", []byte("[]"))
+					for _, textPart := range textParts {
+						toolResult, _ = sjson.SetRawBytes(toolResult, "content.-1", []byte(textPart))
+					}
+				} else {
+					toolResult, _ = sjson.SetBytes(toolResult, "content", outputStr)
+				}
 
 				usr := []byte(`{"role":"user","content":[]}`)
 				usr, _ = sjson.SetRawBytes(usr, "content.-1", toolResult)
@@ -343,17 +468,33 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 	if tools := root.Get("tools"); tools.Exists() && tools.IsArray() {
 		toolsJSON := []byte("[]")
 		tools.ForEach(func(_, tool gjson.Result) bool {
-			tJSON := []byte(`{"name":"","description":"","input_schema":{}}`)
-			if n := tool.Get("name"); n.Exists() {
-				tJSON, _ = sjson.SetBytes(tJSON, "name", n.String())
+			name := strings.TrimSpace(tool.Get("name").String())
+			if name == "" {
+				name = strings.TrimSpace(tool.Get("function.name").String())
 			}
-			if d := tool.Get("description"); d.Exists() {
-				tJSON, _ = sjson.SetBytes(tJSON, "description", d.String())
+			if name == "" {
+				return true
 			}
 
-			if params := tool.Get("parameters"); params.Exists() {
+			tJSON := []byte(`{"name":"","description":"","input_schema":{}}`)
+			tJSON, _ = sjson.SetBytes(tJSON, "name", name)
+			description := strings.TrimSpace(tool.Get("description").String())
+			if description == "" {
+				description = strings.TrimSpace(tool.Get("function.description").String())
+			}
+			if description != "" {
+				tJSON, _ = sjson.SetBytes(tJSON, "description", description)
+			}
+
+			if params := tool.Get("input_schema"); params.Exists() {
+				tJSON, _ = sjson.SetRawBytes(tJSON, "input_schema", []byte(params.Raw))
+			} else if params = tool.Get("parameters"); params.Exists() {
 				tJSON, _ = sjson.SetRawBytes(tJSON, "input_schema", []byte(params.Raw))
 			} else if params = tool.Get("parametersJsonSchema"); params.Exists() {
+				tJSON, _ = sjson.SetRawBytes(tJSON, "input_schema", []byte(params.Raw))
+			} else if params = tool.Get("function.parameters"); params.Exists() {
+				tJSON, _ = sjson.SetRawBytes(tJSON, "input_schema", []byte(params.Raw))
+			} else if params = tool.Get("function.parametersJsonSchema"); params.Exists() {
 				tJSON, _ = sjson.SetRawBytes(tJSON, "input_schema", []byte(params.Raw))
 			}
 

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -1,0 +1,185 @@
+package responses
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIResponsesRequestToClaude_SkipsUnnamedTools(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}],
+		"tools":[
+			{"type":"web_search_preview"},
+			{"type":"function","name":"search_files","description":"Search files","parameters":{"type":"object","properties":{"q":{"type":"string"}}}},
+			{"type":"function","function":{"name":"nested_tool","description":"Nested","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, true)
+	tools := gjson.GetBytes(out, "tools").Array()
+	if len(tools) != 2 {
+		t.Fatalf("tools length = %d, want 2: %s", len(tools), out)
+	}
+	if got := tools[0].Get("name").String(); got != "search_files" {
+		t.Fatalf("tools.0.name = %q, want search_files", got)
+	}
+	if got := tools[0].Get("input_schema.properties.q.type").String(); got != "string" {
+		t.Fatalf("tools.0 input schema q type = %q, want string", got)
+	}
+	if got := tools[1].Get("name").String(); got != "nested_tool" {
+		t.Fatalf("tools.1.name = %q, want nested_tool", got)
+	}
+	if gjson.GetBytes(out, `tools.#(name="")`).Exists() {
+		t.Fatalf("output should not contain unnamed tools: %s", out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_ExtractsEmbeddedDataImageFromInputText(t *testing.T) {
+	imageData := strings.Repeat("A", 512)
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{
+			"role":"user",
+			"content":[{
+				"type":"input_text",
+				"text":"before\n![screenshot](data:image/png;base64,` + imageData + `)\nafter"
+			}]
+		}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, true)
+	content := gjson.GetBytes(out, "messages.0.content")
+	if !content.IsArray() {
+		t.Fatalf("message content should be an array after extracting an embedded image: %s", out)
+	}
+	parts := content.Array()
+	if len(parts) != 3 {
+		t.Fatalf("content parts length = %d, want 3: %s", len(parts), out)
+	}
+	if got := parts[0].Get("type").String(); got != "text" {
+		t.Fatalf("content.0.type = %q, want text", got)
+	}
+	if got := parts[0].Get("text").String(); got != "before\n" {
+		t.Fatalf("content.0.text = %q, want prefix text", got)
+	}
+	if got := parts[1].Get("type").String(); got != "image" {
+		t.Fatalf("content.1.type = %q, want image", got)
+	}
+	if got := parts[1].Get("source.type").String(); got != "base64" {
+		t.Fatalf("content.1.source.type = %q, want base64", got)
+	}
+	if got := parts[1].Get("source.media_type").String(); got != "image/png" {
+		t.Fatalf("content.1.source.media_type = %q, want image/png", got)
+	}
+	if got := parts[1].Get("source.data").String(); got != imageData {
+		t.Fatalf("content.1.source.data length = %d, want %d", len(got), len(imageData))
+	}
+	if got := parts[2].Get("text").String(); got != "\nafter" {
+		t.Fatalf("content.2.text = %q, want suffix text", got)
+	}
+	for _, part := range parts {
+		if strings.Contains(part.Get("text").String(), "data:image") {
+			t.Fatalf("text part should not retain embedded data image URL: %s", out)
+		}
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_LeavesShortDataImageTextLiteral(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{
+			"role":"user",
+			"content":[{
+				"type":"input_text",
+				"text":"Document this literal: data:image/png;base64,AAAA"
+			}]
+		}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, true)
+	content := gjson.GetBytes(out, "messages.0.content")
+	if content.Type != gjson.String {
+		t.Fatalf("short literal data URL should remain legacy string content: %s", out)
+	}
+	if !strings.Contains(content.String(), "data:image/png;base64,AAAA") {
+		t.Fatalf("short literal data URL missing from text content: %s", out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_ExtractsEmbeddedDataImageFromFunctionCallOutput(t *testing.T) {
+	imageData := strings.Repeat("A", 512)
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{
+			"type":"function_call_output",
+			"call_id":"call_123",
+			"output":"before\n![screenshot](data:image/png;base64,` + imageData + `)\nafter"
+		}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, true)
+	toolResult := gjson.GetBytes(out, "messages.0.content.0")
+	if got := toolResult.Get("type").String(); got != "tool_result" {
+		t.Fatalf("messages.0.content.0.type = %q, want tool_result: %s", got, out)
+	}
+	if got := toolResult.Get("tool_use_id").String(); got != "call_123" {
+		t.Fatalf("tool_result.tool_use_id = %q, want call_123", got)
+	}
+	content := toolResult.Get("content")
+	if !content.IsArray() {
+		t.Fatalf("tool_result content should be an array after extracting an embedded image: %s", out)
+	}
+	parts := content.Array()
+	if len(parts) != 3 {
+		t.Fatalf("tool_result content parts length = %d, want 3: %s", len(parts), out)
+	}
+	if got := parts[0].Get("type").String(); got != "text" {
+		t.Fatalf("tool_result.content.0.type = %q, want text", got)
+	}
+	if got := parts[0].Get("text").String(); got != "before\n" {
+		t.Fatalf("tool_result.content.0.text = %q, want prefix text", got)
+	}
+	if got := parts[1].Get("type").String(); got != "image" {
+		t.Fatalf("tool_result.content.1.type = %q, want image", got)
+	}
+	if got := parts[1].Get("source.type").String(); got != "base64" {
+		t.Fatalf("tool_result.content.1.source.type = %q, want base64", got)
+	}
+	if got := parts[1].Get("source.media_type").String(); got != "image/png" {
+		t.Fatalf("tool_result.content.1.source.media_type = %q, want image/png", got)
+	}
+	if got := parts[1].Get("source.data").String(); got != imageData {
+		t.Fatalf("tool_result.content.1.source.data length = %d, want %d", len(got), len(imageData))
+	}
+	if got := parts[2].Get("text").String(); got != "\nafter" {
+		t.Fatalf("tool_result.content.2.text = %q, want suffix text", got)
+	}
+	for _, part := range parts {
+		if strings.Contains(part.Get("text").String(), "data:image") {
+			t.Fatalf("text part should not retain embedded data image URL: %s", out)
+		}
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_LeavesShortDataImageFunctionCallOutputLiteral(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{
+			"type":"function_call_output",
+			"call_id":"call_123",
+			"output":"Document this literal: data:image/png;base64,AAAA"
+		}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, true)
+	content := gjson.GetBytes(out, "messages.0.content.0.content")
+	if content.Type != gjson.String {
+		t.Fatalf("short literal data URL should remain string tool_result content: %s", out)
+	}
+	if !strings.Contains(content.String(), "data:image/png;base64,AAAA") {
+		t.Fatalf("short literal data URL missing from tool_result content: %s", out)
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -220,17 +220,21 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 	case "content_block_stop":
 		idx := int(root.Get("index").Int())
 		if st.InTextBlock {
+			text := st.TextBuf.String()
 			done := []byte(`{"type":"response.output_text.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"text":"","logprobs":[]}`)
 			done, _ = sjson.SetBytes(done, "sequence_number", nextSeq())
 			done, _ = sjson.SetBytes(done, "item_id", st.CurrentMsgID)
+			done, _ = sjson.SetBytes(done, "text", text)
 			out = append(out, emitEvent("response.output_text.done", done))
 			partDone := []byte(`{"type":"response.content_part.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}`)
 			partDone, _ = sjson.SetBytes(partDone, "sequence_number", nextSeq())
 			partDone, _ = sjson.SetBytes(partDone, "item_id", st.CurrentMsgID)
+			partDone, _ = sjson.SetBytes(partDone, "part.text", text)
 			out = append(out, emitEvent("response.content_part.done", partDone))
 			final := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","text":""}],"role":"assistant"}}`)
 			final, _ = sjson.SetBytes(final, "sequence_number", nextSeq())
 			final, _ = sjson.SetBytes(final, "item.id", st.CurrentMsgID)
+			final, _ = sjson.SetBytes(final, "item.content.0.text", text)
 			out = append(out, emitEvent("response.output_item.done", final))
 			st.InTextBlock = false
 		} else if st.InFuncBlock {

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -26,7 +26,9 @@ type claudeToResponsesState struct {
 	FuncNames   map[int]string // index -> function name
 	FuncCallIDs map[int]string // index -> call id
 	// message text aggregation
-	TextBuf strings.Builder
+	TextBuf          strings.Builder
+	TextBlockBuf     strings.Builder
+	CurrentTextIndex int
 	// reasoning state
 	ReasoningActive    bool
 	ReasoningItemID    string
@@ -86,6 +88,8 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			st.InFuncBlock = false
 			st.CurrentMsgID = ""
 			st.CurrentFCID = ""
+			st.CurrentTextIndex = 0
+			st.TextBlockBuf.Reset()
 			st.ReasoningItemID = ""
 			st.ReasoningIndex = 0
 			st.ReasoningPartAdded = false
@@ -128,15 +132,19 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 		if typ == "text" {
 			// open message item + content part
 			st.InTextBlock = true
-			st.CurrentMsgID = fmt.Sprintf("msg_%s_0", st.ResponseID)
+			st.CurrentTextIndex = idx
+			st.TextBlockBuf.Reset()
+			st.CurrentMsgID = fmt.Sprintf("msg_%s_%d", st.ResponseID, idx)
 			item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"in_progress","content":[],"role":"assistant"}}`)
 			item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
+			item, _ = sjson.SetBytes(item, "output_index", idx)
 			item, _ = sjson.SetBytes(item, "item.id", st.CurrentMsgID)
 			out = append(out, emitEvent("response.output_item.added", item))
 
 			part := []byte(`{"type":"response.content_part.added","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}`)
 			part, _ = sjson.SetBytes(part, "sequence_number", nextSeq())
 			part, _ = sjson.SetBytes(part, "item_id", st.CurrentMsgID)
+			part, _ = sjson.SetBytes(part, "output_index", idx)
 			out = append(out, emitEvent("response.content_part.added", part))
 		} else if typ == "tool_use" {
 			st.InFuncBlock = true
@@ -185,10 +193,12 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				msg := []byte(`{"type":"response.output_text.delta","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"delta":"","logprobs":[]}`)
 				msg, _ = sjson.SetBytes(msg, "sequence_number", nextSeq())
 				msg, _ = sjson.SetBytes(msg, "item_id", st.CurrentMsgID)
+				msg, _ = sjson.SetBytes(msg, "output_index", st.CurrentTextIndex)
 				msg, _ = sjson.SetBytes(msg, "delta", t.String())
 				out = append(out, emitEvent("response.output_text.delta", msg))
 				// aggregate text for response.output
 				st.TextBuf.WriteString(t.String())
+				st.TextBlockBuf.WriteString(t.String())
 			}
 		} else if dt == "input_json_delta" {
 			idx := int(root.Get("index").Int())
@@ -220,19 +230,22 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 	case "content_block_stop":
 		idx := int(root.Get("index").Int())
 		if st.InTextBlock {
-			text := st.TextBuf.String()
+			text := st.TextBlockBuf.String()
 			done := []byte(`{"type":"response.output_text.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"text":"","logprobs":[]}`)
 			done, _ = sjson.SetBytes(done, "sequence_number", nextSeq())
 			done, _ = sjson.SetBytes(done, "item_id", st.CurrentMsgID)
+			done, _ = sjson.SetBytes(done, "output_index", st.CurrentTextIndex)
 			done, _ = sjson.SetBytes(done, "text", text)
 			out = append(out, emitEvent("response.output_text.done", done))
 			partDone := []byte(`{"type":"response.content_part.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}`)
 			partDone, _ = sjson.SetBytes(partDone, "sequence_number", nextSeq())
 			partDone, _ = sjson.SetBytes(partDone, "item_id", st.CurrentMsgID)
+			partDone, _ = sjson.SetBytes(partDone, "output_index", st.CurrentTextIndex)
 			partDone, _ = sjson.SetBytes(partDone, "part.text", text)
 			out = append(out, emitEvent("response.content_part.done", partDone))
 			final := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","text":""}],"role":"assistant"}}`)
 			final, _ = sjson.SetBytes(final, "sequence_number", nextSeq())
+			final, _ = sjson.SetBytes(final, "output_index", st.CurrentTextIndex)
 			final, _ = sjson.SetBytes(final, "item.id", st.CurrentMsgID)
 			final, _ = sjson.SetBytes(final, "item.content.0.text", text)
 			out = append(out, emitEvent("response.output_item.done", final))

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -29,6 +29,7 @@ type claudeToResponsesState struct {
 	TextBuf          strings.Builder
 	TextBlockBuf     strings.Builder
 	CurrentTextIndex int
+	TextOutputs      map[int]claudeTextOutput
 	// reasoning state
 	ReasoningActive    bool
 	ReasoningItemID    string
@@ -39,6 +40,11 @@ type claudeToResponsesState struct {
 	InputTokens  int64
 	OutputTokens int64
 	UsageSeen    bool
+}
+
+type claudeTextOutput struct {
+	ID   string
+	Text string
 }
 
 var dataTag = []byte("data:")
@@ -60,7 +66,7 @@ func emitEvent(event string, payload []byte) []byte {
 // ConvertClaudeResponseToOpenAIResponses converts Claude SSE to OpenAI Responses SSE events.
 func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) [][]byte {
 	if *param == nil {
-		*param = &claudeToResponsesState{FuncArgsBuf: make(map[int]*strings.Builder), FuncNames: make(map[int]string), FuncCallIDs: make(map[int]string)}
+		*param = &claudeToResponsesState{FuncArgsBuf: make(map[int]*strings.Builder), FuncNames: make(map[int]string), FuncCallIDs: make(map[int]string), TextOutputs: make(map[int]claudeTextOutput)}
 	}
 	st := (*param).(*claudeToResponsesState)
 
@@ -96,6 +102,7 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			st.FuncArgsBuf = make(map[int]*strings.Builder)
 			st.FuncNames = make(map[int]string)
 			st.FuncCallIDs = make(map[int]string)
+			st.TextOutputs = make(map[int]claudeTextOutput)
 			st.InputTokens = 0
 			st.OutputTokens = 0
 			st.UsageSeen = false
@@ -249,6 +256,10 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			final, _ = sjson.SetBytes(final, "item.id", st.CurrentMsgID)
 			final, _ = sjson.SetBytes(final, "item.content.0.text", text)
 			out = append(out, emitEvent("response.output_item.done", final))
+			if st.TextOutputs == nil {
+				st.TextOutputs = make(map[int]claudeTextOutput)
+			}
+			st.TextOutputs[st.CurrentTextIndex] = claudeTextOutput{ID: st.CurrentMsgID, Text: text}
 			st.InTextBlock = false
 		} else if st.InFuncBlock {
 			args := "{}"
@@ -375,36 +386,36 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 
 		// Build response.output from aggregated state
 		outputsWrapper := []byte(`{"arr":[]}`)
+		outputItems := make(map[int][]byte)
 		// reasoning item (if any)
 		if st.ReasoningBuf.Len() > 0 || st.ReasoningPartAdded {
 			item := []byte(`{"id":"","type":"reasoning","summary":[{"type":"summary_text","text":""}]}`)
 			item, _ = sjson.SetBytes(item, "id", st.ReasoningItemID)
 			item, _ = sjson.SetBytes(item, "summary.0.text", st.ReasoningBuf.String())
-			outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
+			outputItems[st.ReasoningIndex] = item
 		}
-		// assistant message item (if any text)
-		if st.TextBuf.Len() > 0 || st.InTextBlock || st.CurrentMsgID != "" {
+		// assistant message items (if any text)
+		if len(st.TextOutputs) > 0 {
+			textIdxs := make([]int, 0, len(st.TextOutputs))
+			for idx := range st.TextOutputs {
+				textIdxs = append(textIdxs, idx)
+			}
+			for _, idx := range textIdxs {
+				textOutput := st.TextOutputs[idx]
+				item := []byte(`{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`)
+				item, _ = sjson.SetBytes(item, "id", textOutput.ID)
+				item, _ = sjson.SetBytes(item, "content.0.text", textOutput.Text)
+				outputItems[idx] = item
+			}
+		} else if st.TextBuf.Len() > 0 || st.InTextBlock || st.CurrentMsgID != "" {
 			item := []byte(`{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`)
 			item, _ = sjson.SetBytes(item, "id", st.CurrentMsgID)
 			item, _ = sjson.SetBytes(item, "content.0.text", st.TextBuf.String())
-			outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
+			outputItems[st.CurrentTextIndex] = item
 		}
 		// function_call items (in ascending index order for determinism)
 		if len(st.FuncArgsBuf) > 0 {
-			// collect indices
-			idxs := make([]int, 0, len(st.FuncArgsBuf))
 			for idx := range st.FuncArgsBuf {
-				idxs = append(idxs, idx)
-			}
-			// simple sort (small N), avoid adding new imports
-			for i := 0; i < len(idxs); i++ {
-				for j := i + 1; j < len(idxs); j++ {
-					if idxs[j] < idxs[i] {
-						idxs[i], idxs[j] = idxs[j], idxs[i]
-					}
-				}
-			}
-			for _, idx := range idxs {
 				args := ""
 				if b := st.FuncArgsBuf[idx]; b != nil {
 					args = b.String()
@@ -419,7 +430,24 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				item, _ = sjson.SetBytes(item, "arguments", args)
 				item, _ = sjson.SetBytes(item, "call_id", callID)
 				item, _ = sjson.SetBytes(item, "name", name)
-				outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
+				outputItems[idx] = item
+			}
+		}
+		if len(outputItems) > 0 {
+			idxs := make([]int, 0, len(outputItems))
+			for idx := range outputItems {
+				idxs = append(idxs, idx)
+			}
+			// simple sort (small N), avoid adding new imports
+			for i := 0; i < len(idxs); i++ {
+				for j := i + 1; j < len(idxs); j++ {
+					if idxs[j] < idxs[i] {
+						idxs[i], idxs[j] = idxs[j], idxs[i]
+					}
+				}
+			}
+			for _, idx := range idxs {
+				outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", outputItems[idx])
 			}
 		}
 		if gjson.GetBytes(outputsWrapper, "arr.#").Int() > 0 {

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
@@ -1,0 +1,50 @@
+package responses
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func responseEventPayload(t *testing.T, chunk []byte) []byte {
+	t.Helper()
+	prefix := []byte("data: ")
+	idx := bytes.Index(chunk, prefix)
+	if idx < 0 {
+		t.Fatalf("missing data payload in chunk: %s", chunk)
+	}
+	return bytes.TrimSpace(chunk[idx+len(prefix):])
+}
+
+func TestConvertClaudeResponseToOpenAIResponses_TextDoneCarriesAccumulatedText(t *testing.T) {
+	var param any
+	ctx := context.Background()
+	emptyRequest := []byte(`{}`)
+
+	_ = ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"message_start","message":{"id":"msg_123","usage":{"input_tokens":1,"output_tokens":0}}}`), &param)
+	_ = ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`), &param)
+	_ = ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"안녕"}}`), &param)
+	_ = ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"?"}}`), &param)
+
+	out := ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"content_block_stop","index":0}`), &param)
+	if len(out) != 3 {
+		t.Fatalf("content_block_stop emitted %d events, want 3", len(out))
+	}
+
+	outputTextDone := responseEventPayload(t, out[0])
+	if got := gjson.GetBytes(outputTextDone, "text").String(); got != "안녕?" {
+		t.Fatalf("response.output_text.done text = %q, want %q", got, "안녕?")
+	}
+
+	contentPartDone := responseEventPayload(t, out[1])
+	if got := gjson.GetBytes(contentPartDone, "part.text").String(); got != "안녕?" {
+		t.Fatalf("response.content_part.done part.text = %q, want %q", got, "안녕?")
+	}
+
+	outputItemDone := responseEventPayload(t, out[2])
+	if got := gjson.GetBytes(outputItemDone, "item.content.0.text").String(); got != "안녕?" {
+		t.Fatalf("response.output_item.done item.content.0.text = %q, want %q", got, "안녕?")
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
@@ -66,6 +66,28 @@ func TestConvertClaudeResponseToOpenAIResponses_TextDoneUsesCurrentBlockText(t *
 	if got := gjson.GetBytes(outputItemDone, "output_index").Int(); got != 2 {
 		t.Fatalf("second response.output_item.done output_index = %d, want 2", got)
 	}
+
+	completed := ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"message_stop"}`), &param)
+	if len(completed) != 1 {
+		t.Fatalf("message_stop emitted %d events, want 1", len(completed))
+	}
+	completedPayload := responseEventPayload(t, completed[0])
+	outputs := gjson.GetBytes(completedPayload, "response.output").Array()
+	if len(outputs) != 2 {
+		t.Fatalf("response.completed output length = %d, want 2: %s", len(outputs), completedPayload)
+	}
+	if got := outputs[0].Get("id").String(); got != "msg_msg_456_0" {
+		t.Fatalf("response.completed output.0.id = %q, want msg_msg_456_0", got)
+	}
+	if got := outputs[0].Get("content.0.text").String(); got != "first" {
+		t.Fatalf("response.completed output.0 text = %q, want first", got)
+	}
+	if got := outputs[1].Get("id").String(); got != "msg_msg_456_2" {
+		t.Fatalf("response.completed output.1.id = %q, want msg_msg_456_2", got)
+	}
+	if got := outputs[1].Get("content.0.text").String(); got != "second" {
+		t.Fatalf("response.completed output.1 text = %q, want second", got)
+	}
 }
 
 func TestConvertClaudeResponseToOpenAIResponses_TextDoneCarriesAccumulatedText(t *testing.T) {

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
@@ -18,6 +18,56 @@ func responseEventPayload(t *testing.T, chunk []byte) []byte {
 	return bytes.TrimSpace(chunk[idx+len(prefix):])
 }
 
+func TestConvertClaudeResponseToOpenAIResponses_TextDoneUsesCurrentBlockText(t *testing.T) {
+	var param any
+	ctx := context.Background()
+	emptyRequest := []byte(`{}`)
+
+	_ = ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"message_start","message":{"id":"msg_456","usage":{"input_tokens":1,"output_tokens":0}}}`), &param)
+	_ = ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`), &param)
+	_ = ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"first"}}`), &param)
+	_ = ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"content_block_stop","index":0}`), &param)
+
+	startSecond := ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}`), &param)
+	_ = ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"second"}}`), &param)
+	out := ConvertClaudeResponseToOpenAIResponses(ctx, "claude-sonnet", emptyRequest, emptyRequest, []byte(`data: {"type":"content_block_stop","index":2}`), &param)
+
+	if len(startSecond) != 2 {
+		t.Fatalf("second content_block_start emitted %d events, want 2", len(startSecond))
+	}
+	secondItemAdded := responseEventPayload(t, startSecond[0])
+	if got := gjson.GetBytes(secondItemAdded, "output_index").Int(); got != 2 {
+		t.Fatalf("second response.output_item.added output_index = %d, want 2", got)
+	}
+	if got := gjson.GetBytes(secondItemAdded, "item.id").String(); got != "msg_msg_456_2" {
+		t.Fatalf("second response.output_item.added item.id = %q, want msg_msg_456_2", got)
+	}
+
+	if len(out) != 3 {
+		t.Fatalf("second content_block_stop emitted %d events, want 3", len(out))
+	}
+	outputTextDone := responseEventPayload(t, out[0])
+	if got := gjson.GetBytes(outputTextDone, "text").String(); got != "second" {
+		t.Fatalf("second response.output_text.done text = %q, want second", got)
+	}
+	if got := gjson.GetBytes(outputTextDone, "output_index").Int(); got != 2 {
+		t.Fatalf("second response.output_text.done output_index = %d, want 2", got)
+	}
+
+	contentPartDone := responseEventPayload(t, out[1])
+	if got := gjson.GetBytes(contentPartDone, "part.text").String(); got != "second" {
+		t.Fatalf("second response.content_part.done part.text = %q, want second", got)
+	}
+
+	outputItemDone := responseEventPayload(t, out[2])
+	if got := gjson.GetBytes(outputItemDone, "item.content.0.text").String(); got != "second" {
+		t.Fatalf("second response.output_item.done item.content.0.text = %q, want second", got)
+	}
+	if got := gjson.GetBytes(outputItemDone, "output_index").Int(); got != 2 {
+		t.Fatalf("second response.output_item.done output_index = %d, want 2", got)
+	}
+}
+
 func TestConvertClaudeResponseToOpenAIResponses_TextDoneCarriesAccumulatedText(t *testing.T) {
 	var param any
 	ctx := context.Background()


### PR DESCRIPTION
﻿## Summary
- Normalize Claude OAuth/custom tool definitions before sending Anthropic Messages requests upstream.
- Restore normalized tool names in non-streaming, streaming, and error responses so clients keep their original tool names.
- Improve Claude Responses translation for embedded images and separate text block completion handling.
- Add diagnostics for large/image-heavy Claude payloads and tests for the new behavior.

## Validation
- gofmt on changed Go files
- go build -o test-output ./cmd/server
