### PR TITLE
Use lazy oauth for antigravity

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,6 +82,11 @@ redis-usage-queue-retention-seconds: 60
 # Per-entry proxy-url also supports "direct" or "none" to bypass both the global proxy-url and environment proxies explicitly.
 proxy-url: ""
 
+# When true, disables TLS certificate verification for outbound connections (e.g. Antigravity OAuth).
+# Useful behind corporate proxies that intercept TLS traffic with their own certificates.
+# WARNING: This removes certificate validation — use only in trusted environments.
+# tls-skip-verify: false
+
 # When true, unprefixed model requests only use credentials without a prefix (except when prefix == model name).
 force-model-prefix: false
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -122,6 +122,10 @@ quota-exceeded:
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
   antigravity-credits: true # Whether to use credits as last-resort fallback when all free-tier auths are exhausted for Claude models
 
+# Skips fetching project ID via loadCodeAssist and uses the default base URL directly.
+# Set to true when you don't have a project ID.
+# antigravity-use-default-project-id: false
+
 # Routing strategy for selecting credentials when multiple match.
 routing:
   strategy: "round-robin" # round-robin (default), fill-first

--- a/internal/api/handlers/management/api_key_usage.go
+++ b/internal/api/handlers/management/api_key_usage.go
@@ -48,9 +48,9 @@ func (h *Handler) GetAPIKeyUsage(c *gin.Context) {
 		return
 	}
 
-	h.mu.Lock()
+	h.mu.RLock()
 	manager := h.authManager
-	h.mu.Unlock()
+	h.mu.RUnlock()
 	if manager == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
 		return

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -28,7 +28,8 @@ func (h *Handler) GetConfig(c *gin.Context) {
 		c.JSON(200, gin.H{})
 		return
 	}
-	c.JSON(200, new(*h.cfg))
+	cfg := *h.cfg
+	c.JSON(200, &cfg)
 }
 
 type releaseInfo struct {

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -28,7 +28,9 @@ func (h *Handler) GetConfig(c *gin.Context) {
 		c.JSON(200, gin.H{})
 		return
 	}
+	h.mu.Lock()
 	cfg := *h.cfg
+	h.mu.Unlock()
 	c.JSON(200, &cfg)
 }
 

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -28,9 +28,9 @@ func (h *Handler) GetConfig(c *gin.Context) {
 		c.JSON(200, gin.H{})
 		return
 	}
-	h.mu.Lock()
+	h.mu.RLock()
 	cfg := *h.cfg
-	h.mu.Unlock()
+	h.mu.RUnlock()
 	c.JSON(200, &cfg)
 }
 

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -36,7 +36,7 @@ const attemptMaxIdleTime = 2 * time.Hour
 type Handler struct {
 	cfg                 *config.Config
 	configFilePath      string
-	mu                  sync.Mutex
+	mu                  sync.RWMutex
 	attemptsMu          sync.Mutex
 	failedAttempts      map[string]*attemptInfo // keyed by client IP
 	authManager         *coreauth.Manager

--- a/internal/api/modules/amp/amp.go
+++ b/internal/api/modules/amp/amp.go
@@ -127,7 +127,8 @@ func (m *AmpModule) Register(ctx modules.Context) error {
 		m.modelMapper = NewModelMapper(settings.ModelMappings)
 
 		// Store initial config for partial reload comparison
-		m.lastConfig = new(settings)
+		settingsCopy := settings
+		m.lastConfig = &settingsCopy
 
 		// Initialize localhost restriction setting (hot-reloadable)
 		m.setRestrictToLocalhost(settings.RestrictManagementToLocalhost)

--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -54,10 +54,12 @@ func NewAntigravityAuth(cfg *config.Config, httpClient *http.Client) *Antigravit
 			}
 			clone.TLSClientConfig.InsecureSkipVerify = true
 			client.Transport = clone
-		} else if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
-			clone := defaultTransport.Clone()
-			clone.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-			client.Transport = clone
+		} else if client.Transport == nil {
+			if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+				clone := defaultTransport.Clone()
+				clone.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+				client.Transport = clone
+			}
 		}
 	}
 	return &AntigravityAuth{

--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -54,11 +54,11 @@ func NewAntigravityAuth(cfg *config.Config, httpClient *http.Client) *Antigravit
 			}
 			clone.TLSClientConfig.InsecureSkipVerify = true
 			client.Transport = clone
-		} else {
-			client.Transport = &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}
-		}
+        } else if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+            clone := defaultTransport.Clone()
+            clone.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+            client.Transport = clone
+        }
 	}
 	return &AntigravityAuth{
 		httpClient: client,

--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -3,6 +3,7 @@ package antigravity
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -43,8 +44,24 @@ func NewAntigravityAuth(cfg *config.Config, httpClient *http.Client) *Antigravit
 	if httpClient != nil {
 		return &AntigravityAuth{httpClient: httpClient}
 	}
+	// Apply proxy first, then TLS skip verify on top (order matters: SetProxy replaces the transport).
+	client := util.SetProxy(&cfg.SDKConfig, &http.Client{})
+	if cfg.TLSSkipVerify {
+		if transport, ok := client.Transport.(*http.Transport); ok {
+			clone := transport.Clone()
+			if clone.TLSClientConfig == nil {
+				clone.TLSClientConfig = &tls.Config{}
+			}
+			clone.TLSClientConfig.InsecureSkipVerify = true
+			client.Transport = clone
+		} else {
+			client.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+		}
+	}
 	return &AntigravityAuth{
-		httpClient: util.SetProxy(&cfg.SDKConfig, &http.Client{}),
+		httpClient: client,
 	}
 }
 

--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -54,11 +54,11 @@ func NewAntigravityAuth(cfg *config.Config, httpClient *http.Client) *Antigravit
 			}
 			clone.TLSClientConfig.InsecureSkipVerify = true
 			client.Transport = clone
