### PR TITLE
fix(executor/xai): drop orphaned tool_choice when Claude tools array is empty

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -506,6 +506,7 @@ func (e *XAIExecutor) prepareResponsesRequest(ctx context.Context, req cliproxye
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = normalizeXAITools(body)
+	body = normalizeXAIToolChoiceForTools(body)
 	body = normalizeXAIInputReasoningItems(body)
 	body = normalizeCodexInstructions(body)
 	body = sanitizeXAIResponsesBody(body, baseModel)
@@ -713,6 +714,28 @@ func normalizeXAITools(body []byte) []byte {
 		return body
 	}
 	return updated
+}
+
+// normalizeXAIToolChoiceForTools drops tool_choice and parallel_tool_calls
+// when tools are absent or empty (including after normalizeXAITools filtering).
+// xAI rejects payloads that include tool_choice without any tools defined.
+// Existence checks avoid unnecessary sjson parse/copy passes.
+func normalizeXAIToolChoiceForTools(body []byte) []byte {
+	tools := gjson.GetBytes(body, "tools")
+	hasTools := tools.Exists() && tools.IsArray() && len(tools.Array()) > 0
+	if hasTools {
+		return body
+	}
+	if tools.Exists() {
+		body, _ = sjson.DeleteBytes(body, "tools")
+	}
+	if gjson.GetBytes(body, "tool_choice").Exists() {
+		body, _ = sjson.DeleteBytes(body, "tool_choice")
+	}
+	if gjson.GetBytes(body, "parallel_tool_calls").Exists() {
+		body, _ = sjson.DeleteBytes(body, "parallel_tool_calls")
+	}
+	return body
 }
 
 func normalizeXAITool(tool gjson.Result) ([]byte, bool, bool) {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -592,3 +592,57 @@ func TestXAIExecutorExecuteVideosUsesNativeEndpointFromRequestPath(t *testing.T)
 		})
 	}
 }
+
+func TestNormalizeXAIToolChoiceForTools_DropsWhenToolsEmpty(t *testing.T) {
+	body := []byte(`{"model":"grok-4","tools":[],"tool_choice":"auto","parallel_tool_calls":true,"input":"hi"}`)
+	out := normalizeXAIToolChoiceForTools(body)
+
+	if gjson.GetBytes(out, "tools").Exists() {
+		t.Fatalf("empty tools should be removed: %s", string(out))
+	}
+	if gjson.GetBytes(out, "tool_choice").Exists() {
+		t.Fatalf("tool_choice should be removed when tools empty: %s", string(out))
+	}
+	if gjson.GetBytes(out, "parallel_tool_calls").Exists() {
+		t.Fatalf("parallel_tool_calls should be removed when tools empty: %s", string(out))
+	}
+}
+
+func TestNormalizeXAIToolChoiceForTools_DropsWhenToolsMissing(t *testing.T) {
+	body := []byte(`{"model":"grok-4","tool_choice":"auto","input":"hi"}`)
+	out := normalizeXAIToolChoiceForTools(body)
+
+	if gjson.GetBytes(out, "tool_choice").Exists() {
+		t.Fatalf("tool_choice should be removed when tools missing: %s", string(out))
+	}
+}
+
+func TestNormalizeXAIToolChoiceForTools_DropsOrphanedParallelToolCalls(t *testing.T) {
+	body := []byte(`{"model":"grok-4","parallel_tool_calls":true,"input":"hi"}`)
+	out := normalizeXAIToolChoiceForTools(body)
+
+	if gjson.GetBytes(out, "parallel_tool_calls").Exists() {
+		t.Fatalf("parallel_tool_calls should be removed when tools missing even without tool_choice: %s", string(out))
+	}
+}
+
+func TestNormalizeXAIToolChoiceForTools_KeepsWhenToolsPresent(t *testing.T) {
+	body := []byte(`{"model":"grok-4","tools":[{"type":"function","name":"Bash"}],"tool_choice":"auto","input":"hi"}`)
+	out := normalizeXAIToolChoiceForTools(body)
+
+	if !gjson.GetBytes(out, "tools").Exists() {
+		t.Fatalf("tools should be kept: %s", string(out))
+	}
+	if got := gjson.GetBytes(out, "tool_choice").String(); got != "auto" {
+		t.Fatalf("tool_choice = %q, want auto: %s", got, string(out))
+	}
+}
+
+func TestNormalizeXAIToolChoiceForTools_NoOpWhenBothAbsent(t *testing.T) {
+	body := []byte(`{"model":"grok-4","input":"hi"}`)
+	out := normalizeXAIToolChoiceForTools(body)
+
+	if gjson.GetBytes(out, "tool_choice").Exists() {
+		t.Fatalf("tool_choice should not appear: %s", string(out))
+	}
+}


### PR DESCRIPTION
## Context
When Claude Code sends a request without tools (e.g. a stop-hook evaluator), the payload includes `"tools": []` (empty array). The `claude→codex` translator unconditionally emits `tools: []` + `tool_choice: "auto"` + `parallel_tool_calls: true` into the Codex Responses shape.

When that payload is routed to xAI, the upstream rejects with HTTP 400:
```
"A tool_choice was set on the request but no tools were specified."
```

## Issue
- Root cause sits in the `claude→codex` translator (`codex_claude_request.go`) — it treats an empty `tools` array as valid and always sets `tool_choice`.
- However, the translator package is policy-locked (`translator-path-guard` CI check); fixing it standalone is not permitted.
- The same orphan can also occur when every tool in the input is filtered out by `normalizeXAITools` (e.g. all entries are unsupported types like `tool_search` / `image_generation`).

## Solution
Fix entirely in the xAI executor (provider boundary, no translator changes):

- Add `normalizeXAIToolChoiceForTools()` and invoke it right after `normalizeXAITools()` in `prepareResponsesRequest`.
- When `tools` is absent or empty, remove `tools`, `tool_choice`, and `parallel_tool_calls` so the payload xAI receives is internally consistent.
- Existence-check each key before `sjson.DeleteBytes` to avoid unnecessary JSON parse/copy passes.
- Always strip orphaned `parallel_tool_calls` (not gated on `tool_choice` presence).

Per code-review feedback from `gemini-code-assist` (https://github.com/router-for-me/CLIProxyAPI/pull/3649#discussion_r3330503805).

## Verification
- `go build -o test-output ./cmd/server && rm test-output`
- `go test ./internal/runtime/executor/... -count=1` — all pass
- 5 new regression tests:
  - `TestNormalizeXAIToolChoiceForTools_DropsWhenToolsEmpty`
  - `TestNormalizeXAIToolChoiceForTools_DropsWhenToolsMissing`
  - `TestNormalizeXAIToolChoiceForTools_DropsOrphanedParallelToolCalls`
  - `TestNormalizeXAIToolChoiceForTools_KeepsWhenToolsPresent`
  - `TestNormalizeXAIToolChoiceForTools_NoOpWhenBothAbsent`