### PR TITLE
fix(openai/gemini): avoid duplicate tool call IDs

### DIFF
--- a/internal/translator/openai/gemini/openai_gemini_request.go
+++ b/internal/translator/openai/gemini/openai_gemini_request.go
@@ -112,7 +112,8 @@ func ConvertGeminiRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 	out, _ = sjson.SetBytes(out, "stream", stream)
 
 	// Process contents (Gemini messages) -> OpenAI messages
-	var toolCallIDs []string // Track tool call IDs for matching with tool results
+	var toolCallIDs []string   // Track tool call IDs for matching with tool results
+	var toolCallConsumeIdx int // Next index into toolCallIDs to consume for function responses
 
 	// System instruction -> OpenAI system message
 	// Gemini may provide `systemInstruction` or `system_instruction`; support both keys.
@@ -241,14 +242,12 @@ func ConvertGeminiRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 							}
 						}
 
-						// Try to match with previous tool call ID
-						_ = functionResponse.Get("name").String() // functionName not used for now
-						if len(toolCallIDs) > 0 {
-							// Use the last tool call ID (simple matching by function name)
-							// In a real implementation, you might want more sophisticated matching
-							toolMsg, _ = sjson.SetBytes(toolMsg, "tool_call_id", toolCallIDs[len(toolCallIDs)-1])
+						// Match function responses to tool calls in order (FIFO).
+						// Each functionResponse consumes the next pending tool call ID.
+						if toolCallConsumeIdx < len(toolCallIDs) {
+							toolMsg, _ = sjson.SetBytes(toolMsg, "tool_call_id", toolCallIDs[toolCallConsumeIdx])
+							toolCallConsumeIdx++
 						} else {
-							// Generate a tool call ID if none available
 							toolMsg, _ = sjson.SetBytes(toolMsg, "tool_call_id", genToolCallID())
 						}
 

--- a/internal/translator/openai/gemini/openai_gemini_request_test.go
+++ b/internal/translator/openai/gemini/openai_gemini_request_test.go
@@ -1,0 +1,178 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertGeminiRequestToOpenAI_ToolCallIDMatching_MultipleCallsMultipleResponses(t *testing.T) {
+	// Two function calls (Bash, Read) followed by two function responses.
+	// Before the fix, both responses would reuse the last tool call ID (Read),
+	// causing OpenAI-compatible upstreams to reject the request with
+	// "Duplicate value for 'tool_call_id'".
+	input := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"text": "Let me check."}
+				]
+			},
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "Bash", "args": {"cmd": "ls"}}},
+					{"functionCall": {"name": "Read", "args": {"path": "/a"}}},
+					{"functionResponse": {"name": "Bash", "response": {"output": "file1.txt"}}},
+					{"functionResponse": {"name": "Read", "response": {"content": "hello"}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToOpenAI("deepseek-v4-pro", input, true)
+
+	messages := gjson.GetBytes(out, "messages")
+	if !messages.IsArray() {
+		t.Fatal("expected messages to be an array")
+	}
+
+	// Collect tool message tool_call_ids
+	var toolCallIDs []string
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "tool" {
+			id := msg.Get("tool_call_id").String()
+			toolCallIDs = append(toolCallIDs, id)
+		}
+		return true
+	})
+
+	if len(toolCallIDs) != 2 {
+		t.Fatalf("expected 2 tool messages, got %d", len(toolCallIDs))
+	}
+
+	if toolCallIDs[0] == toolCallIDs[1] {
+		t.Errorf("tool_call_ids must be distinct, got duplicate %q", toolCallIDs[0])
+	}
+}
+
+func TestConvertGeminiRequestToOpenAI_ToolCallIDMatching_FIFOConsumption(t *testing.T) {
+	// Three function calls, three function responses in order.
+	// Verify that each response consumes the next pending tool call ID.
+	input := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "A", "args": {}}},
+					{"functionCall": {"name": "B", "args": {}}},
+					{"functionCall": {"name": "C", "args": {}}},
+					{"functionResponse": {"name": "A", "response": {"result": "ok"}}},
+					{"functionResponse": {"name": "B", "response": {"result": "ok"}}},
+					{"functionResponse": {"name": "C", "response": {"result": "ok"}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToOpenAI("deepseek-v4-pro", input, false)
+
+	messages := gjson.GetBytes(out, "messages")
+	var toolCallIDs []string
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "tool" {
+			id := msg.Get("tool_call_id").String()
+			toolCallIDs = append(toolCallIDs, id)
+		}
+		return true
+	})
+
+	if len(toolCallIDs) != 3 {
+		t.Fatalf("expected 3 tool messages, got %d", len(toolCallIDs))
+	}
+
+	seen := make(map[string]bool)
+	for _, id := range toolCallIDs {
+		if seen[id] {
+			t.Errorf("duplicate tool_call_id %q", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestConvertGeminiRequestToOpenAI_ToolCallIDMatching_NoFunctionCalls(t *testing.T) {
+	// functionResponse without any preceding functionCall should get a generated ID.
+	input := []byte(`{
+		"contents": [
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"name": "Bash", "response": {"output": "done"}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToOpenAI("deepseek-v4-pro", input, false)
+
+	messages := gjson.GetBytes(out, "messages")
+	var toolCallIDs []string
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "tool" {
+			id := msg.Get("tool_call_id").String()
+			toolCallIDs = append(toolCallIDs, id)
+		}
+		return true
+	})
+
+	if len(toolCallIDs) != 1 {
+		t.Fatalf("expected 1 tool message, got %d", len(toolCallIDs))
+	}
+	if toolCallIDs[0] == "" {
+		t.Error("tool_call_id should not be empty")
+	}
+}
+
+func TestConvertGeminiRequestToOpenAI_ToolCallIDMatching_MoreResponsesThanCalls(t *testing.T) {
+	// Two function calls, three function responses.
+	// The extra response should get a generated ID.
+	input := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "A", "args": {}}},
+					{"functionCall": {"name": "B", "args": {}}},
+					{"functionResponse": {"name": "A", "response": {"result": "ok"}}},
+					{"functionResponse": {"name": "B", "response": {"result": "ok"}}},
+					{"functionResponse": {"name": "C", "response": {"result": "extra"}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToOpenAI("deepseek-v4-pro", input, false)
+
+	messages := gjson.GetBytes(out, "messages")
+	var toolCallIDs []string
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "tool" {
+			id := msg.Get("tool_call_id").String()
+			toolCallIDs = append(toolCallIDs, id)
+		}
+		return true
+	})
+
+	if len(toolCallIDs) != 3 {
+		t.Fatalf("expected 3 tool messages, got %d", len(toolCallIDs))
+	}
+
+	seen := make(map[string]bool)
+	for _, id := range toolCallIDs {
+		if seen[id] {
+			t.Errorf("duplicate tool_call_id %q", id)
+		}
+		seen[id] = true
+	}
+}

--- a/internal/translator/openai/gemini/openai_gemini_request_test.go
+++ b/internal/translator/openai/gemini/openai_gemini_request_test.go
@@ -6,6 +6,48 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func collectToolCallIDs(messages gjson.Result) ([]string, []string) {
+	var assistantToolCallIDs []string
+	var toolMessageIDs []string
+
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		switch msg.Get("role").String() {
+		case "assistant":
+			msg.Get("tool_calls").ForEach(func(_, toolCall gjson.Result) bool {
+				assistantToolCallIDs = append(assistantToolCallIDs, toolCall.Get("id").String())
+				return true
+			})
+		case "tool":
+			toolMessageIDs = append(toolMessageIDs, msg.Get("tool_call_id").String())
+		}
+		return true
+	})
+
+	return assistantToolCallIDs, toolMessageIDs
+}
+
+func assertDistinctToolCallIDs(t *testing.T, toolMessageIDs []string) {
+	t.Helper()
+
+	seen := make(map[string]bool)
+	for _, id := range toolMessageIDs {
+		if seen[id] {
+			t.Errorf("duplicate tool_call_id %q", id)
+		}
+		seen[id] = true
+	}
+}
+
+func assertToolCallIDsMatch(t *testing.T, assistantToolCallIDs, toolMessageIDs []string, count int) {
+	t.Helper()
+
+	for i := 0; i < count; i++ {
+		if assistantToolCallIDs[i] != toolMessageIDs[i] {
+			t.Errorf("mismatch at index %d: assistant tool call ID %q != tool message ID %q", i, assistantToolCallIDs[i], toolMessageIDs[i])
+		}
+	}
+}
+
 func TestConvertGeminiRequestToOpenAI_ToolCallIDMatching_MultipleCallsMultipleResponses(t *testing.T) {
 	// Two function calls (Bash, Read) followed by two function responses.
 	// Before the fix, both responses would reuse the last tool call ID (Read),
@@ -38,23 +80,17 @@ func TestConvertGeminiRequestToOpenAI_ToolCallIDMatching_MultipleCallsMultipleRe
 		t.Fatal("expected messages to be an array")
 	}
 
-	// Collect tool message tool_call_ids
-	var toolCallIDs []string
-	messages.ForEach(func(_, msg gjson.Result) bool {
-		if msg.Get("role").String() == "tool" {
-			id := msg.Get("tool_call_id").String()
-			toolCallIDs = append(toolCallIDs, id)
-		}
-		return true
-	})
+	assistantToolCallIDs, toolMessageIDs := collectToolCallIDs(messages)
 
-	if len(toolCallIDs) != 2 {
-		t.Fatalf("expected 2 tool messages, got %d", len(toolCallIDs))
+	if len(assistantToolCallIDs) != 2 {
+		t.Fatalf("expected 2 assistant tool calls, got %d", len(assistantToolCallIDs))
+	}
+	if len(toolMessageIDs) != 2 {
+		t.Fatalf("expected 2 tool messages, got %d", len(toolMessageIDs))
 	}
 
-	if toolCallIDs[0] == toolCallIDs[1] {
-		t.Errorf("tool_call_ids must be distinct, got duplicate %q", toolCallIDs[0])
-	}
+	assertToolCallIDsMatch(t, assistantToolCallIDs, toolMessageIDs, 2)
+	assertDistinctToolCallIDs(t, toolMessageIDs)
 }
 
 func TestConvertGeminiRequestToOpenAI_ToolCallIDMatching_FIFOConsumption(t *testing.T) {
@@ -79,26 +115,17 @@ func TestConvertGeminiRequestToOpenAI_ToolCallIDMatching_FIFOConsumption(t *test
 	out := ConvertGeminiRequestToOpenAI("deepseek-v4-pro", input, false)
 
 	messages := gjson.GetBytes(out, "messages")
-	var toolCallIDs []string
-	messages.ForEach(func(_, msg gjson.Result) bool {
-		if msg.Get("role").String() == "tool" {
-			id := msg.Get("tool_call_id").String()
-			toolCallIDs = append(toolCallIDs, id)
-		}
-		return true
-	})
+	assistantToolCallIDs, toolMessageIDs := collectToolCallIDs(messages)
 
-	if len(toolCallIDs) != 3 {
-		t.Fatalf("expected 3 tool messages, got %d", len(toolCallIDs))
+	if len(assistantToolCallIDs) != 3 {
+		t.Fatalf("expected 3 assistant tool calls, got %d", len(assistantToolCallIDs))
+	}
+	if len(toolMessageIDs) != 3 {
+		t.Fatalf("expected 3 tool messages, got %d", len(toolMessageIDs))
 	}
 
-	seen := make(map[string]bool)
-	for _, id := range toolCallIDs {
-		if seen[id] {
-			t.Errorf("duplicate tool_call_id %q", id)
-		}
-		seen[id] = true
-	}
+	assertToolCallIDsMatch(t, assistantToolCallIDs, toolMessageIDs, 3)
+	assertDistinctToolCallIDs(t, toolMessageIDs)
 }
 
 func TestConvertGeminiRequestToOpenAI_ToolCallIDMatching_NoFunctionCalls(t *testing.T) {
@@ -117,19 +144,15 @@ func TestConvertGeminiRequestToOpenAI_ToolCallIDMatching_NoFunctionCalls(t *test
 	out := ConvertGeminiRequestToOpenAI("deepseek-v4-pro", input, false)
 
 	messages := gjson.GetBytes(out, "messages")
-	var toolCallIDs []string
-	messages.ForEach(func(_, msg gjson.Result) bool {
-		if msg.Get("role").String() == "tool" {
-			id := msg.Get("tool_call_id").String()
-			toolCallIDs = append(toolCallIDs, id)
-		}
-		return true
-	})
+	assistantToolCallIDs, toolMessageIDs := collectToolCallIDs(messages)
 
-	if len(toolCallIDs) != 1 {
-		t.Fatalf("expected 1 tool message, got %d", len(toolCallIDs))
+	if len(assistantToolCallIDs) != 0 {
+		t.Fatalf("expected 0 assistant tool calls, got %d", len(assistantToolCallIDs))
 	}
-	if toolCallIDs[0] == "" {
+	if len(toolMessageIDs) != 1 {
+		t.Fatalf("expected 1 tool message, got %d", len(toolMessageIDs))
+	}
+	if toolMessageIDs[0] == "" {
 		t.Error("tool_call_id should not be empty")
 	}
 }
@@ -155,24 +178,15 @@ func TestConvertGeminiRequestToOpenAI_ToolCallIDMatching_MoreResponsesThanCalls(
 	out := ConvertGeminiRequestToOpenAI("deepseek-v4-pro", input, false)
 
 	messages := gjson.GetBytes(out, "messages")
-	var toolCallIDs []string
-	messages.ForEach(func(_, msg gjson.Result) bool {
-		if msg.Get("role").String() == "tool" {
-			id := msg.Get("tool_call_id").String()
-			toolCallIDs = append(toolCallIDs, id)
-		}
-		return true
-	})
+	assistantToolCallIDs, toolMessageIDs := collectToolCallIDs(messages)
 
-	if len(toolCallIDs) != 3 {
-		t.Fatalf("expected 3 tool messages, got %d", len(toolCallIDs))
+	if len(assistantToolCallIDs) != 2 {
+		t.Fatalf("expected 2 assistant tool calls, got %d", len(assistantToolCallIDs))
+	}
+	if len(toolMessageIDs) != 3 {
+		t.Fatalf("expected 3 tool messages, got %d", len(toolMessageIDs))
 	}
 
-	seen := make(map[string]bool)
-	for _, id := range toolCallIDs {
-		if seen[id] {
-			t.Errorf("duplicate tool_call_id %q", id)
-		}
-		seen[id] = true
-	}
+	assertToolCallIDsMatch(t, assistantToolCallIDs, toolMessageIDs, 2)
+	assertDistinctToolCallIDs(t, toolMessageIDs)
 }


### PR DESCRIPTION
## Summary

- Fix Gemini-to-OpenAI tool result translation so each `functionResponse` consumes the next pending `tool_call_id` instead of reusing the last one.
- Preserve generated fallback IDs when a function response has no pending matching call.
- Add unit tests for multi-call/multi-response, FIFO consumption, missing calls, and extra responses.

Fixes #3874.

## Validation

```text
go test ./internal/translator/openai/gemini/ -v -count=1
go build -o /tmp/cliproxy-test-output ./cmd/server
```
