### PR TITLE
fix(executor): normalize single-underscore mcp_ tool prefix on OAuth

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -106,6 +106,34 @@ var oauthToolRenameMap = map[string]string{
 // then the global reverse map incorrectly rewrote every `Bash` in the
 // response to `bash`, causing Amp to reject the tool_use as unknown).
 
+// mcpSingleUnderscorePrefix / mcpDoubleUnderscorePrefix bracket the MCP tool-name
+// normalization. Some third-party clients (e.g. BoltAI) name MCP tools with a
+// single underscore (`mcp_<tool>`). Anthropic's overage gate fingerprints that
+// single-underscore prefix as a user-installed MCP extension and bills it to
+// extra usage, returning HTTP 400 ("third-party apps now draw from your extra
+// usage") on accounts where extra usage is disabled. Claude Code's own
+// convention is the double-underscore form (`mcp__<server>__<tool>`), which is
+// accepted as first-party, so we normalize `mcp_` -> `mcp__` on OAuth traffic.
+const (
+	mcpSingleUnderscorePrefix = "mcp_"
+	mcpDoubleUnderscorePrefix = "mcp__"
+)
+
+// oauthRenamedToolName returns the Claude Code-compatible upstream name for a
+// client-supplied OAuth tool name and whether a rename is needed. It first
+// applies the static built-in rename map (bash -> Bash, ...), then normalizes a
+// single-underscore `mcp_` MCP prefix to the double-underscore form Anthropic
+// recognizes as first-party. Names that are already `mcp__...` pass through.
+func oauthRenamedToolName(name string) (string, bool) {
+	if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
+		return newName, true
+	}
+	if strings.HasPrefix(name, mcpSingleUnderscorePrefix) && !strings.HasPrefix(name, mcpDoubleUnderscorePrefix) {
+		return mcpDoubleUnderscorePrefix + name[len(mcpSingleUnderscorePrefix):], true
+	}
+	return name, false
+}
+
 // oauthToolsToRemove lists tool names that must be stripped from OAuth requests
 // even after remapping. Currently empty — all tools are mapped instead of removed.
 var oauthToolsToRemove = map[string]bool{}
@@ -1174,7 +1202,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			}
 
 			toolJSON := tool.Raw
