### PR TITLE
fix(translator): normalize Cursor Anthropic tool blocks on OpenAI endpoint

### DIFF
--- a/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
@@ -186,6 +186,48 @@ func TestNormalizeAnthropicRequestBlocks_TypedToolNotWrapped(t *testing.T) {
 	}
 }
 
+func TestConvertOpenAIRequestToClaude_TypedServerToolPreserved(t *testing.T) {
+	// End-to-end guard: a typed Anthropic server tool sent alongside a bare
+	// custom tool must survive the FULL conversion, not just the normalizer.
+	// The downstream tool mapper previously emitted only type=="function"
+	// tools, silently dropping typed server tools like web_search_20250305.
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [{"role": "user", "content": "search the web"}],
+		"tools": [
+			{"type": "web_search_20250305", "name": "web_search", "max_uses": 5},
+			{"name": "read_file", "description": "Read a file", "input_schema": {"type": "object"}}
+		]
+	}`
+
+	out := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	outJSON := gjson.ParseBytes(out)
+	tools := outJSON.Get("tools").Array()
+
+	if len(tools) != 2 {
+		t.Fatalf("Expected 2 tools after full conversion, got %d: %s", len(tools), outJSON.Get("tools").Raw)
+	}
+
+	typed := outJSON.Get(`tools.#(name=="web_search")`)
+	if !typed.Exists() {
+		t.Fatalf("Expected typed server tool web_search to survive conversion, got: %s", outJSON.Get("tools").Raw)
+	}
+	if got := typed.Get("type").String(); got != "web_search_20250305" {
+		t.Fatalf("Expected typed tool type preserved as web_search_20250305, got %q (%s)", got, typed.Raw)
+	}
+	if got := typed.Get("max_uses").Int(); got != 5 {
+		t.Fatalf("Expected typed tool fields preserved (max_uses=5), got %d", got)
+	}
+
+	bare := outJSON.Get(`tools.#(name=="read_file")`)
+	if !bare.Exists() {
+		t.Fatalf("Expected bare custom tool read_file mapped to Claude tool, got: %s", outJSON.Get("tools").Raw)
+	}
+	if !bare.Get("input_schema").Exists() {
+		t.Fatalf("Expected read_file mapped with input_schema, got: %s", bare.Raw)
+	}
+}
+
 func TestConvertOpenAIRequestToClaude_StandardOpenAIUnchanged(t *testing.T) {
 	// A normal OpenAI payload must pass through normalization untouched.
 	inputJSON := `{

--- a/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
@@ -170,6 +170,51 @@ func TestConvertOpenAIRequestToClaude_CursorParallelToolResults(t *testing.T) {
 	}
 }
 
+func TestConvertOpenAIRequestToClaude_CursorToolResultIsError(t *testing.T) {
+	// Cursor forwards failed tool executions as Anthropic tool_result blocks with
+	// is_error:true. That flag must survive the full conversion so Claude sees a
+	// failed result instead of an apparent success.
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "tool_use", "id": "toolu_err", "name": "run", "input": {"cmd": "boom"}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "tool_result", "tool_use_id": "toolu_err", "content": "command failed", "is_error": true}
+				]
+			}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+
+	if len(messages) != 2 {
+		t.Fatalf("Expected 2 messages, got %d: %s", len(messages), resultJSON.Get("messages").Raw)
+	}
+
+	tr := messages[1].Get("content.0")
+	if got := tr.Get("type").String(); got != "tool_result" {
+		t.Fatalf("Expected tool_result block, got %q (%s)", got, messages[1].Raw)
+	}
+	if got := tr.Get("tool_use_id").String(); got != "toolu_err" {
+		t.Fatalf("Expected tool_use_id toolu_err, got %q", got)
+	}
+	if !tr.Get("is_error").Exists() || !tr.Get("is_error").Bool() {
+		t.Fatalf("Expected is_error:true preserved on tool_result, got: %s", tr.Raw)
+	}
+	if got := tr.Get("content").String(); got != "command failed" {
+		t.Fatalf("Expected tool_result content preserved, got %q", got)
+	}
+}
+
 func TestConvertOpenAIRequestToClaude_BareAnthropicTools(t *testing.T) {
 	inputJSON := `{
 		"model": "claude-sonnet-4-5",

--- a/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
@@ -215,6 +215,70 @@ func TestConvertOpenAIRequestToClaude_CursorToolResultIsError(t *testing.T) {
 	}
 }
 
+func TestConvertOpenAIRequestToClaude_CursorToolResultNativeContentArray(t *testing.T) {
+	// Cursor can forward a tool_result whose content is an array of Claude-native
+	// blocks (e.g. an image with source, or a tool_reference). These must survive
+	// verbatim instead of being dropped/stringified by the OpenAI part converter.
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "tool_use", "id": "toolu_img", "name": "screenshot", "input": {}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "tool_result",
+						"tool_use_id": "toolu_img",
+						"content": [
+							{"type": "text", "text": "here is the capture"},
+							{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBORw0KGgo="}}
+						]
+					}
+				]
+			}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+
+	if len(messages) != 2 {
+		t.Fatalf("Expected 2 messages, got %d: %s", len(messages), resultJSON.Get("messages").Raw)
+	}
+
+	tr := messages[1].Get("content.0")
+	if got := tr.Get("type").String(); got != "tool_result" {
+		t.Fatalf("Expected tool_result block, got %q (%s)", got, messages[1].Raw)
+	}
+	blocks := tr.Get("content").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("Expected 2 native content blocks preserved, got %d: %s", len(blocks), tr.Raw)
+	}
+	if got := blocks[0].Get("text").String(); got != "here is the capture" {
+		t.Fatalf("Expected text block preserved, got %q", got)
+	}
+	img := blocks[1]
+	if got := img.Get("type").String(); got != "image" {
+		t.Fatalf("Expected native image block preserved, got %q (%s)", got, img.Raw)
+	}
+	if got := img.Get("source.media_type").String(); got != "image/png" {
+		t.Fatalf("Expected image source media_type preserved, got %q (%s)", got, img.Raw)
+	}
+	if got := img.Get("source.data").String(); got != "iVBORw0KGgo=" {
+		t.Fatalf("Expected image source data preserved, got %q", got)
+	}
+	// The internal marker must not leak into the final Claude payload.
+	if messages[1].Get("_anthropic_native_content").Exists() {
+		t.Fatalf("Internal marker _anthropic_native_content leaked into output: %s", messages[1].Raw)
+	}
+}
+
 func TestConvertOpenAIRequestToClaude_BareAnthropicTools(t *testing.T) {
 	inputJSON := `{
 		"model": "claude-sonnet-4-5",

--- a/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
@@ -466,6 +466,36 @@ func TestConvertOpenAIRequestToClaude_TypedServerToolPreserved(t *testing.T) {
 	}
 }
 
+func TestConvertOpenAIRequestToClaude_UnversionedBuiltinToolDropped(t *testing.T) {
+	// An unversioned OpenAI built-in tool type (e.g. {"type":"web_search"}) is NOT
+	// a Claude-native server tool. Forwarding it verbatim would make Claude reject
+	// the request with a 400, so it must be dropped (as before this change), while
+	// a sibling function tool is still mapped normally.
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [{"role": "user", "content": "search"}],
+		"tools": [
+			{"type": "web_search"},
+			{"type": "function", "function": {"name": "read_file", "description": "d", "parameters": {"type": "object"}}}
+		]
+	}`
+
+	out := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	outJSON := gjson.ParseBytes(out)
+	tools := outJSON.Get("tools").Array()
+
+	if len(tools) != 1 {
+		t.Fatalf("Expected only the function tool to survive (unversioned built-in dropped), got %d: %s", len(tools), outJSON.Get("tools").Raw)
+	}
+	if got := tools[0].Get("name").String(); got != "read_file" {
+		t.Fatalf("Expected surviving tool read_file, got %q (%s)", got, tools[0].Raw)
+	}
+	// The unversioned built-in must not be present.
+	if outJSON.Get(`tools.#(type=="web_search")`).Exists() {
+		t.Fatalf("Unversioned web_search built-in should have been dropped: %s", outJSON.Get("tools").Raw)
+	}
+}
+
 func TestConvertOpenAIRequestToClaude_StandardOpenAIUnchanged(t *testing.T) {
 	// A normal OpenAI payload must pass through normalization untouched.
 	inputJSON := `{

--- a/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
@@ -139,6 +139,53 @@ func TestConvertOpenAIRequestToClaude_BareAnthropicTools(t *testing.T) {
 	}
 }
 
+func TestNormalizeAnthropicRequestBlocks_TypedToolNotWrapped(t *testing.T) {
+	// Typed Anthropic server tools (type present, not "function") must NOT be
+	// rewritten into OpenAI function tools by the normalizer; only bare tools
+	// (no "type") are wrapped. This guards against corrupting server tools like
+	// web_search_20250305 into a wrong custom tool with no schema.
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [{"role": "user", "content": "search"}],
+		"tools": [
+			{"type": "web_search_20250305", "name": "web_search", "max_uses": 5},
+			{"name": "read_file", "description": "Read a file", "input_schema": {"type": "object"}}
+		]
+	}`
+
+	normalized := normalizeAnthropicRequestBlocks([]byte(inputJSON))
+	normJSON := gjson.ParseBytes(normalized)
+	tools := normJSON.Get("tools").Array()
+
+	if len(tools) != 2 {
+		t.Fatalf("Expected 2 tools after normalize, got %d: %s", len(tools), normJSON.Get("tools").Raw)
+	}
+
+	// Typed server tool kept verbatim (still its original type, not "function").
+	typed := normJSON.Get(`tools.#(name=="web_search")`)
+	if !typed.Exists() {
+		t.Fatalf("Expected web_search tool preserved, got: %s", normJSON.Get("tools").Raw)
+	}
+	if got := typed.Get("type").String(); got != "web_search_20250305" {
+		t.Fatalf("Expected typed tool type preserved as web_search_20250305, got %q (%s)", got, typed.Raw)
+	}
+	if got := typed.Get("max_uses").Int(); got != 5 {
+		t.Fatalf("Expected typed tool fields preserved (max_uses=5), got %d", got)
+	}
+
+	// Bare tool wrapped into OpenAI function shape.
+	bare := normJSON.Get(`tools.#(function.name=="read_file")`)
+	if !bare.Exists() {
+		t.Fatalf("Expected read_file wrapped into function tool, got: %s", normJSON.Get("tools").Raw)
+	}
+	if got := bare.Get("type").String(); got != "function" {
+		t.Fatalf("Expected wrapped tool type function, got %q", got)
+	}
+	if !bare.Get("function.parameters").Exists() {
+		t.Fatalf("Expected wrapped tool parameters, got: %s", bare.Raw)
+	}
+}
+
 func TestConvertOpenAIRequestToClaude_StandardOpenAIUnchanged(t *testing.T) {
 	// A normal OpenAI payload must pass through normalization untouched.
 	inputJSON := `{

--- a/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
@@ -279,6 +279,72 @@ func TestConvertOpenAIRequestToClaude_CursorToolResultNativeContentArray(t *test
 	}
 }
 
+func TestConvertOpenAIRequestToClaude_CursorThinkingBlocksPreserved(t *testing.T) {
+	// Extended-thinking models send thinking / redacted_thinking blocks before
+	// the tool_use in the assistant turn. Anthropic requires these to be returned
+	// unchanged on subsequent tool-result requests, so they must survive and lead
+	// the Claude assistant content.
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [
+			{"role": "user", "content": "compute"},
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "thinking", "thinking": "let me reason", "signature": "sig-abc"},
+					{"type": "redacted_thinking", "data": "encrypted-xyz"},
+					{"type": "text", "text": "Calling tool"},
+					{"type": "tool_use", "id": "toolu_t", "name": "calc", "input": {"x": 1}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "tool_result", "tool_use_id": "toolu_t", "content": "2"}
+				]
+			}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+
+	if len(messages) != 3 {
+		t.Fatalf("Expected 3 messages, got %d: %s", len(messages), resultJSON.Get("messages").Raw)
+	}
+
+	asst := messages[1]
+	blocks := asst.Get("content").Array()
+	if len(blocks) < 3 {
+		t.Fatalf("Expected thinking + text + tool_use in assistant content, got %d: %s", len(blocks), asst.Raw)
+	}
+	// thinking blocks must lead, unchanged.
+	if got := blocks[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("Expected first block thinking, got %q (%s)", got, asst.Raw)
+	}
+	if got := blocks[0].Get("signature").String(); got != "sig-abc" {
+		t.Fatalf("Expected thinking signature preserved, got %q", got)
+	}
+	if got := blocks[0].Get("thinking").String(); got != "let me reason" {
+		t.Fatalf("Expected thinking text preserved, got %q", got)
+	}
+	if got := blocks[1].Get("type").String(); got != "redacted_thinking" {
+		t.Fatalf("Expected second block redacted_thinking, got %q (%s)", got, asst.Raw)
+	}
+	if got := blocks[1].Get("data").String(); got != "encrypted-xyz" {
+		t.Fatalf("Expected redacted_thinking data preserved, got %q", got)
+	}
+	// tool_use must still be present.
+	if !asst.Get("content.#(type==tool_use)").Exists() {
+		t.Fatalf("Expected tool_use preserved in assistant content: %s", asst.Raw)
+	}
+	// Internal marker must not leak.
+	if asst.Get("_anthropic_thinking").Exists() {
+		t.Fatalf("Internal marker _anthropic_thinking leaked into output: %s", asst.Raw)
+	}
+}
+
 func TestConvertOpenAIRequestToClaude_BareAnthropicTools(t *testing.T) {
 	inputJSON := `{
 		"model": "claude-sonnet-4-5",

--- a/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
@@ -548,6 +548,35 @@ func TestConvertOpenAIRequestToClaude_UnversionedBuiltinToolDropped(t *testing.T
 	}
 }
 
+func TestConvertOpenAIRequestToClaude_AnthropicToolChoicePreserved(t *testing.T) {
+	// Cursor sends bare Anthropic tools together with a native forced tool_choice
+	// {"type":"tool","name":...}. The mapper previously only handled OpenAI's
+	// {"type":"function",...} form, so the forced selection was dropped. It must
+	// be preserved as Claude's {"type":"tool","name":...} shape.
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [{"role": "user", "content": "read it"}],
+		"tools": [
+			{"name": "read_file", "description": "Read a file", "input_schema": {"type": "object"}}
+		],
+		"tool_choice": {"type": "tool", "name": "read_file"}
+	}`
+
+	out := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	outJSON := gjson.ParseBytes(out)
+
+	tc := outJSON.Get("tool_choice")
+	if !tc.Exists() {
+		t.Fatalf("Expected tool_choice preserved, got none: %s", out)
+	}
+	if got := tc.Get("type").String(); got != "tool" {
+		t.Fatalf("Expected tool_choice type tool, got %q (%s)", got, tc.Raw)
+	}
+	if got := tc.Get("name").String(); got != "read_file" {
+		t.Fatalf("Expected forced tool_choice name read_file, got %q (%s)", got, tc.Raw)
+	}
+}
+
 func TestConvertOpenAIRequestToClaude_StandardOpenAIUnchanged(t *testing.T) {
 	// A normal OpenAI payload must pass through normalization untouched.
 	inputJSON := `{

--- a/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
@@ -1,0 +1,180 @@
+package chat_completions
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// Cursor agent mode sends Anthropic-native tool_use / tool_result blocks and
+// bare tool definitions to the OpenAI Chat Completions endpoint. These tests
+// verify normalizeAnthropicRequestBlocks rewrites them into standard OpenAI
+// shapes so the existing translation produces a valid Claude request.
+
+func TestConvertOpenAIRequestToClaude_CursorToolResultBlock(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [
+			{"role": "user", "content": "list files"},
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "text", "text": "Let me check."},
+					{"type": "tool_use", "id": "toolu_1", "name": "list_dir", "input": {"path": "."}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "tool_result", "tool_use_id": "toolu_1", "content": "a.txt\nb.txt"}
+				]
+			}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+
+	if len(messages) != 3 {
+		t.Fatalf("Expected 3 messages, got %d. Messages: %s", len(messages), resultJSON.Get("messages").Raw)
+	}
+
+	// assistant message must carry a tool_use block
+	asst := messages[1]
+	if got := asst.Get("role").String(); got != "assistant" {
+		t.Fatalf("Expected messages[1].role assistant, got %q", got)
+	}
+	toolUse := asst.Get("content.#(type==tool_use)")
+	if !toolUse.Exists() {
+		t.Fatalf("Expected a tool_use block in assistant message, got: %s", asst.Raw)
+	}
+	if got := toolUse.Get("id").String(); got != "toolu_1" {
+		t.Fatalf("Expected tool_use id toolu_1, got %q", got)
+	}
+	if got := toolUse.Get("name").String(); got != "list_dir" {
+		t.Fatalf("Expected tool_use name list_dir, got %q", got)
+	}
+	if got := toolUse.Get("input.path").String(); got != "." {
+		t.Fatalf("Expected tool_use input.path '.', got %q", got)
+	}
+
+	// the tool_result must become a user message with a tool_result block
+	toolResultMsg := messages[2]
+	if got := toolResultMsg.Get("role").String(); got != "user" {
+		t.Fatalf("Expected messages[2].role user, got %q", got)
+	}
+	tr := toolResultMsg.Get("content.0")
+	if got := tr.Get("type").String(); got != "tool_result" {
+		t.Fatalf("Expected tool_result block, got %q (%s)", got, toolResultMsg.Raw)
+	}
+	if got := tr.Get("tool_use_id").String(); got != "toolu_1" {
+		t.Fatalf("Expected tool_use_id toolu_1, got %q", got)
+	}
+	if got := tr.Get("content").String(); got != "a.txt\nb.txt" {
+		t.Fatalf("Expected tool_result content, got %q", got)
+	}
+}
+
+func TestConvertOpenAIRequestToClaude_CursorToolResultWithText(t *testing.T) {
+	// A user turn that mixes a tool_result with a follow-up text instruction.
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [
+			{
+				"role": "user",
+				"content": [
+					{"type": "tool_result", "tool_use_id": "toolu_9", "content": "done"},
+					{"type": "text", "text": "now summarize"}
+				]
+			}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+
+	if len(messages) != 2 {
+		t.Fatalf("Expected 2 messages (tool_result + user text), got %d: %s", len(messages), resultJSON.Get("messages").Raw)
+	}
+
+	if got := messages[0].Get("content.0.type").String(); got != "tool_result" {
+		t.Fatalf("Expected first message tool_result, got %q", got)
+	}
+	if got := messages[1].Get("content.0.text").String(); got != "now summarize" {
+		t.Fatalf("Expected trailing user text 'now summarize', got %q", got)
+	}
+}
+
+func TestConvertOpenAIRequestToClaude_BareAnthropicTools(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": [
+			{
+				"name": "read_file",
+				"description": "Read a file",
+				"input_schema": {"type": "object", "properties": {"path": {"type": "string"}}}
+			}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	tools := resultJSON.Get("tools").Array()
+
+	if len(tools) != 1 {
+		t.Fatalf("Expected 1 tool, got %d: %s", len(tools), resultJSON.Get("tools").Raw)
+	}
+	tool := tools[0]
+	if got := tool.Get("name").String(); got != "read_file" {
+		t.Fatalf("Expected tool name read_file, got %q", got)
+	}
+	if got := tool.Get("description").String(); got != "Read a file" {
+		t.Fatalf("Expected tool description, got %q", got)
+	}
+	if got := tool.Get("input_schema.properties.path.type").String(); got != "string" {
+		t.Fatalf("Expected input_schema preserved, got: %s", tool.Raw)
+	}
+}
+
+func TestConvertOpenAIRequestToClaude_StandardOpenAIUnchanged(t *testing.T) {
+	// A normal OpenAI payload must pass through normalization untouched.
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": "",
+				"tool_calls": [
+					{"id": "call_1", "type": "function", "function": {"name": "do_work", "arguments": "{\"a\":1}"}}
+				]
+			},
+			{"role": "tool", "tool_call_id": "call_1", "content": "ok"}
+		],
+		"tools": [
+			{"type": "function", "function": {"name": "do_work", "description": "d", "parameters": {"type": "object"}}}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+
+	if len(messages) != 2 {
+		t.Fatalf("Expected 2 messages, got %d: %s", len(messages), resultJSON.Get("messages").Raw)
+	}
+	if got := messages[0].Get("content.0.type").String(); got != "tool_use" {
+		t.Fatalf("Expected assistant tool_use, got %q", got)
+	}
+	if got := messages[0].Get("content.0.id").String(); got != "call_1" {
+		t.Fatalf("Expected tool_use id call_1, got %q", got)
+	}
+	if got := messages[1].Get("content.0.type").String(); got != "tool_result" {
+		t.Fatalf("Expected tool_result, got %q", got)
+	}
+	if got := resultJSON.Get("tools.0.name").String(); got != "do_work" {
+		t.Fatalf("Expected tool do_work, got %q", got)
+	}
+}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
@@ -107,6 +107,69 @@ func TestConvertOpenAIRequestToClaude_CursorToolResultWithText(t *testing.T) {
 	}
 }
 
