### PR TITLE
fix(management): preserve pinned panel release URL

### DIFF
--- a/internal/managementasset/updater.go
+++ b/internal/managementasset/updater.go
@@ -322,10 +322,11 @@ func resolveReleaseURL(repo string) string {
 			parsed.Path = parsed.Path + "/latest"
 			return parsed.String()
 		}
-		if !strings.HasSuffix(strings.ToLower(parsed.Path), "/releases/latest") {
-			parsed.Path = parsed.Path + "/releases/latest"
+		if repoPath, ok := gitHubAPIRepoPath(parsed.Path); ok {
+			parsed.Path = repoPath + "/releases/latest"
+			return parsed.String()
 		}
-		return parsed.String()
+		return defaultManagementReleaseURL
 	}
 
 	if host == "github.com" {
@@ -358,9 +359,32 @@ func isGitHubReleaseAPIURLPath(path string) bool {
 		return false
 	}
 	if len(parts) == 5 {
-		return parts[4] != ""
+		return strings.EqualFold(parts[4], "latest") || isGitHubReleaseIDPathSegment(parts[4])
 	}
 	return len(parts) == 6 && strings.EqualFold(parts[4], "tags") && parts[5] != ""
+}
+
+func gitHubAPIRepoPath(path string) (string, bool) {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) < 3 ||
+		!strings.EqualFold(parts[0], "repos") ||
+		parts[1] == "" ||
+		parts[2] == "" {
+		return "", false
+	}
+	return fmt.Sprintf("/repos/%s/%s", parts[1], parts[2]), true
+}
+
+func isGitHubReleaseIDPathSegment(segment string) bool {
+	if segment == "" {
+		return false
+	}
+	for _, char := range segment {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func fetchLatestAsset(ctx context.Context, client *http.Client, releaseURL string) (*releaseAsset, string, error) {

--- a/internal/managementasset/updater.go
+++ b/internal/managementasset/updater.go
@@ -315,6 +315,13 @@ func resolveReleaseURL(repo string) string {
 	parsed.Path = strings.TrimSuffix(parsed.Path, "/")
 
 	if host == "api.github.com" {
+		if isGitHubReleaseAPIURLPath(parsed.Path) {
+			return parsed.String()
+		}
+		if isGitHubReleasesAPIURLPath(parsed.Path) {
+			parsed.Path = parsed.Path + "/latest"
+			return parsed.String()
+		}
 		if !strings.HasSuffix(strings.ToLower(parsed.Path), "/releases/latest") {
 			parsed.Path = parsed.Path + "/releases/latest"
 		}
@@ -330,6 +337,30 @@ func resolveReleaseURL(repo string) string {
 	}
 
 	return defaultManagementReleaseURL
+}
+
+func isGitHubReleasesAPIURLPath(path string) bool {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	return len(parts) == 4 &&
+		strings.EqualFold(parts[0], "repos") &&
+		parts[1] != "" &&
+		parts[2] != "" &&
+		strings.EqualFold(parts[3], "releases")
+}
+
+func isGitHubReleaseAPIURLPath(path string) bool {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) < 5 ||
+		!strings.EqualFold(parts[0], "repos") ||
+		parts[1] == "" ||
+		parts[2] == "" ||
+		!strings.EqualFold(parts[3], "releases") {
+		return false
+	}
+	if len(parts) == 5 {
+		return parts[4] != ""
+	}
+	return len(parts) == 6 && strings.EqualFold(parts[4], "tags") && parts[5] != ""
 }
 
 func fetchLatestAsset(ctx context.Context, client *http.Client, releaseURL string) (*releaseAsset, string, error) {

--- a/internal/managementasset/updater.go
+++ b/internal/managementasset/updater.go
@@ -315,18 +315,43 @@ func resolveReleaseURL(repo string) string {
 	parsed.Path = strings.TrimSuffix(parsed.Path, "/")
 
 	if host == "api.github.com" {
-		if isGitHubReleaseAPIURLPath(parsed.Path) {
-			return parsed.String()
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		if len(parts) < 3 ||
+			!strings.EqualFold(parts[0], "repos") ||
+			parts[1] == "" ||
+			parts[2] == "" {
+			return defaultManagementReleaseURL
 		}
-		if isGitHubReleasesAPIURLPath(parsed.Path) {
-			parsed.Path = parsed.Path + "/latest"
-			return parsed.String()
-		}
-		if repoPath, ok := gitHubAPIRepoPath(parsed.Path); ok {
+
+		repoPath := fmt.Sprintf("/repos/%s/%s", parts[1], parts[2])
+		if len(parts) == 4 && strings.EqualFold(parts[3], "releases") {
 			parsed.Path = repoPath + "/releases/latest"
 			return parsed.String()
 		}
-		return defaultManagementReleaseURL
+		if len(parts) == 5 && strings.EqualFold(parts[3], "releases") {
+			isReleaseID := parts[4] != ""
+			for _, char := range parts[4] {
+				if char < '0' || char > '9' {
+					isReleaseID = false
+					break
+				}
+			}
+			if strings.EqualFold(parts[4], "latest") || isReleaseID {
+				return parsed.String()
+			}
+
+			parsed.Path = repoPath + "/releases/latest"
+			return parsed.String()
+		}
+		if len(parts) == 6 &&
+			strings.EqualFold(parts[3], "releases") &&
+			strings.EqualFold(parts[4], "tags") &&
+			parts[5] != "" {
+			return parsed.String()
+		}
+
+		parsed.Path = repoPath + "/releases/latest"
+		return parsed.String()
 	}
 
 	if host == "github.com" {
@@ -338,53 +363,6 @@ func resolveReleaseURL(repo string) string {
 	}
 
 	return defaultManagementReleaseURL
-}
-
-func isGitHubReleasesAPIURLPath(path string) bool {
-	parts := strings.Split(strings.Trim(path, "/"), "/")
-	return len(parts) == 4 &&
-		strings.EqualFold(parts[0], "repos") &&
-		parts[1] != "" &&
-		parts[2] != "" &&
-		strings.EqualFold(parts[3], "releases")
-}
-
-func isGitHubReleaseAPIURLPath(path string) bool {
-	parts := strings.Split(strings.Trim(path, "/"), "/")
-	if len(parts) < 5 ||
-		!strings.EqualFold(parts[0], "repos") ||
-		parts[1] == "" ||
-		parts[2] == "" ||
-		!strings.EqualFold(parts[3], "releases") {
-		return false
-	}
-	if len(parts) == 5 {
-		return strings.EqualFold(parts[4], "latest") || isGitHubReleaseIDPathSegment(parts[4])
-	}
-	return len(parts) == 6 && strings.EqualFold(parts[4], "tags") && parts[5] != ""
-}
-
-func gitHubAPIRepoPath(path string) (string, bool) {
-	parts := strings.Split(strings.Trim(path, "/"), "/")
-	if len(parts) < 3 ||
-		!strings.EqualFold(parts[0], "repos") ||
-		parts[1] == "" ||
-		parts[2] == "" {
-		return "", false
-	}
-	return fmt.Sprintf("/repos/%s/%s", parts[1], parts[2]), true
-}
-
-func isGitHubReleaseIDPathSegment(segment string) bool {
-	if segment == "" {
-		return false
-	}
-	for _, char := range segment {
-		if char < '0' || char > '9' {
-			return false
-		}
-	}
-	return true
 }
 
 func fetchLatestAsset(ctx context.Context, client *http.Client, releaseURL string) (*releaseAsset, string, error) {

--- a/internal/managementasset/updater_test.go
+++ b/internal/managementasset/updater_test.go
@@ -1,0 +1,65 @@
+package managementasset
+
+import "testing"
+
+func TestResolveReleaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		want string
+	}{
+		{
+			name: "empty uses default",
+			repo: "",
+			want: defaultManagementReleaseURL,
+		},
+		{
+			name: "github repository URL resolves to latest release API",
+			repo: "https://github.com/example/panel",
+			want: "https://api.github.com/repos/example/panel/releases/latest",
+		},
+		{
+			name: "github repository URL trims git suffix",
+			repo: "https://github.com/example/panel.git",
+			want: "https://api.github.com/repos/example/panel/releases/latest",
+		},
+		{
+			name: "api repository URL resolves to latest release API",
+			repo: "https://api.github.com/repos/example/panel",
+			want: "https://api.github.com/repos/example/panel/releases/latest",
+		},
+		{
+			name: "api releases URL resolves to latest release API",
+			repo: "https://api.github.com/repos/example/panel/releases",
+			want: "https://api.github.com/repos/example/panel/releases/latest",
+		},
+		{
+			name: "api latest release URL is preserved",
+			repo: "https://api.github.com/repos/example/panel/releases/latest",
+			want: "https://api.github.com/repos/example/panel/releases/latest",
+		},
+		{
+			name: "api pinned release ID URL is preserved",
+			repo: "https://api.github.com/repos/router-for-me/Cli-Proxy-API-Management-Center/releases/313351637",
+			want: "https://api.github.com/repos/router-for-me/Cli-Proxy-API-Management-Center/releases/313351637",
+		},
+		{
+			name: "api pinned release tag URL is preserved",
+			repo: "https://api.github.com/repos/example/panel/releases/tags/v1.8.0",
+			want: "https://api.github.com/repos/example/panel/releases/tags/v1.8.0",
+		},
+		{
+			name: "invalid URL uses default",
+			repo: "not a url",
+			want: defaultManagementReleaseURL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveReleaseURL(tt.repo); got != tt.want {
+				t.Fatalf("resolveReleaseURL(%q) = %q, want %q", tt.repo, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/managementasset/updater_test.go
+++ b/internal/managementasset/updater_test.go
@@ -49,6 +49,11 @@ func TestResolveReleaseURL(t *testing.T) {
 			want: "https://api.github.com/repos/example/panel/releases/tags/v1.8.0",
 		},
 		{
+			name: "api incomplete release tag URL resolves to latest release API",
+			repo: "https://api.github.com/repos/example/panel/releases/tags",
+			want: "https://api.github.com/repos/example/panel/releases/latest",
+		},
+		{
 			name: "invalid URL uses default",
 			repo: "not a url",
 			want: defaultManagementReleaseURL,


### PR DESCRIPTION
## Summary

- preserve exact GitHub release API URLs in `resolveReleaseURL`
- keep repository and releases-list URLs resolving to `releases/latest`
- add regression coverage for pinned release ID and tag URLs

Fixes #3212.

## Testing

- `go test ./internal/managementasset`
- `go build -o test-output ./cmd/server && rm test-output`

Note: `go test ./...` currently fails in unrelated existing tests under `internal/registry` and `internal/runtime/executor`.