### PR TITLE
feat(translator): add schema sanitization for OpenAI requests

### DIFF
--- a/internal/runtime/executor/antigravity_executor_request.go
+++ b/internal/runtime/executor/antigravity_executor_request.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -173,19 +174,167 @@ func sanitizeAntigravityRequestSchemas(payloadStr string, useAntigravitySchema b
 		payloadStr = renamed
 	}
 
-	toolSchemaCleaner := util.CleanJSONSchemaForGemini
-	if useAntigravitySchema {
-		toolSchemaCleaner = util.CleanJSONSchemaForAntigravity
+	toolSchemaCleaner := func(schema string) string {
+		return util.CleanJSONSchemaForAntigravityTool(schema, useAntigravitySchema)
 	}
-	responseSchemaCleaner := util.CleanJSONSchemaForAntigravityResponse
 
+	sanitizeThenClean := func(schemaRaw string, clean func(string) string) string {
+		sanitized, errSanitize := sanitizeAntigravityBooleanSubschemas([]byte(schemaRaw))
+		if errSanitize != nil {
+			log.Debugf("antigravity: failed to sanitize boolean subschemas: %v", errSanitize)
+			return clean(schemaRaw)
+		}
+		return clean(string(sanitized))
+	}
 	cleanNestedToolSchema := func(schemaRaw string) string {
-		return cleanNestedSchema(toolSchemaCleaner, schemaRaw)
+		return sanitizeThenClean(schemaRaw, func(sanitized string) string {
+			return cleanNestedSchema(toolSchemaCleaner, sanitized)
+		})
+	}
+	cleanResponseSchema := func(schemaRaw string) string {
+		return sanitizeThenClean(schemaRaw, util.CleanJSONSchemaForAntigravityResponse)
 	}
 	payloadStr = cleanAntigravitySchemasAtPaths(payloadStr, antigravityDeclarationSchemaPaths(payloadStr), cleanNestedToolSchema)
-	payloadStr = cleanAntigravitySchemasAtPaths(payloadStr, antigravityGenerationSchemaPaths(payloadStr), responseSchemaCleaner)
+	payloadStr = cleanAntigravitySchemasAtPaths(payloadStr, antigravityGenerationSchemaPaths(payloadStr), cleanResponseSchema)
 	return payloadStr
 }
