### PR TITLE
refactor: dedupe conductor retry loop and type rt ctx key

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1670,9 +1670,7 @@ func (e *AntigravityExecutor) ensureAccessToken(ctx context.Context, auth *clipr
 	}
 	refreshCtx := context.Background()
 	if ctx != nil {
-		if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
-			refreshCtx = context.WithValue(refreshCtx, "cliproxy.roundtripper", rt)
-		}
+		refreshCtx = cliproxyexecutor.WithRoundTripper(refreshCtx, cliproxyexecutor.RoundTripper(ctx))
 	}
 	if refreshed, handled, err := helps.RefreshAuthViaHome(refreshCtx, e.cfg, auth); handled {
 		if err != nil {
@@ -1736,9 +1734,7 @@ func (e *AntigravityExecutor) maybeRefreshAntigravityCreditsHint(ctx context.Con
 
 	refreshCtx := context.Background()
 	if ctx != nil {
-		if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
-			refreshCtx = context.WithValue(refreshCtx, "cliproxy.roundtripper", rt)
-		}
+		refreshCtx = cliproxyexecutor.WithRoundTripper(refreshCtx, cliproxyexecutor.RoundTripper(ctx))
 	}
 	refreshCtx, cancel := context.WithTimeout(refreshCtx, antigravityCreditsHintRefreshTimeout)
 	authCopy := auth.Clone()

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
 func TestAntigravityBuildRequest_SanitizesGeminiToolSchema(t *testing.T) {
@@ -116,7 +117,7 @@ func TestAntigravityPrepareRequestAuth_FetchesMissingProjectID(t *testing.T) {
 		"access_token": "token",
 		"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
 	}}
-	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	ctx := cliproxyexecutor.WithRoundTripper(context.Background(), roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.String() != "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist" {
 			t.Fatalf("unexpected project discovery request: %s", req.URL.String())
 		}

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -399,7 +399,7 @@ func TestEnsureAccessToken_WarmTokenLoadsCreditsHint(t *testing.T) {
 			"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
 		},
 	}
-	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	ctx := cliproxyexecutor.WithRoundTripper(context.Background(), roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.String() != "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist" {
 			t.Fatalf("unexpected request url %s", req.URL.String())
 		}
@@ -450,7 +450,7 @@ func TestUpdateAntigravityCreditsBalance_LoadCodeAssistUserAgent(t *testing.T) {
 		ID:         "auth-load-code-assist-ua",
 		Attributes: map[string]string{"user_agent": configuredUserAgent},
 	}
-	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	ctx := cliproxyexecutor.WithRoundTripper(context.Background(), roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.String() != "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist" {
 			t.Fatalf("unexpected request url %s", req.URL.String())
 		}

--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
 )
@@ -54,7 +55,7 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	}
 
 	// Priority 3: Use RoundTripper from context (typically from RoundTripperFor)
-	if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
+	if rt := cliproxyexecutor.RoundTripper(ctx); rt != nil {
 		httpClient.Transport = rt
 	}
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1336,9 +1336,47 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	)
 }
 
