### PR TITLE
Add CLIProxyAPI Usage Dashboard to usage statistics docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Since v6.10.0, CLIProxyAPI and [CPAMC](https://github.com/router-for-me/Cli-Prox
 
 Standalone persistence and visualization service for CLIProxyAPI, with periodic data sync, SQLite storage, aggregate APIs, and a built-in dashboard for usage and statistics.
 
+### [CLIProxyAPI Usage Dashboard](https://github.com/zhanglunet/cliproxyapi-usage-dashboard)
+
+Local-first usage and quota dashboard for CLIProxyAPI. It collects per-request token usage from the Redis-compatible usage queue into SQLite, visualizes daily and recent-window usage by account and model, and shows Codex 5h/7d quota remaining in a local web UI.
+
 ## Amp CLI Support
 
 CLIProxyAPI includes integrated support for [Amp CLI](https://ampcode.com) and Amp IDE extensions, enabling you to use your Google/ChatGPT/Claude OAuth subscriptions with Amp's coding tools:

--- a/README_CN.md
+++ b/README_CN.md
@@ -84,7 +84,7 @@ CLIProxyAPI 用户手册： [https://help.router-for.me/](https://help.router-fo
 
 ### [CLIProxyAPI Usage Dashboard](https://github.com/zhanglunet/cliproxyapi-usage-dashboard)
 
-面向 CLIProxyAPI 的本地优先使用量与配额看板。它从 Redis 兼容使用量队列采集每次请求的 token 消耗并写入 SQLite，按账号和模型展示当天及最近时间窗口的用量，并在本地网页中显示 Codex 5h/7d 配额余量。
+面向 CLIProxyAPI 的本地优先使用量与配额看板。它从 Redis 兼容使用量队列采集每次请求的 Token 消耗并写入 SQLite，按账号和模型可视化每日及最近时间窗口的用量，并在本地网页中显示 Codex 5h/7d 配额余量。
 
 ## Amp CLI 支持
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -82,6 +82,10 @@ CLIProxyAPI 用户手册： [https://help.router-for.me/](https://help.router-fo
 
 独立的 CLIProxyAPI 使用量持久化与可视化服务，定期同步 CLIProxyAPI 数据，存储到 SQLite，提供聚合 API，并内置使用量分析与统计仪表盘。
 
+### [CLIProxyAPI Usage Dashboard](https://github.com/zhanglunet/cliproxyapi-usage-dashboard)
+
+面向 CLIProxyAPI 的本地优先使用量与配额看板。它从 Redis 兼容使用量队列采集每次请求的 token 消耗并写入 SQLite，按账号和模型展示当天及最近时间窗口的用量，并在本地网页中显示 Codex 5h/7d 配额余量。
+
 ## Amp CLI 支持
 
 CLIProxyAPI 已内置对 [Amp CLI](https://ampcode.com) 和 Amp IDE 扩展的支持，可让你使用自己的 Google/ChatGPT/Claude OAuth 订阅来配合 Amp 编码工具：

--- a/README_JA.md
+++ b/README_JA.md
@@ -80,6 +80,10 @@ v6.10.0以降、CLIProxyAPIおよび [CPAMC](https://github.com/router-for-me/Cl
 
 CLIProxyAPI向けの独立した使用量永続化・可視化サービス。CLIProxyAPIデータを定期同期してSQLiteに保存し、集計APIと、使用量や各種統計を確認できる組み込みダッシュボードを提供します。
 
+### [CLIProxyAPI Usage Dashboard](https://github.com/zhanglunet/cliproxyapi-usage-dashboard)
+
+CLIProxyAPI向けのローカル優先の使用量・クォータダッシュボード。Redis互換の使用量キューからリクエストごとのtoken使用量を収集してSQLiteに保存し、アカウント別・モデル別の日次および直近時間枠の使用量と、Codex 5h/7dクォータ残量をローカルWeb UIで表示します。
+
 ## Amp CLIサポート
 
 CLIProxyAPIは[Amp CLI](https://ampcode.com)およびAmp IDE拡張機能の統合サポートを含んでおり、Google/ChatGPT/ClaudeのOAuthサブスクリプションをAmpのコーディングツールで使用できます：

--- a/README_JA.md
+++ b/README_JA.md
@@ -82,7 +82,7 @@ CLIProxyAPI向けの独立した使用量永続化・可視化サービス。CLI
 
 ### [CLIProxyAPI Usage Dashboard](https://github.com/zhanglunet/cliproxyapi-usage-dashboard)
 
-CLIProxyAPI向けのローカル優先の使用量・クォータダッシュボード。Redis互換の使用量キューからリクエストごとのtoken使用量を収集してSQLiteに保存し、アカウント別・モデル別の日次および直近時間枠の使用量と、Codex 5h/7dクォータ残量をローカルWeb UIで表示します。
+CLIProxyAPI向けのローカル優先の使用量・クォータダッシュボード。Redis互換の使用量キューからリクエストごとのToken使用量を収集してSQLiteに保存し、アカウント別・モデル別の日次および直近時間枠の使用量を可視化し、Codex 5h/7dクォータ残量をローカルWeb UIで表示します。
 
 ## Amp CLIサポート
 


### PR DESCRIPTION
## Summary

- Add CLIProxyAPI Usage Dashboard to the Usage Statistics section
- Include English, Chinese, and Japanese README entries
- Link to the local-first SQLite usage and Codex quota dashboard

## Notes

This is a documentation-only change. The linked project collects per-request token usage from CLIProxyAPI's Redis-compatible usage queue, stores it in SQLite, and shows account/model usage plus Codex 5h/7d quota remaining in a local web UI.

## Checks

- Ran `git diff --check`
- Scanned README changes for local secrets, OAuth tokens, and account emails