### PR TITLE
feat(quota): 添加 antigravity-credits-stick-seconds 配置并修复 credits 路径重试

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -116,6 +116,7 @@ quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
   antigravity-credits: true # Whether to use credits as last-resort fallback when all free-tier auths are exhausted for Claude models
+  antigravity-credits-stick-seconds: 0 # How long (seconds) credits mode stays active after first successful credits request. 0 = disabled, -1 = always use credits
 
 # Routing strategy for selecting credentials when multiple match.
 routing:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,14 @@ type QuotaExceeded struct {
 	// When all free-tier auths are exhausted (429/503), the conductor retries with
 	// an auth that has available Google One AI credits.
 	AntigravityCredits bool `yaml:"antigravity-credits" json:"antigravity-credits"`
+
+	// AntigravityCreditsStickSeconds specifies how long (in seconds) the credits
+	// mode stays active after the first successful credits-based request.
+	// During this window subsequent requests skip the free-tier attempt and use
+	// credits directly. The timer starts on the first success and is never renewed.
+	// 0 (default) disables sticky behavior — each request tries free tier first.
+	// -1 means permanently use credits — always skip free tier for Claude models.
+	AntigravityCreditsStickSeconds int `yaml:"antigravity-credits-stick-seconds" json:"antigravity-credits-stick-seconds"`
 }
 
 // RoutingConfig configures how credentials are selected for requests.

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -89,6 +89,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.QuotaExceeded.AntigravityCredits != newCfg.QuotaExceeded.AntigravityCredits {
 		changes = append(changes, fmt.Sprintf("quota-exceeded.antigravity-credits: %t -> %t", oldCfg.QuotaExceeded.AntigravityCredits, newCfg.QuotaExceeded.AntigravityCredits))
 	}
