### PR TITLE
fix(codex): retry transient capacity errors

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -553,6 +553,9 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 						pendingBootstrapData = true
 					}
 				}
+			case codexStreamControlLine(line):
+				emitTranslatedLine = false
+				pendingBootstrapData = true
 			}
 
 			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, originalPayload, body, translatedLine, &param)
@@ -1087,6 +1090,13 @@ func codexStreamBufferedEvent(eventType string) bool {
 	default:
 		return false
 	}
+}
+
+func codexStreamControlLine(line []byte) bool {
+	line = bytes.TrimSpace(line)
+	return bytes.HasPrefix(line, []byte(":")) ||
+		bytes.HasPrefix(line, []byte("id:")) ||
+		bytes.HasPrefix(line, []byte("retry:"))
 }
 
 func codexStreamStatusErr(eventData []byte) (statusErr, bool) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -40,6 +40,10 @@ var dataTag = []byte("data:")
 const (
 	codexModelCapacityRetryAfter = time.Second
 	codexMissingCompletedMessage = "stream error: stream disconnected before completion: stream closed before response.completed"
+
+	// Keep the retry-sensitive startup window small so long queued streams still
+	// flush headers and lifecycle keep-alives to downstream clients.
+	codexStreamBootstrapBufferLineLimit = 12
 )
 
 // Streamed Codex responses may emit response.output_item.done events while leaving
@@ -507,12 +511,28 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		sawTerminalEvent := false
 		var pendingEventChunks [][]byte
 		pendingBootstrapData := false
+		pendingBufferedLines := 0
+		bootstrapBuffering := true
+		flushPendingEvents := func() bool {
+			for i := range pendingEventChunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: pendingEventChunks[i]}:
+				case <-ctx.Done():
+					return false
+				}
+			}
+			pendingEventChunks = nil
+			pendingBootstrapData = false
+			pendingBufferedLines = 0
+			return true
+		}
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			translatedLine := bytes.Clone(line)
 			eventType := ""
 			emitTranslatedLine := true
