### PR TITLE
fix(watcher): emit initial auth updates even when queue is not yet set

### DIFF
--- a/internal/watcher/dispatcher.go
+++ b/internal/watcher/dispatcher.go
@@ -106,9 +106,6 @@ func (w *Watcher) prepareAuthUpdatesLocked(auths []*coreauth.Auth, force bool) [
 	}
 	if w.currentAuths == nil {
 		w.currentAuths = newState
-		if w.authQueue == nil {
-			return nil
-		}
 		updates := make([]AuthUpdate, 0, len(newState))
 		for id, auth := range newState {
 			updates = append(updates, AuthUpdate{Action: AuthUpdateActionAdd, ID: id, Auth: auth.Clone()})

--- a/internal/watcher/dispatcher.go
+++ b/internal/watcher/dispatcher.go
@@ -112,10 +112,6 @@ func (w *Watcher) prepareAuthUpdatesLocked(auths []*coreauth.Auth, force bool) [
 		}
 		return updates
 	}
-	if w.authQueue == nil {
-		w.currentAuths = newState
-		return nil
-	}
 	updates := make([]AuthUpdate, 0, len(newState)+len(w.currentAuths))
 	for id, auth := range newState {
 		if existing, ok := w.currentAuths[id]; !ok {

--- a/internal/watcher/dispatcher_test.go
+++ b/internal/watcher/dispatcher_test.go
@@ -1,0 +1,53 @@
+package watcher
+
+import (
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// TestPrepareAuthUpdatesLockedNilQueue verifies that prepareAuthUpdatesLocked
+// returns Add updates even when authQueue is nil (i.e. before setAuthUpdateQueue
+// is called at startup). This covers the bug fixed in this PR where the early
+// nil-queue returns silently dropped all initial auth events.
+func TestPrepareAuthUpdatesLockedNilQueue(t *testing.T) {
+	w := &Watcher{} // currentAuths nil, authQueue nil
+
+	auths := []*coreauth.Auth{{ID: "a", Provider: "p"}}
+	updates := w.prepareAuthUpdatesLocked(auths, false)
+
+	if len(updates) != 1 {
+		t.Fatalf("expected 1 update, got %d: %+v", len(updates), updates)
+	}
+	if updates[0].Action != AuthUpdateActionAdd {
+		t.Errorf("expected action Add, got %v", updates[0].Action)
+	}
+	if updates[0].ID != "a" {
+		t.Errorf("expected ID %q, got %q", "a", updates[0].ID)
+	}
+}
+
+// TestPrepareAuthUpdatesLockedNilQueueSubsequent verifies that on subsequent
+// calls with existing state and a nil queue, the diff is still computed
+// and currentAuths is updated.
+func TestPrepareAuthUpdatesLockedNilQueueSubsequent(t *testing.T) {
+	w := &Watcher{}
+
+	// First call: populate state.
+	auths := []*coreauth.Auth{{ID: "a", Provider: "p"}}
+	w.prepareAuthUpdatesLocked(auths, false)
+
+	// Second call with different auth: should produce Modify/Add, not nil.
+	auths2 := []*coreauth.Auth{
+		{ID: "a", Provider: "p"},
+		{ID: "b", Provider: "p"},
+	}
+	updates := w.prepareAuthUpdatesLocked(auths2, false)
+
+	if len(updates) != 1 {
+		t.Fatalf("expected 1 Add update for new account, got %d: %+v", len(updates), updates)
+	}
+	if updates[0].Action != AuthUpdateActionAdd || updates[0].ID != "b" {
+		t.Errorf("expected Add for 'b', got %+v", updates[0])
+	}
+}


### PR DESCRIPTION
`prepareAuthUpdatesLocked` returned `nil` on the very first call if
`authQueue` was `nil` at that moment, dropping all `AuthUpdateActionAdd`
events for accounts discovered at startup.

The queue is wired up later via `setAuthUpdateQueue`, which starts the
dispatch loop, but by then there is nothing queued to send. Those
accounts never became visible to consumers until the next periodic
refresh.

The fix removes the early return: the updates slice is always built and
returned, and `dispatchAuthUpdates` already handles a `nil` queue
gracefully (it is a no-op).
