### PR TITLE
feat: expose codex fast toggle in management UI path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,4 +25,5 @@ services:
       - ${CLI_PROXY_CONFIG_PATH:-./config.yaml}:/CLIProxyAPI/config.yaml
       - ${CLI_PROXY_AUTH_PATH:-./auths}:/root/.cli-proxy-api
       - ${CLI_PROXY_LOG_PATH:-./logs}:/CLIProxyAPI/logs
+      - ${CLI_PROXY_PLUGIN_PATH:-./plugins}:/CLIProxyAPI/plugins
     restart: unless-stopped

--- a/examples/plugin/README.md
+++ b/examples/plugin/README.md
@@ -14,7 +14,7 @@ This directory contains standard dynamic library plugin examples for the CLIProx
 - `protocol-format/`: minimal executor focused on input/output format declarations.
 - `request-translator/`: request translation capability only.
 - `request-normalizer/`: request normalization capability only.
-- `codex-service-tier/`: Go-only request normalizer that sets Codex `gpt-5.5` requests to the priority service tier when enabled.
+- `codex-service-tier/`: Go-only request normalizer that sets Codex `gpt-5.4` and `gpt-5.5` requests to the priority service tier when enabled.
 - `scheduler/`: Go-only scheduler that can select a configured auth ID, delegate to a built-in scheduler, or deny picks.
 - `claude-web-search-router/`: ModelRouter + executor for Claude Code built-in `web_search` (antigravity / codex / xai / Tavily). See `claude-web-search-router/README.md`.
 - `response-translator/`: response translation capability only.
@@ -31,7 +31,7 @@ Most standard capability examples contain `go/`, `c/`, and `rust/` subdirectorie
 
 ## Codex Service Tier
 
-`codex-service-tier` declares the request normalization capability. When `fast` is `true`, it sets `service_tier` to `priority` for requests where `req.ToFormat` is `codex` and `req.Model` is `gpt-5.5`.
+`codex-service-tier` declares the request normalization capability. When `fast` is `true`, it sets `service_tier` to `priority` for requests where `req.ToFormat` is `codex` and `req.Model` is `gpt-5.4` or `gpt-5.5`.
 
 ```yaml
 plugins:

--- a/examples/plugin/README_CN.md
+++ b/examples/plugin/README_CN.md
@@ -14,7 +14,7 @@
 - `protocol-format/`：使用最小执行器重点演示输入和输出格式声明。
 - `request-translator/`：只演示请求转换能力。
 - `request-normalizer/`：只演示请求规整能力。
-- `codex-service-tier/`：仅 Go 实现的请求规整插件，启用后会将 Codex `gpt-5.5` 请求设置为 priority service tier。
+- `codex-service-tier/`：仅 Go 实现的请求规整插件，启用后会将 Codex `gpt-5.4` 和 `gpt-5.5` 请求设置为 priority service tier。
 - `scheduler/`：仅 Go 实现的调度插件，可选择指定 auth ID、委托内置调度器或拒绝调度。
 - `response-translator/`：只演示响应转换能力。
 - `response-normalizer/`：只演示响应规整能力。
@@ -30,7 +30,7 @@
 
 ## Codex Service Tier
 
-`codex-service-tier` 声明请求规整能力。当 `fast` 为 `true` 时，如果 `req.ToFormat` 为 `codex` 且 `req.Model` 为 `gpt-5.5`，它会将 `service_tier` 设置为 `priority`。
+`codex-service-tier` 声明请求规整能力。当 `fast` 为 `true` 时，如果 `req.ToFormat` 为 `codex` 且 `req.Model` 为 `gpt-5.4` 或 `gpt-5.5`，它会将 `service_tier` 设置为 `priority`。
 
 ```yaml
 plugins:

