### PR TITLE
feat(antigravity): auto-retry with credits on 429 quota exhausted for Claude models

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -815,8 +815,12 @@ attemptLoop:
 					case antigravity429DecisionFullQuotaExhausted:
 						if useCredits && antigravityHasExplicitCreditsBalanceExhaustedReason(bodyBytes) {
 							markAntigravityCreditsPermanentlyDisabled(auth)
+						} else if !useCredits && antigravityCreditsRetryEnabled(e.cfg) {
+							// Free quota exhausted for Claude model: immediately retry same auth with credits
+							log.Debugf("antigravity executor: free quota exhausted for model %s on auth %s, retrying with credits", baseModel, auth.ID)
+							useCredits = true
+							continue attemptLoop
 						}
-						// No credits logic - just fall through to error return below
 					}
 				}
 
@@ -1275,8 +1279,12 @@ attemptLoop:
 					case antigravity429DecisionFullQuotaExhausted:
 						if useCredits && antigravityHasExplicitCreditsBalanceExhaustedReason(bodyBytes) {
 							markAntigravityCreditsPermanentlyDisabled(auth)
+						} else if !useCredits && antigravityCreditsRetryEnabled(e.cfg) && strings.Contains(strings.ToLower(baseModel), "claude") {
+							// Free quota exhausted for Claude model: immediately retry same auth with credits
+							log.Debugf("antigravity executor: free quota exhausted for model %s on auth %s, retrying with credits (stream)", baseModel, auth.ID)
+							useCredits = true
+							continue attemptLoop
 						}
-						// No credits logic - just fall through to error return below
 					}
 				}
 

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -266,7 +266,7 @@ func TestAntigravityExecute_CreditsInjectedWhenConductorRequests(t *testing.T) {
 	}
 }
 
-func TestAntigravityExecute_NoCreditsWithoutConductorFlag(t *testing.T) {
+func TestAntigravityExecute_AutoCreditsRetryOnQuotaExhausted(t *testing.T) {
 	resetAntigravityCreditsRetryState()
 	t.Cleanup(resetAntigravityCreditsRetryState)
 
@@ -280,16 +280,27 @@ func TestAntigravityExecute_NoCreditsWithoutConductorFlag(t *testing.T) {
 			return
 		}
 		requestBodies = append(requestBodies, string(body))
-		w.WriteHeader(http.StatusTooManyRequests)
-		_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"QUOTA_EXHAUSTED"}}`))
+		if len(requestBodies) == 1 {
+			// First request: no credits, return 429 quota exhausted
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"QUOTA_EXHAUSTED"}]}}`))
+			return
+		}
+		// Second request: should have credits injected, return success
+		if !strings.Contains(string(body), `"enabledCreditTypes":["GOOGLE_ONE_AI"]`) {
+			t.Fatalf("retry request missing enabledCreditTypes: %s", string(body))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}}`))
 	}))
 	defer server.Close()
 
 	exec := NewAntigravityExecutor(&config.Config{
 		QuotaExceeded: config.QuotaExceeded{AntigravityCredits: true},
+		RequestRetry:  1,
 	})
 	auth := &cliproxyauth.Auth{
-		ID: "auth-no-conductor-flag",
+		ID: "auth-auto-credits-retry",
 		Attributes: map[string]string{
 			"base_url": server.URL,
 		},
@@ -300,22 +311,25 @@ func TestAntigravityExecute_NoCreditsWithoutConductorFlag(t *testing.T) {
 		},
 	}
 
-	// No conductor credits flag set in context
-	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	// No conductor credits flag in context — executor should auto-retry with credits on 429
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "claude-sonnet-4-6",
 		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FormatAntigravity,
 	})
-	if err == nil {
-		t.Fatal("Execute() error = nil, want 429")
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
 	}
-	if len(requestBodies) != 1 {
-		t.Fatalf("request count = %d, want 1", len(requestBodies))
+	if len(resp.Payload) == 0 {
+		t.Fatal("Execute() returned empty payload")
 	}
-	// Should NOT contain credits since conductor didn't request them
+	if len(requestBodies) != 2 {
+		t.Fatalf("request count = %d, want 2 (first without credits, second with credits)", len(requestBodies))
+	}
+	// First request should NOT contain credits
 	if strings.Contains(requestBodies[0], `"enabledCreditTypes"`) {
-		t.Fatalf("request should not contain enabledCreditTypes without conductor flag: %s", requestBodies[0])
+		t.Fatalf("first request should not contain enabledCreditTypes: %s", requestBodies[0])
 	}
 }
 


### PR DESCRIPTION
## Auto-Retry with Credits on 429 Quota Exhausted for Claude Models
## Claude 模型 429 配额耗尽时自动注入积分重试

> [!NOTE]
> This PR is **mutually exclusive** with #3379. Please merge only one of them.
> 本 PR 与 #3379 **互斥**，请仅合并其中之一。

### Summary / 摘要

When a Claude model request hits a 429 (quota exhausted) error, the executor now **immediately retries the same auth with credits injected**, instead of giving up and waiting for the conductor to attempt a separate fallback pass across all auths.

当 Claude 模型请求遇到 429（配额耗尽）错误时，executor 现在会**立即用同一凭证注入积分重试**，而非放弃并等待 conductor 在所有凭证间尝试单独的回退流程。

### Conditions / 触发条件

All three conditions must be met / 以下三个条件必须同时满足：

1. **Global config enabled / 全局配置开启**: `quota-exceeded.antigravity-credits: true`
2. **Claude model / Claude 模型**: Model name contains `claude`
3. **429 Quota Exhausted / 429 配额耗尽**: Error reason is `QUOTA_EXHAUSTED` or equivalent

### How It Works / 工作原理

```
Request Claude model / 请求 Claude 模型
    ↓
