### PR TITLE
Use Codex CLI user agent for OAuth HTTP requests

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -793,7 +793,11 @@ func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, s
 	misc.EnsureHeader(r.Header, ginHeaders, "Version", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Codex-Turn-Metadata", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Client-Request-Id", "")
+	isAPIKey := codexAuthUsesAPIKey(auth)
 	cfgUserAgent, _ := codexHeaderDefaults(cfg, auth)
+	if !isAPIKey && strings.TrimSpace(cfgUserAgent) == "" {
+		cfgUserAgent = codexUserAgent
+	}
 	ensureHeaderWithConfigPrecedence(r.Header, ginHeaders, "User-Agent", cfgUserAgent, codexUserAgent)
 
 	if strings.Contains(r.Header.Get("User-Agent"), "Mac OS") {
@@ -807,12 +811,6 @@ func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, s
 	}
 	r.Header.Set("Connection", "Keep-Alive")
 
-	isAPIKey := false
-	if auth != nil && auth.Attributes != nil {
-		if v := strings.TrimSpace(auth.Attributes["api_key"]); v != "" {
-			isAPIKey = true
-		}
-	}
 	if originator := strings.TrimSpace(ginHeaders.Get("Originator")); originator != "" {
 		r.Header.Set("Originator", originator)
 	} else if !isAPIKey {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -481,6 +481,46 @@ func TestApplyCodexHeadersUsesConfigUserAgentForOAuth(t *testing.T) {
 	}
 }
 
+func TestApplyCodexHeadersUsesDefaultCodexUserAgentForOAuth(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/responses", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"email": "user@example.com"},
+	}
+	req = req.WithContext(contextWithGinHeaders(map[string]string{
+		"User-Agent": "Mozilla/5.0 CherryStudio/1.9.6 Electron/41.2.1",
+	}))
+
+	applyCodexHeaders(req, auth, "oauth-token", true, nil)
+
+	if got := req.Header.Get("User-Agent"); got != codexUserAgent {
+		t.Fatalf("User-Agent = %s, want %s", got, codexUserAgent)
+	}
+}
+
+func TestApplyCodexHeadersPreservesClientUserAgentForAPIKey(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/responses", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	auth := &cliproxyauth.Auth{
+		Provider:   "codex",
+		Attributes: map[string]string{"api_key": "sk-test"},
+	}
+	req = req.WithContext(contextWithGinHeaders(map[string]string{
+		"User-Agent": "api-key-client/1.0",
+	}))
+
+	applyCodexHeaders(req, auth, "sk-test", true, nil)
+
+	if got := req.Header.Get("User-Agent"); got != "api-key-client/1.0" {
+		t.Fatalf("User-Agent = %s, want %s", got, "api-key-client/1.0")
+	}
+}
+
 func TestApplyCodexHeadersPassesThroughClientIdentityHeaders(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, "https://example.com/responses", nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- use the built-in Codex CLI User-Agent for file-backed/OAuth Codex HTTP requests by default
- keep explicit codex-header-defaults.user-agent overrides working
- preserve downstream client User-Agent behavior for Codex API key auth

## Why
When third-party HTTP clients such as Cherry Studio call /v1/responses, their browser/Electron User-Agent can be forwarded to chatgpt.com/backend-api/codex/responses for file-backed Codex OAuth requests. In production this can trigger a Cloudflare managed challenge HTML page, which CLIProxyAPI wraps as a 403 permission_error / insufficient_quota response. Using the Codex CLI identity by default matches the existing websocket default and avoids requiring every deployment to configure codex-header-defaults.user-agent manually.

## Verification
- go test ./internal/runtime/executor -run "TestApplyCodexHeaders|TestApplyCodexWebsocketHeaders"

## Notes
- go test ./internal/runtime/executor currently fails in this checkout in unrelated Antigravity credits tests: TestEnsureAccessToken_WarmTokenLoadsCreditsHint and TestUpdateAntigravityCreditsBalance_LoadCodeAssistUserAgent.