### PR TITLE
fix(openai): preserve Codex HTTP compact evidence

### DIFF
--- a/internal/logging/global_logger.go
+++ b/internal/logging/global_logger.go
@@ -30,7 +30,39 @@ var (
 type LogFormatter struct{}
 
 // logFieldOrder defines the display order for common log fields.
-var logFieldOrder = []string{"provider", "model", "mode", "budget", "level", "original_mode", "original_value", "min", "max", "clamped_to", "error"}
+var logFieldOrder = []string{
+	"provider",
+	"model",
+	"mode",
+	"budget",
+	"level",
+	"original_mode",
+	"original_value",
+	"min",
+	"max",
+	"clamped_to",
+	"route_kind",
+	"compact_request",
+	"has_previous_response_id",
+	"scope_present",
+	"binding_result",
+	"repair_result",
+	"input_item_count",
+	"assistant_message_count",
+	"function_call_count",
+	"function_call_output_count",
+	"compact_output_has_evidence",
+	"same_turn_evidence_hit",
+	"compact_response_evidence_augmented",
+	"recent_evidence_hit",
+	"compact_evidence_augmented",
+	"fail_reason",
+	"bound_output_item_count",
+	"bound_output_assistant_count",
+	"bound_output_tool_call_count",
+	"bound_output_tool_output_count",
+	"error",
+}
 
 // Format renders a single log entry with custom formatting.
 func (m *LogFormatter) Format(entry *log.Entry) ([]byte, error) {

--- a/internal/logging/global_logger_test.go
+++ b/internal/logging/global_logger_test.go
@@ -1,0 +1,87 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestLogFormatterIncludesCodexDirectHTTPCompactDiagnosticFields(t *testing.T) {
+	entry := &log.Entry{
+		Time:    time.Date(2026, 5, 7, 14, 30, 0, 0, time.UTC),
+		Level:   log.InfoLevel,
+		Message: "codex direct http compact evidence diagnostic",
+		Data: log.Fields{
+			"route_kind":                          "compact",
+			"compact_request":                     true,
+			"has_previous_response_id":            false,
+			"scope_present":                       true,
+			"binding_result":                      "none",
+			"repair_result":                       "none",
+			"input_item_count":                    6,
+			"assistant_message_count":             1,
+			"function_call_count":                 2,
+			"function_call_output_count":          2,
+			"compact_output_has_evidence":         false,
+			"same_turn_evidence_hit":              true,
+			"compact_response_evidence_augmented": true,
+			"recent_evidence_hit":                 false,
+			"compact_evidence_augmented":          true,
+			"fail_reason":                         "none",
+			"bound_output_item_count":             6,
+			"bound_output_assistant_count":        1,
+			"bound_output_tool_call_count":        2,
+			"bound_output_tool_output_count":      2,
+			"raw_prompt":                          "do not print prompt",
+			"response_id":                         "resp_do_not_print",
+			"auth_id":                             "auth_do_not_print",
+			"tool_arguments":                      "{}",
+			"message_text":                        "do not print message",
+		},
+	}
+
+	formatted, errFormat := (&LogFormatter{}).Format(entry)
+	if errFormat != nil {
+		t.Fatalf("Format returned error: %v", errFormat)
+	}
+	line := string(formatted)
+	for _, want := range []string{
+		"route_kind=compact",
+		"compact_request=true",
+		"has_previous_response_id=false",
+		"scope_present=true",
+		"binding_result=none",
+		"repair_result=none",
+		"input_item_count=6",
+		"assistant_message_count=1",
+		"function_call_count=2",
+		"function_call_output_count=2",
+		"compact_output_has_evidence=false",
+		"same_turn_evidence_hit=true",
+		"compact_response_evidence_augmented=true",
+		"recent_evidence_hit=false",
+		"compact_evidence_augmented=true",
+		"fail_reason=none",
+		"bound_output_item_count=6",
+		"bound_output_assistant_count=1",
+		"bound_output_tool_call_count=2",
+		"bound_output_tool_output_count=2",
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("formatted log missing %q: %s", want, line)
+		}
+	}
+	for _, forbidden := range []string{
+		"do not print prompt",
+		"resp_do_not_print",
+		"auth_do_not_print",
+		"tool_arguments",
+		"message_text",
+	} {
+		if strings.Contains(line, forbidden) {
+			t.Fatalf("formatted log leaked %q: %s", forbidden, line)
+		}
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_direct_continuation.go
+++ b/sdk/api/handlers/openai/openai_responses_direct_continuation.go
@@ -63,10 +63,11 @@ type codexDirectContinuationTracker struct {
 	scopeKey       string
 	compactRequest bool
 
-	mu                  sync.Mutex
-	authID              string
-	outputItemsByIndex  map[int64][]byte
-	outputItemsFallback [][]byte
+	mu                        sync.Mutex
+	authID                    string
+	compactEvidenceDiagnostic codexDirectCompactEvidenceDiagnostic
+	outputItemsByIndex        map[int64][]byte
+	outputItemsFallback       [][]byte
 }
 
 type codexDirectContinuationSnapshot struct {
@@ -79,6 +80,13 @@ type codexDirectEvidenceCounts struct {
 	assistantMessageCount   int
 	functionCallCount       int
 	functionCallOutputCount int
+}
+
+type codexDirectCompactEvidenceDiagnostic struct {
+	enabled                          bool
+	compactOutputHasEvidence         bool
+	sameTurnEvidenceHit              bool
+	compactResponseEvidenceAugmented bool
 }
 
 func (h *OpenAIResponsesAPIHandler) prepareCodexDirectContinuationContext(c *gin.Context, rawJSON []byte, modelName string, ctx context.Context) (context.Context, []byte, *codexDirectContinuationTracker, bool) {
@@ -126,6 +134,11 @@ func (h *OpenAIResponsesAPIHandler) prepareCodexDirectContinuationContext(c *gin
 	}
 
 	if tracker.compactRequest {
+		if _, _, errEvidence := codexDirectSameTurnEvidenceJSON(requestJSON); errEvidence != nil {
+			tracker.logDecision(requestJSON, "none", "failed", codexDirectContinuationRepairFailReason(errEvidence))
+			writeCodexDirectCompactEvidenceError(c)
+			return ctx, nil, nil, false
+		}
 		tracker.logDecision(requestJSON, "none", "none", "none")
 	}
 
@@ -182,6 +195,7 @@ func (t *codexDirectContinuationTracker) bindResponseIDs(payload []byte) {
 			snapshot.responseOutputJSON,
 			t.routeKind,
 			t.compactRequest,
+			t.getCompactEvidenceDiagnostic(),
 		)
 	}
 }
@@ -309,6 +323,63 @@ func (t *codexDirectContinuationTracker) getAuthID() string {
 	return t.authID
 }
 
+func (t *codexDirectContinuationTracker) compactResponseWithSameTurnEvidence(payload []byte) ([]byte, error) {
+	if t == nil || !t.compactRequest {
+		return payload, nil
+	}
+
+	outputJSON := codexDirectResponseOutputJSON(gjson.ParseBytes(payload))
+	compactOutputHasEvidence := codexDirectOutputHasAssistantOrToolEvidence(outputJSON)
+	evidenceJSON, sameTurnEvidenceHit, errEvidence := codexDirectSameTurnEvidenceJSON(t.requestJSON)
+	if errEvidence != nil {
+		t.setCompactEvidenceDiagnostic(codexDirectCompactEvidenceDiagnostic{
+			enabled:                  true,
+			compactOutputHasEvidence: compactOutputHasEvidence,
+		})
+		return nil, errEvidence
+	}
+
+	diagnostic := codexDirectCompactEvidenceDiagnostic{
+		enabled:                  true,
+		compactOutputHasEvidence: compactOutputHasEvidence,
+		sameTurnEvidenceHit:      sameTurnEvidenceHit,
+	}
+	if !compactOutputHasEvidence && sameTurnEvidenceHit {
+		mergedOutput, errMerge := mergeJSONArrayRaw(string(outputJSON), evidenceJSON)
+		if errMerge != nil {
+			t.setCompactEvidenceDiagnostic(diagnostic)
+			return nil, fmt.Errorf("merge compact same-turn evidence: %w", errMerge)
+		}
+		updated, errSet := codexDirectSetResponseOutputJSON(payload, []byte(mergedOutput))
+		if errSet != nil {
+			t.setCompactEvidenceDiagnostic(diagnostic)
+			return nil, fmt.Errorf("set compact response output: %w", errSet)
+		}
+		payload = updated
+		diagnostic.compactResponseEvidenceAugmented = true
+	}
+	t.setCompactEvidenceDiagnostic(diagnostic)
+	return payload, nil
+}
+
+func (t *codexDirectContinuationTracker) setCompactEvidenceDiagnostic(diagnostic codexDirectCompactEvidenceDiagnostic) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.compactEvidenceDiagnostic = diagnostic
+	t.mu.Unlock()
+}
+
+func (t *codexDirectContinuationTracker) getCompactEvidenceDiagnostic() codexDirectCompactEvidenceDiagnostic {
+	if t == nil {
+		return codexDirectCompactEvidenceDiagnostic{}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.compactEvidenceDiagnostic
+}
+
 func (t *codexDirectContinuationTracker) logDecision(requestJSON []byte, bindingResult, repairResult, failReason string) {
 	if t == nil {
 		return
@@ -330,7 +401,7 @@ func (t *codexDirectContinuationTracker) logDecision(requestJSON []byte, binding
 	log.WithFields(fields).Info("codex direct http continuation diagnostic")
 }
 
-func (s *codexDirectContinuationStore) bind(responseID, authID, modelName, scopeKey string, requestJSON []byte, responseOutputJSON []byte, routeKind string, allowRecentEvidenceAugmentation bool) {
+func (s *codexDirectContinuationStore) bind(responseID, authID, modelName, scopeKey string, requestJSON []byte, responseOutputJSON []byte, routeKind string, allowRecentEvidenceAugmentation bool, diagnostic codexDirectCompactEvidenceDiagnostic) {
 	responseID = strings.TrimSpace(responseID)
 	authID = strings.TrimSpace(authID)
 	modelName = strings.TrimSpace(modelName)
@@ -344,10 +415,14 @@ func (s *codexDirectContinuationStore) bind(responseID, authID, modelName, scope
 	now := time.Now()
 	s.pruneExpiredLocked(now)
 	outputJSON := normalizeCodexDirectResponseOutputJSON(responseOutputJSON)
-	compactOutputHasEvidence := codexDirectOutputHasAssistantOrToolEvidence(outputJSON)
+	outputHasEvidence := codexDirectOutputHasAssistantOrToolEvidence(outputJSON)
+	compactOutputHasEvidence := outputHasEvidence
+	if diagnostic.enabled {
+		compactOutputHasEvidence = diagnostic.compactOutputHasEvidence
+	}
 	recentEvidenceHit := false
-	compactEvidenceAugmented := false
-	if allowRecentEvidenceAugmentation && !compactOutputHasEvidence {
+	compactEvidenceAugmented := diagnostic.compactResponseEvidenceAugmented
+	if allowRecentEvidenceAugmentation && !outputHasEvidence {
 		if recent, ok := s.recentEvidenceLocked(authID, modelName, scopeKey, now); ok {
 			outputJSON = recent.responseOutputJSON
 			recentEvidenceHit = true
@@ -374,6 +449,8 @@ func (s *codexDirectContinuationStore) bind(responseID, authID, modelName, scope
 			requestJSON,
 			outputJSON,
 			compactOutputHasEvidence,
+			diagnostic.sameTurnEvidenceHit,
+			diagnostic.compactResponseEvidenceAugmented,
 			recentEvidenceHit,
 			compactEvidenceAugmented,
 		)
@@ -398,28 +475,30 @@ func codexDirectBaseDiagnosticFields(routeKind string, compactRequest, hasPrevio
 		failReason = "none"
 	}
 	return log.Fields{
-		"route_kind":                     routeKind,
-		"compact_request":                compactRequest,
-		"has_previous_response_id":       hasPreviousResponseID,
-		"scope_present":                  scopePresent,
-		"binding_result":                 bindingResult,
-		"repair_result":                  repairResult,
-		"input_item_count":               counts.itemCount,
-		"assistant_message_count":        counts.assistantMessageCount,
-		"function_call_count":            counts.functionCallCount,
-		"function_call_output_count":     counts.functionCallOutputCount,
-		"compact_output_has_evidence":    false,
-		"recent_evidence_hit":            false,
-		"compact_evidence_augmented":     false,
-		"fail_reason":                    failReason,
-		"bound_output_item_count":        0,
-		"bound_output_assistant_count":   0,
-		"bound_output_tool_call_count":   0,
-		"bound_output_tool_output_count": 0,
+		"route_kind":                          routeKind,
+		"compact_request":                     compactRequest,
+		"has_previous_response_id":            hasPreviousResponseID,
+		"scope_present":                       scopePresent,
+		"binding_result":                      bindingResult,
+		"repair_result":                       repairResult,
+		"input_item_count":                    counts.itemCount,
+		"assistant_message_count":             counts.assistantMessageCount,
+		"function_call_count":                 counts.functionCallCount,
+		"function_call_output_count":          counts.functionCallOutputCount,
+		"compact_output_has_evidence":         false,
+		"same_turn_evidence_hit":              false,
+		"compact_response_evidence_augmented": false,
+		"recent_evidence_hit":                 false,
+		"compact_evidence_augmented":          false,
+		"fail_reason":                         failReason,
+		"bound_output_item_count":             0,
+		"bound_output_assistant_count":        0,
+		"bound_output_tool_call_count":        0,
+		"bound_output_tool_output_count":      0,
 	}
 }
 
-func codexDirectLogCompactEvidenceDiagnostic(routeKind string, scopePresent bool, requestJSON, boundOutputJSON []byte, compactOutputHasEvidence, recentEvidenceHit, compactEvidenceAugmented bool) {
+func codexDirectLogCompactEvidenceDiagnostic(routeKind string, scopePresent bool, requestJSON, boundOutputJSON []byte, compactOutputHasEvidence, sameTurnEvidenceHit, compactResponseEvidenceAugmented, recentEvidenceHit, compactEvidenceAugmented bool) {
 	fields := codexDirectBaseDiagnosticFields(
 		routeKind,
 		true,
@@ -432,6 +511,8 @@ func codexDirectLogCompactEvidenceDiagnostic(routeKind string, scopePresent bool
 	)
 	boundCounts := codexDirectOutputEvidenceCounts(boundOutputJSON)
 	fields["compact_output_has_evidence"] = compactOutputHasEvidence
+	fields["same_turn_evidence_hit"] = sameTurnEvidenceHit
+	fields["compact_response_evidence_augmented"] = compactResponseEvidenceAugmented
 	fields["recent_evidence_hit"] = recentEvidenceHit
 	fields["compact_evidence_augmented"] = compactEvidenceAugmented
 	fields["bound_output_item_count"] = boundCounts.itemCount
@@ -447,6 +528,34 @@ func codexDirectInputEvidenceCounts(rawJSON []byte) codexDirectEvidenceCounts {
 
 func codexDirectOutputEvidenceCounts(rawJSON []byte) codexDirectEvidenceCounts {
 	return codexDirectEvidenceCountsFromArray(gjson.ParseBytes(normalizeCodexDirectResponseOutputJSON(rawJSON)))
+}
+
+func codexDirectSameTurnEvidenceJSON(rawJSON []byte) (string, bool, error) {
+	input := gjson.GetBytes(rawJSON, "input")
+	if !input.IsArray() {
+		return "[]", false, nil
+	}
+
+	items := make([]string, 0, len(input.Array()))
+	for _, item := range input.Array() {
+		itemType := strings.TrimSpace(item.Get("type").String())
+		if itemType == "message" && strings.TrimSpace(item.Get("role").String()) == "assistant" {
+			items = append(items, item.Raw)
+			continue
+		}
+		if isResponsesToolCallType(itemType) || isResponsesToolCallOutputType(itemType) {
+			items = append(items, item.Raw)
+		}
+	}
+	if len(items) == 0 {
+		return "[]", false, nil
+	}
+
+	evidenceJSON := "[" + strings.Join(items, ",") + "]"
+	if errValidate := validateCodexDirectContinuationToolOutputs(evidenceJSON); errValidate != nil {
+		return "", false, fmt.Errorf("invalid compact same-turn evidence: %w", errValidate)
+	}
+	return evidenceJSON, true, nil
 }
 
 func codexDirectEvidenceCountsFromArray(input gjson.Result) codexDirectEvidenceCounts {
@@ -468,6 +577,14 @@ func codexDirectEvidenceCountsFromArray(input gjson.Result) codexDirectEvidenceC
 		}
 	}
 	return counts
+}
+
+func codexDirectSetResponseOutputJSON(payload, outputJSON []byte) ([]byte, error) {
+	root := gjson.ParseBytes(payload)
+	if root.Get("response.output").Exists() {
+		return sjson.SetRawBytes(payload, "response.output", outputJSON)
+	}
+	return sjson.SetRawBytes(payload, "output", outputJSON)
 }
 
 func codexDirectContinuationRepairFailReason(err error) string {
@@ -826,6 +943,19 @@ func writeCodexDirectContinuationRepairError(c *gin.Context) {
 			Message: "Codex continuation cannot be safely reconstructed locally; retry with a full input transcript",
 			Type:    "invalid_request_error",
 			Code:    "codex_continuation_repair_failed",
+		},
+	})
+}
+
+func writeCodexDirectCompactEvidenceError(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	c.JSON(http.StatusConflict, handlers.ErrorResponse{
+		Error: handlers.ErrorDetail{
+			Message: "Codex compact evidence cannot be safely preserved; retry with a full valid input transcript",
+			Type:    "invalid_request_error",
+			Code:    "codex_compact_evidence_unsafe",
 		},
 	})
 }

--- a/sdk/api/handlers/openai/openai_responses_direct_continuation.go
+++ b/sdk/api/handlers/openai/openai_responses_direct_continuation.go
@@ -22,7 +22,8 @@ const (
 	codexDirectCompactPath   = "/backend-api/codex/responses/compact"
 
 	// Direct HTTP continuation state is process-local by design. A restart drops
-	// bindings and forces unknown continuations to fail closed before upstream.
+	// bindings/recent evidence and forces unknown continuations to fail closed
+	// before upstream.
 	codexDirectContinuationTTL                = 30 * time.Minute
 	codexDirectContinuationMaxBindingCapacity = 1024
 )
@@ -35,18 +36,30 @@ type codexDirectContinuationBinding struct {
 	expiresAt          time.Time
 }
 
+type codexDirectRecentEvidence struct {
+	authID             string
+	modelName          string
+	scopeKey           string
+	responseOutputJSON []byte
+	expiresAt          time.Time
+}
+
 type codexDirectContinuationStore struct {
-	mu       sync.Mutex
-	bindings map[string]codexDirectContinuationBinding
+	mu             sync.Mutex
+	bindings       map[string]codexDirectContinuationBinding
+	recentEvidence map[string]codexDirectRecentEvidence
 }
 
 var codexDirectContinuations = &codexDirectContinuationStore{
-	bindings: make(map[string]codexDirectContinuationBinding),
+	bindings:       make(map[string]codexDirectContinuationBinding),
+	recentEvidence: make(map[string]codexDirectRecentEvidence),
 }
 
 type codexDirectContinuationTracker struct {
-	modelName   string
-	requestJSON []byte
+	modelName      string
+	requestJSON    []byte
+	scopeKey       string
+	compactRequest bool
 
 	mu                  sync.Mutex
 	authID              string
@@ -67,8 +80,10 @@ func (h *OpenAIResponsesAPIHandler) prepareCodexDirectContinuationContext(c *gin
 	modelName = strings.TrimSpace(modelName)
 	requestJSON := bytes.Clone(rawJSON)
 	tracker := &codexDirectContinuationTracker{
-		modelName:   modelName,
-		requestJSON: bytes.Clone(requestJSON),
+		modelName:      modelName,
+		requestJSON:    bytes.Clone(requestJSON),
+		scopeKey:       codexDirectContinuationScopeKey(c, requestJSON),
+		compactRequest: isCodexDirectCompactRequest(c),
 	}
 
 	if isCodexDirectResponsesRequest(c) {
@@ -136,7 +151,7 @@ func (t *codexDirectContinuationTracker) bindResponseIDs(payload []byte) {
 		return
 	}
 	for _, snapshot := range t.snapshotsFromPayload(payload) {
-		codexDirectContinuations.bind(snapshot.responseID, authID, t.modelName, t.requestJSON, snapshot.responseOutputJSON)
+		codexDirectContinuations.bind(snapshot.responseID, authID, t.modelName, t.scopeKey, t.requestJSON, snapshot.responseOutputJSON, t.compactRequest)
 	}
 }
 
@@ -263,10 +278,11 @@ func (t *codexDirectContinuationTracker) getAuthID() string {
 	return t.authID
 }
 
-func (s *codexDirectContinuationStore) bind(responseID, authID, modelName string, requestJSON []byte, responseOutputJSON []byte) {
+func (s *codexDirectContinuationStore) bind(responseID, authID, modelName, scopeKey string, requestJSON []byte, responseOutputJSON []byte, allowRecentEvidenceAugmentation bool) {
 	responseID = strings.TrimSpace(responseID)
 	authID = strings.TrimSpace(authID)
 	modelName = strings.TrimSpace(modelName)
+	scopeKey = strings.TrimSpace(scopeKey)
 	if responseID == "" || authID == "" {
 		return
 	}
@@ -276,11 +292,20 @@ func (s *codexDirectContinuationStore) bind(responseID, authID, modelName string
 	s.ensureLocked()
 	now := time.Now()
 	s.pruneExpiredLocked(now)
+	outputJSON := normalizeCodexDirectResponseOutputJSON(responseOutputJSON)
+	if allowRecentEvidenceAugmentation && !codexDirectOutputHasAssistantOrToolEvidence(outputJSON) {
+		if recent, ok := s.recentEvidenceLocked(authID, modelName, scopeKey, now); ok {
+			outputJSON = recent.responseOutputJSON
+		}
+	}
+	if codexDirectOutputHasAssistantOrToolEvidence(outputJSON) {
+		s.rememberRecentEvidenceLocked(authID, modelName, scopeKey, outputJSON, now)
+	}
 	s.bindings[responseID] = codexDirectContinuationBinding{
 		authID:             authID,
 		modelName:          modelName,
 		requestJSON:        bytes.Clone(requestJSON),
-		responseOutputJSON: normalizeCodexDirectResponseOutputJSON(responseOutputJSON),
+		responseOutputJSON: outputJSON,
 		expiresAt:          now.Add(codexDirectContinuationTTL),
 	}
 	s.trimLocked(codexDirectContinuationMaxBindingCapacity)
@@ -317,6 +342,9 @@ func (s *codexDirectContinuationStore) ensureLocked() {
 	if s.bindings == nil {
 		s.bindings = make(map[string]codexDirectContinuationBinding)
 	}
+	if s.recentEvidence == nil {
+		s.recentEvidence = make(map[string]codexDirectRecentEvidence)
+	}
 }
 
 func (s *codexDirectContinuationStore) pruneExpiredLocked(now time.Time) {
@@ -328,12 +356,20 @@ func (s *codexDirectContinuationStore) pruneExpiredLocked(now time.Time) {
 			delete(s.bindings, responseID)
 		}
 	}
+	for key, recent := range s.recentEvidence {
+		if !recent.expiresAt.IsZero() && !now.Before(recent.expiresAt) {
+			delete(s.recentEvidence, key)
+		}
+	}
 }
 
 func (s *codexDirectContinuationStore) trimLocked(maxBindings int) {
 	if maxBindings <= 0 {
 		for responseID := range s.bindings {
 			delete(s.bindings, responseID)
+		}
+		for key := range s.recentEvidence {
+			delete(s.recentEvidence, key)
 		}
 		return
 	}
@@ -351,6 +387,64 @@ func (s *codexDirectContinuationStore) trimLocked(maxBindings int) {
 		}
 		delete(s.bindings, oldestResponseID)
 	}
+	for len(s.recentEvidence) > maxBindings {
+		oldestKey := ""
+		var oldestExpiresAt time.Time
+		for key, recent := range s.recentEvidence {
+			if oldestKey == "" || recent.expiresAt.Before(oldestExpiresAt) {
+				oldestKey = key
+				oldestExpiresAt = recent.expiresAt
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(s.recentEvidence, oldestKey)
+	}
+}
+
+func (s *codexDirectContinuationStore) rememberRecentEvidenceLocked(authID, modelName, scopeKey string, responseOutputJSON []byte, now time.Time) {
+	key := codexDirectRecentEvidenceKey(authID, modelName, scopeKey)
+	if key == "" {
+		return
+	}
+	s.recentEvidence[key] = codexDirectRecentEvidence{
+		authID:             authID,
+		modelName:          modelName,
+		scopeKey:           scopeKey,
+		responseOutputJSON: bytes.Clone(responseOutputJSON),
+		expiresAt:          now.Add(codexDirectContinuationTTL),
+	}
+}
+
+func (s *codexDirectContinuationStore) recentEvidenceLocked(authID, modelName, scopeKey string, now time.Time) (codexDirectRecentEvidence, bool) {
+	key := codexDirectRecentEvidenceKey(authID, modelName, scopeKey)
+	if key == "" {
+		return codexDirectRecentEvidence{}, false
+	}
+	recent, ok := s.recentEvidence[key]
+	if !ok {
+		return codexDirectRecentEvidence{}, false
+	}
+	if !recent.expiresAt.IsZero() && !now.Before(recent.expiresAt) {
+		delete(s.recentEvidence, key)
+		return codexDirectRecentEvidence{}, false
+	}
+	if recent.authID != strings.TrimSpace(authID) || recent.modelName != strings.TrimSpace(modelName) || recent.scopeKey != strings.TrimSpace(scopeKey) {
+		return codexDirectRecentEvidence{}, false
+	}
+	recent.responseOutputJSON = bytes.Clone(recent.responseOutputJSON)
+	return recent, true
+}
+
+func codexDirectRecentEvidenceKey(authID, modelName, scopeKey string) string {
+	authID = strings.TrimSpace(authID)
+	modelName = strings.TrimSpace(modelName)
+	scopeKey = strings.TrimSpace(scopeKey)
+	if authID == "" || modelName == "" || scopeKey == "" {
+		return ""
+	}
+	return authID + "\x00" + modelName + "\x00" + scopeKey
 }
 
 func repairCodexDirectContinuationRequest(rawJSON []byte, binding codexDirectContinuationBinding) ([]byte, error) {
@@ -475,6 +569,38 @@ func normalizeCodexDirectResponseOutputJSON(raw []byte) []byte {
 func codexDirectOutputJSONIsEmpty(raw []byte) bool {
 	result := gjson.ParseBytes(normalizeCodexDirectResponseOutputJSON(raw))
 	return !result.IsArray() || len(result.Array()) == 0
+}
+
+func codexDirectOutputHasAssistantOrToolEvidence(raw []byte) bool {
+	result := gjson.ParseBytes(normalizeCodexDirectResponseOutputJSON(raw))
+	if !result.IsArray() {
+		return false
+	}
+	for _, item := range result.Array() {
+		itemType := strings.TrimSpace(item.Get("type").String())
+		if isResponsesToolCallType(itemType) && strings.TrimSpace(item.Get("call_id").String()) != "" {
+			return true
+		}
+		if itemType == "message" && strings.TrimSpace(item.Get("role").String()) == "assistant" {
+			return true
+		}
+	}
+	return false
+}
+
+func codexDirectContinuationScopeKey(c *gin.Context, rawJSON []byte) string {
+	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(rawJSON, "prompt_cache_key").String()); promptCacheKey != "" {
+		return "prompt_cache_key:" + promptCacheKey
+	}
+	if c == nil || c.Request == nil {
+		return ""
+	}
+	for _, headerName := range []string{"Session_id", "X-Codex-Turn-Metadata"} {
+		if headerValue := strings.TrimSpace(c.Request.Header.Get(headerName)); headerValue != "" {
+			return headerName + ":" + headerValue
+		}
+	}
+	return ""
 }
 
 func isCodexDirectContinuationRequest(c *gin.Context) bool {

--- a/sdk/api/handlers/openai/openai_responses_direct_continuation.go
+++ b/sdk/api/handlers/openai/openai_responses_direct_continuation.go
@@ -1,0 +1,516 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	codexDirectResponsesPath = "/backend-api/codex/responses"
+	codexDirectCompactPath   = "/backend-api/codex/responses/compact"
+
+	// Direct HTTP continuation state is process-local by design. A restart drops
+	// bindings and forces unknown continuations to fail closed before upstream.
+	codexDirectContinuationTTL                = 30 * time.Minute
+	codexDirectContinuationMaxBindingCapacity = 1024
+)
+
+type codexDirectContinuationBinding struct {
+	authID             string
+	modelName          string
+	requestJSON        []byte
+	responseOutputJSON []byte
+	expiresAt          time.Time
+}
+
+type codexDirectContinuationStore struct {
+	mu       sync.Mutex
+	bindings map[string]codexDirectContinuationBinding
+}
+
+var codexDirectContinuations = &codexDirectContinuationStore{
+	bindings: make(map[string]codexDirectContinuationBinding),
+}
+
+type codexDirectContinuationTracker struct {
+	modelName   string
+	requestJSON []byte
+
+	mu                  sync.Mutex
+	authID              string
+	outputItemsByIndex  map[int64][]byte
+	outputItemsFallback [][]byte
+}
+
+type codexDirectContinuationSnapshot struct {
+	responseID         string
+	responseOutputJSON []byte
+}
+
+func (h *OpenAIResponsesAPIHandler) prepareCodexDirectContinuationContext(c *gin.Context, rawJSON []byte, modelName string, ctx context.Context) (context.Context, []byte, *codexDirectContinuationTracker, bool) {
+	if !isCodexDirectContinuationRequest(c) {
+		return ctx, rawJSON, nil, true
+	}
+
+	modelName = strings.TrimSpace(modelName)
+	requestJSON := bytes.Clone(rawJSON)
+	tracker := &codexDirectContinuationTracker{
+		modelName:   modelName,
+		requestJSON: bytes.Clone(requestJSON),
+	}
+
+	if isCodexDirectResponsesRequest(c) {
+		previousResponseID := strings.TrimSpace(gjson.GetBytes(rawJSON, "previous_response_id").String())
+		if previousResponseID != "" {
+			binding, ok := codexDirectContinuations.lookup(previousResponseID, modelName)
+			if !ok || !h.codexDirectContinuationBindingAuthUsable(binding, modelName) {
+				writeCodexDirectContinuationError(c)
+				return ctx, nil, nil, false
+			}
+
+			repairedJSON, errRepair := repairCodexDirectContinuationRequest(rawJSON, binding)
+			if errRepair != nil {
+				writeCodexDirectContinuationRepairError(c)
+				return ctx, nil, nil, false
+			}
+			requestJSON = repairedJSON
+			tracker.requestJSON = bytes.Clone(requestJSON)
+			tracker.setAuthID(binding.authID)
+			ctx = handlers.WithPinnedAuthID(ctx, binding.authID)
+		}
+	}
+
+	ctx = handlers.WithSelectedAuthIDCallback(ctx, tracker.setAuthID)
+	return ctx, requestJSON, tracker, true
+}
+
+func (h *OpenAIResponsesAPIHandler) codexDirectContinuationBindingAuthUsable(binding codexDirectContinuationBinding, modelName string) bool {
+	authID := strings.TrimSpace(binding.authID)
+	if authID == "" || h == nil || h.AuthManager == nil {
+		return false
+	}
+	auth, ok := h.AuthManager.GetByID(authID)
+	if !ok || auth == nil {
+		return false
+	}
+	if !responsesWebsocketAuthAvailableForModel(auth, modelName, time.Now()) {
+		return false
+	}
+	return true
+}
+
+func (t *codexDirectContinuationTracker) observeStream(chunks <-chan []byte) <-chan []byte {
+	if t == nil || chunks == nil {
+		return chunks
+	}
+
+	out := make(chan []byte)
+	go func() {
+		defer close(out)
+		for chunk := range chunks {
+			t.bindResponseIDs(chunk)
+			out <- chunk
+		}
+	}()
+	return out
+}
+
+func (t *codexDirectContinuationTracker) bindResponseIDs(payload []byte) {
+	if t == nil || len(payload) == 0 {
+		return
+	}
+	authID := t.getAuthID()
+	if authID == "" {
+		return
+	}
+	for _, snapshot := range t.snapshotsFromPayload(payload) {
+		codexDirectContinuations.bind(snapshot.responseID, authID, t.modelName, t.requestJSON, snapshot.responseOutputJSON)
+	}
+}
+
+func (t *codexDirectContinuationTracker) snapshotsFromPayload(payload []byte) []codexDirectContinuationSnapshot {
+	payloads := websocketJSONPayloadsFromChunk(payload)
+	if len(payloads) == 0 {
+		return nil
+	}
+
+	snapshots := make([]codexDirectContinuationSnapshot, 0, len(payloads))
+	for _, raw := range payloads {
+		root := gjson.ParseBytes(raw)
+		switch strings.TrimSpace(root.Get("type").String()) {
+		case "response.output_item.done":
+			t.recordOutputItem(root)
+		case "response.completed":
+			responseID := strings.TrimSpace(root.Get("response.id").String())
+			if responseID == "" {
+				continue
+			}
+			outputJSON := codexDirectResponseOutputJSON(root)
+			if codexDirectOutputJSONIsEmpty(outputJSON) {
+				outputJSON = t.completedOutputFromDoneItems()
+			} else {
+				t.clearOutputItems()
+			}
+			snapshots = append(snapshots, codexDirectContinuationSnapshot{
+				responseID:         responseID,
+				responseOutputJSON: outputJSON,
+			})
+		default:
+			responseID := strings.TrimSpace(root.Get("id").String())
+			if responseID == "" {
+				continue
+			}
+			snapshots = append(snapshots, codexDirectContinuationSnapshot{
+				responseID:         responseID,
+				responseOutputJSON: codexDirectResponseOutputJSON(root),
+			})
+		}
+	}
+	return snapshots
+}
+
+func (t *codexDirectContinuationTracker) recordOutputItem(root gjson.Result) {
+	item := root.Get("item")
+	if !item.Exists() || !item.IsObject() || strings.TrimSpace(item.Get("type").String()) == "" {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if outputIndex := root.Get("output_index"); outputIndex.Exists() {
+		if t.outputItemsByIndex == nil {
+			t.outputItemsByIndex = make(map[int64][]byte)
+		}
+		t.outputItemsByIndex[outputIndex.Int()] = bytes.Clone([]byte(item.Raw))
+		return
+	}
+	t.outputItemsFallback = append(t.outputItemsFallback, bytes.Clone([]byte(item.Raw)))
+}
+
+func (t *codexDirectContinuationTracker) completedOutputFromDoneItems() []byte {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.outputItemsByIndex) == 0 && len(t.outputItemsFallback) == 0 {
+		return []byte("[]")
+	}
+
+	indexes := make([]int64, 0, len(t.outputItemsByIndex))
+	for index := range t.outputItemsByIndex {
+		indexes = append(indexes, index)
+	}
+	sort.Slice(indexes, func(i, j int) bool {
+		return indexes[i] < indexes[j]
+	})
+
+	items := make([][]byte, 0, len(t.outputItemsByIndex)+len(t.outputItemsFallback))
+	for _, index := range indexes {
+		items = append(items, t.outputItemsByIndex[index])
+	}
+	items = append(items, t.outputItemsFallback...)
+	t.outputItemsByIndex = nil
+	t.outputItemsFallback = nil
+
+	var out bytes.Buffer
+	out.WriteByte('[')
+	for i, item := range items {
+		if i > 0 {
+			out.WriteByte(',')
+		}
+		out.Write(item)
+	}
+	out.WriteByte(']')
+	return out.Bytes()
+}
+
+func (t *codexDirectContinuationTracker) clearOutputItems() {
+	t.mu.Lock()
+	t.outputItemsByIndex = nil
+	t.outputItemsFallback = nil
+	t.mu.Unlock()
+}
+
+func (t *codexDirectContinuationTracker) setAuthID(authID string) {
+	if t == nil {
+		return
+	}
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return
+	}
+	t.mu.Lock()
+	t.authID = authID
+	t.mu.Unlock()
+}
+
+func (t *codexDirectContinuationTracker) getAuthID() string {
+	if t == nil {
+		return ""
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.authID
+}
+
+func (s *codexDirectContinuationStore) bind(responseID, authID, modelName string, requestJSON []byte, responseOutputJSON []byte) {
+	responseID = strings.TrimSpace(responseID)
+	authID = strings.TrimSpace(authID)
+	modelName = strings.TrimSpace(modelName)
+	if responseID == "" || authID == "" {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	now := time.Now()
+	s.pruneExpiredLocked(now)
+	s.bindings[responseID] = codexDirectContinuationBinding{
+		authID:             authID,
+		modelName:          modelName,
+		requestJSON:        bytes.Clone(requestJSON),
+		responseOutputJSON: normalizeCodexDirectResponseOutputJSON(responseOutputJSON),
+		expiresAt:          now.Add(codexDirectContinuationTTL),
+	}
+	s.trimLocked(codexDirectContinuationMaxBindingCapacity)
+}
+
+func (s *codexDirectContinuationStore) lookup(responseID, modelName string) (codexDirectContinuationBinding, bool) {
+	responseID = strings.TrimSpace(responseID)
+	modelName = strings.TrimSpace(modelName)
+	if responseID == "" {
+		return codexDirectContinuationBinding{}, false
+	}
+
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	s.pruneExpiredLocked(now)
+	binding, ok := s.bindings[responseID]
+	if !ok {
+		return codexDirectContinuationBinding{}, false
+	}
+	if binding.modelName != "" && modelName != "" && binding.modelName != modelName {
+		return codexDirectContinuationBinding{}, false
+	}
+	if strings.TrimSpace(binding.authID) == "" {
+		return codexDirectContinuationBinding{}, false
+	}
+	binding.requestJSON = bytes.Clone(binding.requestJSON)
+	binding.responseOutputJSON = bytes.Clone(binding.responseOutputJSON)
+	return binding, true
+}
+
+func (s *codexDirectContinuationStore) ensureLocked() {
+	if s.bindings == nil {
+		s.bindings = make(map[string]codexDirectContinuationBinding)
+	}
+}
+
+func (s *codexDirectContinuationStore) pruneExpiredLocked(now time.Time) {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	for responseID, binding := range s.bindings {
+		if !binding.expiresAt.IsZero() && !now.Before(binding.expiresAt) {
+			delete(s.bindings, responseID)
+		}
+	}
+}
+
+func (s *codexDirectContinuationStore) trimLocked(maxBindings int) {
+	if maxBindings <= 0 {
+		for responseID := range s.bindings {
+			delete(s.bindings, responseID)
+		}
+		return
+	}
+	for len(s.bindings) > maxBindings {
+		oldestResponseID := ""
+		var oldestExpiresAt time.Time
+		for responseID, binding := range s.bindings {
+			if oldestResponseID == "" || binding.expiresAt.Before(oldestExpiresAt) {
+				oldestResponseID = responseID
+				oldestExpiresAt = binding.expiresAt
+			}
+		}
+		if oldestResponseID == "" {
+			return
+		}
+		delete(s.bindings, oldestResponseID)
+	}
+}
+
+func repairCodexDirectContinuationRequest(rawJSON []byte, binding codexDirectContinuationBinding) ([]byte, error) {
+	if strings.TrimSpace(binding.authID) == "" {
+		return nil, fmt.Errorf("missing bound auth")
+	}
+	nextInput := gjson.GetBytes(rawJSON, "input")
+	if !nextInput.Exists() || !nextInput.IsArray() {
+		return nil, fmt.Errorf("continuation request is missing array input")
+	}
+
+	mergedInput := nextInput.Raw
+	if !inputContainsFullTranscript(nextInput) {
+		previousInput := gjson.GetBytes(binding.requestJSON, "input")
+		if !previousInput.Exists() || !previousInput.IsArray() {
+			return nil, fmt.Errorf("cached continuation request is missing array input")
+		}
+
+		var errMerge error
+		mergedInput, errMerge = mergeJSONArrayRaw(previousInput.Raw, string(normalizeCodexDirectResponseOutputJSON(binding.responseOutputJSON)))
+		if errMerge != nil {
+			return nil, fmt.Errorf("merge cached response output: %w", errMerge)
+		}
+		mergedInput, errMerge = mergeJSONArrayRaw(mergedInput, nextInput.Raw)
+		if errMerge != nil {
+			return nil, fmt.Errorf("merge continuation input: %w", errMerge)
+		}
+	}
+
+	if dedupedInput, errDedupe := dedupeFunctionCallsByCallID(mergedInput); errDedupe == nil {
+		mergedInput = dedupedInput
+	}
+	if errValidate := validateCodexDirectContinuationToolOutputs(mergedInput); errValidate != nil {
+		return nil, fmt.Errorf("invalid repaired tool outputs: %w", errValidate)
+	}
+
+	repaired, errDelete := sjson.DeleteBytes(rawJSON, "previous_response_id")
+	if errDelete != nil {
+		repaired = bytes.Clone(rawJSON)
+	}
+	var errSet error
+	repaired, errSet = sjson.SetRawBytes(repaired, "input", []byte(mergedInput))
+	if errSet != nil {
+		return nil, fmt.Errorf("set repaired input: %w", errSet)
+	}
+	if !gjson.GetBytes(repaired, "model").Exists() {
+		modelName := strings.TrimSpace(gjson.GetBytes(binding.requestJSON, "model").String())
+		if modelName != "" {
+			repaired, _ = sjson.SetBytes(repaired, "model", modelName)
+		}
+	}
+	if !gjson.GetBytes(repaired, "instructions").Exists() {
+		instructions := gjson.GetBytes(binding.requestJSON, "instructions")
+		if instructions.Exists() {
+			repaired, _ = sjson.SetRawBytes(repaired, "instructions", []byte(instructions.Raw))
+		}
+	}
+	return repaired, nil
+}
+
+func validateCodexDirectContinuationToolOutputs(rawArray string) error {
+	rawArray = strings.TrimSpace(rawArray)
+	if rawArray == "" {
+		return nil
+	}
+
+	var items []json.RawMessage
+	if errUnmarshal := json.Unmarshal([]byte(rawArray), &items); errUnmarshal != nil {
+		return errUnmarshal
+	}
+
+	callIDs := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		itemType := strings.TrimSpace(gjson.GetBytes(item, "type").String())
+		if !isResponsesToolCallType(itemType) {
+			continue
+		}
+		callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
+		if callID != "" {
+			callIDs[callID] = struct{}{}
+		}
+	}
+
+	for _, item := range items {
+		itemType := strings.TrimSpace(gjson.GetBytes(item, "type").String())
+		if !isResponsesToolCallOutputType(itemType) {
+			continue
+		}
+		callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
+		if callID == "" {
+			return fmt.Errorf("tool output missing matching call")
+		}
+		if _, ok := callIDs[callID]; !ok {
+			return fmt.Errorf("tool output missing matching call")
+		}
+	}
+	return nil
+}
+
+func codexDirectResponseOutputJSON(root gjson.Result) []byte {
+	for _, path := range []string{"output", "response.output"} {
+		output := root.Get(path)
+		if output.Exists() && output.IsArray() {
+			return bytes.Clone([]byte(output.Raw))
+		}
+	}
+	return []byte("[]")
+}
+
+func normalizeCodexDirectResponseOutputJSON(raw []byte) []byte {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return []byte("[]")
+	}
+	result := gjson.ParseBytes(trimmed)
+	if result.Type == gjson.JSON && result.IsArray() {
+		return bytes.Clone(trimmed)
+	}
+	return []byte("[]")
+}
+
+func codexDirectOutputJSONIsEmpty(raw []byte) bool {
+	result := gjson.ParseBytes(normalizeCodexDirectResponseOutputJSON(raw))
+	return !result.IsArray() || len(result.Array()) == 0
+}
+
+func isCodexDirectContinuationRequest(c *gin.Context) bool {
+	return isCodexDirectResponsesRequest(c) || isCodexDirectCompactRequest(c)
+}
+
+func isCodexDirectResponsesRequest(c *gin.Context) bool {
+	return c != nil && c.Request != nil && c.Request.URL != nil && c.Request.URL.Path == codexDirectResponsesPath
+}
+
+func isCodexDirectCompactRequest(c *gin.Context) bool {
+	return c != nil && c.Request != nil && c.Request.URL != nil && c.Request.URL.Path == codexDirectCompactPath
+}
+
+func writeCodexDirectContinuationError(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	c.JSON(http.StatusConflict, handlers.ErrorResponse{
+		Error: handlers.ErrorDetail{
+			Message: "Codex continuation cannot be safely routed to the original auth; retry without previous_response_id",
+			Type:    "invalid_request_error",
+			Code:    "codex_continuation_auth_unknown",
+		},
+	})
+}
+
+func writeCodexDirectContinuationRepairError(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	c.JSON(http.StatusConflict, handlers.ErrorResponse{
+		Error: handlers.ErrorDetail{
+			Message: "Codex continuation cannot be safely reconstructed locally; retry with a full input transcript",
+			Type:    "invalid_request_error",
+			Code:    "codex_continuation_repair_failed",
+		},
+	})
+}

--- a/sdk/api/handlers/openai/openai_responses_direct_continuation.go
+++ b/sdk/api/handlers/openai/openai_responses_direct_continuation.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -58,6 +59,7 @@ var codexDirectContinuations = &codexDirectContinuationStore{
 type codexDirectContinuationTracker struct {
 	modelName      string
 	requestJSON    []byte
+	routeKind      string
 	scopeKey       string
 	compactRequest bool
 
@@ -72,6 +74,13 @@ type codexDirectContinuationSnapshot struct {
 	responseOutputJSON []byte
 }
 
+type codexDirectEvidenceCounts struct {
+	itemCount               int
+	assistantMessageCount   int
+	functionCallCount       int
+	functionCallOutputCount int
+}
+
 func (h *OpenAIResponsesAPIHandler) prepareCodexDirectContinuationContext(c *gin.Context, rawJSON []byte, modelName string, ctx context.Context) (context.Context, []byte, *codexDirectContinuationTracker, bool) {
 	if !isCodexDirectContinuationRequest(c) {
 		return ctx, rawJSON, nil, true
@@ -82,6 +91,7 @@ func (h *OpenAIResponsesAPIHandler) prepareCodexDirectContinuationContext(c *gin
 	tracker := &codexDirectContinuationTracker{
 		modelName:      modelName,
 		requestJSON:    bytes.Clone(requestJSON),
+		routeKind:      codexDirectRouteKind(c),
 		scopeKey:       codexDirectContinuationScopeKey(c, requestJSON),
 		compactRequest: isCodexDirectCompactRequest(c),
 	}
@@ -90,21 +100,33 @@ func (h *OpenAIResponsesAPIHandler) prepareCodexDirectContinuationContext(c *gin
 		previousResponseID := strings.TrimSpace(gjson.GetBytes(rawJSON, "previous_response_id").String())
 		if previousResponseID != "" {
 			binding, ok := codexDirectContinuations.lookup(previousResponseID, modelName)
-			if !ok || !h.codexDirectContinuationBindingAuthUsable(binding, modelName) {
+			if !ok {
+				tracker.logDecision(rawJSON, "miss", "none", "missing_binding")
+				writeCodexDirectContinuationError(c)
+				return ctx, nil, nil, false
+			}
+			if !h.codexDirectContinuationBindingAuthUsable(binding, modelName) {
+				tracker.logDecision(rawJSON, "unusable", "none", "unusable_auth")
 				writeCodexDirectContinuationError(c)
 				return ctx, nil, nil, false
 			}
 
 			repairedJSON, errRepair := repairCodexDirectContinuationRequest(rawJSON, binding)
 			if errRepair != nil {
+				tracker.logDecision(rawJSON, "hit", "failed", codexDirectContinuationRepairFailReason(errRepair))
 				writeCodexDirectContinuationRepairError(c)
 				return ctx, nil, nil, false
 			}
 			requestJSON = repairedJSON
 			tracker.requestJSON = bytes.Clone(requestJSON)
 			tracker.setAuthID(binding.authID)
+			tracker.logDecision(requestJSON, "hit", "repaired", "none")
 			ctx = handlers.WithPinnedAuthID(ctx, binding.authID)
 		}
+	}
+
+	if tracker.compactRequest {
+		tracker.logDecision(requestJSON, "none", "none", "none")
 	}
 
 	ctx = handlers.WithSelectedAuthIDCallback(ctx, tracker.setAuthID)
@@ -151,7 +173,16 @@ func (t *codexDirectContinuationTracker) bindResponseIDs(payload []byte) {
 		return
 	}
 	for _, snapshot := range t.snapshotsFromPayload(payload) {
-		codexDirectContinuations.bind(snapshot.responseID, authID, t.modelName, t.scopeKey, t.requestJSON, snapshot.responseOutputJSON, t.compactRequest)
+		codexDirectContinuations.bind(
+			snapshot.responseID,
+			authID,
+			t.modelName,
+			t.scopeKey,
+			t.requestJSON,
+			snapshot.responseOutputJSON,
+			t.routeKind,
+			t.compactRequest,
+		)
 	}
 }
 
@@ -278,7 +309,28 @@ func (t *codexDirectContinuationTracker) getAuthID() string {
 	return t.authID
 }
 
-func (s *codexDirectContinuationStore) bind(responseID, authID, modelName, scopeKey string, requestJSON []byte, responseOutputJSON []byte, allowRecentEvidenceAugmentation bool) {
+func (t *codexDirectContinuationTracker) logDecision(requestJSON []byte, bindingResult, repairResult, failReason string) {
+	if t == nil {
+		return
+	}
+	fields := codexDirectBaseDiagnosticFields(
+		t.routeKind,
+		t.compactRequest,
+		strings.TrimSpace(gjson.GetBytes(requestJSON, "previous_response_id").String()) != "" || bindingResult == "hit" || bindingResult == "miss" || bindingResult == "unusable",
+		t.scopeKey != "",
+		bindingResult,
+		repairResult,
+		failReason,
+		codexDirectInputEvidenceCounts(requestJSON),
+	)
+	if repairResult == "failed" {
+		log.WithFields(fields).Warn("codex direct http continuation diagnostic")
+		return
+	}
+	log.WithFields(fields).Info("codex direct http continuation diagnostic")
+}
+
+func (s *codexDirectContinuationStore) bind(responseID, authID, modelName, scopeKey string, requestJSON []byte, responseOutputJSON []byte, routeKind string, allowRecentEvidenceAugmentation bool) {
 	responseID = strings.TrimSpace(responseID)
 	authID = strings.TrimSpace(authID)
 	modelName = strings.TrimSpace(modelName)
@@ -288,14 +340,18 @@ func (s *codexDirectContinuationStore) bind(responseID, authID, modelName, scope
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.ensureLocked()
 	now := time.Now()
 	s.pruneExpiredLocked(now)
 	outputJSON := normalizeCodexDirectResponseOutputJSON(responseOutputJSON)
-	if allowRecentEvidenceAugmentation && !codexDirectOutputHasAssistantOrToolEvidence(outputJSON) {
+	compactOutputHasEvidence := codexDirectOutputHasAssistantOrToolEvidence(outputJSON)
+	recentEvidenceHit := false
+	compactEvidenceAugmented := false
+	if allowRecentEvidenceAugmentation && !compactOutputHasEvidence {
 		if recent, ok := s.recentEvidenceLocked(authID, modelName, scopeKey, now); ok {
 			outputJSON = recent.responseOutputJSON
+			recentEvidenceHit = true
+			compactEvidenceAugmented = true
 		}
 	}
 	if codexDirectOutputHasAssistantOrToolEvidence(outputJSON) {
@@ -309,6 +365,128 @@ func (s *codexDirectContinuationStore) bind(responseID, authID, modelName, scope
 		expiresAt:          now.Add(codexDirectContinuationTTL),
 	}
 	s.trimLocked(codexDirectContinuationMaxBindingCapacity)
+	s.mu.Unlock()
+
+	if allowRecentEvidenceAugmentation {
+		codexDirectLogCompactEvidenceDiagnostic(
+			routeKind,
+			scopeKey != "",
+			requestJSON,
+			outputJSON,
+			compactOutputHasEvidence,
+			recentEvidenceHit,
+			compactEvidenceAugmented,
+		)
+	}
+}
+
+func codexDirectBaseDiagnosticFields(routeKind string, compactRequest, hasPreviousResponseID, scopePresent bool, bindingResult, repairResult, failReason string, counts codexDirectEvidenceCounts) log.Fields {
+	routeKind = strings.TrimSpace(routeKind)
+	if routeKind == "" {
+		routeKind = "unknown"
+	}
+	bindingResult = strings.TrimSpace(bindingResult)
+	if bindingResult == "" {
+		bindingResult = "none"
+	}
+	repairResult = strings.TrimSpace(repairResult)
+	if repairResult == "" {
+		repairResult = "none"
+	}
+	failReason = strings.TrimSpace(failReason)
+	if failReason == "" {
+		failReason = "none"
+	}
+	return log.Fields{
+		"route_kind":                     routeKind,
+		"compact_request":                compactRequest,
+		"has_previous_response_id":       hasPreviousResponseID,
+		"scope_present":                  scopePresent,
+		"binding_result":                 bindingResult,
+		"repair_result":                  repairResult,
+		"input_item_count":               counts.itemCount,
+		"assistant_message_count":        counts.assistantMessageCount,
+		"function_call_count":            counts.functionCallCount,
+		"function_call_output_count":     counts.functionCallOutputCount,
+		"compact_output_has_evidence":    false,
+		"recent_evidence_hit":            false,
+		"compact_evidence_augmented":     false,
+		"fail_reason":                    failReason,
+		"bound_output_item_count":        0,
+		"bound_output_assistant_count":   0,
+		"bound_output_tool_call_count":   0,
+		"bound_output_tool_output_count": 0,
+	}
+}
+
+func codexDirectLogCompactEvidenceDiagnostic(routeKind string, scopePresent bool, requestJSON, boundOutputJSON []byte, compactOutputHasEvidence, recentEvidenceHit, compactEvidenceAugmented bool) {
+	fields := codexDirectBaseDiagnosticFields(
+		routeKind,
+		true,
+		strings.TrimSpace(gjson.GetBytes(requestJSON, "previous_response_id").String()) != "",
+		scopePresent,
+		"none",
+		"none",
+		"none",
+		codexDirectInputEvidenceCounts(requestJSON),
+	)
+	boundCounts := codexDirectOutputEvidenceCounts(boundOutputJSON)
+	fields["compact_output_has_evidence"] = compactOutputHasEvidence
+	fields["recent_evidence_hit"] = recentEvidenceHit
+	fields["compact_evidence_augmented"] = compactEvidenceAugmented
+	fields["bound_output_item_count"] = boundCounts.itemCount
+	fields["bound_output_assistant_count"] = boundCounts.assistantMessageCount
+	fields["bound_output_tool_call_count"] = boundCounts.functionCallCount
+	fields["bound_output_tool_output_count"] = boundCounts.functionCallOutputCount
+	log.WithFields(fields).Info("codex direct http compact evidence diagnostic")
+}
+
+func codexDirectInputEvidenceCounts(rawJSON []byte) codexDirectEvidenceCounts {
+	return codexDirectEvidenceCountsFromArray(gjson.GetBytes(rawJSON, "input"))
+}
+
+func codexDirectOutputEvidenceCounts(rawJSON []byte) codexDirectEvidenceCounts {
+	return codexDirectEvidenceCountsFromArray(gjson.ParseBytes(normalizeCodexDirectResponseOutputJSON(rawJSON)))
+}
+
+func codexDirectEvidenceCountsFromArray(input gjson.Result) codexDirectEvidenceCounts {
+	if !input.IsArray() {
+		return codexDirectEvidenceCounts{}
+	}
+	items := input.Array()
+	counts := codexDirectEvidenceCounts{itemCount: len(items)}
+	for _, item := range items {
+		itemType := strings.TrimSpace(item.Get("type").String())
+		if itemType == "message" && strings.TrimSpace(item.Get("role").String()) == "assistant" {
+			counts.assistantMessageCount++
+		}
+		if isResponsesToolCallType(itemType) {
+			counts.functionCallCount++
+		}
+		if isResponsesToolCallOutputType(itemType) {
+			counts.functionCallOutputCount++
+		}
+	}
+	return counts
+}
+
+func codexDirectContinuationRepairFailReason(err error) string {
+	if err == nil {
+		return "none"
+	}
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "tool output missing matching call"):
+		return "orphan_tool_output"
+	case strings.Contains(message, "missing array input"),
+		strings.Contains(message, "missing array"),
+		strings.Contains(message, "invalid request input"),
+		strings.Contains(message, "invalid previous response output"),
+		strings.Contains(message, "set repaired input"):
+		return "invalid_input"
+	default:
+		return "invalid_input"
+	}
 }
 
 func (s *codexDirectContinuationStore) lookup(responseID, modelName string) (codexDirectContinuationBinding, bool) {
@@ -605,6 +783,17 @@ func codexDirectContinuationScopeKey(c *gin.Context, rawJSON []byte) string {
 
 func isCodexDirectContinuationRequest(c *gin.Context) bool {
 	return isCodexDirectResponsesRequest(c) || isCodexDirectCompactRequest(c)
+}
+
+func codexDirectRouteKind(c *gin.Context) string {
+	switch {
+	case isCodexDirectCompactRequest(c):
+		return "compact"
+	case isCodexDirectResponsesRequest(c):
+		return "responses"
+	default:
+		return "unknown"
+	}
 }
 
 func isCodexDirectResponsesRequest(c *gin.Context) bool {

--- a/sdk/api/handlers/openai/openai_responses_direct_continuation_test.go
+++ b/sdk/api/handlers/openai/openai_responses_direct_continuation_test.go
@@ -230,6 +230,69 @@ func TestCodexDirectCompactContinuationPreservesAssistantAndToolEvidence(t *test
 	}, 6)
 }
 
+func TestCodexDirectHiddenOnlyCompactAugmentsRecentAssistantAndToolEvidence(t *testing.T) {
+	resetCodexDirectContinuationsForTest(t)
+
+	model := "gpt-5.4"
+	promptCacheKey := "hidden-compact-scope"
+	beforeCompactResponseID := "resp-before-hidden-compact"
+	compactResponseID := "resp-hidden-compact"
+	beforeCompactOutput := `[` +
+		`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ready"}]},` +
+		`{"type":"function_call","call_id":"call_fn","name":"shell","arguments":"{}"},` +
+		`{"type":"custom_tool_call","call_id":"call_custom","name":"apply_patch","input":"*** Begin Patch"}` +
+		`]`
+	hiddenOnlyCompactOutput := `[{"type":"compaction_summary","summary":[{"type":"summary_text","text":"hidden compact state"}]}]`
+	capture := &directContinuationUpstreamCapture{}
+	upstream := newDirectContinuationUpstream(t, capture,
+		directContinuationUpstreamResponse{
+			path: directCodexUpstreamResponsesPath,
+			body: directContinuationSSECompleted(beforeCompactResponseID, beforeCompactOutput),
+		},
+		directContinuationUpstreamResponse{
+			path: directCodexUpstreamCompactPath,
+			body: []byte(`{"id":"` + compactResponseID + `","object":"response","status":"completed","output":` + hiddenOnlyCompactOutput + `}`),
+		},
+		directContinuationUpstreamResponse{
+			path: directCodexUpstreamResponsesPath,
+			body: directContinuationSSECompleted("resp-after-hidden-compact", `[{"type":"message","role":"assistant","content":[]}]`),
+		},
+	)
+	defer upstream.Close()
+
+	h := newDirectContinuationHandler(t, nil, directContinuationAuthSpec{
+		id:       "direct-hidden-compact-auth",
+		models:   []string{model},
+		baseURL:  upstream.URL,
+		provider: "codex",
+		apiKey:   "test",
+	})
+
+	firstRecorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationWithPromptCacheKey(directContinuationUserMessageBody(model, true), promptCacheKey))
+	if firstRecorder.Code != http.StatusOK {
+		t.Fatalf("first request status = %d, want %d", firstRecorder.Code, http.StatusOK)
+	}
+	compactRecorder := performDirectContinuationRequest(t, h, directCodexCompactPath, directContinuationWithPromptCacheKey(directContinuationCompactBody(model), promptCacheKey))
+	if compactRecorder.Code != http.StatusOK {
+		t.Fatalf("compact request status = %d, want %d", compactRecorder.Code, http.StatusOK)
+	}
+
+	nextRecorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationWithPromptCacheKey(directContinuationToolOutputsBody(model, true, compactResponseID), promptCacheKey))
+	if nextRecorder.Code != http.StatusOK {
+		t.Fatalf("next request status = %d, want %d", nextRecorder.Code, http.StatusOK)
+	}
+	if capture.calls.Load() != 3 {
+		t.Fatalf("upstream calls = %d, want 3", capture.calls.Load())
+	}
+	assertDirectContinuationUpstreamInputCounts(t, capture.lastBody(), map[string]int{
+		"message":                 2,
+		"function_call":           1,
+		"custom_tool_call":        1,
+		"function_call_output":    1,
+		"custom_tool_call_output": 1,
+	}, 6)
+}
+
 func TestCodexDirectPostContinuationRepairsFromStreamOutputItemDoneWhenCompletedOutputEmpty(t *testing.T) {
 	resetCodexDirectContinuationsForTest(t)
 
@@ -475,6 +538,14 @@ func directContinuationToolOutputsBody(model string, stream bool, previousRespon
 	return raw
 }
 
+func directContinuationWithPromptCacheKey(raw []byte, promptCacheKey string) []byte {
+	updated, err := sjson.SetBytes(raw, "prompt_cache_key", promptCacheKey)
+	if err != nil {
+		panic(err)
+	}
+	return updated
+}
+
 type directContinuationUpstreamResponse struct {
 	path        string
 	body        []byte
@@ -582,6 +653,7 @@ func resetCodexDirectContinuationsForTest(t *testing.T) {
 	reset := func() {
 		codexDirectContinuations.mu.Lock()
 		codexDirectContinuations.bindings = make(map[string]codexDirectContinuationBinding)
+		codexDirectContinuations.recentEvidence = make(map[string]codexDirectRecentEvidence)
 		codexDirectContinuations.mu.Unlock()
 	}
 	reset()

--- a/sdk/api/handlers/openai/openai_responses_direct_continuation_test.go
+++ b/sdk/api/handlers/openai/openai_responses_direct_continuation_test.go
@@ -1,0 +1,589 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	directCodexResponsesPath = "/backend-api/codex/responses"
+	directCodexCompactPath   = "/backend-api/codex/responses/compact"
+)
+
+func TestCodexDirectPostContinuationUnknownPreviousResponseIDFailsClosed(t *testing.T) {
+	resetCodexDirectContinuationsForTest(t)
+
+	model := "gpt-5.4"
+	capture := &directContinuationUpstreamCapture{}
+	upstream := newDirectContinuationUpstream(t, capture, directContinuationUpstreamResponse{
+		path: directCodexUpstreamResponsesPath,
+		body: directContinuationSSECompleted("resp-unused", "[]"),
+	})
+	defer upstream.Close()
+
+	h := newDirectContinuationHandler(t, nil, directContinuationAuthSpec{
+		id:       "direct-unknown-auth",
+		models:   []string{model},
+		baseURL:  upstream.URL,
+		provider: "codex",
+		apiKey:   "test",
+	})
+
+	recorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationToolOutputBody(model, true, "resp-unknown"))
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusConflict)
+	}
+	assertDirectContinuationErrorCode(t, recorder.Body.Bytes(), "codex_continuation_auth_unknown")
+	if capture.calls.Load() != 0 {
+		t.Fatalf("upstream calls = %d, want 0", capture.calls.Load())
+	}
+}
+
+func TestCodexDirectPostContinuationModelMismatchFailsClosed(t *testing.T) {
+	resetCodexDirectContinuationsForTest(t)
+
+	modelA := "gpt-5.4"
+	modelB := "gpt-5.4-mini"
+	responseID := "resp-model-a"
+	capture := &directContinuationUpstreamCapture{}
+	upstream := newDirectContinuationUpstream(t, capture, directContinuationUpstreamResponse{
+		path: directCodexUpstreamResponsesPath,
+		body: directContinuationSSECompleted(responseID, `[{"type":"message","role":"assistant","content":[]}]`),
+	})
+	defer upstream.Close()
+
+	h := newDirectContinuationHandler(t, nil, directContinuationAuthSpec{
+		id:       "direct-model-mismatch-auth",
+		models:   []string{modelA, modelB},
+		baseURL:  upstream.URL,
+		provider: "codex",
+		apiKey:   "test",
+	})
+
+	firstRecorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationUserMessageBody(modelA, true))
+	if firstRecorder.Code != http.StatusOK {
+		t.Fatalf("first request status = %d, want %d", firstRecorder.Code, http.StatusOK)
+	}
+
+	secondRecorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationUserMessageBodyWithPreviousID(modelB, true, responseID))
+	if secondRecorder.Code != http.StatusConflict {
+		t.Fatalf("second request status = %d, want %d", secondRecorder.Code, http.StatusConflict)
+	}
+	assertDirectContinuationErrorCode(t, secondRecorder.Body.Bytes(), "codex_continuation_auth_unknown")
+	if capture.calls.Load() != 1 {
+		t.Fatalf("upstream calls = %d, want 1", capture.calls.Load())
+	}
+}
+
+func TestCodexDirectPostContinuationPinsOriginalSelectedAuth(t *testing.T) {
+	resetCodexDirectContinuationsForTest(t)
+
+	model := "gpt-5.4"
+	responseID := "resp-auth-a"
+	captureA := &directContinuationUpstreamCapture{}
+	upstreamA := newDirectContinuationUpstream(t, captureA,
+		directContinuationUpstreamResponse{
+			path: directCodexUpstreamResponsesPath,
+			body: directContinuationSSECompleted(responseID, `[{"type":"message","role":"assistant","content":[]}]`),
+		},
+		directContinuationUpstreamResponse{
+			path: directCodexUpstreamResponsesPath,
+			body: directContinuationSSECompleted("resp-auth-a-2", `[{"type":"message","role":"assistant","content":[]}]`),
+		},
+	)
+	defer upstreamA.Close()
+
+	captureB := &directContinuationUpstreamCapture{}
+	upstreamB := newDirectContinuationUpstream(t, captureB, directContinuationUpstreamResponse{
+		path: directCodexUpstreamResponsesPath,
+		body: directContinuationSSECompleted("resp-auth-b", `[{"type":"message","role":"assistant","content":[]}]`),
+	})
+	defer upstreamB.Close()
+
+	selector := &directContinuationSequenceSelector{firstID: "direct-pin-auth-a", laterID: "direct-pin-auth-b"}
+	h := newDirectContinuationHandler(t, selector,
+		directContinuationAuthSpec{id: "direct-pin-auth-a", models: []string{model}, baseURL: upstreamA.URL, provider: "codex", apiKey: "test-a"},
+		directContinuationAuthSpec{id: "direct-pin-auth-b", models: []string{model}, baseURL: upstreamB.URL, provider: "codex", apiKey: "test-b"},
+	)
+
+	firstRecorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationUserMessageBody(model, true))
+	if firstRecorder.Code != http.StatusOK {
+		t.Fatalf("first request status = %d, want %d", firstRecorder.Code, http.StatusOK)
+	}
+	secondRecorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationUserMessageBodyWithPreviousID(model, true, responseID))
+	if secondRecorder.Code != http.StatusOK {
+		t.Fatalf("second request status = %d, want %d", secondRecorder.Code, http.StatusOK)
+	}
+	if captureA.calls.Load() != 2 {
+		t.Fatalf("auth A upstream calls = %d, want 2", captureA.calls.Load())
+	}
+	if captureB.calls.Load() != 0 {
+		t.Fatalf("auth B upstream calls = %d, want 0", captureB.calls.Load())
+	}
+	assertDirectContinuationUpstreamInputCounts(t, captureA.lastBody(), map[string]int{"message": 3}, 3)
+}
+
+func TestCodexDirectPostContinuationRejectsOrphanToolOutputBeforeUpstream(t *testing.T) {
+	resetCodexDirectContinuationsForTest(t)
+
+	model := "gpt-5.4"
+	responseID := "resp-missing-tool-call"
+	capture := &directContinuationUpstreamCapture{}
+	upstream := newDirectContinuationUpstream(t, capture, directContinuationUpstreamResponse{
+		path: directCodexUpstreamResponsesPath,
+		body: directContinuationSSECompleted(responseID, "[]"),
+	})
+	defer upstream.Close()
+
+	h := newDirectContinuationHandler(t, nil, directContinuationAuthSpec{
+		id:       "direct-orphan-tool-output-auth",
+		models:   []string{model},
+		baseURL:  upstream.URL,
+		provider: "codex",
+		apiKey:   "test",
+	})
+
+	firstRecorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationUserMessageBody(model, true))
+	if firstRecorder.Code != http.StatusOK {
+		t.Fatalf("first request status = %d, want %d", firstRecorder.Code, http.StatusOK)
+	}
+
+	secondRecorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationToolOutputBody(model, true, responseID))
+	if secondRecorder.Code != http.StatusConflict {
+		t.Fatalf("second request status = %d, want %d", secondRecorder.Code, http.StatusConflict)
+	}
+	assertDirectContinuationErrorCode(t, secondRecorder.Body.Bytes(), "codex_continuation_repair_failed")
+	if capture.calls.Load() != 1 {
+		t.Fatalf("upstream calls = %d, want 1", capture.calls.Load())
+	}
+}
+
+func TestCodexDirectCompactContinuationPreservesAssistantAndToolEvidence(t *testing.T) {
+	resetCodexDirectContinuationsForTest(t)
+
+	model := "gpt-5.4"
+	compactResponseID := "resp-compact-evidence"
+	compactOutput := `[` +
+		`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"summary"}]},` +
+		`{"type":"function_call","call_id":"call_fn","name":"shell","arguments":"{}"},` +
+		`{"type":"custom_tool_call","call_id":"call_custom","name":"apply_patch","input":"*** Begin Patch"}` +
+		`]`
+	capture := &directContinuationUpstreamCapture{}
+	upstream := newDirectContinuationUpstream(t, capture,
+		directContinuationUpstreamResponse{
+			path: directCodexUpstreamCompactPath,
+			body: []byte(`{"id":"` + compactResponseID + `","object":"response","status":"completed","output":` + compactOutput + `}`),
+		},
+		directContinuationUpstreamResponse{
+			path: directCodexUpstreamResponsesPath,
+			body: directContinuationSSECompleted("resp-after-compact", `[{"type":"message","role":"assistant","content":[]}]`),
+		},
+	)
+	defer upstream.Close()
+
+	h := newDirectContinuationHandler(t, nil, directContinuationAuthSpec{
+		id:       "direct-compact-auth",
+		models:   []string{model},
+		baseURL:  upstream.URL,
+		provider: "codex",
+		apiKey:   "test",
+	})
+
+	compactRecorder := performDirectContinuationRequest(t, h, directCodexCompactPath, directContinuationCompactBody(model))
+	if compactRecorder.Code != http.StatusOK {
+		t.Fatalf("compact request status = %d, want %d", compactRecorder.Code, http.StatusOK)
+	}
+
+	nextRecorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationToolOutputsBody(model, true, compactResponseID))
+	if nextRecorder.Code != http.StatusOK {
+		t.Fatalf("next request status = %d, want %d", nextRecorder.Code, http.StatusOK)
+	}
+	if capture.calls.Load() != 2 {
+		t.Fatalf("upstream calls = %d, want 2", capture.calls.Load())
+	}
+	assertDirectContinuationUpstreamInputCounts(t, capture.lastBody(), map[string]int{
+		"message":                 2,
+		"function_call":           1,
+		"custom_tool_call":        1,
+		"function_call_output":    1,
+		"custom_tool_call_output": 1,
+	}, 6)
+}
+
+func TestCodexDirectPostContinuationRepairsFromStreamOutputItemDoneWhenCompletedOutputEmpty(t *testing.T) {
+	resetCodexDirectContinuationsForTest(t)
+
+	model := "gpt-5.4"
+	responseID := "resp-stream-output-item-done"
+	capture := &directContinuationUpstreamCapture{}
+	upstream := newDirectContinuationUpstream(t, capture,
+		directContinuationUpstreamResponse{
+			path: directCodexUpstreamResponsesPath,
+			body: []byte(`data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_fn","name":"tool","arguments":"{}"},"output_index":0}` + "\n" +
+				`data: {"type":"response.completed","response":{"id":"` + responseID + `","object":"response","created_at":0,"status":"completed","background":false,"error":null,"output":[]}}` + "\n\n"),
+		},
+		directContinuationUpstreamResponse{
+			path: directCodexUpstreamResponsesPath,
+			body: directContinuationSSECompleted("resp-after-stream-repair", `[{"type":"message","role":"assistant","content":[]}]`),
+		},
+	)
+	defer upstream.Close()
+
+	h := newDirectContinuationHandler(t, nil, directContinuationAuthSpec{
+		id:       "direct-stream-repair-auth",
+		models:   []string{model},
+		baseURL:  upstream.URL,
+		provider: "codex",
+		apiKey:   "test",
+	})
+
+	firstRecorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationUserMessageBody(model, true))
+	if firstRecorder.Code != http.StatusOK {
+		t.Fatalf("first request status = %d, want %d", firstRecorder.Code, http.StatusOK)
+	}
+
+	secondRecorder := performDirectContinuationRequest(t, h, directCodexResponsesPath, directContinuationFunctionToolOutputBody(model, true, responseID, "call_fn"))
+	if secondRecorder.Code != http.StatusOK {
+		t.Fatalf("second request status = %d, want %d", secondRecorder.Code, http.StatusOK)
+	}
+	if capture.calls.Load() != 2 {
+		t.Fatalf("upstream calls = %d, want 2", capture.calls.Load())
+	}
+	assertDirectContinuationUpstreamInputCounts(t, capture.lastBody(), map[string]int{
+		"message":              1,
+		"function_call":        1,
+		"function_call_output": 1,
+	}, 3)
+}
+
+type directContinuationAuthSpec struct {
+	id       string
+	models   []string
+	baseURL  string
+	provider string
+	apiKey   string
+}
+
+func newDirectContinuationHandler(t *testing.T, selector cliproxyauth.Selector, specs ...directContinuationAuthSpec) *OpenAIResponsesAPIHandler {
+	t.Helper()
+
+	manager := cliproxyauth.NewManager(nil, selector, nil)
+	manager.RegisterExecutor(runtimeexecutor.NewCodexExecutor(&config.Config{}))
+	for _, spec := range specs {
+		registerDirectContinuationAuth(t, manager, spec)
+	}
+
+	return NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager))
+}
+
+func registerDirectContinuationAuth(t *testing.T, manager *cliproxyauth.Manager, spec directContinuationAuthSpec) {
+	t.Helper()
+
+	provider := spec.provider
+	if provider == "" {
+		provider = "codex"
+	}
+	apiKey := spec.apiKey
+	if apiKey == "" {
+		apiKey = "test"
+	}
+	models := make([]*registry.ModelInfo, 0, len(spec.models))
+	for _, model := range spec.models {
+		models = append(models, &registry.ModelInfo{
+			ID:      model,
+			Object:  "model",
+			OwnedBy: provider,
+			Type:    provider,
+		})
+	}
+	registry.GetGlobalRegistry().RegisterClient(spec.id, provider, models)
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(spec.id)
+	})
+
+	if _, err := manager.Register(context.Background(), &cliproxyauth.Auth{
+		ID:       spec.id,
+		Provider: provider,
+		Status:   cliproxyauth.StatusActive,
+		Index:    spec.id,
+		Attributes: map[string]string{
+			"api_key":      apiKey,
+			"base_url":     spec.baseURL,
+			"runtime_only": "true",
+		},
+	}); err != nil {
+		t.Fatalf("register auth %s: %v", spec.id, err)
+	}
+	manager.RefreshSchedulerEntry(spec.id)
+}
+
+type directContinuationSequenceSelector struct {
+	firstID string
+	laterID string
+	calls   atomic.Int32
+}
+
+func (s *directContinuationSequenceSelector) Pick(_ context.Context, _, _ string, _ cliproxyexecutor.Options, auths []*cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	if len(auths) == 0 {
+		return nil, errors.New("no auths")
+	}
+	call := s.calls.Add(1)
+	wanted := s.laterID
+	if call == 1 {
+		wanted = s.firstID
+	}
+	for _, auth := range auths {
+		if auth != nil && auth.ID == wanted {
+			return auth, nil
+		}
+	}
+	return auths[0], nil
+}
+
+func performDirectContinuationRequest(t *testing.T, h *OpenAIResponsesAPIHandler, path string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	switch path {
+	case directCodexCompactPath:
+		h.Compact(c)
+	default:
+		h.Responses(c)
+	}
+	return recorder
+}
+
+func directContinuationUserMessageBody(model string, stream bool) []byte {
+	return directContinuationUserMessageBodyWithText(model, stream, "hello")
+}
+
+func directContinuationUserMessageBodyWithPreviousID(model string, stream bool, previousResponseID string) []byte {
+	raw := directContinuationUserMessageBodyWithText(model, stream, "next")
+	updated, err := sjson.SetBytes(raw, "previous_response_id", previousResponseID)
+	if err != nil {
+		panic(err)
+	}
+	return updated
+}
+
+func directContinuationUserMessageBodyWithText(model string, stream bool, text string) []byte {
+	raw, err := json.Marshal(map[string]any{
+		"model":  model,
+		"stream": stream,
+		"input": []any{
+			map[string]any{
+				"type": "message",
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "input_text", "text": text},
+				},
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func directContinuationCompactBody(model string) []byte {
+	raw, err := json.Marshal(map[string]any{
+		"model": model,
+		"input": []any{
+			map[string]any{
+				"type": "message",
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "input_text", "text": "compact source"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func directContinuationToolOutputBody(model string, stream bool, previousResponseID string) []byte {
+	return directContinuationFunctionToolOutputBody(model, stream, previousResponseID, "call_1")
+}
+
+func directContinuationFunctionToolOutputBody(model string, stream bool, previousResponseID string, callID string) []byte {
+	raw, err := json.Marshal(map[string]any{
+		"model":                model,
+		"stream":               stream,
+		"previous_response_id": previousResponseID,
+		"input": []any{
+			map[string]any{
+				"type":    "function_call_output",
+				"call_id": callID,
+				"output":  "ok",
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func directContinuationToolOutputsBody(model string, stream bool, previousResponseID string) []byte {
+	raw, err := json.Marshal(map[string]any{
+		"model":                model,
+		"stream":               stream,
+		"previous_response_id": previousResponseID,
+		"input": []any{
+			map[string]any{
+				"type":    "function_call_output",
+				"call_id": "call_fn",
+				"output":  "ok",
+			},
+			map[string]any{
+				"type":    "custom_tool_call_output",
+				"call_id": "call_custom",
+				"output":  "ok",
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+type directContinuationUpstreamResponse struct {
+	path        string
+	body        []byte
+	contentType string
+}
+
+const (
+	directCodexUpstreamResponsesPath = "/responses"
+	directCodexUpstreamCompactPath   = "/responses/compact"
+)
+
+type directContinuationUpstreamCapture struct {
+	calls atomic.Int32
+	mu    sync.Mutex
+	paths []string
+	body  []byte
+}
+
+func (c *directContinuationUpstreamCapture) record(path string, body []byte) {
+	c.calls.Add(1)
+	c.mu.Lock()
+	c.paths = append(c.paths, path)
+	c.body = append([]byte(nil), body...)
+	c.mu.Unlock()
+}
+
+func (c *directContinuationUpstreamCapture) lastBody() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]byte(nil), c.body...)
+}
+
+func newDirectContinuationUpstream(t *testing.T, capture *directContinuationUpstreamCapture, responses ...directContinuationUpstreamResponse) *httptest.Server {
+	t.Helper()
+
+	var index atomic.Int32
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+		capture.record(r.URL.Path, body)
+
+		i := int(index.Add(1)) - 1
+		if i >= len(responses) {
+			http.Error(w, "unexpected extra call", http.StatusInternalServerError)
+			return
+		}
+		resp := responses[i]
+		if resp.path != "" && r.URL.Path != resp.path {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		contentType := resp.contentType
+		if contentType == "" {
+			contentType = "text/event-stream"
+		}
+		w.Header().Set("Content-Type", contentType)
+		_, _ = w.Write(resp.body)
+	}))
+}
+
+func directContinuationSSECompleted(responseID string, outputJSON string) []byte {
+	return []byte(`data: {"type":"response.completed","response":{"id":"` + responseID + `","object":"response","created_at":0,"status":"completed","background":false,"error":null,"output":` + outputJSON + `}}` + "\n\n")
+}
+
+func assertDirectContinuationUpstreamInputCounts(t *testing.T, body []byte, expected map[string]int, expectedLen int) {
+	t.Helper()
+
+	if gjson.GetBytes(body, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id leaked to upstream body")
+	}
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		t.Fatalf("upstream input is not an array: %s", input.Raw)
+	}
+	items := input.Array()
+	if len(items) != expectedLen {
+		t.Fatalf("upstream input item count = %d, want %d; input=%s", len(items), expectedLen, input.Raw)
+	}
+
+	counts := map[string]int{}
+	for _, item := range items {
+		counts[item.Get("type").String()]++
+	}
+	for itemType, want := range expected {
+		if counts[itemType] != want {
+			t.Fatalf("upstream %s item count = %d, want %d; input=%s", itemType, counts[itemType], want, input.Raw)
+		}
+	}
+}
+
+func assertDirectContinuationErrorCode(t *testing.T, body []byte, expected string) {
+	t.Helper()
+
+	if got := gjson.GetBytes(body, "error.code").String(); got != expected {
+		t.Fatalf("error.code = %q, want %q; body=%s", got, expected, string(body))
+	}
+}
+
+func resetCodexDirectContinuationsForTest(t *testing.T) {
+	t.Helper()
+
+	reset := func() {
+		codexDirectContinuations.mu.Lock()
+		codexDirectContinuations.bindings = make(map[string]codexDirectContinuationBinding)
+		codexDirectContinuations.mu.Unlock()
+	}
+	reset()
+	t.Cleanup(reset)
+}

--- a/sdk/api/handlers/openai/openai_responses_direct_continuation_test.go
+++ b/sdk/api/handlers/openai/openai_responses_direct_continuation_test.go
@@ -336,6 +336,127 @@ func TestCodexDirectHiddenOnlyCompactAugmentsRecentAssistantAndToolEvidence(t *t
 	assertDirectContinuationLogEntryRedacted(t, entry, promptCacheKey, beforeCompactResponseID, compactResponseID, "ready", "*** Begin Patch")
 }
 
+func TestCodexDirectHiddenOnlyCompactResponsePreservesSameTurnEvidence(t *testing.T) {
+	resetCodexDirectContinuationsForTest(t)
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	model := "gpt-5.4"
+	sessionID := "compact-session-same-turn"
+	compactResponseID := "resp-hidden-same-turn"
+	hiddenOnlyCompactOutput := `[{"type":"compaction_summary","summary":[{"type":"summary_text","text":"hidden compact state"}]}]`
+	capture := &directContinuationUpstreamCapture{}
+	upstream := newDirectContinuationUpstream(t, capture, directContinuationUpstreamResponse{
+		path: directCodexUpstreamCompactPath,
+		body: []byte(`{"id":"` + compactResponseID + `","object":"response","status":"completed","output":` + hiddenOnlyCompactOutput + `}`),
+	})
+	defer upstream.Close()
+
+	h := newDirectContinuationHandler(t, nil, directContinuationAuthSpec{
+		id:       "direct-hidden-same-turn-auth",
+		models:   []string{model},
+		baseURL:  upstream.URL,
+		provider: "codex",
+		apiKey:   "test",
+	})
+
+	compactRecorder := performDirectContinuationRequestWithHeaders(t, h, directCodexCompactPath, directContinuationCompactBodyWithSameTurnEvidence(model), map[string]string{
+		"Session_id": sessionID,
+	})
+	if compactRecorder.Code != http.StatusOK {
+		t.Fatalf("compact request status = %d, want %d; body=%s", compactRecorder.Code, http.StatusOK, compactRecorder.Body.String())
+	}
+	if capture.calls.Load() != 1 {
+		t.Fatalf("upstream calls = %d, want 1", capture.calls.Load())
+	}
+	assertDirectContinuationUpstreamInputCounts(t, capture.lastBody(), map[string]int{
+		"message":                 2,
+		"function_call":           1,
+		"custom_tool_call":        1,
+		"function_call_output":    1,
+		"custom_tool_call_output": 1,
+	}, 6)
+	assertDirectContinuationOutputEvidenceCounts(t, compactRecorder.Body.Bytes(), map[string]int{
+		"compaction_summary":      1,
+		"assistant_message":       1,
+		"function_call":           1,
+		"custom_tool_call":        1,
+		"function_call_output":    1,
+		"custom_tool_call_output": 1,
+	}, 6)
+	entry := assertDirectContinuationLogEntry(t, hook, "codex direct http compact evidence diagnostic", map[string]any{
+		"route_kind":                          "compact",
+		"compact_request":                     true,
+		"has_previous_response_id":            false,
+		"scope_present":                       true,
+		"binding_result":                      "none",
+		"repair_result":                       "none",
+		"input_item_count":                    6,
+		"assistant_message_count":             1,
+		"function_call_count":                 2,
+		"function_call_output_count":          2,
+		"compact_output_has_evidence":         false,
+		"same_turn_evidence_hit":              true,
+		"compact_response_evidence_augmented": true,
+		"recent_evidence_hit":                 false,
+		"compact_evidence_augmented":          true,
+		"bound_output_item_count":             6,
+		"bound_output_assistant_count":        1,
+		"bound_output_tool_call_count":        2,
+		"bound_output_tool_output_count":      2,
+		"fail_reason":                         "none",
+	})
+	assertDirectContinuationLogEntryRedacted(t, entry, sessionID, compactResponseID, "assistant evidence", "*** Begin Patch", "ok")
+}
+
+func TestCodexDirectCompactRejectsOrphanSameTurnToolOutputBeforeUpstream(t *testing.T) {
+	resetCodexDirectContinuationsForTest(t)
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	model := "gpt-5.4"
+	sessionID := "compact-session-orphan"
+	capture := &directContinuationUpstreamCapture{}
+	upstream := newDirectContinuationUpstream(t, capture, directContinuationUpstreamResponse{
+		path: directCodexUpstreamCompactPath,
+		body: []byte(`{"id":"resp-unused","object":"response","status":"completed","output":[]}`),
+	})
+	defer upstream.Close()
+
+	h := newDirectContinuationHandler(t, nil, directContinuationAuthSpec{
+		id:       "direct-compact-orphan-auth",
+		models:   []string{model},
+		baseURL:  upstream.URL,
+		provider: "codex",
+		apiKey:   "test",
+	})
+
+	compactRecorder := performDirectContinuationRequestWithHeaders(t, h, directCodexCompactPath, directContinuationCompactBodyWithOrphanToolOutput(model), map[string]string{
+		"Session_id": sessionID,
+	})
+	if compactRecorder.Code != http.StatusConflict {
+		t.Fatalf("compact request status = %d, want %d; body=%s", compactRecorder.Code, http.StatusConflict, compactRecorder.Body.String())
+	}
+	assertDirectContinuationErrorCode(t, compactRecorder.Body.Bytes(), "codex_compact_evidence_unsafe")
+	if capture.calls.Load() != 0 {
+		t.Fatalf("upstream calls = %d, want 0", capture.calls.Load())
+	}
+	entry := assertDirectContinuationLogEntry(t, hook, "codex direct http continuation diagnostic", map[string]any{
+		"route_kind":                 "compact",
+		"compact_request":            true,
+		"has_previous_response_id":   false,
+		"scope_present":              true,
+		"binding_result":             "none",
+		"repair_result":              "failed",
+		"input_item_count":           2,
+		"assistant_message_count":    0,
+		"function_call_count":        0,
+		"function_call_output_count": 1,
+		"fail_reason":                "orphan_tool_output",
+	})
+	assertDirectContinuationLogEntryRedacted(t, entry, sessionID, "orphan result")
+}
+
 func TestCodexDirectPostContinuationRepairsFromStreamOutputItemDoneWhenCompletedOutputEmpty(t *testing.T) {
 	resetCodexDirectContinuationsForTest(t)
 
@@ -468,11 +589,19 @@ func (s *directContinuationSequenceSelector) Pick(_ context.Context, _, _ string
 
 func performDirectContinuationRequest(t *testing.T, h *OpenAIResponsesAPIHandler, path string, body []byte) *httptest.ResponseRecorder {
 	t.Helper()
+	return performDirectContinuationRequestWithHeaders(t, h, path, body, nil)
+}
+
+func performDirectContinuationRequestWithHeaders(t *testing.T, h *OpenAIResponsesAPIHandler, path string, body []byte, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
 
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 	c.Request = httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	for name, value := range headers {
+		c.Request.Header.Set(name, value)
+	}
 	switch path {
 	case directCodexCompactPath:
 		h.Compact(c)
@@ -525,6 +654,78 @@ func directContinuationCompactBody(model string) []byte {
 				"content": []any{
 					map[string]any{"type": "input_text", "text": "compact source"},
 				},
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func directContinuationCompactBodyWithSameTurnEvidence(model string) []byte {
+	raw, err := json.Marshal(map[string]any{
+		"model": model,
+		"input": []any{
+			map[string]any{
+				"type": "message",
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "input_text", "text": "compact source"},
+				},
+			},
+			map[string]any{
+				"type": "message",
+				"role": "assistant",
+				"content": []any{
+					map[string]any{"type": "output_text", "text": "assistant evidence"},
+				},
+			},
+			map[string]any{
+				"type":      "function_call",
+				"call_id":   "call_fn",
+				"name":      "shell",
+				"arguments": "{}",
+			},
+			map[string]any{
+				"type":    "function_call_output",
+				"call_id": "call_fn",
+				"output":  "ok",
+			},
+			map[string]any{
+				"type":    "custom_tool_call",
+				"call_id": "call_custom",
+				"name":    "apply_patch",
+				"input":   "*** Begin Patch",
+			},
+			map[string]any{
+				"type":    "custom_tool_call_output",
+				"call_id": "call_custom",
+				"output":  "ok",
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func directContinuationCompactBodyWithOrphanToolOutput(model string) []byte {
+	raw, err := json.Marshal(map[string]any{
+		"model": model,
+		"input": []any{
+			map[string]any{
+				"type": "message",
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "input_text", "text": "compact source"},
+				},
+			},
+			map[string]any{
+				"type":    "function_call_output",
+				"call_id": "missing_call",
+				"output":  "orphan result",
 			},
 		},
 	})
@@ -678,6 +879,37 @@ func assertDirectContinuationUpstreamInputCounts(t *testing.T, body []byte, expe
 	for itemType, want := range expected {
 		if counts[itemType] != want {
 			t.Fatalf("upstream %s item count = %d, want %d; input=%s", itemType, counts[itemType], want, input.Raw)
+		}
+	}
+}
+
+func assertDirectContinuationOutputEvidenceCounts(t *testing.T, body []byte, expected map[string]int, expectedLen int) {
+	t.Helper()
+
+	output := gjson.GetBytes(body, "output")
+	if !output.IsArray() {
+		t.Fatalf("response output is not an array: %s", output.Raw)
+	}
+	items := output.Array()
+	if len(items) != expectedLen {
+		t.Fatalf("response output item count = %d, want %d; output=%s", len(items), expectedLen, output.Raw)
+	}
+
+	counts := map[string]int{}
+	for _, item := range items {
+		itemType := item.Get("type").String()
+		if itemType == "message" && item.Get("role").String() == "assistant" {
+			counts["assistant_message"]++
+		} else {
+			counts[itemType]++
+		}
+		if itemType == "message" && item.Get("role").String() == "user" {
+			t.Fatalf("response output must not echo user messages: %s", item.Raw)
+		}
+	}
+	for itemType, want := range expected {
+		if counts[itemType] != want {
+			t.Fatalf("response output %s item count = %d, want %d; output=%s", itemType, counts[itemType], want, output.Raw)
 		}
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_direct_continuation_test.go
+++ b/sdk/api/handlers/openai/openai_responses_direct_continuation_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -21,6 +23,8 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -180,6 +184,8 @@ func TestCodexDirectPostContinuationRejectsOrphanToolOutputBeforeUpstream(t *tes
 
 func TestCodexDirectCompactContinuationPreservesAssistantAndToolEvidence(t *testing.T) {
 	resetCodexDirectContinuationsForTest(t)
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
 
 	model := "gpt-5.4"
 	compactResponseID := "resp-compact-evidence"
@@ -228,10 +234,26 @@ func TestCodexDirectCompactContinuationPreservesAssistantAndToolEvidence(t *test
 		"function_call_output":    1,
 		"custom_tool_call_output": 1,
 	}, 6)
+	entry := assertDirectContinuationLogEntry(t, hook, "codex direct http continuation diagnostic", map[string]any{
+		"route_kind":                 "responses",
+		"compact_request":            false,
+		"has_previous_response_id":   true,
+		"scope_present":              false,
+		"binding_result":             "hit",
+		"repair_result":              "repaired",
+		"input_item_count":           6,
+		"assistant_message_count":    1,
+		"function_call_count":        2,
+		"function_call_output_count": 2,
+		"fail_reason":                "none",
+	})
+	assertDirectContinuationLogEntryRedacted(t, entry, compactResponseID, "summary", "*** Begin Patch", "ok")
 }
 
 func TestCodexDirectHiddenOnlyCompactAugmentsRecentAssistantAndToolEvidence(t *testing.T) {
 	resetCodexDirectContinuationsForTest(t)
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
 
 	model := "gpt-5.4"
 	promptCacheKey := "hidden-compact-scope"
@@ -291,6 +313,27 @@ func TestCodexDirectHiddenOnlyCompactAugmentsRecentAssistantAndToolEvidence(t *t
 		"function_call_output":    1,
 		"custom_tool_call_output": 1,
 	}, 6)
+	entry := assertDirectContinuationLogEntry(t, hook, "codex direct http compact evidence diagnostic", map[string]any{
+		"route_kind":                     "compact",
+		"compact_request":                true,
+		"has_previous_response_id":       false,
+		"scope_present":                  true,
+		"binding_result":                 "none",
+		"repair_result":                  "none",
+		"input_item_count":               1,
+		"assistant_message_count":        0,
+		"function_call_count":            0,
+		"function_call_output_count":     0,
+		"compact_output_has_evidence":    false,
+		"recent_evidence_hit":            true,
+		"compact_evidence_augmented":     true,
+		"bound_output_item_count":        3,
+		"bound_output_assistant_count":   1,
+		"bound_output_tool_call_count":   2,
+		"bound_output_tool_output_count": 0,
+		"fail_reason":                    "none",
+	})
+	assertDirectContinuationLogEntryRedacted(t, entry, promptCacheKey, beforeCompactResponseID, compactResponseID, "ready", "*** Begin Patch")
 }
 
 func TestCodexDirectPostContinuationRepairsFromStreamOutputItemDoneWhenCompletedOutputEmpty(t *testing.T) {
@@ -645,6 +688,49 @@ func assertDirectContinuationErrorCode(t *testing.T, body []byte, expected strin
 	if got := gjson.GetBytes(body, "error.code").String(); got != expected {
 		t.Fatalf("error.code = %q, want %q; body=%s", got, expected, string(body))
 	}
+}
+
+func assertDirectContinuationLogEntry(t *testing.T, hook *logtest.Hook, message string, expected map[string]any) *log.Entry {
+	t.Helper()
+
+	for _, entry := range hook.AllEntries() {
+		if entry.Message != message {
+			continue
+		}
+		matched := true
+		for key, want := range expected {
+			if got := entry.Data[key]; got != want {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return entry
+		}
+	}
+	t.Fatalf("missing log entry %q with fields %v; got %v", message, expected, directContinuationLogFields(hook.AllEntries()))
+	return nil
+}
+
+func assertDirectContinuationLogEntryRedacted(t *testing.T, entry *log.Entry, forbidden ...string) {
+	t.Helper()
+
+	for key, value := range entry.Data {
+		text := fmt.Sprint(value)
+		for _, needle := range forbidden {
+			if needle != "" && strings.Contains(text, needle) {
+				t.Fatalf("log field %q leaked forbidden value %q in %q", key, needle, text)
+			}
+		}
+	}
+}
+
+func directContinuationLogFields(entries []*log.Entry) []log.Fields {
+	fields := make([]log.Fields, 0, len(entries))
+	for _, entry := range entries {
+		fields = append(fields, entry.Data)
+	}
+	return fields
 }
 
 func resetCodexDirectContinuationsForTest(t *testing.T) {

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -437,6 +437,14 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 		return
 	}
 	if continuation != nil {
+		var errCompactEvidence error
+		resp, errCompactEvidence = continuation.compactResponseWithSameTurnEvidence(resp)
+		if errCompactEvidence != nil {
+			continuation.logDecision(requestJSON, "none", "failed", codexDirectContinuationRepairFailReason(errCompactEvidence))
+			writeCodexDirectCompactEvidenceError(c)
+			cliCancel(errCompactEvidence)
+			return
+		}
 		continuation.bindResponseIDs(resp)
 	}
 	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -423,13 +423,21 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 	c.Header("Content-Type", "application/json")
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	cliCtx, requestJSON, continuation, okPrepare := h.prepareCodexDirectContinuationContext(c, rawJSON, modelName, cliCtx)
+	if !okPrepare {
+		cliCancel(nil)
+		return
+	}
 	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
-	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "responses/compact")
+	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, h.HandlerType(), modelName, requestJSON, "responses/compact")
 	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)
 		cliCancel(errMsg.Error)
 		return
+	}
+	if continuation != nil {
+		continuation.bindResponseIDs(resp)
 	}
 	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 	_, _ = c.Writer.Write(resp)
@@ -448,14 +456,22 @@ func (h *OpenAIResponsesAPIHandler) handleNonStreamingResponse(c *gin.Context, r
 
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	cliCtx, requestJSON, continuation, okPrepare := h.prepareCodexDirectContinuationContext(c, rawJSON, modelName, cliCtx)
+	if !okPrepare {
+		cliCancel(nil)
+		return
+	}
 	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
 
-	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, h.HandlerType(), modelName, requestJSON, "")
 	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)
 		cliCancel(errMsg.Error)
 		return
+	}
+	if continuation != nil {
+		continuation.bindResponseIDs(resp)
 	}
 	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 	_, _ = c.Writer.Write(resp)
@@ -485,7 +501,15 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 	// New core execution path
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
-	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+	cliCtx, requestJSON, continuation, okPrepare := h.prepareCodexDirectContinuationContext(c, rawJSON, modelName, cliCtx)
+	if !okPrepare {
+		cliCancel(nil)
+		return
+	}
+	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, requestJSON, "")
+	if continuation != nil {
+		dataChan = continuation.observeStream(dataChan)
+	}
 
 	setSSEHeaders := func() {
 		c.Header("Content-Type", "text/event-stream")


### PR DESCRIPTION
## Summary

This PR preserves Codex HTTP Responses compact evidence when the upstream compact response is summary-only/hidden-only.

- Tracks direct Codex HTTP `/backend-api/codex/responses` response IDs and selected auth ownership.
- Repairs safe `previous_response_id` continuations locally before sending them upstream.
- Preserves same-turn assistant/tool-call/tool-output evidence in downstream `/responses/compact` responses when upstream compact output lacks that evidence.
- Fails closed for unsafe orphan tool outputs instead of forwarding corrupted continuations.
- Adds redacted diagnostics and formatter coverage so compact evidence behavior is visible without logging prompts, response IDs, prompt cache keys, tool arguments, or message text.

## Why

Codex Desktop can receive a compact response whose `output` contains only compact/summary state and no explicit assistant/tool evidence. If the client rebuilds local state from that compact response, a later turn can lose the same-turn tool-call/tool-output relationship.

The fix augments the compact response before returning it to the client, while also keeping the server-side continuation binding as a fallback.

## Validation

- `go test ./sdk/api/handlers/openai -run 'TestCodexDirect'`
- `go test ./sdk/api/handlers/openai`
- `go test ./internal/logging`
- `go build -o test-output ./cmd/server`
- `git diff --check`

Manual runtime validation on a local deployment:

- `POST /backend-api/codex/responses/compact` returned `200`.
- Redacted diagnostics showed `compact_output_has_evidence=false`, `same_turn_evidence_hit=true`, `compact_response_evidence_augmented=true`, and non-zero assistant/tool-call/tool-output counts.
