### PR TITLE
feat(models):Add Antigravity Gemini 3.5 Flash extra-low model to models list

### DIFF
--- a/internal/registry/model_registry_safety_test.go
+++ b/internal/registry/model_registry_safety_test.go
@@ -146,4 +146,25 @@ func TestLookupModelInfoReturnsCloneForStaticDefinitions(t *testing.T) {
 	if second == nil || second.Thinking == nil || len(second.Thinking.Levels) == 0 || second.Thinking.Levels[0] == "mutated" {
 		t.Fatalf("expected static lookup clone, got %+v", second)
 	}
+
+	antigravity := LookupModelInfo("gemini-3.5-flash-extra-low", "antigravity")
+	if antigravity == nil {
+		t.Fatal("expected Antigravity gemini-3.5-flash-extra-low static model")
+	}
+	if antigravity.Type != "antigravity" || antigravity.DisplayName != "Gemini 3.5 Flash (Extra Low)" {
+		t.Fatalf("unexpected Antigravity static model metadata: %+v", antigravity)
+	}
+	if antigravity.ContextLength != 1048576 || antigravity.MaxCompletionTokens != 65535 {
+		t.Fatalf("unexpected Antigravity static model limits: %+v", antigravity)
+	}
+	if antigravity.Thinking == nil ||
+		antigravity.Thinking.Min != 1 ||
+		antigravity.Thinking.Max != 65535 ||
+		!antigravity.Thinking.DynamicAllowed ||
+		len(antigravity.Thinking.Levels) != 3 ||
+		antigravity.Thinking.Levels[0] != "low" ||
+		antigravity.Thinking.Levels[1] != "medium" ||
+		antigravity.Thinking.Levels[2] != "high" {
+		t.Fatalf("unexpected Antigravity static model thinking configuration: %+v", antigravity.Thinking)
+	}
 }

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2032,6 +2032,27 @@
           "high"
         ]
       }
+    },
+    {
+      "id": "gemini-3.5-flash-extra-low",
+      "object": "model",
+      "owned_by": "antigravity",
+      "type": "antigravity",
+      "display_name": "Gemini 3.5 Flash (Extra Low)",
+      "name": "gemini-3.5-flash-extra-low",
+      "description": "Gemini 3.5 Flash (Extra Low)",
+      "context_length": 1048576,
+      "max_completion_tokens": 65535,
+      "thinking": {
+        "min": 1,
+        "max": 65535,
+        "dynamic_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     }
 
   ],


### PR DESCRIPTION
Summary
- add Antigravity `gemini-3.5-flash-extra-low` to the embedded static model catalog
- mirror the existing `gemini-3.5-flash-low` limits/thinking metadata for the new backend low tier id
- extend existing static registry lookup coverage for the Antigravity entry without adding a new test file

Tests
- `go test ./internal/registry ./cmd/fetch_antigravity_models`
- `git diff --check`
- `git diff --cached --check`
- `go build -o test-output ./cmd/server && rm test-output`