### PR TITLE
fix: harden Codex and OpenAI-compatible streaming hangs

### DIFF
--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/singleflight"
 )
 
 // OAuth configuration constants for OpenAI Codex
@@ -26,6 +27,8 @@ const (
 	ClientID    = "app_EMoamEEZ73f0CkXaXp7hrann"
 	RedirectURI = "http://localhost:1455/auth/callback"
 )
+
+var codexRefreshGroup singleflight.Group
 
 // CodexAuth handles the OpenAI OAuth2 authentication flow.
 // It manages the HTTP client and provides methods for generating authorization URLs,
@@ -184,6 +187,24 @@ func (o *CodexAuth) ExchangeCodeForTokensWithRedirect(ctx context.Context, code,
 // This method is called when an access token has expired. It makes a request to the
 // token endpoint to obtain a new set of tokens.
 func (o *CodexAuth) RefreshTokens(ctx context.Context, refreshToken string) (*CodexTokenData, error) {
+	if refreshToken == "" {
+		return nil, fmt.Errorf("refresh token is required")
+	}
+
+	result, err, _ := codexRefreshGroup.Do(refreshToken, func() (interface{}, error) {
+		return o.refreshTokensSingleFlight(context.WithoutCancel(ctx), refreshToken)
+	})
+	if err != nil {
+		return nil, err
+	}
+	tokenData, ok := result.(*CodexTokenData)
+	if !ok || tokenData == nil {
+		return nil, fmt.Errorf("token refresh failed: invalid single-flight result")
+	}
+	return tokenData, nil
+}
+
+func (o *CodexAuth) refreshTokensSingleFlight(ctx context.Context, refreshToken string) (*CodexTokenData, error) {
 	if refreshToken == "" {
 		return nil, fmt.Errorf("refresh token is required")
 	}

--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -28,7 +28,10 @@ const (
 	RedirectURI = "http://localhost:1455/auth/callback"
 )
 
-var codexRefreshGroup singleflight.Group
+var (
+	codexRefreshGroup        singleflight.Group
+	codexRefreshGroupTimeout = time.Minute
+)
 
 // CodexAuth handles the OpenAI OAuth2 authentication flow.
 // It manages the HTTP client and provides methods for generating authorization URLs,
@@ -190,14 +193,35 @@ func (o *CodexAuth) RefreshTokens(ctx context.Context, refreshToken string) (*Co
 	if refreshToken == "" {
 		return nil, fmt.Errorf("refresh token is required")
 	}
-
-	result, err, _ := codexRefreshGroup.Do(refreshToken, func() (interface{}, error) {
-		return o.refreshTokensSingleFlight(context.WithoutCancel(ctx), refreshToken)
-	})
-	if err != nil {
-		return nil, err
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	tokenData, ok := result.(*CodexTokenData)
+	if errCtx := ctx.Err(); errCtx != nil {
+		return nil, errCtx
+	}
+
+	resultC := codexRefreshGroup.DoChan(refreshToken, func() (interface{}, error) {
+		refreshCtx := context.WithoutCancel(ctx)
+		var cancel context.CancelFunc
+		if codexRefreshGroupTimeout > 0 {
+			refreshCtx, cancel = context.WithTimeout(refreshCtx, codexRefreshGroupTimeout)
+		} else {
+			refreshCtx, cancel = context.WithCancel(refreshCtx)
+		}
+		defer cancel()
+		return o.refreshTokensSingleFlight(refreshCtx, refreshToken)
+	})
+
+	var result singleflight.Result
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result = <-resultC:
+	}
+	if result.Err != nil {
+		return nil, result.Err
+	}
+	tokenData, ok := result.Val.(*CodexTokenData)
 	if !ok || tokenData == nil {
 		return nil, fmt.Errorf("token refresh failed: invalid single-flight result")
 	}

--- a/internal/auth/codex/openai_auth_test.go
+++ b/internal/auth/codex/openai_auth_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
@@ -42,6 +44,72 @@ func TestRefreshTokensWithRetry_NonRetryableOnlyAttemptsOnce(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&calls); got != 1 {
 		t.Fatalf("expected 1 refresh attempt, got %d", got)
+	}
+}
+
+func TestRefreshTokens_DeduplicatesConcurrentRefresh(t *testing.T) {
+	var calls int32
+	var wg sync.WaitGroup
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	auth := &CodexAuth{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if atomic.AddInt32(&calls, 1) == 1 {
+					close(entered)
+				}
+				<-release
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"access_token":"access-token",
+						"refresh_token":"next-refresh-token",
+						"id_token":"header.payload.signature",
+						"expires_in":3600
+					}`)),
+					Header:  make(http.Header),
+					Request: req,
+				}, nil
+			}),
+		},
+	}
+
+	results := make(chan *CodexTokenData, 2)
+	errs := make(chan error, 2)
+	runRefresh := func() {
+		defer wg.Done()
+		td, err := auth.RefreshTokens(context.Background(), "shared-refresh-token")
+		if err != nil {
+			errs <- err
+			return
+		}
+		results <- td
+	}
+
+	wg.Add(1)
+	go runRefresh()
+	<-entered
+	wg.Add(1)
+	go runRefresh()
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected refresh error: %v", <-errs)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected 1 refresh request, got %d", got)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected both callers to receive token data, got %d", len(results))
+	}
+	for td := range results {
+		if td.RefreshToken != "next-refresh-token" {
+			t.Fatalf("refresh token = %q, want next-refresh-token", td.RefreshToken)
+		}
 	}
 }
 

--- a/internal/auth/codex/openai_auth_test.go
+++ b/internal/auth/codex/openai_auth_test.go
@@ -113,6 +113,94 @@ func TestRefreshTokens_DeduplicatesConcurrentRefresh(t *testing.T) {
 	}
 }
 
+func TestRefreshTokens_RespectsCallerCancellationWhileSharedRefreshContinues(t *testing.T) {
+	var calls int32
+	var wg sync.WaitGroup
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	auth := &CodexAuth{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if atomic.AddInt32(&calls, 1) == 1 {
+					close(entered)
+				}
+				<-release
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"access_token":"access-token",
+						"refresh_token":"next-refresh-token",
+						"id_token":"header.payload.signature",
+						"expires_in":3600
+					}`)),
+					Header:  make(http.Header),
+					Request: req,
+				}, nil
+			}),
+		},
+	}
+
+	wg.Add(1)
+	firstErr := make(chan error, 1)
+	go func() {
+		defer wg.Done()
+		_, err := auth.RefreshTokens(context.Background(), "shared-refresh-token-cancel")
+		firstErr <- err
+	}()
+	<-entered
+
+	waitCtx, cancel := context.WithCancel(context.Background())
+	waitErr := make(chan error, 1)
+	go func() {
+		_, err := auth.RefreshTokens(waitCtx, "shared-refresh-token-cancel")
+		waitErr <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-waitErr:
+		if err != context.Canceled {
+			t.Fatalf("RefreshTokens error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for canceled caller")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected shared refresh to keep single upstream request, got %d", got)
+	}
+
+	close(release)
+	wg.Wait()
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first refresh error: %v", err)
+	}
+}
+
+func TestRefreshTokens_SharedRefreshHasBoundedTimeout(t *testing.T) {
+	origTimeout := codexRefreshGroupTimeout
+	codexRefreshGroupTimeout = 50 * time.Millisecond
+	defer func() {
+		codexRefreshGroupTimeout = origTimeout
+	}()
+
+	auth := &CodexAuth{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			}),
+		},
+	}
+
+	_, err := auth.RefreshTokens(context.Background(), "shared-refresh-token-timeout")
+	if err == nil {
+		t.Fatal("expected refresh timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("expected deadline exceeded error, got %v", err)
+	}
+}
+
 func TestNewCodexAuthWithProxyURL_OverrideDirectDisablesProxy(t *testing.T) {
 	cfg := &config.Config{SDKConfig: config.SDKConfig{ProxyURL: "http://proxy.example.com:8080"}}
 	auth := NewCodexAuthWithProxyURL(cfg, "direct")

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -584,8 +584,8 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpClient = reporter.TrackHTTPClient(httpClient)
 	applyCodexHTTPStreamFirstResponseTimeout(httpClient, codexHTTPStreamFirstResponseTimeout)
+	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpStartedAt := time.Now()
 	helps.LogWithRequestID(ctx).Infof("codex http stream upstream request start url=%s body_bytes=%d auth=%s", url, len(body), authID)
 	httpResp, err := httpClient.Do(httpReq)

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	codexauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
@@ -35,7 +37,11 @@ const (
 	codexDefaultImageToolModel = "gpt-image-2"
 )
 
-var dataTag = []byte("data:")
+var (
+	dataTag                       = []byte("data:")
+	codexHTTPStreamIdleTimeout    = 5 * time.Minute
+	codexHTTPStreamIdleTimeoutMsg = "codex upstream stream idle timeout after %s"
+)
 
 // Streamed Codex responses may emit response.output_item.done events while leaving
 // response.completed.response.output empty. Keep the stream path aligned with the
@@ -577,12 +583,16 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpStartedAt := time.Now()
+	helps.LogWithRequestID(ctx).Infof("codex http stream upstream request start url=%s body_bytes=%d auth=%s", url, len(body), authID)
 	httpResp, err := httpClient.Do(httpReq)
+	helps.LogWithRequestID(ctx).Infof("codex http stream upstream request returned elapsed=%s err=%v", time.Since(httpStartedAt).Truncate(time.Millisecond), err)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	helps.LogWithRequestID(ctx).Infof("codex http stream upstream connected status=%d content_type=%q", httpResp.StatusCode, httpResp.Header.Get("Content-Type"))
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		data, readErr := io.ReadAll(httpResp.Body)
 		if errClose := httpResp.Body.Close(); errClose != nil {
@@ -600,26 +610,76 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
-		defer func() {
-			if errClose := httpResp.Body.Close(); errClose != nil {
-				log.Errorf("codex executor: close response body error: %v", errClose)
+		startedAt := time.Now()
+		var lineCount atomic.Int64
+		var dataLineCount atomic.Int64
+		var translatedChunkCount atomic.Int64
+		var lastLineAt atomic.Int64
+		lastLineAt.Store(startedAt.UnixNano())
+		progressDone := make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-progressDone:
+					return
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					last := time.Unix(0, lastLineAt.Load())
+					helps.LogWithRequestID(ctx).Warnf("codex http stream still open elapsed=%s idle=%s upstream_lines=%d upstream_data_lines=%d downstream_chunks=%d ctx_err=%v",
+						time.Since(startedAt).Truncate(time.Second),
+						time.Since(last).Truncate(time.Second),
+						lineCount.Load(),
+						dataLineCount.Load(),
+						translatedChunkCount.Load(),
+						ctx.Err(),
+					)
+				}
 			}
 		}()
+		defer close(progressDone)
+		var closeBodyOnce sync.Once
+		var idleTimedOut atomic.Bool
+		closeResponseBody := func() {
+			closeBodyOnce.Do(func() {
+				if errClose := httpResp.Body.Close(); errClose != nil && !idleTimedOut.Load() {
+					log.Errorf("codex executor: close response body error: %v", errClose)
+				}
+			})
+		}
+		defer func() {
+			closeResponseBody()
+		}()
+		stopIdleWatch, markStreamActivity := watchCodexHTTPStreamIdle(ctx, codexHTTPStreamIdleTimeout, &idleTimedOut, closeResponseBody)
+		defer stopIdleWatch()
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
 		outputItemsByIndex := make(map[int64][]byte)
 		var outputItemsFallback [][]byte
 		for scanner.Scan() {
+			markStreamActivity()
+			lineCount.Add(1)
+			lastLineAt.Store(time.Now().UnixNano())
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			translatedLine := bytes.Clone(line)
 
 			if bytes.HasPrefix(line, dataTag) {
+				dataLineCount.Add(1)
 				data := bytes.TrimSpace(line[5:])
 				if streamErr, ok := codexTerminalStreamContextLengthErr(data); ok {
 					helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
 					reporter.PublishFailure(ctx, streamErr)
+					helps.LogWithRequestID(ctx).Warnf("codex http stream terminal upstream context error after %s lines=%d data_lines=%d chunks=%d err=%v",
+						time.Since(startedAt).Truncate(time.Second),
+						lineCount.Load(),
+						dataLineCount.Load(),
+						translatedChunkCount.Load(),
+						streamErr,
+					)
 					select {
 					case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
 					case <-ctx.Done():
@@ -636,28 +696,119 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					publishCodexImageToolUsage(ctx, reporter, body, data)
 					data = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
 					translatedLine = append([]byte("data: "), data...)
+					helps.LogWithRequestID(ctx).Infof("codex http stream saw response.completed after %s lines=%d data_lines=%d chunks=%d",
+						time.Since(startedAt).Truncate(time.Second),
+						lineCount.Load(),
+						dataLineCount.Load(),
+						translatedChunkCount.Load(),
+					)
 				}
 			}
 
 			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, originalPayload, body, translatedLine, &param)
 			for i := range chunks {
+				translatedChunkCount.Add(1)
 				select {
 				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
 				case <-ctx.Done():
+					helps.LogWithRequestID(ctx).Warnf("codex http stream downstream context done while sending chunk after %s lines=%d data_lines=%d chunks=%d ctx_err=%v",
+						time.Since(startedAt).Truncate(time.Second),
+						lineCount.Load(),
+						dataLineCount.Load(),
+						translatedChunkCount.Load(),
+						ctx.Err(),
+					)
 					return
 				}
 			}
 		}
+		if idleTimedOut.Load() {
+			streamErr := statusErr{code: http.StatusGatewayTimeout, msg: fmt.Sprintf(codexHTTPStreamIdleTimeoutMsg, codexHTTPStreamIdleTimeout)}
+			helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+			reporter.PublishFailure(ctx, streamErr)
+			helps.LogWithRequestID(ctx).Warnf("codex http stream idle timeout after %s lines=%d data_lines=%d chunks=%d",
+				time.Since(startedAt).Truncate(time.Second),
+				lineCount.Load(),
+				dataLineCount.Load(),
+				translatedChunkCount.Load(),
+			)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+			case <-ctx.Done():
+			}
+			return
+		}
 		if errScan := scanner.Err(); errScan != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx, errScan)