+
+// sanitizeAntigravityBooleanSubschemas replaces true schemas with their equivalent empty object.
+// False schemas and booleans outside schema-bearing keywords are preserved.
+func sanitizeAntigravityBooleanSubschemas(raw []byte) ([]byte, error) {
+	return sanitizeAntigravitySchemaNode(json.RawMessage(raw))
+}
+
+func sanitizeAntigravitySchemaNode(raw json.RawMessage) (json.RawMessage, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if bytes.Equal(trimmed, []byte("true")) {
+		return json.RawMessage(`{}`), nil
+	}
+	if bytes.Equal(trimmed, []byte("false")) {
+		return append(json.RawMessage(nil), raw...), nil
+	}
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("empty schema")
+	}
+
+	switch trimmed[0] {
+	case '{':
+		var schema map[string]json.RawMessage
+		if errUnmarshal := json.Unmarshal(trimmed, &schema); errUnmarshal != nil {
+			return nil, fmt.Errorf("decode schema object: %w", errUnmarshal)
+		}
+
+		changed := false
+		for _, keyword := range antigravitySingleSchemaKeywords {
+			child, ok := schema[keyword]
+			if !ok {
+				continue
+			}
+			sanitized, errSanitize := sanitizeAntigravitySchemaNode(child)
+			if errSanitize != nil {
+				return nil, fmt.Errorf("sanitize %s: %w", keyword, errSanitize)
+			}
+			if !bytes.Equal(sanitized, child) {
+				schema[keyword] = sanitized
+				changed = true
+			}
+		}
+
+		for _, keyword := range antigravitySchemaMapKeywords {
+			rawChildren, ok := schema[keyword]
+			if !ok {
+				continue
+			}
+			var children map[string]json.RawMessage
+			if errUnmarshal := json.Unmarshal(rawChildren, &children); errUnmarshal != nil {
+				continue
+			}
+			childrenChanged := false
+			for name, child := range children {
+				if keyword == "dependencies" && firstJSONToken(child) == '[' {
+					continue
+				}
+				sanitized, errSanitize := sanitizeAntigravitySchemaNode(child)
+				if errSanitize != nil {
+					return nil, fmt.Errorf("sanitize %s.%s: %w", keyword, name, errSanitize)
+				}
+				if !bytes.Equal(sanitized, child) {
+					children[name] = sanitized
+					childrenChanged = true
+				}
+			}
+			if childrenChanged {
+				updated, errMarshal := json.Marshal(children)
+				if errMarshal != nil {
+					return nil, fmt.Errorf("encode %s: %w", keyword, errMarshal)
+				}
+				schema[keyword] = updated
+				changed = true
+			}
+		}
+
+		if !changed {
+			return append(json.RawMessage(nil), raw...), nil
+		}
+		updated, errMarshal := json.Marshal(schema)
+		if errMarshal != nil {
+			return nil, fmt.Errorf("encode schema object: %w", errMarshal)
+		}
+		return updated, nil
+
+	case '[':
+		var schemas []json.RawMessage
+		if errUnmarshal := json.Unmarshal(trimmed, &schemas); errUnmarshal != nil {
+			return nil, fmt.Errorf("decode schema array: %w", errUnmarshal)
+		}
+		changed := false
+		for i, child := range schemas {
+			sanitized, errSanitize := sanitizeAntigravitySchemaNode(child)
+			if errSanitize != nil {
+				return nil, fmt.Errorf("sanitize schema array item %d: %w", i, errSanitize)
+			}
+			if !bytes.Equal(sanitized, child) {
+				schemas[i] = sanitized
+				changed = true
+			}
+		}
+		if !changed {
+			return append(json.RawMessage(nil), raw...), nil
+		}
+		updated, errMarshal := json.Marshal(schemas)
+		if errMarshal != nil {
+			return nil, fmt.Errorf("encode schema array: %w", errMarshal)
+		}
+		return updated, nil
+
+	default:
+		if !json.Valid(trimmed) {
+			return nil, fmt.Errorf("invalid schema JSON")
+		}
+		return append(json.RawMessage(nil), raw...), nil
+	}
+}
+
+func firstJSONToken(raw json.RawMessage) byte {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return 0
+	}
+	return trimmed[0]
+}
+
+var (
+	antigravitySingleSchemaKeywords = []string{
+		"additionalItems", "additionalProperties", "contains", "contentSchema",
+		"if", "then", "else", "not", "propertyNames", "items",
+		"unevaluatedItems", "unevaluatedProperties",
+		"prefixItems", "allOf", "anyOf", "oneOf",
+	}
+	antigravitySchemaMapKeywords = []string{
+		"properties", "patternProperties", "dependentSchemas", "dependencies",
+		"$defs", "definitions",
+	}
+)
 
 func cleanAntigravitySchemasAtPaths(payloadStr string, schemaPaths []string, clean func(string) string) string {
 	for _, schemaPath := range schemaPaths {
@@ -258,7 +407,8 @@ func antigravityDeclarationSchemaPaths(payloadStr string) []string {
 	paths := make([]string, 0, 8)
 	for _, base := range antigravityFunctionDeclarationPaths(payloadStr) {
 		for _, key := range antigravityDeclarationSchemaKeys {
-			if gjson.Get(payloadStr, base+"."+key).IsObject() {
+			schema := gjson.Get(payloadStr, base+"."+key)
+			if schema.IsObject() || schema.Type == gjson.True || schema.Type == gjson.False {
 				paths = append(paths, base+"."+key)
 			}
 		}
@@ -271,7 +421,8 @@ func antigravityGenerationSchemaPaths(payloadStr string) []string {
 	for _, container := range antigravityGenerationConfigContainers {
 		for _, key := range antigravityGenerationSchemaKeys {
 			path := container + "." + key
-			if gjson.Get(payloadStr, path).IsObject() {
+			schema := gjson.Get(payloadStr, path)
+			if schema.IsObject() || schema.Type == gjson.True || schema.Type == gjson.False {
 				paths = append(paths, path)
 			}
 		}

--- a/internal/runtime/executor/antigravity_executor_request.go
+++ b/internal/runtime/executor/antigravity_executor_request.go
@@ -225,6 +225,41 @@ func sanitizeAntigravitySchemaNode(raw json.RawMessage) (json.RawMessage, error)
 		}
 
 		changed := false
+		for _, keyword := range []string{"anyOf", "oneOf"} {
+			child, ok := schema[keyword]
+			if !ok {
+				continue
+			}
+			normalized, complement, remove, unsatisfiable, errNormalize := normalizeAntigravityBooleanUnion(keyword, child)
+			if errNormalize != nil {
+				return nil, fmt.Errorf("normalize %s: %w", keyword, errNormalize)
+			}
+			if unsatisfiable {
+				return json.RawMessage("false"), nil
+			}
+			if complement != nil {
+				if _, hasExistingNot := schema["not"]; hasExistingNot {
+					// Combining complements requires a union that the downstream cleaner flattens
+					// lossily, so retain the existing compatibility behavior for this rare shape.
+					normalized = child
+				} else {
+					delete(schema, keyword)
+					schema["not"] = complement
+					changed = true
+					continue
+				}
+			}
+			if remove {
+				delete(schema, keyword)
+				changed = true
+				continue
+			}
+			if !bytes.Equal(normalized, child) {
+				schema[keyword] = normalized
+				changed = true
+			}
+		}
+
 		for _, keyword := range antigravitySingleSchemaKeywords {
 			child, ok := schema[keyword]
 			if !ok {
@@ -313,6 +348,64 @@ func sanitizeAntigravitySchemaNode(raw json.RawMessage) (json.RawMessage, error)
 		}
 		return append(json.RawMessage(nil), raw...), nil
 	}
+}
+
+// normalizeAntigravityBooleanUnion simplifies boolean members before true schemas become empty
+// objects. Removing a tautological union preserves constraints carried by its parent schema.
+func normalizeAntigravityBooleanUnion(keyword string, raw json.RawMessage) (normalized, complement json.RawMessage, remove, unsatisfiable bool, err error) {
+	var branches []json.RawMessage
+	if errUnmarshal := json.Unmarshal(raw, &branches); errUnmarshal != nil {
+		return nil, nil, false, false, fmt.Errorf("decode boolean union: %w", errUnmarshal)
+	}
+
+	trueCount := 0
+	falseCount := 0
+	nonBoolean := make([]json.RawMessage, 0, len(branches))
+	for _, branch := range branches {
+		trimmed := bytes.TrimSpace(branch)
+		switch {
+		case bytes.Equal(trimmed, []byte("true")):
+			trueCount++
+		case bytes.Equal(trimmed, []byte("false")):
+			falseCount++
+		default:
+			nonBoolean = append(nonBoolean, branch)
+		}
+	}
+	if trueCount == 0 && falseCount == 0 {
+		return append(json.RawMessage(nil), raw...), nil, false, false, nil
+	}
+
+	switch keyword {
+	case "anyOf":
+		if trueCount > 0 {
+			return nil, nil, true, false, nil
+		}
+		if len(nonBoolean) == 0 {
+			return nil, nil, false, true, nil
+		}
+	case "oneOf":
+		if trueCount > 1 || trueCount == 0 && len(nonBoolean) == 0 {
+			return nil, nil, false, true, nil
+		}
+		if trueCount == 1 {
+			if len(nonBoolean) == 0 {
+				return nil, nil, true, false, nil
+			}
+			if len(nonBoolean) == 1 {
+				return nil, append(json.RawMessage(nil), nonBoolean[0]...), false, false, nil
+			}
+			// A multi-branch complement needs a nested union that the downstream cleaner flattens
+			// lossily, so retain the existing compatibility behavior for that shape.
+			return append(json.RawMessage(nil), raw...), nil, false, false, nil
+		}
+	}
+
+	updated, errMarshal := json.Marshal(nonBoolean)
+	if errMarshal != nil {
+		return nil, nil, false, false, fmt.Errorf("encode boolean union: %w", errMarshal)
+	}
+	return updated, nil, false, false, nil
 }
 
 func firstJSONToken(raw json.RawMessage) byte {

--- a/internal/runtime/executor/antigravity_schema_sanitize_test.go
+++ b/internal/runtime/executor/antigravity_schema_sanitize_test.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	antigravityclaude "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/antigravity/claude"
+	antigravitygemini "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/antigravity/gemini"
 	antigravitychat "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/antigravity/openai/chat-completions"
+	antigravityresponses "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/antigravity/openai/responses"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 )
@@ -40,6 +43,185 @@ const sanitizeTestPayload = `{
     }]}]
   }
 }`
+
+func TestSanitizeAntigravityBooleanSubschemas(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "root true", in: "true", want: "{}"},
+		{name: "root false", in: "false", want: "false"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, errSanitize := sanitizeAntigravityBooleanSubschemas([]byte(testCase.in))
+			if errSanitize != nil {
+				t.Fatalf("sanitize error: %v", errSanitize)
+			}
+			if string(got) != testCase.want {
+				t.Fatalf("sanitize(%s) = %s, want %s", testCase.in, got, testCase.want)
+			}
+		})
+	}
+
+	input := []byte(`{
+		"properties":{"property":true},
+		"patternProperties":{"pattern":true},
+		"dependentSchemas":{"dependent":true},
+		"dependencies":{"schema":true,"propertyList":["a","b"]},
+		"$defs":{"modern":true},
+		"definitions":{"legacy":true},
+		"items":[true,{"properties":{"nested":true}}],
+		"additionalItems":true,
+		"prefixItems":[true],
+		"additionalProperties":false,
+		"contains":true,
+		"contentSchema":true,
+		"if":true,
+		"then":true,
+		"else":true,
+		"not":true,
+		"propertyNames":true,
+		"allOf":[true,false],
+		"anyOf":[true],
+		"oneOf":[true],
+		"unevaluatedItems":true,
+		"unevaluatedProperties":true,
+		"deprecated":true,
+		"readOnly":true,
+		"writeOnly":false,
+		"uniqueItems":true,
+		"enum":[9007199254740993],
+		"minimum":9007199254740993,
+		"maximum":9223372036854775807
+	}`)
+
+	got, errSanitize := sanitizeAntigravityBooleanSubschemas(input)
+	if errSanitize != nil {
+		t.Fatalf("sanitize error: %v", errSanitize)
+	}
+
+	for _, path := range []string{
+		"properties.property",
+		"patternProperties.pattern",
+		"dependentSchemas.dependent",
+		"dependencies.schema",
+		"$defs.modern",
+		"definitions.legacy",
+		"items.0",
+		"items.1.properties.nested",
+		"additionalItems",
+		"prefixItems.0",
+		"contains",
+		"contentSchema",
+		"if",
+		"then",
+		"else",
+		"not",
+		"propertyNames",
+		"allOf.0",
+		"anyOf.0",
+		"oneOf.0",
+		"unevaluatedItems",
+		"unevaluatedProperties",
+	} {
+		if node := gjson.GetBytes(got, path); node.Raw != "{}" {
+			t.Errorf("%s = %s, want {}", path, node.Raw)
+		}
+	}
+	if node := gjson.GetBytes(got, "allOf.1"); node.Raw != "false" {
+		t.Errorf("false schema = %s, want false", node.Raw)
+	}
+	if node := gjson.GetBytes(got, "additionalProperties"); node.Raw != "false" {
+		t.Errorf("additionalProperties = %s, want false", node.Raw)
+	}
+	if node := gjson.GetBytes(got, "dependencies.propertyList"); node.Raw != `["a","b"]` {
+		t.Errorf("property dependency = %s, want unchanged array", node.Raw)
+	}
+	for _, path := range []string{"deprecated", "readOnly", "writeOnly", "uniqueItems"} {
+		if before, after := gjson.GetBytes(input, path).Raw, gjson.GetBytes(got, path).Raw; after != before {
+			t.Errorf("%s = %s, want unchanged %s", path, after, before)
+		}
+	}
+	for _, path := range []string{"enum.0", "minimum"} {
+		if node := gjson.GetBytes(got, path); node.Raw != "9007199254740993" {
+			t.Errorf("%s = %s, want exact large integer", path, node.Raw)
+		}
+	}
+	if node := gjson.GetBytes(got, "maximum"); node.Raw != "9223372036854775807" {
+		t.Errorf("maximum = %s, want exact int64 maximum", node.Raw)
+	}
+}
+
+func TestAntigravityBuildRequestSanitizesBooleanSubschemasFromEveryTranslator(t *testing.T) {
+	const modelName = "gemini-2.5-pro"
+	const schema = `{"type":"object","additionalProperties":false,"properties":{"screenshot_id":true,"denied":{"allOf":[false]},"union":{"anyOf":[{"type":"object","additionalProperties":false}]}}}`
+
+	tests := []struct {
+		name      string
+		translate func() []byte
+	}{
+		{
+			name: "OpenAI Chat Completions",
+			translate: func() []byte {
+				input := []byte(`{"model":"` + modelName + `","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"capture","parameters":` + schema + `}}]}`)
+				return antigravitychat.ConvertOpenAIRequestToAntigravity(modelName, input, false)
+			},
+		},
+		{
+			name: "OpenAI Responses",
+			translate: func() []byte {
+				input := []byte(`{"model":"` + modelName + `","input":"hi","tools":[{"type":"function","name":"capture","parameters":` + schema + `}]}`)
+				return antigravityresponses.ConvertOpenAIResponsesRequestToAntigravity(modelName, input, false)
+			},
+		},
+		{
+			name: "Gemini",
+			translate: func() []byte {
+				input := []byte(`{"model":"` + modelName + `","contents":[{"role":"user","parts":[{"text":"hi"}]}],"tools":[{"functionDeclarations":[{"name":"capture","parametersJsonSchema":` + schema + `}]}]}`)
+				return antigravitygemini.ConvertGeminiRequestToAntigravity(modelName, input, false)
+			},
+		},
+		{
+			name: "Claude",
+			translate: func() []byte {
+				input := []byte(`{"model":"` + modelName + `","max_tokens":128,"messages":[{"role":"user","content":"hi"}],"tools":[{"name":"capture","input_schema":` + schema + `}]}`)
+				return antigravityclaude.ConvertClaudeRequestToAntigravity(modelName, input, false)
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			body := buildRequestBodyFromRawPayload(t, modelName, testCase.translate())
+			encoded, errMarshal := json.Marshal(body)
+			if errMarshal != nil {
+				t.Fatal(errMarshal)
+			}
+
+			declaration := gjson.GetBytes(encoded, "request.tools.0.functionDeclarations.0")
+			if !declaration.Exists() {
+				t.Fatalf("function declaration missing: %s", encoded)
+			}
+			if declaration.Get("parametersJsonSchema").Exists() {
+				t.Fatalf("parametersJsonSchema was not renamed: %s", declaration.Raw)
+			}
+			parameters := declaration.Get("parameters")
+			if node := parameters.Get("properties.screenshot_id"); node.Raw != "{}" {
+				t.Errorf("true subschema = %s, want {}", node.Raw)
+			}
+			if node := parameters.Get("additionalProperties"); node.Raw != "false" {
+				t.Errorf("additionalProperties = %s, want false", node.Raw)
+			}
+			if node := parameters.Get("properties.union.additionalProperties"); node.Raw != "false" {
+				t.Errorf("union additionalProperties = %s, want false", node.Raw)
+			}
+			if node := parameters.Get("properties.denied"); node.Raw != "false" {
+				t.Errorf("false subschema = %s, want false", node.Raw)
+			}
+		})
+	}
+}
 
 // TestSanitizeAntigravityRequestSchemasPreservesHistory guards against the schema cleaner being
 // applied to the whole payload, which silently stripped keys such as "title" from functionCall
@@ -146,7 +328,7 @@ func TestSanitizeAntigravityRequestSchemasCleansResultSchemas(t *testing.T) {
 // added here too; this test only fails once the key is listed below, so treat the pairing as
 // something to check whenever that list changes.
 func TestAntigravitySchemaPathsCoverEverySchemaLocation(t *testing.T) {
-	const schema = `{"type":"object","$id":"drop","properties":{"a":{"type":"string"}}}`
+	const schema = `{"type":"object","$id":"drop","additionalProperties":false,"properties":{"a":true}}`
 
 	// Both spellings of the declarations container are exercised: the Gemini translator forwards
 	// snake_case untouched, so covering only camelCase leaves those requests uncleaned.
@@ -182,6 +364,12 @@ func TestAntigravitySchemaPathsCoverEverySchemaLocation(t *testing.T) {
 					if node.Get(`\$id`).Exists() {
 						t.Errorf("%s was never cleaned, $id reaches upstream: %s", path, node.Raw)
 					}
+					if child := node.Get("properties.a"); child.Raw != "{}" {
+						t.Errorf("%s true subschema = %s, want {}", path, child.Raw)
+					}
+					if child := node.Get("additionalProperties"); child.Raw != "false" {
+						t.Errorf("%s additionalProperties = %s, want false", path, child.Raw)
+					}
 				}
 				base := "request.tools.0." + declContainer + ".0."
 				for _, k := range antigravityDeclarationSchemaKeys {
@@ -191,6 +379,7 @@ func TestAntigravitySchemaPathsCoverEverySchemaLocation(t *testing.T) {
 						if gjson.Get(got, base+k).Exists() {
 							t.Errorf("%s should have been renamed onto parameters: %s", k, got)
 						}
+						check(base + "parameters")
 						continue
 					}
 					check(base + k)
@@ -203,11 +392,10 @@ func TestAntigravitySchemaPathsCoverEverySchemaLocation(t *testing.T) {
 	}
 }
 
-// TestSanitizeAntigravityRequestSchemasMatchesWholePayloadCleaning pins the emitted schema to what
-// whole-payload cleaning produced. Narrowing the scope must change which nodes are cleaned, never
-// the result for a schema node — in particular the Claude VALIDATED placeholder, which the cleaner
-// only adds when the schema is not top-level.
-func TestSanitizeAntigravityRequestSchemasMatchesWholePayloadCleaning(t *testing.T) {
+// TestSanitizeAntigravityRequestSchemasMatchesToolSchemaCleaning pins the emitted schema to the
+// dedicated Antigravity cleaner. The synthetic nesting preserves the placeholder behavior required
+// by Claude VALIDATED mode without ever handing a whole request to a schema-only cleaner.
+func TestSanitizeAntigravityRequestSchemasMatchesToolSchemaCleaning(t *testing.T) {
 	shapes := map[string]string{
 		"optionalOnly": `{"type":"object","properties":{"flag":{"type":"string"}}}`,
 		"emptyProps":   `{"type":"object","properties":{}}`,
@@ -222,14 +410,12 @@ func TestSanitizeAntigravityRequestSchemasMatchesWholePayloadCleaning(t *testing
 	for _, useAntigravitySchema := range []bool{false, true} {
 		for name, schema := range shapes {
 			doc := `{"request":{"tools":[{"functionDeclarations":[{"name":"t","parameters":` + schema + `}]}]}}`
-			whole := util.CleanJSONSchemaForGemini(doc)
-			if useAntigravitySchema {
-				whole = util.CleanJSONSchemaForAntigravity(doc)
-			}
-			want := gjson.Get(whole, schemaPath).Raw
+			want := cleanNestedSchema(func(schema string) string {
+				return util.CleanJSONSchemaForAntigravityTool(schema, useAntigravitySchema)
+			}, schema)
 			got := gjson.Get(sanitizeAntigravityRequestSchemas(doc, useAntigravitySchema), schemaPath).Raw
 			if want != got {
-				t.Errorf("%s (antigravity=%v) diverged from whole-payload cleaning.\nwant: %s\ngot:  %s",
+				t.Errorf("%s (antigravity=%v) diverged from tool-schema cleaning.\nwant: %s\ngot:  %s",
 					name, useAntigravitySchema, want, got)
 			}
 		}

--- a/internal/runtime/executor/antigravity_schema_sanitize_test.go
+++ b/internal/runtime/executor/antigravity_schema_sanitize_test.go
@@ -120,13 +120,16 @@ func TestSanitizeAntigravityBooleanSubschemas(t *testing.T) {
 		"not",
 		"propertyNames",
 		"allOf.0",
-		"anyOf.0",
-		"oneOf.0",
 		"unevaluatedItems",
 		"unevaluatedProperties",
 	} {
 		if node := gjson.GetBytes(got, path); node.Raw != "{}" {
 			t.Errorf("%s = %s, want {}", path, node.Raw)
+		}
+	}
+	for _, keyword := range []string{"anyOf", "oneOf"} {
+		if node := gjson.GetBytes(got, keyword); node.Exists() {
+			t.Errorf("tautological %s was not removed: %s", keyword, node.Raw)
 		}
 	}
 	if node := gjson.GetBytes(got, "allOf.1"); node.Raw != "false" {
@@ -426,6 +429,46 @@ func TestSanitizeAntigravityRequestSchemasMatchesToolSchemaCleaning(t *testing.T
 	got := gjson.Get(sanitizeAntigravityRequestSchemas(doc, true), schemaPath)
 	if req := got.Get("required").Array(); len(req) != 1 || req[0].String() != "_" {
 		t.Errorf("Claude VALIDATED placeholder missing for an optional-only schema: %s", got.Raw)
+	}
+}
+
+func TestSanitizeAntigravityRequestSchemasPreservesUnionSemantics(t *testing.T) {
+	tests := []struct {
+		name  string
+		union string
+		want  string
+	}{
+		{name: "anyOf_false_true", union: `"anyOf":[false,true]`, want: `{}`},
+		{name: "anyOf_true_false", union: `"anyOf":[true,false]`, want: `{}`},
+		{name: "oneOf_false_true", union: `"oneOf":[false,true]`, want: `{}`},
+		{name: "oneOf_true_false", union: `"oneOf":[true,false]`, want: `{}`},
+		{name: "anyOf_all_false", union: `"anyOf":[false,false]`, want: `false`},
+		{name: "oneOf_all_false", union: `"oneOf":[false,false]`, want: `false`},
+		{name: "anyOf_mixed_true", union: `"anyOf":[false,true,{"type":"string"}]`, want: `{}`},
+		{name: "anyOf_mixed_schema", union: `"anyOf":[false,{"type":"string"},false]`, want: `{"type":"string"}`},
+		{name: "oneOf_single_true_mixed", union: `"oneOf":[false,true,false]`, want: `{}`},
+		{name: "oneOf_multiple_true", union: `"oneOf":[true,true]`, want: `false`},
+		{name: "oneOf_multiple_true_mixed", union: `"oneOf":[true,false,true]`, want: `false`},
+		{name: "anyOf_preserves_sibling", union: `"type":"string","anyOf":[false,true]`, want: `{"type":"string"}`},
+		{name: "oneOf_preserves_sibling", union: `"type":"string","oneOf":[false,true]`, want: `{"type":"string"}`},
+		{name: "oneOf_true_schema", union: `"oneOf":[true,{"type":"string"}]`, want: `{"not":{"type":"string"}}`},
+		{name: "oneOf_schema_true", union: `"oneOf":[{"type":"string"},true]`, want: `{"not":{"type":"string"}}`},
+		{name: "oneOf_true_schema_with_false", union: `"oneOf":[true,false,{"type":"string"}]`, want: `{"not":{"type":"string"}}`},
+		{name: "oneOf_complement_preserves_sibling", union: `"type":"number","oneOf":[true,{"type":"string"}]`, want: `{"not":{"type":"string"},"type":"number"}`},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			doc := `{"request":{"tools":[{"functionDeclarations":[{"name":"t","parameters":` +
+				`{"type":"object","properties":{"choice":{` + testCase.union + `}}}}]}]}}`
+			got := gjson.Get(
+				sanitizeAntigravityRequestSchemas(doc, false),
+				"request.tools.0.functionDeclarations.0.parameters.properties.choice",
+			).Raw
+			if got != testCase.want {
+				t.Fatalf("union result = %s, want %s", got, testCase.want)
+			}
+		})
 	}
 }
 

--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -801,10 +801,9 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 			}
 			inputSchemaResult := toolResult.Get("input_schema")
 			if inputSchemaResult.Exists() && inputSchemaResult.IsObject() {
-				// Sanitize the input schema for Antigravity API compatibility
-				inputSchema := util.CleanJSONSchemaForAntigravity(inputSchemaResult.Raw)
+				// The executor owns Antigravity schema normalization after every translator converges.
 				tool, _ := sjson.DeleteBytes([]byte(toolResult.Raw), "input_schema")
-				tool, _ = sjson.SetRawBytes(tool, "parametersJsonSchema", []byte(inputSchema))
+				tool, _ = sjson.SetRawBytes(tool, "parametersJsonSchema", []byte(inputSchemaResult.Raw))
 				nameResult := gjson.GetBytes(tool, "name")
 				originalName := nameResult.String()
 				mappedName := util.MapSanitizedFunctionName(functionNameMap, originalName)

--- a/internal/translator/antigravity/claude/antigravity_claude_request_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request_test.go
@@ -3366,12 +3366,10 @@ func TestConvertClaudeRequestToAntigravity_ToolAndThinking_NoExistingSystem(t *t
 	}
 }
 
-// TestConvertClaudeRequestToAntigravityStripsPropertyNames covers the reported ingress route: a
-// Claude Messages request carrying MCP-style tool schemas. The private Gemini backend rejects the
-// standard JSON Schema keyword "propertyNames" with an unknown-field 400 before inference, so it
-// must not survive translation. Both reported nestings are exercised, including the one where the
-// keyword sits inside a property that is itself named "properties".
-func TestConvertClaudeRequestToAntigravityStripsPropertyNames(t *testing.T) {
+// TestConvertClaudeRequestToAntigravityPreservesSchemaForExecutor verifies that translation only
+// renames the Claude schema field. The executor owns Antigravity compatibility cleaning after every
+// source translator converges, so removing propertyNames here would bypass that single boundary.
+func TestConvertClaudeRequestToAntigravityPreservesSchemaForExecutor(t *testing.T) {
 	inputJSON := []byte(`{
 		"model": "claude-sonnet-4-5",
 		"messages": [{"role": "user", "content": "hi"}],
@@ -3410,8 +3408,8 @@ func TestConvertClaudeRequestToAntigravityStripsPropertyNames(t *testing.T) {
 	if !decls.IsArray() || len(decls.Array()) != 2 {
 		t.Fatalf("expected two function declarations, got: %s", decls.Raw)
 	}
-	if strings.Contains(decls.Raw, `"propertyNames"`) {
-		t.Errorf("propertyNames survived translation: %s", decls.Raw)
+	if !strings.Contains(decls.Raw, `"propertyNames"`) {
+		t.Errorf("propertyNames was cleaned before the executor boundary: %s", decls.Raw)
 	}
 	// The declarations must still be usable, not emptied out by the cleaning.
 	if !decls.Get("0.parametersJsonSchema.properties.records.items.properties.name").Exists() {

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request.go
@@ -13,7 +13,7 @@ import (
 
 func ConvertOpenAIResponsesRequestToAntigravity(modelName string, inputRawJSON []byte, stream bool) []byte {
 	rawJSON := inputRawJSON
-	rawJSON = ConvertOpenAIResponsesRequestToGemini(modelName, rawJSON, stream)
+	rawJSON = ConvertOpenAIResponsesRequestToGeminiWithSchemaCleaner(modelName, rawJSON, stream, func(schema string) string { return schema })
 	rawJSON = rewriteOpenAIResponsesReasoningForAntigravityClaude(modelName, inputRawJSON, rawJSON)
 	return ConvertGeminiRequestToAntigravity(modelName, rawJSON, stream)
 }

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -15,6 +15,12 @@ import (
 const geminiResponsesThoughtSignature = "skip_thought_signature_validator"
 
 func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte, stream bool) []byte {
+	return ConvertOpenAIResponsesRequestToGeminiWithSchemaCleaner(modelName, inputRawJSON, stream, util.CleanJSONSchemaForGemini)
+}
+
+// ConvertOpenAIResponsesRequestToGeminiWithSchemaCleaner converts a Responses request while letting
+// provider-specific callers defer schema normalization to their outbound request boundary.
+func ConvertOpenAIResponsesRequestToGeminiWithSchemaCleaner(modelName string, inputRawJSON []byte, stream bool, cleanSchema func(string) string) []byte {
 	rawJSON := inputRawJSON
 
 	// Note: stream parameter is part of the fixed method signature
@@ -325,7 +331,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 					funcDecl, _ = sjson.SetBytes(funcDecl, "description", desc.String())
 				}
 				if params := tool.Get("parameters"); params.Exists() {
-					funcDecl, _ = sjson.SetRawBytes(funcDecl, "parametersJsonSchema", []byte(util.CleanJSONSchemaForGemini(params.Raw)))
+					funcDecl, _ = sjson.SetRawBytes(funcDecl, "parametersJsonSchema", []byte(cleanSchema(params.Raw)))
 				}
 
 				functionDeclarations = append(functionDeclarations, funcDecl)

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -25,10 +25,11 @@ const placeholderReasonDescription = "Brief explanation of why you are calling t
 // once already; scope every call site to the schema itself.
 
 type jsonSchemaCleanOptions struct {
-	addPlaceholder       bool
-	removeGeminiMetadata bool
-	flattenUnions        bool
-	forceEnumStringType  bool
+	addPlaceholder                    bool
+	removeGeminiMetadata              bool
+	flattenUnions                     bool
+	forceEnumStringType               bool
+	preserveAdditionalPropertiesFalse bool
 }
 
 // CleanJSONSchemaForAntigravity transforms a tool schema to be compatible with Antigravity API.
@@ -45,7 +46,9 @@ func CleanJSONSchemaForAntigravity(jsonStr string) string {
 // CleanJSONSchemaForAntigravityResponse transforms a response schema without applying tool-only
 // compatibility rewrites that would alter the client's structured output contract.
 func CleanJSONSchemaForAntigravityResponse(jsonStr string) string {
-	return cleanJSONSchema(jsonStr, jsonSchemaCleanOptions{})
+	return cleanJSONSchema(jsonStr, jsonSchemaCleanOptions{
+		preserveAdditionalPropertiesFalse: true,
+	})
 }
 
 // CleanJSONSchemaForGemini transforms a JSON schema to be compatible with Gemini tool calling.
@@ -55,6 +58,18 @@ func CleanJSONSchemaForGemini(jsonStr string) string {
 		removeGeminiMetadata: true,
 		flattenUnions:        true,
 		forceEnumStringType:  true,
+	})
+}
+
+// CleanJSONSchemaForAntigravityTool cleans a tool schema for the Antigravity request path.
+// It preserves additionalProperties because removing false weakens the caller's schema contract.
+func CleanJSONSchemaForAntigravityTool(jsonStr string, addPlaceholder bool) string {
+	return cleanJSONSchema(jsonStr, jsonSchemaCleanOptions{
+		addPlaceholder:                    addPlaceholder,
+		removeGeminiMetadata:              !addPlaceholder,
+		flattenUnions:                     true,
+		forceEnumStringType:               true,
+		preserveAdditionalPropertiesFalse: true,
 	})
 }
 
@@ -76,7 +91,7 @@ func cleanJSONSchema(jsonStr string, options jsonSchemaCleanOptions) string {
 	jsonStr = flattenTypeArrays(jsonStr)
 
 	// Phase 3: Cleanup
-	jsonStr = removeUnsupportedKeywords(jsonStr)
+	jsonStr = removeUnsupportedKeywords(jsonStr, options.preserveAdditionalPropertiesFalse)
 	if options.removeGeminiMetadata {
 		// Gemini schema cleanup: remove nullable/title and placeholder-only fields.
 		jsonStr = removeKeywords(jsonStr, []string{"nullable", "title"})
@@ -307,6 +322,17 @@ func mergeAllOf(jsonStr string) string {
 			continue
 		}
 		parentPath := trimSuffix(p, ".allOf")
+		containsFalseSchema := false
+		for _, item := range allOf.Array() {
+			if item.Type == gjson.False {
+				containsFalseSchema = true
+				break
+			}
+		}
+		if containsFalseSchema {
+			jsonStr = setRawAt(jsonStr, parentPath, "false")
+			continue
+		}
 
 		for _, item := range allOf.Array() {
 			if props := item.Get("properties"); props.IsObject() {
@@ -469,8 +495,9 @@ func flattenTypeArrays(jsonStr string) string {
 	return jsonStr
 }
 
-func removeUnsupportedKeywords(jsonStr string) string {
-	keywords := append(unsupportedConstraints,
+func removeUnsupportedKeywords(jsonStr string, preserveAdditionalPropertiesFalse bool) string {
+	keywords := append([]string{}, unsupportedConstraints...)
+	keywords = append(keywords,
 		"$schema", "$defs", "definitions", "const", "$ref", "$id", "additionalProperties",
 		"propertyNames", "patternProperties", // Gemini doesn't support these schema keywords
 		"$comment", "enumDescriptions", "enumTitles", "prefill", "deprecated", // Schema metadata fields unsupported by Gemini
@@ -481,6 +508,9 @@ func removeUnsupportedKeywords(jsonStr string) string {
 	for _, key := range keywords {
 		for _, p := range pathsByField[key] {
 			if isPropertyDefinition(trimSuffix(p, "."+key)) {
+				continue
+			}
+			if key == "additionalProperties" && preserveAdditionalPropertiesFalse && gjson.Get(jsonStr, p).Type == gjson.False {
 				continue
 			}
 			deletePaths = append(deletePaths, p)


### PR DESCRIPTION
## Summary

Fix Antigravity HTTP 400 errors caused by boolean JSON Schema subschemas in OpenAI-compatible function tools.

The OpenAI-to-Antigravity translator forwards `parametersJsonSchema` unchanged. Some MCP tools include nested schemas such as:

```json
"screenshot_id": true
```

Google Antigravity rejects these boolean subschemas in function declarations.

## Changes

- Sanitize translated `parametersJsonSchema` before sending it to Antigravity.
- Convert nested boolean subschemas to empty schema objects:

```json
"screenshot_id": {}
```

- Preserve ordinary boolean keyword values that are not subschemas.

## Validation

- Reproduced with Claude Opus 4.6 Thinking through Antigravity and RevenueCat MCP tools enabled.
- Before the fix, the request failed with HTTP 400 schema validation errors. After building and running the patched
- CLIProxyAPI locally, the same OMP request completed successfully.
- gofmt -w internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
- go build -o bin/cliproxyapi-fixed ./cmd/server