### PR TITLE
feat(auth): add -claude-label flag for multi-org Claude accounts

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,6 +64,7 @@ func main() {
 	var codexLogin bool
 	var codexDeviceLogin bool
 	var claudeLogin bool
+	var claudeLabel string
 	var noBrowser bool
 	var oauthCallbackPort int
 	var antigravityLogin bool
@@ -84,6 +85,7 @@ func main() {
 	flag.BoolVar(&codexLogin, "codex-login", false, "Login to Codex using OAuth")
 	flag.BoolVar(&codexDeviceLogin, "codex-device-login", false, "Login to Codex using device code flow")
 	flag.BoolVar(&claudeLogin, "claude-login", false, "Login to Claude using OAuth")
+	flag.StringVar(&claudeLabel, "claude-label", "", "Label suffix appended to the auth filename (claude-<email>-<label>.json); allows multiple Claude orgs to coexist in one auth-dir")
 	flag.BoolVar(&noBrowser, "no-browser", false, "Don't open browser automatically for OAuth")
 	flag.IntVar(&oauthCallbackPort, "oauth-callback-port", 0, "Override OAuth callback port (defaults to provider-specific port)")
 	flag.BoolVar(&antigravityLogin, "antigravity-login", false, "Login to Antigravity using OAuth")
@@ -516,6 +518,7 @@ func main() {
 	options := &cmd.LoginOptions{
 		NoBrowser:    noBrowser,
 		CallbackPort: oauthCallbackPort,
+		Label:        claudeLabel,
 	}
 
 	// Register the shared token store once so all components use the same persistence backend.

--- a/internal/cmd/anthropic_login.go
+++ b/internal/cmd/anthropic_login.go
@@ -24,6 +24,11 @@ func DoClaudeLogin(cfg *config.Config, options *LoginOptions) {
 		options = &LoginOptions{}
 	}
 
+	if err := sdkAuth.ValidateLabel(options.Label); err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	promptFn := options.Prompt
 	if promptFn == nil {
 		promptFn = defaultProjectPrompt()

--- a/internal/cmd/anthropic_login.go
+++ b/internal/cmd/anthropic_login.go
@@ -36,6 +36,7 @@ func DoClaudeLogin(cfg *config.Config, options *LoginOptions) {
 		CallbackPort: options.CallbackPort,
 		Metadata:     map[string]string{},
 		Prompt:       promptFn,
+		Label:        options.Label,
 	}
 
 	_, savedPath, err := manager.Login(context.Background(), "claude", cfg, authOpts)

--- a/internal/cmd/anthropic_login.go
+++ b/internal/cmd/anthropic_login.go
@@ -25,7 +25,7 @@ func DoClaudeLogin(cfg *config.Config, options *LoginOptions) {
 	}
 
 	if err := sdkAuth.ValidateLabel(options.Label); err != nil {
-		fmt.Println(err)
+		log.Errorf("invalid claude-label: %v", err)
 		return
 	}
 

--- a/internal/cmd/openai_login.go
+++ b/internal/cmd/openai_login.go
@@ -24,6 +24,10 @@ type LoginOptions struct {
 
 	// Prompt allows the caller to provide interactive input when needed.
 	Prompt func(prompt string) (string, error)
+
+	// Label is appended to the auth filename so multiple accounts for the
+	// same provider can coexist in one auth-dir. See sdk/auth.LoginOptions.
+	Label string
 }
 
 // DoCodexLogin triggers the Codex OAuth flow through the shared authentication manager.

--- a/sdk/auth/claude.go
+++ b/sdk/auth/claude.go
@@ -46,6 +46,10 @@ func (a *ClaudeAuthenticator) Login(ctx context.Context, cfg *config.Config, opt
 		opts = &LoginOptions{}
 	}
 
+	if err := ValidateLabel(opts.Label); err != nil {
+		return nil, err
+	}
+
 	callbackPort := a.CallbackPort
 	if opts.CallbackPort > 0 {
 		callbackPort = opts.CallbackPort

--- a/sdk/auth/claude.go
+++ b/sdk/auth/claude.go
@@ -201,6 +201,9 @@ waitForCallback:
 	}
 
 	fileName := fmt.Sprintf("claude-%s.json", tokenStorage.Email)
+	if opts.Label != "" {
+		fileName = fmt.Sprintf("claude-%s-%s.json", tokenStorage.Email, opts.Label)
+	}
 	metadata := map[string]any{
 		"email": tokenStorage.Email,
 	}

--- a/sdk/auth/claude.go
+++ b/sdk/auth/claude.go
@@ -27,6 +27,14 @@ func NewClaudeAuthenticator() *ClaudeAuthenticator {
 	return &ClaudeAuthenticator{CallbackPort: 54545}
 }
 
+// claudeFileName returns the auth filename for a Claude account.
+func claudeFileName(email, label string) string {
+	if label != "" {
+		return fmt.Sprintf("claude-%s-%s.json", email, label)
+	}
+	return fmt.Sprintf("claude-%s.json", email)
+}
+
 func (a *ClaudeAuthenticator) Provider() string {
 	return "claude"
 }
@@ -204,10 +212,7 @@ waitForCallback:
 		return nil, fmt.Errorf("claude token storage missing account information")
 	}
 
-	fileName := fmt.Sprintf("claude-%s.json", tokenStorage.Email)
-	if opts.Label != "" {
-		fileName = fmt.Sprintf("claude-%s-%s.json", tokenStorage.Email, opts.Label)
-	}
+	fileName := claudeFileName(tokenStorage.Email, opts.Label)
 	metadata := map[string]any{
 		"email": tokenStorage.Email,
 	}

--- a/sdk/auth/interfaces.go
+++ b/sdk/auth/interfaces.go
@@ -3,11 +3,15 @@ package auth
 import (
 	"context"
 	"errors"
+	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
+
+var labelRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 var ErrRefreshNotSupported = errors.New("cliproxy auth: refresh not supported")
 
@@ -23,7 +27,20 @@ type LoginOptions struct {
 	// Label, when set, is appended to the auth filename so multiple accounts
 	// for the same provider can coexist in one auth-dir without overwriting
 	// each other. For Claude the file becomes claude-<email>-<label>.json.
+	// Must contain only alphanumeric characters, hyphens and underscores.
 	Label string
+}
+
+// ValidateLabel returns an error if label contains characters that are not
+// safe for use in a filename (anything outside [a-zA-Z0-9_-]).
+func ValidateLabel(label string) error {
+	if label == "" {
+		return nil
+	}
+	if !labelRe.MatchString(label) {
+		return fmt.Errorf("label %q contains invalid characters: only letters, digits, hyphens and underscores are allowed", label)
+	}
+	return nil
 }
 
 // Authenticator manages login and optional refresh flows for a provider.

--- a/sdk/auth/interfaces.go
+++ b/sdk/auth/interfaces.go
@@ -19,6 +19,11 @@ type LoginOptions struct {
 	CallbackPort int
 	Metadata     map[string]string
 	Prompt       func(prompt string) (string, error)
+
+	// Label, when set, is appended to the auth filename so multiple accounts
+	// for the same provider can coexist in one auth-dir without overwriting
+	// each other. For Claude the file becomes claude-<email>-<label>.json.
+	Label string
 }
 
 // Authenticator manages login and optional refresh flows for a provider.

--- a/sdk/auth/interfaces.go
+++ b/sdk/auth/interfaces.go
@@ -37,6 +37,9 @@ func ValidateLabel(label string) error {
 	if label == "" {
 		return nil
 	}
+	if len(label) > 32 {
+		return fmt.Errorf("label %q is too long: maximum 32 characters", label)
+	}
 	if !labelRe.MatchString(label) {
 		return fmt.Errorf("label %q contains invalid characters: only letters, digits, hyphens and underscores are allowed", label)
 	}

--- a/sdk/auth/label_test.go
+++ b/sdk/auth/label_test.go
@@ -38,15 +38,6 @@ func TestValidateLabel(t *testing.T) {
 
 func TestClaudeFilenameConstruction(t *testing.T) {
 	email := "user@example.com"
-
-	// no label: claude-<email>.json
-	withoutLabel := func(email, label string) string {
-		if label != "" {
-			return "claude-" + email + "-" + label + ".json"
-		}
-		return "claude-" + email + ".json"
-	}
-
 	cases := []struct {
 		label string
 		want  string
@@ -57,9 +48,9 @@ func TestClaudeFilenameConstruction(t *testing.T) {
 		{"my_team", "claude-user@example.com-my_team.json"},
 	}
 	for _, tc := range cases {
-		got := withoutLabel(email, tc.label)
+		got := claudeFileName(email, tc.label)
 		if got != tc.want {
-			t.Errorf("filename(%q) = %q, want %q", tc.label, got, tc.want)
+			t.Errorf("claudeFileName(%q, %q) = %q, want %q", email, tc.label, got, tc.want)
 		}
 	}
 }

--- a/sdk/auth/label_test.go
+++ b/sdk/auth/label_test.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateLabel(t *testing.T) {
+	valid := []string{"work", "org-2", "my_team", "ABC", "a1b2", "x"}
+	for _, label := range valid {
+		if err := ValidateLabel(label); err != nil {
+			t.Errorf("ValidateLabel(%q) unexpected error: %v", label, err)
+		}
+	}
+
+	invalid := []string{"a/b", "foo bar", "../etc", "org@home", "label!", "a:b"}
+	for _, label := range invalid {
+		if err := ValidateLabel(label); err == nil {
+			t.Errorf("ValidateLabel(%q) expected error, got nil", label)
+		}
+	}
+
+	// empty string is always valid (no-label path)
+	if err := ValidateLabel(""); err != nil {
+		t.Errorf("ValidateLabel(\"\") unexpected error: %v", err)
+	}
+
+	// length cap
+	long := strings.Repeat("a", 33)
+	if err := ValidateLabel(long); err == nil {
+		t.Errorf("ValidateLabel(%q) expected error for >32 chars, got nil", long)
+	}
+	exactly32 := strings.Repeat("a", 32)
+	if err := ValidateLabel(exactly32); err != nil {
+		t.Errorf("ValidateLabel(%q) unexpected error at exactly 32 chars: %v", exactly32, err)
+	}
+}
+
+func TestClaudeFilenameConstruction(t *testing.T) {
+	email := "user@example.com"
+
+	// no label: claude-<email>.json
+	withoutLabel := func(email, label string) string {
+		if label != "" {
+			return "claude-" + email + "-" + label + ".json"
+		}
+		return "claude-" + email + ".json"
+	}
+
+	cases := []struct {
+		label string
+		want  string
+	}{
+		{"", "claude-user@example.com.json"},
+		{"work", "claude-user@example.com-work.json"},
+		{"org-2", "claude-user@example.com-org-2.json"},
+		{"my_team", "claude-user@example.com-my_team.json"},
+	}
+	for _, tc := range cases {
+		got := withoutLabel(email, tc.label)
+		if got != tc.want {
+			t.Errorf("filename(%q) = %q, want %q", tc.label, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Users with multiple Claude organizations need to log in to each one
independently. Without this, running `-claude-login` a second time
overwrites `claude-<email>.json`, invalidating the first session.

This adds a `Label` field to `LoginOptions` (both the `sdk/auth` and
`internal/cmd` layers) and a `-claude-label` CLI flag. When set, the
auth file is named `claude-<email>-<label>.json` instead of
`claude-<email>.json`, so multiple org tokens can coexist in one
auth-dir.

Usage:

```
# personal org (default, no change)
./CLIProxyAPIPlus -claude-login

# work org
./CLIProxyAPIPlus -claude-login -claude-label work
```

Both files live in the same `auth-dir` and are picked up independently
by the conductor.
