### PR TITLE
fix: repack loose objects before push to fix packfile not found on ephemeral filesystems

### DIFF
--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -858,6 +858,14 @@ func (s *GitTokenStore) commitAndPushLocked(message string, relPaths ...string) 
 	} else if errRewrite := s.rewriteHeadAsSingleCommit(repo, headRef.Name(), commitHash, message, signature); errRewrite != nil {
 		return errRewrite
 	}
+	// Repack loose objects written by rewriteHeadAsSingleCommit before pushing.
+	// On ephemeral filesystems (e.g. Render free tier), the repo is freshly cloned
+	// on every restart so all existing objects live in packfiles. The squashed orphan
+	// commit is written as a loose object; without repacking, go-git cannot locate it
+	// during push and returns "packfile not found".
+	if err := repo.RepackObjects(&git.RepackConfig{}); err != nil {
+		return fmt.Errorf("git token store: repack: %w", err)
+	}
 	pushOpts := &git.PushOptions{Auth: s.gitAuth(), Force: true}
 	if s.branch != "" {
 		pushOpts.RefSpecs = []config.RefSpec{config.RefSpec("refs/heads/" + s.branch + ":refs/heads/" + s.branch)}


### PR DESCRIPTION
## Problem

When deploying CPA on platforms with ephemeral filesystems (e.g. Render free tier, Railway, Fly.io), the git token store fails to push any config changes after a service restart with the following error:

```
failed to persist config change: git token store: push: getting object: packfile not found
```

This affects **all users** on ephemeral filesystem platforms using Git Token Store — they cannot persist any config changes after a service restart.

## Root Cause

In `commitAndPushLocked()` (`internal/store/gitstore.go`):

1. A normal commit is created via `worktree.Commit()`
2. `rewriteHeadAsSingleCommit()` is then called, which creates a **new parentless (orphan) commit object** and writes it directly to `repo.Storer` as a **loose object**
3. The branch reference is updated to point to this new squashed commit hash
4. When `repo.Push()` is called, `go-git` tries to resolve the object for packing but **cannot find it in any packfile** → `packfile not found`

On ephemeral filesystems, the repo is freshly cloned on every service restart. After a fresh clone, **all objects live in packfiles**. The squashed orphan commit is written as a loose object but `go-git`'s push logic fails to locate it, causing the error.

## Fix

Add `repo.RepackObjects()` after `rewriteHeadAsSingleCommit()` and before `Push()` to ensure the newly written loose object is packed before the push attempt. This is a minimal, targeted fix that preserves the existing squash behavior.

```go
// Before (broken on ephemeral fs)
} else if errRewrite := s.rewriteHeadAsSingleCommit(...); errRewrite != nil {
    return errRewrite
}
s.maybeRunGC(repo)

// After (fixed)
} else if errRewrite := s.rewriteHeadAsSingleCommit(...); errRewrite != nil {
    return errRewrite
}
_ = repo.RepackObjects(&git.RepackConfig{})
s.maybeRunGC(repo)
```

## Testing

Verified on Render free Web Service with `GITSTORE_LOCAL_PATH=/tmp`:
- Before fix: every config update fails with `packfile not found` after service restart
- After fix: config updates push successfully even after service restart / fresh clone