### PR TITLE
fix(usage): add check for Gemini family usage token fields in ParseGeminiStreamUsage

### DIFF
--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -450,6 +450,9 @@ func ParseGeminiStreamUsage(line []byte) (usage.Detail, bool) {
 	if !node.Exists() {
 		return usage.Detail{}, false
 	}
+	if !hasGeminiFamilyUsageTokenFields(node) {
+		return usage.Detail{}, false
+	}
 	return parseGeminiFamilyUsageDetail(node), true
 }
 

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -123,6 +123,30 @@ func TestParseGeminiCLIStreamUsage_ResponseSnakeCaseUsageMetadata(t *testing.T) 
 	}
 }
 
+func TestParseGeminiStreamUsage_TopLevelUsageMetadata(t *testing.T) {
+	line := []byte(`data: {"usageMetadata":{"promptTokenCount":13,"candidatesTokenCount":2,"totalTokenCount":15}}`)
+	detail, ok := ParseGeminiStreamUsage(line)
+	if !ok {
+		t.Fatal("ParseGeminiStreamUsage() ok = false, want true")
+	}
+	if detail.InputTokens != 13 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 13)
+	}
+	if detail.OutputTokens != 2 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 2)
+	}
+	if detail.TotalTokens != 15 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 15)
+	}
+}
+
+func TestParseGeminiStreamUsage_IgnoresTrafficTypeOnlyUsageMetadata(t *testing.T) {
+	line := []byte(`data: {"usageMetadata":{"trafficType":"ON_DEMAND"}}`)
+	if detail, ok := ParseGeminiStreamUsage(line); ok {
+		t.Fatalf("ParseGeminiStreamUsage() = (%+v, true), want false for traffic-only usage metadata", detail)
+	}
+}
+
 func TestParseGeminiCLIStreamUsage_IgnoresTrafficTypeOnlyUsageMetadata(t *testing.T) {
 	line := []byte(`data: {"response":{"usageMetadata":{"trafficType":"ON_DEMAND"}}}`)
 	if detail, ok := ParseGeminiCLIStreamUsage(line); ok {


### PR DESCRIPTION
目前当使用流式请求 Vertex 时，Redis 用量接口返回的请求 tokens 计数始终为 0 ，本 pr 修复该问题。

前后测试：

```
0|cpa-adapter  | [usage-debug] queue record raw: {
0|cpa-adapter  |   timestamp: '2026-05-10T09:43:03.155261951+08:00',
0|cpa-adapter  |   latency_ms: 577,
0|cpa-adapter  |   source: 'model-block-45-f8',
0|cpa-adapter  |   auth_index: '4ac79758ba85c',
0|cpa-adapter  |   tokens: {
0|cpa-adapter  |     input_tokens: 0,
0|cpa-adapter  |     output_tokens: 0,
0|cpa-adapter  |     reasoning_tokens: 0,
0|cpa-adapter  |     cached_tokens: 0,
0|cpa-adapter  |     total_tokens: 0
0|cpa-adapter  |   },
0|cpa-adapter  |   failed: false,
0|cpa-adapter  |   fail: { status_code: 200, body: '' },
0|cpa-adapter  |   provider: 'vertex',
0|cpa-adapter  |   model: 'gemini-2.5-flash-lite',
0|cpa-adapter  |   alias: 'gemini-2.5-flash-lite',
0|cpa-adapter  |   endpoint: 'POST /v1/chat/completions',
0|cpa-adapter  |   auth_type: 'oauth',
0|cpa-adapter  |   api_key: '[redacted]',
0|cpa-adapter  |   request_id: '2a1582eb'
0|cpa-adapter  | }
```

```
0|cpa-adapter  | [usage-debug] queue record raw: {
0|cpa-adapter  |   timestamp: '2026-05-10T10:02:24.441076621+08:00',
0|cpa-adapter  |   latency_ms: 574,
0|cpa-adapter  |   source: 'model-block-45-f8',
0|cpa-adapter  |   auth_index: '4ac79758ba85c',
0|cpa-adapter  |   tokens: {
0|cpa-adapter  |     input_tokens: 1,
0|cpa-adapter  |     output_tokens: 10,
0|cpa-adapter  |     reasoning_tokens: 0,
0|cpa-adapter  |     cached_tokens: 0,
0|cpa-adapter  |     total_tokens: 11
0|cpa-adapter  |   },
0|cpa-adapter  |   failed: false,
0|cpa-adapter  |   fail: { status_code: 200, body: '' },
0|cpa-adapter  |   provider: 'vertex',
0|cpa-adapter  |   model: 'gemini-2.5-flash-lite',
0|cpa-adapter  |   alias: 'gemini-2.5-flash-lite',
0|cpa-adapter  |   endpoint: 'POST /v1/chat/completions',
0|cpa-adapter  |   auth_type: 'oauth',
0|cpa-adapter  |   api_key: '[redacted]',
0|cpa-adapter  |   request_id: 'c73a82ab'
0|cpa-adapter  | }
```