### PR TITLE
feat(quota): add antigravity-credits-stick-seconds config option

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -116,6 +116,7 @@ quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
   antigravity-credits: true # Whether to use credits as last-resort fallback when all free-tier auths are exhausted for Claude models
+  antigravity-credits-stick-seconds: 0 # How long (seconds) credits mode stays active after first successful credits request. 0 = disabled, -1 = always use credits
 
 # Routing strategy for selecting credentials when multiple match.
 routing:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,14 @@ type QuotaExceeded struct {
 	// When all free-tier auths are exhausted (429/503), the conductor retries with
 	// an auth that has available Google One AI credits.
 	AntigravityCredits bool `yaml:"antigravity-credits" json:"antigravity-credits"`
+
+	// AntigravityCreditsStickSeconds specifies how long (in seconds) the credits
+	// mode stays active after the first successful credits-based request.
+	// During this window subsequent requests skip the free-tier attempt and use
+	// credits directly. The timer starts on the first success and is never renewed.
+	// 0 (default) disables sticky behavior — each request tries free tier first.
+	// -1 means permanently use credits — always skip free tier for Claude models.
+	AntigravityCreditsStickSeconds int `yaml:"antigravity-credits-stick-seconds" json:"antigravity-credits-stick-seconds"`
 }
 
 // RoutingConfig configures how credentials are selected for requests.

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -89,6 +89,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.QuotaExceeded.AntigravityCredits != newCfg.QuotaExceeded.AntigravityCredits {
 		changes = append(changes, fmt.Sprintf("quota-exceeded.antigravity-credits: %t -> %t", oldCfg.QuotaExceeded.AntigravityCredits, newCfg.QuotaExceeded.AntigravityCredits))
 	}
