### PR TITLE
feat(usagestats): add PostgreSQL-backed token/cost statistics

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/joho/godotenv"
 	configaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/config_access"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/api"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/cmd"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -30,9 +31,11 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/store"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/tui"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usagestats"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -488,6 +491,59 @@ func main() {
 	redisqueue.SetRetentionSeconds(cfg.RedisUsageQueueRetentionSeconds)
 	coreauth.SetQuotaCooldownDisabled(cfg.DisableCooling)
 
+	// Initialize persistent usage statistics if configured.
+	var usageStatsStore usagestats.Store
+	if cfg.UsageStatistics.Enabled {
+		usageDSN := strings.TrimSpace(cfg.UsageStatistics.PostgresDSN)
+		if usageDSN == "" {
+			usageDSN = strings.TrimSpace(pgStoreDSN)
+		}
+		usageSchema := strings.TrimSpace(cfg.UsageStatistics.Schema)
+		if usageSchema == "" {
+			usageSchema = strings.TrimSpace(pgStoreSchema)
+		}
+		if usageDSN != "" {
+			initCtx, initCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			pgStore, errInit := usagestats.NewPostgresStore(initCtx, usagestats.PostgresStoreConfig{
+				DSN:    usageDSN,
+				Schema: usageSchema,
+				Table:  cfg.UsageStatistics.Table,
+			})
+			initCancel()
+			if errInit != nil {
+				log.Errorf("failed to initialize usage statistics store: %v", errInit)
+			} else {
+				schemaCtx, schemaCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				if errSchema := pgStore.EnsureSchema(schemaCtx); errSchema != nil {
+					schemaCancel()
+					log.Errorf("failed to ensure usage statistics schema: %v", errSchema)
+				} else {
+					schemaCancel()
+					usageStatsStore = pgStore
+					log.Info("usage statistics: PostgreSQL store initialized")
+
+					// Build price matcher.
+					var prices []usagestats.ModelPrice
+					for _, p := range cfg.UsageStatistics.Prices {
+						prices = append(prices, usagestats.ModelPrice{
+							Provider:           p.Provider,
+							Model:              p.Model,
+							InputCostPerToken:  p.InputCostPerToken,
+							OutputCostPerToken: p.OutputCostPerToken,
+						})
+					}
+					matcher := usagestats.NewPriceMatcher(prices)
+
+					// Register as usage plugin.
+					plugin := usagestats.NewPlugin(pgStore, matcher)
+					coreusage.RegisterPlugin(plugin)
+				}
+			}
+		} else {
+			log.Warn("usage statistics: enabled but no PostgreSQL DSN configured; persistent stats disabled")
+		}
+	}
+
 	if err = logging.ConfigureLogOutput(cfg); err != nil {
 		log.Errorf("failed to configure log output: %v", err)
 		return
@@ -648,7 +704,7 @@ func main() {
 			} else if cfg.Home.Enabled {
 				log.Info("Home mode: remote model updates disabled")
 			}
-			cmd.StartService(cfg, configFilePath, password)
+			cmd.StartService(cfg, configFilePath, password, api.WithUsageStatsStore(usageStatsStore))
 		}
 	}
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -71,6 +71,38 @@ usage-statistics-enabled: false
 # Default: 60. Max: 3600.
 redis-usage-queue-retention-seconds: 60
 
+# Persistent lightweight token/cost statistics backed by PostgreSQL.
+# This is separate from the in-memory usage queue above.
+# When enabled and a PostgreSQL DSN is available, the server persists sanitized usage events
+# and exposes summary/grouped/recent records via Management API.
+# No sensitive data (prompts, messages, response bodies, raw API keys, tokens, cookies) is stored.
+# Cost calculation is manual-price-only; unmatched models show cost_known=false.
+usage-statistics:
+  # Enable persistent PostgreSQL-backed lightweight token/cost statistics.
+  enabled: false
+
+  # PostgreSQL connection string. When empty, falls back to PGSTORE_DSN environment variable.
+  # If both are empty and enabled=true, the server logs a warning and continues without stats.
+  # postgres-dsn: ""
+
+  # PostgreSQL schema. When empty, falls back to PGSTORE_SCHEMA environment variable.
+  # postgres-schema: ""
+
+  # Table name for usage records. Default: usage_records.
+  # table: "usage_records"
+
+  # Manual model prices. Cost is unknown for provider/model pairs not listed here.
+  # Prices are in USD per token.
+  # prices:
+  #   - provider: "openai"
+  #     model: "gpt-4.1-mini"
+  #     input_cost_per_token: 0.0000004
+  #     output_cost_per_token: 0.0000016
+  #   - provider: "claude"
+  #     model: "claude-sonnet-4"
+  #     input_cost_per_token: 0.000003
+  #     output_cost_per_token: 0.000015
+
 # Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
 # Per-entry proxy-url also supports "direct" or "none" to bypass both the global proxy-url and environment proxies explicitly.
 proxy-url: ""

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usagestats"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"golang.org/x/crypto/bcrypt"
@@ -46,6 +47,7 @@ type Handler struct {
 	envSecret           string
 	logDir              string
 	postAuthHook        coreauth.PostAuthHook
+	usageStatsStore     usagestats.Store
 }
 
 // NewHandler creates a new management handler instance.
