### PR TITLE
fix(executor): add retry-after parsing to gemini and claude executors

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -2404,10 +2404,20 @@ func parseClaudeRetryAfter(header http.Header) *time.Duration {
 	if val == "" {
 		return nil
 	}
+
 	secs, err := strconv.ParseFloat(val, 64)
-	if err != nil || secs <= 0 {
+	if err == nil && secs > 0 {
+		d := time.Duration(secs * float64(time.Second))
+		return &d
+	}
+
+	t, err := http.ParseTime(val)
+	if err != nil {
 		return nil
 	}
-	d := time.Duration(secs * float64(time.Second))
+	d := time.Until(t)
+	if d <= 0 {
+		return nil
+	}
 	return &d
 }

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -252,7 +253,13 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+
+		sErr := statusErr{code: httpResp.StatusCode, msg: string(b)}
+		if httpResp.StatusCode == http.StatusTooManyRequests || httpResp.StatusCode == 529 {
+			sErr.retryAfter = parseClaudeRetryAfter(httpResp.Header)
+		}
+		err = sErr
+
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
@@ -429,7 +436,11 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		sErr := statusErr{code: httpResp.StatusCode, msg: string(b)}
+		if httpResp.StatusCode == http.StatusTooManyRequests || httpResp.StatusCode == 529 {
+			sErr.retryAfter = parseClaudeRetryAfter(httpResp.Header)
+		}
+		err = sErr
 		return nil, err
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
@@ -663,7 +674,11 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
-		return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: string(b)}
+		sErr := statusErr{code: resp.StatusCode, msg: string(b)}
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == 529 {
+			sErr.retryAfter = parseClaudeRetryAfter(resp.Header)
+		}
+		return cliproxyexecutor.Response{}, sErr
 	}
 	decodedBody, err := decodeResponseBody(resp.Body, resp.Header.Get("Content-Encoding"))
 	if err != nil {
@@ -1721,7 +1736,7 @@ Prefer acting on the user's task over describing product-specific workflows.`)
 func buildTextBlock(text string, cacheControl map[string]string) string {
 	block := []byte(`{"type":"text"}`)
 	block, _ = sjson.SetBytes(block, "text", text)
-	if cacheControl != nil && len(cacheControl) > 0 {
+	if len(cacheControl) > 0 {
 		// Build cache_control JSON manually to avoid sjson map marshaling issues.
 		// sjson.SetBytes with map[string]string may not produce expected structure.
 		cc := `{"type":"ephemeral"`
@@ -2382,4 +2397,17 @@ func ensureModelMaxTokens(body []byte, modelID string) []byte {
 	}
 
 	return body
+}
+
+func parseClaudeRetryAfter(header http.Header) *time.Duration {
+	val := header.Get("Retry-After")
+	if val == "" {
+		return nil
+	}
+	secs, err := strconv.ParseFloat(val, 64)
+	if err != nil || secs <= 0 {
+		return nil
+	}
+	d := time.Duration(secs * float64(time.Second))
+	return &d
 }

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -197,7 +197,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newGeminiStatusErr(httpResp.StatusCode, b)
 		return resp, err
 	}
 	data, err := io.ReadAll(httpResp.Body)
@@ -300,7 +300,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("gemini executor: close response body error: %v", errClose)
 		}
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newGeminiStatusErr(httpResp.StatusCode, b)
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -431,7 +431,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", resp.StatusCode, helps.SummarizeErrorBody(resp.Header.Get("Content-Type"), data))
-		return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: string(data)}
+		return cliproxyexecutor.Response{}, newGeminiStatusErr(resp.StatusCode, data)
 	}
 
 	count := gjson.GetBytes(data, "totalTokens").Int()

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -409,7 +409,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newGeminiStatusErr(httpResp.StatusCode, b)
 		return resp, err
 	}
 	data, errRead := io.ReadAll(httpResp.Body)
@@ -531,7 +531,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newGeminiStatusErr(httpResp.StatusCode, b)
 		return resp, err
 	}
 	data, errRead := io.ReadAll(httpResp.Body)
@@ -640,7 +640,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("vertex executor: close response body error: %v", errClose)
 		}
-		return nil, statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return nil, newGeminiStatusErr(httpResp.StatusCode, b)
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -782,7 +782,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("vertex executor: close response body error: %v", errClose)
 		}
-		return nil, statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return nil, newGeminiStatusErr(httpResp.StatusCode, b)
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -908,7 +908,7 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		return cliproxyexecutor.Response{}, statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return cliproxyexecutor.Response{}, newGeminiStatusErr(httpResp.StatusCode, b)
 	}
 	data, errRead := io.ReadAll(httpResp.Body)
 	if errRead != nil {
@@ -998,7 +998,7 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		return cliproxyexecutor.Response{}, statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return cliproxyexecutor.Response{}, newGeminiStatusErr(httpResp.StatusCode, b)
 	}
 	data, errRead := io.ReadAll(httpResp.Body)
 	if errRead != nil {


### PR DESCRIPTION
## What
Add consistent Retry-After parsing to gemini_executor, gemini_vertex_executor,
and claude_executor.

## Changes
- gemini_executor.go: replace raw statusErr with newGeminiStatusErr() at 3 error sites
- gemini_vertex_executor.go: same at 6 error sites
- claude_executor.go: add parseClaudeRetryAfter() to read the standard
  Retry-After HTTP header on 429/529 responses

## Why
Without accurate retry-after, the cooldown system falls back to guessing.
Accounts re-enter the pool before quota actually recovers, causing
repeated failures and increased latency.