### PR TITLE
Add Amp reasoning effort remapping

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -320,9 +320,24 @@ nonstream-keepalive-interval: 0
 #   force-model-mappings: false
 #   # Amp Model Mappings
 #   # Route unavailable Amp models to alternative models available in your local proxy.
-#   # Useful when Amp CLI requests models you don't have access to (e.g., Claude Opus 4.5)
-#   # but you have a similar model available (e.g., Claude Sonnet 4).
+#   # Useful when Amp CLI requests models you don't have access to (e.g., Claude Opus 4.7)
+#   # but you have a similar model available (e.g., GPT-5.5 through Codex OAuth).
 #   model-mappings:
+#     # Smart mode (Opus 4.7) -> GPT-5.5 for users without Claude access.
+#     # Alt+D smart effort high/xhigh/max maps onto GPT-5.5 low/medium/high.
+#     - from: "claude-opus-4-7"
+#       to: "gpt-5.5"
+#       reasoning-effort-mappings:
+#         high: "low"
+#         xhigh: "medium"
+#         max: "high"
+#     # Deep mode (GPT-5.5) -> keep GPT-5.5, but map Amp's xhigh toggle to GPT-5.5 high.
+#     - from: "gpt-5.5"
+#       to: "gpt-5.5"
+#       reasoning-effort-mappings:
+#         low: "low"
+#         medium: "medium"
+#         xhigh: "high"
 #     - from: "claude-opus-4-5-20251101"          # Model requested by Amp CLI
 #       to: "gemini-claude-opus-4-5-thinking"     # Route to this available model instead
 #     - from: "claude-sonnet-4-5-20250929"

--- a/internal/api/modules/amp/fallback_handlers.go
+++ b/internal/api/modules/amp/fallback_handlers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	log "github.com/sirupsen/logrus"
@@ -146,18 +147,18 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 			thinkingSuffix = "(" + suffixResult.RawSuffix + ")"
 		}
 
