### PR TITLE
feat(codex): prefer upstream websockets for responses

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -133,6 +133,10 @@ ws-auth: true
 # Default is false for safety.
 enable-gemini-cli-endpoint: false
 
+# When true, ordinary HTTP/SSE /v1/responses requests prefer Codex credentials
+# marked with websockets=true and use the upstream websocket transport.
+codex-prefer-upstream-websockets: false
+
 # When > 0, emit blank lines every N seconds for non-streaming responses to prevent idle timeouts.
 nonstream-keepalive-interval: 0
 # Streaming behavior (SSE keep-alives + safe bootstrap retries).
@@ -176,6 +180,7 @@ nonstream-keepalive-interval: 0
 #     prefix: "test" # optional: require calls like "test/gpt-5-codex" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
+#     websockets: true # optional: allow this credential to use the Codex Responses websocket transport
 #     headers:
 #       X-Custom-Header: "custom-value"
 #     proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -35,6 +35,10 @@ type SDKConfig struct {
 	// credentials as well.
 	ForceModelPrefix bool `yaml:"force-model-prefix" json:"force-model-prefix"`
 
+	// CodexPreferUpstreamWebsockets allows ordinary HTTP/SSE Responses requests to prefer
+	// Codex credentials marked with websockets=true and use the upstream websocket transport.
+	CodexPreferUpstreamWebsockets bool `yaml:"codex-prefer-upstream-websockets" json:"codex-prefer-upstream-websockets"`
+
 	// RequestLog enables or disables detailed request logging functionality.
 	RequestLog bool `yaml:"request-log" json:"request-log"`
 

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -1558,10 +1558,11 @@ func CloseCodexWebsocketSessionsForAuthID(authID string, reason string) {
 }
 
 // CodexAutoExecutor routes Codex requests to the websocket transport only when:
-//  1. The downstream transport is websocket, and
+//  1. The downstream transport is websocket or upstream websocket transport is preferred, and
 //  2. The selected auth enables websockets.
 //
