### PR TITLE
fix(claude): generic snake_case→TitleCase fallback so custom/MCP tools dodge OAuth extra-usage fingerprint

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1230,30 +1230,35 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 		}
 	}
 
-	// Built-in tool names (web_search, code_execution, etc.) must keep their exact
-	// names: the tools array leaves typed built-ins unchanged, so a forced
-	// tool_choice or a history reference to a built-in must NOT be renamed either,
-	// or it would no longer match any declared tool. Computed once up front.
-	builtinTools := helps.AugmentClaudeBuiltinToolRegistry(body, nil)
-
-	// renameOnce resolves the upstream name for a client tool name once per request
-	// and memoizes it, so tool_choice and message references stay consistent with
-	// the tools array. It is collision-aware: `produced` is seeded with every
-	// declared tool name, so a generated TitleCase name is only used when it does
-	// not collide with another declared or already-produced name. This prevents two
-	// distinct inputs that title-case to the same value (e.g. "tool1_call" and
-	// "tool_1_call" -> "Tool1Call") from creating duplicate upstream tool names
-	// (which the reverse map could not unambiguously restore); the loser keeps its
-	// original name.
+	// One pre-pass over the declared tools collects two sets:
+	//   builtinTools: ONLY tools carrying an Anthropic built-in "type" in THIS request.
+	//     Their names must stay verbatim so a forced tool_choice / history reference
+	//     still matches the tools array. An untyped custom tool that merely happens to
+	//     share a built-in name (e.g. an OpenAI-translated user function "web_search"
+	//     with only name/input_schema and no type) is third-party and is still cloaked.
+	//   produced: every declared tool name, for collision avoidance below so two inputs
+	//     that title-case to the same value (e.g. "tool1_call" and "tool_1_call" ->
+	//     "Tool1Call") never create duplicate upstream tool names (which the reverse map
+	//     could not unambiguously restore); the loser keeps its original name.
+	builtinTools := map[string]bool{}
 	produced := map[string]bool{}
 	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
 		tools.ForEach(func(_, tool gjson.Result) bool {
-			if n := tool.Get("name").String(); n != "" {
-				produced[n] = true
+			n := tool.Get("name").String()
+			if n == "" {
+				return true
+			}
+			produced[n] = true
+			if tool.Get("type").Exists() && tool.Get("type").String() != "" {
+				builtinTools[n] = true
 			}
 			return true
 		})
 	}
