### PR TITLE
fix(openai-compat): inherit static thinking support

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -46,6 +46,22 @@ func NewOpenAICompatExecutor(provider string, cfg *config.Config) *OpenAICompatE
 	return &OpenAICompatExecutor{provider: provider, cfg: cfg}
 }
 
+func openAICompatThinkingModel(requestedModel, resolvedModel string) string {
+	requestedModel = strings.TrimSpace(requestedModel)
+	if requestedModel == "" {
+		return strings.TrimSpace(resolvedModel)
+	}
+	resolvedSuffix := thinking.ParseSuffix(resolvedModel)
+	if resolvedSuffix.HasSuffix && resolvedSuffix.RawSuffix != "" {
+		requestedBase := strings.TrimSpace(thinking.ParseSuffix(requestedModel).ModelName)
+		if requestedBase == "" {
+			requestedBase = requestedModel
+		}
+		return requestedBase + "(" + resolvedSuffix.RawSuffix + ")"
+	}
+	return requestedModel
+}
+
 // Identifier implements cliproxyauth.ProviderExecutor.
 func (e *OpenAICompatExecutor) Identifier() string { return e.provider }
 
@@ -114,8 +130,9 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, opts.Stream)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, opts.Stream)
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	thinkingModel := openAICompatThinkingModel(requestedModel, req.Model)
 
-	translated, err = thinking.ApplyThinking(translated, requestedModel, from.String(), to.String(), e.Identifier())
+	translated, err = thinking.ApplyThinking(translated, thinkingModel, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -315,8 +332,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	thinkingModel := openAICompatThinkingModel(requestedModel, req.Model)
 
-	translated, err = thinking.ApplyThinking(translated, requestedModel, from.String(), to.String(), e.Identifier())
+	translated, err = thinking.ApplyThinking(translated, thinkingModel, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +604,8 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 	modelForCounting := baseModel
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
-	translated, err := thinking.ApplyThinking(translated, requestedModel, from.String(), to.String(), e.Identifier())
+	thinkingModel := openAICompatThinkingModel(requestedModel, req.Model)
+	translated, err := thinking.ApplyThinking(translated, thinkingModel, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -113,13 +113,13 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	originalPayload := originalPayloadSource
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, opts.Stream)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, opts.Stream)
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = thinking.ApplyThinking(translated, requestedModel, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
 
-	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
 	if opts.Alt == "responses/compact" {
@@ -314,13 +314,13 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	originalPayload := originalPayloadSource
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = thinking.ApplyThinking(translated, requestedModel, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
 
-	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
 
@@ -585,7 +585,8 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 
 	modelForCounting := baseModel
 
-	translated, err := thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	translated, err := thinking.ApplyThinking(translated, requestedModel, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -152,6 +152,51 @@ func TestOpenAICompatExecutorThinkingUsesRequestedAliasCapabilities(t *testing.T
 	}
 }
 
+func TestOpenAICompatExecutorThinkingPreservesResolvedSuffixForAlias(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-openai-compat-resolved-suffix-thinking", "openai-compatibility", []*registry.ModelInfo{{
+		ID:       "fast",
+		Object:   "model",
+		Type:     "openai-compatibility",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "medium", "high", "xhigh"}},
+	}})
+	t.Cleanup(func() {
+		reg.UnregisterClient("test-openai-compat-resolved-suffix-thinking")
+	})
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	payload := []byte(`{"model":"fast","messages":[{"role":"user","content":"hi"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5(xhigh)",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       false,
+		Metadata: map[string]any{
+			cliproxyexecutor.RequestedModelMetadataKey: "fast",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := gjson.GetBytes(gotBody, "reasoning_effort").String(); got != "xhigh" {
+		t.Fatalf("reasoning_effort = %q, want xhigh; body=%s", got, string(gotBody))
+	}
+}
+
 func TestOpenAICompatExecutorImagesGenerationsPassthrough(t *testing.T) {
 	var gotPath string
 	var gotBody []byte

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -103,6 +104,51 @@ func TestOpenAICompatExecutorPayloadOverrideWinsOverThinkingSuffix(t *testing.T)
 	}
 	if got := gjson.GetBytes(gotBody, "reasoning_effort").String(); got != "low" {
 		t.Fatalf("reasoning_effort = %q, want %q; body=%s", got, "low", string(gotBody))
+	}
+}
+
+func TestOpenAICompatExecutorThinkingUsesRequestedAliasCapabilities(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-openai-compat-requested-alias-thinking", "openai-compatibility", []*registry.ModelInfo{{
+		ID:       "shared-model",
+		Object:   "model",
+		Type:     "openai-compatibility",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}},
+	}})
+	t.Cleanup(func() {
+		reg.UnregisterClient("test-openai-compat-requested-alias-thinking")
+	})
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	payload := []byte(`{"model":"shared-model(xhigh)","messages":[{"role":"user","content":"hi"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5(xhigh)",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       false,
+		Metadata: map[string]any{
+			cliproxyexecutor.RequestedModelMetadataKey: "shared-model(xhigh)",
+		},
+	})
+	if err == nil {
+		t.Fatalf("Execute error = nil, want xhigh rejected for requested alias")
+	}
+	if gotBody != nil {
+		t.Fatalf("upstream received body despite invalid requested alias thinking: %s", string(gotBody))
 	}
 }
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2276,10 +2276,17 @@ func openAICompatibilityModelThinking(model config.OpenAICompatibilityModel) *re
 	}
 	if upstream := registry.LookupStaticModelInfo(strings.TrimSpace(model.Name)); upstream != nil && upstream.Thinking != nil {
 		if len(upstream.Thinking.Levels) > 0 {
-			return cloneThinkingSupport(upstream.Thinking)
+			return cloneThinkingLevels(upstream.Thinking)
 		}
 	}
 	return &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+}
