### PR TITLE
Fix Responses WebSocket tool output context repair

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -662,6 +662,34 @@ func TestRepairResponsesWebsocketToolCallsInsertsCachedCallForOrphanOutput(t *te
 	}
 }
 
+func TestRepairResponsesWebsocketToolCallsInsertsCachedCallForPreviousResponseOutput(t *testing.T) {
+	outputCache := newWebsocketToolOutputCache(time.Minute, 10)
+	callCache := newWebsocketToolOutputCache(time.Minute, 10)
+	sessionKey := "session-1"
+
+	callCache.record(sessionKey, "call-1", []byte(`{"type":"function_call","id":"fc-1","call_id":"call-1","name":"tool"}`))
+
+	raw := []byte(`{"previous_response_id":"resp-latest","input":[{"type":"function_call_output","call_id":"call-1","id":"tool-out-1","output":"ok"},{"type":"message","id":"msg-1"}]}`)
+	repaired := repairResponsesWebsocketToolCallsWithCaches(outputCache, callCache, sessionKey, raw)
+
+	if got := gjson.GetBytes(repaired, "previous_response_id").String(); got != "resp-latest" {
+		t.Fatalf("previous_response_id = %q, want resp-latest", got)
+	}
+	input := gjson.GetBytes(repaired, "input").Array()
+	if len(input) != 3 {
+		t.Fatalf("repaired input len = %d, want 3: %s", len(input), repaired)
+	}
+	if input[0].Get("type").String() != "function_call" || input[0].Get("call_id").String() != "call-1" {
+		t.Fatalf("missing inserted call: %s", input[0].Raw)
+	}
+	if input[1].Get("type").String() != "function_call_output" || input[1].Get("call_id").String() != "call-1" {
+		t.Fatalf("unexpected output item: %s", input[1].Raw)
+	}
+	if input[2].Get("type").String() != "message" || input[2].Get("id").String() != "msg-1" {
+		t.Fatalf("unexpected trailing item: %s", input[2].Raw)
+	}
+}
+
 func TestRepairResponsesWebsocketToolCallsDropsOrphanOutputWhenCallMissing(t *testing.T) {
 	outputCache := newWebsocketToolOutputCache(time.Minute, 10)
 	callCache := newWebsocketToolOutputCache(time.Minute, 10)

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -300,11 +300,6 @@ func repairResponsesToolCallsArray(outputCache, callCache *websocketToolOutputCa
 				continue
 			}
 
-			if allowOrphanOutputs {
-				filtered = append(filtered, item)
-				continue
-			}
-
 			if _, ok := callPresent[callID]; ok {
 				filtered = append(filtered, item)
 				continue
@@ -320,6 +315,11 @@ func repairResponsesToolCallsArray(outputCache, callCache *websocketToolOutputCa
 					filtered = append(filtered, item)
 					continue
 				}
+			}
+
+			if allowOrphanOutputs {
+				filtered = append(filtered, item)
+				continue
 			}
 
 			// Drop orphaned function_call_output items; upstream rejects transcripts with missing calls.


### PR DESCRIPTION
## Summary
- Insert cached `function_call` items before matching `function_call_output` items even when `previous_response_id` is present.
- Prevent upstream 400 errors like `No tool call found for function call output with call_id ...` for delayed/background tool outputs on Responses WebSocket sessions.
- Add regression coverage for `previous_response_id` incremental tool output repair.

## Root Cause
The WebSocket repair path treated any request with `previous_response_id` as safe to forward orphan `function_call_output` items. For delayed/background tool outputs, `previous_response_id` can point at a newer response that does not contain the original `function_call`, while the proxy has already cached that call from earlier response output events. Upstream then validates the incremental input and rejects the orphan output.

## Fix
For `function_call_output` / `custom_tool_call_output` items, the repair logic now first checks the current payload and cached tool-call context. If a matching cached call exists, it inserts that call before the output. Only when no cached call exists does it preserve the previous `previous_response_id` passthrough behavior.

## Tests
- `go test ./sdk/api/handlers/openai -run 'TestRepairResponsesWebsocketToolCalls|TestNormalizeSubsequentRequestIncrementalInputStillMerges'`
- `go test ./sdk/api/handlers/openai`
- `go build -o test-output ./cmd/server && rm test-output`

## Notes
- `go test ./...` still has unrelated pre-existing failures in `internal/registry` (`TestCodexFreeModelsExcludeGPT55`) and `internal/runtime/executor` Antigravity credits URL tests.