### PR TITLE
[codex] Add transient upstream cooldown config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -102,6 +102,10 @@ max-retry-interval: 30
 # When true, disable auth/model cooldown scheduling globally (prevents blackout windows after failure states).
 disable-cooling: false
 
+# Auth/model cooldown in seconds after transient upstream errors (408/500/502/503/504).
+# Set to 0 to disable only this transient-error cooldown while keeping auth/quota cooldowns.
+transient-error-cooldown-seconds: 60
+
 # disable-image-generation supports: false (default), true, or "chat".
 # - true: disable image_generation everywhere (also returns 404 for /v1/images/generations and /v1/images/edits).
 # - "chat": disable image_generation injection on non-images endpoints, but keep /v1/images/generations and /v1/images/edits enabled.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -102,7 +102,7 @@ max-retry-interval: 30
 # When true, disable auth/model cooldown scheduling globally (prevents blackout windows after failure states).
 disable-cooling: false
 
-# Auth/model cooldown in seconds after transient upstream errors (408/500/502/503/504).
+# Auth/model cooldown in seconds after transient upstream errors (408/500/502/503/504), capped at 3600.
 # Set to 0 to disable only this transient-error cooldown while keeping auth/quota cooldowns.
 transient-error-cooldown-seconds: 60
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -276,6 +276,7 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	}
 	managementasset.SetCurrentConfig(cfg)
 	auth.SetQuotaCooldownDisabled(cfg.DisableCooling)
+	auth.SetTransientErrorCooldown(time.Duration(cfg.TransientErrorCooldownSeconds) * time.Second)
 	applySignatureCacheConfig(nil, cfg)
 	// Initialize management handler
 	s.mgmt = managementHandlers.NewHandler(cfg, configFilePath, authManager)
