### PR TITLE
fix: skip empty tool call names in OpenAI to Claude translator

### DIFF
--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -421,7 +421,7 @@ func convertOpenAINonStreamingToAnthropic(rawJSON []byte) [][]byte {
 				toolUseBlock, _ = sjson.SetBytes(toolUseBlock, "id", util.SanitizeClaudeToolID(toolCall.Get("id").String()))
 				name := toolCall.Get("function.name").String()
 				if name == "" {
-					return true // 跳过这个坏的 tool_call
+					return true // Skip this invalid tool_call
 				}
 
 				toolUseBlock, _ = sjson.SetBytes(

--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -236,8 +236,8 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 
 				// Handle function name
 				if function := toolCall.Get("function"); function.Exists() {
-					if name := function.Get("name"); name.Exists() {
-						accumulator.Name = util.MapToolName(param.ToolNameMap, name.String())
+					if name := function.Get("name"); name.Exists() && name.String() != "" {
+    					accumulator.Name = util.MapToolName(param.ToolNameMap, name.String())
 
 						stopThinkingContentBlock(param, &results)
 
@@ -419,7 +419,16 @@ func convertOpenAINonStreamingToAnthropic(rawJSON []byte) [][]byte {
 			toolCalls.ForEach(func(_, toolCall gjson.Result) bool {
 				toolUseBlock := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
 				toolUseBlock, _ = sjson.SetBytes(toolUseBlock, "id", util.SanitizeClaudeToolID(toolCall.Get("id").String()))
-				toolUseBlock, _ = sjson.SetBytes(toolUseBlock, "name", toolCall.Get("function.name").String())
+				name := toolCall.Get("function.name").String()
+				if name == "" {
+					return true // 跳过这个坏的 tool_call
+				}
+
+				toolUseBlock, _ = sjson.SetBytes(
+					toolUseBlock,
+					"name",
+					name,
+				)
 
 				argsStr := util.FixJSON(toolCall.Get("function.arguments").String())
 				if argsStr != "" && gjson.Valid(argsStr) {


### PR DESCRIPTION
## Summary

Fixes invalid empty tool names generated by the OpenAI-to-Claude translator when upstream OpenAI-compatible providers return tool calls with missing, null, or empty `function.name`.

This prevents downstream clients such as OpenCode from receiving invalid Claude `tool_use` blocks like:

```text
tool_use name=""