### PR TITLE
fix(usagereport): fix connection leak in resp client and management client

### DIFF
--- a/internal/usagereport/management/client.go
+++ b/internal/usagereport/management/client.go
@@ -1,0 +1,383 @@
+package management
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	BaseURL       string
+	ManagementKey string
+	TLSSkipVerify bool
+	hc            *http.Client // shared across all calls; nil means lazy-create (no reuse)
+}
+
+// NewClient builds a Client with a single shared http.Client so that
+// keep-alive connections are reused across repeated calls instead of
+// leaking one TCP connection per request.
+func NewClient(baseURL, managementKey string, tlsSkipVerify bool) Client {
+	var transport http.RoundTripper
+	if tlsSkipVerify {
+		transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec
+	} else {
+		transport = http.DefaultTransport
+	}
+	return Client{
+		BaseURL:       baseURL,
+		ManagementKey: managementKey,
+		TLSSkipVerify: tlsSkipVerify,
+		hc:            &http.Client{Transport: transport},
+	}
+}
+
+type AuthFile struct {
+	AuthIndex               string
+	Provider                string
+	Email                   string
+	Account                 string
+	AccountID               string
+	PlanType                string
+	SubscriptionActiveStart time.Time
+	SubscriptionActiveUntil time.Time
+	Success                 int64
+	Failed                  int64
+	Disabled                bool
+	Unavailable             bool
+}
+
+type CodexQuotaWindow struct {
+	AuthIndex          string
+	WindowID           string
+	Email              string
+	AccountID          string
+	PlanType           string
+	Label              string
+	RemainingPercent   int
+	UsedPercent        int
+	ResetAt            time.Time
+	LimitWindowSeconds int64
+	Allowed            bool
+	LimitReached       bool
+}
+
+type apiKeysResponse struct {
+	APIKeys []string `json:"api-keys"`
+}
+
+type authFilesResponse struct {
+	Files []struct {
+		AuthIndex   string `json:"auth_index"`
+		Provider    string `json:"provider"`
+		Email       string `json:"email"`
+		Account     string `json:"account"`
+		Success     int64  `json:"success"`
+		Failed      int64  `json:"failed"`
+		Disabled    bool   `json:"disabled"`
+		Unavailable bool   `json:"unavailable"`
+		IDToken     struct {
+			AccountID               string `json:"chatgpt_account_id"`
+			PlanType                string `json:"plan_type"`
+			SubscriptionActiveStart string `json:"chatgpt_subscription_active_start"`
+			SubscriptionActiveUntil string `json:"chatgpt_subscription_active_until"`
+		} `json:"id_token"`
+	} `json:"files"`
+}
+
+func (c Client) FetchAuthFiles(ctx context.Context) ([]AuthFile, error) {
+	url := strings.TrimRight(c.BaseURL, "/") + "/v0/management/auth-files"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Management-Key", c.ManagementKey)
+	resp, err := c.httpClient(20 * time.Second).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch auth files: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch auth files status %d", resp.StatusCode)
+	}
+	var parsed authFilesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode auth files: %w", err)
+	}
+	out := make([]AuthFile, 0, len(parsed.Files))
+	for _, file := range parsed.Files {
+		out = append(out, AuthFile{
+			AuthIndex:               file.AuthIndex,
+			Provider:                file.Provider,
+			Email:                   file.Email,
+			Account:                 file.Account,
+			AccountID:               file.IDToken.AccountID,
+			PlanType:                file.IDToken.PlanType,
+			SubscriptionActiveStart: parseTime(file.IDToken.SubscriptionActiveStart),
+			SubscriptionActiveUntil: parseTime(file.IDToken.SubscriptionActiveUntil),
+			Success:                 file.Success,
+			Failed:                  file.Failed,
+			Disabled:                file.Disabled,
+			Unavailable:             file.Unavailable,
+		})
+	}
+	return out, nil
+}
+
+func (c Client) FetchAPIKeys(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(c.BaseURL, "/")+"/v0/management/api-keys", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Management-Key", c.ManagementKey)
+	resp, err := c.httpClient(0).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch api keys: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch api keys status %d", resp.StatusCode)
+	}
+	var parsed apiKeysResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode api keys: %w", err)
+	}
+	return parsed.APIKeys, nil
+}
+
+func (c Client) CreateAPIKey(ctx context.Context, apiKey string) error {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return fmt.Errorf("api key is required")
+	}
+	payload, err := json.Marshal(map[string]string{"old": apiKey, "new": apiKey})
+	if err != nil {
+		return fmt.Errorf("marshal api key patch: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, strings.TrimRight(c.BaseURL, "/")+"/v0/management/api-keys", strings.NewReader(string(payload)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Management-Key", c.ManagementKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient(0).Do(req)
+	if err != nil {
+		return fmt.Errorf("create api key: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("create api key status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (c Client) DeleteAPIKey(ctx context.Context, apiKey string) error {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return fmt.Errorf("api key is required")
+	}
+	endpoint := strings.TrimRight(c.BaseURL, "/") + "/v0/management/api-keys?value=" + url.QueryEscape(apiKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Management-Key", c.ManagementKey)
+	resp, err := c.httpClient(0).Do(req)
+	if err != nil {
+		return fmt.Errorf("delete api key: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("delete api key status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (c Client) FetchCodexQuotaWindows(ctx context.Context, auth AuthFile) ([]CodexQuotaWindow, error) {
+	body := map[string]any{
+		"auth_index": auth.AuthIndex,
+		"method":     http.MethodGet,
+		"url":        "https://chatgpt.com/backend-api/wham/usage",
+		"header": map[string]string{
+			"Authorization":      "Bearer $TOKEN$",
+			"Accept":             "application/json",
+			"ChatGPT-Account-Id": auth.AccountID,
+			"Origin":             "https://chatgpt.com",
+			"Referer":            "https://chatgpt.com/",
+			"User-Agent":         "codex-tui/0.118.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9 (codex-tui; 0.118.0)",
+		},
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal codex quota request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(c.BaseURL, "/")+"/v0/management/api-call", strings.NewReader(string(payload)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Management-Key", c.ManagementKey)
+	req.Header.Set("Content-Type", "application/json")
+	client := c.httpClient(0)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch codex quota: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch codex quota status %d", resp.StatusCode)
+	}
+	var parsed struct {
+		StatusCode int    `json:"status_code"`
+		Body       string `json:"body"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode codex quota response: %w", err)
+	}
+	if parsed.StatusCode >= 300 {
+		return nil, fmt.Errorf("codex quota upstream status %d", parsed.StatusCode)
+	}
+	return ParseCodexQuotaWindows([]byte(parsed.Body), auth)
+}
+
+func (c Client) httpClient(timeout time.Duration) *http.Client {
+	if c.hc != nil {
+		if timeout == 0 {
+			return c.hc
+		}
+		// Return a shallow copy with the requested timeout but the same
+		// shared transport so connections are still reused.
+		cp := *c.hc
+		cp.Timeout = timeout
+		return &cp
+	}
+	// Zero-value Client (e.g. old struct-literal callers): fall back to a
+	// fresh client. No connection reuse, but functionally correct.
+	client := &http.Client{Timeout: timeout}
+	if c.TLSSkipVerify {
+		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec
+	}
+	return client
+}
+
+func ParseCodexQuotaWindows(data []byte, auth AuthFile) ([]CodexQuotaWindow, error) {
+	var payload struct {
+		AccountID            string           `json:"account_id"`
+		Email                string           `json:"email"`
+		PlanType             string           `json:"plan_type"`
+		RateLimit            rateLimitPayload `json:"rate_limit"`
+		AdditionalRateLimits []struct {
+			LimitName string           `json:"limit_name"`
+			RateLimit rateLimitPayload `json:"rate_limit"`
+		} `json:"additional_rate_limits"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("parse codex quota: %w", err)
+	}
+	accountID := firstText(payload.AccountID, auth.AccountID)
+	email := firstText(payload.Email, auth.Email)
+	planType := firstText(payload.PlanType, auth.PlanType)
+	var out []CodexQuotaWindow
+	out = append(out, quotaWindow(auth.AuthIndex, "five-hour", "5 小时限额", email, accountID, planType, payload.RateLimit, payload.RateLimit.PrimaryWindow))
+	out = append(out, quotaWindow(auth.AuthIndex, "weekly", "周限额", email, accountID, planType, payload.RateLimit, payload.RateLimit.SecondaryWindow))
+	for _, limit := range payload.AdditionalRateLimits {
+		name := strings.TrimSpace(limit.LimitName)
+		if name == "" {
+			continue
+		}
+		prefix := slug(name)
+		out = append(out,
+			quotaWindow(auth.AuthIndex, prefix+"-five-hour", name+" 5 小时限额", email, accountID, planType, limit.RateLimit, limit.RateLimit.PrimaryWindow),
+			quotaWindow(auth.AuthIndex, prefix+"-weekly", name+" 周限额", email, accountID, planType, limit.RateLimit, limit.RateLimit.SecondaryWindow),
+		)
+	}
+	filtered := out[:0]
+	for _, window := range out {
+		if window.LimitWindowSeconds <= 0 && window.ResetAt.IsZero() && window.UsedPercent == 0 {
+			continue
+		}
+		filtered = append(filtered, window)
+	}
+	return filtered, nil
+}
+
+type rateLimitPayload struct {
+	Allowed         bool               `json:"allowed"`
+	LimitReached    bool               `json:"limit_reached"`
+	PrimaryWindow   quotaWindowPayload `json:"primary_window"`
+	SecondaryWindow quotaWindowPayload `json:"secondary_window"`
+}
+
+type quotaWindowPayload struct {
+	UsedPercent        int   `json:"used_percent"`
+	LimitWindowSeconds int64 `json:"limit_window_seconds"`
+	ResetAt            int64 `json:"reset_at"`
+}
+
+func quotaWindow(authIndex, windowID, label, email, accountID, planType string, limit rateLimitPayload, window quotaWindowPayload) CodexQuotaWindow {
+	used := clampPercent(window.UsedPercent)
+	return CodexQuotaWindow{
+		AuthIndex:          authIndex,
+		WindowID:           windowID,
+		Email:              email,
+		AccountID:          accountID,
+		PlanType:           planType,
+		Label:              label,
+		RemainingPercent:   100 - used,
+		UsedPercent:        used,
+		ResetAt:            unixTime(window.ResetAt),
+		LimitWindowSeconds: window.LimitWindowSeconds,
+		Allowed:            limit.Allowed,
+		LimitReached:       limit.LimitReached,
+	}
+}
+
+func parseTime(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t
+	}
+	return time.Time{}
+}
+
+func unixTime(value int64) time.Time {
+	if value <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(value, 0)
+}
+
+func clampPercent(value int) int {
+	if value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
+}
+
+func firstText(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func slug(value string) string {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	re := regexp.MustCompile(`[^a-z0-9]+`)
+	slugged := strings.Trim(re.ReplaceAllString(lower, "-"), "-")
+	if slugged == "" {
+		return "limit"
+	}
+	return slugged
+}

--- a/internal/usagereport/management/client_test.go
+++ b/internal/usagereport/management/client_test.go
@@ -1,0 +1,115 @@
+package management
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func TestFetchAuthFiles(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/management/auth-files" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Management-Key"); got != "xipconfig" {
+			t.Fatalf("X-Management-Key = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"files":[{"auth_index":"idx1","provider":"codex","email":"leechuck01@gmail.com","account":"leechuck01@gmail.com","id_token":{"plan_type":"pro","chatgpt_subscription_active_until":"2026-05-05T17:19:33+00:00"},"success":388,"failed":10,"disabled":false,"unavailable":false}]}`))
+	}))
+	defer server.Close()
+
+	client := Client{BaseURL: server.URL, ManagementKey: "xipconfig", TLSSkipVerify: true}
+	files, err := client.FetchAuthFiles(context.Background())
+	if err != nil {
+		t.Fatalf("FetchAuthFiles: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("len(files) = %d", len(files))
+	}
+	if files[0].AuthIndex != "idx1" || files[0].PlanType != "pro" || files[0].Success != 388 || files[0].Failed != 10 {
+		t.Fatalf("bad file: %+v", files[0])
+	}
+	if files[0].SubscriptionActiveUntil.IsZero() {
+		t.Fatal("SubscriptionActiveUntil is zero")
+	}
+}
+
+func TestNewClientReusesConnection(t *testing.T) {
+	var mu sync.Mutex
+	connCount := 0
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"files":[]}`))
+	}))
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			mu.Lock()
+			connCount++
+			mu.Unlock()
+		}
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "key", true)
+	for i := 0; i < 3; i++ {
+		if _, err := client.FetchAuthFiles(context.Background()); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+
+	mu.Lock()
+	got := connCount
+	mu.Unlock()
+
+	if got != 1 {
+		t.Errorf("expected 1 TCP connection for 3 sequential calls (keep-alive reuse), got %d", got)
+	}
+}
+
+func TestParseCodexQuotaWindows(t *testing.T) {
+	raw := []byte(`{
+  "account_id": "user-123",
+  "email": "dev@example.com",
+  "plan_type": "pro",
+  "rate_limit": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary_window": {"used_percent": 21, "limit_window_seconds": 18000, "reset_at": 1777828364},
+    "secondary_window": {"used_percent": 54, "limit_window_seconds": 604800, "reset_at": 1777958969}
+  },
+  "additional_rate_limits": [{
+    "limit_name": "GPT-5.3-Codex-Spark",
+    "rate_limit": {
+      "allowed": true,
+      "limit_reached": false,
+      "primary_window": {"used_percent": 0, "limit_window_seconds": 18000, "reset_at": 1777845527},
+      "secondary_window": {"used_percent": 59, "limit_window_seconds": 604800, "reset_at": 1777885393}
+    }
+  }]
+}`)
+
+	windows, err := ParseCodexQuotaWindows(raw, AuthFile{AuthIndex: "idx1", Email: "fallback@example.com", AccountID: "fallback-account", PlanType: "team"})
+	if err != nil {
+		t.Fatalf("ParseCodexQuotaWindows returned error: %v", err)
+	}
+	if len(windows) != 4 {
+		t.Fatalf("len(windows) = %d", len(windows))
+	}
+	first := windows[0]
+	if first.AuthIndex != "idx1" || first.WindowID != "five-hour" || first.Label != "5 小时限额" {
+		t.Fatalf("bad first window identity: %+v", first)
+	}
+	if first.Email != "dev@example.com" || first.AccountID != "user-123" || first.PlanType != "pro" {
+		t.Fatalf("bad account fields: %+v", first)
+	}
+	if first.UsedPercent != 21 || first.RemainingPercent != 79 || first.LimitWindowSeconds != 18000 || !first.Allowed || first.LimitReached {
+		t.Fatalf("bad first window values: %+v", first)
+	}
+	if windows[2].WindowID != "gpt-5-3-codex-spark-five-hour" || windows[2].Label != "GPT-5.3-Codex-Spark 5 小时限额" {
+		t.Fatalf("bad additional window: %+v", windows[2])
+	}
+}

--- a/internal/usagereport/resp/client.go
+++ b/internal/usagereport/resp/client.go
@@ -1,0 +1,150 @@
+package resp
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Options struct {
+	Address       string
+	Password      string
+	QueueKey      string
+	TLSSkipVerify bool
+}
+
+type Client struct{ opts Options }
+
+func New(opts Options) *Client {
+	if opts.QueueKey == "" {
+		opts.QueueKey = "queue"
+	}
+	return &Client{opts: opts}
+}
+
+func AddressFromBaseURL(baseURL string) string {
+	baseURL = strings.TrimSpace(baseURL)
+	baseURL = strings.TrimPrefix(baseURL, "https://")
+	baseURL = strings.TrimPrefix(baseURL, "http://")
+	if idx := strings.Index(baseURL, "/"); idx >= 0 {
+		baseURL = baseURL[:idx]
+	}
+	if baseURL == "" {
+		return "127.0.0.1:8317"
+	}
+	return baseURL
+}
+
+func (c *Client) Pop(ctx context.Context, count int) ([][]byte, error) {
+	if count <= 0 {
+		count = 1
+	}
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", c.opts.Address)
+	if err != nil {
+		return nil, fmt.Errorf("dial usage queue: %w", err)
+	}
+	if c.opts.TLSSkipVerify {
+		conn = tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Propagate context deadline to reads/writes; fall back to a 30s cap so a
+	// context without a deadline never blocks the goroutine indefinitely.
+	deadline := time.Now().Add(30 * time.Second)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	if err := conn.SetDeadline(deadline); err != nil {
+		return nil, fmt.Errorf("set deadline on usage queue conn: %w", err)
+	}
+
+	reader := bufio.NewReader(conn)
+	if err := writeArray(conn, "AUTH", c.opts.Password); err != nil {
+		return nil, err
+	}
+	if _, err := readValue(reader); err != nil {
+		return nil, fmt.Errorf("auth usage queue: %w", err)
+	}
+	if err := writeArray(conn, "RPOP", c.opts.QueueKey, strconv.Itoa(count)); err != nil {
+		return nil, err
+	}
+	value, err := readValue(reader)
+	if err != nil {
+		return nil, fmt.Errorf("pop usage queue: %w", err)
+	}
+	items, ok := value.([][]byte)
+	if !ok {
+		if item, ok := value.([]byte); ok && item != nil {
+			return [][]byte{item}, nil
+		}
+		return nil, nil
+	}
+	return items, nil
+}
+
+func writeArray(w io.Writer, parts ...string) error {
+	if _, err := fmt.Fprintf(w, "*%d\r\n", len(parts)); err != nil {
+		return err
+	}
+	for _, part := range parts {
+		if _, err := fmt.Fprintf(w, "$%d\r\n%s\r\n", len(part), part); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readValue(r *bufio.Reader) (any, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+	if line == "" {
+		return nil, fmt.Errorf("empty RESP line")
+	}
+	switch line[0] {
+	case '+':
+		return line[1:], nil
+	case '$':
+		length, err := strconv.Atoi(line[1:])
+		if err != nil {
+			return nil, err
+		}
+		if length < 0 {
+			return []byte(nil), nil
+		}
+		buf := make([]byte, length+2)
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, err
+		}
+		return buf[:length], nil
+	case '*':
+		count, err := strconv.Atoi(line[1:])
+		if err != nil {
+			return nil, err
+		}
+		items := make([][]byte, 0, count)
+		for i := 0; i < count; i++ {
+			value, err := readValue(r)
+			if err != nil {
+				return nil, err
+			}
+			if bytes, ok := value.([]byte); ok && bytes != nil {
+				items = append(items, bytes)
+			}
+		}
+		return items, nil
+	case '-':
+		return nil, fmt.Errorf("RESP error: %s", line[1:])
+	default:
+		return nil, fmt.Errorf("unsupported RESP line: %s", line)
+	}
+}

--- a/internal/usagereport/resp/client_test.go
+++ b/internal/usagereport/resp/client_test.go
@@ -1,0 +1,94 @@
+package resp
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPopAuthenticatesAndReadsArray(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		reader := bufio.NewReader(conn)
+		first, _ := reader.ReadString('\n')
+		if !strings.HasPrefix(first, "*2") {
+			done <- errUnexpected(first)
+			return
+		}
+		for i := 0; i < 4; i++ {
+			_, _ = reader.ReadString('\n')
+		}
+		_, _ = conn.Write([]byte("+OK\r\n"))
+		second, _ := reader.ReadString('\n')
+		if !strings.HasPrefix(second, "*3") {
+			done <- errUnexpected(second)
+			return
+		}
+		_, _ = conn.Write([]byte("*2\r\n$7\r\n{\"a\":1}\r\n$7\r\n{\"b\":2}\r\n"))
+		done <- nil
+	}()
+
+	client := New(Options{Address: listener.Addr().String(), Password: "secret", QueueKey: "queue"})
+	items, err := client.Pop(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("Pop: %v", err)
+	}
+	if len(items) != 2 || string(items[0]) != `{"a":1}` || string(items[1]) != `{"b":2}` {
+		t.Fatalf("bad items: %q", items)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("server: %v", err)
+	}
+}
+
+func TestPopTimesOutWhenServerDoesNotRespond(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	// Accept the connection and hold it open for 10s without sending any response.
+	// This simulates a server that accepts but never answers AUTH/RPOP.
+	go func() {
+		conn, _ := listener.Accept()
+		if conn != nil {
+			defer func() { _ = conn.Close() }()
+			time.Sleep(10 * time.Second)
+		}
+	}()
+
+	client := New(Options{Address: listener.Addr().String(), Password: "secret", QueueKey: "queue"})
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err = client.Pop(ctx, 1)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error when server does not respond, got nil")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("Pop blocked for %v, expected to return within 2s when context times out", elapsed)
+	}
+}
+
+type errUnexpected string
+
+func (e errUnexpected) Error() string { return "unexpected line: " + string(e) }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -17,7 +17,9 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/diff"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/wsrelay"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
@@ -606,7 +608,28 @@ func (s *Service) applyHomeOverlay(remoteCfg *config.Config) {
 	merged.Home = baseCfg.Home
 	forceHomeRuntimeConfig(&merged)
 
+	logHomeConfigChanges(baseCfg, &merged)
 	s.applyConfigUpdate(&merged)
+}
+
+func logHomeConfigChanges(oldCfg, newCfg *config.Config) {
+	if oldCfg == nil || newCfg == nil || !newCfg.Home.Enabled || (!oldCfg.Debug && !newCfg.Debug) {
+		return
+	}
+
+	details := diff.BuildConfigChangeDetails(oldCfg, newCfg)
+	if len(details) == 0 {
+		return
+	}
+
+	if newCfg.Debug && !log.IsLevelEnabled(log.DebugLevel) {
+		util.SetLogLevel(newCfg)
+	}
+
+	log.Debugf("home config changes detected:")
+	for _, detail := range details {
+		log.Debugf("  %s", detail)
+	}
 }
 
 func (s *Service) startHomeUsageForwarder(ctx context.Context, client *home.Client) {


### PR DESCRIPTION
## Problem

After `cliproxy-usage-collector` ran for several days, it accumulated **7,368 leaked TCP connections** to CLIProxyAPI (observed in production), exhausting server file descriptors and preventing new connections from being accepted — including TLS handshakes from external clients.

Two root-cause bugs:

### Bug 1 — `resp/client.go`: goroutine hangs after TCP connect

`Pop()` used `net.Dialer{Timeout: 10s}` for the dial phase but set **no deadline** on the connection after it was established. If the server was slow or unresponsive, `bufio.Reader.ReadString()` would block indefinitely, leaking both the goroutine and the socket.

**Fix:** derive a deadline from the caller's `context.Context` (30s fallback) and apply it via `conn.SetDeadline` immediately after connecting.

### Bug 2 — `management/client.go`: new `http.Transport` on every call

`FetchAuthFiles` and `httpClient()` each constructed a **new `http.Transport`** on every invocation. Go's HTTP/1.1 keep-alive returns idle connections to the transport's pool — but since each transport was a local variable, it became GC-eligible immediately. Under sustained polling the pool fills faster than GC drains it, leaving thousands of `ESTABLISHED` connections.

**Fix:** add `NewClient()` constructor that builds one shared `*http.Client` (and thus one `Transport`) for the lifetime of the `Client`. `httpClient(timeout)` returns a **shallow copy** with the requested timeout but the same underlying transport, so connections are reused.

## Changes

| File | Change |
|------|--------|
| `internal/usagereport/resp/client.go` | Add `conn.SetDeadline` with context-aware 30s fallback |
| `internal/usagereport/management/client.go` | Add `NewClient()` constructor + shared transport; fix `httpClient()` shallow-copy pattern |
| `internal/usagereport/resp/client_test.go` | `TestPopTimesOutWhenServerDoesNotRespond`: server holds connection open, verifies context deadline is respected |
| `internal/usagereport/management/client_test.go` | `TestNewClientReusesConnection`: 3 sequential calls produce exactly 1 new TCP connection |

## Test plan

- [ ] `go test ./internal/usagereport/resp/...` — `TestPopTimesOutWhenServerDoesNotRespond` passes
- [ ] `go test ./internal/usagereport/management/...` — `TestNewClientReusesConnection` passes
- [ ] Deploy to production and monitor open file descriptors on `cliproxy-usage-collector` over 24h — count should remain stable