### PR TITLE
feat(management): batch credential status and error-clear endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,22 @@ go build -o test-output ./cmd/server && rm test-output # Verify compile (REQUIRE
 - Auth material defaults under `auths/`
 - Storage backends: file-based default; optional Postgres/git/object store (`PGSTORE_*`, `GITSTORE_*`, `OBJECTSTORE_*`)
 
+### Auth refresh config keys (added in patch series)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `auth-refresh-jitter-minutes` | int | `0` (off) | Spreads refresh scheduling by up to N minutes per credential using a stable FNV-64a hash of the auth ID. Prevents all credentials provisioned at the same time from refreshing simultaneously. |
+| `auth-max-concurrent-refresh-per-provider` | int | `3` | Limits simultaneous token refreshes to the same upstream provider. Prevents thundering-herd on provider token endpoints when many credentials expire around the same time. |
+| `auth-circuit-breaker-threshold` | int | `5` | Number of consecutive transient errors (HTTP 408/500/502/503/504) before the circuit opens and `NextRetryAfter` is extended to the cooldown window. Set to `-1` to disable. |
+| `auth-circuit-breaker-cooldown-minutes` | int | `10` | How long an opened circuit keeps the credential on cooldown before it is eligible for retry. |
+
+### Batch credential management endpoints (added in patch series)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v0/management/auth-files/batch-status` | Enable or disable multiple credentials. Accepts `{"names": [...], "disabled": true}` (uniform) or `[{"name": "...", "disabled": false}]` (per-item). Returns `{"updated": N, "failed": [...]}`. |
+| `POST` | `/v0/management/auth-files/batch-clear-errors` | Reset error/unavailable state on multiple credentials. Accepts `{"names": [...], "provider": "claude"}`. Returns `{"cleared": N}`. Useful after provider outages to unblock credentials without waiting for backoff. |
+
 ## Architecture
 - `cmd/server/` — Server entrypoint
 - `internal/api/` — Gin HTTP API (routes, middleware, modules)

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -3002,6 +3002,196 @@ func (h *Handler) GetAuthStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "wait"})
 }
 