+
+func cloneThinkingLevels(thinking *registry.ThinkingSupport) *registry.ThinkingSupport {
+	if thinking == nil {
+		return nil
+	}
+	return &registry.ThinkingSupport{Levels: append([]string(nil), thinking.Levels...)}
 }
 
 func cloneThinkingSupport(thinking *registry.ThinkingSupport) *registry.ThinkingSupport {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2268,13 +2268,29 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 }
 
 func openAICompatibilityModelThinking(model config.OpenAICompatibilityModel) *registry.ThinkingSupport {
-	if model.Thinking != nil || model.Image {
-		return model.Thinking
+	if model.Image {
+		return nil
+	}
+	if model.Thinking != nil {
+		return cloneThinkingSupport(model.Thinking)
 	}
 	if upstream := registry.LookupStaticModelInfo(strings.TrimSpace(model.Name)); upstream != nil && upstream.Thinking != nil {
-		return upstream.Thinking
+		if len(upstream.Thinking.Levels) > 0 {
+			return cloneThinkingSupport(upstream.Thinking)
+		}
 	}
 	return &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+}
+
+func cloneThinkingSupport(thinking *registry.ThinkingSupport) *registry.ThinkingSupport {
+	if thinking == nil {
+		return nil
+	}
+	cloned := *thinking
+	if thinking.Levels != nil {
+		cloned.Levels = append([]string(nil), thinking.Levels...)
+	}
+	return &cloned
 }
 
 func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*ModelInfo {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2237,14 +2237,18 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 	if compat == nil || len(compat.Models) == 0 {
 		return nil
 	}
+	modelCounts := make(map[string]int, len(compat.Models))
+	for i := range compat.Models {
+		if modelID := openAICompatibilityModelID(compat.Models[i]); modelID != "" {
+			modelCounts[modelID]++
+		}
+	}
+	pooledThinkingLevels := openAICompatibilityPooledThinkingLevels(compat.Models, modelCounts)
 	now := time.Now().Unix()
 	models := make([]*ModelInfo, 0, len(compat.Models))
 	for i := range compat.Models {
 		model := compat.Models[i]
-		modelID := strings.TrimSpace(model.Alias)
-		if modelID == "" {
-			modelID = strings.TrimSpace(model.Name)
-		}
+		modelID := openAICompatibilityModelID(model)
 		if modelID == "" {
 			continue
 		}
@@ -2253,6 +2257,9 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 			modelType = registry.OpenAIImageModelType
 		}
 		thinking := openAICompatibilityModelThinking(model, modelID)
+		if levels, ok := pooledThinkingLevels[modelID]; ok && !model.Image {
+			thinking = &registry.ThinkingSupport{Levels: append([]string(nil), levels...)}
+		}
 		models = append(models, &ModelInfo{
 			ID:          modelID,
 			Object:      "model",
@@ -2265,6 +2272,37 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		})
 	}
 	return models
+}
+
+func openAICompatibilityModelID(model config.OpenAICompatibilityModel) string {
+	modelID := strings.TrimSpace(model.Alias)
+	if modelID == "" {
+		modelID = strings.TrimSpace(model.Name)
+	}
+	return modelID
+}
+
+func openAICompatibilityPooledThinkingLevels(models []config.OpenAICompatibilityModel, modelCounts map[string]int) map[string][]string {
+	pooled := make(map[string][]string)
+	for i := range models {
+		model := models[i]
+		modelID := openAICompatibilityModelID(model)
+		if modelID == "" || modelCounts[modelID] <= 1 || model.Image {
+			continue
+		}
+		levels := openAICompatibilityModelThinkingLevels(model, modelID)
+		if existing, ok := pooled[modelID]; ok {
+			pooled[modelID] = intersectThinkingLevels(existing, levels)
+		} else {
+			pooled[modelID] = append([]string(nil), levels...)
+		}
+	}
+	for modelID, levels := range pooled {
+		if len(levels) == 0 {
+			pooled[modelID] = defaultOpenAICompatibilityThinkingLevels()
+		}
+	}
+	return pooled
 }
 
 func openAICompatibilityModelThinking(model config.OpenAICompatibilityModel, modelID string) *registry.ThinkingSupport {
@@ -2283,7 +2321,36 @@ func openAICompatibilityModelThinking(model config.OpenAICompatibilityModel, mod
 			return cloneThinkingLevels(upstream.Thinking)
 		}
 	}
