### PR TITLE
fix(openai-compat): inherit static thinking support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -589,7 +589,7 @@ type OpenAICompatibilityModel struct {
 	Image bool `yaml:"image,omitempty" json:"image,omitempty"`
 
 	// Thinking configures the thinking/reasoning capability for this model.
-	// If nil, the model defaults to level-based reasoning with levels ["low", "medium", "high"].
+	// If nil, static model definitions are reused when available; otherwise levels default to ["low", "medium", "high"].
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -21,7 +21,12 @@ func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) str
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + fmt.Sprintf("image=%t", model.Image))
+			thinking := ""
+			if model.Thinking != nil {
+				data, _ := json.Marshal(model.Thinking)
+				thinking = string(data)
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + fmt.Sprintf("image=%t", model.Image) + "|thinking=" + thinking)
 		}
 	})
 	return hashJoined(keys)

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 func TestComputeOpenAICompatModelsHash_Deterministic(t *testing.T) {
@@ -33,6 +34,23 @@ func TestComputeOpenAICompatModelsHash_IncludesImageFlag(t *testing.T) {
 	}
 	if textModel == imageModel {
 		t.Fatal("hash should change when image flag changes")
+	}
+}
+
+func TestComputeOpenAICompatModelsHash_IncludesThinking(t *testing.T) {
+	low := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{
+		Name:     "gpt-5.5",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low"}},
+	}})
+	xhigh := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{
+		Name:     "gpt-5.5",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "xhigh"}},
+	}})
+	if low == "" || xhigh == "" {
+		t.Fatal("hashes should not be empty")
+	}
+	if low == xhigh {
+		t.Fatal("hash should change when thinking support changes")
 	}
 }
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -379,6 +379,21 @@ func openAICompatInfoFromAuth(a *coreauth.Auth) (providerKey string, compatName 
 	return "", "", false
 }
 
+// shouldRefreshAuthForModelCatalogChange reports whether an auth's model
+// registration depends on refreshed static catalog data. OpenAI-compatible
+// configured models may inherit thinking metadata from any static provider.
+func shouldRefreshAuthForModelCatalogChange(auth *coreauth.Auth, changedProviders map[string]bool) bool {
+	if auth == nil || len(changedProviders) == 0 {
+		return false
+	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	if changedProviders[provider] {
+		return true
+	}
+	_, _, isCompat := openAICompatInfoFromAuth(auth)
+	return isCompat
+}
+
 func (s *Service) ensureExecutorsForAuth(a *coreauth.Auth) {
 	s.ensureExecutorsForAuthWithMode(a, false)
 }
@@ -873,8 +888,7 @@ func (s *Service) Run(ctx context.Context) error {
 			if !ok || auth == nil || auth.Disabled {
 				continue
 			}
-			provider := strings.ToLower(strings.TrimSpace(auth.Provider))
-			if !providerSet[provider] {
+			if !shouldRefreshAuthForModelCatalogChange(auth, providerSet) {
 				continue
 			}
 			if s.refreshModelRegistrationForAuth(auth) {
@@ -1582,7 +1596,7 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 					thinking = upstream.Thinking
 				}
 			}
-			if thinking == nil && modelID != name {
+			if thinking == nil && name == "" {
 				if upstream := registry.LookupStaticModelInfo(modelID); upstream != nil && upstream.Thinking != nil {
 					thinking = upstream.Thinking
 				}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1576,12 +1576,13 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		}
 		thinking := model.Thinking
 		if thinking == nil && !model.Image {
-			if name := strings.TrimSpace(model.Name); name != "" {
+			name := strings.TrimSpace(model.Name)
+			if name != "" {
 				if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
 					thinking = upstream.Thinking
 				}
 			}
-			if thinking == nil {
+			if thinking == nil && modelID != name {
 				if upstream := registry.LookupStaticModelInfo(modelID); upstream != nil && upstream.Thinking != nil {
 					thinking = upstream.Thinking
 				}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1576,7 +1576,19 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		}
 		thinking := model.Thinking
 		if thinking == nil && !model.Image {
-			thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+			if name := strings.TrimSpace(model.Name); name != "" {
+				if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
+					thinking = upstream.Thinking
+				}
+			}
+			if thinking == nil {
+				if upstream := registry.LookupStaticModelInfo(modelID); upstream != nil && upstream.Thinking != nil {
+					thinking = upstream.Thinking
+				}
+			}
+			if thinking == nil {
+				thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+			}
 		}
 		models = append(models, &ModelInfo{
 			ID:          modelID,

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -132,3 +132,40 @@ func TestRegisterModelsForAuth_OpenAICompatibilityImageModelType(t *testing.T) {
 		t.Fatal("expected chat model to keep default thinking support")
 	}
 }
+
+func TestBuildOpenAICompatibilityConfigModels_InheritsStaticThinking(t *testing.T) {
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "gpt-5.5"},
+			{
+				Name:  "gpt-5.5",
+				Alias: "explicit-gpt-5.5",
+				Thinking: &internalregistry.ThinkingSupport{
+					Levels: []string{"low"},
+				},
+			},
+		},
+	})
+	if len(models) != 2 {
+		t.Fatalf("models len = %d, want 2", len(models))
+	}
+
+	if models[0].Thinking == nil {
+		t.Fatal("expected gpt-5.5 to inherit static thinking support")
+	}
+	hasXHigh := false
+	for _, level := range models[0].Thinking.Levels {
+		if level == "xhigh" {
+			hasXHigh = true
+			break
+		}
+	}
+	if !hasXHigh {
+		t.Fatalf("gpt-5.5 thinking levels = %v, want xhigh", models[0].Thinking.Levels)
+	}
+
+	if got := models[1].Thinking.Levels; len(got) != 1 || got[0] != "low" {
+		t.Fatalf("explicit thinking levels = %v, want [low]", got)
+	}
+}

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -137,7 +137,7 @@ func TestBuildOpenAICompatibilityConfigModels_InheritsStaticThinking(t *testing.
 	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
 		Name: "compat",
 		Models: []config.OpenAICompatibilityModel{
-			{Name: "gpt-5.5"},
+			{Name: "gpt-5.5", Alias: "static-gpt-5.5"},
 			{
 				Name:  "gpt-5.5",
 				Alias: "explicit-gpt-5.5",
@@ -145,14 +145,15 @@ func TestBuildOpenAICompatibilityConfigModels_InheritsStaticThinking(t *testing.
 					Levels: []string{"low"},
 				},
 			},
+			{Name: "custom-upstream", Alias: "gpt-5.5"},
 		},
 	})