+	if oldCfg.QuotaExceeded.AntigravityCreditsStickSeconds != newCfg.QuotaExceeded.AntigravityCreditsStickSeconds {
+		changes = append(changes, fmt.Sprintf("quota-exceeded.antigravity-credits-stick-seconds: %d -> %d", oldCfg.QuotaExceeded.AntigravityCreditsStickSeconds, newCfg.QuotaExceeded.AntigravityCreditsStickSeconds))
+	}
 
 	if oldCfg.Routing.Strategy != newCfg.Routing.Strategy {
 		changes = append(changes, fmt.Sprintf("routing.strategy: %s -> %s", oldCfg.Routing.Strategy, newCfg.Routing.Strategy))

--- a/sdk/cliproxy/auth/antigravity_credits.go
+++ b/sdk/cliproxy/auth/antigravity_credits.go
@@ -72,6 +72,57 @@ func HasKnownAntigravityCreditsHint(authID string) bool {
 	return ok && hint.Known
 }
 
+var antigravityCreditsStickByAuth sync.Map // auth ID → time.Time (first successful credits usage)
+
+// MarkAntigravityCreditsStick records the first successful credits-based request
+// for the given auth. Subsequent calls are no-ops — the window is never renewed.
+func MarkAntigravityCreditsStick(authID string) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return
+	}
+	antigravityCreditsStickByAuth.LoadOrStore(authID, time.Now())
+}
+
+// ClearAntigravityCreditsStick removes the sticky credits state for the given auth.
+func ClearAntigravityCreditsStick(authID string) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return
+	}
+	antigravityCreditsStickByAuth.Delete(authID)
+}
+
+// IsAntigravityCreditsSticky reports whether the given auth is within an active
+// sticky credits window.
+// stickSeconds == 0: disabled. stickSeconds < 0 (-1): permanently sticky.
+func IsAntigravityCreditsSticky(authID string, stickSeconds int) bool {
+	if stickSeconds == 0 {
+		return false
+	}
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return false
+	}
+	if stickSeconds < 0 {
+		return true
+	}
+	val, ok := antigravityCreditsStickByAuth.Load(authID)
+	if !ok {
+		return false
+	}
+	t, ok := val.(time.Time)
+	if !ok {
+		antigravityCreditsStickByAuth.Delete(authID)
+		return false
+	}
+	if time.Since(t) > time.Duration(stickSeconds)*time.Second {
+		antigravityCreditsStickByAuth.Delete(authID)
+		return false
+	}
+	return true
+}
+
 func antigravityCreditsAvailableForModel(auth *Auth, model string) bool {
 	if auth == nil {
 		return false

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1220,6 +1220,25 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
 
+	stickyAttempted := false
+	if ss := m.antigravityCreditsStickSeconds(normalized, req.Model); ss != 0 {
+		var candidates []creditsCandidateEntry
+		if ss < 0 {
+			candidates = m.findAllAntigravityCreditsCandidateAuths(req.Model, opts)
+		} else {
+			candidates = m.findStickyAntigravityCreditsCandidateAuths(req.Model, opts, ss)
+		}
+		if len(candidates) > 0 {
+			stickyAttempted = true
+			if resp, ok := m.creditsExecuteWith(ctx, req, opts, candidates); ok {
+				return resp, nil
+			}
+			if ss < 0 {
+				return cliproxyexecutor.Response{}, &Error{Code: "credits_exhausted", Message: "credits-only mode active but all credits candidates failed"}
+			}
+		}
+	}
+
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
@@ -1238,7 +1257,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		}
 	}
 	if lastErr != nil {
-		if shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
+		if !stickyAttempted && shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
 			if resp, ok := m.tryAntigravityCreditsExecute(ctx, req, opts); ok {
 				return resp, nil
 			}
@@ -1286,6 +1305,25 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
 
+	stickyAttempted := false
+	if ss := m.antigravityCreditsStickSeconds(normalized, req.Model); ss != 0 {
+		var candidates []creditsCandidateEntry
+		if ss < 0 {
+			candidates = m.findAllAntigravityCreditsCandidateAuths(req.Model, opts)
+		} else {
+			candidates = m.findStickyAntigravityCreditsCandidateAuths(req.Model, opts, ss)
+		}
+		if len(candidates) > 0 {
+			stickyAttempted = true
+			if result, ok := m.creditsExecuteStreamWith(ctx, req, opts, candidates); ok {
+				return result, nil
+			}
+			if ss < 0 {
+				return nil, &Error{Code: "credits_exhausted", Message: "credits-only mode active but all credits candidates failed"}
+			}
+		}
+	}
+
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
@@ -1304,7 +1342,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		}
 	}
 	if lastErr != nil {
-		if shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
+		if !stickyAttempted && shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
 			if result, ok := m.tryAntigravityCreditsExecuteStream(ctx, req, opts); ok {
 				return result, nil
 			}
@@ -3632,8 +3670,17 @@ func shouldAttemptAntigravityCreditsFallback(m *Manager, lastErr error, provider
 }
 
 func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, bool) {
+	candidates := m.findAllAntigravityCreditsCandidateAuths(req.Model, opts)
+	return m.creditsExecuteWith(ctx, req, opts, candidates)
+}
+
+func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, bool) {
+	candidates := m.findAllAntigravityCreditsCandidateAuths(req.Model, opts)
+	return m.creditsExecuteStreamWith(ctx, req, opts, candidates)
+}
+
+func (m *Manager) creditsExecuteWith(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, candidates []creditsCandidateEntry) (cliproxyexecutor.Response, bool) {
 	routeModel := req.Model
-	candidates := m.findAllAntigravityCreditsCandidateAuths(routeModel, opts)
 	for _, c := range candidates {
 		if ctx.Err() != nil {
 			return cliproxyexecutor.Response{}, false
@@ -3668,15 +3715,15 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 				continue
 			}
 			m.MarkResult(creditsCtx, result)
+			MarkAntigravityCreditsStick(c.auth.ID)
 			return resp, true
 		}
 	}
 	return cliproxyexecutor.Response{}, false
 }
 
