### PR TITLE
fix(kimi): filter empty text content parts to prevent "text content is empty" errors

### DIFF
--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -115,6 +115,10 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 	if err != nil {
 		return resp, err
 	}
+	body, err = normalizeKimiEmptyTextContent(body)
+	if err != nil {
+		return resp, err
+	}
 	reporter.SetTranslatedReasoningEffort(body, e.Identifier())
 
 	url := kimiauth.KimiAPIBaseURL + "/v1/chat/completions"
@@ -225,6 +229,10 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body, err = normalizeKimiToolMessageLinks(body)
+	if err != nil {
+		return nil, err
+	}
+	body, err = normalizeKimiEmptyTextContent(body)
 	if err != nil {
 		return nil, err
 	}
@@ -570,6 +578,100 @@ func fallbackAssistantReasoning(msg gjson.Result, hasLatest bool, latest string)
 	}
 
 	return "[reasoning unavailable]"
+}
+
+func normalizeKimiEmptyTextContent(body []byte) ([]byte, error) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body, nil
+	}
+
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body, nil
+	}
+
+	msgs := messages.Array()
+	kept := make([]string, 0, len(msgs))
+	modified := false
+	for _, msg := range msgs {
+		content := msg.Get("content")
+		if !content.Exists() || content.Type == gjson.Null {
+			kept = append(kept, msg.Raw)
+			continue
+		}
+		if content.Type == gjson.String {
+			kept = append(kept, msg.Raw)
+			continue
+		}
+		if !content.IsArray() {
+			kept = append(kept, msg.Raw)
+			continue
+		}
+
+		parts := content.Array()
+		filtered := make([]string, 0, len(parts))
+		for _, part := range parts {
+			if !part.IsObject() {
+				filtered = append(filtered, part.Raw)
+				continue
+			}
+			partType := strings.TrimSpace(part.Get("type").String())
+			if partType == "text" {
+				text := strings.TrimSpace(part.Get("text").String())
+				if text == "" {
+					modified = true
+					continue
+				}
+			}
+			filtered = append(filtered, part.Raw)
+		}
+		if len(filtered) == 0 {
+			// Don't drop assistant messages that still carry tool_calls or function_call
+			// even when their content is empty; dropping them would break the tool-call
+			// chain for the subsequent tool message.
+			if hasKimiToolCalls(msg) || hasKimiLegacyFunctionCall(msg) {
+				kept = append(kept, msg.Raw)
+				continue
+			}
+			modified = true
+			continue
+		}
+		if len(filtered) == 1 {
+			// If only one text part remains, flatten to string for better provider compatibility
+			single := gjson.Parse(filtered[0])
+			if strings.TrimSpace(single.Get("type").String()) == "text" && single.Get("text").Exists() {
+				newContent := single.Get("text").String()
+				newMsg, err := sjson.SetBytes([]byte(msg.Raw), "content", newContent)
+				if err != nil {
+					return body, fmt.Errorf("kimi executor: failed to flatten single text content: %w", err)
+				}
+				kept = append(kept, string(newMsg))
+				modified = true
+				continue
+			}
+		}
+		if len(filtered) != len(parts) {
+			newContent := "[" + strings.Join(filtered, ",") + "]"
+			newMsg, err := sjson.SetRawBytes([]byte(msg.Raw), "content", []byte(newContent))
+			if err != nil {
+				return body, fmt.Errorf("kimi executor: failed to filter empty text content: %w", err)
+			}
+			kept = append(kept, string(newMsg))
+			modified = true
+		} else {
+			kept = append(kept, msg.Raw)
+		}
+	}
+	if !modified {
+		return body, nil
+	}
+
+	rawMessages := []byte("[" + strings.Join(kept, ",") + "]")
+	out, err := sjson.SetRawBytes(body, "messages", rawMessages)
+	if err != nil {
+		return body, fmt.Errorf("kimi executor: failed to drop messages with empty text content: %w", err)
+	}
+	return out, nil
 }
 
 // Refresh refreshes the Kimi token using the refresh token.

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -270,3 +270,224 @@ func TestNormalizeKimiToolMessageLinks_PreservesAssistantWithToolLinkOrReasoning
 		t.Fatalf("messages.3.content.0.text = %q, want %q", got, " visible ")
 	}
 }