-func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (cliproxyexecutor.Response, error) {
+// credentialAttempt carries the per-credential state handed to the execution
+// callback used by runMixedOnce after a credential has been selected and its
+// request auth prepared.
+type credentialAttempt struct {
+	auth       *Auth
+	executor   ProviderExecutor
+	provider   string
+	execCtx    context.Context
+	routeModel string
+	models     []string
+	pooled     bool
+	opts       cliproxyexecutor.Options
+}
+
+// runMixedOnce drives a single mixed-provider execution pass shared by
+// executeMixedOnce, executeCountMixedOnce, and executeStreamMixedOnce. It owns
+// the identical credential-iteration scaffold (retry-credential cap, candidate
+// selection, per-auth round-tripper, model preparation, request-auth
+// preparation, and home-mode bookkeeping) and delegates the actual provider call
+// to exec.
+//
+// exec returns (result, err, done): done=true terminates the pass immediately
+// with (result, err); done=false with a non-nil err records the error as the
+// running lastErr and advances to the next credential.
+//
+// withModelAlias mirrors the original behavior where the non-streaming paths
+// attach the requested-model alias to the execution context while the streaming
+// path does not.
+func runMixedOnce[T any](
+	m *Manager,
+	ctx context.Context,
+	providers []string,
+	req cliproxyexecutor.Request,
+	opts cliproxyexecutor.Options,
+	maxRetryCredentials int,
+	zero T,
+	withModelAlias bool,
+	exec func(attempt credentialAttempt) (T, error, bool),
+) (T, error) {
 	if len(providers) == 0 {
-		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
+		return zero, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
 	routeModel := req.Model
 	opts = ensureRequestedModelMetadata(opts, routeModel)
@@ -1350,9 +1388,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 	for {
 		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
 			if lastErr != nil {
-				return cliproxyexecutor.Response{}, lastErr
+				return zero, lastErr
 			}
-			return cliproxyexecutor.Response{}, &Error{Code: "auth_not_found", Message: "no auth available"}
+			return zero, &Error{Code: "auth_not_found", Message: "no auth available"}
 		}
 		pickOpts := opts
 		if homeMode {
@@ -1361,9 +1399,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
 		if errPick != nil {
 			if shouldReturnLastErrorOnPickFailure(homeMode, lastErr, errPick) {
-				return cliproxyexecutor.Response{}, lastErr
+				return zero, lastErr
 			}
-			return cliproxyexecutor.Response{}, errPick
+			return zero, errPick
 		}
 
 		entry := logEntryWithRequestID(ctx)
@@ -1375,7 +1413,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		if rt := m.roundTripperFor(auth); rt != nil {
 			execCtx = cliproxyexecutor.WithRoundTripper(execCtx, rt)
 		}
-		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
+		if withModelAlias {
+			execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
+		}
 
 		models, pooled := m.preparedExecutionModels(auth, routeModel)
 		if len(models) == 0 {
@@ -1393,217 +1433,105 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			lastErr = errPrepare
 			continue
 		}
-		var authErr error
-		for _, upstreamModel := range models {
-			resultModel := m.stateModelForExecution(auth, routeModel, upstreamModel, pooled)
-			execReq := req
-			execReq.Model = upstreamModel
-			resp, errExec := executor.Execute(execCtx, auth, execReq, opts)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
-			if errExec != nil {
-				if errCtx := execCtx.Err(); errCtx != nil {
-					return cliproxyexecutor.Response{}, errCtx
-				}
-				result.Error = &Error{Message: errExec.Error()}
-				if se, ok := errors.AsType[cliproxyexecutor.StatusError](errExec); ok && se != nil {
-					result.Error.HTTPStatus = se.StatusCode()
-				}
-				if ra := retryAfterFromError(errExec); ra != nil {
-					result.RetryAfter = ra
-				}
-				m.MarkResult(execCtx, result)
-				if isRequestInvalidError(errExec) {
-					return cliproxyexecutor.Response{}, errExec
-				}
-				authErr = errExec
-				continue
-			}
-			m.MarkResult(execCtx, result)
-			return resp, nil
+		out, errExec, done := exec(credentialAttempt{
+			auth:       auth,
+			executor:   executor,
+			provider:   provider,
+			execCtx:    execCtx,
+			routeModel: routeModel,
+			models:     models,
+			pooled:     pooled,
+			opts:       opts,
+		})
+		if done {
+			return out, errExec
 		}
-		if authErr != nil {
-			if isRequestInvalidError(authErr) {
-				return cliproxyexecutor.Response{}, authErr
-			}
-			lastErr = authErr
+		if errExec != nil {
+			lastErr = errExec
 			if homeMode {
 				homeAuthCount++
 			}
 			continue
 		}
 	}
+}
+
+// runModelPoolAttempt executes req across a credential's model pool for the
+// non-streaming paths (Execute/CountTokens), preserving the original
+// per-model error handling and result accounting. call performs the actual
+// provider invocation for a single upstream model.
+func (m *Manager) runModelPoolAttempt(req cliproxyexecutor.Request, attempt credentialAttempt, call func(execReq cliproxyexecutor.Request) (cliproxyexecutor.Response, error)) (cliproxyexecutor.Response, error, bool) {
+	var authErr error
+	for _, upstreamModel := range attempt.models {
+		resultModel := m.stateModelForExecution(attempt.auth, attempt.routeModel, upstreamModel, attempt.pooled)
+		execReq := req
+		execReq.Model = upstreamModel
+		resp, errExec := call(execReq)
+		result := Result{AuthID: attempt.auth.ID, Provider: attempt.provider, Model: resultModel, Success: errExec == nil}
+		if errExec != nil {
+			if errCtx := attempt.execCtx.Err(); errCtx != nil {
+				return cliproxyexecutor.Response{}, errCtx, true
+			}
+			result.Error = &Error{Message: errExec.Error()}
+			if se, ok := errors.AsType[cliproxyexecutor.StatusError](errExec); ok && se != nil {
+				result.Error.HTTPStatus = se.StatusCode()
+			}
+			if ra := retryAfterFromError(errExec); ra != nil {
+				result.RetryAfter = ra
+			}
+			m.MarkResult(attempt.execCtx, result)
+			if isRequestInvalidError(errExec) {
+				return cliproxyexecutor.Response{}, errExec, true
+			}
+			authErr = errExec
+			continue
+		}
+		m.MarkResult(attempt.execCtx, result)
+		return resp, nil, true
+	}
+	if authErr != nil && isRequestInvalidError(authErr) {
+		return cliproxyexecutor.Response{}, authErr, true
+	}
+	return cliproxyexecutor.Response{}, authErr, false
+}
+
+func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (cliproxyexecutor.Response, error) {
+	return runMixedOnce(m, ctx, providers, req, opts, maxRetryCredentials, cliproxyexecutor.Response{}, true,
+		func(attempt credentialAttempt) (cliproxyexecutor.Response, error, bool) {
+			return m.runModelPoolAttempt(req, attempt, func(execReq cliproxyexecutor.Request) (cliproxyexecutor.Response, error) {
+				return attempt.executor.Execute(attempt.execCtx, attempt.auth, execReq, attempt.opts)
+			})
+		},
+	)
 }
 
 func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (cliproxyexecutor.Response, error) {
-	if len(providers) == 0 {
-		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
-	}
-	routeModel := req.Model
-	opts = ensureRequestedModelMetadata(opts, routeModel)
-	homeMode := m.HomeEnabled()
-	homeAuthCount := 1
-	tried := make(map[string]struct{})
-	attempted := make(map[string]struct{})
-	var lastErr error
-	for {
-		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
-			if lastErr != nil {
-				return cliproxyexecutor.Response{}, lastErr
-			}
-			return cliproxyexecutor.Response{}, &Error{Code: "auth_not_found", Message: "no auth available"}
-		}
-		pickOpts := opts
-		if homeMode {
-			pickOpts = withHomeAuthCount(opts, homeAuthCount)
-		}
-		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
-		if errPick != nil {
-			if shouldReturnLastErrorOnPickFailure(homeMode, lastErr, errPick) {
-				return cliproxyexecutor.Response{}, lastErr
-			}
-			return cliproxyexecutor.Response{}, errPick
-		}
-
-		entry := logEntryWithRequestID(ctx)
-		debugLogAuthSelection(entry, auth, provider, req.Model)
-		publishSelectedAuthMetadata(opts.Metadata, auth.ID)
-
-		tried[auth.ID] = struct{}{}
-		execCtx := ctx
-		if rt := m.roundTripperFor(auth); rt != nil {
-			execCtx = cliproxyexecutor.WithRoundTripper(execCtx, rt)
-		}
-		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
-
-		models, pooled := m.preparedExecutionModels(auth, routeModel)
-		if len(models) == 0 {
-			continue
-		}
-		attempted[auth.ID] = struct{}{}
-		var errPrepare error
-		auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
-		if errPrepare != nil {
-			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: &Error{Message: errPrepare.Error()}}
-			if se, ok := errors.AsType[cliproxyexecutor.StatusError](errPrepare); ok && se != nil {
-				result.Error.HTTPStatus = se.StatusCode()
-			}
-			m.MarkResult(execCtx, result)
-			lastErr = errPrepare
-			continue
-		}
-		var authErr error
-		for _, upstreamModel := range models {
-			resultModel := m.stateModelForExecution(auth, routeModel, upstreamModel, pooled)
-			execReq := req
-			execReq.Model = upstreamModel
-			resp, errExec := executor.CountTokens(execCtx, auth, execReq, opts)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
-			if errExec != nil {
-				if errCtx := execCtx.Err(); errCtx != nil {
-					return cliproxyexecutor.Response{}, errCtx
-				}
-				result.Error = &Error{Message: errExec.Error()}
-				if se, ok := errors.AsType[cliproxyexecutor.StatusError](errExec); ok && se != nil {
-					result.Error.HTTPStatus = se.StatusCode()
-				}
-				if ra := retryAfterFromError(errExec); ra != nil {
-					result.RetryAfter = ra
-				}
-				m.MarkResult(execCtx, result)
-				if isRequestInvalidError(errExec) {
-					return cliproxyexecutor.Response{}, errExec
-				}
-				authErr = errExec
-				continue
-			}
-			m.MarkResult(execCtx, result)
-			return resp, nil
-		}
-		if authErr != nil {
-			if isRequestInvalidError(authErr) {
-				return cliproxyexecutor.Response{}, authErr
-			}
-			lastErr = authErr
-			if homeMode {
-				homeAuthCount++
-			}
-			continue
-		}
-	}
+	return runMixedOnce(m, ctx, providers, req, opts, maxRetryCredentials, cliproxyexecutor.Response{}, true,
+		func(attempt credentialAttempt) (cliproxyexecutor.Response, error, bool) {
+			return m.runModelPoolAttempt(req, attempt, func(execReq cliproxyexecutor.Request) (cliproxyexecutor.Response, error) {
+				return attempt.executor.CountTokens(attempt.execCtx, attempt.auth, execReq, attempt.opts)
+			})
+		},
+	)
 }
 
 func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (*cliproxyexecutor.StreamResult, error) {
-	if len(providers) == 0 {
-		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
-	}
-	routeModel := req.Model
-	opts = ensureRequestedModelMetadata(opts, routeModel)
-	homeMode := m.HomeEnabled()
-	homeAuthCount := 1
-	tried := make(map[string]struct{})
-	attempted := make(map[string]struct{})
-	var lastErr error
-	for {
-		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
-			if lastErr != nil {
-				return nil, lastErr
+	return runMixedOnce[*cliproxyexecutor.StreamResult](m, ctx, providers, req, opts, maxRetryCredentials, nil, false,
+		func(attempt credentialAttempt) (*cliproxyexecutor.StreamResult, error, bool) {
+			execReq := sanitizeDownstreamWebsocketFallbackRequest(attempt.execCtx, attempt.auth, req)
+			streamResult, errStream := m.executeStreamWithModelPool(attempt.execCtx, attempt.executor, attempt.auth, attempt.provider, execReq, attempt.opts, attempt.routeModel, attempt.models, attempt.pooled)
+			if errStream != nil {
+				if errCtx := attempt.execCtx.Err(); errCtx != nil {
+					return nil, errCtx, true
+				}
+				if isRequestInvalidError(errStream) {
+					return nil, errStream, true
+				}
+				return nil, errStream, false
 			}
-			return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
-		}
-		pickOpts := opts
-		if homeMode {
-			pickOpts = withHomeAuthCount(opts, homeAuthCount)
-		}
-		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
-		if errPick != nil {
-			if shouldReturnLastErrorOnPickFailure(homeMode, lastErr, errPick) {
-				return nil, lastErr
-			}
-			return nil, errPick
-		}
-
-		entry := logEntryWithRequestID(ctx)
-		debugLogAuthSelection(entry, auth, provider, req.Model)
-		publishSelectedAuthMetadata(opts.Metadata, auth.ID)
-
-		tried[auth.ID] = struct{}{}
-		execCtx := ctx
-		if rt := m.roundTripperFor(auth); rt != nil {
-			execCtx = cliproxyexecutor.WithRoundTripper(execCtx, rt)
-		}
-		models, pooled := m.preparedExecutionModels(auth, routeModel)
-		if len(models) == 0 {
-			continue
-		}
-		attempted[auth.ID] = struct{}{}
-		var errPrepare error
-		auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
-		if errPrepare != nil {
-			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: &Error{Message: errPrepare.Error()}}
-			if se, ok := errors.AsType[cliproxyexecutor.StatusError](errPrepare); ok && se != nil {
-				result.Error.HTTPStatus = se.StatusCode()
-			}
-			m.MarkResult(execCtx, result)
-			lastErr = errPrepare
-			continue
-		}
-		execReq := sanitizeDownstreamWebsocketFallbackRequest(execCtx, auth, req)
-		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, execReq, opts, routeModel, models, pooled)
-		if errStream != nil {
-			if errCtx := execCtx.Err(); errCtx != nil {
-				return nil, errCtx
-			}
-			if isRequestInvalidError(errStream) {
-				return nil, errStream
-			}
-			lastErr = errStream
-			if homeMode {
-				homeAuthCount++
-			}
-			continue
-		}
-		return streamResult, nil
-	}
+			return streamResult, nil, true
+		},
+	)
 }
 
 func sanitizeDownstreamWebsocketFallbackRequest(ctx context.Context, auth *Auth, req cliproxyexecutor.Request) cliproxyexecutor.Request {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1224,6 +1224,49 @@ func (m *Manager) Load(ctx context.Context) error {
 
 // Execute performs a non-streaming execution using the configured selector and executor.
 // It supports multiple providers for the same model and round-robins the starting provider per model.
+// runWithRetry drives the attempt/cooldown/retry loop shared by Execute,
+// ExecuteCount, and ExecuteStream. The once callback performs a single mixed
+// execution attempt. onExhausted (optional) runs once the loop terminates with a
+// non-nil error so callers can apply provider-specific fallbacks such as the
+// Antigravity credits path or streaming bootstrap recovery; it returns the
+// fallback result and true when it produced a successful response. zero is the
+// typed empty value returned on failure.
+func runWithRetry[T any](
+	m *Manager,
+	ctx context.Context,
+	providers []string,
+	model string,
+	maxWait time.Duration,
+	zero T,
+	once func() (T, error),
+	onExhausted func(lastErr error) (T, bool),
+) (T, error) {
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		result, errExec := once()
+		if errExec == nil {
+			return result, nil
+		}
+		lastErr = errExec
+		wait, shouldRetry := m.shouldRetryAfterError(errExec, attempt, providers, model, maxWait)
+		if !shouldRetry {
+			break
+		}
+		if errWait := waitForCooldown(ctx, wait); errWait != nil {
+			return zero, errWait
+		}
+	}
+	if lastErr != nil {
+		if onExhausted != nil {
+			if result, ok := onExhausted(lastErr); ok {
+				return result, nil
+			}
+		}
+		return zero, lastErr
+	}
+	return zero, &Error{Code: "auth_not_found", Message: "no auth available"}
+}
+
 func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
@@ -1232,30 +1275,19 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
-	var lastErr error
-	for attempt := 0; ; attempt++ {
-		resp, errExec := m.executeMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
-		if errExec == nil {
-			return resp, nil
-		}
-		lastErr = errExec
-		wait, shouldRetry := m.shouldRetryAfterError(errExec, attempt, normalized, req.Model, maxWait)
-		if !shouldRetry {
-			break
-		}
-		if errWait := waitForCooldown(ctx, wait); errWait != nil {
-			return cliproxyexecutor.Response{}, errWait
-		}
-	}
-	if lastErr != nil {
-		if hasAntigravityProvider(normalized) && shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
-			if resp, ok := m.tryAntigravityCreditsExecute(ctx, req, opts); ok {
-				return resp, nil
+	return runWithRetry(m, ctx, normalized, req.Model, maxWait, cliproxyexecutor.Response{},
+		func() (cliproxyexecutor.Response, error) {
+			return m.executeMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
+		},
+		func(lastErr error) (cliproxyexecutor.Response, bool) {
+			if hasAntigravityProvider(normalized) && shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
+				if resp, ok := m.tryAntigravityCreditsExecute(ctx, req, opts); ok {
+					return resp, true
+				}
 			}
-		}
-		return cliproxyexecutor.Response{}, lastErr
-	}
-	return cliproxyexecutor.Response{}, &Error{Code: "auth_not_found", Message: "no auth available"}
+			return cliproxyexecutor.Response{}, false
+		},
+	)
 }
 
 // It supports multiple providers for the same model and round-robins the starting provider per model.