-func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, bool) {
+func (m *Manager) creditsExecuteStreamWith(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, candidates []creditsCandidateEntry) (*cliproxyexecutor.StreamResult, bool) {
 	routeModel := req.Model
-	candidates := m.findAllAntigravityCreditsCandidateAuths(routeModel, opts)
 	for _, c := range candidates {
 		if ctx.Err() != nil {
 			return nil, false
@@ -3696,9 +3743,75 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		if errStream != nil {
 			continue
 		}
-		return result, true
+		return wrapCreditsStreamForStickyMark(result, c.auth.ID), true
 	}
 	return nil, false
+}
+
+// wrapCreditsStreamForStickyMark wraps a stream result so that
+// MarkAntigravityCreditsStick is called only after the stream completes
+// without any error chunks, preventing premature sticky marking on
+// mid-stream failures.
+func wrapCreditsStreamForStickyMark(sr *cliproxyexecutor.StreamResult, authID string) *cliproxyexecutor.StreamResult {
+	origChunks := sr.Chunks
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		hadError := false
+		for chunk := range origChunks {
+			if chunk.Err != nil {
+				hadError = true
+			}
+			out <- chunk
+		}
+		if !hadError {
+			MarkAntigravityCreditsStick(authID)
+		}
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: sr.Headers, Chunks: out}
+}
+
+// antigravityCreditsStickSeconds returns the configured stick duration when the
+// sticky credits path should be considered. Returns 0 when disabled or
+// preconditions are not met (non-Claude model, no antigravity provider).
+func (m *Manager) antigravityCreditsStickSeconds(providers []string, model string) int {
+	if m == nil {
+		return 0
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil || !cfg.QuotaExceeded.AntigravityCredits || cfg.QuotaExceeded.AntigravityCreditsStickSeconds == 0 {
+		return 0
+	}
+	if !strings.Contains(strings.ToLower(strings.TrimSpace(model)), "claude") {
+		return 0
+	}
+	hasAntigravity := false
+	for _, p := range providers {
+		if strings.EqualFold(strings.TrimSpace(p), "antigravity") {
+			hasAntigravity = true
+			break
+		}
+	}
+	if !hasAntigravity {
+		return 0
+	}
+	return cfg.QuotaExceeded.AntigravityCreditsStickSeconds
+}
+
+// findStickyAntigravityCreditsCandidateAuths returns only the candidates whose
+// auth has an active per-auth sticky window (stickSeconds > 0).
+func (m *Manager) findStickyAntigravityCreditsCandidateAuths(routeModel string, opts cliproxyexecutor.Options, stickSeconds int) []creditsCandidateEntry {
+	all := m.findAllAntigravityCreditsCandidateAuths(routeModel, opts)
+	if stickSeconds <= 0 {
+		return all
+	}
+	var sticky []creditsCandidateEntry
+	for _, c := range all {
+		if IsAntigravityCreditsSticky(c.auth.ID, stickSeconds) {
+			sticky = append(sticky, c)
+		}
+	}
+	return sticky
 }
 
 func (m *Manager) persist(ctx context.Context, auth *Auth) error {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1230,11 +1230,22 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		}
 		if len(candidates) > 0 {
 			stickyAttempted = true
-			if resp, ok := m.creditsExecuteWith(ctx, req, opts, candidates); ok {
-				return resp, nil
-			}
-			if ss < 0 {
-				return cliproxyexecutor.Response{}, &Error{Code: "credits_exhausted", Message: "credits-only mode active but all credits candidates failed"}
+			_, _, maxWaitCredits := m.retrySettings()
+			for creditsAttempt := 0; ; creditsAttempt++ {
+				resp, ok, lastCreditsErr := m.creditsExecuteWith(ctx, req, opts, candidates)
+				if ok {
+					return resp, nil
+				}
+				if lastCreditsErr == nil {
+					break
+				}
+				wait, shouldRetry := m.shouldRetryAfterError(lastCreditsErr, creditsAttempt, normalized, req.Model, maxWaitCredits)
+				if !shouldRetry {
+					break
+				}
+				if errWait := waitForCooldown(ctx, wait); errWait != nil {
+					return cliproxyexecutor.Response{}, errWait
+				}
 			}
 		}
 	}
@@ -1315,11 +1326,22 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		}
 		if len(candidates) > 0 {
 			stickyAttempted = true
-			if result, ok := m.creditsExecuteStreamWith(ctx, req, opts, candidates); ok {
-				return result, nil
-			}
-			if ss < 0 {
-				return nil, &Error{Code: "credits_exhausted", Message: "credits-only mode active but all credits candidates failed"}
+			_, _, maxWaitCredits := m.retrySettings()
+			for creditsAttempt := 0; ; creditsAttempt++ {
+				result, ok, lastCreditsErr := m.creditsExecuteStreamWith(ctx, req, opts, candidates)
+				if ok {
+					return result, nil
+				}
+				if lastCreditsErr == nil {
+					break
+				}
+				wait, shouldRetry := m.shouldRetryAfterError(lastCreditsErr, creditsAttempt, normalized, req.Model, maxWaitCredits)
+				if !shouldRetry {
+					break
+				}
+				if errWait := waitForCooldown(ctx, wait); errWait != nil {
+					return nil, errWait
+				}
 			}
 		}
 	}
@@ -3671,19 +3693,22 @@ func shouldAttemptAntigravityCreditsFallback(m *Manager, lastErr error, provider
 
 func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, bool) {
 	candidates := m.findAllAntigravityCreditsCandidateAuths(req.Model, opts)
-	return m.creditsExecuteWith(ctx, req, opts, candidates)
+	resp, ok, _ := m.creditsExecuteWith(ctx, req, opts, candidates)
+	return resp, ok
 }
 
 func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, bool) {
 	candidates := m.findAllAntigravityCreditsCandidateAuths(req.Model, opts)
-	return m.creditsExecuteStreamWith(ctx, req, opts, candidates)
+	result, ok, _ := m.creditsExecuteStreamWith(ctx, req, opts, candidates)
+	return result, ok
 }
 
