### PR TITLE
fix(amp): proxy thread actors route

### DIFF
--- a/internal/api/modules/amp/routes.go
+++ b/internal/api/modules/amp/routes.go
@@ -199,6 +199,7 @@ func (m *AmpModule) registerManagementRoutes(engine *gin.Engine, baseHandler *ha
 	ampAPI.Any("/telemetry/*path", proxyHandler)
 	ampAPI.Any("/threads", proxyHandler)
 	ampAPI.Any("/threads/*path", proxyHandler)
+	ampAPI.Any("/thread-actors", proxyHandler)
 	ampAPI.Any("/otel", proxyHandler)
 	ampAPI.Any("/otel/*path", proxyHandler)
 	ampAPI.Any("/tab", proxyHandler)

--- a/internal/api/modules/amp/routes_test.go
+++ b/internal/api/modules/amp/routes_test.go
@@ -49,6 +49,7 @@ func TestRegisterManagementRoutes(t *testing.T) {
 		{"/api/meta", http.MethodGet},
 		{"/api/telemetry", http.MethodGet},
 		{"/api/threads", http.MethodGet},
+		{"/api/thread-actors", http.MethodPost},
 		{"/threads/", http.MethodGet},
 		{"/threads.rss", http.MethodGet}, // Root-level route (no /api prefix)
 		{"/api/otel", http.MethodGet},


### PR DESCRIPTION
## Summary
- proxy Amp's new `/api/thread-actors` endpoint through the Amp upstream proxy
- add route coverage for `POST /api/thread-actors`

## Verification
- `git diff --check`
- `env -u AMP_API_KEY -u AMP_URL -u RIVET_PUBLIC_ENDPOINT go test ./internal/api/modules/amp -count=1`
- `env -u AMP_API_KEY -u AMP_URL -u RIVET_PUBLIC_ENDPOINT go build -o test-output ./cmd/server && rm test-output`

## Notes
- Full `go test ./...` still has unrelated existing failures on current `origin/main` in `internal/registry` and `internal/runtime/executor`.
