### PR TITLE
fix: handle codex websocket upstream disconnects

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1451,6 +1451,7 @@ type codexIdentityConfuseState struct {
 	originalPromptCacheKey string
 	promptCacheKey         string
 	turnIDs                []codexIdentityReplacement
+	parentThreadIDs        []codexIdentityReplacement
 }
 
 type codexIdentityReplacement struct {
@@ -1503,20 +1504,24 @@ func applyCodexIdentityConfuseBody(cfg *config.Config, auth *cliproxyauth.Auth, 
 	}
 
 	state := codexIdentityConfuseState{enabled: true, authID: strings.TrimSpace(auth.ID)}
-	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(userPayload, "prompt_cache_key").String()); promptCacheKey != "" {
-		state.originalPromptCacheKey = promptCacheKey
-		state.promptCacheKey = codexIdentityConfuseUUID(auth.ID, "prompt-cache", promptCacheKey)
+	if promptCacheKey := codexIdentityPromptCacheKeyFromPayload(userPayload, rawJSON); promptCacheKey != "" {
+		state.setPromptCacheKey(promptCacheKey)
+	}
+	if state.promptCacheKey != "" && gjson.GetBytes(rawJSON, "prompt_cache_key").Exists() {
 		rawJSON, _ = sjson.SetBytes(rawJSON, "prompt_cache_key", state.promptCacheKey)
 	}
-	if installationID := strings.TrimSpace(gjson.GetBytes(userPayload, "client_metadata.x-codex-installation-id").String()); installationID != "" {
+	if installationID := codexIdentityInstallationIDFromPayload(userPayload, rawJSON); installationID != "" {
 		rawJSON, _ = sjson.SetBytes(rawJSON, "client_metadata.x-codex-installation-id", codexIdentityConfuseUUID(auth.ID, "installation", installationID))
+	}
+	if parentThreadID := codexIdentityParentThreadIDFromPayload(userPayload, rawJSON); parentThreadID != "" {
+		rawJSON, _ = sjson.SetBytes(rawJSON, "client_metadata.x-codex-parent-thread-id", state.confuseParentThreadID(parentThreadID))
 	}
 	if turnMetadata := strings.TrimSpace(gjson.GetBytes(rawJSON, "client_metadata.x-codex-turn-metadata").String()); turnMetadata != "" {
 		rawJSON, _ = sjson.SetBytes(rawJSON, "client_metadata.x-codex-turn-metadata", applyCodexTurnMetadataIdentityConfuse(turnMetadata, &state))
 	}
 	if state.promptCacheKey != "" {
 		if windowID := strings.TrimSpace(gjson.GetBytes(rawJSON, "client_metadata.x-codex-window-id").String()); windowID != "" {
-			rawJSON, _ = sjson.SetBytes(rawJSON, "client_metadata.x-codex-window-id", state.promptCacheKey+":0")
+			rawJSON, _ = sjson.SetBytes(rawJSON, "client_metadata.x-codex-window-id", confuseCodexWindowID(windowID, &state))
 		}
 	}
 
@@ -1531,8 +1536,17 @@ func applyCodexIdentityConfuseHeaders(headers http.Header, state *codexIdentityC
 		return
 	}
 
+	if state.promptCacheKey == "" {
+		state.setPromptCacheKey(codexIdentityPromptCacheKeyFromHeaders(headers))
+	}
+
+	updatedTurnMetadata := ""
 	if rawTurnMetadata := strings.TrimSpace(headers.Get("X-Codex-Turn-Metadata")); rawTurnMetadata != "" {
-		headers.Set("X-Codex-Turn-Metadata", applyCodexTurnMetadataIdentityConfuse(rawTurnMetadata, state))
+		updatedTurnMetadata = applyCodexTurnMetadataIdentityConfuse(rawTurnMetadata, state)
+		headers.Set("X-Codex-Turn-Metadata", updatedTurnMetadata)
+	}
+	if parentThreadID := strings.TrimSpace(headerValueCaseInsensitive(headers, "X-Codex-Parent-Thread-Id")); parentThreadID != "" {
+		headers.Set("X-Codex-Parent-Thread-Id", state.confuseParentThreadID(parentThreadID))
 	}
 	if state.promptCacheKey == "" {
 		return
@@ -1544,7 +1558,11 @@ func applyCodexIdentityConfuseHeaders(headers http.Header, state *codexIdentityC
 	}
 	headers.Set("X-Client-Request-Id", state.promptCacheKey)
 	headers.Set("Thread-Id", state.promptCacheKey)
-	headers.Set("X-Codex-Window-Id", state.promptCacheKey+":0")
+	windowID := strings.TrimSpace(headerValueCaseInsensitive(headers, "X-Codex-Window-Id"))
+	if windowID == "" && updatedTurnMetadata != "" {
+		windowID = strings.TrimSpace(gjson.Get(updatedTurnMetadata, "window_id").String())
+	}
+	headers.Set("X-Codex-Window-Id", confuseCodexWindowID(windowID, state))
 }
 
 func applyCodexTurnMetadataIdentityConfuse(rawTurnMetadata string, state *codexIdentityConfuseState) string {
@@ -1560,16 +1578,146 @@ func applyCodexTurnMetadataIdentityConfuse(rawTurnMetadata string, state *codexI
 	if turnID := strings.TrimSpace(gjson.Get(rawTurnMetadata, "turn_id").String()); turnID != "" {
 		updatedTurnMetadata, _ = sjson.Set(updatedTurnMetadata, "turn_id", state.confuseTurnID(turnID))
 	}
+	if parentThreadID := strings.TrimSpace(gjson.Get(rawTurnMetadata, "parent_thread_id").String()); parentThreadID != "" {
+		updatedTurnMetadata, _ = sjson.Set(updatedTurnMetadata, "parent_thread_id", state.confuseParentThreadID(parentThreadID))
+	}
 	if state.promptCacheKey != "" && gjson.Get(rawTurnMetadata, "window_id").Exists() {
-		updatedTurnMetadata, _ = sjson.Set(updatedTurnMetadata, "window_id", state.promptCacheKey+":0")
+		windowID := strings.TrimSpace(gjson.Get(rawTurnMetadata, "window_id").String())
+		updatedTurnMetadata, _ = sjson.Set(updatedTurnMetadata, "window_id", confuseCodexWindowID(windowID, state))
 	}
 	return updatedTurnMetadata
+}
+
+func codexIdentityPromptCacheKeyFromPayload(userPayload []byte, rawJSON []byte) string {
+	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(userPayload, "prompt_cache_key").String()); promptCacheKey != "" {
+		return promptCacheKey
+	}
+	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(rawJSON, "prompt_cache_key").String()); promptCacheKey != "" {
+		return promptCacheKey
+	}
+	if turnMetadata := strings.TrimSpace(gjson.GetBytes(rawJSON, "client_metadata.x-codex-turn-metadata").String()); turnMetadata != "" {
+		if promptCacheKey := strings.TrimSpace(gjson.Get(turnMetadata, "prompt_cache_key").String()); promptCacheKey != "" {
+			return promptCacheKey
+		}
+		if windowID := strings.TrimSpace(gjson.Get(turnMetadata, "window_id").String()); windowID != "" {
+			if promptCacheKey := codexPromptCacheKeyFromWindowID(windowID); promptCacheKey != "" {
+				return promptCacheKey
+			}
+		}
+	}
+	if windowID := strings.TrimSpace(gjson.GetBytes(rawJSON, "client_metadata.x-codex-window-id").String()); windowID != "" {
+		return codexPromptCacheKeyFromWindowID(windowID)
+	}
+	return ""
+}
+
+func codexIdentityInstallationIDFromPayload(userPayload []byte, rawJSON []byte) string {
+	if installationID := strings.TrimSpace(gjson.GetBytes(userPayload, "client_metadata.x-codex-installation-id").String()); installationID != "" {
+		return installationID
+	}
+	return strings.TrimSpace(gjson.GetBytes(rawJSON, "client_metadata.x-codex-installation-id").String())
+}
+
+func codexIdentityParentThreadIDFromPayload(userPayload []byte, rawJSON []byte) string {
+	if parentThreadID := strings.TrimSpace(gjson.GetBytes(userPayload, "client_metadata.x-codex-parent-thread-id").String()); parentThreadID != "" {
+		return parentThreadID
+	}
+	return strings.TrimSpace(gjson.GetBytes(rawJSON, "client_metadata.x-codex-parent-thread-id").String())
+}
+
+func codexIdentityPromptCacheKeyFromHeaders(headers http.Header) string {
+	if headers == nil {
+		return ""
+	}
+	if turnMetadata := strings.TrimSpace(headers.Get("X-Codex-Turn-Metadata")); turnMetadata != "" {
+		if promptCacheKey := strings.TrimSpace(gjson.Get(turnMetadata, "prompt_cache_key").String()); promptCacheKey != "" {
+			return promptCacheKey
+		}
+		if windowID := strings.TrimSpace(gjson.Get(turnMetadata, "window_id").String()); windowID != "" {
+			if promptCacheKey := codexPromptCacheKeyFromWindowID(windowID); promptCacheKey != "" {
+				return promptCacheKey
+			}
+		}
+	}
+	if windowID := strings.TrimSpace(headerValueCaseInsensitive(headers, "X-Codex-Window-Id")); windowID != "" {
+		if promptCacheKey := codexPromptCacheKeyFromWindowID(windowID); promptCacheKey != "" {
+			return promptCacheKey
+		}
+	}
+	if threadID := strings.TrimSpace(headerValueCaseInsensitive(headers, "Thread-Id")); threadID != "" {
+		return threadID
+	}
+	return ""
+}
+
+func codexPromptCacheKeyFromWindowID(windowID string) string {
+	windowID = strings.TrimSpace(windowID)
+	suffix, ok := codexWindowIDGenerationSuffix(windowID)
+	if !ok {
+		return windowID
+	}
+	return strings.TrimSpace(strings.TrimSuffix(windowID, suffix))
+}
+
+func confuseCodexWindowID(windowID string, state *codexIdentityConfuseState) string {
+	if state == nil || strings.TrimSpace(state.promptCacheKey) == "" {
+		return strings.TrimSpace(windowID)
+	}
+
+	windowID = strings.TrimSpace(windowID)
+	promptCacheKey := strings.TrimSpace(state.promptCacheKey)
+	if windowID == "" {
+		return promptCacheKey + ":0"
+	}
+	if windowID == promptCacheKey || strings.HasPrefix(windowID, promptCacheKey+":") {
+		if windowID == promptCacheKey {
+			return promptCacheKey
+		}
+		if suffix, ok := codexWindowIDGenerationSuffix(windowID); ok {
+			return promptCacheKey + suffix
+		}
+		return promptCacheKey + ":0"
+	}
+
+	originalPromptCacheKey := strings.TrimSpace(state.originalPromptCacheKey)
+	if originalPromptCacheKey != "" {
+		if windowID == originalPromptCacheKey {
+			return promptCacheKey
+		}
+		if strings.HasPrefix(windowID, originalPromptCacheKey+":") {
+			if suffix, ok := codexWindowIDGenerationSuffix(windowID); ok {
+				return promptCacheKey + suffix
+			}
+			return promptCacheKey + ":0"
+		}
+	}
+
+	if suffix, ok := codexWindowIDGenerationSuffix(windowID); ok {
+		return promptCacheKey + suffix
+	}
+	return promptCacheKey + ":0"
+}
+
+func codexWindowIDGenerationSuffix(windowID string) (string, bool) {
+	idx := strings.LastIndex(windowID, ":")
+	if idx < 0 || idx == len(windowID)-1 {
+		return "", false
+	}
+	for _, ch := range windowID[idx+1:] {
+		if ch < '0' || ch > '9' {
+			return "", false
+		}
+	}
+	return windowID[idx:], true
 }
 
 func applyCodexIdentityConfuseResponsePayload(payload []byte, state codexIdentityConfuseState) []byte {
 	payload = replaceCodexIdentityResponsePayload(payload, state.originalPromptCacheKey, state.promptCacheKey)
 	for _, turnID := range state.turnIDs {
 		payload = replaceCodexIdentityResponsePayload(payload, turnID.original, turnID.confused)
+	}
+	for _, parentThreadID := range state.parentThreadIDs {
+		payload = replaceCodexIdentityResponsePayload(payload, parentThreadID.original, parentThreadID.confused)
 	}
 	return payload
 }
@@ -1578,6 +1726,9 @@ func applyCodexIdentityExposeResponsePayload(payload []byte, state codexIdentity
 	payload = replaceCodexIdentityResponsePayload(payload, state.promptCacheKey, state.originalPromptCacheKey)
 	for _, turnID := range state.turnIDs {
 		payload = replaceCodexIdentityResponsePayload(payload, turnID.confused, turnID.original)
+	}
+	for _, parentThreadID := range state.parentThreadIDs {
+		payload = replaceCodexIdentityResponsePayload(payload, parentThreadID.confused, parentThreadID.original)
 	}
 	return payload
 }
@@ -1595,6 +1746,30 @@ func (state *codexIdentityConfuseState) confuseTurnID(turnID string) string {
 	confusedTurnID := codexIdentityConfuseUUID(state.authID, "turn", turnID)
 	state.turnIDs = append(state.turnIDs, codexIdentityReplacement{original: turnID, confused: confusedTurnID})
 	return confusedTurnID
+}
+
+func (state *codexIdentityConfuseState) confuseParentThreadID(parentThreadID string) string {
+	parentThreadID = strings.TrimSpace(parentThreadID)
+	if state == nil || !state.enabled || strings.TrimSpace(state.authID) == "" || parentThreadID == "" {
+		return parentThreadID
+	}
+	for _, replacement := range state.parentThreadIDs {
+		if replacement.original == parentThreadID || replacement.confused == parentThreadID {
+			return replacement.confused
+		}
+	}
+	confusedParentThreadID := codexIdentityConfuseUUID(state.authID, "parent-thread", parentThreadID)
+	state.parentThreadIDs = append(state.parentThreadIDs, codexIdentityReplacement{original: parentThreadID, confused: confusedParentThreadID})
+	return confusedParentThreadID
+}
+
+func (state *codexIdentityConfuseState) setPromptCacheKey(promptCacheKey string) {
+	promptCacheKey = strings.TrimSpace(promptCacheKey)
+	if state == nil || !state.enabled || strings.TrimSpace(state.authID) == "" || promptCacheKey == "" {
+		return
+	}
+	state.originalPromptCacheKey = promptCacheKey
+	state.promptCacheKey = codexIdentityConfuseUUID(state.authID, "prompt-cache", promptCacheKey)
 }
 
 func replaceCodexIdentityResponsePayload(payload []byte, from string, to string) []byte {
@@ -1633,7 +1808,10 @@ func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, s
 	}
 	misc.EnsureHeader(r.Header, ginHeaders, "Version", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Codex-Turn-Metadata", "")
+	misc.EnsureHeader(r.Header, ginHeaders, "X-Codex-Window-Id", "")
+	misc.EnsureHeader(r.Header, ginHeaders, "X-Codex-Parent-Thread-Id", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Client-Request-Id", "")
+	misc.EnsureHeader(r.Header, ginHeaders, "Thread-Id", "")
 	cfgUserAgent, _ := codexHeaderDefaults(cfg, auth)
 	ensureHeaderWithConfigPrecedence(r.Header, ginHeaders, "User-Agent", cfgUserAgent, codexUserAgent)
 

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -3,7 +3,9 @@ package executor
 import (
 	"context"
 	"io"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -154,7 +156,8 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 	recorder := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(recorder)
 	ginCtx.Request = httptest.NewRequest("POST", "/v1/responses", nil)
-	ginCtx.Request.Header.Set("X-Codex-Turn-Metadata", `{"prompt_cache_key":"cache-1","turn_id":"turn-1","window_id":"cache-1:0"}`)
+	ginCtx.Request.Header.Set("X-Codex-Turn-Metadata", `{"prompt_cache_key":"cache-1","turn_id":"turn-1","parent_thread_id":"parent-1","window_id":"cache-1:2"}`)
+	ginCtx.Request.Header.Set("X-Codex-Parent-Thread-Id", "parent-1")
 	ginCtx.Request.Header.Set("X-Client-Request-Id", "client-request-1")
 
 	ctx := context.WithValue(context.Background(), "gin", ginCtx)
@@ -163,7 +166,7 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 		Codex:   config.CodexConfig{IdentityConfuse: true},
 	}}
 	auth := &cliproxyauth.Auth{ID: "auth-1", Provider: "codex"}
-	rawJSON := []byte(`{"model":"gpt-5-codex","stream":true,"client_metadata":{"x-codex-turn-metadata":"{\"prompt_cache_key\":\"cache-1\",\"turn_id\":\"turn-1\",\"window_id\":\"cache-1:0\"}","x-codex-window-id":"cache-1:0"}}`)
+	rawJSON := []byte(`{"model":"gpt-5-codex","stream":true,"client_metadata":{"x-codex-turn-metadata":"{\"prompt_cache_key\":\"cache-1\",\"turn_id\":\"turn-1\",\"parent_thread_id\":\"parent-1\",\"window_id\":\"cache-1:2\"}","x-codex-window-id":"cache-1:2","x-codex-parent-thread-id":"parent-1"}}`)
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5-codex",
 		Payload: []byte(`{"model":"gpt-5-codex","prompt_cache_key":"cache-1","client_metadata":{"x-codex-installation-id":"install-1"}}`),
@@ -179,8 +182,12 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 
 	expectedPromptCacheKey := codexIdentityConfuseUUID("auth-1", "prompt-cache", "cache-1")
 	expectedTurnID := codexIdentityConfuseUUID("auth-1", "turn", "turn-1")
+	expectedParentThreadID := codexIdentityConfuseUUID("auth-1", "parent-thread", "parent-1")
 	if gotKey := gjson.GetBytes(body, "prompt_cache_key").String(); gotKey != expectedPromptCacheKey {
 		t.Fatalf("prompt_cache_key = %q, want %q", gotKey, expectedPromptCacheKey)
+	}
+	if strings.Contains(string(body), "cache-1") {
+		t.Fatalf("upstream body still contains original prompt cache key: %s", string(body))
 	}
 	expectedInstallationID := codexIdentityConfuseUUID("auth-1", "installation", "install-1")
 	if gotID := gjson.GetBytes(body, "client_metadata.x-codex-installation-id").String(); gotID != expectedInstallationID {
@@ -193,11 +200,14 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 	if gotMetadataTurnID := gjson.Get(gotBodyMetadata, "turn_id").String(); gotMetadataTurnID != expectedTurnID {
 		t.Fatalf("client_metadata.x-codex-turn-metadata.turn_id = %q, want %q", gotMetadataTurnID, expectedTurnID)
 	}
-	if gotMetadataWindowID := gjson.Get(gotBodyMetadata, "window_id").String(); gotMetadataWindowID != expectedPromptCacheKey+":0" {
-		t.Fatalf("client_metadata.x-codex-turn-metadata.window_id = %q, want %q", gotMetadataWindowID, expectedPromptCacheKey+":0")
+	if gotMetadataParentThreadID := gjson.Get(gotBodyMetadata, "parent_thread_id").String(); gotMetadataParentThreadID != expectedParentThreadID {
+		t.Fatalf("client_metadata.x-codex-turn-metadata.parent_thread_id = %q, want %q", gotMetadataParentThreadID, expectedParentThreadID)
 	}
-	if gotWindowID := gjson.GetBytes(body, "client_metadata.x-codex-window-id").String(); gotWindowID != expectedPromptCacheKey+":0" {
-		t.Fatalf("client_metadata.x-codex-window-id = %q, want %q", gotWindowID, expectedPromptCacheKey+":0")
+	if gotMetadataWindowID := gjson.Get(gotBodyMetadata, "window_id").String(); gotMetadataWindowID != expectedPromptCacheKey+":2" {
+		t.Fatalf("client_metadata.x-codex-turn-metadata.window_id = %q, want %q", gotMetadataWindowID, expectedPromptCacheKey+":2")
+	}
+	if gotWindowID := gjson.GetBytes(body, "client_metadata.x-codex-window-id").String(); gotWindowID != expectedPromptCacheKey+":2" {
+		t.Fatalf("client_metadata.x-codex-window-id = %q, want %q", gotWindowID, expectedPromptCacheKey+":2")
 	}
 	if gotHeader := httpReq.Header["Session_id"]; len(gotHeader) != 1 || gotHeader[0] != expectedPromptCacheKey {
 		t.Fatalf("Session_id = %#v, want [%q]", gotHeader, expectedPromptCacheKey)
@@ -210,8 +220,11 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 	if gotCanonicalSession := httpReq.Header.Get("Session-Id"); gotCanonicalSession != "" {
 		t.Fatalf("Session-Id = %q, want empty", gotCanonicalSession)
 	}
-	if gotWindow := httpReq.Header.Get("X-Codex-Window-Id"); gotWindow != expectedPromptCacheKey+":0" {
-		t.Fatalf("X-Codex-Window-Id = %q, want %q", gotWindow, expectedPromptCacheKey+":0")
+	if gotWindow := httpReq.Header.Get("X-Codex-Window-Id"); gotWindow != expectedPromptCacheKey+":2" {
+		t.Fatalf("X-Codex-Window-Id = %q, want %q", gotWindow, expectedPromptCacheKey+":2")
+	}
+	if gotParentThreadID := httpReq.Header.Get("X-Codex-Parent-Thread-Id"); gotParentThreadID != expectedParentThreadID {
+		t.Fatalf("X-Codex-Parent-Thread-Id = %q, want %q", gotParentThreadID, expectedParentThreadID)
 	}
 	gotHeaderMetadata := httpReq.Header.Get("X-Codex-Turn-Metadata")
 	if gotMetadataPromptCacheKey := gjson.Get(gotHeaderMetadata, "prompt_cache_key").String(); gotMetadataPromptCacheKey != expectedPromptCacheKey {
@@ -220,8 +233,235 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 	if gotMetadataTurnID := gjson.Get(gotHeaderMetadata, "turn_id").String(); gotMetadataTurnID != expectedTurnID {
 		t.Fatalf("X-Codex-Turn-Metadata.turn_id = %q, want %q", gotMetadataTurnID, expectedTurnID)
 	}
-	if gotMetadataWindowID := gjson.Get(gotHeaderMetadata, "window_id").String(); gotMetadataWindowID != expectedPromptCacheKey+":0" {
-		t.Fatalf("X-Codex-Turn-Metadata.window_id = %q, want %q", gotMetadataWindowID, expectedPromptCacheKey+":0")
+	if gotMetadataParentThreadID := gjson.Get(gotHeaderMetadata, "parent_thread_id").String(); gotMetadataParentThreadID != expectedParentThreadID {
+		t.Fatalf("X-Codex-Turn-Metadata.parent_thread_id = %q, want %q", gotMetadataParentThreadID, expectedParentThreadID)
+	}
+	if gotMetadataWindowID := gjson.Get(gotHeaderMetadata, "window_id").String(); gotMetadataWindowID != expectedPromptCacheKey+":2" {
+		t.Fatalf("X-Codex-Turn-Metadata.window_id = %q, want %q", gotMetadataWindowID, expectedPromptCacheKey+":2")
+	}
+}
+
+func TestApplyCodexIdentityConfuseBodyDerivesPromptCacheKeyFromMetadata(t *testing.T) {
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{Strategy: "fill-first"},
+		Codex:   config.CodexConfig{IdentityConfuse: true},
+	}
+	auth := &cliproxyauth.Auth{ID: "auth-1", Provider: "codex"}
+	rawJSON := []byte(`{"model":"gpt-5-codex","client_metadata":{"x-codex-turn-metadata":"{\"prompt_cache_key\":\"cache-meta-1\",\"turn_id\":\"turn-meta-1\",\"parent_thread_id\":\"parent-meta-1\",\"window_id\":\"cache-meta-1:6\"}","x-codex-window-id":"cache-meta-1:6","x-codex-parent-thread-id":"parent-meta-1"}}`)
+
+	body, state := applyCodexIdentityConfuseBody(cfg, auth, []byte(`{"model":"gpt-5-codex"}`), rawJSON)
+
+	expectedPromptCacheKey := codexIdentityConfuseUUID("auth-1", "prompt-cache", "cache-meta-1")
+	expectedTurnID := codexIdentityConfuseUUID("auth-1", "turn", "turn-meta-1")
+	if state.promptCacheKey != expectedPromptCacheKey {
+		t.Fatalf("state.promptCacheKey = %q, want %q", state.promptCacheKey, expectedPromptCacheKey)
+	}
+	if strings.Contains(string(body), "cache-meta-1") {
+		t.Fatalf("upstream body still contains metadata prompt cache key: %s", string(body))
+	}
+	if strings.Contains(string(body), "parent-meta-1") {
+		t.Fatalf("upstream body still contains parent thread id: %s", string(body))
+	}
+	gotMetadata := gjson.GetBytes(body, "client_metadata.x-codex-turn-metadata").String()
+	if got := gjson.Get(gotMetadata, "prompt_cache_key").String(); got != expectedPromptCacheKey {
+		t.Fatalf("metadata prompt_cache_key = %q, want %q", got, expectedPromptCacheKey)
+	}
+	if got := gjson.Get(gotMetadata, "turn_id").String(); got != expectedTurnID {
+		t.Fatalf("metadata turn_id = %q, want %q", got, expectedTurnID)
+	}
+	expectedParentThreadID := codexIdentityConfuseUUID("auth-1", "parent-thread", "parent-meta-1")
+	if got := gjson.Get(gotMetadata, "parent_thread_id").String(); got != expectedParentThreadID {
+		t.Fatalf("metadata parent_thread_id = %q, want %q", got, expectedParentThreadID)
+	}
+	if got := gjson.Get(gotMetadata, "window_id").String(); got != expectedPromptCacheKey+":6" {
+		t.Fatalf("metadata window_id = %q, want %q", got, expectedPromptCacheKey+":6")
+	}
+	if got := gjson.GetBytes(body, "client_metadata.x-codex-window-id").String(); got != expectedPromptCacheKey+":6" {
+		t.Fatalf("client_metadata.x-codex-window-id = %q, want %q", got, expectedPromptCacheKey+":6")
+	}
+	if got := gjson.GetBytes(body, "client_metadata.x-codex-parent-thread-id").String(); got != expectedParentThreadID {
+		t.Fatalf("parent thread id = %q, want %q", got, expectedParentThreadID)
+	}
+}
+
+func TestApplyCodexIdentityConfuseBodyConfusesRawJSONInstallationID(t *testing.T) {
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{Strategy: "fill-first"},
+		Codex:   config.CodexConfig{IdentityConfuse: true},
+	}
+	auth := &cliproxyauth.Auth{ID: "auth-1", Provider: "codex"}
+	rawJSON := []byte(`{"model":"gpt-5-codex","prompt_cache_key":"cache-1","client_metadata":{"x-codex-installation-id":"install-raw-1"}}`)
+
+	body, _ := applyCodexIdentityConfuseBody(cfg, auth, []byte(`{"model":"gpt-5-codex"}`), rawJSON)
+
+	expectedInstallationID := codexIdentityConfuseUUID("auth-1", "installation", "install-raw-1")
+	if got := gjson.GetBytes(body, "client_metadata.x-codex-installation-id").String(); got != expectedInstallationID {
+		t.Fatalf("installation id = %q, want %q", got, expectedInstallationID)
+	}
+	if strings.Contains(string(body), "install-raw-1") {
+		t.Fatalf("upstream body still contains raw installation id: %s", string(body))
+	}
+}
+
+func TestApplyCodexIdentityConfuseHeadersDerivesPromptCacheKeyFromHeaders(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Codex-Turn-Metadata", `{"prompt_cache_key":"cache-header-1","turn_id":"turn-header-1","parent_thread_id":"parent-header-1","window_id":"cache-header-1:7"}`)
+	headers.Set("X-Codex-Window-Id", "cache-header-1:7")
+	headers.Set("X-Codex-Parent-Thread-Id", "parent-header-1")
+	headers.Set("Thread-Id", "thread-header-1")
+	state := &codexIdentityConfuseState{enabled: true, authID: "auth-1"}
+
+	applyCodexIdentityConfuseHeaders(headers, state)
+
+	expectedPromptCacheKey := codexIdentityConfuseUUID("auth-1", "prompt-cache", "cache-header-1")
+	expectedTurnID := codexIdentityConfuseUUID("auth-1", "turn", "turn-header-1")
+	if strings.Contains(headers.Get("X-Codex-Turn-Metadata"), "cache-header-1") {
+		t.Fatalf("upstream turn metadata still contains original prompt cache key: %s", headers.Get("X-Codex-Turn-Metadata"))
+	}
+	if got := headers.Get("X-Codex-Parent-Thread-Id"); got == "parent-header-1" || got != codexIdentityConfuseUUID("auth-1", "parent-thread", "parent-header-1") {
+		t.Fatalf("X-Codex-Parent-Thread-Id = %q, want confused parent thread id", got)
+	}
+	confusedParentThreadID := headers.Get("X-Codex-Parent-Thread-Id")
+	applyCodexIdentityConfuseHeaders(headers, state)
+	if got := headers.Get("X-Codex-Parent-Thread-Id"); got != confusedParentThreadID {
+		t.Fatalf("X-Codex-Parent-Thread-Id was confused twice: got %q, want %q", got, confusedParentThreadID)
+	}
+	if got := headers.Get("X-Codex-Window-Id"); got != expectedPromptCacheKey+":7" {
+		t.Fatalf("X-Codex-Window-Id = %q, want %q", got, expectedPromptCacheKey+":7")
+	}
+	if got := headers.Get("Thread-Id"); got != expectedPromptCacheKey {
+		t.Fatalf("Thread-Id = %q, want %q", got, expectedPromptCacheKey)
+	}
+	gotMetadata := headers.Get("X-Codex-Turn-Metadata")
+	if got := gjson.Get(gotMetadata, "prompt_cache_key").String(); got != expectedPromptCacheKey {
+		t.Fatalf("metadata prompt_cache_key = %q, want %q", got, expectedPromptCacheKey)
+	}
+	if got := gjson.Get(gotMetadata, "turn_id").String(); got != expectedTurnID {
+		t.Fatalf("metadata turn_id = %q, want %q", got, expectedTurnID)
+	}
+	if got := gjson.Get(gotMetadata, "parent_thread_id").String(); got != confusedParentThreadID {
+		t.Fatalf("metadata parent_thread_id = %q, want %q", got, confusedParentThreadID)
+	}
+	if got := gjson.Get(gotMetadata, "window_id").String(); got != expectedPromptCacheKey+":7" {
+		t.Fatalf("metadata window_id = %q, want %q", got, expectedPromptCacheKey+":7")
+	}
+}
+
+func TestApplyCodexIdentityConfuseHeadersDerivesPromptCacheKeyFromWindowHeader(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Codex-Window-Id", "cache-window-1:8")
+	headers.Set("Thread-Id", "thread-header-1")
+	state := &codexIdentityConfuseState{enabled: true, authID: "auth-1"}
+
+	applyCodexIdentityConfuseHeaders(headers, state)
+
+	expectedPromptCacheKey := codexIdentityConfuseUUID("auth-1", "prompt-cache", "cache-window-1")
+	if got := headers.Get("X-Codex-Window-Id"); got != expectedPromptCacheKey+":8" {
+		t.Fatalf("X-Codex-Window-Id = %q, want %q", got, expectedPromptCacheKey+":8")
+	}
+	if got := headers.Get("Thread-Id"); got != expectedPromptCacheKey {
+		t.Fatalf("Thread-Id = %q, want %q", got, expectedPromptCacheKey)
+	}
+}
+
+func TestApplyCodexIdentityConfuseHeadersConfusesParentThreadWithoutPromptCacheKey(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Codex-Parent-Thread-Id", "parent-only-1")
+	headers.Set("X-Codex-Turn-Metadata", `{"parent_thread_id":"parent-only-1"}`)
+	state := &codexIdentityConfuseState{enabled: true, authID: "auth-1"}
+
+	applyCodexIdentityConfuseHeaders(headers, state)
+
+	expectedParentThreadID := codexIdentityConfuseUUID("auth-1", "parent-thread", "parent-only-1")
+	if got := headers.Get("X-Codex-Parent-Thread-Id"); got != expectedParentThreadID {
+		t.Fatalf("X-Codex-Parent-Thread-Id = %q, want %q", got, expectedParentThreadID)
+	}
+	gotMetadata := headers.Get("X-Codex-Turn-Metadata")
+	if got := gjson.Get(gotMetadata, "parent_thread_id").String(); got != expectedParentThreadID {
+		t.Fatalf("metadata parent_thread_id = %q, want %q", got, expectedParentThreadID)
+	}
+	if got := headers.Get("Thread-Id"); got != "" {
+		t.Fatalf("Thread-Id = %q, want empty without prompt cache key", got)
+	}
+	if got := headers.Get("X-Codex-Window-Id"); got != "" {
+		t.Fatalf("X-Codex-Window-Id = %q, want empty without prompt cache key", got)
+	}
+}
+
+func TestConfuseCodexWindowIDPreservesOnlyGeneration(t *testing.T) {
+	state := &codexIdentityConfuseState{
+		enabled:                true,
+		authID:                 "auth-1",
+		originalPromptCacheKey: "cache-1",
+		promptCacheKey:         codexIdentityConfuseUUID("auth-1", "prompt-cache", "cache-1"),
+	}
+
+	tests := []struct {
+		name     string
+		windowID string
+		want     string
+	}{
+		{
+			name:     "official original window generation",
+			windowID: "cache-1:2",
+			want:     state.promptCacheKey + ":2",
+		},
+		{
+			name:     "already confused window generation",
+			windowID: state.promptCacheKey + ":3",
+			want:     state.promptCacheKey + ":3",
+		},
+		{
+			name:     "multi segment original window keeps only numeric generation",
+			windowID: "cache-1:workspace:4",
+			want:     state.promptCacheKey + ":4",
+		},
+		{
+			name:     "non numeric original suffix falls back",
+			windowID: "cache-1:workspace",
+			want:     state.promptCacheKey + ":0",
+		},
+		{
+			name:     "unrelated window with numeric suffix keeps only generation",
+			windowID: "other-window:5",
+			want:     state.promptCacheKey + ":5",
+		},
+		{
+			name:     "unrelated window without numeric suffix falls back",
+			windowID: "other-window",
+			want:     state.promptCacheKey + ":0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := confuseCodexWindowID(tt.windowID, state); got != tt.want {
+				t.Fatalf("confuseCodexWindowID(%q) = %q, want %q", tt.windowID, got, tt.want)
+			}
+			if strings.Contains(confuseCodexWindowID(tt.windowID, state), "cache-1") {
+				t.Fatalf("confused window id leaked original prompt cache key: %q", confuseCodexWindowID(tt.windowID, state))
+			}
+		})
+	}
+}
+
+func TestApplyCodexHeadersPreservesWindowAndThreadHeaders(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+	ginCtx.Request.Header.Set("X-Codex-Window-Id", "cache-1:2")
+	ginCtx.Request.Header.Set("Thread-Id", "thread-1")
+
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+	httpReq := httptest.NewRequest("POST", "https://example.com/responses", nil).WithContext(ctx)
+
+	applyCodexHeaders(httpReq, &cliproxyauth.Auth{Provider: "codex"}, "oauth-token", true, nil)
+
+	if got := httpReq.Header.Get("X-Codex-Window-Id"); got != "cache-1:2" {
+		t.Fatalf("X-Codex-Window-Id = %q, want cache-1:2", got)
+	}
+	if got := httpReq.Header.Get("Thread-Id"); got != "thread-1" {
+		t.Fatalf("Thread-Id = %q, want thread-1", got)
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -5,6 +5,7 @@ package executor
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -70,10 +71,14 @@ type codexWebsocketSession struct {
 
 	writeMu sync.Mutex
 
-	activeMu     sync.Mutex
-	activeCh     chan codexWebsocketRead
-	activeDone   <-chan struct{}
-	activeCancel context.CancelFunc
+	activeMu        sync.Mutex
+	activeCh        chan codexWebsocketRead
+	activeConn      *websocket.Conn
+	activeDone      <-chan struct{}
+	activeCancel    context.CancelFunc
+	activeClosedCh  chan codexWebsocketRead
+	activeClosedErr error
+	terminalErr     error
 
 	readerConn *websocket.Conn
 
@@ -96,7 +101,20 @@ type codexWebsocketRead struct {
 	err     error
 }
 
-func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
+type codexWebsocketUpstreamResetError struct {
+	cause error
+}
+
+func (e codexWebsocketUpstreamResetError) Error() string {
+	if e.cause == nil {
+		return "codex websockets executor: upstream websocket reset"
+	}
+	return fmt.Sprintf("codex websockets executor: upstream websocket reset: %v", e.cause)
+}
+
+func (e codexWebsocketUpstreamResetError) Unwrap() error { return e.cause }
+
+func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead, conn *websocket.Conn) {
 	if s == nil {
 		return
 	}
@@ -106,8 +124,12 @@ func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
 		s.activeCancel = nil
 		s.activeDone = nil
 	}
+	s.activeClosedCh = nil
+	s.activeClosedErr = nil
 	s.activeCh = ch
+	s.activeConn = nil
 	if ch != nil {
+		s.activeConn = conn
 		activeCtx, activeCancel := context.WithCancel(context.Background())
 		s.activeDone = activeCtx.Done()
 		s.activeCancel = activeCancel
@@ -115,18 +137,71 @@ func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
 	s.activeMu.Unlock()
 }
 
-func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
+func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) bool {
 	if s == nil {
-		return
+		return false
 	}
 	s.activeMu.Lock()
+	cleared := false
 	if s.activeCh == ch {
 		s.activeCh = nil
+		s.activeConn = nil
 		if s.activeCancel != nil {
 			s.activeCancel()
 		}
 		s.activeCancel = nil
 		s.activeDone = nil
+		cleared = true
+	}
+	if s.activeClosedCh == ch {
+		s.activeClosedCh = nil
+		s.activeClosedErr = nil
+	}
+	s.activeMu.Unlock()
+	return cleared
+}
+
+func (s *codexWebsocketSession) activeDoneFor(ch chan codexWebsocketRead) (<-chan struct{}, bool) {
+	if s == nil || ch == nil {
+		return nil, false
+	}
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	if s.activeCh != ch {
+		return nil, false
+	}
+	return s.activeDone, true
+}
+
+func (s *codexWebsocketSession) closedActiveErrorFor(ch chan codexWebsocketRead) error {
+	if s == nil || ch == nil {
+		return nil
+	}
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	if s.activeClosedCh != ch {
+		return nil
+	}
+	return s.activeClosedErr
+}
+
+func (s *codexWebsocketSession) terminalError() error {
+	if s == nil {
+		return nil
+	}
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	return s.terminalErr
+}
+
+func (s *codexWebsocketSession) markTerminalError(err error) {
+	if s == nil || err == nil {
+		return
+	}
+	s.activeMu.Lock()
+	s.terminalErr = err
+	if s.activeClosedCh != nil {
+		s.activeClosedErr = err
 	}
 	s.activeMu.Unlock()
 }
@@ -135,15 +210,69 @@ func (s *codexWebsocketSession) activeReadForConn(conn *websocket.Conn) (chan co
 	if s == nil || conn == nil {
 		return nil, nil, false
 	}
-	s.activeMu.Lock()
-	defer s.activeMu.Unlock()
 	s.connMu.Lock()
 	isCurrent := s.conn == conn
 	s.connMu.Unlock()
 	if !isCurrent {
 		return nil, nil, false
 	}
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	if s.activeConn != conn {
+		return nil, nil, true
+	}
 	return s.activeCh, s.activeDone, true
+}
+
+func (s *codexWebsocketSession) closeActiveReadForConn(conn *websocket.Conn, err error) {
+	if s == nil || conn == nil {
+		return
+	}
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	if s.activeConn != conn || s.activeCh == nil {
+		return
+	}
+	ch := s.activeCh
+	s.activeCh = nil
+	s.activeConn = nil
+	s.activeClosedCh = ch
+	s.activeClosedErr = err
+	if s.activeCancel != nil {
+		s.activeCancel()
+	}
+	s.activeCancel = nil
+	s.activeDone = nil
+	select {
+	case ch <- codexWebsocketRead{conn: conn, err: err}:
+	default:
+	}
+}
+
+func (s *codexWebsocketSession) closeActiveRead(err error) {
+	if s == nil {
+		return
+	}
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	if s.activeCh == nil {
+		return
+	}
+	ch := s.activeCh
+	conn := s.activeConn
+	s.activeCh = nil
+	s.activeConn = nil
+	s.activeClosedCh = ch
+	s.activeClosedErr = err
+	if s.activeCancel != nil {
+		s.activeCancel()
+	}
+	s.activeCancel = nil
+	s.activeDone = nil
+	select {
+	case ch <- codexWebsocketRead{conn: conn, err: err}:
+	default:
+	}
 }
 
 func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, payload []byte) error {
@@ -246,6 +375,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
+	applyCodexWebsocketClientMetadataHeaders(wsHeaders, upstreamBody)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
 
 	var authID, authLabel, authType, authValue string
@@ -277,7 +407,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 	helps.RecordAPIWebsocketRequest(ctx, e.cfg, wsReqLog)
 
-	conn, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
+	conn, respHS, upstreamCreated, errDial := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
 	if errDial != nil {
 		bodyErr := websocketHandshakeBody(respHS)
 		if respHS != nil {
@@ -294,6 +424,11 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 	recordAPIWebsocketHandshake(ctx, e.cfg, respHS)
 	reporter.StartResponseTTFT()
+	if sess != nil && cliproxyexecutor.DownstreamWebsocket(ctx) && upstreamCreated && codexWebsocketRequestNeedsTranscriptReplayOnReset(wsReqBody) {
+		errReplay := codexWebsocketTranscriptReplayRequiredError{reason: "upstream_recreated"}
+		helps.RecordAPIWebsocketError(ctx, e.cfg, "replay_required", errReplay)
+		return resp, errReplay
+	}
 	if sess == nil {
 		logCodexWebsocketConnected(executionSessionID, authID, wsURL)
 		defer func() {
@@ -311,7 +446,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	var readCh chan codexWebsocketRead
 	if sess != nil {
 		readCh = make(chan codexWebsocketRead, 4096)
-		sess.setActive(readCh)
+		sess.setActive(readCh, conn)
 		defer func() {
 			sess.clearActive(readCh)
 		}()
@@ -321,41 +456,45 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		if sess != nil {
 			e.dropUpstreamConn(sess, conn, "send_error", errSend, false)
 			sess.clearActive(readCh)
-			readCh = make(chan codexWebsocketRead, 4096)
-			sess.setActive(readCh)
+			if codexWebsocketRequestNeedsTranscriptReplayOnReset(wsReqBody) {
+				errReplay := codexWebsocketTranscriptReplayRequiredError{reason: "send_error", cause: errSend}
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "replay_required", errReplay)
+				return resp, errReplay
+			}
 
 			// Retry once with a fresh websocket connection. This is mainly to handle
 			// upstream closing the socket between sequential requests within the same
 			// execution session.
-			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
-			if errDialRetry == nil && connRetry != nil {
-				wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
-				helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
-					URL:       wsURL,
-					Method:    "WEBSOCKET",
-					Headers:   wsHeaders.Clone(),
-					Body:      wsReqBodyRetry,
-					Provider:  e.Identifier(),
-					AuthID:    authID,
-					AuthLabel: authLabel,
-					AuthType:  authType,
-					AuthValue: authValue,
-				})
-				recordAPIWebsocketHandshake(ctx, e.cfg, respHSRetry)
-				reporter.StartResponseTTFT()
-				if errSendRetry := writeCodexWebsocketMessage(sess, connRetry, wsReqBodyRetry); errSendRetry == nil {
-					conn = connRetry
-					wsReqBody = wsReqBodyRetry
-				} else {
-					e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry)
-					helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
-					return resp, errSendRetry
-				}
-			} else {
+			connRetry, respHSRetry, _, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
+			if errDialRetry != nil || connRetry == nil {
 				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
 				return resp, errDialRetry
 			}
+			readCh = make(chan codexWebsocketRead, 4096)
+			sess.setActive(readCh, connRetry)
+			wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
+			helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+				URL:       wsURL,
+				Method:    "WEBSOCKET",
+				Headers:   wsHeaders.Clone(),
+				Body:      wsReqBodyRetry,
+				Provider:  e.Identifier(),
+				AuthID:    authID,
+				AuthLabel: authLabel,
+				AuthType:  authType,
+				AuthValue: authValue,
+			})
+			recordAPIWebsocketHandshake(ctx, e.cfg, respHSRetry)
+			reporter.StartResponseTTFT()
+			if errSendRetry := writeCodexWebsocketMessage(sess, connRetry, wsReqBodyRetry); errSendRetry != nil {
+				e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry)
+				sess.clearActive(readCh)
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
+				return resp, errSendRetry
+			}
+			conn = connRetry
+			wsReqBody = wsReqBodyRetry
 		} else {
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
 			return resp, errSend
@@ -368,6 +507,14 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		}
 		msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh)
 		if errRead != nil {
+			if sess != nil && ctx != nil && ctx.Err() != nil {
+				return resp, ctx.Err()
+			}
+			if codexWebsocketReadErrorRequiresTranscriptReplay(wsReqBody, errRead, cliproxyexecutor.DownstreamWebsocket(ctx)) {
+				errReplay := codexWebsocketTranscriptReplayRequiredError{reason: "read_error", cause: errRead}
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "replay_required", errReplay)
+				return resp, errReplay
+			}
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "read", errRead)
 			return resp, errRead
 		}
@@ -392,15 +539,24 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		helps.AppendAPIWebsocketResponse(ctx, e.cfg, payload)
 
 		if wsErr, ok := parseCodexWebsocketError(payload); ok {
+			clientErr := exposeCodexWebsocketError(payload, identityState, wsErr)
 			if sess != nil {
-				if isCodexWebsocketPreviousResponseNotFound(payload) {
-					e.dropUpstreamConn(sess, conn, "previous_response_not_found", wsErr, false)
+				if shouldDropCodexWebsocketUpstreamErrorQuietly(payload, wsErr) {
+					e.dropUpstreamConn(sess, conn, codexWebsocketUpstreamErrorDropReason(payload, wsErr), wsErr, false)
 				} else {
 					e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
 				}
 			}
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
-			return resp, wsErr
+			return resp, clientErr
+		}
+
+		if failedErr, ok := parseCodexWebsocketResponseFailed(payload); ok {
+			if sess != nil {
+				e.dropUpstreamConn(sess, conn, "response_failed", failedErr, false)
+			}
+			helps.RecordAPIWebsocketError(ctx, e.cfg, "response_failed", failedErr)
+			return resp, failedErr
 		}
 
 		payload = normalizeCodexWebsocketCompletion(payload)
@@ -474,6 +630,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, userPayload, body)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
+	applyCodexWebsocketClientMetadataHeaders(wsHeaders, upstreamBody)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
 
 	var authID, authLabel, authType, authValue string
@@ -487,6 +644,11 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		sess = e.getOrCreateSession(executionSessionID)
 		if sess != nil {
 			sess.reqMu.Lock()
+		}
+	}
+	unlockSessionRequest := func() {
+		if sess != nil {
+			sess.reqMu.Unlock()
 		}
 	}
 
@@ -504,7 +666,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 	helps.RecordAPIWebsocketRequest(ctx, e.cfg, wsReqLog)
 
-	conn, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
+	conn, respHS, upstreamCreated, errDial := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
 	var upstreamHeaders http.Header
 	if respHS != nil {
 		upstreamHeaders = respHS.Header.Clone()
@@ -515,19 +677,25 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			helps.RecordAPIWebsocketUpgradeRejection(ctx, e.cfg, websocketUpgradeRequestLog(wsReqLog), respHS.StatusCode, respHS.Header.Clone(), bodyErr)
 		}
 		if respHS != nil && respHS.StatusCode == http.StatusUpgradeRequired {
+			unlockSessionRequest()
 			return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)
 		}
 		if respHS != nil && respHS.StatusCode > 0 {
+			unlockSessionRequest()
 			return nil, statusErr{code: respHS.StatusCode, msg: string(bodyErr)}
 		}
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "dial", errDial)
-		if sess != nil {
-			sess.reqMu.Unlock()
-		}
+		unlockSessionRequest()
 		return nil, errDial
 	}
 	recordAPIWebsocketHandshake(ctx, e.cfg, respHS)
 	reporter.StartResponseTTFT()
+	if sess != nil && cliproxyexecutor.DownstreamWebsocket(ctx) && upstreamCreated && codexWebsocketRequestNeedsTranscriptReplayOnReset(wsReqBody) {
+		errReplay := codexWebsocketTranscriptReplayRequiredError{reason: "upstream_recreated"}
+		helps.RecordAPIWebsocketError(ctx, e.cfg, "replay_required", errReplay)
+		unlockSessionRequest()
+		return nil, errReplay
+	}
 
 	if sess == nil {
 		logCodexWebsocketConnected(executionSessionID, authID, wsURL)
@@ -536,7 +704,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	var readCh chan codexWebsocketRead
 	if sess != nil {
 		readCh = make(chan codexWebsocketRead, 4096)
-		sess.setActive(readCh)
+		sess.setActive(readCh, conn)
 	}
 
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
@@ -544,18 +712,23 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		if sess != nil {
 			e.dropUpstreamConn(sess, conn, "send_error", errSend, false)
 			sess.clearActive(readCh)
-			readCh = make(chan codexWebsocketRead, 4096)
-			sess.setActive(readCh)
+			if codexWebsocketRequestNeedsTranscriptReplayOnReset(wsReqBody) {
+				errReplay := codexWebsocketTranscriptReplayRequiredError{reason: "send_error", cause: errSend}
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "replay_required", errReplay)
+				unlockSessionRequest()
+				return nil, errReplay
+			}
 
 			// Retry once with a new websocket connection for the same execution session.
-			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
+			connRetry, respHSRetry, _, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
 			if errDialRetry != nil || connRetry == nil {
 				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
-				sess.clearActive(readCh)
-				sess.reqMu.Unlock()
+				unlockSessionRequest()
 				return nil, errDialRetry
 			}
+			readCh = make(chan codexWebsocketRead, 4096)
+			sess.setActive(readCh, connRetry)
 			wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
 			helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
 				URL:       wsURL,
@@ -574,7 +747,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
 				e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry)
 				sess.clearActive(readCh)
-				sess.reqMu.Unlock()
+				unlockSessionRequest()
 				return nil, errSendRetry
 			}
 			conn = connRetry
@@ -637,6 +810,13 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				}
 				terminateReason = "read_error"
 				terminateErr = errRead
+				if codexWebsocketReadErrorRequiresTranscriptReplay(wsReqBody, errRead, cliproxyexecutor.DownstreamWebsocket(ctx)) {
+					errReplay := codexWebsocketTranscriptReplayRequiredError{reason: "read_error", cause: errRead}
+					helps.RecordAPIWebsocketError(ctx, e.cfg, "replay_required", errReplay)
+					reporter.PublishFailure(ctx, errReplay)
+					_ = send(cliproxyexecutor.StreamChunk{Err: errReplay})
+					return
+				}
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "read", errRead)
 				reporter.PublishFailure(ctx, errRead)
 				_ = send(cliproxyexecutor.StreamChunk{Err: errRead})
@@ -644,15 +824,15 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 			if msgType != websocket.TextMessage {
 				if msgType == websocket.BinaryMessage {
-					err = fmt.Errorf("codex websockets executor: unexpected binary message")
+					errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
 					terminateReason = "unexpected_binary"
-					terminateErr = err
-					helps.RecordAPIWebsocketError(ctx, e.cfg, "unexpected_binary", err)
-					reporter.PublishFailure(ctx, err)
+					terminateErr = errBinary
+					helps.RecordAPIWebsocketError(ctx, e.cfg, "unexpected_binary", errBinary)
+					reporter.PublishFailure(ctx, errBinary)
 					if sess != nil {
-						e.invalidateUpstreamConn(sess, conn, "unexpected_binary", err)
+						e.invalidateUpstreamConn(sess, conn, "unexpected_binary", errBinary)
 					}
-					_ = send(cliproxyexecutor.StreamChunk{Err: err})
+					_ = send(cliproxyexecutor.StreamChunk{Err: errBinary})
 					return
 				}
 				continue
@@ -667,28 +847,41 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			helps.AppendAPIWebsocketResponse(ctx, e.cfg, payload)
 
 			if wsErr, ok := parseCodexWebsocketError(payload); ok {
+				clientErr := exposeCodexWebsocketError(payload, identityState, wsErr)
 				terminateReason = "upstream_error"
 				terminateErr = wsErr
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
 				reporter.PublishFailure(ctx, wsErr)
 				if sess != nil {
-					if isCodexWebsocketPreviousResponseNotFound(payload) {
-						e.dropUpstreamConn(sess, conn, "previous_response_not_found", wsErr, false)
+					if cliproxyexecutor.DownstreamWebsocket(ctx) {
+						e.dropUpstreamConn(sess, conn, "upstream_error", wsErr, false)
+					} else if shouldDropCodexWebsocketUpstreamErrorQuietly(payload, wsErr) {
+						e.dropUpstreamConn(sess, conn, codexWebsocketUpstreamErrorDropReason(payload, wsErr), wsErr, false)
 					} else {
 						e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
 					}
 				}
-				_ = send(cliproxyexecutor.StreamChunk{Err: wsErr})
+				_ = send(cliproxyexecutor.StreamChunk{Err: clientErr})
 				return
 			}
 
 			eventType := gjson.GetBytes(payload, "type").String()
-			isTerminalEvent := eventType == "response.completed" || eventType == "response.done" || eventType == "error"
+			failedErr, isResponseFailed := parseCodexWebsocketResponseFailed(payload)
+			isTerminalEvent := eventType == "response.completed" || eventType == "response.done" || eventType == "error" || isResponseFailed
 			clientPayload := applyCodexIdentityExposeResponsePayload(payload, identityState)
 			if cliproxyexecutor.DownstreamWebsocket(ctx) {
 				if eventType == "response.completed" || eventType == "response.done" {
 					if detail, ok := helps.ParseCodexUsage(payload); ok {
 						reporter.Publish(ctx, detail)
+					}
+				}
+				if isResponseFailed {
+					terminateReason = "response_failed"
+					terminateErr = failedErr
+					helps.RecordAPIWebsocketError(ctx, e.cfg, "response_failed", failedErr)
+					reporter.PublishFailure(ctx, failedErr)
+					if sess != nil {
+						e.dropUpstreamConn(sess, conn, "response_failed", failedErr, false)
 					}
 				}
 				if !send(cliproxyexecutor.StreamChunk{Payload: clientPayload}) {
@@ -700,6 +893,17 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 					return
 				}
 				continue
+			}
+			if isResponseFailed {
+				terminateReason = "response_failed"
+				terminateErr = failedErr
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "response_failed", failedErr)
+				reporter.PublishFailure(ctx, failedErr)
+				if sess != nil {
+					e.dropUpstreamConn(sess, conn, "response_failed", failedErr, false)
+				}
+				_ = send(cliproxyexecutor.StreamChunk{Err: failedErr})
+				return
 			}
 
 			payload = normalizeCodexWebsocketCompletion(payload)
@@ -787,10 +991,56 @@ func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession,
 	if readCh == nil {
 		return 0, nil, fmt.Errorf("codex websockets executor: session read channel is nil")
 	}
+	readBuffered := func() (int, []byte, error, bool) {
+		for {
+			select {
+			case ev, ok := <-readCh:
+				if !ok {
+					return 0, nil, fmt.Errorf("codex websockets executor: session read channel closed"), true
+				}
+				if ev.conn != conn {
+					continue
+				}
+				if ev.err != nil {
+					if terminalErr := sess.terminalError(); terminalErr != nil {
+						return 0, nil, terminalErr, true
+					}
+					return 0, nil, ev.err, true
+				}
+				return ev.msgType, ev.payload, nil, true
+			default:
+				return 0, nil, nil, false
+			}
+		}
+	}
+	activeDone, active := sess.activeDoneFor(readCh)
+	if !active {
+		if msgType, payload, errRead, ok := readBuffered(); ok {
+			return msgType, payload, errRead
+		}
+		if errRead := sess.closedActiveErrorFor(readCh); errRead != nil {
+			return 0, nil, errRead
+		}
+		if terminalErr := sess.terminalError(); terminalErr != nil {
+			return 0, nil, terminalErr
+		}
+		return 0, nil, fmt.Errorf("codex websockets executor: session read channel inactive")
+	}
 	for {
 		select {
 		case <-ctx.Done():
 			return 0, nil, ctx.Err()
+		case <-activeDone:
+			if msgType, payload, errRead, ok := readBuffered(); ok {
+				return msgType, payload, errRead
+			}
+			if errRead := sess.closedActiveErrorFor(readCh); errRead != nil {
+				return 0, nil, errRead
+			}
+			if terminalErr := sess.terminalError(); terminalErr != nil {
+				return 0, nil, terminalErr
+			}
+			return 0, nil, fmt.Errorf("codex websockets executor: session read channel closed")
 		case ev, ok := <-readCh:
 			if !ok {
 				return 0, nil, fmt.Errorf("codex websockets executor: session read channel closed")
@@ -799,6 +1049,9 @@ func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession,
 				continue
 			}
 			if ev.err != nil {
+				if terminalErr := sess.terminalError(); terminalErr != nil {
+					return 0, nil, terminalErr
+				}
 				return 0, nil, ev.err
 			}
 			return ev.msgType, ev.payload, nil
@@ -941,7 +1194,10 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 	ensureHeaderWithPriority(headers, ginHeaders, "x-codex-beta-features", cfgBetaFeatures, "")
 	misc.EnsureHeader(headers, ginHeaders, "x-codex-turn-state", "")
 	misc.EnsureHeader(headers, ginHeaders, "x-codex-turn-metadata", "")
+	misc.EnsureHeader(headers, ginHeaders, "x-codex-window-id", "")
+	misc.EnsureHeader(headers, ginHeaders, "x-codex-parent-thread-id", "")
 	misc.EnsureHeader(headers, ginHeaders, "x-client-request-id", "")
+	misc.EnsureHeader(headers, ginHeaders, "thread-id", "")
 	misc.EnsureHeader(headers, ginHeaders, "x-responsesapi-include-timing-metrics", "")
 	misc.EnsureHeader(headers, ginHeaders, "Version", "")
 	if isAPIKey {
@@ -985,6 +1241,28 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 	util.ApplyCustomHeadersFromAttrs(&http.Request{Header: headers}, attrs)
 
 	return headers
+}
+
+func applyCodexWebsocketClientMetadataHeaders(headers http.Header, body []byte) {
+	if headers == nil || len(body) == 0 {
+		return
+	}
+	clientMetadata := gjson.GetBytes(body, "client_metadata")
+	if !clientMetadata.Exists() || clientMetadata.Type != gjson.JSON {
+		return
+	}
+	if turnMetadata := strings.TrimSpace(clientMetadata.Get("x-codex-turn-metadata").String()); turnMetadata != "" {
+		headers.Set("X-Codex-Turn-Metadata", turnMetadata)
+	}
+	if windowID := strings.TrimSpace(clientMetadata.Get("x-codex-window-id").String()); windowID != "" {
+		headers.Set("X-Codex-Window-Id", windowID)
+	}
+	if parentThreadID := strings.TrimSpace(clientMetadata.Get("x-codex-parent-thread-id").String()); parentThreadID != "" {
+		headers.Set("X-Codex-Parent-Thread-Id", parentThreadID)
+	}
+	if subagent := strings.TrimSpace(clientMetadata.Get("x-openai-subagent").String()); subagent != "" {
+		headers.Set("X-Openai-Subagent", subagent)
+	}
 }
 
 func ensureCodexWebsocketSessionHeader(target http.Header, source http.Header, fallbackValue string) {
@@ -1186,6 +1464,29 @@ type statusErrWithHeaders struct {
 	headers http.Header
 }
 
+type codexWebsocketTranscriptReplayRequiredError struct {
+	reason string
+	cause  error
+}
+
+func (e codexWebsocketTranscriptReplayRequiredError) Error() string {
+	reason := strings.TrimSpace(e.reason)
+	if reason == "" {
+		reason = "upstream_reset"
+	}
+	msg := "codex websocket upstream reset requires transcript replay: invalid_request_error"
+	if e.cause != nil {
+		return fmt.Sprintf("%s: %s: %v", msg, reason, e.cause)
+	}
+	return fmt.Sprintf("%s: %s", msg, reason)
+}
+
+func (e codexWebsocketTranscriptReplayRequiredError) Unwrap() error { return e.cause }
+
+func (e codexWebsocketTranscriptReplayRequiredError) StatusCode() int { return http.StatusBadRequest }
+
+func (e codexWebsocketTranscriptReplayRequiredError) CodexWebsocketReplayRequired() bool { return true }
+
 func (e statusErrWithHeaders) Headers() http.Header {
 	if e.headers == nil {
 		return nil
@@ -1223,6 +1524,56 @@ func parseCodexWebsocketError(payload []byte) (error, bool) {
 	}, true
 }
 
+func exposeCodexWebsocketError(payload []byte, identityState codexIdentityConfuseState, fallback error) error {
+	clientPayload := applyCodexIdentityExposeResponsePayload(payload, identityState)
+	if clientErr, ok := parseCodexWebsocketError(clientPayload); ok {
+		return clientErr
+	}
+	return fallback
+}
+
+func parseCodexWebsocketResponseFailed(payload []byte) (statusErr, bool) {
+	if len(payload) == 0 || strings.TrimSpace(gjson.GetBytes(payload, "type").String()) != "response.failed" {
+		return statusErr{}, false
+	}
+	if streamErr, _, ok := codexTerminalStreamErr(payload); ok {
+		return streamErr, true
+	}
+
+	body := codexTerminalErrorBody(payload, "response.error")
+	if len(body) == 0 {
+		body = codexTerminalErrorBody(payload, "error")
+	}
+	if len(body) == 0 {
+		body = []byte(`{"error":{"message":"response.failed event received"}}`)
+	}
+	return newCodexStatusErr(codexWebsocketResponseFailedStatus(payload, body), body), true
+}
+
+func codexWebsocketResponseFailedStatus(payload, body []byte) int {
+	for _, path := range []string{"status", "status_code", "response.status_code", "response.error.status", "response.error.status_code", "error.status", "error.status_code"} {
+		status := int(gjson.GetBytes(payload, path).Int())
+		if status > 0 {
+			return status
+		}
+	}
+
+	errType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.type").String()))
+	errCode := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
+	switch {
+	case isCodexUsageLimitError(body) || isCodexModelCapacityError(body) || errType == "rate_limit_error" || errCode == "rate_limit_exceeded":
+		return http.StatusTooManyRequests
+	case errType == "authentication_error":
+		return http.StatusUnauthorized
+	case errType == "permission_error":
+		return http.StatusForbidden
+	case errType == "invalid_request_error" || errCode == "invalid_request_error" || errCode == "previous_response_not_found" || errCode == "context_length_exceeded" || errCode == "context_too_large":
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
 func isCodexWebsocketPreviousResponseNotFound(payload []byte) bool {
 	if len(payload) == 0 {
 		return false
@@ -1232,6 +1583,57 @@ func isCodexWebsocketPreviousResponseNotFound(payload []byte) bool {
 	return upstreamCode == "previous_response_not_found" ||
 		strings.Contains(lower, "previous_response_not_found") ||
 		(strings.Contains(lower, "previous_response") || strings.Contains(lower, "previous response")) && strings.Contains(lower, "not found")
+}
+
+func shouldDropCodexWebsocketUpstreamErrorQuietly(payload []byte, err error) bool {
+	if isCodexWebsocketPreviousResponseNotFound(payload) {
+		return true
+	}
+	switch codexWebsocketErrorStatusCode(err) {
+	case http.StatusUnauthorized, http.StatusPaymentRequired, http.StatusForbidden, http.StatusTooManyRequests:
+		return true
+	default:
+		return false
+	}
+}
+
+func codexWebsocketUpstreamErrorDropReason(payload []byte, err error) string {
+	if isCodexWebsocketPreviousResponseNotFound(payload) {
+		return "previous_response_not_found"
+	}
+	switch codexWebsocketErrorStatusCode(err) {
+	case http.StatusUnauthorized:
+		return "upstream_unauthorized"
+	case http.StatusPaymentRequired:
+		return "upstream_payment_required"
+	case http.StatusForbidden:
+		return "upstream_forbidden"
+	case http.StatusTooManyRequests:
+		return "upstream_rate_limited"
+	default:
+		return "upstream_error"
+	}
+}
+
+func codexWebsocketErrorStatusCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var statusProvider interface{ StatusCode() int }
+	if errors.As(err, &statusProvider) && statusProvider != nil {
+		return statusProvider.StatusCode()
+	}
+	return 0
+}
+
+func codexWebsocketRequestNeedsTranscriptReplayOnReset(payload []byte) bool {
+	return strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String()) != ""
+}
+
+func codexWebsocketReadErrorRequiresTranscriptReplay(payload []byte, err error, allowFullRequestReplay bool) bool {
+	var upstreamReset codexWebsocketUpstreamResetError
+	return errors.As(err, &upstreamReset) &&
+		(allowFullRequestReplay || codexWebsocketRequestNeedsTranscriptReplayOnReset(payload))
 }
 
 func buildCodexWebsocketErrorPayload(payload []byte, status int) []byte {
@@ -1440,9 +1842,67 @@ func (e *CodexWebsocketsExecutor) UpstreamGeneration(sessionID string) uint64 {
 	return generation
 }
 
-func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, authID string, wsURL string, headers http.Header) (*websocket.Conn, *http.Response, error) {
+func (e *CodexWebsocketsExecutor) DropUpstreamSession(sessionID string, reason string) {
+	sessionID = strings.TrimSpace(sessionID)
+	if e == nil || sessionID == "" {
+		return
+	}
+	store := e.store
+	if store == nil {
+		store = globalCodexWebsocketSessionStore
+	}
+	store.mu.Lock()
+	sess := store.sessions[sessionID]
+	store.mu.Unlock()
 	if sess == nil {
-		return e.dialCodexWebsocket(ctx, auth, wsURL, headers)
+		return
+	}
+	sess.connMu.Lock()
+	conn := sess.conn
+	sess.connMu.Unlock()
+	if conn == nil {
+		return
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "upstream_session_dropped"
+	}
+	e.dropUpstreamConn(sess, conn, reason, nil, false)
+}
+
+func (e *CodexWebsocketsExecutor) SendResponseProcessed(sessionID string, responseID string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	responseID = strings.TrimSpace(responseID)
+	if e == nil || sessionID == "" || responseID == "" {
+		return nil
+	}
+	store := e.store
+	if store == nil {
+		store = globalCodexWebsocketSessionStore
+	}
+	store.mu.Lock()
+	sess := store.sessions[sessionID]
+	store.mu.Unlock()
+	if sess == nil {
+		return fmt.Errorf("codex websockets executor: session is unavailable")
+	}
+	sess.connMu.Lock()
+	conn := sess.conn
+	sess.connMu.Unlock()
+	if conn == nil {
+		return fmt.Errorf("codex websockets executor: upstream websocket is unavailable")
+	}
+	payload, errSet := sjson.SetBytes([]byte(`{"type":"response.processed"}`), "response_id", responseID)
+	if errSet != nil {
+		return fmt.Errorf("codex websockets executor: encode response.processed: %w", errSet)
+	}
+	return writeCodexWebsocketMessage(sess, conn, payload)
+}
+
+func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, authID string, wsURL string, headers http.Header) (*websocket.Conn, *http.Response, bool, error) {
+	if sess == nil {
+		conn, resp, err := e.dialCodexWebsocket(ctx, auth, wsURL, headers)
+		return conn, resp, true, err
 	}
 
 	sess.connMu.Lock()
@@ -1457,12 +1917,12 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 			sess.configureConn(conn)
 			go e.readUpstreamLoop(sess, conn)
 		}
-		return conn, nil, nil
+		return conn, nil, false, nil
 	}
 
 	conn, resp, errDial := e.dialCodexWebsocket(ctx, auth, wsURL, headers)
 	if errDial != nil {
-		return nil, resp, errDial
+		return nil, resp, false, errDial
 	}
 
 	sess.connMu.Lock()
@@ -1472,7 +1932,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 		if errClose := conn.Close(); errClose != nil {
 			log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 		}
-		return previous, nil, nil
+		return previous, nil, false, nil
 	}
 	sess.conn = conn
 	sess.wsURL = wsURL
@@ -1483,7 +1943,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	sess.configureConn(conn)
 	go e.readUpstreamLoop(sess, conn)
 	logCodexWebsocketConnected(sess.sessionID, authID, wsURL)
-	return conn, resp, nil
+	return conn, resp, true, nil
 }
 
 func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, conn *websocket.Conn) {
@@ -1494,36 +1954,15 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		_ = conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
 		msgType, payload, errRead := conn.ReadMessage()
 		if errRead != nil {
-			ch, done, current := sess.activeReadForConn(conn)
-			if current && ch != nil {
-				select {
-				case ch <- codexWebsocketRead{conn: conn, err: errRead}:
-				case <-done:
-				default:
-				}
-				sess.clearActive(ch)
-				close(ch)
-			}
 			e.dropUpstreamConn(sess, conn, "upstream_disconnected", errRead, false)
+			sess.closeActiveReadForConn(conn, codexWebsocketUpstreamResetError{cause: errRead})
 			return
 		}
 
 		if msgType != websocket.TextMessage {
 			if msgType == websocket.BinaryMessage {
 				errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
-				ch, done, current := sess.activeReadForConn(conn)
-				if !current {
-					return
-				}
-				if ch != nil {
-					select {
-					case ch <- codexWebsocketRead{conn: conn, err: errBinary}:
-					case <-done:
-					default:
-					}
-					sess.clearActive(ch)
-					close(ch)
-				}
+				sess.closeActiveReadForConn(conn, errBinary)
 				e.invalidateUpstreamConn(sess, conn, "unexpected_binary", errBinary)
 				return
 			}
@@ -1643,21 +2082,30 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 	if reason == "" {
 		reason = "session_closed"
 	}
+	sessionClosedErr := fmt.Errorf("codex websockets executor: execution session closed")
+	sess.markTerminalError(sessionClosedErr)
+	sess.closeActiveRead(sessionClosedErr)
 
 	sess.connMu.Lock()
 	conn := sess.conn
 	authID := sess.authID
 	wsURL := sess.wsURL
-	sess.conn = nil
-	if sess.readerConn == conn {
-		sess.readerConn = nil
-	}
 	sessionID := sess.sessionID
 	sess.connMu.Unlock()
 
 	if conn == nil {
 		return
 	}
+
+	sess.connMu.Lock()
+	if sess.conn == conn {
+		sess.conn = nil
+		if sess.readerConn == conn {
+			sess.readerConn = nil
+		}
+	}
+	sess.connMu.Unlock()
+
 	logCodexWebsocketDisconnected(sessionID, authID, wsURL, reason, nil)
 	if errClose := conn.Close(); errClose != nil {
 		log.Errorf("codex websockets executor: close websocket error: %v", errClose)
@@ -1825,6 +2273,20 @@ func (e *CodexAutoExecutor) UpstreamGeneration(sessionID string) uint64 {
 		return 0
 	}
 	return e.wsExec.UpstreamGeneration(sessionID)
+}
+
+func (e *CodexAutoExecutor) DropUpstreamSession(sessionID string, reason string) {
+	if e == nil || e.wsExec == nil {
+		return
+	}
+	e.wsExec.DropUpstreamSession(sessionID, reason)
+}
+
+func (e *CodexAutoExecutor) SendResponseProcessed(sessionID string, responseID string) error {
+	if e == nil || e.wsExec == nil {
+		return nil
+	}
+	return e.wsExec.SendResponseProcessed(sessionID, responseID)
 }
 
 func codexWebsocketsEnabled(auth *cliproxyauth.Auth) bool {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -77,6 +77,7 @@ type codexWebsocketSession struct {
 
 	readerConn *websocket.Conn
 
+	upstreamGeneration     uint64
 	upstreamDisconnectOnce sync.Once
 	upstreamDisconnectCh   chan error
 }
@@ -128,6 +129,21 @@ func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
 		s.activeDone = nil
 	}
 	s.activeMu.Unlock()
+}
+
+func (s *codexWebsocketSession) activeReadForConn(conn *websocket.Conn) (chan codexWebsocketRead, <-chan struct{}, bool) {
+	if s == nil || conn == nil {
+		return nil, nil, false
+	}
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	s.connMu.Lock()
+	isCurrent := s.conn == conn
+	s.connMu.Unlock()
+	if !isCurrent {
+		return nil, nil, false
+	}
+	return s.activeCh, s.activeDone, true
 }
 
 func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, payload []byte) error {
@@ -296,12 +312,17 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	if sess != nil {
 		readCh = make(chan codexWebsocketRead, 4096)
 		sess.setActive(readCh)
-		defer sess.clearActive(readCh)
+		defer func() {
+			sess.clearActive(readCh)
+		}()
 	}
 
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
 		if sess != nil {
-			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
+			e.dropUpstreamConn(sess, conn, "send_error", errSend, false)
+			sess.clearActive(readCh)
+			readCh = make(chan codexWebsocketRead, 4096)
+			sess.setActive(readCh)
 
 			// Retry once with a fresh websocket connection. This is mainly to handle
 			// upstream closing the socket between sequential requests within the same
@@ -372,7 +393,11 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 
 		if wsErr, ok := parseCodexWebsocketError(payload); ok {
 			if sess != nil {
-				e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
+				if isCodexWebsocketPreviousResponseNotFound(payload) {
+					e.dropUpstreamConn(sess, conn, "previous_response_not_found", wsErr, false)
+				} else {
+					e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
+				}
 			}
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
 			return resp, wsErr
@@ -517,7 +542,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
 		if sess != nil {
-			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
+			e.dropUpstreamConn(sess, conn, "send_error", errSend, false)
+			sess.clearActive(readCh)
+			readCh = make(chan codexWebsocketRead, 4096)
+			sess.setActive(readCh)
 
 			// Retry once with a new websocket connection for the same execution session.
 			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
@@ -644,7 +672,11 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
 				reporter.PublishFailure(ctx, wsErr)
 				if sess != nil {
-					e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
+					if isCodexWebsocketPreviousResponseNotFound(payload) {
+						e.dropUpstreamConn(sess, conn, "previous_response_not_found", wsErr, false)
+					} else {
+						e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
+					}
 				}
 				_ = send(cliproxyexecutor.StreamChunk{Err: wsErr})
 				return
@@ -1191,6 +1223,17 @@ func parseCodexWebsocketError(payload []byte) (error, bool) {
 	}, true
 }
 
+func isCodexWebsocketPreviousResponseNotFound(payload []byte) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(string(payload)))
+	upstreamCode := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "error.code").String()))
+	return upstreamCode == "previous_response_not_found" ||
+		strings.Contains(lower, "previous_response_not_found") ||
+		(strings.Contains(lower, "previous_response") || strings.Contains(lower, "previous response")) && strings.Contains(lower, "not found")
+}
+
 func buildCodexWebsocketErrorPayload(payload []byte, status int) []byte {
 	out := []byte(`{}`)
 	out, _ = sjson.SetBytes(out, "status", status)
@@ -1376,6 +1419,27 @@ func (e *CodexWebsocketsExecutor) UpstreamDisconnectChan(sessionID string) <-cha
 	return sess.upstreamDisconnectCh
 }
 
+func (e *CodexWebsocketsExecutor) UpstreamGeneration(sessionID string) uint64 {
+	sessionID = strings.TrimSpace(sessionID)
+	if e == nil || sessionID == "" {
+		return 0
+	}
+	store := e.store
+	if store == nil {
+		store = globalCodexWebsocketSessionStore
+	}
+	store.mu.Lock()
+	sess := store.sessions[sessionID]
+	store.mu.Unlock()
+	if sess == nil {
+		return 0
+	}
+	sess.connMu.Lock()
+	generation := sess.upstreamGeneration
+	sess.connMu.Unlock()
+	return generation
+}
+
 func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, authID string, wsURL string, headers http.Header) (*websocket.Conn, *http.Response, error) {
 	if sess == nil {
 		return e.dialCodexWebsocket(ctx, auth, wsURL, headers)
@@ -1430,11 +1494,8 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 		_ = conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
 		msgType, payload, errRead := conn.ReadMessage()
 		if errRead != nil {
-			sess.activeMu.Lock()
-			ch := sess.activeCh
-			done := sess.activeDone
-			sess.activeMu.Unlock()
-			if ch != nil {
+			ch, done, current := sess.activeReadForConn(conn)
+			if current && ch != nil {
 				select {
 				case ch <- codexWebsocketRead{conn: conn, err: errRead}:
 				case <-done:
@@ -1443,17 +1504,17 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 				sess.clearActive(ch)
 				close(ch)
 			}
-			e.invalidateUpstreamConn(sess, conn, "upstream_disconnected", errRead)
+			e.dropUpstreamConn(sess, conn, "upstream_disconnected", errRead, false)
 			return
 		}
 
 		if msgType != websocket.TextMessage {
 			if msgType == websocket.BinaryMessage {
 				errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
-				sess.activeMu.Lock()
-				ch := sess.activeCh
-				done := sess.activeDone
-				sess.activeMu.Unlock()
+				ch, done, current := sess.activeReadForConn(conn)
+				if !current {
+					return
+				}
 				if ch != nil {
 					select {
 					case ch <- codexWebsocketRead{conn: conn, err: errBinary}:
@@ -1469,10 +1530,10 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 			continue
 		}
 
-		sess.activeMu.Lock()
-		ch := sess.activeCh
-		done := sess.activeDone
-		sess.activeMu.Unlock()
+		ch, done, current := sess.activeReadForConn(conn)
+		if !current {
+			return
+		}
 		if ch == nil {
 			continue
 		}
@@ -1484,6 +1545,10 @@ func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, 
 }
 
 func (e *CodexWebsocketsExecutor) invalidateUpstreamConn(sess *codexWebsocketSession, conn *websocket.Conn, reason string, err error) {
+	e.dropUpstreamConn(sess, conn, reason, err, true)
+}
+
+func (e *CodexWebsocketsExecutor) dropUpstreamConn(sess *codexWebsocketSession, conn *websocket.Conn, reason string, err error, notifyDownstream bool) {
 	if sess == nil || conn == nil {
 		return
 	}
@@ -1501,10 +1566,15 @@ func (e *CodexWebsocketsExecutor) invalidateUpstreamConn(sess *codexWebsocketSes
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}
+	if !notifyDownstream {
+		sess.upstreamGeneration++
+	}
 	sess.connMu.Unlock()
 
 	logCodexWebsocketDisconnected(sessionID, authID, wsURL, reason, err)
-	sess.notifyUpstreamDisconnect(err)
+	if notifyDownstream {
+		sess.notifyUpstreamDisconnect(err)
+	}
 	if errClose := conn.Close(); errClose != nil {
 		log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 	}
@@ -1748,6 +1818,13 @@ func (e *CodexAutoExecutor) UpstreamDisconnectChan(sessionID string) <-chan erro
 		return nil
 	}
 	return e.wsExec.UpstreamDisconnectChan(sessionID)
+}
+
+func (e *CodexAutoExecutor) UpstreamGeneration(sessionID string) uint64 {
+	if e == nil || e.wsExec == nil {
+		return 0
+	}
+	return e.wsExec.UpstreamGeneration(sessionID)
 }
 
 func codexWebsocketsEnabled(auth *cliproxyauth.Auth) bool {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -215,6 +215,61 @@ func TestCodexWebsocketsExecuteStreamPropagatesUpstreamErrorForDownstreamWebsock
 	}
 }
 
+func TestCodexWebsocketsExecutePreviousResponseNotFoundDropsQuietly(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Fatalf("request path = %s, want /responses", r.URL.Path)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			t.Fatalf("read upstream websocket message: %v", errRead)
+		}
+		errPayload := []byte(`{"type":"error","status":400,"error":{"code":"previous_response_not_found","message":"previous response with id 'resp-1' not found"}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, errPayload); errWrite != nil {
+			t.Fatalf("write websocket error: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-previous-response-missing"
+	defer exec.CloseExecutionSession(sessionID)
+	disconnectCh := exec.UpstreamDisconnectChan(sessionID)
+	if disconnectCh == nil {
+		t.Fatal("expected disconnect channel")
+	}
+
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-1"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+
+	if _, err := exec.Execute(context.Background(), auth, req, opts); err == nil || !strings.Contains(err.Error(), "previous_response_not_found") {
+		t.Fatalf("Execute() error = %v, want previous_response_not_found", err)
+	}
+	if got := exec.UpstreamGeneration(sessionID); got != 1 {
+		t.Fatalf("upstream generation = %d, want 1", got)
+	}
+	select {
+	case errRead, ok := <-disconnectCh:
+		t.Fatalf("unexpected disconnect signal ok=%t err=%v", ok, errRead)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -245,6 +300,9 @@ func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) 
 	if disconnectCh == nil {
 		t.Fatal("expected disconnect channel")
 	}
+	if got := exec.UpstreamGeneration(sessionID); got != 0 {
+		t.Fatalf("initial upstream generation = %d, want 0", got)
+	}
 
 	sess := exec.getOrCreateSession(sessionID)
 	if sess == nil {
@@ -270,6 +328,141 @@ func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) 
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for disconnect signal")
+	}
+}
+
+func TestCodexWebsocketsDropUpstreamConnQuietlyDoesNotSignalDisconnect(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	sessionID := "sess-quiet"
+	defer exec.CloseExecutionSession(sessionID)
+	disconnectCh := exec.UpstreamDisconnectChan(sessionID)
+	if disconnectCh == nil {
+		t.Fatal("expected disconnect channel")
+	}
+
+	sess := exec.getOrCreateSession(sessionID)
+	if sess == nil {
+		t.Fatal("expected session")
+	}
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.authID = "auth-1"
+	sess.wsURL = "ws://example.test/responses"
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+
+	exec.dropUpstreamConn(sess, conn, "upstream_disconnected", errors.New("idle timeout"), false)
+
+	select {
+	case errRead, ok := <-disconnectCh:
+		t.Fatalf("unexpected disconnect signal ok=%t err=%v", ok, errRead)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	sess.connMu.Lock()
+	current := sess.conn
+	readerConn := sess.readerConn
+	sess.connMu.Unlock()
+	if current != nil || readerConn != nil {
+		t.Fatalf("expected upstream connection to be cleared")
+	}
+	if got := exec.UpstreamGeneration(sessionID); got != 1 {
+		t.Fatalf("upstream generation after quiet drop = %d, want 1", got)
+	}
+}
+
+func TestCodexWebsocketsReadLoopIgnoresStaleConnErrors(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	staleConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial stale websocket: %v", err)
+	}
+	currentConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial current websocket: %v", err)
+	}
+	defer func() { _ = currentConn.Close() }()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	sessionID := "sess-stale-reader"
+	defer exec.CloseExecutionSession(sessionID)
+	sess := exec.getOrCreateSession(sessionID)
+	if sess == nil {
+		t.Fatal("expected session")
+	}
+	readCh := make(chan codexWebsocketRead, 1)
+	sess.setActive(readCh)
+	defer func() {
+		sess.clearActive(readCh)
+	}()
+	sess.connMu.Lock()
+	sess.conn = currentConn
+	sess.readerConn = currentConn
+	sess.connMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		exec.readUpstreamLoop(sess, staleConn)
+		close(done)
+	}()
+	if errClose := staleConn.Close(); errClose != nil {
+		t.Fatalf("close stale websocket: %v", errClose)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stale read loop")
+	}
+
+	select {
+	case ev, ok := <-readCh:
+		t.Fatalf("unexpected stale read event ok=%t ev=%+v", ok, ev)
+	default:
+	}
+	sess.activeMu.Lock()
+	activeCh := sess.activeCh
+	sess.activeMu.Unlock()
+	if activeCh != readCh {
+		t.Fatalf("expected active read channel to remain current")
 	}
 }
 
@@ -763,6 +956,15 @@ func TestParseCodexWebsocketErrorPreservesWrappedBodyAndHeaders(t *testing.T) {
 	withHeaders, ok := err.(interface{ Headers() http.Header })
 	if !ok || withHeaders.Headers().Get("x-request-id") != "req-1" {
 		t.Fatalf("headers = %#v, want x-request-id", err)
+	}
+}
+
+func TestIsCodexWebsocketPreviousResponseNotFound(t *testing.T) {
+	if !isCodexWebsocketPreviousResponseNotFound([]byte(`{"type":"error","status":400,"error":{"code":"previous_response_not_found","message":"previous response with id 'resp-1' not found"}}`)) {
+		t.Fatalf("expected previous response not found websocket error")
+	}
+	if isCodexWebsocketPreviousResponseNotFound([]byte(`{"type":"error","status":429,"error":{"code":"websocket_connection_limit_reached","message":"too many websockets"}}`)) {
+		t.Fatalf("connection limit error must not be classified as previous response not found")
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -215,6 +215,242 @@ func TestCodexWebsocketsExecuteStreamPropagatesUpstreamErrorForDownstreamWebsock
 	}
 }
 
+func TestCodexWebsocketsExecuteStreamDoesNotNotifyDownstreamBeforeForwardingError(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	confusedPromptCacheKeyCh := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		_, upstreamPayload, errRead := conn.ReadMessage()
+		if errRead != nil {
+			t.Errorf("read upstream websocket message: %v", errRead)
+			return
+		}
+		confusedPromptCacheKey := strings.TrimSpace(gjson.GetBytes(upstreamPayload, "prompt_cache_key").String())
+		if confusedPromptCacheKey == "" {
+			t.Errorf("upstream prompt_cache_key is empty: %s", upstreamPayload)
+			return
+		}
+		confusedPromptCacheKeyCh <- confusedPromptCacheKey
+		errorPayload := []byte(`{"type":"error","status":500,"error":{"code":"server_error","message":"upstream failed for ` + confusedPromptCacheKey + `:0"}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, errorPayload); errWrite != nil {
+			t.Errorf("write error websocket message: %v", errWrite)
+			return
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{
+		SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll},
+		Routing:   config.RoutingConfig{SessionAffinity: true},
+		Codex:     config.CodexConfig{IdentityConfuse: true},
+	})
+	sessionID := "test-error-forward-session"
+	defer exec.CloseExecutionSession(sessionID)
+	disconnectCh := exec.UpstreamDisconnectChan(sessionID)
+	auth := &cliproxyauth.Auth{
+		ID:         "auth-error-forward",
+		Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL},
+	}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","prompt_cache_key":"cache-error-forward","input":[{"type":"message","role":"user","content":"hello"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FromString("openai-response"),
+		ResponseFormat: sdktranslator.FromString("openai-response"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+
+	result, err := exec.ExecuteStream(ctx, auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	select {
+	case chunk, ok := <-result.Chunks:
+		if !ok {
+			t.Fatal("stream closed before error chunk")
+		}
+		if chunk.Err == nil {
+			t.Fatal("error chunk Err = nil, want upstream error")
+		}
+		errText := chunk.Err.Error()
+		if !strings.Contains(errText, "cache-error-forward:0") {
+			t.Fatalf("error chunk Err = %v, want exposed prompt cache key", chunk.Err)
+		}
+		var confusedPromptCacheKey string
+		select {
+		case confusedPromptCacheKey = <-confusedPromptCacheKeyCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for upstream prompt cache key")
+		}
+		if strings.Contains(errText, confusedPromptCacheKey) {
+			t.Fatalf("error chunk Err leaked confused prompt cache key: %v", chunk.Err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for error stream chunk")
+	}
+
+	select {
+	case errDisconnect, ok := <-disconnectCh:
+		t.Fatalf("downstream disconnect notified before error forwarding completed: ok=%v err=%v", ok, errDisconnect)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamPassesThroughResponseFailedForDownstreamWebsocket(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	failedPayload := []byte(`{"type":"response.failed","response":{"id":"resp-1","status":"failed","error":{"type":"server_error","message":"upstream failed"}}}`)
+	done := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			t.Errorf("read upstream websocket message: %v", errRead)
+			return
+		}
+		if errWrite := conn.WriteMessage(websocket.TextMessage, failedPayload); errWrite != nil {
+			t.Errorf("write response.failed websocket message: %v", errWrite)
+			return
+		}
+		<-done
+	}))
+	defer server.Close()
+	defer close(done)
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-response-failed-downstream"
+	defer exec.CloseExecutionSession(sessionID)
+	disconnectCh := exec.UpstreamDisconnectChan(sessionID)
+	if disconnectCh == nil {
+		t.Fatal("expected disconnect channel")
+	}
+
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","role":"user","content":"hello"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FromString("openai-response"),
+		ResponseFormat: sdktranslator.FromString("openai-response"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+
+	result, err := exec.ExecuteStream(ctx, auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	select {
+	case chunk, ok := <-result.Chunks:
+		if !ok {
+			t.Fatal("stream closed before response.failed chunk")
+		}
+		if chunk.Err != nil {
+			t.Fatalf("response.failed chunk error = %v", chunk.Err)
+		}
+		if !bytes.Equal(bytes.TrimSpace(chunk.Payload), failedPayload) {
+			t.Fatalf("response.failed chunk = %q, want %q", chunk.Payload, failedPayload)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for response.failed chunk")
+	}
+
+	select {
+	case chunk, ok := <-result.Chunks:
+		if ok {
+			t.Fatalf("unexpected chunk after response.failed: payload=%q err=%v", chunk.Payload, chunk.Err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("stream did not close after response.failed")
+	}
+	if got := exec.UpstreamGeneration(sessionID); got != 1 {
+		t.Fatalf("upstream generation = %d, want 1", got)
+	}
+	select {
+	case errRead, ok := <-disconnectCh:
+		t.Fatalf("unexpected disconnect signal ok=%t err=%v", ok, errRead)
+	default:
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamSurfacesResponseFailedForNonWebsocket(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	done := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			t.Errorf("read upstream websocket message: %v", errRead)
+			return
+		}
+		failedPayload := []byte(`{"type":"response.failed","response":{"id":"resp-1","status":"failed","error":{"type":"invalid_request_error","message":"bad request"}}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, failedPayload); errWrite != nil {
+			t.Errorf("write response.failed websocket message: %v", errWrite)
+			return
+		}
+		<-done
+	}))
+	defer server.Close()
+	defer close(done)
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","role":"user","content":"hello"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FromString("openai-response"),
+		ResponseFormat: sdktranslator.FromString("openai-response"),
+	}
+
+	result, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	select {
+	case chunk, ok := <-result.Chunks:
+		if !ok {
+			t.Fatal("stream closed before response.failed error")
+		}
+		if chunk.Err == nil {
+			t.Fatalf("response.failed chunk Err = nil, payload=%q", chunk.Payload)
+		}
+		if got := statusCodeFromTestError(t, chunk.Err); got != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d; err=%v", got, http.StatusBadRequest, chunk.Err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for response.failed error")
+	}
+}
+
 func TestCodexWebsocketsExecutePreviousResponseNotFoundDropsQuietly(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -266,7 +502,80 @@ func TestCodexWebsocketsExecutePreviousResponseNotFoundDropsQuietly(t *testing.T
 	select {
 	case errRead, ok := <-disconnectCh:
 		t.Fatalf("unexpected disconnect signal ok=%t err=%v", ok, errRead)
-	case <-time.After(100 * time.Millisecond):
+	default:
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamRecoverableUpstreamErrorDropsQuietly(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Fatalf("request path = %s, want /responses", r.URL.Path)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			t.Fatalf("read upstream websocket message: %v", errRead)
+		}
+		errPayload := []byte(`{"type":"error","status":429,"error":{"code":"rate_limit_exceeded","message":"rate limited"}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, errPayload); errWrite != nil {
+			t.Fatalf("write websocket error: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-recoverable-upstream-error"
+	defer exec.CloseExecutionSession(sessionID)
+	disconnectCh := exec.UpstreamDisconnectChan(sessionID)
+	if disconnectCh == nil {
+		t.Fatal("expected disconnect channel")
+	}
+
+	auth := &cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","id":"msg-1"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+
+	result, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	if result == nil || result.Chunks == nil {
+		t.Fatal("expected stream result")
+	}
+
+	var chunk cliproxyexecutor.StreamChunk
+	select {
+	case chunk = <-result.Chunks:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upstream error chunk")
+	}
+	if chunk.Err == nil {
+		t.Fatalf("stream chunk error = nil, want 429")
+	}
+	status, ok := chunk.Err.(interface{ StatusCode() int })
+	if !ok || status.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("stream chunk error = %T %v, want 429 status", chunk.Err, chunk.Err)
+	}
+	if got := exec.UpstreamGeneration(sessionID); got != 1 {
+		t.Fatalf("upstream generation = %d, want 1", got)
+	}
+	select {
+	case errRead, ok := <-disconnectCh:
+		t.Fatalf("unexpected disconnect signal ok=%t err=%v", ok, errRead)
+	default:
 	}
 }
 
@@ -379,7 +688,7 @@ func TestCodexWebsocketsDropUpstreamConnQuietlyDoesNotSignalDisconnect(t *testin
 	select {
 	case errRead, ok := <-disconnectCh:
 		t.Fatalf("unexpected disconnect signal ok=%t err=%v", ok, errRead)
-	case <-time.After(100 * time.Millisecond):
+	default:
 	}
 
 	sess.connMu.Lock()
@@ -391,6 +700,1051 @@ func TestCodexWebsocketsDropUpstreamConnQuietlyDoesNotSignalDisconnect(t *testin
 	}
 	if got := exec.UpstreamGeneration(sessionID); got != 1 {
 		t.Fatalf("upstream generation after quiet drop = %d, want 1", got)
+	}
+}
+
+func TestCodexWebsocketsDropUpstreamSessionQuietly(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	sessionID := "sess-drop-session"
+	defer exec.CloseExecutionSession(sessionID)
+	disconnectCh := exec.UpstreamDisconnectChan(sessionID)
+	if disconnectCh == nil {
+		t.Fatal("expected disconnect channel")
+	}
+	sess := exec.getOrCreateSession(sessionID)
+	if sess == nil {
+		t.Fatal("expected session")
+	}
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.authID = "auth-1"
+	sess.wsURL = "ws://example.test/responses"
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+
+	exec.DropUpstreamSession(sessionID, "compact_replay")
+
+	select {
+	case errRead, ok := <-disconnectCh:
+		t.Fatalf("unexpected disconnect signal ok=%t err=%v", ok, errRead)
+	default:
+	}
+	sess.connMu.Lock()
+	current := sess.conn
+	readerConn := sess.readerConn
+	sess.connMu.Unlock()
+	if current != nil || readerConn != nil {
+		t.Fatalf("expected upstream connection to be cleared")
+	}
+	if got := exec.UpstreamGeneration(sessionID); got != 1 {
+		t.Fatalf("upstream generation after session drop = %d, want 1", got)
+	}
+}
+
+func TestCodexAutoExecutorDropUpstreamSessionForwardsToWebsocketExecutor(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	exec := NewCodexAutoExecutor(&config.Config{})
+	sessionID := "sess-auto-drop-session"
+	defer exec.CloseExecutionSession(sessionID)
+	disconnectCh := exec.UpstreamDisconnectChan(sessionID)
+	if disconnectCh == nil {
+		t.Fatal("expected disconnect channel")
+	}
+	sess := exec.wsExec.getOrCreateSession(sessionID)
+	if sess == nil {
+		t.Fatal("expected websocket session")
+	}
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.authID = "auth-1"
+	sess.wsURL = "ws://example.test/responses"
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+
+	exec.DropUpstreamSession(sessionID, "compact_replay")
+
+	select {
+	case errRead, ok := <-disconnectCh:
+		t.Fatalf("unexpected disconnect signal ok=%t err=%v", ok, errRead)
+	default:
+	}
+	sess.connMu.Lock()
+	current := sess.conn
+	readerConn := sess.readerConn
+	sess.connMu.Unlock()
+	if current != nil || readerConn != nil {
+		t.Fatalf("expected upstream connection to be cleared")
+	}
+	if got := exec.UpstreamGeneration(sessionID); got != 1 {
+		t.Fatalf("upstream generation after auto session drop = %d, want 1", got)
+	}
+}
+
+func TestCodexWebsocketsSendResponseProcessedUsesExistingUpstream(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	captured := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, payload, errRead := conn.ReadMessage()
+		if errRead != nil {
+			t.Errorf("read websocket message: %v", errRead)
+			return
+		}
+		captured <- bytes.Clone(payload)
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	sessionID := "sess-response-processed"
+	defer exec.CloseExecutionSession(sessionID)
+	sess := exec.getOrCreateSession(sessionID)
+	if sess == nil {
+		t.Fatal("expected session")
+	}
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.authID = "auth-1"
+	sess.wsURL = "ws://example.test/responses"
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+
+	if errSend := exec.SendResponseProcessed(sessionID, "resp-processed-1"); errSend != nil {
+		t.Fatalf("SendResponseProcessed error: %v", errSend)
+	}
+
+	select {
+	case payload := <-captured:
+		if got := gjson.GetBytes(payload, "type").String(); got != "response.processed" {
+			t.Fatalf("type = %q, want response.processed; payload=%s", got, string(payload))
+		}
+		if got := gjson.GetBytes(payload, "response_id").String(); got != "resp-processed-1" {
+			t.Fatalf("response_id = %q, want resp-processed-1; payload=%s", got, string(payload))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for response.processed upstream frame")
+	}
+}
+
+func TestCloseCodexWebsocketSessionSignalsActiveReader(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	sess := &codexWebsocketSession{sessionID: "sess-close-active"}
+	readCh := make(chan codexWebsocketRead, 1)
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.authID = "auth-1"
+	sess.wsURL = "ws://example.test/responses"
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+	sess.setActive(readCh, conn)
+
+	closeCodexWebsocketSession(sess, "test_close")
+
+	select {
+	case ev, ok := <-readCh:
+		if !ok {
+			t.Fatalf("expected active reader error before close")
+		}
+		if ev.err == nil || !strings.Contains(ev.err.Error(), "execution session closed") {
+			t.Fatalf("active reader error = %v, want execution session closed", ev.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for active reader close signal")
+	}
+
+	sess.connMu.Lock()
+	current := sess.conn
+	readerConn := sess.readerConn
+	sess.connMu.Unlock()
+	if current != nil || readerConn != nil {
+		t.Fatalf("expected session websocket connection to be cleared")
+	}
+}
+
+func TestReadCodexWebsocketMessageDrainsBufferedPayloadAfterActiveDone(t *testing.T) {
+	conn := &websocket.Conn{}
+	sess := &codexWebsocketSession{sessionID: "sess-buffered-active-done"}
+	readCh := make(chan codexWebsocketRead, 2)
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+	sess.setActive(readCh, conn)
+
+	readCh <- codexWebsocketRead{conn: conn, msgType: websocket.TextMessage, payload: []byte(`{"type":"response.completed"}`)}
+	sess.closeActiveReadForConn(conn, errors.New("upstream closed"))
+
+	msgType, payload, err := readCodexWebsocketMessage(context.Background(), sess, conn, readCh)
+	if err != nil {
+		t.Fatalf("readCodexWebsocketMessage() error = %v", err)
+	}
+	if msgType != websocket.TextMessage {
+		t.Fatalf("message type = %d, want text", msgType)
+	}
+	if string(payload) != `{"type":"response.completed"}` {
+		t.Fatalf("payload = %s, want buffered completed", payload)
+	}
+
+	_, _, err = readCodexWebsocketMessage(context.Background(), sess, conn, readCh)
+	if err == nil || !strings.Contains(err.Error(), "upstream closed") {
+		t.Fatalf("second read error = %v, want upstream closed", err)
+	}
+}
+
+func TestReadCodexWebsocketMessagePreservesClosedErrorWhenBufferFull(t *testing.T) {
+	conn := &websocket.Conn{}
+	sess := &codexWebsocketSession{sessionID: "sess-buffered-full-active-done"}
+	readCh := make(chan codexWebsocketRead, 1)
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+	sess.setActive(readCh, conn)
+
+	readCh <- codexWebsocketRead{conn: conn, msgType: websocket.TextMessage, payload: []byte(`{"type":"response.created"}`)}
+	sess.closeActiveReadForConn(conn, errors.New("upstream closed"))
+
+	msgType, payload, err := readCodexWebsocketMessage(context.Background(), sess, conn, readCh)
+	if err != nil {
+		t.Fatalf("readCodexWebsocketMessage() error = %v", err)
+	}
+	if msgType != websocket.TextMessage {
+		t.Fatalf("message type = %d, want text", msgType)
+	}
+	if string(payload) != `{"type":"response.created"}` {
+		t.Fatalf("payload = %s, want buffered created", payload)
+	}
+
+	_, _, err = readCodexWebsocketMessage(context.Background(), sess, conn, readCh)
+	if err == nil || !strings.Contains(err.Error(), "upstream closed") {
+		t.Fatalf("second read error = %v, want preserved upstream closed", err)
+	}
+}
+
+func TestReadCodexWebsocketMessagePrefersTerminalErrorOverUpstreamReset(t *testing.T) {
+	conn := &websocket.Conn{}
+	sess := &codexWebsocketSession{sessionID: "sess-terminal-over-reset"}
+	readCh := make(chan codexWebsocketRead, 1)
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+	sess.setActive(readCh, conn)
+
+	sess.closeActiveReadForConn(conn, codexWebsocketUpstreamResetError{cause: errors.New("read tcp: i/o timeout")})
+	sessionClosedErr := errors.New("codex websockets executor: execution session closed")
+	sess.markTerminalError(sessionClosedErr)
+
+	_, _, err := readCodexWebsocketMessage(context.Background(), sess, conn, readCh)
+	if err == nil || !strings.Contains(err.Error(), "execution session closed") {
+		t.Fatalf("read error = %v, want execution session closed", err)
+	}
+	var replayRequired interface {
+		CodexWebsocketReplayRequired() bool
+	}
+	if errors.As(err, &replayRequired) && replayRequired != nil && replayRequired.CodexWebsocketReplayRequired() {
+		t.Fatalf("read error = %v, must not be replay-required marker", err)
+	}
+}
+
+func TestCloseExecutionSessionOverridesDroppedUpstreamReset(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-close-after-drop"
+	sess := exec.getOrCreateSession(sessionID)
+	readCh := make(chan codexWebsocketRead, 1)
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.readerConn = conn
+	sess.authID = "auth-1"
+	sess.wsURL = wsURL
+	sess.connMu.Unlock()
+	sess.setActive(readCh, conn)
+
+	resetErr := codexWebsocketUpstreamResetError{cause: errors.New("read tcp: i/o timeout")}
+	exec.dropUpstreamConn(sess, conn, "upstream_disconnected", resetErr, false)
+	sess.closeActiveReadForConn(conn, resetErr)
+	exec.CloseExecutionSession(sessionID)
+
+	_, _, err = readCodexWebsocketMessage(context.Background(), sess, conn, readCh)
+	if err == nil || !strings.Contains(err.Error(), "execution session closed") {
+		t.Fatalf("read error = %v, want execution session closed", err)
+	}
+	var upstreamReset codexWebsocketUpstreamResetError
+	if errors.As(err, &upstreamReset) {
+		t.Fatalf("read error = %v, must not expose upstream reset after session close", err)
+	}
+	var replayRequired interface {
+		CodexWebsocketReplayRequired() bool
+	}
+	if errors.As(err, &replayRequired) && replayRequired != nil && replayRequired.CodexWebsocketReplayRequired() {
+		t.Fatalf("read error = %v, must not be replay-required marker", err)
+	}
+}
+
+func TestCodexWebsocketsExecuteSendErrorWithPreviousResponseIDRequiresReplay(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	accepted := make(chan struct{}, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		accepted <- struct{}{}
+		msgType, _, errRead := conn.ReadMessage()
+		if errRead != nil {
+			return
+		}
+		if msgType != websocket.TextMessage {
+			t.Errorf("message type = %d, want text", msgType)
+			return
+		}
+		completed := []byte(`{"type":"response.completed","response":{"id":"resp-retry","output":[]}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+			t.Errorf("write completed websocket message: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	staleConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial stale websocket: %v", err)
+	}
+	select {
+	case <-accepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stale websocket accept")
+	}
+	if errClose := staleConn.Close(); errClose != nil {
+		t.Fatalf("close stale websocket: %v", errClose)
+	}
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-execute-send-replay-required"
+	defer exec.CloseExecutionSession(sessionID)
+	sess := exec.getOrCreateSession(sessionID)
+	sess.connMu.Lock()
+	sess.conn = staleConn
+	sess.readerConn = staleConn
+	sess.authID = "auth-1"
+	sess.wsURL = "ws://example.test/responses"
+	sess.connMu.Unlock()
+
+	auth := &cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+
+	_, err = exec.Execute(context.Background(), auth, req, opts)
+	if err == nil {
+		t.Fatalf("Execute() error = nil, want replay-required error")
+	}
+	var replayRequired interface {
+		CodexWebsocketReplayRequired() bool
+	}
+	if !errors.As(err, &replayRequired) || replayRequired == nil || !replayRequired.CodexWebsocketReplayRequired() {
+		t.Fatalf("Execute() error = %v, want replay-required marker", err)
+	}
+	if got := exec.UpstreamGeneration(sessionID); got != 1 {
+		t.Fatalf("upstream generation after send error = %d, want 1", got)
+	}
+	select {
+	case <-accepted:
+		t.Fatalf("unexpected retry dial with stale previous_response_id")
+	default:
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamSendErrorWithPreviousResponseIDRequiresReplay(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	accepted := make(chan struct{}, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		accepted <- struct{}{}
+		msgType, _, errRead := conn.ReadMessage()
+		if errRead != nil {
+			return
+		}
+		if msgType != websocket.TextMessage {
+			t.Errorf("message type = %d, want text", msgType)
+			return
+		}
+		completed := []byte(`{"type":"response.completed","response":{"id":"resp-retry","output":[]}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+			t.Errorf("write completed websocket message: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	staleConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial stale websocket: %v", err)
+	}
+	select {
+	case <-accepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stale websocket accept")
+	}
+	if errClose := staleConn.Close(); errClose != nil {
+		t.Fatalf("close stale websocket: %v", errClose)
+	}
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-send-replay-required"
+	defer exec.CloseExecutionSession(sessionID)
+	sess := exec.getOrCreateSession(sessionID)
+	sess.connMu.Lock()
+	sess.conn = staleConn
+	sess.readerConn = staleConn
+	sess.authID = "auth-1"
+	sess.wsURL = "ws://example.test/responses"
+	sess.connMu.Unlock()
+
+	auth := &cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+
+	_, err = exec.ExecuteStream(context.Background(), auth, req, opts)
+	if err == nil {
+		t.Fatalf("ExecuteStream() error = nil, want replay-required error")
+	}
+	var replayRequired interface {
+		CodexWebsocketReplayRequired() bool
+	}
+	if !errors.As(err, &replayRequired) || replayRequired == nil || !replayRequired.CodexWebsocketReplayRequired() {
+		t.Fatalf("ExecuteStream() error = %v, want replay-required marker", err)
+	}
+	if got := exec.UpstreamGeneration(sessionID); got != 1 {
+		t.Fatalf("upstream generation after send error = %d, want 1", got)
+	}
+	select {
+	case <-accepted:
+		t.Fatalf("unexpected retry dial with stale previous_response_id")
+	default:
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamMissingUpstreamWithPreviousResponseIDRequiresReplay(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	upstreamPayload := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_ = conn.SetReadDeadline(time.Now().Add(250 * time.Millisecond))
+		msgType, payload, errRead := conn.ReadMessage()
+		if errRead != nil {
+			return
+		}
+		if msgType != websocket.TextMessage {
+			t.Errorf("message type = %d, want text", msgType)
+			return
+		}
+		upstreamPayload <- bytes.Clone(payload)
+		completed := []byte(`{"type":"response.completed","response":{"id":"resp-new","output":[]}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+			t.Errorf("write completed websocket message: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-missing-upstream-replay-required"
+	defer exec.CloseExecutionSession(sessionID)
+	sess := exec.getOrCreateSession(sessionID)
+	sess.connMu.Lock()
+	sess.upstreamGeneration = 1
+	sess.conn = nil
+	sess.readerConn = nil
+	sess.connMu.Unlock()
+
+	auth := &cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+
+	_, err := exec.ExecuteStream(cliproxyexecutor.WithDownstreamWebsocket(context.Background()), auth, req, opts)
+	if err == nil {
+		t.Fatalf("ExecuteStream() error = nil, want replay-required error")
+	}
+	var replayRequired interface {
+		CodexWebsocketReplayRequired() bool
+	}
+	if !errors.As(err, &replayRequired) || replayRequired == nil || !replayRequired.CodexWebsocketReplayRequired() {
+		t.Fatalf("ExecuteStream() error = %v, want replay-required marker", err)
+	}
+	select {
+	case payload := <-upstreamPayload:
+		t.Fatalf("stale previous_response_id request was sent to fresh upstream: %s", payload)
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamReadErrorWithPreviousResponseIDRequiresReplay(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	accepted := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		accepted <- struct{}{}
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			_ = conn.Close()
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-read-replay-required"
+	defer exec.CloseExecutionSession(sessionID)
+
+	auth := &cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+
+	result, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v, want stream result", err)
+	}
+	select {
+	case <-accepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket accept")
+	}
+
+	select {
+	case chunk, ok := <-result.Chunks:
+		if !ok {
+			t.Fatal("stream closed without replay-required error")
+		}
+		if chunk.Err == nil {
+			t.Fatalf("stream chunk error = nil, want replay-required error")
+		}
+		var replayRequired interface {
+			CodexWebsocketReplayRequired() bool
+		}
+		if !errors.As(chunk.Err, &replayRequired) || replayRequired == nil || !replayRequired.CodexWebsocketReplayRequired() {
+			t.Fatalf("stream chunk error = %v, want replay-required marker", chunk.Err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stream replay-required error")
+	}
+	if got := exec.UpstreamGeneration(sessionID); got != 1 {
+		t.Fatalf("upstream generation after read error = %d, want 1", got)
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamReadErrorWithoutPreviousResponseIDDoesNotRequireReplay(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	accepted := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		accepted <- struct{}{}
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			_ = conn.Close()
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-read-reset-no-replay"
+	defer exec.CloseExecutionSession(sessionID)
+
+	auth := &cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","id":"msg-1"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+
+	result, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v, want stream result", err)
+	}
+	select {
+	case <-accepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket accept")
+	}
+
+	select {
+	case chunk, ok := <-result.Chunks:
+		if !ok {
+			t.Fatal("stream closed without read error")
+		}
+		if chunk.Err == nil {
+			t.Fatalf("stream chunk error = nil, want read error")
+		}
+		var replayRequired interface {
+			CodexWebsocketReplayRequired() bool
+		}
+		if errors.As(chunk.Err, &replayRequired) && replayRequired != nil && replayRequired.CodexWebsocketReplayRequired() {
+			t.Fatalf("stream chunk error = %v, must not be replay-required marker", chunk.Err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stream read error")
+	}
+	if got := exec.UpstreamGeneration(sessionID); got != 1 {
+		t.Fatalf("upstream generation after read error = %d, want 1", got)
+	}
+}
+
+func TestCodexWebsocketsExecuteReadErrorWithPreviousResponseIDRequiresReplay(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	accepted := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		accepted <- struct{}{}
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			_ = conn.Close()
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-execute-read-replay-required"
+	defer exec.CloseExecutionSession(sessionID)
+
+	auth := &cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := exec.Execute(context.Background(), auth, req, opts)
+		errCh <- err
+	}()
+
+	select {
+	case <-accepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket accept")
+	}
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("Execute() error = nil, want replay-required error")
+		}
+		var replayRequired interface {
+			CodexWebsocketReplayRequired() bool
+		}
+		if !errors.As(err, &replayRequired) || replayRequired == nil || !replayRequired.CodexWebsocketReplayRequired() {
+			t.Fatalf("Execute() error = %v, want replay-required marker", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Execute replay-required error")
+	}
+	if got := exec.UpstreamGeneration(sessionID); got != 1 {
+		t.Fatalf("upstream generation after read error = %d, want 1", got)
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamUnexpectedBinaryDoesNotRequireReplay(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	receivedRequest := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			return
+		}
+		receivedRequest <- struct{}{}
+		if errWrite := conn.WriteMessage(websocket.BinaryMessage, []byte("unexpected")); errWrite != nil {
+			t.Errorf("write binary websocket message: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-stream-binary-no-replay"
+	defer exec.CloseExecutionSession(sessionID)
+
+	auth := &cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+
+	result, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v, want stream result", err)
+	}
+	select {
+	case <-receivedRequest:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket request")
+	}
+
+	select {
+	case chunk, ok := <-result.Chunks:
+		if !ok {
+			t.Fatal("stream closed without unexpected binary error")
+		}
+		if chunk.Err == nil || !strings.Contains(chunk.Err.Error(), "unexpected binary message") {
+			t.Fatalf("stream chunk error = %v, want unexpected binary", chunk.Err)
+		}
+		var replayRequired interface {
+			CodexWebsocketReplayRequired() bool
+		}
+		if errors.As(chunk.Err, &replayRequired) && replayRequired != nil && replayRequired.CodexWebsocketReplayRequired() {
+			t.Fatalf("stream chunk error = %v, must not be replay-required marker", chunk.Err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for unexpected binary error")
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamSessionCloseWithPreviousResponseIDDoesNotRequireReplay(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	receivedRequest := make(chan struct{}, 1)
+	releaseServer := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			return
+		}
+		receivedRequest <- struct{}{}
+		<-releaseServer
+	}))
+	defer server.Close()
+	defer close(releaseServer)
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-stream-session-close-no-replay"
+	defer exec.CloseExecutionSession(sessionID)
+
+	auth := &cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+
+	result, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v, want stream result", err)
+	}
+	select {
+	case <-receivedRequest:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket request")
+	}
+
+	exec.CloseExecutionSession(sessionID)
+
+	select {
+	case chunk, ok := <-result.Chunks:
+		if !ok {
+			t.Fatal("stream closed without session close error")
+		}
+		if chunk.Err == nil || !strings.Contains(chunk.Err.Error(), "execution session closed") {
+			t.Fatalf("stream chunk error = %v, want execution session closed", chunk.Err)
+		}
+		var replayRequired interface {
+			CodexWebsocketReplayRequired() bool
+		}
+		if errors.As(chunk.Err, &replayRequired) && replayRequired != nil && replayRequired.CodexWebsocketReplayRequired() {
+			t.Fatalf("stream chunk error = %v, must not be replay-required marker", chunk.Err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stream session close error")
+	}
+}
+
+func TestCodexWebsocketsExecuteReadCancelWithPreviousResponseIDDoesNotRequireReplay(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	receivedRequest := make(chan struct{}, 1)
+	releaseServer := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			return
+		}
+		receivedRequest <- struct{}{}
+		<-releaseServer
+	}))
+	defer server.Close()
+	defer close(releaseServer)
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-execute-read-cancel"
+	defer exec.CloseExecutionSession(sessionID)
+
+	auth := &cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := exec.Execute(ctx, auth, req, opts)
+		errCh <- err
+	}()
+
+	select {
+	case <-receivedRequest:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket request")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Execute() error = %v, want context.Canceled", err)
+		}
+		var replayRequired interface {
+			CodexWebsocketReplayRequired() bool
+		}
+		if errors.As(err, &replayRequired) && replayRequired != nil && replayRequired.CodexWebsocketReplayRequired() {
+			t.Fatalf("Execute() error = %v, must not be replay-required marker", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Execute cancellation")
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamHandshakeStatusUnlocksSessionRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	sessionID := "sess-handshake-status-unlock"
+	defer exec.CloseExecutionSession(sessionID)
+	auth := &cliproxyauth.Auth{ID: "auth-1", Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","id":"msg-1"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("codex"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
+
+	if _, err := exec.ExecuteStream(context.Background(), auth, req, opts); err == nil {
+		t.Fatalf("first ExecuteStream() error = nil, want handshake status error")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("second ExecuteStream() error = nil, want handshake status error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("second ExecuteStream() blocked; session request mutex was not released")
 	}
 }
 
@@ -430,7 +1784,6 @@ func TestCodexWebsocketsReadLoopIgnoresStaleConnErrors(t *testing.T) {
 		t.Fatal("expected session")
 	}
 	readCh := make(chan codexWebsocketRead, 1)
-	sess.setActive(readCh)
 	defer func() {
 		sess.clearActive(readCh)
 	}()
@@ -438,6 +1791,7 @@ func TestCodexWebsocketsReadLoopIgnoresStaleConnErrors(t *testing.T) {
 	sess.conn = currentConn
 	sess.readerConn = currentConn
 	sess.connMu.Unlock()
+	sess.setActive(readCh, currentConn)
 
 	done := make(chan struct{})
 	go func() {
@@ -463,6 +1817,74 @@ func TestCodexWebsocketsReadLoopIgnoresStaleConnErrors(t *testing.T) {
 	sess.activeMu.Unlock()
 	if activeCh != readCh {
 		t.Fatalf("expected active read channel to remain current")
+	}
+}
+
+func TestCodexWebsocketsReadLoopKeepsCurrentConnWithoutActiveReader(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	sent := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.created"}`)); errWrite != nil {
+			t.Errorf("write unsolicited websocket message: %v", errWrite)
+			return
+		}
+		sent <- struct{}{}
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	sessionID := "sess-current-no-active-reader"
+	defer exec.CloseExecutionSession(sessionID)
+	sess := exec.getOrCreateSession(sessionID)
+	if sess == nil {
+		t.Fatal("expected session")
+	}
+	sess.connMu.Lock()
+	sess.conn = conn
+	sess.readerConn = conn
+	sess.connMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		exec.readUpstreamLoop(sess, conn)
+		close(done)
+	}()
+
+	select {
+	case <-sent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for unsolicited upstream message")
+	}
+	select {
+	case <-done:
+		t.Fatal("read loop exited after current unsolicited message without active reader")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if errClose := conn.Close(); errClose != nil {
+		t.Fatalf("close websocket: %v", errClose)
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for read loop after connection close")
 	}
 }
 
@@ -784,8 +2206,10 @@ func TestApplyCodexWebsocketHeadersIdentityConfuseRemapsPromptCacheKey(t *testin
 	body, headers := applyCodexPromptCacheHeaders("openai-response", req, []byte(`{"model":"gpt-5-codex"}`))
 	body, identityState := applyCodexIdentityConfuseBody(cfg, auth, req.Payload, body)
 	ctx := contextWithGinHeaders(map[string]string{
-		"X-Codex-Turn-Metadata": `{"prompt_cache_key":"cache-ws-1","turn_id":"turn-ws-1","window_id":"cache-ws-1:0"}`,
+		"X-Codex-Turn-Metadata": `{"prompt_cache_key":"cache-ws-1","turn_id":"turn-ws-1","window_id":"cache-ws-1:3"}`,
+		"X-Codex-Window-Id":     "cache-ws-1:3",
 		"X-Client-Request-Id":   "client-request-1",
+		"Thread-Id":             "thread-ws-1",
 	})
 	headers = applyCodexWebsocketHeaders(ctx, headers, auth, "oauth-token", cfg)
 	applyCodexIdentityConfuseHeaders(headers, &identityState)
@@ -794,6 +2218,12 @@ func TestApplyCodexWebsocketHeadersIdentityConfuseRemapsPromptCacheKey(t *testin
 	expectedTurnID := codexIdentityConfuseUUID("auth-ws-1", "turn", "turn-ws-1")
 	if gotKey := gjson.GetBytes(body, "prompt_cache_key").String(); gotKey != expectedPromptCacheKey {
 		t.Fatalf("prompt_cache_key = %q, want %q", gotKey, expectedPromptCacheKey)
+	}
+	if strings.Contains(string(body), "cache-ws-1") {
+		t.Fatalf("upstream websocket body still contains original prompt cache key: %s", string(body))
+	}
+	if strings.Contains(headers.Get("X-Codex-Turn-Metadata"), "cache-ws-1") {
+		t.Fatalf("upstream websocket metadata still contains original prompt cache key: %s", headers.Get("X-Codex-Turn-Metadata"))
 	}
 	if gotSession := headers["session_id"]; len(gotSession) != 1 || gotSession[0] != expectedPromptCacheKey {
 		t.Fatalf("session_id = %#v, want [%q]", gotSession, expectedPromptCacheKey)
@@ -810,8 +2240,8 @@ func TestApplyCodexWebsocketHeadersIdentityConfuseRemapsPromptCacheKey(t *testin
 	if gotConversation := headers.Get("Conversation_id"); gotConversation != expectedPromptCacheKey {
 		t.Fatalf("Conversation_id = %q, want %q", gotConversation, expectedPromptCacheKey)
 	}
-	if gotWindowID := headers.Get("X-Codex-Window-Id"); gotWindowID != expectedPromptCacheKey+":0" {
-		t.Fatalf("X-Codex-Window-Id = %q, want %q", gotWindowID, expectedPromptCacheKey+":0")
+	if gotWindowID := headers.Get("X-Codex-Window-Id"); gotWindowID != expectedPromptCacheKey+":3" {
+		t.Fatalf("X-Codex-Window-Id = %q, want %q", gotWindowID, expectedPromptCacheKey+":3")
 	}
 	gotMetadata := headers.Get("X-Codex-Turn-Metadata")
 	if gotMetadataPromptCacheKey := gjson.Get(gotMetadata, "prompt_cache_key").String(); gotMetadataPromptCacheKey != expectedPromptCacheKey {
@@ -820,12 +2250,49 @@ func TestApplyCodexWebsocketHeadersIdentityConfuseRemapsPromptCacheKey(t *testin
 	if gotMetadataTurnID := gjson.Get(gotMetadata, "turn_id").String(); gotMetadataTurnID != expectedTurnID {
 		t.Fatalf("X-Codex-Turn-Metadata.turn_id = %q, want %q", gotMetadataTurnID, expectedTurnID)
 	}
-	if gotMetadataWindowID := gjson.Get(gotMetadata, "window_id").String(); gotMetadataWindowID != expectedPromptCacheKey+":0" {
-		t.Fatalf("X-Codex-Turn-Metadata.window_id = %q, want %q", gotMetadataWindowID, expectedPromptCacheKey+":0")
+	if gotMetadataWindowID := gjson.Get(gotMetadata, "window_id").String(); gotMetadataWindowID != expectedPromptCacheKey+":3" {
+		t.Fatalf("X-Codex-Turn-Metadata.window_id = %q, want %q", gotMetadataWindowID, expectedPromptCacheKey+":3")
 	}
 	expectedInstallationID := codexIdentityConfuseUUID("auth-ws-1", "installation", "install-ws-1")
 	if gotInstallationID := gjson.GetBytes(body, "client_metadata.x-codex-installation-id").String(); gotInstallationID != expectedInstallationID {
 		t.Fatalf("installation id = %q, want %q", gotInstallationID, expectedInstallationID)
+	}
+}
+
+func TestApplyCodexWebsocketHeadersPreservesWindowAndThreadHeaders(t *testing.T) {
+	ctx := contextWithGinHeaders(map[string]string{
+		"X-Codex-Window-Id": "cache-ws-1:3",
+		"Thread-Id":         "thread-ws-1",
+	})
+	headers := applyCodexWebsocketHeaders(ctx, nil, &cliproxyauth.Auth{Provider: "codex"}, "oauth-token", nil)
+
+	if got := headers.Get("X-Codex-Window-Id"); got != "cache-ws-1:3" {
+		t.Fatalf("X-Codex-Window-Id = %q, want cache-ws-1:3", got)
+	}
+	if got := headers.Get("Thread-Id"); got != "thread-ws-1" {
+		t.Fatalf("Thread-Id = %q, want thread-ws-1", got)
+	}
+}
+
+func TestApplyCodexWebsocketClientMetadataHeadersOverridesStaleHeaders(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Codex-Turn-Metadata", `{"prompt_cache_key":"cache-old","window_id":"cache-old:0"}`)
+	headers.Set("X-Codex-Window-Id", "cache-old:0")
+	body := []byte(`{"client_metadata":{"x-codex-turn-metadata":"{\"prompt_cache_key\":\"cache-new\",\"window_id\":\"cache-new:2\"}","x-codex-window-id":"cache-new:2","x-codex-parent-thread-id":"parent-1","x-openai-subagent":"compact"}}`)
+
+	applyCodexWebsocketClientMetadataHeaders(headers, body)
+
+	if got := headers.Get("X-Codex-Turn-Metadata"); !strings.Contains(got, "cache-new:2") || strings.Contains(got, "cache-old") {
+		t.Fatalf("X-Codex-Turn-Metadata was not refreshed from client_metadata: %s", got)
+	}
+	if got := headers.Get("X-Codex-Window-Id"); got != "cache-new:2" {
+		t.Fatalf("X-Codex-Window-Id = %q, want cache-new:2", got)
+	}
+	if got := headers.Get("X-Codex-Parent-Thread-Id"); got != "parent-1" {
+		t.Fatalf("X-Codex-Parent-Thread-Id = %q, want parent-1", got)
+	}
+	if got := headers.Get("X-Openai-Subagent"); got != "compact" {
+		t.Fatalf("X-Openai-Subagent = %q, want compact", got)
 	}
 }
 
@@ -965,6 +2432,52 @@ func TestIsCodexWebsocketPreviousResponseNotFound(t *testing.T) {
 	}
 	if isCodexWebsocketPreviousResponseNotFound([]byte(`{"type":"error","status":429,"error":{"code":"websocket_connection_limit_reached","message":"too many websockets"}}`)) {
 		t.Fatalf("connection limit error must not be classified as previous response not found")
+	}
+}
+
+func TestCodexWebsocketRequestNeedsTranscriptReplayOnReset(t *testing.T) {
+	if !codexWebsocketRequestNeedsTranscriptReplayOnReset([]byte(`{"previous_response_id":"resp-1","input":[]}`)) {
+		t.Fatalf("expected previous_response_id request to require transcript replay")
+	}
+	if codexWebsocketRequestNeedsTranscriptReplayOnReset([]byte(`{"input":[]}`)) {
+		t.Fatalf("request without previous_response_id must not require transcript replay")
+	}
+	if codexWebsocketRequestNeedsTranscriptReplayOnReset([]byte(`{"previous_response_id":" ","input":[]}`)) {
+		t.Fatalf("blank previous_response_id must not require transcript replay")
+	}
+}
+
+func TestCodexWebsocketReadErrorRequiresTranscriptReplay(t *testing.T) {
+	resetErr := codexWebsocketUpstreamResetError{cause: errors.New("read tcp: i/o timeout")}
+	if !codexWebsocketReadErrorRequiresTranscriptReplay([]byte(`{"previous_response_id":"resp-1","input":[]}`), resetErr, false) {
+		t.Fatalf("previous_response_id upstream reset should require transcript replay")
+	}
+	if codexWebsocketReadErrorRequiresTranscriptReplay([]byte(`{"input":[]}`), resetErr, false) {
+		t.Fatalf("non-websocket upstream reset without previous_response_id must not require transcript replay")
+	}
+	if !codexWebsocketReadErrorRequiresTranscriptReplay([]byte(`{"input":[]}`), resetErr, true) {
+		t.Fatalf("downstream websocket upstream reset without previous_response_id should require transcript replay")
+	}
+	if codexWebsocketReadErrorRequiresTranscriptReplay([]byte(`{"previous_response_id":"resp-1","input":[]}`), errors.New("other read error"), true) {
+		t.Fatalf("non-reset read error must not require transcript replay")
+	}
+}
+
+func TestCodexWebsocketTranscriptReplayRequiredError(t *testing.T) {
+	cause := errors.New("write failed")
+	errReplay := codexWebsocketTranscriptReplayRequiredError{reason: "send_error", cause: cause}
+
+	if !errors.Is(errReplay, cause) {
+		t.Fatalf("expected replay error to unwrap cause")
+	}
+	if got := errReplay.StatusCode(); got != http.StatusBadRequest {
+		t.Fatalf("StatusCode() = %d, want %d", got, http.StatusBadRequest)
+	}
+	if !errReplay.CodexWebsocketReplayRequired() {
+		t.Fatalf("expected replay-required marker")
+	}
+	if got := errReplay.Error(); !strings.Contains(got, "invalid_request_error") || !strings.Contains(got, "send_error") {
+		t.Fatalf("unexpected replay error message: %s", got)
 	}
 }
 

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -488,7 +488,7 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 	var readCh chan codexWebsocketRead
 	if sess != nil {
 		readCh = make(chan codexWebsocketRead, 4096)
-		sess.setActive(readCh)
+		sess.setActive(readCh, conn)
 	}
 
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -431,6 +431,7 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 		cliCancel(errMsg.Error)
 		return
 	}
+	markResponsesWebsocketCompactReplayForRequest(c.Request, rawJSON)
 	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 	_, _ = c.Writer.Write(resp)
 	cliCancel()

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -37,6 +37,7 @@ const (
 	wsDoneMarker         = "[DONE]"
 	wsTurnStateHeader    = "x-codex-turn-state"
 	wsTimelineBodyKey    = "WEBSOCKET_TIMELINE_OVERRIDE"
+	wsHeartbeatInterval  = 30 * time.Second
 )
 
 var responsesWebsocketUpgrader = websocket.Upgrader{
@@ -226,7 +227,9 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 
 	wsDone := make(chan struct{})
 	defer close(wsDone)
+	setDownstreamWaiting := startResponsesWebsocketHeartbeat(conn, wsDone, passthroughSessionID)
 
+	var upstreamGeneration func() uint64
 	if h != nil && h.AuthManager != nil {
 		type upstreamDisconnectSubscriber interface {
 			UpstreamDisconnectChan(sessionID string) <-chan error
@@ -236,6 +239,14 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			if !ok || exec == nil {
 				continue
 			}
+			type upstreamGenerationProvider interface {
+				UpstreamGeneration(sessionID string) uint64
+			}
+			if provider, ok := exec.(upstreamGenerationProvider); ok && provider != nil {
+				upstreamGeneration = func() uint64 {
+					return provider.UpstreamGeneration(passthroughSessionID)
+				}
+			}
 			if subscriber, ok := exec.(upstreamDisconnectSubscriber); ok && subscriber != nil {
 				disconnectCh := subscriber.UpstreamDisconnectChan(passthroughSessionID)
 				if disconnectCh != nil {
@@ -244,7 +255,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 						case <-wsDone:
 							return
 						case <-disconnectCh:
-							_ = conn.Close()
+							closeResponsesWebsocketWithFrame(conn, websocket.CloseInternalServerErr, "upstream websocket disconnected")
 						}
 					}()
 				}
@@ -277,6 +288,10 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 	var lastResponsePendingToolCallIDs []string
 	pinnedAuthID := ""
 	passthroughModelName := ""
+	seenUpstreamGeneration := uint64(0)
+	if upstreamGeneration != nil {
+		seenUpstreamGeneration = upstreamGeneration()
+	}
 	sessionAuthByID := func(authID string) (*coreauth.Auth, bool) {
 		if h == nil || h.AuthManager == nil {
 			return nil, false
@@ -289,7 +304,9 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 	forceTranscriptReplayNextRequest := false
 
 	for {
+		setDownstreamWaiting(true)
 		msgType, payload, errReadMessage := conn.ReadMessage()
+		setDownstreamWaiting(false)
 		if errReadMessage != nil {
 			wsTerminateErr = errReadMessage
 			if websocket.IsCloseError(errReadMessage, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
@@ -320,21 +337,31 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			requestModelName = strings.TrimSpace(gjson.GetBytes(lastRequest, "model").String())
 		}
 		useUpstreamWebsocketPassthrough := h.responsesWebsocketUsesUpstreamWebsocketPassthrough(requestModelName)
+		replayCurrentRequest := false
+	retryCurrentRequest:
+		currentUpstreamGeneration := seenUpstreamGeneration
+		upstreamGenerationChanged := false
+		if upstreamGeneration != nil {
+			currentUpstreamGeneration = upstreamGeneration()
+			upstreamGenerationChanged = currentUpstreamGeneration != seenUpstreamGeneration
+		}
+
 		allowIncrementalInputWithPreviousResponseID := false
 		allowCompactionReplayBypass := false
-		if !useUpstreamWebsocketPassthrough {
-			if pinnedAuthID != "" {
-				if pinnedAuth, ok := sessionAuthByID(pinnedAuthID); ok && pinnedAuth != nil {
-					allowIncrementalInputWithPreviousResponseID = responsesWebsocketAuthSupportsIncrementalInput(pinnedAuth)
-					allowCompactionReplayBypass = responsesWebsocketAuthSupportsCompactionReplay(pinnedAuth)
-				}
-			} else {
-				allowIncrementalInputWithPreviousResponseID = h.websocketUpstreamSupportsIncrementalInputForModel(requestModelName)
-				allowCompactionReplayBypass = h.websocketUpstreamSupportsCompactionReplayForModel(requestModelName)
+		if pinnedAuthID != "" {
+			if pinnedAuth, ok := sessionAuthByID(pinnedAuthID); ok && pinnedAuth != nil {
+				allowIncrementalInputWithPreviousResponseID = responsesWebsocketAuthSupportsIncrementalInput(pinnedAuth)
+				allowCompactionReplayBypass = responsesWebsocketAuthSupportsCompactionReplay(pinnedAuth)
 			}
-			if forceTranscriptReplayNextRequest {
-				allowIncrementalInputWithPreviousResponseID = false
-			}
+		} else {
+			allowIncrementalInputWithPreviousResponseID = h.websocketUpstreamSupportsIncrementalInputForModel(requestModelName)
+			allowCompactionReplayBypass = h.websocketUpstreamSupportsCompactionReplayForModel(requestModelName)
+		}
+		if forceTranscriptReplayNextRequest || upstreamGenerationChanged || replayCurrentRequest {
+			allowIncrementalInputWithPreviousResponseID = false
+		}
+		if useUpstreamWebsocketPassthrough && (forceTranscriptReplayNextRequest || upstreamGenerationChanged || replayCurrentRequest) {
+			useUpstreamWebsocketPassthrough = false
 		}
 
 		var requestJSON []byte
@@ -342,6 +369,17 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		var errMsg *interfaces.ErrorMessage
 		if useUpstreamWebsocketPassthrough {
 			requestJSON, errMsg = normalizeResponsesWebsocketPassthroughRequest(payload, requestModelName)
+			if errMsg == nil {
+				_, updatedLastRequest, errMsg = normalizeResponsesWebsocketRequestWithIncrementalState(
+					payload,
+					lastRequest,
+					lastResponseOutput,
+					lastResponseID,
+					lastResponsePendingToolCallIDs,
+					false,
+					allowCompactionReplayBypass,
+				)
+			}
 		} else {
 			requestJSON, updatedLastRequest, errMsg = normalizeResponsesWebsocketRequestWithIncrementalState(
 				payload,
@@ -397,10 +435,13 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		previousLastResponseOutput := bytes.Clone(lastResponseOutput)
 		previousLastResponseID := lastResponseID
 		previousLastResponsePendingToolCallIDs := append([]string(nil), lastResponsePendingToolCallIDs...)
-		forcedTranscriptReplay := forceTranscriptReplayNextRequest
+		forcedTranscriptReplay := forceTranscriptReplayNextRequest || upstreamGenerationChanged || replayCurrentRequest
 		if useUpstreamWebsocketPassthrough {
 			if modelName := strings.TrimSpace(gjson.GetBytes(requestJSON, "model").String()); modelName != "" {
 				passthroughModelName = modelName
+			}
+			if len(updatedLastRequest) > 0 {
+				lastRequest = updatedLastRequest
 			}
 			if forcedTranscriptReplay {
 				forceTranscriptReplayNextRequest = false
@@ -438,29 +479,37 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 		dataChan, _, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, requestJSON, "")
 
-		completedOutput, completedResponseID, completedPendingToolCallIDs, forwardErrMsg, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, wsTimelineLog, passthroughSessionID)
+		suppressPreviousResponseNotFound := !forcedTranscriptReplay && strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String()) != ""
+		completedOutput, completedResponseID, completedPendingToolCallIDs, forwardErrMsg, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, wsTimelineLog, passthroughSessionID, suppressPreviousResponseNotFound)
 		if errForward != nil {
 			wsTerminateErr = errForward
 			log.Warnf("responses websocket: forward failed id=%s error=%v", passthroughSessionID, errForward)
 			return
 		}
+		if suppressPreviousResponseNotFound && shouldRetryResponsesWebsocketTranscriptReplay(forwardErrMsg) {
+			replayCurrentRequest = true
+			forceTranscriptReplayNextRequest = false
+			lastRequest = previousLastRequest
+			lastResponseOutput = previousLastResponseOutput
+			goto retryCurrentRequest
+		}
 		if shouldReleaseResponsesWebsocketPinnedAuth(forwardErrMsg) {
 			pinnedAuthID = ""
 			forceTranscriptReplayNextRequest = true
-			if useUpstreamWebsocketPassthrough {
-				passthroughModelName = ""
-			} else {
-				lastRequest = previousLastRequest
-				lastResponseOutput = previousLastResponseOutput
-				lastResponseID = previousLastResponseID
-				lastResponsePendingToolCallIDs = previousLastResponsePendingToolCallIDs
-			}
+			passthroughModelName = ""
+			lastRequest = previousLastRequest
+			lastResponseOutput = previousLastResponseOutput
+			lastResponseID = previousLastResponseID
+			lastResponsePendingToolCallIDs = previousLastResponsePendingToolCallIDs
 			continue
 		}
-		if !useUpstreamWebsocketPassthrough {
-			lastResponseOutput = completedOutput
-			lastResponseID = strings.TrimSpace(completedResponseID)
-			lastResponsePendingToolCallIDs = append([]string(nil), completedPendingToolCallIDs...)
+		lastResponseOutput = completedOutput
+		lastResponseID = strings.TrimSpace(completedResponseID)
+		lastResponsePendingToolCallIDs = append([]string(nil), completedPendingToolCallIDs...)
+		if upstreamGeneration != nil {
+			seenUpstreamGeneration = upstreamGeneration()
+		} else {
+			seenUpstreamGeneration = currentUpstreamGeneration
 		}
 	}
 }
@@ -1295,8 +1344,10 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 	errs <-chan *interfaces.ErrorMessage,
 	wsTimelineLog websocketTimelineAppender,
 	sessionID string,
+	suppressPreviousResponseNotFound bool,
 ) ([]byte, string, []string, *interfaces.ErrorMessage, error) {
 	completed := false
+	forwardedPayload := false
 	completedOutput := []byte("[]")
 	completedResponseID := ""
 	pendingToolCallIDs := make(map[string]struct{})
@@ -1316,6 +1367,10 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 				continue
 			}
 			if errMsg != nil {
+				if suppressPreviousResponseNotFound && !forwardedPayload && shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
+					cancel(errMsg.Error)
+					return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), errMsg, nil
+				}
 				h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), errMsg)
 				markAPIResponseTimestamp(c)
 				errorPayload, errWrite := writeResponsesWebsocketError(conn, wsTimelineLog, errMsg)
@@ -1415,6 +1470,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 					cancel(payloadErrMsg.Error)
 					return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), payloadErrMsg, nil
 				}
+				forwardedPayload = true
 			}
 		}
 	}
@@ -1436,6 +1492,24 @@ func shouldReleaseResponsesWebsocketPinnedAuth(errMsg *interfaces.ErrorMessage) 
 	default:
 		return false
 	}
+}
+
+func shouldRetryResponsesWebsocketTranscriptReplay(errMsg *interfaces.ErrorMessage) bool {
+	if errMsg == nil || errMsg.Error == nil {
+		return false
+	}
+	status := errMsg.StatusCode
+	if status <= 0 {
+		if se, ok := errMsg.Error.(interface{ StatusCode() int }); ok && se != nil {
+			status = se.StatusCode()
+		}
+	}
+	if status > 0 && status != http.StatusBadRequest {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(errMsg.Error.Error()))
+	return strings.Contains(lower, "previous_response_not_found") ||
+		(strings.Contains(lower, "previous_response") || strings.Contains(lower, "previous response")) && strings.Contains(lower, "not found")
 }
 
 func responseCompletedOutputFromPayload(payload []byte) []byte {
@@ -1684,6 +1758,43 @@ func writeResponsesWebsocketPayload(conn *websocket.Conn, wsTimelineLog websocke
 		wsTimelineLog.Append("response", payload, timestamp)
 	}
 	return conn.WriteMessage(websocket.TextMessage, payload)
+}
+
+func startResponsesWebsocketHeartbeat(conn *websocket.Conn, done <-chan struct{}, sessionID string) func(bool) {
+	return startResponsesWebsocketHeartbeatWithInterval(conn, done, sessionID, wsHeartbeatInterval)
+}
+
+func startResponsesWebsocketHeartbeatWithInterval(conn *websocket.Conn, done <-chan struct{}, sessionID string, interval time.Duration) func(bool) {
+	if conn == nil || interval <= 0 {
+		return func(bool) {}
+	}
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				if errWrite := conn.WriteControl(websocket.PingMessage, []byte("ping"), time.Time{}); errWrite != nil {
+					log.Debugf("responses websocket: heartbeat ping failed id=%s error=%v", strings.TrimSpace(sessionID), errWrite)
+					return
+				}
+			}
+		}
+	}()
+	return func(bool) {}
+}
+
+func closeResponsesWebsocketWithFrame(conn *websocket.Conn, code int, text string) {
+	if conn == nil {
+		return
+	}
+	payload := websocket.FormatCloseMessage(code, text)
+	if errWrite := conn.WriteControl(websocket.CloseMessage, payload, time.Time{}); errWrite != nil {
+		log.Debugf("responses websocket: write close frame failed: %v", errWrite)
+	}
+	_ = conn.Close()
 }
 
 func appendWebsocketTimelineDisconnect(timeline websocketTimelineAppender, err error, timestamp time.Time) {

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,15 +30,20 @@ import (
 )
 
 const (
-	wsRequestTypeCreate  = "response.create"
-	wsRequestTypeAppend  = "response.append"
-	wsEventTypeError     = "error"
-	wsEventTypeCompleted = "response.completed"
-	wsEventTypeDone      = "response.done"
-	wsDoneMarker         = "[DONE]"
-	wsTurnStateHeader    = "x-codex-turn-state"
-	wsTimelineBodyKey    = "WEBSOCKET_TIMELINE_OVERRIDE"
-	wsHeartbeatInterval  = 30 * time.Second
+	wsRequestTypeCreate          = "response.create"
+	wsRequestTypeAppend          = "response.append"
+	wsRequestTypeProcessed       = "response.processed"
+	wsEventTypeError             = "error"
+	wsEventTypeCompleted         = "response.completed"
+	wsEventTypeDone              = "response.done"
+	wsEventTypeFailed            = "response.failed"
+	wsDoneMarker                 = "[DONE]"
+	wsTurnStateHeader            = "x-codex-turn-state"
+	wsTimelineBodyKey            = "WEBSOCKET_TIMELINE_OVERRIDE"
+	wsHeartbeatInterval          = 30 * time.Second
+	wsTranscriptReplayMaxRetries = 2
+	wsConnectionLimitReachedCode = "websocket_connection_limit_reached"
+	codexCompactSummaryHead      = "Another language model started to solve this problem and produced a summary of its thinking process."
 )
 
 var responsesWebsocketUpgrader = websocket.Upgrader{
@@ -230,6 +236,8 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 	setDownstreamWaiting := startResponsesWebsocketHeartbeat(conn, wsDone, passthroughSessionID)
 
 	var upstreamGeneration func() uint64
+	var dropUpstreamSession func(reason string)
+	var sendResponseProcessed func(responseID string) error
 	if h != nil && h.AuthManager != nil {
 		type upstreamDisconnectSubscriber interface {
 			UpstreamDisconnectChan(sessionID string) <-chan error
@@ -242,9 +250,25 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			type upstreamGenerationProvider interface {
 				UpstreamGeneration(sessionID string) uint64
 			}
+			type upstreamSessionDropper interface {
+				DropUpstreamSession(sessionID string, reason string)
+			}
+			type responseProcessedSender interface {
+				SendResponseProcessed(sessionID string, responseID string) error
+			}
 			if provider, ok := exec.(upstreamGenerationProvider); ok && provider != nil {
 				upstreamGeneration = func() uint64 {
 					return provider.UpstreamGeneration(passthroughSessionID)
+				}
+			}
+			if dropper, ok := exec.(upstreamSessionDropper); ok && dropper != nil {
+				dropUpstreamSession = func(reason string) {
+					dropper.DropUpstreamSession(passthroughSessionID, reason)
+				}
+			}
+			if sender, ok := exec.(responseProcessedSender); ok && sender != nil {
+				sendResponseProcessed = func(responseID string) error {
+					return sender.SendResponseProcessed(passthroughSessionID, responseID)
 				}
 			}
 			if subscriber, ok := exec.(upstreamDisconnectSubscriber); ok && subscriber != nil {
@@ -328,6 +352,22 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		// )
 		wsTimelineLog.BeginRequest()
 		wsTimelineLog.Append("request", payload, time.Now())
+		if strings.TrimSpace(gjson.GetBytes(payload, "type").String()) == wsRequestTypeProcessed {
+			responseID := strings.TrimSpace(gjson.GetBytes(payload, "response_id").String())
+			if responseID != "" && sendResponseProcessed != nil {
+				if errSendProcessed := sendResponseProcessed(responseID); errSendProcessed != nil {
+					log.Debugf("responses websocket: failed to send response.processed id=%s response_id=%s error=%v", passthroughSessionID, responseID, errSendProcessed)
+				}
+			}
+			continue
+		}
+		requestSessionKeys := websocketDownstreamSessionKeysWithPayload(c.Request, payload)
+		compactReplayPending := hasResponsesWebsocketCompactReplay(requestSessionKeys)
+		requestInput := gjson.GetBytes(payload, "input")
+		requestInputContainsFullTranscript := inputContainsFullTranscript(requestInput)
+		if (compactReplayPending || requestInputContainsFullTranscript) && dropUpstreamSession != nil {
+			dropUpstreamSession("compact_replay")
+		}
 
 		requestModelName := strings.TrimSpace(gjson.GetBytes(payload, "model").String())
 		if requestModelName == "" {
@@ -338,6 +378,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 		useUpstreamWebsocketPassthrough := h.responsesWebsocketUsesUpstreamWebsocketPassthrough(requestModelName)
 		replayCurrentRequest := false
+		transcriptReplayRetries := 0
 	retryCurrentRequest:
 		currentUpstreamGeneration := seenUpstreamGeneration
 		upstreamGenerationChanged := false
@@ -345,6 +386,10 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			currentUpstreamGeneration = upstreamGeneration()
 			upstreamGenerationChanged = currentUpstreamGeneration != seenUpstreamGeneration
 		}
+		forcedTranscriptReplay := forceTranscriptReplayNextRequest || upstreamGenerationChanged || replayCurrentRequest
+		requestReplacesTranscript := compactReplayPending ||
+			requestInputContainsFullTranscript ||
+			responsesWebsocketRequestReplacesTranscript(payload, requestInput, lastRequest)
 
 		allowIncrementalInputWithPreviousResponseID := false
 		allowCompactionReplayBypass := false
@@ -357,10 +402,10 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			allowIncrementalInputWithPreviousResponseID = h.websocketUpstreamSupportsIncrementalInputForModel(requestModelName)
 			allowCompactionReplayBypass = h.websocketUpstreamSupportsCompactionReplayForModel(requestModelName)
 		}
-		if forceTranscriptReplayNextRequest || upstreamGenerationChanged || replayCurrentRequest {
+		if compactReplayPending || forcedTranscriptReplay {
 			allowIncrementalInputWithPreviousResponseID = false
 		}
-		if useUpstreamWebsocketPassthrough && (forceTranscriptReplayNextRequest || upstreamGenerationChanged || replayCurrentRequest) {
+		if useUpstreamWebsocketPassthrough && forcedTranscriptReplay {
 			useUpstreamWebsocketPassthrough = false
 		}
 
@@ -369,8 +414,11 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		var errMsg *interfaces.ErrorMessage
 		if useUpstreamWebsocketPassthrough {
 			requestJSON, errMsg = normalizeResponsesWebsocketPassthroughRequest(payload, requestModelName)
+			if errMsg == nil && (compactReplayPending || requestInputContainsFullTranscript) {
+				requestJSON, _ = sjson.DeleteBytes(requestJSON, "previous_response_id")
+			}
 			if errMsg == nil {
-				_, updatedLastRequest, errMsg = normalizeResponsesWebsocketRequestWithIncrementalState(
+				_, updatedLastRequest, errMsg = normalizeResponsesWebsocketRequestWithReplayMode(
 					payload,
 					lastRequest,
 					lastResponseOutput,
@@ -378,10 +426,12 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 					lastResponsePendingToolCallIDs,
 					false,
 					allowCompactionReplayBypass,
+					compactReplayPending,
+					false,
 				)
 			}
 		} else {
-			requestJSON, updatedLastRequest, errMsg = normalizeResponsesWebsocketRequestWithIncrementalState(
+			requestJSON, updatedLastRequest, errMsg = normalizeResponsesWebsocketRequestWithReplayMode(
 				payload,
 				lastRequest,
 				lastResponseOutput,
@@ -389,6 +439,8 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 				lastResponsePendingToolCallIDs,
 				allowIncrementalInputWithPreviousResponseID,
 				allowCompactionReplayBypass,
+				compactReplayPending,
+				forcedTranscriptReplay && !compactReplayPending,
 			)
 		}
 		if errMsg != nil {
@@ -413,7 +465,11 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			}
 			continue
 		}
-		if !useUpstreamWebsocketPassthrough && shouldHandleResponsesWebsocketPrewarmLocally(payload, lastRequest, allowIncrementalInputWithPreviousResponseID) {
+		resetToolRepairState := requestReplacesTranscript
+		if resetToolRepairState {
+			resetResponsesWebsocketToolCaches(downstreamSessionKey)
+		}
+		if !useUpstreamWebsocketPassthrough && !compactReplayPending && shouldHandleResponsesWebsocketPrewarmLocally(payload, lastRequest, allowIncrementalInputWithPreviousResponseID) {
 			if updated, errDelete := sjson.DeleteBytes(requestJSON, "generate"); errDelete == nil {
 				requestJSON = updated
 			}
@@ -431,11 +487,26 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			continue
 		}
 
+		requestBeforeRepair := bytes.Clone(requestJSON)
+		if !useUpstreamWebsocketPassthrough && !resetToolRepairState {
+			requestJSON = repairResponsesWebsocketToolCalls(downstreamSessionKey, requestJSON)
+		}
+		if !useUpstreamWebsocketPassthrough {
+			requestJSON = dedupeResponsesWebsocketInputItemsByID(requestJSON)
+		}
+		if bytes.Equal(updatedLastRequest, requestBeforeRepair) {
+			updatedLastRequest = bytes.Clone(requestJSON)
+		} else {
+			if !resetToolRepairState {
+				updatedLastRequest = repairResponsesWebsocketToolCalls(downstreamSessionKey, updatedLastRequest)
+			}
+			updatedLastRequest = dedupeResponsesWebsocketInputItemsByID(updatedLastRequest)
+		}
 		previousLastRequest := bytes.Clone(lastRequest)
 		previousLastResponseOutput := bytes.Clone(lastResponseOutput)
 		previousLastResponseID := lastResponseID
 		previousLastResponsePendingToolCallIDs := append([]string(nil), lastResponsePendingToolCallIDs...)
-		forcedTranscriptReplay := forceTranscriptReplayNextRequest || upstreamGenerationChanged || replayCurrentRequest
+		previousForceTranscriptReplayNextRequest := forceTranscriptReplayNextRequest
 		if useUpstreamWebsocketPassthrough {
 			if modelName := strings.TrimSpace(gjson.GetBytes(requestJSON, "model").String()); modelName != "" {
 				passthroughModelName = modelName
@@ -447,9 +518,6 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 				forceTranscriptReplayNextRequest = false
 			}
 		} else {
-			requestJSON = repairResponsesWebsocketToolCalls(downstreamSessionKey, requestJSON)
-			requestJSON = dedupeResponsesWebsocketInputItemsByID(requestJSON)
-			updatedLastRequest = bytes.Clone(requestJSON)
 			lastRequest = updatedLastRequest
 			if forcedTranscriptReplay {
 				forceTranscriptReplayNextRequest = false
@@ -479,18 +547,21 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 		dataChan, _, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, requestJSON, "")
 
-		suppressPreviousResponseNotFound := !forcedTranscriptReplay && strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String()) != ""
-		completedOutput, completedResponseID, completedPendingToolCallIDs, forwardErrMsg, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, wsTimelineLog, passthroughSessionID, suppressPreviousResponseNotFound)
+		allowTranscriptReplayBeforeOutput := transcriptReplayRetries < wsTranscriptReplayMaxRetries
+		completedOutput, completedResponseID, completedPendingToolCallIDs, forwardErrMsg, replayAllowed, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, wsTimelineLog, passthroughSessionID, allowTranscriptReplayBeforeOutput)
 		if errForward != nil {
 			wsTerminateErr = errForward
 			log.Warnf("responses websocket: forward failed id=%s error=%v", passthroughSessionID, errForward)
 			return
 		}
-		if suppressPreviousResponseNotFound && shouldRetryResponsesWebsocketTranscriptReplay(forwardErrMsg) {
+		if replayAllowed && allowTranscriptReplayBeforeOutput && shouldRetryResponsesWebsocketTranscriptReplay(forwardErrMsg) {
+			transcriptReplayRetries++
 			replayCurrentRequest = true
 			forceTranscriptReplayNextRequest = false
 			lastRequest = previousLastRequest
 			lastResponseOutput = previousLastResponseOutput
+			lastResponseID = previousLastResponseID
+			lastResponsePendingToolCallIDs = previousLastResponsePendingToolCallIDs
 			goto retryCurrentRequest
 		}
 		if shouldReleaseResponsesWebsocketPinnedAuth(forwardErrMsg) {
@@ -503,14 +574,24 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			lastResponsePendingToolCallIDs = previousLastResponsePendingToolCallIDs
 			continue
 		}
+		if forwardErrMsg != nil {
+			lastRequest = previousLastRequest
+			lastResponseOutput = previousLastResponseOutput
+			lastResponseID = previousLastResponseID
+			lastResponsePendingToolCallIDs = previousLastResponsePendingToolCallIDs
+			forceTranscriptReplayNextRequest = previousForceTranscriptReplayNextRequest
+			if shouldRetryResponsesWebsocketTranscriptReplay(forwardErrMsg) {
+				forceTranscriptReplayNextRequest = true
+			}
+			continue
+		}
+		if compactReplayPending && forwardErrMsg == nil {
+			consumeResponsesWebsocketCompactReplay(requestSessionKeys)
+		}
 		lastResponseOutput = completedOutput
 		lastResponseID = strings.TrimSpace(completedResponseID)
 		lastResponsePendingToolCallIDs = append([]string(nil), completedPendingToolCallIDs...)
-		if upstreamGeneration != nil {
-			seenUpstreamGeneration = upstreamGeneration()
-		} else {
-			seenUpstreamGeneration = currentUpstreamGeneration
-		}
+		seenUpstreamGeneration = currentUpstreamGeneration
 	}
 }
 
@@ -536,11 +617,11 @@ func websocketUpgradeHeaders(req *http.Request) http.Header {
 }
 
 func normalizeResponsesWebsocketRequest(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte) ([]byte, []byte, *interfaces.ErrorMessage) {
-	return normalizeResponsesWebsocketRequestWithMode(rawJSON, lastRequest, lastResponseOutput, true, true)
+	return normalizeResponsesWebsocketRequestWithMode(rawJSON, lastRequest, lastResponseOutput, true, true, false)
 }
 
-func normalizeResponsesWebsocketRequestWithMode(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool) ([]byte, []byte, *interfaces.ErrorMessage) {
-	return normalizeResponsesWebsocketRequestWithLastResponseID(rawJSON, lastRequest, lastResponseOutput, "", allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass)
+func normalizeResponsesWebsocketRequestWithMode(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool, forceTranscriptReplacement bool) ([]byte, []byte, *interfaces.ErrorMessage) {
+	return normalizeResponsesWebsocketRequestWithReplayMode(rawJSON, lastRequest, lastResponseOutput, "", nil, allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass, forceTranscriptReplacement, false)
 }
 
 func normalizeResponsesWebsocketRequestWithLastResponseID(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, lastResponseID string, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool) ([]byte, []byte, *interfaces.ErrorMessage) {
@@ -548,17 +629,22 @@ func normalizeResponsesWebsocketRequestWithLastResponseID(rawJSON []byte, lastRe
 }
 
 func normalizeResponsesWebsocketRequestWithIncrementalState(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, lastResponseID string, lastResponsePendingToolCallIDs []string, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool) ([]byte, []byte, *interfaces.ErrorMessage) {
+	return normalizeResponsesWebsocketRequestWithReplayMode(rawJSON, lastRequest, lastResponseOutput, lastResponseID, lastResponsePendingToolCallIDs, allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass, false, false)
+}
+
+func normalizeResponsesWebsocketRequestWithReplayMode(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, lastResponseID string, lastResponsePendingToolCallIDs []string, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool, forceTranscriptReplacement bool, forceTranscriptReplay bool) ([]byte, []byte, *interfaces.ErrorMessage) {
 	requestType := strings.TrimSpace(gjson.GetBytes(rawJSON, "type").String())
 	switch requestType {
 	case wsRequestTypeCreate:
 		// log.Infof("responses websocket: response.create request")
 		if len(lastRequest) == 0 {
-			return normalizeResponseCreateRequest(rawJSON)
+			dropPreviousResponseID := forceTranscriptReplacement || inputContainsFullTranscript(gjson.GetBytes(rawJSON, "input"))
+			return normalizeResponseCreateRequest(rawJSON, dropPreviousResponseID, allowCompactionReplayBypass)
 		}
-		return normalizeResponseSubsequentRequest(rawJSON, lastRequest, lastResponseOutput, lastResponseID, lastResponsePendingToolCallIDs, allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass)
+		return normalizeResponseSubsequentRequest(rawJSON, lastRequest, lastResponseOutput, lastResponseID, lastResponsePendingToolCallIDs, allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass, forceTranscriptReplacement, forceTranscriptReplay)
 	case wsRequestTypeAppend:
 		// log.Infof("responses websocket: response.append request")
-		return normalizeResponseSubsequentRequest(rawJSON, lastRequest, lastResponseOutput, lastResponseID, lastResponsePendingToolCallIDs, allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass)
+		return normalizeResponseSubsequentRequest(rawJSON, lastRequest, lastResponseOutput, lastResponseID, lastResponsePendingToolCallIDs, allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass, forceTranscriptReplacement, forceTranscriptReplay)
 	default:
 		return nil, lastRequest, &interfaces.ErrorMessage{
 			StatusCode: http.StatusBadRequest,
@@ -567,14 +653,21 @@ func normalizeResponsesWebsocketRequestWithIncrementalState(rawJSON []byte, last
 	}
 }
 
-func normalizeResponseCreateRequest(rawJSON []byte) ([]byte, []byte, *interfaces.ErrorMessage) {
+func normalizeResponseCreateRequest(rawJSON []byte, dropPreviousResponseID bool, allowCompactionReplayBypass bool) ([]byte, []byte, *interfaces.ErrorMessage) {
 	normalized, errDelete := sjson.DeleteBytes(rawJSON, "type")
 	if errDelete != nil {
 		normalized = bytes.Clone(rawJSON)
 	}
+	if dropPreviousResponseID {
+		normalized, _ = sjson.DeleteBytes(normalized, "previous_response_id")
+	}
 	normalized, _ = sjson.SetBytes(normalized, "stream", true)
 	if !gjson.GetBytes(normalized, "input").Exists() {
 		normalized, _ = sjson.SetRawBytes(normalized, "input", []byte("[]"))
+	}
+	input := gjson.GetBytes(normalized, "input")
+	if inputContainsFullTranscript(input) && !allowCompactionReplayBypass {
+		normalized, _ = sjson.SetRawBytes(normalized, "input", []byte(inputWithoutCompactionItems(input)))
 	}
 
 	modelName := strings.TrimSpace(gjson.GetBytes(normalized, "model").String())
@@ -584,10 +677,10 @@ func normalizeResponseCreateRequest(rawJSON []byte) ([]byte, []byte, *interfaces
 			Error:      fmt.Errorf("missing model in response.create request"),
 		}
 	}
-	return normalized, bytes.Clone(normalized), nil
+	return normalized, responsesWebsocketSnapshotWithoutCompactionTriggers(normalized), nil
 }
 
-func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, lastResponseID string, lastResponsePendingToolCallIDs []string, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool) ([]byte, []byte, *interfaces.ErrorMessage) {
+func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, lastResponseID string, lastResponsePendingToolCallIDs []string, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool, forceTranscriptReplacement bool, forceTranscriptReplay bool) ([]byte, []byte, *interfaces.ErrorMessage) {
 	if len(lastRequest) == 0 {
 		return nil, lastRequest, &interfaces.ErrorMessage{
 			StatusCode: http.StatusBadRequest,
@@ -603,13 +696,33 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 		}
 	}
 
-	// Compaction can cause clients to replace local websocket history with a new
-	// compact transcript on the next `response.create`. When the input already
-	// contains historical model output items, treating it as an incremental append
+	if inputContainsFullTranscript(nextInput) {
+		normalized, errMsg := buildResponsesWebsocketTranscriptState(rawJSON, lastRequest, lastResponseOutput, nextInput, allowCompactionReplayBypass)
+		if errMsg != nil {
+			return nil, lastRequest, errMsg
+		}
+		return normalized, responsesWebsocketSnapshotWithoutCompactionTriggers(normalized), nil
+	}
+
+	// When the input already contains historical model output items but no compact
+	// marker, treating it as an incremental append
 	// duplicates stale turn-state and can leave late orphaned function_call items.
-	if shouldReplaceWebsocketTranscript(rawJSON, nextInput) {
+	if responsesWebsocketRequestReplacesTranscript(rawJSON, nextInput, lastRequest) {
 		normalized := normalizeResponseTranscriptReplacement(rawJSON, lastRequest)
-		return normalized, bytes.Clone(normalized), nil
+		return normalized, responsesWebsocketSnapshotWithoutCompactionTriggers(normalized), nil
+	}
+
+	if forceTranscriptReplacement {
+		normalized := normalizeResponseTranscriptReplacement(rawJSON, lastRequest)
+		return normalized, responsesWebsocketSnapshotWithoutCompactionTriggers(normalized), nil
+	}
+
+	if forceTranscriptReplay {
+		normalized, errMsg := buildResponsesWebsocketTranscriptState(rawJSON, lastRequest, lastResponseOutput, nextInput, allowCompactionReplayBypass)
+		if errMsg != nil {
+			return nil, lastRequest, errMsg
+		}
+		return normalized, responsesWebsocketSnapshotWithoutCompactionTriggers(normalized), nil
 	}
 
 	// Websocket v2 mode uses response.create with previous_response_id + incremental input.
@@ -619,7 +732,7 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 		if prev == "" {
 			if !inputSatisfiesPendingToolCalls(nextInput, lastResponsePendingToolCallIDs) {
 				normalized := normalizeResponseTranscriptReplacement(rawJSON, lastRequest)
-				return normalized, bytes.Clone(normalized), nil
+				return normalized, responsesWebsocketSnapshotWithoutCompactionTriggers(normalized), nil
 			}
 			prev = strings.TrimSpace(lastResponseID)
 		}
@@ -642,30 +755,43 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 				}
 			}
 			normalized, _ = sjson.SetBytes(normalized, "stream", true)
-			return normalized, bytes.Clone(normalized), nil
+			updatedLastRequest, errMsg := buildResponsesWebsocketTranscriptState(rawJSON, lastRequest, lastResponseOutput, nextInput, allowCompactionReplayBypass)
+			if errMsg != nil {
+				return nil, lastRequest, errMsg
+			}
+			return normalized, responsesWebsocketSnapshotWithoutCompactionTriggers(updatedLastRequest), nil
 		}
 	}
 
-	// When the client sends a compact replay for a downstream that can consume it
-	// directly, the input already carries the canonical history. In that case,
-	// skip merging with stale lastRequest/lastResponseOutput to avoid breaking
-	// function_call / function_call_output pairings.
+	normalized, errMsg := buildResponsesWebsocketTranscriptState(rawJSON, lastRequest, lastResponseOutput, nextInput, allowCompactionReplayBypass)
+	if errMsg != nil {
+		return nil, lastRequest, errMsg
+	}
+	return normalized, responsesWebsocketSnapshotWithoutCompactionTriggers(normalized), nil
+}
+
+func buildResponsesWebsocketTranscriptState(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, nextInput gjson.Result, allowCompactionReplayBypass bool) ([]byte, *interfaces.ErrorMessage) {
+	// When the client sends a compact replay, the input already carries the
+	// canonical post-compaction history. In that case, skip merging with stale
+	// lastRequest/lastResponseOutput to avoid re-inflating compacted context or
+	// breaking function_call / function_call_output pairings.
 	// See: https://github.com/router-for-me/CLIProxyAPI/issues/2207
 	var mergedInput string
-	if allowCompactionReplayBypass && inputContainsFullTranscript(nextInput) {
-		log.Infof("responses websocket: full transcript detected, skipping stale merge (input items=%d)", len(nextInput.Array()))
-		mergedInput = nextInput.Raw
+	if inputContainsFullTranscript(nextInput) {
+		if allowCompactionReplayBypass {
+			log.Infof("responses websocket: full transcript detected, skipping stale merge (input items=%d)", len(nextInput.Array()))
+			mergedInput = nextInput.Raw
+		} else {
+			log.Infof("responses websocket: full transcript detected, stripping compaction items for unsupported upstream (input items=%d)", len(nextInput.Array()))
+			mergedInput = inputWithoutCompactionItems(nextInput)
+		}
 	} else {
 		appendInputRaw := nextInput.Raw
-		if inputContainsFullTranscript(nextInput) {
-			appendInputRaw = inputWithoutCompactionItems(nextInput)
-		}
-
 		existingInput := gjson.GetBytes(lastRequest, "input")
 		var errMerge error
 		mergedInput, errMerge = mergeJSONArrayRaw(existingInput.Raw, normalizeJSONArrayRaw(lastResponseOutput))
 		if errMerge != nil {
-			return nil, lastRequest, &interfaces.ErrorMessage{
+			return nil, &interfaces.ErrorMessage{
 				StatusCode: http.StatusBadRequest,
 				Error:      fmt.Errorf("invalid previous response output: %w", errMerge),
 			}
@@ -673,7 +799,7 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 
 		mergedInput, errMerge = mergeJSONArrayRaw(mergedInput, appendInputRaw)
 		if errMerge != nil {
-			return nil, lastRequest, &interfaces.ErrorMessage{
+			return nil, &interfaces.ErrorMessage{
 				StatusCode: http.StatusBadRequest,
 				Error:      fmt.Errorf("invalid request input: %w", errMerge),
 			}
@@ -696,7 +822,7 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 	var errSet error
 	normalized, errSet = sjson.SetRawBytes(normalized, "input", []byte(mergedInput))
 	if errSet != nil {
-		return nil, lastRequest, &interfaces.ErrorMessage{
+		return nil, &interfaces.ErrorMessage{
 			StatusCode: http.StatusBadRequest,
 			Error:      fmt.Errorf("failed to merge websocket input: %w", errSet),
 		}
@@ -714,10 +840,34 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 		}
 	}
 	normalized, _ = sjson.SetBytes(normalized, "stream", true)
-	return normalized, bytes.Clone(normalized), nil
+	return normalized, nil
 }
 
-func shouldReplaceWebsocketTranscript(rawJSON []byte, nextInput gjson.Result) bool {
+func responsesWebsocketSnapshotWithoutCompactionTriggers(payload []byte) []byte {
+	input := gjson.GetBytes(payload, "input")
+	if !input.IsArray() {
+		return bytes.Clone(payload)
+	}
+	filtered := make([]string, 0, len(input.Array()))
+	removed := false
+	for _, item := range input.Array() {
+		if strings.TrimSpace(item.Get("type").String()) == "compaction_trigger" {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, item.Raw)
+	}
+	if !removed {
+		return bytes.Clone(payload)
+	}
+	out, errSet := sjson.SetRawBytes(payload, "input", []byte("["+strings.Join(filtered, ",")+"]"))
+	if errSet != nil {
+		return bytes.Clone(payload)
+	}
+	return out
+}
+
+func shouldReplaceWebsocketTranscript(rawJSON []byte, nextInput gjson.Result, lastRequest []byte) bool {
 	requestType := strings.TrimSpace(gjson.GetBytes(rawJSON, "type").String())
 	if requestType != wsRequestTypeCreate && requestType != wsRequestTypeAppend {
 		return false
@@ -741,6 +891,72 @@ func shouldReplaceWebsocketTranscript(rawJSON []byte, nextInput gjson.Result) bo
 		}
 	}
 
+	return inputStartsWithPreviousRequestInput(nextInput, lastRequest)
+}
+
+func responsesWebsocketRequestReplacesTranscript(rawJSON []byte, nextInput gjson.Result, lastRequest []byte) bool {
+	return shouldReplaceWebsocketTranscript(rawJSON, nextInput, lastRequest) ||
+		isCodexFullWebsocketCreateWithoutPreviousResponseID(rawJSON)
+}
+
+func isCodexFullWebsocketCreateWithoutPreviousResponseID(rawJSON []byte) bool {
+	if strings.TrimSpace(gjson.GetBytes(rawJSON, "type").String()) != wsRequestTypeCreate {
+		return false
+	}
+	if strings.TrimSpace(gjson.GetBytes(rawJSON, "previous_response_id").String()) != "" {
+		return false
+	}
+	if strings.TrimSpace(gjson.GetBytes(rawJSON, "model").String()) == "" {
+		return false
+	}
+	if !gjson.GetBytes(rawJSON, "tools").Exists() ||
+		!gjson.GetBytes(rawJSON, "tool_choice").Exists() ||
+		!gjson.GetBytes(rawJSON, "parallel_tool_calls").Exists() ||
+		!gjson.GetBytes(rawJSON, "store").Exists() ||
+		!gjson.GetBytes(rawJSON, "stream").Exists() ||
+		!gjson.GetBytes(rawJSON, "include").Exists() {
+		return false
+	}
+	clientMetadata := gjson.GetBytes(rawJSON, "client_metadata")
+	if !clientMetadata.IsObject() {
+		return false
+	}
+	return strings.TrimSpace(clientMetadata.Get("x-codex-installation-id").String()) != "" &&
+		strings.TrimSpace(clientMetadata.Get("x-codex-window-id").String()) != ""
+}
+
+func inputStartsWithPreviousRequestInput(nextInput gjson.Result, lastRequest []byte) bool {
+	if !nextInput.Exists() || !nextInput.IsArray() {
+		return false
+	}
+	previousInput := gjson.GetBytes(lastRequest, "input")
+	if !previousInput.Exists() || !previousInput.IsArray() {
+		return false
+	}
+	previousItems := previousInput.Array()
+	nextItems := nextInput.Array()
+	if len(previousItems) == 0 || len(nextItems) < len(previousItems) {
+		return false
+	}
+	for i := range previousItems {
+		if !jsonRawValuesEqual(previousItems[i].Raw, nextItems[i].Raw) {
+			return false
+		}
+	}
+	return true
+}
+
+func jsonRawValuesEqual(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == b {
+		return true
+	}
+	normalizedA, okA := normalizeJSONValueRaw(a)
+	normalizedB, okB := normalizeJSONValueRaw(b)
+	if okA && okB {
+		return bytes.Equal(normalizedA, normalizedB)
+	}
 	return false
 }
 
@@ -771,6 +987,18 @@ func inputSatisfiesPendingToolCalls(input gjson.Result, pendingCallIDs []string)
 		}
 	}
 	return true
+}
+
+func normalizeJSONValueRaw(raw string) ([]byte, bool) {
+	var value any
+	if err := json.Unmarshal([]byte(raw), &value); err != nil {
+		return nil, false
+	}
+	normalized, err := json.Marshal(value)
+	if err != nil {
+		return nil, false
+	}
+	return normalized, true
 }
 
 func normalizeResponseTranscriptReplacement(rawJSON []byte, lastRequest []byte) []byte {
@@ -1289,10 +1517,11 @@ func mergeJSONArrayRaw(existingRaw, appendRaw string) (string, error) {
 }
 
 // inputContainsFullTranscript returns true when the input array carries compact
-// replay markers that indicate the client already sent the full conversation
-// transcript. Merging that input with stale lastRequest/lastResponseOutput
-// would duplicate or break function_call/function_call_output pairings, so the
-// caller should use the input as-is.
+// replay markers or the local Codex compact summary shape. Both indicate the
+// client already sent the full post-compaction transcript. Merging that input
+// with stale lastRequest/lastResponseOutput would duplicate compacted context
+// or break function_call/function_call_output pairings, so the caller should
+// use the input as-is.
 //
 // Assistant messages alone are not enough to classify the payload as a replay:
 // incremental websocket requests may legitimately append assistant items.
@@ -1301,12 +1530,54 @@ func inputContainsFullTranscript(input gjson.Result) bool {
 		return false
 	}
 	for _, item := range input.Array() {
-		t := item.Get("type").String()
-		if t == "compaction" || t == "compaction_summary" {
+		if isResponsesWebsocketCompactionItemType(item.Get("type").String()) {
+			return true
+		}
+		if isResponsesWebsocketLocalCompactionSummaryItem(item) {
 			return true
 		}
 	}
 	return false
+}
+
+func isResponsesWebsocketLocalCompactionSummaryItem(item gjson.Result) bool {
+	if strings.TrimSpace(item.Get("type").String()) != "message" {
+		return false
+	}
+	if strings.TrimSpace(item.Get("role").String()) != "user" {
+		return false
+	}
+	content := item.Get("content")
+	if !content.Exists() {
+		return false
+	}
+	if content.IsArray() {
+		for _, part := range content.Array() {
+			if strings.HasPrefix(part.Get("text").String(), codexCompactSummaryHead) {
+				return true
+			}
+		}
+		return false
+	}
+	return strings.HasPrefix(content.String(), codexCompactSummaryHead)
+}
+
+func isResponsesWebsocketCompactionItemType(t string) bool {
+	switch strings.TrimSpace(t) {
+	case "compaction", "compaction_summary", "compaction_trigger", "context_compaction":
+		return true
+	default:
+		return false
+	}
+}
+
+func isResponsesWebsocketCompactionReplayItemType(t string) bool {
+	switch strings.TrimSpace(t) {
+	case "compaction", "compaction_summary", "context_compaction":
+		return true
+	default:
+		return false
+	}
 }
 
 func inputWithoutCompactionItems(input gjson.Result) string {
@@ -1315,8 +1586,7 @@ func inputWithoutCompactionItems(input gjson.Result) string {
 	}
 	filtered := make([]string, 0, len(input.Array()))
 	for _, item := range input.Array() {
-		t := item.Get("type").String()
-		if t == "compaction" || t == "compaction_summary" {
+		if isResponsesWebsocketCompactionReplayItemType(item.Get("type").String()) {
 			continue
 		}
 		filtered = append(filtered, item.Raw)
@@ -1344,92 +1614,88 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 	errs <-chan *interfaces.ErrorMessage,
 	wsTimelineLog websocketTimelineAppender,
 	sessionID string,
-	suppressPreviousResponseNotFound bool,
-) ([]byte, string, []string, *interfaces.ErrorMessage, error) {
+	allowTranscriptReplayBeforeOutput bool,
+) ([]byte, string, []string, *interfaces.ErrorMessage, bool, error) {
 	completed := false
-	forwardedPayload := false
+	forwardedReplayBoundary := false
 	completedOutput := []byte("[]")
 	completedResponseID := ""
 	pendingToolCallIDs := make(map[string]struct{})
+	outputItemsByIndex := make(map[int64][]byte)
+	var outputItemsFallback [][]byte
 	downstreamSessionKey := ""
 	if c != nil && c.Request != nil {
 		downstreamSessionKey = websocketDownstreamSessionKey(c.Request)
 	}
 
+	handleError := func(errMsg *interfaces.ErrorMessage) ([]byte, string, []string, *interfaces.ErrorMessage, bool, error) {
+		if errMsg != nil {
+			if allowTranscriptReplayBeforeOutput && !forwardedReplayBoundary && shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
+				cancel(errMsg.Error)
+				return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), errMsg, true, nil
+			}
+			if responsesWebsocketErrorRequiresInternalReplay(errMsg) {
+				errMsg = responsesWebsocketTerminalReplayFailure(errMsg)
+			}
+			if h != nil {
+				h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), errMsg)
+			}
+			markAPIResponseTimestamp(c)
+			errorPayload, errWrite := writeResponsesWebsocketError(conn, wsTimelineLog, errMsg)
+			log.Infof(
+				"responses websocket: downstream_out id=%s type=%d event=%s payload=%s",
+				sessionID,
+				websocket.TextMessage,
+				websocketPayloadEventType(errorPayload),
+				websocketPayloadPreview(errorPayload),
+			)
+			if errWrite != nil {
+				// log.Warnf(
+				// 	"responses websocket: downstream_out write failed id=%s event=%s error=%v",
+				// 	sessionID,
+				// 	websocketPayloadEventType(errorPayload),
+				// 	errWrite,
+				// )
+				cancel(errMsg.Error)
+				return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), errMsg, false, errWrite
+			}
+		}
+		if errMsg != nil {
+			cancel(errMsg.Error)
+		} else {
+			cancel(nil)
+		}
+		return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), errMsg, false, nil
+	}
+
 	for {
+		if errMsg, hasErr := receivePendingResponsesWebsocketError(errs); hasErr {
+			return handleError(errMsg)
+		}
 		select {
 		case <-c.Request.Context().Done():
 			cancel(c.Request.Context().Err())
-			return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), nil, c.Request.Context().Err()
+			return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), nil, false, c.Request.Context().Err()
 		case errMsg, ok := <-errs:
 			if !ok {
 				errs = nil
 				continue
 			}
-			if errMsg != nil {
-				if suppressPreviousResponseNotFound && !forwardedPayload && shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
-					cancel(errMsg.Error)
-					return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), errMsg, nil
-				}
-				h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), errMsg)
-				markAPIResponseTimestamp(c)
-				errorPayload, errWrite := writeResponsesWebsocketError(conn, wsTimelineLog, errMsg)
-				log.Infof(
-					"responses websocket: downstream_out id=%s type=%d event=%s payload=%s",
-					sessionID,
-					websocket.TextMessage,
-					websocketPayloadEventType(errorPayload),
-					websocketPayloadPreview(errorPayload),
-				)
-				if errWrite != nil {
-					// log.Warnf(
-					// 	"responses websocket: downstream_out write failed id=%s event=%s error=%v",
-					// 	sessionID,
-					// 	websocketPayloadEventType(errorPayload),
-					// 	errWrite,
-					// )
-					cancel(errMsg.Error)
-					return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), errMsg, errWrite
-				}
-			}
-			if errMsg != nil {
-				cancel(errMsg.Error)
-			} else {
-				cancel(nil)
-			}
-			return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), errMsg, nil
+			return handleError(errMsg)
 		case chunk, ok := <-data:
 			if !ok {
 				if !completed {
+					if errMsg, hasErr := receiveResponsesWebsocketFinalError(errs); hasErr {
+						return handleError(errMsg)
+					}
 					errMsg := &interfaces.ErrorMessage{
 						StatusCode: http.StatusRequestTimeout,
 						Error:      fmt.Errorf("stream closed before response.completed"),
 					}
-					h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), errMsg)
-					markAPIResponseTimestamp(c)
-					errorPayload, errWrite := writeResponsesWebsocketError(conn, wsTimelineLog, errMsg)
-					log.Infof(
-						"responses websocket: downstream_out id=%s type=%d event=%s payload=%s",
-						sessionID,
-						websocket.TextMessage,
-						websocketPayloadEventType(errorPayload),
-						websocketPayloadPreview(errorPayload),
-					)
-					if errWrite != nil {
-						log.Warnf(
-							"responses websocket: downstream_out write failed id=%s event=%s error=%v",
-							sessionID,
-							websocketPayloadEventType(errorPayload),
-							errWrite,
-						)
-						cancel(errMsg.Error)
-						return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), errMsg, errWrite
-					}
-					cancel(errMsg.Error)
-					return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), errMsg, nil
+					return handleError(errMsg)
 				}
 				cancel(nil)
-				return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), nil, nil
+				return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), nil, false, nil
 			}
 
 			payloads := websocketJSONPayloadsFromChunk(chunk)
@@ -1438,15 +1704,22 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 				recordPendingToolCallIDsFromPayload(pendingToolCallIDs, payloads[i])
 				eventType := gjson.GetBytes(payloads[i], "type").String()
 				var payloadErrMsg *interfaces.ErrorMessage
-				if eventType == wsEventTypeError {
+				if eventType == wsEventTypeError || eventType == wsEventTypeFailed {
 					payloadErrMsg = responsesWebsocketErrorMessageFromPayload(payloads[i])
 					if h != nil {
 						h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), payloadErrMsg)
 					}
 				} else if isResponsesWebsocketCompletionEvent(eventType) {
 					completed = true
-					completedOutput = responseCompletedOutputFromPayload(payloads[i])
+					completedOutput = responseCompletedOutputFromPayload(payloads[i], outputItemsByIndex, outputItemsFallback)
 					completedResponseID = responseCompletedIDFromPayload(payloads[i])
+				}
+				if eventType == "response.output_item.done" {
+					collectResponsesWebsocketOutputItemDone(payloads[i], outputItemsByIndex, &outputItemsFallback)
+				}
+				if payloadErrMsg != nil && allowTranscriptReplayBeforeOutput && !forwardedReplayBoundary && shouldRetryResponsesWebsocketTranscriptReplay(payloadErrMsg) {
+					cancel(payloadErrMsg.Error)
+					return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), payloadErrMsg, true, nil
 				}
 				markAPIResponseTimestamp(c)
 				// log.Infof(
@@ -1464,15 +1737,47 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 						errWrite,
 					)
 					cancel(errWrite)
-					return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), nil, errWrite
+					return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), nil, false, errWrite
 				}
 				if payloadErrMsg != nil {
 					cancel(payloadErrMsg.Error)
-					return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), payloadErrMsg, nil
+					return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), payloadErrMsg, false, nil
 				}
-				forwardedPayload = true
+				if responsesWebsocketPayloadPrecludesTranscriptReplay(payloads[i]) {
+					forwardedReplayBoundary = true
+				}
+				if isResponsesWebsocketCompletionEvent(eventType) {
+					cancel(nil)
+					return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), nil, false, nil
+				}
 			}
 		}
+	}
+}
+
+func receivePendingResponsesWebsocketError(errs <-chan *interfaces.ErrorMessage) (*interfaces.ErrorMessage, bool) {
+	if errs == nil {
+		return nil, false
+	}
+	select {
+	case errMsg, ok := <-errs:
+		return errMsg, ok && errMsg != nil
+	default:
+		return nil, false
+	}
+}
+
+func receiveResponsesWebsocketFinalError(errs <-chan *interfaces.ErrorMessage) (*interfaces.ErrorMessage, bool) {
+	return receivePendingResponsesWebsocketError(errs)
+}
+
+func responsesWebsocketPayloadPrecludesTranscriptReplay(payload []byte) bool {
+	eventType := strings.TrimSpace(gjson.GetBytes(payload, "type").String())
+	switch eventType {
+	case "codex.rate_limits":
+		return false
+	default:
+		return true
 	}
 }
 
@@ -1498,6 +1803,12 @@ func shouldRetryResponsesWebsocketTranscriptReplay(errMsg *interfaces.ErrorMessa
 	if errMsg == nil || errMsg.Error == nil {
 		return false
 	}
+	if responsesWebsocketErrorRequiresInternalReplay(errMsg) {
+		return true
+	}
+	if responsesWebsocketErrorIndicatesConnectionLimitReached(errMsg.Error.Error()) {
+		return true
+	}
 	status := errMsg.StatusCode
 	if status <= 0 {
 		if se, ok := errMsg.Error.(interface{ StatusCode() int }); ok && se != nil {
@@ -1507,15 +1818,112 @@ func shouldRetryResponsesWebsocketTranscriptReplay(errMsg *interfaces.ErrorMessa
 	if status > 0 && status != http.StatusBadRequest {
 		return false
 	}
-	lower := strings.ToLower(strings.TrimSpace(errMsg.Error.Error()))
-	return strings.Contains(lower, "previous_response_not_found") ||
-		(strings.Contains(lower, "previous_response") || strings.Contains(lower, "previous response")) && strings.Contains(lower, "not found")
+	return responsesWebsocketErrorIndicatesPreviousResponseNotFound(errMsg.Error.Error())
 }
 
-func responseCompletedOutputFromPayload(payload []byte) []byte {
+func responsesWebsocketErrorRequiresInternalReplay(errMsg *interfaces.ErrorMessage) bool {
+	if errMsg == nil || errMsg.Error == nil {
+		return false
+	}
+	var replayRequired interface {
+		CodexWebsocketReplayRequired() bool
+	}
+	if errors.As(errMsg.Error, &replayRequired) && replayRequired != nil && replayRequired.CodexWebsocketReplayRequired() {
+		return true
+	}
+	return false
+}
+
+type responsesWebsocketTerminalReplayError struct {
+	cause error
+}
+
+func (e responsesWebsocketTerminalReplayError) Error() string {
+	return "upstream websocket reset before response completion"
+}
+
+func (e responsesWebsocketTerminalReplayError) Unwrap() error {
+	return e.cause
+}
+
+func responsesWebsocketTerminalReplayFailure(errMsg *interfaces.ErrorMessage) *interfaces.ErrorMessage {
+	var cause error
+	var addon http.Header
+	if errMsg != nil {
+		cause = errMsg.Error
+		addon = errMsg.Addon
+	}
+	return &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadGateway,
+		Error:      responsesWebsocketTerminalReplayError{cause: cause},
+		Addon:      addon,
+	}
+}
+
+func responsesWebsocketErrorIndicatesConnectionLimitReached(rawError string) bool {
+	rawError = strings.TrimSpace(rawError)
+	if rawError == "" || !json.Valid([]byte(rawError)) {
+		return false
+	}
+	for _, path := range []string{"error.code", "error.type", "body.error.code", "body.error.type", "response.error.code", "response.error.type", "code", "error"} {
+		if strings.EqualFold(strings.TrimSpace(gjson.Get(rawError, path).String()), wsConnectionLimitReachedCode) {
+			return true
+		}
+	}
+	return false
+}
+
+func responsesWebsocketErrorIndicatesPreviousResponseNotFound(rawError string) bool {
+	rawError = strings.TrimSpace(rawError)
+	if rawError == "" {
+		return false
+	}
+	if json.Valid([]byte(rawError)) {
+		hasCode := false
+		for _, path := range []string{"error.code", "body.error.code", "response.error.code", "code"} {
+			code := strings.ToLower(strings.TrimSpace(gjson.Get(rawError, path).String()))
+			if code == "" {
+				continue
+			}
+			hasCode = true
+			if code == "previous_response_not_found" {
+				return true
+			}
+		}
+		if hasCode {
+			return false
+		}
+		for _, path := range []string{"error.message", "body.error.message", "response.error.message", "message"} {
+			if responsesWebsocketErrorMessageIndicatesPreviousResponseNotFound(gjson.Get(rawError, path).String()) {
+				return true
+			}
+		}
+		return false
+	}
+	return responsesWebsocketErrorTextIndicatesPreviousResponseNotFound(rawError)
+}
+
+func responsesWebsocketErrorTextIndicatesPreviousResponseNotFound(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	return strings.Contains(lower, "previous_response_not_found") ||
+		(strings.Contains(lower, "previous_response") || strings.Contains(lower, "previous response")) &&
+			(strings.Contains(lower, "not found") || strings.Contains(lower, "no response found"))
+}
+
+func responsesWebsocketErrorMessageIndicatesPreviousResponseNotFound(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	mentionsPreviousResponse := strings.Contains(lower, "previous_response") || strings.Contains(lower, "previous response")
+	mentionsMissingResponse := strings.Contains(lower, "not found") || strings.Contains(lower, "no response found")
+	return mentionsPreviousResponse && mentionsMissingResponse
+}
+
+func responseCompletedOutputFromPayload(payload []byte, outputItemsByIndex map[int64][]byte, outputItemsFallback [][]byte) []byte {
 	output := gjson.GetBytes(payload, "response.output")
-	if output.Exists() && output.IsArray() {
+	if output.Exists() && output.IsArray() && len(output.Array()) > 0 {
 		return bytes.Clone([]byte(output.Raw))
+	}
+	if collected := responsesWebsocketCollectedOutputItems(outputItemsByIndex, outputItemsFallback); len(collected) > 0 {
+		return collected
 	}
 	return []byte("[]")
 }
@@ -1568,6 +1976,48 @@ func sortedStringSet(values map[string]struct{}) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func collectResponsesWebsocketOutputItemDone(payload []byte, outputItemsByIndex map[int64][]byte, outputItemsFallback *[][]byte) {
+	item := gjson.GetBytes(payload, "item")
+	if !item.Exists() || item.Type != gjson.JSON {
+		return
+	}
+	raw := bytes.Clone([]byte(item.Raw))
+	outputIndex := gjson.GetBytes(payload, "output_index")
+	if outputIndex.Exists() {
+		outputItemsByIndex[outputIndex.Int()] = raw
+		return
+	}
+	*outputItemsFallback = append(*outputItemsFallback, raw)
+}
+
+func responsesWebsocketCollectedOutputItems(outputItemsByIndex map[int64][]byte, outputItemsFallback [][]byte) []byte {
+	if len(outputItemsByIndex) == 0 && len(outputItemsFallback) == 0 {
+		return nil
+	}
+	items := make([]string, 0, len(outputItemsByIndex)+len(outputItemsFallback))
+	indexes := make([]int64, 0, len(outputItemsByIndex))
+	for idx := range outputItemsByIndex {
+		indexes = append(indexes, idx)
+	}
+	sort.Slice(indexes, func(i, j int) bool {
+		return indexes[i] < indexes[j]
+	})
+	for _, idx := range indexes {
+		if item := bytes.TrimSpace(outputItemsByIndex[idx]); len(item) > 0 {
+			items = append(items, string(item))
+		}
+	}
+	for _, item := range outputItemsFallback {
+		if trimmed := bytes.TrimSpace(item); len(trimmed) > 0 {
+			items = append(items, string(trimmed))
+		}
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	return []byte("[" + strings.Join(items, ",") + "]")
 }
 
 func websocketJSONPayloadsFromChunk(chunk []byte) [][]byte {
@@ -1717,17 +2167,33 @@ func isResponsesWebsocketCompletionEvent(eventType string) bool {
 }
 
 func responsesWebsocketErrorMessageFromPayload(payload []byte) *interfaces.ErrorMessage {
-	status := int(gjson.GetBytes(payload, "status").Int())
-	if status <= 0 {
-		status = int(gjson.GetBytes(payload, "status_code").Int())
-	}
-	if status <= 0 {
-		status = http.StatusInternalServerError
-	}
+	status, hasExplicitStatus := responsesWebsocketExplicitErrorStatus(payload)
 
 	errText := strings.TrimSpace(gjson.GetBytes(payload, "error.message").String())
 	if errText == "" {
+		errText = strings.TrimSpace(gjson.GetBytes(payload, "response.error.message").String())
+	}
+	if errText == "" {
+		errText = strings.TrimSpace(gjson.GetBytes(payload, "body.error.message").String())
+	}
+	if errText == "" {
 		errText = strings.TrimSpace(gjson.GetBytes(payload, "message").String())
+	}
+	if errText == "" {
+		errText = strings.TrimSpace(gjson.GetBytes(payload, "error.code").String())
+	}
+	if errText == "" {
+		errText = strings.TrimSpace(gjson.GetBytes(payload, "response.error.code").String())
+	}
+	if errText == "" {
+		errText = strings.TrimSpace(gjson.GetBytes(payload, "body.error.code").String())
+	}
+	errPayload := responsesWebsocketStructuredErrorPayload(payload)
+	if !hasExplicitStatus {
+		status = responsesWebsocketInferredErrorStatus(payload, errText, errPayload)
+	}
+	if status <= 0 {
+		status = http.StatusInternalServerError
 	}
 	if errText == "" {
 		errText = strings.TrimSpace(string(payload))
@@ -1735,7 +2201,90 @@ func responsesWebsocketErrorMessageFromPayload(payload []byte) *interfaces.Error
 	if errText == "" {
 		errText = http.StatusText(status)
 	}
-	return &interfaces.ErrorMessage{StatusCode: status, Error: fmt.Errorf("%s", errText)}
+	if errPayload == "" {
+		errPayload = errText
+	}
+	return &interfaces.ErrorMessage{StatusCode: status, Error: fmt.Errorf("%s", errPayload)}
+}
+
+func responsesWebsocketExplicitErrorStatus(payload []byte) (int, bool) {
+	for _, path := range []string{
+		"status",
+		"status_code",
+		"response.status_code",
+		"response.error.status",
+		"response.error.status_code",
+		"error.status",
+		"error.status_code",
+		"body.error.status",
+		"body.error.status_code",
+	} {
+		status := int(gjson.GetBytes(payload, path).Int())
+		if status > 0 {
+			return status, true
+		}
+	}
+	return 0, false
+}
+
+func responsesWebsocketInferredErrorStatus(payload []byte, errText string, errPayload string) int {
+	if responsesWebsocketErrorTextIndicatesPreviousResponseNotFound(errText) ||
+		responsesWebsocketErrorIndicatesPreviousResponseNotFound(errPayload) {
+		return http.StatusBadRequest
+	}
+
+	errType := responsesWebsocketLowerPayloadString(payload, "error.type", "response.error.type", "body.error.type")
+	errCode := responsesWebsocketLowerPayloadString(payload, "error.code", "response.error.code", "body.error.code", "code")
+	switch {
+	case errType == "usage_limit_reached" ||
+		errType == "insufficient_quota" ||
+		errType == "rate_limit_error" ||
+		errCode == "insufficient_quota" ||
+		errCode == "rate_limit_exceeded" ||
+		responsesWebsocketErrorTextIndicatesModelCapacity(errText):
+		return http.StatusTooManyRequests
+	case errType == "authentication_error":
+		return http.StatusUnauthorized
+	case errType == "permission_error":
+		return http.StatusForbidden
+	case errType == "invalid_request_error" ||
+		errCode == "invalid_request_error" ||
+		errCode == "previous_response_not_found" ||
+		errCode == "context_length_exceeded" ||
+		errCode == "context_too_large":
+		return http.StatusBadRequest
+	default:
+		return 0
+	}
+}
+
+func responsesWebsocketLowerPayloadString(payload []byte, paths ...string) string {
+	for _, path := range paths {
+		value := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, path).String()))
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func responsesWebsocketErrorTextIndicatesModelCapacity(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	return strings.Contains(lower, "selected model is at capacity") ||
+		strings.Contains(lower, "model is at capacity. please try a different model")
+}
+
+func responsesWebsocketStructuredErrorPayload(payload []byte) string {
+	payload = bytes.TrimSpace(payload)
+	if len(payload) == 0 || !json.Valid(payload) {
+		return ""
+	}
+	for _, path := range []string{"error", "body.error", "response.error", "code"} {
+		if gjson.GetBytes(payload, path).Exists() {
+			return string(payload)
+		}
+	}
+	return ""
 }
 
 func setWebsocketTimelineBody(c *gin.Context, body string) {
@@ -1778,6 +2327,7 @@ func startResponsesWebsocketHeartbeatWithInterval(conn *websocket.Conn, done <-c
 			case <-ticker.C:
 				if errWrite := conn.WriteControl(websocket.PingMessage, []byte("ping"), time.Time{}); errWrite != nil {
 					log.Debugf("responses websocket: heartbeat ping failed id=%s error=%v", strings.TrimSpace(sessionID), errWrite)
+					_ = conn.Close()
 					return
 				}
 			}

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -14,9 +15,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
+	appconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	requestlogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	codexexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -34,10 +37,50 @@ type websocketProviderCaptureExecutor struct {
 	websocketCaptureExecutor
 }
 
+func readResponsesWebsocketTestMessage(t *testing.T, conn *websocket.Conn) (int, []byte, error) {
+	t.Helper()
+	if conn == nil {
+		t.Fatal("websocket connection is nil")
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set websocket read deadline: %v", err)
+	}
+	msgType, payload, err := conn.ReadMessage()
+	_ = conn.SetReadDeadline(time.Time{})
+	return msgType, payload, err
+}
+
+func receiveResponsesWebsocketTestError(t *testing.T, ch <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server result")
+		return nil
+	}
+}
+
+func receiveResponsesWebsocketTestBytes(t *testing.T, ch <-chan []byte) []byte {
+	t.Helper()
+	select {
+	case payload := <-ch:
+		return payload
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket output")
+		return nil
+	}
+}
+
 type websocketCompactionCaptureExecutor struct {
-	mu             sync.Mutex
-	streamPayloads [][]byte
-	compactPayload []byte
+	mu              sync.Mutex
+	streamPayloads  [][]byte
+	compactPayload  []byte
+	dropCalls       int
+	dropReasons     []string
+	processedIDs    []string
+	processedCh     chan string
+	failStreamCalls map[int]error
 }
 
 type orderedWebsocketSelector struct {
@@ -98,11 +141,15 @@ type websocketDirectCaptureExecutor struct {
 }
 
 type websocketGenerationReplayExecutor struct {
-	mu                         sync.Mutex
-	generation                 uint64
-	streamCalls                int
-	failPreviousResponseOnCall int
-	payloads                   [][]byte
+	mu                             sync.Mutex
+	generation                     uint64
+	streamCalls                    int
+	failPreviousResponseOnCall     int
+	failPreviousAfterPayloadOnCall int
+	requireReplayOnCall            int
+	requireReplayCalls             map[int]bool
+	streamCallCh                   chan int
+	payloads                       [][]byte
 }
 
 type websocketPinnedFailoverStatusError struct {
@@ -113,6 +160,16 @@ type websocketPinnedFailoverStatusError struct {
 func (e websocketPinnedFailoverStatusError) Error() string { return e.msg }
 
 func (e websocketPinnedFailoverStatusError) StatusCode() int { return e.status }
+
+type websocketReplayRequiredStatusError struct {
+	msg string
+}
+
+func (e websocketReplayRequiredStatusError) Error() string { return e.msg }
+
+func (e websocketReplayRequiredStatusError) StatusCode() int { return http.StatusBadRequest }
+
+func (e websocketReplayRequiredStatusError) CodexWebsocketReplayRequired() bool { return true }
 
 func (e *websocketGenerationReplayExecutor) Identifier() string { return "codex" }
 
@@ -138,10 +195,33 @@ func (e *websocketGenerationReplayExecutor) ExecuteStream(_ context.Context, _ *
 	call := e.streamCalls
 	e.payloads = append(e.payloads, bytes.Clone(req.Payload))
 	failPreviousResponse := e.failPreviousResponseOnCall == call
+	failPreviousAfterPayload := e.failPreviousAfterPayloadOnCall == call
+	requireReplay := e.requireReplayOnCall == call || e.requireReplayCalls[call]
 	e.mu.Unlock()
+	if e.streamCallCh != nil {
+		select {
+		case e.streamCallCh <- call:
+		default:
+		}
+	}
 
-	chunks := make(chan coreexecutor.StreamChunk, 1)
+	if requireReplay {
+		return nil, websocketReplayRequiredStatusError{
+			msg: "codex websocket upstream reset requires transcript replay: invalid_request_error: send_error",
+		}
+	}
+
+	chunks := make(chan coreexecutor.StreamChunk, 2)
 	if failPreviousResponse {
+		chunks <- coreexecutor.StreamChunk{Err: websocketPinnedFailoverStatusError{
+			status: http.StatusBadRequest,
+			msg:    `{"error":{"message":"previous response with id 'resp-1' not found","type":"invalid_request_error","code":"previous_response_not_found"}}`,
+		}}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	if failPreviousAfterPayload {
+		chunks <- coreexecutor.StreamChunk{Payload: []byte(`{"type":"response.output_item.done","item":{"id":"out-partial","type":"message","role":"assistant","content":[{"type":"output_text","text":"partial"}]},"output_index":0}`)}
 		chunks <- coreexecutor.StreamChunk{Err: websocketPinnedFailoverStatusError{
 			status: http.StatusBadRequest,
 			msg:    `{"error":{"message":"previous response with id 'resp-1' not found","type":"invalid_request_error","code":"previous_response_not_found"}}`,
@@ -517,7 +597,7 @@ func (e *websocketCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, 
 	return nil, errors.New("not implemented")
 }
 
-func (e *websocketCompactionCaptureExecutor) Identifier() string { return "test-provider" }
+func (e *websocketCompactionCaptureExecutor) Identifier() string { return "codex" }
 
 func (e *websocketCompactionCaptureExecutor) Execute(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
 	e.mu.Lock()
@@ -533,7 +613,15 @@ func (e *websocketCompactionCaptureExecutor) ExecuteStream(_ context.Context, _ 
 	e.mu.Lock()
 	callIndex := len(e.streamPayloads)
 	e.streamPayloads = append(e.streamPayloads, bytes.Clone(req.Payload))
+	errFail := e.failStreamCalls[callIndex]
 	e.mu.Unlock()
+
+	if errFail != nil {
+		chunks := make(chan coreexecutor.StreamChunk, 1)
+		chunks <- coreexecutor.StreamChunk{Err: errFail}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
 
 	var payload []byte
 	switch callIndex {
@@ -561,6 +649,24 @@ func (e *websocketCompactionCaptureExecutor) CountTokens(context.Context, *corea
 
 func (e *websocketCompactionCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
 	return nil, errors.New("not implemented")
+}
+
+func (e *websocketCompactionCaptureExecutor) DropUpstreamSession(_ string, reason string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.dropCalls++
+	e.dropReasons = append(e.dropReasons, strings.TrimSpace(reason))
+}
+
+func (e *websocketCompactionCaptureExecutor) SendResponseProcessed(_ string, responseID string) error {
+	e.mu.Lock()
+	e.processedIDs = append(e.processedIDs, responseID)
+	processedCh := e.processedCh
+	e.mu.Unlock()
+	if processedCh != nil {
+		processedCh <- responseID
+	}
+	return nil
 }
 
 func TestNormalizeResponsesWebsocketRequestCreate(t *testing.T) {
@@ -626,7 +732,7 @@ func TestNormalizeResponsesWebsocketRequestWithPreviousResponseIDIncremental(t *
 	]`)
 	raw := []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"function_call_output","call_id":"call-1","id":"tool-out-1"}]}`)
 
-	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, true, false)
+	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, true, false, false)
 	if errMsg != nil {
 		t.Fatalf("unexpected error: %v", errMsg.Error)
 	}
@@ -648,6 +754,39 @@ func TestNormalizeResponsesWebsocketRequestWithPreviousResponseIDIncremental(t *
 	}
 	if gjson.GetBytes(normalized, "instructions").String() != "be helpful" {
 		t.Fatalf("unexpected instructions: %s", gjson.GetBytes(normalized, "instructions").String())
+	}
+	if gjson.GetBytes(next, "previous_response_id").Exists() {
+		t.Fatalf("next request snapshot must not include previous_response_id: %s", next)
+	}
+	nextInput := gjson.GetBytes(next, "input").Array()
+	if len(nextInput) != 4 {
+		t.Fatalf("next request snapshot input len = %d, want 4: %s", len(nextInput), next)
+	}
+	for _, id := range []string{"msg-1", "fc-1", "assistant-1", "tool-out-1"} {
+		if !strings.Contains(gjson.GetBytes(next, "input").Raw, fmt.Sprintf(`"id":"%s"`, id)) {
+			t.Fatalf("next request snapshot missing %s: %s", id, next)
+		}
+	}
+	if gjson.GetBytes(next, "model").String() != "test-model" {
+		t.Fatalf("next request snapshot model = %s, want test-model", gjson.GetBytes(next, "model").String())
+	}
+	if gjson.GetBytes(next, "instructions").String() != "be helpful" {
+		t.Fatalf("next request snapshot instructions = %s, want be helpful", gjson.GetBytes(next, "instructions").String())
+	}
+}
+
+func TestNormalizeResponsesWebsocketInitialForcedReplayPreservesPreviousResponseID(t *testing.T) {
+	raw := []byte(`{"type":"response.create","model":"test-model","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-1"}]}`)
+
+	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithReplayMode(raw, nil, nil, "", nil, false, true, false, true)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	if got := gjson.GetBytes(normalized, "previous_response_id").String(); got != "resp-1" {
+		t.Fatalf("previous_response_id = %q, want resp-1", got)
+	}
+	if gjson.GetBytes(normalized, "type").Exists() {
+		t.Fatalf("normalized request must not include type field: %s", normalized)
 	}
 	if !bytes.Equal(next, normalized) {
 		t.Fatalf("next request snapshot should match normalized request")
@@ -682,8 +821,66 @@ func TestNormalizeResponsesWebsocketRequestInjectsPreviousResponseIDForIncrement
 	if gjson.GetBytes(normalized, "instructions").String() != "be helpful" {
 		t.Fatalf("unexpected instructions: %s", gjson.GetBytes(normalized, "instructions").String())
 	}
+	if gjson.GetBytes(next, "previous_response_id").Exists() {
+		t.Fatalf("next request snapshot must not include previous_response_id: %s", next)
+	}
+	nextInput := gjson.GetBytes(next, "input").Array()
+	if len(nextInput) != 4 {
+		t.Fatalf("next request snapshot input len = %d, want 4: %s", len(nextInput), next)
+	}
+	for _, id := range []string{"msg-1", "fc-1", "assistant-1", "tool-out-1"} {
+		if !strings.Contains(gjson.GetBytes(next, "input").Raw, fmt.Sprintf(`"id":"%s"`, id)) {
+			t.Fatalf("next request snapshot missing %s: %s", id, next)
+		}
+	}
+}
+
+func TestNormalizeResponsesWebsocketRequestTreatsCodexFullCreateAsReplacement(t *testing.T) {
+	lastRequest := []byte(`{"model":"test-model","stream":true,"input":[{"type":"message","role":"user","id":"msg-1","content":"original prompt"}]}`)
+	lastResponseOutput := []byte(`[
+		{"type":"message","role":"assistant","id":"assistant-1","content":"original answer"}
+	]`)
+	raw := []byte(`{
+		"type":"response.create",
+		"model":"test-model",
+		"input":[{"type":"message","role":"user","id":"msg-edited","content":"edited prompt"}],
+		"tools":[],
+		"tool_choice":"auto",
+		"parallel_tool_calls":true,
+		"store":false,
+		"stream":true,
+		"include":[],
+		"client_metadata":{
+			"x-codex-installation-id":"install-1",
+			"x-codex-window-id":"thread-1:0"
+		}
+	}`)
+
+	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithLastResponseID(raw, lastRequest, lastResponseOutput, "resp-1", true, false)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	if gjson.GetBytes(normalized, "previous_response_id").Exists() {
+		t.Fatalf("full Codex create must not reuse previous_response_id: %s", normalized)
+	}
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 1 || input[0].Get("id").String() != "msg-edited" {
+		t.Fatalf("full Codex create must replace stale transcript: %s", normalized)
+	}
 	if !bytes.Equal(next, normalized) {
-		t.Fatalf("next request snapshot should match normalized request")
+		t.Fatalf("next request snapshot should match replacement request")
+	}
+
+	replayed, _, errMsg := normalizeResponsesWebsocketRequestWithReplayMode(raw, lastRequest, lastResponseOutput, "resp-1", nil, true, false, false, true)
+	if errMsg != nil {
+		t.Fatalf("unexpected forced replay error: %v", errMsg.Error)
+	}
+	if gjson.GetBytes(replayed, "previous_response_id").Exists() {
+		t.Fatalf("forced replay full Codex create must not reuse previous_response_id: %s", replayed)
+	}
+	replayedInput := gjson.GetBytes(replayed, "input").Array()
+	if len(replayedInput) != 1 || replayedInput[0].Get("id").String() != "msg-edited" {
+		t.Fatalf("forced replay full Codex create must still replace stale transcript: %s", replayed)
 	}
 }
 
@@ -739,7 +936,7 @@ func TestNormalizeResponsesWebsocketRequestWithPreviousResponseIDMergedWhenIncre
 	]`)
 	raw := []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"function_call_output","call_id":"call-1","id":"tool-out-1"}]}`)
 
-	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, false)
+	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, false, false)
 	if errMsg != nil {
 		t.Fatalf("unexpected error: %v", errMsg.Error)
 	}
@@ -758,6 +955,148 @@ func TestNormalizeResponsesWebsocketRequestWithPreviousResponseIDMergedWhenIncre
 	}
 	if !bytes.Equal(next, normalized) {
 		t.Fatalf("next request snapshot should match normalized request")
+	}
+}
+
+func TestNormalizeInitialResponseCreateDropsPreviousResponseIDForTranscriptReplacement(t *testing.T) {
+	tests := []struct {
+		name                        string
+		raw                         []byte
+		allowCompactionReplayBypass bool
+		forceTranscriptReplacement  bool
+		wantInputLen                int
+		wantNoCompactionItems       bool
+	}{
+		{
+			name:                        "compact marker",
+			allowCompactionReplayBypass: true,
+			wantInputLen:                2,
+			raw: []byte(`{"type":"response.create","model":"test-model","previous_response_id":"resp-old","input":[
+				{"type":"message","role":"user","id":"msg-1","content":"compacted question"},
+				{"type":"context_compaction","encrypted_content":"summary"}
+			]}`),
+		},
+		{
+			name:                        "forced compact replay",
+			allowCompactionReplayBypass: true,
+			forceTranscriptReplacement:  true,
+			wantInputLen:                2,
+			raw: []byte(`{"type":"response.create","model":"test-model","previous_response_id":"resp-old","input":[
+				{"type":"message","role":"user","id":"msg-1","content":"compacted summary"},
+				{"type":"message","role":"user","id":"msg-2","content":"new question"}
+			]}`),
+		},
+		{
+			name:                  "unsupported compact marker",
+			wantInputLen:          1,
+			wantNoCompactionItems: true,
+			raw: []byte(`{"type":"response.create","model":"test-model","previous_response_id":"resp-old","input":[
+				{"type":"message","role":"user","id":"msg-1","content":"compacted question"},
+				{"type":"context_compaction","encrypted_content":"summary"}
+			]}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(tt.raw, nil, nil, true, tt.allowCompactionReplayBypass, tt.forceTranscriptReplacement)
+			if errMsg != nil {
+				t.Fatalf("unexpected error: %v", errMsg.Error)
+			}
+			if gjson.GetBytes(normalized, "previous_response_id").Exists() {
+				t.Fatalf("previous_response_id must be removed for initial transcript replacement: %s", normalized)
+			}
+			if !bytes.Equal(next, normalized) {
+				t.Fatalf("next request snapshot should match normalized request")
+			}
+			if gjson.GetBytes(normalized, "type").Exists() {
+				t.Fatalf("normalized request must not include type field")
+			}
+			if !gjson.GetBytes(normalized, "stream").Bool() {
+				t.Fatalf("normalized request must enable stream: %s", normalized)
+			}
+			input := gjson.GetBytes(normalized, "input").Array()
+			if len(input) != tt.wantInputLen {
+				t.Fatalf("normalized input len = %d, want %d: %s", len(input), tt.wantInputLen, normalized)
+			}
+			if tt.wantNoCompactionItems {
+				for _, item := range input {
+					if isResponsesWebsocketCompactionItemType(item.Get("type").String()) {
+						t.Fatalf("compaction item must be stripped for unsupported initial replacement: %s", normalized)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeSubsequentRequestPlainFullCreateSkipsStaleMerge(t *testing.T) {
+	lastRequest := []byte(`{"model":"test-model","stream":true,"input":[
+		{"type":"message","role":"user","id":"msg-1","content":"first question"}
+	]}`)
+	lastResponseOutput := []byte(`[
+		{"type":"message","role":"assistant","id":"out-1","content":"first answer"}
+	]`)
+	raw := []byte(`{"type":"response.create","model":"test-model","input":[
+		{"type":"message","role":"user","id":"msg-1","content":"first question"},
+		{"type":"message","role":"user","id":"msg-2","content":"second question"}
+	]}`)
+
+	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, true, true, false)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	if gjson.GetBytes(normalized, "previous_response_id").Exists() {
+		t.Fatalf("full create replacement must not include previous_response_id: %s", normalized)
+	}
+	if !bytes.Equal(next, normalized) {
+		t.Fatalf("next request snapshot should match normalized replacement")
+	}
+	inputRaw := gjson.GetBytes(normalized, "input").Raw
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 2 {
+		t.Fatalf("input len = %d, want 2 full-create replacement items: %s", len(input), normalized)
+	}
+	for _, id := range []string{"msg-1", "msg-2"} {
+		if !strings.Contains(inputRaw, fmt.Sprintf(`"id":"%s"`, id)) {
+			t.Fatalf("normalized full create missing %s: %s", id, normalized)
+		}
+	}
+	if strings.Contains(inputRaw, `"id":"out-1"`) {
+		t.Fatalf("stale last response output was merged into full create replacement: %s", normalized)
+	}
+}
+
+func TestNormalizeSubsequentRequestCompactionTriggerCleansSnapshot(t *testing.T) {
+	lastRequest := []byte(`{"model":"test-model","stream":true,"input":[
+		{"type":"message","role":"user","id":"msg-old","content":"old prompt"}
+	]}`)
+	lastResponseOutput := []byte(`[
+		{"type":"message","role":"assistant","id":"out-old","content":"old answer"}
+	]`)
+	raw := []byte(`{"type":"response.create","input":[
+		{"type":"message","role":"user","id":"msg-1","content":"compacted prompt"},
+		{"type":"compaction_trigger"},
+		{"type":"context_compaction","encrypted_content":"summary"}
+	]}`)
+
+	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, false, false)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	normalizedInput := gjson.GetBytes(normalized, "input").Array()
+	if len(normalizedInput) != 2 {
+		t.Fatalf("normalized input len = %d, want message + compaction_trigger: %s", len(normalizedInput), normalized)
+	}
+	if normalizedInput[1].Get("type").String() != "compaction_trigger" {
+		t.Fatalf("normalized request must preserve compaction_trigger for executor routing: %s", normalized)
+	}
+	if strings.Contains(gjson.GetBytes(next, "input").Raw, "compaction_trigger") {
+		t.Fatalf("next request snapshot must not retain compaction_trigger: %s", next)
+	}
+	nextInput := gjson.GetBytes(next, "input").Array()
+	if len(nextInput) != 1 || nextInput[0].Get("id").String() != "msg-1" {
+		t.Fatalf("next request snapshot should retain only compacted transcript items: %s", next)
 	}
 }
 
@@ -828,7 +1167,7 @@ func TestWebsocketJSONPayloadsFromPlainJSONChunk(t *testing.T) {
 func TestResponseCompletedOutputFromPayload(t *testing.T) {
 	payload := []byte(`{"type":"response.completed","response":{"id":"resp-1","output":[{"type":"message","id":"out-1"}]}}`)
 
-	output := responseCompletedOutputFromPayload(payload)
+	output := responseCompletedOutputFromPayload(payload, nil, nil)
 	items := gjson.ParseBytes(output).Array()
 	if len(items) != 1 {
 		t.Fatalf("output len = %d, want 1", len(items))
@@ -1245,7 +1584,7 @@ func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 		close(errCh)
 
 		timelineLog := newInMemoryWebsocketTimelineLog()
-		completedOutput, completedResponseID, pendingToolCallIDs, errMsg, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+		completedOutput, completedResponseID, pendingToolCallIDs, errMsg, _, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
 			ctx,
 			conn,
 			func(...interface{}) {},
@@ -1295,7 +1634,7 @@ func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 		}
 	}()
 
-	_, payload, errReadMessage := conn.ReadMessage()
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read websocket message: %v", errReadMessage)
 	}
@@ -1306,7 +1645,7 @@ func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 		t.Fatalf("payload unexpectedly rewrote completed event: %s", payload)
 	}
 
-	if errServer := <-serverErrCh; errServer != nil {
+	if errServer := receiveResponsesWebsocketTestError(t, serverErrCh); errServer != nil {
 		t.Fatalf("server error: %v", errServer)
 	}
 }
@@ -1338,7 +1677,7 @@ func TestForwardResponsesWebsocketTreatsResponseDoneAsTerminalWithoutRewriting(t
 		close(errCh)
 
 		timelineLog := newInMemoryWebsocketTimelineLog()
-		completedOutput, completedResponseID, pendingToolCallIDs, errMsg, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+		completedOutput, completedResponseID, pendingToolCallIDs, errMsg, _, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
 			ctx,
 			conn,
 			func(...interface{}) {},
@@ -1423,7 +1762,7 @@ func TestForwardResponsesWebsocketTreatsErrorPayloadAsTerminal(t *testing.T) {
 		close(data)
 		close(errCh)
 
-		_, _, _, errMsg, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+		_, _, _, errMsg, _, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
 			ctx,
 			conn,
 			func(...interface{}) {},
@@ -1515,7 +1854,7 @@ func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing
 			return
 		}
 
-		_, _, _, _, err = (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+		_, _, _, _, _, err = (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
 			ctx,
 			conn,
 			func(...interface{}) {},
@@ -1550,7 +1889,7 @@ func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing
 		_ = conn.Close()
 	}()
 
-	if errServer := <-serverErrCh; errServer != nil {
+	if errServer := receiveResponsesWebsocketTestError(t, serverErrCh); errServer != nil {
 		t.Fatalf("server error: %v", errServer)
 	}
 }
@@ -1558,6 +1897,7 @@ func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing
 func TestForwardResponsesWebsocketDoesNotSuppressPreviousResponseErrorAfterPayload(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
+	h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
@@ -1578,17 +1918,18 @@ func TestForwardResponsesWebsocketDoesNotSuppressPreviousResponseErrorAfterPaylo
 		data := make(chan []byte)
 		errCh := make(chan *interfaces.ErrorMessage, 1)
 		go func() {
-			data <- []byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n")
+			data <- []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"out-partial\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"partial\"}]},\"output_index\":0}\n\n")
 			errCh <- &interfaces.ErrorMessage{
 				StatusCode: http.StatusBadRequest,
 				Error: websocketPinnedFailoverStatusError{
 					status: http.StatusBadRequest,
 					msg:    `{"error":{"message":"previous response with id 'resp-1' not found","type":"invalid_request_error","code":"previous_response_not_found"}}`,
 				},
+				Addon: http.Header{"x-request-id": []string{"req-previous-response"}},
 			}
 		}()
 
-		_, _, _, errMsg, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+		_, _, _, errMsg, _, err := h.forwardResponsesWebsocket(
 			ctx,
 			conn,
 			func(...interface{}) {},
@@ -1619,27 +1960,597 @@ func TestForwardResponsesWebsocketDoesNotSuppressPreviousResponseErrorAfterPaylo
 		_ = conn.Close()
 	}()
 
-	_, payload, errReadMessage := conn.ReadMessage()
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
-		t.Fatalf("read created websocket message: %v", errReadMessage)
+		t.Fatalf("read output item websocket message: %v", errReadMessage)
 	}
-	if got := gjson.GetBytes(payload, "type").String(); got != "response.created" {
-		t.Fatalf("first payload type = %s, want response.created: %s", got, payload)
+	if got := gjson.GetBytes(payload, "type").String(); got != "response.output_item.done" {
+		t.Fatalf("first payload type = %s, want response.output_item.done: %s", got, payload)
 	}
 
-	_, payload, errReadMessage = conn.ReadMessage()
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read error websocket message: %v", errReadMessage)
 	}
 	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeError {
 		t.Fatalf("second payload type = %s, want %s: %s", got, wsEventTypeError, payload)
 	}
+	if got := gjson.GetBytes(payload, "status").Int(); got != http.StatusBadRequest {
+		t.Fatalf("error status = %d, want %d: %s", got, http.StatusBadRequest, payload)
+	}
+	if got := gjson.GetBytes(payload, "error.code").String(); got != "previous_response_not_found" {
+		t.Fatalf("error code = %s, want previous_response_not_found: %s", got, payload)
+	}
+	if got := gjson.GetBytes(payload, "headers.x-request-id").String(); got != "req-previous-response" {
+		t.Fatalf("error header x-request-id = %s, want req-previous-response: %s", got, payload)
+	}
 	if !strings.Contains(string(payload), "previous_response_not_found") {
 		t.Fatalf("error payload missing previous_response_not_found: %s", payload)
 	}
 
-	if errServer := <-serverErrCh; errServer != nil {
+	if errServer := receiveResponsesWebsocketTestError(t, serverErrCh); errServer != nil {
 		t.Fatalf("server error: %v", errServer)
+	}
+}
+
+func TestForwardResponsesWebsocketPrioritizesPendingErrorWhenDataCloses(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte)
+		errCh := make(chan *interfaces.ErrorMessage, 1)
+		errCh <- &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadRequest,
+			Error: websocketPinnedFailoverStatusError{
+				status: http.StatusBadRequest,
+				msg:    `{"error":{"message":"previous response with id 'resp-1' not found","type":"invalid_request_error","code":"previous_response_not_found"}}`,
+			},
+		}
+		close(errCh)
+		close(data)
+
+		_, _, _, errMsg, replayAllowed, err := h.forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			newInMemoryWebsocketTimelineLog(),
+			"session-1",
+			true,
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		if errMsg == nil {
+			serverErrCh <- errors.New("expected pending previous_response_not_found error")
+			return
+		}
+		if !replayAllowed {
+			serverErrCh <- errors.New("expected pending error to allow transcript replay")
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if errServer := receiveResponsesWebsocketTestError(t, serverErrCh); errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
+func TestForwardResponsesWebsocketReplaysConnectionLimitBeforeOutput(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte)
+		errCh := make(chan *interfaces.ErrorMessage, 1)
+		errCh <- &interfaces.ErrorMessage{
+			StatusCode: http.StatusTooManyRequests,
+			Error:      errors.New(`{"error":{"code":"websocket_connection_limit_reached","message":"too many websockets"}}`),
+		}
+		close(errCh)
+		close(data)
+
+		_, _, _, errMsg, replayAllowed, err := h.forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			newInMemoryWebsocketTimelineLog(),
+			"session-1",
+			true,
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		if errMsg == nil {
+			serverErrCh <- errors.New("expected websocket connection limit error")
+			return
+		}
+		if !replayAllowed {
+			serverErrCh <- errors.New("expected websocket connection limit to allow transcript replay")
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if errServer := receiveResponsesWebsocketTestError(t, serverErrCh); errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
+func TestForwardResponsesWebsocketDoesNotWaitForFinalErrorAfterDataCloses(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte)
+		errCh := make(chan *interfaces.ErrorMessage)
+		close(data)
+
+		_, _, _, errMsg, replayAllowed, err := h.forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			newInMemoryWebsocketTimelineLog(),
+			"session-1",
+			true,
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		if errMsg == nil || errMsg.Error == nil || !strings.Contains(errMsg.Error.Error(), "stream closed before response.completed") {
+			serverErrCh <- fmt.Errorf("expected stream closed error, got %v", errMsg)
+			return
+		}
+		if replayAllowed {
+			serverErrCh <- errors.New("stream closed error must not allow transcript replay")
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read stream-closed websocket error: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeError {
+		t.Fatalf("payload type = %s, want %s: %s", got, wsEventTypeError, payload)
+	}
+	if !strings.Contains(string(payload), "stream closed before response.completed") {
+		t.Fatalf("payload missing stream closed error: %s", payload)
+	}
+
+	if errServer := receiveResponsesWebsocketTestError(t, serverErrCh); errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
+func TestForwardResponsesWebsocketIgnoresErrorAfterCompleted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte)
+		errCh := make(chan *interfaces.ErrorMessage, 1)
+		go func() {
+			data <- []byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"output\":[{\"type\":\"message\",\"id\":\"out-1\"}]}}\n\n")
+			errCh <- &interfaces.ErrorMessage{
+				StatusCode: http.StatusBadRequest,
+				Error:      errors.New("late upstream error"),
+			}
+			close(data)
+			close(errCh)
+		}()
+
+		completedOutput, _, _, errMsg, replayAllowed, err := h.forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			newInMemoryWebsocketTimelineLog(),
+			"session-1",
+			true,
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		if errMsg != nil {
+			serverErrCh <- fmt.Errorf("late error after completed was not ignored: %v", errMsg)
+			return
+		}
+		if replayAllowed {
+			serverErrCh <- errors.New("completed response must not allow transcript replay")
+			return
+		}
+		if got := gjson.GetBytes(completedOutput, "0.id").String(); got != "out-1" {
+			serverErrCh <- fmt.Errorf("completed output id = %s, want out-1", got)
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read completed websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+	_, _, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage == nil {
+		t.Fatal("expected websocket close after completed, got extra message")
+	}
+
+	if errServer := receiveResponsesWebsocketTestError(t, serverErrCh); errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
+func TestForwardResponsesWebsocketDoesNotReplayAfterCreatedEvent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte)
+		errCh := make(chan *interfaces.ErrorMessage, 1)
+		go func() {
+			data <- []byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n")
+			errCh <- &interfaces.ErrorMessage{
+				StatusCode: http.StatusBadRequest,
+				Error: websocketPinnedFailoverStatusError{
+					status: http.StatusBadRequest,
+					msg:    `{"error":{"message":"previous response with id 'resp-1' not found","type":"invalid_request_error","code":"previous_response_not_found"}}`,
+				},
+			}
+			close(data)
+			close(errCh)
+		}()
+
+		_, _, _, errMsg, replayAllowed, err := h.forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			newInMemoryWebsocketTimelineLog(),
+			"session-1",
+			true,
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		if errMsg == nil || !shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
+			serverErrCh <- fmt.Errorf("expected previous_response_not_found replay error, got %v", errMsg)
+			return
+		}
+		if replayAllowed {
+			serverErrCh <- errors.New("forwarded response.created must preclude transcript replay")
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read created websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != "response.created" {
+		t.Fatalf("payload type = %s, want response.created: %s", got, payload)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read terminal websocket error: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeError {
+		t.Fatalf("payload type = %s, want %s: %s", got, wsEventTypeError, payload)
+	}
+
+	if errServer := receiveResponsesWebsocketTestError(t, serverErrCh); errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
+func TestForwardResponsesWebsocketTreatsResponseFailedAsTerminal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte, 1)
+		errCh := make(chan *interfaces.ErrorMessage)
+		data <- []byte(`data: {"type":"response.failed","response":{"id":"resp-1","status":"failed","error":{"code":"context_length_exceeded","message":"context too large"}}}` + "\n\n")
+		close(data)
+		close(errCh)
+
+		_, _, _, errMsg, replayAllowed, errForward := h.forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			newInMemoryWebsocketTimelineLog(),
+			"session-1",
+			true,
+		)
+		if errForward != nil {
+			serverErrCh <- errForward
+			return
+		}
+		if replayAllowed {
+			serverErrCh <- errors.New("non-replayable response.failed must not allow transcript replay")
+			return
+		}
+		if errMsg == nil || errMsg.Error == nil || !strings.Contains(errMsg.Error.Error(), "context too large") {
+			serverErrCh <- fmt.Errorf("response.failed error = %v, want context too large", errMsg)
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read response.failed websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeFailed {
+		t.Fatalf("payload type = %s, want %s: %s", got, wsEventTypeFailed, payload)
+	}
+
+	if errServer := receiveResponsesWebsocketTestError(t, serverErrCh); errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
+func TestForwardResponsesWebsocketReplaysResponseFailedBeforeOutput(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte, 1)
+		errCh := make(chan *interfaces.ErrorMessage)
+		data <- []byte(`data: {"type":"response.failed","response":{"id":"resp-1","status":"failed","error":{"message":"No response found for previous_response_id resp-old"}}}` + "\n\n")
+		close(data)
+		close(errCh)
+
+		_, _, _, errMsg, replayAllowed, errForward := h.forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			newInMemoryWebsocketTimelineLog(),
+			"session-1",
+			true,
+		)
+		if errForward != nil {
+			serverErrCh <- errForward
+			return
+		}
+		if errMsg == nil || !replayAllowed {
+			serverErrCh <- fmt.Errorf("response.failed previous_response_id error should allow replay, err=%v replay=%t", errMsg, replayAllowed)
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if errServer := receiveResponsesWebsocketTestError(t, serverErrCh); errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
+func TestForwardResponsesWebsocketUsesOutputItemDoneWhenCompletedOutputEmpty(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
+	outputCh := make(chan []byte, 1)
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte, 4)
+		errCh := make(chan *interfaces.ErrorMessage)
+		data <- []byte(`data: {"type":"response.output_item.done","item":{"id":"rs-1","type":"reasoning","summary":[],"encrypted_content":"encrypted-reasoning"},"output_index":0}` + "\n\n")
+		data <- []byte(`data: {"type":"response.output_item.done","item":{"id":"fc-1","type":"function_call","call_id":"call-1","name":"lookup","arguments":"{\"q\":\"weather\"}","status":"completed"},"output_index":1}` + "\n\n")
+		data <- []byte(`data: {"type":"response.output_item.done","item":{"id":"msg-1","type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]},"output_index":2}` + "\n\n")
+		data <- []byte(`data: {"type":"response.completed","response":{"id":"resp-1","output":[]}}` + "\n\n")
+		close(data)
+		close(errCh)
+
+		completedOutput, _, _, _, _, err := h.forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			newInMemoryWebsocketTimelineLog(),
+			"session-1",
+			false,
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		outputCh <- completedOutput
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	for i := 0; i < 4; i++ {
+		if _, _, errRead := readResponsesWebsocketTestMessage(t, conn); errRead != nil {
+			t.Fatalf("read websocket message %d: %v", i, errRead)
+		}
+	}
+
+	if errServer := receiveResponsesWebsocketTestError(t, serverErrCh); errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+	completedOutput := receiveResponsesWebsocketTestBytes(t, outputCh)
+	if got := gjson.GetBytes(completedOutput, "0.encrypted_content").String(); got != "encrypted-reasoning" {
+		t.Fatalf("completed reasoning encrypted_content = %q, want encrypted-reasoning; output=%s", got, completedOutput)
+	}
+	if got := gjson.GetBytes(completedOutput, "1.call_id").String(); got != "call-1" {
+		t.Fatalf("completed function call_id = %q, want call-1; output=%s", got, completedOutput)
+	}
+	if got := gjson.GetBytes(completedOutput, "2.content.0.text").String(); got != "ok" {
+		t.Fatalf("completed output text = %q, want ok; output=%s", got, completedOutput)
 	}
 }
 
@@ -1802,7 +2713,7 @@ func TestResponsesWebsocketHeartbeatSendsPing(t *testing.T) {
 	<-readDone
 }
 
-func TestResponsesWebsocketHeartbeatDoesNotCloseOnMissingPong(t *testing.T) {
+func TestResponsesWebsocketHeartbeatDoesNotCloseWithoutPong(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	done := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1812,8 +2723,7 @@ func TestResponsesWebsocketHeartbeatDoesNotCloseOnMissingPong(t *testing.T) {
 			return
 		}
 		defer func() { _ = conn.Close() }()
-		setWaiting := startResponsesWebsocketHeartbeatWithInterval(conn, done, "test-heartbeat-timeout", 10*time.Millisecond)
-		setWaiting(true)
+		startResponsesWebsocketHeartbeatWithInterval(conn, done, "test-heartbeat-no-pong", 10*time.Millisecond)
 		<-done
 	}))
 	defer server.Close()
@@ -1825,20 +2735,36 @@ func TestResponsesWebsocketHeartbeatDoesNotCloseOnMissingPong(t *testing.T) {
 		t.Fatalf("dial websocket: %v", err)
 	}
 	defer func() { _ = conn.Close() }()
+
+	pingCh := make(chan struct{}, 1)
 	conn.SetPingHandler(func(string) error {
+		select {
+		case pingCh <- struct{}{}:
+		default:
+		}
 		return nil
 	})
 
-	errCh := make(chan error, 1)
+	readErrCh := make(chan error, 1)
 	go func() {
-		_, _, errRead := conn.ReadMessage()
-		errCh <- errRead
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				readErrCh <- errRead
+				return
+			}
+		}
 	}()
 
 	select {
-	case errRead := <-errCh:
-		t.Fatalf("unexpected websocket close from missing pong: %v", errRead)
-	case <-time.After(100 * time.Millisecond):
+	case <-pingCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for heartbeat ping")
+	}
+
+	select {
+	case errRead := <-readErrCh:
+		t.Fatalf("downstream websocket closed without pong: %v", errRead)
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 
@@ -1885,7 +2811,7 @@ func TestResponsesWebsocketCodexWebsocketPassthroughPassesCompactedRequestWithou
 		t.Fatalf("read first websocket response: %v", errRead)
 	}
 
-	compactedRequest := []byte(`{"type":"response.create","input":[{"type":"compaction_summary","summary":"compressed history"},{"type":"message","role":"user","content":"after compaction"}]}`)
+	compactedRequest := []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"compaction_summary","summary":"compressed history"},{"type":"message","role":"user","content":"after compaction"}]}`)
 	if errWrite := conn.WriteMessage(websocket.TextMessage, compactedRequest); errWrite != nil {
 		t.Fatalf("write compacted websocket message: %v", errWrite)
 	}
@@ -1909,6 +2835,9 @@ func TestResponsesWebsocketCodexWebsocketPassthroughPassesCompactedRequestWithou
 	if got := gjson.GetBytes(payloads[1], "input").Raw; got != gjson.GetBytes(compactedRequest, "input").Raw {
 		t.Fatalf("compacted passthrough input = %s, want %s", got, gjson.GetBytes(compactedRequest, "input").Raw)
 	}
+	if gjson.GetBytes(payloads[1], "previous_response_id").Exists() {
+		t.Fatalf("compacted passthrough previous_response_id leaked: %s", payloads[1])
+	}
 	if got := gjson.GetBytes(payloads[1], "model").String(); got != "test-model" {
 		t.Fatalf("compacted passthrough model = %s, want test-model", got)
 	}
@@ -1918,6 +2847,84 @@ func TestResponsesWebsocketCodexWebsocketPassthroughPassesCompactedRequestWithou
 	authIDs := executor.AuthIDs()
 	if len(authIDs) != 2 || authIDs[0] != "auth-ws" || authIDs[1] != "auth-ws" {
 		t.Fatalf("passthrough auth IDs = %v, want [auth-ws auth-ws]", authIDs)
+	}
+}
+
+func TestResponsesWebsocketCodexWebsocketPassthroughDoesNotRepairRawRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketDirectCaptureExecutor{done: make(chan struct{})}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-ws-raw",
+		Provider:   "codex",
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	firstRequest := []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","role":"user","content":"first"}]}`)
+	if errWrite := conn.WriteMessage(websocket.TextMessage, firstRequest); errWrite != nil {
+		t.Fatalf("write first websocket message: %v", errWrite)
+	}
+	if _, _, errRead := conn.ReadMessage(); errRead != nil {
+		t.Fatalf("read first websocket response: %v", errRead)
+	}
+
+	rawRequest := []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"function_call_output","call_id":"missing-call","id":"orphan-output","output":"raw output"}]}`)
+	if errWrite := conn.WriteMessage(websocket.TextMessage, rawRequest); errWrite != nil {
+		t.Fatalf("write raw websocket message: %v", errWrite)
+	}
+	if _, _, errRead := conn.ReadMessage(); errRead != nil {
+		t.Fatalf("read raw websocket response: %v", errRead)
+	}
+
+	select {
+	case <-executor.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket passthrough")
+	}
+
+	payloads := executor.Payloads()
+	if len(payloads) != 2 {
+		t.Fatalf("passthrough payload count = %d, want 2", len(payloads))
+	}
+	secondPayload := payloads[1]
+	if got := gjson.GetBytes(secondPayload, "previous_response_id").String(); got != "resp-1" {
+		t.Fatalf("raw passthrough previous_response_id = %s, want resp-1: %s", got, secondPayload)
+	}
+	input := gjson.GetBytes(secondPayload, "input").Array()
+	if len(input) != 1 {
+		t.Fatalf("raw passthrough input len = %d, want 1: %s", len(input), secondPayload)
+	}
+	if got := input[0].Get("id").String(); got != "orphan-output" {
+		t.Fatalf("raw passthrough input id = %s, want orphan-output: %s", got, secondPayload)
+	}
+	authIDs := executor.AuthIDs()
+	if len(authIDs) != 2 || authIDs[0] != "auth-ws-raw" || authIDs[1] != "auth-ws-raw" {
+		t.Fatalf("passthrough auth IDs = %v, want [auth-ws-raw auth-ws-raw]", authIDs)
 	}
 }
 
@@ -2169,7 +3176,7 @@ func TestResponsesWebsocketPrewarmHandledLocallyForSSEUpstream(t *testing.T) {
 		t.Fatalf("write prewarm websocket message: %v", errWrite)
 	}
 
-	_, createdPayload, errReadMessage := conn.ReadMessage()
+	_, createdPayload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read prewarm created message: %v", errReadMessage)
 	}
@@ -2184,7 +3191,7 @@ func TestResponsesWebsocketPrewarmHandledLocallyForSSEUpstream(t *testing.T) {
 		t.Fatalf("stream calls after prewarm = %d, want 0", executor.streamCalls)
 	}
 
-	_, completedPayload, errReadMessage := conn.ReadMessage()
+	_, completedPayload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read prewarm completed message: %v", errReadMessage)
 	}
@@ -2204,7 +3211,7 @@ func TestResponsesWebsocketPrewarmHandledLocallyForSSEUpstream(t *testing.T) {
 		t.Fatalf("write follow-up websocket message: %v", errWrite)
 	}
 
-	_, upstreamPayload, errReadMessage := conn.ReadMessage()
+	_, upstreamPayload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read upstream completed message: %v", errReadMessage)
 	}
@@ -2302,6 +3309,107 @@ func TestResponsesWebsocketInjectsPreviousResponseIDForWebsocketUpstream(t *test
 	}
 	if input[0].Get("id").String() != "msg-2" {
 		t.Fatalf("second upstream input item id = %s, want msg-2", input[0].Get("id").String())
+	}
+}
+
+func TestResponsesWebsocketFullCreateReplacementSkipsToolRepairCache(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	sessionKey := "session-full-create-replacement-repair"
+	resetResponsesWebsocketToolCaches(sessionKey)
+	t.Cleanup(func() {
+		resetResponsesWebsocketToolCaches(sessionKey)
+	})
+
+	executor := &websocketCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-ws",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsHeaders := http.Header{}
+	wsHeaders.Set("X-Client-Request-Id", sessionKey)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, wsHeaders)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
+		t.Fatalf("write initial websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read initial websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("initial payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	defaultWebsocketToolOutputCache.record(sessionKey, "call-1", json.RawMessage(`{"type":"function_call_output","call_id":"call-1","id":"old-output","output":"stale"}`))
+	replacement := []byte(`{
+		"type":"response.create",
+		"model":"test-model",
+		"input":[
+			{"type":"function_call","id":"fc-replacement","call_id":"call-1","name":"tool"},
+			{"type":"message","id":"msg-2","content":"new transcript"}
+		],
+		"tools":[],
+		"tool_choice":"auto",
+		"parallel_tool_calls":true,
+		"store":false,
+		"stream":true,
+		"include":[],
+		"client_metadata":{
+			"x-codex-installation-id":"install-1",
+			"x-codex-window-id":"thread-1:0"
+		}
+	}`)
+	if errWrite := conn.WriteMessage(websocket.TextMessage, replacement); errWrite != nil {
+		t.Fatalf("write replacement websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read replacement websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("replacement payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	if len(executor.payloads) != 2 {
+		t.Fatalf("upstream payload count = %d, want 2", len(executor.payloads))
+	}
+	forwarded := executor.payloads[1]
+	input := gjson.GetBytes(forwarded, "input").Array()
+	if len(input) != 2 {
+		t.Fatalf("replacement input len = %d, want 2 without cached tool output: %s", len(input), forwarded)
+	}
+	if strings.Contains(gjson.GetBytes(forwarded, "input").Raw, "old-output") {
+		t.Fatalf("replacement must not reuse stale tool repair cache: %s", forwarded)
 	}
 }
 
@@ -2423,7 +3531,7 @@ func TestResponsesWebsocketReplaysTranscriptAfterUpstreamGenerationChange(t *tes
 	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
 		t.Fatalf("write initial websocket message: %v", errWrite)
 	}
-	_, payload, errReadMessage := conn.ReadMessage()
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read initial websocket message: %v", errReadMessage)
 	}
@@ -2435,7 +3543,7 @@ func TestResponsesWebsocketReplaysTranscriptAfterUpstreamGenerationChange(t *tes
 	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
 		t.Fatalf("write follow-up websocket message: %v", errWrite)
 	}
-	_, payload, errReadMessage = conn.ReadMessage()
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read follow-up websocket message: %v", errReadMessage)
 	}
@@ -2457,6 +3565,107 @@ func TestResponsesWebsocketReplaysTranscriptAfterUpstreamGenerationChange(t *tes
 	}
 	for _, id := range []string{"msg-1", "out-1", "msg-2"} {
 		if !strings.Contains(gjson.GetBytes(replayed, "input").Raw, fmt.Sprintf(`"id":"%s"`, id)) {
+			t.Fatalf("replayed input missing %s: %s", id, replayed)
+		}
+	}
+}
+
+func TestResponsesWebsocketReplaysFullTranscriptAfterIncrementalSuccessAndUpstreamGenerationChange(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketGenerationReplayExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-codex",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
+		t.Fatalf("write initial websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read initial websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("initial payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
+		t.Fatalf("write incremental websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read incremental websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("incremental payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	executor.BumpGeneration()
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-2","input":[{"type":"message","id":"msg-3"}]}`)); errWrite != nil {
+		t.Fatalf("write replay websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read replay websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("replay payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	payloads := executor.Payloads()
+	if len(payloads) != 3 {
+		t.Fatalf("captured upstream payloads = %d, want 3", len(payloads))
+	}
+	incremental := payloads[1]
+	if got := gjson.GetBytes(incremental, "previous_response_id").String(); got != "resp-1" {
+		t.Fatalf("second upstream previous_response_id = %s, want resp-1: %s", got, incremental)
+	}
+	if input := gjson.GetBytes(incremental, "input").Array(); len(input) != 1 || input[0].Get("id").String() != "msg-2" {
+		t.Fatalf("second upstream should stay incremental: %s", incremental)
+	}
+
+	replayed := payloads[2]
+	if gjson.GetBytes(replayed, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id leaked after upstream generation changed: %s", replayed)
+	}
+	input := gjson.GetBytes(replayed, "input").Array()
+	if len(input) != 5 {
+		t.Fatalf("replayed input len = %d, want 5: %s", len(input), replayed)
+	}
+	inputRaw := gjson.GetBytes(replayed, "input").Raw
+	for _, id := range []string{"msg-1", "out-1", "msg-2", "out-2", "msg-3"} {
+		if !strings.Contains(inputRaw, fmt.Sprintf(`"id":"%s"`, id)) {
 			t.Fatalf("replayed input missing %s: %s", id, replayed)
 		}
 	}
@@ -2504,7 +3713,7 @@ func TestResponsesWebsocketRetriesPreviousResponseNotFoundWithTranscriptReplay(t
 	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
 		t.Fatalf("write initial websocket message: %v", errWrite)
 	}
-	_, payload, errReadMessage := conn.ReadMessage()
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read initial websocket message: %v", errReadMessage)
 	}
@@ -2515,7 +3724,7 @@ func TestResponsesWebsocketRetriesPreviousResponseNotFoundWithTranscriptReplay(t
 	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
 		t.Fatalf("write follow-up websocket message: %v", errWrite)
 	}
-	_, payload, errReadMessage = conn.ReadMessage()
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read retried websocket message: %v", errReadMessage)
 	}
@@ -2538,6 +3747,515 @@ func TestResponsesWebsocketRetriesPreviousResponseNotFoundWithTranscriptReplay(t
 	for _, id := range []string{"msg-1", "out-1", "msg-2"} {
 		if !strings.Contains(inputRaw, fmt.Sprintf(`"id":"%s"`, id)) {
 			t.Fatalf("retry replay input missing %s: %s", id, replayed)
+		}
+	}
+}
+
+func TestResponsesWebsocketDoesNotReplayPreviousResponseNotFoundAfterPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	streamCallCh := make(chan int, 4)
+	executor := &websocketGenerationReplayExecutor{failPreviousAfterPayloadOnCall: 2, streamCallCh: streamCallCh}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-codex",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
+		t.Fatalf("write initial websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read initial websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("initial payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
+		t.Fatalf("write follow-up websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read output item websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != "response.output_item.done" {
+		t.Fatalf("follow-up first payload type = %s, want response.output_item.done: %s", got, payload)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read previous-response error websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeError {
+		t.Fatalf("follow-up second payload type = %s, want %s: %s", got, wsEventTypeError, payload)
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-streamCallCh:
+		default:
+			t.Fatalf("missing expected upstream call %d", i+1)
+		}
+	}
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","input":[{"type":"message","id":"msg-3"}]}`)); errWrite != nil {
+		t.Fatalf("write third websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read third websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("third payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	payloads := executor.Payloads()
+	if len(payloads) != 3 {
+		t.Fatalf("captured upstream payloads = %d, want 3 without replay after forwarded payload", len(payloads))
+	}
+	if got := gjson.GetBytes(payloads[1], "previous_response_id").String(); got != "resp-1" {
+		t.Fatalf("second upstream previous_response_id = %s, want resp-1: %s", got, payloads[1])
+	}
+	if gjson.GetBytes(payloads[2], "previous_response_id").Exists() {
+		t.Fatalf("third upstream previous_response_id leaked: %s", payloads[2])
+	}
+	thirdInput := gjson.GetBytes(payloads[2], "input").Array()
+	if len(thirdInput) != 3 {
+		t.Fatalf("third upstream input len = %d, want 3: %s", len(thirdInput), payloads[2])
+	}
+	thirdInputRaw := gjson.GetBytes(payloads[2], "input").Raw
+	for _, id := range []string{"msg-1", "out-1", "msg-3"} {
+		if !strings.Contains(thirdInputRaw, fmt.Sprintf(`"id":"%s"`, id)) {
+			t.Fatalf("third upstream input missing %s: %s", id, payloads[2])
+		}
+	}
+	if strings.Contains(thirdInputRaw, `"id":"msg-2"`) {
+		t.Fatalf("failed previous-response turn was committed into third upstream input: %s", payloads[2])
+	}
+}
+
+func TestResponsesWebsocketRetriesUpstreamResetWithTranscriptReplay(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketGenerationReplayExecutor{requireReplayOnCall: 2}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-codex",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
+		t.Fatalf("write initial websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read initial websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("initial payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
+		t.Fatalf("write follow-up websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read reset-replayed websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("reset-replayed payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	payloads := executor.Payloads()
+	if len(payloads) != 3 {
+		t.Fatalf("captured upstream payloads = %d, want 3", len(payloads))
+	}
+	if got := gjson.GetBytes(payloads[1], "previous_response_id").String(); got != "resp-1" {
+		t.Fatalf("second upstream previous_response_id = %s, want resp-1: %s", got, payloads[1])
+	}
+	replayed := payloads[2]
+	if gjson.GetBytes(replayed, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id leaked after upstream reset replay: %s", replayed)
+	}
+	inputRaw := gjson.GetBytes(replayed, "input").Raw
+	for _, id := range []string{"msg-1", "out-1", "msg-2"} {
+		if !strings.Contains(inputRaw, fmt.Sprintf(`"id":"%s"`, id)) {
+			t.Fatalf("upstream reset replay input missing %s: %s", id, replayed)
+		}
+	}
+}
+
+func TestResponsesWebsocketRetriesUpstreamResetDuringForcedTranscriptReplay(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketGenerationReplayExecutor{requireReplayOnCall: 2}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-codex",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
+		t.Fatalf("write initial websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read initial websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("initial payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	executor.BumpGeneration()
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
+		t.Fatalf("write follow-up websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read forced-replay websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("forced-replay payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	payloads := executor.Payloads()
+	if len(payloads) != 3 {
+		t.Fatalf("captured upstream payloads = %d, want 3", len(payloads))
+	}
+	for _, replayed := range payloads[1:] {
+		if gjson.GetBytes(replayed, "previous_response_id").Exists() {
+			t.Fatalf("previous_response_id leaked during forced replay retry: %s", replayed)
+		}
+		inputRaw := gjson.GetBytes(replayed, "input").Raw
+		for _, id := range []string{"msg-1", "out-1", "msg-2"} {
+			if !strings.Contains(inputRaw, fmt.Sprintf(`"id":"%s"`, id)) {
+				t.Fatalf("forced replay input missing %s: %s", id, replayed)
+			}
+		}
+	}
+}
+
+func TestResponsesWebsocketDoesNotCommitFailedTranscriptReplayAfterRetryExhaustion(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketGenerationReplayExecutor{
+		requireReplayCalls: map[int]bool{
+			2: true,
+			3: true,
+			4: true,
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-codex",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
+		t.Fatalf("write initial websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read initial websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("initial payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	executor.BumpGeneration()
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
+		t.Fatalf("write retry-exhausted websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read retry-exhausted websocket error: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeError {
+		t.Fatalf("retry-exhausted payload type = %s, want %s: %s", got, wsEventTypeError, payload)
+	}
+	if got := int(gjson.GetBytes(payload, "status").Int()); got != http.StatusBadGateway {
+		t.Fatalf("retry-exhausted status = %d, want %d: %s", got, http.StatusBadGateway, payload)
+	}
+	if strings.Contains(string(payload), "requires transcript replay") {
+		t.Fatalf("internal replay sentinel leaked to downstream: %s", payload)
+	}
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-3"}]}`)); errWrite != nil {
+		t.Fatalf("write recovery websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read recovery websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("recovery payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	payloads := executor.Payloads()
+	if len(payloads) != 5 {
+		t.Fatalf("captured upstream payloads = %d, want 5", len(payloads))
+	}
+	replayed := payloads[4]
+	if gjson.GetBytes(replayed, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id leaked after retry exhaustion recovery: %s", replayed)
+	}
+	inputRaw := gjson.GetBytes(replayed, "input").Raw
+	for _, id := range []string{"msg-1", "out-1", "msg-3"} {
+		if !strings.Contains(inputRaw, fmt.Sprintf(`"id":"%s"`, id)) {
+			t.Fatalf("recovery replay input missing %s: %s", id, replayed)
+		}
+	}
+	if strings.Contains(inputRaw, `"id":"msg-2"`) {
+		t.Fatalf("failed retry-exhausted turn was committed into recovery replay: %s", replayed)
+	}
+}
+
+func TestResponsesWebsocketRetriesRealCodexUpstreamReadResetWithTranscriptReplay(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	var upstreamMu sync.Mutex
+	upstreamPayloads := make([][]byte, 0, 3)
+	upstreamRequests := make(chan int, 3)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade upstream websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			_, payload, errRead := conn.ReadMessage()
+			if errRead != nil {
+				return
+			}
+			upstreamMu.Lock()
+			upstreamPayloads = append(upstreamPayloads, bytes.Clone(payload))
+			call := len(upstreamPayloads)
+			upstreamMu.Unlock()
+			upstreamRequests <- call
+
+			switch call {
+			case 1:
+				completed := []byte(`{"type":"response.completed","response":{"id":"resp-1","output":[{"type":"message","id":"out-1","role":"assistant","content":[{"type":"output_text","text":"first"}]}]}}`)
+				if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+					t.Errorf("write initial upstream response: %v", errWrite)
+					return
+				}
+			case 2:
+				return
+			default:
+				completed := []byte(`{"type":"response.completed","response":{"id":"resp-replayed","output":[{"type":"message","id":"out-replayed","role":"assistant","content":[{"type":"output_text","text":"replayed"}]}]}}`)
+				if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+					t.Errorf("write replayed upstream response: %v", errWrite)
+				}
+				return
+			}
+		}
+	}))
+	defer upstream.Close()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(codexexecutor.NewCodexAutoExecutor(&appconfig.Config{
+		SDKConfig: appconfig.SDKConfig{DisableImageGeneration: appconfig.DisableImageGenerationAll},
+	}))
+	auth := &coreauth.Auth{
+		ID:       "auth-real-codex-ws-reset",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"api_key":    "sk-test",
+			"base_url":   upstream.URL,
+			"websockets": "true",
+		},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "gpt-5-codex"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+	downstream := httptest.NewServer(router)
+	defer downstream.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(downstream.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial downstream websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"gpt-5-codex","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
+		t.Fatalf("write initial downstream request: %v", errWrite)
+	}
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read initial downstream response: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("initial downstream payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
+		t.Fatalf("write follow-up downstream request: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read replayed downstream response: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("replayed downstream payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-upstreamRequests:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for upstream request %d", i+1)
+		}
+	}
+	upstreamMu.Lock()
+	payloads := make([][]byte, len(upstreamPayloads))
+	for i := range upstreamPayloads {
+		payloads[i] = bytes.Clone(upstreamPayloads[i])
+	}
+	upstreamMu.Unlock()
+
+	if len(payloads) != 3 {
+		t.Fatalf("captured upstream payloads = %d, want 3", len(payloads))
+	}
+	if got := gjson.GetBytes(payloads[1], "previous_response_id").String(); got != "resp-1" {
+		t.Fatalf("second upstream previous_response_id = %s, want resp-1: %s", got, payloads[1])
+	}
+	replayed := payloads[2]
+	if gjson.GetBytes(replayed, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id leaked after real upstream read reset: %s", replayed)
+	}
+	inputRaw := gjson.GetBytes(replayed, "input").Raw
+	for _, id := range []string{"msg-1", "out-1", "msg-2"} {
+		if !strings.Contains(inputRaw, fmt.Sprintf(`"id":"%s"`, id)) {
+			t.Fatalf("real upstream read reset replay input missing %s: %s", id, replayed)
 		}
 	}
 }
@@ -2594,7 +4312,7 @@ func TestResponsesWebsocketStripsGenerateWhenWebsocketAttemptFallsBackToHTTP(t *
 	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(request)); errWrite != nil {
 		t.Fatalf("write websocket message: %v", errWrite)
 	}
-	_, payload, errReadMessage := conn.ReadMessage()
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read websocket message: %v", errReadMessage)
 	}
@@ -2704,7 +4422,7 @@ func TestResponsesWebsocketPinsOnlyWebsocketCapableAuth(t *testing.T) {
 		if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(requests[i])); errWrite != nil {
 			t.Fatalf("write websocket message %d: %v", i+1, errWrite)
 		}
-		_, payload, errReadMessage := conn.ReadMessage()
+		_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 		if errReadMessage != nil {
 			t.Fatalf("read websocket message %d: %v", i+1, errReadMessage)
 		}
@@ -2781,7 +4499,7 @@ func TestResponsesWebsocketReleasesPinnedAuthAfterQuotaError(t *testing.T) {
 		if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(requests[i])); errWrite != nil {
 			t.Fatalf("write websocket message %d: %v", i+1, errWrite)
 		}
-		_, payload, errReadMessage := conn.ReadMessage()
+		_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 		if errReadMessage != nil {
 			t.Fatalf("read websocket message %d: %v", i+1, errReadMessage)
 		}
@@ -2893,7 +4611,7 @@ func TestNormalizeResponsesWebsocketRequestDropsDuplicateInputItemsByID(t *testi
 	]`)
 	raw := []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"function_call","id":"fc-1","call_id":"call-2","name":"tool"},{"type":"function_call_output","id":"tool-out-1","call_id":"call-2"}]}`)
 
-	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, true)
+	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, true, false)
 	if errMsg != nil {
 		t.Fatalf("unexpected error: %v", errMsg.Error)
 	}
@@ -3024,8 +4742,14 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnCustomToolTranscriptReplac
 	server := httptest.NewServer(router)
 	defer server.Close()
 
+	sessionID := "session-custom-tool-compact"
+	threadID := "thread-custom-tool-compact"
+	wsHeaders := http.Header{}
+	wsHeaders.Set("X-Client-Request-Id", threadID)
+	wsHeaders.Set("Session-Id", sessionID)
+	wsHeaders.Set("Thread-Id", threadID)
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, wsHeaders)
 	if err != nil {
 		t.Fatalf("dial websocket: %v", err)
 	}
@@ -3043,7 +4767,7 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnCustomToolTranscriptReplac
 		if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(requests[i])); errWrite != nil {
 			t.Fatalf("write websocket message %d: %v", i+1, errWrite)
 		}
-		_, payload, errReadMessage := conn.ReadMessage()
+		_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 		if errReadMessage != nil {
 			t.Fatalf("read websocket message %d: %v", i+1, errReadMessage)
 		}
@@ -3052,11 +4776,18 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnCustomToolTranscriptReplac
 		}
 	}
 
-	compactResp, errPost := server.Client().Post(
+	compactReq, errReq := http.NewRequest(
+		http.MethodPost,
 		server.URL+"/v1/responses/compact",
-		"application/json",
 		strings.NewReader(`{"model":"test-model","input":[{"type":"message","id":"summary-1"}]}`),
 	)
+	if errReq != nil {
+		t.Fatalf("create compact request: %v", errReq)
+	}
+	compactReq.Header.Set("Content-Type", "application/json")
+	compactReq.Header.Set("Session-Id", sessionID)
+	compactReq.Header.Set("Thread-Id", threadID)
+	compactResp, errPost := server.Client().Do(compactReq)
 	if errPost != nil {
 		t.Fatalf("compact request failed: %v", errPost)
 	}
@@ -3071,7 +4802,7 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnCustomToolTranscriptReplac
 	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(postCompact)); errWrite != nil {
 		t.Fatalf("write post-compact websocket message: %v", errWrite)
 	}
-	_, payload, errReadMessage := conn.ReadMessage()
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read post-compact websocket message: %v", errReadMessage)
 	}
@@ -3087,6 +4818,9 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnCustomToolTranscriptReplac
 	}
 	if len(executor.streamPayloads) != 3 {
 		t.Fatalf("stream payload count = %d, want 3", len(executor.streamPayloads))
+	}
+	if executor.dropCalls != 1 || len(executor.dropReasons) != 1 || executor.dropReasons[0] != "compact_replay" {
+		t.Fatalf("drop upstream calls = %d reasons=%v, want one compact_replay", executor.dropCalls, executor.dropReasons)
 	}
 
 	merged := executor.streamPayloads[2]
@@ -3128,8 +4862,14 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnTranscriptReplacement(t *t
 	server := httptest.NewServer(router)
 	defer server.Close()
 
+	sessionID := "session-tool-compact"
+	threadID := "thread-tool-compact"
+	wsHeaders := http.Header{}
+	wsHeaders.Set("X-Client-Request-Id", threadID)
+	wsHeaders.Set("Session-Id", sessionID)
+	wsHeaders.Set("Thread-Id", threadID)
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, wsHeaders)
 	if err != nil {
 		t.Fatalf("dial websocket: %v", err)
 	}
@@ -3147,7 +4887,7 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnTranscriptReplacement(t *t
 		if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(requests[i])); errWrite != nil {
 			t.Fatalf("write websocket message %d: %v", i+1, errWrite)
 		}
-		_, payload, errReadMessage := conn.ReadMessage()
+		_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 		if errReadMessage != nil {
 			t.Fatalf("read websocket message %d: %v", i+1, errReadMessage)
 		}
@@ -3156,11 +4896,18 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnTranscriptReplacement(t *t
 		}
 	}
 
-	compactResp, errPost := server.Client().Post(
+	compactReq, errReq := http.NewRequest(
+		http.MethodPost,
 		server.URL+"/v1/responses/compact",
-		"application/json",
 		strings.NewReader(`{"model":"test-model","input":[{"type":"message","id":"summary-1"}]}`),
 	)
+	if errReq != nil {
+		t.Fatalf("create compact request: %v", errReq)
+	}
+	compactReq.Header.Set("Content-Type", "application/json")
+	compactReq.Header.Set("Session-Id", sessionID)
+	compactReq.Header.Set("Thread-Id", threadID)
+	compactResp, errPost := server.Client().Do(compactReq)
 	if errPost != nil {
 		t.Fatalf("compact request failed: %v", errPost)
 	}
@@ -3177,7 +4924,7 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnTranscriptReplacement(t *t
 	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(postCompact)); errWrite != nil {
 		t.Fatalf("write post-compact websocket message: %v", errWrite)
 	}
-	_, payload, errReadMessage := conn.ReadMessage()
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
 	if errReadMessage != nil {
 		t.Fatalf("read post-compact websocket message: %v", errReadMessage)
 	}
@@ -3194,6 +4941,9 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnTranscriptReplacement(t *t
 	if len(executor.streamPayloads) != 3 {
 		t.Fatalf("stream payload count = %d, want 3", len(executor.streamPayloads))
 	}
+	if executor.dropCalls != 1 || len(executor.dropReasons) != 1 || executor.dropReasons[0] != "compact_replay" {
+		t.Fatalf("drop upstream calls = %d reasons=%v, want one compact_replay", executor.dropCalls, executor.dropReasons)
+	}
 
 	merged := executor.streamPayloads[2]
 	items := gjson.GetBytes(merged, "input").Array()
@@ -3206,6 +4956,639 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnTranscriptReplacement(t *t
 	}
 	if items[0].Get("call_id").String() != "call-1" {
 		t.Fatalf("post-compact function call id = %s, want call-1", items[0].Get("call_id").String())
+	}
+	for _, item := range items {
+		if item.Get("id").String() == "tool-out-1" {
+			t.Fatalf("post-compact replacement must not be repaired with stale pre-compact tool output: %s", merged)
+		}
+	}
+}
+
+func TestResponsesWebsocketCompactMarksNextPlainUserTranscriptReplacement(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketCompactionCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "auth-sse-plain-compact", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+	router.POST("/v1/responses/compact", h.Compact)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	sessionID := "session-plain-compact"
+	threadID := "thread-plain-compact"
+	wsHeaders := http.Header{}
+	wsHeaders.Set("X-Client-Request-Id", threadID)
+	wsHeaders.Set("Session-Id", sessionID)
+	wsHeaders.Set("Thread-Id", threadID)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, wsHeaders)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	requests := []string{
+		`{"type":"response.create","model":"test-model","input":[{"type":"message","role":"user","id":"msg-1","content":"original prompt"}]}`,
+		`{"type":"response.create","input":[{"type":"function_call_output","call_id":"call-1","id":"tool-out-1","output":"old result"}]}`,
+	}
+	for i := range requests {
+		if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(requests[i])); errWrite != nil {
+			t.Fatalf("write websocket message %d: %v", i+1, errWrite)
+		}
+		_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+		if errReadMessage != nil {
+			t.Fatalf("read websocket message %d: %v", i+1, errReadMessage)
+		}
+		if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+			t.Fatalf("message %d payload type = %s, want %s", i+1, got, wsEventTypeCompleted)
+		}
+	}
+
+	compactReq, errReq := http.NewRequest(
+		http.MethodPost,
+		server.URL+"/v1/responses/compact",
+		strings.NewReader(`{"model":"test-model","input":[{"type":"message","role":"user","id":"summary-compact-request"}]}`),
+	)
+	if errReq != nil {
+		t.Fatalf("create compact request: %v", errReq)
+	}
+	compactReq.Header.Set("Content-Type", "application/json")
+	compactReq.Header.Set("Session-Id", sessionID)
+	compactReq.Header.Set("Thread-Id", threadID)
+	compactResp, errPost := server.Client().Do(compactReq)
+	if errPost != nil {
+		t.Fatalf("compact request failed: %v", errPost)
+	}
+	if errClose := compactResp.Body.Close(); errClose != nil {
+		t.Fatalf("close compact response body: %v", errClose)
+	}
+	if compactResp.StatusCode != http.StatusOK {
+		t.Fatalf("compact status = %d, want %d", compactResp.StatusCode, http.StatusOK)
+	}
+
+	postCompact := `{"type":"response.create","input":[{"type":"message","role":"user","id":"summary-msg","content":"compacted summary"},{"type":"message","role":"user","id":"msg-2","content":"question after compact"}]}`
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(postCompact)); errWrite != nil {
+		t.Fatalf("write post-compact websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read post-compact websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("post-compact payload type = %s, want %s", got, wsEventTypeCompleted)
+	}
+
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+
+	if executor.compactPayload == nil {
+		t.Fatalf("compact payload was not captured")
+	}
+	if len(executor.streamPayloads) != 3 {
+		t.Fatalf("stream payload count = %d, want 3", len(executor.streamPayloads))
+	}
+	if executor.dropCalls != 1 || len(executor.dropReasons) != 1 || executor.dropReasons[0] != "compact_replay" {
+		t.Fatalf("drop upstream calls = %d reasons=%v, want one compact_replay", executor.dropCalls, executor.dropReasons)
+	}
+
+	merged := executor.streamPayloads[2]
+	items := gjson.GetBytes(merged, "input").Array()
+	if len(items) != 2 {
+		t.Fatalf("post-compact input len = %d, want 2 replacement items; stale state was merged: %s", len(items), merged)
+	}
+	if items[0].Get("id").String() != "summary-msg" ||
+		items[1].Get("id").String() != "msg-2" {
+		t.Fatalf("unexpected post-compact input order: %s", merged)
+	}
+}
+
+func TestResponsesWebsocketCompactReplayMarkerSurvivesPreCompletionFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketCompactionCaptureExecutor{
+		failStreamCalls: map[int]error{
+			2: websocketPinnedFailoverStatusError{status: http.StatusBadRequest, msg: "post compact failed before completion"},
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "auth-compact-retry", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+	router.POST("/v1/responses/compact", h.Compact)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	sessionID := "session-compact-retry"
+	threadID := "thread-compact-retry"
+	wsHeaders := http.Header{}
+	wsHeaders.Set("X-Client-Request-Id", threadID)
+	wsHeaders.Set("Session-Id", sessionID)
+	wsHeaders.Set("Thread-Id", threadID)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, wsHeaders)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	requests := []string{
+		`{"type":"response.create","model":"test-model","input":[{"type":"message","role":"user","id":"msg-1","content":"original prompt"}]}`,
+		`{"type":"response.create","input":[{"type":"function_call_output","call_id":"call-1","id":"tool-out-1","output":"old result"}]}`,
+	}
+	for i := range requests {
+		if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(requests[i])); errWrite != nil {
+			t.Fatalf("write websocket message %d: %v", i+1, errWrite)
+		}
+		_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+		if errReadMessage != nil {
+			t.Fatalf("read websocket message %d: %v", i+1, errReadMessage)
+		}
+		if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+			t.Fatalf("message %d payload type = %s, want %s", i+1, got, wsEventTypeCompleted)
+		}
+	}
+
+	compactReq, errReq := http.NewRequest(
+		http.MethodPost,
+		server.URL+"/v1/responses/compact",
+		strings.NewReader(`{"model":"test-model","input":[{"type":"message","role":"user","id":"summary-compact-request"}]}`),
+	)
+	if errReq != nil {
+		t.Fatalf("create compact request: %v", errReq)
+	}
+	compactReq.Header.Set("Content-Type", "application/json")
+	compactReq.Header.Set("Session-Id", sessionID)
+	compactReq.Header.Set("Thread-Id", threadID)
+	compactResp, errPost := server.Client().Do(compactReq)
+	if errPost != nil {
+		t.Fatalf("compact request failed: %v", errPost)
+	}
+	if errClose := compactResp.Body.Close(); errClose != nil {
+		t.Fatalf("close compact response body: %v", errClose)
+	}
+	if compactResp.StatusCode != http.StatusOK {
+		t.Fatalf("compact status = %d, want %d", compactResp.StatusCode, http.StatusOK)
+	}
+
+	postCompact := `{"type":"response.create","input":[{"type":"message","role":"user","id":"summary-msg","content":"compacted summary"},{"type":"message","role":"user","id":"msg-2","content":"question after compact"}]}`
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(postCompact)); errWrite != nil {
+		t.Fatalf("write failing post-compact websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read failing post-compact websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeError {
+		t.Fatalf("failing post-compact payload type = %s, want %s", got, wsEventTypeError)
+	}
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(postCompact)); errWrite != nil {
+		t.Fatalf("write retry post-compact websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read retry post-compact websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("retry post-compact payload type = %s, want %s", got, wsEventTypeCompleted)
+	}
+
+	checkReq := httptest.NewRequest(http.MethodGet, "/v1/responses/ws", nil)
+	checkReq.Header.Set("X-Client-Request-Id", threadID)
+	checkReq.Header.Set("Session-Id", sessionID)
+	checkReq.Header.Set("Thread-Id", threadID)
+	checkKeys := websocketDownstreamSessionKeys(checkReq)
+	deadline := time.Now().Add(2 * time.Second)
+	for hasResponsesWebsocketCompactReplay(checkKeys) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if hasResponsesWebsocketCompactReplay(checkKeys) {
+		t.Fatal("compact replay marker must be consumed after successful retry")
+	}
+
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+
+	if len(executor.streamPayloads) != 4 {
+		t.Fatalf("stream payload count = %d, want 4", len(executor.streamPayloads))
+	}
+	if executor.dropCalls != 2 {
+		t.Fatalf("drop upstream calls = %d, want 2 while marker survives retry; reasons=%v", executor.dropCalls, executor.dropReasons)
+	}
+	for idx := 2; idx <= 3; idx++ {
+		merged := executor.streamPayloads[idx]
+		items := gjson.GetBytes(merged, "input").Array()
+		if len(items) != 2 {
+			t.Fatalf("post-compact call %d input len = %d, want replacement-only input; stale state was merged: %s", idx, len(items), merged)
+		}
+		if items[0].Get("id").String() != "summary-msg" || items[1].Get("id").String() != "msg-2" {
+			t.Fatalf("unexpected post-compact call %d input order: %s", idx, merged)
+		}
+	}
+
+}
+
+func TestResponsesWebsocketCompactReplayKeysIncludeCodexWindowOnly(t *testing.T) {
+	tracker := newResponsesWebsocketCompactReplayTracker(time.Minute)
+	reqCompact := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", nil)
+	reqCompact.Header.Set("X-Codex-Window-Id", "window-compact-1")
+	reqCompact.Header.Set("X-Codex-Parent-Thread-Id", "parent-compact-1")
+	reqCompact.Header.Set("X-Codex-Turn-Metadata", `{"window_id":"window-meta-1","parent_thread_id":"parent-meta-1"}`)
+	tracker.mark(websocketDownstreamSessionKeys(reqCompact))
+
+	reqWindow := httptest.NewRequest(http.MethodGet, "/v1/responses/ws", nil)
+	reqWindow.Header.Set("X-Codex-Window-Id", "window-compact-1")
+	if !tracker.has(websocketDownstreamSessionKeys(reqWindow)) {
+		t.Fatal("compact replay marker must match X-Codex-Window-Id")
+	}
+
+	reqParentAsThread := httptest.NewRequest(http.MethodGet, "/v1/responses/ws", nil)
+	reqParentAsThread.Header.Set("Thread-Id", "parent-meta-1")
+	if tracker.has(websocketDownstreamSessionKeys(reqParentAsThread)) {
+		t.Fatal("compact replay marker parent_thread_id must not match Thread-Id")
+	}
+
+	reqMetaParent := httptest.NewRequest(http.MethodGet, "/v1/responses/ws", nil)
+	reqMetaParent.Header.Set("X-Codex-Turn-Metadata", `{"parent_thread_id":"parent-meta-1"}`)
+	if tracker.has(websocketDownstreamSessionKeys(reqMetaParent)) {
+		t.Fatal("compact replay marker must not match parent_thread_id")
+	}
+
+	reqParentHeader := httptest.NewRequest(http.MethodGet, "/v1/responses/ws", nil)
+	reqParentHeader.Header.Set("X-Codex-Parent-Thread-Id", "parent-compact-1")
+	if tracker.has(websocketDownstreamSessionKeys(reqParentHeader)) {
+		t.Fatal("compact replay marker must not match X-Codex-Parent-Thread-Id")
+	}
+
+	if !tracker.consume(websocketDownstreamSessionKeys(reqWindow)) {
+		t.Fatal("compact replay marker must be consumed by X-Codex-Window-Id")
+	}
+	if tracker.has(websocketDownstreamSessionKeys(reqWindow)) {
+		t.Fatal("compact replay marker must be removed from all associated keys after consume")
+	}
+}
+
+func TestResponsesWebsocketCompactReplayKeysIncludeBodyClientMetadata(t *testing.T) {
+	tracker := newResponsesWebsocketCompactReplayTracker(time.Minute)
+	reqCompact := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", nil)
+	compactPayload := []byte(`{"client_metadata":{"x-codex-window-id":"window-body-1","x-codex-parent-thread-id":"parent-body-1","x-codex-turn-metadata":"{\"session_id\":\"session-body-1\",\"thread_id\":\"thread-body-1\",\"window_id\":\"window-meta-body-1\",\"parent_thread_id\":\"parent-meta-1\"}"}}`)
+	tracker.mark(websocketDownstreamSessionKeysWithPayload(reqCompact, compactPayload))
+
+	reqWindowBody := httptest.NewRequest(http.MethodGet, "/v1/responses/ws", nil)
+	windowBodyPayload := []byte(`{"type":"response.create","client_metadata":{"x-codex-window-id":"window-body-1"}}`)
+	if !tracker.has(websocketDownstreamSessionKeysWithPayload(reqWindowBody, windowBodyPayload)) {
+		t.Fatal("compact replay marker must match body client_metadata x-codex-window-id")
+	}
+
+	reqMetaWindowBody := httptest.NewRequest(http.MethodGet, "/v1/responses/ws", nil)
+	metaWindowBodyPayload := []byte(`{"type":"response.create","client_metadata":{"x-codex-turn-metadata":"{\"window_id\":\"window-meta-body-1\"}"}}`)
+	if !tracker.has(websocketDownstreamSessionKeysWithPayload(reqMetaWindowBody, metaWindowBodyPayload)) {
+		t.Fatal("compact replay marker must match body client_metadata x-codex-turn-metadata window_id")
+	}
+
+	reqParentBody := httptest.NewRequest(http.MethodGet, "/v1/responses/ws", nil)
+	parentBodyPayload := []byte(`{"type":"response.create","client_metadata":{"x-codex-parent-thread-id":"parent-body-1","x-codex-turn-metadata":"{\"parent_thread_id\":\"parent-meta-1\"}"}}`)
+	if tracker.has(websocketDownstreamSessionKeysWithPayload(reqParentBody, parentBodyPayload)) {
+		t.Fatal("compact replay marker must not match body parent_thread_id")
+	}
+
+	if !tracker.consume(websocketDownstreamSessionKeysWithPayload(reqWindowBody, windowBodyPayload)) {
+		t.Fatal("compact replay marker must be consumed by body client_metadata x-codex-window-id")
+	}
+	if tracker.has(websocketDownstreamSessionKeysWithPayload(reqMetaWindowBody, metaWindowBodyPayload)) {
+		t.Fatal("compact replay marker must be removed from all body metadata aliases after consume")
+	}
+}
+
+func TestResponsesWebsocketCompactReplayKeysIncludePromptCacheKey(t *testing.T) {
+	tracker := newResponsesWebsocketCompactReplayTracker(time.Minute)
+	reqCompact := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", nil)
+	compactPayload := []byte(`{"prompt_cache_key":"cache-body-1"}`)
+	tracker.mark(websocketDownstreamSessionKeysWithPayload(reqCompact, compactPayload))
+
+	reqFollowup := httptest.NewRequest(http.MethodGet, "/v1/responses/ws", nil)
+	followupPayload := []byte(`{"type":"response.create","prompt_cache_key":"cache-body-1","input":[{"type":"message","id":"msg-1"}]}`)
+	if !tracker.has(websocketDownstreamSessionKeysWithPayload(reqFollowup, followupPayload)) {
+		t.Fatal("compact replay marker must match top-level prompt_cache_key")
+	}
+	if !tracker.consume(websocketDownstreamSessionKeysWithPayload(reqFollowup, followupPayload)) {
+		t.Fatal("compact replay marker must be consumed by top-level prompt_cache_key")
+	}
+}
+
+func TestResponsesWebsocketCompactReplayKeysCanonicalizePromptCacheWindowID(t *testing.T) {
+	tracker := newResponsesWebsocketCompactReplayTracker(time.Minute)
+	reqCompact := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", nil)
+	compactPayload := []byte(`{"prompt_cache_key":"guardian:cache-window-1"}`)
+	tracker.mark(websocketDownstreamSessionKeysWithPayload(reqCompact, compactPayload))
+
+	reqWindow := httptest.NewRequest(http.MethodGet, "/v1/responses/ws", nil)
+	reqWindow.Header.Set("X-Codex-Window-Id", "guardian:cache-window-1:0")
+	if !tracker.has(websocketDownstreamSessionKeys(reqWindow)) {
+		t.Fatal("compact replay marker must match Codex window_id derived from prompt_cache_key")
+	}
+	if !tracker.consume(websocketDownstreamSessionKeys(reqWindow)) {
+		t.Fatal("compact replay marker must be consumed by canonical Codex window_id")
+	}
+}
+
+func TestResponsesWebsocketCompactReplayPrewarmUsesUpstreamResponseID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketCompactionCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-compact-prewarm",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+	router.POST("/v1/responses/compact", h.Compact)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	sessionID := "session-compact-prewarm"
+	threadID := "thread-compact-prewarm"
+	compactReq, errReq := http.NewRequest(
+		http.MethodPost,
+		server.URL+"/v1/responses/compact",
+		strings.NewReader(`{"model":"test-model","input":[{"type":"message","role":"user","id":"summary-compact-request"}]}`),
+	)
+	if errReq != nil {
+		t.Fatalf("create compact request: %v", errReq)
+	}
+	compactReq.Header.Set("Content-Type", "application/json")
+	compactReq.Header.Set("Session-Id", sessionID)
+	compactReq.Header.Set("Thread-Id", threadID)
+	compactResp, errPost := server.Client().Do(compactReq)
+	if errPost != nil {
+		t.Fatalf("compact request failed: %v", errPost)
+	}
+	if errClose := compactResp.Body.Close(); errClose != nil {
+		t.Fatalf("close compact response body: %v", errClose)
+	}
+	if compactResp.StatusCode != http.StatusOK {
+		t.Fatalf("compact status = %d, want %d", compactResp.StatusCode, http.StatusOK)
+	}
+
+	checkReq := httptest.NewRequest(http.MethodGet, "/v1/responses/ws", nil)
+	checkReq.Header.Set("Session-Id", sessionID)
+	checkReq.Header.Set("Thread-Id", threadID)
+	checkKeys := websocketDownstreamSessionKeys(checkReq)
+	if !hasResponsesWebsocketCompactReplay(checkKeys) {
+		t.Fatal("compact replay marker was not created")
+	}
+
+	wsHeaders := http.Header{}
+	wsHeaders.Set("Session-Id", sessionID)
+	wsHeaders.Set("Thread-Id", threadID)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, wsHeaders)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	prewarm := `{"type":"response.create","model":"test-model","generate":false,"input":[{"type":"message","role":"user","id":"summary-msg","content":"compacted summary"}]}`
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(prewarm)); errWrite != nil {
+		t.Fatalf("write prewarm websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read prewarm upstream message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("prewarm payload type = %s, want %s", got, wsEventTypeCompleted)
+	}
+	prewarmResponseID := gjson.GetBytes(payload, "response.id").String()
+	if prewarmResponseID == "" {
+		t.Fatal("prewarm response id is empty")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for hasResponsesWebsocketCompactReplay(checkKeys) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if hasResponsesWebsocketCompactReplay(checkKeys) {
+		t.Fatal("compact replay marker must be consumed after successful upstream prewarm")
+	}
+
+	followUp := fmt.Sprintf(`{"type":"response.create","previous_response_id":%q,"input":[{"type":"message","role":"user","id":"msg-2","content":"question after prewarm"}]}`, prewarmResponseID)
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(followUp)); errWrite != nil {
+		t.Fatalf("write follow-up websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read follow-up websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("follow-up payload type = %s, want %s", got, wsEventTypeCompleted)
+	}
+
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	if len(executor.streamPayloads) != 2 {
+		t.Fatalf("stream payload count = %d, want prewarm + follow-up", len(executor.streamPayloads))
+	}
+	forwardedPrewarm := executor.streamPayloads[0]
+	if !gjson.GetBytes(forwardedPrewarm, "generate").Exists() || gjson.GetBytes(forwardedPrewarm, "generate").Bool() {
+		t.Fatalf("compact prewarm must be forwarded upstream with generate=false: %s", forwardedPrewarm)
+	}
+	prewarmItems := gjson.GetBytes(forwardedPrewarm, "input").Array()
+	if len(prewarmItems) != 1 || prewarmItems[0].Get("id").String() != "summary-msg" {
+		t.Fatalf("unexpected upstream compact prewarm input: %s", forwardedPrewarm)
+	}
+	forwardedFollowUp := executor.streamPayloads[1]
+	if got := gjson.GetBytes(forwardedFollowUp, "previous_response_id").String(); got != prewarmResponseID {
+		t.Fatalf("follow-up previous_response_id = %q, want upstream prewarm id %q; payload=%s", got, prewarmResponseID, forwardedFollowUp)
+	}
+	if strings.HasPrefix(prewarmResponseID, "resp_prewarm_") || strings.Contains(string(forwardedFollowUp), "resp_prewarm_") {
+		t.Fatalf("follow-up must not use synthetic prewarm id: response=%q payload=%s", prewarmResponseID, forwardedFollowUp)
+	}
+	followUpItems := gjson.GetBytes(forwardedFollowUp, "input").Array()
+	if len(followUpItems) != 1 || followUpItems[0].Get("id").String() != "msg-2" {
+		t.Fatalf("unexpected upstream follow-up input: %s", forwardedFollowUp)
+	}
+}
+
+func TestResponsesWebsocketMarkerlessFullTranscriptDropsUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketCompactionCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "auth-markerless-compact", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","role":"user","id":"msg-1","content":"old prompt"}]}`)); errWrite != nil {
+		t.Fatalf("write initial websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read initial websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("initial payload type = %s, want %s", got, wsEventTypeCompleted)
+	}
+
+	markerlessCompact := fmt.Sprintf(
+		`{"type":"response.create","input":[{"type":"message","role":"user","id":"summary-msg","content":[{"type":"input_text","text":%q}]},{"type":"message","role":"user","id":"msg-2","content":"question after compact"}]}`,
+		codexCompactSummaryHead+"\ncompacted summary",
+	)
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(markerlessCompact)); errWrite != nil {
+		t.Fatalf("write markerless compact websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = readResponsesWebsocketTestMessage(t, conn)
+	if errReadMessage != nil {
+		t.Fatalf("read markerless compact websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("markerless compact payload type = %s, want %s", got, wsEventTypeCompleted)
+	}
+
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+
+	if len(executor.streamPayloads) != 2 {
+		t.Fatalf("stream payload count = %d, want 2", len(executor.streamPayloads))
+	}
+	if executor.dropCalls != 1 || len(executor.dropReasons) != 1 || executor.dropReasons[0] != "compact_replay" {
+		t.Fatalf("drop upstream calls = %d reasons=%v, want one compact_replay", executor.dropCalls, executor.dropReasons)
+	}
+
+	merged := executor.streamPayloads[1]
+	items := gjson.GetBytes(merged, "input").Array()
+	if len(items) != 2 {
+		t.Fatalf("markerless compact input len = %d, want compact replacement items without stale merge: %s", len(items), merged)
+	}
+	if items[0].Get("id").String() != "summary-msg" || items[1].Get("id").String() != "msg-2" {
+		t.Fatalf("unexpected markerless compact input: %s", merged)
+	}
+}
+
+func TestResponsesWebsocketResponseProcessedControlFrameDoesNotExecuteStream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketCompactionCaptureExecutor{processedCh: make(chan string, 1)}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "auth-response-processed", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.processed","response_id":"resp-processed-1"}`)); errWrite != nil {
+		t.Fatalf("write response.processed websocket message: %v", errWrite)
+	}
+
+	select {
+	case got := <-executor.processedCh:
+		if got != "resp-processed-1" {
+			t.Fatalf("processed response id = %q, want resp-processed-1", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for response.processed control frame")
+	}
+
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	if len(executor.streamPayloads) != 0 {
+		t.Fatalf("response.processed must not execute stream, got %d calls", len(executor.streamPayloads))
 	}
 }
 
@@ -3220,11 +5603,43 @@ func TestInputContainsFullTranscriptFalseForAssistantMessageOnly(t *testing.T) {
 }
 
 func TestInputContainsFullTranscriptDetectsCompactionItem(t *testing.T) {
-	for _, typ := range []string{"compaction", "compaction_summary"} {
+	for _, typ := range []string{"compaction", "compaction_summary", "compaction_trigger", "context_compaction"} {
 		input := gjson.Parse(`[{"type":"message","role":"user","content":"hello"},{"type":"` + typ + `","encrypted_content":"summary"}]`)
 		if !inputContainsFullTranscript(input) {
 			t.Fatalf("expected full transcript for type=%s", typ)
 		}
+	}
+}
+
+func TestInputWithoutCompactionItemsPreservesCompactionTrigger(t *testing.T) {
+	input := gjson.Parse(`[
+		{"type":"message","role":"user","id":"msg-1","content":"hello"},
+		{"type":"compaction_trigger","trigger":"auto"},
+		{"type":"context_compaction","encrypted_content":"summary"}
+	]`)
+
+	filtered := inputWithoutCompactionItems(input)
+	items := gjson.Parse(filtered).Array()
+	if len(items) != 2 {
+		t.Fatalf("filtered input len = %d, want 2: %s", len(items), filtered)
+	}
+	if items[1].Get("type").String() != "compaction_trigger" {
+		t.Fatalf("compaction_trigger must be preserved for executor routing: %s", filtered)
+	}
+	if strings.Contains(filtered, "context_compaction") {
+		t.Fatalf("context_compaction replay item must still be stripped: %s", filtered)
+	}
+}
+
+func TestInputContainsFullTranscriptDetectsLocalCompactionSummary(t *testing.T) {
+	input := gjson.Parse(fmt.Sprintf(`[
+		{"type":"message","role":"user","content":"kept user prompt"},
+		{"type":"message","role":"user","content":[{"type":"input_text","text":%q}]},
+		{"type":"message","role":"user","content":"question after compact"}
+	]`, codexCompactSummaryHead+"\nsummary text"))
+
+	if !inputContainsFullTranscript(input) {
+		t.Fatal("expected full transcript for local compact summary")
 	}
 }
 
@@ -3238,6 +5653,125 @@ func TestInputContainsFullTranscriptFalseForIncremental(t *testing.T) {
 		if inputContainsFullTranscript(gjson.Parse(raw)) {
 			t.Fatalf("incremental input must not be detected as full transcript: %s", raw)
 		}
+	}
+}
+
+func TestResponsesWebsocketReplayBoundaryIgnoresNonSemanticControlEvents(t *testing.T) {
+	if !responsesWebsocketPayloadPrecludesTranscriptReplay([]byte(`{"type":"response.created","response":{"id":"resp-1"}}`)) {
+		t.Fatal("response.created must preclude transcript replay once forwarded")
+	}
+	if !responsesWebsocketPayloadPrecludesTranscriptReplay([]byte(`{"type":"response.in_progress","response":{"id":"resp-1"}}`)) {
+		t.Fatal("response.in_progress must preclude transcript replay once forwarded")
+	}
+	if responsesWebsocketPayloadPrecludesTranscriptReplay([]byte(`{"type":"codex.rate_limits","rate_limits":[]}`)) {
+		t.Fatal("codex.rate_limits must not preclude transcript replay")
+	}
+	if !responsesWebsocketPayloadPrecludesTranscriptReplay([]byte(`{"type":"response.output_item.done","item":{"id":"msg-1"}}`)) {
+		t.Fatal("semantic output must preclude transcript replay")
+	}
+}
+
+func TestResponsesWebsocketPreviousResponseReplayUsesStructuredErrorCode(t *testing.T) {
+	errMsg := &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadRequest,
+		Error:      errors.New(`{"error":{"code":"invalid_prompt","message":"previous response with id 'resp-1' not found"}}`),
+	}
+	if shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
+		t.Fatal("structured non-previous-response error must not trigger transcript replay")
+	}
+
+	errMsg = &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadRequest,
+		Error:      errors.New(`{"error":{"code":"previous_response_not_found","message":"previous response missing"}}`),
+	}
+	if !shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
+		t.Fatal("structured previous_response_not_found error must trigger transcript replay")
+	}
+
+	errMsg = &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadRequest,
+		Error:      errors.New(`{"error":{"type":"invalid_request_error","message":"No response found for previous_response_id resp_123"}}`),
+	}
+	if !shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
+		t.Fatal("structured previous_response_id not found message must trigger transcript replay")
+	}
+}
+
+func TestResponsesWebsocketConnectionLimitTriggersTranscriptReplay(t *testing.T) {
+	errMsg := &interfaces.ErrorMessage{
+		StatusCode: http.StatusTooManyRequests,
+		Error:      errors.New(`{"error":{"code":"websocket_connection_limit_reached","message":"too many websockets"}}`),
+	}
+	if !shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
+		t.Fatal("websocket connection limit must trigger transcript replay")
+	}
+
+	errMsg = &interfaces.ErrorMessage{
+		StatusCode: http.StatusTooManyRequests,
+		Error:      errors.New(`{"error":{"code":"rate_limit_exceeded","message":"too many requests"}}`),
+	}
+	if shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
+		t.Fatal("ordinary rate limit must not trigger transcript replay")
+	}
+}
+
+func TestResponsesWebsocketErrorPayloadPreservesStructuredCodeForReplay(t *testing.T) {
+	payload := []byte(`{"type":"response.failed","response":{"error":{"code":"invalid_prompt","message":"previous response with id 'resp-1' not found"}}}`)
+	errMsg := responsesWebsocketErrorMessageFromPayload(payload)
+	if shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
+		t.Fatal("response.failed with non-previous-response code must not trigger transcript replay")
+	}
+
+	payload = []byte(`{"type":"response.failed","response":{"error":{"code":"previous_response_not_found","message":"previous response missing"}}}`)
+	errMsg = responsesWebsocketErrorMessageFromPayload(payload)
+	if !shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
+		t.Fatal("response.failed with previous_response_not_found code must trigger transcript replay")
+	}
+
+	payload = []byte(`{"type":"error","status":400,"code":"invalid_prompt","message":"previous response with id 'resp-1' not found"}`)
+	errMsg = responsesWebsocketErrorMessageFromPayload(payload)
+	if shouldRetryResponsesWebsocketTranscriptReplay(errMsg) {
+		t.Fatal("top-level non-previous-response code must not trigger transcript replay")
+	}
+}
+
+func TestResponsesWebsocketResponseFailedInfersAuthStatuses(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		status int
+	}{
+		{
+			name:   "rate limit",
+			raw:    `{"type":"response.failed","response":{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded","message":"too many requests"}}}`,
+			status: http.StatusTooManyRequests,
+		},
+		{
+			name:   "insufficient quota",
+			raw:    `{"type":"response.failed","response":{"error":{"code":"insufficient_quota","message":"quota exceeded"}}}`,
+			status: http.StatusTooManyRequests,
+		},
+		{
+			name:   "authentication",
+			raw:    `{"type":"response.failed","response":{"error":{"type":"authentication_error","message":"expired token"}}}`,
+			status: http.StatusUnauthorized,
+		},
+		{
+			name:   "permission",
+			raw:    `{"type":"response.failed","response":{"error":{"type":"permission_error","message":"forbidden"}}}`,
+			status: http.StatusForbidden,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg := responsesWebsocketErrorMessageFromPayload([]byte(tt.raw))
+			if errMsg.StatusCode != tt.status {
+				t.Fatalf("status = %d, want %d", errMsg.StatusCode, tt.status)
+			}
+			if !shouldReleaseResponsesWebsocketPinnedAuth(errMsg) {
+				t.Fatalf("status %d must release pinned auth", tt.status)
+			}
+		})
 	}
 }
 
@@ -3277,7 +5811,79 @@ func TestNormalizeSubsequentRequestCompactSkipsMerge(t *testing.T) {
 	}
 }
 
-func TestNormalizeSubsequentRequestCompactMergesWhenCompactionReplayUnsupported(t *testing.T) {
+func TestNormalizeSubsequentRequestContextCompactionSkipsMergeAndPreviousResponseID(t *testing.T) {
+	lastRequest := []byte(`{"model":"gpt-5.4","stream":true,"input":[
+		{"type":"message","role":"user","id":"msg-1","content":"original long prompt"},
+		{"type":"message","role":"assistant","id":"msg-2","content":"original long response"},
+		{"type":"function_call","id":"fc-1","call_id":"call-old","name":"bash","arguments":"{}"},
+		{"type":"function_call_output","id":"fco-1","call_id":"call-old","output":"old result"}
+	]}`)
+	lastResponseOutput := []byte(`[
+		{"type":"message","role":"assistant","id":"msg-3","content":"another assistant reply"},
+		{"type":"function_call","id":"fc-2","call_id":"call-stale","name":"read","arguments":"{}"}
+	]`)
+
+	raw := []byte(`{"type":"response.create","previous_response_id":"resp-old","input":[
+		{"type":"message","role":"user","id":"msg-1c","content":"compacted user msg"},
+		{"type":"context_compaction","encrypted_content":"conversation summary"}
+	]}`)
+
+	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, true, true, false)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	if gjson.GetBytes(normalized, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id must be removed for compact transcript replacement: %s", normalized)
+	}
+	if !bytes.Equal(next, normalized) {
+		t.Fatalf("next request snapshot should match compact replacement")
+	}
+
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 2 {
+		t.Fatalf("input len = %d, want 2 (compacted only); stale state was not skipped: %s", len(input), normalized)
+	}
+	if input[0].Get("id").String() != "msg-1c" {
+		t.Fatalf("input[0].id = %q, want %q", input[0].Get("id").String(), "msg-1c")
+	}
+	if input[1].Get("type").String() != "context_compaction" {
+		t.Fatalf("input[1].type = %q, want %q", input[1].Get("type").String(), "context_compaction")
+	}
+}
+
+func TestNormalizeSubsequentRequestForcedPlainUserTranscriptReplacementSkipsMerge(t *testing.T) {
+	lastRequest := []byte(`{"model":"gpt-5.4","stream":true,"input":[
+		{"type":"message","role":"user","id":"msg-1","content":"original long prompt"}
+	]}`)
+	lastResponseOutput := []byte(`[
+		{"type":"message","role":"assistant","id":"msg-2","content":"old assistant output"}
+	]`)
+	raw := []byte(`{"type":"response.create","previous_response_id":"resp-old","input":[
+		{"type":"message","role":"user","id":"summary-msg","content":"compacted summary"},
+		{"type":"message","role":"user","id":"msg-3","content":"new question"}
+	]}`)
+
+	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, true, true, true)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	if gjson.GetBytes(normalized, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id must be removed for forced compact replacement: %s", normalized)
+	}
+	if !bytes.Equal(next, normalized) {
+		t.Fatalf("next request snapshot should match forced compact replacement")
+	}
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 2 {
+		t.Fatalf("input len = %d, want 2 replacement items; stale state was merged: %s", len(input), normalized)
+	}
+	if input[0].Get("id").String() != "summary-msg" ||
+		input[1].Get("id").String() != "msg-3" {
+		t.Fatalf("unexpected replacement input order: %s", normalized)
+	}
+}
+
+func TestNormalizeSubsequentRequestCompactUnsupportedSkipsStaleMerge(t *testing.T) {
 	lastRequest := []byte(`{"model":"gpt-5.4","stream":true,"input":[
 		{"type":"message","role":"user","id":"msg-1","content":"original long prompt"},
 		{"type":"message","role":"assistant","id":"msg-2","content":"original long response"},
@@ -3293,26 +5899,154 @@ func TestNormalizeSubsequentRequestCompactMergesWhenCompactionReplayUnsupported(
 		{"type":"compaction","encrypted_content":"conversation summary"}
 	]}`)
 
-	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, false)
+	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, false, false)
 	if errMsg != nil {
 		t.Fatalf("unexpected error: %v", errMsg.Error)
 	}
 
 	input := gjson.GetBytes(normalized, "input").Array()
-	if len(input) != 7 {
-		t.Fatalf("input len = %d, want 7 (merged fallback without compaction items)", len(input))
+	if len(input) != 1 {
+		t.Fatalf("input len = %d, want 1 compact replacement item without stale merge", len(input))
 	}
-	wantIDs := []string{"msg-1", "msg-2", "fc-1", "fco-1", "msg-3", "fc-2", "msg-1c"}
-	for i, want := range wantIDs {
-		got := input[i].Get("id").String()
-		if got != want {
-			t.Fatalf("input[%d].id = %q, want %q", i, got, want)
-		}
+	if input[0].Get("id").String() != "msg-1c" {
+		t.Fatalf("input[0].id = %q, want msg-1c", input[0].Get("id").String())
 	}
 	for _, item := range input {
 		if item.Get("type").String() == "compaction" || item.Get("type").String() == "compaction_summary" {
 			t.Fatalf("compaction items must be stripped for unsupported downstream fallback: %s", item.Raw)
 		}
+	}
+}
+
+func TestNormalizeSubsequentRequestCompactUnsupportedWithAssistantStripsCompaction(t *testing.T) {
+	lastRequest := []byte(`{"model":"gpt-5.4","stream":true,"input":[
+		{"type":"message","role":"user","id":"msg-1","content":"original long prompt"},
+		{"type":"message","role":"assistant","id":"msg-2","content":"original long response"}
+	]}`)
+	lastResponseOutput := []byte(`[
+		{"type":"message","role":"assistant","id":"msg-3","content":"stale assistant reply"}
+	]`)
+	raw := []byte(`{"type":"response.create","input":[
+		{"type":"message","role":"user","id":"msg-1c","content":"compacted user msg"},
+		{"type":"message","role":"assistant","id":"msg-2c","content":"compacted assistant msg"},
+		{"type":"context_compaction","encrypted_content":"conversation summary"},
+		{"type":"message","role":"user","id":"msg-4","content":"question after compact"}
+	]}`)
+
+	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, false, false)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 3 {
+		t.Fatalf("input len = %d, want 3 compact replacement items without stale merge: %s", len(input), normalized)
+	}
+	if input[0].Get("id").String() != "msg-1c" ||
+		input[1].Get("id").String() != "msg-2c" ||
+		input[2].Get("id").String() != "msg-4" {
+		t.Fatalf("unexpected compact replacement input order: %s", normalized)
+	}
+	for _, item := range input {
+		if isResponsesWebsocketCompactionItemType(item.Get("type").String()) {
+			t.Fatalf("compaction items must be stripped before replacement heuristic: %s", normalized)
+		}
+		if item.Get("id").String() == "msg-1" || item.Get("id").String() == "msg-2" || item.Get("id").String() == "msg-3" {
+			t.Fatalf("stale pre-compact state must not be merged into compact transcript: %s", normalized)
+		}
+	}
+}
+
+func TestNormalizeSubsequentRequestCompactUnsupportedDoesNotUsePreviousResponseID(t *testing.T) {
+	lastRequest := []byte(`{"model":"gpt-5.4","stream":true,"input":[
+		{"type":"message","role":"user","id":"msg-1","content":"original long prompt"}
+	]}`)
+	lastResponseOutput := []byte(`[
+		{"type":"message","role":"assistant","id":"msg-2","content":"another assistant reply"}
+	]`)
+	raw := []byte(`{"type":"response.create","previous_response_id":"resp-old","input":[
+		{"type":"message","role":"user","id":"msg-1c","content":"compacted user msg"},
+		{"type":"context_compaction","encrypted_content":"conversation summary"}
+	]}`)
+
+	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, true, false, false)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	if gjson.GetBytes(normalized, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id must be removed for unsupported compact fallback: %s", normalized)
+	}
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 1 {
+		t.Fatalf("input len = %d, want 1 compact replacement item without stale merge: %s", len(input), normalized)
+	}
+	if input[0].Get("id").String() != "msg-1c" {
+		t.Fatalf("input[0].id = %q, want msg-1c", input[0].Get("id").String())
+	}
+	for _, item := range input {
+		if item.Get("type").String() == "context_compaction" {
+			t.Fatalf("context_compaction item must be stripped for unsupported compact fallback: %s", normalized)
+		}
+	}
+}
+
+func TestNormalizeSubsequentRequestForcedCompactUnsupportedStripsCompaction(t *testing.T) {
+	lastRequest := []byte(`{"model":"gpt-5.4","stream":true,"input":[
+		{"type":"message","role":"user","id":"msg-1","content":"original long prompt"},
+		{"type":"message","role":"assistant","id":"msg-2","content":"old response"}
+	]}`)
+	lastResponseOutput := []byte(`[
+		{"type":"message","role":"assistant","id":"msg-3","content":"another assistant reply"}
+	]`)
+	raw := []byte(`{"type":"response.create","previous_response_id":"resp-old","input":[
+		{"type":"message","role":"user","id":"msg-1c","content":"compacted user msg"},
+		{"type":"compaction","encrypted_content":"conversation summary"}
+	]}`)
+
+	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, true, false, true)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	if gjson.GetBytes(normalized, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id must be removed for forced compact fallback: %s", normalized)
+	}
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 1 {
+		t.Fatalf("input len = %d, want 1 compact replacement item without stale merge: %s", len(input), normalized)
+	}
+	if input[0].Get("id").String() != "msg-1c" {
+		t.Fatalf("input[0].id = %q, want msg-1c", input[0].Get("id").String())
+	}
+	for _, item := range input {
+		if item.Get("type").String() == "compaction" {
+			t.Fatalf("compaction item must be stripped for forced unsupported compact fallback: %s", normalized)
+		}
+	}
+}
+
+func TestResponsesWebsocketCompactReplayTrackerConsumesAliasGroup(t *testing.T) {
+	tracker := newResponsesWebsocketCompactReplayTracker(time.Minute)
+	tracker.mark([]string{"client-request", "session-1", "thread-1"})
+
+	if !tracker.has([]string{"session-1"}) {
+		t.Fatal("expected compact replay marker for session alias")
+	}
+	if !tracker.consume([]string{"session-1"}) {
+		t.Fatal("expected compact replay marker to be consumed")
+	}
+	for _, alias := range []string{"client-request", "session-1", "thread-1"} {
+		if tracker.has([]string{alias}) {
+			t.Fatalf("compact replay alias %q should be consumed with its group", alias)
+		}
+	}
+
+	tracker.mark([]string{"session-2", "thread-2"})
+	tracker.mark([]string{"session-2", "thread-3"})
+	if tracker.has([]string{"thread-2"}) {
+		t.Fatal("old alias group should be replaced when a shared alias is re-marked")
+	}
+	if !tracker.has([]string{"thread-3"}) {
+		t.Fatal("new alias group should remain after re-mark")
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -97,6 +97,14 @@ type websocketDirectCaptureExecutor struct {
 	doneOnce sync.Once
 }
 
+type websocketGenerationReplayExecutor struct {
+	mu                         sync.Mutex
+	generation                 uint64
+	streamCalls                int
+	failPreviousResponseOnCall int
+	payloads                   [][]byte
+}
+
 type websocketPinnedFailoverStatusError struct {
 	status int
 	msg    string
@@ -105,6 +113,69 @@ type websocketPinnedFailoverStatusError struct {
 func (e websocketPinnedFailoverStatusError) Error() string { return e.msg }
 
 func (e websocketPinnedFailoverStatusError) StatusCode() int { return e.status }
+
+func (e *websocketGenerationReplayExecutor) Identifier() string { return "codex" }
+
+func (e *websocketGenerationReplayExecutor) UpstreamGeneration(string) uint64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.generation
+}
+
+func (e *websocketGenerationReplayExecutor) BumpGeneration() {
+	e.mu.Lock()
+	e.generation++
+	e.mu.Unlock()
+}
+
+func (e *websocketGenerationReplayExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *websocketGenerationReplayExecutor) ExecuteStream(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.streamCalls++
+	call := e.streamCalls
+	e.payloads = append(e.payloads, bytes.Clone(req.Payload))
+	failPreviousResponse := e.failPreviousResponseOnCall == call
+	e.mu.Unlock()
+
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	if failPreviousResponse {
+		chunks <- coreexecutor.StreamChunk{Err: websocketPinnedFailoverStatusError{
+			status: http.StatusBadRequest,
+			msg:    `{"error":{"message":"previous response with id 'resp-1' not found","type":"invalid_request_error","code":"previous_response_not_found"}}`,
+		}}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+
+	chunks <- coreexecutor.StreamChunk{Payload: []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":"resp-%d","output":[{"type":"message","id":"out-%d"}]}}`, call, call))}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *websocketGenerationReplayExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *websocketGenerationReplayExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *websocketGenerationReplayExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *websocketGenerationReplayExecutor) Payloads() [][]byte {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([][]byte, len(e.payloads))
+	for i := range e.payloads {
+		out[i] = bytes.Clone(e.payloads[i])
+	}
+	return out
+}
 
 func (e *websocketBootstrapFallbackExecutor) Identifier() string { return "test-provider" }
 
@@ -1182,6 +1253,7 @@ func TestForwardResponsesWebsocketPreservesCompletedEvent(t *testing.T) {
 			errCh,
 			timelineLog,
 			"session-1",
+			false,
 		)
 		if err != nil {
 			serverErrCh <- err
@@ -1274,6 +1346,7 @@ func TestForwardResponsesWebsocketTreatsResponseDoneAsTerminalWithoutRewriting(t
 			errCh,
 			timelineLog,
 			"session-1",
+			false,
 		)
 		if err != nil {
 			serverErrCh <- err
@@ -1358,6 +1431,7 @@ func TestForwardResponsesWebsocketTreatsErrorPayloadAsTerminal(t *testing.T) {
 			errCh,
 			newInMemoryWebsocketTimelineLog(),
 			"session-1",
+			false,
 		)
 		if err != nil {
 			serverErrCh <- err
@@ -1449,6 +1523,7 @@ func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing
 			errCh,
 			timelineLog,
 			"session-1",
+			false,
 		)
 		if err == nil {
 			serverErrCh <- errors.New("expected websocket write failure")
@@ -1474,6 +1549,94 @@ func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing
 	defer func() {
 		_ = conn.Close()
 	}()
+
+	if errServer := <-serverErrCh; errServer != nil {
+		t.Fatalf("server error: %v", errServer)
+	}
+}
+
+func TestForwardResponsesWebsocketDoesNotSuppressPreviousResponseErrorAfterPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	serverErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() {
+			errClose := conn.Close()
+			if errClose != nil {
+				serverErrCh <- errClose
+			}
+		}()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte)
+		errCh := make(chan *interfaces.ErrorMessage, 1)
+		go func() {
+			data <- []byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n")
+			errCh <- &interfaces.ErrorMessage{
+				StatusCode: http.StatusBadRequest,
+				Error: websocketPinnedFailoverStatusError{
+					status: http.StatusBadRequest,
+					msg:    `{"error":{"message":"previous response with id 'resp-1' not found","type":"invalid_request_error","code":"previous_response_not_found"}}`,
+				},
+			}
+		}()
+
+		_, _, _, errMsg, err := (*OpenAIResponsesAPIHandler)(nil).forwardResponsesWebsocket(
+			ctx,
+			conn,
+			func(...interface{}) {},
+			data,
+			errCh,
+			newInMemoryWebsocketTimelineLog(),
+			"session-1",
+			true,
+		)
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		if errMsg == nil {
+			serverErrCh <- errors.New("expected previous response error after forwarded payload")
+			return
+		}
+		serverErrCh <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	_, payload, errReadMessage := conn.ReadMessage()
+	if errReadMessage != nil {
+		t.Fatalf("read created websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != "response.created" {
+		t.Fatalf("first payload type = %s, want response.created: %s", got, payload)
+	}
+
+	_, payload, errReadMessage = conn.ReadMessage()
+	if errReadMessage != nil {
+		t.Fatalf("read error websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeError {
+		t.Fatalf("second payload type = %s, want %s: %s", got, wsEventTypeError, payload)
+	}
+	if !strings.Contains(string(payload), "previous_response_not_found") {
+		t.Fatalf("error payload missing previous_response_not_found: %s", payload)
+	}
 
 	if errServer := <-serverErrCh; errServer != nil {
 		t.Fatalf("server error: %v", errServer)
@@ -1577,6 +1740,105 @@ func TestResponsesWebsocketClosesOnCodexUpstreamDisconnect(t *testing.T) {
 	_, _, err = conn.ReadMessage()
 	if err == nil {
 		t.Fatalf("expected downstream websocket to close after upstream disconnect")
+	}
+	closeErr, ok := err.(*websocket.CloseError)
+	if !ok {
+		t.Fatalf("expected websocket close error, got %T: %v", err, err)
+	}
+	if closeErr.Code != websocket.CloseInternalServerErr {
+		t.Fatalf("close code = %d, want %d", closeErr.Code, websocket.CloseInternalServerErr)
+	}
+}
+
+func TestResponsesWebsocketHeartbeatSendsPing(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	done := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		setWaiting := startResponsesWebsocketHeartbeatWithInterval(conn, done, "test-heartbeat", 10*time.Millisecond)
+		setWaiting(true)
+		<-done
+	}))
+	defer server.Close()
+	defer close(done)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	pingCh := make(chan struct{}, 1)
+	conn.SetPingHandler(func(appData string) error {
+		select {
+		case pingCh <- struct{}{}:
+		default:
+		}
+		return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
+	})
+
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-pingCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for heartbeat ping")
+	}
+	_ = conn.Close()
+	<-readDone
+}
+
+func TestResponsesWebsocketHeartbeatDoesNotCloseOnMissingPong(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	done := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		setWaiting := startResponsesWebsocketHeartbeatWithInterval(conn, done, "test-heartbeat-timeout", 10*time.Millisecond)
+		setWaiting(true)
+		<-done
+	}))
+	defer server.Close()
+	defer close(done)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	conn.SetPingHandler(func(string) error {
+		return nil
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, errRead := conn.ReadMessage()
+		errCh <- errRead
+	}()
+
+	select {
+	case errRead := <-errCh:
+		t.Fatalf("unexpected websocket close from missing pong: %v", errRead)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 
@@ -2116,6 +2378,167 @@ func TestResponsesWebsocketDoesNotInjectPreviousResponseIDWhenPendingToolOutputM
 	}
 	if input[0].Get("id").String() != "summary-1" {
 		t.Fatalf("second upstream input item id = %s, want summary-1", input[0].Get("id").String())
+	}
+}
+
+func TestResponsesWebsocketReplaysTranscriptAfterUpstreamGenerationChange(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketGenerationReplayExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-codex",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
+		t.Fatalf("write initial websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := conn.ReadMessage()
+	if errReadMessage != nil {
+		t.Fatalf("read initial websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("initial payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	executor.BumpGeneration()
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
+		t.Fatalf("write follow-up websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = conn.ReadMessage()
+	if errReadMessage != nil {
+		t.Fatalf("read follow-up websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("follow-up payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	payloads := executor.Payloads()
+	if len(payloads) != 2 {
+		t.Fatalf("captured upstream payloads = %d, want 2", len(payloads))
+	}
+	replayed := payloads[1]
+	if gjson.GetBytes(replayed, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id leaked after upstream generation changed: %s", replayed)
+	}
+	input := gjson.GetBytes(replayed, "input").Array()
+	if len(input) != 3 {
+		t.Fatalf("replayed input len = %d, want 3: %s", len(input), replayed)
+	}
+	for _, id := range []string{"msg-1", "out-1", "msg-2"} {
+		if !strings.Contains(gjson.GetBytes(replayed, "input").Raw, fmt.Sprintf(`"id":"%s"`, id)) {
+			t.Fatalf("replayed input missing %s: %s", id, replayed)
+		}
+	}
+}
+
+func TestResponsesWebsocketRetriesPreviousResponseNotFoundWithTranscriptReplay(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketGenerationReplayExecutor{failPreviousResponseOnCall: 2}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-codex",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"test-model","input":[{"type":"message","id":"msg-1"}]}`)); errWrite != nil {
+		t.Fatalf("write initial websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage := conn.ReadMessage()
+	if errReadMessage != nil {
+		t.Fatalf("read initial websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("initial payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`)); errWrite != nil {
+		t.Fatalf("write follow-up websocket message: %v", errWrite)
+	}
+	_, payload, errReadMessage = conn.ReadMessage()
+	if errReadMessage != nil {
+		t.Fatalf("read retried websocket message: %v", errReadMessage)
+	}
+	if got := gjson.GetBytes(payload, "type").String(); got != wsEventTypeCompleted {
+		t.Fatalf("retried payload type = %s, want %s: %s", got, wsEventTypeCompleted, payload)
+	}
+
+	payloads := executor.Payloads()
+	if len(payloads) != 3 {
+		t.Fatalf("captured upstream payloads = %d, want 3", len(payloads))
+	}
+	if got := gjson.GetBytes(payloads[1], "previous_response_id").String(); got != "resp-1" {
+		t.Fatalf("second upstream previous_response_id = %s, want resp-1: %s", got, payloads[1])
+	}
+	replayed := payloads[2]
+	if gjson.GetBytes(replayed, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id leaked after retry replay: %s", replayed)
+	}
+	inputRaw := gjson.GetBytes(replayed, "input").Raw
+	for _, id := range []string{"msg-1", "out-1", "msg-2"} {
+		if !strings.Contains(inputRaw, fmt.Sprintf(`"id":"%s"`, id)) {
+			t.Fatalf("retry replay input missing %s: %s", id, replayed)
+		}
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -19,6 +19,7 @@ const (
 var defaultWebsocketToolOutputCache = newWebsocketToolOutputCache(0, websocketToolOutputCacheMaxPerSession)
 var defaultWebsocketToolCallCache = newWebsocketToolOutputCache(0, websocketToolOutputCacheMaxPerSession)
 var defaultWebsocketToolSessionRefs = newWebsocketToolSessionRefCounter()
+var defaultResponsesWebsocketCompactReplays = newResponsesWebsocketCompactReplayTracker(websocketToolOutputCacheTTL)
 
 type websocketToolOutputCache struct {
 	mu            sync.Mutex
@@ -156,6 +157,268 @@ func websocketDownstreamSessionKey(req *http.Request) string {
 	return ""
 }
 
+func websocketDownstreamSessionKeys(req *http.Request) []string {
+	if req == nil {
+		return nil
+	}
+	var keys []string
+
+	keys = appendWebsocketDownstreamSessionKey(keys, req.Header.Get("X-Client-Request-Id"))
+	keys = appendWebsocketDownstreamTurnMetadataKeys(keys, req.Header.Get("X-Codex-Turn-Metadata"))
+	keys = appendWebsocketDownstreamSessionKey(keys, req.Header.Get("Session-Id"))
+	keys = appendWebsocketDownstreamSessionKey(keys, req.Header.Get("Session_id"))
+	keys = appendWebsocketDownstreamSessionKey(keys, req.Header.Get("Thread-Id"))
+	keys = appendWebsocketDownstreamSessionKey(keys, req.Header.Get("Thread_id"))
+	keys = appendWebsocketDownstreamWindowSessionKey(keys, req.Header.Get("X-Codex-Window-Id"))
+	return keys
+}
+
+func websocketDownstreamSessionKeysWithPayload(req *http.Request, payload []byte) []string {
+	keys := websocketDownstreamSessionKeys(req)
+	if len(payload) == 0 {
+		return keys
+	}
+	keys = appendWebsocketDownstreamSessionKey(keys, gjson.GetBytes(payload, "prompt_cache_key").String())
+	clientMetadata := gjson.GetBytes(payload, "client_metadata")
+	if !clientMetadata.Exists() || clientMetadata.Type != gjson.JSON {
+		return keys
+	}
+	keys = appendWebsocketDownstreamTurnMetadataKeys(keys, clientMetadata.Get("x-codex-turn-metadata").String())
+	keys = appendWebsocketDownstreamWindowSessionKey(keys, clientMetadata.Get("x-codex-window-id").String())
+	return keys
+}
+
+func appendWebsocketDownstreamTurnMetadataKeys(keys []string, raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return keys
+	}
+	keys = appendWebsocketDownstreamSessionKey(keys, gjson.Get(raw, "session_id").String())
+	keys = appendWebsocketDownstreamSessionKey(keys, gjson.Get(raw, "thread_id").String())
+	keys = appendWebsocketDownstreamWindowSessionKey(keys, gjson.Get(raw, "window_id").String())
+	return keys
+}
+
+func appendWebsocketDownstreamWindowSessionKey(keys []string, key string) []string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return keys
+	}
+	keys = appendWebsocketDownstreamTypedSessionKey(keys, "window", key)
+	if promptCacheKey := websocketPromptCacheKeyFromWindowID(key); promptCacheKey != "" {
+		keys = appendWebsocketDownstreamSessionKey(keys, promptCacheKey)
+	}
+	return keys
+}
+
+func websocketPromptCacheKeyFromWindowID(windowID string) string {
+	windowID = strings.TrimSpace(windowID)
+	idx := strings.LastIndex(windowID, ":")
+	if idx < 0 || idx == len(windowID)-1 {
+		return ""
+	}
+	for _, ch := range windowID[idx+1:] {
+		if ch < '0' || ch > '9' {
+			return ""
+		}
+	}
+	return strings.TrimSpace(windowID[:idx])
+}
+
+func appendWebsocketDownstreamTypedSessionKey(keys []string, prefix string, key string) []string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return keys
+	}
+	return appendWebsocketDownstreamSessionKey(keys, prefix+":"+key)
+}
+
+func appendWebsocketDownstreamSessionKey(keys []string, key string) []string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return keys
+	}
+	for _, existing := range keys {
+		if existing == key {
+			return keys
+		}
+	}
+	return append(keys, key)
+}
+
+type responsesWebsocketCompactReplayTracker struct {
+	mu       sync.Mutex
+	ttl      time.Duration
+	sessions map[string]*responsesWebsocketCompactReplayEntry
+}
+
+type responsesWebsocketCompactReplayEntry struct {
+	lastSeen time.Time
+	keys     []string
+}
+
+func newResponsesWebsocketCompactReplayTracker(ttl time.Duration) *responsesWebsocketCompactReplayTracker {
+	if ttl <= 0 {
+		ttl = websocketToolOutputCacheTTL
+	}
+	return &responsesWebsocketCompactReplayTracker{
+		ttl:      ttl,
+		sessions: make(map[string]*responsesWebsocketCompactReplayEntry),
+	}
+}
+
+func (t *responsesWebsocketCompactReplayTracker) mark(keys []string) {
+	if t == nil || len(keys) == 0 {
+		return
+	}
+	now := time.Now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.cleanupLocked(now)
+
+	normalizedKeys := normalizeResponsesWebsocketCompactReplayKeys(keys)
+	if len(normalizedKeys) == 0 {
+		return
+	}
+	for _, key := range normalizedKeys {
+		if existing := t.sessions[key]; existing != nil {
+			t.deleteEntryLocked(existing)
+		}
+	}
+	entry := &responsesWebsocketCompactReplayEntry{
+		lastSeen: now,
+		keys:     normalizedKeys,
+	}
+	for _, key := range normalizedKeys {
+		t.sessions[key] = entry
+	}
+}
+
+func normalizeResponsesWebsocketCompactReplayKeys(keys []string) []string {
+	if len(keys) == 0 {
+		return nil
+	}
+	normalized := make([]string, 0, len(keys))
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		seen := false
+		for _, existing := range normalized {
+			if existing == key {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			normalized = append(normalized, key)
+		}
+	}
+	return normalized
+}
+
+func (t *responsesWebsocketCompactReplayTracker) has(keys []string) bool {
+	if t == nil || len(keys) == 0 {
+		return false
+	}
+	now := time.Now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.cleanupLocked(now)
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, ok := t.sessions[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *responsesWebsocketCompactReplayTracker) consume(keys []string) bool {
+	if t == nil || len(keys) == 0 {
+		return false
+	}
+	now := time.Now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.cleanupLocked(now)
+
+	matched := make(map[*responsesWebsocketCompactReplayEntry]struct{})
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if entry := t.sessions[key]; entry != nil {
+			matched[entry] = struct{}{}
+		}
+	}
+	if len(matched) == 0 {
+		return false
+	}
+	for entry := range matched {
+		t.deleteEntryLocked(entry)
+	}
+	return true
+}
+
+func (t *responsesWebsocketCompactReplayTracker) cleanupLocked(now time.Time) {
+	if t == nil || t.ttl <= 0 {
+		return
+	}
+	seen := make(map[*responsesWebsocketCompactReplayEntry]struct{}, len(t.sessions))
+	for key, entry := range t.sessions {
+		if entry == nil {
+			delete(t.sessions, key)
+			continue
+		}
+		if _, ok := seen[entry]; ok {
+			continue
+		}
+		seen[entry] = struct{}{}
+		if now.Sub(entry.lastSeen) > t.ttl {
+			t.deleteEntryLocked(entry)
+		}
+	}
+}
+
+func (t *responsesWebsocketCompactReplayTracker) deleteEntryLocked(entry *responsesWebsocketCompactReplayEntry) {
+	if t == nil || entry == nil {
+		return
+	}
+	for _, key := range entry.keys {
+		key = strings.TrimSpace(key)
+		if key != "" && t.sessions[key] == entry {
+			delete(t.sessions, key)
+		}
+	}
+}
+
+func markResponsesWebsocketCompactReplayForRequest(req *http.Request, payload []byte) {
+	if defaultResponsesWebsocketCompactReplays == nil {
+		return
+	}
+	defaultResponsesWebsocketCompactReplays.mark(websocketDownstreamSessionKeysWithPayload(req, payload))
+}
+
+func hasResponsesWebsocketCompactReplay(keys []string) bool {
+	if defaultResponsesWebsocketCompactReplays == nil {
+		return false
+	}
+	return defaultResponsesWebsocketCompactReplays.has(keys)
+}
+
+func consumeResponsesWebsocketCompactReplay(keys []string) bool {
+	if defaultResponsesWebsocketCompactReplays == nil {
+		return false
+	}
+	return defaultResponsesWebsocketCompactReplays.consume(keys)
+}
+
 type websocketToolSessionRefCounter struct {
 	mu     sync.Mutex
 	counts map[string]int
@@ -210,6 +473,19 @@ func releaseResponsesWebsocketToolCaches(sessionKey string) {
 		return
 	}
 
+	if defaultWebsocketToolOutputCache != nil {
+		defaultWebsocketToolOutputCache.deleteSession(sessionKey)
+	}
+	if defaultWebsocketToolCallCache != nil {
+		defaultWebsocketToolCallCache.deleteSession(sessionKey)
+	}
+}
+
+func resetResponsesWebsocketToolCaches(sessionKey string) {
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return
+	}
 	if defaultWebsocketToolOutputCache != nil {
 		defaultWebsocketToolOutputCache.deleteSession(sessionKey)
 	}


### PR DESCRIPTION
### Summary

This PR fixes Codex responses websocket recovery when the upstream websocket is reset while the downstream Codex session is
still alive.

Fixes #3584

### What changed

- Split recoverable upstream websocket failures from terminal downstream failures.
- Quietly drop stale upstream connections on idle/read/send recoverable failures instead of closing the downstream websocket
immediately.
- Retry upstream send errors with a fresh websocket before notifying downstream.
- Add downstream websocket heartbeat and explicit close frames for terminal failures.
- Track upstream websocket generation per Codex execution session.
- When the upstream generation changes, disable `previous_response_id` incremental mode and replay the transcript instead.
- Retry `previous_response_not_found` once with transcript replay when no downstream payload has been forwarded yet.
- Avoid retrying after partial downstream output has already been sent.

### Why

The previous implementation could leave the original Codex session hanging after an upstream websocket idle timeout, especially
through proxy chains such as:

```text
Codex CLI -> sing-box -> CPA -> chatgpt.com responses websocket
```

After preserving the downstream session, a new issue appears: a fresh upstream websocket may not recognize the old
previous_response_id. This PR handles that by switching to transcript replay after upstream reset.

### Validation

- Added tests for quiet upstream drop without downstream disconnect.
- Added tests for stale upstream reader handling.
- Added tests for downstream close frame and heartbeat behavior.
- Added tests for upstream generation replay.
- Added tests for previous_response_not_found replay.
- Added tests to ensure replay is not attempted after downstream payloads have already been forwarded.
