### PR TITLE
Default image generation injection to chat-only

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -95,10 +95,11 @@ max-retry-interval: 30
 # When true, disable auth/model cooldown scheduling globally (prevents blackout windows after failure states).
 disable-cooling: false
 
-# disable-image-generation supports: false (default), true, or "chat".
+# disable-image-generation supports: false, true, or "chat" (default).
+# - false: enable image_generation everywhere.
 # - true: disable image_generation everywhere (also returns 404 for /v1/images/generations and /v1/images/edits).
 # - "chat": disable image_generation injection on non-images endpoints, but keep /v1/images/generations and /v1/images/edits enabled.
-disable-image-generation: false
+disable-image-generation: chat
 
 # Core auth auto-refresh worker pool size (OAuth/file-based auth token refresh).
 # When > 0, overrides the default worker count (16).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -611,45 +611,34 @@ func LoadConfig(configFile string) (*Config, error) {
 }
 
 // LoadConfigOptional reads YAML from configFile.
-// If optional is true and the file is missing, it returns an empty Config.
-// If optional is true and the file is empty or invalid, it returns an empty Config.
+// If optional is true and the file is missing, empty, or invalid, it returns a Config with defaults.
 func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Read the entire configuration file into memory.
 	data, err := os.ReadFile(configFile)
 	if err != nil {
 		if optional {
 			if os.IsNotExist(err) || errors.Is(err, syscall.EISDIR) {
-				// Missing and optional: return empty config (cloud deploy standby).
-				return &Config{}, nil
+				// Missing and optional: return defaults for cloud deploy standby.
+				cfg := defaultConfig()
+				return &cfg, nil
 			}
 		}
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	// In cloud deploy mode (optional=true), if file is empty or contains only whitespace, return empty config.
+	// In cloud deploy mode (optional=true), if file is empty or contains only whitespace, return defaults.
 	if optional && len(data) == 0 {
-		return &Config{}, nil
+		cfg := defaultConfig()
+		return &cfg, nil
 	}
 
 	// Unmarshal the YAML data into the Config struct.
-	var cfg Config
-	// Set defaults before unmarshal so that absent keys keep defaults.
-	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
-	cfg.LoggingToFile = false
-	cfg.LogsMaxTotalSizeMB = 0
-	cfg.ErrorLogsMaxFiles = 10
-	cfg.UsageStatisticsEnabled = false
-	cfg.RedisUsageQueueRetentionSeconds = 60
-	cfg.DisableCooling = false
-	cfg.DisableImageGeneration = DisableImageGenerationOff
-	cfg.Pprof.Enable = false
-	cfg.Pprof.Addr = DefaultPprofAddr
-	cfg.AmpCode.RestrictManagementToLocalhost = false // Default to false: API key auth is sufficient
-	cfg.RemoteManagement.PanelGitHubRepository = DefaultPanelGitHubRepository
+	cfg := defaultConfig()
 	if err = yaml.Unmarshal(data, &cfg); err != nil {
 		if optional {
-			// In cloud deploy mode, if YAML parsing fails, return empty config instead of error.
-			return &Config{}, nil
+			// In cloud deploy mode, if YAML parsing fails, return defaults instead of error.
+			cfg := defaultConfig()
+			return &cfg, nil
 		}
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
@@ -1362,18 +1351,37 @@ func appendPath(path []string, key string) []string {
 // isKnownDefaultValue returns true if the given node at the specified path
 // represents a known default value that should not be written to the config file.
 // This prevents non-zero defaults from polluting the config.
-func isKnownDefaultValue(path []string, node *yaml.Node) bool {
-	// First check if it's a zero value
-	if isZeroValueNode(node) {
-		return true
-	}
+func defaultConfig() Config {
+	var cfg Config
+	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
+	cfg.LoggingToFile = false
+	cfg.LogsMaxTotalSizeMB = 0
+	cfg.ErrorLogsMaxFiles = 10
+	cfg.UsageStatisticsEnabled = false
+	cfg.RedisUsageQueueRetentionSeconds = 60
+	cfg.DisableCooling = false
+	cfg.DisableImageGeneration = DisableImageGenerationChat
+	cfg.Pprof.Enable = false
+	cfg.Pprof.Addr = DefaultPprofAddr
+	cfg.AmpCode.RestrictManagementToLocalhost = false // Default to false: API key auth is sufficient
+	cfg.RemoteManagement.PanelGitHubRepository = DefaultPanelGitHubRepository
+	return cfg
+}
 
-	// Match known non-zero defaults by exact dotted path.
+func isKnownDefaultValue(path []string, node *yaml.Node) bool {
 	if len(path) == 0 {
-		return false
+		return isZeroValueNode(node)
 	}
 
 	fullPath := strings.Join(path, ".")
+	if fullPath == "disable-image-generation" {
+		return node != nil && node.Kind == yaml.ScalarNode && node.Tag == "!!str" && node.Value == "chat"
+	}
+
+	// First check if it's a zero value.
+	if isZeroValueNode(node) {
+		return true
+	}
 
 	// Check string defaults
 	if node.Kind == yaml.ScalarNode && node.Tag == "!!str" {

--- a/internal/config/disable_image_generation_mode_test.go
+++ b/internal/config/disable_image_generation_mode_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -40,6 +42,75 @@ func TestDisableImageGenerationMode_UnmarshalYAML(t *testing.T) {
 		if w.V != DisableImageGenerationChat {
 			t.Fatalf("chat => %v, want %v", w.V, DisableImageGenerationChat)
 		}
+	}
+}
+
+func TestDisableImageGenerationMode_DefaultsToChat(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("port: 8317\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+	if cfg.DisableImageGeneration != DisableImageGenerationChat {
+		t.Fatalf("ParseConfigBytes default = %v, want %v", cfg.DisableImageGeneration, DisableImageGenerationChat)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if errWrite := os.WriteFile(configPath, []byte("port: 8317\n"), 0o600); errWrite != nil {
+		t.Fatalf("write config: %v", errWrite)
+	}
+	loaded, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+	if loaded.DisableImageGeneration != DisableImageGenerationChat {
+		t.Fatalf("LoadConfigOptional default = %v, want %v", loaded.DisableImageGeneration, DisableImageGenerationChat)
+	}
+}
+
+func TestDisableImageGenerationMode_OptionalConfigDefaultsToChat(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing.yaml")
+	missing, err := LoadConfigOptional(missingPath, true)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional(missing, optional) error = %v", err)
+	}
+	if missing.DisableImageGeneration != DisableImageGenerationChat {
+		t.Fatalf("missing optional default = %v, want %v", missing.DisableImageGeneration, DisableImageGenerationChat)
+	}
+
+	emptyPath := filepath.Join(t.TempDir(), "empty.yaml")
+	if errWrite := os.WriteFile(emptyPath, nil, 0o600); errWrite != nil {
+		t.Fatalf("write empty config: %v", errWrite)
+	}
+	empty, err := LoadConfigOptional(emptyPath, true)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional(empty, optional) error = %v", err)
+	}
+	if empty.DisableImageGeneration != DisableImageGenerationChat {
+		t.Fatalf("empty optional default = %v, want %v", empty.DisableImageGeneration, DisableImageGenerationChat)
+	}
+
+	invalidPath := filepath.Join(t.TempDir(), "invalid.yaml")
+	if errWrite := os.WriteFile(invalidPath, []byte("invalid: [\n"), 0o600); errWrite != nil {
+		t.Fatalf("write invalid config: %v", errWrite)
+	}
+	invalid, err := LoadConfigOptional(invalidPath, true)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional(invalid, optional) error = %v", err)
+	}
+	if invalid.DisableImageGeneration != DisableImageGenerationChat {
+		t.Fatalf("invalid optional default = %v, want %v", invalid.DisableImageGeneration, DisableImageGenerationChat)
+	}
+}
+
+func TestDisableImageGenerationMode_IsKnownDefaultValue(t *testing.T) {
+	chatNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "chat"}
+	if !isKnownDefaultValue([]string{"disable-image-generation"}, chatNode) {
+		t.Fatalf("disable-image-generation=chat should be treated as a known default")
+	}
+
+	falseNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "false"}
+	if isKnownDefaultValue([]string{"disable-image-generation"}, falseNode) {
+		t.Fatalf("disable-image-generation=false should be preserved as an explicit non-default")
 	}
 }
 

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -16,20 +16,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 		return nil, fmt.Errorf("config payload is empty")
 	}
 
