### PR TITLE
Add Azure OpenAI ingress routes

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -250,6 +250,8 @@ nonstream-keepalive-interval: 0
 #     disabled: false # optional: set to true to disable this provider without removing it
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
+#     # api-type: "azure-openai" # optional: use Azure OpenAI deployment URL/auth semantics.
+#     # api-version: "2025-04-01-preview" # required when api-type is azure-openai.
 #     disable-cooling: false # optional: per-provider override for auth/model cooldown scheduling
 #     headers:
 #       X-Custom-Header: "custom-value"
@@ -275,6 +277,37 @@ nonstream-keepalive-interval: 0
 #         alias: "claude-opus-4.66"
 #       - name: "kimi-k2.5"
 #         alias: "claude-opus-4.66"
+#
+#   # Azure OpenAI example using deployment path mode. This is disabled by default because
+#   # it is only an example; remove the comment markers and set your own endpoint/key.
+#   - name: "azure-gpt4"
+#     disabled: true
+#     base-url: "https://example.openai.azure.com"
+#     api-type: "azure-openai"
+#     api-version: "2025-04-01-preview"
+#     deployment: "prod-gpt-4-1"
+#     path-mode: "deployment"
+#     auth-type: "api-key"
+#     include-usage: true
+#     api-key-entries:
+#       - api-key: "${AZURE_OPENAI_API_KEY}"
+#     models:
+#       - name: "prod-gpt-4-1"
+#         alias: "azure-gpt-4.1"
+#
+#   # Azure OpenAI v1 path mode example. api-version is optional for GA v1 usage;
+#   # set api-version: "preview" for preview v1 APIs when required by Azure.
+#   - name: "azure-v1"
+#     disabled: true
+#     base-url: "https://example.openai.azure.com"
+#     api-type: "azure-openai"
+#     path-mode: "v1"
+#     auth-type: "api-key"
+#     api-key-entries:
+#       - api-key: "${AZURE_OPENAI_API_KEY}"
+#     models:
+#       - name: "prod-gpt-4-1"
+#         alias: "azure-v1-gpt-4.1"
 
 # Vertex API keys (Vertex-compatible endpoints, base-url is optional)
 # vertex-api-key:

--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -62,13 +62,14 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 	authHeader := r.Header.Get("Authorization")
 	authHeaderGoogle := r.Header.Get("X-Goog-Api-Key")
 	authHeaderAnthropic := r.Header.Get("X-Api-Key")
+	authHeaderAzure := r.Header.Get("api-key")
 	queryKey := ""
 	queryAuthToken := ""
 	if r.URL != nil {
 		queryKey = r.URL.Query().Get("key")
 		queryAuthToken = r.URL.Query().Get("auth_token")
 	}
-	if authHeader == "" && authHeaderGoogle == "" && authHeaderAnthropic == "" && queryKey == "" && queryAuthToken == "" {
+	if authHeader == "" && authHeaderGoogle == "" && authHeaderAnthropic == "" && authHeaderAzure == "" && queryKey == "" && queryAuthToken == "" {
 		return nil, sdkaccess.NewNoCredentialsError()
 	}
 
@@ -81,6 +82,7 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 		{apiKey, "authorization"},
 		{authHeaderGoogle, "x-goog-api-key"},
 		{authHeaderAnthropic, "x-api-key"},
+		{authHeaderAzure, "api-key"},
 		{queryKey, "query-key"},
 		{queryAuthToken, "query-auth-token"},
 	}

