### PR TITLE
fix: apply default auth-dir when config value is empty

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ import (
 const (
 	DefaultPanelGitHubRepository = "https://github.com/router-for-me/Cli-Proxy-API-Management-Center"
 	DefaultPprofAddr             = "127.0.0.1:8316"
+	DefaultAuthDir               = "~/.cli-proxy-api"
 )
 
 // Config represents the application's configuration, loaded from a YAML file.

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -75,7 +75,7 @@ func SetLogLevel(cfg *config.Config) {
 // It expands a leading tilde (~) to the user's home directory and returns a cleaned path.
 func ResolveAuthDir(authDir string) (string, error) {
 	if authDir == "" {
-		return "", nil
+		authDir = "~/.cli-proxy-api"
 	}
 	if strings.HasPrefix(authDir, "~") {
 		home, err := os.UserHomeDir()

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -73,9 +73,10 @@ func SetLogLevel(cfg *config.Config) {
 
 // ResolveAuthDir normalizes the auth directory path for consistent reuse throughout the app.
 // It expands a leading tilde (~) to the user's home directory and returns a cleaned path.
+// If authDir is empty, it defaults to ~/.cli-proxy-api.
 func ResolveAuthDir(authDir string) (string, error) {
 	if authDir == "" {
-		authDir = "~/.cli-proxy-api"
+		authDir = config.DefaultAuthDir
 	}
 	if strings.HasPrefix(authDir, "~") {
 		home, err := os.UserHomeDir()


### PR DESCRIPTION
## Summary

Fixes a startup crash when  is not specified in config.yaml.

When  is empty,  returns an empty string which causes  to fail with no path. This change applies the documented default value  instead of returning empty.

## Fix

One line change in : when , set it to  instead of returning empty string. The existing tilde expansion logic handles the rest.

## Testing

- When auth-dir is specified: behavior unchanged (existing path expansion)
- When auth-dir is empty: now falls through to tilde expansion with default path
- Docker Compose deployments without explicit auth-dir will now start successfully

Fixes #3272