### PR TITLE
feat(translator): freeform custom tool (apply_patch) downgrade for OpenAI Responses

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_custom_tool_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_custom_tool_test.go
@@ -1,0 +1,221 @@
+package responses
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// customToolRequest is a minimal Responses-API request declaring apply_patch as
+// a freeform `custom` tool alongside a regular `function` tool (shell). The
+// response side uses the request's tools list to decide which tool calls must
+// be re-emitted as custom_tool_call (bare input) vs function_call (JSON args).
+const customToolRequest = `{"model":"gpt-5","tools":[` +
+	`{"type":"custom","name":"apply_patch","description":"Use the apply_patch tool to edit files."},` +
+	`{"type":"function","name":"shell","parameters":{"type":"object","properties":{"command":{"type":"string"}}}}` +
+	`]}`
+
+// barePatch is the literal text the Codex host expects inside custom_tool_call.input.
+const barePatch = "*** Begin Patch\n*** Add File: /tmp/x.txt\n+hi\n*** End Patch"
+
+// Streaming: a Claude tool_use for apply_patch (declared custom) must come back
+// as a custom_tool_call carrying bare `input` text (no JSON wrapper, no
+// arguments field).
+func TestConvertClaudeResponse_Stream_CustomToolEmitsCustomToolCall(t *testing.T) {
+	// The model was told to wrap the payload into the JSON `input` argument;
+	// emit it as two input_json_delta fragments to mimic real streaming.
+	lines := []string{
+		`data: {"type":"message_start","message":{"id":"msg_cust","usage":{"input_tokens":5}}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"id":"toolu_patch","type":"tool_use","name":"apply_patch"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"input\":\"*** Begin Patch\\n*** Add File: /tmp/x.txt\\n"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"+hi\\n*** End Patch\"}"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"message_stop"}`,
+	}
+
+	req := []byte(customToolRequest)
+	var state any
+	var addedItem, inputDone, doneItem, completed string
+	for _, ln := range lines {
+		evs := ConvertClaudeResponseToOpenAIResponses(context.Background(), "claude", req, req, []byte(ln), &state)
+		for _, e := range evs {
+			s := string(e)
+			if strings.Contains(s, "response.output_item.added") && strings.Contains(s, `"custom_tool_call"`) {
+				addedItem = s
+			}
+			if strings.Contains(s, "response.custom_tool_call_input.done") {
+				inputDone = s
+			}
+			if strings.Contains(s, "response.output_item.done") && strings.Contains(s, `"custom_tool_call"`) {
+				doneItem = s
+			}
+			if strings.Contains(s, "response.completed") {
+				completed = s
+			}
+		}
+	}
+
+	if addedItem == "" {
+		t.Fatal("expected an output_item.added event with type custom_tool_call")
+	}
+	addedPayload := addedItem[strings.Index(addedItem, "{"):]
+	if got := gjson.Get(addedPayload, "item.type").String(); got != "custom_tool_call" {
+		t.Fatalf("added item.type = %q, want custom_tool_call: %s", got, addedPayload)
+	}
+	if got := gjson.Get(addedPayload, "item.name").String(); got != "apply_patch" {
+		t.Fatalf("added item.name = %q, want apply_patch", got)
+	}
+	if gjson.Get(addedPayload, "item.arguments").Exists() {
+		t.Fatalf("added item must not carry arguments field: %s", addedPayload)
+	}
+
+	if inputDone == "" {
+		t.Fatal("expected a response.custom_tool_call_input.done event")
+	}
+	inDonePayload := inputDone[strings.Index(inputDone, "{"):]
+	if got := gjson.Get(inDonePayload, "input").String(); got != barePatch {
+		t.Fatalf("custom_tool_call_input.done input = %q, want bare patch %q", got, barePatch)
+	}
+
+	if doneItem == "" {
+		t.Fatal("expected an output_item.done event with type custom_tool_call")
+	}
+	donePayload := doneItem[strings.Index(doneItem, "{"):]
+	if got := gjson.Get(donePayload, "item.type").String(); got != "custom_tool_call" {
+		t.Fatalf("done item.type = %q, want custom_tool_call: %s", got, donePayload)
+	}
+	if got := gjson.Get(donePayload, "item.input").String(); got != barePatch {
+		t.Fatalf("done item.input = %q, want bare patch (no JSON wrapper): %s", got, donePayload)
+	}
+	if gjson.Get(donePayload, "item.arguments").Exists() {
+		t.Fatalf("done item must not carry arguments field: %s", donePayload)
+	}
+	if got := gjson.Get(donePayload, "item.call_id").String(); got != "toolu_patch" {
+		t.Fatalf("done item.call_id = %q, want toolu_patch", got)
+	}
+
+	// The custom_tool_call must also surface in the final aggregated output.
+	if completed == "" {
+		t.Fatal("expected a response.completed event")
+	}
+	cp := completed[strings.Index(completed, "{"):]
+	found := false
+	gjson.Get(cp, "response.output").ForEach(func(_, v gjson.Result) bool {
+		if v.Get("type").String() == "custom_tool_call" {
+			found = true
+			if got := v.Get("input").String(); got != barePatch {
+				t.Fatalf("completed custom_tool_call input = %q, want bare patch", got)
+			}
+			if v.Get("arguments").Exists() {
+				t.Fatalf("completed custom_tool_call must not carry arguments: %s", v.Raw)
+			}
+		}
+		return true
+	})
+	if !found {
+		t.Fatalf("expected custom_tool_call in response.completed output: %s", cp)
+	}
+}
+
+// Non-stream: same scenario via the aggregating non-stream converter.
+func TestConvertClaudeResponse_NonStream_CustomToolEmitsCustomToolCall(t *testing.T) {
+	raw := []byte(strings.Join([]string{
+		`data: {"type":"message_start","message":{"id":"msg_cust2"}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"id":"toolu_patch2","type":"tool_use","name":"apply_patch"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"input\":\"*** Begin Patch\\n*** Add File: /tmp/x.txt\\n"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"+hi\\n*** End Patch\"}"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"message_stop"}`,
+	}, "\n"))
+
+	req := []byte(customToolRequest)
+	var state any
+	out := ConvertClaudeResponseToOpenAIResponsesNonStream(context.Background(), "claude", req, req, raw, &state)
+
+	item := gjson.GetBytes(out, "output.0")
+	if got := item.Get("type").String(); got != "custom_tool_call" {
+		t.Fatalf("output[0].type = %q, want custom_tool_call: %s", got, string(out))
+	}
+	if got := item.Get("name").String(); got != "apply_patch" {
+		t.Fatalf("output[0].name = %q, want apply_patch", got)
+	}
+	if got := item.Get("input").String(); got != barePatch {
+		t.Fatalf("output[0].input = %q, want bare patch (no JSON wrapper): %s", got, string(out))
+	}
+	if item.Get("arguments").Exists() {
+		t.Fatalf("output[0] must not carry arguments field: %s", string(out))
+	}
+	if got := item.Get("call_id").String(); got != "toolu_patch2" {
+		t.Fatalf("output[0].call_id = %q, want toolu_patch2", got)
+	}
+}
+
+// Regression: a regular `function` tool (shell) must keep emitting
+// function_call + JSON arguments and must NOT be turned into custom_tool_call.
+func TestConvertClaudeResponse_NonStream_RegularFunctionUnaffected(t *testing.T) {
+	raw := []byte(strings.Join([]string{
+		`data: {"type":"message_start","message":{"id":"msg_fn"}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"id":"toolu_sh","type":"tool_use","name":"shell"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"ls\"}"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"message_stop"}`,
+	}, "\n"))
+
+	req := []byte(customToolRequest)
+	var state any
+	out := ConvertClaudeResponseToOpenAIResponsesNonStream(context.Background(), "claude", req, req, raw, &state)
+
+	item := gjson.GetBytes(out, "output.0")
+	if got := item.Get("type").String(); got != "function_call" {
+		t.Fatalf("output[0].type = %q, want function_call: %s", got, string(out))
+	}
+	if got := item.Get("name").String(); got != "shell" {
+		t.Fatalf("output[0].name = %q, want shell", got)
+	}
+	if got := item.Get("arguments").String(); got != `{"command":"ls"}` {
+		t.Fatalf("output[0].arguments = %q, want JSON arguments", got)
+	}
+	if item.Get("input").Exists() {
+		t.Fatalf("regular function_call must not carry input field: %s", string(out))
+	}
+}
+
+// Regression (streaming): a regular function tool must keep emitting
+// function_call output items with JSON arguments.
+func TestConvertClaudeResponse_Stream_RegularFunctionUnaffected(t *testing.T) {
+	lines := []string{
+		`data: {"type":"message_start","message":{"id":"msg_fn2"}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"id":"toolu_sh2","type":"tool_use","name":"shell"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"ls\"}"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"message_stop"}`,
+	}
+
+	req := []byte(customToolRequest)
+	var state any
+	var doneItem string
+	for _, ln := range lines {
+		evs := ConvertClaudeResponseToOpenAIResponses(context.Background(), "claude", req, req, []byte(ln), &state)
+		for _, e := range evs {
+			s := string(e)
+			if strings.Contains(s, "response.output_item.done") && strings.Contains(s, `"function_call"`) {
+				doneItem = s
+			}
+			if strings.Contains(s, `"custom_tool_call"`) {
+				t.Fatalf("regular function tool must not emit custom_tool_call: %s", s)
+			}
+		}
+	}
+	if doneItem == "" {
+		t.Fatal("expected an output_item.done event with type function_call")
+	}
+	donePayload := doneItem[strings.Index(doneItem, "{"):]
+	if got := gjson.Get(donePayload, "item.arguments").String(); got != `{"command":"ls"}` {
+		t.Fatalf("done item.arguments = %q, want JSON arguments: %s", got, donePayload)
+	}
+	if got := gjson.Get(donePayload, "item.name").String(); got != "shell" {
+		t.Fatalf("done item.name = %q, want shell", got)
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_custom_tool_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_custom_tool_test.go
@@ -120,6 +120,48 @@ func TestConvertClaudeResponse_Stream_CustomToolEmitsCustomToolCall(t *testing.T
 }
 
 // Non-stream: same scenario via the aggregating non-stream converter.
+func TestConvertClaudeResponse_Stream_CustomToolDoesNotLeakWrapperDelta(t *testing.T) {
+	// For downgraded custom tools the streamed input_json_delta fragments are
+	// pieces of the JSON wrapper ({"input":"...). Emitting them verbatim as
+	// response.custom_tool_call_input.delta corrupts the bare-input stream the
+	// host concatenates. We must NOT emit custom_tool_call_input.delta events;
+	// the bare input is delivered once at .done.
+	lines := []string{
+		`data: {"type":"message_start","message":{"id":"msg_cust","usage":{"input_tokens":5}}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"id":"toolu_patch","type":"tool_use","name":"apply_patch"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"input\":\"*** Begin Patch\\n*** Add File: /tmp/x.txt\\n"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"+hi\\n*** End Patch\"}"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"message_stop"}`,
+	}
+	req := []byte(customToolRequest)
+	var state any
+	var inputDone string
+	deltaCount := 0
+	for _, ln := range lines {
+		evs := ConvertClaudeResponseToOpenAIResponses(context.Background(), "claude", req, req, []byte(ln), &state)
+		for _, e := range evs {
+			s := string(e)
+			if strings.Contains(s, "response.custom_tool_call_input.delta") {
+				deltaCount++
+			}
+			if strings.Contains(s, "response.custom_tool_call_input.done") {
+				inputDone = s
+			}
+		}
+	}
+	if deltaCount != 0 {
+		t.Fatalf("custom tools must NOT emit custom_tool_call_input.delta (raw JSON wrapper would corrupt the stream); got %d delta events", deltaCount)
+	}
+	if inputDone == "" {
+		t.Fatal("expected the bare input to still arrive via custom_tool_call_input.done")
+	}
+	inDonePayload := inputDone[strings.Index(inputDone, "{"):]
+	if got := gjson.Get(inDonePayload, "input").String(); got != barePatch {
+		t.Fatalf("input.done must carry the bare patch, got %q", got)
+	}
+}
+
 func TestConvertClaudeResponse_NonStream_CustomToolEmitsCustomToolCall(t *testing.T) {
 	raw := []byte(strings.Join([]string{
 		`data: {"type":"message_start","message":{"id":"msg_cust2"}}`,

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -12,6 +12,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -335,14 +336,20 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 					pendingReasoningParts = append(pendingReasoningParts, string(thinkingPart))
 				}
 
-			case "function_call":
-				// Map to assistant tool_use
+			case "function_call", "custom_tool_call":
+				// Map to assistant tool_use. custom_tool_call is the freeform
+				// form (apply_patch) carrying a bare `input` text instead of
+				// JSON `arguments`; wrap it back into the {"input": ...} object
+				// the downgraded function tool expects.
 				callID := item.Get("call_id").String()
 				if callID == "" {
 					callID = genToolCallID()
 				}
 				name := item.Get("name").String()
 				argsStr := item.Get("arguments").String()
+				if typ == "custom_tool_call" {
+					argsStr = translatorcommon.WrapCustomToolInput(item.Get("input").String())
+				}
 
 				toolUse := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
 				toolUse, _ = sjson.SetBytes(toolUse, "id", callID)
@@ -362,7 +369,7 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 				asst, _ = sjson.SetRawBytes(asst, "content.-1", toolUse)
 				out, _ = sjson.SetRawBytes(out, "messages.-1", asst)
 
-			case "function_call_output":
+			case "function_call_output", "custom_tool_call_output":
 				flushPendingReasoning()
 				// Map to user tool_result
 				callID := item.Get("call_id").String()
@@ -483,6 +490,17 @@ func convertResponsesToolToClaudeTools(tool gjson.Result, toolNameMap map[string
 			}
 			return [][]byte{tJSON}
 		}
+	case "custom":
+		// apply_patch and other freeform `custom` tools have no Claude-native
+		// equivalent. Downgrade to a regular function tool carrying a single
+		// string `input` argument; the response side re-emits the model's
+		// tool_use as a custom_tool_call with the bare input text.
+		if tJSON, ok := convertResponsesCustomToolToClaude(tool); ok {
+			if name := gjson.GetBytes(tJSON, "name").String(); name != "" {
+				toolNameMap[name] = name
+			}
+			return [][]byte{tJSON}
+		}
 	default:
 		if isUnsupportedOpenAIBuiltinToolType(toolType) {
 			return nil
@@ -492,6 +510,20 @@ func convertResponsesToolToClaudeTools(tool gjson.Result, toolNameMap map[string
 		}
 	}
 	return nil
+}
+
+// convertResponsesCustomToolToClaude downgrades a freeform `custom` tool into a
+// Claude function tool with a single string `input` parameter.
+func convertResponsesCustomToolToClaude(tool gjson.Result) ([]byte, bool) {
+	name := responsesToolName(tool)
+	if name == "" {
+		return nil, false
+	}
+	tJSON := []byte(`{"name":"","description":"","input_schema":{}}`)
+	tJSON, _ = sjson.SetBytes(tJSON, "name", name)
+	tJSON, _ = sjson.SetBytes(tJSON, "description", translatorcommon.CustomToolDescription(responsesToolDescription(tool)))
+	tJSON, _ = sjson.SetRawBytes(tJSON, "input_schema", translatorcommon.CustomToolFunctionSchema())
+	return tJSON, true
 }
 
 func convertResponsesNamespaceToolToClaude(tool gjson.Result, toolNameMap map[string]string) [][]byte {

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -23,8 +23,13 @@ type claudeToResponsesState struct {
 	InFuncBlock  bool
 	FuncArgsBuf  map[int]*strings.Builder // index -> args
 	// function call bookkeeping for output aggregation
-	FuncNames   map[int]string // index -> function name
-	FuncCallIDs map[int]string // index -> call id
+	FuncNames    map[int]string // index -> function name
+	FuncCallIDs  map[int]string // index -> call id
+	FuncIsCustom map[int]bool   // index -> is freeform custom tool (apply_patch)
+	// CustomToolNames is the set of tool names declared as freeform `custom`
+	// tools in the original request; such tool calls must be re-emitted as
+	// custom_tool_call (bare input) instead of function_call (JSON arguments).
+	CustomToolNames map[string]struct{}
 	// message text aggregation
 	TextBuf        strings.Builder
 	CurrentTextBuf strings.Builder
@@ -60,7 +65,13 @@ func emitEvent(event string, payload []byte) []byte {
 // ConvertClaudeResponseToOpenAIResponses converts Claude SSE to OpenAI Responses SSE events.
 func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) [][]byte {
 	if *param == nil {
-		*param = &claudeToResponsesState{FuncArgsBuf: make(map[int]*strings.Builder), FuncNames: make(map[int]string), FuncCallIDs: make(map[int]string)}
+		*param = &claudeToResponsesState{
+			FuncArgsBuf:     make(map[int]*strings.Builder),
+			FuncNames:       make(map[int]string),
+			FuncCallIDs:     make(map[int]string),
+			FuncIsCustom:    make(map[int]bool),
+			CustomToolNames: translatorcommon.CustomToolNamesFromRequest(pickRequestJSON(originalRequestRawJSON, requestRawJSON)),
+		}
 	}
 	st := (*param).(*claudeToResponsesState)
 
@@ -147,13 +158,28 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			st.InFuncBlock = true
 			st.CurrentFCID = cb.Get("id").String()
 			name := cb.Get("name").String()
-			item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
-			item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
-			item, _ = sjson.SetBytes(item, "output_index", idx)
-			item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("fc_%s", st.CurrentFCID))
-			item, _ = sjson.SetBytes(item, "item.call_id", st.CurrentFCID)
-			item, _ = sjson.SetBytes(item, "item.name", name)
-			out = append(out, emitEvent("response.output_item.added", item))
+			isCustom := isCustomToolName(st.CustomToolNames, name)
+			st.FuncIsCustom[idx] = isCustom
+			if isCustom {
+				// Freeform custom tool (e.g. apply_patch): the host expects a
+				// custom_tool_call carrying bare `input` text, not a
+				// function_call with JSON arguments.
+				item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"in_progress","call_id":"","name":"","input":""}}`)
+				item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
+				item, _ = sjson.SetBytes(item, "output_index", idx)
+				item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("fc_%s", st.CurrentFCID))
+				item, _ = sjson.SetBytes(item, "item.call_id", st.CurrentFCID)
+				item, _ = sjson.SetBytes(item, "item.name", name)
+				out = append(out, emitEvent("response.output_item.added", item))
+			} else {
+				item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
+				item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
+				item, _ = sjson.SetBytes(item, "output_index", idx)
+				item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("fc_%s", st.CurrentFCID))
+				item, _ = sjson.SetBytes(item, "item.call_id", st.CurrentFCID)
+				item, _ = sjson.SetBytes(item, "item.name", name)
+				out = append(out, emitEvent("response.output_item.added", item))
+			}
 			if st.FuncArgsBuf[idx] == nil {
 				st.FuncArgsBuf[idx] = &strings.Builder{}
 			}
@@ -208,12 +234,25 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 					st.FuncArgsBuf[idx] = &strings.Builder{}
 				}
 				st.FuncArgsBuf[idx].WriteString(pj.String())
-				msg := []byte(`{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
-				msg, _ = sjson.SetBytes(msg, "sequence_number", nextSeq())
-				msg, _ = sjson.SetBytes(msg, "item_id", fmt.Sprintf("fc_%s", st.CurrentFCID))
-				msg, _ = sjson.SetBytes(msg, "output_index", idx)
-				msg, _ = sjson.SetBytes(msg, "delta", pj.String())
-				out = append(out, emitEvent("response.function_call_arguments.delta", msg))
+				if st.FuncIsCustom[idx] {
+					// Custom tools buffer the JSON arguments here and unwrap the
+					// bare input only at content_block_stop; the partial JSON
+					// fragments are not valid standalone input text, so we emit
+					// the custom delta event using the raw fragment best-effort.
+					msg := []byte(`{"type":"response.custom_tool_call_input.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
+					msg, _ = sjson.SetBytes(msg, "sequence_number", nextSeq())
+					msg, _ = sjson.SetBytes(msg, "item_id", fmt.Sprintf("fc_%s", st.CurrentFCID))
+					msg, _ = sjson.SetBytes(msg, "output_index", idx)
+					msg, _ = sjson.SetBytes(msg, "delta", pj.String())
+					out = append(out, emitEvent("response.custom_tool_call_input.delta", msg))
+				} else {
+					msg := []byte(`{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
+					msg, _ = sjson.SetBytes(msg, "sequence_number", nextSeq())
+					msg, _ = sjson.SetBytes(msg, "item_id", fmt.Sprintf("fc_%s", st.CurrentFCID))
+					msg, _ = sjson.SetBytes(msg, "output_index", idx)
+					msg, _ = sjson.SetBytes(msg, "delta", pj.String())
+					out = append(out, emitEvent("response.function_call_arguments.delta", msg))
+				}
 			}
 		} else if dt == "thinking_delta" {
 			if st.ReasoningActive {
@@ -261,21 +300,42 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 					args = buf.String()
 				}
 			}
-			fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
-			fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
-			fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", st.CurrentFCID))
-			fcDone, _ = sjson.SetBytes(fcDone, "output_index", idx)
-			fcDone, _ = sjson.SetBytes(fcDone, "arguments", args)
-			out = append(out, emitEvent("response.function_call_arguments.done", fcDone))
-			itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
-			itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
-			itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
-			itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.CurrentFCID))
-			itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", args)
-			itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.CurrentFCID)
-			itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[idx])
-			out = append(out, emitEvent("response.output_item.done", itemDone))
-			st.InFuncBlock = false
+			if st.FuncIsCustom[idx] {
+				// Freeform custom tool: unwrap the bare payload text out of the
+				// JSON `input` wrapper and emit a custom_tool_call (no arguments).
+				input := translatorcommon.UnwrapCustomToolInput(args)
+				inDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
+				inDone, _ = sjson.SetBytes(inDone, "sequence_number", nextSeq())
+				inDone, _ = sjson.SetBytes(inDone, "item_id", fmt.Sprintf("fc_%s", st.CurrentFCID))
+				inDone, _ = sjson.SetBytes(inDone, "output_index", idx)
+				inDone, _ = sjson.SetBytes(inDone, "input", input)
+				out = append(out, emitEvent("response.custom_tool_call_input.done", inDone))
+				itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"completed","call_id":"","name":"","input":""}}`)
+				itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+				itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+				itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.CurrentFCID))
+				itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.CurrentFCID)
+				itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[idx])
+				itemDone, _ = sjson.SetBytes(itemDone, "item.input", input)
+				out = append(out, emitEvent("response.output_item.done", itemDone))
+				st.InFuncBlock = false
+			} else {
+				fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
+				fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
+				fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", st.CurrentFCID))
+				fcDone, _ = sjson.SetBytes(fcDone, "output_index", idx)
+				fcDone, _ = sjson.SetBytes(fcDone, "arguments", args)
+				out = append(out, emitEvent("response.function_call_arguments.done", fcDone))
+				itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
+				itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+				itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+				itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.CurrentFCID))
+				itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", args)
+				itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.CurrentFCID)
+				itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[idx])
+				out = append(out, emitEvent("response.output_item.done", itemDone))
+				st.InFuncBlock = false
+			}
 		} else if st.ReasoningActive {
 			full := st.ReasoningBuf.String()
 			textDone := []byte(`{"type":"response.reasoning_summary_text.done","sequence_number":0,"item_id":"","output_index":0,"summary_index":0,"text":""}`)
@@ -434,6 +494,16 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				if callID == "" && st.CurrentFCID != "" {
 					callID = st.CurrentFCID
 				}
+				if st.FuncIsCustom[idx] {
+					input := translatorcommon.UnwrapCustomToolInput(args)
+					item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","call_id":"","name":"","input":""}`)
+					item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
+					item, _ = sjson.SetBytes(item, "call_id", callID)
+					item, _ = sjson.SetBytes(item, "name", name)
+					item, _ = sjson.SetBytes(item, "input", input)
+					outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
+					continue
+				}
 				item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
 				item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
 				item, _ = sjson.SetBytes(item, "arguments", args)