--- a/internal/access/config_access/provider_test.go
+++ b/internal/access/config_access/provider_test.go
@@ -1,0 +1,88 @@
+package configaccess
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestProviderAuthenticateAcceptsConfiguredKeySources(t *testing.T) {
+	const configuredKey = "configured-key"
+
+	tests := []struct {
+		name       string
+		configure  func(*http.Request)
+		wantSource string
+	}{
+		{
+			name: "authorization bearer",
+			configure: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer "+configuredKey)
+			},
+			wantSource: "authorization",
+		},
+		{
+			name: "x-goog-api-key",
+			configure: func(r *http.Request) {
+				r.Header.Set("X-Goog-Api-Key", configuredKey)
+			},
+			wantSource: "x-goog-api-key",
+		},
+		{
+			name: "x-api-key",
+			configure: func(r *http.Request) {
+				r.Header.Set("X-Api-Key", configuredKey)
+			},
+			wantSource: "x-api-key",
+		},
+		{
+			name: "api-key",
+			configure: func(r *http.Request) {
+				r.Header.Set("api-key", configuredKey)
+			},
+			wantSource: "api-key",
+		},
+		{
+			name: "query key",
+			configure: func(r *http.Request) {
+				query := r.URL.Query()
+				query.Set("key", configuredKey)
+				r.URL.RawQuery = query.Encode()
+			},
+			wantSource: "query-key",
+		},
+		{
+			name: "query auth_token",
+			configure: func(r *http.Request) {
+				query := r.URL.Query()
+				query.Set("auth_token", configuredKey)
+				r.URL.RawQuery = query.Encode()
+			},
+			wantSource: "query-auth-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request, err := http.NewRequest(http.MethodGet, "https://example.test/v1/models", nil)
+			if err != nil {
+				t.Fatalf("NewRequest() error = %v", err)
+			}
+			tt.configure(request)
+
+			result, authErr := newProvider("", []string{configuredKey}).Authenticate(context.Background(), request)
+			if authErr != nil {
+				t.Fatalf("Authenticate() authErr = %v", authErr)
+			}
+			if result == nil {
+				t.Fatal("Authenticate() result is nil")
+			}
+			if result.Principal != configuredKey {
+				t.Fatalf("Authenticate() principal = %q, want %q", result.Principal, configuredKey)
+			}
+			if got := result.Metadata["source"]; got != tt.wantSource {
+				t.Fatalf("Authenticate() source = %q, want %q", got, tt.wantSource)
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/azureopenai"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/claude"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/gemini"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai"
@@ -373,10 +374,19 @@ func (s *Server) setupRoutes() {
 
 	s.engine.GET("/management.html", s.serveManagementControlPanel)
 	openaiHandlers := openai.NewOpenAIAPIHandler(s.handlers)
+	azureOpenAIHandlers := azureopenai.NewAzureOpenAIAPIHandler(s.handlers)
 	geminiHandlers := gemini.NewGeminiAPIHandler(s.handlers)
 	geminiCLIHandlers := gemini.NewGeminiCLIAPIHandler(s.handlers)
 	claudeCodeHandlers := claude.NewClaudeCodeAPIHandler(s.handlers)
 	openaiResponsesHandlers := openai.NewOpenAIResponsesAPIHandler(s.handlers)
+
+	// Azure OpenAI client-facing API routes
+	azureOpenAI := s.engine.Group("/openai")
+	azureOpenAI.Use(AuthMiddleware(s.accessManager))
+	{
+		azureOpenAI.POST("/deployments/:deployment/chat/completions", azureOpenAIHandlers.DeploymentChatCompletions)
+		azureOpenAI.POST("/v1/chat/completions", azureOpenAIHandlers.ChatCompletions)
+	}
 
 	// OpenAI compatible API routes
 	v1 := s.engine.Group("/v1")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -554,6 +554,25 @@ type OpenAICompatibility struct {
 	// BaseURL is the base URL for the external OpenAI-compatible API endpoint.
 	BaseURL string `yaml:"base-url" json:"base-url"`
 
+	// APIType selects provider-specific request semantics for compatible configurations.
+	// Empty uses generic OpenAI-compatible behavior; "azure-openai" uses Azure request semantics.
+	APIType string `yaml:"api-type,omitempty" json:"api-type,omitempty"`
+
+	// APIVersion is appended as the api-version query parameter for Azure OpenAI requests.
+	APIVersion string `yaml:"api-version,omitempty" json:"api-version,omitempty"`
+
+	// Deployment is the Azure OpenAI deployment identifier used by deployment path mode.
+	Deployment string `yaml:"deployment,omitempty" json:"deployment,omitempty"`
+
+	// PathMode selects the Azure OpenAI URL shape: "deployment" or "v1".
+	PathMode string `yaml:"path-mode,omitempty" json:"path-mode,omitempty"`
+
+	// AuthType selects Azure OpenAI authentication semantics: "api-key" or "aad".
+	AuthType string `yaml:"auth-type,omitempty" json:"auth-type,omitempty"`
+
+	// IncludeUsage controls whether stream_options.include_usage is requested for streams.
+	IncludeUsage *bool `yaml:"include-usage,omitempty" json:"include-usage,omitempty"`
+
 	// APIKeyEntries defines API keys with optional per-key proxy configuration.
 	APIKeyEntries []OpenAICompatibilityAPIKey `yaml:"api-key-entries,omitempty" json:"api-key-entries,omitempty"`
 
@@ -565,6 +584,46 @@ type OpenAICompatibility struct {
 
 	// DisableCooling disables auth/model cooldown scheduling for this provider when true.
 	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
+}
+
+// OpenAICompatibilityAPIKey represents an API key configuration with optional proxy setting.
+func (c *OpenAICompatibility) UnmarshalYAML(value *yaml.Node) error {
+	type plain OpenAICompatibility
+	var out plain
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	var aliases struct {
+		APIType      string `yaml:"api_type"`
+		APIVersion   string `yaml:"api_version"`
+		Deployment   string `yaml:"deployment_id"`
+		PathMode     string `yaml:"path_mode"`
+		AuthType     string `yaml:"auth_type"`
+		IncludeUsage *bool  `yaml:"include_usage"`
+	}
+	if err := value.Decode(&aliases); err != nil {
+		return err
+	}
+	if out.APIType == "" {
+		out.APIType = aliases.APIType
+	}
+	if out.APIVersion == "" {
+		out.APIVersion = aliases.APIVersion
+	}
+	if out.Deployment == "" {
+		out.Deployment = aliases.Deployment
+	}
+	if out.PathMode == "" {
+		out.PathMode = aliases.PathMode
+	}
+	if out.AuthType == "" {
+		out.AuthType = aliases.AuthType
+	}
+	if out.IncludeUsage == nil {
+		out.IncludeUsage = aliases.IncludeUsage
+	}
+	*c = OpenAICompatibility(out)
+	return nil
 }
 
 // OpenAICompatibilityAPIKey represents an API key configuration with optional proxy setting.

--- a/internal/config/openai_compatibility_test.go
+++ b/internal/config/openai_compatibility_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestOpenAICompatibilityUnmarshalAzureSnakeCaseAliases(t *testing.T) {
+	var cfg Config
+	input := []byte(`openai-compatibility:
+  - name: azure
+    base-url: https://example.openai.azure.com
+    api_type: azure-openai
+    api_version: 2025-04-01-preview
+    deployment_id: prod-gpt-4-1
+    path_mode: deployment
+    auth_type: aad
+    include_usage: false
+    api-key-entries:
+      - api-key: token
+    models:
+      - name: prod-gpt-4-1
+        alias: azure-gpt-4.1
+`)
+
+	if err := yaml.Unmarshal(input, &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if len(cfg.OpenAICompatibility) != 1 {
+		t.Fatalf("OpenAICompatibility length = %d", len(cfg.OpenAICompatibility))
+	}
+	compat := cfg.OpenAICompatibility[0]
+	if compat.APIType != "azure-openai" {
+		t.Fatalf("APIType = %q", compat.APIType)
+	}
+	if compat.APIVersion != "2025-04-01-preview" {
+		t.Fatalf("APIVersion = %q", compat.APIVersion)
+	}
+	if compat.Deployment != "prod-gpt-4-1" {
+		t.Fatalf("Deployment = %q", compat.Deployment)
+	}
+	if compat.PathMode != "deployment" {
+		t.Fatalf("PathMode = %q", compat.PathMode)
+	}
+	if compat.AuthType != "aad" {
+		t.Fatalf("AuthType = %q", compat.AuthType)
+	}
+	if compat.IncludeUsage == nil || *compat.IncludeUsage {
+		t.Fatalf("IncludeUsage = %v", compat.IncludeUsage)
+	}
+}

--- a/internal/runtime/executor/azure_openai_executor.go
+++ b/internal/runtime/executor/azure_openai_executor.go
@@ -1,0 +1,542 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	azureOpenAIProvider           = "azure-openai"
+	azureOpenAIUserAgent          = "cli-proxy-azure-openai"
+	azureOpenAIPathModeDeployment = "deployment"
+	azureOpenAIPathModeV1         = "v1"
+	azureOpenAIAuthTypeAPIKey     = "api-key"
+	azureOpenAIAuthTypeAAD        = "aad"
+)
+
+type AzureOpenAIExecutor struct {
+	provider string
+	cfg      *config.Config
+}
+
+type azureOpenAIOptions struct {
+	Endpoint     string
+	APIVersion   string
+	Deployment   string
+	PathMode     string
+	AuthType     string
+	IncludeUsage bool
+	APIKey       string
+	AADToken     string
+}
+
+func NewAzureOpenAIExecutor(provider string, cfg *config.Config) *AzureOpenAIExecutor {
+	if strings.TrimSpace(provider) == "" {
+		provider = azureOpenAIProvider
+	}
+	return &AzureOpenAIExecutor{provider: provider, cfg: cfg}
+}
+
+func (e *AzureOpenAIExecutor) Identifier() string { return e.provider }
+
+func (e *AzureOpenAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	reporter := helps.NewUsageReporter(ctx, e.Identifier(), baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	azOpts := e.resolveOptions(auth)
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("openai")
+	translated, deployment, err := e.translateChatPayload(ctx, req, opts, baseModel, from, to, azOpts, false)
+	if err != nil {
+		return resp, err
+	}
+	azOpts.Deployment = deployment
+	reporter.SetTranslatedReasoningEffort(translated, to.String())
+
+	requestURL, err := buildAzureChatCompletionsURL(azOpts)
+	if err != nil {
+		return resp, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(translated))
+	if err != nil {
+		return resp, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("User-Agent", azureOpenAIUserAgent)
+	e.applyHeaders(httpReq, auth, azOpts)
+	e.recordRequest(ctx, auth, requestURL, httpReq.Header, translated)
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("azure openai executor: close response body error: %v", errClose)
+		}
+	}()
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	helps.AppendAPIResponseChunk(ctx, e.cfg, body)
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), body))
+		err = statusErr{code: httpResp.StatusCode, msg: string(body)}
+		return resp, err
+	}
+	reporter.Publish(ctx, helps.ParseOpenAIUsage(body))
+	reporter.EnsurePublished(ctx)
+	var param any
+	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, body, &param)
+	return cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}, nil
+}
+
+func (e *AzureOpenAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	reporter := helps.NewUsageReporter(ctx, e.Identifier(), baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	azOpts := e.resolveOptions(auth)
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("openai")
+	translated, deployment, err := e.translateChatPayload(ctx, req, opts, baseModel, from, to, azOpts, true)
+	if err != nil {
+		return nil, err
+	}
+	azOpts.Deployment = deployment
+	reporter.SetTranslatedReasoningEffort(translated, to.String())
+
+	requestURL, err := buildAzureChatCompletionsURL(azOpts)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(translated))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("User-Agent", azureOpenAIUserAgent)
+	httpReq.Header.Set("Accept", "text/event-stream")
+	httpReq.Header.Set("Cache-Control", "no-cache")
+	e.applyHeaders(httpReq, auth, azOpts)
+	e.recordRequest(ctx, auth, requestURL, httpReq.Header, translated)
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return nil, err
+	}
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("azure openai executor: close response body error: %v", errClose)
+		}
+		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return nil, err
+	}
+
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("azure openai executor: close response body error: %v", errClose)
+			}
+		}()
+		scanner := bufio.NewScanner(httpResp.Body)
+		scanner.Buffer(nil, 52_428_800)
+		var param any
+		seenDone := false
+		streamFailed := false
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+			if detail, ok := helps.ParseOpenAIStreamUsage(line); ok {
+				reporter.Publish(ctx, detail)
+			}
+			trimmedLine := bytes.TrimSpace(line)
+			if len(trimmedLine) == 0 {
+				continue
+			}
+			if !bytes.HasPrefix(trimmedLine, []byte("data:")) {
+				if bytes.HasPrefix(trimmedLine, []byte(":")) || bytes.HasPrefix(trimmedLine, []byte("event:")) ||
+					bytes.HasPrefix(trimmedLine, []byte("id:")) || bytes.HasPrefix(trimmedLine, []byte("retry:")) {
+					continue
+				}
+				if bytes.HasPrefix(trimmedLine, []byte("{")) || bytes.HasPrefix(trimmedLine, []byte("[")) {
+					streamFailed = true
+					streamErr := statusErr{code: http.StatusBadGateway, msg: string(trimmedLine)}
+					helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+					reporter.PublishFailure(ctx, streamErr)
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+					case <-ctx.Done():
+					}
+					return
+				}
+				continue
+			}
+
+			dataPayload := bytes.TrimSpace(bytes.TrimPrefix(trimmedLine, []byte("data:")))
+			if bytes.Equal(dataPayload, []byte("[DONE]")) {
+				seenDone = true
+			} else if gjson.GetBytes(dataPayload, "error").Exists() {
+				streamFailed = true
+				streamErr := statusErr{code: http.StatusBadGateway, msg: string(dataPayload)}
+				helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+				reporter.PublishFailure(ctx, streamErr)
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+				case <-ctx.Done():
+				}
+				return
+			}
+			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, bytes.Clone(trimmedLine), &param)
+			for i := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+		if errScan := scanner.Err(); errScan != nil {
+			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
+			reporter.PublishFailure(ctx, errScan)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
+			case <-ctx.Done():
+			}
+		} else if !seenDone && !streamFailed {
+			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, []byte("data: [DONE]"), &param)
+			for i := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+		reporter.EnsurePublished(ctx)
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+func (e *AzureOpenAIExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	from := opts.SourceFormat
+	to := sdktranslator.FromString("openai")
+	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+
+	translated, err := thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+
+	enc, err := helps.TokenizerForModel(baseModel)
+	if err != nil {
+		return cliproxyexecutor.Response{}, fmt.Errorf("azure openai executor: tokenizer init failed: %w", err)
+	}
+	count, err := helps.CountOpenAIChatTokens(enc, translated)
+	if err != nil {
+		return cliproxyexecutor.Response{}, fmt.Errorf("azure openai executor: token counting failed: %w", err)
+	}
+
+	usageJSON := helps.BuildOpenAIUsageJSON(count)
+	translatedUsage := sdktranslator.TranslateTokenCount(ctx, to, from, count, usageJSON)
+	return cliproxyexecutor.Response{Payload: translatedUsage}, nil
+}
+
+func (e *AzureOpenAIExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	log.Debugf("azure openai executor: refresh called")
+	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
+		return refreshed, err
+	}
+	return auth, nil
+}
+
+func (e *AzureOpenAIExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
+	if req == nil {
+		return nil
+	}
+	e.applyHeaders(req, auth, e.resolveOptions(auth))
+	return nil
+}
+
+func (e *AzureOpenAIExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("azure openai executor: request is nil")
+	}
+	if ctx == nil {
+		ctx = req.Context()
+	}
+	httpReq := req.WithContext(ctx)
+	if err := e.PrepareRequest(httpReq, auth); err != nil {
+		return nil, err
+	}
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	return httpClient.Do(httpReq)
+}
+
+func (e *AzureOpenAIExecutor) translateChatPayload(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, baseModel string, from sdktranslator.Format, to sdktranslator.Format, azOpts azureOpenAIOptions, stream bool) ([]byte, string, error) {
+	originalPayloadSource := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayloadSource = opts.OriginalRequest
+	}
+	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayloadSource, stream)
+	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
+	translated, err := thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return nil, "", err
+	}
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	requestPath := helps.PayloadRequestPath(opts)
+	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
+	deployment := firstNonEmpty(azOpts.Deployment, baseModel, gjson.GetBytes(translated, "model").String())
+	if deployment == "" {
+		return nil, "", statusErr{code: http.StatusBadRequest, msg: "missing azure openai deployment"}
+	}
+	patched, err := patchAzureOpenAIRequestBody(translated, deployment, stream, azOpts.IncludeUsage)
+	if err != nil {
+		return nil, "", err
+	}
+	return patched, deployment, nil
+}
+
+func (e *AzureOpenAIExecutor) resolveOptions(auth *cliproxyauth.Auth) azureOpenAIOptions {
+	opts := azureOpenAIOptions{PathMode: azureOpenAIPathModeDeployment, IncludeUsage: true}
+	if compat := e.resolveCompatConfig(auth); compat != nil {
+		opts.Endpoint = strings.TrimSpace(compat.BaseURL)
+		opts.APIVersion = strings.TrimSpace(compat.APIVersion)
+		if len(compat.APIKeyEntries) > 0 {
+			opts.APIKey = strings.TrimSpace(compat.APIKeyEntries[0].APIKey)
+		}
+	}
+	if auth != nil && auth.Attributes != nil {
+		attrs := auth.Attributes
+		opts.Endpoint = firstNonEmpty(attrs["endpoint"], attrs["base_url"], opts.Endpoint)
+		opts.APIVersion = firstNonEmpty(attrs["api_version"], attrs["api-version"], opts.APIVersion)
+		opts.Deployment = firstNonEmpty(attrs["deployment_id"], attrs["deployment"], attrs["azure_deployment"])
+		opts.PathMode = strings.ToLower(firstNonEmpty(attrs["path_mode"], attrs["path-mode"], opts.PathMode))
+		opts.AuthType = strings.ToLower(strings.TrimSpace(attrs["auth_type"]))
+		opts.APIKey = firstNonEmpty(attrs["api_key"], opts.APIKey)
+		opts.AADToken = firstNonEmpty(attrs["aad_token"], attrs["access_token"], attrs["bearer_token"])
+		if includeUsage, ok := parseAzureBoolAttr(attrs, "include_usage"); ok {
+			opts.IncludeUsage = includeUsage
+		}
+	}
+	if opts.AuthType == "" {
+		switch {
+		case opts.APIKey != "":
+			opts.AuthType = azureOpenAIAuthTypeAPIKey
+		case opts.AADToken != "":
+			opts.AuthType = azureOpenAIAuthTypeAAD
+		default:
+			opts.AuthType = azureOpenAIAuthTypeAPIKey
+		}
+	}
+	if opts.AuthType == azureOpenAIAuthTypeAAD && opts.AADToken == "" {
+		opts.AADToken = opts.APIKey
+	}
+	return opts
+}
+
+func (e *AzureOpenAIExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *config.OpenAICompatibility {
+	if auth == nil || e.cfg == nil {
+		return nil
+	}
+	candidates := make([]string, 0, 3)
+	if auth.Attributes != nil {
+		if v := strings.TrimSpace(auth.Attributes["compat_name"]); v != "" {
+			candidates = append(candidates, v)
+		}
+		if v := strings.TrimSpace(auth.Attributes["provider_key"]); v != "" {
+			candidates = append(candidates, v)
+		}
+	}
+	if v := strings.TrimSpace(auth.Provider); v != "" {
+		candidates = append(candidates, v)
+	}
+	for i := range e.cfg.OpenAICompatibility {
+		compat := &e.cfg.OpenAICompatibility[i]
+		if compat.Disabled {
+			continue
+		}
+		for _, candidate := range candidates {
+			if candidate != "" && strings.EqualFold(strings.TrimSpace(candidate), compat.Name) {
+				return compat
+			}
+		}
+	}
+	return nil
+}
+
+func (e *AzureOpenAIExecutor) applyHeaders(req *http.Request, auth *cliproxyauth.Auth, opts azureOpenAIOptions) {
+	if req == nil {
+		return
+	}
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(req, attrs)
+	switch strings.ToLower(strings.TrimSpace(opts.AuthType)) {
+	case azureOpenAIAuthTypeAAD:
+		req.Header.Del("api-key")
+		if opts.AADToken != "" {
+			req.Header.Set("Authorization", "Bearer "+opts.AADToken)
+		}
+	default:
+		req.Header.Del("Authorization")
+		if opts.APIKey != "" {
+			req.Header.Set("api-key", opts.APIKey)
+		}
+	}
+}
+
+func (e *AzureOpenAIExecutor) recordRequest(ctx context.Context, auth *cliproxyauth.Auth, requestURL string, headers http.Header, body []byte) {
+	authID, authLabel, authType, authValue := authLogFields(auth)
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       requestURL,
+		Method:    http.MethodPost,
+		Headers:   headers.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+}
+
+func buildAzureChatCompletionsURL(opts azureOpenAIOptions) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(opts.Endpoint))
+	if err != nil {
+		return "", fmt.Errorf("azure openai executor: invalid endpoint: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("azure openai executor: invalid endpoint")
+	}
+	pathMode := strings.ToLower(strings.TrimSpace(opts.PathMode))
+	if pathMode == "" {
+		pathMode = azureOpenAIPathModeDeployment
+	}
+	basePath := strings.TrimRight(parsed.Path, "/")
+	baseEscapedPath := strings.TrimRight(parsed.EscapedPath(), "/")
+	switch pathMode {
+	case azureOpenAIPathModeDeployment:
+		deployment := strings.TrimSpace(opts.Deployment)
+		if deployment == "" {
+			return "", statusErr{code: http.StatusBadRequest, msg: "missing azure openai deployment"}
+		}
+		if strings.TrimSpace(opts.APIVersion) == "" {
+			return "", statusErr{code: http.StatusBadRequest, msg: "missing azure openai api-version"}
+		}
+		parsed.Path = basePath + "/openai/deployments/" + deployment + "/chat/completions"
+		parsed.RawPath = baseEscapedPath + "/openai/deployments/" + url.PathEscape(deployment) + "/chat/completions"
+		query := parsed.Query()
+		query.Set("api-version", opts.APIVersion)
+		parsed.RawQuery = query.Encode()
+	case azureOpenAIPathModeV1:
+		parsed.Path = basePath + "/openai/v1/chat/completions"
+		parsed.RawPath = baseEscapedPath + "/openai/v1/chat/completions"
+		if strings.TrimSpace(opts.APIVersion) != "" {
+			query := parsed.Query()
+			query.Set("api-version", opts.APIVersion)
+			parsed.RawQuery = query.Encode()
+		}
+	default:
+		return "", statusErr{code: http.StatusBadRequest, msg: "unsupported azure openai path_mode: " + pathMode}
+	}
+	return parsed.String(), nil
+}
+
+func azureOpenAIChatCompletionsURL(baseURL, deploymentID, apiVersion string) (string, error) {
+	return buildAzureChatCompletionsURL(azureOpenAIOptions{
+		Endpoint:   baseURL,
+		APIVersion: apiVersion,
+		Deployment: deploymentID,
+		PathMode:   azureOpenAIPathModeDeployment,
+	})
+}
+
+func patchAzureOpenAIRequestBody(body []byte, deployment string, stream bool, includeUsage bool) ([]byte, error) {
+	if !gjson.ParseBytes(body).IsObject() {
+		return nil, statusErr{code: http.StatusBadRequest, msg: "azure openai request body must be a json object"}
+	}
+	patched, err := sjson.SetBytes(body, "model", deployment)
+	if err != nil {
+		return nil, err
+	}
+	if stream && includeUsage {
+		patched, err = sjson.SetBytes(patched, "stream_options.include_usage", true)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return patched, nil
+}
+
+func parseAzureBoolAttr(attrs map[string]string, key string) (bool, bool) {
+	value, ok := attrs[key]
+	if !ok {
+		return false, false
+	}
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true, true
+	case "0", "false", "no", "off":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func authLogFields(auth *cliproxyauth.Auth) (authID, authLabel, authType, authValue string) {
+	if auth == nil {
+		return "", "", "", ""
+	}
+	authID = auth.ID
+	authLabel = auth.Label
+	authType, authValue = auth.AccountInfo()
+	return authID, authLabel, authType, authValue
+}

--- a/internal/runtime/executor/azure_openai_executor_test.go
+++ b/internal/runtime/executor/azure_openai_executor_test.go
@@ -1,0 +1,381 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+const azureTestChatCompletion = `{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+
+func TestAzureOpenAIChatCompletionsURL(t *testing.T) {
+	got, err := azureOpenAIChatCompletionsURL("https://example.openai.azure.com/base?existing=1", "deploy/name", "2025-04-01-preview")
+	if err != nil {
+		t.Fatalf("azureOpenAIChatCompletionsURL error: %v", err)
+	}
+	want := "https://example.openai.azure.com/base/openai/deployments/deploy%2Fname/chat/completions?api-version=2025-04-01-preview&existing=1"
+	if got != want {
+		t.Fatalf("url = %q, want %q", got, want)
+	}
+}
+
+func TestAzureOpenAIChatCompletionsURLV1(t *testing.T) {
+	got, err := buildAzureChatCompletionsURL(azureOpenAIOptions{
+		Endpoint: "https://example.openai.azure.com/base?existing=1",
+		PathMode: azureOpenAIPathModeV1,
+	})
+	if err != nil {
+		t.Fatalf("buildAzureChatCompletionsURL v1 error: %v", err)
+	}
+	want := "https://example.openai.azure.com/base/openai/v1/chat/completions?existing=1"
+	if got != want {
+		t.Fatalf("url = %q, want %q", got, want)
+	}
+}
+
+func TestAzureOpenAIChatCompletionsURLValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		opts azureOpenAIOptions
+	}{
+		{name: "missing endpoint", opts: azureOpenAIOptions{Deployment: "dep", APIVersion: "2025-04-01-preview"}},
+		{name: "missing api version", opts: azureOpenAIOptions{Endpoint: "https://example.openai.azure.com", Deployment: "dep", PathMode: azureOpenAIPathModeDeployment}},
+		{name: "unsupported path mode", opts: azureOpenAIOptions{Endpoint: "https://example.openai.azure.com", Deployment: "dep", APIVersion: "2025-04-01-preview", PathMode: "bad"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := buildAzureChatCompletionsURL(tt.opts); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}
+
+func TestAzureOpenAIExecutorUsesDeploymentURLAndAPIKey(t *testing.T) {
+	var gotPath string
+	var gotQuery string
+	var gotAPIKey string
+	var gotAuthorization string
+	var gotCustomHeader string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		gotQuery = r.URL.Query().Get("api-version")
+		gotAPIKey = r.Header.Get("api-key")
+		gotAuthorization = r.Header.Get("Authorization")
+		gotCustomHeader = r.Header.Get("X-Custom-Header")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(azureTestChatCompletion))
+	}))
+	defer server.Close()
+
+	executor := NewAzureOpenAIExecutor("azure-openai", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":               server.URL,
+		"api_version":            "2025-04-01-preview",
+		"api_key":                "azure-key",
+		"deployment":             "deployment-one",
+		"header:X-Custom-Header": "custom-value",
+	}}
+	payload := []byte(`{"model":"ignored-alias","messages":[{"role":"user","content":"hi"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "alias-model",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/openai/deployments/deployment-one/chat/completions" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotQuery != "2025-04-01-preview" {
+		t.Fatalf("api-version = %q", gotQuery)
+	}
+	if gotAPIKey != "azure-key" {
+		t.Fatalf("api-key = %q", gotAPIKey)
+	}
+	if gotAuthorization != "" {
+		t.Fatalf("Authorization should be empty, got %q", gotAuthorization)
+	}
+	if gotCustomHeader != "custom-value" {
+		t.Fatalf("X-Custom-Header = %q", gotCustomHeader)
+	}
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "deployment-one" {
+		t.Fatalf("body model = %q, want deployment-one", gotModel)
+	}
+}
+
+func TestAzureOpenAIExecutorUsesAADBearerFromAPIKeyWhenAuthTypeAAD(t *testing.T) {
+	var gotAuthorization string
+	var gotAPIKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthorization = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("api-key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(azureTestChatCompletion))
+	}))
+	defer server.Close()
+
+	executor := NewAzureOpenAIExecutor("azure-openai", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":    server.URL,
+		"api_version": "2025-04-01-preview",
+		"api_key":     "aad-token",
+		"auth_type":   "aad",
+	}}
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deployment-one",
+		Payload: []byte(`{"model":"deployment-one","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotAuthorization != "Bearer aad-token" {
+		t.Fatalf("Authorization = %q", gotAuthorization)
+	}
+	if gotAPIKey != "" {
+		t.Fatalf("api-key should be empty, got %q", gotAPIKey)
+	}
+}
+
+func TestAzureOpenAIExecutorUsesV1PathWithoutAPIVersion(t *testing.T) {
+	var gotPath string
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(azureTestChatCompletion))
+	}))
+	defer server.Close()
+
+	executor := NewAzureOpenAIExecutor("azure-openai", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":  server.URL,
+		"api_key":   "azure-key",
+		"path_mode": "v1",
+	}}
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deployment-one",
+		Payload: []byte(`{"model":"deployment-one","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/openai/v1/chat/completions" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotQuery != "" {
+		t.Fatalf("query = %q", gotQuery)
+	}
+}
+
+func TestAzureOpenAIExecutorStreamsSSEAndRequestsUsage(t *testing.T) {
+	var gotAccept string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAccept = r.Header.Get("Accept")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewAzureOpenAIExecutor("azure-openai", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":    server.URL,
+		"api_version": "2025-04-01-preview",
+		"api_key":     "azure-key",
+	}}
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deployment-one",
+		Payload: []byte(`{"model":"deployment-one","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai"), Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	var chunks []string
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		chunks = append(chunks, string(chunk.Payload))
+	}
+	if gotAccept != "text/event-stream" {
+		t.Fatalf("Accept = %q", gotAccept)
+	}
+	if !gjson.GetBytes(gotBody, "stream_options.include_usage").Bool() {
+		t.Fatalf("stream_options.include_usage not set in body: %s", string(gotBody))
+	}
+	if len(chunks) == 0 || !strings.Contains(strings.Join(chunks, ""), "ok") {
+		t.Fatalf("expected translated SSE chunks, got %#v", chunks)
+	}
+}
+
+func TestAzureOpenAIExecutorStreamCanDisableUsage(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewAzureOpenAIExecutor("azure-openai", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":      server.URL,
+		"api_version":   "2025-04-01-preview",
+		"api_key":       "azure-key",
+		"include_usage": "false",
+	}}
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deployment-one",
+		Payload: []byte(`{"model":"deployment-one","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai"), Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+	if gjson.GetBytes(gotBody, "stream_options.include_usage").Exists() {
+		t.Fatalf("stream_options.include_usage should not be set in body: %s", string(gotBody))
+	}
+}
+
+func TestAzureOpenAIChatCompletionsURLPreservesEndpointQuerySlash(t *testing.T) {
+	got, err := buildAzureChatCompletionsURL(azureOpenAIOptions{
+		Endpoint:   "https://example.openai.azure.com/base?existing=/",
+		Deployment: "deployment-one",
+		APIVersion: "2025-04-01-preview",
+		PathMode:   azureOpenAIPathModeDeployment,
+	})
+	if err != nil {
+		t.Fatalf("buildAzureChatCompletionsURL error: %v", err)
+	}
+	want := "https://example.openai.azure.com/base/openai/deployments/deployment-one/chat/completions?api-version=2025-04-01-preview&existing=%2F"
+	if got != want {
+		t.Fatalf("url = %q, want %q", got, want)
+	}
+}
+
+func TestAzureOpenAIExecutorStreamDoesNotEmitExtraPayloadAfterDone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewAzureOpenAIExecutor("azure-openai", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":    server.URL,
+		"api_version": "2025-04-01-preview",
+		"api_key":     "azure-key",
+	}}
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deployment-one",
+		Payload: []byte(`{"model":"deployment-one","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai"), Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	var chunks []string
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		chunks = append(chunks, string(chunk.Payload))
+	}
+	if len(chunks) != 1 || !strings.Contains(chunks[0], "ok") {
+		t.Fatalf("chunks = %#v", chunks)
+	}
+}
+
+func TestAzureOpenAIExecutorStreamDataErrorReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"Rate limit exceeded\"}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewAzureOpenAIExecutor("azure-openai", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":    server.URL,
+		"api_version": "2025-04-01-preview",
+		"api_key":     "azure-key",
+	}}
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deployment-one",
+		Payload: []byte(`{"model":"deployment-one","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai"), Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	var gotErr error
+	var joined strings.Builder
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			gotErr = chunk.Err
+			continue
+		}
+		joined.Write(chunk.Payload)
+	}
+	if gotErr == nil {
+		t.Fatalf("expected stream error")
+	}
+	if !strings.Contains(gotErr.Error(), "rate_limit_exceeded") {
+		t.Fatalf("error = %q", gotErr.Error())
+	}
+	if strings.Contains(joined.String(), "[DONE]") {
+		t.Fatalf("unexpected synthetic DONE after error: %q", joined.String())
+	}
+}
+
+func TestAzureOpenAIExecutorPreservesErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":"rate_limit_exceeded","message":"Rate limit exceeded","type":"too_many_requests","inner_error":{"code":"TokensPerMinuteExceeded"}}}`))
+	}))
+	defer server.Close()
+
+	executor := NewAzureOpenAIExecutor("azure-openai", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":    server.URL,
+		"api_version": "2025-04-01-preview",
+		"api_key":     "azure-key",
+	}}
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deployment-one",
+		Payload: []byte(`{"model":"deployment-one","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	errText := err.Error()
+	for _, want := range []string{"rate_limit_exceeded", "Rate limit exceeded", "TokensPerMinuteExceeded"} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error %q does not contain %q", errText, want)
+		}
+	}
+}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -227,6 +227,11 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 			providerName = "openai-compatibility"
 		}
 		base := strings.TrimSpace(compat.BaseURL)
+		apiType := strings.TrimSpace(compat.APIType)
+		apiVersion := strings.TrimSpace(compat.APIVersion)
+		deployment := strings.TrimSpace(compat.Deployment)
+		pathMode := strings.TrimSpace(compat.PathMode)
+		authType := strings.TrimSpace(compat.AuthType)
 		disableCooling := compat.DisableCooling
 
 		// Handle new APIKeyEntries format (preferred)
@@ -242,6 +247,24 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				"base_url":     base,
 				"compat_name":  compat.Name,
 				"provider_key": providerName,
+			}
+			if apiType != "" {
+				attrs["api_type"] = apiType
+			}
+			if apiVersion != "" {
+				attrs["api_version"] = apiVersion
+			}
+			if deployment != "" {
+				attrs["deployment"] = deployment
+			}
+			if pathMode != "" {
+				attrs["path_mode"] = pathMode
+			}
+			if authType != "" {
+				attrs["auth_type"] = authType
+			}
+			if compat.IncludeUsage != nil {
+				attrs["include_usage"] = strconv.FormatBool(*compat.IncludeUsage)
 			}
 			metadata := map[string]any{}
 			if disableCooling {
@@ -284,6 +307,24 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				"base_url":     base,
 				"compat_name":  compat.Name,
 				"provider_key": providerName,
+			}
+			if apiType != "" {
+				attrs["api_type"] = apiType
+			}
+			if apiVersion != "" {
+				attrs["api_version"] = apiVersion
+			}
+			if deployment != "" {
+				attrs["deployment"] = deployment
+			}
+			if pathMode != "" {
+				attrs["path_mode"] = pathMode
+			}
+			if authType != "" {
+				attrs["auth_type"] = authType
+			}
+			if compat.IncludeUsage != nil {
+				attrs["include_usage"] = strconv.FormatBool(*compat.IncludeUsage)
 			}
 			metadata := map[string]any{}
 			if disableCooling {

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -400,6 +400,56 @@ func TestConfigSynthesizer_OpenAICompat(t *testing.T) {
 	}
 }
 
+func TestConfigSynthesizer_OpenAICompat_AzureAttrs(t *testing.T) {
+	includeUsage := false
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			OpenAICompatibility: []config.OpenAICompatibility{
+				{
+					Name:         "AzureGPT4",
+					BaseURL:      "https://example.openai.azure.com",
+					APIType:      "azure-openai",
+					APIVersion:   "2025-04-01-preview",
+					Deployment:   "prod-gpt-4-1",
+					PathMode:     "deployment",
+					AuthType:     "api-key",
+					IncludeUsage: &includeUsage,
+					APIKeyEntries: []config.OpenAICompatibilityAPIKey{
+						{APIKey: "azure-key"},
+					},
+				},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth, got %d", len(auths))
+	}
+	attrs := auths[0].Attributes
+	wantAttrs := map[string]string{
+		"base_url":      "https://example.openai.azure.com",
+		"api_type":      "azure-openai",
+		"api_version":   "2025-04-01-preview",
+		"deployment":    "prod-gpt-4-1",
+		"path_mode":     "deployment",
+		"auth_type":     "api-key",
+		"include_usage": "false",
+		"api_key":       "azure-key",
+	}
+	for key, want := range wantAttrs {
+		if got := attrs[key]; got != want {
+			t.Fatalf("attrs[%q] = %q, want %q", key, got, want)
+		}
+	}
+}
+
 func TestConfigSynthesizer_VertexCompat(t *testing.T) {
 	synth := NewConfigSynthesizer()
 	ctx := &SynthesisContext{

--- a/sdk/api/handlers/azure_handler_e2e_test.go
+++ b/sdk/api/handlers/azure_handler_e2e_test.go
@@ -1,0 +1,191 @@
+package handlers_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	claudehandlers "github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/claude"
+	openaihandlers "github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/tidwall/gjson"
+)
+
+func TestAzureOpenAIChatCompletionsHandlerRoutesAliasToDeployment(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		provider   = "azure-openai-handler-chat"
+		authID     = "azure-openai-handler-chat-auth"
+		modelAlias = "azure-openai-handler-chat-alias"
+		deployment = "gpt-4o-handler-chat"
+	)
+
+	var gotPath string
+	var gotRawQuery string
+	var gotAPIKey string
+	var gotAuthorization string
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotRawQuery = r.URL.RawQuery
+		gotAPIKey = r.Header.Get("api-key")
+		gotAuthorization = r.Header.Get("Authorization")
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read upstream body: %v", errRead)
+		}
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_handler_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"azure ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer upstream.Close()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(runtimeexecutor.NewAzureOpenAIExecutor(provider, &config.Config{}))
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: provider,
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"base_url":    upstream.URL,
+			"api_version": "2024-10-21",
+			"api_key":     "test-azure-key",
+			"deployment":  deployment,
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelAlias, Type: "openai", UserDefined: true}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := openaihandlers.NewOpenAIAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/chat/completions", h.ChatCompletions)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"`+modelAlias+`","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	wantPath := "/openai/deployments/" + deployment + "/chat/completions"
+	if gotPath != wantPath {
+		t.Fatalf("upstream path = %q, want %q", gotPath, wantPath)
+	}
+	if gotRawQuery != "api-version=2024-10-21" {
+		t.Fatalf("upstream query = %q, want api-version=2024-10-21", gotRawQuery)
+	}
+	if gotAPIKey != "test-azure-key" {
+		t.Fatalf("api-key header = %q, want test-azure-key", gotAPIKey)
+	}
+	if gotAuthorization != "" {
+		t.Fatalf("Authorization header = %q, want empty", gotAuthorization)
+	}
+	if got := gjson.GetBytes(gotBody, "model").String(); got != deployment {
+		t.Fatalf("upstream model = %q, want %q; body=%s", got, deployment, string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "messages.0.content").String(); got != "hi" {
+		t.Fatalf("upstream message content = %q, want hi; body=%s", got, string(gotBody))
+	}
+	if got := gjson.Get(resp.Body.String(), "choices.0.message.content").String(); got != "azure ok" {
+		t.Fatalf("response content = %q, want azure ok; body=%s", got, resp.Body.String())
+	}
+}
+
+func TestAzureOpenAIClaudeMessagesHandlerTranslatesThroughAzure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		provider   = "azure-openai-handler-claude"
+		authID     = "azure-openai-handler-claude-auth"
+		modelAlias = "azure-openai-handler-claude-alias"
+		deployment = "gpt-4o-handler-claude"
+	)
+
+	var gotPath string
+	var gotAPIKey string
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("api-key")
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read upstream body: %v", errRead)
+		}
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_handler_2","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hello from azure"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}}`))
+	}))
+	defer upstream.Close()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(runtimeexecutor.NewAzureOpenAIExecutor(provider, &config.Config{}))
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: provider,
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"base_url":    upstream.URL,
+			"api_version": "2024-10-21",
+			"api_key":     "test-azure-key",
+			"deployment":  deployment,
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelAlias, Type: "claude", UserDefined: true}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := claudehandlers.NewClaudeCodeAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/messages", h.ClaudeMessages)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"`+modelAlias+`","max_tokens":64,"messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	wantPath := "/openai/deployments/" + deployment + "/chat/completions"
+	if gotPath != wantPath {
+		t.Fatalf("upstream path = %q, want %q", gotPath, wantPath)
+	}
+	if gotAPIKey != "test-azure-key" {
+		t.Fatalf("api-key header = %q, want test-azure-key", gotAPIKey)
+	}
+	if got := gjson.GetBytes(gotBody, "model").String(); got != deployment {
+		t.Fatalf("upstream model = %q, want %q; body=%s", got, deployment, string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "messages.0.content").String(); got != "hi" {
+		t.Fatalf("translated upstream content = %q, want hi; body=%s", got, string(gotBody))
+	}
+	if got := gjson.Get(resp.Body.String(), "content.0.text").String(); got != "hello from azure" {
+		t.Fatalf("Claude response text = %q, want hello from azure; body=%s", got, resp.Body.String())
+	}
+	if got := gjson.Get(resp.Body.String(), "type").String(); got != "message" {
+		t.Fatalf("Claude response type = %q, want message; body=%s", got, resp.Body.String())
+	}
+}

