### PR TITLE
fix: rotate auth on Anthropic "out of extra usage" 400 (relates to #2599)

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2182,6 +2182,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					}
 
 					statusCode := statusCodeFromResult(result.Error)
+					// Anthropic 400 "out of extra usage" is per-credential
+					// subscription quota; treat like 429 so the auth gets cooled
+					// rather than returning the error to the client.
+					if statusCode == http.StatusBadRequest && result.Error != nil &&
+						(strings.Contains(result.Error.Message, "out of extra usage") ||
+							strings.Contains(result.Error.Message, "claude.ai/settings/usage")) {
+						statusCode = http.StatusTooManyRequests
+					}
 					if isModelSupportResultError(result.Error) {
 						next := now.Add(12 * time.Hour)
 						state.NextRetryAfter = next
@@ -2586,6 +2594,13 @@ func isRequestInvalidError(err error) bool {
 	switch status {
 	case http.StatusBadRequest:
 		msg := err.Error()
+		// Anthropic OAuth subscription quota exhaustion arrives as 400
+		// invalid_request_error but is per-credential, not per-request.
+		// Let it fall through to rotation + cool-down (see MarkResult promotion).
+		if strings.Contains(msg, "out of extra usage") ||
+			strings.Contains(msg, "claude.ai/settings/usage") {
+			return false
+		}
 		return strings.Contains(msg, "invalid_request_error") ||
 			strings.Contains(msg, "INVALID_ARGUMENT") ||
 			strings.Contains(msg, "FAILED_PRECONDITION")


### PR DESCRIPTION
## Summary

Fixes a rotation gap where the proxy returns Anthropic's subscription-quota 400 directly to the client without trying any other credential in the auth pool, even though the failure is per-credential rather than per-request.

## Symptom

When an OAuth-backed Claude account in the auth pool runs out of "extra usage", Anthropic returns:

```http
HTTP/1.1 400 Bad Request
Content-Type: application/json

{"type":"error","error":{"type":"invalid_request_error","message":"You're out of extra usage. Add more at claude.ai/settings/usage and keep going."}}
```

The current `isRequestInvalidError` classifier in `sdk/cliproxy/auth/conductor.go` treats every 400 containing the substring `invalid_request_error` as a client-shape error and short-circuits the retry/rotate loop. Effects:

1. The depleted credential is never marked exhausted (`Quota.Exceeded` is only set on 429 in `MarkResult`).
2. The next request from the pool can pick the same depleted credential and fail again.
3. Other healthy credentials in the pool are never tried.

I observed this with three OAuth pool entries when one account hit the wall: every Hermes-style request (~55KB system prompt) returned a 400 with the message above, with the other two healthy accounts sitting idle.

## Patch

Two hunks in `sdk/cliproxy/auth/conductor.go`:

1. **`isRequestInvalidError`** returns `false` for 400 with body containing `out of extra usage` or `claude.ai/settings/usage`. That lets the retry/rotate path take over instead of bailing to the client.
2. **`MarkResult`** promotes that same 400 → `http.StatusTooManyRequests` so the credential is cooled like a normal 429 and the existing `Quota.Exceeded` machinery skips it on subsequent selections.

Both checks are scoped narrowly to the two body markers Anthropic uses for this specific error; other 400 `invalid_request_error` cases (genuine client-shape errors) keep the existing fast-fail behaviour.

## Relationship to #2599

#2599 tracks the **cause-side** workaround — injecting a Claude Code system prompt via `payload.default` so requests count against included plan usage instead of extra usage, so this 400 is never returned in the first place.

This PR is the **effect-side** fix — when this 400 *is* returned (because the cause-side workaround isn't enabled, or the user really has exhausted included usage too), a multi-account pool now degrades gracefully instead of failing the request.

The two fixes are complementary, not exclusive.

## Test plan

- [x] Built locally with three OAuth pool entries.
- [x] Confirmed previous behaviour: 400 returned to client without rotation (depleted account, single-credential pool — request fails outright).
- [x] Confirmed patched behaviour: with one depleted + two healthy credentials in pool, requests succeed via rotation. Hermes-style 55KB chat-completion requests that previously failed with 400 now return 200 with valid `msg_*` IDs.
- [x] No tests broken — only narrowed an existing classifier; existing 400 `invalid_request_error` paths unchanged.

## Notes

- This affects OAuth-backed Claude accounts specifically (where the proxy is acting as a token broker for a Claude subscription). API-key-backed access doesn't return this body shape.
- The cooldown duration on the promoted 429 follows the existing 429 path — `nextQuotaCooldown` with the auth's current `BackoffLevel`.
