### PR TITLE
[codex] Publish usage events for Shop ledger

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/store"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/tui"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -510,6 +511,7 @@ func main() {
 		log.Errorf("failed to configure log output: %v", err)
 		return
 	}
+	usage.RegisterUsageEventPluginFromEnv()
 
 	log.Infof("CLIProxyAPI Version: %s, Commit: %s, BuiltAt: %s", buildinfo.Version, buildinfo.Commit, buildinfo.BuildDate)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -92,6 +92,15 @@ usage-statistics-enabled: false
 # Default: 60. Max: 3600.
 redis-usage-queue-retention-seconds: 60
 
+# Usage event ledger for Shop/admin billing observability is configured by environment variables.
+# It is independent from usage-statistics-enabled and writes a local JSONL ledger before optional sync.
+# USAGE_EVENTS_ENABLED=true
+# USAGE_EVENTS_LOG_DIR=logs/usage
+# USAGE_EVENTS_RETENTION_DAYS=90
+# YUI_USAGE_EVENT_URL=http://127.0.0.1:4173/api/internal/usage-events
+# YUI_USAGE_EVENT_TOKEN=change-me-internal-token
+# YUI_USAGE_EVENT_HMAC_SECRET=change-me-hmac-secret
+
 # Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
 # Per-entry proxy-url also supports "direct" or "none" to bypass both the global proxy-url and environment proxies explicitly.
 proxy-url: ""

--- a/docs/ai/context/20260609-142133-usage-event-publisher-design_CN.md
+++ b/docs/ai/context/20260609-142133-usage-event-publisher-design_CN.md
@@ -1,0 +1,201 @@
+# CLIProxyAPI Usage Event 发布设计
+
+## 背景
+
+`CLIProxyAPI` 已有 `UsageReporter` 和 `sdk/cliproxy/usage` 插件机制。当前内存 usage 统计适合运行期看板，但不适合作为 `yui.web` Shop 的月度用量账本。
+
+第一阶段需要让 `CLIProxyAPI` 在不影响模型请求可用性的前提下，把每个 client API Key 的 usage record 写成本地结构化 JSONL，并实时同步到同机 `yui.web`。
+
+## 目标
+
+- 复用现有 usage record，不解析普通 request-log。
+- 为每个 usage record 生成结构化 usage event。
+- 本地按月写 JSONL，记录所有 client API Key，包括 `LOCAL` key。
+- 实时 POST 到 `yui.web`，由 `yui.web` 关联 Shop 订单和未托管 key。
+- 不记录 prompt、response body、完整 API Key、客户端 IP。
+- 同步失败或本地写入失败不影响用户请求。
+
+## 非目标
+
+- 不替换现有 `/v0/management/usage`。
+- 不用普通 request-log 做账本。
+- 不在 CLIProxyAPI 侧做金额计算。
+- 不在 CLIProxyAPI 侧判断是否 Shop key。
+- 不因为 usage event 同步失败而拒绝模型请求。
+
+## 现有可复用能力
+
+- `sdk/cliproxy/usage/manager.go` 已支持注册 usage plugin。
+- `internal/runtime/executor/helps/usage_helpers.go` 已从 Gin context 中读取 `apiKey`，并构造 `usage.Record`。
+- 各 executor 已在 streaming/non-streaming 路径解析 usage 并调用 `reporter.Publish`。
+- `UsageReporter.EnsurePublished` 已能在上游没有 usage 时保证请求计数。
+
+## 事件生成位置
+
+新增一个 usage plugin，监听 `sdk/cliproxy/usage.Record`。
+
+推荐位置：
+
+```text
+internal/usage/event_plugin.go
+```
+
+职责：
+
+- 从 `usage.Record` 和 Gin context 中提取事件字段。
+- 生成或读取 `request_id`。
+- 生成 `api_key_hash` 和 `api_key_preview`。
+- 规范化 token、时间、成功/失败状态。
+- 发送给本地 JSONL writer。
+- 发送给 yui.web sync client。
+
+## Usage Event 字段
+
+```json
+{
+  "version": 1,
+  "request_id": "req_...",
+  "api_key_hash": "sha256_hex",
+  "api_key_preview": "sk-...abcd",
+  "provider": "codex",
+  "model": "gpt-5.4",
+  "endpoint": "/v1/responses",
+  "source": "upstream account label or email",
+  "auth_index": "0",
+  "success": true,
+  "failed": false,
+  "input_tokens": 0,
+  "output_tokens": 0,
+  "reasoning_tokens": 0,
+  "cached_tokens": 0,
+  "total_tokens": 0,
+  "latency_ms": 0,
+  "requested_at": "2026-06-09T14:21:33+09:00"
+}
+```
+
+字段来源：
+
+- `provider`：`usage.Record.Provider`。
+- `model`：`usage.Record.Model`，为空时使用 `unknown`。
+- `source`：`usage.Record.Source`。
+- `auth_index`：`usage.Record.AuthIndex`。
+- token 字段：`usage.Record.Detail`。
+- `requested_at`：`usage.Record.RequestedAt`，为空时使用当前时间。
+- `latency_ms`：`usage.Record.Latency`。
+- `endpoint`：从 Gin context 的 `FullPath()` 或 `Request.URL.Path` 读取。
+- `api_key_hash` / `api_key_preview`：从 `usage.Record.APIKey` 生成。
+- `request_id`：优先使用现有 request id；没有时生成随机唯一 ID。
+
+## API Key 处理
+
+- 完整 API Key 只在内存中用于 hash 和 preview。
+- JSONL、同步事件、yui.web SQLite 都不保存完整 API Key。
+- hash 使用稳定 SHA-256 十六进制值，方便 yui.web 对已有 `api_keys.api_key` 回填同样 hash。
+- preview 沿用现有风格，例如前缀 + 后 6 位；preview 只用于展示，不能作为关联键。
+
+## 本地 JSONL
+
+文件路径：
+
+```text
+<usage-log-dir>/usage-events-YYYY-MM.jsonl
+```
+
+默认建议：
+
+```text
+logs/usage/usage-events-YYYY-MM.jsonl
+```
+
+规则：
+
+- 每行一个完整 usage event JSON。
+- 文件按 `requested_at` 所在月份切分。
+- 写入采用 append。
+- 写入失败只记录应用错误日志，不影响模型请求。
+- 清理 90 天之前的 usage JSONL。
+- 清理逻辑只处理 `usage-events-*.jsonl`，不碰普通 request log 和 error log。
+
+## yui.web 同步
+
+同步 URL：
+
+```text
+http://127.0.0.1:4173/api/internal/usage-events
+```
+
+请求头：
+
+```text
+x-internal-token: <token>
+x-usage-timestamp: <unix seconds>
+x-usage-signature: <hex hmac>
+content-type: application/json
+```
+
+签名：
+
+```text
+HMAC_SHA256(secret, timestamp + "\n" + raw_body)
+```
+
+行为：
+
+- 先写本地 JSONL，再尝试同步 yui.web。
+- 同步失败不重试阻塞当前请求。
+- 同步失败写应用错误日志，并保留本地 JSONL 供后续导入。
+- yui.web 用 `request_id` 幂等去重，重复同步不会重复计数。
+
+## 配置建议
+
+MVP 可用环境变量，避免改动过多配置结构：
+
+```env
+USAGE_EVENTS_ENABLED=true
+USAGE_EVENTS_LOG_DIR=logs/usage
+USAGE_EVENTS_RETENTION_DAYS=90
+YUI_USAGE_EVENT_URL=http://127.0.0.1:4173/api/internal/usage-events
+YUI_USAGE_EVENT_TOKEN=<same-as-yui-internal-token>
+YUI_USAGE_EVENT_HMAC_SECRET=<strong-random-secret>
+```
+
+后续如果要通过管理面板修改，再把这些配置迁入 `config.yaml`。
+
+## 失败语义
+
+- usage event 生成失败：记录错误，不影响请求。
+- JSONL 写失败：记录错误，不影响请求。
+- yui.web POST 失败：记录错误，不影响请求。
+- HMAC 配置缺失：本地 JSONL 仍可写；同步禁用并记录配置错误。
+- URL 未配置：只写本地 JSONL。
+
+## 与现有 usage 统计关系
+
+- 保留现有 `internal/usage/logger_plugin.go` 内存统计。
+- 新 usage event plugin 与现有 logger plugin 并行注册。
+- `usage-statistics-enabled` 只控制内存统计，不应阻止 JSONL 账本记录。
+- 如果需要单独开关，使用 `USAGE_EVENTS_ENABLED`。
+
+## 测试范围
+
+- event 不包含完整 API Key。
+- API Key hash 对同一 key 稳定。
+- preview 不为空且不能恢复完整 key。
+- request_id 缺失时生成唯一 ID。
+- token total 为 0 时按 input + output + reasoning 兜底。
+- failed record 没有 usage 时仍写入失败请求事件。
+- 月度 JSONL 文件名正确。
+- JSONL append 格式为一行一个 JSON。
+- 90 天清理只删除 usage JSONL。
+- 同步请求 HMAC 正确。
+- 同步失败不返回错误给 usage manager。
+- URL 或 secret 缺失时只写本地 JSONL。
+- streaming/non-streaming 路径都能触发 event。
+
+## 与 yui.web 的分工
+
+- CLIProxyAPI：只负责真实请求 usage 事件。
+- yui.web：负责订单关联、SQLite 账本、管理员展示、手动导入。
+- CLIProxyAPI 不判断一个 key 是否属于 Shop。
+- yui.web 未匹配到 Shop 订单时，把 key 显示为本地/未托管。