@@ -1227,6 +1228,9 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 
 	if oldCfg == nil || oldCfg.DisableCooling != cfg.DisableCooling {
 		auth.SetQuotaCooldownDisabled(cfg.DisableCooling)
+	}
+	if oldCfg == nil || oldCfg.TransientErrorCooldownSeconds != cfg.TransientErrorCooldownSeconds {
+		auth.SetTransientErrorCooldown(time.Duration(cfg.TransientErrorCooldownSeconds) * time.Second)
 	}
 
 	if oldCfg != nil && oldCfg.DisableImageGeneration != cfg.DisableImageGeneration {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -204,6 +204,8 @@ type Server struct {
 // Returns:
 //   - *Server: A new server instance
 func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdkaccess.Manager, configFilePath string, opts ...ServerOption) *Server {
+	cfg.ApplyRuntimeDefaults()
+
 	optionState := &serverOptionConfig{
 		requestLoggerFactory: defaultRequestLoggerFactory,
 	}
@@ -1181,6 +1183,8 @@ func (s *Server) applyAccessConfig(oldCfg, newCfg *config.Config) {
 //   - clients: The new slice of AI service clients
 //   - cfg: The new application configuration
 func (s *Server) UpdateClients(cfg *config.Config) {
+	cfg.ApplyRuntimeDefaults()
+
 	// Reconstruct old config from YAML snapshot to avoid reference sharing issues
 	var oldCfg *config.Config
 	if len(s.oldConfigYaml) > 0 {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -46,6 +47,64 @@ func newTestServer(t *testing.T) *Server {
 
 	configPath := filepath.Join(tmpDir, "config.yaml")
 	return NewServer(cfg, authManager, accessManager, configPath)
+}
+
+func TestNewServer_NormalizesTransientCooldownForStructConfig(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tmpDir := t.TempDir()
+	authDir := filepath.Join(tmpDir, "auth")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("failed to create auth dir: %v", err)
+	}
+
+	auth.SetTransientErrorCooldown(0)
+	t.Cleanup(func() {
+		auth.SetTransientErrorCooldown(time.Minute)
+	})
+
+	cfg := &proxyconfig.Config{
+		SDKConfig: sdkconfig.SDKConfig{
+			APIKeys: []string{"test-key"},
+		},
+		AuthDir: authDir,
+		Debug:   true,
+	}
+	authManager := auth.NewManager(nil, nil, nil)
+
+	NewServer(cfg, authManager, sdkaccess.NewManager(), filepath.Join(tmpDir, "config.yaml"))
+
+	if got := cfg.TransientErrorCooldownSeconds; got != proxyconfig.DefaultTransientErrorCooldownSeconds {
+		t.Fatalf("TransientErrorCooldownSeconds = %d, want %d", got, proxyconfig.DefaultTransientErrorCooldownSeconds)
+	}
+
+	runtimeManager := auth.NewManager(nil, nil, nil)
+	runtimeAuth := &auth.Auth{
+		ID:       "auth-transient-default",
+		Provider: "claude",
+	}
+	if _, errRegister := runtimeManager.Register(context.Background(), runtimeAuth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	runtimeManager.MarkResult(context.Background(), auth.Result{
+		AuthID:   runtimeAuth.ID,
+		Provider: "claude",
+		Model:    "test-model",
+		Success:  false,
+		Error:    &auth.Error{HTTPStatus: http.StatusServiceUnavailable, Message: "upstream unavailable"},
+	})
+
+	updated, ok := runtimeManager.GetByID(runtimeAuth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates["test-model"]
+	if state == nil {
+		t.Fatalf("expected model state to be present")
+	}
+	if state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected transient error cooldown to remain enabled")
+	}
 }
 
 func TestHealthz(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -701,6 +701,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	if cfg.TransientErrorCooldownSeconds < 0 {
 		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds cannot be negative; clamping to 0")
 		cfg.TransientErrorCooldownSeconds = 0
+	} else if cfg.TransientErrorCooldownSeconds > 3600 {
+		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds too large; clamping to 3600")
+		cfg.TransientErrorCooldownSeconds = 3600
 	}
 
 	if cfg.MaxRetryCredentials < 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,9 +20,13 @@ import (
 )
 
 const (
-	DefaultPanelGitHubRepository = "https://github.com/router-for-me/Cli-Proxy-API-Management-Center"
-	DefaultPprofAddr             = "127.0.0.1:8316"
-	DefaultAuthDir               = "~/.cli-proxy-api"
+	DefaultPanelGitHubRepository         = "https://github.com/router-for-me/Cli-Proxy-API-Management-Center"
+	DefaultPprofAddr                     = "127.0.0.1:8316"
+	DefaultAuthDir                       = "~/.cli-proxy-api"
+	DefaultTransientErrorCooldownSeconds = 60
+
+	maxTransientErrorCooldownSeconds = 3600
+	transientErrorCooldownKey        = "transient-error-cooldown-seconds"
 )
 
 // Config represents the application's configuration, loaded from a YAML file.
@@ -80,6 +84,7 @@ type Config struct {
 	// TransientErrorCooldownSeconds controls auth/model cooldown after transient upstream failures.
 	// Applies to 408/500/502/503/504 responses. Set to 0 to disable only this cooldown.
 	TransientErrorCooldownSeconds int `yaml:"transient-error-cooldown-seconds" json:"transient-error-cooldown-seconds"`
+	transientErrorCooldownSet     bool
 
 	// AuthAutoRefreshWorkers overrides the size of the core auth auto-refresh worker pool.
 	// When <= 0, the default worker count is used.
@@ -151,6 +156,62 @@ type Config struct {
 	Payload PayloadConfig `yaml:"payload" json:"payload"`
 
 	legacyMigrationPending bool `yaml:"-" json:"-"`
+}
+
+// ApplyRuntimeDefaults fills defaults that cannot be represented by Go zero values.
+func (cfg *Config) ApplyRuntimeDefaults() {
+	if cfg == nil {
+		return
+	}
+	cfg.normalizeTransientErrorCooldown()
+}
+
+// SetTransientErrorCooldownSeconds marks the cooldown as explicitly configured.
+func (cfg *Config) SetTransientErrorCooldownSeconds(seconds int) {
+	if cfg == nil {
+		return
+	}
+	cfg.TransientErrorCooldownSeconds = seconds
+	cfg.transientErrorCooldownSet = true
+	cfg.normalizeTransientErrorCooldown()
+}
+
+func (cfg *Config) normalizeTransientErrorCooldown() {
+	if cfg == nil {
+		return
+	}
+	if cfg.TransientErrorCooldownSeconds < 0 {
+		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds cannot be negative; clamping to 0")
+		cfg.TransientErrorCooldownSeconds = 0
+		cfg.transientErrorCooldownSet = true
+		return
+	}
+	if cfg.TransientErrorCooldownSeconds > maxTransientErrorCooldownSeconds {
+		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds too large; clamping to 3600")
+		cfg.TransientErrorCooldownSeconds = maxTransientErrorCooldownSeconds
+		cfg.transientErrorCooldownSet = true
+		return
+	}
+	if cfg.TransientErrorCooldownSeconds == 0 && !cfg.transientErrorCooldownSet {
+		cfg.TransientErrorCooldownSeconds = DefaultTransientErrorCooldownSeconds
+	}
+}
+
+func hasTopLevelYAMLKey(data []byte, key string) bool {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return false
+	}
+	if len(root.Content) == 0 || root.Content[0] == nil || root.Content[0].Kind != yaml.MappingNode {
+		return false
+	}
+	mapping := root.Content[0]
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i] != nil && mapping.Content[i].Value == key {
+			return true
+		}
+	}
+	return false
 }
 
 // ClaudeHeaderDefaults configures default header values injected into Claude API requests.
@@ -630,7 +691,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.UsageStatisticsEnabled = false
 	cfg.RedisUsageQueueRetentionSeconds = 60
 	cfg.DisableCooling = false
-	cfg.TransientErrorCooldownSeconds = 60
+	cfg.TransientErrorCooldownSeconds = DefaultTransientErrorCooldownSeconds
 	cfg.DisableImageGeneration = DisableImageGenerationOff
 	cfg.Pprof.Enable = false
 	cfg.Pprof.Addr = DefaultPprofAddr
@@ -643,6 +704,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		}
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
+	cfg.transientErrorCooldownSet = hasTopLevelYAMLKey(data, transientErrorCooldownKey)
 
 	// NOTE: Startup legacy key migration is intentionally disabled.
 	// Reason: avoid mutating config.yaml during server startup.
@@ -698,13 +760,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		log.WithField("value", cfg.RedisUsageQueueRetentionSeconds).Warn("redis-usage-queue-retention-seconds too large; clamping to 3600")
 		cfg.RedisUsageQueueRetentionSeconds = 3600
 	}
-	if cfg.TransientErrorCooldownSeconds < 0 {
-		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds cannot be negative; clamping to 0")
-		cfg.TransientErrorCooldownSeconds = 0
-	} else if cfg.TransientErrorCooldownSeconds > 3600 {
-		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds too large; clamping to 3600")
-		cfg.TransientErrorCooldownSeconds = 3600
-	}
+	cfg.ApplyRuntimeDefaults()
 
 	if cfg.MaxRetryCredentials < 0 {
 		cfg.MaxRetryCredentials = 0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,10 @@ type Config struct {
 	// DisableCooling disables quota cooldown scheduling when true.
 	DisableCooling bool `yaml:"disable-cooling" json:"disable-cooling"`
 
+	// TransientErrorCooldownSeconds controls auth/model cooldown after transient upstream failures.
+	// Applies to 408/500/502/503/504 responses. Set to 0 to disable only this cooldown.
+	TransientErrorCooldownSeconds int `yaml:"transient-error-cooldown-seconds" json:"transient-error-cooldown-seconds"`
+
 	// AuthAutoRefreshWorkers overrides the size of the core auth auto-refresh worker pool.
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`
@@ -626,6 +630,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.UsageStatisticsEnabled = false
 	cfg.RedisUsageQueueRetentionSeconds = 60
 	cfg.DisableCooling = false
+	cfg.TransientErrorCooldownSeconds = 60
 	cfg.DisableImageGeneration = DisableImageGenerationOff
 	cfg.Pprof.Enable = false
 	cfg.Pprof.Addr = DefaultPprofAddr
@@ -692,6 +697,10 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	} else if cfg.RedisUsageQueueRetentionSeconds > 3600 {
 		log.WithField("value", cfg.RedisUsageQueueRetentionSeconds).Warn("redis-usage-queue-retention-seconds too large; clamping to 3600")
 		cfg.RedisUsageQueueRetentionSeconds = 3600
+	}
+	if cfg.TransientErrorCooldownSeconds < 0 {
+		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds cannot be negative; clamping to 0")
+		cfg.TransientErrorCooldownSeconds = 0
 	}
 
 	if cfg.MaxRetryCredentials < 0 {

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -25,6 +25,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	cfg.UsageStatisticsEnabled = false
 	cfg.RedisUsageQueueRetentionSeconds = 60
 	cfg.DisableCooling = false
+	cfg.TransientErrorCooldownSeconds = 60
 	cfg.DisableImageGeneration = DisableImageGenerationOff
 	cfg.Pprof.Enable = false
 	cfg.Pprof.Addr = DefaultPprofAddr
@@ -67,6 +68,10 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	} else if cfg.RedisUsageQueueRetentionSeconds > 3600 {
 		log.WithField("value", cfg.RedisUsageQueueRetentionSeconds).Warn("redis-usage-queue-retention-seconds too large; clamping to 3600")
 		cfg.RedisUsageQueueRetentionSeconds = 3600
+	}
+	if cfg.TransientErrorCooldownSeconds < 0 {
+		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds cannot be negative; clamping to 0")
+		cfg.TransientErrorCooldownSeconds = 0
 	}
 
 	if cfg.MaxRetryCredentials < 0 {

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -72,6 +72,9 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	if cfg.TransientErrorCooldownSeconds < 0 {
 		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds cannot be negative; clamping to 0")
 		cfg.TransientErrorCooldownSeconds = 0
+	} else if cfg.TransientErrorCooldownSeconds > 3600 {
+		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds too large; clamping to 3600")
+		cfg.TransientErrorCooldownSeconds = 3600
 	}
 
 	if cfg.MaxRetryCredentials < 0 {

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -25,7 +25,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	cfg.UsageStatisticsEnabled = false
 	cfg.RedisUsageQueueRetentionSeconds = 60
 	cfg.DisableCooling = false
-	cfg.TransientErrorCooldownSeconds = 60
+	cfg.TransientErrorCooldownSeconds = DefaultTransientErrorCooldownSeconds
 	cfg.DisableImageGeneration = DisableImageGenerationOff
 	cfg.Pprof.Enable = false
 	cfg.Pprof.Addr = DefaultPprofAddr
@@ -35,6 +35,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config payload: %w", err)
 	}
+	cfg.transientErrorCooldownSet = hasTopLevelYAMLKey(data, transientErrorCooldownKey)
 
 	// Hash remote management key if plaintext is detected (nested), but do NOT persist.
 	if cfg.RemoteManagement.SecretKey != "" && !looksLikeBcrypt(cfg.RemoteManagement.SecretKey) {
@@ -69,13 +70,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 		log.WithField("value", cfg.RedisUsageQueueRetentionSeconds).Warn("redis-usage-queue-retention-seconds too large; clamping to 3600")
 		cfg.RedisUsageQueueRetentionSeconds = 3600
 	}
-	if cfg.TransientErrorCooldownSeconds < 0 {
-		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds cannot be negative; clamping to 0")
-		cfg.TransientErrorCooldownSeconds = 0
-	} else if cfg.TransientErrorCooldownSeconds > 3600 {
-		log.WithField("value", cfg.TransientErrorCooldownSeconds).Warn("transient-error-cooldown-seconds too large; clamping to 3600")
-		cfg.TransientErrorCooldownSeconds = 3600
-	}
+	cfg.ApplyRuntimeDefaults()
 
 	if cfg.MaxRetryCredentials < 0 {
 		cfg.MaxRetryCredentials = 0

--- a/internal/config/transient_error_cooldown_test.go
+++ b/internal/config/transient_error_cooldown_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigApplyRuntimeDefaults_TransientErrorCooldownDirectStruct(t *testing.T) {
+	cfg := &Config{}
+
+	cfg.ApplyRuntimeDefaults()
+
+	if got := cfg.TransientErrorCooldownSeconds; got != DefaultTransientErrorCooldownSeconds {
+		t.Fatalf("TransientErrorCooldownSeconds = %d, want %d", got, DefaultTransientErrorCooldownSeconds)
+	}
+}
+
+func TestConfigSetTransientErrorCooldownSeconds_AllowsExplicitZero(t *testing.T) {
+	cfg := &Config{}
+
+	cfg.SetTransientErrorCooldownSeconds(0)
+	cfg.ApplyRuntimeDefaults()
+
+	if got := cfg.TransientErrorCooldownSeconds; got != 0 {
+		t.Fatalf("TransientErrorCooldownSeconds = %d, want 0", got)
+	}
+}
+
+func TestLoadConfigOptional_TransientErrorCooldownExplicitZero(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	configYAML := []byte("transient-error-cooldown-seconds: 0\n")
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+
+	if got := cfg.TransientErrorCooldownSeconds; got != 0 {
+		t.Fatalf("TransientErrorCooldownSeconds = %d, want 0", got)
+	}
+}
+
+func TestParseConfigBytes_TransientErrorCooldownExplicitZero(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("transient-error-cooldown-seconds: 0\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+
+	if got := cfg.TransientErrorCooldownSeconds; got != 0 {
+		t.Fatalf("TransientErrorCooldownSeconds = %d, want 0", got)
+	}
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -45,6 +45,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.DisableCooling != newCfg.DisableCooling {
 		changes = append(changes, fmt.Sprintf("disable-cooling: %t -> %t", oldCfg.DisableCooling, newCfg.DisableCooling))
 	}
+	if oldCfg.TransientErrorCooldownSeconds != newCfg.TransientErrorCooldownSeconds {
+		changes = append(changes, fmt.Sprintf("transient-error-cooldown-seconds: %d -> %d", oldCfg.TransientErrorCooldownSeconds, newCfg.TransientErrorCooldownSeconds))
+	}
 	if oldCfg.DisableImageGeneration != newCfg.DisableImageGeneration {
 		changes = append(changes, fmt.Sprintf("disable-image-generation: %v -> %v", oldCfg.DisableImageGeneration, newCfg.DisableImageGeneration))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -219,21 +219,22 @@ func TestBuildConfigChangeDetails_SecretsAndCounts(t *testing.T) {
 
 func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 	oldCfg := &config.Config{
-		Port:                   1000,
-		AuthDir:                "/old",
-		Debug:                  false,
-		LoggingToFile:          false,
-		UsageStatisticsEnabled: false,
-		DisableCooling:         false,
-		RequestRetry:           1,
-		MaxRetryCredentials:    1,
-		MaxRetryInterval:       1,
-		WebsocketAuth:          false,
-		QuotaExceeded:          config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
-		ClaudeKey:              []config.ClaudeKey{{APIKey: "c1"}},
-		CodexKey:               []config.CodexKey{{APIKey: "x1"}},
-		AmpCode:                config.AmpCode{UpstreamAPIKey: "keep", RestrictManagementToLocalhost: false},
-		RemoteManagement:       config.RemoteManagement{DisableControlPanel: false, PanelGitHubRepository: "old/repo", SecretKey: "keep"},
+		Port:                          1000,
+		AuthDir:                       "/old",
+		Debug:                         false,
+		LoggingToFile:                 false,
+		UsageStatisticsEnabled:        false,
+		DisableCooling:                false,
+		TransientErrorCooldownSeconds: 60,
+		RequestRetry:                  1,
+		MaxRetryCredentials:           1,
+		MaxRetryInterval:              1,
+		WebsocketAuth:                 false,
+		QuotaExceeded:                 config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
+		ClaudeKey:                     []config.ClaudeKey{{APIKey: "c1"}},
+		CodexKey:                      []config.CodexKey{{APIKey: "x1"}},
+		AmpCode:                       config.AmpCode{UpstreamAPIKey: "keep", RestrictManagementToLocalhost: false},
+		RemoteManagement:              config.RemoteManagement{DisableControlPanel: false, PanelGitHubRepository: "old/repo", SecretKey: "keep"},
 		SDKConfig: sdkconfig.SDKConfig{
 			RequestLog:                 false,
 			ProxyURL:                   "http://old-proxy",
@@ -243,17 +244,18 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 		},
 	}
 	newCfg := &config.Config{
-		Port:                   2000,
-		AuthDir:                "/new",
-		Debug:                  true,
-		LoggingToFile:          true,
-		UsageStatisticsEnabled: true,
-		DisableCooling:         true,
-		RequestRetry:           2,
-		MaxRetryCredentials:    3,
-		MaxRetryInterval:       3,
-		WebsocketAuth:          true,
-		QuotaExceeded:          config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
+		Port:                          2000,
+		AuthDir:                       "/new",
+		Debug:                         true,
+		LoggingToFile:                 true,
+		UsageStatisticsEnabled:        true,
+		DisableCooling:                true,
+		TransientErrorCooldownSeconds: 0,
+		RequestRetry:                  2,
+		MaxRetryCredentials:           3,
+		MaxRetryInterval:              3,
+		WebsocketAuth:                 true,
+		QuotaExceeded:                 config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
 		ClaudeKey: []config.ClaudeKey{
 			{APIKey: "c1", BaseURL: "http://new", ProxyURL: "http://p", Headers: map[string]string{"H": "1"}, ExcludedModels: []string{"a"}},
 			{APIKey: "c2"},
@@ -288,6 +290,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 	expectContains(t, details, "logging-to-file: false -> true")
 	expectContains(t, details, "usage-statistics-enabled: false -> true")
 	expectContains(t, details, "disable-cooling: false -> true")
+	expectContains(t, details, "transient-error-cooldown-seconds: 60 -> 0")
 	expectContains(t, details, "disable-image-generation: false -> true")
 	expectContains(t, details, "request-log: false -> true")
 	expectContains(t, details, "request-retry: 1 -> 2")
@@ -313,17 +316,18 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 
 func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 	oldCfg := &config.Config{
-		Port:                   1,
-		AuthDir:                "/a",
-		Debug:                  false,
-		LoggingToFile:          false,
-		UsageStatisticsEnabled: false,
-		DisableCooling:         false,
-		RequestRetry:           1,
-		MaxRetryCredentials:    1,
-		MaxRetryInterval:       1,
-		WebsocketAuth:          false,
-		QuotaExceeded:          config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
+		Port:                          1,
+		AuthDir:                       "/a",
+		Debug:                         false,
+		LoggingToFile:                 false,
+		UsageStatisticsEnabled:        false,
+		DisableCooling:                false,
+		TransientErrorCooldownSeconds: 60,
+		RequestRetry:                  1,
+		MaxRetryCredentials:           1,
+		MaxRetryInterval:              1,
+		WebsocketAuth:                 false,
+		QuotaExceeded:                 config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
 		GeminiKey: []config.GeminiKey{
 			{APIKey: "g-old", BaseURL: "http://g-old", ProxyURL: "http://gp-old", Headers: map[string]string{"A": "1"}},
 		},
@@ -367,17 +371,18 @@ func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 		},
 	}
 	newCfg := &config.Config{
-		Port:                   2,
-		AuthDir:                "/b",
-		Debug:                  true,
-		LoggingToFile:          true,
-		UsageStatisticsEnabled: true,
-		DisableCooling:         true,
-		RequestRetry:           2,
-		MaxRetryCredentials:    3,
-		MaxRetryInterval:       3,
-		WebsocketAuth:          true,
-		QuotaExceeded:          config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
+		Port:                          2,
+		AuthDir:                       "/b",
+		Debug:                         true,
+		LoggingToFile:                 true,
+		UsageStatisticsEnabled:        true,
+		DisableCooling:                true,
+		TransientErrorCooldownSeconds: 0,
+		RequestRetry:                  2,
+		MaxRetryCredentials:           3,
+		MaxRetryInterval:              3,
+		WebsocketAuth:                 true,
+		QuotaExceeded:                 config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
 		GeminiKey: []config.GeminiKey{
 			{APIKey: "g-new", BaseURL: "http://g-new", ProxyURL: "http://gp-new", Headers: map[string]string{"A": "2"}, ExcludedModels: []string{"x", "y"}},
 		},
@@ -434,6 +439,7 @@ func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 	expectContains(t, changes, "logging-to-file: false -> true")
 	expectContains(t, changes, "usage-statistics-enabled: false -> true")
 	expectContains(t, changes, "disable-cooling: false -> true")
+	expectContains(t, changes, "transient-error-cooldown-seconds: 60 -> 0")
 	expectContains(t, changes, "disable-image-generation: false -> true")
 	expectContains(t, changes, "request-retry: 1 -> 2")
 	expectContains(t, changes, "max-retry-credentials: 1 -> 3")

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -76,11 +76,35 @@ const (
 	quotaBackoffMax           = 30 * time.Minute
 )
 
-var quotaCooldownDisabled atomic.Bool
+var (
+	quotaCooldownDisabled         atomic.Bool
+	transientErrorCooldownSeconds atomic.Int64
+)
+
+func init() {
+	transientErrorCooldownSeconds.Store(int64((1 * time.Minute) / time.Second))
+}
 
 // SetQuotaCooldownDisabled toggles quota cooldown scheduling globally.
 func SetQuotaCooldownDisabled(disable bool) {
 	quotaCooldownDisabled.Store(disable)
+}
+
+// SetTransientErrorCooldown updates the cooldown used for transient upstream errors.
+// Set duration to 0 to keep auths immediately reusable after 408/500/502/503/504.
+func SetTransientErrorCooldown(duration time.Duration) {
+	if duration < 0 {
+		duration = 0
+	}
+	transientErrorCooldownSeconds.Store(int64(duration / time.Second))
+}
+
+func transientErrorCooldown() time.Duration {
+	seconds := transientErrorCooldownSeconds.Load()
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 func quotaCooldownDisabledForAuth(auth *Auth) bool {
@@ -2252,9 +2276,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						case 408, 500, 502, 503, 504:
 							if disableCooling {
 								state.NextRetryAfter = time.Time{}
-							} else {
-								next := now.Add(1 * time.Minute)
+							} else if cooldown := transientErrorCooldown(); cooldown > 0 {
+								next := now.Add(cooldown)
 								state.NextRetryAfter = next
+							} else {
+								state.NextRetryAfter = time.Time{}
 							}
 						default:
 							state.NextRetryAfter = time.Time{}
@@ -2671,8 +2697,10 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.StatusMessage = "transient upstream error"
 		if disableCooling {
 			auth.NextRetryAfter = time.Time{}
+		} else if cooldown := transientErrorCooldown(); cooldown > 0 {
+			auth.NextRetryAfter = now.Add(cooldown)
 		} else {
-			auth.NextRetryAfter = now.Add(1 * time.Minute)
+			auth.NextRetryAfter = time.Time{}
 		}
 	default:
 		if auth.StatusMessage == "" {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -78,11 +78,11 @@ const (
 
 var (
 	quotaCooldownDisabled         atomic.Bool
-	transientErrorCooldownSeconds atomic.Int64
+	transientErrorCooldownNanos   atomic.Int64
 )
 
 func init() {
-	transientErrorCooldownSeconds.Store(int64((1 * time.Minute) / time.Second))
+	transientErrorCooldownNanos.Store(int64(1 * time.Minute))
 }
 
 // SetQuotaCooldownDisabled toggles quota cooldown scheduling globally.
@@ -96,15 +96,15 @@ func SetTransientErrorCooldown(duration time.Duration) {
 	if duration < 0 {
 		duration = 0
 	}
-	transientErrorCooldownSeconds.Store(int64(duration / time.Second))
+	transientErrorCooldownNanos.Store(int64(duration))
 }
 
 func transientErrorCooldown() time.Duration {
-	seconds := transientErrorCooldownSeconds.Load()
-	if seconds <= 0 {
+	nanos := transientErrorCooldownNanos.Load()
+	if nanos <= 0 {
 		return 0
 	}
-	return time.Duration(seconds) * time.Second
+	return time.Duration(nanos)
 }
 
 func quotaCooldownDisabledForAuth(auth *Auth) bool {

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -525,11 +525,11 @@ func TestManager_MarkResult_RespectsAuthDisableCoolingOverride(t *testing.T) {
 func TestManager_MarkResult_TransientErrorCooldownCanBeDisabled(t *testing.T) {
 	prevCooling := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)
-	prevTransient := transientErrorCooldownSeconds.Load()
+	prevTransient := transientErrorCooldownNanos.Load()
 	SetTransientErrorCooldown(0)
 	t.Cleanup(func() {
 		quotaCooldownDisabled.Store(prevCooling)
-		transientErrorCooldownSeconds.Store(prevTransient)
+		transientErrorCooldownNanos.Store(prevTransient)
 	})
 
 	m := NewManager(nil, nil, nil)

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -522,6 +522,51 @@ func TestManager_MarkResult_RespectsAuthDisableCoolingOverride(t *testing.T) {
 	}
 }
 
+func TestManager_MarkResult_TransientErrorCooldownCanBeDisabled(t *testing.T) {
+	prevCooling := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldown(0)
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(prevCooling)
+		transientErrorCooldownSeconds.Store(prevTransient)
+	})
+
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:       "auth-transient",
+		Provider: "claude",
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "test-model-transient"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "claude",
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusServiceUnavailable, Message: "upstream unavailable"},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected model state to be present")
+	}
+	if !state.Unavailable {
+		t.Fatalf("expected model state to record the transient failure")
+	}
+	if !state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected transient NextRetryAfter to be zero, got %v", state.NextRetryAfter)
+	}
+}
+
 func TestManager_MarkResult_RespectsAuthDisableCoolingOverride_On403(t *testing.T) {
 	prev := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -172,6 +172,7 @@ func (b *Builder) Build() (*Service, error) {
 	if b.configPath == "" {
 		return nil, fmt.Errorf("cliproxy: configuration path is required")
 	}
+	b.cfg.ApplyRuntimeDefaults()
 
 	tokenProvider := b.tokenProvider
 	if tokenProvider == nil {

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -32,7 +32,8 @@ type OpenAICompatibilityModel = internalconfig.OpenAICompatibilityModel
 type TLS = internalconfig.TLSConfig
 
 const (
-	DefaultPanelGitHubRepository = internalconfig.DefaultPanelGitHubRepository
+	DefaultPanelGitHubRepository         = internalconfig.DefaultPanelGitHubRepository
+	DefaultTransientErrorCooldownSeconds = internalconfig.DefaultTransientErrorCooldownSeconds
 )
 
 func LoadConfig(configFile string) (*Config, error) { return internalconfig.LoadConfig(configFile) }


### PR DESCRIPTION
## Summary

Adds a granular `transient-error-cooldown-seconds` config option for auth/model cooldown after transient upstream failures.

The default remains `60`, preserving existing behavior. Setting it to `0` disables only the short cooldown after transient upstream statuses (`408/500/502/503/504`), while keeping the broader `disable-cooling` behavior and existing auth/quota cooldown protection intact.

Closes #3315

## Changes

- Adds `transient-error-cooldown-seconds` to config parsing and example config.
- Applies the setting on server startup and config reload.
- Uses the configured duration for `408/500/502/503/504` cooldowns in `sdk/cliproxy/auth/conductor.go`.
- Adds config-diff output and a focused auth manager test for disabling transient cooldown.

## Validation

- `git diff --check`
- `go test ./internal/config` passed before stopping the broader test run.

Not run:

- Full Go test suite. The broader package test run was stopped before completion to avoid long compile time in this environment.