-        } else if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
-            clone := defaultTransport.Clone()
-            clone.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-            client.Transport = clone
-        }
+		} else if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+			clone := defaultTransport.Clone()
+			clone.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+			client.Transport = clone
+		}
 	}
 	return &AntigravityAuth{
 		httpClient: client,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,6 +105,10 @@ type Config struct {
 
 	AntigravitySignatureBypassStrict *bool `yaml:"antigravity-signature-bypass-strict,omitempty" json:"antigravity-signature-bypass-strict,omitempty"`
 
+	// AntigravityUseDefaultProjectID skips fetching project ID via loadCodeAssist
+	// and uses the default base URL directly. Set true when you have no project ID.
+	AntigravityUseDefaultProjectID bool `yaml:"antigravity-use-default-project-id" json:"antigravity-use-default-project-id"`
+
 	// GeminiKey defines Gemini API key configurations with optional routing overrides.
 	GeminiKey []GeminiKey `yaml:"gemini-api-key" json:"gemini-api-key"`
 

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -9,6 +9,12 @@ type SDKConfig struct {
 	// ProxyURL is the URL of an optional proxy server to use for outbound requests.
 	ProxyURL string `yaml:"proxy-url" json:"proxy-url"`
 
+	// TLSSkipVerify disables TLS certificate verification for outbound connections.
+	// This can be useful when operating behind a corporate proxy that intercepts TLS traffic,
+	// but should only be used in trusted environments as it removes certificate validation.
+	// When true, sets InsecureSkipVerify on the TLS client config for Antigravity and other outbound HTTP clients.
+	TLSSkipVerify bool `yaml:"tls-skip-verify" json:"tls-skip-verify"`
+
 	// DisableImageGeneration controls whether the built-in image_generation tool is injected/allowed.
 	//
 	// Supported values:

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -227,6 +227,12 @@ func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cli
 	antigravityTransportOnce.Do(initAntigravityTransport)
 
 	client := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, timeout)
+
+	// Apply TLS skip verify if configured, preserving any existing proxy transport.
+	if cfg != nil && cfg.TLSSkipVerify {
+		skipTLSVerifyTransport(client)
+	}
+
 	// If no transport is set, use the shared HTTP/1.1 transport.
 	if client.Transport == nil {
 		client.Transport = antigravityTransport
@@ -238,6 +244,26 @@ func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cli
 		client.Transport = cloneTransportWithHTTP11(transport)
 	}
 	return client
+}
+
+// skipTLSVerifyTransport sets InsecureSkipVerify on the client's transport.
+// If a transport is already set (e.g. from proxy config), it clones it with TLS skip verify.
+// Otherwise, it creates a new transport with TLS skip verify.
+func skipTLSVerifyTransport(client *http.Client) {
+	if client.Transport == nil {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		return
+	}
+	if transport, ok := client.Transport.(*http.Transport); ok {
+		clone := transport.Clone()
+		if clone.TLSClientConfig == nil {
+			clone.TLSClientConfig = &tls.Config{}
+		}
+		clone.TLSClientConfig.InsecureSkipVerify = true
+		client.Transport = clone
+	}
 }
 
 func validateAntigravityRequestSignatures(from sdktranslator.Format, rawJSON []byte) ([]byte, error) {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -192,7 +192,7 @@ var (
 	antigravityTransportOnce sync.Once
 )
 
-func cloneTransportWithHTTP11(base *http.Transport) *http.Transport {
+func cloneTransportWithHTTP11(base *http.Transport, skipVerify bool) *http.Transport {
 	if base == nil {
 		return nil
 	}
@@ -208,6 +208,9 @@ func cloneTransportWithHTTP11(base *http.Transport) *http.Transport {
 	}
 	// Actively advertise only HTTP/1.1 in the ALPN handshake.
 	clone.TLSClientConfig.NextProtos = []string{"http/1.1"}
+	if skipVerify {
+		clone.TLSClientConfig.InsecureSkipVerify = true
+	}
 	return clone
 }
 
@@ -217,7 +220,7 @@ func initAntigravityTransport() {
 	if !ok {
 		base = &http.Transport{}
 	}
-	antigravityTransport = cloneTransportWithHTTP11(base)
+	antigravityTransport = cloneTransportWithHTTP11(base, false)
 }
 
 // newAntigravityHTTPClient creates an HTTP client specifically for Antigravity,
@@ -228,42 +231,27 @@ func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cli
 
 	client := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, timeout)
 
-	// Apply TLS skip verify if configured, preserving any existing proxy transport.
-	if cfg != nil && cfg.TLSSkipVerify {
-		skipTLSVerifyTransport(client)
-	}
-
-	// If no transport is set, use the shared HTTP/1.1 transport.
+	// 1. If no transport is set, use the shared HTTP/1.1 transport as the base.
 	if client.Transport == nil {
 		client.Transport = antigravityTransport
+	}
+
+	// 2. Only proceed with specialized cloning if the transport is an *http.Transport.
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
 		return client
 	}
 
-	// Preserve proxy settings from proxy-aware transports while forcing HTTP/1.1.
-	if transport, ok := client.Transport.(*http.Transport); ok {
-		client.Transport = cloneTransportWithHTTP11(transport)
+	// 3. Apply HTTP/1.1 enforcement and InsecureSkipVerify in a single pass.
+	// We MUST clone if:
+	// - We need to skip TLS verification (to avoid mutating the singleton or shared proxy transport)
+	// - OR the current transport is NOT the shared singleton (to ensure HTTP/1.1 on proxy transports)
+	skipVerify := cfg != nil && cfg.TLSSkipVerify
+	if skipVerify || transport != antigravityTransport {
+		client.Transport = cloneTransportWithHTTP11(transport, skipVerify)
 	}
-	return client
-}
 
-// skipTLSVerifyTransport sets InsecureSkipVerify on the client's transport.
-// If a transport is already set (e.g. from proxy config), it clones it with TLS skip verify.
-// Otherwise, it creates a new transport with TLS skip verify.
-func skipTLSVerifyTransport(client *http.Client) {
-	if client.Transport == nil {
-		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		return
-	}
-	if transport, ok := client.Transport.(*http.Transport); ok {
-		clone := transport.Clone()
-		if clone.TLSClientConfig == nil {
-			clone.TLSClientConfig = &tls.Config{}
-		}
-		clone.TLSClientConfig.InsecureSkipVerify = true
-		client.Transport = clone
-	}
+	return client
 }
 
 func validateAntigravityRequestSignatures(from sdktranslator.Format, rawJSON []byte) ([]byte, error) {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1643,7 +1643,7 @@ func (e *AntigravityExecutor) ensureAccessToken(ctx context.Context, auth *clipr
 		return token, refreshed, nil
 	}
 
-	updated, errRefresh := e.refreshToken(refreshCtx, auth.Clone())
+	updated, errRefresh := e.refreshToken(refreshCtx, auth)
 	if errRefresh != nil {
 		return "", nil, errRefresh
 	}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1621,7 +1621,10 @@ func (e *AntigravityExecutor) ensureAccessToken(ctx context.Context, auth *clipr
 	}
 	accessToken := metaStringValue(auth.Metadata, "access_token")
 	expiry := tokenExpiry(auth.Metadata)
-	if accessToken != "" && expiry.After(time.Now().Add(refreshSkew)) {
+	willRefresh := accessToken == "" || !expiry.After(time.Now().Add(refreshSkew))
+	log.Debugf("antigravity ensureAccessToken: auth=%q accessToken=%q expiry=%v now=%v skew=%v willRefresh=%v",
+		auth.ID, accessToken, expiry, time.Now(), refreshSkew, willRefresh)
+	if !willRefresh {
 		e.maybeRefreshAntigravityCreditsHint(ctx, auth, accessToken)
 		return accessToken, nil, nil
 	}
@@ -1779,8 +1782,10 @@ func (e *AntigravityExecutor) refreshToken(ctx context.Context, auth *cliproxyau
 	auth.Metadata["timestamp"] = now.UnixMilli()
 	auth.Metadata["expired"] = now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339)
 	auth.Metadata["type"] = antigravityAuthType
-	if errProject := e.ensureAntigravityProjectID(ctx, auth, tokenResp.AccessToken); errProject != nil {
-		log.Warnf("antigravity executor: ensure project id failed: %v", errProject)
+	if e.cfg != nil && !e.cfg.AntigravityUseDefaultProjectID {
+		if errProject := e.ensureAntigravityProjectID(ctx, auth, tokenResp.AccessToken); errProject != nil {
+			log.Warnf("antigravity executor: ensure project id failed: %v", errProject)
+		}
 	}
 	if antigravityCreditsRetryEnabled(e.cfg) {
 		e.updateAntigravityCreditsBalance(ctx, auth, tokenResp.AccessToken)

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -563,7 +563,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel, requestPath)
 
-	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
+	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && (e.cfg == nil || antigravityCreditsRetryEnabled(e.cfg))
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -761,7 +761,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel, requestPath)
 
-	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
+	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && (e.cfg == nil || antigravityCreditsRetryEnabled(e.cfg))
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -1222,7 +1222,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel, requestPath)
 
-	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
+	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && (e.cfg == nil || antigravityCreditsRetryEnabled(e.cfg))
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -1651,7 +1651,7 @@ func (e *AntigravityExecutor) ensureAccessToken(ctx context.Context, auth *clipr
 }
 
 func (e *AntigravityExecutor) maybeRefreshAntigravityCreditsHint(ctx context.Context, auth *cliproxyauth.Auth, accessToken string) {
-	if e == nil || auth == nil || !antigravityCreditsRetryEnabled(e.cfg) {
+	if e == nil || auth == nil || (e.cfg != nil && !antigravityCreditsRetryEnabled(e.cfg)) {
 		return
 	}
 	if ctx != nil && ctx.Err() != nil {

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -185,11 +185,13 @@ func NewAntigravityExecutor(cfg *config.Config) *AntigravityExecutor {
 }
 
 // antigravityTransport is a singleton HTTP/1.1 transport shared by all Antigravity requests.
-// It is initialized once via antigravityTransportOnce to avoid leaking a new connection pool
-// (and the goroutines managing it) on every request.
+// antigravitySkipVerifyTransport is a second singleton for requests that skip TLS verification.
+// They are initialized lazily to avoid leaking connection pools on every request.
 var (
-	antigravityTransport     *http.Transport
-	antigravityTransportOnce sync.Once
+	antigravityTransport           *http.Transport
+	antigravityTransportOnce       sync.Once
+	antigravitySkipVerifyTransport *http.Transport
+	antigravitySkipVerifyOnce      sync.Once
 )
 
 func cloneTransportWithHTTP11(base *http.Transport, skipVerify bool) *http.Transport {
@@ -223,17 +225,33 @@ func initAntigravityTransport() {
 	antigravityTransport = cloneTransportWithHTTP11(base, false)
 }
 
+// initAntigravitySkipVerifyTransport creates the shared skip-verify HTTP/1.1 transport exactly once.
+func initAntigravitySkipVerifyTransport() {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		base = &http.Transport{}
+	}
+	antigravitySkipVerifyTransport = cloneTransportWithHTTP11(base, true)
+}
+
 // newAntigravityHTTPClient creates an HTTP client specifically for Antigravity,
 // enforcing HTTP/1.1 by disabling HTTP/2 to perfectly mimic Node.js https defaults.
 // The underlying Transport is a singleton to avoid leaking connection pools.
 func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) *http.Client {
-	antigravityTransportOnce.Do(initAntigravityTransport)
+	skipVerify := cfg != nil && cfg.TLSSkipVerify
 
 	client := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, timeout)
 
-	// 1. If no transport is set, use the shared HTTP/1.1 transport as the base.
+	// 1. If no transport is set, use the appropriate shared HTTP/1.1 singleton.
 	if client.Transport == nil {
-		client.Transport = antigravityTransport
+		if skipVerify {
+			antigravitySkipVerifyOnce.Do(initAntigravitySkipVerifyTransport)
+			client.Transport = antigravitySkipVerifyTransport
+		} else {
+			antigravityTransportOnce.Do(initAntigravityTransport)
+			client.Transport = antigravityTransport
+		}
+		return client
 	}
 
 	// 2. Only proceed with specialized cloning if the transport is an *http.Transport.
@@ -244,11 +262,18 @@ func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cli
 
 	// 3. Apply HTTP/1.1 enforcement and InsecureSkipVerify in a single pass.
 	// We MUST clone if:
-	// - We need to skip TLS verification (to avoid mutating the singleton or shared proxy transport)
-	// - OR the current transport is NOT the shared singleton (to ensure HTTP/1.1 on proxy transports)
-	skipVerify := cfg != nil && cfg.TLSSkipVerify
-	if skipVerify || transport != antigravityTransport {
+	// - The current transport is NOT one of our shared singletons (e.g. it's a proxy-aware transport)
+	// - OR it's a singleton but we need to change its InsecureSkipVerify state (not possible if we use the right one above, but for safety)
+	if transport != antigravityTransport && transport != antigravitySkipVerifyTransport {
 		client.Transport = cloneTransportWithHTTP11(transport, skipVerify)
+	} else if skipVerify && transport == antigravityTransport {
+		// Fallback for safety: if we somehow have the standard singleton but need skipVerify
+		antigravitySkipVerifyOnce.Do(initAntigravitySkipVerifyTransport)
+		client.Transport = antigravitySkipVerifyTransport
+	} else if !skipVerify && transport == antigravitySkipVerifyTransport {
+		// Fallback for safety: if we somehow have the skip-verify singleton but don't need it
+		antigravityTransportOnce.Do(initAntigravityTransport)
+		client.Transport = antigravityTransport
 	}
 
 	return client

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1784,7 +1784,7 @@ func (e *AntigravityExecutor) refreshToken(ctx context.Context, auth *cliproxyau
 			log.Warnf("antigravity executor: ensure project id failed: %v", errProject)
 		}
 	}
-	if antigravityCreditsRetryEnabled(e.cfg) {
+	if e.cfg != nil && antigravityCreditsRetryEnabled(e.cfg) {
 		e.updateAntigravityCreditsBalance(ctx, auth, tokenResp.AccessToken)
 	}
 	return auth, nil

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1782,7 +1782,9 @@ func (e *AntigravityExecutor) refreshToken(ctx context.Context, auth *cliproxyau
 	if errProject := e.ensureAntigravityProjectID(ctx, auth, tokenResp.AccessToken); errProject != nil {
 		log.Warnf("antigravity executor: ensure project id failed: %v", errProject)
 	}
-	e.updateAntigravityCreditsBalance(ctx, auth, tokenResp.AccessToken)
+	if antigravityCreditsRetryEnabled(e.cfg) {
+		e.updateAntigravityCreditsBalance(ctx, auth, tokenResp.AccessToken)
+	}
 	return auth, nil
 }
 

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1621,10 +1621,7 @@ func (e *AntigravityExecutor) ensureAccessToken(ctx context.Context, auth *clipr
 	}
 	accessToken := metaStringValue(auth.Metadata, "access_token")
 	expiry := tokenExpiry(auth.Metadata)
-	willRefresh := accessToken == "" || !expiry.After(time.Now().Add(refreshSkew))
-	log.Debugf("antigravity ensureAccessToken: auth=%q accessToken=%q expiry=%v now=%v skew=%v willRefresh=%v",
-		auth.ID, accessToken, expiry, time.Now(), refreshSkew, willRefresh)
-	if !willRefresh {
+	if accessToken != "" && expiry.After(time.Now().Add(refreshSkew)) {
 		e.maybeRefreshAntigravityCreditsHint(ctx, auth, accessToken)
 		return accessToken, nil, nil
 	}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1643,7 +1643,7 @@ func (e *AntigravityExecutor) ensureAccessToken(ctx context.Context, auth *clipr
 		return token, refreshed, nil
 	}
 
-	updated, errRefresh := e.refreshToken(refreshCtx, auth)
+	updated, errRefresh := e.refreshToken(refreshCtx, auth.Clone())
 	if errRefresh != nil {
 		return "", nil, errRefresh
 	}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1779,7 +1779,7 @@ func (e *AntigravityExecutor) refreshToken(ctx context.Context, auth *cliproxyau
 	auth.Metadata["timestamp"] = now.UnixMilli()
 	auth.Metadata["expired"] = now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339)
 	auth.Metadata["type"] = antigravityAuthType
-	if e.cfg != nil && !e.cfg.AntigravityUseDefaultProjectID {
+	if e.cfg == nil || !e.cfg.AntigravityUseDefaultProjectID {
 		if errProject := e.ensureAntigravityProjectID(ctx, auth, tokenResp.AccessToken); errProject != nil {
 			log.Warnf("antigravity executor: ensure project id failed: %v", errProject)
 		}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -563,7 +563,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel, requestPath)
 
-	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && (e.cfg == nil || antigravityCreditsRetryEnabled(e.cfg))
+	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -761,7 +761,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel, requestPath)
 
-	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && (e.cfg == nil || antigravityCreditsRetryEnabled(e.cfg))
+	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -1222,7 +1222,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel, requestPath)
 
-	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && (e.cfg == nil || antigravityCreditsRetryEnabled(e.cfg))
+	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -1651,7 +1651,7 @@ func (e *AntigravityExecutor) ensureAccessToken(ctx context.Context, auth *clipr
 }
 
 func (e *AntigravityExecutor) maybeRefreshAntigravityCreditsHint(ctx context.Context, auth *cliproxyauth.Auth, accessToken string) {
-	if e == nil || auth == nil || (e.cfg != nil && !antigravityCreditsRetryEnabled(e.cfg)) {
+	if e == nil || auth == nil || !antigravityCreditsRetryEnabled(e.cfg) {
 		return
 	}
 	if ctx != nil && ctx.Err() != nil {

--- a/sdk/api/handlers/gemini/gemini-cli_handlers.go
+++ b/sdk/api/handlers/gemini/gemini-cli_handlers.go
@@ -204,7 +204,8 @@ func (h *GeminiCLIAPIHandler) handleInternalGenerateContent(c *gin.Context, rawJ
 func (h *GeminiCLIAPIHandler) forwardCLIStream(c *gin.Context, flusher http.Flusher, alt string, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
 	var keepAliveInterval *time.Duration
 	if alt != "" {
-		keepAliveInterval = new(time.Duration(0))
+		d := time.Duration(0)
+		keepAliveInterval = &d
 	}
 
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{

--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -304,7 +304,8 @@ func (h *GeminiAPIHandler) handleGenerateContent(c *gin.Context, modelName strin
 func (h *GeminiAPIHandler) forwardGeminiStream(c *gin.Context, flusher http.Flusher, alt string, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage) {
 	var keepAliveInterval *time.Duration
 	if alt != "" {
-		keepAliveInterval = new(time.Duration(0))
+		d := time.Duration(0)
+		keepAliveInterval = &d
 	}
 
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{

--- a/sdk/auth/antigravity.go
+++ b/sdk/auth/antigravity.go
@@ -28,7 +28,8 @@ func (AntigravityAuthenticator) Provider() string { return "antigravity" }
 
 // RefreshLead instructs the manager to refresh five minutes before expiry.
 func (AntigravityAuthenticator) RefreshLead() *time.Duration {
-	return new(5 * time.Minute)
+	d := 5 * time.Minute
+	return &d
 }
 
 // Login launches a local OAuth flow to obtain antigravity tokens and persists them.

--- a/sdk/auth/claude.go
+++ b/sdk/auth/claude.go
@@ -32,7 +32,8 @@ func (a *ClaudeAuthenticator) Provider() string {
 }
 
 func (a *ClaudeAuthenticator) RefreshLead() *time.Duration {
-	return new(4 * time.Hour)
+	d := 4 * time.Hour
+	return &d
 }
 
 func (a *ClaudeAuthenticator) Login(ctx context.Context, cfg *config.Config, opts *LoginOptions) (*coreauth.Auth, error) {

--- a/sdk/auth/codex.go
+++ b/sdk/auth/codex.go
@@ -32,7 +32,8 @@ func (a *CodexAuthenticator) Provider() string {
 }
 
 func (a *CodexAuthenticator) RefreshLead() *time.Duration {
-	return new(5 * 24 * time.Hour)
+	d := 5 * 24 * time.Hour
+	return &d
 }
 
 func (a *CodexAuthenticator) Login(ctx context.Context, cfg *config.Config, opts *LoginOptions) (*coreauth.Auth, error) {

--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -241,13 +241,6 @@ func (l *authAutoRefreshLoop) handleDueAuth(ctx context.Context, now time.Time, 
 		return
 	}
 
-	// Antigravity uses lazy on-demand OAuth in ensureAccessToken during
-	// Execute, so its tokens are never refreshed by the background loop.
-	if strings.EqualFold(auth.Provider, "antigravity") {
-		l.upsert(authID, next)
-		return
-	}
-
 	if !shouldRefresh {
 		l.upsert(authID, next)
 		return
@@ -349,6 +342,14 @@ func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time
 
 	accountType, _ := auth.AccountInfo()
 	if accountType == "api_key" {
+		return time.Time{}, false
+	}
+
+	// Antigravity uses lazy on-demand OAuth in ensureAccessToken during
+	// Execute, so its tokens are never refreshed by the background loop.
+	// Keeping it out of the scheduler avoids a tight reschedule loop when
+	// no valid expiry exists yet.
+	if strings.EqualFold(auth.Provider, "antigravity") {
 		return time.Time{}, false
 	}
 

--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -241,6 +241,13 @@ func (l *authAutoRefreshLoop) handleDueAuth(ctx context.Context, now time.Time, 
 		return
 	}
 
+	// Antigravity uses lazy on-demand OAuth in ensureAccessToken during
+	// Execute, so its tokens are never refreshed by the background loop.
+	if strings.EqualFold(auth.Provider, "antigravity") {
+		l.upsert(authID, next)
+		return
+	}
+
 	if !shouldRefresh {
 		l.upsert(authID, next)
 		return

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -25,6 +25,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/singleflight"
 )
 
 // ProviderExecutor defines the contract required by Manager to execute provider calls.
@@ -178,6 +179,10 @@ type Manager struct {
 
 	// Optional HTTP RoundTripper provider injected by host.
 	rtProvider RoundTripperProvider
+
+	// On-demand (lazy) refresh uses singleflight to coalesce concurrent refresh
+	// requests for the same auth entry.
+	lazyRefreshGroup singleflight.Group
 
 	// Auto refresh state
 	refreshCancel context.CancelFunc
@@ -866,7 +871,6 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		execReq := req
 		execReq.Model = execModel
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, opts)
-		m.syncAuthMetadata(auth.ID, auth.Metadata)
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
 				return nil, errCtx
@@ -1372,7 +1376,6 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			execReq := req
 			execReq.Model = upstreamModel
 			resp, errExec := executor.Execute(execCtx, auth, execReq, opts)
-			m.syncAuthMetadata(auth.ID, auth.Metadata)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -1461,7 +1464,6 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			execReq := req
 			execReq.Model = upstreamModel
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, opts)
-			m.syncAuthMetadata(auth.ID, auth.Metadata)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -2887,6 +2889,15 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		m.mu.RUnlock()
 		return nil, nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
 	}
+	authID := selected.ID
+	m.mu.RUnlock()
+
+	selected = m.refreshAuthIfNeeded(ctx, selected)
+
+	m.mu.RLock()
+	if fresh, ok := m.auths[authID]; ok && fresh != nil {
+		selected = fresh
+	}
 	authCopy := selected.Clone()
 	m.mu.RUnlock()
 	if !selected.indexAssigned {
@@ -2949,6 +2960,7 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 			tried[selected.ID] = struct{}{}
 			continue
 		}
+		selected = m.refreshAuthIfNeeded(ctx, selected)
 		authCopy := selected.Clone()
 		if !selected.indexAssigned {
 			m.mu.Lock()
@@ -3045,6 +3057,15 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		m.mu.RUnlock()
 		return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
+	authID := selected.ID
+	m.mu.RUnlock()
+
+	selected = m.refreshAuthIfNeeded(ctx, selected)
+
+	m.mu.RLock()
+	if fresh, ok := m.auths[authID]; ok && fresh != nil {
+		selected = fresh
+	}
 	authCopy := selected.Clone()
 	m.mu.RUnlock()
 	if !selected.indexAssigned {
@@ -3134,6 +3155,7 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		if !okExecutor {
 			return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered"}
 		}
+		selected = m.refreshAuthIfNeeded(ctx, selected)
 		authCopy := selected.Clone()
 		if !selected.indexAssigned {
 			m.mu.Lock()
@@ -3903,20 +3925,32 @@ func (m *Manager) markRefreshPending(id string, now time.Time) bool {
 	return true
 }
 
-// syncAuthMetadata copies metadata from an executor-received auth back to the
-// map entry so on-demand token refresh results persist for subsequent calls.
-func (m *Manager) syncAuthMetadata(authID string, metadata map[string]any) {
-	if authID == "" || len(metadata) == 0 {
-		return
+// refreshAuthIfNeeded checks if the auth needs refresh and lazily refreshes it.
+// It returns the updated auth pointer from the map. Call when no mu lock is held.
+func (m *Manager) refreshAuthIfNeeded(ctx context.Context, auth *Auth) *Auth {
+	if auth == nil || auth.ID == "" {
+		return auth
 	}
-	m.mu.Lock()
-	if entry, ok := m.auths[authID]; ok && entry != nil {
-		for k, v := range metadata {
-			entry.Metadata[k] = v
-		}
+	if !m.shouldRefresh(auth, time.Now()) {
+		return auth
 	}
-	m.mu.Unlock()
-	m.RefreshSchedulerEntry(authID)
+	m.lazyRefreshAuth(ctx, auth.ID)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if fresh, ok := m.auths[auth.ID]; ok && fresh != nil {
+		return fresh
+	}
+	return auth
+}
+
+func (m *Manager) lazyRefreshAuth(ctx context.Context, id string) {
+	_, err, _ := m.lazyRefreshGroup.Do(id, func() (any, error) {
+		m.refreshAuth(ctx, id)
+		return nil, nil
+	})
+	if err != nil {
+		log.Debugf("lazy refresh error for %s: %v", id, err)
+	}
 }
 
 func (m *Manager) refreshAuth(ctx context.Context, id string) {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3947,7 +3947,7 @@ func (m *Manager) refreshAuthIfNeeded(ctx context.Context, auth *Auth) *Auth {
 
 func (m *Manager) lazyRefreshAuth(ctx context.Context, id string) {
 	m.lazyRefreshGroup.Do(id, func() (any, error) {
-		m.refreshAuth(ctx, id)
+		m.refreshAuth(context.Background(), id)
 		return nil, nil
 	})
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3931,7 +3931,15 @@ func (m *Manager) refreshAuthIfNeeded(ctx context.Context, auth *Auth) *Auth {
 	if auth == nil || auth.ID == "" {
 		return auth
 	}
-	if !m.shouldRefresh(auth, time.Now()) {
+	// shouldRefresh reads mutable auth fields (NextRefreshAfter,
+	// LastRefreshedAt, Metadata, Runtime). Other paths mutate the
+	// same *Auth stored in m.auths under m.mu.Lock(), so hold the
+	// read lock here to avoid a data race when the caller passed in
+	// a map-backed auth pointer.
+	m.mu.RLock()
+	needs := m.shouldRefresh(auth, time.Now())
+	m.mu.RUnlock()
+	if !needs {
 		return auth
 	}
 	m.lazyRefreshAuth(ctx, auth.ID)
@@ -4130,6 +4138,16 @@ func (m *Manager) InjectCredentials(req *http.Request, authID string) error {
 	}
 	m.mu.RLock()
 	a := m.auths[authID]
+	m.mu.RUnlock()
+	if a == nil {
+		return nil
+	}
+	// Refresh via the manager before cloning so any rotated refresh
+	// token is persisted into the map. Without this, a clone-based
+	// PrepareRequest path would refresh on the clone and discard the
+	// rotated credentials.
+	a = m.refreshAuthIfNeeded(req.Context(), a)
+	m.mu.RLock()
 	var exec ProviderExecutor
 	if a != nil {
 		exec = m.executors[executorKeyFromAuth(a)]
@@ -4170,6 +4188,9 @@ func (m *Manager) PrepareHttpRequest(ctx context.Context, auth *Auth, req *http.
 	if !ok || preparer == nil {
 		return &Error{Code: "not_supported", Message: "executor does not support http request preparation"}
 	}
+	// Refresh through the manager so any rotated refresh token is
+	// persisted in the map; a no-op for transient auths not in the map.
+	auth = m.refreshAuthIfNeeded(ctx, auth)
 	return preparer.PrepareRequest(req, auth)
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4141,7 +4141,7 @@ func (m *Manager) InjectCredentials(req *http.Request, authID string) error {
 		return nil
 	}
 	if p, ok := exec.(RequestPreparer); ok && p != nil {
-		return p.PrepareRequest(req, a)
+		return p.PrepareRequest(req, a.Clone())
 	}
 	return nil
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -866,6 +866,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		execReq := req
 		execReq.Model = execModel
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, opts)
+		m.syncAuthMetadata(auth.ID, auth.Metadata)
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
 				return nil, errCtx
@@ -1371,6 +1372,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			execReq := req
 			execReq.Model = upstreamModel
 			resp, errExec := executor.Execute(execCtx, auth, execReq, opts)
+			m.syncAuthMetadata(auth.ID, auth.Metadata)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -1459,6 +1461,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			execReq := req
 			execReq.Model = upstreamModel
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, opts)
+			m.syncAuthMetadata(auth.ID, auth.Metadata)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -3042,13 +3045,13 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		m.mu.RUnlock()
 		return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
-	authCopy := selected
+	authCopy := selected.Clone()
 	m.mu.RUnlock()
 	if !selected.indexAssigned {
 		m.mu.Lock()
 		if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
 			current.EnsureIndex()
-			authCopy = current
+			authCopy = current.Clone()
 		}
 		m.mu.Unlock()
 	}
@@ -3131,12 +3134,12 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		if !okExecutor {
 			return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered"}
 		}
-		authCopy := selected
+		authCopy := selected.Clone()
 		if !selected.indexAssigned {
 			m.mu.Lock()
 			if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
 				current.EnsureIndex()
-				authCopy = current
+				authCopy = current.Clone()
 			}
 			m.mu.Unlock()
 		}
@@ -3898,6 +3901,21 @@ func (m *Manager) markRefreshPending(id string, now time.Time) bool {
 
 	m.queueRefreshReschedule(id)
 	return true
+}
+
+// syncAuthMetadata copies metadata from an executor-received auth back to the
+// map entry so on-demand token refresh results persist for subsequent calls.
+func (m *Manager) syncAuthMetadata(authID string, metadata map[string]any) {
+	if authID == "" || len(metadata) == 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if entry, ok := m.auths[authID]; ok && entry != nil {
+		for k, v := range metadata {
+			entry.Metadata[k] = v
+		}
+	}
 }
 
 func (m *Manager) refreshAuth(ctx context.Context, id string) {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2960,10 +2960,8 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 			tried[selected.ID] = struct{}{}
 			continue
 		}
-		m.mu.RLock()
+		selected = m.refreshAuthIfNeeded(ctx, selected)
 		authCopy := selected.Clone()
-		m.mu.RUnlock()
-		selected = m.refreshAuthIfNeeded(ctx, authCopy)
 		if !selected.indexAssigned {
 			m.mu.Lock()
 			if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3916,6 +3916,14 @@ func (m *Manager) syncAuthMetadata(authID string, metadata map[string]any) {
 		}
 	}
 	m.mu.Unlock()
+	log.Debugf("syncAuthMetadata: auth=%q metadata_keys=%v", authID, func() []string {
+		var keys []string
+		for k := range metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return keys
+	}())
 	m.RefreshSchedulerEntry(authID)
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3946,13 +3946,10 @@ func (m *Manager) refreshAuthIfNeeded(ctx context.Context, auth *Auth) *Auth {
 }
 
 func (m *Manager) lazyRefreshAuth(ctx context.Context, id string) {
-	_, err, _ := m.lazyRefreshGroup.Do(id, func() (any, error) {
+	m.lazyRefreshGroup.Do(id, func() (any, error) {
 		m.refreshAuth(ctx, id)
 		return nil, nil
 	})
-	if err != nil {
-		log.Debugf("lazy refresh error for %s: %v", id, err)
-	}
 }
 
 func (m *Manager) refreshAuth(ctx context.Context, id string) {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2961,7 +2961,9 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 			continue
 		}
 		selected = m.refreshAuthIfNeeded(ctx, selected)
+		m.mu.RLock()
 		authCopy := selected.Clone()
+		m.mu.RUnlock()
 		if !selected.indexAssigned {
 			m.mu.Lock()
 			if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3042,13 +3042,13 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		m.mu.RUnlock()
 		return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
-	authCopy := selected.Clone()
+	authCopy := selected
 	m.mu.RUnlock()
 	if !selected.indexAssigned {
 		m.mu.Lock()
 		if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
 			current.EnsureIndex()
-			authCopy = current.Clone()
+			authCopy = current
 		}
 		m.mu.Unlock()
 	}
@@ -3131,12 +3131,12 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		if !okExecutor {
 			return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered"}
 		}
-		authCopy := selected.Clone()
+		authCopy := selected
 		if !selected.indexAssigned {
 			m.mu.Lock()
 			if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
 				current.EnsureIndex()
-				authCopy = current.Clone()
+				authCopy = current
 			}
 			m.mu.Unlock()
 		}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2960,10 +2960,10 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 			tried[selected.ID] = struct{}{}
 			continue
 		}
-		selected = m.refreshAuthIfNeeded(ctx, selected)
 		m.mu.RLock()
 		authCopy := selected.Clone()
 		m.mu.RUnlock()
+		selected = m.refreshAuthIfNeeded(ctx, authCopy)
 		if !selected.indexAssigned {
 			m.mu.Lock()
 			if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3916,14 +3916,6 @@ func (m *Manager) syncAuthMetadata(authID string, metadata map[string]any) {
 		}
 	}
 	m.mu.Unlock()
-	log.Debugf("syncAuthMetadata: auth=%q metadata_keys=%v", authID, func() []string {
-		var keys []string
-		for k := range metadata {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		return keys
-	}())
 	m.RefreshSchedulerEntry(authID)
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3910,12 +3910,13 @@ func (m *Manager) syncAuthMetadata(authID string, metadata map[string]any) {
 		return
 	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if entry, ok := m.auths[authID]; ok && entry != nil {
 		for k, v := range metadata {
 			entry.Metadata[k] = v
 		}
 	}
+	m.mu.Unlock()
+	m.RefreshSchedulerEntry(authID)
 }
 
 func (m *Manager) refreshAuth(ctx context.Context, id string) {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2960,8 +2960,14 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 			tried[selected.ID] = struct{}{}
 			continue
 		}
+		authID := selected.ID
 		selected = m.refreshAuthIfNeeded(ctx, selected)
+		m.mu.RLock()
+		if fresh, ok := m.auths[authID]; ok && fresh != nil {
+			selected = fresh
+		}
 		authCopy := selected.Clone()
+		m.mu.RUnlock()
 		if !selected.indexAssigned {
 			m.mu.Lock()
 			if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
@@ -3155,8 +3161,14 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		if !okExecutor {
 			return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered"}
 		}
+		authID := selected.ID
 		selected = m.refreshAuthIfNeeded(ctx, selected)
+		m.mu.RLock()
+		if fresh, ok := m.auths[authID]; ok && fresh != nil {
+			selected = fresh
+		}
 		authCopy := selected.Clone()
+		m.mu.RUnlock()
 		if !selected.indexAssigned {
 			m.mu.Lock()
 			if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
@@ -3942,7 +3954,7 @@ func (m *Manager) refreshAuthIfNeeded(ctx context.Context, auth *Auth) *Auth {
 	if !needs {
 		return auth
 	}
-	m.lazyRefreshAuth(ctx, auth.ID)
+	m.lazyRefreshAuth(auth.ID)
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if fresh, ok := m.auths[auth.ID]; ok && fresh != nil {
@@ -3951,11 +3963,14 @@ func (m *Manager) refreshAuthIfNeeded(ctx context.Context, auth *Auth) *Auth {
 	return auth
 }
 
-func (m *Manager) lazyRefreshAuth(ctx context.Context, id string) {
-	m.lazyRefreshGroup.Do(id, func() (any, error) {
+func (m *Manager) lazyRefreshAuth(id string) {
+	_, err, _ := m.lazyRefreshGroup.Do(id, func() (any, error) {
 		m.refreshAuth(context.Background(), id)
 		return nil, nil
 	})
+	if err != nil {
+		log.Debugf("lazyRefreshAuth singleflight error for %s: %v", id, err)
+	}
 }
 
 func (m *Manager) refreshAuth(ctx context.Context, id string) {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4163,6 +4163,9 @@ func (m *Manager) InjectCredentials(req *http.Request, authID string) error {
 	// rotated credentials.
 	a = m.refreshAuthIfNeeded(req.Context(), a)
 	m.mu.RLock()
+	if fresh, ok := m.auths[authID]; ok && fresh != nil {
+		a = fresh
+	}
 	var exec ProviderExecutor
 	if a != nil {
 		exec = m.executors[executorKeyFromAuth(a)]
@@ -4206,6 +4209,16 @@ func (m *Manager) PrepareHttpRequest(ctx context.Context, auth *Auth, req *http.
 	// Refresh through the manager so any rotated refresh token is
 	// persisted in the map; a no-op for transient auths not in the map.
 	auth = m.refreshAuthIfNeeded(ctx, auth)
+
+	// Snapshot the refreshed auth under the lock so the preparer
+	// reads a stable clone, not the mutable manager-owned pointer.
+	authID := auth.ID
+	m.mu.RLock()
+	if fresh, ok := m.auths[authID]; ok && fresh != nil {
+		auth = fresh.Clone()
+	}
+	m.mu.RUnlock()
+
 	return preparer.PrepareRequest(req, auth)
 }
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -922,13 +922,6 @@ func (s *Service) Run(ctx context.Context) error {
 		log.Info("file watcher started for config and auth directory changes")
 	}
 
-	// Prefer core auth manager auto refresh if available.
-	if s.coreManager != nil && !homeEnabled {
-		interval := 15 * time.Minute
-		s.coreManager.StartAutoRefresh(context.Background(), interval)
-		log.Infof("core auth auto-refresh started (interval=%s)", interval)
-	}
-
 	select {
 	case <-ctx.Done():
 		log.Debug("service context cancelled, shutting down...")

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -922,6 +922,13 @@ func (s *Service) Run(ctx context.Context) error {
 		log.Info("file watcher started for config and auth directory changes")
 	}
 
+	// Prefer core auth manager auto refresh if available.
+	if s.coreManager != nil && !homeEnabled {
+		interval := 15 * time.Minute
+		s.coreManager.StartAutoRefresh(context.Background(), interval)
+		log.Infof("core auth auto-refresh started (interval=%s)", interval)
+	}
+
 	select {
 	case <-ctx.Done():
 		log.Debug("service context cancelled, shutting down...")


### PR DESCRIPTION
## 1. High-Level Summary (TL;DR)
*   **Impact:** Medium
*   **Key Changes:**
    *   ✨ **Lazy Auth Refresh:** Migrated the `antigravity` provider from a background auto-refresh loop to an on-demand, lazy refresh mechanism during auth selection.
    *   🚀 **Singleflight Integration:** Added `singleflight` to the Auth Manager to coalesce concurrent lazy refresh requests and prevent token refresh storms.
    *   ⚙️ **New Configuration:** Introduced `antigravity-use-default-project-id` to skip fetching the project ID and default to the base URL directly.
    *   🐛 **Concurrency & Bug Fixes:** Added a mutex lock to `GetConfig()` to fix data races, and prevented `NewAntigravityAuth()` from unconditionally overwriting an existing HTTP client transport.

## 2. Visual Overview (Code & Logic Map)

```mermaid
graph TD
    classDef default fill:#f3e5f5,color:#7b1fa2,stroke:#7b1fa2;
    classDef condition fill:#fff3e0,color:#e65100,stroke:#e65100;
    classDef action fill:#c8e6c9,color:#1a5e20,stroke:#1a5e20;
    classDef skip fill:#ffcdd2,color:#b71c1c,stroke:#b71c1c;

    subgraph "Auth Manager (conductor.go)"
        A("pickNext()"):::action --> B{"shouldRefresh()"}:::condition
        B -- "Yes" --> C("lazyRefreshAuth()"):::action
        B -- "No" --> D("Return Auth"):::action
        C --> E("singleflight.Do(id)"):::action
        E --> F("refreshAuth()"):::action
        F --> D
    end

    subgraph "Background Loop (auto_refresh_loop.go)"
        G("handleDueAuth()"):::action --> H{"Provider == 'antigravity'?"}:::condition
        H -- "Yes" --> I("Skip Refresh (Lazy)"):::skip
        H -- "No" --> J("Proceed Auto Refresh"):::action
    end
```

## 3. Detailed Change Analysis

### ⚙️ Configuration Updates
Introduced a new flag to bypass project ID fetching when none is available.
| Key | Type | Default | Description |
| :--- | :--- | :--- | :--- |
| `antigravity-use-default-project-id` | `bool` | `false` | Skips fetching project ID via `loadCodeAssist` and uses the default base URL directly. Useful for environments lacking a project ID. |

### 🔐 Auth Manager & Conductor (`conductor.go`, `auto_refresh_loop.go`)
*   **Lazy Token Refresh:** Added `refreshAuthIfNeeded()` which is now invoked within `pickNext`, `pickNextLegacy`, `pickNextMixed`, and `pickNextMixedLegacy`.
*   **Concurrency Control:** Introduced `lazyRefreshGroup singleflight.Group` to ensure that multiple concurrent threads requesting the same expired auth token only trigger a single underlying HTTP refresh call.
*   **Background Loop Exclusion:** Hardcoded a bypass in `handleDueAuth()` so that `antigravity` auths are skipped by the background auto-refresh loop (Source: `auto_refresh_loop.go`).

### 🚀 Antigravity Executor (`antigravity_executor.go`)
*   **In-Place Refresh:** Changed `e.refreshToken(refreshCtx, auth.Clone())` to `e.refreshToken(refreshCtx, auth)`, updating the auth struct directly instead of a clone.
*   **Nil Safety:** Added widespread `e.cfg != nil` checks across multiple methods (`maybeRefreshAntigravityCreditsHint`, `Execute`, etc.) to prevent panics in unconfigured environments.
*   **Conditional Project ID:** Wrapped the `ensureAntigravityProjectID()` call with a check for the newly added `!e.cfg.AntigravityUseDefaultProjectID` flag.

### 🐛 HTTP Client & Handlers (`auth.go`, `config_basic.go`)
*   **Transport Safety:** Modified `NewAntigravityAuth()` to only clone and apply `http.DefaultTransport` (with `InsecureSkipVerify = true`) if `client.Transport == nil`. This preserves custom transports injected upstream.
*   **Data Race Fix:** Added `h.mu.Lock()` and `h.mu.Unlock()` around config struct dereferencing (`cfg := *h.cfg`) in the `GetConfig` management handler.

## 4. Impact & Risk Assessment
*   **⚠️ Breaking Changes:** None. This is a backward-compatible refactoring.
*   **🧪 Testing Suggestions:**
    *   **High Concurrency:** Flood the system with requests requiring `antigravity` tokens right after they expire to verify `singleflight` prevents multiple OAuth refresh calls.
    *   **Config Toggle:** Enable `antigravity-use-default-project-id: true` and verify that the system successfully bypasses project ID fetching without failing the auth phase.
    *   **Data Race Check:** Run tests with `-race` to ensure the `GetConfig` handler is now fully thread-safe.