### PR TITLE
fix: DeepSeek reasoning_content 处理和多轮对话兼容性

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -372,6 +372,15 @@ func (s *Server) setupRoutes() {
 		codexDirect.POST("/responses/compact", openaiResponsesHandlers.Compact)
 	}
 
+	// Codex CLI wire_api="responses" 根路径路由
+	// 当 Codex config.toml 配置 wire_api = "responses" 时，请求直接发到 /responses
+	s.engine.GET("/responses", AuthMiddleware(s.accessManager), openaiResponsesHandlers.ResponsesWebsocket)
+	s.engine.POST("/responses", AuthMiddleware(s.accessManager), openaiResponsesHandlers.Responses)
+	s.engine.POST("/responses/compact", AuthMiddleware(s.accessManager), openaiResponsesHandlers.Compact)
+
+	// Codex CLI 兼容路由：/models（不带 /v1 前缀）
+	s.engine.GET("/models", AuthMiddleware(s.accessManager), s.unifiedModelsHandler(openaiHandlers, claudeCodeHandlers))
+
 	// Gemini compatible API routes
 	v1beta := s.engine.Group("/v1beta")
 	v1beta.Use(AuthMiddleware(s.accessManager))

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1873,6 +1873,41 @@
       }
     }
   ],
+  "deepseek": [
+    {
+      "id": "deepseek-v4-pro",
+      "object": "model",
+      "created": 1778150400,
+      "owned_by": "deepseek",
+      "type": "deepseek",
+      "display_name": "DeepSeek V4 Pro",
+      "description": "DeepSeek V4 Pro - Advanced reasoning model with extended thinking capabilities",
+      "context_length": 128000,
+      "max_completion_tokens": 8192,
+      "thinking": {
+        "min": 1024,
+        "max": 32000,
+        "zero_allowed": true,
+        "dynamic_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "object": "model",
+      "created": 1778150400,
+      "owned_by": "deepseek",
+      "type": "deepseek",
+      "display_name": "DeepSeek V4 Flash",
+      "description": "DeepSeek V4 Flash - Fast and efficient model for general tasks",
+      "context_length": 128000,
+      "max_completion_tokens": 8192
+    }
+  ],
   "antigravity": [
     {
       "id": "claude-opus-4-6-thinking",

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -90,6 +90,7 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 	if providerKey == "" {
 		providerKey = providerFormat
 	}
+
 	fromFormat = strings.ToLower(strings.TrimSpace(fromFormat))
 	if fromFormat == "" {
 		fromFormat = providerFormat

--- a/internal/translator/codex/openai/chat-completions/codex_openai_request.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -28,6 +29,16 @@ import (
 //   - []byte: The transformed request data in OpenAI Responses API format
 func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream bool) []byte {
 	rawJSON := inputRawJSON
+
+	// DEBUG: 打印原始请求
+	log.Debugf("codex chat-completions: raw input JSON (first 2000 chars): %s", func() string {
+		s := string(rawJSON)
+		if len(s) > 2000 {
+			return s[:2000] + "..."
+		}
+		return s
+	}())
+
 	// Start with empty JSON object
 	out := []byte(`{"instructions":""}`)
 
@@ -197,6 +208,19 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 					}
 				}
 
+				// Handle reasoning_content for assistant messages (DeepSeek requires passing back in multi-turn)
+				// Convert reasoning_content string to reasoning type with summary
+				if role == "assistant" {
+					rc := m.Get("reasoning_content")
+					if rc.Exists() && rc.Type == gjson.String && rc.String() != "" {
+						reasoningPart := []byte(`{}`)
+						reasoningPart, _ = sjson.SetBytes(reasoningPart, "type", "reasoning")
+						reasoningPart, _ = sjson.SetRawBytes(reasoningPart, "summary", []byte(`[{"type":"summary_text","text":""}]`))
+						reasoningPart, _ = sjson.SetBytes(reasoningPart, "summary.0.text", rc.String())
+						msg, _ = sjson.SetRawBytes(msg, "content.-1", reasoningPart)
+					}
+				}
+
 				// Don't emit empty assistant messages when only tool_calls
 				// are present — Responses API needs function_call items
 				// directly, otherwise call_id matching fails (#2132).
@@ -356,6 +380,16 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 	}
 
 	out, _ = sjson.SetBytes(out, "store", false)
+
+	// DEBUG: 打印翻译后的请求
+	log.Debugf("codex chat-completions: translated output JSON (first 2000 chars): %s", func() string {
+		s := string(out)
+		if len(s) > 2000 {
+			return s[:2000] + "..."
+		}
+		return s
+	}())
+
 	return out
 }
 

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -11,6 +11,15 @@ import (
 func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte, _ bool) []byte {
 	rawJSON := inputRawJSON
 
+	// DEBUG: 打印原始请求
+	log.Debugf("codex responses: raw input JSON (first 2000 chars): %s", func() string {
+		s := string(rawJSON)
+		if len(s) > 2000 {
+			return s[:2000] + "..."
+		}
+		return s
+	}())
+
 	inputResult := gjson.GetBytes(rawJSON, "input")
 	if inputResult.Type == gjson.String {
 		input, _ := sjson.SetBytes([]byte(`[{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}]`), "0.content.0.text", inputResult.String())
@@ -40,7 +49,18 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 
 	// Convert role "system" to "developer" in input array to comply with Codex API requirements.
 	rawJSON = convertSystemRoleToDeveloper(rawJSON)
+	// Convert reasoning_content to reasoning type for DeepSeek multi-turn compatibility.
+	rawJSON = convertReasoningContentToReasoning(rawJSON)
 	rawJSON = normalizeCodexBuiltinTools(rawJSON)
+
+	// DEBUG: 打印翻译后的请求
+	log.Debugf("codex responses: translated output JSON (first 2000 chars): %s", func() string {
+		s := string(rawJSON)
+		if len(s) > 2000 {
+			return s[:2000] + "..."
+		}
+		return s
+	}())
 
 	return rawJSON
 }
@@ -80,6 +100,61 @@ func convertSystemRoleToDeveloper(rawJSON []byte) []byte {
 		if gjson.GetBytes(result, rolePath).String() == "system" {
 			result, _ = sjson.SetBytes(result, rolePath, "developer")
 		}
+	}
+
+	return result
+}
+
+// convertReasoningContentToReasoning traverses the input array and converts
+// reasoning_content in assistant messages to reasoning type with summary.
+// DeepSeek requires passing reasoning_content back in multi-turn conversations.
+func convertReasoningContentToReasoning(rawJSON []byte) []byte {
+	inputResult := gjson.GetBytes(rawJSON, "input")
+	if !inputResult.IsArray() {
+		return rawJSON
+	}
+
+	inputArray := inputResult.Array()
+	result := rawJSON
+
+	for i := 0; i < len(inputArray); i++ {
+		rolePath := fmt.Sprintf("input.%d.role", i)
+		role := gjson.GetBytes(result, rolePath).String()
+
+		// Only process assistant messages
+		if role != "assistant" {
+			continue
+		}
+
+		// Check if reasoning_content exists
+		rcPath := fmt.Sprintf("input.%d.reasoning_content", i)
+		rc := gjson.GetBytes(result, rcPath)
+		if !rc.Exists() || rc.Type != gjson.String || rc.String() == "" {
+			continue
+		}
+
+		// Get content array
+		contentPath := fmt.Sprintf("input.%d.content", i)
+		contentResult := gjson.GetBytes(result, contentPath)
+		if !contentResult.IsArray() {
+			// Create content array if it doesn't exist
+			result, _ = sjson.SetRawBytes(result, contentPath, []byte(`[]`))
+		}
+
+		// Add reasoning item to content
+		// Find the last index of content array
+		contentArray := gjson.GetBytes(result, contentPath).Array()
+		lastIdx := len(contentArray)
+
+		// Create reasoning summary item
+		reasoningItemPath := fmt.Sprintf("input.%d.content.%d", i, lastIdx)
+		reasoningItem := []byte(`{"type":"reasoning","summary":[{"type":"summary_text","text":""}]}`)
+		reasoningItem, _ = sjson.SetBytes(reasoningItem, "summary.0.text", rc.String())
+
+		result, _ = sjson.SetRawBytes(result, reasoningItemPath, reasoningItem)
+
+		// Delete the original reasoning_content field
+		result, _ = sjson.DeleteBytes(result, rcPath)
 	}
 
 	return result

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -28,6 +28,7 @@ import (
 //   - []byte: The transformed request data in OpenAI chat completions format
 func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inputRawJSON []byte, stream bool) []byte {
 	rawJSON := inputRawJSON
+
 	// Base OpenAI chat completions template with default values
 	out := []byte(`{"model":"","messages":[],"stream":false}`)
 
@@ -67,6 +68,10 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			case "message", "":
 				// Handle regular message conversion
 				role := item.Get("role").String()
+				// Skip items with empty role - these are invalid messages
+				if role == "" {
+					return true
+				}
 				if role == "developer" {
 					role = "user"
 				}
@@ -109,6 +114,14 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					message, _ = sjson.SetBytes(message, "content", content.String())
 				}
 
+				// Handle reasoning_content in message (for DeepSeek thinking mode)
+				// When assistant message has reasoning_content, pass it through
+				if role == "assistant" {
+					if rc := item.Get("reasoning_content"); rc.Exists() && rc.String() != "" {
+						message, _ = sjson.SetBytes(message, "reasoning_content", rc.String())
+					}
+				}
+
 				out, _ = sjson.SetRawBytes(out, "messages.-1", message)
 
 			case "function_call":
@@ -145,6 +158,38 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				}
 
 				out, _ = sjson.SetRawBytes(out, "messages.-1", toolMessage)
+
+			case "reasoning":
+				// Handle reasoning item conversion for DeepSeek thinking mode
+				// DeepSeek requires reasoning_content to be passed back in subsequent requests
+				// The reasoning item has a summary array with text content
+				summary := item.Get("summary")
+				if summary.Exists() && summary.IsArray() {
+					// Concatenate all summary text parts
+					var reasoningText strings.Builder
+					summary.ForEach(func(_, summaryItem gjson.Result) bool {
+						if summaryItem.Get("type").String() == "summary_text" {
+							text := summaryItem.Get("text").String()
+							if text != "" {
+								reasoningText.WriteString(text)
+							}
+						}
+						return true
+					})
+
+					// DeepSeek V4 requires reasoning_content even if empty
+					// When Codex CLI sends empty reasoning text, fill with placeholder
+					reasoningStr := reasoningText.String()
+					if reasoningStr == "" {
+						reasoningStr = "[reasoning unavailable]"
+					}
+
+					// Create assistant message with reasoning_content for DeepSeek
+					// DeepSeek expects: {"role":"assistant","content":"","reasoning_content":"..."}
+					reasoningMessage := []byte(`{"role":"assistant","content":"","reasoning_content":""}`)
+					reasoningMessage, _ = sjson.SetBytes(reasoningMessage, "reasoning_content", reasoningStr)
+					out, _ = sjson.SetRawBytes(out, "messages.-1", reasoningMessage)
+				}
 			}
 
 			return true