+			helps.LogWithRequestID(ctx).Warnf("codex http stream scanner exited with error after %s lines=%d data_lines=%d chunks=%d ctx_err=%v scan_err=%v",
+				time.Since(startedAt).Truncate(time.Second),
+				lineCount.Load(),
+				dataLineCount.Load(),
+				translatedChunkCount.Load(),
+				ctx.Err(),
+				errScan,
+			)
 			select {
 			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
 			case <-ctx.Done():
 			}
+			return
 		}
+		helps.LogWithRequestID(ctx).Infof("codex http stream scanner completed after %s lines=%d data_lines=%d chunks=%d ctx_err=%v",
+			time.Since(startedAt).Truncate(time.Second),
+			lineCount.Load(),
+			dataLineCount.Load(),
+			translatedChunkCount.Load(),
+			ctx.Err(),
+		)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+func watchCodexHTTPStreamIdle(ctx context.Context, timeout time.Duration, idleTimedOut *atomic.Bool, closeResponseBody func()) (func(), func()) {
+	if timeout <= 0 {
+		return func() {}, func() {}
+	}
+	activity := make(chan struct{}, 1)
+	done := make(chan struct{})
+	var stopOnce sync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			close(done)
+		})
+	}
+	markActivity := func() {
+		select {
+		case activity <- struct{}{}:
+		default:
+		}
+	}
+	go func() {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			case <-activity:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(timeout)
+			case <-timer.C:
+				idleTimedOut.Store(true)
+				closeResponseBody()
+				return
+			}
+		}
+	}()
+	return stop, markActivity
 }
 
 func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -38,9 +38,11 @@ const (
 )
 
 var (
-	dataTag                       = []byte("data:")
-	codexHTTPStreamIdleTimeout    = 5 * time.Minute
-	codexHTTPStreamIdleTimeoutMsg = "codex upstream stream idle timeout after %s"
+	dataTag                                = []byte("data:")
+	codexHTTPStreamFirstResponseTimeout    = 2 * time.Minute
+	codexHTTPStreamFirstResponseTimeoutMsg = "codex upstream stream first response timeout after %s"
+	codexHTTPStreamIdleTimeout             = 5 * time.Minute
+	codexHTTPStreamIdleTimeoutMsg          = "codex upstream stream idle timeout after %s"
 )
 
 // Streamed Codex responses may emit response.output_item.done events while leaving
