### PR TITLE
test: assert embedded model catalog passes validation on every CI run

### DIFF
--- a/internal/registry/model_updater_embed_test.go
+++ b/internal/registry/model_updater_embed_test.go
@@ -1,9 +1,16 @@
 package registry
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestEmbeddedModelsCatalogIsValid(t *testing.T) {
-	if err := loadModelsFromBytes(embeddedModelsJSON, "embed"); err != nil {
+	var parsed staticModelsJSON
+	if err := json.Unmarshal(embeddedModelsJSON, &parsed); err != nil {
+		t.Fatalf("embedded models.json failed to decode: %v", err)
+	}
+	if err := validateModelsCatalog(&parsed); err != nil {
 		t.Fatalf("embedded models.json failed validation: %v", err)
 	}
 }

--- a/internal/registry/model_updater_embed_test.go
+++ b/internal/registry/model_updater_embed_test.go
@@ -1,0 +1,9 @@
+package registry
+
+import "testing"
+
+func TestEmbeddedModelsCatalogIsValid(t *testing.T) {
+	if err := loadModelsFromBytes(embeddedModelsJSON, "embed"); err != nil {
+		t.Fatalf("embedded models.json failed validation: %v", err)
+	}
+}


### PR DESCRIPTION
The v7.1.0 image (published 2026-05-16T17:10:21Z) panicked immediately on startup:

```
panic: registry: failed to parse embedded models.json: embed: validate models catalog: xai section is empty
```

The embedded `models.json` shipped with an empty `xai` section. Because `validateModelsCatalog` fires in `package init()` — before config or flags are processed — there was no workaround; affected containers could enter a restart loop. The outage lasted until v7.1.1 was published at 17:37:41Z (~27 minutes), plus however long users took to pull and redeploy.

This test decodes and validates the actual embedded bytes used by startup, covering the same catalog validation that `init()` depends on. Any required provider section that ships empty will now fail CI before a tag is cut rather than reaching users.

No behavior changes.