### PR TITLE
feat(config): allow context length for OpenAI-compatible models

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -291,6 +291,7 @@ nonstream-keepalive-interval: 0
 #       - name: "moonshotai/kimi-k2:free" # The actual model name.
 #         alias: "kimi-k2"               # The alias used in the API.
 #         image: false                   # optional: set true to allow this model on /v1/images/generations and /v1/images/edits
+#         context-length: 1000000        # optional: override advertised context window (tokens). 0 = use upstream default
 #         thinking:                      # optional: omit to default to levels ["low","medium","high"]
 #           levels: ["low", "medium", "high"]
 #       # You may repeat the same alias to build an internal model pool.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -681,7 +681,7 @@ type OpenAICompatibilityModel struct {
 	Image bool `yaml:"image,omitempty" json:"image,omitempty"`
 
 	// ContextLength overrides the advertised model context window.
-	ContextLength int `yaml:"context-length,omitempty" json:"context_length,omitempty"`
+	ContextLength int `yaml:"context-length,omitempty" json:"context-length,omitempty"`
 
 	// Thinking configures the thinking/reasoning capability for this model.
 	// If nil, the model defaults to level-based reasoning with levels ["low", "medium", "high"].

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -680,6 +680,9 @@ type OpenAICompatibilityModel struct {
 	// Image marks this model as callable through /v1/images/generations and /v1/images/edits.
 	Image bool `yaml:"image,omitempty" json:"image,omitempty"`
 
+	// ContextLength overrides the advertised model context window.
+	ContextLength int `yaml:"context-length,omitempty" json:"context_length,omitempty"`
+
 	// Thinking configures the thinking/reasoning capability for this model.
 	// If nil, the model defaults to level-based reasoning with levels ["low", "medium", "high"].
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -21,7 +21,7 @@ func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) str
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + fmt.Sprintf("image=%t", model.Image))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + fmt.Sprintf("image=%t|context=%d", model.Image, model.ContextLength))
 		}
 	})
 	return hashJoined(keys)

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -36,6 +36,17 @@ func TestComputeOpenAICompatModelsHash_IncludesImageFlag(t *testing.T) {
 	}
 }
 
