### PR TITLE
fix(translator/claude): pair tool_use/tool_result to avoid Bedrock 400

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -366,6 +366,15 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 					lastRole := gjson.GetBytes(out, fmt.Sprintf("messages.%d.role", lastIdx)).String()
 					lastContent := gjson.GetBytes(out, fmt.Sprintf("messages.%d.content", lastIdx))
 					if lastRole == "assistant" && lastContent.IsArray() {
+						// Attach any pending (signed) reasoning blocks to THIS assistant
+						// message BEFORE the tool_use, then clear them. Otherwise they
+						// linger and get flushed later (e.g. just before the
+						// function_call_output), moving the signed thinking block after
+						// the tool call/result instead of before the call.
+						for _, partJSON := range pendingReasoningParts {
+							out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content.-1", lastIdx), []byte(partJSON))
+						}
+						pendingReasoningParts = nil
 						out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content.-1", lastIdx), toolUse)
 						appendedToolUse = true
 					}
@@ -398,7 +407,12 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 					lastIdx := msgsCount - 1
 					lastRole := gjson.GetBytes(out, fmt.Sprintf("messages.%d.role", lastIdx)).String()
 					lastContent := gjson.GetBytes(out, fmt.Sprintf("messages.%d.content", lastIdx))
-					if lastRole == "user" && lastContent.IsArray() {
+					// Only append into the previous user message when it is a genuine
+					// tool_result container (every block is a tool_result). A user array
+					// holding multi-part text / image / document input is NOT a
+					// tool_result container; appending a tool_result into it would create
+					// an invalid mixed-content turn, so fall through to a new user message.
+					if lastRole == "user" && lastContent.IsArray() && isAllToolResultBlocks(lastContent) {
 						out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content.-1", lastIdx), toolResult)
 						appendedToolResult = true
 					}
@@ -477,6 +491,26 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 	out = reorderClaudeToolUseResultPairs(out)
 
 	return out
+}
+
+// isAllToolResultBlocks reports whether every block in a (user message) content
+// array is a tool_result. Used to decide whether a tool_result may be appended
+// into the previous user message: a multi-part text/image/document user array is
+// NOT a tool_result container and must not absorb a tool_result block.
+func isAllToolResultBlocks(content gjson.Result) bool {
+	if !content.IsArray() {
+		return false
+	}
+	blocks := content.Array()
+	if len(blocks) == 0 {
+		return false
+	}
+	for _, b := range blocks {
+		if b.Get("type").String() != "tool_result" {
+			return false
+		}
+	}
+	return true
 }
 
 func convertResponsesReasoningToClaudeThinking(item gjson.Result) []byte {

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -354,13 +354,31 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 					}
 				}
 
-				asst := []byte(`{"role":"assistant","content":[]}`)
-				for _, partJSON := range pendingReasoningParts {
-					asst, _ = sjson.SetRawBytes(asst, "content.-1", []byte(partJSON))
+				// FIX (parallel-tool-merge): If the last message in the array is already
+				// an assistant message whose content is an array (i.e., a tool_use container),
+				// append this tool_use to that message instead of creating a new assistant
+				// message. This avoids producing consecutive same-role messages, which violate
+				// the Anthropic Messages API requirement that user/assistant strictly alternate
+				// and which AWS Bedrock rejects as TOOL_USE_RESULT_MISMATCH (HTTP 400).
+				appendedToolUse := false
+				if msgsCount := gjson.GetBytes(out, "messages.#").Int(); msgsCount > 0 {
+					lastIdx := msgsCount - 1
+					lastRole := gjson.GetBytes(out, fmt.Sprintf("messages.%d.role", lastIdx)).String()
+					lastContent := gjson.GetBytes(out, fmt.Sprintf("messages.%d.content", lastIdx))
+					if lastRole == "assistant" && lastContent.IsArray() {
+						out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content.-1", lastIdx), toolUse)
+						appendedToolUse = true
+					}
 				}
-				pendingReasoningParts = nil
-				asst, _ = sjson.SetRawBytes(asst, "content.-1", toolUse)
-				out, _ = sjson.SetRawBytes(out, "messages.-1", asst)
+				if !appendedToolUse {
+					asst := []byte(`{"role":"assistant","content":[]}`)
+					for _, partJSON := range pendingReasoningParts {
+						asst, _ = sjson.SetRawBytes(asst, "content.-1", []byte(partJSON))
+					}
+					pendingReasoningParts = nil
+					asst, _ = sjson.SetRawBytes(asst, "content.-1", toolUse)
+					out, _ = sjson.SetRawBytes(out, "messages.-1", asst)
+				}
 
 			case "function_call_output":
 				flushPendingReasoning()
@@ -371,9 +389,25 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 				toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", callID)
 				toolResult, _ = sjson.SetBytes(toolResult, "content", outputStr)
 
-				usr := []byte(`{"role":"user","content":[]}`)
-				usr, _ = sjson.SetRawBytes(usr, "content.-1", toolResult)
-				out, _ = sjson.SetRawBytes(out, "messages.-1", usr)
+				// FIX (parallel-tool-merge): Mirror of the function_call branch.
+				// If the last message is already a user message whose content is an array
+				// (i.e., a tool_result container), append this tool_result instead of creating
+				// a new user message, to keep user/assistant strictly alternating.
+				appendedToolResult := false
+				if msgsCount := gjson.GetBytes(out, "messages.#").Int(); msgsCount > 0 {
+					lastIdx := msgsCount - 1
+					lastRole := gjson.GetBytes(out, fmt.Sprintf("messages.%d.role", lastIdx)).String()
+					lastContent := gjson.GetBytes(out, fmt.Sprintf("messages.%d.content", lastIdx))
+					if lastRole == "user" && lastContent.IsArray() {
+						out, _ = sjson.SetRawBytes(out, fmt.Sprintf("messages.%d.content.-1", lastIdx), toolResult)
+						appendedToolResult = true
+					}
+				}
+				if !appendedToolResult {
+					usr := []byte(`{"role":"user","content":[]}`)
+					usr, _ = sjson.SetRawBytes(usr, "content.-1", toolResult)
+					out, _ = sjson.SetRawBytes(out, "messages.-1", usr)
+				}
 			}
 			return true
 		})
