### PR TITLE
Handle rejected encrypted reasoning retries

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -315,18 +315,65 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
 	}
-	defer func() {
-		if errClose := httpResp.Body.Close(); errClose != nil {
+	defer func(body io.Closer) {
+		if errClose := body.Close(); errClose != nil {
 			log.Errorf("codex executor: close response body error: %v", errClose)
 		}
-	}()
+	}(httpResp.Body)
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = newCodexStatusErr(httpResp.StatusCode, b)
-		return resp, err
+		if isInvalidResponsesEncryptedContentError(httpResp.StatusCode, b) {
+			if strippedBody, changed := stripInvalidEncryptedContentFromResponsesBody(body); changed {
+				helps.LogWithRequestID(ctx).Warn("codex executor: upstream rejected encrypted_content; retrying once without encrypted reasoning context")
+				retryReq, retryBuildErr := e.cacheHelper(ctx, from, url, req, strippedBody)
+				if retryBuildErr != nil {
+					err = retryBuildErr
+					return resp, err
+				}
+				applyCodexHeaders(retryReq, auth, apiKey, true, e.cfg)
+				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+					URL:       url,
+					Method:    http.MethodPost,
+					Headers:   retryReq.Header.Clone(),
+					Body:      strippedBody,
+					Provider:  e.Identifier(),
+					AuthID:    authID,
+					AuthLabel: authLabel,
+					AuthType:  authType,
+					AuthValue: authValue,
+				})
+				retryResp, retryErr := httpClient.Do(retryReq)
+				if retryErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, retryErr)
+					err = retryErr
+					return resp, err
+				}
+				defer func(body io.Closer) {
+					if errClose := body.Close(); errClose != nil {
+						log.Errorf("codex executor: close retry response body error: %v", errClose)
+					}
+				}(retryResp.Body)
+				helps.RecordAPIResponseMetadata(ctx, e.cfg, retryResp.StatusCode, retryResp.Header.Clone())
+				if retryResp.StatusCode < 200 || retryResp.StatusCode >= 300 {
+					b, _ = io.ReadAll(retryResp.Body)
+					helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+					helps.LogWithRequestID(ctx).Debugf("request retry error, error status: %d, error message: %s", retryResp.StatusCode, helps.SummarizeErrorBody(retryResp.Header.Get("Content-Type"), b))
+					err = newCodexStatusErr(retryResp.StatusCode, b)
+					return resp, err
+				}
+				body = strippedBody
+				httpResp = retryResp
+			} else {
+				err = newCodexStatusErr(httpResp.StatusCode, b)
+				return resp, err
+			}
+		} else {
+			err = newCodexStatusErr(httpResp.StatusCode, b)
+			return resp, err
+		}
 	}
 	data, err := io.ReadAll(httpResp.Body)
 	if err != nil {
@@ -471,18 +518,65 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
 	}
