### PR TITLE
fix(openai): route image generation to compat providers

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -81,6 +81,9 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
 		return
 	}
+	if strings.EqualFold(opts.SourceFormat.String(), "openai-image") {
+		return e.executeImage(ctx, auth, req, opts, baseModel, baseURL, apiKey)
+	}
 
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("openai")
@@ -177,6 +180,87 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, body, &param)
 	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 	return resp, nil
+}
+
+func (e *OpenAICompatExecutor) executeImage(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, baseModel string, baseURL string, apiKey string) (resp cliproxyexecutor.Response, err error) {
+	endpoint := "/images/generations"
+	switch path := helps.PayloadRequestPath(opts); {
+	case strings.HasSuffix(path, "/images/edits"):
+		endpoint = "/images/edits"
+	case strings.HasSuffix(path, "/images/generations"):
+		endpoint = "/images/generations"
+	}
+
+	payload := req.Payload
+	if len(payload) == 0 && len(opts.OriginalRequest) > 0 {
+		payload = opts.OriginalRequest
+	}
+	if len(payload) == 0 {
+		payload = []byte(`{}`)
+	}
+	payload, _ = sjson.SetBytes(payload, "model", baseModel)
+	payload, _ = sjson.DeleteBytes(payload, "stream")
+
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	requestPath := helps.PayloadRequestPath(opts)
+	payload = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "openai-image", "", payload, opts.OriginalRequest, requestedModel, requestPath)
+
+	url := strings.TrimSuffix(baseURL, "/") + endpoint
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return resp, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       url,
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      payload,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("openai compat image executor: close response body error: %v", errClose)
+		}
+	}()
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	body, readErr := io.ReadAll(httpResp.Body)
+	if readErr != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, readErr)
+		return resp, readErr
+	}
+	helps.AppendAPIResponseChunk(ctx, e.cfg, body)
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), body))
+		return resp, statusErr{code: httpResp.StatusCode, msg: string(body)}
+	}
+	return cliproxyexecutor.Response{Payload: body, Headers: httpResp.Header.Clone()}, nil
 }
 
 func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -58,6 +58,51 @@ func TestOpenAICompatExecutorCompactPassthrough(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatExecutorImagesGenerationsPassthrough(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":123,"data":[{"b64_json":"AA=="}]}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	payload := []byte(`{"model":"compat/gpt-image-2","prompt":"draw a square","stream":true}`)
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-image-2",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-image"),
+		Stream:       false,
+		Metadata: map[string]any{
+			cliproxyexecutor.RequestPathMetadataKey: "/v1/images/generations",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/v1/images/generations" {
+		t.Fatalf("path = %q, want %q", gotPath, "/v1/images/generations")
+	}
+	if got := gjson.GetBytes(gotBody, "model").String(); got != "gpt-image-2" {
+		t.Fatalf("model = %q, want gpt-image-2; body=%s", got, string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "stream").Exists() {
+		t.Fatalf("stream should be removed for image passthrough: %s", string(gotBody))
+	}
+	if string(resp.Payload) != `{"created":123,"data":[{"b64_json":"AA=="}]}` {
+		t.Fatalf("payload = %s", string(resp.Payload))
+	}
+}
+
 func TestOpenAICompatExecutorPayloadOverrideWinsOverThinkingSuffix(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -534,7 +534,7 @@ func appendAPIResponse(c *gin.Context, data []byte) {
 // ExecuteWithAuthManager executes a non-streaming request via the core auth manager.
 // This path is the only supported execution route.
 func (h *BaseAPIHandler) ExecuteWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string) ([]byte, http.Header, *interfaces.ErrorMessage) {
-	providers, normalizedModel, errMsg := h.getRequestDetails(modelName)
+	providers, normalizedModel, errMsg := h.getRequestDetails(handlerType, modelName)
 	if errMsg != nil {
 		return nil, nil, errMsg
 	}
@@ -582,7 +582,7 @@ func (h *BaseAPIHandler) ExecuteWithAuthManager(ctx context.Context, handlerType
 // ExecuteCountWithAuthManager executes a non-streaming request via the core auth manager.
 // This path is the only supported execution route.
 func (h *BaseAPIHandler) ExecuteCountWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string) ([]byte, http.Header, *interfaces.ErrorMessage) {
-	providers, normalizedModel, errMsg := h.getRequestDetails(modelName)
+	providers, normalizedModel, errMsg := h.getRequestDetails(handlerType, modelName)
 	if errMsg != nil {
 		return nil, nil, errMsg
 	}
@@ -631,7 +631,7 @@ func (h *BaseAPIHandler) ExecuteCountWithAuthManager(ctx context.Context, handle
 // This path is the only supported execution route.
 // The returned http.Header carries upstream response headers captured before streaming begins.
 func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string) (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
-	providers, normalizedModel, errMsg := h.getRequestDetails(modelName)
+	providers, normalizedModel, errMsg := h.getRequestDetails(handlerType, modelName)
 	if errMsg != nil {
 		errChan := make(chan *interfaces.ErrorMessage, 1)
 		errChan <- errMsg
@@ -846,7 +846,7 @@ func statusFromError(err error) int {
 	return 0
 }
 
-func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
+func (h *BaseAPIHandler) getRequestDetails(handlerType, modelName string) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
 	resolvedModelName := modelName
 	initialSuffix := thinking.ParseSuffix(modelName)
 	if initialSuffix.ModelName == "auto" {
@@ -871,7 +871,7 @@ func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string
 	parsed := thinking.ParseSuffix(resolvedModelName)
 	baseModel := strings.TrimSpace(parsed.ModelName)
 
-	if strings.EqualFold(baseModel, "gpt-image-2") {
+	if strings.EqualFold(baseModel, "gpt-image-2") && !strings.EqualFold(strings.TrimSpace(handlerType), "openai-image") {
 		return nil, "", &interfaces.ErrorMessage{
 			StatusCode: http.StatusServiceUnavailable,
 			Error:      fmt.Errorf("model %s is only supported on /v1/images/generations and /v1/images/edits", baseModel),
@@ -892,6 +892,10 @@ func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string
 		providers = util.GetProviderName(resolvedModelName)
 	}
 
+	if strings.EqualFold(strings.TrimSpace(handlerType), "openai-image") && strings.EqualFold(baseModel, "gpt-image-2") {
+		providers = preferNonCodexProviders(providers)
+	}
+
 	if len(providers) == 0 {
 		return nil, "", &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("unknown provider for model %s", modelName)}
 	}
@@ -899,6 +903,23 @@ func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string
 	// The thinking suffix is preserved in the model name itself, so no
 	// metadata-based configuration passing is needed.
 	return providers, resolvedModelName, nil
+}
+
+func preferNonCodexProviders(providers []string) []string {
+	if len(providers) == 0 {
+		return providers
+	}
+	filtered := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		if strings.EqualFold(strings.TrimSpace(provider), "codex") {
+			continue
+		}
+		filtered = append(filtered, provider)
+	}
+	if len(filtered) == 0 {
+		return providers
+	}
+	return filtered
 }
 
 func cloneBytes(src []byte) []byte {

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -102,7 +102,7 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			providers, model, errMsg := handler.getRequestDetails(tt.inputModel)
+			providers, model, errMsg := handler.getRequestDetails("openai", tt.inputModel)
 			if (errMsg != nil) != tt.wantErr {
 				t.Fatalf("getRequestDetails() error = %v, wantErr %v", errMsg, tt.wantErr)
 			}
@@ -122,7 +122,7 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 func TestGetRequestDetails_ImageModelReturns503(t *testing.T) {
 	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, coreauth.NewManager(nil, nil, nil))
 
-	_, _, errMsg := handler.getRequestDetails("gpt-image-2")
+	_, _, errMsg := handler.getRequestDetails("openai", "gpt-image-2")
 	if errMsg == nil {
 		t.Fatalf("expected error for gpt-image-2, got nil")
 	}

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -457,6 +458,10 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 	if isXAIImagesModel(imageModel) {
 		xaiReq := buildXAIImagesGenerationsRequest(rawJSON, imageModel, responseFormat)
 		h.handleXAIImages(c, xaiReq, responseFormat, "image_generation", stream)
+		return
+	}
+	if shouldPassthroughOpenAICompatImages(imageModel) {
+		h.handleOpenAICompatImages(c, rawJSON, responseFormat, "image_generation", stream)
 		return
 	}
 
@@ -902,6 +907,121 @@ func (h *OpenAIAPIHandler) handleXAIImages(c *gin.Context, xaiReq []byte, respon
 		return
 	}
 	h.collectXAIImages(c, xaiReq, responseFormat)
+}
+
+func shouldPassthroughOpenAICompatImages(model string) bool {
+	if isXAIImagesModel(model) || imagesModelBase(model) != defaultImagesToolModel {
+		return false
+	}
+	for _, candidate := range []string{strings.TrimSpace(model), imagesModelBase(model)} {
+		if candidate == "" {
+			continue
+		}
+		for _, provider := range util.GetProviderName(candidate) {
+			provider = strings.TrimSpace(provider)
+			if provider != "" && !strings.EqualFold(provider, "codex") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (h *OpenAIAPIHandler) handleOpenAICompatImages(c *gin.Context, rawJSON []byte, responseFormat string, streamPrefix string, stream bool) {
+	if stream {
+		h.streamOpenAICompatImages(c, rawJSON, responseFormat, streamPrefix)
+		return
+	}
+	h.collectOpenAICompatImages(c, rawJSON)
+}
+
+func (h *OpenAIAPIHandler) collectOpenAICompatImages(c *gin.Context, rawJSON []byte) {
+	c.Header("Content-Type", "application/json")
+
+	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
+
+	imageModel := strings.TrimSpace(gjson.GetBytes(rawJSON, "model").String())
+	if imageModel == "" {
+		imageModel = defaultImagesToolModel
+	}
+	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, xaiImagesHandlerType, imageModel, rawJSON, "")
+	stopKeepAlive()
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		if errMsg.Error != nil {
+			cliCancel(errMsg.Error)
+		} else {
+			cliCancel(nil)
+		}
+		return
+	}
+
+	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+	_, _ = c.Writer.Write(resp)
+	cliCancel(nil)
+}
+
+func (h *OpenAIAPIHandler) streamOpenAICompatImages(c *gin.Context, rawJSON []byte, responseFormat string, streamPrefix string) {
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{
+				Message: "Streaming not supported",
+				Type:    "server_error",
+			},
+		})
+		return
+	}
+
+	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	imageModel := strings.TrimSpace(gjson.GetBytes(rawJSON, "model").String())
+	if imageModel == "" {
+		imageModel = defaultImagesToolModel
+	}
+	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, xaiImagesHandlerType, imageModel, rawJSON, "")
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		if errMsg.Error != nil {
+			cliCancel(errMsg.Error)
+		} else {
+			cliCancel(nil)
+		}
+		return
+	}
+
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("Access-Control-Allow-Origin", "*")
+	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+
+	eventName := streamPrefix + ".completed"
+	responseFormat = normalizeImagesResponseFormat(responseFormat)
+	for _, item := range gjson.GetBytes(resp, "data").Array() {
+		data := []byte(`{"type":""}`)
+		data, _ = sjson.SetBytes(data, "type", eventName)
+		if responseFormat == "url" {
+			if url := strings.TrimSpace(item.Get("url").String()); url != "" {
+				data, _ = sjson.SetBytes(data, "url", url)
+			} else {
+				data, _ = sjson.SetBytes(data, "url", "data:image/png;base64,"+strings.TrimSpace(item.Get("b64_json").String()))
+			}
+		} else if b64 := strings.TrimSpace(item.Get("b64_json").String()); b64 != "" {
+			data, _ = sjson.SetBytes(data, "b64_json", b64)
+		} else if url := strings.TrimSpace(item.Get("url").String()); url != "" {
+			data, _ = sjson.SetBytes(data, "url", url)
+		}
+		if revised := strings.TrimSpace(item.Get("revised_prompt").String()); revised != "" {
+			data, _ = sjson.SetBytes(data, "revised_prompt", revised)
+		}
+		if strings.TrimSpace(eventName) != "" {
+			_, _ = fmt.Fprintf(c.Writer, "event: %s\n", eventName)
+		}
+		_, _ = fmt.Fprintf(c.Writer, "data: %s\n\n", string(data))
+		flusher.Flush()
+	}
+	cliCancel(nil)
 }
 
 func (h *OpenAIAPIHandler) collectXAIImages(c *gin.Context, xaiReq []byte, responseFormat string) {

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"github.com/tidwall/gjson"
@@ -60,6 +61,19 @@ func TestImagesModelValidationAllowsGPTImage2AndXAIModels(t *testing.T) {
 	}
 	if isSupportedImagesModel("codex/grok-imagine-image") {
 		t.Fatal("expected codex/grok-imagine-image to be rejected")
+	}
+}
+
+func TestShouldPassthroughOpenAICompatImages(t *testing.T) {
+	r := registry.GetGlobalRegistry()
+	r.RegisterClient("test-openai-compat-image", "openai-compatibility", []*registry.ModelInfo{{ID: defaultImagesToolModel}})
+	t.Cleanup(func() { r.UnregisterClient("test-openai-compat-image") })
+
+	if !shouldPassthroughOpenAICompatImages(defaultImagesToolModel) {
+		t.Fatalf("expected %s to prefer openai-compatible passthrough when registered", defaultImagesToolModel)
+	}
+	if shouldPassthroughOpenAICompatImages(defaultXAIImagesModel) {
+		t.Fatalf("xAI image models must stay on the xAI image handler")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix `/v1/images/generations` for OpenAI-compatible `gpt-image-2` providers by routing image requests to the matching OpenAI-compatible provider when one is registered, instead of always translating the request through the Codex Responses `image_generation` tool path.

This keeps the existing Codex fallback for deployments that only have Codex auth, but allows configured OpenAI-compatible image providers to handle their native `/images/generations` endpoint.

Related: #3406, #3314, #2973

## What changed

- Allow `gpt-image-2` to be resolved through the core auth manager for the `openai-image` handler type.
- Prefer non-Codex providers for `openai-image` + `gpt-image-2` when such providers are registered.
- Add OpenAI-compatible image passthrough in the image handler:
  - if `gpt-image-2` is available from an OpenAI-compatible provider, use native image passthrough;
  - otherwise keep the existing Codex Responses fallback.
- Add OpenAI-compatible executor support for the `openai-image` source format:
  - forwards to `/images/generations` or `/images/edits` based on the original request path;
  - preserves the image API response payload;
  - strips `stream` for the upstream non-stream passthrough request.

## Tests

```bash
GOPROXY=https://goproxy.cn,direct go test ./sdk/api/handlers ./sdk/api/handlers/openai
GOPROXY=https://goproxy.cn,direct go test ./internal/runtime/executor -run 'TestOpenAICompatExecutor(CompactPassthrough|ImagesGenerationsPassthrough|PayloadOverrideWinsOverThinkingSuffix|StreamRejectsPlainJSONAfterBlankLines|StreamSkipsKeepAliveUntilDataLine)$'
```

Note: `go test ./internal/runtime/executor` currently has unrelated Antigravity credit tests failing on current `main` in this environment; the OpenAI-compatible executor regression tests above pass.
