### PR TITLE
Expose model details in /v1/models

### DIFF
--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -917,7 +917,7 @@ func cloneThinkingSupportMap(thinking *ThinkingSupport) map[string]any {
 	return result
 }
 
-func buildThinkingLevelDetails(thinking *ThinkingSupport) ([]string, map[string]int) {
+func buildThinkingLevelDetails(thinking *ThinkingSupport) ([]string, map[string]any) {
 	if thinking == nil {
 		return nil, nil
 	}
@@ -956,7 +956,7 @@ func buildThinkingLevelDetails(thinking *ThinkingSupport) ([]string, map[string]
 		}
 	}
 
-	levelBudgets := make(map[string]int)
+	levelBudgets := make(map[string]any)
 	for _, level := range levels {
 		for _, entry := range standardThinkingLevelBudgets {
 			if level == entry.level {
@@ -1248,19 +1248,19 @@ func (r *ModelRegistry) convertModelToMap(model *ModelInfo, handlerType string) 
 			result["supported_parameters"] = append([]string(nil), model.SupportedParameters...)
 		}
 		if model.InputTokenLimit > 0 {
-			result["inputTokenLimit"] = model.InputTokenLimit
+			result["input_token_limit"] = model.InputTokenLimit
 		}
 		if model.OutputTokenLimit > 0 {
-			result["outputTokenLimit"] = model.OutputTokenLimit
+			result["output_token_limit"] = model.OutputTokenLimit
 		}
 		if len(model.SupportedGenerationMethods) > 0 {
-			result["supportedGenerationMethods"] = append([]string(nil), model.SupportedGenerationMethods...)
+			result["supported_generation_methods"] = append([]string(nil), model.SupportedGenerationMethods...)
 		}
 		if len(model.SupportedInputModalities) > 0 {
-			result["supportedInputModalities"] = append([]string(nil), model.SupportedInputModalities...)
+			result["supported_input_modalities"] = append([]string(nil), model.SupportedInputModalities...)
 		}
 		if len(model.SupportedOutputModalities) > 0 {
-			result["supportedOutputModalities"] = append([]string(nil), model.SupportedOutputModalities...)
+			result["supported_output_modalities"] = append([]string(nil), model.SupportedOutputModalities...)
 		}
 		if thinking := cloneThinkingSupportMap(model.Thinking); thinking != nil {
 			result["thinking"] = thinking

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -869,6 +869,112 @@ func cloneModelMapValue(value any) any {
 	}
 }
 
+var standardThinkingLevelBudgets = []struct {
+	level  string
+	budget int
+}{
+	{level: "minimal", budget: 512},
+	{level: "low", budget: 1024},
+	{level: "medium", budget: 8192},
+	{level: "high", budget: 24576},
+	{level: "xhigh", budget: 32768},
+	{level: "max", budget: 128000},
+}
+
+func cloneThinkingSupportMap(thinking *ThinkingSupport) map[string]any {
+	if thinking == nil {
+		return nil
+	}
+
+	result := make(map[string]any)
+	if thinking.Min > 0 {
+		result["min"] = thinking.Min
+	}
+	if thinking.Max > 0 {
+		result["max"] = thinking.Max
+	}
+	if thinking.ZeroAllowed {
+		result["zero_allowed"] = thinking.ZeroAllowed
+	}
+	if thinking.DynamicAllowed {
+		result["dynamic_allowed"] = thinking.DynamicAllowed
+	}
+	if len(thinking.Levels) > 0 {
+		result["levels"] = append([]string(nil), thinking.Levels...)
+	}
+
+	supportedLevels, levelBudgets := buildThinkingLevelDetails(thinking)
+	if len(supportedLevels) > 0 {
+		result["supported_levels"] = supportedLevels
+	}
+	if len(levelBudgets) > 0 {
+		result["level_budgets"] = levelBudgets
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func buildThinkingLevelDetails(thinking *ThinkingSupport) ([]string, map[string]int) {
+	if thinking == nil {
+		return nil, nil
+	}
+
+	levels := make([]string, 0, len(thinking.Levels)+2+len(standardThinkingLevelBudgets))
+	seen := make(map[string]struct{})
+	addLevel := func(level string) {
+		if level == "" {
+			return
+		}
+		if _, ok := seen[level]; ok {
+			return
+		}
+		seen[level] = struct{}{}
+		levels = append(levels, level)
+	}
+
+	if thinking.ZeroAllowed {
+		addLevel("none")
+	}
+	if thinking.DynamicAllowed {
+		addLevel("auto")
+	}
+	for _, level := range thinking.Levels {
+		addLevel(level)
+	}
+	if len(thinking.Levels) == 0 && (thinking.Min > 0 || thinking.Max > 0) {
+		for _, entry := range standardThinkingLevelBudgets {
+			if thinking.Min > 0 && entry.budget < thinking.Min {
+				continue
+			}
+			if thinking.Max > 0 && entry.budget > thinking.Max {
+				continue
+			}
+			addLevel(entry.level)
+		}
+	}
+
+	levelBudgets := make(map[string]int)
+	for _, level := range levels {
+		for _, entry := range standardThinkingLevelBudgets {
+			if level == entry.level {
+				if thinking.Min > 0 && entry.budget < thinking.Min {
+					break
+				}
+				if thinking.Max > 0 && entry.budget > thinking.Max {
+					break
+				}
+				levelBudgets[level] = entry.budget
+				break
+			}
+		}
+	}
+
+	return levels, levelBudgets
+}
+
 // GetAvailableModelsByProvider returns models available for the given provider identifier.
 // Parameters:
 //   - provider: Provider identifier (e.g., "codex", "gemini", "antigravity")
@@ -1140,6 +1246,24 @@ func (r *ModelRegistry) convertModelToMap(model *ModelInfo, handlerType string) 
 		}
 		if len(model.SupportedParameters) > 0 {
 			result["supported_parameters"] = append([]string(nil), model.SupportedParameters...)
+		}
+		if model.InputTokenLimit > 0 {
+			result["inputTokenLimit"] = model.InputTokenLimit
+		}
+		if model.OutputTokenLimit > 0 {
+			result["outputTokenLimit"] = model.OutputTokenLimit
+		}
+		if len(model.SupportedGenerationMethods) > 0 {
+			result["supportedGenerationMethods"] = append([]string(nil), model.SupportedGenerationMethods...)
+		}
+		if len(model.SupportedInputModalities) > 0 {
+			result["supportedInputModalities"] = append([]string(nil), model.SupportedInputModalities...)
+		}
+		if len(model.SupportedOutputModalities) > 0 {
+			result["supportedOutputModalities"] = append([]string(nil), model.SupportedOutputModalities...)
+		}
+		if thinking := cloneThinkingSupportMap(model.Thinking); thinking != nil {
+			result["thinking"] = thinking
 		}
 		return result
 

--- a/internal/registry/model_registry_safety_test.go
+++ b/internal/registry/model_registry_safety_test.go
@@ -135,6 +135,87 @@ func TestGetAvailableModelsReturnsClonedSupportedParameters(t *testing.T) {
 	}
 }
 
+func TestGetAvailableModelsOpenAIIncludesModelDetailsAndThinking(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("client-1", "openai", []*ModelInfo{{
+		ID:                         "m1",
+		OwnedBy:                    "team-a",
+		Type:                       "openai",
+		DisplayName:                "Model One",
+		Version:                    "v1",
+		Description:                "Detailed model",
+		ContextLength:              128000,
+		MaxCompletionTokens:        32768,
+		InputTokenLimit:            128000,
+		OutputTokenLimit:           32768,
+		SupportedParameters:        []string{"tools"},
+		SupportedGenerationMethods: []string{"generateContent"},
+		SupportedInputModalities:   []string{"TEXT", "IMAGE"},
+		SupportedOutputModalities:  []string{"TEXT"},
+		Thinking: &ThinkingSupport{
+			Min:            128,
+			Max:            32768,
+			ZeroAllowed:    true,
+			DynamicAllowed: true,
+			Levels:         []string{"low", "medium", "high"},
+		},
+	}})
+
+	models := r.GetAvailableModels("openai")
+	if len(models) != 1 {
+		t.Fatalf("expected one model, got %d", len(models))
+	}
+	model := models[0]
+
+	checks := map[string]any{
+		"context_length":        128000,
+		"max_completion_tokens": 32768,
+		"inputTokenLimit":       128000,
+		"outputTokenLimit":      32768,
+	}
+	for key, want := range checks {
+		if got := model[key]; got != want {
+			t.Fatalf("expected %s=%v, got %#v", key, want, got)
+		}
+	}
+
+	thinking, ok := model["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected thinking map, got %#v", model["thinking"])
+	}
+	if thinking["min"] != 128 || thinking["max"] != 32768 {
+		t.Fatalf("unexpected thinking range: %#v", thinking)
+	}
+	if thinking["zero_allowed"] != true || thinking["dynamic_allowed"] != true {
+		t.Fatalf("unexpected thinking flags: %#v", thinking)
+	}
+	levels, ok := thinking["levels"].([]string)
+	if !ok || len(levels) != 3 || levels[0] != "low" {
+		t.Fatalf("unexpected thinking levels: %#v", thinking["levels"])
+	}
+	supportedLevels, ok := thinking["supported_levels"].([]string)
+	if !ok || len(supportedLevels) != 5 || supportedLevels[0] != "none" || supportedLevels[1] != "auto" || supportedLevels[2] != "low" {
+		t.Fatalf("unexpected supported thinking levels: %#v", thinking["supported_levels"])
+	}
+	levelBudgets, ok := thinking["level_budgets"].(map[string]int)
+	if !ok || levelBudgets["low"] != 1024 || levelBudgets["high"] != 24576 {
+		t.Fatalf("unexpected thinking level budgets: %#v", thinking["level_budgets"])
+	}
+
+	levels[0] = "mutated"
+	supportedLevels[0] = "mutated"
+	second := r.GetAvailableModels("openai")
+	secondThinking := second[0]["thinking"].(map[string]any)
+	secondLevels := secondThinking["levels"].([]string)
+	if secondLevels[0] != "low" {
+		t.Fatalf("expected cloned thinking levels, got %#v", secondLevels)
+	}
+	secondSupportedLevels := secondThinking["supported_levels"].([]string)
+	if secondSupportedLevels[0] != "none" {
+		t.Fatalf("expected cloned supported thinking levels, got %#v", secondSupportedLevels)
+	}
+}
+
 func TestLookupModelInfoReturnsCloneForStaticDefinitions(t *testing.T) {
 	first := LookupModelInfo("claude-sonnet-4-6")
 	if first == nil || first.Thinking == nil || len(first.Thinking.Levels) == 0 {

--- a/internal/registry/model_registry_safety_test.go
+++ b/internal/registry/model_registry_safety_test.go
@@ -170,8 +170,8 @@ func TestGetAvailableModelsOpenAIIncludesModelDetailsAndThinking(t *testing.T) {
 	checks := map[string]any{
 		"context_length":        128000,
 		"max_completion_tokens": 32768,
-		"inputTokenLimit":       128000,
-		"outputTokenLimit":      32768,
+		"input_token_limit":     128000,
+		"output_token_limit":    32768,
 	}
 	for key, want := range checks {
 		if got := model[key]; got != want {
@@ -197,7 +197,7 @@ func TestGetAvailableModelsOpenAIIncludesModelDetailsAndThinking(t *testing.T) {
 	if !ok || len(supportedLevels) != 5 || supportedLevels[0] != "none" || supportedLevels[1] != "auto" || supportedLevels[2] != "low" {
 		t.Fatalf("unexpected supported thinking levels: %#v", thinking["supported_levels"])
 	}
-	levelBudgets, ok := thinking["level_budgets"].(map[string]int)
+	levelBudgets, ok := thinking["level_budgets"].(map[string]any)
 	if !ok || levelBudgets["low"] != 1024 || levelBudgets["high"] != 24576 {
 		t.Fatalf("unexpected thinking level budgets: %#v", thinking["level_budgets"])
 	}

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -59,33 +59,9 @@ func (h *OpenAIAPIHandler) Models() []map[string]any {
 // It returns a list of available AI models with their capabilities
 // and specifications in OpenAI-compatible format.
 func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
-	// Get all available models
-	allModels := h.Models()
-
-	// Filter to only include the 4 required fields: id, object, created, owned_by
-	filteredModels := make([]map[string]any, len(allModels))
-	for i, model := range allModels {
-		filteredModel := map[string]any{
-			"id":     model["id"],
-			"object": model["object"],
-		}
-
-		// Add created field if it exists
-		if created, exists := model["created"]; exists {
-			filteredModel["created"] = created
-		}
-
-		// Add owned_by field if it exists
-		if ownedBy, exists := model["owned_by"]; exists {
-			filteredModel["owned_by"] = ownedBy
-		}
-
-		filteredModels[i] = filteredModel
-	}
-
 	c.JSON(http.StatusOK, gin.H{
 		"object": "list",
-		"data":   filteredModels,
+		"data":   h.Models(),
 	})
 }
 

--- a/sdk/api/handlers/openai/openai_models_test.go
+++ b/sdk/api/handlers/openai/openai_models_test.go
@@ -1,0 +1,109 @@
+package openai
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestOpenAIModelsIncludesModelDetails(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	modelRegistry := registry.GetGlobalRegistry()
+	clientID := "openai-model-details-test-client"
+	modelRegistry.RegisterClient(clientID, "openai", []*registry.ModelInfo{{
+		ID:                  "test-model-details",
+		Object:              "model",
+		Created:             123,
+		OwnedBy:             "test-owner",
+		Type:                "openai",
+		DisplayName:         "Test Model Details",
+		ContextLength:       128000,
+		MaxCompletionTokens: 32768,
+		InputTokenLimit:     128000,
+		OutputTokenLimit:    32768,
+		SupportedParameters: []string{"tools"},
+		Thinking: &registry.ThinkingSupport{
+			Min:            128,
+			Max:            32768,
+			ZeroAllowed:    true,
+			DynamicAllowed: true,
+			Levels:         []string{"minimal", "low", "high", "xhigh"},
+		},
+	}})
+	defer modelRegistry.UnregisterClient(clientID)
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler := NewOpenAIAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/models", handler.OpenAIModels)
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	var response struct {
+		Object string           `json:"object"`
+		Data   []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var model map[string]any
+	for _, candidate := range response.Data {
+		if candidate["id"] == "test-model-details" {
+			model = candidate
+			break
+		}
+	}
+	if model == nil {
+		t.Fatalf("model test-model-details not found in response: %#v", response.Data)
+	}
+
+	if got := model["context_length"]; got != float64(128000) {
+		t.Fatalf("context_length = %#v, want 128000", got)
+	}
+	if got := model["max_completion_tokens"]; got != float64(32768) {
+		t.Fatalf("max_completion_tokens = %#v, want 32768", got)
+	}
+	if got := model["inputTokenLimit"]; got != float64(128000) {
+		t.Fatalf("inputTokenLimit = %#v, want 128000", got)
+	}
+	if got := model["outputTokenLimit"]; got != float64(32768) {
+		t.Fatalf("outputTokenLimit = %#v, want 32768", got)
+	}
+
+	thinking, ok := model["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("thinking = %#v, want object", model["thinking"])
+	}
+	if got := thinking["max"]; got != float64(32768) {
+		t.Fatalf("thinking.max = %#v, want 32768", got)
+	}
+	levels, ok := thinking["levels"].([]any)
+	if !ok || len(levels) != 4 || levels[0] != "minimal" {
+		t.Fatalf("thinking.levels = %#v, want [minimal low high xhigh]", thinking["levels"])
+	}
+	supportedLevels, ok := thinking["supported_levels"].([]any)
+	if !ok || len(supportedLevels) != 6 || supportedLevels[0] != "none" || supportedLevels[1] != "auto" || supportedLevels[2] != "minimal" {
+		t.Fatalf("thinking.supported_levels = %#v, want [none auto minimal low high xhigh]", thinking["supported_levels"])
+	}
+	levelBudgets, ok := thinking["level_budgets"].(map[string]any)
+	if !ok {
+		t.Fatalf("thinking.level_budgets = %#v, want object", thinking["level_budgets"])
+	}
+	if got := levelBudgets["xhigh"]; got != float64(32768) {
+		t.Fatalf("thinking.level_budgets.xhigh = %#v, want 32768", got)
+	}
+}

--- a/sdk/api/handlers/openai/openai_models_test.go
+++ b/sdk/api/handlers/openai/openai_models_test.go
@@ -77,11 +77,11 @@ func TestOpenAIModelsIncludesModelDetails(t *testing.T) {
 	if got := model["max_completion_tokens"]; got != float64(32768) {
 		t.Fatalf("max_completion_tokens = %#v, want 32768", got)
 	}
-	if got := model["inputTokenLimit"]; got != float64(128000) {
-		t.Fatalf("inputTokenLimit = %#v, want 128000", got)
+	if got := model["input_token_limit"]; got != float64(128000) {
+		t.Fatalf("input_token_limit = %#v, want 128000", got)
 	}
-	if got := model["outputTokenLimit"]; got != float64(32768) {
-		t.Fatalf("outputTokenLimit = %#v, want 32768", got)
+	if got := model["output_token_limit"]; got != float64(32768) {
+		t.Fatalf("output_token_limit = %#v, want 32768", got)
 	}
 
 	thinking, ok := model["thinking"].(map[string]any)


### PR DESCRIPTION
## Summary
- Return full registered model metadata from OpenAI-compatible `/v1/models` instead of filtering to `id/object/created/owned_by` only.
- Include token limits, supported modalities/generation methods, supported parameters, and thinking metadata.
- Add derived `thinking.supported_levels` and `thinking.level_budgets` so clients can choose reasoning effort from the model list.
- Add regression tests for registry metadata and `/v1/models` response.

## Tests
- `go test ./internal/registry -run 'TestGetAvailableModelsOpenAIIncludesModelDetailsAndThinking|TestGetAvailableModelsReturnsClonedSupportedParameters'`\n- `go test ./sdk/api/handlers/openai -run TestOpenAIModelsIncludesModelDetails`\n\n## Note\n- Full `go test ./internal/registry ./sdk/api/handlers/openai` currently hits an unrelated upstream failure: `TestCodexFreeModelsExcludeGPT55` expects free tier to exclude `gpt-5.5`.