### PR TITLE
feat: per-request passthrough-system flag (preserve caller system prompt under OAuth)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -345,6 +345,15 @@ type CloakConfig struct {
 	// CacheUserID controls whether Claude user_id values are cached per API key.
 	// When false, a fresh random user_id is generated for every request.
 	CacheUserID *bool `yaml:"cache-user-id,omitempty" json:"cache-user-id,omitempty"`
+
+	// PassthroughSystem, when true, suppresses the OAuth-mode sanitization that
+	// replaces the caller's forwarded system prompt with a generic stub. The
+	// canonical Claude Code system field (billing/agent/static blocks) is still
+	// injected so the request body remains recognizable to Anthropic; only the
+	// caller-supplied system message survives verbatim into the first user
+	// message. Can also be enabled per-request via the X-CPA-Passthrough-System
+	// header (value "true"/"1").
+	PassthroughSystem bool `yaml:"passthrough-system,omitempty" json:"passthrough-system,omitempty"`
 }
 
 // ClaudeKey represents the configuration for a Claude API key,

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1006,7 +1006,7 @@ func claudeCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {
 }
 
 func checkSystemInstructions(payload []byte) []byte {
-	return checkSystemInstructionsWithSigningMode(payload, false, false, false, "2.1.63", "", "")
+	return checkSystemInstructionsWithSigningMode(payload, false, false, false, false, "2.1.63", "", "")
 }
 
 func isClaudeOAuthToken(apiKey string) bool {
@@ -1430,11 +1430,22 @@ func getWorkloadFromContext(ctx context.Context) string {
 	return ""
 }
 
+// getPassthroughSystemFromContext reads X-CPA-Passthrough-System from the
+// inbound HTTP request. Values "true" or "1" enable passthrough; anything else
+// (including missing header) leaves the decision to config/auth attributes.
+func getPassthroughSystemFromContext(ctx context.Context) bool {
+	if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
+		v := strings.ToLower(strings.TrimSpace(ginCtx.GetHeader("X-CPA-Passthrough-System")))
+		return v == "true" || v == "1"
+	}
+	return false
+}
+
 // getCloakConfigFromAuth extracts cloak configuration from auth attributes.
-// Returns (cloakMode, strictMode, sensitiveWords, cacheUserID).
-func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (string, bool, []string, bool) {
+// Returns (cloakMode, strictMode, sensitiveWords, cacheUserID, passthroughSystem).
+func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (string, bool, []string, bool, bool) {
 	if auth == nil || auth.Attributes == nil {
-		return "auto", false, nil, false
+		return "auto", false, nil, false, false
 	}
 
 	cloakMode := auth.Attributes["cloak_mode"]
@@ -1453,8 +1464,9 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (string, bool, []string, bo
 	}
 
 	cacheUserID := strings.EqualFold(strings.TrimSpace(auth.Attributes["cloak_cache_user_id"]), "true")
+	passthroughSystem := strings.EqualFold(strings.TrimSpace(auth.Attributes["cloak_passthrough_system"]), "true")
 
-	return cloakMode, strictMode, sensitiveWords, cacheUserID
+	return cloakMode, strictMode, sensitiveWords, cacheUserID, passthroughSystem
 }
 
 // injectFakeUserID generates and injects a fake user ID into the request metadata.
@@ -1525,7 +1537,7 @@ func generateBillingHeader(payload []byte, experimentalCCHSigning bool, version,
 }
 
 func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
-	return checkSystemInstructionsWithSigningMode(payload, strictMode, false, false, "2.1.63", "", "")
+	return checkSystemInstructionsWithSigningMode(payload, strictMode, false, false, false, "2.1.63", "", "")
 }
 
 // checkSystemInstructionsWithSigningMode injects Claude Code-style system blocks:
@@ -1536,7 +1548,12 @@ func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
 //	system[3]: system instructions (no cache_control)
 //	system[4]: doing tasks (no cache_control)
 //	system[5]: user system messages moved to first user message