+	if oldCfg.QuotaExceeded.AntigravityCreditsStickSeconds != newCfg.QuotaExceeded.AntigravityCreditsStickSeconds {
+		changes = append(changes, fmt.Sprintf("quota-exceeded.antigravity-credits-stick-seconds: %d -> %d", oldCfg.QuotaExceeded.AntigravityCreditsStickSeconds, newCfg.QuotaExceeded.AntigravityCreditsStickSeconds))
+	}
 
 	if oldCfg.Routing.Strategy != newCfg.Routing.Strategy {
 		changes = append(changes, fmt.Sprintf("routing.strategy: %s -> %s", oldCfg.Routing.Strategy, newCfg.Routing.Strategy))

--- a/sdk/cliproxy/auth/antigravity_credits.go
+++ b/sdk/cliproxy/auth/antigravity_credits.go
@@ -72,6 +72,84 @@ func HasKnownAntigravityCreditsHint(authID string) bool {
 	return ok && hint.Known
 }
 
+var antigravityCreditsStickByAuth sync.Map // auth ID → time.Time (first successful credits usage)
+
+// MarkAntigravityCreditsStick records the first successful credits-based request
+// for the given auth. Subsequent calls are no-ops — the window is never renewed.
+func MarkAntigravityCreditsStick(authID string) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return
+	}
+	antigravityCreditsStickByAuth.LoadOrStore(authID, time.Now())
+}
+
+// ClearAntigravityCreditsStick removes the sticky credits state for the given auth.
+func ClearAntigravityCreditsStick(authID string) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return
+	}
+	antigravityCreditsStickByAuth.Delete(authID)
+}
+
+// IsAntigravityCreditsSticky reports whether the given auth is within an active
+// sticky credits window.
+// stickSeconds == 0: disabled. stickSeconds < 0 (-1): permanently sticky.
+func IsAntigravityCreditsSticky(authID string, stickSeconds int) bool {
+	if stickSeconds == 0 {
+		return false
+	}
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return false
+	}
+	if stickSeconds < 0 {
+		return true
+	}
+	val, ok := antigravityCreditsStickByAuth.Load(authID)
+	if !ok {
+		return false
+	}
+	t, ok := val.(time.Time)
+	if !ok {
+		antigravityCreditsStickByAuth.Delete(authID)
+		return false
+	}
+	if time.Since(t) > time.Duration(stickSeconds)*time.Second {
+		antigravityCreditsStickByAuth.Delete(authID)
+		return false
+	}
+	return true
+}
+
+// HasAnyAntigravityCreditsSticky reports whether any antigravity auth currently
+// has an active sticky credits window.
+// stickSeconds < 0 (-1) means permanently sticky — always returns true.
+func HasAnyAntigravityCreditsSticky(stickSeconds int) bool {
+	if stickSeconds == 0 {
+		return false
+	}
+	if stickSeconds < 0 {
+		return true
+	}
+	found := false
+	antigravityCreditsStickByAuth.Range(func(key, value any) bool {
+		t, ok := value.(time.Time)
+		if !ok {
+			antigravityCreditsStickByAuth.Delete(key)
+			return true
+		}
+		if time.Since(t) <= time.Duration(stickSeconds)*time.Second {
+			found = true
+			return false
+		}
+		antigravityCreditsStickByAuth.Delete(key)
+		return true
+	})
+	return found
+}
+
 func antigravityCreditsAvailableForModel(auth *Auth, model string) bool {
 	if auth == nil {
 		return false

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1220,6 +1220,12 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
 
+	if m.antigravityCreditsSticky(normalized, req.Model) {
+		if resp, ok := m.tryAntigravityCreditsExecute(ctx, req, opts); ok {
+			return resp, nil
+		}
+	}
+
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
@@ -1284,6 +1290,12 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
+	}
+
+	if m.antigravityCreditsSticky(normalized, req.Model) {
+		if result, ok := m.tryAntigravityCreditsExecuteStream(ctx, req, opts); ok {
+			return result, nil
+		}
 	}
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
@@ -3513,6 +3525,30 @@ type creditsCandidateEntry struct {
 	provider string
 }
 
+func (m *Manager) antigravityCreditsSticky(providers []string, model string) bool {
+	if m == nil {
+		return false
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil || !cfg.QuotaExceeded.AntigravityCredits || cfg.QuotaExceeded.AntigravityCreditsStickSeconds == 0 {
+		return false
+	}
+	if !strings.Contains(strings.ToLower(strings.TrimSpace(model)), "claude") {
+		return false
+	}
+	hasAntigravity := false
+	for _, p := range providers {
+		if strings.EqualFold(strings.TrimSpace(p), "antigravity") {
+			hasAntigravity = true
+			break
+		}
+	}
+	if !hasAntigravity {
+		return false
+	}
+	return HasAnyAntigravityCreditsSticky(cfg.QuotaExceeded.AntigravityCreditsStickSeconds)
+}
+
 func shouldAttemptAntigravityCreditsFallback(m *Manager, lastErr error, providers []string) bool {
 	status := statusCodeFromError(lastErr)
 	log.WithFields(log.Fields{
@@ -3594,6 +3630,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 				continue
 			}
 			m.MarkResult(creditsCtx, result)
+			MarkAntigravityCreditsStick(c.auth.ID)
 			return resp, true
 		}
 	}
@@ -3622,6 +3659,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		if errStream != nil {
 			continue
 		}
+		MarkAntigravityCreditsStick(c.auth.ID)
 		return result, true
 	}
 	return nil, false

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1220,8 +1220,14 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
 
-	if m.antigravityCreditsSticky(normalized, req.Model) {
-		if resp, ok := m.tryAntigravityCreditsExecute(ctx, req, opts); ok {
+	if ss := m.antigravityCreditsStickSeconds(normalized, req.Model); ss != 0 {
+		var candidates []creditsCandidateEntry
+		if ss < 0 {
+			candidates = m.findAllAntigravityCreditsCandidateAuths(req.Model, opts)
+		} else {
+			candidates = m.findStickyAntigravityCreditsCandidateAuths(req.Model, opts, ss)
+		}
+		if resp, ok := m.creditsExecuteWith(ctx, req, opts, candidates); ok {
 			return resp, nil
 		}
 	}
@@ -1292,8 +1298,14 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
 
-	if m.antigravityCreditsSticky(normalized, req.Model) {
-		if result, ok := m.tryAntigravityCreditsExecuteStream(ctx, req, opts); ok {
+	if ss := m.antigravityCreditsStickSeconds(normalized, req.Model); ss != 0 {
+		var candidates []creditsCandidateEntry
+		if ss < 0 {
+			candidates = m.findAllAntigravityCreditsCandidateAuths(req.Model, opts)
+		} else {
+			candidates = m.findStickyAntigravityCreditsCandidateAuths(req.Model, opts, ss)
+		}
+		if result, ok := m.creditsExecuteStreamWith(ctx, req, opts, candidates); ok {
 			return result, nil
 		}
 	}
@@ -3525,16 +3537,18 @@ type creditsCandidateEntry struct {
 	provider string
 }
 
-func (m *Manager) antigravityCreditsSticky(providers []string, model string) bool {
+// antigravityCreditsStickSeconds returns the configured stick duration if the
+// sticky credits path should be attempted. Returns 0 when disabled.
+func (m *Manager) antigravityCreditsStickSeconds(providers []string, model string) int {
 	if m == nil {
-		return false
+		return 0
 	}
 	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
 	if cfg == nil || !cfg.QuotaExceeded.AntigravityCredits || cfg.QuotaExceeded.AntigravityCreditsStickSeconds == 0 {
-		return false
+		return 0
 	}
 	if !strings.Contains(strings.ToLower(strings.TrimSpace(model)), "claude") {
-		return false
+		return 0
 	}
 	hasAntigravity := false
 	for _, p := range providers {
@@ -3544,9 +3558,29 @@ func (m *Manager) antigravityCreditsSticky(providers []string, model string) boo
 		}
 	}
 	if !hasAntigravity {
-		return false
+		return 0
 	}
-	return HasAnyAntigravityCreditsSticky(cfg.QuotaExceeded.AntigravityCreditsStickSeconds)
+	ss := cfg.QuotaExceeded.AntigravityCreditsStickSeconds
+	if !HasAnyAntigravityCreditsSticky(ss) {
+		return 0
+	}
+	return ss
+}
+
+// findStickyAntigravityCreditsCandidateAuths returns only the candidates whose
+// auth has an active per-auth sticky window (stickSeconds > 0).
+func (m *Manager) findStickyAntigravityCreditsCandidateAuths(routeModel string, opts cliproxyexecutor.Options, stickSeconds int) []creditsCandidateEntry {
+	all := m.findAllAntigravityCreditsCandidateAuths(routeModel, opts)
+	if stickSeconds <= 0 {
+		return all
+	}
+	var sticky []creditsCandidateEntry
+	for _, c := range all {
+		if IsAntigravityCreditsSticky(c.auth.ID, stickSeconds) {
+			sticky = append(sticky, c)
+		}
+	}
+	return sticky
 }
 
 func shouldAttemptAntigravityCreditsFallback(m *Manager, lastErr error, providers []string) bool {
@@ -3594,8 +3628,17 @@ func shouldAttemptAntigravityCreditsFallback(m *Manager, lastErr error, provider
 }
 
 func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, bool) {
+	candidates := m.findAllAntigravityCreditsCandidateAuths(req.Model, opts)
+	return m.creditsExecuteWith(ctx, req, opts, candidates)
+}
+
+func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, bool) {
+	candidates := m.findAllAntigravityCreditsCandidateAuths(req.Model, opts)
+	return m.creditsExecuteStreamWith(ctx, req, opts, candidates)
+}
+
+func (m *Manager) creditsExecuteWith(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, candidates []creditsCandidateEntry) (cliproxyexecutor.Response, bool) {
 	routeModel := req.Model
-	candidates := m.findAllAntigravityCreditsCandidateAuths(routeModel, opts)
 	for _, c := range candidates {
 		if ctx.Err() != nil {
 			return cliproxyexecutor.Response{}, false
@@ -3637,9 +3680,8 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 	return cliproxyexecutor.Response{}, false
 }
 
-func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, bool) {
+func (m *Manager) creditsExecuteStreamWith(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, candidates []creditsCandidateEntry) (*cliproxyexecutor.StreamResult, bool) {
 	routeModel := req.Model
-	candidates := m.findAllAntigravityCreditsCandidateAuths(routeModel, opts)
 	for _, c := range candidates {
 		if ctx.Err() != nil {
 			return nil, false


### PR DESCRIPTION
## Summary / 概述

Add a new configuration option `antigravity-credits-stick-seconds` under `quota-exceeded` that allows the credits mode to persist for a configurable duration after the first successful credits-based request.

新增配置项 `antigravity-credits-stick-seconds`（位于 `quota-exceeded` 下），允许在首次 credits 请求成功后，将付费 credits 模式保持一段可配置的时间。

## Motivation / 动机

Currently, every request independently decides whether to use credits — it always tries the free tier first, and only falls back to credits after a 429/503 failure. This wastes a round-trip on every request when the free quota is already known to be exhausted.

当前每次请求都独立判断是否使用 credits——始终先尝试免费配额，失败后才回退到 credits。当免费配额已知耗尽时，每次请求都浪费一次失败的往返。

## Configuration / 配置说明

```yaml
quota-exceeded:
  antigravity-credits: true
  antigravity-credits-stick-seconds: 300  # see below
```

| Value / 值 | Behavior / 行为 |
|---|---|
| `0` (default) | Disabled — per-request fallback only (original behavior) / 禁用——逐请求回退（原有行为） |
| `> 0` (e.g. `300`) | Credits mode stays active for N seconds from the **first** success (timer is never renewed) / 首次成功后保持 N 秒（计时器不续期） |
| `-1` | Permanently use credits — always skip free tier for Claude models / 永久使用 credits——Claude 模型始终跳过免费配额 |

## Changes / 修改内容

- **`internal/config/config.go`** — Add `AntigravityCreditsStickSeconds int` field to `QuotaExceeded` struct / 在 `QuotaExceeded` 结构体中新增字段
- **`config.example.yaml`** — Add config example with documentation / 添加配置示例和说明
- **`sdk/cliproxy/auth/antigravity_credits.go`** — Add sticky state management (`MarkAntigravityCreditsStick`, `ClearAntigravityCreditsStick`, `IsAntigravityCreditsSticky`, `HasAnyAntigravityCreditsSticky`) using `sync.Map` with `LoadOrStore` (no renewal) / 新增 sticky 状态管理，使用 `LoadOrStore` 确保不续期
- **`sdk/cliproxy/auth/conductor.go`** — Check sticky window at `Execute`/`ExecuteStream` entry; record timestamp on credits success; add `antigravityCreditsSticky` helper / 在 `Execute`/`ExecuteStream` 入口检查 sticky 窗口，credits 成功时记录时间戳
- **`internal/watcher/diff/config_diff.go`** — Track config hot-reload changes for the new field / 追踪新字段的配置热更新变化

## Test plan / 测试计划

- [x] `go build ./...` passes
- [x] All existing tests pass (`sdk/cliproxy/auth`, `internal/config`, `internal/watcher/diff`)
- [x] Two pre-existing test failures in `internal/runtime/executor` (`TestEnsureAccessToken_WarmTokenLoadsCreditsHint`, `TestUpdateAntigravityCreditsBalance_LoadCodeAssistUserAgent`) are unrelated — they fail identically on unmodified `main`
- [ ] Manual testing with `antigravity-credits-stick-seconds: -1` (permanent mode)
- [ ] Manual testing with `antigravity-credits-stick-seconds: 300` (timed sticky)
- [ ] Verify timer does not renew on subsequent credits successes

🤖 Generated with [Claude Code](https://claude.com/claude-code)