### PR TITLE
fix(openai): add missing `data: [DONE]` SSE terminal marker in /v1/re…

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -567,7 +567,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flush
 		},
 		WriteDone: func() {
 			framer.Flush(c.Writer)
-			_, _ = c.Writer.Write([]byte("\n"))
+			_, _ = fmt.Fprint(c.Writer, "data: [DONE]\n\n")
 		},
 	})
 }


### PR DESCRIPTION
## Summary
- /v1/responses streaming endpoint was missing the `data: [DONE]` SSE terminal marker, causing OpenAI SDK clients (`openai>=2.6`) to throw `JSONDecodeError` after `response.completed`
- the `WriteDone` callback only wrote a `\n`; changed to emit `data: [DONE]\n\n`, matching the existing /v1/chat/completions behavior in `openai_handlers.go:680`

## Testing
- `go build ./sdk/api/handlers/openai/` passes