### PR TITLE
feat: add GitHub Copilot provider support

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -10,17 +10,18 @@ const codexBuiltinImageModelID = "gpt-image-2"
 
 // staticModelsJSON mirrors the top-level structure of models.json.
 type staticModelsJSON struct {
-	Claude      []*ModelInfo `json:"claude"`
-	Gemini      []*ModelInfo `json:"gemini"`
-	Vertex      []*ModelInfo `json:"vertex"`
-	GeminiCLI   []*ModelInfo `json:"gemini-cli"`
-	AIStudio    []*ModelInfo `json:"aistudio"`
-	CodexFree   []*ModelInfo `json:"codex-free"`
-	CodexTeam   []*ModelInfo `json:"codex-team"`
-	CodexPlus   []*ModelInfo `json:"codex-plus"`
-	CodexPro    []*ModelInfo `json:"codex-pro"`
-	Kimi        []*ModelInfo `json:"kimi"`
-	Antigravity []*ModelInfo `json:"antigravity"`
+	Claude        []*ModelInfo `json:"claude"`
+	Gemini        []*ModelInfo `json:"gemini"`
+	Vertex        []*ModelInfo `json:"vertex"`
+	GeminiCLI     []*ModelInfo `json:"gemini-cli"`
+	AIStudio      []*ModelInfo `json:"aistudio"`
+	CodexFree     []*ModelInfo `json:"codex-free"`
+	CodexTeam     []*ModelInfo `json:"codex-team"`
+	CodexPlus     []*ModelInfo `json:"codex-plus"`
+	CodexPro      []*ModelInfo `json:"codex-pro"`
+	Kimi          []*ModelInfo `json:"kimi"`
+	Antigravity   []*ModelInfo `json:"antigravity"`
+	GithubCopilot []*ModelInfo `json:"github-copilot"`
 }
 
 // GetClaudeModels returns the standard Claude model definitions.
@@ -76,6 +77,11 @@ func GetKimiModels() []*ModelInfo {
 // GetAntigravityModels returns the standard Antigravity model definitions.
 func GetAntigravityModels() []*ModelInfo {
 	return cloneModelInfos(getModels().Antigravity)
+}
+
+// GetGithubCopilotModels returns the standard GitHub Copilot model definitions.
+func GetGithubCopilotModels() []*ModelInfo {
+	return cloneModelInfos(getModels().GithubCopilot)
 }
 
 // WithCodexBuiltins injects hard-coded Codex-only model definitions that should
@@ -186,6 +192,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		return GetKimiModels()
 	case "antigravity":
 		return GetAntigravityModels()
+	case "github-copilot":
+		return GetGithubCopilotModels()
 	default:
 		return nil
 	}
@@ -208,6 +216,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		data.CodexPro,
 		data.Kimi,
 		data.Antigravity,
+		data.GithubCopilot,
 	}
 	for _, models := range allModels {
 		for _, m := range models {

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -124,6 +124,11 @@ func tryRefreshModels(ctx context.Context, label string) {
 	// Detect changes before updating store.
 	changed := detectChangedProviders(oldData, parsed)
 
+	// Preserve embedded github-copilot models if remote doesn't have them.
+	if len(parsed.GithubCopilot) == 0 && oldData != nil && len(oldData.GithubCopilot) > 0 {
+		parsed.GithubCopilot = oldData.GithubCopilot
+	}
+
 	// Update store with new data regardless.
 	modelsCatalogStore.mu.Lock()
 	modelsCatalogStore.data = parsed
@@ -215,6 +220,7 @@ func detectChangedProviders(oldData, newData *staticModelsJSON) []string {
 		{"codex", oldData.CodexPro, newData.CodexPro},
 		{"kimi", oldData.Kimi, newData.Kimi},
 		{"antigravity", oldData.Antigravity, newData.Antigravity},
+		{"github-copilot", oldData.GithubCopilot, newData.GithubCopilot},
 	}
 
 	seen := make(map[string]bool, len(sections))

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2064,5 +2064,167 @@
         ]
       }
     }