--- a/examples/plugin/codex-service-tier/README.md
+++ b/examples/plugin/codex-service-tier/README.md
@@ -5,7 +5,7 @@ This plugin is a request normalizer for Codex outbound requests.
 When the plugin is enabled and `fast` is set to `true`, it sets the top-level `service_tier` field to `priority` for requests where:
 
 - `req.ToFormat` is `codex`
-- `req.Model` is `gpt-5.5`
+- `req.Model` is `gpt-5.4` or `gpt-5.5`
 
 Requests that do not match these conditions are returned unchanged.
 
@@ -22,4 +22,4 @@ plugins:
       fast: false
 ```
 
-`fast` is a boolean field. Set it to `true` to enable priority service tier shaping for matching Codex `gpt-5.5` requests.
+`fast` is a boolean field. Set it to `true` to enable priority service tier shaping for matching Codex `gpt-5.4` and `gpt-5.5` requests.

--- a/examples/plugin/codex-service-tier/go/main.go
+++ b/examples/plugin/codex-service-tier/go/main.go
@@ -169,7 +169,7 @@ func pluginRegistration() registration {
 			ConfigFields: []pluginapi.ConfigField{{
 				Name:        "fast",
 				Type:        pluginapi.ConfigFieldTypeBoolean,
-				Description: "Sets Codex gpt-5.5 Responses requests to the priority service tier.",
+				Description: "Sets Codex gpt-5.4 and gpt-5.5 Responses requests to the priority service tier.",
 			}},
 		},
 		Capabilities: registrationCapability{
@@ -201,7 +201,7 @@ func shouldSetPriorityServiceTier(req pluginapi.RequestTransformRequest) bool {
 	if !strings.EqualFold(req.ToFormat, "codex") {
 		return false
 	}
-	return req.Model == "gpt-5.5"
+	return req.Model == "gpt-5.4" || req.Model == "gpt-5.5"
 }
 
 func decodeFastConfig(configYAML []byte) (bool, error) {

--- a/examples/plugin/codex-service-tier/go/main_test.go
+++ b/examples/plugin/codex-service-tier/go/main_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func TestShouldSetPriorityServiceTier(t *testing.T) {
+	cases := []struct {
+		name     string
+		fast     bool
+		toFormat string
+		model    string
+		want     bool
+	}{
+		{
+			name:     "gpt-5.4 with codex fast",
+			fast:     true,
+			toFormat: "codex",
+			model:    "gpt-5.4",
+			want:     true,
+		},
+		{
+			name:     "gpt-5.5 with codex fast",
+			fast:     true,
+			toFormat: "codex",
+			model:    "gpt-5.5",
+			want:     true,
+		},
+		{
+			name:     "other model with codex fast",
+			fast:     true,
+			toFormat: "codex",
+			model:    "gpt-4",
+			want:     false,
+		},
+		{
+			name:     "gpt-5.5 with non-codex fast",
+			fast:     true,
+			toFormat: "openai",
+			model:    "gpt-5.5",
+			want:     false,
+		},
+		{
+			name:     "gpt-5.4 with codex but fast disabled",
+			fast:     false,
+			toFormat: "codex",
+			model:    "gpt-5.4",
+			want:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fastEnabled.Store(tc.fast)
+			req := pluginapi.RequestTransformRequest{
+				ToFormat: tc.toFormat,
+				Model:    tc.model,
+			}
+			if got := shouldSetPriorityServiceTier(req); got != tc.want {
+				t.Fatalf("shouldSetPriorityServiceTier() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeRequestInjectsPriorityServiceTierForBothModelsWhenFastEnabled(t *testing.T) {
+	fastEnabled.Store(true)
+	body := []byte(`{"input": "hello"}`)
+
+	for _, model := range []string{"gpt-5.4", "gpt-5.5"} {
+		t.Run(model, func(t *testing.T) {
+			req := pluginapi.RequestTransformRequest{
+				ToFormat: "codex",
+				Model:    model,
+				Body:     body,
+			}
+			raw, err := json.Marshal(req)
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+
+			respRaw, err := normalizeRequest(raw)
+			if err != nil {
+				t.Fatalf("normalizeRequest: %v", err)
+			}
+
+			var resp struct {
+				OK     bool                      `json:"ok"`
+				Result pluginapi.PayloadResponse `json:"result"`
+			}
+			if err := json.Unmarshal(respRaw, &resp); err != nil {
+				t.Fatalf("unmarshal envelope: %v", err)
+			}
+			if !resp.OK {
+				t.Fatal("normalizeRequest should return ok response")
+			}
+
+			var updated map[string]any
+			if err := json.Unmarshal(resp.Result.Body, &updated); err != nil {
+				t.Fatalf("unmarshal updated body: %v", err)
+			}
+			if got := updated["service_tier"]; got != "priority" {
+				t.Fatalf("service_tier = %v, want priority", got)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/management/handler_test.go
+++ b/internal/api/handlers/management/handler_test.go
@@ -86,3 +86,4 @@ func TestMiddlewareSetsSupportPluginHeader(t *testing.T) {
 		}
 	})
 }
+

--- a/internal/api/handlers/management/plugins.go
+++ b/internal/api/handlers/management/plugins.go
@@ -232,38 +232,6 @@ func (h *Handler) PatchPluginEnabled(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
-// GetPluginConfig returns plugins.configs.<id> as a JSON object for editing.
-func (h *Handler) GetPluginConfig(c *gin.Context) {
-	id, okID := pluginIDFromRequest(c)
-	if !okID {
-		return
-	}
-
-	h.mu.Lock()
-	item := h.cfg.Plugins.Configs[id]
-	h.mu.Unlock()
-
-	node := pluginConfigNode(item)
-	if node == nil || node.Kind != yaml.MappingNode {
-		c.JSON(http.StatusOK, gin.H{})
-		return
-	}
-
-	body := make(map[string]any, len(node.Content)/2)
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		key := node.Content[i]
-		value := node.Content[i+1]
-		if key == nil || key.Value == "" {
-			continue
-		}
-		body[key.Value] = yamlNodeToJSONValue(value)
-	}
-	if body == nil {
-		body = map[string]any{}
-	}
-	c.JSON(http.StatusOK, body)
-}
-
 // PutPluginConfig replaces plugins.configs.<id> with the request object.
 func (h *Handler) PutPluginConfig(c *gin.Context) {
 	id, okID := pluginIDFromRequest(c)
@@ -587,49 +555,6 @@ func yamlNodeFromJSONObject(body map[string]any) (*yaml.Node, error) {
 		setYAMLMappingValue(node, key, valueNode)
 	}
 	return node, nil
-}
-
-func yamlNodeToJSONValue(node *yaml.Node) any {
-	if node == nil {
-		return nil
-	}
-	switch node.Kind {
-	case yaml.MappingNode:
-		out := make(map[string]any, len(node.Content)/2)
-		for i := 0; i+1 < len(node.Content); i += 2 {
-			key := node.Content[i]
-			value := node.Content[i+1]
-			if key == nil || key.Value == "" {
-				continue
-			}
-			out[key.Value] = yamlNodeToJSONValue(value)
-		}
-		return out
-	case yaml.SequenceNode:
-		out := make([]any, 0, len(node.Content))
-		for _, child := range node.Content {
-			out = append(out, yamlNodeToJSONValue(child))
-		}
-		return out
-	case yaml.ScalarNode:
-		switch node.Tag {
-		case "!!null":
-			return nil
-		case "!!bool":
-			return strings.EqualFold(node.Value, "true")
-		case "!!int":
-			if v, err := strconv.ParseInt(strings.TrimSpace(node.Value), 10, 64); err == nil {
-				return v
-			}
-		case "!!float":
-			if v, err := strconv.ParseFloat(strings.TrimSpace(node.Value), 64); err == nil {
-				return v
-			}
-		}
-		return node.Value
-	default:
-		return node.Value
-	}
 }
 
 func yamlNodeFromJSONValue(value any) (*yaml.Node, error) {

--- a/internal/api/handlers/management/plugins.go
+++ b/internal/api/handlers/management/plugins.go
@@ -232,6 +232,38 @@ func (h *Handler) PatchPluginEnabled(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
+// GetPluginConfig returns plugins.configs.<id> as a JSON object for editing.
+func (h *Handler) GetPluginConfig(c *gin.Context) {
+	id, okID := pluginIDFromRequest(c)
+	if !okID {
+		return
+	}
+
+	h.mu.Lock()
+	item := h.cfg.Plugins.Configs[id]
+	h.mu.Unlock()
+
+	node := pluginConfigNode(item)
+	if node == nil || node.Kind != yaml.MappingNode {
+		c.JSON(http.StatusOK, gin.H{})
+		return
+	}
+
+	body := make(map[string]any, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		value := node.Content[i+1]
+		if key == nil || key.Value == "" {
+			continue
+		}
+		body[key.Value] = yamlNodeToJSONValue(value)
+	}
+	if body == nil {
+		body = map[string]any{}
+	}
+	c.JSON(http.StatusOK, body)
+}
+
 // PutPluginConfig replaces plugins.configs.<id> with the request object.
 func (h *Handler) PutPluginConfig(c *gin.Context) {
 	id, okID := pluginIDFromRequest(c)
@@ -555,6 +587,49 @@ func yamlNodeFromJSONObject(body map[string]any) (*yaml.Node, error) {
 		setYAMLMappingValue(node, key, valueNode)
 	}
 	return node, nil
+}
+
+func yamlNodeToJSONValue(node *yaml.Node) any {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.MappingNode:
+		out := make(map[string]any, len(node.Content)/2)
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i]
+			value := node.Content[i+1]
+			if key == nil || key.Value == "" {
+				continue
+			}
+			out[key.Value] = yamlNodeToJSONValue(value)
+		}
+		return out
+	case yaml.SequenceNode:
+		out := make([]any, 0, len(node.Content))
+		for _, child := range node.Content {
+			out = append(out, yamlNodeToJSONValue(child))
+		}
+		return out
+	case yaml.ScalarNode:
+		switch node.Tag {
+		case "!!null":
+			return nil
+		case "!!bool":
+			return strings.EqualFold(node.Value, "true")
+		case "!!int":
+			if v, err := strconv.ParseInt(strings.TrimSpace(node.Value), 10, 64); err == nil {
+				return v
+			}
+		case "!!float":
+			if v, err := strconv.ParseFloat(strings.TrimSpace(node.Value), 64); err == nil {
+				return v
+			}
+		}
+		return node.Value
+	default:
+		return node.Value
+	}
 }
 
 func yamlNodeFromJSONValue(value any) (*yaml.Node, error) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -615,16 +615,12 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/config.yaml", s.mgmt.GetConfigYAML)
 		mgmt.PUT("/config.yaml", s.mgmt.PutConfigYAML)
 		mgmt.GET("/latest-version", s.mgmt.GetLatestVersion)
-		mgmt.GET("/plugins", s.mgmt.ListPlugins)
-<<<<<<< HEAD
-		mgmt.GET("/plugin-store", s.mgmt.ListPluginStore)
-		mgmt.POST("/plugin-store/:id/install", s.mgmt.InstallPluginFromStore)
-		mgmt.DELETE("/plugins/:id", s.mgmt.DeletePlugin)
-=======
-		mgmt.GET("/plugins/:id/config", s.mgmt.GetPluginConfig)
->>>>>>> a72cc55b (Add management plugin config GET endpoint)
-		mgmt.PATCH("/plugins/:id/enabled", s.mgmt.PatchPluginEnabled)
-		mgmt.GET("/plugins/:id/config", s.mgmt.GetPluginConfig)
+			mgmt.GET("/plugins", s.mgmt.ListPlugins)
+			mgmt.GET("/plugin-store", s.mgmt.ListPluginStore)
+			mgmt.POST("/plugin-store/:id/install", s.mgmt.InstallPluginFromStore)
+			mgmt.DELETE("/plugins/:id", s.mgmt.DeletePlugin)
+			mgmt.PATCH("/plugins/:id/enabled", s.mgmt.PatchPluginEnabled)
+			mgmt.GET("/plugins/:id/config", s.mgmt.GetPluginConfig)
 		mgmt.PUT("/plugins/:id/config", s.mgmt.PutPluginConfig)
 		mgmt.PATCH("/plugins/:id/config", s.mgmt.PatchPluginConfig)
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -616,9 +616,13 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PUT("/config.yaml", s.mgmt.PutConfigYAML)
 		mgmt.GET("/latest-version", s.mgmt.GetLatestVersion)
 		mgmt.GET("/plugins", s.mgmt.ListPlugins)
+<<<<<<< HEAD
 		mgmt.GET("/plugin-store", s.mgmt.ListPluginStore)
 		mgmt.POST("/plugin-store/:id/install", s.mgmt.InstallPluginFromStore)
 		mgmt.DELETE("/plugins/:id", s.mgmt.DeletePlugin)
+=======
+		mgmt.GET("/plugins/:id/config", s.mgmt.GetPluginConfig)
+>>>>>>> a72cc55b (Add management plugin config GET endpoint)
 		mgmt.PATCH("/plugins/:id/enabled", s.mgmt.PatchPluginEnabled)
 		mgmt.GET("/plugins/:id/config", s.mgmt.GetPluginConfig)
 		mgmt.PUT("/plugins/:id/config", s.mgmt.PutPluginConfig)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -228,8 +228,8 @@ func TestManagementPluginsRouteRegistered(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d body=%s", rr.Code, http.StatusOK, rr.Body.String())
 	}
-	if got := rr.Header().Get("X-CPA-SUPPORT-PLUGIN"); got != "true" {
-		t.Fatalf("X-CPA-SUPPORT-PLUGIN header = %q, want %q", got, "true")
+	if got := rr.Header().Get("X-CPA-SUPPORT-PLUGIN"); got != pluginhost.SupportPluginHeaderValue() {
+		t.Fatalf("X-CPA-SUPPORT-PLUGIN header = %q, want %q", got, pluginhost.SupportPluginHeaderValue())
 	}
 
 	var payload struct {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -228,6 +228,9 @@ func TestManagementPluginsRouteRegistered(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d body=%s", rr.Code, http.StatusOK, rr.Body.String())
 	}
+	if got := rr.Header().Get("X-CPA-SUPPORT-PLUGIN"); got != "true" {
+		t.Fatalf("X-CPA-SUPPORT-PLUGIN header = %q, want %q", got, "true")
+	}
 
 	var payload struct {
 		PluginsEnabled bool  `json:"plugins_enabled"`


### PR DESCRIPTION
## Summary
- share `codex-service-tier.fast` across `gpt-5.4` and `gpt-5.5`
- expose plugin management support and plugin config reads required by the management UI
- mount the plugin directory in the local Docker runtime so the shared fast-toggle plugin loads correctly

## Test Plan
- [x] `go test ./internal/api/handlers/management ./internal/api`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] isolated runtime verification of `gpt-5.4` / `gpt-5.5` with UI-driven `fast` off/on toggles
- [ ] `go test ./...` on top of latest `origin/main`

## Notes
- `go test ./...` on the clean sync branch based on the current `origin/main` still reports an unrelated pre-existing upstream failure in `internal/runtime/executor` (`TestXAIExecutorOmitsUnsupportedReasoningEffort`).
- The feature-specific management/API tests and server build pass on this branch.
