### PR TITLE
feat: add weighted round-robin credential selection

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -167,7 +167,11 @@ quota-exceeded:
 
 # Routing strategy for selecting credentials when multiple match.
 routing:
-  strategy: "round-robin" # round-robin (default), fill-first
+  strategy: "round-robin" # round-robin (default), fill-first, weighted-round-robin
+  # weighted-round-robin uses each credential's selection-weight within the
+  # highest available priority bucket. With session-affinity enabled, weights
+  # affect only new session bindings; existing sessions stay pinned until TTL
+  # expiry or credential unavailability.
   # Enable universal session-sticky routing for all clients.
   # Session IDs are extracted from: metadata.user_id (Claude Code session format),
   # X-Session-ID, Session_id (Codex), X-Client-Request-Id (PI), conversation_id,
@@ -179,7 +183,8 @@ routing:
 
 # Codex provider behavior.
 codex:
-  # When true, and routing.strategy is fill-first or routing.session-affinity is true,
+  # When true, and routing.strategy is fill-first or weighted-round-robin, or
+  # routing.session-affinity is true,
   # remap Codex prompt_cache_key and installation identity per selected auth.
   # Some superstitious users believe request tracking identifiers can be used
   # as evidence for TOS enforcement bans; this option only satisfies those odd concerns.
@@ -209,6 +214,7 @@ nonstream-keepalive-interval: 0
 # gemini-api-key:
 #   - api-key: "AIzaSy...01"
 #     prefix: "test" # optional: require calls like "test/gemini-3-pro-preview" to target this credential
+#     selection-weight: 1 # optional: weighted-round-robin share within the same priority bucket; 0 drains new selections
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://generativelanguage.googleapis.com"
 #     headers:
@@ -248,6 +254,7 @@ nonstream-keepalive-interval: 0
 # codex-api-key:
 #   - api-key: "sk-atSM..."
 #     prefix: "test" # optional: require calls like "test/gpt-5-codex" to target this credential
+#     selection-weight: 1 # optional: weighted-round-robin share within the same priority bucket; 0 drains new selections
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
 #     headers:
@@ -270,6 +277,7 @@ nonstream-keepalive-interval: 0
 #   - api-key: "sk-atSM..." # use the official claude API key, no need to set the base url
 #   - api-key: "sk-atSM..."
 #     prefix: "test" # optional: require calls like "test/claude-sonnet-latest" to target this credential
+#     selection-weight: 1 # optional: weighted-round-robin share within the same priority bucket; 0 drains new selections
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://www.example.com" # use the custom claude API endpoint
 #     headers:
@@ -332,12 +340,14 @@ nonstream-keepalive-interval: 0
 #   - name: "openrouter" # The name of the provider; it will be used in the user agent and other places.
 #     disabled: false # optional: set to true to disable this provider without removing it
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
+#     selection-weight: 1 # optional default for this provider's api-key-entries
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
 #     disable-cooling: false # optional: per-provider override for auth/model cooldown scheduling
 #     headers:
 #       X-Custom-Header: "custom-value"
 #     api-key-entries:
 #       - api-key: "sk-or-v1-...b780"
+#         selection-weight: 2 # optional: overrides provider selection-weight for this key
 #         proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
 #         # proxy-url: "direct" # optional: explicit direct connect for this credential
 #       - api-key: "sk-or-v1-...b781" # without proxy-url
@@ -366,6 +376,7 @@ nonstream-keepalive-interval: 0
 # vertex-api-key:
 #   - api-key: "vk-123..."                        # x-goog-api-key header
 #     prefix: "test"                              # optional: require calls like "test/vertex-pro" to target this credential
+#     selection-weight: 1                         # optional: weighted-round-robin share within the same priority bucket
 #     base-url: "https://example.com/api"         # optional, e.g. https://zenmux.ai/api; falls back to Google Vertex when omitted
 #     proxy-url: "socks5://proxy.example.com:1080" # optional per-key proxy override
 #     # proxy-url: "direct" # optional: explicit direct connect for this credential

--- a/examples/plugin/README.md
+++ b/examples/plugin/README.md
@@ -76,7 +76,7 @@ The default example model is `gpt-5.5`, but the request succeeds only when the c
 
 ## Scheduler
 
-`scheduler` declares the scheduler capability. It can select a configured auth ID from the candidate list, delegate to the built-in `fill-first` or `round-robin` scheduler, or reject picks when `deny` is `true`.
+`scheduler` declares the scheduler capability. It can select a configured auth ID from the candidate list, delegate to the built-in `fill-first`, `round-robin`, or `weighted-round-robin` scheduler, or reject picks when `deny` is `true`.
 
 ```yaml
 plugins:
@@ -89,7 +89,7 @@ plugins:
       deny: false
 ```
 
-`auth_id` selects a matching candidate when `delegate` is empty. `delegate` accepts `""`, `fill-first`, or `round-robin`; other non-empty values leave the pick unhandled. `deny` returns a scheduler error.
+`auth_id` selects a matching candidate when `delegate` is empty. `delegate` accepts `""`, `fill-first`, `round-robin`, or `weighted-round-robin`; other non-empty values leave the pick unhandled. `deny` returns a scheduler error.
 
 ## Build All Examples
 

--- a/examples/plugin/README_CN.md
+++ b/examples/plugin/README_CN.md
@@ -75,7 +75,7 @@ plugins:
 
 ## Scheduler
 
-`scheduler` 声明调度能力。它可以从候选列表中选择配置的 auth ID，委托内置的 `fill-first` 或 `round-robin` 调度器，或在 `deny` 为 `true` 时拒绝调度。
+`scheduler` 声明调度能力。它可以从候选列表中选择配置的 auth ID，委托内置的 `fill-first`、`round-robin` 或 `weighted-round-robin` 调度器，或在 `deny` 为 `true` 时拒绝调度。
 
 ```yaml
 plugins:
@@ -88,7 +88,7 @@ plugins:
       deny: false
 ```
 
-`auth_id` 会在 `delegate` 为空时选择匹配候选。`delegate` 支持 `""`、`fill-first` 和 `round-robin`；其他非空值会让本插件不处理本次调度。`deny` 会返回调度错误。
+`auth_id` 会在 `delegate` 为空时选择匹配候选。`delegate` 支持 `""`、`fill-first`、`round-robin` 和 `weighted-round-robin`；其他非空值会让本插件不处理本次调度。`deny` 会返回调度错误。
 
 ## 构建全部示例
 

--- a/examples/plugin/scheduler/README.md
+++ b/examples/plugin/scheduler/README.md
@@ -28,13 +28,13 @@ plugins:
 Fields:
 
 - `auth_id`: selects this auth ID when it appears in the scheduler candidates.
-- `delegate`: delegates selection to a built-in scheduler. Supported values are `""`, `fill-first`, and `round-robin`.
+- `delegate`: delegates selection to a built-in scheduler. Supported values are `""`, `fill-first`, `round-robin`, and `weighted-round-robin`.
 - `deny`: returns a scheduler error when set to `true`.
 
 Behavior:
 
 - When `deny` is `true`, the plugin returns an error envelope with code `scheduler_denied`.
-- When `delegate` is `fill-first` or `round-robin`, the plugin returns `DelegateBuiltin` and marks the pick as handled.
+- When `delegate` is `fill-first`, `round-robin`, or `weighted-round-robin`, the plugin returns `DelegateBuiltin` and marks the pick as handled.
 - When `delegate` is any other non-empty value, the plugin leaves the pick unhandled.
 - When `delegate` is empty and `auth_id` exists in the candidates, the plugin returns that auth ID and marks the pick as handled.
 - When no rule matches, the plugin leaves the pick unhandled.

--- a/examples/plugin/scheduler/go/main.go
+++ b/examples/plugin/scheduler/go/main.go
@@ -186,8 +186,8 @@ func pluginRegistration() registration {
 				{
 					Name:        "delegate",
 					Type:        pluginapi.ConfigFieldTypeEnum,
-					EnumValues:  []string{"", pluginapi.SchedulerBuiltinFillFirst, pluginapi.SchedulerBuiltinRoundRobin},
-					Description: "Delegates selection to a built-in scheduler when set to fill-first or round-robin.",
+					EnumValues:  []string{"", pluginapi.SchedulerBuiltinFillFirst, pluginapi.SchedulerBuiltinRoundRobin, pluginapi.SchedulerBuiltinWeightedRoundRobin},
+					Description: "Delegates selection to a built-in scheduler when set to fill-first, round-robin, or weighted-round-robin.",
 				},
 				{
 					Name:        "deny",
@@ -213,7 +213,7 @@ func pickAuth(raw []byte) ([]byte, error) {
 		return errorEnvelope("scheduler_denied", "scheduler pick denied by plugin configuration"), nil
 	}
 	switch cfg.Delegate {
-	case pluginapi.SchedulerBuiltinFillFirst, pluginapi.SchedulerBuiltinRoundRobin:
+	case pluginapi.SchedulerBuiltinFillFirst, pluginapi.SchedulerBuiltinRoundRobin, pluginapi.SchedulerBuiltinWeightedRoundRobin:
 		return okEnvelope(pluginapi.SchedulerPickResponse{
 			DelegateBuiltin: cfg.Delegate,
 			Handled:         true,

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -427,6 +428,11 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 						}
 					}
 				}
+				if weight, okWeight := gjsonSelectionWeight(data); okWeight {
+					fileData["selection_weight"] = weight
+				} else {
+					fileData["selection_weight"] = 1
+				}
 				if nv := gjson.GetBytes(data, "note"); nv.Exists() && nv.Type == gjson.String {
 					if trimmed := strings.TrimSpace(nv.String()); trimmed != "" {
 						fileData["note"] = trimmed
@@ -553,6 +559,7 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 			}
 		}
 	}
+	entry["selection_weight"] = effectiveAuthFileSelectionWeight(auth)
 	// Expose note from Attributes (set by synthesizer from JSON "note" field).
 	// Fall back to Metadata for auths registered via UploadAuthFile (no synthesizer).
 	if note := strings.TrimSpace(authAttribute(auth, "note")); note != "" {
@@ -1218,6 +1225,7 @@ func (h *Handler) buildAuthFromFileData(path string, data []byte) (*coreauth.Aut
 		}
 	}
 	coreauth.ApplyCustomHeadersFromMetadata(auth)
+	syncAuthFileSelectionWeightAttribute(auth)
 	return auth, nil
 }
 
@@ -1497,6 +1505,28 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 		if targetAuth.Metadata == nil {
 			targetAuth.Metadata = make(map[string]any)
 		}
+		root := rootAuthFileField(fieldPath)
+		if root == "selection_weight" || root == "selection-weight" {
+			if fieldPath != root {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid field %s", fieldPath)})
+				return
+			}
+			if value != nil {
+				if _, okWeight := authFileSelectionWeightValue(value); !okWeight {
+					c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid field %s", fieldPath)})
+					return
+				}
+			}
+			fieldPath = "selection_weight"
+			delete(targetAuth.Metadata, "selection-weight")
+			root = "selection_weight"
+			if value == nil {
+				delete(targetAuth.Metadata, "selection_weight")
+				touchedRoots[root] = struct{}{}
+				changed = true
+				continue
+			}
+		}
 
 		if fieldPath == "headers" {
 			applyAuthFileHeadersPatch(targetAuth, value)
@@ -1504,7 +1534,7 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": errSet.Error()})
 			return
 		}