+// BatchPatchAuthFileStatus enables or disables multiple credentials in one call.
+//
+// POST /v0/management/auth-files/batch-status
+//
+// Accepts either a uniform object body:
+//
+//	{"names": ["a.json", "b.json"], "disabled": true}
+//
+// or a per-item array body:
+//
+//	[{"name": "a.json", "disabled": true}, {"name": "b.json", "disabled": false}]
+//
+// Returns {"updated": N, "failed": [...]} where failed contains names that were not found.
+func (h *Handler) BatchPatchAuthFileStatus(c *gin.Context) {
+	if h.authManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
+		return
+	}
+
+	type itemReq struct {
+		Name     string `json:"name"`
+		Disabled *bool  `json:"disabled"`
+	}
+	type uniformReq struct {
+		Names    []string `json:"names"`
+		Disabled *bool    `json:"disabled"`
+	}
+
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read body"})
+		return
+	}
+	body = bytes.TrimSpace(body)
+
+	var items []itemReq
+	if len(body) > 0 && body[0] == '[' {
+		if err := json.Unmarshal(body, &items); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+	} else {
+		var req uniformReq
+		if err := json.Unmarshal(body, &req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+		if req.Disabled == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "disabled is required"})
+			return
+		}
+		for _, name := range req.Names {
+			d := *req.Disabled
+			items = append(items, itemReq{Name: name, Disabled: &d})
+		}
+	}
+
+	if len(items) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no items provided"})
+		return
+	}
+
+	ctx := c.Request.Context()
+	updated := 0
+	var failed []string
+	now := time.Now()
+
+	for _, item := range items {
+		name := strings.TrimSpace(item.Name)
+		if name == "" || item.Disabled == nil {
+			failed = append(failed, name)
+			continue
+		}
+
+		var target *coreauth.Auth
+		if auth, ok := h.authManager.GetByID(name); ok {
+			target = auth
+		} else {
+			for _, auth := range h.authManager.List() {
+				if auth.FileName == name {
+					target = auth
+					break
+				}
+			}
+		}
+		if target == nil {
+			failed = append(failed, name)
+			continue
+		}
+
+		target.Disabled = *item.Disabled
+		target.UpdatedAt = now
+		if *item.Disabled {
+			target.Status = coreauth.StatusDisabled
+			target.StatusMessage = "disabled via management API"
+		} else {
+			target.Status = coreauth.StatusActive
+			target.StatusMessage = ""
+		}
+		if _, err := h.authManager.Update(ctx, target); err != nil {
+			failed = append(failed, name)
+			continue
+		}
+		updated++
+	}
+
+	c.JSON(http.StatusOK, gin.H{"updated": updated, "failed": failed})
+}
+
+// BatchClearAuthErrors resets the error/unavailable state on multiple credentials.
+// Useful after a provider outage to unblock credentials without waiting for the
+// built-in backoff to expire.
+//
+// POST /v0/management/auth-files/batch-clear-errors
+//
+// Body: {"names": ["a.json"], "provider": "claude"}
+//   - names: specific auth IDs or file names to clear (optional if provider is given)
+//   - provider: if set, clears all credentials for that provider (case-insensitive)
+//
+// Returns {"cleared": N}.
+func (h *Handler) BatchClearAuthErrors(c *gin.Context) {
+	if h.authManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
+		return
+	}
+
+	var req struct {
+		Names    []string `json:"names"`
+		Provider string   `json:"provider"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	if len(req.Names) == 0 && strings.TrimSpace(req.Provider) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "names or provider is required"})
+		return
+	}
+
+	provider := strings.ToLower(strings.TrimSpace(req.Provider))
+	nameSet := make(map[string]struct{}, len(req.Names))
+	for _, n := range req.Names {
+		if n = strings.TrimSpace(n); n != "" {
+			nameSet[n] = struct{}{}
+		}
+	}
+
+	ctx := c.Request.Context()
+	cleared := 0
+	now := time.Now()
+
+	for _, auth := range h.authManager.List() {
+		matched := false
+		if provider != "" && strings.ToLower(auth.Provider) == provider {
+			matched = true
+		}
+		if !matched {
+			if _, ok := nameSet[auth.ID]; ok {
+				matched = true
+			}
+		}
+		if !matched {
+			if _, ok := nameSet[auth.FileName]; ok {
+				matched = true
+			}
+		}
+		if !matched {
+			continue
+		}
+
+		auth.Unavailable = false
+		auth.NextRetryAfter = time.Time{}
+		auth.LastError = nil
+		auth.StatusMessage = ""
+		if auth.Status == coreauth.StatusError {
+			auth.Status = coreauth.StatusActive
+		}
+		auth.Quota = coreauth.QuotaState{}
+		auth.UpdatedAt = now
+
+		if _, err := h.authManager.Update(ctx, auth); err != nil {
+			continue
+		}
+		cleared++
+	}
+
+	c.JSON(http.StatusOK, gin.H{"cleared": cleared})
+}
+
 // PopulateAuthContext extracts request info and adds it to the context
 func PopulateAuthContext(ctx context.Context, c *gin.Context) context.Context {
 	info := &coreauth.RequestInfo{

--- a/internal/api/handlers/management/auth_files_batch_ops_test.go
+++ b/internal/api/handlers/management/auth_files_batch_ops_test.go
@@ -1,0 +1,331 @@
+package management
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func registerBatchTestAuth(t *testing.T, m *coreauth.Manager, id, provider, fileName string) {
+	t.Helper()
+	_, err := m.Register(context.Background(), &coreauth.Auth{
+		ID:       id,
+		Provider: provider,
+		FileName: fileName,
+		Metadata: map[string]any{"email": id + "@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("register auth %s: %v", id, err)
+	}
+}
+
+// ---- BatchPatchAuthFileStatus ----
+
+func TestBatchPatchAuthFileStatus_UniformBody_DisablesAll(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := coreauth.NewManager(nil, nil, nil)
+	registerBatchTestAuth(t, m, "auth-1", "claude", "auth1.json")
+	registerBatchTestAuth(t, m, "auth-2", "claude", "auth2.json")
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, m)
+
+	disabled := true
+	reqBody, _ := json.Marshal(map[string]any{"names": []string{"auth-1", "auth-2"}, "disabled": disabled})
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/batch-status", bytes.NewReader(reqBody))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.BatchPatchAuthFileStatus(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := int(resp["updated"].(float64)); got != 2 {
+		t.Fatalf("expected updated=2, got %d", got)
+	}
+
+	for _, id := range []string{"auth-1", "auth-2"} {
+		auth, ok := m.GetByID(id)
+		if !ok {
+			t.Fatalf("auth %s not found after batch disable", id)
+		}
+		if !auth.Disabled {
+			t.Fatalf("auth %s: expected Disabled=true", id)
+		}
+		if auth.Status != coreauth.StatusDisabled {
+			t.Fatalf("auth %s: expected Status=disabled, got %v", id, auth.Status)
+		}
+	}
+}
+
+func TestBatchPatchAuthFileStatus_PerItemBody_MixedEnable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := coreauth.NewManager(nil, nil, nil)
+	registerBatchTestAuth(t, m, "auth-a", "claude", "a.json")
+	registerBatchTestAuth(t, m, "auth-b", "claude", "b.json")
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, m)
+
+	d1 := false
+	d2 := true
+	items := []map[string]any{
+		{"name": "auth-a", "disabled": d1},
+		{"name": "auth-b", "disabled": d2},
+	}
+	reqBody, _ := json.Marshal(items)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/batch-status", bytes.NewReader(reqBody))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.BatchPatchAuthFileStatus(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	authA, _ := m.GetByID("auth-a")
+	if authA.Disabled {
+		t.Fatalf("auth-a should be enabled")
+	}
+	authB, _ := m.GetByID("auth-b")
+	if !authB.Disabled {
+		t.Fatalf("auth-b should be disabled")
+	}
+}
+
+func TestBatchPatchAuthFileStatus_LookupByFileName(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := coreauth.NewManager(nil, nil, nil)
+	registerBatchTestAuth(t, m, "auth-x", "claude", "myfile.json")
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, m)
+
+	disabled := true
+	reqBody, _ := json.Marshal(map[string]any{"names": []string{"myfile.json"}, "disabled": disabled})
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/batch-status", bytes.NewReader(reqBody))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.BatchPatchAuthFileStatus(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	auth, _ := m.GetByID("auth-x")
+	if !auth.Disabled {
+		t.Fatal("expected auth to be disabled via fileName lookup")
+	}
+}
+
+func TestBatchPatchAuthFileStatus_UnknownNameGoesToFailed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := coreauth.NewManager(nil, nil, nil)
+	registerBatchTestAuth(t, m, "real-auth", "claude", "real.json")
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, m)
+
+	disabled := true
+	reqBody, _ := json.Marshal(map[string]any{"names": []string{"real-auth", "ghost-auth"}, "disabled": disabled})
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/batch-status", bytes.NewReader(reqBody))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.BatchPatchAuthFileStatus(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if int(resp["updated"].(float64)) != 1 {
+		t.Fatalf("expected updated=1, got %v", resp["updated"])
+	}
+	failed, _ := resp["failed"].([]any)
+	if len(failed) != 1 || failed[0].(string) != "ghost-auth" {
+		t.Fatalf("expected failed=[ghost-auth], got %v", failed)
+	}
+}
+
+func TestBatchPatchAuthFileStatus_EmptyBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := coreauth.NewManager(nil, nil, nil)
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, m)
+
+	reqBody, _ := json.Marshal(map[string]any{"names": []string{}, "disabled": true})
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/batch-status", bytes.NewReader(reqBody))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.BatchPatchAuthFileStatus(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty names, got %d", rec.Code)
+	}
+}
+
+// ---- BatchClearAuthErrors ----
+
+func TestBatchClearAuthErrors_ByProvider(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := coreauth.NewManager(nil, nil, nil)
+
+	registerBatchTestAuth(t, m, "err-1", "claude", "err1.json")
+	registerBatchTestAuth(t, m, "err-2", "claude", "err2.json")
+	registerBatchTestAuth(t, m, "err-3", "codex", "err3.json")
+
+	// Mark err-1 and err-2 as having errors.
+	for _, id := range []string{"err-1", "err-2"} {
+		auth, _ := m.GetByID(id)
+		auth.Unavailable = true
+		auth.Status = coreauth.StatusError
+		auth.StatusMessage = "something went wrong"
+		auth.LastError = &coreauth.Error{Message: "upstream error", HTTPStatus: 503}
+		m.Update(context.Background(), auth) //nolint
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, m)
+
+	reqBody, _ := json.Marshal(map[string]any{"provider": "claude"})
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/batch-clear-errors", bytes.NewReader(reqBody))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.BatchClearAuthErrors(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if int(resp["cleared"].(float64)) != 2 {
+		t.Fatalf("expected cleared=2, got %v", resp["cleared"])
+	}
+
+	for _, id := range []string{"err-1", "err-2"} {
+		auth, _ := m.GetByID(id)
+		if auth.Unavailable {
+			t.Fatalf("auth %s: Unavailable should be cleared", id)
+		}
+		if auth.LastError != nil {
+			t.Fatalf("auth %s: LastError should be nil after clear", id)
+		}
+		if auth.Status == coreauth.StatusError {
+			t.Fatalf("auth %s: Status should not be error after clear", id)
+		}
+	}
+
+	// codex auth should be untouched.
+	errAuth3, _ := m.GetByID("err-3")
+	if errAuth3.Unavailable {
+		t.Fatal("err-3 (codex) should not have been cleared by claude provider filter")
+	}
+}
+
+func TestBatchClearAuthErrors_ByName(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := coreauth.NewManager(nil, nil, nil)
+
+	registerBatchTestAuth(t, m, "clr-a", "claude", "clr-a.json")
+	registerBatchTestAuth(t, m, "clr-b", "claude", "clr-b.json")
+
+	for _, id := range []string{"clr-a", "clr-b"} {
+		auth, _ := m.GetByID(id)
+		auth.Unavailable = true
+		auth.Status = coreauth.StatusError
+		m.Update(context.Background(), auth) //nolint
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, m)
+
+	// Only clear clr-a by ID.
+	reqBody, _ := json.Marshal(map[string]any{"names": []string{"clr-a"}})
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/batch-clear-errors", bytes.NewReader(reqBody))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.BatchClearAuthErrors(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	authA, _ := m.GetByID("clr-a")
+	if authA.Unavailable {
+		t.Fatal("clr-a should have been cleared")
+	}
+	authB, _ := m.GetByID("clr-b")
+	if !authB.Unavailable {
+		t.Fatal("clr-b should not have been cleared")
+	}
+}
+
+func TestBatchClearAuthErrors_MissingBothNamesAndProvider(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := coreauth.NewManager(nil, nil, nil)
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, m)
+
+	reqBody, _ := json.Marshal(map[string]any{})
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/batch-clear-errors", bytes.NewReader(reqBody))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.BatchClearAuthErrors(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBatchClearAuthErrors_QuotaStateCleared(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := coreauth.NewManager(nil, nil, nil)
+
+	registerBatchTestAuth(t, m, "quota-auth", "claude", "quota.json")
+
+	auth, _ := m.GetByID("quota-auth")
+	auth.Quota = coreauth.QuotaState{Exceeded: true, Reason: "quota", BackoffLevel: 3}
+	auth.Status = coreauth.StatusError
+	m.Update(context.Background(), auth) //nolint
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, m)
+
+	reqBody, _ := json.Marshal(map[string]any{"names": []string{"quota-auth"}})
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/auth-files/batch-clear-errors", bytes.NewReader(reqBody))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	h.BatchClearAuthErrors(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	updated, _ := m.GetByID("quota-auth")
+	if updated.Quota.Exceeded {
+		t.Fatal("QuotaState.Exceeded should be cleared")
+	}
+	if updated.Quota.BackoffLevel != 0 {
+		t.Fatalf("QuotaState.BackoffLevel should be 0, got %d", updated.Quota.BackoffLevel)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -697,6 +697,8 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.DELETE("/auth-files", s.mgmt.DeleteAuthFile)
 		mgmt.PATCH("/auth-files/status", s.mgmt.PatchAuthFileStatus)
 		mgmt.PATCH("/auth-files/fields", s.mgmt.PatchAuthFileFields)
+		mgmt.POST("/auth-files/batch-status", s.mgmt.BatchPatchAuthFileStatus)
+		mgmt.POST("/auth-files/batch-clear-errors", s.mgmt.BatchClearAuthErrors)
 		mgmt.POST("/vertex/import", s.mgmt.ImportVertexCredential)
 
 		mgmt.GET("/anthropic-auth-url", s.mgmt.RequestAnthropicToken)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,11 @@ type Config struct {
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`
 
+	// AuthRefreshJitterMinutes adds a per-credential random jitter (0..N minutes) to refresh
+	// scheduling. Spreads simultaneous refreshes when many credentials share similar expiry
+	// times (e.g. after bulk onboarding). When <= 0, no jitter is applied.
+	AuthRefreshJitterMinutes int `yaml:"auth-refresh-jitter-minutes" json:"auth-refresh-jitter-minutes"`
+
 	// RequestRetry defines the retry times when the request failed.
 	RequestRetry int `yaml:"request-retry" json:"request-retry"`
 	// MaxRetryCredentials defines the maximum number of credentials to try for a failed request.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,11 @@ type Config struct {
 	// times (e.g. after bulk onboarding). When <= 0, no jitter is applied.
 	AuthRefreshJitterMinutes int `yaml:"auth-refresh-jitter-minutes" json:"auth-refresh-jitter-minutes"`
 
+	// AuthMaxConcurrentRefreshPerProvider limits how many token refresh operations can run
+	// simultaneously for the same provider. Prevents bursts of refreshes from overwhelming
+	// provider token endpoints. When <= 0, the default (3) is used.
+	AuthMaxConcurrentRefreshPerProvider int `yaml:"auth-max-concurrent-refresh-per-provider" json:"auth-max-concurrent-refresh-per-provider"`
+
 	// RequestRetry defines the retry times when the request failed.
 	RequestRetry int `yaml:"request-retry" json:"request-retry"`
 	// MaxRetryCredentials defines the maximum number of credentials to try for a failed request.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,15 @@ type Config struct {
 	// provider token endpoints. When <= 0, the default (3) is used.
 	AuthMaxConcurrentRefreshPerProvider int `yaml:"auth-max-concurrent-refresh-per-provider" json:"auth-max-concurrent-refresh-per-provider"`
 
+	// AuthCircuitBreakerThreshold is the number of consecutive transient errors (5xx/408)
+	// required before a credential's circuit is opened. When <= 0, the default (5) is used.
+	// Set to -1 to disable the circuit breaker entirely.
+	AuthCircuitBreakerThreshold int `yaml:"auth-circuit-breaker-threshold" json:"auth-circuit-breaker-threshold"`
+
+	// AuthCircuitBreakerCooldownMinutes is how long (in minutes) to hold a credential in the
+	// open-circuit state before allowing it to be retried. When <= 0, the default (10) is used.
+	AuthCircuitBreakerCooldownMinutes int `yaml:"auth-circuit-breaker-cooldown-minutes" json:"auth-circuit-breaker-cooldown-minutes"`
+
 	// RequestRetry defines the retry times when the request failed.
 	RequestRetry int `yaml:"request-retry" json:"request-retry"`
 	// MaxRetryCredentials defines the maximum number of credentials to try for a failed request.

--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -3,17 +3,21 @@ package auth
 import (
 	"container/heap"
 	"context"
+	"hash/fnv"
 	"strings"
 	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
 type authAutoRefreshLoop struct {
-	manager     *Manager
-	interval    time.Duration
-	concurrency int
+	manager      *Manager
+	interval     time.Duration
+	concurrency  int
+	jitterWindow time.Duration // max random jitter added to refresh scheduling
 
 	mu    sync.Mutex
 	queue refreshMinHeap
@@ -35,15 +39,34 @@ func newAuthAutoRefreshLoop(manager *Manager, interval time.Duration, concurrenc
 	if jobBuffer < 64 {
 		jobBuffer = 64
 	}
-	return &authAutoRefreshLoop{
-		manager:     manager,
-		interval:    interval,
-		concurrency: concurrency,
-		index:       make(map[string]*refreshHeapItem),
-		dirty:       make(map[string]struct{}),
-		wakeCh:      make(chan struct{}, 1),
-		jobs:        make(chan string, jobBuffer),
+	var jitter time.Duration
+	if cfg, ok := manager.runtimeConfig.Load().(*internalconfig.Config); ok && cfg != nil {
+		if cfg.AuthRefreshJitterMinutes > 0 {
+			jitter = time.Duration(cfg.AuthRefreshJitterMinutes) * time.Minute
+		}
 	}
+	return &authAutoRefreshLoop{
+		manager:      manager,
+		interval:     interval,
+		concurrency:  concurrency,
+		jitterWindow: jitter,
+		index:        make(map[string]*refreshHeapItem),
+		dirty:        make(map[string]struct{}),
+		wakeCh:       make(chan struct{}, 1),
+		jobs:         make(chan string, jobBuffer),
+	}
+}
+
+// stableJitter returns a deterministic duration in [0, window) derived from the auth ID.
+// Using a hash of the ID ensures the same credential always gets the same offset, so
+// rebuild() doesn't shift scheduled refreshes unpredictably.
+func stableJitter(authID string, window time.Duration) time.Duration {
+	if window <= 0 || authID == "" {
+		return 0
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(authID))
+	return time.Duration(h.Sum64() % uint64(window))
 }
 
 func (l *authAutoRefreshLoop) queueReschedule(authID string) {
@@ -100,7 +123,7 @@ func (l *authAutoRefreshLoop) rebuild(now time.Time) {
 
 	l.manager.mu.RLock()
 	for id, auth := range l.manager.auths {
-		next, ok := nextRefreshCheckAt(now, auth, l.interval)
+		next, ok := nextRefreshCheckAt(now, auth, l.interval, l.jitterWindow)
 		if !ok {
 			continue
 		}
@@ -231,7 +254,7 @@ func (l *authAutoRefreshLoop) handleDueAuth(ctx context.Context, now time.Time, 
 		manager.mu.RUnlock()
 		return
 	}
-	next, shouldSchedule := nextRefreshCheckAt(now, auth, l.interval)
+	next, shouldSchedule := nextRefreshCheckAt(now, auth, l.interval, l.jitterWindow)
 	shouldRefresh := manager.shouldRefresh(auth, now)
 	exec := manager.executors[auth.Provider]
 	manager.mu.RUnlock()
@@ -254,7 +277,7 @@ func (l *authAutoRefreshLoop) handleDueAuth(ctx context.Context, now time.Time, 
 	if !manager.markRefreshPending(authID, now) {
 		manager.mu.RLock()
 		auth = manager.auths[authID]
-		next, shouldSchedule = nextRefreshCheckAt(now, auth, l.interval)
+		next, shouldSchedule = nextRefreshCheckAt(now, auth, l.interval, l.jitterWindow)
 		manager.mu.RUnlock()
 		if shouldSchedule {
 			l.upsert(authID, next)
@@ -280,7 +303,7 @@ func (l *authAutoRefreshLoop) applyDirty(now time.Time) {
 	for _, authID := range dirty {
 		l.manager.mu.RLock()
 		auth := l.manager.auths[authID]
-		next, ok := nextRefreshCheckAt(now, auth, l.interval)
+		next, ok := nextRefreshCheckAt(now, auth, l.interval, l.jitterWindow)
 		l.manager.mu.RUnlock()
 
 		if !ok {
@@ -335,7 +358,10 @@ func (l *authAutoRefreshLoop) remove(authID string) {
 	delete(l.index, authID)
 }
 
-func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time.Time, bool) {
+// nextRefreshCheckAt computes when auth should next be checked for refresh.
+// jitterWindow, if > 0, adds a stable per-credential random offset to the
+// scheduled time to spread bulk-provisioned credentials over a rolling window.
+func nextRefreshCheckAt(now time.Time, auth *Auth, interval, jitterWindow time.Duration) (time.Time, bool) {
 	if auth == nil {
 		return time.Time{}, false
 	}
@@ -392,20 +418,22 @@ func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time
 		return next, true
 	}
 
+	jitter := stableJitter(auth.ID, jitterWindow)
+
 	provider := strings.ToLower(auth.Provider)
 	lead := ProviderRefreshLead(provider, auth.Runtime)
 	if lead == nil {
 		return time.Time{}, false
 	}
 	if hasExpiry && !expiry.IsZero() {
-		dueAt := expiry.Add(-*lead)
+		dueAt := expiry.Add(-*lead).Add(jitter)
 		if !dueAt.After(now) {
 			return now, true
 		}
 		return dueAt, true
 	}
 	if !lastRefresh.IsZero() {
-		dueAt := lastRefresh.Add(*lead)
+		dueAt := lastRefresh.Add(*lead).Add(jitter)
 		if !dueAt.After(now) {
 			return now, true
 		}

--- a/sdk/cliproxy/auth/auto_refresh_loop_test.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop_test.go
@@ -52,7 +52,7 @@ func TestNextRefreshCheckAt_DisabledUnschedule(t *testing.T) {
 		},
 	}
 
-	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute)
+	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, 0)
 	if !ok {
 		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
 	}
@@ -65,7 +65,7 @@ func TestNextRefreshCheckAt_DisabledUnschedule(t *testing.T) {
 func TestNextRefreshCheckAt_APIKeyUnschedule(t *testing.T) {
 	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
 	auth := &Auth{ID: "a1", Provider: "test", Attributes: map[string]string{"api_key": "k"}}
-	if _, ok := nextRefreshCheckAt(now, auth, 15*time.Minute); ok {
+	if _, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, 0); ok {
 		t.Fatalf("nextRefreshCheckAt() ok = true, want false")
 	}
 }
@@ -79,7 +79,7 @@ func TestNextRefreshCheckAt_NextRefreshAfterGate(t *testing.T) {
 		NextRefreshAfter: nextAfter,
 		Metadata:         map[string]any{"email": "x@example.com"},
 	}
-	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute)
+	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, 0)
 	if !ok {
 		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
 	}
@@ -101,7 +101,7 @@ func TestNextRefreshCheckAt_PreferredInterval_PicksEarliestCandidate(t *testing.
 			"refresh_interval_seconds": 900, // 15m
 		},
 	}
-	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute)
+	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, 0)
 	if !ok {
 		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
 	}
@@ -129,7 +129,7 @@ func TestNextRefreshCheckAt_ProviderLead_Expiry(t *testing.T) {
 		},
 	}
 
-	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute)
+	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, 0)
 	if !ok {
 		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
 	}
@@ -148,7 +148,7 @@ func TestNextRefreshCheckAt_RefreshEvaluatorFallback(t *testing.T) {
 		Metadata: map[string]any{"email": "x@example.com"},
 		Runtime:  testRefreshEvaluator{},
 	}
-	got, ok := nextRefreshCheckAt(now, auth, interval)
+	got, ok := nextRefreshCheckAt(now, auth, interval, 0)
 	if !ok {
 		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
 	}

--- a/sdk/cliproxy/auth/circuit_breaker_test.go
+++ b/sdk/cliproxy/auth/circuit_breaker_test.go
@@ -1,0 +1,233 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func registerAuthForCB(t *testing.T, m *Manager, id, provider string) {
+	t.Helper()
+	_, err := m.Register(context.Background(), &Auth{
+		ID:       id,
+		Provider: provider,
+		Metadata: map[string]any{"email": id + "@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("register auth %s: %v", id, err)
+	}
+}
+
+// markTransientFailureWithModel uses the model path so that auth.NextRetryAfter
+// is only set by the circuit breaker (model-state aggregation for 503 sets model
+// state.NextRetryAfter to now+1m, but circuit breaker sets auth.NextRetryAfter
+// to now+cooldown when threshold is reached).
+func markTransientFailureWithModel(m *Manager, authID string, statusCode int) {
+	m.MarkResult(context.Background(), Result{
+		AuthID:  authID,
+		Model:   "test-model",
+		Success: false,
+		Error:   &Error{HTTPStatus: statusCode},
+	})
+}
+
+func markSuccessWithModel(m *Manager, authID string) {
+	m.MarkResult(context.Background(), Result{
+		AuthID:  authID,
+		Model:   "test-model",
+		Success: true,
+	})
+}
+
+// TestCircuitBreaker_CounterIncrements verifies ConsecutiveTransientFailures increments
+// on each transient failure.
+func TestCircuitBreaker_CounterIncrements(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		AuthCircuitBreakerThreshold:       10,
+		AuthCircuitBreakerCooldownMinutes: 10,
+	})
+	registerAuthForCB(t, m, "cb-count", "claude")
+
+	for i := 1; i <= 3; i++ {
+		markTransientFailureWithModel(m, "cb-count", 503)
+		auth, ok := m.GetByID("cb-count")
+		if !ok {
+			t.Fatal("auth not found")
+		}
+		if auth.ConsecutiveTransientFailures != i {
+			t.Fatalf("after failure %d: expected ConsecutiveTransientFailures=%d, got %d", i, i, auth.ConsecutiveTransientFailures)
+		}
+	}
+}
+
+// TestCircuitBreaker_OpensAfterThreshold verifies that NextRetryAfter is extended
+// to the cooldown duration once ConsecutiveTransientFailures reaches the threshold.
+func TestCircuitBreaker_OpensAfterThreshold(t *testing.T) {
+	const threshold = 3
+	const cooldownMins = 10
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		AuthCircuitBreakerThreshold:       threshold,
+		AuthCircuitBreakerCooldownMinutes: cooldownMins,
+	})
+	registerAuthForCB(t, m, "cb-open", "claude")
+
+	// threshold-1 failures — counter at 2, circuit not yet open.
+	for i := 0; i < threshold-1; i++ {
+		markTransientFailureWithModel(m, "cb-open", 503)
+	}
+	auth, _ := m.GetByID("cb-open")
+	if auth.ConsecutiveTransientFailures != threshold-1 {
+		t.Fatalf("after %d failures: expected counter=%d, got %d", threshold-1, threshold-1, auth.ConsecutiveTransientFailures)
+	}
+
+	// threshold-th failure — circuit should open; NextRetryAfter extended to cooldown.
+	before := time.Now()
+	markTransientFailureWithModel(m, "cb-open", 503)
+	after := time.Now()
+
+	auth, _ = m.GetByID("cb-open")
+	if auth.ConsecutiveTransientFailures < threshold {
+		t.Fatalf("expected ConsecutiveTransientFailures >= %d, got %d", threshold, auth.ConsecutiveTransientFailures)
+	}
+
+	minExpected := before.Add(cooldownMins * time.Minute)
+	maxExpected := after.Add(cooldownMins * time.Minute)
+	if auth.NextRetryAfter.Before(minExpected) || auth.NextRetryAfter.After(maxExpected) {
+		t.Fatalf("NextRetryAfter %v not in cooldown range [%v, %v]", auth.NextRetryAfter, minExpected, maxExpected)
+	}
+}
+
+// TestCircuitBreaker_ResetOnSuccess verifies that a success call clears the counter.
+func TestCircuitBreaker_ResetOnSuccess(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		AuthCircuitBreakerThreshold:       5,
+		AuthCircuitBreakerCooldownMinutes: 10,
+	})
+	registerAuthForCB(t, m, "cb-reset", "claude")
+
+	// Accumulate failures below threshold.
+	for i := 0; i < 3; i++ {
+		markTransientFailureWithModel(m, "cb-reset", 502)
+	}
+
+	// Success resets counter.
+	markSuccessWithModel(m, "cb-reset")
+
+	auth, _ := m.GetByID("cb-reset")
+	if auth.ConsecutiveTransientFailures != 0 {
+		t.Fatalf("expected ConsecutiveTransientFailures=0 after success, got %d", auth.ConsecutiveTransientFailures)
+	}
+}
+
+// TestCircuitBreaker_NonTransientErrorResetsCounter verifies that a 429 does not
+// increment the transient failure counter and resets it instead.
+func TestCircuitBreaker_NonTransientErrorResetsCounter(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		AuthCircuitBreakerThreshold:       5,
+		AuthCircuitBreakerCooldownMinutes: 10,
+	})
+	registerAuthForCB(t, m, "cb-nontransient", "claude")
+
+	// Build up some transient failures.
+	for i := 0; i < 2; i++ {
+		markTransientFailureWithModel(m, "cb-nontransient", 503)
+	}
+
+	// A 429 is not in the transient set — counter should reset.
+	m.MarkResult(context.Background(), Result{
+		AuthID:  "cb-nontransient",
+		Model:   "test-model",
+		Success: false,
+		Error:   &Error{HTTPStatus: 429},
+	})
+
+	auth, _ := m.GetByID("cb-nontransient")
+	if auth.ConsecutiveTransientFailures != 0 {
+		t.Fatalf("expected counter reset on non-transient error, got %d", auth.ConsecutiveTransientFailures)
+	}
+}
+
+// TestCircuitBreaker_Disabled verifies that threshold=-1 disables the breaker entirely.
+// With disabled circuit breaker, NextRetryAfter should only reflect the base backoff
+// (1 minute for transient errors), not the 10-minute cooldown.
+func TestCircuitBreaker_Disabled(t *testing.T) {
+	const cooldownMins = 10
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		AuthCircuitBreakerThreshold:       -1,
+		AuthCircuitBreakerCooldownMinutes: cooldownMins,
+	})
+	registerAuthForCB(t, m, "cb-disabled", "claude")
+
+	before := time.Now()
+	for i := 0; i < 20; i++ {
+		markTransientFailureWithModel(m, "cb-disabled", 503)
+	}
+
+	auth, _ := m.GetByID("cb-disabled")
+	// When disabled, the circuit breaker never extends NextRetryAfter to cooldown.
+	// The base model-state backoff (1m) may still aggregate to auth.NextRetryAfter,
+	// but it should never reach the cooldown window.
+	maxBaseline := before.Add(cooldownMins * time.Minute)
+	if !auth.NextRetryAfter.IsZero() && auth.NextRetryAfter.After(maxBaseline) {
+		t.Fatalf("circuit breaker disabled but NextRetryAfter %v exceeds cooldown ceiling %v", auth.NextRetryAfter, maxBaseline)
+	}
+}
+
+// TestCircuitBreaker_DefaultThreshold verifies defaults (threshold=0 → 5, cooldown=0 → 10m).
+func TestCircuitBreaker_DefaultThreshold(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	// AuthCircuitBreakerThreshold=0 → use defaultCircuitBreakerThreshold (5)
+	m.SetConfig(&internalconfig.Config{})
+	registerAuthForCB(t, m, "cb-default", "claude")
+
+	// Fail threshold-1 times — circuit should still use model-state backoff only.
+	for i := 0; i < defaultCircuitBreakerThreshold-1; i++ {
+		markTransientFailureWithModel(m, "cb-default", 504)
+	}
+	auth, _ := m.GetByID("cb-default")
+	if auth.ConsecutiveTransientFailures != defaultCircuitBreakerThreshold-1 {
+		t.Fatalf("expected counter=%d, got %d", defaultCircuitBreakerThreshold-1, auth.ConsecutiveTransientFailures)
+	}
+
+	// One more failure — counter should reach threshold, NextRetryAfter extended.
+	before := time.Now()
+	markTransientFailureWithModel(m, "cb-default", 504)
+	after := time.Now()
+
+	auth, _ = m.GetByID("cb-default")
+	if auth.ConsecutiveTransientFailures < defaultCircuitBreakerThreshold {
+		t.Fatalf("expected counter >= %d at threshold, got %d", defaultCircuitBreakerThreshold, auth.ConsecutiveTransientFailures)
+	}
+
+	minExpected := before.Add(defaultCircuitBreakerCooldownMinutes * time.Minute)
+	maxExpected := after.Add(defaultCircuitBreakerCooldownMinutes * time.Minute)
+	if auth.NextRetryAfter.Before(minExpected) || auth.NextRetryAfter.After(maxExpected) {
+		t.Fatalf("NextRetryAfter %v not in default cooldown range [%v, %v]", auth.NextRetryAfter, minExpected, maxExpected)
+	}
+}
+
+// TestCircuitBreaker_RaceCondition exercises concurrent SetConfig + MarkResult under -race.
+func TestCircuitBreaker_RaceCondition(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{AuthCircuitBreakerThreshold: 3})
+	registerAuthForCB(t, m, "cb-race", "claude")
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			m.SetConfig(&internalconfig.Config{AuthCircuitBreakerThreshold: 3})
+		}
+		close(done)
+	}()
+	for i := 0; i < 100; i++ {
+		markTransientFailureWithModel(m, "cb-race", 503)
+	}
+	<-done
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -196,6 +196,12 @@ type Manager struct {
 	// Map key is lowercase provider name; value is a chan struct{} semaphore.
 	providerRefreshSems   map[string]chan struct{}
 	providerRefreshSemsMu sync.RWMutex
+
+	// circuitBreakerThreshold is the consecutive-failure count that opens the circuit.
+	// 0 means use the package default; -1 disables the circuit breaker entirely.
+	circuitBreakerThreshold int
+	// circuitBreakerCooldown is how long an open circuit stays open before half-open retry.
+	circuitBreakerCooldown time.Duration
 }
 
 // NewManager constructs a manager with optional custom selector and hook.
