### PR TITLE
fix(executor): normalize SSE event ordering for openai-compat models

### DIFF
--- a/internal/runtime/executor/helps/sse_normalize.go
+++ b/internal/runtime/executor/helps/sse_normalize.go
@@ -26,13 +26,11 @@ type SSENormalizer struct {
 }
 
 // sseEventType extracts the event type from an SSE "event:" line.
+// Handles both "event: type" and "event:type" with optional extra whitespace.
 func sseEventType(line []byte) string {
 	trimmed := bytes.TrimSpace(line)
-	if bytes.HasPrefix(trimmed, []byte("event: ")) {
-		return string(bytes.TrimPrefix(trimmed, []byte("event: ")))
-	}
 	if bytes.HasPrefix(trimmed, []byte("event:")) {
-		return string(bytes.TrimPrefix(trimmed, []byte("event:")))
+		return string(bytes.TrimSpace(bytes.TrimPrefix(trimmed, []byte("event:"))))
 	}
 	return ""
 }

--- a/internal/runtime/executor/helps/sse_normalize.go
+++ b/internal/runtime/executor/helps/sse_normalize.go
@@ -1,0 +1,180 @@
+package helps
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// SSENormalizer buffers and reorders Claude SSE events to ensure
+// message_stop is always the last event in the stream.
+//
+// Some upstream models (e.g. Baidu-glm-5.1, Tencent-glm-5.1) emit
+// content blocks after message_stop, violating the Anthropic SSE protocol:
+//
+//	...content_block_* → message_delta → message_stop → content_block_* → message_delta
+//
+// Strategy: once we see the first message_delta (which signals the start of
+// the stream epilog), we buffer everything. On Flush, we reorder the buffer
+// so all content_block events come first, then message_delta, then message_stop.
+// For correctly-ordered streams, this is a no-op (buffer is already in order).
+type SSENormalizer struct {
+	buffering bool // true after first message_delta is seen
+	buffer    [][]byte
+}
+
+// sseEventType extracts the event type from an SSE "event:" line.
+func sseEventType(line []byte) string {
+	trimmed := bytes.TrimSpace(line)
+	if bytes.HasPrefix(trimmed, []byte("event: ")) {
+		return string(bytes.TrimPrefix(trimmed, []byte("event: ")))
+	}
+	if bytes.HasPrefix(trimmed, []byte("event:")) {
+		return string(bytes.TrimPrefix(trimmed, []byte("event:")))
+	}
+	return ""
+}
+
+// ProcessLine processes a single SSE line and returns lines to emit.
+// After the first message_delta, all subsequent lines are buffered
+// until Flush is called.
+func (n *SSENormalizer) ProcessLine(line []byte) [][]byte {
+	eventType := sseEventType(line)
+
+	// Start buffering when we see the first message_delta.
+	// message_delta is only emitted in the epilog of a Claude stream,
+	// so all subsequent events (including message_stop and any
+	// misplaced content blocks) should be buffered for reordering.
+	if eventType == "message_delta" && !n.buffering {
+		n.buffering = true
+	}
+
+	if n.buffering {
+		// A new message_start means a brand new message; flush current buffer first.
+		if eventType == "message_start" {
+			result := n.Flush()
+			return append(result, line)
+		}
+		n.buffer = append(n.buffer, append([]byte(nil), line...))
+		return nil
+	}
+
+	return [][]byte{line}
+}
+
+// Flush emits all buffered events in the correct order.
+// Content block events come first, then message_delta, then message_stop.
+// Must be called after the last ProcessLine.
+func (n *SSENormalizer) Flush() [][]byte {
+	if !n.buffering || len(n.buffer) == 0 {
+		n.buffering = false
+		n.buffer = nil
+		return nil
+	}
+
+	// Classify buffered lines by tracking the current event: type.
+	currentType := ""
+	var contentLines [][]byte
+	var deltaLines [][]byte
+	var stopLines [][]byte
+	var otherLines [][]byte
+
+	for _, line := range n.buffer {
+		et := sseEventType(line)
+		if et != "" {
+			currentType = et
+		}
+
+		switch currentType {
+		case "content_block_start", "content_block_delta", "content_block_stop":
+			contentLines = append(contentLines, line)
+		case "message_delta":
+			deltaLines = append(deltaLines, line)
+		case "message_stop":
+			stopLines = append(stopLines, line)
+		default:
+			otherLines = append(otherLines, line)
+		}
+	}
+
+	var result [][]byte
+	result = append(result, contentLines...)
+	result = append(result, deltaLines...)
+	result = append(result, stopLines...)
+	result = append(result, otherLines...)
+
+	n.buffering = false
+	n.buffer = nil
+
+	return result
+}
+
+// NormalizeNonStreamContentOrder reorders content blocks in a non-stream
+// Claude API response so that thinking blocks come before text blocks,
+// matching the Anthropic protocol convention.
+//
+// Some models return content in [text, thinking] order instead of
+// [thinking, text]. This function normalizes to [thinking, text, tool_use].
+func NormalizeNonStreamContentOrder(data []byte) []byte {
+	content := gjson.GetBytes(data, "content")
+	if !content.Exists() || !content.IsArray() {
+		return data
+	}
+
+	arr := content.Array()
+	if len(arr) <= 1 {
+		return data
+	}
+
+	// Check if any thinking block appears after a text block.
+	needReorder := false
+	seenText := false
+	for _, block := range arr {
+		t := block.Get("type").String()
+		if t == "text" {
+			seenText = true
+		}
+		if t == "thinking" && seenText {
+			needReorder = true
+			break
+		}
+	}
+	if !needReorder {
+		return data
+	}
+
+	// Reorder: thinking blocks first, then text, then tool_use, then others.
+	var thinkingBlocks []interface{}
+	var textBlocks []interface{}
+	var toolUseBlocks []interface{}
+	var otherBlocks []interface{}
+
+	for _, block := range arr {
+		t := block.Get("type").String()
+		raw := json.RawMessage(block.Raw)
+		switch t {
+		case "thinking":
+			thinkingBlocks = append(thinkingBlocks, raw)
+		case "text":
+			textBlocks = append(textBlocks, raw)
+		case "tool_use":
+			toolUseBlocks = append(toolUseBlocks, raw)
+		default:
+			otherBlocks = append(otherBlocks, raw)
+		}
+	}
+
+	var reordered []interface{}
+	reordered = append(reordered, thinkingBlocks...)
+	reordered = append(reordered, textBlocks...)
+	reordered = append(reordered, toolUseBlocks...)
+	reordered = append(reordered, otherBlocks...)
+
+	result, err := sjson.SetBytes(data, "content", reordered)
+	if err != nil {
+		return data
+	}
+	return result
+}