-	defer func() {
-		if errClose := httpResp.Body.Close(); errClose != nil {
+	defer func(body io.Closer) {
+		if errClose := body.Close(); errClose != nil {
 			log.Errorf("codex executor: close response body error: %v", errClose)
 		}
-	}()
+	}(httpResp.Body)
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = newCodexStatusErr(httpResp.StatusCode, b)
-		return resp, err
+		if isInvalidResponsesEncryptedContentError(httpResp.StatusCode, b) {
+			if strippedBody, changed := stripInvalidEncryptedContentFromResponsesBody(body); changed {
+				helps.LogWithRequestID(ctx).Warn("codex compact executor: upstream rejected encrypted_content; retrying once without encrypted reasoning context")
+				retryReq, retryBuildErr := e.cacheHelper(ctx, from, url, req, strippedBody)
+				if retryBuildErr != nil {
+					err = retryBuildErr
+					return resp, err
+				}
+				applyCodexHeaders(retryReq, auth, apiKey, false, e.cfg)
+				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+					URL:       url,
+					Method:    http.MethodPost,
+					Headers:   retryReq.Header.Clone(),
+					Body:      strippedBody,
+					Provider:  e.Identifier(),
+					AuthID:    authID,
+					AuthLabel: authLabel,
+					AuthType:  authType,
+					AuthValue: authValue,
+				})
+				retryResp, retryErr := httpClient.Do(retryReq)
+				if retryErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, retryErr)
+					err = retryErr
+					return resp, err
+				}
+				defer func(body io.Closer) {
+					if errClose := body.Close(); errClose != nil {
+						log.Errorf("codex compact executor: close retry response body error: %v", errClose)
+					}
+				}(retryResp.Body)
+				helps.RecordAPIResponseMetadata(ctx, e.cfg, retryResp.StatusCode, retryResp.Header.Clone())
+				if retryResp.StatusCode < 200 || retryResp.StatusCode >= 300 {
+					b, _ = io.ReadAll(retryResp.Body)
+					helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+					helps.LogWithRequestID(ctx).Debugf("request retry error, error status: %d, error message: %s", retryResp.StatusCode, helps.SummarizeErrorBody(retryResp.Header.Get("Content-Type"), b))
+					err = newCodexStatusErr(retryResp.StatusCode, b)
+					return resp, err
+				}
+				body = strippedBody
+				httpResp = retryResp
+			} else {
+				err = newCodexStatusErr(httpResp.StatusCode, b)
+				return resp, err
+			}
+		} else {
+			err = newCodexStatusErr(httpResp.StatusCode, b)
+			return resp, err
+		}
 	}
 	data, err := io.ReadAll(httpResp.Body)
 	if err != nil {
@@ -585,8 +679,55 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
-		err = newCodexStatusErr(httpResp.StatusCode, data)
-		return nil, err
+		if isInvalidResponsesEncryptedContentError(httpResp.StatusCode, data) {
+			if strippedBody, changed := stripInvalidEncryptedContentFromResponsesBody(body); changed {
+				helps.LogWithRequestID(ctx).Warn("codex stream executor: upstream rejected encrypted_content; retrying once without encrypted reasoning context")
+				retryReq, retryBuildErr := e.cacheHelper(ctx, from, url, req, strippedBody)
+				if retryBuildErr != nil {
+					return nil, retryBuildErr
+				}
+				applyCodexHeaders(retryReq, auth, apiKey, true, e.cfg)
+				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+					URL:       url,
+					Method:    http.MethodPost,
+					Headers:   retryReq.Header.Clone(),
+					Body:      strippedBody,
+					Provider:  e.Identifier(),
+					AuthID:    authID,
+					AuthLabel: authLabel,
+					AuthType:  authType,
+					AuthValue: authValue,
+				})
+				retryResp, retryErr := httpClient.Do(retryReq)
+				if retryErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, retryErr)
+					return nil, retryErr
+				}
+				helps.RecordAPIResponseMetadata(ctx, e.cfg, retryResp.StatusCode, retryResp.Header.Clone())
+				if retryResp.StatusCode < 200 || retryResp.StatusCode >= 300 {
+					retryData, retryReadErr := io.ReadAll(retryResp.Body)
+					if errClose := retryResp.Body.Close(); errClose != nil {
+						log.Errorf("codex executor: close retry response body error: %v", errClose)
+					}
+					if retryReadErr != nil {
+						helps.RecordAPIResponseError(ctx, e.cfg, retryReadErr)
+						return nil, retryReadErr
+					}
+					helps.AppendAPIResponseChunk(ctx, e.cfg, retryData)
+					helps.LogWithRequestID(ctx).Debugf("request retry error, error status: %d, error message: %s", retryResp.StatusCode, helps.SummarizeErrorBody(retryResp.Header.Get("Content-Type"), retryData))
+					err = newCodexStatusErr(retryResp.StatusCode, retryData)
+					return nil, err
+				}
+				body = strippedBody
+				httpResp = retryResp
+			} else {
+				err = newCodexStatusErr(httpResp.StatusCode, data)
+				return nil, err
+			}
+		} else {
+			err = newCodexStatusErr(httpResp.StatusCode, data)
+			return nil, err
+		}
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -166,18 +166,70 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
 	}
