### PR TITLE
fix(codex): keep responses websocket across recoverable upstream disconnects

### DIFF
--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -77,8 +77,9 @@ type codexWebsocketSession struct {
 
 	readerConn *websocket.Conn
 
-	upstreamDisconnectOnce sync.Once
-	upstreamDisconnectCh   chan error
+	upstreamDisconnectMu     sync.Mutex
+	upstreamDisconnectCh     chan error
+	upstreamDisconnectClosed bool
 }
 
 func NewCodexWebsocketsExecutor(cfg *config.Config) *CodexWebsocketsExecutor {
@@ -158,16 +159,30 @@ func (s *codexWebsocketSession) notifyUpstreamDisconnect(err error) {
 	if s == nil {
 		return
 	}
-	s.upstreamDisconnectOnce.Do(func() {
-		if s.upstreamDisconnectCh == nil {
-			return
-		}
-		select {
-		case s.upstreamDisconnectCh <- err:
-		default:
-		}
-		close(s.upstreamDisconnectCh)
-	})
+	s.upstreamDisconnectMu.Lock()
+	defer s.upstreamDisconnectMu.Unlock()
+	if s.upstreamDisconnectCh == nil || s.upstreamDisconnectClosed {
+		return
+	}
+	select {
+	case s.upstreamDisconnectCh <- err:
+	default:
+	}
+	close(s.upstreamDisconnectCh)
+	s.upstreamDisconnectClosed = true
+}
+
+func (s *codexWebsocketSession) upstreamDisconnectChan() <-chan error {
+	if s == nil {
+		return nil
+	}
+	s.upstreamDisconnectMu.Lock()
+	defer s.upstreamDisconnectMu.Unlock()
+	if s.upstreamDisconnectCh == nil || s.upstreamDisconnectClosed {
+		s.upstreamDisconnectCh = make(chan error, 1)
+		s.upstreamDisconnectClosed = false
+	}
+	return s.upstreamDisconnectCh
 }
 
 func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
@@ -291,7 +306,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
 		if sess != nil {
-			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
+			e.invalidateUpstreamConn(sess, conn, "send_error", errSend, false)
 
 			// Retry once with a fresh websocket connection. This is mainly to handle
 			// upstream closing the socket between sequential requests within the same
@@ -315,7 +330,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 					conn = connRetry
 					wsReqBody = wsReqBodyRetry
 				} else {
-					e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry)
+					e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry, false)
 					helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
 					return resp, errSendRetry
 				}
@@ -343,7 +358,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			if msgType == websocket.BinaryMessage {
 				err = fmt.Errorf("codex websockets executor: unexpected binary message")
 				if sess != nil {
-					e.invalidateUpstreamConn(sess, conn, "unexpected_binary", err)
+					e.invalidateUpstreamConn(sess, conn, "unexpected_binary", err, true)
 				}
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "unexpected_binary", err)
 				return resp, err
@@ -359,7 +374,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 
 		if wsErr, ok := parseCodexWebsocketError(payload); ok {
 			if sess != nil {
-				e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
+				e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr, true)
 			}
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
 			return resp, wsErr
@@ -488,7 +503,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
 		if sess != nil {
-			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
+			e.invalidateUpstreamConn(sess, conn, "send_error", errSend, false)
 
 			// Retry once with a new websocket connection for the same execution session.
 			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
@@ -514,7 +529,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			recordAPIWebsocketHandshake(ctx, e.cfg, respHSRetry)
 			if errSendRetry := writeCodexWebsocketMessage(sess, connRetry, wsReqBodyRetry); errSendRetry != nil {
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
-				e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry)
+				e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry, false)
 				sess.clearActive(readCh)
 				sess.reqMu.Unlock()
 				return nil, errSendRetry
@@ -592,7 +607,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 					helps.RecordAPIWebsocketError(ctx, e.cfg, "unexpected_binary", err)
 					reporter.PublishFailure(ctx)
 					if sess != nil {
-						e.invalidateUpstreamConn(sess, conn, "unexpected_binary", err)
+						e.invalidateUpstreamConn(sess, conn, "unexpected_binary", err, true)
 					}
 					_ = send(cliproxyexecutor.StreamChunk{Err: err})
 					return
