### PR TITLE
feat: add Codex quota ping endpoint

### DIFF
--- a/internal/api/handlers/management/codex_ping.go
+++ b/internal/api/handlers/management/codex_ping.go
@@ -1,0 +1,312 @@
+package management
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	codexPingDefaultModel     = "gpt-5.4-mini"
+	codexPingDefaultReasoning = "none"
+	codexPingDefaultPrompt    = "ping"
+)
+
+type codexPingUsage struct {
+	InputTokens       int `json:"input_tokens"`
+	CachedInputTokens int `json:"cached_input_tokens"`
+	OutputTokens      int `json:"output_tokens"`
+	ReasoningTokens   int `json:"reasoning_tokens"`
+	TotalTokens       int `json:"total_tokens"`
+}
+
+type codexPingResponse struct {
+	Message string         `json:"message"`
+	Usage   codexPingUsage `json:"usage"`
+}
+
+// CodexPing sends a request-scoped stateless ping through a selected Codex auth file.
+func (h *Handler) CodexPing(c *gin.Context) {
+	var req struct {
+		AuthIndexSnake  *string `json:"auth_index"`
+		AuthIndexCamel  *string `json:"authIndex"`
+		AuthIndexPascal *string `json:"AuthIndex"`
+	}
+	if errBindJSON := c.ShouldBindJSON(&req); errBindJSON != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+
+	authIndex := firstNonEmptyString(req.AuthIndexSnake, req.AuthIndexCamel, req.AuthIndexPascal)
+	if authIndex == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing auth_index"})
+		return
+	}
+	if h == nil || h.authManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth manager unavailable"})
+		return
+	}
+
+	auth := h.authByIndex(authIndex)
+	if auth == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "auth file not found"})
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth file is not codex"})
+		return
+	}
+	if auth.Disabled {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth file is disabled"})
+		return
+	}
+	if isCodexAPIKeyConfigAuth(auth) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "codex api key configs are not supported"})
+		return
+	}
+
+	logger := log.WithFields(log.Fields{
+		"auth_index":    authIndex,
+		"auth_id":       auth.ID,
+		"model":         codexPingDefaultModel,
+		"prompt_length": len(codexPingDefaultPrompt),
+		"prompt_sha256": codexPingPromptHash(codexPingDefaultPrompt),
+	})
+	logger.Info("management codex ping sending request")
+
+	result, errPing := h.sendCodexPing(c.Request.Context(), auth)
+	if errPing != nil {
+		logger = logger.WithError(errPing)
+		if upstreamStatus := codexPingUpstreamStatus(errPing); upstreamStatus > 0 {
+			logger = logger.WithField("upstream_status", upstreamStatus)
+		}
+		logger.Warn("management codex ping failed")
+		c.JSON(http.StatusBadGateway, gin.H{"error": safeCodexPingError(errPing)})
+		return
+	}
+
+	logger.WithFields(log.Fields{
+		"input_tokens":        result.Usage.InputTokens,
+		"cached_input_tokens": result.Usage.CachedInputTokens,
+		"output_tokens":       result.Usage.OutputTokens,
+		"reasoning_tokens":    result.Usage.ReasoningTokens,
+		"total_tokens":        result.Usage.TotalTokens,
+	}).Info("management codex ping succeeded")
+
+	c.JSON(http.StatusOK, result)
+}
+
+func (h *Handler) sendCodexPing(ctx context.Context, auth *coreauth.Auth) (codexPingResponse, error) {
+	body, errMarshal := json.Marshal(map[string]any{
+		"model":               codexPingDefaultModel,
+		"input":               codexPingDefaultPrompt,
+		"stream":              true,
+		"store":               false,
+		"parallel_tool_calls": true,
+		"reasoning": map[string]string{
+			"effort": codexPingDefaultReasoning,
+		},
+	})
+	if errMarshal != nil {
+		return codexPingResponse{}, errMarshal
+	}
+
+	executor, okExecutor := h.authManager.Executor("codex")
+	if !okExecutor || executor == nil {
+		return codexPingResponse{}, fmt.Errorf("codex executor not registered")
+	}
+
+	streamResult, errStream := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   codexPingDefaultModel,
+		Payload: body,
+		Format:  sdktranslator.FromString("openai-response"),
+	}, cliproxyexecutor.Options{
+		Stream:          true,
+		SourceFormat:    sdktranslator.FromString("openai-response"),
+		OriginalRequest: body,
+		Metadata: map[string]any{
+			cliproxyexecutor.PinnedAuthMetadataKey:     auth.ID,
+			cliproxyexecutor.RequestedModelMetadataKey: codexPingDefaultModel,
+			cliproxyexecutor.RequestPathMetadataKey:    "/v0/management/codex/ping",
+		},
+	})
+	if errStream != nil {
+		return codexPingResponse{}, errStream
+	}
+	if streamResult == nil || streamResult.Chunks == nil {
+		return codexPingResponse{}, fmt.Errorf("codex executor returned empty stream")
+	}
+
+	var stream bytes.Buffer
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			return codexPingResponse{}, chunk.Err
+		}
+		if len(chunk.Payload) == 0 {
+			continue
+		}
+		stream.Write(chunk.Payload)
+	}
+
+	message, usage, completed := parseCodexPingStream(stream.Bytes())
+	if !completed {
+		return codexPingResponse{}, fmt.Errorf("stream closed before response.completed")
+	}
+	if strings.TrimSpace(message) == "" {
+		message = "Pong"
+	}
+	return codexPingResponse{Message: strings.TrimSpace(message), Usage: usage}, nil
+}
+
+func isCodexAPIKeyConfigAuth(auth *coreauth.Auth) bool {
+	if auth == nil || auth.Attributes == nil {
+		return false
+	}
+	apiKey := strings.TrimSpace(auth.Attributes["api_key"])
+	path := strings.TrimSpace(auth.Attributes["path"])
+	return apiKey != "" && path == ""
+}
+
+func parseCodexPingStream(data []byte) (string, codexPingUsage, bool) {
+	var text strings.Builder
+	var outputTextDone strings.Builder
+	var outputItemDone strings.Builder
+	var completedText string
+	var usage codexPingUsage
+	completed := false
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		raw := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if raw == "" || raw == "[DONE]" {
+			continue
+		}
+
+		event := gjson.Parse(raw)
+		eventType := event.Get("type").String()
+		switch eventType {
+		case "response.output_text.delta":
+			text.WriteString(event.Get("delta").String())
+		case "response.output_text.done":
+			outputTextDone.WriteString(event.Get("text").String())
+		case "response.output_item.done":
+			outputItemDone.WriteString(codexPingTextFromOutputItem(event.Get("item")))
+		case "response.completed":
+			completed = true
+			completedText = codexPingTextFromCompletedResponse(event.Get("response"))
+			if usageResult := event.Get("response.usage"); usageResult.Exists() {
+				usage = codexPingUsageFromResult(usageResult)
+			}
+		}
+	}
+
+	message := text.String()
+	if strings.TrimSpace(message) == "" {
+		message = outputItemDone.String()
+	}
+	if strings.TrimSpace(message) == "" {
+		message = outputTextDone.String()
+	}
+	if strings.TrimSpace(message) == "" {
+		message = completedText
+	}
+	return message, usage, completed
+}
+
+func codexPingTextFromCompletedResponse(response gjson.Result) string {
+	if text := response.Get("output_text").String(); strings.TrimSpace(text) != "" {
+		return text
+	}
+	var out strings.Builder
+	response.Get("output").ForEach(func(_, item gjson.Result) bool {
+		text := codexPingTextFromOutputItem(item)
+		if strings.TrimSpace(text) != "" {
+			out.WriteString(text)
+		}
+		return true
+	})
+	return out.String()
+}
+
+func codexPingTextFromOutputItem(item gjson.Result) string {
+	var out strings.Builder
+	item.Get("content").ForEach(func(_, content gjson.Result) bool {
+		if text := content.Get("text").String(); strings.TrimSpace(text) != "" {
+			out.WriteString(text)
+			return true
+		}
+		if text := content.Get("transcript").String(); strings.TrimSpace(text) != "" {
+			out.WriteString(text)
+		}
+		return true
+	})
+	return out.String()
+}
+
+func codexPingUsageFromResult(usage gjson.Result) codexPingUsage {
+	input, _ := codexPingInt(usage, "input_tokens", "inputTokens")
+	output, _ := codexPingInt(usage, "output_tokens", "outputTokens")
+	total, okTotal := codexPingInt(usage, "total_tokens", "totalTokens")
+	cached, _ := codexPingInt(usage, "input_tokens_details.cached_tokens", "inputTokensDetails.cachedTokens", "cached_input_tokens", "cachedInputTokens")
+	reasoning, _ := codexPingInt(usage, "output_tokens_details.reasoning_tokens", "outputTokensDetails.reasoningTokens", "reasoning_tokens", "reasoningTokens")
+	if !okTotal {
+		total = input + output
+	}
+	return codexPingUsage{
+		InputTokens:       input,
+		CachedInputTokens: cached,
+		OutputTokens:      output,
+		ReasoningTokens:   reasoning,
+		TotalTokens:       total,
+	}
+}
+
+func codexPingInt(result gjson.Result, keys ...string) (int, bool) {
+	for _, key := range keys {
+		value := result.Get(key)
+		if !value.Exists() {
+			continue
+		}
+		return int(value.Int()), true
+	}
+	return 0, false
+}
+
+func codexPingPromptHash(prompt string) string {
+	sum := sha256.Sum256([]byte(prompt))
+	return hex.EncodeToString(sum[:])
+}
+
+func codexPingUpstreamStatus(err error) int {
+	var statusErr cliproxyexecutor.StatusError
+	if errors.As(err, &statusErr) && statusErr != nil {
+		return statusErr.StatusCode()
+	}
+	return 0
+}
+
+func safeCodexPingError(err error) string {
+	if upstreamStatus := codexPingUpstreamStatus(err); upstreamStatus > 0 {
+		return fmt.Sprintf("codex ping failed (upstream status %d)", upstreamStatus)
+	}
+	return "codex ping failed"
+}

