### PR TITLE
fix(management): bound log API responses

### DIFF
--- a/internal/api/handlers/management/logs.go
+++ b/internal/api/handlers/management/logs.go
@@ -60,7 +60,7 @@ func (h *Handler) GetLogs(c *gin.Context) {
 		return
 	}
 
-	limit, errLimit := parseLimit(c.Query("limit"))
+	limit, limitProvided, errLimit := parseLimit(c.Query("limit"))
 	if errLimit != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid limit: %v", errLimit)})
 		return
@@ -81,7 +81,11 @@ func (h *Handler) GetLogs(c *gin.Context) {
 		return
 	}
 
-	acc := newLogAccumulator(cutoff, limit)
+	incrementalLimit := limit
+	if !limitProvided {
+		incrementalLimit = 0
+	}
+	acc := newLogAccumulator(cutoff, incrementalLimit)
 	for i := range files {
 		if !logFileMayContainAfter(files[i], cutoff) {
 			continue
@@ -473,23 +477,22 @@ func readRecentLogLines(files []string, limit int) ([]string, int, int64, error)
 	}
 	lines := make([]string, 0, limit)
 	for i := len(files) - 1; i >= 0 && len(lines) < limit; i-- {
-		fileLines := make([]string, 0, defaultLogLimit)
+		remaining := limit - len(lines)
+		fileLines := make([]string, 0, remaining)
 		if err := scanLogFile(files[i], func(line string) {
 			fileLines = append(fileLines, line)
+			if len(fileLines) > remaining {
+				copy(fileLines, fileLines[1:])
+				fileLines = fileLines[:remaining]
+			}
 		}); err != nil {
 			return nil, 0, 0, err
 		}
 		if len(fileLines) == 0 {
 			continue
 		}
-		remaining := limit - len(lines)
-		start := len(fileLines) - remaining
-		if start < 0 {
-			start = 0
-		}
-		selected := fileLines[start:]
-		combined := make([]string, 0, len(selected)+len(lines))
-		combined = append(combined, selected...)
+		combined := make([]string, 0, len(fileLines)+len(lines))
+		combined = append(combined, fileLines...)
 		combined = append(combined, lines...)
 		lines = combined
 	}
@@ -562,22 +565,22 @@ func parseCutoff(raw string) int64 {
 	return ts
 }
 
-func parseLimit(raw string) (int, error) {
+func parseLimit(raw string) (int, bool, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
-		return defaultLogLimit, nil
+		return defaultLogLimit, false, nil
 	}
 	limit, err := strconv.Atoi(value)
 	if err != nil {
-		return 0, fmt.Errorf("must be a positive integer")
+		return 0, true, fmt.Errorf("must be a positive integer")
 	}
 	if limit <= 0 {
-		return 0, fmt.Errorf("must be greater than zero")
+		return 0, true, fmt.Errorf("must be greater than zero")
 	}
 	if limit > maxLogLimit {
-		return maxLogLimit, nil
+		return maxLogLimit, true, nil
 	}
-	return limit, nil
+	return limit, true, nil
 }
 
 func parseTimestamp(line string) int64 {

--- a/internal/api/handlers/management/logs.go
+++ b/internal/api/handlers/management/logs.go
@@ -476,10 +476,14 @@ func readRecentLogLines(files []string, limit int) ([]string, int, int64, error)
 		limit = defaultLogLimit
 	}
 	lines := make([]string, 0, limit)
+	latest := int64(0)
 	for i := len(files) - 1; i >= 0 && len(lines) < limit; i-- {
 		remaining := limit - len(lines)
 		fileLines := make([]string, 0, remaining)
 		if err := scanLogFile(files[i], func(line string) {
+			if ts := parseTimestamp(line); ts > latest {
+				latest = ts
+			}
 			fileLines = append(fileLines, line)
 			if len(fileLines) > remaining {
 				copy(fileLines, fileLines[1:])
@@ -497,12 +501,6 @@ func readRecentLogLines(files []string, limit int) ([]string, int, int64, error)
 		lines = combined
 	}
 
-	latest := int64(0)
-	for _, line := range lines {
-		if ts := parseTimestamp(line); ts > latest {
-			latest = ts
-		}
-	}
 	if lines == nil {
 		lines = []string{}
 	}

--- a/internal/api/handlers/management/logs.go
+++ b/internal/api/handlers/management/logs.go
@@ -18,6 +18,8 @@ import (
 
 const (
 	defaultLogFileName      = "main.log"
+	defaultLogLimit         = 200
+	maxLogLimit             = 5000
 	logScannerInitialBuffer = 64 * 1024
 	logScannerMaxBuffer     = 8 * 1024 * 1024
 )
@@ -65,8 +67,25 @@ func (h *Handler) GetLogs(c *gin.Context) {
 	}
 
 	cutoff := parseCutoff(c.Query("after"))
+	if cutoff == 0 {
+		lines, total, latest, errRecent := readRecentLogLines(files, limit)
+		if errRecent != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to read log files: %v", errRecent)})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"lines":            lines,
+			"line-count":       total,
+			"latest-timestamp": latest,
+		})
+		return
+	}
+
 	acc := newLogAccumulator(cutoff, limit)
 	for i := range files {
+		if !logFileMayContainAfter(files[i], cutoff) {
+			continue
+		}
 		if errProcess := acc.consumeFile(files[i]); errProcess != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to read log file %s: %v", files[i], errProcess)})
 			return
@@ -419,6 +438,12 @@ func newLogAccumulator(cutoff int64, limit int) *logAccumulator {
 }
 
 func (acc *logAccumulator) consumeFile(path string) error {
+	return scanLogFile(path, func(line string) {
+		acc.addLine(line)
+	})
+}
+
+func scanLogFile(path string, visit func(string)) error {
 	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -434,12 +459,62 @@ func (acc *logAccumulator) consumeFile(path string) error {
 	buf := make([]byte, 0, logScannerInitialBuffer)
 	scanner.Buffer(buf, logScannerMaxBuffer)
 	for scanner.Scan() {
-		acc.addLine(scanner.Text())
+		visit(strings.TrimRight(scanner.Text(), "\r"))
 	}
 	if errScan := scanner.Err(); errScan != nil {
 		return errScan
 	}
 	return nil
+}
+
+func readRecentLogLines(files []string, limit int) ([]string, int, int64, error) {
+	if limit <= 0 {
+		limit = defaultLogLimit
+	}
+	lines := make([]string, 0, limit)
+	for i := len(files) - 1; i >= 0 && len(lines) < limit; i-- {
+		fileLines := make([]string, 0, defaultLogLimit)
+		if err := scanLogFile(files[i], func(line string) {
+			fileLines = append(fileLines, line)
+		}); err != nil {
+			return nil, 0, 0, err
+		}
+		if len(fileLines) == 0 {
+			continue
+		}
+		remaining := limit - len(lines)
+		start := len(fileLines) - remaining
+		if start < 0 {
+			start = 0
+		}
+		selected := fileLines[start:]
+		combined := make([]string, 0, len(selected)+len(lines))
+		combined = append(combined, selected...)
+		combined = append(combined, lines...)
+		lines = combined
+	}
+
+	latest := int64(0)
+	for _, line := range lines {
+		if ts := parseTimestamp(line); ts > latest {
+			latest = ts
+		}
+	}
+	if lines == nil {
+		lines = []string{}
+	}
+	return lines, len(lines), latest, nil
+}
+
+func logFileMayContainAfter(path string, cutoff int64) bool {
+	if cutoff <= 0 {
+		return true
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return true
+	}
+	return info.ModTime().Unix() >= cutoff
 }
 
 func (acc *logAccumulator) addLine(raw string) {
@@ -490,7 +565,7 @@ func parseCutoff(raw string) int64 {
 func parseLimit(raw string) (int, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
-		return 0, nil
+		return defaultLogLimit, nil
 	}
 	limit, err := strconv.Atoi(value)
 	if err != nil {
@@ -498,6 +573,9 @@ func parseLimit(raw string) (int, error) {
 	}
 	if limit <= 0 {
 		return 0, fmt.Errorf("must be greater than zero")
+	}
+	if limit > maxLogLimit {
+		return maxLogLimit, nil
 	}
 	return limit, nil
 }

--- a/internal/api/handlers/management/logs_test.go
+++ b/internal/api/handlers/management/logs_test.go
@@ -100,6 +100,56 @@ func TestGetLogsSkipsOldFilesForIncrementalReads(t *testing.T) {
 	}
 }
 
+func TestGetLogsKeepsFullIncrementalDeltaWhenLimitOmitted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+
+	base := time.Date(2026, 1, 2, 0, 0, 0, 0, time.Local)
+	logPath := filepath.Join(dir, defaultLogFileName)
+	writeLogFile(t, logPath, makeLogLines(base, defaultLogLimit+25, "new"))
+	modTime := base.Add(time.Hour)
+	if err := os.Chtimes(logPath, modTime, modTime); err != nil {
+		t.Fatalf("failed to set active log mtime: %v", err)
+	}
+
+	resp := performGetLogs(t, dir, fmt.Sprintf("/v0/management/logs?after=%d", base.Add(-time.Second).Unix()))
+
+	if len(resp.Lines) != defaultLogLimit+25 {
+		t.Fatalf("expected full incremental delta of %d lines, got %d", defaultLogLimit+25, len(resp.Lines))
+	}
+	if !strings.Contains(resp.Lines[0], "new-001") {
+		t.Fatalf("expected first returned line to be new-001, got %q", resp.Lines[0])
+	}
+	if !strings.Contains(resp.Lines[len(resp.Lines)-1], "new-225") {
+		t.Fatalf("expected last returned line to be new-225, got %q", resp.Lines[len(resp.Lines)-1])
+	}
+}
+
+func TestGetLogsHonorsExplicitIncrementalLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+
+	base := time.Date(2026, 1, 2, 0, 0, 0, 0, time.Local)
+	logPath := filepath.Join(dir, defaultLogFileName)
+	writeLogFile(t, logPath, makeLogLines(base, 10, "new"))
+	modTime := base.Add(time.Hour)
+	if err := os.Chtimes(logPath, modTime, modTime); err != nil {
+		t.Fatalf("failed to set active log mtime: %v", err)
+	}
+
+	resp := performGetLogs(t, dir, fmt.Sprintf("/v0/management/logs?after=%d&limit=3", base.Add(-time.Second).Unix()))
+
+	if len(resp.Lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(resp.Lines))
+	}
+	if !strings.Contains(resp.Lines[0], "new-008") {
+		t.Fatalf("expected first returned line to be new-008, got %q", resp.Lines[0])
+	}
+	if !strings.Contains(resp.Lines[len(resp.Lines)-1], "new-010") {
+		t.Fatalf("expected last returned line to be new-010, got %q", resp.Lines[len(resp.Lines)-1])
+	}
+}
+
 func TestGetLogsRejectsInvalidLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	dir := t.TempDir()

--- a/internal/api/handlers/management/logs_test.go
+++ b/internal/api/handlers/management/logs_test.go
@@ -1,0 +1,153 @@
+package management
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+type logsResponse struct {
+	Lines           []string `json:"lines"`
+	LineCount       int      `json:"line-count"`
+	LatestTimestamp int64    `json:"latest-timestamp"`
+}
+
+func TestGetLogsDefaultsToRecentLines(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+
+	oldBase := time.Date(2026, 1, 1, 0, 0, 0, 0, time.Local)
+	newBase := time.Date(2026, 1, 2, 0, 0, 0, 0, time.Local)
+	writeLogFile(t, filepath.Join(dir, "main-2026-01-01T00-00-00.log"), makeLogLines(oldBase, 10, "old"))
+	writeLogFile(t, filepath.Join(dir, defaultLogFileName), makeLogLines(newBase, 250, "new"))
+
+	resp := performGetLogs(t, dir, "/v0/management/logs")
+
+	if len(resp.Lines) != defaultLogLimit {
+		t.Fatalf("expected %d lines, got %d", defaultLogLimit, len(resp.Lines))
+	}
+	if resp.LineCount != defaultLogLimit {
+		t.Fatalf("expected line-count %d, got %d", defaultLogLimit, resp.LineCount)
+	}
+	if !strings.Contains(resp.Lines[0], "new-051") {
+		t.Fatalf("expected first returned line to be new-051, got %q", resp.Lines[0])
+	}
+	if !strings.Contains(resp.Lines[len(resp.Lines)-1], "new-250") {
+		t.Fatalf("expected last returned line to be new-250, got %q", resp.Lines[len(resp.Lines)-1])
+	}
+	wantLatest := newBase.Add(249 * time.Second).Unix()
+	if resp.LatestTimestamp != wantLatest {
+		t.Fatalf("expected latest timestamp %d, got %d", wantLatest, resp.LatestTimestamp)
+	}
+}
+
+func TestGetLogsClampsLargeLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+
+	base := time.Date(2026, 1, 2, 0, 0, 0, 0, time.Local)
+	writeLogFile(t, filepath.Join(dir, defaultLogFileName), makeLogLines(base, maxLogLimit+25, "line"))
+
+	resp := performGetLogs(t, dir, "/v0/management/logs?limit=999999")
+
+	if len(resp.Lines) != maxLogLimit {
+		t.Fatalf("expected %d lines, got %d", maxLogLimit, len(resp.Lines))
+	}
+	if !strings.Contains(resp.Lines[0], "line-026") {
+		t.Fatalf("expected first returned line to be line-026, got %q", resp.Lines[0])
+	}
+	if !strings.Contains(resp.Lines[len(resp.Lines)-1], "line-5025") {
+		t.Fatalf("expected last returned line to be line-5025, got %q", resp.Lines[len(resp.Lines)-1])
+	}
+}
+
+func TestGetLogsSkipsOldFilesForIncrementalReads(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+
+	oldPath := filepath.Join(dir, "main-2026-01-01T00-00-00.log")
+	writeLogFile(t, oldPath, []string{strings.Repeat("x", logScannerMaxBuffer+1)})
+	oldTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.Local)
+	if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
+		t.Fatalf("failed to set old log mtime: %v", err)
+	}
+
+	newBase := time.Date(2026, 1, 2, 0, 0, 0, 0, time.Local)
+	newPath := filepath.Join(dir, defaultLogFileName)
+	writeLogFile(t, newPath, makeLogLines(newBase, 3, "new"))
+	newTime := newBase.Add(time.Minute)
+	if err := os.Chtimes(newPath, newTime, newTime); err != nil {
+		t.Fatalf("failed to set active log mtime: %v", err)
+	}
+
+	cutoff := newBase.Add(-time.Second).Unix()
+	resp := performGetLogs(t, dir, fmt.Sprintf("/v0/management/logs?after=%d", cutoff))
+
+	if len(resp.Lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(resp.Lines))
+	}
+	if !strings.Contains(resp.Lines[0], "new-001") || !strings.Contains(resp.Lines[2], "new-003") {
+		t.Fatalf("unexpected lines: %#v", resp.Lines)
+	}
+}
+
+func TestGetLogsRejectsInvalidLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+	writeLogFile(t, filepath.Join(dir, defaultLogFileName), []string{"[2026-01-01 00:00:00] hello"})
+
+	h := &Handler{cfg: &config.Config{LoggingToFile: true}, logDir: dir}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/logs?limit=0", nil)
+
+	h.GetLogs(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+}
+
+func performGetLogs(t *testing.T, dir string, target string) logsResponse {
+	t.Helper()
+
+	h := &Handler{cfg: &config.Config{LoggingToFile: true}, logDir: dir}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, target, nil)
+
+	h.GetLogs(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var resp logsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return resp
+}
+
+func writeLogFile(t *testing.T, path string, lines []string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write log file %s: %v", path, err)
+	}
+}
+
+func makeLogLines(base time.Time, count int, prefix string) []string {
+	lines := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		lines = append(lines, fmt.Sprintf("[%s] [info ] %s-%03d", base.Add(time.Duration(i)*time.Second).Format("2006-01-02 15:04:05"), prefix, i+1))
+	}
+	return lines
+}