First attempt (no credits) / 首次尝试（无积分）
    ↓
429 QUOTA_EXHAUSTED
    ↓
Conditions met? / 满足条件？
    ├── No → Return error (original behavior) / 返回错误（原始行为）
    └── Yes → Retry same auth with enabledCreditTypes injected / 用同一凭证注入积分重试
         ↓
      Success or other error / 成功或其他错误
```

### Changes / 改动内容

**`antigravity_executor.go`** — Modified 2 `FullQuotaExhausted` handlers:

- `executeClaudeNonStream`: When quota exhausted + global config enabled + not already using credits → set `useCredits = true` and `continue attemptLoop`
- `ExecuteStream`: Same logic, with additional Claude model name check (since `ExecuteStream` handles all models)

**`antigravity_executor.go`** — 修改了 2 处 `FullQuotaExhausted` 处理块：

- `executeClaudeNonStream`：配额耗尽 + 全局配置启用 + 尚未使用积分 → 设置 `useCredits = true` 并 `continue attemptLoop`
- `ExecuteStream`：相同逻辑，额外检查模型名是否包含 `claude`（因为 `ExecuteStream` 处理所有模型）

### Key Design Decisions / 关键设计决策

1. **Same auth retry / 同凭证重试** — Credits are injected and retried on the *same* auth that got the 429, no auth switching needed.
   积分注入后用*同一个*获得 429 的凭证重试，无需切换凭证。

2. **One-shot upgrade / 一次性升级** — The `useCredits` flag is a one-way toggle. If credits also fail with `INSUFFICIENT_G1_CREDITS_BALANCE`, the auth is permanently marked disabled for credits.
   `useCredits` 标志是单向切换。如果积分也因 `INSUFFICIENT_G1_CREDITS_BALANCE` 失败，该凭证的积分功能将被永久禁用。

3. **Backward compatible / 向后兼容** — When `antigravity-credits: false` (default), behavior is identical to the original code.
   当 `antigravity-credits: false`（默认值）时，行为与原始代码完全一致。

4. **Conductor fallback preserved / 保留 conductor 回退** — The conductor-level credits fallback mechanism remains unchanged and can still operate as a secondary fallback.
   conductor 层的积分回退机制保持不变，仍可作为二级回退运行。

### Difference from #3379 / 与 #3379 的区别

| | #3379 (per-auth enable_credit) | This PR (auto-retry on 429) |
|---|---|---|
| Trigger / 触发方式 | Per-auth `enable_credit` metadata field / 凭证级 `enable_credit` 字段 | 429 quota exhausted error / 429 配额耗尽错误 |
| Credits injection timing / 积分注入时机 | Every Claude request from the start / 从一开始每个 Claude 请求都注入 | Only after free quota is exhausted / 仅在免费配额耗尽后 |
| Config dependency / 配置依赖 | None (per-auth control) / 无（凭证级控制） | Global `antigravity-credits: true` / 全局配置 |