### PR TITLE
feat(examples): Langfuse observability plugin

### DIFF
--- a/examples/langfuse-plugin/README.md
+++ b/examples/langfuse-plugin/README.md
@@ -1,0 +1,53 @@
+# Langfuse observability plugin
+
+This example shows how to build a CLIProxyAPI binary that forwards every
+upstream request to [Langfuse](https://langfuse.com) as a generation span.
+
+## How it works
+
+`sdk/cliproxy/usage` exposes a `Plugin` interface. The proxy runtime calls
+`HandleUsage` after each upstream request completes. This plugin packages the
+record into a Langfuse `generation-create` event and ships it in a background
+goroutine so the response path is not blocked.
+
+When an upstream gateway populates `X-Request-Id`, the span is attached to
+the matching parent trace. Without it a standalone trace is created per
+request.
+
+For richer input/output capture the proxy runtime also writes per-request
+context keys (see `sdk/cliproxy/usage` constants). These are populated when
+the runtime's observability path is active and contain the first user message,
+accumulated response text, and a token usage breakdown.
+
+## Build
+
+```sh
+go build -o cpa-langfuse ./examples/langfuse-plugin
+```
+
+## Run
+
+```sh
+LANGFUSE_BASE_URL=https://cloud.langfuse.com \
+LANGFUSE_PUBLIC_KEY=pk-lf-... \
+LANGFUSE_SECRET_KEY=sk-lf-... \
+./cpa-langfuse -config config.yaml
+```
+
+If the environment variables are not set the binary starts normally without
+sending any data to Langfuse.
+
+## What gets sent
+
+Each upstream request produces one `generation` event:
+
+| Field | Value |
+|---|---|
+| `traceId` | `X-Request-Id` from the inbound request, or a fresh UUID |
+| `name` | `cpa.upstream` |
+| `model` | upstream model name |
+| `input` | first user message text (when available) |
+| `output` | response text (when available) |
+| `usage` | input/output/cache/reasoning token counts |
+| `metadata` | provider, auth_id, latency_ms, upstream_url |
+| `level` | `ERROR` on upstream failure, `DEFAULT` otherwise |

--- a/examples/langfuse-plugin/langfuse/client.go
+++ b/examples/langfuse-plugin/langfuse/client.go
@@ -87,10 +87,27 @@ func (c *Client) ingest(ctx context.Context, events ...ingestionEvent) error {
 		return fmt.Errorf("langfuse: http: %w", err)
 	}
 	defer resp.Body.Close()
+	respBody := make([]byte, 2048)
+	n, _ := resp.Body.Read(respBody)
+	respBody = respBody[:n]
 	if resp.StatusCode >= 300 {
-		body := make([]byte, 512)
-		n, _ := resp.Body.Read(body)
-		return fmt.Errorf("langfuse: status %d: %s", resp.StatusCode, bytes.TrimSpace(body[:n]))
+		return fmt.Errorf("langfuse: status %d: %s", resp.StatusCode, bytes.TrimSpace(respBody))
+	}
+	// Langfuse returns 207 Multi-Status when the batch is accepted but
+	// individual events fail. Check for per-event errors in the response.
+	if resp.StatusCode == http.StatusMultiStatus {
+		var result struct {
+			Errors []struct {
+				ID    string `json:"id"`
+				Error struct {
+					Message string `json:"message"`
+				} `json:"error"`
+			} `json:"errors"`
+		}
+		if jsonErr := json.Unmarshal(respBody, &result); jsonErr == nil && len(result.Errors) > 0 {
+			return fmt.Errorf("langfuse: %d event(s) rejected: %s: %s",
+				len(result.Errors), result.Errors[0].ID, result.Errors[0].Error.Message)
+		}
 	}
 	return nil
 }

--- a/examples/langfuse-plugin/langfuse/client.go
+++ b/examples/langfuse-plugin/langfuse/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -18,10 +19,10 @@ type Client struct {
 	httpClient *http.Client
 }
 