--- a/docs/ai/context/20260609-142619-usage-event-publisher-implementation-plan_CN.md
+++ b/docs/ai/context/20260609-142619-usage-event-publisher-implementation-plan_CN.md
@@ -1,0 +1,138 @@
+# CLIProxyAPI Usage Event Publisher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a non-blocking usage event publisher to CLIProxyAPI that writes monthly local JSONL and syncs signed usage events to yui.web.
+
+**Architecture:** Reuse the existing `sdk/cliproxy/usage` plugin pipeline so every executor path that already publishes usage can produce a structured event. The publisher writes a local JSONL ledger first, then optionally POSTs to yui.web with `x-internal-token`, timestamp, and HMAC signature; all failures are logged but never propagated to the user request.
+
+**Tech Stack:** Go, existing CLIProxyAPI usage manager, logrus, Gin request context, HTTP client, HMAC SHA-256, JSONL files.
+
+---
+
+## Scope
+
+This is the CLIProxyAPI-side execution slice of the cross-repo plan. The yui.web-side canonical plan is:
+
+`/Users/wujianxiang/CodeSpace/yui.web/docs/ai/context/20260609-142619-shop-usage-monitoring-mvp-implementation-plan_CN.md`
+
+## File Structure
+
+- Create `internal/usage/event_types.go`: event DTO and helper functions.
+- Create `internal/usage/event_writer.go`: JSONL writer and retention cleanup.
+- Create `internal/usage/event_sync.go`: signed sync client.
+- Create `internal/usage/event_plugin.go`: plugin wiring.
+- Create or extend `internal/usage/event_plugin_test.go`: unit tests.
+- Modify `cmd/server/main.go`: register publisher from environment.
+- Modify `config.example.yaml`: document env settings.
+
+## Task 1: Event Types and API Key Privacy
+
+**Files:**
+- Create: `internal/usage/event_types.go`
+- Test: `internal/usage/event_plugin_test.go`
+
+- [ ] Write tests proving marshaled events do not contain full API keys.
+- [ ] Write tests proving key hash is stable and preview is non-empty.
+- [ ] Write tests proving token totals normalize from input + output + reasoning when total is zero.
+- [ ] Run `go test ./internal/usage -run TestUsageEvent -count=1` and confirm failure.
+- [ ] Implement `UsageEvent`, `newUsageEvent`, `hashAPIKey`, `resolveEventRequestID`, and `resolveEventEndpoint`.
+- [ ] Run `go test ./internal/usage -run TestUsageEvent -count=1` and confirm pass.
+- [ ] Commit:
+
+```bash
+git add internal/usage/event_types.go internal/usage/event_plugin_test.go
+git commit -m "feat: add usage event model"
+```
+
+## Task 2: Monthly JSONL Ledger
+
+**Files:**
+- Create: `internal/usage/event_writer.go`
+- Test: `internal/usage/event_plugin_test.go`
+
+- [ ] Write tests for append-only monthly JSONL files.
+- [ ] Write tests for 90-day cleanup limited to `usage-events-*.jsonl`.
+- [ ] Run `go test ./internal/usage -run TestUsageEventWriter -count=1` and confirm failure.
+- [ ] Implement writer with `usage-events-YYYY-MM.jsonl` naming, append writes, and safe directory creation.
+- [ ] Run `go test ./internal/usage -run TestUsageEventWriter -count=1` and confirm pass.
+- [ ] Commit:
+
+```bash
+git add internal/usage/event_writer.go internal/usage/event_plugin_test.go
+git commit -m "feat: write usage event jsonl"
+```
+
+## Task 3: Signed yui.web Sync Client
+
+**Files:**
+- Create: `internal/usage/event_sync.go`
+- Test: `internal/usage/event_plugin_test.go`
+
+- [ ] Write tests with `httptest.Server` that assert `x-internal-token`, `x-usage-timestamp`, and `x-usage-signature`.
+- [ ] Write tests that server failure returns an error to the plugin but does not panic.
+- [ ] Run `go test ./internal/usage -run TestUsageEventSync -count=1` and confirm failure.
+- [ ] Implement HMAC over `timestamp + "\n" + raw_body`.
+- [ ] Run `go test ./internal/usage -run TestUsageEventSync -count=1` and confirm pass.
+- [ ] Commit:
+
+```bash
+git add internal/usage/event_sync.go internal/usage/event_plugin_test.go
+git commit -m "feat: sign usage event sync"
+```
+
+## Task 4: Plugin Registration
+
+**Files:**
+- Create: `internal/usage/event_plugin.go`
+- Modify: `cmd/server/main.go`
+- Modify: `config.example.yaml`
+- Test: `internal/usage/event_plugin_test.go`
+
+- [ ] Write tests for enabled env, disabled env, sync failure, and JSONL write failure behavior.
+- [ ] Run `go test ./internal/usage -run TestUsageEventPlugin -count=1` and confirm failure.
+- [ ] Implement `RegisterUsageEventPluginFromEnv`.
+- [ ] Register from `cmd/server/main.go`.
+- [ ] Document env settings in `config.example.yaml`.
+- [ ] Run:
+
+```bash
+go test ./internal/usage -count=1
+go build -o test-output ./cmd/server
+rm test-output
+```
+
+- [ ] Commit:
+
+```bash
+git add internal/usage/event_plugin.go internal/usage/event_plugin_test.go cmd/server/main.go config.example.yaml
+git commit -m "feat: publish usage events"
+```
+
+## Task 5: Integration With yui.web
+
+**Files:**
+- Modify only files with bugs found during integration.
+
+- [ ] Start yui.web with internal token and HMAC secret.
+- [ ] Start CLIProxyAPI with matching env values.
+- [ ] Send one test request with a local client key.
+- [ ] Confirm `logs/usage/usage-events-YYYY-MM.jsonl` exists.
+- [ ] Confirm yui.web receives or can import the event.
+- [ ] Run:
+
+```bash
+go test ./internal/usage -count=1
+go build -o test-output ./cmd/server
+rm test-output
+```
+
+- [ ] Commit verification note if integration changes operational assumptions.
+
+## Implementation Guardrails
+
+- Never write full API keys to event JSON, logs, tests, or API responses.
+- Never record prompt, response body, or client IP.
+- Never let JSONL or sync errors block model requests.
+- Do not make `usage-statistics-enabled` gate the JSONL event ledger.
+- Keep all new code outside `internal/translator/`.

