### PR TITLE
fix(signature): drop empty signed Claude thinking

### DIFF
--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -124,6 +124,15 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 			}
 
 			rawSignature := part.Get("signature").String()
+			// A signed thinking block whose text was stripped by a client cannot be
+			// replayed safely: provider-side signature validation checks the
+			// signature against the original thinking text. Drop the block so the
+			// conversation can continue without replaying invalid signed content.
+			if targetProvider == SignatureProviderClaude && strings.TrimSpace(rawSignature) != "" && strings.TrimSpace(claudeThinkingBlockText(part)) == "" {
+				report.DroppedBlocks++
+				messageModified = true
+				continue
+			}
 			decision := DecideSignatureCompatibility(targetProvider, rawSignature, SignatureBlockKindClaudeThinking)
 			decision.Reason = fmt.Sprintf("messages[%d].content[%d]: %s", i, j, decision.Reason)
 			report.Decisions = append(report.Decisions, decision)

--- a/internal/signature/provider_compatibility_test.go
+++ b/internal/signature/provider_compatibility_test.go
@@ -317,6 +317,46 @@ func TestSanitizeClaudeMessagesForClaudeUpstream_DropsInvalidThinkingAndCleansTo
 	}
 }
 
+func TestSanitizeClaudeMessagesForClaudeUpstream_DropsSignedThinkingWithEmptyText(t *testing.T) {
+	nativeSig := testClaudeThinkingSignature()
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"","signature":"` + nativeSig + `"},{"type":"text","text":"answer"}]}]}`)
+
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
+	if report.DroppedBlocks != 1 {
+		t.Fatalf("DroppedBlocks = %d, want 1; report=%+v", report.DroppedBlocks, report)
+	}
+	if report.Preserved != 0 {
+		t.Fatalf("Preserved = %d, want 0; report=%+v", report.Preserved, report)
+	}
+	parts := gjson.GetBytes(output, "messages.0.content").Array()
+	if len(parts) != 1 {
+		t.Fatalf("content length = %d, want 1: %s", len(parts), output)
+	}
+	if got := parts[0].Get("type").String(); got != "text" {
+		t.Fatalf("remaining part type = %q, want text: %s", got, parts[0].Raw)
+	}
+	if got := parts[0].Get("text").String(); got != "answer" {
+		t.Fatalf("remaining text = %q, want answer", got)
+	}
+}
+
+func TestSanitizeClaudeMessagesSignaturesForModel_PreservesGPTSignatureOnlyReasoningForGPT(t *testing.T) {
+	sig := testGPTReasoningSignature()
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"","signature":"` + sig + `"},{"type":"text","text":"answer"}]}]}`)
+
+	output, report := SanitizeClaudeMessagesSignaturesForModel(input, "gpt-5.2")
+	if report.Preserved != 1 || report.DroppedBlocks != 0 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	parts := gjson.GetBytes(output, "messages.0.content").Array()
+	if len(parts) != 2 {
+		t.Fatalf("content length = %d, want 2: %s", len(parts), output)
+	}
+	if got := parts[0].Get("signature").String(); got != sig {
+		t.Fatalf("signature = %q, want preserved %q", got, sig)
+	}
+}
+
 func TestSanitizeClaudeMessagesForClaudeUpstream_NormalizesValidThinkingAndDropsEmptyMessage(t *testing.T) {
 	nativeSig := testClaudeThinkingSignature()
 	doubleEncoded := base64.StdEncoding.EncodeToString([]byte(nativeSig))


### PR DESCRIPTION
Fixes #3663

## Summary
- drop Claude `thinking` blocks when a non-empty Claude-target signature is replayed with empty/stripped thinking text
- keep the rest of the message content intact so conversations can continue instead of forwarding an invalid signed block upstream
- add a regression test for a valid-looking Claude signature paired with empty thinking text
- preserve GPT/Codex signature-only reasoning blocks when the target provider is GPT/Codex

## Rationale
Claude validates signed thinking blocks against their original thinking text. If a client round-trips an assistant message and strips the text but keeps the signature, preserving that block for a native Claude upstream can trigger a provider-side signature validation error. Dropping the invalid Claude-target block matches the existing sanitizer behavior for incompatible thinking blocks and avoids the 400.

## Review follow-up
- addressed Codex automated review feedback by limiting the empty-text drop to Claude targets
- added a regression test to ensure GPT/Codex signature-only reasoning remains preserved for GPT targets

## Validation
Ran inside `golang:1.26-alpine` because the host has no Go toolchain installed:

- `/usr/local/go/bin/gofmt -w internal/signature/claude_messages_sanitize.go internal/signature/provider_compatibility_test.go`
- `/usr/local/go/bin/go test ./internal/signature -run "TestSanitizeClaudeMessagesForClaudeUpstream_DropsSignedThinkingWithEmptyText|TestSanitizeClaudeMessagesSignaturesForModel_PreservesGPTSignatureOnlyReasoningForGPT" -count=1`
- `/usr/local/go/bin/go test ./internal/signature -count=1`
- `/usr/local/go/bin/go test ./... -count=1`
- `/usr/local/go/bin/go build -o test-output ./cmd/server && rm test-output`
