### PR TITLE
feat(antigravity): per-auth enable_credit for Claude credits injection

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -405,6 +405,39 @@ func antigravityCreditsRetryEnabled(cfg *config.Config) bool {
 	return cfg != nil && cfg.QuotaExceeded.AntigravityCredits
 }
 
+// antigravityAuthEnableCredit checks if the auth has enable_credit set to true in its metadata
+// AND the model is a Claude model (credits only apply to Claude models on Antigravity;
+// Gemini models are free and do not consume credits).
+// This implements gcli2api-style per-credential credit control: each auth independently
+// decides whether to consume Google One AI credits via the enable_credit metadata field.
+func antigravityAuthEnableCredit(auth *cliproxyauth.Auth, model string) bool {
+	if auth == nil || auth.Metadata == nil {
+		return false
+	}
+	// Credits only apply to Claude models; Gemini models are free.
+	if !strings.Contains(strings.ToLower(strings.TrimSpace(model)), "claude") {
+		return false
+	}
+	for _, key := range []string{"enable_credit", "enable-credit"} {
+		if val, ok := auth.Metadata[key]; ok {
+			switch v := val.(type) {
+			case bool:
+				return v
+			case string:
+				trimmed := strings.TrimSpace(strings.ToLower(v))
+				return trimmed == "true" || trimmed == "1" || trimmed == "yes"
+			case float64:
+				return v != 0
+			case json.Number:
+				if i, err := v.Int64(); err == nil {
+					return i != 0
+				}
+			}
+		}
+	}
+	return false
+}
+
 func clearAntigravityCreditsFailureState(auth *cliproxyauth.Auth) {
 	if auth == nil || strings.TrimSpace(auth.ID) == "" {
 		return
@@ -524,7 +557,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel, requestPath)
 
-	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
+	useCredits := antigravityAuthEnableCredit(auth, baseModel)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -722,7 +755,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel, requestPath)
 
-	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
+	useCredits := antigravityAuthEnableCredit(auth, baseModel)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -1183,7 +1216,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "antigravity", "request", translated, originalTranslated, requestedModel, requestPath)
 
