### PR TITLE
fix(codex/claude): preserve service_tier in Claude-to-Codex request translation

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -34,6 +34,18 @@ import (
 //
 // Returns:
 //   - []byte: The transformed request data in internal client format
+func normalizeCodexServiceTier(result gjson.Result) string {
+	if !result.Exists() || result.Type != gjson.String {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(result.String())) {
+	case "fast", "priority":
+		return "priority"
+	default:
+		return ""
+	}
+}
+
 func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) []byte {
 	rawJSON := inputRawJSON
 
@@ -321,6 +333,9 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 	}
 	template, _ = sjson.SetBytes(template, "reasoning.effort", reasoningEffort)
 	template, _ = sjson.SetBytes(template, "reasoning.summary", "auto")
+	if serviceTier := normalizeCodexServiceTier(rootResult.Get("service_tier")); serviceTier != "" {
+		template, _ = sjson.SetBytes(template, "service_tier", serviceTier)
+	}
 	template, _ = sjson.SetBytes(template, "stream", true)
 	template, _ = sjson.SetBytes(template, "store", false)
 	template, _ = sjson.SetBytes(template, "include", []string{"reasoning.encrypted_content"})

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -34,18 +34,6 @@ import (
 //
 // Returns:
 //   - []byte: The transformed request data in internal client format
-func normalizeCodexServiceTier(result gjson.Result) string {
-	if !result.Exists() || result.Type != gjson.String {
-		return ""
-	}
-	switch strings.ToLower(strings.TrimSpace(result.String())) {
-	case "fast", "priority":
-		return "priority"
-	default:
-		return ""
-	}
-}
-
 func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) []byte {
 	rawJSON := inputRawJSON
 
@@ -562,4 +550,16 @@ func normalizeToolParameters(raw string) string {
 		schema, _ = sjson.SetRawBytes(schema, "properties", []byte(`{}`))
 	}
 	return string(schema)
+}
+
+func normalizeCodexServiceTier(result gjson.Result) string {
+	if !result.Exists() || result.Type != gjson.String {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(result.String())) {
+	case "fast", "priority":
+		return "priority"
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
## Summary

Fixes the Claude-compatible translator dropping the service_tier field when translating to Codex format. This prevents Fast mode from working through the Claude-compatible path.

## Fix

- Add normalizeCodexServiceTier helper that maps both legacy/fast and priority to the Codex-supported priority value
- Pass service_tier through after reasoning.summary in ConvertClaudeRequestToCodex
- Only applies when service_tier is fast or priority, unsupported values are omitted as before

## Testing

- Requests without service_tier: behavior unchanged (field omitted)
- Requests with service_tier priority: now correctly passed through
- Requests with service_tier fast: normalized to priority and passed through
- Requests with other values: omitted as before

Fixes #3276