### PR TITLE
feat(api): Add Disabled Field Support and Unified /provider Endpoint

### DIFF
--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -34,18 +34,20 @@ type openAICompatibilityAPIKeyWithAuthIndex struct {
 }
 
 type openAICompatibilityWithAuthIndex struct {
-	Name          string                                   `json:"name"`
-	Priority      int                                      `json:"priority,omitempty"`
-	Disabled      bool                                     `json:"disabled"`
-	Prefix        string                                   `json:"prefix,omitempty"`
-	BaseURL       string                                   `json:"base-url"`
-	APIKeyEntries []openAICompatibilityAPIKeyWithAuthIndex `json:"api-key-entries,omitempty"`
-	Models        []config.OpenAICompatibilityModel        `json:"models,omitempty"`
-	Headers       map[string]string                        `json:"headers,omitempty"`
-	ExcludedModels []string                                `json:"excluded-models,omitempty"`
-	AuthIndex     string                                   `json:"auth-index,omitempty"`
+	Name           string                                   `json:"name"`
+	Priority       int                                      `json:"priority,omitempty"`
+	Disabled       bool                                     `json:"disabled"`
+	Prefix         string                                   `json:"prefix,omitempty"`
+	BaseURL        string                                   `json:"base-url"`
+	APIKeyEntries  []openAICompatibilityAPIKeyWithAuthIndex `json:"api-key-entries,omitempty"`
+	Models         []config.OpenAICompatibilityModel        `json:"models,omitempty"`
+	Headers        map[string]string                        `json:"headers,omitempty"`
+	ExcludedModels []string                                 `json:"excluded-models,omitempty"`
+	AuthIndex      string                                   `json:"auth-index,omitempty"`
 }
 
