### PR TITLE
Refactor access management and introduce home access provider

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/joho/godotenv"
-	configaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/config_access"
+	accessproviders "github.com/router-for-me/CLIProxyAPI/v7/internal/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/cmd"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -552,7 +552,7 @@ func main() {
 	}
 
 	// Register built-in access providers before constructing services.
-	configaccess.Register(&cfg.SDKConfig)
+	accessproviders.RegisterBuiltInProviders(cfg)
 	pluginHost.ApplyConfig(context.Background(), cfg)
 	if pluginHost.HasTriggeredCommandLineFlags() {
 		if exitCode, handled := pluginHost.ExecuteCommandLine(context.Background(), os.Args[0], os.Args[1:], configFilePath, flag.CommandLine); handled {

--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -59,62 +59,27 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 	if len(p.keys) == 0 {
 		return nil, sdkaccess.NewNotHandledError()
 	}
-	authHeader := r.Header.Get("Authorization")
-	authHeaderGoogle := r.Header.Get("X-Goog-Api-Key")
-	authHeaderAnthropic := r.Header.Get("X-Api-Key")
-	queryKey := ""
-	queryAuthToken := ""
-	if r.URL != nil {
-		queryKey = r.URL.Query().Get("key")
-		queryAuthToken = r.URL.Query().Get("auth_token")
-	}
-	if authHeader == "" && authHeaderGoogle == "" && authHeaderAnthropic == "" && queryKey == "" && queryAuthToken == "" {
+	candidates, ok := sdkaccess.CredentialCandidatesFromRequest(r)
+	if !ok {
 		return nil, sdkaccess.NewNoCredentialsError()
 	}
 
-	apiKey := extractBearerToken(authHeader)
-
-	candidates := []struct {
-		value  string
-		source string
-	}{
-		{apiKey, "authorization"},
-		{authHeaderGoogle, "x-goog-api-key"},
-		{authHeaderAnthropic, "x-api-key"},
-		{queryKey, "query-key"},
-		{queryAuthToken, "query-auth-token"},
-	}
-
 	for _, candidate := range candidates {
-		if candidate.value == "" {
+		if candidate.Value == "" {
 			continue
 		}
-		if _, ok := p.keys[candidate.value]; ok {
+		if _, ok := p.keys[candidate.Value]; ok {
 			return &sdkaccess.Result{
 				Provider:  p.Identifier(),
-				Principal: candidate.value,
+				Principal: candidate.Value,
 				Metadata: map[string]string{
-					"source": candidate.source,
+					"source": candidate.Source,
 				},
 			}, nil
 		}
 	}
 
 	return nil, sdkaccess.NewInvalidCredentialError()
-}
-
-func extractBearerToken(header string) string {
-	if header == "" {
-		return ""
-	}
-	parts := strings.SplitN(header, " ", 2)
-	if len(parts) != 2 {
-		return header
-	}
-	if strings.ToLower(parts[0]) != "bearer" {
-		return header
-	}
-	return strings.TrimSpace(parts[1])
 }
 
 func normalizeKeys(keys []string) []string {

--- a/internal/access/home_access/provider.go
+++ b/internal/access/home_access/provider.go
@@ -1,0 +1,194 @@
+package homeaccess
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+)
+
+const (
+	ProviderTypeHome = "home-api-key"
+	providerName     = "home-api-key"
+)
+
+type accessClient interface {
+	HeartbeatOK() bool
+	ValidateAccess(ctx context.Context, headers http.Header, query url.Values) ([]byte, error)
+}
+
+type provider struct {
+	client func() accessClient
+}
+
+type validationResponse struct {
+	Authenticated bool              `json:"authenticated"`
+	Provider      string            `json:"provider"`
+	Principal     string            `json:"principal"`
+	Metadata      map[string]string `json:"metadata"`
+	Error         *validationError  `json:"error"`
+}
+
+type validationError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	Code    string `json:"code,omitempty"`
+}
+
+// Register ensures the Home-backed provider is available to the access manager.
+func Register() {
+	sdkaccess.RegisterProvider(ProviderTypeHome, NewProvider(nil))
+}
+
+// Unregister removes the Home-backed provider from the access manager registry.
+func Unregister() {
+	sdkaccess.UnregisterProvider(ProviderTypeHome)
+}
+
+// NewProvider constructs a Home-backed access provider.
+func NewProvider(client func() accessClient) sdkaccess.Provider {
+	if client == nil {
+		client = func() accessClient {
+			return home.Current()
+		}
+	}
+	return &provider{client: client}
+}
+
+func (p *provider) Identifier() string {
+	return providerName
+}
+
+func (p *provider) Authenticate(ctx context.Context, r *http.Request) (*sdkaccess.Result, *sdkaccess.AuthError) {
+	if p == nil {
+		return nil, sdkaccess.NewNotHandledError()
+	}
+	candidates, _ := sdkaccess.CredentialCandidatesFromRequest(r)
+
+	client := p.client()
+	if client == nil || !client.HeartbeatOK() {
+		return nil, sdkaccess.NewServiceUnavailableAuthError("Home control center unavailable", nil)
+	}
+
+	raw, errValidate := client.ValidateAccess(ctx, credentialHeadersFromRequest(r), credentialQueryFromRequest(r))
+	if errValidate != nil {
+		return nil, sdkaccess.NewServiceUnavailableAuthError("Home authentication unavailable", errValidate)
+	}
+
+	resp, authErr := parseValidationResponse(raw)
+	if authErr != nil {
+		return nil, authErr
+	}
+	if !resp.Authenticated {
+		return nil, sdkaccess.NewInvalidCredentialError()
+	}
+	principal := strings.TrimSpace(resp.Principal)
+	if principal == "" {
+		return nil, sdkaccess.NewServiceUnavailableAuthError("Home returned invalid authentication payload", nil)
+	}
+	metadata := cloneMetadata(resp.Metadata)
+	if strings.TrimSpace(metadata["source"]) == "" {
+		if source := sourceForPrincipal(candidates, principal); source != "" {
+			if metadata == nil {
+				metadata = map[string]string{}
+			}
+			metadata["source"] = source
+		}
+	}
+
+	resultProvider := strings.TrimSpace(resp.Provider)
+	if resultProvider == "" {
+		resultProvider = p.Identifier()
+	}
+	return &sdkaccess.Result{
+		Provider:  resultProvider,
+		Principal: principal,
+		Metadata:  metadata,
+	}, nil
+}
+
+func parseValidationResponse(raw []byte) (*validationResponse, *sdkaccess.AuthError) {
+	if len(raw) == 0 {
+		return nil, sdkaccess.NewServiceUnavailableAuthError("Home returned empty authentication payload", nil)
+	}
+	var resp validationResponse
+	if errUnmarshal := json.Unmarshal(raw, &resp); errUnmarshal != nil {
+		return nil, sdkaccess.NewServiceUnavailableAuthError("Home returned invalid authentication payload", errUnmarshal)
+	}
+	if resp.Error == nil {
+		return &resp, nil
+	}
+
+	code := strings.TrimSpace(resp.Error.Type)
+	if code == "" {
+		code = strings.TrimSpace(resp.Error.Code)
+	}
+	message := strings.TrimSpace(resp.Error.Message)
+	switch strings.ToLower(code) {
+	case string(sdkaccess.AuthErrorCodeNoCredentials):
+		return nil, sdkaccess.NewNoCredentialsError()
+	case string(sdkaccess.AuthErrorCodeInvalidCredential):
+		return nil, sdkaccess.NewInvalidCredentialError()
+	default:
+		return nil, sdkaccess.NewServiceUnavailableAuthError(message, fmt.Errorf("home auth error: %s", code))
+	}
+}
+
+func credentialHeadersFromRequest(r *http.Request) http.Header {
+	headers := http.Header{}
+	if r == nil {
+		return headers
+	}
+	for _, key := range []string{"Authorization", "X-Goog-Api-Key", "X-Api-Key"} {
+		if value := r.Header.Get(key); value != "" {
+			headers.Set(key, value)
+		}
+	}
+	return headers
+}
+
+func credentialQueryFromRequest(r *http.Request) url.Values {
+	query := url.Values{}
+	if r == nil || r.URL == nil {
+		return query
+	}
+	source := r.URL.Query()
+	for _, key := range []string{"key", "auth_token"} {
+		for _, value := range source[key] {
+			query.Add(key, value)
+		}
+	}
+	return query
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = strings.TrimSpace(value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func sourceForPrincipal(candidates []sdkaccess.CredentialCandidate, principal string) string {
+	for _, candidate := range candidates {
+		if candidate.Value == principal {
+			return strings.TrimSpace(candidate.Source)
+		}
+	}
+	return ""
+}

--- a/internal/access/home_access/provider_test.go
+++ b/internal/access/home_access/provider_test.go
@@ -1,0 +1,174 @@
+package homeaccess
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+)
+
+type fakeAccessClient struct {
+	heartbeat bool
+	raw       []byte
+	err       error
+	calls     int
+	headers   http.Header
+	query     url.Values
+}
+
+func (c *fakeAccessClient) HeartbeatOK() bool {
+	return c != nil && c.heartbeat
+}
+
+func (c *fakeAccessClient) ValidateAccess(_ context.Context, headers http.Header, query url.Values) ([]byte, error) {
+	c.calls++
+	c.headers = headers.Clone()
+	c.query = cloneValues(query)
+	return c.raw, c.err
+}
+
+func TestProviderAuthenticate(t *testing.T) {
+	cases := []struct {
+		name          string
+		target        string
+		header        map[string]string
+		client        *fakeAccessClient
+		wantCode      sdkaccess.AuthErrorCode
+		wantStatus    int
+		wantPrincipal string
+		wantSource    string
+		wantCalls     int
+	}{
+		{
+			name:          "valid query key",
+			target:        "/v1/models?key=valid-client-key",
+			client:        &fakeAccessClient{heartbeat: true, raw: []byte(`{"authenticated":true,"provider":"cluster-api-key","principal":"valid-client-key","metadata":{"source":"query-key"}}`)},
+			wantPrincipal: "valid-client-key",
+			wantSource:    "query-key",
+			wantCalls:     1,
+		},
+		{
+			name:       "home invalid",
+			target:     "/v1/models",
+			header:     map[string]string{"Authorization": "Bearer invalid-client-key"},
+			client:     &fakeAccessClient{heartbeat: true, raw: []byte(`{"authenticated":false,"error":{"type":"invalid_credential","message":"Invalid API key"}}`)},
+			wantCode:   sdkaccess.AuthErrorCodeInvalidCredential,
+			wantStatus: http.StatusUnauthorized,
+			wantCalls:  1,
+		},
+		{
+			name:       "home missing",
+			target:     "/v1/models",
+			header:     map[string]string{"Authorization": "Bearer client-key"},
+			client:     &fakeAccessClient{heartbeat: true, raw: []byte(`{"authenticated":false,"error":{"type":"no_credentials","message":"Missing API key"}}`)},
+			wantCode:   sdkaccess.AuthErrorCodeNoCredentials,
+			wantStatus: http.StatusUnauthorized,
+			wantCalls:  1,
+		},
+		{
+			name:       "home unavailable",
+			target:     "/v1/models",
+			header:     map[string]string{"X-Api-Key": "client-key"},
+			client:     &fakeAccessClient{heartbeat: false},
+			wantCode:   sdkaccess.AuthErrorCodeInternal,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCalls:  0,
+		},
+		{
+			name:       "home unsupported",
+			target:     "/v1/models",
+			header:     map[string]string{"X-Api-Key": "client-key"},
+			client:     &fakeAccessClient{heartbeat: true, err: errors.New("ERR unsupported type")},
+			wantCode:   sdkaccess.AuthErrorCodeInternal,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCalls:  1,
+		},
+		{
+			name:       "home missing without credentials",
+			target:     "/v1/models",
+			client:     &fakeAccessClient{heartbeat: true, raw: []byte(`{"authenticated":false,"error":{"type":"no_credentials","message":"Missing API key"}}`)},
+			wantCode:   sdkaccess.AuthErrorCodeNoCredentials,
+			wantStatus: http.StatusUnauthorized,
+			wantCalls:  1,
+		},
+		{
+			name:       "home authenticated without principal",
+			target:     "/v1/models",
+			client:     &fakeAccessClient{heartbeat: true, raw: []byte(`{"authenticated":true,"metadata":{"source":"anonymous"}}`)},
+			wantCode:   sdkaccess.AuthErrorCodeInternal,
+			wantStatus: http.StatusServiceUnavailable,
+			wantCalls:  1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.target, nil)
+			for key, value := range tc.header {
+				req.Header.Set(key, value)
+			}
+			p := NewProvider(func() accessClient { return tc.client })
+
+			result, authErr := p.Authenticate(context.Background(), req)
+			if tc.wantCode != "" {
+				if !sdkaccess.IsAuthErrorCode(authErr, tc.wantCode) {
+					t.Fatalf("Authenticate() error = %v, want code %s", authErr, tc.wantCode)
+				}
+				if authErr.HTTPStatusCode() != tc.wantStatus {
+					t.Fatalf("HTTPStatusCode() = %d, want %d", authErr.HTTPStatusCode(), tc.wantStatus)
+				}
+			} else if authErr != nil {
+				t.Fatalf("Authenticate() error = %v", authErr)
+			}
+			if tc.wantPrincipal != "" || tc.wantSource != "" {
+				if result == nil {
+					t.Fatal("result = nil")
+				}
+				if result.Principal != tc.wantPrincipal {
+					t.Fatalf("principal = %q, want %q", result.Principal, tc.wantPrincipal)
+				}
+				if result.Metadata["source"] != tc.wantSource {
+					t.Fatalf("metadata.source = %q, want %q", result.Metadata["source"], tc.wantSource)
+				}
+			}
+			if tc.client.calls != tc.wantCalls {
+				t.Fatalf("ValidateAccess calls = %d, want %d", tc.client.calls, tc.wantCalls)
+			}
+		})
+	}
+}
+
+func TestProviderAuthenticateUsesFirstCredentialHeaderValue(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Add("Authorization", "Bearer client-key")
+	req.Header.Add("Authorization", "Bearer keep")
+	client := &fakeAccessClient{
+		heartbeat: true,
+		raw:       []byte(`{"authenticated":true,"provider":"cluster-api-key","principal":"client-key"}`),
+	}
+	p := NewProvider(func() accessClient { return client })
+
+	if _, authErr := p.Authenticate(context.Background(), req); authErr != nil {
+		t.Fatalf("Authenticate() error = %v", authErr)
+	}
+
+	values := client.headers.Values("Authorization")
+	if len(values) != 1 {
+		t.Fatalf("forwarded Authorization values = %v, want one value", values)
+	}
+	if values[0] != "Bearer client-key" {
+		t.Fatalf("forwarded Authorization = %q, want first header value", values[0])
+	}
+}
+
+func cloneValues(values url.Values) url.Values {
+	out := url.Values{}
+	for key, list := range values {
+		out[key] = append([]string(nil), list...)
+	}
+	return out
+}

--- a/internal/access/reconcile.go
+++ b/internal/access/reconcile.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 
-	configaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	log "github.com/sirupsen/logrus"
@@ -85,7 +84,7 @@ func ApplyAccessProviders(manager *sdkaccess.Manager, oldCfg, newCfg *config.Con
 	}
 
 	existing := manager.Providers()
-	configaccess.Register(&newCfg.SDKConfig)
+	RegisterBuiltInProviders(newCfg)
 	providers, added, updated, removed, err := ReconcileProviders(oldCfg, newCfg, existing)
 	if err != nil {
 		log.Errorf("failed to reconcile request auth providers: %v", err)

--- a/internal/access/register.go
+++ b/internal/access/register.go
@@ -1,0 +1,44 @@
+package access
+
+import (
+	"strings"
+
+	configaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/config_access"
+	homeaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/home_access"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+)
+
+// RegisterBuiltInProviders updates built-in access providers for the active config.
+func RegisterBuiltInProviders(cfg *config.Config) {
+	if cfg == nil {
+		configaccess.Register(nil)
+		homeaccess.Unregister()
+		sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeAnonymous)
+		return
+	}
+	configaccess.Register(&cfg.SDKConfig)
+	if cfg.Home.Enabled {
+		sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeAnonymous)
+		homeaccess.Register()
+		return
+	}
+	homeaccess.Unregister()
+	if !hasConfiguredAPIKeys(cfg) {
+		sdkaccess.RegisterProvider(sdkaccess.AccessProviderTypeAnonymous, sdkaccess.NewAnonymousProvider(sdkaccess.DefaultAnonymousProviderName))
+		return
+	}
+	sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeAnonymous)
+}
+
+func hasConfiguredAPIKeys(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, key := range cfg.SDKConfig.APIKeys {
+		if strings.TrimSpace(key) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/access/register_test.go
+++ b/internal/access/register_test.go
@@ -1,0 +1,28 @@
+package access
+
+import (
+	"testing"
+
+	homeaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/home_access"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+)
+
+func TestRegisterBuiltInProvidersHomeEnabledWithEmptyAPIKeys(t *testing.T) {
+	sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeConfigAPIKey)
+	homeaccess.Unregister()
+	t.Cleanup(func() {
+		sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeConfigAPIKey)
+		homeaccess.Unregister()
+	})
+
+	RegisterBuiltInProviders(&config.Config{Home: config.HomeConfig{Enabled: true}})
+
+	providers := sdkaccess.RegisteredProviders()
+	if len(providers) != 1 {
+		t.Fatalf("RegisteredProviders() len = %d, want 1", len(providers))
+	}
+	if providers[0].Identifier() != homeaccess.ProviderTypeHome {
+		t.Fatalf("RegisteredProviders()[0] = %q, want %q", providers[0].Identifier(), homeaccess.ProviderTypeHome)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1684,12 +1684,12 @@ func (s *Server) SetWebsocketAuthChangeHandler(fn func(bool, bool)) {
 // (management handlers moved to internal/api/handlers/management)
 
 // AuthMiddleware returns a Gin middleware handler that authenticates requests
-// using the configured authentication providers. When no providers are available,
-// it allows all requests (legacy behaviour).
+// using the configured authentication providers.
 func AuthMiddleware(manager *sdkaccess.Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if manager == nil {
-			c.Next()
+			err := sdkaccess.NewNoCredentialsError()
+			c.AbortWithStatusJSON(err.HTTPStatusCode(), gin.H{"error": err.Message})
 			return
 		}
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	gin "github.com/gin-gonic/gin"
+	homeaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/home_access"
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
@@ -90,6 +92,66 @@ func TestHealthz(t *testing.T) {
 			t.Fatalf("expected empty body for HEAD request, got %q", rr.Body.String())
 		}
 	})
+}
+
+func TestV1ModelsRejectsMissingAPIKeyWithNoAccessProviders(t *testing.T) {
+	sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeConfigAPIKey)
+	homeaccess.Unregister()
+	t.Cleanup(func() {
+		sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeConfigAPIKey)
+		homeaccess.Unregister()
+	})
+
+	gin.SetMode(gin.TestMode)
+	tmpDir := t.TempDir()
+	cfg := &proxyconfig.Config{
+		Port:          0,
+		AuthDir:       filepath.Join(tmpDir, "auth"),
+		LoggingToFile: false,
+	}
+	authManager := auth.NewManager(nil, nil, nil)
+	accessManager := sdkaccess.NewManager()
+	server := NewServer(cfg, authManager, accessManager, filepath.Join(tmpDir, "config.yaml"))
+	server.accessManager.SetProviders(nil)
+	if got := len(server.accessManager.Providers()); got != 0 {
+		t.Fatalf("access providers = %d, want 0", got)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusUnauthorized, rr.Body.String())
+	}
+}
+
+func TestStandaloneNoAPIKeysAllowsModels(t *testing.T) {
+	sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeConfigAPIKey)
+	homeaccess.Unregister()
+	t.Cleanup(func() {
+		sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeConfigAPIKey)
+		homeaccess.Unregister()
+	})
+
+	gin.SetMode(gin.TestMode)
+	tmpDir := t.TempDir()
+	cfg := &proxyconfig.Config{
+		Port:          0,
+		AuthDir:       filepath.Join(tmpDir, "auth"),
+		LoggingToFile: false,
+	}
+	authManager := auth.NewManager(nil, nil, nil)
+	accessManager := sdkaccess.NewManager()
+	server := NewServer(cfg, authManager, accessManager, filepath.Join(tmpDir, "config.yaml"))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
 }
 
 func TestManagementResponseExposesPluginSupportHeaderForCORS(t *testing.T) {
@@ -205,6 +267,95 @@ func TestManagementUsageRequiresManagementAuthAndPopsArray(t *testing.T) {
 
 	if remaining := redisqueue.PopOldest(1); len(remaining) != 0 {
 		t.Fatalf("remaining queue = %q, want empty", remaining)
+	}
+}
+
+// TestV1RoutesRejectInvalidAPIKey reproduces a real-world credential-stuffing
+// symptom: a client sends a non-configured bearer token (e.g. a leaked
+// "cli-..." key) to the OpenAI/Claude business routes. AuthMiddleware must
+// reject every /v1 route with 401 before any upstream call happens. If any of
+// these routes returns 502, AuthMiddleware is being bypassed and the request
+// reaches an upstream that re-authenticates it.
+func TestV1RoutesRejectInvalidAPIKey(t *testing.T) {
+	server := newTestServer(t)
+
+	// Sanity check: confirm the configured provider actually loaded into the
+	// manager, so a failure here is not just an empty-provider-list pass-through.
+	providers := server.accessManager.Providers()
+	if len(providers) == 0 {
+		t.Fatalf("access manager has no providers registered; invalid-key rejection requires the configured provider")
+	}
+	t.Logf("registered access providers: %d", len(providers))
+
+	cases := []struct {
+		name       string
+		method     string
+		path       string
+		body       string
+		authHeader string // full Authorization header value
+	}{
+		{
+			name:       "v1/responses POST with leaked cli- key",
+			method:     http.MethodPost,
+			path:       "/v1/responses",
+			body:       `{"model":"gpt-5.4","input":"你是谁？","max_output_tokens":256,"stream":true}`,
+			authHeader: "Bearer cli-ENiyNotARealKeyDeadbeef1234",
+		},
+		{
+			name:       "v1/chat/completions POST with leaked cli- key",
+			method:     http.MethodPost,
+			path:       "/v1/chat/completions",
+			body:       `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`,
+			authHeader: "Bearer cli-ENiyNotARealKeyDeadbeef1234",
+		},
+		{
+			name:       "v1/messages POST with leaked cli- key (Claude route)",
+			method:     http.MethodPost,
+			path:       "/v1/messages",
+			body:       `{"model":"claude-3-5-sonnet","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`,
+			authHeader: "Bearer cli-ENiyNotARealKeyDeadbeef1234",
+		},
+		{
+			name:       "v1/models GET with leaked cli- key",
+			method:     http.MethodGet,
+			path:       "/v1/models",
+			body:       "",
+			authHeader: "Bearer cli-ENiyNotARealKeyDeadbeef1234",
+		},
+		{
+			name:       "v1beta Gemini route with key= query param",
+			method:     http.MethodPost,
+			path:       "/v1beta/models/gemini-pro:generateContent?key=ABC-not-real-3456",
+			body:       `{"contents":[{"parts":[{"text":"hi"}]}]}`,
+			authHeader: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body *strings.Reader
+			if tc.body != "" {
+				body = strings.NewReader(tc.body)
+			}
+			var bodyReader io.Reader
+			if body != nil {
+				bodyReader = body
+			}
+			req := httptest.NewRequest(tc.method, tc.path, bodyReader)
+			req.Header.Set("Content-Type", "application/json")
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			rr := httptest.NewRecorder()
+			server.engine.ServeHTTP(rr, req)
+
+			t.Logf("path=%s status=%d body=%s", tc.path, rr.Code, rr.Body.String())
+
+			if rr.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want %d (AuthMiddleware should reject an invalid bearer before any upstream call); body=%s",
+					rr.Code, http.StatusUnauthorized, rr.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strconv"
@@ -568,6 +569,60 @@ func newAuthDispatchRequest(requestedModel string, sessionID string, headers htt
 		SessionID: strings.TrimSpace(sessionID),
 		Headers:   headersToLowerMap(headers),
 	}
+}
+
+func queryToLowerMap(query url.Values) map[string]string {
+	if len(query) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(query))
+	for key, values := range query {
+		k := strings.ToLower(strings.TrimSpace(key))
+		if k == "" {
+			continue
+		}
+		if len(values) == 0 {
+			out[k] = ""
+			continue
+		}
+		out[k] = strings.TrimSpace(values[0])
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func newAccessAuthRequest(headers http.Header, query url.Values) accessAuthRequest {
+	return accessAuthRequest{
+		Type:    "auth-validate",
+		Headers: headersToLowerMap(headers),
+		Query:   queryToLowerMap(query),
+	}
+}
+
+func (c *Client) ValidateAccess(ctx context.Context, headers http.Header, query url.Values) ([]byte, error) {
+	cmd, errClient := c.commandClient()
+	if errClient != nil {
+		return nil, errClient
+	}
+	req := newAccessAuthRequest(headers, query)
+	keyBytes, err := json.Marshal(&req)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := cmd.RPop(ctx, string(keyBytes)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrAuthNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return nil, ErrEmptyResponse
+	}
+	return raw, nil
 }
 
 func (c *Client) RPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int) ([]byte, error) {

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -32,6 +33,20 @@ func TestAuthDispatchRequestDefaultsCountToOne(t *testing.T) {
 
 	if req.Count != 1 {
 		t.Fatalf("count = %d, want 1", req.Count)
+	}
+}
+
+func TestAccessAuthRequestUsesFirstQueryCredentialValue(t *testing.T) {
+	req := newAccessAuthRequest(nil, url.Values{
+		"key":        {"client-key", "keep"},
+		"auth_token": {"auth-client-key", "auth-keep"},
+	})
+
+	if got := req.Query["key"]; got != "client-key" {
+		t.Fatalf("query key = %q, want client-key", got)
+	}
+	if got := req.Query["auth_token"]; got != "auth-client-key" {
+		t.Fatalf("query auth_token = %q, want auth-client-key", got)
 	}
 }
 

--- a/internal/home/requests.go
+++ b/internal/home/requests.go
@@ -8,6 +8,12 @@ type authDispatchRequest struct {
 	Headers   map[string]string `json:"headers,omitempty"`
 }
 
+type accessAuthRequest struct {
+	Type    string            `json:"type"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Query   map[string]string `json:"query,omitempty"`
+}
+
 type refreshRequest struct {
 	Type      string `json:"type"`
 	AuthIndex string `json:"auth_index"`

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -2196,6 +2196,39 @@ func TestRegisterFrontendAuthProvidersPrunesStaleKeys(t *testing.T) {
 	}
 }
 
+func TestRegisterFrontendAuthProvidersTakesPrecedenceOverAnonymousFallback(t *testing.T) {
+	const key = "plugin:auth-active:custom-auth"
+	sdkaccess.UnregisterProvider(key)
+	sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeAnonymous)
+	sdkaccess.ClearExclusiveProvider()
+	defer sdkaccess.UnregisterProvider(key)
+	defer sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeAnonymous)
+	defer sdkaccess.ClearExclusiveProvider()
+
+	sdkaccess.RegisterProvider(sdkaccess.AccessProviderTypeAnonymous, sdkaccess.NewAnonymousProvider(sdkaccess.DefaultAnonymousProviderName))
+	host := newHostWithRecords(capabilityRecord{
+		id: "auth-active",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			FrontendAuthProvider: frontendAuthProviderFunc{
+				identifier: "custom-auth",
+				authenticate: func(ctx context.Context, req pluginapi.FrontendAuthRequest) (pluginapi.FrontendAuthResponse, error) {
+					return pluginapi.FrontendAuthResponse{Authenticated: true}, nil
+				},
+			},
+		}},
+	})
+
+	host.RegisterFrontendAuthProviders()
+
+	providers := sdkaccess.RegisteredProviders()
+	if len(providers) != 1 {
+		t.Fatalf("RegisteredProviders() len = %d, want 1", len(providers))
+	}
+	if providers[0].Identifier() != key {
+		t.Fatalf("RegisteredProviders()[0] = %q, want %q", providers[0].Identifier(), key)
+	}
+}
+
 func TestRegisterFrontendAuthProvidersIdentifierPanicFusesPlugin(t *testing.T) {
 	host := newHostWithRecords(capabilityRecord{
 		id: "auth-identifier-panic",

--- a/sdk/access/anonymous.go
+++ b/sdk/access/anonymous.go
@@ -1,0 +1,31 @@
+package access
+
+import (
+	"context"
+	"net/http"
+)
+
+// NewAnonymousProvider constructs a provider that explicitly allows requests.
+func NewAnonymousProvider(name string) Provider {
+	return anonymousProvider{name: name}
+}
+
+type anonymousProvider struct {
+	name string
+}
+
+func (p anonymousProvider) Identifier() string {
+	if p.name == "" {
+		return "anonymous"
+	}
+	return p.name
+}
+
+func (p anonymousProvider) Authenticate(_ context.Context, _ *http.Request) (*Result, *AuthError) {
+	return &Result{
+		Provider: p.Identifier(),
+		Metadata: map[string]string{
+			"source": "anonymous",
+		},
+	}, nil
+}

--- a/sdk/access/credentials.go
+++ b/sdk/access/credentials.go
@@ -1,0 +1,56 @@
+package access
+
+import (
+	"net/http"
+	"strings"
+)
+
+// CredentialCandidate is one API-key credential extracted from a request.
+type CredentialCandidate struct {
+	Value  string
+	Source string
+}
+
+// CredentialCandidatesFromRequest extracts API-key credentials in provider order.
+func CredentialCandidatesFromRequest(r *http.Request) ([]CredentialCandidate, bool) {
+	if r == nil {
+		return nil, false
+	}
+
+	authHeader := r.Header.Get("Authorization")
+	authHeaderGoogle := r.Header.Get("X-Goog-Api-Key")
+	authHeaderAnthropic := r.Header.Get("X-Api-Key")
+	queryKey := ""
+	queryAuthToken := ""
+	if r.URL != nil {
+		queryKey = r.URL.Query().Get("key")
+		queryAuthToken = r.URL.Query().Get("auth_token")
+	}
+	if authHeader == "" && authHeaderGoogle == "" && authHeaderAnthropic == "" && queryKey == "" && queryAuthToken == "" {
+		return nil, false
+	}
+
+	candidates := []CredentialCandidate{
+		{Value: extractBearerToken(authHeader), Source: "authorization"},
+		{Value: strings.TrimSpace(authHeaderGoogle), Source: "x-goog-api-key"},
+		{Value: strings.TrimSpace(authHeaderAnthropic), Source: "x-api-key"},
+		{Value: strings.TrimSpace(queryKey), Source: "query-key"},
+		{Value: strings.TrimSpace(queryAuthToken), Source: "query-auth-token"},
+	}
+	return candidates, true
+}
+
+func extractBearerToken(header string) string {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return ""
+	}
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 {
+		return header
+	}
+	if strings.ToLower(parts[0]) != "bearer" {
+		return header
+	}
+	return strings.TrimSpace(parts[1])
+}

--- a/sdk/access/errors.go
+++ b/sdk/access/errors.go
@@ -82,6 +82,14 @@ func NewInternalAuthError(message string, cause error) *AuthError {
 	return newAuthError(AuthErrorCodeInternal, normalizedMessage, http.StatusInternalServerError, cause)
 }
 
+func NewServiceUnavailableAuthError(message string, cause error) *AuthError {
+	normalizedMessage := strings.TrimSpace(message)
+	if normalizedMessage == "" {
+		normalizedMessage = "Authentication service unavailable"
+	}
+	return newAuthError(AuthErrorCodeInternal, normalizedMessage, http.StatusServiceUnavailable, cause)
+}
+
 func IsAuthErrorCode(authErr *AuthError, code AuthErrorCode) bool {
 	if authErr == nil {
 		return false

--- a/sdk/access/manager.go
+++ b/sdk/access/manager.go
@@ -44,11 +44,11 @@ func (m *Manager) Providers() []Provider {
 // Authenticate evaluates providers until one succeeds.
 func (m *Manager) Authenticate(ctx context.Context, r *http.Request) (*Result, *AuthError) {
 	if m == nil {
-		return nil, nil
+		return nil, NewNoCredentialsError()
 	}
 	providers := m.Providers()
 	if len(providers) == 0 {
-		return nil, nil
+		return nil, NewNoCredentialsError()
 	}
 
 	var (

--- a/sdk/access/manager_test.go
+++ b/sdk/access/manager_test.go
@@ -1,0 +1,16 @@
+package access
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestManagerAuthenticateFailClosedWithoutProviders(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	_, authErr := NewManager().Authenticate(context.Background(), req)
+	if !IsAuthErrorCode(authErr, AuthErrorCodeNoCredentials) {
+		t.Fatalf("Authenticate() error = %v, want no credentials", authErr)
+	}
+}

--- a/sdk/access/registry.go
+++ b/sdk/access/registry.go
@@ -93,13 +93,21 @@ func RegisteredProviders() []Provider {
 		}
 	}
 	providers := make([]Provider, 0, len(order))
+	var anonymous Provider
 	for _, providerType := range order {
 		provider, exists := registry[providerType]
 		if !exists || provider == nil {
 			continue
 		}
+		if providerType == AccessProviderTypeAnonymous {
+			anonymous = provider
+			continue
+		}
 		providers = append(providers, provider)
 	}
 	registryMu.RUnlock()
+	if len(providers) == 0 && anonymous != nil {
+		return []Provider{anonymous}
+	}
 	return providers
 }

--- a/sdk/access/registry_test.go
+++ b/sdk/access/registry_test.go
@@ -79,3 +79,32 @@ func TestRegisteredProvidersIgnoresStaleExclusiveProvider(t *testing.T) {
 		t.Fatalf("RegisteredProviders()[0] = %q, want test-a", providers[0].Identifier())
 	}
 }
+
+func TestRegisteredProvidersUsesAnonymousOnlyAsFallback(t *testing.T) {
+	UnregisterProvider("test-a")
+	UnregisterProvider(AccessProviderTypeAnonymous)
+	ClearExclusiveProvider()
+	defer UnregisterProvider("test-a")
+	defer UnregisterProvider(AccessProviderTypeAnonymous)
+	defer ClearExclusiveProvider()
+
+	RegisterProvider(AccessProviderTypeAnonymous, NewAnonymousProvider(DefaultAnonymousProviderName))
+
+	providers := RegisteredProviders()
+	if len(providers) != 1 {
+		t.Fatalf("RegisteredProviders() len = %d, want 1", len(providers))
+	}
+	if providers[0].Identifier() != DefaultAnonymousProviderName {
+		t.Fatalf("RegisteredProviders()[0] = %q, want %q", providers[0].Identifier(), DefaultAnonymousProviderName)
+	}
+
+	RegisterProvider("test-a", testProvider{id: "test-a"})
+
+	providers = RegisteredProviders()
+	if len(providers) != 1 {
+		t.Fatalf("RegisteredProviders() len = %d, want 1", len(providers))
+	}
+	if providers[0].Identifier() != "test-a" {
+		t.Fatalf("RegisteredProviders()[0] = %q, want test-a", providers[0].Identifier())
+	}
+}

--- a/sdk/access/types.go
+++ b/sdk/access/types.go
@@ -30,6 +30,12 @@ const (
 
 	// DefaultAccessProviderName is applied when no provider name is supplied.
 	DefaultAccessProviderName = "config-inline"
+
+	// AccessProviderTypeAnonymous explicitly preserves open access when no local API keys are configured.
+	AccessProviderTypeAnonymous = "anonymous"
+
+	// DefaultAnonymousProviderName is applied to the built-in anonymous provider.
+	DefaultAnonymousProviderName = "anonymous"
 )
 
 // MakeInlineAPIKeyProvider constructs an inline API key provider configuration.

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	configaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/config_access"
+	accessproviders "github.com/router-for-me/CLIProxyAPI/v7/internal/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/api"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher"
@@ -213,7 +213,7 @@ func (b *Builder) Build() (*Service, error) {
 		accessManager = sdkaccess.NewManager()
 	}
 
-	configaccess.Register(&b.cfg.SDKConfig)
+	accessproviders.RegisterBuiltInProviders(b.cfg)
 	pluginHost := b.pluginHost
 	if pluginHost == nil {
 		pluginHost = pluginhost.New()


### PR DESCRIPTION
- Moved access provider registration logic to a new package for better organization.
- Implemented a home access provider to handle authentication via home API keys.
- Updated existing authentication logic to utilize new credential extraction methods.
- Enhanced error handling for service availability and invalid credentials.
- Added tests for new home access provider and refactored existing tests for clarity.
- Introduced anonymous access provider to allow open access when no API keys are configured.