--- a/docs/ai/context/20260609-152720-usage-event-publisher-implementation_CN.md
+++ b/docs/ai/context/20260609-152720-usage-event-publisher-implementation_CN.md
@@ -1,0 +1,63 @@
+# Usage Event Publisher Implementation
+
+## 背景
+
+本次实现 API Key 用量监控 MVP 的 CLIProxyAPI 侧能力。目标是从现有 `sdk/cliproxy/usage` 记录生成结构化 usage event，先写本地月度 JSONL，再可选同步到同机 `yui.web` 内部接口。
+
+## 改动范围
+
+- 新增 `internal/usage/event_types.go`
+  - 定义 `UsageEvent`。
+  - 生成 `api_key_hash` 和 `api_key_preview`。
+  - 解析 request id、endpoint、token breakdown、latency、requested_at。
+  - 对 `source` 中可能嵌入的 API key / token 进行脱敏，避免 JSONL 或 sync event 保存完整 secret。
+- 新增 `internal/usage/event_writer.go`
+  - 按 `requested_at` 写入 `usage-events-YYYY-MM.jsonl`。
+  - 每行一个 JSON event。
+  - 目录权限收紧为 `0700`，文件权限为 `0600`。
+  - retention 只清理字面目录内过期的普通 `usage-events-*.jsonl` 文件，不跟随 symlink。
+- 新增 `internal/usage/event_sync.go`
+  - POST 到 yui.web。
+  - 请求头包含 `x-internal-token`、`x-usage-timestamp`、`x-usage-signature`。
+  - HMAC 口径为 `timestamp + "\n" + raw_body`。
+  - 遵循项目 timeout 约束，没有额外设置 HTTP client timeout。
+- 新增 `internal/usage/event_plugin.go`
+  - 注册 usage plugin。
+  - `USAGE_EVENTS_ENABLED=true` 时启用。
+  - `USAGE_EVENTS_LOG_DIR`、`USAGE_EVENTS_RETENTION_DAYS` 控制本地账本。
+  - `YUI_USAGE_EVENT_URL`、`YUI_USAGE_EVENT_TOKEN`、`YUI_USAGE_EVENT_HMAC_SECRET` 控制可选同步。
+  - JSONL 写入或同步失败只记录 warning，不影响模型请求。
+- 修改 `cmd/server/main.go`
+  - 启动时从环境变量注册 usage event plugin。
+- 修改 `config.example.yaml`
+  - 追加 env-only usage event 配置说明。
+
+## 验证
+
+通过：
+
+```bash
+go test ./internal/usage -count=1
+go build -o test-output ./cmd/server && rm test-output
+```
+
+补充运行：
+
+```bash
+go test ./...
+```
+
+该命令未全量通过，失败点在既有的非本任务测试：
+
+- `internal/api/modules/amp` 的 `TestModifyResponse_GzipScenarios/skips_non_2xx_status`
+- `internal/runtime/executor` 的 `TestEnsureQwenSystemMessage_MergeStringSystem`
+- `sdk/cliproxy` 的 `TestServiceApplyCoreAuthAddOrUpdate_DeleteReAddDoesNotInheritStaleRuntimeState`
+
+这些失败不在本次 usage event 改动文件范围内。
+
+## 安全边界
+
+- event、JSONL、sync body 不保存完整 client API key。
+- `source` 字段如果等于或嵌入 token-like secret，会被脱敏。
+- 不记录 prompt、response body、客户端 IP。
+- HMAC secret 和 internal token 只通过环境变量配置，不写入代码。

--- a/docs/ai/context/20260609-153509-usage-event-empty-api-key-boundary_CN.md
+++ b/docs/ai/context/20260609-153509-usage-event-empty-api-key-boundary_CN.md
@@ -1,0 +1,25 @@
+# Usage Event Empty API Key Boundary
+
+## 背景
+
+API Key 用量监控 MVP 的账本目标是按 client API key 统计 token 和请求量。自审时发现如果某条 `usage.Record` 没有 `APIKey`，旧实现会对空字符串计算 SHA-256，并在 JSONL / yui.web 中形成一个空 key 的未托管用量项。
+
+## 决策
+
+`usageEventPlugin.HandleUsage` 遇到空白 `record.APIKey` 时直接跳过，不写本地 JSONL，也不同步到 yui.web。
+
+## 原因
+
+- 没有 client API key 就无法归属到用户、Shop 订单或本地 key。
+- 空字符串 hash 会把所有缺失 key 的事件聚合成同一个伪 key，污染管理员看板。
+- 跳过缺失 key 的 record 不影响已有 `UsageReporter` 的内存统计能力，只影响新增的 per-key 账本。
+
+## 验证
+
+新增测试：
+
+```bash
+go test ./internal/usage -run TestUsageEventPluginSkipsRecordWithoutAPIKey -count=1
+```
+
+结果通过，确认缺失 API key 时不会写 JSONL，也不会触发 sync。