+func TestComputeOpenAICompatModelsHash_IncludesContextLength(t *testing.T) {
+	defaultContext := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "deepseek-v4-pro"}})
+	oneMillionContext := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "deepseek-v4-pro", ContextLength: 1000000}})
+	if defaultContext == "" || oneMillionContext == "" {
+		t.Fatal("hashes should not be empty")
+	}
+	if defaultContext == oneMillionContext {
+		t.Fatal("hash should change when context length changes")
+	}
+}
+
 func TestComputeOpenAICompatModelsHash_NormalizesAndDedups(t *testing.T) {
 	a := []config.OpenAICompatibilityModel{
 		{Name: "gpt-4", Alias: "gpt4"},

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -53,7 +53,7 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 
 		if template, ok := templates[id]; ok {
 			entry := cloneCodexClientModelMap(template)
-			applyCodexClientContextWindowOverride(entry, id, model)
+			applyCodexClientContextWindowOverride(entry, model)
 			sanitizeCodexClientReasoningMetadata(entry)
 			applyCodexClientVisibilityOverride(entry, id)
 			result = append(result, entry)
@@ -98,7 +98,7 @@ func loadCodexClientModelTemplates() (map[string]map[string]any, map[string]any,
 	return codexClientModelTemplates, codexClientDefaultTemplate, codexClientModelTemplatesErr
 }
 
-func applyCodexClientContextWindowOverride(entry map[string]any, id string, model map[string]any) {
+func applyCodexClientContextWindowOverride(entry map[string]any, model map[string]any) {
 	contextWindow := intModelValue(model, "context_length")
 	if contextWindow <= 0 {
 		return

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -53,6 +53,7 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 
 		if template, ok := templates[id]; ok {
 			entry := cloneCodexClientModelMap(template)
+			applyCodexClientContextWindowOverride(entry, id, model)
 			sanitizeCodexClientReasoningMetadata(entry)
 			applyCodexClientVisibilityOverride(entry, id)
 			result = append(result, entry)
@@ -95,6 +96,20 @@ func loadCodexClientModelTemplates() (map[string]map[string]any, map[string]any,
 	})
 
 	return codexClientModelTemplates, codexClientDefaultTemplate, codexClientModelTemplatesErr
+}
+
+func applyCodexClientContextWindowOverride(entry map[string]any, id string, model map[string]any) {
+	contextWindow := intModelValue(model, "context_length")
+	if contextWindow <= 0 {
+		if info := registry.LookupModelInfo(id); info != nil {
+			contextWindow = info.ContextLength
+		}
+	}
+	if contextWindow <= 0 {
+		return
+	}
+	entry["context_window"] = contextWindow
+	entry["max_context_window"] = contextWindow
 }
 
 func applyCodexClientModelMetadata(entry map[string]any, id string, model map[string]any) {

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -101,11 +101,6 @@ func loadCodexClientModelTemplates() (map[string]map[string]any, map[string]any,
 func applyCodexClientContextWindowOverride(entry map[string]any, id string, model map[string]any) {
 	contextWindow := intModelValue(model, "context_length")
 	if contextWindow <= 0 {
-		if info := registry.LookupModelInfo(id); info != nil {
-			contextWindow = info.ContextLength
-		}
-	}
-	if contextWindow <= 0 {
 		return
 	}
 	entry["context_window"] = contextWindow
@@ -126,7 +121,7 @@ func applyCodexClientModelMetadata(entry map[string]any, id string, model map[st
 		if info.Description != "" {
 			description = info.Description
 		}
-		if info.ContextLength > 0 {
+		if info.ContextLength > 0 && contextWindow <= 0 {
 			contextWindow = info.ContextLength
 		}
 		if info.Type == registry.OpenAIImageModelType {

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -1,0 +1,25 @@
+package openai
+
+import "testing"
+
+func TestBuildCodexClientModelsAppliesContextLengthToTemplateModel(t *testing.T) {
+	models := buildCodexClientModels([]map[string]any{{
+		"id":             "gpt-5.4",
+		"object":         "model",
+		"owned_by":       "heybox",
+		"context_length": 700000,
+	}})
+
+	if len(models) != 1 {
+		t.Fatalf("models len = %d, want 1", len(models))
+	}
+	if got := intModelValue(models[0], "context_window"); got != 700000 {
+		t.Fatalf("context_window = %d, want 700000", got)
+	}
+	if got := intModelValue(models[0], "max_context_window"); got != 700000 {
+		t.Fatalf("max_context_window = %d, want 700000", got)
+	}
+	if _, ok := models[0]["apply_patch_tool_type"]; !ok {
+		t.Fatal("expected template metadata to be preserved")
+	}
+}

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -23,3 +23,40 @@ func TestBuildCodexClientModelsAppliesContextLengthToTemplateModel(t *testing.T)
 		t.Fatal("expected template metadata to be preserved")
 	}
 }
+
+func TestBuildCodexClientModelsLeavesTemplateContextUnchangedWithoutOverride(t *testing.T) {
+	models := buildCodexClientModels([]map[string]any{{
+		"id":       "gpt-5.4",
+		"object":   "model",
+		"owned_by": "heybox",
+	}})
+
+	if len(models) != 1 {
+		t.Fatalf("models len = %d, want 1", len(models))
+	}
+	if got := intModelValue(models[0], "context_window"); got != 272000 {
+		t.Fatalf("context_window = %d, want template default 272000", got)
+	}
+	if got := intModelValue(models[0], "max_context_window"); got != 1000000 {
+		t.Fatalf("max_context_window = %d, want template default 1000000", got)
+	}
+}
+
+func TestBuildCodexClientModelsPrefersModelContextLengthForCustomModel(t *testing.T) {
+	models := buildCodexClientModels([]map[string]any{{
+		"id":             "gpt-5.4-custom",
+		"object":         "model",
+		"owned_by":       "heybox",
+		"context_length": 700000,
+	}})
+
+	if len(models) != 1 {
+		t.Fatalf("models len = %d, want 1", len(models))
+	}
+	if got := intModelValue(models[0], "context_window"); got != 700000 {
+		t.Fatalf("context_window = %d, want 700000", got)
+	}
+	if got := intModelValue(models[0], "max_context_window"); got != 700000 {
+		t.Fatalf("max_context_window = %d, want 700000", got)
+	}
+}

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -67,31 +67,33 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 	// Get all available models
 	allModels := h.Models()
 
-	// Filter to only include the 4 required fields: id, object, created, owned_by
-	filteredModels := make([]map[string]any, len(allModels))
-	for i, model := range allModels {
+	c.JSON(http.StatusOK, gin.H{
+		"object": "list",
+		"data":   filterOpenAIModelsResponse(allModels),
+	})
+}
+
+func filterOpenAIModelsResponse(models []map[string]any) []map[string]any {
+	filteredModels := make([]map[string]any, len(models))
+	for i, model := range models {
 		filteredModel := map[string]any{
 			"id":     model["id"],
 			"object": model["object"],
 		}
 
-		// Add created field if it exists
 		if created, exists := model["created"]; exists {
 			filteredModel["created"] = created
 		}
-
-		// Add owned_by field if it exists
 		if ownedBy, exists := model["owned_by"]; exists {
 			filteredModel["owned_by"] = ownedBy
+		}
+		if contextLength, exists := model["context_length"]; exists {
+			filteredModel["context_length"] = contextLength
 		}
 
 		filteredModels[i] = filteredModel
 	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"object": "list",
-		"data":   filteredModels,
-	})
+	return filteredModels
 }
 
 // ChatCompletions handles the /v1/chat/completions endpoint.

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -87,7 +87,7 @@ func filterOpenAIModelsResponse(models []map[string]any) []map[string]any {
 		if ownedBy, exists := model["owned_by"]; exists {
 			filteredModel["owned_by"] = ownedBy
 		}
-		if contextLength, exists := model["context_length"]; exists {
+		if contextLength := intModelValue(model, "context_length"); contextLength > 0 {
 			filteredModel["context_length"] = contextLength
 		}
 

--- a/sdk/api/handlers/openai/openai_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_handlers_test.go
@@ -22,3 +22,19 @@ func TestFilterOpenAIModelsResponseIncludesContextLength(t *testing.T) {
 		t.Fatal("expected display_name to remain filtered")
 	}
 }
+
+func TestFilterOpenAIModelsResponseOmitsNonPositiveContextLength(t *testing.T) {
+	models := filterOpenAIModelsResponse([]map[string]any{{
+		"id":             "gpt-5.4",
+		"object":         "model",
+		"owned_by":       "heybox",
+		"context_length": 0,
+	}})
+
+	if len(models) != 1 {
+		t.Fatalf("models len = %d, want 1", len(models))
+	}
+	if _, ok := models[0]["context_length"]; ok {
+		t.Fatal("expected context_length to be omitted when it is not positive")
+	}
+}

--- a/sdk/api/handlers/openai/openai_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_handlers_test.go
@@ -1,0 +1,24 @@
+package openai
+
+import "testing"
+
+func TestFilterOpenAIModelsResponseIncludesContextLength(t *testing.T) {
+	models := filterOpenAIModelsResponse([]map[string]any{{
+		"id":             "gpt-5.4",
+		"object":         "model",
+		"created":        int64(123),
+		"owned_by":       "heybox",
+		"context_length": 700000,
+		"display_name":   "GPT-5.4",
+	}})
+
+	if len(models) != 1 {
+		t.Fatalf("models len = %d, want 1", len(models))
+	}
+	if got := intModelValue(models[0], "context_length"); got != 700000 {
+		t.Fatalf("context_length = %d, want 700000", got)
+	}
+	if _, ok := models[0]["display_name"]; ok {
+		t.Fatal("expected display_name to remain filtered")
+	}
+}

--- a/sdk/cliproxy/openai_compat_models_test.go
+++ b/sdk/cliproxy/openai_compat_models_test.go
@@ -22,3 +22,20 @@ func TestBuildOpenAICompatibilityConfigModelsIncludesContextLength(t *testing.T)
 		t.Fatalf("ContextLength = %d, want 1000000", got)
 	}
 }
+
+func TestBuildOpenAICompatibilityConfigModelsClampsNegativeContextLength(t *testing.T) {
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{{
+			Name:          "bad-context-model",
+			ContextLength: -1,
+		}},
+	})
+
+	if len(models) != 1 {
+		t.Fatalf("models len = %d, want 1", len(models))
+	}
+	if got := models[0].ContextLength; got != 0 {
+		t.Fatalf("ContextLength = %d, want 0", got)
+	}
+}

--- a/sdk/cliproxy/openai_compat_models_test.go
+++ b/sdk/cliproxy/openai_compat_models_test.go
@@ -1,0 +1,24 @@
+package cliproxy
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestBuildOpenAICompatibilityConfigModelsIncludesContextLength(t *testing.T) {
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "heybox-deepseek",
+		Models: []config.OpenAICompatibilityModel{{
+			Name:          "deepseek-v4-pro",
+			ContextLength: 1000000,
+		}},
+	})
+
+	if len(models) != 1 {
+		t.Fatalf("models len = %d, want 1", len(models))
+	}
+	if got := models[0].ContextLength; got != 1000000 {
+		t.Fatalf("ContextLength = %d, want 1000000", got)
+	}
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2196,6 +2196,10 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		if thinking == nil && !model.Image {
 			thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
 		}
+		contextLength := model.ContextLength
+		if contextLength < 0 {
+			contextLength = 0
+		}
 		models = append(models, &ModelInfo{
 			ID:            modelID,
 			Object:        "model",
@@ -2203,7 +2207,7 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 			OwnedBy:       compat.Name,
 			Type:          modelType,
 			DisplayName:   modelID,
-			ContextLength: model.ContextLength,
+			ContextLength: contextLength,
 			UserDefined:   false,
 			Thinking:      thinking,
 		})

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2197,14 +2197,15 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 			thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
 		}
 		models = append(models, &ModelInfo{
-			ID:          modelID,
-			Object:      "model",
-			Created:     now,
-			OwnedBy:     compat.Name,
-			Type:        modelType,
-			DisplayName: modelID,
-			UserDefined: false,
-			Thinking:    thinking,
+			ID:            modelID,
+			Object:        "model",
+			Created:       now,
+			OwnedBy:       compat.Name,
+			Type:          modelType,
+			DisplayName:   modelID,
+			ContextLength: model.ContextLength,
+			UserDefined:   false,
+			Thinking:      thinking,
 		})
 	}
 	return models


### PR DESCRIPTION

## Summary

Add optional `context-length` configuration to `openai-compatibility.models[]`, allowing proxy operators to override the advertised context window for OpenAI-compatible models.

### Motivation

Some large-context models (e.g. DeepSeek V4 Pro, MiniMax-M3 1M, Mimo V2.5 Pro) support up to 1,000,000 tokens of context, but their upstream `/v1/models` endpoint may not advertise this — or a proxy may want to explicitly set it regardless of upstream metadata.

Without this field, Codex and other clients that rely on `/v1/models` to determine model capabilities see an incorrect or default `context_window`, which can cause:
- **Truncation warnings** at thresholds far below the model's actual capacity
- **Unnecessary context compaction** when the model could handle more
- **Misleading model selection** where users avoid models that appear to have smaller windows

### Changes

- `internal/config/config.go`: add `ContextLength int` field to `OpenAICompatibilityModel` with yaml tag `context-length`
- `sdk/cliproxy/service.go`: propagate configured context length into registered model metadata; clamp negative values to 0
- `internal/watcher/diff/model_hash.go`: include context length in model hash so hot reloads detect metadata-only changes
- `sdk/cliproxy/openai_compat_models_test.go`: unit tests for context length propagation and negative value clamping
- `internal/watcher/diff/model_hash_test.go`: unit test for hash sensitivity to context length changes

### Configuration Example

```yaml
openai-compatibility:
  - name: "deepseek"
    base-url: "https://api.deepseek.com/v1"
    api-key-entries:
      - api-key: "sk-..."
    models:
      - name: "deepseek-v4-pro"
        context-length: 1000000  # advertise 1M context window
      - name: "deepseek-chat"
        # omit context-length to use upstream default
```

### Backward Compatibility

`context-length` is optional and defaults to 0 (omitted from JSON output). Existing configurations without this field behave identically to before.

## Test Plan
- `GOWORK=off go test ./internal/watcher/diff ./sdk/cliproxy -run 'TestComputeOpenAICompatModelsHash|TestBuildOpenAICompatibilityConfigModelsIncludesContextLength' -count=1`
- `GOWORK=off go build -o /tmp/cliproxyapi-pr-build ./cmd/server`