-// For non-websocket downstream requests, it always uses the legacy HTTP implementation.
+// For non-websocket downstream requests without an upstream websocket preference, it uses the
+// legacy HTTP implementation.
 type CodexAutoExecutor struct {
 	httpExec *CodexExecutor
 	wsExec   *CodexWebsocketsExecutor
@@ -1594,7 +1595,7 @@ func (e *CodexAutoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth
 	if e == nil || e.httpExec == nil || e.wsExec == nil {
 		return cliproxyexecutor.Response{}, fmt.Errorf("codex auto executor: executor is nil")
 	}
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
+	if codexShouldUseWebsockets(ctx, auth) {
 		return e.wsExec.Execute(ctx, auth, req, opts)
 	}
 	return e.httpExec.Execute(ctx, auth, req, opts)
@@ -1604,7 +1605,7 @@ func (e *CodexAutoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyaut
 	if e == nil || e.httpExec == nil || e.wsExec == nil {
 		return nil, fmt.Errorf("codex auto executor: executor is nil")
 	}
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
+	if codexShouldUseWebsockets(ctx, auth) {
 		return e.wsExec.ExecuteStream(ctx, auth, req, opts)
 	}
 	return e.httpExec.ExecuteStream(ctx, auth, req, opts)
@@ -1668,4 +1669,11 @@ func codexWebsocketsEnabled(auth *cliproxyauth.Auth) bool {
 	default:
 	}
 	return false
+}
+
+func codexShouldUseWebsockets(ctx context.Context, auth *cliproxyauth.Auth) bool {
+	if !codexWebsocketsEnabled(auth) {
+		return false
+	}
+	return cliproxyexecutor.DownstreamWebsocket(ctx) || cliproxyexecutor.PreferUpstreamWebsocket(ctx)
 }

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -403,7 +403,13 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("codex")
-	body := req.Payload
+	originalPayloadSource := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayloadSource = opts.OriginalRequest
+	}
+	originalPayload := originalPayloadSource
+	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
+	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 
 	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -412,7 +418,11 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
-	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, body, requestedModel, requestPath, opts.Headers)
+	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
+	body, _ = sjson.SetBytes(body, "model", baseModel)
+	body, _ = sjson.SetBytes(body, "stream", true)
+	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
+	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body = normalizeCodexInstructions(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
@@ -635,7 +645,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 
 			line := encodeCodexWebsocketAsSSE(payload)
-			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, body, body, line, &param)
+			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, originalPayload, body, line, &param)
 			for i := range chunks {
 				if !send(cliproxyexecutor.StreamChunk{Payload: chunks[i]}) {
 					terminateReason = "context_done"

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -255,6 +255,10 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	helps.RecordAPIWebsocketRequest(ctx, e.cfg, wsReqLog)
 
 	conn, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
+	var upstreamHeaders http.Header
+	if respHS != nil {
+		upstreamHeaders = respHS.Header.Clone()
+	}
 	if errDial != nil {
 		bodyErr := websocketHandshakeBody(respHS)
 		if respHS != nil {
@@ -301,6 +305,9 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			// execution session.
 			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
 			if errDialRetry == nil && connRetry != nil {
+				if respHSRetry != nil {
+					upstreamHeaders = respHSRetry.Header.Clone()
+				}
 				wsReqBodyRetry := buildCodexWebsocketRequestBody(body)
 				helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
 					URL:       wsURL,
@@ -364,6 +371,15 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		reporter.MarkFirstResponseByte()
 		helps.AppendAPIWebsocketResponse(ctx, e.cfg, payload)
 
+		if streamErr, ok := codexTerminalStreamContextLengthErr(payload); ok {
+			err = streamErr
+			if sess != nil {
+				e.invalidateUpstreamConn(sess, conn, "upstream_error", err)
+			}
+			helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", err)
+			return resp, err
+		}
+
 		if wsErr, ok := parseCodexWebsocketError(payload); ok {
 			if sess != nil {
 				e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
@@ -378,14 +394,22 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			collectCodexOutputItemDone(payload, outputItemsByIndex, &outputItemsFallback)
 			continue
 		}
+		if wsErr, ok := codexWebsocketTerminalError(payload); ok {
+			if sess != nil {
+				e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
+			}
+			helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
+			return resp, wsErr
+		}
 		if eventType == "response.completed" {
 			payload = patchCodexCompletedOutput(payload, outputItemsByIndex, outputItemsFallback)
 			if detail, ok := helps.ParseCodexUsage(payload); ok {
 				reporter.Publish(ctx, detail)
 			}
+			publishCodexImageToolUsage(ctx, reporter, body, payload)
 			var param any
 			out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, originalPayload, body, payload, &param)
-			resp = cliproxyexecutor.Response{Payload: out}
+			resp = cliproxyexecutor.Response{Payload: out, Headers: upstreamHeaders}
 			return resp, nil
 		}
 	}
@@ -1096,6 +1120,29 @@ func parseCodexWebsocketError(payload []byte) (error, bool) {
 		statusErr: statusError,
 		headers:   headers,
 	}, true
+}
+
+func codexWebsocketTerminalError(payload []byte) (error, bool) {
+	eventType := strings.TrimSpace(gjson.GetBytes(payload, "type").String())
+	var body []byte
+	switch eventType {
+	case "error":
+		body = codexTerminalErrorBody(payload, "error")
+		if len(body) == 0 {
+			body = codexTerminalTopLevelErrorBody(payload)
+		}
+	case "response.failed":
+		body = codexTerminalErrorBody(payload, "response.error")
+		if len(body) == 0 {
+			body = codexTerminalErrorBody(payload, "error")
+		}
+	default:
+		return nil, false
+	}
+	if len(body) == 0 {
+		body = bytes.Clone(payload)
+	}
+	return newCodexStatusErr(http.StatusBadGateway, body), true
 }
 
 func buildCodexWebsocketErrorPayload(payload []byte, status int) []byte {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -209,6 +209,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	body, _ = sjson.SetBytes(body, "stream", true)
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
+	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = normalizeCodexInstructions(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
@@ -423,6 +424,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	body, _ = sjson.SetBytes(body, "stream", true)
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
+	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = normalizeCodexInstructions(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -334,6 +334,8 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		}
 	}
 
+	outputItemsByIndex := make(map[int64][]byte)
+	var outputItemsFallback [][]byte
 	for {
 		if ctx != nil && ctx.Err() != nil {
 			return resp, ctx.Err()
@@ -372,7 +374,12 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 
 		payload = normalizeCodexWebsocketCompletion(payload)
 		eventType := gjson.GetBytes(payload, "type").String()
+		if eventType == "response.output_item.done" {
+			collectCodexOutputItemDone(payload, outputItemsByIndex, &outputItemsFallback)
+			continue
+		}
 		if eventType == "response.completed" {
+			payload = patchCodexCompletedOutput(payload, outputItemsByIndex, outputItemsFallback)
 			if detail, ok := helps.ParseCodexUsage(payload); ok {
 				reporter.Publish(ctx, detail)
 			}

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -149,6 +149,93 @@ func TestCodexAutoExecutorPreferUpstreamWebsocketUsesWebsocketTransport(t *testi
 	}
 }
 
+func TestCodexAutoExecutorPreferUpstreamWebsocketStreamTranslatesOpenAIResponses(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	capturedPayload := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Fatalf("request path = %s, want /responses", r.URL.Path)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		msgType, payload, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read upstream websocket message: %v", err)
+		}
+		if msgType != websocket.TextMessage {
+			t.Fatalf("message type = %d, want text", msgType)
+		}
+		capturedPayload <- bytes.Clone(payload)
+
+		completed := []byte(`{"type":"response.completed","response":{"id":"resp-2","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+			t.Fatalf("write completed websocket message: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexAutoExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":    "sk-test",
+		"base_url":   server.URL,
+		"websockets": "true",
+	}}
+	req := cliproxyexecutor.Request{
+		Model: "gpt-5-codex",
+		Payload: []byte(`{
+			"model":"gpt-5-codex",
+			"input":[
+				{"type":"message","role":"system","content":[{"type":"input_text","text":"Be concise."}]},
+				{"type":"message","role":"user","content":[{"type":"input_text","text":"Hello"}]}
+			],
+			"max_output_tokens":128,
+			"temperature":0.2,
+			"context_management":{"compaction":{"type":"auto"}}
+		}`),
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response"), Stream: true}
+	ctx := cliproxyexecutor.WithPreferUpstreamWebsocket(context.Background())
+
+	result, err := exec.ExecuteStream(ctx, auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var payload []byte
+	select {
+	case payload = <-capturedPayload:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upstream websocket payload")
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+	}
+
+	if got := gjson.GetBytes(payload, "type").String(); got != "response.create" {
+		t.Fatalf("upstream type = %s, want response.create; payload=%s", got, payload)
+	}
+	if got := gjson.GetBytes(payload, "input.0.role").String(); got != "developer" {
+		t.Fatalf("upstream input.0.role = %s, want developer; payload=%s", got, payload)
+	}
+	for _, path := range []string{"max_output_tokens", "temperature", "context_management"} {
+		if gjson.GetBytes(payload, path).Exists() {
+			t.Fatalf("upstream %s should be stripped; payload=%s", path, payload)
+		}
+	}
+	if got := gjson.GetBytes(payload, "model").String(); got != "gpt-5-codex" {
+		t.Fatalf("upstream model = %s, want gpt-5-codex; payload=%s", got, payload)
+	}
+	if !gjson.GetBytes(payload, "stream").Bool() {
+		t.Fatalf("upstream stream should be true; payload=%s", payload)
+	}
+}
+
 func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -149,6 +150,55 @@ func TestCodexAutoExecutorPreferUpstreamWebsocketUsesWebsocketTransport(t *testi
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for upstream websocket payload")
+	}
+}
+
+func TestCodexAutoExecutorPreferUpstreamWebsocketNonStreamUsesOutputItemDone(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Fatalf("request path = %s, want /responses", r.URL.Path)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			t.Fatalf("read upstream websocket message: %v", errRead)
+		}
+
+		itemDone := []byte(`{"type":"response.output_item.done","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]},"output_index":0}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, itemDone); errWrite != nil {
+			t.Fatalf("write output_item.done websocket message: %v", errWrite)
+		}
+		completed := []byte(`{"type":"response.completed","response":{"id":"resp-2","object":"response","created_at":1775555723,"status":"completed","model":"gpt-5-codex","output":[],"usage":{"input_tokens":8,"output_tokens":28,"total_tokens":36}}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+			t.Fatalf("write completed websocket message: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexAutoExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":    "sk-test",
+		"base_url":   server.URL,
+		"websockets": "true",
+	}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"Say ok"}]}]}`),
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response")}
+	ctx := cliproxyexecutor.WithPreferUpstreamWebsocket(context.Background())
+
+	resp, err := exec.Execute(ctx, auth, req, opts)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := gjson.GetBytes(resp.Payload, "output.0.content.0.text").String(); got != "ok" {
+		t.Fatalf("response output text = %q, want %q; payload=%s", got, "ok", resp.Payload)
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -93,6 +93,62 @@ func TestCodexWebsocketsExecutePreservesPreviousResponseIDUpstream(t *testing.T)
 	}
 }
 
+func TestCodexAutoExecutorPreferUpstreamWebsocketUsesWebsocketTransport(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	capturedPayload := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Fatalf("request path = %s, want /responses", r.URL.Path)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		msgType, payload, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read upstream websocket message: %v", err)
+		}
+		if msgType != websocket.TextMessage {
+			t.Fatalf("message type = %d, want text", msgType)
+		}
+		capturedPayload <- bytes.Clone(payload)
+
+		completed := []byte(`{"type":"response.completed","response":{"id":"resp-2","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+			t.Fatalf("write completed websocket message: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexAutoExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":    "sk-test",
+		"base_url":   server.URL,
+		"websockets": "true",
+	}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","role":"user","content":"hello"}]}`),
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("codex")}
+	ctx := cliproxyexecutor.WithPreferUpstreamWebsocket(context.Background())
+
+	if _, err := exec.Execute(ctx, auth, req, opts); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	select {
+	case payload := <-capturedPayload:
+		if got := gjson.GetBytes(payload, "type").String(); got != "response.create" {
+			t.Fatalf("upstream type = %s, want response.create; payload=%s", got, payload)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upstream websocket payload")
+	}
+}
+
 func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -148,6 +204,20 @@ func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) 
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for disconnect signal")
+	}
+}
+
+func TestCodexShouldUseWebsocketsRequiresTransportPreference(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"websockets": "true"}}
+
+	if codexShouldUseWebsockets(context.Background(), auth) {
+		t.Fatal("plain context unexpectedly uses websocket transport")
+	}
+	if !codexShouldUseWebsockets(cliproxyexecutor.WithPreferUpstreamWebsocket(context.Background()), auth) {
+		t.Fatal("prefer upstream websocket context did not use websocket transport")
+	}
+	if !codexShouldUseWebsockets(cliproxyexecutor.WithDownstreamWebsocket(context.Background()), auth) {
+		t.Fatal("downstream websocket context did not use websocket transport")
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -153,6 +153,48 @@ func TestCodexAutoExecutorPreferUpstreamWebsocketUsesWebsocketTransport(t *testi
 	}
 }
 
+func TestCodexWebsocketsExecutePreservesHandshakeHeaders(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Fatalf("request path = %s, want /responses", r.URL.Path)
+		}
+		responseHeaders := http.Header{}
+		responseHeaders.Set("X-Upstream-Test", "ok")
+		conn, err := upgrader.Upgrade(w, r, responseHeaders)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			t.Fatalf("read upstream websocket message: %v", errRead)
+		}
+
+		completed := []byte(`{"type":"response.completed","response":{"id":"resp-2","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+			t.Fatalf("write completed websocket message: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","role":"user","content":"hello"}]}`),
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("codex")}
+
+	resp, err := exec.Execute(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := resp.Headers.Get("X-Upstream-Test"); got != "ok" {
+		t.Fatalf("X-Upstream-Test = %q, want ok; headers=%v", got, resp.Headers)
+	}
+}
+
 func TestCodexAutoExecutorPreferUpstreamWebsocketNonStreamUsesOutputItemDone(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -199,6 +241,50 @@ func TestCodexAutoExecutorPreferUpstreamWebsocketNonStreamUsesOutputItemDone(t *
 	}
 	if got := gjson.GetBytes(resp.Payload, "output.0.content.0.text").String(); got != "ok" {
 		t.Fatalf("response output text = %q, want %q; payload=%s", got, "ok", resp.Payload)
+	}
+}
+
+func TestCodexWebsocketsExecuteSurfacesTerminalContextLengthError(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Fatalf("request path = %s, want /responses", r.URL.Path)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			t.Fatalf("read upstream websocket message: %v", errRead)
+		}
+
+		failed := []byte(`{"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again."}}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, failed); errWrite != nil {
+			t.Fatalf("write failed websocket message: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","role":"user","content":"hello"}]}`),
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response")}
+
+	_, err := exec.Execute(context.Background(), auth, req, opts)
+	if err == nil {
+		t.Fatal("expected terminal stream error, got nil")
+	}
+	if got := statusCodeFromTestError(t, err); got != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusBadRequest, err)
+	}
+	assertCodexErrorCode(t, err.Error(), "invalid_request_error", "context_too_large")
+	if !strings.Contains(err.Error(), "Your input exceeds the context window") {
+		t.Fatalf("error message missing upstream context text: %v", err)
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -130,7 +130,7 @@ func TestCodexAutoExecutorPreferUpstreamWebsocketUsesWebsocketTransport(t *testi
 	}}
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5-codex",
-		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","role":"user","content":"hello"}]}`),
+		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","role":"user","content":"hello"}],"stream_options":{"include_usage":true}}`),
 	}
 	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("codex")}
 	ctx := cliproxyexecutor.WithPreferUpstreamWebsocket(context.Background())