-	var cfg Config
-	// Keep defaults aligned with LoadConfigOptional.
-	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
-	cfg.LoggingToFile = false
-	cfg.LogsMaxTotalSizeMB = 0
-	cfg.ErrorLogsMaxFiles = 10
-	cfg.UsageStatisticsEnabled = false
-	cfg.RedisUsageQueueRetentionSeconds = 60
-	cfg.DisableCooling = false
-	cfg.DisableImageGeneration = DisableImageGenerationOff
-	cfg.Pprof.Enable = false
-	cfg.Pprof.Addr = DefaultPprofAddr
-	cfg.AmpCode.RestrictManagementToLocalhost = false // Default to false: API key auth is sufficient
-	cfg.RemoteManagement.PanelGitHubRepository = DefaultPanelGitHubRepository
+	cfg := defaultConfig()
 
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config payload: %w", err)

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -12,10 +12,10 @@ type SDKConfig struct {
 	// DisableImageGeneration controls whether the built-in image_generation tool is injected/allowed.
 	//
 	// Supported values:
-	//   - false (default): image_generation is enabled everywhere (normal behavior).
+	//   - false: image_generation is enabled everywhere.
 	//   - true: image_generation is disabled everywhere. The server stops injecting it, removes it from request payloads,
 	//     and returns 404 for /v1/images/generations and /v1/images/edits.
-	//   - "chat": disable image_generation injection for all non-images endpoints (e.g. /v1/responses, /v1/chat/completions),
+	//   - "chat" (default): disable image_generation injection for all non-images endpoints (e.g. /v1/responses, /v1/chat/completions),
 	//     while keeping /v1/images/generations and /v1/images/edits enabled and preserving image_generation there.
 	DisableImageGeneration DisableImageGenerationMode `yaml:"disable-image-generation" json:"disable-image-generation"`
 


### PR DESCRIPTION
## Summary

- Change `disable-image-generation` default from `false` to `chat`
- Update `config.example.yaml` and SDK config comments
- Add config default coverage for both `ParseConfigBytes` and `LoadConfigOptional`

## Why

With the previous default, normal Codex `/v1/responses` requests can receive auth-dependent `image_generation` tool injection. Mixed free/non-free Codex auth pools can then send different `tools` for the same `prompt_cache_key`, which affects OpenAI prompt cache prefix matching.

Closes #3531

## Tests

```bash
go test ./internal/config -run 'TestDisableImageGenerationMode' -count=1
go build -o test-output ./cmd/server && rm test-output
```
