### PR TITLE
fix(openai-compat): avoid rejecting xhigh for known upstream models

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -264,7 +264,7 @@ nonstream-keepalive-interval: 0
 #     models: # The models supported by the provider.
 #       - name: "moonshotai/kimi-k2:free" # The actual model name.
 #         alias: "kimi-k2"               # The alias used in the API.
-#         thinking:                      # optional: omit to default to levels ["low","medium","high"]
+#         thinking:                      # optional: omit to inherit known static capabilities, otherwise default to ["low","medium","high"]
 #           levels: ["low", "medium", "high"]
 #       # You may repeat the same alias to build an internal model pool.
 #       # The client still sees only one alias in the model list.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -574,7 +574,8 @@ type OpenAICompatibilityModel struct {
 	Alias string `yaml:"alias" json:"alias"`
 
 	// Thinking configures the thinking/reasoning capability for this model.
-	// If nil, the model defaults to level-based reasoning with levels ["low", "medium", "high"].
+	// If nil, the model inherits static thinking metadata for known upstream models when available;
+	// otherwise it defaults to level-based reasoning with levels ["low", "medium", "high"].
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -56,8 +56,8 @@ type ModelInfo struct {
 	// This is optional and currently used for Gemini thinking budget normalization.
 	Thinking *ThinkingSupport `json:"thinking,omitempty"`
 
-	// UserDefined indicates this model was defined through config file's models[]
-	// array (e.g., openai-compatibility.*.models[], *-api-key.models[]).
+	// UserDefined indicates this model was defined as a passthrough alias via
+	// config file models[] entries (for example, *-api-key.models[]).
 	// UserDefined models have thinking configuration passed through without validation.
 	UserDefined bool `json:"-"`
 }

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -34,9 +34,9 @@ func RegisterProvider(name string, applier ProviderApplier) {
 // IsUserDefinedModel reports whether the model is a user-defined model that should
 // have thinking configuration passed through without validation.
 //
-// User-defined models are configured via config file's models[] array
-// (e.g., openai-compatibility.*.models[], *-api-key.models[]). These models
-// are marked with UserDefined=true at registration time.
+// User-defined models are passthrough aliases configured via config file
+// models[] entries (for example, *-api-key.models[]). These models are marked
+// with UserDefined=true at registration time.
 //
 // User-defined models should have their thinking configuration applied directly,
 // letting the upstream service validate the configuration.

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1215,6 +1215,8 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 							OwnedBy:     compat.Name,
 							Type:        "openai-compatibility",
 							DisplayName: modelID,
+							// Keep compatibility models validated against explicit or inherited
+							// capability metadata instead of treating them as passthrough aliases.
 							UserDefined: false,
 							Thinking:    resolveOpenAICompatibilityThinking(m),
 						})
@@ -1600,25 +1602,34 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 			DisplayName: display,
 			UserDefined: true,
 		}
-		if name != "" {
-			if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
-				info.Thinking = upstream.Thinking
-			}
+		if thinking, ok := lookupStaticThinkingSupport(name); ok {
+			info.Thinking = thinking
 		}
 		out = append(out, info)
 	}
 	return out
 }
 
+func lookupStaticThinkingSupport(name string) (*registry.ThinkingSupport, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, false
+	}
+	upstream := registry.LookupStaticModelInfo(name)
+	if upstream == nil {
+		return nil, false
+	}
+	return upstream.Thinking, true
+}
+
 func resolveOpenAICompatibilityThinking(model config.OpenAICompatibilityModel) *registry.ThinkingSupport {
 	if model.Thinking != nil {
 		return model.Thinking
 	}
-	name := strings.TrimSpace(model.Name)
-	if name != "" {
-		if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
-			return upstream.Thinking
-		}
+	if thinking, ok := lookupStaticThinkingSupport(model.Name); ok {
+		// Treat a known static model as authoritative even when it intentionally
+		// declares no thinking support.
+		return thinking
 	}
 	return &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1602,7 +1602,7 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 			DisplayName: display,
 			UserDefined: true,
 		}
-		if thinking, ok := lookupStaticThinkingSupport(name); ok {
+		if thinking, ok := lookupStaticThinkingSupport(name, alias); ok {
 			info.Thinking = thinking
 		}
 		out = append(out, info)
@@ -1610,12 +1610,17 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 	return out
 }
 
