### PR TITLE
fix: suspend auth on 400 credit balance too low, allowing fill-first to try next key

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2849,6 +2849,19 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								shouldSuspendModel = true
 								setModelQuota = true
 							}
+						case 400:
+							if isInsufficientBalanceResultError(result.Error) {
+								if disableCooling {
+									state.NextRetryAfter = time.Time{}
+								} else {
+									next := now.Add(30 * time.Minute)
+									state.NextRetryAfter = next
+									suspendReason = "insufficient_balance"
+									shouldSuspendModel = true
+								}
+							} else {
+								state.NextRetryAfter = time.Time{}
+							}
 						case 408, 500, 502, 503, 504:
 							if disableCooling {
 								state.NextRetryAfter = time.Time{}
@@ -3247,6 +3260,19 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 	return isRequestScopedNotFoundMessage(err.Message)
 }
 
+// isInsufficientBalanceResultError returns true if the error indicates the
+// API key or account has insufficient credit balance to process the request.
+func isInsufficientBalanceResultError(err *Error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(err.Message))
+	return strings.Contains(lower, "credit balance") ||
+		strings.Contains(lower, "insufficient balance") ||
+		strings.Contains(lower, "balance is too low") ||
+		strings.Contains(lower, "insufficient_quota")
+}
+
 // isRequestInvalidError returns true if the error represents a client request
 // error that should not be retried. Specifically, it treats 400 responses with
 // "invalid_request_error", request-scoped 404 item misses caused by `store=false`,
@@ -3267,6 +3293,11 @@ func isRequestInvalidError(err error) bool {
 	switch status {
 	case http.StatusBadRequest:
 		msg := err.Error()
+		if strings.Contains(msg, "credit balance") ||
+			strings.Contains(msg, "insufficient balance") ||
+			strings.Contains(msg, "balance is too low") {
+			return false
+		}
 		return strings.Contains(msg, "invalid_request_error") ||
 			strings.Contains(msg, "INVALID_ARGUMENT") ||
 			strings.Contains(msg, "FAILED_PRECONDITION")

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3292,15 +3292,16 @@ func isRequestInvalidError(err error) bool {
 	status := statusCodeFromError(err)
 	switch status {
 	case http.StatusBadRequest:
-		msg := err.Error()
+		msg := strings.ToLower(err.Error())
 		if strings.Contains(msg, "credit balance") ||
 			strings.Contains(msg, "insufficient balance") ||
-			strings.Contains(msg, "balance is too low") {
+			strings.Contains(msg, "balance is too low") ||
+			strings.Contains(msg, "insufficient_quota") {
 			return false
 		}
 		return strings.Contains(msg, "invalid_request_error") ||
-			strings.Contains(msg, "INVALID_ARGUMENT") ||
-			strings.Contains(msg, "FAILED_PRECONDITION")
+			strings.Contains(msg, "invalid_argument") ||
+			strings.Contains(msg, "failed_precondition")
 	case http.StatusNotFound:
 		return isRequestScopedNotFoundMessage(err.Error())
 	case http.StatusUnprocessableEntity:


### PR DESCRIPTION
## Description

When using `fill-first` routing with multiple Claude API keys, a `400 "Your credit balance is too low"` error was never triggering auth suspension, causing the routing layer to keep selecting the same broken key and returning the error to the client — even if another configured key had sufficient balance.

### Root Cause

In `MarkResult` (`sdk/cliproxy/auth/conductor.go`), the `switch statusCode` handles 401, 402/403, 404, 429, and 5xx — but **400 fell through to `default`**, which only clears `NextRetryAfter` without suspending.

Additionally, `isRequestInvalidError` matched the "invalid_request_error" type in Anthropic's 400 response, classifying it as a request-shape failure — telling the router **not to retry** with another key.

### Changes

| File | Change |
|------|--------|
| `sdk/cliproxy/auth/conductor.go` | +31 lines |

1. **`case 400:`** in `MarkResult` — checks if the error message indicates insufficient balance via `isInsufficientBalanceResultError`. If matched, suspends the auth for 30 minutes with reason `insufficient_balance`, allowing `fill-first` to try the next key.

2. **`isInsufficientBalanceResultError`** — new helper that detects patterns: `credit balance`, `insufficient balance`, `balance is too low`, `insufficient_quota` (case-insensitive).

3. **`isRequestInvalidError`** — excludes insufficient-balance messages from the "invalid request" classification, so the routing layer attempts other keys.

### Testing

- [x] Verified `isInsufficientBalanceResultError` matches Anthropic's exact error: `Your credit balance is too low to access the Anthropic API`
- [x] 400 with other messages (e.g. invalid JSON, bad model name) still falls through to `default` (no suspension)
- [x] `isRequestInvalidError` no longer blocks retry for balance errors

Closes #3858

### Related

- ProxyPal issue: heyhuynhgiabuu/proxypal#227
- ProxyPal PR (workaround): heyhuynhgiabuu/proxypal#228
