### PR TITLE
fix: preserve OpenAI-compatible alias matching before canonical fallback

### DIFF
--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -233,7 +233,7 @@ func (l *authAutoRefreshLoop) handleDueAuth(ctx context.Context, now time.Time, 
 	}
 	next, shouldSchedule := nextRefreshCheckAt(now, auth, l.interval)
 	shouldRefresh := manager.shouldRefresh(auth, now)
-	exec := manager.executors[auth.Provider]
+	exec := manager.executors[executorProviderKey(auth.Provider)]
 	manager.mu.RUnlock()
 
 	if !shouldSchedule {

--- a/sdk/cliproxy/auth/auto_refresh_loop_test.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -30,6 +31,41 @@ func setRefreshLeadFactory(t *testing.T, provider string, factory func() *time.D
 		}
 		refreshLeadMu.Unlock()
 	})
+}
+
+func TestAutoRefreshLoopUsesCanonicalProviderKeyForExecutorLookup(t *testing.T) {
+	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
+	lead := 10 * time.Minute
+	setRefreshLeadFactory(t, "YT", func() *time.Duration {
+		d := lead
+		return &d
+	})
+
+	manager := NewManager(nil, nil, nil)
+	exec := &replaceAwareExecutor{id: "yt"}
+	manager.RegisterExecutor(exec)
+
+	const authID = "refresh-canonical-provider-auth"
+	manager.mu.Lock()
+	manager.auths[authID] = &Auth{
+		ID:       authID,
+		Provider: "YT",
+		Status:   StatusActive,
+		Metadata: map[string]any{"email": "x@example.com"},
+	}
+	manager.mu.Unlock()
+
+	loop := newAuthAutoRefreshLoop(manager, time.Hour, 1)
+	loop.handleDueAuth(context.Background(), now, authID)
+
+	select {
+	case got := <-loop.jobs:
+		if got != authID {
+			t.Fatalf("refresh job auth ID = %q, want %q", got, authID)
+		}
+	default:
+		t.Fatalf("expected refresh job to be queued for canonical provider executor lookup")
+	}
 }
 
 func TestNextRefreshCheckAt_DisabledUnschedule(t *testing.T) {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -228,6 +228,10 @@ func isBuiltInSelector(selector Selector) bool {
 	}
 }
 
