### PR TITLE
feat(codex): add compact routing controls

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -178,11 +178,18 @@ nonstream-keepalive-interval: 0
 #       - "*flash*"            # wildcard matching substring (e.g. gemini-2.5-flash-lite)
 #   - api-key: "AIzaSy...02"
 
+# compact-default controls /v1/responses/compact routing for codex/openai-compatible
+# credentials whose per-credential compact mode is "auto" (the default).
+#   allow (default): auto credentials may serve compact requests (backward compatible)
+#   deny: auto credentials are excluded; only credentials with compact: force_on serve compact
+# compact-default: allow
+
 # Codex API keys
 # codex-api-key:
 #   - api-key: "sk-atSM..."
 #     prefix: "test" # optional: require calls like "test/gpt-5-codex" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
+#     compact: "auto"   # "auto" (follows compact-default) | "force_on" | "force_off"
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
 #     headers:
 #       X-Custom-Header: "custom-value"
@@ -257,6 +264,7 @@ nonstream-keepalive-interval: 0
 #   - name: "openrouter" # The name of the provider; it will be used in the user agent and other places.
 #     disabled: false # optional: set to true to disable this provider without removing it
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
+#     compact: "auto" # provider-level: "auto" | "force_on" | "force_off"
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
 #     disable-cooling: false # optional: per-provider override for auth/model cooldown scheduling
 #     headers:

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -28,6 +28,7 @@ import (
 	geminiAuth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/gemini"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kimi"
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -364,6 +365,11 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 						}
 					}
 				}
+				if cv := gjson.GetBytes(data, "compact"); cv.Exists() && cv.Type == gjson.String {
+					if trimmed := strings.TrimSpace(cv.String()); trimmed != "" {
+						fileData["compact"] = trimmed
+					}
+				}
 			}
 
 			files = append(files, fileData)
@@ -486,6 +492,15 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	}
 	if websockets, ok := authWebsocketsValue(auth); ok {
 		entry["websockets"] = websockets
+	}
+	if mode := strings.TrimSpace(authAttribute(auth, "compact_mode")); mode != "" {
+		entry["compact"] = mode
+	} else if auth.Metadata != nil {
+		if rawCompact, ok := auth.Metadata["compact"].(string); ok {
+			if trimmed := strings.TrimSpace(rawCompact); trimmed != "" {
+				entry["compact"] = trimmed
+			}
+		}
 	}
 	return entry
 }
@@ -1262,6 +1277,11 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid field %s", fieldPath)})
 			return
 		}
+		value = normalizeAuthFileFieldValue(fieldPath, value)
+		if errField := validateAuthFileFieldValue(fieldPath, value); errField != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": errField.Error()})
+			return
+		}
 		if targetAuth.Metadata == nil {
 			targetAuth.Metadata = make(map[string]any)
 		}
@@ -1278,7 +1298,7 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 		changed = true
 	}
 	if changed {
-		syncAuthFileMetadataFields(targetAuth, touchedRoots)
+		syncAuthFileMetadataFields(targetAuth, touchedRoots, h.cfg)
 	}
 
 	if !changed {
@@ -1315,6 +1335,33 @@ func rootAuthFileField(path string) string {
 		return strings.TrimSpace(path[:idx])
 	}
 	return path
+}
+
+func normalizeAuthFileFieldValue(path string, value any) any {
+	if strings.TrimSpace(path) != "compact" {
+		return value
+	}
+	raw, ok := value.(string)
+	if !ok {
+		return value
+	}
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func validateAuthFileFieldValue(path string, value any) error {
+	if strings.TrimSpace(path) != "compact" {
+		return nil
+	}
+	raw, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("compact must be a string")
+	}
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case coreauth.CompactModeAuto, coreauth.CompactModeForceOn, coreauth.CompactModeForceOff:
+		return nil
+	default:
+		return fmt.Errorf("compact must be one of auto, force_on, force_off")
+	}
 }
 
 func setAuthFileMetadataValue(metadata map[string]any, path string, value any) error {
@@ -1403,7 +1450,7 @@ func authFileHeadersStringMap(value any) (map[string]string, bool) {
 	}
 }
 
