### PR TITLE
feat: add Kimi K2.7 Code model (kimi-k2.7-code)

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1820,6 +1820,23 @@
         "zero_allowed": true,
         "dynamic_allowed": true
       }
+    },
+    {
+      "id": "kimi-k2.7-code",
+      "object": "model",
+      "created": 1780396800,
+      "owned_by": "moonshot",
+      "type": "kimi",
+      "display_name": "Kimi K2.7 Code",
+      "description": "Kimi K2.7 Code - Moonshot AI's latest coding-focused model",
+      "context_length": 262144,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "min": 1024,
+        "max": 32000,
+        "zero_allowed": false,
+        "dynamic_allowed": true
+      }
     }
   ],
   "antigravity": [


### PR DESCRIPTION
## Summary

Add support for the new **Kimi K2.7 Code** model (`kimi-k2.7-code`) from Moonshot AI.

### Changes

1. **`internal/registry/models/models.json`** — Added `kimi-k2.7-code` model entry to the `kimi` provider section with:
   - 262K context length
   - 65K max completion tokens
   - Thinking support (dynamic, 1024–32000 budget)

2. **`internal/translator/openai/openai/responses/openai_openai-responses_request_test.go`** — Added 3 test cases for `kimi-k2.7-code` mirroring the existing `kimi-k2.6` tests:
   - Merge consecutive function calls
   - Split function calls when interrupted
   - Defer message until tool output

Closes #3826