### PR TITLE
fix(logging): track Codex backend request IDs

### DIFF
--- a/internal/logging/gin_logger.go
+++ b/internal/logging/gin_logger.go
@@ -26,7 +26,7 @@ var aiAPIPrefixes = []string{
 	"/v1/responses",
 	"/v1beta/models/",
 	"/api/provider/",
-	"/backend-api/codex",
+	"/backend-api/codex/",
 }
 
 const (

--- a/internal/logging/gin_logger.go
+++ b/internal/logging/gin_logger.go
@@ -26,6 +26,7 @@ var aiAPIPrefixes = []string{
 	"/v1/responses",
 	"/v1beta/models/",
 	"/api/provider/",
+	"/backend-api/codex",
 }
 
 const (

--- a/internal/logging/gin_logger_test.go
+++ b/internal/logging/gin_logger_test.go
@@ -84,6 +84,9 @@ func TestIsAIAPIPathIncludesCodexBackend(t *testing.T) {
 			t.Fatalf("expected %s to be treated as AI API path", path)
 		}
 	}
+	if isAIAPIPath("/backend-api/codex-status") {
+		t.Fatalf("expected /backend-api/codex-status not to be treated as AI API path")
+	}
 }
 
 func TestGinLogrusLoggerAddsRequestIDForCodexBackend(t *testing.T) {

--- a/internal/logging/gin_logger_test.go
+++ b/internal/logging/gin_logger_test.go
@@ -73,3 +73,44 @@ func TestIsAIAPIPathIncludesImages(t *testing.T) {
 		t.Fatalf("expected /v1/videos/video_123 to be treated as AI API path")
 	}
 }
+
+func TestIsAIAPIPathIncludesCodexBackend(t *testing.T) {
+	paths := []string{
+		"/backend-api/codex/responses",
+		"/backend-api/codex/responses/compact",
+	}
+	for _, path := range paths {
+		if !isAIAPIPath(path) {
+			t.Fatalf("expected %s to be treated as AI API path", path)
+		}
+	}
+}
+
+func TestGinLogrusLoggerAddsRequestIDForCodexBackend(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	engine.Use(GinLogrusLogger())
+
+	var requestIDFromContext string
+	var requestIDFromGin string
+	engine.POST("/backend-api/codex/responses", func(c *gin.Context) {
+		requestIDFromContext = GetRequestID(c.Request.Context())
+		requestIDFromGin = GetGinRequestID(c)
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/backend-api/codex/responses", nil)
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", recorder.Code)
+	}
+	if requestIDFromContext == "" {
+		t.Fatalf("expected request ID in request context")
+	}
+	if requestIDFromGin != requestIDFromContext {
+		t.Fatalf("expected Gin request ID %q to match context request ID %q", requestIDFromGin, requestIDFromContext)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds request ID tracking for Codex backend-compatible routes.
- Covers:
  - `/backend-api/codex/responses`
  - `/backend-api/codex/responses/compact`
- Adds regression tests for path matching and request ID propagation.

Fixes #3787

## Why

Redis usage payloads use the request context to populate `request_id`.

Before this change, `/backend-api/codex/...` requests did not receive request ID tracking, so `internal/redisqueue/plugin.go` could publish usage records with an empty `request_id`.

Downstream usage consumers such as `cpa-usage-keeper` require `request_id` for decoding, persistence, and log correlation. Empty `request_id` payloads are rejected instead of being counted.

## Changes

- `internal/logging/gin_logger.go`
  - Include `/backend-api/codex` in AI API paths that receive request ID tracking.

- `internal/logging/gin_logger_test.go`
  - Add coverage for Codex backend path matching.
  - Add coverage that `GinLogrusLogger()` writes the generated request ID into both Gin context and request context for Codex backend requests.

## Compatibility

No usage payload schema changes.

This only makes Codex backend-compatible routes receive the same request ID behavior already used by other AI API routes such as `/v1/responses`.

## Test plan

```bash
go test ./internal/logging
go test ./internal/redisqueue
go build -o /tmp/cli-proxy-api-test-output ./cmd/server
```

All passed.