### PR TITLE
feat(observability): expose upstream request/response data in gin context

### DIFF
--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -605,6 +605,37 @@ func extractFirstUserText(body []byte) string {
 		}
 	}
 
+	// Responses API (Codex): input as string or input[].content[].text
+	if input := gjson.GetBytes(body, "input"); input.Exists() {
+		var text string
+		if input.Type == gjson.String {
+			text = strings.TrimSpace(input.String())
+		} else if input.IsArray() {
+			input.ForEach(func(_, item gjson.Result) bool {
+				if role := item.Get("role").String(); role != "" && role != "user" {
+					return true
+				}
+				item.Get("content").ForEach(func(_, block gjson.Result) bool {
+					if block.Get("type").String() == "input_text" {
+						if t := strings.TrimSpace(block.Get("text").String()); t != "" {
+							text = t
+							return false
+						}
+					}
+					return true
+				})
+				return text == ""
+			})
+		}
+		if text != "" {
+			const maxLen = 2000
+			if len(text) > maxLen {
+				text = text[:maxLen] + "..."
+			}
+			return text
+		}
+	}
+
 	// Anthropic/OpenAI: messages[].content
 	messages := gjson.GetBytes(body, "messages")
 	if !messages.Exists() || !messages.IsArray() {
@@ -702,6 +733,10 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 			if gjson.GetBytes(data, "type").String() != "response.output_text.delta" {
 				delta = ""
 			}
+		}
+		if delta == "" {
+			// Gemini streaming: response.candidates[0].content.parts[0].text
+			delta = gjson.GetBytes(data, "response.candidates.0.content.parts.0.text").String()
 		}
 		if delta == "" {
 			continue

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -732,6 +732,21 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 		if text == "" {
 			text = gjson.GetBytes(chunk, "response.candidates.0.content.parts.0.text").String()
 		}
+		// Codex Responses API: top-level output[].content[].text (compact/non-streaming)
+		if text == "" {
+			gjson.GetBytes(chunk, "output").ForEach(func(_, item gjson.Result) bool {
+				item.Get("content").ForEach(func(_, block gjson.Result) bool {
+					if block.Get("type").String() == "output_text" {
+						if t := strings.TrimSpace(block.Get("text").String()); t != "" {
+							text = t
+							return false
+						}
+					}
+					return true
+				})
+				return text == ""
+			})
+		}
 		// Codex Responses API: response.completed event - response.output[].content[].text
 		if text == "" {
 			gjson.GetBytes(chunk, "response.output").ForEach(func(_, item gjson.Result) bool {

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -25,6 +25,12 @@ const (
 	apiResponseKey          = "API_RESPONSE"
 	apiWebsocketTimelineKey = "API_WEBSOCKET_TIMELINE"
 	creditsUsedKey          = "__antigravity_credits_used__"
+
+	// Context keys written regardless of RequestLog; available to plugins and middleware.
+	UpstreamURLKey          = "upstream_url"
+	UpstreamFirstUserMsgKey = "upstream_first_user_msg"
+	UpstreamResponseTextKey = "upstream_response_text"
+	UpstreamRawUsageKey     = "upstream_raw_usage"
 )
 
 // UpstreamRequestLog captures the outbound upstream request details for logging.
@@ -55,6 +61,18 @@ type upstreamAttempt struct {
 
 // RecordAPIRequest stores the upstream request metadata in Gin context for request logging.
 func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequestLog) {
+	// Always-on: store the upstream URL and first user message for plugins.
+	if ginCtx := ginContextFrom(ctx); ginCtx != nil {
+		if info.URL != "" {
+			ginCtx.Set(UpstreamURLKey, info.URL)
+		}
+		if len(info.Body) > 0 {
+			if msg := extractFirstUserText(info.Body); msg != "" {
+				ginCtx.Set(UpstreamFirstUserMsgKey, msg)
+			}
+		}
+	}
+
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}
@@ -153,6 +171,11 @@ func RecordAPIResponseError(ctx context.Context, cfg *config.Config, err error) 
 
 // AppendAPIResponseChunk appends an upstream response chunk to Gin context for request logging.
 func AppendAPIResponseChunk(ctx context.Context, cfg *config.Config, chunk []byte) {
+	// Always-on: accumulate response text for plugins.
+	if ginCtx := ginContextFrom(ctx); ginCtx != nil {
+		accumulateResponseText(ginCtx, chunk)
+	}
+
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}
@@ -546,6 +569,134 @@ func extractHTMLTitle(body []byte) string {
 		return ""
 	}
 	return strings.Join(strings.Fields(title), " ")
+}
+
+// extractFirstUserText returns the text of the first user message in an
+// Anthropic /v1/messages JSON body. Returns empty string on any parse error.
+func extractFirstUserText(body []byte) string {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return ""
+	}
+	var text string
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "user" {
+			return true
+		}
+		content := msg.Get("content")
+		if content.IsArray() {
+			content.ForEach(func(_, block gjson.Result) bool {
+				if block.Get("type").String() == "text" {
+					t := strings.TrimSpace(block.Get("text").String())
+					if t != "" {
+						text = t
+						return false
+					}
+				}
+				return true
+			})
+		} else if content.Type == gjson.String {
+			text = strings.TrimSpace(content.String())
+		}
+		return false
+	})
+	const maxLen = 2000
+	if len(text) > maxLen {
+		text = text[:maxLen] + "..."
+	}
+	return text
+}
+
+// accumulateResponseText appends text content from SSE chunks or a full JSON
+// body into UpstreamResponseTextKey and usage counters into UpstreamRawUsageKey.
+func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
+	chunk = bytes.TrimSpace(chunk)
+	if len(chunk) == 0 {
+		return
+	}
+	// Non-streaming: full JSON body.
+	if bytes.HasPrefix(chunk, []byte("{")) {
+		accumulateUsage(ginCtx, chunk)
+		text := gjson.GetBytes(chunk, "content.0.text").String()
+		if text == "" {
+			text = gjson.GetBytes(chunk, "content.#.text").String()
+		}
+		if text != "" {
+			const maxLen = 4000
+			if len(text) > maxLen {
+				text = text[:maxLen] + "..."
+			}
+			ginCtx.Set(UpstreamResponseTextKey, text)
+		}
+		return
+	}
+	// Streaming SSE: one TCP chunk may carry multiple events.
+	for _, line := range bytes.Split(chunk, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if len(data) == 0 || bytes.Equal(data, []byte("[DONE]")) {
+			continue
+		}
+		accumulateUsage(ginCtx, data)
+		ev := gjson.GetBytes(data, "delta")
+		if !ev.Exists() || ev.Get("type").String() != "text_delta" {
+			continue
+		}
+		delta := ev.Get("text").String()
+		if delta == "" {
+			continue
+		}
+		var current string
+		if v, ok := ginCtx.Get(UpstreamResponseTextKey); ok {
+			if s, ok := v.(string); ok {
+				current = s
+			}
+		}
+		const maxLen = 4000
+		if len(current) < maxLen {
+			current += delta
+			if len(current) > maxLen {
+				current = current[:maxLen] + "..."
+			}
+			ginCtx.Set(UpstreamResponseTextKey, current)
+		}
+	}
+}
+
+func accumulateUsage(ginCtx *gin.Context, data []byte) {
+	usage := gjson.GetBytes(data, "usage")
+	if !usage.Exists() {
+		return
+	}
+	current := map[string]int64{}
+	if v, ok := ginCtx.Get(UpstreamRawUsageKey); ok {
+		if m, ok := v.(map[string]int64); ok {
+			for k, val := range m {
+				current[k] = val
+			}
+		}
+	}
+	setMax := func(key string) {
+		if r := usage.Get(key); r.Exists() {
+			if v := r.Int(); v > current[key] {
+				current[key] = v
+			}
+		}
+	}
+	for _, key := range []string{
+		"input_tokens", "output_tokens",
+		"cache_read_input_tokens", "cache_creation_input_tokens",
+		"reasoning_tokens", "total_tokens",
+	} {
+		setMax(key)
+	}
+	if current["total_tokens"] == 0 {
+		current["total_tokens"] = current["input_tokens"] + current["output_tokens"] + current["reasoning_tokens"]
+	}
+	ginCtx.Set(UpstreamRawUsageKey, current)
 }
 
 // extractJSONErrorMessage attempts to extract error.message from JSON error responses

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -62,7 +62,11 @@ type upstreamAttempt struct {
 // RecordAPIRequest stores the upstream request metadata in Gin context for request logging.
 func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequestLog) {
 	// Always-on: store the upstream URL and first user message for plugins.
+	// Response and usage keys are reset here so retried attempts do not mix
+	// data from a failed attempt with the final response.
 	if ginCtx := ginContextFrom(ctx); ginCtx != nil {
+		ginCtx.Set(UpstreamResponseTextKey, "")
+		ginCtx.Set(UpstreamRawUsageKey, nil)
 		if info.URL != "" {
 			ginCtx.Set(UpstreamURLKey, info.URL)
 		}
@@ -614,15 +618,20 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 	if len(chunk) == 0 {
 		return
 	}
+	const maxLen = 4000
 	// Non-streaming: full JSON body.
 	if bytes.HasPrefix(chunk, []byte("{")) {
 		accumulateUsage(ginCtx, chunk)
+		// Anthropic: content[0].text
 		text := gjson.GetBytes(chunk, "content.0.text").String()
 		if text == "" {
 			text = gjson.GetBytes(chunk, "content.#.text").String()
 		}
+		// OpenAI-compatible: choices[0].message.content
+		if text == "" {
+			text = gjson.GetBytes(chunk, "choices.0.message.content").String()
+		}
 		if text != "" {
-			const maxLen = 4000
 			if len(text) > maxLen {
 				text = text[:maxLen] + "..."
 			}
@@ -631,6 +640,14 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 		return
 	}
 	// Streaming SSE: one TCP chunk may carry multiple events.
+	// Read current value once and write back only if changed.
+	var current string
+	if v, ok := ginCtx.Get(UpstreamResponseTextKey); ok {
+		if s, ok := v.(string); ok {
+			current = s
+		}
+	}
+	updated := false
 	for _, line := range bytes.Split(chunk, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if !bytes.HasPrefix(line, []byte("data:")) {
@@ -641,28 +658,25 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 			continue
 		}
 		accumulateUsage(ginCtx, data)
-		ev := gjson.GetBytes(data, "delta")
-		if !ev.Exists() || ev.Get("type").String() != "text_delta" {
-			continue
+		// Anthropic: delta.type == "text_delta", delta.text
+		delta := gjson.GetBytes(data, "delta.text").String()
+		if delta == "" {
+			// OpenAI-compatible: choices[0].delta.content
+			delta = gjson.GetBytes(data, "choices.0.delta.content").String()
 		}
-		delta := ev.Get("text").String()
 		if delta == "" {
 			continue
 		}
-		var current string
-		if v, ok := ginCtx.Get(UpstreamResponseTextKey); ok {
-			if s, ok := v.(string); ok {
-				current = s
-			}
-		}
-		const maxLen = 4000
 		if len(current) < maxLen {
 			current += delta
 			if len(current) > maxLen {
 				current = current[:maxLen] + "..."
 			}
-			ginCtx.Set(UpstreamResponseTextKey, current)
+			updated = true
 		}
+	}
+	if updated {
+		ginCtx.Set(UpstreamResponseTextKey, current)
 	}
 }
 
@@ -687,14 +701,18 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 		}
 	}
 	for _, key := range []string{
+		// Anthropic
 		"input_tokens", "output_tokens",
 		"cache_read_input_tokens", "cache_creation_input_tokens",
 		"reasoning_tokens", "total_tokens",
+		// OpenAI-compatible
+		"prompt_tokens", "completion_tokens",
 	} {
 		setMax(key)
 	}
 	if current["total_tokens"] == 0 {
-		current["total_tokens"] = current["input_tokens"] + current["output_tokens"] + current["reasoning_tokens"]
+		current["total_tokens"] = current["input_tokens"] + current["output_tokens"] +
+			current["prompt_tokens"] + current["completion_tokens"] + current["reasoning_tokens"]
 	}
 	ginCtx.Set(UpstreamRawUsageKey, current)
 }

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -732,6 +732,21 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 		if text == "" {
 			text = gjson.GetBytes(chunk, "response.candidates.0.content.parts.0.text").String()
 		}