+
+func TestNormalizeKimiEmptyTextContent_DropsEmptyTextParts(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"hello"},{"type":"text","text":""},{"type":"text","text":"world"}]},
+			{"role":"assistant","content":"ok"}
+		]
+	}`)
+
+	out, err := normalizeKimiEmptyTextContent(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiEmptyTextContent() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("messages length = %d, want 2, raw = %s", len(messages), gjson.GetBytes(out, "messages").Raw)
+	}
+	parts := messages[0].Get("content").Array()
+	if len(parts) != 2 {
+		t.Fatalf("messages.0.content length = %d, want 2", len(parts))
+	}
+	if got := parts[0].Get("text").String(); got != "hello" {
+		t.Fatalf("messages.0.content.0.text = %q, want %q", got, "hello")
+	}
+	if got := parts[1].Get("text").String(); got != "world" {
+		t.Fatalf("messages.0.content.1.text = %q, want %q", got, "world")
+	}
+}
+
+func TestNormalizeKimiEmptyTextContent_DropsMessageWithAllEmptyParts(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":""}]},
+			{"role":"assistant","content":"ok"}
+		]
+	}`)
+
+	out, err := normalizeKimiEmptyTextContent(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiEmptyTextContent() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 1 {
+		t.Fatalf("messages length = %d, want 1, raw = %s", len(messages), gjson.GetBytes(out, "messages").Raw)
+	}
+	if got := messages[0].Get("content").String(); got != "ok" {
+		t.Fatalf("messages.0.content = %q, want %q", got, "ok")
+	}
+}
+
+func TestNormalizeKimiEmptyTextContent_FlattensSingleTextPart(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"hello"}]},
+			{"role":"assistant","content":"ok"}
+		]
+	}`)
+
+	out, err := normalizeKimiEmptyTextContent(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiEmptyTextContent() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("messages length = %d, want 2, raw = %s", len(messages), gjson.GetBytes(out, "messages").Raw)
+	}
+	if got := messages[0].Get("content").String(); got != "hello" {
+		t.Fatalf("messages.0.content = %q, want %q", got, "hello")
+	}
+}
+
+func TestNormalizeKimiEmptyTextContent_PreservesNonTextParts(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"user","content":[{"type":"image_url","image_url":{"url":"http://example.com/img.png"}},{"type":"text","text":""}]},
+			{"role":"assistant","content":"ok"}
+		]
+	}`)
+
+	out, err := normalizeKimiEmptyTextContent(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiEmptyTextContent() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("messages length = %d, want 2, raw = %s", len(messages), gjson.GetBytes(out, "messages").Raw)
+	}
+	parts := messages[0].Get("content").Array()
+	if len(parts) != 1 {
+		t.Fatalf("messages.0.content length = %d, want 1", len(parts))
+	}
+	if got := parts[0].Get("type").String(); got != "image_url" {
+		t.Fatalf("messages.0.content.0.type = %q, want %q", got, "image_url")
+	}
+}
+
+func TestNormalizeKimiEmptyTextContent_PreservesStringContent(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"user","content":"hello"},
+			{"role":"assistant","content":"ok"}
+		]
+	}`)
+
+	out, err := normalizeKimiEmptyTextContent(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiEmptyTextContent() error = %v", err)
+	}
+
+	if string(out) != string(body) {
+		t.Fatalf("output should be unchanged for string content, got %s", out)
+	}
+}
+
+func TestNormalizeKimiEmptyTextContent_MixedRolesWithEmptyDeveloper(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"developer","content":[{"type":"text","text":""}]},
+			{"role":"user","content":[{"type":"text","text":"ping"}]},
+			{"role":"developer","content":[{"type":"text","text":""}]}
+		]
+	}`)
+
+	out, err := normalizeKimiEmptyTextContent(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiEmptyTextContent() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 1 {
+		t.Fatalf("messages length = %d, want 1, raw = %s", len(messages), gjson.GetBytes(out, "messages").Raw)
+	}
+	if got := messages[0].Get("content").String(); got != "ping" {
+		t.Fatalf("messages.0.content = %q, want %q", got, "ping")
+	}
+}
+
+func TestNormalizeKimiEmptyTextContent_PreservesAssistantWithToolCalls(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"user","content":"do it"},
+			{"role":"assistant","content":[{"type":"text","text":""}],"tool_calls":[{"id":"call_1","type":"function","function":{"name":"list_directory","arguments":"{}"}}]},
+			{"role":"tool","tool_call_id":"call_1","content":"[]"}
+		]
+	}`)
+
+	out, err := normalizeKimiEmptyTextContent(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiEmptyTextContent() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 3 {
+		t.Fatalf("messages length = %d, want 3, raw = %s", len(messages), gjson.GetBytes(out, "messages").Raw)
+	}
+	if !messages[1].Get("tool_calls").Exists() {
+		t.Fatalf("messages.1.tool_calls should exist")
+	}
+	if got := messages[1].Get("tool_calls.0.id").String(); got != "call_1" {
+		t.Fatalf("messages.1.tool_calls.0.id = %q, want %q", got, "call_1")
+	}
+	if got := messages[2].Get("tool_call_id").String(); got != "call_1" {
+		t.Fatalf("messages.2.tool_call_id = %q, want %q", got, "call_1")
+	}
+}
+
+func TestNormalizeKimiEmptyTextContent_PreservesAssistantWithLegacyFunctionCall(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"user","content":"do it"},
+			{"role":"assistant","content":[{"type":"text","text":""}],"function_call":{"name":"list_directory","arguments":"{}"}},
+			{"role":"tool","tool_call_id":"call_1","content":"[]"}
+		]
+	}`)
+
+	out, err := normalizeKimiEmptyTextContent(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiEmptyTextContent() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 3 {
+		t.Fatalf("messages length = %d, want 3, raw = %s", len(messages), gjson.GetBytes(out, "messages").Raw)
+	}
+	if !messages[1].Get("function_call").Exists() {
+		t.Fatalf("messages.1.function_call should exist")
+	}
+	if got := messages[1].Get("function_call.name").String(); got != "list_directory" {
+		t.Fatalf("messages.1.function_call.name = %q, want %q", got, "list_directory")
+	}
+}
+
+func TestNormalizeKimiEmptyTextContent_DropsEmptyAssistantWithoutToolCalls(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"user","content":"do it"},
+			{"role":"assistant","content":[{"type":"text","text":""}]},
+			{"role":"user","content":"next"}
+		]
+	}`)
+
+	out, err := normalizeKimiEmptyTextContent(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiEmptyTextContent() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("messages length = %d, want 2, raw = %s", len(messages), gjson.GetBytes(out, "messages").Raw)
+	}
+	if got := messages[0].Get("content").String(); got != "do it" {
+		t.Fatalf("messages.0.content = %q, want %q", got, "do it")
+	}
+	if got := messages[1].Get("content").String(); got != "next" {
+		t.Fatalf("messages.1.content = %q, want %q", got, "next")
+	}
+}


### PR DESCRIPTION
### Problem
When using Codex CLI with `kimi-k2.7-code` via CLIProxyAPI, requests fail with:

```json
{"error":{"message":"text content is empty","type":"invalid_request_error"}}
 ```
#### Root cause: 
Codex sends /v1/responses requests containing developer messages with input_text parts that have text: "". The OpenAI
Responses → Chat Completions translator preserves these empty parts, and Kimi's upstream API rejects any message whose content array contains a text part with an empty string.

### Solution
Add normalizeKimiEmptyTextContent() in KimiExecutor and call it in both Execute and ExecuteStream before forwarding to Kimi.

#### What it does:
 1. Filters content parts where type == "text" and text is empty/whitespace-only
 2. Drops entire messages if all their content parts become empty
 3. Flattens a single remaining text part to a plain string ("hello" instead of [{"type":"text","text":"hello"}]) for better upstream compatibility