--- a/sdk/api/handlers/azureopenai/azure_openai_handlers.go
+++ b/sdk/api/handlers/azureopenai/azure_openai_handlers.go
@@ -1,0 +1,57 @@
+// Package azureopenai provides HTTP handlers for Azure OpenAI client-facing endpoints.
+package azureopenai
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+type AzureOpenAIAPIHandler struct {
+	openAIHandler *openai.OpenAIAPIHandler
+}
+
+func NewAzureOpenAIAPIHandler(apiHandlers *handlers.BaseAPIHandler) *AzureOpenAIAPIHandler {
+	return &AzureOpenAIAPIHandler{openAIHandler: openai.NewOpenAIAPIHandler(apiHandlers)}
+}
+
+func (h *AzureOpenAIAPIHandler) ChatCompletions(c *gin.Context) {
+	h.openAIHandler.ChatCompletions(c)
+}
+
+func (h *AzureOpenAIAPIHandler) DeploymentChatCompletions(c *gin.Context) {
+	deployment := strings.TrimSpace(c.Param("deployment"))
+	if deployment == "" {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{Error: handlers.ErrorDetail{Message: "Missing Azure OpenAI deployment", Type: "invalid_request_error"}})
+		return
+	}
+
+	rawJSON, err := handlers.ReadRequestBody(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{Error: handlers.ErrorDetail{Message: fmt.Sprintf("Invalid request: %v", err), Type: "invalid_request_error"}})
+		return
+	}
+	if !gjson.ParseBytes(rawJSON).IsObject() {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{Error: handlers.ErrorDetail{Message: "Azure OpenAI chat completions request body must be a JSON object", Type: "invalid_request_error"}})
+		return
+	}
+
+	updatedJSON, err := sjson.SetBytes(rawJSON, "model", deployment)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{Error: handlers.ErrorDetail{Message: fmt.Sprintf("Invalid request JSON: %v", err), Type: "invalid_request_error"}})
+		return
+	}
+
+	c.Request.Body = io.NopCloser(bytes.NewReader(updatedJSON))
+	c.Request.ContentLength = int64(len(updatedJSON))
+	c.Request.Header.Del("Content-Encoding")
+	h.openAIHandler.ChatCompletions(c)
+}

