### PR TITLE
claude: short-circuit probe requests & drop context-1m beta on OAuth

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -975,6 +975,20 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 			}
 		}
 	}
+	// OAuth (subscription) upstreams reject context-1m-2025-08-07 with a
+	// 429 "Usage credits are required for long context requests" unless the
+	// account has pay-as-you-go credits enabled. Strip it for OAuth so the
+	// request silently falls back to the 200k window instead of failing.
+	if !useAPIKey && strings.Contains(baseBetas, "context-1m-2025-08-07") {
+		parts := strings.Split(baseBetas, ",")
+		kept := parts[:0]
+		for _, p := range parts {
+			if strings.TrimSpace(p) != "context-1m-2025-08-07" {
+				kept = append(kept, p)
+			}
+		}
+		baseBetas = strings.Join(kept, ",")
+	}
 	r.Header.Set("Anthropic-Beta", baseBetas)
 
 	misc.EnsureHeader(r.Header, ginHeaders, "Anthropic-Version", "2023-06-01")

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 // ClaudeCodeAPIHandler contains the handlers for Claude API endpoints.
@@ -75,6 +76,11 @@ func (h *ClaudeCodeAPIHandler) ClaudeMessages(c *gin.Context) {
 				Type:    "invalid_request_error",
 			},
 		})
+		return
+	}
+
+	if shouldShortCircuitClaudeSample(rawJSON) {
+		h.writeClaudeSampleResponse(c, rawJSON)
 		return
 	}
 
@@ -474,4 +480,73 @@ func appendClaudeAPIResponse(c *gin.Context, data []byte) {
 		}
 	}
 	c.Set("API_RESPONSE", bytes.Clone(data))
+}
+
+func shouldShortCircuitClaudeSample(rawJSON []byte) bool {
+	maxTokens := gjson.GetBytes(rawJSON, "max_tokens")
+	return maxTokens.Exists() && maxTokens.Int() == 1
+}
+
+func buildClaudeSampleResponseBody(rawJSON []byte, now time.Time) []byte {
+	modelName := gjson.GetBytes(rawJSON, "model").String()
+	if strings.TrimSpace(modelName) == "" {
+		modelName = "claude-sonnet-4-6"
+	}
+	responseID := fmt.Sprintf("msg_cli_proxy_sample_%d", now.UnixNano())
+	out := []byte(`{"id":"","type":"message","role":"assistant","model":"","content":[],"stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":8,"output_tokens":0}}`)
+	out, _ = sjson.SetBytes(out, "id", responseID)
+	out, _ = sjson.SetBytes(out, "model", modelName)
+	return out
+}
+
+func buildClaudeSampleSSE(rawJSON []byte, now time.Time) []byte {
+	modelName := gjson.GetBytes(rawJSON, "model").String()
+	if strings.TrimSpace(modelName) == "" {
+		modelName = "claude-sonnet-4-6"
+	}
+	responseID := fmt.Sprintf("msg_cli_proxy_sample_%d", now.UnixNano())
+	messageStart := []byte(`{"type":"message_start","message":{"id":"","type":"message","role":"assistant","content":[],"model":"","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":8,"output_tokens":0}}}`)
+	messageStart, _ = sjson.SetBytes(messageStart, "message.id", responseID)
+	messageStart, _ = sjson.SetBytes(messageStart, "message.model", modelName)
+
+	messageDelta := []byte(`{"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"input_tokens":8,"output_tokens":0}}`)
+	messageStop := []byte(`{"type":"message_stop"}`)
+
+	var out []byte
+	out = appendClaudeSSEEvent(out, "message_start", messageStart)
+	out = appendClaudeSSEEvent(out, "message_delta", messageDelta)
+	out = appendClaudeSSEEvent(out, "message_stop", messageStop)
+	return out
+}
+
+func appendClaudeSSEEvent(dst []byte, event string, data []byte) []byte {
+	dst = append(dst, "event: "...)
+	dst = append(dst, event...)
+	dst = append(dst, '\n')
+	dst = append(dst, "data: "...)
+	dst = append(dst, data...)
+	dst = append(dst, '\n', '\n')
+	return dst
+}
+
+func (h *ClaudeCodeAPIHandler) writeClaudeSampleResponse(c *gin.Context, rawJSON []byte) {
+	streamResult := gjson.GetBytes(rawJSON, "stream")
+	now := time.Now()
+	if streamResult.Exists() && streamResult.Type != gjson.False {
+		payload := buildClaudeSampleSSE(rawJSON, now)
+		c.Header("Content-Type", "text/event-stream")
+		c.Header("Cache-Control", "no-cache")
+		c.Header("Connection", "keep-alive")
+		c.Header("Access-Control-Allow-Origin", "*")
+		appendClaudeAPIResponse(c, payload)
+		c.Status(http.StatusOK)
+		_, _ = c.Writer.Write(payload)
+		return
+	}
+
+	payload := buildClaudeSampleResponseBody(rawJSON, now)
+	appendClaudeAPIResponse(c, payload)
+	c.Header("Content-Type", "application/json")
+	c.Status(http.StatusOK)
+	_, _ = c.Writer.Write(payload)
 }

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -483,10 +483,10 @@ func appendClaudeAPIResponse(c *gin.Context, data []byte) {
 }
 
 // shouldShortCircuitClaudeSample matches the liveness/auth probe shape that