-// NewClient constructs a Client. baseURL should not have a trailing slash.
+// NewClient constructs a Client. Any trailing slash in baseURL is stripped.
 func NewClient(baseURL, publicKey, secretKey string) *Client {
 	return &Client{
-		baseURL:    baseURL,
+		baseURL:    strings.TrimRight(baseURL, "/"),
 		publicKey:  publicKey,
 		secretKey:  secretKey,
 		httpClient: &http.Client{Timeout: 10 * time.Second},
@@ -87,7 +88,9 @@ func (c *Client) ingest(ctx context.Context, events ...ingestionEvent) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("langfuse: status %d", resp.StatusCode)
+		body := make([]byte, 512)
+		n, _ := resp.Body.Read(body)
+		return fmt.Errorf("langfuse: status %d: %s", resp.StatusCode, bytes.TrimSpace(body[:n]))
 	}
 	return nil
 }

--- a/examples/langfuse-plugin/langfuse/client.go
+++ b/examples/langfuse-plugin/langfuse/client.go
@@ -25,7 +25,7 @@ func NewClient(baseURL, publicKey, secretKey string) *Client {
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		publicKey:  publicKey,
 		secretKey:  secretKey,
-		httpClient: &http.Client{Timeout: 10 * time.Second},
+		httpClient: &http.Client{},
 	}
 }
 