--- a/internal/usage/event_plugin.go
+++ b/internal/usage/event_plugin.go
@@ -1,0 +1,107 @@
+package usage
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	defaultUsageEventLogDir        = "logs/usage"
+	defaultUsageEventRetentionDays = 90
+)
+
+type usageEventSyncer interface {
+	sync(ctx context.Context, event UsageEvent) error
+}
+
+type usageEventPlugin struct {
+	writer *usageEventWriter
+	syncer usageEventSyncer
+}
+
+func newUsageEventPlugin(writer *usageEventWriter, syncer usageEventSyncer) *usageEventPlugin {
+	return &usageEventPlugin{writer: writer, syncer: syncer}
+}
+
+func (p *usageEventPlugin) HandleUsage(ctx context.Context, record coreusage.Record) {
+	if p == nil {
+		return
+	}
+	if strings.TrimSpace(record.APIKey) == "" {
+		return
+	}
+	event := newUsageEvent(ctx, record)
+	if p.writer != nil {
+		if err := p.writer.write(event); err != nil {
+			log.WithError(err).Warn("usage event write failed")
+		}
+	}
+	if p.syncer != nil {
+		if err := p.syncer.sync(ctx, event); err != nil {
+			log.WithError(err).Warn("usage event sync failed")
+		}
+	}
+}
+
+func RegisterUsageEventPluginFromEnv() bool {
+	plugin, enabled := newUsageEventPluginFromEnv()
+	if !enabled || plugin == nil {
+		return false
+	}
+	coreusage.RegisterPlugin(plugin)
+	return true
+}
+
+func newUsageEventPluginFromEnv() (*usageEventPlugin, bool) {
+	if !usageEventEnvEnabled(os.Getenv("USAGE_EVENTS_ENABLED")) {
+		return nil, false
+	}
+
+	logDir := strings.TrimSpace(os.Getenv("USAGE_EVENTS_LOG_DIR"))
+	if logDir == "" {
+		logDir = defaultUsageEventLogDir
+	}
+	retentionDays := parseUsageEventRetentionDays(os.Getenv("USAGE_EVENTS_RETENTION_DAYS"))
+	writer := newUsageEventWriter(logDir, retentionDays)
+
+	syncer := usageEventSyncer(nil)
+	url := strings.TrimSpace(os.Getenv("YUI_USAGE_EVENT_URL"))
+	token := strings.TrimSpace(os.Getenv("YUI_USAGE_EVENT_TOKEN"))
+	hmacSecret := strings.TrimSpace(os.Getenv("YUI_USAGE_EVENT_HMAC_SECRET"))
+	if url != "" {
+		if token == "" || hmacSecret == "" {
+			log.Warn("usage event sync disabled because token or hmac secret is empty")
+		} else {
+			syncer = newUsageEventSyncClient(url, token, hmacSecret)
+		}
+	}
+
+	return newUsageEventPlugin(writer, syncer), true
+}
+
+func usageEventEnvEnabled(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true", "1", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseUsageEventRetentionDays(value string) int {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return defaultUsageEventRetentionDays
+	}
+	days, err := strconv.Atoi(trimmed)
+	if err != nil {
+		log.WithError(err).Warn("invalid USAGE_EVENTS_RETENTION_DAYS, using default")
+		return defaultUsageEventRetentionDays
+	}
+	return days
+}

