### PR TITLE
feat: expose DeepSeek cache split usage

### DIFF
--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -72,10 +72,14 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		CacheCreationTokens:  record.Detail.CacheCreationTokens,
 		TotalTokens:          record.Detail.TotalTokens,
 	}
+	hasInputCacheStats := tokens.CachedTokens > 0 || tokens.CacheHitInputTokens > 0 || tokens.CacheMissInputTokens > 0
 	if tokens.CacheHitInputTokens == 0 && tokens.CachedTokens > 0 {
 		tokens.CacheHitInputTokens = tokens.CachedTokens
 	}
-	if tokens.CacheMissInputTokens == 0 && tokens.InputTokens > tokens.CacheHitInputTokens {
+	if tokens.InputTokens == 0 && hasInputCacheStats {
+		tokens.InputTokens = tokens.CacheHitInputTokens + tokens.CacheMissInputTokens
+	}
+	if tokens.CacheMissInputTokens == 0 && hasInputCacheStats && tokens.InputTokens > tokens.CacheHitInputTokens {
 		tokens.CacheMissInputTokens = tokens.InputTokens - tokens.CacheHitInputTokens
 	}
 	if tokens.TotalTokens == 0 {

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -62,13 +62,21 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	}
 
 	tokens := tokenStats{
-		InputTokens:         record.Detail.InputTokens,
-		OutputTokens:        record.Detail.OutputTokens,
-		ReasoningTokens:     record.Detail.ReasoningTokens,
-		CachedTokens:        record.Detail.CachedTokens,
-		CacheReadTokens:     record.Detail.CacheReadTokens,
-		CacheCreationTokens: record.Detail.CacheCreationTokens,
-		TotalTokens:         record.Detail.TotalTokens,
+		InputTokens:          record.Detail.InputTokens,
+		OutputTokens:         record.Detail.OutputTokens,
+		ReasoningTokens:      record.Detail.ReasoningTokens,
+		CachedTokens:         record.Detail.CachedTokens,
+		CacheHitInputTokens:  record.Detail.CacheHitInputTokens,
+		CacheMissInputTokens: record.Detail.CacheMissInputTokens,
+		CacheReadTokens:      record.Detail.CacheReadTokens,
+		CacheCreationTokens:  record.Detail.CacheCreationTokens,
+		TotalTokens:          record.Detail.TotalTokens,
+	}
+	if tokens.CacheHitInputTokens == 0 && tokens.CachedTokens > 0 {
+		tokens.CacheHitInputTokens = tokens.CachedTokens
+	}
+	if tokens.CacheMissInputTokens == 0 && tokens.InputTokens > tokens.CacheHitInputTokens {
+		tokens.CacheMissInputTokens = tokens.InputTokens - tokens.CacheHitInputTokens
 	}
 	if tokens.TotalTokens == 0 {
 		tokens.TotalTokens = tokens.InputTokens + tokens.OutputTokens + tokens.ReasoningTokens
@@ -141,13 +149,15 @@ type requestDetail struct {
 }
 
 type tokenStats struct {
-	InputTokens         int64 `json:"input_tokens"`
-	OutputTokens        int64 `json:"output_tokens"`
-	ReasoningTokens     int64 `json:"reasoning_tokens"`
-	CachedTokens        int64 `json:"cached_tokens"`
-	CacheReadTokens     int64 `json:"cache_read_tokens"`
-	CacheCreationTokens int64 `json:"cache_creation_tokens"`
-	TotalTokens         int64 `json:"total_tokens"`
+	InputTokens          int64 `json:"input_tokens"`
+	OutputTokens         int64 `json:"output_tokens"`
+	ReasoningTokens      int64 `json:"reasoning_tokens"`
+	CachedTokens         int64 `json:"cached_tokens"`
+	CacheHitInputTokens  int64 `json:"cache_hit_input_tokens"`
+	CacheMissInputTokens int64 `json:"cache_miss_input_tokens"`
+	CacheReadTokens      int64 `json:"cache_read_tokens"`
+	CacheCreationTokens  int64 `json:"cache_creation_tokens"`
+	TotalTokens          int64 `json:"total_tokens"`
 }
 
 type failDetail struct {

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -61,6 +62,43 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 		requireHeaderField(t, payload, "response_headers", "Retry-After", []string{"30"})
 		requireBoolField(t, payload, "failed", false)
 		requireFailField(t, payload, http.StatusOK, "")
+	})
+}
+
+func TestUsageQueuePluginPayloadIncludesDeepSeekCacheSplit(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := internallogging.WithRequestID(context.Background(), "deepseek-request-id")
+		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
+		ctx = internallogging.WithResponseStatusHolder(ctx)
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		plugin := &usageQueuePlugin{}
+		plugin.HandleUsage(ctx, coreusage.Record{
+			Provider:    "deepseek",
+			Model:       "deepseek-v4-pro",
+			Alias:       "deepseek-reasoner",
+			APIKey:      "test-key",
+			AuthIndex:   "0",
+			AuthType:    "apikey",
+			RequestedAt: time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC),
+			Detail: coreusage.Detail{
+				InputTokens:          1222504,
+				OutputTokens:         12287,
+				ReasoningTokens:      3544,
+				CachedTokens:         1056256,
+				CacheHitInputTokens:  1056256,
+				CacheMissInputTokens: 166248,
+				TotalTokens:          1234791,
+			},
+		})
+
+		payload := popSinglePayload(t)
+		requireIntField(t, payload, "tokens.input_tokens", 1222504)
+		requireIntField(t, payload, "tokens.output_tokens", 12287)
+		requireIntField(t, payload, "tokens.reasoning_tokens", 3544)
+		requireIntField(t, payload, "tokens.cached_tokens", 1056256)
+		requireIntField(t, payload, "tokens.cache_hit_input_tokens", 1056256)
+		requireIntField(t, payload, "tokens.cache_miss_input_tokens", 166248)
 	})
 }
 