-func lookupStaticThinkingSupport(name string) (*registry.ThinkingSupport, bool) {
+func lookupStaticThinkingSupport(name, alias string) (*registry.ThinkingSupport, bool) {
 	name = strings.TrimSpace(name)
-	if name == "" {
+	alias = strings.TrimSpace(alias)
+	lookupID := name
+	if lookupID == "" {
+		lookupID = alias
+	}
+	if lookupID == "" {
 		return nil, false
 	}
-	upstream := registry.LookupStaticModelInfo(name)
+	upstream := registry.LookupStaticModelInfo(lookupID)
 	if upstream == nil {
 		return nil, false
 	}
@@ -1626,7 +1631,7 @@ func resolveOpenAICompatibilityThinking(model config.OpenAICompatibilityModel) *
 	if model.Thinking != nil {
 		return model.Thinking
 	}
-	if thinking, ok := lookupStaticThinkingSupport(model.Name); ok {
+	if thinking, ok := lookupStaticThinkingSupport(model.Name, model.Alias); ok {
 		// Treat a known static model as authoritative even when it intentionally
 		// declares no thinking support.
 		return thinking

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1208,10 +1208,6 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 						if modelID == "" {
 							modelID = m.Name
 						}
-						thinking := m.Thinking
-						if thinking == nil {
-							thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
-						}
 						ms = append(ms, &ModelInfo{
 							ID:          modelID,
 							Object:      "model",
@@ -1220,7 +1216,7 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 							Type:        "openai-compatibility",
 							DisplayName: modelID,
 							UserDefined: false,
-							Thinking:    thinking,
+							Thinking:    resolveOpenAICompatibilityThinking(m),
 						})
 					}
 					// Register and return
@@ -1612,6 +1608,19 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 		out = append(out, info)
 	}
 	return out
+}
+
+func resolveOpenAICompatibilityThinking(model config.OpenAICompatibilityModel) *registry.ThinkingSupport {
+	if model.Thinking != nil {
+		return model.Thinking
+	}
+	name := strings.TrimSpace(model.Name)
+	if name != "" {
+		if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
+			return upstream.Thinking
+		}
+	}
+	return &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
 }
 
 func buildVertexCompatConfigModels(entry *config.VertexCompatKey) []*ModelInfo {

--- a/sdk/cliproxy/service_openai_compat_thinking_test.go
+++ b/sdk/cliproxy/service_openai_compat_thinking_test.go
@@ -57,6 +57,22 @@ func TestResolveOpenAICompatibilityThinking_KnownModelWithoutThinkingRemainsNil(
 	}
 }
 
+func TestResolveOpenAICompatibilityThinking_UsesAliasWhenNameIsEmpty(t *testing.T) {
+	upstream := registry.LookupStaticModelInfo("gpt-5.5")
+	if upstream == nil || upstream.Thinking == nil {
+		t.Fatal("expected gpt-5.5 static model definition with thinking support")
+	}
+
+	model := config.OpenAICompatibilityModel{
+		Alias: "gpt-5.5",
+	}
+
+	got := resolveOpenAICompatibilityThinking(model)
+	if !reflect.DeepEqual(got, upstream.Thinking) {
+		t.Fatalf("thinking mismatch: got %+v, want %+v", got, upstream.Thinking)
+	}
+}
+
 func TestResolveOpenAICompatibilityThinking_FallsBackToDefaultLevels(t *testing.T) {
 	model := config.OpenAICompatibilityModel{
 		Name:  "custom-openai-model",

--- a/sdk/cliproxy/service_openai_compat_thinking_test.go
+++ b/sdk/cliproxy/service_openai_compat_thinking_test.go
@@ -16,27 +16,44 @@ func TestResolveOpenAICompatibilityThinking_UsesExplicitConfig(t *testing.T) {
 	}
 
 	got := resolveOpenAICompatibilityThinking(model)
-	if got == nil {
-		t.Fatal("expected thinking support")
-	}
 	if !reflect.DeepEqual(got.Levels, []string{"low", "high"}) {
 		t.Fatalf("levels mismatch: got %v", got.Levels)
 	}
 }
 
 func TestResolveOpenAICompatibilityThinking_InheritsStaticModelSupport(t *testing.T) {
+	upstream := registry.LookupStaticModelInfo("gpt-5.5")
+	if upstream == nil || upstream.Thinking == nil {
+		t.Fatal("expected gpt-5.5 static model definition with thinking support")
+	}
+
 	model := config.OpenAICompatibilityModel{
 		Name:  "gpt-5.5",
 		Alias: "team/gpt-5.5",
 	}
 
 	got := resolveOpenAICompatibilityThinking(model)
-	if got == nil {
-		t.Fatal("expected thinking support")
+	if !reflect.DeepEqual(got, upstream.Thinking) {
+		t.Fatalf("thinking mismatch: got %+v, want %+v", got, upstream.Thinking)
 	}
-	want := []string{"low", "medium", "high", "xhigh"}
-	if !reflect.DeepEqual(got.Levels, want) {
-		t.Fatalf("levels mismatch: got %v, want %v", got.Levels, want)
+}
+
+func TestResolveOpenAICompatibilityThinking_KnownModelWithoutThinkingRemainsNil(t *testing.T) {
+	upstream := registry.LookupStaticModelInfo("kimi-k2")
+	if upstream == nil {
+		t.Fatal("expected kimi-k2 static model definition")
+	}
+	if upstream.Thinking != nil {
+		t.Fatal("expected kimi-k2 to have no static thinking support")
+	}
+
+	model := config.OpenAICompatibilityModel{
+		Name:  "kimi-k2",
+		Alias: "team/kimi-k2",
+	}
+
+	if got := resolveOpenAICompatibilityThinking(model); got != nil {
+		t.Fatalf("expected nil thinking support, got %+v", got)
 	}
 }
 
@@ -47,9 +64,6 @@ func TestResolveOpenAICompatibilityThinking_FallsBackToDefaultLevels(t *testing.
 	}
 
 	got := resolveOpenAICompatibilityThinking(model)
-	if got == nil {
-		t.Fatal("expected thinking support")
-	}
 	want := []string{"low", "medium", "high"}
 	if !reflect.DeepEqual(got.Levels, want) {
 		t.Fatalf("levels mismatch: got %v, want %v", got.Levels, want)

--- a/sdk/cliproxy/service_openai_compat_thinking_test.go
+++ b/sdk/cliproxy/service_openai_compat_thinking_test.go
@@ -1,0 +1,57 @@
+package cliproxy
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestResolveOpenAICompatibilityThinking_UsesExplicitConfig(t *testing.T) {
+	model := config.OpenAICompatibilityModel{
+		Name:     "gpt-5.5",
+		Alias:    "team/gpt-5.5",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "high"}},
+	}
+
+	got := resolveOpenAICompatibilityThinking(model)
+	if got == nil {
+		t.Fatal("expected thinking support")
+	}
+	if !reflect.DeepEqual(got.Levels, []string{"low", "high"}) {
+		t.Fatalf("levels mismatch: got %v", got.Levels)
+	}
+}
+
+func TestResolveOpenAICompatibilityThinking_InheritsStaticModelSupport(t *testing.T) {
+	model := config.OpenAICompatibilityModel{
+		Name:  "gpt-5.5",
+		Alias: "team/gpt-5.5",
+	}
+
+	got := resolveOpenAICompatibilityThinking(model)
+	if got == nil {
+		t.Fatal("expected thinking support")
+	}
+	want := []string{"low", "medium", "high", "xhigh"}
+	if !reflect.DeepEqual(got.Levels, want) {
+		t.Fatalf("levels mismatch: got %v, want %v", got.Levels, want)
+	}
+}
+
+func TestResolveOpenAICompatibilityThinking_FallsBackToDefaultLevels(t *testing.T) {
+	model := config.OpenAICompatibilityModel{
+		Name:  "custom-openai-model",
+		Alias: "team/custom-openai-model",
+	}
+
+	got := resolveOpenAICompatibilityThinking(model)
+	if got == nil {
+		t.Fatal("expected thinking support")
+	}
+	want := []string{"low", "medium", "high"}
+	if !reflect.DeepEqual(got.Levels, want) {
+		t.Fatalf("levels mismatch: got %v, want %v", got.Levels, want)
+	}
+}


### PR DESCRIPTION
## Problem

`openai-compatibility` could reject `reasoning_effort: "xhigh"` locally even when the known upstream model already supports it.

When `openai-compatibility.models[].thinking` was omitted, the compatibility model was always registered with the fallback levels `low/medium/high`, so `xhigh` was treated as unsupported before the request ever reached the upstream provider.

Observed error:

```json
{"error":{"message":"level \"xhigh\" not supported, valid levels: low, medium, high","type":"invalid_request_error"}}
```

There were also two related edge cases in the same area:
- known static models with `Thinking == nil` could incorrectly fall back to `low/medium/high`
- alias-only compatibility entries could miss static thinking inheritance when `name` was empty

## Fix

- inherit static thinking metadata for known upstream models when explicit `models[].thinking` is not provided
- treat a successful static model lookup as authoritative even when `Thinking` is `nil`
- use the same `name -> alias` fallback during static lookup for alias-only compatibility entries
- keep the `low/medium/high` fallback only for unknown model IDs
- deduplicate static thinking metadata lookup and tighten the related comments/tests

## Validation

- `go test -v -run TestResolveOpenAICompatibilityThinking ./sdk/cliproxy`
- `go build -o test-output ./cmd/server && rm test-output`