-		resolveMappedModel := func() (string, []string) {
+		resolveMappedModel := func() (string, []string, config.AmpModelMapping) {
 			if fh.modelMapper == nil {
-				return "", nil
+				return "", nil, config.AmpModelMapping{}
 			}
 
-			mappedModel := fh.modelMapper.MapModel(modelName)
-			if mappedModel == "" {
-				mappedModel = fh.modelMapper.MapModel(normalizedModel)
+			mapped := fh.modelMapper.MapModelWithInfo(modelName)
+			if mapped.Model == "" {
+				mapped = fh.modelMapper.MapModelWithInfo(normalizedModel)
 			}
-			mappedModel = strings.TrimSpace(mappedModel)
+			mappedModel := strings.TrimSpace(mapped.Model)
 			if mappedModel == "" {
-				return "", nil
+				return "", nil, config.AmpModelMapping{}
 			}
 
 			// Preserve dynamic thinking suffix (e.g. "(xhigh)") when mapping applies, unless the target
@@ -172,15 +173,16 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 			mappedBaseModel := thinking.ParseSuffix(mappedModel).ModelName
 			mappedProviders := util.GetProviderName(mappedBaseModel)
 			if len(mappedProviders) == 0 {
-				return "", nil
+				return "", nil, config.AmpModelMapping{}
 			}
 
-			return mappedModel, mappedProviders
+			return mappedModel, mappedProviders, mapped.Mapping
 		}
 
 		// Track resolved model for logging (may change if mapping is applied)
 		resolvedModel := normalizedModel
 		usedMapping := false
+		var appliedMapping config.AmpModelMapping
 		var providers []string
 
 		// Check if model mappings should be forced ahead of local API keys
@@ -189,14 +191,16 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 		if forceMappings {
 			// FORCE MODE: Check model mappings FIRST (takes precedence over local API keys)
 			// This allows users to route Amp requests to their preferred OAuth providers
-			if mappedModel, mappedProviders := resolveMappedModel(); mappedModel != "" {
+			if mappedModel, mappedProviders, mapping := resolveMappedModel(); mappedModel != "" {
 				// Mapping found and provider available - rewrite the model in request body
+				bodyBytes = applyReasoningEffortMapping(bodyBytes, mapping)
 				bodyBytes = rewriteModelInRequest(bodyBytes, mappedModel)
 				c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 				// Store mapped model in context for handlers that check it (like gemini bridge)
 				c.Set(MappedModelContextKey, mappedModel)
 				resolvedModel = mappedModel
 				usedMapping = true
+				appliedMapping = mapping
 				providers = mappedProviders
 			}
 
@@ -210,14 +214,16 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 
 			if len(providers) == 0 {
 				// No providers configured - check if we have a model mapping
-				if mappedModel, mappedProviders := resolveMappedModel(); mappedModel != "" {
+				if mappedModel, mappedProviders, mapping := resolveMappedModel(); mappedModel != "" {
 					// Mapping found and provider available - rewrite the model in request body
+					bodyBytes = applyReasoningEffortMapping(bodyBytes, mapping)
 					bodyBytes = rewriteModelInRequest(bodyBytes, mappedModel)
 					c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 					// Store mapped model in context for handlers that check it (like gemini bridge)
 					c.Set(MappedModelContextKey, mappedModel)
 					resolvedModel = mappedModel
 					usedMapping = true
+					appliedMapping = mapping
 					providers = mappedProviders
 				}
 			}
@@ -250,6 +256,9 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 
 		if usedMapping {
 			// Log: Model was mapped to another model
+			if len(appliedMapping.ReasoningEffortMappings) > 0 {
+				log.Debugf("amp model mapping: applied reasoning effort mapping for %s -> %s", normalizedModel, resolvedModel)
+			}
 			log.Debugf("amp model mapping: request %s -> %s", normalizedModel, resolvedModel)
 			logAmpRouting(RouteTypeModelMapping, modelName, resolvedModel, providerName, requestPath)
 			rewriter := NewResponseRewriter(c.Writer, modelName)
@@ -293,6 +302,40 @@ func filterAntropicBetaHeader(c *gin.Context) {
 			c.Request.Header.Del("Anthropic-Beta")
 		}
 	}
+}
+
+// applyReasoningEffortMapping remaps common reasoning effort fields when an Amp model mapping requests it.
+func applyReasoningEffortMapping(body []byte, mapping config.AmpModelMapping) []byte {
+	if len(mapping.ReasoningEffortMappings) == 0 || !gjson.ValidBytes(body) {
+		return body
+	}
+
+	paths := []string{"output_config.effort", "reasoning.effort", "reasoning_effort"}
+	result := body
+	for _, path := range paths {
+		current := gjson.GetBytes(result, path)
+		if !current.Exists() || current.Type != gjson.String {
+			continue
+		}
+		value := strings.ToLower(strings.TrimSpace(current.String()))
+		if value == "" {
+			continue
+		}
+		mappedEffort := strings.TrimSpace(mapping.ReasoningEffortMappings[value])
+		if mappedEffort == "" {
+			mappedEffort = strings.TrimSpace(mapping.ReasoningEffortMappings[current.String()])
+		}
+		if mappedEffort == "" {
+			continue
+		}
+		updated, err := sjson.SetBytes(result, path, mappedEffort)
+		if err != nil {
+			log.Warnf("amp model mapping: failed to remap reasoning effort at %s: %v", path, err)
+			continue
+		}
+		result = updated
+	}
+	return result
 }
 
 // rewriteModelInRequest replaces the model name in a JSON request body

--- a/internal/api/modules/amp/fallback_handlers_test.go
+++ b/internal/api/modules/amp/fallback_handlers_test.go
@@ -13,6 +13,88 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
+func TestFallbackHandler_ModelMapping_RemapReasoningEffort(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-client-amp-effort", "codex", []*registry.ModelInfo{
+		{ID: "gpt-5.5", OwnedBy: "openai", Type: "codex"},
+	})
+	defer reg.UnregisterClient("test-client-amp-effort")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{
+		{
+			From: "claude-opus-4-7",
+			To:   "gpt-5.5",
+			ReasoningEffortMappings: map[string]string{
+				"high":  "low",
+				"xhigh": "medium",
+				"max":   "high",
+			},
+		},
+	})
+
+	fallback := NewFallbackHandlerWithMapper(func() *httputil.ReverseProxy { return nil }, mapper, func() bool { return true })
+
+	handler := func(c *gin.Context) {
+		var req struct {
+			Model        string `json:"model"`
+			OutputConfig struct {
+				Effort string `json:"effort"`
+			} `json:"output_config"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"model":  req.Model,
+			"effort": req.OutputConfig.Effort,
+		})
+	}
+
+	r := gin.New()
+	r.POST("/v1/messages", fallback.WrapHandler(handler))
+
+	cases := []struct {
+		name       string
+		inEffort   string
+		wantEffort string
+	}{
+		{name: "high to low", inEffort: "high", wantEffort: "low"},
+		{name: "xhigh to medium", inEffort: "xhigh", wantEffort: "medium"},
+		{name: "max to high", inEffort: "max", wantEffort: "high"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqBody := []byte(`{"model":"claude-opus-4-7","output_config":{"effort":"` + tc.inEffort + `"}}`)
+			req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(reqBody))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+			}
+
+			var resp struct {
+				Model  string `json:"model"`
+				Effort string `json:"effort"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("Failed to parse response JSON: %v", err)
+			}
+			if resp.Model != "claude-opus-4-7" {
+				t.Errorf("Expected response model claude-opus-4-7, got %s", resp.Model)
+			}
+			if resp.Effort != tc.wantEffort {
+				t.Errorf("Expected handler to see remapped effort %s, got %s", tc.wantEffort, resp.Effort)
+			}
+		})
+	}
+}
+
 func TestFallbackHandler_ModelMapping_PreservesThinkingSuffixAndRewritesResponse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/api/modules/amp/model_mapping.go