--- a/internal/usage/event_plugin_test.go
+++ b/internal/usage/event_plugin_test.go
@@ -1,0 +1,645 @@
+package usage
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+const (
+	testAPIKey     = "sk-test-secret-value-123456"
+	testAPIKeyHash = "5bfe2fcb866dba4b0eaea7173dfdfbaea58874001c6f909745fd729a830365f0"
+)
+
+func TestUsageEventRedactsAPIKeyAndNormalisesTokens(t *testing.T) {
+	record := coreusage.Record{
+		Provider:    " codex ",
+		Model:       "",
+		APIKey:      "  " + testAPIKey + "  ",
+		Source:      " proxy ",
+		AuthIndex:   " 7 ",
+		RequestedAt: time.Date(2026, 6, 9, 12, 30, 45, 123456789, time.UTC),
+		Latency:     1250 * time.Millisecond,
+		Failed:      false,
+		Detail: coreusage.Detail{
+			InputTokens:     10,
+			OutputTokens:    20,
+			ReasoningTokens: 3,
+			CachedTokens:    -99,
+			TotalTokens:     0,
+		},
+	}
+
+	event := newUsageEvent(context.Background(), record)
+	payload, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal usage event: %v", err)
+	}
+	payloadText := string(payload)
+
+	if strings.Contains(payloadText, testAPIKey) {
+		t.Fatal("marshaled event contains full API key")
+	}
+	if event.APIKeyHash == "" {
+		t.Fatal("expected non-empty API key hash")
+	}
+	if event.APIKeyHash != testAPIKeyHash {
+		t.Fatalf("expected stable API key hash, got %q want %q", event.APIKeyHash, testAPIKeyHash)
+	}
+	if event.APIKeyPreview == "" {
+		t.Fatal("expected non-empty API key preview")
+	}
+	if event.APIKeyPreview == testAPIKey {
+		t.Fatal("expected API key preview to differ from full API key")
+	}
+	if event.Model != "unknown" {
+		t.Fatalf("expected unknown model for empty model, got %q", event.Model)
+	}
+	if event.CachedTokens != 0 {
+		t.Fatalf("expected negative cached tokens to become 0, got %d", event.CachedTokens)
+	}
+	if event.TotalTokens != 33 {
+		t.Fatalf("expected total tokens fallback to input + output + reasoning, got %d", event.TotalTokens)
+	}
+	if event.Provider != "codex" {
+		t.Fatalf("expected trimmed provider, got %q", event.Provider)
+	}
+	if event.Source != "proxy" {
+		t.Fatalf("expected trimmed source, got %q", event.Source)
+	}
+	if event.AuthIndex != "7" {
+		t.Fatalf("expected trimmed auth index, got %q", event.AuthIndex)
+	}
+	if event.Success != true || event.Failed != false {
+		t.Fatalf("expected success=true failed=false, got success=%v failed=%v", event.Success, event.Failed)
+	}
+	if event.LatencyMs != 1250 {
+		t.Fatalf("expected latency in milliseconds, got %d", event.LatencyMs)
+	}
+	if event.RequestedAt != record.RequestedAt.Format(time.RFC3339Nano) {
+		t.Fatalf("expected requested_at from record, got %q", event.RequestedAt)
+	}
+}
+
+func TestUsageEventNegativeTokensBecomeZero(t *testing.T) {
+	event := newUsageEvent(context.Background(), coreusage.Record{
+		APIKey: testAPIKey,
+		Detail: coreusage.Detail{
+			InputTokens:     -1,
+			OutputTokens:    -2,
+			ReasoningTokens: -3,
+			CachedTokens:    -4,
+			TotalTokens:     -5,
+		},
+	})
+
+	if event.InputTokens != 0 {
+		t.Fatalf("expected input tokens to become 0, got %d", event.InputTokens)
+	}
+	if event.OutputTokens != 0 {
+		t.Fatalf("expected output tokens to become 0, got %d", event.OutputTokens)
+	}
+	if event.ReasoningTokens != 0 {
+		t.Fatalf("expected reasoning tokens to become 0, got %d", event.ReasoningTokens)
+	}
+	if event.CachedTokens != 0 {
+		t.Fatalf("expected cached tokens to become 0, got %d", event.CachedTokens)
+	}
+	if event.TotalTokens != 0 {
+		t.Fatalf("expected total tokens to become 0, got %d", event.TotalTokens)
+	}
+}
+
+func TestUsageEventRedactsSourceWhenItContainsAPIKey(t *testing.T) {
+	event := newUsageEvent(context.Background(), coreusage.Record{
+		APIKey: testAPIKey,
+		Source: "  " + testAPIKey + "  ",
+	})
+	payload, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal usage event: %v", err)
+	}
+
+	if event.Source == testAPIKey {
+		t.Fatal("expected source credential to be redacted")
+	}
+	if strings.Contains(string(payload), testAPIKey) {
+		t.Fatal("marshaled event contains full source credential")
+	}
+}
+
+func TestUsageEventRedactsEmbeddedSourceSecrets(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		secret     string
+		wantPrefix string
+	}{
+		{
+			name:       "bearer api key",
+			source:     "Bearer " + testAPIKey,
+			secret:     testAPIKey,
+			wantPrefix: "Bearer ",
+		},
+		{
+			name:       "source parameter token",
+			source:     "source=sk-test-secret-value-abcdef",
+			secret:     "sk-test-secret-value-abcdef",
+			wantPrefix: "source=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := newUsageEvent(context.Background(), coreusage.Record{
+				APIKey: testAPIKey,
+				Source: tt.source,
+			})
+			payload, err := json.Marshal(event)
+			if err != nil {
+				t.Fatalf("marshal usage event: %v", err)
+			}
+
+			if strings.Contains(event.Source, tt.secret) {
+				t.Fatal("source contains full embedded credential")
+			}
+			if strings.Contains(string(payload), tt.secret) {
+				t.Fatal("marshaled event contains full embedded source credential")
+			}
+			if !strings.HasPrefix(event.Source, tt.wantPrefix) {
+				t.Fatalf("expected source to preserve non-secret prefix for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestUsageEventHashAPIKeyTrimsAndUsesStableSHA256(t *testing.T) {
+	if got := hashAPIKey("  " + testAPIKey + "  "); got != testAPIKeyHash {
+		t.Fatalf("hashAPIKey() = %q, want %q", got, testAPIKeyHash)
+	}
+}
+
+func TestUsageEventRequestIDFromContext(t *testing.T) {
+	ctx := logging.WithRequestID(context.Background(), "req-context")
+
+	if got := resolveEventRequestID(ctx); got != "req-context" {
+		t.Fatalf("resolveEventRequestID() = %q, want %q", got, "req-context")
+	}
+}
+
+func TestUsageEventEndpointUsesGinRequestPathFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions?stream=true", nil)
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+
+	if got := resolveEventEndpoint(ctx); got != "/v1/chat/completions" {
+		t.Fatalf("resolveEventEndpoint() = %q, want %q", got, "/v1/chat/completions")
+	}
+}
+
+func TestUsageEventWriterAppendsMonthlyJSONL(t *testing.T) {
+	dir := t.TempDir()
+	event := newUsageEvent(context.Background(), coreusage.Record{
+		APIKey:      testAPIKey,
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+		Detail: coreusage.Detail{
+			InputTokens:  1,
+			OutputTokens: 2,
+		},
+	})
+	event.RequestID = "req-jsonl"
+
+	writer := newUsageEventWriter(dir, 0)
+	if err := writer.write(event); err != nil {
+		t.Fatalf("write usage event: %v", err)
+	}
+
+	path := filepath.Join(dir, "usage-events-2026-06.jsonl")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read usage event ledger: %v", err)
+	}
+	lines := strings.Split(strings.TrimSuffix(string(content), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected one JSONL line, got %d", len(lines))
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &payload); err != nil {
+		t.Fatalf("expected valid JSONL payload: %v", err)
+	}
+	if payload["request_id"] != "req-jsonl" {
+		t.Fatalf("expected request_id in payload, got %q", payload["request_id"])
+	}
+	if strings.Contains(lines[0], testAPIKey) {
+		t.Fatal("JSONL payload contains full API key")
+	}
+}
+
+func TestUsageEventWriterAppendsWithoutOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	writer := newUsageEventWriter(dir, 0)
+
+	first := newUsageEvent(context.Background(), coreusage.Record{
+		APIKey:      testAPIKey,
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+	})
+	first.RequestID = "req-jsonl-1"
+	second := first
+	second.RequestID = "req-jsonl-2"
+
+	if err := writer.write(first); err != nil {
+		t.Fatalf("write first usage event: %v", err)
+	}
+	if err := writer.write(second); err != nil {
+		t.Fatalf("write second usage event: %v", err)
+	}
+
+	path := filepath.Join(dir, "usage-events-2026-06.jsonl")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read usage event ledger: %v", err)
+	}
+	lines := strings.Split(strings.TrimSuffix(string(content), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected two JSONL lines, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "req-jsonl-1") || !strings.Contains(lines[1], "req-jsonl-2") {
+		t.Fatal("expected appended request IDs in order")
+	}
+}
+
+func TestUsageEventWriterCleanupOnlyUsageJSONL(t *testing.T) {
+	dir := t.TempDir()
+	oldJSONL := filepath.Join(dir, "usage-events-2026-01.jsonl")
+	oldRequestLog := filepath.Join(dir, "request.log")
+	oldTextLedger := filepath.Join(dir, "usage-events-2026-01.txt")
+	oldSubDir := filepath.Join(dir, "usage-events-2026-02.jsonl")
+
+	for _, path := range []string{oldJSONL, oldRequestLog, oldTextLedger} {
+		if err := os.WriteFile(path, []byte("old\n"), 0o600); err != nil {
+			t.Fatalf("write fixture %s: %v", path, err)
+		}
+	}
+	if err := os.Mkdir(oldSubDir, 0o700); err != nil {
+		t.Fatalf("create fixture subdir: %v", err)
+	}
+	oldTime := time.Now().Add(-48 * time.Hour)
+	for _, path := range []string{oldJSONL, oldRequestLog, oldTextLedger, oldSubDir} {
+		if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+			t.Fatalf("age fixture %s: %v", path, err)
+		}
+	}
+
+	event := newUsageEvent(context.Background(), coreusage.Record{
+		APIKey:      testAPIKey,
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+	})
+	event.RequestID = "req-jsonl"
+
+	writer := newUsageEventWriter(dir, 1)
+	if err := writer.write(event); err != nil {
+		t.Fatalf("write usage event: %v", err)
+	}
+
+	if _, err := os.Stat(oldJSONL); !os.IsNotExist(err) {
+		t.Fatalf("expected old JSONL ledger to be deleted, stat err=%v", err)
+	}
+	for _, path := range []string{oldRequestLog, oldTextLedger, oldSubDir} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected non-JSONL fixture to remain at %s: %v", path, err)
+		}
+	}
+}
+
+func TestUsageEventWriterCleanupHandlesGlobSpecialCharsInDirectory(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "usage[events]")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatalf("create usage event dir fixture: %v", err)
+	}
+
+	oldJSONL := filepath.Join(dir, "usage-events-2026-01.jsonl")
+	if err := os.WriteFile(oldJSONL, []byte("old\n"), 0o600); err != nil {
+		t.Fatalf("write old usage event ledger: %v", err)
+	}
+	oldTime := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(oldJSONL, oldTime, oldTime); err != nil {
+		t.Fatalf("age old usage event ledger: %v", err)
+	}
+
+	event := newUsageEvent(context.Background(), coreusage.Record{
+		APIKey:      testAPIKey,
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+	})
+	event.RequestID = "req-jsonl"
+
+	writer := newUsageEventWriter(dir, 1)
+	if err := writer.write(event); err != nil {
+		t.Fatalf("write usage event: %v", err)
+	}
+
+	if _, err := os.Stat(oldJSONL); !os.IsNotExist(err) {
+		t.Fatalf("expected old JSONL ledger in literal glob dir to be deleted, stat err=%v", err)
+	}
+}
+
+func TestUsageEventWriterCleanupSkipsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target-ledger.jsonl")
+	link := filepath.Join(dir, "usage-events-2026-03.jsonl")
+	if err := os.WriteFile(target, []byte("old\n"), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	oldTime := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(target, oldTime, oldTime); err != nil {
+		t.Fatalf("age symlink target: %v", err)
+	}
+
+	event := newUsageEvent(context.Background(), coreusage.Record{
+		APIKey:      testAPIKey,
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+	})
+	event.RequestID = "req-jsonl"
+
+	writer := newUsageEventWriter(dir, 1)
+	if err := writer.write(event); err != nil {
+		t.Fatalf("write usage event: %v", err)
+	}
+
+	if info, err := os.Lstat(link); err != nil {
+		t.Fatalf("expected symlink ledger to remain: %v", err)
+	} else if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected ledger fixture to remain a symlink")
+	}
+}
+
+func TestUsageEventWriterCleanupSkipsBrokenSymlink(t *testing.T) {
+	dir := t.TempDir()
+	link := filepath.Join(dir, "usage-events-2026-04.jsonl")
+	if err := os.Symlink(filepath.Join(dir, "missing-target.jsonl"), link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	event := newUsageEvent(context.Background(), coreusage.Record{
+		APIKey:      testAPIKey,
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+	})
+	event.RequestID = "req-jsonl"
+
+	writer := newUsageEventWriter(dir, 1)
+	if err := writer.write(event); err != nil {
+		t.Fatalf("write usage event with broken symlink fixture: %v", err)
+	}
+
+	if info, err := os.Lstat(link); err != nil {
+		t.Fatalf("expected broken symlink ledger to remain: %v", err)
+	} else if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected broken ledger fixture to remain a symlink")
+	}
+}
+
+func TestUsageEventWriterTightensExistingDirectoryPermissions(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatalf("relax temp dir permissions: %v", err)
+	}
+
+	event := newUsageEvent(context.Background(), coreusage.Record{
+		APIKey:      testAPIKey,
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+	})
+	event.RequestID = "req-jsonl"
+
+	writer := newUsageEventWriter(dir, 0)
+	if err := writer.write(event); err != nil {
+		t.Fatalf("write usage event: %v", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat usage event dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("expected usage event dir permissions 0700, got %o", got)
+	}
+}
+
+func TestUsageEventSyncClientSignsRequest(t *testing.T) {
+	event := newUsageEvent(context.Background(), coreusage.Record{
+		APIKey:      testAPIKey,
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+	})
+	event.RequestID = "req-sync"
+
+	const internalToken = "internal-token"
+	const hmacSecret = "hmac-secret"
+	var sawRequest bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("x-internal-token"); got != internalToken {
+			t.Fatalf("x-internal-token = %q, want %q", got, internalToken)
+		}
+		timestamp := r.Header.Get("x-usage-timestamp")
+		if timestamp == "" {
+			t.Fatal("missing x-usage-timestamp")
+		}
+		if _, err := strconv.ParseInt(timestamp, 10, 64); err != nil {
+			t.Fatalf("invalid timestamp header: %v", err)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		if strings.Contains(string(body), testAPIKey) {
+			t.Fatal("sync request body contains full API key")
+		}
+		expectedSignature := signUsageEventBody(hmacSecret, timestamp, body)
+		if got := r.Header.Get("x-usage-signature"); got != expectedSignature {
+			t.Fatalf("x-usage-signature = %q, want %q", got, expectedSignature)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"inserted":1,"skipped":0}`))
+	}))
+	defer server.Close()
+
+	client := newUsageEventSyncClient(server.URL, internalToken, hmacSecret)
+	if err := client.sync(context.Background(), event); err != nil {
+		t.Fatalf("sync usage event: %v", err)
+	}
+	if !sawRequest {
+		t.Fatal("expected sync request")
+	}
+}
+
+func TestUsageEventSyncClientReportsServerFailure(t *testing.T) {
+	event := UsageEvent{Version: 1, RequestID: "req-sync-failure", RequestedAt: "2026-06-09T12:00:00Z"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"failed"}`))
+	}))
+	defer server.Close()
+
+	client := newUsageEventSyncClient(server.URL, "internal-token", "hmac-secret")
+	if err := client.sync(context.Background(), event); err == nil {
+		t.Fatal("expected server failure error")
+	}
+}
+
+func signUsageEventBody(secret, timestamp string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp))
+	_, _ = mac.Write([]byte("\n"))
+	_, _ = mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestUsageEventPluginWritesJSONLAndSyncs(t *testing.T) {
+	dir := t.TempDir()
+	syncer := &recordingUsageEventSyncer{}
+	plugin := newUsageEventPlugin(newUsageEventWriter(dir, 0), syncer)
+
+	plugin.HandleUsage(context.Background(), coreusage.Record{
+		APIKey:      testAPIKey,
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+		Detail:      coreusage.Detail{InputTokens: 1, OutputTokens: 2},
+	})
+
+	content, err := os.ReadFile(filepath.Join(dir, "usage-events-2026-06.jsonl"))
+	if err != nil {
+		t.Fatalf("read usage event ledger: %v", err)
+	}
+	if strings.Contains(string(content), testAPIKey) {
+		t.Fatal("usage event ledger contains full API key")
+	}
+	if len(syncer.events) != 1 {
+		t.Fatalf("synced event count = %d, want 1", len(syncer.events))
+	}
+	if syncer.events[0].Model != "gpt-5.4" {
+		t.Fatalf("synced model = %q, want gpt-5.4", syncer.events[0].Model)
+	}
+}
+
+func TestUsageEventPluginContinuesWhenSyncFails(t *testing.T) {
+	dir := t.TempDir()
+	plugin := newUsageEventPlugin(newUsageEventWriter(dir, 0), failingUsageEventSyncer{})
+
+	plugin.HandleUsage(context.Background(), coreusage.Record{
+		APIKey:      testAPIKey,
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+	})
+
+	if _, err := os.Stat(filepath.Join(dir, "usage-events-2026-06.jsonl")); err != nil {
+		t.Fatalf("expected JSONL write despite sync failure: %v", err)
+	}
+}
+
+func TestUsageEventPluginSkipsRecordWithoutAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	syncer := &recordingUsageEventSyncer{}
+	plugin := newUsageEventPlugin(newUsageEventWriter(dir, 0), syncer)
+
+	plugin.HandleUsage(context.Background(), coreusage.Record{
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+		Detail:      coreusage.Detail{InputTokens: 1, OutputTokens: 2},
+	})
+
+	if _, err := os.Stat(filepath.Join(dir, "usage-events-2026-06.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("expected no JSONL write for missing API key, stat err=%v", err)
+	}
+	if len(syncer.events) != 0 {
+		t.Fatalf("expected no sync for missing API key, got %d event(s)", len(syncer.events))
+	}
+}
+
+func TestUsageEventPluginFromEnvDisabled(t *testing.T) {
+	t.Setenv("USAGE_EVENTS_ENABLED", "false")
+	t.Setenv("USAGE_EVENTS_LOG_DIR", t.TempDir())
+
+	plugin, enabled := newUsageEventPluginFromEnv()
+	if enabled {
+		t.Fatal("expected usage event plugin to be disabled")
+	}
+	if plugin != nil {
+		t.Fatal("expected disabled usage event plugin to be nil")
+	}
+}
+
+func TestUsageEventPluginFromEnvEnabledWritesJSONLWithoutSyncConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("USAGE_EVENTS_ENABLED", "true")
+	t.Setenv("USAGE_EVENTS_LOG_DIR", dir)
+	t.Setenv("USAGE_EVENTS_RETENTION_DAYS", "0")
+	t.Setenv("YUI_USAGE_EVENT_URL", "")
+	t.Setenv("YUI_USAGE_EVENT_TOKEN", "")
+	t.Setenv("YUI_USAGE_EVENT_HMAC_SECRET", "")
+
+	plugin, enabled := newUsageEventPluginFromEnv()
+	if !enabled {
+		t.Fatal("expected usage event plugin to be enabled")
+	}
+	if plugin == nil {
+		t.Fatal("expected usage event plugin")
+	}
+	plugin.HandleUsage(context.Background(), coreusage.Record{
+		APIKey:      testAPIKey,
+		Model:       "gpt-5.4",
+		RequestedAt: time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+	})
+
+	if _, err := os.Stat(filepath.Join(dir, "usage-events-2026-06.jsonl")); err != nil {
+		t.Fatalf("expected env-enabled plugin to write JSONL: %v", err)
+	}
+}
+
+type recordingUsageEventSyncer struct {
+	events []UsageEvent
+}
+
+func (s *recordingUsageEventSyncer) sync(ctx context.Context, event UsageEvent) error {
+	s.events = append(s.events, event)
+	return nil
+}
+
+type failingUsageEventSyncer struct{}
+
+func (failingUsageEventSyncer) sync(ctx context.Context, event UsageEvent) error {
+	return errors.New("sync failed")
+}