-// Claude Desktop App and Claude Code send periodically: max_tokens=1, a
-// pre-filled assistant turn (real classifier inputs are user-only), and no
-// tools (tool-gated classifiers won't be probed). Bare max_tokens=1 is a
-// legitimate single-token classification setting and must pass through.
+// Claude Desktop App and Claude Code send periodically: max_tokens=1, the
+// last message pre-filled as assistant (real classifier inputs end on user),
+// and no tools (tool-gated classifiers won't be probed). Bare max_tokens=1
+// is a legitimate single-token classification setting and must pass through.
 func shouldShortCircuitClaudeSample(rawJSON []byte) bool {
 	if v := gjson.GetBytes(rawJSON, "max_tokens"); !v.Exists() || v.Int() != 1 {
 		return false
@@ -494,15 +494,8 @@ func shouldShortCircuitClaudeSample(rawJSON []byte) bool {
 	if gjson.GetBytes(rawJSON, "tools").Exists() || gjson.GetBytes(rawJSON, "tool_choice").Exists() {
 		return false
 	}
-	hasAssistant := false
-	gjson.GetBytes(rawJSON, "messages").ForEach(func(_, msg gjson.Result) bool {
-		if msg.Get("role").String() == "assistant" {
-			hasAssistant = true
-			return false
-		}
-		return true
-	})
-	return hasAssistant
+	lastMsg := gjson.GetBytes(rawJSON, "messages.-1")
+	return lastMsg.Exists() && lastMsg.Get("role").String() == "assistant"
 }
 
 func buildClaudeSampleResponseBody(rawJSON []byte, now time.Time) []byte {

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -482,9 +482,27 @@ func appendClaudeAPIResponse(c *gin.Context, data []byte) {
 	c.Set("API_RESPONSE", bytes.Clone(data))
 }
 
+// shouldShortCircuitClaudeSample matches the liveness/auth probe shape that
+// Claude Desktop App and Claude Code send periodically: max_tokens=1, a
+// pre-filled assistant turn (real classifier inputs are user-only), and no
+// tools (tool-gated classifiers won't be probed). Bare max_tokens=1 is a
+// legitimate single-token classification setting and must pass through.
 func shouldShortCircuitClaudeSample(rawJSON []byte) bool {
-	maxTokens := gjson.GetBytes(rawJSON, "max_tokens")
-	return maxTokens.Exists() && maxTokens.Int() == 1
+	if v := gjson.GetBytes(rawJSON, "max_tokens"); !v.Exists() || v.Int() != 1 {
+		return false
+	}
+	if gjson.GetBytes(rawJSON, "tools").Exists() || gjson.GetBytes(rawJSON, "tool_choice").Exists() {
+		return false
+	}
+	hasAssistant := false
+	gjson.GetBytes(rawJSON, "messages").ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "assistant" {
+			hasAssistant = true
+			return false
+		}
+		return true
+	})
+	return hasAssistant
 }
 
 func buildClaudeSampleResponseBody(rawJSON []byte, now time.Time) []byte {

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -509,7 +509,7 @@ func buildClaudeSampleSSE(rawJSON []byte, now time.Time) []byte {
 	messageStart, _ = sjson.SetBytes(messageStart, "message.id", responseID)
 	messageStart, _ = sjson.SetBytes(messageStart, "message.model", modelName)
 
-	messageDelta := []byte(`{"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"input_tokens":8,"output_tokens":0}}`)
+	messageDelta := []byte(`{"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"output_tokens":0}}`)
 	messageStop := []byte(`{"type":"message_stop"}`)
 
 	var out []byte

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -482,27 +482,9 @@ func appendClaudeAPIResponse(c *gin.Context, data []byte) {
 	c.Set("API_RESPONSE", bytes.Clone(data))
 }
 
-// shouldShortCircuitClaudeSample matches the liveness/auth probe shape that
-// Claude Desktop App and Claude Code send periodically: max_tokens=1, a
-// pre-filled assistant turn (real classifier inputs are user-only), and no
-// tools (tool-gated classifiers won't be probed). Bare max_tokens=1 is a
-// legitimate single-token classification setting and must pass through.
 func shouldShortCircuitClaudeSample(rawJSON []byte) bool {
-	if v := gjson.GetBytes(rawJSON, "max_tokens"); !v.Exists() || v.Int() != 1 {
-		return false
-	}
-	if gjson.GetBytes(rawJSON, "tools").Exists() || gjson.GetBytes(rawJSON, "tool_choice").Exists() {
-		return false
-	}
-	hasAssistant := false
-	gjson.GetBytes(rawJSON, "messages").ForEach(func(_, msg gjson.Result) bool {
-		if msg.Get("role").String() == "assistant" {
-			hasAssistant = true
-			return false
-		}
-		return true
-	})
-	return hasAssistant
+	maxTokens := gjson.GetBytes(rawJSON, "max_tokens")
+	return maxTokens.Exists() && maxTokens.Int() == 1
 }
 
 func buildClaudeSampleResponseBody(rawJSON []byte, now time.Time) []byte {

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -483,10 +483,10 @@ func appendClaudeAPIResponse(c *gin.Context, data []byte) {
 }
 
 // shouldShortCircuitClaudeSample matches the liveness/auth probe shape that
-// Claude Desktop App and Claude Code send periodically: max_tokens=1, the
-// last message pre-filled as assistant (real classifier inputs end on user),
-// and no tools (tool-gated classifiers won't be probed). Bare max_tokens=1
-// is a legitimate single-token classification setting and must pass through.
+// Claude Desktop App and Claude Code send periodically: max_tokens=1, a
+// pre-filled assistant turn (real classifier inputs are user-only), and no
+// tools (tool-gated classifiers won't be probed). Bare max_tokens=1 is a
+// legitimate single-token classification setting and must pass through.
 func shouldShortCircuitClaudeSample(rawJSON []byte) bool {
 	if v := gjson.GetBytes(rawJSON, "max_tokens"); !v.Exists() || v.Int() != 1 {
 		return false
@@ -494,8 +494,15 @@ func shouldShortCircuitClaudeSample(rawJSON []byte) bool {
 	if gjson.GetBytes(rawJSON, "tools").Exists() || gjson.GetBytes(rawJSON, "tool_choice").Exists() {
 		return false
 	}
-	lastMsg := gjson.GetBytes(rawJSON, "messages.-1")
-	return lastMsg.Exists() && lastMsg.Get("role").String() == "assistant"
+	hasAssistant := false
+	gjson.GetBytes(rawJSON, "messages").ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "assistant" {
+			hasAssistant = true
+			return false
+		}
+		return true
+	})
+	return hasAssistant
 }
 
 func buildClaudeSampleResponseBody(rawJSON []byte, now time.Time) []byte {

--- a/sdk/api/handlers/claude/code_handlers_probe_test.go
+++ b/sdk/api/handlers/claude/code_handlers_probe_test.go
@@ -15,7 +15,7 @@ func TestClaudeMessagesShortCircuitNonStreamingSample(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
-	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewBufferString(`{"model":"claude-sonnet-4-6","max_tokens":1,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"x"}]}`))
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewBufferString(`{"model":"claude-sonnet-4-6","max_tokens":1,"messages":[{"role":"user","content":"hello"}]}`))
 	c.Request.Header.Set("Content-Type", "application/json")
 
 	handler := &ClaudeCodeAPIHandler{}
@@ -77,33 +77,18 @@ func TestShouldShortCircuitClaudeSample(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "single user message not shorted",
+			name: "single message not shorted",
 			body: `{"max_tokens":64,"messages":[{"role":"user","content":"hello"}]}`,
 			want: false,
 		},
 		{
-			name: "probe shape shorts",
+			name: "max tokens one",
 			body: `{"max_tokens":1,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"}]}`,
 			want: true,
 		},
 		{
-			name: "normal multi-turn request not shorted",
+			name: "normal request",
 			body: `{"max_tokens":64,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"}]}`,
-			want: false,
-		},
-		{
-			name: "single-token classifier (user only) not shorted",
-			body: `{"max_tokens":1,"messages":[{"role":"user","content":"Is this spam? Reply yes or no."}]}`,
-			want: false,
-		},
-		{
-			name: "single-token tool-gated classifier not shorted",
-			body: `{"max_tokens":1,"tools":[{"name":"check","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"."},{"role":"assistant","content":"x"}]}`,
-			want: false,
-		},
-		{
-			name: "single-token tool_choice forced not shorted",
-			body: `{"max_tokens":1,"tool_choice":{"type":"any"},"messages":[{"role":"user","content":"."},{"role":"assistant","content":"x"}]}`,
 			want: false,
 		},
 	}

--- a/sdk/api/handlers/claude/code_handlers_probe_test.go
+++ b/sdk/api/handlers/claude/code_handlers_probe_test.go
@@ -1,0 +1,103 @@
+package claude
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+func TestClaudeMessagesShortCircuitNonStreamingSample(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewBufferString(`{"model":"claude-sonnet-4-6","max_tokens":1,"messages":[{"role":"user","content":"hello"}]}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := &ClaudeCodeAPIHandler{}
+	handler.ClaudeMessages(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Fatalf("content-type = %q, want application/json", got)
+	}
+	body := recorder.Body.Bytes()
+	if got := gjson.GetBytes(body, "content").Raw; got != "[]" {
+		t.Fatalf("content = %q, want []; body=%s", got, body)
+	}
+	if got := gjson.GetBytes(body, "usage.output_tokens").Int(); got != 0 {
+		t.Fatalf("output_tokens = %d, want 0; body=%s", got, body)
+	}
+	if got := gjson.GetBytes(body, "stop_reason").String(); got != "max_tokens" {
+		t.Fatalf("stop_reason = %q, want max_tokens; body=%s", got, body)
+	}
+	if got := gjson.GetBytes(body, "model").String(); got != "claude-sonnet-4-6" {
+		t.Fatalf("model = %q, want claude-sonnet-4-6; body=%s", got, body)
+	}
+}
+
+func TestClaudeMessagesShortCircuitStreamingSample(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewBufferString(`{"model":"claude-sonnet-4-6","max_tokens":1,"stream":true,"messages":[{"role":"user","content":"."},{"role":"assistant","content":"x"}]}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := &ClaudeCodeAPIHandler{}
+	handler.ClaudeMessages(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("content-type = %q, want text/event-stream", got)
+	}
+	body := recorder.Body.String()
+	for _, want := range []string{
+		"event: message_start",
+		`"stop_reason":"max_tokens"`,
+		"event: message_stop",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("stream missing %q; body=%s", want, body)
+		}
+	}
+}
+
+func TestShouldShortCircuitClaudeSample(t *testing.T) {
+	testCases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "single message not shorted",
+			body: `{"max_tokens":64,"messages":[{"role":"user","content":"hello"}]}`,
+			want: false,
+		},
+		{
+			name: "max tokens one",
+			body: `{"max_tokens":1,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"}]}`,
+			want: true,
+		},
+		{
+			name: "normal request",
+			body: `{"max_tokens":64,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"}]}`,
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldShortCircuitClaudeSample([]byte(tc.body)); got != tc.want {
+				t.Fatalf("shouldShortCircuitClaudeSample() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/sdk/api/handlers/claude/code_handlers_probe_test.go
+++ b/sdk/api/handlers/claude/code_handlers_probe_test.go
@@ -15,7 +15,7 @@ func TestClaudeMessagesShortCircuitNonStreamingSample(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
-	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewBufferString(`{"model":"claude-sonnet-4-6","max_tokens":1,"messages":[{"role":"user","content":"hello"}]}`))
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewBufferString(`{"model":"claude-sonnet-4-6","max_tokens":1,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"x"}]}`))
 	c.Request.Header.Set("Content-Type", "application/json")
 
 	handler := &ClaudeCodeAPIHandler{}
@@ -77,18 +77,33 @@ func TestShouldShortCircuitClaudeSample(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "single message not shorted",
+			name: "single user message not shorted",
 			body: `{"max_tokens":64,"messages":[{"role":"user","content":"hello"}]}`,
 			want: false,
 		},
 		{
-			name: "max tokens one",
+			name: "probe shape shorts",
 			body: `{"max_tokens":1,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"}]}`,
 			want: true,
 		},
 		{
-			name: "normal request",
+			name: "normal multi-turn request not shorted",
 			body: `{"max_tokens":64,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"}]}`,
+			want: false,
+		},
+		{
+			name: "single-token classifier (user only) not shorted",
+			body: `{"max_tokens":1,"messages":[{"role":"user","content":"Is this spam? Reply yes or no."}]}`,
+			want: false,
+		},
+		{
+			name: "single-token tool-gated classifier not shorted",
+			body: `{"max_tokens":1,"tools":[{"name":"check","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"."},{"role":"assistant","content":"x"}]}`,
+			want: false,
+		},
+		{
+			name: "single-token tool_choice forced not shorted",
+			body: `{"max_tokens":1,"tool_choice":{"type":"any"},"messages":[{"role":"user","content":"."},{"role":"assistant","content":"x"}]}`,
 			want: false,
 		},
 	}

--- a/sdk/api/handlers/claude/code_handlers_probe_test.go
+++ b/sdk/api/handlers/claude/code_handlers_probe_test.go
@@ -106,11 +106,6 @@ func TestShouldShortCircuitClaudeSample(t *testing.T) {
 			body: `{"max_tokens":1,"tool_choice":{"type":"any"},"messages":[{"role":"user","content":"."},{"role":"assistant","content":"x"}]}`,
 			want: false,
 		},
-		{
-			name: "multi-turn ending on user not shorted",
-			body: `{"max_tokens":1,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"},{"role":"user","content":"next"}]}`,
-			want: false,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/sdk/api/handlers/claude/code_handlers_probe_test.go
+++ b/sdk/api/handlers/claude/code_handlers_probe_test.go
@@ -106,6 +106,11 @@ func TestShouldShortCircuitClaudeSample(t *testing.T) {
 			body: `{"max_tokens":1,"tool_choice":{"type":"any"},"messages":[{"role":"user","content":"."},{"role":"assistant","content":"x"}]}`,
 			want: false,
 		},
+		{
+			name: "multi-turn ending on user not shorted",
+			body: `{"max_tokens":1,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"},{"role":"user","content":"next"}]}`,
+			want: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary
- **claude_executor**: when upstream auth is OAuth (no `api_key`), strip `context-1m-2025-08-07` from `Anthropic-Beta`. Anthropic returns `429 Usage credits are required for long context requests` for subscription accounts whose pay-as-you-go credits are not enabled; clients like the Claude Desktop App in cowork mode advertise the beta unconditionally and break sub-200k requests. API-key paths are unchanged and keep the full 1M window.
- **code_handlers**: short-circuit `/v1/messages` locally when the request matches the actual Claude Desktop / Claude Code liveness-probe fingerprint (not bare `max_tokens=1`, which is a legitimate single-token classifier setting). The synthesized response carries `stop_reason=max_tokens` for both JSON and SSE. Probe predicate requires:
  - `max_tokens == 1`
  - `messages` contain a pre-filled `assistant` turn (real classifier inputs are user-only)
  - no `tools` / `tool_choice` (tool-gated classifiers won't be probed)
- Adds `code_handlers_probe_test.go` covering the JSON path, SSE path, the positive predicate, and the false-positive shapes (single-token user-only classifier, tool-gated classifier via `tools` and via `tool_choice`).

## History
Continuation of #3566 (closed); same branch, no force-pushes. Resolved feedback already incorporated:
- `gemini-code-assist[bot]`: `message_delta` `usage` now carries only `output_tokens` (commit `e17b18d`).
- `chatgpt-codex-connector[bot]` P1: probe predicate tightened to avoid false positives on real classification workloads (commit `5e4bd68`).

## Test plan
- [x] \`go build ./cmd/server\` (verified inside Docker multi-stage build, \`golang:1.26-alpine\`)
- [x] \`go test ./sdk/api/handlers/claude/...\` (probe tests including false-positive cases)
- [x] Deployed image under cowork-mode traffic; previously failing long-context requests now succeed at 200k; probe traffic short-circuits without hitting upstream; classifier-style \`max_tokens=1\` requests pass through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)