@@ -583,11 +585,16 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
+	applyCodexHTTPStreamFirstResponseTimeout(httpClient, codexHTTPStreamFirstResponseTimeout)
 	httpStartedAt := time.Now()
 	helps.LogWithRequestID(ctx).Infof("codex http stream upstream request start url=%s body_bytes=%d auth=%s", url, len(body), authID)
 	httpResp, err := httpClient.Do(httpReq)
 	helps.LogWithRequestID(ctx).Infof("codex http stream upstream request returned elapsed=%s err=%v", time.Since(httpStartedAt).Truncate(time.Millisecond), err)
 	if err != nil {
+		if isCodexHTTPStreamFirstResponseTimeout(err, codexHTTPStreamFirstResponseTimeout) && ctx.Err() == nil {
+			err = statusErr{code: http.StatusGatewayTimeout, msg: fmt.Sprintf(codexHTTPStreamFirstResponseTimeoutMsg, codexHTTPStreamFirstResponseTimeout)}
+		}
+		httpClient.CloseIdleConnections()
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err
 	}
@@ -598,6 +605,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("codex executor: close response body error: %v", errClose)
 		}
+		httpClient.CloseIdleConnections()
 		if readErr != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, readErr)
 			return nil, readErr
@@ -647,6 +655,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				if errClose := httpResp.Body.Close(); errClose != nil && !idleTimedOut.Load() {
 					log.Errorf("codex executor: close response body error: %v", errClose)
 				}
+				httpClient.CloseIdleConnections()
 			})
 		}
 		defer func() {
@@ -809,6 +818,32 @@ func watchCodexHTTPStreamIdle(ctx context.Context, timeout time.Duration, idleTi
 		}
 	}()
 	return stop, markActivity
+}
+
+func applyCodexHTTPStreamFirstResponseTimeout(client *http.Client, timeout time.Duration) {
+	if client == nil || timeout <= 0 {
+		return
+	}
+	if client.Transport == nil {
+		if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok && defaultTransport != nil {
+			transport := defaultTransport.Clone()
+			transport.ResponseHeaderTimeout = timeout
+			client.Transport = transport
+		}
+		return
+	}
+	if transport, ok := client.Transport.(*http.Transport); ok && transport != nil {
+		clone := transport.Clone()
+		clone.ResponseHeaderTimeout = timeout
+		client.Transport = clone
+	}
+}
+
+func isCodexHTTPStreamFirstResponseTimeout(err error, timeout time.Duration) bool {
+	if err == nil || timeout <= 0 {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "timeout awaiting response headers")
 }
 
 func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"sort"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -41,8 +40,6 @@ var (
 	dataTag                                = []byte("data:")
 	codexHTTPStreamFirstResponseTimeout    = 2 * time.Minute
 	codexHTTPStreamFirstResponseTimeoutMsg = "codex upstream stream first response timeout after %s"
-	codexHTTPStreamIdleTimeout             = 5 * time.Minute
-	codexHTTPStreamIdleTimeoutMsg          = "codex upstream stream idle timeout after %s"
 )
 
 // Streamed Codex responses may emit response.output_item.done events while leaving
@@ -648,28 +645,18 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			}
 		}()
 		defer close(progressDone)
-		var closeBodyOnce sync.Once
-		var idleTimedOut atomic.Bool
-		closeResponseBody := func() {
-			closeBodyOnce.Do(func() {
-				if errClose := httpResp.Body.Close(); errClose != nil && !idleTimedOut.Load() {
-					log.Errorf("codex executor: close response body error: %v", errClose)
-				}
-				httpClient.CloseIdleConnections()
-			})
-		}
 		defer func() {
-			closeResponseBody()
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("codex executor: close response body error: %v", errClose)
+			}
+			httpClient.CloseIdleConnections()
 		}()
-		stopIdleWatch, markStreamActivity := watchCodexHTTPStreamIdle(ctx, codexHTTPStreamIdleTimeout, &idleTimedOut, closeResponseBody)
-		defer stopIdleWatch()
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
 		outputItemsByIndex := make(map[int64][]byte)
 		var outputItemsFallback [][]byte
 		for scanner.Scan() {
-			markStreamActivity()
 			lineCount.Add(1)
 			lastLineAt.Store(time.Now().UnixNano())
 			line := scanner.Bytes()
@@ -731,22 +718,6 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				}
 			}
 		}
-		if idleTimedOut.Load() {
-			streamErr := statusErr{code: http.StatusGatewayTimeout, msg: fmt.Sprintf(codexHTTPStreamIdleTimeoutMsg, codexHTTPStreamIdleTimeout)}
-			helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
-			reporter.PublishFailure(ctx, streamErr)
-			helps.LogWithRequestID(ctx).Warnf("codex http stream idle timeout after %s lines=%d data_lines=%d chunks=%d",
-				time.Since(startedAt).Truncate(time.Second),
-				lineCount.Load(),
-				dataLineCount.Load(),
-				translatedChunkCount.Load(),
-			)
-			select {
-			case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
-			case <-ctx.Done():
-			}
-			return
-		}
 		if errScan := scanner.Err(); errScan != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx, errScan)
@@ -773,51 +744,6 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
-}
-
-func watchCodexHTTPStreamIdle(ctx context.Context, timeout time.Duration, idleTimedOut *atomic.Bool, closeResponseBody func()) (func(), func()) {
-	if timeout <= 0 {
-		return func() {}, func() {}
-	}
-	activity := make(chan struct{}, 1)
-	done := make(chan struct{})
-	var stopOnce sync.Once
-	stop := func() {
-		stopOnce.Do(func() {
-			close(done)
-		})
-	}
-	markActivity := func() {
-		select {
-		case activity <- struct{}{}:
-		default:
-		}
-	}
-	go func() {
-		timer := time.NewTimer(timeout)
-		defer timer.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-done:
-				return
-			case <-activity:
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
-				timer.Reset(timeout)
-			case <-timer.C:
-				idleTimedOut.Store(true)
-				closeResponseBody()
-				return
-			}
-		}
-	}()
-	return stop, markActivity
 }
 
 func applyCodexHTTPStreamFirstResponseTimeout(client *http.Client, timeout time.Duration) {

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -180,6 +180,55 @@ func TestCodexExecutorExecuteStreamTimesOutIdleUpstream(t *testing.T) {
 	}
 }
 