+++ b/internal/api/modules/amp/model_mapping.go
@@ -21,21 +21,30 @@ type ModelMapper interface {
 	// model has available providers. Returns empty string if no mapping applies.
 	MapModel(requestedModel string) string
 
+	// MapModelWithInfo returns the target model plus the matching mapping metadata.
+	MapModelWithInfo(requestedModel string) MappingResult
+
 	// UpdateMappings refreshes the mapping configuration (for hot-reload).
 	UpdateMappings(mappings []config.AmpModelMapping)
+}
+
+// MappingResult is the result of resolving an Amp model mapping.
+type MappingResult struct {
+	Model   string
+	Mapping config.AmpModelMapping
 }
 
 // DefaultModelMapper implements ModelMapper with thread-safe mapping storage.
 type DefaultModelMapper struct {
 	mu       sync.RWMutex
-	mappings map[string]string // exact: from -> to (normalized lowercase keys)
-	regexps  []regexMapping    // regex rules evaluated in order
+	mappings map[string]config.AmpModelMapping // exact: from -> mapping (normalized lowercase keys)
+	regexps  []regexMapping                    // regex rules evaluated in order
 }
 
 // NewModelMapper creates a new model mapper with the given initial mappings.
 func NewModelMapper(mappings []config.AmpModelMapping) *DefaultModelMapper {
 	m := &DefaultModelMapper{
-		mappings: make(map[string]string),
+		mappings: make(map[string]config.AmpModelMapping),
 		regexps:  nil,
 	}
 	m.UpdateMappings(mappings)
@@ -51,8 +60,15 @@ func NewModelMapper(mappings []config.AmpModelMapping) *DefaultModelMapper {
 // However, if the mapping target already contains a suffix, the config suffix
 // takes priority over the user's suffix.
 func (m *DefaultModelMapper) MapModel(requestedModel string) string {
+	return m.MapModelWithInfo(requestedModel).Model
+}
+
+// MapModelWithInfo checks if a mapping exists for the requested model and if the
+// target model has available local providers. It returns the mapped model name
+// and matching mapping metadata, or an empty result if no valid mapping exists.
+func (m *DefaultModelMapper) MapModelWithInfo(requestedModel string) MappingResult {
 	if requestedModel == "" {
-		return ""
+		return MappingResult{}
 	}
 
 	m.mu.RLock()
@@ -66,21 +82,22 @@ func (m *DefaultModelMapper) MapModel(requestedModel string) string {
 	normalizedBase := strings.ToLower(strings.TrimSpace(baseModel))
 
 	// Check for direct mapping using base model name
-	targetModel, exists := m.mappings[normalizedBase]
+	mapping, exists := m.mappings[normalizedBase]
 	if !exists {
 		// Try regex mappings in order using base model only
 		// (suffix is handled separately via ParseSuffix)
 		for _, rm := range m.regexps {
 			if rm.re.MatchString(baseModel) {
-				targetModel = rm.to
+				mapping = rm.mapping
 				exists = true
 				break
 			}
 		}
 		if !exists {
-			return ""
+			return MappingResult{}
 		}
 	}
+	targetModel := strings.TrimSpace(mapping.To)
 
 	// Check if target model already has a thinking suffix (config priority)
 	targetResult := thinking.ParseSuffix(targetModel)
@@ -89,23 +106,23 @@ func (m *DefaultModelMapper) MapModel(requestedModel string) string {
 	providers := util.GetProviderName(targetResult.ModelName)
 	if len(providers) == 0 {
 		log.Debugf("amp model mapping: target model %s has no available providers, skipping mapping", targetModel)
-		return ""
+		return MappingResult{}
 	}
 
 	// Suffix handling: config suffix takes priority, otherwise preserve user suffix
 	if targetResult.HasSuffix {
 		// Config's "to" already contains a suffix - use it as-is (config priority)
-		return targetModel
+		return MappingResult{Model: targetModel, Mapping: mapping}
 	}
 
 	// Preserve user's thinking suffix on the mapped model
 	// (skip empty suffixes to avoid returning "model()")
 	if requestResult.HasSuffix && requestResult.RawSuffix != "" {
-		return targetModel + "(" + requestResult.RawSuffix + ")"
+		targetModel += "(" + requestResult.RawSuffix + ")"
 	}
 
 	// Note: Detailed routing log is handled by logAmpRouting in fallback_handlers.go
-	return targetModel
+	return MappingResult{Model: targetModel, Mapping: mapping}
 }
 
 // UpdateMappings refreshes the mapping configuration from config.
@@ -115,7 +132,7 @@ func (m *DefaultModelMapper) UpdateMappings(mappings []config.AmpModelMapping) {
 	defer m.mu.Unlock()
 
 	// Clear and rebuild mappings
-	m.mappings = make(map[string]string, len(mappings))
+	m.mappings = make(map[string]config.AmpModelMapping, len(mappings))
 	m.regexps = make([]regexMapping, 0, len(mappings))
 
 	for _, mapping := range mappings {
@@ -127,6 +144,20 @@ func (m *DefaultModelMapper) UpdateMappings(mappings []config.AmpModelMapping) {
 			continue
 		}
 
+		mapping.From = from
+		mapping.To = to
+		if len(mapping.ReasoningEffortMappings) > 0 {
+			normalizedEfforts := make(map[string]string, len(mapping.ReasoningEffortMappings))
+			for fromEffort, toEffort := range mapping.ReasoningEffortMappings {
+				fromEffort = strings.ToLower(strings.TrimSpace(fromEffort))
+				toEffort = strings.TrimSpace(toEffort)
+				if fromEffort == "" || toEffort == "" {
+					continue
+				}
+				normalizedEfforts[fromEffort] = toEffort
+			}
+			mapping.ReasoningEffortMappings = normalizedEfforts
+		}
 		if mapping.Regex {
 			// Compile case-insensitive regex; wrap with (?i) to match behavior of exact lookups
 			pattern := "(?i)" + from
@@ -135,12 +166,12 @@ func (m *DefaultModelMapper) UpdateMappings(mappings []config.AmpModelMapping) {
 				log.Warnf("amp model mapping: invalid regex %q: %v", from, err)
 				continue
 			}
-			m.regexps = append(m.regexps, regexMapping{re: re, to: to})
+			m.regexps = append(m.regexps, regexMapping{re: re, mapping: mapping})
 			log.Debugf("amp model regex mapping registered: /%s/ -> %s", from, to)
 		} else {
 			// Store with normalized lowercase key for case-insensitive lookup
 			normalizedFrom := strings.ToLower(from)
-			m.mappings[normalizedFrom] = to
+			m.mappings[normalizedFrom] = mapping
 			log.Debugf("amp model mapping registered: %s -> %s", from, to)
 		}
 	}
@@ -160,12 +191,12 @@ func (m *DefaultModelMapper) GetMappings() map[string]string {
 
 	result := make(map[string]string, len(m.mappings))
 	for k, v := range m.mappings {
-		result[k] = v
+		result[k] = v.To
 	}
 	return result
 }
 
 type regexMapping struct {
-	re *regexp.Regexp
-	to string
+	re      *regexp.Regexp
+	mapping config.AmpModelMapping
 }

--- a/internal/api/modules/amp/model_mapping_test.go
+++ b/internal/api/modules/amp/model_mapping_test.go
@@ -71,6 +71,32 @@ func TestModelMapper_MapModel_WithProvider(t *testing.T) {
 	}
 }
 
+func TestModelMapper_MapModelWithInfo_ReturnsEffortMappings(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-client-effort-info", "codex", []*registry.ModelInfo{
+		{ID: "gpt-5.5", OwnedBy: "openai", Type: "codex"},
+	})
+	defer reg.UnregisterClient("test-client-effort-info")
+
+	mapper := NewModelMapper([]config.AmpModelMapping{{
+		From: "claude-opus-4-7",
+		To:   "gpt-5.5",
+		ReasoningEffortMappings: map[string]string{
+			"high":  "low",
+			"xhigh": "medium",
+			"max":   "high",
+		},
+	}})
+
+	result := mapper.MapModelWithInfo("claude-opus-4-7")
+	if result.Model != "gpt-5.5" {
+		t.Fatalf("Expected gpt-5.5, got %s", result.Model)
+	}
+	if got := result.Mapping.ReasoningEffortMappings["max"]; got != "high" {
+		t.Fatalf("Expected max effort to map to high, got %q", got)
+	}
+}
+
 func TestModelMapper_MapModel_TargetWithThinkingSuffix(t *testing.T) {
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient("test-client-thinking", "codex", []*registry.ModelInfo{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -265,6 +265,12 @@ type AmpModelMapping struct {
 	// expression for matching model names. When true, this mapping is evaluated
 	// after exact matches and in the order provided. Defaults to false (exact match).
 	Regex bool `yaml:"regex,omitempty" json:"regex,omitempty"`
+
+	// ReasoningEffortMappings remaps request-body reasoning effort values when this
+	// model mapping is applied. This is useful when Amp's source model exposes a
+	// different effort ladder than the target model (for example, Opus 4.7 smart
+	// mode high/xhigh/max -> GPT-5.5 low/medium/high).
+	ReasoningEffortMappings map[string]string `yaml:"reasoning-effort-mappings,omitempty" json:"reasoning-effort-mappings,omitempty"`
 }
 
 // AmpCode groups Amp CLI integration settings including upstream routing,

--- a/internal/watcher/diff/oauth_excluded.go
+++ b/internal/watcher/diff/oauth_excluded.go
@@ -104,7 +104,17 @@ func SummarizeAmpModelMappings(mappings []config.AmpModelMapping) AmpModelMappin
 		if from == "" && to == "" {
 			continue
 		}
-		entries = append(entries, from+"->"+to)
+		efforts := make([]string, 0, len(mapping.ReasoningEffortMappings))
+		for fromEffort, toEffort := range mapping.ReasoningEffortMappings {
+			fromEffort = strings.ToLower(strings.TrimSpace(fromEffort))
+			toEffort = strings.ToLower(strings.TrimSpace(toEffort))
+			if fromEffort == "" && toEffort == "" {
+				continue
+			}
+			efforts = append(efforts, fromEffort+":"+toEffort)
+		}
+		sort.Strings(efforts)
+		entries = append(entries, from+"->"+to+"|effort="+strings.Join(efforts, ","))
 	}
 	if len(entries) == 0 {
 		return AmpModelMappingsSummary{}


### PR DESCRIPTION
## Summary
- add optional `ampcode.model-mappings[].reasoning-effort-mappings` for per-model Amp effort translation
- apply mappings to Anthropic/OpenAI/Codex effort fields when Amp model mappings are used
- preserve mapping metadata for hot reload diffs and add GPT-5.5 example for Opus 4.7 smart mode

## Verification
- `go test ./internal/api/modules/amp -run 'TestFallbackHandler_ModelMapping_RemapReasoningEffort|TestModelMapper_MapModelWithInfo_ReturnsEffortMappings'`\n- `go test ./internal/watcher/diff`\n- `go build -o test-output ./cmd/server && rm test-output`\n\n## Notes\nThis is useful for Amp smart mode when mapping Claude Opus 4.7 to GPT-5.5: `high -> low`, `xhigh -> medium`, `max -> high`.\n