### PR TITLE
fix(auth/codex): de-duplicate concurrent token refreshes via singleflight

### DIFF
--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/singleflight"
 )
 
 // OAuth configuration constants for OpenAI Codex
@@ -180,14 +181,43 @@ func (o *CodexAuth) ExchangeCodeForTokensWithRedirect(ctx context.Context, code,
 	return bundle, nil
 }
 
+// codexRefreshGroup de-duplicates concurrent refreshes for the same refresh token
+// within this process. OpenAI rotates the refresh token on every successful refresh
+// and immediately invalidates the previous one, so two concurrent refreshes of the
+// same token would race: the first succeeds while the second sends the now-stale
+// token and fails with "refresh_token_reused". singleflight collapses concurrent
+// refreshes of the same token into a single upstream call whose result is shared.
+var codexRefreshGroup singleflight.Group
+
 // RefreshTokens refreshes an access token using a refresh token.
 // This method is called when an access token has expired. It makes a request to the
-// token endpoint to obtain a new set of tokens.
+// token endpoint to obtain a new set of tokens. Concurrent calls for the same refresh
+// token are collapsed via singleflight to avoid refresh_token_reused races caused by
+// rotating refresh tokens.
 func (o *CodexAuth) RefreshTokens(ctx context.Context, refreshToken string) (*CodexTokenData, error) {
 	if refreshToken == "" {
 		return nil, fmt.Errorf("refresh token is required")
 	}
 
+	// Use WithoutCancel so a single caller's cancellation does not abort the shared
+	// refresh that other waiting callers depend on.
+	result, err, _ := codexRefreshGroup.Do(refreshToken, func() (interface{}, error) {
+		return o.refreshTokensSingleFlight(context.WithoutCancel(ctx), refreshToken)
+	})
+	if err != nil {
+		return nil, err
+	}
+	tokenData, ok := result.(*CodexTokenData)
+	if !ok || tokenData == nil {
+		return nil, fmt.Errorf("token refresh failed: invalid single-flight result")
+	}
+	return tokenData, nil
+}
+
+// refreshTokensSingleFlight performs the actual token refresh HTTP request against the
+// OpenAI token endpoint. It is invoked by RefreshTokens through singleflight so that at
+// most one in-flight refresh runs per refresh token at a time.
+func (o *CodexAuth) refreshTokensSingleFlight(ctx context.Context, refreshToken string) (*CodexTokenData, error) {
 	data := url.Values{
 		"client_id":     {ClientID},
 		"grant_type":    {"refresh_token"},

--- a/internal/auth/codex/openai_auth_test.go
+++ b/internal/auth/codex/openai_auth_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
@@ -42,6 +44,69 @@ func TestRefreshTokensWithRetry_NonRetryableOnlyAttemptsOnce(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&calls); got != 1 {
 		t.Fatalf("expected 1 refresh attempt, got %d", got)
+	}
+}
+
+// TestRefreshTokens_ConcurrentSingleFlight verifies that concurrent refreshes for the
+// same refresh token are collapsed into a single upstream call. OpenAI rotates the
+// refresh token on each success, so without de-duplication concurrent refreshes race
+// and the loser fails with refresh_token_reused.
+func TestRefreshTokens_ConcurrentSingleFlight(t *testing.T) {
+	const concurrency = 8
+	var calls int32
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	auth := &CodexAuth{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				atomic.AddInt32(&calls, 1)
+				select {
+				case entered <- struct{}{}:
+				default:
+				}
+				// Block so concurrent callers coalesce into the in-flight refresh.
+				<-release
+				body := `{"access_token":"new_access","refresh_token":"new_refresh","id_token":"","expires_in":3600}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			}),
+		},
+	}
+
+	var (
+		wg      sync.WaitGroup
+		started sync.WaitGroup
+		results = make([]error, concurrency)
+	)
+	started.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			started.Done()
+			_, err := auth.RefreshTokens(context.Background(), "shared_refresh_token")
+			results[idx] = err
+		}(i)
+	}
+
+	started.Wait()
+	<-entered                         // the single upstream call has reached the transport
+	time.Sleep(50 * time.Millisecond) // let the remaining callers coalesce via singleflight
+	close(release)                    // allow the upstream call to complete
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected exactly 1 upstream refresh call, got %d", got)
+	}
+	for i, err := range results {
+		if err != nil {
+			t.Fatalf("concurrent refresh %d failed: %v", i, err)
+		}
 	}
 }
 


### PR DESCRIPTION
### What

Wrap `(*CodexAuth).RefreshTokens` in a package-level `singleflight.Group` keyed by the refresh token, so concurrent refreshes for the same Codex (OpenAI) credential collapse into a single upstream call whose result is shared.

Fixes #3783.

### Why

OpenAI rotates refresh tokens on every successful refresh and immediately invalidates the previous one. The Codex refresh path had no in-process de-duplication, so two concurrent refreshes of the same token race: the first succeeds and rotates the token, while the second sends the now-stale token and fails with `refresh_token_reused`.

The Claude auth path (`internal/auth/claude/anthropic_auth.go`) already solves this with `singleflight`; this change brings Codex in line.

### How

`internal/auth/codex/openai_auth.go`:
- Add a package-level `var codexRefreshGroup singleflight.Group`.
- `RefreshTokens` now calls `codexRefreshGroup.Do(refreshToken, ...)`; the actual HTTP exchange moves into a new unexported `refreshTokensSingleFlight`.
- The inner call uses `context.WithoutCancel(ctx)` so one caller's cancellation does not abort the shared refresh that other waiting callers depend on.
- The group is package-level on purpose: the executor constructs a fresh `CodexAuth` per refresh, so an instance-scoped group would not de-duplicate.

### Test

Added `TestRefreshTokens_ConcurrentSingleFlight`: launches N concurrent `RefreshTokens` calls for the same token against a blocking transport and asserts exactly one upstream call is made and all callers succeed.

```
go test -race -run 'TestRefreshTokens|TestNewCodexAuth' ./internal/auth/codex/
```

passes.

### Scope / limitation

`singleflight` de-duplicates **within a single process** only. Multiple processes sharing the same auth store still race the rotating token and need a single-writer guarantee at the deployment level — noted in #3783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
