### PR TITLE
feat: add Astraflow provider support via openai-compatibility

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -253,6 +253,30 @@ nonstream-keepalive-interval: 0
 #       - api-key: "sk-or-v1-...b780"
 #         proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
 #         # proxy-url: "direct" # optional: explicit direct connect for this credential
+# Astraflow (OpenAI-compatible, 200+ models by UCloud)
+# Global endpoint — sign up at https://astraflow.ucloud-global.com
+# openai-compatibility:
+#   - name: "astraflow"
+#     disabled: false
+#     base-url: "https://api-us-ca.umodelverse.ai/v1"
+#     api-key-entries:
+#       - api-key: "your-astraflow-api-key" # ASTRAFLOW_API_KEY
+#     models:
+#       - name: "deepseek-v3"     # upstream model name on Astraflow
+#         alias: "deepseek-v3"   # client-visible alias
+#       - name: "gpt-4o"
+#         alias: "gpt-4o"
+# China endpoint — sign up at https://astraflow.ucloud.cn
+# openai-compatibility:
+#   - name: "astraflow-cn"
+#     disabled: false
+#     base-url: "https://api.modelverse.cn/v1"
+#     api-key-entries:
+#       - api-key: "your-astraflow-cn-api-key" # ASTRAFLOW_CN_API_KEY
+#     models:
+#       - name: "deepseek-v3"
+#         alias: "deepseek-v3"
+
 #       - api-key: "sk-or-v1-...b781" # without proxy-url
 #     models: # The models supported by the provider.
 #       - name: "moonshotai/kimi-k2:free" # The actual model name.


### PR DESCRIPTION
## Summary

Adds configuration examples for **Astraflow** — an OpenAI-compatible AI model aggregation platform by UCloud (优刻得) supporting 200+ models — to `config.example.yaml`.

Because Astraflow exposes a fully OpenAI-compatible API, no new code or packages are required. The integration is a simple `openai-compatibility` entry already supported by CLIProxyAPI.

## What changed

**`config.example.yaml`** — Added two commented-out example blocks under `openai-compatibility`:

| Entry | Base URL | Env var |
|---|---|---|
| `astraflow` (global) | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| `astraflow-cn` (China) | `https://api.modelverse.cn/v1` | `ASTRAFLOW_CN_API_KEY` |

## How to use

Uncomment and fill in the relevant block in your `config.yaml`:

```yaml
openai-compatibility:
  - name: "astraflow"
    base-url: "https://api-us-ca.umodelverse.ai/v1"
    api-key-entries:
      - api-key: "your-astraflow-api-key"
    models:
      - name: "deepseek-v3"
        alias: "deepseek-v3"
      - name: "gpt-4o"
        alias: "gpt-4o"
```

## References

- Astraflow global: https://astraflow.ucloud-global.com
- Astraflow China: https://astraflow.ucloud.cn
- Supports 200+ models via a single OpenAI-compatible endpoint
