### PR TITLE
fix(codex): 避免增量 WebSocket 回放缓存工具调用

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -691,13 +691,15 @@ func TestRepairResponsesWebsocketToolCallsInsertsCachedCallForOrphanOutput(t *te
 	}
 }
 
-func TestRepairResponsesWebsocketToolCallsInsertsCachedCallForPreviousResponseOutput(t *testing.T) {
+func TestRepairResponsesWebsocketToolCallsKeepsPreviousResponseOutputIncremental(t *testing.T) {
 	outputCache := newWebsocketToolOutputCache(time.Minute, 10)
 	callCache := newWebsocketToolOutputCache(time.Minute, 10)
 	sessionKey := "session-1"
 
 	callCache.record(sessionKey, "call-1", []byte(`{"type":"function_call","id":"fc-1","call_id":"call-1","name":"tool"}`))
 
+	// previous_response_id requests are incremental; the cached call belongs to the
+	// prior upstream response and must not be replayed into this frame.
 	raw := []byte(`{"previous_response_id":"resp-latest","input":[{"type":"function_call_output","call_id":"call-1","id":"tool-out-1","output":"ok"},{"type":"message","id":"msg-1"}]}`)
 	repaired := repairResponsesWebsocketToolCallsWithCaches(outputCache, callCache, sessionKey, raw)
 
@@ -705,17 +707,14 @@ func TestRepairResponsesWebsocketToolCallsInsertsCachedCallForPreviousResponseOu
 		t.Fatalf("previous_response_id = %q, want resp-latest", got)
 	}
 	input := gjson.GetBytes(repaired, "input").Array()
-	if len(input) != 3 {
-		t.Fatalf("repaired input len = %d, want 3: %s", len(input), repaired)
+	if len(input) != 2 {
+		t.Fatalf("repaired input len = %d, want 2: %s", len(input), repaired)
 	}
-	if input[0].Get("type").String() != "function_call" || input[0].Get("call_id").String() != "call-1" {
-		t.Fatalf("missing inserted call: %s", input[0].Raw)
+	if input[0].Get("type").String() != "function_call_output" || input[0].Get("call_id").String() != "call-1" {
+		t.Fatalf("unexpected output item: %s", input[0].Raw)
 	}
-	if input[1].Get("type").String() != "function_call_output" || input[1].Get("call_id").String() != "call-1" {
-		t.Fatalf("unexpected output item: %s", input[1].Raw)
-	}
-	if input[2].Get("type").String() != "message" || input[2].Get("id").String() != "msg-1" {
-		t.Fatalf("unexpected trailing item: %s", input[2].Raw)
+	if input[1].Get("type").String() != "message" || input[1].Get("id").String() != "msg-1" {
+		t.Fatalf("unexpected trailing item: %s", input[1].Raw)
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -305,6 +305,13 @@ func repairResponsesToolCallsArray(outputCache, callCache *websocketToolOutputCa
 				continue
 			}
 
+			if allowOrphanOutputs {
+				// previous_response_id frames are incremental; the upstream response history
+				// already owns the function_call, so replaying a cached call here duplicates it.
+				filtered = append(filtered, item)
+				continue
+			}
+
 			if callCache != nil {
 				if cached, ok := callCache.get(sessionKey, callID); ok {
 					if _, already := insertedCalls[callID]; !already {
@@ -315,11 +322,6 @@ func repairResponsesToolCallsArray(outputCache, callCache *websocketToolOutputCa
 					filtered = append(filtered, item)
 					continue
 				}
-			}
-
-			if allowOrphanOutputs {
-				filtered = append(filtered, item)
-				continue
 			}
 
 			// Drop orphaned function_call_output items; upstream rejects transcripts with missing calls.


### PR DESCRIPTION
## 摘要

- 修复 Codex WebSocket v2 `previous_response_id` 增量请求中的 tool-call repair 逻辑
- 带 `previous_response_id` 时保留本轮 `function_call_output`，不再从 cache 回填历史 `function_call`
- 保留无 `previous_response_id` 的 full transcript / replay adjacency repair 行为

## 测试

- `gofmt -d sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go sdk/api/handlers/openai/openai_responses_websocket_test.go`
- `go test ./sdk/api/handlers/openai -run 'TestRepairResponsesWebsocketToolCalls(KeepsPreviousResponseOutputIncremental|InsertsCachedCallForOrphanOutput|DropsOrphanOutputWhenCallMissing|InsertsCachedCustomToolCallForOrphanOutput|DropsOrphanCustomToolOutputWhenCallMissing)$'`
- `go test ./sdk/api/handlers/openai`
- `git diff --check`

Fixes #3569