### PR TITLE
fix(gemini-translator): sanitize stale required entries in OpenAI tool schemas

### DIFF
--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
@@ -327,6 +327,14 @@ func ConvertOpenAIRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 						} else {
 							fnRaw = renamed
 						}
+						// Sanitize the renamed parametersJsonSchema for Gemini API compatibility.
+						// Removes unsupported keywords, flattens anyOf/oneOf/allOf, normalizes enums,
+						// and strips required entries that do not exist in properties to avoid
+						// "GenerateContentRequest.tools[].function_declarations[].parameters.required[].property is not defined" errors.
+						schemaNode := gjson.Get(fnRaw, "parametersJsonSchema")
+						if schemaNode.Exists() {
+							fnRaw = string(util.CleanJSONSchemaForGemini(fnRaw))
+						}
 					} else {
 						var errSet error
 						fnRawBytes := []byte(fnRaw)

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
@@ -333,7 +333,8 @@ func ConvertOpenAIRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 						// "GenerateContentRequest.tools[].function_declarations[].parameters.required[].property is not defined" errors.
 						schemaNode := gjson.Get(fnRaw, "parametersJsonSchema")
 						if schemaNode.Exists() {
-							fnRaw = string(util.CleanJSONSchemaForGemini(fnRaw))
+							cleaned := util.CleanJSONSchemaForGemini(schemaNode.Raw)
+							fnRaw, _ = sjson.SetRaw(fnRaw, "parametersJsonSchema", cleaned)
 						}
 					} else {
 						var errSet error

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_request_sanitize_test.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_request_sanitize_test.go
@@ -1,0 +1,129 @@
+package chat_completions
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// TestConvertOpenAIRequestToGemini_SanitizesStaleRequiredEntries verifies that the
+// OpenAI -> Gemini translator strips required entries that are missing from
+// properties. Without this fix, Gemini API returns
+//
+//	"AI_APICallError: GenerateContentRequest.tools[0].function_declarations[N].parameters.required[M]: property is not defined"
+//
+// even though the original OpenAI request was accepted by the client.
+func TestConvertOpenAIRequestToGemini_SanitizesStaleRequiredEntries(t *testing.T) {
+	input := []byte(`{
+  "model": "gemini-2.0-flash",
+  "messages": [{"role":"user","content":"hi"}],
+  "tools": [{
+    "type": "function",
+    "function": {
+      "name": "search_company",
+      "description": "Search",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "country": {"type": "string"},
+          "industry": {"type": "string"}
+        },
+        "required": ["country", "industry", "stale_field", "another_stale"]
+      }
+    }
+  }]
+}`)
+
+	out := ConvertOpenAIRequestToGemini("gemini-2.0-flash", input, false)
+
+	// Find the renamed parametersJsonSchema
+	schema := gjson.GetBytes(out, "tools.0.functionDeclarations.0.parametersJsonSchema")
+	if !schema.Exists() {
+		t.Fatalf("expected parametersJsonSchema to exist after conversion, got: %s", string(out))
+	}
+
+	// Required array should be filtered to only the keys present in properties.
+	reqArr := schema.Get("required")
+	if !reqArr.IsArray() {
+		t.Fatalf("expected required to be an array, got %v", reqArr.Type)
+	}
+	got := []string{}
+	for _, r := range reqArr.Array() {
+		got = append(got, r.String())
+	}
+	want := []string{"country", "industry"}
+	if len(got) != len(want) {
+		t.Fatalf("required mismatch: got %v, want %v (full: %s)", got, want, schema.Raw)
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("required[%d]: got %q, want %q", i, got[i], v)
+		}
+	}
+}
+
+// TestConvertOpenAIRequestToGemini_DropsEmptyRequiredArray ensures that a required
+// array whose entries were all stale is fully removed (not left as []).
+func TestConvertOpenAIRequestToGemini_DropsEmptyRequiredArray(t *testing.T) {
+	input := []byte(`{
+  "model": "gemini-2.0-flash",
+  "messages": [{"role":"user","content":"hi"}],
+  "tools": [{
+    "type": "function",
+    "function": {
+      "name": "noop",
+      "description": "Noop",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "x": {"type": "string"}
+        },
+        "required": ["missing_one", "missing_two"]
+      }
+    }
+  }]
+}`)
+
+	out := ConvertOpenAIRequestToGemini("gemini-2.0-flash", input, false)
+	schema := gjson.GetBytes(out, "tools.0.functionDeclarations.0.parametersJsonSchema")
+	if !schema.Exists() {
+		t.Fatalf("expected parametersJsonSchema to exist")
+	}
+	if schema.Get("required").Exists() {
+		t.Fatalf("expected required to be removed when all entries are stale, got: %s", schema.Raw)
+	}
+}
+
+// TestConvertOpenAIRequestToGemini_AllRequiredValidPassesThrough ensures we do
+// not regress valid OpenAI requests where every required entry is declared.
+func TestConvertOpenAIRequestToGemini_AllRequiredValidPassesThrough(t *testing.T) {
+	input := []byte(`{
+  "model": "gemini-2.0-flash",
+  "messages": [{"role":"user","content":"hi"}],
+  "tools": [{
+    "type": "function",
+    "function": {
+      "name": "ok_tool",
+      "description": "ok",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "a": {"type": "string"},
+          "b": {"type": "number"}
+        },
+        "required": ["a", "b"]
+      }
+    }
+  }]
+}`)
+
+	out := ConvertOpenAIRequestToGemini("gemini-2.0-flash", input, false)
+	schema := gjson.GetBytes(out, "tools.0.functionDeclarations.0.parametersJsonSchema")
+	req := schema.Get("required")
+	if !req.IsArray() {
+		t.Fatalf("expected required array, got %v", req.Type)
+	}
+	if len(req.Array()) != 2 {
+		t.Fatalf("expected 2 required entries, got %d: %s", len(req.Array()), schema.Raw)
+	}
+}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -384,14 +384,9 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 					funcDecl, _ = sjson.SetBytes(funcDecl, "description", desc.String())
 				}
 				if params := tool.Get("parameters"); params.Exists() {
-					funcDecl, _ = sjson.SetRawBytes(funcDecl, "parametersJsonSchema", []byte(params.Raw))
+					cleaned := util.CleanJSONSchemaForGemini(params.Raw)
+					funcDecl, _ = sjson.SetRawBytes(funcDecl, "parametersJsonSchema", []byte(cleaned))
 				}