@@ -612,7 +627,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
 				reporter.PublishFailure(ctx)
 				if sess != nil {
-					e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
+					e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr, true)
 				}
 				_ = send(cliproxyexecutor.StreamChunk{Err: wsErr})
 				return
@@ -1253,7 +1268,7 @@ func (e *CodexWebsocketsExecutor) UpstreamDisconnectChan(sessionID string) <-cha
 	if sess == nil {
 		return nil
 	}
-	return sess.upstreamDisconnectCh
+	return sess.upstreamDisconnectChan()
 }
 
 func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, authID string, wsURL string, headers http.Header) (*websocket.Conn, *http.Response, error) {
@@ -1314,6 +1329,7 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 			ch := sess.activeCh
 			done := sess.activeDone
 			sess.activeMu.Unlock()
+			notifyDisconnect := ch == nil
 			if ch != nil {
 				select {
 				case ch <- codexWebsocketRead{conn: conn, err: errRead}:
@@ -1323,7 +1339,7 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 				sess.clearActive(ch)
 				close(ch)
 			}
-			e.invalidateUpstreamConn(sess, conn, "upstream_disconnected", errRead)
+			e.invalidateUpstreamConn(sess, conn, "upstream_disconnected", errRead, notifyDisconnect)
 			return
 		}
 
@@ -1343,7 +1359,7 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 					sess.clearActive(ch)
 					close(ch)
 				}
-				e.invalidateUpstreamConn(sess, conn, "unexpected_binary", errBinary)
+				e.invalidateUpstreamConn(sess, conn, "unexpected_binary", errBinary, true)
 				return
 			}
 			continue
@@ -1363,7 +1379,7 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 	}
 }
 