+
+	// renameOnce resolves the upstream name for a client tool name once per request and
+	// memoizes it, so tool_choice and message references stay consistent with the tools
+	// array (collision-aware via `produced`, built-in-safe via `builtinTools`).
 	forwardMap := map[string]string{}
 	renameOnce := func(name string) (string, bool) {
 		if fn, ok := forwardMap[name]; ok {

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -109,6 +110,53 @@ var oauthToolRenameMap = map[string]string{
 // oauthToolsToRemove lists tool names that must be stripped from OAuth requests
 // even after remapping. Currently empty — all tools are mapped instead of removed.
 var oauthToolsToRemove = map[string]bool{}
+
+// thirdPartyToolNamePattern matches OpenCode/MCP-style lowercase or snake_case
+// tool names (e.g. "bash", "browser_navigate", "list_dir") that Anthropic's OAuth
+// tool-name fingerprint flags as third-party. Names already in Claude Code's
+// TitleCase form (e.g. "Bash", "BrowserNavigate") or any mixed/camel case do NOT
+// match and are therefore left untouched — this is what keeps clients that
+// already send TitleCase names (e.g. Amp CLI's `Bash`) safe.
+var thirdPartyToolNamePattern = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
+
+// titleCaseToolName converts a snake_case/lowercase tool name to Claude
+// Code-style TitleCase, e.g. "browser_navigate" -> "BrowserNavigate", "bash" -> "Bash".
+func titleCaseToolName(name string) string {
+	parts := strings.Split(name, "_")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, "")
+}
+
+// oauthRenameToolName returns the cloaked tool name for an OAuth request and
+// whether a rename occurred. It first honours the curated oauthToolRenameMap
+// (canonical official names), then falls back to a generic snake_case/lowercase
+// -> TitleCase transform so that custom and MCP tools — which are NOT in the
+// curated map (e.g. "browser_navigate", "list_dir") — are normalised too.
+//
+// Without this fallback, any tool name outside the curated map kept its
+// lowercase form and re-triggered Anthropic's third-party tool-name fingerprint,
+// causing tool-heavy requests to be metered/blocked as "out of extra usage" even
+// though the curated tools in the same request were cloaked correctly. Empirically
+// a request whose tools are all TitleCase passes while the same tools in
+// snake_case are rejected, regardless of whether the names are real Claude Code
+// tools — i.e. it is the casing/style that is fingerprinted, not a fixed
+// vocabulary, which is exactly what this generic fallback addresses.
+func oauthRenameToolName(name string) (string, bool) {
+	if mapped, ok := oauthToolRenameMap[name]; ok && mapped != name {
+		return mapped, true
+	}
+	if thirdPartyToolNamePattern.MatchString(name) {
+		if titled := titleCaseToolName(name); titled != name {
+			return titled, true
+		}
+	}
+	return name, false
+}
 
 // Anthropic-compatible upstreams may reject or even crash when Claude models
 // omit max_tokens. Prefer registered model metadata before using a fallback.
@@ -1174,7 +1222,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			}
 
 			toolJSON := tool.Raw
-			if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
+			if newName, ok := oauthRenameToolName(name); ok {
 				updatedTool, err := sjson.Set(toolJSON, "name", newName)
 				if err == nil {
 					toolJSON = updatedTool
@@ -1201,7 +1249,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			// The chosen tool was removed from the tools array, so drop tool_choice to
 			// keep the payload internally consistent and fall back to normal auto tool use.
 			body, _ = sjson.DeleteBytes(body, "tool_choice")
-		} else if newName, ok := oauthToolRenameMap[tcName]; ok && newName != tcName {
+		} else if newName, ok := oauthRenameToolName(tcName); ok {
 			body, _ = sjson.SetBytes(body, "tool_choice.name", newName)
 			recordRename(tcName, newName)
 		}
@@ -1220,14 +1268,14 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 				switch partType {
 				case "tool_use":
 					name := part.Get("name").String()
-					if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
+					if newName, ok := oauthRenameToolName(name); ok {
 						path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
 						body, _ = sjson.SetBytes(body, path, newName)
 						recordRename(name, newName)
 					}
 				case "tool_reference":
 					toolName := part.Get("tool_name").String()
-					if newName, ok := oauthToolRenameMap[toolName]; ok && newName != toolName {
+					if newName, ok := oauthRenameToolName(toolName); ok {
 						path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
 						body, _ = sjson.SetBytes(body, path, newName)
 						recordRename(toolName, newName)
@@ -1241,7 +1289,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 						nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
 							if nestedPart.Get("type").String() == "tool_reference" {
 								nestedToolName := nestedPart.Get("tool_name").String()
-								if newName, ok := oauthToolRenameMap[nestedToolName]; ok && newName != nestedToolName {
+								if newName, ok := oauthRenameToolName(nestedToolName); ok {
 									nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
 									body, _ = sjson.SetBytes(body, nestedPath, newName)
 									recordRename(nestedToolName, newName)

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1236,6 +1236,43 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 	// or it would no longer match any declared tool. Computed once up front.
 	builtinTools := helps.AugmentClaudeBuiltinToolRegistry(body, nil)
 
+	// renameOnce resolves the upstream name for a client tool name once per request
+	// and memoizes it, so tool_choice and message references stay consistent with
+	// the tools array. It is collision-aware: `produced` is seeded with every
+	// declared tool name, so a generated TitleCase name is only used when it does
+	// not collide with another declared or already-produced name. This prevents two
+	// distinct inputs that title-case to the same value (e.g. "tool1_call" and
+	// "tool_1_call" -> "Tool1Call") from creating duplicate upstream tool names
+	// (which the reverse map could not unambiguously restore); the loser keeps its
+	// original name.
+	produced := map[string]bool{}
+	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			if n := tool.Get("name").String(); n != "" {
+				produced[n] = true
+			}
+			return true
+		})
+	}
+	forwardMap := map[string]string{}
+	renameOnce := func(name string) (string, bool) {
+		if fn, ok := forwardMap[name]; ok {
+			return fn, fn != name
+		}
+		final := name
+		if !builtinTools[name] {
+			if cand, ok := oauthRenameToolName(name); ok && (cand == name || !produced[cand]) {
+				final = cand
+			}
+		}
+		forwardMap[name] = final
+		if final != name {
+			produced[final] = true
+			recordRename(name, final)
+		}
+		return final, final != name
+	}
+
 	// 1. Rewrite tools array in a single pass (if present).
 	// IMPORTANT: do not mutate names first and then rebuild from an older gjson
 	// snapshot. gjson results are snapshots of the original bytes; rebuilding from a
@@ -1264,11 +1301,9 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			}
 
 			toolJSON := tool.Raw
-			if newName, ok := oauthRenameToolName(name); ok && !builtinTools[name] {
-				updatedTool, err := sjson.Set(toolJSON, "name", newName)
-				if err == nil {
+			if newName, ok := renameOnce(name); ok {
+				if updatedTool, err := sjson.Set(toolJSON, "name", newName); err == nil {
 					toolJSON = updatedTool
-					recordRename(name, newName)
 				}
 			}
 
@@ -1291,9 +1326,8 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			// The chosen tool was removed from the tools array, so drop tool_choice to
 			// keep the payload internally consistent and fall back to normal auto tool use.
 			body, _ = sjson.DeleteBytes(body, "tool_choice")
-		} else if newName, ok := oauthRenameToolName(tcName); ok && !builtinTools[tcName] {
+		} else if newName, ok := renameOnce(tcName); ok {
 			body, _ = sjson.SetBytes(body, "tool_choice.name", newName)
-			recordRename(tcName, newName)
 		}
 	}
 
@@ -1310,17 +1344,15 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 				switch partType {
 				case "tool_use":
 					name := part.Get("name").String()
-					if newName, ok := oauthRenameToolName(name); ok && !builtinTools[name] {
+					if newName, ok := renameOnce(name); ok {
 						path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
 						body, _ = sjson.SetBytes(body, path, newName)
-						recordRename(name, newName)
 					}
 				case "tool_reference":
 					toolName := part.Get("tool_name").String()
-					if newName, ok := oauthRenameToolName(toolName); ok && !builtinTools[toolName] {
+					if newName, ok := renameOnce(toolName); ok {
 						path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
 						body, _ = sjson.SetBytes(body, path, newName)
-						recordRename(toolName, newName)
 					}
 				case "tool_result":
 					// Handle nested tool_reference blocks inside tool_result.content[]
@@ -1331,10 +1363,9 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 						nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
 							if nestedPart.Get("type").String() == "tool_reference" {
 								nestedToolName := nestedPart.Get("tool_name").String()
-								if newName, ok := oauthRenameToolName(nestedToolName); ok && !builtinTools[nestedToolName] {
+								if newName, ok := renameOnce(nestedToolName); ok {
 									nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
 									body, _ = sjson.SetBytes(body, nestedPath, newName)
-									recordRename(nestedToolName, newName)
 								}
 							}
 							return true

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1230,6 +1230,12 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 		}
 	}
 
+	// Built-in tool names (web_search, code_execution, etc.) must keep their exact
+	// names: the tools array leaves typed built-ins unchanged, so a forced
+	// tool_choice or a history reference to a built-in must NOT be renamed either,
+	// or it would no longer match any declared tool. Computed once up front.
+	builtinTools := helps.AugmentClaudeBuiltinToolRegistry(body, nil)
+
 	// 1. Rewrite tools array in a single pass (if present).
 	// IMPORTANT: do not mutate names first and then rebuild from an older gjson
 	// snapshot. gjson results are snapshots of the original bytes; rebuilding from a
@@ -1258,7 +1264,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			}
 
 			toolJSON := tool.Raw
-			if newName, ok := oauthRenameToolName(name); ok {
+			if newName, ok := oauthRenameToolName(name); ok && !builtinTools[name] {
 				updatedTool, err := sjson.Set(toolJSON, "name", newName)
 				if err == nil {
 					toolJSON = updatedTool
@@ -1285,7 +1291,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			// The chosen tool was removed from the tools array, so drop tool_choice to
 			// keep the payload internally consistent and fall back to normal auto tool use.
 			body, _ = sjson.DeleteBytes(body, "tool_choice")
-		} else if newName, ok := oauthRenameToolName(tcName); ok {
+		} else if newName, ok := oauthRenameToolName(tcName); ok && !builtinTools[tcName] {
 			body, _ = sjson.SetBytes(body, "tool_choice.name", newName)
 			recordRename(tcName, newName)
 		}
@@ -1304,14 +1310,14 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 				switch partType {
 				case "tool_use":
 					name := part.Get("name").String()
-					if newName, ok := oauthRenameToolName(name); ok {
+					if newName, ok := oauthRenameToolName(name); ok && !builtinTools[name] {
 						path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
 						body, _ = sjson.SetBytes(body, path, newName)
 						recordRename(name, newName)
 					}
 				case "tool_reference":
 					toolName := part.Get("tool_name").String()
-					if newName, ok := oauthRenameToolName(toolName); ok {
+					if newName, ok := oauthRenameToolName(toolName); ok && !builtinTools[toolName] {
 						path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
 						body, _ = sjson.SetBytes(body, path, newName)
 						recordRename(toolName, newName)
@@ -1325,7 +1331,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 						nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
 							if nestedPart.Get("type").String() == "tool_reference" {
 								nestedToolName := nestedPart.Get("tool_name").String()
-								if newName, ok := oauthRenameToolName(nestedToolName); ok {
+								if newName, ok := oauthRenameToolName(nestedToolName); ok && !builtinTools[nestedToolName] {
 									nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
 									body, _ = sjson.SetBytes(body, nestedPath, newName)
 									recordRename(nestedToolName, newName)

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
 	"strings"
 	"time"
 
@@ -111,25 +110,62 @@ var oauthToolRenameMap = map[string]string{
 // even after remapping. Currently empty — all tools are mapped instead of removed.
 var oauthToolsToRemove = map[string]bool{}
 
-// thirdPartyToolNamePattern matches OpenCode/MCP-style lowercase or snake_case
-// tool names (e.g. "bash", "browser_navigate", "list_dir") that Anthropic's OAuth
-// tool-name fingerprint flags as third-party. Names already in Claude Code's
-// TitleCase form (e.g. "Bash", "BrowserNavigate") or any mixed/camel case do NOT
-// match and are therefore left untouched — this is what keeps clients that
-// already send TitleCase names (e.g. Amp CLI's `Bash`) safe.
-var thirdPartyToolNamePattern = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
+// isSnakeCase reports whether name is a simple lowercase / snake_case tool name
+// (e.g. "bash", "browser_navigate", "list_dir") — the OpenCode/third-party form
+// Anthropic's OAuth tool-name fingerprint flags. It is a single-pass equivalent of
+// `^[a-z][a-z0-9]*(_[a-z0-9]+)*$` (no regexp/allocation in this per-request path).
+//
+// It deliberately returns false for:
+//   - names already in TitleCase / mixed / camel case (e.g. Amp CLI's `Bash`,
+//     `BrowserNavigate`) — these must pass through unchanged, and
+//   - MCP-style names using the `mcp__server__tool` convention (consecutive
+//     underscores / empty segments). Claude Code emits those lowercase MCP names
+//     natively (e.g. `mcp__context7__query_docs`), so they are already
+//     first-party-safe; rewriting them would produce a form Claude Code never
+//     sends and break MCP tool routing on the response side.
+func isSnakeCase(s string) bool {
+	if len(s) == 0 || s[0] < 'a' || s[0] > 'z' {
+		return false
+	}
+	lastWasUnderscore := false
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '_':
+			if lastWasUnderscore {
+				return false
+			}
+			lastWasUnderscore = true
+		case (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'):
+			lastWasUnderscore = false
+		default:
+			return false
+		}
+	}
+	return !lastWasUnderscore
+}
 
 // titleCaseToolName converts a snake_case/lowercase tool name to Claude
-// Code-style TitleCase, e.g. "browser_navigate" -> "BrowserNavigate", "bash" -> "Bash".
+// Code-style TitleCase in a single pass (no intermediate slices/strings),
+// e.g. "browser_navigate" -> "BrowserNavigate", "bash" -> "Bash".
 func titleCaseToolName(name string) string {
-	parts := strings.Split(name, "_")
-	for i, p := range parts {
-		if p == "" {
+	var sb strings.Builder
+	sb.Grow(len(name))
+	upperNext := true
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c == '_' {
+			upperNext = true
 			continue
 		}
-		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		if upperNext && c >= 'a' && c <= 'z' {
+			sb.WriteByte(c - 32)
+		} else {
+			sb.WriteByte(c)
+		}
+		upperNext = false
 	}
-	return strings.Join(parts, "")
+	return sb.String()
 }
 
 // oauthRenameToolName returns the cloaked tool name for an OAuth request and
@@ -150,7 +186,7 @@ func oauthRenameToolName(name string) (string, bool) {
 	if mapped, ok := oauthToolRenameMap[name]; ok && mapped != name {
 		return mapped, true
 	}
-	if thirdPartyToolNamePattern.MatchString(name) {
+	if isSnakeCase(name) {
 		if titled := titleCaseToolName(name); titled != name {
 			return titled, true
 		}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2358,3 +2358,20 @@ func TestRemapOAuthToolNames_CustomTitleCase_Untouched(t *testing.T) {
 		t.Fatalf("reverseMap = %v, want empty", reverseMap)
 	}
 }
+
+// TestRemapOAuthToolNames_MCPDoubleUnderscore_Untouched verifies that MCP-style
+// tool names (mcp__server__tool, with consecutive underscores) are left
+// unchanged. Claude Code emits these lowercase MCP names natively, so they are
+// already first-party-safe; rewriting them would produce a form Claude Code
+// never sends and break MCP tool routing on the response side.
+func TestRemapOAuthToolNames_MCPDoubleUnderscore_Untouched(t *testing.T) {
+	body := []byte(`{"tools":[{"name":"mcp__context7__query_docs","input_schema":{"type":"object","properties":{}}}],"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	out, reverseMap := remapOAuthToolNames(body)
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "mcp__context7__query_docs" {
+		t.Fatalf("tools.0.name = %q, want %q (unchanged)", got, "mcp__context7__query_docs")
+	}
+	if len(reverseMap) != 0 {
+		t.Fatalf("reverseMap = %v, want empty", reverseMap)
+	}
+}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2318,3 +2318,43 @@ func TestRestoreClaudeOAuthToolNamesFromStreamLine_MixedCaseWithPrefix(t *testin
 		t.Fatalf("Glob should be restored to glob, got: %s", string(out))
 	}
 }
+
+// TestRemapOAuthToolNames_CustomSnakeCase_GenericFallback verifies that custom /
+// MCP tools whose names are NOT in oauthToolRenameMap (e.g. "browser_navigate")
+// are still normalised to TitleCase via the generic fallback, and that the
+// response tool_use name is reversed back to the client's original snake_case.
+func TestRemapOAuthToolNames_CustomSnakeCase_GenericFallback(t *testing.T) {
+	body := []byte(`{"tools":[{"name":"browser_navigate","input_schema":{"type":"object","properties":{"url":{"type":"string"}}}}],"tool_choice":{"type":"tool","name":"browser_navigate"},"messages":[{"role":"user","content":[{"type":"text","text":"open example.com"}]}]}`)
+
+	out, reverseMap := remapOAuthToolNames(body)
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "BrowserNavigate" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "BrowserNavigate")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "BrowserNavigate" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "BrowserNavigate")
+	}
+	if reverseMap["BrowserNavigate"] != "browser_navigate" {
+		t.Fatalf("reverseMap = %v, want entry BrowserNavigate->browser_navigate", reverseMap)
+	}
+
+	resp := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"BrowserNavigate","input":{"url":"https://example.com"}}]}`)
+	reversed := reverseRemapOAuthToolNames(resp, reverseMap)
+	if got := gjson.GetBytes(reversed, "content.0.name").String(); got != "browser_navigate" {
+		t.Fatalf("content.0.name = %q, want %q", got, "browser_navigate")
+	}
+}
+
+// TestRemapOAuthToolNames_CustomTitleCase_Untouched verifies that a custom tool
+// already supplied in TitleCase is left unchanged by the generic fallback and
+// produces no reverse-map entry (so it cannot corrupt the response).
+func TestRemapOAuthToolNames_CustomTitleCase_Untouched(t *testing.T) {
+	body := []byte(`{"tools":[{"name":"BrowserNavigate","input_schema":{"type":"object","properties":{"url":{"type":"string"}}}}],"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	out, reverseMap := remapOAuthToolNames(body)
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "BrowserNavigate" {
+		t.Fatalf("tools.0.name = %q, want %q (unchanged)", got, "BrowserNavigate")
+	}
+	if len(reverseMap) != 0 {
+		t.Fatalf("reverseMap = %v, want empty", reverseMap)
+	}
+}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2399,3 +2399,28 @@ func TestRemapOAuthToolNames_ToolChoiceBuiltin_NotRenamed(t *testing.T) {
 		t.Fatalf("web_search must not be renamed/reversed: %v", reverseMap)
 	}
 }
+
+// TestRemapOAuthToolNames_TitleCaseCollision_NoDuplicate verifies that two
+// distinct client tool names that title-case to the same value (e.g. "tool1_call"
+// and "tool_1_call" -> "Tool1Call") never produce duplicate upstream tool names:
+// the first wins the TitleCase slot, the second keeps its original name, and the
+// reverse map restores each unambiguously.
+func TestRemapOAuthToolNames_TitleCaseCollision_NoDuplicate(t *testing.T) {
+	body := []byte(`{"tools":[{"name":"tool1_call","input_schema":{"type":"object","properties":{}}},{"name":"tool_1_call","input_schema":{"type":"object","properties":{}}}],"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	out, reverseMap := remapOAuthToolNames(body)
+	n0 := gjson.GetBytes(out, "tools.0.name").String()
+	n1 := gjson.GetBytes(out, "tools.1.name").String()
+	if n0 == n1 {
+		t.Fatalf("duplicate upstream tool names: both %q", n0)
+	}
+	if n0 != "Tool1Call" {
+		t.Fatalf("tools.0.name = %q, want Tool1Call", n0)
+	}
+	if n1 != "tool_1_call" {
+		t.Fatalf("tools.1.name = %q, want tool_1_call (kept to avoid collision)", n1)
+	}
+	if reverseMap["Tool1Call"] != "tool1_call" {
+		t.Fatalf("reverseMap[Tool1Call] = %q, want tool1_call", reverseMap["Tool1Call"])
+	}
+}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2375,3 +2375,27 @@ func TestRemapOAuthToolNames_MCPDoubleUnderscore_Untouched(t *testing.T) {
 		t.Fatalf("reverseMap = %v, want empty", reverseMap)
 	}
 }
+
+// TestRemapOAuthToolNames_ToolChoiceBuiltin_NotRenamed verifies that forcing an
+// Anthropic built-in tool via tool_choice keeps the built-in's lowercase name so
+// it still matches the typed tool in the tools array (which is intentionally left
+// unchanged). A custom tool declared alongside it is still cloaked. Without the
+// built-in guard the generic fallback would rewrite the choice to "WebSearch",
+// producing a tool_choice/tools mismatch that Anthropic rejects.
+func TestRemapOAuthToolNames_ToolChoiceBuiltin_NotRenamed(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"web_search_20250305","name":"web_search"},{"name":"browser_navigate","input_schema":{"type":"object","properties":{}}}],"tool_choice":{"type":"tool","name":"web_search"},"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	out, reverseMap := remapOAuthToolNames(body)
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "web_search" {
+		t.Fatalf("tool_choice.name = %q, want %q (built-in unchanged)", got, "web_search")
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "web_search" {
+		t.Fatalf("tools.0.name = %q, want web_search (built-in unchanged)", got)
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "BrowserNavigate" {
+		t.Fatalf("tools.1.name = %q, want BrowserNavigate (custom still cloaked)", got)
+	}
+	if _, exists := reverseMap["WebSearch"]; exists {
+		t.Fatalf("web_search must not be renamed/reversed: %v", reverseMap)
+	}
+}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2424,3 +2424,20 @@ func TestRemapOAuthToolNames_TitleCaseCollision_NoDuplicate(t *testing.T) {
 		t.Fatalf("reverseMap[Tool1Call] = %q, want tool1_call", reverseMap["Tool1Call"])
 	}
 }
+
+// TestRemapOAuthToolNames_UntypedCustomNamedLikeBuiltin_Renamed verifies that a
+// custom tool whose name merely matches an Anthropic built-in (e.g. "web_search")
+// but is declared WITHOUT a built-in "type" (only name/input_schema, as the OpenAI
+// chat-completions translator emits) is still cloaked to TitleCase — only tools
+// with an actual built-in "type" are protected.
+func TestRemapOAuthToolNames_UntypedCustomNamedLikeBuiltin_Renamed(t *testing.T) {
+	body := []byte(`{"tools":[{"name":"web_search","input_schema":{"type":"object","properties":{"q":{"type":"string"}}}}],"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	out, reverseMap := remapOAuthToolNames(body)
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "WebSearch" {
+		t.Fatalf("tools.0.name = %q, want WebSearch (untyped custom tool must be cloaked)", got)
+	}
+	if reverseMap["WebSearch"] != "web_search" {
+		t.Fatalf("reverseMap[WebSearch] = %q, want web_search", reverseMap["WebSearch"])
+	}
+}


### PR DESCRIPTION
## Summary

The OAuth tool-name cloak only renames the **14 names hard-coded in `oauthToolRenameMap`** (`bash→Bash`, `read→Read`, …). Any **custom or MCP tool whose name is not in that map** — e.g. `browser_navigate`, `list_dir`, `search_files` — keeps its lowercase / `snake_case` form and re-triggers Anthropic's third-party **tool-name fingerprint** on OAuth traffic, so tool-heavy requests get metered/blocked as **`out of extra usage`** even though the curated tools in the same request are cloaked correctly.

This generalizes the cloak: after consulting the curated map, fall back to a generic `snake_case`/lowercase → `TitleCase` transform.

Relates to #2599. Complements #2621 (curated map) and #3214 (`type:"custom"` classification) — neither renames names **outside** the curated map, so real-world agents that ship their own toolset (browser tools, MCP servers, etc.) still leak a third-party fingerprint today.

## Why a generic fallback (evidence)

The gate keys on **casing/style, not a fixed vocabulary**. Replaying one real tool-heavy OAuth request while changing *only* the tool-name casing (same schemas, same count, same everything else):

| tools | result |
|---|---|
| 34 custom tools, `snake_case` (e.g. `browser_navigate`) | **400 `out of extra usage`** |
| the *same* 34 tools renamed to `TitleCase` (e.g. `BrowserNavigate`) | **200** |
| 14 real Claude Code names (`Bash`/`Read`/…) | **200** |

`BrowserNavigate` is **not** a real Claude Code tool yet it passes — so matching the official vocabulary isn't required; matching the *naming style* is. The curated map already fixes style for its 14 entries; this change extends the same treatment to every tool, which is what the map's own comment ("Renaming to official names avoids extra-usage billing") is ultimately after.

## What changed

- New `oauthRenameToolName(name)`: curated `oauthToolRenameMap` first (canonical names preserved), then a generic `snake_case`/lowercase → `TitleCase` fallback.
- Applied at every existing rename site: `tools[]`, `tool_choice`, and message `tool_use` / `tool_reference` / nested `tool_reference`.
- The fallback only matches `^[a-z][a-z0-9]*(_[a-z0-9]+)*$`, so **names already in TitleCase or mixed/camel case are left untouched and produce no reverse-map entry** — this preserves the mixed-case behavior hardened in #2737 / #3149 (e.g. Amp CLI's `Bash` is never rewritten).
- Renamed names go through the **existing per-request reverse map**, so both non-stream (`reverseRemapOAuthToolNames`) and streaming (`restoreClaudeOAuthToolNamesFromStreamLine`) responses restore the client's original names with no extra plumbing.

## Tests

- `TestRemapOAuthToolNames_CustomSnakeCase_GenericFallback` — custom `browser_navigate` → `BrowserNavigate` in `tools` + `tool_choice`, reverse-mapped back to `browser_navigate` in the response.
- `TestRemapOAuthToolNames_CustomTitleCase_Untouched` — an already-TitleCase custom tool is unchanged and yields an empty reverse map.
- Existing remap/prefix tests still pass; `go vet` and `gofmt` clean.

> Note: one pre-existing, unrelated failure (`TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders`) reproduces on a clean checkout and is untouched by this change.
