### PR TITLE
feat(images): support Gemini image models at /v1/images/generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ VisionCoder is also offering our users a limited-time <a href="https://coder.vis
 - Streaming, non-streaming, and WebSocket responses where supported
 - Function calling/tools support
 - Multimodal input support (text and images)
+- Gemini image generation via standard `/v1/images/generations` endpoint (e.g. `gemini-3.1-flash-image`)
 - Multiple accounts with round-robin load balancing (Gemini, OpenAI, Claude, Grok)
 - Simple CLI authentication flows (Gemini, OpenAI, Claude, Grok)
 - Generative Language API Key support

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -214,12 +214,17 @@ func isXAIImagesModel(model string) bool {
 	return prefix == "" || prefix == "xai" || prefix == "x-ai" || prefix == "grok"
 }
 
+func isGeminiChatImageModel(model string) bool {
+	base := strings.ToLower(strings.TrimSpace(imagesModelBase(model)))
+	return strings.Contains(base, "flash-image") || strings.Contains(base, "imagen")
+}
+
 func isSupportedImagesModel(model string) bool {
 	baseModel := imagesModelBase(model)
 	if baseModel == defaultImagesToolModel {
 		return true
 	}
-	return isXAIImagesModel(model) || isOpenAICompatImagesModel(model)
+	return isXAIImagesModel(model) || isOpenAICompatImagesModel(model) || isGeminiChatImageModel(model)
 }
 
 func isDefaultImagesToolModel(model string) bool {
@@ -642,6 +647,11 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 		h.handleOpenAICompatImages(c, compatReq, imageModel, responseFormat, "image_generation", stream)
 		return
 	}
+	if isGeminiChatImageModel(imageModel) {
+		chatReq := buildGeminiChatImagesRequest(prompt, imageModel)
+		h.collectGeminiChatImages(c, chatReq, imageModel, responseFormat)
+		return
+	}
 
 	tool := []byte(`{"type":"image_generation","action":"generate"}`)
 	tool, _ = sjson.SetBytes(tool, "model", imageModel)
@@ -1003,6 +1013,81 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 		return
 	}
 	h.collectImagesFromResponses(c, responsesReq, responseFormat)
+}
+
+func buildGeminiChatImagesRequest(prompt, model string) []byte {
+	req := []byte(`{"messages":[{"role":"user","content":""}],"modalities":["image","text"]}`)
+	req, _ = sjson.SetBytes(req, "model", strings.TrimSpace(model))
+	req, _ = sjson.SetBytes(req, "messages.0.content", strings.TrimSpace(prompt))
+	return req
+}
+
+func extractImagesFromChatCompletions(resp []byte) ([]imageCallResult, int64, error) {
+	createdAt := gjson.GetBytes(resp, "created").Int()
+	if createdAt <= 0 {
+		createdAt = time.Now().Unix()
+	}
+	imagesArr := gjson.GetBytes(resp, "choices.0.message.images")
+	if !imagesArr.IsArray() || len(imagesArr.Array()) == 0 {
+		return nil, createdAt, fmt.Errorf("upstream did not return image output")
+	}
+	var results []imageCallResult
+	for _, img := range imagesArr.Array() {
+		dataURI := strings.TrimSpace(img.Get("image_url.url").String())
+		if dataURI == "" {
+			continue
+		}
+		entry := imageCallResult{}
+		if idx := strings.Index(dataURI, ";base64,"); idx >= 0 {
+			mimeType := strings.TrimPrefix(dataURI[:idx], "data:")
+			entry.OutputFormat = strings.TrimPrefix(mimeType, "image/")
+			entry.Result = dataURI[idx+len(";base64,"):]
+		} else {
+			entry.Result = dataURI
+		}
+		results = append(results, entry)
+	}
+	if len(results) == 0 {
+		return nil, createdAt, fmt.Errorf("upstream did not return image output")
+	}
+	return results, createdAt, nil
+}
+
+func (h *OpenAIAPIHandler) collectGeminiChatImages(c *gin.Context, chatReq []byte, model, responseFormat string) {
+	c.Header("Content-Type", "application/json")
+	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	cliCtx = handlers.WithDisallowFreeAuth(cliCtx)
+	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
+
+	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, "openai", model, chatReq, "")
+	stopKeepAlive()
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		if errMsg.Error != nil {
+			cliCancel(errMsg.Error)
+		} else {
+			cliCancel(nil)
+		}
+		return
+	}
+
+	results, createdAt, err := extractImagesFromChatCompletions(resp)
+	if err != nil {
+		h.WriteErrorResponse(c, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: err})
+		cliCancel(err)
+		return
+	}
+
+	out, err := buildImagesAPIResponse(results, createdAt, nil, results[0], responseFormat)
+	if err != nil {
+		h.WriteErrorResponse(c, &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: err})
+		cliCancel(err)
+		return
+	}
+
+	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+	_, _ = c.Writer.Write(out)
+	cliCancel(nil)
 }
 
 func buildImagesResponsesRequest(prompt string, images []string, toolJSON []byte) []byte {

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -85,6 +85,66 @@ func TestImagesModelValidationAllowsOpenAICompatImageModels(t *testing.T) {
 	}
 }
 