@@ -467,6 +537,20 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 	}
 
 	return out
+}
+
+// isCustomToolName reports whether the given tool name was declared as a
+// freeform `custom` tool in the original request. As a defensive fallback it
+// also treats the well-known "apply_patch" name as custom even if the request
+// scan came up empty (e.g. the original request JSON was unavailable).
+func isCustomToolName(customNames map[string]struct{}, name string) bool {
+	if name == "" {
+		return false
+	}
+	if _, ok := customNames[name]; ok {
+		return true
+	}
+	return name == "apply_patch"
 }
 
 // ConvertClaudeResponseToOpenAIResponsesNonStream aggregates Claude SSE into a single OpenAI Responses JSON.
@@ -517,6 +601,11 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 		args strings.Builder
 	}
 	toolCalls := make(map[int]*toolState)
+
+	// Names of freeform `custom` tools (e.g. apply_patch) declared in the
+	// original request; these must be re-emitted as custom_tool_call items
+	// carrying bare `input` text instead of function_call JSON arguments.
+	customToolNames := translatorcommon.CustomToolNamesFromRequest(pickRequestJSON(originalRequestRawJSON, requestRawJSON))
 
 	// Walk through SSE chunks to fill state
 	for _, ch := range chunks {
@@ -712,6 +801,16 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 			args := st.args.String()
 			if args == "" {
 				args = "{}"
+			}
+			if isCustomToolName(customToolNames, st.name) {
+				input := translatorcommon.UnwrapCustomToolInput(args)
+				item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","call_id":"","name":"","input":""}`)
+				item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", st.id))
+				item, _ = sjson.SetBytes(item, "call_id", st.id)
+				item, _ = sjson.SetBytes(item, "name", st.name)
+				item, _ = sjson.SetBytes(item, "input", input)
+				outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
+				continue
 			}
 			item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
 			item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", st.id))

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -30,6 +30,9 @@ type claudeToResponsesState struct {
 	// tools in the original request; such tool calls must be re-emitted as
 	// custom_tool_call (bare input) instead of function_call (JSON arguments).
 	CustomToolNames map[string]struct{}
+	// RequestHasTools reports whether the request snapshot declared any tools;
+	// gates the apply_patch fallback (see isCustomToolName).
+	RequestHasTools bool
 	// message text aggregation
 	TextBuf        strings.Builder
 	CurrentTextBuf strings.Builder
@@ -71,6 +74,7 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			FuncCallIDs:     make(map[int]string),
 			FuncIsCustom:    make(map[int]bool),
 			CustomToolNames: translatorcommon.CustomToolNamesFromRequest(pickRequestJSON(originalRequestRawJSON, requestRawJSON)),
+			RequestHasTools: translatorcommon.RequestDeclaresTools(pickRequestJSON(originalRequestRawJSON, requestRawJSON)),
 		}
 	}
 	st := (*param).(*claudeToResponsesState)
