### PR TITLE
Add linux armv7 release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: goreleaser
 
 on:
+  workflow_dispatch:
   push:
-    # run only against tags
     tags:
       - '*'
 
@@ -16,6 +16,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Ensure manual release uses tag ref
+        if: github.event_name == 'workflow_dispatch' && github.ref_type != 'tag'
+        run: |
+          echo "Manual releases must be dispatched from a tag ref."
+          exit 1
       - name: Refresh models catalog
         run: |
           git fetch --depth 1 https://github.com/router-for-me/models.git main

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,11 +16,29 @@ builds:
     binary: cli-proxy-api
     ldflags:
       - -s -w -X 'main.Version={{.Version}}' -X 'main.Commit={{.ShortCommit}}' -X 'main.BuildDate={{.Date}}'
+
+  - id: "cli-proxy-api-linux-armv7"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - "7"
+    main: ./cmd/server/
+    binary: cli-proxy-api
+    ldflags:
+      - -s -w -X 'main.Version={{.Version}}' -X 'main.Commit={{.ShortCommit}}' -X 'main.BuildDate={{.Date}}'
+
 archives:
   - id: "cli-proxy-api"
+    builds:
+      - cli-proxy-api
+      - cli-proxy-api-linux-armv7
     format: tar.gz
     name_template: >-
-      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{- if eq .Arch "arm64" -}}aarch64{{- else -}}{{ .Arch }}{{- end -}}
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{- if eq .Arch "arm64" -}}aarch64{{- else if eq .Arch "arm" -}}armv{{ .Arm }}{{- else -}}{{ .Arch }}{{- end -}}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
## Summary
- Add a linux armv7 GoReleaser build target and include it in the release archive set.
- Update archive naming so arm builds emit `armv{{ .Arm }}` names.
- Add manual release dispatch while guarding formal releases to tag refs only.

## Test plan
- [x] Verified diff is limited to `.github/workflows/release.yaml` and `.goreleaser.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)