+func executorProviderKey(provider string) string {
+	return strings.ToLower(strings.TrimSpace(provider))
+}
+
 func (m *Manager) syncSchedulerFromSnapshot(auths []*Auth) {
 	if m == nil || m.scheduler == nil {
 		return
@@ -726,6 +730,10 @@ func (m *Manager) authSupportsRouteModel(registryRef *registry.ModelRegistry, au
 	if registryRef == nil || auth == nil {
 		return true
 	}
+	rawRouteModel := strings.TrimSpace(routeModel)
+	if rawRouteModel != "" && registryRef.ClientSupportsModel(auth.ID, rawRouteModel) {
+		return true
+	}
 	routeKey := canonicalModelKey(routeModel)
 	if routeKey == "" {
 		return true
@@ -1121,7 +1129,7 @@ func (m *Manager) RegisterExecutor(executor ProviderExecutor) {
 	if executor == nil {
 		return
 	}
-	provider := strings.TrimSpace(executor.Identifier())
+	provider := executorProviderKey(executor.Identifier())
 	if provider == "" {
 		return
 	}
@@ -1142,7 +1150,7 @@ func (m *Manager) RegisterExecutor(executor ProviderExecutor) {
 
 // UnregisterExecutor removes the executor associated with the provider key.
 func (m *Manager) UnregisterExecutor(provider string) {
-	provider = strings.ToLower(strings.TrimSpace(provider))
+	provider = executorProviderKey(provider)
 	if provider == "" {
 		return
 	}
@@ -3081,19 +3089,13 @@ func (m *Manager) Executor(provider string) (ProviderExecutor, bool) {
 	if m == nil {
 		return nil, false
 	}
-	provider = strings.TrimSpace(provider)
+	provider = executorProviderKey(provider)
 	if provider == "" {
 		return nil, false
 	}
 
 	m.mu.RLock()
 	executor, okExecutor := m.executors[provider]
-	if !okExecutor {
-		lowerProvider := strings.ToLower(provider)
-		if lowerProvider != provider {
-			executor, okExecutor = m.executors[lowerProvider]
-		}
-	}
 	m.mu.RUnlock()
 
 	if !okExecutor || executor == nil {
@@ -3162,6 +3164,10 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		auth, exec, _, err := m.pickNextViaHome(ctx, model, opts, tried)
 		return auth, exec, err
 	}
+	provider = executorProviderKey(provider)
+	if provider == "" {
+		return nil, nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
+	}
 
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
 	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
@@ -3183,7 +3189,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 	}
 	registryRef := registry.GetGlobalRegistry()
 	for _, candidate := range m.auths {
-		if candidate.Provider != provider || candidate.Disabled {
+		if executorProviderKey(candidate.Provider) != provider || candidate.Disabled {
 			continue
 		}
 		if pinnedAuthID != "" && candidate.ID != pinnedAuthID {
@@ -3303,7 +3309,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 
 	providerSet := make(map[string]struct{}, len(providers))
 	for _, provider := range providers {
-		p := strings.TrimSpace(strings.ToLower(provider))
+		p := executorProviderKey(provider)
 		if p == "" {
 			continue
 		}
@@ -3334,7 +3340,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		if disallowFreeAuth && isFreeCodexAuth(candidate) {
 			continue
 		}
-		providerKey := strings.TrimSpace(strings.ToLower(candidate.Provider))
+		providerKey := executorProviderKey(candidate.Provider)
 		if providerKey == "" {
 			continue
 		}
@@ -3370,7 +3376,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		m.mu.RUnlock()
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "selector returned no auth"}
 	}
-	providerKey := strings.TrimSpace(strings.ToLower(selected.Provider))
+	providerKey := executorProviderKey(selected.Provider)
 	executor, okExecutor := m.executors[providerKey]
 	if !okExecutor {
 		m.mu.RUnlock()
@@ -3877,7 +3883,7 @@ func (m *Manager) findAllAntigravityCreditsCandidateAuths(routeModel string, opt
 		if !strings.Contains(strings.ToLower(strings.TrimSpace(routeModel)), "claude") {
 			continue
 		}
-		providerKey := strings.TrimSpace(strings.ToLower(auth.Provider))
+		providerKey := executorProviderKey(auth.Provider)
 		executor, ok := m.executors[providerKey]
 		if !ok {
 			continue
@@ -4369,7 +4375,7 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	var exec ProviderExecutor
 	var cloned *Auth
 	if auth != nil {
-		exec = m.executors[auth.Provider]
+		exec = m.executors[executorKeyFromAuth(auth)]
 		cloned = auth.Clone()
 	}
 	m.mu.RUnlock()
@@ -4428,6 +4434,10 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 }
 
 func (m *Manager) executorFor(provider string) ProviderExecutor {
+	provider = executorProviderKey(provider)
+	if provider == "" {
+		return nil
+	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.executors[provider]
@@ -4469,10 +4479,10 @@ func executorKeyFromAuth(auth *Auth) string {
 			if providerKey == "" {
 				providerKey = compatName
 			}
-			return strings.ToLower(providerKey)
+			return executorProviderKey(providerKey)
 		}
 	}
-	return strings.ToLower(strings.TrimSpace(auth.Provider))
+	return executorProviderKey(auth.Provider)
 }
 
 // logEntryWithRequestID returns a logrus entry with request_id field if available in context.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3160,6 +3160,9 @@ func (m *Manager) routeAwareSelectionRequired(auth *Auth, routeModel string) boo
 }
 
 func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
+	if m == nil {
+		return nil, nil, &Error{Code: "manager_nil", Message: "manager is nil"}
+	}
 	if m.HomeEnabled() {
 		auth, exec, _, err := m.pickNextViaHome(ctx, model, opts, tried)
 		return auth, exec, err
@@ -3300,6 +3303,9 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 }
 
 func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, string, error) {
+	if m == nil {
+		return nil, nil, "", &Error{Code: "manager_nil", Message: "manager is nil"}
+	}
 	if m.HomeEnabled() {
 		return m.pickNextViaHome(ctx, model, opts, tried)
 	}

--- a/sdk/cliproxy/auth/conductor_executor_replace_test.go
+++ b/sdk/cliproxy/auth/conductor_executor_replace_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
@@ -100,5 +101,40 @@ func TestManagerExecutorReturnsRegisteredExecutor(t *testing.T) {
 	_, okMissing := manager.Executor("unknown")
 	if okMissing {
 		t.Fatal("expected unknown provider lookup to fail")
+	}
+}
+
+func TestManagerMixedLegacyFindsExecutorWithCanonicalProviderKey(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	exec := &replaceAwareExecutor{id: "YT"}
+	manager.RegisterExecutor(exec)
+
+	const authID = "compat-auth-canonical-provider"
+	const routeModel = "YT-GPT-5.5(high)"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "yt", []*registry.ModelInfo{{ID: routeModel}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	_, errRegister := manager.Register(context.Background(), &Auth{
+		ID:       authID,
+		Provider: "yt",
+		Status:   StatusActive,
+	})
+	if errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	selected, selectedExec, provider, errPick := manager.pickNextMixedLegacy(context.Background(), []string{"yt"}, routeModel, cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixedLegacy() error = %v", errPick)
+	}
+	if selected == nil || selected.ID != authID {
+		t.Fatalf("pickNextMixedLegacy() auth ID = %v, want %q", selected, authID)
+	}
+	if selectedExec != exec {
+		t.Fatalf("pickNextMixedLegacy() executor = %T, want registered executor", selectedExec)
+	}
+	if provider != "yt" {
+		t.Fatalf("pickNextMixedLegacy() provider = %q, want yt", provider)
 	}
 }


### PR DESCRIPTION
## Summary
- normalize executor provider keys consistently when registering and resolving executors
- preserve exact route-model matching before falling back to canonical/selection keys
- add a regression test for mixed-case provider identifiers with suffixed OpenAI-compatible aliases

## Problem
OpenAI-compatible aliases that include a visible suffix such as `(high)` can be listed successfully, but fail during auth selection when the runtime checks support only against canonicalized model keys. If the registry stores the exact alias while selection strips the suffix first, the candidate auth can be filtered out before any upstream request is attempted.

## Root cause
`authSupportsRouteModel()` checked canonicalized route keys before considering the exact route model string, while OpenAI-compatible registries can expose the exact alias string as the supported model id. In mixed provider-id casing scenarios, executor lookup also benefits from using the same normalization helper everywhere.

## Fix
- add `executorProviderKey()` and use it consistently for executor register/lookup/unregister and legacy picker paths
- make `authSupportsRouteModel()` try the raw `routeModel` first, then fall back to canonical/selection keys
- add regression coverage for `Identifier() == "YT"`, auth provider `yt`, and route model `YT-GPT-5.5(high)`

## Validation
```bash
go test ./sdk/cliproxy/auth -run 'TestManager(ExecutorReturnsRegisteredExecutor|MixedLegacyFindsExecutorWithCanonicalProviderKey|RegisterExecutorClosesReplacedExecutionSessions)$'
go build -o /tmp/cli-proxy-api-pr-verify ./cmd/server && rm -f /tmp/cli-proxy-api-pr-verify
```