--- a/internal/api/handlers/management/logs_test.go
+++ b/internal/api/handlers/management/logs_test.go
@@ -50,6 +50,30 @@ func TestGetLogsDefaultsToRecentLines(t *testing.T) {
 	}
 }
 
+func TestGetLogsPreservesLatestTimestampWhenTailHasContinuations(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dir := t.TempDir()
+
+	base := time.Date(2026, 1, 2, 0, 0, 0, 0, time.Local)
+	lines := []string{fmt.Sprintf("[%s] [error] request failed", base.Format("2006-01-02 15:04:05"))}
+	for i := 0; i < defaultLogLimit+25; i++ {
+		lines = append(lines, fmt.Sprintf("continuation-%03d", i+1))
+	}
+	writeLogFile(t, filepath.Join(dir, defaultLogFileName), lines)
+
+	resp := performGetLogs(t, dir, "/v0/management/logs")
+
+	if len(resp.Lines) != defaultLogLimit {
+		t.Fatalf("expected %d lines, got %d", defaultLogLimit, len(resp.Lines))
+	}
+	if !strings.Contains(resp.Lines[0], "continuation-026") {
+		t.Fatalf("expected first returned line to be continuation-026, got %q", resp.Lines[0])
+	}
+	if resp.LatestTimestamp != base.Unix() {
+		t.Fatalf("expected latest timestamp %d, got %d", base.Unix(), resp.LatestTimestamp)
+	}
+}
+
 func TestGetLogsClampsLargeLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- default `/v0/management/logs` to the latest 200 lines instead of returning every log line
- clamp requested log limits to 5000 lines
- read initial log views from newest files backward and skip old rotated files for incremental reads
- add regression tests for default, clamped, incremental, and invalid limit behavior

## Tests
- `go test ./internal/api/handlers/management`
- `go test ./internal/api/...`