### PR TITLE
fix: rebind session affinity after fallback success

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -123,6 +123,10 @@ type Selector interface {
 	Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error)
 }
 
+type sessionAffinityBinder interface {
+	Bind(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, authID string)
+}
+
 type PluginScheduler interface {
 	PickAuth(context.Context, pluginapi.SchedulerPickRequest) (pluginapi.SchedulerPickResponse, bool, error)
 }
@@ -1218,6 +1222,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			close(closedCh)
 			remaining = closedCh
 		}
+		m.bindSessionAffinitySuccess(ctx, provider, routeModel, opts, auth.ID)
 		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining), nil
 	}
 	if lastErr == nil {
@@ -1840,6 +1845,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				continue
 			}
 			m.MarkResult(execCtx, result)
+			m.bindSessionAffinitySuccess(execCtx, provider, routeModel, execOpts, auth.ID)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -1941,6 +1947,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				continue
 			}
 			m.MarkResult(execCtx, result)
+			m.bindSessionAffinitySuccess(execCtx, provider, routeModel, execOpts, auth.ID)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -2718,6 +2725,18 @@ func waitForCooldown(ctx context.Context, wait time.Duration) error {
 		return ctx.Err()
 	case <-timer.C:
 		return nil
+	}
+}
+
+func (m *Manager) bindSessionAffinitySuccess(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, authID string) {
+	if m == nil || strings.TrimSpace(authID) == "" {
+		return
+	}
+	m.mu.RLock()
+	selector := m.selector
+	m.mu.RUnlock()
+	if binder, ok := selector.(sessionAffinityBinder); ok && binder != nil {
+		binder.Bind(ctx, provider, selectionArgForSelector(selector, model), opts, authID)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1845,7 +1845,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			m.bindSessionAffinitySuccess(execCtx, provider, routeModel, opts, auth.ID)
+			m.bindSessionAffinitySuccess(execCtx, sessionAffinitySelectorProviderKey(providers, provider), routeModel, opts, auth.ID)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -1947,7 +1947,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			m.bindSessionAffinitySuccess(execCtx, provider, routeModel, opts, auth.ID)
+			m.bindSessionAffinitySuccess(execCtx, sessionAffinitySelectorProviderKey(providers, provider), routeModel, opts, auth.ID)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -2738,6 +2738,13 @@ func (m *Manager) bindSessionAffinitySuccess(ctx context.Context, provider, mode
 	if binder, ok := selector.(sessionAffinityBinder); ok && binder != nil {
 		binder.Bind(ctx, provider, selectionArgForSelector(selector, model), opts, authID)
 	}
+}
+
+func sessionAffinitySelectorProviderKey(providers []string, selectedProvider string) string {
+	if len(providers) == 1 {
+		return selectedProvider
+	}
+	return "mixed"
 }
 
 // MarkResult records an execution result and notifies hooks.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1845,7 +1845,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			m.bindSessionAffinitySuccess(execCtx, provider, routeModel, execOpts, auth.ID)
+			m.bindSessionAffinitySuccess(execCtx, provider, routeModel, opts, auth.ID)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -1947,7 +1947,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			m.bindSessionAffinitySuccess(execCtx, provider, routeModel, execOpts, auth.ID)
+			m.bindSessionAffinitySuccess(execCtx, provider, routeModel, opts, auth.ID)
 			return resp, nil
 		}
 		if authErr != nil {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1222,7 +1222,6 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			close(closedCh)
 			remaining = closedCh
 		}
-		m.bindSessionAffinitySuccess(ctx, provider, routeModel, opts, auth.ID)
 		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining), nil
 	}
 	if lastErr == nil {
@@ -1845,7 +1844,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			m.bindSessionAffinitySuccess(execCtx, sessionAffinitySelectorProviderKey(providers, provider), routeModel, opts, auth.ID)
+			m.bindSessionAffinitySuccess(execCtx, "mixed", routeModel, opts, auth.ID)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -1947,7 +1946,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			m.bindSessionAffinitySuccess(execCtx, sessionAffinitySelectorProviderKey(providers, provider), routeModel, opts, auth.ID)
+			m.bindSessionAffinitySuccess(execCtx, "mixed", routeModel, opts, auth.ID)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -2034,6 +2033,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			}
 			continue
 		}
+		m.bindSessionAffinitySuccess(ctx, "mixed", routeModel, opts, auth.ID)
 		return streamResult, nil
 	}
 }
