### PR TITLE
fix(codex): log account on token refresh failure

### DIFF
--- a/cmd/fetch_codex_models/main.go
+++ b/cmd/fetch_codex_models/main.go
@@ -195,7 +195,7 @@ func ensureAccessToken(ctx context.Context, store *sdkauth.FileTokenStore, auth 
 	}
 
 	svc := codexauth.NewCodexAuthWithProxyURL(nil, auth.ProxyURL)
-	tokenData, errRefresh := svc.RefreshTokensWithRetry(ctx, refreshToken, 3)
+	tokenData, errRefresh := svc.RefreshTokensWithRetry(ctx, refreshToken, 3, auth.ID)
 	if errRefresh != nil {
 		return "", false, errRefresh
 	}

--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -274,7 +274,7 @@ func (o *CodexAuth) CreateTokenStorage(bundle *CodexAuthBundle) *CodexTokenStora
 // RefreshTokensWithRetry refreshes tokens with a built-in retry mechanism.
 // It attempts to refresh the tokens up to a specified maximum number of retries,
 // with an exponential backoff strategy to handle transient network errors.
-func (o *CodexAuth) RefreshTokensWithRetry(ctx context.Context, refreshToken string, maxRetries int) (*CodexTokenData, error) {
+func (o *CodexAuth) RefreshTokensWithRetry(ctx context.Context, refreshToken string, maxRetries int, authID string) (*CodexTokenData, error) {
 	var lastErr error
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
@@ -292,12 +292,12 @@ func (o *CodexAuth) RefreshTokensWithRetry(ctx context.Context, refreshToken str
 			return tokenData, nil
 		}
 		if isNonRetryableRefreshErr(err) {
-			log.Warnf("Token refresh attempt %d failed with non-retryable error: %v", attempt+1, err)
+			log.Warnf("Token refresh attempt %d for auth %s failed with non-retryable error: %v", attempt+1, authID, err)
 			return nil, err
 		}
 
 		lastErr = err
-		log.Warnf("Token refresh attempt %d failed: %v", attempt+1, err)
+		log.Warnf("Token refresh attempt %d for auth %s failed: %v", attempt+1, authID, err)
 	}
 
 	return nil, fmt.Errorf("token refresh failed after %d attempts: %w", maxRetries, lastErr)

--- a/internal/auth/codex/openai_auth_test.go
+++ b/internal/auth/codex/openai_auth_test.go
@@ -33,7 +33,7 @@ func TestRefreshTokensWithRetry_NonRetryableOnlyAttemptsOnce(t *testing.T) {
 		},
 	}
 
-	_, err := auth.RefreshTokensWithRetry(context.Background(), "dummy_refresh_token", 3)
+	_, err := auth.RefreshTokensWithRetry(context.Background(), "dummy_refresh_token", 3, "test-auth")
 	if err == nil {
 		t.Fatalf("expected error for non-retryable refresh failure")
 	}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1386,7 +1386,7 @@ func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 		return auth, nil
 	}
 	svc := codexauth.NewCodexAuthWithProxyURL(e.cfg, auth.ProxyURL)
-	td, err := svc.RefreshTokensWithRetry(ctx, refreshToken, 3)
+	td, err := svc.RefreshTokensWithRetry(ctx, refreshToken, 3, auth.ID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# 中文
修复 Codex token 刷新失败日志缺少 auth 标识

在 Codex OAuth token 刷新重试日志中增加 auth 标识，使用与 selector 日志一致的 auth ID，便于定位 refresh_token_reused 等刷新失败对应的具体账号文件。

同时更新 fetch_codex_models 和相关测试中的 Codex RefreshTokensWithRetry 调用，保持函数签名一致。

# English
fix(codex): include auth identifier in token refresh failure logs

Add the auth identifier to Codex OAuth token refresh retry warnings, using the same auth ID shown in selector logs. This makes it easier to identify which auth entry is affected by failures such as refresh_token_reused.

Update the Codex RefreshTokensWithRetry call sites in fetch_codex_models and tests to match the new function signature.

<img width="3000" height="397" alt="image" src="https://github.com/user-attachments/assets/78f6e21c-1a1d-46b1-bdec-8f036b7c143e" />
