### PR TITLE
fix: recover image generation stream disconnects

### DIFF
--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -591,9 +591,10 @@ func (h *OpenAIAPIHandler) collectImagesFromResponses(c *gin.Context, responsesR
 	if mainModel == "" {
 		mainModel = defaultImagesMainModel
 	}
-	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, "openai-response", mainModel, responsesReq, "")
-
-	out, errMsg := collectImagesFromResponsesStream(cliCtx, dataChan, errChan, responseFormat)
+	maxAttempts := 1 + handlers.StreamingBootstrapRetries(h.Cfg)
+	out, upstreamHeaders, errMsg := collectImagesFromResponsesWithRetry(cliCtx, maxAttempts, responseFormat, func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+		return h.ExecuteStreamWithAuthManager(cliCtx, "openai-response", mainModel, responsesReq, "")
+	})
 	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)
@@ -609,8 +610,62 @@ func (h *OpenAIAPIHandler) collectImagesFromResponses(c *gin.Context, responsesR
 	cliCancel()
 }
 
+type imagesResponsesStreamStarter func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage)
+
+func collectImagesFromResponsesWithRetry(ctx context.Context, attempts int, responseFormat string, start imagesResponsesStreamStarter) ([]byte, http.Header, *interfaces.ErrorMessage) {
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var upstreamHeaders http.Header
+	for attempt := 0; attempt < attempts; attempt++ {
+		dataChan, headers, errChan := start()
+		upstreamHeaders = headers
+
+		out, errMsg := collectImagesFromResponsesStream(ctx, dataChan, errChan, responseFormat)
+		if errMsg == nil {
+			return out, upstreamHeaders, nil
+		}
+		if !isRecoverableImageStreamDisconnect(errMsg) || attempt == attempts-1 {
+			return nil, upstreamHeaders, errMsg
+		}
+	}
+
+	return nil, upstreamHeaders, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("stream disconnected before completion")}
+}
+
+func isRecoverableImageStreamDisconnect(errMsg *interfaces.ErrorMessage) bool {
+	if errMsg == nil || errMsg.Error == nil {
+		return false
+	}
+	if errMsg.StatusCode > 0 && errMsg.StatusCode < http.StatusInternalServerError {
+		return false
+	}
+	return strings.Contains(strings.ToLower(errMsg.Error.Error()), "stream disconnected before completion")
+}
+
 func collectImagesFromResponsesStream(ctx context.Context, data <-chan []byte, errs <-chan *interfaces.ErrorMessage, responseFormat string) ([]byte, *interfaces.ErrorMessage) {
 	acc := &sseFrameAccumulator{}
+	var recoveredResults []imageCallResult
+	var recoveredFirstMeta imageCallResult
+
+	appendRecoveredResult := func(result imageCallResult) {
+		if len(recoveredResults) == 0 {
+			recoveredFirstMeta = result
+		}
+		recoveredResults = append(recoveredResults, result)
+	}
+
+	buildRecoveredResponse := func() ([]byte, *interfaces.ErrorMessage) {
+		if len(recoveredResults) == 0 {
+			return nil, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("stream disconnected before completion")}
+		}
+		out, err := buildImagesAPIResponse(recoveredResults, time.Now().Unix(), nil, recoveredFirstMeta, responseFormat)
+		if err != nil {
+			return nil, &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: err}
+		}
+		return out, nil
+	}
 
 	processFrame := func(frame []byte) ([]byte, bool, *interfaces.ErrorMessage) {
 		for _, line := range bytes.Split(frame, []byte("\n")) {
@@ -629,22 +684,25 @@ func collectImagesFromResponsesStream(ctx context.Context, data <-chan []byte, e
 				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("invalid SSE data JSON")}
 			}
 
-			if gjson.GetBytes(payload, "type").String() != "response.completed" {
-				continue
+			switch gjson.GetBytes(payload, "type").String() {
+			case "response.output_item.done":
+				if result, ok := extractImageResultFromOutputItem(gjson.GetBytes(payload, "item")); ok {
+					appendRecoveredResult(result)
+				}
+			case "response.completed":
+				results, createdAt, usageRaw, firstMeta, err := extractImagesFromResponsesCompleted(payload)
+				if err != nil {
+					return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: err}
+				}
+				if len(results) == 0 {
+					return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("upstream did not return image output")}
+				}
+				out, err := buildImagesAPIResponse(results, createdAt, usageRaw, firstMeta, responseFormat)
+				if err != nil {
+					return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: err}
+				}
+				return out, true, nil
 			}
-
-			results, createdAt, usageRaw, firstMeta, err := extractImagesFromResponsesCompleted(payload)
-			if err != nil {
-				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: err}
-			}
-			if len(results) == 0 {
-				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("upstream did not return image output")}
-			}
-			out, err := buildImagesAPIResponse(results, createdAt, usageRaw, firstMeta, responseFormat)
-			if err != nil {
-				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: err}
-			}
-			return out, true, nil
 		}
 		return nil, false, nil
 	}
@@ -667,7 +725,7 @@ func collectImagesFromResponsesStream(ctx context.Context, data <-chan []byte, e
 						return out, nil
 					}
 				}
-				return nil, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("stream disconnected before completion")}
+				return buildRecoveredResponse()
 			}
 			for _, frame := range acc.AddChunk(chunk) {
 				if out, done, errMsg := processFrame(frame); errMsg != nil {
@@ -678,6 +736,24 @@ func collectImagesFromResponsesStream(ctx context.Context, data <-chan []byte, e
 			}
 		}
 	}
