### PR TITLE
[codex] fix claude embedded image data urls

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
@@ -20,6 +21,102 @@ var (
 	account = ""
 	session = ""
 )
+
+const minEmbeddedImageDataBytes = 512
+
+var embeddedImageDataURLPattern = regexp.MustCompile(`(?i)data:(image/[a-z0-9.+-]+);base64,([A-Za-z0-9+/=_-]+)`)
+
+func makeClaudeTextPart(text string) string {
+	contentPart := []byte(`{"type":"text","text":""}`)
+	contentPart, _ = sjson.SetBytes(contentPart, "text", text)
+	return string(contentPart)
+}
+
+func makeClaudeImagePart(mediaType, data string) string {
+	contentPart := []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
+	contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
+	contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
+	return string(contentPart)
+}
+
+func claudeTextPartsWithEmbeddedImages(text string) ([]string, bool) {
+	if text == "" || !strings.Contains(strings.ToLower(text), "data:image/") {
+		return nil, false
+	}
+
+	var parts []string
+	cursor := 0
+	searchStart := 0
+	extractedImage := false
+	for searchStart < len(text) {
+		match := embeddedImageDataURLPattern.FindStringSubmatchIndex(text[searchStart:])
+		if match == nil {
+			break
+		}
+
+		start := searchStart + match[0]
+		end := searchStart + match[1]
+		mediaType := text[searchStart+match[2] : searchStart+match[3]]
+		data := text[searchStart+match[4] : searchStart+match[5]]
+		if !shouldExtractEmbeddedImageData(mediaType, data) {
+			searchStart = end
+			continue
+		}
+
+		textEnd := start
+		imageEnd := end
+		if wrapperStart, wrapperEnd, ok := markdownImageWrapperBounds(text, cursor, start, end); ok {
+			textEnd = wrapperStart
+			imageEnd = wrapperEnd
+		}
+
+		appendClaudeTextPart(&parts, text[cursor:textEnd])
+		parts = append(parts, makeClaudeImagePart(mediaType, data))
+		cursor = imageEnd
+		searchStart = imageEnd
+		extractedImage = true
+	}
+
+	if !extractedImage {
+		return nil, false
+	}
+	appendClaudeTextPart(&parts, text[cursor:])
+	return parts, true
+}
+
+func shouldExtractEmbeddedImageData(mediaType, data string) bool {
+	if !strings.HasPrefix(strings.ToLower(mediaType), "image/") {
+		return false
+	}
+	if len(data) < minEmbeddedImageDataBytes {
+		return false
+	}
+	return len(data)%4 != 1
+}
+
+func markdownImageWrapperBounds(text string, cursor, start, end int) (int, int, bool) {
+	prefix := text[cursor:start]
+	openRelative := strings.LastIndex(prefix, "![")
+	if openRelative < 0 {
+		return start, end, false
+	}
+	open := cursor + openRelative
+	wrapperPrefix := text[open:start]
+	if strings.ContainsAny(wrapperPrefix, "\r\n") || !strings.HasSuffix(wrapperPrefix, "](") {
+		return start, end, false
+	}
+	if end >= len(text) || text[end] != ')' {
+		return start, end, false
+	}
+	return open, end + 1, true
+}
+
+func appendClaudeTextPart(parts *[]string, text string) {
+	if text == "" {
+		return
+	}
+	*parts = append(*parts, makeClaudeTextPart(text))
+}
 
 // ConvertOpenAIResponsesRequestToClaude transforms an OpenAI Responses API request
 // into a Claude Messages API request using only gjson/sjson for JSON handling.
@@ -62,7 +159,7 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 			supportsMax := supportsAdaptive && thinking.HasLevel(mi.Thinking.Levels, string(thinking.LevelMax))
 
 			// Claude 4.6 supports adaptive thinking with output_config.effort.
-			// MapToClaudeEffort normalizes levels (e.g. minimal→low, xhigh→high) to avoid
+			// MapToClaudeEffort normalizes levels (for example, minimal to low and xhigh to high) to avoid
 			// validation errors since validate treats same-provider unsupported levels as errors.
 			if supportsAdaptive {
 				switch effort {
@@ -192,10 +289,19 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 						case "input_text", "output_text":
 							if t := part.Get("text"); t.Exists() {
 								txt := t.String()
-								textAggregate.WriteString(txt)
-								contentPart := []byte(`{"type":"text","text":""}`)
-								contentPart, _ = sjson.SetBytes(contentPart, "text", txt)
-								partsJSON = append(partsJSON, string(contentPart))
+								if ptype == "input_text" {
+									textParts, extractedImage := claudeTextPartsWithEmbeddedImages(txt)
+									if extractedImage {
+										partsJSON = append(partsJSON, textParts...)
+										hasImage = true
+									} else {
+										textAggregate.WriteString(txt)
+										partsJSON = append(partsJSON, makeClaudeTextPart(txt))
+									}
+								} else {
+									textAggregate.WriteString(txt)
+									partsJSON = append(partsJSON, makeClaudeTextPart(txt))
+								}
 							}
 							if ptype == "input_text" {
 								role = "user"
@@ -265,7 +371,18 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 						return true
 					})
 				} else if parts.Type == gjson.String {
-					textAggregate.WriteString(parts.String())
+					txt := parts.String()
+					if strings.EqualFold(item.Get("role").String(), "user") {
+						textParts, extractedImage := claudeTextPartsWithEmbeddedImages(txt)
+						if extractedImage {
+							partsJSON = append(partsJSON, textParts...)
+							hasImage = true
+						} else {
+							textAggregate.WriteString(txt)
+						}
+					} else {
+						textAggregate.WriteString(txt)
+					}
 				}
 
 				// Fallback to given role if content types not decisive
