### PR TITLE
fix(cliproxy): warn when oauth-model-alias upstream matches exclusion

### DIFF
--- a/internal/watcher/synthesizer/alias_exclusion_test.go
+++ b/internal/watcher/synthesizer/alias_exclusion_test.go
@@ -1,0 +1,195 @@
+package synthesizer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestWarnAuthAliasExclusionConflicts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		auth           *coreauth.Auth
+		cfg            *config.Config
+		perKey         []string
+		authKind       string
+		wantCount      int
+		wantSubstrings []string
+	}{
+		{
+			name: "Daniel's documented case — antigravity per-account claude-* blocks claude-opus aliases",
+			auth: &coreauth.Auth{ID: "antigravity-larry@ebsources.com.json", Provider: "antigravity"},
+			cfg: &config.Config{
+				OAuthModelAlias: map[string][]config.OAuthModelAlias{
+					"antigravity": {
+						{Name: "claude-opus-4-6-thinking", Alias: "opus"},
+						{Name: "claude-opus-4-6-thinking", Alias: "opus[1m]"},
+					},
+				},
+			},
+			perKey:    []string{"claude-*"},
+			authKind:  "oauth",
+			wantCount: 2,
+			wantSubstrings: []string{
+				`auth="antigravity-larry@ebsources.com.json"`,
+				`channel="antigravity"`,
+				`alias="opus"`,
+				`alias="opus[1m]"`,
+				`pattern="claude-*"`,
+			},
+		},
+		{
+			name:      "no aliases configured for channel — no warnings",
+			auth:      &coreauth.Auth{ID: "claude-acct.json", Provider: "claude"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"antigravity": {{Name: "x", Alias: "y"}}}},
+			perKey:    []string{"claude-*"},
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+		{
+			name:      "empty perKey — no warnings",
+			auth:      &coreauth.Auth{ID: "x", Provider: "antigravity"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"antigravity": {{Name: "claude-opus", Alias: "opus"}}}},
+			perKey:    nil,
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+		{
+			name:      "apikey authKind has no channel — no warnings even with matching pattern",
+			auth:      &coreauth.Auth{ID: "claude-key", Provider: "claude"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"claude": {{Name: "claude-opus-4-6", Alias: "opus"}}}},
+			perKey:    []string{"claude-*"},
+			authKind:  "apikey",
+			wantCount: 0,
+		},
+		{
+			name:      "self-alias is filtered (case-insensitive)",
+			auth:      &coreauth.Auth{ID: "x", Provider: "antigravity"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"antigravity": {{Name: "Claude-Opus-4-6", Alias: "claude-opus-4-6"}}}},
+			perKey:    []string{"claude-*"},
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+		{
+			name:      "non-matching upstream produces no warning",
+			auth:      &coreauth.Auth{ID: "x", Provider: "antigravity"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"antigravity": {{Name: "gemini-2.5-pro", Alias: "pro"}}}},
+			perKey:    []string{"claude-*"},
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+		{
+			name:      "case-insensitive match against mixed-case upstream",
+			auth:      &coreauth.Auth{ID: "x", Provider: "claude"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"claude": {{Name: "Claude-Sonnet-4-5", Alias: "sonnet"}}}},
+			perKey:    []string{"CLAUDE-*"},
+			authKind:  "oauth",
+			wantCount: 1,
+		},
+		{
+			name:      "exact match without wildcard",
+			auth:      &coreauth.Auth{ID: "x", Provider: "claude"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"claude": {{Name: "claude-opus-4-6", Alias: "opus"}}}},
+			perKey:    []string{"claude-opus-4-6"},
+			authKind:  "oauth",
+			wantCount: 1,
+		},
+		{
+			name:      "auth with empty ID falls back to <unknown>",
+			auth:      &coreauth.Auth{ID: "", Provider: "antigravity"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"antigravity": {{Name: "claude-opus", Alias: "opus"}}}},
+			perKey:    []string{"claude-*"},
+			authKind:  "oauth",
+			wantCount: 1,
+			wantSubstrings: []string{
+				`auth="<unknown>"`,
+			},
+		},
+		{
+			name:      "nil cfg returns nil",
+			auth:      &coreauth.Auth{ID: "x", Provider: "claude"},
+			cfg:       nil,
+			perKey:    []string{"claude-*"},
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+		{
+			name:      "nil auth returns nil",
+			auth:      nil,
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"claude": {{Name: "x", Alias: "y"}}}},
+			perKey:    []string{"x"},
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+		{
+			name: "unsupported provider (gemini) yields empty channel — no warnings",
+			auth: &coreauth.Auth{ID: "x", Provider: "gemini"},
+			cfg: &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{
+				"gemini": {{Name: "gemini-2.5-pro-exp", Alias: "pro"}},
+			}},
+			perKey:    []string{"gemini-*"},
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := WarnAuthAliasExclusionConflicts(tt.auth, tt.cfg, tt.perKey, tt.authKind)
+			if len(got) != tt.wantCount {
+				t.Errorf("warning count: got %d, want %d; warnings=%v", len(got), tt.wantCount, got)
+			}
+			for _, want := range tt.wantSubstrings {
+				found := false
+				for _, w := range got {
+					if strings.Contains(w, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected warning containing %q, got %v", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestMatchExclusionWildcard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		pattern string
+		value   string
+		want    bool
+	}{
+		{"", "anything", false},
+		{"claude-opus-4-6", "claude-opus-4-6", true},
+		{"claude-opus-4-6", "claude-opus-4-7", false},
+		{"claude-*", "claude-opus-4-6-thinking", true},
+		{"claude-*", "gemini-2.5-pro", false},
+		{"*-thinking", "claude-opus-4-6-thinking", true},
+		{"*-thinking", "claude-opus-4-6", false},
+		{"claude-*-thinking", "claude-opus-4-6-thinking", true},
+		{"claude-*-thinking", "claude--thinking", true}, // empty middle segment between literal dashes
+		{"claude-*-thinking", "claude-thinking", false}, // missing inner dash separator
+		{"claude-*-*-thinking", "claude-opus-4-6-thinking", true},
+		{"*", "anything", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_vs_"+tt.value, func(t *testing.T) {
+			t.Parallel()
+			got := matchExclusionWildcard(tt.pattern, tt.value)
+			if got != tt.want {
+				t.Errorf("matchExclusionWildcard(%q, %q): got %v, want %v", tt.pattern, tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/geminicli"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -159,6 +161,9 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 	}
 	coreauth.ApplyCustomHeadersFromMetadata(a)
 	ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, "oauth")
+	for _, w := range WarnAuthAliasExclusionConflicts(a, cfg, perAccountExcluded, "oauth") {
+		log.Warnf("%s", w)
+	}
 	// For codex auth files, extract plan_type from the JWT id_token.
 	if provider == "codex" {
 		if idTokenRaw, ok := metadata["id_token"].(string); ok && strings.TrimSpace(idTokenRaw) != "" {
@@ -173,6 +178,9 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 		if virtuals := SynthesizeGeminiVirtualAuths(a, metadata, now); len(virtuals) > 0 {
 			for _, v := range virtuals {
 				ApplyAuthExcludedModelsMeta(v, cfg, perAccountExcluded, "oauth")
+				for _, w := range WarnAuthAliasExclusionConflicts(v, cfg, perAccountExcluded, "oauth") {
+					log.Warnf("%s", w)
+				}
 			}
 			out := make([]*coreauth.Auth, 0, 1+len(virtuals))
 			out = append(out, a)

--- a/internal/watcher/synthesizer/helpers.go
+++ b/internal/watcher/synthesizer/helpers.go
@@ -103,6 +103,95 @@ func ApplyAuthExcludedModelsMeta(auth *coreauth.Auth, cfg *config.Config, perKey
 	}
 }
 
+// WarnAuthAliasExclusionConflicts returns warnings for any oauth-model-alias
+// upstream that would be wildcard-blocked by this auth's per-account
+// excluded_models. Counterpart to validateOAuthAliasExclusions in
+// sdk/cliproxy (which handles provider-wide exclusions at config-load).
+//
+// Per-account exclusions live as auth attributes populated by
+// ApplyAuthExcludedModelsMeta, so this check only fires meaningfully at
+// synthesizer time when both the alias config and the auth's perKey list
+// are visible together. Returns nil when there's nothing to check.
+//
+// Caller logs each returned string at WARN level. Cardinality: one call per
+// synthesized auth file per synthesizer pass.
+func WarnAuthAliasExclusionConflicts(auth *coreauth.Auth, cfg *config.Config, perKey []string, authKind string) []string {
+	if auth == nil || cfg == nil || len(cfg.OAuthModelAlias) == 0 || len(perKey) == 0 {
+		return nil
+	}
+	channel := coreauth.OAuthModelAliasChannel(strings.TrimSpace(auth.Provider), authKind)
+	if channel == "" {
+		return nil
+	}
+	aliases := cfg.OAuthModelAlias[channel]
+	if len(aliases) == 0 {
+		return nil
+	}
+	authID := strings.TrimSpace(auth.ID)
+	if authID == "" {
+		authID = "<unknown>"
+	}
+	var warnings []string
+	for _, entry := range aliases {
+		upstream := strings.TrimSpace(entry.Name)
+		alias := strings.TrimSpace(entry.Alias)
+		if upstream == "" || alias == "" || strings.EqualFold(upstream, alias) {
+			continue
+		}
+		upstreamLower := strings.ToLower(upstream)
+		for _, pattern := range perKey {
+			p := strings.TrimSpace(pattern)
+			if p == "" {
+				continue
+			}
+			if matchExclusionWildcard(strings.ToLower(p), upstreamLower) {
+				warnings = append(warnings, fmt.Sprintf(
+					"oauth-model-alias: auth=%q channel=%q alias=%q upstream=%q matches per-account excluded-models pattern=%q — alias will not resolve at runtime",
+					authID, channel, alias, upstream, p,
+				))
+			}
+		}
+	}
+	return warnings
+}
+
+// matchExclusionWildcard performs case-insensitive wildcard matching where
+// '*' matches any substring. Inputs are expected pre-lowercased by callers.
+// Mirrors sdk/cliproxy.matchWildcard semantics; duplicated here to keep
+// this package's import surface narrow (no synthesizer -> sdk/cliproxy edge).
+func matchExclusionWildcard(pattern, value string) bool {
+	if pattern == "" {
+		return false
+	}
+	if !strings.Contains(pattern, "*") {
+		return pattern == value
+	}
+	parts := strings.Split(pattern, "*")
+	if prefix := parts[0]; prefix != "" {
+		if !strings.HasPrefix(value, prefix) {
+			return false
+		}
+		value = value[len(prefix):]
+	}
+	if suffix := parts[len(parts)-1]; suffix != "" {
+		if !strings.HasSuffix(value, suffix) {
+			return false
+		}
+		value = value[:len(value)-len(suffix)]
+	}
+	for _, segment := range parts[1 : len(parts)-1] {
+		if segment == "" {
+			continue
+		}
+		idx := strings.Index(value, segment)
+		if idx < 0 {
+			return false
+		}
+		value = value[idx+len(segment):]
+	}
+	return true
+}
+
 // addConfigHeadersToAttrs adds header configuration to auth attributes.
 // Headers are prefixed with "header:" in the attributes map.
 func addConfigHeadersToAttrs(headers map[string]string, attrs map[string]string) {

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
@@ -243,6 +245,9 @@ func (b *Builder) Build() (*Service, error) {
 	coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
 	coreManager.SetConfig(b.cfg)
 	coreManager.SetOAuthModelAlias(b.cfg.OAuthModelAlias)
+	for _, w := range validateOAuthAliasExclusions(b.cfg.OAuthModelAlias, b.cfg.OAuthExcludedModels) {
+		log.Warnf("%s", w)
+	}
 
 	service := &Service{
 		cfg:            b.cfg,

--- a/sdk/cliproxy/oauth_alias_validation.go
+++ b/sdk/cliproxy/oauth_alias_validation.go
@@ -1,0 +1,70 @@
+package cliproxy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// validateOAuthAliasExclusions returns human-readable warning strings for any
+// (channel, alias) -> upstream_name mapping in `aliases` whose upstream_name
+// matches any pattern in `excluded[channel]`. The match uses the same
+// case-insensitive wildcard semantics as routing-time exclusion via
+// matchWildcard.
+//
+// An alias that resolves to an excluded upstream silently fails at request
+// time with a generic "unknown provider for model" error. This surface fires
+// the warning at config-load and reload, before any request lands, so the
+// misconfiguration is visible at the boundary instead of at every request.
+//
+// Returns nil if no conflicts. Caller logs each entry at WARN level.
+//
+// Channel names match provider names for the alias-supported set
+// (vertex, claude, codex, antigravity, aistudio, gemini-cli, kimi); see
+// auth.OAuthModelAliasChannel. Per-account excluded_models stored as auth
+// attributes are not consulted here — they live at synthesizer time and need
+// a separate hook.
+func validateOAuthAliasExclusions(aliases map[string][]config.OAuthModelAlias, excluded map[string][]string) []string {
+	if len(aliases) == 0 || len(excluded) == 0 {
+		return nil
+	}
+	var warnings []string
+	for rawChannel, entries := range aliases {
+		channel := strings.ToLower(strings.TrimSpace(rawChannel))
+		if channel == "" || len(entries) == 0 {
+			continue
+		}
+		patterns := excluded[channel]
+		if len(patterns) == 0 {
+			continue
+		}
+		for _, entry := range entries {
+			upstream := strings.TrimSpace(entry.Name)
+			alias := strings.TrimSpace(entry.Alias)
+			if upstream == "" || alias == "" {
+				continue
+			}
+			// Mirror auth.compileOAuthModelAliasTable: self-aliases (upstream
+			// equals alias, case-insensitive) never enter the runtime table,
+			// so warning about them would be misleading.
+			if strings.EqualFold(upstream, alias) {
+				continue
+			}
+			upstreamLower := strings.ToLower(upstream)
+			for _, pattern := range patterns {
+				p := strings.TrimSpace(pattern)
+				if p == "" {
+					continue
+				}
+				if matchWildcard(strings.ToLower(p), upstreamLower) {
+					warnings = append(warnings, fmt.Sprintf(
+						"oauth-model-alias: alias=%q channel=%q upstream=%q matches provider-wide exclusion pattern=%q — alias will not resolve at runtime",
+						alias, channel, upstream, p,
+					))
+				}
+			}
+		}
+	}
+	return warnings
+}

--- a/sdk/cliproxy/oauth_alias_validation_test.go
+++ b/sdk/cliproxy/oauth_alias_validation_test.go
@@ -1,0 +1,186 @@
+package cliproxy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestValidateOAuthAliasExclusions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		aliases  map[string][]config.OAuthModelAlias
+		excluded map[string][]string
+		// wantSubstrings asserts each substring appears in at least one returned warning.
+		wantSubstrings []string
+		wantCount      int
+	}{
+		{
+			name:      "empty aliases returns nil",
+			aliases:   nil,
+			excluded:  map[string][]string{"claude": {"claude-*"}},
+			wantCount: 0,
+		},
+		{
+			name: "empty exclusions returns nil",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "claude-opus-4-6-thinking", Alias: "opus"}},
+			},
+			excluded:  nil,
+			wantCount: 0,
+		},
+		{
+			name: "wildcard matches alias upstream — same channel and provider",
+			aliases: map[string][]config.OAuthModelAlias{
+				"antigravity": {{Name: "claude-opus-4-6-thinking", Alias: "opus"}},
+			},
+			excluded:  map[string][]string{"antigravity": {"claude-*"}},
+			wantCount: 1,
+			wantSubstrings: []string{
+				`alias="opus"`,
+				`channel="antigravity"`,
+				`upstream="claude-opus-4-6-thinking"`,
+				`pattern="claude-*"`,
+			},
+		},
+		{
+			name: "exact match — no wildcard",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "claude-sonnet-4-5", Alias: "sonnet"}},
+			},
+			excluded:  map[string][]string{"claude": {"claude-sonnet-4-5"}},
+			wantCount: 1,
+			wantSubstrings: []string{
+				`alias="sonnet"`,
+				`upstream="claude-sonnet-4-5"`,
+				`pattern="claude-sonnet-4-5"`,
+			},
+		},
+		{
+			name: "non-matching upstream produces no warning",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "claude-haiku-4-5", Alias: "haiku"}},
+			},
+			excluded:  map[string][]string{"claude": {"claude-opus-*"}},
+			wantCount: 0,
+		},
+		{
+			name: "exclusion on different channel does not fire",
+			aliases: map[string][]config.OAuthModelAlias{
+				"antigravity": {{Name: "claude-opus-4-6-thinking", Alias: "opus"}},
+			},
+			excluded:  map[string][]string{"claude": {"claude-*"}},
+			wantCount: 0,
+		},
+		{
+			name: "case-insensitive matching against mixed-case upstream",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "Claude-Opus-4-6", Alias: "opus"}},
+			},
+			excluded:  map[string][]string{"claude": {"CLAUDE-*"}},
+			wantCount: 1,
+			wantSubstrings: []string{
+				`upstream="Claude-Opus-4-6"`,
+				`pattern="CLAUDE-*"`,
+			},
+		},
+		{
+			name: "thinking-suffix preserved in upstream — wildcard still matches",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "claude-sonnet-4-5-20250514(low)", Alias: "sonnet"}},
+			},
+			excluded:  map[string][]string{"claude": {"claude-sonnet-*"}},
+			wantCount: 1,
+		},
+		{
+			name: "multiple aliases, only one collides",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {
+					{Name: "claude-opus-4-6-thinking", Alias: "opus"},
+					{Name: "claude-haiku-4-5", Alias: "haiku"},
+				},
+			},
+			excluded:  map[string][]string{"claude": {"claude-opus-*"}},
+			wantCount: 1,
+			wantSubstrings: []string{
+				`alias="opus"`,
+			},
+		},
+		{
+			name: "empty pattern is skipped",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "claude-opus-4-6", Alias: "opus"}},
+			},
+			excluded:  map[string][]string{"claude": {"", "claude-*"}},
+			wantCount: 1,
+		},
+		{
+			name: "empty alias name is skipped",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "", Alias: "opus"}, {Name: "claude-opus-4-6", Alias: ""}},
+			},
+			excluded:  map[string][]string{"claude": {"claude-*"}},
+			wantCount: 0,
+		},
+		{
+			name: "channel key is normalized to lowercase",
+			aliases: map[string][]config.OAuthModelAlias{
+				" CLAUDE ": {{Name: "claude-opus-4-6", Alias: "opus"}},
+			},
+			excluded:  map[string][]string{"claude": {"claude-*"}},
+			wantCount: 1,
+		},
+		{
+			name: "Daniel's documented case — antigravity per-channel exclusion blocks claude aliases (self-alias filtered)",
+			aliases: map[string][]config.OAuthModelAlias{
+				"antigravity": {
+					{Name: "claude-opus-4-6-thinking", Alias: "opus"},
+					{Name: "claude-opus-4-6-thinking", Alias: "opus[1m]"},
+					// Self-alias is filtered to mirror compileOAuthModelAliasTable's
+					// behavior — never enters the runtime table.
+					{Name: "claude-opus-4-6-thinking", Alias: "claude-opus-4-6-thinking"},
+				},
+			},
+			excluded:  map[string][]string{"antigravity": {"claude-*"}},
+			wantCount: 2,
+			wantSubstrings: []string{
+				`alias="opus"`,
+				`alias="opus[1m]"`,
+			},
+		},
+		{
+			name: "self-alias is filtered (case-insensitive) regardless of exclusion match",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "Claude-Opus-4-6", Alias: "claude-opus-4-6"}},
+			},
+			excluded:  map[string][]string{"claude": {"claude-*"}},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := validateOAuthAliasExclusions(tt.aliases, tt.excluded)
+			if len(got) != tt.wantCount {
+				t.Errorf("warning count: got %d, want %d; warnings=%v", len(got), tt.wantCount, got)
+			}
+			for _, want := range tt.wantSubstrings {
+				found := false
+				for _, w := range got {
+					if strings.Contains(w, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected warning containing %q, got %v", want, got)
+				}
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -684,6 +684,9 @@ func (s *Service) Run(ctx context.Context) error {
 		if s.coreManager != nil {
 			s.coreManager.SetConfig(newCfg)
 			s.coreManager.SetOAuthModelAlias(newCfg.OAuthModelAlias)
+			for _, w := range validateOAuthAliasExclusions(newCfg.OAuthModelAlias, newCfg.OAuthExcludedModels) {
+				log.Warnf("%s", w)
+			}
 		}
 		s.rebindExecutors()
 	}


### PR DESCRIPTION
## Summary

`oauth-model-alias` and excluded-models populate independently in two layers, with no cross-validation. When an alias's upstream model name matches an exclusion pattern (provider-wide or per-account), the alias silently fails at request time with a generic `"unknown provider for model"` error. The misconfig is invisible until traffic hits.

This PR adds warning surfaces at both layers:

- **Layer 1 — config-load** (`sdk/cliproxy/oauth_alias_validation.go`): walks `cfg.OAuthModelAlias` against `cfg.OAuthExcludedModels[channel]` whenever `SetOAuthModelAlias` is called (initial startup in `builder.go:245`, config reload in `service.go:686`). Catches global provider-wide misconfigs.
- **Layer 2 — synthesizer-time** (`internal/watcher/synthesizer/helpers.go`): walks `cfg.OAuthModelAlias[channel]` against the auth file's per-account `excluded_models` whenever an OAuth auth is synthesized (both call sites in `file.go`). Catches the per-account JSON-file case.

Both layers use the same case-insensitive wildcard semantics as routing-time exclusion (`matchWildcard`), and both mirror `auth.compileOAuthModelAliasTable`'s self-alias filter — they only warn about entries that would actually enter the runtime alias table.

Warnings are non-fatal. Logged at WARN via the existing `logrus` setup. Ops sees the misconfig at the config boundary instead of at every request.

## Why two layers?

The two exclusion sources have different lifetimes and different visibilities:

| Layer | Source | Visible at | Caught here |
|---|---|---|---|
| Provider-wide | `cfg.OAuthExcludedModels[channel]` | config load / reload | Layer 1 |
| Per-account | auth file's `excluded-models` JSON field, merged into auth attributes | synthesizer pass | Layer 2 |

A single layer doesn't see the other's data. Provider-wide is global config; per-account lives in the auth JSON file. Both can independently block alias resolution; both now warn.

## Test plan

- [x] `go test ./internal/watcher/synthesizer/... ./sdk/cliproxy/... -count=1` — green
- [x] `go test ./internal/watcher/... ./sdk/... -count=1` — green
- [x] `go vet` — clean
- [x] `gofmt -l` — clean
- [x] 13 table-driven tests for Layer 1 in `oauth_alias_validation_test.go`
- [x] 12 table-driven tests for Layer 2 in `alias_exclusion_test.go` (including the originating real-world case: antigravity per-account `claude-*` blocking `claude-opus-4-6-thinking` aliases)
- [x] 12 wildcard primitive tests in `TestMatchExclusionWildcard`

## Files

```
 internal/watcher/synthesizer/alias_exclusion_test.go | 195 +++++++++++++++++++
 internal/watcher/synthesizer/file.go                 |   8 +
 internal/watcher/synthesizer/helpers.go              |  89 +++++++++
 sdk/cliproxy/builder.go                              |   5 +
 sdk/cliproxy/oauth_alias_validation.go               |  77 ++++++++
 sdk/cliproxy/oauth_alias_validation_test.go          | 179 ++++++++++++++++++
 sdk/cliproxy/service.go                              |   3 +
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)