### PR TITLE
fix(antigravity): add general fallback for unknown tool result types

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -294,8 +294,21 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 									}
 
 									nonImageCount++
-									lastNonImageRaw = fr.Raw
-									filteredJSON, _ = sjson.SetRawBytes(filteredJSON, "-1", []byte(fr.Raw))
+									itemRaw := fr.Raw
+									partTypeResult := fr.Get("type")
+									// Only trigger fallback if the child element is a JSON object and has a non-standard, non-empty type
+									if fr.IsObject() && partTypeResult.Exists() && partTypeResult.Type == gjson.String {
+										partType := partTypeResult.String()
+										if partType != "text" && partType != "image" && partType != "" {
+											// Fallback for unknown / private control types (e.g. tool_reference)
+											// Convert them to a safe plain text part to prevent upstream schema validation failure
+											textPart := []byte(`{"type":"text","text":""}`)
+											textPart, _ = sjson.SetBytes(textPart, "text", itemRaw)
+											itemRaw = string(textPart)
+										}
+									}
+									lastNonImageRaw = itemRaw
+									filteredJSON, _ = sjson.SetRawBytes(filteredJSON, "-1", []byte(itemRaw))
 								}
 
 								if nonImageCount == 1 {
@@ -330,7 +343,19 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 									functionResponseJSON, _ = sjson.SetRawBytes(functionResponseJSON, "parts", imagePartsJSON)
 									functionResponseJSON, _ = sjson.SetBytes(functionResponseJSON, "response.result", "")
 								} else {
-									functionResponseJSON, _ = sjson.SetRawBytes(functionResponseJSON, "response.result", []byte(functionResponseResult.Raw))
+									partTypeResult := functionResponseResult.Get("type")
+									// Only escape the object raw JSON string if it explicitly specifies a non-standard type
+									if partTypeResult.Exists() && partTypeResult.Type == gjson.String {
+										partType := partTypeResult.String()
+										if partType != "" && partType != "text" && partType != "image" {
+											// Fallback for unknown object types: write raw JSON as a safe string to prevent validation error
+											functionResponseJSON, _ = sjson.SetBytes(functionResponseJSON, "response.result", functionResponseResult.Raw)
+										} else {
+											functionResponseJSON, _ = sjson.SetRawBytes(functionResponseJSON, "response.result", []byte(functionResponseResult.Raw))
+										}
+									} else {
+										functionResponseJSON, _ = sjson.SetRawBytes(functionResponseJSON, "response.result", []byte(functionResponseResult.Raw))
+									}
 								}
 							} else if functionResponseResult.Raw != "" {
 								functionResponseJSON, _ = sjson.SetRawBytes(functionResponseJSON, "response.result", []byte(functionResponseResult.Raw))


### PR DESCRIPTION
## Summary
This Pull Request fixes a critical bug where the CLI Proxy API (CPA) returns a malformed response (HTTP 200 empty stream) or throws a 500 error (`context canceled`) after a user loads a Skill or dynamically searches for a tool (which triggers a deferred tool load).

### Problem
- When a user loads a Skill or runs a deferred tool (e.g. `WebSearch`), the Claude Code client inserts a special `tool_result` into the conversation history containing `{"type": "tool_reference", "tool_name": "..."}`.
- In `antigravity_claude_request.go`, the translator loop for `tool_result` array parts and objects did not inspect the `type` field of these sub-elements. It directly serialized unknown JSON objects using `sjson.SetRawBytes` and passed them raw into `response.result` of the Google `FunctionResponse` payload.
- Because Google Cloud Vertex AI API gateway enforces a strict schema validation on `FunctionResponse` responses (which are mapped from `google.protobuf.Struct`), passing the unexpected nested `tool_reference` structure causes the upstream server to fail schema validation and immediately reset the connection, throwing `context canceled` on the proxy side.
- For streaming requests, the proxy has already written the HTTP 200 OK headers to the client. The sudden upstream reset cuts the chunked stream short, presenting as an empty/malformed HTTP 200 stream error to the Claude Code CLI.

### Solution
- Implemented a robust and general fallback mechanism in `ConvertClaudeRequestToAntigravity`.
- For array parts: We only trigger the fallback wrap if the child element is a JSON object and explicitly specifies a non-standard, non-empty `type` (neither `text` nor `image`). In such cases, we safely wrap it in a standard `text` part.
- For single objects: We check if the object has a non-standard `type` attribute. If so, we use `sjson.SetBytes` to escape the raw JSON as a plain string instead of injecting a raw object.
- **No Regressions**: This approach strictly avoids wrapping normal plain strings (where the `type` field is empty or doesn't exist), preventing regressions during normal string array conversions.

## Testing
Successfully formatted the code, verified the build, and ran the translator unit tests locally:
- `gofmt -w internal/translator/antigravity/claude/antigravity_claude_request.go`
- `go build -o test-output ./cmd/server && rm -f test-output` (Passes)
- `go test -v ./internal/translator/antigravity/claude/...` (78 tests passed, 0 failures)