--- a/internal/api/handlers/management/codex_ping_test.go
+++ b/internal/api/handlers/management/codex_ping_test.go
@@ -1,0 +1,311 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+type codexPingTestExecutor struct {
+	body     string
+	chunks   []string
+	err      error
+	lastAuth *coreauth.Auth
+	lastReq  cliproxyexecutor.Request
+	lastOpts cliproxyexecutor.Options
+}
+
+func (e *codexPingTestExecutor) Identifier() string { return "codex" }
+
+func (e *codexPingTestExecutor) Execute(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *codexPingTestExecutor) ExecuteStream(_ context.Context, auth *coreauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+	e.lastAuth = auth
+	e.lastReq = req
+	e.lastOpts = opts
+	chunks := e.chunks
+	if len(chunks) == 0 {
+		chunks = []string{e.body}
+	}
+	ch := make(chan cliproxyexecutor.StreamChunk, len(chunks))
+	for _, chunk := range chunks {
+		ch <- cliproxyexecutor.StreamChunk{Payload: []byte(chunk)}
+	}
+	close(ch)
+	return &cliproxyexecutor.StreamResult{Chunks: ch}, nil
+}
+
+func (e *codexPingTestExecutor) Refresh(context.Context, *coreauth.Auth) (*coreauth.Auth, error) {
+	return nil, nil
+}
+
+func (e *codexPingTestExecutor) CountTokens(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *codexPingTestExecutor) HttpRequest(_ context.Context, _ *coreauth.Auth, req *http.Request) (*http.Response, error) {
+	return nil, errors.New("unexpected HttpRequest call")
+}
+
+func TestCodexPingValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name     string
+		body     string
+		auth     *coreauth.Auth
+		wantCode int
+	}{
+		{name: "missing auth index", body: `{}`, wantCode: http.StatusBadRequest},
+		{name: "unknown auth", body: `{"auth_index":"missing"}`, wantCode: http.StatusNotFound},
+		{
+			name: "disabled auth",
+			auth: &coreauth.Auth{
+				ID:         "disabled",
+				Provider:   "codex",
+				Disabled:   true,
+				Attributes: map[string]string{"path": "/tmp/codex.json"},
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "non codex auth",
+			auth: &coreauth.Auth{
+				ID:         "gemini",
+				Provider:   "gemini",
+				Attributes: map[string]string{"path": "/tmp/gemini.json"},
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "codex api key config auth",
+			auth: &coreauth.Auth{
+				ID:         "codex-key",
+				Provider:   "codex",
+				Attributes: map[string]string{"api_key": "secret"},
+			},
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			manager := coreauth.NewManager(nil, nil, nil)
+			manager.RegisterExecutor(&codexPingTestExecutor{})
+			body := tc.body
+			if tc.auth != nil {
+				if _, errRegister := manager.Register(context.Background(), tc.auth); errRegister != nil {
+					t.Fatalf("Register() error = %v", errRegister)
+				}
+				body = `{"auth_index":"` + tc.auth.EnsureIndex() + `"}`
+			}
+
+			rec := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(rec)
+			req := httptest.NewRequest(http.MethodPost, "/v0/management/codex/ping", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			ctx.Request = req
+			(&Handler{authManager: manager}).CodexPing(ctx)
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d, body %s", rec.Code, tc.wantCode, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestCodexPingSendsStatelessResponsesRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	stream := `data: {"type":"response.output_text.delta","delta":"Pong"}` + "\n\n" +
+		`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"input_tokens_details":{"cached_tokens":0},"output_tokens":2,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":3}}}` + "\n\n"
+	exec := &codexPingTestExecutor{body: stream}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(exec)
+	auth := &coreauth.Auth{
+		ID:       "codex.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path":     "/tmp/codex.json",
+			"base_url": "https://codex.example.test/backend-api/codex",
+		},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"account_id":   "acct_123",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/codex/ping", strings.NewReader(`{"auth_index":"`+auth.EnsureIndex()+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	(&Handler{authManager: manager}).CodexPing(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if exec.lastAuth == nil {
+		t.Fatal("expected executor ExecuteStream to be called")
+	}
+	if exec.lastAuth.ID != auth.ID {
+		t.Fatalf("auth id = %q, want %q", exec.lastAuth.ID, auth.ID)
+	}
+	if exec.lastReq.Model != codexPingDefaultModel {
+		t.Fatalf("request model = %q, want %q", exec.lastReq.Model, codexPingDefaultModel)
+	}
+	if exec.lastReq.Format != sdktranslator.FromString("openai-response") {
+		t.Fatalf("request format = %q", exec.lastReq.Format)
+	}
+	if !exec.lastOpts.Stream {
+		t.Fatal("stream option = false, want true")
+	}
+	if exec.lastOpts.SourceFormat != sdktranslator.FromString("openai-response") {
+		t.Fatalf("source format = %q", exec.lastOpts.SourceFormat)
+	}
+	if got := exec.lastOpts.Metadata[cliproxyexecutor.PinnedAuthMetadataKey]; got != auth.ID {
+		t.Fatalf("pinned auth metadata = %v, want %q", got, auth.ID)
+	}
+	payload := gjson.ParseBytes(exec.lastReq.Payload)
+	if got := payload.Get("model").String(); got != codexPingDefaultModel {
+		t.Fatalf("model = %q, want %q", got, codexPingDefaultModel)
+	}
+	if got := payload.Get("stream").Bool(); !got {
+		t.Fatal("stream = false, want true")
+	}
+	if got := payload.Get("store").Bool(); got {
+		t.Fatal("store = true, want false")
+	}
+	if payload.Get("previous_response_id").Exists() {
+		t.Fatal("previous_response_id should be absent")
+	}
+	if got := payload.Get("reasoning.effort").String(); got != codexPingDefaultReasoning {
+		t.Fatalf("reasoning.effort = %q, want %q", got, codexPingDefaultReasoning)
+	}
+	if got := payload.Get("input").String(); got != codexPingDefaultPrompt {
+		t.Fatalf("prompt = %q, want %q", got, codexPingDefaultPrompt)
+	}
+
+	var response codexPingResponse
+	if errDecode := json.Unmarshal(rec.Body.Bytes(), &response); errDecode != nil {
+		t.Fatalf("failed to decode response: %v", errDecode)
+	}
+	if response.Message != "Pong" {
+		t.Fatalf("message = %q, want Pong", response.Message)
+	}
+	if response.Usage.TotalTokens != 3 || response.Usage.InputTokens != 1 || response.Usage.OutputTokens != 2 {
+		t.Fatalf("usage = %+v", response.Usage)
+	}
+}
+
+func TestParseCodexPingStreamFallbackMessageAndUsage(t *testing.T) {
+	stream := []byte(`data: {"type":"response.completed","response":{"output":[{"content":[{"type":"output_text","text":"Pong"}]}],"usage":{"inputTokens":4,"cachedInputTokens":1,"outputTokens":2,"reasoningTokens":0}}}` + "\n\n")
+
+	message, usage, completed := parseCodexPingStream(stream)
+	if !completed {
+		t.Fatal("completed = false, want true")
+	}
+	if message != "Pong" {
+		t.Fatalf("message = %q, want Pong", message)
+	}
+	if usage.InputTokens != 4 || usage.CachedInputTokens != 1 || usage.OutputTokens != 2 || usage.TotalTokens != 6 {
+		t.Fatalf("usage = %+v", usage)
+	}
+}
+
+func TestParseCodexPingStreamConcatenatesOutputItemFallbacks(t *testing.T) {
+	stream := []byte(`data: {"type":"response.output_item.done","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Po"}]}}` + "\n\n" +
+		`data: {"type":"response.output_item.done","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ng"}]}}` + "\n\n" +
+		`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}` + "\n\n")
+
+	message, usage, completed := parseCodexPingStream(stream)
+	if !completed {
+		t.Fatal("completed = false, want true")
+	}
+	if message != "Pong" {
+		t.Fatalf("message = %q, want Pong", message)
+	}
+	if usage.InputTokens != 1 || usage.OutputTokens != 2 || usage.TotalTokens != 3 {
+		t.Fatalf("usage = %+v", usage)
+	}
+}
+
+func TestCodexPingPreservesSplitStreamChunks(t *testing.T) {
+	exec := &codexPingTestExecutor{chunks: []string{
+		`data: {"type":"response.output_text.delta","delta":"Po`,
+		`ng!"}` + "\n\n",
+		`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}` + "\n\n",
+	}}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(exec)
+	auth := &coreauth.Auth{
+		ID:         "codex.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"path": "/tmp/codex.json"},
+		Metadata:   map[string]any{"access_token": "token"},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	response, errPing := (&Handler{authManager: manager}).sendCodexPing(context.Background(), auth)
+	if errPing != nil {
+		t.Fatalf("sendCodexPing() error = %v", errPing)
+	}
+	if response.Message != "Pong!" {
+		t.Fatalf("message = %q, want Pong!", response.Message)
+	}
+	if response.Usage.TotalTokens != 3 {
+		t.Fatalf("usage = %+v", response.Usage)
+	}
+}
+
+func TestCodexPingUpstreamFailureReturnsSafeError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	exec := &codexPingTestExecutor{err: errors.New("bad upstream secret-token")}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(exec)
+	auth := &coreauth.Auth{
+		ID:         "codex.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"path": "/tmp/codex.json"},
+		Metadata:   map[string]any{"access_token": "secret-token"},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/codex/ping", strings.NewReader(`{"auth_index":"`+auth.EnsureIndex()+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	(&Handler{authManager: manager}).CodexPing(ctx)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body %s", rec.Code, http.StatusBadGateway, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "secret-token") || strings.Contains(rec.Body.String(), "bad upstream") {
+		t.Fatalf("response leaked upstream detail: %s", rec.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -568,6 +568,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.DELETE("/proxy-url", s.mgmt.DeleteProxyURL)
 
 		mgmt.POST("/api-call", s.mgmt.APICall)
+		mgmt.POST("/codex/ping", s.mgmt.CodexPing)
 
 		mgmt.GET("/quota-exceeded/switch-project", s.mgmt.GetSwitchProject)
 		mgmt.PUT("/quota-exceeded/switch-project", s.mgmt.PutSwitchProject)


### PR DESCRIPTION
## Summary
- Add management Codex ping endpoint for selected auth files
- Send a stateless Codex Responses ping through the existing Codex executor
- Parse streamed message and token usage for the UI

## Tests
- go test ./internal/api/handlers/management -run 'TestCodexPing|TestParseCodexPing' -count=1
- go build -o test-output ./cmd/server && rm test-output

## Notes
- Full `go test ./...` still fails on unrelated existing registry and Antigravity tests.
