### PR TITLE
feat(api): dynamically list endpoints on root /

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -222,6 +222,11 @@ type Server struct {
 	// pluginHost owns dynamic plugin Management API route dispatch.
 	pluginHost *pluginhost.Host
 
+	// rootEndpoints caches the dynamic endpoint list for GET /.
+	// Computed once on first request; routes are static after startup.
+	rootEndpointsOnce sync.Once
+	rootEndpoints     []string
+
 	// managementRoutesRegistered tracks whether the management routes have been attached to the engine.
 	managementRoutesRegistered atomic.Bool
 	// managementRoutesEnabled controls whether management endpoints serve real handlers.
@@ -474,24 +479,26 @@ func (s *Server) setupRoutes() {
 
 	// Root endpoint — dynamically lists all registered public API routes.
 	s.engine.GET("/", func(c *gin.Context) {
-		routes := s.engine.Routes()
-		endpoints := make([]string, 0, len(routes))
-		for _, r := range routes {
-			path := r.Path
-			// Include only public API routes; exclude root, health, management,
-			// OAuth callbacks, internal, and any other non-API paths.
-			if path == "/" || path == "/healthz" || path == "/management.html" {
-				continue
+		s.rootEndpointsOnce.Do(func() {
+			routes := s.engine.Routes()
+			s.rootEndpoints = make([]string, 0, len(routes))
+			for _, r := range routes {
+				path := r.Path
+				// Include only public API routes; exclude root, health, management,
+				// OAuth callbacks, internal, and any other non-API paths.
+				if path == "/" || path == "/healthz" || path == "/management.html" {
+					continue
+				}
+				if strings.HasPrefix(path, "/v1/") || strings.HasPrefix(path, "/v1beta/") ||
+					strings.HasPrefix(path, "/backend-api/") {
+					s.rootEndpoints = append(s.rootEndpoints, r.Method+" "+path)
+				}
 			}
-			if strings.HasPrefix(path, "/v1/") || strings.HasPrefix(path, "/v1beta/") ||
-				strings.HasPrefix(path, "/backend-api/") {
-				endpoints = append(endpoints, r.Method+" "+path)
-			}
-		}
-		sort.Strings(endpoints)
+			sort.Strings(s.rootEndpoints)
+		})
 		c.JSON(http.StatusOK, gin.H{
 			"message":   "CLI Proxy API Server",
-			"endpoints": endpoints,
+			"endpoints": s.rootEndpoints,
 		})
 	})
 	s.engine.POST("/v1internal:method", geminiCLIHandlers.CLIHandler)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -472,15 +472,26 @@ func (s *Server) setupRoutes() {
 		v1beta.GET("/models/*action", s.geminiGetHandler(geminiHandlers))
 	}
 
-	// Root endpoint
+	// Root endpoint — dynamically lists all registered public API routes.
 	s.engine.GET("/", func(c *gin.Context) {
+		routes := s.engine.Routes()
+		endpoints := make([]string, 0, len(routes))
+		for _, r := range routes {
+			path := r.Path
+			// Include only public API routes; exclude root, health, management,
+			// OAuth callbacks, internal, and any other non-API paths.
+			if path == "/" || path == "/healthz" || path == "/management.html" {
+				continue
+			}
+			if strings.HasPrefix(path, "/v1/") || strings.HasPrefix(path, "/v1beta/") ||
+				strings.HasPrefix(path, "/backend-api/") {
+				endpoints = append(endpoints, r.Method+" "+path)
+			}
+		}
+		sort.Strings(endpoints)
 		c.JSON(http.StatusOK, gin.H{
-			"message": "CLI Proxy API Server",
-			"endpoints": []string{
-				"POST /v1/chat/completions",
-				"POST /v1/completions",
-				"GET /v1/models",
-			},
+			"message":   "CLI Proxy API Server",
+			"endpoints": endpoints,
 		})
 	})
 	s.engine.POST("/v1internal:method", geminiCLIHandlers.CLIHandler)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -490,7 +490,7 @@ func (s *Server) setupRoutes() {
 					continue
 				}
 				if strings.HasPrefix(path, "/v1/") || strings.HasPrefix(path, "/v1beta/") ||
-					strings.HasPrefix(path, "/backend-api/") {
+					strings.HasPrefix(path, "/backend-api/") || strings.HasPrefix(path, "/openai/") {
 					s.rootEndpoints = append(s.rootEndpoints, r.Method+" "+path)
 				}
 			}


### PR DESCRIPTION
## Summary

Replace the hardcoded three-endpoint list on `GET /` with a dynamic enumeration of all registered public API routes (`/v1/*`, `/v1beta/*`, `/backend-api/*`).

Previously the root endpoint returned only `chat/completions`, `completions`, and `models` — missing newer endpoints like `/v1/images/generations`, `/v1/messages`, `/v1/responses`, and others.

## Changes

- `internal/api/server.go`: Dynamic enumeration from `s.engine.Routes()` with path prefix filtering
- Filter: only `/v1/*`, `/v1beta/*`, `/backend-api/*` (excludes health, management, OAuth callbacks)
- Sorted alphabetically for consistent output

## Motivation

The static list misled users — e.g. [#2809](https://github.com/router-for-me/CLIProxyAPI/issues/2809) wrote "only exposes 3 endpoints" based on the root response, when the instance supports 15+.

Fixes #2809