### PR TITLE
feat antigravity2.0.0 support + model (3.5 variant ) support

### DIFF
--- a/cmd/fetch_antigravity_models/main.go
+++ b/cmd/fetch_antigravity_models/main.go
@@ -35,10 +35,11 @@ import (
 )
 
 const (
-	antigravityBaseURLDaily        = "https://daily-cloudcode-pa.googleapis.com"
-	antigravitySandboxBaseURLDaily = "https://daily-cloudcode-pa.sandbox.googleapis.com"
-	antigravityBaseURLProd         = "https://cloudcode-pa.googleapis.com"
-	antigravityModelsPath          = "/v1internal:fetchAvailableModels"
+	antigravityBaseURLDaily           = "https://daily-cloudcode-pa.googleapis.com"
+	antigravitySandboxBaseURLDaily    = "https://daily-cloudcode-pa.sandbox.googleapis.com"
+	antigravitySandboxBaseURLAutopush = "https://autopush-cloudcode-pa.sandbox.googleapis.com"
+	antigravityBaseURLProd            = "https://cloudcode-pa.googleapis.com"
+	antigravityModelsPath             = "/v1internal:fetchAvailableModels"
 )
 
 func init() {
@@ -167,96 +168,128 @@ func fetchModels(ctx context.Context, auth *coreauth.Auth) []modelEntry {
 		return nil
 	}
 
-	baseURLs := []string{antigravityBaseURLProd, antigravityBaseURLDaily, antigravitySandboxBaseURLDaily}
+	baseURLs := []string{
+		antigravityBaseURLProd,
+		antigravityBaseURLDaily,
+		antigravitySandboxBaseURLDaily,
+		antigravitySandboxBaseURLAutopush,
+	}
+	var bestModels []modelEntry
 
 	for _, baseURL := range baseURLs {
-		modelsURL := baseURL + antigravityModelsPath
-
-		var payload []byte
+		payloads := [][]byte{[]byte(`{}`)}
 		if auth != nil && auth.Metadata != nil {
 			if pid, ok := auth.Metadata["project_id"].(string); ok && strings.TrimSpace(pid) != "" {
-				payload = []byte(fmt.Sprintf(`{"project": "%s"}`, strings.TrimSpace(pid)))
+				if raw, errMarshal := json.Marshal(map[string]string{"project": strings.TrimSpace(pid)}); errMarshal == nil {
+					payloads = append([][]byte{raw}, payloads...)
+				}
 			}
 		}
-		if len(payload) == 0 {
-			payload = []byte(`{}`)
-		}
 
-		httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, modelsURL, strings.NewReader(string(payload)))
-		if errReq != nil {
-			continue
-		}
-		httpReq.Close = true
-		httpReq.Header.Set("Content-Type", "application/json")
-		httpReq.Header.Set("Authorization", "Bearer "+accessToken)
-		httpReq.Header.Set("User-Agent", misc.AntigravityUserAgent())
+		for _, payload := range payloads {
+			modelsURL := baseURL + antigravityModelsPath
 
-		httpClient := &http.Client{Timeout: 30 * time.Second}
-		if transport, _, errProxy := proxyutil.BuildHTTPTransport(auth.ProxyURL); errProxy == nil && transport != nil {
-			httpClient.Transport = transport
-		}
-		httpResp, errDo := httpClient.Do(httpReq)
-		if errDo != nil {
-			continue
-		}
-
-		bodyBytes, errRead := io.ReadAll(httpResp.Body)
-		httpResp.Body.Close()
-		if errRead != nil {
-			continue
-		}
-
-		if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
-			continue
-		}
-
-		result := gjson.GetBytes(bodyBytes, "models")
-		if !result.Exists() {
-			continue
-		}
-
-		var models []modelEntry
-
-		for originalName, modelData := range result.Map() {
-			modelID := strings.TrimSpace(originalName)
-			if modelID == "" {
+			httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, modelsURL, strings.NewReader(string(payload)))
+			if errReq != nil {
 				continue
 			}
-			// Skip internal/experimental models
-			switch modelID {
-			case "chat_20706", "chat_23310", "tab_flash_lite_preview", "tab_jump_flash_lite_preview", "gemini-2.5-flash-thinking", "gemini-2.5-pro":
+			httpReq.Close = true
+			httpReq.Header.Set("Content-Type", "application/json")
+			httpReq.Header.Set("Accept", "application/json")
+			httpReq.Header.Set("Authorization", "Bearer "+accessToken)
+			httpReq.Header.Set("User-Agent", misc.AntigravityUserAgent())
+			httpReq.Header.Set("X-Client-Name", "antigravity")
+			httpReq.Header.Set("X-Client-Version", misc.AntigravityLatestVersion())
+			httpReq.Header.Set("x-request-source", "local")
+
+			httpClient := &http.Client{Timeout: 30 * time.Second}
+			if transport, _, errProxy := proxyutil.BuildHTTPTransport(auth.ProxyURL); errProxy == nil && transport != nil {
+				httpClient.Transport = transport
+			}
+			httpResp, errDo := httpClient.Do(httpReq)
+			if errDo != nil {
 				continue
 			}
 
-			displayName := modelData.Get("displayName").String()
-			if displayName == "" {
-				displayName = modelID
+			bodyBytes, errRead := io.ReadAll(httpResp.Body)
+			httpResp.Body.Close()
+			if errRead != nil {
+				continue
 			}
 
-			entry := modelEntry{
-				ID:          modelID,
-				Object:      "model",
-				OwnedBy:     "antigravity",
-				Type:        "antigravity",
-				DisplayName: displayName,
-				Name:        modelID,
-				Description: displayName,
+			if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
+				continue
 			}
 
-			if maxTok := modelData.Get("maxTokens").Int(); maxTok > 0 {
-				entry.ContextLength = int(maxTok)
-			}
-			if maxOut := modelData.Get("maxOutputTokens").Int(); maxOut > 0 {
-				entry.MaxCompletionTokens = int(maxOut)
+			result := gjson.GetBytes(bodyBytes, "models")
+			if !result.Exists() {
+				continue
 			}
 
-			models = append(models, entry)
+			var models []modelEntry
+
+			for originalName, modelData := range result.Map() {
+				modelID := strings.TrimSpace(originalName)
+				if modelID == "" {
+					continue
+				}
+				// Skip internal/experimental models
+				switch modelID {
+				case "chat_20706", "chat_23310", "tab_flash_lite_preview", "tab_jump_flash_lite_preview", "gemini-2.5-flash-thinking", "gemini-2.5-pro":
+					continue
+				}
+
+				displayName := misc.AntigravityDisplayName(modelID, modelData.Get("displayName").String())
+
+				entry := modelEntry{
+					ID:          modelID,
+					Object:      "model",
+					OwnedBy:     "antigravity",
+					Type:        "antigravity",
+					DisplayName: displayName,
+					Name:        modelID,
+					Description: displayName,
+				}
+
+				if maxTok := modelData.Get("maxTokens").Int(); maxTok > 0 {
+					entry.ContextLength = int(maxTok)
+				}
+				if maxOut := modelData.Get("maxOutputTokens").Int(); maxOut > 0 {
+					entry.MaxCompletionTokens = int(maxOut)
+				}
+
+				models = append(models, entry)
+			}
+
+			if len(models) == 0 {
+				continue
+			}
+			if bestModels == nil {
+				bestModels = models
+			}
+			if hasAntigravity35FlashPair(models) {
+				return models
+			}
 		}
-
-		return models
 	}
 
-	return nil
+	return bestModels
+}
+
+func hasAntigravity35FlashPair(models []modelEntry) bool {
+	hasHigh := false
+	hasMedium := false
+	for _, model := range models {
+		modelID := strings.ToLower(strings.TrimSpace(model.ID))
+		displayName := strings.ToLower(strings.TrimSpace(model.DisplayName))
+		switch {
+		case modelID == "gemini-3-flash-agent" || modelID == "gemini-3.5-flash-high" || strings.Contains(displayName, "gemini 3.5 flash (high)"):
+			hasHigh = true
+		case modelID == "gemini-3.5-flash-low" || modelID == "gemini-3.5-flash-medium" || strings.Contains(displayName, "gemini 3.5 flash (medium)"):
+			hasMedium = true
+		}
+	}
+	return hasHigh && hasMedium
 }
 
 func metaStringValue(m map[string]interface{}, key string) string {

--- a/cmd/fetch_antigravity_models/main_test.go
+++ b/cmd/fetch_antigravity_models/main_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestHasAntigravity35FlashPair(t *testing.T) {
 	models := []modelEntry{
-		{ID: "gemini-3-flash-agent", DisplayName: "Gemini 3.5 Flash (High)"},
-		{ID: "gemini-3.5-flash-low", DisplayName: "Gemini 3.5 Flash (Medium)"},
+		{ID: "gemini-3.5-flash-high", DisplayName: "Gemini 3.5 Flash (High)"},
+		{ID: "gemini-3.5-flash-medium", DisplayName: "Gemini 3.5 Flash (Medium)"},
 	}
 
 	if !hasAntigravity35FlashPair(models) {

--- a/cmd/fetch_antigravity_models/main_test.go
+++ b/cmd/fetch_antigravity_models/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestHasAntigravity35FlashPair(t *testing.T) {
+	models := []modelEntry{
+		{ID: "gemini-3-flash-agent", DisplayName: "Gemini 3.5 Flash (High)"},
+		{ID: "gemini-3.5-flash-low", DisplayName: "Gemini 3.5 Flash (Medium)"},
+	}
+
+	if !hasAntigravity35FlashPair(models) {
+		t.Fatal("expected Gemini 3.5 Flash high/medium pair")
+	}
+}
+
+func TestHasAntigravity35FlashPairRejectsSingleVariant(t *testing.T) {
+	models := []modelEntry{
+		{ID: "gemini-3-flash-agent", DisplayName: "Gemini 3.5 Flash (High)"},
+	}
+
+	if hasAntigravity35FlashPair(models) {
+		t.Fatal("expected single Gemini 3.5 Flash variant to be incomplete")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,7 +215,7 @@ type QuotaExceeded struct {
 	// SwitchPreviewModel indicates whether to automatically switch to a preview model when a quota is exceeded.
 	SwitchPreviewModel bool `yaml:"switch-preview-model" json:"switch-preview-model"`
 
-	// AntigravityCredits enables credits-based last-resort fallback for Claude models.
+	// AntigravityCredits enables credits-based last-resort fallback for eligible Antigravity models.
 	// When all free-tier auths are exhausted (429/503), the conductor retries with
 	// an auth that has available Google One AI credits.
 	AntigravityCredits bool `yaml:"antigravity-credits" json:"antigravity-credits"`

--- a/internal/misc/antigravity_model_test.go
+++ b/internal/misc/antigravity_model_test.go
@@ -1,0 +1,32 @@
+package misc
+
+import "testing"
+
+func TestAntigravityWireModel_Gemini35FlashVariants(t *testing.T) {
+	tests := map[string]string{
+		"gemini-3.5-flash-high":   "gemini-3-flash-agent",
+		"gemini-3.5-flash-medium": "gemini-3.5-flash-low",
+		"gemini-3.5-flash":        "gemini-3.5-flash-low",
+		"gemini-3-flash-medium":   "gemini-3-flash",
+		"gemini-3-flash":          "gemini-3-flash",
+	}
+
+	for input, want := range tests {
+		if got := AntigravityWireModel(input); got != want {
+			t.Fatalf("AntigravityWireModel(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestAntigravityDisplayName_Gemini35BackendKeys(t *testing.T) {
+	tests := map[string]string{
+		"gemini-3-flash-agent": "Gemini 3.5 Flash (High)",
+		"gemini-3.5-flash-low": "Gemini 3.5 Flash (Medium)",
+	}
+
+	for input, want := range tests {
+		if got := AntigravityDisplayName(input, "fallback"); got != want {
+			t.Fatalf("AntigravityDisplayName(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/internal/misc/antigravity_model_test.go
+++ b/internal/misc/antigravity_model_test.go
@@ -4,9 +4,9 @@ import "testing"
 
 func TestAntigravityWireModel_Gemini35FlashVariants(t *testing.T) {
 	tests := map[string]string{
-		"gemini-3.5-flash-high":   "gemini-3.5-flash-high",
-		"gemini-3.5-flash-medium": "gemini-3.5-flash-medium",
-		"gemini-3.5-flash":        "gemini-3.5-flash",
+		"gemini-3.5-flash-high":   "gemini-3-flash-agent",
+		"gemini-3.5-flash-medium": "gemini-3.5-flash-low",
+		"gemini-3.5-flash":        "gemini-3.5-flash-low",
 		"gemini-3-flash-medium":   "gemini-3-flash",
 		"gemini-3-flash":          "gemini-3-flash",
 	}

--- a/internal/misc/antigravity_model_test.go
+++ b/internal/misc/antigravity_model_test.go
@@ -4,9 +4,9 @@ import "testing"
 
 func TestAntigravityWireModel_Gemini35FlashVariants(t *testing.T) {
 	tests := map[string]string{
-		"gemini-3.5-flash-high":   "gemini-3-flash-agent",
-		"gemini-3.5-flash-medium": "gemini-3.5-flash-low",
-		"gemini-3.5-flash":        "gemini-3.5-flash-low",
+		"gemini-3.5-flash-high":   "gemini-3.5-flash-high",
+		"gemini-3.5-flash-medium": "gemini-3.5-flash-medium",
+		"gemini-3.5-flash":        "gemini-3.5-flash",
 		"gemini-3-flash-medium":   "gemini-3-flash",
 		"gemini-3-flash":          "gemini-3-flash",
 	}
@@ -20,8 +20,10 @@ func TestAntigravityWireModel_Gemini35FlashVariants(t *testing.T) {
 
 func TestAntigravityDisplayName_Gemini35BackendKeys(t *testing.T) {
 	tests := map[string]string{
-		"gemini-3-flash-agent": "Gemini 3.5 Flash (High)",
-		"gemini-3.5-flash-low": "Gemini 3.5 Flash (Medium)",
+		"gemini-3.5-flash-high":   "Gemini 3.5 Flash (High)",
+		"gemini-3.5-flash-medium": "Gemini 3.5 Flash (Medium)",
+		"gemini-3-flash-agent":    "Gemini 3.5 Flash (High)",
+		"gemini-3.5-flash-low":    "Gemini 3.5 Flash (Medium)",
 	}
 
 	for input, want := range tests {

--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -169,15 +169,11 @@ func AntigravityVersionFromUserAgent(userAgent string) string {
 	return rest
 }
 
-// AntigravityWireModel resolves user-facing Antigravity model IDs to the
-// backend model keys returned by Antigravity's fetchAvailableModels endpoint.
+// AntigravityWireModel resolves legacy Antigravity model aliases to their
+// backend model keys while preserving native Gemini 3.5 Flash variant IDs.
 func AntigravityWireModel(modelName string) string {
 	normalized := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(modelName, "models/")))
 	switch normalized {
-	case "gemini-3.5-flash-high":
-		return "gemini-3-flash-agent"
-	case "gemini-3.5-flash-medium", "gemini-3.5-flash":
-		return "gemini-3.5-flash-low"
 	case "gemini-3-flash-high", "gemini-3-flash-medium", "gemini-3-flash-low":
 		return "gemini-3-flash"
 	default:

--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -107,7 +108,29 @@ func AntigravityLatestVersion() string {
 // AntigravityUserAgent returns the User-Agent string for antigravity requests
 // using the latest version fetched from the releases API.
 func AntigravityUserAgent() string {
-	return fmt.Sprintf("antigravity/%s darwin/arm64", AntigravityLatestVersion())
+	return fmt.Sprintf("antigravity/%s %s/%s", AntigravityLatestVersion(), antigravityOS(), antigravityArch())
+}
+
+func antigravityOS() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "win32"
+	case "darwin":
+		return "darwin"
+	default:
+		return "linux"
+	}
+}
+
+func antigravityArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x64"
+	case "arm64":
+		return "arm64"
+	default:
+		return "x86"
+	}
 }
 
 func antigravityBaseUserAgent(userAgent string) string {
@@ -169,11 +192,15 @@ func AntigravityVersionFromUserAgent(userAgent string) string {
 	return rest
 }
 
-// AntigravityWireModel resolves legacy Antigravity model aliases to their
-// backend model keys while preserving native Gemini 3.5 Flash variant IDs.
+// AntigravityWireModel resolves public Antigravity model IDs to the backend
+// model keys currently accepted by the Antigravity generation endpoint.
 func AntigravityWireModel(modelName string) string {
 	normalized := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(modelName, "models/")))
 	switch normalized {
+	case "gemini-3.5-flash-high":
+		return "gemini-3-flash-agent"
+	case "gemini-3.5-flash", "gemini-3.5-flash-medium":
+		return "gemini-3.5-flash-low"
 	case "gemini-3-flash-high", "gemini-3-flash-medium", "gemini-3-flash-low":
 		return "gemini-3-flash"
 	default:

--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	antigravityReleasesURL     = "https://antigravity-auto-updater-974169037036.us-central1.run.app/releases"
-	antigravityFallbackVersion = "1.21.9"
+	antigravityFallbackVersion = "2.0.1"
 	antigravityVersionCacheTTL = 6 * time.Hour
 	antigravityFetchTimeout    = 10 * time.Second
 	AntigravityNodeAPIClientUA = "google-api-nodejs-client/10.3.0"
@@ -167,6 +167,47 @@ func AntigravityVersionFromUserAgent(userAgent string) string {
 		return AntigravityLatestVersion()
 	}
 	return rest
+}
+
+// AntigravityWireModel resolves user-facing Antigravity model IDs to the
+// backend model keys returned by Antigravity's fetchAvailableModels endpoint.
+func AntigravityWireModel(modelName string) string {
+	normalized := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(modelName, "models/")))
+	switch normalized {
+	case "gemini-3.5-flash-high":
+		return "gemini-3-flash-agent"
+	case "gemini-3.5-flash-medium", "gemini-3.5-flash":
+		return "gemini-3.5-flash-low"
+	case "gemini-3-flash-high", "gemini-3-flash-medium", "gemini-3-flash-low":
+		return "gemini-3-flash"
+	default:
+		return modelName
+	}
+}
+
+// AntigravityDisplayName normalizes backend model keys to the user-facing
+// labels used by Antigravity's model picker and quota UI.
+func AntigravityDisplayName(modelName, fallback string) string {
+	normalized := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(modelName, "models/")))
+	switch normalized {
+	case "gemini-3.5-flash-high", "gemini-3-flash-agent":
+		return "Gemini 3.5 Flash (High)"
+	case "gemini-3.5-flash-medium", "gemini-3.5-flash-low":
+		return "Gemini 3.5 Flash (Medium)"
+	case "gemini-3.5-flash":
+		return "Gemini 3.5 Flash"
+	case "gemini-3-flash-high":
+		return "Gemini 3 Flash (High)"
+	case "gemini-3-flash-medium":
+		return "Gemini 3 Flash (Medium)"
+	case "gemini-3-flash-low":
+		return "Gemini 3 Flash (Low)"
+	}
+	fallback = strings.TrimSpace(fallback)
+	if fallback != "" {
+		return fallback
+	}
+	return strings.TrimSpace(modelName)
 }
 
 func fetchAntigravityLatestVersion(ctx context.Context) (string, error) {

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -11,6 +11,9 @@ const (
 	xaiBuiltinImageModelID        = "grok-imagine-image"
 	xaiBuiltinImageQualityModelID = "grok-imagine-image-quality"
 	xaiBuiltinVideoModelID        = "grok-imagine-video"
+	antigravityGemini35FlashID    = "gemini-3.5-flash"
+	antigravityGemini35HighID     = "gemini-3.5-flash-high"
+	antigravityGemini35MediumID   = "gemini-3.5-flash-medium"
 )
 
 // staticModelsJSON mirrors the top-level structure of models.json.
@@ -81,7 +84,7 @@ func GetKimiModels() []*ModelInfo {
 
 // GetAntigravityModels returns the standard Antigravity model definitions.
 func GetAntigravityModels() []*ModelInfo {
-	return cloneModelInfos(getModels().Antigravity)
+	return WithAntigravityBuiltins(cloneModelInfos(getModels().Antigravity))
 }
 
 // GetXAIModels returns the standard xAI Grok model definitions.
@@ -100,6 +103,29 @@ func WithCodexBuiltins(models []*ModelInfo) []*ModelInfo {
 // not depend on remote models.json updates.
 func WithXAIBuiltins(models []*ModelInfo) []*ModelInfo {
 	return upsertModelInfos(models, xaiBuiltinImageModelInfo(), xaiBuiltinImageQualityModelInfo(), xaiBuiltinVideoModelInfo())
+}
+
+// WithAntigravityBuiltins injects canonical Antigravity Gemini 3.5 Flash model
+// definitions and removes legacy alias IDs that some remote catalogs still
+// publish for those same variants.
+func WithAntigravityBuiltins(models []*ModelInfo) []*ModelInfo {
+	filtered := make([]*ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(model.ID)) {
+		case "gemini-3-flash-agent", "gemini-3.5-flash-low":
+			continue
+		default:
+			filtered = append(filtered, model)
+		}
+	}
+	return upsertModelInfos(filtered,
+		antigravityGemini35FlashModelInfo(),
+		antigravityGemini35HighModelInfo(),
+		antigravityGemini35MediumModelInfo(),
+	)
 }
 
 func codexBuiltinImageModelInfo() *ModelInfo {
@@ -151,6 +177,45 @@ func xaiBuiltinVideoModelInfo() *ModelInfo {
 		Name:        xaiBuiltinVideoModelID,
 		Description: "xAI Grok video generation model.",
 	}
+}
+
+func antigravityGemini35FlashModelInfo() *ModelInfo {
+	return &ModelInfo{
+		ID:                  antigravityGemini35FlashID,
+		Object:              "model",
+		Created:             1735689600, // 2025-01-01
+		OwnedBy:             "antigravity",
+		Type:                "antigravity",
+		DisplayName:         "Gemini 3.5 Flash",
+		Name:                antigravityGemini35FlashID,
+		Description:         "Gemini 3.5 Flash",
+		ContextLength:       1048576,
+		MaxCompletionTokens: 65536,
+		Thinking: &ThinkingSupport{
+			Levels:         []string{"minimal", "low", "medium", "high"},
+			Min:            128,
+			Max:            32768,
+			DynamicAllowed: true,
+		},
+	}
+}
+
+func antigravityGemini35HighModelInfo() *ModelInfo {
+	model := antigravityGemini35FlashModelInfo()
+	model.ID = antigravityGemini35HighID
+	model.DisplayName = "Gemini 3.5 Flash (High)"
+	model.Name = antigravityGemini35HighID
+	model.Description = "Gemini 3.5 Flash (High)"
+	return model
+}
+
+func antigravityGemini35MediumModelInfo() *ModelInfo {
+	model := antigravityGemini35FlashModelInfo()
+	model.ID = antigravityGemini35MediumID
+	model.DisplayName = "Gemini 3.5 Flash (Medium)"
+	model.Name = antigravityGemini35MediumID
+	model.Description = "Gemini 3.5 Flash (Medium)"
+	return model
 }
 
 func upsertModelInfos(models []*ModelInfo, extras ...*ModelInfo) []*ModelInfo {
@@ -257,17 +322,19 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		return nil
 	}
 
-	data := getModels()
 	allModels := [][]*ModelInfo{
-		data.Claude,
-		data.Gemini,
-		data.Vertex,
-		data.GeminiCLI,
-		data.AIStudio,
-		data.CodexPro,
-		data.Kimi,
-		data.Antigravity,
-		data.XAI,
+		GetClaudeModels(),
+		GetGeminiModels(),
+		GetGeminiVertexModels(),
+		GetGeminiCLIModels(),
+		GetAIStudioModels(),
+		GetCodexFreeModels(),
+		GetCodexTeamModels(),
+		GetCodexPlusModels(),
+		GetCodexProModels(),
+		GetKimiModels(),
+		GetAntigravityModels(),
+		GetXAIModels(),
 	}
 	for _, models := range allModels {
 		for _, m := range models {

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -74,6 +74,55 @@ func TestAntigravityModelsIncludeGemini35FlashVariants(t *testing.T) {
 	}
 }
 
+func TestAntigravityModelsNormalizeLegacyGemini35Aliases(t *testing.T) {
+	modelsCatalogStore.mu.Lock()
+	original := modelsCatalogStore.data
+	modelsCatalogStore.data = &staticModelsJSON{
+		Claude:    []*ModelInfo{{ID: "claude-test"}},
+		Gemini:    []*ModelInfo{{ID: "gemini-test"}},
+		Vertex:    []*ModelInfo{{ID: "vertex-test"}},
+		GeminiCLI: []*ModelInfo{{ID: "gemini-cli-test"}},
+		AIStudio:  []*ModelInfo{{ID: "aistudio-test"}},
+		CodexFree: []*ModelInfo{{ID: "codex-free-test"}},
+		CodexTeam: []*ModelInfo{{ID: "codex-team-test"}},
+		CodexPlus: []*ModelInfo{{ID: "codex-plus-test"}},
+		CodexPro:  []*ModelInfo{{ID: "codex-pro-test"}},
+		Kimi:      []*ModelInfo{{ID: "kimi-test"}},
+		XAI:       []*ModelInfo{{ID: "xai-test"}},
+		Antigravity: []*ModelInfo{
+			{ID: "gemini-3-flash", Object: "model", OwnedBy: "antigravity", Type: "antigravity", DisplayName: "Gemini 3 Flash"},
+			{ID: "gemini-3-flash-agent", Object: "model", OwnedBy: "antigravity", Type: "antigravity", DisplayName: "Gemini 3.5 Flash (High)"},
+			{ID: "gemini-3.5-flash-low", Object: "model", OwnedBy: "antigravity", Type: "antigravity", DisplayName: "Gemini 3.5 Flash (Medium)"},
+		},
+	}
+	modelsCatalogStore.mu.Unlock()
+
+	t.Cleanup(func() {
+		modelsCatalogStore.mu.Lock()
+		modelsCatalogStore.data = original
+		modelsCatalogStore.mu.Unlock()
+	})
+
+	models := GetAntigravityModels()
+	for _, id := range []string{"gemini-3.5-flash", "gemini-3.5-flash-high", "gemini-3.5-flash-medium"} {
+		if findModelInfo(models, id) == nil {
+			t.Fatalf("expected canonical Antigravity model %s", id)
+		}
+		if LookupStaticModelInfo(id) == nil {
+			t.Fatalf("expected static lookup for %s", id)
+		}
+	}
+
+	for _, legacyID := range []string{"gemini-3-flash-agent", "gemini-3.5-flash-low"} {
+		if findModelInfo(models, legacyID) != nil {
+			t.Fatalf("did not expect legacy alias model %s in Antigravity models", legacyID)
+		}
+		if LookupStaticModelInfo(legacyID) != nil {
+			t.Fatalf("did not expect static lookup to expose legacy alias %s", legacyID)
+		}
+	}
+}
+
 func TestValidateModelsCatalogAllowsMissingSections(t *testing.T) {
 	data := validTestModelsCatalog()
 	data.XAI = nil

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -49,6 +49,31 @@ func TestWithXAIBuiltinsAddsVideoModel(t *testing.T) {
 	}
 }
 
+func TestAntigravityModelsIncludeGemini35FlashVariants(t *testing.T) {
+	models := GetAntigravityModels()
+	tests := map[string]string{
+		"gemini-3.5-flash":        "Gemini 3.5 Flash",
+		"gemini-3.5-flash-high":   "Gemini 3.5 Flash (High)",
+		"gemini-3.5-flash-medium": "Gemini 3.5 Flash (Medium)",
+	}
+
+	for id, displayName := range tests {
+		model := findModelInfo(models, id)
+		if model == nil {
+			t.Fatalf("expected Antigravity model %s", id)
+		}
+		if model.DisplayName != displayName {
+			t.Fatalf("%s display name = %q, want %q", id, model.DisplayName, displayName)
+		}
+		if model.Thinking == nil {
+			t.Fatalf("%s should keep Antigravity thinking support", id)
+		}
+		if !hasLevel(model.Thinking.Levels, "medium") || !hasLevel(model.Thinking.Levels, "high") {
+			t.Fatalf("%s thinking levels = %v, want medium and high", id, model.Thinking.Levels)
+		}
+	}
+}
+
 func TestValidateModelsCatalogAllowsMissingSections(t *testing.T) {
 	data := validTestModelsCatalog()
 	data.XAI = nil
@@ -83,6 +108,15 @@ func validTestModelsCatalog() *staticModelsJSON {
 		Antigravity: models,
 		XAI:         models,
 	}
+}
+
+func hasLevel(levels []string, want string) bool {
+	for _, level := range levels {
+		if level == want {
+			return true
+		}
+	}
+	return false
 }
 
 func findModelInfo(models []*ModelInfo, id string) *ModelInfo {

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1955,6 +1955,72 @@
       }
     },
     {
+      "id": "gemini-3.5-flash",
+      "object": "model",
+      "owned_by": "antigravity",
+      "type": "antigravity",
+      "display_name": "Gemini 3.5 Flash",
+      "name": "gemini-3.5-flash",
+      "description": "Gemini 3.5 Flash",
+      "context_length": 1048576,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "gemini-3.5-flash-high",
+      "object": "model",
+      "owned_by": "antigravity",
+      "type": "antigravity",
+      "display_name": "Gemini 3.5 Flash (High)",
+      "name": "gemini-3.5-flash-high",
+      "description": "Gemini 3.5 Flash (High)",
+      "context_length": 1048576,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "gemini-3.5-flash-medium",
+      "object": "model",
+      "owned_by": "antigravity",
+      "type": "antigravity",
+      "display_name": "Gemini 3.5 Flash (Medium)",
+      "name": "gemini-3.5-flash-medium",
+      "description": "Gemini 3.5 Flash (Medium)",
+      "context_length": 1048576,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
       "id": "gemini-3-pro-high",
       "object": "model",
       "owned_by": "antigravity",

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -2220,9 +2220,9 @@ func antigravityShouldRetryEndpointNotFound(statusCode int) bool {
 func antigravityDefaultThinkingLevel(modelName string) string {
 	normalized := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(modelName, "models/")))
 	switch normalized {
-	case "gemini-3.5-flash-high", "gemini-3-flash-agent":
+	case "gemini-3.5-flash-high":
 		return "high"
-	case "gemini-3.5-flash-medium", "gemini-3.5-flash-low":
+	case "gemini-3.5-flash-medium":
 		return "medium"
 	default:
 		return ""

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -613,12 +613,8 @@ attemptLoop:
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
-				if antigravityShouldRetryEndpointNotFound(httpResp.StatusCode) && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: endpoint/model not found on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
-				}
-				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+				if antigravityShouldRetryEndpointUnavailable(httpResp.StatusCode, bodyBytes) && idx+1 < len(baseURLs) {
+					log.Debugf("antigravity executor: endpoint/model unavailable on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
 					continue
 				}
 				if antigravityShouldRetryTransientResourceExhausted429(httpResp.StatusCode, bodyBytes) && attempt+1 < attempts {
@@ -828,12 +824,8 @@ attemptLoop:
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
-				if antigravityShouldRetryEndpointNotFound(httpResp.StatusCode) && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: endpoint/model not found on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
-				}
-				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+				if antigravityShouldRetryEndpointUnavailable(httpResp.StatusCode, bodyBytes) && idx+1 < len(baseURLs) {
+					log.Debugf("antigravity executor: endpoint/model unavailable on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
 					continue
 				}
 				if antigravityShouldRetryTransientResourceExhausted429(httpResp.StatusCode, bodyBytes) && attempt+1 < attempts {
@@ -1292,12 +1284,8 @@ attemptLoop:
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
-				if antigravityShouldRetryEndpointNotFound(httpResp.StatusCode) && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: endpoint/model not found on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-					continue
-				}
-				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+				if antigravityShouldRetryEndpointUnavailable(httpResp.StatusCode, bodyBytes) && idx+1 < len(baseURLs) {
+					log.Debugf("antigravity executor: endpoint/model unavailable on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
 					continue
 				}
 				if antigravityShouldRetryTransientResourceExhausted429(httpResp.StatusCode, bodyBytes) && attempt+1 < attempts {
@@ -1560,12 +1548,8 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 		lastStatus = httpResp.StatusCode
 		lastBody = append([]byte(nil), bodyBytes...)
 		lastErr = nil
-		if antigravityShouldRetryEndpointNotFound(httpResp.StatusCode) && idx+1 < len(baseURLs) {
-			log.Debugf("antigravity executor: endpoint/model not found on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
-			continue
-		}
-		if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
-			log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+		if antigravityShouldRetryEndpointUnavailable(httpResp.StatusCode, bodyBytes) && idx+1 < len(baseURLs) {
+			log.Debugf("antigravity executor: endpoint/model unavailable on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
 			continue
 		}
 		sErr := statusErr{code: httpResp.StatusCode, msg: string(bodyBytes)}
@@ -1821,7 +1805,7 @@ func (e *AntigravityExecutor) updateAntigravityCreditsBalance(ctx context.Contex
 		log.Debugf("antigravity executor: marshal loadCodeAssist request error: %v", errMarshal)
 		return
 	}
-	baseURL := buildBaseURL(auth)
+	baseURL := buildLoadCodeAssistBaseURL(auth)
 	endpointURL := strings.TrimSuffix(baseURL, "/") + "/v1internal:loadCodeAssist"
 	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(loadReqBody))
 	if errReq != nil {
@@ -1951,8 +1935,9 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	isClaude := strings.Contains(lowerWireModelName, "claude")
 	useAntigravitySchema := isClaude || strings.Contains(lowerWireModelName, "gemini-3-pro") || strings.Contains(lowerWireModelName, "gemini-3.1-pro")
 	var (
-		bodyReader io.Reader
-		payloadLog []byte
+		bodyReader       io.Reader
+		payloadLog       []byte
+		requestSessionID string
 	)
 	if antigravityRequestNeedsSchemaSanitization(payload) {
 		payloadStr := string(payload)
@@ -1976,6 +1961,7 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 		}
 
 		bodyReader = strings.NewReader(payloadStr)
+		requestSessionID = strings.TrimSpace(gjson.Get(payloadStr, "request.sessionId").String())
 		if e.cfg != nil && e.cfg.RequestLog {
 			payloadLog = []byte(payloadStr)
 		}
@@ -1987,6 +1973,7 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 		}
 
 		bodyReader = bytes.NewReader(payload)
+		requestSessionID = strings.TrimSpace(gjson.GetBytes(payload, "request.sessionId").String())
 		if e.cfg != nil && e.cfg.RequestLog {
 			payloadLog = append([]byte(nil), payload...)
 		}
@@ -2013,6 +2000,10 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("User-Agent", resolveUserAgent(auth))
+	httpReq.Header.Set("x-request-source", "local")
+	if requestSessionID != "" {
+		httpReq.Header.Set("X-Machine-Session-Id", requestSessionID)
+	}
 	if host := resolveHost(base); host != "" {
 		httpReq.Host = host
 	}
@@ -2121,6 +2112,13 @@ func buildBaseURL(auth *cliproxyauth.Auth) string {
 	return antigravityBaseURLDaily
 }
 
+func buildLoadCodeAssistBaseURL(auth *cliproxyauth.Auth) string {
+	if base := resolveCustomAntigravityBaseURL(auth); base != "" {
+		return base
+	}
+	return antigravityBaseURLProd
+}
+
 func resolveHost(base string) string {
 	parsed, errParse := url.Parse(base)
 	if errParse != nil {
@@ -2213,8 +2211,17 @@ func antigravityShouldRetrySoftRateLimit(statusCode int, body []byte) bool {
 	return decideAntigravity429(body).kind == antigravity429DecisionSoftRetry
 }
 
-func antigravityShouldRetryEndpointNotFound(statusCode int) bool {
-	return statusCode == http.StatusNotFound
+func antigravityShouldRetryEndpointUnavailable(statusCode int, body []byte) bool {
+	if statusCode == http.StatusNotFound {
+		return true
+	}
+	if statusCode != http.StatusForbidden || len(body) == 0 {
+		return false
+	}
+	msg := strings.ToLower(string(body))
+	return strings.Contains(msg, "gemini for google cloud api (staging)") &&
+		strings.Contains(msg, "staging-cloudaicompanion.sandbox.googleapis.com") &&
+		strings.Contains(msg, "disabled")
 }
 
 func antigravityDefaultThinkingLevel(modelName string) string {
@@ -2352,7 +2359,6 @@ var antigravityBaseURLFallbackOrder = func(auth *cliproxyauth.Auth) []string {
 	}
 	return []string{
 		antigravityBaseURLDaily,
-		antigravitySandboxBaseURLDaily,
 		antigravitySandboxBaseURLAutopush,
 		antigravityBaseURLProd,
 	}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -43,13 +43,14 @@ import (
 const (
 	antigravityBaseURLDaily                = "https://daily-cloudcode-pa.googleapis.com"
 	antigravitySandboxBaseURLDaily         = "https://daily-cloudcode-pa.sandbox.googleapis.com"
+	antigravitySandboxBaseURLAutopush      = "https://autopush-cloudcode-pa.sandbox.googleapis.com"
 	antigravityBaseURLProd                 = "https://cloudcode-pa.googleapis.com"
 	antigravityCountTokensPath             = "/v1internal:countTokens"
 	antigravityStreamPath                  = "/v1internal:streamGenerateContent"
 	antigravityGeneratePath                = "/v1internal:generateContent"
 	antigravityClientID                    = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
 	antigravityClientSecret                = "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"
-	defaultAntigravityAgent                = "antigravity/1.21.9 darwin/arm64" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
+	defaultAntigravityAgent                = "antigravity/2.0.1 darwin/arm64" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
 	antigravityAuthType                    = "antigravity"
 	refreshSkew                            = 3000 * time.Second
 	antigravityCreditsHintRefreshInterval  = 10 * time.Minute
@@ -612,6 +613,10 @@ attemptLoop:
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
+				if antigravityShouldRetryEndpointNotFound(httpResp.StatusCode) && idx+1 < len(baseURLs) {
+					log.Debugf("antigravity executor: endpoint/model not found on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+					continue
+				}
 				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
 					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
 					continue
@@ -823,6 +828,10 @@ attemptLoop:
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
+				if antigravityShouldRetryEndpointNotFound(httpResp.StatusCode) && idx+1 < len(baseURLs) {
+					log.Debugf("antigravity executor: endpoint/model not found on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+					continue
+				}
 				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
 					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
 					continue
@@ -1283,6 +1292,10 @@ attemptLoop:
 				lastStatus = httpResp.StatusCode
 				lastBody = append([]byte(nil), bodyBytes...)
 				lastErr = nil
+				if antigravityShouldRetryEndpointNotFound(httpResp.StatusCode) && idx+1 < len(baseURLs) {
+					log.Debugf("antigravity executor: endpoint/model not found on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+					continue
+				}
 				if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
 					log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
 					continue
@@ -1547,6 +1560,10 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 		lastStatus = httpResp.StatusCode
 		lastBody = append([]byte(nil), bodyBytes...)
 		lastErr = nil
+		if antigravityShouldRetryEndpointNotFound(httpResp.StatusCode) && idx+1 < len(baseURLs) {
+			log.Debugf("antigravity executor: endpoint/model not found on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
+			continue
+		}
 		if httpResp.StatusCode == http.StatusTooManyRequests && idx+1 < len(baseURLs) {
 			log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
 			continue
@@ -1916,8 +1933,10 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 			projectID = strings.TrimSpace(pid)
 		}
 	}
-	payload = geminiToAntigravity(modelName, payload, projectID)
-	payload, _ = sjson.SetBytes(payload, "model", modelName)
+	wireModelName := misc.AntigravityWireModel(modelName)
+	payload = geminiToAntigravity(wireModelName, payload, projectID)
+	payload, _ = sjson.SetBytes(payload, "model", wireModelName)
+	payload = antigravityApplyDefaultVariantThinking(payload, modelName)
 
 	// Cap maxOutputTokens to model's max_completion_tokens from registry
 	if maxOut := gjson.GetBytes(payload, "request.generationConfig.maxOutputTokens"); maxOut.Exists() && maxOut.Type == gjson.Number {
@@ -1928,7 +1947,9 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 		}
 	}
 
-	useAntigravitySchema := strings.Contains(modelName, "claude") || strings.Contains(modelName, "gemini-3-pro") || strings.Contains(modelName, "gemini-3.1-pro")
+	lowerWireModelName := strings.ToLower(wireModelName)
+	isClaude := strings.Contains(lowerWireModelName, "claude")
+	useAntigravitySchema := isClaude || strings.Contains(lowerWireModelName, "gemini-3-pro") || strings.Contains(lowerWireModelName, "gemini-3.1-pro")
 	var (
 		bodyReader io.Reader
 		payloadLog []byte
@@ -1947,7 +1968,7 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 			payloadStr = util.CleanJSONSchemaForGemini(payloadStr)
 		}
 
-		if strings.Contains(modelName, "claude") {
+		if isClaude {
 			updated, _ := sjson.SetBytes([]byte(payloadStr), "request.toolConfig.functionCallingConfig.mode", "VALIDATED")
 			payloadStr = string(updated)
 		} else {
@@ -1959,7 +1980,7 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 			payloadLog = []byte(payloadStr)
 		}
 	} else {
-		if strings.Contains(modelName, "claude") {
+		if isClaude {
 			payload, _ = sjson.SetBytes(payload, "request.toolConfig.functionCallingConfig.mode", "VALIDATED")
 		} else {
 			payload, _ = sjson.DeleteBytes(payload, "request.generationConfig.maxOutputTokens")
@@ -2192,6 +2213,39 @@ func antigravityShouldRetrySoftRateLimit(statusCode int, body []byte) bool {
 	return decideAntigravity429(body).kind == antigravity429DecisionSoftRetry
 }
 
+func antigravityShouldRetryEndpointNotFound(statusCode int) bool {
+	return statusCode == http.StatusNotFound
+}
+
+func antigravityDefaultThinkingLevel(modelName string) string {
+	normalized := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(modelName, "models/")))
+	switch normalized {
+	case "gemini-3.5-flash-high", "gemini-3-flash-agent":
+		return "high"
+	case "gemini-3.5-flash-medium", "gemini-3.5-flash-low":
+		return "medium"
+	default:
+		return ""
+	}
+}
+
+func antigravityApplyDefaultVariantThinking(payload []byte, modelName string) []byte {
+	level := antigravityDefaultThinkingLevel(modelName)
+	if level == "" || len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return payload
+	}
+	const thinkingPath = "request.generationConfig.thinkingConfig"
+	if gjson.GetBytes(payload, thinkingPath+".thinkingLevel").Exists() ||
+		gjson.GetBytes(payload, thinkingPath+".thinking_level").Exists() ||
+		gjson.GetBytes(payload, thinkingPath+".thinkingBudget").Exists() ||
+		gjson.GetBytes(payload, thinkingPath+".thinking_budget").Exists() {
+		return payload
+	}
+	updated, _ := sjson.SetBytes(payload, thinkingPath+".thinkingLevel", level)
+	updated, _ = sjson.SetBytes(updated, thinkingPath+".includeThoughts", true)
+	return updated
+}
+
 func antigravityShouldBypassShortCooldown(ctx context.Context, cfg *config.Config) bool {
 	return cliproxyauth.AntigravityCreditsRequested(ctx) && antigravityCreditsRetryEnabled(cfg)
 }
@@ -2298,8 +2352,9 @@ var antigravityBaseURLFallbackOrder = func(auth *cliproxyauth.Auth) []string {
 	}
 	return []string{
 		antigravityBaseURLDaily,
+		antigravitySandboxBaseURLDaily,
+		antigravitySandboxBaseURLAutopush,
 		antigravityBaseURLProd,
-		// antigravitySandboxBaseURLDaily,
 	}
 }
 

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -35,7 +35,7 @@ func TestAntigravityBuildRequest_SanitizesAntigravityToolSchema(t *testing.T) {
 	assertSchemaSanitizedAndPropertyPreserved(t, params)
 }
 
-func TestAntigravityBuildRequest_PreservesGemini35FlashWireModels(t *testing.T) {
+func TestAntigravityBuildRequest_UsesGemini35FlashBackendWireModels(t *testing.T) {
 	medium := buildRequestBodyFromRawPayload(t, "gemini-3.5-flash-medium", []byte(`{
 		"request": {
 			"contents": [
@@ -43,8 +43,8 @@ func TestAntigravityBuildRequest_PreservesGemini35FlashWireModels(t *testing.T) 
 			]
 		}
 	}`))
-	if got, _ := medium["model"].(string); got != "gemini-3.5-flash-medium" {
-		t.Fatalf("medium wire model = %q, want gemini-3.5-flash-medium", got)
+	if got, _ := medium["model"].(string); got != "gemini-3.5-flash-low" {
+		t.Fatalf("medium wire model = %q, want gemini-3.5-flash-low", got)
 	}
 	assertThinkingLevel(t, medium, "medium")
 
@@ -55,8 +55,8 @@ func TestAntigravityBuildRequest_PreservesGemini35FlashWireModels(t *testing.T) 
 			]
 		}
 	}`))
-	if got, _ := high["model"].(string); got != "gemini-3.5-flash-high" {
-		t.Fatalf("high wire model = %q, want gemini-3.5-flash-high", got)
+	if got, _ := high["model"].(string); got != "gemini-3-flash-agent" {
+		t.Fatalf("high wire model = %q, want gemini-3-flash-agent", got)
 	}
 	assertThinkingLevel(t, high, "high")
 
@@ -67,8 +67,8 @@ func TestAntigravityBuildRequest_PreservesGemini35FlashWireModels(t *testing.T) 
 			]
 		}
 	}`))
-	if got, _ := base["model"].(string); got != "gemini-3.5-flash" {
-		t.Fatalf("base wire model = %q, want gemini-3.5-flash", got)
+	if got, _ := base["model"].(string); got != "gemini-3.5-flash-low" {
+		t.Fatalf("base wire model = %q, want gemini-3.5-flash-low", got)
 	}
 }
 
@@ -149,7 +149,6 @@ func TestAntigravityBaseURLFallbackOrderIncludesAntigravity20Sandboxes(t *testin
 	got := antigravityBaseURLFallbackOrder(nil)
 	want := []string{
 		antigravityBaseURLDaily,
-		antigravitySandboxBaseURLDaily,
 		antigravitySandboxBaseURLAutopush,
 		antigravityBaseURLProd,
 	}

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -35,7 +35,7 @@ func TestAntigravityBuildRequest_SanitizesAntigravityToolSchema(t *testing.T) {
 	assertSchemaSanitizedAndPropertyPreserved(t, params)
 }
 
-func TestAntigravityBuildRequest_ResolvesGemini35FlashWireModels(t *testing.T) {
+func TestAntigravityBuildRequest_PreservesGemini35FlashWireModels(t *testing.T) {
 	medium := buildRequestBodyFromRawPayload(t, "gemini-3.5-flash-medium", []byte(`{
 		"request": {
 			"contents": [
@@ -43,8 +43,8 @@ func TestAntigravityBuildRequest_ResolvesGemini35FlashWireModels(t *testing.T) {
 			]
 		}
 	}`))
-	if got, _ := medium["model"].(string); got != "gemini-3.5-flash-low" {
-		t.Fatalf("medium wire model = %q, want gemini-3.5-flash-low", got)
+	if got, _ := medium["model"].(string); got != "gemini-3.5-flash-medium" {
+		t.Fatalf("medium wire model = %q, want gemini-3.5-flash-medium", got)
 	}
 	assertThinkingLevel(t, medium, "medium")
 
@@ -55,10 +55,21 @@ func TestAntigravityBuildRequest_ResolvesGemini35FlashWireModels(t *testing.T) {
 			]
 		}
 	}`))
-	if got, _ := high["model"].(string); got != "gemini-3-flash-agent" {
-		t.Fatalf("high wire model = %q, want gemini-3-flash-agent", got)
+	if got, _ := high["model"].(string); got != "gemini-3.5-flash-high" {
+		t.Fatalf("high wire model = %q, want gemini-3.5-flash-high", got)
 	}
 	assertThinkingLevel(t, high, "high")
+
+	base := buildRequestBodyFromRawPayload(t, "gemini-3.5-flash", []byte(`{
+		"request": {
+			"contents": [
+				{"role": "user", "parts": [{"text": "hello"}]}
+			]
+		}
+	}`))
+	if got, _ := base["model"].(string); got != "gemini-3.5-flash" {
+		t.Fatalf("base wire model = %q, want gemini-3.5-flash", got)
+	}
 }
 
 func TestAntigravityBuildRequest_PreservesExplicitGemini35FlashThinking(t *testing.T) {

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -35,6 +35,50 @@ func TestAntigravityBuildRequest_SanitizesAntigravityToolSchema(t *testing.T) {
 	assertSchemaSanitizedAndPropertyPreserved(t, params)
 }
 
+func TestAntigravityBuildRequest_ResolvesGemini35FlashWireModels(t *testing.T) {
+	medium := buildRequestBodyFromRawPayload(t, "gemini-3.5-flash-medium", []byte(`{
+		"request": {
+			"contents": [
+				{"role": "user", "parts": [{"text": "hello"}]}
+			]
+		}
+	}`))
+	if got, _ := medium["model"].(string); got != "gemini-3.5-flash-low" {
+		t.Fatalf("medium wire model = %q, want gemini-3.5-flash-low", got)
+	}
+	assertThinkingLevel(t, medium, "medium")
+
+	high := buildRequestBodyFromRawPayload(t, "gemini-3.5-flash-high", []byte(`{
+		"request": {
+			"contents": [
+				{"role": "user", "parts": [{"text": "hello"}]}
+			]
+		}
+	}`))
+	if got, _ := high["model"].(string); got != "gemini-3-flash-agent" {
+		t.Fatalf("high wire model = %q, want gemini-3-flash-agent", got)
+	}
+	assertThinkingLevel(t, high, "high")
+}
+
+func TestAntigravityBuildRequest_PreservesExplicitGemini35FlashThinking(t *testing.T) {
+	body := buildRequestBodyFromRawPayload(t, "gemini-3.5-flash-medium", []byte(`{
+		"request": {
+			"contents": [
+				{"role": "user", "parts": [{"text": "hello"}]}
+			],
+			"generationConfig": {
+				"thinkingConfig": {
+					"thinkingLevel": "low",
+					"includeThoughts": false
+				}
+			}
+		}
+	}`))
+
+	assertThinkingLevel(t, body, "low")
+}
+
 func TestAntigravityBuildRequest_SkipsSchemaSanitizationWithoutToolsField(t *testing.T) {
 	body := buildRequestBodyFromRawPayload(t, "gemini-3.1-flash-image", []byte(`{
 		"request": {
@@ -90,6 +134,24 @@ func TestAntigravityBuildRequest_SkipsSchemaSanitizationWithEmptyToolsArray(t *t
 	assertNonSchemaRequestPreserved(t, body)
 }
 
+func TestAntigravityBaseURLFallbackOrderIncludesAntigravity20Sandboxes(t *testing.T) {
+	got := antigravityBaseURLFallbackOrder(nil)
+	want := []string{
+		antigravityBaseURLDaily,
+		antigravitySandboxBaseURLDaily,
+		antigravitySandboxBaseURLAutopush,
+		antigravityBaseURLProd,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("fallback order length = %d, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("fallback order[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func assertNonSchemaRequestPreserved(t *testing.T, body map[string]any) {
 	t.Helper()
 
@@ -125,6 +187,26 @@ func assertNonSchemaRequestPreserved(t *testing.T, body map[string]any) {
 		if _, ok := generationConfig["maxOutputTokens"]; ok {
 			t.Fatalf("maxOutputTokens should still be removed for non-Claude requests")
 		}
+	}
+}
+
+func assertThinkingLevel(t *testing.T, body map[string]any, want string) {
+	t.Helper()
+
+	request, ok := body["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("request missing or invalid type")
+	}
+	generationConfig, ok := request["generationConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("generationConfig missing or invalid type")
+	}
+	thinkingConfig, ok := generationConfig["thinkingConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("thinkingConfig missing or invalid type")
+	}
+	if got, _ := thinkingConfig["thinkingLevel"].(string); got != want {
+		t.Fatalf("thinkingLevel = %q, want %q", got, want)
 	}
 }
 

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -128,6 +128,19 @@ func TestAntigravityShouldRetryNoCapacity_Standard503(t *testing.T) {
 	}
 }
 
+func TestAntigravityShouldRetryEndpointUnavailable_Staging403(t *testing.T) {
+	body := []byte(`{"error":{"code":403,"message":"Gemini for Google Cloud API (Staging) has not been used in project vertical-kite-22hpz before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/staging-cloudaicompanion.sandbox.googleapis.com/overview?project=vertical-kite-22hpz then retry.","status":"PERMISSION_DENIED"}}`)
+	if !antigravityShouldRetryEndpointUnavailable(http.StatusForbidden, body) {
+		t.Fatal("antigravityShouldRetryEndpointUnavailable() = false, want true for staging endpoint 403")
+	}
+	if antigravityShouldRetryEndpointUnavailable(http.StatusForbidden, []byte(`{"error":{"message":"permission denied"}}`)) {
+		t.Fatal("antigravityShouldRetryEndpointUnavailable() = true for generic 403, want false")
+	}
+	if !antigravityShouldRetryEndpointUnavailable(http.StatusNotFound, nil) {
+		t.Fatal("antigravityShouldRetryEndpointUnavailable() = false for 404, want true")
+	}
+}
+
 func TestInjectEnabledCreditTypes(t *testing.T) {
 	body := []byte(`{"model":"claude-sonnet-4-6","request":{}}`)
 	got := injectEnabledCreditTypes(body)
@@ -205,6 +218,62 @@ func TestAntigravityExecute_RetriesTransient429ResourceExhausted(t *testing.T) {
 	}
 	if requestCount != 2 {
 		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+}
+
+func TestAntigravityExecute_DoesNotFallbackBaseURLOnQuota429(t *testing.T) {
+	resetAntigravityCreditsRetryState()
+	t.Cleanup(resetAntigravityCreditsRetryState)
+
+	var primaryCount int
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		primaryCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"quota exhausted","status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"QUOTA_EXHAUSTED"}]}}`))
+	}))
+	defer primary.Close()
+
+	var fallbackCount int
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"unexpected fallback"}]}}]}}`))
+	}))
+	defer fallback.Close()
+
+	originalOrder := antigravityBaseURLFallbackOrder
+	antigravityBaseURLFallbackOrder = func(auth *cliproxyauth.Auth) []string {
+		return []string{primary.URL, fallback.URL}
+	}
+	t.Cleanup(func() {
+		antigravityBaseURLFallbackOrder = originalOrder
+	})
+
+	exec := NewAntigravityExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-quota-429",
+		Metadata: map[string]any{
+			"access_token": "token",
+			"project_id":   "project-1",
+			"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-4-6",
+		Payload: []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatAntigravity,
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want 429")
+	}
+	if primaryCount != 1 {
+		t.Fatalf("primary request count = %d, want 1", primaryCount)
+	}
+	if fallbackCount != 0 {
+		t.Fatalf("fallback request count = %d, want 0", fallbackCount)
 	}
 }
 

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/translator/gemini/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	log "github.com/sirupsen/logrus"
@@ -36,7 +37,7 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 	rawJSON := inputRawJSON
 	template := `{"project":"","request":{},"model":""}`
 	templateBytes, _ := sjson.SetRawBytes([]byte(template), "request", rawJSON)
-	templateBytes, _ = sjson.SetBytes(templateBytes, "model", modelName)
+	templateBytes, _ = sjson.SetBytes(templateBytes, "model", misc.AntigravityWireModel(modelName))
 	template = string(templateBytes)
 	template, _ = sjson.Delete(template, "request.model")
 

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
@@ -37,6 +37,30 @@ func TestConvertGeminiRequestToAntigravity_ReplacesClientSignatureOnFunctionCall
 	}
 }
 
+func TestConvertGeminiRequestToAntigravity_ResolvesGemini35FlashWireModels(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gemini-3.5-flash-medium",
+		"contents": [
+			{
+				"role": "user",
+				"parts": [
+					{"text": "hello"}
+				]
+			}
+		]
+	}`)
+
+	medium := ConvertGeminiRequestToAntigravity("gemini-3.5-flash-medium", inputJSON, false)
+	if got := gjson.GetBytes(medium, "model").String(); got != "gemini-3.5-flash-low" {
+		t.Fatalf("medium wire model = %q, want gemini-3.5-flash-low", got)
+	}
+
+	high := ConvertGeminiRequestToAntigravity("gemini-3.5-flash-high", inputJSON, false)
+	if got := gjson.GetBytes(high, "model").String(); got != "gemini-3-flash-agent" {
+		t.Fatalf("high wire model = %q, want gemini-3-flash-agent", got)
+	}
+}
+
 func TestConvertGeminiRequestToAntigravity_ReplacesClientSignatureOnTextPart(t *testing.T) {
 	validSignature := "abc123validSignature1234567890123456789012345678901234567890"
 	inputJSON := []byte(fmt.Sprintf(`{

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
@@ -51,18 +51,18 @@ func TestConvertGeminiRequestToAntigravity_PreservesGemini35FlashWireModels(t *t
 	}`)
 
 	medium := ConvertGeminiRequestToAntigravity("gemini-3.5-flash-medium", inputJSON, false)
-	if got := gjson.GetBytes(medium, "model").String(); got != "gemini-3.5-flash-medium" {
-		t.Fatalf("medium wire model = %q, want gemini-3.5-flash-medium", got)
+	if got := gjson.GetBytes(medium, "model").String(); got != "gemini-3.5-flash-low" {
+		t.Fatalf("medium wire model = %q, want gemini-3.5-flash-low", got)
 	}
 
 	high := ConvertGeminiRequestToAntigravity("gemini-3.5-flash-high", inputJSON, false)
-	if got := gjson.GetBytes(high, "model").String(); got != "gemini-3.5-flash-high" {
-		t.Fatalf("high wire model = %q, want gemini-3.5-flash-high", got)
+	if got := gjson.GetBytes(high, "model").String(); got != "gemini-3-flash-agent" {
+		t.Fatalf("high wire model = %q, want gemini-3-flash-agent", got)
 	}
 
 	base := ConvertGeminiRequestToAntigravity("gemini-3.5-flash", inputJSON, false)
-	if got := gjson.GetBytes(base, "model").String(); got != "gemini-3.5-flash" {
-		t.Fatalf("base wire model = %q, want gemini-3.5-flash", got)
+	if got := gjson.GetBytes(base, "model").String(); got != "gemini-3.5-flash-low" {
+		t.Fatalf("base wire model = %q, want gemini-3.5-flash-low", got)
 	}
 }
 

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
@@ -37,7 +37,7 @@ func TestConvertGeminiRequestToAntigravity_ReplacesClientSignatureOnFunctionCall
 	}
 }
 
-func TestConvertGeminiRequestToAntigravity_ResolvesGemini35FlashWireModels(t *testing.T) {
+func TestConvertGeminiRequestToAntigravity_PreservesGemini35FlashWireModels(t *testing.T) {
 	inputJSON := []byte(`{
 		"model": "gemini-3.5-flash-medium",
 		"contents": [
@@ -51,13 +51,18 @@ func TestConvertGeminiRequestToAntigravity_ResolvesGemini35FlashWireModels(t *te
 	}`)
 
 	medium := ConvertGeminiRequestToAntigravity("gemini-3.5-flash-medium", inputJSON, false)
-	if got := gjson.GetBytes(medium, "model").String(); got != "gemini-3.5-flash-low" {
-		t.Fatalf("medium wire model = %q, want gemini-3.5-flash-low", got)
+	if got := gjson.GetBytes(medium, "model").String(); got != "gemini-3.5-flash-medium" {
+		t.Fatalf("medium wire model = %q, want gemini-3.5-flash-medium", got)
 	}
 
 	high := ConvertGeminiRequestToAntigravity("gemini-3.5-flash-high", inputJSON, false)
-	if got := gjson.GetBytes(high, "model").String(); got != "gemini-3-flash-agent" {
-		t.Fatalf("high wire model = %q, want gemini-3-flash-agent", got)
+	if got := gjson.GetBytes(high, "model").String(); got != "gemini-3.5-flash-high" {
+		t.Fatalf("high wire model = %q, want gemini-3.5-flash-high", got)
+	}
+
+	base := ConvertGeminiRequestToAntigravity("gemini-3.5-flash", inputJSON, false)
+	if got := gjson.GetBytes(base, "model").String(); got != "gemini-3.5-flash" {
+		t.Fatalf("base wire model = %q, want gemini-3.5-flash", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/antigravity_credits.go
+++ b/sdk/cliproxy/auth/antigravity_credits.go
@@ -72,6 +72,14 @@ func HasKnownAntigravityCreditsHint(authID string) bool {
 	return ok && hint.Known
 }
 
+func antigravityCreditsEligibleModel(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" {
+		return false
+	}
+	return strings.Contains(model, "claude") || strings.HasPrefix(model, "gemini-3.5-flash")
+}
+
 func antigravityCreditsAvailableForModel(auth *Auth, model string) bool {
 	if auth == nil {
 		return false
@@ -79,7 +87,7 @@ func antigravityCreditsAvailableForModel(auth *Auth, model string) bool {
 	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "antigravity") {
 		return false
 	}
-	if !strings.Contains(strings.ToLower(strings.TrimSpace(model)), "claude") {
+	if !antigravityCreditsEligibleModel(model) {
 		return false
 	}
 	hint, ok := GetAntigravityCreditsHint(auth.ID)

--- a/sdk/cliproxy/auth/antigravity_credits_test.go
+++ b/sdk/cliproxy/auth/antigravity_credits_test.go
@@ -13,13 +13,22 @@ import (
 )
 
 type antigravityCreditsFallbackExecutor struct {
-	streamCreditsRequested []bool
+	executeCreditsRequested []bool
+	streamCreditsRequested  []bool
 }
 
 func (e *antigravityCreditsFallbackExecutor) Identifier() string { return "antigravity" }
 
-func (e *antigravityCreditsFallbackExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "Execute not implemented"}
+func (e *antigravityCreditsFallbackExecutor) Execute(ctx context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	creditsRequested := AntigravityCreditsRequested(ctx)
+	e.executeCreditsRequested = append(e.executeCreditsRequested, creditsRequested)
+	if !creditsRequested {
+		return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"}
+	}
+	return cliproxyexecutor.Response{
+		Payload: []byte("credits fallback"),
+		Headers: http.Header{"X-Credits": {req.Model}},
+	}, nil
 }
 
 func (e *antigravityCreditsFallbackExecutor) ExecuteStream(ctx context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
@@ -49,42 +58,87 @@ func (e *antigravityCreditsFallbackExecutor) HttpRequest(context.Context, *Auth,
 }
 
 func TestManagerExecuteStream_AntigravityCreditsFallbackAfterBootstrap429(t *testing.T) {
-	const model = "claude-opus-4-6-thinking"
+	tests := []struct {
+		name   string
+		authID string
+		model  string
+	}{
+		{name: "claude", authID: "ag-credits-claude", model: "claude-opus-4-6-thinking"},
+		{name: "gemini35", authID: "ag-credits-gemini35", model: "gemini-3.5-flash-high"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &antigravityCreditsFallbackExecutor{}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{
+				QuotaExceeded: internalconfig.QuotaExceeded{AntigravityCredits: true},
+			})
+			manager.RegisterExecutor(executor)
+			registry.GetGlobalRegistry().RegisterClient(tt.authID, "antigravity", []*registry.ModelInfo{{ID: tt.model}})
+			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(tt.authID) })
+			if _, errRegister := manager.Register(context.Background(), &Auth{ID: tt.authID, Provider: "antigravity"}); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+
+			streamResult, errExecute := manager.ExecuteStream(context.Background(), []string{"antigravity"}, cliproxyexecutor.Request{Model: tt.model}, cliproxyexecutor.Options{})
+			if errExecute != nil {
+				t.Fatalf("execute stream: %v", errExecute)
+			}
+
+			var payload []byte
+			for chunk := range streamResult.Chunks {
+				if chunk.Err != nil {
+					t.Fatalf("unexpected stream error: %v", chunk.Err)
+				}
+				payload = append(payload, chunk.Payload...)
+			}
+			if string(payload) != "credits fallback" {
+				t.Fatalf("payload = %q, want %q", string(payload), "credits fallback")
+			}
+			if got := streamResult.Headers.Get("X-Credits"); got != tt.model {
+				t.Fatalf("X-Credits header = %q, want routed model", got)
+			}
+			if len(executor.streamCreditsRequested) != 2 {
+				t.Fatalf("stream calls = %d, want 2", len(executor.streamCreditsRequested))
+			}
+			if executor.streamCreditsRequested[0] || !executor.streamCreditsRequested[1] {
+				t.Fatalf("credits flags = %v, want [false true]", executor.streamCreditsRequested)
+			}
+		})
+	}
+}
+
+func TestManagerExecute_AntigravityCreditsFallbackAfterGemini35Quota429(t *testing.T) {
+	const model = "gemini-3.5-flash-high"
+	const authID = "ag-credits-gemini35-nonstream"
 	executor := &antigravityCreditsFallbackExecutor{}
 	manager := NewManager(nil, nil, nil)
 	manager.SetConfig(&internalconfig.Config{
 		QuotaExceeded: internalconfig.QuotaExceeded{AntigravityCredits: true},
 	})
 	manager.RegisterExecutor(executor)
-	registry.GetGlobalRegistry().RegisterClient("ag-credits", "antigravity", []*registry.ModelInfo{{ID: model}})
-	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient("ag-credits") })
-	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "ag-credits", Provider: "antigravity"}); errRegister != nil {
+	registry.GetGlobalRegistry().RegisterClient(authID, "antigravity", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: authID, Provider: "antigravity"}); errRegister != nil {
 		t.Fatalf("register auth: %v", errRegister)
 	}
 
-	streamResult, errExecute := manager.ExecuteStream(context.Background(), []string{"antigravity"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	resp, errExecute := manager.Execute(context.Background(), []string{"antigravity"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
 	if errExecute != nil {
-		t.Fatalf("execute stream: %v", errExecute)
+		t.Fatalf("execute: %v", errExecute)
 	}
-
-	var payload []byte
-	for chunk := range streamResult.Chunks {
-		if chunk.Err != nil {
-			t.Fatalf("unexpected stream error: %v", chunk.Err)
-		}
-		payload = append(payload, chunk.Payload...)
+	if string(resp.Payload) != "credits fallback" {
+		t.Fatalf("payload = %q, want %q", string(resp.Payload), "credits fallback")
 	}
-	if string(payload) != "credits fallback" {
-		t.Fatalf("payload = %q, want %q", string(payload), "credits fallback")
-	}
-	if got := streamResult.Headers.Get("X-Credits"); got != model {
+	if got := resp.Headers.Get("X-Credits"); got != model {
 		t.Fatalf("X-Credits header = %q, want routed model", got)
 	}
-	if len(executor.streamCreditsRequested) != 2 {
-		t.Fatalf("stream calls = %d, want 2", len(executor.streamCreditsRequested))
+	if len(executor.executeCreditsRequested) != 2 {
+		t.Fatalf("execute calls = %d, want 2", len(executor.executeCreditsRequested))
 	}
-	if executor.streamCreditsRequested[0] || !executor.streamCreditsRequested[1] {
-		t.Fatalf("credits flags = %v, want [false true]", executor.streamCreditsRequested)
+	if executor.executeCreditsRequested[0] || !executor.executeCreditsRequested[1] {
+		t.Fatalf("credits flags = %v, want [false true]", executor.executeCreditsRequested)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3545,7 +3545,7 @@ func (m *Manager) findAllAntigravityCreditsCandidateAuths(routeModel string, opt
 		if !strings.EqualFold(strings.TrimSpace(auth.Provider), "antigravity") {
 			continue
 		}
-		if !strings.Contains(strings.ToLower(strings.TrimSpace(routeModel)), "claude") {
+		if !antigravityCreditsEligibleModel(routeModel) {
 			continue
 		}
 		providerKey := strings.TrimSpace(strings.ToLower(auth.Provider))
@@ -3589,11 +3589,18 @@ type creditsCandidateEntry struct {
 
 func shouldAttemptAntigravityCreditsFallback(m *Manager, lastErr error, providers []string) bool {
 	status := statusCodeFromError(lastErr)
+	creditsEnabled := false
+	if m != nil {
+		cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+		creditsEnabled = cfg != nil && cfg.QuotaExceeded.AntigravityCredits
+	}
 	log.WithFields(log.Fields{
-		"lastErr":   errorString(lastErr),
-		"status":    status,
-		"providers": providers,
+		"lastErr":                     errorString(lastErr),
+		"status":                      status,
+		"providers":                   providers,
+		"antigravity_credits_enabled": creditsEnabled,
 	}).Debug("shouldAttemptAntigravityCreditsFallback")
+	log.Debugf("shouldAttemptAntigravityCreditsFallback status=%d providers=%v antigravity_credits_enabled=%t lastErr=%s", status, providers, creditsEnabled, errorString(lastErr))
 	if m == nil || lastErr == nil {
 		return false
 	}
@@ -3609,8 +3616,7 @@ func shouldAttemptAntigravityCreditsFallback(m *Manager, lastErr error, provider
 			return false
 		}
 	}
-	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
-	if cfg == nil || !cfg.QuotaExceeded.AntigravityCredits {
+	if !creditsEnabled {
 		return false
 	}
 	switch status {
@@ -3634,6 +3640,11 @@ func shouldAttemptAntigravityCreditsFallback(m *Manager, lastErr error, provider
 func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, bool) {
 	routeModel := req.Model
 	candidates := m.findAllAntigravityCreditsCandidateAuths(routeModel, opts)
+	log.WithFields(log.Fields{
+		"routeModel": routeModel,
+		"candidates": len(candidates),
+	}).Debug("antigravity credits fallback candidates")
+	log.Debugf("antigravity credits fallback candidates routeModel=%s candidates=%d", routeModel, len(candidates))
 	for _, c := range candidates {
 		if ctx.Err() != nil {
 			return cliproxyexecutor.Response{}, false
@@ -3648,6 +3659,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth.ID)
 		models := m.executionModelCandidates(c.auth, routeModel)
 		if len(models) == 0 {
+			log.Debugf("antigravity credits fallback skipped auth=%s routeModel=%s reason=no_execution_models", c.auth.ID, routeModel)
 			continue
 		}
 		for _, upstreamModel := range models {
@@ -3677,6 +3689,11 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, bool) {
 	routeModel := req.Model
 	candidates := m.findAllAntigravityCreditsCandidateAuths(routeModel, opts)
+	log.WithFields(log.Fields{
+		"routeModel": routeModel,
+		"candidates": len(candidates),
+	}).Debug("antigravity credits stream fallback candidates")
+	log.Debugf("antigravity credits stream fallback candidates routeModel=%s candidates=%d", routeModel, len(candidates))
 	for _, c := range candidates {
 		if ctx.Err() != nil {
 			return nil, false
@@ -3690,6 +3707,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth.ID)
 		models := m.executionModelCandidates(c.auth, routeModel)
 		if len(models) == 0 {
+			log.Debugf("antigravity credits stream fallback skipped auth=%s routeModel=%s reason=no_execution_models", c.auth.ID, routeModel)
 			continue
 		}
 		result, errStream := m.executeStreamWithModelPool(creditsCtx, c.executor, c.auth, c.provider, req, creditsOpts, routeModel, models, len(models) > 1)

--- a/sdk/cliproxy/auth/conductor_credits_candidates_test.go
+++ b/sdk/cliproxy/auth/conductor_credits_candidates_test.go
@@ -43,9 +43,20 @@ func TestFindAllAntigravityCreditsCandidateAuths_PrefersKnownCreditsThenUnknown(
 		t.Fatalf("candidates[1].auth.ID = %q, want %q", candidates[1].auth.ID, "aa-unknown")
 	}
 
-	nonClaude := m.findAllAntigravityCreditsCandidateAuths("gemini-3-flash", opts)
-	if len(nonClaude) != 0 {
-		t.Fatalf("nonClaude len = %d, want 0", len(nonClaude))
+	gemini35 := m.findAllAntigravityCreditsCandidateAuths("gemini-3.5-flash-high", opts)
+	if len(gemini35) != 2 {
+		t.Fatalf("gemini35 len = %d, want 2", len(gemini35))
+	}
+	if gemini35[0].auth.ID != "zz-credits" {
+		t.Fatalf("gemini35[0].auth.ID = %q, want %q", gemini35[0].auth.ID, "zz-credits")
+	}
+	if gemini35[1].auth.ID != "aa-unknown" {
+		t.Fatalf("gemini35[1].auth.ID = %q, want %q", gemini35[1].auth.ID, "aa-unknown")
+	}
+
+	olderGemini := m.findAllAntigravityCreditsCandidateAuths("gemini-3-flash", opts)
+	if len(olderGemini) != 0 {
+		t.Fatalf("olderGemini len = %d, want 0", len(olderGemini))
 	}
 
 	pinnedOpts := cliproxyexecutor.Options{


### PR DESCRIPTION
## Summary
- add Antigravity Gemini 3.5 Flash base/high/medium entries for model listing and registry validation
- route Gemini 3.5 Flash variants through the Antigravity executor path with Antigravity wire-model resolution and default thinking levels
- add Antigravity 2.0.x fallback identity plus daily/autopush/prod endpoint fallback on Antigravity 404s
- update the Antigravity quota fetcher to keep searching until the Gemini 3.5 Flash high/medium quota pair is found and normalize display labels

## Verification
- `go test ./internal/misc ./internal/translator/antigravity/gemini ./cmd/fetch_antigravity_models ./internal/registry -run TestAntigravity|TestConvertGeminiRequestToAntigravity_ResolvesGemini35FlashWireModels|TestHasAntigravity35FlashPair`
- `go test ./internal/runtime/executor -run TestAntigravityBuildRequest|TestAntigravityBaseURLFallbackOrder`
- `go build -o test-output.exe ./cmd/server; if ($LASTEXITCODE -eq 0) { Remove-Item -LiteralPath .\test-output.exe }`

## Notes
- The Antigravity release endpoint currently reports 2.0.1 first; runtime still refreshes from that endpoint and only uses the fallback when release lookup is unavailable.
- A broader targeted package test run still hits existing unrelated failures in `internal/registry` (`TestCodexFreeModelsExcludeGPT55`) and `internal/runtime/executor` credits tests that expect the prod `loadCodeAssist` URL.