### PR TITLE
feat(amp): support feature-aware model mapping via request fingerprint

### DIFF
--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1362,16 +1362,18 @@ func (h *Handler) DeleteAmpModelMappings(c *gin.Context) {
 
 // ampMappingKey returns a stable identity for a mapping entry, accounting
 // for the regex flag and the optional When clause so that PATCH can
-// distinguish multiple rules sharing the same From.
+// distinguish multiple rules sharing the same From. When fields are
+// lower-cased to match ConditionMatches' case-insensitive semantics, so
+// a PATCH that differs only by case is recognized as the same rule.
 func ampMappingKey(m config.AmpModelMapping) string {
 	when := ""
 	if m.When != nil {
-		when = strings.TrimSpace(m.When.Feature) + "\x1f" +
-			strings.TrimSpace(m.When.ToolChoice) + "\x1f" +
-			strings.TrimSpace(m.When.UserSuffix) + "\x1f" +
-			strings.TrimSpace(m.When.SystemPrefix)
+		when = strings.ToLower(strings.TrimSpace(m.When.Feature)) + "\x1f" +
+			strings.ToLower(strings.TrimSpace(m.When.ToolChoice)) + "\x1f" +
+			strings.ToLower(strings.TrimSpace(m.When.UserSuffix)) + "\x1f" +
+			strings.ToLower(strings.TrimSpace(m.When.SystemPrefix))
 	}
-	return strings.TrimSpace(m.From) + "\x1e" + strconv.FormatBool(m.Regex) + "\x1e" + when
+	return strings.ToLower(strings.TrimSpace(m.From)) + "\x1e" + strconv.FormatBool(m.Regex) + "\x1e" + when
 }
 
 // GetAmpForceModelMappings returns whether model mappings are forced.

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1365,13 +1365,21 @@ func (h *Handler) DeleteAmpModelMappings(c *gin.Context) {
 // distinguish multiple rules sharing the same From. When fields are
 // lower-cased to match ConditionMatches' case-insensitive semantics, so
 // a PATCH that differs only by case is recognized as the same rule.
+// A condition whose every field trims to empty (e.g. `when: {}`) is
+// treated identically to a nil When, mirroring selectTarget's
+// "effectively empty" classification so that PATCH does not create a
+// duplicate entry for what is, semantically, the same unconditional
+// rule.
 func ampMappingKey(m config.AmpModelMapping) string {
 	when := ""
 	if m.When != nil {
-		when = strings.ToLower(strings.TrimSpace(m.When.Feature)) + "\x1f" +
-			strings.ToLower(strings.TrimSpace(m.When.ToolChoice)) + "\x1f" +
-			strings.ToLower(strings.TrimSpace(m.When.UserSuffix)) + "\x1f" +
-			strings.ToLower(strings.TrimSpace(m.When.SystemPrefix))
+		feat := strings.ToLower(strings.TrimSpace(m.When.Feature))
+		tool := strings.ToLower(strings.TrimSpace(m.When.ToolChoice))
+		usuf := strings.ToLower(strings.TrimSpace(m.When.UserSuffix))
+		spre := strings.ToLower(strings.TrimSpace(m.When.SystemPrefix))
+		if feat != "" || tool != "" || usuf != "" || spre != "" {
+			when = feat + "\x1f" + tool + "\x1f" + usuf + "\x1f" + spre
+		}
 	}
 	return strings.ToLower(strings.TrimSpace(m.From)) + "\x1e" + strconv.FormatBool(m.Regex) + "\x1e" + when
 }

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1315,7 +1315,10 @@ func (h *Handler) PatchAmpModelMappings(c *gin.Context) {
 
 	existing := make(map[string]int)
 	for i, m := range h.cfg.AmpCode.ModelMappings {
-		existing[ampMappingKey(m)] = i
+		key := ampMappingKey(m)
+		if _, ok := existing[key]; !ok {
+			existing[key] = i
+		}
 	}
 
 	for _, newMapping := range body.Value {

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -3,6 +3,7 @@ package management
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -1299,6 +1300,10 @@ func (h *Handler) PutAmpModelMappings(c *gin.Context) {
 }
 
 // PatchAmpModelMappings adds or updates model mappings.
+//
+// Identity for update is the tuple (from, regex, when), so multiple
+// mappings sharing the same From but different When clauses can be
+// patched independently.
 func (h *Handler) PatchAmpModelMappings(c *gin.Context) {
 	var body struct {
 		Value []config.AmpModelMapping `json:"value"`
@@ -1310,22 +1315,26 @@ func (h *Handler) PatchAmpModelMappings(c *gin.Context) {
 
 	existing := make(map[string]int)
 	for i, m := range h.cfg.AmpCode.ModelMappings {
-		existing[strings.TrimSpace(m.From)] = i
+		existing[ampMappingKey(m)] = i
 	}
 
 	for _, newMapping := range body.Value {
-		from := strings.TrimSpace(newMapping.From)
-		if idx, ok := existing[from]; ok {
+		key := ampMappingKey(newMapping)
+		if idx, ok := existing[key]; ok {
 			h.cfg.AmpCode.ModelMappings[idx] = newMapping
 		} else {
 			h.cfg.AmpCode.ModelMappings = append(h.cfg.AmpCode.ModelMappings, newMapping)
-			existing[from] = len(h.cfg.AmpCode.ModelMappings) - 1
+			existing[key] = len(h.cfg.AmpCode.ModelMappings) - 1
 		}
 	}
 	h.persist(c)
 }
 
-// DeleteAmpModelMappings removes specified model mappings by "from" field.
+// DeleteAmpModelMappings removes specified model mappings.
+//
+// Each entry in body.Value is interpreted as a "from" string. All mappings
+// sharing that From are removed, regardless of regex flag or When clause.
+// Pass an empty body to clear all mappings.
 func (h *Handler) DeleteAmpModelMappings(c *gin.Context) {
 	var body struct {
 		Value []string `json:"value"`
@@ -1349,6 +1358,19 @@ func (h *Handler) DeleteAmpModelMappings(c *gin.Context) {
 	}
 	h.cfg.AmpCode.ModelMappings = newMappings
 	h.persist(c)
+}
+
+// ampMappingKey returns a stable identity for a mapping entry, accounting
+// for the regex flag and the optional When clause so that PATCH can
+// distinguish multiple rules sharing the same From.
+func ampMappingKey(m config.AmpModelMapping) string {
+	when := ""
+	if m.When != nil {
+		when = strings.TrimSpace(m.When.Feature) + "\x1f" +
+			strings.TrimSpace(m.When.ToolChoice) + "\x1f" +
+			strings.TrimSpace(m.When.UserSuffix)
+	}
+	return strings.TrimSpace(m.From) + "\x1e" + strconv.FormatBool(m.Regex) + "\x1e" + when
 }
 
 // GetAmpForceModelMappings returns whether model mappings are forced.

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1368,7 +1368,8 @@ func ampMappingKey(m config.AmpModelMapping) string {
 	if m.When != nil {
 		when = strings.TrimSpace(m.When.Feature) + "\x1f" +
 			strings.TrimSpace(m.When.ToolChoice) + "\x1f" +
-			strings.TrimSpace(m.When.UserSuffix)
+			strings.TrimSpace(m.When.UserSuffix) + "\x1f" +
+			strings.TrimSpace(m.When.SystemPrefix)
 	}
 	return strings.TrimSpace(m.From) + "\x1e" + strconv.FormatBool(m.Regex) + "\x1e" + when
 }

--- a/internal/api/handlers/management/config_lists_amp_key_test.go
+++ b/internal/api/handlers/management/config_lists_amp_key_test.go
@@ -48,6 +48,25 @@ func TestAmpMappingKey_CaseInsensitiveAlignsWithConditionMatches(t *testing.T) {
 	}
 }
 
+// TestAmpMappingKey_NilAndEmptyWhenAreEquivalent verifies that
+// `When: nil` and `When: &AmpMappingCondition{}` collapse to the same
+// PATCH identity. Both forms match unconditionally at runtime
+// (selectTarget routes them through the fallback bucket), so PATCH
+// must treat them as the same rule and update in place rather than
+// appending a duplicate that would never win at runtime.
+func TestAmpMappingKey_NilAndEmptyWhenAreEquivalent(t *testing.T) {
+	a := config.AmpModelMapping{From: "gemini-3-flash-preview", To: "x"}
+	b := config.AmpModelMapping{
+		From: "gemini-3-flash-preview",
+		To:   "x",
+		When: &config.AmpMappingCondition{},
+	}
+	if ampMappingKey(a) != ampMappingKey(b) {
+		t.Fatalf("nil When and empty When must share a key:\n a=%q\n b=%q",
+			ampMappingKey(a), ampMappingKey(b))
+	}
+}
+
 // TestAmpMappingKey_DistinguishesAllWhenFields verifies each When field
 // participates in the identity key.
 func TestAmpMappingKey_DistinguishesAllWhenFields(t *testing.T) {

--- a/internal/api/handlers/management/config_lists_amp_key_test.go
+++ b/internal/api/handlers/management/config_lists_amp_key_test.go
@@ -1,0 +1,61 @@
+package management
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// TestAmpMappingKey_DistinguishesSystemPrefix ensures that two mappings
+// differing only by When.SystemPrefix produce distinct identity keys, so
+// PATCH updates routed through the management API do not collide.
+func TestAmpMappingKey_DistinguishesSystemPrefix(t *testing.T) {
+	a := config.AmpModelMapping{
+		From: "claude-opus-4-6",
+		To:   "target-a",
+		When: &config.AmpMappingCondition{SystemPrefix: "you are agg man"},
+	}
+	b := config.AmpModelMapping{
+		From: "claude-opus-4-6",
+		To:   "target-b",
+		When: &config.AmpMappingCondition{SystemPrefix: "you are amp"},
+	}
+	if ampMappingKey(a) == ampMappingKey(b) {
+		t.Fatalf("keys collide for distinct SystemPrefix:\n a=%q\n b=%q",
+			ampMappingKey(a), ampMappingKey(b))
+	}
+}
+
+// TestAmpMappingKey_DistinguishesAllWhenFields verifies each When field
+// participates in the identity key.
+func TestAmpMappingKey_DistinguishesAllWhenFields(t *testing.T) {
+	base := config.AmpModelMapping{From: "m", To: "t"}
+	cases := []struct {
+		name string
+		mod  func(m *config.AmpModelMapping)
+	}{
+		{"feature", func(m *config.AmpModelMapping) {
+			m.When = &config.AmpMappingCondition{Feature: "handoff"}
+		}},
+		{"tool_choice", func(m *config.AmpModelMapping) {
+			m.When = &config.AmpMappingCondition{ToolChoice: "create_handoff_context"}
+		}},
+		{"user_suffix", func(m *config.AmpModelMapping) {
+			m.When = &config.AmpMappingCondition{UserSuffix: "x"}
+		}},
+		{"system_prefix", func(m *config.AmpModelMapping) {
+			m.When = &config.AmpMappingCondition{SystemPrefix: "y"}
+		}},
+	}
+	seen := map[string]string{}
+	seen[ampMappingKey(base)] = "base"
+	for _, c := range cases {
+		m := base
+		c.mod(&m)
+		k := ampMappingKey(m)
+		if prev, ok := seen[k]; ok {
+			t.Errorf("%s collides with %s: key=%q", c.name, prev, k)
+		}
+		seen[k] = c.name
+	}
+}

--- a/internal/api/handlers/management/config_lists_amp_key_test.go
+++ b/internal/api/handlers/management/config_lists_amp_key_test.go
@@ -26,6 +26,28 @@ func TestAmpMappingKey_DistinguishesSystemPrefix(t *testing.T) {
 	}
 }
 
+// TestAmpMappingKey_CaseInsensitiveAlignsWithConditionMatches verifies
+// that the identity key normalizes case the same way ConditionMatches
+// does, so a PATCH that differs only by case (e.g. "HANDOFF" vs
+// "handoff") updates the existing rule instead of appending a stale
+// duplicate that is semantically equivalent.
+func TestAmpMappingKey_CaseInsensitiveAlignsWithConditionMatches(t *testing.T) {
+	a := config.AmpModelMapping{
+		From: "Gemini-3-Flash-Preview",
+		To:   "x",
+		When: &config.AmpMappingCondition{Feature: "HANDOFF", ToolChoice: "Create_Handoff_Context"},
+	}
+	b := config.AmpModelMapping{
+		From: "gemini-3-flash-preview",
+		To:   "x",
+		When: &config.AmpMappingCondition{Feature: "handoff", ToolChoice: "create_handoff_context"},
+	}
+	if ampMappingKey(a) != ampMappingKey(b) {
+		t.Fatalf("keys differ for case-equivalent mappings:\n a=%q\n b=%q",
+			ampMappingKey(a), ampMappingKey(b))
+	}
+}
+
 // TestAmpMappingKey_DistinguishesAllWhenFields verifies each When field
 // participates in the identity key.
 func TestAmpMappingKey_DistinguishesAllWhenFields(t *testing.T) {

--- a/internal/api/modules/amp/amp.go
+++ b/internal/api/modules/amp/amp.go
@@ -331,7 +331,8 @@ func sameAmpMappingCondition(a, b *config.AmpMappingCondition) bool {
 	}
 	return strings.TrimSpace(a.Feature) == strings.TrimSpace(b.Feature) &&
 		strings.TrimSpace(a.ToolChoice) == strings.TrimSpace(b.ToolChoice) &&
-		strings.TrimSpace(a.UserSuffix) == strings.TrimSpace(b.UserSuffix)
+		strings.TrimSpace(a.UserSuffix) == strings.TrimSpace(b.UserSuffix) &&
+		strings.TrimSpace(a.SystemPrefix) == strings.TrimSpace(b.SystemPrefix)
 }
 
 // cloneAmpCodeSettings returns a deep copy of an AmpCode value suitable for

--- a/internal/api/modules/amp/amp.go
+++ b/internal/api/modules/amp/amp.go
@@ -126,8 +126,11 @@ func (m *AmpModule) Register(ctx modules.Context) error {
 		// Initialize model mapper from config (for routing unavailable models to alternatives)
 		m.modelMapper = NewModelMapper(settings.ModelMappings)
 
-		// Store initial config for partial reload comparison
-		m.lastConfig = new(settings)
+		// Store initial config for partial reload comparison.
+		// Deep-clone so subsequent in-place mutations of the live config
+		// (e.g. management PATCH handlers writing to ModelMappings[idx])
+		// cannot retroactively affect the stored "old" snapshot.
+		m.lastConfig = cloneAmpCodeSettings(settings)
 
 		// Initialize localhost restriction setting (hot-reloadable)
 		m.setRestrictToLocalhost(settings.RestrictManagementToLocalhost)
@@ -248,10 +251,11 @@ func (m *AmpModule) OnConfigUpdated(cfg *config.Config) error {
 
 	}
 
-	// Store current config for next comparison
+	// Store current config for next comparison.
+	// Deep-clone for the same reason as in Register: live config slices
+	// can be mutated in place by management handlers.
 	m.configMu.Lock()
-	settingsCopy := newSettings // copy struct
-	m.lastConfig = &settingsCopy
+	m.lastConfig = cloneAmpCodeSettings(newSettings)
 	m.configMu.Unlock()
 
 	return nil
@@ -328,6 +332,37 @@ func sameAmpMappingCondition(a, b *config.AmpMappingCondition) bool {
 	return strings.TrimSpace(a.Feature) == strings.TrimSpace(b.Feature) &&
 		strings.TrimSpace(a.ToolChoice) == strings.TrimSpace(b.ToolChoice) &&
 		strings.TrimSpace(a.UserSuffix) == strings.TrimSpace(b.UserSuffix)
+}
+
+// cloneAmpCodeSettings returns a deep copy of an AmpCode value suitable for
+// storing as a "previous snapshot" for hot-reload comparison. A shallow
+// copy would share slice backing arrays with the live configuration, so
+// in-place mutations performed by management handlers (e.g. assigning to
+// ModelMappings[idx]) would retroactively change the snapshot and hide
+// real changes from the diff logic.
+func cloneAmpCodeSettings(in config.AmpCode) *config.AmpCode {
+	out := in
+
+	if in.ModelMappings != nil {
+		out.ModelMappings = append([]config.AmpModelMapping(nil), in.ModelMappings...)
+		for i := range out.ModelMappings {
+			if out.ModelMappings[i].When != nil {
+				c := *out.ModelMappings[i].When
+				out.ModelMappings[i].When = &c
+			}
+		}
+	}
+
+	if in.UpstreamAPIKeys != nil {
+		out.UpstreamAPIKeys = append([]config.AmpUpstreamAPIKeyEntry(nil), in.UpstreamAPIKeys...)
+		for i := range out.UpstreamAPIKeys {
+			if in.UpstreamAPIKeys[i].APIKeys != nil {
+				out.UpstreamAPIKeys[i].APIKeys = append([]string(nil), in.UpstreamAPIKeys[i].APIKeys...)
+			}
+		}
+	}
+
+	return &out
 }
 
 // hasAPIKeyChanged compares old and new API keys.

--- a/internal/api/modules/amp/amp.go
+++ b/internal/api/modules/amp/amp.go
@@ -290,37 +290,44 @@ func (m *AmpModule) enableUpstreamProxy(upstreamURL string, settings *config.Amp
 }
 
 // hasModelMappingsChanged compares old and new model mappings.
+// Order is semantically meaningful (conditional rules are matched against
+// per-request fingerprints in declaration order), so this comparison is
+// strictly positional and includes the optional When clause.
 func (m *AmpModule) hasModelMappingsChanged(old *config.AmpCode, new *config.AmpCode) bool {
 	if old == nil {
 		return len(new.ModelMappings) > 0
 	}
-
 	if len(old.ModelMappings) != len(new.ModelMappings) {
 		return true
 	}
-
-	// Build map for efficient and robust comparison
-	type mappingInfo struct {
-		to    string
-		regex bool
-	}
-	oldMap := make(map[string]mappingInfo, len(old.ModelMappings))
-	for _, mapping := range old.ModelMappings {
-		oldMap[strings.TrimSpace(mapping.From)] = mappingInfo{
-			to:    strings.TrimSpace(mapping.To),
-			regex: mapping.Regex,
-		}
-	}
-
-	for _, mapping := range new.ModelMappings {
-		from := strings.TrimSpace(mapping.From)
-		to := strings.TrimSpace(mapping.To)
-		if oldVal, exists := oldMap[from]; !exists || oldVal.to != to || oldVal.regex != mapping.Regex {
+	for i := range old.ModelMappings {
+		if !sameAmpModelMapping(old.ModelMappings[i], new.ModelMappings[i]) {
 			return true
 		}
 	}
-
 	return false
+}
+
+func sameAmpModelMapping(a, b config.AmpModelMapping) bool {
+	if strings.TrimSpace(a.From) != strings.TrimSpace(b.From) {
+		return false
+	}
+	if strings.TrimSpace(a.To) != strings.TrimSpace(b.To) {
+		return false
+	}
+	if a.Regex != b.Regex {
+		return false
+	}
+	return sameAmpMappingCondition(a.When, b.When)
+}
+
+func sameAmpMappingCondition(a, b *config.AmpMappingCondition) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return strings.TrimSpace(a.Feature) == strings.TrimSpace(b.Feature) &&
+		strings.TrimSpace(a.ToolChoice) == strings.TrimSpace(b.ToolChoice) &&
+		strings.TrimSpace(a.UserSuffix) == strings.TrimSpace(b.UserSuffix)
 }
 
 // hasAPIKeyChanged compares old and new API keys.

--- a/internal/api/modules/amp/amp_hot_reload_test.go
+++ b/internal/api/modules/amp/amp_hot_reload_test.go
@@ -55,3 +55,31 @@ func TestHasModelMappingsChanged_DetectsAddedWhen(t *testing.T) {
 		t.Error("expected change when When is added")
 	}
 }
+
+// TestCloneAmpCodeSettings_IsolatesFromInPlaceMutation guards the snapshot
+// stored in lastConfig from in-place mutations of the live config slices,
+// which is exactly what management PATCH handlers do.
+func TestCloneAmpCodeSettings_IsolatesFromInPlaceMutation(t *testing.T) {
+	live := config.AmpCode{
+		ModelMappings: []config.AmpModelMapping{
+			{From: "gemini-3-flash-preview", To: "gpt-default"},
+			{From: "gemini-3-flash-preview", To: "gpt-handoff", When: &config.AmpMappingCondition{Feature: "handoff"}},
+		},
+	}
+	snapshot := cloneAmpCodeSettings(live)
+
+	// Simulate management handler doing h.cfg.AmpCode.ModelMappings[idx] = ...
+	live.ModelMappings[0] = config.AmpModelMapping{From: "gemini-3-flash-preview", To: "gpt-mutated"}
+	live.ModelMappings[1].When.Feature = "search"
+
+	mod := &AmpModule{}
+	if !mod.hasModelMappingsChanged(snapshot, &live) {
+		t.Error("snapshot must remain unchanged after in-place mutation; hot reload would otherwise miss PATCH updates")
+	}
+	if snapshot.ModelMappings[0].To != "gpt-default" {
+		t.Errorf("snapshot[0].To mutated: %q", snapshot.ModelMappings[0].To)
+	}
+	if snapshot.ModelMappings[1].When.Feature != "handoff" {
+		t.Errorf("snapshot[1].When.Feature mutated: %q", snapshot.ModelMappings[1].When.Feature)
+	}
+}

--- a/internal/api/modules/amp/amp_hot_reload_test.go
+++ b/internal/api/modules/amp/amp_hot_reload_test.go
@@ -1,0 +1,57 @@
+package amp
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestHasModelMappingsChanged_DetectsWhenChange(t *testing.T) {
+	mod := &AmpModule{}
+	old := &config.AmpCode{ModelMappings: []config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "gpt-handoff", When: &config.AmpMappingCondition{Feature: "handoff"}},
+	}}
+	newer := &config.AmpCode{ModelMappings: []config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "gpt-handoff", When: &config.AmpMappingCondition{ToolChoice: "create_handoff_context"}},
+	}}
+	if !mod.hasModelMappingsChanged(old, newer) {
+		t.Error("expected change to be detected when only When clause changes")
+	}
+}
+
+func TestHasModelMappingsChanged_DetectsReorder(t *testing.T) {
+	mod := &AmpModule{}
+	a := config.AmpModelMapping{From: "gemini-3-flash-preview", To: "gpt-handoff", When: &config.AmpMappingCondition{Feature: "handoff"}}
+	b := config.AmpModelMapping{From: "gemini-3-flash-preview", To: "gpt-default"}
+	old := &config.AmpCode{ModelMappings: []config.AmpModelMapping{a, b}}
+	newer := &config.AmpCode{ModelMappings: []config.AmpModelMapping{b, a}}
+	if !mod.hasModelMappingsChanged(old, newer) {
+		t.Error("expected change to be detected when mappings are reordered")
+	}
+}
+
+func TestHasModelMappingsChanged_NoChange(t *testing.T) {
+	mod := &AmpModule{}
+	mappings := []config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "gpt-handoff", When: &config.AmpMappingCondition{Feature: "handoff"}},
+		{From: "gemini-3-flash-preview", To: "gpt-default"},
+	}
+	old := &config.AmpCode{ModelMappings: mappings}
+	newer := &config.AmpCode{ModelMappings: append([]config.AmpModelMapping(nil), mappings...)}
+	if mod.hasModelMappingsChanged(old, newer) {
+		t.Error("expected no change for identical mappings")
+	}
+}
+
+func TestHasModelMappingsChanged_DetectsAddedWhen(t *testing.T) {
+	mod := &AmpModule{}
+	old := &config.AmpCode{ModelMappings: []config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "gpt-x"},
+	}}
+	newer := &config.AmpCode{ModelMappings: []config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "gpt-x", When: &config.AmpMappingCondition{Feature: "handoff"}},
+	}}
+	if !mod.hasModelMappingsChanged(old, newer) {
+		t.Error("expected change when When is added")
+	}
+}