--- a/sdk/api/handlers/azureopenai/azure_openai_handlers_test.go
+++ b/sdk/api/handlers/azureopenai/azure_openai_handlers_test.go
@@ -1,0 +1,311 @@
+package azureopenai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/tidwall/gjson"
+)
+
+func TestAzureOpenAIDeploymentChatCompletionsRoutesToOpenAICompat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		provider = "azure-ingress-openai"
+		authID   = "azure-ingress-openai-auth"
+		alias    = "azure-ingress-openai-alias"
+	)
+
+	var gotPath string
+	var gotRawQuery string
+	var gotAuthorization string
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotRawQuery = r.URL.RawQuery
+		gotAuthorization = r.Header.Get("Authorization")
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read upstream body: %v", errRead)
+		}
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_azure_ingress_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"openai ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer upstream.Close()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(runtimeexecutor.NewOpenAICompatExecutor(provider, &config.Config{}))
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: provider,
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"base_url": upstream.URL,
+			"api_key":  "openai-upstream-key",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: alias, Type: "openai", UserDefined: true}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+
+	router := newAzureOpenAITestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/openai/deployments/"+alias+"/chat/completions?api-version=2024-10-21", strings.NewReader(`{"model":"conflicting-client-model","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if gotPath != "/chat/completions" {
+		t.Fatalf("upstream path = %q, want /chat/completions", gotPath)
+	}
+	if gotRawQuery != "" {
+		t.Fatalf("upstream query = %q, want empty", gotRawQuery)
+	}
+	if gotAuthorization != "Bearer openai-upstream-key" {
+		t.Fatalf("Authorization = %q", gotAuthorization)
+	}
+	if got := gjson.GetBytes(gotBody, "model").String(); got != alias {
+		t.Fatalf("upstream model = %q, want %q; body=%s", got, alias, string(gotBody))
+	}
+	if got := gjson.Get(resp.Body.String(), "choices.0.message.content").String(); got != "openai ok" {
+		t.Fatalf("response content = %q, want openai ok; body=%s", got, resp.Body.String())
+	}
+}
+
+func TestAzureOpenAIV1ChatCompletionsRoutesToOpenAICompat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		provider = "azure-ingress-openai-v1"
+		authID   = "azure-ingress-openai-v1-auth"
+		alias    = "azure-ingress-openai-v1-alias"
+	)
+
+	var gotPath string
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read upstream body: %v", errRead)
+		}
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_azure_ingress_2","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"v1 ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer upstream.Close()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(runtimeexecutor.NewOpenAICompatExecutor(provider, &config.Config{}))
+	auth := &coreauth.Auth{ID: authID, Provider: provider, Status: coreauth.StatusActive, Attributes: map[string]string{"base_url": upstream.URL, "api_key": "openai-upstream-key"}}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: alias, Type: "openai", UserDefined: true}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+
+	router := newAzureOpenAITestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions?api-version=preview", strings.NewReader(`{"model":"`+alias+`","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if gotPath != "/chat/completions" {
+		t.Fatalf("upstream path = %q, want /chat/completions", gotPath)
+	}
+	if got := gjson.GetBytes(gotBody, "model").String(); got != alias {
+		t.Fatalf("upstream model = %q, want %q; body=%s", got, alias, string(gotBody))
+	}
+}
+
+func TestAzureOpenAIDeploymentChatCompletionsRoutesToClaude(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		authID = "azure-ingress-claude-auth"
+		alias  = "azure-ingress-claude-alias"
+	)
+
+	var gotPath string
+	var gotAuthorization string
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuthorization = r.Header.Get("Authorization")
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read upstream body: %v", errRead)
+		}
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message_start\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_azure_ingress_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-test\",\"content\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":0}}}\n\n"))
+		_, _ = w.Write([]byte("event: content_block_start\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n"))
+		_, _ = w.Write([]byte("event: content_block_delta\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"claude ok\"}}\n\n"))
+		_, _ = w.Write([]byte("event: message_delta\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":1}}\n\n"))
+		_, _ = w.Write([]byte("event: message_stop\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer upstream.Close()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(runtimeexecutor.NewClaudeExecutor(&config.Config{}))
+	auth := &coreauth.Auth{ID: authID, Provider: "claude", Status: coreauth.StatusActive, Attributes: map[string]string{"base_url": upstream.URL, "api_key": "claude-upstream-key"}}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: alias, Type: "openai", UserDefined: true}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+
+	router := newAzureOpenAITestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/openai/deployments/"+alias+"/chat/completions?api-version=2024-10-21", strings.NewReader(`{"messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if gotPath != "/v1/messages" {
+		t.Fatalf("upstream path = %q, want /v1/messages", gotPath)
+	}
+	if gotAuthorization != "Bearer claude-upstream-key" {
+		t.Fatalf("Authorization = %q", gotAuthorization)
+	}
+	if got := gjson.GetBytes(gotBody, "model").String(); got != alias {
+		t.Fatalf("upstream Claude model = %q, want %q; body=%s", got, alias, string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "messages.0.content.0.text").String(); got != "hi" {
+		t.Fatalf("upstream Claude content = %q, want hi; body=%s", got, string(gotBody))
+	}
+	if got := gjson.Get(resp.Body.String(), "choices.0.message.content").String(); got != "claude ok" {
+		t.Fatalf("OpenAI response content = %q, want claude ok; body=%s", got, resp.Body.String())
+	}
+}
+
+func TestAzureOpenAIV1ChatCompletionsRoutesToClaude(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		authID = "azure-ingress-claude-v1-auth"
+		alias  = "azure-ingress-claude-v1-alias"
+	)
+
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message_start\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_azure_ingress_2\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-test\",\"content\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":0}}}\n\n"))
+		_, _ = w.Write([]byte("event: content_block_start\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n"))
+		_, _ = w.Write([]byte("event: content_block_delta\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"claude v1 ok\"}}\n\n"))
+		_, _ = w.Write([]byte("event: message_delta\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":1}}\n\n"))
+		_, _ = w.Write([]byte("event: message_stop\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer upstream.Close()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(runtimeexecutor.NewClaudeExecutor(&config.Config{}))
+	auth := &coreauth.Auth{ID: authID, Provider: "claude", Status: coreauth.StatusActive, Attributes: map[string]string{"base_url": upstream.URL, "api_key": "claude-upstream-key"}}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: alias, Type: "openai", UserDefined: true}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+
+	router := newAzureOpenAITestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader(`{"model":"`+alias+`","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if gotPath != "/v1/messages" {
+		t.Fatalf("upstream path = %q, want /v1/messages", gotPath)
+	}
+	if got := gjson.Get(resp.Body.String(), "choices.0.message.content").String(); got != "claude v1 ok" {
+		t.Fatalf("OpenAI response content = %q, want claude v1 ok; body=%s", got, resp.Body.String())
+	}
+}
+
+func TestAzureOpenAIDeploymentChatCompletionsStreamsOpenAICompat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		provider = "azure-ingress-openai-stream"
+		authID   = "azure-ingress-openai-stream-auth"
+		alias    = "azure-ingress-openai-stream-alias"
+	)
+
+	var gotRawQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRawQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_stream\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"stream ok\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer upstream.Close()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(runtimeexecutor.NewOpenAICompatExecutor(provider, &config.Config{}))
+	auth := &coreauth.Auth{ID: authID, Provider: provider, Status: coreauth.StatusActive, Attributes: map[string]string{"base_url": upstream.URL, "api_key": "openai-upstream-key"}}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: alias, Type: "openai", UserDefined: true}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+
+	router := newAzureOpenAITestRouter(manager)
+	req := httptest.NewRequest(http.MethodPost, "/openai/deployments/"+alias+"/chat/completions?api-version=2024-10-21", strings.NewReader(`{"messages":[{"role":"user","content":"hi"}],"stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if gotRawQuery != "" {
+		t.Fatalf("upstream query = %q, want empty", gotRawQuery)
+	}
+	if !strings.Contains(resp.Body.String(), "stream ok") {
+		t.Fatalf("stream body missing content: %s", resp.Body.String())
+	}
+}
+
+func newAzureOpenAITestRouter(manager *coreauth.Manager) *gin.Engine {
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewAzureOpenAIAPIHandler(base)
+	router := gin.New()
+	router.POST("/openai/deployments/:deployment/chat/completions", h.DeploymentChatCompletions)
+	router.POST("/openai/v1/chat/completions", h.ChatCompletions)
+	return router
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -381,6 +381,24 @@ func openAICompatInfoFromAuth(a *coreauth.Auth) (providerKey string, compatName 
 	return "", "", false
 }
 
+func isAzureOpenAIAuth(a *coreauth.Auth) bool {
+	if a == nil {
+		return false
+	}
+	apiType := ""
+	if len(a.Attributes) > 0 {
+		apiType = strings.ToLower(strings.TrimSpace(a.Attributes["api_type"]))
+	}
+	if apiType == "azure-openai" || apiType == "azure_openai" || apiType == "azure" {
+		return true
+	}
+	if _, _, isCompat := openAICompatInfoFromAuth(a); isCompat {
+		return false
+	}
+	provider := strings.ToLower(strings.TrimSpace(a.Provider))
+	return provider == "azure-openai" || provider == "azure_openai"
+}
+
 func (s *Service) ensureExecutorsForAuth(a *coreauth.Auth) {
 	s.ensureExecutorsForAuthWithMode(a, false)
 }
@@ -415,6 +433,10 @@ func (s *Service) ensureExecutorsForAuthWithMode(a *coreauth.Auth, forceReplace 
 		if compatProviderKey == "" {
 			compatProviderKey = "openai-compatibility"
 		}
+		if isAzureOpenAIAuth(a) {
+			s.coreManager.RegisterExecutor(executor.NewAzureOpenAIExecutor(compatProviderKey, s.cfg))
+			return
+		}
 		s.coreManager.RegisterExecutor(executor.NewOpenAICompatExecutor(compatProviderKey, s.cfg))
 		return
 	}
@@ -438,6 +460,8 @@ func (s *Service) ensureExecutorsForAuthWithMode(a *coreauth.Auth, forceReplace 
 		s.coreManager.RegisterExecutor(executor.NewKimiExecutor(s.cfg))
 	case "xai":
 		s.coreManager.RegisterExecutor(executor.NewXAIExecutor(s.cfg))
+	case "azure-openai", "azure_openai":
+		s.coreManager.RegisterExecutor(executor.NewAzureOpenAIExecutor("azure-openai", s.cfg))
 	default:
 		providerKey := strings.ToLower(strings.TrimSpace(a.Provider))
 		if providerKey == "" {
@@ -594,6 +618,7 @@ func (s *Service) registerHomeExecutors() {
 	s.coreManager.RegisterExecutor(executor.NewAIStudioExecutor(s.cfg, "", s.wsGateway))
 	s.coreManager.RegisterExecutor(executor.NewAntigravityExecutor(s.cfg))
 	s.coreManager.RegisterExecutor(executor.NewKimiExecutor(s.cfg))
+	s.coreManager.RegisterExecutor(executor.NewAzureOpenAIExecutor("azure-openai", s.cfg))
 	s.coreManager.RegisterExecutor(executor.NewOpenAICompatExecutor("openai-compatibility", s.cfg))
 }
 

--- a/sdk/cliproxy/service_azure_executor_binding_test.go
+++ b/sdk/cliproxy/service_azure_executor_binding_test.go
@@ -1,0 +1,112 @@
+package cliproxy
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestEnsureExecutorsForAuth_AzureDirectProviderBindsAzureExecutor(t *testing.T) {
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: coreauth.NewManager(nil, nil, nil),
+	}
+	auth := &coreauth.Auth{
+		ID:       "azure-auth-1",
+		Provider: "azure-openai",
+		Status:   coreauth.StatusActive,
+	}
+
+	service.ensureExecutorsForAuth(auth)
+	resolved, ok := service.coreManager.Executor("azure-openai")
+	if !ok || resolved == nil {
+		t.Fatal("expected azure-openai executor after bind")
+	}
+	if _, isAzure := resolved.(*executor.AzureOpenAIExecutor); !isAzure {
+		t.Fatalf("executor type = %T, want *executor.AzureOpenAIExecutor", resolved)
+	}
+}
+
+func TestEnsureExecutorsForAuth_AzureOpenAICompatBindsProviderKey(t *testing.T) {
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: coreauth.NewManager(nil, nil, nil),
+	}
+	auth := &coreauth.Auth{
+		ID:       "azure-compat-auth-1",
+		Provider: "azure-provider-key",
+		Label:    "AzureCompat",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"compat_name":  "AzureCompat",
+			"provider_key": "azure-provider-key",
+			"api_type":     "azure-openai",
+		},
+	}
+
+	service.ensureExecutorsForAuth(auth)
+	resolved, ok := service.coreManager.Executor("azure-provider-key")
+	if !ok || resolved == nil {
+		t.Fatal("expected Azure executor under OpenAI compatibility provider key")
+	}
+	if _, isAzure := resolved.(*executor.AzureOpenAIExecutor); !isAzure {
+		t.Fatalf("executor type = %T, want *executor.AzureOpenAIExecutor", resolved)
+	}
+	if _, okGeneric := service.coreManager.Executor("openai-compatibility"); okGeneric {
+		t.Fatal("azure compatibility auth must not register the generic compatibility executor")
+	}
+}
+
+func TestEnsureExecutorsForAuth_OpenAICompatNamedAzureWithoutAPITypeStaysGeneric(t *testing.T) {
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: coreauth.NewManager(nil, nil, nil),
+	}
+	auth := &coreauth.Auth{
+		ID:       "generic-azure-name-auth-1",
+		Provider: "azure-openai",
+		Label:    "azure-openai",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"compat_name":  "azure-openai",
+			"provider_key": "azure-openai",
+		},
+	}
+
+	service.ensureExecutorsForAuth(auth)
+	resolved, ok := service.coreManager.Executor("azure-openai")
+	if !ok || resolved == nil {
+		t.Fatal("expected generic compatibility executor after bind")
+	}
+	if _, isGeneric := resolved.(*executor.OpenAICompatExecutor); !isGeneric {
+		t.Fatalf("executor type = %T, want *executor.OpenAICompatExecutor", resolved)
+	}
+}
+
+func TestEnsureExecutorsForAuth_GenericOpenAICompatStillBindsGenericExecutor(t *testing.T) {
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: coreauth.NewManager(nil, nil, nil),
+	}
+	auth := &coreauth.Auth{
+		ID:       "generic-compat-auth-1",
+		Provider: "generic-provider-key",
+		Label:    "GenericCompat",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"compat_name":  "GenericCompat",
+			"provider_key": "generic-provider-key",
+		},
+	}
+
+	service.ensureExecutorsForAuth(auth)
+	resolved, ok := service.coreManager.Executor("generic-provider-key")
+	if !ok || resolved == nil {
+		t.Fatal("expected generic compatibility executor after bind")
+	}
+	if _, isGeneric := resolved.(*executor.OpenAICompatExecutor); !isGeneric {
+		t.Fatalf("executor type = %T, want *executor.OpenAICompatExecutor", resolved)
+	}
+}