@@ -2738,13 +2738,6 @@ func (m *Manager) bindSessionAffinitySuccess(ctx context.Context, provider, mode
 	if binder, ok := selector.(sessionAffinityBinder); ok && binder != nil {
 		binder.Bind(ctx, provider, selectionArgForSelector(selector, model), opts, authID)
 	}
-}
-
-func sessionAffinitySelectorProviderKey(providers []string, selectedProvider string) string {
-	if len(providers) == 1 {
-		return selectedProvider
-	}
-	return "mixed"
 }
 
 // MarkResult records an execution result and notifies hooks.

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -568,6 +568,29 @@ func (s *SessionAffinitySelector) InvalidateAuth(authID string) {
 	}
 }
 
+// Bind records the resolved auth for the current session, overriding any
+// provisional binding selected earlier in the request.
+func (s *SessionAffinitySelector) Bind(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, authID string) {
+	if s == nil || s.cache == nil {
+		return
+	}
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return
+	}
+	primaryID, fallbackID := extractSessionIDs(opts.Headers, opts.OriginalRequest, opts.Metadata)
+	if primaryID == "" {
+		return
+	}
+	cacheKey := provider + "::" + primaryID + "::" + model
+	s.cache.Set(cacheKey, authID)
+	if fallbackID != "" && fallbackID != primaryID {
+		fallbackKey := provider + "::" + fallbackID + "::" + model
+		s.cache.Set(fallbackKey, authID)
+	}
+	selectorLogEntry(ctx).Debugf("session-affinity: rebound session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), authID, provider, model)
+}
+
 // ExtractSessionID extracts session identifier from multiple sources.
 // Priority order:
 //  1. metadata.user_id (Claude Code format with _session_{uuid}) - highest priority for Claude Code clients

--- a/sdk/cliproxy/auth/session_affinity_execute_test.go
+++ b/sdk/cliproxy/auth/session_affinity_execute_test.go
@@ -215,3 +215,97 @@ func TestManagerExecute_SessionAffinityRebindUsesMixedSelectorProviderKey(t *tes
 		}
 	}
 }
+
+func TestManagerExecuteStream_SessionAffinityRebindUsesMixedKeyOnly(t *testing.T) {
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	manager := NewManager(nil, selector, nil)
+	executor := &authFallbackExecutor{
+		id: "claude",
+		streamFirstErrors: map[string]error{
+			"auth-a": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota"},
+		},
+	}
+	manager.RegisterExecutor(executor)
+
+	for _, auth := range []*Auth{
+		{ID: "auth-a", Provider: "claude"},
+		{ID: "auth-b", Provider: "claude"},
+	} {
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("register auth %s: %v", auth.ID, errRegister)
+		}
+	}
+
+	const model = "claude-3"
+	for _, authID := range []string{"auth-a", "auth-b"} {
+		registry.GetGlobalRegistry().RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+	}
+	t.Cleanup(func() {
+		for _, authID := range []string{"auth-a", "auth-b"} {
+			registry.GetGlobalRegistry().UnregisterClient(authID)
+		}
+	})
+
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_stream-mixed-key-uuid"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+	providers := []string{"claude", "missing-provider"}
+
+	streamResult, errExecute := manager.ExecuteStream(context.Background(), providers, cliproxyexecutor.Request{Model: model}, opts)
+	if errExecute != nil {
+		t.Fatalf("first ExecuteStream error: %v", errExecute)
+	}
+	firstChunk, ok := <-streamResult.Chunks
+	if !ok {
+		t.Fatal("first ExecuteStream closed without chunk")
+	}
+	if firstChunk.Err != nil {
+		t.Fatalf("first ExecuteStream chunk error: %v", firstChunk.Err)
+	}
+	if got := string(firstChunk.Payload); got != "auth-b" {
+		t.Fatalf("first ExecuteStream chunk payload = %q, want auth-b", got)
+	}
+
+	primaryID, _ := extractSessionIDs(opts.Headers, opts.OriginalRequest, opts.Metadata)
+	if primaryID == "" {
+		t.Fatal("expected non-empty session id")
+	}
+	mixedKey := "mixed::" + primaryID + "::" + model
+	if got, ok := selector.cache.Get(mixedKey); !ok || got != "auth-b" {
+		t.Fatalf("mixed cache binding = (%q, %v), want (auth-b, true)", got, ok)
+	}
+	providerKey := "claude::" + primaryID + "::" + model
+	if got, ok := selector.cache.Get(providerKey); ok {
+		t.Fatalf("provider-scoped cache binding = (%q, %v), want no binding", got, ok)
+	}
+
+	streamResult, errExecute = manager.ExecuteStream(context.Background(), providers, cliproxyexecutor.Request{Model: model}, opts)
+	if errExecute != nil {
+		t.Fatalf("second ExecuteStream error: %v", errExecute)
+	}
+	secondChunk, ok := <-streamResult.Chunks
+	if !ok {
+		t.Fatal("second ExecuteStream closed without chunk")
+	}
+	if secondChunk.Err != nil {
+		t.Fatalf("second ExecuteStream chunk error: %v", secondChunk.Err)
+	}
+	if got := string(secondChunk.Payload); got != "auth-b" {
+		t.Fatalf("second ExecuteStream chunk payload = %q, want auth-b", got)
+	}
+
+	calls := executor.StreamCalls()
+	want := []string{"auth-a", "auth-b", "auth-b"}
+	if len(calls) != len(want) {
+		t.Fatalf("stream calls = %#v, want %#v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("stream calls[%d] = %q, want %q (all calls: %#v)", i, calls[i], want[i], calls)
+		}
+	}
+}

