### PR TITLE
fix(translator): preserve reasoning_content across Codex Responses round-trip

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -74,6 +74,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 		pendingToolCallIDs := make([]string, 0)
 		awaitingToolOutputs := make(map[string]struct{})
 		deferredMessages := make([][]byte, 0)
+		pendingReasoningContent := ""
 
 		flushPendingToolCalls := func() {
 			if len(pendingToolCalls) == 0 {
@@ -81,6 +82,10 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			}
 			assistantMessage := []byte(`{"role":"assistant","tool_calls":[]}`)
 			assistantMessage, _ = sjson.SetBytes(assistantMessage, "tool_calls", pendingToolCalls)
+			if pendingReasoningContent != "" {
+				assistantMessage, _ = sjson.SetBytes(assistantMessage, "reasoning_content", pendingReasoningContent)
+				pendingReasoningContent = ""
+			}
 			out, _ = sjson.SetRawBytes(out, "messages.-1", assistantMessage)
 			for _, id := range pendingToolCallIDs {
 				if strings.TrimSpace(id) == "" {
@@ -125,6 +130,24 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			}
 
 			switch itemType {
+			case "reasoning":
+				// Collect reasoning content from summary text or encrypted_content.
+				// Codex preserves encrypted_content but strips summary text, so try both.
+				ecText := item.Get("encrypted_content").String()
+				if summary := item.Get("summary"); summary.Exists() && summary.IsArray() {
+					for _, part := range summary.Array() {
+						if t := part.Get("text").String(); t != "" {
+							if pendingReasoningContent != "" {
+								pendingReasoningContent += "\n"
+							}
+							pendingReasoningContent += t
+						}
+					}
+				}
+				// Fallback: use encrypted_content if summary was empty (Codex strips summary).
+				if pendingReasoningContent == "" && ecText != "" {
+					pendingReasoningContent = ecText
+				}
 			case "message", "":
 				// Handle regular message conversion
 				role := item.Get("role").String()
@@ -170,6 +193,12 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					message, _ = sjson.SetBytes(message, "content", content.String())
 				}
 
+				if role == "assistant" && pendingReasoningContent != "" {
+					message, _ = sjson.SetBytes(message, "reasoning_content", pendingReasoningContent)
+				} else if role != "assistant" && role != "tool" {
+					// Clear reasoning content when moving to a new non-assistant turn.
+					pendingReasoningContent = ""
+				}
 				appendRegularMessage(message)
 
 			case "function_call":

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -342,6 +342,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 		outputItemDone, _ = sjson.SetBytes(outputItemDone, "item.id", st.ReasoningID)
 		outputItemDone, _ = sjson.SetBytes(outputItemDone, "output_index", st.ReasoningIndex)
 		outputItemDone, _ = sjson.SetBytes(outputItemDone, "item.summary.text", text)
+		outputItemDone, _ = sjson.SetBytes(outputItemDone, "item.encrypted_content", text)
 		out = append(out, emitRespEvent("response.output_item.done", outputItemDone))
 
 		st.Reasonings = append(st.Reasonings, oaiToResponsesStateReasoning{ReasoningID: st.ReasoningID, ReasoningData: text, OutputIndex: st.ReasoningIndex})
@@ -728,12 +729,13 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 		if strings.HasPrefix(rid, "resp_") {
 			rid = strings.TrimPrefix(rid, "resp_")
 		}
-		// Prefer summary_text from reasoning_content; encrypted_content is optional
+		// Fill encrypted_content with reasoning text so Codex clients preserve it across turns.
 		reasoningItem := []byte(`{"id":"","type":"reasoning","encrypted_content":"","summary":[]}`)
 		reasoningItem, _ = sjson.SetBytes(reasoningItem, "id", fmt.Sprintf("rs_%s", rid))
 		if rcText != "" {
 			reasoningItem, _ = sjson.SetBytes(reasoningItem, "summary.0.type", "summary_text")
 			reasoningItem, _ = sjson.SetBytes(reasoningItem, "summary.0.text", rcText)
+			reasoningItem, _ = sjson.SetBytes(reasoningItem, "encrypted_content", rcText)
 		}
 		outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", reasoningItem)
 	}


### PR DESCRIPTION
## Problem

Codex clients using the Responses API (`/v1/responses`) with DeepSeek V4 thinking models fail on multi-turn conversations with:

```
Error from provider (DeepSeek): The `reasoning_content` in the thinking mode must be passed back to the API.
```

Root cause: Codex clients discard reasoning item `summary.text` but retain `encrypted_content` between turns. The response translator only populated `summary.text` and left `encrypted_content` empty. The request translator also had no reasoning item handler at all.

## Changes

### Response translator (both streaming and non-streaming)
- Populate `encrypted_content` with the same text as `summary.text` in reasoning output items

### Request translator
- Add `case "reasoning":` handler for input items
- Extract reasoning content from `summary.text` first, falling back to `encrypted_content` (Codex behavior)
- Attach `reasoning_content` to the next assistant message (both regular text and tool_calls)

## Verification
- [x] Existing tests pass
- [x] Tested end-to-end with Codex CLI v0.125.0 + DeepSeek V4 Pro via OpenAI-compatible provider: multi-turn conversations with tool calls no longer fail

## Related Issues
- Fixes #2999
- Fixes #3451