### PR TITLE
fix(management): preserve truncated API keys on config save

### DIFF
--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -301,6 +301,18 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	// Protect truncated API keys from being saved
+	for i := range arr {
+		if isTruncatedKey(arr[i].APIKey) && i < len(h.cfg.ClaudeKey) {
+			if h.cfg.ClaudeKey[i].APIKey != "" && !isTruncatedKey(h.cfg.ClaudeKey[i].APIKey) {
+				log.WithFields(log.Fields{
+					"handler": "PutClaudeKeys",
+					"index":   i,
+				}).Warn("detected truncated API key, preserving original from in-memory config")
+				arr[i].APIKey = h.cfg.ClaudeKey[i].APIKey
+			}
+		}
+	}
 	h.cfg.ClaudeKey = arr
 	h.cfg.SanitizeClaudeKeys()
 	h.persistLocked(c)

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1,3 +1,11 @@
+
+// isTruncatedKey checks if a string looks like a truncated/masked API key.
+// Returns true if the key contains literal "..." (three dots) which indicates
+// the management panel UI saved a masked display value instead of the real key.
+func isTruncatedKey(key string) bool {
+	return strings.Contains(key, "...")
+}
+
 package management
 
 import (
@@ -301,15 +309,23 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	// Protect truncated API keys from being saved
+	// Protect truncated API keys: match incoming keys to current config by
+	// (prefix + baseUrl) identity instead of list index, so reordering or
+	// deletion in the management panel doesn't map to wrong original keys.
 	for i := range arr {
-		if isTruncatedKey(arr[i].APIKey) && i < len(h.cfg.ClaudeKey) {
-			if h.cfg.ClaudeKey[i].APIKey != "" && !isTruncatedKey(h.cfg.ClaudeKey[i].APIKey) {
+		if !isTruncatedKey(arr[i].APIKey) {
+			continue
+		}
+		identity := arr[i].Prefix + "|" + arr[i].BaseURL
+		for j := range h.cfg.ClaudeKey {
+			candidate := h.cfg.ClaudeKey[j].Prefix + "|" + h.cfg.ClaudeKey[j].BaseURL
+			if candidate == identity && !isTruncatedKey(h.cfg.ClaudeKey[j].APIKey) && h.cfg.ClaudeKey[j].APIKey != "" {
 				log.WithFields(log.Fields{
 					"handler": "PutClaudeKeys",
-					"index":   i,
+					"prefix":  arr[i].Prefix,
 				}).Warn("detected truncated API key, preserving original from in-memory config")
-				arr[i].APIKey = h.cfg.ClaudeKey[i].APIKey
+				arr[i].APIKey = h.cfg.ClaudeKey[j].APIKey
+				break
 			}
 		}
 	}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1,11 +1,3 @@
-
-// isTruncatedKey checks if a string looks like a truncated/masked API key.
-// Returns true if the key contains literal "..." (three dots) which indicates
-// the management panel UI saved a masked display value instead of the real key.
-func isTruncatedKey(key string) bool {
-	return strings.Contains(key, "...")
-}
-
 package management
 
 import (
@@ -16,6 +8,14 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
+// isTruncatedKey checks if a string looks like a truncated/masked API key.
+// Returns true if the key contains literal "..." (three dots), which indicates
+// the management panel UI saved a masked display value instead of the real key.
+func isTruncatedKey(key string) bool {
+	return strings.Contains(key, "...")
+}
+
+
 
 // Generic helpers for list[string]
 func (h *Handler) putStringList(c *gin.Context, set func([]string), after func()) {
@@ -309,9 +309,8 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	// Protect truncated API keys: match incoming keys to current config by
-	// (prefix + baseUrl) identity instead of list index, so reordering or
-	// deletion in the management panel doesn't map to wrong original keys.
+	// Protect truncated API keys: match by (prefix + baseUrl) identity
+	// instead of list index, so reordering/deletion doesn't corrupt keys.
 	for i := range arr {
 		if !isTruncatedKey(arr[i].APIKey) {
 			continue

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"


### PR DESCRIPTION
## Description

When the management panel saves configuration (e.g. PUT /v0/management/claude-api-key), API keys that appear truncated in the UI (containing literal "..." like "sk-xxx...xxxx") can be written back to config.yaml.

This adds a defense-in-depth check: before persisting, compare incoming API key values against the current in-memory config. If an incoming key looks truncated (contains "...") and the in-memory key is full, the original is preserved.

## Testing

- Verified "..." pattern (0x2E 0x2E 0x2E) is literal in corrupted configs
- Go backend normalize/sanitize functions do NOT truncate keys
- Fix is defensive: logs warning, doesn't block save

Fixes #3819