### PR TITLE
fix(claude): preserve Amp system context in Claude OAuth cloaking

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1689,10 +1689,10 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 		}
 
 		if len(userSystemParts) > 0 {
-			combined := strings.Join(userSystemParts, "\n\n")
 			if oauthMode {
-				combined = sanitizeForwardedSystemPrompt(combined)
+				userSystemParts[0] = sanitizeForwardedSystemPrompt(userSystemParts[0])
 			}
+			combined := strings.Join(userSystemParts, "\n\n")
 			if strings.TrimSpace(combined) != "" {
 				payload = prependToFirstUserMessage(payload, combined)
 			}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1923,6 +1923,36 @@ func TestCheckSystemInstructionsWithMode_ArraySystemStillWorks(t *testing.T) {
 	}
 }
 
+func TestCheckSystemInstructionsWithSigningMode_OAuthPreservesAdditionalSystemBlocks(t *testing.T) {
+	payload := []byte(`{
+		"system":[
+			{"type":"text","text":"Original Amp agent prompt that should be sanitized."},
+			{"type":"text","text":"AGENTS.md guidance should remain."},
+			{"type":"text","text":"Available skills: behavior-driven-development should remain.","cache_control":{"type":"ephemeral"}}
+		],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]
+	}`)
+
+	out := checkSystemInstructionsWithSigningMode(payload, false, false, true, "2.1.63", "", "")
+
+	forwarded := gjson.GetBytes(out, "messages.0.content.0.text").String()
+	if !strings.Contains(forwarded, sanitizeForwardedSystemPrompt("Original Amp agent prompt that should be sanitized.")) {
+		t.Fatalf("forwarded system prompt should include sanitized first block, got %q", forwarded)
+	}
+	if strings.Contains(forwarded, "Original Amp agent prompt that should be sanitized.") {
+		t.Fatalf("forwarded system prompt should not include raw first block, got %q", forwarded)
+	}
+	if !strings.Contains(forwarded, "AGENTS.md guidance should remain.") {
+		t.Fatalf("forwarded system prompt should preserve AGENTS guidance, got %q", forwarded)
+	}
+	if !strings.Contains(forwarded, "Available skills: behavior-driven-development should remain.") {
+		t.Fatalf("forwarded system prompt should preserve skill descriptions, got %q", forwarded)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.1.text").String(); got != "hi" {
+		t.Fatalf("original user content should remain after forwarded system context, got %q", got)
+	}
+}
+
 // Test case 5: Special characters in string system prompt survive forwarding
 func TestCheckSystemInstructionsWithMode_StringWithSpecialChars(t *testing.T) {
 	payload := []byte(`{"system":"Use <xml> tags & \"quotes\" in output.","messages":[{"role":"user","content":"hi"}]}`)


### PR DESCRIPTION
## Summary

- Preserve additional forwarded system blocks during Claude OAuth cloaking
- Keep Amp-provided project guidance, AGENTS.md content, and skill descriptions in the first user message
- Add regression test `TestCheckSystemInstructionsWithSigningMode_OAuthPreservesAdditionalSystemBlocks`

## Problem

When Amp requests are routed through the Claude OAuth path, CLIProxyAPI applies Claude Code-style cloaking before sending the request upstream.

Amp sends its system context as multiple `system[]` blocks, not as a single prompt. The first block contains Amp's main agent prompt, while later blocks can include important runtime context such as:

- AGENTS.md project guidance
- available / loaded skill descriptions
- workspace and environment context
- cache-control-marked context blocks

Before this change, OAuth cloaking collected all forwarded system blocks into one string and passed the entire combined text through `sanitizeForwardedSystemPrompt()`. That function intentionally replaces input with a short generic reminder:

`Use the available tools when needed to help with software engineering tasks...`

As a result, not only Amp's first agent prompt but also the later system blocks were dropped. This caused Amp to lose important project instructions and skill descriptions, which can significantly affect tool use and task behavior.

Reproduction context from #3245:

Amp + Claude OAuth cloaking can drop forwarded system prompt context. In practice, the generated upstream request keeps only the sanitized generic reminder and loses additional Amp system context.

## Fix

Keep the existing OAuth cloaking behavior for the first forwarded system block, but limit sanitization to that first block only.

The updated flow is:

1. Collect forwarded `system[]` text blocks as before.
2. In OAuth mode, sanitize only `userSystemParts[0]`.
3. Preserve `userSystemParts[1:]` unchanged.
4. Join all parts and prepend them to the first user message using the existing `<system-reminder>` path.

This keeps the Claude OAuth cloaking safety behavior for the primary third-party agent prompt while preserving Amp's additional project guidance and skill descriptions.

## Test Plan

- [x] `TestCheckSystemInstructionsWithSigningMode_OAuthPreservesAdditionalSystemBlocks` -- verifies OAuth cloaking sanitizes the first forwarded system block but preserves later AGENTS.md guidance and skill description blocks
- [x] `go test -run 'TestCheckSystemInstructions' ./internal/runtime/executor`
- [x] `go build -o test-output ./cmd/server && rm test-output`

Refs #3245