@@ -399,6 +405,7 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 	}
 	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
 	m.rebuildProviderRefreshSems(cfg)
+	m.rebuildCircuitBreakerConfig(cfg)
 }
 
 const defaultMaxConcurrentRefreshPerProvider = 3
@@ -441,6 +448,66 @@ func (m *Manager) providerRefreshSem(provider string) chan struct{} {
 	sem := m.providerRefreshSems[strings.ToLower(provider)]
 	m.providerRefreshSemsMu.RUnlock()
 	return sem
+}
+
+const (
+	defaultCircuitBreakerThreshold       = 5
+	defaultCircuitBreakerCooldownMinutes = 10
+)
+
+// rebuildCircuitBreakerConfig reads circuit breaker settings from cfg.
+// threshold == -1 disables the circuit breaker; 0 keeps the package default.
+func (m *Manager) rebuildCircuitBreakerConfig(cfg *internalconfig.Config) {
+	if cfg == nil {
+		m.circuitBreakerThreshold = 0
+		m.circuitBreakerCooldown = 0
+		return
+	}
+	m.circuitBreakerThreshold = cfg.AuthCircuitBreakerThreshold
+	if cfg.AuthCircuitBreakerCooldownMinutes > 0 {
+		m.circuitBreakerCooldown = time.Duration(cfg.AuthCircuitBreakerCooldownMinutes) * time.Minute
+	} else {
+		m.circuitBreakerCooldown = 0
+	}
+}
+
+// applyCircuitBreaker checks whether auth has accumulated enough consecutive transient
+// failures to open the circuit. Must be called with m.mu held.
+func (m *Manager) applyCircuitBreaker(auth *Auth, statusCode int, now time.Time) {
+	if auth == nil || m == nil {
+		return
+	}
+	// -1 or a negative threshold other than the sentinel means disabled.
+	threshold := m.circuitBreakerThreshold
+	if threshold < 0 {
+		return
+	}
+	if threshold == 0 {
+		threshold = defaultCircuitBreakerThreshold
+	}
+	cooldown := m.circuitBreakerCooldown
+	if cooldown <= 0 {
+		cooldown = defaultCircuitBreakerCooldownMinutes * time.Minute
+	}
+
+	switch statusCode {
+	case 408, 500, 502, 503, 504:
+		// transient — count toward circuit breaker
+	default:
+		// non-transient error: reset counter so isolated 401/429 doesn't accumulate
+		auth.ConsecutiveTransientFailures = 0
+		return
+	}
+
+	auth.ConsecutiveTransientFailures++
+	if auth.ConsecutiveTransientFailures >= threshold {
+		next := now.Add(cooldown)
+		if auth.NextRetryAfter.IsZero() || auth.NextRetryAfter.Before(next) {
+			auth.NextRetryAfter = next
+			log.Warnf("circuit breaker opened: %s/%s after %d consecutive transient failures, retry after %s",
+				auth.Provider, auth.ID, auth.ConsecutiveTransientFailures, next.Format(time.RFC3339))
+		}
+	}
 }
 
 // HomeEnabled reports whether the home control plane integration is enabled in the runtime config.