--- a/test/azure_openai_compat_test.go
+++ b/test/azure_openai_compat_test.go
@@ -1,0 +1,98 @@
+package test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestAzureOpenAICompatOpenAINonStream(t *testing.T) {
+	var gotPath string
+	var gotAPIVersion string
+	var gotAPIKey string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		gotAPIVersion = r.URL.Query().Get("api-version")
+		gotAPIKey = r.Header.Get("api-key")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_azure","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"azure ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`))
+	}))
+	defer server.Close()
+
+	executor := runtimeexecutor.NewAzureOpenAIExecutor("azure-openai", &config.Config{})
+	resp, err := executor.Execute(context.Background(), &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":    server.URL,
+		"api_version": "2025-04-01-preview",
+		"api_key":     "azure-key",
+		"deployment":  "prod-gpt-4-1",
+	}}, cliproxyexecutor.Request{
+		Model:   "azure-gpt-4.1",
+		Payload: []byte(`{"model":"azure-gpt-4.1","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/openai/deployments/prod-gpt-4-1/chat/completions" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAPIVersion != "2025-04-01-preview" {
+		t.Fatalf("api-version = %q", gotAPIVersion)
+	}
+	if gotAPIKey != "azure-key" {
+		t.Fatalf("api-key = %q", gotAPIKey)
+	}
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "prod-gpt-4-1" {
+		t.Fatalf("upstream body model = %q", gotModel)
+	}
+	if object := gjson.GetBytes(resp.Payload, "object").String(); object != "chat.completion" {
+		t.Fatalf("response object = %q", object)
+	}
+}
+
+func TestAzureOpenAICompatClaudeNonStream(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_azure","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"azure ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`))
+	}))
+	defer server.Close()
+
+	executor := runtimeexecutor.NewAzureOpenAIExecutor("azure-openai", &config.Config{})
+	resp, err := executor.Execute(context.Background(), &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":    server.URL,
+		"api_version": "2025-04-01-preview",
+		"api_key":     "azure-key",
+	}}, cliproxyexecutor.Request{
+		Model:   "prod-claude-facing-deployment",
+		Payload: []byte(`{"model":"claude-facing-model","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatClaude,
+		OriginalRequest: []byte(`{"model":"claude-facing-model","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotMessages := gjson.GetBytes(gotBody, "messages").Array(); len(gotMessages) != 1 {
+		t.Fatalf("upstream messages length = %d", len(gotMessages))
+	}
+	if gotModel := gjson.GetBytes(gotBody, "model").String(); gotModel != "prod-claude-facing-deployment" {
+		t.Fatalf("upstream body model = %q", gotModel)
+	}
+	if responseType := gjson.GetBytes(resp.Payload, "type").String(); responseType != "message" {
+		t.Fatalf("response type = %q", responseType)
+	}
+}


### PR DESCRIPTION
## Summary
- Add Azure OpenAI client-facing Chat Completions routes for deployment and v1 URL shapes.
- Normalize Azure deployment aliases into the existing OpenAI handler pipeline so requests can route to OpenAI-compatible or Claude upstreams.
- Accept Azure-style `api-key` for configured server access authentication and add E2E coverage.
- Address AI review feedback by avoiding duplicate JSON parsing in Azure request validation.

## Test plan
- [x] go build -o test-output ./cmd/server
- [x] go test ./internal/access/config_access ./sdk/api/handlers/azureopenai ./sdk/api/handlers/... ./internal/api/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)