+func TestCodexExecutorExecuteStreamTimesOutWaitingForUpstreamResponse(t *testing.T) {
+	origTimeout := codexHTTPStreamFirstResponseTimeout
+	codexHTTPStreamFirstResponseTimeout = 50 * time.Millisecond
+	defer func() {
+		codexHTTPStreamFirstResponseTimeout = origTimeout
+	}()
+
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	errC := make(chan error, 1)
+	go func() {
+		_, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+			Model:   "gpt-5.5",
+			Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+		}, cliproxyexecutor.Options{
+			SourceFormat: sdktranslator.FromString("openai-response"),
+			Stream:       true,
+		})
+		errC <- err
+	}()
+
+	var err error
+	select {
+	case err = <-errC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream first response timeout error")
+	}
+	if err == nil {
+		t.Fatal("expected first response timeout error, got nil")
+	}
+	if got := statusCodeFromTestError(t, err); got != http.StatusGatewayTimeout {
+		t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusGatewayTimeout, err)
+	}
+	if !strings.Contains(err.Error(), "codex upstream stream first response timeout after 50ms") {
+		t.Fatalf("error message missing first response timeout: %v", err)
+	}
+}
+
 func TestCodexTerminalStreamContextLengthErrFromResponseFailed(t *testing.T) {
 	err, ok := codexTerminalStreamContextLengthErr([]byte(`{"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again."}}}`))
 	if !ok {

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -128,58 +128,6 @@ func TestCodexExecutorExecuteStreamSurfacesTerminalStreamError(t *testing.T) {
 	assertCodexErrorCode(t, streamErr.Error(), "invalid_request_error", "context_too_large")
 }
 
-func TestCodexExecutorExecuteStreamTimesOutIdleUpstream(t *testing.T) {
-	origTimeout := codexHTTPStreamIdleTimeout
-	codexHTTPStreamIdleTimeout = 50 * time.Millisecond
-	defer func() {
-		codexHTTPStreamIdleTimeout = origTimeout
-	}()
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		if flusher, ok := w.(http.Flusher); ok {
-			flusher.Flush()
-		}
-		<-r.Context().Done()
-	}))
-	defer server.Close()
-
-	executor := NewCodexExecutor(&config.Config{})
-	auth := &cliproxyauth.Auth{Attributes: map[string]string{
-		"base_url": server.URL,
-		"api_key":  "test",
-	}}
-
-	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
-		Model:   "gpt-5.5",
-		Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
-	}, cliproxyexecutor.Options{
-		SourceFormat: sdktranslator.FromString("openai-response"),
-		Stream:       true,
-	})
-	if err != nil {
-		t.Fatalf("ExecuteStream error: %v", err)
-	}
-
-	select {
-	case chunk, ok := <-result.Chunks:
-		if !ok {
-			t.Fatal("stream closed without idle timeout error")
-		}
-		if chunk.Err == nil {
-			t.Fatalf("stream chunk error = nil, payload=%q", string(chunk.Payload))
-		}
-		if got := statusCodeFromTestError(t, chunk.Err); got != http.StatusGatewayTimeout {
-			t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusGatewayTimeout, chunk.Err)
-		}
-		if !strings.Contains(chunk.Err.Error(), "codex upstream stream idle timeout after 50ms") {
-			t.Fatalf("error message missing idle timeout: %v", chunk.Err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for stream idle timeout error")
-	}
-}
-
 func TestCodexExecutorExecuteStreamTimesOutWaitingForUpstreamResponse(t *testing.T) {
 	origTimeout := codexHTTPStreamFirstResponseTimeout
 	codexHTTPStreamFirstResponseTimeout = 50 * time.Millisecond

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
@@ -125,6 +126,58 @@ func TestCodexExecutorExecuteStreamSurfacesTerminalStreamError(t *testing.T) {
 		t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusBadRequest, streamErr)
 	}
 	assertCodexErrorCode(t, streamErr.Error(), "invalid_request_error", "context_too_large")
+}
+
+func TestCodexExecutorExecuteStreamTimesOutIdleUpstream(t *testing.T) {
+	origTimeout := codexHTTPStreamIdleTimeout
+	codexHTTPStreamIdleTimeout = 50 * time.Millisecond
+	defer func() {
+		codexHTTPStreamIdleTimeout = origTimeout
+	}()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	select {
+	case chunk, ok := <-result.Chunks:
+		if !ok {
+			t.Fatal("stream closed without idle timeout error")
+		}
+		if chunk.Err == nil {
+			t.Fatalf("stream chunk error = nil, payload=%q", string(chunk.Payload))
+		}
+		if got := statusCodeFromTestError(t, chunk.Err); got != http.StatusGatewayTimeout {
+			t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusGatewayTimeout, chunk.Err)
+		}
+		if !strings.Contains(chunk.Err.Error(), "codex upstream stream idle timeout after 50ms") {
+			t.Fatalf("error message missing idle timeout: %v", chunk.Err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stream idle timeout error")
+	}
 }
 
 func TestCodexTerminalStreamContextLengthErrFromResponseFailed(t *testing.T) {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -368,8 +368,8 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpClient = reporter.TrackHTTPClient(httpClient)
 	applyOpenAICompatStreamFirstResponseTimeout(httpClient, openAICompatStreamFirstResponseTimeout)
+	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		if isOpenAICompatStreamFirstResponseTimeout(err, openAICompatStreamFirstResponseTimeout) && ctx.Err() == nil {
@@ -526,8 +526,8 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpClient = reporter.TrackHTTPClient(httpClient)
 	applyOpenAICompatStreamFirstResponseTimeout(httpClient, openAICompatStreamFirstResponseTimeout)
+	httpClient = reporter.TrackHTTPClient(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		if isOpenAICompatStreamFirstResponseTimeout(err, openAICompatStreamFirstResponseTimeout) && ctx.Err() == nil {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -33,6 +33,11 @@ const (
 	openAICompatMultipartMemory       int64 = 32 << 20
 )
 
+var (
+	openAICompatStreamFirstResponseTimeout    = 2 * time.Minute
+	openAICompatStreamFirstResponseTimeoutMsg = "openai-compatible upstream stream first response timeout after %s"
+)
+
 // OpenAICompatExecutor implements a stateless executor for OpenAI-compatible providers.
 // It performs request/response translation and executes against the provider base URL
 // using per-auth credentials (API key) and per-auth HTTP transport (proxy) from context.
@@ -364,8 +369,13 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
+	applyOpenAICompatStreamFirstResponseTimeout(httpClient, openAICompatStreamFirstResponseTimeout)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
+		if isOpenAICompatStreamFirstResponseTimeout(err, openAICompatStreamFirstResponseTimeout) && ctx.Err() == nil {
+			err = statusErr{code: http.StatusGatewayTimeout, msg: fmt.Sprintf(openAICompatStreamFirstResponseTimeoutMsg, openAICompatStreamFirstResponseTimeout)}
+		}
+		httpClient.CloseIdleConnections()
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err
 	}
@@ -377,6 +387,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("openai compat executor: close response body error: %v", errClose)
 		}
+		httpClient.CloseIdleConnections()
 		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
 		return nil, err
 	}
@@ -387,6 +398,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			if errClose := httpResp.Body.Close(); errClose != nil {
 				log.Errorf("openai compat executor: close response body error: %v", errClose)
 			}
+			httpClient.CloseIdleConnections()
 		}()
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
@@ -515,8 +527,13 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
+	applyOpenAICompatStreamFirstResponseTimeout(httpClient, openAICompatStreamFirstResponseTimeout)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
+		if isOpenAICompatStreamFirstResponseTimeout(err, openAICompatStreamFirstResponseTimeout) && ctx.Err() == nil {
+			err = statusErr{code: http.StatusGatewayTimeout, msg: fmt.Sprintf(openAICompatStreamFirstResponseTimeoutMsg, openAICompatStreamFirstResponseTimeout)}
+		}
+		httpClient.CloseIdleConnections()
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err
 	}
@@ -527,6 +544,7 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("openai compat executor: close response body error: %v", errClose)
 		}
+		httpClient.CloseIdleConnections()
 		if errRead != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errRead)
 			return nil, errRead
@@ -543,6 +561,7 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 			if errClose := httpResp.Body.Close(); errClose != nil {
 				log.Errorf("openai compat executor: close response body error: %v", errClose)
 			}
+			httpClient.CloseIdleConnections()
 			reporter.EnsurePublished(ctx)
 		}()
 		buffer := make([]byte, 32*1024)
@@ -600,6 +619,32 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 	usageJSON := helps.BuildOpenAIUsageJSON(count)
 	translatedUsage := sdktranslator.TranslateTokenCount(ctx, to, from, count, usageJSON)
 	return cliproxyexecutor.Response{Payload: translatedUsage}, nil
