### PR TITLE
fix(codex): Remove 'gpt-5.3-codex-spark' model for codex-plus

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1503,29 +1503,6 @@
   ],
   "codex-plus": [
     {
-      "id": "gpt-5.3-codex-spark",
-      "object": "model",
-      "created": 1770912000,
-      "owned_by": "openai",
-      "type": "openai",
-      "display_name": "GPT 5.3 Codex Spark",
-      "version": "gpt-5.3",
-      "description": "Ultra-fast coding model.",
-      "context_length": 128000,
-      "max_completion_tokens": 128000,
-      "supported_parameters": [
-        "tools"
-      ],
-      "thinking": {
-        "levels": [
-          "low",
-          "medium",
-          "high",
-          "xhigh"
-        ]
-      }
-    },
-    {
       "id": "gpt-5.4",
       "object": "model",
       "created": 1772668800,


### PR DESCRIPTION
Due to ChatGPT Plus account does not have access to codex-spark, proposed to remove this model config in codex-plus section.

This PR address following issue: https://github.com/router-for-me/CLIProxyAPI/issues/3370