### PR TITLE
Fix GPT-5.5 max context window metadata

### DIFF
--- a/internal/registry/models/codex_client_models.json
+++ b/internal/registry/models/codex_client_models.json
@@ -17,7 +17,7 @@
       },
       "supports_parallel_tool_calls": true,
       "context_window": 272000,
-      "max_context_window": 272000,
+      "max_context_window": 1000000,
       "auto_compact_token_limit": null,
       "reasoning_summary_format": "experimental",
       "default_reasoning_summary": "none",


### PR DESCRIPTION
中文：修正 GPT-5.5 的 `max_context_window` 为 1M。官方 Codex catalog 已将 GPT-5.4 标为 `max_context_window = 1000000`，但后续的 GPT-5.5 仍被错误地标为 272k；这个不一致会让客户端低估 GPT-5.5 支持的最大上下文。此 PR 保留默认 `context_window` 不变，只修正最大上下文的值。

English: Fix GPT-5.5 `max_context_window` metadata to 1M. The official Codex catalog already advertises GPT-5.4 with `max_context_window = 1000000`, while the later GPT-5.5 entry still reports 272k; that inconsistency causes clients to underestimate GPT-5.5’s supported maximum context. This PR keeps the default `context_window` unchanged and only corrects the maximum context capability.