### PR TITLE
feat: per-client-key provider access control (openai-compatibility allowed-keys)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -259,6 +259,12 @@ nonstream-keepalive-interval: 0
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
 #     disable-cooling: false # optional: per-provider override for auth/model cooldown scheduling
+#     allowed-keys:          # optional: make this provider private to specific client API keys.
+#       - "your-api-key-1"   # values must match entries in the top-level api-keys list.
+#       # When omitted or empty the provider is public (every client key may use it).
+#       # When set, only the listed client keys can see this provider's models in the
+#       # model listings and route to them; other keys get HTTP 403 (model_not_allowed)
+#       # if they request a model that only this provider serves.
 #     headers:
 #       X-Custom-Header: "custom-value"
 #     api-key-entries:

--- a/internal/config/allowed_keys_test.go
+++ b/internal/config/allowed_keys_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestNormalizeClientKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, nil},
+		{"empty-and-blank", []string{"", "   "}, nil},
+		{"trim", []string{"  key-1 "}, []string{"key-1"}},
+		{"dedupe-preserve-order", []string{"b", "a", "b"}, []string{"b", "a"}},
+		{"case-preserved", []string{"KeyA", "keya"}, []string{"KeyA", "keya"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeClientKeys(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("NormalizeClientKeys(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOpenAICompatibilityAllowedKeysParse(t *testing.T) {
+	const data = `
+openai-compatibility:
+  - name: "linkapi"
+    base-url: "https://api.linkapi.ai/v1"
+    allowed-keys:
+      - "  team-a "
+      - "team-a"
+      - "team-b"
+    models:
+      - name: "gpt-5.5"
+        alias: "gpt-5.5"
+  - name: "public-provider"
+    base-url: "https://example.com/v1"
+    models:
+      - name: "m1"
+        alias: "m1"
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(data), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cfg.SanitizeOpenAICompatibility()
+	if len(cfg.OpenAICompatibility) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(cfg.OpenAICompatibility))
+	}
+	got := cfg.OpenAICompatibility[0].AllowedKeys
+	if want := []string{"team-a", "team-b"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("private provider allowed-keys = %v, want %v (trimmed + deduped)", got, want)
+	}
+	if cfg.OpenAICompatibility[1].AllowedKeys != nil {
+		t.Fatalf("public provider should have no allowed-keys, got %v", cfg.OpenAICompatibility[1].AllowedKeys)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -573,6 +573,13 @@ type OpenAICompatibility struct {
 
 	// DisableCooling disables auth/model cooldown scheduling for this provider when true.
 	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
+
+	// AllowedKeys restricts this provider to the listed client API keys (values from the
+	// top-level api-keys list). When empty or omitted the provider is public and every
+	// client key may see and use its models. When non-empty the provider becomes private:
+	// only the listed client keys can see its models in the model listings and route to
+	// them; any other key is treated as if the provider's models do not exist.
+	AllowedKeys []string `yaml:"allowed-keys,omitempty" json:"allowed-keys,omitempty"`
 }
 
 // OpenAICompatibilityAPIKey represents an API key configuration with optional proxy setting.
@@ -901,6 +908,7 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
 		e.Headers = NormalizeHeaders(e.Headers)
+		e.AllowedKeys = NormalizeClientKeys(e.AllowedKeys)
 		if e.BaseURL == "" {
 			// Skip providers with no base-url; treated as removed
 			continue
@@ -1021,6 +1029,33 @@ func NormalizeExcludedModels(models []string) []string {
 	out := make([]string, 0, len(models))
 	for _, raw := range models {
 		trimmed := strings.ToLower(strings.TrimSpace(raw))
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// NormalizeClientKeys cleans a list of client API keys used for access control
+// (e.g. openai-compatibility.allowed-keys). It trims surrounding whitespace, drops
+// empty entries and removes duplicates while preserving order. Unlike model names,
+// API keys are opaque secrets and are matched case-sensitively, so case is preserved.
+func NormalizeClientKeys(keys []string) []string {
+	if len(keys) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(keys))
+	out := make([]string, 0, len(keys))
+	for _, raw := range keys {
+		trimmed := strings.TrimSpace(raw)
 		if trimmed == "" {
 			continue
 		}

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -122,6 +122,9 @@ type ModelRegistry struct {
 	clientModelInfos map[string]map[string]*ModelInfo
 	// clientProviders maps client ID to its provider identifier
 	clientProviders map[string]string
+	// clientKeyACL maps client ID to the list of client API keys allowed to use it.
+	// An absent or empty entry means the client (provider) is public to every key.
+	clientKeyACL map[string][]string
 	// mutex ensures thread-safe access to the registry
 	mutex *sync.RWMutex
 	// availableModelsCache stores per-handler snapshots for GetAvailableModels.
@@ -142,6 +145,7 @@ func GetGlobalRegistry() *ModelRegistry {
 			clientModels:         make(map[string][]string),
 			clientModelInfos:     make(map[string]map[string]*ModelInfo),
 			clientProviders:      make(map[string]string),
+			clientKeyACL:         make(map[string][]string),
 			availableModelsCache: make(map[string]availableModelsCacheEntry),
 			mutex:                &sync.RWMutex{},
 		}
@@ -627,6 +631,7 @@ func (r *ModelRegistry) unregisterClientInternal(clientID string) {
 
 	delete(r.clientModels, clientID)
 	delete(r.clientModelInfos, clientID)
+	delete(r.clientKeyACL, clientID)
 	if hasProvider {
 		delete(r.clientProviders, clientID)
 	}
@@ -777,7 +782,7 @@ func (r *ModelRegistry) GetAvailableModels(handlerType string) []map[string]any 
 		return cloneModelMaps(cache.models)
 	}
 
-	models, expiresAt := r.buildAvailableModelsLocked(handlerType, now)
+	models, expiresAt := r.buildAvailableModelsLocked(handlerType, now, nil)
 	r.availableModelsCache[handlerType] = availableModelsCacheEntry{
 		models:    cloneModelMaps(models),
 		expiresAt: expiresAt,
@@ -786,11 +791,14 @@ func (r *ModelRegistry) GetAvailableModels(handlerType string) []map[string]any 
 	return models
 }
 
-func (r *ModelRegistry) buildAvailableModelsLocked(handlerType string, now time.Time) ([]map[string]any, time.Time) {
+func (r *ModelRegistry) buildAvailableModelsLocked(handlerType string, now time.Time, allow func(modelID string) bool) ([]map[string]any, time.Time) {
 	models := make([]map[string]any, 0, len(r.models))
 	var expiresAt time.Time
 
-	for _, registration := range r.models {
+	for modelID, registration := range r.models {
+		if allow != nil && !allow(modelID) {
+			continue
+		}
 		availableClients := registration.Count
 
 		expiredClients := 0
@@ -833,6 +841,109 @@ func (r *ModelRegistry) buildAvailableModelsLocked(handlerType string, now time.
 	}
 
 	return models, expiresAt
+}
+
+// SetClientKeyACL records which client API keys may access the given registry client
+// (provider auth). An empty keys slice removes any restriction, making the client public.
+// Keys are matched case-sensitively; callers should pass already-normalized values.
+func (r *ModelRegistry) SetClientKeyACL(clientID string, keys []string) {
+	clientID = strings.TrimSpace(clientID)
+	if clientID == "" {
+		return
+	}
+	cleaned := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if k = strings.TrimSpace(k); k != "" {
+			cleaned = append(cleaned, k)
+		}
+	}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.clientKeyACL == nil {
+		r.clientKeyACL = make(map[string][]string)
+	}
+	if len(cleaned) == 0 {
+		delete(r.clientKeyACL, clientID)
+		return
+	}
+	r.clientKeyACL[clientID] = cleaned
+}
+
+// clientAccessibleToKeyLocked reports whether the given client (provider auth) may be used
+// by the supplied client API key. Clients with no ACL are public.
+func (r *ModelRegistry) clientAccessibleToKeyLocked(clientID, clientKey string) bool {
+	acl := r.clientKeyACL[clientID]
+	if len(acl) == 0 {
+		return true
+	}
+	if clientKey == "" {
+		return false
+	}
+	for _, k := range acl {
+		if k == clientKey {
+			return true
+		}
+	}
+	return false
+}
+
+// GetAvailableModelsForKey returns the available models visible to the supplied client API
+// key, hiding models that are served only by providers private to other keys. When no
+// private providers are configured it is equivalent to GetAvailableModels.
+func (r *ModelRegistry) GetAvailableModelsForKey(handlerType, clientKey string) []map[string]any {
+	clientKey = strings.TrimSpace(clientKey)
+	r.mutex.RLock()
+	if len(r.clientKeyACL) == 0 {
+		r.mutex.RUnlock()
+		return r.GetAvailableModels(handlerType)
+	}
+	visible := make(map[string]struct{})
+	for clientID, modelIDs := range r.clientModels {
+		if !r.clientAccessibleToKeyLocked(clientID, clientKey) {
+			continue
+		}
+		for _, mid := range modelIDs {
+			visible[strings.ToLower(strings.TrimSpace(mid))] = struct{}{}
+		}
+	}
+	allow := func(modelID string) bool {
+		_, ok := visible[strings.ToLower(strings.TrimSpace(modelID))]
+		return ok
+	}
+	models, _ := r.buildAvailableModelsLocked(handlerType, time.Now(), allow)
+	r.mutex.RUnlock()
+	return models
+}
+
+// IsModelAllowedForKey reports whether the supplied client API key may use the given model.
+// It returns false only when the model is provided exclusively by providers that are private
+// to other keys. Unknown models return true so that normal not-found handling applies.
+func (r *ModelRegistry) IsModelAllowedForKey(modelID, clientKey string) bool {
+	modelID = strings.ToLower(strings.TrimSpace(modelID))
+	if modelID == "" {
+		return true
+	}
+	clientKey = strings.TrimSpace(clientKey)
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	if len(r.clientKeyACL) == 0 {
+		return true
+	}
+	known := false
+	for clientID, modelIDs := range r.clientModels {
+		for _, mid := range modelIDs {
+			if strings.ToLower(strings.TrimSpace(mid)) != modelID {
+				continue
+			}
+			known = true
+			if r.clientAccessibleToKeyLocked(clientID, clientKey) {
+				return true
+			}
+			break
+		}
+	}
+	// Unknown model: defer to normal not-found handling. Known but no accessible provider: deny.
+	return !known
 }
 
 func cloneModelMaps(models []map[string]any) []map[string]any {

--- a/internal/registry/model_registry_acl_test.go
+++ b/internal/registry/model_registry_acl_test.go
@@ -1,0 +1,120 @@
+package registry
+
+import (
+	"sort"
+	"testing"
+)
+
+func modelIDSet(models []map[string]any) map[string]bool {
+	out := make(map[string]bool, len(models))
+	for _, m := range models {
+		if id, ok := m["id"].(string); ok {
+			out[id] = true
+		}
+	}
+	return out
+}
+
+func sortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestGetAvailableModelsForKey_PrivateProviderHidden verifies that models served only by a
+// provider with an allow-list are hidden from keys outside the list, while shared models
+// (also served by a public provider) remain visible to everyone.
+func TestGetAvailableModelsForKey_PrivateProviderHidden(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("public-client", "OpenAI", []*ModelInfo{
+		{ID: "shared", OwnedBy: "team"},
+		{ID: "pub-only", OwnedBy: "team"},
+	})
+	r.RegisterClient("private-client", "OpenAI", []*ModelInfo{
+		{ID: "shared", OwnedBy: "team"},
+		{ID: "priv-only", OwnedBy: "team"},
+	})
+	r.SetClientKeyACL("private-client", []string{"keyA"})
+
+	allowed := modelIDSet(r.GetAvailableModelsForKey("openai", "keyA"))
+	if !allowed["shared"] || !allowed["pub-only"] || !allowed["priv-only"] {
+		t.Fatalf("allowed key should see all models, got %v", sortedKeys(allowed))
+	}
+
+	denied := modelIDSet(r.GetAvailableModelsForKey("openai", "keyB"))
+	if !denied["shared"] || !denied["pub-only"] {
+		t.Fatalf("denied key should still see public models, got %v", sortedKeys(denied))
+	}
+	if denied["priv-only"] {
+		t.Fatalf("denied key must not see private-only model, got %v", sortedKeys(denied))
+	}
+
+	empty := modelIDSet(r.GetAvailableModelsForKey("openai", ""))
+	if empty["priv-only"] {
+		t.Fatalf("empty key must not see private-only model, got %v", sortedKeys(empty))
+	}
+}
+
+// TestGetAvailableModelsForKey_NoACLUnchanged verifies that without any private providers the
+// per-key listing is identical to the unfiltered listing.
+func TestGetAvailableModelsForKey_NoACLUnchanged(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("c1", "OpenAI", []*ModelInfo{{ID: "m1", OwnedBy: "team"}})
+
+	full := modelIDSet(r.GetAvailableModels("openai"))
+	perKey := modelIDSet(r.GetAvailableModelsForKey("openai", "anything"))
+	if len(full) != len(perKey) || !perKey["m1"] {
+		t.Fatalf("expected identical listing without ACLs, full=%v perKey=%v", sortedKeys(full), sortedKeys(perKey))
+	}
+}
+
+// TestIsModelAllowedForKey covers allow, deny, shared, public and unknown models.
+func TestIsModelAllowedForKey(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("public-client", "OpenAI", []*ModelInfo{
+		{ID: "shared", OwnedBy: "team"},
+		{ID: "pub-only", OwnedBy: "team"},
+	})
+	r.RegisterClient("private-client", "OpenAI", []*ModelInfo{
+		{ID: "shared", OwnedBy: "team"},
+		{ID: "priv-only", OwnedBy: "team"},
+	})
+	r.SetClientKeyACL("private-client", []string{"keyA"})
+
+	cases := []struct {
+		model string
+		key   string
+		want  bool
+	}{
+		{"priv-only", "keyA", true},
+		{"priv-only", "keyB", false},
+		{"priv-only", "", false},
+		{"shared", "keyB", true},   // also served by public provider
+		{"pub-only", "keyB", true}, // public
+		{"unknown", "keyB", true},  // unknown -> defer to normal not-found handling
+	}
+	for _, tc := range cases {
+		if got := r.IsModelAllowedForKey(tc.model, tc.key); got != tc.want {
+			t.Errorf("IsModelAllowedForKey(%q, %q) = %v, want %v", tc.model, tc.key, got, tc.want)
+		}
+	}
+}
+
+// TestSetClientKeyACL_EmptyClearsRestriction verifies that clearing the ACL makes a provider
+// public again.
+func TestSetClientKeyACL_EmptyClearsRestriction(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("private-client", "OpenAI", []*ModelInfo{{ID: "priv-only", OwnedBy: "team"}})
+	r.SetClientKeyACL("private-client", []string{"keyA"})
+
+	if r.IsModelAllowedForKey("priv-only", "keyB") {
+		t.Fatalf("expected keyB to be denied before clearing ACL")
+	}
+	r.SetClientKeyACL("private-client", nil)
+	if !r.IsModelAllowedForKey("priv-only", "keyB") {
+		t.Fatalf("expected keyB to be allowed after clearing ACL")
+	}
+}

--- a/internal/watcher/synthesizer/allowed_keys_test.go
+++ b/internal/watcher/synthesizer/allowed_keys_test.go
@@ -1,0 +1,63 @@
+package synthesizer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// TestSynthesizeOpenAICompat_AllowedKeysAttribute verifies that a provider's allowed-keys are
+// stamped onto the synthesized auth's "allowed_keys" attribute, and that public providers
+// (no allowed-keys) carry no such attribute.
+func TestSynthesizeOpenAICompat_AllowedKeysAttribute(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.OpenAICompatibility = []config.OpenAICompatibility{
+		{
+			Name:          "linkapi",
+			BaseURL:       "https://api.linkapi.ai/v1",
+			AllowedKeys:   []string{"team-a", "team-b"},
+			APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "sk-linkapi"}},
+			Models:        []config.OpenAICompatibilityModel{{Name: "gpt-5.5", Alias: "gpt-5.5"}},
+		},
+		{
+			Name:          "public",
+			BaseURL:       "https://example.com/v1",
+			APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "sk-pub"}},
+			Models:        []config.OpenAICompatibilityModel{{Name: "m1", Alias: "m1"}},
+		},
+	}
+
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{Config: cfg, Now: time.Now(), IDGenerator: NewStableIDGenerator()}
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("synthesize: %v", err)
+	}
+
+	byName := func(name string) *coreauth.Auth {
+		for _, a := range auths {
+			if a != nil && a.Attributes["compat_name"] == name {
+				return a
+			}
+		}
+		return nil
+	}
+
+	private := byName("linkapi")
+	if private == nil {
+		t.Fatal("expected synthesized auth for linkapi")
+	}
+	if got := private.Attributes["allowed_keys"]; got != "team-a,team-b" {
+		t.Fatalf("linkapi allowed_keys attribute = %q, want %q", got, "team-a,team-b")
+	}
+
+	public := byName("public")
+	if public == nil {
+		t.Fatal("expected synthesized auth for public provider")
+	}
+	if got, ok := public.Attributes["allowed_keys"]; ok {
+		t.Fatalf("public provider should have no allowed_keys attribute, got %q", got)
+	}
+}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -257,6 +257,9 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				attrs["models_hash"] = hash
 			}
 			addConfigHeadersToAttrs(compat.Headers, attrs)
+			if joined := strings.Join(compat.AllowedKeys, ","); joined != "" {
+				attrs["allowed_keys"] = joined
+			}
 			a := &coreauth.Auth{
 				ID:         id,
 				Provider:   providerName,
@@ -296,6 +299,9 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				attrs["models_hash"] = hash
 			}
 			addConfigHeadersToAttrs(compat.Headers, attrs)
+			if joined := strings.Join(compat.AllowedKeys, ","); joined != "" {
+				attrs["allowed_keys"] = joined
+			}
 			a := &coreauth.Auth{
 				ID:         id,
 				Provider:   providerName,

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -131,7 +131,8 @@ func (h *ClaudeCodeAPIHandler) ClaudeCountTokens(c *gin.Context) {
 // Parameters:
 //   - c: The Gin context for the request.
 func (h *ClaudeCodeAPIHandler) ClaudeModels(c *gin.Context) {
-	models := h.Models()
+	// Hide models served only by providers private to other client API keys.
+	models := registry.GetGlobalRegistry().GetAvailableModelsForKey("claude", c.GetString("userApiKey"))
 	firstID := ""
 	lastID := ""
 	if len(models) > 0 {

--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -48,7 +48,8 @@ func (h *GeminiAPIHandler) Models() []map[string]any {
 // GeminiModels handles the Gemini models listing endpoint.
 // It returns a JSON response containing available Gemini models and their specifications.
 func (h *GeminiAPIHandler) GeminiModels(c *gin.Context) {
-	rawModels := h.Models()
+	// Hide models served only by providers private to other client API keys.
+	rawModels := registry.GetGlobalRegistry().GetAvailableModelsForKey("gemini", c.GetString("userApiKey"))
 	normalizedModels := make([]map[string]any, 0, len(rawModels))
 	defaultMethods := []string{"generateContent"}
 	for _, model := range rawModels {

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -560,6 +561,32 @@ func appendAPIResponse(c *gin.Context, data []byte) {
 	c.Set("API_RESPONSE", bytes.Clone(data))
 }
 
+// clientKeyModelAccessError enforces provider allow-lists (openai-compatibility allowed-keys).
+// It returns a 403 permission error when the requested client-facing model is served only by
+// providers private to other client API keys, so callers never reach the routing layer.
+// modelName must be the client-facing model id (alias), which is how models are keyed in the
+// registry. Returns nil when access is permitted or cannot be determined.
+func (h *BaseAPIHandler) clientKeyModelAccessError(ctx context.Context, modelName string) *interfaces.ErrorMessage {
+	base := strings.TrimSpace(thinking.ParseSuffix(modelName).ModelName)
+	if base == "" {
+		base = strings.TrimSpace(modelName)
+	}
+	if base == "" {
+		return nil
+	}
+	clientKey := ""
+	if c, ok := ctx.Value("gin").(*gin.Context); ok && c != nil {
+		clientKey = strings.TrimSpace(c.GetString("userApiKey"))
+	}
+	if registry.GetGlobalRegistry().IsModelAllowedForKey(base, clientKey) {
+		return nil
+	}
+	return &interfaces.ErrorMessage{
+		StatusCode: http.StatusForbidden,
+		Error:      fmt.Errorf("model %q is not allowed for this API key", base),
+	}
+}
+
 // ExecuteWithAuthManager executes a non-streaming request via the core auth manager.
 // This path is the only supported execution route.
 func (h *BaseAPIHandler) ExecuteWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string) ([]byte, http.Header, *interfaces.ErrorMessage) {
@@ -575,6 +602,9 @@ func (h *BaseAPIHandler) executeWithAuthManager(ctx context.Context, handlerType
 	providers, normalizedModel, errMsg := h.getRequestDetailsWithOptions(modelName, allowImageModel)
 	if errMsg != nil {
 		return nil, nil, errMsg
+	}
+	if accessErr := h.clientKeyModelAccessError(ctx, modelName); accessErr != nil {
+		return nil, nil, accessErr
 	}
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = modelName
@@ -625,6 +655,9 @@ func (h *BaseAPIHandler) ExecuteCountWithAuthManager(ctx context.Context, handle
 	providers, normalizedModel, errMsg := h.getRequestDetails(modelName)
 	if errMsg != nil {
 		return nil, nil, errMsg
+	}
+	if accessErr := h.clientKeyModelAccessError(ctx, modelName); accessErr != nil {
+		return nil, nil, accessErr
 	}
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = modelName
@@ -686,6 +719,12 @@ func (h *BaseAPIHandler) executeStreamWithAuthManager(ctx context.Context, handl
 	if errMsg != nil {
 		errChan := make(chan *interfaces.ErrorMessage, 1)
 		errChan <- errMsg
+		close(errChan)
+		return nil, nil, errChan
+	}
+	if accessErr := h.clientKeyModelAccessError(ctx, modelName); accessErr != nil {
+		errChan := make(chan *interfaces.ErrorMessage, 1)
+		errChan <- accessErr
 		close(errChan)
 		return nil, nil, errChan
 	}

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -64,8 +64,10 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 		return
 	}
 
-	// Get all available models
-	allModels := h.Models()
+	// Get the models visible to the requesting client API key. Providers configured with
+	// allowed-keys are hidden from keys that are not in their allow-list.
+	clientKey := c.GetString("userApiKey")
+	allModels := registry.GetGlobalRegistry().GetAvailableModelsForKey("openai", clientKey)
 
 	// Filter to only include the 4 required fields: id, object, created, owned_by
 	filteredModels := make([]map[string]any, len(allModels))

--- a/sdk/cliproxy/auth/allowed_keys_test.go
+++ b/sdk/cliproxy/auth/allowed_keys_test.go
@@ -1,0 +1,28 @@
+package auth
+
+import "testing"
+
+func TestAuthAllowedForClientKey(t *testing.T) {
+	cases := []struct {
+		name string
+		auth *Auth
+		key  string
+		want bool
+	}{
+		{"nil-auth", nil, "k", false},
+		{"no-attributes-public", &Auth{}, "anything", true},
+		{"empty-allowed-keys-public", &Auth{Attributes: map[string]string{"allowed_keys": ""}}, "anything", true},
+		{"listed-key-allowed", &Auth{Attributes: map[string]string{"allowed_keys": "keyA,keyB"}}, "keyA", true},
+		{"unlisted-key-denied", &Auth{Attributes: map[string]string{"allowed_keys": "keyA,keyB"}}, "keyC", false},
+		{"empty-key-denied-when-private", &Auth{Attributes: map[string]string{"allowed_keys": "keyA"}}, "", false},
+		{"csv-whitespace-tolerated", &Auth{Attributes: map[string]string{"allowed_keys": " keyA , keyB "}}, "keyB", true},
+		{"case-sensitive", &Auth{Attributes: map[string]string{"allowed_keys": "KeyA"}}, "keya", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := authAllowedForClientKey(tc.auth, tc.key); got != tc.want {
+				t.Fatalf("authAllowedForClientKey(%v, %q) = %v, want %v", tc.auth, tc.key, got, tc.want)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3014,6 +3014,59 @@ func (m *Manager) routeAwareSelectionRequired(auth *Auth, routeModel string) boo
 	return m.selectionModelKeyForAuth(auth, routeModel) != canonicalModelKey(routeModel)
 }
 
+// clientAPIKeyFromContext extracts the authenticated client API key that the API auth
+// middleware stored on the gin context carried inside ctx. Returns "" when unavailable.
+func clientAPIKeyFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	ginCtx, ok := ctx.Value("gin").(interface{ Get(string) (any, bool) })
+	if !ok || ginCtx == nil {
+		return ""
+	}
+	if raw, exists := ginCtx.Get("userApiKey"); exists {
+		return strings.TrimSpace(contextStringValue(raw))
+	}
+	return ""
+}
+
+// authAllowedForClientKey reports whether the auth (provider) may be used by the given
+// client API key. Auths whose "allowed_keys" attribute is empty are public to every key;
+// otherwise the key must appear in the comma-separated, case-sensitive allow-list.
+func authAllowedForClientKey(auth *Auth, clientKey string) bool {
+	if auth == nil {
+		return false
+	}
+	raw := ""
+	if auth.Attributes != nil {
+		raw = strings.TrimSpace(auth.Attributes["allowed_keys"])
+	}
+	if raw == "" {
+		return true
+	}
+	if clientKey == "" {
+		return false
+	}
+	for _, k := range strings.Split(raw, ",") {
+		if strings.TrimSpace(k) == clientKey {
+			return true
+		}
+	}
+	return false
+}
+
+// errModelNotAllowedForKey is returned when every auth that could serve a model was
+// filtered out solely because the requesting client API key is not in the provider's
+// allow-list. It maps to HTTP 403 so clients receive a clear permission error rather
+// than a generic not-found.
+func errModelNotAllowedForKey() *Error {
+	return &Error{
+		Code:       "model_not_allowed",
+		Message:    "model not allowed for this API key",
+		HTTPStatus: http.StatusForbidden,
+	}
+}
+
 func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
 	if m.HomeEnabled() {
 		auth, exec, _, err := m.pickNextViaHome(ctx, model, opts, tried)
@@ -3039,6 +3092,8 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		}
 	}
 	registryRef := registry.GetGlobalRegistry()
+	clientKey := clientAPIKeyFromContext(ctx)
+	clientKeyBlocked := false
 	for _, candidate := range m.auths {
 		if candidate.Provider != provider || candidate.Disabled {
 			continue
@@ -3055,10 +3110,17 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		if modelKey != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
 			continue
 		}
+		if !authAllowedForClientKey(candidate, clientKey) {
+			clientKeyBlocked = true
+			continue
+		}
 		candidates = append(candidates, candidate)
 	}
 	if len(candidates) == 0 {
 		m.mu.RUnlock()
+		if clientKeyBlocked {
+			return nil, nil, errModelNotAllowedForKey()
+		}
 		return nil, nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
 	available, errAvailable := m.availableAuthsForRouteModel(candidates, provider, model, time.Now())
@@ -3181,6 +3243,8 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		}
 	}
 	registryRef := registry.GetGlobalRegistry()
+	clientKey := clientAPIKeyFromContext(ctx)
+	clientKeyBlocked := false
 	for _, candidate := range m.auths {
 		if candidate == nil || candidate.Disabled {
 			continue
@@ -3207,10 +3271,17 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		if modelKey != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
 			continue
 		}
+		if !authAllowedForClientKey(candidate, clientKey) {
+			clientKeyBlocked = true
+			continue
+		}
 		candidates = append(candidates, candidate)
 	}
 	if len(candidates) == 0 {
 		m.mu.RUnlock()
+		if clientKeyBlocked {
+			return nil, nil, "", errModelNotAllowedForKey()
+		}
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
 	available, errAvailable := m.availableAuthsForRouteModel(candidates, "mixed", model, time.Now())

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -256,8 +256,12 @@ func (s *authScheduler) pickSingle(ctx context.Context, provider, model string, 
 	if shard == nil {
 		return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
+	clientKey := clientAPIKeyFromContext(ctx)
 	predicate := func(entry *scheduledAuth) bool {
 		if entry == nil || entry.auth == nil {
+			return false
+		}
+		if !authAllowedForClientKey(entry.auth, clientKey) {
 			return false
 		}
 		if pinnedAuthID != "" && entry.auth.ID != pinnedAuthID {
@@ -329,7 +333,14 @@ func (s *authScheduler) pickMixed(ctx context.Context, providers []string, model
 		return nil, "", shard.unavailableErrorLocked("mixed", model, predicate)
 	}
 
-	predicate := triedPredicate(tried)
+	basePredicate := triedPredicate(tried)
+	clientKey := clientAPIKeyFromContext(ctx)
+	predicate := func(entry *scheduledAuth) bool {
+		if entry == nil || entry.auth == nil || !authAllowedForClientKey(entry.auth, clientKey) {
+			return false
+		}
+		return basePredicate(entry)
+	}
 	candidateShards := make([]*modelScheduler, len(normalized))
 	bestPriority := 0
 	hasCandidate := false

--- a/sdk/cliproxy/model_registry.go
+++ b/sdk/cliproxy/model_registry.go
@@ -17,6 +17,9 @@ type ModelRegistry interface {
 	ClientSupportsModel(clientID, modelID string) bool
 	GetAvailableModels(handlerType string) []map[string]any
 	GetAvailableModelsByProvider(provider string) []*ModelInfo
+	// SetClientKeyACL records which client API keys may access the given registry client
+	// (provider auth). An empty list makes the client public to every key.
+	SetClientKeyACL(clientID string, keys []string)
 }
 
 // GlobalModelRegistry returns the shared registry instance.

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -456,6 +456,16 @@ func (s *Service) registerResolvedModelsForAuth(a *coreauth.Auth, providerKey st
 		return
 	}
 	GlobalModelRegistry().RegisterClient(a.ID, providerKey, models)
+	// Propagate per-client-key provider access control (openai-compatibility allowed-keys).
+	// The synthesizer stamps the normalized allow-list onto the auth's "allowed_keys"
+	// attribute; an empty attribute clears any restriction (public provider).
+	var allowedKeys []string
+	if a.Attributes != nil {
+		if v := strings.TrimSpace(a.Attributes["allowed_keys"]); v != "" {
+			allowedKeys = strings.Split(v, ",")
+		}
+	}
+	GlobalModelRegistry().SetClientKeyACL(a.ID, allowedKeys)
 }
 
 // rebindExecutors refreshes provider executors so they observe the latest configuration.


### PR DESCRIPTION
## Summary

Adds an optional `allowed-keys` list to `openai-compatibility` providers so a provider can be made **private to specific client API keys**. This implements the request in #1107 (whitelist models/providers for specific API keys) at the provider level.

- **Omitted / empty → public** (every client key may see and use it) — fully backward compatible.
- **Non-empty → private**: only the listed client keys (values from the top-level `api-keys`) can see the provider's models in the model listings and route to them. Other keys never see those models, and an explicit request for a model served **only** by a private provider returns **HTTP 403 `model_not_allowed`**. A model also served by a public provider stays available to everyone via the public provider.
- Client keys are opaque secrets, so matching is exact/case-sensitive (no wildcards).

```yaml
openai-compatibility:
  - name: "linkapi"
    base-url: "https://api.linkapi.ai/v1"
    allowed-keys:
      - "client-key-A"        # one of the top-level api-keys
    api-key-entries:
      - api-key: "sk-linkapi-..."
    models:
      - { name: "gpt-5.5", alias: "gpt-5.5" }
```

## Implementation

The change reuses the existing auth-attribute + registry machinery (the same path `excluded-models` already uses):

- `internal/config`: `OpenAICompatibility.AllowedKeys` + `NormalizeClientKeys` (trim/dedupe, **case-preserving** since keys are secrets), normalized in `SanitizeOpenAICompatibility`.
- `internal/watcher/synthesizer`: stamps the allow-list onto the synthesized auth's `allowed_keys` attribute.
- `internal/registry`: per-client-key ACL (`SetClientKeyACL`) + `GetAvailableModelsForKey` / `IsModelAllowedForKey`.
- `sdk/cliproxy/service`: pushes the ACL into the registry on (re)registration.
- `sdk/cliproxy/auth` (conductor + scheduler): skips auth candidates not permitted for the request's client key (key read from the gin context already on `ctx`).
- `sdk/api/handlers`: a pre-routing 403 guard (`model_not_allowed`) and per-key `/v1/models` filtering for the OpenAI, Gemini and Claude listing endpoints.
- `config.example.yaml`: documents `allowed-keys`.

No changes under `internal/translator/`.

## Tests

- config parse + `NormalizeClientKeys` (string forms, trim, dedupe, case-sensitivity)
- synthesizer attribute stamping (private vs public)
- registry: per-key listing + `IsModelAllowedForKey` (public / private-allowed / private-denied / overlap / unknown)
- conductor allow/deny matcher

`gofmt`, `go vet`, `go build ./cmd/server`, and `go test ./...` all pass.

## Manual verification

Ran a built binary with a private `linkapi` provider (`allowed-keys: [keyA]`) and a public provider:

| Request | keyA (allowed) | keyB (denied) |
|---|---|---|
| `GET /v1/models` | sees `linkapi-*` + public | only public (linkapi hidden) |
| `POST /v1/chat/completions` linkapi model | routes to upstream | **403 `model_not_allowed`** |
| streaming linkapi model | routes to upstream | **403 `model_not_allowed`** |
| public model | works | works |

Companion UI PR (allowed-keys editor): router-for-me/Cli-Proxy-API-Management-Center.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