+func TestConvertOpenAIRequestToClaude_CursorParallelToolResults(t *testing.T) {
+	// Cursor agent mode runs parallel tool calls: one assistant turn with
+	// multiple tool_use blocks, answered by a single user turn carrying multiple
+	// tool_result blocks. Claude requires all tool_result blocks for the prior
+	// assistant tool_use turn to be grouped in ONE user message; splitting them
+	// into separate user turns breaks the tool_use/tool_result pairing.
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [
+			{"role": "user", "content": "inspect both files"},
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "tool_use", "id": "toolu_a", "name": "read_file", "input": {"path": "a.txt"}},
+					{"type": "tool_use", "id": "toolu_b", "name": "read_file", "input": {"path": "b.txt"}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "tool_result", "tool_use_id": "toolu_a", "content": "alpha"},
+					{"type": "tool_result", "tool_use_id": "toolu_b", "content": "beta"}
+				]
+			}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+
+	// user, assistant(2 tool_use), user(2 tool_result grouped) -> 3 messages
+	if len(messages) != 3 {
+		t.Fatalf("Expected 3 messages (parallel results grouped), got %d: %s", len(messages), resultJSON.Get("messages").Raw)
+	}
+
+	asst := messages[1]
+	if got := len(asst.Get("content").Array()); got != 2 {
+		t.Fatalf("Expected 2 tool_use blocks in assistant turn, got %d: %s", got, asst.Raw)
+	}
+
+	toolTurn := messages[2]
+	if got := toolTurn.Get("role").String(); got != "user" {
+		t.Fatalf("Expected grouped tool_result turn role user, got %q", got)
+	}
+	blocks := toolTurn.Get("content").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("Expected 2 tool_result blocks grouped in one user turn, got %d: %s", len(blocks), toolTurn.Raw)
+	}
+	if got := blocks[0].Get("tool_use_id").String(); got != "toolu_a" {
+		t.Fatalf("Expected first tool_result tool_use_id toolu_a, got %q", got)
+	}
+	if got := blocks[0].Get("content").String(); got != "alpha" {
+		t.Fatalf("Expected first tool_result content alpha, got %q", got)
+	}
+	if got := blocks[1].Get("tool_use_id").String(); got != "toolu_b" {
+		t.Fatalf("Expected second tool_result tool_use_id toolu_b, got %q", got)
+	}
+	if got := blocks[1].Get("content").String(); got != "beta" {
+		t.Fatalf("Expected second tool_result content beta, got %q", got)
+	}
+}
+
 func TestConvertOpenAIRequestToClaude_BareAnthropicTools(t *testing.T) {
 	inputJSON := `{
 		"model": "claude-sonnet-4-5",

--- a/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_normalize_test.go
@@ -345,6 +345,58 @@ func TestConvertOpenAIRequestToClaude_CursorThinkingBlocksPreserved(t *testing.T
 	}
 }
 
+func TestConvertOpenAIRequestToClaude_CursorServerToolHistoryPreserved(t *testing.T) {
+	// After a server tool (e.g. web_search_20250305) runs, Claude returns
+	// server_tool_use and web_search_tool_result blocks in the assistant turn.
+	// On the next request these must survive instead of being stripped to text.
+	inputJSON := `{
+		"model": "claude-sonnet-4-5",
+		"messages": [
+			{"role": "user", "content": "search the web"},
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "text", "text": "Searching"},
+					{"type": "server_tool_use", "id": "srv_1", "name": "web_search", "input": {"query": "golang"}},
+					{"type": "web_search_tool_result", "tool_use_id": "srv_1", "content": [{"type": "web_search_result", "title": "Go", "url": "https://go.dev"}]}
+				]
+			},
+			{"role": "user", "content": "thanks"}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+
+	if len(messages) != 3 {
+		t.Fatalf("Expected 3 messages, got %d: %s", len(messages), resultJSON.Get("messages").Raw)
+	}
+
+	asst := messages[1]
+	stu := asst.Get(`content.#(type=="server_tool_use")`)
+	if !stu.Exists() {
+		t.Fatalf("Expected server_tool_use preserved in assistant content: %s", asst.Raw)
+	}
+	if got := stu.Get("name").String(); got != "web_search" {
+		t.Fatalf("Expected server_tool_use name web_search, got %q", got)
+	}
+	wstr := asst.Get(`content.#(type=="web_search_tool_result")`)
+	if !wstr.Exists() {
+		t.Fatalf("Expected web_search_tool_result preserved in assistant content: %s", asst.Raw)
+	}
+	if got := wstr.Get("tool_use_id").String(); got != "srv_1" {
+		t.Fatalf("Expected web_search_tool_result tool_use_id srv_1, got %q", got)
+	}
+	if got := wstr.Get("content.0.title").String(); got != "Go" {
+		t.Fatalf("Expected nested web_search_result preserved, got %q (%s)", got, wstr.Raw)
+	}
+	// Internal marker must not leak.
+	if asst.Get("_anthropic_server_tools").Exists() {
+		t.Fatalf("Internal marker _anthropic_server_tools leaked into output: %s", asst.Raw)
+	}
+}
+
 func TestConvertOpenAIRequestToClaude_BareAnthropicTools(t *testing.T) {
 	inputJSON := `{
 		"model": "claude-sonnet-4-5",

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -343,10 +344,12 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 
 				out, _ = sjson.SetRawBytes(out, "tools.-1", anthropicTool)
 				hasAnthropicTools = true
-			} else if t := tool.Get("type").String(); t != "" {
+			} else if t := tool.Get("type").String(); isClaudeNativeServerToolType(t) {
 				// Typed Anthropic server tools (e.g. {"type":"web_search_20250305",...})
 				// are already in Claude's native shape. Pass them through unchanged
-				// instead of dropping them, so they survive the full conversion.
+				// so they survive the full conversion. Unversioned OpenAI built-ins
+				// (e.g. {"type":"web_search"}) are NOT Claude-native and would cause
+				// an upstream 400, so they are left to be dropped as before.
 				out, _ = sjson.SetRawBytes(out, "tools.-1", []byte(tool.Raw))
 				hasAnthropicTools = true
 			}
@@ -622,6 +625,18 @@ func messageHasAnthropicBlocks(content gjson.Result) bool {
 		return true
 	})
 	return found
+}
+
+// claudeNativeServerToolTypeRe matches Anthropic's versioned server-tool type
+// names, e.g. web_search_20250305, code_execution_20250522, computer_20250124.
+var claudeNativeServerToolTypeRe = regexp.MustCompile(`_\d{8}$`)
+
+// isClaudeNativeServerToolType reports whether a tool "type" is an Anthropic
+// native server tool (versioned, e.g. web_search_20250305). Unversioned OpenAI
+// built-in types (e.g. "web_search") are not Claude-native and must not be
+// forwarded verbatim, or Claude rejects the request with a 400.
+func isClaudeNativeServerToolType(t string) bool {
+	return t != "" && t != "function" && claudeNativeServerToolTypeRe.MatchString(t)
 }
 
 // toolResultContentIsAnthropicNative reports whether a tool_result content array

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -298,6 +298,12 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 
 				out, _ = sjson.SetRawBytes(out, "tools.-1", anthropicTool)
 				hasAnthropicTools = true
+			} else if t := tool.Get("type").String(); t != "" {
+				// Typed Anthropic server tools (e.g. {"type":"web_search_20250305",...})
+				// are already in Claude's native shape. Pass them through unchanged
+				// instead of dropping them, so they survive the full conversion.
+				out, _ = sjson.SetRawBytes(out, "tools.-1", []byte(tool.Raw))
+				hasAnthropicTools = true
 			}
 			return true
 		})

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -388,11 +388,28 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 			}
 		case gjson.JSON:
 			// Specific tool choice mapping
-			if toolChoice.Get("type").String() == "function" {
+			switch toolChoice.Get("type").String() {
+			case "function":
+				// OpenAI object form: {"type":"function","function":{"name":...}}
 				functionName := toolChoice.Get("function.name").String()
 				toolChoiceJSON := []byte(`{"type":"tool","name":""}`)
 				toolChoiceJSON, _ = sjson.SetBytes(toolChoiceJSON, "name", functionName)
 				out, _ = sjson.SetRawBytes(out, "tool_choice", toolChoiceJSON)
+			case "tool":
+				// Anthropic-native forced choice {"type":"tool","name":...} (sent
+				// by Cursor alongside bare tools) is already Claude's shape; keep
+				// it so the forced tool selection is not silently dropped.
+				if name := toolChoice.Get("name").String(); name != "" {
+					toolChoiceJSON := []byte(`{"type":"tool","name":""}`)
+					toolChoiceJSON, _ = sjson.SetBytes(toolChoiceJSON, "name", name)
+					out, _ = sjson.SetRawBytes(out, "tool_choice", toolChoiceJSON)
+				}
+			case "auto":
+				out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"auto"}`))
+			case "any":
+				out, _ = sjson.SetRawBytes(out, "tool_choice", []byte(`{"type":"any"}`))
+			case "none":
+				// Don't set tool_choice; Claude will not use tools.
 			}
 		default:
 		}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -223,6 +223,18 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 					})
 				}
 
