### PR TITLE
fix(management): preserve auth metadata and Codex priority on save

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1214,8 +1214,11 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 	}
 
 	var req struct {
-		Name     string `json:"name"`
-		Disabled *bool  `json:"disabled"`
+		Name     string         `json:"name"`
+		Disabled *bool          `json:"disabled"`
+		Metadata map[string]any `json:"metadata"`
+		Type     string         `json:"type"`
+		Provider string         `json:"provider"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -1253,8 +1256,17 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 		return
 	}
 
+	if err := h.mergeAuthFileStatusMetadata(targetAuth, req.Metadata, req.Type, req.Provider); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to merge auth metadata: %v", err)})
+		return
+	}
+
 	// Update disabled state
 	targetAuth.Disabled = *req.Disabled
+	if targetAuth.Metadata == nil {
+		targetAuth.Metadata = make(map[string]any)
+	}
+	targetAuth.Metadata["disabled"] = *req.Disabled
 	if *req.Disabled {
 		targetAuth.Status = coreauth.StatusDisabled
 		targetAuth.StatusMessage = "disabled via management API"
@@ -1270,6 +1282,84 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "disabled": *req.Disabled})
+}
+
+func (h *Handler) mergeAuthFileStatusMetadata(auth *coreauth.Auth, requestMetadata map[string]any, requestType, requestProvider string) error {
+	if auth == nil {
+		return nil
+	}
+	merged := make(map[string]any)
+	diskFound := false
+	if diskMetadata, errRead := h.readAuthMetadataForStatusPatch(auth); errRead == nil {
+		for key, value := range diskMetadata {
+			merged[key] = value
+		}
+		diskFound = true
+	} else if !errors.Is(errRead, os.ErrNotExist) {
+		return errRead
+	}
+	if !diskFound {
+		for key, value := range auth.Metadata {
+			merged[key] = value
+		}
+	}
+	for key, value := range requestMetadata {
+		merged[key] = value
+	}
+
+	provider := strings.TrimSpace(requestType)
+	if provider == "" {
+		provider = strings.TrimSpace(requestProvider)
+	}
+	if provider == "" {
+		provider = strings.TrimSpace(valueAsString(merged["type"]))
+	}
+	if provider == "" {
+		provider = strings.TrimSpace(auth.Provider)
+	}
+	if provider != "" && !strings.EqualFold(provider, "unknown") {
+		merged["type"] = provider
+		auth.Provider = provider
+	}
+	auth.Metadata = merged
+	return nil
+}
+
+func (h *Handler) readAuthMetadataForStatusPatch(auth *coreauth.Auth) (map[string]any, error) {
+	path := strings.TrimSpace(authAttribute(auth, "path"))
+	if path == "" {
+		path = strings.TrimSpace(authAttribute(auth, "source"))
+	}
+	if path == "" {
+		fileName := strings.TrimSpace(auth.FileName)
+		if fileName == "" {
+			fileName = strings.TrimSpace(auth.ID)
+		}
+		if fileName != "" && h != nil && h.cfg != nil {
+			authDir := strings.TrimSpace(h.cfg.AuthDir)
+			if resolvedAuthDir, errResolve := util.ResolveAuthDir(authDir); errResolve == nil && resolvedAuthDir != "" {
+				authDir = resolvedAuthDir
+			}
+			if authDir != "" {
+				path = filepath.Join(authDir, fileName)
+			}
+		}
+	}
+	if path == "" {
+		return nil, os.ErrNotExist
+	}
+	raw, errRead := os.ReadFile(path)
+	if errRead != nil {
+		return nil, errRead
+	}
+	if len(raw) == 0 {
+		return nil, os.ErrNotExist
+	}
+	metadata := make(map[string]any)
+	if errUnmarshal := json.Unmarshal(raw, &metadata); errUnmarshal != nil {
+		return nil, errUnmarshal
+	}
+	return metadata, nil
 }
 
 // PatchAuthFileFields updates arbitrary metadata fields of an auth file.

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1288,20 +1288,19 @@ func (h *Handler) mergeAuthFileStatusMetadata(auth *coreauth.Auth, requestMetada
 	if auth == nil {
 		return nil
 	}
+	// Layer the sources so later ones win: on-disk metadata (the persisted
+	// baseline) is overlaid by in-memory updates (e.g. a token refresh not yet
+	// flushed), then by the explicit request metadata.
 	merged := make(map[string]any)
-	diskFound := false
 	if diskMetadata, errRead := h.readAuthMetadataForStatusPatch(auth); errRead == nil {
 		for key, value := range diskMetadata {
 			merged[key] = value
 		}
-		diskFound = true
 	} else if !errors.Is(errRead, os.ErrNotExist) {
 		return errRead
 	}
-	if !diskFound {
-		for key, value := range auth.Metadata {
-			merged[key] = value
-		}
+	for key, value := range auth.Metadata {
+		merged[key] = value
 	}
 	for key, value := range requestMetadata {
 		merged[key] = value

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1321,6 +1321,11 @@ func (h *Handler) mergeAuthFileStatusMetadata(auth *coreauth.Auth, requestMetada
 		auth.Provider = provider
 	}
 	auth.Metadata = merged
+	// The scheduler derives priority from Attributes["priority"], not Metadata,
+	// so mirror the merged priority into attributes. Otherwise a re-enabled
+	// account whose in-memory attributes lacked the priority would be scheduled
+	// at priority 0 until the next reload.
+	syncAuthFilePriorityAttribute(auth)
 	return nil
 }
 

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1321,11 +1321,19 @@ func (h *Handler) mergeAuthFileStatusMetadata(auth *coreauth.Auth, requestMetada
 		auth.Provider = provider
 	}
 	auth.Metadata = merged
-	// The scheduler derives priority from Attributes["priority"], not Metadata,
-	// so mirror the merged priority into attributes. Otherwise a re-enabled
-	// account whose in-memory attributes lacked the priority would be scheduled
-	// at priority 0 until the next reload.
-	syncAuthFilePriorityAttribute(auth)
+	// Mirror the merged metadata into the runtime fields/attributes the
+	// executors and scheduler read (custom headers, proxy_url, prefix,
+	// priority, note, websockets). Without this, re-enabling a partially-loaded
+	// auth would republish it missing its configured headers/proxy/priority
+	// until a later file reload. Disabled state is handled by the caller.
+	syncAuthFileMetadataFields(auth, map[string]struct{}{
+		"prefix":     {},
+		"proxy_url":  {},
+		"headers":    {},
+		"priority":   {},
+		"note":       {},
+		"websockets": {},
+	})
 	return nil
 }
 

--- a/internal/api/handlers/management/auth_files_patch_fields_test.go
+++ b/internal/api/handlers/management/auth_files_patch_fields_test.go
@@ -280,3 +280,65 @@ func TestPatchAuthFileFields_ArbitraryFieldsPersistToFile(t *testing.T) {
 		t.Fatalf("fgh.ijk = %#v, want true", got)
 	}
 }
+
+// Regression: clearing all custom headers via a fields patch must persist to
+// disk. Previously the file token store re-merged on-disk metadata on save,
+// which resurrected the just-removed "headers" key after the write.
+func TestPatchAuthFileFields_ClearingHeadersPersistsToDisk(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	fileName := "codex.json"
+	filePath := filepath.Join(authDir, fileName)
+
+	store := fileauth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	manager := coreauth.NewManager(store, nil, nil)
+	// Register with the full metadata the manager would hold after loading the
+	// file from disk, including the access token and the custom header.
+	record := &coreauth.Auth{
+		ID:         fileName,
+		FileName:   fileName,
+		Provider:   "codex",
+		Attributes: map[string]string{"path": filePath, "header:X-Old": "old"},
+		Metadata: map[string]any{
+			"type":         "codex",
+			"access_token": "access",
+			"headers":      map[string]any{"X-Old": "old"},
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+
+	// Clear the only custom header.
+	body := `{"name":"codex.json","headers":{"X-Old":""}}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	raw, errRead := os.ReadFile(filePath)
+	if errRead != nil {
+		t.Fatalf("read auth file: %v", errRead)
+	}
+	var data map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &data); errUnmarshal != nil {
+		t.Fatalf("unmarshal auth file: %v; raw=%s", errUnmarshal, string(raw))
+	}
+	if _, ok := data["headers"]; ok {
+		t.Fatalf("headers should be removed from disk after clearing; raw=%s", string(raw))
+	}
+	if got := data["access_token"]; got != "access" {
+		t.Fatalf("access_token=%#v, want preserved access; raw=%s", got, string(raw))
+	}
+}

