### PR TITLE
fix(usage): parse DeepSeek prompt cache fields

### DIFF
--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -306,6 +306,8 @@ func hasOpenAIStyleUsageTokenFields(usageNode gjson.Result) bool {
 		usageNode.Get("total_tokens").Exists() ||
 		usageNode.Get("prompt_tokens_details.cached_tokens").Exists() ||
 		usageNode.Get("input_tokens_details.cached_tokens").Exists() ||
+		usageNode.Get("prompt_cache_hit_tokens").Exists() ||
+		usageNode.Get("prompt_cache_miss_tokens").Exists() ||
 		usageNode.Get("completion_tokens_details.reasoning_tokens").Exists() ||
 		usageNode.Get("output_tokens_details.reasoning_tokens").Exists()
 }
@@ -328,8 +330,16 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	if !cached.Exists() {
 		cached = usageNode.Get("input_tokens_details.cached_tokens")
 	}
+	promptCacheHit := usageNode.Get("prompt_cache_hit_tokens")
+	promptCacheMiss := usageNode.Get("prompt_cache_miss_tokens")
+	if !cached.Exists() {
+		cached = promptCacheHit
+	}
 	if cached.Exists() {
 		detail.CachedTokens = cached.Int()
+	}
+	if detail.InputTokens == 0 && (promptCacheHit.Exists() || promptCacheMiss.Exists()) {
+		detail.InputTokens = promptCacheHit.Int() + promptCacheMiss.Int()
 	}
 	reasoning := usageNode.Get("completion_tokens_details.reasoning_tokens")
 	if !reasoning.Exists() {
@@ -338,7 +348,7 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	if reasoning.Exists() {
 		detail.ReasoningTokens = reasoning.Int()
 	}
-	return detail
+	return normalizeUsageDetailTotal(detail)
 }
 
 func ParseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -48,6 +48,93 @@ func TestParseOpenAIUsageResponses(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIUsageDeepSeekPromptCacheFields(t *testing.T) {
+	data := []byte(`{"usage":{"prompt_tokens":16075935,"completion_tokens":44056,"total_tokens":16119991,"prompt_cache_hit_tokens":14771712,"prompt_cache_miss_tokens":1260167}}`)
+	detail := ParseOpenAIUsage(data)
+	if detail.InputTokens != 16075935 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 16075935)
+	}
+	if detail.OutputTokens != 44056 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 44056)
+	}
+	if detail.TotalTokens != 16119991 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 16119991)
+	}
+	if detail.CachedTokens != 14771712 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 14771712)
+	}
+}
+
+func TestParseOpenAIStreamUsageDeepSeekPromptCacheFields(t *testing.T) {
+	line := []byte(`data: {"id":"chunk_1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":16075935,"completion_tokens":44056,"total_tokens":16119991,"prompt_cache_hit_tokens":14771712,"prompt_cache_miss_tokens":1260167}}`)
+	detail, ok := ParseOpenAIStreamUsage(line)
+	if !ok {
+		t.Fatal("ParseOpenAIStreamUsage() ok = false, want true")
+	}
+	if detail.InputTokens != 16075935 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 16075935)
+	}
+	if detail.OutputTokens != 44056 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 44056)
+	}
+	if detail.TotalTokens != 16119991 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 16119991)
+	}
+	if detail.CachedTokens != 14771712 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 14771712)
+	}
+}
+
+func TestParseOpenAIUsageDeepSeekCacheOnlyFields(t *testing.T) {
+	data := []byte(`{"usage":{"completion_tokens":5,"prompt_cache_hit_tokens":13,"prompt_cache_miss_tokens":7}}`)
+	detail := ParseOpenAIUsage(data)
+	if detail.InputTokens != 20 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 20)
+	}
+	if detail.OutputTokens != 5 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 5)
+	}
+	if detail.TotalTokens != 25 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 25)
+	}
+	if detail.CachedTokens != 13 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 13)
+	}
+}
+
+func TestParseOpenAIUsageDoesNotRecoverInputFromCachedDetailsOnly(t *testing.T) {
+	testCases := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "prompt tokens details",
+			data: []byte(`{"usage":{"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":13}}}`),
+		},
+		{
+			name: "input tokens details",
+			data: []byte(`{"usage":{"completion_tokens":5,"input_tokens_details":{"cached_tokens":13}}}`),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			detail := ParseOpenAIUsage(tc.data)
+			if detail.InputTokens != 0 {
+				t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 0)
+			}
+			if detail.OutputTokens != 5 {
+				t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 5)
+			}
+			if detail.TotalTokens != 5 {
+				t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 5)
+			}
+			if detail.CachedTokens != 13 {
+				t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 13)
+			}
+		})
+	}
+}
+
 func TestParseOpenAIUsageIgnoresNullUsage(t *testing.T) {
 	data := []byte(`{"usage":null}`)
 	detail := ParseOpenAIUsage(data)


### PR DESCRIPTION
## Summary
- parse DeepSeek `prompt_cache_hit_tokens` as cached input tokens for OpenAI-compatible usage payloads
- recognize DeepSeek `prompt_cache_miss_tokens` as a valid usage field
- recover input tokens from hit + miss when an upstream omits `prompt_tokens`
- add non-streaming and streaming unit coverage for DeepSeek prompt cache usage fields

Fixes #3358

## Tests
- `go test ./internal/runtime/executor/helps`