--- a/internal/usage/event_sync.go
+++ b/internal/usage/event_sync.go
@@ -1,0 +1,84 @@
+package usage
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type usageEventSyncClient struct {
+	url        string
+	token      string
+	hmacSecret string
+	httpClient *http.Client
+}
+
+func newUsageEventSyncClient(url, token, hmacSecret string) *usageEventSyncClient {
+	return &usageEventSyncClient{
+		url:        strings.TrimSpace(url),
+		token:      strings.TrimSpace(token),
+		hmacSecret: strings.TrimSpace(hmacSecret),
+		httpClient: http.DefaultClient,
+	}
+}
+
+func (c *usageEventSyncClient) sync(ctx context.Context, event UsageEvent) error {
+	if c == nil || c.url == "" {
+		return nil
+	}
+	if c.token == "" {
+		return fmt.Errorf("usage event sync token is empty")
+	}
+	if c.hmacSecret == "" {
+		return fmt.Errorf("usage event sync hmac secret is empty")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	body, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal usage event sync body: %w", err)
+	}
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create usage event sync request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("x-internal-token", c.token)
+	request.Header.Set("x-usage-timestamp", timestamp)
+	request.Header.Set("x-usage-signature", signUsageEventSyncBody(c.hmacSecret, timestamp, body))
+
+	client := c.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("post usage event sync request: %w", err)
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("usage event sync status %d", response.StatusCode)
+	}
+	return nil
+}
+
+func signUsageEventSyncBody(secret, timestamp string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(timestamp))
+	_, _ = mac.Write([]byte("\n"))
+	_, _ = mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/usage/event_types.go
+++ b/internal/usage/event_types.go
@@ -1,0 +1,239 @@
+package usage
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+// UsageEvent is the stable DTO emitted by usage event publishers.
+type UsageEvent struct {
+	Version         int    `json:"version"`
+	RequestID       string `json:"request_id"`
+	APIKeyHash      string `json:"api_key_hash"`
+	APIKeyPreview   string `json:"api_key_preview"`
+	Provider        string `json:"provider"`
+	Model           string `json:"model"`
+	Endpoint        string `json:"endpoint"`
+	Source          string `json:"source"`
+	AuthIndex       string `json:"auth_index"`
+	Success         bool   `json:"success"`
+	Failed          bool   `json:"failed"`
+	InputTokens     int64  `json:"input_tokens"`
+	OutputTokens    int64  `json:"output_tokens"`
+	ReasoningTokens int64  `json:"reasoning_tokens"`
+	CachedTokens    int64  `json:"cached_tokens"`
+	TotalTokens     int64  `json:"total_tokens"`
+	LatencyMs       int64  `json:"latency_ms"`
+	RequestedAt     string `json:"requested_at"`
+}
+
+func newUsageEvent(ctx context.Context, record coreusage.Record) UsageEvent {
+	requestedAt := record.RequestedAt
+	if requestedAt.IsZero() {
+		requestedAt = time.Now()
+	}
+
+	inputTokens, outputTokens, reasoningTokens, cachedTokens, totalTokens := normaliseEventTokens(record.Detail)
+	failed := record.Failed
+
+	model := strings.TrimSpace(record.Model)
+	if model == "" {
+		model = "unknown"
+	}
+
+	return UsageEvent{
+		Version:         1,
+		RequestID:       resolveEventRequestID(ctx),
+		APIKeyHash:      hashAPIKey(record.APIKey),
+		APIKeyPreview:   previewAPIKey(record.APIKey),
+		Provider:        strings.TrimSpace(record.Provider),
+		Model:           model,
+		Endpoint:        resolveEventEndpoint(ctx),
+		Source:          normaliseEventSource(record.Source, record.APIKey),
+		AuthIndex:       strings.TrimSpace(record.AuthIndex),
+		Success:         !failed,
+		Failed:          failed,
+		InputTokens:     inputTokens,
+		OutputTokens:    outputTokens,
+		ReasoningTokens: reasoningTokens,
+		CachedTokens:    cachedTokens,
+		TotalTokens:     totalTokens,
+		LatencyMs:       normaliseLatency(record.Latency),
+		RequestedAt:     requestedAt.Format(time.RFC3339Nano),
+	}
+}
+
+func hashAPIKey(apiKey string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(apiKey)))
+	return hex.EncodeToString(sum[:])
+}
+
+func resolveEventRequestID(ctx context.Context) string {
+	if ginCtx := eventGinContext(ctx); ginCtx != nil {
+		if requestID := strings.TrimSpace(logging.GetGinRequestID(ginCtx)); requestID != "" {
+			return requestID
+		}
+	}
+	if requestID := strings.TrimSpace(logging.GetRequestID(ctx)); requestID != "" {
+		return requestID
+	}
+	return "usage_" + logging.GenerateRequestID() + "_" + strconv.FormatInt(time.Now().UnixNano(), 10)
+}
+
+func resolveEventEndpoint(ctx context.Context) string {
+	ginCtx := eventGinContext(ctx)
+	if ginCtx == nil {
+		return ""
+	}
+	if path := ginCtx.FullPath(); path != "" {
+		return path
+	}
+	if ginCtx.Request == nil || ginCtx.Request.URL == nil {
+		return ""
+	}
+	return ginCtx.Request.URL.Path
+}
+
+func normaliseEventTokens(detail coreusage.Detail) (int64, int64, int64, int64, int64) {
+	inputTokens := normaliseEventToken(detail.InputTokens)
+	outputTokens := normaliseEventToken(detail.OutputTokens)
+	reasoningTokens := normaliseEventToken(detail.ReasoningTokens)
+	cachedTokens := normaliseEventToken(detail.CachedTokens)
+	totalTokens := normaliseEventToken(detail.TotalTokens)
+	if totalTokens == 0 {
+		totalTokens = inputTokens + outputTokens + reasoningTokens
+	}
+	return inputTokens, outputTokens, reasoningTokens, cachedTokens, totalTokens
+}
+
+func normaliseEventToken(token int64) int64 {
+	if token < 0 {
+		return 0
+	}
+	return token
+}
+
+func normaliseLatency(latency time.Duration) int64 {
+	if latency < 0 {
+		return 0
+	}
+	return latency.Milliseconds()
+}
+
+func previewAPIKey(apiKey string) string {
+	return redactEventSecret(apiKey)
+}
+
+func normaliseEventSource(source, apiKey string) string {
+	trimmedSource := strings.TrimSpace(source)
+	if trimmedSource == "" {
+		return ""
+	}
+	if trimmedSource == strings.TrimSpace(apiKey) {
+		return redactEventSecret(trimmedSource)
+	}
+	redactedSource := redactEmbeddedEventSourceSecrets(trimmedSource, apiKey)
+	if looksLikeEventSecret(redactedSource) {
+		return redactEventSecret(redactedSource)
+	}
+	return redactedSource
+}
+
+func redactEventSecret(value string) string {
+	preview := util.HideAPIKey(value)
+	if strings.TrimSpace(value) != "" && preview == value {
+		return "***"
+	}
+	return preview
+}
+
+func redactEmbeddedEventSourceSecrets(source, apiKey string) string {
+	trimmedAPIKey := strings.TrimSpace(apiKey)
+	if trimmedAPIKey != "" {
+		source = strings.ReplaceAll(source, trimmedAPIKey, redactEventSecret(trimmedAPIKey))
+	}
+
+	var builder strings.Builder
+	tokenStart := -1
+	flushToken := func(end int) {
+		if tokenStart < 0 {
+			return
+		}
+		token := source[tokenStart:end]
+		if looksLikeEventSecret(token) {
+			builder.WriteString(redactEventSecret(token))
+		} else {
+			builder.WriteString(token)
+		}
+		tokenStart = -1
+	}
+
+	for i, r := range source {
+		if isEventSecretTokenRune(r) {
+			if tokenStart < 0 {
+				tokenStart = i
+			}
+			continue
+		}
+		flushToken(i)
+		builder.WriteRune(r)
+	}
+	flushToken(len(source))
+	return builder.String()
+}
+
+func isEventSecretTokenRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9') ||
+		r == '-' ||
+		r == '_' ||
+		r == '.'
+}
+
+func looksLikeEventSecret(value string) bool {
+	lowerValue := strings.ToLower(value)
+	if strings.HasPrefix(lowerValue, "sk-") || strings.HasPrefix(lowerValue, "codex_") {
+		return true
+	}
+	if len(value) < 32 || strings.Contains(value, "@") {
+		return false
+	}
+
+	hasLetter := false
+	hasDigit := false
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			hasLetter = true
+		case r >= 'A' && r <= 'Z':
+			hasLetter = true
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return false
+		}
+	}
+	return hasLetter && hasDigit
+}
+
+func eventGinContext(ctx context.Context) *gin.Context {
+	if ctx == nil {
+		return nil
+	}
+	ginCtx, ok := ctx.Value("gin").(*gin.Context)
+	if !ok {
+		return nil
+	}
+	return ginCtx
+}

