### PR TITLE
feat(registry): add MiniMax provider channel with M3 as default

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -284,6 +284,21 @@ nonstream-keepalive-interval: 0
 #       - name: "kimi-k2.5"
 #         alias: "claude-opus-4.66"
 
+# MiniMax (MiniMax AI) - configure as an OpenAI-compatible provider
+#   Set name: "minimax" so the request is routed through the MiniMax channel
+#   exposed by the model registry (default model: MiniMax-M3).
+#   Docs: https://platform.minimax.io/docs/api-reference/text-openai-api
+# openai-compatibility:
+#   - name: "minimax"
+#     base-url: "https://api.minimax.io/v1"
+#     api-key-entries:
+#       - api-key: "your-minimax-api-key"
+#     models:
+#       - name: "MiniMax-M3"            # default MiniMax model (512K context, 128K max output)
+#         alias: "MiniMax-M3"
+#       - name: "MiniMax-M2.7"          # kept for backward compatibility
+#         alias: "MiniMax-M2.7"
+
 # Vertex API keys (Vertex-compatible endpoints, base-url is optional)
 # vertex-api-key:
 #   - api-key: "vk-123..."                        # x-goog-api-key header

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -28,6 +28,7 @@ type staticModelsJSON struct {
 	Kimi        []*ModelInfo `json:"kimi"`
 	Antigravity []*ModelInfo `json:"antigravity"`
 	XAI         []*ModelInfo `json:"xai"`
+	MiniMax     []*ModelInfo `json:"minimax"`
 }
 
 // GetClaudeModels returns the standard Claude model definitions.
@@ -88,6 +89,11 @@ func GetAntigravityModels() []*ModelInfo {
 // GetXAIModels returns the standard xAI Grok model definitions.
 func GetXAIModels() []*ModelInfo {
 	return WithXAIBuiltins(cloneModelInfos(getModels().XAI))
+}
+
+// GetMiniMaxModels returns the standard MiniMax model definitions.
+func GetMiniMaxModels() []*ModelInfo {
+	return cloneModelInfos(getModels().MiniMax)
 }
 
 // WithCodexBuiltins injects hard-coded Codex-only model definitions that should
@@ -238,6 +244,7 @@ func cloneModelInfos(models []*ModelInfo) []*ModelInfo {
 //   - kimi
 //   - antigravity
 //   - xai
+//   - minimax
 func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	key := strings.ToLower(strings.TrimSpace(channel))
 	switch key {
@@ -259,6 +266,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		return GetAntigravityModels()
 	case "xai", "x-ai", "grok":
 		return GetXAIModels()
+	case "minimax":
+		return GetMiniMaxModels()
 	default:
 		return nil
 	}
@@ -282,6 +291,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		data.Kimi,
 		data.Antigravity,
 		data.XAI,
+		data.MiniMax,
 	}
 	for _, models := range allModels {
 		for _, m := range models {

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -16,3 +16,41 @@ func TestWithXAIBuiltinsIncludesVideoPreviewModel(t *testing.T) {
 
 	t.Fatalf("expected xAI builtin model %s", xaiBuiltinVideo15PreviewModelID)
 }
+
+func TestGetMiniMaxModelsReturnsEmbeddedEntries(t *testing.T) {
+	models := GetMiniMaxModels()
+	if len(models) == 0 {
+		t.Fatalf("expected MiniMax models to be populated from embedded catalog")
+	}
+
+	ids := make(map[string]struct{}, len(models))
+	for _, m := range models {
+		if m == nil {
+			continue
+		}
+		ids[m.ID] = struct{}{}
+	}
+	if _, ok := ids["MiniMax-M3"]; !ok {
+		t.Fatalf("expected MiniMax-M3 to be the default MiniMax model")
+	}
+	if _, ok := ids["MiniMax-M2.7"]; !ok {
+		t.Fatalf("expected MiniMax-M2.7 to be kept for backward compatibility")
+	}
+}
+
+func TestGetStaticModelDefinitionsByChannelIncludesMiniMax(t *testing.T) {
+	models := GetStaticModelDefinitionsByChannel("minimax")
+	if len(models) == 0 {
+		t.Fatalf("expected MiniMax channel to return model definitions")
+	}
+}
+
+func TestLookupStaticModelInfoFindsMiniMax(t *testing.T) {
+	info := LookupStaticModelInfo("MiniMax-M3")
+	if info == nil {
+		t.Fatalf("expected MiniMax-M3 to be discoverable via LookupStaticModelInfo")
+	}
+	if info.Type != "minimax" {
+		t.Fatalf("expected MiniMax-M3 type to be minimax, got %q", info.Type)
+	}
+}

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2200,7 +2200,7 @@
       "type": "minimax",
       "display_name": "MiniMax M2.7",
       "name": "MiniMax-M2.7",
-      "description": "MiniMax M2.7 - prior generation MiniMax model with 1M context, 40960 max output.",
+      "description": "MiniMax M2.7 - prior generation MiniMax model with 192K context, 40960 max output.",
       "context_length": 1048576,
       "max_completion_tokens": 40960
     }

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2178,5 +2178,31 @@
         ]
       }
     }
+  ],
+  "minimax": [
+    {
+      "id": "MiniMax-M3",
+      "object": "model",
+      "created": 1777420800,
+      "owned_by": "MiniMax",
+      "type": "minimax",
+      "display_name": "MiniMax M3",
+      "name": "MiniMax-M3",
+      "description": "MiniMax M3 - default MiniMax model with 512K context, 128K max output, supports image input.",
+      "context_length": 512000,
+      "max_completion_tokens": 128000
+    },
+    {
+      "id": "MiniMax-M2.7",
+      "object": "model",
+      "created": 1771372800,
+      "owned_by": "MiniMax",
+      "type": "minimax",
+      "display_name": "MiniMax M2.7",
+      "name": "MiniMax-M2.7",
+      "description": "MiniMax M2.7 - prior generation MiniMax model with 1M context, 40960 max output.",
+      "context_length": 1048576,
+      "max_completion_tokens": 40960
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- **New channel**: MiniMax (`minimax`) registered in the static model registry.
- **Default model**: `MiniMax-M3` (512K context, 128K max output, image input).
- **Kept for backward compatibility**: `MiniMax-M2.7` (1M context, 40960 max output).
- **Removed**: older MiniMax generations are not part of this PR (none were present in the previous closed #2155 default).
- **Configuration**: the existing `openai-compatibility` section is reused with `name: "minimax"` and `base-url: https://api.minimax.io/v1`. No new executor is required — `OpenAICompatExecutor` already routes the `minimax` provider key (see `sdk/cliproxy/service.go` default case).
- **Tests**: three new unit tests in `internal/registry/model_definitions_test.go` covering the channel lookup, default and backward-compat model presence, and `LookupStaticModelInfo` resolution.

## Configuration example

```yaml
openai-compatibility:
  - name: "minimax"
    base-url: "https://api.minimax.io/v1"
    api-key-entries:
      - api-key: "your-minimax-api-key"
    models:
      - name: "MiniMax-M3"            # default MiniMax model (512K context, 128K max output)
        alias: "MiniMax-M3"
      - name: "MiniMax-M2.7"          # kept for backward compatibility
        alias: "MiniMax-M2.7"
```

The example block is also added to `config.example.yaml` so users can copy it directly.

## API reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Notes

- No new executor code is added; the existing `OpenAICompatExecutor` already handles any OpenAI-compatible provider key through the default switch case.
- The `minimax` model entry follows the same shape as the existing `kimi` / `xai` / `claude` entries (id, owned_by, type, display_name, description, context_length, max_completion_tokens).