### PR TITLE
fix(management): clear Codex quota state after reset

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -195,11 +195,37 @@ func (h *Handler) APICall(c *gin.Context) {
 		return
 	}
 
+	if isCodexQuotaResetConsumeAPICall(method, parsedURL, resp.StatusCode, auth) && h != nil && h.authManager != nil {
+		if h.authManager.ClearQuotaState(c.Request.Context(), auth.ID) {
+			log.WithField("auth_id", auth.ID).Debug("cleared Codex quota routing state after reset credit consume")
+		}
+	}
+
 	c.JSON(http.StatusOK, apiCallResponse{
 		StatusCode: resp.StatusCode,
 		Header:     resp.Header,
 		Body:       string(respBody),
 	})
+}
+
+func isCodexQuotaResetConsumeAPICall(method string, parsedURL *url.URL, statusCode int, auth *coreauth.Auth) bool {
+	if auth == nil || parsedURL == nil {
+		return false
+	}
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return false
+	}
+	if strings.ToUpper(strings.TrimSpace(method)) != http.MethodPost {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return false
+	}
+	host := strings.ToLower(strings.TrimSpace(parsedURL.Hostname()))
+	if host != "chatgpt.com" {
+		return false
+	}
+	return strings.TrimSpace(parsedURL.EscapedPath()) == "/backend-api/wham/rate-limit-reset-credits/consume"
 }
 
 func firstNonEmptyString(values ...*string) string {

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -3,6 +3,7 @@ package management
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -208,5 +209,78 @@ func TestAuthByIndexDistinguishesSharedAPIKeysAcrossProviders(t *testing.T) {
 	}
 	if gotCompat.ID != compatAuth.ID {
 		t.Fatalf("authByIndex(compat) returned %q, want %q", gotCompat.ID, compatAuth.ID)
+	}
+}
+
+func TestIsCodexQuotaResetConsumeAPICall(t *testing.T) {
+	t.Parallel()
+
+	resetURL, errParse := url.Parse("https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume")
+	if errParse != nil {
+		t.Fatalf("parse reset URL: %v", errParse)
+	}
+	auth := &coreauth.Auth{Provider: "codex"}
+
+	if !isCodexQuotaResetConsumeAPICall(http.MethodPost, resetURL, http.StatusOK, auth) {
+		t.Fatal("expected Codex quota reset consume call to match")
+	}
+
+	cases := []struct {
+		name       string
+		method     string
+		target     string
+		statusCode int
+		auth       *coreauth.Auth
+	}{
+		{
+			name:       "non post",
+			method:     http.MethodGet,
+			target:     resetURL.String(),
+			statusCode: http.StatusOK,
+			auth:       auth,
+		},
+		{
+			name:       "failed upstream",
+			method:     http.MethodPost,
+			target:     resetURL.String(),
+			statusCode: http.StatusTooManyRequests,
+			auth:       auth,
+		},
+		{
+			name:       "non codex auth",
+			method:     http.MethodPost,
+			target:     resetURL.String(),
+			statusCode: http.StatusOK,
+			auth:       &coreauth.Auth{Provider: "gemini"},
+		},
+		{
+			name:       "wrong host",
+			method:     http.MethodPost,
+			target:     "https://example.com/backend-api/wham/rate-limit-reset-credits/consume",
+			statusCode: http.StatusOK,
+			auth:       auth,
+		},
+		{
+			name:       "wrong path",
+			method:     http.MethodPost,
+			target:     "https://chatgpt.com/backend-api/wham/usage",
+			statusCode: http.StatusOK,
+			auth:       auth,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, errParse := url.Parse(tc.target)
+			if errParse != nil {
+				t.Fatalf("parse target: %v", errParse)
+			}
+			if isCodexQuotaResetConsumeAPICall(tc.method, parsed, tc.statusCode, tc.auth) {
+				t.Fatal("expected call not to match")
+			}
+		})
 	}
 }

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -672,6 +672,48 @@ func (r *ModelRegistry) ClearModelQuotaExceeded(clientID, modelID string) {
 	}
 }
 
