### PR TITLE
fix(translator/claude): Anthropic/Bedrock compatibility for OpenAI Responses conversion

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
@@ -51,6 +52,13 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 
 	// Base Claude message payload
 	out := []byte(fmt.Sprintf(`{"model":"","max_tokens":32000,"messages":[],"metadata":{"user_id":"%s"}}`, userID))
+
+	// toolNameMap maps the *Anthropic-safe* name (i.e. what we send upstream)
+	// back to the original Codex tool name. Populated both when we sanitize a
+	// history function_call name and when a namespace tool's qualified name
+	// gets sanitized. Used downstream by tool_choice + by the response-side
+	// translator via setMcpToolNameOnItem to recover the original name.
+	toolNameMap := map[string]string{}
 
 	root := gjson.ParseBytes(rawJSON)
 
@@ -341,7 +349,14 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 				if callID == "" {
 					callID = genToolCallID()
 				}
-				name := item.Get("name").String()
+				rawName := item.Get("name").String()
+				if ns := item.Get("namespace").String(); ns != "" {
+					rawName = qualifyResponsesNamespaceToolName(ns, rawName)
+				}
+				name := sanitizeAnthropicToolName(rawName)
+				if name != rawName {
+					toolNameMap[name] = rawName
+				}
 				argsStr := item.Get("arguments").String()
 
 				toolUse := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
@@ -354,26 +369,144 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 					}
 				}
 
-				asst := []byte(`{"role":"assistant","content":[]}`)
-				for _, partJSON := range pendingReasoningParts {
-					asst, _ = sjson.SetRawBytes(asst, "content.-1", []byte(partJSON))
+				// FIX (parallel-tool-merge): If the last message in the array is already
+				// an assistant message whose content is an array (i.e., a tool_use container),
+				// append this tool_use to that message instead of creating a new assistant
+				// message. This avoids producing consecutive same-role messages, which violate
+				// the Anthropic Messages API requirement that user/assistant strictly alternate
+				// and which AWS Bedrock rejects as TOOL_USE_RESULT_MISMATCH (HTTP 400).
+				appendedToolUse := false
+				if msgsCount := gjson.GetBytes(out, "messages.#").Int(); msgsCount > 0 {
+					lastIdx := msgsCount - 1
+					lastRole := gjson.GetBytes(out, fmt.Sprintf("messages.%d.role", lastIdx)).String()
+					lastContent := gjson.GetBytes(out, fmt.Sprintf("messages.%d.content", lastIdx))
+					if lastRole == "assistant" {
+						// If the previous assistant message stored its content as a
+						// plain string (single-text case), promote it to an array so
+						// the tool_use can be appended instead of forcing a new
+						// consecutive assistant message (which Bedrock rejects with 400).
+						if lastContent.Type == gjson.String {
+							textBlock := []byte(`{"type":"text","text":""}`)
+							textBlock, _ = sjson.SetBytes(textBlock, "text", lastContent.String())
+							out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content", lastIdx), []byte("[]"))
+							out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content.-1", lastIdx), textBlock)
+							lastContent = gjson.GetBytes(out, fmt.Sprintf("messages.%d.content", lastIdx))
+						}
+						if lastContent.IsArray() {
+							// Flush any pending reasoning parts into this same assistant
+							// message *before* the tool_use, so the reasoning stays attached
+							// to the merged tool call instead of being emitted as a separate
+							// assistant message between the tool_use and its tool_result.
+							for _, partJSON := range pendingReasoningParts {
+								out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content.-1", lastIdx), []byte(partJSON))
+							}
+							pendingReasoningParts = nil
+							out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content.-1", lastIdx), toolUse)
+							appendedToolUse = true
+						}
+					}
 				}
-				pendingReasoningParts = nil
-				asst, _ = sjson.SetRawBytes(asst, "content.-1", toolUse)
-				out, _ = sjson.SetRawBytes(out, "messages.-1", asst)
+				if !appendedToolUse {
+					asst := []byte(`{"role":"assistant","content":[]}`)
+					// upstream reasoning-signature: flush any pending reasoning parts
+					// into the new assistant message before the tool_use.
+					for _, partJSON := range pendingReasoningParts {
+						asst, _ = sjson.SetRawBytes(asst, "content.-1", []byte(partJSON))
+					}
+					pendingReasoningParts = nil
+					asst, _ = sjson.SetRawBytes(asst, "content.-1", toolUse)
+					out, _ = sjson.SetRawBytes(out, "messages.-1", asst)
+				}
 
 			case "function_call_output":
 				flushPendingReasoning()
 				// Map to user tool_result
 				callID := item.Get("call_id").String()
-				outputStr := item.Get("output").String()
 				toolResult := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
 				toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", callID)
-				toolResult, _ = sjson.SetBytes(toolResult, "content", outputStr)
+				output := item.Get("output")
+				var resultParts []string
+				if output.IsArray() {
+					output.ForEach(func(_, part gjson.Result) bool {
+						if part.Get("type").String() == "input_image" {
+							url := part.Get("image_url").String()
+							if url == "" {
+								url = part.Get("url").String()
+							}
+							if url == "" {
+								return true
+							}
+							var contentPart []byte
+							if strings.HasPrefix(url, "data:") {
+								trimmed := strings.TrimPrefix(url, "data:")
+								mediaAndData := strings.SplitN(trimmed, ";base64,", 2)
+								mediaType := "application/octet-stream"
+								data := ""
+								if len(mediaAndData) == 2 {
+									if mediaAndData[0] != "" {
+										mediaType = mediaAndData[0]
+									}
+									data = mediaAndData[1]
+								}
+								if data != "" {
+									contentPart = []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
+									contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
+									contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
+								}
+							} else {
+								contentPart = []byte(`{"type":"image","source":{"type":"url","url":""}}`)
+								contentPart, _ = sjson.SetBytes(contentPart, "source.url", url)
+							}
+							if len(contentPart) > 0 {
+								resultParts = append(resultParts, string(contentPart))
+							}
+						} else if t := part.Get("text"); t.Exists() {
+							contentPart := []byte(`{"type":"text","text":""}`)
+							contentPart, _ = sjson.SetBytes(contentPart, "text", t.String())
+							resultParts = append(resultParts, string(contentPart))
+						}
+						return true
+					})
+				}
+				if len(resultParts) > 0 {
+					toolResult, _ = sjson.SetRawBytes(toolResult, "content", []byte("[]"))
+					for _, partJSON := range resultParts {
+						toolResult, _ = sjson.SetRawBytes(toolResult, "content.-1", []byte(partJSON))
+					}
+				} else {
+					toolResult, _ = sjson.SetBytes(toolResult, "content", output.String())
+				}
 
-				usr := []byte(`{"role":"user","content":[]}`)
-				usr, _ = sjson.SetRawBytes(usr, "content.-1", toolResult)
-				out, _ = sjson.SetRawBytes(out, "messages.-1", usr)
+				// FIX (parallel-tool-merge): Mirror of the function_call branch.
+				// If the last message is already a user message whose content is an array
+				// (i.e., a tool_result container), append this tool_result instead of creating
+				// a new user message, to keep user/assistant strictly alternating.
+				appendedToolResult := false
+				if msgsCount := gjson.GetBytes(out, "messages.#").Int(); msgsCount > 0 {
+					lastIdx := msgsCount - 1
+					lastRole := gjson.GetBytes(out, fmt.Sprintf("messages.%d.role", lastIdx)).String()
+					lastContent := gjson.GetBytes(out, fmt.Sprintf("messages.%d.content", lastIdx))
+					if lastRole == "user" {
+						// Promote a string-valued user content to an array first, so the
+						// tool_result merges in instead of creating a consecutive user message.
+						if lastContent.Type == gjson.String {
+							textBlock := []byte(`{"type":"text","text":""}`)
+							textBlock, _ = sjson.SetBytes(textBlock, "text", lastContent.String())
+							out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content", lastIdx), []byte("[]"))
+							out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content.-1", lastIdx), textBlock)
+							lastContent = gjson.GetBytes(out, fmt.Sprintf("messages.%d.content", lastIdx))
+						}
+						if lastContent.IsArray() {
+							out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content.-1", lastIdx), toolResult)
+							appendedToolResult = true
+						}
+					}
+				}
+				if !appendedToolResult {
+					usr := []byte(`{"role":"user","content":[]}`)
+					usr, _ = sjson.SetRawBytes(usr, "content.-1", toolResult)
+					out, _ = sjson.SetRawBytes(out, "messages.-1", usr)
+				}
 			}
 			return true
 		})