@@ -2335,11 +2402,13 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					auth.StatusMessage = ""
 					auth.Status = StatusActive
 				}
+				auth.ConsecutiveTransientFailures = 0
 				auth.UpdatedAt = now
 				shouldResumeModel = true
 				clearModelQuota = true
 			} else {
 				clearAuthStateOnSuccess(auth, now)
+				auth.ConsecutiveTransientFailures = 0
 			}
 		} else {
 			if result.Model != "" {
@@ -2432,9 +2501,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					auth.Status = StatusError
 					auth.UpdatedAt = now
 					updateAggregatedAvailability(auth, now)
+					m.applyCircuitBreaker(auth, statusCodeFromResult(result.Error), now)
 				}
 			} else {
 				applyAuthFailureState(auth, result.Error, result.RetryAfter, now)
+				m.applyCircuitBreaker(auth, statusCodeFromResult(result.Error), now)
 			}
 		}
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -196,12 +196,6 @@ type Manager struct {
 	// Map key is lowercase provider name; value is a chan struct{} semaphore.
 	providerRefreshSems   map[string]chan struct{}
 	providerRefreshSemsMu sync.RWMutex
-
-	// circuitBreakerThreshold is the consecutive-failure count that opens the circuit.
-	// 0 means use the package default; -1 disables the circuit breaker entirely.
-	circuitBreakerThreshold int
-	// circuitBreakerCooldown is how long an open circuit stays open before half-open retry.
-	circuitBreakerCooldown time.Duration
 }
 
 // NewManager constructs a manager with optional custom selector and hook.
