### PR TITLE
fix(codex): scope session keys by auth

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -898,7 +898,7 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 	if from == "claude" {
 		userIDResult := gjson.GetBytes(req.Payload, "metadata.user_id")
 		if userIDResult.Exists() {
-			key := fmt.Sprintf("%s-%s", req.Model, userIDResult.String())
+			key := codexClaudeCacheKey(req.Model, auth, userIDResult.String())
 			var ok bool
 			if cache, ok = helps.GetCodexCache(key); !ok {
 				cache = helps.CodexCache{
@@ -911,11 +911,11 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 	} else if from == "openai-response" {
 		promptCacheKey := gjson.GetBytes(req.Payload, "prompt_cache_key")
 		if promptCacheKey.Exists() {
-			cache.ID = promptCacheKey.String()
+			cache.ID = scopedCodexPromptCacheKey(auth, promptCacheKey.String())
 		}
 	} else if from == "openai" {
 		if apiKey := strings.TrimSpace(helps.APIKeyFromContext(ctx)); apiKey != "" {
-			cache.ID = uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:prompt-cache:"+apiKey)).String()
+			cache.ID = scopedCodexPromptCacheKey(auth, uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:prompt-cache:"+apiKey)).String())
 		}
 	}
 
@@ -930,6 +930,9 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(rawJSON))
 	if err != nil {
 		return nil, nil, codexIdentityConfuseState{}, err
+	}
+	if cache.ID != "" && codexAuthSessionNamespace(auth) != "" {
+		httpReq.Header.Set("Session_id", cache.ID)
 	}
 	return httpReq, rawJSON, identityState, nil
 }
@@ -976,6 +979,7 @@ func applyCodexIdentityConfuseHeaders(headers http.Header, state *codexIdentityC
 		return
 	}
 
+	headers.Del("Session_id")
 	setHeaderCasePreserved(headers, "Session-Id", state.promptCacheKey)
 	headers.Set("X-Client-Request-Id", state.promptCacheKey)
 	headers.Set("Thread-Id", state.promptCacheKey)
@@ -1052,6 +1056,56 @@ func codexIdentityConfuseEnabled(cfg *config.Config) bool {
 func codexIdentityConfuseUUID(authID string, kind string, value string) string {
 	name := strings.Join([]string{"cli-proxy-api", "codex", "identity-confuse", kind, strings.TrimSpace(authID), strings.TrimSpace(value)}, ":")
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(name)).String()
+}
+
+func codexClaudeCacheKey(model string, auth *cliproxyauth.Auth, userID string) string {
+	namespace := codexAuthSessionNamespace(auth)
+	if namespace == "" {
+		return fmt.Sprintf("%s-%s", model, userID)
+	}
+	return codexScopedSHA1Key("cli-proxy-api:codex:claude-session", model, namespace, userID)
+}
+
+func scopedCodexPromptCacheKey(auth *cliproxyauth.Auth, promptCacheKey string) string {
+	promptCacheKey = strings.TrimSpace(promptCacheKey)
+	if promptCacheKey == "" {
+		return ""
+	}
+	namespace := codexAuthSessionNamespace(auth)
+	if namespace == "" {
+		return promptCacheKey
+	}
+	return codexScopedSHA1Key("cli-proxy-api:codex:auth-session", namespace, promptCacheKey)
+}
+
+func codexScopedSHA1Key(prefix string, components ...string) string {
+	var b strings.Builder
+	b.WriteString(prefix)
+	for _, component := range components {
+		fmt.Fprintf(&b, ":%d:%s", len(component), component)
+	}
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(b.String())).String()
+}
+
+func codexAuthSessionNamespace(auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	for _, key := range []string{"codex_installation_id", "installation_id"} {
+		if auth.Metadata != nil {
+			if value, ok := auth.Metadata[key].(string); ok {
+				if trimmed := strings.TrimSpace(value); trimmed != "" {
+					return trimmed
+				}
+			}
+		}
+		if auth.Attributes != nil {
+			if value := strings.TrimSpace(auth.Attributes[key]); value != "" {
+				return value
+			}
+		}
+	}
+	return strings.TrimSpace(auth.ID)
 }
 
 func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config) {

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -69,6 +69,7 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 	recorder := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(recorder)
 	ginCtx.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+	ginCtx.Request.Header.Set("Session_id", "client-session")
 	ginCtx.Request.Header.Set("X-Codex-Turn-Metadata", `{"prompt_cache_key":"cache-1","turn_id":"turn-1","window_id":"cache-1:0"}`)
 	ginCtx.Request.Header.Set("X-Client-Request-Id", "client-request-1")
 
@@ -155,5 +156,127 @@ func TestCodexIdentityConfuseKeepsClientBodySeparateFromUpstreamBody(t *testing.
 	}
 	if gotKey := gjson.GetBytes(clientBody, "prompt_cache_key").String(); gotKey != "cache-1" {
 		t.Fatalf("client prompt_cache_key = %q, want cache-1", gotKey)
+	}
+}
+
+func TestCodexClaudeCacheKeyPreservesLegacyKeyWithoutNamespace(t *testing.T) {
+	got := codexClaudeCacheKey("gpt-5-codex", nil, "user-1")
+	if got != "gpt-5-codex-user-1" {
+		t.Fatalf("codexClaudeCacheKey without namespace = %q, want legacy key", got)
+	}
+}
+
+func TestCodexClaudeCacheKeyDisambiguatesScopedComponents(t *testing.T) {
+	authAB := &cliproxyauth.Auth{Metadata: map[string]any{"codex_installation_id": "a-b"}}
+	authA := &cliproxyauth.Auth{Metadata: map[string]any{"codex_installation_id": "a"}}
+
+	keyABUserC := codexClaudeCacheKey("gpt-5-codex", authAB, "c")
+	keyAUserBC := codexClaudeCacheKey("gpt-5-codex", authA, "b-c")
+	if keyABUserC == "" || keyAUserBC == "" {
+		t.Fatalf("codexClaudeCacheKey returned empty scoped key")
+	}
+	if keyABUserC == "gpt-5-codex-a-b-c" || keyAUserBC == "gpt-5-codex-a-b-c" {
+		t.Fatalf("codexClaudeCacheKey used ambiguous delimiter-only key")
+	}
+	if keyABUserC == keyAUserBC {
+		t.Fatalf("codexClaudeCacheKey collided for namespace/user components containing hyphens")
+	}
+
+	keyABUserC2 := codexClaudeCacheKey("gpt-5-codex", authAB, "c")
+	if keyABUserC2 != keyABUserC {
+		t.Fatalf("codexClaudeCacheKey = %q, want stable %q", keyABUserC2, keyABUserC)
+	}
+}
+
+func TestCodexExecutorCacheHelper_OpenAIResponsesScopesPromptCacheKeyByAuth(t *testing.T) {
+	ctx := context.Background()
+	executor := &CodexExecutor{}
+	rawJSON := []byte(`{"model":"gpt-5-codex","prompt_cache_key":"shared-session"}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: rawJSON,
+	}
+	url := "https://example.com/responses"
+	authA := &cliproxyauth.Auth{
+		ID:       "auth-a",
+		Metadata: map[string]any{"codex_installation_id": "install-a"},
+	}
+	authB := &cliproxyauth.Auth{
+		ID:       "auth-b",
+		Metadata: map[string]any{"codex_installation_id": "install-b"},
+	}
+
+	httpReqA, bodyA, _, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), url, authA, req, rawJSON, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper auth A error: %v", err)
+	}
+	keyA := gjson.GetBytes(bodyA, "prompt_cache_key").String()
+	if keyA == "" || keyA == "shared-session" {
+		t.Fatalf("auth A prompt_cache_key = %q, want scoped key", keyA)
+	}
+	if gotSession := httpReqA.Header.Get("Session_id"); gotSession != keyA {
+		t.Fatalf("auth A Session_id = %q, want %q", gotSession, keyA)
+	}
+
+	_, bodyB, _, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), url, authB, req, rawJSON, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper auth B error: %v", err)
+	}
+	keyB := gjson.GetBytes(bodyB, "prompt_cache_key").String()
+	if keyB == "" || keyB == keyA {
+		t.Fatalf("auth B prompt_cache_key = %q, want different from auth A %q", keyB, keyA)
+	}
+
+	_, bodyA2, _, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), url, authA, req, rawJSON, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper auth A second error: %v", err)
+	}
+	keyA2 := gjson.GetBytes(bodyA2, "prompt_cache_key").String()
+	if keyA2 != keyA {
+		t.Fatalf("auth A prompt_cache_key second = %q, want stable %q", keyA2, keyA)
+	}
+}
+
+func TestApplyCodexHeadersPreservesScopedSessionIDOverMacClientHeader(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+	ginCtx.Request.Header.Set("User-Agent", codexUserAgent)
+	ginCtx.Request.Header.Set("Session_id", "client-session")
+
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+	httpReq := httptest.NewRequest("POST", "https://example.com/responses", nil).WithContext(ctx)
+	httpReq.Header.Set("Session_id", "scoped-session")
+
+	applyCodexHeaders(httpReq, &cliproxyauth.Auth{ID: "auth-a"}, "oauth-token", true, nil)
+
+	if gotSession := httpReq.Header.Get("Session_id"); gotSession != "scoped-session" {
+		t.Fatalf("Session_id = %q, want scoped-session", gotSession)
+	}
+}
+
+func TestScopedCodexPromptCacheKeyDisambiguatesScopedComponents(t *testing.T) {
+	authAB := &cliproxyauth.Auth{Metadata: map[string]any{"codex_installation_id": "a:b"}}
+	authA := &cliproxyauth.Auth{Metadata: map[string]any{"codex_installation_id": "a"}}
+
+	keyABWithC := scopedCodexPromptCacheKey(authAB, "c")
+	keyAWithBC := scopedCodexPromptCacheKey(authA, "b:c")
+	if keyABWithC == "" || keyAWithBC == "" {
+		t.Fatalf("scopedCodexPromptCacheKey returned empty scoped key")
+	}
+	if keyABWithC == keyAWithBC {
+		t.Fatalf("scopedCodexPromptCacheKey collided for namespace/prompt_cache_key components containing colons")
+	}
+
+	ambiguousDelimiterKey := uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:auth-session:a:b:c")).String()
+	if keyABWithC == ambiguousDelimiterKey || keyAWithBC == ambiguousDelimiterKey {
+		t.Fatalf("scopedCodexPromptCacheKey used ambiguous delimiter-only input")
+	}
+
+	if got := scopedCodexPromptCacheKey(nil, " cache-1 "); got != "cache-1" {
+		t.Fatalf("scopedCodexPromptCacheKey without namespace = %q, want trimmed legacy key", got)
+	}
+	if got := scopedCodexPromptCacheKey(authA, "   "); got != "" {
+		t.Fatalf("scopedCodexPromptCacheKey blank key = %q, want empty", got)
 	}
 }

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -220,7 +220,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		return resp, err
 	}
 
-	body, wsHeaders := applyCodexPromptCacheHeaders(from, req, body)
+	body, wsHeaders := applyCodexPromptCacheHeaders(from, auth, req, body)
 	clientBody := body
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
@@ -435,7 +435,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		return nil, err
 	}
 
-	body, wsHeaders := applyCodexPromptCacheHeaders(from, req, body)
+	body, wsHeaders := applyCodexPromptCacheHeaders(from, auth, req, body)
 	clientBody := body
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, userPayload, body)
@@ -828,7 +828,7 @@ func buildCodexResponsesWebsocketURL(httpURL string) (string, error) {
 	return parsed.String(), nil
 }
 
-func applyCodexPromptCacheHeaders(from sdktranslator.Format, req cliproxyexecutor.Request, rawJSON []byte) ([]byte, http.Header) {
+func applyCodexPromptCacheHeaders(from sdktranslator.Format, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, rawJSON []byte) ([]byte, http.Header) {
 	headers := http.Header{}
 	if len(rawJSON) == 0 {
 		return rawJSON, headers
@@ -838,7 +838,7 @@ func applyCodexPromptCacheHeaders(from sdktranslator.Format, req cliproxyexecuto
 	if from == "claude" {
 		userIDResult := gjson.GetBytes(req.Payload, "metadata.user_id")
 		if userIDResult.Exists() {
-			key := fmt.Sprintf("%s-%s", req.Model, userIDResult.String())
+			key := codexClaudeCacheKey(req.Model, auth, userIDResult.String())
 			if cached, ok := helps.GetCodexCache(key); ok {
 				cache = cached
 			} else {
@@ -851,12 +851,15 @@ func applyCodexPromptCacheHeaders(from sdktranslator.Format, req cliproxyexecuto
 		}
 	} else if from == "openai-response" {
 		if promptCacheKey := gjson.GetBytes(req.Payload, "prompt_cache_key"); promptCacheKey.Exists() {
-			cache.ID = promptCacheKey.String()
+			cache.ID = scopedCodexPromptCacheKey(auth, promptCacheKey.String())
 		}
 	}
 
 	if cache.ID != "" {
 		rawJSON, _ = sjson.SetBytes(rawJSON, "prompt_cache_key", cache.ID)
+		if codexAuthSessionNamespace(auth) != "" {
+			setHeaderCasePreserved(headers, "Session-Id", cache.ID)
+		}
 	}
 
 	return rawJSON, headers

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -344,13 +344,40 @@ func TestApplyCodexWebsocketHeadersPreservesExplicitAPIKeyUserAgent(t *testing.T
 func TestApplyCodexPromptCacheHeadersDoesNotSetDeprecatedConversationHeader(t *testing.T) {
 	req := cliproxyexecutor.Request{Model: "gpt-5-codex", Payload: []byte(`{"prompt_cache_key":"cache-1"}`)}
 
-	_, headers := applyCodexPromptCacheHeaders("openai-response", req, []byte(`{"model":"gpt-5-codex"}`))
+	_, headers := applyCodexPromptCacheHeaders("openai-response", nil, req, []byte(`{"model":"gpt-5-codex"}`))
 
 	if got := headerValueCaseInsensitive(headers, "session_id"); got != "" {
 		t.Fatalf("session_id = %q, want empty", got)
 	}
 	if got := headers.Get("Conversation_id"); got != "" {
 		t.Fatalf("Conversation_id = %q, want empty", got)
+	}
+}
+
+func TestApplyCodexPromptCacheHeadersScopesSessionByAuth(t *testing.T) {
+	req := cliproxyexecutor.Request{Model: "gpt-5-codex", Payload: []byte(`{"prompt_cache_key":"cache-1"}`)}
+	authA := &cliproxyauth.Auth{ID: "auth-a", Metadata: map[string]any{"codex_installation_id": "install-a"}}
+	authB := &cliproxyauth.Auth{ID: "auth-b", Metadata: map[string]any{"codex_installation_id": "install-b"}}
+
+	bodyA, headersA := applyCodexPromptCacheHeaders("openai-response", authA, req, []byte(`{"model":"gpt-5-codex"}`))
+	bodyB, headersB := applyCodexPromptCacheHeaders("openai-response", authB, req, []byte(`{"model":"gpt-5-codex"}`))
+
+	keyA := gjson.GetBytes(bodyA, "prompt_cache_key").String()
+	keyB := gjson.GetBytes(bodyB, "prompt_cache_key").String()
+	if keyA == "" || keyA == "cache-1" {
+		t.Fatalf("auth A prompt_cache_key = %q, want scoped key", keyA)
+	}
+	if keyB == "" || keyB == keyA {
+		t.Fatalf("auth B prompt_cache_key = %q, want different from auth A %q", keyB, keyA)
+	}
+	if got := headersA.Get("Session-Id"); got != keyA {
+		t.Fatalf("auth A Session-Id = %q, want %q", got, keyA)
+	}
+	if got := headerValueCaseInsensitive(headersA, "session_id"); got != "" {
+		t.Fatalf("auth A deprecated session_id = %q, want empty", got)
+	}
+	if got := headersB.Get("Conversation_id"); got != "" {
+		t.Fatalf("auth B Conversation_id = %q, want empty", got)
 	}
 }
 
@@ -365,7 +392,7 @@ func TestApplyCodexWebsocketHeadersIdentityConfuseRemapsPromptCacheKey(t *testin
 		Payload: []byte(`{"prompt_cache_key":"cache-ws-1","client_metadata":{"x-codex-installation-id":"install-ws-1"}}`),
 	}
 
-	body, headers := applyCodexPromptCacheHeaders("openai-response", req, []byte(`{"model":"gpt-5-codex"}`))
+	body, headers := applyCodexPromptCacheHeaders("openai-response", auth, req, []byte(`{"model":"gpt-5-codex"}`))
 	body, identityState := applyCodexIdentityConfuseBody(cfg, auth, req.Payload, body)
 	ctx := contextWithGinHeaders(map[string]string{
 		"X-Codex-Turn-Metadata": `{"prompt_cache_key":"cache-ws-1","turn_id":"turn-ws-1","window_id":"cache-ws-1:0"}`,
@@ -382,11 +409,10 @@ func TestApplyCodexWebsocketHeadersIdentityConfuseRemapsPromptCacheKey(t *testin
 	if gotSession := headerValueCaseInsensitive(headers, "session_id"); gotSession != "" {
 		t.Fatalf("session_id = %q, want empty", gotSession)
 	}
-	if gotRequestID := headers.Get("X-Client-Request-Id"); gotRequestID != expectedPromptCacheKey {
-		t.Fatalf("X-Client-Request-Id = %q, want %q", gotRequestID, expectedPromptCacheKey)
-	}
-	if gotThreadID := headers.Get("Thread-Id"); gotThreadID != expectedPromptCacheKey {
-		t.Fatalf("Thread-Id = %q, want %q", gotThreadID, expectedPromptCacheKey)
+	for _, headerName := range []string{"Session-Id", "X-Client-Request-Id", "Thread-Id"} {
+		if gotHeader := headers.Get(headerName); gotHeader != expectedPromptCacheKey {
+			t.Fatalf("%s = %q, want %q", headerName, gotHeader, expectedPromptCacheKey)
+		}
 	}
 	if gotConversation := headers.Get("Conversation_id"); gotConversation != "" {
 		t.Fatalf("Conversation_id = %q, want empty", gotConversation)


### PR DESCRIPTION
## Summary
- Scope Codex upstream `prompt_cache_key` / session headers by the selected auth namespace before forwarding requests upstream.
- Preserve stable keys within the same auth while preventing cross-auth session reuse.
- Apply the behavior to direct HTTP and WebSocket Codex paths.
- Keep legacy Claude cache lookup keys when no auth namespace exists, and use an unambiguous scoped lookup key when a namespace is present.

## Why this is needed
In a multi-account proxy/token-pool deployment, different downstream clients can send the same Codex `prompt_cache_key` or session ID while being routed through different upstream auth accounts. If the proxy forwards that key unchanged, upstream can observe different accounts continuing the same logical conversation/session chain.

That cross-account session reuse can contaminate upstream conversation state and may look like account-linking or anomalous shared-session behavior to upstream risk-control systems. Deriving the upstream session key from the selected auth namespace keeps per-account continuity, but prevents one account's session key from being reused by another account.

## Tests
- `go test ./internal/runtime/executor -run 'TestCodexExecutorCacheHelper|TestCodexClaudeCacheKey|TestApplyCodexPromptCacheHeaders' -count=1`