-	useCredits := cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)
+	useCredits := antigravityAuthEnableCredit(auth, baseModel)
 
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
@@ -1612,7 +1645,27 @@ func (e *AntigravityExecutor) ensureAccessToken(ctx context.Context, auth *clipr
 }
 
 func (e *AntigravityExecutor) maybeRefreshAntigravityCreditsHint(ctx context.Context, auth *cliproxyauth.Auth, accessToken string) {
-	if e == nil || auth == nil || !antigravityCreditsRetryEnabled(e.cfg) {
+	if e == nil || auth == nil {
+		return
+	}
+	// Only refresh credits hint if auth has enable_credit set
+	if auth.Metadata == nil {
+		return
+	}
+	hasEnableCredit := false
+	for _, key := range []string{"enable_credit", "enable-credit"} {
+		if val, ok := auth.Metadata[key]; ok {
+			switch v := val.(type) {
+			case bool:
+				hasEnableCredit = v
+			case string:
+				trimmed := strings.TrimSpace(strings.ToLower(v))
+				hasEnableCredit = trimmed == "true" || trimmed == "1" || trimmed == "yes"
+			}
+			break
+		}
+	}
+	if !hasEnableCredit {
 		return
 	}
 	if ctx != nil && ctx.Err() != nil {
@@ -2193,6 +2246,8 @@ func antigravityShouldRetrySoftRateLimit(statusCode int, body []byte) bool {
 }
 
 func antigravityShouldBypassShortCooldown(ctx context.Context, cfg *config.Config) bool {
+	// Keep original behavior: when credits are requested via context AND global config allows it,
+	// bypass short cooldown. This path is still used by the conductor's fallback mechanism.
 	return cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(cfg)
 }
 

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -240,14 +240,15 @@ func TestAntigravityExecute_CreditsInjectedWhenConductorRequests(t *testing.T) {
 			"base_url": server.URL,
 		},
 		Metadata: map[string]any{
-			"access_token": "token",
-			"project_id":   "project-1",
-			"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+			"access_token":  "token",
+			"project_id":    "project-1",
+			"expired":       time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+			"enable_credit": true,
 		},
 	}
 
-	// Simulate conductor setting credits requested flag in context
-	ctx := cliproxyauth.WithAntigravityCredits(context.Background())
+	// With per-auth enable_credit in metadata, credits should be injected
+	ctx := context.Background()
 
 	resp, err := exec.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model:   "claude-sonnet-4-6",
@@ -395,8 +396,9 @@ func TestEnsureAccessToken_WarmTokenLoadsCreditsHint(t *testing.T) {
 	auth := &cliproxyauth.Auth{
 		ID: "auth-warm-token-credits",
 		Metadata: map[string]any{
-			"access_token": "token",
-			"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+			"access_token":  "token",
+			"expired":       time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+			"enable_credit": true,
 		},
 	}
 	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -448,6 +450,9 @@ func TestUpdateAntigravityCreditsBalance_LoadCodeAssistUserAgent(t *testing.T) {
 	auth := &cliproxyauth.Auth{
 		ID:         "auth-load-code-assist-ua",
 		Attributes: map[string]string{"user_agent": userAgent},
+		Metadata: map[string]any{
+			"enable_credit": true,
+		},
 	}
 	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.String() != "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist" {


### PR DESCRIPTION
## Per-Auth `enable_credit` for Claude Credits Injection
## 凭证级 `enable_credit` 积分注入控制

### Summary / 摘要

This PR adds per-credential control for Google One AI credits injection via a new `enable_credit` metadata field in auth files. Instead of relying on the global config + context two-level switch, each auth can now independently decide whether to consume credits for Claude model requests.

本 PR 通过在 auth 文件中新增 `enable_credit` 元数据字段，实现了凭证级别的 Google One AI 积分注入控制。每个凭证可以独立决定是否在 Claude 模型请求中消耗积分，不再依赖全局配置 + 上下文两级开关。

### Changes / 改动内容

**New function / 新增函数：**
- `antigravityAuthEnableCredit(auth, model)` — Reads `enable_credit` (or `enable-credit`) from `auth.Metadata` and only returns true when the model is a Claude model.
- `antigravityAuthEnableCredit(auth, model)` — 从 `auth.Metadata` 读取 `enable_credit`（或 `enable-credit`）字段，仅当模型为 Claude 模型时返回 true。

**Modified logic / 修改逻辑：**
- All 3 `useCredits` assignments in `Execute`, `executeClaudeNonStream`, and `ExecuteStream` now use `antigravityAuthEnableCredit(auth, baseModel)` instead of `cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)`.
- `Execute`、`executeClaudeNonStream`、`ExecuteStream` 中的 3 处 `useCredits` 赋值现在使用 `antigravityAuthEnableCredit(auth, baseModel)` 替代原来的 `cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(e.cfg)`。

- `maybeRefreshAntigravityCreditsHint` now checks `enable_credit` metadata directly instead of the global config.
- `maybeRefreshAntigravityCreditsHint` 现在直接检查 `enable_credit` 元数据字段，而非全局配置。

- The conductor's fallback mechanism (`antigravityShouldBypassShortCooldown`) is preserved unchanged.
- conductor 层的回退机制（`antigravityShouldBypassShortCooldown`）保持不变。

### Usage / 使用方式

Add `enable_credit` to your auth JSON file: / 在 auth JSON 文件中添加 `enable_credit` 字段：

```json
{
  "access_token": "...",
  "refresh_token": "...",
  "enable_credit": true,
  "type": "antigravity"
}
```

| `enable_credit` | Claude Models / Claude 模型 | Gemini Models / Gemini 模型 |
|---|---|---|
| `true` | ✅ Credits injected / 注入积分 | ❌ No effect / 无影响 |
| `false` or missing / `false` 或不设置 | ❌ Free quota only / 仅免费配额 | ❌ No effect / 无影响 |

### Key Design Decisions / 关键设计决策

1. **Claude-only restriction / 仅限 Claude 模型** — Credits are only injected for models containing "claude" in their name. Gemini models are free and do not need credits. / 积分仅注入模型名包含 "claude" 的请求，Gemini 模型免费无需积分。

2. **Backward compatible / 向后兼容** — Existing auth files without `enable_credit` field will behave exactly as before (no credits). The global config flag `antigravity-credits` is preserved for the conductor's fallback path. / 没有 `enable_credit` 字段的现有 auth 文件行为完全不变（不消耗积分）。全局配置 `antigravity-credits` 保留用于 conductor 的回退路径。

3. **Flexible value parsing / 灵活的值解析** — Supports `bool`, `string` ("true"/"1"/"yes"), `float64`, and `json.Number` types. Also accepts the kebab-case variant `enable-credit`. / 支持 `bool`、`string`（"true"/"1"/"yes"）、`float64` 和 `json.Number` 类型，同时接受短横线形式 `enable-credit`。