@@ -158,7 +162,7 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			st.InFuncBlock = true
 			st.CurrentFCID = cb.Get("id").String()
 			name := cb.Get("name").String()
-			isCustom := isCustomToolName(st.CustomToolNames, name)
+			isCustom := isCustomToolName(st.CustomToolNames, name, st.RequestHasTools)
 			st.FuncIsCustom[idx] = isCustom
 			if isCustom {
 				// Freeform custom tool (e.g. apply_patch): the host expects a
@@ -235,16 +239,14 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				}
 				st.FuncArgsBuf[idx].WriteString(pj.String())
 				if st.FuncIsCustom[idx] {
-					// Custom tools buffer the JSON arguments here and unwrap the
-					// bare input only at content_block_stop; the partial JSON
-					// fragments are not valid standalone input text, so we emit
-					// the custom delta event using the raw fragment best-effort.
-					msg := []byte(`{"type":"response.custom_tool_call_input.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
-					msg, _ = sjson.SetBytes(msg, "sequence_number", nextSeq())
-					msg, _ = sjson.SetBytes(msg, "item_id", fmt.Sprintf("fc_%s", st.CurrentFCID))
-					msg, _ = sjson.SetBytes(msg, "output_index", idx)
-					msg, _ = sjson.SetBytes(msg, "delta", pj.String())
-					out = append(out, emitEvent("response.custom_tool_call_input.delta", msg))
+					// Custom tools buffer the JSON-wrapper fragments here and unwrap
+					// the BARE input only at content_block_stop. The partial_json
+					// fragments are pieces of {"input":"..."} — NOT valid bare input
+					// text — so we must NOT emit response.custom_tool_call_input.delta
+					// with them: a streaming host concatenates deltas before .done and
+					// would otherwise see JSON syntax / escaped chars that don't match
+					// the final bare input. Buffer only; the bare input is delivered
+					// once via custom_tool_call_input.done at content_block_stop.
 				} else {
 					msg := []byte(`{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
 					msg, _ = sjson.SetBytes(msg, "sequence_number", nextSeq())
@@ -543,14 +545,16 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 // freeform `custom` tool in the original request. As a defensive fallback it
 // also treats the well-known "apply_patch" name as custom even if the request
 // scan came up empty (e.g. the original request JSON was unavailable).
-func isCustomToolName(customNames map[string]struct{}, name string) bool {
+func isCustomToolName(customNames map[string]struct{}, name string, requestHasTools bool) bool {
 	if name == "" {
 		return false
 	}
 	if _, ok := customNames[name]; ok {
 		return true
 	}
-	return name == "apply_patch"
+	// Defensive fallback only when the request snapshot was unavailable; a
+	// declared regular function named apply_patch must stay a function_call.
+	return name == "apply_patch" && !requestHasTools
 }
 
 // ConvertClaudeResponseToOpenAIResponsesNonStream aggregates Claude SSE into a single OpenAI Responses JSON.
@@ -606,6 +610,7 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 	// original request; these must be re-emitted as custom_tool_call items
 	// carrying bare `input` text instead of function_call JSON arguments.
 	customToolNames := translatorcommon.CustomToolNamesFromRequest(pickRequestJSON(originalRequestRawJSON, requestRawJSON))
+	customReqHasTools := translatorcommon.RequestDeclaresTools(pickRequestJSON(originalRequestRawJSON, requestRawJSON))
 
 	// Walk through SSE chunks to fill state
 	for _, ch := range chunks {
@@ -802,7 +807,7 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 			if args == "" {
 				args = "{}"
 			}
-			if isCustomToolName(customToolNames, st.name) {
+			if isCustomToolName(customToolNames, st.name, customReqHasTools) {
 				input := translatorcommon.UnwrapCustomToolInput(args)
 				item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","call_id":"","name":"","input":""}`)
 				item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", st.id))

--- a/internal/translator/common/custom_tool.go
+++ b/internal/translator/common/custom_tool.go
@@ -45,6 +45,18 @@ func CustomToolNamesFromRequest(rawJSON []byte) map[string]struct{} {
 	return out
 }
 
+// RequestDeclaresTools reports whether the request snapshot declares a non-empty
+// `tools` array. It distinguishes "snapshot available" (tools were declared, so
+// the custom-tool set is authoritative) from "snapshot unavailable" (no tools
+// found — either the request had none or the snapshot was lost). Callers use
+// this to decide whether the defensive apply_patch fallback should fire: when
+// the snapshot IS available and apply_patch is absent from the custom set, it is
+// a deliberately-declared regular function and must NOT be force-customed.
+func RequestDeclaresTools(rawJSON []byte) bool {
+	tools := gjson.GetBytes(rawJSON, "tools")
+	return tools.Exists() && tools.IsArray() && len(tools.Array()) > 0
+}
+
 // CustomToolFunctionSchema returns the JSON Schema (as raw bytes) used when a
 // freeform custom tool is downgraded to a regular function. The freeform tool
 // carries no JSON-Schema parameters of its own (the model emits raw text), so
@@ -69,6 +81,10 @@ func CustomToolDescription(original string) string {
 		"This is a FREEFORM tool, so do not wrap the patch in JSON",
 		"do not wrap the patch in JSON.",
 		"do not wrap the patch in JSON",
+		"This is a freeform tool, so do not wrap the patch in JSON.",
+		"This is a freeform tool, so do not wrap the patch in JSON",
+		"Do not wrap the patch in JSON.",
+		"Do not wrap the patch in JSON",
 	} {
 		desc = strings.ReplaceAll(desc, bad, "")
 	}
@@ -121,16 +137,41 @@ func UnwrapCustomToolInput(argumentsJSON string) string {
 func escapeControlCharsInJSONString(in string) string {
 	var b strings.Builder
 	b.Grow(len(in))
+	inString := false // are we currently inside a double-quoted JSON string literal?
+	escaped := false  // was the previous byte a backslash inside a string?
 	for i := 0; i < len(in); i++ {
-		switch in[i] {
-		case '\n':
-			b.WriteString(`\n`)
-		case '\r':
-			b.WriteString(`\r`)
-		case '\t':
-			b.WriteString(`\t`)
-		default:
-			b.WriteByte(in[i])
+		ch := in[i]
+		if inString {
+			if escaped {
+				// previous byte was '\\'; emit this byte verbatim (it's the escapee)
+				b.WriteByte(ch)
+				escaped = false
+				continue
+			}
+			switch ch {
+			case '\\':
+				b.WriteByte(ch)
+				escaped = true
+			case '"':
+				b.WriteByte(ch)
+				inString = false
+			case '\n':
+				b.WriteString(`\n`)
+			case '\r':
+				b.WriteString(`\r`)
+			case '\t':
+				b.WriteString(`\t`)
+			default:
+				b.WriteByte(ch)
+			}
+		} else {
+			// Outside string literals: never escape. Structural whitespace
+			// (newlines/indent in pretty-printed JSON) must be left untouched,
+			// otherwise we'd corrupt valid JSON into invalid JSON.
+			if ch == '"' {
+				inString = true
+			}
+			b.WriteByte(ch)
 		}
 	}
 	return b.String()

--- a/internal/translator/common/custom_tool.go
+++ b/internal/translator/common/custom_tool.go
@@ -1,0 +1,147 @@
+package common
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// CustomToolInputKey is the synthetic JSON parameter name used when a freeform
+// OpenAI `custom` tool (e.g. apply_patch) is downgraded into a regular
+// `function` tool for backends (Claude/Gemini/DeepSeek) that do not natively
+// support the Responses-API `custom` tool type.
+//
+// On the request side we declare the function with a single string parameter
+// named CustomToolInputKey; on the response side we unwrap that argument back
+// into the bare `input` text the Codex host expects for a custom_tool_call.
+const CustomToolInputKey = "input"
+
+// IsResponsesCustomTool reports whether a Responses-API tool entry is a
+// freeform `custom` tool (the only current example is apply_patch).
+func IsResponsesCustomTool(tool gjson.Result) bool {
+	return strings.TrimSpace(tool.Get("type").String()) == "custom"
+}
+
+// CustomToolNamesFromRequest scans the original Responses-API request JSON and
+// returns the set of tool names whose type is `custom`. The response side uses
+// this to decide whether a tool call coming back from the backend must be
+// re-emitted as a `custom_tool_call` (bare input text) instead of a
+// `function_call` (JSON arguments).
+func CustomToolNamesFromRequest(rawJSON []byte) map[string]struct{} {
+	out := map[string]struct{}{}
+	tools := gjson.GetBytes(rawJSON, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return out
+	}
+	tools.ForEach(func(_, tool gjson.Result) bool {
+		if IsResponsesCustomTool(tool) {
+			if name := strings.TrimSpace(tool.Get("name").String()); name != "" {
+				out[name] = struct{}{}
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// CustomToolFunctionSchema returns the JSON Schema (as raw bytes) used when a
+// freeform custom tool is downgraded to a regular function. The freeform tool
+// carries no JSON-Schema parameters of its own (the model emits raw text), so
+// we wrap it in a single required string parameter named CustomToolInputKey.
+func CustomToolFunctionSchema() []byte {
+	return []byte(`{"type":"object","properties":{"` + CustomToolInputKey +
+		`":{"type":"string","description":"The full tool payload as a single raw text string."}},"required":["` +
+		CustomToolInputKey + `"]}`)
+}
+
+// CustomToolDescription rewrites a freeform custom tool's description so it no
+// longer instructs the model to avoid JSON (the original apply_patch
+// description says "do not wrap the patch in JSON"). After downgrade the model
+// MUST place the payload inside the JSON `input` argument, so the contradictory
+// sentence is stripped and a clear instruction is appended.
+func CustomToolDescription(original string) string {
+	desc := strings.TrimSpace(original)
+	// Remove the freeform-only instruction that conflicts with the function
+	// (JSON-arguments) form we downgrade into.
+	for _, bad := range []string{
+		"This is a FREEFORM tool, so do not wrap the patch in JSON.",
+		"This is a FREEFORM tool, so do not wrap the patch in JSON",
+		"do not wrap the patch in JSON.",
+		"do not wrap the patch in JSON",
+	} {
+		desc = strings.ReplaceAll(desc, bad, "")
+	}
+	desc = strings.TrimSpace(desc)
+	suffix := "Provide the entire tool payload as a single string in the `" +
+		CustomToolInputKey + "` argument."
+	if desc == "" {
+		return suffix
+	}
+	return desc + " " + suffix
+}
+
+// UnwrapCustomToolInput extracts the bare payload text from a downgraded
+// function call's JSON arguments. The model was told to put the whole payload
+// into the `input` string argument, so we read it back out. If the arguments
+// are not the expected wrapper (e.g. the model emitted raw text anyway, or a
+// different shape), the raw arguments string is returned unchanged as a
+// best-effort fallback.
+func UnwrapCustomToolInput(argumentsJSON string) string {
+	trimmed := strings.TrimSpace(argumentsJSON)
+	if trimmed == "" {
+		return ""
+	}
+	if gjson.Valid(trimmed) {
+		parsed := gjson.Parse(trimmed)
+		if parsed.IsObject() {
+			if v := parsed.Get(CustomToolInputKey); v.Exists() {
+				return v.String()
+			}
+		}
+	}
+	// Some backends emit the wrapper with unescaped control characters (raw
+	// newlines/tabs) inside the string value, which makes the payload invalid
+	// JSON. Try escaping the common offenders and re-parsing before giving up.
+	if escaped := escapeControlCharsInJSONString(trimmed); escaped != trimmed && gjson.Valid(escaped) {
+		parsed := gjson.Parse(escaped)
+		if parsed.IsObject() {
+			if v := parsed.Get(CustomToolInputKey); v.Exists() {
+				return v.String()
+			}
+		}
+	}
+	return argumentsJSON
+}
+
+// escapeControlCharsInJSONString escapes raw control characters (newline,
+// carriage return, tab) inside a JSON-ish wrapper so a payload that arrived
+// with literal control bytes can still be parsed. It only rewrites those
+// bytes; it does not attempt full JSON repair.
+func escapeControlCharsInJSONString(in string) string {
+	var b strings.Builder
+	b.Grow(len(in))
+	for i := 0; i < len(in); i++ {
+		switch in[i] {
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			b.WriteByte(in[i])
+		}
+	}
+	return b.String()
+}
+
+// WrapCustomToolInput is the inverse of UnwrapCustomToolInput: given the bare
+// input text from a historical custom_tool_call, it produces the JSON
+// arguments string a downgraded function tool would carry, so multi-turn
+// history replays consistently to the backend.
+func WrapCustomToolInput(input string) string {
+	out := []byte(`{}`)
+	out, _ = sjson.SetBytes(out, CustomToolInputKey, input)
+	return string(out)
+}

--- a/internal/translator/common/custom_tool_test.go
+++ b/internal/translator/common/custom_tool_test.go
@@ -1,0 +1,81 @@
+package common
+
+import "testing"
+
+func TestCustomToolNamesFromRequest(t *testing.T) {
+	req := []byte(`{"tools":[
+		{"type":"function","name":"shell"},
+		{"type":"custom","name":"apply_patch","description":"x"},
+		{"type":"web_search","name":"web_search"}
+	]}`)
+	got := CustomToolNamesFromRequest(req)
+	if _, ok := got["apply_patch"]; !ok {
+		t.Fatalf("expected apply_patch in custom set, got %v", got)
+	}
+	if _, ok := got["shell"]; ok {
+		t.Fatalf("shell must NOT be in custom set, got %v", got)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 custom tool, got %d: %v", len(got), got)
+	}
+}
+
+func TestCustomToolNamesFromRequest_NoTools(t *testing.T) {
+	if got := CustomToolNamesFromRequest([]byte(`{}`)); len(got) != 0 {
+		t.Fatalf("expected empty set, got %v", got)
+	}
+}
+
+func TestUnwrapCustomToolInput(t *testing.T) {
+	patch := "*** Begin Patch\n*** Add File: /tmp/x.txt\n+hi\n*** End Patch"
+	wrapped := WrapCustomToolInput(patch)
+	// round-trip
+	if got := UnwrapCustomToolInput(wrapped); got != patch {
+		t.Fatalf("round-trip mismatch:\n want %q\n got  %q", patch, got)
+	}
+	// direct wrapper
+	if got := UnwrapCustomToolInput(`{"input":"hello"}`); got != "hello" {
+		t.Fatalf("expected hello, got %q", got)
+	}
+	// fallback: not the expected shape -> return raw
+	if got := UnwrapCustomToolInput(`raw text not json`); got != "raw text not json" {
+		t.Fatalf("fallback mismatch, got %q", got)
+	}
+	// fallback: json object without input key -> return raw
+	if got := UnwrapCustomToolInput(`{"other":"v"}`); got != `{"other":"v"}` {
+		t.Fatalf("fallback (no input key) mismatch, got %q", got)
+	}
+}
+
+func TestCustomToolDescription(t *testing.T) {
+	orig := "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON."
+	got := CustomToolDescription(orig)
+	if got == "" {
+		t.Fatal("description must not be empty")
+	}
+	if contains(got, "do not wrap the patch in JSON") {
+		t.Fatalf("contradictory sentence must be stripped, got %q", got)
+	}
+	if !contains(got, CustomToolInputKey) {
+		t.Fatalf("description must mention the input arg, got %q", got)
+	}
+}
+
+func TestCustomToolFunctionSchema(t *testing.T) {
+	s := string(CustomToolFunctionSchema())
+	if !contains(s, `"input"`) || !contains(s, `"required"`) {
+		t.Fatalf("schema missing input/required: %s", s)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (indexOf(s, sub) >= 0)
+}
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/translator/common/custom_tool_test.go
+++ b/internal/translator/common/custom_tool_test.go
@@ -47,6 +47,33 @@ func TestUnwrapCustomToolInput(t *testing.T) {
 	}
 }
 
+func TestUnwrapCustomToolInput_RawControlCharsInsideString(t *testing.T) {
+	// A backend emits the wrapper with literal (unescaped) newlines INSIDE the
+	// "input" string value, which makes it invalid JSON. The control-char escape
+	// fallback must repair it and recover the multi-line payload.
+	raw := "{\"input\":\"line1\nline2\tend\"}"
+	got := UnwrapCustomToolInput(raw)
+	if got != "line1\nline2\tend" {
+		t.Fatalf("expected recovered multi-line payload, got %q", got)
+	}
+}
+
+func TestUnwrapCustomToolInput_PreservesStructuralWhitespace(t *testing.T) {
+	// A pretty-printed wrapper (structural newlines/indent OUTSIDE string literals)
+	// whose input value ALSO contains a raw, unescaped newline. The first
+	// gjson.Valid fails (raw newline in the string), so the escape fallback runs.
+	// The OLD global escape turned BOTH the in-string newline AND the structural
+	// newlines into literal \n tokens -> {\n ... became invalid JSON -> fallback
+	// failed and the raw blob leaked. The state-machine escape must escape ONLY
+	// the in-string control chars and leave structural whitespace intact, so the
+	// repaired JSON parses and the multi-line payload is recovered.
+	pretty := "{\n  \"input\": \"line1\nline2\"\n}"
+	got := UnwrapCustomToolInput(pretty)
+	if got != "line1\nline2" {
+		t.Fatalf("pretty wrapper with in-string newline must unwrap to multi-line payload, got %q", got)
+	}
+}
+
 func TestCustomToolDescription(t *testing.T) {
 	orig := "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON."
 	got := CustomToolDescription(orig)
@@ -58,6 +85,23 @@ func TestCustomToolDescription(t *testing.T) {
 	}
 	if !contains(got, CustomToolInputKey) {
 		t.Fatalf("description must mention the input arg, got %q", got)
+	}
+}
+
+func TestCustomToolDescription_CapitalizedVariants(t *testing.T) {
+	// The contradictory instruction can appear with different capitalization.
+	// All variants must be stripped, otherwise the downgraded function tool keeps
+	// a "do not wrap in JSON" instruction that conflicts with the JSON-arguments form.
+	cases := []string{
+		"Use apply_patch. Do not wrap the patch in JSON.",
+		"Use apply_patch. This is a freeform tool, so do not wrap the patch in JSON.",
+	}
+	for _, orig := range cases {
+		got := CustomToolDescription(orig)
+		lower := got
+		if contains(lower, "wrap the patch in JSON") {
+			t.Fatalf("capitalized contradictory sentence must be stripped, got %q", got)
+		}
 	}
 }
 

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -6,6 +6,7 @@ import (
 
 	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/translator/gemini/common"
+	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -388,6 +389,15 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				}
 
 				geminiTools, _ = sjson.SetRawBytes(geminiTools, "0.functionDeclarations.-1", funcDecl)
+			} else if tool.Get("type").String() == "custom" {
+				// Freeform `custom` tools (apply_patch) have no Gemini-native
+				// equivalent. Downgrade to a functionDeclaration carrying a
+				// single string `input` argument; the response side re-emits
+				// the model's functionCall as a custom_tool_call with the bare
+				// input text.
+				if funcDecl := buildGeminiResponsesCustomDeclaration(tool); funcDecl != nil {
+					geminiTools, _ = sjson.SetRawBytes(geminiTools, "0.functionDeclarations.-1", funcDecl)
+				}
 			}
 			return true
 		})
@@ -458,4 +468,22 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 
 func openAIResponsesGeminiThoughtSignature(rawSignature string) string {
 	return sigcompat.GeminiReplaySignatureOrBypass(rawSignature, sigcompat.SignatureBlockKindGeminiModelPart)
+}
+
+// buildGeminiResponsesCustomDeclaration downgrades a freeform `custom` tool
+// (e.g. apply_patch) into a Gemini functionDeclaration with a single string
+// `input` parameter, since the freeform tool carries no JSON-Schema of its own.
+func buildGeminiResponsesCustomDeclaration(tool gjson.Result) []byte {
+	name := strings.TrimSpace(tool.Get("name").String())
+	if name == "" {
+		name = strings.TrimSpace(tool.Get("function.name").String())
+	}
+	if name == "" {
+		return nil
+	}
+	funcDecl := []byte(`{"name":"","description":"","parametersJsonSchema":{}}`)
+	funcDecl, _ = sjson.SetBytes(funcDecl, "name", util.SanitizeFunctionName(name))
+	funcDecl, _ = sjson.SetBytes(funcDecl, "description", translatorcommon.CustomToolDescription(tool.Get("description").String()))
+	funcDecl, _ = sjson.SetRawBytes(funcDecl, "parametersJsonSchema", translatorcommon.CustomToolFunctionSchema())
+	return funcDecl
 }

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
@@ -42,7 +42,9 @@ type geminiToResponsesState struct {
 	FuncNames        map[int]string
 	FuncCallIDs      map[int]string
 	FuncDone         map[int]bool
+	CustomDone       map[int]bool
 	SanitizedNameMap map[string]string
+	CustomToolNames  map[string]struct{}
 }
 
 // responseIDCounter provides a process-wide unique counter for synthesized response identifiers.
@@ -96,7 +98,9 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 			FuncNames:        make(map[int]string),
 			FuncCallIDs:      make(map[int]string),
 			FuncDone:         make(map[int]bool),
+			CustomDone:       make(map[int]bool),
 			SanitizedNameMap: util.SanitizedToolNameMap(originalRequestRawJSON),
+			CustomToolNames:  translatorcommon.CustomToolNamesFromRequest(pickRequestJSON(originalRequestRawJSON, requestRawJSON)),
 		}
 	}
 	st := (*param).(*geminiToResponsesState)
@@ -112,8 +116,14 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 	if st.FuncDone == nil {
 		st.FuncDone = make(map[int]bool)
 	}
+	if st.CustomDone == nil {
+		st.CustomDone = make(map[int]bool)
+	}
 	if st.SanitizedNameMap == nil {
 		st.SanitizedNameMap = util.SanitizedToolNameMap(originalRequestRawJSON)
+	}
+	if st.CustomToolNames == nil {
+		st.CustomToolNames = translatorcommon.CustomToolNamesFromRequest(pickRequestJSON(originalRequestRawJSON, requestRawJSON))
 	}
 
 	if bytes.HasPrefix(rawJSON, []byte("data:")) {
@@ -313,6 +323,13 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 				finalizeReasoning()
 				finalizeMessage()
 				name := util.RestoreSanitizedToolName(st.SanitizedNameMap, fc.Get("name").String())
+				// A freeform `custom` tool (e.g. apply_patch) was downgraded to a
+				// regular function on the request side; the host expects it back as a
+				// custom_tool_call carrying bare `input` text, not a function_call.
+				_, isCustom := st.CustomToolNames[name]
+				if !isCustom && name == "apply_patch" {
+					isCustom = true
+				}
 				idx := st.NextIndex
 				st.NextIndex++
 				// Ensure buffers
@@ -323,6 +340,9 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 					st.FuncCallIDs[idx] = fmt.Sprintf("call_%d_%d", time.Now().UnixNano(), atomic.AddUint64(&funcCallIDCounter, 1))
 				}
 				st.FuncNames[idx] = name
+				if isCustom {
+					st.CustomDone[idx] = true
+				}
 
 				argsJSON := "{}"
 				if args := fc.Get("args"); args.Exists() {
@@ -330,6 +350,48 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 				}
 				if st.FuncArgsBuf[idx].Len() == 0 && argsJSON != "" {
 					st.FuncArgsBuf[idx].WriteString(argsJSON)
+				}
+
+				if isCustom {
+					// custom_tool_call: bare input text, no JSON arguments wrapper.
+					customInput := translatorcommon.UnwrapCustomToolInput(argsJSON)
+
+					item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"in_progress","call_id":"","name":"","input":""}}`)
+					item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
+					item, _ = sjson.SetBytes(item, "output_index", idx)
+					item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+					item, _ = sjson.SetBytes(item, "item.call_id", st.FuncCallIDs[idx])
+					item, _ = sjson.SetBytes(item, "item.name", name)
+					out = append(out, emitEvent("response.output_item.added", item))
+
+					if !st.FuncDone[idx] {
+						delta := []byte(`{"type":"response.custom_tool_call_input.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
+						delta, _ = sjson.SetBytes(delta, "sequence_number", nextSeq())
+						delta, _ = sjson.SetBytes(delta, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+						delta, _ = sjson.SetBytes(delta, "output_index", idx)
+						delta, _ = sjson.SetBytes(delta, "delta", customInput)
+						out = append(out, emitEvent("response.custom_tool_call_input.delta", delta))
+
+						inputDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
+						inputDone, _ = sjson.SetBytes(inputDone, "sequence_number", nextSeq())
+						inputDone, _ = sjson.SetBytes(inputDone, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+						inputDone, _ = sjson.SetBytes(inputDone, "output_index", idx)
+						inputDone, _ = sjson.SetBytes(inputDone, "input", customInput)
+						out = append(out, emitEvent("response.custom_tool_call_input.done", inputDone))
+
+						itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"completed","call_id":"","name":"","input":""}}`)
+						itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+						itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+						itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+						itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
+						itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[idx])
+						itemDone, _ = sjson.SetBytes(itemDone, "item.input", customInput)
+						out = append(out, emitEvent("response.output_item.done", itemDone))
+
+						st.FuncDone[idx] = true
+					}
+
+					return true
 				}
 
 				// Emit item.added for function call
@@ -524,6 +586,15 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 				if b := st.FuncArgsBuf[idx]; b != nil && b.Len() > 0 {
 					args = b.String()
 				}
+				if st.CustomDone[idx] {
+					item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","call_id":"","name":"","input":""}`)
+					item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
+					item, _ = sjson.SetBytes(item, "call_id", callID)
+					item, _ = sjson.SetBytes(item, "name", st.FuncNames[idx])
+					item, _ = sjson.SetBytes(item, "input", translatorcommon.UnwrapCustomToolInput(args))
+					outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
+					continue
+				}
 				item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
 				item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
 				item, _ = sjson.SetBytes(item, "arguments", args)
@@ -572,6 +643,7 @@ func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 	root := gjson.ParseBytes(rawJSON)
 	root = unwrapGeminiResponseRoot(root)
 	sanitizedNameMap := util.SanitizedToolNameMap(originalRequestRawJSON)
+	customNames := translatorcommon.CustomToolNamesFromRequest(pickRequestJSON(originalRequestRawJSON, requestRawJSON))
 
 	// Base response scaffold
 	resp := []byte(`{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null,"incomplete_details":null}`)
@@ -704,14 +776,30 @@ func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 				name := util.RestoreSanitizedToolName(sanitizedNameMap, fc.Get("name").String())
 				args := fc.Get("args")
 				callID := fmt.Sprintf("call_%x_%d", time.Now().UnixNano(), atomic.AddUint64(&funcCallIDCounter, 1))
-				itemJSON := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
-				itemJSON, _ = sjson.SetBytes(itemJSON, "id", fmt.Sprintf("fc_%s", callID))
-				itemJSON, _ = sjson.SetBytes(itemJSON, "call_id", callID)
-				itemJSON, _ = sjson.SetBytes(itemJSON, "name", name)
 				argsStr := ""
 				if args.Exists() {
 					argsStr = args.Raw
 				}
+				// A freeform `custom` tool (e.g. apply_patch) was downgraded to a
+				// regular function on the request side; the host expects it back as a
+				// custom_tool_call carrying bare `input` text, not a function_call.
+				_, isCustom := customNames[name]
+				if !isCustom && name == "apply_patch" {
+					isCustom = true
+				}
+				if isCustom {
+					itemJSON := []byte(`{"id":"","type":"custom_tool_call","status":"completed","call_id":"","name":"","input":""}`)
+					itemJSON, _ = sjson.SetBytes(itemJSON, "id", fmt.Sprintf("fc_%s", callID))
+					itemJSON, _ = sjson.SetBytes(itemJSON, "call_id", callID)
+					itemJSON, _ = sjson.SetBytes(itemJSON, "name", name)
+					itemJSON, _ = sjson.SetBytes(itemJSON, "input", translatorcommon.UnwrapCustomToolInput(argsStr))
+					appendOutput(itemJSON)
+					return true
+				}
+				itemJSON := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
+				itemJSON, _ = sjson.SetBytes(itemJSON, "id", fmt.Sprintf("fc_%s", callID))
+				itemJSON, _ = sjson.SetBytes(itemJSON, "call_id", callID)
+				itemJSON, _ = sjson.SetBytes(itemJSON, "name", name)
 				itemJSON, _ = sjson.SetBytes(itemJSON, "arguments", argsStr)
 				appendOutput(itemJSON)
 				return true

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
@@ -45,6 +45,7 @@ type geminiToResponsesState struct {
 	CustomDone       map[int]bool
 	SanitizedNameMap map[string]string
 	CustomToolNames  map[string]struct{}
+	RequestHasTools  bool
 }
 
 // responseIDCounter provides a process-wide unique counter for synthesized response identifiers.
@@ -101,6 +102,7 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 			CustomDone:       make(map[int]bool),
 			SanitizedNameMap: util.SanitizedToolNameMap(originalRequestRawJSON),
 			CustomToolNames:  translatorcommon.CustomToolNamesFromRequest(pickRequestJSON(originalRequestRawJSON, requestRawJSON)),
+			RequestHasTools:  translatorcommon.RequestDeclaresTools(pickRequestJSON(originalRequestRawJSON, requestRawJSON)),
 		}
 	}
 	st := (*param).(*geminiToResponsesState)
@@ -124,6 +126,7 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 	}
 	if st.CustomToolNames == nil {
 		st.CustomToolNames = translatorcommon.CustomToolNamesFromRequest(pickRequestJSON(originalRequestRawJSON, requestRawJSON))
+		st.RequestHasTools = translatorcommon.RequestDeclaresTools(pickRequestJSON(originalRequestRawJSON, requestRawJSON))
 	}
 
 	if bytes.HasPrefix(rawJSON, []byte("data:")) {
@@ -327,7 +330,7 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 				// regular function on the request side; the host expects it back as a
 				// custom_tool_call carrying bare `input` text, not a function_call.
 				_, isCustom := st.CustomToolNames[name]
-				if !isCustom && name == "apply_patch" {
+				if !isCustom && name == "apply_patch" && !st.RequestHasTools {
 					isCustom = true
 				}
 				idx := st.NextIndex
@@ -644,6 +647,7 @@ func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 	root = unwrapGeminiResponseRoot(root)
 	sanitizedNameMap := util.SanitizedToolNameMap(originalRequestRawJSON)
 	customNames := translatorcommon.CustomToolNamesFromRequest(pickRequestJSON(originalRequestRawJSON, requestRawJSON))
+	customReqHasTools := translatorcommon.RequestDeclaresTools(pickRequestJSON(originalRequestRawJSON, requestRawJSON))
 
 	// Base response scaffold
 	resp := []byte(`{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null,"incomplete_details":null}`)
@@ -784,7 +788,7 @@ func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 				// regular function on the request side; the host expects it back as a
 				// custom_tool_call carrying bare `input` text, not a function_call.
 				_, isCustom := customNames[name]
-				if !isCustom && name == "apply_patch" {
+				if !isCustom && name == "apply_patch" && !customReqHasTools {
 					isCustom = true
 				}
 				if isCustom {

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_response_custom_tool_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_response_custom_tool_test.go
@@ -1,0 +1,231 @@
+package responses
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// customToolRequest is a Responses-API request that declares apply_patch as a
+// freeform `custom` tool plus a regular `function` tool (shell). The response
+// side uses the request to decide which returned tool calls must be re-emitted
+// as custom_tool_call (bare input) vs function_call (JSON arguments).
+const customToolRequest = `{
+  "model": "gpt-5",
+  "tools": [
+    {"type": "custom", "name": "apply_patch", "description": "Use the apply_patch tool to edit files."},
+    {"type": "function", "name": "shell", "parameters": {"type": "object", "properties": {"cmd": {"type": "string"}}}}
+  ]
+}`
+
+const barePatch = "*** Begin Patch\n*** Add File: /tmp/x.txt\n+hi\n*** End Patch"
+
+// geminiArgsWithInput wraps the bare patch text the way Gemini emits it after
+// the request-side downgrade: the function is declared with a single string
+// parameter named "input", so the model returns args={"input":"<patch>"}.
+func geminiArgsWithInput(t *testing.T, input string) string {
+	t.Helper()
+	return `{"input":` + jsonQuote(input) + `}`
+}
+
+func jsonQuote(s string) string {
+	// Minimal JSON string quoting sufficient for the test payloads.
+	out := []rune{'"'}
+	for _, r := range s {
+		switch r {
+		case '"':
+			out = append(out, '\\', '"')
+		case '\\':
+			out = append(out, '\\', '\\')
+		case '\n':
+			out = append(out, '\\', 'n')
+		case '\t':
+			out = append(out, '\\', 't')
+		case '\r':
+			out = append(out, '\\', 'r')
+		default:
+			out = append(out, r)
+		}
+	}
+	out = append(out, '"')
+	return string(out)
+}
+
+// TestConvertGeminiResponseStream_ApplyPatchCustomToolCall verifies that an
+// apply_patch (declared as a custom tool) functionCall coming back from Gemini
+// is re-emitted as a custom_tool_call with bare `input` text and no arguments.
+func TestConvertGeminiResponseStream_ApplyPatchCustomToolCall(t *testing.T) {
+	args := geminiArgsWithInput(t, barePatch)
+	lines := []string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"apply_patch","args":` + args + `}}]}}],"responseId":"req_ct_1"}`,
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2,"totalTokenCount":5},"responseId":"req_ct_1"}`,
+	}
+
+	var param any
+	var out [][]byte
+	for _, line := range lines {
+		out = append(out, ConvertGeminiResponseToOpenAIResponses(context.Background(), "test-model", []byte(customToolRequest), nil, []byte(line), &param)...)
+	}
+
+	var (
+		gotAdded     bool
+		gotInputDone bool
+		gotItemDone  bool
+		gotCompleted bool
+	)
+
+	for _, chunk := range out {
+		ev, data := parseSSEEvent(t, chunk)
+		switch ev {
+		case "response.output_item.added":
+			if data.Get("item.type").String() == "custom_tool_call" {
+				gotAdded = true
+				if data.Get("item.name").String() != "apply_patch" {
+					t.Fatalf("added item name = %q, want apply_patch", data.Get("item.name").String())
+				}
+				if data.Get("item.arguments").Exists() {
+					t.Fatalf("custom_tool_call added must not carry arguments: %s", data.Raw)
+				}
+			}
+		case "response.custom_tool_call_input.done":
+			gotInputDone = true
+			if data.Get("input").String() != barePatch {
+				t.Fatalf("input.done input = %q, want bare patch %q", data.Get("input").String(), barePatch)
+			}
+		case "response.output_item.done":
+			if data.Get("item.type").String() == "custom_tool_call" {
+				gotItemDone = true
+				if data.Get("item.input").String() != barePatch {
+					t.Fatalf("item.done input = %q, want bare patch", data.Get("item.input").String())
+				}
+				if data.Get("item.arguments").Exists() {
+					t.Fatalf("custom_tool_call done must not carry arguments: %s", data.Raw)
+				}
+			}
+		case "response.completed":
+			gotCompleted = true
+			outputs := data.Get("response.output")
+			found := false
+			outputs.ForEach(func(_, item gjson.Result) bool {
+				if item.Get("type").String() == "custom_tool_call" {
+					found = true
+					if item.Get("input").String() != barePatch {
+						t.Fatalf("completed custom_tool_call input = %q, want bare patch", item.Get("input").String())
+					}
+					if item.Get("arguments").Exists() {
+						t.Fatalf("completed custom_tool_call must not carry arguments: %s", item.Raw)
+					}
+				}
+				return true
+			})
+			if !found {
+				t.Fatalf("response.completed output missing custom_tool_call: %s", data.Raw)
+			}
+		}
+	}
+
+	if !gotAdded || !gotInputDone || !gotItemDone || !gotCompleted {
+		t.Fatalf("missing events: added=%v inputDone=%v itemDone=%v completed=%v", gotAdded, gotInputDone, gotItemDone, gotCompleted)
+	}
+}
+
+// TestConvertGeminiResponseStream_RegularFunctionStillFunctionCall verifies a
+// normal function tool (shell) still produces a function_call with JSON args.
+func TestConvertGeminiResponseStream_RegularFunctionStillFunctionCall(t *testing.T) {
+	lines := []string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"shell","args":{"cmd":"ls"}}}]}}],"responseId":"req_fn_1"}`,
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2,"totalTokenCount":5},"responseId":"req_fn_1"}`,
+	}
+
+	var param any
+	var out [][]byte
+	for _, line := range lines {
+		out = append(out, ConvertGeminiResponseToOpenAIResponses(context.Background(), "test-model", []byte(customToolRequest), nil, []byte(line), &param)...)
+	}
+
+	gotFuncAdded := false
+	for _, chunk := range out {
+		ev, data := parseSSEEvent(t, chunk)
+		if ev == "response.output_item.added" && data.Get("item.type").String() == "function_call" {
+			gotFuncAdded = true
+			if data.Get("item.name").String() != "shell" {
+				t.Fatalf("function_call name = %q, want shell", data.Get("item.name").String())
+			}
+		}
+		if ev == "response.output_item.added" && data.Get("item.type").String() == "custom_tool_call" {
+			t.Fatalf("regular function must not become custom_tool_call: %s", data.Raw)
+		}
+		if ev == "response.completed" {
+			data.Get("response.output").ForEach(func(_, item gjson.Result) bool {
+				if item.Get("type").String() == "function_call" {
+					if item.Get("arguments").String() != `{"cmd":"ls"}` {
+						t.Fatalf("function_call arguments = %q", item.Get("arguments").String())
+					}
+				}
+				return true
+			})
+		}
+	}
+	if !gotFuncAdded {
+		t.Fatalf("expected a function_call output_item.added for shell")
+	}
+}
+
+// TestConvertGeminiResponseNonStream_ApplyPatchCustomToolCall verifies the
+// non-streaming aggregator emits a custom_tool_call with bare input.
+func TestConvertGeminiResponseNonStream_ApplyPatchCustomToolCall(t *testing.T) {
+	args := geminiArgsWithInput(t, barePatch)
+	raw := `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"apply_patch","args":` + args + `}}]}}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2,"totalTokenCount":5},"modelVersion":"test-model","responseId":"req_ct_ns_1"}`
+
+	var param any
+	out := ConvertGeminiResponseToOpenAIResponsesNonStream(context.Background(), "test-model", []byte(customToolRequest), nil, []byte(raw), &param)
+
+	root := gjson.ParseBytes(out)
+	found := false
+	root.Get("output").ForEach(func(_, item gjson.Result) bool {
+		if item.Get("type").String() == "custom_tool_call" {
+			found = true
+			if item.Get("name").String() != "apply_patch" {
+				t.Fatalf("custom_tool_call name = %q, want apply_patch", item.Get("name").String())
+			}
+			if item.Get("input").String() != barePatch {
+				t.Fatalf("custom_tool_call input = %q, want bare patch", item.Get("input").String())
+			}
+			if item.Get("arguments").Exists() {
+				t.Fatalf("custom_tool_call must not carry arguments: %s", item.Raw)
+			}
+		}
+		return true
+	})
+	if !found {
+		t.Fatalf("non-stream output missing custom_tool_call: %s", string(out))
+	}
+}
+
+// TestConvertGeminiResponseNonStream_RegularFunctionStillFunctionCall verifies a
+// normal function still produces function_call with JSON arguments (non-stream).
+func TestConvertGeminiResponseNonStream_RegularFunctionStillFunctionCall(t *testing.T) {
+	raw := `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"shell","args":{"cmd":"ls"}}}]}}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2,"totalTokenCount":5},"modelVersion":"test-model","responseId":"req_fn_ns_1"}`
+
+	var param any
+	out := ConvertGeminiResponseToOpenAIResponsesNonStream(context.Background(), "test-model", []byte(customToolRequest), nil, []byte(raw), &param)
+
+	root := gjson.ParseBytes(out)
+	found := false
+	root.Get("output").ForEach(func(_, item gjson.Result) bool {
+		if item.Get("type").String() == "function_call" && item.Get("name").String() == "shell" {
+			found = true
+			if item.Get("arguments").String() != `{"cmd":"ls"}` {
+				t.Fatalf("function_call arguments = %q", item.Get("arguments").String())
+			}
+		}
+		if item.Get("type").String() == "custom_tool_call" {
+			t.Fatalf("regular function must not become custom_tool_call: %s", item.Raw)
+		}
+		return true
+	})
+	if !found {
+		t.Fatalf("non-stream output missing shell function_call: %s", string(out))
+	}
+}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_custom_tool_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_custom_tool_test.go
@@ -1,0 +1,133 @@
+package responses
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+const applyPatchPayload = "*** Begin Patch\n*** Add File: /tmp/x.txt\n+hi\n*** End Patch"
+
+// request side: a custom (apply_patch) tool must be downgraded to a chat
+// function tool carrying a single string `input` parameter (not dropped).
+func TestDeepSeekRequest_CustomToolDowngraded(t *testing.T) {
+	raw := []byte(`{
+		"model":"deepseek-v4-pro",
+		"input":"edit a file",
+		"tools":[
+			{"type":"function","name":"shell","description":"run","parameters":{"type":"object","properties":{}}},
+			{"type":"custom","name":"apply_patch","description":"Use the apply_patch tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON."}
+		]
+	}`)
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("deepseek-v4-pro", raw, false)
+	tools := gjson.GetBytes(out, "tools")
+	if !tools.IsArray() {
+		t.Fatalf("tools missing: %s", out)
+	}
+	var ap gjson.Result
+	tools.ForEach(func(_, tool gjson.Result) bool {
+		if tool.Get("function.name").String() == "apply_patch" {
+			ap = tool
+		}
+		return true
+	})
+	if !ap.Exists() {
+		t.Fatalf("apply_patch was dropped, got: %s", out)
+	}
+	if ap.Get("type").String() != "function" {
+		t.Fatalf("apply_patch must be downgraded to function, got type %q", ap.Get("type").String())
+	}
+	if !ap.Get("function.parameters.properties.input").Exists() {
+		t.Fatalf("downgraded apply_patch must carry an `input` string param, got: %s", ap.Raw)
+	}
+	if strings.Contains(ap.Get("function.description").String(), "do not wrap the patch in JSON") {
+		t.Fatalf("contradictory freeform sentence must be stripped from description")
+	}
+}
+
+// request side multi-turn: a historical custom_tool_call (bare input) must
+// replay to the backend as an assistant tool_call with wrapped JSON arguments.
+func TestDeepSeekRequest_CustomToolCallHistoryReplay(t *testing.T) {
+	raw := []byte(`{
+		"model":"deepseek-v4-pro",
+		"tools":[{"type":"custom","name":"apply_patch","description":"x"}],
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"edit"}]},
+			{"type":"custom_tool_call","call_id":"call_1","name":"apply_patch","input":"` + strings.ReplaceAll(applyPatchPayload, "\n", "\\n") + `"},
+			{"type":"custom_tool_call_output","call_id":"call_1","output":"Success. Updated."}
+		]
+	}`)
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("deepseek-v4-pro", raw, false)
+	// find the assistant tool_call carrying apply_patch
+	found := false
+	gjson.GetBytes(out, "messages").ForEach(func(_, msg gjson.Result) bool {
+		msg.Get("tool_calls").ForEach(func(_, tc gjson.Result) bool {
+			if tc.Get("function.name").String() == "apply_patch" {
+				args := tc.Get("function.arguments").String()
+				if gjson.Get(args, "input").String() == applyPatchPayload {
+					found = true
+				}
+			}
+			return true
+		})
+		return true
+	})
+	if !found {
+		t.Fatalf("custom_tool_call history must replay as tool_call with {\"input\":patch} args, got: %s", out)
+	}
+}
+
+// response side non-stream: a DeepSeek tool_call for apply_patch must surface
+// as a custom_tool_call output item with bare input text (no JSON wrapper).
+func TestDeepSeekResponse_NonStreamCustomToolCall(t *testing.T) {
+	originalReq := []byte(`{"tools":[{"type":"custom","name":"apply_patch","description":"x"}]}`)
+	// DeepSeek returns the downgraded function call with wrapped JSON args
+	backendResp := []byte(`{
+		"choices":[{"message":{"role":"assistant","tool_calls":[
+			{"id":"call_9","type":"function","function":{"name":"apply_patch","arguments":"{\"input\":\"` + strings.ReplaceAll(applyPatchPayload, "\n", "\\n") + `\"}"}}
+		]},"finish_reason":"tool_calls"}]
+	}`)
+	out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "deepseek-v4-pro", originalReq, originalReq, backendResp, nil)
+	var item gjson.Result
+	gjson.GetBytes(out, "output").ForEach(func(_, it gjson.Result) bool {
+		if it.Get("name").String() == "apply_patch" {
+			item = it
+		}
+		return true
+	})
+	if !item.Exists() {
+		t.Fatalf("no apply_patch output item, got: %s", out)
+	}
+	if item.Get("type").String() != "custom_tool_call" {
+		t.Fatalf("apply_patch must be custom_tool_call, got %q: %s", item.Get("type").String(), item.Raw)
+	}
+	if item.Get("input").String() != applyPatchPayload {
+		t.Fatalf("input must be bare patch text, got %q", item.Get("input").String())
+	}
+	if item.Get("arguments").Exists() && item.Get("arguments").String() != "" {
+		t.Fatalf("custom_tool_call must NOT carry JSON arguments, got %q", item.Get("arguments").String())
+	}
+}
+
+// regression: a normal function tool call stays a function_call.
+func TestDeepSeekResponse_NonStreamFunctionUnaffected(t *testing.T) {
+	originalReq := []byte(`{"tools":[{"type":"function","name":"shell"}]}`)
+	backendResp := []byte(`{
+		"choices":[{"message":{"role":"assistant","tool_calls":[
+			{"id":"call_5","type":"function","function":{"name":"shell","arguments":"{\"cmd\":\"ls\"}"}}
+		]},"finish_reason":"tool_calls"}]
+	}`)
+	out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "deepseek-v4-pro", originalReq, originalReq, backendResp, nil)
+	var item gjson.Result
+	gjson.GetBytes(out, "output").ForEach(func(_, it gjson.Result) bool {
+		if it.Get("name").String() == "shell" {
+			item = it
+		}
+		return true
+	})
+	if item.Get("type").String() != "function_call" {
+		t.Fatalf("shell must stay function_call, got %q", item.Get("type").String())
+	}
+}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_custom_tool_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_custom_tool_test.go
@@ -131,3 +131,34 @@ func TestDeepSeekResponse_NonStreamFunctionUnaffected(t *testing.T) {
 		t.Fatalf("shell must stay function_call, got %q", item.Get("type").String())
 	}
 }