-
-				// Sanitize the function declaration for Gemini API compatibility.
-				// Strips unsupported keywords, flattens complex unions, and removes required
-				// entries that do not exist in properties to avoid
-				// "GenerateContentRequest.tools[].function_declarations[].parameters.required[].property is not defined" errors.
-				funcDecl = []byte(util.CleanJSONSchemaForGemini(string(funcDecl)))
 
 				geminiTools, _ = sjson.SetRawBytes(geminiTools, "0.functionDeclarations.-1", funcDecl)
 			}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -387,6 +387,12 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 					funcDecl, _ = sjson.SetRawBytes(funcDecl, "parametersJsonSchema", []byte(params.Raw))
 				}
 
+				// Sanitize the function declaration for Gemini API compatibility.
+				// Strips unsupported keywords, flattens complex unions, and removes required
+				// entries that do not exist in properties to avoid
+				// "GenerateContentRequest.tools[].function_declarations[].parameters.required[].property is not defined" errors.
+				funcDecl = []byte(util.CleanJSONSchemaForGemini(string(funcDecl)))
+
 				geminiTools, _ = sjson.SetRawBytes(geminiTools, "0.functionDeclarations.-1", funcDecl)
 			}
 			return true

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_sanitize_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_sanitize_test.go
@@ -1,0 +1,57 @@
+package responses
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// TestConvertOpenAIResponsesRequestToGemini_SanitizesStaleRequiredEntries verifies
+// that stale `required` entries (declared in the OpenAI tool schema but missing
+// from `properties`) are stripped before the request is forwarded to Gemini,
+// preventing
+//
+//	"AI_APICallError: GenerateContentRequest.tools[0].function_declarations[N].parameters.required[M]: property is not defined".
+func TestConvertOpenAIResponsesRequestToGemini_SanitizesStaleRequiredEntries(t *testing.T) {
+	input := []byte(`{
+  "model": "gpt-5",
+  "input": [{"type": "message", "role": "user", "content": "hi"}],
+  "tools": [{
+    "type": "function",
+    "name": "search_company",
+    "description": "Search",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "country": {"type": "string"},
+        "industry": {"type": "string"}
+      },
+      "required": ["country", "industry", "stale_field", "another_stale"]
+    }
+  }]
+}`)
+
+	out := ConvertOpenAIResponsesRequestToGemini("gpt-5", input, false)
+	schema := gjson.GetBytes(out, "tools.0.functionDeclarations.0.parametersJsonSchema")
+	if !schema.Exists() {
+		t.Fatalf("expected parametersJsonSchema to exist, got: %s", string(out))
+	}
+
+	reqArr := schema.Get("required")
+	if !reqArr.IsArray() {
+		t.Fatalf("expected required to be an array, got %v", reqArr.Type)
+	}
+	got := []string{}
+	for _, r := range reqArr.Array() {
+		got = append(got, r.String())
+	}
+	want := []string{"country", "industry"}
+	if len(got) != len(want) {
+		t.Fatalf("required mismatch: got %v, want %v (full: %s)", got, want, schema.Raw)
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("required[%d]: got %q, want %q", i, got[i], v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fix `AI_APICallError: GenerateContentRequest.tools[0].function_declarations[N].parameters.required[M]: property is not defined` raised by Gemini API when an OpenAI Chat Completions / Responses tool declares `required` entries that are missing from `properties`.

The OpenAI → Gemini translator renamed `tools[].function.parameters` to `parametersJsonSchema` but never ran the renamed payload through `util.CleanJSONSchemaForGemini`. Other translators (claude→gemini, antigravity→gemini) already do so for the same reason. Without that sanitization, `cleanupRequiredFields` is skipped and every stale `required` name is forwarded to Gemini, which then rejects the request with the API error above.

## Changes

- `internal/translator/gemini/openai/chat-completions/gemini_openai_request.go`
  After renaming `parameters` → `parametersJsonSchema`, run the renamed value through `util.CleanJSONSchemaForGemini`. This calls `cleanupRequiredFields` (which intersects `required` with `properties`, removing any name that does not have a corresponding property) and also flattens anyOf/oneOf/allOf, removes unsupported keywords, normalizes enums, and strips x-\* extension fields — all of which Gemini API rejects.
- `internal/translator/gemini/openai/responses/gemini_openai-responses_request.go`
  Same fix for the OpenAI Responses translator.

## Tests

New regression tests in:

- `internal/translator/gemini/openai/chat-completions/gemini_openai_request_sanitize_test.go`
  - `TestConvertOpenAIRequestToGemini_SanitizesStaleRequiredEntries` — pins down the original bug.
  - `TestConvertOpenAIRequestToGemini_DropsEmptyRequiredArray` — confirms the all-stale case is fully removed.
  - `TestConvertOpenAIRequestToGemini_AllRequiredValidPassesThrough` — guards against regressions in the happy path.
- `internal/translator/gemini/openai/responses/gemini_openai-responses_request_sanitize_test.go`
  - `TestConvertOpenAIResponsesRequestToGemini_SanitizesStaleRequiredEntries` — same coverage for the responses translator.

All tests in the touched packages pass, `gofmt` is clean, and `go build -o test-output ./cmd/server && rm test-output` (the AGENTS.md compile guard) succeeds.

Fixes #3863