@@ -282,6 +320,36 @@ func requireStringField(t *testing.T, payload map[string]json.RawMessage, key, w
 	}
 	if got != want {
 		t.Fatalf("%s = %q, want %q", key, got, want)
+	}
+}
+
+func requireIntField(t *testing.T, payload map[string]json.RawMessage, dottedPath string, want int64) {
+	t.Helper()
+
+	parts := strings.Split(dottedPath, ".")
+	current := payload
+	var raw json.RawMessage
+	for index, part := range parts {
+		value, ok := current[part]
+		if !ok {
+			t.Fatalf("payload missing field %q", dottedPath)
+		}
+		if index == len(parts)-1 {
+			raw = value
+			break
+		}
+		var next map[string]json.RawMessage
+		if err := json.Unmarshal(value, &next); err != nil {
+			t.Fatalf("unmarshal nested field %q: %v", part, err)
+		}
+		current = next
+	}
+	var got int64
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal int field %q: %v", dottedPath, err)
+	}
+	if got != want {
+		t.Fatalf("field %q = %d, want %d", dottedPath, got, want)
 	}
 }
 

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -102,6 +102,62 @@ func TestUsageQueuePluginPayloadIncludesDeepSeekCacheSplit(t *testing.T) {
 	})
 }
 
+func TestUsageQueuePluginPayloadInfersInputFromCachedTokensOnly(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := internallogging.WithRequestID(context.Background(), "cached-only-request-id")
+		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
+		ctx = internallogging.WithResponseStatusHolder(ctx)
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		plugin := &usageQueuePlugin{}
+		plugin.HandleUsage(ctx, coreusage.Record{
+			Provider:    "openai",
+			Model:       "gpt-5.4",
+			APIKey:      "test-key",
+			AuthIndex:   "0",
+			AuthType:    "apikey",
+			RequestedAt: time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC),
+			Detail: coreusage.Detail{
+				CachedTokens: 11,
+			},
+		})
+
+		payload := popSinglePayload(t)
+		requireIntField(t, payload, "tokens.input_tokens", 11)
+		requireIntField(t, payload, "tokens.cached_tokens", 11)
+		requireIntField(t, payload, "tokens.cache_hit_input_tokens", 11)
+		requireIntField(t, payload, "tokens.cache_miss_input_tokens", 0)
+	})
+}
+
+func TestUsageQueuePluginPayloadDoesNotInferCacheMissWithoutCacheFields(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := internallogging.WithRequestID(context.Background(), "plain-usage-request-id")
+		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
+		ctx = internallogging.WithResponseStatusHolder(ctx)
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		plugin := &usageQueuePlugin{}
+		plugin.HandleUsage(ctx, coreusage.Record{
+			Provider:    "openai",
+			Model:       "gpt-5.4",
+			APIKey:      "test-key",
+			AuthIndex:   "0",
+			AuthType:    "apikey",
+			RequestedAt: time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC),
+			Detail: coreusage.Detail{
+				InputTokens:  42,
+				OutputTokens: 7,
+			},
+		})
+
+		payload := popSinglePayload(t)
+		requireIntField(t, payload, "tokens.input_tokens", 42)
+		requireIntField(t, payload, "tokens.cache_hit_input_tokens", 0)
+		requireIntField(t, payload, "tokens.cache_miss_input_tokens", 0)
+	})
+}
+
 func TestUsageQueuePluginAsyncUsesRecordResponseHeaders(t *testing.T) {
 	withEnabledQueue(t, func() {
 		ctx := internallogging.WithRequestID(context.Background(), "ctx-request-id")

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -490,6 +490,8 @@ func hasOpenAIStyleUsageTokenFields(usageNode gjson.Result) bool {
 		usageNode.Get("completion_tokens").Exists() ||
 		usageNode.Get("output_tokens").Exists() ||
 		usageNode.Get("total_tokens").Exists() ||
+		usageNode.Get("prompt_cache_hit_tokens").Exists() ||
+		usageNode.Get("prompt_cache_miss_tokens").Exists() ||
 		usageNode.Get("prompt_tokens_details.cached_tokens").Exists() ||
 		usageNode.Get("input_tokens_details.cached_tokens").Exists() ||
 		usageNode.Get("completion_tokens_details.reasoning_tokens").Exists() ||
@@ -510,12 +512,28 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 		OutputTokens: outputNode.Int(),
 		TotalTokens:  usageNode.Get("total_tokens").Int(),
 	}
+	cacheHit := usageNode.Get("prompt_cache_hit_tokens")
+	cacheMiss := usageNode.Get("prompt_cache_miss_tokens")
+	if cacheHit.Exists() {
+		detail.CacheHitInputTokens = cacheHit.Int()
+		detail.CachedTokens = detail.CacheHitInputTokens
+	}
+	if cacheMiss.Exists() {
+		detail.CacheMissInputTokens = cacheMiss.Int()
+	}
+	if detail.InputTokens == 0 && (detail.CacheHitInputTokens > 0 || detail.CacheMissInputTokens > 0) {
+		detail.InputTokens = detail.CacheHitInputTokens + detail.CacheMissInputTokens
+	}
 	cached := usageNode.Get("prompt_tokens_details.cached_tokens")
 	if !cached.Exists() {
 		cached = usageNode.Get("input_tokens_details.cached_tokens")
 	}
-	if cached.Exists() {
+	if cached.Exists() && detail.CachedTokens == 0 {
 		detail.CachedTokens = cached.Int()
+		detail.CacheHitInputTokens = detail.CachedTokens
+		if detail.InputTokens > detail.CacheHitInputTokens {
+			detail.CacheMissInputTokens = detail.InputTokens - detail.CacheHitInputTokens
+		}
 	}
 	reasoning := usageNode.Get("completion_tokens_details.reasoning_tokens")
 	if !reasoning.Exists() {

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -521,9 +521,6 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	if cacheMiss.Exists() {
 		detail.CacheMissInputTokens = cacheMiss.Int()
 	}
-	if detail.InputTokens == 0 && (detail.CacheHitInputTokens > 0 || detail.CacheMissInputTokens > 0) {
-		detail.InputTokens = detail.CacheHitInputTokens + detail.CacheMissInputTokens
-	}
 	cached := usageNode.Get("prompt_tokens_details.cached_tokens")
 	if !cached.Exists() {
 		cached = usageNode.Get("input_tokens_details.cached_tokens")
@@ -534,6 +531,9 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 		if detail.InputTokens > detail.CacheHitInputTokens {
 			detail.CacheMissInputTokens = detail.InputTokens - detail.CacheHitInputTokens
 		}
+	}
+	if detail.InputTokens == 0 && (detail.CacheHitInputTokens > 0 || detail.CacheMissInputTokens > 0) {
+		detail.InputTokens = detail.CacheHitInputTokens + detail.CacheMissInputTokens
 	}
 	reasoning := usageNode.Get("completion_tokens_details.reasoning_tokens")
 	if !reasoning.Exists() {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -51,6 +51,52 @@ func TestParseOpenAIUsageResponses(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIUsageDeepSeekPromptCacheFields(t *testing.T) {
+	data := []byte(`{"usage":{"prompt_tokens":1222504,"completion_tokens":12287,"total_tokens":1234791,"prompt_cache_hit_tokens":1056256,"prompt_cache_miss_tokens":166248,"completion_tokens_details":{"reasoning_tokens":3544}}}`)
+	detail := ParseOpenAIUsage(data)
+	if detail.InputTokens != 1222504 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 1222504)
+	}
+	if detail.OutputTokens != 12287 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 12287)
+	}
+	if detail.CacheHitInputTokens != 1056256 {
+		t.Fatalf("cache hit input tokens = %d, want %d", detail.CacheHitInputTokens, 1056256)
+	}
+	if detail.CacheMissInputTokens != 166248 {
+		t.Fatalf("cache miss input tokens = %d, want %d", detail.CacheMissInputTokens, 166248)
+	}
+	if detail.CachedTokens != 1056256 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 1056256)
+	}
+	if detail.ReasoningTokens != 3544 {
+		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 3544)
+	}
+	if detail.TotalTokens != 1234791 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 1234791)
+	}
+}
+
+func TestParseOpenAIUsageDeepSeekInfersInputFromCacheSplit(t *testing.T) {
+	data := []byte(`{"usage":{"completion_tokens":7,"prompt_cache_hit_tokens":11,"prompt_cache_miss_tokens":13}}`)
+	detail := ParseOpenAIUsage(data)
+	if detail.InputTokens != 24 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 24)
+	}
+	if detail.OutputTokens != 7 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 7)
+	}
+	if detail.CacheHitInputTokens != 11 {
+		t.Fatalf("cache hit input tokens = %d, want %d", detail.CacheHitInputTokens, 11)
+	}
+	if detail.CacheMissInputTokens != 13 {
+		t.Fatalf("cache miss input tokens = %d, want %d", detail.CacheMissInputTokens, 13)
+	}
+	if detail.CachedTokens != 11 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 11)
+	}
+}
+
 func TestParseOpenAIUsageIgnoresNullUsage(t *testing.T) {
 	data := []byte(`{"usage":null}`)
 	detail := ParseOpenAIUsage(data)

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -97,6 +97,23 @@ func TestParseOpenAIUsageDeepSeekInfersInputFromCacheSplit(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIUsageInfersInputFromCachedTokensDetails(t *testing.T) {
+	data := []byte(`{"usage":{"completion_tokens":7,"prompt_tokens_details":{"cached_tokens":11}}}`)
+	detail := ParseOpenAIUsage(data)
+	if detail.InputTokens != 11 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 11)
+	}
+	if detail.CacheHitInputTokens != 11 {
+		t.Fatalf("cache hit input tokens = %d, want %d", detail.CacheHitInputTokens, 11)
+	}
+	if detail.CacheMissInputTokens != 0 {
+		t.Fatalf("cache miss input tokens = %d, want %d", detail.CacheMissInputTokens, 0)
+	}
+	if detail.CachedTokens != 11 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 11)
+	}
+}
+
 func TestParseOpenAIUsageIgnoresNullUsage(t *testing.T) {
 	data := []byte(`{"usage":null}`)
 	detail := ParseOpenAIUsage(data)

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -47,13 +47,15 @@ type Failure struct {
 
 // Detail holds the token usage breakdown.
 type Detail struct {
-	InputTokens         int64
-	OutputTokens        int64
-	ReasoningTokens     int64
-	CachedTokens        int64
-	CacheReadTokens     int64
-	CacheCreationTokens int64
-	TotalTokens         int64
+	InputTokens          int64
+	OutputTokens         int64
+	ReasoningTokens      int64
+	CachedTokens         int64
+	CacheHitInputTokens  int64
+	CacheMissInputTokens int64
+	CacheReadTokens      int64
+	CacheCreationTokens  int64
+	TotalTokens          int64
 }
 
 type requestedModelAliasContextKey struct{}


### PR DESCRIPTION
## Summary
- Parse DeepSeek/OpenAI-style `prompt_cache_hit_tokens` and `prompt_cache_miss_tokens` into usage detail.
- Add cache hit/miss input token fields to the core usage record and Redis queue payload.
- Cover parser and queue payload behavior with focused tests.

## Test Plan
- go test -run 'TestParseOpenAIUsageDeepSeek|TestParseOpenAIUsage' ./internal/runtime/executor/helps && go test ./internal/redisqueue\n- go build -o test-output ./cmd/server && rm test-output\n- go test ./...\n- git diff --check\n\n## Notes\nThis lets downstream billing systems distinguish cache-hit input, cache-miss input, and output tokens instead of deriving everything from aggregate input/cached totals.