+		// Codex Responses API: response.completed event - response.output[].content[].text
+		if text == "" {
+			gjson.GetBytes(chunk, "response.output").ForEach(func(_, item gjson.Result) bool {
+				item.Get("content").ForEach(func(_, block gjson.Result) bool {
+					if block.Get("type").String() == "output_text" {
+						if t := strings.TrimSpace(block.Get("text").String()); t != "" {
+							text = t
+							return false
+						}
+					}
+					return true
+				})
+				return text == ""
+			})
+		}
 		if text != "" {
 			if len(text) > maxLen {
 				text = text[:maxLen] + "..."

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -888,15 +888,21 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 		setMax(key)
 	}
 	// OpenAI nested details: prompt_tokens_details.cached_tokens,
-	// output_tokens_details.reasoning_tokens, etc.
+	// output_tokens_details.reasoning_tokens (Responses API),
+	// completion_tokens_details.reasoning_tokens (chat completions).
 	if r := usage.Get("prompt_tokens_details.cached_tokens"); r.Exists() {
 		if v := r.Int(); v > current["cache_read_input_tokens"] {
 			current["cache_read_input_tokens"] = v
 		}
 	}
-	if r := usage.Get("output_tokens_details.reasoning_tokens"); r.Exists() {
-		if v := r.Int(); v > current["reasoning_tokens"] {
-			current["reasoning_tokens"] = v
+	for _, path := range []string{
+		"output_tokens_details.reasoning_tokens",
+		"completion_tokens_details.reasoning_tokens",
+	} {
+		if r := usage.Get(path); r.Exists() {
+			if v := r.Int(); v > current["reasoning_tokens"] {
+				current["reasoning_tokens"] = v
+			}
 		}
 	}
 	// Derive total_tokens from input + output when the upstream omits it or

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -816,9 +816,14 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 	if !usage.Exists() {
 		usage = gjson.GetBytes(data, "usage")
 	}
+	// Claude streaming: message_start event carries usage under message.usage.
+	if !usage.Exists() {
+		usage = gjson.GetBytes(data, "message.usage")
+	}
 	if !usage.Exists() {
 		// Check Gemini usageMetadata path before giving up.
-		if !gjson.GetBytes(data, "usageMetadata").Exists() {
+		if !gjson.GetBytes(data, "usageMetadata").Exists() &&
+			!gjson.GetBytes(data, "response.usageMetadata").Exists() {
 			return
 		}
 	}
@@ -846,6 +851,18 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 		"prompt_tokens", "completion_tokens",
 	} {
 		setMax(key)
+	}
+	// OpenAI nested details: prompt_tokens_details.cached_tokens,
+	// output_tokens_details.reasoning_tokens, etc.
+	if r := usage.Get("prompt_tokens_details.cached_tokens"); r.Exists() {
+		if v := r.Int(); v > current["cache_read_input_tokens"] {
+			current["cache_read_input_tokens"] = v
+		}
+	}
+	if r := usage.Get("output_tokens_details.reasoning_tokens"); r.Exists() {
+		if v := r.Int(); v > current["reasoning_tokens"] {
+			current["reasoning_tokens"] = v
+		}
 	}
 	// Always recompute derived total so late-arriving output_tokens events
 	// don't leave total_tokens stale from an earlier partial usage event.

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -575,9 +575,37 @@ func extractHTMLTitle(body []byte) string {
 	return strings.Join(strings.Fields(title), " ")
 }
 
-// extractFirstUserText returns the text of the first user message in an
-// Anthropic /v1/messages JSON body. Returns empty string on any parse error.
+// extractFirstUserText returns the text of the first user message in a
+// request body. Supports Anthropic /v1/messages and Gemini /generateContent
+// formats. Returns empty string on any parse error.
 func extractFirstUserText(body []byte) string {
+	// Gemini: contents[].parts[].text (role=user or no role)
+	if contents := gjson.GetBytes(body, "contents"); contents.Exists() && contents.IsArray() {
+		var text string
+		contents.ForEach(func(_, item gjson.Result) bool {
+			role := item.Get("role").String()
+			if role != "" && role != "user" {
+				return true
+			}
+			item.Get("parts").ForEach(func(_, part gjson.Result) bool {
+				if t := strings.TrimSpace(part.Get("text").String()); t != "" {
+					text = t
+					return false
+				}
+				return true
+			})
+			return text == ""
+		})
+		if text != "" {
+			const maxLen = 2000
+			if len(text) > maxLen {
+				text = text[:maxLen] + "..."
+			}
+			return text
+		}
+	}
+
+	// Anthropic/OpenAI: messages[].content
 	messages := gjson.GetBytes(body, "messages")
 	if !messages.Exists() || !messages.IsArray() {
 		return ""
@@ -725,6 +753,21 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 		current["total_tokens"] = current["input_tokens"] + current["output_tokens"] +
 			current["prompt_tokens"] + current["completion_tokens"] + current["reasoning_tokens"]
 	}
+
+	// Gemini usageMetadata lives at the top level, not under "usage".
+	if meta := gjson.GetBytes(data, "usageMetadata"); meta.Exists() {
+		setFromPath := func(key, path string) {
+			if r := meta.Get(path); r.Exists() {
+				if v := r.Int(); v > current[key] {
+					current[key] = v
+				}
+			}
+		}
+		setFromPath("prompt_tokens", "promptTokenCount")
+		setFromPath("completion_tokens", "candidatesTokenCount")
+		setFromPath("total_tokens", "totalTokenCount")
+	}
+
 	ginCtx.Set(UpstreamRawUsageKey, current)
 }
 

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -749,6 +749,7 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 		}
 	}
 	updated := false
+	sawOutputTextDelta := false
 	for _, line := range bytes.Split(chunk, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if !bytes.HasPrefix(line, []byte("data:")) {
@@ -767,13 +768,17 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 		}
 		if delta == "" {
 			// Responses API (Codex): response.output_text.delta
-			delta = gjson.GetBytes(data, "delta").String()
-			if gjson.GetBytes(data, "type").String() != "response.output_text.delta" {
-				delta = ""
+			if gjson.GetBytes(data, "type").String() == "response.output_text.delta" {
+				delta = gjson.GetBytes(data, "delta").String()
+				if delta != "" {
+					sawOutputTextDelta = true
+				}
 			}
 		}
-		if delta == "" {
-			// Responses API (Codex): response.output_item.done - final text in item.content[].text
+		if delta == "" && !sawOutputTextDelta {
+			// Responses API (Codex): response.output_item.done - final text in item.content[].text.
+			// Only use when no output_text.delta events were seen; otherwise the
+			// full text is already accumulated from deltas and this would duplicate it.
 			if gjson.GetBytes(data, "type").String() == "response.output_item.done" {
 				gjson.GetBytes(data, "item.content").ForEach(func(_, block gjson.Result) bool {
 					if block.Get("type").String() == "output_text" {
@@ -864,10 +869,12 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 			current["reasoning_tokens"] = v
 		}
 	}
-	// Always recompute derived total so late-arriving output_tokens events
-	// don't leave total_tokens stale from an earlier partial usage event.
+	// Derive total_tokens from input + output when the upstream omits it or
+	// when a late SSE event raises output_tokens without updating total_tokens.
+	// reasoning_tokens is a subset of output_tokens/completion_tokens, so it
+	// must NOT be added again here lest we double-count it.
 	if derived := current["input_tokens"] + current["output_tokens"] +
-		current["prompt_tokens"] + current["completion_tokens"] + current["reasoning_tokens"]; derived > current["total_tokens"] {
+		current["prompt_tokens"] + current["completion_tokens"]; derived > current["total_tokens"] {
 		current["total_tokens"] = derived
 	}
 

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -690,9 +690,13 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 		if text == "" {
 			text = gjson.GetBytes(chunk, "choices.0.message.content").String()
 		}
-		// Gemini/Vertex: candidates[0].content.parts[0].text
+		// Gemini/Vertex non-streaming: candidates[0].content.parts[0].text
 		if text == "" {
 			text = gjson.GetBytes(chunk, "candidates.0.content.parts.0.text").String()
+		}
+		// Antigravity wrapper: response.candidates[0].content.parts[0].text
+		if text == "" {
+			text = gjson.GetBytes(chunk, "response.candidates.0.content.parts.0.text").String()
 		}
 		if text != "" {
 			if len(text) > maxLen {
@@ -735,7 +739,11 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 			}
 		}
 		if delta == "" {
-			// Gemini streaming: response.candidates[0].content.parts[0].text
+			// Gemini SSE (native): candidates[0].content.parts[0].text
+			delta = gjson.GetBytes(data, "candidates.0.content.parts.0.text").String()
+		}
+		if delta == "" {
+			// Gemini SSE (Antigravity wrapper): response.candidates[0].content.parts[0].text
 			delta = gjson.GetBytes(data, "response.candidates.0.content.parts.0.text").String()
 		}
 		if delta == "" {

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -747,6 +747,20 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 			}
 		}
 		if delta == "" {
+			// Responses API (Codex): response.output_item.done - final text in item.content[].text
+			if gjson.GetBytes(data, "type").String() == "response.output_item.done" {
+				gjson.GetBytes(data, "item.content").ForEach(func(_, block gjson.Result) bool {
+					if block.Get("type").String() == "output_text" {
+						if t := strings.TrimSpace(block.Get("text").String()); t != "" {
+							delta = t
+							return false
+						}
+					}
+					return true
+				})
+			}
+		}
+		if delta == "" {
 			// Gemini SSE (native): candidates[0].content.parts[0].text
 			delta = gjson.GetBytes(data, "candidates.0.content.parts.0.text").String()
 		}

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -222,10 +222,22 @@ func AppendAPIResponseChunk(ctx context.Context, cfg *config.Config, chunk []byt
 
 // RecordAPIWebsocketRequest stores an upstream websocket request event in Gin context.
 func RecordAPIWebsocketRequest(ctx context.Context, cfg *config.Config, info UpstreamRequestLog) {
+	ginCtx := ginContextFrom(ctx)
+	if ginCtx != nil {
+		// Always-on: populate context keys for plugins regardless of RequestLog.
+		ginCtx.Set(UpstreamRawUsageKey, nil)
+		if info.URL != "" {
+			ginCtx.Set(UpstreamURLKey, info.URL)
+		}
+		if len(info.Body) > 0 {
+			if msg := extractFirstUserText(info.Body); msg != "" {
+				ginCtx.Set(UpstreamFirstUserMsgKey, msg)
+			}
+		}
+	}
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}
-	ginCtx := ginContextFrom(ctx)
 	if ginCtx == nil {
 		return
 	}

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -631,6 +631,10 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 		if text == "" {
 			text = gjson.GetBytes(chunk, "choices.0.message.content").String()
 		}
+		// Gemini/Vertex: candidates[0].content.parts[0].text
+		if text == "" {
+			text = gjson.GetBytes(chunk, "candidates.0.content.parts.0.text").String()
+		}
 		if text != "" {
 			if len(text) > maxLen {
 				text = text[:maxLen] + "..."
@@ -658,11 +662,18 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 			continue
 		}
 		accumulateUsage(ginCtx, data)
-		// Anthropic: delta.type == "text_delta", delta.text
+		// Anthropic: delta.text
 		delta := gjson.GetBytes(data, "delta.text").String()
 		if delta == "" {
 			// OpenAI-compatible: choices[0].delta.content
 			delta = gjson.GetBytes(data, "choices.0.delta.content").String()
+		}
+		if delta == "" {
+			// Responses API (Codex): response.output_text.delta
+			delta = gjson.GetBytes(data, "delta").String()
+			if gjson.GetBytes(data, "type").String() != "response.output_text.delta" {
+				delta = ""
+			}
 		}
 		if delta == "" {
 			continue

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -755,9 +755,16 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 }
 
 func accumulateUsage(ginCtx *gin.Context, data []byte) {
-	usage := gjson.GetBytes(data, "usage")
+	// Responses API: response.completed event carries usage under response.usage.
+	usage := gjson.GetBytes(data, "response.usage")
 	if !usage.Exists() {
-		return
+		usage = gjson.GetBytes(data, "usage")
+	}
+	if !usage.Exists() {
+		// Check Gemini usageMetadata path before giving up.
+		if !gjson.GetBytes(data, "usageMetadata").Exists() {
+			return
+		}
 	}
 	current := map[string]int64{}
 	if v, ok := ginCtx.Get(UpstreamRawUsageKey); ok {

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -579,6 +579,32 @@ func extractHTMLTitle(body []byte) string {
 // request body. Supports Anthropic /v1/messages and Gemini /generateContent
 // formats. Returns empty string on any parse error.
 func extractFirstUserText(body []byte) string {
+	// Antigravity: request.contents[].parts[].text
+	if contents := gjson.GetBytes(body, "request.contents"); contents.Exists() && contents.IsArray() {
+		var text string
+		contents.ForEach(func(_, item gjson.Result) bool {
+			role := item.Get("role").String()
+			if role != "" && role != "user" {
+				return true
+			}
+			item.Get("parts").ForEach(func(_, part gjson.Result) bool {
+				if t := strings.TrimSpace(part.Get("text").String()); t != "" {
+					text = t
+					return false
+				}
+				return true
+			})
+			return text == ""
+		})
+		if text != "" {
+			const maxLen = 2000
+			if len(text) > maxLen {
+				text = text[:maxLen] + "..."
+			}
+			return text
+		}
+	}
+
 	// Gemini: contents[].parts[].text (role=user or no role)
 	if contents := gjson.GetBytes(body, "contents"); contents.Exists() && contents.IsArray() {
 		var text string
@@ -826,6 +852,20 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 	if derived := current["input_tokens"] + current["output_tokens"] +
 		current["prompt_tokens"] + current["completion_tokens"] + current["reasoning_tokens"]; derived > current["total_tokens"] {
 		current["total_tokens"] = derived
+	}
+
+	// Antigravity wrapper: response.usageMetadata
+	if meta := gjson.GetBytes(data, "response.usageMetadata"); meta.Exists() {
+		setFromPath := func(key, path string) {
+			if r := meta.Get(path); r.Exists() {
+				if v := r.Int(); v > current[key] {
+					current[key] = v
+				}
+			}
+		}
+		setFromPath("prompt_tokens", "promptTokenCount")
+		setFromPath("completion_tokens", "candidatesTokenCount")
+		setFromPath("total_tokens", "totalTokenCount")
 	}
 
 	// Gemini usageMetadata lives at the top level, not under "usage".

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -681,11 +681,19 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 	// Non-streaming: full JSON body.
 	if bytes.HasPrefix(chunk, []byte("{")) {
 		accumulateUsage(ginCtx, chunk)
-		// Anthropic: content[0].text
-		text := gjson.GetBytes(chunk, "content.0.text").String()
-		if text == "" {
-			text = gjson.GetBytes(chunk, "content.#.text").String()
-		}
+		// Anthropic: walk content blocks to find the first text block.
+		// content[0].text misses responses where a thinking/tool block
+		// comes first; content.#.text returns a JSON array, not a string.
+		var text string
+		gjson.GetBytes(chunk, "content").ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() == "text" {
+				if t := strings.TrimSpace(block.Get("text").String()); t != "" {
+					text = t
+					return false
+				}
+			}
+			return true
+		})
 		// OpenAI-compatible: choices[0].message.content
 		if text == "" {
 			text = gjson.GetBytes(chunk, "choices.0.message.content").String()
@@ -799,9 +807,11 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 	} {
 		setMax(key)
 	}
-	if current["total_tokens"] == 0 {
-		current["total_tokens"] = current["input_tokens"] + current["output_tokens"] +
-			current["prompt_tokens"] + current["completion_tokens"] + current["reasoning_tokens"]
+	// Always recompute derived total so late-arriving output_tokens events
+	// don't leave total_tokens stale from an earlier partial usage event.
+	if derived := current["input_tokens"] + current["output_tokens"] +
+		current["prompt_tokens"] + current["completion_tokens"] + current["reasoning_tokens"]; derived > current["total_tokens"] {
+		current["total_tokens"] = derived
 	}
 
 	// Gemini usageMetadata lives at the top level, not under "usage".

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -323,14 +323,18 @@ func WebsocketUpgradeRequestURL(rawURL string) string {
 
 // AppendAPIWebsocketResponse stores an upstream websocket response frame in Gin context.
 func AppendAPIWebsocketResponse(ctx context.Context, cfg *config.Config, payload []byte) {
-	if cfg == nil || !cfg.RequestLog {
-		return
-	}
 	data := bytes.TrimSpace(payload)
 	if len(data) == 0 {
 		return
 	}
 	ginCtx := ginContextFrom(ctx)
+	if ginCtx != nil {
+		// Always-on: accumulate response text and usage for plugins.
+		accumulateResponseText(ginCtx, data)
+	}
+	if cfg == nil || !cfg.RequestLog {
+		return
+	}
 	if ginCtx == nil {
 		return
 	}

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -31,6 +31,10 @@ const (
 	UpstreamFirstUserMsgKey = "upstream_first_user_msg"
 	UpstreamResponseTextKey = "upstream_response_text"
 	UpstreamRawUsageKey     = "upstream_raw_usage"
+
+	// Private keys used by accumulateResponseText; reset alongside public keys on retry.
+	responseTextBuilderKey  = "upstream_response_text_builder"
+	sawOutputTextDeltaKey   = "upstream_saw_output_text_delta"
 )
 
 // UpstreamRequestLog captures the outbound upstream request details for logging.
@@ -67,6 +71,9 @@ func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequ
 	if ginCtx := ginContextFrom(ctx); ginCtx != nil {
 		ginCtx.Set(UpstreamResponseTextKey, "")
 		ginCtx.Set(UpstreamRawUsageKey, nil)
+		// Reset private streaming accumulators so a retry starts clean.
+		ginCtx.Set(responseTextBuilderKey, nil)
+		ginCtx.Set(sawOutputTextDeltaKey, false)
 		if info.URL != "" {
 			ginCtx.Set(UpstreamURLKey, info.URL)
 		}
@@ -331,7 +338,12 @@ func AppendAPIWebsocketResponse(ctx context.Context, cfg *config.Config, payload
 	ginCtx := ginContextFrom(ctx)
 	if ginCtx != nil {
 		// Always-on: accumulate response text and usage for plugins.
-		accumulateResponseText(ginCtx, data)
+		// Websocket frames are raw JSON objects, not SSE lines. Wrap in
+		// SSE format so accumulateResponseText takes the streaming path
+		// and correctly handles Codex delta/done event types.
+		sse := append([]byte("data: "), data...)
+		sse = append(sse, '\n', '\n')
+		accumulateResponseText(ginCtx, sse)
 	}
 	if cfg == nil || !cfg.RequestLog {
 		return
@@ -790,19 +802,17 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 	// Streaming SSE: one TCP chunk may carry multiple events.
 	// Use a *strings.Builder stored in the gin context to avoid O(n²)
 	// allocations from repeated string concatenation across chunks.
-	const builderKey = "upstream_response_text_builder"
 	var sb *strings.Builder
-	if v, ok := ginCtx.Get(builderKey); ok {
+	if v, ok := ginCtx.Get(responseTextBuilderKey); ok {
 		sb, _ = v.(*strings.Builder)
 	}
 	if sb == nil {
 		sb = &strings.Builder{}
-		ginCtx.Set(builderKey, sb)
+		ginCtx.Set(responseTextBuilderKey, sb)
 	}
 	updated := false
-	const sawDeltaKey = "upstream_saw_output_text_delta"
 	sawOutputTextDelta := false
-	if v, ok := ginCtx.Get(sawDeltaKey); ok {
+	if v, ok := ginCtx.Get(sawOutputTextDeltaKey); ok {
 		sawOutputTextDelta, _ = v.(bool)
 	}
 	for _, line := range bytes.Split(chunk, []byte("\n")) {
@@ -831,7 +841,7 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 				delta = gjson.GetBytes(data, "delta").String()
 				if delta != "" {
 					sawOutputTextDelta = true
-					ginCtx.Set(sawDeltaKey, true)
+					ginCtx.Set(sawOutputTextDeltaKey, true)
 				}
 			}
 		}

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -976,6 +976,7 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 		}
 	}
 	// Antigravity wrapper: response.usageMetadata / response.usage_metadata
+	var sawGeminiMeta bool
 	for _, metaKey := range []string{"response.usageMetadata", "response.usage_metadata"} {
 		if meta := gjson.GetBytes(data, metaKey); meta.Exists() {
 			setFromPath := func(key, path string) {
@@ -990,6 +991,7 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 			setFromPath("total_tokens", "totalTokenCount")
 			setFromPath("reasoning_tokens", "thoughtsTokenCount")
 			setFromPath("cache_read_input_tokens", "cachedContentTokenCount")
+			sawGeminiMeta = true
 			break
 		}
 	}
@@ -1009,6 +1011,7 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 			setFromPath("total_tokens", "totalTokenCount")
 			setFromPath("reasoning_tokens", "thoughtsTokenCount")
 			setFromPath("cache_read_input_tokens", "cachedContentTokenCount")
+			sawGeminiMeta = true
 			break
 		}
 	}
@@ -1026,12 +1029,11 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 		outputSide = current["completion_tokens"]
 	}
 	// For Gemini, reasoning_tokens (thoughtsTokenCount) is separate from
-	// candidatesTokenCount and must be included. For OpenAI, reasoning_tokens
-	// is already a subset of output/completion and must not be added again.
-	// Heuristic: include it only when there are no output/completion tokens
-	// (pure Gemini metadata path where only prompt+candidates+thoughts exist).
+	// candidatesTokenCount and must be included in the fallback total.
+	// For OpenAI, reasoning_tokens is already a subset of output/completion
+	// and must not be added again. Use sawGeminiMeta to distinguish.
 	reasoningSide := int64(0)
-	if outputSide == 0 {
+	if sawGeminiMeta {
 		reasoningSide = current["reasoning_tokens"]
 	}
 	if derived := inputSide + outputSide + reasoningSide; derived > current["total_tokens"] {

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -338,16 +338,18 @@ func AppendAPIWebsocketResponse(ctx context.Context, cfg *config.Config, payload
 	ginCtx := ginContextFrom(ctx)
 	if ginCtx != nil {
 		// Always-on: accumulate response text and usage for plugins.
-		// Websocket frames are raw JSON objects. First try the non-streaming
-		// path (handles response.completed with response.output[]) then wrap
-		// as SSE so delta/done event types reach the streaming branch.
-		accumulateResponseText(ginCtx, data)
-		// Only wrap as SSE if no text was captured by the non-streaming pass,
-		// to avoid double-accumulation for completed frames.
-		if s, _ := ginCtx.Get(UpstreamResponseTextKey); s == "" || s == nil {
+		// Websocket frames are raw JSON objects. Route by event type:
+		// - Streaming events (response.output_text.delta, response.output_item.done)
+		//   must go through the SSE path so the streaming branch handles them.
+		// - Completed/non-streaming frames (response.completed with response.output[])
+		//   must go through the non-streaming path.
+		eventType := gjson.GetBytes(data, "type").String()
+		if eventType == "response.output_text.delta" || eventType == "response.output_item.done" {
 			sse := append([]byte("data: "), data...)
 			sse = append(sse, '\n', '\n')
 			accumulateResponseText(ginCtx, sse)
+		} else {
+			accumulateResponseText(ginCtx, data)
 		}
 	}
 	if cfg == nil || !cfg.RequestLog {

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -606,6 +606,21 @@ func extractHTMLTitle(body []byte) string {
 
 // extractFirstUserText returns the text of the first user message in a
 // request body. Supports Anthropic /v1/messages and Gemini /generateContent
+// geminiPartsText walks a gjson array of Gemini content parts and returns
+// the first non-empty text field. Handles responses where the first part is
+// a function call, inline data, or thought and text appears in a later part.
+func geminiPartsText(parts gjson.Result) string {
+	var text string
+	parts.ForEach(func(_, part gjson.Result) bool {
+		if t := strings.TrimSpace(part.Get("text").String()); t != "" {
+			text = t
+			return false
+		}
+		return true
+	})
+	return text
+}
+
 // formats. Returns empty string on any parse error.
 func extractFirstUserText(body []byte) string {
 	// Antigravity: request.contents[].parts[].text
@@ -753,13 +768,13 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 		if text == "" {
 			text = gjson.GetBytes(chunk, "choices.0.message.content").String()
 		}
-		// Gemini/Vertex non-streaming: candidates[0].content.parts[0].text
+		// Gemini/Vertex non-streaming: walk parts to find first text field.
 		if text == "" {
-			text = gjson.GetBytes(chunk, "candidates.0.content.parts.0.text").String()
+			text = geminiPartsText(gjson.GetBytes(chunk, "candidates.0.content.parts"))
 		}
-		// Antigravity wrapper: response.candidates[0].content.parts[0].text
+		// Antigravity wrapper: response.candidates[0].content.parts[]
 		if text == "" {
-			text = gjson.GetBytes(chunk, "response.candidates.0.content.parts.0.text").String()
+			text = geminiPartsText(gjson.GetBytes(chunk, "response.candidates.0.content.parts"))
 		}
 		// Codex Responses API: top-level output[].content[].text (compact/non-streaming)
 		if text == "" {
@@ -862,12 +877,12 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 			}
 		}
 		if delta == "" {
-			// Gemini SSE (native): candidates[0].content.parts[0].text
-			delta = gjson.GetBytes(data, "candidates.0.content.parts.0.text").String()
+			// Gemini SSE (native): walk parts to find first text field.
+			delta = geminiPartsText(gjson.GetBytes(data, "candidates.0.content.parts"))
 		}
 		if delta == "" {
-			// Gemini SSE (Antigravity wrapper): response.candidates[0].content.parts[0].text
-			delta = gjson.GetBytes(data, "response.candidates.0.content.parts.0.text").String()
+			// Gemini SSE (Antigravity wrapper): response.candidates[0].content.parts[]
+			delta = geminiPartsText(gjson.GetBytes(data, "response.candidates.0.content.parts"))
 		}
 		if delta == "" {
 			continue
@@ -897,9 +912,13 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 		usage = gjson.GetBytes(data, "message.usage")
 	}
 	if !usage.Exists() {
-		// Check Gemini usageMetadata path before giving up.
-		if !gjson.GetBytes(data, "usageMetadata").Exists() &&
-			!gjson.GetBytes(data, "response.usageMetadata").Exists() {
+		// Check Gemini usageMetadata path before giving up (both camelCase
+		// and snake_case variants used by different Gemini/Antigravity paths).
+		hasMetadata := gjson.GetBytes(data, "usageMetadata").Exists() ||
+			gjson.GetBytes(data, "usage_metadata").Exists() ||
+			gjson.GetBytes(data, "response.usageMetadata").Exists() ||
+			gjson.GetBytes(data, "response.usage_metadata").Exists()
+		if !hasMetadata {
 			return
 		}
 	}
@@ -966,36 +985,42 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 		current["total_tokens"] = derived
 	}
 
-	// Antigravity wrapper: response.usageMetadata
-	if meta := gjson.GetBytes(data, "response.usageMetadata"); meta.Exists() {
-		setFromPath := func(key, path string) {
-			if r := meta.Get(path); r.Exists() {
-				if v := r.Int(); v > current[key] {
-					current[key] = v
+	// Antigravity wrapper: response.usageMetadata / response.usage_metadata
+	for _, metaKey := range []string{"response.usageMetadata", "response.usage_metadata"} {
+		if meta := gjson.GetBytes(data, metaKey); meta.Exists() {
+			setFromPath := func(key, path string) {
+				if r := meta.Get(path); r.Exists() {
+					if v := r.Int(); v > current[key] {
+						current[key] = v
+					}
 				}
 			}
+			setFromPath("prompt_tokens", "promptTokenCount")
+			setFromPath("completion_tokens", "candidatesTokenCount")
+			setFromPath("total_tokens", "totalTokenCount")
+			setFromPath("reasoning_tokens", "thoughtsTokenCount")
+			setFromPath("cache_read_input_tokens", "cachedContentTokenCount")
+			break
 		}
-		setFromPath("prompt_tokens", "promptTokenCount")
-		setFromPath("completion_tokens", "candidatesTokenCount")
-		setFromPath("total_tokens", "totalTokenCount")
-		setFromPath("reasoning_tokens", "thoughtsTokenCount")
-		setFromPath("cache_read_input_tokens", "cachedContentTokenCount")
 	}
 
 	// Gemini usageMetadata lives at the top level, not under "usage".
-	if meta := gjson.GetBytes(data, "usageMetadata"); meta.Exists() {
-		setFromPath := func(key, path string) {
-			if r := meta.Get(path); r.Exists() {
-				if v := r.Int(); v > current[key] {
-					current[key] = v
+	for _, metaKey := range []string{"usageMetadata", "usage_metadata"} {
+		if meta := gjson.GetBytes(data, metaKey); meta.Exists() {
+			setFromPath := func(key, path string) {
+				if r := meta.Get(path); r.Exists() {
+					if v := r.Int(); v > current[key] {
+						current[key] = v
+					}
 				}
 			}
+			setFromPath("prompt_tokens", "promptTokenCount")
+			setFromPath("completion_tokens", "candidatesTokenCount")
+			setFromPath("total_tokens", "totalTokenCount")
+			setFromPath("reasoning_tokens", "thoughtsTokenCount")
+			setFromPath("cache_read_input_tokens", "cachedContentTokenCount")
+			break
 		}
-		setFromPath("prompt_tokens", "promptTokenCount")
-		setFromPath("completion_tokens", "candidatesTokenCount")
-		setFromPath("total_tokens", "totalTokenCount")
-		setFromPath("reasoning_tokens", "thoughtsTokenCount")
-		setFromPath("cache_read_input_tokens", "cachedContentTokenCount")
 	}
 
 	ginCtx.Set(UpstreamRawUsageKey, current)

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -693,7 +693,10 @@ func extractFirstUserText(body []byte) string {
 					return true
 				}
 				item.Get("content").ForEach(func(_, block gjson.Result) bool {
-					if block.Get("type").String() == "input_text" {
+					// Accept explicit input_text blocks and blocks with no type
+					// (the Responses converter treats missing type as input_text).
+					blockType := block.Get("type").String()
+					if blockType == "input_text" || blockType == "" {
 						if t := strings.TrimSpace(block.Get("text").String()); t != "" {
 							text = t
 							return false

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -787,15 +787,23 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 		return
 	}
 	// Streaming SSE: one TCP chunk may carry multiple events.
-	// Read current value once and write back only if changed.
-	var current string
-	if v, ok := ginCtx.Get(UpstreamResponseTextKey); ok {
-		if s, ok := v.(string); ok {
-			current = s
-		}
+	// Use a *strings.Builder stored in the gin context to avoid O(n²)
+	// allocations from repeated string concatenation across chunks.
+	const builderKey = "upstream_response_text_builder"
+	var sb *strings.Builder
+	if v, ok := ginCtx.Get(builderKey); ok {
+		sb, _ = v.(*strings.Builder)
+	}
+	if sb == nil {
+		sb = &strings.Builder{}
+		ginCtx.Set(builderKey, sb)
 	}
 	updated := false
+	const sawDeltaKey = "upstream_saw_output_text_delta"
 	sawOutputTextDelta := false
+	if v, ok := ginCtx.Get(sawDeltaKey); ok {
+		sawOutputTextDelta, _ = v.(bool)
+	}
 	for _, line := range bytes.Split(chunk, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if !bytes.HasPrefix(line, []byte("data:")) {
@@ -818,6 +826,7 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 				delta = gjson.GetBytes(data, "delta").String()
 				if delta != "" {
 					sawOutputTextDelta = true
+					ginCtx.Set(sawDeltaKey, true)
 				}
 			}
 		}
@@ -848,16 +857,17 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 		if delta == "" {
 			continue
 		}
-		if len(current) < maxLen {
-			current += delta
-			if len(current) > maxLen {
-				current = current[:maxLen] + "..."
-			}
+		if sb.Len() < maxLen {
+			sb.WriteString(delta)
 			updated = true
 		}
 	}
 	if updated {
-		ginCtx.Set(UpstreamResponseTextKey, current)
+		s := sb.String()
+		if len(s) > maxLen {
+			s = s[:maxLen] + "..."
+		}
+		ginCtx.Set(UpstreamResponseTextKey, s)
 	}
 }
 
@@ -921,12 +931,20 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 			}
 		}
 	}
-	// Derive total_tokens from input + output when the upstream omits it or
-	// when a late SSE event raises output_tokens without updating total_tokens.
-	// reasoning_tokens is a subset of output_tokens/completion_tokens, so it
-	// must NOT be added again here lest we double-count it.
-	if derived := current["input_tokens"] + current["output_tokens"] +
-		current["prompt_tokens"] + current["completion_tokens"]; derived > current["total_tokens"] {
+	// Derive total_tokens when the upstream omits it or a late SSE event
+	// updates a component without updating the total.
+	// Use max(input_tokens, prompt_tokens) + max(output_tokens, completion_tokens)
+	// to avoid double-counting when a provider reports both Anthropic-style and
+	// OpenAI-style fields (e.g. after usageMetadata mapping).
+	inputSide := current["input_tokens"]
+	if current["prompt_tokens"] > inputSide {
+		inputSide = current["prompt_tokens"]
+	}
+	outputSide := current["output_tokens"]
+	if current["completion_tokens"] > outputSide {
+		outputSide = current["completion_tokens"]
+	}
+	if derived := inputSide + outputSide; derived > current["total_tokens"] {
 		current["total_tokens"] = derived
 	}
 

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -338,12 +338,17 @@ func AppendAPIWebsocketResponse(ctx context.Context, cfg *config.Config, payload
 	ginCtx := ginContextFrom(ctx)
 	if ginCtx != nil {
 		// Always-on: accumulate response text and usage for plugins.
-		// Websocket frames are raw JSON objects, not SSE lines. Wrap in
-		// SSE format so accumulateResponseText takes the streaming path
-		// and correctly handles Codex delta/done event types.
-		sse := append([]byte("data: "), data...)
-		sse = append(sse, '\n', '\n')
-		accumulateResponseText(ginCtx, sse)
+		// Websocket frames are raw JSON objects. First try the non-streaming
+		// path (handles response.completed with response.output[]) then wrap
+		// as SSE so delta/done event types reach the streaming branch.
+		accumulateResponseText(ginCtx, data)
+		// Only wrap as SSE if no text was captured by the non-streaming pass,
+		// to avoid double-accumulation for completed frames.
+		if s, _ := ginCtx.Get(UpstreamResponseTextKey); s == "" || s == nil {
+			sse := append([]byte("data: "), data...)
+			sse = append(sse, '\n', '\n')
+			accumulateResponseText(ginCtx, sse)
+		}
 	}
 	if cfg == nil || !cfg.RequestLog {
 		return

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -225,6 +225,7 @@ func RecordAPIWebsocketRequest(ctx context.Context, cfg *config.Config, info Ups
 	ginCtx := ginContextFrom(ctx)
 	if ginCtx != nil {
 		// Always-on: populate context keys for plugins regardless of RequestLog.
+		ginCtx.Set(UpstreamResponseTextKey, "")
 		ginCtx.Set(UpstreamRawUsageKey, nil)
 		if info.URL != "" {
 			ginCtx.Set(UpstreamURLKey, info.URL)
@@ -814,8 +815,12 @@ func accumulateResponseText(ginCtx *gin.Context, chunk []byte) {
 			continue
 		}
 		accumulateUsage(ginCtx, data)
-		// Anthropic: delta.text
-		delta := gjson.GetBytes(data, "delta.text").String()
+		// Anthropic: delta.text, only when delta.type is text_delta to avoid
+		// capturing non-text deltas such as input_json_delta.
+		var delta string
+		if dt := gjson.GetBytes(data, "delta.type").String(); dt == "" || dt == "text_delta" {
+			delta = gjson.GetBytes(data, "delta.text").String()
+		}
 		if delta == "" {
 			// OpenAI-compatible: choices[0].delta.content
 			delta = gjson.GetBytes(data, "choices.0.delta.content").String()

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -975,23 +975,6 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 			}
 		}
 	}
-	// Derive total_tokens when the upstream omits it or a late SSE event
-	// updates a component without updating the total.
-	// Use max(input_tokens, prompt_tokens) + max(output_tokens, completion_tokens)
-	// to avoid double-counting when a provider reports both Anthropic-style and
-	// OpenAI-style fields (e.g. after usageMetadata mapping).
-	inputSide := current["input_tokens"]
-	if current["prompt_tokens"] > inputSide {
-		inputSide = current["prompt_tokens"]
-	}
-	outputSide := current["output_tokens"]
-	if current["completion_tokens"] > outputSide {
-		outputSide = current["completion_tokens"]
-	}
-	if derived := inputSide + outputSide; derived > current["total_tokens"] {
-		current["total_tokens"] = derived
-	}
-
 	// Antigravity wrapper: response.usageMetadata / response.usage_metadata
 	for _, metaKey := range []string{"response.usageMetadata", "response.usage_metadata"} {
 		if meta := gjson.GetBytes(data, metaKey); meta.Exists() {
@@ -1028,6 +1011,31 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 			setFromPath("cache_read_input_tokens", "cachedContentTokenCount")
 			break
 		}
+	}
+
+	// Derive total_tokens after all fields (including Gemini metadata) are
+	// mapped. Use max(input, prompt) + max(output, completion) + reasoning
+	// to handle Gemini responses that omit totalTokenCount but report
+	// thoughtsTokenCount separately.
+	inputSide := current["input_tokens"]
+	if current["prompt_tokens"] > inputSide {
+		inputSide = current["prompt_tokens"]
+	}
+	outputSide := current["output_tokens"]
+	if current["completion_tokens"] > outputSide {
+		outputSide = current["completion_tokens"]
+	}
+	// For Gemini, reasoning_tokens (thoughtsTokenCount) is separate from
+	// candidatesTokenCount and must be included. For OpenAI, reasoning_tokens
+	// is already a subset of output/completion and must not be added again.
+	// Heuristic: include it only when there are no output/completion tokens
+	// (pure Gemini metadata path where only prompt+candidates+thoughts exist).
+	reasoningSide := int64(0)
+	if outputSide == 0 {
+		reasoningSide = current["reasoning_tokens"]
+	}
+	if derived := inputSide + outputSide + reasoningSide; derived > current["total_tokens"] {
+		current["total_tokens"] = derived
 	}
 
 	ginCtx.Set(UpstreamRawUsageKey, current)

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -928,12 +928,15 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 	} {
 		setMax(key)
 	}
-	// OpenAI nested details: prompt_tokens_details.cached_tokens,
-	// output_tokens_details.reasoning_tokens (Responses API),
-	// completion_tokens_details.reasoning_tokens (chat completions).
-	if r := usage.Get("prompt_tokens_details.cached_tokens"); r.Exists() {
-		if v := r.Int(); v > current["cache_read_input_tokens"] {
-			current["cache_read_input_tokens"] = v
+	// OpenAI/Codex nested details.
+	for _, path := range []string{
+		"prompt_tokens_details.cached_tokens",  // chat completions
+		"input_tokens_details.cached_tokens",   // Responses API
+	} {
+		if r := usage.Get(path); r.Exists() {
+			if v := r.Int(); v > current["cache_read_input_tokens"] {
+				current["cache_read_input_tokens"] = v
+			}
 		}
 	}
 	for _, path := range []string{
@@ -975,6 +978,8 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 		setFromPath("prompt_tokens", "promptTokenCount")
 		setFromPath("completion_tokens", "candidatesTokenCount")
 		setFromPath("total_tokens", "totalTokenCount")
+		setFromPath("reasoning_tokens", "thoughtsTokenCount")
+		setFromPath("cache_read_input_tokens", "cachedContentTokenCount")
 	}
 
 	// Gemini usageMetadata lives at the top level, not under "usage".
@@ -989,6 +994,8 @@ func accumulateUsage(ginCtx *gin.Context, data []byte) {
 		setFromPath("prompt_tokens", "promptTokenCount")
 		setFromPath("completion_tokens", "candidatesTokenCount")
 		setFromPath("total_tokens", "totalTokenCount")
+		setFromPath("reasoning_tokens", "thoughtsTokenCount")
+		setFromPath("cache_read_input_tokens", "cachedContentTokenCount")
 	}
 
 	ginCtx.Set(UpstreamRawUsageKey, current)

--- a/internal/runtime/executor/helps/observability_helpers_test.go
+++ b/internal/runtime/executor/helps/observability_helpers_test.go
@@ -1,0 +1,385 @@
+package helps
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func newTestGinCtx() *gin.Context {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	return c
+}
+
+func getUsage(c *gin.Context) map[string]int64 {
+	v, _ := c.Get(UpstreamRawUsageKey)
+	m, _ := v.(map[string]int64)
+	return m
+}
+
+// ---- TestExtractFirstUserText ------------------------------------------------
+
+func TestExtractFirstUserText(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "anthropic string content",
+			body: `{"messages":[{"role":"user","content":"hello"}]}`,
+			want: "hello",
+		},
+		{
+			name: "anthropic array content blocks",
+			body: `{"messages":[{"role":"user","content":[{"type":"text","text":"world"}]}]}`,
+			want: "world",
+		},
+		{
+			name: "gemini contents",
+			body: `{"contents":[{"role":"user","parts":[{"text":"gemini msg"}]}]}`,
+			want: "gemini msg",
+		},
+		{
+			name: "antigravity request.contents",
+			body: `{"request":{"contents":[{"role":"user","parts":[{"text":"antgrav"}]}]}}`,
+			want: "antgrav",
+		},
+		{
+			name: "responses api input string",
+			body: `{"input":"resp input"}`,
+			want: "resp input",
+		},
+		{
+			name: "responses api input array",
+			body: `{"input":[{"role":"user","content":[{"type":"input_text","text":"arr input"}]}]}`,
+			want: "arr input",
+		},
+		{
+			name: "empty body",
+			body: `{}`,
+			want: "",
+		},
+		{
+			name: "malformed json",
+			body: `{bad`,
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractFirstUserText([]byte(tc.body))
+			if got != tc.want {
+				t.Fatalf("extractFirstUserText() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("truncation", func(t *testing.T) {
+		long := strings.Repeat("x", 2500)
+		body := `{"messages":[{"role":"user","content":"` + long + `"}]}`
+		got := extractFirstUserText([]byte(body))
+		if len(got) > 2003 {
+			t.Fatalf("len(result) = %d, want <= 2003", len(got))
+		}
+	})
+}
+
+// ---- TestAccumulateResponseText ---------------------------------------------
+
+func TestAccumulateResponseText(t *testing.T) {
+	getResponseText := func(c *gin.Context) string {
+		v, _ := c.Get(UpstreamResponseTextKey)
+		s, _ := v.(string)
+		return s
+	}
+
+	// Non-streaming subtests.
+	nonStreaming := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "anthropic text block",
+			body: `{"content":[{"type":"text","text":"ant resp"}]}`,
+			want: "ant resp",
+		},
+		{
+			name: "anthropic thinking+text",
+			body: `{"content":[{"type":"thinking","thinking":"..."},{"type":"text","text":"answer"}]}`,
+			want: "answer",
+		},
+		{
+			name: "openai choices",
+			body: `{"choices":[{"message":{"content":"oai resp"}}]}`,
+			want: "oai resp",
+		},
+		{
+			name: "gemini",
+			body: `{"candidates":[{"content":{"parts":[{"text":"gem resp"}]}}]}`,
+			want: "gem resp",
+		},
+		{
+			name: "antigravity",
+			body: `{"response":{"candidates":[{"content":{"parts":[{"text":"antgrav resp"}]}}]}}`,
+			want: "antgrav resp",
+		},
+		{
+			name: "codex output[]",
+			body: `{"output":[{"content":[{"type":"output_text","text":"codex resp"}]}]}`,
+			want: "codex resp",
+		},
+		{
+			name: "codex response.output[]",
+			body: `{"response":{"output":[{"content":[{"type":"output_text","text":"codex sse"}]}]}}`,
+			want: "codex sse",
+		},
+		{
+			name: "empty",
+			body: `{}`,
+			want: "",
+		},
+	}
+	for _, tc := range nonStreaming {
+		t.Run("non-streaming/"+tc.name, func(t *testing.T) {
+			c := newTestGinCtx()
+			accumulateResponseText(c, []byte(tc.body))
+			got := getResponseText(c)
+			if got != tc.want {
+				t.Fatalf("accumulateResponseText() text = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("non-streaming/truncation", func(t *testing.T) {
+		long := strings.Repeat("y", 5000)
+		body := `{"content":[{"type":"text","text":"` + long + `"}]}`
+		c := newTestGinCtx()
+		accumulateResponseText(c, []byte(body))
+		got := getResponseText(c)
+		if len(got) > 4003 {
+			t.Fatalf("len(result) = %d, want <= 4003", len(got))
+		}
+	})
+
+	// Streaming SSE subtests.
+	sse := func(jsonStr string) []byte {
+		return []byte("data: " + jsonStr + "\n\n")
+	}
+
+	streamingCases := []struct {
+		name string
+		body []byte
+		want string
+	}{
+		{
+			name: "anthropic delta",
+			body: sse(`{"delta":{"type":"text_delta","text":"hello"}}`),
+			want: "hello",
+		},
+		{
+			name: "openai delta",
+			body: sse(`{"choices":[{"delta":{"content":"world"}}]}`),
+			want: "world",
+		},
+		{
+			name: "codex output_text.delta",
+			body: sse(`{"type":"response.output_text.delta","delta":"codex d"}`),
+			want: "codex d",
+		},
+		{
+			name: "gemini native",
+			body: sse(`{"candidates":[{"content":{"parts":[{"text":"gem d"}]}}]}`),
+			want: "gem d",
+		},
+		{
+			name: "gemini antigravity",
+			body: sse(`{"response":{"candidates":[{"content":{"parts":[{"text":"ag d"}]}}]}}`),
+			want: "ag d",
+		},
+	}
+	for _, tc := range streamingCases {
+		t.Run("streaming/"+tc.name, func(t *testing.T) {
+			c := newTestGinCtx()
+			accumulateResponseText(c, tc.body)
+			got := getResponseText(c)
+			if got != tc.want {
+				t.Fatalf("accumulateResponseText() text = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("streaming/accumulation", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateResponseText(c, sse(`{"delta":{"type":"text_delta","text":"foo"}}`))
+		accumulateResponseText(c, sse(`{"delta":{"type":"text_delta","text":"bar"}}`))
+		got := getResponseText(c)
+		if got != "foobar" {
+			t.Fatalf("accumulateResponseText() text = %q, want %q", got, "foobar")
+		}
+	})
+
+	t.Run("streaming/codex output_item.done no prior delta", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateResponseText(c, sse(`{"type":"response.output_item.done","item":{"content":[{"type":"output_text","text":"done"}]}}`))
+		got := getResponseText(c)
+		if got != "done" {
+			t.Fatalf("accumulateResponseText() text = %q, want %q", got, "done")
+		}
+	})
+
+	t.Run("streaming/codex output_item.done after delta", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateResponseText(c, sse(`{"type":"response.output_text.delta","delta":"x"}`))
+		accumulateResponseText(c, sse(`{"type":"response.output_item.done","item":{"content":[{"type":"output_text","text":"full"}]}}`))
+		got := getResponseText(c)
+		if got != "x" {
+			t.Fatalf("accumulateResponseText() text = %q, want %q", got, "x")
+		}
+	})
+}
+
+// ---- TestAccumulateUsage ----------------------------------------------------
+
+func TestAccumulateUsage(t *testing.T) {
+	t.Run("anthropic", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateUsage(c, []byte(`{"usage":{"input_tokens":10,"output_tokens":20,"total_tokens":30}}`))
+		m := getUsage(c)
+		if m["input_tokens"] != 10 {
+			t.Fatalf("input_tokens = %d, want 10", m["input_tokens"])
+		}
+		if m["output_tokens"] != 20 {
+			t.Fatalf("output_tokens = %d, want 20", m["output_tokens"])
+		}
+		if m["total_tokens"] != 30 {
+			t.Fatalf("total_tokens = %d, want 30", m["total_tokens"])
+		}
+	})
+
+	t.Run("openai", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateUsage(c, []byte(`{"usage":{"prompt_tokens":5,"completion_tokens":15,"total_tokens":20}}`))
+		m := getUsage(c)
+		if m["prompt_tokens"] != 5 {
+			t.Fatalf("prompt_tokens = %d, want 5", m["prompt_tokens"])
+		}
+		if m["completion_tokens"] != 15 {
+			t.Fatalf("completion_tokens = %d, want 15", m["completion_tokens"])
+		}
+		if m["total_tokens"] != 20 {
+			t.Fatalf("total_tokens = %d, want 20", m["total_tokens"])
+		}
+	})
+
+	t.Run("claude message.usage", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateUsage(c, []byte(`{"message":{"usage":{"input_tokens":8,"output_tokens":12}}}`))
+		m := getUsage(c)
+		if m["input_tokens"] != 8 {
+			t.Fatalf("input_tokens = %d, want 8", m["input_tokens"])
+		}
+		if m["output_tokens"] != 12 {
+			t.Fatalf("output_tokens = %d, want 12", m["output_tokens"])
+		}
+		if m["total_tokens"] != 20 {
+			t.Fatalf("total_tokens = %d, want 20", m["total_tokens"])
+		}
+	})
+
+	t.Run("responses api", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateUsage(c, []byte(`{"response":{"usage":{"input_tokens":3,"output_tokens":7,"total_tokens":10}}}`))
+		m := getUsage(c)
+		if m["input_tokens"] != 3 {
+			t.Fatalf("input_tokens = %d, want 3", m["input_tokens"])
+		}
+		if m["output_tokens"] != 7 {
+			t.Fatalf("output_tokens = %d, want 7", m["output_tokens"])
+		}
+		if m["total_tokens"] != 10 {
+			t.Fatalf("total_tokens = %d, want 10", m["total_tokens"])
+		}
+	})
+
+	t.Run("gemini usageMetadata", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateUsage(c, []byte(`{"usageMetadata":{"promptTokenCount":4,"candidatesTokenCount":6,"totalTokenCount":10}}`))
+		m := getUsage(c)
+		if m["prompt_tokens"] != 4 {
+			t.Fatalf("prompt_tokens = %d, want 4", m["prompt_tokens"])
+		}
+		if m["completion_tokens"] != 6 {
+			t.Fatalf("completion_tokens = %d, want 6", m["completion_tokens"])
+		}
+		if m["total_tokens"] != 10 {
+			t.Fatalf("total_tokens = %d, want 10", m["total_tokens"])
+		}
+	})
+
+	t.Run("antigravity response.usageMetadata", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateUsage(c, []byte(`{"response":{"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":8,"totalTokenCount":10}}}`))
+		m := getUsage(c)
+		if m["prompt_tokens"] != 2 {
+			t.Fatalf("prompt_tokens = %d, want 2", m["prompt_tokens"])
+		}
+		if m["completion_tokens"] != 8 {
+			t.Fatalf("completion_tokens = %d, want 8", m["completion_tokens"])
+		}
+		if m["total_tokens"] != 10 {
+			t.Fatalf("total_tokens = %d, want 10", m["total_tokens"])
+		}
+	})
+
+	t.Run("nested details", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateUsage(c, []byte(`{"usage":{"prompt_tokens":10,"completion_tokens":20,"prompt_tokens_details":{"cached_tokens":5},"completion_tokens_details":{"reasoning_tokens":3}}}`))
+		m := getUsage(c)
+		if m["cache_read_input_tokens"] != 5 {
+			t.Fatalf("cache_read_input_tokens = %d, want 5", m["cache_read_input_tokens"])
+		}
+		if m["reasoning_tokens"] != 3 {
+			t.Fatalf("reasoning_tokens = %d, want 3", m["reasoning_tokens"])
+		}
+	})
+
+	t.Run("no double-count", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateUsage(c, []byte(`{"usage":{"input_tokens":10,"output_tokens":20,"prompt_tokens":10,"completion_tokens":20}}`))
+		m := getUsage(c)
+		if m["total_tokens"] != 30 {
+			t.Fatalf("total_tokens = %d, want 30", m["total_tokens"])
+		}
+	})
+
+	t.Run("setMax", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateUsage(c, []byte(`{"usage":{"input_tokens":10,"output_tokens":5}}`))
+		accumulateUsage(c, []byte(`{"usage":{"input_tokens":5,"output_tokens":5}}`))
+		m := getUsage(c)
+		if m["input_tokens"] != 10 {
+			t.Fatalf("input_tokens = %d, want 10 (setMax should keep higher value)", m["input_tokens"])
+		}
+	})
+
+	t.Run("empty body no panic", func(t *testing.T) {
+		c := newTestGinCtx()
+		accumulateUsage(c, []byte(`{}`))
+		m := getUsage(c)
+		if len(m) > 0 {
+			// Acceptable: map may be nil or empty; non-zero values would be wrong.
+			for k, v := range m {
+				if v != 0 {
+					t.Fatalf("expected zero usage for key %q, got %d", k, v)
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
`RecordAPIRequest` and `AppendAPIResponseChunk` previously wrote nothing
to the gin context when `RequestLog` was disabled. External plugins
(tracing, billing, observability sidecars) had no way to read the
upstream URL, the request content, or the response without forcing
`request_log: true` for all users.

This adds four context keys that are written unconditionally, regardless
of `RequestLog`:

| Key | Content |
|---|---|
| `upstream_url` | outbound upstream URL |
| `upstream_first_user_msg` | text of the first user message (max 2000 chars) |
| `upstream_response_text` | accumulated response text from streaming or full body (max 4000 chars) |
| `upstream_raw_usage` | `map[string]int64` of token counts from `usage` fields |

The keys are exported as named constants from the `helps` package so
plugins can reference them without hardcoding strings.

The existing `RequestLog`-gated logging path is unchanged.
