### PR TITLE
test: add server regression for /v1/responses/compact route

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -147,6 +147,24 @@ func TestManagementUsageRequiresManagementAuthAndPopsArray(t *testing.T) {
 	}
 }
 
+func TestServerRegistersResponsesCompactRoute(t *testing.T) {
+	server := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(`{"model":"test-model","stream":true}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("unexpected status code: got %d want %d; body=%s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "Streaming not supported for compact responses") {
+		t.Fatalf("response body missing compact stream rejection: %s", body)
+	}
+}
+
 func TestAmpProviderModelRoutes(t *testing.T) {
 	testCases := []struct {
 		name         string

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -148,20 +148,39 @@ func TestManagementUsageRequiresManagementAuthAndPopsArray(t *testing.T) {
 }
 
 func TestServerRegistersResponsesCompactRoute(t *testing.T) {
-	server := newTestServer(t)
-
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(`{"model":"test-model","stream":true}`))
-	req.Header.Set("Authorization", "Bearer test-key")
-	req.Header.Set("Content-Type", "application/json")
-
-	rr := httptest.NewRecorder()
-	server.engine.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("unexpected status code: got %d want %d; body=%s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	testCases := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "v1 route",
+			path: "/v1/responses/compact",
+		},
+		{
+			name: "codex alias route",
+			path: "/backend-api/codex/responses/compact",
+		},
 	}
-	if body := rr.Body.String(); !strings.Contains(body, "Streaming not supported for compact responses") {
-		t.Fatalf("response body missing compact stream rejection: %s", body)
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := newTestServer(t)
+
+			req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(`{"model":"test-model","stream":true}`))
+			req.Header.Set("Authorization", "Bearer test-key")
+			req.Header.Set("Content-Type", "application/json")
+
+			rr := httptest.NewRecorder()
+			server.engine.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("unexpected status code for %s: got %d want %d; body=%s", tc.path, rr.Code, http.StatusBadRequest, rr.Body.String())
+			}
+			if body := rr.Body.String(); !strings.Contains(body, "Streaming not supported for compact responses") {
+				t.Fatalf("response body for %s missing compact stream rejection: %s", tc.path, body)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a server-level regression test for `POST /v1/responses/compact`
- verify route wiring + handler dispatch using `stream: true` rejection path
- assert `400` with `Streaming not supported for compact responses`

## Testing
- go test ./internal/api -run TestServerRegistersResponsesCompactRoute