-	return &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+	return &registry.ThinkingSupport{Levels: defaultOpenAICompatibilityThinkingLevels()}
+}
+
+func openAICompatibilityModelThinkingLevels(model config.OpenAICompatibilityModel, modelID string) []string {
+	thinking := openAICompatibilityModelThinking(model, modelID)
+	if thinking == nil || len(thinking.Levels) == 0 {
+		return defaultOpenAICompatibilityThinkingLevels()
+	}
+	return append([]string(nil), thinking.Levels...)
+}
+
+func intersectThinkingLevels(left, right []string) []string {
+	out := make([]string, 0, len(left))
+	for _, candidate := range left {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		for _, supported := range right {
+			if strings.EqualFold(candidate, strings.TrimSpace(supported)) {
+				out = append(out, candidate)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func defaultOpenAICompatibilityThinkingLevels() []string {
+	return []string{"low", "medium", "high"}
 }
 
 func cloneThinkingLevels(thinking *registry.ThinkingSupport) *registry.ThinkingSupport {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/diff"
@@ -2316,6 +2317,7 @@ func openAICompatibilityModelThinking(model config.OpenAICompatibilityModel, mod
 	if staticModelID == "" {
 		staticModelID = strings.TrimSpace(modelID)
 	}
+	staticModelID = strings.TrimSpace(thinking.ParseSuffix(staticModelID).ModelName)
 	if upstream := registry.LookupStaticModelInfo(staticModelID); upstream != nil && upstream.Thinking != nil {
 		if len(upstream.Thinking.Levels) > 0 {
 			return cloneThinkingLevels(upstream.Thinking)

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2252,7 +2252,7 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		if model.Image {
 			modelType = registry.OpenAIImageModelType
 		}
-		thinking := openAICompatibilityModelThinking(model)
+		thinking := openAICompatibilityModelThinking(model, modelID)
 		models = append(models, &ModelInfo{
 			ID:          modelID,
 			Object:      "model",
@@ -2267,14 +2267,18 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 	return models
 }
 
-func openAICompatibilityModelThinking(model config.OpenAICompatibilityModel) *registry.ThinkingSupport {
+func openAICompatibilityModelThinking(model config.OpenAICompatibilityModel, modelID string) *registry.ThinkingSupport {
 	if model.Image {
 		return nil
 	}
 	if model.Thinking != nil {
 		return cloneThinkingSupport(model.Thinking)
 	}
-	if upstream := registry.LookupStaticModelInfo(strings.TrimSpace(model.Name)); upstream != nil && upstream.Thinking != nil {
+	staticModelID := strings.TrimSpace(model.Name)
+	if staticModelID == "" {
+		staticModelID = strings.TrimSpace(modelID)
+	}
+	if upstream := registry.LookupStaticModelInfo(staticModelID); upstream != nil && upstream.Thinking != nil {
 		if len(upstream.Thinking.Levels) > 0 {
 			return cloneThinkingLevels(upstream.Thinking)
 		}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2252,10 +2252,7 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		if model.Image {
 			modelType = registry.OpenAIImageModelType
 		}
-		thinking := model.Thinking
-		if thinking == nil && !model.Image {
-			thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
-		}
+		thinking := openAICompatibilityModelThinking(model)
 		models = append(models, &ModelInfo{
 			ID:          modelID,
 			Object:      "model",
@@ -2268,6 +2265,16 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		})
 	}
 	return models
+}
+
+func openAICompatibilityModelThinking(model config.OpenAICompatibilityModel) *registry.ThinkingSupport {
+	if model.Thinking != nil || model.Image {
+		return model.Thinking
+	}
+	if upstream := registry.LookupStaticModelInfo(strings.TrimSpace(model.Name)); upstream != nil && upstream.Thinking != nil {
+		return upstream.Thinking
+	}
+	return &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
 }
 
 func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*ModelInfo {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -188,6 +188,28 @@ func TestBuildOpenAICompatibilityConfigModelsUsesDefaultThinkingForStaticBudgetO
 	}
 }
 
+func TestBuildOpenAICompatibilityConfigModelsInheritsOnlyStaticThinkingLevels(t *testing.T) {
+	staticModel := internalregistry.LookupStaticModelInfo("gemini-3.1-pro-preview")
+	if staticModel == nil || staticModel.Thinking == nil || len(staticModel.Thinking.Levels) == 0 || staticModel.Thinking.Max == 0 || !staticModel.Thinking.DynamicAllowed {
+		t.Fatal("expected static gemini-3.1-pro-preview to have hybrid thinking support")
+	}
+
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "gemini-3.1-pro-preview"},
+		},
+	})
+
+	if len(models) != 1 {
+		t.Fatalf("models length = %d, want 1", len(models))
+	}
+	requireThinkingLevels(t, models[0].Thinking, staticModel.Thinking.Levels)
+	if models[0].Thinking.Min != 0 || models[0].Thinking.Max != 0 || models[0].Thinking.DynamicAllowed || models[0].Thinking.ZeroAllowed {
+		t.Fatalf("thinking support = %+v, want levels-only static inheritance", models[0].Thinking)
+	}
+}
+
 func TestBuildOpenAICompatibilityConfigModelsUsesDefaultThinkingForUnknownModel(t *testing.T) {
 	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
 		Name: "compat",

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -166,6 +166,23 @@ func TestBuildOpenAICompatibilityConfigModelsInheritsStaticThinkingSupport(t *te
 	}
 }
 
+func TestBuildOpenAICompatibilityConfigModelsInheritsStaticThinkingSupportFromAliasOnlyModel(t *testing.T) {
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{
+			{Alias: "gpt-5.5"},
+		},
+	})
+
+	if len(models) != 1 {
+		t.Fatalf("models length = %d, want 1", len(models))
+	}
+	if models[0].ID != "gpt-5.5" {
+		t.Fatalf("model ID = %q, want gpt-5.5", models[0].ID)
+	}
+	requireThinkingLevels(t, models[0].Thinking, []string{"low", "medium", "high", "xhigh"})
+}
+
 func TestBuildOpenAICompatibilityConfigModelsUsesDefaultThinkingForStaticBudgetOnlyModel(t *testing.T) {
 	staticModel := internalregistry.LookupStaticModelInfo("gemini-2.5-pro")
 	if staticModel == nil || staticModel.Thinking == nil || len(staticModel.Thinking.Levels) > 0 || staticModel.Thinking.Max == 0 {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -136,6 +136,61 @@ func TestRegisterModelsForAuth_OpenAICompatibilityImageModelType(t *testing.T) {
 	}
 }
 
+func TestBuildOpenAICompatibilityConfigModelsInheritsStaticThinkingSupport(t *testing.T) {
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "gpt-5.5"},
+		},
+	})
+
+	if len(models) != 1 {
+		t.Fatalf("models length = %d, want 1", len(models))
+	}
+	requireThinkingLevels(t, models[0].Thinking, []string{"low", "medium", "high", "xhigh"})
+}
+
+func TestBuildOpenAICompatibilityConfigModelsUsesDefaultThinkingForUnknownModel(t *testing.T) {
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "not-a-static-model"},
+		},
+	})
+
+	if len(models) != 1 {
+		t.Fatalf("models length = %d, want 1", len(models))
+	}
+	requireThinkingLevels(t, models[0].Thinking, []string{"low", "medium", "high"})
+}
+
+func TestBuildOpenAICompatibilityConfigModelsKeepsExplicitThinkingSupport(t *testing.T) {
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{
+			{
+				Name:     "gpt-5.5",
+				Thinking: &internalregistry.ThinkingSupport{Levels: []string{"low"}},
+			},
+		},
+	})
+
+	if len(models) != 1 {
+		t.Fatalf("models length = %d, want 1", len(models))
+	}
+	requireThinkingLevels(t, models[0].Thinking, []string{"low"})
+}
+
+func requireThinkingLevels(t *testing.T, thinking *internalregistry.ThinkingSupport, want []string) {
+	t.Helper()
+	if thinking == nil {
+		t.Fatalf("thinking = nil, want levels %v", want)
+	}
+	if got := strings.Join(thinking.Levels, ","); got != strings.Join(want, ",") {
+		t.Fatalf("thinking levels = [%s], want %v", got, want)
+	}
+}
+
 func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.T) {
 	var sawFetch bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -183,6 +183,23 @@ func TestBuildOpenAICompatibilityConfigModelsInheritsStaticThinkingSupportFromAl
 	requireThinkingLevels(t, models[0].Thinking, []string{"low", "medium", "high", "xhigh"})
 }
 
