### PR TITLE
Suppress successful management access logs

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,6 +22,10 @@ remote-management:
   # Leave empty to disable the Management API entirely (404 for all /v0/management routes).
   secret-key: ""
 
+  # Hide successful /v0/management access logs from dashboard polling.
+  # 4xx/5xx management requests are still logged.
+  suppress-success-access-logs: false
+
   # Disable the bundled management control panel asset download and HTTP route when true.
   disable-control-panel: false
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -180,6 +180,8 @@ type Server struct {
 	managementRoutesRegistered atomic.Bool
 	// managementRoutesEnabled controls whether management endpoints serve real handlers.
 	managementRoutesEnabled atomic.Bool
+	// managementSuccessAccessLogsSuppressed hides successful management access logs while preserving failures.
+	managementSuccessAccessLogsSuppressed atomic.Bool
 
 	// envManagementSecret indicates whether MANAGEMENT_PASSWORD is configured.
 	envManagementSecret bool
@@ -221,9 +223,33 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 		optionState.engineConfigurator(engine)
 	}
 
+	wd, err := os.Getwd()
+	if err != nil {
+		wd = configFilePath
+	}
+
+	envAdminPassword, envAdminPasswordSet := os.LookupEnv("MANAGEMENT_PASSWORD")
+	envAdminPassword = strings.TrimSpace(envAdminPassword)
+	envManagementSecret := envAdminPasswordSet && envAdminPassword != ""
+
+	// Create server instance early so middleware can read hot-reloadable state from it.
+	s := &Server{
+		engine:              engine,
+		handlers:            handlers.NewBaseAPIHandlers(&cfg.SDKConfig, authManager),
+		cfg:                 cfg,
+		accessManager:       accessManager,
+		configFilePath:      configFilePath,
+		currentPath:         wd,
+		envManagementSecret: envManagementSecret,
+		wsRoutes:            make(map[string]struct{}),
+	}
+	s.wsAuthEnabled.Store(cfg.WebsocketAuth)
+	s.managementSuccessAccessLogsSuppressed.Store(cfg.RemoteManagement.SuppressSuccessAccessLogs)
+
 	// Add middleware
 	engine.Use(logging.GinLogrusLogger())
 	engine.Use(logging.GinLogrusRecovery())
+	engine.Use(s.suppressSuccessfulManagementAccessLogs())
 	for _, mw := range optionState.extraMiddleware {
 		engine.Use(mw)
 	}
@@ -243,31 +269,10 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 			}
 		}
 	}
+	s.requestLogger = requestLogger
+	s.loggerToggle = toggle
 
 	engine.Use(corsMiddleware())
-	wd, err := os.Getwd()
-	if err != nil {
-		wd = configFilePath
-	}
-
-	envAdminPassword, envAdminPasswordSet := os.LookupEnv("MANAGEMENT_PASSWORD")
-	envAdminPassword = strings.TrimSpace(envAdminPassword)
-	envManagementSecret := envAdminPasswordSet && envAdminPassword != ""
-
-	// Create server instance
-	s := &Server{
-		engine:              engine,
-		handlers:            handlers.NewBaseAPIHandlers(&cfg.SDKConfig, authManager),
-		cfg:                 cfg,
-		accessManager:       accessManager,
-		requestLogger:       requestLogger,
-		loggerToggle:        toggle,
-		configFilePath:      configFilePath,
-		currentPath:         wd,
-		envManagementSecret: envManagementSecret,
-		wsRoutes:            make(map[string]struct{}),
-	}
-	s.wsAuthEnabled.Store(cfg.WebsocketAuth)
 	// Save initial YAML snapshot
 	s.oldConfigYaml, _ = yaml.Marshal(cfg)
 	s.applyAccessConfig(nil, cfg)
@@ -341,9 +346,9 @@ func (s *Server) homeHeartbeatMiddleware() gin.HandlerFunc {
 			c.Next()
 			return
 		}