+}
+
+func applyOpenAICompatStreamFirstResponseTimeout(client *http.Client, timeout time.Duration) {
+	if client == nil || timeout <= 0 {
+		return
+	}
+	if client.Transport == nil {
+		if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok && defaultTransport != nil {
+			transport := defaultTransport.Clone()
+			transport.ResponseHeaderTimeout = timeout
+			client.Transport = transport
+		}
+		return
+	}
+	if transport, ok := client.Transport.(*http.Transport); ok && transport != nil {
+		clone := transport.Clone()
+		clone.ResponseHeaderTimeout = timeout
+		client.Transport = clone
+	}
+}
+
+func isOpenAICompatStreamFirstResponseTimeout(err error, timeout time.Duration) bool {
+	if err == nil || timeout <= 0 {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "timeout awaiting response headers")
 }
 
 // Refresh is a no-op for API-key based compatibility providers.

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -11,6 +11,7 @@ import (
 	"net/textproto"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -404,6 +405,59 @@ func TestOpenAICompatExecutorStreamRejectsPlainJSONAfterBlankLines(t *testing.T)
 	}
 	if !strings.Contains(gotErr.Error(), "upstream failed") {
 		t.Fatalf("stream error = %v", gotErr)
+	}
+}
+
+func TestOpenAICompatExecutorStreamTimesOutWaitingForUpstreamResponse(t *testing.T) {
+	origTimeout := openAICompatStreamFirstResponseTimeout
+	openAICompatStreamFirstResponseTimeout = 50 * time.Millisecond
+	defer func() {
+		openAICompatStreamFirstResponseTimeout = origTimeout
+	}()
+
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+
+	errC := make(chan error, 1)
+	go func() {
+		_, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+			Model:   "openrouter-model",
+			Payload: []byte(`{"model":"openrouter-model","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+		}, cliproxyexecutor.Options{
+			SourceFormat: sdktranslator.FromString("openai"),
+			Stream:       true,
+		})
+		errC <- err
+	}()
+
+	var err error
+	select {
+	case err = <-errC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream first response timeout error")
+	}
+	if err == nil {
+		t.Fatal("expected first response timeout error, got nil")
+	}
+	statusErr, ok := err.(interface{ StatusCode() int })
+	if !ok {
+		t.Fatalf("error %T does not expose StatusCode(): %v", err, err)
+	}
+	if got := statusErr.StatusCode(); got != http.StatusGatewayTimeout {
+		t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusGatewayTimeout, err)
+	}
+	if !strings.Contains(err.Error(), "openai-compatible upstream stream first response timeout after 50ms") {
+		t.Fatalf("error message missing first response timeout: %v", err)
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -14,12 +14,15 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	. "github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -485,7 +488,38 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 	// New core execution path
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	requestLog := log.WithField("request_id", "--------")
+	if reqID := logging.GetRequestID(cliCtx); reqID != "" {
+		requestLog = log.WithField("request_id", reqID)
+	}
+	streamStartedAt := time.Now()
+	requestLog.Infof("openai responses stream start model=%q body_bytes=%d", modelName, len(rawJSON))
+	executeDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-executeDone:
+				return
+			case <-c.Request.Context().Done():
+				return
+			case <-ticker.C:
+				requestLog.Warnf("openai responses stream waiting ExecuteStreamWithAuthManager elapsed=%s request_ctx_err=%v cli_ctx_err=%v",
+					time.Since(streamStartedAt).Truncate(time.Second),
+					c.Request.Context().Err(),
+					cliCtx.Err(),
+				)
+			}
+		}
+	}()
 	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+	close(executeDone)
+	requestLog.Infof("openai responses stream ExecuteStreamWithAuthManager returned elapsed=%s data_chan_nil=%t err_chan_nil=%t",
+		time.Since(streamStartedAt).Truncate(time.Millisecond),
+		dataChan == nil,
+		errChan == nil,
+	)
 
 	setSSEHeaders := func() {
 		c.Header("Content-Type", "text/event-stream")
@@ -494,13 +528,18 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		c.Header("Access-Control-Allow-Origin", "*")
 	}
 	framer := &responsesSSEFramer{}
+	firstChunkWait := time.NewTicker(30 * time.Second)
+	defer firstChunkWait.Stop()
 
 	// Peek at the first chunk
 	for {
 		select {
 		case <-c.Request.Context().Done():
+			requestLog.Warnf("openai responses stream downstream canceled while waiting first chunk elapsed=%s err=%v", time.Since(streamStartedAt).Truncate(time.Second), c.Request.Context().Err())
 			cliCancel(c.Request.Context().Err())
 			return
+		case <-firstChunkWait.C:
+			requestLog.Warnf("openai responses stream still waiting first chunk elapsed=%s request_ctx_err=%v cli_ctx_err=%v", time.Since(streamStartedAt).Truncate(time.Second), c.Request.Context().Err(), cliCtx.Err())
 		case errMsg, ok := <-errChan:
 			if !ok {
 				// Err channel closed cleanly; wait for data channel.
@@ -508,6 +547,11 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 				continue
 			}
 			// Upstream failed immediately. Return proper error status and JSON.
+			if errMsg != nil {
+				requestLog.Warnf("openai responses stream failed before first chunk elapsed=%s status=%d err=%v", time.Since(streamStartedAt).Truncate(time.Second), errMsg.StatusCode, errMsg.Error)
+			} else {
+				requestLog.Warnf("openai responses stream failed before first chunk elapsed=%s err=<nil>", time.Since(streamStartedAt).Truncate(time.Second))
+			}
 			h.WriteErrorResponse(c, errMsg)
 			if errMsg != nil {
 				cliCancel(errMsg.Error)
@@ -518,6 +562,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		case chunk, ok := <-dataChan:
 			if !ok {
 				// Stream closed without data? Send headers and done.
+				requestLog.Warnf("openai responses stream data channel closed before first chunk elapsed=%s", time.Since(streamStartedAt).Truncate(time.Second))
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 				_, _ = c.Writer.Write([]byte("\n"))
@@ -527,6 +572,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			}
 
 			// Success! Set headers.
+			requestLog.Infof("openai responses stream first chunk received elapsed=%s bytes=%d", time.Since(streamStartedAt).Truncate(time.Millisecond), len(chunk))
 			setSSEHeaders()
 			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 

--- a/sdk/api/handlers/stream_forwarder.go
+++ b/sdk/api/handlers/stream_forwarder.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	log "github.com/sirupsen/logrus"
 )
 
 type StreamForwardOptions struct {
@@ -62,9 +64,36 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 	}
 
 	var terminalErr *interfaces.ErrorMessage
+	startedAt := time.Now()
+	lastActivityAt := startedAt
+	chunksForwarded := 0
+	bytesForwarded := 0
+	logEntry := log.WithField("request_id", "--------")
+	if c.Request != nil {
+		if reqID := logging.GetRequestID(c.Request.Context()); reqID != "" {
+			logEntry = log.WithField("request_id", reqID)
+		}
+	}
+	logProgress := func(reason string, warn bool) {
+		msg := "stream forwarder " + reason
+		args := []interface{}{
+			time.Since(startedAt).Truncate(time.Second),
+			time.Since(lastActivityAt).Truncate(time.Second),
+			chunksForwarded,
+			bytesForwarded,
+			c.Writer.Status(),
+			c.Request.Context().Err(),
+		}
+		if warn {
+			logEntry.Warnf(msg+" elapsed=%s idle=%s chunks=%d bytes=%d writer_status=%d request_ctx_err=%v", args...)
+			return
+		}
+		logEntry.Infof(msg+" elapsed=%s idle=%s chunks=%d bytes=%d writer_status=%d request_ctx_err=%v", args...)
+	}
 	for {
 		select {
 		case <-c.Request.Context().Done():
+			logProgress("request context done", true)
 			cancel(c.Request.Context().Err())
 			return
 		case chunk, ok := <-data:
@@ -83,19 +112,37 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 					if opts.WriteTerminalError != nil {
 						opts.WriteTerminalError(terminalErr)
 					}
+					logProgress("terminal error before flush", true)
 					flusher.Flush()
+					logProgress("terminal error flushed", true)
 					cancel(terminalErr.Error)
 					return
 				}
 				if opts.WriteDone != nil {
 					opts.WriteDone()
 				}
+				logProgress("data channel closed before final flush", false)
 				flusher.Flush()
+				logProgress("data channel closed flushed", false)
 				cancel(nil)
 				return
 			}
+			lastActivityAt = time.Now()
+			chunksForwarded++
+			bytesForwarded += len(chunk)
 			writeChunk(chunk)
+			beforeFlush := time.Now()
 			flusher.Flush()
+			if flushDuration := time.Since(beforeFlush); flushDuration > time.Second {
+				logEntry.Warnf("stream forwarder slow flush duration=%s elapsed=%s chunks=%d bytes=%d writer_status=%d request_ctx_err=%v",
+					flushDuration.Truncate(time.Millisecond),
+					time.Since(startedAt).Truncate(time.Second),
+					chunksForwarded,
+					bytesForwarded,
+					c.Writer.Status(),
+					c.Request.Context().Err(),
+				)
+			}
 		case errMsg, ok := <-errs:
 			if !ok {
 				continue
@@ -104,7 +151,9 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 				terminalErr = errMsg
 				if opts.WriteTerminalError != nil {
 					opts.WriteTerminalError(errMsg)
+					logProgress("error channel received before flush", true)
 					flusher.Flush()
+					logProgress("error channel received flushed", true)
 				}
 			}
 			var execErr error
@@ -114,8 +163,20 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 			cancel(execErr)
 			return
 		case <-keepAliveC:
+			lastActivityAt = time.Now()
 			writeKeepAlive()
+			beforeFlush := time.Now()
 			flusher.Flush()
+			if flushDuration := time.Since(beforeFlush); flushDuration > time.Second {
+				logEntry.Warnf("stream forwarder slow keepalive flush duration=%s elapsed=%s chunks=%d bytes=%d writer_status=%d request_ctx_err=%v",
+					flushDuration.Truncate(time.Millisecond),
+					time.Since(startedAt).Truncate(time.Second),
+					chunksForwarded,
+					bytesForwarded,
+					c.Writer.Status(),
+					c.Request.Context().Err(),
+				)
+			}
 		}
 	}
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2469,7 +2469,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 		} else {
 			if result.Model != "" {
-				if !isRequestScopedNotFoundResultError(result.Error) {
+				if !isRequestScopedNotFoundResultError(result.Error) && !isLocalStreamTimeoutResultError(result.Error) {
 					disableCooling := quotaCooldownDisabledForAuth(auth)
 					state := ensureModelState(auth, result.Model)
 					state.Unavailable = true
@@ -2905,6 +2905,16 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 		return false
 	}
 	return isRequestScopedNotFoundMessage(err.Message)
+}
+
+func isLocalStreamTimeoutResultError(err *Error) bool {
+	if err == nil || statusCodeFromResult(err) != http.StatusGatewayTimeout {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(err.Message))
+	return strings.HasPrefix(lower, "codex upstream stream first response timeout after ") ||
+		strings.HasPrefix(lower, "codex upstream stream idle timeout after ") ||
+		strings.HasPrefix(lower, "openai-compatible upstream stream first response timeout after ")
 }
 
 // isRequestInvalidError returns true if the error represents a client request

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2913,7 +2913,6 @@ func isLocalStreamTimeoutResultError(err *Error) bool {
 	}
 	lower := strings.ToLower(strings.TrimSpace(err.Message))
 	return strings.HasPrefix(lower, "codex upstream stream first response timeout after ") ||
-		strings.HasPrefix(lower, "codex upstream stream idle timeout after ") ||
 		strings.HasPrefix(lower, "openai-compatible upstream stream first response timeout after ")
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -870,12 +870,31 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
 	ctx = contextWithRequestedModelAlias(ctx, opts, routeModel)
+	entry := logEntryWithRequestID(ctx)
 	var lastErr error
 	for idx, execModel := range execModels {
 		resultModel := m.stateModelForExecution(auth, routeModel, execModel, pooled)
 		execReq := req
 		execReq.Model = execModel
+		modelStartedAt := time.Now()
+		entry.Infof("auth stream model attempt start provider=%s auth=%s route_model=%s exec_model=%s attempt=%d/%d", provider, safeAuthID(auth), routeModel, execModel, idx+1, len(execModels))
+		stopExecuteWatch := startAuthStreamStageWatch(ctx, "executor.ExecuteStream", map[string]any{
+			"provider":    provider,
+			"auth":        safeAuthID(auth),
+			"route_model": routeModel,
+			"exec_model":  execModel,
+		})
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, opts)
+		stopExecuteWatch()
+		entry.Infof("auth stream executor.ExecuteStream returned provider=%s auth=%s route_model=%s exec_model=%s elapsed=%s err=%v result_nil=%t",
+			provider,
+			safeAuthID(auth),
+			routeModel,
+			execModel,
+			time.Since(modelStartedAt).Truncate(time.Millisecond),
+			errStream,
+			streamResult == nil,
+		)
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
 				return nil, errCtx
@@ -894,7 +913,25 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			continue
 		}
 
+		bootstrapStartedAt := time.Now()
+		stopBootstrapWatch := startAuthStreamStageWatch(ctx, "readStreamBootstrap", map[string]any{
+			"provider":    provider,
+			"auth":        safeAuthID(auth),
+			"route_model": routeModel,
+			"exec_model":  execModel,
+		})
 		buffered, closed, bootstrapErr := readStreamBootstrap(ctx, streamResult.Chunks)
+		stopBootstrapWatch()
+		entry.Infof("auth stream readStreamBootstrap returned provider=%s auth=%s route_model=%s exec_model=%s elapsed=%s buffered=%d closed=%t err=%v",
+			provider,
+			safeAuthID(auth),
+			routeModel,
+			execModel,
+			time.Since(bootstrapStartedAt).Truncate(time.Millisecond),
+			len(buffered),
+			closed,
+			bootstrapErr,
+		)
 		if bootstrapErr != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
 				discardStreamChunks(streamResult.Chunks)
@@ -1295,13 +1332,25 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	if len(normalized) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
+	entry := logEntryWithRequestID(ctx)
+	startedAt := time.Now()
+	entry.Infof("auth manager ExecuteStream start providers=%s model=%s payload_bytes=%d", strings.Join(normalized, ","), req.Model, len(req.Payload))
+	stopWatch := startAuthStreamStageWatch(ctx, "Manager.ExecuteStream", map[string]any{
+		"providers": strings.Join(normalized, ","),
+		"model":     req.Model,
+	})
+	defer stopWatch()
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
 	for attempt := 0; ; attempt++ {
+		attemptStartedAt := time.Now()
+		entry.Infof("auth manager ExecuteStream attempt start attempt=%d providers=%s model=%s", attempt+1, strings.Join(normalized, ","), req.Model)
 		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
+		entry.Infof("auth manager ExecuteStream attempt returned attempt=%d elapsed=%s err=%v result_nil=%t", attempt+1, time.Since(attemptStartedAt).Truncate(time.Millisecond), errStream, result == nil)
 		if errStream == nil {
+			entry.Infof("auth manager ExecuteStream success elapsed=%s attempts=%d", time.Since(startedAt).Truncate(time.Millisecond), attempt+1)
 			return result, nil
 		}
 		lastErr = errStream
@@ -1323,8 +1372,10 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		if errors.As(lastErr, &bootstrapErr) && bootstrapErr != nil {
 			return streamErrorResult(bootstrapErr.Headers(), bootstrapErr.cause), nil
 		}
+		entry.Warnf("auth manager ExecuteStream failed elapsed=%s err=%v", time.Since(startedAt).Truncate(time.Millisecond), lastErr)
 		return nil, lastErr
 	}
+	entry.Warnf("auth manager ExecuteStream failed elapsed=%s err=auth_not_found", time.Since(startedAt).Truncate(time.Millisecond))
 	return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 }
 
@@ -1536,6 +1587,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 	homeAuthCount := 1
 	tried := make(map[string]struct{})
 	attempted := make(map[string]struct{})
+	entry := logEntryWithRequestID(ctx)
 	var lastErr error
 	for {
 		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
@@ -1548,7 +1600,29 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		if homeMode {
 			pickOpts = withHomeAuthCount(opts, homeAuthCount)
 		}
+		pickStartedAt := time.Now()
+		entry.Infof("auth stream pickNextMixed start providers=%s route_model=%s tried=%d attempted=%d home_mode=%t home_auth_count=%d",
+			strings.Join(providers, ","),
+			routeModel,
+			len(tried),
+			len(attempted),
+			homeMode,
+			homeAuthCount,
+		)
+		stopPickWatch := startAuthStreamStageWatch(ctx, "pickNextMixed", map[string]any{
+			"providers":   strings.Join(providers, ","),
+			"route_model": routeModel,
+			"tried":       len(tried),
+			"attempted":   len(attempted),
+		})
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
+		stopPickWatch()
+		entry.Infof("auth stream pickNextMixed returned elapsed=%s provider=%s auth=%s err=%v",
+			time.Since(pickStartedAt).Truncate(time.Millisecond),
+			provider,
+			safeAuthID(auth),
+			errPick,
+		)
 		if errPick != nil {
 			if shouldReturnLastErrorOnPickFailure(homeMode, lastErr, errPick) {
 				return nil, lastErr
@@ -1567,12 +1641,34 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
 		models, pooled := m.preparedExecutionModels(auth, routeModel)
+		entry.Infof("auth stream prepared execution models provider=%s auth=%s route_model=%s models=%s pooled=%t",
+			provider,
+			safeAuthID(auth),
+			routeModel,
+			strings.Join(models, ","),
+			pooled,
+		)
 		if len(models) == 0 {
 			continue
 		}
 		attempted[auth.ID] = struct{}{}
 		var errPrepare error
+		prepareStartedAt := time.Now()
+		entry.Infof("auth stream prepareRequestAuth start provider=%s auth=%s route_model=%s", provider, safeAuthID(auth), routeModel)
+		stopPrepareWatch := startAuthStreamStageWatch(execCtx, "prepareRequestAuth", map[string]any{
+			"provider":    provider,
+			"auth":        safeAuthID(auth),
+			"route_model": routeModel,
+		})
 		auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
+		stopPrepareWatch()
+		entry.Infof("auth stream prepareRequestAuth returned provider=%s auth=%s route_model=%s elapsed=%s err=%v",
+			provider,
+			safeAuthID(auth),
+			routeModel,
+			time.Since(prepareStartedAt).Truncate(time.Millisecond),
+			errPrepare,
+		)
 		if errPrepare != nil {
 			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: &Error{Message: errPrepare.Error()}}
 			if se, ok := errors.AsType[cliproxyexecutor.StatusError](errPrepare); ok && se != nil {
@@ -1583,7 +1679,17 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			continue
 		}
 		execReq := sanitizeDownstreamWebsocketFallbackRequest(execCtx, auth, req)
+		executeStartedAt := time.Now()
+		entry.Infof("auth stream executeStreamWithModelPool start provider=%s auth=%s route_model=%s models=%s", provider, safeAuthID(auth), routeModel, strings.Join(models, ","))
 		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, execReq, opts, routeModel, models, pooled)
+		entry.Infof("auth stream executeStreamWithModelPool returned provider=%s auth=%s route_model=%s elapsed=%s err=%v result_nil=%t",
+			provider,
+			safeAuthID(auth),
+			routeModel,
+			time.Since(executeStartedAt).Truncate(time.Millisecond),
+			errStream,
+			streamResult == nil,
+		)
 		if errStream != nil {
 			if errCtx := execCtx.Err(); errCtx != nil {
 				return nil, errCtx
@@ -1701,16 +1807,35 @@ func (m *Manager) prepareRequestAuth(ctx context.Context, executor ProviderExecu
 
 	id := strings.TrimSpace(auth.ID)
 	if id == "" {
-		return preparer.PrepareRequestAuth(ctx, auth.Clone())
+		entry := logEntryWithRequestID(ctx)
+		startedAt := time.Now()
+		entry.Infof("auth prepare direct start auth=<empty> provider=%s", auth.Provider)
+		updated, errPrepare := preparer.PrepareRequestAuth(ctx, auth.Clone())
+		entry.Infof("auth prepare direct returned auth=<empty> provider=%s elapsed=%s err=%v", auth.Provider, time.Since(startedAt).Truncate(time.Millisecond), errPrepare)
+		return updated, errPrepare
 	}
 
 	lockValue, _ := m.requestPrepareLocks.LoadOrStore(id, &requestAuthPrepareLock{})
 	lock, ok := lockValue.(*requestAuthPrepareLock)
 	if !ok || lock == nil {
-		return preparer.PrepareRequestAuth(ctx, auth.Clone())
+		entry := logEntryWithRequestID(ctx)
+		startedAt := time.Now()
+		entry.Infof("auth prepare direct start auth=%s provider=%s no_lock=true", safeAuthID(auth), auth.Provider)
+		updated, errPrepare := preparer.PrepareRequestAuth(ctx, auth.Clone())
+		entry.Infof("auth prepare direct returned auth=%s provider=%s no_lock=true elapsed=%s err=%v", safeAuthID(auth), auth.Provider, time.Since(startedAt).Truncate(time.Millisecond), errPrepare)
+		return updated, errPrepare
 	}
 
+	entry := logEntryWithRequestID(ctx)
+	lockStartedAt := time.Now()
+	entry.Infof("auth prepare lock wait start auth=%s provider=%s", safeAuthID(auth), auth.Provider)
+	stopLockWatch := startAuthStreamStageWatch(ctx, "prepareRequestAuth.lock", map[string]any{
+		"auth":     safeAuthID(auth),
+		"provider": auth.Provider,
+	})
 	lock.mu.Lock()
+	stopLockWatch()
+	entry.Infof("auth prepare lock acquired auth=%s provider=%s elapsed=%s", safeAuthID(auth), auth.Provider, time.Since(lockStartedAt).Truncate(time.Millisecond))
 	defer lock.mu.Unlock()
 
 	target := auth.Clone()
@@ -1721,10 +1846,19 @@ func (m *Manager) prepareRequestAuth(ctx context.Context, executor ProviderExecu
 	m.mu.RUnlock()
 
 	if !preparer.ShouldPrepareRequestAuth(target) {
+		entry.Infof("auth prepare skipped after lock auth=%s provider=%s", safeAuthID(target), target.Provider)
 		return target, nil
 	}
 
+	prepareStartedAt := time.Now()
+	entry.Infof("auth prepare provider call start auth=%s provider=%s", safeAuthID(target), target.Provider)
+	stopPrepareWatch := startAuthStreamStageWatch(ctx, "PrepareRequestAuth.provider", map[string]any{
+		"auth":     safeAuthID(target),
+		"provider": target.Provider,
+	})
 	updated, errPrepare := preparer.PrepareRequestAuth(ctx, target)
+	stopPrepareWatch()
+	entry.Infof("auth prepare provider call returned auth=%s provider=%s elapsed=%s err=%v", safeAuthID(target), target.Provider, time.Since(prepareStartedAt).Truncate(time.Millisecond), errPrepare)
 	if errPrepare != nil {
 		return auth, errPrepare
 	}
@@ -1732,7 +1866,10 @@ func (m *Manager) prepareRequestAuth(ctx context.Context, executor ProviderExecu
 		return target, nil
 	}
 
+	updateStartedAt := time.Now()
+	entry.Infof("auth prepare manager update start auth=%s provider=%s", safeAuthID(updated), updated.Provider)
 	saved, errUpdate := m.Update(ctx, updated)
+	entry.Infof("auth prepare manager update returned auth=%s provider=%s elapsed=%s err=%v", safeAuthID(updated), updated.Provider, time.Since(updateStartedAt).Truncate(time.Millisecond), errUpdate)
 	if errUpdate != nil {
 		return updated, errUpdate
 	}
@@ -2647,10 +2784,13 @@ func isUnauthorizedError(err error) bool {
 	if err == nil {
 		return false
 	}
+	raw := strings.ToLower(err.Error())
+	if strings.Contains(raw, "refresh_token_reused") {
+		return false
+	}
 	if statusCodeFromError(err) == http.StatusUnauthorized {
 		return true
 	}
-	raw := strings.ToLower(err.Error())
 	return strings.Contains(raw, "status 401") || strings.Contains(raw, "401 unauthorized")
 }
 
@@ -4452,4 +4592,57 @@ func (m *Manager) HttpRequest(ctx context.Context, auth *Auth, req *http.Request
 		return nil, &Error{Code: "provider_not_found", Message: "executor not registered for provider: " + providerKey}
 	}
 	return exec.HttpRequest(ctx, auth, req)
+}
+
+func safeAuthID(auth *Auth) string {
+	if auth == nil {
+		return "<nil>"
+	}
+	id := strings.TrimSpace(auth.ID)
+	if id != "" {
+		return id
+	}
+	file := strings.TrimSpace(auth.FileName)
+	if file != "" {
+		return filepath.Base(file)
+	}
+	label := strings.TrimSpace(auth.Label)
+	if label != "" {
+		return label
+	}
+	return "<empty>"
+}
+
+func startAuthStreamStageWatch(ctx context.Context, stage string, fields map[string]any) func() {
+	stage = strings.TrimSpace(stage)
+	if stage == "" {
+		stage = "unknown"
+	}
+	done := make(chan struct{})
+	var once sync.Once
+	startedAt := time.Now()
+	stop := func() {
+		once.Do(func() {
+			close(done)
+		})
+	}
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		entry := logEntryWithRequestID(ctx)
+		for k, v := range fields {
+			entry = entry.WithField(k, v)
+		}
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				entry.Warnf("auth stream stage still running stage=%s elapsed=%s ctx_err=%v", stage, time.Since(startedAt).Truncate(time.Second), ctx.Err())
+			}
+		}
+	}()
+	return stop
 }

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -779,6 +779,110 @@ func TestManager_MarkResult_RequestScopedNotFoundDoesNotCooldownAuth(t *testing.
 	}
 }
 
+func TestManager_MarkResult_LocalStreamTimeoutDoesNotCooldownAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:       "auth-local-timeout",
+		Provider: "openai-compatibility",
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "gpt-5.5"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusGatewayTimeout,
+			Message:    "openai-compatible upstream stream first response timeout after 2m0s",
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if updated.Unavailable {
+		t.Fatalf("expected local stream timeout to keep auth available")
+	}
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected local stream timeout to keep auth cooldown unset, got %v", updated.NextRetryAfter)
+	}
+	if state := updated.ModelStates[model]; state != nil {
+		t.Fatalf("expected local stream timeout to avoid model cooldown state, got %#v", state)
+	}
+	if updated.Failed != 1 {
+		t.Fatalf("failed count = %d, want 1", updated.Failed)
+	}
+}
+
+func TestManager_ExecuteStream_LocalStreamTimeoutDoesNotBlackoutOnlyAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(0, 0, 0)
+	executor := &authFallbackExecutor{
+		id: "openai-compatibility",
+		streamFirstErrors: map[string]error{
+			"auth-local-timeout-stream": &retryAfterStatusError{
+				status:  http.StatusGatewayTimeout,
+				message: "codex upstream stream idle timeout after 5m0s",
+			},
+		},
+	}
+	m.RegisterExecutor(executor)
+
+	auth := &Auth{
+		ID:       "auth-local-timeout-stream",
+		Provider: "openai-compatibility",
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "gpt-5.5"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	req := cliproxyexecutor.Request{Model: model}
+	streamResult1, errExecute1 := m.ExecuteStream(context.Background(), []string{auth.Provider}, req, cliproxyexecutor.Options{})
+	if errExecute1 != nil {
+		t.Fatalf("first ExecuteStream returned setup error = %v", errExecute1)
+	}
+	var chunkErr error
+	for chunk := range streamResult1.Chunks {
+		if chunk.Err != nil {
+			chunkErr = chunk.Err
+		}
+	}
+	if chunkErr == nil {
+		t.Fatal("expected first stream chunk error")
+	}
+	if statusCodeFromError(chunkErr) != http.StatusGatewayTimeout {
+		t.Fatalf("first stream chunk status = %d, want %d", statusCodeFromError(chunkErr), http.StatusGatewayTimeout)
+	}
+
+	streamResult2, errExecute2 := m.ExecuteStream(context.Background(), []string{auth.Provider}, req, cliproxyexecutor.Options{})
+	if errExecute2 != nil {
+		t.Fatalf("second ExecuteStream error = %v, want same auth to remain selectable", errExecute2)
+	}
+	for range streamResult2.Chunks {
+	}
+
+	calls := executor.StreamCalls()
+	if len(calls) != 2 {
+		t.Fatalf("stream calls = %v, want two calls to same auth", calls)
+	}
+	for i, call := range calls {
+		if call != auth.ID {
+			t.Fatalf("stream call %d auth = %q, want %q", i, call, auth.ID)
+		}
+	}
+}
+
 func TestManager_RequestScopedNotFoundStopsRetryWithoutSuspendingAuth(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	executor := &authFallbackExecutor{

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -828,7 +828,7 @@ func TestManager_ExecuteStream_LocalStreamTimeoutDoesNotBlackoutOnlyAuth(t *test
 		streamFirstErrors: map[string]error{
 			"auth-local-timeout-stream": &retryAfterStatusError{
 				status:  http.StatusGatewayTimeout,
-				message: "codex upstream stream idle timeout after 5m0s",
+				message: "codex upstream stream first response timeout after 2m0s",
 			},
 		},
 	}

--- a/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
@@ -45,6 +45,14 @@ func (e unauthorizedRefreshTestExecutor) Refresh(ctx context.Context, auth *Auth
 	return nil, errors.New("token refresh failed with status 401: invalid_grant")
 }
 
+type refreshTokenReusedTestExecutor struct {
+	schedulerProviderTestExecutor
+}
+
+func (e refreshTokenReusedTestExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	return nil, errors.New("token refresh failed with status 401: {\"error\":{\"code\":\"refresh_token_reused\"}}")
+}
+
 func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(nil, &RoundRobinSelector{}, nil)
@@ -87,6 +95,51 @@ func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.
 	}
 	if _, shouldSchedule := nextRefreshCheckAt(now, updated, time.Second); shouldSchedule {
 		t.Fatal("expected unauthorized auth to be removed from the auto-refresh schedule")
+	}
+}
+
+func TestManager_RefreshAuthTokenReusedDoesNotMarkAuthUnavailable(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(refreshTokenReusedTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "codex"},
+	})
+
+	auth := &Auth{
+		ID:       "refresh-token-reused",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"email": "x@example.com",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	before := time.Now()
+	manager.refreshAuth(ctx, auth.ID)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+	if updated.Unavailable {
+		t.Fatal("refresh_token_reused should not mark auth unavailable")
+	}
+	if updated.LastError == nil {
+		t.Fatal("expected refresh_token_reused failure to be recorded")
+	}
+	if got := updated.LastError.Code; got == "unauthorized" {
+		t.Fatalf("LastError.Code = %q, want non-unauthorized", got)
+	}
+	if got := updated.LastError.StatusCode(); got == http.StatusUnauthorized {
+		t.Fatalf("LastError.StatusCode() = %d, want non-unauthorized", got)
+	}
+	if !updated.NextRefreshAfter.After(before) {
+		t.Fatalf("NextRefreshAfter = %s, want retry backoff after %s", updated.NextRefreshAfter, before)
+	}
+	if manager.shouldRefresh(updated, time.Now()) {
+		t.Fatal("expected refresh_token_reused auth to wait for retry backoff")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add first-response and idle watchdog handling for Codex HTTP streaming so stalled upstream streams return explicit 504 errors instead of hanging indefinitely
- add first-response timeout handling for OpenAI-compatible streaming and image streaming paths
- improve streaming diagnostics and avoid cooling auth/model pools for local proxy-generated timeout errors

## Test Plan
- docker run --rm -v "$PWD":/app -w /app golang:1.26-alpine sh -lc '/usr/local/go/bin/go test ./internal/runtime/executor ./sdk/api/handlers/... ./sdk/cliproxy/auth -count=1 -timeout=120s'\n- docker run --rm -v "$PWD":/app -w /app golang:1.26-alpine sh -lc '/usr/local/go/bin/go test ./... -count=1 -timeout=180s'