+  ],
+  "github-copilot": [
+    {
+      "id": "claude-sonnet-4.6",
+      "object": "model",
+      "created": 1771372800,
+      "owned_by": "github-copilot",
+      "type": "github-copilot",
+      "display_name": "Claude Sonnet 4.6",
+      "context_length": 200000,
+      "max_completion_tokens": 64000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "claude-sonnet-4.5",
+      "object": "model",
+      "created": 1759104000,
+      "owned_by": "github-copilot",
+      "type": "github-copilot",
+      "display_name": "Claude Sonnet 4.5",
+      "context_length": 200000,
+      "max_completion_tokens": 64000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true
+      }
+    },
+    {
+      "id": "claude-haiku-4.5",
+      "object": "model",
+      "created": 1759276800,
+      "owned_by": "github-copilot",
+      "type": "github-copilot",
+      "display_name": "Claude Haiku 4.5",
+      "context_length": 200000,
+      "max_completion_tokens": 64000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true
+      }
+    },
+    {
+      "id": "gpt-5.4",
+      "object": "model",
+      "created": 1772668800,
+      "owned_by": "github-copilot",
+      "type": "github-copilot",
+      "display_name": "GPT 5.4",
+      "context_length": 1050000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "object": "model",
+      "created": 1773705600,
+      "owned_by": "github-copilot",
+      "type": "github-copilot",
+      "display_name": "GPT 5.4 Mini",
+      "context_length": 400000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.3-codex",
+      "object": "model",
+      "created": 1770307200,
+      "owned_by": "github-copilot",
+      "type": "github-copilot",
+      "display_name": "GPT 5.3 Codex",
+      "context_length": 400000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.2-codex",
+      "object": "model",
+      "created": 1765440000,
+      "owned_by": "github-copilot",
+      "type": "github-copilot",
+      "display_name": "GPT 5.2 Codex",
+      "context_length": 400000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5.2",
+      "object": "model",
+      "created": 1765440000,
+      "owned_by": "github-copilot",
+      "type": "github-copilot",
+      "display_name": "GPT 5.2",
+      "context_length": 400000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ]
+      }
+    },
+    {
+      "id": "gpt-5-mini",
+      "object": "model",
+      "created": 1752192000,
+      "owned_by": "github-copilot",
+      "type": "github-copilot",
+      "display_name": "GPT 5 Mini",
+      "context_length": 1047576,
+      "max_completion_tokens": 65536
+    },
+    {
+      "id": "gpt-4.1",
+      "object": "model",
+      "created": 1744761600,
+      "owned_by": "github-copilot",
+      "type": "github-copilot",
+      "display_name": "GPT 4.1",
+      "context_length": 1047576,
+      "max_completion_tokens": 32768
+    }
   ]
 }

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -109,6 +111,15 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		if updated, errDelete := sjson.DeleteBytes(translated, "stream"); errDelete == nil {
 			translated = updated
 		}
+	}
+
+	// Copilot GPT models require max_completion_tokens instead of max_tokens
+	if e.provider == "github-copilot" {
+		if v := gjson.GetBytes(translated, "max_tokens"); v.Exists() {
+			translated, _ = sjson.SetBytes(translated, "max_completion_tokens", v.Value())
+			translated, _ = sjson.DeleteBytes(translated, "max_tokens")
+		}
+		translated, _ = sjson.DeleteBytes(translated, "reasoning_effort")
 	}
 
 	url := strings.TrimSuffix(baseURL, "/") + endpoint
@@ -213,6 +224,16 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	// Request usage data in the final streaming chunk so that token statistics
 	// are captured even when the upstream is an OpenAI-compatible provider.
 	translated, _ = sjson.SetBytes(translated, "stream_options.include_usage", true)
