### PR TITLE
feat(quota): add antigravity-credits-stick-seconds for credits-first mode

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -109,6 +109,7 @@ quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
   antigravity-credits: true # Whether to use credits as last-resort fallback when all free-tier auths are exhausted for Claude models
+  antigravity-credits-stick-seconds: 0 # 0 = disabled (default), -1 = always use credits first (skip free tier, retry with cooldown on failure)
 
 # Routing strategy for selecting credentials when multiple match.
 routing:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,11 @@ type QuotaExceeded struct {
 	// When all free-tier auths are exhausted (429/503), the conductor retries with
 	// an auth that has available Google One AI credits.
 	AntigravityCredits bool `yaml:"antigravity-credits" json:"antigravity-credits"`
+
+	// AntigravityCreditsStickSeconds controls credits-first behavior for Claude models.
+	// 0 (default): disabled — each request tries free tier first.
+	// -1: always use credits — skip free tier entirely, retry with cooldown on failure.
+	AntigravityCreditsStickSeconds int `yaml:"antigravity-credits-stick-seconds" json:"antigravity-credits-stick-seconds"`
 }
 
 // RoutingConfig configures how credentials are selected for requests.

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -89,6 +89,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.QuotaExceeded.AntigravityCredits != newCfg.QuotaExceeded.AntigravityCredits {
 		changes = append(changes, fmt.Sprintf("quota-exceeded.antigravity-credits: %t -> %t", oldCfg.QuotaExceeded.AntigravityCredits, newCfg.QuotaExceeded.AntigravityCredits))
 	}
+	if oldCfg.QuotaExceeded.AntigravityCreditsStickSeconds != newCfg.QuotaExceeded.AntigravityCreditsStickSeconds {
+		changes = append(changes, fmt.Sprintf("quota-exceeded.antigravity-credits-stick-seconds: %d -> %d", oldCfg.QuotaExceeded.AntigravityCreditsStickSeconds, newCfg.QuotaExceeded.AntigravityCreditsStickSeconds))
+	}
 
 	if oldCfg.Routing.Strategy != newCfg.Routing.Strategy {
 		changes = append(changes, fmt.Sprintf("routing.strategy: %s -> %s", oldCfg.Routing.Strategy, newCfg.Routing.Strategy))

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1229,6 +1229,32 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
 
+	if m.isAntigravityCreditsFirst(normalized, req.Model) {
+		_, _, maxWait := m.retrySettings()
+		var lastCreditsErr error
+		for attempt := 0; ; attempt++ {
+			resp, ok, creditsErr := m.tryAntigravityCreditsExecute(ctx, req, opts)
+			if ok {
+				return resp, nil
+			}
+			if creditsErr == nil {
+				break
+			}
+			lastCreditsErr = creditsErr
+			wait, shouldRetry := m.shouldRetryAfterError(creditsErr, attempt, []string{"antigravity"}, req.Model, maxWait)
+			if !shouldRetry {
+				break
+			}
+			if errWait := waitForCooldown(ctx, wait); errWait != nil {
+				return cliproxyexecutor.Response{}, errWait
+			}
+		}
+		if lastCreditsErr != nil {
+			return cliproxyexecutor.Response{}, lastCreditsErr
+		}
+		return cliproxyexecutor.Response{}, &Error{Code: "credits_exhausted", Message: "all credits candidates exhausted"}
+	}
+
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
@@ -1248,7 +1274,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 	}
 	if lastErr != nil {
 		if hasAntigravityProvider(normalized) && shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
-			if resp, ok := m.tryAntigravityCreditsExecute(ctx, req, opts); ok {
+			if resp, ok, _ := m.tryAntigravityCreditsExecute(ctx, req, opts); ok {
 				return resp, nil
 			}
 		}
@@ -1295,6 +1321,32 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
 
+	if m.isAntigravityCreditsFirst(normalized, req.Model) {
+		_, _, maxWait := m.retrySettings()
+		var lastCreditsErr error
+		for attempt := 0; ; attempt++ {
+			result, ok, creditsErr := m.tryAntigravityCreditsExecuteStream(ctx, req, opts)
+			if ok {
+				return result, nil
+			}
+			if creditsErr == nil {
+				break
+			}
+			lastCreditsErr = creditsErr
+			wait, shouldRetry := m.shouldRetryAfterError(creditsErr, attempt, []string{"antigravity"}, req.Model, maxWait)
+			if !shouldRetry {
+				break
+			}
+			if errWait := waitForCooldown(ctx, wait); errWait != nil {
+				return nil, errWait
+			}
+		}
+		if lastCreditsErr != nil {
+			return nil, lastCreditsErr
+		}
+		return nil, &Error{Code: "credits_exhausted", Message: "all credits candidates exhausted"}
+	}
+
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
@@ -1314,7 +1366,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	}
 	if lastErr != nil {
 		if hasAntigravityProvider(normalized) && shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
-			if result, ok := m.tryAntigravityCreditsExecuteStream(ctx, req, opts); ok {
+			if result, ok, _ := m.tryAntigravityCreditsExecuteStream(ctx, req, opts); ok {
 				return result, nil
 			}
 		}
@@ -3748,12 +3800,13 @@ func shouldAttemptAntigravityCreditsFallback(m *Manager, lastErr error, provider
 	}
 }
 