-func (e *CodexWebsocketsExecutor) invalidateUpstreamConn(sess *codexWebsocketSession, conn *websocket.Conn, reason string, err error) {
+func (e *CodexWebsocketsExecutor) invalidateUpstreamConn(sess *codexWebsocketSession, conn *websocket.Conn, reason string, err error, notifyDisconnect bool) {
 	if sess == nil || conn == nil {
 		return
 	}
@@ -1384,7 +1400,9 @@ func (e *CodexWebsocketsExecutor) invalidateUpstreamConn(sess *codexWebsocketSes
 	sess.connMu.Unlock()
 
 	logCodexWebsocketDisconnected(sessionID, authID, wsURL, reason, err)
-	sess.notifyUpstreamDisconnect(err)
+	if notifyDisconnect {
+		sess.notifyUpstreamDisconnect(err)
+	}
 	if errClose := conn.Close(); errClose != nil {
 		log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 	}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -1460,6 +1460,9 @@ func (e *CodexWebsocketsExecutor) closeAllExecutionSessions(reason string) {
 }
 
 func (e *CodexWebsocketsExecutor) closeExecutionSession(sess *codexWebsocketSession, reason string) {
+	if sess != nil {
+		sess.notifyUpstreamDisconnect(fmt.Errorf("codex websocket session closed: %s", strings.TrimSpace(reason)))
+	}
 	closeCodexWebsocketSession(sess, reason)
 }
 

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -93,7 +93,7 @@ func TestCodexWebsocketsExecutePreservesPreviousResponseIDUpstream(t *testing.T)
 	}
 }
 
-func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) {
+func TestCodexWebsocketsUpstreamDisconnectChanIgnoresRetryableInvalidate(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
@@ -136,7 +136,30 @@ func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) 
 	sess.connMu.Unlock()
 
 	upstreamErr := errors.New("upstream gone")
-	exec.invalidateUpstreamConn(sess, conn, "test_invalidate", upstreamErr)
+	exec.invalidateUpstreamConn(sess, conn, "test_invalidate", upstreamErr, false)
+
+	select {
+	case errRead, ok := <-disconnectCh:
+		t.Fatalf("unexpected disconnect signal ok=%v err=%v", ok, errRead)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestCodexWebsocketsUpstreamDisconnectChanSignalsAndResets(t *testing.T) {
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	sessionID := "sess-reset"
+	disconnectCh := exec.UpstreamDisconnectChan(sessionID)
+	if disconnectCh == nil {
+		t.Fatal("expected disconnect channel")
+	}
+
+	sess := exec.getOrCreateSession(sessionID)
+	if sess == nil {
+		t.Fatal("expected session")
+	}
+
+	upstreamErr := errors.New("upstream gone")
+	sess.notifyUpstreamDisconnect(upstreamErr)
 
 	select {
 	case errRead, ok := <-disconnectCh:
@@ -148,6 +171,22 @@ func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) 
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for disconnect signal")
+	}
+	if _, ok := <-disconnectCh; ok {
+		t.Fatal("expected first disconnect channel to close")
+	}
+
+	nextCh := exec.UpstreamDisconnectChan(sessionID)
+	if nextCh == nil {
+		t.Fatal("expected replacement disconnect channel")
+	}
+	if nextCh == disconnectCh {
+		t.Fatal("expected replacement disconnect channel after prior close")
+	}
+	select {
+	case errRead, ok := <-nextCh:
+		t.Fatalf("replacement channel was already closed or signaled ok=%v err=%v", ok, errRead)
+	default:
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -190,6 +190,32 @@ func TestCodexWebsocketsUpstreamDisconnectChanSignalsAndResets(t *testing.T) {
 	}
 }
 
+func TestCodexWebsocketsCloseExecutionSessionSignalsDisconnect(t *testing.T) {
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	sessionID := "sess-close"
+	disconnectCh := exec.UpstreamDisconnectChan(sessionID)
+	if disconnectCh == nil {
+		t.Fatal("expected disconnect channel")
+	}
+
+	exec.CloseExecutionSession(sessionID)
+
+	select {
+	case errRead, ok := <-disconnectCh:
+		if !ok {
+			t.Fatal("expected disconnect channel to deliver error before closing")
+		}
+		if errRead == nil || !strings.Contains(errRead.Error(), "session_closed") {
+			t.Fatalf("disconnect error = %v, want session_closed", errRead)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for disconnect signal")
+	}
+	if _, ok := <-disconnectCh; ok {
+		t.Fatal("expected disconnect channel to close")
+	}
+}
+
 func TestApplyCodexWebsocketHeadersDefaultsToCurrentResponsesBeta(t *testing.T) {
 	headers := applyCodexWebsocketHeaders(context.Background(), http.Header{}, nil, "", nil)
 

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -57,30 +57,6 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 	clientIP := websocketClientAddress(c)
 	log.Infof("responses websocket: client connected id=%s remote=%s", passthroughSessionID, clientIP)
 
-	wsDone := make(chan struct{})
-	defer close(wsDone)
-
-	if h != nil && h.AuthManager != nil {
-		if exec, ok := h.AuthManager.Executor("codex"); ok && exec != nil {
-			type upstreamDisconnectSubscriber interface {
-				UpstreamDisconnectChan(sessionID string) <-chan error
-			}
-			if subscriber, ok := exec.(upstreamDisconnectSubscriber); ok && subscriber != nil {
-				disconnectCh := subscriber.UpstreamDisconnectChan(passthroughSessionID)
-				if disconnectCh != nil {
-					go func() {
-						select {
-						case <-wsDone:
-							return
-						case <-disconnectCh:
-							_ = conn.Close()
-						}
-					}()
-				}
-			}
-		}
-	}
-
 	var wsTerminateErr error
 	var wsTimelineLog strings.Builder
 	defer func() {

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -85,79 +85,6 @@ func (e websocketPinnedFailoverStatusError) Error() string { return e.msg }
 
 func (e websocketPinnedFailoverStatusError) StatusCode() int { return e.status }
 
-type websocketUpstreamDisconnectExecutor struct {
-	mu         sync.Mutex
-	subscribed chan string
-	sessions   map[string]chan error
-}
-
-func (e *websocketUpstreamDisconnectExecutor) Identifier() string { return "codex" }
-
-func (e *websocketUpstreamDisconnectExecutor) UpstreamDisconnectChan(sessionID string) <-chan error {
-	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" {
-		return nil
-	}
-	e.mu.Lock()
-	if e.sessions == nil {
-		e.sessions = make(map[string]chan error)
-	}
-	ch, ok := e.sessions[sessionID]
-	if !ok {
-		ch = make(chan error, 1)
-		e.sessions[sessionID] = ch
-	}
-	subscribed := e.subscribed
-	e.mu.Unlock()
-
-	if subscribed != nil {
-		select {
-		case subscribed <- sessionID:
-		default:
-		}
-	}
-	return ch
-}
-
-func (e *websocketUpstreamDisconnectExecutor) TriggerDisconnect(sessionID string, err error) {
-	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" {
-		return
-	}
-	e.mu.Lock()
-	ch := e.sessions[sessionID]
-	delete(e.sessions, sessionID)
-	e.mu.Unlock()
-	if ch == nil {
-		return
-	}
-	select {
-	case ch <- err:
-	default:
-	}
-	close(ch)
-}
-
-func (e *websocketUpstreamDisconnectExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
-	return coreexecutor.Response{}, errors.New("not implemented")
-}
-
-func (e *websocketUpstreamDisconnectExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (e *websocketUpstreamDisconnectExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
-	return auth, nil
-}
-
-func (e *websocketUpstreamDisconnectExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
-	return coreexecutor.Response{}, errors.New("not implemented")
-}
-
-func (e *websocketUpstreamDisconnectExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
-	return nil, errors.New("not implemented")
-}
-
 func (e *websocketAuthCaptureExecutor) Identifier() string { return "test-provider" }
 
 func (e *websocketAuthCaptureExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
@@ -1004,43 +931,6 @@ func TestResponsesWebsocketTimelineRecordsDisconnectEvent(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for websocket timeline")
-	}
-}
-
-func TestResponsesWebsocketClosesOnCodexUpstreamDisconnect(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	executor := &websocketUpstreamDisconnectExecutor{subscribed: make(chan string, 1)}
-	manager := coreauth.NewManager(nil, nil, nil)
-	manager.RegisterExecutor(executor)
-	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
-	h := NewOpenAIResponsesAPIHandler(base)
-
-	router := gin.New()
-	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
-	server := httptest.NewServer(router)
-	defer server.Close()
-
-	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
-	if err != nil {
-		t.Fatalf("dial websocket: %v", err)
-	}
-	defer func() { _ = conn.Close() }()
-
-	var sessionID string
-	select {
-	case sessionID = <-executor.subscribed:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for upstream disconnect subscription")
-	}
-
-	executor.TriggerDisconnect(sessionID, errors.New("upstream disconnected"))
-
-	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	_, _, err = conn.ReadMessage()
-	if err == nil {
-		t.Fatalf("expected downstream websocket to close after upstream disconnect")
 	}
 }
 


### PR DESCRIPTION
## Summary
- avoid closing downstream /v1/responses/ws connections for retryable Codex upstream websocket resets
- reset the upstream disconnect channel when a session ID is reused after a terminal disconnect
- remove the downstream handler subscription that closed clients on any upstream disconnect signal

## Context
This fixes regressions from fb08b92402187cd87f888d371ee5d6f5107f6d36 where recoverable upstream websocket reconnects could terminate downstream websocket clients, and reused session IDs could subscribe to an already-closed disconnect channel.

## Tests
- go test ./internal/runtime/executor -run 'TestCodexWebsocketsUpstreamDisconnectChan|TestCodexWebsockets.*' -count=1
- go test ./sdk/api/handlers/openai -run 'TestResponsesWebsocket|TestWebsocketUpstream' -count=1
- go build -o test-output ./cmd/server && rm test-output
- git diff --check