+func TestBuildOpenAICompatibilityConfigModelsStripsSuffixForStaticThinkingLookup(t *testing.T) {
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "gpt-5.5(xhigh)", Alias: "fast"},
+		},
+	})
+
+	if len(models) != 1 {
+		t.Fatalf("models length = %d, want 1", len(models))
+	}
+	if models[0].ID != "fast" {
+		t.Fatalf("model ID = %q, want fast", models[0].ID)
+	}
+	requireThinkingLevels(t, models[0].Thinking, []string{"low", "medium", "high", "xhigh"})
+}
+
 func TestBuildOpenAICompatibilityConfigModelsUsesSharedThinkingForDuplicateAlias(t *testing.T) {
 	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
 		Name: "compat",

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -137,6 +137,15 @@ func TestRegisterModelsForAuth_OpenAICompatibilityImageModelType(t *testing.T) {
 }
 
 func TestBuildOpenAICompatibilityConfigModelsInheritsStaticThinkingSupport(t *testing.T) {
+	staticModel := internalregistry.LookupStaticModelInfo("gpt-5.5")
+	if staticModel == nil || staticModel.Thinking == nil {
+		t.Fatal("expected static gpt-5.5 thinking support")
+	}
+	originalLevels := append([]string(nil), staticModel.Thinking.Levels...)
+	defer func() {
+		staticModel.Thinking.Levels = originalLevels
+	}()
+
 	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
 		Name: "compat",
 		Models: []config.OpenAICompatibilityModel{
@@ -148,6 +157,35 @@ func TestBuildOpenAICompatibilityConfigModelsInheritsStaticThinkingSupport(t *te
 		t.Fatalf("models length = %d, want 1", len(models))
 	}
 	requireThinkingLevels(t, models[0].Thinking, []string{"low", "medium", "high", "xhigh"})
+	if models[0].Thinking == staticModel.Thinking {
+		t.Fatal("expected inherited thinking support to be cloned")
+	}
+	models[0].Thinking.Levels[0] = "mutated"
+	if staticModel.Thinking.Levels[0] != originalLevels[0] {
+		t.Fatal("mutating inherited thinking support should not change static registry")
+	}
+}
+
+func TestBuildOpenAICompatibilityConfigModelsUsesDefaultThinkingForStaticBudgetOnlyModel(t *testing.T) {
+	staticModel := internalregistry.LookupStaticModelInfo("gemini-2.5-pro")
+	if staticModel == nil || staticModel.Thinking == nil || len(staticModel.Thinking.Levels) > 0 || staticModel.Thinking.Max == 0 {
+		t.Fatal("expected static gemini-2.5-pro to be budget-only")
+	}
+
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "gemini-2.5-pro"},
+		},
+	})
+
+	if len(models) != 1 {
+		t.Fatalf("models length = %d, want 1", len(models))
+	}
+	requireThinkingLevels(t, models[0].Thinking, []string{"low", "medium", "high"})
+	if models[0].Thinking.Min != 0 || models[0].Thinking.Max != 0 {
+		t.Fatalf("thinking budget range = [%d,%d], want default level-only support", models[0].Thinking.Min, models[0].Thinking.Max)
+	}
 }
 
 func TestBuildOpenAICompatibilityConfigModelsUsesDefaultThinkingForUnknownModel(t *testing.T) {
@@ -165,12 +203,13 @@ func TestBuildOpenAICompatibilityConfigModelsUsesDefaultThinkingForUnknownModel(
 }
 
 func TestBuildOpenAICompatibilityConfigModelsKeepsExplicitThinkingSupport(t *testing.T) {
+	explicitThinking := &internalregistry.ThinkingSupport{Levels: []string{"low"}}
 	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
 		Name: "compat",
 		Models: []config.OpenAICompatibilityModel{
 			{
 				Name:     "gpt-5.5",
-				Thinking: &internalregistry.ThinkingSupport{Levels: []string{"low"}},
+				Thinking: explicitThinking,
 			},
 		},
 	})