-			if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
+			if newName, ok := oauthRenamedToolName(name); ok {
 				updatedTool, err := sjson.Set(toolJSON, "name", newName)
 				if err == nil {
 					toolJSON = updatedTool
@@ -1201,7 +1229,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			// The chosen tool was removed from the tools array, so drop tool_choice to
 			// keep the payload internally consistent and fall back to normal auto tool use.
 			body, _ = sjson.DeleteBytes(body, "tool_choice")
-		} else if newName, ok := oauthToolRenameMap[tcName]; ok && newName != tcName {
+		} else if newName, ok := oauthRenamedToolName(tcName); ok {
 			body, _ = sjson.SetBytes(body, "tool_choice.name", newName)
 			recordRename(tcName, newName)
 		}
@@ -1220,14 +1248,14 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 				switch partType {
 				case "tool_use":
 					name := part.Get("name").String()
-					if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
+					if newName, ok := oauthRenamedToolName(name); ok {
 						path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
 						body, _ = sjson.SetBytes(body, path, newName)
 						recordRename(name, newName)
 					}
 				case "tool_reference":
 					toolName := part.Get("tool_name").String()
-					if newName, ok := oauthToolRenameMap[toolName]; ok && newName != toolName {
+					if newName, ok := oauthRenamedToolName(toolName); ok {
 						path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
 						body, _ = sjson.SetBytes(body, path, newName)
 						recordRename(toolName, newName)
@@ -1241,7 +1269,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 						nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
 							if nestedPart.Get("type").String() == "tool_reference" {
 								nestedToolName := nestedPart.Get("tool_name").String()
-								if newName, ok := oauthToolRenameMap[nestedToolName]; ok && newName != nestedToolName {
+								if newName, ok := oauthRenamedToolName(nestedToolName); ok {
 									nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
 									body, _ = sjson.SetBytes(body, nestedPath, newName)
 									recordRename(nestedToolName, newName)

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2255,6 +2255,62 @@ func TestReverseRemapOAuthToolNamesFromStreamLine_HonorsPerRequestMap(t *testing
 	}
 }
 
+// TestRemapOAuthToolNames_McpSingleUnderscore_NormalizedAndReversed guards the
+// fix for third-party clients (e.g. BoltAI) that name MCP tools with a single
+// underscore `mcp_<tool>` prefix. Anthropic's overage gate fingerprints that
+// prefix as a user-installed MCP extension and rejects OAuth requests with a 400
+// ("third-party apps now draw from your extra usage"). Claude Code's own
+// convention is the double-underscore `mcp__` prefix, which is accepted as
+// first-party, so we normalize `mcp_` -> `mcp__` upstream and restore the
+// client's original single-underscore name on the response.
+func TestRemapOAuthToolNames_McpSingleUnderscore_NormalizedAndReversed(t *testing.T) {
+	body := []byte(`{"tools":[` +
+		`{"name":"mcp_search_youtube_z50gm8","input_schema":{"type":"object","properties":{"query":{"type":"string"}}}},` +
+		`{"name":"mcp__already__ok","input_schema":{"type":"object","properties":{"q":{"type":"string"}}}}` +
+		`],"tool_choice":{"type":"tool","name":"mcp_search_youtube_z50gm8"},` +
+		`"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"mcp_search_youtube_z50gm8","input":{"query":"go"}}]}]}`)
+
+	out, reverseMap := remapOAuthToolNames(body)
+
+	// Forward: single-underscore mcp_ prefix is doubled upstream.
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "mcp__search_youtube_z50gm8" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "mcp__search_youtube_z50gm8")
+	}
+	// Forward: an already double-underscore name must pass through unchanged.
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "mcp__already__ok" {
+		t.Fatalf("tools.1.name = %q, want unchanged %q", got, "mcp__already__ok")
+	}
+	// Forward: tool_choice.name is normalized too (else Anthropic 400s on mismatch).
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "mcp__search_youtube_z50gm8" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "mcp__search_youtube_z50gm8")
+	}
+	// Forward: tool_use in message history is normalized.
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "mcp__search_youtube_z50gm8" {
+		t.Fatalf("history tool_use name = %q, want %q", got, "mcp__search_youtube_z50gm8")
+	}
+	// Reverse map records ONLY the renamed tool, not the already-correct one.
+	if reverseMap["mcp__search_youtube_z50gm8"] != "mcp_search_youtube_z50gm8" {
+		t.Fatalf("reverseMap = %v, want entry mcp__search_youtube_z50gm8 -> mcp_search_youtube_z50gm8", reverseMap)
+	}
+	if _, exists := reverseMap["mcp__already__ok"]; exists {
+		t.Fatalf("reverseMap must not contain already-double-underscore name: %v", reverseMap)
+	}
+
+	// Reverse (buffered): response tool_use restored to client's single-underscore name.
+	resp := []byte(`{"content":[{"type":"tool_use","id":"toolu_02","name":"mcp__search_youtube_z50gm8","input":{"query":"go"}}]}`)
+	reversed := reverseRemapOAuthToolNames(resp, reverseMap)
+	if got := gjson.GetBytes(reversed, "content.0.name").String(); got != "mcp_search_youtube_z50gm8" {
+		t.Fatalf("content.0.name = %q, want restored %q", got, "mcp_search_youtube_z50gm8")
+	}
+
+	// Reverse (streaming): same restoration on the SSE content_block.
+	line := []byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_02","name":"mcp__search_youtube_z50gm8","input":{}}}`)
+	outLine := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
+	if !bytes.Contains(outLine, []byte(`"name":"mcp_search_youtube_z50gm8"`)) {
+		t.Fatalf("stream reverse failed, got: %s", string(outLine))
+	}
+}
+
 func TestPrepareClaudeOAuthToolNamesForUpstream_MixedCaseWithPrefix(t *testing.T) {
 	body := []byte(`{"tools":[` +
 		`{"name":"Bash","input_schema":{"type":"object","properties":{"cmd":{"type":"string"}}}},` +


### PR DESCRIPTION
## Problem

Third-party clients that name MCP tools with a **single-underscore** prefix
(`mcp_<tool>`) get rejected on OAuth (Claude Code) traffic. Anthropic's overage
gate fingerprints that single-underscore prefix as a user-installed third-party
MCP extension and bills it to "extra usage". On accounts where extra usage is
disabled at the org level, the request fails with **HTTP 400**:

> Third-party apps now draw from your extra usage, not your plan limits. Add more
> at claude.ai/settings/usage and keep going.

Claude Code's own convention is the **double-underscore** form
(`mcp__<server>__<tool>`), which Anthropic accepts as first-party.

Reproduced with BoltAI (`ai-sdk/anthropic/...-boltai.2`), which emits
`mcp_<tool>` tool names, against an OAuth account with org-level extra usage
disabled (`Anthropic-Ratelimit-Unified-Overage-Disabled-Reason: org_level_disabled`).

## Fix

Add `oauthRenamedToolName()` in the Claude executor. It applies the existing
static rename map (`bash` -> `Bash`, ...) and then normalizes a single-underscore
`mcp_` prefix to the double-underscore `mcp__` form, while leaving names that are
already `mcp__...` untouched. It's wired into every OAuth tool-name rewrite site:
the `tools` array, `tool_choice`, `tool_use` / `tool_reference` message parts, and
nested content.

The existing reverse mapping restores the client's original `mcp_` name on the
response, so the client never sees the rewrite.

## Evidence (credentials/PII redacted)

Same BoltAI request, same model, **same account with overage still disabled** --
the only variable is the outbound prefix.

**Before** -- proxy forwards `mcp_*` upstream -> **400**:
```
Status: 400
Anthropic-Ratelimit-Unified-Overage-Disabled-Reason: org_level_disabled
{"type":"error","error":{"type":"invalid_request_error",
 "message":"Third-party apps now draw from your extra usage, ..."}}
```

**After** -- proxy rewrites to `mcp__*` upstream -> **200** (overage still disabled):
```
Status: 200
Anthropic-Ratelimit-Unified-Overage-Disabled-Reason: org_level_disabled
Anthropic-Ratelimit-Unified-Overage-Status: rejected
Anthropic-Ratelimit-Unified-Status: allowed
```
Downstream response reverses the name back to the client's original
`mcp_get_youtube_transcript_...`, confirming the full round-trip.

## Test

`TestRemapOAuthToolNames_McpSingleUnderscore_NormalizedAndReversed` covers the
forward normalization and reverse restoration.

`go test ./internal/runtime/executor/...` passes; `gofmt` clean; server builds.
