### PR TITLE
fix: preserve parallel tool-call grouping for OpenAI Responses

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -1,6 +1,7 @@
 package responses
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/tidwall/gjson"
@@ -32,6 +33,22 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 	out := []byte(`{"model":"","messages":[],"stream":false}`)
 
 	root := gjson.ParseBytes(rawJSON)
+	appendMessage := func(message []byte) {
+		out, _ = sjson.SetRawBytes(out, "messages.-1", message)
+	}
+
+	flushAssistantToolCalls := func(toolCalls []string) {
+		if len(toolCalls) == 0 {
+			return
+		}
+
+		assistantMessage := []byte(`{"role":"assistant","tool_calls":[]}`)
+		for idx, toolCall := range toolCalls {
+			path := "tool_calls." + strconv.Itoa(idx)
+			assistantMessage, _ = sjson.SetRawBytes(assistantMessage, path, []byte(toolCall))
+		}
+		appendMessage(assistantMessage)
+	}
 
 	// Set model name
 	out, _ = sjson.SetBytes(out, "model", modelName)
@@ -57,6 +74,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 
 	// Convert input array to messages
 	if input := root.Get("input"); input.Exists() && input.IsArray() {
+		pendingAssistantToolCalls := make([]string, 0)
 		input.ForEach(func(_, item gjson.Result) bool {
 			itemType := item.Get("type").String()
 			if itemType == "" && item.Get("role").String() != "" {
@@ -65,6 +83,8 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 
 			switch itemType {
 			case "message", "":
+				flushAssistantToolCalls(pendingAssistantToolCalls)
+				pendingAssistantToolCalls = pendingAssistantToolCalls[:0]
 				// Handle regular message conversion
 				role := item.Get("role").String()
 				if role == "developer" {
@@ -109,12 +129,11 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					message, _ = sjson.SetBytes(message, "content", content.String())
 				}
 
-				out, _ = sjson.SetRawBytes(out, "messages.-1", message)
+				appendMessage(message)
 
 			case "function_call":
-				// Handle function call conversion to assistant message with tool_calls
-				assistantMessage := []byte(`{"role":"assistant","tool_calls":[]}`)
-
+				// Consecutive Responses function_call items belong to the same assistant
+				// turn and must remain grouped under one Chat Completions message.
 				toolCall := []byte(`{"id":"","type":"function","function":{"name":"","arguments":""}}`)
 
 				if callId := item.Get("call_id"); callId.Exists() {
@@ -129,10 +148,11 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					toolCall, _ = sjson.SetBytes(toolCall, "function.arguments", arguments.String())
 				}
 
-				assistantMessage, _ = sjson.SetRawBytes(assistantMessage, "tool_calls.0", toolCall)
-				out, _ = sjson.SetRawBytes(out, "messages.-1", assistantMessage)
+				pendingAssistantToolCalls = append(pendingAssistantToolCalls, string(toolCall))
 
 			case "function_call_output":
+				flushAssistantToolCalls(pendingAssistantToolCalls)
+				pendingAssistantToolCalls = pendingAssistantToolCalls[:0]
 				// Handle function call output conversion to tool message
 				toolMessage := []byte(`{"role":"tool","tool_call_id":"","content":""}`)
 
@@ -144,16 +164,17 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					toolMessage, _ = sjson.SetBytes(toolMessage, "content", output.String())
 				}
 
-				out, _ = sjson.SetRawBytes(out, "messages.-1", toolMessage)
+				appendMessage(toolMessage)
 			}
 
 			return true
 		})
+		flushAssistantToolCalls(pendingAssistantToolCalls)
 	} else if input.Type == gjson.String {
 		msg := []byte(`{}`)
 		msg, _ = sjson.SetBytes(msg, "role", "user")
 		msg, _ = sjson.SetBytes(msg, "content", input.String())
-		out, _ = sjson.SetRawBytes(out, "messages.-1", msg)
+		appendMessage(msg)
 	}
 
 	// Convert tools from responses format to chat completions format

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -1,0 +1,90 @@
+package responses
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_GroupsParallelFunctionCalls(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"model":"kimi-k2.6",
+		"parallel_tool_calls":true,
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"read files"}]},
+			{"type":"function_call","call_id":"read_a:0","name":"read_a","arguments":"{\"path\":\"a.txt\"}"},
+			{"type":"function_call","call_id":"read_b:1","name":"read_b","arguments":"{\"path\":\"b.txt\"}"},
+			{"type":"function_call_output","call_id":"read_a:0","output":"A"},
+			{"type":"function_call_output","call_id":"read_b:1","output":"B"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k2.6", raw, false)
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 4 {
+		t.Fatalf("messages length = %d, want 4, raw = %s", len(messages), out)
+	}
+
+	if messages[1].Get("role").String() != "assistant" {
+		t.Fatalf("messages.1.role = %q, want assistant", messages[1].Get("role").String())
+	}
+
+	toolCalls := messages[1].Get("tool_calls").Array()
+	if len(toolCalls) != 2 {
+		t.Fatalf("messages.1.tool_calls length = %d, want 2, raw = %s", len(toolCalls), messages[1].Get("tool_calls").Raw)
+	}
+
+	if got := toolCalls[0].Get("id").String(); got != "read_a:0" {
+		t.Fatalf("tool call 0 id = %q, want %q", got, "read_a:0")
+	}
+	if got := toolCalls[1].Get("id").String(); got != "read_b:1" {
+		t.Fatalf("tool call 1 id = %q, want %q", got, "read_b:1")
+	}
+	if got := toolCalls[0].Get("function.name").String(); got != "read_a" {
+		t.Fatalf("tool call 0 name = %q, want %q", got, "read_a")
+	}
+	if got := toolCalls[1].Get("function.name").String(); got != "read_b" {
+		t.Fatalf("tool call 1 name = %q, want %q", got, "read_b")
+	}
+
+	if got := messages[2].Get("tool_call_id").String(); got != "read_a:0" {
+		t.Fatalf("messages.2.tool_call_id = %q, want %q", got, "read_a:0")
+	}
+	if got := messages[3].Get("tool_call_id").String(); got != "read_b:1" {
+		t.Fatalf("messages.3.tool_call_id = %q, want %q", got, "read_b:1")
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_PreservesSingleFunctionCallFlow(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"model":"kimi-k2.6",
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"list files"}]},
+			{"type":"function_call","call_id":"list_files:0","name":"list_files","arguments":"{}"},
+			{"type":"function_call_output","call_id":"list_files:0","output":"[]"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k2.6", raw, false)
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 3 {
+		t.Fatalf("messages length = %d, want 3, raw = %s", len(messages), out)
+	}
+
+	toolCalls := messages[1].Get("tool_calls").Array()
+	if len(toolCalls) != 1 {
+		t.Fatalf("messages.1.tool_calls length = %d, want 1", len(toolCalls))
+	}
+	if got := toolCalls[0].Get("id").String(); got != "list_files:0" {
+		t.Fatalf("tool call id = %q, want %q", got, "list_files:0")
+	}
+	if got := messages[2].Get("tool_call_id").String(); got != "list_files:0" {
+		t.Fatalf("messages.2.tool_call_id = %q, want %q", got, "list_files:0")
+	}
+}