@@ -179,6 +218,13 @@ func TestBuildOpenAICompatibilityConfigModelsKeepsExplicitThinkingSupport(t *tes
 		t.Fatalf("models length = %d, want 1", len(models))
 	}
 	requireThinkingLevels(t, models[0].Thinking, []string{"low"})
+	if models[0].Thinking == explicitThinking {
+		t.Fatal("expected explicit thinking support to be cloned")
+	}
+	models[0].Thinking.Levels[0] = "mutated"
+	if explicitThinking.Levels[0] != "low" {
+		t.Fatal("mutating registered thinking support should not change explicit config")
+	}
 }
 
 func requireThinkingLevels(t *testing.T, thinking *internalregistry.ThinkingSupport, want []string) {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -183,6 +183,26 @@ func TestBuildOpenAICompatibilityConfigModelsInheritsStaticThinkingSupportFromAl
 	requireThinkingLevels(t, models[0].Thinking, []string{"low", "medium", "high", "xhigh"})
 }
 
+func TestBuildOpenAICompatibilityConfigModelsUsesSharedThinkingForDuplicateAlias(t *testing.T) {
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{
+			{Name: "gpt-5.5", Alias: "shared-model"},
+			{Name: "not-a-static-model", Alias: "shared-model"},
+		},
+	})
+
+	if len(models) != 2 {
+		t.Fatalf("models length = %d, want 2", len(models))
+	}
+	for _, model := range models {
+		if model.ID != "shared-model" {
+			t.Fatalf("model ID = %q, want shared-model", model.ID)
+		}
+		requireThinkingLevels(t, model.Thinking, []string{"low", "medium", "high"})
+	}
+}
+
 func TestBuildOpenAICompatibilityConfigModelsUsesDefaultThinkingForStaticBudgetOnlyModel(t *testing.T) {
 	staticModel := internalregistry.LookupStaticModelInfo("gemini-2.5-pro")
 	if staticModel == nil || staticModel.Thinking == nil || len(staticModel.Thinking.Levels) > 0 || staticModel.Thinking.Max == 0 {


### PR DESCRIPTION
## Summary

Fix OpenAI-compatible configured models so they inherit thinking/reasoning support from the static model registry when available.

Previously, OpenAI-compatible models without explicit `thinking` config always defaulted to:

```yaml
levels: [low, medium, high]
```

That caused models such as `gpt-5.5`, which already support `xhigh` in the static registry, to reject valid Codex/Responses requests using `reasoning.effort = xhigh` before forwarding to the upstream provider.

## Changes

- Keep explicit per-model `thinking` config as the highest priority.
- Keep image models without thinking support.
- For OpenAI-compatible non-image models without explicit `thinking`, look up the static model definition by upstream model name.
- If the static model has thinking support, inherit it.
- Fall back to the existing `low/medium/high` default for unknown models.

## Why

This preserves the current conservative fallback for unknown OpenAI-compatible models, while allowing known models like `gpt-5.5` to use their declared static capabilities such as `xhigh`.

## Tests

```bash
go test -mod=readonly ./sdk/cliproxy
go test -mod=readonly ./internal/thinking ./sdk/api/handlers/openai
```