### PR TITLE
fix: allow disabled OAuth auths to keep auto-refreshing

### DIFF
--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -336,7 +336,7 @@ func (l *authAutoRefreshLoop) remove(authID string) {
 }
 
 func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time.Time, bool) {
-	if auth == nil || auth.Disabled {
+	if auth == nil {
 		return time.Time{}, false
 	}
 

--- a/sdk/cliproxy/auth/auto_refresh_loop_test.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop_test.go
@@ -32,11 +32,31 @@ func setRefreshLeadFactory(t *testing.T, provider string, factory func() *time.D
 	})
 }
 
-func TestNextRefreshCheckAt_DisabledUnschedule(t *testing.T) {
+func TestNextRefreshCheckAt_DisabledOAuthSchedules(t *testing.T) {
 	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
-	auth := &Auth{ID: "a1", Provider: "test", Disabled: true}
-	if _, ok := nextRefreshCheckAt(now, auth, 15*time.Minute); ok {
-		t.Fatalf("nextRefreshCheckAt() ok = true, want false")
+	expiry := now.Add(time.Hour)
+	lead := 10 * time.Minute
+	setRefreshLeadFactory(t, "disabled-oauth", func() *time.Duration {
+		d := lead
+		return &d
+	})
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "disabled-oauth",
+		Disabled: true,
+		Metadata: map[string]any{
+			"email":      "x@example.com",
+			"expires_at": expiry.Format(time.RFC3339),
+		},
+	}
+	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute)
+	if !ok {
+		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
+	}
+	want := expiry.Add(-lead)
+	if !got.Equal(want) {
+		t.Fatalf("nextRefreshCheckAt() = %s, want %s", got, want)
 	}
 }
 
@@ -114,6 +134,28 @@ func TestNextRefreshCheckAt_ProviderLead_Expiry(t *testing.T) {
 	want := expiry.Add(-lead)
 	if !got.Equal(want) {
 		t.Fatalf("nextRefreshCheckAt() = %s, want %s", got, want)
+	}
+}
+
+func TestShouldRefresh_DisabledOAuthStillRefreshes(t *testing.T) {
+	now := time.Now().UTC()
+	lead := 10 * time.Minute
+	setRefreshLeadFactory(t, "disabled-refresh", func() *time.Duration {
+		d := lead
+		return &d
+	})
+
+	auth := &Auth{
+		ID:       "a1",
+		Provider: "disabled-refresh",
+		Disabled: true,
+		Metadata: map[string]any{
+			"email":      "x@example.com",
+			"expires_at": now.Add(5 * time.Minute).Format(time.RFC3339),
+		},
+	}
+	if !((&Manager{}).shouldRefresh(auth, now)) {
+		t.Fatalf("shouldRefresh() = false, want true")
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3271,7 +3271,7 @@ func (m *Manager) queueRefreshReschedule(authID string) {
 }
 
 func (m *Manager) shouldRefresh(a *Auth, now time.Time) bool {
-	if a == nil || a.Disabled {
+	if a == nil {
 		return false
 	}
 	if !a.NextRefreshAfter.IsZero() && now.Before(a.NextRefreshAfter) {
@@ -3478,7 +3478,7 @@ func lookupMetadataTime(meta map[string]any, keys ...string) (time.Time, bool) {
 func (m *Manager) markRefreshPending(id string, now time.Time) bool {
 	m.mu.Lock()
 	auth, ok := m.auths[id]
-	if !ok || auth == nil || auth.Disabled {
+	if !ok || auth == nil {
 		m.mu.Unlock()
 		return false
 	}


### PR DESCRIPTION
## Summary

This change allows disabled OAuth auth files to continue participating in the auto-refresh flow.

Disabled auths are still excluded from request routing and scheduling. The change only separates traffic eligibility from OAuth credential refresh.

## Why

Some operators temporarily disable auth files for quota or maintenance reasons. If disabled OAuth auths stop refreshing, their tokens may expire before they are re-enabled.