### PR DESCRIPTION
## Summary

This fixes a bug in the OpenAI Responses -> Chat Completions request conversion path that breaks parallel tool calling for Kimi-compatible upstreams.

## Root cause

OpenAI Responses can emit multiple consecutive `function_call` items in a single assistant turn when `parallel_tool_calls` is enabled.

Before this patch, `ConvertOpenAIResponsesRequestToOpenAIChatCompletions` converted each `function_call` item into its own assistant message containing a single `tool_calls` entry.

That rewrote a single assistant turn like:

- assistant: `function_call(read_a:0)`
- assistant: `function_call(read_b:1)`
- tool: `function_call_output(read_a:0)`
- tool: `function_call_output(read_b:1)`

into Chat Completions messages shaped like:

- assistant with `tool_calls=[read_a:0]`
- assistant with `tool_calls=[read_b:1]`
- tool result for `read_a:0`
- tool result for `read_b:1`

Some upstreams, including Kimi on the Responses compatibility path, validate tool results strictly against the immediately preceding assistant tool-call turn. Because the parallel calls were split across multiple assistant messages, the first tool result no longer matched the expected transcript shape and upstream rejected it with errors like:

- `an assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'`
- `The following tool_call_ids did not have response messages: read_a:0`

## Fix

- Buffer consecutive Responses `function_call` items.
- Flush them as a single Chat Completions assistant message with multiple `tool_calls` entries.
- Flush buffered tool calls before any normal message or any `function_call_output` item.
- Keep single-tool behavior unchanged.

## Tests

Added request-conversion regression tests covering:

- single function call + output stays unchanged
- parallel function calls are grouped into one assistant `tool_calls` message
- corresponding tool outputs keep their original `tool_call_id` / `call_id` mapping, including `name:index`-style ids such as `read_a:0`

## Validation

Ran:

- `go test -run 'TestConvertOpenAIResponsesRequestToOpenAIChatCompletions|TestNormalizeKimiToolMessageLinks' ./internal/translator/openai/openai/responses ./internal/runtime/executor`
- `go build -o /tmp/cli-proxy-api-test ./cmd/server && rm /tmp/cli-proxy-api-test`

Note: `go test ./internal/runtime/executor` currently includes unrelated pre-existing `antigravity` failures in this environment, so validation was scoped to the affected Responses/Kimi paths.