--- a/internal/api/modules/amp/fallback_handlers.go
+++ b/internal/api/modules/amp/fallback_handlers.go
@@ -146,14 +146,17 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 			thinkingSuffix = "(" + suffixResult.RawSuffix + ")"
 		}
 
+		// Extract per-request fingerprint once for feature-aware mapping.
+		fingerprint := ExtractFingerprint(bodyBytes)
+
 		resolveMappedModel := func() (string, []string) {
 			if fh.modelMapper == nil {
 				return "", nil
 			}
 
-			mappedModel := fh.modelMapper.MapModel(modelName)
+			mappedModel := fh.modelMapper.MapModelCtx(modelName, fingerprint)
 			if mappedModel == "" {
-				mappedModel = fh.modelMapper.MapModel(normalizedModel)
+				mappedModel = fh.modelMapper.MapModelCtx(normalizedModel, fingerprint)
 			}
 			mappedModel = strings.TrimSpace(mappedModel)
 			if mappedModel == "" {

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -25,7 +25,7 @@ type RequestFingerprint struct {
 	// ToolChoice is the forced tool name extracted from the request body.
 	// Anthropic: tool_choice.name; OpenAI: tool_choice.function.name;
 	// Gemini: toolConfig.functionCallingConfig.allowedFunctionNames[0]
-	// when mode is ANY/AUTO and exactly one tool is allowed.
+	// when mode is ANY and exactly one tool is allowed.
 	ToolChoice string
 
 	// LastUserText is the trimmed text content of the final user-role message,
@@ -35,6 +35,11 @@ type RequestFingerprint struct {
 
 // Feature returns the canonical Amp feature alias inferred from the
 // fingerprint, or an empty string if no high-level feature can be deduced.
+//
+// Currently only "handoff" is inferred. Other Amp features (search,
+// look-at, oracle, painter, titling, ...) can still be matched at the
+// configuration level using ToolChoice / UserSuffix when the user knows
+// the relevant fingerprint.
 func (f RequestFingerprint) Feature() string {
 	if strings.EqualFold(f.ToolChoice, HandoffToolName) {
 		return "handoff"
@@ -78,7 +83,7 @@ func extractToolChoiceName(body []byte) string {
 		names := gjson.GetBytes(body, "toolConfig.functionCallingConfig.allowedFunctionNames")
 		if names.IsArray() {
 			arr := names.Array()
-			if len(arr) == 1 {
+			if len(arr) == 1 && arr[0].Type == gjson.String {
 				return arr[0].String()
 			}
 		}
@@ -87,8 +92,10 @@ func extractToolChoiceName(body []byte) string {
 }
 
 // extractLastUserText returns the last user-role textual content from
-// Anthropic, OpenAI, or Gemini schemas. Only the trailing text is needed
-// for suffix matching; multi-part contents are concatenated in order.
+// Anthropic, OpenAI, or Gemini schemas. For Gemini contents[], a missing
+// role is treated as user (single-turn requests sometimes omit it). Only
+// the trailing text is needed for suffix matching; multi-part contents
+// are concatenated in order.
 func extractLastUserText(body []byte) string {
 	// Anthropic / OpenAI Chat: messages[] with role+content.
 	if msgs := gjson.GetBytes(body, "messages"); msgs.IsArray() {
@@ -106,7 +113,8 @@ func extractLastUserText(body []byte) string {
 		arr := cts.Array()
 		for i := len(arr) - 1; i >= 0; i-- {
 			m := arr[i]
-			if !strings.EqualFold(m.Get("role").String(), "user") {
+			role := m.Get("role").String()
+			if role != "" && !strings.EqualFold(role, "user") {
 				continue
 			}
 			var b strings.Builder
@@ -147,16 +155,18 @@ func ConditionMatches(cond *config.AmpMappingCondition, fp RequestFingerprint) b
 	if cond == nil {
 		return true
 	}
-	if cond.ToolChoice != "" && !strings.EqualFold(cond.ToolChoice, fp.ToolChoice) {
-		return false
-	}
-	if cond.UserSuffix != "" {
-		if !strings.HasSuffix(strings.ToLower(fp.LastUserText), strings.ToLower(cond.UserSuffix)) {
+	if tc := strings.TrimSpace(cond.ToolChoice); tc != "" {
+		if !strings.EqualFold(tc, strings.TrimSpace(fp.ToolChoice)) {
 			return false
 		}
 	}
-	if cond.Feature != "" {
-		want := strings.ToLower(strings.TrimSpace(cond.Feature))
+	if suffix := strings.TrimSpace(cond.UserSuffix); suffix != "" {
+		if !strings.HasSuffix(strings.ToLower(strings.TrimSpace(fp.LastUserText)), strings.ToLower(suffix)) {
+			return false
+		}
+	}
+	if feature := strings.TrimSpace(cond.Feature); feature != "" {
+		want := strings.ToLower(feature)
 		if want == "look_at" {
 			want = "search"
 		}

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -17,6 +17,7 @@ import (
 // Known Amp tool names used to identify features.
 const (
 	HandoffToolName = "create_handoff_context"
+	TitlingToolName = "set_title"
 )
 
 // RequestFingerprint captures the per-request features a mapping condition
@@ -36,13 +37,19 @@ type RequestFingerprint struct {
 // Feature returns the canonical Amp feature alias inferred from the
 // fingerprint, or an empty string if no high-level feature can be deduced.
 //
-// Currently only "handoff" is inferred. Other Amp features (search,
-// look-at, oracle, painter, titling, ...) can still be matched at the
-// configuration level using ToolChoice / UserSuffix when the user knows
-// the relevant fingerprint.
+// Inferred via forced tool name (the most reliable signal Amp emits):
+//   - "handoff": Amp thread handoff. Tool: create_handoff_context.
+//   - "titling": Amp thread title generation. Tool: set_title.
+//
+// Other Amp features (search subagent, look-at, oracle, painter, review,
+// ...) do not force a unique tool. Match those at the configuration level
+// using ToolChoice / UserSuffix when their fingerprint is known.
 func (f RequestFingerprint) Feature() string {
-	if strings.EqualFold(f.ToolChoice, HandoffToolName) {
+	switch {
+	case strings.EqualFold(f.ToolChoice, HandoffToolName):
 		return "handoff"
+	case strings.EqualFold(f.ToolChoice, TitlingToolName):
+		return "titling"
 	}
 	// User-suffix based detection (cheap, anchored on Amp's actual prompt).
 	lower := strings.ToLower(f.LastUserText)

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -27,25 +27,44 @@ const (
 // change when Amp itself is upgraded. Keep prefixes long enough to avoid
 // collisions but short enough to tolerate trailing whitespace/newlines.
 const (
-	OraclePromptPrefix        = "you are the oracle - an expert ai advisor"
-	SearchPromptPrefix        = "you are a fast, parallel code search agent"
-	LookAtPromptPrefix        = "you are an ai assistant that analyzes files for a software engineer"
-	ReviewPromptPrefix        = "you are an expert software engineer reviewing code changes"
-	ReviewMainPromptPrefix    = "you are an expert senior engineer with deep knowledge of software engineering best practices"
-	TitlingPromptPrefix       = "you are an assistant that generates short, descriptive titles"
-	HandoffPromptPrefix       = "you are an assistant tasked with creating a handoff context"
-	LibrarianPromptPrefix     = "you are the librarian, a specialized codebase understanding agent"
-	ClassifierPromptPrefix    = "you are a classifier that answers yes/no questions"
-	GitListPromptPrefix       = "you generate git commands to list changed files"
-	GitDiffPromptPrefix       = "you generate git diff commands that show the actual diff content"
-	ThreadExtractPromptPrefix = "you are helping me extract relevant information from the mentioned thread"
-	ErrorSummaryPromptPrefix  = "you are helping summarize work done by an ai coding agent"
+	OraclePromptPrefix     = "you are the oracle - an expert ai advisor"
+	SearchPromptPrefix     = "you are a fast, parallel code search agent"
+	LookAtPromptPrefix     = "you are an ai assistant that analyzes files for a software engineer"
+	ReviewPromptPrefix     = "you are an expert software engineer reviewing code changes"
+	ReviewMainPromptPrefix = "you are an expert senior engineer with deep knowledge of software engineering best practices"
+	TitlingPromptPrefix    = "you are an assistant that generates short, descriptive titles"
+	HandoffPromptPrefix    = "you are an assistant tasked with creating a handoff context"
+	LibrarianPromptPrefix  = "you are the librarian, a specialized codebase understanding agent"
+	ClassifierPromptPrefix = "you are a classifier that answers yes/no questions"
+	// Git helper prefixes use the full first sentence to avoid collision
+	// with any future "you generate git ..." prompt variants.
+	GitListPromptPrefix = "you generate git commands to list changed files. output commands wrapped in <command></command> tags."
+	GitDiffPromptPrefix = "you generate git diff commands that show the actual diff content. output commands in xml format:"
 )
 
-// Suffix of the user-message template emitted by the codereview-check
-// subagent (`Run the "${name}" code review check.`). Combined with the
-// claude-haiku-4-5 model name this is a strong fingerprint.
-const CodereviewCheckUserSuffix = "code review check."
+// codereview-check user-message template anchors. The full template is
+// `Run the "${name}" code review check.`. Match both the prefix and
+// suffix so that loose phrases like "please run a code review check"
+// in normal review traffic do not collide.
+const (
+	codereviewCheckUserPrefix = `run the "`
+	codereviewCheckUserSuffix = `" code review check.`
+)
+
+// isCodereviewCheckUserText reports whether the given user message
+// matches the codereview-check template exactly, after lowering and
+// trimming whitespace.
+func isCodereviewCheckUserText(s string) bool {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if !strings.HasPrefix(s, codereviewCheckUserPrefix) {
+		return false
+	}
+	if !strings.HasSuffix(s, codereviewCheckUserSuffix) {
+		return false
+	}
+	// Need at least one byte for the check name between the anchors.
+	return len(s) > len(codereviewCheckUserPrefix)+len(codereviewCheckUserSuffix)
+}
 
 // RequestFingerprint captures the per-request features a mapping condition
 // can match against. All fields are optional; absent fields cannot match.
@@ -99,10 +118,8 @@ func (f RequestFingerprint) Feature() string {
 	}
 
 	lastUser := strings.ToLower(strings.TrimSpace(f.LastUserText))
-	if lastUser != "" {
-		if strings.HasSuffix(lastUser, CodereviewCheckUserSuffix) {
-			return "codereview_check"
-		}
+	if isCodereviewCheckUserText(f.LastUserText) {
+		return "codereview_check"
 	}
 
 	sys := strings.ToLower(strings.TrimSpace(f.SystemText))
@@ -130,10 +147,6 @@ func (f RequestFingerprint) Feature() string {
 			return "git_list"
 		case strings.HasPrefix(sys, GitDiffPromptPrefix):
 			return "git_diff"
-		case strings.HasPrefix(sys, ThreadExtractPromptPrefix):
-			return "thread_extract"
-		case strings.HasPrefix(sys, ErrorSummaryPromptPrefix):
-			return "error_summary"
 		}
 	}
 

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -20,6 +20,20 @@ const (
 	TitlingToolName = "set_title"
 )
 
+// Hardcoded system-prompt prefixes used by the Amp client binary to invoke
+// specific features. These literals appear as JS string constants in the
+// bundled Amp executable, so they are stable per Amp release and only
+// change when Amp itself is upgraded. Keep prefixes long enough to avoid
+// collisions but short enough to tolerate trailing whitespace/newlines.
+const (
+	OraclePromptPrefix  = "you are the oracle - an expert ai advisor"
+	SearchPromptPrefix  = "you are a fast, parallel code search agent."
+	LookAtPromptPrefix  = "you are an ai assistant that analyzes files for a software engineer."
+	ReviewPromptPrefix  = "you are an expert software engineer reviewing code changes."
+	TitlingPromptPrefix = "you are an assistant that generates short, descriptive titles"
+	HandoffPromptPrefix = "you are an assistant tasked with creating a handoff context"
+)
+
 // RequestFingerprint captures the per-request features a mapping condition
 // can match against. All fields are optional; absent fields cannot match.
 type RequestFingerprint struct {
@@ -32,18 +46,27 @@ type RequestFingerprint struct {
 	// LastUserText is the trimmed text content of the final user-role message,
 	// used by AmpMappingCondition.UserSuffix.
 	LastUserText string
+
+	// SystemText is the concatenated text of the request's system /
+	// systemInstruction / instructions field. Used by SystemPrefix matching
+	// and by Feature() to recognize features whose system prompts are
+	// hardcoded in the Amp client binary.
+	SystemText string
+
+	// HasImageOutput indicates the request asks the upstream model to emit
+	// an image (Gemini generationConfig.responseModalities contains
+	// "IMAGE"). Used to identify the Amp painter feature.
+	HasImageOutput bool
 }
 
 // Feature returns the canonical Amp feature alias inferred from the
 // fingerprint, or an empty string if no high-level feature can be deduced.
 //
-// Inferred via forced tool name (the most reliable signal Amp emits):
-//   - "handoff": Amp thread handoff. Tool: create_handoff_context.
-//   - "titling": Amp thread title generation. Tool: set_title.
-//
-// Other Amp features (search subagent, look-at, oracle, painter, review,
-// ...) do not force a unique tool. Match those at the configuration level
-// using ToolChoice / UserSuffix when their fingerprint is known.
+// Detection order (first match wins):
+//  1. Forced tool name (most reliable; emitted by Amp's tool_choice).
+//  2. responseModalities=IMAGE (painter).
+//  3. System-prompt prefix (hardcoded literals in the Amp binary).
+//  4. User-suffix heuristic (handoff fallback).
 func (f RequestFingerprint) Feature() string {
 	switch {
 	case strings.EqualFold(f.ToolChoice, HandoffToolName):
@@ -51,6 +74,29 @@ func (f RequestFingerprint) Feature() string {
 	case strings.EqualFold(f.ToolChoice, TitlingToolName):
 		return "titling"
 	}
+
+	if f.HasImageOutput {
+		return "painter"
+	}
+
+	sys := strings.ToLower(strings.TrimSpace(f.SystemText))
+	if sys != "" {
+		switch {
+		case strings.HasPrefix(sys, OraclePromptPrefix):
+			return "oracle"
+		case strings.HasPrefix(sys, SearchPromptPrefix):
+			return "search"
+		case strings.HasPrefix(sys, LookAtPromptPrefix):
+			return "look_at"
+		case strings.HasPrefix(sys, ReviewPromptPrefix):
+			return "review"
+		case strings.HasPrefix(sys, TitlingPromptPrefix):
+			return "titling"
+		case strings.HasPrefix(sys, HandoffPromptPrefix):
+			return "handoff"
+		}
+	}
+
 	// User-suffix based detection (cheap, anchored on Amp's actual prompt).
 	lower := strings.ToLower(f.LastUserText)
 	if strings.HasSuffix(lower, "use the create_handoff_context tool to extract relevant information and files.") {
@@ -69,8 +115,10 @@ func ExtractFingerprint(body []byte) RequestFingerprint {
 	}
 
 	fp := RequestFingerprint{
-		ToolChoice:   extractToolChoiceName(body),
-		LastUserText: extractLastUserText(body),
+		ToolChoice:     extractToolChoiceName(body),
+		LastUserText:   extractLastUserText(body),
+		SystemText:     extractSystemText(body),
+		HasImageOutput: extractHasImageOutput(body),
 	}
 	return fp
 }
@@ -115,6 +163,17 @@ func extractLastUserText(body []byte) string {
 			return strings.TrimSpace(messageContentText(m.Get("content")))
 		}
 	}
+	// OpenAI Responses: input[] with role+content[].text/input_text.
+	if inp := gjson.GetBytes(body, "input"); inp.IsArray() {
+		arr := inp.Array()
+		for i := len(arr) - 1; i >= 0; i-- {
+			m := arr[i]
+			if !strings.EqualFold(m.Get("role").String(), "user") {
+				continue
+			}
+			return strings.TrimSpace(messageContentText(m.Get("content")))
+		}
+	}
 	// Gemini: contents[] with role+parts[].text
 	if cts := gjson.GetBytes(body, "contents"); cts.IsArray() {
 		arr := cts.Array()
@@ -134,6 +193,67 @@ func extractLastUserText(body []byte) string {
 		}
 	}
 	return ""
+}
+
+// extractSystemText returns the textual system / systemInstruction /
+// instructions content of the request, concatenating multiple parts in
+// order. Anthropic and OpenAI accept either a string or an array of typed
+// parts; Gemini wraps it in systemInstruction.parts[].text. OpenAI
+// Responses additionally allows a system-role entry inside input[].
+func extractSystemText(body []byte) string {
+	// Anthropic / OpenAI Chat: top-level "system" (string or array).
+	if v := gjson.GetBytes(body, "system"); v.Exists() {
+		if s := strings.TrimSpace(messageContentText(v)); s != "" {
+			return s
+		}
+	}
+	// OpenAI Responses: top-level "instructions" (string).
+	if v := gjson.GetBytes(body, "instructions"); v.Exists() && v.Type == gjson.String {
+		if s := strings.TrimSpace(v.String()); s != "" {
+			return s
+		}
+	}
+	// OpenAI Responses: input[] entries with role=system/developer.
+	if inp := gjson.GetBytes(body, "input"); inp.IsArray() {
+		for _, m := range inp.Array() {
+			role := strings.ToLower(m.Get("role").String())
+			if role != "system" && role != "developer" {
+				continue
+			}
+			if s := strings.TrimSpace(messageContentText(m.Get("content"))); s != "" {
+				return s
+			}
+		}
+	}
+	// Gemini: systemInstruction.parts[].text
+	if si := gjson.GetBytes(body, "systemInstruction"); si.Exists() {
+		var b strings.Builder
+		for _, p := range si.Get("parts").Array() {
+			if t := p.Get("text"); t.Exists() {
+				b.WriteString(t.String())
+			}
+		}
+		if s := strings.TrimSpace(b.String()); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// extractHasImageOutput reports whether the request asks Gemini to emit
+// an image (used by Amp's painter feature). Only Gemini exposes this hint
+// via generationConfig.responseModalities.
+func extractHasImageOutput(body []byte) bool {
+	mods := gjson.GetBytes(body, "generationConfig.responseModalities")
+	if !mods.IsArray() {
+		return false
+	}
+	for _, m := range mods.Array() {
+		if strings.EqualFold(m.String(), "IMAGE") {
+			return true
+		}
+	}
+	return false
 }
 
 // messageContentText extracts text from an Anthropic/OpenAI message.content
@@ -172,11 +292,13 @@ func ConditionMatches(cond *config.AmpMappingCondition, fp RequestFingerprint) b
 			return false
 		}
 	}
+	if prefix := strings.TrimSpace(cond.SystemPrefix); prefix != "" {
+		if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(fp.SystemText)), strings.ToLower(prefix)) {
+			return false
+		}
+	}
 	if feature := strings.TrimSpace(cond.Feature); feature != "" {
 		want := strings.ToLower(feature)
-		if want == "look_at" {
-			want = "search"
-		}
 		got := fp.Feature()
 		if got == "" || got != want {
 			return false

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -38,8 +38,10 @@ const (
 	ClassifierPromptPrefix = "you are a classifier that answers yes/no questions"
 	// Git helper prefixes use the full first sentence to avoid collision
 	// with any future "you generate git ..." prompt variants.
-	GitListPromptPrefix = "you generate git commands to list changed files. output commands wrapped in <command></command> tags."
-	GitDiffPromptPrefix = "you generate git diff commands that show the actual diff content. output commands in xml format:"
+	GitListPromptPrefix       = "you generate git commands to list changed files. output commands wrapped in <command></command> tags."
+	GitDiffPromptPrefix       = "you generate git diff commands that show the actual diff content. output commands in xml format:"
+	ThreadExtractPromptPrefix = "you are helping me extract relevant information from the mentioned thread"
+	ErrorSummaryPromptPrefix  = "you are helping summarize work done by an ai coding agent"
 )
 
 // codereview-check user-message template anchors. The full template is
@@ -147,6 +149,10 @@ func (f RequestFingerprint) Feature() string {
 			return "git_list"
 		case strings.HasPrefix(sys, GitDiffPromptPrefix):
 			return "git_diff"
+		case strings.HasPrefix(sys, ThreadExtractPromptPrefix):
+			return "thread_extract"
+		case strings.HasPrefix(sys, ErrorSummaryPromptPrefix):
+			return "error_summary"
 		}
 	}
 

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -339,6 +339,23 @@ func messageContentText(content gjson.Result) string {
 	return b.String()
 }
 
+// IsConditionEffectivelyEmpty reports whether a mapping condition has no
+// active predicates. A nil condition or one whose every field trims to
+// the empty string carries no routing information and is treated as
+// unconditional. This avoids the surprising case where `when: {}` from
+// YAML or an API client appears to be a "conditional" rule (because the
+// pointer is non-nil) yet always matches and therefore silently shadows
+// other unconditional rules sharing the same From.
+func IsConditionEffectivelyEmpty(cond *config.AmpMappingCondition) bool {
+	if cond == nil {
+		return true
+	}
+	return strings.TrimSpace(cond.Feature) == "" &&
+		strings.TrimSpace(cond.ToolChoice) == "" &&
+		strings.TrimSpace(cond.UserSuffix) == "" &&
+		strings.TrimSpace(cond.SystemPrefix) == ""
+}
+
 // ConditionMatches reports whether the given mapping condition is satisfied
 // by the fingerprint. A nil condition always matches (unconditional mapping).
 func ConditionMatches(cond *config.AmpMappingCondition, fp RequestFingerprint) bool {

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -26,13 +26,14 @@ const (
 // change when Amp itself is upgraded. Keep prefixes long enough to avoid
 // collisions but short enough to tolerate trailing whitespace/newlines.
 const (
-	OraclePromptPrefix    = "you are the oracle - an expert ai advisor"
-	SearchPromptPrefix    = "you are a fast, parallel code search agent."
-	LookAtPromptPrefix    = "you are an ai assistant that analyzes files for a software engineer."
-	ReviewPromptPrefix    = "you are an expert software engineer reviewing code changes."
-	TitlingPromptPrefix   = "you are an assistant that generates short, descriptive titles"
-	HandoffPromptPrefix   = "you are an assistant tasked with creating a handoff context"
-	LibrarianPromptPrefix = "you are the librarian, a specialized codebase understanding agent"
+	OraclePromptPrefix     = "you are the oracle - an expert ai advisor"
+	SearchPromptPrefix     = "you are a fast, parallel code search agent"
+	LookAtPromptPrefix     = "you are an ai assistant that analyzes files for a software engineer"
+	ReviewPromptPrefix     = "you are an expert software engineer reviewing code changes"
+	ReviewMainPromptPrefix = "you are an expert senior engineer with deep knowledge of software engineering best practices"
+	TitlingPromptPrefix    = "you are an assistant that generates short, descriptive titles"
+	HandoffPromptPrefix    = "you are an assistant tasked with creating a handoff context"
+	LibrarianPromptPrefix  = "you are the librarian, a specialized codebase understanding agent"
 )
 
 // RequestFingerprint captures the per-request features a mapping condition
@@ -90,6 +91,8 @@ func (f RequestFingerprint) Feature() string {
 		case strings.HasPrefix(sys, LookAtPromptPrefix):
 			return "look_at"
 		case strings.HasPrefix(sys, ReviewPromptPrefix):
+			return "review"
+		case strings.HasPrefix(sys, ReviewMainPromptPrefix):
 			return "review"
 		case strings.HasPrefix(sys, LibrarianPromptPrefix):
 			return "librarian"

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -81,10 +81,11 @@ type RequestFingerprint struct {
 	// used by AmpMappingCondition.UserSuffix.
 	LastUserText string
 
-	// SystemText is the concatenated text of the request's system /
-	// systemInstruction / instructions field. Used by SystemPrefix matching
-	// and by Feature() to recognize features whose system prompts are
-	// hardcoded in the Amp client binary.
+	// SystemText is the first non-empty system-like text extracted from
+	// system / instructions / input[] system|developer / systemInstruction
+	// (in that order). Used by SystemPrefix matching and by Feature() to
+	// recognize features whose system prompts are hardcoded in the Amp
+	// client binary.
 	SystemText string
 
 	// HasImageOutput indicates the request asks the upstream model to emit
@@ -256,11 +257,12 @@ func extractLastUserText(body []byte) string {
 // extractSystemText returns the textual system / systemInstruction /
 // instructions content of the request. Sources are tried in order
 // (top-level system, top-level instructions, input[] system/developer
-// entries, systemInstruction); the first non-empty source wins and its
-// text parts are concatenated in declaration order. Anthropic and
-// OpenAI accept either a string or an array of typed parts; Gemini
-// wraps it in systemInstruction.parts[].text. OpenAI Responses
-// additionally allows a system/developer-role entry inside input[].
+// entries, systemInstruction); the first non-empty source wins. For
+// input[] specifically, the first non-empty system/developer entry in
+// declaration order wins; later entries are not considered. Within the
+// chosen source/entry, text parts are concatenated in declaration
+// order. Anthropic and OpenAI accept either a string or an array of
+// typed parts; Gemini wraps it in systemInstruction.parts[].text.
 func extractSystemText(body []byte) string {
 	// Anthropic / OpenAI Chat: top-level "system" (string or array).
 	if v := gjson.GetBytes(body, "system"); v.Exists() {

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -265,9 +265,9 @@ func extractSystemText(body []byte) string {
 			return s
 		}
 	}
-	// OpenAI Responses: top-level "instructions" (string).
-	if v := gjson.GetBytes(body, "instructions"); v.Exists() && v.Type == gjson.String {
-		if s := strings.TrimSpace(v.String()); s != "" {
+	// OpenAI Responses: top-level "instructions" (string or array of typed parts).
+	if v := gjson.GetBytes(body, "instructions"); v.Exists() {
+		if s := strings.TrimSpace(messageContentText(v)); s != "" {
 			return s
 		}
 	}

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -222,15 +222,21 @@ func extractLastUserText(body []byte) string {
 			return strings.TrimSpace(messageContentText(m.Get("content")))
 		}
 	}
-	// OpenAI Responses: input[] with role+content[].text/input_text.
-	if inp := gjson.GetBytes(body, "input"); inp.IsArray() {
-		arr := inp.Array()
-		for i := len(arr) - 1; i >= 0; i-- {
-			m := arr[i]
-			if !strings.EqualFold(m.Get("role").String(), "user") {
-				continue
+	// OpenAI Responses: input[] with role+content[].text/input_text,
+	// or a plain string (treated as the user message).
+	if inp := gjson.GetBytes(body, "input"); inp.Exists() {
+		if inp.Type == gjson.String {
+			return strings.TrimSpace(inp.String())
+		}
+		if inp.IsArray() {
+			arr := inp.Array()
+			for i := len(arr) - 1; i >= 0; i-- {
+				m := arr[i]
+				if !strings.EqualFold(m.Get("role").String(), "user") {
+					continue
+				}
+				return strings.TrimSpace(messageContentText(m.Get("content")))
 			}
-			return strings.TrimSpace(messageContentText(m.Get("content")))
 		}
 	}
 	// Gemini: contents[] with role+parts[].text

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -26,12 +26,13 @@ const (
 // change when Amp itself is upgraded. Keep prefixes long enough to avoid
 // collisions but short enough to tolerate trailing whitespace/newlines.
 const (
-	OraclePromptPrefix  = "you are the oracle - an expert ai advisor"
-	SearchPromptPrefix  = "you are a fast, parallel code search agent."
-	LookAtPromptPrefix  = "you are an ai assistant that analyzes files for a software engineer."
-	ReviewPromptPrefix  = "you are an expert software engineer reviewing code changes."
-	TitlingPromptPrefix = "you are an assistant that generates short, descriptive titles"
-	HandoffPromptPrefix = "you are an assistant tasked with creating a handoff context"
+	OraclePromptPrefix    = "you are the oracle - an expert ai advisor"
+	SearchPromptPrefix    = "you are a fast, parallel code search agent."
+	LookAtPromptPrefix    = "you are an ai assistant that analyzes files for a software engineer."
+	ReviewPromptPrefix    = "you are an expert software engineer reviewing code changes."
+	TitlingPromptPrefix   = "you are an assistant that generates short, descriptive titles"
+	HandoffPromptPrefix   = "you are an assistant tasked with creating a handoff context"
+	LibrarianPromptPrefix = "you are the librarian, a specialized codebase understanding agent"
 )
 
 // RequestFingerprint captures the per-request features a mapping condition
@@ -90,6 +91,8 @@ func (f RequestFingerprint) Feature() string {
 			return "look_at"
 		case strings.HasPrefix(sys, ReviewPromptPrefix):
 			return "review"
+		case strings.HasPrefix(sys, LibrarianPromptPrefix):
+			return "librarian"
 		case strings.HasPrefix(sys, TitlingPromptPrefix):
 			return "titling"
 		case strings.HasPrefix(sys, HandoffPromptPrefix):

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -288,6 +288,18 @@ func extractSystemText(body []byte) string {
 			}
 		}
 	}
+	// OpenAI Chat / compat providers: messages[] entries with role=system/developer.
+	if msgs := gjson.GetBytes(body, "messages"); msgs.IsArray() {
+		for _, m := range msgs.Array() {
+			role := strings.ToLower(m.Get("role").String())
+			if role != "system" && role != "developer" {
+				continue
+			}
+			if s := strings.TrimSpace(messageContentText(m.Get("content"))); s != "" {
+				return s
+			}
+		}
+	}
 	// Gemini: systemInstruction.parts[].text
 	if si := gjson.GetBytes(body, "systemInstruction"); si.Exists() {
 		var b strings.Builder

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -1,0 +1,169 @@
+// Package amp - request fingerprinting for feature-aware model routing.
+//
+// Amp shares some upstream models across multiple features (e.g. Gemini 3
+// Flash is used for handoff, search subagent, look-at). Name-based mapping
+// alone cannot distinguish them. RequestFingerprint inspects the request
+// body to recover semantic information about which Amp feature originated
+// the request so that AmpModelMapping.When can route per feature.
+package amp
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/tidwall/gjson"
+)
+
+// Known Amp tool names used to identify features.
+const (
+	HandoffToolName = "create_handoff_context"
+)
+
+// RequestFingerprint captures the per-request features a mapping condition
+// can match against. All fields are optional; absent fields cannot match.
+type RequestFingerprint struct {
+	// ToolChoice is the forced tool name extracted from the request body.
+	// Anthropic: tool_choice.name; OpenAI: tool_choice.function.name;
+	// Gemini: toolConfig.functionCallingConfig.allowedFunctionNames[0]
+	// when mode is ANY/AUTO and exactly one tool is allowed.
+	ToolChoice string
+
+	// LastUserText is the trimmed text content of the final user-role message,
+	// used by AmpMappingCondition.UserSuffix.
+	LastUserText string
+}
+
+// Feature returns the canonical Amp feature alias inferred from the
+// fingerprint, or an empty string if no high-level feature can be deduced.
+func (f RequestFingerprint) Feature() string {
+	if strings.EqualFold(f.ToolChoice, HandoffToolName) {
+		return "handoff"
+	}
+	// User-suffix based detection (cheap, anchored on Amp's actual prompt).
+	lower := strings.ToLower(f.LastUserText)
+	if strings.HasSuffix(lower, "use the create_handoff_context tool to extract relevant information and files.") {
+		return "handoff"
+	}
+	return ""
+}
+
+// ExtractFingerprint inspects a JSON request body (Anthropic, OpenAI/Codex,
+// or Gemini schema) and returns the best-effort fingerprint. The function
+// is read-only and tolerant of malformed input; missing fields yield empty
+// values rather than errors.
+func ExtractFingerprint(body []byte) RequestFingerprint {
+	if len(body) == 0 {
+		return RequestFingerprint{}
+	}
+
+	fp := RequestFingerprint{
+		ToolChoice:   extractToolChoiceName(body),
+		LastUserText: extractLastUserText(body),
+	}
+	return fp
+}
+
+func extractToolChoiceName(body []byte) string {
+	// Anthropic Messages: { "tool_choice": { "type": "tool", "name": "..." } }
+	if v := gjson.GetBytes(body, "tool_choice.name"); v.Exists() && v.Type == gjson.String {
+		return v.String()
+	}
+	// OpenAI Chat / Responses: { "tool_choice": { "type": "function", "function": { "name": "..." } } }
+	if v := gjson.GetBytes(body, "tool_choice.function.name"); v.Exists() && v.Type == gjson.String {
+		return v.String()
+	}
+	// Gemini: forced tool through allowedFunctionNames when mode is ANY.
+	mode := gjson.GetBytes(body, "toolConfig.functionCallingConfig.mode").String()
+	if strings.EqualFold(mode, "ANY") {
+		names := gjson.GetBytes(body, "toolConfig.functionCallingConfig.allowedFunctionNames")
+		if names.IsArray() {
+			arr := names.Array()
+			if len(arr) == 1 {
+				return arr[0].String()
+			}
+		}
+	}
+	return ""
+}
+
+// extractLastUserText returns the last user-role textual content from
+// Anthropic, OpenAI, or Gemini schemas. Only the trailing text is needed
+// for suffix matching; multi-part contents are concatenated in order.
+func extractLastUserText(body []byte) string {
+	// Anthropic / OpenAI Chat: messages[] with role+content.
+	if msgs := gjson.GetBytes(body, "messages"); msgs.IsArray() {
+		arr := msgs.Array()
+		for i := len(arr) - 1; i >= 0; i-- {
+			m := arr[i]
+			if !strings.EqualFold(m.Get("role").String(), "user") {
+				continue
+			}
+			return strings.TrimSpace(messageContentText(m.Get("content")))
+		}
+	}
+	// Gemini: contents[] with role+parts[].text
+	if cts := gjson.GetBytes(body, "contents"); cts.IsArray() {
+		arr := cts.Array()
+		for i := len(arr) - 1; i >= 0; i-- {
+			m := arr[i]
+			if !strings.EqualFold(m.Get("role").String(), "user") {
+				continue
+			}
+			var b strings.Builder
+			for _, p := range m.Get("parts").Array() {
+				if t := p.Get("text"); t.Exists() {
+					b.WriteString(t.String())
+				}
+			}
+			return strings.TrimSpace(b.String())
+		}
+	}
+	return ""
+}
+
+// messageContentText extracts text from an Anthropic/OpenAI message.content
+// value, which may be a plain string or an array of typed parts.
+func messageContentText(content gjson.Result) string {
+	if content.Type == gjson.String {
+		return content.String()
+	}
+	if !content.IsArray() {
+		return ""
+	}
+	var b strings.Builder
+	for _, part := range content.Array() {
+		// Anthropic: { type: "text", text: "..." }
+		// OpenAI:    { type: "text", text: "..." } or { type: "input_text", text: "..." }
+		if t := part.Get("text"); t.Exists() && t.Type == gjson.String {
+			b.WriteString(t.String())
+		}
+	}
+	return b.String()
+}
+
+// ConditionMatches reports whether the given mapping condition is satisfied
+// by the fingerprint. A nil condition always matches (unconditional mapping).
+func ConditionMatches(cond *config.AmpMappingCondition, fp RequestFingerprint) bool {
+	if cond == nil {
+		return true
+	}
+	if cond.ToolChoice != "" && !strings.EqualFold(cond.ToolChoice, fp.ToolChoice) {
+		return false
+	}
+	if cond.UserSuffix != "" {
+		if !strings.HasSuffix(strings.ToLower(fp.LastUserText), strings.ToLower(cond.UserSuffix)) {
+			return false
+		}
+	}
+	if cond.Feature != "" {
+		want := strings.ToLower(strings.TrimSpace(cond.Feature))
+		if want == "look_at" {
+			want = "search"
+		}
+		got := fp.Feature()
+		if got == "" || got != want {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -254,10 +254,13 @@ func extractLastUserText(body []byte) string {
 }
 
 // extractSystemText returns the textual system / systemInstruction /
-// instructions content of the request, concatenating multiple parts in
-// order. Anthropic and OpenAI accept either a string or an array of typed
-// parts; Gemini wraps it in systemInstruction.parts[].text. OpenAI
-// Responses additionally allows a system-role entry inside input[].
+// instructions content of the request. Sources are tried in order
+// (top-level system, top-level instructions, input[] system/developer
+// entries, systemInstruction); the first non-empty source wins and its
+// text parts are concatenated in declaration order. Anthropic and
+// OpenAI accept either a string or an array of typed parts; Gemini
+// wraps it in systemInstruction.parts[].text. OpenAI Responses
+// additionally allows a system/developer-role entry inside input[].
 func extractSystemText(body []byte) string {
 	// Anthropic / OpenAI Chat: top-level "system" (string or array).
 	if v := gjson.GetBytes(body, "system"); v.Exists() {

--- a/internal/api/modules/amp/fingerprint.go
+++ b/internal/api/modules/amp/fingerprint.go
@@ -16,8 +16,9 @@ import (
 
 // Known Amp tool names used to identify features.
 const (
-	HandoffToolName = "create_handoff_context"
-	TitlingToolName = "set_title"
+	HandoffToolName    = "create_handoff_context"
+	TitlingToolName    = "set_title"
+	ClassifierToolName = "answer_question"
 )
 
 // Hardcoded system-prompt prefixes used by the Amp client binary to invoke
@@ -26,15 +27,25 @@ const (
 // change when Amp itself is upgraded. Keep prefixes long enough to avoid
 // collisions but short enough to tolerate trailing whitespace/newlines.
 const (
-	OraclePromptPrefix     = "you are the oracle - an expert ai advisor"
-	SearchPromptPrefix     = "you are a fast, parallel code search agent"
-	LookAtPromptPrefix     = "you are an ai assistant that analyzes files for a software engineer"
-	ReviewPromptPrefix     = "you are an expert software engineer reviewing code changes"
-	ReviewMainPromptPrefix = "you are an expert senior engineer with deep knowledge of software engineering best practices"
-	TitlingPromptPrefix    = "you are an assistant that generates short, descriptive titles"
-	HandoffPromptPrefix    = "you are an assistant tasked with creating a handoff context"
-	LibrarianPromptPrefix  = "you are the librarian, a specialized codebase understanding agent"
+	OraclePromptPrefix        = "you are the oracle - an expert ai advisor"
+	SearchPromptPrefix        = "you are a fast, parallel code search agent"
+	LookAtPromptPrefix        = "you are an ai assistant that analyzes files for a software engineer"
+	ReviewPromptPrefix        = "you are an expert software engineer reviewing code changes"
+	ReviewMainPromptPrefix    = "you are an expert senior engineer with deep knowledge of software engineering best practices"
+	TitlingPromptPrefix       = "you are an assistant that generates short, descriptive titles"
+	HandoffPromptPrefix       = "you are an assistant tasked with creating a handoff context"
+	LibrarianPromptPrefix     = "you are the librarian, a specialized codebase understanding agent"
+	ClassifierPromptPrefix    = "you are a classifier that answers yes/no questions"
+	GitListPromptPrefix       = "you generate git commands to list changed files"
+	GitDiffPromptPrefix       = "you generate git diff commands that show the actual diff content"
+	ThreadExtractPromptPrefix = "you are helping me extract relevant information from the mentioned thread"
+	ErrorSummaryPromptPrefix  = "you are helping summarize work done by an ai coding agent"
 )
+
+// Suffix of the user-message template emitted by the codereview-check
+// subagent (`Run the "${name}" code review check.`). Combined with the
+// claude-haiku-4-5 model name this is a strong fingerprint.
+const CodereviewCheckUserSuffix = "code review check."
 
 // RequestFingerprint captures the per-request features a mapping condition
 // can match against. All fields are optional; absent fields cannot match.
@@ -67,18 +78,31 @@ type RequestFingerprint struct {
 // Detection order (first match wins):
 //  1. Forced tool name (most reliable; emitted by Amp's tool_choice).
 //  2. responseModalities=IMAGE (painter).
-//  3. System-prompt prefix (hardcoded literals in the Amp binary).
-//  4. User-suffix heuristic (handoff fallback).
+//  3. User-suffix templates that uniquely identify a feature (e.g.
+//     codereview-check `Run the "..." code review check.`). These take
+//     priority over system-prompt prefix because codereview-check shares
+//     its system prompt with the main review subagent.
+//  4. System-prompt prefix (hardcoded literals in the Amp binary).
+//  5. User-suffix heuristic (handoff fallback).
 func (f RequestFingerprint) Feature() string {
 	switch {
 	case strings.EqualFold(f.ToolChoice, HandoffToolName):
 		return "handoff"
 	case strings.EqualFold(f.ToolChoice, TitlingToolName):
 		return "titling"
+	case strings.EqualFold(f.ToolChoice, ClassifierToolName):
+		return "classifier"
 	}
 
 	if f.HasImageOutput {
 		return "painter"
+	}
+
+	lastUser := strings.ToLower(strings.TrimSpace(f.LastUserText))
+	if lastUser != "" {
+		if strings.HasSuffix(lastUser, CodereviewCheckUserSuffix) {
+			return "codereview_check"
+		}
 	}
 
 	sys := strings.ToLower(strings.TrimSpace(f.SystemText))
@@ -100,12 +124,21 @@ func (f RequestFingerprint) Feature() string {
 			return "titling"
 		case strings.HasPrefix(sys, HandoffPromptPrefix):
 			return "handoff"
+		case strings.HasPrefix(sys, ClassifierPromptPrefix):
+			return "classifier"
+		case strings.HasPrefix(sys, GitListPromptPrefix):
+			return "git_list"
+		case strings.HasPrefix(sys, GitDiffPromptPrefix):
+			return "git_diff"
+		case strings.HasPrefix(sys, ThreadExtractPromptPrefix):
+			return "thread_extract"
+		case strings.HasPrefix(sys, ErrorSummaryPromptPrefix):
+			return "error_summary"
 		}
 	}
 
 	// User-suffix based detection (cheap, anchored on Amp's actual prompt).
-	lower := strings.ToLower(f.LastUserText)
-	if strings.HasSuffix(lower, "use the create_handoff_context tool to extract relevant information and files.") {
+	if strings.HasSuffix(lastUser, "use the create_handoff_context tool to extract relevant information and files.") {
 		return "handoff"
 	}
 	return ""

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -154,6 +154,20 @@ func TestExtractFingerprint_Painter(t *testing.T) {
 	}
 }
 
+// TestExtractFingerprint_Librarian uses the real Anthropic payload
+// captured from the Amp librarian tool (claude-sonnet-4-6).
+func TestExtractFingerprint_Librarian(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-sonnet-4-6",
+		"system":"You are the Librarian, a specialized codebase understanding agent that helps users answer questions about large, complex codebases across repositories.",
+		"messages":[{"role":"user","content":"Briefly describe what the github.com/router-for-me/CLIProxyAPI repository does — its purpose, main features, and how it works."}]
+	}`)
+	fp := ExtractFingerprint(body)
+	if got := fp.Feature(); got != "librarian" {
+		t.Fatalf("Feature = %q, want librarian", got)
+	}
+}
+
 // TestExtractFingerprint_SystemPrefixCustom verifies users can match an
 // arbitrary system prompt prefix that is not encoded in Feature().
 func TestExtractFingerprint_SystemPrefixCustom(t *testing.T) {

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -447,9 +447,9 @@ func TestModelMapper_RegexOrderRespectedAcrossOverlappingPatterns(t *testing.T) 
 
 	// Two distinct regex patterns that both match "gemini-3-flash-preview".
 	// Earlier rule is unconditional; later rule has a handoff condition.
-	// Since the earlier group's fallback is committed at the group
-	// transition, the later conditional rule must NOT steal a handoff
-	// request that already had a perfectly good earlier match.
+	// Groups are evaluated in declaration order, so the earlier group's
+	// unconditional fallback is returned before the later group's
+	// conditional rule is considered.
 	mapper := NewModelMapper([]config.AmpModelMapping{
 		{From: "^gemini-3-.*$", To: "early-target", Regex: true},
 		{From: "^.*-flash-.*$", To: "late-handoff-target", Regex: true,

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -270,41 +270,32 @@ func TestExtractFingerprint_CodereviewCheck_DoesNotCollideWithReview(t *testing.
 	}
 }
 
-// TestExtractFingerprint_ThreadExtractManualMatch verifies that the
-// read_thread internal-extraction prompt — not yet captured through the
-// proxy and therefore intentionally not encoded as a canonical
-// Feature() — can still be routed via SystemPrefix.
-func TestExtractFingerprint_ThreadExtractManualMatch(t *testing.T) {
+// TestExtractFingerprint_ThreadExtract matches the read_thread tool's
+// internal extraction call. Source-confirmed via `await KW(kb, ...)`
+// in the binary, which is the same Gemini wrapper used by error_summary
+// and review-summary (both observed flowing through /api/provider/google).
+func TestExtractFingerprint_ThreadExtract(t *testing.T) {
 	body := []byte(`{
 		"contents":[{"role":"user","parts":[{"text":"thread content..."}]}],
 		"systemInstruction":{"parts":[{"text":"You are helping me extract relevant information from the mentioned thread based on a goal."}]}
 	}`)
-	fp := ExtractFingerprint(body)
-	if got := fp.Feature(); got != "" {
-		t.Fatalf("Feature = %q, want empty (thread_extract is not canonical)", got)
-	}
-	cond := &config.AmpMappingCondition{SystemPrefix: "you are helping me extract relevant information from the mentioned thread"}
-	if !ConditionMatches(cond, fp) {
-		t.Fatalf("expected SystemPrefix to match")
+	if got := ExtractFingerprint(body).Feature(); got != "thread_extract" {
+		t.Fatalf("Feature = %q, want thread_extract", got)
 	}
 }
 
-// TestExtractFingerprint_ErrorSummaryManualMatch mirrors the
-// thread_extract case: the subagent error-recovery summarizer prompt
-// is recognized only via the manual SystemPrefix matcher until a real
-// /api/provider/* capture confirms it.
-func TestExtractFingerprint_ErrorSummaryManualMatch(t *testing.T) {
+// TestExtractFingerprint_ErrorSummary matches the subagent error-recovery
+// summarizer that fires when a Task subagent hits a fatal error. Source-
+// confirmed: same KW(kb, ...) Gemini wrapper as thread_extract, with the
+// binary's debug log explicitly saying "Failed to summarize subagent
+// work with Gemini".
+func TestExtractFingerprint_ErrorSummary(t *testing.T) {
 	body := []byte(`{
 		"contents":[{"role":"user","parts":[{"text":"work history..."}]}],
 		"systemInstruction":{"parts":[{"text":"You are helping summarize work done by an AI coding agent (subagent) before it encountered an error."}]}
 	}`)
-	fp := ExtractFingerprint(body)
-	if got := fp.Feature(); got != "" {
-		t.Fatalf("Feature = %q, want empty (error_summary is not canonical)", got)
-	}
-	cond := &config.AmpMappingCondition{SystemPrefix: "you are helping summarize work done by an ai coding agent"}
-	if !ConditionMatches(cond, fp) {
-		t.Fatalf("expected SystemPrefix to match")
+	if got := ExtractFingerprint(body).Feature(); got != "error_summary" {
+		t.Fatalf("Feature = %q, want error_summary", got)
 	}
 }
 

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -257,27 +257,54 @@ func TestExtractFingerprint_CodereviewCheck(t *testing.T) {
 	}
 }
 
-// TestExtractFingerprint_ThreadExtract matches the read_thread tool's
-// internal extraction call.
-func TestExtractFingerprint_ThreadExtract(t *testing.T) {
+// TestExtractFingerprint_CodereviewCheck_DoesNotCollideWithReview ensures
+// that loose phrases ending in "code review check" inside a review-main
+// request do not get reclassified away from "review".
+func TestExtractFingerprint_CodereviewCheck_DoesNotCollideWithReview(t *testing.T) {
+	body := []byte(`{
+		"contents":[{"role":"user","parts":[{"text":"Please run a thorough code review check."}]}],
+		"systemInstruction":{"parts":[{"text":"You are an expert senior engineer with deep knowledge of software engineering best practices."}]}
+	}`)
+	if got := ExtractFingerprint(body).Feature(); got != "review" {
+		t.Fatalf("Feature = %q, want review (codereview_check should not collide)", got)
+	}
+}
+
+// TestExtractFingerprint_ThreadExtractManualMatch verifies that the
+// read_thread internal-extraction prompt — not yet captured through the
+// proxy and therefore intentionally not encoded as a canonical
+// Feature() — can still be routed via SystemPrefix.
+func TestExtractFingerprint_ThreadExtractManualMatch(t *testing.T) {
 	body := []byte(`{
 		"contents":[{"role":"user","parts":[{"text":"thread content..."}]}],
 		"systemInstruction":{"parts":[{"text":"You are helping me extract relevant information from the mentioned thread based on a goal."}]}
 	}`)
-	if got := ExtractFingerprint(body).Feature(); got != "thread_extract" {
-		t.Fatalf("Feature = %q, want thread_extract", got)
+	fp := ExtractFingerprint(body)
+	if got := fp.Feature(); got != "" {
+		t.Fatalf("Feature = %q, want empty (thread_extract is not canonical)", got)
+	}
+	cond := &config.AmpMappingCondition{SystemPrefix: "you are helping me extract relevant information from the mentioned thread"}
+	if !ConditionMatches(cond, fp) {
+		t.Fatalf("expected SystemPrefix to match")
 	}
 }
 
-// TestExtractFingerprint_ErrorSummary matches the subagent error-recovery
-// summarizer that fires when a Task subagent hits a fatal error.
-func TestExtractFingerprint_ErrorSummary(t *testing.T) {
+// TestExtractFingerprint_ErrorSummaryManualMatch mirrors the
+// thread_extract case: the subagent error-recovery summarizer prompt
+// is recognized only via the manual SystemPrefix matcher until a real
+// /api/provider/* capture confirms it.
+func TestExtractFingerprint_ErrorSummaryManualMatch(t *testing.T) {
 	body := []byte(`{
 		"contents":[{"role":"user","parts":[{"text":"work history..."}]}],
 		"systemInstruction":{"parts":[{"text":"You are helping summarize work done by an AI coding agent (subagent) before it encountered an error."}]}
 	}`)
-	if got := ExtractFingerprint(body).Feature(); got != "error_summary" {
-		t.Fatalf("Feature = %q, want error_summary", got)
+	fp := ExtractFingerprint(body)
+	if got := fp.Feature(); got != "" {
+		t.Fatalf("Feature = %q, want empty (error_summary is not canonical)", got)
+	}
+	cond := &config.AmpMappingCondition{SystemPrefix: "you are helping summarize work done by an ai coding agent"}
+	if !ConditionMatches(cond, fp) {
+		t.Fatalf("expected SystemPrefix to match")
 	}
 }
 

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -71,8 +71,109 @@ func TestExtractFingerprint_Empty(t *testing.T) {
 	}
 }
 
+// TestExtractFingerprint_Oracle uses a real OpenAI Responses payload
+// captured from `amp -x "use the oracle tool ..."`. Oracle has no
+// tool_choice; it is identified by its hardcoded system prompt.
+func TestExtractFingerprint_Oracle(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.4",
+		"input":[
+			{"role":"system","content":"You are the Oracle - an expert AI advisor with advanced reasoning capabilities.\n\nYour role is to provide high-quality technical guidance, code reviews, architectural advice, and strategic planning for software engineering tasks."},
+			{"role":"user","content":[{"type":"input_text","text":"Task: review fingerprint.go"}]}
+		],
+		"reasoning":{"effort":"high","summary":"auto"}
+	}`)
+	fp := ExtractFingerprint(body)
+	if fp.ToolChoice != "" {
+		t.Fatalf("ToolChoice = %q, want empty", fp.ToolChoice)
+	}
+	if got := fp.Feature(); got != "oracle" {
+		t.Fatalf("Feature = %q, want oracle", got)
+	}
+}
+
+// TestExtractFingerprint_SearchSubagent uses the real Gemini payload
+// captured from the Amp finder (search subagent) tool. Identified by
+// its hardcoded systemInstruction prefix.
+func TestExtractFingerprint_SearchSubagent(t *testing.T) {
+	body := []byte(`{
+		"contents":[{"role":"user","parts":[{"text":"Find OAuth callback handlers."}]}],
+		"systemInstruction":{"parts":[{"text":"You are a fast, parallel code search agent.\n\n## Task\nFind files and line ranges relevant to the user's query (provided in the first message)."}]},
+		"tools":[{"functionDeclarations":[{"name":"glob"},{"name":"Grep"},{"name":"Read"}]}]
+	}`)
+	fp := ExtractFingerprint(body)
+	if got := fp.Feature(); got != "search" {
+		t.Fatalf("Feature = %q, want search", got)
+	}
+}
+
+// TestExtractFingerprint_LookAt uses the real Gemini payload captured
+// from the Amp look_at tool. Identified by its hardcoded
+// systemInstruction prefix.
+func TestExtractFingerprint_LookAt(t *testing.T) {
+	body := []byte(`{
+		"contents":[{"role":"user","parts":[
+			{"inlineData":{"mimeType":"image/png","data":"AA=="}},
+			{"text":"User asked for a brief description of the image.\n\nAnalyze this file with the following objective:\n\nBriefly describe the contents of the image."}
+		]}],
+		"systemInstruction":{"parts":[{"text":"You are an AI assistant that analyzes files for a software engineer.\n\n# Core Principles\n\n- Be concise and direct."}]}
+	}`)
+	fp := ExtractFingerprint(body)
+	if got := fp.Feature(); got != "look_at" {
+		t.Fatalf("Feature = %q, want look_at", got)
+	}
+}
+
+// TestExtractFingerprint_Review uses the Amp review systemInstruction
+// (compiled into the Amp binary at amp.review).
+func TestExtractFingerprint_Review(t *testing.T) {
+	body := []byte(`{
+		"contents":[{"role":"user","parts":[{"text":"diff..."}]}],
+		"systemInstruction":{"parts":[{"text":"You are an expert software engineer reviewing code changes."}]}
+	}`)
+	fp := ExtractFingerprint(body)
+	if got := fp.Feature(); got != "review" {
+		t.Fatalf("Feature = %q, want review", got)
+	}
+}
+
+// TestExtractFingerprint_Painter uses the real Gemini image-generation
+// payload captured from the Amp painter tool. Identified by
+// generationConfig.responseModalities containing "IMAGE".
+func TestExtractFingerprint_Painter(t *testing.T) {
+	body := []byte(`{
+		"contents":[{"role":"user","parts":[{"text":"A small solid red circle centered on a plain white background."}]}],
+		"generationConfig":{"responseModalities":["TEXT","IMAGE"],"imageConfig":{"imageSize":"1K"}}
+	}`)
+	fp := ExtractFingerprint(body)
+	if !fp.HasImageOutput {
+		t.Fatalf("HasImageOutput = false, want true")
+	}
+	if got := fp.Feature(); got != "painter" {
+		t.Fatalf("Feature = %q, want painter", got)
+	}
+}
+
+// TestExtractFingerprint_SystemPrefixCustom verifies users can match an
+// arbitrary system prompt prefix that is not encoded in Feature().
+func TestExtractFingerprint_SystemPrefixCustom(t *testing.T) {
+	body := []byte(`{
+		"contents":[{"role":"user","parts":[{"text":"hi"}]}],
+		"systemInstruction":{"parts":[{"text":"You are an expert senior engineer with deep knowledge of software engineering best practices."}]}
+	}`)
+	fp := ExtractFingerprint(body)
+	cond := &config.AmpMappingCondition{SystemPrefix: "you are an expert senior engineer"}
+	if !ConditionMatches(cond, fp) {
+		t.Fatalf("expected SystemPrefix to match")
+	}
+}
+
 func TestConditionMatches(t *testing.T) {
-	fp := RequestFingerprint{ToolChoice: "create_handoff_context", LastUserText: "blah\nUse the create_handoff_context tool to extract relevant information and files."}
+	fp := RequestFingerprint{
+		ToolChoice:   "create_handoff_context",
+		LastUserText: "blah\nUse the create_handoff_context tool to extract relevant information and files.",
+		SystemText:   "You are an expert senior engineer with deep knowledge.",
+	}
 	cases := []struct {
 		name string
 		cond *config.AmpMappingCondition
@@ -85,6 +186,8 @@ func TestConditionMatches(t *testing.T) {
 		{"tool_choice no match", &config.AmpMappingCondition{ToolChoice: "other"}, false},
 		{"user_suffix match", &config.AmpMappingCondition{UserSuffix: "extract relevant information and files."}, true},
 		{"user_suffix no match", &config.AmpMappingCondition{UserSuffix: "nope"}, false},
+		{"system_prefix match", &config.AmpMappingCondition{SystemPrefix: "you are an expert senior engineer"}, true},
+		{"system_prefix no match", &config.AmpMappingCondition{SystemPrefix: "you are batman"}, false},
 		{"AND match", &config.AmpMappingCondition{Feature: "handoff", ToolChoice: "create_handoff_context"}, true},
 		{"AND fail", &config.AmpMappingCondition{Feature: "handoff", ToolChoice: "x"}, false},
 	}

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -489,6 +489,34 @@ func TestModelMapper_RegexConditionalWinsWithinSameGroup(t *testing.T) {
 	}
 }
 
+// TestModelMapper_RegexCaseVariantSharesGroup verifies that two regex
+// rules whose From patterns differ only by letter case share the same
+// group (since UpdateMappings compiles them case-insensitively). A
+// later same-pattern conditional must remain reachable behind an
+// earlier case-variant fallback.
+func TestModelMapper_RegexCaseVariantSharesGroup(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-regex-case", "anthropic", []*registry.ModelInfo{
+		{ID: "case-conditional-target", OwnedBy: "anthropic", Type: "claude"},
+		{ID: "case-fallback-target", OwnedBy: "anthropic", Type: "claude"},
+	})
+	defer reg.UnregisterClient("test-regex-case")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{From: "^GEMINI-3-.*$", To: "case-fallback-target", Regex: true},
+		{From: "^gemini-3-.*$", To: "case-conditional-target", Regex: true,
+			When: &config.AmpMappingCondition{Feature: "handoff"}},
+	})
+
+	if got := mapper.MapModelCtx("gemini-3-flash-preview",
+		RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "case-conditional-target" {
+		t.Errorf("got %q, want case-conditional-target (case-variant regex must share group)", got)
+	}
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "case-fallback-target" {
+		t.Errorf("got %q, want case-fallback-target", got)
+	}
+}
+
 func TestModelMapper_MapModelCtx_ConditionalThenFallback(t *testing.T) {
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient("test-cond", "openai", []*registry.ModelInfo{

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -71,6 +71,22 @@ func TestExtractFingerprint_Empty(t *testing.T) {
 	}
 }
 
+// TestExtractFingerprint_OracleArrayInstructions verifies that an Oracle
+// request using array-form `instructions` (instead of a plain string)
+// still has its system text extracted and feature detection works.
+// OpenAI Responses accepts both shapes.
+func TestExtractFingerprint_OracleArrayInstructions(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.4",
+		"instructions":[{"type":"text","text":"You are the Oracle - an expert AI advisor with advanced reasoning capabilities."}],
+		"input":[{"role":"user","content":[{"type":"input_text","text":"Task: review fingerprint.go"}]}]
+	}`)
+	fp := ExtractFingerprint(body)
+	if got := fp.Feature(); got != "oracle" {
+		t.Fatalf("Feature = %q, want oracle (array-form instructions must be parsed)", got)
+	}
+}
+
 // TestExtractFingerprint_Oracle uses a real OpenAI Responses payload
 // captured from `amp -x "use the oracle tool ..."`. Oracle has no
 // tool_choice; it is identified by its hardcoded system prompt.

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -121,3 +121,87 @@ func TestModelMapper_MapModelCtx_ConditionalOnlyNoFallback(t *testing.T) {
 		t.Errorf("got %q, want empty", got)
 	}
 }
+
+// TestModelMapper_MapModelCtx_ConditionalWinsRegardlessOfOrder verifies the
+// documented "conditional wins" semantics hold even when the unconditional
+// fallback appears before the conditional rule in config.
+func TestModelMapper_MapModelCtx_ConditionalWinsRegardlessOfOrder(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-cond3", "openai", []*registry.ModelInfo{
+		{ID: "gpt-handoff", OwnedBy: "openai", Type: "openai"},
+		{ID: "gpt-default", OwnedBy: "openai", Type: "openai"},
+	})
+	defer reg.UnregisterClient("test-cond3")
+
+	// Fallback FIRST, conditional SECOND
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "gpt-default"},
+		{From: "gemini-3-flash-preview", To: "gpt-handoff", When: &config.AmpMappingCondition{Feature: "handoff"}},
+	})
+
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "gpt-handoff" {
+		t.Errorf("handoff (fallback-before-conditional): got %q want gpt-handoff", got)
+	}
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "gpt-default" {
+		t.Errorf("default: got %q want gpt-default", got)
+	}
+}
+
+// TestModelMapper_ExactBeforeRegex verifies that exact rules win over regex
+// rules even when the regex rule is declared first.
+func TestModelMapper_ExactBeforeRegex(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-exact-regex", "anthropic", []*registry.ModelInfo{
+		{ID: "claude-sonnet-4", OwnedBy: "anthropic", Type: "claude"},
+		{ID: "claude-opus-4", OwnedBy: "anthropic", Type: "claude"},
+	})
+	defer reg.UnregisterClient("test-exact-regex")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{From: "^gpt-5.*$", To: "claude-sonnet-4", Regex: true},
+		{From: "gpt-5", To: "claude-opus-4"},
+	})
+	if got := mapper.MapModel("gpt-5"); got != "claude-opus-4" {
+		t.Errorf("got %q, want claude-opus-4 (exact must beat regex)", got)
+	}
+}
+
+// TestModelMapper_DeepCopiesWhen verifies that mutating the original config
+// after UpdateMappings does not affect the mapper's internal state.
+func TestModelMapper_DeepCopiesWhen(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-deepcopy", "openai", []*registry.ModelInfo{
+		{ID: "gpt-handoff", OwnedBy: "openai", Type: "openai"},
+	})
+	defer reg.UnregisterClient("test-deepcopy")
+
+	cond := &config.AmpMappingCondition{Feature: "handoff"}
+	mappings := []config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "gpt-handoff", When: cond},
+	}
+	mapper := NewModelMapper(mappings)
+
+	// Mutate original condition after construction.
+	cond.Feature = "search"
+
+	// Mapper should still match the handoff fingerprint (mutation ignored).
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "gpt-handoff" {
+		t.Errorf("got %q, want gpt-handoff (mapper must deep-copy When)", got)
+	}
+}
+
+// TestConditionMatches_TrimsConfigWhitespace verifies trailing whitespace in
+// configuration values does not break matching.
+func TestConditionMatches_TrimsConfigWhitespace(t *testing.T) {
+	fp := RequestFingerprint{
+		ToolChoice:   "create_handoff_context",
+		LastUserText: "Use the create_handoff_context tool to extract relevant information and files.",
+	}
+	cond := &config.AmpMappingCondition{
+		ToolChoice: "  create_handoff_context  ",
+		UserSuffix: "  extract relevant information and files.  ",
+	}
+	if !ConditionMatches(cond, fp) {
+		t.Error("expected match after trimming whitespace from config")
+	}
+}

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -200,6 +200,87 @@ func TestExtractFingerprint_SystemPrefixCustom(t *testing.T) {
 	}
 }
 
+// TestExtractFingerprint_Classifier matches the internal yes/no classifier
+// (Anthropic claude-haiku-4-5 with tool_choice = answer_question, system
+// "You are a classifier that answers yes/no questions...").
+func TestExtractFingerprint_Classifier(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-haiku-4-5-20251001",
+		"system":"You are a classifier that answers yes/no questions. You must use the provided tool to give your answer with reasoning.",
+		"messages":[{"role":"user","content":"Should we compact this thread?"}],
+		"tool_choice":{"type":"tool","name":"answer_question"},
+		"tools":[{"name":"answer_question"}]
+	}`)
+	fp := ExtractFingerprint(body)
+	if got := fp.Feature(); got != "classifier" {
+		t.Fatalf("Feature = %q, want classifier", got)
+	}
+}
+
+// TestExtractFingerprint_GitListHelper matches the amp.review git-list
+// preparation call (claude-haiku-4-5).
+func TestExtractFingerprint_GitListHelper(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-haiku-4-5-20251001",
+		"system":"You generate git commands to list changed files. Output commands wrapped in <command></command> tags.",
+		"messages":[{"role":"user","content":"HEAD~1"}]
+	}`)
+	if got := ExtractFingerprint(body).Feature(); got != "git_list" {
+		t.Fatalf("Feature = %q, want git_list", got)
+	}
+}
+
+// TestExtractFingerprint_GitDiffHelper matches the amp.review git-diff
+// preparation call (claude-haiku-4-5).
+func TestExtractFingerprint_GitDiffHelper(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-haiku-4-5-20251001",
+		"system":"You generate git diff commands that show the actual diff content. Output commands in XML format:\n<command>...</command>",
+		"messages":[{"role":"user","content":"HEAD~1"}]
+	}`)
+	if got := ExtractFingerprint(body).Feature(); got != "git_diff" {
+		t.Fatalf("Feature = %q, want git_diff", got)
+	}
+}
+
+// TestExtractFingerprint_CodereviewCheck matches the per-check review
+// subagent invoked by `amp review --checks-only` when a check is found.
+// User message template: `Run the "${name}" code review check.`
+func TestExtractFingerprint_CodereviewCheck(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-haiku-4-5-20251001",
+		"system":"You are an expert senior engineer with deep knowledge of software engineering best practices, security, performance, and maintainability.\n\n## Files to Review\n...",
+		"messages":[{"role":"user","content":"Run the \"sql-injection-checker\" code review check."}]
+	}`)
+	if got := ExtractFingerprint(body).Feature(); got != "codereview_check" {
+		t.Fatalf("Feature = %q, want codereview_check", got)
+	}
+}
+
+// TestExtractFingerprint_ThreadExtract matches the read_thread tool's
+// internal extraction call.
+func TestExtractFingerprint_ThreadExtract(t *testing.T) {
+	body := []byte(`{
+		"contents":[{"role":"user","parts":[{"text":"thread content..."}]}],
+		"systemInstruction":{"parts":[{"text":"You are helping me extract relevant information from the mentioned thread based on a goal."}]}
+	}`)
+	if got := ExtractFingerprint(body).Feature(); got != "thread_extract" {
+		t.Fatalf("Feature = %q, want thread_extract", got)
+	}
+}
+
+// TestExtractFingerprint_ErrorSummary matches the subagent error-recovery
+// summarizer that fires when a Task subagent hits a fatal error.
+func TestExtractFingerprint_ErrorSummary(t *testing.T) {
+	body := []byte(`{
+		"contents":[{"role":"user","parts":[{"text":"work history..."}]}],
+		"systemInstruction":{"parts":[{"text":"You are helping summarize work done by an AI coding agent (subagent) before it encountered an error."}]}
+	}`)
+	if got := ExtractFingerprint(body).Feature(); got != "error_summary" {
+		t.Fatalf("Feature = %q, want error_summary", got)
+	}
+}
+
 func TestConditionMatches(t *testing.T) {
 	fp := RequestFingerprint{
 		ToolChoice:   "create_handoff_context",

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -7,6 +7,25 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 )
 
+func TestExtractFingerprint_Titling(t *testing.T) {
+	// Real Amp titling request observed: Anthropic Claude Haiku with
+	// tool_choice forcing set_title, message wrapped in <message>...</message>.
+	body := []byte(`{
+		"model":"claude-haiku-4-5-20251001",
+		"max_tokens":60,
+		"system":"You are an assistant that generates short, descriptive titles (maximum 5 words) ...",
+		"messages":[{"role":"user","content":"<message>say hi in one word</message>"}],
+		"tool_choice":{"type":"tool","name":"set_title","disable_parallel_tool_use":true}
+	}`)
+	fp := ExtractFingerprint(body)
+	if fp.ToolChoice != "set_title" {
+		t.Fatalf("ToolChoice = %q", fp.ToolChoice)
+	}
+	if got := fp.Feature(); got != "titling" {
+		t.Fatalf("Feature = %q, want titling", got)
+	}
+}
+
 func TestExtractFingerprint_AnthropicHandoff(t *testing.T) {
 	body := []byte(`{
 		"model":"gemini-3-flash-preview",

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -1,0 +1,123 @@
+package amp
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+)
+
+func TestExtractFingerprint_AnthropicHandoff(t *testing.T) {
+	body := []byte(`{
+		"model":"gemini-3-flash-preview",
+		"system":"",
+		"messages":[{"role":"user","content":[{"type":"text","text":"Earlier we did X.\nUse the create_handoff_context tool to extract relevant information and files."}]}],
+		"tool_choice":{"type":"tool","name":"create_handoff_context"}
+	}`)
+	fp := ExtractFingerprint(body)
+	if fp.ToolChoice != "create_handoff_context" {
+		t.Fatalf("ToolChoice = %q", fp.ToolChoice)
+	}
+	if got := fp.Feature(); got != "handoff" {
+		t.Fatalf("Feature = %q, want handoff", got)
+	}
+}
+
+func TestExtractFingerprint_OpenAI(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"hi"}],"tool_choice":{"type":"function","function":{"name":"create_handoff_context"}}}`)
+	fp := ExtractFingerprint(body)
+	if fp.ToolChoice != "create_handoff_context" {
+		t.Fatalf("ToolChoice = %q", fp.ToolChoice)
+	}
+}
+
+func TestExtractFingerprint_GeminiAnyMode(t *testing.T) {
+	body := []byte(`{
+		"contents":[{"role":"user","parts":[{"text":"foo Use the create_handoff_context tool to extract relevant information and files."}]}],
+		"toolConfig":{"functionCallingConfig":{"mode":"ANY","allowedFunctionNames":["create_handoff_context"]}}
+	}`)
+	fp := ExtractFingerprint(body)
+	if fp.ToolChoice != "create_handoff_context" {
+		t.Fatalf("ToolChoice = %q", fp.ToolChoice)
+	}
+	if fp.Feature() != "handoff" {
+		t.Fatal("expected handoff feature")
+	}
+}
+
+func TestExtractFingerprint_Empty(t *testing.T) {
+	fp := ExtractFingerprint(nil)
+	if fp.ToolChoice != "" || fp.LastUserText != "" {
+		t.Fatalf("expected empty, got %+v", fp)
+	}
+}
+
+func TestConditionMatches(t *testing.T) {
+	fp := RequestFingerprint{ToolChoice: "create_handoff_context", LastUserText: "blah\nUse the create_handoff_context tool to extract relevant information and files."}
+	cases := []struct {
+		name string
+		cond *config.AmpMappingCondition
+		want bool
+	}{
+		{"nil matches", nil, true},
+		{"feature handoff", &config.AmpMappingCondition{Feature: "handoff"}, true},
+		{"feature search no match", &config.AmpMappingCondition{Feature: "search"}, false},
+		{"tool_choice match", &config.AmpMappingCondition{ToolChoice: "create_handoff_context"}, true},
+		{"tool_choice no match", &config.AmpMappingCondition{ToolChoice: "other"}, false},
+		{"user_suffix match", &config.AmpMappingCondition{UserSuffix: "extract relevant information and files."}, true},
+		{"user_suffix no match", &config.AmpMappingCondition{UserSuffix: "nope"}, false},
+		{"AND match", &config.AmpMappingCondition{Feature: "handoff", ToolChoice: "create_handoff_context"}, true},
+		{"AND fail", &config.AmpMappingCondition{Feature: "handoff", ToolChoice: "x"}, false},
+	}
+	for _, c := range cases {
+		if got := ConditionMatches(c.cond, fp); got != c.want {
+			t.Errorf("%s: got %v want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestModelMapper_MapModelCtx_ConditionalThenFallback(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-cond", "openai", []*registry.ModelInfo{
+		{ID: "gpt-handoff", OwnedBy: "openai", Type: "openai"},
+		{ID: "gpt-default", OwnedBy: "openai", Type: "openai"},
+	})
+	defer reg.UnregisterClient("test-cond")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "gpt-handoff", When: &config.AmpMappingCondition{Feature: "handoff"}},
+		{From: "gemini-3-flash-preview", To: "gpt-default"},
+	})
+
+	// Handoff request -> conditional rule wins
+	fpHandoff := RequestFingerprint{ToolChoice: "create_handoff_context"}
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", fpHandoff); got != "gpt-handoff" {
+		t.Errorf("handoff: got %q want gpt-handoff", got)
+	}
+
+	// Non-handoff request -> fallback rule
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "gpt-default" {
+		t.Errorf("default: got %q want gpt-default", got)
+	}
+
+	// MapModel (no fp) should also pick the fallback
+	if got := mapper.MapModel("gemini-3-flash-preview"); got != "gpt-default" {
+		t.Errorf("MapModel: got %q want gpt-default", got)
+	}
+}
+
+func TestModelMapper_MapModelCtx_ConditionalOnlyNoFallback(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-cond2", "openai", []*registry.ModelInfo{
+		{ID: "gpt-handoff", OwnedBy: "openai", Type: "openai"},
+	})
+	defer reg.UnregisterClient("test-cond2")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "gpt-handoff", When: &config.AmpMappingCondition{Feature: "handoff"}},
+	})
+	// Without matching fingerprint, no mapping
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -362,35 +362,32 @@ func TestConditionMatches(t *testing.T) {
 	}
 }
 
-// TestModelMapper_DuplicateExactFallbackLastWins regression-tests the
-// pre-existing semantic where a later duplicate unconditional exact
-// mapping overrides an earlier one. The original implementation used
-// map[from]to (last write wins); preserving that on the grouped path
-// avoids silently re-routing requests after upgrade.
-func TestModelMapper_DuplicateExactFallbackLastWins(t *testing.T) {
+// TestModelMapper_DuplicateExactFallbackFirstWins verifies that when
+// multiple unconditional rules share the same From, the first one wins
+// (top-to-bottom declaration order).
+func TestModelMapper_DuplicateExactFallbackFirstWins(t *testing.T) {
 	reg := registry.GetGlobalRegistry()
-	reg.RegisterClient("test-dup-last", "openai", []*registry.ModelInfo{
+	reg.RegisterClient("test-dup-first", "openai", []*registry.ModelInfo{
 		{ID: "first-target", OwnedBy: "openai", Type: "openai"},
 		{ID: "second-target", OwnedBy: "openai", Type: "openai"},
 	})
-	defer reg.UnregisterClient("test-dup-last")
+	defer reg.UnregisterClient("test-dup-first")
 
 	mapper := NewModelMapper([]config.AmpModelMapping{
 		{From: "gemini-3-flash-preview", To: "first-target"},
 		{From: "gemini-3-flash-preview", To: "second-target"},
 	})
 
-	if got := mapper.MapModel("gemini-3-flash-preview"); got != "second-target" {
-		t.Errorf("got %q, want second-target (last-declared duplicate fallback must win)", got)
+	if got := mapper.MapModel("gemini-3-flash-preview"); got != "first-target" {
+		t.Errorf("got %q, want first-target (first-declared rule must win)", got)
 	}
 }
 
-// TestModelMapper_NonContiguousSameFromConditionalIsReachable
-// regression-tests the case where a same-From conditional rule appears
-// after a different overlapping rule. The conditional rule must still
-// be evaluated and win for matching requests; the earlier overlapping
-// rule's fallback must not be returned prematurely.
-func TestModelMapper_NonContiguousSameFromConditionalIsReachable(t *testing.T) {
+// TestModelMapper_NonContiguousSameFromFallbackWins verifies that with
+// top-to-bottom semantics, an earlier unconditional rule wins over a
+// later conditional rule even if they share the same From pattern.
+// Users must place conditional rules before the fallback.
+func TestModelMapper_NonContiguousSameFromFallbackWins(t *testing.T) {
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient("test-non-contiguous", "anthropic", []*registry.ModelInfo{
 		{ID: "early-fallback", OwnedBy: "anthropic", Type: "claude"},
@@ -400,25 +397,23 @@ func TestModelMapper_NonContiguousSameFromConditionalIsReachable(t *testing.T) {
 	defer reg.UnregisterClient("test-non-contiguous")
 
 	mapper := NewModelMapper([]config.AmpModelMapping{
-		// Group A: matches gemini-3-flash-preview, unconditional.
+		// Unconditional fallback declared first — wins for all requests.
 		{From: "^gemini-3-.*$", To: "early-fallback", Regex: true},
-		// Group B: also matches gemini-3-flash-preview, unconditional.
+		// Unrelated pattern in between.
 		{From: "^.*-flash-.*$", To: "interleaved", Regex: true},
-		// Group A again, conditional. Appended later (e.g. via PATCH).
+		// Same From, conditional, but declared after fallback — unreachable.
 		{From: "^gemini-3-.*$", To: "late-conditional", Regex: true,
 			When: &config.AmpMappingCondition{Feature: "handoff"}},
 	})
 
-	// Handoff request must reach the late conditional rule despite the
-	// interleaved unrelated unconditional in between.
+	// Even handoff goes to early-fallback because it is declared first.
 	got := mapper.MapModelCtx("gemini-3-flash-preview",
 		RequestFingerprint{ToolChoice: "create_handoff_context"})
-	if got != "late-conditional" {
-		t.Errorf("got %q, want late-conditional (non-contiguous same-From conditional must be reachable)", got)
+	if got != "early-fallback" {
+		t.Errorf("got %q, want early-fallback (first matching rule wins top-to-bottom)", got)
 	}
-	// Non-handoff still falls back to the earliest declared group.
 	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "early-fallback" {
-		t.Errorf("got %q, want early-fallback (earliest declared group's fallback)", got)
+		t.Errorf("got %q, want early-fallback", got)
 	}
 }
 
@@ -503,10 +498,10 @@ func TestModelMapper_RegexOrderRespectedAcrossOverlappingPatterns(t *testing.T) 
 	}
 }
 
-// TestModelMapper_RegexConditionalWinsWithinSameGroup verifies that a
-// conditional rule still wins over an unconditional rule sharing the
-// same regex pattern (within-group conditional-wins semantics).
-func TestModelMapper_RegexConditionalWinsWithinSameGroup(t *testing.T) {
+// TestModelMapper_RegexConditionalAfterFallbackIsUnreachable verifies
+// that with top-to-bottom semantics, a regex conditional rule declared
+// after an unconditional rule sharing the same pattern is unreachable.
+func TestModelMapper_RegexConditionalAfterFallbackIsUnreachable(t *testing.T) {
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient("test-regex-group", "anthropic", []*registry.ModelInfo{
 		{ID: "conditional-target", OwnedBy: "anthropic", Type: "claude"},
@@ -520,21 +515,20 @@ func TestModelMapper_RegexConditionalWinsWithinSameGroup(t *testing.T) {
 			When: &config.AmpMappingCondition{Feature: "handoff"}},
 	})
 
+	// Fallback is first, so it wins even for handoff requests.
 	if got := mapper.MapModelCtx("gemini-3-flash-preview",
-		RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "conditional-target" {
-		t.Errorf("got %q, want conditional-target (same-pattern conditional must win)", got)
+		RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "fallback-target" {
+		t.Errorf("got %q, want fallback-target (first rule wins)", got)
 	}
 	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "fallback-target" {
-		t.Errorf("got %q, want fallback-target (no condition match)", got)
+		t.Errorf("got %q, want fallback-target", got)
 	}
 }
 
-// TestModelMapper_RegexCaseVariantSharesGroup verifies that two regex
-// rules whose From patterns differ only by letter case share the same
-// group (since UpdateMappings compiles them case-insensitively). A
-// later same-pattern conditional must remain reachable behind an
-// earlier case-variant fallback.
-func TestModelMapper_RegexCaseVariantSharesGroup(t *testing.T) {
+// TestModelMapper_RegexCaseVariantLinearOrder verifies that two regex
+// rules whose From patterns differ only by letter case are both valid
+// rules. With top-to-bottom semantics, the first matching rule wins.
+func TestModelMapper_RegexCaseVariantLinearOrder(t *testing.T) {
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient("test-regex-case", "anthropic", []*registry.ModelInfo{
 		{ID: "case-conditional-target", OwnedBy: "anthropic", Type: "claude"},
@@ -548,9 +542,10 @@ func TestModelMapper_RegexCaseVariantSharesGroup(t *testing.T) {
 			When: &config.AmpMappingCondition{Feature: "handoff"}},
 	})
 
+	// First rule (unconditional) wins for all requests since it is declared first.
 	if got := mapper.MapModelCtx("gemini-3-flash-preview",
-		RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "case-conditional-target" {
-		t.Errorf("got %q, want case-conditional-target (case-variant regex must share group)", got)
+		RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "case-fallback-target" {
+		t.Errorf("got %q, want case-fallback-target (first rule wins)", got)
 	}
 	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "case-fallback-target" {
 		t.Errorf("got %q, want case-fallback-target", got)
@@ -559,13 +554,8 @@ func TestModelMapper_RegexCaseVariantSharesGroup(t *testing.T) {
 
 // TestModelMapper_EmptyWhenTreatedAsUnconditional verifies that a
 // mapping with `When: &AmpMappingCondition{}` (all fields empty) is
-// classified as unconditional, mirroring `When: nil`. Otherwise it
-// would be evaluated in the conditional bucket and silently shadow
-// other unconditional rules sharing the same From, since
-// ConditionMatches always returns true for an all-empty condition.
-//
-// Among unconditional duplicates the last declaration wins, matching
-// the pre-existing map[from]to semantics.
+// treated as unconditional, same as `When: nil`. With top-to-bottom
+// semantics, the first declared rule wins.
 func TestModelMapper_EmptyWhenTreatedAsUnconditional(t *testing.T) {
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient("test-empty-when", "openai", []*registry.ModelInfo{
@@ -579,17 +569,12 @@ func TestModelMapper_EmptyWhenTreatedAsUnconditional(t *testing.T) {
 		{From: "gemini-3-flash-preview", To: "gpt-second", When: &config.AmpMappingCondition{}},
 	})
 
-	// Both calls must hit the second rule because the empty-When rule
-	// is treated as unconditional and last-declared duplicate wins.
-	// Without the empty-When guard, the second rule would land in the
-	// conditional bucket and would also beat the first rule (because
-	// ConditionMatches returns true for an empty condition), so this
-	// test still detects regressions of the empty-When classification.
-	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "gpt-second" {
-		t.Errorf("got %q, want gpt-second (last duplicate fallback wins, no fingerprint)", got)
+	// First rule wins for both calls.
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "gpt-first" {
+		t.Errorf("got %q, want gpt-first (first rule wins, no fingerprint)", got)
 	}
-	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "gpt-second" {
-		t.Errorf("got %q, want gpt-second (last duplicate fallback wins, with fingerprint)", got)
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "gpt-first" {
+		t.Errorf("got %q, want gpt-first (first rule wins, with fingerprint)", got)
 	}
 }
 
@@ -639,10 +624,10 @@ func TestModelMapper_MapModelCtx_ConditionalOnlyNoFallback(t *testing.T) {
 	}
 }
 
-// TestModelMapper_MapModelCtx_ConditionalWinsRegardlessOfOrder verifies the
-// documented "conditional wins" semantics hold even when the unconditional
-// fallback appears before the conditional rule in config.
-func TestModelMapper_MapModelCtx_ConditionalWinsRegardlessOfOrder(t *testing.T) {
+// TestModelMapper_MapModelCtx_ConditionalMustBeDeclaredFirst verifies that
+// with top-to-bottom semantics, a conditional rule must be declared before
+// the fallback to take effect. When fallback is first, it always wins.
+func TestModelMapper_MapModelCtx_ConditionalMustBeDeclaredFirst(t *testing.T) {
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient("test-cond3", "openai", []*registry.ModelInfo{
 		{ID: "gpt-handoff", OwnedBy: "openai", Type: "openai"},
@@ -650,14 +635,14 @@ func TestModelMapper_MapModelCtx_ConditionalWinsRegardlessOfOrder(t *testing.T) 
 	})
 	defer reg.UnregisterClient("test-cond3")
 
-	// Fallback FIRST, conditional SECOND
+	// Fallback FIRST, conditional SECOND — fallback always wins.
 	mapper := NewModelMapper([]config.AmpModelMapping{
 		{From: "gemini-3-flash-preview", To: "gpt-default"},
 		{From: "gemini-3-flash-preview", To: "gpt-handoff", When: &config.AmpMappingCondition{Feature: "handoff"}},
 	})
 
-	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "gpt-handoff" {
-		t.Errorf("handoff (fallback-before-conditional): got %q want gpt-handoff", got)
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "gpt-default" {
+		t.Errorf("handoff (fallback-before-conditional): got %q want gpt-default (first rule wins)", got)
 	}
 	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "gpt-default" {
 		t.Errorf("default: got %q want gpt-default", got)

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -154,6 +154,21 @@ func TestExtractFingerprint_Painter(t *testing.T) {
 	}
 }
 
+// TestExtractFingerprint_ReviewMain captures the `amp review` main
+// analysis prompt (gemini-3.1-pro-preview). Folded into the same
+// "review" feature alias as the summary call so users can route the
+// whole review feature with one rule.
+func TestExtractFingerprint_ReviewMain(t *testing.T) {
+	body := []byte(`{
+		"contents":[{"role":"user","parts":[{"text":"diff..."}]}],
+		"systemInstruction":{"parts":[{"text":"You are an expert senior engineer with deep knowledge of software engineering best practices, security, performance, and maintainability."}]}
+	}`)
+	fp := ExtractFingerprint(body)
+	if got := fp.Feature(); got != "review" {
+		t.Fatalf("Feature = %q, want review", got)
+	}
+}
+
 // TestExtractFingerprint_Librarian uses the real Anthropic payload
 // captured from the Amp librarian tool (claude-sonnet-4-6).
 func TestExtractFingerprint_Librarian(t *testing.T) {
@@ -173,10 +188,13 @@ func TestExtractFingerprint_Librarian(t *testing.T) {
 func TestExtractFingerprint_SystemPrefixCustom(t *testing.T) {
 	body := []byte(`{
 		"contents":[{"role":"user","parts":[{"text":"hi"}]}],
-		"systemInstruction":{"parts":[{"text":"You are an expert senior engineer with deep knowledge of software engineering best practices."}]}
+		"systemInstruction":{"parts":[{"text":"You are Agg Man, Amp's platform control-plane assistant."}]}
 	}`)
 	fp := ExtractFingerprint(body)
-	cond := &config.AmpMappingCondition{SystemPrefix: "you are an expert senior engineer"}
+	if got := fp.Feature(); got != "" {
+		t.Fatalf("Feature = %q, want empty (unrecognized)", got)
+	}
+	cond := &config.AmpMappingCondition{SystemPrefix: "you are agg man"}
 	if !ConditionMatches(cond, fp) {
 		t.Fatalf("expected SystemPrefix to match")
 	}

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -329,6 +329,43 @@ func TestConditionMatches(t *testing.T) {
 	}
 }
 
+// TestModelMapper_NonContiguousSameFromConditionalIsReachable
+// regression-tests the case where a same-From conditional rule appears
+// after a different overlapping rule. The conditional rule must still
+// be evaluated and win for matching requests; the earlier overlapping
+// rule's fallback must not be returned prematurely.
+func TestModelMapper_NonContiguousSameFromConditionalIsReachable(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-non-contiguous", "anthropic", []*registry.ModelInfo{
+		{ID: "early-fallback", OwnedBy: "anthropic", Type: "claude"},
+		{ID: "interleaved", OwnedBy: "anthropic", Type: "claude"},
+		{ID: "late-conditional", OwnedBy: "anthropic", Type: "claude"},
+	})
+	defer reg.UnregisterClient("test-non-contiguous")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		// Group A: matches gemini-3-flash-preview, unconditional.
+		{From: "^gemini-3-.*$", To: "early-fallback", Regex: true},
+		// Group B: also matches gemini-3-flash-preview, unconditional.
+		{From: "^.*-flash-.*$", To: "interleaved", Regex: true},
+		// Group A again, conditional. Appended later (e.g. via PATCH).
+		{From: "^gemini-3-.*$", To: "late-conditional", Regex: true,
+			When: &config.AmpMappingCondition{Feature: "handoff"}},
+	})
+
+	// Handoff request must reach the late conditional rule despite the
+	// interleaved unrelated unconditional in between.
+	got := mapper.MapModelCtx("gemini-3-flash-preview",
+		RequestFingerprint{ToolChoice: "create_handoff_context"})
+	if got != "late-conditional" {
+		t.Errorf("got %q, want late-conditional (non-contiguous same-From conditional must be reachable)", got)
+	}
+	// Non-handoff still falls back to the earliest declared group.
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "early-fallback" {
+		t.Errorf("got %q, want early-fallback (earliest declared group's fallback)", got)
+	}
+}
+
 // TestModelMapper_ConditionalUnavailableFallsThroughToFallback verifies
 // that when a conditional rule's `to` model has no local providers, the
 // mapper continues scanning and returns the same-From unconditional

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -517,6 +517,37 @@ func TestModelMapper_RegexCaseVariantSharesGroup(t *testing.T) {
 	}
 }
 
+// TestModelMapper_EmptyWhenTreatedAsUnconditional verifies that a
+// mapping with `When: &AmpMappingCondition{}` (all fields empty) is
+// classified as unconditional, mirroring `When: nil`. Otherwise it
+// would be evaluated in the conditional bucket and silently shadow
+// other unconditional rules sharing the same From, since
+// ConditionMatches always returns true for an all-empty condition.
+func TestModelMapper_EmptyWhenTreatedAsUnconditional(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-empty-when", "openai", []*registry.ModelInfo{
+		{ID: "gpt-first", OwnedBy: "openai", Type: "openai"},
+		{ID: "gpt-second", OwnedBy: "openai", Type: "openai"},
+	})
+	defer reg.UnregisterClient("test-empty-when")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "gpt-first"},
+		{From: "gemini-3-flash-preview", To: "gpt-second", When: &config.AmpMappingCondition{}},
+	})
+
+	// Both calls must hit the first declared rule because the second
+	// rule is effectively unconditional too. Without this guard, the
+	// second rule would jump into the conditional bucket, beat the
+	// first rule's fallback, and reroute every request.
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "gpt-first" {
+		t.Errorf("got %q, want gpt-first (no fingerprint)", got)
+	}
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "gpt-first" {
+		t.Errorf("got %q, want gpt-first (with fingerprint)", got)
+	}
+}
+
 func TestModelMapper_MapModelCtx_ConditionalThenFallback(t *testing.T) {
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient("test-cond", "openai", []*registry.ModelInfo{

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -329,6 +329,63 @@ func TestConditionMatches(t *testing.T) {
 	}
 }
 
+// TestModelMapper_RegexOrderRespectedAcrossOverlappingPatterns verifies
+// that when two regex rules with different From patterns both match the
+// same model, the earlier rule's unconditional target wins over the
+// later rule, regardless of conditional rules attached to the later
+// pattern. Cross-group declaration order must be preserved.
+func TestModelMapper_RegexOrderRespectedAcrossOverlappingPatterns(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-regex-order", "anthropic", []*registry.ModelInfo{
+		{ID: "early-target", OwnedBy: "anthropic", Type: "claude"},
+		{ID: "late-handoff-target", OwnedBy: "anthropic", Type: "claude"},
+	})
+	defer reg.UnregisterClient("test-regex-order")
+
+	// Two distinct regex patterns that both match "gemini-3-flash-preview".
+	// Earlier rule is unconditional; later rule has a handoff condition.
+	// Since the earlier group's fallback is committed at the group
+	// transition, the later conditional rule must NOT steal a handoff
+	// request that already had a perfectly good earlier match.
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{From: "^gemini-3-.*$", To: "early-target", Regex: true},
+		{From: "^.*-flash-.*$", To: "late-handoff-target", Regex: true,
+			When: &config.AmpMappingCondition{Feature: "handoff"}},
+	})
+
+	got := mapper.MapModelCtx("gemini-3-flash-preview",
+		RequestFingerprint{ToolChoice: "create_handoff_context"})
+	if got != "early-target" {
+		t.Errorf("got %q, want early-target (declaration order must win across overlapping patterns)", got)
+	}
+}
+
+// TestModelMapper_RegexConditionalWinsWithinSameGroup verifies that a
+// conditional rule still wins over an unconditional rule sharing the
+// same regex pattern (within-group conditional-wins semantics).
+func TestModelMapper_RegexConditionalWinsWithinSameGroup(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-regex-group", "anthropic", []*registry.ModelInfo{
+		{ID: "conditional-target", OwnedBy: "anthropic", Type: "claude"},
+		{ID: "fallback-target", OwnedBy: "anthropic", Type: "claude"},
+	})
+	defer reg.UnregisterClient("test-regex-group")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{From: "^gemini-3-.*$", To: "fallback-target", Regex: true},
+		{From: "^gemini-3-.*$", To: "conditional-target", Regex: true,
+			When: &config.AmpMappingCondition{Feature: "handoff"}},
+	})
+
+	if got := mapper.MapModelCtx("gemini-3-flash-preview",
+		RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "conditional-target" {
+		t.Errorf("got %q, want conditional-target (same-pattern conditional must win)", got)
+	}
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "fallback-target" {
+		t.Errorf("got %q, want fallback-target (no condition match)", got)
+	}
+}
+
 func TestModelMapper_MapModelCtx_ConditionalThenFallback(t *testing.T) {
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient("test-cond", "openai", []*registry.ModelInfo{

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -71,6 +71,23 @@ func TestExtractFingerprint_Empty(t *testing.T) {
 	}
 }
 
+// TestExtractFingerprint_ChatMessagesSystemRole verifies that
+// extractSystemText reads the system/developer entry from messages[]
+// for OpenAI-Chat-style payloads (groq, kimi, openrouter, fireworks
+// compat providers, etc.) when no top-level `system` field is set.
+func TestExtractFingerprint_ChatMessagesSystemRole(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-5.4",
+		"messages":[
+			{"role":"system","content":"You are the Oracle - an expert AI advisor with advanced reasoning capabilities."},
+			{"role":"user","content":"hello"}
+		]
+	}`)
+	if got := ExtractFingerprint(body).Feature(); got != "oracle" {
+		t.Fatalf("Feature = %q, want oracle (chat messages[] system entry must be parsed)", got)
+	}
+}
+
 // TestExtractFingerprint_OracleArrayInstructions verifies that an Oracle
 // request using array-form `instructions` (instead of a plain string)
 // still has its system text extracted and feature detection works.
@@ -345,6 +362,29 @@ func TestConditionMatches(t *testing.T) {
 	}
 }
 
+// TestModelMapper_DuplicateExactFallbackLastWins regression-tests the
+// pre-existing semantic where a later duplicate unconditional exact
+// mapping overrides an earlier one. The original implementation used
+// map[from]to (last write wins); preserving that on the grouped path
+// avoids silently re-routing requests after upgrade.
+func TestModelMapper_DuplicateExactFallbackLastWins(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-dup-last", "openai", []*registry.ModelInfo{
+		{ID: "first-target", OwnedBy: "openai", Type: "openai"},
+		{ID: "second-target", OwnedBy: "openai", Type: "openai"},
+	})
+	defer reg.UnregisterClient("test-dup-last")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "first-target"},
+		{From: "gemini-3-flash-preview", To: "second-target"},
+	})
+
+	if got := mapper.MapModel("gemini-3-flash-preview"); got != "second-target" {
+		t.Errorf("got %q, want second-target (last-declared duplicate fallback must win)", got)
+	}
+}
+
 // TestModelMapper_NonContiguousSameFromConditionalIsReachable
 // regression-tests the case where a same-From conditional rule appears
 // after a different overlapping rule. The conditional rule must still
@@ -523,6 +563,9 @@ func TestModelMapper_RegexCaseVariantSharesGroup(t *testing.T) {
 // would be evaluated in the conditional bucket and silently shadow
 // other unconditional rules sharing the same From, since
 // ConditionMatches always returns true for an all-empty condition.
+//
+// Among unconditional duplicates the last declaration wins, matching
+// the pre-existing map[from]to semantics.
 func TestModelMapper_EmptyWhenTreatedAsUnconditional(t *testing.T) {
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient("test-empty-when", "openai", []*registry.ModelInfo{
@@ -536,15 +579,17 @@ func TestModelMapper_EmptyWhenTreatedAsUnconditional(t *testing.T) {
 		{From: "gemini-3-flash-preview", To: "gpt-second", When: &config.AmpMappingCondition{}},
 	})
 
-	// Both calls must hit the first declared rule because the second
-	// rule is effectively unconditional too. Without this guard, the
-	// second rule would jump into the conditional bucket, beat the
-	// first rule's fallback, and reroute every request.
-	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "gpt-first" {
-		t.Errorf("got %q, want gpt-first (no fingerprint)", got)
+	// Both calls must hit the second rule because the empty-When rule
+	// is treated as unconditional and last-declared duplicate wins.
+	// Without the empty-When guard, the second rule would land in the
+	// conditional bucket and would also beat the first rule (because
+	// ConditionMatches returns true for an empty condition), so this
+	// test still detects regressions of the empty-When classification.
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{}); got != "gpt-second" {
+		t.Errorf("got %q, want gpt-second (last duplicate fallback wins, no fingerprint)", got)
 	}
-	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "gpt-first" {
-		t.Errorf("got %q, want gpt-first (with fingerprint)", got)
+	if got := mapper.MapModelCtx("gemini-3-flash-preview", RequestFingerprint{ToolChoice: "create_handoff_context"}); got != "gpt-second" {
+		t.Errorf("got %q, want gpt-second (last duplicate fallback wins, with fingerprint)", got)
 	}
 }
 

--- a/internal/api/modules/amp/fingerprint_test.go
+++ b/internal/api/modules/amp/fingerprint_test.go
@@ -329,6 +329,56 @@ func TestConditionMatches(t *testing.T) {
 	}
 }
 
+// TestModelMapper_ConditionalUnavailableFallsThroughToFallback verifies
+// that when a conditional rule's `to` model has no local providers, the
+// mapper continues scanning and returns the same-From unconditional
+// fallback, rather than silently giving up and returning "".
+func TestModelMapper_ConditionalUnavailableFallsThroughToFallback(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	// Register only the fallback target. The conditional target is
+	// intentionally NOT registered so it has no providers.
+	reg.RegisterClient("test-cond-unavail", "openai", []*registry.ModelInfo{
+		{ID: "gpt-fallback", OwnedBy: "openai", Type: "openai"},
+	})
+	defer reg.UnregisterClient("test-cond-unavail")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{From: "gemini-3-flash-preview", To: "gpt-handoff-missing",
+			When: &config.AmpMappingCondition{Feature: "handoff"}},
+		{From: "gemini-3-flash-preview", To: "gpt-fallback"},
+	})
+
+	got := mapper.MapModelCtx("gemini-3-flash-preview",
+		RequestFingerprint{ToolChoice: "create_handoff_context"})
+	if got != "gpt-fallback" {
+		t.Errorf("got %q, want gpt-fallback (conditional target unavailable must fall through)", got)
+	}
+}
+
+// TestModelMapper_RegexConditionalUnavailableFallsThroughToOverlapping
+// verifies the same fall-through behavior across overlapping regex
+// patterns: when an earlier conditional regex's target is unavailable,
+// the next matching regex (or unconditional fallback) is used instead.
+func TestModelMapper_RegexConditionalUnavailableFallsThroughToOverlapping(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-regex-unavail", "anthropic", []*registry.ModelInfo{
+		{ID: "late-fallback", OwnedBy: "anthropic", Type: "claude"},
+	})
+	defer reg.UnregisterClient("test-regex-unavail")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{From: "^gemini-3-.*$", To: "missing-conditional", Regex: true,
+			When: &config.AmpMappingCondition{Feature: "handoff"}},
+		{From: "^.*-flash-.*$", To: "late-fallback", Regex: true},
+	})
+
+	got := mapper.MapModelCtx("gemini-3-flash-preview",
+		RequestFingerprint{ToolChoice: "create_handoff_context"})
+	if got != "late-fallback" {
+		t.Errorf("got %q, want late-fallback (unavailable conditional must not block later overlapping rule)", got)
+	}
+}
+
 // TestModelMapper_RegexOrderRespectedAcrossOverlappingPatterns verifies
 // that when two regex rules with different From patterns both match the
 // same model, the earlier rule's unconditional target wins over the

--- a/internal/api/modules/amp/model_mapping.go
+++ b/internal/api/modules/amp/model_mapping.go
@@ -32,12 +32,19 @@ type ModelMapper interface {
 
 // DefaultModelMapper implements ModelMapper with thread-safe mapping storage.
 //
-// Mappings are stored in declaration order so that conditional rules ("When")
-// can be evaluated first and an unconditional rule for the same From acts as
-// a fallback. Lookups iterate the slice in order.
+// Lookup order:
+//  1. exact rules (in declaration order)
+//  2. regex rules (in declaration order)
+//
+// Within each pass, conditional rules ("When") are evaluated first; the
+// first matching unconditional rule for the same From is remembered and
+// used as a fallback when no conditional rule matches. This guarantees the
+// conditional-wins semantics regardless of the order users write them in
+// configuration.
 type DefaultModelMapper struct {
-	mu    sync.RWMutex
-	rules []mappingRule
+	mu     sync.RWMutex
+	exacts []mappingRule
+	regexs []mappingRule
 }
 
 // mappingRule is a normalized form of a single AmpModelMapping entry.
@@ -63,7 +70,8 @@ func (m *DefaultModelMapper) MapModel(requestedModel string) string {
 
 // MapModelCtx checks if a mapping exists for the requested model and if the
 // target model has available local providers. Conditional rules (When) are
-// evaluated against fp; rules with a non-matching condition are skipped.
+// evaluated against fp; an unconditional fallback for the same From is used
+// when no conditional rule matches.
 //
 // If the requested model contains a thinking suffix (e.g., "g25p(8192)"),
 // the suffix is preserved in the returned model name (e.g., "gemini-2.5-pro(8192)").
@@ -74,33 +82,18 @@ func (m *DefaultModelMapper) MapModelCtx(requestedModel string, fp RequestFinger
 		return ""
 	}
 
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	// Extract thinking suffix from requested model using ParseSuffix
 	requestResult := thinking.ParseSuffix(requestedModel)
 	baseModel := requestResult.ModelName
 	normalizedBase := strings.ToLower(strings.TrimSpace(baseModel))
 
-	targetModel := ""
-	for _, r := range m.rules {
-		if r.exactFrom != "" {
-			if r.exactFrom != normalizedBase {
-				continue
-			}
-		} else if r.re != nil {
-			if !r.re.MatchString(baseModel) {
-				continue
-			}
-		} else {
-			continue
-		}
-		if !ConditionMatches(r.when, fp) {
-			continue
-		}
-		targetModel = r.to
-		break
+	m.mu.RLock()
+	targetModel := selectTarget(m.exacts, baseModel, normalizedBase, fp, false)
+	if targetModel == "" {
+		targetModel = selectTarget(m.regexs, baseModel, normalizedBase, fp, true)
 	}
+	m.mu.RUnlock()
+
 	if targetModel == "" {
 		return ""
 	}
@@ -125,16 +118,44 @@ func (m *DefaultModelMapper) MapModelCtx(requestedModel string, fp RequestFinger
 	return targetModel
 }
 
+// selectTarget scans rules of one class (exact or regex) and returns the
+// best target model name. Conditional rules win; the first matching
+// unconditional rule is remembered as a fallback. Returns "" if nothing
+// matches.
+func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp RequestFingerprint, isRegex bool) string {
+	fallback := ""
+	for _, r := range rules {
+		if isRegex {
+			if r.re == nil || !r.re.MatchString(baseModel) {
+				continue
+			}
+		} else {
+			if r.exactFrom == "" || r.exactFrom != normalizedBase {
+				continue
+			}
+		}
+		if r.when == nil {
+			if fallback == "" {
+				fallback = r.to
+			}
+			continue
+		}
+		if ConditionMatches(r.when, fp) {
+			return r.to
+		}
+	}
+	return fallback
+}
+
 // UpdateMappings refreshes the mapping configuration from config.
 // This is called during initialization and on config hot-reload.
 func (m *DefaultModelMapper) UpdateMappings(mappings []config.AmpModelMapping) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.rules = make([]mappingRule, 0, len(mappings))
+	m.exacts = m.exacts[:0]
+	m.regexs = m.regexs[:0]
 
-	exact := 0
-	regex := 0
 	conditional := 0
 	for _, mapping := range mappings {
 		from := strings.TrimSpace(mapping.From)
@@ -144,7 +165,14 @@ func (m *DefaultModelMapper) UpdateMappings(mappings []config.AmpModelMapping) {
 			continue
 		}
 
-		rule := mappingRule{to: to, when: mapping.When}
+		// Deep-copy When so the mapper does not share state with the
+		// caller's config object.
+		var when *config.AmpMappingCondition
+		if mapping.When != nil {
+			c := *mapping.When
+			when = &c
+		}
+		rule := mappingRule{to: to, when: when}
 
 		if mapping.Regex {
 			pattern := "(?i)" + from
@@ -154,40 +182,39 @@ func (m *DefaultModelMapper) UpdateMappings(mappings []config.AmpModelMapping) {
 				continue
 			}
 			rule.re = re
-			regex++
-			log.Debugf("amp model regex mapping registered: /%s/ -> %s (when=%v)", from, to, mapping.When)
+			m.regexs = append(m.regexs, rule)
+			log.Debugf("amp model regex mapping registered: /%s/ -> %s (when=%+v)", from, to, when)
 		} else {
 			rule.exactFrom = strings.ToLower(from)
-			exact++
-			log.Debugf("amp model mapping registered: %s -> %s (when=%v)", from, to, mapping.When)
+			m.exacts = append(m.exacts, rule)
+			log.Debugf("amp model mapping registered: %s -> %s (when=%+v)", from, to, when)
 		}
-		if mapping.When != nil {
+		if when != nil {
 			conditional++
 		}
-		m.rules = append(m.rules, rule)
 	}
 
-	if exact > 0 {
-		log.Infof("amp model mapping: loaded %d mapping(s)", exact)
+	if n := len(m.exacts); n > 0 {
+		log.Infof("amp model mapping: loaded %d mapping(s)", n)
 	}
-	if regex > 0 {
-		log.Infof("amp model mapping: loaded %d regex mapping(s)", regex)
+	if n := len(m.regexs); n > 0 {
+		log.Infof("amp model mapping: loaded %d regex mapping(s)", n)
 	}
 	if conditional > 0 {
 		log.Infof("amp model mapping: %d mapping(s) are feature-conditional", conditional)
 	}
 }
 
-// GetMappings returns a snapshot of current exact mappings (for debugging/status).
-// Conditional rules and regex rules are not included; they can be inspected via
-// configuration.
+// GetMappings returns a snapshot of current unconditional exact mappings
+// (for debugging/status). Conditional and regex rules are excluded; they
+// can be inspected via configuration.
 func (m *DefaultModelMapper) GetMappings() map[string]string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	result := make(map[string]string)
-	for _, r := range m.rules {
-		if r.exactFrom == "" || r.when != nil {
+	for _, r := range m.exacts {
+		if r.when != nil {
 			continue
 		}
 		// First wins; do not overwrite existing entries.

--- a/internal/api/modules/amp/model_mapping.go
+++ b/internal/api/modules/amp/model_mapping.go
@@ -22,12 +22,9 @@ type ModelMapper interface {
 	// Equivalent to MapModelCtx with an empty fingerprint.
 	MapModel(requestedModel string) string
 
-	// MapModelCtx is the feature-aware variant. Selection follows the
-	// grouped semantics documented on selectTarget: exact groups before
-	// regex groups; within a group, the first conditional rule (in
-	// declaration order) whose When matches and whose target is
-	// available wins, otherwise the first available unconditional
-	// fallback in the same group is used.
+	// MapModelCtx is the feature-aware variant. Rules are scanned in
+	// declaration order (exact before regex); the first matching rule
+	// whose condition is satisfied and whose target is available wins.
 	MapModelCtx(requestedModel string, fp RequestFingerprint) string
 
 	// UpdateMappings refreshes the mapping configuration (for hot-reload).
@@ -37,17 +34,13 @@ type ModelMapper interface {
 // DefaultModelMapper implements ModelMapper with thread-safe mapping storage.
 //
 // Selection order (see selectTarget for the full algorithm):
-//  1. exact rules
-//  2. regex rules
+//  1. exact rules (in declaration order)
+//  2. regex rules (in declaration order)
 //
-// Within each pass, matching rules are bucketed by their normalized
-// From key into groups (in declaration order of each group's first
-// matching rule). Groups are then evaluated in order: a group's first
-// conditional rule whose When matches and whose target has registered
-// providers wins; otherwise the first available unconditional rule in
-// that group is used as fallback. Across groups, an earlier group's
-// available fallback is returned before any later group's conditional
-// rule is considered.
+// Within each pass, rules are scanned top-to-bottom. The first rule
+// whose From matches, whose When condition is satisfied, and whose
+// target has available providers wins. Users must place conditional
+// rules before their unconditional fallback.
 type DefaultModelMapper struct {
 	mu     sync.RWMutex
 	exacts []mappingRule
@@ -133,85 +126,29 @@ func hasProviders(targetModel string) bool {
 	return len(util.GetProviderName(res.ModelName)) > 0
 }
 
-// selectTarget scans rules of one class (exact or regex) and returns the
-// best target model name with the following semantics:
-//
-//   - Rules are grouped by their normalized From key. A group's
-//     "declaration order" is the position of its first matching rule
-//     in the input slice.
-//   - Within one group, the first conditional rule (in declaration
-//     order) whose When matches the fingerprint and whose target is
-//     reported available wins. This holds regardless of where the
-//     conditional and unconditional rules are interleaved (so a
-//     same-key conditional appended later, e.g. via PATCH, is still
-//     reachable even if rules from another From appear in between).
-//   - If no conditional rule wins, the group's fallback is the first
-//     unconditional rule in declaration order whose target is
-//     available.
-//   - Across groups, the earliest-declared group is tried first: if
-//     its conditional matches, use that; otherwise if it has an
-//     available unconditional fallback, use that; otherwise move on
-//     to the next group in declaration order.
-//   - A rule whose `to` model has no local providers (per `available`)
-//     is skipped during both conditional matching and fallback
-//     selection.
+// selectTarget scans rules of one class (exact or regex) in declaration
+// order and returns the first matching target. A rule matches when:
+//  1. Its From matches the requested model (exact or regex).
+//  2. Its When condition is satisfied by the fingerprint (or is nil/empty).
+//  3. Its target model has available local providers.
 //
 // Returns "" if no rule produces an available target.
 func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp RequestFingerprint, isRegex bool, available func(string) bool) string {
-	type group struct {
-		key         string
-		conditional []mappingRule // ordered as declared, only matching this baseModel
-		fallback    string        // first available unconditional `to`
-	}
-	groups := make([]*group, 0)
-	groupIdx := make(map[string]int)
 	for _, r := range rules {
-		var key string
 		if isRegex {
 			if r.re == nil || !r.re.MatchString(baseModel) {
 				continue
 			}
-			// Regex patterns are compiled case-insensitively (UpdateMappings
-			// prefixes "(?i)"), so two rules differing only by letter case
-			// match the same inputs and must share a group. Lower-case the
-			// pattern string when grouping so case-variant From values do
-			// not split into separate groups and hide a same-From
-			// conditional behind an earlier fallback.
-			key = strings.ToLower(r.re.String())
 		} else {
 			if r.exactFrom == "" || r.exactFrom != normalizedBase {
 				continue
 			}
-			key = r.exactFrom
 		}
-		idx, ok := groupIdx[key]
-		if !ok {
-			groups = append(groups, &group{key: key})
-			idx = len(groups) - 1
-			groupIdx[key] = idx
-		}
-		g := groups[idx]
-		if IsConditionEffectivelyEmpty(r.when) {
-			// Last-declared duplicate fallback wins, matching the
-			// pre-existing map[from]to semantics where the last
-			// duplicate exact mapping replaced earlier ones. The
-			// group's order in `groups` is still its first appearance,
-			// so cross-group declaration order is unchanged.
-			if available(r.to) {
-				g.fallback = r.to
-			}
+		if !IsConditionEffectivelyEmpty(r.when) && !ConditionMatches(r.when, fp) {
 			continue
 		}
-		g.conditional = append(g.conditional, r)
-	}
-	for _, g := range groups {
-		for _, r := range g.conditional {
-			if ConditionMatches(r.when, fp) && available(r.to) {
-				return r.to
-			}
-		}
-		if g.fallback != "" {
-			return g.fallback
+		if available(r.to) {
+			return r.to
 		}
 	}
 	return ""

--- a/internal/api/modules/amp/model_mapping.go
+++ b/internal/api/modules/amp/model_mapping.go
@@ -22,8 +22,12 @@ type ModelMapper interface {
 	// Equivalent to MapModelCtx with an empty fingerprint.
 	MapModel(requestedModel string) string
 
-	// MapModelCtx is the feature-aware variant. Conditional mappings (When)
-	// are evaluated against fp; the first matching rule wins.
+	// MapModelCtx is the feature-aware variant. Selection follows the
+	// grouped semantics documented on selectTarget: exact groups before
+	// regex groups; within a group, the first conditional rule (in
+	// declaration order) whose When matches and whose target is
+	// available wins, otherwise the first available unconditional
+	// fallback in the same group is used.
 	MapModelCtx(requestedModel string, fp RequestFingerprint) string
 
 	// UpdateMappings refreshes the mapping configuration (for hot-reload).
@@ -32,15 +36,18 @@ type ModelMapper interface {
 
 // DefaultModelMapper implements ModelMapper with thread-safe mapping storage.
 //
-// Lookup order:
-//  1. exact rules (in declaration order)
-//  2. regex rules (in declaration order)
+// Selection order (see selectTarget for the full algorithm):
+//  1. exact rules
+//  2. regex rules
 //
-// Within each pass, conditional rules ("When") are evaluated first; the
-// first matching unconditional rule for the same From is remembered and
-// used as a fallback when no conditional rule matches. This guarantees the
-// conditional-wins semantics regardless of the order users write them in
-// configuration.
+// Within each pass, matching rules are bucketed by their normalized
+// From key into groups (in declaration order of each group's first
+// matching rule). Groups are then evaluated in order: a group's first
+// conditional rule whose When matches and whose target has registered
+// providers wins; otherwise the first available unconditional rule in
+// that group is used as fallback. Across groups, an earlier group's
+// available fallback is returned before any later group's conditional
+// rule is considered.
 type DefaultModelMapper struct {
 	mu     sync.RWMutex
 	exacts []mappingRule
@@ -63,7 +70,9 @@ func NewModelMapper(mappings []config.AmpModelMapping) *DefaultModelMapper {
 }
 
 // MapModel is a convenience wrapper for callers that have no fingerprint.
-// Conditional rules are skipped.
+// Equivalent to MapModelCtx with an empty fingerprint, so conditions
+// requiring a non-empty Feature/ToolChoice/UserSuffix/SystemPrefix
+// will not match (rules with a nil When still apply normally).
 func (m *DefaultModelMapper) MapModel(requestedModel string) string {
 	return m.MapModelCtx(requestedModel, RequestFingerprint{})
 }
@@ -130,16 +139,22 @@ func hasProviders(targetModel string) bool {
 //   - Rules are grouped by their normalized From key. A group's
 //     "declaration order" is the position of its first matching rule
 //     in the input slice.
-//   - Within one group, conditional rules win over the unconditional
-//     fallback regardless of where each is declared (so a same-key
-//     conditional appended later, e.g. via PATCH, is still reachable
-//     even if rules from another From appear in between).
+//   - Within one group, the first conditional rule (in declaration
+//     order) whose When matches the fingerprint and whose target is
+//     reported available wins. This holds regardless of where the
+//     conditional and unconditional rules are interleaved (so a
+//     same-key conditional appended later, e.g. via PATCH, is still
+//     reachable even if rules from another From appear in between).
+//   - If no conditional rule wins, the group's fallback is the first
+//     unconditional rule in declaration order whose target is
+//     available.
 //   - Across groups, the earliest-declared group is tried first: if
 //     its conditional matches, use that; otherwise if it has an
-//     unconditional fallback, use that; otherwise move on to the next
-//     group in declaration order.
+//     available unconditional fallback, use that; otherwise move on
+//     to the next group in declaration order.
 //   - A rule whose `to` model has no local providers (per `available`)
-//     is skipped.
+//     is skipped during both conditional matching and fallback
+//     selection.
 //
 // Returns "" if no rule produces an available target.
 func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp RequestFingerprint, isRegex bool, available func(string) bool) string {

--- a/internal/api/modules/amp/model_mapping.go
+++ b/internal/api/modules/amp/model_mapping.go
@@ -88,9 +88,9 @@ func (m *DefaultModelMapper) MapModelCtx(requestedModel string, fp RequestFinger
 	normalizedBase := strings.ToLower(strings.TrimSpace(baseModel))
 
 	m.mu.RLock()
-	targetModel := selectTarget(m.exacts, baseModel, normalizedBase, fp, false)
+	targetModel := selectTarget(m.exacts, baseModel, normalizedBase, fp, false, hasProviders)
 	if targetModel == "" {
-		targetModel = selectTarget(m.regexs, baseModel, normalizedBase, fp, true)
+		targetModel = selectTarget(m.regexs, baseModel, normalizedBase, fp, true, hasProviders)
 	}
 	m.mu.RUnlock()
 
@@ -98,15 +98,9 @@ func (m *DefaultModelMapper) MapModelCtx(requestedModel string, fp RequestFinger
 		return ""
 	}
 
-	// Check if target model already has a thinking suffix (config priority)
+	// Target was already validated by selectTarget; ParseSuffix again
+	// only to decide on suffix-merge behavior below.
 	targetResult := thinking.ParseSuffix(targetModel)
-
-	// Verify target model has available providers (use base model for lookup)
-	providers := util.GetProviderName(targetResult.ModelName)
-	if len(providers) == 0 {
-		log.Debugf("amp model mapping: target model %s has no available providers, skipping mapping", targetModel)
-		return ""
-	}
 
 	// Suffix handling: config suffix takes priority, otherwise preserve user suffix
 	if targetResult.HasSuffix {
@@ -118,6 +112,18 @@ func (m *DefaultModelMapper) MapModelCtx(requestedModel string, fp RequestFinger
 	return targetModel
 }
 
+// hasProviders reports whether a target model (possibly with a thinking
+// suffix) has any registered local providers. Used by selectTarget to
+// skip rules whose target is unavailable so that fallback rules can
+// still apply.
+func hasProviders(targetModel string) bool {
+	if targetModel == "" {
+		return false
+	}
+	res := thinking.ParseSuffix(targetModel)
+	return len(util.GetProviderName(res.ModelName)) > 0
+}
+
 // selectTarget scans rules of one class (exact or regex) and returns the
 // best target model name. Within a contiguous group of rules sharing the
 // same From pattern, conditional rules win and the first unconditional is
@@ -126,7 +132,12 @@ func (m *DefaultModelMapper) MapModelCtx(requestedModel string, fp RequestFinger
 // later conditional from the same group matched), it wins over any
 // later group's matches. This avoids letting a later regex rule with a
 // different From pattern silently override an earlier matching rule.
-func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp RequestFingerprint, isRegex bool) string {
+//
+// `available` is called for every candidate target. If a matching rule's
+// target is unavailable locally, the scan continues so that an
+// alternative rule (typically the same-From unconditional fallback, or a
+// later overlapping pattern) can still produce a valid target.
+func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp RequestFingerprint, isRegex bool, available func(string) bool) string {
 	var (
 		groupKey      string
 		groupHas      bool
@@ -156,12 +167,12 @@ func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp Requ
 		groupKey = key
 		groupHas = true
 		if r.when == nil {
-			if groupFallback == "" {
+			if groupFallback == "" && available(r.to) {
 				groupFallback = r.to
 			}
 			continue
 		}
-		if ConditionMatches(r.when, fp) {
+		if ConditionMatches(r.when, fp) && available(r.to) {
 			return r.to
 		}
 	}

--- a/internal/api/modules/amp/model_mapping.go
+++ b/internal/api/modules/amp/model_mapping.go
@@ -192,7 +192,12 @@ func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp Requ
 		}
 		g := groups[idx]
 		if IsConditionEffectivelyEmpty(r.when) {
-			if g.fallback == "" && available(r.to) {
+			// Last-declared duplicate fallback wins, matching the
+			// pre-existing map[from]to semantics where the last
+			// duplicate exact mapping replaced earlier ones. The
+			// group's order in `groups` is still its first appearance,
+			// so cross-group declaration order is unchanged.
+			if available(r.to) {
 				g.fallback = r.to
 			}
 			continue

--- a/internal/api/modules/amp/model_mapping.go
+++ b/internal/api/modules/amp/model_mapping.go
@@ -125,24 +125,31 @@ func hasProviders(targetModel string) bool {
 }
 
 // selectTarget scans rules of one class (exact or regex) and returns the
-// best target model name. Within a contiguous group of rules sharing the
-// same From pattern, conditional rules win and the first unconditional is
-// remembered as that group's fallback. Cross-group declaration order is
-// respected: as soon as one group's fallback is locked in (because no
-// later conditional from the same group matched), it wins over any
-// later group's matches. This avoids letting a later regex rule with a
-// different From pattern silently override an earlier matching rule.
+// best target model name with the following semantics:
 //
-// `available` is called for every candidate target. If a matching rule's
-// target is unavailable locally, the scan continues so that an
-// alternative rule (typically the same-From unconditional fallback, or a
-// later overlapping pattern) can still produce a valid target.
+//   - Rules are grouped by their normalized From key. A group's
+//     "declaration order" is the position of its first matching rule
+//     in the input slice.
+//   - Within one group, conditional rules win over the unconditional
+//     fallback regardless of where each is declared (so a same-key
+//     conditional appended later, e.g. via PATCH, is still reachable
+//     even if rules from another From appear in between).
+//   - Across groups, the earliest-declared group is tried first: if
+//     its conditional matches, use that; otherwise if it has an
+//     unconditional fallback, use that; otherwise move on to the next
+//     group in declaration order.
+//   - A rule whose `to` model has no local providers (per `available`)
+//     is skipped.
+//
+// Returns "" if no rule produces an available target.
 func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp RequestFingerprint, isRegex bool, available func(string) bool) string {
-	var (
-		groupKey      string
-		groupHas      bool
-		groupFallback string
-	)
+	type group struct {
+		key         string
+		conditional []mappingRule // ordered as declared, only matching this baseModel
+		fallback    string        // first available unconditional `to`
+	}
+	groups := make([]*group, 0)
+	groupIdx := make(map[string]int)
 	for _, r := range rules {
 		var key string
 		if isRegex {
@@ -156,27 +163,32 @@ func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp Requ
 			}
 			key = r.exactFrom
 		}
-		// Group transition: commit the previous group's fallback if any.
-		if groupHas && key != groupKey {
-			if groupFallback != "" {
-				return groupFallback
-			}
-			groupHas = false
-			groupFallback = ""
+		idx, ok := groupIdx[key]
+		if !ok {
+			groups = append(groups, &group{key: key})
+			idx = len(groups) - 1
+			groupIdx[key] = idx
 		}
-		groupKey = key
-		groupHas = true
+		g := groups[idx]
 		if r.when == nil {
-			if groupFallback == "" && available(r.to) {
-				groupFallback = r.to
+			if g.fallback == "" && available(r.to) {
+				g.fallback = r.to
 			}
 			continue
 		}
-		if ConditionMatches(r.when, fp) && available(r.to) {
-			return r.to
+		g.conditional = append(g.conditional, r)
+	}
+	for _, g := range groups {
+		for _, r := range g.conditional {
+			if ConditionMatches(r.when, fp) && available(r.to) {
+				return r.to
+			}
+		}
+		if g.fallback != "" {
+			return g.fallback
 		}
 	}
-	return groupFallback
+	return ""
 }
 
 // UpdateMappings refreshes the mapping configuration from config.

--- a/internal/api/modules/amp/model_mapping.go
+++ b/internal/api/modules/amp/model_mapping.go
@@ -119,24 +119,45 @@ func (m *DefaultModelMapper) MapModelCtx(requestedModel string, fp RequestFinger
 }
 
 // selectTarget scans rules of one class (exact or regex) and returns the
-// best target model name. Conditional rules win; the first matching
-// unconditional rule is remembered as a fallback. Returns "" if nothing
-// matches.
+// best target model name. Within a contiguous group of rules sharing the
+// same From pattern, conditional rules win and the first unconditional is
+// remembered as that group's fallback. Cross-group declaration order is
+// respected: as soon as one group's fallback is locked in (because no
+// later conditional from the same group matched), it wins over any
+// later group's matches. This avoids letting a later regex rule with a
+// different From pattern silently override an earlier matching rule.
 func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp RequestFingerprint, isRegex bool) string {
-	fallback := ""
+	var (
+		groupKey      string
+		groupHas      bool
+		groupFallback string
+	)
 	for _, r := range rules {
+		var key string
 		if isRegex {
 			if r.re == nil || !r.re.MatchString(baseModel) {
 				continue
 			}
+			key = r.re.String()
 		} else {
 			if r.exactFrom == "" || r.exactFrom != normalizedBase {
 				continue
 			}
+			key = r.exactFrom
 		}
+		// Group transition: commit the previous group's fallback if any.
+		if groupHas && key != groupKey {
+			if groupFallback != "" {
+				return groupFallback
+			}
+			groupHas = false
+			groupFallback = ""
+		}
+		groupKey = key
+		groupHas = true
 		if r.when == nil {
-			if fallback == "" {
-				fallback = r.to
+			if groupFallback == "" {
+				groupFallback = r.to
 			}
 			continue
 		}
@@ -144,7 +165,7 @@ func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp Requ
 			return r.to
 		}
 	}
-	return fallback
+	return groupFallback
 }
 
 // UpdateMappings refreshes the mapping configuration from config.

--- a/internal/api/modules/amp/model_mapping.go
+++ b/internal/api/modules/amp/model_mapping.go
@@ -156,7 +156,13 @@ func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp Requ
 			if r.re == nil || !r.re.MatchString(baseModel) {
 				continue
 			}
-			key = r.re.String()
+			// Regex patterns are compiled case-insensitively (UpdateMappings
+			// prefixes "(?i)"), so two rules differing only by letter case
+			// match the same inputs and must share a group. Lower-case the
+			// pattern string when grouping so case-variant From values do
+			// not split into separate groups and hide a same-From
+			// conditional behind an earlier fallback.
+			key = strings.ToLower(r.re.String())
 		} else {
 			if r.exactFrom == "" || r.exactFrom != normalizedBase {
 				continue

--- a/internal/api/modules/amp/model_mapping.go
+++ b/internal/api/modules/amp/model_mapping.go
@@ -191,7 +191,7 @@ func selectTarget(rules []mappingRule, baseModel, normalizedBase string, fp Requ
 			groupIdx[key] = idx
 		}
 		g := groups[idx]
-		if r.when == nil {
+		if IsConditionEffectivelyEmpty(r.when) {
 			if g.fallback == "" && available(r.to) {
 				g.fallback = r.to
 			}

--- a/internal/api/modules/amp/model_mapping.go
+++ b/internal/api/modules/amp/model_mapping.go
@@ -19,38 +19,57 @@ import (
 type ModelMapper interface {
 	// MapModel returns the target model name if a mapping exists and the target
 	// model has available providers. Returns empty string if no mapping applies.
+	// Equivalent to MapModelCtx with an empty fingerprint.
 	MapModel(requestedModel string) string
+
+	// MapModelCtx is the feature-aware variant. Conditional mappings (When)
+	// are evaluated against fp; the first matching rule wins.
+	MapModelCtx(requestedModel string, fp RequestFingerprint) string
 
 	// UpdateMappings refreshes the mapping configuration (for hot-reload).
 	UpdateMappings(mappings []config.AmpModelMapping)
 }
 
 // DefaultModelMapper implements ModelMapper with thread-safe mapping storage.
+//
+// Mappings are stored in declaration order so that conditional rules ("When")
+// can be evaluated first and an unconditional rule for the same From acts as
+// a fallback. Lookups iterate the slice in order.
 type DefaultModelMapper struct {
-	mu       sync.RWMutex
-	mappings map[string]string // exact: from -> to (normalized lowercase keys)
-	regexps  []regexMapping    // regex rules evaluated in order
+	mu    sync.RWMutex
+	rules []mappingRule
+}
+
+// mappingRule is a normalized form of a single AmpModelMapping entry.
+type mappingRule struct {
+	exactFrom string                      // lower-cased exact from, "" if regex
+	re        *regexp.Regexp              // compiled regex, nil if exact
+	to        string                      // raw target (may include thinking suffix)
+	when      *config.AmpMappingCondition // optional condition
 }
 
 // NewModelMapper creates a new model mapper with the given initial mappings.
 func NewModelMapper(mappings []config.AmpModelMapping) *DefaultModelMapper {
-	m := &DefaultModelMapper{
-		mappings: make(map[string]string),
-		regexps:  nil,
-	}
+	m := &DefaultModelMapper{}
 	m.UpdateMappings(mappings)
 	return m
 }
 
-// MapModel checks if a mapping exists for the requested model and if the
-// target model has available local providers. Returns the mapped model name
-// or empty string if no valid mapping exists.
+// MapModel is a convenience wrapper for callers that have no fingerprint.
+// Conditional rules are skipped.
+func (m *DefaultModelMapper) MapModel(requestedModel string) string {
+	return m.MapModelCtx(requestedModel, RequestFingerprint{})
+}
+
+// MapModelCtx checks if a mapping exists for the requested model and if the
+// target model has available local providers. Conditional rules (When) are
+// evaluated against fp; rules with a non-matching condition are skipped.
 //
 // If the requested model contains a thinking suffix (e.g., "g25p(8192)"),
 // the suffix is preserved in the returned model name (e.g., "gemini-2.5-pro(8192)").
 // However, if the mapping target already contains a suffix, the config suffix
 // takes priority over the user's suffix.
-func (m *DefaultModelMapper) MapModel(requestedModel string) string {
+func (m *DefaultModelMapper) MapModelCtx(requestedModel string, fp RequestFingerprint) string {
 	if requestedModel == "" {
 		return ""
 	}
@@ -61,25 +80,29 @@ func (m *DefaultModelMapper) MapModel(requestedModel string) string {
 	// Extract thinking suffix from requested model using ParseSuffix
 	requestResult := thinking.ParseSuffix(requestedModel)
 	baseModel := requestResult.ModelName
-
-	// Normalize the base model for lookup (case-insensitive)
 	normalizedBase := strings.ToLower(strings.TrimSpace(baseModel))
 
-	// Check for direct mapping using base model name
-	targetModel, exists := m.mappings[normalizedBase]
-	if !exists {
-		// Try regex mappings in order using base model only
-		// (suffix is handled separately via ParseSuffix)
-		for _, rm := range m.regexps {
-			if rm.re.MatchString(baseModel) {
-				targetModel = rm.to
-				exists = true
-				break
+	targetModel := ""
+	for _, r := range m.rules {
+		if r.exactFrom != "" {
+			if r.exactFrom != normalizedBase {
+				continue
 			}
+		} else if r.re != nil {
+			if !r.re.MatchString(baseModel) {
+				continue
+			}
+		} else {
+			continue
 		}
-		if !exists {
-			return ""
+		if !ConditionMatches(r.when, fp) {
+			continue
 		}
+		targetModel = r.to
+		break
+	}
+	if targetModel == "" {
+		return ""
 	}
 
 	// Check if target model already has a thinking suffix (config priority)
@@ -94,17 +117,11 @@ func (m *DefaultModelMapper) MapModel(requestedModel string) string {
 
 	// Suffix handling: config suffix takes priority, otherwise preserve user suffix
 	if targetResult.HasSuffix {
-		// Config's "to" already contains a suffix - use it as-is (config priority)
 		return targetModel
 	}
-
-	// Preserve user's thinking suffix on the mapped model
-	// (skip empty suffixes to avoid returning "model()")
 	if requestResult.HasSuffix && requestResult.RawSuffix != "" {
 		return targetModel + "(" + requestResult.RawSuffix + ")"
 	}
-
-	// Note: Detailed routing log is handled by logAmpRouting in fallback_handlers.go
 	return targetModel
 }
 
@@ -114,58 +131,69 @@ func (m *DefaultModelMapper) UpdateMappings(mappings []config.AmpModelMapping) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Clear and rebuild mappings
-	m.mappings = make(map[string]string, len(mappings))
-	m.regexps = make([]regexMapping, 0, len(mappings))
+	m.rules = make([]mappingRule, 0, len(mappings))
 
+	exact := 0
+	regex := 0
+	conditional := 0
 	for _, mapping := range mappings {
 		from := strings.TrimSpace(mapping.From)
 		to := strings.TrimSpace(mapping.To)
-
 		if from == "" || to == "" {
 			log.Warnf("amp model mapping: skipping invalid mapping (from=%q, to=%q)", from, to)
 			continue
 		}
 
+		rule := mappingRule{to: to, when: mapping.When}
+
 		if mapping.Regex {
-			// Compile case-insensitive regex; wrap with (?i) to match behavior of exact lookups
 			pattern := "(?i)" + from
 			re, err := regexp.Compile(pattern)
 			if err != nil {
 				log.Warnf("amp model mapping: invalid regex %q: %v", from, err)
 				continue
 			}
-			m.regexps = append(m.regexps, regexMapping{re: re, to: to})
-			log.Debugf("amp model regex mapping registered: /%s/ -> %s", from, to)
+			rule.re = re
+			regex++
+			log.Debugf("amp model regex mapping registered: /%s/ -> %s (when=%v)", from, to, mapping.When)
 		} else {
-			// Store with normalized lowercase key for case-insensitive lookup
-			normalizedFrom := strings.ToLower(from)
-			m.mappings[normalizedFrom] = to
-			log.Debugf("amp model mapping registered: %s -> %s", from, to)
+			rule.exactFrom = strings.ToLower(from)
+			exact++
+			log.Debugf("amp model mapping registered: %s -> %s (when=%v)", from, to, mapping.When)
 		}
+		if mapping.When != nil {
+			conditional++
+		}
+		m.rules = append(m.rules, rule)
 	}
 
-	if len(m.mappings) > 0 {
-		log.Infof("amp model mapping: loaded %d mapping(s)", len(m.mappings))
+	if exact > 0 {
+		log.Infof("amp model mapping: loaded %d mapping(s)", exact)
 	}
-	if n := len(m.regexps); n > 0 {
-		log.Infof("amp model mapping: loaded %d regex mapping(s)", n)
+	if regex > 0 {
+		log.Infof("amp model mapping: loaded %d regex mapping(s)", regex)
+	}
+	if conditional > 0 {
+		log.Infof("amp model mapping: %d mapping(s) are feature-conditional", conditional)
 	}
 }
 
-// GetMappings returns a copy of current mappings (for debugging/status).
+// GetMappings returns a snapshot of current exact mappings (for debugging/status).
+// Conditional rules and regex rules are not included; they can be inspected via
+// configuration.
 func (m *DefaultModelMapper) GetMappings() map[string]string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make(map[string]string, len(m.mappings))
-	for k, v := range m.mappings {
-		result[k] = v
+	result := make(map[string]string)
+	for _, r := range m.rules {
+		if r.exactFrom == "" || r.when != nil {
+			continue
+		}
+		// First wins; do not overwrite existing entries.
+		if _, ok := result[r.exactFrom]; !ok {
+			result[r.exactFrom] = r.to
+		}
 	}
 	return result
-}
-
-type regexMapping struct {
-	re *regexp.Regexp
-	to string
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,8 +282,10 @@ type AmpModelMapping struct {
 // non-empty fields must match for the condition to be satisfied (logical AND).
 type AmpMappingCondition struct {
 	// Feature is a high-level semantic alias for a known Amp feature.
-	// Recognized values: "handoff", "titling", "painter", "search",
-	// "look_at" (alias of "search"), "oracle". Case-insensitive.
+	// Currently only "handoff" is inferred by the proxy. Other Amp features
+	// (search, look-at, oracle, painter, titling, ...) should be matched
+	// via ToolChoice or UserSuffix when their fingerprint is known.
+	// Case-insensitive.
 	Feature string `yaml:"feature,omitempty" json:"feature,omitempty"`
 
 	// ToolChoice matches when the request forces a specific tool by name via

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -267,6 +267,34 @@ type AmpModelMapping struct {
 	// expression for matching model names. When true, this mapping is evaluated
 	// after exact matches and in the order provided. Defaults to false (exact match).
 	Regex bool `yaml:"regex,omitempty" json:"regex,omitempty"`
+
+	// When optionally constrains this mapping to requests matching specific
+	// feature/tool fingerprints. When omitted, the mapping applies unconditionally
+	// (subject to From matching). Multiple entries with the same From may be
+	// declared with different When clauses; they are evaluated in declaration
+	// order and the first match wins. A trailing entry with no When acts as the
+	// fallback for that From value.
+	When *AmpMappingCondition `yaml:"when,omitempty" json:"when,omitempty"`
+}
+
+// AmpMappingCondition expresses a per-request fingerprint condition used to
+// scope an AmpModelMapping to a specific Amp feature/tool invocation. All
+// non-empty fields must match for the condition to be satisfied (logical AND).
+type AmpMappingCondition struct {
+	// Feature is a high-level semantic alias for a known Amp feature.
+	// Recognized values: "handoff", "titling", "painter", "search",
+	// "look_at" (alias of "search"), "oracle". Case-insensitive.
+	Feature string `yaml:"feature,omitempty" json:"feature,omitempty"`
+
+	// ToolChoice matches when the request forces a specific tool by name via
+	// the Anthropic/OpenAI/Gemini tool-choice mechanism (e.g.
+	// "create_handoff_context" for Amp handoff). Case-insensitive.
+	ToolChoice string `yaml:"tool_choice,omitempty" json:"tool_choice,omitempty"`
+
+	// UserSuffix matches when the last user message ends with the given
+	// substring (case-insensitive, after trimming trailing whitespace).
+	// Useful for distinguishing prompts that share a model.
+	UserSuffix string `yaml:"user_suffix,omitempty" json:"user_suffix,omitempty"`
 }
 
 // AmpCode groups Amp CLI integration settings including upstream routing,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -296,8 +296,6 @@ type AmpMappingCondition struct {
 	//   - "git_list"         (Amp review git-list helper; claude-haiku-4-5)
 	//   - "git_diff"         (Amp review git-diff helper; claude-haiku-4-5)
 	//   - "codereview_check" (Amp per-check review subagent; claude-haiku-4-5)
-	//   - "thread_extract"   (Amp read_thread internal extraction)
-	//   - "error_summary"    (Amp subagent error-recovery summarizer)
 	// Other Amp features should be matched via ToolChoice / UserSuffix /
 	// SystemPrefix when their fingerprint is known. Case-insensitive.
 	Feature string `yaml:"feature,omitempty" json:"feature,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,10 +282,11 @@ type AmpModelMapping struct {
 // non-empty fields must match for the condition to be satisfied (logical AND).
 type AmpMappingCondition struct {
 	// Feature is a high-level semantic alias for a known Amp feature.
-	// Currently only "handoff" is inferred by the proxy. Other Amp features
-	// (search, look-at, oracle, painter, titling, ...) should be matched
-	// via ToolChoice or UserSuffix when their fingerprint is known.
-	// Case-insensitive.
+	// Inferred via forced tool name. Currently recognized values:
+	//   - "handoff" (Amp thread handoff; tool create_handoff_context)
+	//   - "titling" (Amp thread title generation; tool set_title)
+	// Other Amp features should be matched via ToolChoice or UserSuffix
+	// when their fingerprint is known. Case-insensitive.
 	Feature string `yaml:"feature,omitempty" json:"feature,omitempty"`
 
 	// ToolChoice matches when the request forces a specific tool by name via

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,14 +284,20 @@ type AmpMappingCondition struct {
 	// Feature is a high-level semantic alias for a known Amp feature.
 	// Inferred via forced tool name or hardcoded system-prompt prefixes
 	// observed in the Amp client binary. Currently recognized values:
-	//   - "handoff"   (Amp thread handoff; tool create_handoff_context)
-	//   - "titling"   (Amp thread title generation; tool set_title)
-	//   - "oracle"    (Amp Oracle advisor; gpt-5.4 via Responses API)
-	//   - "search"    (Amp finder/search subagent; gemini-3-flash)
-	//   - "look_at"   (Amp look_at file analyzer; gemini-3-flash)
-	//   - "review"    (Amp code review summary; gemini-3-flash)
-	//   - "painter"   (Amp painter image generation; gemini-3-pro-image)
-	//   - "librarian" (Amp librarian repo-understanding subagent; claude-sonnet-4-6)
+	//   - "handoff"          (Amp thread handoff; tool create_handoff_context)
+	//   - "titling"          (Amp thread title generation; tool set_title)
+	//   - "oracle"           (Amp Oracle advisor; gpt-5.4 via Responses API)
+	//   - "search"           (Amp finder/search subagent; gemini-3-flash)
+	//   - "look_at"          (Amp look_at file analyzer; gemini-3-flash)
+	//   - "review"           (Amp code review main + summary; gemini-3.1-pro / gemini-3-flash)
+	//   - "painter"          (Amp painter image generation; gemini-3-pro-image)
+	//   - "librarian"        (Amp librarian repo-understanding subagent; claude-sonnet-4-6)
+	//   - "classifier"       (Amp internal yes/no classifier; tool answer_question, claude-haiku-4-5)
+	//   - "git_list"         (Amp review git-list helper; claude-haiku-4-5)
+	//   - "git_diff"         (Amp review git-diff helper; claude-haiku-4-5)
+	//   - "codereview_check" (Amp per-check review subagent; claude-haiku-4-5)
+	//   - "thread_extract"   (Amp read_thread internal extraction)
+	//   - "error_summary"    (Amp subagent error-recovery summarizer)
 	// Other Amp features should be matched via ToolChoice / UserSuffix /
 	// SystemPrefix when their fingerprint is known. Case-insensitive.
 	Feature string `yaml:"feature,omitempty" json:"feature,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,11 +282,17 @@ type AmpModelMapping struct {
 // non-empty fields must match for the condition to be satisfied (logical AND).
 type AmpMappingCondition struct {
 	// Feature is a high-level semantic alias for a known Amp feature.
-	// Inferred via forced tool name. Currently recognized values:
+	// Inferred via forced tool name or hardcoded system-prompt prefixes
+	// observed in the Amp client binary. Currently recognized values:
 	//   - "handoff" (Amp thread handoff; tool create_handoff_context)
 	//   - "titling" (Amp thread title generation; tool set_title)
-	// Other Amp features should be matched via ToolChoice or UserSuffix
-	// when their fingerprint is known. Case-insensitive.
+	//   - "oracle"  (Amp Oracle advisor; gpt-5.4 via Responses API)
+	//   - "search"  (Amp finder/search subagent; gemini-3-flash)
+	//   - "look_at" (Amp look_at file analyzer; gemini-3-flash)
+	//   - "review"  (Amp code review summary; gemini-3-flash)
+	//   - "painter" (Amp painter image generation; gemini-3-pro-image)
+	// Other Amp features should be matched via ToolChoice / UserSuffix /
+	// SystemPrefix when their fingerprint is known. Case-insensitive.
 	Feature string `yaml:"feature,omitempty" json:"feature,omitempty"`
 
 	// ToolChoice matches when the request forces a specific tool by name via
@@ -298,6 +304,12 @@ type AmpMappingCondition struct {
 	// substring (case-insensitive, after trimming trailing whitespace).
 	// Useful for distinguishing prompts that share a model.
 	UserSuffix string `yaml:"user_suffix,omitempty" json:"user_suffix,omitempty"`
+
+	// SystemPrefix matches when the request's system / systemInstruction
+	// prompt starts with the given substring (case-insensitive, after
+	// trimming leading whitespace). Useful for identifying Amp features
+	// whose system prompts are hardcoded in the client binary.
+	SystemPrefix string `yaml:"system_prefix,omitempty" json:"system_prefix,omitempty"`
 }
 
 // AmpCode groups Amp CLI integration settings including upstream routing,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -296,6 +296,8 @@ type AmpMappingCondition struct {
 	//   - "git_list"         (Amp review git-list helper; claude-haiku-4-5)
 	//   - "git_diff"         (Amp review git-diff helper; claude-haiku-4-5)
 	//   - "codereview_check" (Amp per-check review subagent; claude-haiku-4-5)
+	//   - "thread_extract"   (Amp read_thread internal Gemini extraction)
+	//   - "error_summary"    (Amp subagent error-recovery Gemini summarizer)
 	// Other Amp features should be matched via ToolChoice / UserSuffix /
 	// SystemPrefix when their fingerprint is known. Case-insensitive.
 	Feature string `yaml:"feature,omitempty" json:"feature,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,13 +284,14 @@ type AmpMappingCondition struct {
 	// Feature is a high-level semantic alias for a known Amp feature.
 	// Inferred via forced tool name or hardcoded system-prompt prefixes
 	// observed in the Amp client binary. Currently recognized values:
-	//   - "handoff" (Amp thread handoff; tool create_handoff_context)
-	//   - "titling" (Amp thread title generation; tool set_title)
-	//   - "oracle"  (Amp Oracle advisor; gpt-5.4 via Responses API)
-	//   - "search"  (Amp finder/search subagent; gemini-3-flash)
-	//   - "look_at" (Amp look_at file analyzer; gemini-3-flash)
-	//   - "review"  (Amp code review summary; gemini-3-flash)
-	//   - "painter" (Amp painter image generation; gemini-3-pro-image)
+	//   - "handoff"   (Amp thread handoff; tool create_handoff_context)
+	//   - "titling"   (Amp thread title generation; tool set_title)
+	//   - "oracle"    (Amp Oracle advisor; gpt-5.4 via Responses API)
+	//   - "search"    (Amp finder/search subagent; gemini-3-flash)
+	//   - "look_at"   (Amp look_at file analyzer; gemini-3-flash)
+	//   - "review"    (Amp code review summary; gemini-3-flash)
+	//   - "painter"   (Amp painter image generation; gemini-3-pro-image)
+	//   - "librarian" (Amp librarian repo-understanding subagent; claude-sonnet-4-6)
 	// Other Amp features should be matched via ToolChoice / UserSuffix /
 	// SystemPrefix when their fingerprint is known. Case-insensitive.
 	Feature string `yaml:"feature,omitempty" json:"feature,omitempty"`

--- a/internal/watcher/diff/oauth_excluded.go
+++ b/internal/watcher/diff/oauth_excluded.go
@@ -93,6 +93,8 @@ type AmpModelMappingsSummary struct {
 }
 
 // SummarizeAmpModelMappings hashes Amp model mappings for change detection.
+// Order is semantically meaningful (conditional rules win in declaration
+// order) and the optional When clause must contribute to the hash.
 func SummarizeAmpModelMappings(mappings []config.AmpModelMapping) AmpModelMappingsSummary {
 	if len(mappings) == 0 {
 		return AmpModelMappingsSummary{}
@@ -104,12 +106,22 @@ func SummarizeAmpModelMappings(mappings []config.AmpModelMapping) AmpModelMappin
 		if from == "" && to == "" {
 			continue
 		}
-		entries = append(entries, from+"->"+to)
+		regex := "0"
+		if mapping.Regex {
+			regex = "1"
+		}
+		when := ""
+		if mapping.When != nil {
+			when = strings.TrimSpace(mapping.When.Feature) + "\x1f" +
+				strings.TrimSpace(mapping.When.ToolChoice) + "\x1f" +
+				strings.TrimSpace(mapping.When.UserSuffix)
+		}
+		entries = append(entries, from+"\x1e"+to+"\x1e"+regex+"\x1e"+when)
 	}
 	if len(entries) == 0 {
 		return AmpModelMappingsSummary{}
 	}
-	sort.Strings(entries)
+	// Order matters: do not sort. Hash entries in declaration order.
 	sum := sha256.Sum256([]byte(strings.Join(entries, "|")))
 	return AmpModelMappingsSummary{
 		hash:  hex.EncodeToString(sum[:]),

--- a/internal/watcher/diff/oauth_excluded.go
+++ b/internal/watcher/diff/oauth_excluded.go
@@ -114,7 +114,8 @@ func SummarizeAmpModelMappings(mappings []config.AmpModelMapping) AmpModelMappin
 		if mapping.When != nil {
 			when = strings.TrimSpace(mapping.When.Feature) + "\x1f" +
 				strings.TrimSpace(mapping.When.ToolChoice) + "\x1f" +
-				strings.TrimSpace(mapping.When.UserSuffix)
+				strings.TrimSpace(mapping.When.UserSuffix) + "\x1f" +
+				strings.TrimSpace(mapping.When.SystemPrefix)
 		}
 		entries = append(entries, from+"\x1e"+to+"\x1e"+regex+"\x1e"+when)
 	}

--- a/internal/watcher/diff/oauth_excluded_test.go
+++ b/internal/watcher/diff/oauth_excluded_test.go
@@ -96,6 +96,21 @@ func TestSummarizeAmpModelMappings_WhenContributesToHash(t *testing.T) {
 	}
 }
 
+// TestSummarizeAmpModelMappings_SystemPrefixContributesToHash verifies that
+// two mappings differing only by When.SystemPrefix produce different hashes,
+// so the config-diff logger does not silently drop SystemPrefix-only edits.
+func TestSummarizeAmpModelMappings_SystemPrefixContributesToHash(t *testing.T) {
+	a := SummarizeAmpModelMappings([]config.AmpModelMapping{
+		{From: "x", To: "X", When: &config.AmpMappingCondition{SystemPrefix: "you are agg man"}},
+	})
+	b := SummarizeAmpModelMappings([]config.AmpModelMapping{
+		{From: "x", To: "X", When: &config.AmpMappingCondition{SystemPrefix: "you are amp"}},
+	})
+	if a.hash == b.hash {
+		t.Fatal("expected different hashes for distinct SystemPrefix")
+	}
+}
+
 // TestSummarizeAmpModelMappings_RegexContributesToHash verifies the regex
 // flag is part of the hash.
 func TestSummarizeAmpModelMappings_RegexContributesToHash(t *testing.T) {

--- a/internal/watcher/diff/oauth_excluded_test.go
+++ b/internal/watcher/diff/oauth_excluded_test.go
@@ -59,6 +59,57 @@ func TestSummarizeAmpModelMappings(t *testing.T) {
 	}
 }
 
+// TestSummarizeAmpModelMappings_OrderMatters verifies that reordering
+// produces a different hash, since order is semantically meaningful for
+// conditional rules.
+func TestSummarizeAmpModelMappings_OrderMatters(t *testing.T) {
+	a := SummarizeAmpModelMappings([]config.AmpModelMapping{
+		{From: "x", To: "X"},
+		{From: "y", To: "Y"},
+	})
+	b := SummarizeAmpModelMappings([]config.AmpModelMapping{
+		{From: "y", To: "Y"},
+		{From: "x", To: "X"},
+	})
+	if a.hash == b.hash {
+		t.Fatal("expected different hashes for reordered mappings")
+	}
+}
+
+// TestSummarizeAmpModelMappings_WhenContributesToHash verifies that
+// changing the When clause produces a different hash.
+func TestSummarizeAmpModelMappings_WhenContributesToHash(t *testing.T) {
+	a := SummarizeAmpModelMappings([]config.AmpModelMapping{
+		{From: "x", To: "X", When: &config.AmpMappingCondition{Feature: "handoff"}},
+	})
+	b := SummarizeAmpModelMappings([]config.AmpModelMapping{
+		{From: "x", To: "X", When: &config.AmpMappingCondition{ToolChoice: "create_handoff_context"}},
+	})
+	c := SummarizeAmpModelMappings([]config.AmpModelMapping{
+		{From: "x", To: "X"},
+	})
+	if a.hash == b.hash {
+		t.Fatal("expected different hashes for different When conditions")
+	}
+	if a.hash == c.hash {
+		t.Fatal("expected different hashes when adding/removing When")
+	}
+}
+
+// TestSummarizeAmpModelMappings_RegexContributesToHash verifies the regex
+// flag is part of the hash.
+func TestSummarizeAmpModelMappings_RegexContributesToHash(t *testing.T) {
+	a := SummarizeAmpModelMappings([]config.AmpModelMapping{
+		{From: "x", To: "X"},
+	})
+	b := SummarizeAmpModelMappings([]config.AmpModelMapping{
+		{From: "x", To: "X", Regex: true},
+	})
+	if a.hash == b.hash {
+		t.Fatal("expected different hashes when regex flag toggles")
+	}
+}
+
 func TestSummarizeOAuthExcludedModels_NormalizesKeys(t *testing.T) {
 	out := SummarizeOAuthExcludedModels(map[string][]string{
 		"ProvA": {"X"},


### PR DESCRIPTION
## Summary
- Add a `when:` clause on `ampcode.model-mappings` so the same upstream Amp model can route to different local providers based on the originating Amp feature (e.g. `handoff` vs `search` subagent vs `look_at`), instead of by model name alone.
- Recognize 14 canonical Amp features from request fingerprint (`tool_choice`, hardcoded system-prompt prefix, image output modality, user-message template, user-message suffix).
- Simple top-to-bottom declaration-order semantics: exact rules are scanned first, then regex rules; within each pass the first matching rule whose condition is satisfied and whose target is available wins. Users must place conditional rules before their unconditional fallback.
- Automatic fall-through when a rule's `to` model has no local providers: scan continues to the next matching rule instead of silently giving up.
- Hot-reloadable: model-mappings (including the new `When` clause) and order changes are picked up at runtime; deep-copy snapshot prevents in-place mutation from masking diffs.
- Pure additive: existing name-only mappings keep working unchanged.

## Why
Amp shares a single upstream model across multiple features. The clearest case: `gemini-3-flash-preview` is used for the handoff fallback, the finder/search subagent, look_at, and the review summary. A name-only mapping (`gemini-3-flash-preview -> X`) forces all four onto `X`, so users cannot route only handoff (or only painter, or only review) to a different provider.

Detection is grounded in the **Amp client binary** (`~/.amp/bin/amp`, Bun-bundled ELF), not captured traffic. The compiled binary is the source of truth: a call site that exists there will execute when the user triggers it, and the proxy will see it then.

## Quick example

```yaml
ampcode:
  upstream-url: https://ampcode.com
  force-model-mappings: true
  model-mappings:
    - from: gemini-3-flash-preview
      to: gpt-5.4-mini
      when:
        feature: handoff      # only Amp's create_handoff_context call

    - from: gemini-3-flash-preview
      to: gemini-2.5-flash    # everything else with this model
```

## Config syntax

```yaml
when:
  feature:       <string>   # high-level feature alias inferred by the proxy
  tool_choice:   <string>   # forced tool name in the request
  user_suffix:   <string>   # last user message ends with this substring
  system_prefix: <string>   # system / systemInstruction starts with this substring
```

All four fields are optional and AND-combined; matching is case-insensitive and trims whitespace.

Resolution rules:
1. Exact `from` rules are scanned before regex rules.
2. Within each pass, rules are evaluated top-to-bottom in declaration order. The first rule whose `from` matches, whose `when` condition is satisfied, and whose `to` model has available local providers wins.
3. Place conditional rules **before** their unconditional fallback for the same `from` — the first match wins.
4. Rules whose `to` model has no local providers are skipped, allowing fall-through to the next matching rule.

## Recognized features

| Feature alias       | Detection signal                                                                                  |
|---------------------|---------------------------------------------------------------------------------------------------|
| `handoff`           | `tool_choice = create_handoff_context`                                                            |
| `titling`           | `tool_choice = set_title`                                                                         |
| `classifier`        | `tool_choice = answer_question` or system prefix `You are a classifier that answers yes/no questions` |
| `oracle`            | system prefix `You are the Oracle - an expert AI advisor`                                         |
| `search`            | systemInstruction prefix `You are a fast, parallel code search agent`                             |
| `look_at`           | systemInstruction prefix `You are an AI assistant that analyzes files for a software engineer`   |
| `review`            | systemInstruction prefix `You are an expert software engineer reviewing code changes` (summary) **or** `You are an expert senior engineer with deep knowledge of software engineering best practices` (main analysis) |
| `painter`           | Gemini `generationConfig.responseModalities` contains `"IMAGE"`                                  |
| `librarian`         | system prefix `You are the Librarian, a specialized codebase understanding agent`                |
| `git_list`          | system prefix `You generate git commands to list changed files. Output commands wrapped in <command></command> tags.` |
| `git_diff`          | system prefix `You generate git diff commands that show the actual diff content. Output commands in xml format:` |
| `codereview_check`  | user message matches the full template `Run the "${name}" code review check.` (anchored both ends) |
| `thread_extract`    | system prefix `You are helping me extract relevant information from the mentioned thread`        |
| `error_summary`     | system prefix `You are helping summarize work done by an AI coding agent`                        |

Detection order (first match wins): `tool_choice` → image output → codereview-check user-message template → system-prompt prefix → handoff fallback by user suffix.

## Resolved upstream models per feature (from binary)

| Feature            | Provider wrapper                  | Model                                              |
|--------------------|-----------------------------------|----------------------------------------------------|
| `handoff`          | Anthropic `messages.create` (auto fallback to Gemini if input exceeds the model's `contextWindow - maxOutputTokens` or provider is `fireworks`) | current `--mode` model; fallback `gemini-3-flash-preview` |
| `titling` / `classifier` / `git_list` / `git_diff` | Anthropic `messages.create` | `claude-haiku-4-5-20251001`                        |
| `search` (finder)  | `Mo.run` → Gemini                 | `gemini-3-flash-preview`                           |
| `librarian`        | `Mo.run` → Anthropic              | `claude-sonnet-4-6`                                |
| `oracle`           | `Mo.run` → OpenAI Responses       | `gpt-5.4` (variants by `internal.oracleReasoningEffort`) |
| `review` (main)    | `Mo.run` → Gemini                 | `gemini-3.1-pro-preview`                           |
| `review` (summary) / `look_at` / `thread_extract` / `error_summary` | Gemini `generateContent` (`KW(kb,…)`) | `gemini-3-flash-preview` |
| `codereview_check` | `Mo.run` → Anthropic              | `claude-haiku-4-5-20251001`                        |
| `painter` (default)| Gemini image                      | `gemini-3-pro-image-preview`                       |
| `painter` (alt)    | OpenAI images                     | `gpt-image-2` (when `painter.model = gpt-image-2`) |

## Validation
- PASS: `gofmt -l internal/api/modules/amp/ internal/api/handlers/management/ internal/watcher/diff/ internal/config/`
- PASS: `go test ./internal/api/modules/amp/ ./internal/api/handlers/management/ ./internal/watcher/diff/ ./internal/config/`
- PASS: `go build -o test-output ./cmd/server && rm test-output`
- Tests use synthesized payloads that mirror the Amp binary's exact prompt strings and call shape for all 14 features, plus regression cases for: hot-reload snapshot deep-copy, fall-through on unavailable target, top-to-bottom ordering, and SystemPrefix participation in PATCH identity / config-diff hash.

## Notes
- `when:` is purely additive; existing name-only mappings keep working unchanged.
- Hot reload of `ampcode.model-mappings` (file edit or management API PATCH) picks up `when:` changes and order changes.
- Anything not yet recognized as a canonical `feature` (e.g. the hidden Agg control-plane mode, `gpt-image-2` painter backend) can still be matched today via `tool_choice` / `user_suffix` / `system_prefix`.

## Review fixes (after initial open)
- P1 (Codex): include `SystemPrefix` in `ampMappingKey` so management-API PATCH can distinguish two rules differing only by SystemPrefix.
- P1 (self-review): same fix in `SummarizeAmpModelMappings` (config-diff logging hash).
- P1 (Codex): when a matched rule's target is unavailable locally, continue scanning instead of returning empty so a later matching rule still wins.
- Simplification: replaced grouped/bucketed selection algorithm with a simple linear top-to-bottom scan. Users place conditional rules before their fallback (like nginx/iptables). Removed ~80 lines of grouping logic.
