### PR TITLE
feat: preserve model metadata in OpenAI models list

### DIFF
--- a/internal/registry/model_registry_cache_test.go
+++ b/internal/registry/model_registry_cache_test.go
@@ -22,6 +22,52 @@ func TestGetAvailableModelsReturnsClonedSnapshots(t *testing.T) {
 	}
 }
 
+func TestGetAvailableModelsOpenAIPreservesMetadata(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("client-1", "OpenAI", []*ModelInfo{{
+		ID:                  "m1",
+		Object:              "model",
+		Created:             1776902400,
+		OwnedBy:             "openai",
+		Type:                "openai",
+		DisplayName:         "Model One",
+		Version:             "m1",
+		Description:         "Model with metadata.",
+		ContextLength:       272000,
+		MaxCompletionTokens: 128000,
+		SupportedParameters: []string{"tools"},
+	}})
+
+	models := r.GetAvailableModels("openai")
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	model := models[0]
+
+	want := map[string]any{
+		"id":                    "m1",
+		"object":                "model",
+		"created":               int64(1776902400),
+		"owned_by":              "openai",
+		"type":                  "openai",
+		"display_name":          "Model One",
+		"version":               "m1",
+		"description":           "Model with metadata.",
+		"context_length":        272000,
+		"max_completion_tokens": 128000,
+	}
+	for key, expected := range want {
+		if got := model[key]; got != expected {
+			t.Fatalf("expected %s=%#v, got %#v", key, expected, got)
+		}
+	}
+
+	params, ok := model["supported_parameters"].([]string)
+	if !ok || len(params) != 1 || params[0] != "tools" {
+		t.Fatalf("expected supported_parameters [tools], got %#v", model["supported_parameters"])
+	}
+}
+
 func TestGetAvailableModelsInvalidatesCacheOnRegistryChanges(t *testing.T) {
 	r := newTestModelRegistry()
 	r.RegisterClient("client-1", "OpenAI", []*ModelInfo{{ID: "m1", OwnedBy: "team-a", DisplayName: "Model One"}})

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -59,33 +59,21 @@ func (h *OpenAIAPIHandler) Models() []map[string]any {
 // It returns a list of available AI models with their capabilities
 // and specifications in OpenAI-compatible format.
 func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
-	// Get all available models
 	allModels := h.Models()
-
-	// Filter to only include the 4 required fields: id, object, created, owned_by
-	filteredModels := make([]map[string]any, len(allModels))
+	models := make([]map[string]any, len(allModels))
 	for i, model := range allModels {
-		filteredModel := map[string]any{
-			"id":     model["id"],
-			"object": model["object"],
+		copyModel := make(map[string]any, len(model))
+		for k, v := range model {
+			copyModel[k] = v
 		}
-
-		// Add created field if it exists
-		if created, exists := model["created"]; exists {
-			filteredModel["created"] = created
+		if _, ok := copyModel["object"]; !ok {
+			copyModel["object"] = "model"
 		}
-
-		// Add owned_by field if it exists
-		if ownedBy, exists := model["owned_by"]; exists {
-			filteredModel["owned_by"] = ownedBy
-		}
-
-		filteredModels[i] = filteredModel
+		models[i] = copyModel
 	}
-
 	c.JSON(http.StatusOK, gin.H{
 		"object": "list",
-		"data":   filteredModels,
+		"data":   models,
 	})
 }
 

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -59,21 +59,9 @@ func (h *OpenAIAPIHandler) Models() []map[string]any {
 // It returns a list of available AI models with their capabilities
 // and specifications in OpenAI-compatible format.
 func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
-	allModels := h.Models()
-	models := make([]map[string]any, len(allModels))
-	for i, model := range allModels {
-		copyModel := make(map[string]any, len(model))
-		for k, v := range model {
-			copyModel[k] = v
-		}
-		if _, ok := copyModel["object"]; !ok {
-			copyModel["object"] = "model"
-		}
-		models[i] = copyModel
-	}
 	c.JSON(http.StatusOK, gin.H{
 		"object": "list",
-		"data":   models,
+		"data":   h.Models(),
 	})
 }
 

--- a/sdk/api/handlers/openai/openai_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_handlers_test.go
@@ -1,0 +1,101 @@
+package openai
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestOpenAIModelsPreservesModelMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	clientID := "openai-models-metadata-test-client-" + time.Now().Format("20060102150405.000000000")
+	modelID := "openai-models-metadata-test-model-" + time.Now().Format("20060102150405.000000000")
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(clientID, "openai", []*registry.ModelInfo{{
+		ID:                  modelID,
+		Object:              "model",
+		Created:             1776902400,
+		OwnedBy:             "openai",
+		Type:                "openai",
+		DisplayName:         "Metadata Test Model",
+		Version:             modelID,
+		Description:         "Model with optional metadata.",
+		ContextLength:       272000,
+		MaxCompletionTokens: 128000,
+		SupportedParameters: []string{"tools"},
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	router := gin.New()
+	handler := &OpenAIAPIHandler{}
+	router.GET("/v1/models", handler.OpenAIModels)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	var response struct {
+		Object string           `json:"object"`
+		Data   []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Object != "list" {
+		t.Fatalf("expected object list, got %q", response.Object)
+	}
+
+	var found map[string]any
+	for _, model := range response.Data {
+		if model["id"] == modelID {
+			found = model
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected to find model %q in response", modelID)
+	}
+
+	assertJSONNumber(t, found, "context_length", 272000)
+	assertJSONNumber(t, found, "max_completion_tokens", 128000)
+	assertJSONNumber(t, found, "created", 1776902400)
+	assertStringField(t, found, "id", modelID)
+	assertStringField(t, found, "object", "model")
+	assertStringField(t, found, "owned_by", "openai")
+	assertStringField(t, found, "type", "openai")
+	assertStringField(t, found, "display_name", "Metadata Test Model")
+	assertStringField(t, found, "version", modelID)
+	assertStringField(t, found, "description", "Model with optional metadata.")
+
+	params, ok := found["supported_parameters"].([]any)
+	if !ok || len(params) != 1 || params[0] != "tools" {
+		t.Fatalf("expected supported_parameters [tools], got %#v", found["supported_parameters"])
+	}
+}
+
+func assertStringField(t *testing.T, model map[string]any, key, want string) {
+	t.Helper()
+	got, ok := model[key].(string)
+	if !ok || got != want {
+		t.Fatalf("expected %s=%q, got %#v", key, want, model[key])
+	}
+}
+
+func assertJSONNumber(t *testing.T, model map[string]any, key string, want float64) {
+	t.Helper()
+	got, ok := model[key].(float64)
+	if !ok || got != want {
+		t.Fatalf("expected %s=%v, got %#v", key, want, model[key])
+	}
+}


### PR DESCRIPTION
## Summary
- Preserve optional model metadata in OpenAI-compatible `/v1/models` responses instead of stripping entries to only id/object/created/owned_by.
- Keep backwards-compatible `object: model` fallback when the registry map lacks an object field.
- Add registry and HTTP handler tests covering fields such as `context_length`, `max_completion_tokens`, `display_name`, `type`, `version`, `description`, and `supported_parameters`.

## Test Plan
- `PATH=/tmp/go126/go/bin:$PATH go test ./sdk/api/handlers/openai`
- `PATH=/tmp/go126/go/bin:$PATH go test ./internal/registry -run 'TestGetAvailableModels'`
- `PATH=/tmp/go126/go/bin:$PATH go build -o test-output ./cmd/server && rm -f test-output`

Note: full `go test ./internal/registry` currently fails on upstream `TestCodexFreeModelsExcludeGPT55` because the current model definitions include `gpt-5.5` in the free tier; targeted new registry tests pass.
