### PR TITLE
fix(claude): remap Bifrost custom tools for OAuth cloaking

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1349,7 +1349,8 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 		toolCount := 0
 		tools.ForEach(func(_, tool gjson.Result) bool {
 			// Keep Anthropic built-in tools (web_search, code_execution, etc.) unchanged.
-			if tool.Get("type").Exists() && tool.Get("type").String() != "" {
+			toolType := tool.Get("type").String()
+			if helps.IsClaudeBuiltinToolType(toolType) {
 				if toolCount > 0 {
 					toolsJSON.WriteByte(',')
 				}
@@ -1364,6 +1365,12 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			}
 
 			toolJSON := tool.Raw
+			if toolType != "" {
+				updatedTool, err := sjson.Delete(toolJSON, "type")
+				if err == nil {
+					toolJSON = updatedTool
+				}
+			}
 			if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
 				updatedTool, err := sjson.Set(toolJSON, "name", newName)
 				if err == nil {
@@ -1547,7 +1554,7 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 		tools.ForEach(func(index, tool gjson.Result) bool {
 			// Skip built-in tools (web_search, code_execution, etc.) which have
 			// a "type" field and require their name to remain unchanged.
-			if tool.Get("type").Exists() && tool.Get("type").String() != "" {
+			if helps.IsClaudeBuiltinToolType(tool.Get("type").String()) {
 				if n := tool.Get("name").String(); n != "" {
 					builtinTools[n] = true
 				}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1328,7 +1328,7 @@ func restoreClaudeOAuthToolNamesFromStreamLine(line []byte, prefix string, prefi
 // regardless of what the client originally sent.
 func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 	reverseMap := make(map[string]string, len(oauthToolRenameMap))
-	builtinTools := helps.AugmentClaudeBuiltinToolRegistry(body, map[string]bool{})
+	preservedTools := helps.AugmentClaudePreservedToolRegistry(body, map[string]bool{})
 	recordRename := func(original, renamed string) {
 		// Preserve the first-seen original name if the same upstream name is
 		// produced from multiple call sites; they all map back identically.
@@ -1351,7 +1351,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 		tools.ForEach(func(_, tool gjson.Result) bool {
 			// Keep Anthropic built-in tools (web_search, code_execution, etc.) unchanged.
 			toolType := tool.Get("type").String()
-			if helps.IsClaudeBuiltinToolType(toolType) {
+			if helps.IsClaudePreservedTypedToolType(toolType) {
 				if toolCount > 0 {
 					toolsJSON.WriteByte(',')
 				}
@@ -1366,7 +1366,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			}
 
 			toolJSON := tool.Raw
-			if toolType != "" {
+			if helps.IsClaudeCustomToolType(toolType) {
 				updatedTool, err := sjson.Delete(toolJSON, "type")
 				if err == nil {
 					toolJSON = updatedTool
@@ -1399,7 +1399,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			// The chosen tool was removed from the tools array, so drop tool_choice to
 			// keep the payload internally consistent and fall back to normal auto tool use.
 			body, _ = sjson.DeleteBytes(body, "tool_choice")
-		} else if !builtinTools[tcName] {
+		} else if !preservedTools[tcName] {
 			if newName, ok := oauthToolRenameMap[tcName]; ok && newName != tcName {
 				body, _ = sjson.SetBytes(body, "tool_choice.name", newName)
 				recordRename(tcName, newName)
@@ -1420,7 +1420,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 				switch partType {
 				case "tool_use":
 					name := part.Get("name").String()
-					if !builtinTools[name] {
+					if !preservedTools[name] {
 						if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
 							path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
 							body, _ = sjson.SetBytes(body, path, newName)
@@ -1429,7 +1429,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 					}
 				case "tool_reference":
 					toolName := part.Get("tool_name").String()
-					if !builtinTools[toolName] {
+					if !preservedTools[toolName] {
 						if newName, ok := oauthToolRenameMap[toolName]; ok && newName != toolName {
 							path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
 							body, _ = sjson.SetBytes(body, path, newName)
@@ -1445,7 +1445,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 						nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
 							if nestedPart.Get("type").String() == "tool_reference" {
 								nestedToolName := nestedPart.Get("tool_name").String()
-								if !builtinTools[nestedToolName] {
+								if !preservedTools[nestedToolName] {
 									if newName, ok := oauthToolRenameMap[nestedToolName]; ok && newName != nestedToolName {
 										nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
 										body, _ = sjson.SetBytes(body, nestedPath, newName)
@@ -1555,18 +1555,17 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 		return body
 	}
 
-	// Collect built-in tool names from the authoritative fallback seed list and
-	// augment it with any typed built-ins present in the current request body.
-	builtinTools := helps.AugmentClaudeBuiltinToolRegistry(body, nil)
+	// Collect tool names that must stay untouched: fallback built-in names plus
+	// any typed tool definitions in the current request except synthetic
+	// type:"custom" wrappers.
+	preservedTools := helps.AugmentClaudeBuiltinToolRegistry(body, nil)
+	preservedTools = helps.AugmentClaudePreservedToolRegistry(body, preservedTools)
 
 	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
 		tools.ForEach(func(index, tool gjson.Result) bool {
-			// Skip built-in tools (web_search, code_execution, etc.) which have
-			// a "type" field and require their name to remain unchanged.
-			if helps.IsClaudeBuiltinToolType(tool.Get("type").String()) {
-				if n := tool.Get("name").String(); n != "" {
-					builtinTools[n] = true
-				}
+			// Skip builtin and other opaque typed tools, but still allow synthetic
+			// type:"custom" wrappers to flow through the custom-tool prefix logic.
+			if helps.IsClaudePreservedTypedToolType(tool.Get("type").String()) {
 				return true
 			}
 			name := tool.Get("name").String()
@@ -1581,7 +1580,7 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 
 	if gjson.GetBytes(body, "tool_choice.type").String() == "tool" {
 		name := gjson.GetBytes(body, "tool_choice.name").String()
-		if name != "" && !strings.HasPrefix(name, prefix) && !builtinTools[name] {
+		if name != "" && !strings.HasPrefix(name, prefix) && !preservedTools[name] {
 			body, _ = sjson.SetBytes(body, "tool_choice.name", prefix+name)
 		}
 	}
@@ -1597,14 +1596,14 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 				switch partType {
 				case "tool_use":
 					name := part.Get("name").String()
-					if name == "" || strings.HasPrefix(name, prefix) || builtinTools[name] {
+					if name == "" || strings.HasPrefix(name, prefix) || preservedTools[name] {
 						return true
 					}
 					path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
 					body, _ = sjson.SetBytes(body, path, prefix+name)
 				case "tool_reference":
 					toolName := part.Get("tool_name").String()
-					if toolName == "" || strings.HasPrefix(toolName, prefix) || builtinTools[toolName] {
+					if toolName == "" || strings.HasPrefix(toolName, prefix) || preservedTools[toolName] {
 						return true
 					}
 					path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
@@ -1616,7 +1615,7 @@ func applyClaudeToolPrefix(body []byte, prefix string) []byte {
 						nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
 							if nestedPart.Get("type").String() == "tool_reference" {
 								nestedToolName := nestedPart.Get("tool_name").String()
-								if nestedToolName != "" && !strings.HasPrefix(nestedToolName, prefix) && !builtinTools[nestedToolName] {
+								if nestedToolName != "" && !strings.HasPrefix(nestedToolName, prefix) && !preservedTools[nestedToolName] {
 									nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
 									body, _ = sjson.SetBytes(body, nestedPath, prefix+nestedToolName)
 								}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1328,6 +1328,7 @@ func restoreClaudeOAuthToolNamesFromStreamLine(line []byte, prefix string, prefi
 // regardless of what the client originally sent.
 func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 	reverseMap := make(map[string]string, len(oauthToolRenameMap))
+	builtinTools := helps.AugmentClaudeBuiltinToolRegistry(body, map[string]bool{})
 	recordRename := func(original, renamed string) {
 		// Preserve the first-seen original name if the same upstream name is
 		// produced from multiple call sites; they all map back identically.
@@ -1398,9 +1399,11 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			// The chosen tool was removed from the tools array, so drop tool_choice to
 			// keep the payload internally consistent and fall back to normal auto tool use.
 			body, _ = sjson.DeleteBytes(body, "tool_choice")
-		} else if newName, ok := oauthToolRenameMap[tcName]; ok && newName != tcName {
-			body, _ = sjson.SetBytes(body, "tool_choice.name", newName)
-			recordRename(tcName, newName)
+		} else if !builtinTools[tcName] {
+			if newName, ok := oauthToolRenameMap[tcName]; ok && newName != tcName {
+				body, _ = sjson.SetBytes(body, "tool_choice.name", newName)
+				recordRename(tcName, newName)
+			}
 		}
 	}
 
@@ -1417,17 +1420,21 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 				switch partType {
 				case "tool_use":
 					name := part.Get("name").String()
-					if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
-						path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
-						body, _ = sjson.SetBytes(body, path, newName)
-						recordRename(name, newName)
+					if !builtinTools[name] {
+						if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
+							path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
+							body, _ = sjson.SetBytes(body, path, newName)
+							recordRename(name, newName)
+						}
 					}
 				case "tool_reference":
 					toolName := part.Get("tool_name").String()
-					if newName, ok := oauthToolRenameMap[toolName]; ok && newName != toolName {
-						path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
-						body, _ = sjson.SetBytes(body, path, newName)
-						recordRename(toolName, newName)
+					if !builtinTools[toolName] {
+						if newName, ok := oauthToolRenameMap[toolName]; ok && newName != toolName {
+							path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
+							body, _ = sjson.SetBytes(body, path, newName)
+							recordRename(toolName, newName)
+						}
 					}
 				case "tool_result":
 					// Handle nested tool_reference blocks inside tool_result.content[]
@@ -1438,10 +1445,12 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 						nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
 							if nestedPart.Get("type").String() == "tool_reference" {
 								nestedToolName := nestedPart.Get("tool_name").String()
-								if newName, ok := oauthToolRenameMap[nestedToolName]; ok && newName != nestedToolName {
-									nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
-									body, _ = sjson.SetBytes(body, nestedPath, newName)
-									recordRename(nestedToolName, newName)
+								if !builtinTools[nestedToolName] {
+									if newName, ok := oauthToolRenameMap[nestedToolName]; ok && newName != nestedToolName {
+										nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
+										body, _ = sjson.SetBytes(body, nestedPath, newName)
+										recordRename(nestedToolName, newName)
+									}
 								}
 							}
 							return true

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -747,6 +747,41 @@ func TestApplyClaudeToolPrefix_CustomTypedToolsArePrefixed(t *testing.T) {
 	}
 }
 
+func TestApplyClaudeToolPrefix_UntypedBashStaysCustom(t *testing.T) {
+	body := []byte(`{
+		"tools": [
+			{"name": "bash"}
+		],
+		"tool_choice": {"type": "tool", "name": "bash"},
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "tool_use", "name": "bash", "id": "b1", "input": {}},
+				{"type": "tool_reference", "tool_name": "bash"},
+				{"type": "tool_result", "tool_use_id": "b1", "content": [
+					{"type": "tool_reference", "tool_name": "bash"}
+				]}
+			]}
+		]
+	}`)
+	out := applyClaudeToolPrefix(body, "proxy_")
+
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "proxy_bash" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "proxy_bash")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "proxy_bash" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "proxy_bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "proxy_bash" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "proxy_bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.tool_name").String(); got != "proxy_bash" {
+		t.Fatalf("messages.0.content.1.tool_name = %q, want %q", got, "proxy_bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.2.content.0.tool_name").String(); got != "proxy_bash" {
+		t.Fatalf("messages.0.content.2.content.0.tool_name = %q, want %q", got, "proxy_bash")
+	}
+}
+
 func TestApplyClaudeToolPrefix_KnownBuiltinInHistoryOnly(t *testing.T) {
 	body := []byte(`{
 		"tools": [
@@ -3084,5 +3119,50 @@ func TestRemapOAuthToolNames_BuiltinTypedToolsStayUntouched(t *testing.T) {
 	}
 	if got := gjson.GetBytes(out, "messages.0.content.2.content.0.tool_name").String(); got != "web_search" {
 		t.Fatalf("messages.0.content.2.content.0.tool_name = %q, want %q", got, "web_search")
+	}
+}
+
+func TestRemapOAuthToolNames_NewBuiltinTypedToolsStayUntouched(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolType string
+		toolName string
+	}{
+		{name: "bash", toolType: "bash_20250124", toolName: "bash"},
+		{name: "memory", toolType: "memory_20250818", toolName: "memory"},
+		{name: "web fetch", toolType: "web_fetch_20260209", toolName: "web_fetch"},
+		{name: "tool search", toolType: "tool_search_tool_regex_20251119", toolName: "tool_search_tool_regex"},
+		{name: "advisor", toolType: "advisor_20260301", toolName: "advisor"},
+		{name: "mcp toolset", toolType: "mcp_toolset", toolName: "mcp_toolset"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(fmt.Sprintf(`{"tools":[{"type":%q,"name":%q}],"tool_choice":{"type":"tool","name":%q},"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":%q,"input":{}},{"type":"tool_reference","tool_name":%q},{"type":"tool_result","tool_use_id":"toolu_01","content":[{"type":"tool_reference","tool_name":%q}]}]}]}`,
+				tt.toolType, tt.toolName, tt.toolName, tt.toolName, tt.toolName, tt.toolName))
+
+			out, reverseMap := remapOAuthToolNames(body)
+			if len(reverseMap) != 0 {
+				t.Fatalf("reverseMap = %v, want empty map", reverseMap)
+			}
+			if got := gjson.GetBytes(out, "tools.0.name").String(); got != tt.toolName {
+				t.Fatalf("tools.0.name = %q, want %q", got, tt.toolName)
+			}
+			if got := gjson.GetBytes(out, "tools.0.type").String(); got != tt.toolType {
+				t.Fatalf("tools.0.type = %q, want %q", got, tt.toolType)
+			}
+			if got := gjson.GetBytes(out, "tool_choice.name").String(); got != tt.toolName {
+				t.Fatalf("tool_choice.name = %q, want %q", got, tt.toolName)
+			}
+			if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != tt.toolName {
+				t.Fatalf("messages.0.content.0.name = %q, want %q", got, tt.toolName)
+			}
+			if got := gjson.GetBytes(out, "messages.0.content.1.tool_name").String(); got != tt.toolName {
+				t.Fatalf("messages.0.content.1.tool_name = %q, want %q", got, tt.toolName)
+			}
+			if got := gjson.GetBytes(out, "messages.0.content.2.content.0.tool_name").String(); got != tt.toolName {
+				t.Fatalf("messages.0.content.2.content.0.tool_name = %q, want %q", got, tt.toolName)
+			}
+		})
 	}
 }

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -712,6 +712,41 @@ func TestApplyClaudeToolPrefix_BuiltinToolSkipped(t *testing.T) {
 	}
 }
 
+func TestApplyClaudeToolPrefix_CustomTypedToolsArePrefixed(t *testing.T) {
+	body := []byte(`{
+		"tools": [
+			{"type": "custom", "name": "Read"}
+		],
+		"tool_choice": {"type": "tool", "name": "Read"},
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "tool_use", "name": "Read", "id": "r1", "input": {}},
+				{"type": "tool_reference", "tool_name": "Read"},
+				{"type": "tool_result", "tool_use_id": "r1", "content": [
+					{"type": "tool_reference", "tool_name": "Read"}
+				]}
+			]}
+		]
+	}`)
+	out := applyClaudeToolPrefix(body, "proxy_")
+
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "proxy_Read" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "proxy_Read")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "proxy_Read" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "proxy_Read")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "proxy_Read" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "proxy_Read")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.tool_name").String(); got != "proxy_Read" {
+		t.Fatalf("messages.0.content.1.tool_name = %q, want %q", got, "proxy_Read")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.2.content.0.tool_name").String(); got != "proxy_Read" {
+		t.Fatalf("messages.0.content.2.content.0.tool_name = %q, want %q", got, "proxy_Read")
+	}
+}
+
 func TestApplyClaudeToolPrefix_KnownBuiltinInHistoryOnly(t *testing.T) {
 	body := []byte(`{
 		"tools": [
@@ -2977,5 +3012,77 @@ func TestEnsureClaudeThinkingDisplay_SkipsWhenThinkingMissing(t *testing.T) {
 
 	if gjson.GetBytes(out, "thinking").Exists() {
 		t.Fatalf("thinking should remain absent: %s", out)
+	}
+}
+
+func TestRemapOAuthToolNames_CustomTypedToolsAreRenamedAndUntyped(t *testing.T) {
+	body := []byte(`{
+		"tools": [
+			{"type":"custom","name":"bash","description":"Run shell commands","input_schema":{"type":"object","properties":{"cmd":{"type":"string"}}}}
+		],
+		"tool_choice": {"type":"tool","name":"bash"},
+		"messages": [
+			{"role":"assistant","content":[
+				{"type":"tool_use","id":"toolu_01","name":"bash","input":{"cmd":"ls"}},
+				{"type":"tool_reference","tool_name":"bash"},
+				{"type":"tool_result","tool_use_id":"toolu_01","content":[{"type":"tool_reference","tool_name":"bash"}]}
+			]}
+		]
+	}`)
+
+	out, reverseMap := remapOAuthToolNames(body)
+	if len(reverseMap) != 1 || reverseMap["Bash"] != "bash" {
+		t.Fatalf("reverseMap = %v, want {Bash:bash}", reverseMap)
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "Bash" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "Bash")
+	}
+	if gjson.GetBytes(out, "tools.0.type").Exists() {
+		t.Fatalf("tools.0.type should be removed for custom tools, got %q", gjson.GetBytes(out, "tools.0.type").String())
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "Bash" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "Bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "Bash" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "Bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.tool_name").String(); got != "Bash" {
+		t.Fatalf("messages.0.content.1.tool_name = %q, want %q", got, "Bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.2.content.0.tool_name").String(); got != "Bash" {
+		t.Fatalf("messages.0.content.2.content.0.tool_name = %q, want %q", got, "Bash")
+	}
+
+	resp := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"cmd":"ls"}}]}`)
+	reversed := reverseRemapOAuthToolNames(resp, reverseMap)
+	if got := gjson.GetBytes(reversed, "content.0.name").String(); got != "bash" {
+		t.Fatalf("content.0.name = %q, want %q", got, "bash")
+	}
+}
+
+func TestRemapOAuthToolNames_BuiltinTypedToolsStayUntouched(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"web_search_20250305","name":"web_search"}],"tool_choice":{"type":"tool","name":"web_search"},"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"web_search","input":{}},{"type":"tool_reference","tool_name":"web_search"},{"type":"tool_result","tool_use_id":"toolu_01","content":[{"type":"tool_reference","tool_name":"web_search"}]}]}]}`)
+
+	out, reverseMap := remapOAuthToolNames(body)
+	if len(reverseMap) != 0 {
+		t.Fatalf("reverseMap = %v, want empty map", reverseMap)
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "web_search" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "web_search_20250305" {
+		t.Fatalf("tools.0.type = %q, want %q", got, "web_search_20250305")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "web_search" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "web_search" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.tool_name").String(); got != "web_search" {
+		t.Fatalf("messages.0.content.1.tool_name = %q, want %q", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.2.content.0.tool_name").String(); got != "web_search" {
+		t.Fatalf("messages.0.content.2.content.0.tool_name = %q, want %q", got, "web_search")
 	}
 }

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -747,6 +747,44 @@ func TestApplyClaudeToolPrefix_CustomTypedToolsArePrefixed(t *testing.T) {
 	}
 }
 
+func TestApplyClaudeToolPrefix_UnknownTypedToolsStayUntouched(t *testing.T) {
+	body := []byte(`{
+		"tools": [
+			{"type": "custom_builtin_20250401", "name": "bash"}
+		],
+		"tool_choice": {"type": "tool", "name": "bash"},
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "tool_use", "name": "bash", "id": "b1", "input": {}},
+				{"type": "tool_reference", "tool_name": "bash"},
+				{"type": "tool_result", "tool_use_id": "b1", "content": [
+					{"type": "tool_reference", "tool_name": "bash"}
+				]}
+			]}
+		]
+	}`)
+	out := applyClaudeToolPrefix(body, "proxy_")
+
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "bash" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "bash")
+	}
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "custom_builtin_20250401" {
+		t.Fatalf("tools.0.type = %q, want %q", got, "custom_builtin_20250401")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "bash" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "bash" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.tool_name").String(); got != "bash" {
+		t.Fatalf("messages.0.content.1.tool_name = %q, want %q", got, "bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.2.content.0.tool_name").String(); got != "bash" {
+		t.Fatalf("messages.0.content.2.content.0.tool_name = %q, want %q", got, "bash")
+	}
+}
+
 func TestApplyClaudeToolPrefix_UntypedBashStaysCustom(t *testing.T) {
 	body := []byte(`{
 		"tools": [
@@ -3092,6 +3130,45 @@ func TestRemapOAuthToolNames_CustomTypedToolsAreRenamedAndUntyped(t *testing.T) 
 	reversed := reverseRemapOAuthToolNames(resp, reverseMap)
 	if got := gjson.GetBytes(reversed, "content.0.name").String(); got != "bash" {
 		t.Fatalf("content.0.name = %q, want %q", got, "bash")
+	}
+}
+
+func TestRemapOAuthToolNames_UnknownTypedToolsStayUntouched(t *testing.T) {
+	body := []byte(`{
+		"tools": [
+			{"type":"custom_builtin_20250401","name":"bash","description":"Run shell commands","input_schema":{"type":"object","properties":{"cmd":{"type":"string"}}}}
+		],
+		"tool_choice": {"type":"tool","name":"bash"},
+		"messages": [
+			{"role":"assistant","content":[
+				{"type":"tool_use","id":"toolu_01","name":"bash","input":{"cmd":"ls"}},
+				{"type":"tool_reference","tool_name":"bash"},
+				{"type":"tool_result","tool_use_id":"toolu_01","content":[{"type":"tool_reference","tool_name":"bash"}]}
+			]}
+		]
+	}`)
+
+	out, reverseMap := remapOAuthToolNames(body)
+	if len(reverseMap) != 0 {
+		t.Fatalf("reverseMap = %v, want empty map", reverseMap)
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "bash" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "bash")
+	}
+	if got := gjson.GetBytes(out, "tools.0.type").String(); got != "custom_builtin_20250401" {
+		t.Fatalf("tools.0.type = %q, want %q", got, "custom_builtin_20250401")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "bash" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "bash" {
+		t.Fatalf("messages.0.content.0.name = %q, want %q", got, "bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.tool_name").String(); got != "bash" {
+		t.Fatalf("messages.0.content.1.tool_name = %q, want %q", got, "bash")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.2.content.0.tool_name").String(); got != "bash" {
+		t.Fatalf("messages.0.content.2.content.0.tool_name = %q, want %q", got, "bash")
 	}
 }
 

--- a/internal/runtime/executor/helps/claude_builtin_tools.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools.go
@@ -14,21 +14,21 @@ var defaultClaudeBuiltinToolNames = []string{
 }
 
 type claudeBuiltinToolTypeFamily struct {
-	exact     string
-	exactOnly bool
+	exact  string
+	prefix string
 }
 
 var defaultClaudeBuiltinToolTypeFamilies = []claudeBuiltinToolTypeFamily{
-	{exact: "web_search"},
-	{exact: "code_execution"},
-	{exact: "text_editor"},
-	{exact: "computer"},
-	{exact: "bash"},
-	{exact: "memory"},
-	{exact: "web_fetch"},
-	{exact: "tool_search_tool_regex"},
-	{exact: "advisor"},
-	{exact: "mcp_toolset", exactOnly: true},
+	{exact: "web_search", prefix: "web_search_"},
+	{exact: "code_execution", prefix: "code_execution_"},
+	{exact: "text_editor", prefix: "text_editor_"},
+	{exact: "computer", prefix: "computer_"},
+	{exact: "bash", prefix: "bash_"},
+	{exact: "memory", prefix: "memory_"},
+	{exact: "web_fetch", prefix: "web_fetch_"},
+	{exact: "tool_search_tool_regex", prefix: "tool_search_tool_regex_"},
+	{exact: "advisor", prefix: "advisor_"},
+	{exact: "mcp_toolset"},
 }
 
 func newClaudeBuiltinToolRegistry() map[string]bool {
@@ -48,7 +48,7 @@ func IsClaudeBuiltinToolType(toolType string) bool {
 		if toolType == family.exact {
 			return true
 		}
-		if !family.exactOnly && strings.HasPrefix(toolType, family.exact+"_") {
+		if family.prefix != "" && strings.HasPrefix(toolType, family.prefix) {
 			return true
 		}
 	}

--- a/internal/runtime/executor/helps/claude_builtin_tools.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools.go
@@ -13,6 +13,24 @@ var defaultClaudeBuiltinToolNames = []string{
 	"computer",
 }
 
+type claudeBuiltinToolTypeFamily struct {
+	exact     string
+	exactOnly bool
+}
+
+var defaultClaudeBuiltinToolTypeFamilies = []claudeBuiltinToolTypeFamily{
+	{exact: "web_search"},
+	{exact: "code_execution"},
+	{exact: "text_editor"},
+	{exact: "computer"},
+	{exact: "bash"},
+	{exact: "memory"},
+	{exact: "web_fetch"},
+	{exact: "tool_search_tool_regex"},
+	{exact: "advisor"},
+	{exact: "mcp_toolset", exactOnly: true},
+}
+
 func newClaudeBuiltinToolRegistry() map[string]bool {
 	registry := make(map[string]bool, len(defaultClaudeBuiltinToolNames))
 	for _, name := range defaultClaudeBuiltinToolNames {
@@ -26,8 +44,11 @@ func IsClaudeBuiltinToolType(toolType string) bool {
 	if toolType == "" {
 		return false
 	}
-	for _, builtinName := range defaultClaudeBuiltinToolNames {
-		if toolType == builtinName || strings.HasPrefix(toolType, builtinName+"_") {
+	for _, family := range defaultClaudeBuiltinToolTypeFamilies {
+		if toolType == family.exact {
+			return true
+		}
+		if !family.exactOnly && strings.HasPrefix(toolType, family.exact+"_") {
 			return true
 		}
 	}

--- a/internal/runtime/executor/helps/claude_builtin_tools.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools.go
@@ -55,6 +55,15 @@ func IsClaudeBuiltinToolType(toolType string) bool {
 	return false
 }
 
+func IsClaudeCustomToolType(toolType string) bool {
+	return strings.TrimSpace(toolType) == "custom"
+}
+
+func IsClaudePreservedTypedToolType(toolType string) bool {
+	toolType = strings.TrimSpace(toolType)
+	return toolType != "" && toolType != "custom"
+}
+
 func AugmentClaudeBuiltinToolRegistry(body []byte, registry map[string]bool) map[string]bool {
 	if registry == nil {
 		registry = newClaudeBuiltinToolRegistry()
@@ -65,6 +74,26 @@ func AugmentClaudeBuiltinToolRegistry(body []byte, registry map[string]bool) map
 	}
 	tools.ForEach(func(_, tool gjson.Result) bool {
 		if !IsClaudeBuiltinToolType(tool.Get("type").String()) {
+			return true
+		}
+		if name := tool.Get("name").String(); name != "" {
+			registry[name] = true
+		}
+		return true
+	})
+	return registry
+}
+
+func AugmentClaudePreservedToolRegistry(body []byte, registry map[string]bool) map[string]bool {
+	if registry == nil {
+		registry = make(map[string]bool)
+	}
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return registry
+	}
+	tools.ForEach(func(_, tool gjson.Result) bool {
+		if !IsClaudePreservedTypedToolType(tool.Get("type").String()) {
 			return true
 		}
 		if name := tool.Get("name").String(); name != "" {

--- a/internal/runtime/executor/helps/claude_builtin_tools.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools.go
@@ -1,6 +1,10 @@
 package helps
 
-import "github.com/tidwall/gjson"
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
 
 var defaultClaudeBuiltinToolNames = []string{
 	"web_search",
@@ -17,6 +21,19 @@ func newClaudeBuiltinToolRegistry() map[string]bool {
 	return registry
 }
 
+func IsClaudeBuiltinToolType(toolType string) bool {
+	toolType = strings.TrimSpace(toolType)
+	if toolType == "" {
+		return false
+	}
+	for _, builtinName := range defaultClaudeBuiltinToolNames {
+		if toolType == builtinName || strings.HasPrefix(toolType, builtinName+"_") {
+			return true
+		}
+	}
+	return false
+}
+
 func AugmentClaudeBuiltinToolRegistry(body []byte, registry map[string]bool) map[string]bool {
 	if registry == nil {
 		registry = newClaudeBuiltinToolRegistry()
@@ -26,7 +43,7 @@ func AugmentClaudeBuiltinToolRegistry(body []byte, registry map[string]bool) map
 		return registry
 	}
 	tools.ForEach(func(_, tool gjson.Result) bool {
-		if tool.Get("type").String() == "" {
+		if !IsClaudeBuiltinToolType(tool.Get("type").String()) {
 			return true
 		}
 		if name := tool.Get("name").String(); name != "" {

--- a/internal/runtime/executor/helps/claude_builtin_tools_test.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools_test.go
@@ -15,7 +15,7 @@ func TestClaudeBuiltinToolRegistry_AugmentsTypedBuiltinsFromBody(t *testing.T) {
 	registry := AugmentClaudeBuiltinToolRegistry([]byte(`{
 		"tools": [
 			{"type": "web_search_20250305", "name": "web_search"},
-			{"type": "custom_builtin_20250401", "name": "special_builtin"},
+			{"type": "computer_20250124", "name": "computer"},
 			{"name": "Read"}
 		]
 	}`), nil)
@@ -23,10 +23,26 @@ func TestClaudeBuiltinToolRegistry_AugmentsTypedBuiltinsFromBody(t *testing.T) {
 	if !registry["web_search"] {
 		t.Fatal("expected default typed builtin web_search in registry")
 	}
-	if !registry["special_builtin"] {
+	if !registry["computer"] {
 		t.Fatal("expected typed builtin from body to be added to registry")
 	}
 	if registry["Read"] {
 		t.Fatal("expected untyped custom tool to stay out of builtin registry")
+	}
+}
+
+func TestClaudeBuiltinToolRegistry_CustomTypedToolsStayOutOfRegistry(t *testing.T) {
+	registry := AugmentClaudeBuiltinToolRegistry([]byte(`{
+		"tools": [
+			{"type": "custom", "name": "Read"},
+			{"type": "custom_builtin_20250401", "name": "special_builtin"}
+		]
+	}`), nil)
+
+	if registry["Read"] {
+		t.Fatal("expected type=custom tool to stay out of builtin registry")
+	}
+	if registry["special_builtin"] {
+		t.Fatal("expected unknown typed tool to stay out of builtin registry")
 	}
 }

--- a/internal/runtime/executor/helps/claude_builtin_tools_test.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools_test.go
@@ -2,6 +2,34 @@ package helps
 
 import "testing"
 
+func TestIsClaudeBuiltinToolType_KnownFamilies(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolType string
+		want     bool
+	}{
+		{name: "empty", toolType: "", want: false},
+		{name: "custom", toolType: "custom", want: false},
+		{name: "unknown typed", toolType: "custom_builtin_20250401", want: false},
+		{name: "web search", toolType: "web_search_20250305", want: true},
+		{name: "computer", toolType: "computer_20250124", want: true},
+		{name: "bash", toolType: "bash_20250124", want: true},
+		{name: "memory", toolType: "memory_20250818", want: true},
+		{name: "web fetch", toolType: "web_fetch_20260209", want: true},
+		{name: "tool search", toolType: "tool_search_tool_regex_20251119", want: true},
+		{name: "advisor", toolType: "advisor_20260301", want: true},
+		{name: "mcp toolset", toolType: "mcp_toolset", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsClaudeBuiltinToolType(tt.toolType); got != tt.want {
+				t.Fatalf("IsClaudeBuiltinToolType(%q) = %v, want %v", tt.toolType, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClaudeBuiltinToolRegistry_DefaultSeedFallback(t *testing.T) {
 	registry := AugmentClaudeBuiltinToolRegistry(nil, nil)
 	for _, name := range defaultClaudeBuiltinToolNames {
@@ -31,11 +59,12 @@ func TestClaudeBuiltinToolRegistry_AugmentsTypedBuiltinsFromBody(t *testing.T) {
 	}
 }
 
-func TestClaudeBuiltinToolRegistry_CustomTypedToolsStayOutOfRegistry(t *testing.T) {
+func TestClaudeBuiltinToolRegistry_CustomTypedToolsStayOutAndKnownBuiltinsStayIn(t *testing.T) {
 	registry := AugmentClaudeBuiltinToolRegistry([]byte(`{
 		"tools": [
 			{"type": "custom", "name": "Read"},
-			{"type": "custom_builtin_20250401", "name": "special_builtin"}
+			{"type": "custom_builtin_20250401", "name": "special_builtin"},
+			{"type": "mcp_toolset", "name": "mcp_toolset"}
 		]
 	}`), nil)
 
@@ -44,5 +73,8 @@ func TestClaudeBuiltinToolRegistry_CustomTypedToolsStayOutOfRegistry(t *testing.
 	}
 	if registry["special_builtin"] {
 		t.Fatal("expected unknown typed tool to stay out of builtin registry")
+	}
+	if !registry["mcp_toolset"] {
+		t.Fatal("expected known builtin mcp_toolset to stay in builtin registry")
 	}
 }


### PR DESCRIPTION
## Summary
This fixes Claude OAuth tool cloaking for Anthropic Messages requests that pass through Bifrost.
When Bifrost forwards custom tools, it normalizes them into Anthropic-style entries such as:
```json
{
  "type": "custom",
  "name": "bash"
}
```
CLIProxyAPI was treating any tool with a non-empty `type` as a Claude built-in tool. That worked for real Anthropic built-ins like `web_search_20250305`, but it also caused Bifrost-shaped custom tools to be skipped by the OAuth tool remapping logic.
As a result, requests forwarded through Bifrost could still expose lowercase third-party tool names like `bash`, `read`, and `glob`, even though direct Claude Code / OpenCode-style traffic would be remapped to `Bash`, `Read`, and `Glob`.
## Why this matters
For Claude OAuth traffic, tool naming is part of the request fingerprint.
This project already remaps third-party tool names to Claude Code-style names to avoid that fingerprint. But the previous logic broke down once an upstream proxy rewrote custom tools into `type: "custom"` entries.
In practice, this meant:
- direct requests could be cloaked correctly
- the same request forwarded through Bifrost could bypass that cloaking
- custom tools could be misclassified as built-ins and left unchanged
That made the behavior inconsistent across Anthropic Messages clients and proxy paths.
## What changed
This patch makes the built-in detection stricter:
- only real Anthropic built-in tool types are treated as built-ins
- `type: "custom"` tools are still handled as third-party custom tools
- unknown typed tools are no longer added to the Claude built-in registry
For Bifrost-shaped custom tools, the request is now normalized back into the form expected by the existing OAuth cloaking flow:
- the custom tool name is remapped (`bash` -> `Bash`, etc.)
- the synthetic `type: "custom"` field is removed before forwarding upstream
## Tests
Added regression coverage for:
- `type: "custom"` tools still receiving Claude OAuth tool prefix/remap handling
- real built-in typed tools remaining untouched
- `type: "custom"` and unknown typed tools staying out of the built-in registry
## Validation
Tested with focused executor and helper package tests.
This was also verified against real traffic: after rebasing and deploying the patch, OpenCode requests forwarded through Bifrost were handled correctly by the Claude OAuth cloaking path.
```
## Optional shorter version
If you want a slightly shorter body for GitHub:
```md
## Summary
Fix Claude OAuth tool cloaking for Anthropic Messages requests forwarded through Bifrost.
Bifrost normalizes custom tools into entries like:
```json
{"type":"custom","name":"bash"}
```
CLIProxyAPI was treating any typed tool as a Claude built-in tool. That was too broad. Real built-ins such as `web_search_20250305` should be preserved, but Bifrost-shaped custom tools should still go through the OAuth remapping path.
Because of that misclassification, forwarded requests could skip remapping for custom tools like `bash`, `read`, and `glob`, even though direct traffic would correctly become `Bash`, `Read`, and `Glob`.
## Changes
- treat only real Anthropic built-in tool types as built-ins
- keep `type: "custom"` tools in the third-party remap flow
- remove synthetic `type: "custom"` before forwarding upstream
- prevent `type: "custom"` and other unknown typed tools from entering the built-in registry
## Why this is needed
For Claude OAuth traffic, tool names are part of the client fingerprint. This project already rewrites third-party tool names to match Claude Code behavior, but that protection was bypassed when a proxy rewrote custom tools into `type: "custom"` entries.
This patch restores consistent cloaking behavior for both direct and Bifrost-forwarded Anthropic Messages requests.
## Tests
Added regression tests covering:
- remapping of Bifrost-shaped custom tools
- no remapping for real built-in typed tools
- correct built-in registry behavior for `type: "custom"` tools