+// ClearClientQuotaState removes quota tracking and quota-caused suspension for a client.
+func (r *ModelRegistry) ClearClientQuotaState(clientID string) int {
+	clientID = strings.TrimSpace(clientID)
+	if clientID == "" {
+		return 0
+	}
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.ensureAvailableModelsCacheLocked()
+
+	cleared := 0
+	now := time.Now()
+	for _, registration := range r.models {
+		if registration == nil {
+			continue
+		}
+		changedRegistration := false
+		if registration.QuotaExceededClients != nil {
+			if _, ok := registration.QuotaExceededClients[clientID]; ok {
+				delete(registration.QuotaExceededClients, clientID)
+				cleared++
+				changedRegistration = true
+			}
+		}
+		if registration.SuspendedClients != nil {
+			if reason, ok := registration.SuspendedClients[clientID]; ok && strings.EqualFold(strings.TrimSpace(reason), "quota") {
+				delete(registration.SuspendedClients, clientID)
+				cleared++
+				changedRegistration = true
+			}
+		}
+		if changedRegistration {
+			registration.LastUpdated = now
+		}
+	}
+	if cleared > 0 {
+		r.invalidateAvailableModelsCacheLocked()
+	}
+	return cleared
+}
+
 // SuspendClientModel marks a client's model as temporarily unavailable until explicitly resumed.
 // Parameters:
 //   - clientID: The client to suspend

--- a/internal/registry/model_registry_safety_test.go
+++ b/internal/registry/model_registry_safety_test.go
@@ -110,6 +110,44 @@ func TestCleanupExpiredQuotasInvalidatesAvailableModelsCache(t *testing.T) {
 	}
 }
 