+func TestImagesModelValidationAllowsGeminiImageModels(t *testing.T) {
+	for _, model := range []string{"gemini-3.1-flash-image", "antigravity/gemini-3.1-flash-image", "gemini-2.5-flash-image-preview", "imagen-3"} {
+		if !isSupportedImagesModel(model) {
+			t.Fatalf("expected %s to be supported", model)
+		}
+	}
+	for _, model := range []string{"gemini-2.5-flash", "gemini-2.5-pro"} {
+		if isSupportedImagesModel(model) {
+			t.Fatalf("expected %s to be rejected (no image in name)", model)
+		}
+	}
+}
+
+func TestBuildGeminiChatImagesRequest(t *testing.T) {
+	req := buildGeminiChatImagesRequest("a red apple", "antigravity/gemini-3.1-flash-image")
+
+	if got := gjson.GetBytes(req, "model").String(); got != "antigravity/gemini-3.1-flash-image" {
+		t.Fatalf("model = %q, want antigravity/gemini-3.1-flash-image", got)
+	}
+	if got := gjson.GetBytes(req, "messages.0.role").String(); got != "user" {
+		t.Fatalf("messages.0.role = %q, want user", got)
+	}
+	if got := gjson.GetBytes(req, "messages.0.content").String(); got != "a red apple" {
+		t.Fatalf("messages.0.content = %q, want a red apple", got)
+	}
+	if got := gjson.GetBytes(req, "modalities.0").String(); got != "image" {
+		t.Fatalf("modalities.0 = %q, want image", got)
+	}
+}
+
+func TestExtractImagesFromChatCompletions(t *testing.T) {
+	resp := []byte(`{"created":1700000000,"choices":[{"message":{"role":"assistant","images":[{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,/9j/ABC="}}]}}]}`)
+
+	results, createdAt, err := extractImagesFromChatCompletions(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if createdAt != 1700000000 {
+		t.Fatalf("createdAt = %d, want 1700000000", createdAt)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0].Result != "/9j/ABC=" {
+		t.Fatalf("result = %q, want /9j/ABC=", results[0].Result)
+	}
+	if results[0].OutputFormat != "jpeg" {
+		t.Fatalf("output_format = %q, want jpeg", results[0].OutputFormat)
+	}
+}
+
+func TestExtractImagesFromChatCompletionsNoImages(t *testing.T) {
+	resp := []byte(`{"created":1700000000,"choices":[{"message":{"role":"assistant","content":"hello"}}]}`)
+
+	_, _, err := extractImagesFromChatCompletions(resp)
+	if err == nil {
+		t.Fatal("expected error for response with no images")
+	}
+}
+
 func TestBuildXAIImagesGenerationsRequest(t *testing.T) {
 	rawJSON := []byte(`{"model":"xai/grok-imagine-image-quality","prompt":"abstract art","aspect_ratio":"landscape","resolution":"2k","n":2,"response_format":"url"}`)
 


### PR DESCRIPTION
## Summary

- Gemini image models (e.g. `gemini-3.1-flash-image`) previously only worked via `/v1/chat/completions` but were rejected at the standard `/v1/images/generations` endpoint with a 400 error
- Bridges through chat completions internally: builds a request with `modalities:[image,text]`, executes via the normal routing path, and extracts the returned data URIs from `choices[0].message.images[]`
- Adds `isGeminiChatImageModel` detection (matches model names containing `flash-image` or `imagen`)
- Updates `isSupportedImagesModel` to accept Gemini image models
- Routes Gemini models to `collectGeminiChatImages` before the default Responses API fallback

## Test plan

- [ ] `gemini-3.1-flash-image` returns valid image at `POST /v1/images/generations` with `response_format: b64_json`
- [ ] `gemini-3.1-flash-image` returns valid image with `response_format: url` (data URI)
- [ ] Non-image Gemini models (e.g. `gemini-2.5-flash`) still rejected with 400
- [ ] `gpt-image-2` and XAI models unaffected (existing behaviour preserved)
- [ ] All existing unit tests pass (`go test ./sdk/api/handlers/openai/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)