### PR TITLE
fix: align responses tool conversion with Vertex schema

### DIFF
--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -118,7 +118,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 
 			switch itemType {
 			case "message":
-				if strings.EqualFold(itemRole, "system") {
+				if strings.EqualFold(itemRole, "system") || strings.EqualFold(itemRole, "developer") {
 					if contentArray := item.Get("content"); contentArray.Exists() {
 						systemInstr := []byte(`{"parts":[]}`)
 						if systemInstructionResult := gjson.GetBytes(out, "systemInstruction"); systemInstructionResult.Exists() {
@@ -299,7 +299,6 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				functionCall := []byte(`{"functionCall":{"name":"","args":{}}}`)
 				functionCall, _ = sjson.SetBytes(functionCall, "functionCall.name", name)
 				functionCall, _ = sjson.SetBytes(functionCall, "thoughtSignature", geminiResponsesThoughtSignature)
-				functionCall, _ = sjson.SetBytes(functionCall, "functionCall.id", item.Get("call_id").String())
 
 				// Parse arguments JSON string and set as args object
 				if arguments != "" {
@@ -337,7 +336,6 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				functionName = util.SanitizeFunctionName(functionName)
 
 				functionResponse, _ = sjson.SetBytes(functionResponse, "functionResponse.name", functionName)
-				functionResponse, _ = sjson.SetBytes(functionResponse, "functionResponse.id", callID)
 
 				// Set the raw JSON output directly (preserves string encoding)
 				if outputRaw != "" && outputRaw != "null" {

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -1,0 +1,60 @@
+package responses
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestDeveloperRoleToSystem(t *testing.T) {
+	in := mustJSON(t, map[string]any{
+		"input": []map[string]any{
+			{"role": "developer", "content": "dev"},
+			{"role": "user", "content": "hi"},
+		},
+	})
+	out := ConvertOpenAIResponsesRequestToGemini("m", in, false)
+	got := gjson.ParseBytes(out)
+	if got.Get("systemInstruction.parts.0.text").String() != "dev" {
+		t.Fatalf("missing systemInstruction: %s", out)
+	}
+	if got.Get("contents.#(role=developer)").Exists() {
+		t.Fatalf("developer role leaked: %s", out)
+	}
+}
+
+func TestFunctionIDsNotForwarded(t *testing.T) {
+	in := mustJSON(t, map[string]any{
+		"input": []map[string]any{
+			{"role": "user", "content": "call"},
+			{
+				"type":      "function_call",
+				"call_id":   "c1",
+				"name":      "echo",
+				"arguments": `{"v":"x"}`,
+			},
+			{"type": "function_call_output", "call_id": "c1", "output": "x"},
+		},
+	})
+	out := ConvertOpenAIResponsesRequestToGemini("m", in, false)
+	got := gjson.ParseBytes(out)
+	if got.Get("contents.1.parts.0.functionCall.id").Exists() {
+		t.Fatalf("functionCall id leaked: %s", out)
+	}
+	if got.Get("contents.2.parts.0.functionResponse.id").Exists() {
+		t.Fatalf("functionResponse id leaked: %s", out)
+	}
+	if got.Get("contents.1.parts.0.functionCall.name").String() != "echo" {
+		t.Fatalf("missing function call: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Treat OpenAI Responses `developer` messages as Gemini system instructions when converting to Gemini requests.
- Stop forwarding OpenAI Responses `call_id` values as `functionCall.id` / `functionResponse.id`, which Vertex Gemini rejects as unknown fields.
- Add request-conversion tests covering both cases.

## Why
When Codex uses the OpenAI Responses API through CLIProxyAPI against Vertex Gemini, tool-call history can fail with errors like:

```
Unknown name "id" at 'contents[].parts[].function_call': Cannot find field.
Unknown name "id" at 'contents[].parts[].function_response': Cannot find field.
```

Codex can also send `developer` role messages, while Gemini request contents only accept Gemini roles such as `user` and `model`; system/developer instructions should be represented via `systemInstruction`.

## Test plan
- `go test ./internal/translator/gemini/openai/responses ./sdk/api/handlers/openai`