--- a/internal/api/handlers/management/auth_files_status_test.go
+++ b/internal/api/handlers/management/auth_files_status_test.go
@@ -1,0 +1,153 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	fileauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestPatchAuthFileStatus_MergesDiskMetadataBeforePersist(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	fileName := "codex.json"
+	filePath := filepath.Join(authDir, fileName)
+	original := `{"type":"codex","access_token":"access","refresh_token":"refresh","email":"u@example.com","nested":{"keep":true}}`
+	if errWrite := os.WriteFile(filePath, []byte(original), 0o600); errWrite != nil {
+		t.Fatalf("failed to write auth file: %v", errWrite)
+	}
+
+	store := fileauth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       fileName,
+		FileName: fileName,
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": filePath,
+		},
+		Metadata: map[string]any{
+			"name": fileName,
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+	if errWrite := os.WriteFile(filePath, []byte(original), 0o600); errWrite != nil {
+		t.Fatalf("failed to restore full auth file after registration: %v", errWrite)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/auth-files?name="+fileName, strings.NewReader(`{"name":"codex.json","disabled":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+
+	h.PatchAuthFileStatus(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	raw, errRead := os.ReadFile(filePath)
+	if errRead != nil {
+		t.Fatalf("failed to read auth file: %v", errRead)
+	}
+	var data map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &data); errUnmarshal != nil {
+		t.Fatalf("failed to unmarshal auth file: %v; raw=%s", errUnmarshal, string(raw))
+	}
+	if got := data["type"]; got != "codex" {
+		t.Fatalf("type = %#v, want codex; raw=%s", got, string(raw))
+	}
+	if got := data["access_token"]; got != "access" {
+		t.Fatalf("access_token = %#v, want preserved access; raw=%s", got, string(raw))
+	}
+	if got := data["refresh_token"]; got != "refresh" {
+		t.Fatalf("refresh_token = %#v, want preserved refresh; raw=%s", got, string(raw))
+	}
+	if got := data["disabled"]; got != true {
+		t.Fatalf("disabled = %#v, want true; raw=%s", got, string(raw))
+	}
+}
+
+func TestPatchAuthFileStatus_AcceptsMetadataAndTypeFromRequest(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	fileName := "partial.json"
+	filePath := filepath.Join(authDir, fileName)
+	if errWrite := os.WriteFile(filePath, []byte(`{"name":"partial.json"}`), 0o600); errWrite != nil {
+		t.Fatalf("failed to write auth file: %v", errWrite)
+	}
+
+	store := fileauth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       fileName,
+		FileName: fileName,
+		Provider: "unknown",
+		Attributes: map[string]string{
+			"path": filePath,
+		},
+		Metadata: map[string]any{
+			"name": fileName,
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	body := `{"name":"partial.json","disabled":false,"type":"codex","metadata":{"access_token":"access","refresh_token":"refresh","email":"u@example.com"}}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/auth-files?name="+fileName, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+
+	h.PatchAuthFileStatus(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	raw, errRead := os.ReadFile(filePath)
+	if errRead != nil {
+		t.Fatalf("failed to read auth file: %v", errRead)
+	}
+	var data map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &data); errUnmarshal != nil {
+		t.Fatalf("failed to unmarshal auth file: %v; raw=%s", errUnmarshal, string(raw))
+	}
+	if got := data["type"]; got != "codex" {
+		t.Fatalf("type = %#v, want codex; raw=%s", got, string(raw))
+	}
+	if got := data["access_token"]; got != "access" {
+		t.Fatalf("access_token = %#v, want request metadata access; raw=%s", got, string(raw))
+	}
+	if got := data["disabled"]; got != false {
+		t.Fatalf("disabled = %#v, want false; raw=%s", got, string(raw))
+	}
+
+	updated, ok := manager.GetByID(fileName)
+	if !ok || updated == nil {
+		t.Fatalf("expected updated auth")
+	}
+	if got := updated.Provider; got != "codex" {
+		t.Fatalf("updated.Provider = %q, want codex", got)
+	}
+}

--- a/internal/api/handlers/management/auth_files_status_test.go
+++ b/internal/api/handlers/management/auth_files_status_test.go
@@ -152,18 +152,18 @@ func TestPatchAuthFileStatus_AcceptsMetadataAndTypeFromRequest(t *testing.T) {
 	}
 }
 
-// Regression: re-enabling an account whose in-memory attributes lack a priority
-// must sync the priority preserved from disk into Attributes, so the scheduler
-// (which reads Attributes["priority"]) sees it immediately, not only after a
-// reload.
-func TestPatchAuthFileStatus_SyncsPriorityIntoAttributes(t *testing.T) {
+// Regression: re-enabling an account whose in-memory record is partial must
+// sync the runtime fields the executors/scheduler read (priority, proxy_url,
+// custom headers, ...) from the metadata merged off disk, not only after a
+// later file reload.
+func TestPatchAuthFileStatus_SyncsRuntimeFieldsFromMergedMetadata(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "")
 	gin.SetMode(gin.TestMode)
 
 	authDir := t.TempDir()
 	fileName := "codex.json"
 	filePath := filepath.Join(authDir, fileName)
-	original := `{"type":"codex","access_token":"access","priority":5}`
+	original := `{"type":"codex","access_token":"access","priority":5,"proxy_url":"http://proxy.local","headers":{"X-Old":"old"}}`
 	if errWrite := os.WriteFile(filePath, []byte(original), 0o600); errWrite != nil {
 		t.Fatalf("seed auth file: %v", errWrite)
 	}
@@ -171,7 +171,7 @@ func TestPatchAuthFileStatus_SyncsPriorityIntoAttributes(t *testing.T) {
 	store := fileauth.NewFileTokenStore()
 	store.SetBaseDir(authDir)
 	manager := coreauth.NewManager(store, nil, nil)
-	// In-memory record is partial: no priority in Metadata or Attributes.
+	// In-memory record is partial: no priority/proxy/headers in runtime fields.
 	record := &coreauth.Auth{
 		ID:         fileName,
 		FileName:   fileName,
@@ -204,5 +204,11 @@ func TestPatchAuthFileStatus_SyncsPriorityIntoAttributes(t *testing.T) {
 	}
 	if got := updated.Attributes["priority"]; got != "5" {
 		t.Fatalf("Attributes[priority] = %q, want \"5\" (synced for scheduler)", got)
+	}
+	if got := updated.ProxyURL; got != "http://proxy.local" {
+		t.Fatalf("ProxyURL = %q, want http://proxy.local (synced from metadata)", got)
+	}
+	if got := updated.Attributes["header:X-Old"]; got != "old" {
+		t.Fatalf("Attributes[header:X-Old] = %q, want \"old\" (custom headers synced)", got)
 	}
 }

--- a/internal/api/handlers/management/auth_files_status_test.go
+++ b/internal/api/handlers/management/auth_files_status_test.go
@@ -151,3 +151,58 @@ func TestPatchAuthFileStatus_AcceptsMetadataAndTypeFromRequest(t *testing.T) {
 		t.Fatalf("updated.Provider = %q, want codex", got)
 	}
 }
+
+// Regression: re-enabling an account whose in-memory attributes lack a priority
+// must sync the priority preserved from disk into Attributes, so the scheduler
+// (which reads Attributes["priority"]) sees it immediately, not only after a
+// reload.
+func TestPatchAuthFileStatus_SyncsPriorityIntoAttributes(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	fileName := "codex.json"
+	filePath := filepath.Join(authDir, fileName)
+	original := `{"type":"codex","access_token":"access","priority":5}`
+	if errWrite := os.WriteFile(filePath, []byte(original), 0o600); errWrite != nil {
+		t.Fatalf("seed auth file: %v", errWrite)
+	}
+
+	store := fileauth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	manager := coreauth.NewManager(store, nil, nil)
+	// In-memory record is partial: no priority in Metadata or Attributes.
+	record := &coreauth.Auth{
+		ID:         fileName,
+		FileName:   fileName,
+		Provider:   "codex",
+		Attributes: map[string]string{"path": filePath},
+		Metadata:   map[string]any{"name": fileName},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("register auth record: %v", errRegister)
+	}
+	if errWrite := os.WriteFile(filePath, []byte(original), 0o600); errWrite != nil {
+		t.Fatalf("restore seed after registration: %v", errWrite)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/auth-files?name="+fileName, strings.NewReader(`{"name":"codex.json","disabled":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileStatus(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID(fileName)
+	if !ok || updated == nil {
+		t.Fatalf("expected updated auth")
+	}
+	if got := updated.Attributes["priority"]; got != "5" {
+		t.Fatalf("Attributes[priority] = %q, want \"5\" (synced for scheduler)", got)
+	}
+}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -962,6 +962,7 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 		Models         *[]config.CodexModel `json:"models"`
 		Headers        *map[string]string   `json:"headers"`
 		ExcludedModels *[]string            `json:"excluded-models"`
+		Priority       *int                 `json:"priority"`
 	}
 	var body struct {
 		Index *int           `json:"index"`
@@ -1021,6 +1022,9 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 	}
 	if body.Value.ExcludedModels != nil {
 		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
+	}
+	if body.Value.Priority != nil {
+		entry.Priority = *body.Value.Priority
 	}
 	normalizeCodexKey(&entry)
 	h.cfg.CodexKey[targetIndex] = entry

--- a/internal/api/handlers/management/config_lists_delete_keys_test.go
+++ b/internal/api/handlers/management/config_lists_delete_keys_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -20,6 +21,35 @@ func writeTestConfigFile(t *testing.T) string {
 		t.Fatalf("failed to write test config: %v", errWrite)
 	}
 	return path
+}
+
+func TestPatchCodexKey_UpdatesPriority(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	h := &Handler{
+		cfg: &config.Config{
+			CodexKey: []config.CodexKey{
+				{APIKey: "codex-key", BaseURL: "https://api.openai.com", Priority: 1},
+			},
+		},
+		configFilePath: writeTestConfigFile(t),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := `{"match":"codex-key","value":{"priority":42}}`
+	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/codex-api-key", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PatchCodexKey(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := h.cfg.CodexKey[0].Priority; got != 42 {
+		t.Fatalf("priority = %d, want 42", got)
+	}
 }
 
 func TestDeleteGeminiKey_RequiresBaseURLWhenAPIKeyDuplicated(t *testing.T) {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -113,7 +113,7 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 			return "", err
 		}
 	case auth.Metadata != nil:
-		auth.Metadata = mergeAuthMetadataForSave(path, auth.Metadata, auth.Provider, auth.Disabled)
+		auth.Metadata = normalizeAuthMetadataForSave(auth.Metadata, auth.Provider, auth.Disabled)
 		raw, errMarshal := json.Marshal(auth.Metadata)
 		if errMarshal != nil {
 			return "", fmt.Errorf("auth filestore: marshal metadata failed: %w", errMarshal)
@@ -156,26 +156,26 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 	return path, nil
 }
 
-func mergeAuthMetadataForSave(path string, metadata map[string]any, provider string, disabled bool) map[string]any {
-	merged := make(map[string]any)
-	if existing, errRead := os.ReadFile(path); errRead == nil && len(existing) > 0 {
-		var diskMetadata map[string]any
-		if errUnmarshal := json.Unmarshal(existing, &diskMetadata); errUnmarshal == nil {
-			for key, value := range diskMetadata {
-				merged[key] = value
-			}
-		}
-	}
-	for key, value := range metadata {
-		merged[key] = value
+// normalizeAuthMetadataForSave prepares metadata for persistence without
+// reading the existing file. The store writes exactly the metadata it is
+// given (so callers that intentionally drop a key have it removed), while the
+// provider type is backfilled when missing and the disabled flag is set.
+//
+// Field preservation across a partial update is the caller's responsibility:
+// the management handlers merge on-disk metadata into the record before save
+// (see mergeAuthFileStatusMetadata). Merging here as well would resurrect keys
+// a caller intentionally deleted (e.g. clearing all custom headers).
+func normalizeAuthMetadataForSave(metadata map[string]any, provider string, disabled bool) map[string]any {
+	if metadata == nil {
+		metadata = make(map[string]any)
 	}
 	if provider = strings.TrimSpace(provider); provider != "" && !strings.EqualFold(provider, "unknown") {
-		if rawType, _ := merged["type"].(string); strings.TrimSpace(rawType) == "" || strings.EqualFold(strings.TrimSpace(rawType), "unknown") {
-			merged["type"] = provider
+		if rawType, _ := metadata["type"].(string); strings.TrimSpace(rawType) == "" || strings.EqualFold(strings.TrimSpace(rawType), "unknown") {
+			metadata["type"] = provider
 		}
 	}
-	merged["disabled"] = disabled
-	return merged
+	metadata["disabled"] = disabled
+	return metadata
 }
 
 // List enumerates all auth JSON files under the configured directory.

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -113,7 +113,7 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 			return "", err
 		}
 	case auth.Metadata != nil:
-		auth.Metadata["disabled"] = auth.Disabled
+		auth.Metadata = mergeAuthMetadataForSave(path, auth.Metadata, auth.Provider, auth.Disabled)
 		raw, errMarshal := json.Marshal(auth.Metadata)
 		if errMarshal != nil {
 			return "", fmt.Errorf("auth filestore: marshal metadata failed: %w", errMarshal)
@@ -154,6 +154,28 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 	}
 
 	return path, nil
+}
+
+func mergeAuthMetadataForSave(path string, metadata map[string]any, provider string, disabled bool) map[string]any {
+	merged := make(map[string]any)
+	if existing, errRead := os.ReadFile(path); errRead == nil && len(existing) > 0 {
+		var diskMetadata map[string]any
+		if errUnmarshal := json.Unmarshal(existing, &diskMetadata); errUnmarshal == nil {
+			for key, value := range diskMetadata {
+				merged[key] = value
+			}
+		}
+	}
+	for key, value := range metadata {
+		merged[key] = value
+	}
+	if provider = strings.TrimSpace(provider); provider != "" && !strings.EqualFold(provider, "unknown") {
+		if rawType, _ := merged["type"].(string); strings.TrimSpace(rawType) == "" || strings.EqualFold(strings.TrimSpace(rawType), "unknown") {
+			merged["type"] = provider
+		}
+	}
+	merged["disabled"] = disabled
+	return merged
 }
 
 // List enumerates all auth JSON files under the configured directory.

--- a/sdk/auth/filestore_disabled_test.go
+++ b/sdk/auth/filestore_disabled_test.go
@@ -63,11 +63,14 @@ func TestFileTokenStore_Save_DisabledPersistsFlagForTokenStorage(t *testing.T) {
 	}
 }
 
-func TestFileTokenStore_Save_MergesPartialMetadataWithExistingAuthFile(t *testing.T) {
+func TestFileTokenStore_Save_WritesMetadataVerbatim(t *testing.T) {
 	ctx := context.Background()
 	baseDir := t.TempDir()
 	path := filepath.Join(baseDir, "codex.json")
 
+	// The store must persist exactly the metadata it is handed. Field
+	// preservation across a partial update is the caller's job (the handlers
+	// merge on-disk metadata first), so the store does not re-read the file.
 	seed := `{"type":"codex","access_token":"access","refresh_token":"refresh","email":"u@example.com","disabled":false}`
 	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
 		t.Fatalf("seed auth file: %v", err)
@@ -80,7 +83,7 @@ func TestFileTokenStore_Save_MergesPartialMetadataWithExistingAuthFile(t *testin
 		Provider: "codex",
 		FileName: "codex.json",
 		Disabled: true,
-		Metadata: map[string]any{"name": "codex.json"},
+		Metadata: map[string]any{"name": "codex.json", "access_token": "access"},
 	}
 
 	if _, err := store.Save(ctx, auth); err != nil {
@@ -95,19 +98,62 @@ func TestFileTokenStore_Save_MergesPartialMetadataWithExistingAuthFile(t *testin
 	if err := json.Unmarshal(raw, &meta); err != nil {
 		t.Fatalf("unmarshal auth file: %v", err)
 	}
+	// Provided keys are written; type is backfilled; disabled reflects the auth.
 	if got := meta["type"]; got != "codex" {
 		t.Fatalf("type=%#v, want codex (raw=%s)", got, string(raw))
 	}
 	if got := meta["access_token"]; got != "access" {
-		t.Fatalf("access_token=%#v, want preserved access (raw=%s)", got, string(raw))
-	}
-	if got := meta["refresh_token"]; got != "refresh" {
-		t.Fatalf("refresh_token=%#v, want preserved refresh (raw=%s)", got, string(raw))
+		t.Fatalf("access_token=%#v, want access (raw=%s)", got, string(raw))
 	}
 	if got := meta["disabled"]; got != true {
 		t.Fatalf("disabled=%#v, want true (raw=%s)", got, string(raw))
 	}
-	if got := meta["name"]; got != "codex.json" {
-		t.Fatalf("name=%#v, want codex.json (raw=%s)", got, string(raw))
+	// Disk-only keys not in the update are NOT resurrected from disk.
+	if _, ok := meta["refresh_token"]; ok {
+		t.Fatalf("refresh_token should not be resurrected from disk (raw=%s)", string(raw))
+	}
+	if _, ok := meta["email"]; ok {
+		t.Fatalf("email should not be resurrected from disk (raw=%s)", string(raw))
+	}
+}
+
+func TestFileTokenStore_Save_DropsKeyDeletedFromUpdate(t *testing.T) {
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "codex.json")
+
+	// Regression test: a key present on disk but intentionally omitted from the
+	// update (e.g. clearing all custom headers) must not reappear after save.
+	seed := `{"type":"codex","access_token":"access","headers":{"X-Test":"1"}}`
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auth := &cliproxyauth.Auth{
+		ID:       "codex.json",
+		Provider: "codex",
+		FileName: "codex.json",
+		Metadata: map[string]any{"type": "codex", "access_token": "access"},
+	}
+
+	if _, err := store.Save(ctx, auth); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read auth file: %v", err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		t.Fatalf("unmarshal auth file: %v", err)
+	}
+	if _, ok := meta["headers"]; ok {
+		t.Fatalf("deleted 'headers' was resurrected from disk (raw=%s)", string(raw))
+	}
+	if got := meta["access_token"]; got != "access" {
+		t.Fatalf("access_token=%#v, want access (raw=%s)", got, string(raw))
 	}
 }

--- a/sdk/auth/filestore_disabled_test.go
+++ b/sdk/auth/filestore_disabled_test.go
@@ -62,3 +62,52 @@ func TestFileTokenStore_Save_DisabledPersistsFlagForTokenStorage(t *testing.T) {
 		t.Fatalf("disabled=%v, want true (raw=%s)", meta["disabled"], string(raw))
 	}
 }
+
+func TestFileTokenStore_Save_MergesPartialMetadataWithExistingAuthFile(t *testing.T) {
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "codex.json")
+
+	seed := `{"type":"codex","access_token":"access","refresh_token":"refresh","email":"u@example.com","disabled":false}`
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auth := &cliproxyauth.Auth{
+		ID:       "codex.json",
+		Provider: "codex",
+		FileName: "codex.json",
+		Disabled: true,
+		Metadata: map[string]any{"name": "codex.json"},
+	}
+
+	if _, err := store.Save(ctx, auth); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read auth file: %v", err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		t.Fatalf("unmarshal auth file: %v", err)
+	}
+	if got := meta["type"]; got != "codex" {
+		t.Fatalf("type=%#v, want codex (raw=%s)", got, string(raw))
+	}
+	if got := meta["access_token"]; got != "access" {
+		t.Fatalf("access_token=%#v, want preserved access (raw=%s)", got, string(raw))
+	}
+	if got := meta["refresh_token"]; got != "refresh" {
+		t.Fatalf("refresh_token=%#v, want preserved refresh (raw=%s)", got, string(raw))
+	}
+	if got := meta["disabled"]; got != true {
+		t.Fatalf("disabled=%#v, want true (raw=%s)", got, string(raw))
+	}
+	if got := meta["name"]; got != "codex.json" {
+		t.Fatalf("name=%#v, want codex.json (raw=%s)", got, string(raw))
+	}
+}


### PR DESCRIPTION
## Summary

When updating an auth file via the management API (status/fields patch), the save path previously serialized only the in-memory metadata payload. Any field that existed **only on disk** — and was not part of the update — was silently dropped. For Codex accounts this notably lost the account `priority` and subscription metadata on a simple enable/disable toggle.

This PR makes the save merge the existing on-disk metadata with the incoming update, so fields the caller did not send are preserved.

## Behavior

- On save, existing metadata is read from the auth file and merged under the incoming metadata (incoming wins).
- The provider `type` is backfilled only when missing/`unknown`, and the `disabled` flag is always written.
- Status/fields patches preserve unspecified metadata (including Codex `priority`) instead of overwriting the record wholesale.

## Changes

- `sdk/auth/filestore.go` — add `mergeAuthMetadataForSave(path, metadata, provider, disabled)`; the token store `Save` now merges with on-disk metadata before writing.
- `internal/api/handlers/management/auth_files.go` — `mergeAuthFileStatusMetadata` / `readAuthMetadataForStatusPatch` preserve existing metadata and Codex priority on a status patch.
- `internal/api/handlers/management/config_lists.go` — keep metadata intact on the related delete path.
- Unit tests: disabled-flag persistence, partial-metadata merge, and a regression test asserting an on-disk `priority` survives a partial-metadata save.

## Testing

- `go build ./...`
- `go test ./internal/api/handlers/management/... ./sdk/auth/...` — all pass
- `gofmt`/`go vet` clean