@@ -435,6 +469,12 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 
 		}
 	}
+
+	// Defense-in-depth pairing sanitization: reorder any non-tool message that
+	// got wedged between an assistant tool_use and its matching user tool_result
+	// so the pair stays contiguous. AWS Bedrock rejects unpaired/interleaved
+	// tool_use/tool_result sequences with HTTP 400.
+	out = reorderClaudeToolUseResultPairs(out)
 
 	return out
 }

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_pairing.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_pairing.go
@@ -1,0 +1,278 @@
+package responses
+
+import (
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// reorderClaudeToolUseResultPairs performs a defense-in-depth "pairing
+// sanitization" pass over the final Anthropic `messages` array produced by
+// ConvertOpenAIResponsesRequestToClaude.
+//
+// Background: AWS Bedrock (Anthropic on Bedrock) rejects requests with HTTP 400
+// "tool_use and tool_result blocks must be correctly paired and ordered" when a
+// non-tool message (e.g. a compact-continuation developer/text message) is
+// inserted between an assistant tool_use message and its matching user
+// tool_result message.
+//
+// This pass works at the content-BLOCK level, not the message level. For every
+// assistant message carrying one or more tool_use blocks (a "batch"), it pulls
+// the matching tool_result BLOCKS to sit in a user message immediately after the
+// tool_use message — matching strictly on tool_use_id.
+//
+// Why block-level and not message-level: the request converter merges ADJACENT
+// function_call_output items into a SINGLE user message (see
+// claude_openai-responses_request.go, the "parallel-tool-merge" mirror branch).
+// So a single user message can carry tool_result blocks belonging to TWO
+// different assistant batches, e.g. input
+//
+//	assistant[use:a] | user(compact) | assistant[use:b] | output:a | output:b
+//
+// collapses to a user message content=[tool_result:a, tool_result:b]. Moving the
+// WHOLE message after use:a would orphan tool_result:b (use:b would have nothing
+// after it) — re-triggering the very Bedrock 400 this pass prevents. Instead we
+// split the merged container: tool_result:a goes after use:a, tool_result:b goes
+// after use:b. Anthropic requires that the parallel tool_result blocks for one
+// batch all live in the single user turn right after that batch, so a batch's
+// matched results are gathered into one user message together.
+//
+// The pass is idempotent: an already-correctly-ordered sequence is returned with
+// the original bytes untouched (the identity permutation short-circuits), and a
+// sequence that was actually reordered is left byte-identical on a second pass.
+func reorderClaudeToolUseResultPairs(out []byte) []byte {
+	msgs := gjson.GetBytes(out, "messages")
+	if !msgs.IsArray() {
+		return out
+	}
+	arr := msgs.Array()
+	n := len(arr)
+	if n < 2 {
+		return out
+	}
+
+	// Pre-parse each message's content blocks (only meaningful for array
+	// content; string content yields nil).
+	blocks := make([][]contentBlock, n)
+	blockTaken := make([][]bool, n)
+	for i := range arr {
+		blocks[i] = parseContentBlocks(arr[i])
+		if blocks[i] != nil {
+			blockTaken[i] = make([]bool, len(blocks[i]))
+		}
+	}
+
+	consumed := make([]bool, n)
+	// An emitted entry is either an original message (idx >= 0) or a freshly
+	// constructed message (idx == -1, use raw).
+	type entry struct {
+		idx int
+		raw []byte
+	}
+	emitted := make([]entry, 0, n)
+
+	for i := 0; i < n; i++ {
+		if consumed[i] {
+			continue
+		}
+		consumed[i] = true
+
+		ids := toolUseIDsOrdered(arr[i])
+		if len(ids) == 0 {
+			// Not an assistant tool_use batch. If some of this message's
+			// tool_result blocks were already pulled out by an earlier batch,
+			// emit only the leftover blocks; otherwise emit the message as-is.
+			if blocks[i] == nil {
+				emitted = append(emitted, entry{idx: i})
+				continue
+			}
+			anyTaken := false
+			for _, t := range blockTaken[i] {
+				if t {
+					anyTaken = true
+					break
+				}
+			}
+			if !anyTaken {
+				emitted = append(emitted, entry{idx: i})
+				continue
+			}
+			remaining := make([]string, 0, len(blocks[i]))
+			for bi, b := range blocks[i] {
+				if !blockTaken[i][bi] {
+					remaining = append(remaining, b.raw)
+				}
+			}
+			if len(remaining) == 0 {
+				// Every block was pulled elsewhere; drop the now-empty container.
+				continue
+			}
+			emitted = append(emitted, entry{idx: -1, raw: buildBlocksMessage(arr[i].Get("role").String(), remaining)})
+			continue
+		}
+
+		// Assistant tool_use batch: emit it, then pull the matching tool_result
+		// blocks (forward only) to sit immediately after it.
+		emitted = append(emitted, entry{idx: i})
+
+		matchedRaw := make([]string, 0, len(ids))
+		srcMsg := -1
+		singleSrc := true
+		for _, id := range ids {
+			mi, bi, ok := findForwardResultBlock(blocks, blockTaken, consumed, i+1, id)
+			if !ok {
+				continue
+			}
+			blockTaken[mi][bi] = true
+			matchedRaw = append(matchedRaw, blocks[mi][bi].raw)
+			if srcMsg == -1 {
+				srcMsg = mi
+			} else if srcMsg != mi {
+				singleSrc = false
+			}
+		}
+		if len(matchedRaw) == 0 {
+			continue
+		}
+
+		// Byte-preservation fast path: when every matched result came from one
+		// still-unconsumed message that holds ONLY these tool_result blocks
+		// (nothing else, nothing extra), keep that message verbatim instead of
+		// rebuilding it. This is what keeps an already-canonical sequence
+		// byte-identical (idempotency).
+		if singleSrc && srcMsg >= 0 && !consumed[srcMsg] &&
+			len(matchedRaw) == len(blocks[srcMsg]) && allToolResults(blocks[srcMsg]) {
+			consumed[srcMsg] = true
+			emitted = append(emitted, entry{idx: srcMsg})
+			continue
+		}
+		emitted = append(emitted, entry{idx: -1, raw: buildBlocksMessage("user", matchedRaw)})
+	}
+
+	// Idempotency guard: if the emitted order is the identity permutation of the
+	// original messages (no splits, no moves), return the original bytes.
+	identity := len(emitted) == n
+	if identity {
+		for k, e := range emitted {
+			if e.idx != k {
+				identity = false
+				break
+			}
+		}
+	}
+	if identity {
+		return out
+	}
+
+	rebuilt := []byte(`[]`)
+	for _, e := range emitted {
+		if e.idx >= 0 {
+			rebuilt, _ = sjson.SetRawBytes(rebuilt, "-1", []byte(arr[e.idx].Raw))
+		} else {
+			rebuilt, _ = sjson.SetRawBytes(rebuilt, "-1", e.raw)
+		}
+	}
+	result, err := sjson.SetRawBytes(out, "messages", rebuilt)
+	if err != nil {
+		return out
+	}
+	return result
+}
+
+// contentBlock is a lightweight view of one content array element. For
+// tool_result blocks it carries the tool_use_id so results can be matched to
+// their owning assistant batch.
+type contentBlock struct {
+	raw      string
+	isResult bool
+	id       string
+}
+
+// parseContentBlocks returns the content array blocks of a message, or nil when
+// the message content is not an array (e.g. a plain string text message).
+func parseContentBlocks(msg gjson.Result) []contentBlock {
+	content := msg.Get("content")
+	if !content.IsArray() {
+		return nil
+	}
+	var out []contentBlock
+	content.ForEach(func(_, b gjson.Result) bool {
+		cb := contentBlock{raw: b.Raw}
+		if b.Get("type").String() == "tool_result" {
+			cb.isResult = true
+			cb.id = b.Get("tool_use_id").String()
+		}
+		out = append(out, cb)
+		return true
+	})
+	return out
+}
+
+// toolUseIDsOrdered returns the tool_use ids carried by an assistant message
+// whose content is an array of content blocks, in first-appearance order and
+// de-duplicated. Returns nil for any message that is not an assistant tool_use
+// container.
+func toolUseIDsOrdered(msg gjson.Result) []string {
+	if msg.Get("role").String() != "assistant" {
+		return nil
+	}
+	content := msg.Get("content")
+	if !content.IsArray() {
+		return nil
+	}
+	var ids []string
+	seen := map[string]struct{}{}
+	content.ForEach(func(_, b gjson.Result) bool {
+		if b.Get("type").String() == "tool_use" {
+			id := b.Get("id").String()
+			if id != "" {
+				if _, ok := seen[id]; !ok {
+					seen[id] = struct{}{}
+					ids = append(ids, id)
+				}
+			}
+		}
+		return true
+	})
+	return ids
+}
+
+// findForwardResultBlock scans forward from message index `from` for the first
+// untaken tool_result block whose tool_use_id equals `id`. Returns the message
+// index, block index, and whether a match was found. Forward-only by design:
+// results that appear BEFORE their tool_use (a separate, out-of-scope concern)
+// are left untouched.
+func findForwardResultBlock(blocks [][]contentBlock, blockTaken [][]bool, consumed []bool, from int, id string) (int, int, bool) {
+	for j := from; j < len(blocks); j++ {
+		if consumed[j] || blocks[j] == nil {
+			continue
+		}
+		for bi, b := range blocks[j] {
+			if b.isResult && !blockTaken[j][bi] && b.id == id {
+				return j, bi, true
+			}
+		}
+	}
+	return -1, -1, false
+}
+
+// allToolResults reports whether every block in bs is a tool_result block (and
+// the slice is non-empty).
+func allToolResults(bs []contentBlock) bool {
+	for _, b := range bs {
+		if !b.isResult {
+			return false
+		}
+	}
+	return len(bs) > 0
+}
+
+// buildBlocksMessage constructs a `{"role":role,"content":[...]}` message from
+// the given raw content-block JSON fragments, preserving their order.
+func buildBlocksMessage(role string, rawBlocks []string) []byte {
+	msg := []byte(`{"role":"","content":[]}`)
+	msg, _ = sjson.SetBytes(msg, "role", role)
+	for _, r := range rawBlocks {
+		msg, _ = sjson.SetRawBytes(msg, "content.-1", []byte(r))
+	}
+	return msg
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_pairing.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_pairing.go
@@ -171,11 +171,76 @@ func reorderClaudeToolUseResultPairs(out []byte) []byte {
 			rebuilt, _ = sjson.SetRawBytes(rebuilt, "-1", e.raw)
 		}
 	}
+	// Moving an intervening message after a tool_use/tool_result pair can leave two
+	// consecutive same-role messages (e.g. the relocated tool_result user message
+	// followed by an intervening user message). Anthropic/Bedrock require strict
+	// user/assistant alternation and reject violations with HTTP 400, so merge any
+	// consecutive same-role messages by concatenating their content blocks.
+	rebuilt = mergeConsecutiveSameRoleMessages(rebuilt)
 	result, err := sjson.SetRawBytes(out, "messages", rebuilt)
 	if err != nil {
 		return out
 	}
 	return result
+}
+
+// mergeConsecutiveSameRoleMessages collapses adjacent messages that share the
+// same role into a single message whose content is the concatenation of both
+// messages' content blocks. String content is wrapped into a single text block
+// so it can be merged with array content. Input is a JSON array of messages;
+// output is the (possibly shorter) JSON array.
+func mergeConsecutiveSameRoleMessages(msgsJSON []byte) []byte {
+	arr := gjson.ParseBytes(msgsJSON).Array()
+	if len(arr) < 2 {
+		return msgsJSON
+	}
+	// contentBlocksOf returns the raw JSON of each content block for a message,
+	// wrapping string content into one text block.
+	contentBlocksOf := func(m gjson.Result) []string {
+		c := m.Get("content")
+		if c.IsArray() {
+			var bs []string
+			c.ForEach(func(_, b gjson.Result) bool {
+				bs = append(bs, b.Raw)
+				return true
+			})
+			return bs
+		}
+		tb := []byte(`{"type":"text","text":""}`)
+		tb, _ = sjson.SetBytes(tb, "text", c.String())
+		return []string{string(tb)}
+	}
+
+	merged := false
+	out := []byte(`[]`)
+	var curRole string
+	var curBlocks []string
+	haveCur := false
+	flush := func() {
+		if !haveCur {
+			return
+		}
+		out, _ = sjson.SetRawBytes(out, "-1", buildBlocksMessage(curRole, curBlocks))
+	}
+	for _, m := range arr {
+		role := m.Get("role").String()
+		if haveCur && role == curRole {
+			curBlocks = append(curBlocks, contentBlocksOf(m)...)
+			merged = true
+			continue
+		}
+		flush()
+		curRole = role
+		curBlocks = contentBlocksOf(m)
+		haveCur = true
+	}
+	flush()
+	if !merged {
+		// No adjacent same-role messages: keep original bytes (preserves any
+		// string-content messages verbatim instead of rewrapping into blocks).
+		return msgsJSON
+	}
+	return out
 }
 
 // contentBlock is a lightweight view of one content array element. For

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_pairing_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_pairing_test.go
@@ -1,0 +1,325 @@
+package responses
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// findToolUseMsgIndex returns the index of the first assistant message whose
+// content array contains a tool_use block, or -1.
+func findToolUseMsgIndex(msgs []gjson.Result) int {
+	for i, m := range msgs {
+		if m.Get("role").String() != "assistant" {
+			continue
+		}
+		content := m.Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		found := false
+		content.ForEach(func(_, b gjson.Result) bool {
+			if b.Get("type").String() == "tool_use" {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return i
+		}
+	}
+	return -1
+}
+
+// msgHasToolResult reports whether the message is a user message whose content
+// array contains at least one tool_result block.
+func msgHasToolResult(m gjson.Result) bool {
+	if m.Get("role").String() != "user" {
+		return false
+	}
+	content := m.Get("content")
+	if !content.IsArray() {
+		return false
+	}
+	found := false
+	content.ForEach(func(_, b gjson.Result) bool {
+		if b.Get("type").String() == "tool_result" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// TestConvertOpenAIResponses_ReordersInterveningMessageAfterPair verifies that a
+// non-tool message inserted between a tool_use and its tool_result (e.g. a
+// compact continuation developer message) is moved AFTER the pair so the
+// tool_use message is immediately followed by the matching tool_result message.
+func TestConvertOpenAIResponses_ReordersInterveningMessageAfterPair(t *testing.T) {
+	body := []byte(`{
+		"model": "kiro-api/claude-opus-4-7-thinking",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+			{"type":"function_call","call_id":"toolu_a","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"[compact] resuming previous session"}]},
+			{"type":"function_call_output","call_id":"toolu_a","output":"file1\nfile2"}
+		],
+		"tools": []
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("kiro-api/claude-opus-4-7-thinking", body, false)
+	msgs := gjson.GetBytes(out, "messages").Array()
+
+	tuIdx := findToolUseMsgIndex(msgs)
+	if tuIdx < 0 {
+		t.Fatalf("no tool_use message found in output: %s", string(out))
+	}
+	if tuIdx+1 >= len(msgs) {
+		t.Fatalf("tool_use message is last; no following message: %s", string(out))
+	}
+	if !msgHasToolResult(msgs[tuIdx+1]) {
+		t.Fatalf("expected tool_result message immediately after tool_use; got role=%q content=%s\nfull=%s",
+			msgs[tuIdx+1].Get("role").String(), msgs[tuIdx+1].Get("content").Raw, string(out))
+	}
+	// The intervening compact message must still be present somewhere after the pair.
+	foundCompact := false
+	for _, m := range msgs {
+		if m.Get("content").String() == "[compact] resuming previous session" {
+			foundCompact = true
+		}
+		m.Get("content").ForEach(func(_, b gjson.Result) bool {
+			if b.Get("text").String() == "[compact] resuming previous session" {
+				foundCompact = true
+			}
+			return true
+		})
+	}
+	if !foundCompact {
+		t.Fatalf("intervening compact message was dropped: %s", string(out))
+	}
+}
+
+// TestConvertOpenAIResponses_PairingIdempotent verifies that an already
+// correctly-ordered tool_use/tool_result sequence is unchanged by the
+// sanitization pass (running it again produces identical bytes).
+func TestConvertOpenAIResponses_PairingIdempotent(t *testing.T) {
+	body := []byte(`{
+		"model": "kiro-api/claude-opus-4-7-thinking",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+			{"type":"function_call","call_id":"toolu_a","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"},
+			{"type":"function_call_output","call_id":"toolu_a","output":"file1"}
+		],
+		"tools": []
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("kiro-api/claude-opus-4-7-thinking", body, false)
+	again := reorderClaudeToolUseResultPairs(out)
+	if string(again) != string(out) {
+		t.Fatalf("reorder is not idempotent.\nbefore=%s\nafter =%s", string(out), string(again))
+	}
+	msgs := gjson.GetBytes(out, "messages").Array()
+	tuIdx := findToolUseMsgIndex(msgs)
+	if tuIdx < 0 || tuIdx+1 >= len(msgs) || !msgHasToolResult(msgs[tuIdx+1]) {
+		t.Fatalf("expected contiguous tool_use/tool_result pair: %s", string(out))
+	}
+}
+
+// TestConvertOpenAIResponses_ParallelBatchReorder verifies that a parallel
+// tool_use batch (multiple tool_use ids in one assistant message) keeps its
+// matching multi-result user message together when an intervening message is
+// moved out of the way.
+func TestConvertOpenAIResponses_ParallelBatchReorder(t *testing.T) {
+	body := []byte(`{
+		"model": "kiro-api/claude-opus-4-7-thinking",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+			{"type":"function_call","call_id":"toolu_a","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"},
+			{"type":"function_call","call_id":"toolu_b","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"[compact] note"}]},
+			{"type":"function_call_output","call_id":"toolu_a","output":"a"},
+			{"type":"function_call_output","call_id":"toolu_b","output":"b"}
+		],
+		"tools": []
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("kiro-api/claude-opus-4-7-thinking", body, false)
+	msgs := gjson.GetBytes(out, "messages").Array()
+
+	tuIdx := findToolUseMsgIndex(msgs)
+	if tuIdx < 0 {
+		t.Fatalf("no tool_use message found: %s", string(out))
+	}
+	useIDs := map[string]bool{}
+	msgs[tuIdx].Get("content").ForEach(func(_, b gjson.Result) bool {
+		if b.Get("type").String() == "tool_use" {
+			useIDs[b.Get("id").String()] = true
+		}
+		return true
+	})
+	if !useIDs["toolu_a"] || !useIDs["toolu_b"] {
+		t.Fatalf("expected both tool_use ids in batch, got %v: %s", useIDs, string(out))
+	}
+	if tuIdx+1 >= len(msgs) || !msgHasToolResult(msgs[tuIdx+1]) {
+		t.Fatalf("expected tool_result message right after batch tool_use: %s", string(out))
+	}
+	resIDs := map[string]bool{}
+	msgs[tuIdx+1].Get("content").ForEach(func(_, b gjson.Result) bool {
+		if b.Get("type").String() == "tool_result" {
+			resIDs[b.Get("tool_use_id").String()] = true
+		}
+		return true
+	})
+	if !resIDs["toolu_a"] || !resIDs["toolu_b"] {
+		t.Fatalf("expected both tool_result ids in batch, got %v: %s", resIDs, string(out))
+	}
+}
+
+// findToolUseMsgIndexByID returns the index of the first assistant message whose
+// content array contains a tool_use block with the given id, or -1.
+func findToolUseMsgIndexByID(msgs []gjson.Result, id string) int {
+	for i, m := range msgs {
+		if m.Get("role").String() != "assistant" {
+			continue
+		}
+		content := m.Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		found := false
+		content.ForEach(func(_, b gjson.Result) bool {
+			if b.Get("type").String() == "tool_use" && b.Get("id").String() == id {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return i
+		}
+	}
+	return -1
+}
+
+// resultIDsInMessage returns the set of tool_result tool_use_ids in a user
+// message whose content is an array.
+func resultIDsInMessage(m gjson.Result) map[string]bool {
+	ids := map[string]bool{}
+	if m.Get("role").String() != "user" {
+		return ids
+	}
+	content := m.Get("content")
+	if !content.IsArray() {
+		return ids
+	}
+	content.ForEach(func(_, b gjson.Result) bool {
+		if b.Get("type").String() == "tool_result" {
+			ids[b.Get("tool_use_id").String()] = true
+		}
+		return true
+	})
+	return ids
+}
+
+// TestConvertOpenAIResponses_ReorderSplitBatchesWithMergedResults reproduces the
+// Reviewer bad case: two SEPARATE assistant tool_use batches (use:a then use:b,
+// with a compact message wedged between them), whose function_call_output items
+// are ADJACENT in the input and therefore get merged by the request converter
+// into a SINGLE user message [tool_result:a, tool_result:b].
+//
+// The old "move the whole user message" strategy pulled [res:a, res:b] after
+// use:a, orphaning res:b (use:b ends up with nothing after it) -> exactly the
+// Bedrock 400 this pass is meant to prevent. After the fix, each tool_use must
+// be immediately followed by a user message holding ONLY its own batch's
+// tool_result(s): use:a -> [res:a], use:b -> [res:b], with no orphans.
+func TestConvertOpenAIResponses_ReorderSplitBatchesWithMergedResults(t *testing.T) {
+	body := []byte(`{
+		"model": "kiro-api/claude-opus-4-7-thinking",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+			{"type":"function_call","call_id":"toolu_a","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"[compact] resuming previous session"}]},
+			{"type":"function_call","call_id":"toolu_b","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"},
+			{"type":"function_call_output","call_id":"toolu_a","output":"outA"},
+			{"type":"function_call_output","call_id":"toolu_b","output":"outB"}
+		],
+		"tools": []
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("kiro-api/claude-opus-4-7-thinking", body, false)
+	msgs := gjson.GetBytes(out, "messages").Array()
+
+	aIdx := findToolUseMsgIndexByID(msgs, "toolu_a")
+	bIdx := findToolUseMsgIndexByID(msgs, "toolu_b")
+	if aIdx < 0 || bIdx < 0 {
+		t.Fatalf("missing tool_use messages a=%d b=%d: %s", aIdx, bIdx, string(out))
+	}
+
+	// use:a must be immediately followed by a user message containing res:a
+	// (and NOT res:b - res:b belongs to use:b's batch).
+	if aIdx+1 >= len(msgs) || !msgHasToolResult(msgs[aIdx+1]) {
+		t.Fatalf("expected tool_result message right after use:a: %s", string(out))
+	}
+	aRes := resultIDsInMessage(msgs[aIdx+1])
+	if !aRes["toolu_a"] {
+		t.Fatalf("res:a not found after use:a, got %v: %s", aRes, string(out))
+	}
+	if aRes["toolu_b"] {
+		t.Fatalf("res:b was wrongly merged after use:a (orphaning use:b): %v\n%s", aRes, string(out))
+	}
+
+	// use:b must be immediately followed by a user message containing res:b.
+	if bIdx+1 >= len(msgs) || !msgHasToolResult(msgs[bIdx+1]) {
+		t.Fatalf("expected tool_result message right after use:b (res:b orphaned!): %s", string(out))
+	}
+	bRes := resultIDsInMessage(msgs[bIdx+1])
+	if !bRes["toolu_b"] {
+		t.Fatalf("res:b not found after use:b, got %v: %s", bRes, string(out))
+	}
+	if bRes["toolu_a"] {
+		t.Fatalf("res:a wrongly placed after use:b: %v\n%s", bRes, string(out))
+	}
+
+	// The compact message must survive somewhere.
+	foundCompact := false
+	for _, m := range msgs {
+		if m.Get("content").String() == "[compact] resuming previous session" {
+			foundCompact = true
+		}
+	}
+	if !foundCompact {
+		t.Fatalf("intervening compact message was dropped: %s", string(out))
+	}
+}
+
+// TestConvertOpenAIResponses_PairingIdempotentAfterRealReorder verifies real
+// idempotency (Reviewer issue #4): run reorder once on a sequence that ACTUALLY
+// gets reordered, then run it AGAIN on that reordered result and assert the
+// bytes are unchanged. This exercises the rebuild path, not just the identity
+// short-circuit.
+func TestConvertOpenAIResponses_PairingIdempotentAfterRealReorder(t *testing.T) {
+	body := []byte(`{
+		"model": "kiro-api/claude-opus-4-7-thinking",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+			{"type":"function_call","call_id":"toolu_a","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"[compact] resuming previous session"}]},
+			{"type":"function_call","call_id":"toolu_b","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"},
+			{"type":"function_call_output","call_id":"toolu_a","output":"outA"},
+			{"type":"function_call_output","call_id":"toolu_b","output":"outB"}
+		],
+		"tools": []
+	}`)
+	// First pass happens inside Convert; capture the reordered output.
+	first := ConvertOpenAIResponsesRequestToClaude("kiro-api/claude-opus-4-7-thinking", body, false)
+	// Sanity: the first pass really moved something (otherwise this test would
+	// degenerate into the identity short-circuit and prove nothing).
+	aIdx := findToolUseMsgIndexByID(gjson.GetBytes(first, "messages").Array(), "toolu_a")
+	if aIdx < 0 || aIdx+1 >= len(gjson.GetBytes(first, "messages").Array()) ||
+		!msgHasToolResult(gjson.GetBytes(first, "messages").Array()[aIdx+1]) {
+		t.Fatalf("precondition: first pass did not produce paired use:a/res:a: %s", string(first))
+	}
+	// Second pass over the already-reordered bytes must be a no-op.
+	second := reorderClaudeToolUseResultPairs(first)
+	if string(second) != string(first) {
+		t.Fatalf("reorder not idempotent on a truly-reordered sequence.\nfirst =%s\nsecond=%s", string(first), string(second))
+	}
+}

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_pairing_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_pairing_test.go
@@ -100,6 +100,39 @@ func TestConvertOpenAIResponses_ReordersInterveningMessageAfterPair(t *testing.T
 	}
 }
 
+// TestConvertOpenAIResponses_ReorderKeepsStrictRoleAlternation verifies that when
+// an intervening user message is moved after a tool_use/tool_result pair, the
+// result does NOT contain consecutive same-role messages (which Anthropic/Bedrock
+// reject with HTTP 400). Any consecutive same-role messages produced by the
+// reorder must be merged.
+func TestConvertOpenAIResponses_ReorderKeepsStrictRoleAlternation(t *testing.T) {
+	body := []byte(`{
+		"model": "kiro-api/claude-opus-4-7-thinking",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+			{"type":"function_call","call_id":"toolu_a","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"[compact] resuming previous session"}]},
+			{"type":"function_call_output","call_id":"toolu_a","output":"file1\nfile2"}
+		],
+		"tools": []
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("kiro-api/claude-opus-4-7-thinking", body, false)
+	msgs := gjson.GetBytes(out, "messages").Array()
+	lastRole := ""
+	for i, m := range msgs {
+		role := m.Get("role").String()
+		if role == lastRole {
+			t.Fatalf("consecutive same-role messages at index %d (role=%q) violate alternation:\n%s", i, role, string(out))
+		}
+		lastRole = role
+	}
+	// And it must still be idempotent (running reorder again is a no-op).
+	again := reorderClaudeToolUseResultPairs(out)
+	if string(again) != string(out) {
+		t.Fatalf("reorder not idempotent after merge.\nbefore=%s\nafter=%s", string(out), string(again))
+	}
+}
+
 // TestConvertOpenAIResponses_PairingIdempotent verifies that an already
 // correctly-ordered tool_use/tool_result sequence is unchanged by the
 // sanitization pass (running it again produces identical bytes).
@@ -278,12 +311,21 @@ func TestConvertOpenAIResponses_ReorderSplitBatchesWithMergedResults(t *testing.
 		t.Fatalf("res:a wrongly placed after use:b: %v\n%s", bRes, string(out))
 	}
 
-	// The compact message must survive somewhere.
+	// The compact message must survive somewhere. After the strict-alternation
+	// merge pass it may be a text block inside an adjacent user message rather
+	// than a standalone string-content message, so check both forms (same as
+	// TestConvertOpenAIResponses_ReordersInterveningMessageAfterPair).
 	foundCompact := false
 	for _, m := range msgs {
 		if m.Get("content").String() == "[compact] resuming previous session" {
 			foundCompact = true
 		}
+		m.Get("content").ForEach(func(_, b gjson.Result) bool {
+			if b.Get("text").String() == "[compact] resuming previous session" {
+				foundCompact = true
+			}
+			return true
+		})
 	}
 	if !foundCompact {
 		t.Fatalf("intervening compact message was dropped: %s", string(out))
@@ -321,5 +363,111 @@ func TestConvertOpenAIResponses_PairingIdempotentAfterRealReorder(t *testing.T) 
 	second := reorderClaudeToolUseResultPairs(first)
 	if string(second) != string(first) {
 		t.Fatalf("reorder not idempotent on a truly-reordered sequence.\nfirst =%s\nsecond=%s", string(first), string(second))
+	}
+}
+
+// TestConvertOpenAIResponses_ReasoningAttachedBeforeAppendedToolUse verifies the
+// append path keeps signed reasoning attached to the assistant message BEFORE
+// the tool_use it precedes. The sequence: assistant text -> function_call(a) ->
+// reasoning -> function_call(b). The reasoning must land in the assistant
+// message in front of tool_use(b), not get flushed later (which would move the
+// signed thinking block after the tool call and break ordering).
+func TestConvertOpenAIResponses_ReasoningAttachedBeforeAppendedToolUse(t *testing.T) {
+	rawSignature, _ := testClaudeResponsesThinkingSignature(t)
+	body := []byte(`{
+		"model": "kiro-api/claude-opus-4-7-thinking",
+		"input": [
+			{"type":"function_call","call_id":"toolu_a","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"},
+			{"type":"reasoning","encrypted_content":"` + rawSignature + `","summary":[{"type":"summary_text","text":"thinking before b"}]},
+			{"type":"function_call","call_id":"toolu_b","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"}
+		],
+		"tools": []
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("kiro-api/claude-opus-4-7-thinking", body, false)
+	msgs := gjson.GetBytes(out, "messages").Array()
+
+	// Locate the assistant message that carries tool_use toolu_b.
+	bIdx := findToolUseMsgIndexByID(msgs, "toolu_b")
+	if bIdx < 0 {
+		t.Fatalf("no assistant message with tool_use toolu_b: %s", string(out))
+	}
+	asst := msgs[bIdx]
+	blocks := asst.Get("content").Array()
+	// Find positions of the thinking block and the toolu_b tool_use block.
+	thinkPos, bPos := -1, -1
+	for i, b := range blocks {
+		switch b.Get("type").String() {
+		case "thinking", "reasoning":
+			thinkPos = i
+		case "tool_use":
+			if b.Get("id").String() == "toolu_b" {
+				bPos = i
+			}
+		}
+	}
+	if bPos < 0 {
+		t.Fatalf("tool_use toolu_b not found in assistant content: %s", asst.Raw)
+	}
+	if thinkPos < 0 {
+		t.Fatalf("reasoning block was not attached to the assistant message before tool_use(b); it was lost or flushed elsewhere: %s", string(out))
+	}
+	if thinkPos > bPos {
+		t.Fatalf("reasoning must come BEFORE tool_use(b) in the same assistant message; got think@%d use@%d: %s", thinkPos, bPos, asst.Raw)
+	}
+}
+
+// TestConvertOpenAIResponses_ToolResultNotAppendedIntoNonToolUserArray verifies that
+// a tool_result is never appended AFTER non-tool content in a user message. Anthropic/
+// Bedrock require tool_result block(s) to come FIRST in a user turn; the old append
+// path put a tool_result behind existing text blocks (text, text, tool_result),
+// producing an invalid turn. After the fix any user message that contains a
+// tool_result must have it before any text/other block, and role alternation holds.
+func TestConvertOpenAIResponses_ToolResultNotAppendedIntoNonToolUserArray(t *testing.T) {
+	body := []byte(`{
+		"model": "kiro-api/claude-opus-4-7-thinking",
+		"input": [
+			{"type":"function_call","call_id":"toolu_a","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"part1"},{"type":"input_text","text":"part2"}]},
+			{"type":"function_call_output","call_id":"toolu_a","output":"done"}
+		],
+		"tools": []
+	}`)
+	out := ConvertOpenAIResponsesRequestToClaude("kiro-api/claude-opus-4-7-thinking", body, false)
+	msgs := gjson.GetBytes(out, "messages").Array()
+	// Invariant 1: in any user message, no tool_result may appear AFTER a non
+	// tool_result block (tool_result must be first).
+	for _, m := range msgs {
+		if m.Get("role").String() != "user" {
+			continue
+		}
+		c := m.Get("content")
+		if !c.IsArray() {
+			continue
+		}
+		seenNonToolResult := false
+		c.ForEach(func(_, b gjson.Result) bool {
+			if b.Get("type").String() == "tool_result" {
+				if seenNonToolResult {
+					t.Fatalf("tool_result placed AFTER non-tool content (invalid turn): %s", string(out))
+				}
+			} else {
+				seenNonToolResult = true
+			}
+			return true
+		})
+	}
+	// Invariant 2: strict role alternation.
+	lastRole := ""
+	for i, m := range msgs {
+		role := m.Get("role").String()
+		if role == lastRole {
+			t.Fatalf("consecutive same-role at %d (%q): %s", i, role, string(out))
+		}
+		lastRole = role
+	}
+	// Invariant 3: tool_use toolu_a is immediately followed by its tool_result.
+	tuIdx := findToolUseMsgIndexByID(msgs, "toolu_a")
+	if tuIdx < 0 || tuIdx+1 >= len(msgs) || !msgHasToolResult(msgs[tuIdx+1]) {
+		t.Fatalf("tool_use toolu_a not immediately followed by tool_result: %s", string(out))
 	}
 }


### PR DESCRIPTION
## What

When converting OpenAI Responses history to Claude/Anthropic for Bedrock-backed models, parallel `function_call` / `function_call_output` items can land as **consecutive same-role messages** or **interleaved tool_use/tool_result pairs**. Bedrock rejects these with a 400 `TOOL_USE_RESULT_MISMATCH` (tool_use and its tool_result must stay paired and contiguous, with strict role alternation).

This PR adds defensive pairing on the Claude responses-request path:

- **Parallel-merge**: append a `tool_use` / `tool_result` block into the existing last same-role message instead of starting a new consecutive same-role message.
- **Reorder pass** (`reorderClaudeToolUseResultPairs`): move any stray non-tool message out from between a tool_use and its matching tool_result so the pair stays contiguous.
- Idempotent: re-running the reorder on already-correct input is a no-op (covered by tests).

## Test
`go build ./...` clean; `go test ./internal/translator/...` green (0 failed); 5 new pairing tests (Reorder / Idempotent / ParallelBatch / SplitBatch / IdempotentAfterRealReorder).

## Notes
Adds `claude_openai-responses_request_pairing.go` + minimal edits to `claude_openai-responses_request.go`; no unrelated changes. Independent of #3790.