-		if root := rootAuthFileField(fieldPath); root != "" {
+		if root != "" {
 			touchedRoots[root] = struct{}{}
 		}
 		changed = true
@@ -1655,6 +1685,12 @@ func syncAuthFileMetadataFields(auth *coreauth.Auth, touchedRoots map[string]str
 	if _, ok := touchedRoots["priority"]; ok {
 		syncAuthFilePriorityAttribute(auth)
 	}
+	if _, ok := touchedRoots["selection_weight"]; ok {
+		syncAuthFileSelectionWeightAttribute(auth)
+	}
+	if _, ok := touchedRoots["selection-weight"]; ok {
+		syncAuthFileSelectionWeightAttribute(auth)
+	}
 	if _, ok := touchedRoots["note"]; ok {
 		syncAuthFileNoteAttribute(auth)
 	}
@@ -1706,6 +1742,8 @@ func authFileIntValue(value any) (int, bool) {
 	switch typed := value.(type) {
 	case int:
 		return typed, true
+	case int32:
+		return int(typed), true
 	case int64:
 		return int(typed), true
 	case float64:
@@ -1717,6 +1755,111 @@ func authFileIntValue(value any) (int, bool) {
 	case string:
 		if i, err := strconv.Atoi(strings.TrimSpace(typed)); err == nil {
 			return i, true
+		}
+	}
+	return 0, false
+}
+
+func authFileSelectionWeightValue(value any) (int, bool) {
+	weight, ok := authFileStrictIntValue(value)
+	if !ok || weight < 0 {
+		return 0, false
+	}
+	return weight, true
+}
+
+func authFileStrictIntValue(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int32:
+		return int(typed), true
+	case int64:
+		return int(typed), true
+	case float64:
+		if math.Trunc(typed) != typed {
+			return 0, false
+		}
+		return int(typed), true
+	case json.Number:
+		if i, err := typed.Int64(); err == nil {
+			return int(i), true
+		}
+	case string:
+		if i, err := strconv.Atoi(strings.TrimSpace(typed)); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func syncAuthFileSelectionWeightAttribute(auth *coreauth.Auth) {
+	if auth == nil {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	weight, ok := metadataAuthFileSelectionWeight(auth.Metadata)
+	if !ok {
+		delete(auth.Attributes, "selection_weight")
+		return
+	}
+	auth.Attributes["selection_weight"] = strconv.Itoa(weight)
+}
+
+func metadataAuthFileSelectionWeight(metadata map[string]any) (int, bool) {
+	if metadata == nil {
+		return 0, false
+	}
+	value, ok := metadata["selection_weight"]
+	if !ok {
+		value, ok = metadata["selection-weight"]
+	}
+	if !ok || value == nil {
+		return 0, false
+	}
+	return authFileSelectionWeightValue(value)
+}
+
+func effectiveAuthFileSelectionWeight(auth *coreauth.Auth) int {
+	if auth == nil {
+		return 1
+	}
+	for _, key := range []string{"selection_weight", "selection-weight", "weight"} {
+		if raw := strings.TrimSpace(authAttribute(auth, key)); raw != "" {
+			parsed, errParse := strconv.Atoi(raw)
+			if errParse == nil && parsed >= 0 {
+				return parsed
+			}
+			return 1
+		}
+	}
+	if weight, ok := metadataAuthFileSelectionWeight(auth.Metadata); ok {
+		return weight
+	}
+	return 1
+}
+
+func gjsonSelectionWeight(data []byte) (int, bool) {
+	value := gjson.GetBytes(data, "selection_weight")
+	if !value.Exists() {
+		value = gjson.GetBytes(data, "selection-weight")
+	}
+	if !value.Exists() {
+		return 0, false
+	}
+	switch value.Type {
+	case gjson.Number:
+		parsed, errParse := strconv.ParseInt(value.Raw, 10, 0)
+		if errParse != nil || parsed < 0 {
+			return 0, false
+		}
+		return int(parsed), true
+	case gjson.String:
+		parsed, errParse := strconv.Atoi(strings.TrimSpace(value.String()))
+		if errParse == nil && parsed >= 0 {
+			return parsed, true
 		}
 	}
 	return 0, false

--- a/internal/api/handlers/management/auth_files_patch_fields_test.go
+++ b/internal/api/handlers/management/auth_files_patch_fields_test.go
@@ -212,6 +212,264 @@ func TestPatchAuthFileFields_WebsocketsFalseIsUpdate(t *testing.T) {
 	}
 }
 
+func TestPatchAuthFileFields_SelectionWeightIsSynced(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "weighted.json",
+		FileName: "weighted.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "/tmp/weighted.json",
+		},
+		Metadata: map[string]any{
+			"type": "codex",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	body := `{"name":"weighted.json","selection_weight":0}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("weighted.json")
+	if !ok || updated == nil {
+		t.Fatalf("expected auth record to exist after patch")
+	}
+	if got := updated.Attributes["selection_weight"]; got != "0" {
+		t.Fatalf("attrs selection_weight = %q, want 0", got)
+	}
+	if got, ok := updated.Metadata["selection_weight"].(json.Number); !ok || got.String() != "0" {
+		t.Fatalf("metadata.selection_weight = %#v, want json.Number(0)", updated.Metadata["selection_weight"])
+	}
+}
+
+func TestPatchAuthFileFields_SelectionWeightCanonicalizesAlias(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "weighted.json",
+		FileName: "weighted.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path":             "/tmp/weighted.json",
+			"selection_weight": "2",
+		},
+		Metadata: map[string]any{
+			"type":             "codex",
+			"selection-weight": 2,
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	body := `{"name":"weighted.json","selection_weight":0}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("weighted.json")
+	if !ok || updated == nil {
+		t.Fatalf("expected auth record to exist after patch")
+	}
+	if _, ok := updated.Metadata["selection-weight"]; ok {
+		t.Fatalf("metadata still contains selection-weight alias: %#v", updated.Metadata)
+	}
+	if got, ok := updated.Metadata["selection_weight"].(json.Number); !ok || got.String() != "0" {
+		t.Fatalf("metadata.selection_weight = %#v, want json.Number(0)", updated.Metadata["selection_weight"])
+	}
+	if got := updated.Attributes["selection_weight"]; got != "0" {
+		t.Fatalf("attrs selection_weight = %q, want 0", got)
+	}
+}
+
+func TestPatchAuthFileFields_SelectionWeightNullClearsField(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "weighted.json",
+		FileName: "weighted.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path":             "/tmp/weighted.json",
+			"selection_weight": "2",
+		},
+		Metadata: map[string]any{
+			"type":             "codex",
+			"selection_weight": 2,
+			"selection-weight": 3,
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	body := `{"name":"weighted.json","selection_weight":null}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("weighted.json")
+	if !ok || updated == nil {
+		t.Fatalf("expected auth record to exist after patch")
+	}
+	if _, ok := updated.Metadata["selection_weight"]; ok {
+		t.Fatalf("metadata still contains selection_weight: %#v", updated.Metadata)
+	}
+	if _, ok := updated.Metadata["selection-weight"]; ok {
+		t.Fatalf("metadata still contains selection-weight alias: %#v", updated.Metadata)
+	}
+	if _, ok := updated.Attributes["selection_weight"]; ok {
+		t.Fatalf("attrs still contain selection_weight: %#v", updated.Attributes)
+	}
+}
+
+func TestPatchAuthFileFields_SelectionWeightRejectsNegative(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "weighted.json",
+		FileName: "weighted.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "/tmp/weighted.json",
+		},
+		Metadata: map[string]any{
+			"type": "codex",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	body := `{"name":"weighted.json","selection_weight":-1}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+}
+
+func TestPatchAuthFileFields_SelectionWeightRejectsFractional(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "weighted.json",
+		FileName: "weighted.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path": "/tmp/weighted.json",
+		},
+		Metadata: map[string]any{
+			"type": "codex",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	body := `{"name":"weighted.json","selection_weight":1.5}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+}
+
+func TestBuildAuthFromFileDataSelectionWeightFallback(t *testing.T) {
+	authPath := filepath.Join(t.TempDir(), "weighted.json")
+	auth, err := (&Handler{}).buildAuthFromFileData(authPath, []byte(`{"type":"codex","selection_weight":0}`))
+	if err != nil {
+		t.Fatalf("buildAuthFromFileData() error = %v", err)
+	}
+	if auth == nil {
+		t.Fatalf("buildAuthFromFileData() = nil")
+	}
+	if got := auth.Attributes["selection_weight"]; got != "0" {
+		t.Fatalf("Attributes selection_weight = %q, want 0", got)
+	}
+}
+
+func TestAuthFileSelectionWeightValueProgrammaticIntegerTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  any
+		want   int
+		wantOK bool
+	}{
+		{name: "int32", value: int32(7), want: 7, wantOK: true},
+		{name: "json number", value: json.Number("8"), want: 8, wantOK: true},
+		{name: "fractional json number", value: json.Number("1.5"), wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := authFileSelectionWeightValue(tt.value)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Fatalf("weight = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPatchAuthFileFields_ArbitraryFieldsPersistToFile(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "")
 

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -34,16 +34,17 @@ type openAICompatibilityAPIKeyWithAuthIndex struct {
 }
 
 type openAICompatibilityWithAuthIndex struct {
-	Name           string                                   `json:"name"`
-	Priority       int                                      `json:"priority,omitempty"`
-	Disabled       bool                                     `json:"disabled"`
-	Prefix         string                                   `json:"prefix,omitempty"`
-	BaseURL        string                                   `json:"base-url"`
-	APIKeyEntries  []openAICompatibilityAPIKeyWithAuthIndex `json:"api-key-entries,omitempty"`
-	Models         []config.OpenAICompatibilityModel        `json:"models,omitempty"`
-	Headers        map[string]string                        `json:"headers,omitempty"`
-	DisableCooling bool                                     `json:"disable-cooling,omitempty"`
-	AuthIndex      string                                   `json:"auth-index,omitempty"`
+	Name            string                                   `json:"name"`
+	Priority        int                                      `json:"priority,omitempty"`
+	SelectionWeight *int                                     `json:"selection-weight,omitempty"`
+	Disabled        bool                                     `json:"disabled"`
+	Prefix          string                                   `json:"prefix,omitempty"`
+	BaseURL         string                                   `json:"base-url"`
+	APIKeyEntries   []openAICompatibilityAPIKeyWithAuthIndex `json:"api-key-entries,omitempty"`
+	Models          []config.OpenAICompatibilityModel        `json:"models,omitempty"`
+	Headers         map[string]string                        `json:"headers,omitempty"`
+	DisableCooling  bool                                     `json:"disable-cooling,omitempty"`
+	AuthIndex       string                                   `json:"auth-index,omitempty"`
 }
 
 func (h *Handler) liveAuthIndexByID() map[string]string {
@@ -244,15 +245,16 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 		idKind := fmt.Sprintf("openai-compatibility:%s", providerName)
 
 		response := openAICompatibilityWithAuthIndex{
-			Name:           entry.Name,
-			Priority:       entry.Priority,
-			Disabled:       entry.Disabled,
-			Prefix:         entry.Prefix,
-			BaseURL:        entry.BaseURL,
-			Models:         entry.Models,
-			Headers:        entry.Headers,
-			DisableCooling: entry.DisableCooling,
-			AuthIndex:      "",
+			Name:            entry.Name,
+			Priority:        entry.Priority,
+			SelectionWeight: entry.SelectionWeight,
+			Disabled:        entry.Disabled,
+			Prefix:          entry.Prefix,
+			BaseURL:         entry.BaseURL,
+			Models:          entry.Models,
+			Headers:         entry.Headers,
+			DisableCooling:  entry.DisableCooling,
+			AuthIndex:       "",
 		}
 		if len(entry.APIKeyEntries) == 0 {
 			id, _ := idGen.Next(idKind, entry.BaseURL)

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -286,6 +286,8 @@ func normalizeRoutingStrategy(strategy string) (string, bool) {
 		return "round-robin", true
 	case "fill-first", "fillfirst", "ff":
 		return "fill-first", true
+	case "weighted-round-robin", "weighted_round_robin", "weighted-rr", "weightedrr", "wrr":
+		return "weighted-round-robin", true
 	default:
 		return "", false
 	}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -139,6 +139,11 @@ func (h *Handler) PutGeminiKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
+	for i := range arr {
+		if !validateSelectionWeightPatch(c, arr[i].SelectionWeight) {
+			return
+		}
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.cfg.GeminiKey = append([]config.GeminiKey(nil), arr...)
@@ -147,12 +152,13 @@ func (h *Handler) PutGeminiKeys(c *gin.Context) {
 }
 func (h *Handler) PatchGeminiKey(c *gin.Context) {
 	type geminiKeyPatch struct {
-		APIKey         *string            `json:"api-key"`
-		Prefix         *string            `json:"prefix"`
-		BaseURL        *string            `json:"base-url"`
-		ProxyURL       *string            `json:"proxy-url"`
-		Headers        *map[string]string `json:"headers"`
-		ExcludedModels *[]string          `json:"excluded-models"`
+		APIKey          *string            `json:"api-key"`
+		SelectionWeight *int               `json:"selection-weight"`
+		Prefix          *string            `json:"prefix"`
+		BaseURL         *string            `json:"base-url"`
+		ProxyURL        *string            `json:"proxy-url"`
+		Headers         *map[string]string `json:"headers"`
+		ExcludedModels  *[]string          `json:"excluded-models"`
 	}
 	var body struct {
 		Index *int            `json:"index"`
@@ -199,6 +205,12 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
+	}
+	if body.Value.SelectionWeight != nil {
+		if !validateSelectionWeightPatch(c, body.Value.SelectionWeight) {
+			return
+		}
+		entry.SelectionWeight = body.Value.SelectionWeight
 	}
 	if body.Value.BaseURL != nil {
 		entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
@@ -459,6 +471,9 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 	}
 	for i := range arr {
 		normalizeClaudeKey(&arr[i])
+		if !validateSelectionWeightPatch(c, arr[i].SelectionWeight) {
+			return
+		}
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -469,6 +484,7 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 func (h *Handler) PatchClaudeKey(c *gin.Context) {
 	type claudeKeyPatch struct {
 		APIKey                  *string               `json:"api-key"`
+		SelectionWeight         *int                  `json:"selection-weight"`
 		Prefix                  *string               `json:"prefix"`
 		BaseURL                 *string               `json:"base-url"`
 		ProxyURL                *string               `json:"proxy-url"`
@@ -513,6 +529,12 @@ func (h *Handler) PatchClaudeKey(c *gin.Context) {
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
+	}
+	if body.Value.SelectionWeight != nil {
+		if !validateSelectionWeightPatch(c, body.Value.SelectionWeight) {
+			return
+		}
+		entry.SelectionWeight = body.Value.SelectionWeight
 	}
 	if body.Value.BaseURL != nil {
 		entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
@@ -615,6 +637,12 @@ func (h *Handler) PutOpenAICompat(c *gin.Context) {
 	filtered := make([]config.OpenAICompatibility, 0, len(arr))
 	for i := range arr {
 		normalizeOpenAICompatibilityEntry(&arr[i])
+		if !validateSelectionWeightPatch(c, arr[i].SelectionWeight) {
+			return
+		}
+		if !validateOpenAICompatAPIKeyEntriesPatch(c, arr[i].APIKeyEntries) {
+			return
+		}
 		if strings.TrimSpace(arr[i].BaseURL) != "" {
 			filtered = append(filtered, arr[i])
 		}
@@ -627,14 +655,15 @@ func (h *Handler) PutOpenAICompat(c *gin.Context) {
 }
 func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	type openAICompatPatch struct {
-		Name           *string                             `json:"name"`
-		Prefix         *string                             `json:"prefix"`
-		Disabled       *bool                               `json:"disabled"`
-		DisableCooling *bool                               `json:"disable-cooling"`
-		BaseURL        *string                             `json:"base-url"`
-		APIKeyEntries  *[]config.OpenAICompatibilityAPIKey `json:"api-key-entries"`
-		Models         *[]config.OpenAICompatibilityModel  `json:"models"`
-		Headers        *map[string]string                  `json:"headers"`
+		Name            *string                             `json:"name"`
+		SelectionWeight *int                                `json:"selection-weight"`
+		Prefix          *string                             `json:"prefix"`
+		Disabled        *bool                               `json:"disabled"`
+		DisableCooling  *bool                               `json:"disable-cooling"`
+		BaseURL         *string                             `json:"base-url"`
+		APIKeyEntries   *[]config.OpenAICompatibilityAPIKey `json:"api-key-entries"`
+		Models          *[]config.OpenAICompatibilityModel  `json:"models"`
+		Headers         *map[string]string                  `json:"headers"`
 	}
 	var body struct {
 		Name  *string            `json:"name"`
@@ -673,6 +702,12 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
 	}
+	if body.Value.SelectionWeight != nil {
+		if !validateSelectionWeightPatch(c, body.Value.SelectionWeight) {
+			return
+		}
+		entry.SelectionWeight = body.Value.SelectionWeight
+	}
 	if body.Value.Disabled != nil {
 		entry.Disabled = *body.Value.Disabled
 	}
@@ -690,7 +725,11 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		entry.BaseURL = trimmed
 	}
 	if body.Value.APIKeyEntries != nil {
-		entry.APIKeyEntries = append([]config.OpenAICompatibilityAPIKey(nil), (*body.Value.APIKeyEntries)...)
+		nextEntries := append([]config.OpenAICompatibilityAPIKey(nil), (*body.Value.APIKeyEntries)...)
+		if !validateOpenAICompatAPIKeyEntriesPatch(c, nextEntries) {
+			return
+		}
+		entry.APIKeyEntries = nextEntries
 	}
 	if body.Value.Models != nil {
 		entry.Models = append([]config.OpenAICompatibilityModel(nil), (*body.Value.Models)...)
@@ -755,6 +794,9 @@ func (h *Handler) PutVertexCompatKeys(c *gin.Context) {
 	}
 	for i := range arr {
 		normalizeVertexCompatKey(&arr[i])
+		if !validateSelectionWeightPatch(c, arr[i].SelectionWeight) {
+			return
+		}
 		if arr[i].APIKey == "" {
 			c.JSON(400, gin.H{"error": fmt.Sprintf("vertex-api-key[%d].api-key is required", i)})
 			return
@@ -768,13 +810,14 @@ func (h *Handler) PutVertexCompatKeys(c *gin.Context) {
 }
 func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 	type vertexCompatPatch struct {
-		APIKey         *string                     `json:"api-key"`
-		Prefix         *string                     `json:"prefix"`
-		BaseURL        *string                     `json:"base-url"`
-		ProxyURL       *string                     `json:"proxy-url"`
-		Headers        *map[string]string          `json:"headers"`
-		Models         *[]config.VertexCompatModel `json:"models"`
-		ExcludedModels *[]string                   `json:"excluded-models"`
+		APIKey          *string                     `json:"api-key"`
+		SelectionWeight *int                        `json:"selection-weight"`
+		Prefix          *string                     `json:"prefix"`
+		BaseURL         *string                     `json:"base-url"`
+		ProxyURL        *string                     `json:"proxy-url"`
+		Headers         *map[string]string          `json:"headers"`
+		Models          *[]config.VertexCompatModel `json:"models"`
+		ExcludedModels  *[]string                   `json:"excluded-models"`
 	}
 	var body struct {
 		Index *int               `json:"index"`
@@ -821,6 +864,12 @@ func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
+	}
+	if body.Value.SelectionWeight != nil {
+		if !validateSelectionWeightPatch(c, body.Value.SelectionWeight) {
+			return
+		}
+		entry.SelectionWeight = body.Value.SelectionWeight
 	}
 	if body.Value.BaseURL != nil {
 		trimmed := strings.TrimSpace(*body.Value.BaseURL)
@@ -1111,6 +1160,9 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 	for i := range arr {
 		entry := arr[i]
 		normalizeCodexKey(&entry)
+		if !validateSelectionWeightPatch(c, entry.SelectionWeight) {
+			return
+		}
 		if entry.BaseURL == "" {
 			continue
 		}
@@ -1124,13 +1176,14 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 }
 func (h *Handler) PatchCodexKey(c *gin.Context) {
 	type codexKeyPatch struct {
-		APIKey         *string              `json:"api-key"`
-		Prefix         *string              `json:"prefix"`
-		BaseURL        *string              `json:"base-url"`
-		ProxyURL       *string              `json:"proxy-url"`
-		Models         *[]config.CodexModel `json:"models"`
-		Headers        *map[string]string   `json:"headers"`
-		ExcludedModels *[]string            `json:"excluded-models"`
+		APIKey          *string              `json:"api-key"`
+		SelectionWeight *int                 `json:"selection-weight"`
+		Prefix          *string              `json:"prefix"`
+		BaseURL         *string              `json:"base-url"`
+		ProxyURL        *string              `json:"proxy-url"`
+		Models          *[]config.CodexModel `json:"models"`
+		Headers         *map[string]string   `json:"headers"`
+		ExcludedModels  *[]string            `json:"excluded-models"`
 	}
 	var body struct {
 		Index *int           `json:"index"`
@@ -1168,6 +1221,12 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
+	}
+	if body.Value.SelectionWeight != nil {
+		if !validateSelectionWeightPatch(c, body.Value.SelectionWeight) {
+			return
+		}
+		entry.SelectionWeight = body.Value.SelectionWeight
 	}
 	if body.Value.BaseURL != nil {
 		trimmed := strings.TrimSpace(*body.Value.BaseURL)
@@ -1281,6 +1340,23 @@ func normalizedOpenAICompatibilityEntries(entries []config.OpenAICompatibility) 
 		out[i] = copyEntry
 	}
 	return out
+}
+
+func validateSelectionWeightPatch(c *gin.Context, value *int) bool {
+	if value == nil || *value >= 0 {
+		return true
+	}
+	c.JSON(400, gin.H{"error": "selection-weight must be a non-negative integer"})
+	return false
+}
+
+func validateOpenAICompatAPIKeyEntriesPatch(c *gin.Context, entries []config.OpenAICompatibilityAPIKey) bool {
+	for i := range entries {
+		if !validateSelectionWeightPatch(c, entries[i].SelectionWeight) {
+			return false
+		}
+	}
+	return true
 }
 
 func normalizeClaudeKey(entry *config.ClaudeKey) {

--- a/internal/api/handlers/management/config_lists_selection_weight_test.go
+++ b/internal/api/handlers/management/config_lists_selection_weight_test.go
@@ -1,0 +1,136 @@
+package management
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestPatchOpenAICompatRejectsNegativeAPIKeyEntrySelectionWeight(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	cfg := &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:    "compat",
+			BaseURL: "https://compat.example.com",
+		}},
+	}
+	h := NewHandlerWithoutConfigFilePath(cfg, nil)
+
+	body := `{"name":"compat","value":{"api-key-entries":[{"api-key":"key-a","selection-weight":-1}]}}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/config/openai-compatibility", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchOpenAICompat(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body = %s, want %d", rec.Code, rec.Body.String(), http.StatusBadRequest)
+	}
+	if len(cfg.OpenAICompatibility[0].APIKeyEntries) != 0 {
+		t.Fatalf("api-key-entries mutated on rejected patch: %#v", cfg.OpenAICompatibility[0].APIKeyEntries)
+	}
+}
+
+func TestPutConfigListsRejectNegativeSelectionWeight(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	tests := []struct {
+		name   string
+		path   string
+		body   string
+		call   func(*Handler, *gin.Context)
+		assert func(*testing.T, *config.Config)
+	}{
+		{
+			name: "gemini",
+			path: "/v0/management/config/gemini-api-key",
+			body: `[{"api-key":"key-a","selection-weight":-1}]`,
+			call: (*Handler).PutGeminiKeys,
+			assert: func(t *testing.T, cfg *config.Config) {
+				if len(cfg.GeminiKey) != 0 {
+					t.Fatalf("GeminiKey mutated: %#v", cfg.GeminiKey)
+				}
+			},
+		},
+		{
+			name: "claude",
+			path: "/v0/management/config/claude-api-key",
+			body: `[{"api-key":"key-a","selection-weight":-1}]`,
+			call: (*Handler).PutClaudeKeys,
+			assert: func(t *testing.T, cfg *config.Config) {
+				if len(cfg.ClaudeKey) != 0 {
+					t.Fatalf("ClaudeKey mutated: %#v", cfg.ClaudeKey)
+				}
+			},
+		},
+		{
+			name: "openai compat provider",
+			path: "/v0/management/config/openai-compatibility",
+			body: `[{"name":"compat","base-url":"https://compat.example.com","selection-weight":-1}]`,
+			call: (*Handler).PutOpenAICompat,
+			assert: func(t *testing.T, cfg *config.Config) {
+				if len(cfg.OpenAICompatibility) != 0 {
+					t.Fatalf("OpenAICompatibility mutated: %#v", cfg.OpenAICompatibility)
+				}
+			},
+		},
+		{
+			name: "openai compat api key",
+			path: "/v0/management/config/openai-compatibility",
+			body: `[{"name":"compat","base-url":"https://compat.example.com","api-key-entries":[{"api-key":"key-a","selection-weight":-1}]}]`,
+			call: (*Handler).PutOpenAICompat,
+			assert: func(t *testing.T, cfg *config.Config) {
+				if len(cfg.OpenAICompatibility) != 0 {
+					t.Fatalf("OpenAICompatibility mutated: %#v", cfg.OpenAICompatibility)
+				}
+			},
+		},
+		{
+			name: "vertex",
+			path: "/v0/management/config/vertex-api-key",
+			body: `[{"api-key":"key-a","selection-weight":-1}]`,
+			call: (*Handler).PutVertexCompatKeys,
+			assert: func(t *testing.T, cfg *config.Config) {
+				if len(cfg.VertexCompatAPIKey) != 0 {
+					t.Fatalf("VertexCompatAPIKey mutated: %#v", cfg.VertexCompatAPIKey)
+				}
+			},
+		},
+		{
+			name: "codex",
+			path: "/v0/management/config/codex-api-key",
+			body: `[{"api-key":"key-a","base-url":"https://codex.example.com","selection-weight":-1}]`,
+			call: (*Handler).PutCodexKeys,
+			assert: func(t *testing.T, cfg *config.Config) {
+				if len(cfg.CodexKey) != 0 {
+					t.Fatalf("CodexKey mutated: %#v", cfg.CodexKey)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			h := NewHandlerWithoutConfigFilePath(cfg, nil)
+
+			rec := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(rec)
+			req := httptest.NewRequest(http.MethodPut, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			ctx.Request = req
+			tt.call(h, ctx)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body = %s, want %d", rec.Code, rec.Body.String(), http.StatusBadRequest)
+			}
+			tt.assert(t, cfg)
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -334,7 +334,7 @@ type QuotaExceeded struct {
 // RoutingConfig configures how credentials are selected for requests.
 type RoutingConfig struct {
 	// Strategy selects the credential selection strategy.
-	// Supported values: "round-robin" (default), "fill-first".
+	// Supported values: "round-robin" (default), "fill-first", "weighted-round-robin".
 	Strategy string `yaml:"strategy,omitempty" json:"strategy,omitempty"`
 
 	// SessionAffinity enables universal session-sticky routing for all clients.
@@ -445,6 +445,10 @@ type ClaudeKey struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// SelectionWeight controls weighted-round-robin share within the same priority bucket.
+	// Defaults to 1 when unset; 0 drains new selections without disabling the credential.
+	SelectionWeight *int `yaml:"selection-weight,omitempty" json:"selection-weight,omitempty"`
+
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/claude-sonnet-4").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 
@@ -512,6 +516,10 @@ type CodexKey struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// SelectionWeight controls weighted-round-robin share within the same priority bucket.
+	// Defaults to 1 when unset; 0 drains new selections without disabling the credential.
+	SelectionWeight *int `yaml:"selection-weight,omitempty" json:"selection-weight,omitempty"`
+
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/gpt-5-codex").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 
@@ -571,6 +579,10 @@ type GeminiKey struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// SelectionWeight controls weighted-round-robin share within the same priority bucket.
+	// Defaults to 1 when unset; 0 drains new selections without disabling the credential.
+	SelectionWeight *int `yaml:"selection-weight,omitempty" json:"selection-weight,omitempty"`
+
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/gemini-3-pro-preview").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 
@@ -626,6 +638,10 @@ type OpenAICompatibility struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// SelectionWeight controls weighted-round-robin share for credentials derived from this provider.
+	// Per-key entries may override it. Defaults to 1 when unset.
+	SelectionWeight *int `yaml:"selection-weight,omitempty" json:"selection-weight,omitempty"`
+
 	// Disabled prevents this provider from being used for routing.
 	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
 
@@ -652,6 +668,10 @@ type OpenAICompatibility struct {
 type OpenAICompatibilityAPIKey struct {
 	// APIKey is the authentication key for accessing the external API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// SelectionWeight controls weighted-round-robin share for this API key.
+	// Defaults to the provider selection-weight, then 1.
+	SelectionWeight *int `yaml:"selection-weight,omitempty" json:"selection-weight,omitempty"`
 
 	// ProxyURL overrides the global proxy setting for this API key if provided.
 	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
@@ -995,8 +1015,12 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 		e := cfg.OpenAICompatibility[i]
 		e.Name = strings.TrimSpace(e.Name)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
+		e.SelectionWeight = normalizeSelectionWeight(e.SelectionWeight)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
 		e.Headers = NormalizeHeaders(e.Headers)
+		for j := range e.APIKeyEntries {
+			e.APIKeyEntries[j].SelectionWeight = normalizeSelectionWeight(e.APIKeyEntries[j].SelectionWeight)
+		}
 		if e.BaseURL == "" {
 			// Skip providers with no base-url; treated as removed
 			continue
@@ -1016,6 +1040,7 @@ func (cfg *Config) SanitizeCodexKeys() {
 	for i := range cfg.CodexKey {
 		e := cfg.CodexKey[i]
 		e.Prefix = normalizeModelPrefix(e.Prefix)
+		e.SelectionWeight = normalizeSelectionWeight(e.SelectionWeight)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
 		e.Headers = NormalizeHeaders(e.Headers)
 		e.ExcludedModels = NormalizeExcludedModels(e.ExcludedModels)
@@ -1035,6 +1060,7 @@ func (cfg *Config) SanitizeClaudeKeys() {
 	for i := range cfg.ClaudeKey {
 		entry := &cfg.ClaudeKey[i]
 		entry.Prefix = normalizeModelPrefix(entry.Prefix)
+		entry.SelectionWeight = normalizeSelectionWeight(entry.SelectionWeight)
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
 	}
@@ -1050,6 +1076,7 @@ func sanitizeGeminiKeyEntries(entries []GeminiKey) []GeminiKey {
 			continue
 		}
 		entry.Prefix = normalizeModelPrefix(entry.Prefix)
+		entry.SelectionWeight = normalizeSelectionWeight(entry.SelectionWeight)
 		entry.BaseURL = strings.TrimSpace(entry.BaseURL)
 		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 		entry.Headers = NormalizeHeaders(entry.Headers)
@@ -1080,6 +1107,13 @@ func (cfg *Config) SanitizeInteractionsKeys() {
 		return
 	}
 	cfg.InteractionsKey = sanitizeGeminiKeyEntries(cfg.InteractionsKey)
+}
+
+func normalizeSelectionWeight(weight *int) *int {
+	if weight == nil || *weight >= 0 {
+		return weight
+	}
+	return nil
 }
 
 func normalizeModelPrefix(prefix string) string {

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -17,6 +17,10 @@ type VertexCompatKey struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// SelectionWeight controls weighted-round-robin share within the same priority bucket.
+	// Defaults to 1 when unset; 0 drains new selections without disabling the credential.
+	SelectionWeight *int `yaml:"selection-weight,omitempty" json:"selection-weight,omitempty"`
+
 	// Prefix optionally namespaces model aliases for this credential (e.g., "teamA/vertex-pro").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 
@@ -78,6 +82,7 @@ func (cfg *Config) SanitizeVertexCompatKeys() {
 			continue
 		}
 		entry.Prefix = normalizeModelPrefix(entry.Prefix)
+		entry.SelectionWeight = normalizeSelectionWeight(entry.SelectionWeight)
 		entry.BaseURL = strings.TrimSpace(entry.BaseURL)
 		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 		entry.Headers = NormalizeHeaders(entry.Headers)

--- a/internal/pluginhost/auth_callbacks.go
+++ b/internal/pluginhost/auth_callbacks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -196,6 +197,11 @@ func (h *Host) listAuthFilesFromDisk() ([]pluginapi.HostAuthFileEntry, error) {
 						fileEntry.Priority = priority
 					}
 				}
+				if selectionWeight, okWeight := parseSelectionWeightMetadata(metadata); okWeight {
+					fileEntry.SelectionWeight = selectionWeight
+				} else {
+					fileEntry.SelectionWeight = 1
+				}
 				if note, ok := metadata["note"].(string); ok {
 					fileEntry.Note = strings.TrimSpace(note)
 				}
@@ -352,6 +358,7 @@ func (h *Host) buildAuthFromFileData(path string, data []byte) (*coreauth.Auth, 
 		}
 	}
 	coreauth.ApplyCustomHeadersFromMetadata(auth)
+	syncHostAuthSelectionWeightAttribute(auth)
 	return auth, nil
 }
 
@@ -463,6 +470,7 @@ func (h *Host) buildHostAuthFileEntry(auth *coreauth.Auth) *pluginapi.HostAuthFi
 			}
 		}
 	}
+	entry.SelectionWeight = effectiveHostAuthSelectionWeight(auth)
 	if note := strings.TrimSpace(authAttribute(auth, "note")); note != "" {
 		entry.Note = note
 	} else if auth.Metadata != nil {
@@ -609,6 +617,86 @@ func parsePriorityValue(raw any) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+func effectiveHostAuthSelectionWeight(auth *coreauth.Auth) int {
+	if auth == nil {
+		return 1
+	}
+	for _, key := range []string{"selection_weight", "selection-weight", "weight"} {
+		if raw := strings.TrimSpace(authAttribute(auth, key)); raw != "" {
+			parsed, errParse := strconv.Atoi(raw)
+			if errParse == nil && parsed >= 0 {
+				return parsed
+			}
+			return 1
+		}
+	}
+	if weight, ok := parseSelectionWeightMetadata(auth.Metadata); ok {
+		return weight
+	}
+	return 1
+}
+
+func syncHostAuthSelectionWeightAttribute(auth *coreauth.Auth) {
+	if auth == nil {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	weight, ok := parseSelectionWeightMetadata(auth.Metadata)
+	if !ok {
+		delete(auth.Attributes, "selection_weight")
+		return
+	}
+	auth.Attributes["selection_weight"] = strconv.Itoa(weight)
+}
+
+func parseSelectionWeightMetadata(metadata map[string]any) (int, bool) {
+	if metadata == nil {
+		return 0, false
+	}
+	value, ok := metadata["selection_weight"]
+	if !ok {
+		value, ok = metadata["selection-weight"]
+	}
+	if !ok {
+		return 0, false
+	}
+	return parseSelectionWeightValue(value)
+}
+
+func parseSelectionWeightValue(raw any) (int, bool) {
+	var parsed int
+	var ok bool
+	switch v := raw.(type) {
+	case int:
+		parsed, ok = v, true
+	case int32:
+		parsed, ok = int(v), true
+	case int64:
+		parsed, ok = int(v), true
+	case float64:
+		if math.Trunc(v) != v {
+			return 0, false
+		}
+		parsed, ok = int(v), true
+	case json.Number:
+		value, err := v.Int64()
+		if err == nil {
+			parsed, ok = int(value), true
+		}
+	case string:
+		value, err := strconv.Atoi(strings.TrimSpace(v))
+		if err == nil {
+			parsed, ok = value, true
+		}
+	}
+	if !ok || parsed < 0 {
+		return 0, false
+	}
+	return parsed, true
 }
 
 func parseWebsocketsValue(raw any) (bool, bool) {

--- a/internal/pluginhost/auth_callbacks_test.go
+++ b/internal/pluginhost/auth_callbacks_test.go
@@ -247,3 +247,139 @@ func TestHostAuthSaveCallbackWritesPhysicalFile(t *testing.T) {
 		t.Fatalf("auths = %#v, want one registered auth", auths)
 	}
 }
+
+func TestHostAuthSaveCallbackSyncsSelectionWeightAttribute(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{name: "underscore", json: `{"type":"codex","email":"saved@example.com","selection_weight":0}`},
+		{name: "hyphen", json: `{"type":"codex","email":"saved@example.com","selection-weight":2}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authDir := t.TempDir()
+			host := New()
+			host.runtimeConfig = &config.Config{AuthDir: authDir}
+			host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+
+			req, errMarshal := json.Marshal(pluginapi.HostAuthSaveRequest{
+				Name: "saved.json",
+				JSON: json.RawMessage(tt.json),
+			})
+			if errMarshal != nil {
+				t.Fatalf("marshal request: %v", errMarshal)
+			}
+			rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthSave, req)
+			if errCall != nil {
+				t.Fatalf("callFromPlugin() error = %v", errCall)
+			}
+			if _, errDecode := decodeRPCEnvelope[pluginapi.HostAuthSaveResponse](rawResp); errDecode != nil {
+				t.Fatalf("decode response: %v", errDecode)
+			}
+			auths := host.currentAuthManager().List()
+			if len(auths) != 1 {
+				t.Fatalf("auths = %#v, want one registered auth", auths)
+			}
+			want := "0"
+			if tt.name == "hyphen" {
+				want = "2"
+			}
+			if got := auths[0].Attributes["selection_weight"]; got != want {
+				t.Fatalf("selection_weight attribute = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestBuildAuthFromFileDataSelectionWeightAttribute(t *testing.T) {
+	authPath := filepath.Join(t.TempDir(), "weighted.json")
+	auth, err := (&Host{}).buildAuthFromFileData(authPath, []byte(`{"type":"codex","selection-weight":0}`))
+	if err != nil {
+		t.Fatalf("buildAuthFromFileData() error = %v", err)
+	}
+	if auth == nil {
+		t.Fatalf("buildAuthFromFileData() = nil")
+	}
+	if got := auth.Attributes["selection_weight"]; got != "0" {
+		t.Fatalf("Attributes selection_weight = %q, want 0", got)
+	}
+}
+
+func TestBuildAuthFromFileDataSelectionWeightRejectsFractional(t *testing.T) {
+	authPath := filepath.Join(t.TempDir(), "weighted.json")
+	auth, err := (&Host{}).buildAuthFromFileData(authPath, []byte(`{"type":"codex","selection-weight":1.5}`))
+	if err != nil {
+		t.Fatalf("buildAuthFromFileData() error = %v", err)
+	}
+	if auth == nil {
+		t.Fatalf("buildAuthFromFileData() = nil")
+	}
+	if got, ok := auth.Attributes["selection_weight"]; ok {
+		t.Fatalf("Attributes selection_weight = %q, want absent", got)
+	}
+}
+
+func TestParseSelectionWeightValueProgrammaticNumberTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  any
+		want   int
+		wantOK bool
+	}{
+		{name: "int32", value: int32(3), want: 3, wantOK: true},
+		{name: "json number", value: json.Number("4"), want: 4, wantOK: true},
+		{name: "fractional json number", value: json.Number("1.5"), wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseSelectionWeightValue(tt.value)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Fatalf("weight = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildHostAuthFileEntrySelectionWeight(t *testing.T) {
+	authDir := t.TempDir()
+	authPath := filepath.Join(authDir, "codex.json")
+	if err := os.WriteFile(authPath, []byte(`{"type":"codex"}`), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	auth := &coreauth.Auth{
+		ID:       "codex.json",
+		FileName: "codex.json",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"path":             authPath,
+			"selection_weight": "0",
+		},
+	}
+
+	entry := (&Host{}).buildHostAuthFileEntry(auth)
+	if entry == nil {
+		t.Fatalf("buildHostAuthFileEntry() = nil")
+	}
+	if entry.SelectionWeight != 0 {
+		t.Fatalf("SelectionWeight = %d, want 0", entry.SelectionWeight)
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	var encoded map[string]any
+	if err := json.Unmarshal(data, &encoded); err != nil {
+		t.Fatalf("unmarshal entry: %v", err)
+	}
+	if got, ok := encoded["selection_weight"].(float64); !ok || got != 0 {
+		t.Fatalf("encoded selection_weight = %#v, want 0", encoded["selection_weight"])
+	}
+}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1582,7 +1582,10 @@ func codexIdentityConfuseEnabled(cfg *config.Config) bool {
 		return false
 	}
 	strategy := strings.ToLower(strings.TrimSpace(cfg.Routing.Strategy))
-	return cfg.Routing.SessionAffinity || strategy == "fill-first" || strategy == "fillfirst" || strategy == "ff"
+	return cfg.Routing.SessionAffinity ||
+		strategy == "fill-first" || strategy == "fillfirst" || strategy == "ff" ||
+		strategy == "weighted-round-robin" || strategy == "weighted_round_robin" ||
+		strategy == "weighted-rr" || strategy == "weightedrr" || strategy == "wrr"
 }
 
 func codexIdentityConfuseUUID(authID string, kind string, value string) string {

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -227,6 +227,33 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 	}
 }
 
+func TestCodexIdentityConfuseEnabledRoutingStrategies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		strategy string
+		want     bool
+	}{
+		{name: "weighted round robin", strategy: "weighted-round-robin", want: true},
+		{name: "round robin", strategy: "round-robin", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Config{
+				Routing: config.RoutingConfig{Strategy: tt.strategy},
+				Codex:   config.CodexConfig{IdentityConfuse: true},
+			}
+			if got := codexIdentityConfuseEnabled(cfg); got != tt.want {
+				t.Fatalf("codexIdentityConfuseEnabled(%q) = %v, want %v", tt.strategy, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyCodexHeadersUsesAccountHeaderForOAuth(t *testing.T) {
 	httpReq := httptest.NewRequest("POST", "https://example.com/responses", nil)
 	auth := &cliproxyauth.Auth{

--- a/internal/tui/auth_tab.go
+++ b/internal/tui/auth_tab.go
@@ -14,13 +14,14 @@ import (
 // editableField represents an editable field on an auth file.
 type editableField struct {
 	label string
-	key   string // API field key: "prefix", "proxy_url", "priority"
+	key   string // API field key: "prefix", "proxy_url", "priority", "selection_weight"
 }
 
 var authEditableFields = []editableField{
 	{label: "Prefix", key: "prefix"},
 	{label: "Proxy URL", key: "proxy_url"},
 	{label: "Priority", key: "priority"},
+	{label: "Selection Weight", key: "selection_weight"},
 }
 
 // authTabModel displays auth credential files with interactive management.
@@ -280,6 +281,7 @@ func (m authTabModel) renderDetail(f map[string]any) string {
 		{"Prefix", "prefix", true},
 		{"Proxy URL", "proxy_url", true},
 		{"Priority", "priority", true},
+		{"Selection Weight", "selection_weight", true},
 		{"Project ID", "project_id", false},
 		{"Disabled", "disabled", false},
 		{"Created", "created_at", false},
@@ -336,9 +338,14 @@ func (m authTabModel) handleEditInput(msg tea.KeyMsg) (authTabModel, tea.Cmd) {
 		m.editing = false
 		m.editInput.Blur()
 		fields := map[string]any{}
-		if fieldKey == "priority" {
+		if fieldKey == "priority" || fieldKey == "selection_weight" {
 			p, err := strconv.Atoi(value)
 			if err != nil {
+				return m, func() tea.Msg {
+					return authActionMsg{err: fmt.Errorf("%s: %s", T("invalid_int"), value)}
+				}
+			}
+			if fieldKey == "selection_weight" && p < 0 {
 				return m, func() tea.Msg {
 					return authActionMsg{err: fmt.Errorf("%s: %s", T("invalid_int"), value)}
 				}
@@ -445,6 +452,8 @@ func (m authTabModel) handleNormalInput(msg tea.KeyMsg) (authTabModel, tea.Cmd) 
 		return m, m.startEdit(1) // proxy_url
 	case "3":
 		return m, m.startEdit(2) // priority
+	case "4":
+		return m, m.startEdit(3) // selection_weight
 	case "r":
 		m.status = ""
 		return m, m.fetchFiles

--- a/internal/tui/i18n.go
+++ b/internal/tui/i18n.go
@@ -136,7 +136,7 @@ var zhStrings = map[string]string{
 	// ── Auth Files ──
 	"auth_title":      "🔑 认证文件",
 	"auth_help1":      " [↑↓/jk] 导航 • [Enter] 展开 • [e] 启用/停用 • [d] 删除 • [r] 刷新",
-	"auth_help2":      " [1] 编辑 prefix • [2] 编辑 proxy_url • [3] 编辑 priority",
+	"auth_help2":      " [1] 编辑 prefix • [2] 编辑 proxy_url • [3] 编辑 priority • [4] 编辑 selection weight",
 	"no_auth_files":   "  无认证文件",
 	"confirm_delete":  "⚠ 删除 %s? [y/n]",
 	"deleted":         "已删除 %s",
@@ -291,7 +291,7 @@ var enStrings = map[string]string{
 	// ── Auth Files ──
 	"auth_title":      "🔑 Auth Files",
 	"auth_help1":      " [↑↓/jk] Navigate • [Enter] Expand • [e] Enable/Disable • [d] Delete • [r] Refresh",
-	"auth_help2":      " [1] Edit prefix • [2] Edit proxy_url • [3] Edit priority",
+	"auth_help2":      " [1] Edit prefix • [2] Edit proxy_url • [3] Edit priority • [4] Edit selection weight",
 	"no_auth_files":   "  No auth files found",
 	"confirm_delete":  "⚠ Delete %s? [y/n]",
 	"deleted":         "Deleted %s",

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -134,6 +134,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 			if strings.TrimSpace(o.Prefix) != strings.TrimSpace(n.Prefix) {
 				changes = append(changes, fmt.Sprintf("gemini[%d].prefix: %s -> %s", i, strings.TrimSpace(o.Prefix), strings.TrimSpace(n.Prefix)))
 			}
+			if effectiveSelectionWeight(o.SelectionWeight) != effectiveSelectionWeight(n.SelectionWeight) {
+				changes = append(changes, fmt.Sprintf("gemini[%d].selection-weight: %d -> %d", i, effectiveSelectionWeight(o.SelectionWeight), effectiveSelectionWeight(n.SelectionWeight)))
+			}
 			if strings.TrimSpace(o.APIKey) != strings.TrimSpace(n.APIKey) {
 				changes = append(changes, fmt.Sprintf("gemini[%d].api-key: updated", i))
 			}
@@ -202,6 +205,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 			if strings.TrimSpace(o.Prefix) != strings.TrimSpace(n.Prefix) {
 				changes = append(changes, fmt.Sprintf("claude[%d].prefix: %s -> %s", i, strings.TrimSpace(o.Prefix), strings.TrimSpace(n.Prefix)))
 			}
+			if effectiveSelectionWeight(o.SelectionWeight) != effectiveSelectionWeight(n.SelectionWeight) {
+				changes = append(changes, fmt.Sprintf("claude[%d].selection-weight: %d -> %d", i, effectiveSelectionWeight(o.SelectionWeight), effectiveSelectionWeight(n.SelectionWeight)))
+			}
 			if strings.TrimSpace(o.APIKey) != strings.TrimSpace(n.APIKey) {
 				changes = append(changes, fmt.Sprintf("claude[%d].api-key: updated", i))
 			}
@@ -250,6 +256,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 			}
 			if strings.TrimSpace(o.Prefix) != strings.TrimSpace(n.Prefix) {
 				changes = append(changes, fmt.Sprintf("codex[%d].prefix: %s -> %s", i, strings.TrimSpace(o.Prefix), strings.TrimSpace(n.Prefix)))
+			}
+			if effectiveSelectionWeight(o.SelectionWeight) != effectiveSelectionWeight(n.SelectionWeight) {
+				changes = append(changes, fmt.Sprintf("codex[%d].selection-weight: %d -> %d", i, effectiveSelectionWeight(o.SelectionWeight), effectiveSelectionWeight(n.SelectionWeight)))
 			}
 			if o.Websockets != n.Websockets {
 				changes = append(changes, fmt.Sprintf("codex[%d].websockets: %t -> %t", i, o.Websockets, n.Websockets))
@@ -330,6 +339,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 			if strings.TrimSpace(o.Prefix) != strings.TrimSpace(n.Prefix) {
 				changes = append(changes, fmt.Sprintf("vertex[%d].prefix: %s -> %s", i, strings.TrimSpace(o.Prefix), strings.TrimSpace(n.Prefix)))
 			}
+			if effectiveSelectionWeight(o.SelectionWeight) != effectiveSelectionWeight(n.SelectionWeight) {
+				changes = append(changes, fmt.Sprintf("vertex[%d].selection-weight: %d -> %d", i, effectiveSelectionWeight(o.SelectionWeight), effectiveSelectionWeight(n.SelectionWeight)))
+			}
 			if strings.TrimSpace(o.APIKey) != strings.TrimSpace(n.APIKey) {
 				changes = append(changes, fmt.Sprintf("vertex[%d].api-key: updated", i))
 			}
@@ -358,6 +370,13 @@ func trimStrings(in []string) []string {
 		out[i] = strings.TrimSpace(in[i])
 	}
 	return out
+}
+
+func effectiveSelectionWeight(weight *int) int {
+	if weight == nil || *weight < 0 {
+		return 1
+	}
+	return *weight
 }
 
 func appendPayloadConfigChanges(changes []string, oldPayload, newPayload config.PayloadConfig) []string {

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -93,6 +93,34 @@ func TestBuildConfigChangeDetails_NoChanges(t *testing.T) {
 	}
 }
 
+func TestBuildConfigChangeDetails_SelectionWeights(t *testing.T) {
+	claudeWeight := 0
+	codexWeight := 2
+	vertexWeight := 3
+	oldCfg := &config.Config{
+		GeminiKey: []config.GeminiKey{{APIKey: "g1"}},
+		ClaudeKey: []config.ClaudeKey{{APIKey: "c1"}},
+		CodexKey:  []config.CodexKey{{APIKey: "x1"}},
+		VertexCompatAPIKey: []config.VertexCompatKey{
+			{APIKey: "v1", BaseURL: "http://v1"},
+		},
+	}
+	newCfg := &config.Config{
+		GeminiKey: []config.GeminiKey{{APIKey: "g1"}},
+		ClaudeKey: []config.ClaudeKey{{APIKey: "c1", SelectionWeight: &claudeWeight}},
+		CodexKey:  []config.CodexKey{{APIKey: "x1", SelectionWeight: &codexWeight}},
+		VertexCompatAPIKey: []config.VertexCompatKey{
+			{APIKey: "v1", BaseURL: "http://v1", SelectionWeight: &vertexWeight},
+		},
+	}
+
+	changes := BuildConfigChangeDetails(oldCfg, newCfg)
+	expectContains(t, changes, "claude[0].selection-weight: 1 -> 0")
+	expectContains(t, changes, "codex[0].selection-weight: 1 -> 2")
+	expectContains(t, changes, "vertex[0].selection-weight: 1 -> 3")
+	expectNotContains(t, changes, "gemini[0].selection-weight")
+}
+
 func TestBuildConfigChangeDetails_GeminiVertexHeaders(t *testing.T) {
 	oldCfg := &config.Config{
 		GeminiKey: []config.GeminiKey{

--- a/internal/watcher/diff/oauth_excluded_test.go
+++ b/internal/watcher/diff/oauth_excluded_test.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -86,4 +87,13 @@ func expectContains(t *testing.T, list []string, target string) {
 		}
 	}
 	t.Fatalf("expected list to contain %q, got %#v", target, list)
+}
+
+func expectNotContains(t *testing.T, list []string, target string) {
+	t.Helper()
+	for _, entry := range list {
+		if strings.Contains(entry, target) {
+			t.Fatalf("expected list not to contain %q, got %#v", target, list)
+		}
+	}
 }

--- a/internal/watcher/diff/openai_compat.go
+++ b/internal/watcher/diff/openai_compat.go
@@ -69,8 +69,14 @@ func describeOpenAICompatibilityUpdate(oldEntry, newEntry config.OpenAICompatibi
 	if oldEntry.Disabled != newEntry.Disabled {
 		details = append(details, fmt.Sprintf("disabled %t -> %t", oldEntry.Disabled, newEntry.Disabled))
 	}
+	if effectiveSelectionWeight(oldEntry.SelectionWeight) != effectiveSelectionWeight(newEntry.SelectionWeight) {
+		details = append(details, fmt.Sprintf("selection-weight %d -> %d", effectiveSelectionWeight(oldEntry.SelectionWeight), effectiveSelectionWeight(newEntry.SelectionWeight)))
+	}
 	if oldKeyCount != newKeyCount {
 		details = append(details, fmt.Sprintf("api-keys %d -> %d", oldKeyCount, newKeyCount))
+	}
+	if openAICompatAPIKeySelectionWeightsChanged(oldEntry.APIKeyEntries, newEntry.APIKeyEntries) {
+		details = append(details, "api-key selection-weights updated")
 	}
 	if oldModelCount != newModelCount {
 		details = append(details, fmt.Sprintf("models %d -> %d", oldModelCount, newModelCount))
@@ -82,6 +88,18 @@ func describeOpenAICompatibilityUpdate(oldEntry, newEntry config.OpenAICompatibi
 		return ""
 	}
 	return "(" + strings.Join(details, ", ") + ")"
+}
+
+func openAICompatAPIKeySelectionWeightsChanged(oldEntries, newEntries []config.OpenAICompatibilityAPIKey) bool {
+	if len(oldEntries) != len(newEntries) {
+		return false
+	}
+	for i := range oldEntries {
+		if effectiveSelectionWeight(oldEntries[i].SelectionWeight) != effectiveSelectionWeight(newEntries[i].SelectionWeight) {
+			return true
+		}
+	}
+	return false
 }
 
 func countAPIKeys(entry config.OpenAICompatibility) int {

--- a/internal/watcher/diff/openai_compat_test.go
+++ b/internal/watcher/diff/openai_compat_test.go
@@ -67,6 +67,31 @@ func TestDiffOpenAICompatibility_RemovedAndUnchanged(t *testing.T) {
 	expectContains(t, changes, "provider removed: provider-a (api-keys=1, models=1)")
 }
 
+func TestDiffOpenAICompatibility_SelectionWeights(t *testing.T) {
+	providerWeight := 4
+	keyWeight := 0
+	oldList := []config.OpenAICompatibility{
+		{
+			Name: "provider-a",
+			APIKeyEntries: []config.OpenAICompatibilityAPIKey{
+				{APIKey: "key-a"},
+			},
+		},
+	}
+	newList := []config.OpenAICompatibility{
+		{
+			Name:            "provider-a",
+			SelectionWeight: &providerWeight,
+			APIKeyEntries: []config.OpenAICompatibilityAPIKey{
+				{APIKey: "key-a", SelectionWeight: &keyWeight},
+			},
+		},
+	}
+
+	changes := DiffOpenAICompatibility(oldList, newList)
+	expectContains(t, changes, "provider updated: provider-a (selection-weight 1 -> 4, api-key selection-weights updated)")
+}
+
 func TestOpenAICompatKeyFallbacks(t *testing.T) {
 	entry := config.OpenAICompatibility{
 		BaseURL: "http://base",

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -81,6 +81,7 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeyEntries(ctx *SynthesisContext, en
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}
+		addSelectionWeightAttr(attrs, entry.SelectionWeight)
 		if base != "" {
 			attrs["base_url"] = base
 		}
@@ -136,6 +137,7 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 		if ck.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(ck.Priority)
 		}
+		addSelectionWeightAttr(attrs, ck.SelectionWeight)
 		if base != "" {
 			attrs["base_url"] = base
 		}
@@ -194,6 +196,7 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 		if ck.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(ck.Priority)
 		}
+		addSelectionWeightAttr(attrs, ck.SelectionWeight)
 		if ck.BaseURL != "" {
 			attrs["base_url"] = ck.BaseURL
 		}
@@ -268,6 +271,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 			if compat.Priority != 0 {
 				attrs["priority"] = strconv.Itoa(compat.Priority)
 			}
+			addSelectionWeightAttr(attrs, firstSelectionWeight(entry.SelectionWeight, compat.SelectionWeight))
 			if key != "" {
 				attrs["api_key"] = key
 			}
@@ -310,6 +314,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 			if compat.Priority != 0 {
 				attrs["priority"] = strconv.Itoa(compat.Priority)
 			}
+			addSelectionWeightAttr(attrs, compat.SelectionWeight)
 			if hash := diff.ComputeOpenAICompatModelsHash(compat.Models); hash != "" {
 				attrs["models_hash"] = hash
 			}
@@ -359,6 +364,7 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 		if compat.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(compat.Priority)
 		}
+		addSelectionWeightAttr(attrs, compat.SelectionWeight)
 		if key != "" {
 			attrs["api_key"] = key
 		}
@@ -381,4 +387,21 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 		out = append(out, a)
 	}
 	return out
+}
+
+func firstSelectionWeight(primary, fallback *int) *int {
+	if primary != nil {
+		return primary
+	}
+	return fallback
+}
+
+func addSelectionWeightAttr(attrs map[string]string, weight *int) {
+	if attrs == nil || weight == nil {
+		return
+	}
+	if *weight < 0 {
+		return
+	}
+	attrs["selection_weight"] = strconv.Itoa(*weight)
 }

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -691,23 +691,28 @@ func TestConfigSynthesizer_IDStability(t *testing.T) {
 }
 
 func TestConfigSynthesizer_AllProviders(t *testing.T) {
+	geminiWeight := 2
+	claudeWeight := 3
+	codexWeight := 4
+	compatWeight := 5
+	vertexWeight := 6
 	synth := NewConfigSynthesizer()
 	ctx := &SynthesisContext{
 		Config: &config.Config{
 			GeminiKey: []config.GeminiKey{
-				{APIKey: "gemini-key"},
+				{APIKey: "gemini-key", SelectionWeight: &geminiWeight},
 			},
 			ClaudeKey: []config.ClaudeKey{
-				{APIKey: "claude-key"},
+				{APIKey: "claude-key", SelectionWeight: &claudeWeight},
 			},
 			CodexKey: []config.CodexKey{
-				{APIKey: "codex-key"},
+				{APIKey: "codex-key", SelectionWeight: &codexWeight},
 			},
 			OpenAICompatibility: []config.OpenAICompatibility{
-				{Name: "compat", BaseURL: "https://compat.api"},
+				{Name: "compat", BaseURL: "https://compat.api", SelectionWeight: &compatWeight},
 			},
 			VertexCompatAPIKey: []config.VertexCompatKey{
-				{APIKey: "vertex-key", BaseURL: "https://vertex.api"},
+				{APIKey: "vertex-key", BaseURL: "https://vertex.api", SelectionWeight: &vertexWeight},
 			},
 		},
 		Now:         time.Now(),
@@ -723,8 +728,10 @@ func TestConfigSynthesizer_AllProviders(t *testing.T) {
 	}
 
 	providers := make(map[string]bool)
+	weights := make(map[string]string)
 	for _, a := range auths {
 		providers[a.Provider] = true
+		weights[a.Provider] = a.Attributes["selection_weight"]
 	}
 
 	expected := []string{"gemini", "claude", "codex", "openai-compatible-compat", "vertex"}
@@ -732,5 +739,59 @@ func TestConfigSynthesizer_AllProviders(t *testing.T) {
 		if !providers[p] {
 			t.Errorf("expected provider %s not found", p)
 		}
+	}
+	expectedWeights := map[string]string{
+		"gemini":                   "2",
+		"claude":                   "3",
+		"codex":                    "4",
+		"openai-compatible-compat": "5",
+		"vertex":                   "6",
+	}
+	for provider, wantWeight := range expectedWeights {
+		if got := weights[provider]; got != wantWeight {
+			t.Errorf("provider %s selection_weight = %q, want %q", provider, got, wantWeight)
+		}
+	}
+}
+
+func TestConfigSynthesizer_OpenAICompatSelectionWeightPerKeyOverride(t *testing.T) {
+	providerWeight := 2
+	keyWeight := 5
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			OpenAICompatibility: []config.OpenAICompatibility{
+				{
+					Name:            "compat",
+					BaseURL:         "https://compat.api",
+					SelectionWeight: &providerWeight,
+					APIKeyEntries: []config.OpenAICompatibilityAPIKey{
+						{APIKey: "key-a"},
+						{APIKey: "key-b", SelectionWeight: &keyWeight},
+					},
+				},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("expected 2 auths, got %d", len(auths))
+	}
+
+	weightsByKey := map[string]string{}
+	for _, auth := range auths {
+		weightsByKey[auth.Attributes["api_key"]] = auth.Attributes["selection_weight"]
+	}
+	if got := weightsByKey["key-a"]; got != "2" {
+		t.Fatalf("key-a selection_weight = %q, want 2", got)
+	}
+	if got := weightsByKey["key-b"]; got != "5" {
+		t.Fatalf("key-b selection_weight = %q, want 5", got)
 	}
 }

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -3,6 +3,7 @@ package synthesizer
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -196,6 +197,9 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			}
 		}
 	}
+	if weight, ok := metadataSelectionWeight(metadata); ok {
+		a.Attributes["selection_weight"] = strconv.Itoa(weight)
+	}
 	// Read note from auth file.
 	if rawNote, ok := metadata["note"]; ok {
 		if note, isStr := rawNote.(string); isStr {
@@ -276,6 +280,55 @@ func extractOAuthModelAliasesFromMetadata(metadata map[string]any) []config.OAut
 	}
 	cfg.SanitizeOAuthModelAlias()
 	return cfg.OAuthModelAlias["auth"]
+}
+
+func metadataSelectionWeight(metadata map[string]any) (int, bool) {
+	if metadata == nil {
+		return 0, false
+	}
+	raw, ok := metadata["selection_weight"]
+	if !ok {
+		raw, ok = metadata["selection-weight"]
+	}
+	if !ok {
+		return 0, false
+	}
+	switch v := raw.(type) {
+	case int:
+		if v < 0 {
+			return 0, false
+		}
+		return v, true
+	case int32:
+		if v < 0 {
+			return 0, false
+		}
+		return int(v), true
+	case int64:
+		if v < 0 {
+			return 0, false
+		}
+		return int(v), true
+	case float64:
+		if v < 0 || math.Trunc(v) != v {
+			return 0, false
+		}
+		return int(v), true
+	case json.Number:
+		parsed, errParse := v.Int64()
+		if errParse != nil || parsed < 0 {
+			return 0, false
+		}
+		return int(parsed), true
+	case string:
+		weight := strings.TrimSpace(v)
+		parsed, errAtoi := strconv.Atoi(weight)
+		if errAtoi != nil || parsed < 0 {
+			return 0, false
+		}
+		return parsed, true
+	}
+	return 0, false
 }
 
 // extractExcludedModelsFromMetadata reads per-account excluded models from the OAuth JSON metadata.

--- a/internal/watcher/synthesizer/file_test.go
+++ b/internal/watcher/synthesizer/file_test.go
@@ -505,6 +505,135 @@ func TestFileSynthesizer_Synthesize_PriorityParsing(t *testing.T) {
 	}
 }
 
+func TestFileSynthesizer_Synthesize_SelectionWeightParsing(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldName string
+		weight    any
+		want      string
+		hasValue  bool
+	}{
+		{
+			name:      "string with spaces",
+			fieldName: "selection_weight",
+			weight:    " 10 ",
+			want:      "10",
+			hasValue:  true,
+		},
+		{
+			name:      "hyphen field",
+			fieldName: "selection-weight",
+			weight:    8,
+			want:      "8",
+			hasValue:  true,
+		},
+		{
+			name:      "zero drains new selections",
+			fieldName: "selection_weight",
+			weight:    0,
+			want:      "0",
+			hasValue:  true,
+		},
+		{
+			name:      "invalid string",
+			fieldName: "selection_weight",
+			weight:    "1x",
+			hasValue:  false,
+		},
+		{
+			name:      "negative",
+			fieldName: "selection_weight",
+			weight:    -1,
+			hasValue:  false,
+		},
+		{
+			name:      "fractional number",
+			fieldName: "selection_weight",
+			weight:    1.5,
+			hasValue:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			authData := map[string]any{
+				"type":       "claude",
+				tt.fieldName: tt.weight,
+			}
+			data, _ := json.Marshal(authData)
+			errWriteFile := os.WriteFile(filepath.Join(tempDir, "auth.json"), data, 0644)
+			if errWriteFile != nil {
+				t.Fatalf("failed to write auth file: %v", errWriteFile)
+			}
+
+			synth := NewFileSynthesizer()
+			ctx := &SynthesisContext{
+				Config:      &config.Config{},
+				AuthDir:     tempDir,
+				Now:         time.Now(),
+				IDGenerator: NewStableIDGenerator(),
+			}
+
+			auths, errSynthesize := synth.Synthesize(ctx)
+			if errSynthesize != nil {
+				t.Fatalf("unexpected error: %v", errSynthesize)
+			}
+			if len(auths) != 1 {
+				t.Fatalf("expected 1 auth, got %d", len(auths))
+			}
+
+			value, ok := auths[0].Attributes["selection_weight"]
+			if tt.hasValue {
+				if !ok {
+					t.Fatal("expected selection_weight attribute to be set")
+				}
+				if value != tt.want {
+					t.Fatalf("expected selection_weight %q, got %q", tt.want, value)
+				}
+				return
+			}
+			if ok {
+				t.Fatalf("expected selection_weight attribute to be absent, got %q", value)
+			}
+		})
+	}
+}
+
+func TestMetadataSelectionWeight_ProgrammaticIntegerTypes(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   any
+		want    int
+		wantOK  bool
+		keyName string
+	}{
+		{name: "int", value: int(2), want: 2, wantOK: true},
+		{name: "int32", value: int32(3), want: 3, wantOK: true},
+		{name: "int64", value: int64(4), want: 4, wantOK: true},
+		{name: "json number", value: json.Number("5"), want: 5, wantOK: true},
+		{name: "hyphen json number", keyName: "selection-weight", value: json.Number("6"), want: 6, wantOK: true},
+		{name: "negative int", value: int(-1), wantOK: false},
+		{name: "fractional json number", value: json.Number("1.5"), wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keyName := tt.keyName
+			if keyName == "" {
+				keyName = "selection_weight"
+			}
+			got, ok := metadataSelectionWeight(map[string]any{keyName: tt.value})
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Fatalf("weight = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFileSynthesizer_Synthesize_OAuthExcludedModelsMerged(t *testing.T) {
 	tempDir := t.TempDir()
 	authData := map[string]any{

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -286,6 +286,7 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(&internalconfig.Config{})
 	manager.apiKeyModelAlias.Store(apiKeyModelAliasTable(nil))
+	manager.bindSessionAffinitySelector(selector)
 	manager.scheduler = newAuthScheduler(selector)
 	return manager
 }
@@ -317,7 +318,7 @@ func (m *Manager) hasPluginScheduler() bool {
 
 func isBuiltInSelector(selector Selector) bool {
 	switch selector.(type) {
-	case *RoundRobinSelector, *FillFirstSelector:
+	case *RoundRobinSelector, *FillFirstSelector, *WeightedRoundRobinSelector:
 		return true
 	default:
 		return false
@@ -469,6 +470,7 @@ func (m *Manager) SetSelector(selector Selector) {
 	if selector == nil {
 		selector = &RoundRobinSelector{}
 	}
+	m.bindSessionAffinitySelector(selector)
 	m.mu.Lock()
 	m.selector = selector
 	m.mu.Unlock()
@@ -476,6 +478,14 @@ func (m *Manager) SetSelector(selector Selector) {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()
 	}
+}
+
+func (m *Manager) bindSessionAffinitySelector(selector Selector) {
+	sessionSelector, ok := selector.(*SessionAffinitySelector)
+	if !ok || sessionSelector == nil {
+		return
+	}
+	sessionSelector.SetModelResolver(m.selectionModelForAuth)
 }
 
 // SetStore swaps the underlying persistence store.
@@ -1417,6 +1427,71 @@ func (m *Manager) availableAuthsForRouteModel(auths []*Auth, provider, routeMode
 	return available, nil
 }
 
+func (m *Manager) allAvailableAuthsForRouteModel(auths []*Auth, provider, routeModel string, now time.Time) ([]*Auth, error) {
+	if len(auths) == 0 {
+		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
+	}
+
+	available := make([]*Auth, 0, len(auths))
+	cooldownCount := 0
+	var earliest time.Time
+	for _, candidate := range auths {
+		checkModel := m.selectionModelForAuth(candidate, routeModel)
+		blocked, reason, next := isAuthBlockedForModel(candidate, checkModel, now)
+		if !blocked {
+			available = append(available, candidate)
+			continue
+		}
+		if reason == blockReasonCooldown {
+			cooldownCount++
+			if !next.IsZero() && (earliest.IsZero() || next.Before(earliest)) {
+				earliest = next
+			}
+		}
+	}
+	if len(available) == 0 {
+		if cooldownCount == len(auths) && !earliest.IsZero() {
+			providerForError := provider
+			if providerForError == "mixed" {
+				providerForError = ""
+			}
+			resetIn := earliest.Sub(now)
+			if resetIn < 0 {
+				resetIn = 0
+			}
+			return nil, newModelCooldownError(routeModel, providerForError, resetIn)
+		}
+		return nil, &Error{Code: "auth_unavailable", Message: "no auth available"}
+	}
+	sort.Slice(available, func(i, j int) bool {
+		leftPriority := authPriority(available[i])
+		rightPriority := authPriority(available[j])
+		if leftPriority != rightPriority {
+			return leftPriority > rightPriority
+		}
+		return available[i].ID < available[j].ID
+	})
+	return available, nil
+}
+
+func (m *Manager) availableAuthsForRouteModelForSelector(auths []*Auth, provider, routeModel string, now time.Time, selector Selector) ([]*Auth, error) {
+	if selectorNeedsAllAvailableAuths(selector) {
+		return m.allAvailableAuthsForRouteModel(auths, provider, routeModel, now)
+	}
+	return m.availableAuthsForRouteModel(auths, provider, routeModel, now)
+}
+
+func selectorNeedsAllAvailableAuths(selector Selector) bool {
+	switch typed := selector.(type) {
+	case *WeightedRoundRobinSelector:
+		return true
+	case *SessionAffinitySelector:
+		return typed != nil
+	default:
+		return false
+	}
+}
+
 func selectionArgForSelector(selector Selector, routeModel string) string {
 	if isBuiltInSelector(selector) {
 		return ""
@@ -1500,11 +1575,12 @@ func schedulerAuthCandidates(auths []*Auth) []pluginapi.SchedulerAuthCandidate {
 			continue
 		}
 		out = append(out, pluginapi.SchedulerAuthCandidate{
-			ID:         auth.ID,
-			Provider:   strings.ToLower(strings.TrimSpace(auth.Provider)),
-			Priority:   authPriority(auth),
-			Status:     string(auth.Status),
-			Attributes: schedulerSafeAttributes(auth.Attributes),
+			ID:              auth.ID,
+			Provider:        strings.ToLower(strings.TrimSpace(auth.Provider)),
+			Priority:        authPriority(auth),
+			SelectionWeight: authSelectionWeight(auth),
+			Status:          string(auth.Status),
+			Attributes:      schedulerSafeAttributes(auth.Attributes),
 		})
 	}
 	return out
@@ -1557,6 +1633,8 @@ func builtinSchedulerStrategy(delegate string) (schedulerStrategy, bool) {
 		return schedulerStrategyRoundRobin, true
 	case pluginapi.SchedulerBuiltinFillFirst:
 		return schedulerStrategyFillFirst, true
+	case pluginapi.SchedulerBuiltinWeightedRoundRobin:
+		return schedulerStrategyWeightedRR, true
 	default:
 		return schedulerStrategyCustom, false
 	}
@@ -4561,7 +4639,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		m.mu.RUnlock()
 		return nil, nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	available, errAvailable := m.availableAuthsForRouteModel(candidates, provider, model, time.Now())
+	available, errAvailable := m.availableAuthsForRouteModelForSelector(candidates, provider, model, time.Now(), selector)
 	if errAvailable != nil {
 		m.mu.RUnlock()
 		return nil, nil, errAvailable
@@ -4731,7 +4809,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		m.mu.RUnlock()
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	available, errAvailable := m.availableAuthsForRouteModel(candidates, "mixed", model, time.Now())
+	available, errAvailable := m.availableAuthsForRouteModelForSelector(candidates, "mixed", model, time.Now(), selector)
 	if errAvailable != nil {
 		m.mu.RUnlock()
 		return nil, nil, "", errAvailable

--- a/sdk/cliproxy/auth/conductor_oauth_alias_suspension_test.go
+++ b/sdk/cliproxy/auth/conductor_oauth_alias_suspension_test.go
@@ -128,3 +128,105 @@ func TestManagerExecute_OAuthAliasBypassesBlockedRouteModel(t *testing.T) {
 		t.Fatalf("execute alias = %q, want %q", gotAliases[0], routeModel)
 	}
 }
+
+func TestManagerPickNextLegacySessionAffinityKeepsOAuthAliasBindingWhenRouteModelBlocked(t *testing.T) {
+	const (
+		provider    = "antigravity-affinity"
+		routeModel  = "claude-opus-4-6-affinity"
+		targetModel = "claude-opus-4-6-affinity-thinking"
+	)
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &RoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	manager := NewManager(nil, selector, nil)
+	manager.RegisterExecutor(&aliasRoutingExecutor{id: provider})
+	manager.SetOAuthModelAlias(map[string][]internalconfig.OAuthModelAlias{
+		provider: {{
+			Name:  targetModel,
+			Alias: routeModel,
+			Fork:  true,
+		}},
+	})
+
+	reg := registry.GetGlobalRegistry()
+	for _, authID := range []string{"alias-high", "alias-low"} {
+		reg.RegisterClient(authID, provider, []*registry.ModelInfo{{ID: routeModel}, {ID: targetModel}})
+	}
+	t.Cleanup(func() {
+		reg.UnregisterClient("alias-high")
+		reg.UnregisterClient("alias-low")
+	})
+
+	now := time.Now()
+	high := &Auth{
+		ID:       "alias-high",
+		Provider: provider,
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"priority": "10",
+		},
+		Metadata: map[string]any{"email": "high@example.com"},
+		ModelStates: map[string]*ModelState{
+			targetModel: {
+				Unavailable:    true,
+				Status:         StatusError,
+				NextRetryAfter: now.Add(time.Hour),
+			},
+		},
+	}
+	low := &Auth{
+		ID:             "alias-low",
+		Provider:       provider,
+		Status:         StatusActive,
+		Unavailable:    true,
+		NextRetryAfter: now.Add(time.Hour),
+		Metadata:       map[string]any{"email": "low@example.com"},
+		ModelStates: map[string]*ModelState{
+			routeModel: {
+				Unavailable:    true,
+				Status:         StatusError,
+				NextRetryAfter: now.Add(time.Hour),
+			},
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), high); errRegister != nil {
+		t.Fatalf("register high: %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), low); errRegister != nil {
+		t.Fatalf("register low: %v", errRegister)
+	}
+
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_alias-affinity"}}`),
+	}
+	got, _, errPick := manager.pickNext(context.Background(), provider, routeModel, opts, nil)
+	if errPick != nil {
+		t.Fatalf("first pickNext() error = %v", errPick)
+	}
+	if got == nil || got.ID != "alias-low" {
+		t.Fatalf("first pickNext() = %#v, want alias-low", got)
+	}
+
+	high.ModelStates = map[string]*ModelState{
+		routeModel: {
+			Unavailable:    false,
+			Status:         StatusActive,
+			NextRetryAfter: time.Time{},
+		},
+	}
+	if _, errUpdate := manager.Update(context.Background(), high); errUpdate != nil {
+		t.Fatalf("update high: %v", errUpdate)
+	}
+
+	got, _, errPick = manager.pickNext(context.Background(), provider, routeModel, opts, nil)
+	if errPick != nil {
+		t.Fatalf("second pickNext() error = %v", errPick)
+	}
+	if got == nil || got.ID != "alias-low" {
+		t.Fatalf("second pickNext() = %#v, want sticky alias-low", got)
+	}
+}

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -19,6 +19,7 @@ const (
 	schedulerStrategyCustom     schedulerStrategy = 0
 	schedulerStrategyRoundRobin schedulerStrategy = 1
 	schedulerStrategyFillFirst  schedulerStrategy = 2
+	schedulerStrategyWeightedRR schedulerStrategy = 3
 )
 
 // scheduledState describes how an auth currently participates in a model shard.
@@ -52,6 +53,7 @@ type scheduledAuthMeta struct {
 	auth              *Auth
 	providerKey       string
 	priority          int
+	selectionWeight   int
 	websocketEnabled  bool
 	supportedModelSet map[string]struct{}
 }
@@ -97,6 +99,10 @@ type readyBucketCursorState struct {
 	ws  readyViewCursorState
 }
 
+type modelSchedulerCursorState map[int]readyBucketCursorState
+type providerSchedulerCursorState map[string]modelSchedulerCursorState
+type schedulerCursorState map[string]providerSchedulerCursorState
+
 func snapshotReadyViewCursors(view readyView) readyViewCursorState {
 	return readyViewCursorState{cursor: view.cursor}
 }
@@ -106,7 +112,10 @@ func restoreReadyViewCursors(view *readyView, state readyViewCursorState) {
 		return
 	}
 	if len(view.flat) > 0 {
-		view.cursor = normalizeCursor(state.cursor, len(view.flat))
+		view.cursor = state.cursor
+		if view.cursor < 0 || view.cursor >= 2_147_483_640 {
+			view.cursor = 0
+		}
 	}
 }
 
@@ -119,6 +128,52 @@ func normalizeCursor(cursor, size int) int {
 		cursor += size
 	}
 	return cursor
+}
+
+func snapshotSchedulerCursors(providers map[string]*providerScheduler) schedulerCursorState {
+	if len(providers) == 0 {
+		return nil
+	}
+	out := make(schedulerCursorState, len(providers))
+	for providerKey, providerState := range providers {
+		if providerState == nil || len(providerState.modelShards) == 0 {
+			continue
+		}
+		providerStateOut := make(providerSchedulerCursorState, len(providerState.modelShards))
+		for modelKey, shard := range providerState.modelShards {
+			if shard == nil || len(shard.readyByPriority) == 0 {
+				continue
+			}
+			modelState := make(modelSchedulerCursorState, len(shard.readyByPriority))
+			for priority, bucket := range shard.readyByPriority {
+				if bucket == nil {
+					continue
+				}
+				modelState[priority] = readyBucketCursorState{
+					all: snapshotReadyViewCursors(bucket.all),
+					ws:  snapshotReadyViewCursors(bucket.ws),
+				}
+			}
+			if len(modelState) > 0 {
+				providerStateOut[modelKey] = modelState
+			}
+		}
+		if len(providerStateOut) > 0 {
+			out[providerKey] = providerStateOut
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func cloneMixedCursors(cursors map[string]int) map[string]int {
+	out := make(map[string]int, len(cursors))
+	for key, cursor := range cursors {
+		out[key] = cursor
+	}
+	return out
 }
 
 // newAuthScheduler constructs an empty scheduler configured for the supplied selector strategy.
@@ -136,6 +191,8 @@ func selectorStrategy(selector Selector) schedulerStrategy {
 	switch selector.(type) {
 	case *FillFirstSelector:
 		return schedulerStrategyFillFirst
+	case *WeightedRoundRobinSelector:
+		return schedulerStrategyWeightedRR
 	case nil, *RoundRobinSelector:
 		return schedulerStrategyRoundRobin
 	default:
@@ -161,12 +218,38 @@ func (s *authScheduler) rebuild(auths []*Auth) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	cursorState := snapshotSchedulerCursors(s.providers)
+	mixedCursors := cloneMixedCursors(s.mixedCursors)
 	s.providers = make(map[string]*providerScheduler)
 	s.authProviders = make(map[string]string)
-	s.mixedCursors = make(map[string]int)
+	s.mixedCursors = mixedCursors
 	now := time.Now()
 	for _, auth := range auths {
 		s.upsertAuthLocked(auth, now)
+	}
+	s.restoreSchedulerCursorsLocked(cursorState, now)
+}
+
+func (s *authScheduler) restoreSchedulerCursorsLocked(cursorState schedulerCursorState, now time.Time) {
+	for providerKey, providerState := range cursorState {
+		providerScheduler := s.providers[providerKey]
+		if providerScheduler == nil {
+			continue
+		}
+		for modelKey, modelState := range providerState {
+			shard := providerScheduler.ensureModelLocked(modelKey, now)
+			if shard == nil {
+				continue
+			}
+			for priority, bucketState := range modelState {
+				bucket := shard.readyByPriority[priority]
+				if bucket == nil {
+					continue
+				}
+				restoreReadyViewCursors(&bucket.all, bucketState.all)
+				restoreReadyViewCursors(&bucket.ws, bucketState.ws)
+			}
+		}
 	}
 }
 
@@ -213,6 +296,7 @@ func (s *authScheduler) pickSingleWithStrategy(ctx context.Context, provider, mo
 	if strategy == schedulerStrategyCurrent {
 		strategy = s.strategy
 	}
+	pickStrategy := strategyForPinnedAuth(strategy, pinnedAuthID)
 	providerState := s.providers[providerKey]
 	if providerState == nil {
 		return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
@@ -235,10 +319,17 @@ func (s *authScheduler) pickSingleWithStrategy(ctx context.Context, provider, mo
 		}
 		return true
 	}
-	if picked := shard.pickReadyLocked(preferWebsocket, strategy, predicate); picked != nil {
+	if picked := shard.pickReadyLocked(preferWebsocket, pickStrategy, predicate); picked != nil {
 		return picked, nil
 	}
 	return nil, shard.unavailableErrorLocked(provider, model, predicate)
+}
+
+func strategyForPinnedAuth(strategy schedulerStrategy, pinnedAuthID string) schedulerStrategy {
+	if strategy == schedulerStrategyWeightedRR && strings.TrimSpace(pinnedAuthID) != "" {
+		return schedulerStrategyRoundRobin
+	}
+	return strategy
 }
 
 func providerPrefersWebsocketTransport(providerKey string) bool {
@@ -284,6 +375,7 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 	if strategy == schedulerStrategyCurrent {
 		strategy = s.strategy
 	}
+	pickStrategy := strategyForPinnedAuth(strategy, pinnedAuthID)
 	if pinnedAuthID != "" {
 		providerKey := s.authProviders[pinnedAuthID]
 		if providerKey == "" || !containsProvider(normalized, providerKey) {
@@ -304,7 +396,7 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 			_, ok := tried[pinnedAuthID]
 			return !ok
 		}
-		if picked := shard.pickReadyLocked(false, strategy, predicate); picked != nil {
+		if picked := shard.pickReadyLocked(false, pickStrategy, predicate); picked != nil {
 			return picked, providerKey, nil
 		}
 		return nil, "", shard.unavailableErrorLocked("mixed", model, predicate)
@@ -325,7 +417,7 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 		if shard == nil {
 			continue
 		}
-		priorityReady, okPriority := shard.highestReadyPriorityLocked(false, predicate)
+		priorityReady, okPriority := shard.highestReadyPriorityLocked(false, strategy, predicate)
 		if !okPriority {
 			continue
 		}
@@ -360,7 +452,7 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 	for providerIndex, shard := range candidateShards {
 		segmentStarts[providerIndex] = totalWeight
 		if shard != nil {
-			weights[providerIndex] = shard.readyCountAtPriorityLocked(false, bestPriority)
+			weights[providerIndex] = shard.readySlotWeightAtPriorityLocked(false, bestPriority, strategy, predicate)
 		}
 		totalWeight += weights[providerIndex]
 		segmentEnds[providerIndex] = totalWeight
@@ -398,7 +490,7 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 		if shard == nil {
 			continue
 		}
-		picked := shard.pickReadyAtPriorityLocked(false, bestPriority, schedulerStrategyRoundRobin, predicate)
+		picked := shard.pickReadyAtPriorityLocked(false, bestPriority, strategy, predicate)
 		if picked == nil {
 			continue
 		}
@@ -543,6 +635,7 @@ func buildScheduledAuthMeta(auth *Auth) *scheduledAuthMeta {
 		auth:              auth,
 		providerKey:       providerKey,
 		priority:          authPriority(auth),
+		selectionWeight:   authSelectionWeight(auth),
 		websocketEnabled:  authWebsocketsEnabled(auth),
 		supportedModelSet: supportedModelSetForAuth(auth.ID),
 	}
@@ -654,9 +747,11 @@ func (m *modelScheduler) upsertEntryLocked(meta *scheduledAuthMeta, now time.Tim
 	previousState := entry.state
 	previousNextRetryAt := entry.nextRetryAt
 	previousPriority := 0
+	previousSelectionWeight := 1
 	previousWebsocketEnabled := false
 	if entry.meta != nil {
 		previousPriority = entry.meta.priority
+		previousSelectionWeight = entry.meta.selectionWeight
 		previousWebsocketEnabled = entry.meta.websocketEnabled
 	}
 
@@ -677,7 +772,7 @@ func (m *modelScheduler) upsertEntryLocked(meta *scheduledAuthMeta, now time.Tim
 		entry.nextRetryAt = next
 	}
 
-	if ok && previousState == entry.state && previousNextRetryAt.Equal(entry.nextRetryAt) && previousPriority == meta.priority && previousWebsocketEnabled == meta.websocketEnabled {
+	if ok && previousState == entry.state && previousNextRetryAt.Equal(entry.nextRetryAt) && previousPriority == meta.priority && previousSelectionWeight == meta.selectionWeight && previousWebsocketEnabled == meta.websocketEnabled {
 		return
 	}
 	m.rebuildIndexesLocked()
@@ -736,7 +831,7 @@ func (m *modelScheduler) pickReadyLocked(preferWebsocket bool, strategy schedule
 		return nil
 	}
 	m.promoteExpiredLocked(time.Now())
-	priorityReady, okPriority := m.highestReadyPriorityLocked(preferWebsocket, predicate)
+	priorityReady, okPriority := m.highestReadyPriorityLocked(preferWebsocket, strategy, predicate)
 	if !okPriority {
 		return nil
 	}
@@ -745,7 +840,7 @@ func (m *modelScheduler) pickReadyLocked(preferWebsocket bool, strategy schedule
 
 // highestReadyPriorityLocked returns the highest priority bucket that still has a matching ready auth.
 // The caller must ensure expired entries are already promoted when needed.
-func (m *modelScheduler) highestReadyPriorityLocked(preferWebsocket bool, predicate func(*scheduledAuth) bool) (int, bool) {
+func (m *modelScheduler) highestReadyPriorityLocked(preferWebsocket bool, strategy schedulerStrategy, predicate func(*scheduledAuth) bool) (int, bool) {
 	if m == nil {
 		return 0, false
 	}
@@ -757,7 +852,7 @@ func (m *modelScheduler) highestReadyPriorityLocked(preferWebsocket bool, predic
 			if bucket == nil {
 				continue
 			}
-			if bucket.ws.pickFirst(predicate) != nil {
+			if bucket.ws.hasSelectable(strategy, predicate) {
 				return priority, true
 			}
 		}
@@ -767,7 +862,7 @@ func (m *modelScheduler) highestReadyPriorityLocked(preferWebsocket bool, predic
 		if bucket == nil {
 			continue
 		}
-		if bucket.all.pickFirst(predicate) != nil {
+		if bucket.all.hasSelectable(strategy, predicate) {
 			return priority, true
 		}
 	}
@@ -785,13 +880,16 @@ func (m *modelScheduler) pickReadyAtPriorityLocked(preferWebsocket bool, priorit
 		return nil
 	}
 	view := &bucket.all
-	if preferWebsocket && bucket.ws.pickFirst(predicate) != nil {
+	if preferWebsocket && bucket.ws.hasSelectable(strategy, predicate) {
 		view = &bucket.ws
 	}
 	var picked *scheduledAuth
-	if strategy == schedulerStrategyFillFirst {
+	switch strategy {
+	case schedulerStrategyFillFirst:
 		picked = view.pickFirst(predicate)
-	} else {
+	case schedulerStrategyWeightedRR:
+		picked = view.pickWeightedRoundRobin(predicate)
+	default:
 		picked = view.pickRoundRobin(predicate)
 	}
 	if picked == nil || picked.auth == nil {
@@ -800,7 +898,7 @@ func (m *modelScheduler) pickReadyAtPriorityLocked(preferWebsocket bool, priorit
 	return picked.auth
 }
 
-func (m *modelScheduler) readyCountAtPriorityLocked(preferWebsocket bool, priority int) int {
+func (m *modelScheduler) readySlotWeightAtPriorityLocked(preferWebsocket bool, priority int, strategy schedulerStrategy, predicate func(*scheduledAuth) bool) int {
 	if m == nil {
 		return 0
 	}
@@ -808,10 +906,10 @@ func (m *modelScheduler) readyCountAtPriorityLocked(preferWebsocket bool, priori
 	if bucket == nil {
 		return 0
 	}
-	if preferWebsocket && len(bucket.ws.flat) > 0 {
-		return len(bucket.ws.flat)
+	if preferWebsocket && bucket.ws.hasSelectable(strategy, predicate) {
+		return bucket.ws.slotWeight(strategy, predicate)
 	}
-	return len(bucket.all.flat)
+	return bucket.all.slotWeight(strategy, predicate)
 }
 
 // unavailableErrorLocked returns the correct unavailable or cooldown error for the shard.
@@ -954,6 +1052,36 @@ func (v *readyView) pickFirst(predicate func(*scheduledAuth) bool) *scheduledAut
 	return nil
 }
 
+func (v *readyView) hasSelectable(strategy schedulerStrategy, predicate func(*scheduledAuth) bool) bool {
+	if strategy == schedulerStrategyWeightedRR {
+		for _, entry := range v.flat {
+			if predicate != nil && !predicate(entry) {
+				continue
+			}
+			if scheduledAuthSelectionWeight(entry) > 0 {
+				return true
+			}
+		}
+		return false
+	}
+	return v.pickFirst(predicate) != nil
+}
+
+func (v *readyView) slotWeight(strategy schedulerStrategy, predicate func(*scheduledAuth) bool) int {
+	total := 0
+	for _, entry := range v.flat {
+		if predicate != nil && !predicate(entry) {
+			continue
+		}
+		if strategy == schedulerStrategyWeightedRR {
+			total += scheduledAuthSelectionWeight(entry)
+			continue
+		}
+		total++
+	}
+	return total
+}
+
 // pickRoundRobin returns the next ready entry using flat round-robin traversal.
 func (v *readyView) pickRoundRobin(predicate func(*scheduledAuth) bool) *scheduledAuth {
 	if len(v.flat) == 0 {
@@ -971,6 +1099,41 @@ func (v *readyView) pickRoundRobin(predicate func(*scheduledAuth) bool) *schedul
 		}
 		v.cursor = index + 1
 		return entry
+	}
+	return nil
+}
+
+// pickWeightedRoundRobin returns the next ready entry using weighted slot traversal.
+func (v *readyView) pickWeightedRoundRobin(predicate func(*scheduledAuth) bool) *scheduledAuth {
+	if len(v.flat) == 0 {
+		return nil
+	}
+	totalWeight := v.slotWeight(schedulerStrategyWeightedRR, predicate)
+	if totalWeight <= 0 {
+		return nil
+	}
+	cursor := v.cursor
+	if cursor >= 2_147_483_640 {
+		cursor = 0
+	}
+	slot := cursor % totalWeight
+	if slot < 0 {
+		slot += totalWeight
+	}
+	running := 0
+	for _, entry := range v.flat {
+		if predicate != nil && !predicate(entry) {
+			continue
+		}
+		weight := scheduledAuthSelectionWeight(entry)
+		if weight <= 0 {
+			continue
+		}
+		running += weight
+		if slot < running {
+			v.cursor = cursor + 1
+			return entry
+		}
 	}
 	return nil
 }

--- a/sdk/cliproxy/auth/scheduler_test.go
+++ b/sdk/cliproxy/auth/scheduler_test.go
@@ -148,6 +148,140 @@ func TestSchedulerPick_FillFirstSticksToFirstReady(t *testing.T) {
 	}
 }
 
+func TestSchedulerPick_WeightedRoundRobinUsesSelectionWeights(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newSchedulerForTest(
+		&WeightedRoundRobinSelector{},
+		&Auth{ID: "b", Provider: "gemini", Attributes: map[string]string{"selection_weight": "3"}},
+		&Auth{ID: "a", Provider: "gemini", Attributes: map[string]string{"selection_weight": "1"}},
+	)
+
+	want := []string{"a", "b", "b", "b", "a"}
+	for index, wantID := range want {
+		got, errPick := scheduler.pickSingle(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickSingle() #%d error = %v", index, errPick)
+		}
+		if got == nil {
+			t.Fatalf("pickSingle() #%d auth = nil", index)
+		}
+		if got.ID != wantID {
+			t.Fatalf("pickSingle() #%d auth.ID = %q, want %q", index, got.ID, wantID)
+		}
+	}
+}
+
+func TestSchedulerPick_WeightedRoundRobinCursorSurvivesRebuild(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newSchedulerForTest(
+		&WeightedRoundRobinSelector{},
+		&Auth{ID: "b", Provider: "gemini", Attributes: map[string]string{"selection_weight": "3"}},
+		&Auth{ID: "a", Provider: "gemini", Attributes: map[string]string{"selection_weight": "1"}},
+	)
+
+	for index, wantID := range []string{"a", "b"} {
+		got, errPick := scheduler.pickSingle(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickSingle() #%d error = %v", index, errPick)
+		}
+		if got == nil || got.ID != wantID {
+			t.Fatalf("pickSingle() #%d = %#v, want %s", index, got, wantID)
+		}
+	}
+
+	scheduler.upsertAuth(&Auth{ID: "a", Provider: "gemini", Attributes: map[string]string{"selection_weight": "1", "websockets": "true"}})
+
+	got, errPick := scheduler.pickSingle(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickSingle() after rebuild error = %v", errPick)
+	}
+	if got == nil || got.ID != "b" {
+		t.Fatalf("pickSingle() after rebuild = %#v, want b", got)
+	}
+}
+
+func TestSchedulerPick_WeightedRoundRobinCursorSurvivesFullRebuild(t *testing.T) {
+	t.Parallel()
+
+	auths := []*Auth{
+		{ID: "b", Provider: "gemini", Attributes: map[string]string{"selection_weight": "3"}},
+		{ID: "a", Provider: "gemini", Attributes: map[string]string{"selection_weight": "1"}},
+	}
+	scheduler := newSchedulerForTest(&WeightedRoundRobinSelector{}, auths...)
+
+	for index, wantID := range []string{"a", "b"} {
+		got, errPick := scheduler.pickSingle(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickSingle() #%d error = %v", index, errPick)
+		}
+		if got == nil || got.ID != wantID {
+			t.Fatalf("pickSingle() #%d = %#v, want %s", index, got, wantID)
+		}
+	}
+
+	scheduler.rebuild(auths)
+
+	got, errPick := scheduler.pickSingle(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickSingle() after full rebuild error = %v", errPick)
+	}
+	if got == nil || got.ID != "b" {
+		t.Fatalf("pickSingle() after full rebuild = %#v, want b", got)
+	}
+}
+
+func TestSchedulerPick_WeightedRoundRobinSkipsZeroWeightPriorityBucket(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newSchedulerForTest(
+		&WeightedRoundRobinSelector{},
+		&Auth{ID: "high", Provider: "gemini", Attributes: map[string]string{"priority": "10", "selection_weight": "0"}},
+		&Auth{ID: "low", Provider: "gemini", Attributes: map[string]string{"priority": "0", "selection_weight": "1"}},
+	)
+
+	got, errPick := scheduler.pickSingle(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickSingle() error = %v", errPick)
+	}
+	if got == nil {
+		t.Fatalf("pickSingle() auth = nil")
+	}
+	if got.ID != "low" {
+		t.Fatalf("pickSingle() auth.ID = %q, want %q", got.ID, "low")
+	}
+}
+
+func TestManagerPickNextLegacyWeightedSessionAffinitySkipsZeroWeightPriorityBucket(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &WeightedRoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+	manager := NewManager(nil, selector, nil)
+	manager.executors["gemini"] = schedulerTestExecutor{}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "high", Provider: "gemini", Attributes: map[string]string{"priority": "10", "selection_weight": "0"}}); errRegister != nil {
+		t.Fatalf("Register(high) error = %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "low", Provider: "gemini", Attributes: map[string]string{"priority": "0", "selection_weight": "1"}}); errRegister != nil {
+		t.Fatalf("Register(low) error = %v", errRegister)
+	}
+
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}}`),
+	}
+	got, _, errPick := manager.pickNext(context.Background(), "gemini", "", opts, nil)
+	if errPick != nil {
+		t.Fatalf("pickNext() error = %v", errPick)
+	}
+	if got == nil || got.ID != "low" {
+		t.Fatalf("pickNext() = %#v, want low", got)
+	}
+}
+
 func TestSchedulerPick_PromotesExpiredCooldownBeforePick(t *testing.T) {
 	t.Parallel()
 
@@ -284,6 +418,64 @@ func TestSchedulerPick_MixedProvidersUsesWeightedProviderRotationOverReadyCandid
 		if got.ID != wantIDs[index] {
 			t.Fatalf("pickMixed() #%d auth.ID = %q, want %q", index, got.ID, wantIDs[index])
 		}
+	}
+}
+
+func TestSchedulerPick_MixedProvidersUsesSelectionWeightSums(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newSchedulerForTest(
+		&WeightedRoundRobinSelector{},
+		&Auth{ID: "gemini-a", Provider: "gemini", Attributes: map[string]string{"selection_weight": "1"}},
+		&Auth{ID: "claude-a", Provider: "claude", Attributes: map[string]string{"selection_weight": "3"}},
+	)
+
+	wantProviders := []string{"gemini", "claude", "claude", "claude", "gemini"}
+	wantIDs := []string{"gemini-a", "claude-a", "claude-a", "claude-a", "gemini-a"}
+	for index := range wantProviders {
+		got, provider, errPick := scheduler.pickMixed(context.Background(), []string{"gemini", "claude"}, "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickMixed() #%d error = %v", index, errPick)
+		}
+		if got == nil {
+			t.Fatalf("pickMixed() #%d auth = nil", index)
+		}
+		if provider != wantProviders[index] {
+			t.Fatalf("pickMixed() #%d provider = %q, want %q", index, provider, wantProviders[index])
+		}
+		if got.ID != wantIDs[index] {
+			t.Fatalf("pickMixed() #%d auth.ID = %q, want %q", index, got.ID, wantIDs[index])
+		}
+	}
+}
+
+func TestSchedulerPick_MixedWeightedCursorSurvivesFullRebuild(t *testing.T) {
+	t.Parallel()
+
+	auths := []*Auth{
+		{ID: "gemini-a", Provider: "gemini", Attributes: map[string]string{"selection_weight": "1"}},
+		{ID: "claude-a", Provider: "claude", Attributes: map[string]string{"selection_weight": "3"}},
+	}
+	scheduler := newSchedulerForTest(&WeightedRoundRobinSelector{}, auths...)
+
+	for index, wantProvider := range []string{"gemini", "claude"} {
+		got, provider, errPick := scheduler.pickMixed(context.Background(), []string{"gemini", "claude"}, "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickMixed() #%d error = %v", index, errPick)
+		}
+		if got == nil || provider != wantProvider {
+			t.Fatalf("pickMixed() #%d = auth %#v provider %q, want provider %s", index, got, provider, wantProvider)
+		}
+	}
+
+	scheduler.rebuild(auths)
+
+	got, provider, errPick := scheduler.pickMixed(context.Background(), []string{"gemini", "claude"}, "", cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickMixed() after full rebuild error = %v", errPick)
+	}
+	if got == nil || provider != "claude" || got.ID != "claude-a" {
+		t.Fatalf("pickMixed() after full rebuild = auth %#v provider %q, want claude-a via claude", got, provider)
 	}
 }
 
@@ -673,6 +865,76 @@ func TestManagerPluginSchedulerDelegatesBuiltin(t *testing.T) {
 			t.Fatalf("fill-first pick = %q, want auth-a", got.ID)
 		}
 	})
+
+	t.Run("weighted-round-robin", func(t *testing.T) {
+		manager := NewManager(nil, &FillFirstSelector{}, nil)
+		manager.executors["gemini"] = schedulerTestExecutor{}
+		if _, errRegister := manager.Register(context.Background(), &Auth{ID: "auth-b", Provider: "gemini", Attributes: map[string]string{"selection_weight": "3"}}); errRegister != nil {
+			t.Fatalf("Register(auth-b) error = %v", errRegister)
+		}
+		if _, errRegister := manager.Register(context.Background(), &Auth{ID: "auth-a", Provider: "gemini", Attributes: map[string]string{"selection_weight": "1"}}); errRegister != nil {
+			t.Fatalf("Register(auth-a) error = %v", errRegister)
+		}
+		manager.SetPluginScheduler(&fakePluginScheduler{
+			resp:    pluginapi.SchedulerPickResponse{Handled: true, DelegateBuiltin: pluginapi.SchedulerBuiltinWeightedRoundRobin},
+			handled: true,
+		})
+
+		want := []string{"auth-a", "auth-b", "auth-b", "auth-b", "auth-a"}
+		for index, wantID := range want {
+			got, _, errPick := manager.pickNext(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+			if errPick != nil {
+				t.Fatalf("pickNext() #%d error = %v", index, errPick)
+			}
+			if got == nil {
+				t.Fatalf("pickNext() #%d auth = nil", index)
+			}
+			if got.ID != wantID {
+				t.Fatalf("weighted-round-robin pick #%d = %q, want %q", index, got.ID, wantID)
+			}
+		}
+	})
+}
+
+func TestManagerWeightedSchedulerPinnedZeroWeightAuth(t *testing.T) {
+	manager := NewManager(nil, &WeightedRoundRobinSelector{}, nil)
+	manager.executors["gemini"] = schedulerTestExecutor{}
+	if _, errRegister := manager.Register(context.Background(), &Auth{
+		ID:       "other",
+		Provider: "gemini",
+		Attributes: map[string]string{
+			"priority":         "10",
+			"selection_weight": "5",
+		},
+	}); errRegister != nil {
+		t.Fatalf("Register(other) error = %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{
+		ID:       "pinned",
+		Provider: "gemini",
+		Attributes: map[string]string{
+			"priority":         "0",
+			"selection_weight": "0",
+		},
+	}); errRegister != nil {
+		t.Fatalf("Register(pinned) error = %v", errRegister)
+	}
+
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.PinnedAuthMetadataKey: "pinned",
+		},
+	}
+	got, _, errPick := manager.pickNext(context.Background(), "gemini", "", opts, nil)
+	if errPick != nil {
+		t.Fatalf("pickNext() error = %v", errPick)
+	}
+	if got == nil {
+		t.Fatalf("pickNext() auth = nil")
+	}
+	if got.ID != "pinned" {
+		t.Fatalf("pickNext() auth.ID = %q, want pinned", got.ID)
+	}
 }
 
 func TestManagerPluginSchedulerDelegateRoundRobinUsesNativeMixedRotation(t *testing.T) {
@@ -796,11 +1058,12 @@ func TestManagerPluginSchedulerCandidatesAreSafeCopies(t *testing.T) {
 		Provider: "gemini",
 		Status:   StatusActive,
 		Attributes: map[string]string{
-			"access_token": "token-value",
-			"api_key":      "api-key-value",
-			"cookie":       "cookie-value",
-			"priority":     "7",
-			"team":         "alpha",
+			"access_token":     "token-value",
+			"api_key":          "api-key-value",
+			"cookie":           "cookie-value",
+			"priority":         "7",
+			"selection_weight": "3",
+			"team":             "alpha",
 		},
 		Metadata: map[string]any{"tenant": "one"},
 	}
@@ -815,7 +1078,7 @@ func TestManagerPluginSchedulerCandidatesAreSafeCopies(t *testing.T) {
 				t.Fatalf("len(req.Candidates) = %d, want %d", len(req.Candidates), 1)
 			}
 			candidate := req.Candidates[0]
-			if candidate.ID != "auth-a" || candidate.Provider != "gemini" || candidate.Priority != 7 || candidate.Status != string(StatusActive) {
+			if candidate.ID != "auth-a" || candidate.Provider != "gemini" || candidate.Priority != 7 || candidate.SelectionWeight != 3 || candidate.Status != string(StatusActive) {
 				t.Fatalf("scheduler candidate = %#v, want sanitized auth-a metadata", candidate)
 			}
 			for _, key := range []string{"access_token", "api_key", "cookie"} {
@@ -825,6 +1088,9 @@ func TestManagerPluginSchedulerCandidatesAreSafeCopies(t *testing.T) {
 			}
 			if candidate.Attributes["priority"] != "7" {
 				t.Fatalf("scheduler candidate priority attribute = %q, want 7", candidate.Attributes["priority"])
+			}
+			if candidate.Attributes["selection_weight"] != "3" {
+				t.Fatalf("scheduler candidate selection_weight attribute = %q, want 3", candidate.Attributes["selection_weight"])
 			}
 			if len(candidate.Metadata) != 0 {
 				t.Fatalf("scheduler candidate Metadata = %#v, want empty", candidate.Metadata)

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -29,6 +29,14 @@ type RoundRobinSelector struct {
 	maxKeys int
 }
 
+// WeightedRoundRobinSelector selects available credentials according to each
+// credential's selection_weight attribute within the highest priority bucket.
+type WeightedRoundRobinSelector struct {
+	mu      sync.Mutex
+	cursors map[string]int
+	maxKeys int
+}
+
 // FillFirstSelector selects the first available credential (deterministic ordering).
 // This "burns" one account before moving to the next, which can help stagger
 // rolling-window subscription caps (e.g. chat message limits).
@@ -125,6 +133,31 @@ func authPriority(auth *Auth) int {
 		return 0
 	}
 	return parsed
+}
+
+func authSelectionWeight(auth *Auth) int {
+	if auth == nil || auth.Attributes == nil {
+		return 1
+	}
+	for _, key := range []string{"selection_weight", "selection-weight", "weight"} {
+		raw := strings.TrimSpace(auth.Attributes[key])
+		if raw == "" {
+			continue
+		}
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			return 1
+		}
+		return parsed
+	}
+	return 1
+}
+
+func scheduledAuthSelectionWeight(entry *scheduledAuth) int {
+	if entry == nil || entry.meta == nil {
+		return 0
+	}
+	return entry.meta.selectionWeight
 }
 
 func canonicalModelKey(model string) string {
@@ -253,6 +286,75 @@ func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]
 	return available, nil
 }
 
+func getWeightedAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]*Auth, error) {
+	if len(auths) == 0 {
+		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
+	}
+
+	availableByPriority, cooldownCount, earliest := collectAvailableByPriority(auths, model, now)
+	if len(availableByPriority) == 0 {
+		if cooldownCount == len(auths) && !earliest.IsZero() {
+			providerForError := provider
+			if providerForError == "mixed" {
+				providerForError = ""
+			}
+			resetIn := earliest.Sub(now)
+			if resetIn < 0 {
+				resetIn = 0
+			}
+			return nil, newModelCooldownError(model, providerForError, resetIn)
+		}
+		return nil, &Error{Code: "auth_unavailable", Message: "no auth available"}
+	}
+
+	priorities := make([]int, 0, len(availableByPriority))
+	for priority := range availableByPriority {
+		priorities = append(priorities, priority)
+	}
+	sort.Slice(priorities, func(i, j int) bool { return priorities[i] > priorities[j] })
+
+	for _, priority := range priorities {
+		available := availableByPriority[priority]
+		hasPositiveWeight := false
+		for _, candidate := range available {
+			if authSelectionWeight(candidate) > 0 {
+				hasPositiveWeight = true
+				break
+			}
+		}
+		if !hasPositiveWeight {
+			continue
+		}
+		if len(available) > 1 {
+			sort.Slice(available, func(i, j int) bool { return available[i].ID < available[j].ID })
+		}
+		return available, nil
+	}
+
+	return nil, &Error{Code: "auth_unavailable", Message: "no auth available"}
+}
+
+func getPinnedAvailableAuth(auths []*Auth, provider, model, authID string, now time.Time) (*Auth, error) {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+	}
+	for _, auth := range auths {
+		if auth == nil || auth.ID != authID {
+			continue
+		}
+		available, err := getAvailableAuths([]*Auth{auth}, provider, model, now)
+		if err != nil {
+			return nil, err
+		}
+		if len(available) == 0 {
+			return nil, &Error{Code: "auth_unavailable", Message: "no auth available"}
+		}
+		return available[0], nil
+	}
+	return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+}
+
 // Pick selects the next available auth for the provider in a round-robin manner.
 func (s *RoundRobinSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
 	_ = opts
@@ -282,9 +384,82 @@ func (s *RoundRobinSelector) Pick(ctx context.Context, provider, model string, o
 	return available[index%len(available)], nil
 }
 
+// Pick selects the next available auth for the provider using weighted round-robin.
+func (s *WeightedRoundRobinSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	now := time.Now()
+	if pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata); pinnedAuthID != "" {
+		return getPinnedAvailableAuth(auths, provider, model, pinnedAuthID, now)
+	}
+	available, err := getWeightedAvailableAuths(auths, provider, model, now)
+	if err != nil {
+		return nil, err
+	}
+	available = preferCodexWebsocketAuths(ctx, provider, available)
+	key := provider + ":" + canonicalModelKey(model)
+	s.mu.Lock()
+	if s.cursors == nil {
+		s.cursors = make(map[string]int)
+	}
+	limit := s.maxKeys
+	if limit <= 0 {
+		limit = 4096
+	}
+
+	s.ensureCursorKey(key, limit)
+	cursor := s.cursors[key]
+	if cursor >= 2_147_483_640 {
+		cursor = 0
+	}
+	picked, nextCursor := pickWeightedAuth(available, cursor)
+	if picked == nil {
+		s.mu.Unlock()
+		return nil, &Error{Code: "auth_unavailable", Message: "no auth available"}
+	}
+	s.cursors[key] = nextCursor
+	s.mu.Unlock()
+	return picked, nil
+}
+
+func pickWeightedAuth(auths []*Auth, cursor int) (*Auth, int) {
+	totalWeight := 0
+	for _, auth := range auths {
+		weight := authSelectionWeight(auth)
+		if weight > 0 {
+			totalWeight += weight
+		}
+	}
+	if totalWeight <= 0 {
+		return nil, cursor
+	}
+	slot := cursor % totalWeight
+	if slot < 0 {
+		slot += totalWeight
+	}
+	running := 0
+	for _, auth := range auths {
+		weight := authSelectionWeight(auth)
+		if weight <= 0 {
+			continue
+		}
+		running += weight
+		if slot < running {
+			return auth, cursor + 1
+		}
+	}
+	return nil, cursor
+}
+
 // ensureCursorKey ensures the cursor map has capacity for the given key.
 // Must be called with s.mu held.
 func (s *RoundRobinSelector) ensureCursorKey(key string, limit int) {
+	if _, ok := s.cursors[key]; !ok && len(s.cursors) >= limit {
+		s.cursors = make(map[string]int)
+	}
+}
+
+// ensureCursorKey ensures the cursor map has capacity for the given key.
+// Must be called with s.mu held.
+func (s *WeightedRoundRobinSelector) ensureCursorKey(key string, limit int) {
 	if _, ok := s.cursors[key]; !ok && len(s.cursors) >= limit {
 		s.cursors = make(map[string]int)
 	}
@@ -369,14 +544,21 @@ var sessionPattern = regexp.MustCompile(`_session_([a-f0-9-]+)$`)
 // It extracts session ID from multiple sources and maintains session-to-auth
 // mappings with automatic failover when the bound auth becomes unavailable.
 type SessionAffinitySelector struct {
-	fallback Selector
-	cache    *SessionCache
+	fallback        Selector
+	cache           *SessionCache
+	modelResolverMu sync.RWMutex
+	modelResolver   SessionAffinityModelResolver
 }
+
+// SessionAffinityModelResolver resolves the model used to validate a bound
+// auth's availability in route-aware manager flows.
+type SessionAffinityModelResolver func(auth *Auth, routeModel string) string
 
 // SessionAffinityConfig configures the session affinity selector.
 type SessionAffinityConfig struct {
-	Fallback Selector
-	TTL      time.Duration
+	Fallback      Selector
+	TTL           time.Duration
+	ModelResolver SessionAffinityModelResolver
 }
 
 // NewSessionAffinitySelector creates a new session-aware selector.
@@ -396,9 +578,75 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 		cfg.TTL = time.Hour
 	}
 	return &SessionAffinitySelector{
-		fallback: cfg.Fallback,
-		cache:    NewSessionCache(cfg.TTL),
+		fallback:      cfg.Fallback,
+		cache:         NewSessionCache(cfg.TTL),
+		modelResolver: cfg.ModelResolver,
 	}
+}
+
+// SetModelResolver updates the optional route-aware availability model resolver.
+func (s *SessionAffinitySelector) SetModelResolver(resolver SessionAffinityModelResolver) {
+	if s == nil {
+		return
+	}
+	s.modelResolverMu.Lock()
+	s.modelResolver = resolver
+	s.modelResolverMu.Unlock()
+}
+
+func (s *SessionAffinitySelector) availabilityModel(auth *Auth, routeModel string) string {
+	if s == nil {
+		return routeModel
+	}
+	s.modelResolverMu.RLock()
+	resolver := s.modelResolver
+	s.modelResolverMu.RUnlock()
+	if resolver == nil {
+		return routeModel
+	}
+	if resolved := strings.TrimSpace(resolver(auth, routeModel)); resolved != "" {
+		return resolved
+	}
+	return routeModel
+}
+
+func (s *SessionAffinitySelector) hasModelResolver() bool {
+	if s == nil {
+		return false
+	}
+	s.modelResolverMu.RLock()
+	hasResolver := s.modelResolver != nil
+	s.modelResolverMu.RUnlock()
+	return hasResolver
+}
+
+func (s *SessionAffinitySelector) pickFallback(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	if !s.hasModelResolver() {
+		return s.fallback.Pick(ctx, provider, model, opts, auths)
+	}
+
+	sanitized := make([]*Auth, 0, len(auths))
+	for _, auth := range auths {
+		if auth == nil {
+			continue
+		}
+		candidate := auth.Clone()
+		candidate.ModelStates = nil
+		candidate.Unavailable = false
+		candidate.NextRetryAfter = time.Time{}
+		candidate.Quota = QuotaState{}
+		sanitized = append(sanitized, candidate)
+	}
+	picked, err := s.fallback.Pick(ctx, provider, model, opts, sanitized)
+	if err != nil || picked == nil {
+		return picked, err
+	}
+	for _, auth := range auths {
+		if auth != nil && auth.ID == picked.ID {
+			return auth, nil
+		}
+	}
+	return picked, nil
 }
 
 // Pick selects an auth with session affinity when possible.
@@ -419,26 +667,18 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	primaryID, fallbackID := extractSessionIDs(opts.Headers, opts.OriginalRequest, opts.Metadata)
 	if primaryID == "" {
 		entry.Debugf("session-affinity: no session ID extracted, falling back to default selector | provider=%s model=%s", provider, model)
-		return s.fallback.Pick(ctx, provider, model, opts, auths)
-	}
-
-	now := time.Now()
-	available, err := getAvailableAuths(auths, provider, model, now)
-	if err != nil {
-		return nil, err
+		return s.pickFallback(ctx, provider, model, opts, auths)
 	}
 
 	cacheKey := provider + "::" + primaryID + "::" + model
 
 	if cachedAuthID, ok := s.cache.GetAndRefresh(cacheKey); ok {
-		for _, auth := range available {
-			if auth.ID == cachedAuthID {
-				entry.Infof("session-affinity: cache hit | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
-				return auth, nil
-			}
+		if auth := s.availableAuthByID(auths, cachedAuthID, model, time.Now()); auth != nil {
+			entry.Infof("session-affinity: cache hit | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
+			return auth, nil
 		}
 		// Cached auth not available, reselect via fallback selector for even distribution
-		auth, err := s.fallback.Pick(ctx, provider, model, opts, auths)
+		auth, err := s.pickFallback(ctx, provider, model, opts, auths)
 		if err != nil {
 			return nil, err
 		}
@@ -450,23 +690,39 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	if fallbackID != "" && fallbackID != primaryID {
 		fallbackKey := provider + "::" + fallbackID + "::" + model
 		if cachedAuthID, ok := s.cache.Get(fallbackKey); ok {
-			for _, auth := range available {
-				if auth.ID == cachedAuthID {
-					s.cache.Set(cacheKey, auth.ID)
-					entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
-					return auth, nil
-				}
+			if auth := s.availableAuthByID(auths, cachedAuthID, model, time.Now()); auth != nil {
+				s.cache.Set(cacheKey, auth.ID)
+				entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
+				return auth, nil
 			}
 		}
 	}
 
-	auth, err := s.fallback.Pick(ctx, provider, model, opts, auths)
+	auth, err := s.pickFallback(ctx, provider, model, opts, auths)
 	if err != nil {
 		return nil, err
 	}
 	s.cache.Set(cacheKey, auth.ID)
 	entry.Infof("session-affinity: cache miss, new binding | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 	return auth, nil
+}
+
+func (s *SessionAffinitySelector) availableAuthByID(auths []*Auth, authID string, model string, now time.Time) *Auth {
+	authID = strings.TrimSpace(authID)
+	if authID == "" {
+		return nil
+	}
+	for _, auth := range auths {
+		if auth == nil || auth.ID != authID {
+			continue
+		}
+		blocked, _, _ := isAuthBlockedForModel(auth, s.availabilityModel(auth, model), now)
+		if !blocked {
+			return auth
+		}
+		return nil
+	}
+	return nil
 }
 
 func selectorLogEntry(ctx context.Context) *log.Entry {

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -205,7 +205,7 @@ func authWebsocketsEnabled(auth *Auth) bool {
 	return false
 }
 
-func preferCodexWebsocketAuths(ctx context.Context, provider string, available []*Auth) []*Auth {
+func preferCodexWebsocketAuths(ctx context.Context, provider string, available []*Auth, selectable func(*Auth) bool) []*Auth {
 	if len(available) == 0 {
 		return available
 	}
@@ -219,7 +219,7 @@ func preferCodexWebsocketAuths(ctx context.Context, provider string, available [
 	wsEnabled := make([]*Auth, 0, len(available))
 	for i := 0; i < len(available); i++ {
 		candidate := available[i]
-		if authWebsocketsEnabled(candidate) {
+		if authWebsocketsEnabled(candidate) && (selectable == nil || selectable(candidate)) {
 			wsEnabled = append(wsEnabled, candidate)
 		}
 	}
@@ -363,7 +363,7 @@ func (s *RoundRobinSelector) Pick(ctx context.Context, provider, model string, o
 	if err != nil {
 		return nil, err
 	}
-	available = preferCodexWebsocketAuths(ctx, provider, available)
+	available = preferCodexWebsocketAuths(ctx, provider, available, nil)
 	key := provider + ":" + canonicalModelKey(model)
 	s.mu.Lock()
 	if s.cursors == nil {
@@ -394,7 +394,9 @@ func (s *WeightedRoundRobinSelector) Pick(ctx context.Context, provider, model s
 	if err != nil {
 		return nil, err
 	}
-	available = preferCodexWebsocketAuths(ctx, provider, available)
+	available = preferCodexWebsocketAuths(ctx, provider, available, func(auth *Auth) bool {
+		return authSelectionWeight(auth) > 0
+	})
 	key := provider + ":" + canonicalModelKey(model)
 	s.mu.Lock()
 	if s.cursors == nil {
@@ -473,7 +475,7 @@ func (s *FillFirstSelector) Pick(ctx context.Context, provider, model string, op
 	if err != nil {
 		return nil, err
 	}
-	available = preferCodexWebsocketAuths(ctx, provider, available)
+	available = preferCodexWebsocketAuths(ctx, provider, available, nil)
 	return available[0], nil
 }
 

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -134,6 +134,28 @@ func TestWeightedRoundRobinSelectorPick_ZeroWeightFallsBackToLowerPriority(t *te
 	}
 }
 
+func TestWeightedRoundRobinSelectorPick_WebsocketZeroWeightFallsBackToPositiveWeight(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{
+		{ID: "draining-ws", Provider: "codex", Attributes: map[string]string{"selection_weight": "0", "websockets": "true"}},
+		{ID: "ready-http", Provider: "codex", Attributes: map[string]string{"selection_weight": "1"}},
+	}
+	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+
+	got, err := selector.Pick(ctx, "codex", "", cliproxyexecutor.Options{}, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if got == nil {
+		t.Fatalf("Pick() auth = nil")
+	}
+	if got.ID != "ready-http" {
+		t.Fatalf("Pick() auth.ID = %q, want ready-http", got.ID)
+	}
+}
+
 func TestWeightedRoundRobinSelectorPick_PinnedZeroWeightAuth(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -89,6 +89,77 @@ func TestRoundRobinSelectorPick_PriorityBuckets(t *testing.T) {
 	}
 }
 
+func TestWeightedRoundRobinSelectorPick_UsesSelectionWeights(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{
+		{ID: "b", Attributes: map[string]string{"selection_weight": "3"}},
+		{ID: "a", Attributes: map[string]string{"selection_weight": "1"}},
+	}
+
+	want := []string{"a", "b", "b", "b", "a"}
+	for i, id := range want {
+		got, err := selector.Pick(context.Background(), "gemini", "", cliproxyexecutor.Options{}, auths)
+		if err != nil {
+			t.Fatalf("Pick() #%d error = %v", i, err)
+		}
+		if got == nil {
+			t.Fatalf("Pick() #%d auth = nil", i)
+		}
+		if got.ID != id {
+			t.Fatalf("Pick() #%d auth.ID = %q, want %q", i, got.ID, id)
+		}
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_ZeroWeightFallsBackToLowerPriority(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{
+		{ID: "high", Attributes: map[string]string{"priority": "10", "selection_weight": "0"}},
+		{ID: "low", Attributes: map[string]string{"priority": "0", "selection_weight": "1"}},
+	}
+
+	got, err := selector.Pick(context.Background(), "gemini", "", cliproxyexecutor.Options{}, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if got == nil {
+		t.Fatalf("Pick() auth = nil")
+	}
+	if got.ID != "low" {
+		t.Fatalf("Pick() auth.ID = %q, want %q", got.ID, "low")
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_PinnedZeroWeightAuth(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{
+		{ID: "other", Attributes: map[string]string{"priority": "10", "selection_weight": "5"}},
+		{ID: "pinned", Attributes: map[string]string{"priority": "0", "selection_weight": "0"}},
+	}
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.PinnedAuthMetadataKey: "pinned",
+		},
+	}
+
+	got, err := selector.Pick(context.Background(), "gemini", "", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if got == nil {
+		t.Fatalf("Pick() auth = nil")
+	}
+	if got.ID != "pinned" {
+		t.Fatalf("Pick() auth.ID = %q, want pinned", got.ID)
+	}
+}
+
 func TestFillFirstSelectorPick_PriorityFallbackCooldown(t *testing.T) {
 	t.Parallel()
 
@@ -606,6 +677,44 @@ func TestSessionAffinitySelector_FailoverWhenAuthUnavailable(t *testing.T) {
 		if got.ID != second.ID {
 			t.Fatalf("Pick() #%d after failover inconsistent: got %q, want %q", i, got.ID, second.ID)
 		}
+	}
+}
+
+func TestSessionAffinitySelector_WeightedBindingSurvivesPriorityRecovery(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &WeightedRoundRobinSelector{},
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}}`),
+	}
+	initialAuths := []*Auth{
+		{ID: "high", Attributes: map[string]string{"priority": "10", "selection_weight": "0"}},
+		{ID: "low", Attributes: map[string]string{"priority": "0", "selection_weight": "1"}},
+	}
+
+	first, err := selector.Pick(context.Background(), "gemini", "gemini-pro", opts, initialAuths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if first == nil || first.ID != "low" {
+		t.Fatalf("first Pick() = %#v, want low", first)
+	}
+
+	recoveredAuths := []*Auth{
+		{ID: "high", Attributes: map[string]string{"priority": "10", "selection_weight": "1"}},
+		{ID: "low", Attributes: map[string]string{"priority": "0", "selection_weight": "1"}},
+	}
+	second, err := selector.Pick(context.Background(), "gemini", "gemini-pro", opts, recoveredAuths)
+	if err != nil {
+		t.Fatalf("Pick() after recovery error = %v", err)
+	}
+	if second == nil || second.ID != "low" {
+		t.Fatalf("Pick() after recovery = %#v, want existing low binding", second)
 	}
 }
 

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -248,6 +248,8 @@ func (b *Builder) Build() (*Service, error) {
 		switch strategy {
 		case "fill-first", "fillfirst", "ff":
 			selector = &coreauth.FillFirstSelector{}
+		case "weighted-round-robin", "weighted_round_robin", "weighted-rr", "weightedrr", "wrr":
+			selector = &coreauth.WeightedRoundRobinSelector{}
 		default:
 			selector = &coreauth.RoundRobinSelector{}
 		}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1281,6 +1281,8 @@ func (s *Service) applyConfigUpdateWithAuthSynthesis(newCfg *config.Config, synt
 		switch strategy {
 		case "fill-first", "fillfirst", "ff":
 			return "fill-first"
+		case "weighted-round-robin", "weighted_round_robin", "weighted-rr", "weightedrr", "wrr":
+			return "weighted-round-robin"
 		default:
 			return "round-robin"
 		}
@@ -1300,6 +1302,8 @@ func (s *Service) applyConfigUpdateWithAuthSynthesis(newCfg *config.Config, synt
 		switch nextStrategy {
 		case "fill-first":
 			selector = &coreauth.FillFirstSelector{}
+		case "weighted-round-robin":
+			selector = &coreauth.WeightedRoundRobinSelector{}
 		default:
 			selector = &coreauth.RoundRobinSelector{}
 		}

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -456,6 +456,8 @@ const (
 	SchedulerBuiltinRoundRobin = "round-robin"
 	// SchedulerBuiltinFillFirst delegates auth selection to the built-in fill-first scheduler.
 	SchedulerBuiltinFillFirst = "fill-first"
+	// SchedulerBuiltinWeightedRoundRobin delegates auth selection to the built-in weighted round-robin scheduler.
+	SchedulerBuiltinWeightedRoundRobin = "weighted-round-robin"
 )
 
 // Scheduler chooses an auth candidate before the built-in scheduler runs.
@@ -503,6 +505,8 @@ type SchedulerAuthCandidate struct {
 	Provider string
 	// Priority is the host priority assigned to the auth record.
 	Priority int
+	// SelectionWeight is the host selection weight used by weighted schedulers.
+	SelectionWeight int
 	// Status is the current host-visible auth status.
 	Status string
 	// Attributes contains immutable routing and provider attributes.
@@ -715,6 +719,8 @@ type HostAuthFileEntry struct {
 	Account string `json:"account,omitempty"`
 	// Priority is the credential routing priority when available.
 	Priority int `json:"priority,omitempty"`
+	// SelectionWeight is the credential routing selection weight.
+	SelectionWeight int `json:"selection_weight"`
 	// Note is the credential note when available.
 	Note string `json:"note,omitempty"`
 	// Websockets reports whether websocket mode is enabled when available.


### PR DESCRIPTION
## Summary

Adds a `weighted-round-robin` routing strategy that distributes requests by credential selection weight while preserving existing priority semantics. Higher `priority` credentials are still considered first; within the selected priority bucket, `selection-weight` controls the proportional share. A weight of `0` drains the credential from new weighted selections and allows fallback to lower-priority ready credentials when needed.

This wires `selection-weight` through config parsing, auth files, management APIs, TUI, plugin APIs, scheduler/conductor behavior, config diff, watcher synthesis, and examples so the behavior can be configured and inspected consistently.

## Details

- Supports `selection-weight` for Gemini, Claude, Codex, Vertex, OpenAI-compatible providers, and OpenAI-compatible per-key entries.
- Supports `selection_weight` / `selection-weight` in auth files, including strict non-negative integer validation and null clearing through the management fields API.
- Keeps default behavior backward-compatible: missing or invalid selection weight resolves to `1`; missing or invalid priority resolves to `0`.
- Preserves session affinity semantics: weights affect new bindings, while existing sessions stay pinned until TTL expiry or credential unavailability.
- Extends scheduler/plugin examples and config diff output so hot reloads and plugin integrations expose weight changes.

## Related

- Implements the weighted selection behavior requested in https://github.com/router-for-me/CLIProxyAPI/issues/3836.
- Follows the converted discussion and expected semantics in https://github.com/router-for-me/CLIProxyAPI/discussions/3929.
- Companion management UI PR: https://github.com/router-for-me/Cli-Proxy-API-Management-Center/pull/325.

## Validation

- `go test ./internal/watcher/synthesizer -run 'TestFileSynthesizer_Synthesize_SelectionWeightParsing|TestMetadataSelectionWeight_ProgrammaticIntegerTypes' -count=1`
- `go test ./internal/api/handlers/management -run 'TestPatchAuthFileFields_SelectionWeight|TestBuildAuthFromFileDataSelectionWeight|Test(PatchOpenAICompatRejectsNegativeAPIKeyEntrySelectionWeight|PutConfigListsRejectNegativeSelectionWeight)' -count=1`
- `go test ./internal/watcher/diff ./internal/watcher/synthesizer ./internal/pluginhost ./sdk/cliproxy/auth -count=1`
- `go test -count=1` in `examples/plugin/scheduler/go`
- `go build -o test-output ./cmd/server && rm test-output`
- `git diff --check`