@@ -381,7 +514,6 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 	flushPendingReasoning()
 
 	includedToolNames := map[string]struct{}{}
-	toolNameMap := map[string]string{}
 
 	// tools mapping: parameters -> input_schema
 	if tools := root.Get("tools"); tools.Exists() && tools.IsArray() {
@@ -427,7 +559,7 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 				}
 				if _, ok := includedToolNames[fn]; ok {
 					toolChoiceJSON := []byte(`{"name":"","type":"tool"}`)
-					toolChoiceJSON, _ = sjson.SetBytes(toolChoiceJSON, "name", fn)
+					toolChoiceJSON, _ = sjson.SetBytes(toolChoiceJSON, "name", sanitizeAnthropicToolName(fn))
 					out, _ = sjson.SetRawBytes(out, "tool_choice", toolChoiceJSON)
 				}
 			}
@@ -511,6 +643,13 @@ func convertResponsesNamespaceToolToClaude(tool gjson.Result, toolNameMap map[st
 			if childName != "" {
 				toolNameMap[childName] = qualifiedName
 			}
+			// If the qualified name had to be sanitized for Anthropic, also
+			// register the sanitized form so the response-side can recover the
+			// original namespace-qualified name when the model echoes the
+			// sanitized version back in tool_use.name.
+			if cleaned := sanitizeAnthropicToolName(qualifiedName); cleaned != qualifiedName && cleaned != "" {
+				toolNameMap[cleaned] = qualifiedName
+			}
 		}
 		return true
 	})
@@ -526,8 +665,9 @@ func convertResponsesFunctionToolToClaude(tool gjson.Result, overrideName string
 		return nil, false
 	}
 
+	cleanName := sanitizeAnthropicToolName(name)
 	tJSON := []byte(`{"name":"","description":"","input_schema":{}}`)
-	tJSON, _ = sjson.SetBytes(tJSON, "name", name)
+	tJSON, _ = sjson.SetBytes(tJSON, "name", cleanName)
 	if d := responsesToolDescription(tool); d != "" {
 		tJSON, _ = sjson.SetBytes(tJSON, "description", d)
 	}