@@ -173,18 +218,45 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			chatTool := []byte(`{"type":"function","function":{}}`)
 
 			// Convert tool structure from responses format to chat completions format
+			// Handle both flat format {"name": "xxx"} and nested format {"function": {"name": "xxx"}}
 			function := []byte(`{"name":"","description":"","parameters":{}}`)
 
-			if name := tool.Get("name"); name.Exists() {
-				function, _ = sjson.SetBytes(function, "name", name.String())
+			// Try nested format first (Codex CLI sends {"type": "function", "function": {"name": "xxx"}})
+			nestedFunction := tool.Get("function")
+			if nestedFunction.Exists() && nestedFunction.IsObject() {
+				if name := nestedFunction.Get("name"); name.Exists() {
+					function, _ = sjson.SetBytes(function, "name", name.String())
+				}
+				if description := nestedFunction.Get("description"); description.Exists() {
+					function, _ = sjson.SetBytes(function, "description", description.String())
+				}
+				if parameters := nestedFunction.Get("parameters"); parameters.Exists() {
+					function, _ = sjson.SetRawBytes(function, "parameters", []byte(parameters.Raw))
+				}
+				// Ensure parameters has type: object (required by most providers)
+				if !gjson.GetBytes(function, "parameters.type").Exists() {
+					function, _ = sjson.SetBytes(function, "parameters.type", "object")
+				}
+			} else {
+				// Fall back to flat format {"type": "function", "name": "xxx"}
+				if name := tool.Get("name"); name.Exists() {
+					function, _ = sjson.SetBytes(function, "name", name.String())
+				}
+				if description := tool.Get("description"); description.Exists() {
+					function, _ = sjson.SetBytes(function, "description", description.String())
+				}
+				if parameters := tool.Get("parameters"); parameters.Exists() {
+					function, _ = sjson.SetRawBytes(function, "parameters", []byte(parameters.Raw))
+				}
+				// Ensure parameters has type: object (required by most providers)
+				if !gjson.GetBytes(function, "parameters.type").Exists() {
+					function, _ = sjson.SetBytes(function, "parameters.type", "object")
+				}
 			}
 
-			if description := tool.Get("description"); description.Exists() {
-				function, _ = sjson.SetBytes(function, "description", description.String())
-			}
-
-			if parameters := tool.Get("parameters"); parameters.Exists() {
-				function, _ = sjson.SetRawBytes(function, "parameters", []byte(parameters.Raw))
+			// Skip tools with empty names (invalid for most providers)
+			if gjson.GetBytes(function, "name").String() == "" {
+				return true
 			}
 
 			chatTool, _ = sjson.SetRawBytes(chatTool, "function", function)

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -983,8 +983,13 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 							modelID = m.Name
 						}
 						thinking := m.Thinking
+
+						// DEBUG: 打印 config 中的 thinking 值
+						log.Debugf("registerModelsForAuth: model=%s, config thinking=%v, type=%T", modelID, thinking, thinking)
+
 						if thinking == nil {
 							thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+							log.Debugf("registerModelsForAuth: model=%s, using default thinking", modelID)
 						}
 						ms = append(ms, &ModelInfo{
 							ID:          modelID,


### PR DESCRIPTION
## Summary

修复 Codex CLI + DeepSeek 多轮对话失败问题。

### 核心修复

- **reasoning item 空 text 处理**：转换为 `[reasoning unavailable]` placeholder，满足 DeepSeek V4 要求
- **reasoning.effort 映射**：正确映射到 `reasoning_effort` 字段
- **reasoning_content 透传**：在 Responses API → Chat Completions 转换中保留 reasoning_content

### 其他改进

- 添加 `/responses` 根路径路由支持 `wire_api="responses"`
- 注册 DeepSeek V4 Pro/Flash 模型到 registry
- 处理嵌套和扁平格式的 tool 定义（Codex CLI 发送嵌套格式）
- 跳过空名称的 tool 和空 role 的 message

## Test Plan

- [x] 第一次请求（无历史）→ 成功
- [x] 第二次请求（带 reasoning + 有内容）→ 成功
- [x] 第二次请求（带 reasoning + 空 text）→ 成功
- [x] Streaming 模式 → 成功

## Files Changed

| File | Changes |
|------|---------|
| `internal/translator/openai/openai/responses/openai_openai-responses_request.go` | reasoning 转换逻辑 |
| `internal/translator/codex/openai/responses/codex_openai-responses_request.go` | reasoning_content → reasoning 转换 |
| `internal/translator/codex/openai/chat-completions/codex_openai_request.go` | reasoning_content 处理 |
| `internal/registry/models/models.json` | DeepSeek 模型注册 |
| `internal/api/server.go` | `/responses` 路路由 |