### PR TITLE
fix(registry): support effort=max for claude-sonnet-4-6 thinking

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -46,7 +46,8 @@
         "levels": [
           "low",
           "medium",
-          "high"
+          "high",
+          "max"
         ]
       }
     },


### PR DESCRIPTION
## Summary

`claude-sonnet-4-6` rejects adaptive-thinking requests that use `output_config.effort: "max"`. Its entry in `internal/registry/models/models.json` only declared thinking `levels` `["low", "medium", "high"]`, so `internal/thinking/validate.go` rejected `max` before the request could reach the Claude OAuth upstream.

This adds `"max"` to the model's `levels`, matching the sibling `claude-opus-4-6` entry (which already supports `max`).

## Change

`internal/registry/models/models.json` — `claude` provider, `claude-sonnet-4-6`:

```diff
         "levels": [
           "low",
           "medium",
-          "high"
+          "high",
+          "max"
         ]
```

## Testing

This request now passes validation instead of being rejected up front:

```bash
curl http://127.0.0.1:8317/v1/messages \
    -H "Content-Type: application/json" \
    -H "x-api-key: $API_KEY" \
    -d '{
      "model": "claude-sonnet-4-6",
      "max_tokens": 32000,
      "thinking": { "type": "adaptive" },
      "output_config": { "effort": "max" },
      "messages": [{ "role": "user", "content": "hi" }]
    }'
```

The file was validated as well-formed JSON (`python3 -c 'import json; json.load(open(...))'`).

Fixes #3901

🤖 Generated with [Claude Code](https://claude.com/claude-code)