-func (m *Manager) creditsExecuteWith(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, candidates []creditsCandidateEntry) (cliproxyexecutor.Response, bool) {
+func (m *Manager) creditsExecuteWith(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, candidates []creditsCandidateEntry) (cliproxyexecutor.Response, bool, error) {
 	routeModel := req.Model
+	var lastErr error
 	for _, c := range candidates {
 		if ctx.Err() != nil {
-			return cliproxyexecutor.Response{}, false
+			return cliproxyexecutor.Response{}, false, ctx.Err()
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
@@ -3704,6 +3729,7 @@ func (m *Manager) creditsExecuteWith(ctx context.Context, req cliproxyexecutor.R
 			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
 			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
+				lastErr = errExec
 				result.Error = &Error{Message: errExec.Error()}
 				if se, ok := errors.AsType[cliproxyexecutor.StatusError](errExec); ok && se != nil {
 					result.Error.HTTPStatus = se.StatusCode()
@@ -3716,17 +3742,18 @@ func (m *Manager) creditsExecuteWith(ctx context.Context, req cliproxyexecutor.R
 			}
 			m.MarkResult(creditsCtx, result)
 			MarkAntigravityCreditsStick(c.auth.ID)
-			return resp, true
+			return resp, true, nil
 		}
 	}
-	return cliproxyexecutor.Response{}, false
+	return cliproxyexecutor.Response{}, false, lastErr
 }
 
-func (m *Manager) creditsExecuteStreamWith(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, candidates []creditsCandidateEntry) (*cliproxyexecutor.StreamResult, bool) {
+func (m *Manager) creditsExecuteStreamWith(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, candidates []creditsCandidateEntry) (*cliproxyexecutor.StreamResult, bool, error) {
 	routeModel := req.Model
+	var lastErr error
 	for _, c := range candidates {
 		if ctx.Err() != nil {
-			return nil, false
+			return nil, false, ctx.Err()
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
@@ -3741,11 +3768,12 @@ func (m *Manager) creditsExecuteStreamWith(ctx context.Context, req cliproxyexec
 		}
 		result, errStream := m.executeStreamWithModelPool(creditsCtx, c.executor, c.auth, c.provider, req, creditsOpts, routeModel, models, len(models) > 1)
 		if errStream != nil {
+			lastErr = errStream
 			continue
 		}
-		return wrapCreditsStreamForStickyMark(result, c.auth.ID), true
+		return wrapCreditsStreamForStickyMark(result, c.auth.ID), true, nil
 	}
-	return nil, false
+	return nil, false, lastErr
 }
 
 // wrapCreditsStreamForStickyMark wraps a stream result so that


### PR DESCRIPTION
## 概述

本 PR 在 `quota-exceeded` 配置段中新增 `antigravity-credits-stick-seconds` 选项，允许 credits 模式在首次成功使用后持续一段时间，避免每次请求都经历"免费层失败 -> 回退 credits"的流程。同时修复了 sticky credits 路径缺少 conductor 级别重试机制的严重问题。

## 新增功能

### `antigravity-credits-stick-seconds` 配置项

| 值 | 行为 |
|---|---|
| `0`（默认） | 禁用，保持原有行为 |
| `> 0` | 首次 credits 成功后，在指定秒数内后续请求直接走 credits 路径 |
| `-1` | 永久 credits-first 模式，所有请求始终注入 credits |

### 核心实现

1. **Per-auth sticky 状态管理**（`antigravity_credits.go`）
   - `MarkAntigravityCreditsStick(authID)` -- 使用 `LoadOrStore` 记录首次成功时间，不续期
   - `IsAntigravityCreditsSticky(authID, stickSeconds)` -- O(1) 查询，过期自动清理
   - `ClearAntigravityCreditsStick(authID)` -- 主动清除

2. **Sticky 路径 conductor 级别重试**（`conductor.go`）
   - `creditsExecuteWith` / `creditsExecuteStreamWith` 返回值新增 `error`，传出最后一个失败错误
   - Execute / ExecuteStream 的 sticky 路径中，围绕 credits 执行加入 `shouldRetryAfterError` + `waitForCooldown` 循环，与正常流程使用相同的 `max-retry-interval` 配置
   - 重试耗尽后 fall through 到正常流程（与原版行为一致）

3. **配置热更新支持**（`config_diff.go`）
   - `antigravity-credits-stick-seconds` 变更时自动生效，无需重启

## 修复的问题

### credits_exhausted 500 错误

原始实现中，当 `ss < 0`（永久 credits 模式）且所有 candidate 失败时，直接返回硬编码的 `credits_exhausted` 500 错误。在上游短暂 429 限流时，这会导致本可通过等待重试恢复的请求直接失败。

**修复方案：** 删除 `credits_exhausted` 硬错误，替换为与正常流程一致的 retry+cooldown 循环。上游 429 时等待 `max-retry-interval` 后重试，而非立即返回错误。

### 缺少 conductor 级别重试

原始 `creditsExecuteWith` 对每个 candidate 只尝试一次，遇到 429 直接跳到下一个 candidate，全部失败后无法重试。而正常流程（`executeMixedOnce` 外层循环）有完整的 `shouldRetryAfterError` + `waitForCooldown` 机制。

**修复方案：** 在 sticky 路径外层包裹相同的重试循环，使 credits 路径具备与正常流程等价的容错能力。

## 设计决策

- **Per-auth 而非全局 sticky**：避免 O(N) 遍历 sync.Map 和跨账号误判
- **`LoadOrStore` 不续期**：sticky 窗口从首次成功开始计时，不因后续成功而延长，防止无限粘滞
- **`wrapCreditsStreamForStickyMark`**：流式请求仅在整个 stream 无错误完成后才标记 sticky，避免中途失败污染状态
- **`stickyAttempted` 标志**：防止 sticky 路径已经尝试过 credits 后，正常流程末尾的 fallback 再次重复执行

## 变更文件

| 文件 | 变更 |
|------|------|
| `config.example.yaml` | 新增配置示例 |
| `internal/config/config.go` | 新增 `AntigravityCreditsStickSeconds` 字段 |
| `internal/watcher/diff/config_diff.go` | 热更新 diff 追踪 |
| `sdk/cliproxy/auth/antigravity_credits.go` | sticky 状态管理函数 |
| `sdk/cliproxy/auth/conductor.go` | sticky 路径 + retry 循环 |

## 测试

- 已在生产环境验证：credits 正确注入（日志标记 `[credits]`）
- 429 限流时 retry+cooldown 正常工作，大部分请求最终 200
- 两个账号轮换 + 限流恢复后自动 resume