@@ -405,7 +399,6 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 	}
 	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
 	m.rebuildProviderRefreshSems(cfg)
-	m.rebuildCircuitBreakerConfig(cfg)
 }
 
 const defaultMaxConcurrentRefreshPerProvider = 3
@@ -455,39 +448,25 @@ const (
 	defaultCircuitBreakerCooldownMinutes = 10
 )
 
-// rebuildCircuitBreakerConfig reads circuit breaker settings from cfg.
-// threshold == -1 disables the circuit breaker; 0 keeps the package default.
-func (m *Manager) rebuildCircuitBreakerConfig(cfg *internalconfig.Config) {
-	if cfg == nil {
-		m.circuitBreakerThreshold = 0
-		m.circuitBreakerCooldown = 0
-		return
-	}
-	m.circuitBreakerThreshold = cfg.AuthCircuitBreakerThreshold
-	if cfg.AuthCircuitBreakerCooldownMinutes > 0 {
-		m.circuitBreakerCooldown = time.Duration(cfg.AuthCircuitBreakerCooldownMinutes) * time.Minute
-	} else {
-		m.circuitBreakerCooldown = 0
-	}
-}
-
 // applyCircuitBreaker checks whether auth has accumulated enough consecutive transient
 // failures to open the circuit. Must be called with m.mu held.
 func (m *Manager) applyCircuitBreaker(auth *Auth, statusCode int, now time.Time) {
 	if auth == nil || m == nil {
 		return
 	}
-	// -1 or a negative threshold other than the sentinel means disabled.
-	threshold := m.circuitBreakerThreshold
-	if threshold < 0 {
-		return
-	}
-	if threshold == 0 {
-		threshold = defaultCircuitBreakerThreshold
-	}
-	cooldown := m.circuitBreakerCooldown
-	if cooldown <= 0 {
-		cooldown = defaultCircuitBreakerCooldownMinutes * time.Minute
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	threshold := defaultCircuitBreakerThreshold
+	cooldown := defaultCircuitBreakerCooldownMinutes * time.Minute
+	if cfg != nil {
+		if cfg.AuthCircuitBreakerThreshold < 0 {
+			return // disabled
+		}
+		if cfg.AuthCircuitBreakerThreshold > 0 {
+			threshold = cfg.AuthCircuitBreakerThreshold
+		}
+		if cfg.AuthCircuitBreakerCooldownMinutes > 0 {
+			cooldown = time.Duration(cfg.AuthCircuitBreakerCooldownMinutes) * time.Minute
+		}
 	}
 
 	switch statusCode {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -191,6 +191,11 @@ type Manager struct {
 	refreshLoop   *authAutoRefreshLoop
 
 	requestPrepareLocks sync.Map
+
+	// providerRefreshSems limits concurrent token refreshes per provider.
+	// Map key is lowercase provider name; value is a chan struct{} semaphore.
+	providerRefreshSems   map[string]chan struct{}
+	providerRefreshSemsMu sync.RWMutex
 }
 
 // NewManager constructs a manager with optional custom selector and hook.
@@ -393,6 +398,49 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 		m.clearHomeRuntimeAuths()
 	}
 	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
+	m.rebuildProviderRefreshSems(cfg)
+}
+
+const defaultMaxConcurrentRefreshPerProvider = 3
+
+// rebuildProviderRefreshSems recreates per-provider semaphores based on config.
+// Called on SetConfig; existing semaphores (and goroutines waiting on them) are
+// replaced; in-flight refreshes that already acquired the old semaphore finish
+// normally because the defer still releases the channel they hold.
+func (m *Manager) rebuildProviderRefreshSems(cfg *internalconfig.Config) {
+	limit := defaultMaxConcurrentRefreshPerProvider
+	if cfg != nil && cfg.AuthMaxConcurrentRefreshPerProvider > 0 {
+		limit = cfg.AuthMaxConcurrentRefreshPerProvider
+	}
+	// Build semaphores keyed by provider from the executors map (keys are already provider names).
+	m.mu.RLock()
+	providers := make([]string, 0, len(m.executors))
+	for provider := range m.executors {
+		providers = append(providers, strings.ToLower(provider))
+	}
+	m.mu.RUnlock()
+
+	sems := make(map[string]chan struct{}, len(providers))
+	for _, p := range providers {
+		if _, exists := sems[p]; !exists {
+			sems[p] = make(chan struct{}, limit)
+		}
+	}
+	m.providerRefreshSemsMu.Lock()
+	m.providerRefreshSems = sems
+	m.providerRefreshSemsMu.Unlock()
+}
+
+// providerRefreshSem returns the semaphore channel for the given provider,
+// or nil if no limit is configured.
+func (m *Manager) providerRefreshSem(provider string) chan struct{} {
+	if m == nil {
+		return nil
+	}
+	m.providerRefreshSemsMu.RLock()
+	sem := m.providerRefreshSems[strings.ToLower(provider)]
+	m.providerRefreshSemsMu.RUnlock()
+	return sem
 }
 
 // HomeEnabled reports whether the home control plane integration is enabled in the runtime config.
@@ -4154,6 +4202,17 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	if auth == nil || exec == nil {
 		return
 	}
+
+	// Acquire per-provider semaphore to limit concurrent refresh storms.
+	if sem := m.providerRefreshSem(auth.Provider); sem != nil {
+		select {
+		case <-ctx.Done():
+			return
+		case sem <- struct{}{}:
+		}
+		defer func() { <-sem }()
+	}
+
 	updated, err := exec.Refresh(ctx, cloned)
 	if err != nil && errors.Is(err, context.Canceled) {
 		log.Debugf("refresh canceled for %s, %s", auth.Provider, auth.ID)

--- a/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
@@ -85,7 +85,7 @@ func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.
 	if manager.shouldRefresh(updated, now) {
 		t.Fatal("expected unauthorized auth to stop refresh attempts")
 	}
-	if _, shouldSchedule := nextRefreshCheckAt(now, updated, time.Second); shouldSchedule {
+	if _, shouldSchedule := nextRefreshCheckAt(now, updated, time.Second, 0); shouldSchedule {
 		t.Fatal("expected unauthorized auth to be removed from the auto-refresh schedule")
 	}
 }

--- a/sdk/cliproxy/auth/stagger_patch_test.go
+++ b/sdk/cliproxy/auth/stagger_patch_test.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// minimalExecutor satisfies ProviderExecutor with a configurable provider name.
+type minimalExecutor struct{ provider string }
+
+func (e *minimalExecutor) Identifier() string { return e.provider }
+func (e *minimalExecutor) Execute(_ context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e *minimalExecutor) ExecuteStream(_ context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+func (e *minimalExecutor) Refresh(_ context.Context, a *Auth) (*Auth, error) { return a, nil }
+func (e *minimalExecutor) CountTokens(_ context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e *minimalExecutor) HttpRequest(_ context.Context, _ *Auth, _ *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+// ---- stableJitter tests ----
+
+func TestStableJitter_Determinism(t *testing.T) {
+	window := 10 * time.Minute
+	first := stableJitter("user@example.com", window)
+	second := stableJitter("user@example.com", window)
+	if first != second {
+		t.Fatalf("stableJitter not deterministic: got %v then %v", first, second)
+	}
+}
+
+func TestStableJitter_Range(t *testing.T) {
+	window := 30 * time.Minute
+	ids := []string{"a", "b", "alpha@example.com", "z9999", "long-auth-id-with-dashes"}
+	for _, id := range ids {
+		got := stableJitter(id, window)
+		if got < 0 || got >= window {
+			t.Fatalf("stableJitter(%q, %v) = %v, want [0, %v)", id, window, got, window)
+		}
+	}
+}
+
+func TestStableJitter_ZeroWindow(t *testing.T) {
+	got := stableJitter("any-id", 0)
+	if got != 0 {
+		t.Fatalf("stableJitter with zero window: got %v, want 0", got)
+	}
+}
+
+func TestStableJitter_NegativeWindow(t *testing.T) {
+	got := stableJitter("any-id", -5*time.Minute)
+	if got != 0 {
+		t.Fatalf("stableJitter with negative window: got %v, want 0", got)
+	}
+}
+
+func TestStableJitter_EmptyID(t *testing.T) {
+	got := stableJitter("", 10*time.Minute)
+	if got != 0 {
+		t.Fatalf("stableJitter with empty ID: got %v, want 0", got)
+	}
+}
+
+// ---- Per-provider semaphore tests ----
+
+func TestRebuildProviderRefreshSems_CapacityMatchesConfig(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(&minimalExecutor{provider: "testprovider"})
+
+	cfg := &internalconfig.Config{AuthMaxConcurrentRefreshPerProvider: 2}
+	m.rebuildProviderRefreshSems(cfg)
+
+	sem := m.providerRefreshSem("testprovider")
+	if sem == nil {
+		t.Fatal("expected semaphore for testprovider, got nil")
+	}
+	if cap(sem) != 2 {
+		t.Fatalf("expected semaphore capacity 2, got %d", cap(sem))
+	}
+}
+
+func TestRebuildProviderRefreshSems_DefaultCapacity(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(&minimalExecutor{provider: "myprovider"})
+
+	// Passing nil uses the package default.
+	m.rebuildProviderRefreshSems(nil)
+
+	sem := m.providerRefreshSem("myprovider")
+	if sem == nil {
+		t.Fatal("expected semaphore for myprovider, got nil")
+	}
+	if cap(sem) != defaultMaxConcurrentRefreshPerProvider {
+		t.Fatalf("expected capacity %d, got %d", defaultMaxConcurrentRefreshPerProvider, cap(sem))
+	}
+}
+
+func TestProviderRefreshSem_UnknownProvider(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(&minimalExecutor{provider: "known"})
+	m.rebuildProviderRefreshSems(nil)
+
+	sem := m.providerRefreshSem("unknown")
+	if sem != nil {
+		t.Fatalf("expected nil semaphore for unknown provider, got %v", sem)
+	}
+}
+
+func TestProviderRefreshSem_CaseInsensitive(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	// Executor registers as "Claude" (mixed case).
+	m.RegisterExecutor(&minimalExecutor{provider: "Claude"})
+	m.rebuildProviderRefreshSems(nil)
+
+	// All case variants should return the same semaphore.
+	for _, name := range []string{"claude", "CLAUDE", "Claude"} {
+		sem := m.providerRefreshSem(name)
+		if sem == nil {
+			t.Fatalf("expected semaphore for provider name %q, got nil", name)
+		}
+	}
+}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -96,6 +96,10 @@ type Auth struct {
 	Success int64 `json:"-"`
 	Failed  int64 `json:"-"`
 
+	// ConsecutiveTransientFailures counts consecutive 5xx/408 execution errors.
+	// Reset to zero on any successful request. Used by the circuit breaker.
+	ConsecutiveTransientFailures int `json:"-"`
+
 	recentRequests recentRequestRing `json:"-"`
 	indexAssigned  bool              `json:"-"`
 }


### PR DESCRIPTION
## Summary

Adds two batch management API endpoints to reduce ops friction when working with large numbers of credentials:

**`POST /v0/management/auth-files/batch-status`**
Enable or disable multiple credentials in one call. Accepts either:
- Uniform body: `{"names": ["a.json", "b.json"], "disabled": true}`
- Per-item array: `[{"name": "a.json", "disabled": false}, {"name": "b.json", "disabled": true}]`

Credentials can be identified by auth ID or file name. Returns `{"updated": N, "failed": [...]}`.

**`POST /v0/management/auth-files/batch-clear-errors`**
Reset error/unavailable/quota state on multiple credentials after a provider outage, without waiting for backoff to expire.
- `{"names": [...], "provider": "claude"}` — provider filter or specific names (or both)
- Clears: `Unavailable`, `NextRetryAfter`, `LastError`, `StatusMessage`, `Quota`, resets `Status` from error → active

Returns `{"cleared": N}`.

## Also includes

- Tests for all batch handler paths (9 test cases)
- CLIProxy config keys and batch API docs added to `AGENTS.md`
- Race fix and jitter test signature fixes (stacks on `patch/per-proxy-health`)

## Test plan
- [ ] `go test ./internal/api/handlers/management/ -run "TestBatchPatch|TestBatchClear" -v` — all 9 pass
- [ ] Full management package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)