### PR TITLE
fix(codex): strip unsupported image generation tools

### DIFF
--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -37,6 +37,7 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 
 	// Delete the user field as it is not supported by the Codex upstream.
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "user")
+	rawJSON = filterUnsupportedTools(rawJSON)
 
 	// Convert role "system" to "developer" in input array to comply with Codex API requirements.
 	rawJSON = convertSystemRoleToDeveloper(rawJSON)
@@ -60,6 +61,34 @@ func applyResponsesCompactionCompatibility(rawJSON []byte) []byte {
 
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "context_management")
 	return rawJSON
+}
+
+// filterUnsupportedTools removes Responses built-in tools that Codex does not accept.
+func filterUnsupportedTools(rawJSON []byte) []byte {
+	tools := gjson.GetBytes(rawJSON, "tools")
+	if !tools.IsArray() {
+		return rawJSON
+	}
+
+	filtered := []byte("[]")
+	tools.ForEach(func(_, tool gjson.Result) bool {
+		if !isUnsupportedCodexResponsesTool(tool.Get("type").String()) {
+			filtered, _ = sjson.SetRawBytes(filtered, "-1", []byte(tool.Raw))
+		}
+		return true
+	})
+
+	if len(gjson.ParseBytes(filtered).Array()) == 0 {
+		rawJSON, _ = sjson.DeleteBytes(rawJSON, "tools")
+		return rawJSON
+	}
+
+	rawJSON, _ = sjson.SetRawBytes(rawJSON, "tools", filtered)
+	return rawJSON
+}
+
+func isUnsupportedCodexResponsesTool(toolType string) bool {
+	return toolType == "image_generation"
 }
 
 // convertSystemRoleToDeveloper traverses the input array and converts any message items

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
@@ -219,6 +219,69 @@ func TestConvertOpenAIResponsesRequestToCodex_OriginalIssue(t *testing.T) {
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToCodex_RemovesImageGenerationTools(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gpt-5.2",
+		"input": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [{"type": "input_text", "text": "Hello"}]
+			}
+		],
+		"tools": [
+			{"type": "image_generation", "model": "gpt-image-2"}
+		]
+	}`)
+
+	output := ConvertOpenAIResponsesRequestToCodex("gpt-5.2", inputJSON, false)
+	outputStr := string(output)
+
+	if gjson.Get(outputStr, "tools").Exists() {
+		t.Fatalf("expected image_generation tools to be removed, got: %s", outputStr)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToCodex_PreservesFunctionTools(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gpt-5.2",
+		"input": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [{"type": "input_text", "text": "Hello"}]
+			}
+		],
+		"tools": [
+			{"type": "image_generation", "model": "gpt-image-2"},
+			{
+				"type": "function",
+				"name": "lookup_order",
+				"description": "Look up an order",
+				"parameters": {
+					"type": "object",
+					"properties": {
+						"order_id": {"type": "string"}
+					}
+				}
+			}
+		]
+	}`)
+
+	output := ConvertOpenAIResponsesRequestToCodex("gpt-5.2", inputJSON, false)
+	outputStr := string(output)
+
+	if got := gjson.Get(outputStr, "tools.#").Int(); got != 1 {
+		t.Fatalf("expected exactly one function tool, got %d: %s", got, outputStr)
+	}
+	if got := gjson.Get(outputStr, "tools.0.type").String(); got != "function" {
+		t.Fatalf("expected function tool to be preserved, got %q: %s", got, outputStr)
+	}
+	if got := gjson.Get(outputStr, "tools.0.name").String(); got != "lookup_order" {
+		t.Fatalf("expected function tool name to be preserved, got %q: %s", got, outputStr)
+	}
+}
+
 // TestConvertSystemRoleToDeveloper_AssistantRole tests that assistant role is preserved
 func TestConvertSystemRoleToDeveloper_AssistantRole(t *testing.T) {
 	inputJSON := []byte(`{


### PR DESCRIPTION
Fixes #3725.

## Summary
- remove unsupported `image_generation` tools before forwarding OpenAI Responses requests to Codex
- drop the `tools` field when no supported tools remain
- preserve function tools and existing Codex built-in tool normalization

## Tests
- `go test ./internal/translator/codex/openai/...`
- `go test ./...`