+			countAsBootstrapBuffer := false
 
 			switch {
 			case bytes.HasPrefix(line, dataTag):
@@ -540,45 +560,67 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					data = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
 					translatedLine = append([]byte("data: "), data...)
 				case "response.created", "response.in_progress", "response.queued":
-					emitTranslatedLine = false
-					pendingBootstrapData = true
+					if bootstrapBuffering {
+						emitTranslatedLine = false
+						pendingBootstrapData = true
+						countAsBootstrapBuffer = true
+					}
 				case "response.incomplete", "response.failed", "response.error", "error":
 					sawTerminalEvent = true
 				}
 			case bytes.HasPrefix(line, []byte("event:")):
 				eventType = strings.TrimSpace(string(line[len("event:"):]))
 				if codexStreamBufferedEvent(eventType) {
-					emitTranslatedLine = false
-					if codexStreamBootstrapEvent(eventType) {
+					isBootstrapEvent := codexStreamBootstrapEvent(eventType)
+					if bootstrapBuffering || !isBootstrapEvent {
+						emitTranslatedLine = false
+					}
+					if bootstrapBuffering && isBootstrapEvent {
 						pendingBootstrapData = true
+						countAsBootstrapBuffer = true
 					}
 				}
 			case codexStreamControlLine(line):
-				emitTranslatedLine = false
-				pendingBootstrapData = true
+				if bootstrapBuffering {
+					emitTranslatedLine = false
+					pendingBootstrapData = true
+					countAsBootstrapBuffer = true
+				}
 			}
 
 			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, originalPayload, body, translatedLine, &param)
 			if len(bytes.TrimSpace(line)) == 0 {
 				if len(pendingEventChunks) > 0 {
 					pendingEventChunks = append(pendingEventChunks, []byte("\n\n"))
+					if bootstrapBuffering && pendingBootstrapData {
+						pendingBufferedLines++
+						if pendingBufferedLines >= codexStreamBootstrapBufferLineLimit {
+							if !flushPendingEvents() {
+								return
+							}
+							bootstrapBuffering = false
+						}
+					}
 				}
 				continue
 			}
 			if !emitTranslatedLine {
 				pendingEventChunks = append(pendingEventChunks, chunks...)
+				if countAsBootstrapBuffer {
+					pendingBufferedLines++
+					if pendingBufferedLines >= codexStreamBootstrapBufferLineLimit {
+						if !flushPendingEvents() {
+							return
+						}
+						bootstrapBuffering = false
+					}
+				}
 				continue
 			}
 			if len(pendingEventChunks) > 0 {
-				for i := range pendingEventChunks {
-					select {
-					case out <- cliproxyexecutor.StreamChunk{Payload: pendingEventChunks[i]}:
-					case <-ctx.Done():
-						return
-					}
+				if !flushPendingEvents() {
+					return
 				}
-				pendingEventChunks = nil
-				pendingBootstrapData = false
 			}
 			for i := range chunks {
 				select {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1107,10 +1107,21 @@ func codexStreamStatusErr(eventData []byte) (statusErr, bool) {
 	if isCodexModelCapacityError(errorBody) {
 		return newCodexStatusErr(http.StatusBadRequest, errorBody), true
 	}
-	if _, _, okClassified := codexStatusErrorClassification(http.StatusBadRequest, errorBody); okClassified {
-		return newCodexStatusErr(http.StatusBadRequest, errorBody), true
+	if statusCode, okClassified := codexStreamClassifiedStatus(errorBody); okClassified {
+		return newCodexStatusErr(statusCode, errorBody), true
 	}
 	return newCodexStatusErr(http.StatusRequestTimeout, errorBody), true
+}
+
+func codexStreamClassifiedStatus(errorBody []byte) (int, bool) {
+	code, errType, ok := codexStatusErrorClassification(http.StatusBadRequest, errorBody)
+	if !ok {
+		return 0, false
+	}
+	if errType == "authentication_error" || code == "auth_unavailable" {
+		return http.StatusUnauthorized, true
+	}
+	return http.StatusBadRequest, true
 }
 
 func codexStreamErrorBody(eventData []byte) ([]byte, bool) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -495,13 +495,19 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		var param any
 		outputItemsByIndex := make(map[int64][]byte)
 		var outputItemsFallback [][]byte
+		var bootstrapChunks [][]byte
+		bufferBootstrap := true
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			translatedLine := bytes.Clone(line)
+			eventType := ""
+			isEventLine := false
 
-			if bytes.HasPrefix(line, dataTag) {
+			switch {
+			case bytes.HasPrefix(line, dataTag):
 				data := bytes.TrimSpace(line[5:])
+				eventType = gjson.GetBytes(data, "type").String()
 				if errStream, ok := codexStreamStatusErr(data); ok {
 					helps.RecordAPIResponseError(ctx, e.cfg, errStream)
 					reporter.PublishFailure(ctx)
@@ -511,7 +517,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					}
 					return
 				}
-				switch gjson.GetBytes(data, "type").String() {
+				switch eventType {
 				case "response.output_item.done":
 					collectCodexOutputItemDone(data, outputItemsByIndex, &outputItemsFallback)
 				case "response.completed":
@@ -522,9 +528,37 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					data = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
 					translatedLine = append([]byte("data: "), data...)
 				}
+			case bytes.HasPrefix(line, []byte("event:")):
+				eventType = strings.TrimSpace(string(line[len("event:"):]))
+				isEventLine = true
 			}
 
 			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, originalPayload, body, translatedLine, &param)
+			if bufferBootstrap && len(bytes.TrimSpace(line)) == 0 {
+				if len(bootstrapChunks) > 0 {
+					bootstrapChunks = append(bootstrapChunks, []byte("\n\n"))
+				}
+				continue
+			}
+			if bufferBootstrap && isEventLine && codexStreamBufferedEvent(eventType) {
+				bootstrapChunks = append(bootstrapChunks, chunks...)
+				continue
+			}
+			if bufferBootstrap && !isEventLine && codexStreamBootstrapEvent(eventType) {
+				bootstrapChunks = append(bootstrapChunks, chunks...)
+				continue
+			}
+			if bufferBootstrap {
+				bufferBootstrap = false
+				for i := range bootstrapChunks {
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Payload: bootstrapChunks[i]}:
+					case <-ctx.Done():
+						return
+					}
+				}
+				bootstrapChunks = nil
+			}
 			for i := range chunks {
 				select {
 				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
@@ -989,14 +1023,38 @@ func isCodexModelCapacityError(errorBody []byte) bool {
 	return false
 }
 
-func codexStreamStatusErr(eventData []byte) (statusErr, bool) {
-	if !isCodexModelCapacityError(eventData) {
-		return statusErr{}, false
+func codexStreamBootstrapEvent(eventType string) bool {
+	switch eventType {
+	case "response.created", "response.in_progress", "response.queued":
+		return true
+	default:
+		return false
 	}
-	return newCodexStatusErr(http.StatusBadRequest, codexStreamErrorBody(eventData)), true
 }
 
-func codexStreamErrorBody(eventData []byte) []byte {
+func codexStreamBufferedEvent(eventType string) bool {
+	if codexStreamBootstrapEvent(eventType) {
+		return true
+	}
+	switch eventType {
+	case "response.failed", "response.error", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func codexStreamStatusErr(eventData []byte) (statusErr, bool) {
+	errorBody, ok := codexStreamErrorBody(eventData)
+	if !ok || !isCodexModelCapacityError(errorBody) {
+		return statusErr{}, false
+	}
+	return newCodexStatusErr(http.StatusBadRequest, errorBody), true
+}
+
+func codexStreamErrorBody(eventData []byte) ([]byte, bool) {
+	eventType := strings.TrimSpace(gjson.GetBytes(eventData, "type").String())
+	isErrorEvent := eventType == "response.failed" || eventType == "response.error" || eventType == "error"
 	candidates := []string{
 		"error",
 		"response.error",
@@ -1009,29 +1067,35 @@ func codexStreamErrorBody(eventData []byte) []byte {
 		if result.Type == gjson.JSON {
 			body := []byte(`{"error":` + result.Raw + `}`)
 			if gjson.GetBytes(body, "error.message").String() != "" {
-				return body
+				return body, true
 			}
 			continue
 		}
 		if msg := strings.TrimSpace(result.String()); msg != "" {
 			body := []byte(`{"error":{}}`)
 			body, _ = sjson.SetBytes(body, "error.message", msg)
-			return body
+			return body, true
 		}
 	}
 	messagePaths := []string{
 		"error.message",
 		"response.error.message",
-		"message",
 	}
 	for _, path := range messagePaths {
 		if msg := strings.TrimSpace(gjson.GetBytes(eventData, path).String()); msg != "" {
 			body := []byte(`{"error":{}}`)
 			body, _ = sjson.SetBytes(body, "error.message", msg)
-			return body
+			return body, true
 		}
 	}
-	return eventData
+	if isErrorEvent {
+		if msg := strings.TrimSpace(gjson.GetBytes(eventData, "message").String()); msg != "" {
+			body := []byte(`{"error":{}}`)
+			body, _ = sjson.SetBytes(body, "error.message", msg)
+			return body, true
+		}
+	}
+	return nil, false
 }
 
 func parseCodexRetryAfter(statusCode int, errorBody []byte, now time.Time) *time.Duration {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -37,7 +37,10 @@ const (
 
 var dataTag = []byte("data:")
 
-const codexModelCapacityRetryAfter = time.Second
+const (
+	codexModelCapacityRetryAfter = time.Second
+	codexMissingCompletedMessage = "stream error: stream disconnected before completion: stream closed before response.completed"
+)
 
 // Streamed Codex responses may emit response.output_item.done events while leaving
 // response.completed.response.output empty. Keep the stream path aligned with the
@@ -248,6 +251,11 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		eventData := bytes.TrimSpace(line[5:])
 		eventType := gjson.GetBytes(eventData, "type").String()
 
+		if errStream, ok := codexStreamStatusErr(eventData); ok {
+			err = errStream
+			return resp, err
+		}
+
 		if eventType == "response.output_item.done" {
 			itemResult := gjson.GetBytes(eventData, "item")
 			if !itemResult.Exists() || itemResult.Type != gjson.JSON {
@@ -299,7 +307,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 		return resp, nil
 	}
-	err = statusErr{code: 408, msg: "stream error: stream disconnected before completion: stream closed before response.completed"}
+	err = newCodexMissingCompletedErr()
 	return resp, err
 }
 
@@ -495,14 +503,16 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		var param any
 		outputItemsByIndex := make(map[int64][]byte)
 		var outputItemsFallback [][]byte
-		var bootstrapChunks [][]byte
-		bufferBootstrap := true
+		sawCompleted := false
+		sawTerminalEvent := false
+		var pendingEventChunks [][]byte
+		pendingBootstrapData := false
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			translatedLine := bytes.Clone(line)
 			eventType := ""
-			isEventLine := false
+			emitTranslatedLine := true
 
 			switch {
 			case bytes.HasPrefix(line, dataTag):
@@ -521,43 +531,51 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				case "response.output_item.done":
 					collectCodexOutputItemDone(data, outputItemsByIndex, &outputItemsFallback)
 				case "response.completed":
+					sawCompleted = true
+					sawTerminalEvent = true
 					if detail, ok := helps.ParseCodexUsage(data); ok {
 						reporter.Publish(ctx, detail)
 					}
 					publishCodexImageToolUsage(ctx, reporter, body, data)
 					data = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
 					translatedLine = append([]byte("data: "), data...)
+				case "response.created", "response.in_progress", "response.queued":
+					emitTranslatedLine = false
+					pendingBootstrapData = true
+				case "response.incomplete", "response.failed", "response.error", "error":
+					sawTerminalEvent = true
 				}
 			case bytes.HasPrefix(line, []byte("event:")):
 				eventType = strings.TrimSpace(string(line[len("event:"):]))
-				isEventLine = true
+				if codexStreamBufferedEvent(eventType) {
+					emitTranslatedLine = false
+					if codexStreamBootstrapEvent(eventType) {
+						pendingBootstrapData = true
+					}
+				}
 			}
 
 			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, originalPayload, body, translatedLine, &param)
-			if bufferBootstrap && len(bytes.TrimSpace(line)) == 0 {
-				if len(bootstrapChunks) > 0 {
-					bootstrapChunks = append(bootstrapChunks, []byte("\n\n"))
+			if len(bytes.TrimSpace(line)) == 0 {
+				if len(pendingEventChunks) > 0 {
+					pendingEventChunks = append(pendingEventChunks, []byte("\n\n"))
 				}
 				continue
 			}
-			if bufferBootstrap && isEventLine && codexStreamBufferedEvent(eventType) {
-				bootstrapChunks = append(bootstrapChunks, chunks...)
+			if !emitTranslatedLine {
+				pendingEventChunks = append(pendingEventChunks, chunks...)
 				continue
 			}
-			if bufferBootstrap && !isEventLine && codexStreamBootstrapEvent(eventType) {
-				bootstrapChunks = append(bootstrapChunks, chunks...)
-				continue
-			}
-			if bufferBootstrap {
-				bufferBootstrap = false
-				for i := range bootstrapChunks {
+			if len(pendingEventChunks) > 0 {
+				for i := range pendingEventChunks {
 					select {
-					case out <- cliproxyexecutor.StreamChunk{Payload: bootstrapChunks[i]}:
+					case out <- cliproxyexecutor.StreamChunk{Payload: pendingEventChunks[i]}:
 					case <-ctx.Done():
 						return
 					}
 				}
-				bootstrapChunks = nil
+				pendingEventChunks = nil
+				pendingBootstrapData = false
 			}
 			for i := range chunks {
 				select {
@@ -572,6 +590,29 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			reporter.PublishFailure(ctx)
 			select {
 			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
+			case <-ctx.Done():
+			}
+			return
+		}
+		if len(pendingEventChunks) > 0 {
+			if !pendingBootstrapData {
+				for i := range pendingEventChunks {
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Payload: pendingEventChunks[i]}:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+			pendingEventChunks = nil
+			pendingBootstrapData = false
+		}
+		if !sawCompleted && !sawTerminalEvent {
+			missingCompletedErr := newCodexMissingCompletedErr()
+			helps.RecordAPIResponseError(ctx, e.cfg, missingCompletedErr)
+			reporter.PublishFailure(ctx)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: missingCompletedErr}:
 			case <-ctx.Done():
 			}
 		}
@@ -933,6 +974,10 @@ func codexStatusErrorClassification(statusCode int, body []byte) (code string, e
 	}
 }
 
+func newCodexMissingCompletedErr() statusErr {
+	return statusErr{code: http.StatusRequestTimeout, msg: codexMissingCompletedMessage}
+}
+
 func normalizeCodexInstructions(body []byte) []byte {
 	instructions := gjson.GetBytes(body, "instructions")
 	if !instructions.Exists() || instructions.Type == gjson.Null {
@@ -1046,10 +1091,16 @@ func codexStreamBufferedEvent(eventType string) bool {
 
 func codexStreamStatusErr(eventData []byte) (statusErr, bool) {
 	errorBody, ok := codexStreamErrorBody(eventData)
-	if !ok || !isCodexModelCapacityError(errorBody) {
+	if !ok {
 		return statusErr{}, false
 	}
-	return newCodexStatusErr(http.StatusBadRequest, errorBody), true
+	if isCodexModelCapacityError(errorBody) {
+		return newCodexStatusErr(http.StatusBadRequest, errorBody), true
+	}
+	if _, _, okClassified := codexStatusErrorClassification(http.StatusBadRequest, errorBody); okClassified {
+		return newCodexStatusErr(http.StatusBadRequest, errorBody), true
+	}
+	return newCodexStatusErr(http.StatusRequestTimeout, errorBody), true
 }
 
 func codexStreamErrorBody(eventData []byte) ([]byte, bool) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -37,6 +37,8 @@ const (
 
 var dataTag = []byte("data:")
 
+const codexModelCapacityRetryAfter = time.Second
+
 // Streamed Codex responses may emit response.output_item.done events while leaving
 // response.completed.response.output empty. Keep the stream path aligned with the
 // already-patched non-stream path by reconstructing response.output from those items.
@@ -500,6 +502,15 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 
 			if bytes.HasPrefix(line, dataTag) {
 				data := bytes.TrimSpace(line[5:])
+				if errStream, ok := codexStreamStatusErr(data); ok {
+					helps.RecordAPIResponseError(ctx, e.cfg, errStream)
+					reporter.PublishFailure(ctx)
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Err: errStream}:
+					case <-ctx.Done():
+					}
+					return
+				}
 				switch gjson.GetBytes(data, "type").String() {
 				case "response.output_item.done":
 					collectCodexOutputItemDone(data, outputItemsByIndex, &outputItemsFallback)
@@ -825,11 +836,17 @@ func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, s
 
 func newCodexStatusErr(statusCode int, body []byte) statusErr {
 	errCode := statusCode
-	if isCodexModelCapacityError(body) {
+	isCapacityError := isCodexModelCapacityError(body)
+	if isCapacityError {
 		errCode = http.StatusTooManyRequests
 	}
 	body = classifyCodexStatusError(errCode, body)
 	err := statusErr{code: errCode, msg: string(body)}
+	if isCapacityError {
+		retryAfter := codexModelCapacityRetryAfter
+		err.retryAfter = &retryAfter
+		return err
+	}
 	if retryAfter := parseCodexRetryAfter(errCode, body, time.Now()); retryAfter != nil {
 		err.retryAfter = retryAfter
 	}
@@ -970,6 +987,51 @@ func isCodexModelCapacityError(errorBody []byte) bool {
 		}
 	}
 	return false
+}
+
+func codexStreamStatusErr(eventData []byte) (statusErr, bool) {
+	if !isCodexModelCapacityError(eventData) {
+		return statusErr{}, false
+	}
+	return newCodexStatusErr(http.StatusBadRequest, codexStreamErrorBody(eventData)), true
+}
+
+func codexStreamErrorBody(eventData []byte) []byte {
+	candidates := []string{
+		"error",
+		"response.error",
+	}
+	for _, path := range candidates {
+		result := gjson.GetBytes(eventData, path)
+		if !result.Exists() {
+			continue
+		}
+		if result.Type == gjson.JSON {
+			body := []byte(`{"error":` + result.Raw + `}`)
+			if gjson.GetBytes(body, "error.message").String() != "" {
+				return body
+			}
+			continue
+		}
+		if msg := strings.TrimSpace(result.String()); msg != "" {
+			body := []byte(`{"error":{}}`)
+			body, _ = sjson.SetBytes(body, "error.message", msg)
+			return body
+		}
+	}
+	messagePaths := []string{
+		"error.message",
+		"response.error.message",
+		"message",
+	}
+	for _, path := range messagePaths {
+		if msg := strings.TrimSpace(gjson.GetBytes(eventData, path).String()); msg != "" {
+			body := []byte(`{"error":{}}`)
+			body, _ = sjson.SetBytes(body, "error.message", msg)
+			return body
+		}
+	}
+	return eventData
 }
 
 func parseCodexRetryAfter(statusCode int, errorBody []byte, now time.Time) *time.Duration {

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -210,6 +210,49 @@ func TestCodexExecutorExecuteStream_BuffersTerminalEventBeforeCapacityError(t *t
 	}
 }
 
+func TestCodexExecutorExecuteStream_BuffersControlLinesBeforeCapacityError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(": keep-alive\n"))
+		_, _ = w.Write([]byte("id: resp_123\n"))
+		_, _ = w.Write([]byte("retry: 1000\n\n"))
+		_, _ = w.Write([]byte("event: response.failed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"Selected model is at capacity. Please try a different model.\"}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	chunk, ok := <-result.Chunks
+	if !ok {
+		t.Fatalf("expected capacity error chunk")
+	}
+	if len(chunk.Payload) > 0 {
+		t.Fatalf("expected no control-line payload before capacity error, got %q", string(chunk.Payload))
+	}
+	if chunk.Err == nil {
+		t.Fatalf("expected capacity error chunk")
+	}
+	if got := statusCodeFromCodexTestError(chunk.Err); got != http.StatusTooManyRequests {
+		t.Fatalf("status code = %d, want %d", got, http.StatusTooManyRequests)
+	}
+}
+
 func TestCodexExecutorExecuteStream_DoesNotBufferContentEventLine(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -415,6 +415,49 @@ func TestCodexExecutorExecuteStream_PreservesInvalidRequestFailureStatus(t *test
 	}
 }
 
+func TestCodexExecutorExecuteStream_PreservesAuthenticationFailureStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.failed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"invalid or expired token\",\"type\":\"authentication_error\",\"code\":\"invalid_api_key\"}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	chunk, ok := <-result.Chunks
+	if !ok {
+		t.Fatalf("expected auth error chunk")
+	}
+	if len(chunk.Payload) > 0 {
+		t.Fatalf("expected no payload before auth error, got %q", string(chunk.Payload))
+	}
+	if chunk.Err == nil {
+		t.Fatalf("expected auth error chunk")
+	}
+	if got := statusCodeFromCodexTestError(chunk.Err); got != http.StatusUnauthorized {
+		t.Fatalf("status code = %d, want %d", got, http.StatusUnauthorized)
+	}
+	if !strings.Contains(chunk.Err.Error(), "auth_unavailable") {
+		t.Fatalf("expected classified auth error, got %v", chunk.Err)
+	}
+}
+
 func TestCodexExecutorExecuteStream_ReturnsMissingCompletedOnBootstrapOnlyEOF(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -253,6 +253,59 @@ func TestCodexExecutorExecuteStream_BuffersControlLinesBeforeCapacityError(t *te
 	}
 }
 
+func TestCodexExecutorExecuteStream_FlushesLongBootstrapBufferBeforeContent(t *testing.T) {
+	bootstrapFlushed := make(chan struct{})
+	allowContent := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		for i := 0; i < 4; i++ {
+			_, _ = w.Write([]byte("event: response.in_progress\n"))
+			_, _ = w.Write([]byte("data: {\"type\":\"response.in_progress\"}\n\n"))
+		}
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		close(bootstrapFlushed)
+		<-allowContent
+		_, _ = w.Write([]byte("event: response.output_text.delta\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n"))
+		_, _ = w.Write([]byte("event: response.completed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_123\",\"output\":[]}}\n\n"))
+	}))
+	defer server.Close()
+	defer close(allowContent)
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	<-bootstrapFlushed
+	select {
+	case chunk := <-result.Chunks:
+		if chunk.Err != nil {
+			t.Fatalf("expected buffered bootstrap payload, got error %v", chunk.Err)
+		}
+		if !bytes.Contains(chunk.Payload, []byte("response.in_progress")) {
+			t.Fatalf("expected bootstrap payload before content, got %q", string(chunk.Payload))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for bounded bootstrap buffer to flush")
+	}
+}
+
 func TestCodexExecutorExecuteStream_DoesNotBufferContentEventLine(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -160,11 +160,9 @@ func TestCodexExecutorExecuteStream_ReturnsErrorForStreamCapacityEvent(t *testin
 	}
 }
 
-func TestCodexExecutorExecuteStream_BuffersBootstrapBeforeCapacityEvent(t *testing.T) {
+func TestCodexExecutorExecuteStream_BuffersTerminalEventBeforeCapacityError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = w.Write([]byte("event: response.created\n"))
-		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_123\",\"created_at\":1700000000,\"model\":\"gpt-5.5\"}}\n\n"))
 		_, _ = w.Write([]byte("event: response.failed\n"))
 		_, _ = w.Write([]byte("data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"Selected model is at capacity. Please try a different model.\"}}}\n\n"))
 	}))
@@ -189,10 +187,10 @@ func TestCodexExecutorExecuteStream_BuffersBootstrapBeforeCapacityEvent(t *testi
 
 	chunk, ok := <-result.Chunks
 	if !ok {
-		t.Fatalf("expected error chunk")
+		t.Fatalf("expected capacity error chunk")
 	}
 	if len(chunk.Payload) > 0 {
-		t.Fatalf("expected bootstrap payload to be buffered, got %q", string(chunk.Payload))
+		t.Fatalf("expected no payload before capacity error, got %q", string(chunk.Payload))
 	}
 	if chunk.Err == nil {
 		t.Fatalf("expected capacity error chunk")
@@ -256,6 +254,8 @@ func TestCodexExecutorExecuteStream_PreservesBufferedBootstrapDelimiter(t *testi
 		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_123\",\"created_at\":1700000000,\"model\":\"gpt-5.5\"}}\n\n"))
 		_, _ = w.Write([]byte("event: response.output_text.delta\n"))
 		_, _ = w.Write([]byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n"))
+		_, _ = w.Write([]byte("event: response.completed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_123\",\"output\":[]}}\n\n"))
 	}))
 	defer server.Close()
 
@@ -277,11 +277,7 @@ func TestCodexExecutorExecuteStream_PreservesBufferedBootstrapDelimiter(t *testi
 	}
 
 	var payloads [][]byte
-	for i := 0; i < 4; i++ {
-		chunk, ok := <-result.Chunks
-		if !ok {
-			t.Fatalf("expected at least 4 chunks, got %d", len(payloads))
-		}
+	for chunk := range result.Chunks {
 		if chunk.Err != nil {
 			t.Fatalf("expected payload chunk, got error %v", chunk.Err)
 		}
@@ -293,7 +289,7 @@ func TestCodexExecutorExecuteStream_PreservesBufferedBootstrapDelimiter(t *testi
 	}
 }
 
-func TestCodexExecutorExecuteStream_DoesNotDropNonCapacityFailureData(t *testing.T) {
+func TestCodexExecutorExecuteStream_ReturnsErrorForNonCapacityFailureEvent(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("event: response.failed\n"))
@@ -320,13 +316,263 @@ func TestCodexExecutorExecuteStream_DoesNotDropNonCapacityFailureData(t *testing
 
 	chunk, ok := <-result.Chunks
 	if !ok {
-		t.Fatalf("expected failure payload chunk")
+		t.Fatalf("expected failure error chunk")
 	}
-	if chunk.Err != nil {
-		t.Fatalf("expected payload chunk, got error %v", chunk.Err)
+	if len(chunk.Payload) > 0 {
+		t.Fatalf("expected no payload before failure error, got %q", string(chunk.Payload))
 	}
-	if len(chunk.Payload) == 0 {
-		t.Fatalf("expected non-empty payload")
+	if chunk.Err == nil {
+		t.Fatalf("expected failure error chunk")
+	}
+	if got := statusCodeFromCodexTestError(chunk.Err); got != http.StatusRequestTimeout {
+		t.Fatalf("status code = %d, want %d", got, http.StatusRequestTimeout)
+	}
+}
+
+func TestCodexExecutorExecuteStream_PreservesInvalidRequestFailureStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.failed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"context length exceeded\",\"type\":\"invalid_request_error\",\"code\":\"context_length_exceeded\"}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	chunk, ok := <-result.Chunks
+	if !ok {
+		t.Fatalf("expected failure error chunk")
+	}
+	if len(chunk.Payload) > 0 {
+		t.Fatalf("expected no payload before failure error, got %q", string(chunk.Payload))
+	}
+	if chunk.Err == nil {
+		t.Fatalf("expected failure error chunk")
+	}
+	if got := statusCodeFromCodexTestError(chunk.Err); got != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want %d", got, http.StatusBadRequest)
+	}
+	if !strings.Contains(chunk.Err.Error(), "context_too_large") {
+		t.Fatalf("expected classified context error, got %v", chunk.Err)
+	}
+}
+
+func TestCodexExecutorExecuteStream_ReturnsMissingCompletedOnBootstrapOnlyEOF(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.created\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_123\",\"created_at\":1700000000,\"model\":\"gpt-5.5\"}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var gotPayload bool
+	var gotErr error
+	for chunk := range result.Chunks {
+		if len(chunk.Payload) > 0 {
+			gotPayload = true
+		}
+		if chunk.Err != nil {
+			gotErr = chunk.Err
+		}
+	}
+	if gotPayload {
+		t.Fatalf("expected bootstrap payload to be buffered and dropped before missing-completed error")
+	}
+	if gotErr == nil {
+		t.Fatalf("expected missing completed error")
+	}
+	if got := statusCodeFromCodexTestError(gotErr); got != http.StatusRequestTimeout {
+		t.Fatalf("status code = %d, want %d", got, http.StatusRequestTimeout)
+	}
+}
+
+func TestCodexExecutorExecuteStream_DropsBootstrapEventLineOnEOF(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.created\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var gotPayload []byte
+	var gotErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			gotErr = chunk.Err
+			continue
+		}
+		gotPayload = append(gotPayload, chunk.Payload...)
+	}
+	if len(gotPayload) > 0 {
+		t.Fatalf("expected no payload before missing-completed error, got %q", string(gotPayload))
+	}
+	if gotErr == nil {
+		t.Fatalf("expected missing completed error")
+	}
+	if got := statusCodeFromCodexTestError(gotErr); got != http.StatusRequestTimeout {
+		t.Fatalf("status code = %d, want %d", got, http.StatusRequestTimeout)
+	}
+}
+
+func TestCodexExecutorExecuteStream_DoesNotAppendMissingCompletedAfterIncomplete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.incomplete\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp_123\",\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var gotPayload bool
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected stream error: %v", chunk.Err)
+		}
+		if len(chunk.Payload) > 0 {
+			gotPayload = true
+		}
+	}
+	if !gotPayload {
+		t.Fatalf("expected incomplete payload to be forwarded")
+	}
+}
+
+func TestCodexExecutorExecute_TreatsResponseFailedCapacityAsRetryableRateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.created\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_123\",\"created_at\":1700000000,\"model\":\"gpt-5.5\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.failed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"Selected model is at capacity. Please try a different model.\"}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err == nil {
+		t.Fatal("expected execute error")
+	}
+
+	statusErr, ok := err.(interface {
+		StatusCode() int
+		RetryAfter() *time.Duration
+	})
+	if !ok {
+		t.Fatalf("execute error does not expose status/retryAfter: %T", err)
+	}
+	if got := statusErr.StatusCode(); got != http.StatusTooManyRequests {
+		t.Fatalf("status code = %d, want %d", got, http.StatusTooManyRequests)
+	}
+	if statusErr.RetryAfter() == nil {
+		t.Fatalf("expected retryAfter")
+	}
+	if got := *statusErr.RetryAfter(); got != codexModelCapacityRetryAfter {
+		t.Fatalf("retryAfter = %v, want %v", got, codexModelCapacityRetryAfter)
+	}
+}
+
+func TestCodexExecutorExecute_DoesNotClassifyGenericResponseFailedAsBadRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.failed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"upstream failed\"}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err == nil {
+		t.Fatal("expected execute error")
+	}
+	if got := statusCodeFromCodexTestError(err); got == http.StatusBadRequest {
+		t.Fatalf("generic streamed failure status = %d, must not be forced to bad request; err=%v", got, err)
+	}
+	if got := statusCodeFromCodexTestError(err); got != http.StatusRequestTimeout {
+		t.Fatalf("generic streamed failure status = %d, want %d", got, http.StatusRequestTimeout)
 	}
 }
 
@@ -398,6 +644,16 @@ func TestNewCodexStatusErrPreservesUnclassifiedErrors(t *testing.T) {
 	}
 }
 
+func TestNewCodexMissingCompletedErr(t *testing.T) {
+	err := newCodexMissingCompletedErr()
+	if got := err.StatusCode(); got != http.StatusRequestTimeout {
+		t.Fatalf("status code = %d, want %d", got, http.StatusRequestTimeout)
+	}
+	if got := err.Error(); got != codexMissingCompletedMessage {
+		t.Fatalf("error = %s, want %s", got, codexMissingCompletedMessage)
+	}
+}
+
 func assertCodexErrorCode(t *testing.T, raw string, wantType string, wantCode string) {
 	t.Helper()
 
@@ -420,4 +676,14 @@ func assertCodexErrorCode(t *testing.T, raw string, wantType string, wantCode st
 
 func itoa(v int64) string {
 	return strconv.FormatInt(v, 10)
+}
+
+func statusCodeFromCodexTestError(err error) int {
+	type statusCoder interface {
+		StatusCode() int
+	}
+	if se, ok := err.(statusCoder); ok && se != nil {
+		return se.StatusCode()
+	}
+	return 0
 }

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -1,11 +1,13 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -104,6 +106,14 @@ func TestCodexStreamStatusErrTreatsCapacityAsRetryableRateLimit(t *testing.T) {
 	}
 }
 
+func TestCodexStreamStatusErrIgnoresCapacityTextInOutput(t *testing.T) {
+	event := []byte(`{"type":"response.output_text.delta","delta":"Selected model is at capacity. Please try a different model."}`)
+
+	if err, ok := codexStreamStatusErr(event); ok {
+		t.Fatalf("expected normal output text to pass through, got %v", err)
+	}
+}
+
 func TestCodexExecutorExecuteStream_ReturnsErrorForStreamCapacityEvent(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -147,6 +157,176 @@ func TestCodexExecutorExecuteStream_ReturnsErrorForStreamCapacityEvent(t *testin
 	}
 	if statusErr.RetryAfter() == nil {
 		t.Fatalf("expected retryAfter")
+	}
+}
+
+func TestCodexExecutorExecuteStream_BuffersBootstrapBeforeCapacityEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.created\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_123\",\"created_at\":1700000000,\"model\":\"gpt-5.5\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.failed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"Selected model is at capacity. Please try a different model.\"}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	chunk, ok := <-result.Chunks
+	if !ok {
+		t.Fatalf("expected error chunk")
+	}
+	if len(chunk.Payload) > 0 {
+		t.Fatalf("expected bootstrap payload to be buffered, got %q", string(chunk.Payload))
+	}
+	if chunk.Err == nil {
+		t.Fatalf("expected capacity error chunk")
+	}
+	statusErr, ok := chunk.Err.(interface {
+		StatusCode() int
+		RetryAfter() *time.Duration
+	})
+	if !ok {
+		t.Fatalf("stream error does not expose status/retryAfter: %T", chunk.Err)
+	}
+	if got := statusErr.StatusCode(); got != http.StatusTooManyRequests {
+		t.Fatalf("status code = %d, want %d", got, http.StatusTooManyRequests)
+	}
+	if statusErr.RetryAfter() == nil {
+		t.Fatalf("expected retryAfter")
+	}
+}
+
+func TestCodexExecutorExecuteStream_DoesNotBufferContentEventLine(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.output_text.delta\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	chunk, ok := <-result.Chunks
+	if !ok {
+		t.Fatalf("expected content event chunk")
+	}
+	if chunk.Err != nil {
+		t.Fatalf("expected payload chunk, got error %v", chunk.Err)
+	}
+	if len(chunk.Payload) == 0 {
+		t.Fatalf("expected non-empty payload")
+	}
+}
+
+func TestCodexExecutorExecuteStream_PreservesBufferedBootstrapDelimiter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.created\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_123\",\"created_at\":1700000000,\"model\":\"gpt-5.5\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.output_text.delta\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var payloads [][]byte
+	for i := 0; i < 4; i++ {
+		chunk, ok := <-result.Chunks
+		if !ok {
+			t.Fatalf("expected at least 4 chunks, got %d", len(payloads))
+		}
+		if chunk.Err != nil {
+			t.Fatalf("expected payload chunk, got error %v", chunk.Err)
+		}
+		payloads = append(payloads, chunk.Payload)
+	}
+	joined := string(bytes.Join(payloads, nil))
+	if !strings.Contains(joined, "gpt-5.5\"}}\n\nevent: response.output_text.delta") {
+		t.Fatalf("buffered bootstrap delimiter missing from payloads: %q", joined)
+	}
+}
+
+func TestCodexExecutorExecuteStream_DoesNotDropNonCapacityFailureData(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.failed\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"upstream failed\"}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	chunk, ok := <-result.Chunks
+	if !ok {
+		t.Fatalf("expected failure payload chunk")
+	}
+	if chunk.Err != nil {
+		t.Fatalf("expected payload chunk, got error %v", chunk.Err)
+	}
+	if len(chunk.Payload) == 0 {
+		t.Fatalf("expected non-empty payload")
 	}
 }
 

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -1,11 +1,19 @@
 package executor
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 )
 
 func TestParseCodexRetryAfter(t *testing.T) {
@@ -69,8 +77,76 @@ func TestNewCodexStatusErrTreatsCapacityAsRetryableRateLimit(t *testing.T) {
 	if got := err.StatusCode(); got != http.StatusTooManyRequests {
 		t.Fatalf("status code = %d, want %d", got, http.StatusTooManyRequests)
 	}
-	if err.RetryAfter() != nil {
-		t.Fatalf("expected nil explicit retryAfter for capacity fallback, got %v", *err.RetryAfter())
+	if err.RetryAfter() == nil {
+		t.Fatalf("expected retryAfter for capacity fallback")
+	}
+	if got := *err.RetryAfter(); got != codexModelCapacityRetryAfter {
+		t.Fatalf("retryAfter = %v, want %v", got, codexModelCapacityRetryAfter)
+	}
+}
+
+func TestCodexStreamStatusErrTreatsCapacityAsRetryableRateLimit(t *testing.T) {
+	event := []byte(`{"type":"response.failed","response":{"error":{"message":"Selected model is at capacity. Please try a different model."}}}`)
+
+	err, ok := codexStreamStatusErr(event)
+
+	if !ok {
+		t.Fatalf("expected stream capacity error")
+	}
+	if got := err.StatusCode(); got != http.StatusTooManyRequests {
+		t.Fatalf("status code = %d, want %d", got, http.StatusTooManyRequests)
+	}
+	if err.RetryAfter() == nil {
+		t.Fatalf("expected retryAfter for capacity fallback")
+	}
+	if got := *err.RetryAfter(); got != codexModelCapacityRetryAfter {
+		t.Fatalf("retryAfter = %v, want %v", got, codexModelCapacityRetryAfter)
+	}
+}
+
+func TestCodexExecutorExecuteStream_ReturnsErrorForStreamCapacityEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"Selected model is at capacity. Please try a different model.\"}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"Say ok"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	chunk, ok := <-result.Chunks
+	if !ok {
+		t.Fatalf("expected error chunk")
+	}
+	if chunk.Err == nil {
+		t.Fatalf("expected error chunk, got payload %q", string(chunk.Payload))
+	}
+	statusErr, ok := chunk.Err.(interface {
+		StatusCode() int
+		RetryAfter() *time.Duration
+	})
+	if !ok {
+		t.Fatalf("stream error does not expose status/retryAfter: %T", chunk.Err)
+	}
+	if got := statusErr.StatusCode(); got != http.StatusTooManyRequests {
+		t.Fatalf("status code = %d, want %d", got, http.StatusTooManyRequests)
+	}
+	if statusErr.RetryAfter() == nil {
+		t.Fatalf("expected retryAfter")
 	}
 }
 

--- a/sdk/cliproxy/auth/antigravity_credits_test.go
+++ b/sdk/cliproxy/auth/antigravity_credits_test.go
@@ -97,6 +97,25 @@ func TestStatusCodeFromError_UnwrapsStreamBootstrap429(t *testing.T) {
 	}
 }
 
+func TestRetryAfterFromError_UnwrapsStreamBootstrapRetryAfter(t *testing.T) {
+	retryAfter := 123 * time.Millisecond
+	cause := &retryAfterStatusError{
+		status:     http.StatusTooManyRequests,
+		message:    "Selected model is at capacity. Please try a different model.",
+		retryAfter: retryAfter,
+	}
+	bootstrapErr := newStreamBootstrapError(cause, nil)
+	wrappedErr := fmt.Errorf("conductor stream failed: %w", bootstrapErr)
+
+	got := retryAfterFromError(wrappedErr)
+	if got == nil {
+		t.Fatalf("expected retryAfter, got nil")
+	}
+	if *got != retryAfter {
+		t.Fatalf("retryAfterFromError() = %v, want %v", *got, retryAfter)
+	}
+}
+
 func TestIsAuthBlockedForModel_ClaudeWithCreditsStillBlockedDuringCooldown(t *testing.T) {
 	auth := &Auth{
 		ID:       "ag-1",

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2401,8 +2401,8 @@ func retryAfterFromError(err error) *time.Duration {
 	type retryAfterProvider interface {
 		RetryAfter() *time.Duration
 	}
-	rap, ok := err.(retryAfterProvider)
-	if !ok || rap == nil {
+	var rap retryAfterProvider
+	if !errors.As(err, &rap) || rap == nil {
 		return nil
 	}
 	retryAfter := rap.RetryAfter()

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -741,6 +741,50 @@ func TestManager_Execute_DisableCooling_RetriesAfter429RetryAfter(t *testing.T) 
 	}
 }
 
+func TestManager_Execute_RetriesAfterTransientCapacity429(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(1, 100*time.Millisecond, 0)
+
+	executor := &authFallbackExecutor{
+		id: "codex",
+		executeErrors: map[string]error{
+			"auth-capacity-exec": &retryAfterStatusError{
+				status:     http.StatusTooManyRequests,
+				message:    "Selected model is at capacity. Please try a different model.",
+				retryAfter: time.Millisecond,
+			},
+		},
+	}
+	m.RegisterExecutor(executor)
+
+	auth := &Auth{
+		ID:       "auth-capacity-exec",
+		Provider: "codex",
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "gpt-5.1-codex"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	req := cliproxyexecutor.Request{Model: model}
+	_, errExecute := m.Execute(context.Background(), []string{"codex"}, req, cliproxyexecutor.Options{})
+	if errExecute == nil {
+		t.Fatal("expected execute error")
+	}
+	if statusCodeFromError(errExecute) != http.StatusTooManyRequests {
+		t.Fatalf("execute status = %d, want %d", statusCodeFromError(errExecute), http.StatusTooManyRequests)
+	}
+
+	calls := executor.ExecuteCalls()
+	if len(calls) != 2 {
+		t.Fatalf("execute calls = %d, want 2 (initial + retry)", len(calls))
+	}
+}
+
 func TestManager_MarkResult_RequestScopedNotFoundDoesNotCooldownAuth(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 


### PR DESCRIPTION
## Summary
- add a short retry hint for Codex model capacity errors after mapping them to 429
- keep existing reset-based Retry-After parsing for usage-limit responses
- add a manager-level regression test proving transient capacity 429s use request retry

## Testing
- go test ./internal/runtime/executor -run 'Test(NewCodexStatusErrTreatsCapacityAsRetryableRateLimit|ParseCodexRetryAfter)' -count=1\n- go test ./sdk/cliproxy/auth -run 'TestManager_Execute_RetriesAfterTransientCapacity429|TestManager_Execute_DisableCooling_RetriesAfter429RetryAfter' -count=1\n- go build -o test-output ./cmd/server && rm test-output