+				// Server-tool history blocks (server_tool_use, *_tool_result) are
+				// already Claude-native; re-emit them verbatim so prior server-tool
+				// context survives into the next turn.
+				if role == "assistant" {
+					if serverTools := message.Get("_anthropic_server_tools"); serverTools.Exists() && serverTools.IsArray() {
+						serverTools.ForEach(func(_, block gjson.Result) bool {
+							msg, _ = sjson.SetRawBytes(msg, "content.-1", []byte(block.Raw))
+							return true
+						})
+					}
+				}
+
 				// Handle tool calls (for assistant messages)
 				if toolCalls := message.Get("tool_calls"); toolCalls.Exists() && toolCalls.IsArray() && role == "assistant" {
 					toolCalls.ForEach(func(_, toolCall gjson.Result) bool {
@@ -486,8 +498,10 @@ func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
 				textParts := make([]string, 0)
 				toolUses := make([]gjson.Result, 0)
 				thinkingBlocks := make([]gjson.Result, 0)
+				serverToolBlocks := make([]gjson.Result, 0)
 				content.ForEach(func(_, block gjson.Result) bool {
-					switch block.Get("type").String() {
+					blockType := block.Get("type").String()
+					switch blockType {
 					case "tool_use":
 						toolUses = append(toolUses, block)
 					case "text":
@@ -496,6 +510,15 @@ func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
 						}
 					case "thinking", "redacted_thinking":
 						thinkingBlocks = append(thinkingBlocks, block)
+					case "server_tool_use":
+						serverToolBlocks = append(serverToolBlocks, block)
+					default:
+						// Server-tool result history (e.g. web_search_tool_result)
+						// is already Claude-native and would be dropped by the
+						// OpenAI content converter, so carry it through verbatim.
+						if strings.HasSuffix(blockType, "_tool_result") {
+							serverToolBlocks = append(serverToolBlocks, block)
+						}
 					}
 					return true
 				})
@@ -510,6 +533,15 @@ func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
 					asstMsg, _ = sjson.SetRaw(asstMsg, "_anthropic_thinking", "[]")
 					for _, tb := range thinkingBlocks {
 						asstMsg, _ = sjson.SetRaw(asstMsg, "_anthropic_thinking.-1", tb.Raw)
+					}
+				}
+				// Carry server-tool history blocks (server_tool_use and
+				// *_tool_result) through verbatim so a follow-up turn that includes
+				// prior server-tool context is not stripped to text only.
+				if len(serverToolBlocks) > 0 {
+					asstMsg, _ = sjson.SetRaw(asstMsg, "_anthropic_server_tools", "[]")
+					for _, sb := range serverToolBlocks {
+						asstMsg, _ = sjson.SetRaw(asstMsg, "_anthropic_server_tools.-1", sb.Raw)
 					}
 				}
 				if len(toolUses) > 0 {
@@ -610,21 +642,35 @@ func anthropicBlocksPresent(root gjson.Result) bool {
 }
 
 // messageHasAnthropicBlocks reports whether a message content array contains
-// tool_use or tool_result blocks.
+// Anthropic-native blocks that require normalization: tool_use / tool_result,
+// or server-tool history blocks (server_tool_use, *_tool_result such as
+// web_search_tool_result) that the OpenAI content converter would otherwise
+// drop.
 func messageHasAnthropicBlocks(content gjson.Result) bool {
 	if !content.IsArray() {
 		return false
 	}
 	found := false
 	content.ForEach(func(_, block gjson.Result) bool {
-		switch block.Get("type").String() {
-		case "tool_use", "tool_result":
+		if isAnthropicNativeBlockType(block.Get("type").String()) {
 			found = true
 			return false
 		}
 		return true
 	})
 	return found
+}
+
+// isAnthropicNativeBlockType reports whether a content block type is an
+// Anthropic-native shape that the OpenAI content-part converter cannot map and
+// would silently drop (tool_use / tool_result, server_tool_use, and server-tool
+// result blocks like web_search_tool_result).
+func isAnthropicNativeBlockType(t string) bool {
+	switch t {
+	case "tool_use", "tool_result", "server_tool_use":
+		return true
+	}
+	return strings.HasSuffix(t, "_tool_result")
 }
 
 // claudeNativeServerToolTypeRe matches Anthropic's versioned server-tool type

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -195,6 +195,18 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 				msg := []byte(`{"role":"","content":[]}`)
 				msg, _ = sjson.SetBytes(msg, "role", role)
 
+				// Signed thinking / redacted_thinking blocks must lead the Claude
+				// assistant content, unchanged, so extended-thinking tool histories
+				// stay valid. They are carried verbatim from normalization.
+				if role == "assistant" {
+					if thinking := message.Get("_anthropic_thinking"); thinking.Exists() && thinking.IsArray() {
+						thinking.ForEach(func(_, block gjson.Result) bool {
+							msg, _ = sjson.SetRawBytes(msg, "content.-1", []byte(block.Raw))
+							return true
+						})
+					}
+				}
+
 				// Handle content based on its type (string or array)
 				if contentResult.Exists() && contentResult.Type == gjson.String && contentResult.String() != "" {
 					part := []byte(`{"type":"text","text":""}`)
@@ -470,6 +482,7 @@ func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
 			case "assistant":
 				textParts := make([]string, 0)
 				toolUses := make([]gjson.Result, 0)
+				thinkingBlocks := make([]gjson.Result, 0)
 				content.ForEach(func(_, block gjson.Result) bool {
 					switch block.Get("type").String() {
 					case "tool_use":
@@ -478,12 +491,24 @@ func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
 						if t := block.Get("text").String(); t != "" {
 							textParts = append(textParts, t)
 						}
+					case "thinking", "redacted_thinking":
+						thinkingBlocks = append(thinkingBlocks, block)
 					}
 					return true
 				})
 
 				asstMsg := `{"role":"assistant","content":""}`
 				asstMsg, _ = sjson.Set(asstMsg, "content", strings.Join(textParts, ""))
+				// Carry signed thinking / redacted_thinking blocks through so the
+				// downstream Claude mapper can return them unchanged. Anthropic
+				// requires prior thinking blocks to be preserved on subsequent
+				// tool-result requests from extended-thinking models.
+				if len(thinkingBlocks) > 0 {
+					asstMsg, _ = sjson.SetRaw(asstMsg, "_anthropic_thinking", "[]")
+					for _, tb := range thinkingBlocks {
+						asstMsg, _ = sjson.SetRaw(asstMsg, "_anthropic_thinking.-1", tb.Raw)
+					}
+				}
 				if len(toolUses) > 0 {
 					asstMsg, _ = sjson.SetRaw(asstMsg, "tool_calls", "[]")
 					for _, tu := range toolUses {

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -44,7 +44,12 @@ var (
 // Returns:
 //   - []byte: The transformed request data in Claude Code API format
 func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream bool) []byte {
-	rawJSON := inputRawJSON
+	// Some OpenAI-compatible clients (notably Cursor in agent/tool mode) send
+	// Anthropic-native content blocks (tool_use / tool_result) and bare tool
+	// definitions to the OpenAI Chat Completions endpoint. Those payloads are not
+	// valid OpenAI format, so normalize them to standard OpenAI shape before the
+	// regular translation below runs.
+	rawJSON := normalizeAnthropicRequestBlocks(inputRawJSON)
 
 	if account == "" {
 		u, _ := uuid.NewRandom()
@@ -328,6 +333,222 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 	}
 
 	return out
+}
+
+// normalizeAnthropicRequestBlocks rewrites Anthropic-native message and tool
+// shapes into standard OpenAI Chat Completions shapes. It is a no-op for
+// already-valid OpenAI payloads.
+//
+// Conversions:
+//  1. user message content with tool_result blocks -> separate role:"tool"
+//     messages ({tool_call_id, content}). Any sibling text blocks are kept as a
+//     trailing role:"user" message.
+//  2. assistant message content with tool_use blocks -> assistant message with
+//     tool_calls[].function (and text blocks merged into content).
+//  3. bare tool definitions ({name, description, input_schema}) -> wrapped
+//     {type:"function", function:{name, description, parameters}}.
+func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
+	root := gjson.ParseBytes(rawJSON)
+
+	if !anthropicBlocksPresent(root) {
+		return rawJSON
+	}
+
+	out := rawJSON
+
+	// Rebuild messages array if any message carries Anthropic content blocks.
+	if messages := root.Get("messages"); messages.Exists() && messages.IsArray() {
+		newMessages := []byte("[]")
+		messages.ForEach(func(_, message gjson.Result) bool {
+			role := message.Get("role").String()
+			content := message.Get("content")
+
+			if !content.IsArray() || !messageHasAnthropicBlocks(content) {
+				newMessages, _ = sjson.SetRawBytes(newMessages, "-1", []byte(message.Raw))
+				return true
+			}
+
+			switch role {
+			case "user":
+				textParts := make([]string, 0)
+				toolResults := make([]gjson.Result, 0)
+				passthrough := make([]gjson.Result, 0)
+				content.ForEach(func(_, block gjson.Result) bool {
+					switch block.Get("type").String() {
+					case "tool_result":
+						toolResults = append(toolResults, block)
+					case "text":
+						if t := block.Get("text").String(); t != "" {
+							textParts = append(textParts, t)
+						}
+					default:
+						passthrough = append(passthrough, block)
+					}
+					return true
+				})
+
+				// tool_result blocks become standalone role:"tool" messages so
+				// the downstream translator pairs them with the prior tool_calls.
+				for _, tr := range toolResults {
+					toolMsg := []byte(`{"role":"tool","tool_call_id":"","content":""}`)
+					toolMsg, _ = sjson.SetBytes(toolMsg, "tool_call_id", tr.Get("tool_use_id").String())
+					trContent := tr.Get("content")
+					if trContent.IsArray() {
+						toolMsg, _ = sjson.SetRawBytes(toolMsg, "content", []byte(trContent.Raw))
+					} else {
+						toolMsg, _ = sjson.SetBytes(toolMsg, "content", flattenAnthropicToolResultText(trContent))
+					}
+					newMessages, _ = sjson.SetRawBytes(newMessages, "-1", toolMsg)
+				}
+
+				// Remaining text / passthrough parts stay as a user message.
+				if len(textParts) > 0 || len(passthrough) > 0 {
+					userMsg := []byte(`{"role":"user","content":[]}`)
+					for _, t := range textParts {
+						textPart := []byte(`{"type":"text","text":""}`)
+						textPart, _ = sjson.SetBytes(textPart, "text", t)
+						userMsg, _ = sjson.SetRawBytes(userMsg, "content.-1", textPart)
+					}
+					for _, p := range passthrough {
+						userMsg, _ = sjson.SetRawBytes(userMsg, "content.-1", []byte(p.Raw))
+					}
+					newMessages, _ = sjson.SetRawBytes(newMessages, "-1", userMsg)
+				}
+
+			case "assistant":
+				textParts := make([]string, 0)
+				toolUses := make([]gjson.Result, 0)
+				content.ForEach(func(_, block gjson.Result) bool {
+					switch block.Get("type").String() {
+					case "tool_use":
+						toolUses = append(toolUses, block)
+					case "text":
+						if t := block.Get("text").String(); t != "" {
+							textParts = append(textParts, t)
+						}
+					}
+					return true
+				})
+
+				asstMsg := []byte(`{"role":"assistant","content":""}`)
+				asstMsg, _ = sjson.SetBytes(asstMsg, "content", strings.Join(textParts, ""))
+				if len(toolUses) > 0 {
+					asstMsg, _ = sjson.SetRawBytes(asstMsg, "tool_calls", []byte("[]"))
+					for _, tu := range toolUses {
+						toolCall := []byte(`{"id":"","type":"function","function":{"name":"","arguments":"{}"}}`)
+						toolCall, _ = sjson.SetBytes(toolCall, "id", tu.Get("id").String())
+						toolCall, _ = sjson.SetBytes(toolCall, "function.name", tu.Get("name").String())
+						if input := tu.Get("input"); input.Exists() && input.IsObject() {
+							toolCall, _ = sjson.SetBytes(toolCall, "function.arguments", input.Raw)
+						}
+						asstMsg, _ = sjson.SetRawBytes(asstMsg, "tool_calls.-1", toolCall)
+					}
+				}
+				newMessages, _ = sjson.SetRawBytes(newMessages, "-1", asstMsg)
+
+			default:
+				newMessages, _ = sjson.SetRawBytes(newMessages, "-1", []byte(message.Raw))
+			}
+			return true
+		})
+		out, _ = sjson.SetRawBytes(out, "messages", newMessages)
+	}
+
+	// Wrap bare Anthropic tool definitions into OpenAI function tools.
+	if tools := root.Get("tools"); tools.Exists() && tools.IsArray() && len(tools.Array()) > 0 {
+		needsWrap := false
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			if tool.Get("type").String() != "function" && tool.Get("name").Exists() {
+				needsWrap = true
+				return false
+			}
+			return true
+		})
+
+		if needsWrap {
+			newTools := []byte("[]")
+			tools.ForEach(func(_, tool gjson.Result) bool {
+				if tool.Get("type").String() == "function" {
+					newTools, _ = sjson.SetRawBytes(newTools, "-1", []byte(tool.Raw))
+					return true
+				}
+				wrapped := []byte(`{"type":"function","function":{"name":"","description":""}}`)
+				wrapped, _ = sjson.SetBytes(wrapped, "function.name", tool.Get("name").String())
+				wrapped, _ = sjson.SetBytes(wrapped, "function.description", tool.Get("description").String())
+				if schema := tool.Get("input_schema"); schema.Exists() {
+					wrapped, _ = sjson.SetRawBytes(wrapped, "function.parameters", []byte(schema.Raw))
+				} else if schema := tool.Get("parameters"); schema.Exists() {
+					wrapped, _ = sjson.SetRawBytes(wrapped, "function.parameters", []byte(schema.Raw))
+				}
+				newTools, _ = sjson.SetRawBytes(newTools, "-1", wrapped)
+				return true
+			})
+			out, _ = sjson.SetRawBytes(out, "tools", newTools)
+		}
+	}
+
+	return out
+}
+
+// anthropicBlocksPresent reports whether the request carries any Anthropic-native
+// message content blocks or bare tool definitions.
+func anthropicBlocksPresent(root gjson.Result) bool {
+	if messages := root.Get("messages"); messages.Exists() && messages.IsArray() {
+		found := false
+		messages.ForEach(func(_, message gjson.Result) bool {
+			if messageHasAnthropicBlocks(message.Get("content")) {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+
+	if tools := root.Get("tools"); tools.Exists() && tools.IsArray() {
+		found := false
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			if tool.Get("type").String() != "function" && tool.Get("name").Exists() {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+
+	return false
+}
+
+// messageHasAnthropicBlocks reports whether a message content array contains
+// tool_use or tool_result blocks.
+func messageHasAnthropicBlocks(content gjson.Result) bool {
+	if !content.IsArray() {
+		return false
+	}
+	found := false
+	content.ForEach(func(_, block gjson.Result) bool {
+		switch block.Get("type").String() {
+		case "tool_use", "tool_result":
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// flattenAnthropicToolResultText reduces a tool_result content value to a plain
+// string for the non-array case.
+func flattenAnthropicToolResultText(content gjson.Result) string {
+	if content.Type == gjson.String {
+		return content.String()
+	}
+	return content.Raw
 }
 
 func convertOpenAIContentPartToClaudePart(part gjson.Result) string {

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -254,14 +255,34 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 				toolCallID := message.Get("tool_call_id").String()
 				toolContentResult := message.Get("content")
 
-				msg := []byte(`{"role":"user","content":[{"type":"tool_result","tool_use_id":"","content":""}]}`)
-				msg, _ = sjson.SetBytes(msg, "content.0.tool_use_id", toolCallID)
+				toolResultBlock := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
+				toolResultBlock, _ = sjson.SetBytes(toolResultBlock, "tool_use_id", toolCallID)
 				toolResultContent, toolResultContentRaw := convertOpenAIToolResultContent(toolContentResult)
 				if toolResultContentRaw {
-					msg, _ = sjson.SetRawBytes(msg, "content.0.content", []byte(toolResultContent))
+					toolResultBlock, _ = sjson.SetRawBytes(toolResultBlock, "content", []byte(toolResultContent))
 				} else {
-					msg, _ = sjson.SetBytes(msg, "content.0.content", toolResultContent)
+					toolResultBlock, _ = sjson.SetBytes(toolResultBlock, "content", toolResultContent)
 				}
+
+				// Claude expects all tool_result blocks that answer the preceding
+				// assistant tool_use turn to be grouped in a single user message.
+				// Parallel tool calls arrive as consecutive role:"tool" messages, so
+				// append to the previous user/tool_result turn when present instead of
+				// emitting a separate user message per result.
+				if messageIndex > 0 {
+					lastIdx := messageIndex - 1
+					lastMsg := gjson.GetBytes(out, "messages."+strconv.Itoa(lastIdx))
+					lastContent := lastMsg.Get("content")
+					if lastMsg.Get("role").String() == "user" &&
+						lastContent.IsArray() && len(lastContent.Array()) > 0 &&
+						lastContent.Array()[len(lastContent.Array())-1].Get("type").String() == "tool_result" {
+						out, _ = sjson.SetRawBytes(out, "messages."+strconv.Itoa(lastIdx)+".content.-1", toolResultBlock)
+						return true
+					}
+				}
+
+				msg := []byte(`{"role":"user","content":[]}`)
+				msg, _ = sjson.SetRawBytes(msg, "content.-1", toolResultBlock)
 				out, _ = sjson.SetRawBytes(out, "messages.-1", msg)
 				messageIndex++
 			}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -358,13 +358,13 @@ func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
 
 	// Rebuild messages array if any message carries Anthropic content blocks.
 	if messages := root.Get("messages"); messages.Exists() && messages.IsArray() {
-		newMessages := []byte("[]")
+		newMessages := "[]"
 		messages.ForEach(func(_, message gjson.Result) bool {
 			role := message.Get("role").String()
 			content := message.Get("content")
 
 			if !content.IsArray() || !messageHasAnthropicBlocks(content) {
-				newMessages, _ = sjson.SetRawBytes(newMessages, "-1", []byte(message.Raw))
+				newMessages, _ = sjson.SetRaw(newMessages, "-1", message.Raw)
 				return true
 			}
 
@@ -390,29 +390,29 @@ func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
 				// tool_result blocks become standalone role:"tool" messages so
 				// the downstream translator pairs them with the prior tool_calls.
 				for _, tr := range toolResults {
-					toolMsg := []byte(`{"role":"tool","tool_call_id":"","content":""}`)
-					toolMsg, _ = sjson.SetBytes(toolMsg, "tool_call_id", tr.Get("tool_use_id").String())
+					toolMsg := `{"role":"tool","tool_call_id":"","content":""}`
+					toolMsg, _ = sjson.Set(toolMsg, "tool_call_id", tr.Get("tool_use_id").String())
 					trContent := tr.Get("content")
 					if trContent.IsArray() {
-						toolMsg, _ = sjson.SetRawBytes(toolMsg, "content", []byte(trContent.Raw))
+						toolMsg, _ = sjson.SetRaw(toolMsg, "content", trContent.Raw)
 					} else {
-						toolMsg, _ = sjson.SetBytes(toolMsg, "content", flattenAnthropicToolResultText(trContent))
+						toolMsg, _ = sjson.Set(toolMsg, "content", flattenAnthropicToolResultText(trContent))
 					}
-					newMessages, _ = sjson.SetRawBytes(newMessages, "-1", toolMsg)
+					newMessages, _ = sjson.SetRaw(newMessages, "-1", toolMsg)
 				}
 
 				// Remaining text / passthrough parts stay as a user message.
 				if len(textParts) > 0 || len(passthrough) > 0 {
-					userMsg := []byte(`{"role":"user","content":[]}`)
+					userMsg := `{"role":"user","content":[]}`
 					for _, t := range textParts {
-						textPart := []byte(`{"type":"text","text":""}`)
-						textPart, _ = sjson.SetBytes(textPart, "text", t)
-						userMsg, _ = sjson.SetRawBytes(userMsg, "content.-1", textPart)
+						textPart := `{"type":"text","text":""}`
+						textPart, _ = sjson.Set(textPart, "text", t)
+						userMsg, _ = sjson.SetRaw(userMsg, "content.-1", textPart)
 					}
 					for _, p := range passthrough {
-						userMsg, _ = sjson.SetRawBytes(userMsg, "content.-1", []byte(p.Raw))
+						userMsg, _ = sjson.SetRaw(userMsg, "content.-1", p.Raw)
 					}
-					newMessages, _ = sjson.SetRawBytes(newMessages, "-1", userMsg)
+					newMessages, _ = sjson.SetRaw(newMessages, "-1", userMsg)
 				}
 
 			case "assistant":
@@ -430,35 +430,38 @@ func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
 					return true
 				})
 
-				asstMsg := []byte(`{"role":"assistant","content":""}`)
-				asstMsg, _ = sjson.SetBytes(asstMsg, "content", strings.Join(textParts, ""))
+				asstMsg := `{"role":"assistant","content":""}`
+				asstMsg, _ = sjson.Set(asstMsg, "content", strings.Join(textParts, ""))
 				if len(toolUses) > 0 {
-					asstMsg, _ = sjson.SetRawBytes(asstMsg, "tool_calls", []byte("[]"))
+					asstMsg, _ = sjson.SetRaw(asstMsg, "tool_calls", "[]")
 					for _, tu := range toolUses {
-						toolCall := []byte(`{"id":"","type":"function","function":{"name":"","arguments":"{}"}}`)
-						toolCall, _ = sjson.SetBytes(toolCall, "id", tu.Get("id").String())
-						toolCall, _ = sjson.SetBytes(toolCall, "function.name", tu.Get("name").String())
+						toolCall := `{"id":"","type":"function","function":{"name":"","arguments":"{}"}}`
+						toolCall, _ = sjson.Set(toolCall, "id", tu.Get("id").String())
+						toolCall, _ = sjson.Set(toolCall, "function.name", tu.Get("name").String())
 						if input := tu.Get("input"); input.Exists() && input.IsObject() {
-							toolCall, _ = sjson.SetBytes(toolCall, "function.arguments", input.Raw)
+							toolCall, _ = sjson.Set(toolCall, "function.arguments", input.Raw)
 						}
-						asstMsg, _ = sjson.SetRawBytes(asstMsg, "tool_calls.-1", toolCall)
+						asstMsg, _ = sjson.SetRaw(asstMsg, "tool_calls.-1", toolCall)
 					}
 				}
-				newMessages, _ = sjson.SetRawBytes(newMessages, "-1", asstMsg)
+				newMessages, _ = sjson.SetRaw(newMessages, "-1", asstMsg)
 
 			default:
-				newMessages, _ = sjson.SetRawBytes(newMessages, "-1", []byte(message.Raw))
+				newMessages, _ = sjson.SetRaw(newMessages, "-1", message.Raw)
 			}
 			return true
 		})
-		out, _ = sjson.SetRawBytes(out, "messages", newMessages)
+		out, _ = sjson.SetRawBytes(out, "messages", []byte(newMessages))
 	}
 
 	// Wrap bare Anthropic tool definitions into OpenAI function tools.
+	// Only tools with NO "type" field are treated as bare custom tools. Typed
+	// Anthropic server tools (e.g. {"type":"web_search_20250305","name":...})
+	// are left untouched so the downstream mapper can handle them correctly.
 	if tools := root.Get("tools"); tools.Exists() && tools.IsArray() && len(tools.Array()) > 0 {
 		needsWrap := false
 		tools.ForEach(func(_, tool gjson.Result) bool {
-			if tool.Get("type").String() != "function" && tool.Get("name").Exists() {
+			if !tool.Get("type").Exists() && tool.Get("name").Exists() {
 				needsWrap = true
 				return false
 			}
@@ -466,24 +469,26 @@ func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
 		})
 
 		if needsWrap {
-			newTools := []byte("[]")
+			newTools := "[]"
 			tools.ForEach(func(_, tool gjson.Result) bool {
-				if tool.Get("type").String() == "function" {
-					newTools, _ = sjson.SetRawBytes(newTools, "-1", []byte(tool.Raw))
+				// Pass through anything that already has a type (OpenAI function
+				// tools and typed Anthropic server tools) unchanged.
+				if tool.Get("type").Exists() {
+					newTools, _ = sjson.SetRaw(newTools, "-1", tool.Raw)
 					return true
 				}
-				wrapped := []byte(`{"type":"function","function":{"name":"","description":""}}`)
-				wrapped, _ = sjson.SetBytes(wrapped, "function.name", tool.Get("name").String())
-				wrapped, _ = sjson.SetBytes(wrapped, "function.description", tool.Get("description").String())
+				wrapped := `{"type":"function","function":{"name":"","description":""}}`
+				wrapped, _ = sjson.Set(wrapped, "function.name", tool.Get("name").String())
+				wrapped, _ = sjson.Set(wrapped, "function.description", tool.Get("description").String())
 				if schema := tool.Get("input_schema"); schema.Exists() {
-					wrapped, _ = sjson.SetRawBytes(wrapped, "function.parameters", []byte(schema.Raw))
+					wrapped, _ = sjson.SetRaw(wrapped, "function.parameters", schema.Raw)
 				} else if schema := tool.Get("parameters"); schema.Exists() {
-					wrapped, _ = sjson.SetRawBytes(wrapped, "function.parameters", []byte(schema.Raw))
+					wrapped, _ = sjson.SetRaw(wrapped, "function.parameters", schema.Raw)
 				}
-				newTools, _ = sjson.SetRawBytes(newTools, "-1", wrapped)
+				newTools, _ = sjson.SetRaw(newTools, "-1", wrapped)
 				return true
 			})
-			out, _ = sjson.SetRawBytes(out, "tools", newTools)
+			out, _ = sjson.SetRawBytes(out, "tools", []byte(newTools))
 		}
 	}
 
@@ -510,7 +515,7 @@ func anthropicBlocksPresent(root gjson.Result) bool {
 	if tools := root.Get("tools"); tools.Exists() && tools.IsArray() {
 		found := false
 		tools.ForEach(func(_, tool gjson.Result) bool {
-			if tool.Get("type").String() != "function" && tool.Get("name").Exists() {
+			if !tool.Get("type").Exists() && tool.Get("name").Exists() {
 				found = true
 				return false
 			}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -263,6 +263,11 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 				} else {
 					toolResultBlock, _ = sjson.SetBytes(toolResultBlock, "content", toolResultContent)
 				}
+				// Reconstruct the Anthropic is_error flag carried from a Cursor
+				// tool_result so a failed tool execution stays marked as failed.
+				if isErr := message.Get("is_error"); isErr.Exists() && isErr.Bool() {
+					toolResultBlock, _ = sjson.SetBytes(toolResultBlock, "is_error", true)
+				}
 
 				// Claude expects all tool_result blocks that answer the preceding
 				// assistant tool_use turn to be grouped in a single user message.
@@ -424,6 +429,12 @@ func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
 						toolMsg, _ = sjson.SetRaw(toolMsg, "content", trContent.Raw)
 					} else {
 						toolMsg, _ = sjson.Set(toolMsg, "content", flattenAnthropicToolResultText(trContent))
+					}
+					// Carry the Anthropic is_error flag so the downstream Claude
+					// mapper can reconstruct a failed tool_result instead of
+					// silently turning a failure into an apparent success.
+					if isErr := tr.Get("is_error"); isErr.Exists() && isErr.Bool() {
+						toolMsg, _ = sjson.Set(toolMsg, "is_error", true)
 					}
 					newMessages, _ = sjson.SetRaw(newMessages, "-1", toolMsg)
 				}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -257,11 +257,18 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 
 				toolResultBlock := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
 				toolResultBlock, _ = sjson.SetBytes(toolResultBlock, "tool_use_id", toolCallID)
-				toolResultContent, toolResultContentRaw := convertOpenAIToolResultContent(toolContentResult)
-				if toolResultContentRaw {
-					toolResultBlock, _ = sjson.SetRawBytes(toolResultBlock, "content", []byte(toolResultContent))
+				if message.Get("_anthropic_native_content").Bool() && toolContentResult.IsArray() {
+					// Content is already a Claude-native block array; keep it raw so
+					// blocks like image/source and tool_reference are not dropped or
+					// stringified by the OpenAI content-part converter.
+					toolResultBlock, _ = sjson.SetRawBytes(toolResultBlock, "content", []byte(toolContentResult.Raw))
 				} else {
-					toolResultBlock, _ = sjson.SetBytes(toolResultBlock, "content", toolResultContent)
+					toolResultContent, toolResultContentRaw := convertOpenAIToolResultContent(toolContentResult)
+					if toolResultContentRaw {
+						toolResultBlock, _ = sjson.SetRawBytes(toolResultBlock, "content", []byte(toolResultContent))
+					} else {
+						toolResultBlock, _ = sjson.SetBytes(toolResultBlock, "content", toolResultContent)
+					}
 				}
 				// Reconstruct the Anthropic is_error flag carried from a Cursor
 				// tool_result so a failed tool execution stays marked as failed.
@@ -427,6 +434,13 @@ func normalizeAnthropicRequestBlocks(rawJSON []byte) []byte {
 					trContent := tr.Get("content")
 					if trContent.IsArray() {
 						toolMsg, _ = sjson.SetRaw(toolMsg, "content", trContent.Raw)
+						// When the array holds Claude-native blocks (e.g. image with
+						// source, tool_reference), flag it so the downstream mapper
+						// keeps it verbatim instead of routing it through the OpenAI
+						// content-part converter, which would drop unknown blocks.
+						if toolResultContentIsAnthropicNative(trContent) {
+							toolMsg, _ = sjson.Set(toolMsg, "_anthropic_native_content", true)
+						}
 					} else {
 						toolMsg, _ = sjson.Set(toolMsg, "content", flattenAnthropicToolResultText(trContent))
 					}
@@ -583,6 +597,31 @@ func messageHasAnthropicBlocks(content gjson.Result) bool {
 		return true
 	})
 	return found
+}
+
+// toolResultContentIsAnthropicNative reports whether a tool_result content array
+// holds Claude-native blocks that the OpenAI content-part converter does not
+// understand (anything other than text / image_url / file). Such arrays must be
+// passed through verbatim so blocks like image (with source) or tool_reference
+// are not dropped or stringified.
+func toolResultContentIsAnthropicNative(content gjson.Result) bool {
+	if !content.IsArray() {
+		return false
+	}
+	native := false
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Type == gjson.String {
+			return true
+		}
+		switch block.Get("type").String() {
+		case "text", "image_url", "file":
+			return true
+		default:
+			native = true
+			return false
+		}
+	})
+	return native
 }
 
 // flattenAnthropicToolResultText reduces a tool_result content value to a plain


### PR DESCRIPTION
## Problem

Cursor in **agent / tool mode** sends **Anthropic-native content blocks** to the **OpenAI** `/v1/chat/completions` endpoint instead of OpenAI-format tool messages. Specifically:

- `user.content` arrays containing `{ "type": "tool_result", "tool_use_id": ..., "content": ... }`
- `assistant.content` arrays containing `{ "type": "tool_use", "id": ..., "name": ..., "input": {...} }`
- bare tool definitions `{ "name", "description", "input_schema" }` (no `type: "function"` wrapper)

`ConvertOpenAIRequestToClaude` assumes valid OpenAI shapes (`tool_calls`, `role:"tool"`, `tools[].type=="function"`), so these payloads were dropped, producing an invalid Claude request and errors like:

```
messages.N: user messages must have non-empty content
```

or silently broken tool calling. This matches #1165 and the Cursor community report ["Wrong tools handling on OpenAI compatible endpoint"](https://forum.cursor.com/t/wrong-tools-handling-on-openai-compatible-endpoint/145588).

## Fix

Add `normalizeAnthropicRequestBlocks`, a pre-processing pass at the top of `ConvertOpenAIRequestToClaude` that rewrites Anthropic-native shapes into standard OpenAI shapes before the existing translation runs:

1. `user` content `tool_result` blocks -> standalone `role:"tool"` messages (`tool_call_id`, `content`); sibling text blocks are preserved as a trailing `user` message.
2. `assistant` content `tool_use` blocks -> `assistant.tool_calls[].function` (text blocks merged into `content`).
3. bare `{ name, description, input_schema }` tools -> `{ type:"function", function:{ name, description, parameters } }`.

Standard OpenAI payloads are detected via `anthropicBlocksPresent` and **pass through untouched** (no behavior change for existing clients).

## Why this matters

Without this, Cursor users must run an external request-rewriting proxy/shim in front of CLIProxyAPI to use agent mode with Claude over OAuth. This fix makes the OpenAI endpoint accept Cursor's payloads natively.

## Tests

Added `claude_openai_normalize_test.go`:

- `TestConvertOpenAIRequestToClaude_CursorToolResultBlock` - full assistant `tool_use` + user `tool_result` round trip
- `TestConvertOpenAIRequestToClaude_CursorToolResultWithText` - mixed `tool_result` + trailing text
- `TestConvertOpenAIRequestToClaude_BareAnthropicTools` - bare tool definition wrapping
- `TestConvertOpenAIRequestToClaude_StandardOpenAIUnchanged` - regression guard for normal OpenAI payloads

```
go test ./internal/translator/claude/openai/chat-completions/...
ok
go build ./internal/translator/...
go vet ./internal/translator/claude/openai/chat-completions/...
```

Refs #1165