### PR TITLE
feat(misc): align Antigravity runtime UA with agy CLI version sources

### DIFF
--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -7,6 +7,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -17,7 +18,8 @@ import (
 )
 
 const (
-	antigravityFallbackVersion = "2.1.0"
+	antigravityFallbackVersion = "1.0.8"
+	antigravityCLIPlatform     = "darwin/arm64"
 	antigravityVersionCacheTTL = 6 * time.Hour
 	antigravityFetchTimeout    = 10 * time.Second
 	AntigravityNodeAPIClientUA = "google-api-nodejs-client/10.3.0"
@@ -25,20 +27,22 @@ const (
 )
 
 var (
-	antigravityHubGCSListURL = "https://storage.googleapis.com/antigravity-public/?prefix=antigravity-hub/&delimiter=/"
-	antigravityReleasesURL   = "https://antigravity-auto-updater-974169037036.us-central1.run.app/releases"
+	antigravityCLIUpdaterBaseURL = "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests"
+	antigravityCLILatestURL      = "https://storage.googleapis.com/antigravity-public/antigravity-cli/latest"
+	antigravityCLIGCSListURL     = "https://storage.googleapis.com/antigravity-public/?prefix=antigravity-cli/&delimiter=/"
 )
 
-type antigravityRelease struct {
-	Version     string `json:"version"`
-	ExecutionID string `json:"execution_id"`
+type antigravityCLIUpdaterManifest struct {
+	Version string `json:"version"`
+	URL     string `json:"url"`
+	SHA512  string `json:"sha512"`
 }
 
-type antigravityHubGCSList struct {
-	CommonPrefixes []antigravityHubGCSPrefix `xml:"CommonPrefixes"`
+type antigravityGCSList struct {
+	CommonPrefixes []antigravityGCSPrefix `xml:"CommonPrefixes"`
 }
 
-type antigravityHubGCSPrefix struct {
+type antigravityGCSPrefix struct {
 	Prefix string `xml:"Prefix"`
 }
 
@@ -123,10 +127,13 @@ func AntigravityLatestVersion() string {
 	return antigravityFallbackVersion
 }
 
-// AntigravityUserAgent returns the User-Agent string for antigravity requests
-// using the latest version fetched from the releases API.
+// AntigravityUserAgent returns the User-Agent string used by the agy CLI family.
 func AntigravityUserAgent() string {
-	return fmt.Sprintf("antigravity/%s darwin/arm64", AntigravityLatestVersion())
+	return fmt.Sprintf("antigravity/cli/%s %s", AntigravityLatestVersion(), antigravityCLIPlatform)
+}
+
+func isAntigravityFamilyUserAgent(lower string) bool {
+	return strings.HasPrefix(lower, "antigravity/cli/") || strings.HasPrefix(lower, "antigravity/")
 }
 
 func antigravityBaseUserAgent(userAgent string) string {
@@ -135,7 +142,7 @@ func antigravityBaseUserAgent(userAgent string) string {
 		return AntigravityUserAgent()
 	}
 	lower := strings.ToLower(userAgent)
-	if strings.HasPrefix(lower, "antigravity/") {
+	if isAntigravityFamilyUserAgent(lower) {
 		if idx := strings.Index(lower, " google-api-nodejs-client/"); idx >= 0 {
 			trimmed := strings.TrimSpace(userAgent[:idx])
 			if trimmed != "" {
@@ -160,7 +167,7 @@ func AntigravityLoadCodeAssistUserAgent(userAgent string) string {
 		return AntigravityUserAgent() + " " + AntigravityNodeAPIClientUA
 	}
 	lower := strings.ToLower(userAgent)
-	if !strings.HasPrefix(lower, "antigravity/") {
+	if !isAntigravityFamilyUserAgent(lower) {
 		return userAgent
 	}
 	if strings.Contains(lower, "google-api-nodejs-client/") {
@@ -174,10 +181,24 @@ func AntigravityLoadCodeAssistUserAgent(userAgent string) string {
 func AntigravityVersionFromUserAgent(userAgent string) string {
 	base := antigravityBaseUserAgent(userAgent)
 	lower := strings.ToLower(base)
-	if !strings.HasPrefix(lower, "antigravity/") {
+	for _, familyPrefix := range []string{"antigravity/cli/", "antigravity/hub/"} {
+		if strings.HasPrefix(lower, familyPrefix) {
+			rest := base[len(familyPrefix):]
+			if idx := strings.IndexAny(rest, " \t"); idx >= 0 {
+				rest = rest[:idx]
+			}
+			rest = strings.TrimSpace(rest)
+			if rest == "" {
+				return AntigravityLatestVersion()
+			}
+			return rest
+		}
+	}
+	const legacyPrefix = "antigravity/"
+	if !strings.HasPrefix(lower, legacyPrefix) {
 		return AntigravityLatestVersion()
 	}
-	rest := base[len("antigravity/"):]
+	rest := base[len(legacyPrefix):]
 	if idx := strings.IndexAny(rest, " \t"); idx >= 0 {
 		rest = rest[:idx]
 	}
@@ -188,6 +209,10 @@ func AntigravityVersionFromUserAgent(userAgent string) string {
 	return rest
 }
 
+func antigravityCLIUpdaterManifestName() string {
+	return strings.ReplaceAll(antigravityCLIPlatform, "/", "_")
+}
+
 func fetchAntigravityLatestVersion(ctx context.Context) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -195,44 +220,127 @@ func fetchAntigravityLatestVersion(ctx context.Context) (string, error) {
 
 	client := &http.Client{Timeout: antigravityFetchTimeout}
 
-	version, errHub := fetchAntigravityHubGCSLatestVersion(ctx, client)
-	if errHub == nil {
+	version, errManifest := fetchAntigravityCLIUpdaterManifestVersion(ctx, client)
+	if errManifest == nil {
 		return version, nil
 	}
 
-	log.WithError(errHub).Debug("failed to fetch antigravity hub GCS version, trying legacy releases API")
+	log.WithError(errManifest).Debug("failed to fetch antigravity CLI updater manifest, trying CLI latest pointer")
 
-	version, errLegacy := fetchAntigravityLegacyLatestVersion(ctx, client)
-	if errLegacy == nil {
+	version, errLatest := fetchAntigravityCLILatestVersion(ctx, client)
+	if errLatest == nil {
 		return version, nil
 	}
 
-	return "", fmt.Errorf("fetch antigravity hub GCS version: %v; fetch legacy releases: %w", errHub, errLegacy)
+	log.WithError(errLatest).Debug("failed to fetch antigravity CLI latest version, trying CLI GCS prefix list")
+
+	version, errList := fetchAntigravityCLIGCSLatestVersion(ctx, client)
+	if errList == nil {
+		return version, nil
+	}
+
+	return "", fmt.Errorf("fetch antigravity CLI updater manifest: %v; fetch antigravity CLI latest: %v; fetch antigravity CLI GCS version: %w", errManifest, errLatest, errList)
 }
 
-func fetchAntigravityHubGCSLatestVersion(ctx context.Context, client *http.Client) (string, error) {
-	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodGet, antigravityHubGCSListURL, nil)
+func fetchAntigravityCLIUpdaterManifestVersion(ctx context.Context, client *http.Client) (string, error) {
+	manifestURL := fmt.Sprintf("%s/%s.json", strings.TrimSuffix(antigravityCLIUpdaterBaseURL, "/"), antigravityCLIUpdaterManifestName())
+	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
 	if errReq != nil {
-		return "", fmt.Errorf("build antigravity hub GCS request: %w", errReq)
+		return "", fmt.Errorf("build antigravity CLI updater manifest request: %w", errReq)
 	}
 
 	resp, errDo := client.Do(httpReq)
 	if errDo != nil {
-		return "", fmt.Errorf("fetch antigravity hub GCS list: %w", errDo)
+		return "", fmt.Errorf("fetch antigravity CLI updater manifest: %w", errDo)
 	}
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
-			log.WithError(errClose).Warn("antigravity hub GCS response body close error")
+			log.WithError(errClose).Warn("antigravity CLI updater manifest response body close error")
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("antigravity hub GCS list returned status %d", resp.StatusCode)
+		return "", fmt.Errorf("antigravity CLI updater manifest returned status %d", resp.StatusCode)
 	}
 
-	var list antigravityHubGCSList
+	raw, errRead := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if errRead != nil {
+		return "", fmt.Errorf("read antigravity CLI updater manifest: %w", errRead)
+	}
+
+	var manifest antigravityCLIUpdaterManifest
+	if errDecode := json.Unmarshal(raw, &manifest); errDecode != nil {
+		return "", fmt.Errorf("decode antigravity CLI updater manifest: %w", errDecode)
+	}
+
+	version := strings.TrimSpace(manifest.Version)
+	if version == "" {
+		return "", errors.New("antigravity CLI updater manifest returned empty version")
+	}
+	if _, ok := parseAntigravitySemVersion(version); !ok {
+		return "", fmt.Errorf("antigravity CLI updater manifest returned invalid version %q", version)
+	}
+	return version, nil
+}
+
+func fetchAntigravityCLILatestVersion(ctx context.Context, client *http.Client) (string, error) {
+	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodGet, antigravityCLILatestURL, nil)
+	if errReq != nil {
+		return "", fmt.Errorf("build antigravity CLI latest request: %w", errReq)
+	}
+
+	resp, errDo := client.Do(httpReq)
+	if errDo != nil {
+		return "", fmt.Errorf("fetch antigravity CLI latest: %w", errDo)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.WithError(errClose).Warn("antigravity CLI latest response body close error")
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("antigravity CLI latest returned status %d", resp.StatusCode)
+	}
+
+	raw, errRead := io.ReadAll(io.LimitReader(resp.Body, 256))
+	if errRead != nil {
+		return "", fmt.Errorf("read antigravity CLI latest: %w", errRead)
+	}
+	version := strings.TrimSpace(string(raw))
+	if version == "" {
+		return "", errors.New("antigravity CLI latest returned empty version")
+	}
+	semVersion, ok := parseAntigravitySemVersion(version)
+	if !ok {
+		return "", fmt.Errorf("antigravity CLI latest returned invalid version %q", version)
+	}
+	return semVersion.raw, nil
+}
+
+func fetchAntigravityCLIGCSLatestVersion(ctx context.Context, client *http.Client) (string, error) {
+	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodGet, antigravityCLIGCSListURL, nil)
+	if errReq != nil {
+		return "", fmt.Errorf("build antigravity CLI GCS request: %w", errReq)
+	}
+
+	resp, errDo := client.Do(httpReq)
+	if errDo != nil {
+		return "", fmt.Errorf("fetch antigravity CLI GCS list: %w", errDo)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.WithError(errClose).Warn("antigravity CLI GCS response body close error")
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("antigravity CLI GCS list returned status %d", resp.StatusCode)
+	}
+
+	var list antigravityGCSList
 	if errDecode := xml.NewDecoder(resp.Body).Decode(&list); errDecode != nil {
-		return "", fmt.Errorf("decode antigravity hub GCS list: %w", errDecode)
+		return "", fmt.Errorf("decode antigravity CLI GCS list: %w", errDecode)
 	}
 
 	prefixes := make([]string, 0, len(list.CommonPrefixes))
@@ -240,52 +348,15 @@ func fetchAntigravityHubGCSLatestVersion(ctx context.Context, client *http.Clien
 		prefixes = append(prefixes, commonPrefix.Prefix)
 	}
 
-	return latestAntigravityHubVersionFromPrefixes(prefixes)
+	return latestAntigravityCLIVersionFromPrefixes(prefixes)
 }
 
-func fetchAntigravityLegacyLatestVersion(ctx context.Context, client *http.Client) (string, error) {
-	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodGet, antigravityReleasesURL, nil)
-	if errReq != nil {
-		return "", fmt.Errorf("build antigravity releases request: %w", errReq)
-	}
-
-	resp, errDo := client.Do(httpReq)
-	if errDo != nil {
-		return "", fmt.Errorf("fetch antigravity releases: %w", errDo)
-	}
-	defer func() {
-		if errClose := resp.Body.Close(); errClose != nil {
-			log.WithError(errClose).Warn("antigravity releases response body close error")
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("antigravity releases API returned status %d", resp.StatusCode)
-	}
-
-	var releases []antigravityRelease
-	if errDecode := json.NewDecoder(resp.Body).Decode(&releases); errDecode != nil {
-		return "", fmt.Errorf("decode antigravity releases response: %w", errDecode)
-	}
-
-	if len(releases) == 0 {
-		return "", errors.New("antigravity releases API returned empty list")
-	}
-
-	version := releases[0].Version
-	if version == "" {
-		return "", errors.New("antigravity releases API returned empty version")
-	}
-
-	return version, nil
-}
-
-func latestAntigravityHubVersionFromPrefixes(prefixes []string) (string, error) {
+func latestAntigravityCLIVersionFromPrefixes(prefixes []string) (string, error) {
 	var best antigravitySemVersion
 	found := false
 
 	for _, prefix := range prefixes {
-		version, ok := antigravityHubVersionFromPrefix(prefix)
+		version, ok := antigravityCLIVersionFromPrefix(prefix)
 		if !ok {
 			continue
 		}
@@ -300,38 +371,52 @@ func latestAntigravityHubVersionFromPrefixes(prefixes []string) (string, error) 
 	}
 
 	if !found {
-		return "", errors.New("antigravity hub GCS list contained no version prefixes")
+		return "", errors.New("antigravity-cli GCS list contained no version prefixes")
 	}
 
 	return best.raw, nil
 }
 
-func antigravityHubVersionFromPrefix(prefix string) (string, bool) {
-	const hubPrefix = "antigravity-hub/"
-
+func antigravityCLIVersionFromPrefix(prefix string) (string, bool) {
+	const cliPrefix = "antigravity-cli/"
 	prefix = strings.TrimSpace(prefix)
 	prefix = strings.TrimSuffix(prefix, "/")
-	if !strings.HasPrefix(prefix, hubPrefix) {
+	if !strings.HasPrefix(prefix, cliPrefix) {
 		return "", false
 	}
 
-	name := strings.TrimPrefix(prefix, hubPrefix)
+	name := strings.TrimPrefix(prefix, cliPrefix)
+	if name == "latest" || name == "test" || name == "tools" || strings.HasPrefix(name, "v") {
+		return "", false
+	}
+
 	separator := strings.LastIndex(name, "-")
-	if separator <= 0 || separator == len(name)-1 {
-		return "", false
-	}
-
-	version := strings.TrimSpace(name[:separator])
-	executionID := name[separator+1:]
-	if version == "" || executionID == "" {
-		return "", false
-	}
-	for _, ch := range executionID {
-		if ch < '0' || ch > '9' {
-			return "", false
+	if separator > 0 && separator < len(name)-1 {
+		version := strings.TrimSpace(name[:separator])
+		executionID := name[separator+1:]
+		if version != "" && executionID != "" {
+			allDigits := true
+			for _, ch := range executionID {
+				if ch < '0' || ch > '9' {
+					allDigits = false
+					break
+				}
+			}
+			if allDigits {
+				if _, ok := parseAntigravitySemVersion(version); ok {
+					return version, true
+				}
+			}
 		}
 	}
 
+	version := strings.TrimSpace(name)
+	if version == "" {
+		return "", false
+	}
+	if _, ok := parseAntigravitySemVersion(version); !ok {
+		return "", false
+	}
 	return version, true
 }
 

--- a/internal/misc/antigravity_version_test.go
+++ b/internal/misc/antigravity_version_test.go
@@ -9,17 +9,20 @@ import (
 	"time"
 )
 
-func overrideAntigravityVersionURLsForTest(t *testing.T, hubURL string, legacyURL string) func() {
+func overrideAntigravityVersionURLsForTest(t *testing.T, updaterBaseURL string, cliLatestURL string, cliListURL string) func() {
 	t.Helper()
 
-	oldHubURL := antigravityHubGCSListURL
-	oldLegacyURL := antigravityReleasesURL
-	antigravityHubGCSListURL = hubURL
-	antigravityReleasesURL = legacyURL
+	oldUpdater := antigravityCLIUpdaterBaseURL
+	oldCLILatest := antigravityCLILatestURL
+	oldCLIList := antigravityCLIGCSListURL
+	antigravityCLIUpdaterBaseURL = updaterBaseURL
+	antigravityCLILatestURL = cliLatestURL
+	antigravityCLIGCSListURL = cliListURL
 
 	return func() {
-		antigravityHubGCSListURL = oldHubURL
-		antigravityReleasesURL = oldLegacyURL
+		antigravityCLIUpdaterBaseURL = oldUpdater
+		antigravityCLILatestURL = oldCLILatest
+		antigravityCLIGCSListURL = oldCLIList
 	}
 }
 
@@ -41,108 +44,148 @@ func overrideAntigravityVersionCacheForTest(t *testing.T, version string, expiry
 	}
 }
 
-func TestAntigravityLatestVersionUsesCurrentHubFallback(t *testing.T) {
+func TestAntigravityLatestVersionUsesCurrentCLIFallback(t *testing.T) {
 	restore := overrideAntigravityVersionCacheForTest(t, "", time.Time{})
 	defer restore()
 
 	version := AntigravityLatestVersion()
-	if version != "2.1.0" {
-		t.Fatalf("AntigravityLatestVersion() = %q, want %q", version, "2.1.0")
+	if version != "1.0.8" {
+		t.Fatalf("AntigravityLatestVersion() = %q, want %q", version, "1.0.8")
 	}
 }
 
-func TestFetchAntigravityLatestVersionPrefersHubGCSList(t *testing.T) {
-	var legacyRequests atomic.Int32
+func TestAntigravityUserAgentUsesCLIFamily(t *testing.T) {
+	restore := overrideAntigravityVersionCacheForTest(t, "1.0.8", time.Now().Add(time.Hour))
+	defer restore()
+
+	want := "antigravity/cli/1.0.8 darwin/arm64"
+	if got := AntigravityUserAgent(); got != want {
+		t.Fatalf("AntigravityUserAgent() = %q, want %q", got, want)
+	}
+}
+
+func TestAntigravityVersionFromUserAgentParsesCLIFamily(t *testing.T) {
+	if got := AntigravityVersionFromUserAgent("antigravity/cli/1.0.8 darwin/arm64"); got != "1.0.8" {
+		t.Fatalf("AntigravityVersionFromUserAgent() = %q, want %q", got, "1.0.8")
+	}
+}
+
+func TestAntigravityCLIUpdaterManifestName(t *testing.T) {
+	if got := antigravityCLIUpdaterManifestName(); got != "darwin_arm64" {
+		t.Fatalf("antigravityCLIUpdaterManifestName() = %q, want %q", got, "darwin_arm64")
+	}
+}
+
+func TestFetchAntigravityLatestVersionPrefersDarwinManifest(t *testing.T) {
+	var cliLatestRequests atomic.Int32
+	var cliListRequests atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/gcs":
+		case "/manifests/darwin_arm64.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"1.0.8","url":"https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.8-5963827121094656/darwin-arm/cli_mac_arm64.tar.gz"}`))
+		case "/cli-latest":
+			cliLatestRequests.Add(1)
+			http.Error(w, "should not be called", http.StatusInternalServerError)
+		case "/cli-list":
+			cliListRequests.Add(1)
+			http.Error(w, "should not be called", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/manifests", server.URL+"/cli-latest", server.URL+"/cli-list")
+	defer restore()
+
+	version, errFetch := fetchAntigravityLatestVersion(context.Background())
+	if errFetch != nil {
+		t.Fatalf("fetchAntigravityLatestVersion() error = %v", errFetch)
+	}
+	if version != "1.0.8" {
+		t.Fatalf("fetchAntigravityLatestVersion() = %q, want %q", version, "1.0.8")
+	}
+	if got := cliLatestRequests.Load(); got != 0 {
+		t.Fatalf("CLI latest requests = %d, want 0", got)
+	}
+	if got := cliListRequests.Load(); got != 0 {
+		t.Fatalf("CLI GCS list requests = %d, want 0", got)
+	}
+}
+
+func TestFetchAntigravityLatestVersionFallsBackToCLILatest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifests/darwin_arm64.json":
+			http.Error(w, "temporary outage", http.StatusInternalServerError)
+		case "/cli-latest":
+			_, _ = w.Write([]byte("1.0.9"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/manifests", server.URL+"/cli-latest", server.URL+"/cli-list")
+	defer restore()
+
+	version, errFetch := fetchAntigravityLatestVersion(context.Background())
+	if errFetch != nil {
+		t.Fatalf("fetchAntigravityLatestVersion() error = %v", errFetch)
+	}
+	if version != "1.0.9" {
+		t.Fatalf("fetchAntigravityLatestVersion() = %q, want %q", version, "1.0.9")
+	}
+}
+
+func TestFetchAntigravityLatestVersionFallsBackToCLIGCSList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifests/darwin_arm64.json":
+			http.Error(w, "temporary outage", http.StatusInternalServerError)
+		case "/cli-latest":
+			http.Error(w, "temporary outage", http.StatusInternalServerError)
+		case "/cli-list":
 			w.Header().Set("Content-Type", "application/xml")
 			_, _ = w.Write([]byte(`<?xml version='1.0' encoding='UTF-8'?>
 <ListBucketResult xmlns='http://doc.s3.amazonaws.com/2006-03-01'>
-  <CommonPrefixes><Prefix>antigravity-hub/2.0.9-4666288509943808/</Prefix></CommonPrefixes>
-  <CommonPrefixes><Prefix>antigravity-hub/2.0.11-6560309696135168/</Prefix></CommonPrefixes>
-  <CommonPrefixes><Prefix>antigravity-hub/2.1.0-6066040229199872/</Prefix></CommonPrefixes>
+  <CommonPrefixes><Prefix>antigravity-cli/1.0.7/</Prefix></CommonPrefixes>
+  <CommonPrefixes><Prefix>antigravity-cli/1.0.8/</Prefix></CommonPrefixes>
+  <CommonPrefixes><Prefix>antigravity-cli/1.0.8-5963827121094656/</Prefix></CommonPrefixes>
 </ListBucketResult>`))
-		case "/legacy":
-			legacyRequests.Add(1)
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`[{"version":"9.9.9","execution_id":"1"}]`))
 		default:
 			http.NotFound(w, r)
 		}
 	}))
 	defer server.Close()
 
-	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/gcs", server.URL+"/legacy")
+	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/manifests", server.URL+"/cli-latest", server.URL+"/cli-list")
 	defer restore()
 
 	version, errFetch := fetchAntigravityLatestVersion(context.Background())
 	if errFetch != nil {
 		t.Fatalf("fetchAntigravityLatestVersion() error = %v", errFetch)
 	}
-	if version != "2.1.0" {
-		t.Fatalf("fetchAntigravityLatestVersion() = %q, want %q", version, "2.1.0")
-	}
-	if got := legacyRequests.Load(); got != 0 {
-		t.Fatalf("legacy releases API requests = %d, want 0", got)
+	if version != "1.0.8" {
+		t.Fatalf("fetchAntigravityLatestVersion() = %q, want %q", version, "1.0.8")
 	}
 }
 
-func TestFetchAntigravityLatestVersionFallsBackToLegacyReleases(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/gcs":
-			http.Error(w, "temporary outage", http.StatusInternalServerError)
-		case "/legacy":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`[{"version":"2.0.0","execution_id":"6324554176528384"}]`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
-	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/gcs", server.URL+"/legacy")
-	defer restore()
-
-	version, errFetch := fetchAntigravityLatestVersion(context.Background())
-	if errFetch != nil {
-		t.Fatalf("fetchAntigravityLatestVersion() error = %v", errFetch)
-	}
-	if version != "2.0.0" {
-		t.Fatalf("fetchAntigravityLatestVersion() = %q, want %q", version, "2.0.0")
-	}
-}
-
-func TestLatestAntigravityHubVersionFromPrefixesSortsByNumericSemver(t *testing.T) {
+func TestLatestAntigravityCLIVersionFromPrefixesSortsByNumericSemver(t *testing.T) {
 	prefixes := []string{
-		"antigravity-hub/2.0.9-4666288509943808/",
-		"antigravity-hub/2.0.10-5119448496078848/",
-		"antigravity-hub/2.0.11-6560309696135168/",
-		"antigravity-hub/not-a-version/",
+		"antigravity-cli/1.0.7/",
+		"antigravity-cli/1.0.8/",
+		"antigravity-cli/1.0.8-5963827121094656/",
+		"antigravity-cli/latest/",
 	}
 
-	version, errParse := latestAntigravityHubVersionFromPrefixes(prefixes)
+	version, errParse := latestAntigravityCLIVersionFromPrefixes(prefixes)
 	if errParse != nil {
-		t.Fatalf("latestAntigravityHubVersionFromPrefixes() error = %v", errParse)
+		t.Fatalf("latestAntigravityCLIVersionFromPrefixes() error = %v", errParse)
 	}
-	if version != "2.0.11" {
-		t.Fatalf("latestAntigravityHubVersionFromPrefixes() = %q, want %q", version, "2.0.11")
-	}
-}
-
-func TestLatestAntigravityHubVersionFromPrefixesIgnoresSignedVersionParts(t *testing.T) {
-	prefixes := []string{
-		"antigravity-hub/9.+9.9-4666288509943808/",
-		"antigravity-hub/2.1.0-6066040229199872/",
-	}
-
-	version, errParse := latestAntigravityHubVersionFromPrefixes(prefixes)
-	if errParse != nil {
-		t.Fatalf("latestAntigravityHubVersionFromPrefixes() error = %v", errParse)
-	}
-	if version != "2.1.0" {
-		t.Fatalf("latestAntigravityHubVersionFromPrefixes() = %q, want %q", version, "2.1.0")
+	if version != "1.0.8" {
+		t.Fatalf("latestAntigravityCLIVersionFromPrefixes() = %q, want %q", version, "1.0.8")
 	}
 }

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -51,7 +51,7 @@ const (
 	antigravityGeneratePath                = "/v1internal:generateContent"
 	antigravityClientID                    = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
 	antigravityClientSecret                = "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"
-	defaultAntigravityAgent                = "antigravity/1.21.9 darwin/arm64" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
+	defaultAntigravityAgent                = "antigravity/cli/1.0.8 darwin/arm64" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
 	antigravityAuthType                    = "antigravity"
 	refreshSkew                            = 3000 * time.Second
 	antigravityCreditsHintRefreshInterval  = 10 * time.Minute


### PR DESCRIPTION
## Summary

Aligns CPA Antigravity runtime `User-Agent` version resolution with the agy CLI source chain, while keeping the host platform as `darwin/arm64` on macOS CPA deployments.

## Changes

- Resolve Antigravity CLI version in order:
  1. `manifests/darwin_arm64.json`
  2. `antigravity-cli/latest`
  3. GCS prefix listing fallback
  4. Hard fallback `1.0.8`
- Update unit tests for the new lookup order and fallbacks.
- Document default UA behavior in `antigravity_executor.go`.

## Verification

- `go test ./internal/misc -run Antigravity -count=1`
- `go build ./cmd/server`

## Notes

This PR does not change quota APIs or `retrieveUserQuotaSummary` handling (tracked separately in #3876).