@@ -327,9 +444,17 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 				// Map to user tool_result
 				callID := item.Get("call_id").String()
 				outputStr := item.Get("output").String()
+				textParts, extractedImage := claudeTextPartsWithEmbeddedImages(outputStr)
 				toolResult := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
 				toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", callID)
-				toolResult, _ = sjson.SetBytes(toolResult, "content", outputStr)
+				if extractedImage {
+					toolResult, _ = sjson.SetRawBytes(toolResult, "content", []byte("[]"))
+					for _, textPart := range textParts {
+						toolResult, _ = sjson.SetRawBytes(toolResult, "content.-1", []byte(textPart))
+					}
+				} else {
+					toolResult, _ = sjson.SetBytes(toolResult, "content", outputStr)
+				}
 
 				usr := []byte(`{"role":"user","content":[]}`)
 				usr, _ = sjson.SetRawBytes(usr, "content.-1", toolResult)

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -1,0 +1,212 @@
+package responses
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIResponsesRequestToClaude_SkipsUnnamedTools(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}],
+		"tools":[
+			{"type":"web_search_preview"},
+			{"type":"function","name":"search_files","description":"Search files","parameters":{"type":"object","properties":{"q":{"type":"string"}}}},
+			{"type":"function","function":{"name":"nested_tool","description":"Nested","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, true)
+	tools := gjson.GetBytes(out, "tools").Array()
+	if len(tools) != 2 {
+		t.Fatalf("tools length = %d, want 2: %s", len(tools), out)
+	}
+	if got := tools[0].Get("name").String(); got != "search_files" {
+		t.Fatalf("tools.0.name = %q, want search_files", got)
+	}
+	if got := tools[0].Get("input_schema.properties.q.type").String(); got != "string" {
+		t.Fatalf("tools.0 input schema q type = %q, want string", got)
+	}
+	if got := tools[1].Get("name").String(); got != "nested_tool" {
+		t.Fatalf("tools.1.name = %q, want nested_tool", got)
+	}
+	if gjson.GetBytes(out, `tools.#(name="")`).Exists() {
+		t.Fatalf("output should not contain unnamed tools: %s", out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_ExtractsEmbeddedDataImageFromInputText(t *testing.T) {
+	imageData := strings.Repeat("A", 512)
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{
+			"role":"user",
+			"content":[{
+				"type":"input_text",
+				"text":"before\n![screenshot](data:image/png;base64,` + imageData + `)\nafter"
+			}]
+		}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, true)
+	content := gjson.GetBytes(out, "messages.0.content")
+	if !content.IsArray() {
+		t.Fatalf("message content should be an array after extracting an embedded image: %s", out)
+	}
+	parts := content.Array()
+	if len(parts) != 3 {
+		t.Fatalf("content parts length = %d, want 3: %s", len(parts), out)
+	}
+	if got := parts[0].Get("type").String(); got != "text" {
+		t.Fatalf("content.0.type = %q, want text", got)
+	}
+	if got := parts[0].Get("text").String(); got != "before\n" {
+		t.Fatalf("content.0.text = %q, want prefix text", got)
+	}
+	if got := parts[1].Get("type").String(); got != "image" {
+		t.Fatalf("content.1.type = %q, want image", got)
+	}
+	if got := parts[1].Get("source.type").String(); got != "base64" {
+		t.Fatalf("content.1.source.type = %q, want base64", got)
+	}
+	if got := parts[1].Get("source.media_type").String(); got != "image/png" {
+		t.Fatalf("content.1.source.media_type = %q, want image/png", got)
+	}
+	if got := parts[1].Get("source.data").String(); got != imageData {
+		t.Fatalf("content.1.source.data length = %d, want %d", len(got), len(imageData))
+	}
+	if got := parts[2].Get("text").String(); got != "\nafter" {
+		t.Fatalf("content.2.text = %q, want suffix text", got)
+	}
+	for _, part := range parts {
+		if strings.Contains(part.Get("text").String(), "data:image") {
+			t.Fatalf("text part should not retain embedded data image URL: %s", out)
+		}
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_LeavesShortDataImageTextLiteral(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{
+			"role":"user",
+			"content":[{
+				"type":"input_text",
+				"text":"Document this literal: data:image/png;base64,AAAA"
+			}]
+		}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, true)
+	content := gjson.GetBytes(out, "messages.0.content")
+	if content.Type != gjson.String {
+		t.Fatalf("short literal data URL should remain legacy string content: %s", out)
+	}
+	if !strings.Contains(content.String(), "data:image/png;base64,AAAA") {
+		t.Fatalf("short literal data URL missing from text content: %s", out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_ExtractsEmbeddedDataImageFromStringContent(t *testing.T) {
+	imageData := strings.Repeat("A", 512)
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{
+			"role":"user",
+			"content":"before data:image/jpeg;base64,` + imageData + ` after"
+		}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, true)
+	content := gjson.GetBytes(out, "messages.0.content")
+	if !content.IsArray() {
+		t.Fatalf("string content should become an array after extracting an embedded image: %s", out)
+	}
+	parts := content.Array()
+	if len(parts) != 3 {
+		t.Fatalf("content parts length = %d, want 3: %s", len(parts), out)
+	}
+	if got := parts[1].Get("source.media_type").String(); got != "image/jpeg" {
+		t.Fatalf("content.1.source.media_type = %q, want image/jpeg", got)
+	}
+	if got := parts[1].Get("source.data").String(); got != imageData {
+		t.Fatalf("content.1.source.data length = %d, want %d", len(got), len(imageData))
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_ExtractsEmbeddedDataImageFromFunctionCallOutput(t *testing.T) {
+	imageData := strings.Repeat("A", 512)
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{
+			"type":"function_call_output",
+			"call_id":"call_123",
+			"output":"before\n![screenshot](data:image/png;base64,` + imageData + `)\nafter"
+		}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, true)
+	toolResult := gjson.GetBytes(out, "messages.0.content.0")
+	if got := toolResult.Get("type").String(); got != "tool_result" {
+		t.Fatalf("messages.0.content.0.type = %q, want tool_result: %s", got, out)
+	}
+	if got := toolResult.Get("tool_use_id").String(); got != "call_123" {
+		t.Fatalf("tool_result.tool_use_id = %q, want call_123", got)
+	}
+	content := toolResult.Get("content")
+	if !content.IsArray() {
+		t.Fatalf("tool_result content should be an array after extracting an embedded image: %s", out)
+	}
+	parts := content.Array()
+	if len(parts) != 3 {
+		t.Fatalf("tool_result content parts length = %d, want 3: %s", len(parts), out)
+	}
+	if got := parts[0].Get("type").String(); got != "text" {
+		t.Fatalf("tool_result.content.0.type = %q, want text", got)
+	}
+	if got := parts[0].Get("text").String(); got != "before\n" {
+		t.Fatalf("tool_result.content.0.text = %q, want prefix text", got)
+	}
+	if got := parts[1].Get("type").String(); got != "image" {
+		t.Fatalf("tool_result.content.1.type = %q, want image", got)
+	}
+	if got := parts[1].Get("source.type").String(); got != "base64" {
+		t.Fatalf("tool_result.content.1.source.type = %q, want base64", got)
+	}
+	if got := parts[1].Get("source.media_type").String(); got != "image/png" {
+		t.Fatalf("tool_result.content.1.source.media_type = %q, want image/png", got)
+	}
+	if got := parts[1].Get("source.data").String(); got != imageData {
+		t.Fatalf("tool_result.content.1.source.data length = %d, want %d", len(got), len(imageData))
+	}
+	if got := parts[2].Get("text").String(); got != "\nafter" {
+		t.Fatalf("tool_result.content.2.text = %q, want suffix text", got)
+	}
+	for _, part := range parts {
+		if strings.Contains(part.Get("text").String(), "data:image") {
+			t.Fatalf("text part should not retain embedded data image URL: %s", out)
+		}
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_LeavesShortDataImageFunctionCallOutputLiteral(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{
+			"type":"function_call_output",
+			"call_id":"call_123",
+			"output":"Document this literal: data:image/png;base64,AAAA"
+		}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, true)
+	content := gjson.GetBytes(out, "messages.0.content.0.content")
+	if content.Type != gjson.String {
+		t.Fatalf("short literal data URL should remain string tool_result content: %s", out)
+	}
+	if !strings.Contains(content.String(), "data:image/png;base64,AAAA") {
+		t.Fatalf("short literal data URL missing from tool_result content: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Extract large embedded `data:image/...;base64,...` URLs from OpenAI Responses user text before forwarding to Claude.
- Convert extracted image data into Claude `image` content blocks while preserving surrounding text.
- Apply the same extraction to `function_call_output` content and keep short data URL literals unchanged.

## Root Cause
Codex-style image prompts can arrive as base64 data URLs embedded in text content instead of structured `input_image` parts. The Claude Responses translator forwarded those data URLs as text, which made Claude prompt/token sizes grow abnormally.

## Validation
- `go test ./internal/translator/claude/openai/responses`
- `go build -o test-output.exe ./cmd/server`