### PR TITLE
fix(antigravity): update fallback version and add deprecated version safeguard

### DIFF
--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	antigravityReleasesURL     = "https://antigravity-auto-updater-974169037036.us-central1.run.app/releases"
-	antigravityFallbackVersion = "1.21.9"
+	antigravityFallbackVersion = "2.10.0"
 	antigravityVersionCacheTTL = 6 * time.Hour
 	antigravityFetchTimeout    = 10 * time.Second
 	AntigravityNodeAPIClientUA = "google-api-nodejs-client/10.3.0"
@@ -75,9 +75,12 @@ func refreshAntigravityVersion(ctx context.Context) {
 
 	if errFetch == nil {
 		cachedAntigravityVersion = version
-		antigravityVersionExpiry = now.Add(antigravityVersionCacheTTL)
-		log.WithField("version", version).Info("fetched latest antigravity version")
-		return
+		if strings.HasPrefix(version, "2.") || strings.HasPrefix(version, "3.") {
+			antigravityVersionExpiry = now.Add(antigravityVersionCacheTTL)
+			log.WithField("version", version).Info("fetched latest antigravity version")
+			return
+		}
+		log.WithField("version", version).Warn("fetched antigravity version is deprecated, using fallback")
 	}
 
 	if cachedAntigravityVersion == "" || now.After(antigravityVersionExpiry) {
@@ -91,15 +94,16 @@ func refreshAntigravityVersion(ctx context.Context) {
 }
 
 // AntigravityLatestVersion returns the cached antigravity version refreshed by StartAntigravityVersionUpdater.
-// It falls back to antigravityFallbackVersion if the cache is empty or stale.
+// It falls back to antigravityFallbackVersion if the cache is empty, stale, or deprecated.
 func AntigravityLatestVersion() string {
 	antigravityVersionMu.RLock()
+	defer antigravityVersionMu.RUnlock()
+
 	if cachedAntigravityVersion != "" && time.Now().Before(antigravityVersionExpiry) {
-		v := cachedAntigravityVersion
-		antigravityVersionMu.RUnlock()
-		return v
+		if strings.HasPrefix(cachedAntigravityVersion, "2.") || strings.HasPrefix(cachedAntigravityVersion, "3.") {
+			return cachedAntigravityVersion
+		}
 	}
-	antigravityVersionMu.RUnlock()
 
 	return antigravityFallbackVersion
 }


### PR DESCRIPTION

    ### Summary
    This PR resolves the `This version of Antigravity is no longer supported` error returned by the Google backend API when proxied through CLIProxy.

    ### Root Cause
    The Google Antigravity backend API enforces strict client version checks on the request headers.
    1. The `antigravityReleasesURL` endpoint currently returns a pre-2.0 version (`0.8.2`), which the proxy was caching and sending upstream, causing the API to reject
  requests.
    2. The hardcoded fallback version was set to `1.21.9`, which is also classified as deprecated following the release of Antigravity 2.0.

    ### Solution
    This PR introduces a robust version validation safeguard:
    - Updates `antigravityFallbackVersion` to `2.10.0`.
    - Validates the dynamically fetched version string. If the version returned by the updater API is deprecated (i.e. does not start with `2.` or `3.`), the proxy
  automatically discards it and falls back to the safe `2.10.0` header.
    - Maintains dynamic compatibility by allowing any future `2.x` or `3.x` release strings to be cached and used as normal.

    ### Verification
    - Successfully compiled the server package using `go build`.
    - Verified that routing requests using `gemini-3.5-flash` and `gemini-3.1-pro` now return `200 OK` from the Google backend API under the new `2.10.0` header format.