-	if len(models) != 2 {
-		t.Fatalf("models len = %d, want 2", len(models))
+	if len(models) != 3 {
+		t.Fatalf("models len = %d, want 3", len(models))
 	}
 
 	if models[0].Thinking == nil {
-		t.Fatal("expected gpt-5.5 to inherit static thinking support")
+		t.Fatal("expected static-gpt-5.5 to inherit static thinking support")
 	}
 	hasXHigh := false
 	for _, level := range models[0].Thinking.Levels {
@@ -162,10 +163,42 @@ func TestBuildOpenAICompatibilityConfigModels_InheritsStaticThinking(t *testing.
 		}
 	}
 	if !hasXHigh {
-		t.Fatalf("gpt-5.5 thinking levels = %v, want xhigh", models[0].Thinking.Levels)
+		t.Fatalf("static-gpt-5.5 thinking levels = %v, want xhigh", models[0].Thinking.Levels)
 	}
 
 	if got := models[1].Thinking.Levels; len(got) != 1 || got[0] != "low" {
 		t.Fatalf("explicit thinking levels = %v, want [low]", got)
+	}
+
+	if models[2].Thinking == nil {
+		t.Fatal("expected custom-upstream alias to keep default thinking support")
+	}
+	for _, level := range models[2].Thinking.Levels {
+		if level == "xhigh" {
+			t.Fatalf("custom-upstream alias thinking levels = %v, want no inherited xhigh", models[2].Thinking.Levels)
+		}
+	}
+}
+
+func TestShouldRefreshAuthForModelCatalogChange(t *testing.T) {
+	changedProviders := map[string]bool{"codex": true}
+
+	if !shouldRefreshAuthForModelCatalogChange(&coreauth.Auth{Provider: "codex"}, changedProviders) {
+		t.Fatal("expected direct codex auth to refresh")
+	}
+	if !shouldRefreshAuthForModelCatalogChange(&coreauth.Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"compat_name":  "compat",
+			"provider_key": "compat",
+		},
+	}, changedProviders) {
+		t.Fatal("expected openai-compatible auth to refresh after static catalog change")
+	}
+	if shouldRefreshAuthForModelCatalogChange(&coreauth.Auth{Provider: "gemini"}, changedProviders) {
+		t.Fatal("did not expect unrelated provider auth to refresh")
+	}
+	if shouldRefreshAuthForModelCatalogChange(&coreauth.Auth{Provider: "openai-compatibility"}, nil) {
+		t.Fatal("did not expect refresh without changed providers")
 	}
 }


### PR DESCRIPTION
## Summary
- Inherit static model thinking support for OpenAI-compatible configured models before falling back to the generic low/medium/high default
- Include OpenAI-compatible model thinking metadata in the hot-reload model hash
- Add regressions for gpt-5.5 xhigh inheritance and thinking hash changes

## Tests
- `go test ./sdk/cliproxy ./internal/watcher/diff`
- `go build -o test-output ./cmd/server && rm test-output`
- `git diff --check`