-	defer func() {
-		if errClose := httpResp.Body.Close(); errClose != nil {
+	defer func(body io.Closer) {
+		if errClose := body.Close(); errClose != nil {
 			log.Errorf("openai compat executor: close response body error: %v", errClose)
 		}
-	}()
+	}(httpResp.Body)
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
-		return resp, err
+		if opts.Alt == "responses/compact" && isInvalidResponsesEncryptedContentError(httpResp.StatusCode, b) {
+			if strippedTranslated, changed := stripInvalidEncryptedContentFromResponsesBody(translated); changed {
+				helps.LogWithRequestID(ctx).Warn("openai compat executor: upstream rejected encrypted_content; retrying once without encrypted reasoning context")
+				retryReq, retryBuildErr := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(strippedTranslated))
+				if retryBuildErr != nil {
+					err = retryBuildErr
+					return resp, err
+				}
+				retryReq.Header.Set("Content-Type", "application/json")
+				if apiKey != "" {
+					retryReq.Header.Set("Authorization", "Bearer "+apiKey)
+				}
+				retryReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
+				util.ApplyCustomHeadersFromAttrs(retryReq, attrs)
+				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+					URL:       url,
+					Method:    http.MethodPost,
+					Headers:   retryReq.Header.Clone(),
+					Body:      strippedTranslated,
+					Provider:  e.Identifier(),
+					AuthID:    authID,
+					AuthLabel: authLabel,
+					AuthType:  authType,
+					AuthValue: authValue,
+				})
+				retryResp, retryErr := httpClient.Do(retryReq)
+				if retryErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, retryErr)
+					err = retryErr
+					return resp, err
+				}
+				defer func(body io.Closer) {
+					if errClose := body.Close(); errClose != nil {
+						log.Errorf("openai compat executor: close retry response body error: %v", errClose)
+					}
+				}(retryResp.Body)
+				helps.RecordAPIResponseMetadata(ctx, e.cfg, retryResp.StatusCode, retryResp.Header.Clone())
+				if retryResp.StatusCode < 200 || retryResp.StatusCode >= 300 {
+					b, _ = io.ReadAll(retryResp.Body)
+					helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+					helps.LogWithRequestID(ctx).Debugf("request retry error, error status: %d, error message: %s", retryResp.StatusCode, helps.SummarizeErrorBody(retryResp.Header.Get("Content-Type"), b))
+					err = statusErr{code: retryResp.StatusCode, msg: string(b)}
+					return resp, err
+				}
+				translated = strippedTranslated
+				httpResp = retryResp
+			} else {
+				err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+				return resp, err
+			}
+		} else {
+			err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+			return resp, err
+		}
 	}
 	body, err := io.ReadAll(httpResp.Body)
 	if err != nil {

--- a/internal/runtime/executor/responses_encrypted_retry.go
+++ b/internal/runtime/executor/responses_encrypted_retry.go
@@ -1,0 +1,119 @@
+package executor
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+func isInvalidResponsesEncryptedContentError(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest {
+		return false
+	}
+	for _, path := range []string{"error.code", "detail.code", "code"} {
+		if strings.EqualFold(strings.TrimSpace(gjson.GetBytes(body, path).String()), "invalid_encrypted_content") {
+			return true
+		}
+	}
+
+	msgParts := []string{
+		gjson.GetBytes(body, "error.message").String(),
+		gjson.GetBytes(body, "detail").String(),
+		string(body),
+	}
+	for _, msg := range msgParts {
+		msg = strings.ToLower(msg)
+		if strings.Contains(msg, "invalid_encrypted_content") {
+			return true
+		}
+		if strings.Contains(msg, "encrypted content") &&
+			(strings.Contains(msg, "could not be verified") || strings.Contains(msg, "could not be decrypted")) {
+			return true
+		}
+	}
+	return false
+}
+
+func stripInvalidEncryptedContentFromResponsesBody(body []byte) ([]byte, bool) {
+	var root map[string]any
+	if err := json.Unmarshal(body, &root); err != nil || root == nil {
+		return body, false
+	}
+	input, ok := root["input"]
+	if !ok {
+		return body, false
+	}
+	strippedInput, changed, keep := stripInvalidEncryptedContentValue(input, false)
+	if !changed {
+		return body, false
+	}
+	if keep {
+		root["input"] = strippedInput
+	} else {
+		delete(root, "input")
+	}
+	stripped, err := json.Marshal(root)
+	if err != nil {
+		return body, false
+	}
+	return stripped, true
+}
+
+func stripInvalidEncryptedContentValue(value any, arrayItem bool) (any, bool, bool) {
+	switch v := value.(type) {
+	case []any:
+		changed := false
+		out := make([]any, 0, len(v))
+		for _, item := range v {
+			stripped, itemChanged, keep := stripInvalidEncryptedContentValue(item, true)
+			if itemChanged {
+				changed = true
+			}
+			if !keep {
+				changed = true
+				continue
+			}
+			out = append(out, stripped)
+		}
+		return out, changed, true
+	case map[string]any:
+		changed := false
+		if strings.TrimSpace(firstNonEmptyAnyString(v["type"])) == "reasoning" {
+			if _, hasEncrypted := v["encrypted_content"]; hasEncrypted {
+				if arrayItem {
+					return nil, true, false
+				}
+				delete(v, "encrypted_content")
+				changed = true
+			}
+		} else if _, hasEncrypted := v["encrypted_content"]; hasEncrypted {
+			delete(v, "encrypted_content")
+			changed = true
+		}
+		for key, child := range v {
+			stripped, childChanged, keep := stripInvalidEncryptedContentValue(child, false)
+			if childChanged {
+				changed = true
+			}
+			if keep {
+				v[key] = stripped
+			} else {
+				delete(v, key)
+			}
+		}
+		return v, changed, true
+	default:
+		return value, false, true
+	}
+}
+
+func firstNonEmptyAnyString(values ...any) string {
+	for _, value := range values {
+		if s, ok := value.(string); ok && strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/runtime/executor/responses_encrypted_retry_test.go
+++ b/internal/runtime/executor/responses_encrypted_retry_test.go
@@ -1,0 +1,56 @@
+package executor
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestIsInvalidResponsesEncryptedContentError(t *testing.T) {
+	body := []byte(`{
+		"error":{
+			"code":"invalid_encrypted_content",
+			"type":"invalid_request_error",
+			"message":"The encrypted content gAAA...Vw== could not be verified. Reason: Encrypted content could not be decrypted or parsed."
+		}
+	}`)
+
+	if !isInvalidResponsesEncryptedContentError(http.StatusBadRequest, body) {
+		t.Fatalf("expected invalid encrypted content error to be detected")
+	}
+	if isInvalidResponsesEncryptedContentError(http.StatusInternalServerError, body) {
+		t.Fatalf("non-400 response should not trigger encrypted content fallback")
+	}
+}
+
+func TestStripInvalidEncryptedContentFromResponsesBody(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":[
+			{"type":"message","role":"user","content":"hello"},
+			{"type":"reasoning","id":"rs_bad","encrypted_content":"gAAA"},
+			{"type":"function_call","call_id":"call_123","name":"lookup","arguments":"{}"},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done","encrypted_content":"nested"}]}
+		]
+	}`)
+
+	got, changed := stripInvalidEncryptedContentFromResponsesBody(raw)
+	if !changed {
+		t.Fatalf("expected body to be changed")
+	}
+	items := gjson.GetBytes(got, "input").Array()
+	if len(items) != 3 {
+		t.Fatalf("expected reasoning item to be removed, got %d items: %s", len(items), got)
+	}
+	if typ := gjson.GetBytes(got, "input.0.type").String(); typ != "message" {
+		t.Fatalf("first input should remain message, got %q; body=%s", typ, got)
+	}
+	if typ := gjson.GetBytes(got, "input.1.type").String(); typ != "function_call" {
+		t.Fatalf("function call should remain, got %q; body=%s", typ, got)
+	}
+	if strings.Contains(string(got), "encrypted_content") {
+		t.Fatalf("encrypted_content should be removed from retry body: %s", got)
+	}
+}

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -53,12 +53,11 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		return &config, nil
 	}
 
-	// allowClampUnsupported determines whether to clamp unsupported levels instead of returning an error.
-	// This applies when crossing provider families (e.g., openai→gemini, claude→gemini) and the target
-	// model supports discrete levels. Same-family conversions require strict validation.
+	// allowClampUnsupported determines whether to clamp unsupported recognized levels instead of returning an error.
+	// This applies when the target model supports discrete levels, including same-family requests.
 	toCapability := detectModelCapability(modelInfo)
 	toHasLevelSupport := toCapability == CapabilityLevelOnly || toCapability == CapabilityHybrid
-	allowClampUnsupported := toHasLevelSupport && !isSameProviderFamily(fromFormat, toFormat)
+	allowClampUnsupported := toHasLevelSupport
 
 	// strictBudget determines whether to enforce strict budget range validation.
 	// This applies when: (1) config comes from request body (not suffix), (2) source format is known,

--- a/test/thinking_conversion_test.go
+++ b/test/thinking_conversion_test.go
@@ -73,15 +73,16 @@ func TestThinkingE2EMatrix_Suffix(t *testing.T) {
 			expectValue: "medium",
 			expectErr:   false,
 		},
-		// Case 3: Specified xhigh → out of range error
+		// Case 3: Specified xhigh -> clamped to high
 		{
 			name:        "3",
 			from:        "openai",
 			to:          "codex",
 			model:       "level-model(xhigh)",
 			inputJSON:   `{"model":"level-model(xhigh)","messages":[{"role":"user","content":"hi"}]}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 4: Level none → clamped to minimal (ZeroAllowed=false)
 		{
@@ -963,15 +964,16 @@ func TestThinkingE2EMatrix_Suffix(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 81: OpenAI to OpenAI, level xhigh → out of range error
+		// Case 81: OpenAI to OpenAI, level xhigh -> clamped to high
 		{
 			name:        "81",
 			from:        "openai",
 			to:          "openai",
 			model:       "level-model(xhigh)",
 			inputJSON:   `{"model":"level-model(xhigh)","messages":[{"role":"user","content":"hi"}]}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning_effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 82: OpenAI-Response to Codex, level high → passthrough reasoning.effort
 		{
@@ -984,15 +986,16 @@ func TestThinkingE2EMatrix_Suffix(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 83: OpenAI-Response to Codex, level xhigh → out of range error
+		// Case 83: OpenAI-Response to Codex, level xhigh -> clamped to high
 		{
 			name:        "83",
 			from:        "openai-response",
 			to:          "codex",
 			model:       "level-model(xhigh)",
 			inputJSON:   `{"model":"level-model(xhigh)","input":[{"role":"user","content":"hi"}]}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 84: Gemini to Gemini, budget 8192 → passthrough thinkingBudget
 		{
@@ -1179,15 +1182,16 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			expectValue: "medium",
 			expectErr:   false,
 		},
-		// Case 3: reasoning_effort=xhigh → out of range error
+		// Case 3: reasoning_effort=xhigh -> clamped to high
 		{
 			name:        "3",
 			from:        "openai",
 			to:          "codex",
 			model:       "level-model",
 			inputJSON:   `{"model":"level-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 4: reasoning_effort=none → clamped to minimal
 		{
@@ -2069,15 +2073,16 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 81: OpenAI to OpenAI, reasoning_effort=xhigh → out of range error
+		// Case 81: OpenAI to OpenAI, reasoning_effort=xhigh -> clamped to high
 		{
 			name:        "81",
 			from:        "openai",
 			to:          "openai",
 			model:       "level-model",
 			inputJSON:   `{"model":"level-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning_effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 82: OpenAI-Response to Codex, reasoning.effort=high → passthrough
 		{
@@ -2090,15 +2095,16 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 83: OpenAI-Response to Codex, reasoning.effort=xhigh → out of range error
+		// Case 83: OpenAI-Response to Codex, reasoning.effort=xhigh -> clamped to high
 		{
 			name:        "83",
 			from:        "openai-response",
 			to:          "codex",
 			model:       "level-model",
 			inputJSON:   `{"model":"level-model","input":[{"role":"user","content":"hi"}],"reasoning":{"effort":"xhigh"}}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 84: Gemini to Gemini, thinkingBudget=8192 → passthrough
 		{
@@ -2697,12 +2703,16 @@ func TestThinkingE2EClaudeAdaptive_Body(t *testing.T) {
 			expectErr:    false,
 		},
 		{
-			name:      "C24",
-			from:      "claude",
-			to:        "claude",
-			model:     "claude-opus-4-6-model",
-			inputJSON: `{"model":"claude-opus-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`,
-			expectErr: true,
+			name:         "C24",
+			from:         "claude",
+			to:           "claude",
+			model:        "claude-opus-4-6-model",
+			inputJSON:    `{"model":"claude-opus-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`,
+			expectField:  "thinking.type",
+			expectValue:  "adaptive",
+			expectField2: "output_config.effort",
+			expectValue2: "high",
+			expectErr:    false,
 		},
 		{
 			name:         "C25",
@@ -2717,20 +2727,28 @@ func TestThinkingE2EClaudeAdaptive_Body(t *testing.T) {
 			expectErr:    false,
 		},
 		{
-			name:      "C26",
-			from:      "claude",
-			to:        "claude",
-			model:     "claude-sonnet-4-6-model",
-			inputJSON: `{"model":"claude-sonnet-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`,
-			expectErr: true,
+			name:         "C26",
+			from:         "claude",
+			to:           "claude",
+			model:        "claude-sonnet-4-6-model",
+			inputJSON:    `{"model":"claude-sonnet-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`,
+			expectField:  "thinking.type",
+			expectValue:  "adaptive",
+			expectField2: "output_config.effort",
+			expectValue2: "high",
+			expectErr:    false,
 		},
 		{
-			name:      "C27",
-			from:      "claude",
-			to:        "claude",
-			model:     "claude-sonnet-4-6-model",
-			inputJSON: `{"model":"claude-sonnet-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`,
-			expectErr: true,
+			name:         "C27",
+			from:         "claude",
+			to:           "claude",
+			model:        "claude-sonnet-4-6-model",
+			inputJSON:    `{"model":"claude-sonnet-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`,
+			expectField:  "thinking.type",
+			expectValue:  "adaptive",
+			expectField2: "output_config.effort",
+			expectValue2: "high",
+			expectErr:    false,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- retry Codex/OpenAI Responses requests once when upstream rejects invalid encrypted reasoning content
- strip reasoning items and nested encrypted_content from the retry payload
- clamp unsupported recognized thinking effort levels instead of failing compatible conversions

## Tests

- added encrypted reasoning retry helper tests
- updated thinking conversion expectations
- CI build/checks pass on this PR