@@ -1267,25 +1299,12 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
-	var lastErr error
-	for attempt := 0; ; attempt++ {
-		resp, errExec := m.executeCountMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
-		if errExec == nil {
-			return resp, nil
-		}
-		lastErr = errExec
-		wait, shouldRetry := m.shouldRetryAfterError(errExec, attempt, normalized, req.Model, maxWait)
-		if !shouldRetry {
-			break
-		}
-		if errWait := waitForCooldown(ctx, wait); errWait != nil {
-			return cliproxyexecutor.Response{}, errWait
-		}
-	}
-	if lastErr != nil {
-		return cliproxyexecutor.Response{}, lastErr
-	}
-	return cliproxyexecutor.Response{}, &Error{Code: "auth_not_found", Message: "no auth available"}
+	return runWithRetry(m, ctx, normalized, req.Model, maxWait, cliproxyexecutor.Response{},
+		func() (cliproxyexecutor.Response, error) {
+			return m.executeCountMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
+		},
+		nil,
+	)
 }
 
 // ExecuteStream performs a streaming execution using the configured selector and executor.
@@ -1298,34 +1317,23 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
-	var lastErr error
-	for attempt := 0; ; attempt++ {
-		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
-		if errStream == nil {
-			return result, nil
-		}
-		lastErr = errStream
-		wait, shouldRetry := m.shouldRetryAfterError(errStream, attempt, normalized, req.Model, maxWait)
-		if !shouldRetry {
-			break
-		}
-		if errWait := waitForCooldown(ctx, wait); errWait != nil {
-			return nil, errWait
-		}
-	}
-	if lastErr != nil {
-		if hasAntigravityProvider(normalized) && shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
-			if result, ok := m.tryAntigravityCreditsExecuteStream(ctx, req, opts); ok {
-				return result, nil
+	return runWithRetry[*cliproxyexecutor.StreamResult](m, ctx, normalized, req.Model, maxWait, nil,
+		func() (*cliproxyexecutor.StreamResult, error) {
+			return m.executeStreamMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
+		},
+		func(lastErr error) (*cliproxyexecutor.StreamResult, bool) {
+			if hasAntigravityProvider(normalized) && shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
+				if result, ok := m.tryAntigravityCreditsExecuteStream(ctx, req, opts); ok {
+					return result, true
+				}
 			}
-		}
-		var bootstrapErr *streamBootstrapError
-		if errors.As(lastErr, &bootstrapErr) && bootstrapErr != nil {
-			return streamErrorResult(bootstrapErr.Headers(), bootstrapErr.cause), nil
-		}
-		return nil, lastErr
-	}
-	return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+			var bootstrapErr *streamBootstrapError
+			if errors.As(lastErr, &bootstrapErr) && bootstrapErr != nil {
+				return streamErrorResult(bootstrapErr.Headers(), bootstrapErr.cause), true
+			}
+			return nil, false
+		},
+	)
 }
 
 func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (cliproxyexecutor.Response, error) {
@@ -1365,8 +1373,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		tried[auth.ID] = struct{}{}
 		execCtx := ctx
 		if rt := m.roundTripperFor(auth); rt != nil {
-			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
-			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
+			execCtx = cliproxyexecutor.WithRoundTripper(execCtx, rt)
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
@@ -1464,8 +1471,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		tried[auth.ID] = struct{}{}
 		execCtx := ctx
 		if rt := m.roundTripperFor(auth); rt != nil {
-			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
-			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
+			execCtx = cliproxyexecutor.WithRoundTripper(execCtx, rt)
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
@@ -1563,8 +1569,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		tried[auth.ID] = struct{}{}
 		execCtx := ctx
 		if rt := m.roundTripperFor(auth); rt != nil {
-			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
-			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
+			execCtx = cliproxyexecutor.WithRoundTripper(execCtx, rt)
 		}
 		models, pooled := m.preparedExecutionModels(auth, routeModel)
 		if len(models) == 0 {
@@ -3794,8 +3799,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
-			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
-			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
+			creditsCtx = cliproxyexecutor.WithRoundTripper(creditsCtx, rt)
 		}
 		creditsOpts := ensureRequestedModelMetadata(opts, routeModel)
 		creditsCtx = contextWithRequestedModelAlias(creditsCtx, creditsOpts, routeModel)
@@ -3842,8 +3846,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
-			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
-			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
+			creditsCtx = cliproxyexecutor.WithRoundTripper(creditsCtx, rt)
 		}
 		creditsOpts := ensureRequestedModelMetadata(opts, routeModel)
 		preparedAuth, errPrepare := m.prepareRequestAuth(creditsCtx, c.executor, c.auth)
@@ -4247,9 +4250,6 @@ func (m *Manager) executorFor(provider string) ProviderExecutor {
 	defer m.mu.RUnlock()
 	return m.executors[provider]
 }
-
-// roundTripperContextKey is an unexported context key type to avoid collisions.
-type roundTripperContextKey struct{}
 
 // roundTripperFor retrieves an HTTP RoundTripper for the given auth if a provider is registered.
 func (m *Manager) roundTripperFor(auth *Auth) http.RoundTripper {

--- a/sdk/cliproxy/executor/context.go
+++ b/sdk/cliproxy/executor/context.go
@@ -1,6 +1,34 @@
 package executor
 
-import "context"
+import (
+	"context"
+	"net/http"
+)
+
+type roundTripperContextKey struct{}
+
+// WithRoundTripper attaches a per-auth HTTP RoundTripper to the context so
+// downstream executors can reuse the credential's configured transport (e.g. a
+// proxy). It uses an unexported typed key to avoid cross-package collisions.
+func WithRoundTripper(ctx context.Context, rt http.RoundTripper) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if rt == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, roundTripperContextKey{}, rt)
+}
+
+// RoundTripper returns the per-auth HTTP RoundTripper previously stored with
+// WithRoundTripper, or nil when none is present.
+func RoundTripper(ctx context.Context) http.RoundTripper {
+	if ctx == nil {
+		return nil
+	}
+	rt, _ := ctx.Value(roundTripperContextKey{}).(http.RoundTripper)
+	return rt
+}
 
 type downstreamWebsocketContextKey struct{}
 


### PR DESCRIPTION
## Summary

Three small, behavior-preserving cleanups in the core auth/runtime layer.

### 1. Dedupe the conductor retry loop
`Manager.Execute`, `ExecuteCount`, and `ExecuteStream` carried three
near-identical attempt → `shouldRetryAfterError` → `waitForCooldown` loops with
copy-pasted "exhausted" handling. They are now driven by a single generic
`runWithRetry[T]` helper. Each method supplies only its single-attempt closure
and an optional exhausted-fallback hook:
- `Execute`: Antigravity credits fallback
- `ExecuteStream`: Antigravity credits fallback + stream-bootstrap recovery
- `ExecuteCount`: no fallback

### 2. Dedupe the mixed-once credential iteration scaffold
`executeMixedOnce`, `executeCountMixedOnce`, and `executeStreamMixedOnce` shared
a byte-identical credential-iteration scaffold (retry-credential cap, candidate
selection, per-auth round-tripper, model preparation, request-auth preparation,
home-mode bookkeeping) with only the provider call differing. Extracted into a
generic `runMixedOnce[T]` driver plus a `runModelPoolAttempt` helper for the
non-streaming model-pool loop. Two original subtleties are preserved exactly:
the streaming path still skips the requested-model alias on the execution
context, and `opts` mutation/order is unchanged. Net -72 lines.

### 3. Type the round-tripper context key
The per-auth transport was passed across package boundaries via a bare string
key `"cliproxy.roundtripper"`, which `go vet` flags as collision-prone.
Alongside it, the `auth` package also wrote a private `roundTripperContextKey{}`
that was never read anywhere (dead). This introduces a shared typed key with
`WithRoundTripper`/`RoundTripper` accessors in `sdk/cliproxy/executor`, removes
the dead private type, and routes all producers, consumers, and their tests
through the typed accessors. The string key is fully eliminated from the
codebase.

All three changes are behavior-preserving; no public SDK signatures changed
(the new `WithRoundTripper`/`RoundTripper` accessors are additive).

## Verification

```
gofmt -w <changed files>
go build ./...
go vet ./sdk/cliproxy/auth/... ./sdk/cliproxy/executor/... ./internal/runtime/executor/...
go test ./...
```

All green; full suite passes with no failures.