@@ -143,6 +143,9 @@ func TestCodexAutoExecutorPreferUpstreamWebsocketUsesWebsocketTransport(t *testi
 	case payload := <-capturedPayload:
 		if got := gjson.GetBytes(payload, "type").String(); got != "response.create" {
 			t.Fatalf("upstream type = %s, want response.create; payload=%s", got, payload)
+		}
+		if gjson.GetBytes(payload, "stream_options").Exists() {
+			t.Fatalf("upstream stream_options should be stripped; payload=%s", payload)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for upstream websocket payload")
@@ -188,14 +191,15 @@ func TestCodexAutoExecutorPreferUpstreamWebsocketStreamTranslatesOpenAIResponses
 		Model: "gpt-5-codex",
 		Payload: []byte(`{
 			"model":"gpt-5-codex",
-			"input":[
-				{"type":"message","role":"system","content":[{"type":"input_text","text":"Be concise."}]},
-				{"type":"message","role":"user","content":[{"type":"input_text","text":"Hello"}]}
-			],
-			"max_output_tokens":128,
-			"temperature":0.2,
-			"context_management":{"compaction":{"type":"auto"}}
-		}`),
+				"input":[
+					{"type":"message","role":"system","content":[{"type":"input_text","text":"Be concise."}]},
+					{"type":"message","role":"user","content":[{"type":"input_text","text":"Hello"}]}
+				],
+				"max_output_tokens":128,
+				"temperature":0.2,
+				"context_management":{"compaction":{"type":"auto"}},
+				"stream_options":{"include_usage":true}
+			}`),
 	}
 	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response"), Stream: true}
 	ctx := cliproxyexecutor.WithPreferUpstreamWebsocket(context.Background())
@@ -223,7 +227,7 @@ func TestCodexAutoExecutorPreferUpstreamWebsocketStreamTranslatesOpenAIResponses
 	if got := gjson.GetBytes(payload, "input.0.role").String(); got != "developer" {
 		t.Fatalf("upstream input.0.role = %s, want developer; payload=%s", got, payload)
 	}
-	for _, path := range []string{"max_output_tokens", "temperature", "context_management"} {
+	for _, path := range []string{"max_output_tokens", "temperature", "context_management", "stream_options"} {
 		if gjson.GetBytes(payload, path).Exists() {
 			t.Fatalf("upstream %s should be stripped; payload=%s", path, payload)
 		}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -78,6 +78,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.ForceModelPrefix != newCfg.ForceModelPrefix {
 		changes = append(changes, fmt.Sprintf("force-model-prefix: %t -> %t", oldCfg.ForceModelPrefix, newCfg.ForceModelPrefix))
 	}
+	if oldCfg.CodexPreferUpstreamWebsockets != newCfg.CodexPreferUpstreamWebsockets {
+		changes = append(changes, fmt.Sprintf("codex-prefer-upstream-websockets: %t -> %t", oldCfg.CodexPreferUpstreamWebsockets, newCfg.CodexPreferUpstreamWebsockets))
+	}
 	if oldCfg.NonStreamKeepAliveInterval != newCfg.NonStreamKeepAliveInterval {
 		changes = append(changes, fmt.Sprintf("nonstream-keepalive-interval: %d -> %d", oldCfg.NonStreamKeepAliveInterval, newCfg.NonStreamKeepAliveInterval))
 	}

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -448,6 +449,7 @@ func (h *OpenAIResponsesAPIHandler) handleNonStreamingResponse(c *gin.Context, r
 
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	cliCtx = h.codexUpstreamWebsocketContext(cliCtx)
 	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
 
 	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
@@ -485,6 +487,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 	// New core execution path
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	cliCtx = h.codexUpstreamWebsocketContext(cliCtx)
 	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
 
 	setSSEHeaders := func() {
@@ -539,6 +542,13 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			return
 		}
 	}
+}
+
+func (h *OpenAIResponsesAPIHandler) codexUpstreamWebsocketContext(ctx context.Context) context.Context {
+	if h == nil || h.Cfg == nil || !h.Cfg.CodexPreferUpstreamWebsockets {
+		return ctx
+	}
+	return cliproxyexecutor.WithPreferUpstreamWebsocket(ctx)
 }
 
 func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage, framer *responsesSSEFramer) {

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"github.com/tidwall/gjson"
 )
@@ -30,6 +32,28 @@ func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *h
 	}
 
 	return h, recorder, c, flusher
+}
+
+func TestCodexUpstreamWebsocketContextFollowsConfig(t *testing.T) {
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexPreferUpstreamWebsockets: true}, nil)
+	h := NewOpenAIResponsesAPIHandler(base)
+
+	ctx := h.codexUpstreamWebsocketContext(context.Background())
+
+	if !cliproxyexecutor.PreferUpstreamWebsocket(ctx) {
+		t.Fatal("expected upstream websocket preference")
+	}
+}
+
+func TestCodexUpstreamWebsocketContextDisabledByDefault(t *testing.T) {
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	h := NewOpenAIResponsesAPIHandler(base)
+
+	ctx := h.codexUpstreamWebsocketContext(context.Background())
+
+	if cliproxyexecutor.PreferUpstreamWebsocket(ctx) {
+		t.Fatal("unexpected upstream websocket preference")
+	}
 }
 
 func TestForwardResponsesStreamSeparatesDataOnlySSEChunks(t *testing.T) {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -227,6 +227,17 @@ func isBuiltInSelector(selector Selector) bool {
 	}
 }
 
+func selectorSupportsCodexWebsocketPreference(selector Selector) bool {
+	switch typed := selector.(type) {
+	case nil, *RoundRobinSelector, *FillFirstSelector:
+		return true
+	case *SessionAffinitySelector:
+		return typed != nil && selectorSupportsCodexWebsocketPreference(typed.fallback)
+	default:
+		return false
+	}
+}
+
 func (m *Manager) syncSchedulerFromSnapshot(auths []*Auth) {
 	if m == nil || m.scheduler == nil {
 		return
@@ -696,6 +707,47 @@ func (m *Manager) availableAuthsForRouteModel(auths []*Auth, provider, routeMode
 		sort.Slice(available, func(i, j int) bool { return available[i].ID < available[j].ID })
 	}
 	return available, nil
+}
+
+func (m *Manager) preferredCodexWebsocketAuthsForRouteModel(ctx context.Context, auths []*Auth, provider, routeModel string, now time.Time) ([]*Auth, bool) {
+	if len(auths) == 0 {
+		return nil, false
+	}
+	if !cliproxyexecutor.DownstreamWebsocket(ctx) && !cliproxyexecutor.PreferUpstreamWebsocket(ctx) {
+		return nil, false
+	}
+	providerKey := strings.TrimSpace(provider)
+	if !strings.EqualFold(providerKey, "codex") && !strings.EqualFold(providerKey, "mixed") {
+		return nil, false
+	}
+
+	wsCandidates := make([]*Auth, 0, len(auths))
+	for _, candidate := range auths {
+		if candidate == nil || !strings.EqualFold(strings.TrimSpace(candidate.Provider), "codex") {
+			continue
+		}
+		if authWebsocketsEnabled(candidate) {
+			wsCandidates = append(wsCandidates, candidate)
+		}
+	}
+	if len(wsCandidates) == 0 {
+		return nil, false
+	}
+
+	available, errAvailable := m.availableAuthsForRouteModel(wsCandidates, provider, routeModel, now)
+	if errAvailable != nil || len(available) == 0 {
+		return nil, false
+	}
+	return available, true
+}
+
+func (m *Manager) availableAuthsForRouteModelWithPreference(ctx context.Context, auths []*Auth, provider, routeModel string, now time.Time) ([]*Auth, error) {
+	if selectorSupportsCodexWebsocketPreference(m.selector) {
+		if preferred, ok := m.preferredCodexWebsocketAuthsForRouteModel(ctx, auths, provider, routeModel, now); ok {
+			return preferred, nil
+		}
+	}
+	return m.availableAuthsForRouteModel(auths, provider, routeModel, now)
 }
 
 func selectionArgForSelector(selector Selector, routeModel string) string {
@@ -3047,7 +3099,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		m.mu.RUnlock()
 		return nil, nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	available, errAvailable := m.availableAuthsForRouteModel(candidates, provider, model, time.Now())
+	available, errAvailable := m.availableAuthsForRouteModelWithPreference(ctx, candidates, provider, model, time.Now())
 	if errAvailable != nil {
 		m.mu.RUnlock()
 		return nil, nil, errAvailable
@@ -3199,7 +3251,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		m.mu.RUnlock()
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	available, errAvailable := m.availableAuthsForRouteModel(candidates, "mixed", model, time.Now())
+	available, errAvailable := m.availableAuthsForRouteModelWithPreference(ctx, candidates, "mixed", model, time.Now())
 	if errAvailable != nil {
 		m.mu.RUnlock()
 		return nil, nil, "", errAvailable

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -244,7 +244,7 @@ func (s *authScheduler) pickSingle(ctx context.Context, provider, model string, 
 	providerKey := strings.ToLower(strings.TrimSpace(provider))
 	modelKey := canonicalModelKey(model)
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
-	preferWebsocket := cliproxyexecutor.DownstreamWebsocket(ctx) && providerKey == "codex" && pinnedAuthID == ""
+	preferWebsocket := (cliproxyexecutor.DownstreamWebsocket(ctx) || cliproxyexecutor.PreferUpstreamWebsocket(ctx)) && providerKey == "codex" && pinnedAuthID == ""
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -334,15 +334,35 @@ func (s *authScheduler) pickMixed(ctx context.Context, providers []string, model
 	bestPriority := 0
 	hasCandidate := false
 	now := time.Now()
-	for providerIndex, providerKey := range normalized {
-		providerState := s.providers[providerKey]
-		if providerState == nil {
-			continue
+	if cliproxyexecutor.DownstreamWebsocket(ctx) || cliproxyexecutor.PreferUpstreamWebsocket(ctx) {
+		for providerIndex, providerKey := range normalized {
+			if providerKey != "codex" {
+				continue
+			}
+			providerState := s.providers[providerKey]
+			if providerState == nil {
+				continue
+			}
+			shard := providerState.ensureModelLocked(modelKey, now)
+			candidateShards[providerIndex] = shard
+			if picked := shard.pickReadyWebsocketLocked(s.strategy, predicate); picked != nil {
+				return picked, providerKey, nil
+			}
+			break
 		}
-		shard := providerState.ensureModelLocked(modelKey, now)
-		candidateShards[providerIndex] = shard
+	}
+	for providerIndex, providerKey := range normalized {
+		shard := candidateShards[providerIndex]
 		if shard == nil {
-			continue
+			providerState := s.providers[providerKey]
+			if providerState == nil {
+				continue
+			}
+			shard = providerState.ensureModelLocked(modelKey, now)
+			candidateShards[providerIndex] = shard
+			if shard == nil {
+				continue
+			}
 		}
 		priorityReady, okPriority := shard.highestReadyPriorityLocked(false, predicate)
 		if !okPriority {
@@ -769,6 +789,21 @@ func (m *modelScheduler) pickReadyLocked(preferWebsocket bool, strategy schedule
 	return m.pickReadyAtPriorityLocked(preferWebsocket, priorityReady, strategy, predicate)
 }
 
+func (m *modelScheduler) pickReadyWebsocketLocked(strategy schedulerStrategy, predicate func(*scheduledAuth) bool) *Auth {
+	if m == nil {
+		return nil
+	}
+	m.promoteExpiredLocked(time.Now())
+	for _, priority := range m.priorityOrder {
+		bucket := m.readyByPriority[priority]
+		if bucket == nil || bucket.ws.pickFirst(predicate) == nil {
+			continue
+		}
+		return m.pickReadyAtPriorityLocked(true, priority, strategy, predicate)
+	}
+	return nil
+}
+
 // highestReadyPriorityLocked returns the highest priority bucket that still has a matching ready auth.
 // The caller must ensure expired entries are already promoted when needed.
 func (m *modelScheduler) highestReadyPriorityLocked(preferWebsocket bool, predicate func(*scheduledAuth) bool) (int, bool) {
@@ -776,8 +811,8 @@ func (m *modelScheduler) highestReadyPriorityLocked(preferWebsocket bool, predic
 		return 0, false
 	}
 	if preferWebsocket {
-		// When downstream is websocket and Codex supports websocket transport, prefer websocket-enabled
-		// credentials even if they are in a lower priority tier than HTTP-only credentials.
+		// When Codex websocket transport is preferred, prefer websocket-enabled credentials
+		// even if they are in a lower priority tier than HTTP-only credentials.
 		for _, priority := range m.priorityOrder {
 			bucket := m.readyByPriority[priority]
 			if bucket == nil {

--- a/sdk/cliproxy/auth/scheduler_test.go
+++ b/sdk/cliproxy/auth/scheduler_test.go
@@ -234,6 +234,70 @@ func TestSchedulerPick_CodexWebsocketPrefersWebsocketEnabledAcrossPriorities(t *
 	}
 }
 
+func TestSchedulerPick_CodexPreferUpstreamWebsocketPrefersWebsocketEnabledSubset(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newSchedulerForTest(
+		&RoundRobinSelector{},
+		&Auth{ID: "codex-http", Provider: "codex", Attributes: map[string]string{"priority": "10"}},
+		&Auth{ID: "codex-ws-a", Provider: "codex", Attributes: map[string]string{"priority": "0", "websockets": "true"}},
+		&Auth{ID: "codex-ws-b", Provider: "codex", Attributes: map[string]string{"priority": "0", "websockets": "true"}},
+	)
+
+	ctx := cliproxyexecutor.WithPreferUpstreamWebsocket(context.Background())
+	want := []string{"codex-ws-a", "codex-ws-b", "codex-ws-a"}
+	for index, wantID := range want {
+		got, errPick := scheduler.pickSingle(ctx, "codex", "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickSingle() #%d error = %v", index, errPick)
+		}
+		if got == nil {
+			t.Fatalf("pickSingle() #%d auth = nil", index)
+		}
+		if got.ID != wantID {
+			t.Fatalf("pickSingle() #%d auth.ID = %q, want %q", index, got.ID, wantID)
+		}
+	}
+}
+
+func TestSchedulerPick_MixedProvidersPreferCodexUpstreamWebsocket(t *testing.T) {
+	t.Parallel()
+
+	model := "gpt-5-codex"
+	registerSchedulerModels(t, "openai-compatible", model, "openai-compat")
+	registerSchedulerModels(t, "codex", model, "codex-http", "codex-ws")
+
+	scheduler := newSchedulerForTest(
+		&RoundRobinSelector{},
+		&Auth{ID: "openai-compat", Provider: "openai-compatible", Attributes: map[string]string{"priority": "10"}},
+		&Auth{ID: "codex-http", Provider: "codex", Attributes: map[string]string{"priority": "10"}},
+		&Auth{ID: "codex-ws", Provider: "codex", Attributes: map[string]string{"priority": "0", "websockets": "true"}},
+	)
+
+	got, provider, errPick := scheduler.pickMixed(context.Background(), []string{"openai-compatible", "codex"}, model, cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickMixed() without preference error = %v", errPick)
+	}
+	if got == nil {
+		t.Fatal("pickMixed() without preference auth = nil")
+	}
+	if provider != "openai-compatible" || got.ID != "openai-compat" {
+		t.Fatalf("pickMixed() without preference = (%q, %q), want (openai-compatible, openai-compat)", provider, got.ID)
+	}
+
+	ctx := cliproxyexecutor.WithPreferUpstreamWebsocket(context.Background())
+	got, provider, errPick = scheduler.pickMixed(ctx, []string{"openai-compatible", "codex"}, model, cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickMixed() with preference error = %v", errPick)
+	}
+	if got == nil {
+		t.Fatal("pickMixed() with preference auth = nil")
+	}
+	if provider != "codex" || got.ID != "codex-ws" {
+		t.Fatalf("pickMixed() with preference = (%q, %q), want (codex, codex-ws)", provider, got.ID)
+	}
+}
+
 func TestSchedulerPick_MixedProvidersUsesWeightedProviderRotationOverReadyCandidates(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/auth/scheduler_test.go
+++ b/sdk/cliproxy/auth/scheduler_test.go
@@ -430,6 +430,90 @@ func TestManager_PickNextMixed_DisallowFreeAuthSkipsCodexFreePlan(t *testing.T) 
 	}
 }
 
+func TestManagerPickNext_RouteAwarePreferUpstreamWebsocketKeepsLowerPriorityCodexWebsocket(t *testing.T) {
+	t.Parallel()
+
+	const (
+		routeModel    = "team/gpt-5-codex-route-aware-single"
+		upstreamModel = "gpt-5-codex-route-aware-single"
+		httpAuthID    = "codex-http-route-aware-single"
+		wsAuthID      = "codex-ws-route-aware-single"
+	)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(httpAuthID, "codex", []*registry.ModelInfo{{ID: routeModel}})
+	reg.RegisterClient(wsAuthID, "codex", []*registry.ModelInfo{{ID: upstreamModel}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(httpAuthID)
+		reg.UnregisterClient(wsAuthID)
+	})
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.executors["codex"] = schedulerTestExecutor{}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: httpAuthID, Provider: "codex", Attributes: map[string]string{"priority": "10"}}); errRegister != nil {
+		t.Fatalf("Register(%s) error = %v", httpAuthID, errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: wsAuthID, Provider: "codex", Prefix: "team", Attributes: map[string]string{"priority": "0", "websockets": "true"}}); errRegister != nil {
+		t.Fatalf("Register(%s) error = %v", wsAuthID, errRegister)
+	}
+
+	ctx := cliproxyexecutor.WithPreferUpstreamWebsocket(context.Background())
+	got, _, errPick := manager.pickNext(ctx, "codex", routeModel, cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNext() error = %v", errPick)
+	}
+	if got == nil {
+		t.Fatal("pickNext() auth = nil")
+	}
+	if got.ID != wsAuthID {
+		t.Fatalf("pickNext() auth.ID = %q, want %q", got.ID, wsAuthID)
+	}
+}
+
+func TestManagerPickNextMixed_RouteAwarePreferUpstreamWebsocketKeepsLowerPriorityCodexWebsocket(t *testing.T) {
+	t.Parallel()
+
+	const (
+		routeModel       = "team/gpt-5-codex-route-aware-mixed"
+		upstreamModel    = "gpt-5-codex-route-aware-mixed"
+		compatAuthID     = "openai-compat-route-aware-mixed"
+		codexWSAuthID    = "codex-ws-route-aware-mixed"
+		compatProvider   = "openai-compatible"
+		codexProviderKey = "codex"
+	)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(compatAuthID, compatProvider, []*registry.ModelInfo{{ID: routeModel}})
+	reg.RegisterClient(codexWSAuthID, codexProviderKey, []*registry.ModelInfo{{ID: upstreamModel}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(compatAuthID)
+		reg.UnregisterClient(codexWSAuthID)
+	})
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.executors[compatProvider] = schedulerTestExecutor{}
+	manager.executors[codexProviderKey] = schedulerTestExecutor{}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: compatAuthID, Provider: compatProvider, Attributes: map[string]string{"priority": "10"}}); errRegister != nil {
+		t.Fatalf("Register(%s) error = %v", compatAuthID, errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: codexWSAuthID, Provider: codexProviderKey, Prefix: "team", Attributes: map[string]string{"priority": "0", "websockets": "true"}}); errRegister != nil {
+		t.Fatalf("Register(%s) error = %v", codexWSAuthID, errRegister)
+	}
+
+	ctx := cliproxyexecutor.WithPreferUpstreamWebsocket(context.Background())
+	got, _, provider, errPick := manager.pickNextMixed(ctx, []string{compatProvider, codexProviderKey}, routeModel, cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixed() error = %v", errPick)
+	}
+	if got == nil {
+		t.Fatal("pickNextMixed() auth = nil")
+	}
+	if provider != codexProviderKey {
+		t.Fatalf("pickNextMixed() provider = %q, want %q", provider, codexProviderKey)
+	}
+	if got.ID != codexWSAuthID {
+		t.Fatalf("pickNextMixed() auth.ID = %q, want %q", got.ID, codexWSAuthID)
+	}
+}
+
 func TestManagerCustomSelector_FallsBackToLegacyPath(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -173,28 +173,36 @@ func authWebsocketsEnabled(auth *Auth) bool {
 	return false
 }
 
-func preferCodexWebsocketAuths(ctx context.Context, provider string, available []*Auth) []*Auth {
-	if len(available) == 0 {
-		return available
+func preferredCodexWebsocketAuths(ctx context.Context, provider string, model string, now time.Time, auths []*Auth) ([]*Auth, bool) {
+	if len(auths) == 0 {
+		return nil, false
 	}
-	if !cliproxyexecutor.DownstreamWebsocket(ctx) {
-		return available
+	if !cliproxyexecutor.DownstreamWebsocket(ctx) && !cliproxyexecutor.PreferUpstreamWebsocket(ctx) {
+		return nil, false
 	}
-	if !strings.EqualFold(strings.TrimSpace(provider), "codex") {
-		return available
+	providerKey := strings.TrimSpace(provider)
+	if !strings.EqualFold(providerKey, "codex") && !strings.EqualFold(providerKey, "mixed") {
+		return nil, false
 	}
 
-	wsEnabled := make([]*Auth, 0, len(available))
-	for i := 0; i < len(available); i++ {
-		candidate := available[i]
+	wsCandidates := make([]*Auth, 0, len(auths))
+	for i := 0; i < len(auths); i++ {
+		candidate := auths[i]
+		if candidate == nil || !strings.EqualFold(strings.TrimSpace(candidate.Provider), "codex") {
+			continue
+		}
 		if authWebsocketsEnabled(candidate) {
-			wsEnabled = append(wsEnabled, candidate)
+			wsCandidates = append(wsCandidates, candidate)
 		}
 	}
-	if len(wsEnabled) > 0 {
-		return wsEnabled
+	if len(wsCandidates) == 0 {
+		return nil, false
 	}
-	return available
+	available, err := getAvailableAuths(wsCandidates, provider, model, now)
+	if err != nil || len(available) == 0 {
+		return nil, false
+	}
+	return available, true
 }
 
 func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (available map[int][]*Auth, cooldownCount int, earliest time.Time) {
@@ -261,11 +269,14 @@ func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]
 func (s *RoundRobinSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
 	_ = opts
 	now := time.Now()
-	available, err := getAvailableAuths(auths, provider, model, now)
-	if err != nil {
-		return nil, err
+	available, ok := preferredCodexWebsocketAuths(ctx, provider, model, now, auths)
+	if !ok {
+		var err error
+		available, err = getAvailableAuths(auths, provider, model, now)
+		if err != nil {
+			return nil, err
+		}
 	}
-	available = preferCodexWebsocketAuths(ctx, provider, available)
 	key := provider + ":" + canonicalModelKey(model)
 	s.mu.Lock()
 	if s.cursors == nil {
@@ -360,11 +371,14 @@ func groupByVirtualParent(auths []*Auth) (map[string][]*Auth, []string) {
 func (s *FillFirstSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
 	_ = opts
 	now := time.Now()
-	available, err := getAvailableAuths(auths, provider, model, now)
-	if err != nil {
-		return nil, err
+	available, ok := preferredCodexWebsocketAuths(ctx, provider, model, now, auths)
+	if !ok {
+		var err error
+		available, err = getAvailableAuths(auths, provider, model, now)
+		if err != nil {
+			return nil, err
+		}
 	}
-	available = preferCodexWebsocketAuths(ctx, provider, available)
 	return available[0], nil
 }
 

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -89,6 +89,29 @@ func TestRoundRobinSelectorPick_PriorityBuckets(t *testing.T) {
 	}
 }
 
+func TestRoundRobinSelectorPick_MixedPreferUpstreamWebsocketChoosesCodexWebsocket(t *testing.T) {
+	t.Parallel()
+
+	selector := &RoundRobinSelector{}
+	auths := []*Auth{
+		{ID: "openai-compat", Provider: "openai-compatible", Attributes: map[string]string{"priority": "10"}},
+		{ID: "codex-http", Provider: "codex", Attributes: map[string]string{"priority": "10"}},
+		{ID: "codex-ws", Provider: "codex", Attributes: map[string]string{"priority": "0", "websockets": "true"}},
+	}
+
+	ctx := cliproxyexecutor.WithPreferUpstreamWebsocket(context.Background())
+	got, err := selector.Pick(ctx, "mixed", "", cliproxyexecutor.Options{}, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("Pick() auth = nil")
+	}
+	if got.ID != "codex-ws" {
+		t.Fatalf("Pick() auth.ID = %q, want codex-ws", got.ID)
+	}
+}
+
 func TestFillFirstSelectorPick_PriorityFallbackCooldown(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/executor/context.go
+++ b/sdk/cliproxy/executor/context.go
@@ -3,6 +3,7 @@ package executor
 import "context"
 
 type downstreamWebsocketContextKey struct{}
+type preferUpstreamWebsocketContextKey struct{}
 
 // WithDownstreamWebsocket marks the current request as coming from a downstream websocket connection.
 func WithDownstreamWebsocket(ctx context.Context) context.Context {
@@ -18,6 +19,24 @@ func DownstreamWebsocket(ctx context.Context) bool {
 		return false
 	}
 	raw := ctx.Value(downstreamWebsocketContextKey{})
+	enabled, ok := raw.(bool)
+	return ok && enabled
+}
+
+// WithPreferUpstreamWebsocket marks a request that should prefer an upstream websocket transport.
+func WithPreferUpstreamWebsocket(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, preferUpstreamWebsocketContextKey{}, true)
+}
+
+// PreferUpstreamWebsocket reports whether the request should prefer an upstream websocket transport.
+func PreferUpstreamWebsocket(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	raw := ctx.Value(preferUpstreamWebsocketContextKey{})
 	enabled, ok := raw.(bool)
 	return ok && enabled
 }


### PR DESCRIPTION
配置项中添加：codex-prefer-upstream-websockets: false
用于控制 codex下游http/sse连接cpa时，cpa是否使用websocket与OpenAI建立连接（需要auth的json文件配置"websockets":true，否则回退为http）