+func TestClearClientQuotaStateClearsOnlyQuotaMarkers(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("client-1", "codex", []*ModelInfo{
+		{ID: "quota-model"},
+		{ID: "blocked-model"},
+	})
+	r.SetModelQuotaExceeded("client-1", "quota-model")
+	r.SuspendClientModel("client-1", "quota-model", "quota")
+	r.SuspendClientModel("client-1", "blocked-model", "unauthorized")
+
+	cleared := r.ClearClientQuotaState("client-1")
+	if cleared != 2 {
+		t.Fatalf("ClearClientQuotaState cleared %d markers, want 2", cleared)
+	}
+
+	quotaRegistration := r.models["quota-model"]
+	if quotaRegistration == nil {
+		t.Fatal("expected quota-model registration")
+	}
+	if _, ok := quotaRegistration.QuotaExceededClients["client-1"]; ok {
+		t.Fatal("expected quota exceeded marker to be cleared")
+	}
+	if _, ok := quotaRegistration.SuspendedClients["client-1"]; ok {
+		t.Fatal("expected quota suspension to be cleared")
+	}
+
+	blockedRegistration := r.models["blocked-model"]
+	if blockedRegistration == nil {
+		t.Fatal("expected blocked-model registration")
+	}
+	if got := blockedRegistration.SuspendedClients["client-1"]; got != "unauthorized" {
+		t.Fatalf("expected unauthorized suspension to remain, got %q", got)
+	}
+	if clearedAgain := r.ClearClientQuotaState("client-1"); clearedAgain != 0 {
+		t.Fatalf("second ClearClientQuotaState cleared %d markers, want 0", clearedAgain)
+	}
+}
+
 func TestGetAvailableModelsReturnsClonedSupportedParameters(t *testing.T) {
 	r := newTestModelRegistry()
 	r.RegisterClient("client-1", "openai", []*ModelInfo{{

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -486,9 +486,6 @@ func (m *Manager) ClearQuotaState(ctx context.Context, authID string) bool {
 		}
 		managerChanged = clearQuotaStateForAuth(auth, now)
 		if managerChanged {
-			if errPersist := m.persist(ctx, auth); errPersist != nil {
-				logEntryWithRequestID(ctx).WithField("auth_id", auth.ID).Warnf("failed to persist auth quota reset state: %v", errPersist)
-			}
 			snapshot = auth.Clone()
 		}
 		if trackCooldownState {
@@ -498,6 +495,11 @@ func (m *Manager) ClearQuotaState(ctx context.Context, authID string) bool {
 	}
 	m.mu.Unlock()
 
+	if managerChanged && snapshot != nil {
+		if errPersist := m.persist(ctx, snapshot); errPersist != nil {
+			logEntryWithRequestID(ctx).WithField("auth_id", snapshot.ID).Warnf("failed to persist auth quota reset state: %v", errPersist)
+		}
+	}
 	if m.scheduler != nil {
 		switch {
 		case snapshot != nil:

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -457,6 +457,61 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 }
 
+// ClearQuotaState clears quota-related auth and registry state for one auth.
+func (m *Manager) ClearQuotaState(ctx context.Context, authID string) bool {
+	if m == nil {
+		return false
+	}
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return false
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	registryCleared := registry.GetGlobalRegistry().ClearClientQuotaState(authID)
+
+	var snapshot *Auth
+	cooldownStateChanged := false
+	managerChanged := false
+	now := time.Now()
+
+	m.mu.Lock()
+	if auth, ok := m.auths[authID]; ok && auth != nil {
+		var cooldownRecordsBefore []CooldownStateRecord
+		trackCooldownState := m.cooldownStore != nil
+		if trackCooldownState {
+			cooldownRecordsBefore = m.cooldownStateRecordsForAuthLocked(auth, now)
+		}
+		managerChanged = clearQuotaStateForAuth(auth, now)
+		if managerChanged {
+			if errPersist := m.persist(ctx, auth); errPersist != nil {
+				logEntryWithRequestID(ctx).WithField("auth_id", auth.ID).Warnf("failed to persist auth quota reset state: %v", errPersist)
+			}
+			snapshot = auth.Clone()
+		}
+		if trackCooldownState {
+			cooldownRecordsAfter := m.cooldownStateRecordsForAuthLocked(auth, now)
+			cooldownStateChanged = !cooldownStateRecordsEqual(cooldownRecordsBefore, cooldownRecordsAfter)
+		}
+	}
+	m.mu.Unlock()
+
+	if m.scheduler != nil {
+		switch {
+		case snapshot != nil:
+			m.scheduler.upsertAuth(snapshot)
+		case registryCleared > 0:
+			m.RefreshSchedulerEntry(authID)
+		}
+	}
+	if cooldownStateChanged {
+		m.persistCooldownStates(ctx)
+	}
+	return managerChanged || registryCleared > 0
+}
+
 func (m *Manager) SetSelector(selector Selector) {
 	if m == nil {
 		return
@@ -684,6 +739,127 @@ func clearCooldownStateForAuth(auth *Auth, now time.Time) bool {
 		updateAggregatedAvailability(auth, now)
 	}
 	return changed
+}
+
+func clearQuotaStateForAuth(auth *Auth, now time.Time) bool {
+	if auth == nil {
+		return false
+	}
+	changed := false
+	authQuotaState := quotaStateIsResettable(auth.Quota) || errorIsResettableQuota(auth.LastError) || quotaMessageIsResettable(auth.StatusMessage)
+	if authQuotaState {
+		if auth.Unavailable || !auth.NextRetryAfter.IsZero() || !quotaStateIsEmpty(auth.Quota) {
+			auth.Unavailable = false
+			auth.NextRetryAfter = time.Time{}
+			auth.Quota = QuotaState{}
+			changed = true
+		}
+		if errorIsResettableQuota(auth.LastError) {
+			auth.LastError = nil
+			changed = true
+		}
+		if quotaMessageIsResettable(auth.StatusMessage) {
+			auth.StatusMessage = ""
+			changed = true
+		}
+	}
+	for _, state := range auth.ModelStates {
+		if !modelStateHasResettableQuota(state) {
+			continue
+		}
+		if !modelStateIsClean(state) {
+			resetModelState(state, now)
+			changed = true
+		}
+	}
+	if !changed {
+		return false
+	}
+	if len(auth.ModelStates) > 0 {
+		updateAggregatedAvailability(auth, now)
+	} else {
+		clearAggregatedAvailability(auth)
+	}
+	if !hasModelError(auth, now) {
+		auth.LastError = nil
+		auth.StatusMessage = ""
+		if !auth.Disabled && auth.Status != StatusDisabled {
+			auth.Status = StatusActive
+		}
+	} else {
+		if errorIsResettableQuota(auth.LastError) {
+			auth.LastError = nil
+		}
+		if quotaMessageIsResettable(auth.StatusMessage) {
+			auth.StatusMessage = ""
+		}
+	}
+	auth.UpdatedAt = now
+	return true
+}
+
+func quotaStateIsResettable(quota QuotaState) bool {
+	reason := strings.ToLower(strings.TrimSpace(quota.Reason))
+	if quotaReasonIsNonResettable(reason) {
+		return false
+	}
+	if quota.Exceeded {
+		return reason == "" || quotaMessageIsResettable(reason)
+	}
+	return quotaMessageIsResettable(reason)
+}
+
+func quotaStateIsEmpty(quota QuotaState) bool {
+	return !quota.Exceeded && quota.Reason == "" && quota.NextRecoverAt.IsZero() && quota.BackoffLevel == 0
+}
+
+func modelStateHasResettableQuota(state *ModelState) bool {
+	if state == nil {
+		return false
+	}
+	if quotaStateIsResettable(state.Quota) {
+		return true
+	}
+	if errorIsResettableQuota(state.LastError) {
+		return true
+	}
+	return quotaMessageIsResettable(state.StatusMessage)
+}
+
+func errorIsResettableQuota(err *Error) bool {
+	if err == nil {
+		return false
+	}
+	if quotaMessageIsResettable(err.Code) || quotaMessageIsResettable(err.Message) {
+		return true
+	}
+	if err.StatusCode() != http.StatusTooManyRequests {
+		return false
+	}
+	combined := strings.TrimSpace(err.Code + " " + err.Message)
+	return quotaMessageIsResettable(combined)
+}
+
+func quotaMessageIsResettable(message string) bool {
+	lower := strings.ToLower(strings.TrimSpace(message))
+	if lower == "" || quotaReasonIsNonResettable(lower) {
+		return false
+	}
+	return strings.Contains(lower, "quota") ||
+		strings.Contains(lower, "rate limit") ||
+		strings.Contains(lower, "rate limited") ||
+		strings.Contains(lower, "rate_limit") ||
+		strings.Contains(lower, "rate-limit") ||
+		strings.Contains(lower, "too many requests") ||
+		strings.Contains(lower, "too_many_requests")
+}
+
+func quotaReasonIsNonResettable(reason string) bool {
+	reason = strings.ToLower(strings.TrimSpace(reason))
+	if reason == "" {
+		return false
+	}
+	return strings.Contains(reason, "cloudflare") || strings.Contains(reason, "challenge")
 }
 
 func (m *Manager) persistCooldownStates(ctx context.Context) {

--- a/sdk/cliproxy/auth/conductor_update_test.go
+++ b/sdk/cliproxy/auth/conductor_update_test.go
@@ -2,7 +2,11 @@ package auth
 
 import (
 	"context"
+	"net/http"
 	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
 func TestManager_Update_PreservesModelStates(t *testing.T) {
@@ -200,5 +204,73 @@ func TestManager_Update_ActiveInheritsModelStates(t *testing.T) {
 	}
 	if state.Quota.BackoffLevel != backoffLevel {
 		t.Fatalf("expected BackoffLevel to be %d, got %d", backoffLevel, state.Quota.BackoffLevel)
+	}
+}
+
+func TestManager_ClearQuotaStateClearsQuotaModelAndPreservesOtherFailures(t *testing.T) {
+	ctx := context.Background()
+	const (
+		authID        = "auth-clear-quota-state"
+		quotaModel    = "codex-quota-reset-model"
+		blockedModel  = "codex-unauthorized-model"
+		quotaProvider = "codex"
+	)
+	registry.GetGlobalRegistry().RegisterClient(authID, quotaProvider, []*registry.ModelInfo{
+		{ID: quotaModel},
+		{ID: blockedModel},
+	})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(authID)
+	})
+
+	m := NewManager(nil, &RoundRobinSelector{}, nil)
+	if _, errRegister := m.Register(ctx, &Auth{ID: authID, Provider: quotaProvider, Status: StatusActive}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	m.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: quotaProvider,
+		Model:    quotaModel,
+		Success:  false,
+		Error:    &Error{Code: "rate_limit", Message: "quota exceeded", HTTPStatus: http.StatusTooManyRequests},
+	})
+	m.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: quotaProvider,
+		Model:    blockedModel,
+		Success:  false,
+		Error:    &Error{Code: "unauthorized", Message: "unauthorized", HTTPStatus: http.StatusUnauthorized},
+	})
+
+	if _, errPick := m.scheduler.pickSingle(ctx, quotaProvider, quotaModel, cliproxyexecutor.Options{}, nil); errPick == nil {
+		t.Fatal("expected quota model to be unavailable before clearing quota state")
+	}
+
+	if !m.ClearQuotaState(ctx, authID) {
+		t.Fatal("expected ClearQuotaState to report a change")
+	}
+
+	picked, errPick := m.scheduler.pickSingle(ctx, quotaProvider, quotaModel, cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("expected quota model to be routable after clearing quota state: %v", errPick)
+	}
+	if picked == nil || picked.ID != authID {
+		t.Fatalf("picked auth = %+v, want %q", picked, authID)
+	}
+
+	updated, ok := m.GetByID(authID)
+	if !ok || updated == nil {
+		t.Fatal("expected auth after clearing quota state")
+	}
+	if state := updated.ModelStates[quotaModel]; state == nil || !modelStateIsClean(state) {
+		t.Fatalf("expected quota model state to be clean, got %+v", state)
+	}
+	blockedState := updated.ModelStates[blockedModel]
+	if blockedState == nil || blockedState.LastError == nil || blockedState.LastError.StatusCode() != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized model state to remain, got %+v", blockedState)
+	}
+	if clearedAgain := registry.GetGlobalRegistry().ClearClientQuotaState(authID); clearedAgain != 0 {
+		t.Fatalf("expected registry quota markers to be cleared, clearedAgain=%d", clearedAgain)
 	}
 }


### PR DESCRIPTION
Fixes #3866.

## Summary
- clear Codex quota-related auth/model state after the management `api-call` successfully posts to `https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume`
- clear registry quota markers and quota-caused model suspensions for the selected auth while preserving non-quota suspension reasons such as `unauthorized` and `not_found`
- refresh scheduler state so the reset account can be selected again without waiting for the old cooldown or restarting the service

## Validation
- `gofmt -w internal/registry/model_registry.go internal/registry/model_registry_safety_test.go sdk/cliproxy/auth/conductor.go sdk/cliproxy/auth/conductor_update_test.go internal/api/handlers/management/api_tools.go internal/api/handlers/management/api_tools_test.go`
- `git diff --check`
- `go test ./internal/registry ./sdk/cliproxy/auth`
- `go test ./internal/api/handlers/management -run 'TestIsCodexQuotaResetConsumeAPICall|TestAPICallTransport|TestAuthByIndexDistinguishesSharedAPIKeysAcrossProviders'`
- `go build -o test-output ./cmd/server && rm -f test-output`

## Known existing test failure
- `go test ./internal/api/handlers/management` still fails at `TestWriteOAuthCallbackFileForPendingSessionCreatesMissingAuthDirForCallbackProviders/gemini` with `unsupported oauth provider`; this is outside the reset-quota path changed here.