--- a/internal/runtime/executor/helps/sse_normalize_test.go
+++ b/internal/runtime/executor/helps/sse_normalize_test.go
@@ -254,6 +254,27 @@ func TestSSENormalizer_BlankLinesPassThrough(t *testing.T) {
 	}
 }
 
+func TestSSEEventType_MultipleSpaces(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"event: message_stop", "message_stop"},
+		{"event:message_stop", "message_stop"},
+		{"event:  message_stop", "message_stop"},
+		{"event:\tmessage_stop", "message_stop"},
+		{"  event: message_stop  ", "message_stop"},
+		{"data: {}", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := sseEventType([]byte(tt.input))
+		if got != tt.expected {
+			t.Errorf("sseEventType(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
 func TestNormalizeNonStreamContentOrder_CorrectOrder(t *testing.T) {
 	input := []byte(`{"content":[{"type":"thinking","thinking":"..."},{"type":"text","text":"4"}],"stop_reason":"end_turn"}`)
 	result := NormalizeNonStreamContentOrder(input)

--- a/internal/runtime/executor/helps/sse_normalize_test.go
+++ b/internal/runtime/executor/helps/sse_normalize_test.go
@@ -1,0 +1,310 @@
+package helps
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestSSENormalizer_NormalStream(t *testing.T) {
+	// A correctly ordered stream should pass through unchanged.
+	var n SSENormalizer
+
+	lines := []string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_1"}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Hello"}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":0}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"4"}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":1}`,
+		"",
+		"event: message_delta",
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":50}}`,
+		"",
+		"event: message_stop",
+		`data: {"type":"message_stop"}`,
+		"",
+	}
+
+	var output [][]byte
+	for _, line := range lines {
+		result := n.ProcessLine([]byte(line))
+		for _, r := range result {
+			output = append(output, r)
+		}
+	}
+	flushed := n.Flush()
+	output = append(output, flushed...)
+
+	// message_stop should be the last event
+	lastEventType := ""
+	for i := len(output) - 1; i >= 0; i-- {
+		et := sseEventType(output[i])
+		if et != "" {
+			lastEventType = et
+			break
+		}
+	}
+	if lastEventType != "message_stop" {
+		t.Errorf("expected last event to be message_stop, got %q", lastEventType)
+	}
+
+	// Should have same number of event: lines as input
+	inputEvents := 0
+	for _, l := range lines {
+		if sseEventType([]byte(l)) != "" {
+			inputEvents++
+		}
+	}
+	outputEvents := 0
+	for _, l := range output {
+		if sseEventType(l) != "" {
+			outputEvents++
+		}
+	}
+	if inputEvents != outputEvents {
+		t.Errorf("expected %d events, got %d", inputEvents, outputEvents)
+	}
+}
+
+func TestSSENormalizer_ReorderBrokenStream(t *testing.T) {
+	// Baidu-glm-5.1 pattern: message_stop followed by extra content blocks
+	var n SSENormalizer
+
+	lines := []string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_1"}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":0}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":1}`,
+		"",
+		"event: message_delta",
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":50}}`,
+		"",
+		"event: message_stop",
+		`data: {"type":"message_stop"}`,
+		"",
+		// Extra content block AFTER message_stop (the bug)
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"2 + 2 = 4"}}`,
+		"",
+		"event: message_delta",
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":55}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":2}`,
+		"",
+	}
+
+	var output [][]byte
+	for _, line := range lines {
+		result := n.ProcessLine([]byte(line))
+		for _, r := range result {
+			output = append(output, r)
+		}
+	}
+	flushed := n.Flush()
+	output = append(output, flushed...)
+
+	// After normalization, message_stop must be the last event
+	lastEventType := ""
+	for i := len(output) - 1; i >= 0; i-- {
+		et := sseEventType(output[i])
+		if et != "" {
+			lastEventType = et
+			break
+		}
+	}
+	if lastEventType != "message_stop" {
+		t.Errorf("expected last event to be message_stop, got %q", lastEventType)
+	}
+
+	// All content_block events should appear before any message_delta/message_stop
+	lastContentBlockIdx := -1
+	firstDeltaIdx := -1
+	firstStopIdx := -1
+	for i, line := range output {
+		et := sseEventType(line)
+		switch et {
+		case "content_block_start", "content_block_delta", "content_block_stop":
+			lastContentBlockIdx = i
+		case "message_delta":
+			if firstDeltaIdx == -1 {
+				firstDeltaIdx = i
+			}
+		case "message_stop":
+			if firstStopIdx == -1 {
+				firstStopIdx = i
+			}
+		}
+	}
+
+	if firstDeltaIdx == -1 {
+		t.Fatal("expected to find message_delta event")
+	}
+	if firstStopIdx == -1 {
+		t.Fatal("expected to find message_stop event")
+	}
+	if lastContentBlockIdx > firstDeltaIdx {
+		t.Errorf("content block at index %d should come before message_delta at index %d", lastContentBlockIdx, firstDeltaIdx)
+	}
+	if lastContentBlockIdx > firstStopIdx {
+		t.Errorf("content block at index %d should come before message_stop at index %d", lastContentBlockIdx, firstStopIdx)
+	}
+
+	// Should preserve all events (no data loss)
+	inputEvents := 0
+	for _, l := range lines {
+		if sseEventType([]byte(l)) != "" {
+			inputEvents++
+		}
+	}
+	outputEvents := 0
+	for _, l := range output {
+		if sseEventType(l) != "" {
+			outputEvents++
+		}
+	}
+	if inputEvents != outputEvents {
+		t.Errorf("expected %d events, got %d (data loss)", inputEvents, outputEvents)
+	}
+}
+
+func TestSSENormalizer_ToolUseStream(t *testing.T) {
+	// Tool use streams end with stop_reason=tool_use — no events after message_stop.
+	var n SSENormalizer
+
+	lines := []string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_1"}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":0}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"call_1","name":"get_weather","input":{}}}`,
+		"",
+		"event: content_block_stop",
+		`data: {"type":"content_block_stop","index":1}`,
+		"",
+		"event: message_delta",
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":30}}`,
+		"",
+		"event: message_stop",
+		`data: {"type":"message_stop"}`,
+		"",
+	}
+
+	var output [][]byte
+	for _, line := range lines {
+		result := n.ProcessLine([]byte(line))
+		for _, r := range result {
+			output = append(output, r)
+		}
+	}
+	flushed := n.Flush()
+	output = append(output, flushed...)
+
+	eventCount := 0
+	for _, line := range output {
+		if sseEventType(line) != "" {
+			eventCount++
+		}
+	}
+	if eventCount != 7 {
+		t.Errorf("expected 7 events, got %d", eventCount)
+	}
+}
+
+func TestSSENormalizer_BlankLinesPassThrough(t *testing.T) {
+	var n SSENormalizer
+
+	result := n.ProcessLine([]byte(""))
+	if len(result) != 1 || string(result[0]) != "" {
+		t.Errorf("expected blank line to pass through, got %v", result)
+	}
+}
+
+func TestNormalizeNonStreamContentOrder_CorrectOrder(t *testing.T) {
+	input := []byte(`{"content":[{"type":"thinking","thinking":"..."},{"type":"text","text":"4"}],"stop_reason":"end_turn"}`)
+	result := NormalizeNonStreamContentOrder(input)
+	if string(result) != string(input) {
+		t.Errorf("expected no change for correct order, got %s", result)
+	}
+}
+
+func TestNormalizeNonStreamContentOrder_WrongOrder(t *testing.T) {
+	input := []byte(`{"content":[{"type":"text","text":"4"},{"type":"thinking","thinking":"..."}],"stop_reason":"end_turn"}`)
+	result := NormalizeNonStreamContentOrder(input)
+
+	firstType := gjson.GetBytes(result, "content.0.type").String()
+	if firstType != "thinking" {
+		t.Errorf("expected first block to be thinking, got %q", firstType)
+	}
+	secondType := gjson.GetBytes(result, "content.1.type").String()
+	if secondType != "text" {
+		t.Errorf("expected second block to be text, got %q", secondType)
+	}
+}
+
+func TestNormalizeNonStreamContentOrder_WithToolUse(t *testing.T) {
+	input := []byte(`{"content":[{"type":"text","text":"4"},{"type":"thinking","thinking":"..."},{"type":"tool_use","id":"c1","name":"fn","input":{}}],"stop_reason":"tool_use"}`)
+	result := NormalizeNonStreamContentOrder(input)
+
+	types := []string{
+		gjson.GetBytes(result, "content.0.type").String(),
+		gjson.GetBytes(result, "content.1.type").String(),
+		gjson.GetBytes(result, "content.2.type").String(),
+	}
+	expected := []string{"thinking", "text", "tool_use"}
+	for i, exp := range expected {
+		if types[i] != exp {
+			t.Errorf("content[%d]: expected %q, got %q", i, exp, types[i])
+		}
+	}
+}
+
+func TestNormalizeNonStreamContentOrder_SingleBlock(t *testing.T) {
+	input := []byte(`{"content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn"}`)
+	result := NormalizeNonStreamContentOrder(input)
+	if string(result) != string(input) {
+		t.Errorf("expected no change for single block, got %s", result)
+	}
+}
+
+func TestNormalizeNonStreamContentOrder_NoContent(t *testing.T) {
+	input := []byte(`{"stop_reason":"end_turn"}`)
+	result := NormalizeNonStreamContentOrder(input)
+	if string(result) != string(input) {
+		t.Errorf("expected no change for missing content, got %s", result)
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -430,6 +430,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 				// protocol. The normalizer buffers and reorders so that
 				// message_stop is always the last event.
 				for _, sseLine := range bytes.Split(chunks[i], []byte("\n")) {
+					if len(sseLine) == 0 {
+						continue
+					}
 					for _, outLine := range sseNormalizer.ProcessLine(sseLine) {
 						cloned := make([]byte, len(outLine)+1)
 						copy(cloned, outLine)
@@ -467,8 +470,29 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			// response.completed events are still emitted exactly once.
 			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, []byte("data: [DONE]"), &param)
 			for i := range chunks {
+				for _, sseLine := range bytes.Split(chunks[i], []byte("\n")) {
+					if len(sseLine) == 0 {
+						continue
+					}
+					for _, outLine := range sseNormalizer.ProcessLine(sseLine) {
+						cloned := make([]byte, len(outLine)+1)
+						copy(cloned, outLine)
+						cloned[len(outLine)] = '\n'
+						select {
+						case out <- cliproxyexecutor.StreamChunk{Payload: cloned}:
+						case <-ctx.Done():
+							return
+						}
+					}
+				}
+			}
+			// Flush normalizer after synthetic [DONE].
+			for _, outLine := range sseNormalizer.Flush() {
+				cloned := make([]byte, len(outLine)+1)
+				copy(cloned, outLine)
+				cloned[len(outLine)] = '\n'
 				select {
-				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case out <- cliproxyexecutor.StreamChunk{Payload: cloned}:
 				case <-ctx.Done():
 					return
 				}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -194,6 +194,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	// Translate response back to source format when needed
 	var param any
 	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, body, &param)
+	out = helps.NormalizeNonStreamContentOrder(out)
 	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 	return resp, nil
 }
@@ -391,6 +392,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
+		var sseNormalizer helps.SSENormalizer
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
@@ -423,11 +425,33 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			// OpenAI-compatible streams must use SSE data lines.
 			chunks := sdktranslator.TranslateStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, bytes.Clone(trimmedLine), &param)
 			for i := range chunks {
-				select {
-				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
-				case <-ctx.Done():
-					return
+				// Normalize SSE event ordering: some upstream models emit
+				// content blocks after message_stop, violating the Anthropic
+				// protocol. The normalizer buffers and reorders so that
+				// message_stop is always the last event.
+				for _, sseLine := range bytes.Split(chunks[i], []byte("\n")) {
+					for _, outLine := range sseNormalizer.ProcessLine(sseLine) {
+						cloned := make([]byte, len(outLine)+1)
+						copy(cloned, outLine)
+						cloned[len(outLine)] = '\n'
+						select {
+						case out <- cliproxyexecutor.StreamChunk{Payload: cloned}:
+						case <-ctx.Done():
+							return
+						}
+					}
 				}
+			}
+		}
+		// Flush any remaining buffered SSE events (e.g. held message_stop).
+		for _, outLine := range sseNormalizer.Flush() {
+			cloned := make([]byte, len(outLine)+1)
+			copy(cloned, outLine)
+			cloned[len(outLine)] = '\n'
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Payload: cloned}:
+			case <-ctx.Done():
+				return
 			}
 		}
 		if errScan := scanner.Err(); errScan != nil {


### PR DESCRIPTION
# fix(executor): normalize SSE event ordering for openai-compat models

## Summary

- **SSE stream normalizer**: Some upstream models (e.g. Baidu-glm-5.1, Tencent-glm-5.1) emit Claude SSE events with `message_stop` followed by additional content blocks, violating the Anthropic streaming protocol. The Claude Code SDK stops parsing after `message_stop`, causing text content to be silently truncated in `end_turn` scenarios. The new `SSENormalizer` in the openai-compat executor buffers events after the first `message_delta` and reorders them on flush so that `message_stop` is always the last event.
- **Non-stream content block reordering**: `NormalizeNonStreamContentOrder` ensures `thinking` blocks always appear before `text` blocks in non-stream responses, matching the Anthropic protocol convention.

## Root Cause

Baidu-glm-5.1 and similar models configured under `openai-compatibility` in config.yaml flow through `OpenAICompatExecutor`. The OpenAI→Claude translator correctly converts the protocol, but the upstream model's SSE output has the following broken pattern:

```
[content blocks] → message_delta → message_stop → [extra content blocks] → message_delta
```

The Anthropic protocol requires:

```
[content blocks] → message_delta → message_stop
```

Note: `tool_use` scenarios already produce correct SSE ordering — only `end_turn` is affected.

## Changes

| File | Type | Description |
|------|------|-------------|
| `internal/runtime/executor/helps/sse_normalize.go` | New | `SSENormalizer` (stream) and `NormalizeNonStreamContentOrder` (non-stream) |
| `internal/runtime/executor/helps/sse_normalize_test.go` | New | Unit tests for both normalizers |
| `internal/runtime/executor/openai_compat_executor.go` | Modified | Integrate normalizer into `ExecuteStream` and `Execute` |

### SSENormalizer Strategy

1. Pass through all events before the first `message_delta` (normal streaming body)
2. After first `message_delta`, buffer all subsequent events (epilog)
3. On `Flush()`, emit buffered events in correct order: content_block → message_delta → message_stop
4. For correctly-ordered streams, this is a no-op (buffer is already in order)

### NormalizeNonStreamContentOrder

1. Detect if any `thinking` block appears after a `text` block
2. If so, reorder to: `thinking` → `text` → `tool_use` → other
3. If already correct, return unchanged

## Commits

### Commit 1: Core implementation

Initial `SSENormalizer` + `NormalizeNonStreamContentOrder` + integration into `openai_compat_executor.go`.

### Commit 2: Bot review feedback

Addressed three review suggestions:

1. **`sseEventType` robustness** (Gemini Code Assist): Simplified to single `HasPrefix("event:")` + `TrimSpace`, correctly handling multi-space variants like `event:  message_stop` and `event:\tmessage_stop`.

2. **`bytes.Split` empty line filter** (Gemini Code Assist): `TranslateStream` output ends with `\n\n` (trailing newlines). `bytes.Split` by `"\n"` produces trailing empty strings that become redundant newlines in the output. Added `if len(sseLine) == 0 { continue }` to skip them.

3. **Synthetic `[DONE]` path through normalizer** (based on ChatGPT Codex Connector review): The original synthetic `[DONE]` path bypassed the normalizer entirely. If the translator emitted any epilog events from the synthetic `[DONE]` (e.g. a belated `message_stop`), they would be sent out of order. Routed through normalizer + flush to ensure consistent ordering. Note: the original suggestion to flush on `[DONE]` detection was adapted — the real issue was the bypass, not the timing.