@@ -545,7 +685,7 @@ func convertResponsesWebSearchToolToClaude(tool gjson.Result) ([]byte, bool) {
 		name = "web_search"
 	}
 	tJSON := []byte(`{"type":"web_search_20250305","name":""}`)
-	tJSON, _ = sjson.SetBytes(tJSON, "name", name)
+	tJSON, _ = sjson.SetBytes(tJSON, "name", sanitizeAnthropicToolName(name))
 	if maxUses := tool.Get("max_uses"); maxUses.Exists() {
 		tJSON, _ = sjson.SetBytes(tJSON, "max_uses", maxUses.Int())
 	}
@@ -606,6 +746,48 @@ func normalizeClaudeToolInputSchema(parameters gjson.Result) []byte {
 		schema, _ = sjson.SetRawBytes(schema, "properties", []byte(`{}`))
 	}
 	return schema
+}
+
+// anthropicToolNameSafeRe matches characters that are NOT allowed in
+// Anthropic tool_use.name (which is constrained to ^[a-zA-Z0-9_-]{1,64}$).
+// Common offenders we have seen in the wild:
+//   - "computer-use:computer-use" (colon comes from a Codex plugin skill mention
+//     [$plugin:skill] being mis-interpreted as a tool name).
+//   - dotted names from non-Anthropic upstreams (e.g. "multi_agent_v1.spawn_agent").
+//   - whitespace from sloppy model output.
+var anthropicToolNameSafeRe = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+
+// sanitizeAnthropicToolName replaces every character that is illegal under the
+// Anthropic Messages API tool name pattern with "__". The mapping is reversible
+// at the response side via splitMcpFlatName + bareCodexInternalLeafToNamespace
+// for known Codex-internal namespaces, and otherwise via toolNameMap when the
+// translator records the original "<sanitized>" -> "<original>" pair.
+//
+// Empty input returns empty (caller is expected to have the usual TrimSpace
+// already done). Names that already match the Anthropic pattern are returned
+// unchanged so that there is zero behavior change for the 99% case.
+func sanitizeAnthropicToolName(name string) string {
+	if name == "" {
+		return name
+	}
+	if !anthropicToolNameSafeRe.MatchString(name) && len(name) <= 64 {
+		return name
+	}
+	cleaned := anthropicToolNameSafeRe.ReplaceAllString(name, "__")
+	// collapse runs of "__" that came from adjacent illegal chars
+	for strings.Contains(cleaned, "____") {
+		cleaned = strings.ReplaceAll(cleaned, "____", "__")
+	}
+	cleaned = strings.Trim(cleaned, "_")
+	if cleaned == "" {
+		// All chars were illegal; fall back to a deterministic placeholder so
+		// the upstream still gets *some* valid name and we don't crash schema.
+		cleaned = "tool"
+	}
+	if len(cleaned) > 64 {
+		cleaned = cleaned[:64]
+	}
+	return cleaned
 }
 
 func qualifyResponsesNamespaceToolName(namespaceName, childName string) string {

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_sanitize_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_sanitize_test.go
@@ -1,0 +1,90 @@
+package responses
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestSanitizeAnthropicToolName_BasicCases(t *testing.T) {
+	cases := map[string]string{
+		"":                              "",
+		"exec_command":                  "exec_command",
+		"mcp__computer_use__list_apps":  "mcp__computer_use__list_apps",
+		"multi_agent_v1__spawn_agent":   "multi_agent_v1__spawn_agent",
+		"computer-use:computer-use":     "computer-use__computer-use",
+		"plugin.skill.name":             "plugin__skill__name",
+		"   spaced name   ":             "spaced__name",
+		"!!!":                           "tool",
+		"a:b:c:d":                       "a__b__c__d",
+		"a..b..c":                       "a__b__c",
+	}
+	for in, want := range cases {
+		got := sanitizeAnthropicToolName(in)
+		if got != want {
+			t.Errorf("sanitizeAnthropicToolName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSanitizeAnthropicToolName_LengthCap(t *testing.T) {
+	long := strings.Repeat("a", 100)
+	got := sanitizeAnthropicToolName(long)
+	if len(got) != 64 {
+		t.Errorf("expected 64-char cap, got %d", len(got))
+	}
+}
+
+func TestSanitizeAnthropicToolName_PreservesValidNames(t *testing.T) {
+	good := []string{"exec_command", "view_image", "apply_patch", "mcp__Serena__find_symbol", "multi_agent_v1__wait_agent"}
+	for _, n := range good {
+		if got := sanitizeAnthropicToolName(n); got != n {
+			t.Errorf("expected passthrough for %q, got %q", n, got)
+		}
+	}
+}
+
+func TestConvertOpenAIResponses_ToolUseNameSanitized(t *testing.T) {
+	body := []byte(`{
+		"model": "kiro-api/claude-opus-4-7-thinking",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+			{"type":"function_call","call_id":"tooluse_xxx","name":"computer-use:computer-use","arguments":"{\"app\":\"/Applications/Tor Browser.app\"}"},
+			{"type":"function_call_output","call_id":"tooluse_xxx","output":"unsupported call: computer-use:computer-use"}
+		],
+		"tools": []
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("kiro-api/claude-opus-4-7-thinking", body, false)
+	gj := gjson.ParseBytes(out)
+	msgs := gj.Get("messages")
+	if !msgs.IsArray() {
+		t.Fatalf("no messages produced: %s", string(out))
+	}
+	found := false
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() != "assistant" {
+			return true
+		}
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(_, blk gjson.Result) bool {
+			if blk.Get("type").String() == "tool_use" {
+				name := blk.Get("name").String()
+				if strings.ContainsAny(name, ":.") {
+					t.Errorf("tool_use.name still contains illegal char: %q", name)
+				}
+				if name == "computer-use__computer-use" {
+					found = true
+				}
+			}
+			return true
+		})
+		return true
+	})
+	if !found {
+		t.Errorf("did not find sanitized tool_use name; full out=%s", string(out))
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -2,12 +2,111 @@ package responses
 
 import (
 	"encoding/base64"
-	"testing"
-
 	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/tidwall/gjson"
 	"google.golang.org/protobuf/encoding/protowire"
+	"testing"
 )
+
+func TestConvertOpenAIResponsesRequestToClaude_PreservesBuiltinWebSearchForNonKiroClaude(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"search"}]}],
+		"tools":[{"type":"web_search"}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, false)
+
+	gotType := gjson.GetBytes(out, "tools.0.type").String()
+	gotName := gjson.GetBytes(out, "tools.0.name").String()
+	if gotType != "web_search_20250305" || gotName != "web_search" {
+		t.Fatalf("expected builtin Claude web search tool, got type=%q name=%q body=%s", gotType, gotName, string(out))
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_FunctionCallOutputImage(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{"type":"function_call_output","call_id":"call_1","output":[
+			{"type":"output_text","text":"here is the image"},
+			{"type":"input_image","image_url":"data:image/png;base64,iVBORw0KGgo="}
+		]}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, false)
+
+	content := gjson.GetBytes(out, "messages.0.content.0.content")
+	if !content.IsArray() {
+		t.Fatalf("expected tool_result.content to be an array, got: %s", string(out))
+	}
+	parts := content.Array()
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 content parts, got %d: %s", len(parts), string(out))
+	}
+	if parts[0].Get("type").String() != "text" || parts[0].Get("text").String() != "here is the image" {
+		t.Fatalf("expected first part text block, got: %s", parts[0].Raw)
+	}
+	if parts[1].Get("type").String() != "image" {
+		t.Fatalf("expected second part image block, got: %s", parts[1].Raw)
+	}
+	if parts[1].Get("source.type").String() != "base64" ||
+		parts[1].Get("source.media_type").String() != "image/png" ||
+		parts[1].Get("source.data").String() != "iVBORw0KGgo=" {
+		t.Fatalf("expected base64 image source, got: %s", parts[1].Raw)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_FunctionCallOutputPlainText(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-7",
+		"input":[{"type":"function_call_output","call_id":"call_2","output":"plain result"}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-opus-4-7", input, false)
+
+	content := gjson.GetBytes(out, "messages.0.content.0.content")
+	if content.IsArray() {
+		t.Fatalf("expected tool_result.content to stay a string, got array: %s", string(out))
+	}
+	if content.String() != "plain result" {
+		t.Fatalf("expected content %q, got %q: %s", "plain result", content.String(), string(out))
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_FunctionCallNamespaceRejoin(t *testing.T) {
+	input := []byte(`{
+		"model":"kiro-api/claude-opus-4-7-thinking",
+		"input":[
+			{"type":"function_call","call_id":"call_js","name":"js","namespace":"mcp__node_repl","arguments":"{}"},
+			{"type":"function_call","call_id":"call_spawn","name":"spawn_agent","namespace":"multi_agent_v1","arguments":"{}"},
+			{"type":"function_call","call_id":"call_exec","name":"exec_command","arguments":"{}"}
+		],
+		"tools":[]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("kiro-api/claude-opus-4-7-thinking", input, false)
+
+	names := make(map[string]bool)
+	gjson.GetBytes(out, "messages").ForEach(func(_, msg gjson.Result) bool {
+		msg.Get("content").ForEach(func(_, blk gjson.Result) bool {
+			if blk.Get("type").String() == "tool_use" {
+				names[blk.Get("name").String()] = true
+			}
+			return true
+		})
+		return true
+	})
+
+	if !names["mcp__node_repl__js"] {
+		t.Errorf("expected rejoined MCP tool name mcp__node_repl__js, got %v; out=%s", names, string(out))
+	}
+	if !names["multi_agent_v1__spawn_agent"] {
+		t.Errorf("expected rejoined codex-internal name multi_agent_v1__spawn_agent, got %v; out=%s", names, string(out))
+	}
+	if !names["exec_command"] {
+		t.Errorf("expected exec_command to pass through unchanged, got %v; out=%s", names, string(out))
+	}
+}
 
 func TestConvertOpenAIResponsesRequestToClaude_ReasoningItemToThinkingBlock(t *testing.T) {
 	rawSignature, expectedSignature := testClaudeResponsesThinkingSignature(t)
@@ -161,4 +260,153 @@ func testGPTResponsesReasoningSignature() string {
 		payload[i] = byte(i)
 	}
 	return base64.URLEncoding.EncodeToString(payload)
+}
+
+// Merge regression: reasoning + parallel tool_use must keep reasoning attached
+// to the assistant message and not leak/duplicate across the parallel calls.
+func TestConvertOpenAIResponsesRequestToClaude_ReasoningWithParallelToolUse(t *testing.T) {
+	rawSignature, _ := testClaudeResponsesThinkingSignature(t)
+	raw := []byte(`{
+		"model":"claude-test",
+		"input":[
+			{"type":"reasoning","encrypted_content":"` + rawSignature + `","summary":[{"type":"summary_text","text":"plan"}]},
+			{"type":"function_call","call_id":"c1","name":"exec_command","arguments":"{}"},
+			{"type":"function_call","call_id":"c2","name":"read_file","arguments":"{}"}
+		]
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+	// thinking blocks across whole output must be exactly 1 (no leak/dup)
+	n := 0
+	gjson.GetBytes(out, "messages").ForEach(func(_, msg gjson.Result) bool {
+		msg.Get("content").ForEach(func(_, c gjson.Result) bool {
+			if c.Get("type").String() == "thinking" {
+				n++
+			}
+			return true
+		})
+		return true
+	})
+	if n != 1 {
+		t.Fatalf("expected exactly 1 thinking block (reasoning not lost/duplicated), got %d; out=%s", n, string(out))
+	}
+	// both tool_use must survive
+	tu := 0
+	gjson.GetBytes(out, "messages").ForEach(func(_, msg gjson.Result) bool {
+		msg.Get("content").ForEach(func(_, c gjson.Result) bool {
+			if c.Get("type").String() == "tool_use" {
+				tu++
+			}
+			return true
+		})
+		return true
+	})
+	if tu != 2 {
+		t.Fatalf("expected 2 tool_use (parallel merge), got %d; out=%s", tu, string(out))
+	}
+}
+
+// Regression: a single-text assistant message is stored with string content
+// (see the single-text legacy path). A following function_call must still merge
+// into that message instead of creating a consecutive assistant message, which
+// Bedrock rejects with TOOL_USE_RESULT_MISMATCH (HTTP 400).
+func TestConvertOpenAIResponsesRequestToClaude_MergeToolUseIntoStringContent(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-test",
+		"input":[
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"thinking out loud"}]},
+			{"type":"function_call","call_id":"c1","name":"exec_command","arguments":"{}"}
+		]
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+	// no two consecutive assistant messages
+	var prevRole string
+	consecutive := false
+	gjson.GetBytes(out, "messages").ForEach(func(_, msg gjson.Result) bool {
+		r := msg.Get("role").String()
+		if r == "assistant" && prevRole == "assistant" {
+			consecutive = true
+		}
+		prevRole = r
+		return true
+	})
+	if consecutive {
+		t.Fatalf("found consecutive assistant messages (string-content merge failed); out=%s", string(out))
+	}
+	// tool_use must survive and the original text must be preserved
+	tu, hasText := 0, false
+	gjson.GetBytes(out, "messages").ForEach(func(_, msg gjson.Result) bool {
+		msg.Get("content").ForEach(func(_, c gjson.Result) bool {
+			switch c.Get("type").String() {
+			case "tool_use":
+				tu++
+			case "text":
+				if c.Get("text").String() == "thinking out loud" {
+					hasText = true
+				}
+			}
+			return true
+		})
+		return true
+	})
+	if tu != 1 {
+		t.Fatalf("expected tool_use to survive merge, got %d; out=%s", tu, string(out))
+	}
+	if !hasText {
+		t.Fatalf("original assistant text lost during string->array promotion; out=%s", string(out))
+	}
+}
+
+// Regression for the merged-tool-call + pending-reasoning interaction:
+// when an assistant text item is followed by a reasoning item and a function_call,
+// the tool_use must merge into the prior assistant message AND carry the reasoning
+// in the same message — otherwise the later function_call_output flush inserts a
+// thinking message between tool_use and tool_result, breaking the sequence.
+func TestConvertOpenAIResponsesRequestToClaude_ReasoningAttachedToMergedToolCall(t *testing.T) {
+	rawSignature, _ := testClaudeResponsesThinkingSignature(t)
+	raw := []byte(`{
+		"model":"claude-test",
+		"input":[
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"let me check"}]},
+			{"type":"reasoning","encrypted_content":"` + rawSignature + `","summary":[{"type":"summary_text","text":"plan"}]},
+			{"type":"function_call","call_id":"c1","name":"exec_command","arguments":"{}"},
+			{"type":"function_call_output","call_id":"c1","output":"done"}
+		]
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+	// roles must strictly alternate (no consecutive same-role); and there must be
+	// no standalone assistant thinking message wedged between tool_use and tool_result.
+	roles := []string{}
+	gjson.GetBytes(out, "messages").ForEach(func(_, m gjson.Result) bool {
+		roles = append(roles, m.Get("role").String())
+		return true
+	})
+	for i := 1; i < len(roles); i++ {
+		if roles[i] == roles[i-1] {
+			t.Fatalf("consecutive same-role messages %v; out=%s", roles, string(out))
+		}
+	}
+	// the assistant message that holds the tool_use must also hold the thinking block
+	foundMerged := false
+	gjson.GetBytes(out, "messages").ForEach(func(_, m gjson.Result) bool {
+		if m.Get("role").String() != "assistant" {
+			return true
+		}
+		hasTool, hasThinking := false, false
+		m.Get("content").ForEach(func(_, c gjson.Result) bool {
+			switch c.Get("type").String() {
+			case "tool_use":
+				hasTool = true
+			case "thinking":
+				hasThinking = true
+			}
+			return true
+		})
+		if hasTool && hasThinking {
+			foundMerged = true
+		}
+		return true
+	})
+	if !foundMerged {
+		t.Fatalf("reasoning not attached to the merged tool_use message; out=%s", string(out))
+	}
 }

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -39,9 +39,61 @@ type claudeToResponsesState struct {
 	InputTokens  int64
 	OutputTokens int64
 	UsageSeen    bool
+	// web_search aggregation (server_tool_use + web_search_tool_result)
+	WebSearchID      string
+	WebSearchQuery   string
+	WebSearchItems   [][]byte // completed web_search_call items for output aggregation
 }
 
 var dataTag = []byte("data:")
+
+// webSearchToolName is the Anthropic server_tool_use name CPA translates into an
+// OpenAI Responses web_search_call item.
+const webSearchToolName = "web_search"
+
+// buildWebSearchCallItem builds an OpenAI Responses web_search_call output item.
+// The host (codex) parses {id?, status?, action:{type:"search",query,queries}};
+// it ignores unknown fields, so search results are attached under "result" to
+// preserve title/url/encrypted_content/page_age without breaking deserialization.
+func buildWebSearchCallItem(id, query, status string, results []byte) []byte {
+	item := []byte(`{"id":"","type":"web_search_call","status":"","action":{"type":"search"}}`)
+	if id != "" {
+		item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ws_%s", id))
+	}
+	item, _ = sjson.SetBytes(item, "status", status)
+	if query != "" {
+		item, _ = sjson.SetBytes(item, "action.query", query)
+		item, _ = sjson.SetBytes(item, "action.queries.-1", query)
+	}
+	if len(results) > 0 {
+		item, _ = sjson.SetRawBytes(item, "result", results)
+	}
+	return item
+}
+
+// buildWebSearchResultArray maps Anthropic web_search_result entries into a JSON
+// array, preserving title/url/encrypted_content/page_age (no native OpenAI slot,
+// so kept verbatim under the web_search_call item's "result" field).
+func buildWebSearchResultArray(content gjson.Result) []byte {
+	arr := []byte(`[]`)
+	if !content.IsArray() {
+		return arr
+	}
+	content.ForEach(func(_, r gjson.Result) bool {
+		entry := []byte(`{}`)
+		entry, _ = sjson.SetBytes(entry, "title", r.Get("title").String())
+		entry, _ = sjson.SetBytes(entry, "url", r.Get("url").String())
+		if enc := r.Get("encrypted_content"); enc.Exists() {
+			entry, _ = sjson.SetBytes(entry, "encrypted_content", enc.String())
+		}
+		if pageAge := r.Get("page_age"); pageAge.Exists() && pageAge.Type != gjson.Null {
+			entry, _ = sjson.SetBytes(entry, "page_age", pageAge.String())
+		}
+		arr, _ = sjson.SetRawBytes(arr, "-1", entry)
+		return true
+	})
+	return arr
+}
 
 func pickRequestJSON(originalRequestRawJSON, requestRawJSON []byte) []byte {
 	if len(originalRequestRawJSON) > 0 && gjson.ValidBytes(originalRequestRawJSON) {
@@ -99,6 +151,9 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			st.InputTokens = 0
 			st.OutputTokens = 0
 			st.UsageSeen = false
+			st.WebSearchID = ""
+			st.WebSearchQuery = ""
+			st.WebSearchItems = nil
 			if usage := msg.Get("usage"); usage.Exists() {
 				if v := usage.Get("input_tokens"); v.Exists() {
 					st.InputTokens = v.Int()
@@ -183,6 +238,30 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			part, _ = sjson.SetBytes(part, "output_index", idx)
 			out = append(out, emitEvent("response.reasoning_summary_part.added", part))
 			st.ReasoningPartAdded = true
+		} else if typ == "server_tool_use" && cb.Get("name").String() == webSearchToolName {
+			// Anthropic server_tool_use(web_search): input arrives complete here
+			// (no input_json_delta), so emit an in_progress web_search_call item.
+			st.WebSearchID = cb.Get("id").String()
+			st.WebSearchQuery = cb.Get("input.query").String()
+			item := buildWebSearchCallItem(st.WebSearchID, st.WebSearchQuery, "in_progress", nil)
+			added := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{}}`)
+			added, _ = sjson.SetBytes(added, "sequence_number", nextSeq())
+			added, _ = sjson.SetBytes(added, "output_index", idx)
+			added, _ = sjson.SetRawBytes(added, "item", item)
+			out = append(out, emitEvent("response.output_item.added", added))
+		} else if typ == "web_search_tool_result" {
+			// Anthropic web_search_tool_result: results arrive complete here. Emit a
+			// completed web_search_call item carrying the mapped results.
+			results := buildWebSearchResultArray(cb.Get("content"))
+			item := buildWebSearchCallItem(st.WebSearchID, st.WebSearchQuery, "completed", results)
+			st.WebSearchItems = append(st.WebSearchItems, item)
+			done := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{}}`)
+			done, _ = sjson.SetBytes(done, "sequence_number", nextSeq())
+			done, _ = sjson.SetBytes(done, "output_index", idx)
+			done, _ = sjson.SetRawBytes(done, "item", item)
+			out = append(out, emitEvent("response.output_item.done", done))
+			st.WebSearchID = ""
+			st.WebSearchQuery = ""
 		}
 	case "content_block_delta":
 		d := root.Get("delta")
@@ -442,6 +521,10 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
 			}
 		}
+		// web_search_call items (completed during the message)
+		for _, item := range st.WebSearchItems {
+			outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
+		}
 		if gjson.GetBytes(outputsWrapper, "arr.#").Int() > 0 {
 			completed, _ = sjson.SetRawBytes(completed, "response.output", []byte(gjson.GetBytes(outputsWrapper, "arr").Raw))
 		}
@@ -518,6 +601,13 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 	}
 	toolCalls := make(map[int]*toolState)
 
+	// web_search aggregation (server_tool_use + web_search_tool_result)
+	var (
+		webSearchID    string
+		webSearchQuery string
+		webSearchItems [][]byte
+	)
+
 	// Walk through SSE chunks to fill state
 	for _, ch := range chunks {
 		root := gjson.ParseBytes(ch)
@@ -559,6 +649,16 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 				if signature := cb.Get("signature"); signature.Exists() && signature.String() != "" {
 					reasoningSig = signature.String()
 				}
+			case "server_tool_use":
+				if cb.Get("name").String() == webSearchToolName {
+					webSearchID = cb.Get("id").String()
+					webSearchQuery = cb.Get("input.query").String()
+				}
+			case "web_search_tool_result":
+				results := buildWebSearchResultArray(cb.Get("content"))
+				webSearchItems = append(webSearchItems, buildWebSearchCallItem(webSearchID, webSearchQuery, "completed", results))
+				webSearchID = ""
+				webSearchQuery = ""
 			}
 
 		case "content_block_delta":
@@ -721,6 +821,9 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 			outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
 		}
 	}
+	for _, item := range webSearchItems {
+		outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
+	}
 	if gjson.GetBytes(outputsWrapper, "arr.#").Int() > 0 {
 		out, _ = sjson.SetRawBytes(out, "output", []byte(gjson.GetBytes(outputsWrapper, "arr").Raw))
 	}
@@ -740,3 +843,4 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 
 	return out
 }
