### PR TITLE
feat(server): add HOME_ADDR and HOME_PASSWORD env var fallback

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -247,18 +247,6 @@ func main() {
 	// Parse the command-line flags.
 	flag.Parse()
 
-	// Allow env var fallback for home flags so they can be configured without command args.
-	if strings.TrimSpace(homeAddr) == "" {
-		if v, ok := os.LookupEnv("HOME_ADDR"); ok {
-			homeAddr = strings.TrimSpace(v)
-		}
-	}
-	if strings.TrimSpace(homePassword) == "" {
-		if v, ok := os.LookupEnv("HOME_PASSWORD"); ok {
-			homePassword = strings.TrimSpace(v)
-		}
-	}
-
 	// Core application variables.
 	var err error
 	var cfg *config.Config
@@ -311,6 +299,19 @@ func main() {
 		return "", false
 	}
 	writableBase := util.WritablePath()
+
+	// Allow env var fallback for home flags so they can be configured without command args.
+	if strings.TrimSpace(homeAddr) == "" {
+		if v, ok := lookupEnv("HOME_ADDR", "home_addr"); ok {
+			homeAddr = v
+		}
+	}
+	if strings.TrimSpace(homePassword) == "" {
+		if v, ok := lookupEnv("HOME_PASSWORD", "home_password"); ok {
+			homePassword = v
+		}
+	}
+
 	if value, ok := lookupEnv("PGSTORE_DSN", "pgstore_dsn"); ok {
 		usePostgresStore = true
 		pgStoreDSN = value

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -247,6 +247,18 @@ func main() {
 	// Parse the command-line flags.
 	flag.Parse()
 
+	// Allow env var fallback for home flags so they can be configured without command args.
+	if strings.TrimSpace(homeAddr) == "" {
+		if v, ok := os.LookupEnv("HOME_ADDR"); ok {
+			homeAddr = strings.TrimSpace(v)
+		}
+	}
+	if strings.TrimSpace(homePassword) == "" {
+		if v, ok := os.LookupEnv("HOME_PASSWORD"); ok {
+			homePassword = strings.TrimSpace(v)
+		}
+	}
+
 	// Core application variables.
 	var err error
 	var cfg *config.Config


### PR DESCRIPTION
## Summary
- Add `HOME_ADDR` and `HOME_PASSWORD` environment variable fallbacks for the `--home` and `--home-password` command-line flags
- Enables Docker Swarm stack deployments using `env_file` / `environment` without needing `docker service update --args` after each `docker stack deploy`

## Changes
- After `flag.Parse()`, if `homeAddr` / `homePassword` are empty, check `HOME_ADDR` / `HOME_PASSWORD` env vars respectively

## Use case
When deploying CLIProxyAPI in Docker Swarm with a `docker-stack.yml`, the `command` directive does not reliably map to Swarm ContainerSpec. Using environment variables allows the home connection to be configured purely through the stack's `env_file` or `environment` section:

```yaml
cliproxyapi:
  image: eceasy/cli-proxy-api:latest
  env_file:
    - env/.env.cliproxyapi
  deploy:
    replicas: 3
```

```env
# env/.env.cliproxyapi
HOME_ADDR=redis://cliproxyapihome:8327
HOME_PASSWORD=my-secret-password
```

## Test plan
- [x] `go build ./cmd/server` compiles
- [x] `go test ./cmd/server/...` passes (4/4)
- [x] Deployed to production Docker Swarm (3 replicas, 18 models available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)