### PR TITLE
fix(translator): pass reasoning_content for DeepSeek/MiMo tool calls

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -133,10 +133,8 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			case "reasoning":
 				// Extract reasoning content to attach to the next assistant message with tool_calls.
 				// Per DeepSeek docs: reasoning_content must be passed back when tool calls occur.
-				if summary := item.Get("summary"); summary.Exists() && summary.IsArray() && summary.Array()[0].Exists() {
-					if summaryText := summary.Array()[0].Get("text"); summaryText.Exists() {
-						pendingReasoningContent = summaryText.String()
-					}
+				if summaryText := item.Get("summary.0.text"); summaryText.Exists() {
+					pendingReasoningContent = summaryText.String()
 				}
 
 			case "message", "":

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -72,6 +72,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 
 		pendingToolCalls := make([]interface{}, 0)
 		pendingToolCallIDs := make([]string, 0)
+		pendingReasoningContent := ""
 		awaitingToolOutputs := make(map[string]struct{})
 		deferredMessages := make([][]byte, 0)
 
@@ -81,6 +82,10 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			}
 			assistantMessage := []byte(`{"role":"assistant","tool_calls":[]}`)
 			assistantMessage, _ = sjson.SetBytes(assistantMessage, "tool_calls", pendingToolCalls)
+			if pendingReasoningContent != "" {
+				assistantMessage, _ = sjson.SetBytes(assistantMessage, "reasoning_content", pendingReasoningContent)
+				pendingReasoningContent = ""
+			}
 			out, _ = sjson.SetRawBytes(out, "messages.-1", assistantMessage)
 			for _, id := range pendingToolCallIDs {
 				if strings.TrimSpace(id) == "" {
@@ -125,6 +130,15 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			}
 
 			switch itemType {
+			case "reasoning":
+				// Extract reasoning content to attach to the next assistant message with tool_calls.
+				// Per DeepSeek docs: reasoning_content must be passed back when tool calls occur.
+				if summary := item.Get("summary"); summary.Exists() && summary.IsArray() && summary.Array()[0].Exists() {
+					if summaryText := summary.Array()[0].Get("text"); summaryText.Exists() {
+						pendingReasoningContent = summaryText.String()
+					}
+				}
+
 			case "message", "":
 				// Handle regular message conversion
 				role := item.Get("role").String()


### PR DESCRIPTION
## Summary

Fixes missing `reasoning_content` field when converting OpenAI Responses API requests to Chat Completions format for DeepSeek and MiMo reasoning models, preventing 400 errors during multi-turn tool-calling conversations.

### Problem

When using DeepSeek or MiMo reasoning models with Codex through the `openai-compatibility` configuration, multi-turn conversations involving tool calls fail with:

```
The reasoning_content in the thinking mode must be passed back to the API.
```

This occurs because the Responses-to-Chat-Completions translator in `internal/translator/openai/openai/responses/openai_openai-responses_request.go` did not handle `reasoning` type input items, causing the reasoning context to be dropped across turns.

### Root Cause

Per [DeepSeek documentation](https://api-docs.deepseek.com/guides/thinking_mode):
> Between two `user` messages, if the model performed a tool call, the intermediate assistant's `reasoning_content` must participate in context concatenation and be passed back to the API in all subsequent user interaction turns.

The translator's `switch itemType` handled `message`, `function_call`, and `function_call_output` cases, but **not `reasoning`**. When Codex sent conversation history containing reasoning items (returned by prior assistant turns), the translator silently skipped them, breaking the required context chain.

### Solution

This PR adds minimal handling for `reasoning` type input items:

1. **Buffer reasoning content**: introduce `pendingReasoningContent` to track extracted reasoning text
2. **Extract summary**: add `case "reasoning"` to parse `summary[0].text` from Responses reasoning items
3. **Inject into tool-call messages**: when flushing pending tool calls into an assistant message, attach the buffered `reasoning_content` field

### Changes

- `internal/translator/openai/openai/responses/openai_openai-responses_request.go`:
  - Add `pendingReasoningContent string` variable (line 75)
  - Inject `reasoning_content` into assistant messages with tool_calls (lines 85-88)
  - Handle `case "reasoning"` to extract summary text (lines 133-140)

### Example Flow

**Before (broken)**:
```json
// Codex sends:
{"input": [
  {"type": "message", "role": "user", "content": [...]},
  {"type": "reasoning", "summary": [{"text": "I need to call tool X"}]},
  {"type": "function_call", "call_id": "123", ...}
]}

// Translator outputs (reasoning lost):
{"messages": [
  {"role": "user", "content": "..."},
  {"role": "assistant", "tool_calls": [...]}
]}
```

**After (fixed)**:
```json
// Translator outputs (reasoning preserved):
{"messages": [
  {"role": "user", "content": "..."},
  {"role": "assistant", "reasoning_content": "I need to call tool X", "tool_calls": [...]}
]}
```

### Backward Compatibility

- Non-reasoning models: `pendingReasoningContent` stays empty, no `reasoning_content` field added (JSON omits empty strings)
- Existing tool-call flows: unchanged behavior when no reasoning items present
- Other translator paths: unaffected (change is isolated to Responses → Chat Completions)

### Related Work

This issue affects multiple projects integrating DeepSeek with Codex-style APIs:
- [yxlao/deepseek-cursor-proxy](https://github.com/yxlao/deepseek-cursor-proxy) — dedicated proxy fixing the same missing field
- [OpenCode Issue #24385](https://github.com/anomalyco/opencode/issues/24385)
- [QwenPaw Issue #3782](https://github.com/agentscope-ai/QwenPaw/issues/3782)

### Testing

- **Syntax**: `gofmt` clean
- **Build**: blocked by network timeout (Go module downloads), but local syntax validation passes
- **Manual test**: recommend verifying with DeepSeek/MiMo model + multi-turn tool calls

### Configuration Example

```yaml
openai-compatibility:
  - name: "deepseek"
    base-url: "https://api.deepseek.com/v1"
    api-key-entries:
      - api-key: "sk-..."
    models:
      - name: "deepseek-reasoner"
        alias: "deepseek-v4-pro"

  - name: "mimo"
    base-url: "https://platform.xiaomimomo.com/v1"
    api-key-entries:
      - api-key: "sk-..."
    models:
      - name: "mimo-v2.5-pro"
```

---

**Checklist**:
- [x] Follows project commit conventions (`fix(translator): ...`)
- [x] Minimal code change (3 additions, 14 total lines changed)
- [x] Preserves existing behavior for non-reasoning flows
- [x] Documented root cause and solution
- [ ] Full build verification (pending network access)