--- a/sdk/cliproxy/auth/session_affinity_execute_test.go
+++ b/sdk/cliproxy/auth/session_affinity_execute_test.go
@@ -148,3 +148,70 @@ func TestManagerExecute_SessionAffinityRebindUsesOriginalRequestAfterInterceptor
 		}
 	}
 }
+
+func TestManagerExecute_SessionAffinityRebindUsesMixedSelectorProviderKey(t *testing.T) {
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	manager := NewManager(nil, selector, nil)
+	executor := &authFallbackExecutor{
+		id: "claude",
+		executeErrors: map[string]error{
+			"auth-a": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota"},
+		},
+	}
+	manager.RegisterExecutor(executor)
+
+	for _, auth := range []*Auth{
+		{ID: "auth-a", Provider: "claude"},
+		{ID: "auth-b", Provider: "claude"},
+	} {
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("register auth %s: %v", auth.ID, errRegister)
+		}
+	}
+
+	const model = "claude-3"
+	for _, authID := range []string{"auth-a", "auth-b"} {
+		registry.GetGlobalRegistry().RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+	}
+	t.Cleanup(func() {
+		for _, authID := range []string{"auth-a", "auth-b"} {
+			registry.GetGlobalRegistry().UnregisterClient(authID)
+		}
+	})
+
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_rebind-mixed-provider-uuid"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+	providers := []string{"claude", "missing-provider"}
+
+	resp, errExecute := manager.Execute(context.Background(), providers, cliproxyexecutor.Request{Model: model}, opts)
+	if errExecute != nil {
+		t.Fatalf("first Execute error: %v", errExecute)
+	}
+	if got := string(resp.Payload); got != "auth-b" {
+		t.Fatalf("first Execute payload = %q, want auth-b", got)
+	}
+
+	resp, errExecute = manager.Execute(context.Background(), providers, cliproxyexecutor.Request{Model: model}, opts)
+	if errExecute != nil {
+		t.Fatalf("second Execute error: %v", errExecute)
+	}
+	if got := string(resp.Payload); got != "auth-b" {
+		t.Fatalf("second Execute payload = %q, want auth-b", got)
+	}
+
+	calls := executor.ExecuteCalls()
+	want := []string{"auth-a", "auth-b", "auth-b"}
+	if len(calls) != len(want) {
+		t.Fatalf("execute calls = %#v, want %#v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("execute calls[%d] = %q, want %q (all calls: %#v)", i, calls[i], want[i], calls)
+		}
+	}
+}

--- a/sdk/cliproxy/auth/session_affinity_execute_test.go
+++ b/sdk/cliproxy/auth/session_affinity_execute_test.go
@@ -75,3 +75,76 @@ func TestManagerExecute_SessionAffinityRebindsToSuccessfulFallbackAuth(t *testin
 		}
 	}
 }