-		if c != nil && c.Request != nil {
+		if c != nil && c.Request != nil && c.Request.URL != nil {
 			path := c.Request.URL.Path
-			if strings.HasPrefix(path, "/v0/management/") || path == "/v0/management" || path == "/management.html" {
+			if isManagementAPIPath(path) || path == "/management.html" {
 				c.Next()
 				return
 			}
@@ -355,6 +360,29 @@ func (s *Server) homeHeartbeatMiddleware() gin.HandlerFunc {
 		}
 		c.Next()
 	}
+}
+
+func (s *Server) suppressSuccessfulManagementAccessLogs() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+
+		if s == nil || !s.managementSuccessAccessLogsSuppressed.Load() || c == nil || c.Request == nil || c.Request.URL == nil {
+			return
+		}
+		if c.Writer.Status() >= http.StatusBadRequest {
+			return
+		}
+		if isManagementAPIPath(c.Request.URL.Path) {
+			// The access logger runs after this middleware unwinds, so marking here
+			// suppresses only successful dashboard polling while failed polls stay visible.
+			logging.SkipGinRequestLogging(c)
+		}
+	}
+}
+
+func isManagementAPIPath(path string) bool {
+	const managementAPIPath = "/v0/management"
+	return path == managementAPIPath || strings.HasPrefix(path, managementAPIPath+"/")
 }
 
 // setupRoutes configures the API routes for the server.
@@ -1351,6 +1379,8 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 	if len(s.oldConfigYaml) > 0 {
 		_ = yaml.Unmarshal(s.oldConfigYaml, &oldCfg)
 	}
+
+	s.managementSuccessAccessLogsSuppressed.Store(cfg.RemoteManagement.SuppressSuccessAccessLogs)
 
 	// Update request logger enabled state if it has changed
 	previousRequestLog := false

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,7 @@ import (
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	log "github.com/sirupsen/logrus"
 )
 
 func newTestServer(t *testing.T) *Server {
@@ -84,6 +86,69 @@ func TestHealthz(t *testing.T) {
 			t.Fatalf("expected empty body for HEAD request, got %q", rr.Body.String())
 		}
 	})