+

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response_websearch_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response_websearch_test.go
@@ -1,0 +1,152 @@
+package responses
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// Streaming: Anthropic server_tool_use(web_search) + web_search_tool_result must
+// translate into OpenAI web_search_call items (in_progress added, completed done).
+func TestConvertClaudeResponse_StreamWebSearch(t *testing.T) {
+	lines := []string{
+		`data: {"type":"message_start","message":{"id":"msg_ws","usage":{"input_tokens":5}}}`,
+		`data: {"type":"content_block_start","index":1,"content_block":{"id":"srvtoolu_abc","type":"server_tool_use","name":"web_search","input":{"query":"weather seattle"}}}`,
+		`data: {"type":"content_block_stop","index":1}`,
+		`data: {"type":"content_block_start","index":2,"content_block":{"type":"web_search_tool_result","content":[{"type":"web_search_result","title":"Seattle Weather","url":"https://example.com/wx","encrypted_content":"sunny 60F","page_age":"October 7, 2025"}]}}`,
+		`data: {"type":"content_block_stop","index":2}`,
+		`data: {"type":"message_stop"}`,
+	}
+
+	var state any
+	var added, doneItem, completed string
+	for _, ln := range lines {
+		evs := ConvertClaudeResponseToOpenAIResponses(context.Background(), "claude", nil, nil, []byte(ln), &state)
+		for _, e := range evs {
+			s := string(e)
+			if strings.Contains(s, `"web_search_call"`) && strings.Contains(s, "response.output_item.added") {
+				added = s
+			}
+			if strings.Contains(s, `"web_search_call"`) && strings.Contains(s, "response.output_item.done") {
+				doneItem = s
+			}
+			if strings.Contains(s, "response.completed") {
+				completed = s
+			}
+		}
+	}
+
+	if added == "" {
+		t.Fatal("expected an in_progress web_search_call output_item.added event")
+	}
+	addedPayload := added[strings.Index(added, "{"):]
+	if got := gjson.Get(addedPayload, "item.status").String(); got != "in_progress" {
+		t.Fatalf("added status = %q, want in_progress: %s", got, addedPayload)
+	}
+	if got := gjson.Get(addedPayload, "item.action.query").String(); got != "weather seattle" {
+		t.Fatalf("added action.query = %q, want weather seattle: %s", got, addedPayload)
+	}
+	if got := gjson.Get(addedPayload, "item.action.queries.0").String(); got != "weather seattle" {
+		t.Fatalf("added action.queries[0] = %q, want weather seattle", got)
+	}
+	if got := gjson.Get(addedPayload, "item.id").String(); got != "ws_srvtoolu_abc" {
+		t.Fatalf("added item.id = %q, want ws_srvtoolu_abc", got)
+	}
+
+	if doneItem == "" {
+		t.Fatal("expected a completed web_search_call output_item.done event")
+	}
+	donePayload := doneItem[strings.Index(doneItem, "{"):]
+	if got := gjson.Get(donePayload, "item.status").String(); got != "completed" {
+		t.Fatalf("done status = %q, want completed: %s", got, donePayload)
+	}
+	if got := gjson.Get(donePayload, "item.result.0.title").String(); got != "Seattle Weather" {
+		t.Fatalf("done result[0].title = %q, want Seattle Weather: %s", got, donePayload)
+	}
+	if got := gjson.Get(donePayload, "item.result.0.url").String(); got != "https://example.com/wx" {
+		t.Fatalf("done result[0].url = %q", got)
+	}
+	if got := gjson.Get(donePayload, "item.result.0.encrypted_content").String(); got != "sunny 60F" {
+		t.Fatalf("done result[0].encrypted_content = %q (must not be dropped)", got)
+	}
+	if got := gjson.Get(donePayload, "item.result.0.page_age").String(); got != "October 7, 2025" {
+		t.Fatalf("done result[0].page_age = %q (must not be dropped)", got)
+	}
+
+	// The web_search_call item must also appear in the final response.output.
+	if completed == "" {
+		t.Fatal("expected response.completed event")
+	}
+	cp := completed[strings.Index(completed, "{"):]
+	found := false
+	gjson.Get(cp, "response.output").ForEach(func(_, v gjson.Result) bool {
+		if v.Get("type").String() == "web_search_call" && v.Get("status").String() == "completed" {
+			found = true
+		}
+		return true
+	})
+	if !found {
+		t.Fatalf("response.output missing completed web_search_call: %s", cp)
+	}
+}
+
+// Non-stream: aggregated output must contain a completed web_search_call item.
+func TestConvertClaudeResponseNonStream_WebSearch(t *testing.T) {
+	raw := strings.Join([]string{
+		`data: {"type":"message_start","message":{"id":"msg_ws2","usage":{"input_tokens":3}}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"id":"srvtoolu_x","type":"server_tool_use","name":"web_search","input":{"query":"golang sjson"}}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","content":[{"type":"web_search_result","title":"sjson docs","url":"https://github.com/tidwall/sjson","encrypted_content":"set json values fast","page_age":null}]}}`,
+		`data: {"type":"content_block_stop","index":1}`,
+		`data: {"type":"message_stop"}`,
+	}, "\n")
+
+	var state any
+	out := ConvertClaudeResponseToOpenAIResponsesNonStream(context.Background(), "claude", nil, nil, []byte(raw), &state)
+
+	var item gjson.Result
+	gjson.GetBytes(out, "output").ForEach(func(_, v gjson.Result) bool {
+		if v.Get("type").String() == "web_search_call" {
+			item = v
+		}
+		return true
+	})
+	if !item.Exists() {
+		t.Fatalf("non-stream output missing web_search_call: %s", string(out))
+	}
+	if got := item.Get("status").String(); got != "completed" {
+		t.Fatalf("status = %q, want completed", got)
+	}
+	if got := item.Get("action.query").String(); got != "golang sjson" {
+		t.Fatalf("action.query = %q, want golang sjson", got)
+	}
+	if got := item.Get("result.0.title").String(); got != "sjson docs" {
+		t.Fatalf("result[0].title = %q", got)
+	}
+	if got := item.Get("result.0.encrypted_content").String(); got != "set json values fast" {
+		t.Fatalf("result[0].encrypted_content = %q (must not be dropped)", got)
+	}
+	// page_age was null upstream -> must be omitted, not "null" string.
+	if item.Get("result.0.page_age").Exists() {
+		t.Fatalf("result[0].page_age should be omitted when upstream null: %s", item.Raw)
+	}
+}
+
+// Regression: a normal (non-web_search) tool_use must still produce a function_call,
+// never a web_search_call.
+func TestConvertClaudeResponseNonStream_NormalToolUseUnaffected(t *testing.T) {
+	raw := strings.Join([]string{
+		`data: {"type":"message_start","message":{"id":"msg_t"}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"id":"toolu_1","type":"tool_use","name":"exec_command"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"cmd\":\"ls\"}"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"message_stop"}`,
+	}, "\n")
+	var state any
+	out := ConvertClaudeResponseToOpenAIResponsesNonStream(context.Background(), "claude", nil, nil, []byte(raw), &state)
+	if gjson.GetBytes(out, "output.0.type").String() != "function_call" {
+		t.Fatalf("normal tool_use must stay function_call: %s", string(out))
+	}
+}


### PR DESCRIPTION
## What

Three correctness fixes in the OpenAI Responses → Claude (Anthropic/Bedrock) request translation:

1. **Tool-name sanitization** — `sanitizeAnthropicToolName` strips characters that are illegal under Anthropic's tool-name regex (e.g. colons). Tool names containing a colon currently cause a `400`.
2. **Parallel tool_use / tool_result merge** — consecutive `function_call` / `function_call_output` items in the same turn are merged into a single assistant/user message instead of creating one message each. Separate messages violate Anthropic's alternation rule and trigger Bedrock `TOOL_USE_RESULT_MISMATCH` (`400`).
3. **`input_image` in `function_call_output`** — converted into a proper Claude `tool_result` image block.

## Why

When a client (e.g. an agent harness) sends parallel tool calls or tool names with colons through the Responses→Claude path, Bedrock rejects the request with a `400`. These are general protocol-compatibility issues, not specific to any deployment.

## Tests

Added regression tests:
- `claude_openai-responses_request_sanitize_test.go`
- `claude_openai-responses_response_websearch_test.go`
- extended `claude_openai-responses_request_test.go`

`go build ./...` clean; `go test ./internal/translator/...` passes.
