### PR TITLE
fix(executor): preserve canonical Session_id header casing in Codex identity-confuse

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -980,7 +980,10 @@ func applyCodexIdentityConfuseHeaders(headers http.Header, state *codexIdentityC
 
 	setHeaderCasePreserved(headers, "Session-Id", state.promptCacheKey)
 	if headerValueCaseInsensitive(headers, "session_id") != "" {
-		setHeaderCasePreserved(headers, "session_id", state.promptCacheKey)
+		// Use the canonical "Session_id" key (same as cacheHelper) so that
+		// http.Header.Get("Session_id") can resolve it; a lowercase literal
+		// key bypasses Go header canonicalization and stays unreadable via Get.
+		setHeaderCasePreserved(headers, "Session_id", state.promptCacheKey)
 	}
 	if headerValueCaseInsensitive(headers, "Conversation_id") != "" {
 		setHeaderCasePreserved(headers, "Conversation_id", state.promptCacheKey)


### PR DESCRIPTION
## Summary

`TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders` fails on `main` (on every platform) because the Codex identity-confuse path writes the `session_id` request header under a lowercase map key that `http.Header.Get("Session_id")` cannot resolve.

## Root cause

In `applyCodexIdentityConfuseHeaders` (`internal/runtime/executor/codex_executor.go`):

```go
if headerValueCaseInsensitive(headers, "session_id") != "" {
    setHeaderCasePreserved(headers, "session_id", state.promptCacheKey)
}
```

`setHeaderCasePreserved` assigns `headers[key] = ...` directly (to preserve exact casing), which bypasses Go's MIME header canonicalization. With a hardcoded lowercase `"session_id"`, the map key is stored as lowercase `session_id`.

Meanwhile `cacheHelper` sets the same header via the canonical form:

```go
httpReq.Header.Set("Session_id", cache.ID) // stored under canonical key "Session_id"
```

So after identity-confuse runs, the canonical `Session_id` entry is deleted and replaced by a lowercase `session_id` one. The test reads it back with `httpReq.Header.Get("Session_id")`, which canonicalizes the lookup key to `Session_id` and finds nothing, returning an empty string.

### Minimal reproduction

```go
h := http.Header{}
h.Set("Session_id", "ORIGINAL")              // map[Session_id:[ORIGINAL]]
setHeaderCasePreserved(h, "session_id", "X")  // map[session_id:[X]]   <- key is now lowercase
h.Get("Session_id")                           // "" (canonical lookup misses the lowercase key)
```

## Fix

Use the canonical `"Session_id"` key, matching `cacheHelper` and the sibling `Conversation_id` branch:

```go
setHeaderCasePreserved(headers, "Session_id", state.promptCacheKey)
```

## Impact

- Fixes the failing test on all platforms.
- No runtime behavior change: HTTP header field names are case-insensitive, so the upstream Codex endpoint receives the same `session_id` value either way. This only aligns the in-memory map key so that `Header.Get` (and the test) can resolve it.

Single-line change plus an explanatory comment.