+}
+
+func extractImageResultFromOutputItem(item gjson.Result) (imageCallResult, bool) {
+	if item.Get("type").String() != "image_generation_call" {
+		return imageCallResult{}, false
+	}
+	res := strings.TrimSpace(item.Get("result").String())
+	if res == "" {
+		return imageCallResult{}, false
+	}
+	return imageCallResult{
+		Result:        res,
+		RevisedPrompt: strings.TrimSpace(item.Get("revised_prompt").String()),
+		OutputFormat:  strings.TrimSpace(item.Get("output_format").String()),
+		Size:          strings.TrimSpace(item.Get("size").String()),
+		Background:    strings.TrimSpace(item.Get("background").String()),
+		Quality:       strings.TrimSpace(item.Get("quality").String()),
+	}, true
 }
 
 func extractImagesFromResponsesCompleted(payload []byte) (results []imageCallResult, createdAt int64, usageRaw []byte, firstMeta imageCallResult, err error) {
@@ -693,20 +769,9 @@ func extractImagesFromResponsesCompleted(payload []byte) (results []imageCallRes
 	output := gjson.GetBytes(payload, "response.output")
 	if output.IsArray() {
 		for _, item := range output.Array() {
-			if item.Get("type").String() != "image_generation_call" {
+			entry, ok := extractImageResultFromOutputItem(item)
+			if !ok {
 				continue
-			}
-			res := strings.TrimSpace(item.Get("result").String())
-			if res == "" {
-				continue
-			}
-			entry := imageCallResult{
-				Result:        res,
-				RevisedPrompt: strings.TrimSpace(item.Get("revised_prompt").String()),
-				OutputFormat:  strings.TrimSpace(item.Get("output_format").String()),
-				Size:          strings.TrimSpace(item.Get("size").String()),
-				Background:    strings.TrimSpace(item.Get("background").String()),
-				Quality:       strings.TrimSpace(item.Get("quality").String()),
 			}
 			if len(results) == 0 {
 				firstMeta = entry

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 	"github.com/tidwall/gjson"
@@ -57,6 +59,71 @@ func TestImagesModelValidationAllowsGPTImage2WithOptionalPrefix(t *testing.T) {
 	}
 	if isSupportedImagesModel("gpt-5.4-mini") {
 		t.Fatal("expected gpt-5.4-mini to be rejected")
+	}
+}
+
+func TestCollectImagesFromResponsesStreamUsesCompletedOutputItemOnDisconnect(t *testing.T) {
+	data := make(chan []byte, 1)
+	errs := make(chan *interfaces.ErrorMessage)
+	close(errs)
+	data <- []byte(`data: {"type":"response.output_item.done","item":{"type":"image_generation_call","result":"aGVsbG8=","revised_prompt":"A concise prompt","output_format":"png","size":"1024x1024","background":"auto","quality":"high"}}` + "\n\n")
+	close(data)
+
+	out, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+	if errMsg != nil {
+		t.Fatalf("errMsg = %v, want nil", errMsg.Error)
+	}
+
+	if got := gjson.GetBytes(out, "data.0.b64_json").String(); got != "aGVsbG8=" {
+		t.Fatalf("b64_json = %q, want image result", got)
+	}
+	if got := gjson.GetBytes(out, "data.0.revised_prompt").String(); got != "A concise prompt" {
+		t.Fatalf("revised_prompt = %q, want recovered prompt", got)
+	}
+	if got := gjson.GetBytes(out, "output_format").String(); got != "png" {
+		t.Fatalf("output_format = %q, want png", got)
+	}
+	if got := gjson.GetBytes(out, "size").String(); got != "1024x1024" {
+		t.Fatalf("size = %q, want 1024x1024", got)
+	}
+	if got := gjson.GetBytes(out, "quality").String(); got != "high" {
+		t.Fatalf("quality = %q, want high", got)
+	}
+}
+
+func TestCollectImagesFromResponsesWithRetryRetriesDisconnectedStream(t *testing.T) {
+	attempts := 0
+
+	out, upstreamHeaders, errMsg := collectImagesFromResponsesWithRetry(context.Background(), 2, "b64_json", func() (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+		attempts++
+		data := make(chan []byte, 1)
+		errs := make(chan *interfaces.ErrorMessage)
+		close(errs)
+		headers := http.Header{}
+
+		if attempts == 1 {
+			headers.Set("X-Attempt", "first")
+			close(data)
+			return data, headers, errs
+		}
+
+		headers.Set("X-Attempt", "second")
+		data <- []byte(`data: {"type":"response.completed","response":{"created_at":123,"output":[{"type":"image_generation_call","result":"Zm9v","output_format":"png"}]}}` + "\n\n")
+		close(data)
+		return data, headers, errs
+	})
+
+	if errMsg != nil {
+		t.Fatalf("errMsg = %v, want nil", errMsg.Error)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if got := upstreamHeaders.Get("X-Attempt"); got != "second" {
+		t.Fatalf("upstream header = %q, want second attempt header", got)
+	}
+	if got := gjson.GetBytes(out, "data.0.b64_json").String(); got != "Zm9v" {
+		t.Fatalf("b64_json = %q, want retry result", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- recover completed image output items when upstream closes before `response.completed`
- retry recoverable image stream disconnects according to `streaming.bootstrap-retries`
- add regression tests for output-item recovery and retry behavior

## Verification
- `go test ./sdk/api/handlers/openai -count=1`
- `go build -o /tmp/cli-proxy-api-release-check ./cmd/server`

## Notes
- `go test ./... -count=1` still has unrelated existing failures in `internal/registry` (`TestCodexFreeModelsExcludeGPT55`) and `internal/runtime/executor` antigravity credits tests.