-func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, bool) {
+func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, bool, error) {
 	routeModel := req.Model
 	candidates := m.findAllAntigravityCreditsCandidateAuths(routeModel, opts)
+	var lastErr error
 	for _, c := range candidates {
 		if ctx.Err() != nil {
-			return cliproxyexecutor.Response{}, false
+			return cliproxyexecutor.Response{}, false, ctx.Err()
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
@@ -3779,6 +3832,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
 			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
+				lastErr = errExec
 				result.Error = &Error{Message: errExec.Error()}
 				if se, ok := errors.AsType[cliproxyexecutor.StatusError](errExec); ok && se != nil {
 					result.Error.HTTPStatus = se.StatusCode()
@@ -3790,18 +3844,19 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 				continue
 			}
 			m.MarkResult(creditsCtx, result)
-			return resp, true
+			return resp, true, nil
 		}
 	}
-	return cliproxyexecutor.Response{}, false
+	return cliproxyexecutor.Response{}, false, lastErr
 }
 
-func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, bool) {
+func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, bool, error) {
 	routeModel := req.Model
 	candidates := m.findAllAntigravityCreditsCandidateAuths(routeModel, opts)
+	var lastErr error
 	for _, c := range candidates {
 		if ctx.Err() != nil {
-			return nil, false
+			return nil, false, ctx.Err()
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
@@ -3821,11 +3876,29 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		}
 		result, errStream := m.executeStreamWithModelPool(creditsCtx, c.executor, c.auth, c.provider, req, creditsOpts, routeModel, models, len(models) > 1)
 		if errStream != nil {
+			lastErr = errStream
 			continue
 		}
-		return result, true
+		return result, true, nil
 	}
-	return nil, false
+	return nil, false, lastErr
+}
+
+func (m *Manager) isAntigravityCreditsFirst(providers []string, model string) bool {
+	if m == nil {
+		return false
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil || !cfg.QuotaExceeded.AntigravityCredits {
+		return false
+	}
+	if cfg.QuotaExceeded.AntigravityCreditsStickSeconds >= 0 {
+		return false
+	}
+	if !strings.Contains(strings.ToLower(strings.TrimSpace(model)), "claude") {
+		return false
+	}
+	return hasAntigravityProvider(providers)
 }
 
 func (m *Manager) persist(ctx context.Context, auth *Auth) error {


### PR DESCRIPTION
## Summary

- Add `antigravity-credits-stick-seconds` config option. When set to `-1`, Claude model requests skip free-tier entirely and go directly through credits candidates
- Credits-first path has full retry+cooldown support (same `shouldRetryAfterError` + `waitForCooldown` mechanism), only considering antigravity auth cooldowns during retry decisions
- `tryAntigravityCreditsExecute` / `tryAntigravityCreditsExecuteStream` now return `error` to support outer retry loop decisions
- Hot-reload supported via `config_diff.go`

## Design

| Config value | Behavior |
|---|---|
| `0` (default) | Disabled — original behavior (free-tier first, credits fallback) |
| `-1` | Credits-first — skip free-tier, retry credits with cooldown on failure |

### Why not fall through to free-tier on credits failure

When a user sets `-1`, they explicitly want credits-only. If credits are 429'd, free-tier is almost certainly also exhausted (that's why credits mode is needed). Falling through would add latency without benefit.

### Differences from #3434

This is a simplified reimplementation that only supports `-1` (not timed sticky windows), avoiding the issues identified in #3434:
- No per-auth sticky state tracking → no `sync.Map` timestamps
- No `wrapCreditsStreamForStickyMark` → no goroutine leak risk
- `-1` tries ALL credits candidates → `creditsFirst` flag skipping fallback doesn't miss any auth
- Built on current dev (v7.1.22) with `prepareRequestAuth` support

## Changed files

| File | Change |
|---|---|
| `config.example.yaml` | Add config example |
| `internal/config/config.go` | Add `AntigravityCreditsStickSeconds` field |
| `internal/watcher/diff/config_diff.go` | Hot-reload diff tracking |
| `sdk/cliproxy/auth/conductor.go` | Credits-first path + retry loop, updated function signatures |

## Test plan

- [x] `antigravity-credits-stick-seconds: 0` — verify original behavior unchanged
- [x] `antigravity-credits-stick-seconds: -1` with Claude model — verify requests skip free-tier, use credits directly
- [x] Credits 429 → verify retry+cooldown works (logs show wait then retry)
- [x] Credits retries exhausted → verify error returned (not fall through to free-tier)
- [x] Non-Claude model with `-1` → verify original behavior (credits-first only applies to Claude)
- [x] Hot-reload: change value at runtime → verify new behavior takes effect without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)