+
+	// Copilot GPT models require max_completion_tokens instead of max_tokens
+	if e.provider == "github-copilot" {
+		if v := gjson.GetBytes(translated, "max_tokens"); v.Exists() {
+			translated, _ = sjson.SetBytes(translated, "max_completion_tokens", v.Value())
+			translated, _ = sjson.DeleteBytes(translated, "max_tokens")
+		}
+		// Copilot /chat/completions doesn't support reasoning_effort with tools
+		translated, _ = sjson.DeleteBytes(translated, "reasoning_effort")
+	}
 
 	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
@@ -388,6 +409,14 @@ func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (base
 		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
 		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
 	}
+	// For github-copilot, exchange GitHub OAuth token for Copilot API token
+	if e.provider == "github-copilot" && apiKey != "" && baseURL != "" {
+		if copilotToken, err := exchangeCopilotToken(apiKey); err == nil {
+			apiKey = copilotToken
+		} else {
+			log.Debugf("github-copilot token exchange failed: %v", err)
+		}
+	}
 	return
 }
 
@@ -443,3 +472,38 @@ func (e statusErr) Error() string {
 }
 func (e statusErr) StatusCode() int            { return e.code }
 func (e statusErr) RetryAfter() *time.Duration { return e.retryAfter }
+
+// exchangeCopilotToken exchanges a GitHub OAuth token for a short-lived Copilot API token.
+func exchangeCopilotToken(githubToken string) (string, error) {
+	req, err := http.NewRequest("GET", "https://api.github.com/copilot_internal/v2/token", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "token "+githubToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "GithubCopilot/1.300.0")
+	req.Header.Set("Editor-Version", "vscode/1.100.0")
+	req.Header.Set("Editor-Plugin-Version", "copilot/1.300.0")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("copilot token exchange failed: %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if result.Token == "" {
+		return "", fmt.Errorf("copilot token exchange returned empty token")
+	}
+	return result.Token, nil
+}

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -169,6 +169,18 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			}
 		}
 	}
+	// For github-copilot auth files, set base_url and api_key for OpenAICompatExecutor.
+	if provider == "github-copilot" {
+		if accessToken, ok := metadata["access_token"].(string); ok && strings.TrimSpace(accessToken) != "" {
+			a.Attributes["api_key"] = accessToken
+			a.Attributes["base_url"] = "https://api.githubcopilot.com"
+			a.Attributes["header:Copilot-Integration-Id"] = "vscode-chat"
+			a.Attributes["header:Editor-Version"] = "vscode/1.100.0"
+			a.Attributes["header:Editor-Plugin-Version"] = "copilot-chat/0.25.0"
+			a.Attributes["header:User-Agent"] = "GitHubCopilotChat/0.25.0"
+			a.Attributes["header:Openai-Intent"] = "conversation-panel"
+		}
+	}
 	if provider == "gemini-cli" {
 		if virtuals := SynthesizeGeminiVirtualAuths(a, metadata, now); len(virtuals) > 0 {
 			for _, v := range virtuals {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1130,6 +1130,9 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 	case "kimi":
 		models = registry.GetKimiModels()
 		models = applyExcludedModels(models, excluded)
+	case "github-copilot":
+		models = registry.GetGithubCopilotModels()
+		models = applyExcludedModels(models, excluded)
 	default:
 		// Handle OpenAI-compatibility providers by name using config
 		if s.cfg != nil {


### PR DESCRIPTION
- Add github-copilot section to models.json with available models
- Register github-copilot provider in model definitions and service
- Preserve embedded github-copilot data when remote models.json lacks it
- Implement Copilot token exchange (GitHub OAuth to Copilot API token)
- Set correct Copilot headers (Integration-Id, Editor-Version, etc.)
- Convert max_tokens to max_completion_tokens for Copilot GPT models
- Remove reasoning_effort param (unsupported by Copilot chat/completions)
- Set base_url and api_key in synthesizer for github-copilot auth files