### PR TITLE
fix(xai): normalize custom tool call input items

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -33,7 +33,11 @@ const (
 	xaiImageHandlerType         = "openai-image"
 	xaiVideoHandlerType         = "openai-video"
 	xaiCustomToolType           = "custom"
+	xaiCustomToolCallType       = "custom_tool_call"
+	xaiCustomToolCallOutputType = "custom_tool_call_output"
 	xaiFunctionToolType         = "function"
+	xaiFunctionCallType         = "function_call"
+	xaiFunctionCallOutputType   = "function_call_output"
 	xaiImageGenerationToolType  = "image_generation"
 	xaiNamespaceToolType        = "namespace"
 	xaiToolSearchType           = "tool_search"
@@ -507,6 +511,7 @@ func (e *XAIExecutor) prepareResponsesRequest(ctx context.Context, req cliproxye
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = normalizeXAITools(body)
 	body = normalizeXAIToolChoiceForTools(body)
+	body = normalizeXAIInputCustomToolCalls(body)
 	body = normalizeXAIInputReasoningItems(body)
 	body = normalizeCodexInstructions(body)
 	body = sanitizeXAIResponsesBody(body, baseModel)
@@ -774,6 +779,98 @@ func normalizeXAITool(tool gjson.Result) ([]byte, bool, bool) {
 		changed = true
 	}
 	return raw, changed, true
+}
+
+func normalizeXAIInputCustomToolCalls(body []byte) []byte {
+	input := gjson.GetBytes(body, "input")
+	if !input.Exists() || !input.IsArray() {
+		return body
+	}
+
+	inputArray := input.Array()
+	changed := false
+	items := make([]json.RawMessage, 0, len(inputArray))
+	for _, item := range inputArray {
+		raw := []byte(item.Raw)
+		switch item.Get("type").String() {
+		case xaiCustomToolCallType:
+			updated, errSet := sjson.SetBytes(raw, "type", xaiFunctionCallType)
+			if errSet != nil {
+				return body
+			}
+			raw = updated
+			if item.Get("input").Exists() {
+				arguments := xaiCustomToolCallArguments(item.Get("input"))
+				updated, errSet = sjson.SetBytes(raw, "arguments", arguments)
+				if errSet != nil {
+					return body
+				}
+				raw = updated
+				updated, errDel := sjson.DeleteBytes(raw, "input")
+				if errDel != nil {
+					return body
+				}
+				raw = updated
+			} else if !item.Get("arguments").Exists() {
+				updated, errSet = sjson.SetBytes(raw, "arguments", "{}")
+				if errSet != nil {
+					return body
+				}
+				raw = updated
+			}
+			changed = true
+		case xaiCustomToolCallOutputType:
+			updated, errSet := sjson.SetBytes(raw, "type", xaiFunctionCallOutputType)
+			if errSet != nil {
+				return body
+			}
+			raw = updated
+			changed = true
+		}
+		items = append(items, json.RawMessage(raw))
+	}
+	if !changed {
+		return body
+	}
+
+	rawInput, errMarshal := json.Marshal(items)
+	if errMarshal != nil {
+		return body
+	}
+	updated, errSet := sjson.SetRawBytes(body, "input", rawInput)
+	if errSet != nil {
+		return body
+	}
+	return updated
+}
+
+func xaiCustomToolCallArguments(input gjson.Result) string {
+	if !input.Exists() {
+		return "{}"
+	}
+
+	if input.Type == gjson.String {
+		text := input.String()
+		trimmed := strings.TrimSpace(text)
+		if strings.HasPrefix(trimmed, "{") {
+			var object map[string]any
+			if errUnmarshal := json.Unmarshal([]byte(trimmed), &object); errUnmarshal == nil {
+				return trimmed
+			}
+		}
+		if encoded, errMarshal := json.Marshal(text); errMarshal == nil {
+			return `{"input":` + string(encoded) + `}`
+		}
+		return "{}"
+	}
+
+	if input.IsObject() {
+		return input.Raw
+	}
+	if input.Raw != "" {
+		return `{"input":` + input.Raw + `}`
+	}
+	return "{}"
 }
 
 func normalizeXAIInputReasoningItems(body []byte) []byte {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -196,6 +196,58 @@ func TestXAIExecutorOmitsUnsupportedReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestXAIExecutorNormalizesCustomToolCallInput(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var errRead error
+		gotBody, errRead = io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read body: %v", errRead)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"model\":\"grok-4.3\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}]}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider:   "xai",
+		Attributes: map[string]string{"base_url": server.URL},
+		Metadata:   map[string]any{"access_token": "xai-token"},
+	}
+
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "grok-4.3",
+		Payload: []byte(`{"model":"grok-4.3","stream":false,"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]},{"type":"custom_tool_call","call_id":"c0","name":"ApplyPatch","input":"*** Begin Patch"},{"type":"custom_tool_call_output","call_id":"c0","output":"done"}],"tools":[],"tool_choice":"auto","parallel_tool_calls":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if gjson.GetBytes(gotBody, "tool_choice").Exists() {
+		t.Fatalf("tool_choice should be removed when tools are empty: %s", string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "parallel_tool_calls").Exists() {
+		t.Fatalf("parallel_tool_calls should be removed when tools are empty: %s", string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "tools").Exists() {
+		t.Fatalf("empty tools should be removed: %s", string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "input.1.type").String(); got != "function_call" {
+		t.Fatalf("input.1.type = %q, want function_call: %s", got, string(gotBody))
+	}
+	arguments := gjson.GetBytes(gotBody, "input.1.arguments").String()
+	if got := gjson.Get(arguments, "input").String(); got != "*** Begin Patch" {
+		t.Fatalf("arguments.input = %q, want patch text; arguments=%s body=%s", got, arguments, string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "input.2.type").String(); got != "function_call_output" {
+		t.Fatalf("input.2.type = %q, want function_call_output: %s", got, string(gotBody))
+	}
+}
+
 func TestXAIExecutorAppliesThinkingSuffix(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -644,5 +696,56 @@ func TestNormalizeXAIToolChoiceForTools_NoOpWhenBothAbsent(t *testing.T) {
 
 	if gjson.GetBytes(out, "tool_choice").Exists() {
 		t.Fatalf("tool_choice should not appear: %s", string(out))
+	}
+}
+
+func TestNormalizeXAIInputCustomToolCalls_ConvertsCustomCalls(t *testing.T) {
+	body := []byte(`{"model":"grok-4","input":[{"type":"custom_tool_call","call_id":"c0","name":"ApplyPatch","input":"*** Begin Patch"},{"type":"custom_tool_call_output","call_id":"c0","output":"done"},{"type":"function_call","call_id":"f0","name":"lookup","arguments":"{}"}]}`)
+	out := normalizeXAIInputCustomToolCalls(body)
+
+	if got := gjson.GetBytes(out, "input.0.type").String(); got != "function_call" {
+		t.Fatalf("input.0.type = %q, want function_call: %s", got, string(out))
+	}
+	if gjson.GetBytes(out, "input.0.input").Exists() {
+		t.Fatalf("input.0.input should be removed after conversion: %s", string(out))
+	}
+	arguments := gjson.GetBytes(out, "input.0.arguments").String()
+	if got := gjson.Get(arguments, "input").String(); got != "*** Begin Patch" {
+		t.Fatalf("arguments.input = %q, want patch text; arguments=%s body=%s", got, arguments, string(out))
+	}
+	if got := gjson.GetBytes(out, "input.1.type").String(); got != "function_call_output" {
+		t.Fatalf("input.1.type = %q, want function_call_output: %s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "input.1.output").String(); got != "done" {
+		t.Fatalf("input.1.output = %q, want done: %s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, "input.2.type").String(); got != "function_call" {
+		t.Fatalf("input.2.type = %q, want existing function_call preserved: %s", got, string(out))
+	}
+}
+
+func TestNormalizeXAIInputCustomToolCalls_KeepsObjectArguments(t *testing.T) {
+	body := []byte(`{"model":"grok-4","input":[{"type":"custom_tool_call","call_id":"c0","name":"custom_lookup","input":"{\"query\":\"weather\"}"}]}`)
+	out := normalizeXAIInputCustomToolCalls(body)
+
+	arguments := gjson.GetBytes(out, "input.0.arguments").String()
+	if got := gjson.Get(arguments, "query").String(); got != "weather" {
+		t.Fatalf("arguments.query = %q, want weather; arguments=%s body=%s", got, arguments, string(out))
+	}
+	if gjson.Get(arguments, "input").Exists() {
+		t.Fatalf("object input should not be wrapped under input: arguments=%s body=%s", arguments, string(out))
+	}
+}
+
+func TestNormalizeXAIInputCustomToolCalls_PreservesExistingArguments(t *testing.T) {
+	body := []byte(`{"model":"grok-4","input":[{"type":"custom_tool_call","call_id":"c0","name":"custom_lookup","arguments":"{\"query\":\"weather\"}"}]}`)
+	out := normalizeXAIInputCustomToolCalls(body)
+
+	if got := gjson.GetBytes(out, "input.0.type").String(); got != "function_call" {
+		t.Fatalf("input.0.type = %q, want function_call: %s", got, string(out))
+	}
+	arguments := gjson.GetBytes(out, "input.0.arguments").String()
+	if got := gjson.Get(arguments, "query").String(); got != "weather" {
+		t.Fatalf("arguments.query = %q, want weather; arguments=%s body=%s", got, arguments, string(out))
 	}
 }


### PR DESCRIPTION
Fixes #3704.

## Summary
- normalize xAI Responses `input` items from `custom_tool_call` to `function_call`
- map custom tool freeform `input` into JSON-object `arguments` strings accepted by xAI
- normalize `custom_tool_call_output` to `function_call_output` while preserving call output fields
- keep the existing xAI-only cleanup for orphaned `tool_choice`/`parallel_tool_calls` covered in the executor flow test
- incorporated Gemini review feedback to avoid repeated `input.Array()` calls and reduce JSON marshal/unmarshal overhead

## Tests
- `/usr/local/go/bin/go test ./internal/runtime/executor -run "TestXAIExecutorNormalizesCustomToolCallInput|TestNormalizeXAIInputCustomToolCalls|TestNormalizeXAIToolChoiceForTools" -count=1`
- `/usr/local/go/bin/go test ./internal/runtime/executor -count=1`
- `/usr/local/go/bin/go test ./... -count=1`
- `/usr/local/go/bin/go build -o test-output ./cmd/server && rm test-output`

Note: this stays in `internal/runtime/executor` and does not touch standalone translator code.