### PR TITLE
fix(openai): emit keepalive for non-streaming chat completions

### DIFF
--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -431,7 +431,9 @@ func (h *OpenAIAPIHandler) handleNonStreamingResponse(c *gin.Context, rawJSON []
 
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
 	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, h.GetAlt(c))
+	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)
 		cliCancel(errMsg.Error)

--- a/sdk/api/handlers/openai/openai_handlers_keepalive_test.go
+++ b/sdk/api/handlers/openai/openai_handlers_keepalive_test.go
@@ -1,0 +1,99 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+type delayedOpenAIExecutor struct {
+	delay   time.Duration
+	payload []byte
+}
+
+func (e *delayedOpenAIExecutor) Identifier() string { return "openai" }
+
+func (e *delayedOpenAIExecutor) Execute(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	_ = auth
+	_ = req
+	_ = opts
+	select {
+	case <-time.After(e.delay):
+		return coreexecutor.Response{Payload: e.payload}, nil
+	case <-ctx.Done():
+		return coreexecutor.Response{}, ctx.Err()
+	}
+}
+
+func (e *delayedOpenAIExecutor) ExecuteStream(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	_ = ctx
+	_ = auth
+	_ = req
+	_ = opts
+	return nil, nil
+}
+
+func (e *delayedOpenAIExecutor) Refresh(ctx context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	_ = ctx
+	return auth, nil
+}
+
+func (e *delayedOpenAIExecutor) CountTokens(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	return e.Execute(ctx, auth, req, opts)
+}
+
+func (e *delayedOpenAIExecutor) HttpRequest(ctx context.Context, auth *coreauth.Auth, req *http.Request) (*http.Response, error) {
+	_ = ctx
+	_ = auth
+	_ = req
+	return nil, nil
+}
+
+func TestChatCompletionsNonStreamingEmitsKeepAliveWhileWaiting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const model = "slow-openai-model"
+	const authID = "openai-keepalive-test-auth"
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(&delayedOpenAIExecutor{
+		delay:   1200 * time.Millisecond,
+		payload: []byte(`{"id":"chatcmpl-test"}`),
+	})
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       authID,
+		Provider: "openai",
+		Status:   coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "openai", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(authID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{NonStreamKeepAliveInterval: 1}, manager)
+	handler := NewOpenAIAPIHandler(base)
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"`+model+`","messages":[{"role":"user","content":"hi"}]}`))
+
+	handler.ChatCompletions(ctx)
+
+	if body := rec.Body.String(); !strings.HasPrefix(body, "\n") {
+		t.Fatalf("expected non-streaming chat completions to emit keepalive before final JSON, got %q", body)
+	}
+}


### PR DESCRIPTION
## Summary

- Start non-streaming keepalive emission while `/v1/chat/completions` waits for upstream execution.
- Add a regression test covering delayed non-streaming chat completions responses.

## Why

Other non-streaming handlers already use `StartNonStreamingKeepAlive`, but OpenAI-compatible `/v1/chat/completions` did not. Long non-streaming requests could therefore remain idle long enough for intermediaries such as Cloudflare to close the connection before CLIProxyAPI writes the final JSON response.

## Validation

- `go test ./sdk/api/handlers/openai -count=1`