+}
+
+func TestSuppressSuccessfulManagementAccessLogs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var output bytes.Buffer
+	logger := log.StandardLogger()
+	previousOutput := logger.Out
+	previousFormatter := logger.Formatter
+	previousLevel := log.GetLevel()
+	log.SetOutput(&output)
+	log.SetFormatter(&log.TextFormatter{DisableTimestamp: true, DisableColors: true})
+	log.SetLevel(log.InfoLevel)
+	t.Cleanup(func() {
+		log.SetOutput(previousOutput)
+		log.SetFormatter(previousFormatter)
+		log.SetLevel(previousLevel)
+	})
+
+	server := &Server{}
+	server.managementSuccessAccessLogsSuppressed.Store(true)
+
+	engine := gin.New()
+	engine.Use(internallogging.GinLogrusLogger())
+	engine.Use(server.suppressSuccessfulManagementAccessLogs())
+	engine.GET("/v0/management/config", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+	engine.GET("/v0/management/fail", func(c *gin.Context) {
+		c.AbortWithStatus(http.StatusUnauthorized)
+	})
+	engine.GET("/v0/managementish", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	serve := func(path string, wantStatus int) string {
+		t.Helper()
+		output.Reset()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rr := httptest.NewRecorder()
+		engine.ServeHTTP(rr, req)
+		if rr.Code != wantStatus {
+			t.Fatalf("%s status = %d, want %d", path, rr.Code, wantStatus)
+		}
+		return output.String()
+	}
+
+	if got := serve("/v0/management/config", http.StatusOK); strings.TrimSpace(got) != "" {
+		t.Fatalf("expected successful management access log to be suppressed, got %q", got)
+	}
+
+	if got := serve("/v0/management/fail", http.StatusUnauthorized); !strings.Contains(got, "/v0/management/fail") {
+		t.Fatalf("expected failed management access log to remain visible, got %q", got)
+	}
+
+	if got := serve("/v0/managementish", http.StatusOK); !strings.Contains(got, "/v0/managementish") {
+		t.Fatalf("expected lookalike non-management path to remain visible, got %q", got)
+	}
+
+	server.managementSuccessAccessLogsSuppressed.Store(false)
+	if got := serve("/v0/management/config", http.StatusOK); !strings.Contains(got, "/v0/management/config") {
+		t.Fatalf("expected management access log when suppression is disabled, got %q", got)
+	}
 }
 
 func TestManagementUsageRequiresManagementAuthAndPopsArray(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -196,6 +196,8 @@ type RemoteManagement struct {
 	AllowRemote bool `yaml:"allow-remote"`
 	// SecretKey is the management key (plaintext or bcrypt hashed). YAML key intentionally 'secret-key'.
 	SecretKey string `yaml:"secret-key"`
+	// SuppressSuccessAccessLogs hides successful management API access logs while keeping 4xx/5xx logs visible.
+	SuppressSuccessAccessLogs bool `yaml:"suppress-success-access-logs"`
 	// DisableControlPanel skips serving and syncing the bundled management UI when true.
 	DisableControlPanel bool `yaml:"disable-control-panel"`
 	// DisableAutoUpdatePanel disables automatic periodic background updates of the management panel asset from GitHub.

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -265,6 +265,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.RemoteManagement.AllowRemote != newCfg.RemoteManagement.AllowRemote {
 		changes = append(changes, fmt.Sprintf("remote-management.allow-remote: %t -> %t", oldCfg.RemoteManagement.AllowRemote, newCfg.RemoteManagement.AllowRemote))
 	}
+	if oldCfg.RemoteManagement.SuppressSuccessAccessLogs != newCfg.RemoteManagement.SuppressSuccessAccessLogs {
+		changes = append(changes, fmt.Sprintf("remote-management.suppress-success-access-logs: %t -> %t", oldCfg.RemoteManagement.SuppressSuccessAccessLogs, newCfg.RemoteManagement.SuppressSuccessAccessLogs))
+	}
 	if oldCfg.RemoteManagement.DisableControlPanel != newCfg.RemoteManagement.DisableControlPanel {
 		changes = append(changes, fmt.Sprintf("remote-management.disable-control-panel: %t -> %t", oldCfg.RemoteManagement.DisableControlPanel, newCfg.RemoteManagement.DisableControlPanel))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -20,11 +20,12 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 			RestrictManagementToLocalhost: false,
 		},
 		RemoteManagement: config.RemoteManagement{
-			AllowRemote:            false,
-			SecretKey:              "old",
-			DisableControlPanel:    false,
-			DisableAutoUpdatePanel: false,
-			PanelGitHubRepository:  "repo-old",
+			AllowRemote:               false,
+			SecretKey:                 "old",
+			SuppressSuccessAccessLogs: false,
+			DisableControlPanel:       false,
+			DisableAutoUpdatePanel:    false,
+			PanelGitHubRepository:     "repo-old",
 		},
 		OAuthExcludedModels: map[string][]string{
 			"providerA": {"m1"},
@@ -55,11 +56,12 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 			},
 		},
 		RemoteManagement: config.RemoteManagement{
-			AllowRemote:            true,
-			SecretKey:              "new",
-			DisableControlPanel:    true,
-			DisableAutoUpdatePanel: true,
-			PanelGitHubRepository:  "repo-new",
+			AllowRemote:               true,
+			SecretKey:                 "new",
+			SuppressSuccessAccessLogs: true,
+			DisableControlPanel:       true,
+			DisableAutoUpdatePanel:    true,
+			PanelGitHubRepository:     "repo-new",
 		},
 		OAuthExcludedModels: map[string][]string{
 			"providerA": {"m1", "m2"},
@@ -90,6 +92,7 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 	expectContains(t, details, "ampcode.upstream-url: http://old-upstream -> http://new-upstream")
 	expectContains(t, details, "ampcode.model-mappings: updated (1 -> 2 entries)")
 	expectContains(t, details, "remote-management.allow-remote: false -> true")
+	expectContains(t, details, "remote-management.suppress-success-access-logs: false -> true")
 	expectContains(t, details, "remote-management.disable-auto-update-panel: false -> true")
 	expectContains(t, details, "remote-management.secret-key: updated")
 	expectContains(t, details, "oauth-excluded-models[providera]: updated (1 -> 2 entries)")


### PR DESCRIPTION
## Motivation

External dashboards can poll `/v0/management` endpoints frequently to refresh status and configuration data. Those successful polling requests currently produce a large volume of Gin access logs, making operational logs harder to scan while adding little diagnostic value. Failed management requests should still remain visible because they can indicate authentication, availability, or server-side issues.
<img width="752" height="197" alt="image" src="https://github.com/user-attachments/assets/7c43a59e-3903-49b5-bc05-093cfb01694d" />

## Summary

- Add `remote-management.suppress-success-access-logs` to hide successful `/v0/management` access logs produced by dashboard polling.
- Preserve failed management access logs by only suppressing responses with status codes below `400`.
- Keep the management path match exact to `/v0/management` and `/v0/management/...`, avoiding lookalike paths such as `/v0/managementish`.
- Report changes to the new setting in config hot-reload diff output and document it in `config.example.yaml`.

## Testing

- `go test ./internal/api ./internal/watcher/diff`
- `go build -o test-output ./cmd/server`

## Notes

- The detailed request logger already skips management endpoints; this change only affects the standard Gin access log line.
- The setting is hot-reloadable through `UpdateClients` and defaults to `false`.