+
+func TestManagerExecute_SessionAffinityRebindUsesOriginalRequestAfterInterceptorRewrite(t *testing.T) {
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	manager := NewManager(nil, selector, nil)
+	executor := &authFallbackExecutor{
+		id: "claude",
+		executeErrors: map[string]error{
+			"auth-a": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota"},
+		},
+	}
+	manager.RegisterExecutor(executor)
+
+	for _, auth := range []*Auth{
+		{ID: "auth-a", Provider: "claude"},
+		{ID: "auth-b", Provider: "claude"},
+	} {
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("register auth %s: %v", auth.ID, errRegister)
+		}
+	}
+
+	const model = "claude-3"
+	for _, authID := range []string{"auth-a", "auth-b"} {
+		registry.GetGlobalRegistry().RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+	}
+	t.Cleanup(func() {
+		for _, authID := range []string{"auth-a", "auth-b"} {
+			registry.GetGlobalRegistry().UnregisterClient(authID)
+		}
+	})
+
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_rebind-interceptor-uuid"},"messages":[{"role":"user","content":"hello"}]}`)
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: payload,
+		RequestAfterAuthInterceptor: func(_ context.Context, _ cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+			return cliproxyexecutor.RequestAfterAuthInterceptResponse{
+				Body: []byte(`{"messages":[{"role":"user","content":"rewritten"}]}`),
+			}
+		},
+	}
+
+	resp, errExecute := manager.Execute(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model, Payload: payload}, opts)
+	if errExecute != nil {
+		t.Fatalf("first Execute error: %v", errExecute)
+	}
+	if got := string(resp.Payload); got != "auth-b" {
+		t.Fatalf("first Execute payload = %q, want auth-b", got)
+	}
+
+	resp, errExecute = manager.Execute(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model, Payload: payload}, opts)
+	if errExecute != nil {
+		t.Fatalf("second Execute error: %v", errExecute)
+	}
+	if got := string(resp.Payload); got != "auth-b" {
+		t.Fatalf("second Execute payload = %q, want auth-b", got)
+	}
+
+	calls := executor.ExecuteCalls()
+	want := []string{"auth-a", "auth-b", "auth-b"}
+	if len(calls) != len(want) {
+		t.Fatalf("execute calls = %#v, want %#v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("execute calls[%d] = %q, want %q (all calls: %#v)", i, calls[i], want[i], calls)
+		}
+	}
+}

--- a/sdk/cliproxy/auth/session_affinity_execute_test.go
+++ b/sdk/cliproxy/auth/session_affinity_execute_test.go
@@ -1,0 +1,79 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestManagerExecute_SessionAffinityRebindsToSuccessfulFallbackAuth(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	manager := NewManager(nil, selector, nil)
+	executor := &authFallbackExecutor{
+		id: "claude",
+		executeErrors: map[string]error{
+			"auth-a": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota"},
+		},
+	}
+	manager.RegisterExecutor(executor)
+
+	for _, auth := range []*Auth{
+		{ID: "auth-a", Provider: "claude"},
+		{ID: "auth-b", Provider: "claude"},
+	} {
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("register auth %s: %v", auth.ID, errRegister)
+		}
+	}
+
+	const model = "claude-3"
+	for _, authID := range []string{"auth-a", "auth-b"} {
+		registry.GetGlobalRegistry().RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+	}
+	t.Cleanup(func() {
+		for _, authID := range []string{"auth-a", "auth-b"} {
+			registry.GetGlobalRegistry().UnregisterClient(authID)
+		}
+	})
+
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_rebind-success-uuid"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+
+	resp, errExecute := manager.Execute(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, opts)
+	if errExecute != nil {
+		t.Fatalf("first Execute error: %v", errExecute)
+	}
+	if got := string(resp.Payload); got != "auth-b" {
+		t.Fatalf("first Execute payload = %q, want auth-b", got)
+	}
+
+	resp, errExecute = manager.Execute(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, opts)
+	if errExecute != nil {
+		t.Fatalf("second Execute error: %v", errExecute)
+	}
+	if got := string(resp.Payload); got != "auth-b" {
+		t.Fatalf("second Execute payload = %q, want auth-b", got)
+	}
+
+	calls := executor.ExecuteCalls()
+	want := []string{"auth-a", "auth-b", "auth-b"}
+	if len(calls) != len(want) {
+		t.Fatalf("execute calls = %#v, want %#v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("execute calls[%d] = %q, want %q (all calls: %#v)", i, calls[i], want[i], calls)
+		}
+	}
+}

--- a/sdk/cliproxy/auth/session_affinity_execute_test.go
+++ b/sdk/cliproxy/auth/session_affinity_execute_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestManagerExecute_SessionAffinityRebindsToSuccessfulFallbackAuth(t *testing.T) {
-	t.Parallel()
-
 	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
 		Fallback: &RoundRobinSelector{},
 		TTL:      time.Minute,


### PR DESCRIPTION
## Summary

Fix session affinity so a request that falls back to another auth after an initial auth fails will stick to the auth that actually succeeds.

Previously, session affinity was bound when the selector first picked an auth. If that auth failed and the same request retried another auth successfully, the sticky binding could still point to the earlier auth until a later invalidation happened.

## What changed

- add a narrow `Bind(...)` hook to `SessionAffinitySelector`
- rebind session affinity on successful execute/count/stream success paths
- preserve fallback session-hash inheritance when rebinding
- add a manager-level regression test covering:
  - first auth fails
  - fallback auth succeeds
  - next request sticks to the successful fallback auth

## Validation

- `go test ./sdk/cliproxy/auth`
- `go test ./...`
- `go build -o cli-proxy-api ./cmd/server`