### PR TITLE
fix(codex): normalize spawn_agent session id schema

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -185,6 +185,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = normalizeCodexSpawnAgentSessionIDToolSchema(body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -336,6 +337,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = normalizeCodexSpawnAgentSessionIDToolSchema(body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses/compact"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -434,6 +436,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = normalizeCodexSpawnAgentSessionIDToolSchema(body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)

--- a/internal/runtime/executor/codex_spawn_agent_session_id.go
+++ b/internal/runtime/executor/codex_spawn_agent_session_id.go
@@ -1,0 +1,65 @@
+package executor
+
+import (
+	"fmt"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+var codexSpawnAgentSessionIDSchemaJSON = []byte(`{"type":["string","null"],"default":null,"description":"Existing subagent session id to continue. For creating a new subagent, omit this field or set it to JSON null. Never use empty string, /null, <null>, string null, or whitespace."}`)
+
+func normalizeCodexSpawnAgentSessionIDToolSchema(rawJSON []byte) []byte {
+	tools := gjson.GetBytes(rawJSON, "tools")
+	if !tools.IsArray() {
+		return rawJSON
+	}
+
+	result := rawJSON
+	for i, tool := range tools.Array() {
+		if tool.Get("type").String() != "function" || tool.Get("name").String() != "spawn_agent" {
+			continue
+		}
+
+		schemaPath := fmt.Sprintf("tools.%d.parameters.properties.session_id", i)
+		if !gjson.GetBytes(result, schemaPath).Exists() {
+			continue
+		}
+		if updated, err := sjson.SetRawBytes(result, schemaPath, codexSpawnAgentSessionIDSchemaJSON); err == nil {
+			result = updated
+		}
+
+		requiredPath := fmt.Sprintf("tools.%d.parameters.required", i)
+		result = removeCodexRequiredToolField(result, requiredPath, "session_id")
+	}
+	return result
+}
+
+func removeCodexRequiredToolField(rawJSON []byte, path string, field string) []byte {
+	required := gjson.GetBytes(rawJSON, path)
+	if !required.IsArray() {
+		return rawJSON
+	}
+
+	changed := false
+	filtered := []byte(`[]`)
+	for _, item := range required.Array() {
+		value := item.String()
+		if value == field {
+			changed = true
+			continue
+		}
+		if updated, err := sjson.SetBytes(filtered, "-1", value); err == nil {
+			filtered = updated
+		}
+	}
+	if !changed {
+		return rawJSON
+	}
+
+	updated, err := sjson.SetRawBytes(rawJSON, path, filtered)
+	if err != nil {
+		return rawJSON
+	}
+	return updated
+}

--- a/internal/runtime/executor/codex_spawn_agent_session_id_test.go
+++ b/internal/runtime/executor/codex_spawn_agent_session_id_test.go
@@ -1,0 +1,55 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestNormalizeCodexSpawnAgentSessionIDToolSchema(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gpt-5.5",
+		"tools": [
+			{
+				"type": "function",
+				"name": "diagnostics",
+				"parameters": {"type":"object","properties":{}}
+			},
+			{
+				"type": "function",
+				"name": "spawn_agent",
+				"parameters": {
+					"type": "object",
+					"required": ["label", "message", "session_id"],
+					"properties": {
+						"label": {"type": "string"},
+						"message": {"type": "string"},
+						"session_id": {
+							"type": "string",
+							"default": null,
+							"nullable": true,
+							"description": "Session ID of an existing agent session."
+						}
+					}
+				}
+			}
+		]
+	}`)
+
+	output := normalizeCodexSpawnAgentSessionIDToolSchema(inputJSON)
+
+	if got := gjson.GetBytes(output, "tools.1.parameters.properties.session_id.type.0").String(); got != "string" {
+		t.Fatalf("session_id type[0] = %q, want string: %s", got, string(output))
+	}
+	if got := gjson.GetBytes(output, "tools.1.parameters.properties.session_id.type.1").String(); got != "null" {
+		t.Fatalf("session_id type[1] = %q, want null: %s", got, string(output))
+	}
+	if gjson.GetBytes(output, "tools.1.parameters.properties.session_id.nullable").Exists() {
+		t.Fatalf("session_id nullable should be removed: %s", string(output))
+	}
+	for _, required := range gjson.GetBytes(output, "tools.1.parameters.required").Array() {
+		if required.String() == "session_id" {
+			t.Fatalf("session_id should not be required: %s", string(output))
+		}
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -194,6 +194,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = normalizeCodexSpawnAgentSessionIDToolSchema(body)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
@@ -394,6 +395,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = normalizeCodexSpawnAgentSessionIDToolSchema(body)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)


### PR DESCRIPTION
## Summary
- Normalize the `spawn_agent.session_id` tool schema at the Codex executor request boundary.
- Allow JSON null for `session_id` and remove it from required fields so clients can create new subagents without invalid placeholder strings.
- Add executor-level regression coverage for the request schema normalization.

## Test Plan
- [x] `go test ./internal/runtime/executor -run "SpawnAgentSessionID|Codex" -count=1`
- [x] `go build -o C:\Users\Atop\Desktop\cliproxyapi-debug\CLIProxyAPI\build\cliproxyapi-spawn-agent-schema-fix.exe .\cmd\server`
- [x] `git diff --check origin/main...HEAD`

## Notes
This fixes Zed subagent failures observed with Codex-backed Responses tools. Local testing showed the request-side schema normalization is sufficient; response-side argument rewriting was removed from this PR.