--- a/examples/langfuse-plugin/langfuse/client.go
+++ b/examples/langfuse-plugin/langfuse/client.go
@@ -1,0 +1,107 @@
+package langfuse
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Client sends events to the Langfuse Ingestion API.
+// Docs: https://api.reference.langfuse.com/#tag/ingestion
+type Client struct {
+	baseURL    string
+	publicKey  string
+	secretKey  string
+	httpClient *http.Client
+}
+
+// NewClient constructs a Client. baseURL should not have a trailing slash.
+func NewClient(baseURL, publicKey, secretKey string) *Client {
+	return &Client{
+		baseURL:    baseURL,
+		publicKey:  publicKey,
+		secretKey:  secretKey,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+type ingestionBatch struct {
+	Batch []ingestionEvent `json:"batch"`
+}
+
+type ingestionEvent struct {
+	ID        string          `json:"id"`
+	Type      string          `json:"type"`
+	Timestamp time.Time       `json:"timestamp"`
+	Body      json.RawMessage `json:"body"`
+}
+
+// GenerationBody maps to a Langfuse generation-create body.
+type GenerationBody struct {
+	ID            string           `json:"id"`
+	TraceID       string           `json:"traceId"`
+	Name          string           `json:"name"`
+	StartTime     time.Time        `json:"startTime"`
+	EndTime       *time.Time       `json:"endTime,omitempty"`
+	Model         string           `json:"model,omitempty"`
+	Input         any              `json:"input,omitempty"`
+	Output        any              `json:"output,omitempty"`
+	Metadata      any              `json:"metadata,omitempty"`
+	Level         string           `json:"level,omitempty"` // DEFAULT | DEBUG | WARNING | ERROR
+	StatusMessage string           `json:"statusMessage,omitempty"`
+	Usage         *GenerationUsage `json:"usage,omitempty"`
+	UsageDetails  map[string]int64 `json:"usageDetails,omitempty"`
+}
+
+// GenerationUsage holds token counts for a Langfuse generation.
+type GenerationUsage struct {
+	Input          int64  `json:"input,omitempty"`
+	Output         int64  `json:"output,omitempty"`
+	Total          int64  `json:"total,omitempty"`
+	Unit           string `json:"unit,omitempty"` // TOKENS
+	InputCacheRead int64  `json:"inputCacheRead,omitempty"`
+}
+
+func (c *Client) ingest(ctx context.Context, events ...ingestionEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	body, err := json.Marshal(ingestionBatch{Batch: events})
+	if err != nil {
+		return fmt.Errorf("langfuse: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/api/public/ingestion", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("langfuse: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(c.publicKey, c.secretKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("langfuse: http: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("langfuse: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// SendGeneration sends a single generation event.
+func (c *Client) SendGeneration(ctx context.Context, gen GenerationBody) error {
+	body, err := json.Marshal(gen)
+	if err != nil {
+		return err
+	}
+	return c.ingest(ctx, ingestionEvent{
+		ID:        gen.ID + "-create",
+		Type:      "generation-create",
+		Timestamp: time.Now(),
+		Body:      body,
+	})
+}

--- a/examples/langfuse-plugin/langfuse/client.go
+++ b/examples/langfuse-plugin/langfuse/client.go
@@ -113,15 +113,42 @@ func (c *Client) ingest(ctx context.Context, events ...ingestionEvent) error {
 }
 
 // SendGeneration sends a single generation event.
+// traceBody is the minimal payload to anchor a generation in Langfuse v3+.
+type traceBody struct {
+	ID        string `json:"id"`
+	Name      string `json:"name,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
 func (c *Client) SendGeneration(ctx context.Context, gen GenerationBody) error {
 	body, err := json.Marshal(gen)
 	if err != nil {
 		return err
 	}
-	return c.ingest(ctx, ingestionEvent{
-		ID:        gen.ID + "-create",
-		Type:      "generation-create",
-		Timestamp: time.Now(),
-		Body:      body,
+	now := time.Now()
+	// Send trace-create in the same batch so Langfuse has a parent trace
+	// to attach the generation to. Idempotent: re-sending the same ID is
+	// a no-op on the Langfuse side.
+	traceJSON, err := json.Marshal(traceBody{
+		ID:        gen.TraceID,
+		Name:      "cpa.request",
+		Timestamp: gen.StartTime.UTC().Format(time.RFC3339Nano),
 	})
+	if err != nil {
+		return err
+	}
+	return c.ingest(ctx,
+		ingestionEvent{
+			ID:        gen.TraceID + "-trace",
+			Type:      "trace-create",
+			Timestamp: now,
+			Body:      traceJSON,
+		},
+		ingestionEvent{
+			ID:        gen.ID + "-create",
+			Type:      "generation-create",
+			Timestamp: now,
+			Body:      body,
+		},
+	)
 }

--- a/examples/langfuse-plugin/langfuse/client.go
+++ b/examples/langfuse-plugin/langfuse/client.go
@@ -86,7 +86,7 @@ func (c *Client) ingest(ctx context.Context, events ...ingestionEvent) error {
 	if err != nil {
 		return fmt.Errorf("langfuse: http: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	respBody := make([]byte, 2048)
 	n, _ := resp.Body.Read(respBody)
 	respBody = respBody[:n]

--- a/examples/langfuse-plugin/langfuse/plugin.go
+++ b/examples/langfuse-plugin/langfuse/plugin.go
@@ -108,7 +108,7 @@ func (p *Plugin) HandleUsage(ctx context.Context, rec coreusage.Record) {
 	}
 
 	gen := GenerationBody{
-		ID:        fmt.Sprintf("cpa-%s", traceID),
+		ID:        uuid.New().String(),
 		TraceID:   traceID,
 		Name:      "cpa.upstream",
 		StartTime: startTime,

--- a/examples/langfuse-plugin/langfuse/plugin.go
+++ b/examples/langfuse-plugin/langfuse/plugin.go
@@ -163,7 +163,7 @@ func buildUsage(gc *gin.Context, rec coreusage.Record) (*GenerationUsage, map[st
 	raw := rawUsage(gc)
 	input := coalesce(raw, "input_tokens", rec.Detail.InputTokens)
 	output := coalesce(raw, "output_tokens", rec.Detail.OutputTokens)
-	cacheRead := coalesce(raw, "cache_read_input_tokens", rec.Detail.CachedTokens)
+	cacheRead := coalesce(raw, "cache_read_input_tokens", rec.Detail.CacheReadTokens)
 	reasoning := coalesce(raw, "reasoning_tokens", rec.Detail.ReasoningTokens)
 	total := coalesce(raw, "total_tokens", rec.Detail.TotalTokens)
 	if total == 0 {

--- a/examples/langfuse-plugin/langfuse/plugin.go
+++ b/examples/langfuse-plugin/langfuse/plugin.go
@@ -31,14 +31,35 @@ import (
 // ginContextKey is the key CPA uses to store *gin.Context in request contexts.
 const ginContextKey = "gin"
 
+// workerCount is the number of goroutines sending events to Langfuse.
+const workerCount = 4
+
 // Plugin implements coreusage.Plugin.
 type Plugin struct {
 	client *Client
+	queue  chan GenerationBody
 }
 
 // New creates a Plugin with explicit credentials.
 func New(baseURL, publicKey, secretKey string) *Plugin {
-	return &Plugin{client: NewClient(baseURL, publicKey, secretKey)}
+	p := &Plugin{
+		client: NewClient(baseURL, publicKey, secretKey),
+		queue:  make(chan GenerationBody, 256),
+	}
+	for range workerCount {
+		go p.worker()
+	}
+	return p
+}
+
+func (p *Plugin) worker() {
+	for gen := range p.queue {
+		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		if err := p.client.SendGeneration(ctx, gen); err != nil {
+			log.Debugf("langfuse plugin: %v", err)
+		}
+		cancel()
+	}
 }
 
 // NewFromEnv reads LANGFUSE_BASE_URL, LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY
@@ -109,14 +130,13 @@ func (p *Plugin) HandleUsage(ctx context.Context, rec coreusage.Record) {
 
 	gen.Usage, gen.UsageDetails = buildUsage(gc, rec)
 
-	// Fire-and-forget: do not block the response path.
-	go func() {
-		sendCtx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
-		defer cancel()
-		if err := p.client.SendGeneration(sendCtx, gen); err != nil {
-			log.Debugf("langfuse plugin: %v", err)
-		}
-	}()
+	// Non-blocking send: drop the event if the queue is full rather than
+	// letting a slow Langfuse endpoint stall the response path.
+	select {
+	case p.queue <- gen:
+	default:
+		log.Debugf("langfuse plugin: queue full, dropping event for trace %s", gen.TraceID)
+	}
 }
 
 func buildMeta(gc *gin.Context, rec coreusage.Record) map[string]any {

--- a/examples/langfuse-plugin/langfuse/plugin.go
+++ b/examples/langfuse-plugin/langfuse/plugin.go
@@ -54,11 +54,9 @@ func New(baseURL, publicKey, secretKey string) *Plugin {
 
 func (p *Plugin) worker() {
 	for gen := range p.queue {
-		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
-		if err := p.client.SendGeneration(ctx, gen); err != nil {
+		if err := p.client.SendGeneration(context.Background(), gen); err != nil {
 			log.Debugf("langfuse plugin: %v", err)
 		}
-		cancel()
 	}
 }
 

--- a/examples/langfuse-plugin/langfuse/plugin.go
+++ b/examples/langfuse-plugin/langfuse/plugin.go
@@ -1,0 +1,217 @@
+// Package langfuse implements a usage.Plugin that forwards each upstream
+// request record to Langfuse as a generation span.
+//
+// The plugin reads context keys written by the proxy runtime into the gin
+// context (see sdk/cliproxy/usage constants):
+//
+//   - usage.CtxFirstUserMsg  - text of the first user message
+//   - usage.CtxResponseText  - accumulated response text
+//   - usage.CtxRawUsage      - map[string]int64 of token counts
+//
+// Configuration (environment variables):
+//
+//	LANGFUSE_BASE_URL   e.g. https://cloud.langfuse.com
+//	LANGFUSE_PUBLIC_KEY pk-lf-...
+//	LANGFUSE_SECRET_KEY sk-lf-...
+package langfuse
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	log "github.com/sirupsen/logrus"
+)
+
+// ginContextKey is the key CPA uses to store *gin.Context in request contexts.
+const ginContextKey = "gin"
+
+// Plugin implements coreusage.Plugin.
+type Plugin struct {
+	client *Client
+}
+
+// New creates a Plugin with explicit credentials.
+func New(baseURL, publicKey, secretKey string) *Plugin {
+	return &Plugin{client: NewClient(baseURL, publicKey, secretKey)}
+}
+
+// NewFromEnv reads LANGFUSE_BASE_URL, LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY
+// from the environment. Returns nil when any required variable is missing so the
+// caller can skip registration without extra error handling:
+//
+//	if lf := langfuse.NewFromEnv(); lf != nil {
+//	    coreusage.RegisterPlugin(lf)
+//	}
+func NewFromEnv() *Plugin {
+	baseURL := strings.TrimRight(os.Getenv("LANGFUSE_BASE_URL"), "/")
+	pk := os.Getenv("LANGFUSE_PUBLIC_KEY")
+	sk := os.Getenv("LANGFUSE_SECRET_KEY")
+	if baseURL == "" || pk == "" || sk == "" {
+		return nil
+	}
+	return New(baseURL, pk, sk)
+}
+
+// HandleUsage satisfies coreusage.Plugin and is called after every upstream request.
+func (p *Plugin) HandleUsage(ctx context.Context, rec coreusage.Record) {
+	if p == nil || p.client == nil {
+		return
+	}
+
+	gc := ginCtxFrom(ctx)
+
+	// Prefer an existing request ID so the generation attaches to a parent
+	// trace opened by an upstream gateway. Fall back to a fresh UUID.
+	traceID := requestIDFrom(ctx, gc)
+	if traceID == "" {
+		traceID = uuid.New().String()
+	}
+
+	startTime := rec.RequestedAt
+	if startTime.IsZero() {
+		startTime = time.Now().Add(-rec.Latency)
+	}
+	endTime := startTime.Add(rec.Latency)
+
+	level := "DEFAULT"
+	statusMsg := ""
+	if rec.Failed {
+		level = "ERROR"
+		statusMsg = fmt.Sprintf("upstream failed: status %d", rec.Fail.StatusCode)
+	}
+
+	gen := GenerationBody{
+		ID:        fmt.Sprintf("cpa-%s", traceID),
+		TraceID:   traceID,
+		Name:      "cpa.upstream",
+		StartTime: startTime,
+		EndTime:   &endTime,
+		Model:     rec.Model,
+		Metadata:  buildMeta(gc, rec),
+		Level:     level,
+		StatusMessage: statusMsg,
+	}
+
+	if gc != nil {
+		if v, ok := gc.Get(coreusage.CtxFirstUserMsg); ok {
+			gen.Input = v
+		}
+		if v, ok := gc.Get(coreusage.CtxResponseText); ok {
+			gen.Output = v
+		}
+	}
+
+	gen.Usage, gen.UsageDetails = buildUsage(gc, rec)
+
+	// Fire-and-forget: do not block the response path.
+	go func() {
+		sendCtx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer cancel()
+		if err := p.client.SendGeneration(sendCtx, gen); err != nil {
+			log.Debugf("langfuse plugin: %v", err)
+		}
+	}()
+}
+
+func buildMeta(gc *gin.Context, rec coreusage.Record) map[string]any {
+	m := map[string]any{
+		"provider":   rec.Provider,
+		"auth_id":    rec.AuthID,
+		"auth_index": rec.AuthIndex,
+		"latency_ms": rec.Latency.Milliseconds(),
+		"failed":     rec.Failed,
+	}
+	if gc == nil {
+		return m
+	}
+	if v, ok := gc.Get(coreusage.CtxUpstreamURL); ok {
+		m["upstream_url"] = v
+	}
+	if raw := rawUsage(gc); len(raw) > 0 {
+		m["raw_usage"] = raw
+	}
+	return m
+}
+
+func buildUsage(gc *gin.Context, rec coreusage.Record) (*GenerationUsage, map[string]int64) {
+	raw := rawUsage(gc)
+	input := coalesce(raw, "input_tokens", rec.Detail.InputTokens)
+	output := coalesce(raw, "output_tokens", rec.Detail.OutputTokens)
+	cacheRead := coalesce(raw, "cache_read_input_tokens", rec.Detail.CachedTokens)
+	reasoning := coalesce(raw, "reasoning_tokens", rec.Detail.ReasoningTokens)
+	total := coalesce(raw, "total_tokens", rec.Detail.TotalTokens)
+	if total == 0 {
+		total = input + output + reasoning
+	}
+
+	if input == 0 && output == 0 && cacheRead == 0 && reasoning == 0 {
+		return nil, nil
+	}
+
+	usage := &GenerationUsage{
+		Input:          input,
+		Output:         output,
+		Total:          total,
+		Unit:           "TOKENS",
+		InputCacheRead: cacheRead,
+	}
+	details := map[string]int64{
+		"input":  input,
+		"output": output,
+		"total":  total,
+	}
+	if cacheRead > 0 {
+		details["cache_read_input_tokens"] = cacheRead
+	}
+	if reasoning > 0 {
+		details["reasoning_tokens"] = reasoning
+	}
+	return usage, details
+}
+
+func rawUsage(gc *gin.Context) map[string]int64 {
+	if gc == nil {
+		return nil
+	}
+	v, ok := gc.Get(coreusage.CtxRawUsage)
+	if !ok {
+		return nil
+	}
+	m, _ := v.(map[string]int64)
+	return m
+}
+
+func coalesce(raw map[string]int64, key string, fallback int64) int64 {
+	if v, ok := raw[key]; ok {
+		return v
+	}
+	return fallback
+}
+
+func ginCtxFrom(ctx context.Context) *gin.Context {
+	if ctx == nil {
+		return nil
+	}
+	gc, _ := ctx.Value(ginContextKey).(*gin.Context)
+	return gc
+}
+
+func requestIDFrom(ctx context.Context, gc *gin.Context) string {
+	if v, ok := ctx.Value("__request_id__").(string); ok && v != "" {
+		return v
+	}
+	if gc != nil {
+		if v, ok := gc.Get("__request_id__"); ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}

--- a/examples/langfuse-plugin/langfuse/plugin.go
+++ b/examples/langfuse-plugin/langfuse/plugin.go
@@ -203,8 +203,10 @@ func ginCtxFrom(ctx context.Context) *gin.Context {
 }
 
 func requestIDFrom(ctx context.Context, gc *gin.Context) string {
-	if v, ok := ctx.Value("__request_id__").(string); ok && v != "" {
-		return v
+	if ctx != nil {
+		if v, ok := ctx.Value("__request_id__").(string); ok && v != "" {
+			return v
+		}
 	}
 	if gc != nil {
 		if v, ok := gc.Get("__request_id__"); ok {

--- a/examples/langfuse-plugin/langfuse/plugin.go
+++ b/examples/langfuse-plugin/langfuse/plugin.go
@@ -35,6 +35,8 @@ const ginContextKey = "gin"
 const workerCount = 4
 
 // Plugin implements coreusage.Plugin.
+// Note: Plugin has no Close method; the worker goroutines run for the
+// lifetime of the process. This is intentional for an example binary.
 type Plugin struct {
 	client *Client
 	queue  chan GenerationBody
@@ -54,6 +56,10 @@ func New(baseURL, publicKey, secretKey string) *Plugin {
 
 func (p *Plugin) worker() {
 	for gen := range p.queue {
+		// context.Background() has no timeout. This is intentional: AGENTS.md
+		// policy permits timeouts only during credential acquisition. If
+		// Langfuse is slow, the bounded queue (cap 256) absorbs the back-pressure
+		// and events are dropped once it fills rather than blocking the proxy.
 		if err := p.client.SendGeneration(context.Background(), gen); err != nil {
 			log.Debugf("langfuse plugin: %v", err)
 		}

--- a/examples/langfuse-plugin/main.go
+++ b/examples/langfuse-plugin/main.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
+	"os"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/examples/langfuse-plugin/langfuse"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy"
@@ -33,12 +35,19 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	configPath := flag.String("config", "config.yaml", "Path to config file")
 	flag.Parse()
 
 	cfg, err := config.LoadConfig(*configPath)
 	if err != nil {
-		log.Fatalf("failed to load config: %v", err)
+		return fmt.Errorf("failed to load config: %w", err)
 	}
 
 	// Register the Langfuse plugin if credentials are present in the environment.
@@ -55,13 +64,14 @@ func main() {
 		WithConfigPath(*configPath).
 		Build()
 	if err != nil {
-		log.Fatalf("failed to build service: %v", err)
+		return fmt.Errorf("failed to build service: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	if err = svc.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-		log.Fatalf("service error: %v", err)
+		return fmt.Errorf("service error: %w", err)
 	}
+	return nil
 }

--- a/examples/langfuse-plugin/main.go
+++ b/examples/langfuse-plugin/main.go
@@ -1,0 +1,63 @@
+// Package main shows how to build a CLIProxyAPI binary with Langfuse
+// observability enabled.
+//
+// Every upstream request is forwarded to Langfuse as a generation span.
+// When an upstream gateway sets X-Request-Id the span is attached to the
+// parent trace; otherwise a fresh trace is created.
+//
+// Required environment variables:
+//
+//	LANGFUSE_BASE_URL   e.g. https://cloud.langfuse.com
+//	LANGFUSE_PUBLIC_KEY pk-lf-...
+//	LANGFUSE_SECRET_KEY sk-lf-...
+//
+// Build and run:
+//
+//	go build -o cpa-langfuse ./examples/langfuse-plugin
+//	LANGFUSE_BASE_URL=https://cloud.langfuse.com \
+//	LANGFUSE_PUBLIC_KEY=pk-lf-... \
+//	LANGFUSE_SECRET_KEY=sk-lf-... \
+//	./cpa-langfuse -config config.yaml
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/examples/langfuse-plugin/langfuse"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	log "github.com/sirupsen/logrus"
+)
+
+func main() {
+	cfg, err := config.LoadConfig("config.yaml")
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	// Register the Langfuse plugin if credentials are present in the environment.
+	// No-op when env vars are not set, so the binary is safe to run without them.
+	if lf := langfuse.NewFromEnv(); lf != nil {
+		coreusage.RegisterPlugin(lf)
+		log.Info("langfuse plugin: registered")
+	} else {
+		log.Info("langfuse plugin: skipped (LANGFUSE_BASE_URL / PUBLIC_KEY / SECRET_KEY not set)")
+	}
+
+	svc, err := cliproxy.NewBuilder().
+		WithConfig(cfg).
+		WithConfigPath("config.yaml").
+		Build()
+	if err != nil {
+		log.Fatalf("failed to build service: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err = svc.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		log.Fatalf("service error: %v", err)
+	}
+}

--- a/examples/langfuse-plugin/main.go
+++ b/examples/langfuse-plugin/main.go
@@ -23,6 +23,7 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/examples/langfuse-plugin/langfuse"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy"
@@ -32,7 +33,10 @@ import (
 )
 
 func main() {
-	cfg, err := config.LoadConfig("config.yaml")
+	configPath := flag.String("config", "config.yaml", "Path to config file")
+	flag.Parse()
+
+	cfg, err := config.LoadConfig(*configPath)
 	if err != nil {
 		log.Fatalf("failed to load config: %v", err)
 	}
@@ -48,7 +52,7 @@ func main() {
 
 	svc, err := cliproxy.NewBuilder().
 		WithConfig(cfg).
-		WithConfigPath("config.yaml").
+		WithConfigPath(*configPath).
 		Build()
 	if err != nil {
 		log.Fatalf("failed to build service: %v", err)

--- a/examples/langfuse-plugin/main.go
+++ b/examples/langfuse-plugin/main.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/joho/godotenv"
 	"github.com/router-for-me/CLIProxyAPI/v7/examples/langfuse-plugin/langfuse"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
@@ -44,6 +45,11 @@ func main() {
 func run() error {
 	configPath := flag.String("config", "config.yaml", "Path to config file")
 	flag.Parse()
+
+	// Load .env if present so credentials can be supplied via a dotenv file
+	// rather than the shell environment. Errors are silently ignored because
+	// the file is optional.
+	_ = godotenv.Load()
 
 	cfg, err := config.LoadConfig(*configPath)
 	if err != nil {

--- a/examples/langfuse-plugin/main.go
+++ b/examples/langfuse-plugin/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/router-for-me/CLIProxyAPI/v7/examples/langfuse-plugin/langfuse"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator/builtin"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -73,6 +73,19 @@ func RequestedModelAliasFromContext(ctx context.Context) string {
 	}
 }
 
+// Context keys written to the gin context by the proxy runtime regardless of
+// request logging settings. Plugins can read these to access request data.
+const (
+	// CtxUpstreamURL is the outbound upstream URL for the request.
+	CtxUpstreamURL = "upstream_url"
+	// CtxFirstUserMsg is the text of the first user message (truncated to 2000 chars).
+	CtxFirstUserMsg = "upstream_first_user_msg"
+	// CtxResponseText is the accumulated response text (truncated to 4000 chars).
+	CtxResponseText = "upstream_response_text"
+	// CtxRawUsage holds token counts as map[string]int64 from upstream usage fields.
+	CtxRawUsage = "upstream_raw_usage"
+)
+
 // Plugin consumes usage records emitted by the proxy runtime.
 type Plugin interface {
 	HandleUsage(ctx context.Context, record Record)

--- a/sdk/cliproxy/usage/manager_test.go
+++ b/sdk/cliproxy/usage/manager_test.go
@@ -1,0 +1,28 @@
+package usage_test
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+// TestContextKeyConstants guards against accidental renames of the SDK
+// constants that plugin authors reference. The string values must stay
+// stable because they are the contract between the runtime and plugins.
+func TestContextKeyConstants(t *testing.T) {
+	cases := []struct {
+		name  string
+		got   string
+		want  string
+	}{
+		{"CtxUpstreamURL", usage.CtxUpstreamURL, "upstream_url"},
+		{"CtxFirstUserMsg", usage.CtxFirstUserMsg, "upstream_first_user_msg"},
+		{"CtxResponseText", usage.CtxResponseText, "upstream_response_text"},
+		{"CtxRawUsage", usage.CtxRawUsage, "upstream_raw_usage"},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds a working example of a [Langfuse](https://langfuse.com) observability
plugin built on top of the `usage.Plugin` interface.

**Depends on #3392** (always-on gin context keys). Without that PR the
plugin still works but `input`, `output` and token counts will be empty
unless the provider populates them through `Record.Detail`.

## What is added

`examples/langfuse-plugin/` - a standalone binary that can be built and
run in place of the standard `CLIProxyAPIPlus`:

```
examples/langfuse-plugin/
  main.go              entry point, registers plugin and starts the service
  langfuse/
    client.go          thin HTTP client for Langfuse Ingestion API
    plugin.go          usage.Plugin implementation
  README.md
```

`sdk/cliproxy/usage/manager.go` - four exported constants for the gin
context keys written by the runtime (`CtxUpstreamURL`, `CtxFirstUserMsg`,
`CtxResponseText`, `CtxRawUsage`). These let plugin authors reference the
keys without depending on `internal/`.

## How it works

The plugin implements `HandleUsage(ctx, record)`. For each upstream
request it produces one Langfuse `generation-create` event:

| Field | Source |
|---|---|
| `traceId` | `__request_id__` from gin context, or fresh UUID |
| `model` | `record.Model` |
| `input` | `upstream_first_user_msg` gin key |
| `output` | `upstream_response_text` gin key |
| `usage` | `upstream_raw_usage` gin key, falls back to `record.Detail` |
| `metadata` | provider, auth_id, latency_ms, upstream_url |

The HTTP call is fire-and-forget in a goroutine.

## Usage

```sh
go build -o cpa-langfuse ./examples/langfuse-plugin

LANGFUSE_BASE_URL=https://cloud.langfuse.com \
LANGFUSE_PUBLIC_KEY=pk-lf-... \
LANGFUSE_SECRET_KEY=sk-lf-... \
./cpa-langfuse -config config.yaml
```

When the env vars are absent the binary starts normally with no Langfuse
traffic.
