### PR TITLE
fix(auth): fail fast on unavailable session-affinity auth for /v1/responses

### DIFF
--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -504,6 +504,15 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 				return auth, nil
 			}
 		}
+		if requestPath, strict := sessionAffinityStrictLeasePath(opts); strict {
+			entry.Warnf("session-affinity: cache hit but auth unavailable, failing fast for stateful endpoint | session=%s auth=%s provider=%s model=%s path=%s", truncateSessionID(primaryID), cachedAuthID, provider, model, requestPath)
+			return nil, &Error{
+				Code:       "session_auth_unavailable",
+				Message:    "session-affinity pinned auth is temporarily unavailable for stateful /v1/responses continuation",
+				Retryable:  true,
+				HTTPStatus: http.StatusServiceUnavailable,
+			}
+		}
 		// Cached auth not available, reselect via fallback selector for even distribution
 		auth, err := s.fallback.Pick(ctx, provider, model, opts, auths)
 		if err != nil {
@@ -534,6 +543,23 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	s.cache.Set(cacheKey, auth.ID)
 	entry.Infof("session-affinity: cache miss, new binding | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 	return auth, nil
+}
+
+func sessionAffinityStrictLeasePath(opts cliproxyexecutor.Options) (string, bool) {
+	if len(opts.Metadata) == 0 {
+		return "", false
+	}
+	raw, ok := opts.Metadata[cliproxyexecutor.RequestPathMetadataKey]
+	if !ok || raw == nil {
+		return "", false
+	}
+
+	path := strings.TrimSpace(fmt.Sprint(raw))
+	if path == "" {
+		return "", false
+	}
+	path = strings.TrimRight(path, "/")
+	return path, path == "/v1/responses"
 }
 
 func selectorLogEntry(ctx context.Context) *log.Entry {

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -700,6 +700,122 @@ func TestSessionAffinitySelector_FailoverWhenAuthUnavailable(t *testing.T) {
 	}
 }
 
+func TestSessionAffinitySelector_FailsFastForResponsesWhenAuthUnavailable(t *testing.T) {
+	t.Parallel()
+
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a"},
+		{ID: "auth-b"},
+		{ID: "auth-c"},
+	}
+
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Session-Id": []string{"responses-strict-test"},
+		},
+		Metadata: map[string]any{
+			cliproxyexecutor.RequestPathMetadataKey: "/v1/responses",
+		},
+	}
+
+	first, err := selector.Pick(context.Background(), "codex", "gpt-5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+
+	availableWithoutFirst := make([]*Auth, 0, len(auths)-1)
+	for _, a := range auths {
+		if a.ID != first.ID {
+			availableWithoutFirst = append(availableWithoutFirst, a)
+		}
+	}
+
+	got, err := selector.Pick(context.Background(), "codex", "gpt-5", opts, availableWithoutFirst)
+	if err == nil {
+		t.Fatalf("Pick() error = nil, auth = %#v", got)
+	}
+	if got != nil {
+		t.Fatalf("Pick() auth = %#v, want nil", got)
+	}
+	var authErr *Error
+	if !errors.As(err, &authErr) {
+		t.Fatalf("Pick() error type = %T, want *Error", err)
+	}
+	if authErr.Code != "session_auth_unavailable" {
+		t.Fatalf("error code = %q, want %q", authErr.Code, "session_auth_unavailable")
+	}
+	if authErr.HTTPStatus != http.StatusServiceUnavailable {
+		t.Fatalf("HTTPStatus = %d, want %d", authErr.HTTPStatus, http.StatusServiceUnavailable)
+	}
+	if !authErr.Retryable {
+		t.Fatalf("Retryable = false, want true")
+	}
+
+	restored, err := selector.Pick(context.Background(), "codex", "gpt-5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() after auth restore error = %v", err)
+	}
+	if restored.ID != first.ID {
+		t.Fatalf("Pick() after auth restore ID = %q, want original %q", restored.ID, first.ID)
+	}
+}
+
+func TestSessionAffinitySelector_ReselectsForNonResponsesWhenAuthUnavailable(t *testing.T) {
+	t.Parallel()
+
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: fallback,
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a"},
+		{ID: "auth-b"},
+		{ID: "auth-c"},
+	}
+
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Session-Id": []string{"non-responses-test"},
+		},
+		Metadata: map[string]any{
+			cliproxyexecutor.RequestPathMetadataKey: "/v1/chat/completions",
+		},
+	}
+
+	first, err := selector.Pick(context.Background(), "codex", "gpt-5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+
+	availableWithoutFirst := make([]*Auth, 0, len(auths)-1)
+	for _, a := range auths {
+		if a.ID != first.ID {
+			availableWithoutFirst = append(availableWithoutFirst, a)
+		}
+	}
+
+	second, err := selector.Pick(context.Background(), "codex", "gpt-5", opts, availableWithoutFirst)
+	if err != nil {
+		t.Fatalf("Pick() after reselect error = %v", err)
+	}
+	if second == nil {
+		t.Fatalf("Pick() after reselect auth = nil")
+	}
+	if second.ID == first.ID {
+		t.Fatalf("Pick() after reselect returned same auth %q, expected different", first.ID)
+	}
+}
+
 func TestRoundRobinSelectorPick_MixedVirtualAndNonVirtualFallsBackToFlat(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Fail fast with a retryable `session_auth_unavailable` error and HTTP 503 when `/v1/responses` session-affinity has a cached auth that is temporarily unavailable.
- Preserve the existing fallback/reselect behavior for non-Responses endpoints.
- Keep the original session binding intact so a restored pinned auth can continue the same stateful Responses session.

## Root cause
`/v1/responses` continuations can depend on encrypted/reasoning state tied to the auth that created the session. The previous cache-hit-unavailable path silently selected another auth and replaced the cache binding, which can break state continuity for stateful Responses workflows.

## Validation
- `go test ./sdk/cliproxy/auth ./sdk/api/handlers`