@@ -140,6 +142,14 @@ func (h *Handler) SetLogDirectory(dir string) {
 // SetPostAuthHook registers a hook to be called after auth record creation but before persistence.
 func (h *Handler) SetPostAuthHook(hook coreauth.PostAuthHook) {
 	h.postAuthHook = hook
+}
+
+// SetUsageStatsStore sets the usage statistics store for the summary endpoint.
+func (h *Handler) SetUsageStatsStore(store usagestats.Store) {
+	if h == nil {
+		return
+	}
+	h.usageStatsStore = store
 }
 
 // Middleware enforces access control for management endpoints.

--- a/internal/api/handlers/management/usage_statistics.go
+++ b/internal/api/handlers/management/usage_statistics.go
@@ -1,0 +1,96 @@
+package management
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usagestats"
+)
+
+const (
+	defaultRecentLimit = 0
+	maxRecentLimit     = 100
+)
+
+// GetUsageStatisticsSummary handles GET /v0/management/usage-statistics/summary.
+func (h *Handler) GetUsageStatisticsSummary(c *gin.Context) {
+	if h == nil || h.usageStatsStore == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "usage statistics unavailable",
+		})
+		return
+	}
+
+	// Parse from.
+	fromStr := strings.TrimSpace(c.Query("from"))
+	from, err := usagestats.ParseTime(fromStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid from", "message": err.Error()})
+		return
+	}
+
+	// Parse to.
+	toStr := strings.TrimSpace(c.Query("to"))
+	to, err := usagestats.ParseTime(toStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid to", "message": err.Error()})
+		return
+	}
+
+	// Default to = now.
+	if to.IsZero() {
+		to = time.Now()
+	}
+	// Default from = 30 days ago.
+	if from.IsZero() {
+		from = to.AddDate(0, 0, -30)
+	}
+	if !from.Before(to) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid range", "message": "from must be before to"})
+		return
+	}
+
+	// Parse group_by.
+	groupByStr := strings.TrimSpace(c.Query("group_by"))
+	groupBy, ok := usagestats.ParseGroupBy(groupByStr)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "invalid group_by",
+			"message": fmt.Sprintf("must be one of: day, provider, model, api_key, auth, call_type"),
+		})
+		return
+	}
+
+	// Parse recent_limit.
+	recentLimit := defaultRecentLimit
+	if rlStr := strings.TrimSpace(c.Query("recent_limit")); rlStr != "" {
+		rl, err := strconv.Atoi(rlStr)
+		if err != nil || rl < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid recent_limit", "message": "must be a non-negative integer"})
+			return
+		}
+		if rl > maxRecentLimit {
+			rl = maxRecentLimit
+		}
+		recentLimit = rl
+	}
+
+	result, err := h.usageStatsStore.Summary(c.Request.Context(), usagestats.Query{
+		From:        from,
+		To:          to,
+		GroupBy:     groupBy,
+		RecentLimit: recentLimit,
+	})
+	if err != nil {
+		log.WithError(err).Warn("usagestats: summary query failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "query_failed", "message": "failed to query usage statistics"})
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}

--- a/internal/api/handlers/management/usage_statistics_test.go
+++ b/internal/api/handlers/management/usage_statistics_test.go
@@ -1,0 +1,176 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usagestats"
+)
+
+// mockStore implements usagestats.Store for testing.
+type mockStore struct {
+	summaryResult *usagestats.SummaryResult
+	summaryErr    error
+	appendErr     error
+	schemaErr     error
+}
+
+func (m *mockStore) EnsureSchema(_ context.Context) error { return m.schemaErr }
+func (m *mockStore) Append(_ context.Context, _ usagestats.Event) error {
+	return m.appendErr
+}
+func (m *mockStore) Summary(_ context.Context, query usagestats.Query) (*usagestats.SummaryResult, error) {
+	return m.summaryResult, m.summaryErr
+}
+func (m *mockStore) Close() error { return nil }
+
+func setupTestHandler(store usagestats.Store) (*Handler, *gin.Engine) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{}
+	h := NewHandler(cfg, "", nil)
+	if store != nil {
+		h.usageStatsStore = store
+	}
+	r := gin.New()
+	return h, r
+}
+
+func TestGetUsageStatisticsSummary_NoStore(t *testing.T) {
+	h, _ := setupTestHandler(nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	h.GetUsageStatisticsSummary(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestGetUsageStatisticsSummary_InvalidFrom(t *testing.T) {
+	store := &mockStore{}
+	h, _ := setupTestHandler(store)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/?from=not-a-date", nil)
+
+	h.GetUsageStatisticsSummary(c)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestGetUsageStatisticsSummary_InvalidGroupBy(t *testing.T) {
+	store := &mockStore{}
+	h, _ := setupTestHandler(store)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/?group_by=invalid", nil)
+
+	h.GetUsageStatisticsSummary(c)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	var body map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body["error"] != "invalid group_by" {
+		t.Errorf("error = %q, want 'invalid group_by'", body["error"])
+	}
+}
+
+func TestGetUsageStatisticsSummary_FromAfterTo(t *testing.T) {
+	store := &mockStore{}
+	h, _ := setupTestHandler(store)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/?from=2026-06-01&to=2026-05-01", nil)
+
+	h.GetUsageStatisticsSummary(c)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestGetUsageStatisticsSummary_InvalidRecentLimit(t *testing.T) {
+	store := &mockStore{}
+	h, _ := setupTestHandler(store)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/?recent_limit=abc", nil)
+
+	h.GetUsageStatisticsSummary(c)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestGetUsageStatisticsSummary_Success(t *testing.T) {
+	store := &mockStore{
+		summaryResult: &usagestats.SummaryResult{
+			From:     "2026-05-01T00:00:00Z",
+			To:       "2026-05-27T00:00:00Z",
+			GroupBy:  "day",
+			Summary:  usagestats.SummaryTotal{Reqs: 10, OK: 8, Fail: 2},
+			Groups:   []usagestats.SummaryRow{{Key: "2026-05-27", Reqs: 10}},
+			Recent:   nil,
+		},
+	}
+	h, _ := setupTestHandler(store)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/?from=2026-05-01&to=2026-05-27&group_by=day&recent_limit=10", nil)
+
+	h.GetUsageStatisticsSummary(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var result usagestats.SummaryResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.Summary.Reqs != 10 {
+		t.Errorf("requests = %d, want 10", result.Summary.Reqs)
+	}
+}
+
+func TestGetUsageStatisticsSummary_RecentLimitCapped(t *testing.T) {
+	store := &mockStore{
+		summaryResult: &usagestats.SummaryResult{
+			From:    time.Now().AddDate(0, 0, -1).Format(time.RFC3339),
+			To:      time.Now().Format(time.RFC3339),
+			GroupBy: "day",
+		},
+	}
+	h, _ := setupTestHandler(store)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	// Request 500, should be capped to 100.
+	c.Request = httptest.NewRequest("GET", "/?recent_limit=500", nil)
+
+	h.GetUsageStatisticsSummary(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+}
+
+func TestGetUsageStatisticsSummary_StoreError(t *testing.T) {
+	store := &mockStore{
+		summaryErr: fmt.Errorf("db connection lost"),
+	}
+	h, _ := setupTestHandler(store)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/", nil)
+
+	h.GetUsageStatisticsSummary(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/managementasset"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usagestats"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
@@ -59,6 +60,7 @@ type serverOptionConfig struct {
 	keepAliveTimeout     time.Duration
 	keepAliveOnTimeout   func()
 	postAuthHook         auth.PostAuthHook
+	usageStatsStore      usagestats.Store
 }
 
 // ServerOption customises HTTP server construction.
@@ -123,6 +125,16 @@ func WithRequestLoggerFactory(factory func(*config.Config, string) logging.Reque
 func WithPostAuthHook(hook auth.PostAuthHook) ServerOption {
 	return func(cfg *serverOptionConfig) {
 		cfg.postAuthHook = hook
+	}
+}
+
+// WithUsageStatsStore sets the persistent usage statistics store for the management API.
+// Passing nil is safe and will result in 503 for the statistics endpoint.
+func WithUsageStatsStore(store usagestats.Store) ServerOption {
+	return func(cfg *serverOptionConfig) {
+		if store != nil {
+			cfg.usageStatsStore = store
+		}
 	}
 }
 
@@ -286,6 +298,9 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	s.mgmt.SetLogDirectory(logDir)
 	if optionState.postAuthHook != nil {
 		s.mgmt.SetPostAuthHook(optionState.postAuthHook)
+	}
+	if optionState.usageStatsStore != nil {
+		s.mgmt.SetUsageStatsStore(optionState.usageStatsStore)
 	}
 	s.localPassword = optionState.localPassword
 
@@ -602,6 +617,8 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.DELETE("/api-keys", s.mgmt.DeleteAPIKeys)
 		mgmt.GET("/api-key-usage", s.mgmt.GetAPIKeyUsage)
 		mgmt.GET("/usage-queue", s.mgmt.GetUsageQueue)
+
+		mgmt.GET("/usage-statistics/summary", s.mgmt.GetUsageStatisticsSummary)
 
 		mgmt.GET("/gemini-api-key", s.mgmt.GetGeminiKeys)
 		mgmt.PUT("/gemini-api-key", s.mgmt.PutGeminiKeys)

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -24,7 +24,8 @@ import (
 //   - cfg: The application configuration
 //   - configPath: The path to the configuration file
 //   - localPassword: Optional password accepted for local management requests
-func StartService(cfg *config.Config, configPath string, localPassword string) {
+//   - extraOpts: Optional additional server options
+func StartService(cfg *config.Config, configPath string, localPassword string, extraOpts ...api.ServerOption) {
 	builder := cliproxy.NewBuilder().
 		WithConfig(cfg).
 		WithConfigPath(configPath).
@@ -41,6 +42,10 @@ func StartService(cfg *config.Config, configPath string, localPassword string) {
 			log.Warn("keep-alive endpoint idle for 10s, shutting down")
 			keepAliveCancel()
 		}))
+	}
+
+	if len(extraOpts) > 0 {
+		builder = builder.WithServerOptions(extraOpts...)
 	}
 
 	service, err := builder.Build()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,10 @@ type Config struct {
 	// Default: 60. Max: 3600.
 	RedisUsageQueueRetentionSeconds int `yaml:"redis-usage-queue-retention-seconds" json:"redis-usage-queue-retention-seconds"`
 
+	// UsageStatistics configures persistent PostgreSQL-backed lightweight token/cost statistics.
+	// This is separate from the in-memory usage queue controlled by UsageStatisticsEnabled.
+	UsageStatistics UsageStatisticsConfig `yaml:"usage-statistics" json:"usage-statistics"`
+
 	// DisableCooling disables quota cooldown scheduling when true.
 	DisableCooling bool `yaml:"disable-cooling" json:"disable-cooling"`
 
@@ -356,6 +360,30 @@ type PayloadModelRule struct {
 	Exist []string `yaml:"exist" json:"exist"`
 	// NotExist requires payload JSON paths to be missing or null.
 	NotExist []string `yaml:"not-exist" json:"not-exist"`
+}
+
+// UsageStatisticsConfig configures persistent PostgreSQL-backed lightweight token/cost statistics.
+// This is separate from the in-memory usage queue controlled by UsageStatisticsEnabled.
+type UsageStatisticsConfig struct {
+	// Enabled toggles persistent usage statistics recording.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// PostgresDSN is the PostgreSQL connection string. When empty, falls back to PGSTORE_DSN env.
+	// JSON tag is \"-\" to prevent leaking the DSN in management API responses.
+	PostgresDSN string `yaml:"postgres-dsn" json:"-"`
+	// Schema is the PostgreSQL schema. When empty, falls back to PGSTORE_SCHEMA env.
+	Schema string `yaml:"postgres-schema" json:"postgres-schema"`
+	// Table is the table name for usage records. Default: usage_records.
+	Table string `yaml:"table" json:"table"`
+	// Prices defines manual per-token pricing for provider+model pairs.
+	Prices []UsageModelPrice `yaml:"prices" json:"prices"`
+}
+
+// UsageModelPrice defines manual per-token pricing for a specific provider+model pair.
+type UsageModelPrice struct {
+	Provider           string  `yaml:"provider" json:"provider"`
+	Model              string  `yaml:"model" json:"model"`
+	InputCostPerToken  float64 `yaml:"input_cost_per_token" json:"input_cost_per_token"`
+	OutputCostPerToken float64 `yaml:"output_cost_per_token" json:"output_cost_per_token"`
 }
 
 // CloakConfig configures request cloaking for non-Claude-Code clients.

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -73,6 +73,11 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 		cfg.MaxRetryCredentials = 0
 	}
 
+	// Normalize usage-statistics config.
+	if cfg.UsageStatistics.Table == "" {
+		cfg.UsageStatistics.Table = "usage_records"
+	}
+
 	// Apply the same sanitization pipeline.
 	cfg.SanitizeGeminiKeys()
 	cfg.SanitizeVertexCompatKeys()

--- a/internal/config/usage_statistics_config_test.go
+++ b/internal/config/usage_statistics_config_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestUsageStatisticsConfigDefaults(t *testing.T) {
+	yamlInput := `
+usage-statistics:
+  enabled: true
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlInput), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !cfg.UsageStatistics.Enabled {
+		t.Error("expected enabled=true")
+	}
+	if cfg.UsageStatistics.Table != "" {
+		// Defaults are applied in ParseConfigBytes, not raw unmarshal.
+		// This test verifies the raw YAML field mapping works.
+		t.Logf("table=%q (raw unmarshal; defaults applied later)", cfg.UsageStatistics.Table)
+	}
+}
+
+func TestUsageStatisticsConfigWithPrices(t *testing.T) {
+	yamlInput := `
+usage-statistics:
+  enabled: true
+  postgres-dsn: "postgres://user:pass@localhost:5432/db"
+  postgres-schema: "myschema"
+  table: "custom_usage"
+  prices:
+    - provider: "openai"
+      model: "gpt-4.1-mini"
+      input_cost_per_token: 0.0000004
+      output_cost_per_token: 0.0000016
+    - provider: "claude"
+      model: "claude-sonnet-4"
+      input_cost_per_token: 0.000003
+      output_cost_per_token: 0.000015
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlInput), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !cfg.UsageStatistics.Enabled {
+		t.Error("expected enabled=true")
+	}
+	if cfg.UsageStatistics.PostgresDSN != "postgres://user:pass@localhost:5432/db" {
+		t.Errorf("dsn = %q", cfg.UsageStatistics.PostgresDSN)
+	}
+	if cfg.UsageStatistics.Schema != "myschema" {
+		t.Errorf("schema = %q", cfg.UsageStatistics.Schema)
+	}
+	if cfg.UsageStatistics.Table != "custom_usage" {
+		t.Errorf("table = %q", cfg.UsageStatistics.Table)
+	}
+	if len(cfg.UsageStatistics.Prices) != 2 {
+		t.Fatalf("prices count = %d, want 2", len(cfg.UsageStatistics.Prices))
+	}
+	p := cfg.UsageStatistics.Prices[0]
+	if p.Provider != "openai" || p.Model != "gpt-4.1-mini" {
+		t.Errorf("price[0] = %+v", p)
+	}
+	if p.InputCostPerToken != 0.0000004 {
+		t.Errorf("input cost = %v", p.InputCostPerToken)
+	}
+}
+
+func TestUsageStatisticsConfigDSNNotInJSON(t *testing.T) {
+	cfg := Config{
+		SDKConfig: SDKConfig{},
+	}
+	cfg.UsageStatistics.Enabled = true
+	cfg.UsageStatistics.PostgresDSN = "postgres://secret:password@localhost/db"
+	cfg.UsageStatistics.Table = "usage_records"
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	jsonStr := string(data)
+
+	// The DSN must NOT appear in JSON output.
+	if strings.Contains(jsonStr, "secret:password") {
+		t.Error("DSN secret leaked into JSON output")
+	}
+	if strings.Contains(jsonStr, "postgres://secret") {
+		t.Error("DSN leaked into JSON output")
+	}
+	// The enabled flag should be present.
+	if !strings.Contains(jsonStr, `"enabled":true`) {
+		t.Error("enabled flag not in JSON output")
+	}
+}
+
+func TestUsageStatisticsConfigDisabledByDefault(t *testing.T) {
+	yamlInput := `port: 8080`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlInput), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.UsageStatistics.Enabled {
+		t.Error("expected disabled by default")
+	}
+}
+
+func TestParseConfigBytesUsageStatisticsTableDefault(t *testing.T) {
+	yamlInput := `
+port: 8080
+usage-statistics:
+  enabled: true
+`
+	parsed, err := ParseConfigBytes([]byte(yamlInput))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if parsed.UsageStatistics.Table != "usage_records" {
+		t.Errorf("table = %q, want usage_records", parsed.UsageStatistics.Table)
+	}
+}
+

--- a/internal/usagestats/cost.go
+++ b/internal/usagestats/cost.go
@@ -1,0 +1,68 @@
+package usagestats
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PriceMatcher looks up manual pricing for a given provider+model pair.
+type PriceMatcher struct {
+	// prices maps "provider|model" (both lowercased, trimmed) to ModelPrice.
+	prices map[string]ModelPrice
+}
+
+// NewPriceMatcher builds a price lookup table from the given manual prices.
+// Provider and model are normalized to lowercase for matching.
+func NewPriceMatcher(prices []ModelPrice) *PriceMatcher {
+	m := make(map[string]ModelPrice, len(prices))
+	for _, p := range prices {
+		key := priceKey(p.Provider, p.Model)
+		m[key] = p
+	}
+	return &PriceMatcher{prices: m}
+}
+
+// Match returns the price entry for the given provider+model pair.
+// Returns (price, true) if found, or (ModelPrice{}, false) if no match.
+// Matching is case-insensitive and trims whitespace.
+func (pm *PriceMatcher) Match(provider, model string) (ModelPrice, bool) {
+	if pm == nil {
+		return ModelPrice{}, false
+	}
+	key := priceKey(provider, model)
+	p, ok := pm.prices[key]
+	return p, ok
+}
+
+// CalculateCost computes cost micros for the given token counts using the
+// provided price. Returns (inputCostMicros, outputCostMicros, totalCostMicros).
+// One micro-dollar = 1e-6 USD.
+// The calculation uses: cost_micros = round(tokens * cost_per_token * 1e6).
+func CalculateCost(price ModelPrice, inputTokens, outputTokens int64) (inputCostMicros, outputCostMicros, totalCostMicros int64) {
+	inputCostMicros = toMicros(price.InputCostPerToken, inputTokens)
+	outputCostMicros = toMicros(price.OutputCostPerToken, outputTokens)
+	totalCostMicros = inputCostMicros + outputCostMicros
+	return
+}
+
+// MicrosToUSD converts integer micro-dollars to a float USD value.
+func MicrosToUSD(micros int64) float64 {
+	return float64(micros) / 1e6
+}
+
+func priceKey(provider, model string) string {
+	return strings.TrimSpace(strings.ToLower(provider)) + "|" + strings.TrimSpace(strings.ToLower(model))
+}
+
+func toMicros(costPerToken float64, tokens int64) int64 {
+	// cost_per_token * tokens * 1e6, rounded to nearest integer
+	return int64(float64(tokens)*costPerToken*1e6 + 0.5)
+}
+
+// String returns a human-readable description of the price matcher entries.
+func (pm *PriceMatcher) String() string {
+	if pm == nil || len(pm.prices) == 0 {
+		return "PriceMatcher(empty)"
+	}
+	return fmt.Sprintf("PriceMatcher(%d entries)", len(pm.prices))
+}

--- a/internal/usagestats/cost_test.go
+++ b/internal/usagestats/cost_test.go
@@ -1,0 +1,149 @@
+package usagestats
+
+import (
+	"math"
+	"testing"
+)
+
+func TestPriceMatcherExactMatch(t *testing.T) {
+	pm := NewPriceMatcher([]ModelPrice{
+		{Provider: "openai", Model: "gpt-4.1-mini", InputCostPerToken: 0.0000004, OutputCostPerToken: 0.0000016},
+		{Provider: "claude", Model: "claude-sonnet-4", InputCostPerToken: 0.000003, OutputCostPerToken: 0.000015},
+	})
+
+	p, ok := pm.Match("openai", "gpt-4.1-mini")
+	if !ok {
+		t.Fatal("expected match for openai/gpt-4.1-mini")
+	}
+	if p.InputCostPerToken != 0.0000004 {
+		t.Errorf("input cost = %v, want 0.0000004", p.InputCostPerToken)
+	}
+	if p.OutputCostPerToken != 0.0000016 {
+		t.Errorf("output cost = %v, want 0.0000016", p.OutputCostPerToken)
+	}
+}
+
+func TestPriceMatcherCaseInsensitive(t *testing.T) {
+	pm := NewPriceMatcher([]ModelPrice{
+		{Provider: "OpenAI", Model: "GPT-4.1-Mini", InputCostPerToken: 0.0000004, OutputCostPerToken: 0.0000016},
+	})
+
+	_, ok := pm.Match("openai", "gpt-4.1-mini")
+	if !ok {
+		t.Fatal("expected case-insensitive match")
+	}
+
+	_, ok = pm.Match("OPENAI", "GPT-4.1-MINI")
+	if !ok {
+		t.Fatal("expected uppercase match")
+	}
+}
+
+func TestPriceMatcherWhitespace(t *testing.T) {
+	pm := NewPriceMatcher([]ModelPrice{
+		{Provider: " openai ", Model: " gpt-4.1-mini ", InputCostPerToken: 0.0000004, OutputCostPerToken: 0.0000016},
+	})
+
+	_, ok := pm.Match("openai", "gpt-4.1-mini")
+	if !ok {
+		t.Fatal("expected whitespace-trimmed match")
+	}
+}
+
+func TestPriceMatcherNoMatch(t *testing.T) {
+	pm := NewPriceMatcher([]ModelPrice{
+		{Provider: "openai", Model: "gpt-4.1-mini", InputCostPerToken: 0.0000004, OutputCostPerToken: 0.0000016},
+	})
+
+	_, ok := pm.Match("anthropic", "claude-sonnet-4")
+	if ok {
+		t.Fatal("expected no match for unknown provider/model")
+	}
+}
+
+func TestPriceMatcherNil(t *testing.T) {
+	var pm *PriceMatcher
+	_, ok := pm.Match("openai", "gpt-4.1-mini")
+	if ok {
+		t.Fatal("expected no match on nil matcher")
+	}
+}
+
+func TestPriceMatcherEmpty(t *testing.T) {
+	pm := NewPriceMatcher(nil)
+	_, ok := pm.Match("openai", "gpt-4.1-mini")
+	if ok {
+		t.Fatal("expected no match on empty matcher")
+	}
+}
+
+func TestCalculateCostBasic(t *testing.T) {
+	price := ModelPrice{
+		InputCostPerToken:  0.0000004, // $0.40/1M tokens
+		OutputCostPerToken: 0.0000016, // $1.60/1M tokens
+	}
+	inputTokens := int64(1000)
+	outputTokens := int64(500)
+
+	inputMicros, outputMicros, totalMicros := CalculateCost(price, inputTokens, outputTokens)
+
+	// Expected: 1000 * 0.0000004 * 1e6 = 400 micros
+	if inputMicros != 400 {
+		t.Errorf("input cost micros = %d, want 400", inputMicros)
+	}
+	// Expected: 500 * 0.0000016 * 1e6 = 800 micros
+	if outputMicros != 800 {
+		t.Errorf("output cost micros = %d, want 800", outputMicros)
+	}
+	if totalMicros != 1200 {
+		t.Errorf("total cost micros = %d, want 1200", totalMicros)
+	}
+}
+
+func TestCalculateCostZeroTokens(t *testing.T) {
+	price := ModelPrice{
+		InputCostPerToken:  0.0000004,
+		OutputCostPerToken: 0.0000016,
+	}
+	inputMicros, outputMicros, totalMicros := CalculateCost(price, 0, 0)
+	if inputMicros != 0 || outputMicros != 0 || totalMicros != 0 {
+		t.Errorf("expected all zeros for zero tokens, got input=%d output=%d total=%d", inputMicros, outputMicros, totalMicros)
+	}
+}
+
+func TestCalculateCostRounding(t *testing.T) {
+	price := ModelPrice{
+		InputCostPerToken:  0.00000003,
+		OutputCostPerToken: 0.00000007,
+	}
+	// 1 * 0.00000003 * 1e6 = 0.03 -> rounds to 0
+	// 1 * 0.00000007 * 1e6 = 0.07 -> rounds to 0
+	inputMicros, outputMicros, totalMicros := CalculateCost(price, 1, 1)
+	if inputMicros != 0 {
+		t.Errorf("input micros = %d, want 0 (rounding)", inputMicros)
+	}
+	if outputMicros != 0 {
+		t.Errorf("output micros = %d, want 0 (rounding)", outputMicros)
+	}
+	if totalMicros != 0 {
+		t.Errorf("total micros = %d, want 0", totalMicros)
+	}
+}
+
+func TestMicrosToUSD(t *testing.T) {
+	tests := []struct {
+		micros int64
+		want   float64
+	}{
+		{0, 0},
+		{1200000, 1.2},
+		{400, 0.0004},
+		{1, 0.000001},
+	}
+	for _, tt := range tests {
+		got := MicrosToUSD(tt.micros)
+		if math.Abs(got-tt.want) > 1e-10 {
+			t.Errorf("MicrosToUSD(%d) = %f, want %f", tt.micros, got, tt.want)
+		}
+	}
+}

--- a/internal/usagestats/event.go
+++ b/internal/usagestats/event.go
@@ -1,0 +1,259 @@
+package usagestats
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+const (
+	// apiKeyIDPrefix is prepended to the hashed API key for identification.
+	apiKeyIDPrefix = "key_"
+	// apiKeyIDHexLen is how many hex characters of the SHA-256 hash to keep.
+	apiKeyIDHexLen = 16
+)
+
+// RecordToEvent converts a usage.Record into a sanitized Event suitable for
+// persistent storage. It applies strict whitelist mapping and never copies
+// sensitive fields such as raw API keys, tokens, cookies, prompts, messages,
+// response bodies, headers, or full error bodies.
+//
+// Parameters:
+//   - ctx: used to extract request ID and endpoint metadata
+//   - record: the raw usage record from the pipeline
+//   - matcher: optional price matcher for cost calculation; nil means unknown cost
+func RecordToEvent(ctx context.Context, record coreusage.Record, matcher *PriceMatcher) Event {
+	now := time.Now()
+	requestedAt := record.RequestedAt
+	if requestedAt.IsZero() {
+		requestedAt = now
+	}
+
+	provider := safeString(record.Provider)
+	model := safeString(record.Model)
+	alias := safeString(record.Alias)
+	if alias == "" {
+		alias = model
+	}
+	authType := safeString(record.AuthType)
+	authIndex := safeString(record.AuthIndex)
+	authID := safeString(record.AuthID)
+	reasoningEffort := safeString(record.ReasoningEffort)
+	endpoint := safeString(resolveEndpointFromContext(ctx))
+	requestID := safeString(resolveRequestIDFromContext(ctx))
+
+	// Sanitize API key: never store raw key, only stable hash prefix.
+	apiKeyID := SafeAPIKeyID(record.APIKey)
+
+	// Sanitize source label: only use if it looks like a safe label (email,
+	// project ID, file path), never a raw API key or token.
+	sourceLabel := safeSourceLabel(record.Source)
+
+	// Map failure to coarse error type only, never store full body.
+	failed := record.Failed
+	statusCode := record.Fail.StatusCode
+	errorType := coarseErrorType(statusCode, failed)
+	if !failed {
+		statusCode = 0
+	}
+
+	// Token detail: whitelist copy only.
+	inputTokens := record.Detail.InputTokens
+	outputTokens := record.Detail.OutputTokens
+	reasoningTokens := record.Detail.ReasoningTokens
+	cachedTokens := record.Detail.CachedTokens
+	cacheReadTokens := record.Detail.CacheReadTokens
+	cacheCreationTokens := record.Detail.CacheCreationTokens
+	totalTokens := record.Detail.TotalTokens
+	if totalTokens == 0 {
+		totalTokens = inputTokens + outputTokens + reasoningTokens
+	}
+	if totalTokens == 0 {
+		totalTokens = inputTokens + outputTokens + reasoningTokens + cachedTokens
+	}
+
+	// Cost calculation.
+	var costKnown bool
+	var inputCostMicros, outputCostMicros, totalCostMicros int64
+	if matcher != nil {
+		if price, ok := matcher.Match(provider, model); ok {
+			costKnown = true
+			inputCostMicros, outputCostMicros, totalCostMicros = CalculateCost(price, inputTokens, outputTokens)
+		}
+	}
+
+	return Event{
+		RequestID:           requestID,
+		RequestedAt:         requestedAt,
+		CallType:            classifyCallType(endpoint),
+		Provider:            provider,
+		Model:               model,
+		Alias:               alias,
+		Endpoint:            endpoint,
+		APIKeyID:            apiKeyID,
+		AuthID:              authID,
+		AuthIndex:           authIndex,
+		AuthType:            authType,
+		SourceLabel:         sourceLabel,
+		ReasoningEffort:     reasoningEffort,
+		Failed:              failed,
+		StatusCode:          statusCode,
+		ErrorType:           errorType,
+		LatencyMs:           record.Latency.Milliseconds(),
+		InputTokens:         inputTokens,
+		OutputTokens:        outputTokens,
+		ReasoningTokens:     reasoningTokens,
+		CachedTokens:        cachedTokens,
+		CacheReadTokens:     cacheReadTokens,
+		CacheCreationTokens: cacheCreationTokens,
+		TotalTokens:         totalTokens,
+		CostKnown:           costKnown,
+		InputCostMicros:     inputCostMicros,
+		OutputCostMicros:    outputCostMicros,
+		TotalCostMicros:     totalCostMicros,
+	}
+}
+
+// SafeAPIKeyID returns a non-secret stable identifier from a raw API key.
+// Returns empty string if the key is empty or whitespace-only.
+func SafeAPIKeyID(rawKey string) string {
+	rawKey = strings.TrimSpace(rawKey)
+	if rawKey == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(rawKey))
+	hexStr := hex.EncodeToString(sum[:])
+	if len(hexStr) > apiKeyIDHexLen {
+		hexStr = hexStr[:apiKeyIDHexLen]
+	}
+	return apiKeyIDPrefix + hexStr
+}
+
+// safeSourceLabel returns a display-safe source label.
+// If the source looks like it could be a raw API key (long base64/hex with no
+// @ sign), it returns empty string instead.
+func safeSourceLabel(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return ""
+	}
+	// If it contains @, it's likely an email — safe to store.
+	if strings.Contains(source, "@") {
+		return source
+	}
+	// If it looks like a file path (contains / or \), it's safe.
+	if strings.Contains(source, "/") || strings.Contains(source, "\\") {
+		return source
+	}
+	// If it's a project ID pattern (alphanumeric with - or _), and not too long,
+	// allow it as safe label.
+	if isLikelySafeLabel(source) {
+		return source
+	}
+	// Everything else (could be API key, token, etc.) is not safe.
+	return ""
+}
+
+// isLikelySafeLabel checks if the source looks like a non-secret identifier.
+func isLikelySafeLabel(s string) bool {
+	if len(s) > 128 {
+		return false
+	}
+	// Simple heuristic: if it has @ it's email (handled above).
+	// If it contains only alphanumeric, dash, underscore, dot, and spaces,
+	// and is not too long, consider it safe.
+	for _, r := range s {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
+			r == '-' || r == '_' || r == '.' || r == ' ' || r == '(' || r == ')') {
+			return false
+		}
+	}
+	return true
+}
+
+// coarseErrorType maps an HTTP status code to a coarse error classification.
+// It never returns the raw error body.
+func coarseErrorType(statusCode int, failed bool) string {
+	if !failed {
+		return ""
+	}
+	switch {
+	case statusCode <= 0:
+		return "unknown_error"
+	case statusCode >= 500:
+		return fmt.Sprintf("http_%d", statusCode)
+	case statusCode >= 400:
+		return fmt.Sprintf("http_%d", statusCode)
+	default:
+		return "unknown_error"
+	}
+}
+
+func safeString(s string) string {
+	return strings.TrimSpace(s)
+}
+
+func resolveEndpointFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	return strings.TrimSpace(internallogging.GetEndpoint(ctx))
+}
+
+func resolveRequestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	return strings.TrimSpace(internallogging.GetRequestID(ctx))
+}
+
+// classifyCallType derives a short call type label from the request endpoint path.
+// e.g. "POST /v1/chat/completions" -> "chat",
+// "POST /v1/images/generations" -> "images", etc.
+func classifyCallType(endpoint string) string {
+	// Strip method prefix ("POST ", "GET ", etc.)
+	path := endpoint
+	if idx := strings.Index(endpoint, " "); idx >= 0 {
+		path = endpoint[idx+1:]
+	}
+	path = strings.TrimSpace(path)
+
+	// Normalize: strip leading version prefix like /v1/
+	normalized := strings.TrimPrefix(path, "/v1/")
+	normalized = strings.TrimPrefix(normalized, "/v1")
+
+	// Match known API patterns.
+	switch {
+	case strings.HasPrefix(normalized, "chat/completions"):
+		return "chat"
+	case strings.HasPrefix(normalized, "completions"):
+		return "completions"
+	case strings.HasPrefix(normalized, "messages/count_tokens"):
+		return "count_tokens"
+	case strings.HasPrefix(normalized, "messages"):
+		return "chat" // Claude messages endpoint is chat
+	case strings.HasPrefix(normalized, "responses"):
+		return "responses"
+	case strings.HasPrefix(normalized, "images"):
+		return "images"
+	case strings.HasPrefix(normalized, "videos"):
+		return "videos"
+	case strings.HasPrefix(normalized, "embeddings"):
+		return "embeddings"
+	case strings.HasPrefix(normalized, "audio/"):
+		return "audio"
+	case strings.HasPrefix(normalized, "models"):
+		return "models"
+	default:
+		if normalized != "" {
+			return "other"
+		}
+		return ""
+	}
+}

--- a/internal/usagestats/event_test.go
+++ b/internal/usagestats/event_test.go
@@ -1,0 +1,357 @@
+package usagestats
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+func TestRecordToEventBasicFields(t *testing.T) {
+	record := coreusage.Record{
+		Provider:        "openai",
+		Model:           "gpt-4.1-mini",
+		Alias:           "gpt-4.1-mini",
+		AuthID:          "auth-001",
+		AuthIndex:       "abc12345",
+		AuthType:        "oauth",
+		ReasoningEffort: "high",
+		RequestedAt:     time.Date(2026, 5, 27, 4, 0, 0, 0, time.UTC),
+		Latency:         1500 * time.Millisecond,
+		Detail: coreusage.Detail{
+			InputTokens:  1000,
+			OutputTokens: 500,
+			TotalTokens:  1500,
+		},
+	}
+
+	event := RecordToEvent(context.Background(), record, nil)
+
+	if event.Provider != "openai" {
+		t.Errorf("provider = %q, want openai", event.Provider)
+	}
+	if event.Model != "gpt-4.1-mini" {
+		t.Errorf("model = %q, want gpt-4.1-mini", event.Model)
+	}
+	if event.AuthIndex != "abc12345" {
+		t.Errorf("auth_index = %q, want abc12345", event.AuthIndex)
+	}
+	if event.LatencyMs != 1500 {
+		t.Errorf("latency_ms = %d, want 1500", event.LatencyMs)
+	}
+	if event.InputTokens != 1000 {
+		t.Errorf("input_tokens = %d, want 1000", event.InputTokens)
+	}
+	if event.OutputTokens != 500 {
+		t.Errorf("output_tokens = %d, want 500", event.OutputTokens)
+	}
+	if event.TotalTokens != 1500 {
+		t.Errorf("total_tokens = %d, want 1500", event.TotalTokens)
+	}
+	if event.RequestedAt != time.Date(2026, 5, 27, 4, 0, 0, 0, time.UTC) {
+		t.Errorf("requested_at = %v, want 2026-05-27T04:00:00Z", event.RequestedAt)
+	}
+	if event.Failed {
+		t.Error("failed = true, want false")
+	}
+}
+
+func TestRecordToEventWithCost(t *testing.T) {
+	record := coreusage.Record{
+		Provider: "openai",
+		Model:    "gpt-4.1-mini",
+		Detail: coreusage.Detail{
+			InputTokens:  1000,
+			OutputTokens: 500,
+		},
+	}
+	pm := NewPriceMatcher([]ModelPrice{
+		{Provider: "openai", Model: "gpt-4.1-mini", InputCostPerToken: 0.0000004, OutputCostPerToken: 0.0000016},
+	})
+
+	event := RecordToEvent(context.Background(), record, pm)
+
+	if !event.CostKnown {
+		t.Fatal("cost_known = false, want true")
+	}
+	if event.InputCostMicros != 400 {
+		t.Errorf("input_cost_micros = %d, want 400", event.InputCostMicros)
+	}
+	if event.OutputCostMicros != 800 {
+		t.Errorf("output_cost_micros = %d, want 800", event.OutputCostMicros)
+	}
+	if event.TotalCostMicros != 1200 {
+		t.Errorf("total_cost_micros = %d, want 1200", event.TotalCostMicros)
+	}
+}
+
+func TestRecordToEventUnknownCost(t *testing.T) {
+	record := coreusage.Record{
+		Provider: "anthropic",
+		Model:    "claude-opus-4",
+		Detail: coreusage.Detail{
+			InputTokens:  2000,
+			OutputTokens: 1000,
+		},
+	}
+	pm := NewPriceMatcher([]ModelPrice{
+		{Provider: "openai", Model: "gpt-4.1-mini", InputCostPerToken: 0.0000004, OutputCostPerToken: 0.0000016},
+	})
+
+	event := RecordToEvent(context.Background(), record, pm)
+
+	if event.CostKnown {
+		t.Fatal("cost_known = true for unmatched model, want false")
+	}
+	if event.InputCostMicros != 0 || event.OutputCostMicros != 0 || event.TotalCostMicros != 0 {
+		t.Errorf("cost micros should all be 0 for unknown price, got input=%d output=%d total=%d",
+			event.InputCostMicros, event.OutputCostMicros, event.TotalCostMicros)
+	}
+}
+
+func TestRecordToEventNoMatcher(t *testing.T) {
+	record := coreusage.Record{
+		Provider: "openai",
+		Model:    "gpt-4.1-mini",
+		Detail: coreusage.Detail{
+			InputTokens:  1000,
+			OutputTokens: 500,
+		},
+	}
+
+	event := RecordToEvent(context.Background(), record, nil)
+
+	if event.CostKnown {
+		t.Fatal("cost_known = true with nil matcher, want false")
+	}
+}
+
+func TestRecordToEventAPIKeyHashing(t *testing.T) {
+	rawKey := "sk-proj-abcdef1234567890"
+	record := coreusage.Record{
+		Provider: "openai",
+		Model:    "gpt-4.1-mini",
+		APIKey:   rawKey,
+	}
+
+	event := RecordToEvent(context.Background(), record, nil)
+
+	// The raw API key must NOT appear in the event.
+	if strings.Contains(event.APIKeyID, rawKey) {
+		t.Fatal("raw API key leaked into APIKeyID")
+	}
+	// APIKeyID should start with "key_" prefix.
+	if !strings.HasPrefix(event.APIKeyID, "key_") {
+		t.Errorf("api_key_id = %q, want prefix 'key_'", event.APIKeyID)
+	}
+	// APIKeyID should have "key_" + 16 hex chars.
+	if len(event.APIKeyID) != 4+16 {
+		t.Errorf("api_key_id length = %d, want 20", len(event.APIKeyID))
+	}
+}
+
+func TestRecordToEventEmptyAPIKey(t *testing.T) {
+	record := coreusage.Record{
+		Provider: "openai",
+		Model:    "gpt-4.1-mini",
+		APIKey:   "",
+	}
+
+	event := RecordToEvent(context.Background(), record, nil)
+	if event.APIKeyID != "" {
+		t.Errorf("api_key_id = %q, want empty for empty key", event.APIKeyID)
+	}
+}
+
+func TestRecordToEventSafeSourceLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{"email", "user@example.com", "user@example.com"},
+		{"project ID", "my-project-123", "my-project-123"},
+		{"file path", "/auths/openai.json", "/auths/openai.json"},
+		{"empty", "", ""},
+		{"raw API key", "sk-proj-abcdef1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := coreusage.Record{
+				Provider: "openai",
+				Model:    "gpt-4.1-mini",
+				Source:   tt.source,
+			}
+			event := RecordToEvent(context.Background(), record, nil)
+			if event.SourceLabel != tt.want {
+				t.Errorf("source_label = %q, want %q", event.SourceLabel, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordToEventFailureCoarseErrorType(t *testing.T) {
+	tests := []struct {
+		name       string
+		failed     bool
+		statusCode int
+		want       string
+	}{
+		{"success", false, 200, ""},
+		{"429", true, 429, "http_429"},
+		{"500", true, 500, "http_500"},
+		{"403", true, 403, "http_403"},
+		{"no status", true, 0, "unknown_error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := coreusage.Record{
+				Provider: "openai",
+				Model:    "gpt-4.1-mini",
+				Failed:   tt.failed,
+				Fail:     coreusage.Failure{StatusCode: tt.statusCode, Body: "sensitive error body"},
+			}
+			event := RecordToEvent(context.Background(), record, nil)
+			if event.ErrorType != tt.want {
+				t.Errorf("error_type = %q, want %q", event.ErrorType, tt.want)
+			}
+			// The raw error body must NEVER appear in the event.
+			if strings.Contains(event.ErrorType, "sensitive error body") {
+				t.Fatal("raw error body leaked into error_type")
+			}
+		})
+	}
+}
+
+func TestRecordToEventNoSensitiveFieldsInJSON(t *testing.T) {
+	record := coreusage.Record{
+		Provider:        "openai",
+		Model:           "gpt-4.1-mini",
+		APIKey:          "sk-secret-key-12345",
+		Source:          "sk-secret-key-12345",
+		ResponseHeaders: http.Header{"Authorization": []string{"Bearer secret-token"}},
+		Fail:            coreusage.Failure{StatusCode: 500, Body: "internal server error with token abc123"},
+		Failed:          true,
+	}
+
+	event := RecordToEvent(context.Background(), record, nil)
+
+	// Serialize to JSON and check for sensitive values.
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	jsonStr := string(data)
+
+	forbidden := []string{
+		"sk-secret-key-12345",
+		"Bearer secret-token",
+		"secret-token",
+		"internal server error with token abc123",
+		"abc123",
+	}
+	for _, secret := range forbidden {
+		if strings.Contains(jsonStr, secret) {
+			t.Errorf("JSON output contains forbidden secret %q", secret)
+		}
+	}
+}
+
+func TestRecordToEventDefaultAlias(t *testing.T) {
+	record := coreusage.Record{
+		Provider: "openai",
+		Model:    "gpt-4.1-mini",
+		Alias:    "",
+	}
+
+	event := RecordToEvent(context.Background(), record, nil)
+	if event.Alias != "gpt-4.1-mini" {
+		t.Errorf("alias = %q, want model name when alias is empty", event.Alias)
+	}
+}
+
+func TestRecordToEventTotalTokensFallback(t *testing.T) {
+	record := coreusage.Record{
+		Provider: "openai",
+		Model:    "gpt-4.1-mini",
+		Detail: coreusage.Detail{
+			InputTokens:  100,
+			OutputTokens: 50,
+			// TotalTokens intentionally 0 to test fallback.
+		},
+	}
+
+	event := RecordToEvent(context.Background(), record, nil)
+	if event.TotalTokens != 150 {
+		t.Errorf("total_tokens = %d, want 150 (fallback from input+output)", event.TotalTokens)
+	}
+}
+
+func TestSafeAPIKeyIDDeterministic(t *testing.T) {
+	key := "sk-test-key"
+	id1 := SafeAPIKeyID(key)
+	id2 := SafeAPIKeyID(key)
+	if id1 != id2 {
+		t.Errorf("same key produced different IDs: %q vs %q", id1, id2)
+	}
+}
+
+func TestSafeAPIKeyIDDifferentKeys(t *testing.T) {
+	id1 := SafeAPIKeyID("key-one")
+	id2 := SafeAPIKeyID("key-two")
+	if id1 == id2 {
+		t.Errorf("different keys produced same ID: %q", id1)
+	}
+}
+
+func TestClassifyCallType(t *testing.T) {
+	tests := []struct {
+		endpoint string
+		want     string
+	}{
+		{"POST /v1/chat/completions", "chat"},
+		{"POST /v1/completions", "completions"},
+		{"POST /v1/messages", "chat"},
+		{"POST /v1/messages/count_tokens", "count_tokens"},
+		{"POST /v1/responses", "responses"},
+		{"POST /v1/images/generations", "images"},
+		{"POST /v1/images/edits", "images"},
+		{"POST /v1/videos", "videos"},
+		{"POST /v1/videos/generations", "videos"},
+		{"POST /v1/embeddings", "embeddings"},
+		{"POST /v1/audio/transcriptions", "audio"},
+		{"GET /v1/models", "models"},
+		{"POST /v1/unknown/endpoint", "other"},
+		{"", ""},
+		{"/v1/chat/completions", "chat"},
+	}
+	for _, tt := range tests {
+		got := classifyCallType(tt.endpoint)
+		if got != tt.want {
+			t.Errorf("classifyCallType(%q) = %q, want %q", tt.endpoint, got, tt.want)
+		}
+	}
+}
+
+func TestRecordToEventCallType(t *testing.T) {
+	ctx := context.Background()
+	ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
+	record := coreusage.Record{
+		Provider: "openai",
+		Model:    "gpt-4o",
+	}
+	evt := RecordToEvent(ctx, record, nil)
+	if evt.CallType != "chat" {
+		t.Errorf("CallType = %q, want %q", evt.CallType, "chat")
+	}
+	if evt.Endpoint != "POST /v1/chat/completions" {
+		t.Errorf("Endpoint = %q, want %q", evt.Endpoint, "POST /v1/chat/completions")
+	}
+}

--- a/internal/usagestats/plugin.go
+++ b/internal/usagestats/plugin.go
@@ -1,0 +1,93 @@
+package usagestats
+
+import (
+	"context"
+	"sync/atomic"
+
+	log "github.com/sirupsen/logrus"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+// Plugin implements coreusage.Plugin and persists sanitized usage events
+// to a Store. It is safe for concurrent use.
+//
+// When the store is nil or disabled, HandleUsage is a no-op.
+// Store append errors are logged but never propagate to the caller,
+// ensuring statistics recording never blocks or fails user requests.
+type Plugin struct {
+	enabled atomic.Bool
+	store   Store
+	matcher *PriceMatcher
+}
+
+// NewPlugin creates a usage statistics plugin.
+// If store is nil, the plugin is disabled and HandleUsage is a no-op.
+func NewPlugin(store Store, matcher *PriceMatcher) *Plugin {
+	p := &Plugin{
+		store:   store,
+		matcher: matcher,
+	}
+	if store != nil {
+		p.enabled.Store(true)
+	}
+	return p
+}
+
+// HandleUsage implements coreusage.Plugin.
+// It converts the record to a sanitized Event and appends it to the store.
+// Errors are logged and never returned to the caller.
+func (p *Plugin) HandleUsage(ctx context.Context, record coreusage.Record) {
+	if p == nil || !p.enabled.Load() || p.store == nil {
+		return
+	}
+
+	event := RecordToEvent(ctx, record, p.matcher)
+
+	if err := p.store.Append(ctx, event); err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"provider": event.Provider,
+			"model":    event.Model,
+		}).Warn("usagestats: failed to persist usage event")
+	}
+}
+
+// SetEnabled enables or disables the plugin.
+func (p *Plugin) SetEnabled(enabled bool) {
+	if p == nil {
+		return
+	}
+	p.enabled.Store(enabled)
+}
+
+// Enabled returns whether the plugin is active.
+func (p *Plugin) Enabled() bool {
+	if p == nil {
+		return false
+	}
+	return p.enabled.Load()
+}
+
+// SetStore updates the store. Pass nil to disable persistence.
+func (p *Plugin) SetStore(store Store) {
+	if p == nil {
+		return
+	}
+	p.store = store
+	p.enabled.Store(store != nil)
+}
+
+// SetMatcher updates the price matcher.
+func (p *Plugin) SetMatcher(matcher *PriceMatcher) {
+	if p == nil {
+		return
+	}
+	p.matcher = matcher
+}
+
+// Store returns the current store, or nil if disabled.
+func (p *Plugin) Store() Store {
+	if p == nil {
+		return nil
+	}
+	return p.store
+}

--- a/internal/usagestats/plugin_test.go
+++ b/internal/usagestats/plugin_test.go
@@ -1,0 +1,144 @@
+package usagestats
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+// mockStoreForPlugin tracks append calls.
+type mockStoreForPlugin struct {
+	appendCount atomic.Int32
+	appendErr   error
+	lastEvent   Event
+}
+
+func (m *mockStoreForPlugin) EnsureSchema(_ context.Context) error { return nil }
+func (m *mockStoreForPlugin) Append(_ context.Context, event Event) error {
+	m.lastEvent = event
+	m.appendCount.Add(1)
+	return m.appendErr
+}
+func (m *mockStoreForPlugin) Summary(_ context.Context, _ Query) (*SummaryResult, error) {
+	return nil, nil
+}
+func (m *mockStoreForPlugin) Close() error { return nil }
+
+func TestPlugin_HandleUsage_Appends(t *testing.T) {
+	store := &mockStoreForPlugin{}
+	pm := NewPriceMatcher([]ModelPrice{
+		{Provider: "openai", Model: "gpt-4.1-mini", InputCostPerToken: 0.0000004, OutputCostPerToken: 0.0000016},
+	})
+	plugin := NewPlugin(store, pm)
+
+	record := coreusage.Record{
+		Provider: "openai",
+		Model:    "gpt-4.1-mini",
+		Detail: coreusage.Detail{
+			InputTokens:  100,
+			OutputTokens: 50,
+		},
+	}
+	plugin.HandleUsage(context.Background(), record)
+
+	if store.appendCount.Load() != 1 {
+		t.Errorf("append count = %d, want 1", store.appendCount.Load())
+	}
+	if store.lastEvent.Provider != "openai" {
+		t.Errorf("provider = %q, want openai", store.lastEvent.Provider)
+	}
+	if !store.lastEvent.CostKnown {
+		t.Error("cost_known = false, want true")
+	}
+}
+
+func TestPlugin_HandleUsage_Disabled(t *testing.T) {
+	store := &mockStoreForPlugin{}
+	plugin := NewPlugin(nil, nil) // nil store means disabled
+
+	record := coreusage.Record{
+		Provider: "openai",
+		Model:    "gpt-4.1-mini",
+	}
+	plugin.HandleUsage(context.Background(), record)
+
+	if store.appendCount.Load() != 0 {
+		t.Errorf("append count = %d, want 0 for disabled plugin", store.appendCount.Load())
+	}
+}
+
+func TestPlugin_HandleUsage_StoreError_NoPanic(t *testing.T) {
+	store := &mockStoreForPlugin{
+		appendErr: fmt.Errorf("db error"),
+	}
+	plugin := NewPlugin(store, nil)
+
+	record := coreusage.Record{
+		Provider: "openai",
+		Model:    "gpt-4.1-mini",
+	}
+	// Must not panic.
+	plugin.HandleUsage(context.Background(), record)
+
+	if store.appendCount.Load() != 1 {
+		t.Errorf("append count = %d, want 1 (error does not prevent attempt)", store.appendCount.Load())
+	}
+}
+
+func TestPlugin_SetEnabled(t *testing.T) {
+	store := &mockStoreForPlugin{}
+	plugin := NewPlugin(store, nil)
+
+	if !plugin.Enabled() {
+		t.Error("expected enabled with non-nil store")
+	}
+
+	plugin.SetEnabled(false)
+	if plugin.Enabled() {
+		t.Error("expected disabled after SetEnabled(false)")
+	}
+
+	// Disabled plugin should not append.
+	record := coreusage.Record{Provider: "openai", Model: "gpt-4.1-mini"}
+	plugin.HandleUsage(context.Background(), record)
+	if store.appendCount.Load() != 0 {
+		t.Errorf("append count = %d, want 0 when disabled", store.appendCount.Load())
+	}
+}
+
+func TestPlugin_SetStore(t *testing.T) {
+	plugin := NewPlugin(nil, nil) // starts disabled
+
+	if plugin.Enabled() {
+		t.Error("expected disabled with nil store")
+	}
+
+	store := &mockStoreForPlugin{}
+	plugin.SetStore(store)
+	if !plugin.Enabled() {
+		t.Error("expected enabled after SetStore")
+	}
+
+	plugin.SetStore(nil)
+	if plugin.Enabled() {
+		t.Error("expected disabled after SetStore(nil)")
+	}
+}
+
+func TestPlugin_NilReceiver(t *testing.T) {
+	var plugin *Plugin
+	// All methods should be safe on nil.
+	plugin.HandleUsage(context.Background(), coreusage.Record{})
+	plugin.SetEnabled(true)
+	plugin.SetStore(nil)
+	plugin.SetMatcher(nil)
+	if plugin.Enabled() {
+		t.Error("nil plugin should not be enabled")
+	}
+	if plugin.Store() != nil {
+		t.Error("nil plugin store should be nil")
+	}
+}

--- a/internal/usagestats/postgres_store.go
+++ b/internal/usagestats/postgres_store.go
@@ -1,0 +1,450 @@
+package usagestats
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	defaultTableName = "usage_records"
+	maxRecentLimit   = 100
+)
+
+// PostgresStoreConfig holds configuration for the PostgreSQL-backed usage store.
+type PostgresStoreConfig struct {
+	DSN    string
+	Schema string
+	Table  string
+}
+
+// PostgresStore implements Store backed by PostgreSQL.
+type PostgresStore struct {
+	db    *sql.DB
+	cfg   PostgresStoreConfig
+	table string // fully qualified, quoted table name
+}
+
+// NewPostgresStore opens a connection and validates reachability.
+// It does NOT create schema; call EnsureSchema separately.
+func NewPostgresStore(ctx context.Context, cfg PostgresStoreConfig) (*PostgresStore, error) {
+	dsn := strings.TrimSpace(cfg.DSN)
+	if dsn == "" {
+		return nil, fmt.Errorf("usagestats: postgres DSN is required")
+	}
+	table := strings.TrimSpace(cfg.Table)
+	if table == "" {
+		table = defaultTableName
+	}
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("usagestats: open database: %w", err)
+	}
+	if err = db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("usagestats: ping database: %w", err)
+	}
+
+	return &PostgresStore{
+		db:    db,
+		cfg:   cfg,
+		table: fullTableName(cfg.Schema, table),
+	}, nil
+}
+
+// EnsureSchema creates the usage_records table and indexes idempotently.
+func (s *PostgresStore) EnsureSchema(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("usagestats: store not initialized")
+	}
+
+	// Create schema if specified.
+	if schema := strings.TrimSpace(s.cfg.Schema); schema != "" {
+		_, err := s.db.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quoteID(schema)))
+		if err != nil {
+			return fmt.Errorf("usagestats: create schema: %w", err)
+		}
+	}
+
+	// Create table.
+	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id BIGSERIAL PRIMARY KEY,
+			request_id TEXT NOT NULL DEFAULT '',
+			requested_at TIMESTAMPTZ NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			call_type TEXT NOT NULL DEFAULT '',
+			provider TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			alias TEXT NOT NULL DEFAULT '',
+			endpoint TEXT NOT NULL DEFAULT '',
+			api_key_id TEXT NOT NULL DEFAULT '',
+			auth_id TEXT NOT NULL DEFAULT '',
+			auth_index TEXT NOT NULL DEFAULT '',
+			auth_type TEXT NOT NULL DEFAULT '',
+			source_label TEXT NOT NULL DEFAULT '',
+			reasoning_effort TEXT NOT NULL DEFAULT '',
+			failed BOOLEAN NOT NULL DEFAULT FALSE,
+			status_code INTEGER NOT NULL DEFAULT 0,
+			error_type TEXT NOT NULL DEFAULT '',
+			latency_ms BIGINT NOT NULL DEFAULT 0,
+			input_tokens BIGINT NOT NULL DEFAULT 0,
+			output_tokens BIGINT NOT NULL DEFAULT 0,
+			reasoning_tokens BIGINT NOT NULL DEFAULT 0,
+			cached_tokens BIGINT NOT NULL DEFAULT 0,
+			cache_read_tokens BIGINT NOT NULL DEFAULT 0,
+			cache_creation_tokens BIGINT NOT NULL DEFAULT 0,
+			total_tokens BIGINT NOT NULL DEFAULT 0,
+			cost_known BOOLEAN NOT NULL DEFAULT FALSE,
+			input_cost_micros BIGINT NOT NULL DEFAULT 0,
+			output_cost_micros BIGINT NOT NULL DEFAULT 0,
+			total_cost_micros BIGINT NOT NULL DEFAULT 0
+		)`, s.table))
+	if err != nil {
+		return fmt.Errorf("usagestats: create table: %w", err)
+	}
+
+	// Create indexes.
+	indexes := []string{
+		fmt.Sprintf("CREATE INDEX IF NOT EXISTS usage_records_requested_at_idx ON %s (requested_at DESC)", s.table),
+		fmt.Sprintf("CREATE INDEX IF NOT EXISTS usage_records_call_type_idx ON %s (call_type, requested_at DESC)", s.table),
+		fmt.Sprintf("CREATE INDEX IF NOT EXISTS usage_records_provider_model_idx ON %s (provider, model, requested_at DESC)", s.table),
+		fmt.Sprintf("CREATE INDEX IF NOT EXISTS usage_records_api_key_idx ON %s (api_key_id, requested_at DESC)", s.table),
+		fmt.Sprintf("CREATE INDEX IF NOT EXISTS usage_records_auth_idx ON %s (auth_index, requested_at DESC)", s.table),
+	}
+	for _, idx := range indexes {
+		if _, err = s.db.ExecContext(ctx, idx); err != nil {
+			return fmt.Errorf("usagestats: create index: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Append inserts a sanitized usage event into PostgreSQL.
+func (s *PostgresStore) Append(ctx context.Context, event Event) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("usagestats: store not initialized")
+	}
+	_, err := s.db.ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO %s (
+			request_id, requested_at,
+			call_type,
+			provider, model, alias, endpoint,
+			api_key_id, auth_id, auth_index, auth_type, source_label,
+			reasoning_effort,
+			failed, status_code, error_type, latency_ms,
+			input_tokens, output_tokens, reasoning_tokens,
+			cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens,
+			cost_known, input_cost_micros, output_cost_micros, total_cost_micros
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28)
+	`, s.table),
+		event.RequestID, event.RequestedAt,
+		event.CallType,
+		event.Provider, event.Model, event.Alias, event.Endpoint,
+		event.APIKeyID, event.AuthID, event.AuthIndex, event.AuthType, event.SourceLabel,
+		event.ReasoningEffort,
+		event.Failed, event.StatusCode, event.ErrorType, event.LatencyMs,
+		event.InputTokens, event.OutputTokens, event.ReasoningTokens,
+		event.CachedTokens, event.CacheReadTokens, event.CacheCreationTokens, event.TotalTokens,
+		event.CostKnown, event.InputCostMicros, event.OutputCostMicros, event.TotalCostMicros,
+	)
+	if err != nil {
+		return fmt.Errorf("usagestats: append: %w", err)
+	}
+	return nil
+}
+
+// Summary returns aggregated usage statistics.
+func (s *PostgresStore) Summary(ctx context.Context, query Query) (*SummaryResult, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("usagestats: store not initialized")
+	}
+
+	from := query.From
+	to := query.To
+	if to.IsZero() {
+		to = time.Now()
+	}
+	if from.IsZero() {
+		from = to.AddDate(0, 0, -30) // default 30 days
+	}
+
+	groupBy := query.GroupBy
+	if groupBy == "" {
+		groupBy = GroupByDay
+	}
+
+	// Build overall summary.
+	total, err := s.queryTotal(ctx, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build grouped rows.
+	groups, err := s.queryGroups(ctx, from, to, groupBy)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build recent records.
+	var recent []RecentRecord
+	if query.RecentLimit > 0 {
+		limit := query.RecentLimit
+		if limit > maxRecentLimit {
+			limit = maxRecentLimit
+		}
+		recent, err = s.queryRecent(ctx, from, to, limit)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &SummaryResult{
+		From:    from.Format(time.RFC3339),
+		To:      to.Format(time.RFC3339),
+		GroupBy: string(groupBy),
+		Summary: *total,
+		Groups:  groups,
+		Recent:  recent,
+	}, nil
+}
+
+// Close releases the database connection.
+func (s *PostgresStore) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+func (s *PostgresStore) queryTotal(ctx context.Context, from, to time.Time) (*SummaryTotal, error) {
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT
+			COUNT(*) AS requests,
+			COUNT(*) FILTER (WHERE NOT failed) AS success,
+			COUNT(*) FILTER (WHERE failed) AS failed,
+			COALESCE(SUM(input_tokens), 0),
+			COALESCE(SUM(output_tokens), 0),
+			COALESCE(SUM(reasoning_tokens), 0),
+			COALESCE(SUM(cached_tokens), 0),
+			COALESCE(SUM(cache_read_tokens), 0),
+			COALESCE(SUM(cache_creation_tokens), 0),
+			COALESCE(SUM(total_tokens), 0),
+			COALESCE(SUM(total_cost_micros) FILTER (WHERE cost_known), 0),
+			COUNT(*) FILTER (WHERE NOT cost_known),
+			COALESCE(SUM(total_tokens) FILTER (WHERE NOT cost_known), 0)
+		FROM %s WHERE requested_at >= $1 AND requested_at < $2
+	`, s.table), from, to)
+
+	var t SummaryTotal
+	var totalCostMicros int64
+	err := row.Scan(
+		&t.Reqs, &t.OK, &t.Fail,
+		&t.Tokens.InputTokens, &t.Tokens.OutputTokens, &t.Tokens.ReasoningTokens,
+		&t.Tokens.CachedTokens, &t.Tokens.CacheReadTokens, &t.Tokens.CacheCreationTokens,
+		&t.Tokens.TotalTokens,
+		&totalCostMicros,
+		&t.Cost.UnknownReqs,
+		&t.Cost.UnknownTokens,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("usagestats: query total: %w", err)
+	}
+	t.Cost.TotalMicros = totalCostMicros
+	t.Cost.TotalUSD = MicrosToUSD(totalCostMicros)
+	t.Cost.Known = t.Cost.UnknownReqs == 0 && t.Reqs > 0
+	return &t, nil
+}
+
+func (s *PostgresStore) queryGroups(ctx context.Context, from, to time.Time, groupBy GroupBy) ([]SummaryRow, error) {
+	groupExpr := groupExprFor(groupBy)
+	if groupExpr == "" {
+		return nil, nil
+	}
+
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT
+			%s AS key,
+			COUNT(*) AS requests,
+			COUNT(*) FILTER (WHERE NOT failed) AS success,
+			COUNT(*) FILTER (WHERE failed) AS failed,
+			COALESCE(SUM(input_tokens), 0),
+			COALESCE(SUM(output_tokens), 0),
+			COALESCE(SUM(reasoning_tokens), 0),
+			COALESCE(SUM(cached_tokens), 0),
+			COALESCE(SUM(cache_read_tokens), 0),
+			COALESCE(SUM(cache_creation_tokens), 0),
+			COALESCE(SUM(total_tokens), 0),
+			COALESCE(SUM(total_cost_micros) FILTER (WHERE cost_known), 0),
+			COUNT(*) FILTER (WHERE NOT cost_known),
+			COALESCE(SUM(total_tokens) FILTER (WHERE NOT cost_known), 0)
+		FROM %s WHERE requested_at >= $1 AND requested_at < $2
+		GROUP BY %s ORDER BY MIN(requested_at) ASC
+	`, groupExpr, s.table, groupExpr), from, to)
+	if err != nil {
+		return nil, fmt.Errorf("usagestats: query groups: %w", err)
+	}
+	defer func() {
+		if errClose := rows.Close(); errClose != nil {
+			log.WithError(errClose).Debug("usagestats: close group rows")
+		}
+	}()
+
+	var result []SummaryRow
+	for rows.Next() {
+		var r SummaryRow
+		var totalCostMicros int64
+		err = rows.Scan(
+			&r.Key, &r.Reqs, &r.OK, &r.Fail,
+			&r.Tokens.InputTokens, &r.Tokens.OutputTokens, &r.Tokens.ReasoningTokens,
+			&r.Tokens.CachedTokens, &r.Tokens.CacheReadTokens, &r.Tokens.CacheCreationTokens,
+			&r.Tokens.TotalTokens,
+			&totalCostMicros,
+			&r.Cost.UnknownReqs,
+			&r.Cost.UnknownTokens,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("usagestats: scan group row: %w", err)
+		}
+		r.Cost.TotalMicros = totalCostMicros
+		r.Cost.TotalUSD = MicrosToUSD(totalCostMicros)
+		r.Cost.Known = r.Cost.UnknownReqs == 0 && r.Reqs > 0
+		result = append(result, r)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("usagestats: iterate group rows: %w", err)
+	}
+	return result, nil
+}
+
+func (s *PostgresStore) queryRecent(ctx context.Context, from, to time.Time, limit int) ([]RecentRecord, error) {
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT
+			requested_at, request_id, provider, model, alias,
+			failed, status_code, error_type, latency_ms,
+			input_tokens, output_tokens, reasoning_tokens,
+			cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens,
+			cost_known, total_cost_micros,
+			api_key_id, auth_index, auth_type, reasoning_effort
+		FROM %s WHERE requested_at >= $1 AND requested_at < $2
+		ORDER BY requested_at DESC LIMIT $3
+	`, s.table), from, to, limit)
+	if err != nil {
+		return nil, fmt.Errorf("usagestats: query recent: %w", err)
+	}
+	defer func() {
+		if errClose := rows.Close(); errClose != nil {
+			log.WithError(errClose).Debug("usagestats: close recent rows")
+		}
+	}()
+
+	var result []RecentRecord
+	for rows.Next() {
+		var rec RecentRecord
+		var requestedAt time.Time
+		var costKnown bool
+		var totalCostMicros int64
+		err = rows.Scan(
+			&requestedAt, &rec.RequestID, &rec.Provider, &rec.Model, &rec.Alias,
+			&rec.Failed, &rec.StatusCode, &rec.ErrorType, &rec.LatencyMs,
+			&rec.Tokens.InputTokens, &rec.Tokens.OutputTokens, &rec.Tokens.ReasoningTokens,
+			&rec.Tokens.CachedTokens, &rec.Tokens.CacheReadTokens, &rec.Tokens.CacheCreationTokens, &rec.Tokens.TotalTokens,
+			&costKnown, &totalCostMicros,
+			&rec.APIKeyID, &rec.AuthIndex, &rec.AuthType, &rec.ReasoningEffort,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("usagestats: scan recent row: %w", err)
+		}
+		rec.Time = requestedAt.Format(time.RFC3339)
+		rec.Cost.Known = costKnown
+		rec.Cost.TotalUSD = MicrosToUSD(totalCostMicros)
+		rec.Cost.TotalMicros = totalCostMicros
+		result = append(result, rec)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("usagestats: iterate recent rows: %w", err)
+	}
+	return result, nil
+}
+
+// groupExprFor returns the SQL expression for the given group_by dimension.
+// Returns empty string for invalid/unsupported values.
+func groupExprFor(gb GroupBy) string {
+	switch gb {
+	case GroupByDay:
+		return "TO_CHAR(requested_at, 'YYYY-MM-DD')"
+	case GroupByProvider:
+		return "provider"
+	case GroupByModel:
+		return "provider || '/' || model"
+	case GroupByAPIKey:
+		return "api_key_id"
+	case GroupByAuth:
+		return "auth_index"
+	case GroupByCallType:
+		return "call_type"
+	default:
+		return ""
+	}
+}
+
+// fullTableName returns a properly quoted table name, optionally schema-qualified.
+func fullTableName(schema, table string) string {
+	if schema = strings.TrimSpace(schema); schema != "" {
+		return quoteID(schema) + "." + quoteID(table)
+	}
+	return quoteID(table)
+}
+
+// quoteID safely quotes a PostgreSQL identifier.
+func quoteID(id string) string {
+	return "\"" + strings.ReplaceAll(id, "\"", "\"\"") + "\""
+}
+
+// ParseTime parses a query parameter as either RFC3339 or YYYY-MM-DD.
+func ParseTime(s string) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, nil
+	}
+	// Try YYYY-MM-DD first.
+	if len(s) == 10 && s[4] == '-' && s[7] == '-' {
+		t, err := time.Parse("2006-01-02", s)
+		if err == nil {
+			return t, nil
+		}
+	}
+	// Try RFC3339.
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid time format %q: expected RFC3339 or YYYY-MM-DD", s)
+	}
+	return t, nil
+}
+
+// parseInt parses a query parameter as an integer with bounds.
+func parseInt(s string, min, max, def int) (int, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return def, nil
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer %q", s)
+	}
+	if v < min {
+		v = min
+	}
+	if max > 0 && v > max {
+		v = max
+	}
+	return v, nil
+}

--- a/internal/usagestats/store.go
+++ b/internal/usagestats/store.go
@@ -1,0 +1,102 @@
+package usagestats
+
+import (
+	"context"
+	"time"
+)
+
+// Store is the persistence interface for usage statistics events.
+// Implementations must be safe for concurrent use.
+type Store interface {
+	// EnsureSchema creates required tables and indexes if they do not exist.
+	// It is idempotent and safe to call on every startup.
+	EnsureSchema(ctx context.Context) error
+
+	// Append inserts a sanitized usage event.
+	// Errors should be logged but must not fail the caller's request.
+	Append(ctx context.Context, event Event) error
+
+	// Summary returns aggregated statistics and optional recent records.
+	Summary(ctx context.Context, query Query) (*SummaryResult, error)
+
+	// Close releases underlying resources.
+	Close() error
+}
+
+// Query defines parameters for a usage statistics summary query.
+type Query struct {
+	From        time.Time
+	To          time.Time
+	GroupBy     GroupBy
+	RecentLimit int
+}
+
+// TokenSummary holds aggregated token counts.
+type TokenSummary struct {
+	InputTokens         int64 `json:"input_tokens"`
+	OutputTokens        int64 `json:"output_tokens"`
+	ReasoningTokens     int64 `json:"reasoning_tokens"`
+	CachedTokens        int64 `json:"cached_tokens"`
+	CacheReadTokens     int64 `json:"cache_read_tokens"`
+	CacheCreationTokens int64 `json:"cache_creation_tokens"`
+	TotalTokens         int64 `json:"total_tokens"`
+}
+
+// CostSummary holds aggregated cost information.
+type CostSummary struct {
+	// Known indicates whether all aggregated records had a matching price.
+	// When false, total_usd reflects only priced records; unknown counts are separate.
+	Known         bool    `json:"known"`
+	TotalUSD      float64 `json:"total_usd"`
+	TotalMicros   int64   `json:"-"`
+	UnknownReqs   int64   `json:"unknown_requests"`
+	UnknownTokens int64   `json:"unknown_tokens"`
+}
+
+// SummaryRow is one row of grouped aggregation results.
+type SummaryRow struct {
+	Key     string      `json:"key"`
+	Reqs    int64       `json:"requests"`
+	OK      int64       `json:"success"`
+	Fail    int64       `json:"failed"`
+	Tokens  TokenSummary `json:"tokens"`
+	Cost    CostSummary  `json:"cost"`
+}
+
+// SummaryTotal is the overall summary across all matching records.
+type SummaryTotal struct {
+	Reqs   int64        `json:"requests"`
+	OK     int64        `json:"success"`
+	Fail   int64        `json:"failed"`
+	Tokens TokenSummary `json:"tokens"`
+	Cost   CostSummary  `json:"cost"`
+}
+
+// RecentRecord is a sanitized recent usage record for API responses.
+type RecentRecord struct {
+	Time            string     `json:"time"`
+	RequestID       string     `json:"request_id"`
+	Provider        string     `json:"provider"`
+	Model           string     `json:"model"`
+	Alias           string     `json:"alias"`
+	StatusCode      int        `json:"status_code"`
+	Failed          bool       `json:"failed"`
+	Tokens          TokenSummary `json:"tokens"`
+	Cost            CostSummary  `json:"cost"`
+	APIKeyID        string     `json:"api_key_id"`
+	AuthIndex       string     `json:"auth_index"`
+	AuthType        string     `json:"auth_type"`
+	LatencyMs       int64      `json:"latency_ms"`
+	ErrorType       string     `json:"error_type"`
+	ReasoningEffort string     `json:"reasoning_effort"`
+}
+
+// SummaryResult is the full API response for usage statistics queries.
+type SummaryResult struct {
+	From   string        `json:"from"`
+	To     string        `json:"to"`
+	GroupBy string       `json:"group_by"`
+	Summary SummaryTotal `json:"summary"`
+	Groups  []SummaryRow `json:"groups"`
+	Recent  []RecentRecord `json:"recent,omitempty"`
+}

--- a/internal/usagestats/types.go
+++ b/internal/usagestats/types.go
@@ -1,0 +1,103 @@
+package usagestats
+
+import (
+	"time"
+)
+
+// Event is a sanitized usage record safe for persistent storage.
+// It never contains prompts, messages, response bodies, raw API keys,
+// tokens, cookies, refresh tokens, or other secret material.
+type Event struct {
+	RequestID string `json:"request_id" db:"request_id"`
+	// RequestedAt is the timestamp when the upstream request was initiated.
+	RequestedAt time.Time `json:"requested_at" db:"requested_at"`
+
+	CallType string `json:"call_type" db:"call_type"`
+
+	Provider string `json:"provider" db:"provider"`
+	Model    string `json:"model" db:"model"`
+	Alias    string `json:"alias" db:"alias"`
+	Endpoint string `json:"endpoint" db:"endpoint"`
+
+	// APIKeyID is a non-secret stable identifier derived from the client API key.
+	// It is never the raw API key value.
+	APIKeyID string `json:"api_key_id" db:"api_key_id"`
+	// AuthID is the auth record ID (non-secret file-based identifier).
+	AuthID string `json:"auth_id" db:"auth_id"`
+	// AuthIndex is a stable hash derived from auth credentials, never the raw credential.
+	AuthIndex string `json:"auth_index" db:"auth_index"`
+	// AuthType is the authentication kind, e.g. "oauth", "apikey".
+	AuthType string `json:"auth_type" db:"auth_type"`
+	// SourceLabel is a safe display label (email, project ID) for the upstream account.
+	// It is never a raw API key, token, or cookie.
+	SourceLabel string `json:"source_label" db:"source_label"`
+
+	ReasoningEffort string `json:"reasoning_effort" db:"reasoning_effort"`
+
+	Failed     bool `json:"failed" db:"failed"`
+	StatusCode int  `json:"status_code" db:"status_code"`
+	// ErrorType is a coarse error classification, e.g. "http_429", "upstream_error".
+	// It is never a full error body.
+	ErrorType string `json:"error_type" db:"error_type"`
+	LatencyMs int64 `json:"latency_ms" db:"latency_ms"`
+
+	InputTokens         int64 `json:"input_tokens" db:"input_tokens"`
+	OutputTokens        int64 `json:"output_tokens" db:"output_tokens"`
+	ReasoningTokens     int64 `json:"reasoning_tokens" db:"reasoning_tokens"`
+	CachedTokens        int64 `json:"cached_tokens" db:"cached_tokens"`
+	CacheReadTokens     int64 `json:"cache_read_tokens" db:"cache_read_tokens"`
+	CacheCreationTokens int64 `json:"cache_creation_tokens" db:"cache_creation_tokens"`
+	TotalTokens         int64 `json:"total_tokens" db:"total_tokens"`
+
+	CostKnown       bool  `json:"cost_known" db:"cost_known"`
+	InputCostMicros int64 `json:"input_cost_micros" db:"input_cost_micros"`
+	OutputCostMicros int64 `json:"output_cost_micros" db:"output_cost_micros"`
+	TotalCostMicros  int64 `json:"total_cost_micros" db:"total_cost_micros"`
+}
+
+// ModelPrice defines manual per-token pricing for a specific provider+model pair.
+type ModelPrice struct {
+	Provider           string  `yaml:"provider" json:"provider"`
+	Model              string  `yaml:"model" json:"model"`
+	InputCostPerToken  float64 `yaml:"input_cost_per_token" json:"input_cost_per_token"`
+	OutputCostPerToken float64 `yaml:"output_cost_per_token" json:"output_cost_per_token"`
+}
+
+// GroupBy defines the aggregation dimension for summary queries.
+type GroupBy string
+
+const (
+	GroupByDay      GroupBy = "day"
+	GroupByProvider GroupBy = "provider"
+	GroupByModel    GroupBy = "model"
+	GroupByAPIKey   GroupBy = "api_key"
+	GroupByAuth     GroupBy = "auth"
+	GroupByCallType GroupBy = "call_type"
+)
+
+// ValidGroupByValues returns all supported group_by values.
+func ValidGroupByValues() []GroupBy {
+	return []GroupBy{GroupByDay, GroupByProvider, GroupByModel, GroupByAPIKey, GroupByAuth, GroupByCallType}
+}
+
+// IsValidGroupBy checks whether a group_by value is valid.
+func IsValidGroupBy(s string) bool {
+	for _, gb := range ValidGroupByValues() {
+		if string(gb) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseGroupBy parses and validates a group_by string. Returns the default
+// GroupByDay for empty input.
+func ParseGroupBy(s string) (GroupBy, bool) {
+	if s == "" {
+		return GroupByDay, true
+	}
+	if IsValidGroupBy(s) {
+		return GroupBy(s), true
+	}
+	return "", false
+}


### PR DESCRIPTION
## Summary

Add lightweight, optional token/cost statistics to CLIProxyAPI with PostgreSQL persistence.

## Changes

### New `internal/usagestats/` package (9 files: 6 source + 3 tests)
- `types.go` — Event, ModelPrice, GroupBy type definitions
- `event.go` — Record→Event whitelist mapping + call_type classification
- `cost.go` — PriceMatcher + micro-dollar precision calculation
- `store.go` — Store interface + Query/SummaryResult types
- `postgres_store.go` — PostgreSQL implementation (auto schema, indexes, aggregate queries)
- `plugin.go` — usage.Plugin implementation (async consumption of usage.Record)

### Modified files (7)
- `cmd/server/main.go` — startup wiring
- `internal/api/server.go` — route registration
- `internal/api/handlers/management/` — HTTP handler + store injection
- `internal/config/` — UsageStatisticsConfig + parsing + tests
- `config.example.yaml` — configuration examples

## Features

- Optional feature, disabled by default (`usage-statistics.enabled: false`)
- Graceful degradation when PostgreSQL is unavailable (warning log only)
- 6 aggregation dimensions: day, provider, model, api_key, auth, call_type
- Auto `call_type` classification from request endpoint (chat, images, embeddings, etc.)
- Cost stored as integer micro-dollars to avoid floating-point precision issues
- **Never stores** prompts, messages, response bodies, or raw API keys

## API

```
GET /v0/management/usage-statistics/summary
  ?from=2026-05-20&to=2026-05-27&group_by=day&recent_limit=0
```

## Configuration

```yaml
usage-statistics:
  enabled: true
  postgres-dsn: "postgres://user:pass@localhost:5432/mydb"
  model-prices:
    - provider: "openai"
      model: "gpt-4o"
      input_cost_per_token: 0.0000025
      output_cost_per_token: 0.00001
```

## Testing

```bash
go test ./internal/usagestats/... -run 'TestClassifyCallType|TestRecordToEventCallType|TestCalculateCost|TestPriceMatcher'
```