### PR TITLE
fix(api): add 30s deadline to acceptMuxConnections to prevent accept loop stall

### DIFF
--- a/internal/api/protocol_multiplexer.go
+++ b/internal/api/protocol_multiplexer.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -48,6 +49,10 @@ func (s *Server) acceptMuxConnections(listener net.Listener, httpListener *muxLi
 			continue
 		}
 
+		// Guard TLS handshake and protocol peek with a deadline so a client
+		// that connects but never sends data cannot block the accept loop.
+		_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
+
 		tlsConn, ok := conn.(*tls.Conn)
 		if ok {
 			if errHandshake := tlsConn.Handshake(); errHandshake != nil {
@@ -58,6 +63,7 @@ func (s *Server) acceptMuxConnections(listener net.Listener, httpListener *muxLi
 			}
 			proto := strings.TrimSpace(tlsConn.ConnectionState().NegotiatedProtocol)
 			if proto == "h2" || proto == "http/1.1" {
+				_ = conn.SetDeadline(time.Time{})
 				if httpListener == nil {
 					if errClose := conn.Close(); errClose != nil {
 						log.Errorf("failed to close connection: %v", errClose)
@@ -75,6 +81,7 @@ func (s *Server) acceptMuxConnections(listener net.Listener, httpListener *muxLi
 
 		reader := bufio.NewReader(conn)
 		prefix, errPeek := reader.Peek(1)
+		_ = conn.SetDeadline(time.Time{})
 		if errPeek != nil {
 			if errClose := conn.Close(); errClose != nil {
 				log.Errorf("failed to close connection after protocol peek failure: %v", errClose)


### PR DESCRIPTION
## Summary

- `acceptMuxConnections` 是单 goroutine 串行处理所有连接的协议检测（TLS 握手 + `Peek(1)` 判断协议类型）
- 两个阻塞操作原先**均无超时**：若客户端完成 TLS 握手后停止发数据，goroutine 永久阻塞
- 整个 accept loop 被卡死后，所有新连接只能在内核 backlog 堆积，最终积累成大量 CLOSE-WAIT

**生产现象**：stale TLS 连接使 goroutine 阻塞约 16 分钟，期间产生 200+ CLOSE-WAIT，服务对所有新请求停止响应（pprof goroutine dump 确认：41 个 goroutine，0 个正在处理 HTTP 请求）。

## Fix

在 `Accept()` 之后、TLS 握手和 `Peek()` 之前，对连接设置 **30 秒 deadline**；成功分发到 handler 后立即清除，不影响正常请求处理。

```go
// Guard TLS handshake and protocol peek with a deadline so a client
// that connects but never sends data cannot block the accept loop.
_ = conn.SetDeadline(time.Now().Add(30 * time.Second))

// ... TLS handshake + ALPN check ...
// For h2/http1.1 path:
_ = conn.SetDeadline(time.Time{})  // clear before handing off

// For non-ALPN path:
prefix, errPeek := reader.Peek(1)
_ = conn.SetDeadline(time.Time{})  // clear after peek
```

## Test plan

- [ ] 本地 `go build ./internal/api/...` 编译通过
- [ ] 使用 `openssl s_client` 建立 TLS 连接后不发数据，确认 30 秒后连接被服务端关闭，accept loop 继续正常工作
- [ ] 正常 HTTP/2 和 HTTP/1.1 请求不受影响（deadline 在分发后清除）
- [ ] 正常 Redis RESP 请求不受影响