+// liveAuthIndexByID builds a map of auth ID -> auth index from the live auth manager.
+// This method acquires and releases h.mu internally; callers should not hold the lock.
 func (h *Handler) liveAuthIndexByID() map[string]string {
 	out := map[string]string{}
 	if h == nil {
@@ -57,7 +59,7 @@ func (h *Handler) liveAuthIndexByID() map[string]string {
 	if manager == nil {
 		return out
 	}
-	// authManager.List() returns clones, so EnsureIndex only affects these copies.
+	// authManager.List() returns clones; EnsureIndex modifies only these temporary copies.
 	for _, auth := range manager.List() {
 		if auth == nil {
 			continue
@@ -78,18 +80,24 @@ func (h *Handler) liveAuthIndexByID() map[string]string {
 	return out
 }
 
+// geminiKeysWithAuthIndex returns Gemini key configs with auth index.
+// liveAuthIndexByID acquires/releases h.mu internally, then this method acquires h.mu to protect cfg.
 func (h *Handler) geminiKeysWithAuthIndex() []geminiKeyWithAuthIndex {
 	if h == nil {
 		return nil
 	}
 	liveIndexByID := h.liveAuthIndexByID()
-
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.cfg == nil {
 		return nil
 	}
+	return h.geminiKeysWithAuthIndexWithoutLock(liveIndexByID)
+}
 
+// geminiKeysWithAuthIndexWithoutLock returns Gemini key configs with auth index (no lock management).
+// Caller must hold h.mu. h.cfg must not be nil.
+func (h *Handler) geminiKeysWithAuthIndexWithoutLock(liveIndexByID map[string]string) []geminiKeyWithAuthIndex {
 	idGen := synthesizer.NewStableIDGenerator()
 	out := make([]geminiKeyWithAuthIndex, len(h.cfg.GeminiKey))
 	for i := range h.cfg.GeminiKey {
@@ -107,18 +115,24 @@ func (h *Handler) geminiKeysWithAuthIndex() []geminiKeyWithAuthIndex {
 	return out
 }
 
+// claudeKeysWithAuthIndex returns Claude key configs with auth index.
+// liveAuthIndexByID acquires/releases h.mu internally, then this method acquires h.mu to protect cfg.
 func (h *Handler) claudeKeysWithAuthIndex() []claudeKeyWithAuthIndex {
 	if h == nil {
 		return nil
 	}
 	liveIndexByID := h.liveAuthIndexByID()
-
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.cfg == nil {
 		return nil
 	}
+	return h.claudeKeysWithAuthIndexWithoutLock(liveIndexByID)
+}
 
+// claudeKeysWithAuthIndexWithoutLock returns Claude key configs with auth index (no lock management).
+// Caller must hold h.mu. h.cfg must not be nil.
+func (h *Handler) claudeKeysWithAuthIndexWithoutLock(liveIndexByID map[string]string) []claudeKeyWithAuthIndex {
 	idGen := synthesizer.NewStableIDGenerator()
 	out := make([]claudeKeyWithAuthIndex, len(h.cfg.ClaudeKey))
 	for i := range h.cfg.ClaudeKey {
@@ -136,18 +150,24 @@ func (h *Handler) claudeKeysWithAuthIndex() []claudeKeyWithAuthIndex {
 	return out
 }
 
+// codexKeysWithAuthIndex returns Codex key configs with auth index.
+// liveAuthIndexByID acquires/releases h.mu internally, then this method acquires h.mu to protect cfg.
 func (h *Handler) codexKeysWithAuthIndex() []codexKeyWithAuthIndex {
 	if h == nil {
 		return nil
 	}
 	liveIndexByID := h.liveAuthIndexByID()
-
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.cfg == nil {
 		return nil
 	}
+	return h.codexKeysWithAuthIndexWithoutLock(liveIndexByID)
+}
 
+// codexKeysWithAuthIndexWithoutLock returns Codex key configs with auth index (no lock management).
+// Caller must hold h.mu. h.cfg must not be nil.
+func (h *Handler) codexKeysWithAuthIndexWithoutLock(liveIndexByID map[string]string) []codexKeyWithAuthIndex {
 	idGen := synthesizer.NewStableIDGenerator()
 	out := make([]codexKeyWithAuthIndex, len(h.cfg.CodexKey))
 	for i := range h.cfg.CodexKey {
@@ -165,18 +185,24 @@ func (h *Handler) codexKeysWithAuthIndex() []codexKeyWithAuthIndex {
 	return out
 }
 
+// vertexCompatKeysWithAuthIndex returns Vertex key configs with auth index.
+// liveAuthIndexByID acquires/releases h.mu internally, then this method acquires h.mu to protect cfg.
 func (h *Handler) vertexCompatKeysWithAuthIndex() []vertexCompatKeyWithAuthIndex {
 	if h == nil {
 		return nil
 	}
 	liveIndexByID := h.liveAuthIndexByID()
-
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.cfg == nil {
 		return nil
 	}
+	return h.vertexCompatKeysWithAuthIndexWithoutLock(liveIndexByID)
+}
 
+// vertexCompatKeysWithAuthIndexWithoutLock returns Vertex key configs with auth index (no lock management).
+// Caller must hold h.mu. h.cfg must not be nil.
+func (h *Handler) vertexCompatKeysWithAuthIndexWithoutLock(liveIndexByID map[string]string) []vertexCompatKeyWithAuthIndex {
 	idGen := synthesizer.NewStableIDGenerator()
 	out := make([]vertexCompatKeyWithAuthIndex, len(h.cfg.VertexCompatAPIKey))
 	for i := range h.cfg.VertexCompatAPIKey {
@@ -191,18 +217,24 @@ func (h *Handler) vertexCompatKeysWithAuthIndex() []vertexCompatKeyWithAuthIndex
 	return out
 }
 
+// openAICompatibilityWithAuthIndex returns OpenAI compatibility configs with auth index.
+// liveAuthIndexByID acquires/releases h.mu internally, then this method acquires h.mu to protect cfg.
 func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAuthIndex {
 	if h == nil {
 		return nil
 	}
 	liveIndexByID := h.liveAuthIndexByID()
-
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.cfg == nil {
 		return nil
 	}
+	return h.openAICompatibilityWithAuthIndexWithoutLock(liveIndexByID)
+}
 
+// openAICompatibilityWithAuthIndexWithoutLock returns OpenAI compatibility configs with auth index (no lock management).
+// Caller must hold h.mu. h.cfg must not be nil.
+func (h *Handler) openAICompatibilityWithAuthIndexWithoutLock(liveIndexByID map[string]string) []openAICompatibilityWithAuthIndex {
 	normalized := normalizedOpenAICompatibilityEntries(h.cfg.OpenAICompatibility)
 	out := make([]openAICompatibilityWithAuthIndex, len(normalized))
 	idGen := synthesizer.NewStableIDGenerator()
@@ -242,4 +274,31 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 		out[i] = response
 	}
 	return out
+}
+
+// allProvidersWithAuthIndex returns all provider configurations with auth index.
+// Acquires h.mu once for all providers (vs 5 separate lock acquisitions
+// when calling individual *WithAuthIndex() methods).
+// liveAuthIndexByID acquires/releases h.mu internally, then this method acquires h.mu
+// and delegates to *WithoutLock methods to build all results.
+func (h *Handler) allProvidersWithAuthIndex() map[string]any {
+	if h == nil {
+		return nil
+	}
+	liveIndexByID := h.liveAuthIndexByID()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.cfg == nil {
+		return nil
+	}
+
+	result := make(map[string]any, 5)
+	result["gemini-api-key"] = h.geminiKeysWithAuthIndexWithoutLock(liveIndexByID)
+	result["claude-api-key"] = h.claudeKeysWithAuthIndexWithoutLock(liveIndexByID)
+	result["codex-api-key"] = h.codexKeysWithAuthIndexWithoutLock(liveIndexByID)
+	result["openai-compatibility"] = h.openAICompatibilityWithAuthIndexWithoutLock(liveIndexByID)
+	result["vertex-api-key"] = h.vertexCompatKeysWithAuthIndexWithoutLock(liveIndexByID)
+
+	return result
 }

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -42,6 +42,7 @@ type openAICompatibilityWithAuthIndex struct {
 	APIKeyEntries []openAICompatibilityAPIKeyWithAuthIndex `json:"api-key-entries,omitempty"`
 	Models        []config.OpenAICompatibilityModel        `json:"models,omitempty"`
 	Headers       map[string]string                        `json:"headers,omitempty"`
+	ExcludedModels []string                                `json:"excluded-models,omitempty"`
 	AuthIndex     string                                   `json:"auth-index,omitempty"`
 }
 
@@ -214,14 +215,15 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 		idKind := fmt.Sprintf("openai-compatibility:%s", providerName)
 
 		response := openAICompatibilityWithAuthIndex{
-			Name:      entry.Name,
-			Priority:  entry.Priority,
-			Disabled:  entry.Disabled,
-			Prefix:    entry.Prefix,
-			BaseURL:   entry.BaseURL,
-			Models:    entry.Models,
-			Headers:   entry.Headers,
-			AuthIndex: "",
+			Name:           entry.Name,
+			Priority:       entry.Priority,
+			Disabled:       entry.Disabled,
+			Prefix:         entry.Prefix,
+			BaseURL:        entry.BaseURL,
+			Models:         entry.Models,
+			Headers:        entry.Headers,
+			ExcludedModels: entry.ExcludedModels,
+			AuthIndex:      "",
 		}
 		if len(entry.APIKeyEntries) == 0 {
 			id, _ := idGen.Next(idKind, entry.BaseURL)

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -9,6 +9,30 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
+// parseRawItemsForDisabledCheck parses the request body to extract raw items
+// for disabled field detection. Supports both direct array format:
+//
+//	[{"api-key": "...", "disabled": true}, ...]
+//
+// and {"items": [...]} wrapper format (used by some SDK callers):
+//
+//	{"items": [{"api-key": "...", "disabled": true}, ...]}
+//
+// Returns nil if neither format can be parsed.
+func parseRawItemsForDisabledCheck(data []byte) []map[string]any {
+	var raw []map[string]any
+	if err := json.Unmarshal(data, &raw); err == nil {
+		return raw
+	}
+	var obj struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(data, &obj); err == nil {
+		return obj.Items
+	}
+	return nil
+}
+
 // Generic helpers for list[string]
 func (h *Handler) putStringList(c *gin.Context, set func([]string), after func()) {
 	data, err := c.GetRawData()
@@ -140,15 +164,15 @@ func (h *Handler) PutGeminiKeys(c *gin.Context) {
 		arr = obj.Items
 	}
 	// Check if "disabled" field was explicitly provided in raw JSON.
-	var raw []map[string]any
-	_ = json.Unmarshal(data, &raw)
+	// Supports both direct array and {"items": [...]} wrapper format.
+	rawItems := parseRawItemsForDisabledCheck(data)
 	for i := range arr {
 		normalizeGeminiKey(&arr[i])
 		// If excluded-models is ["*"] and "disabled" was not explicitly set,
 		// auto-enable disabled to maintain backward compatibility.
 		disabledProvided := false
-		if raw != nil && i < len(raw) {
-			if _, ok := raw[i]["disabled"]; ok {
+		if rawItems != nil && i < len(rawItems) {
+			if _, ok := rawItems[i]["disabled"]; ok {
 				disabledProvided = true
 			}
 		}
@@ -314,15 +338,15 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 		arr = obj.Items
 	}
 	// Check if "disabled" field was explicitly provided in raw JSON.
-	var raw []map[string]any
-	_ = json.Unmarshal(data, &raw)
+	// Supports both direct array and {"items": [...]} wrapper format.
+	rawItems := parseRawItemsForDisabledCheck(data)
 	for i := range arr {
 		normalizeClaudeKey(&arr[i])
 		// If excluded-models is ["*"] and "disabled" was not explicitly set,
 		// auto-enable disabled to maintain backward compatibility.
 		disabledProvided := false
-		if raw != nil && i < len(raw) {
-			if _, ok := raw[i]["disabled"]; ok {
+		if rawItems != nil && i < len(rawItems) {
+			if _, ok := rawItems[i]["disabled"]; ok {
 				disabledProvided = true
 			}
 		}
@@ -490,16 +514,16 @@ func (h *Handler) PutOpenAICompat(c *gin.Context) {
 		arr = obj.Items
 	}
 	// Check if "disabled" field was explicitly provided in raw JSON.
-	var raw []map[string]any
-	_ = json.Unmarshal(data, &raw)
+	// Supports both direct array and {"items": [...]} wrapper format.
+	rawItems := parseRawItemsForDisabledCheck(data)
 	filtered := make([]config.OpenAICompatibility, 0, len(arr))
 	for i := range arr {
 		normalizeOpenAICompatibilityEntry(&arr[i])
 		// If excluded-models is ["*"] and "disabled" was not explicitly set,
 		// auto-enable disabled to maintain backward compatibility.
 		disabledProvided := false
-		if raw != nil && i < len(raw) {
-			if _, ok := raw[i]["disabled"]; ok {
+		if rawItems != nil && i < len(rawItems) {
+			if _, ok := rawItems[i]["disabled"]; ok {
 				disabledProvided = true
 			}
 		}
@@ -641,15 +665,15 @@ func (h *Handler) PutVertexCompatKeys(c *gin.Context) {
 		arr = obj.Items
 	}
 	// Check if "disabled" field was explicitly provided in raw JSON.
-	var raw []map[string]any
-	_ = json.Unmarshal(data, &raw)
+	// Supports both direct array and {"items": [...]} wrapper format.
+	rawItems := parseRawItemsForDisabledCheck(data)
 	for i := range arr {
 		normalizeVertexCompatKey(&arr[i])
 		// If excluded-models is ["*"] and "disabled" was not explicitly set,
 		// auto-enable disabled to maintain backward compatibility.
 		disabledProvided := false
-		if raw != nil && i < len(raw) {
-			if _, ok := raw[i]["disabled"]; ok {
+		if rawItems != nil && i < len(rawItems) {
+			if _, ok := rawItems[i]["disabled"]; ok {
 				disabledProvided = true
 			}
 		}
@@ -1008,8 +1032,8 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 		arr = obj.Items
 	}
 	// Check if "disabled" field was explicitly provided in raw JSON.
-	var raw []map[string]any
-	_ = json.Unmarshal(data, &raw)
+	// Supports both direct array and {"items": [...]} wrapper format.
+	rawItems := parseRawItemsForDisabledCheck(data)
 	// Filter out codex entries with empty base-url (treat as removed)
 	filtered := make([]config.CodexKey, 0, len(arr))
 	for i := range arr {
@@ -1018,8 +1042,8 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 		// If excluded-models is ["*"] and "disabled" was not explicitly set,
 		// auto-enable disabled to maintain backward compatibility.
 		disabledProvided := false
-		if raw != nil && i < len(raw) {
-			if _, ok := raw[i]["disabled"]; ok {
+		if rawItems != nil && i < len(rawItems) {
+			if _, ok := rawItems[i]["disabled"]; ok {
 				disabledProvided = true
 			}
 		}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -139,6 +139,23 @@ func (h *Handler) PutGeminiKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
+	// Check if "disabled" field was explicitly provided in raw JSON.
+	var raw []map[string]any
+	_ = json.Unmarshal(data, &raw)
+	for i := range arr {
+		normalizeGeminiKey(&arr[i])
+		// If excluded-models is ["*"] and "disabled" was not explicitly set,
+		// auto-enable disabled to maintain backward compatibility.
+		disabledProvided := false
+		if raw != nil && i < len(raw) {
+			if _, ok := raw[i]["disabled"]; ok {
+				disabledProvided = true
+			}
+		}
+		if !disabledProvided && len(arr[i].ExcludedModels) == 1 && arr[i].ExcludedModels[0] == "*" {
+			arr[i].Disabled = true
+		}
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.cfg.GeminiKey = append([]config.GeminiKey(nil), arr...)
@@ -296,8 +313,22 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
+	// Check if "disabled" field was explicitly provided in raw JSON.
+	var raw []map[string]any
+	_ = json.Unmarshal(data, &raw)
 	for i := range arr {
 		normalizeClaudeKey(&arr[i])
+		// If excluded-models is ["*"] and "disabled" was not explicitly set,
+		// auto-enable disabled to maintain backward compatibility.
+		disabledProvided := false
+		if raw != nil && i < len(raw) {
+			if _, ok := raw[i]["disabled"]; ok {
+				disabledProvided = true
+			}
+		}
+		if !disabledProvided && len(arr[i].ExcludedModels) == 1 && arr[i].ExcludedModels[0] == "*" {
+			arr[i].Disabled = true
+		}
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -426,6 +457,17 @@ func (h *Handler) DeleteClaudeKey(c *gin.Context) {
 	c.JSON(400, gin.H{"error": "missing api-key or index"})
 }
 
+// provider: returns all provider configurations aggregated
+func (h *Handler) GetProvider(c *gin.Context) {
+	c.JSON(200, gin.H{
+		"gemini-api-key":       h.geminiKeysWithAuthIndex(),
+		"claude-api-key":       h.claudeKeysWithAuthIndex(),
+		"codex-api-key":        h.codexKeysWithAuthIndex(),
+		"openai-compatibility": h.openAICompatibilityWithAuthIndex(),
+		"vertex-api-key":       h.vertexCompatKeysWithAuthIndex(),
+	})
+}
+
 // openai-compatibility: []OpenAICompatibility
 func (h *Handler) GetOpenAICompat(c *gin.Context) {
 	c.JSON(200, gin.H{"openai-compatibility": h.openAICompatibilityWithAuthIndex()})
@@ -447,9 +489,23 @@ func (h *Handler) PutOpenAICompat(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
+	// Check if "disabled" field was explicitly provided in raw JSON.
+	var raw []map[string]any
+	_ = json.Unmarshal(data, &raw)
 	filtered := make([]config.OpenAICompatibility, 0, len(arr))
 	for i := range arr {
 		normalizeOpenAICompatibilityEntry(&arr[i])
+		// If excluded-models is ["*"] and "disabled" was not explicitly set,
+		// auto-enable disabled to maintain backward compatibility.
+		disabledProvided := false
+		if raw != nil && i < len(raw) {
+			if _, ok := raw[i]["disabled"]; ok {
+				disabledProvided = true
+			}
+		}
+		if !disabledProvided && len(arr[i].ExcludedModels) == 1 && arr[i].ExcludedModels[0] == "*" {
+			arr[i].Disabled = true
+		}
 		if strings.TrimSpace(arr[i].BaseURL) != "" {
 			filtered = append(filtered, arr[i])
 		}
@@ -584,8 +640,22 @@ func (h *Handler) PutVertexCompatKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
+	// Check if "disabled" field was explicitly provided in raw JSON.
+	var raw []map[string]any
+	_ = json.Unmarshal(data, &raw)
 	for i := range arr {
 		normalizeVertexCompatKey(&arr[i])
+		// If excluded-models is ["*"] and "disabled" was not explicitly set,
+		// auto-enable disabled to maintain backward compatibility.
+		disabledProvided := false
+		if raw != nil && i < len(raw) {
+			if _, ok := raw[i]["disabled"]; ok {
+				disabledProvided = true
+			}
+		}
+		if !disabledProvided && len(arr[i].ExcludedModels) == 1 && arr[i].ExcludedModels[0] == "*" {
+			arr[i].Disabled = true
+		}
 		if arr[i].APIKey == "" {
 			c.JSON(400, gin.H{"error": fmt.Sprintf("vertex-api-key[%d].api-key is required", i)})
 			return
@@ -937,11 +1007,25 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
+	// Check if "disabled" field was explicitly provided in raw JSON.
+	var raw []map[string]any
+	_ = json.Unmarshal(data, &raw)
 	// Filter out codex entries with empty base-url (treat as removed)
 	filtered := make([]config.CodexKey, 0, len(arr))
 	for i := range arr {
 		entry := arr[i]
 		normalizeCodexKey(&entry)
+		// If excluded-models is ["*"] and "disabled" was not explicitly set,
+		// auto-enable disabled to maintain backward compatibility.
+		disabledProvided := false
+		if raw != nil && i < len(raw) {
+			if _, ok := raw[i]["disabled"]; ok {
+				disabledProvided = true
+			}
+		}
+		if !disabledProvided && len(entry.ExcludedModels) == 1 && entry.ExcludedModels[0] == "*" {
+			entry.Disabled = true
+		}
 		if entry.BaseURL == "" {
 			continue
 		}
@@ -1088,6 +1172,7 @@ func normalizeOpenAICompatibilityEntry(entry *config.OpenAICompatibility) {
 	// Trim base-url; empty base-url indicates provider should be removed by sanitization
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
 	existing := make(map[string]struct{}, len(entry.APIKeyEntries))
 	for i := range entry.APIKeyEntries {
 		trimmed := strings.TrimSpace(entry.APIKeyEntries[i].APIKey)
@@ -1127,6 +1212,32 @@ func normalizeClaudeKey(entry *config.ClaudeKey) {
 		return
 	}
 	normalized := make([]config.ClaudeModel, 0, len(entry.Models))
+	for i := range entry.Models {
+		model := entry.Models[i]
+		model.Name = strings.TrimSpace(model.Name)
+		model.Alias = strings.TrimSpace(model.Alias)
+		if model.Name == "" && model.Alias == "" {
+			continue
+		}
+		normalized = append(normalized, model)
+	}
+	entry.Models = normalized
+}
+
+// normalizeGeminiKey normalizes a Gemini key entry.
+func normalizeGeminiKey(entry *config.GeminiKey) {
+	if entry == nil {
+		return
+	}
+	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	if len(entry.Models) == 0 {
+		return
+	}
+	normalized := make([]config.GeminiModel, 0, len(entry.Models))
 	for i := range entry.Models {
 		model := entry.Models[i]
 		model.Name = strings.TrimSpace(model.Name)

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -483,13 +483,7 @@ func (h *Handler) DeleteClaudeKey(c *gin.Context) {
 
 // provider: returns all provider configurations aggregated
 func (h *Handler) GetProvider(c *gin.Context) {
-	c.JSON(200, gin.H{
-		"gemini-api-key":       h.geminiKeysWithAuthIndex(),
-		"claude-api-key":       h.claudeKeysWithAuthIndex(),
-		"codex-api-key":        h.codexKeysWithAuthIndex(),
-		"openai-compatibility": h.openAICompatibilityWithAuthIndex(),
-		"vertex-api-key":       h.vertexCompatKeysWithAuthIndex(),
-	})
+	c.JSON(200, h.allProvidersWithAuthIndex())
 }
 
 // openai-compatibility: []OpenAICompatibility

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -584,6 +584,8 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/api-key-usage", s.mgmt.GetAPIKeyUsage)
 		mgmt.GET("/usage-queue", s.mgmt.GetUsageQueue)
 
+		mgmt.GET("/provider", s.mgmt.GetProvider)
+
 		mgmt.GET("/gemini-api-key", s.mgmt.GetGeminiKeys)
 		mgmt.PUT("/gemini-api-key", s.mgmt.PutGeminiKeys)
 		mgmt.PATCH("/gemini-api-key", s.mgmt.PatchGeminiKey)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -379,6 +379,9 @@ type ClaudeKey struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// Disabled prevents this credential from being used for routing.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/claude-sonnet-4").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 
@@ -435,6 +438,9 @@ type CodexKey struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// Disabled prevents this credential from being used for routing.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/gpt-5-codex").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 
@@ -485,6 +491,9 @@ type GeminiKey struct {
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+
+	// Disabled prevents this credential from being used for routing.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
 
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/gemini-3-pro-preview").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
@@ -550,6 +559,9 @@ type OpenAICompatibility struct {
 
 	// Headers optionally adds extra HTTP headers for requests sent to this provider.
 	Headers map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+
+	// ExcludedModels lists model IDs that should be excluded for this provider.
+	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
 
 	// DisableCooling disables auth/model cooldown scheduling for this provider when true.
 	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -17,6 +17,9 @@ type VertexCompatKey struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// Disabled prevents this credential from being used for routing.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+
 	// Prefix optionally namespaces model aliases for this credential (e.g., "teamA/vertex-pro").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -74,12 +74,17 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeys(ctx *SynthesisContext) []*corea
 			attrs["models_hash"] = hash
 		}
 		addConfigHeadersToAttrs(entry.Headers, attrs)
+		authStatus := coreauth.StatusActive
+		if entry.Disabled {
+			authStatus = coreauth.StatusDisabled
+		}
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "gemini",
 			Label:      "gemini-apikey",
 			Prefix:     prefix,
-			Status:     coreauth.StatusActive,
+			Status:     authStatus,
+			Disabled:   entry.Disabled,
 			ProxyURL:   proxyURL,
 			Attributes: attrs,
 			Metadata:   metadata,
@@ -130,12 +135,17 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 		}
 		addConfigHeadersToAttrs(ck.Headers, attrs)
 		proxyURL := strings.TrimSpace(ck.ProxyURL)
+		authStatus := coreauth.StatusActive
+		if ck.Disabled {
+			authStatus = coreauth.StatusDisabled
+		}
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "claude",
 			Label:      "claude-apikey",
 			Prefix:     prefix,
-			Status:     coreauth.StatusActive,
+			Status:     authStatus,
+			Disabled:   ck.Disabled,
 			ProxyURL:   proxyURL,
 			Attributes: attrs,
 			Metadata:   metadata,
@@ -188,12 +198,17 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 		}
 		addConfigHeadersToAttrs(ck.Headers, attrs)
 		proxyURL := strings.TrimSpace(ck.ProxyURL)
+		authStatus := coreauth.StatusActive
+		if ck.Disabled {
+			authStatus = coreauth.StatusDisabled
+		}
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "codex",
 			Label:      "codex-apikey",
 			Prefix:     prefix,
-			Status:     coreauth.StatusActive,
+			Status:     authStatus,
+			Disabled:   ck.Disabled,
 			ProxyURL:   proxyURL,
 			Attributes: attrs,
 			Metadata:   metadata,
@@ -348,12 +363,17 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 			attrs["models_hash"] = hash
 		}
 		addConfigHeadersToAttrs(compat.Headers, attrs)
+		authStatus := coreauth.StatusActive
+		if compat.Disabled {
+			authStatus = coreauth.StatusDisabled
+		}
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   providerName,
 			Label:      "vertex-apikey",
 			Prefix:     prefix,
-			Status:     coreauth.StatusActive,
+			Status:     authStatus,
+			Disabled:   compat.Disabled,
 			ProxyURL:   proxyURL,
 			Attributes: attrs,
 			CreatedAt:  now,

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1223,6 +1223,11 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 							Thinking:    thinking,
 						})
 					}
+					// Apply excluded-models for OpenAI-compatibility providers
+					if authKind == "apikey" {
+						excluded = compat.ExcludedModels
+					}
+					ms = applyExcludedModels(ms, excluded)
 					// Register and return
 					if len(ms) > 0 {
 						if providerKey == "" {


### PR DESCRIPTION
## Summary

This PR introduces a `Disabled` field for all provider credential types and implements `ExcludedModels` support for `OpenAICompatibility`. It also adds a new `/provider` aggregation endpoint to simplify configuration management and cross-node synchronization.

## Motivation

Currently, synchronizing configurations between nodes is cumbersome when users need to filter out invalid or temporarily inactive accounts. By exposing the `Disabled` status:

1. **Efficient Syncing**: Users can export configurations, filter out disabled credentials (e.g., via `jq`), and re-import them to other nodes without manual intervention.
2. **State Retention**: Credentials can be deactivated without being deleted, preserving them for future troubleshooting.
3. **Feature Parity**: `OpenAICompatibility` now has the same fine-grained model exclusion capabilities as other provider types.

## Key Changes

### 1. Model Extensions

- **Disabled Field**: Added to `Claude`, `Gemini`, `Codex`, and `Vertex` structs. Used `omitempty` JSON tags to ensure **full backwards compatibility** with existing configuration files.
- **OpenAI Enhancement**: Added `ExcludedModels` support to `OpenAICompatibility` to align its capabilities with other providers.

### 2. Critical Bug Fix: Runtime Propagation

I discovered that the `ConfigSynthesizer` was previously hardcoding `StatusActive` for most providers during runtime object conversion. This meant that setting `disabled: true` in the config file had no actual effect on the scheduler. **This PR ensures the `Disabled` status correctly propagates to the core routing logic.**

### 3. Smart Logic & Normalization

- **Auto-Disable Trigger**: In `PUT` requests, if a user sets `excluded-models=["*"]` without explicitly providing a `disabled` value, the system now automatically infers `disabled: true`.
- **Input Sanitization**: Introduced a `NormalizeExcludedModels` utility to handle whitespace trimming, casing, and de-duplication across all provider types.

### 4. New Aggregation Endpoint

- **Endpoint**: `GET /provider`
- **Purpose**: Returns a complete snapshot of all provider configurations (including `auth_index`). This acts as a "one-stop-shop" for configuration backups and cluster-wide monitoring.

## Known Limitations

- Currently, toggling the `disabled` field via `PATCH` is only implemented for `OpenAICompatibility`.
- For other providers, users should use the `PUT` handler for full-replacement updates. Full `PATCH` support for these types is planned for a follow-up PR.

## Usage & Test Examples

This PR has been tested locally and verified through `curl`. All modified endpoints and the new `/provider` endpoint are functioning as expected.

- [x] Verified `Disabled` field persistence in config files.
- [x] Verified `ExcludedModels` filtering logic.
- [x] Confirmed the auto-disable trigger when `excluded-models=["*"]`.
- [x] Confirmed that `disabled: true` correctly stops credentials from being used at runtime.

### 1. Triggering Auto-Disable

Bash

```
# Setting excluded-models to ["*"] automatically marks the key as disabled
curl -X PUT http://localhost:8317/gemini-api-key \
  -H "Content-Type: application/json" \
  -d '[{"api-key": "your-key", "excluded-models": ["*"]}]'
```

### 2. Cross-Node Sync (Filtering Disabled Keys)

Bash

```
# Export from Node A, filter out disabled entries, and save for Node B
curl http://node-a:8317/provider | \
jq 'with_entries(.value |= map(select(.disabled != true)))' > filtered_config.json
```
<img width="1365" height="436" alt="image" src="https://github.com/user-attachments/assets/d016c8a0-b144-4a9f-8b19-39dbc0a9a398" />

<img width="1064" height="217" alt="image" src="https://github.com/user-attachments/assets/61abe1df-9bcf-4cd9-b2e7-f5e9da1ed83f" />