-func syncAuthFileMetadataFields(auth *coreauth.Auth, touchedRoots map[string]struct{}) {
+func syncAuthFileMetadataFields(auth *coreauth.Auth, touchedRoots map[string]struct{}, cfg *config.Config) {
 	if auth == nil || len(touchedRoots) == 0 {
 		return
 	}
@@ -1428,6 +1475,9 @@ func syncAuthFileMetadataFields(auth *coreauth.Auth, touchedRoots map[string]str
 	}
 	if _, ok := touchedRoots["websockets"]; ok {
 		syncAuthFileWebsocketsAttribute(auth)
+	}
+	if _, ok := touchedRoots["compact"]; ok {
+		syncAuthFileCompactAttribute(auth, cfg)
 	}
 	if _, ok := touchedRoots["disabled"]; ok {
 		syncAuthFileDisabledState(auth)
@@ -1523,6 +1573,26 @@ func syncAuthFileWebsocketsAttribute(auth *coreauth.Auth) {
 		return
 	}
 	auth.Attributes["websockets"] = strconv.FormatBool(websockets)
+}
+
+func syncAuthFileCompactAttribute(auth *coreauth.Auth, cfg *config.Config) {
+	if auth == nil {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	raw, ok := auth.Metadata["compact"].(string)
+	if !ok {
+		delete(auth.Attributes, "compact_mode")
+		delete(auth.Attributes, "compact_allowed")
+		return
+	}
+	defaultAllow := true
+	if cfg != nil && strings.EqualFold(strings.TrimSpace(cfg.CompactDefault), "deny") {
+		defaultAllow = false
+	}
+	coreauth.ApplyCompactAttributes(auth, raw, defaultAllow)
 }
 
 func authFileBoolValue(value any) (bool, bool) {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -365,9 +365,11 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 						}
 					}
 				}
-				if cv := gjson.GetBytes(data, "compact"); cv.Exists() && cv.Type == gjson.String {
-					if trimmed := strings.TrimSpace(cv.String()); trimmed != "" {
-						fileData["compact"] = trimmed
+				if strings.EqualFold(typeValue, "codex") {
+					if cv := gjson.GetBytes(data, "compact"); cv.Exists() && cv.Type == gjson.String {
+						if trimmed := strings.TrimSpace(cv.String()); trimmed != "" {
+							fileData["compact"] = trimmed
+						}
 					}
 				}
 			}
@@ -493,12 +495,14 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	if websockets, ok := authWebsocketsValue(auth); ok {
 		entry["websockets"] = websockets
 	}
-	if mode := strings.TrimSpace(authAttribute(auth, "compact_mode")); mode != "" {
-		entry["compact"] = mode
-	} else if auth.Metadata != nil {
-		if rawCompact, ok := auth.Metadata["compact"].(string); ok {
-			if trimmed := strings.TrimSpace(rawCompact); trimmed != "" {
-				entry["compact"] = trimmed
+	if strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		if mode := strings.TrimSpace(authAttribute(auth, "compact_mode")); mode != "" {
+			entry["compact"] = mode
+		} else if auth.Metadata != nil {
+			if rawCompact, ok := auth.Metadata["compact"].(string); ok {
+				if trimmed := strings.TrimSpace(rawCompact); trimmed != "" {
+					entry["compact"] = trimmed
+				}
 			}
 		}
 	}
@@ -1278,7 +1282,7 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			return
 		}
 		value = normalizeAuthFileFieldValue(fieldPath, value)
-		if errField := validateAuthFileFieldValue(fieldPath, value); errField != nil {
+		if errField := validateAuthFileFieldValue(targetAuth, fieldPath, value); errField != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": errField.Error()})
 			return
 		}
@@ -1338,7 +1342,7 @@ func rootAuthFileField(path string) string {
 }
 
 func normalizeAuthFileFieldValue(path string, value any) any {
-	if strings.TrimSpace(path) != "compact" {
+	if rootAuthFileField(path) != "compact" || strings.TrimSpace(path) != "compact" {
 		return value
 	}
 	raw, ok := value.(string)
@@ -1348,9 +1352,16 @@ func normalizeAuthFileFieldValue(path string, value any) any {
 	return strings.ToLower(strings.TrimSpace(raw))
 }
 
-func validateAuthFileFieldValue(path string, value any) error {
-	if strings.TrimSpace(path) != "compact" {
+func validateAuthFileFieldValue(auth *coreauth.Auth, path string, value any) error {
+	root := rootAuthFileField(path)
+	if root != "compact" {
 		return nil
+	}
+	if strings.TrimSpace(path) != "compact" {
+		return fmt.Errorf("compact must be a top-level field")
+	}
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return fmt.Errorf("compact is only supported for codex auth files")
 	}
 	raw, ok := value.(string)
 	if !ok {
@@ -1581,6 +1592,11 @@ func syncAuthFileCompactAttribute(auth *coreauth.Auth, cfg *config.Config) {
 	}
 	if auth.Attributes == nil {
 		auth.Attributes = make(map[string]string)
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		delete(auth.Attributes, "compact_mode")
+		delete(auth.Attributes, "compact_allowed")
+		return
 	}
 	raw, ok := auth.Metadata["compact"].(string)
 	if !ok {

--- a/internal/api/handlers/management/auth_files_compact_test.go
+++ b/internal/api/handlers/management/auth_files_compact_test.go
@@ -17,31 +17,48 @@ import (
 )
 
 func TestSyncAuthFileCompactAttribute(t *testing.T) {
-	on := &coreauth.Auth{ID: "on", Metadata: map[string]any{"compact": "force_on"}}
+	on := &coreauth.Auth{ID: "on", Provider: "codex", Metadata: map[string]any{"compact": "force_on"}}
 	syncAuthFileCompactAttribute(on, &config.Config{})
 	if on.Attributes["compact_mode"] != "force_on" || on.Attributes["compact_allowed"] != "true" {
 		t.Fatalf("force_on attrs = %#v", on.Attributes)
 	}
 
-	off := &coreauth.Auth{ID: "off", Metadata: map[string]any{"compact": "force_off"}}
+	off := &coreauth.Auth{ID: "off", Provider: "codex", Metadata: map[string]any{"compact": "force_off"}}
 	syncAuthFileCompactAttribute(off, &config.Config{})
 	if off.Attributes["compact_mode"] != "force_off" || off.Attributes["compact_allowed"] != "false" {
 		t.Fatalf("force_off attrs = %#v", off.Attributes)
 	}
 
-	autoDenied := &coreauth.Auth{ID: "auto", Metadata: map[string]any{"compact": "auto"}}
+	autoDenied := &coreauth.Auth{ID: "auto", Provider: "codex", Metadata: map[string]any{"compact": "auto"}}
 	syncAuthFileCompactAttribute(autoDenied, &config.Config{CompactDefault: "deny"})
 	if autoDenied.Attributes["compact_mode"] != "auto" || autoDenied.Attributes["compact_allowed"] != "false" {
 		t.Fatalf("auto attrs = %#v", autoDenied.Attributes)
 	}
 
-	cleared := &coreauth.Auth{ID: "c", Attributes: map[string]string{"compact_mode": "force_on", "compact_allowed": "true"}}
+	cleared := &coreauth.Auth{ID: "c", Provider: "codex", Attributes: map[string]string{"compact_mode": "force_on", "compact_allowed": "true"}}
 	syncAuthFileCompactAttribute(cleared, &config.Config{}) // no Metadata["compact"] -> remove mode
 	if _, ok := cleared.Attributes["compact_mode"]; ok {
 		t.Fatalf("compact_mode should be removed, got %#v", cleared.Attributes)
 	}
 	if _, ok := cleared.Attributes["compact_allowed"]; ok {
 		t.Fatalf("compact_allowed should be removed, got %#v", cleared.Attributes)
+	}
+
+	nonCodex := &coreauth.Auth{
+		ID:       "n",
+		Provider: "gemini",
+		Attributes: map[string]string{
+			"compact_mode":    "force_on",
+			"compact_allowed": "true",
+		},
+		Metadata: map[string]any{"compact": "force_off"},
+	}
+	syncAuthFileCompactAttribute(nonCodex, &config.Config{})
+	if _, ok := nonCodex.Attributes["compact_mode"]; ok {
+		t.Fatalf("non-codex compact_mode should be removed, got %#v", nonCodex.Attributes)
+	}
+	if _, ok := nonCodex.Attributes["compact_allowed"]; ok {
+		t.Fatalf("non-codex compact_allowed should be removed, got %#v", nonCodex.Attributes)
 	}
 }
 
@@ -51,6 +68,24 @@ func TestBuildAuthFileEntry_ExposesCompact(t *testing.T) {
 	entry := h.buildAuthFileEntry(auth)
 	if entry["compact"] != "force_off" {
 		t.Fatalf("entry[compact] = %v, want force_off", entry["compact"])
+	}
+}
+
+func TestBuildAuthFileEntry_DoesNotExposeCompactForNonCodex(t *testing.T) {
+	h := &Handler{}
+	auth := &coreauth.Auth{
+		ID:       "x",
+		Provider: "gemini",
+		Attributes: map[string]string{
+			"runtime_only":    "true",
+			"compact_mode":    "force_off",
+			"compact_allowed": "false",
+		},
+		Metadata: map[string]any{"compact": "force_off"},
+	}
+	entry := h.buildAuthFileEntry(auth)
+	if _, ok := entry["compact"]; ok {
+		t.Fatalf("entry[compact] = %v, want absent", entry["compact"])
 	}
 }
 
@@ -161,5 +196,77 @@ func TestPatchAuthFileFields_InvalidCompactRejected(t *testing.T) {
 	}
 	if _, exists := updated.Metadata["compact"]; exists {
 		t.Fatalf("expected invalid compact not to persist, metadata = %#v", updated.Metadata)
+	}
+}
+
+func TestPatchAuthFileFields_NestedCompactRejected(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "codex.json",
+		FileName: "codex.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "/tmp/codex.json",
+		},
+		Metadata: map[string]any{
+			"type": "codex",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	body := `{"name":"codex.json","compact.mode":"force_on"}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+}
+
+func TestPatchAuthFileFields_CompactRejectedForNonCodex(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "gemini.json",
+		FileName: "gemini.json",
+		Provider: "gemini",
+		Attributes: map[string]string{
+			"path": "/tmp/gemini.json",
+		},
+		Metadata: map[string]any{
+			"type": "gemini",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	body := `{"name":"gemini.json","compact":"force_on"}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusBadRequest, rec.Code, rec.Body.String())
 	}
 }

--- a/internal/api/handlers/management/auth_files_compact_test.go
+++ b/internal/api/handlers/management/auth_files_compact_test.go
@@ -1,0 +1,165 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	fileauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestSyncAuthFileCompactAttribute(t *testing.T) {
+	on := &coreauth.Auth{ID: "on", Metadata: map[string]any{"compact": "force_on"}}
+	syncAuthFileCompactAttribute(on, &config.Config{})
+	if on.Attributes["compact_mode"] != "force_on" || on.Attributes["compact_allowed"] != "true" {
+		t.Fatalf("force_on attrs = %#v", on.Attributes)
+	}
+
+	off := &coreauth.Auth{ID: "off", Metadata: map[string]any{"compact": "force_off"}}
+	syncAuthFileCompactAttribute(off, &config.Config{})
+	if off.Attributes["compact_mode"] != "force_off" || off.Attributes["compact_allowed"] != "false" {
+		t.Fatalf("force_off attrs = %#v", off.Attributes)
+	}
+
+	autoDenied := &coreauth.Auth{ID: "auto", Metadata: map[string]any{"compact": "auto"}}
+	syncAuthFileCompactAttribute(autoDenied, &config.Config{CompactDefault: "deny"})
+	if autoDenied.Attributes["compact_mode"] != "auto" || autoDenied.Attributes["compact_allowed"] != "false" {
+		t.Fatalf("auto attrs = %#v", autoDenied.Attributes)
+	}
+
+	cleared := &coreauth.Auth{ID: "c", Attributes: map[string]string{"compact_mode": "force_on", "compact_allowed": "true"}}
+	syncAuthFileCompactAttribute(cleared, &config.Config{}) // no Metadata["compact"] -> remove mode
+	if _, ok := cleared.Attributes["compact_mode"]; ok {
+		t.Fatalf("compact_mode should be removed, got %#v", cleared.Attributes)
+	}
+	if _, ok := cleared.Attributes["compact_allowed"]; ok {
+		t.Fatalf("compact_allowed should be removed, got %#v", cleared.Attributes)
+	}
+}
+
+func TestBuildAuthFileEntry_ExposesCompact(t *testing.T) {
+	h := &Handler{}
+	auth := &coreauth.Auth{ID: "x", Provider: "codex", Attributes: map[string]string{"runtime_only": "true", "compact_mode": "force_off"}}
+	entry := h.buildAuthFileEntry(auth)
+	if entry["compact"] != "force_off" {
+		t.Fatalf("entry[compact] = %v, want force_off", entry["compact"])
+	}
+}
+
+func TestPatchAuthFileFields_CompactAutoResolvesAgainstDefaultAndPersists(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	fileName := "codex.json"
+	filePath := filepath.Join(authDir, fileName)
+	store := fileauth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       fileName,
+		FileName: fileName,
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": filePath,
+		},
+		Metadata: map[string]any{
+			"type": "codex",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir, CompactDefault: "deny"}, manager)
+
+	body := `{"name":"codex.json","compact":"AUTO"}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID(fileName)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth record to exist after patch")
+	}
+	if got := updated.Attributes["compact_mode"]; got != "auto" {
+		t.Fatalf("compact_mode = %q, want auto", got)
+	}
+	if got := updated.Attributes["compact_allowed"]; got != "false" {
+		t.Fatalf("compact_allowed = %q, want false", got)
+	}
+	if got, ok := updated.Metadata["compact"].(string); !ok || got != "auto" {
+		t.Fatalf("metadata.compact = %#v, want auto", updated.Metadata["compact"])
+	}
+
+	raw, errRead := os.ReadFile(filePath)
+	if errRead != nil {
+		t.Fatalf("failed to read updated auth file: %v", errRead)
+	}
+	var data map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &data); errUnmarshal != nil {
+		t.Fatalf("failed to unmarshal updated auth file: %v", errUnmarshal)
+	}
+	if got := data["compact"]; got != "auto" {
+		t.Fatalf("persisted compact = %#v, want auto", got)
+	}
+}
+
+func TestPatchAuthFileFields_InvalidCompactRejected(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "codex.json",
+		FileName: "codex.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "/tmp/codex.json",
+		},
+		Metadata: map[string]any{
+			"type": "codex",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	body := `{"name":"codex.json","compact":"garbage"}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("codex.json")
+	if !ok || updated == nil {
+		t.Fatalf("expected auth record to exist after patch")
+	}
+	if _, exists := updated.Metadata["compact"]; exists {
+		t.Fatalf("expected invalid compact not to persist, metadata = %#v", updated.Metadata)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,6 +111,10 @@ type Config struct {
 	// Codex defines a list of Codex API key configurations as specified in the YAML configuration file.
 	CodexKey []CodexKey `yaml:"codex-api-key" json:"codex-api-key"`
 
+	// CompactDefault controls how credentials with compact mode "auto" are treated for
+	// /responses/compact routing: "allow" (default, backward compatible) or "deny".
+	CompactDefault string `yaml:"compact-default,omitempty" json:"compact-default,omitempty"`
+
 	// Codex configures provider-wide Codex request behavior.
 	Codex CodexConfig `yaml:"codex" json:"codex"`
 
@@ -465,6 +469,10 @@ type CodexKey struct {
 	// Websockets enables the Responses API websocket transport for this credential.
 	Websockets bool `yaml:"websockets,omitempty" json:"websockets,omitempty"`
 
+	// Compact controls /responses/compact eligibility for this credential:
+	// "auto" (default, follows compact-default), "force_on", or "force_off".
+	Compact string `yaml:"compact,omitempty" json:"compact,omitempty"`
+
 	// ProxyURL overrides the global proxy setting for this API key if provided.
 	ProxyURL string `yaml:"proxy-url" json:"proxy-url"`
 
@@ -558,6 +566,10 @@ type OpenAICompatibility struct {
 
 	// Prefix optionally namespaces model aliases for this provider (e.g., "teamA/kimi-k2").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+
+	// Compact controls /responses/compact eligibility for all credentials of this provider:
+	// "auto" (default, follows compact-default), "force_on", or "force_off".
+	Compact string `yaml:"compact,omitempty" json:"compact,omitempty"`
 
 	// BaseURL is the base URL for the external OpenAI-compatible API endpoint.
 	BaseURL string `yaml:"base-url" json:"base-url"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -733,6 +733,8 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		cfg.MaxRetryCredentials = 0
 	}
 
+	cfg.CompactDefault = normalizeConfigCompactDefault(cfg.CompactDefault)
+
 	// Sanitize Gemini API key configuration and migrate legacy entries.
 	cfg.SanitizeGeminiKeys()
 
@@ -912,6 +914,7 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 		e.Name = strings.TrimSpace(e.Name)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.Compact = normalizeConfigCompactMode(e.Compact, fmt.Sprintf("openai-compatibility[%d].compact", i))
 		e.Headers = NormalizeHeaders(e.Headers)
 		if e.BaseURL == "" {
 			// Skip providers with no base-url; treated as removed
@@ -933,6 +936,7 @@ func (cfg *Config) SanitizeCodexKeys() {
 		e := cfg.CodexKey[i]
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.Compact = normalizeConfigCompactMode(e.Compact, fmt.Sprintf("codex-api-key[%d].compact", i))
 		e.Headers = NormalizeHeaders(e.Headers)
 		e.ExcludedModels = NormalizeExcludedModels(e.ExcludedModels)
 		if e.BaseURL == "" {
@@ -996,6 +1000,37 @@ func normalizeModelPrefix(prefix string) string {
 		return ""
 	}
 	return trimmed
+}
+
+func normalizeConfigCompactDefault(raw string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(raw))
+	switch trimmed {
+	case "", "allow":
+		return "allow"
+	case "deny":
+		return "deny"
+	default:
+		log.WithField("value", raw).Warn("invalid compact-default; falling back to allow")
+		return "allow"
+	}
+}
+
+func normalizeConfigCompactMode(raw string, location string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(raw))
+	switch trimmed {
+	case "", "auto":
+		return "auto"
+	case "force_on":
+		return "force_on"
+	case "force_off":
+		return "force_off"
+	default:
+		log.WithFields(log.Fields{
+			"field": location,
+			"value": raw,
+		}).Warn("invalid compact mode; falling back to auto")
+		return "auto"
+	}
 }
 
 // looksLikeBcrypt returns true if the provided string appears to be a bcrypt hash.

--- a/internal/config/config_compact_test.go
+++ b/internal/config/config_compact_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCompactFieldsUnmarshal(t *testing.T) {
+	raw := []byte(`
+compact-default: deny
+codex-api-key:
+  - api-key: "sk-A"
+    compact: force_on
+openai-compatibility:
+  - name: "kimi"
+    base-url: "https://example.com"
+    compact: force_off
+`)
+	var cfg Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.CompactDefault != "deny" {
+		t.Fatalf("CompactDefault = %q, want deny", cfg.CompactDefault)
+	}
+	if len(cfg.CodexKey) != 1 || cfg.CodexKey[0].Compact != "force_on" {
+		t.Fatalf("CodexKey compact = %+v", cfg.CodexKey)
+	}
+	if len(cfg.OpenAICompatibility) != 1 || cfg.OpenAICompatibility[0].Compact != "force_off" {
+		t.Fatalf("OpenAICompatibility compact = %+v", cfg.OpenAICompatibility)
+	}
+}

--- a/internal/config/config_compact_test.go
+++ b/internal/config/config_compact_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -29,5 +31,71 @@ openai-compatibility:
 	}
 	if len(cfg.OpenAICompatibility) != 1 || cfg.OpenAICompatibility[0].Compact != "force_off" {
 		t.Fatalf("OpenAICompatibility compact = %+v", cfg.OpenAICompatibility)
+	}
+}
+
+func TestLoadConfigOptional_NormalizesCompactSettings(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	configYAML := []byte(`
+compact-default: "  DeNy "
+codex-api-key:
+  - api-key: "sk-A"
+    base-url: "https://example.com"
+    compact: " FORCE_OFF "
+openai-compatibility:
+  - name: "kimi"
+    base-url: "https://example.com"
+    compact: " Force_On "
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+	if got := cfg.CompactDefault; got != "deny" {
+		t.Fatalf("CompactDefault = %q, want deny", got)
+	}
+	if got := cfg.CodexKey[0].Compact; got != "force_off" {
+		t.Fatalf("CodexKey[0].Compact = %q, want force_off", got)
+	}
+	if got := cfg.OpenAICompatibility[0].Compact; got != "force_on" {
+		t.Fatalf("OpenAICompatibility[0].Compact = %q, want force_on", got)
+	}
+}
+
+func TestLoadConfigOptional_InvalidCompactSettingsFallback(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	configYAML := []byte(`
+compact-default: "invalid"
+codex-api-key:
+  - api-key: "sk-A"
+    base-url: "https://example.com"
+    compact: "wrong"
+openai-compatibility:
+  - name: "kimi"
+    base-url: "https://example.com"
+    compact: "wrong"
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+	if got := cfg.CompactDefault; got != "allow" {
+		t.Fatalf("CompactDefault = %q, want allow", got)
+	}
+	if got := cfg.CodexKey[0].Compact; got != "auto" {
+		t.Fatalf("CodexKey[0].Compact = %q, want auto", got)
+	}
+	if got := cfg.OpenAICompatibility[0].Compact; got != "auto" {
+		t.Fatalf("OpenAICompatibility[0].Compact = %q, want auto", got)
 	}
 }

--- a/internal/watcher/synthesizer/compact_meta_test.go
+++ b/internal/watcher/synthesizer/compact_meta_test.go
@@ -1,0 +1,52 @@
+package synthesizer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestSynthesizeCodexKeys_CompactResolution(t *testing.T) {
+	cfg := &config.Config{
+		CompactDefault: "deny",
+		CodexKey: []config.CodexKey{
+			{APIKey: "sk-on", Compact: "force_on"},
+			{APIKey: "sk-off", Compact: "force_off"},
+			{APIKey: "sk-auto"}, // auto -> follows deny
+		},
+	}
+	synth := NewConfigSynthesizer()
+	auths := synth.synthesizeCodexKeys(&SynthesisContext{
+		Config: cfg, Now: time.Now(), IDGenerator: NewStableIDGenerator(),
+	})
+	got := map[string]string{}
+	for _, a := range auths {
+		got[a.Attributes["api_key"]] = a.Attributes["compact_allowed"]
+	}
+	if got["sk-on"] != "true" || got["sk-off"] != "false" || got["sk-auto"] != "false" {
+		t.Fatalf("compact_allowed = %#v", got)
+	}
+}
+
+func TestSynthesizeOpenAICompat_CompactResolution(t *testing.T) {
+	cfg := &config.Config{
+		CompactDefault: "allow",
+		OpenAICompatibility: []config.OpenAICompatibility{
+			{
+				Name: "kimi", BaseURL: "https://example.com", Compact: "force_off",
+				APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "k1"}},
+			},
+		},
+	}
+	synth := NewConfigSynthesizer()
+	auths := synth.synthesizeOpenAICompat(&SynthesisContext{
+		Config: cfg, Now: time.Now(), IDGenerator: NewStableIDGenerator(),
+	})
+	if len(auths) != 1 {
+		t.Fatalf("want 1 auth, got %d", len(auths))
+	}
+	if auths[0].Attributes["compact_allowed"] != "false" {
+		t.Fatalf("compact_allowed = %q, want false", auths[0].Attributes["compact_allowed"])
+	}
+}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -201,6 +201,7 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, ck.ExcludedModels, "apikey")
+		ApplyAuthCompactMeta(a, cfg, ck.Compact)
 		if len(a.Metadata) == 0 {
 			a.Metadata = nil
 		}
@@ -269,6 +270,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}
+			ApplyAuthCompactMeta(a, cfg, compat.Compact)
 			if len(a.Metadata) == 0 {
 				a.Metadata = nil
 			}
@@ -307,6 +309,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}
+			ApplyAuthCompactMeta(a, cfg, compat.Compact)
 			if len(a.Metadata) == 0 {
 				a.Metadata = nil
 			}

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -169,6 +169,10 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			}
 		}
 	}
+	if provider == "codex" {
+		rawCompact, _ := metadata["compact"].(string)
+		ApplyAuthCompactMeta(a, cfg, rawCompact)
+	}
 	if provider == "gemini-cli" {
 		if virtuals := SynthesizeGeminiVirtualAuths(a, metadata, now); len(virtuals) > 0 {
 			for _, v := range virtuals {

--- a/internal/watcher/synthesizer/helpers.go
+++ b/internal/watcher/synthesizer/helpers.go
@@ -103,6 +103,17 @@ func ApplyAuthExcludedModelsMeta(auth *coreauth.Auth, cfg *config.Config, perKey
 	}
 }
 
+// ApplyAuthCompactMeta resolves the per-credential compact mode against the global
+// compact-default and records compact_mode + compact_allowed on the auth. Call only for
+// compact-capable providers (codex, openai-compatibility).
+func ApplyAuthCompactMeta(auth *coreauth.Auth, cfg *config.Config, mode string) {
+	if auth == nil || cfg == nil {
+		return
+	}
+	defaultAllow := !strings.EqualFold(strings.TrimSpace(cfg.CompactDefault), "deny")
+	coreauth.ApplyCompactAttributes(auth, mode, defaultAllow)
+}
+
 // addConfigHeadersToAttrs adds header configuration to auth attributes.
 // Headers are prefixed with "header:" in the attributes map.
 func addConfigHeadersToAttrs(headers map[string]string, attrs map[string]string) {

--- a/sdk/cliproxy/auth/compact.go
+++ b/sdk/cliproxy/auth/compact.go
@@ -1,0 +1,90 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// Compact mode values stored in Attributes["compact_mode"].
+const (
+	// CompactModeAuto follows the global compact-default when deciding eligibility.
+	CompactModeAuto = "auto"
+	// CompactModeForceOn always treats the credential as compact-capable.
+	CompactModeForceOn = "force_on"
+	// CompactModeForceOff always excludes the credential from compact routing.
+	CompactModeForceOff = "force_off"
+)
+
+// NormalizeCompactMode maps arbitrary input to a known compact mode, defaulting to auto.
+func NormalizeCompactMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case CompactModeForceOn:
+		return CompactModeForceOn
+	case CompactModeForceOff:
+		return CompactModeForceOff
+	default:
+		return CompactModeAuto
+	}
+}
+
+// ApplyCompactAttributes resolves the credential compact mode against the global default
+// (defaultAllow: true for compact-default=allow, false for deny) and stores both the raw
+// mode (compact_mode) and the resolved boolean (compact_allowed) on the auth.
+func ApplyCompactAttributes(auth *Auth, mode string, defaultAllow bool) {
+	if auth == nil {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	norm := NormalizeCompactMode(mode)
+	auth.Attributes["compact_mode"] = norm
+	allowed := defaultAllow
+	switch norm {
+	case CompactModeForceOn:
+		allowed = true
+	case CompactModeForceOff:
+		allowed = false
+	}
+	if allowed {
+		auth.Attributes["compact_allowed"] = "true"
+	} else {
+		auth.Attributes["compact_allowed"] = "false"
+	}
+}
+
+// authCompactAllowed reports whether the credential may serve a /responses/compact request.
+// A missing attribute means allowed, keeping non-compact and pre-existing auths backward compatible.
+func authCompactAllowed(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if auth.Attributes == nil {
+		return true
+	}
+	return auth.Attributes["compact_allowed"] != "false"
+}
+
+// requireCompactRequest reports whether the request targets the /responses/compact endpoint.
+func requireCompactRequest(opts cliproxyexecutor.Options) bool {
+	return opts.Alt == cliproxyexecutor.ResponsesCompactAlt
+}
+
+// compactCandidateAllowed gates one candidate for a (possibly compact) request.
+func compactCandidateAllowed(auth *Auth, requireCompact bool) bool {
+	if !requireCompact {
+		return true
+	}
+	return authCompactAllowed(auth)
+}
+
+// noCompactAuthError is returned when credentials exist but none allow compact.
+func noCompactAuthError() *Error {
+	return &Error{
+		Code:       "compact_unsupported",
+		Message:    "no available credential supports /responses/compact",
+		HTTPStatus: http.StatusServiceUnavailable,
+	}
+}

--- a/sdk/cliproxy/auth/compact_test.go
+++ b/sdk/cliproxy/auth/compact_test.go
@@ -1,0 +1,79 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestApplyCompactAttributes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		mode         string
+		defaultAllow bool
+		wantMode     string
+		wantAllowed  string
+	}{
+		{"force_on under deny", "force_on", false, "force_on", "true"},
+		{"force_off under allow", "force_off", true, "force_off", "false"},
+		{"auto follows allow", "auto", true, "auto", "true"},
+		{"auto follows deny", "auto", false, "auto", "false"},
+		{"empty treated as auto under deny", "", false, "auto", "false"},
+		{"unknown treated as auto under allow", "garbage", true, "auto", "true"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Auth{ID: "x"}
+			ApplyCompactAttributes(a, tc.mode, tc.defaultAllow)
+			if got := a.Attributes["compact_mode"]; got != tc.wantMode {
+				t.Fatalf("compact_mode = %q, want %q", got, tc.wantMode)
+			}
+			if got := a.Attributes["compact_allowed"]; got != tc.wantAllowed {
+				t.Fatalf("compact_allowed = %q, want %q", got, tc.wantAllowed)
+			}
+		})
+	}
+}
+
+func TestAuthCompactAllowed(t *testing.T) {
+	t.Parallel()
+	if !authCompactAllowed(&Auth{ID: "no-attrs"}) {
+		t.Fatal("missing attributes should be allowed")
+	}
+	if !authCompactAllowed(&Auth{ID: "true", Attributes: map[string]string{"compact_allowed": "true"}}) {
+		t.Fatal(`"true" should be allowed`)
+	}
+	if authCompactAllowed(&Auth{ID: "false", Attributes: map[string]string{"compact_allowed": "false"}}) {
+		t.Fatal(`"false" should be denied`)
+	}
+}
+
+func TestRequireCompactRequestAndCandidate(t *testing.T) {
+	t.Parallel()
+	if !requireCompactRequest(cliproxyexecutor.Options{Alt: cliproxyexecutor.ResponsesCompactAlt}) {
+		t.Fatal("compact alt should require compact")
+	}
+	if requireCompactRequest(cliproxyexecutor.Options{Alt: ""}) {
+		t.Fatal("empty alt should not require compact")
+	}
+	off := &Auth{ID: "off", Attributes: map[string]string{"compact_allowed": "false"}}
+	if !compactCandidateAllowed(off, false) {
+		t.Fatal("non-compact request must ignore the flag")
+	}
+	if compactCandidateAllowed(off, true) {
+		t.Fatal("compact request must drop force_off candidate")
+	}
+}
+
+func TestNoCompactAuthError(t *testing.T) {
+	t.Parallel()
+	err := noCompactAuthError()
+	if err.Code != "compact_unsupported" {
+		t.Fatalf("code = %q", err.Code)
+	}
+	if err.StatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", err.StatusCode())
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3030,6 +3030,8 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		return nil, nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
 	candidates := make([]*Auth, 0, len(m.auths))
+	requireCompact := requireCompactRequest(opts)
+	compactBlocked := false
 	modelKey := strings.TrimSpace(model)
 	// Always use base model name (without thinking suffix) for auth matching.
 	if modelKey != "" {
@@ -3055,10 +3057,17 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		if modelKey != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
 			continue
 		}
+		if !compactCandidateAllowed(candidate, requireCompact) {
+			compactBlocked = true
+			continue
+		}
 		candidates = append(candidates, candidate)
 	}
 	if len(candidates) == 0 {
 		m.mu.RUnlock()
+		if requireCompact && compactBlocked {
+			return nil, nil, noCompactAuthError()
+		}
 		return nil, nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
 	available, errAvailable := m.availableAuthsForRouteModel(candidates, provider, model, time.Now())
@@ -3092,6 +3101,10 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 	if m.HomeEnabled() {
 		auth, exec, _, err := m.pickNextViaHome(ctx, model, opts, tried)
 		return auth, exec, err
+	}
+
+	if requireCompactRequest(opts) {
+		return m.pickNextLegacy(ctx, provider, model, opts, tried)
 	}
 
 	if !m.useSchedulerFastPath() {
@@ -3172,6 +3185,8 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 
 	m.mu.RLock()
 	candidates := make([]*Auth, 0, len(m.auths))
+	requireCompact := requireCompactRequest(opts)
+	compactBlocked := false
 	modelKey := strings.TrimSpace(model)
 	// Always use base model name (without thinking suffix) for auth matching.
 	if modelKey != "" {
@@ -3207,10 +3222,17 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		if modelKey != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
 			continue
 		}
+		if !compactCandidateAllowed(candidate, requireCompact) {
+			compactBlocked = true
+			continue
+		}
 		candidates = append(candidates, candidate)
 	}
 	if len(candidates) == 0 {
 		m.mu.RUnlock()
+		if requireCompact && compactBlocked {
+			return nil, nil, "", noCompactAuthError()
+		}
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
 	available, errAvailable := m.availableAuthsForRouteModel(candidates, "mixed", model, time.Now())
@@ -3249,6 +3271,10 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, string, error) {
 	if m.HomeEnabled() {
 		return m.pickNextViaHome(ctx, model, opts, tried)
+	}
+
+	if requireCompactRequest(opts) {
+		return m.pickNextMixedLegacy(ctx, providers, model, opts, tried)
 	}
 
 	if !m.useSchedulerFastPath() {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3590,12 +3590,21 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 	}
 	executionSessionID := homeExecutionSessionIDFromMetadata(opts.Metadata)
 	count := homeAuthCountFromMetadata(opts.Metadata)
+	requireCompact := requireCompactRequest(opts)
+	compactBlocked := false
+	blockedCompactAuths := make(map[string]struct{})
 	if cliproxyexecutor.DownstreamWebsocket(ctx) && executionSessionID != "" && count <= 1 {
 		if pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata); pinnedAuthID != "" {
 			_, alreadyTried := tried[pinnedAuthID]
 			if !alreadyTried {
 				if auth, executor, providerKey, ok := m.homeRuntimeAuthByID(executionSessionID, pinnedAuthID); ok {
-					return auth, executor, providerKey, nil
+					if compactCandidateAllowed(auth, requireCompact) {
+						return auth, executor, providerKey, nil
+					}
+					compactBlocked = true
+					if auth != nil && strings.TrimSpace(auth.ID) != "" {
+						blockedCompactAuths[auth.ID] = struct{}{}
+					}
 				}
 			}
 		}
@@ -3609,82 +3618,96 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 	requestedModel := requestedModelFromMetadata(opts.Metadata, model)
 	sessionID := ExtractSessionID(opts.Headers, opts.OriginalRequest, opts.Metadata)
 	dispatchHeaders := homeDispatchHeaders(ctx, opts.Headers)
-
-	raw, err := client.RPopAuth(ctx, requestedModel, sessionID, dispatchHeaders, count)
-	if err != nil {
-		return nil, nil, "", &Error{Code: "auth_not_found", Message: err.Error(), HTTPStatus: http.StatusServiceUnavailable}
-	}
-
-	var env homeErrorEnvelope
-	if errUnmarshal := json.Unmarshal(raw, &env); errUnmarshal == nil && env.Error != nil {
-		code := strings.TrimSpace(env.Error.Type)
-		if code == "" {
-			code = strings.TrimSpace(env.Error.Code)
+	requestCount := count
+	for {
+		raw, err := client.RPopAuth(ctx, requestedModel, sessionID, dispatchHeaders, requestCount)
+		if err != nil {
+			if requireCompact && compactBlocked && errors.Is(err, home.ErrAuthNotFound) {
+				return nil, nil, "", noCompactAuthError()
+			}
+			return nil, nil, "", &Error{Code: "auth_not_found", Message: err.Error(), HTTPStatus: http.StatusServiceUnavailable}
 		}
-		msg := strings.TrimSpace(env.Error.Message)
-		if msg == "" {
-			msg = "home returned error"
-		}
-		status := http.StatusBadGateway
-		switch strings.ToLower(code) {
-		case "model_not_found":
-			status = http.StatusNotFound
-		case "authentication_error", "unauthorized":
-			status = http.StatusUnauthorized
-		}
-		return nil, nil, "", &Error{Code: code, Message: msg, HTTPStatus: status}
-	}
 
-	var dispatch homeAuthDispatchResponse
-	if errUnmarshal := json.Unmarshal(raw, &dispatch); errUnmarshal != nil {
-		return nil, nil, "", &Error{Code: "invalid_auth", Message: "home returned invalid auth payload", HTTPStatus: http.StatusBadGateway}
-	}
-	setHomeUserAPIKeyOnGinContext(ctx, dispatch.UserAPIKey)
-	auth := dispatch.Auth
-	if strings.TrimSpace(auth.ID) == "" {
-		// Backward compatibility: older home instances returned the auth directly.
-		if errUnmarshal := json.Unmarshal(raw, &auth); errUnmarshal != nil {
+		var env homeErrorEnvelope
+		if errUnmarshal := json.Unmarshal(raw, &env); errUnmarshal == nil && env.Error != nil {
+			code := strings.TrimSpace(env.Error.Type)
+			if code == "" {
+				code = strings.TrimSpace(env.Error.Code)
+			}
+			msg := strings.TrimSpace(env.Error.Message)
+			if msg == "" {
+				msg = "home returned error"
+			}
+			status := http.StatusBadGateway
+			switch strings.ToLower(code) {
+			case "model_not_found":
+				status = http.StatusNotFound
+			case "authentication_error", "unauthorized":
+				status = http.StatusUnauthorized
+			}
+			return nil, nil, "", &Error{Code: code, Message: msg, HTTPStatus: status}
+		}
+
+		var dispatch homeAuthDispatchResponse
+		if errUnmarshal := json.Unmarshal(raw, &dispatch); errUnmarshal != nil {
 			return nil, nil, "", &Error{Code: "invalid_auth", Message: "home returned invalid auth payload", HTTPStatus: http.StatusBadGateway}
 		}
-	}
-	if upstreamModel := strings.TrimSpace(dispatch.Model); upstreamModel != "" {
-		if auth.Attributes == nil {
-			auth.Attributes = make(map[string]string, 1)
+		setHomeUserAPIKeyOnGinContext(ctx, dispatch.UserAPIKey)
+		auth := dispatch.Auth
+		if strings.TrimSpace(auth.ID) == "" {
+			// Backward compatibility: older home instances returned the auth directly.
+			if errUnmarshal := json.Unmarshal(raw, &auth); errUnmarshal != nil {
+				return nil, nil, "", &Error{Code: "invalid_auth", Message: "home returned invalid auth payload", HTTPStatus: http.StatusBadGateway}
+			}
 		}
-		auth.Attributes[homeUpstreamModelAttributeKey] = upstreamModel
-	}
-	if strings.TrimSpace(auth.ID) == "" {
-		return nil, nil, "", &Error{Code: "invalid_auth", Message: "home returned auth without id", HTTPStatus: http.StatusBadGateway}
-	}
-	providerKey := strings.ToLower(strings.TrimSpace(auth.Provider))
-	if providerKey == "" {
-		return nil, nil, "", &Error{Code: "invalid_auth", Message: "home returned auth without provider", HTTPStatus: http.StatusBadGateway}
-	}
-
-	homeAuthIndex := strings.TrimSpace(dispatch.AuthIndex)
-	if homeAuthIndex != "" {
-		auth.Index = homeAuthIndex
-		auth.indexAssigned = true
-	} else {
-		auth.EnsureIndex()
-	}
-
-	executor, ok := m.Executor(providerKey)
-	if !ok && auth.Attributes != nil && strings.TrimSpace(auth.Attributes["base_url"]) != "" {
-		executor, ok = m.Executor("openai-compatibility")
-		if ok {
-			providerKey = "openai-compatibility"
+		if upstreamModel := strings.TrimSpace(dispatch.Model); upstreamModel != "" {
+			if auth.Attributes == nil {
+				auth.Attributes = make(map[string]string, 1)
+			}
+			auth.Attributes[homeUpstreamModelAttributeKey] = upstreamModel
 		}
-	}
-	if !ok {
-		return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered", HTTPStatus: http.StatusBadGateway}
-	}
+		if strings.TrimSpace(auth.ID) == "" {
+			return nil, nil, "", &Error{Code: "invalid_auth", Message: "home returned auth without id", HTTPStatus: http.StatusBadGateway}
+		}
+		if !compactCandidateAllowed(&auth, requireCompact) {
+			compactBlocked = true
+			if _, seen := blockedCompactAuths[auth.ID]; seen {
+				return nil, nil, "", noCompactAuthError()
+			}
+			blockedCompactAuths[auth.ID] = struct{}{}
+			requestCount++
+			continue
+		}
+		providerKey := strings.ToLower(strings.TrimSpace(auth.Provider))
+		if providerKey == "" {
+			return nil, nil, "", &Error{Code: "invalid_auth", Message: "home returned auth without provider", HTTPStatus: http.StatusBadGateway}
+		}
 
-	authCopy := auth.Clone()
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && executionSessionID != "" && authWebsocketsEnabled(authCopy) {
-		m.rememberHomeRuntimeAuth(executionSessionID, authCopy)
+		homeAuthIndex := strings.TrimSpace(dispatch.AuthIndex)
+		if homeAuthIndex != "" {
+			auth.Index = homeAuthIndex
+			auth.indexAssigned = true
+		} else {
+			auth.EnsureIndex()
+		}
+
+		executor, ok := m.Executor(providerKey)
+		if !ok && auth.Attributes != nil && strings.TrimSpace(auth.Attributes["base_url"]) != "" {
+			executor, ok = m.Executor("openai-compatibility")
+			if ok {
+				providerKey = "openai-compatibility"
+			}
+		}
+		if !ok {
+			return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered", HTTPStatus: http.StatusBadGateway}
+		}
+
+		authCopy := auth.Clone()
+		if cliproxyexecutor.DownstreamWebsocket(ctx) && executionSessionID != "" && authWebsocketsEnabled(authCopy) {
+			m.rememberHomeRuntimeAuth(executionSessionID, authCopy)
+		}
+		return authCopy, executor, providerKey, nil
 	}
-	return authCopy, executor, providerKey, nil
 }
 
 func requestedModelFromMetadata(metadata map[string]any, fallback string) string {

--- a/sdk/cliproxy/auth/conductor_compact_test.go
+++ b/sdk/cliproxy/auth/conductor_compact_test.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type compactProbeExecutor struct{}
+
+func (compactProbeExecutor) Identifier() string { return "codex" }
+func (compactProbeExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (compactProbeExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+func (compactProbeExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) { return auth, nil }
+func (compactProbeExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (compactProbeExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func newCompactTestManager(t *testing.T) *Manager {
+	t.Helper()
+	m := NewManager(nil, &RoundRobinSelector{}, nil)
+	m.RegisterExecutor(compactProbeExecutor{})
+	return m
+}
+
+func TestPickNextMixed_CompactSkipsForceOff(t *testing.T) {
+	m := newCompactTestManager(t)
+	ctx := context.Background()
+	if _, err := m.Register(ctx, &Auth{ID: "on", Provider: "codex", Attributes: map[string]string{"compact_allowed": "true"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Register(ctx, &Auth{ID: "off", Provider: "codex", Attributes: map[string]string{"compact_allowed": "false"}}); err != nil {
+		t.Fatal(err)
+	}
+	opts := cliproxyexecutor.Options{Alt: cliproxyexecutor.ResponsesCompactAlt}
+	for i := 0; i < 5; i++ {
+		auth, _, _, err := m.pickNextMixed(ctx, []string{"codex"}, "", opts, map[string]struct{}{})
+		if err != nil {
+			t.Fatalf("pick #%d error: %v", i, err)
+		}
+		if auth.ID != "on" {
+			t.Fatalf("pick #%d = %q, want on", i, auth.ID)
+		}
+	}
+}
+
+func TestPickNextMixed_CompactNoneEligibleReturns503(t *testing.T) {
+	m := newCompactTestManager(t)
+	ctx := context.Background()
+	if _, err := m.Register(ctx, &Auth{ID: "off", Provider: "codex", Attributes: map[string]string{"compact_allowed": "false"}}); err != nil {
+		t.Fatal(err)
+	}
+	opts := cliproxyexecutor.Options{Alt: cliproxyexecutor.ResponsesCompactAlt}
+	_, _, _, err := m.pickNextMixed(ctx, []string{"codex"}, "", opts, map[string]struct{}{})
+	var ae *Error
+	if !errors.As(err, &ae) || ae.Code != "compact_unsupported" || ae.StatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("err = %v, want compact_unsupported/503", err)
+	}
+}
+
+func TestPickNextMixed_NonCompactIgnoresFlag(t *testing.T) {
+	m := newCompactTestManager(t)
+	ctx := context.Background()
+	if _, err := m.Register(ctx, &Auth{ID: "off", Provider: "codex", Attributes: map[string]string{"compact_allowed": "false"}}); err != nil {
+		t.Fatal(err)
+	}
+	auth, _, _, err := m.pickNextMixed(ctx, []string{"codex"}, "", cliproxyexecutor.Options{}, map[string]struct{}{})
+	if err != nil || auth == nil || auth.ID != "off" {
+		t.Fatalf("non-compact pick: auth=%v err=%v", auth, err)
+	}
+}

--- a/sdk/cliproxy/auth/home_websocket_reuse_test.go
+++ b/sdk/cliproxy/auth/home_websocket_reuse_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
@@ -53,6 +54,46 @@ func TestPickNextViaHomeReusesPinnedWebsocketAuthWithoutHomeDispatch(t *testing.
 	}
 	if provider != "test" {
 		t.Fatalf("pickNextViaHome() provider = %q, want test", provider)
+	}
+}
+
+func TestPickNextViaHomeDoesNotReusePinnedCompactBlockedWebsocketAuth(t *testing.T) {
+	home.ClearCurrent()
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.RegisterExecutor(schedulerTestExecutor{})
+
+	auth := &Auth{
+		ID:       "home-auth-1",
+		Provider: "codex",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"websockets":      "true",
+			"compact_allowed": "false",
+		},
+	}
+	auth.EnsureIndex()
+	manager.rememberHomeRuntimeAuth("session-1", auth)
+
+	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+	opts := cliproxyexecutor.Options{
+		Alt: cliproxyexecutor.ResponsesCompactAlt,
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: "session-1",
+			cliproxyexecutor.PinnedAuthMetadataKey:       "home-auth-1",
+		},
+	}
+
+	got, executor, provider, errPick := manager.pickNextViaHome(ctx, "gpt-5.4", opts, nil)
+	if errPick == nil {
+		t.Fatal("pickNextViaHome() error is nil, want home_unavailable")
+	}
+	var authErr *Error
+	if !errors.As(errPick, &authErr) || authErr.Code != "home_unavailable" {
+		t.Fatalf("pickNextViaHome() error = %v, want home_unavailable", errPick)
+	}
+	if got != nil || executor != nil || provider != "" {
+		t.Fatalf("pickNextViaHome() reused compact-blocked auth: auth=%#v executor=%#v provider=%q", got, executor, provider)
 	}
 }
 

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -46,6 +46,9 @@ type Request struct {
 	Metadata map[string]any
 }
 
+// ResponsesCompactAlt is the Options.Alt value identifying a POST /v1/responses/compact request.
+const ResponsesCompactAlt = "responses/compact"
+
 // Options controls execution behavior for both streaming and non-streaming calls.
 type Options struct {
 	// Stream toggles streaming mode.


### PR DESCRIPTION
  ## Summary

  - add `compact-default` and per-credential `compact` controls for codex and openai-compatible credentials
  - resolve compact eligibility into auth attributes during synthesis
  - route `/v1/responses/compact` through legacy credential selection and filter out credentials that do not
  support compact
  - return `compact_unsupported` with HTTP 503 when compact requests have credentials but none are eligible
  - expose and validate `compact` in codex auth-file management flows
  - document the new config in `config.example.yaml`

  ## Why

  Codex compact requests use the `/v1/responses/compact` endpoint. Many API providers do not implement that
  endpoint, so sending compact requests to them fails even though the same credential can still handle normal `/v1/
  responses` requests.

  This change lets operators explicitly control which credentials can receive compact requests. When the currently
  selected provider does not support compact, the router can automatically fall back to another eligible credential
  instead of sending the request to an unsupported endpoint.

  ## Verification

  - `gofmt -w .`
  - `go build -o test-output ./cmd/server && rm test-output`
  - `go test ./...`