### PR TITLE
fix(xai): default missing function tool parameters

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -726,11 +726,20 @@ func normalizeXAITool(tool gjson.Result) ([]byte, bool, bool) {
 			return nil, false, false
 		}
 		raw = updatedTool
+		toolType = xaiFunctionToolType
 		changed = true
 	}
 	if toolType == xaiWebSearchToolType && tool.Get("external_web_access").Exists() {
 		updatedTool, errDel := sjson.DeleteBytes(raw, "external_web_access")
 		if errDel != nil {
+			return nil, false, false
+		}
+		raw = updatedTool
+		changed = true
+	}
+	if toolType == xaiFunctionToolType && !tool.Get("parameters").Exists() {
+		updatedTool, errSet := sjson.SetRawBytes(raw, "parameters", []byte(`{"type":"object","properties":{}}`))
+		if errSet != nil {
 			return nil, false, false
 		}
 		raw = updatedTool

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -114,6 +114,9 @@ func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 		if toolType != "function" && toolType != "web_search" {
 			t.Fatalf("tools.%d.type = %q, want function or web_search; body=%s", i, toolType, string(gotBody))
 		}
+		if toolType == "function" && !tool.Get("parameters").Exists() {
+			t.Fatalf("tools.%d.parameters missing for xAI function tool; body=%s", i, string(gotBody))
+		}
 		if got := tool.Get("name").String(); got == "apply_patch" {
 			t.Fatalf("tools.%d.name = apply_patch, want removed; body=%s", i, string(gotBody))
 		}
@@ -242,6 +245,9 @@ func TestXAIExecutorExecuteStreamFiltersToolSearchTool(t *testing.T) {
 		}
 		if toolType != "function" && toolType != "web_search" {
 			t.Fatalf("tools.%d.type = %q, want function or web_search; body=%s", i, toolType, string(gotBody))
+		}
+		if toolType == "function" && !tool.Get("parameters").Exists() {
+			t.Fatalf("tools.%d.parameters missing for xAI function tool; body=%s", i, string(gotBody))
 		}
 		if got := tool.Get("name").String(); got == "apply_patch" {
 			t.Fatalf("tools.%d.name = apply_patch, want removed; body=%s", i, string(gotBody))


### PR DESCRIPTION
## Summary

Fix xAI Responses requests that fail when a downstream client sends a function tool without a `parameters` schema.

Some OpenAI Responses clients can send custom/freeform tools that reach the xAI executor as function tools without `parameters`. xAI rejects those requests before generation with:

```text
Failed to deserialize the JSON body into the target type: missing field `parameters`
```

OpenAI's Responses API appears to tolerate this shape, but xAI's Responses endpoint requires `parameters` on function tools.

## Change

- In `normalizeXAITool`, when a tool is normalized to `type: "function"` and lacks `parameters`, add an empty object schema:

```json
{ "type": "object", "properties": {} }
```

- Preserve existing xAI behavior that removes unsupported `apply_patch`, `tool_search`, and image-generation tools.
- Update xAI executor tests to assert every function tool forwarded to xAI includes `parameters`.

## Validation

Passed:

```bash
gofmt -w internal/runtime/executor/xai_executor.go internal/runtime/executor/xai_executor_test.go
env GOCACHE=/private/tmp/go-build-cache-ai-cli-proxy-api go test ./internal/runtime/executor -run 'TestXAIExecutor'
env GOCACHE=/private/tmp/go-build-cache-ai-cli-proxy-api go build -o cli-proxy-api ./cmd/server
git diff --check
```

Also ran:

```bash
env GOCACHE=/private/tmp/go-build-cache-ai-cli-proxy-api go test ./...
```

That broad suite still fails on existing upstream baseline failures unrelated to this patch:

- `internal/registry`: `TestCodexFreeModelsExcludeGPT55` expects Codex free tier not to include `gpt-5.5`.
- `internal/runtime/executor`: Antigravity credit tests expect a different `loadCodeAssist` URL than the current `daily-cloudcode-pa.googleapis.com` request.

## Notes

This is intentionally scoped to the xAI executor because the observed failure comes from `https://api.x.ai/v1/responses`, not from the generic OpenAI-compatible or Codex translator path.

Related prior tool-schema work: #3243, #3389.
