### PR TITLE
feat: port Claude/Codex compatibility fixes and retry transient EOFs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   cli-proxy-api:
-    image: ${CLI_PROXY_IMAGE:-eceasy/cli-proxy-api:latest}
-    pull_policy: always
+    image: ${CLI_PROXY_IMAGE:-cli-proxy-api:local}
     build:
       context: .
       dockerfile: Dockerfile

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -685,11 +685,28 @@ func codexReplayComparableCallIDs(callID string) []string {
 		return nil
 	}
 
-	claudeVisibleCallID := shortenCodexReplayCallIDIfNeeded(util.SanitizeClaudeToolID(callID))
-	if claudeVisibleCallID == "" || claudeVisibleCallID == callID {
-		return []string{callID}
+	variants := make([]string, 0, 4)
+	seen := make(map[string]struct{}, 4)
+	appendVariant := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		variants = append(variants, id)
 	}
-	return []string{callID, claudeVisibleCallID}
+
+	appendVariant(callID)
+	appendVariant(shortenCodexReplayCallIDIfNeeded(callID))
+
+	sanitized := util.SanitizeClaudeToolID(callID)
+	appendVariant(sanitized)
+	appendVariant(shortenCodexReplayCallIDIfNeeded(sanitized))
+
+	return variants
 }
 
 func shortenCodexReplayCallIDIfNeeded(id string) string {

--- a/internal/runtime/executor/codex_executor_reasoning_replay_cache_test.go
+++ b/internal/runtime/executor/codex_executor_reasoning_replay_cache_test.go
@@ -15,6 +15,7 @@ import (
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -847,5 +848,97 @@ func TestCodexExecutorReasoningReplayCacheMatchesShortenedClaudeToolResultCallID
 	}
 	if got := gjson.GetBytes(secondBody, "input.3.call_id").String(); got != shortCallID {
 		t.Fatalf("input.3.call_id = %q, want shortened call_id %q; body=%s", got, shortCallID, string(secondBody))
+	}
+}
+
+func TestCodexExecutorReasoningReplayCacheMatchesSanitizedClaudeToolResultCallID(t *testing.T) {
+	internalcache.ClearCodexReasoningReplayCache()
+	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
+
+	longCallID := "call_" + strings.Repeat("a", 62)
+	shortCallID := util.SanitizeClaudeToolID(longCallID)
+	if len(longCallID) <= 64 || len(shortCallID) > 64 || shortCallID == longCallID {
+		t.Fatalf("invalid test setup: long=%q short=%q", longCallID, shortCallID)
+	}
+
+	reasoningEncryptedContent := validCodexReasoningEncryptedContentForTestSeed(14)
+	var bodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read body: %v", errRead)
+		}
+		bodies = append(bodies, body)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","item":{"id":"rs_long","type":"reasoning","summary":[],"encrypted_content":"` + reasoningEncryptedContent + `"},"output_index":0}` + "\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","item":{"id":"fc_long","type":"function_call","call_id":"` + longCallID + `","name":"lookup","arguments":"{\"q\":\"weather\"}","status":"completed"},"output_index":1}` + "\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":0,"status":"completed","model":"gpt-5.4","output":[]}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-replay-claude-sanitized-tool",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+		Stream:       false,
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model: "gpt-5.4",
+		Payload: []byte(`{
+			"model":"gpt-5.4",
+			"metadata":{"user_id":"{\"device_id\":\"device-test\",\"account_uuid\":\"\",\"session_id\":\"claude-session-sanitized-tool\"}"},
+			"messages":[{"role":"user","content":[{"type":"text","text":"call lookup"}]}],
+			"tools":[{"name":"lookup","input_schema":{"type":"object","properties":{"q":{"type":"string"}}}}]
+		}`),
+	}, opts)
+	if err != nil {
+		t.Fatalf("first Execute error: %v", err)
+	}
+
+	_, err = executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model: "gpt-5.4",
+		Payload: []byte(`{
+			"model":"gpt-5.4",
+			"metadata":{"user_id":"{\"device_id\":\"device-test\",\"account_uuid\":\"\",\"session_id\":\"claude-session-sanitized-tool\"}"},
+			"messages":[
+				{"role":"user","content":[{"type":"text","text":"call lookup"}]},
+				{"role":"user","content":[{"type":"tool_result","tool_use_id":"` + shortCallID + `","content":"sunny"}]}
+			],
+			"tools":[{"name":"lookup","input_schema":{"type":"object","properties":{"q":{"type":"string"}}}}]
+		}`),
+	}, opts)
+	if err != nil {
+		t.Fatalf("second Execute error: %v", err)
+	}
+
+	if len(bodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(bodies))
+	}
+	secondBody := bodies[1]
+	if got := gjson.GetBytes(secondBody, "input.0.type").String(); got != "message" {
+		t.Fatalf("input.0.type = %q, want initial user message; body=%s", got, string(secondBody))
+	}
+	if got := gjson.GetBytes(secondBody, "input.1.type").String(); got != "reasoning" {
+		t.Fatalf("input.1.type = %q, want cached reasoning; body=%s", got, string(secondBody))
+	}
+	if got := gjson.GetBytes(secondBody, "input.2.type").String(); got != "function_call" {
+		t.Fatalf("input.2.type = %q, want cached function_call; body=%s", got, string(secondBody))
+	}
+	if got := gjson.GetBytes(secondBody, "input.2.call_id").String(); got != shortCallID {
+		t.Fatalf("input.2.call_id = %q, want sanitized call_id %q; body=%s", got, shortCallID, string(secondBody))
+	}
+	if got := gjson.GetBytes(secondBody, "input.3.type").String(); got != "function_call_output" {
+		t.Fatalf("input.3.type = %q, want function_call_output after cached call; body=%s", got, string(secondBody))
+	}
+	if got := gjson.GetBytes(secondBody, "input.3.call_id").String(); got != shortCallID {
+		t.Fatalf("input.3.call_id = %q, want sanitized call_id %q; body=%s", got, shortCallID, string(secondBody))
 	}
 }

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -47,36 +47,49 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 	template, _ = sjson.SetBytes(template, "model", modelName)
 
 	// Process system messages and convert them to input content format.
-	systemsResult := rootResult.Get("system")
-	if systemsResult.Exists() {
-		message := []byte(`{"type":"message","role":"developer","content":[]}`)
-		contentIndex := 0
+	developerMessage := []byte(`{"type":"message","role":"developer","content":[]}`)
+	developerContentIndex := 0
 
-		appendSystemText := func(text string) {
-			if text == "" || util.IsClaudeCodeAttributionSystemText(text) {
-				return
-			}
-
-			message, _ = sjson.SetBytes(message, fmt.Sprintf("content.%d.type", contentIndex), "input_text")
-			message, _ = sjson.SetBytes(message, fmt.Sprintf("content.%d.text", contentIndex), text)
-			contentIndex++
+	appendDeveloperText := func(text string) {
+		if text == "" || util.IsClaudeCodeAttributionSystemText(text) {
+			return
 		}
 
-		if systemsResult.Type == gjson.String {
-			appendSystemText(systemsResult.String())
-		} else if systemsResult.IsArray() {
-			systemResults := systemsResult.Array()
-			for i := 0; i < len(systemResults); i++ {
-				systemResult := systemResults[i]
-				if systemResult.Get("type").String() == "text" {
-					appendSystemText(systemResult.Get("text").String())
+		developerMessage, _ = sjson.SetBytes(developerMessage, fmt.Sprintf("content.%d.type", developerContentIndex), "input_text")
+		developerMessage, _ = sjson.SetBytes(developerMessage, fmt.Sprintf("content.%d.text", developerContentIndex), text)
+		developerContentIndex++
+	}
+
+	appendDeveloperContent := func(content gjson.Result) {
+		if content.Type == gjson.String {
+			appendDeveloperText(content.String())
+			return
+		}
+		if content.IsArray() {
+			contentResults := content.Array()
+			for i := 0; i < len(contentResults); i++ {
+				contentResult := contentResults[i]
+				if contentResult.Get("type").String() == "text" {
+					appendDeveloperText(contentResult.Get("text").String())
 				}
 			}
 		}
+	}
 
-		if contentIndex > 0 {
-			template, _ = sjson.SetRawBytes(template, "input.-1", message)
+	if systemsResult := rootResult.Get("system"); systemsResult.Exists() {
+		appendDeveloperContent(systemsResult)
+	}
+	if messagesResult := rootResult.Get("messages"); messagesResult.IsArray() {
+		messageResults := messagesResult.Array()
+		for i := 0; i < len(messageResults); i++ {
+			messageResult := messageResults[i]
+			if messageResult.Get("role").String() == "system" {
+				appendDeveloperContent(messageResult.Get("content"))
+			}
 		}
+	}
+	if developerContentIndex > 0 {
+		template, _ = sjson.SetRawBytes(template, "input.-1", developerMessage)
 	}
 
 	// Process messages and transform their contents to appropriate formats.
@@ -88,7 +101,7 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 			messageResult := messageResults[i]
 			messageRole := messageResult.Get("role").String()
 			if messageRole == "system" {
-				messageRole = "developer"
+				continue
 			}
 
 			newMessage := func() []byte {

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -68,6 +68,19 @@ func TestConvertClaudeRequestToCodex_SystemMessageScenarios(t *testing.T) {
 			wantHasDeveloper: true,
 			wantTexts:        []string{"Block 1", "Block 2"},
 		},
+		{
+			name: "Top-level and message system fields are merged",
+			inputJSON: `{
+				"model": "claude-3-opus",
+				"system": "Top system",
+				"messages": [
+					{"role": "system", "content": [{"type":"text","text":"Message system"}]},
+					{"role": "user", "content": "hello"}
+				]
+			}`,
+			wantHasDeveloper: true,
+			wantTexts:        []string{"Top system", "Message system"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -79,6 +92,11 @@ func TestConvertClaudeRequestToCodex_SystemMessageScenarios(t *testing.T) {
 			hasDeveloper := len(inputs) > 0 && inputs[0].Get("role").String() == "developer"
 			if hasDeveloper != tt.wantHasDeveloper {
 				t.Fatalf("got hasDeveloper = %v, want %v. Output: %s", hasDeveloper, tt.wantHasDeveloper, resultJSON.Get("input").Raw)
+			}
+			for i, input := range inputs {
+				if got := input.Get("role").String(); got == "system" {
+					t.Fatalf("input[%d] role = system, want no system roles. Output: %s", i, resultJSON.Get("input").Raw)
+				}
 			}
 
 			if !tt.wantHasDeveloper {

--- a/internal/translator/openai/claude/openai_claude_request.go
+++ b/internal/translator/openai/claude/openai_claude_request.go
@@ -100,38 +100,78 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 	// Process messages and system
 	messagesJSON := []byte(`[]`)
 
-	// Handle system message first
-	systemMsgJSON := []byte(`{"role":"system","content":[]}`)
-	hasSystemContent := false
-	if system := root.Get("system"); system.Exists() {
-		if system.Type == gjson.String {
-			if system.String() != "" && !util.IsClaudeCodeAttributionSystemText(system.String()) {
-				oldSystem := []byte(`{"type":"text","text":""}`)
-				oldSystem, _ = sjson.SetBytes(oldSystem, "text", system.String())
-				systemMsgJSON, _ = sjson.SetRawBytes(systemMsgJSON, "content.-1", oldSystem)
-				hasSystemContent = true
+	// Collect Claude system content so it can be folded into the emitted
+	// conversation flow without sending OpenAI role:"system" messages.
+	systemContentItems := make([][]byte, 0)
+	appendSystemContent := func(content gjson.Result) {
+		if !content.Exists() {
+			return
+		}
+		if content.Type == gjson.String {
+			text := content.String()
+			if text == "" || util.IsClaudeCodeAttributionSystemText(text) {
+				return
 			}
-		} else if system.Type == gjson.JSON {
-			if system.IsArray() {
-				systemResults := system.Array()
-				for i := 0; i < len(systemResults); i++ {
-					if contentItem, ok := convertClaudeContentPart(systemResults[i]); ok {
-						systemMsgJSON, _ = sjson.SetRawBytes(systemMsgJSON, "content.-1", []byte(contentItem))
-						hasSystemContent = true
-					}
+			oldSystem := []byte(`{"type":"text","text":""}`)
+			oldSystem, _ = sjson.SetBytes(oldSystem, "text", text)
+			systemContentItems = append(systemContentItems, oldSystem)
+			return
+		}
+		if content.IsArray() {
+			content.ForEach(func(_, item gjson.Result) bool {
+				if item.Get("type").String() == "text" && util.IsClaudeCodeAttributionSystemText(item.Get("text").String()) {
+					return true
 				}
-			}
+				if contentItem, ok := convertClaudeContentPart(item); ok {
+					systemContentItems = append(systemContentItems, []byte(contentItem))
+				}
+				return true
+			})
 		}
 	}
-	// Only add system message if it has content
-	if hasSystemContent {
-		messagesJSON, _ = sjson.SetRawBytes(messagesJSON, "-1", systemMsgJSON)
+	emitPendingSystemAsUser := func() {
+		if len(systemContentItems) == 0 {
+			return
+		}
+		msgJSON := []byte(`{"role":"user","content":[]}`)
+		for _, contentItem := range systemContentItems {
+			msgJSON, _ = sjson.SetRawBytes(msgJSON, "content.-1", contentItem)
+		}
+		messagesJSON, _ = sjson.SetRawBytes(messagesJSON, "-1", msgJSON)
+		systemContentItems = nil
+	}
+	prependPendingSystemContent := func(contentItems [][]byte) [][]byte {
+		if len(systemContentItems) == 0 {
+			return contentItems
+		}
+		merged := make([][]byte, 0, len(systemContentItems)+len(contentItems))
+		merged = append(merged, systemContentItems...)
+		merged = append(merged, contentItems...)
+		systemContentItems = nil
+		return merged
+	}
+	if system := root.Get("system"); system.Exists() {
+		appendSystemContent(system)
+	}
+	if messages := root.Get("messages"); messages.Exists() && messages.IsArray() {
+		messages.ForEach(func(_, message gjson.Result) bool {
+			if message.Get("role").String() == "system" {
+				appendSystemContent(message.Get("content"))
+			}
+			return true
+		})
 	}
 
 	// Process Anthropic messages
 	if messages := root.Get("messages"); messages.Exists() && messages.IsArray() {
 		messages.ForEach(func(_, message gjson.Result) bool {
 			role := message.Get("role").String()
+			if role == "system" {
+				return true
+			}
+			if role != "user" {
+				emitPendingSystemAsUser()
+			}
 			contentResult := message.Get("content")
 
 			// Handle content
@@ -205,6 +245,10 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 					reasoningContent = strings.Join(reasoningParts, "\n\n")
 				}
 
+				if role == "user" {
+					contentItems = prependPendingSystemContent(contentItems)
+				}
+
 				hasContent := len(contentItems) > 0
 				hasReasoning := reasoningContent != ""
 				hasToolCalls := len(toolCalls) > 0
@@ -268,15 +312,29 @@ func ConvertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 
 			} else if contentResult.Exists() && contentResult.Type == gjson.String {
 				// Simple string content
-				msgJSON := []byte(`{"role":"","content":""}`)
-				msgJSON, _ = sjson.SetBytes(msgJSON, "role", role)
-				msgJSON, _ = sjson.SetBytes(msgJSON, "content", contentResult.String())
-				messagesJSON, _ = sjson.SetRawBytes(messagesJSON, "-1", msgJSON)
+				if role == "user" && len(systemContentItems) > 0 {
+					msgJSON := []byte(`{"role":"user","content":[]}`)
+					for _, contentItem := range systemContentItems {
+						msgJSON, _ = sjson.SetRawBytes(msgJSON, "content.-1", contentItem)
+					}
+					textItem := []byte(`{"type":"text","text":""}`)
+					textItem, _ = sjson.SetBytes(textItem, "text", contentResult.String())
+					msgJSON, _ = sjson.SetRawBytes(msgJSON, "content.-1", textItem)
+					messagesJSON, _ = sjson.SetRawBytes(messagesJSON, "-1", msgJSON)
+					systemContentItems = nil
+				} else {
+					msgJSON := []byte(`{"role":"","content":""}`)
+					msgJSON, _ = sjson.SetBytes(msgJSON, "role", role)
+					msgJSON, _ = sjson.SetBytes(msgJSON, "content", contentResult.String())
+					messagesJSON, _ = sjson.SetRawBytes(messagesJSON, "-1", msgJSON)
+				}
 			}
 
 			return true
 		})
 	}
+
+	emitPendingSystemAsUser()
 
 	// Set messages
 	if msgs := gjson.ParseBytes(messagesJSON); msgs.IsArray() && len(msgs.Array()) > 0 {

--- a/internal/translator/openai/claude/openai_claude_request_test.go
+++ b/internal/translator/openai/claude/openai_claude_request_test.go
@@ -101,7 +101,7 @@ func TestConvertClaudeRequestToOpenAI_ThinkingToReasoningContent(t *testing.T) {
 			// System messages don't have reasoning_content mapping
 			wantReasoningContent:    "",
 			wantHasReasoningContent: false,
-			wantContentText:         "Hello",
+			wantContentText:         "System prompt.",
 			wantHasContent:          true,
 		},
 		{
@@ -356,12 +356,63 @@ func validGPTChatReasoningSignature() string {
 	return base64.URLEncoding.EncodeToString(raw)
 }
 
+func TestConvertClaudeRequestToOpenAI_SystemContentDoesNotEmitSystemRole(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-3-opus",
+		"system": "Initial instructions",
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "first"}]},
+			{"role": "system", "content": [{"type": "text", "text": "mid instructions"}]},
+			{"role": "assistant", "content": [{"type": "text", "text": "answer"}]},
+			{"role": "system", "content": "string instructions"},
+			{"role": "user", "content": [{"type": "text", "text": "second"}]}
+		]
+	}`
+
+	result := ConvertClaudeRequestToOpenAI("test-model", []byte(inputJSON), false)
+	messages := gjson.ParseBytes(result).Get("messages").Array()
+
+	if len(messages) != 3 {
+		t.Fatalf("Expected 3 messages, got %d. Messages: %s", len(messages), gjson.GetBytes(result, "messages").Raw)
+	}
+
+	for i, message := range messages {
+		if got := message.Get("role").String(); got == "system" {
+			t.Fatalf("Expected no system messages, got system role at messages[%d]. Messages: %s", i, gjson.GetBytes(result, "messages").Raw)
+		}
+	}
+
+	if got := messages[0].Get("role").String(); got != "user" {
+		t.Fatalf("Expected first message role %q, got %q", "user", got)
+	}
+	if got := messages[0].Get("content.0.text").String(); got != "Initial instructions" {
+		t.Fatalf("Expected initial system text %q, got %q", "Initial instructions", got)
+	}
+	if got := messages[0].Get("content.1.text").String(); got != "mid instructions" {
+		t.Fatalf("Expected moved mid system text %q, got %q", "mid instructions", got)
+	}
+	if got := messages[0].Get("content.2.text").String(); got != "string instructions" {
+		t.Fatalf("Expected moved string system text %q, got %q", "string instructions", got)
+	}
+	if got := messages[0].Get("content.3.text").String(); got != "first" {
+		t.Fatalf("Expected first user text %q, got %q", "first", got)
+	}
+
+	wantRoles := []string{"user", "assistant", "user"}
+	for i, want := range wantRoles {
+		if got := messages[i].Get("role").String(); got != want {
+			t.Fatalf("Expected messages[%d] role %q, got %q. Messages: %s", i, want, got, gjson.GetBytes(result, "messages").Raw)
+		}
+	}
+}
+
 func TestConvertClaudeRequestToOpenAI_SystemMessageScenarios(t *testing.T) {
 	tests := []struct {
-		name        string
-		inputJSON   string
-		wantHasSys  bool
-		wantSysText string
+		name               string
+		inputJSON          string
+		wantFirstRole      string
+		wantFirstText      string
+		wantLastSystemText string
 	}{
 		{
 			name: "No system field",
@@ -369,7 +420,7 @@ func TestConvertClaudeRequestToOpenAI_SystemMessageScenarios(t *testing.T) {
 				"model": "claude-3-opus",
 				"messages": [{"role": "user", "content": "hello"}]
 			}`,
-			wantHasSys: false,
+			wantFirstRole: "user",
 		},
 		{
 			name: "Empty string system field",
@@ -378,7 +429,7 @@ func TestConvertClaudeRequestToOpenAI_SystemMessageScenarios(t *testing.T) {
 				"system": "",
 				"messages": [{"role": "user", "content": "hello"}]
 			}`,
-			wantHasSys: false,
+			wantFirstRole: "user",
 		},
 		{
 			name: "String system field",
@@ -387,8 +438,9 @@ func TestConvertClaudeRequestToOpenAI_SystemMessageScenarios(t *testing.T) {
 				"system": "Be helpful",
 				"messages": [{"role": "user", "content": "hello"}]
 			}`,
-			wantHasSys:  true,
-			wantSysText: "Be helpful",
+			wantFirstRole:      "user",
+			wantFirstText:      "Be helpful",
+			wantLastSystemText: "Be helpful",
 		},
 		{
 			name: "Array system field with text",
@@ -397,8 +449,9 @@ func TestConvertClaudeRequestToOpenAI_SystemMessageScenarios(t *testing.T) {
 				"system": [{"type": "text", "text": "Array system"}],
 				"messages": [{"role": "user", "content": "hello"}]
 			}`,
-			wantHasSys:  true,
-			wantSysText: "Array system",
+			wantFirstRole:      "user",
+			wantFirstText:      "Array system",
+			wantLastSystemText: "Array system",
 		},
 		{
 			name: "Array system field with multiple text blocks",
@@ -410,8 +463,9 @@ func TestConvertClaudeRequestToOpenAI_SystemMessageScenarios(t *testing.T) {
 				],
 				"messages": [{"role": "user", "content": "hello"}]
 			}`,
-			wantHasSys:  true,
-			wantSysText: "Block 2", // We will update the test logic to check all blocks or specifically the second one
+			wantFirstRole:      "user",
+			wantFirstText:      "Block 1",
+			wantLastSystemText: "Block 2",
 		},
 	}
 
@@ -420,34 +474,34 @@ func TestConvertClaudeRequestToOpenAI_SystemMessageScenarios(t *testing.T) {
 			result := ConvertClaudeRequestToOpenAI("test-model", []byte(tt.inputJSON), false)
 			resultJSON := gjson.ParseBytes(result)
 			messages := resultJSON.Get("messages").Array()
-
-			hasSys := false
-			var sysMsg gjson.Result
-			if len(messages) > 0 && messages[0].Get("role").String() == "system" {
-				hasSys = true
-				sysMsg = messages[0]
+			if len(messages) == 0 {
+				t.Fatalf("expected at least one message. Output: %s", resultJSON.Get("messages").Raw)
 			}
 
-			if hasSys != tt.wantHasSys {
-				t.Errorf("got hasSystem = %v, want %v", hasSys, tt.wantHasSys)
-			}
-
-			if tt.wantHasSys {
-				// Check content - it could be string or array in OpenAI
-				content := sysMsg.Get("content")
-				var gotText string
-				if content.IsArray() {
-					arr := content.Array()
-					if len(arr) > 0 {
-						// Get the last element's text for validation
-						gotText = arr[len(arr)-1].Get("text").String()
-					}
-				} else {
-					gotText = content.String()
+			for i, message := range messages {
+				if got := message.Get("role").String(); got == "system" {
+					t.Fatalf("messages[%d] role = system, want no system roles. Output: %s", i, resultJSON.Get("messages").Raw)
 				}
+			}
 
-				if tt.wantSysText != "" && gotText != tt.wantSysText {
-					t.Errorf("got system text = %q, want %q", gotText, tt.wantSysText)
+			if got := messages[0].Get("role").String(); got != tt.wantFirstRole {
+				t.Fatalf("messages[0].role = %q, want %q. Output: %s", got, tt.wantFirstRole, resultJSON.Get("messages").Raw)
+			}
+
+			if tt.wantFirstText != "" {
+				if got := messages[0].Get("content.0.text").String(); got != tt.wantFirstText {
+					t.Fatalf("messages[0].content[0].text = %q, want %q. Output: %s", got, tt.wantFirstText, resultJSON.Get("messages").Raw)
+				}
+			}
+			if tt.wantLastSystemText != "" {
+				content := messages[0].Get("content").Array()
+				if len(content) == 0 {
+					t.Fatalf("messages[0].content is empty. Output: %s", resultJSON.Get("messages").Raw)
+				}
+				if got := content[len(content)-1].Get("text").String(); got != tt.wantLastSystemText && len(content) > 1 {
+					if got2 := content[len(content)-2].Get("text").String(); got2 != tt.wantLastSystemText {
+						t.Fatalf("system text not preserved as expected. Output: %s", resultJSON.Get("messages").Raw)
+					}
 				}
 			}
 		})
@@ -771,15 +825,23 @@ func TestConvertClaudeRequestToOpenAI_StripsClaudeCodeAttribution(t *testing.T) 
 
 	output := ConvertClaudeRequestToOpenAI("gpt-5", inputJSON, false)
 	messages := gjson.GetBytes(output, "messages").Array()
-	if len(messages) == 0 || messages[0].Get("role").String() != "system" {
-		t.Fatalf("Expected first message to be system, got: %s", gjson.GetBytes(output, "messages").Raw)
+	if len(messages) == 0 || messages[0].Get("role").String() != "user" {
+		t.Fatalf("Expected first message to be user, got: %s", gjson.GetBytes(output, "messages").Raw)
+	}
+	for i, message := range messages {
+		if got := message.Get("role").String(); got == "system" {
+			t.Fatalf("messages[%d] role = system, want no system roles: %s", i, gjson.GetBytes(output, "messages").Raw)
+		}
 	}
 
 	content := messages[0].Get("content").Array()
-	if len(content) != 1 {
-		t.Fatalf("Expected 1 system content item after attribution strip, got %d: %s", len(content), messages[0].Get("content").Raw)
+	if len(content) != 2 {
+		t.Fatalf("Expected 2 user content items after attribution strip, got %d: %s", len(content), messages[0].Get("content").Raw)
 	}
 	if got := content[0].Get("text").String(); got != "User system prompt" {
-		t.Fatalf("Unexpected system content: %q", got)
+		t.Fatalf("Unexpected preserved system content: %q", got)
+	}
+	if got := content[1].Get("text").String(); got != "hi" {
+		t.Fatalf("Unexpected user content: %q", got)
 	}
 }

--- a/internal/util/claude_tool_id.go
+++ b/internal/util/claude_tool_id.go
@@ -1,24 +1,55 @@
 package util
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"regexp"
+	"strings"
 	"sync/atomic"
 	"time"
 )
 
+const claudeToolIDMaxLength = 64
+
 var (
 	claudeToolUseIDSanitizer = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+	claudeToolUseIDSuffix    = regexp.MustCompile(`(?:-|_)[0-9]+(?:-|_)[0-9]+$`)
 	claudeToolUseIDCounter   uint64
 )
 
 // SanitizeClaudeToolID ensures the given id conforms to Claude's
-// tool_use.id regex ^[a-zA-Z0-9_-]+$.  Non-conforming characters are
-// replaced with '_'; an empty result gets a generated fallback.
+// tool_use.id regex ^[a-zA-Z0-9_-]+$ and keeps it within the 64-char
+// upstream limit. Non-conforming characters are replaced with '_'; an
+// empty result gets a generated fallback.
 func SanitizeClaudeToolID(id string) string {
 	s := claudeToolUseIDSanitizer.ReplaceAllString(id, "_")
 	if s == "" {
 		s = fmt.Sprintf("toolu_%d_%d", time.Now().UnixNano(), atomic.AddUint64(&claudeToolUseIDCounter, 1))
 	}
-	return s
+	if len(s) <= claudeToolIDMaxLength {
+		return s
+	}
+	hash := sha256.Sum256([]byte(s))
+	hashSuffix := hex.EncodeToString(hash[:])[:8]
+	base := s
+	if suffix := claudeToolUseIDSuffix.FindStringIndex(base); suffix != nil {
+		base = base[:suffix[0]]
+	}
+	prefixBudget := claudeToolIDMaxLength - len(hashSuffix) - 1
+	if prefixBudget <= 0 {
+		return hashSuffix
+	}
+	if len(base) > prefixBudget {
+		base = base[:prefixBudget]
+		base = strings.TrimRight(base, "_")
+	}
+	if base == "" {
+		base = "toolu"
+	}
+	shortID := base + "_" + hashSuffix
+	if len(shortID) > claudeToolIDMaxLength {
+		shortID = shortID[:claudeToolIDMaxLength]
+	}
+	return shortID
 }

--- a/internal/util/claude_tool_id_test.go
+++ b/internal/util/claude_tool_id_test.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeClaudeToolID_ShortensLongIDsToClaudeLimit(t *testing.T) {
+	longID := "mcp__synthpilot__connect_hardware_server-1776264133559318385-226896"
+	if len(longID) <= 64 {
+		t.Fatalf("test setup error: longID len = %d, want > 64", len(longID))
+	}
+
+	sanitized := SanitizeClaudeToolID(longID)
+
+	if sanitized == longID {
+		t.Fatalf("SanitizeClaudeToolID left long id unchanged: %q", sanitized)
+	}
+	if len(sanitized) > 64 {
+		t.Fatalf("SanitizeClaudeToolID returned len %d, want <= 64: %q", len(sanitized), sanitized)
+	}
+	if !strings.HasPrefix(sanitized, "mcp__synthpilot__connect_hardware_server_") {
+		t.Fatalf("SanitizeClaudeToolID should keep readable prefix, got %q", sanitized)
+	}
+}

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -21,9 +21,11 @@ import (
 	. "github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 // ClaudeCodeAPIHandler contains the handlers for Claude API endpoints.
@@ -58,6 +60,57 @@ func (h *ClaudeCodeAPIHandler) Models() []map[string]any {
 	return modelRegistry.GetAvailableModels("claude")
 }
 
+func sanitizeClaudeMessagesToolIDs(rawJSON []byte) []byte {
+	if len(rawJSON) == 0 {
+		return rawJSON
+	}
+	messages := gjson.GetBytes(rawJSON, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return rawJSON
+	}
+	toolIDMap := make(map[string]string)
+	updated := rawJSON
+	messages.ForEach(func(msgIdx, msg gjson.Result) bool {
+		content := msg.Get("content")
+		if !content.Exists() || !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(contentIdx, part gjson.Result) bool {
+			typ := part.Get("type").String()
+			switch typ {
+			case "tool_use":
+				id := part.Get("id").String()
+				if id == "" {
+					return true
+				}
+				sanitized := util.SanitizeClaudeToolID(id)
+				toolIDMap[id] = sanitized
+				if sanitized != id {
+					path := fmt.Sprintf("messages.%d.content.%d.id", msgIdx.Int(), contentIdx.Int())
+					updated, _ = sjson.SetBytes(updated, path, sanitized)
+				}
+			case "tool_result":
+				id := part.Get("tool_use_id").String()
+				if id == "" {
+					return true
+				}
+				sanitized, ok := toolIDMap[id]
+				if !ok {
+					sanitized = util.SanitizeClaudeToolID(id)
+					toolIDMap[id] = sanitized
+				}
+				if sanitized != id {
+					path := fmt.Sprintf("messages.%d.content.%d.tool_use_id", msgIdx.Int(), contentIdx.Int())
+					updated, _ = sjson.SetBytes(updated, path, sanitized)
+				}
+			}
+			return true
+		})
+		return true
+	})
+	return updated
+}
+
 // ClaudeMessages handles Claude-compatible streaming chat completions.
 // This function implements a sophisticated client rotation and quota management system
 // to ensure high availability and optimal resource utilization across multiple backend clients.
@@ -77,6 +130,8 @@ func (h *ClaudeCodeAPIHandler) ClaudeMessages(c *gin.Context) {
 		})
 		return
 	}
+
+	rawJSON = sanitizeClaudeMessagesToolIDs(rawJSON)
 
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")

--- a/sdk/api/handlers/claude/code_handlers_test.go
+++ b/sdk/api/handlers/claude/code_handlers_test.go
@@ -1,0 +1,116 @@
+package claude
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/tidwall/gjson"
+)
+
+type claudeMessagesCaptureExecutor struct {
+	mu      sync.Mutex
+	payload []byte
+}
+
+func (e *claudeMessagesCaptureExecutor) Identifier() string { return "test-provider" }
+
+func (e *claudeMessagesCaptureExecutor) Execute(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (coreexecutor.Response, error) {
+	e.mu.Lock()
+	e.payload = bytes.Clone(req.Payload)
+	e.mu.Unlock()
+	return coreexecutor.Response{Payload: []byte(`{"type":"message","content":[]}`)}, nil
+}
+
+func (e *claudeMessagesCaptureExecutor) ExecuteStream(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.payload = bytes.Clone(req.Payload)
+	e.mu.Unlock()
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: message_stop\ndata: {}\n\n")}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *claudeMessagesCaptureExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *claudeMessagesCaptureExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *claudeMessagesCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestClaudeMessagesRewritesLongCallIDsBeforeUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &claudeMessagesCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "auth-claude", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "claude-test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewClaudeCodeAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/messages", h.ClaudeMessages)
+
+	longCallID := "mcp__synthpilot__connect_hardware_server-1776264133559318385-226896"
+	if len(longCallID) <= 64 {
+		t.Fatalf("test setup error: longCallID len = %d, want > 64", len(longCallID))
+	}
+	body := `{"model":"claude-test-model","stream":false,"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"` + longCallID + `","name":"mcp__synthpilot__connect_hardware_server","input":{}},{"type":"tool_result","tool_use_id":"` + longCallID + `","content":"ok"}]}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	executor.mu.Lock()
+	captured := bytes.Clone(executor.payload)
+	executor.mu.Unlock()
+	if len(captured) == 0 {
+		t.Fatalf("no upstream payload captured")
+	}
+	msgContent := gjson.GetBytes(captured, "messages.0.content").Array()
+	if len(msgContent) != 2 {
+		t.Fatalf("captured content len = %d, want 2: %s", len(msgContent), captured)
+	}
+	id0 := msgContent[0].Get("id").String()
+	id1 := msgContent[1].Get("tool_use_id").String()
+	if id0 == longCallID || id1 == longCallID {
+		t.Fatalf("claude messages handler left long tool id in upstream payload: %s", captured)
+	}
+	if len(id0) > 64 || len(id1) > 64 {
+		t.Fatalf("captured tool id exceeds 64 chars: %q / %q", id0, id1)
+	}
+	if id0 == "" || id1 == "" || id0 != id1 {
+		t.Fatalf("captured tool id mismatch: %q / %q", id0, id1)
+	}
+	if !strings.HasPrefix(id0, "mcp__synthpilot__connect_hardware_server_") {
+		t.Fatalf("captured tool id should keep readable tool-name prefix, got %q", id0)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2669,6 +2669,19 @@ func (m *Manager) retryAllowed(attempt int, providers []string) bool {
 	return false
 }
 
+func isTransientTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	lower := strings.ToLower(strings.TrimSpace(err.Error()))
+	return strings.Contains(lower, "unexpected eof") ||
+		strings.Contains(lower, `: eof`) ||
+		strings.Contains(lower, "transport connection broken")
+}
+
 func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []string, model string, maxWait time.Duration) (time.Duration, bool) {
 	if err == nil {
 		return 0, false
@@ -2682,6 +2695,12 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 	}
 	if isRequestInvalidError(err) {
 		return 0, false
+	}
+	if isTransientTransportError(err) {
+		if !m.retryAllowed(attempt, providers) {
+			return 0, false
+		}
+		return 0, true
 	}
 	wait, found := m.closestCooldownWait(providers, model, attempt)
 	if found {

--- a/sdk/cliproxy/auth/conductor_transient_retry_test.go
+++ b/sdk/cliproxy/auth/conductor_transient_retry_test.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type flakyEOFExecutor struct {
+	id string
+	mu sync.Mutex
+
+	calls int
+}
+
+func (e *flakyEOFExecutor) Identifier() string { return e.id }
+
+func (e *flakyEOFExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.calls++
+	if e.calls < 3 {
+		return cliproxyexecutor.Response{}, errors.New(`Post "https://chatgpt.com/backend-api/codex/responses": EOF`)
+	}
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (e *flakyEOFExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "ExecuteStream not implemented"}
+}
+
+func (e *flakyEOFExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *flakyEOFExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "CountTokens not implemented"}
+}
+
+func (e *flakyEOFExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "HttpRequest not implemented"}
+}
+
+func (e *flakyEOFExecutor) Calls() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.calls
+}
+
+func TestManagerExecute_RetriesTransientEOFTransportErrors(t *testing.T) {
+	const (
+		provider = "codex"
+		model    = "gpt-5.5"
+	)
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetRetryConfig(3, 30, 0)
+	executor := &flakyEOFExecutor{id: provider}
+	manager.RegisterExecutor(executor)
+
+	auth := &Auth{ID: "auth-eof", Provider: provider, Status: StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	manager.RefreshSchedulerEntry(auth.ID)
+
+	resp, err := manager.Execute(context.Background(), []string{provider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want success after retries", err)
+	}
+	if string(resp.Payload) != "ok" {
+		t.Fatalf("payload = %q, want ok", string(resp.Payload))
+	}
+	if got := executor.Calls(); got != 3 {
+		t.Fatalf("executor calls = %d, want 3", got)
+	}
+}


### PR DESCRIPTION
## Summary
- port the locally validated Claude/Codex compatibility fixes onto the latest upstream main baseline
- sanitize long Claude tool IDs in the shared utility and Claude handler path so paired tool_use/tool_result IDs stay aligned
- retry transient Codex upstream EOF transport failures so intermittent upstream disconnects are absorbed instead of surfacing as user-visible 500s

## Test Plan
- [x] `go test ./...`
- [x] rebuild and restart `cli-proxy-api` from the updated local main checkout
- [x] verify `/management.html` and authenticated `/v1/models` on the live runtime
- [x] verify representative Claude `/v1/messages?beta=true` requests, including a continuation/tool-result flow with a long tool ID