### PR TITLE
feat(models): add Claude Opus 4.8 model entry to registry JSON

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -96,6 +96,29 @@
       }
     },
     {
+      "id": "claude-opus-4-8",
+      "object": "model",
+      "created": 1779926400,
+      "owned_by": "anthropic",
+      "type": "claude",
+      "display_name": "Claude Opus 4.8",
+      "description": "Premium model combining maximum intelligence with practical performance",
+      "context_length": 1000000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
+    },
+    {
       "id": "claude-opus-4-5-20251101",
       "object": "model",
       "created": 1761955200,


### PR DESCRIPTION
## Summary

Adds the newly released **Claude Opus 4.8** to the model registry, following the exact same pattern as commit `5dcca69e` which added Claude Opus 4.7.

A single new entry is inserted in `internal/registry/models/models.json` right after `claude-opus-4-7`, mirroring the previous addition's structure (description, context length, max completion tokens and supported thinking levels).

## Changes

- `internal/registry/models/models.json`: add `claude-opus-4-8` entry (`Claude Opus 4.8`, 1M context, 128k max completion tokens, thinking levels `low`/`medium`/`high`/`xhigh`/`max`).

## Test plan

- [x] JSON syntax validated with `python3 -m json.tool`
- [x] Verified the new model appears in `/v1/models` listings after a server restart
