### PR TITLE
docs: add Panopticon to "Who is with us?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ Windows-focused, local-first desktop management platform for Codex CLI built on 
 
 Native macOS SwiftUI app for monitoring ChatGPT/Codex account quotas in CLIProxyAPI pools. Displays account availability, Plus-base capacity, 5-hour and weekly quota bars, plan weights, and restore forecasts through the Management API.
 
+### [Panopticon](https://github.com/eltmon/panopticon-cli)
+
+Multi-agent orchestration for AI coding assistants. Runs CLIProxyAPI as a local sidecar so its agents can drive GPT models through a ChatGPT subscription, pointing Claude Code at an Anthropic-compatible endpoint with no OpenAI API key required.
+
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.
 


### PR DESCRIPTION
Adds [Panopticon](https://github.com/eltmon/panopticon-cli) to the "Who is with us?" list.

Panopticon is a multi-agent orchestrator for AI coding assistants. It runs CLIProxyAPI as a local sidecar so its agents can drive GPT models through a ChatGPT subscription — pointing Claude Code at an Anthropic-compatible endpoint with no OpenAI API key required.

Thanks for building CLIProxyAPI!