+
+// regression: when the request snapshot IS available and declares apply_patch as
+// a *regular function* (not a freeform custom tool), the response must keep it as
+// a function_call with its JSON arguments intact. The defensive apply_patch
+// fallback must only fire when the request snapshot is unavailable, not whenever
+// the name happens to be absent from the (correctly empty) custom set.
+func TestDeepSeekResponse_NonStreamRegularApplyPatchNotForcedCustom(t *testing.T) {
+	originalReq := []byte(`{"tools":[{"type":"function","name":"apply_patch","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}]}`)
+	backendResp := []byte(`{
+		"choices":[{"message":{"role":"assistant","tool_calls":[
+			{"id":"call_7","type":"function","function":{"name":"apply_patch","arguments":"{\"path\":\"/tmp/x\"}"}}
+		]},"finish_reason":"tool_calls"}]
+	}`)
+	out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "deepseek-v4-pro", originalReq, originalReq, backendResp, nil)
+	var item gjson.Result
+	gjson.GetBytes(out, "output").ForEach(func(_, it gjson.Result) bool {
+		if it.Get("name").String() == "apply_patch" {
+			item = it
+		}
+		return true
+	})
+	if !item.Exists() {
+		t.Fatalf("no apply_patch output item, got: %s", out)
+	}
+	if item.Get("type").String() != "function_call" {
+		t.Fatalf("regular function apply_patch must stay function_call, got %q: %s", item.Get("type").String(), item.Raw)
+	}
+	if item.Get("arguments").String() != `{"path":"/tmp/x"}` {
+		t.Fatalf("function_call must keep JSON arguments, got %q", item.Get("arguments").String())
+	}
+}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -3,6 +3,7 @@ package responses
 import (
 	"strings"
 
+	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -60,7 +61,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 		inputItems := input.Array()
 		outputCallIDs := make(map[string]struct{})
 		for _, item := range inputItems {
-			if item.Get("type").String() != "function_call_output" {
+			if t := item.Get("type").String(); t != "function_call_output" && t != "custom_tool_call_output" {
 				continue
 			}
 			callID := strings.TrimSpace(item.Get("call_id").String())
@@ -172,8 +173,11 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 
 				appendRegularMessage(message)
 
-			case "function_call":
+			case "function_call", "custom_tool_call":
 				// Buffer consecutive function calls and emit them as one assistant message.
+				// custom_tool_call is the freeform form (apply_patch): it carries a bare
+				// `input` text instead of JSON `arguments`; wrap it back into the
+				// {"input": ...} object the downgraded function tool expects.
 				toolCall := []byte(`{"id":"","type":"function","function":{"name":"","arguments":""}}`)
 
 				if callId := item.Get("call_id"); callId.Exists() {
@@ -184,7 +188,9 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					toolCall, _ = sjson.SetBytes(toolCall, "function.name", name.String())
 				}
 
-				if arguments := item.Get("arguments"); arguments.Exists() {
+				if item.Get("type").String() == "custom_tool_call" {
+					toolCall, _ = sjson.SetBytes(toolCall, "function.arguments", translatorcommon.WrapCustomToolInput(item.Get("input").String()))
+				} else if arguments := item.Get("arguments"); arguments.Exists() {
 					toolCall, _ = sjson.SetBytes(toolCall, "function.arguments", arguments.String())
 				}
 				pendingToolCalls = append(pendingToolCalls, gjson.ParseBytes(toolCall).Value())
@@ -192,7 +198,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					pendingToolCallIDs = append(pendingToolCallIDs, callID)
 				}
 
-			case "function_call_output":
+			case "function_call_output", "custom_tool_call_output":
 				// Handle function call output conversion to tool message
 				toolMessage := []byte(`{"role":"tool","tool_call_id":"","content":""}`)
 				callID := ""
@@ -233,6 +239,22 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			// Built-in tools (e.g. {"type":"web_search"}) are already compatible with the Chat Completions schema.
 			// Only function tools need structural conversion because Chat Completions nests details under "function".
 			toolType := tool.Get("type").String()
+			if toolType == "custom" {
+				// Freeform `custom` tools (apply_patch) have no chat-completions
+				// equivalent. Downgrade to a function tool carrying a single
+				// string `input` argument; the response side re-emits the
+				// model's tool_call as a custom_tool_call with bare input text.
+				name := strings.TrimSpace(tool.Get("name").String())
+				if name == "" {
+					return true
+				}
+				chatTool := []byte(`{"type":"function","function":{"name":"","description":"","parameters":{}}}`)
+				chatTool, _ = sjson.SetBytes(chatTool, "function.name", name)
+				chatTool, _ = sjson.SetBytes(chatTool, "function.description", translatorcommon.CustomToolDescription(tool.Get("description").String()))
+				chatTool, _ = sjson.SetRawBytes(chatTool, "function.parameters", translatorcommon.CustomToolFunctionSchema())
+				chatCompletionsTools = append(chatCompletionsTools, gjson.ParseBytes(chatTool).Value())
+				return true
+			}
 			if toolType != "" && toolType != "function" && tool.IsObject() {
 				// Almost all providers lack built-in tools, so we just ignore them.
 				// chatCompletionsTools = append(chatCompletionsTools, tool.Value())

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -46,6 +46,10 @@ type oaiToResponsesState struct {
 	// function item done state
 	FuncArgsDone map[string]bool
 	FuncItemDone map[string]bool
+	// CustomToolNames is the set of tool names declared as freeform `custom`
+	// tools in the original request; their tool calls must be re-emitted as
+	// custom_tool_call (bare input) instead of function_call (JSON arguments).
+	CustomToolNames map[string]struct{}
 	// usage aggregation
 	PromptTokens     int64
 	CachedTokens     int64
@@ -171,6 +175,9 @@ func buildResponsesCompletedEvent(st *oaiToResponsesState, requestRawJSON []byte
 			item, _ = sjson.SetBytes(item, "arguments", args)
 			item, _ = sjson.SetBytes(item, "call_id", callID)
 			item, _ = sjson.SetBytes(item, "name", name)
+			if isCustomToolName(st.CustomToolNames, name) {
+				item = rewriteFunctionCallItemAsCustom(item)
+			}
 			outputItems = append(outputItems, completedOutputItem{index: st.FuncOutputIx[key], raw: item})
 		}
 	}
@@ -214,6 +221,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 			FuncArgsDone:    make(map[string]bool),
 			FuncItemDone:    make(map[string]bool),
 			Reasonings:      make([]oaiToResponsesStateReasoning, 0),
+			CustomToolNames: translatorcommon.CustomToolNamesFromRequest(pickResponsesRequestJSON(originalRequestRawJSON, requestRawJSON)),
 		}
 	}
 	st := (*param).(*oaiToResponsesState)
@@ -483,12 +491,22 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 
 						if shouldEmitItem && effectiveCallID != "" {
 							outputIndex := st.FuncOutputIx[key]
-							o := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
-							o, _ = sjson.SetBytes(o, "sequence_number", nextSeq())
-							o, _ = sjson.SetBytes(o, "output_index", outputIndex)
-							o, _ = sjson.SetBytes(o, "item.id", fmt.Sprintf("fc_%s", effectiveCallID))
-							o, _ = sjson.SetBytes(o, "item.call_id", effectiveCallID)
-							o, _ = sjson.SetBytes(o, "item.name", st.FuncNames[key])
+							var o []byte
+							if isCustomToolName(st.CustomToolNames, st.FuncNames[key]) {
+								o = []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"in_progress","call_id":"","name":"","input":""}}`)
+								o, _ = sjson.SetBytes(o, "sequence_number", nextSeq())
+								o, _ = sjson.SetBytes(o, "output_index", outputIndex)
+								o, _ = sjson.SetBytes(o, "item.id", fmt.Sprintf("fc_%s", effectiveCallID))
+								o, _ = sjson.SetBytes(o, "item.call_id", effectiveCallID)
+								o, _ = sjson.SetBytes(o, "item.name", st.FuncNames[key])
+							} else {
+								o = []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
+								o, _ = sjson.SetBytes(o, "sequence_number", nextSeq())
+								o, _ = sjson.SetBytes(o, "output_index", outputIndex)
+								o, _ = sjson.SetBytes(o, "item.id", fmt.Sprintf("fc_%s", effectiveCallID))
+								o, _ = sjson.SetBytes(o, "item.call_id", effectiveCallID)
+								o, _ = sjson.SetBytes(o, "item.name", st.FuncNames[key])
+							}
 							out = append(out, emitRespEvent("response.output_item.added", o))
 						}
 
@@ -501,7 +519,11 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 							if refCallID == "" {
 								refCallID = newCallID
 							}
-							if refCallID != "" {
+							// For freeform custom tools (apply_patch) the arguments
+							// arrive as a {"input": "..."} JSON wrapper; we cannot
+							// stream partial JSON as the bare input text, so we only
+							// buffer here and emit the unwrapped input at done.
+							if refCallID != "" && !isCustomToolName(st.CustomToolNames, st.FuncNames[key]) {
 								outputIndex := st.FuncOutputIx[key]
 								ad := []byte(`{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
 								ad, _ = sjson.SetBytes(ad, "sequence_number", nextSeq())
@@ -588,6 +610,27 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 						args := "{}"
 						if b := st.FuncArgsBuf[key]; b != nil && b.Len() > 0 {
 							args = b.String()
+						}
+						if isCustomToolName(st.CustomToolNames, st.FuncNames[key]) {
+							input := translatorcommon.UnwrapCustomToolInput(args)
+							ctcDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
+							ctcDone, _ = sjson.SetBytes(ctcDone, "sequence_number", nextSeq())
+							ctcDone, _ = sjson.SetBytes(ctcDone, "item_id", fmt.Sprintf("fc_%s", callID))
+							ctcDone, _ = sjson.SetBytes(ctcDone, "output_index", outputIndex)
+							ctcDone, _ = sjson.SetBytes(ctcDone, "input", input)
+							out = append(out, emitRespEvent("response.custom_tool_call_input.done", ctcDone))
+
+							itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"completed","call_id":"","name":"","input":""}}`)
+							itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+							itemDone, _ = sjson.SetBytes(itemDone, "output_index", outputIndex)
+							itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", callID))
+							itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", callID)
+							itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[key])
+							itemDone, _ = sjson.SetBytes(itemDone, "item.input", input)
+							out = append(out, emitRespEvent("response.output_item.done", itemDone))
+							st.FuncItemDone[key] = true
+							st.FuncArgsDone[key] = true
+							continue
 						}
 						fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
 						fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
@@ -752,6 +795,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 
 				// Function/tool calls
 				if tcs := msg.Get("tool_calls"); tcs.Exists() && tcs.IsArray() {
+					customNames := translatorcommon.CustomToolNamesFromRequest(pickResponsesRequestJSON(originalRequestRawJSON, requestRawJSON))
 					tcs.ForEach(func(_, tc gjson.Result) bool {
 						callID := tc.Get("id").String()
 						name := tc.Get("function.name").String()
@@ -761,6 +805,9 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 						item, _ = sjson.SetBytes(item, "arguments", args)
 						item, _ = sjson.SetBytes(item, "call_id", callID)
 						item, _ = sjson.SetBytes(item, "name", name)
+						if isCustomToolName(customNames, name) {
+							item = rewriteFunctionCallItemAsCustom(item)
+						}
 						outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
 						return true
 					})
@@ -794,4 +841,42 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 	}
 
 	return resp
+}
+
+// pickResponsesRequestJSON returns the most authoritative request JSON
+// available (original Responses request preferred) for extracting metadata
+// like the set of freeform custom tool names.
+func pickResponsesRequestJSON(originalRequestRawJSON, requestRawJSON []byte) []byte {
+	if len(originalRequestRawJSON) > 0 && gjson.ValidBytes(originalRequestRawJSON) {
+		return originalRequestRawJSON
+	}
+	return requestRawJSON
+}
+
+// isCustomToolName reports whether name was declared as a freeform `custom`
+// tool in the original request.
+func isCustomToolName(customNames map[string]struct{}, name string) bool {
+	if name == "" {
+		return false
+	}
+	if _, ok := customNames[name]; ok {
+		return true
+	}
+	// Defensive fallback: apply_patch is the canonical freeform tool even if
+	// the request snapshot was unavailable.
+	return name == "apply_patch"
+}
+
+// rewriteFunctionCallItemAsCustom converts a completed `function_call` output
+// item (with JSON `arguments`) into a `custom_tool_call` item with the bare
+// `input` text the Codex host expects for freeform tools.
+func rewriteFunctionCallItemAsCustom(item []byte) []byte {
+	args := gjson.GetBytes(item, "arguments").String()
+	input := translatorcommon.UnwrapCustomToolInput(args)
+	rebuilt := []byte(`{"id":"","type":"custom_tool_call","status":"completed","call_id":"","name":"","input":""}`)
+	rebuilt, _ = sjson.SetBytes(rebuilt, "id", gjson.GetBytes(item, "id").String())
+	rebuilt, _ = sjson.SetBytes(rebuilt, "call_id", gjson.GetBytes(item, "call_id").String())
+	rebuilt, _ = sjson.SetBytes(rebuilt, "name", gjson.GetBytes(item, "name").String())
+	rebuilt, _ = sjson.SetBytes(rebuilt, "input", input)
+	return rebuilt
 }

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -50,6 +50,11 @@ type oaiToResponsesState struct {
 	// tools in the original request; their tool calls must be re-emitted as
 	// custom_tool_call (bare input) instead of function_call (JSON arguments).
 	CustomToolNames map[string]struct{}
+	// RequestHasTools reports whether the request snapshot declared any tools.
+	// When true, CustomToolNames is authoritative and the apply_patch fallback
+	// must NOT fire (a declared regular function named apply_patch stays a
+	// function_call). When false (snapshot unavailable), the fallback applies.
+	RequestHasTools bool
 	// usage aggregation
 	PromptTokens     int64
 	CachedTokens     int64
@@ -175,7 +180,7 @@ func buildResponsesCompletedEvent(st *oaiToResponsesState, requestRawJSON []byte
 			item, _ = sjson.SetBytes(item, "arguments", args)
 			item, _ = sjson.SetBytes(item, "call_id", callID)
 			item, _ = sjson.SetBytes(item, "name", name)
-			if isCustomToolName(st.CustomToolNames, name) {
+			if isCustomToolName(st.CustomToolNames, name, st.RequestHasTools) {
 				item = rewriteFunctionCallItemAsCustom(item)
 			}
 			outputItems = append(outputItems, completedOutputItem{index: st.FuncOutputIx[key], raw: item})
@@ -222,6 +227,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 			FuncItemDone:    make(map[string]bool),
 			Reasonings:      make([]oaiToResponsesStateReasoning, 0),
 			CustomToolNames: translatorcommon.CustomToolNamesFromRequest(pickResponsesRequestJSON(originalRequestRawJSON, requestRawJSON)),
+			RequestHasTools: translatorcommon.RequestDeclaresTools(pickResponsesRequestJSON(originalRequestRawJSON, requestRawJSON)),
 		}
 	}
 	st := (*param).(*oaiToResponsesState)
@@ -492,7 +498,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 						if shouldEmitItem && effectiveCallID != "" {
 							outputIndex := st.FuncOutputIx[key]
 							var o []byte
-							if isCustomToolName(st.CustomToolNames, st.FuncNames[key]) {
+							if isCustomToolName(st.CustomToolNames, st.FuncNames[key], st.RequestHasTools) {
 								o = []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"in_progress","call_id":"","name":"","input":""}}`)
 								o, _ = sjson.SetBytes(o, "sequence_number", nextSeq())
 								o, _ = sjson.SetBytes(o, "output_index", outputIndex)
@@ -523,7 +529,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 							// arrive as a {"input": "..."} JSON wrapper; we cannot
 							// stream partial JSON as the bare input text, so we only
 							// buffer here and emit the unwrapped input at done.
-							if refCallID != "" && !isCustomToolName(st.CustomToolNames, st.FuncNames[key]) {
+							if refCallID != "" && !isCustomToolName(st.CustomToolNames, st.FuncNames[key], st.RequestHasTools) {
 								outputIndex := st.FuncOutputIx[key]
 								ad := []byte(`{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
 								ad, _ = sjson.SetBytes(ad, "sequence_number", nextSeq())
@@ -611,7 +617,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 						if b := st.FuncArgsBuf[key]; b != nil && b.Len() > 0 {
 							args = b.String()
 						}
-						if isCustomToolName(st.CustomToolNames, st.FuncNames[key]) {
+						if isCustomToolName(st.CustomToolNames, st.FuncNames[key], st.RequestHasTools) {
 							input := translatorcommon.UnwrapCustomToolInput(args)
 							ctcDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
 							ctcDone, _ = sjson.SetBytes(ctcDone, "sequence_number", nextSeq())
@@ -795,7 +801,9 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 
 				// Function/tool calls
 				if tcs := msg.Get("tool_calls"); tcs.Exists() && tcs.IsArray() {
-					customNames := translatorcommon.CustomToolNamesFromRequest(pickResponsesRequestJSON(originalRequestRawJSON, requestRawJSON))
+					reqJSON := pickResponsesRequestJSON(originalRequestRawJSON, requestRawJSON)
+					customNames := translatorcommon.CustomToolNamesFromRequest(reqJSON)
+					reqHasTools := translatorcommon.RequestDeclaresTools(reqJSON)
 					tcs.ForEach(func(_, tc gjson.Result) bool {
 						callID := tc.Get("id").String()
 						name := tc.Get("function.name").String()
@@ -805,7 +813,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 						item, _ = sjson.SetBytes(item, "arguments", args)
 						item, _ = sjson.SetBytes(item, "call_id", callID)
 						item, _ = sjson.SetBytes(item, "name", name)
-						if isCustomToolName(customNames, name) {
+						if isCustomToolName(customNames, name, reqHasTools) {
 							item = rewriteFunctionCallItemAsCustom(item)
 						}
 						outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
@@ -855,16 +863,19 @@ func pickResponsesRequestJSON(originalRequestRawJSON, requestRawJSON []byte) []b
 
 // isCustomToolName reports whether name was declared as a freeform `custom`
 // tool in the original request.
-func isCustomToolName(customNames map[string]struct{}, name string) bool {
+func isCustomToolName(customNames map[string]struct{}, name string, requestHasTools bool) bool {
 	if name == "" {
 		return false
 	}
 	if _, ok := customNames[name]; ok {
 		return true
 	}
-	// Defensive fallback: apply_patch is the canonical freeform tool even if
-	// the request snapshot was unavailable.
-	return name == "apply_patch"
+	// Defensive fallback: apply_patch is the canonical freeform tool, but ONLY
+	// when the request snapshot was unavailable (no tools declared). When the
+	// snapshot IS available and apply_patch is absent from the custom set, it was
+	// deliberately declared as a regular function — keep it a function_call and
+	// preserve its JSON arguments.
+	return name == "apply_patch" && !requestHasTools
 }
 
 // rewriteFunctionCallItemAsCustom converts a completed `function_call` output


### PR DESCRIPTION
## What

Codex sends `apply_patch` as a **freeform `custom` tool** (Responses API `type: custom`, bare-text input, no JSON schema). Backends translated from OpenAI Responses (Claude/Gemini/DeepSeek) don't support the custom tool type natively, so today the call is dropped/mis-shaped and the model reports the patch as aborted.

This PR adds custom-tool handling across the three `*/openai/responses/` translators:

- **Request side**: downgrade a `custom` tool to a regular `function` tool with a single string param; replay historical `custom_tool_call` / `custom_tool_call_output` items consistently.
- **Response side**: when a tool call comes back for a name that was originally `custom`, re-emit it as a `custom_tool_call` (bare input text) instead of a `function_call` (JSON args), so the Codex host gets the shape it expects.
- Shared helpers in `internal/translator/common/custom_tool.go` (`IsResponsesCustomTool`, `CustomToolInputKey`, `Wrap/UnwrapCustomToolInput`), covering both stream and non-stream.

## Test
`go build ./...` clean; `go test ./internal/translator/...` green (0 failed), incl. new custom_tool tests for claude/gemini/openai (stream + non-stream) and common helpers.

## Notes
New files + minimal edits to existing responses translators; no unrelated changes. Independent of any open PR.