### PR TITLE
fix: reuse uTLS roundtrippers for upstream connections

### DIFF
--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -40,6 +40,10 @@ var utlsRoundTripperCache = struct {
 	items: make(map[string]cachedUtlsRoundTripper),
 }
 
+var newUtlsTLSConfig = func(host string) *tls.Config {
+	return &tls.Config{ServerName: host}
+}
+
 func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	var dialer proxy.Dialer = proxy.Direct
 	if proxyURL != "" {
@@ -99,8 +103,7 @@ func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientCon
 		return nil, err
 	}
 
-	tlsConfig := &tls.Config{ServerName: host}
-	tlsConn := tls.UClient(conn, tlsConfig, tls.HelloChrome_Auto)
+	tlsConn := tls.UClient(conn, newUtlsTLSConfig(host), tls.HelloChrome_Auto)
 
 	if err := tlsConn.Handshake(); err != nil {
 		conn.Close()

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -57,39 +57,39 @@ func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	}
 }
 
-func (t *utlsRoundTripper) getOrCreateConnection(hostname, addr string) (*http2.ClientConn, error) {
+func (t *utlsRoundTripper) getOrCreateConnection(host, addr string) (*http2.ClientConn, error) {
 	t.mu.Lock()
 
-	if h2Conn, ok := t.connections[addr]; ok && h2Conn.CanTakeNewRequest() {
+	if h2Conn, ok := t.connections[host]; ok && h2Conn.CanTakeNewRequest() {
 		t.mu.Unlock()
 		return h2Conn, nil
 	}
 
-	if cond, ok := t.pending[addr]; ok {
+	if cond, ok := t.pending[host]; ok {
 		cond.Wait()
-		if h2Conn, ok := t.connections[addr]; ok && h2Conn.CanTakeNewRequest() {
+		if h2Conn, ok := t.connections[host]; ok && h2Conn.CanTakeNewRequest() {
 			t.mu.Unlock()
 			return h2Conn, nil
 		}
 	}
 
 	cond := sync.NewCond(&t.mu)
-	t.pending[addr] = cond
+	t.pending[host] = cond
 	t.mu.Unlock()
 
-	h2Conn, err := t.createConnection(hostname, addr)
+	h2Conn, err := t.createConnection(host, addr)
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	delete(t.pending, addr)
+	delete(t.pending, host)
 	cond.Broadcast()
 
 	if err != nil {
 		return nil, err
 	}
 
-	t.connections[addr] = h2Conn
+	t.connections[host] = h2Conn
 	return h2Conn, nil
 }
 
@@ -119,7 +119,11 @@ func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientCon
 
 func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	hostname := req.URL.Hostname()
-	addr := utlsConnectionKey(hostname, req.URL.Port())
+	port := req.URL.Port()
+	if port == "" {
+		port = "443"
+	}
+	addr := net.JoinHostPort(hostname, port)
 
 	h2Conn, err := t.getOrCreateConnection(hostname, addr)
 	if err != nil {
@@ -129,21 +133,14 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	resp, err := h2Conn.RoundTrip(req)
 	if err != nil {
 		t.mu.Lock()
-		if cached, ok := t.connections[addr]; ok && cached == h2Conn {
-			delete(t.connections, addr)
+		if cached, ok := t.connections[hostname]; ok && cached == h2Conn {
+			delete(t.connections, hostname)
 		}
 		t.mu.Unlock()
 		return nil, err
 	}
 
 	return resp, nil
-}
-
-func utlsConnectionKey(hostname, port string) string {
-	if port == "" {
-		port = "443"
-	}
-	return net.JoinHostPort(hostname, port)
 }
 
 // utlsProtectedHosts contains the hosts that should use utls Chrome TLS fingerprint

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -26,6 +26,18 @@ type utlsRoundTripper struct {
 	dialer      proxy.Dialer
 }
 
+type cachedUtlsRoundTripper struct {
+	utls     http.RoundTripper
+	fallback http.RoundTripper
+}
+
+var utlsRoundTripperCache = struct {
+	mu    sync.RWMutex
+	items map[string]cachedUtlsRoundTripper
+}{
+	items: make(map[string]cachedUtlsRoundTripper),
+}
+
 func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	var dialer proxy.Dialer = proxy.Direct
 	if proxyURL != "" {
@@ -152,6 +164,33 @@ func (f *fallbackRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 	return f.fallback.RoundTrip(req)
 }
 
+func cachedUtlsRoundTrippers(proxyURL string) cachedUtlsRoundTripper {
+	utlsRoundTripperCache.mu.RLock()
+	cached, ok := utlsRoundTripperCache.items[proxyURL]
+	utlsRoundTripperCache.mu.RUnlock()
+	if ok {
+		return cached
+	}
+
+	cached = cachedUtlsRoundTripper{
+		utls:     newUtlsRoundTripper(proxyURL),
+		fallback: http.DefaultTransport,
+	}
+	if proxyURL != "" {
+		if transport := buildProxyTransport(proxyURL); transport != nil {
+			cached.fallback = transport
+		}
+	}
+
+	utlsRoundTripperCache.mu.Lock()
+	defer utlsRoundTripperCache.mu.Unlock()
+	if existing, ok := utlsRoundTripperCache.items[proxyURL]; ok {
+		return existing
+	}
+	utlsRoundTripperCache.items[proxyURL] = cached
+	return cached
+}
+
 // NewUtlsHTTPClient creates an HTTP client using utls Chrome TLS fingerprint.
 // Use this for provider requests that need a Chrome-like TLS fingerprint.
 // Falls back to standard transport for non-HTTPS requests.
@@ -169,21 +208,20 @@ func NewUtlsHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyau
 		ctxRoundTripper, _ = ctx.Value("cliproxy.roundtripper").(http.RoundTripper)
 	}
 
-	var utlsRT http.RoundTripper = newUtlsRoundTripper(proxyURL)
-	var standardTransport http.RoundTripper = http.DefaultTransport
-	if proxyURL != "" {
-		if transport := buildProxyTransport(proxyURL); transport != nil {
-			standardTransport = transport
+	var roundTrippers cachedUtlsRoundTripper
+	if proxyURL == "" && ctxRoundTripper != nil {
+		roundTrippers = cachedUtlsRoundTripper{
+			utls:     ctxRoundTripper,
+			fallback: ctxRoundTripper,
 		}
-	} else if ctxRoundTripper != nil {
-		utlsRT = ctxRoundTripper
-		standardTransport = ctxRoundTripper
+	} else {
+		roundTrippers = cachedUtlsRoundTrippers(proxyURL)
 	}
 
 	client := &http.Client{
 		Transport: &fallbackRoundTripper{
-			utls:     utlsRT,
-			fallback: standardTransport,
+			utls:     roundTrippers.utls,
+			fallback: roundTrippers.fallback,
 		},
 	}
 	if timeout > 0 {

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -31,6 +31,8 @@ type cachedUtlsRoundTripper struct {
 	fallback http.RoundTripper
 }
 
+const maxCachedUtlsRoundTrippers = 128
+
 var utlsRoundTripperCache = struct {
 	mu    sync.RWMutex
 	items map[string]cachedUtlsRoundTripper
@@ -55,39 +57,39 @@ func newUtlsRoundTripper(proxyURL string) *utlsRoundTripper {
 	}
 }
 
-func (t *utlsRoundTripper) getOrCreateConnection(host, addr string) (*http2.ClientConn, error) {
+func (t *utlsRoundTripper) getOrCreateConnection(hostname, addr string) (*http2.ClientConn, error) {
 	t.mu.Lock()
 
-	if h2Conn, ok := t.connections[host]; ok && h2Conn.CanTakeNewRequest() {
+	if h2Conn, ok := t.connections[addr]; ok && h2Conn.CanTakeNewRequest() {
 		t.mu.Unlock()
 		return h2Conn, nil
 	}
 
-	if cond, ok := t.pending[host]; ok {
+	if cond, ok := t.pending[addr]; ok {
 		cond.Wait()
-		if h2Conn, ok := t.connections[host]; ok && h2Conn.CanTakeNewRequest() {
+		if h2Conn, ok := t.connections[addr]; ok && h2Conn.CanTakeNewRequest() {
 			t.mu.Unlock()
 			return h2Conn, nil
 		}
 	}
 
 	cond := sync.NewCond(&t.mu)
-	t.pending[host] = cond
+	t.pending[addr] = cond
 	t.mu.Unlock()
 
-	h2Conn, err := t.createConnection(host, addr)
+	h2Conn, err := t.createConnection(hostname, addr)
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	delete(t.pending, host)
+	delete(t.pending, addr)
 	cond.Broadcast()
 
 	if err != nil {
 		return nil, err
 	}
 
-	t.connections[host] = h2Conn
+	t.connections[addr] = h2Conn
 	return h2Conn, nil
 }
 
@@ -117,11 +119,7 @@ func (t *utlsRoundTripper) createConnection(host, addr string) (*http2.ClientCon
 
 func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	hostname := req.URL.Hostname()
-	port := req.URL.Port()
-	if port == "" {
-		port = "443"
-	}
-	addr := net.JoinHostPort(hostname, port)
+	addr := utlsConnectionKey(hostname, req.URL.Port())
 
 	h2Conn, err := t.getOrCreateConnection(hostname, addr)
 	if err != nil {
@@ -131,14 +129,21 @@ func (t *utlsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	resp, err := h2Conn.RoundTrip(req)
 	if err != nil {
 		t.mu.Lock()
-		if cached, ok := t.connections[hostname]; ok && cached == h2Conn {
-			delete(t.connections, hostname)
+		if cached, ok := t.connections[addr]; ok && cached == h2Conn {
+			delete(t.connections, addr)
 		}
 		t.mu.Unlock()
 		return nil, err
 	}
 
 	return resp, nil
+}
+
+func utlsConnectionKey(hostname, port string) string {
+	if port == "" {
+		port = "443"
+	}
+	return net.JoinHostPort(hostname, port)
 }
 
 // utlsProtectedHosts contains the hosts that should use utls Chrome TLS fingerprint
@@ -186,6 +191,9 @@ func cachedUtlsRoundTrippers(proxyURL string) cachedUtlsRoundTripper {
 	defer utlsRoundTripperCache.mu.Unlock()
 	if existing, ok := utlsRoundTripperCache.items[proxyURL]; ok {
 		return existing
+	}
+	if len(utlsRoundTripperCache.items) >= maxCachedUtlsRoundTrippers {
+		return cached
 	}
 	utlsRoundTripperCache.items[proxyURL] = cached
 	return cached

--- a/internal/runtime/executor/helps/utls_client_test.go
+++ b/internal/runtime/executor/helps/utls_client_test.go
@@ -2,6 +2,7 @@ package helps
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -17,7 +18,7 @@ func (f utlsClientRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, e
 }
 
 func TestNewUtlsHTTPClientReusesCachedRoundTrippers(t *testing.T) {
-	t.Parallel()
+	resetUtlsRoundTripperCache(t)
 
 	first := NewUtlsHTTPClient(context.Background(), nil, nil, 0)
 	second := NewUtlsHTTPClient(context.Background(), nil, nil, 0)
@@ -33,7 +34,7 @@ func TestNewUtlsHTTPClientReusesCachedRoundTrippers(t *testing.T) {
 }
 
 func TestNewUtlsHTTPClientReusesCachedRoundTrippersForProxyKeys(t *testing.T) {
-	t.Parallel()
+	resetUtlsRoundTripperCache(t)
 
 	tests := []struct {
 		name     string
@@ -45,8 +46,6 @@ func TestNewUtlsHTTPClientReusesCachedRoundTrippersForProxyKeys(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			auth := &cliproxyauth.Auth{ProxyURL: tt.proxyURL}
 			first := NewUtlsHTTPClient(context.Background(), nil, auth, 0)
 			second := NewUtlsHTTPClient(context.Background(), nil, auth, 0)
@@ -64,8 +63,6 @@ func TestNewUtlsHTTPClientReusesCachedRoundTrippersForProxyKeys(t *testing.T) {
 }
 
 func TestNewUtlsHTTPClientUsesContextRoundTripperForProtectedHost(t *testing.T) {
-	t.Parallel()
-
 	called := false
 	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", utlsClientRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		called = true
@@ -93,6 +90,58 @@ func TestNewUtlsHTTPClientUsesContextRoundTripperForProtectedHost(t *testing.T) 
 	}
 }
 
+func TestNewUtlsHTTPClientDoesNotGrowCachePastLimit(t *testing.T) {
+	resetUtlsRoundTripperCache(t)
+
+	for i := 0; i < maxCachedUtlsRoundTrippers; i++ {
+		auth := &cliproxyauth.Auth{ProxyURL: fmt.Sprintf("http://proxy-%d.example.com:8080", i)}
+		NewUtlsHTTPClient(context.Background(), nil, auth, 0)
+	}
+
+	utlsRoundTripperCache.mu.RLock()
+	cachedCount := len(utlsRoundTripperCache.items)
+	utlsRoundTripperCache.mu.RUnlock()
+	if cachedCount != maxCachedUtlsRoundTrippers {
+		t.Fatalf("cached round trippers = %d, want %d", cachedCount, maxCachedUtlsRoundTrippers)
+	}
+
+	overflowAuth := &cliproxyauth.Auth{ProxyURL: "http://overflow.example.com:8080"}
+	client := NewUtlsHTTPClient(context.Background(), nil, overflowAuth, 0)
+	overflowUtls, overflowFallback := utlsClientRoundTrippers(t, client)
+	if overflowUtls == nil {
+		t.Fatal("expected overflow uTLS RoundTripper to be returned")
+	}
+	if overflowFallback == nil {
+		t.Fatal("expected overflow fallback RoundTripper to be returned")
+	}
+
+	utlsRoundTripperCache.mu.RLock()
+	cachedCount = len(utlsRoundTripperCache.items)
+	_, overflowCached := utlsRoundTripperCache.items[overflowAuth.ProxyURL]
+	utlsRoundTripperCache.mu.RUnlock()
+	if cachedCount != maxCachedUtlsRoundTrippers {
+		t.Fatalf("cached round trippers after overflow = %d, want %d", cachedCount, maxCachedUtlsRoundTrippers)
+	}
+	if overflowCached {
+		t.Fatal("expected overflow proxy key not to be cached")
+	}
+}
+
+func TestUtlsConnectionKeyIncludesPort(t *testing.T) {
+	defaultPortKey := utlsConnectionKey("chatgpt.com", "")
+	customPortKey := utlsConnectionKey("chatgpt.com", "8443")
+
+	if defaultPortKey != "chatgpt.com:443" {
+		t.Fatalf("default port key = %q, want chatgpt.com:443", defaultPortKey)
+	}
+	if customPortKey != "chatgpt.com:8443" {
+		t.Fatalf("custom port key = %q, want chatgpt.com:8443", customPortKey)
+	}
+	if defaultPortKey == customPortKey {
+		t.Fatal("expected different ports for the same host to use different connection keys")
+	}
+}
+
 func utlsClientRoundTrippers(t *testing.T, client *http.Client) (http.RoundTripper, http.RoundTripper) {
 	t.Helper()
 
@@ -101,4 +150,19 @@ func utlsClientRoundTrippers(t *testing.T, client *http.Client) (http.RoundTripp
 		t.Fatalf("transport type = %T, want *fallbackRoundTripper", client.Transport)
 	}
 	return fallback.utls, fallback.fallback
+}
+
+func resetUtlsRoundTripperCache(t *testing.T) {
+	t.Helper()
+
+	utlsRoundTripperCache.mu.Lock()
+	previous := utlsRoundTripperCache.items
+	utlsRoundTripperCache.items = make(map[string]cachedUtlsRoundTripper)
+	utlsRoundTripperCache.mu.Unlock()
+
+	t.Cleanup(func() {
+		utlsRoundTripperCache.mu.Lock()
+		utlsRoundTripperCache.items = previous
+		utlsRoundTripperCache.mu.Unlock()
+	})
 }

--- a/internal/runtime/executor/helps/utls_client_test.go
+++ b/internal/runtime/executor/helps/utls_client_test.go
@@ -4,17 +4,31 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	tls "github.com/refraction-networking/utls"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"golang.org/x/net/http2"
 )
 
 type utlsClientRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f utlsClientRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+type staticAddressDialer struct {
+	address string
+}
+
+func (d staticAddressDialer) Dial(network, _ string) (net.Conn, error) {
+	return net.Dial(network, d.address)
 }
 
 func TestNewUtlsHTTPClientReusesCachedRoundTrippers(t *testing.T) {
@@ -90,6 +104,94 @@ func TestNewUtlsHTTPClientUsesContextRoundTripperForProtectedHost(t *testing.T) 
 	}
 }
 
+func TestNewUtlsHTTPClientReusesSingleUtlsConnectionForConcurrentProtectedRequests(t *testing.T) {
+	resetUtlsRoundTripperCache(t)
+
+	var acceptedConnections atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Host != "api.anthropic.com" {
+			t.Errorf("host = %q, want api.anthropic.com", req.Host)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, "{}")
+	}))
+	server.EnableHTTP2 = true
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			acceptedConnections.Add(1)
+		}
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	serverTLSConfig := server.Client().Transport.(*http.Transport).TLSClientConfig
+	serverHost, _, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split server address: %v", err)
+	}
+	restoreTLSConfig := overrideUtlsTLSConfig(t, func(_ string) *tls.Config {
+		return &tls.Config{
+			ServerName: serverHost,
+			RootCAs:    serverTLSConfig.RootCAs,
+			NextProtos: []string{"h2"},
+		}
+	})
+	defer restoreTLSConfig()
+
+	utlsRT := &utlsRoundTripper{
+		connections: make(map[string]*http2.ClientConn),
+		pending:     make(map[string]*sync.Cond),
+		dialer:      staticAddressDialer{address: server.Listener.Addr().String()},
+	}
+	utlsRoundTripperCache.mu.Lock()
+	utlsRoundTripperCache.items[""] = cachedUtlsRoundTripper{
+		utls:     utlsRT,
+		fallback: http.DefaultTransport,
+	}
+	utlsRoundTripperCache.mu.Unlock()
+
+	const requestCount = 32
+	var wg sync.WaitGroup
+	errs := make(chan error, requestCount)
+	for i := 0; i < requestCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			client := NewUtlsHTTPClient(context.Background(), nil, nil, 0)
+			resp, err := client.Get("https://api.anthropic.com/v1/messages")
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer func() {
+				if errClose := resp.Body.Close(); errClose != nil {
+					errs <- errClose
+				}
+			}()
+			if resp.StatusCode != http.StatusOK {
+				errs <- fmt.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := acceptedConnections.Load(); got != 1 {
+		t.Fatalf("accepted connections = %d, want 1", got)
+	}
+	utlsRT.mu.Lock()
+	cachedConnections := len(utlsRT.connections)
+	utlsRT.mu.Unlock()
+	if cachedConnections != 1 {
+		t.Fatalf("cached uTLS connections = %d, want 1", cachedConnections)
+	}
+}
+
 func TestNewUtlsHTTPClientDoesNotGrowCachePastLimit(t *testing.T) {
 	resetUtlsRoundTripperCache(t)
 
@@ -124,6 +226,16 @@ func TestNewUtlsHTTPClientDoesNotGrowCachePastLimit(t *testing.T) {
 	}
 	if overflowCached {
 		t.Fatal("expected overflow proxy key not to be cached")
+	}
+}
+
+func overrideUtlsTLSConfig(t *testing.T, next func(string) *tls.Config) func() {
+	t.Helper()
+
+	previous := newUtlsTLSConfig
+	newUtlsTLSConfig = next
+	return func() {
+		newUtlsTLSConfig = previous
 	}
 }
 

--- a/internal/runtime/executor/helps/utls_client_test.go
+++ b/internal/runtime/executor/helps/utls_client_test.go
@@ -6,12 +6,61 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 type utlsClientRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f utlsClientRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func TestNewUtlsHTTPClientReusesCachedRoundTrippers(t *testing.T) {
+	t.Parallel()
+
+	first := NewUtlsHTTPClient(context.Background(), nil, nil, 0)
+	second := NewUtlsHTTPClient(context.Background(), nil, nil, 0)
+
+	firstUtls, firstFallback := utlsClientRoundTrippers(t, first)
+	secondUtls, secondFallback := utlsClientRoundTrippers(t, second)
+	if firstUtls != secondUtls {
+		t.Fatal("expected default uTLS RoundTripper to be cached")
+	}
+	if firstFallback != secondFallback {
+		t.Fatal("expected default fallback RoundTripper to be cached")
+	}
+}
+
+func TestNewUtlsHTTPClientReusesCachedRoundTrippersForProxyKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		proxyURL string
+	}{
+		{name: "direct", proxyURL: "direct"},
+		{name: "http proxy", proxyURL: "http://proxy.example.com:8080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			auth := &cliproxyauth.Auth{ProxyURL: tt.proxyURL}
+			first := NewUtlsHTTPClient(context.Background(), nil, auth, 0)
+			second := NewUtlsHTTPClient(context.Background(), nil, auth, 0)
+
+			firstUtls, firstFallback := utlsClientRoundTrippers(t, first)
+			secondUtls, secondFallback := utlsClientRoundTrippers(t, second)
+			if firstUtls != secondUtls {
+				t.Fatalf("expected uTLS RoundTripper to be cached for proxy %q", tt.proxyURL)
+			}
+			if firstFallback != secondFallback {
+				t.Fatalf("expected fallback RoundTripper to be cached for proxy %q", tt.proxyURL)
+			}
+		})
+	}
 }
 
 func TestNewUtlsHTTPClientUsesContextRoundTripperForProtectedHost(t *testing.T) {
@@ -42,4 +91,14 @@ func TestNewUtlsHTTPClientUsesContextRoundTripperForProtectedHost(t *testing.T) 
 	if !called {
 		t.Fatal("expected context RoundTripper to handle protected host request")
 	}
+}
+
+func utlsClientRoundTrippers(t *testing.T, client *http.Client) (http.RoundTripper, http.RoundTripper) {
+	t.Helper()
+
+	fallback, ok := client.Transport.(*fallbackRoundTripper)
+	if !ok {
+		t.Fatalf("transport type = %T, want *fallbackRoundTripper", client.Transport)
+	}
+	return fallback.utls, fallback.fallback
 }

--- a/internal/runtime/executor/helps/utls_client_test.go
+++ b/internal/runtime/executor/helps/utls_client_test.go
@@ -127,21 +127,6 @@ func TestNewUtlsHTTPClientDoesNotGrowCachePastLimit(t *testing.T) {
 	}
 }
 
-func TestUtlsConnectionKeyIncludesPort(t *testing.T) {
-	defaultPortKey := utlsConnectionKey("chatgpt.com", "")
-	customPortKey := utlsConnectionKey("chatgpt.com", "8443")
-
-	if defaultPortKey != "chatgpt.com:443" {
-		t.Fatalf("default port key = %q, want chatgpt.com:443", defaultPortKey)
-	}
-	if customPortKey != "chatgpt.com:8443" {
-		t.Fatalf("custom port key = %q, want chatgpt.com:8443", customPortKey)
-	}
-	if defaultPortKey == customPortKey {
-		t.Fatal("expected different ports for the same host to use different connection keys")
-	}
-}
-
 func utlsClientRoundTrippers(t *testing.T, client *http.Client) (http.RoundTripper, http.RoundTripper) {
 	t.Helper()
 


### PR DESCRIPTION
## Why
- `NewUtlsHTTPClient` created a fresh uTLS round tripper for each request.
- The uTLS HTTP/2 connection pool is stored inside that round tripper, so protected upstreams like `api.anthropic.com` and `chatgpt.com` could not reuse existing connections across requests.
- This caused repeated new TCP/TLS connections even when keep-alive should have been possible.
- These screenshots show the observed connection buildup before this fix.
   <img width="299" height="120" alt="image" src="https://github.com/user-attachments/assets/d1644ab2-302d-497a-b8a6-9213e7da94a3" />
   <img width="240" height="142" alt="image" src="https://github.com/user-attachments/assets/7299554e-92ea-4c94-be01-e34ca1900a53" />



## What
- Cache uTLS and fallback round trippers by normalized proxy URL.
- Reuse the no-proxy uTLS round tripper across Claude/Codex upstream requests.
- Preserve context-injected `cliproxy.roundtripper` behavior so tests and custom transports can still override the default path.
- Add tests covering default reuse, proxy-key reuse, and context round tripper precedence.

## Validation
- `go test ./internal/runtime/executor/helps`
- `go build -o test-output ./cmd/server && rm test-output`