-func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, experimentalCCHSigning bool, oauthMode bool, version, entrypoint, workload string) []byte {
+//
+// When passthroughSystem is true, the OAuth-mode sanitize step is skipped and
+// the caller's forwarded system prompt is prepended to the first user message
+// verbatim. The canonical Claude Code system field is still injected so the
+// outbound request looks recognizable to Anthropic.
+func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, experimentalCCHSigning bool, oauthMode bool, passthroughSystem bool, version, entrypoint, workload string) []byte {
 	system := gjson.GetBytes(payload, "system")
 
 	// Extract original message text for fingerprint computation (before billing injection).
@@ -1599,7 +1616,7 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 
 		if len(userSystemParts) > 0 {
 			combined := strings.Join(userSystemParts, "\n\n")
-			if oauthMode {
+			if oauthMode && !passthroughSystem {
 				combined = sanitizeForwardedSystemPrompt(combined)
 			}
 			if strings.TrimSpace(combined) != "" {
@@ -1704,13 +1721,14 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 
 	// Get cloak config from ClaudeKey configuration
 	cloakCfg := resolveClaudeKeyCloakConfig(cfg, auth)
-	attrMode, attrStrict, attrWords, attrCache := getCloakConfigFromAuth(auth)
+	attrMode, attrStrict, attrWords, attrCache, attrPassthrough := getCloakConfigFromAuth(auth)
 
 	// Determine cloak settings
 	cloakMode := attrMode
 	strictMode := attrStrict
 	sensitiveWords := attrWords
 	cacheUserID := attrCache
+	passthroughSystem := attrPassthrough
 
 	if cloakCfg != nil {
 		if mode := strings.TrimSpace(cloakCfg.Mode); mode != "" {
@@ -1725,6 +1743,15 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 		if cloakCfg.CacheUserID != nil {
 			cacheUserID = *cloakCfg.CacheUserID
 		}
+		if cloakCfg.PassthroughSystem {
+			passthroughSystem = true
+		}
+	}
+
+	// Per-request header takes highest precedence so callers can opt in without
+	// needing config-side state. Header missing/false leaves config decision intact.
+	if getPassthroughSystemFromContext(ctx) {
+		passthroughSystem = true
 	}
 
 	// Determine if cloaking should be applied
@@ -1737,7 +1764,7 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 		billingVersion := helps.DefaultClaudeVersion(cfg)
 		entrypoint := parseEntrypointFromUA(clientUserAgent)
 		workload := getWorkloadFromContext(ctx)
-		payload = checkSystemInstructionsWithSigningMode(payload, strictMode, useCCHSigning, oauthToken, billingVersion, entrypoint, workload)
+		payload = checkSystemInstructionsWithSigningMode(payload, strictMode, useCCHSigning, oauthToken, passthroughSystem, billingVersion, entrypoint, workload)
 	}
 
 	// Inject fake user ID


### PR DESCRIPTION
Adds an opt-in mechanism to preserve the caller's forwarded `system` content under Claude OAuth mode instead of having `sanitizeForwardedSystemPrompt` replace it with a generic 3-line stub. The canonical Claude Code system field, `cch` signing, and fake user_id are all unchanged — only the sanitize step becomes opt-out-able.

## Three control surfaces (any one activates it)

1. Request header `X-CPA-Passthrough-System: true|1` (highest priority — useful for routers/gateways with per-request control)
2. Auth attribute `cloak_passthrough_system: "true"` (per-credential default via the SDK's auth.Attributes)
3. ClaudeKey config field `passthrough-system: true` (static config-driven)

Default behavior: unchanged. Existing call sites and tests untouched (the 2-arg wrapper `checkSystemInstructionsWithMode` is preserved; only the inner `WithSigningMode` gained a parameter).

## Diff

- `internal/config/config.go`: +9 LOC — new `PassthroughSystem bool` on `CloakConfig`
- `internal/runtime/executor/claude_executor.go`: +47 LOC — header context reader, attribute reader (5th return value from `getCloakConfigFromAuth`), signature threading, merge logic in `applyCloaking`

~56 LOC total.

## Motivation

Self-hosted small-team setups frequently want to share one Claude Pro/Max subscription across multiple apps via CLIProxyAPI: a daily-driver Claude Code session AND an in-house specialist app (medical info, legal aid, support triage). Today only the daily-driver case works correctly because the specialist app's system prompt is deleted in `sanitizeForwardedSystemPrompt`. This PR closes that gap without adding a second subscription or a separate API key.

## Validation

Built v6.9.26-passthrough from this branch. Ran 6 probes against the live Anthropic endpoint through the patched binary:

| Test | Header | Result |
|------|--------|--------|
| knee-pain + MedChat system msg | none | refuses ("I'm not able to help with medical concerns") — upstream behavior preserved |
| same | `X-CPA-Passthrough-System: true` | asks 4 intake questions (age, location, duration, modifiers) — caller persona honored |
| chest pain emergency + MedChat | passthrough on | "Call 911 immediately. Classic warning signs of a heart attack." |
| PubMed meta-analysis query + MedChat | passthrough on | detailed retrieval-style summary |
| Python dataclass coding query + MedChat | passthrough on | correct Python answer (passthrough doesn't break coding) |
| same | none | same answer, Claude Code persona path — regression-clean |

Zero OAuth flagging across the run.

## Test plan

- [x] Manual probes of all four behavior buckets against live Anthropic
- [x] Regression: coding queries still work with and without the header
- [x] End-to-end via a multi-hop proxy chain (nexus-router → CLIProxyAPI → Anthropic) on a real medical-info product surface
- [ ] Reviewers may want to run the existing `internal/runtime/executor` test suite — wrapper signatures preserved, only inner `*WithSigningMode` gained a parameter

Happy to add inline unit tests for the new code path on request.