--- a/internal/usage/event_writer.go
+++ b/internal/usage/event_writer.go
@@ -1,0 +1,110 @@
+package usage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type usageEventWriter struct {
+	dir           string
+	retentionDays int
+}
+
+func newUsageEventWriter(dir string, retentionDays int) *usageEventWriter {
+	return &usageEventWriter{
+		dir:           dir,
+		retentionDays: retentionDays,
+	}
+}
+
+func (w *usageEventWriter) write(event UsageEvent) error {
+	if err := os.MkdirAll(w.dir, 0o700); err != nil {
+		return fmt.Errorf("create usage event directory: %w", err)
+	}
+	if err := os.Chmod(w.dir, 0o700); err != nil {
+		return fmt.Errorf("set usage event directory permissions: %w", err)
+	}
+
+	path := filepath.Join(w.dir, "usage-events-"+resolveUsageEventMonth(event)+".jsonl")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("open usage event ledger: %w", err)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		if closeErr := file.Close(); closeErr != nil {
+			return fmt.Errorf("set usage event ledger permissions: %w; close usage event ledger: %w", err, closeErr)
+		}
+		return fmt.Errorf("set usage event ledger permissions: %w", err)
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		if closeErr := file.Close(); closeErr != nil {
+			return fmt.Errorf("marshal usage event: %w; close usage event ledger: %w", err, closeErr)
+		}
+		return fmt.Errorf("marshal usage event: %w", err)
+	}
+	payload = append(payload, '\n')
+	if _, err := file.Write(payload); err != nil {
+		if closeErr := file.Close(); closeErr != nil {
+			return fmt.Errorf("write usage event ledger: %w; close usage event ledger: %w", err, closeErr)
+		}
+		return fmt.Errorf("write usage event ledger: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close usage event ledger: %w", err)
+	}
+
+	if err := w.cleanupExpiredLedgers(); err != nil {
+		return fmt.Errorf("cleanup usage event ledgers: %w", err)
+	}
+	return nil
+}
+
+func resolveUsageEventMonth(event UsageEvent) string {
+	requestedAt, err := time.Parse(time.RFC3339Nano, event.RequestedAt)
+	if err != nil {
+		requestedAt = time.Now()
+	}
+	return requestedAt.Format("2006-01")
+}
+
+func (w *usageEventWriter) cleanupExpiredLedgers() error {
+	if w.retentionDays <= 0 {
+		return nil
+	}
+
+	entries, err := os.ReadDir(w.dir)
+	if err != nil {
+		return fmt.Errorf("list usage event ledgers: %w", err)
+	}
+	cutoff := time.Now().AddDate(0, 0, -w.retentionDays)
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, "usage-events-") || !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+		path := filepath.Join(w.dir, name)
+		info, err := os.Lstat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("stat usage event ledger %s: %w", path, err)
+		}
+		if !info.Mode().IsRegular() || !info.ModTime().Before(cutoff) {
+			continue
+		}
+		if err := os.Remove(path); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("remove expired usage event ledger %s: %w", path, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add a usage event publisher plugin that converts existing usage records into privacy-preserving per-key ledger events.
- Write monthly local JSONL ledgers and optionally sync signed events to yui.web via token + HMAC headers.
- Document environment-only setup for Shop/admin billing observability.

## Validation
- go test -count=1 ./internal/usage
- go build -o test-output ./cmd/server && rm test-output

## Review notes
- This clean branch is based on the latest upstream main and intentionally excludes the older inbound-limit/local-key branch.
- Events skip records without a client API key to avoid empty-key ledger buckets.
- Event bodies do not include full client API keys, prompts, response bodies, or client IPs.