### PR TITLE
fix(openai-compatible): ignore null stream usage chunks

### DIFF
--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -301,27 +301,29 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	return detail
 }
 
+func isOpenAIStyleUsageNode(usageNode gjson.Result) bool {
+	return usageNode.IsObject() &&
+		(usageNode.Get("prompt_tokens").Exists() ||
+			usageNode.Get("input_tokens").Exists() ||
+			usageNode.Get("completion_tokens").Exists() ||
+			usageNode.Get("output_tokens").Exists() ||
+			usageNode.Get("total_tokens").Exists() ||
+			usageNode.Get("prompt_tokens_details.cached_tokens").Exists() ||
+			usageNode.Get("input_tokens_details.cached_tokens").Exists() ||
+			usageNode.Get("completion_tokens_details.reasoning_tokens").Exists() ||
+			usageNode.Get("output_tokens_details.reasoning_tokens").Exists())
+}
+
 func ParseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {
 	payload := jsonPayload(line)
 	if len(payload) == 0 || !gjson.ValidBytes(payload) {
 		return usage.Detail{}, false
 	}
 	usageNode := gjson.GetBytes(payload, "usage")
-	if !usageNode.Exists() {
+	if !isOpenAIStyleUsageNode(usageNode) {
 		return usage.Detail{}, false
 	}
-	detail := usage.Detail{
-		InputTokens:  usageNode.Get("prompt_tokens").Int(),
-		OutputTokens: usageNode.Get("completion_tokens").Int(),
-		TotalTokens:  usageNode.Get("total_tokens").Int(),
-	}
-	if cached := usageNode.Get("prompt_tokens_details.cached_tokens"); cached.Exists() {
-		detail.CachedTokens = cached.Int()
-	}
-	if reasoning := usageNode.Get("completion_tokens_details.reasoning_tokens"); reasoning.Exists() {
-		detail.ReasoningTokens = reasoning.Int()
-	}
-	return detail, true
+	return parseOpenAIStyleUsageNode(usageNode), true
 }
 
 func ParseClaudeUsage(data []byte) usage.Detail {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -48,6 +48,50 @@ func TestParseOpenAIUsageResponses(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIStreamUsageIgnoresNullUsage(t *testing.T) {
+	line := []byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}],"usage":null}`)
+	if detail, ok := ParseOpenAIStreamUsage(line); ok {
+		t.Fatalf("ParseOpenAIStreamUsage() = (%+v, true), want false for null usage", detail)
+	}
+}
+
+func TestParseOpenAIStreamUsageIgnoresUsageWithoutTokenFields(t *testing.T) {
+	lines := map[string][]byte{
+		"empty object":  []byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[],"usage":{}}`),
+		"metadata only": []byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[],"usage":{"status":"pending"}}`),
+	}
+	for name, line := range lines {
+		t.Run(name, func(t *testing.T) {
+			if detail, ok := ParseOpenAIStreamUsage(line); ok {
+				t.Fatalf("ParseOpenAIStreamUsage() = (%+v, true), want false for usage without token fields", detail)
+			}
+		})
+	}
+}
+
+func TestParseOpenAIStreamUsageResponsesFields(t *testing.T) {
+	line := []byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[],"usage":{"input_tokens":10,"output_tokens":20,"total_tokens":30,"input_tokens_details":{"cached_tokens":7},"output_tokens_details":{"reasoning_tokens":9}}}`)
+	detail, ok := ParseOpenAIStreamUsage(line)
+	if !ok {
+		t.Fatal("ParseOpenAIStreamUsage() ok = false, want true")
+	}
+	if detail.InputTokens != 10 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 10)
+	}
+	if detail.OutputTokens != 20 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 20)
+	}
+	if detail.TotalTokens != 30 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 30)
+	}
+	if detail.CachedTokens != 7 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 7)
+	}
+	if detail.ReasoningTokens != 9 {
+		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 9)
+	}
+}
+
 func TestParseGeminiCLIUsage_TopLevelUsageMetadata(t *testing.T) {
 	data := []byte(`{"usageMetadata":{"promptTokenCount":11,"candidatesTokenCount":7,"thoughtsTokenCount":3,"totalTokenCount":21,"cachedContentTokenCount":5}}`)
 	detail := ParseGeminiCLIUsage(data)

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -2,13 +2,16 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/redisqueue"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
@@ -178,4 +181,98 @@ func TestOpenAICompatExecutorStreamSkipsKeepAliveUntilDataLine(t *testing.T) {
 	if gjson.Get(got.String(), "choices.0.delta.content").String() != "hello" {
 		t.Fatalf("stream payload = %s", got.String())
 	}
+}
+
+func TestOpenAICompatExecutorStreamPublishesFinalUsageAfterNullUsageChunks(t *testing.T) {
+	withOpenAICompatUsageQueue(t, func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}],"usage":null}` + "\n"))
+			_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}}` + "\n"))
+			_, _ = w.Write([]byte("data: [DONE]\n"))
+		}))
+		defer server.Close()
+
+		executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+		auth := &cliproxyauth.Auth{Attributes: map[string]string{
+			"base_url": server.URL + "/v1",
+			"api_key":  "test",
+		}}
+		result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+			Model:   "deepseek-chat",
+			Payload: []byte(`{"model":"deepseek-chat","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+		}, cliproxyexecutor.Options{
+			SourceFormat: sdktranslator.FromString("openai"),
+			Stream:       true,
+		})
+		if err != nil {
+			t.Fatalf("ExecuteStream error: %v", err)
+		}
+
+		for chunk := range result.Chunks {
+			if chunk.Err != nil {
+				t.Fatalf("unexpected stream error: %v", chunk.Err)
+			}
+		}
+
+		payload := waitForOpenAICompatUsagePayload(t)
+		if payload.Model != "deepseek-chat" {
+			t.Fatalf("queued model = %q, want %q", payload.Model, "deepseek-chat")
+		}
+		if payload.Tokens.InputTokens != 11 || payload.Tokens.OutputTokens != 7 || payload.Tokens.TotalTokens != 18 {
+			t.Fatalf("queued tokens = %+v, want input=11 output=7 total=18", payload.Tokens)
+		}
+	})
+}
+
+type openAICompatQueuedUsagePayload struct {
+	Model  string `json:"model"`
+	Tokens struct {
+		InputTokens  int64 `json:"input_tokens"`
+		OutputTokens int64 `json:"output_tokens"`
+		TotalTokens  int64 `json:"total_tokens"`
+	} `json:"tokens"`
+}
+
+func withOpenAICompatUsageQueue(t *testing.T, fn func()) {
+	t.Helper()
+
+	prevQueueEnabled := redisqueue.Enabled()
+	prevUsageEnabled := redisqueue.UsageStatisticsEnabled()
+
+	redisqueue.SetEnabled(false)
+	redisqueue.SetEnabled(true)
+	redisqueue.SetUsageStatisticsEnabled(true)
+
+	defer func() {
+		redisqueue.SetEnabled(false)
+		redisqueue.SetEnabled(prevQueueEnabled)
+		redisqueue.SetUsageStatisticsEnabled(prevUsageEnabled)
+	}()
+
+	fn()
+}
+
+func waitForOpenAICompatUsagePayload(t *testing.T) openAICompatQueuedUsagePayload {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		items := redisqueue.PopOldest(10)
+		if len(items) == 0 {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if len(items) != 1 {
+			t.Fatalf("queued usage item count = %d, want 1", len(items))
+		}
+		var payload openAICompatQueuedUsagePayload
+		if err := json.Unmarshal(items[0], &payload); err != nil {
+			t.Fatalf("unmarshal queued usage payload: %v", err)
+		}
+		return payload
+	}
+
+	t.Fatalf("timed out waiting for queued usage payload")
+	return openAICompatQueuedUsagePayload{}
 }


### PR DESCRIPTION
## Summary
- Ignore stream usage chunks unless usage is an OpenAI-style object with known token fields.
- Reuse the shared OpenAI-style usage parser for stream usage.
- Add regression coverage for usage:null and token-less usage objects before the final usage chunk.

## Tests
- go test ./internal/runtime/executor/helps ./internal/runtime/executor ./internal/redisqueue ./internal/api/handlers/management ./test -run 'TestParseOpenAI|TestOpenAICompat|TestUsageQueue|TestGetUsageQueue|TestGeminiExecutorRecordsSuccessfulZeroUsageInQueue'
- go build -o /private/tmp/cpa-cli-proxy-api-test-output ./cmd/server