### PR TITLE
feat(auth): support command-backed config credentials

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -244,6 +244,15 @@ nonstream-keepalive-interval: 0
 #       - "gpt-5-*"         # wildcard matching prefix (e.g. gpt-5-medium, gpt-5-codex)
 #       - "*-mini"          # wildcard matching suffix (e.g. gpt-5-codex-mini)
 #       - "*codex*"         # wildcard matching substring (e.g. gpt-5-codex-low)
+#   - base-url: "https://proxy.example.com/v1" # command auth is mutually exclusive with api-key
+#     auth:
+#       command: "/usr/local/bin/fetch-codex-token"
+#       args: ["--audience", "codex"]
+#       timeout-ms: 5000
+#       refresh-interval-ms: 300000
+#     models:
+#       - name: "gpt-5-codex"
+#         alias: "codex-command"
 
 # Claude API keys
 # claude-api-key:
@@ -337,6 +346,16 @@ nonstream-keepalive-interval: 0
 #         alias: "claude-opus-4.66"
 #       - name: "kimi-k2.5"
 #         alias: "claude-opus-4.66"
+#   - name: "internal-proxy"
+#     base-url: "https://proxy.example.com/v1" # command auth is mutually exclusive with non-empty api-key-entries
+#     auth:
+#       command: "/usr/local/bin/fetch-codex-token"
+#       args: ["--audience", "codex"]
+#       timeout-ms: 5000
+#       refresh-interval-ms: 300000
+#     models:
+#       - name: "gpt-5"
+#         alias: "gpt-5-internal"
 
 # Vertex API keys (Vertex-compatible endpoints, base-url is optional)
 # vertex-api-key:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -223,6 +223,14 @@ nonstream-keepalive-interval: 0
 #       - "gemini-2.5-*"       # wildcard matching prefix (e.g. gemini-2.5-flash, gemini-2.5-pro)
 #       - "*-preview"          # wildcard matching suffix (e.g. gemini-3-pro-preview)
 #       - "*flash*"            # wildcard matching substring (e.g. gemini-2.5-flash-lite)
+#   - auth:                    # command auth is mutually exclusive with api-key
+#       command: "/usr/local/bin/fetch-gemini-token"
+#       args: ["--audience", "gemini"]
+#       timeout-ms: 5000
+#       refresh-interval-ms: 300000
+#     models:
+#       - name: "gemini-2.5-pro"
+#         alias: "gemini-command"
 #   - api-key: "AIzaSy...02"
 
 # Codex API keys
@@ -291,6 +299,14 @@ nonstream-keepalive-interval: 0
 #       cache-user-id: true          # optional: default is false; set true to reuse cached user_id per API key instead of generating a random one each request
 #     experimental-cch-signing: false # optional: default is false; when true, sign the final /v1/messages body using the current Claude Code cch algorithm
 #                                     # keep this disabled unless you explicitly need the behavior, so upstream seed changes fall back to legacy proxy behavior
+#   - auth:                         # command auth is mutually exclusive with api-key
+#       command: "/usr/local/bin/fetch-claude-token"
+#       args: ["--audience", "claude"]
+#       timeout-ms: 5000
+#       refresh-interval-ms: 300000
+#     models:
+#       - name: "claude-3-5-sonnet-20241022"
+#         alias: "claude-command"
 
 # Default headers for Claude API requests. Update when Claude Code releases new versions.
 # In legacy mode, user-agent/package-version/runtime-version/timeout are used as fallbacks
@@ -374,6 +390,15 @@ nonstream-keepalive-interval: 0
 #     excluded-models:                            # optional: models to exclude from listing
 #       - "imagen-3.0-generate-002"
 #       - "imagen-*"
+#   - auth:                                      # command auth is mutually exclusive with api-key
+#       command: "/usr/local/bin/fetch-vertex-token"
+#       args: ["--audience", "vertex"]
+#       timeout-ms: 5000
+#       refresh-interval-ms: 300000
+#     base-url: "https://example.com/api"
+#     models:
+#       - name: "gemini-2.5-pro"
+#         alias: "vertex-command"
 
 # Global OAuth model name aliases (per channel)
 # These aliases rename model IDs for both model listing and request routing.

--- a/internal/api/handlers/management/api_key_usage.go
+++ b/internal/api/handlers/management/api_key_usage.go
@@ -10,9 +10,68 @@ import (
 )
 
 type apiKeyUsageEntry struct {
+	AuthIndex      string                         `json:"auth_index,omitempty"`
+	AuthKey        string                         `json:"auth_key,omitempty"`
+	AuthSource     string                         `json:"auth_source,omitempty"`
 	Success        int64                          `json:"success"`
 	Failed         int64                          `json:"failed"`
 	RecentRequests []coreauth.RecentRequestBucket `json:"recent_requests"`
+}
+
+type apiKeyUsageIdentity struct {
+	provider string
+	key      string
+	authKey  string
+	source   string
+}
+
+func apiKeyUsageIdentityForAuth(auth *coreauth.Auth) (apiKeyUsageIdentity, bool) {
+	var identity apiKeyUsageIdentity
+	if auth == nil {
+		return identity, false
+	}
+
+	baseURL := ""
+	apiKey := ""
+	commandKey := ""
+	if auth.Attributes != nil {
+		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
+		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
+		if baseURL == "" {
+			baseURL = strings.TrimSpace(auth.Attributes["base-url"])
+		}
+		commandKey = strings.TrimSpace(auth.Attributes[coreauth.AttrAuthCommandKey])
+	}
+
+	identity.provider = apiKeyUsageProviderKey(auth)
+
+	if apiKey != "" {
+		identity.key = baseURL + "|" + apiKey
+		identity.authKey = apiKey
+		identity.source = "api_key"
+		return identity, true
+	}
+
+	if coreauth.IsCommandAuth(auth) {
+		if commandKey == "" {
+			commandKey = auth.EnsureIndex()
+		}
+		if commandKey == "" {
+			commandKey = strings.TrimSpace(auth.ID)
+		}
+		if commandKey == "" {
+			return identity, false
+		}
+		identity.authKey = "auth-command:" + commandKey
+		identity.source = coreauth.AttrAuthSourceCommand
+		// Older management frontends key config credentials as "base_url|api_key".
+		// Command-auth entries intentionally have no static api_key, so use the
+		// empty-key shape while exposing the stable command identity in auth_key.
+		identity.key = baseURL + "|"
+		return identity, true
+	}
+
+	return identity, false
 }
 
 func mergeRecentRequestBuckets(dst, src []coreauth.RecentRequestBucket) []coreauth.RecentRequestBucket {
@@ -53,8 +112,10 @@ func apiKeyUsageProviderKey(auth *coreauth.Auth) string {
 	return provider
 }
 
-// GetAPIKeyUsage returns recent request buckets for all in-memory api_key auths,
-// grouped by provider and keyed by "base_url|api_key".
+// GetAPIKeyUsage returns recent request buckets for in-memory API-key-class auths,
+// grouped by provider and keyed by "base_url|api_key". Command-auth credentials
+// have no static api_key, so they use the legacy-compatible "base_url|" key and
+// expose their stable command identity in the entry's auth_key field.
 func (h *Handler) GetAPIKeyUsage(c *gin.Context) {
 	if h == nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler not initialized"})
@@ -72,41 +133,28 @@ func (h *Handler) GetAPIKeyUsage(c *gin.Context) {
 	now := time.Now()
 	out := make(map[string]map[string]apiKeyUsageEntry)
 	for _, auth := range manager.List() {
-		if auth == nil {
+		identity, okIdentity := apiKeyUsageIdentityForAuth(auth)
+		if !okIdentity {
 			continue
 		}
-		kind, apiKey := auth.AccountInfo()
-		if !strings.EqualFold(strings.TrimSpace(kind), "api_key") {
-			continue
-		}
-		apiKey = strings.TrimSpace(apiKey)
-		if apiKey == "" {
-			continue
-		}
-		baseURL := ""
-		if auth.Attributes != nil {
-			baseURL = strings.TrimSpace(auth.Attributes["base_url"])
-			if baseURL == "" {
-				baseURL = strings.TrimSpace(auth.Attributes["base-url"])
-			}
-		}
-		compositeKey := baseURL + "|" + apiKey
-		provider := apiKeyUsageProviderKey(auth)
 
 		recent := auth.RecentRequestsSnapshot(now)
-		providerBucket, ok := out[provider]
+		providerBucket, ok := out[identity.provider]
 		if !ok {
 			providerBucket = make(map[string]apiKeyUsageEntry)
-			out[provider] = providerBucket
+			out[identity.provider] = providerBucket
 		}
-		if existing, exists := providerBucket[compositeKey]; exists {
+		if existing, exists := providerBucket[identity.key]; exists {
 			existing.Success += auth.Success
 			existing.Failed += auth.Failed
 			existing.RecentRequests = mergeRecentRequestBuckets(existing.RecentRequests, recent)
-			providerBucket[compositeKey] = existing
+			providerBucket[identity.key] = existing
 			continue
 		}
-		providerBucket[compositeKey] = apiKeyUsageEntry{
+		providerBucket[identity.key] = apiKeyUsageEntry{
+			AuthIndex:      auth.EnsureIndex(),
+			AuthKey:        identity.authKey,
+			AuthSource:     identity.source,
 			Success:        auth.Success,
 			Failed:         auth.Failed,
 			RecentRequests: recent,

--- a/internal/api/handlers/management/api_key_usage.go
+++ b/internal/api/handlers/management/api_key_usage.go
@@ -119,8 +119,8 @@ func apiKeyUsageProviderKey(auth *coreauth.Auth) string {
 
 // GetAPIKeyUsage returns recent request buckets for in-memory API-key-class auths,
 // grouped by provider. Static API-key credentials are keyed by "base_url|api_key".
-// Command-auth credentials have no static api_key, so they keep the legacy
-// "base_url|" key and expose their stable non-secret identity in auth_key.
+// Command-auth credentials have no static api_key, so they are keyed by the
+// stable non-secret command identity exposed in auth_key.
 func (h *Handler) GetAPIKeyUsage(c *gin.Context) {
 	if h == nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler not initialized"})

--- a/internal/api/handlers/management/api_key_usage.go
+++ b/internal/api/handlers/management/api_key_usage.go
@@ -72,10 +72,7 @@ func apiKeyUsageIdentityForAuth(auth *coreauth.Auth) (apiKeyUsageIdentity, bool)
 		}
 		identity.authKey = commandAuthManagementKey(commandKey)
 		identity.source = coreauth.AttrAuthSourceCommand
-		// Keep the legacy composite key so older management frontends that look up
-		// command auth entries as "base_url|" continue to receive statistics. Newer
-		// frontends should prefer the explicit auth_key/auth_source fields.
-		identity.key = baseURL + "|"
+		identity.key = baseURL + "|" + identity.authKey
 		return identity, true
 	}
 

--- a/internal/api/handlers/management/api_key_usage.go
+++ b/internal/api/handlers/management/api_key_usage.go
@@ -25,6 +25,14 @@ type apiKeyUsageIdentity struct {
 	source   string
 }
 
+func commandAuthManagementKey(commandKey string) string {
+	commandKey = strings.TrimSpace(commandKey)
+	if commandKey == "" {
+		return ""
+	}
+	return "auth-command:" + commandKey
+}
+
 func apiKeyUsageIdentityForAuth(auth *coreauth.Auth) (apiKeyUsageIdentity, bool) {
 	var identity apiKeyUsageIdentity
 	if auth == nil {
@@ -62,11 +70,11 @@ func apiKeyUsageIdentityForAuth(auth *coreauth.Auth) (apiKeyUsageIdentity, bool)
 		if commandKey == "" {
 			return identity, false
 		}
-		identity.authKey = "auth-command:" + commandKey
+		identity.authKey = commandAuthManagementKey(commandKey)
 		identity.source = coreauth.AttrAuthSourceCommand
-		// Older management frontends key config credentials as "base_url|api_key".
-		// Command-auth entries intentionally have no static api_key, so use the
-		// empty-key shape while exposing the stable command identity in auth_key.
+		// Keep the legacy composite key so older management frontends that look up
+		// command auth entries as "base_url|" continue to receive statistics. Newer
+		// frontends should prefer the explicit auth_key/auth_source fields.
 		identity.key = baseURL + "|"
 		return identity, true
 	}
@@ -113,9 +121,9 @@ func apiKeyUsageProviderKey(auth *coreauth.Auth) string {
 }
 
 // GetAPIKeyUsage returns recent request buckets for in-memory API-key-class auths,
-// grouped by provider and keyed by "base_url|api_key". Command-auth credentials
-// have no static api_key, so they use the legacy-compatible "base_url|" key and
-// expose their stable command identity in the entry's auth_key field.
+// grouped by provider. Static API-key credentials are keyed by "base_url|api_key".
+// Command-auth credentials have no static api_key, so they keep the legacy
+// "base_url|" key and expose their stable non-secret identity in auth_key.
 func (h *Handler) GetAPIKeyUsage(c *gin.Context) {
 	if h == nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler not initialized"})

--- a/internal/api/handlers/management/api_key_usage_test.go
+++ b/internal/api/handlers/management/api_key_usage_test.go
@@ -93,6 +93,63 @@ func TestGetAPIKeyUsage_GroupsByProviderAndAPIKey(t *testing.T) {
 	}
 }
 
+func TestGetAPIKeyUsage_IncludesCommandAuthCredentials(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "gemini-command-auth",
+		Provider: "gemini",
+		Attributes: map[string]string{
+			coreauth.AttrAuthKind:       coreauth.AttrAuthKindAPIKey,
+			coreauth.AttrAuthSource:     coreauth.AttrAuthSourceCommand,
+			coreauth.AttrAuthCommand:    "fetch-token",
+			coreauth.AttrAuthCommandKey: "command-identity",
+			"base_url":                  "https://gemini.example.com",
+		},
+	}); err != nil {
+		t.Fatalf("register command auth: %v", err)
+	}
+
+	manager.MarkResult(context.Background(), coreauth.Result{AuthID: "gemini-command-auth", Provider: "gemini", Model: "gemini-pro", Success: true})
+	manager.MarkResult(context.Background(), coreauth.Result{AuthID: "gemini-command-auth", Provider: "gemini", Model: "gemini-pro", Success: false})
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/api-key-usage", nil)
+	ginCtx.Request = req
+	h.GetAPIKeyUsage(ginCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var payload map[string]map[string]apiKeyUsageEntry
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+
+	entry := payload["gemini"]["https://gemini.example.com|"]
+	if entry.Success != 1 || entry.Failed != 1 {
+		t.Fatalf("command auth totals = %d/%d, want 1/1", entry.Success, entry.Failed)
+	}
+	if entry.AuthSource != coreauth.AttrAuthSourceCommand {
+		t.Fatalf("command auth source = %q, want %q", entry.AuthSource, coreauth.AttrAuthSourceCommand)
+	}
+	if entry.AuthKey != "auth-command:command-identity" {
+		t.Fatalf("command auth key = %q", entry.AuthKey)
+	}
+	if entry.AuthIndex == "" {
+		t.Fatal("command auth index is empty")
+	}
+	success, failed := sumRecentRequestBuckets(entry.RecentRequests)
+	if success != 1 || failed != 1 {
+		t.Fatalf("command auth bucket totals = %d/%d, want 1/1", success, failed)
+	}
+}
+
 func TestGetAPIKeyUsage_GroupsOpenAICompatibleByCompatName(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "")
 

--- a/internal/api/handlers/management/api_key_usage_test.go
+++ b/internal/api/handlers/management/api_key_usage_test.go
@@ -138,7 +138,7 @@ func TestGetAPIKeyUsage_IncludesCommandAuthCredentials(t *testing.T) {
 	if entry.AuthSource != coreauth.AttrAuthSourceCommand {
 		t.Fatalf("command auth source = %q, want %q", entry.AuthSource, coreauth.AttrAuthSourceCommand)
 	}
-	if entry.AuthKey != "auth-command:command-identity" {
+	if entry.AuthKey != commandAuthManagementKey("command-identity") {
 		t.Fatalf("command auth key = %q", entry.AuthKey)
 	}
 	if entry.AuthIndex == "" {

--- a/internal/api/handlers/management/api_key_usage_test.go
+++ b/internal/api/handlers/management/api_key_usage_test.go
@@ -131,7 +131,7 @@ func TestGetAPIKeyUsage_IncludesCommandAuthCredentials(t *testing.T) {
 		t.Fatalf("decode payload: %v", err)
 	}
 
-	entry := payload["gemini"]["https://gemini.example.com|"]
+	entry := payload["gemini"]["https://gemini.example.com|"+commandAuthManagementKey("command-identity")]
 	if entry.Success != 1 || entry.Failed != 1 {
 		t.Fatalf("command auth totals = %d/%d, want 1/1", entry.Success, entry.Failed)
 	}
@@ -147,6 +147,75 @@ func TestGetAPIKeyUsage_IncludesCommandAuthCredentials(t *testing.T) {
 	success, failed := sumRecentRequestBuckets(entry.RecentRequests)
 	if success != 1 || failed != 1 {
 		t.Fatalf("command auth bucket totals = %d/%d, want 1/1", success, failed)
+	}
+}
+
+func TestGetAPIKeyUsage_SeparatesCommandAuthCredentialsWithSameBaseURL(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	for _, auth := range []*coreauth.Auth{
+		{
+			ID:       "command-auth-a",
+			Provider: "gemini",
+			Attributes: map[string]string{
+				coreauth.AttrAuthKind:       coreauth.AttrAuthKindAPIKey,
+				coreauth.AttrAuthSource:     coreauth.AttrAuthSourceCommand,
+				coreauth.AttrAuthCommand:    "fetch-token-a",
+				coreauth.AttrAuthCommandKey: "command-identity-a",
+				"base_url":                  "https://gemini.example.com",
+			},
+		},
+		{
+			ID:       "command-auth-b",
+			Provider: "gemini",
+			Attributes: map[string]string{
+				coreauth.AttrAuthKind:       coreauth.AttrAuthKindAPIKey,
+				coreauth.AttrAuthSource:     coreauth.AttrAuthSourceCommand,
+				coreauth.AttrAuthCommand:    "fetch-token-b",
+				coreauth.AttrAuthCommandKey: "command-identity-b",
+				"base_url":                  "https://gemini.example.com",
+			},
+		},
+	} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register command auth %s: %v", auth.ID, err)
+		}
+	}
+
+	manager.MarkResult(context.Background(), coreauth.Result{AuthID: "command-auth-a", Provider: "gemini", Model: "gemini-pro", Success: true})
+	manager.MarkResult(context.Background(), coreauth.Result{AuthID: "command-auth-b", Provider: "gemini", Model: "gemini-pro", Success: false})
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/api-key-usage", nil)
+	ginCtx.Request = req
+	h.GetAPIKeyUsage(ginCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var payload map[string]map[string]apiKeyUsageEntry
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+
+	geminiBucket := payload["gemini"]
+	firstKey := "https://gemini.example.com|" + commandAuthManagementKey("command-identity-a")
+	secondKey := "https://gemini.example.com|" + commandAuthManagementKey("command-identity-b")
+	first := geminiBucket[firstKey]
+	second := geminiBucket[secondKey]
+	if first.Success != 1 || first.Failed != 0 {
+		t.Fatalf("first command auth totals = %d/%d, want 1/0 payload=%#v", first.Success, first.Failed, geminiBucket)
+	}
+	if second.Success != 0 || second.Failed != 1 {
+		t.Fatalf("second command auth totals = %d/%d, want 0/1 payload=%#v", second.Success, second.Failed, geminiBucket)
+	}
+	if _, exists := geminiBucket["https://gemini.example.com|"]; exists {
+		t.Fatalf("legacy command auth key should not be used when auth_key is available: %#v", geminiBucket)
 	}
 }
 

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -607,16 +607,30 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
 type apiKeyConfigEntry interface {
 	GetAPIKey() string
 	GetBaseURL() string
+	GetCommandAuth() *config.CommandAuthConfig
 }
 
 func resolveAPIKeyConfig[T apiKeyConfigEntry](entries []T, auth *coreauth.Auth) *T {
 	if auth == nil || len(entries) == 0 {
 		return nil
 	}
-	attrKey, attrBase := "", ""
+	attrKey, attrBase, attrCommandKey := "", "", ""
 	if auth.Attributes != nil {
 		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
 		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+		attrCommandKey = strings.TrimSpace(auth.Attributes[coreauth.AttrAuthCommandKey])
+	}
+	if attrCommandKey != "" {
+		for i := range entries {
+			entry := &entries[i]
+			cfgCommandKey := config.CommandAuthIdentity((*entry).GetCommandAuth())
+			cfgBase := strings.TrimSpace((*entry).GetBaseURL())
+			if cfgCommandKey != "" && strings.EqualFold(attrCommandKey, cfgCommandKey) {
+				if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
+					return entry
+				}
+			}
+		}
 	}
 	for i := range entries {
 		entry := &entries[i]
@@ -653,7 +667,7 @@ func proxyURLFromAPIKeyConfig(cfg *config.Config, auth *coreauth.Auth) string {
 		return ""
 	}
 	authKind, authAccount := auth.AccountInfo()
-	if !strings.EqualFold(strings.TrimSpace(authKind), "api_key") {
+	if !strings.EqualFold(strings.TrimSpace(authKind), "api_key") && !coreauth.IsCommandAuth(auth) {
 		return ""
 	}
 
@@ -665,6 +679,9 @@ func proxyURLFromAPIKeyConfig(cfg *config.Config, auth *coreauth.Auth) string {
 		providerKey = strings.TrimSpace(attrs["provider_key"])
 	}
 	if compatName != "" || strings.EqualFold(strings.TrimSpace(auth.Provider), "openai-compatibility") {
+		if coreauth.IsCommandAuth(auth) {
+			return resolveOpenAICompatCommandAuthProxyURL(cfg, auth, providerKey, compatName)
+		}
 		return resolveOpenAICompatAPIKeyProxyURL(cfg, auth, strings.TrimSpace(authAccount), providerKey, compatName)
 	}
 
@@ -681,8 +698,20 @@ func proxyURLFromAPIKeyConfig(cfg *config.Config, auth *coreauth.Auth) string {
 		if entry := resolveAPIKeyConfig(cfg.CodexKey, auth); entry != nil {
 			return strings.TrimSpace(entry.ProxyURL)
 		}
+	case "vertex":
+		if entry := resolveAPIKeyConfig(cfg.VertexCompatAPIKey, auth); entry != nil {
+			return strings.TrimSpace(entry.ProxyURL)
+		}
 	}
 	return ""
+}
+
+func resolveOpenAICompatCommandAuthProxyURL(cfg *config.Config, auth *coreauth.Auth, providerKey, compatName string) string {
+	entry := resolveOpenAICompatConfigForAuth(cfg, auth, providerKey, compatName)
+	if entry == nil {
+		return ""
+	}
+	return strings.TrimSpace(entry.ProxyURL)
 }
 
 func resolveOpenAICompatAPIKeyProxyURL(cfg *config.Config, auth *coreauth.Auth, apiKey, providerKey, compatName string) string {
@@ -722,6 +751,34 @@ func resolveOpenAICompatAPIKeyProxyURL(cfg *config.Config, auth *coreauth.Auth, 
 		}
 	}
 	return ""
+}
+
+func resolveOpenAICompatConfigForAuth(cfg *config.Config, auth *coreauth.Auth, providerKey, compatName string) *config.OpenAICompatibility {
+	if cfg == nil || auth == nil {
+		return nil
+	}
+	candidates := make([]string, 0, 3)
+	if v := strings.TrimSpace(compatName); v != "" {
+		candidates = append(candidates, v)
+	}
+	if v := strings.TrimSpace(providerKey); v != "" {
+		candidates = append(candidates, v)
+	}
+	if v := strings.TrimSpace(auth.Provider); v != "" {
+		candidates = append(candidates, v)
+	}
+	for i := range cfg.OpenAICompatibility {
+		compat := &cfg.OpenAICompatibility[i]
+		if compat.Disabled {
+			continue
+		}
+		for _, candidate := range candidates {
+			if candidate != "" && strings.EqualFold(strings.TrimSpace(candidate), compat.Name) {
+				return compat
+			}
+		}
+	}
+	return nil
 }
 
 func buildProxyTransport(proxyStr string) *http.Transport {

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -64,9 +64,10 @@ type apiCallResponse struct {
 //   - url (required): Absolute URL including scheme and host, e.g. "https://api.example.com/v1/ping".
 //   - header (optional): Request headers map.
 //     Supports magic variable "$TOKEN$" which is replaced using the selected credential:
-//     1) metadata.access_token
-//     2) attributes.api_key
-//     3) metadata.token / metadata.id_token / metadata.cookie
+//     1) command auth output, when the credential is command-backed
+//     2) metadata.access_token
+//     3) attributes.api_key
+//     4) metadata.token / metadata.id_token / metadata.cookie
 //     Example: {"Authorization":"Bearer $TOKEN$"}.
 //     Note: if you need to override the HTTP Host header, set header["Host"].
 //   - data (optional): Raw request body as string (useful for POST/PUT/PATCH).
@@ -148,6 +149,21 @@ func (h *Handler) APICall(c *gin.Context) {
 			continue
 		}
 		reqHeaders[key] = strings.ReplaceAll(value, "$TOKEN$", token)
+	}
+	if auth == nil && !hasHeader(reqHeaders, "authorization") {
+		if inferredAuth := h.commandAuthForAPICallURL(parsedURL); inferredAuth != nil {
+			inferredToken, errToken := h.resolveTokenForAuth(c.Request.Context(), inferredAuth)
+			if errToken != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "auth token refresh failed"})
+				return
+			}
+			if inferredToken == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "auth token not found"})
+				return
+			}
+			auth = inferredAuth
+			reqHeaders["Authorization"] = "Bearer " + inferredToken
+		}
 	}
 
 	var requestBody io.Reader
@@ -234,12 +250,98 @@ func (h *Handler) resolveTokenForAuth(ctx context.Context, auth *coreauth.Auth) 
 		return "", nil
 	}
 
+	if coreauth.IsCommandAuth(auth) {
+		return h.resolveCommandAuthToken(ctx, auth)
+	}
+
 	if strings.EqualFold(strings.TrimSpace(auth.Provider), "antigravity") {
 		token, errToken := h.refreshAntigravityOAuthAccessToken(ctx, auth)
 		return token, errToken
 	}
 
 	return tokenValueForAuth(auth), nil
+}
+
+func (h *Handler) resolveCommandAuthToken(ctx context.Context, auth *coreauth.Auth) (string, error) {
+	if h == nil || h.authManager == nil {
+		return "", fmt.Errorf("command auth manager unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req, errReq := http.NewRequestWithContext(ctx, http.MethodGet, "https://cliproxy.local/", nil)
+	if errReq != nil {
+		return "", errReq
+	}
+	if errPrepare := h.authManager.PrepareHttpRequest(ctx, auth, req); errPrepare != nil {
+		return "", errPrepare
+	}
+	if token := bearerTokenFromAuthorization(req.Header.Get("Authorization")); token != "" {
+		return token, nil
+	}
+	if current, ok := h.authManager.GetByID(auth.ID); ok {
+		return tokenValueForAuth(current), nil
+	}
+	return tokenValueForAuth(auth), nil
+}
+
+func bearerTokenFromAuthorization(value string) string {
+	value = strings.TrimSpace(value)
+	const prefix = "Bearer "
+	if len(value) >= len(prefix) && strings.EqualFold(value[:len(prefix)], prefix) {
+		return strings.TrimSpace(value[len(prefix):])
+	}
+	return ""
+}
+
+func hasHeader(headers map[string]string, name string) bool {
+	name = strings.TrimSpace(name)
+	for key := range headers {
+		if strings.EqualFold(strings.TrimSpace(key), name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *Handler) commandAuthForAPICallURL(target *url.URL) *coreauth.Auth {
+	if h == nil || h.authManager == nil || target == nil {
+		return nil
+	}
+	var matched *coreauth.Auth
+	for _, auth := range h.authManager.List() {
+		if !coreauth.IsCommandAuth(auth) || !authBaseURLMatches(target, auth) {
+			continue
+		}
+		if matched != nil {
+			return nil
+		}
+		matched = auth
+	}
+	return matched
+}
+
+func authBaseURLMatches(target *url.URL, auth *coreauth.Auth) bool {
+	if target == nil || auth == nil || auth.Attributes == nil {
+		return false
+	}
+	baseRaw := strings.TrimSpace(auth.Attributes["base_url"])
+	if baseRaw == "" {
+		return false
+	}
+	baseURL, errParse := url.Parse(baseRaw)
+	if errParse != nil || baseURL.Scheme == "" || baseURL.Host == "" {
+		return false
+	}
+	if !strings.EqualFold(baseURL.Scheme, target.Scheme) || !strings.EqualFold(baseURL.Host, target.Host) {
+		return false
+	}
+	basePath := strings.TrimRight(baseURL.EscapedPath(), "/")
+	targetPath := strings.TrimRight(target.EscapedPath(), "/")
+	if basePath == "" {
+		return true
+	}
+	return targetPath == basePath || strings.HasPrefix(targetPath, basePath+"/")
 }
 
 func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *coreauth.Auth) (string, error) {

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -310,7 +310,7 @@ func (h *Handler) commandAuthForAPICallURL(target *url.URL) *coreauth.Auth {
 	}
 	var matched *coreauth.Auth
 	for _, auth := range h.authManager.List() {
-		if !coreauth.IsCommandAuth(auth) || !authBaseURLMatches(target, auth) {
+		if !coreauth.IsCommandAuth(auth) || !commandAuthAvailableForAPICall(auth) || !authBaseURLMatches(target, auth) {
 			continue
 		}
 		if matched != nil {
@@ -319,6 +319,20 @@ func (h *Handler) commandAuthForAPICallURL(target *url.URL) *coreauth.Auth {
 		matched = auth
 	}
 	return matched
+}
+
+func commandAuthAvailableForAPICall(auth *coreauth.Auth) bool {
+	if auth == nil || auth.Disabled || auth.Status == coreauth.StatusDisabled {
+		return false
+	}
+	if auth.Attributes != nil {
+		for _, item := range strings.Split(auth.Attributes["excluded_models"], ",") {
+			if strings.TrimSpace(item) == configAPIKeyDisablePattern {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func authBaseURLMatches(target *url.URL, auth *coreauth.Auth) bool {

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -546,6 +546,41 @@ func TestCommandAuthForAPICallURLReturnsNilWhenAmbiguous(t *testing.T) {
 	}
 }
 
+func TestCommandAuthForAPICallURLSkipsDisabledAuths(t *testing.T) {
+	t.Parallel()
+
+	script := writeAPICallTokenScript(t, "Bearer inferred-token")
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor.NewCodexAutoExecutor(nil))
+
+	disabled := commandAPICallAuth("disabled-command-auth", "https://aiden-aiproxy.bytedance.net/v2", script)
+	disabled.Disabled = true
+	statusDisabled := commandAPICallAuth("status-disabled-command-auth", "https://aiden-aiproxy.bytedance.net/v2", script)
+	statusDisabled.Status = coreauth.StatusDisabled
+	excludedAll := commandAPICallAuth("excluded-all-command-auth", "https://aiden-aiproxy.bytedance.net/v2", script)
+	excludedAll.Attributes["excluded_models"] = "gpt-5, *"
+	active := commandAPICallAuth("active-command-auth", "https://aiden-aiproxy.bytedance.net/v2", script)
+
+	for _, auth := range []*coreauth.Auth{disabled, statusDisabled, excludedAll, active} {
+		if _, errRegister := manager.Register(coreauth.WithSkipPersist(context.Background()), auth); errRegister != nil {
+			t.Fatalf("register %s: %v", auth.ID, errRegister)
+		}
+	}
+
+	target, errParse := url.Parse("https://aiden-aiproxy.bytedance.net/v2/models")
+	if errParse != nil {
+		t.Fatalf("parse url: %v", errParse)
+	}
+
+	auth := (&Handler{authManager: manager}).commandAuthForAPICallURL(target)
+	if auth == nil {
+		t.Fatal("commandAuthForAPICallURL returned nil, want active command auth")
+	}
+	if auth.ID != active.ID {
+		t.Fatalf("commandAuthForAPICallURL returned %q, want %q", auth.ID, active.ID)
+	}
+}
+
 func commandAPICallAuth(id, baseURL, script string) *coreauth.Auth {
 	return &coreauth.Auth{
 		ID:       id,

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -2,10 +2,21 @@ package management
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	executor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
@@ -209,4 +220,319 @@ func TestAuthByIndexDistinguishesSharedAPIKeysAcrossProviders(t *testing.T) {
 	if gotCompat.ID != compatAuth.ID {
 		t.Fatalf("authByIndex(compat) returned %q, want %q", gotCompat.ID, compatAuth.ID)
 	}
+}
+
+func TestResolveTokenForAuthRunsCommandAuth(t *testing.T) {
+	t.Parallel()
+
+	script := writeAPICallTokenScript(t, "Bearer api-call-token")
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor.NewOpenAICompatExecutor("openai-compatibility", nil))
+
+	auth := &coreauth.Auth{
+		ID:       "command-auth",
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"base_url":                            "https://example.com/v1",
+			coreauth.AttrAuthKind:                 coreauth.AttrAuthKindAPIKey,
+			coreauth.AttrAuthSource:               coreauth.AttrAuthSourceCommand,
+			coreauth.AttrAuthCommand:              script,
+			coreauth.AttrAuthArgsJSON:             "[]",
+			coreauth.AttrAuthTimeoutMS:            "5000",
+			coreauth.AttrAuthRefreshIntervalMS:    strconv.Itoa(int(time.Hour / time.Millisecond)),
+			coreauth.AttrAuthInvalidatesOnNext401: "true",
+		},
+		Status: coreauth.StatusActive,
+	}
+	if _, errRegister := manager.Register(coreauth.WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("register command auth: %v", errRegister)
+	}
+
+	h := &Handler{authManager: manager}
+	token, errToken := h.resolveTokenForAuth(context.Background(), auth)
+	if errToken != nil {
+		t.Fatalf("resolveTokenForAuth error: %v", errToken)
+	}
+	if token != "api-call-token" {
+		t.Fatalf("token = %q, want api-call-token", token)
+	}
+
+	current, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected auth in manager")
+	}
+	if got, _ := current.Metadata["access_token"].(string); got != "api-call-token" {
+		t.Fatalf("cached access_token = %q, want api-call-token", got)
+	}
+}
+
+func TestResolveTokenForAuthRunsCodexCommandAuth(t *testing.T) {
+	t.Parallel()
+
+	script := writeAPICallTokenScript(t, "Bearer codex-api-call-token")
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor.NewCodexAutoExecutor(nil))
+
+	auth := &coreauth.Auth{
+		ID:       "codex-command-auth",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"base_url":                            "https://example.com/v2",
+			coreauth.AttrAuthKind:                 coreauth.AttrAuthKindAPIKey,
+			coreauth.AttrAuthSource:               coreauth.AttrAuthSourceCommand,
+			coreauth.AttrAuthCommand:              script,
+			coreauth.AttrAuthArgsJSON:             "[]",
+			coreauth.AttrAuthTimeoutMS:            "5000",
+			coreauth.AttrAuthRefreshIntervalMS:    strconv.Itoa(int(time.Hour / time.Millisecond)),
+			coreauth.AttrAuthInvalidatesOnNext401: "true",
+		},
+		Status: coreauth.StatusActive,
+	}
+	if _, errRegister := manager.Register(coreauth.WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("register command auth: %v", errRegister)
+	}
+
+	h := &Handler{authManager: manager}
+	token, errToken := h.resolveTokenForAuth(context.Background(), auth)
+	if errToken != nil {
+		t.Fatalf("resolveTokenForAuth error: %v", errToken)
+	}
+	if token != "codex-api-call-token" {
+		t.Fatalf("token = %q, want codex-api-call-token", token)
+	}
+}
+
+func TestCodexCommandAuthIndexResolvesToken(t *testing.T) {
+	t.Parallel()
+
+	script := writeAPICallTokenScript(t, "Bearer indexed-codex-token")
+	cfg := &config.Config{
+		CodexKey: []config.CodexKey{
+			{
+				Auth: &config.CommandAuthConfig{
+					Command:           script,
+					Args:              []string{},
+					TimeoutMS:         5000,
+					RefreshIntervalMS: int(time.Hour / time.Millisecond),
+				},
+				BaseURL:    "https://aiden-aiproxy.bytedance.net/v2",
+				Websockets: true,
+			},
+		},
+	}
+	auths, errSynth := synthesizer.NewConfigSynthesizer().Synthesize(&synthesizer.SynthesisContext{
+		Config:      cfg,
+		Now:         time.Now(),
+		IDGenerator: synthesizer.NewStableIDGenerator(),
+	})
+	if errSynth != nil {
+		t.Fatalf("synthesize auths: %v", errSynth)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor.NewCodexAutoExecutor(cfg))
+	if _, errRegister := manager.Register(coreauth.WithSkipPersist(context.Background()), auths[0]); errRegister != nil {
+		t.Fatalf("register command auth: %v", errRegister)
+	}
+
+	h := &Handler{cfg: cfg, authManager: manager}
+	keys := h.codexKeysWithAuthIndex()
+	if len(keys) != 1 {
+		t.Fatalf("codex key count = %d, want 1", len(keys))
+	}
+	if strings.TrimSpace(keys[0].AuthIndex) == "" {
+		t.Fatalf("codex command auth-index is empty: %#v", keys[0])
+	}
+
+	auth := h.authByIndex(keys[0].AuthIndex)
+	if auth == nil {
+		t.Fatalf("authByIndex(%q) returned nil", keys[0].AuthIndex)
+	}
+	token, errToken := h.resolveTokenForAuth(context.Background(), auth)
+	if errToken != nil {
+		t.Fatalf("resolveTokenForAuth error: %v", errToken)
+	}
+	if token != "indexed-codex-token" {
+		t.Fatalf("token = %q, want indexed-codex-token", token)
+	}
+}
+
+func TestResolveTokenForAuthRefreshesExpiredCommandAuth(t *testing.T) {
+	t.Parallel()
+
+	script := writeAPICallTokenScript(t, "Bearer fresh-token")
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor.NewOpenAICompatExecutor("openai-compatibility", nil))
+
+	auth := &coreauth.Auth{
+		ID:       "expired-command-auth",
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"base_url":                         "https://example.com/v1",
+			coreauth.AttrAuthKind:              coreauth.AttrAuthKindAPIKey,
+			coreauth.AttrAuthSource:            coreauth.AttrAuthSourceCommand,
+			coreauth.AttrAuthCommand:           script,
+			coreauth.AttrAuthArgsJSON:          "[]",
+			coreauth.AttrAuthTimeoutMS:         "5000",
+			coreauth.AttrAuthRefreshIntervalMS: strconv.Itoa(int(time.Hour / time.Millisecond)),
+		},
+		Metadata:         map[string]any{"access_token": "stale-token"},
+		NextRefreshAfter: time.Now().Add(-time.Minute),
+		Status:           coreauth.StatusActive,
+	}
+	if _, errRegister := manager.Register(coreauth.WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("register command auth: %v", errRegister)
+	}
+
+	h := &Handler{authManager: manager}
+	token, errToken := h.resolveTokenForAuth(context.Background(), auth)
+	if errToken != nil {
+		t.Fatalf("resolveTokenForAuth error: %v", errToken)
+	}
+	if token != "fresh-token" {
+		t.Fatalf("token = %q, want fresh-token", token)
+	}
+}
+
+func TestAPICallInfersCommandAuthFromURL(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"model-a"}]}`))
+	}))
+	defer upstream.Close()
+
+	script := writeAPICallTokenScript(t, "Bearer inferred-token")
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor.NewCodexAutoExecutor(nil))
+	auth := commandAPICallAuth("codex-command-auth", upstream.URL+"/v2", script)
+	if _, errRegister := manager.Register(coreauth.WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("register command auth: %v", errRegister)
+	}
+
+	body := map[string]any{
+		"method": "GET",
+		"url":    upstream.URL + "/v2/models",
+	}
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	ginCtx.Request = jsonRequest(t, body)
+
+	(&Handler{authManager: manager}).APICall(ginCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if gotAuth != "Bearer inferred-token" {
+		t.Fatalf("Authorization = %q, want Bearer inferred-token", gotAuth)
+	}
+}
+
+func TestAPICallDoesNotInferCommandAuthForMismatchedURL(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer upstream.Close()
+
+	script := writeAPICallTokenScript(t, "Bearer inferred-token")
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor.NewCodexAutoExecutor(nil))
+	auth := commandAPICallAuth("codex-command-auth", upstream.URL+"/v2", script)
+	if _, errRegister := manager.Register(coreauth.WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("register command auth: %v", errRegister)
+	}
+
+	body := map[string]any{
+		"method": "GET",
+		"url":    upstream.URL + "/other/models",
+	}
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	ginCtx.Request = jsonRequest(t, body)
+
+	(&Handler{authManager: manager}).APICall(ginCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if gotAuth != "" {
+		t.Fatalf("Authorization = %q, want empty", gotAuth)
+	}
+}
+
+func TestCommandAuthForAPICallURLReturnsNilWhenAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	script := writeAPICallTokenScript(t, "Bearer inferred-token")
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor.NewCodexAutoExecutor(nil))
+	for _, id := range []string{"codex-command-auth-1", "codex-command-auth-2"} {
+		auth := commandAPICallAuth(id, "https://aiden-aiproxy.bytedance.net/v2", script)
+		if _, errRegister := manager.Register(coreauth.WithSkipPersist(context.Background()), auth); errRegister != nil {
+			t.Fatalf("register command auth: %v", errRegister)
+		}
+	}
+
+	target, errParse := url.Parse("https://aiden-aiproxy.bytedance.net/v2/models")
+	if errParse != nil {
+		t.Fatalf("parse url: %v", errParse)
+	}
+
+	if auth := (&Handler{authManager: manager}).commandAuthForAPICallURL(target); auth != nil {
+		t.Fatalf("commandAuthForAPICallURL returned %q, want nil", auth.ID)
+	}
+}
+
+func commandAPICallAuth(id, baseURL, script string) *coreauth.Auth {
+	return &coreauth.Auth{
+		ID:       id,
+		Provider: "codex",
+		Attributes: map[string]string{
+			"base_url":                         baseURL,
+			coreauth.AttrAuthKind:              coreauth.AttrAuthKindAPIKey,
+			coreauth.AttrAuthSource:            coreauth.AttrAuthSourceCommand,
+			coreauth.AttrAuthCommand:           script,
+			coreauth.AttrAuthArgsJSON:          "[]",
+			coreauth.AttrAuthTimeoutMS:         "5000",
+			coreauth.AttrAuthRefreshIntervalMS: strconv.Itoa(int(time.Hour / time.Millisecond)),
+		},
+		Status: coreauth.StatusActive,
+	}
+}
+
+func jsonRequest(t *testing.T, body any) *http.Request {
+	t.Helper()
+	raw, errMarshal := json.Marshal(body)
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/api-call", strings.NewReader(string(raw)))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func writeAPICallTokenScript(t *testing.T, token string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token.sh")
+	body := "#!/bin/sh\nprintf '%s\\n' " + shellSingleQuote(token) + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write token script: %v", err)
+	}
+	return path
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -87,6 +87,10 @@ func TestAPICallTransportAPIKeyAuthFallsBackToConfigProxyURL(t *testing.T) {
 				APIKey:   "codex-key",
 				ProxyURL: "http://codex-proxy.example.com:8080",
 			}},
+			VertexCompatAPIKey: []config.VertexCompatKey{{
+				APIKey:   "vertex-key",
+				ProxyURL: "http://vertex-proxy.example.com:8080",
+			}},
 			OpenAICompatibility: []config.OpenAICompatibility{{
 				Name:    "bohe",
 				BaseURL: "https://bohe.example.com",
@@ -128,6 +132,14 @@ func TestAPICallTransportAPIKeyAuthFallsBackToConfigProxyURL(t *testing.T) {
 			wantProxy: "http://codex-proxy.example.com:8080",
 		},
 		{
+			name: "vertex",
+			auth: &coreauth.Auth{
+				Provider:   "vertex",
+				Attributes: map[string]string{"api_key": "vertex-key"},
+			},
+			wantProxy: "http://vertex-proxy.example.com:8080",
+		},
+		{
 			name: "openai-compatibility",
 			auth: &coreauth.Auth{
 				Provider: "bohe",
@@ -165,6 +177,46 @@ func TestAPICallTransportAPIKeyAuthFallsBackToConfigProxyURL(t *testing.T) {
 				t.Fatalf("proxy URL = %v, want %s", proxyURL, tc.wantProxy)
 			}
 		})
+	}
+}
+
+func TestAPICallTransportCommandAuthFallsBackToConfigProxyURL(t *testing.T) {
+	t.Parallel()
+
+	commandAuth := &config.CommandAuthConfig{Command: "fetch-token"}
+	cfg := &config.Config{
+		GeminiKey: []config.GeminiKey{{
+			Auth:     commandAuth,
+			ProxyURL: "http://gemini-command-proxy.example.com:8080",
+		}},
+	}
+	cfg.SanitizeGeminiKeys()
+	h := &Handler{cfg: cfg}
+	auth := &coreauth.Auth{
+		Provider: "gemini",
+		Attributes: map[string]string{
+			coreauth.AttrAuthKind:       coreauth.AttrAuthKindAPIKey,
+			coreauth.AttrAuthSource:     coreauth.AttrAuthSourceCommand,
+			coreauth.AttrAuthCommand:    "fetch-token",
+			coreauth.AttrAuthCommandKey: config.CommandAuthIdentity(cfg.GeminiKey[0].Auth),
+		},
+	}
+
+	transport := h.apiCallTransport(auth)
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", transport)
+	}
+	req, errRequest := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if errRequest != nil {
+		t.Fatalf("http.NewRequest returned error: %v", errRequest)
+	}
+	proxyURL, errProxy := httpTransport.Proxy(req)
+	if errProxy != nil {
+		t.Fatalf("httpTransport.Proxy returned error: %v", errProxy)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://gemini-command-proxy.example.com:8080" {
+		t.Fatalf("proxy URL = %v, want http://gemini-command-proxy.example.com:8080", proxyURL)
 	}
 }
 

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1285,7 +1285,7 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 		return
 	}
 
-	if coreauth.IsConfigAPIKeyAuth(targetAuth) {
+	if coreauth.IsConfigCredentialAuth(targetAuth) {
 		h.mu.Lock()
 		handled, errToggle := toggleConfigAPIKeyExcludedAll(h.cfg, targetAuth, *req.Disabled)
 		if errToggle != nil {

--- a/internal/api/handlers/management/config_apikey_disable.go
+++ b/internal/api/handlers/management/config_apikey_disable.go
@@ -31,7 +31,7 @@ func setConfigAPIKeyExcludedAll(models []string, disable bool) []string {
 }
 
 func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disable bool) (bool, error) {
-	if cfg == nil || auth == nil || !coreauth.IsConfigAPIKeyAuth(auth) {
+	if cfg == nil || auth == nil || !coreauth.IsConfigCredentialAuth(auth) {
 		return false, nil
 	}
 	authID := strings.TrimSpace(auth.ID)
@@ -59,7 +59,13 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 	}
 	for i := range cfg.CodexKey {
 		entry := &cfg.CodexKey[i]
-		id, _ := idGen.Next("codex:apikey", entry.APIKey, entry.BaseURL)
+		var id string
+		if strings.TrimSpace(entry.APIKey) != "" {
+			id, _ = idGen.Next("codex:apikey", entry.APIKey, entry.BaseURL)
+		} else if entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL)
+			id, _ = idGen.Next("codex:apikey", idParts...)
+		}
 		if id == authID {
 			entry.ExcludedModels = setConfigAPIKeyExcludedAll(entry.ExcludedModels, disable)
 			return true, nil

--- a/internal/api/handlers/management/config_apikey_disable.go
+++ b/internal/api/handlers/management/config_apikey_disable.go
@@ -83,6 +83,26 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 			return true, nil
 		}
 	}
+	for i := range cfg.OpenAICompatibility {
+		compat := &cfg.OpenAICompatibility[i]
+		if compat.Auth == nil || strings.TrimSpace(compat.Auth.Command) == "" {
+			continue
+		}
+		providerName := strings.ToLower(strings.TrimSpace(compat.Name))
+		if providerName == "" {
+			providerName = "openai-compatibility"
+		}
+		idKind := fmt.Sprintf("openai-compatibility:%s", providerName)
+		idParts := append(synthesizer.CommandAuthIDParts(compat.Auth), strings.TrimSpace(compat.BaseURL), strings.TrimSpace(compat.ProxyURL))
+		id, _ := idGen.Next(idKind, idParts...)
+		if id == authID {
+			// OpenAI-compatibility providers expose no per-credential excluded-models field.
+			// A command-auth provider maps to a single synthesized credential, so toggling the
+			// provider's Disabled flag is the persistent equivalent of disabling that credential.
+			compat.Disabled = disable
+			return true, nil
+		}
+	}
 	for i := range cfg.VertexCompatAPIKey {
 		entry := &cfg.VertexCompatAPIKey[i]
 		var id string

--- a/internal/api/handlers/management/config_apikey_disable.go
+++ b/internal/api/handlers/management/config_apikey_disable.go
@@ -43,7 +43,13 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 
 	for i := range cfg.GeminiKey {
 		entry := &cfg.GeminiKey[i]
-		id, _ := idGen.Next("gemini:apikey", entry.APIKey, entry.BaseURL)
+		var id string
+		if strings.TrimSpace(entry.APIKey) != "" {
+			id, _ = idGen.Next("gemini:apikey", entry.APIKey, entry.BaseURL)
+		} else if entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL)
+			id, _ = idGen.Next("gemini:apikey", idParts...)
+		}
 		if id == authID {
 			entry.ExcludedModels = setConfigAPIKeyExcludedAll(entry.ExcludedModels, disable)
 			return true, nil
@@ -51,7 +57,13 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 	}
 	for i := range cfg.ClaudeKey {
 		entry := &cfg.ClaudeKey[i]
-		id, _ := idGen.Next("claude:apikey", entry.APIKey, entry.BaseURL)
+		var id string
+		if strings.TrimSpace(entry.APIKey) != "" {
+			id, _ = idGen.Next("claude:apikey", entry.APIKey, entry.BaseURL)
+		} else if entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL)
+			id, _ = idGen.Next("claude:apikey", idParts...)
+		}
 		if id == authID {
 			entry.ExcludedModels = setConfigAPIKeyExcludedAll(entry.ExcludedModels, disable)
 			return true, nil
@@ -73,7 +85,13 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 	}
 	for i := range cfg.VertexCompatAPIKey {
 		entry := &cfg.VertexCompatAPIKey[i]
-		id, _ := idGen.Next("vertex:apikey", entry.APIKey, entry.BaseURL, entry.ProxyURL)
+		var id string
+		if strings.TrimSpace(entry.APIKey) != "" {
+			id, _ = idGen.Next("vertex:apikey", entry.APIKey, entry.BaseURL, entry.ProxyURL)
+		} else if entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL, strings.TrimSpace(entry.ProxyURL))
+			id, _ = idGen.Next("vertex:apikey", idParts...)
+		}
 		if id == authID {
 			entry.ExcludedModels = setConfigAPIKeyExcludedAll(entry.ExcludedModels, disable)
 			return true, nil

--- a/internal/api/handlers/management/config_apikey_disable_test.go
+++ b/internal/api/handlers/management/config_apikey_disable_test.go
@@ -1,8 +1,10 @@
 package management
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
@@ -94,5 +96,50 @@ func TestToggleConfigAPIKeyExcludedAll_OpenAICompatCommandAuth(t *testing.T) {
 	}
 	if cfg.OpenAICompatibility[0].Disabled {
 		t.Fatalf("expected provider re-enabled, got %#v", cfg.OpenAICompatibility[0])
+	}
+}
+
+func TestToggleConfigAPIKeyExcludedAll_OpenAICompatCommandAuthSynthesizesDisabledAuth(t *testing.T) {
+	cfg := &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:     "proxy",
+			BaseURL:  "https://proxy.example.com/v1",
+			ProxyURL: "http://proxy.local",
+			Disabled: true,
+			Auth:     &config.CommandAuthConfig{Command: "fetch-token"},
+		}},
+	}
+
+	auths, err := synthesizer.NewConfigSynthesizer().Synthesize(&synthesizer.SynthesisContext{
+		Config:      cfg,
+		Now:         time.Now(),
+		IDGenerator: synthesizer.NewStableIDGenerator(),
+	})
+	if err != nil {
+		t.Fatalf("synthesize disabled command auth: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auths len = %d, want 1", len(auths))
+	}
+	auth := auths[0]
+	if !auth.Disabled || auth.Status != coreauth.StatusDisabled {
+		t.Fatalf("auth disabled/status = %v/%s, want true/%s", auth.Disabled, auth.Status, coreauth.StatusDisabled)
+	}
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register disabled command auth: %v", err)
+	}
+	loaded, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("disabled synthesized auth %q not found in manager", auth.ID)
+	}
+
+	handled, err := toggleConfigAPIKeyExcludedAll(cfg, loaded, false)
+	if err != nil || !handled {
+		t.Fatalf("toggle enable after reload: handled=%v err=%v", handled, err)
+	}
+	if cfg.OpenAICompatibility[0].Disabled {
+		t.Fatalf("expected provider re-enabled from disabled synthesized auth, got %#v", cfg.OpenAICompatibility[0])
 	}
 }

--- a/internal/api/handlers/management/config_apikey_disable_test.go
+++ b/internal/api/handlers/management/config_apikey_disable_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -52,5 +53,46 @@ func TestToggleConfigAPIKeyExcludedAll_Codex(t *testing.T) {
 	}
 	if len(cfg.CodexKey[0].ExcludedModels) != 0 {
 		t.Fatalf("expected excluded-models cleared, got %#v", cfg.CodexKey[0].ExcludedModels)
+	}
+}
+
+func TestToggleConfigAPIKeyExcludedAll_OpenAICompatCommandAuth(t *testing.T) {
+	cfg := &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:    "proxy",
+			BaseURL: "https://proxy.example.com/v1",
+			Auth:    &config.CommandAuthConfig{Command: "fetch-token"},
+		}},
+	}
+	compat := &cfg.OpenAICompatibility[0]
+	idGen := synthesizer.NewStableIDGenerator()
+	idParts := append(synthesizer.CommandAuthIDParts(compat.Auth), strings.TrimSpace(compat.BaseURL), strings.TrimSpace(compat.ProxyURL))
+	authID, _ := idGen.Next("openai-compatibility:proxy", idParts...)
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"source":                    "config:proxy[abc]",
+			coreauth.AttrAuthKind:       coreauth.AttrAuthKindAPIKey,
+			coreauth.AttrAuthSource:     coreauth.AttrAuthSourceCommand,
+			coreauth.AttrAuthCommand:    "fetch-token",
+			coreauth.AttrAuthCommandKey: config.CommandAuthIdentity(compat.Auth),
+		},
+	}
+
+	handled, err := toggleConfigAPIKeyExcludedAll(cfg, auth, true)
+	if err != nil || !handled {
+		t.Fatalf("toggle disable: handled=%v err=%v", handled, err)
+	}
+	if !cfg.OpenAICompatibility[0].Disabled {
+		t.Fatalf("expected provider disabled, got %#v", cfg.OpenAICompatibility[0])
+	}
+
+	handled, err = toggleConfigAPIKeyExcludedAll(cfg, auth, false)
+	if err != nil || !handled {
+		t.Fatalf("toggle enable: handled=%v err=%v", handled, err)
+	}
+	if cfg.OpenAICompatibility[0].Disabled {
+		t.Fatalf("expected provider re-enabled, got %#v", cfg.OpenAICompatibility[0])
 	}
 }

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -6,31 +6,42 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 type geminiKeyWithAuthIndex struct {
 	config.GeminiKey
-	AuthIndex string `json:"auth-index,omitempty"`
+	AuthIndex  string `json:"auth-index,omitempty"`
+	AuthKey    string `json:"auth-key,omitempty"`
+	AuthSource string `json:"auth-source,omitempty"`
 }
 
 type claudeKeyWithAuthIndex struct {
 	config.ClaudeKey
-	AuthIndex string `json:"auth-index,omitempty"`
+	AuthIndex  string `json:"auth-index,omitempty"`
+	AuthKey    string `json:"auth-key,omitempty"`
+	AuthSource string `json:"auth-source,omitempty"`
 }
 
 type codexKeyWithAuthIndex struct {
 	config.CodexKey
-	AuthIndex string `json:"auth-index,omitempty"`
+	AuthIndex  string `json:"auth-index,omitempty"`
+	AuthKey    string `json:"auth-key,omitempty"`
+	AuthSource string `json:"auth-source,omitempty"`
 }
 
 type vertexCompatKeyWithAuthIndex struct {
 	config.VertexCompatKey
-	AuthIndex string `json:"auth-index,omitempty"`
+	AuthIndex  string `json:"auth-index,omitempty"`
+	AuthKey    string `json:"auth-key,omitempty"`
+	AuthSource string `json:"auth-source,omitempty"`
 }
 
 type openAICompatibilityAPIKeyWithAuthIndex struct {
 	config.OpenAICompatibilityAPIKey
-	AuthIndex string `json:"auth-index,omitempty"`
+	AuthIndex  string `json:"auth-index,omitempty"`
+	AuthKey    string `json:"auth-key,omitempty"`
+	AuthSource string `json:"auth-source,omitempty"`
 }
 
 type openAICompatibilityWithAuthIndex struct {
@@ -46,6 +57,38 @@ type openAICompatibilityWithAuthIndex struct {
 	Headers        map[string]string                        `json:"headers,omitempty"`
 	DisableCooling bool                                     `json:"disable-cooling,omitempty"`
 	AuthIndex      string                                   `json:"auth-index,omitempty"`
+	AuthKey        string                                   `json:"auth-key,omitempty"`
+	AuthSource     string                                   `json:"auth-source,omitempty"`
+}
+
+type configWithAuthMetadata struct {
+	config.Config
+	GeminiKey           []geminiKeyWithAuthIndex           `json:"gemini-api-key"`
+	CodexKey            []codexKeyWithAuthIndex            `json:"codex-api-key"`
+	ClaudeKey           []claudeKeyWithAuthIndex           `json:"claude-api-key"`
+	VertexCompatAPIKey  []vertexCompatKeyWithAuthIndex     `json:"vertex-api-key"`
+	OpenAICompatibility []openAICompatibilityWithAuthIndex `json:"openai-compatibility"`
+}
+
+func (h *Handler) managementConfigSnapshot() configWithAuthMetadata {
+	if h == nil {
+		return configWithAuthMetadata{}
+	}
+	h.mu.Lock()
+	base := config.Config{}
+	if h.cfg != nil {
+		base = *h.cfg
+	}
+	h.mu.Unlock()
+
+	return configWithAuthMetadata{
+		Config:              base,
+		GeminiKey:           h.geminiKeysWithAuthIndex(),
+		CodexKey:            h.codexKeysWithAuthIndex(),
+		ClaudeKey:           h.claudeKeysWithAuthIndex(),
+		VertexCompatAPIKey:  h.vertexCompatKeysWithAuthIndex(),
+		OpenAICompatibility: h.openAICompatibilityWithAuthIndex(),
+	}
 }
 
 func (h *Handler) liveAuthIndexByID() map[string]string {
@@ -80,6 +123,22 @@ func (h *Handler) liveAuthIndexByID() map[string]string {
 	return out
 }
 
+func commandAuthConfigManagementKey(auth *config.CommandAuthConfig) string {
+	return commandAuthManagementKey(config.CommandAuthIdentity(auth))
+}
+
+func isCommandAuthAPIKey(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), "auth-command:")
+}
+
+func clearCommandAuthAPIKey(apiKey string, auth *config.CommandAuthConfig) string {
+	apiKey = strings.TrimSpace(apiKey)
+	if auth != nil && isCommandAuthAPIKey(apiKey) {
+		return ""
+	}
+	return apiKey
+}
+
 func (h *Handler) geminiKeysWithAuthIndex() []geminiKeyWithAuthIndex {
 	if h == nil {
 		return nil
@@ -97,6 +156,8 @@ func (h *Handler) geminiKeysWithAuthIndex() []geminiKeyWithAuthIndex {
 	for i := range h.cfg.GeminiKey {
 		entry := h.cfg.GeminiKey[i]
 		authIndex := ""
+		authKey := ""
+		authSource := ""
 		if key := strings.TrimSpace(entry.APIKey); key != "" {
 			id, _ := idGen.Next("gemini:apikey", key, entry.BaseURL)
 			authIndex = liveIndexByID[id]
@@ -104,10 +165,14 @@ func (h *Handler) geminiKeysWithAuthIndex() []geminiKeyWithAuthIndex {
 			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL)
 			id, _ := idGen.Next("gemini:apikey", idParts...)
 			authIndex = liveIndexByID[id]
+			authKey = commandAuthConfigManagementKey(entry.Auth)
+			authSource = coreauth.AttrAuthSourceCommand
 		}
 		out[i] = geminiKeyWithAuthIndex{
-			GeminiKey: entry,
-			AuthIndex: authIndex,
+			GeminiKey:  entry,
+			AuthIndex:  authIndex,
+			AuthKey:    authKey,
+			AuthSource: authSource,
 		}
 	}
 	return out
@@ -130,6 +195,8 @@ func (h *Handler) claudeKeysWithAuthIndex() []claudeKeyWithAuthIndex {
 	for i := range h.cfg.ClaudeKey {
 		entry := h.cfg.ClaudeKey[i]
 		authIndex := ""
+		authKey := ""
+		authSource := ""
 		if key := strings.TrimSpace(entry.APIKey); key != "" {
 			id, _ := idGen.Next("claude:apikey", key, entry.BaseURL)
 			authIndex = liveIndexByID[id]
@@ -137,10 +204,14 @@ func (h *Handler) claudeKeysWithAuthIndex() []claudeKeyWithAuthIndex {
 			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL)
 			id, _ := idGen.Next("claude:apikey", idParts...)
 			authIndex = liveIndexByID[id]
+			authKey = commandAuthConfigManagementKey(entry.Auth)
+			authSource = coreauth.AttrAuthSourceCommand
 		}
 		out[i] = claudeKeyWithAuthIndex{
-			ClaudeKey: entry,
-			AuthIndex: authIndex,
+			ClaudeKey:  entry,
+			AuthIndex:  authIndex,
+			AuthKey:    authKey,
+			AuthSource: authSource,
 		}
 	}
 	return out
@@ -163,6 +234,8 @@ func (h *Handler) codexKeysWithAuthIndex() []codexKeyWithAuthIndex {
 	for i := range h.cfg.CodexKey {
 		entry := h.cfg.CodexKey[i]
 		authIndex := ""
+		authKey := ""
+		authSource := ""
 		if key := strings.TrimSpace(entry.APIKey); key != "" {
 			id, _ := idGen.Next("codex:apikey", key, entry.BaseURL)
 			authIndex = liveIndexByID[id]
@@ -170,10 +243,14 @@ func (h *Handler) codexKeysWithAuthIndex() []codexKeyWithAuthIndex {
 			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL)
 			id, _ := idGen.Next("codex:apikey", idParts...)
 			authIndex = liveIndexByID[id]
+			authKey = commandAuthConfigManagementKey(entry.Auth)
+			authSource = coreauth.AttrAuthSourceCommand
 		}
 		out[i] = codexKeyWithAuthIndex{
-			CodexKey:  entry,
-			AuthIndex: authIndex,
+			CodexKey:   entry,
+			AuthIndex:  authIndex,
+			AuthKey:    authKey,
+			AuthSource: authSource,
 		}
 	}
 	return out
@@ -196,16 +273,22 @@ func (h *Handler) vertexCompatKeysWithAuthIndex() []vertexCompatKeyWithAuthIndex
 	for i := range h.cfg.VertexCompatAPIKey {
 		entry := h.cfg.VertexCompatAPIKey[i]
 		var id string
+		authKey := ""
+		authSource := ""
 		if strings.TrimSpace(entry.APIKey) != "" {
 			id, _ = idGen.Next("vertex:apikey", entry.APIKey, entry.BaseURL, entry.ProxyURL)
 		} else if entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
 			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL, strings.TrimSpace(entry.ProxyURL))
 			id, _ = idGen.Next("vertex:apikey", idParts...)
+			authKey = commandAuthConfigManagementKey(entry.Auth)
+			authSource = coreauth.AttrAuthSourceCommand
 		}
 		authIndex := liveIndexByID[id]
 		out[i] = vertexCompatKeyWithAuthIndex{
 			VertexCompatKey: entry,
 			AuthIndex:       authIndex,
+			AuthKey:         authKey,
+			AuthSource:      authSource,
 		}
 	}
 	return out
@@ -251,6 +334,8 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL, strings.TrimSpace(entry.ProxyURL))
 			id, _ := idGen.Next(idKind, idParts...)
 			response.AuthIndex = liveIndexByID[id]
+			response.AuthKey = commandAuthConfigManagementKey(entry.Auth)
+			response.AuthSource = coreauth.AttrAuthSourceCommand
 		} else if len(entry.APIKeyEntries) == 0 {
 			id, _ := idGen.Next(idKind, entry.BaseURL)
 			response.AuthIndex = liveIndexByID[id]

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -100,6 +100,10 @@ func (h *Handler) geminiKeysWithAuthIndex() []geminiKeyWithAuthIndex {
 		if key := strings.TrimSpace(entry.APIKey); key != "" {
 			id, _ := idGen.Next("gemini:apikey", key, entry.BaseURL)
 			authIndex = liveIndexByID[id]
+		} else if entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL)
+			id, _ := idGen.Next("gemini:apikey", idParts...)
+			authIndex = liveIndexByID[id]
 		}
 		out[i] = geminiKeyWithAuthIndex{
 			GeminiKey: entry,
@@ -128,6 +132,10 @@ func (h *Handler) claudeKeysWithAuthIndex() []claudeKeyWithAuthIndex {
 		authIndex := ""
 		if key := strings.TrimSpace(entry.APIKey); key != "" {
 			id, _ := idGen.Next("claude:apikey", key, entry.BaseURL)
+			authIndex = liveIndexByID[id]
+		} else if entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL)
+			id, _ := idGen.Next("claude:apikey", idParts...)
 			authIndex = liveIndexByID[id]
 		}
 		out[i] = claudeKeyWithAuthIndex{
@@ -187,7 +195,13 @@ func (h *Handler) vertexCompatKeysWithAuthIndex() []vertexCompatKeyWithAuthIndex
 	out := make([]vertexCompatKeyWithAuthIndex, len(h.cfg.VertexCompatAPIKey))
 	for i := range h.cfg.VertexCompatAPIKey {
 		entry := h.cfg.VertexCompatAPIKey[i]
-		id, _ := idGen.Next("vertex:apikey", entry.APIKey, entry.BaseURL, entry.ProxyURL)
+		var id string
+		if strings.TrimSpace(entry.APIKey) != "" {
+			id, _ = idGen.Next("vertex:apikey", entry.APIKey, entry.BaseURL, entry.ProxyURL)
+		} else if entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL, strings.TrimSpace(entry.ProxyURL))
+			id, _ = idGen.Next("vertex:apikey", idParts...)
+		}
 		authIndex := liveIndexByID[id]
 		out[i] = vertexCompatKeyWithAuthIndex{
 			VertexCompatKey: entry,

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -39,6 +39,8 @@ type openAICompatibilityWithAuthIndex struct {
 	Disabled       bool                                     `json:"disabled"`
 	Prefix         string                                   `json:"prefix,omitempty"`
 	BaseURL        string                                   `json:"base-url"`
+	ProxyURL       string                                   `json:"proxy-url,omitempty"`
+	Auth           *config.CommandAuthConfig                `json:"auth,omitempty"`
 	APIKeyEntries  []openAICompatibilityAPIKeyWithAuthIndex `json:"api-key-entries,omitempty"`
 	Models         []config.OpenAICompatibilityModel        `json:"models,omitempty"`
 	Headers        map[string]string                        `json:"headers,omitempty"`
@@ -156,6 +158,10 @@ func (h *Handler) codexKeysWithAuthIndex() []codexKeyWithAuthIndex {
 		if key := strings.TrimSpace(entry.APIKey); key != "" {
 			id, _ := idGen.Next("codex:apikey", key, entry.BaseURL)
 			authIndex = liveIndexByID[id]
+		} else if entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL)
+			id, _ := idGen.Next("codex:apikey", idParts...)
+			authIndex = liveIndexByID[id]
 		}
 		out[i] = codexKeyWithAuthIndex{
 			CodexKey:  entry,
@@ -220,12 +226,18 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 			Disabled:       entry.Disabled,
 			Prefix:         entry.Prefix,
 			BaseURL:        entry.BaseURL,
+			ProxyURL:       entry.ProxyURL,
+			Auth:           entry.Auth,
 			Models:         entry.Models,
 			Headers:        entry.Headers,
 			DisableCooling: entry.DisableCooling,
 			AuthIndex:      "",
 		}
-		if len(entry.APIKeyEntries) == 0 {
+		if entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+			idParts := append(synthesizer.CommandAuthIDParts(entry.Auth), entry.BaseURL, strings.TrimSpace(entry.ProxyURL))
+			id, _ := idGen.Next(idKind, idParts...)
+			response.AuthIndex = liveIndexByID[id]
+		} else if len(entry.APIKeyEntries) == 0 {
 			id, _ := idGen.Next(idKind, entry.BaseURL)
 			response.AuthIndex = liveIndexByID[id]
 		} else {

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -75,19 +75,25 @@ func (h *Handler) managementConfigSnapshot() configWithAuthMetadata {
 		return configWithAuthMetadata{}
 	}
 	h.mu.Lock()
-	base := config.Config{}
+	var base *config.Config
+	manager := h.authManager
 	if h.cfg != nil {
-		base = *h.cfg
+		base = h.cfg.CloneForRuntime()
 	}
 	h.mu.Unlock()
+	if base == nil {
+		base = &config.Config{}
+	}
+
+	snapshotHandler := &Handler{cfg: base, authManager: manager}
 
 	return configWithAuthMetadata{
-		Config:              base,
-		GeminiKey:           h.geminiKeysWithAuthIndex(),
-		CodexKey:            h.codexKeysWithAuthIndex(),
-		ClaudeKey:           h.claudeKeysWithAuthIndex(),
-		VertexCompatAPIKey:  h.vertexCompatKeysWithAuthIndex(),
-		OpenAICompatibility: h.openAICompatibilityWithAuthIndex(),
+		Config:              *base,
+		GeminiKey:           snapshotHandler.geminiKeysWithAuthIndex(),
+		CodexKey:            snapshotHandler.codexKeysWithAuthIndex(),
+		ClaudeKey:           snapshotHandler.claudeKeysWithAuthIndex(),
+		VertexCompatAPIKey:  snapshotHandler.vertexCompatKeysWithAuthIndex(),
+		OpenAICompatibility: snapshotHandler.openAICompatibilityWithAuthIndex(),
 	}
 }
 

--- a/internal/api/handlers/management/config_auth_index_test.go
+++ b/internal/api/handlers/management/config_auth_index_test.go
@@ -109,6 +109,40 @@ func TestManagementConfigSnapshotExposesCommandAuthMetadata(t *testing.T) {
 	}
 }
 
+func TestManagementConfigSnapshotDeepCopiesConfigData(t *testing.T) {
+	h := &Handler{cfg: &config.Config{
+		OAuthModelAlias: map[string][]config.OAuthModelAlias{
+			"codex": {{Name: "source", Alias: "alias"}},
+		},
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:    "proxy",
+			BaseURL: "https://proxy.example.com/v1",
+			Headers: map[string]string{
+				"X-Test": "source",
+			},
+			Models: []config.OpenAICompatibilityModel{{
+				Name:  "gpt-5",
+				Alias: "gpt",
+			}},
+		}},
+	}}
+
+	got := h.managementConfigSnapshot()
+	got.OAuthModelAlias["codex"][0].Alias = "snapshot"
+	got.OpenAICompatibility[0].Headers["X-Test"] = "snapshot"
+	got.OpenAICompatibility[0].Models[0].Alias = "snapshot"
+
+	if h.cfg.OAuthModelAlias["codex"][0].Alias != "alias" {
+		t.Fatalf("source OAuthModelAlias mutated to %q", h.cfg.OAuthModelAlias["codex"][0].Alias)
+	}
+	if h.cfg.OpenAICompatibility[0].Headers["X-Test"] != "source" {
+		t.Fatalf("source header mutated to %q", h.cfg.OpenAICompatibility[0].Headers["X-Test"])
+	}
+	if h.cfg.OpenAICompatibility[0].Models[0].Alias != "gpt" {
+		t.Fatalf("source model alias mutated to %q", h.cfg.OpenAICompatibility[0].Models[0].Alias)
+	}
+}
+
 func TestNormalizeCommandAuthPseudoAPIKeyDropsDisplayOnlyValue(t *testing.T) {
 	authCfg := &config.CommandAuthConfig{Command: "fetch-token"}
 	pseudoKey := commandAuthConfigManagementKey(authCfg)

--- a/internal/api/handlers/management/config_auth_index_test.go
+++ b/internal/api/handlers/management/config_auth_index_test.go
@@ -1,0 +1,134 @@
+package management
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestCommandAuthConfigListsExposeAuthMetadataWithoutPseudoAPIKey(t *testing.T) {
+	authCfg := &config.CommandAuthConfig{Command: "fetch-token", Args: []string{"--audience", "gemini"}}
+	h := &Handler{cfg: &config.Config{GeminiKey: []config.GeminiKey{{
+		BaseURL: "https://gemini.example.com",
+		Auth:    authCfg,
+	}}}}
+
+	got := h.geminiKeysWithAuthIndex()
+	if len(got) != 1 {
+		t.Fatalf("gemini keys len = %d, want 1", len(got))
+	}
+	wantAuthKey := commandAuthConfigManagementKey(authCfg)
+	if wantAuthKey == "" {
+		t.Fatal("auth key is empty")
+	}
+	if got[0].APIKey != "" {
+		t.Fatalf("response api-key = %q, want empty", got[0].APIKey)
+	}
+	if got[0].AuthKey != wantAuthKey {
+		t.Fatalf("response auth-key = %q, want %q", got[0].AuthKey, wantAuthKey)
+	}
+	if got[0].AuthSource != coreauth.AttrAuthSourceCommand {
+		t.Fatalf("response auth-source = %q, want command", got[0].AuthSource)
+	}
+	if h.cfg.GeminiKey[0].APIKey != "" {
+		t.Fatalf("config api-key mutated to %q, want empty", h.cfg.GeminiKey[0].APIKey)
+	}
+}
+
+func TestOpenAICompatCommandAuthConfigListExposesAuthMetadata(t *testing.T) {
+	authCfg := &config.CommandAuthConfig{Command: "fetch-openai-token"}
+	h := &Handler{cfg: &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{
+		Name:     "proxy",
+		BaseURL:  "https://proxy.example.com/v1",
+		ProxyURL: "http://proxy.local",
+		Auth:     authCfg,
+	}}}}
+
+	got := h.openAICompatibilityWithAuthIndex()
+	if len(got) != 1 {
+		t.Fatalf("openai compatibility len = %d, want 1", len(got))
+	}
+	if len(got[0].APIKeyEntries) != 0 {
+		t.Fatalf("api-key entries len = %d, want 0", len(got[0].APIKeyEntries))
+	}
+	wantAuthKey := commandAuthConfigManagementKey(authCfg)
+	if got[0].AuthKey != wantAuthKey {
+		t.Fatalf("response auth-key = %q, want %q", got[0].AuthKey, wantAuthKey)
+	}
+	if got[0].AuthSource != coreauth.AttrAuthSourceCommand {
+		t.Fatalf("response auth-source = %q, want command", got[0].AuthSource)
+	}
+	if len(h.cfg.OpenAICompatibility[0].APIKeyEntries) != 0 {
+		t.Fatalf("config api-key entries mutated to %#v, want empty", h.cfg.OpenAICompatibility[0].APIKeyEntries)
+	}
+}
+
+func TestManagementConfigSnapshotExposesCommandAuthMetadata(t *testing.T) {
+	codexAuth := &config.CommandAuthConfig{Command: "fetch-codex-token"}
+	claudeAuth := &config.CommandAuthConfig{Command: "fetch-claude-token"}
+	openAIAuth := &config.CommandAuthConfig{Command: "fetch-openai-token"}
+	h := &Handler{cfg: &config.Config{
+		CodexKey: []config.CodexKey{{
+			BaseURL: "https://codex.example.com/v1",
+			Auth:    codexAuth,
+		}},
+		ClaudeKey: []config.ClaudeKey{{
+			BaseURL: "https://claude.example.com",
+			Auth:    claudeAuth,
+		}},
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:    "proxy",
+			BaseURL: "https://proxy.example.com/v1",
+			Auth:    openAIAuth,
+		}},
+	}}
+
+	got := h.managementConfigSnapshot()
+	if got.CodexKey[0].APIKey != "" {
+		t.Fatalf("codex snapshot api-key = %q, want empty", got.CodexKey[0].APIKey)
+	}
+	if got.CodexKey[0].AuthKey != commandAuthConfigManagementKey(codexAuth) {
+		t.Fatalf("codex snapshot auth-key = %q", got.CodexKey[0].AuthKey)
+	}
+	if got.ClaudeKey[0].APIKey != "" {
+		t.Fatalf("claude snapshot api-key = %q, want empty", got.ClaudeKey[0].APIKey)
+	}
+	if got.ClaudeKey[0].AuthKey != commandAuthConfigManagementKey(claudeAuth) {
+		t.Fatalf("claude snapshot auth-key = %q", got.ClaudeKey[0].AuthKey)
+	}
+	if len(got.OpenAICompatibility[0].APIKeyEntries) != 0 {
+		t.Fatalf("openai snapshot api-key entries len = %d, want 0", len(got.OpenAICompatibility[0].APIKeyEntries))
+	}
+	if got.OpenAICompatibility[0].AuthKey != commandAuthConfigManagementKey(openAIAuth) {
+		t.Fatalf("openai snapshot auth-key = %q", got.OpenAICompatibility[0].AuthKey)
+	}
+
+	if h.cfg.CodexKey[0].APIKey != "" || h.cfg.ClaudeKey[0].APIKey != "" || len(h.cfg.OpenAICompatibility[0].APIKeyEntries) != 0 {
+		t.Fatalf("source config mutated: %#v", h.cfg)
+	}
+}
+
+func TestNormalizeCommandAuthPseudoAPIKeyDropsDisplayOnlyValue(t *testing.T) {
+	authCfg := &config.CommandAuthConfig{Command: "fetch-token"}
+	pseudoKey := commandAuthConfigManagementKey(authCfg)
+
+	codexEntry := config.CodexKey{APIKey: pseudoKey, Auth: authCfg, BaseURL: "https://codex.example.com"}
+	normalizeCodexKey(&codexEntry)
+	if codexEntry.APIKey != "" {
+		t.Fatalf("codex api-key = %q, want empty", codexEntry.APIKey)
+	}
+
+	compatEntry := config.OpenAICompatibility{
+		Name:    "proxy",
+		BaseURL: "https://proxy.example.com",
+		Auth:    authCfg,
+		APIKeyEntries: []config.OpenAICompatibilityAPIKey{{
+			APIKey: pseudoKey,
+		}},
+	}
+	normalizeOpenAICompatibilityEntry(&compatEntry)
+	if got := compatEntry.APIKeyEntries[0].APIKey; got != "" {
+		t.Fatalf("openai compat api-key = %q, want empty", got)
+	}
+}

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -28,7 +28,7 @@ func (h *Handler) GetConfig(c *gin.Context) {
 		c.JSON(200, gin.H{})
 		return
 	}
-	c.JSON(200, new(*h.cfg))
+	c.JSON(200, h.managementConfigSnapshot())
 }
 
 type releaseInfo struct {

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -141,18 +141,25 @@ func (h *Handler) PutGeminiKeys(c *gin.Context) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.cfg.GeminiKey = append([]config.GeminiKey(nil), arr...)
+	old := cloneGeminiKeys(h.cfg.GeminiKey)
+	h.cfg.GeminiKey = cloneGeminiKeys(arr)
 	h.cfg.SanitizeGeminiKeys()
+	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+		h.cfg.GeminiKey = old
+		c.JSON(400, gin.H{"error": errValidate.Error()})
+		return
+	}
 	h.persistLocked(c)
 }
 func (h *Handler) PatchGeminiKey(c *gin.Context) {
 	type geminiKeyPatch struct {
-		APIKey         *string            `json:"api-key"`
-		Prefix         *string            `json:"prefix"`
-		BaseURL        *string            `json:"base-url"`
-		ProxyURL       *string            `json:"proxy-url"`
-		Headers        *map[string]string `json:"headers"`
-		ExcludedModels *[]string          `json:"excluded-models"`
+		APIKey         *string                   `json:"api-key"`
+		Auth           *config.CommandAuthConfig `json:"auth"`
+		Prefix         *string                   `json:"prefix"`
+		BaseURL        *string                   `json:"base-url"`
+		ProxyURL       *string                   `json:"proxy-url"`
+		Headers        *map[string]string        `json:"headers"`
+		ExcludedModels *[]string                 `json:"excluded-models"`
 	}
 	var body struct {
 		Index *int            `json:"index"`
@@ -188,14 +195,16 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 
 	entry := h.cfg.GeminiKey[targetIndex]
 	if body.Value.APIKey != nil {
-		trimmed := strings.TrimSpace(*body.Value.APIKey)
-		if trimmed == "" {
-			h.cfg.GeminiKey = append(h.cfg.GeminiKey[:targetIndex], h.cfg.GeminiKey[targetIndex+1:]...)
-			h.cfg.SanitizeGeminiKeys()
-			h.persistLocked(c)
-			return
-		}
-		entry.APIKey = trimmed
+		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+	}
+	if body.Value.Auth != nil {
+		entry.Auth = commandAuthFromPatch(body.Value.Auth)
+	}
+	if body.Value.APIKey != nil && entry.APIKey == "" && entry.Auth == nil {
+		h.cfg.GeminiKey = append(h.cfg.GeminiKey[:targetIndex], h.cfg.GeminiKey[targetIndex+1:]...)
+		h.cfg.SanitizeGeminiKeys()
+		h.persistLocked(c)
+		return
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
@@ -212,8 +221,14 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 	if body.Value.ExcludedModels != nil {
 		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
 	}
+	old := cloneGeminiKeys(h.cfg.GeminiKey)
 	h.cfg.GeminiKey[targetIndex] = entry
 	h.cfg.SanitizeGeminiKeys()
+	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+		h.cfg.GeminiKey = old
+		c.JSON(400, gin.H{"error": errValidate.Error()})
+		return
+	}
 	h.persistLocked(c)
 }
 
@@ -301,20 +316,27 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.cfg.ClaudeKey = arr
+	old := cloneClaudeKeys(h.cfg.ClaudeKey)
+	h.cfg.ClaudeKey = cloneClaudeKeys(arr)
 	h.cfg.SanitizeClaudeKeys()
+	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+		h.cfg.ClaudeKey = old
+		c.JSON(400, gin.H{"error": errValidate.Error()})
+		return
+	}
 	h.persistLocked(c)
 }
 func (h *Handler) PatchClaudeKey(c *gin.Context) {
 	type claudeKeyPatch struct {
-		APIKey                  *string               `json:"api-key"`
-		Prefix                  *string               `json:"prefix"`
-		BaseURL                 *string               `json:"base-url"`
-		ProxyURL                *string               `json:"proxy-url"`
-		Models                  *[]config.ClaudeModel `json:"models"`
-		Headers                 *map[string]string    `json:"headers"`
-		ExcludedModels          *[]string             `json:"excluded-models"`
-		RebuildMidSystemMessage *bool                 `json:"rebuild-mid-system-message"`
+		APIKey                  *string                   `json:"api-key"`
+		Auth                    *config.CommandAuthConfig `json:"auth"`
+		Prefix                  *string                   `json:"prefix"`
+		BaseURL                 *string                   `json:"base-url"`
+		ProxyURL                *string                   `json:"proxy-url"`
+		Models                  *[]config.ClaudeModel     `json:"models"`
+		Headers                 *map[string]string        `json:"headers"`
+		ExcludedModels          *[]string                 `json:"excluded-models"`
+		RebuildMidSystemMessage *bool                     `json:"rebuild-mid-system-message"`
 	}
 	var body struct {
 		Index *int            `json:"index"`
@@ -350,6 +372,9 @@ func (h *Handler) PatchClaudeKey(c *gin.Context) {
 	if body.Value.APIKey != nil {
 		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
 	}
+	if body.Value.Auth != nil {
+		entry.Auth = commandAuthFromPatch(body.Value.Auth)
+	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
 	}
@@ -372,8 +397,14 @@ func (h *Handler) PatchClaudeKey(c *gin.Context) {
 		entry.RebuildMidSystemMessage = *body.Value.RebuildMidSystemMessage
 	}
 	normalizeClaudeKey(&entry)
+	old := cloneClaudeKeys(h.cfg.ClaudeKey)
 	h.cfg.ClaudeKey[targetIndex] = entry
 	h.cfg.SanitizeClaudeKeys()
+	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+		h.cfg.ClaudeKey = old
+		c.JSON(400, gin.H{"error": errValidate.Error()})
+		return
+	}
 	h.persistLocked(c)
 }
 
@@ -546,12 +577,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
 	}
 	if body.Value.Auth != nil {
-		if strings.TrimSpace(body.Value.Auth.Command) == "" && len(body.Value.Auth.Args) == 0 && body.Value.Auth.TimeoutMS == 0 && body.Value.Auth.RefreshIntervalMS == 0 {
-			entry.Auth = nil
-		} else {
-			auth := *body.Value.Auth
-			entry.Auth = &auth
-		}
+		entry.Auth = commandAuthFromPatch(body.Value.Auth)
 	}
 	if body.Value.APIKeyEntries != nil {
 		entry.APIKeyEntries = append([]config.OpenAICompatibilityAPIKey(nil), (*body.Value.APIKeyEntries)...)
@@ -625,20 +651,27 @@ func (h *Handler) PutVertexCompatKeys(c *gin.Context) {
 	}
 	for i := range arr {
 		normalizeVertexCompatKey(&arr[i])
-		if arr[i].APIKey == "" {
+		if arr[i].APIKey == "" && (arr[i].Auth == nil || strings.TrimSpace(arr[i].Auth.Command) == "") {
 			c.JSON(400, gin.H{"error": fmt.Sprintf("vertex-api-key[%d].api-key is required", i)})
 			return
 		}
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.cfg.VertexCompatAPIKey = append([]config.VertexCompatKey(nil), arr...)
+	old := cloneVertexCompatKeys(h.cfg.VertexCompatAPIKey)
+	h.cfg.VertexCompatAPIKey = cloneVertexCompatKeys(arr)
 	h.cfg.SanitizeVertexCompatKeys()
+	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+		h.cfg.VertexCompatAPIKey = old
+		c.JSON(400, gin.H{"error": errValidate.Error()})
+		return
+	}
 	h.persistLocked(c)
 }
 func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 	type vertexCompatPatch struct {
 		APIKey         *string                     `json:"api-key"`
+		Auth           *config.CommandAuthConfig   `json:"auth"`
 		Prefix         *string                     `json:"prefix"`
 		BaseURL        *string                     `json:"base-url"`
 		ProxyURL       *string                     `json:"proxy-url"`
@@ -680,14 +713,16 @@ func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 
 	entry := h.cfg.VertexCompatAPIKey[targetIndex]
 	if body.Value.APIKey != nil {
-		trimmed := strings.TrimSpace(*body.Value.APIKey)
-		if trimmed == "" {
-			h.cfg.VertexCompatAPIKey = append(h.cfg.VertexCompatAPIKey[:targetIndex], h.cfg.VertexCompatAPIKey[targetIndex+1:]...)
-			h.cfg.SanitizeVertexCompatKeys()
-			h.persistLocked(c)
-			return
-		}
-		entry.APIKey = trimmed
+		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+	}
+	if body.Value.Auth != nil {
+		entry.Auth = commandAuthFromPatch(body.Value.Auth)
+	}
+	if body.Value.APIKey != nil && entry.APIKey == "" && entry.Auth == nil {
+		h.cfg.VertexCompatAPIKey = append(h.cfg.VertexCompatAPIKey[:targetIndex], h.cfg.VertexCompatAPIKey[targetIndex+1:]...)
+		h.cfg.SanitizeVertexCompatKeys()
+		h.persistLocked(c)
+		return
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
@@ -715,8 +750,14 @@ func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
 	}
 	normalizeVertexCompatKey(&entry)
+	old := cloneVertexCompatKeys(h.cfg.VertexCompatAPIKey)
 	h.cfg.VertexCompatAPIKey[targetIndex] = entry
 	h.cfg.SanitizeVertexCompatKeys()
+	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+		h.cfg.VertexCompatAPIKey = old
+		c.JSON(400, gin.H{"error": errValidate.Error()})
+		return
+	}
 	h.persistLocked(c)
 }
 
@@ -1063,12 +1104,7 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 		entry.BaseURL = trimmed
 	}
 	if body.Value.Auth != nil {
-		if strings.TrimSpace(body.Value.Auth.Command) == "" && len(body.Value.Auth.Args) == 0 && body.Value.Auth.TimeoutMS == 0 && body.Value.Auth.RefreshIntervalMS == 0 {
-			entry.Auth = nil
-		} else {
-			auth := *body.Value.Auth
-			entry.Auth = &auth
-		}
+		entry.Auth = commandAuthFromPatch(body.Value.Auth)
 	}
 	if body.Value.ProxyURL != nil {
 		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
@@ -1155,6 +1191,7 @@ func normalizeOpenAICompatibilityEntry(entry *config.OpenAICompatibility) {
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
 	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.Auth = commandAuthFromPatch(entry.Auth)
 	existing := make(map[string]struct{}, len(entry.APIKeyEntries))
 	for i := range entry.APIKeyEntries {
 		trimmed := strings.TrimSpace(entry.APIKeyEntries[i].APIKey)
@@ -1184,9 +1221,7 @@ func cloneOpenAICompatibilityEntries(entries []config.OpenAICompatibility) []con
 	for i := range entries {
 		copyEntry := entries[i]
 		if copyEntry.Auth != nil {
-			auth := *copyEntry.Auth
-			auth.Args = append([]string(nil), copyEntry.Auth.Args...)
-			copyEntry.Auth = &auth
+			copyEntry.Auth = cloneCommandAuth(copyEntry.Auth)
 		}
 		if len(copyEntry.APIKeyEntries) > 0 {
 			copyEntry.APIKeyEntries = append([]config.OpenAICompatibilityAPIKey(nil), copyEntry.APIKeyEntries...)
@@ -1210,9 +1245,7 @@ func cloneCodexKeys(entries []config.CodexKey) []config.CodexKey {
 	for i := range entries {
 		copyEntry := entries[i]
 		if copyEntry.Auth != nil {
-			auth := *copyEntry.Auth
-			auth.Args = append([]string(nil), copyEntry.Auth.Args...)
-			copyEntry.Auth = &auth
+			copyEntry.Auth = cloneCommandAuth(copyEntry.Auth)
 		}
 		if len(copyEntry.Models) > 0 {
 			copyEntry.Models = append([]config.CodexModel(nil), copyEntry.Models...)
@@ -1228,6 +1261,88 @@ func cloneCodexKeys(entries []config.CodexKey) []config.CodexKey {
 	return out
 }
 
+func cloneGeminiKeys(entries []config.GeminiKey) []config.GeminiKey {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]config.GeminiKey, len(entries))
+	for i := range entries {
+		copyEntry := entries[i]
+		copyEntry.Auth = cloneCommandAuth(copyEntry.Auth)
+		if len(copyEntry.Models) > 0 {
+			copyEntry.Models = append([]config.GeminiModel(nil), copyEntry.Models...)
+		}
+		if len(copyEntry.Headers) > 0 {
+			copyEntry.Headers = config.NormalizeHeaders(copyEntry.Headers)
+		}
+		if len(copyEntry.ExcludedModels) > 0 {
+			copyEntry.ExcludedModels = append([]string(nil), copyEntry.ExcludedModels...)
+		}
+		out[i] = copyEntry
+	}
+	return out
+}
+
+func cloneClaudeKeys(entries []config.ClaudeKey) []config.ClaudeKey {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]config.ClaudeKey, len(entries))
+	for i := range entries {
+		copyEntry := entries[i]
+		copyEntry.Auth = cloneCommandAuth(copyEntry.Auth)
+		if len(copyEntry.Models) > 0 {
+			copyEntry.Models = append([]config.ClaudeModel(nil), copyEntry.Models...)
+		}
+		if len(copyEntry.Headers) > 0 {
+			copyEntry.Headers = config.NormalizeHeaders(copyEntry.Headers)
+		}
+		if len(copyEntry.ExcludedModels) > 0 {
+			copyEntry.ExcludedModels = append([]string(nil), copyEntry.ExcludedModels...)
+		}
+		out[i] = copyEntry
+	}
+	return out
+}
+
+func cloneVertexCompatKeys(entries []config.VertexCompatKey) []config.VertexCompatKey {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]config.VertexCompatKey, len(entries))
+	for i := range entries {
+		copyEntry := entries[i]
+		copyEntry.Auth = cloneCommandAuth(copyEntry.Auth)
+		if len(copyEntry.Models) > 0 {
+			copyEntry.Models = append([]config.VertexCompatModel(nil), copyEntry.Models...)
+		}
+		if len(copyEntry.Headers) > 0 {
+			copyEntry.Headers = config.NormalizeHeaders(copyEntry.Headers)
+		}
+		if len(copyEntry.ExcludedModels) > 0 {
+			copyEntry.ExcludedModels = append([]string(nil), copyEntry.ExcludedModels...)
+		}
+		out[i] = copyEntry
+	}
+	return out
+}
+
+func cloneCommandAuth(auth *config.CommandAuthConfig) *config.CommandAuthConfig {
+	if auth == nil {
+		return nil
+	}
+	copyAuth := *auth
+	copyAuth.Args = append([]string(nil), auth.Args...)
+	return &copyAuth
+}
+
+func commandAuthFromPatch(auth *config.CommandAuthConfig) *config.CommandAuthConfig {
+	if auth == nil || strings.TrimSpace(auth.Command) == "" && len(auth.Args) == 0 && auth.TimeoutMS == 0 && auth.RefreshIntervalMS == 0 {
+		return nil
+	}
+	return cloneCommandAuth(auth)
+}
+
 func normalizeClaudeKey(entry *config.ClaudeKey) {
 	if entry == nil {
 		return
@@ -1237,6 +1352,7 @@ func normalizeClaudeKey(entry *config.ClaudeKey) {
 	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.Auth = commandAuthFromPatch(entry.Auth)
 	if len(entry.Models) == 0 {
 		return
 	}
@@ -1263,6 +1379,7 @@ func normalizeCodexKey(entry *config.CodexKey) {
 	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.Auth = commandAuthFromPatch(entry.Auth)
 	if len(entry.Models) == 0 {
 		return
 	}
@@ -1289,6 +1406,7 @@ func normalizeVertexCompatKey(entry *config.VertexCompatKey) {
 	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.Auth = commandAuthFromPatch(entry.Auth)
 	if len(entry.Models) == 0 {
 		return
 	}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -139,6 +139,9 @@ func (h *Handler) PutGeminiKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
+	for i := range arr {
+		normalizeGeminiKey(&arr[i])
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	old := cloneGeminiKeys(h.cfg.GeminiKey)
@@ -221,6 +224,7 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 	if body.Value.ExcludedModels != nil {
 		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
 	}
+	normalizeGeminiKey(&entry)
 	old := cloneGeminiKeys(h.cfg.GeminiKey)
 	h.cfg.GeminiKey[targetIndex] = entry
 	h.cfg.SanitizeGeminiKeys()
@@ -1195,6 +1199,9 @@ func normalizeOpenAICompatibilityEntry(entry *config.OpenAICompatibility) {
 	existing := make(map[string]struct{}, len(entry.APIKeyEntries))
 	for i := range entry.APIKeyEntries {
 		trimmed := strings.TrimSpace(entry.APIKeyEntries[i].APIKey)
+		if entry.Auth != nil && isCommandAuthAPIKey(trimmed) {
+			trimmed = ""
+		}
 		entry.APIKeyEntries[i].APIKey = trimmed
 		if trimmed != "" {
 			existing[trimmed] = struct{}{}
@@ -1343,11 +1350,38 @@ func commandAuthFromPatch(auth *config.CommandAuthConfig) *config.CommandAuthCon
 	return cloneCommandAuth(auth)
 }
 
+func normalizeGeminiKey(entry *config.GeminiKey) {
+	if entry == nil {
+		return
+	}
+	entry.APIKey = clearCommandAuthAPIKey(entry.APIKey, entry.Auth)
+	entry.Prefix = strings.TrimSpace(entry.Prefix)
+	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
+	entry.Headers = config.NormalizeHeaders(entry.Headers)
+	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)
+	entry.Auth = commandAuthFromPatch(entry.Auth)
+	if len(entry.Models) == 0 {
+		return
+	}
+	normalized := make([]config.GeminiModel, 0, len(entry.Models))
+	for i := range entry.Models {
+		model := entry.Models[i]
+		model.Name = strings.TrimSpace(model.Name)
+		model.Alias = strings.TrimSpace(model.Alias)
+		if model.Name == "" && model.Alias == "" {
+			continue
+		}
+		normalized = append(normalized, model)
+	}
+	entry.Models = normalized
+}
+
 func normalizeClaudeKey(entry *config.ClaudeKey) {
 	if entry == nil {
 		return
 	}
-	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.APIKey = clearCommandAuthAPIKey(entry.APIKey, entry.Auth)
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
 	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
@@ -1373,7 +1407,7 @@ func normalizeCodexKey(entry *config.CodexKey) {
 	if entry == nil {
 		return
 	}
-	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.APIKey = clearCommandAuthAPIKey(entry.APIKey, entry.Auth)
 	entry.Prefix = strings.TrimSpace(entry.Prefix)
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
 	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
@@ -1400,7 +1434,7 @@ func normalizeVertexCompatKey(entry *config.VertexCompatKey) {
 	if entry == nil {
 		return
 	}
-	entry.APIKey = strings.TrimSpace(entry.APIKey)
+	entry.APIKey = clearCommandAuthAPIKey(entry.APIKey, entry.Auth)
 	entry.Prefix = strings.TrimSpace(entry.Prefix)
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
 	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -460,7 +460,7 @@ func (h *Handler) PutOpenAICompat(c *gin.Context) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	old := h.cfg.OpenAICompatibility
+	old := cloneOpenAICompatibilityEntries(h.cfg.OpenAICompatibility)
 	h.cfg.OpenAICompatibility = filtered
 	h.cfg.SanitizeOpenAICompatibility()
 	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
@@ -529,7 +529,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	if body.Value.BaseURL != nil {
 		trimmed := strings.TrimSpace(*body.Value.BaseURL)
 		if trimmed == "" {
-			old := h.cfg.OpenAICompatibility
+			old := cloneOpenAICompatibilityEntries(h.cfg.OpenAICompatibility)
 			h.cfg.OpenAICompatibility = append(h.cfg.OpenAICompatibility[:targetIndex], h.cfg.OpenAICompatibility[targetIndex+1:]...)
 			h.cfg.SanitizeOpenAICompatibility()
 			if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
@@ -563,7 +563,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
 	}
 	normalizeOpenAICompatibilityEntry(&entry)
-	old := h.cfg.OpenAICompatibility
+	old := cloneOpenAICompatibilityEntries(h.cfg.OpenAICompatibility)
 	h.cfg.OpenAICompatibility[targetIndex] = entry
 	h.cfg.SanitizeOpenAICompatibility()
 	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
@@ -988,7 +988,7 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	old := h.cfg.CodexKey
+	old := cloneCodexKeys(h.cfg.CodexKey)
 	h.cfg.CodexKey = filtered
 	h.cfg.SanitizeCodexKeys()
 	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
@@ -1049,7 +1049,7 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 	if body.Value.BaseURL != nil {
 		trimmed := strings.TrimSpace(*body.Value.BaseURL)
 		if trimmed == "" {
-			old := h.cfg.CodexKey
+			old := cloneCodexKeys(h.cfg.CodexKey)
 			h.cfg.CodexKey = append(h.cfg.CodexKey[:targetIndex], h.cfg.CodexKey[targetIndex+1:]...)
 			h.cfg.SanitizeCodexKeys()
 			if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
@@ -1083,7 +1083,7 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
 	}
 	normalizeCodexKey(&entry)
-	old := h.cfg.CodexKey
+	old := cloneCodexKeys(h.cfg.CodexKey)
 	h.cfg.CodexKey[targetIndex] = entry
 	h.cfg.SanitizeCodexKeys()
 	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
@@ -1169,13 +1169,60 @@ func normalizedOpenAICompatibilityEntries(entries []config.OpenAICompatibility) 
 	if len(entries) == 0 {
 		return nil
 	}
+	out := cloneOpenAICompatibilityEntries(entries)
+	for i := range out {
+		normalizeOpenAICompatibilityEntry(&out[i])
+	}
+	return out
+}
+
+func cloneOpenAICompatibilityEntries(entries []config.OpenAICompatibility) []config.OpenAICompatibility {
+	if len(entries) == 0 {
+		return nil
+	}
 	out := make([]config.OpenAICompatibility, len(entries))
 	for i := range entries {
 		copyEntry := entries[i]
+		if copyEntry.Auth != nil {
+			auth := *copyEntry.Auth
+			auth.Args = append([]string(nil), copyEntry.Auth.Args...)
+			copyEntry.Auth = &auth
+		}
 		if len(copyEntry.APIKeyEntries) > 0 {
 			copyEntry.APIKeyEntries = append([]config.OpenAICompatibilityAPIKey(nil), copyEntry.APIKeyEntries...)
 		}
-		normalizeOpenAICompatibilityEntry(&copyEntry)
+		if len(copyEntry.Models) > 0 {
+			copyEntry.Models = append([]config.OpenAICompatibilityModel(nil), copyEntry.Models...)
+		}
+		if len(copyEntry.Headers) > 0 {
+			copyEntry.Headers = config.NormalizeHeaders(copyEntry.Headers)
+		}
+		out[i] = copyEntry
+	}
+	return out
+}
+
+func cloneCodexKeys(entries []config.CodexKey) []config.CodexKey {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]config.CodexKey, len(entries))
+	for i := range entries {
+		copyEntry := entries[i]
+		if copyEntry.Auth != nil {
+			auth := *copyEntry.Auth
+			auth.Args = append([]string(nil), copyEntry.Auth.Args...)
+			copyEntry.Auth = &auth
+		}
+		if len(copyEntry.Models) > 0 {
+			copyEntry.Models = append([]config.CodexModel(nil), copyEntry.Models...)
+		}
+		if len(copyEntry.Headers) > 0 {
+			copyEntry.Headers = config.NormalizeHeaders(copyEntry.Headers)
+		}
+		if len(copyEntry.ExcludedModels) > 0 {
+			copyEntry.ExcludedModels = append([]string(nil), copyEntry.ExcludedModels...)
+		}
 		out[i] = copyEntry
 	}
 	return out

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -460,8 +460,14 @@ func (h *Handler) PutOpenAICompat(c *gin.Context) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	old := h.cfg.OpenAICompatibility
 	h.cfg.OpenAICompatibility = filtered
 	h.cfg.SanitizeOpenAICompatibility()
+	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+		h.cfg.OpenAICompatibility = old
+		c.JSON(400, gin.H{"error": errValidate.Error()})
+		return
+	}
 	h.persistLocked(c)
 }
 func (h *Handler) PatchOpenAICompat(c *gin.Context) {
@@ -471,6 +477,8 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		Disabled       *bool                               `json:"disabled"`
 		DisableCooling *bool                               `json:"disable-cooling"`
 		BaseURL        *string                             `json:"base-url"`
+		ProxyURL       *string                             `json:"proxy-url"`
+		Auth           *config.CommandAuthConfig           `json:"auth"`
 		APIKeyEntries  *[]config.OpenAICompatibilityAPIKey `json:"api-key-entries"`
 		Models         *[]config.OpenAICompatibilityModel  `json:"models"`
 		Headers        *map[string]string                  `json:"headers"`
@@ -521,12 +529,29 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	if body.Value.BaseURL != nil {
 		trimmed := strings.TrimSpace(*body.Value.BaseURL)
 		if trimmed == "" {
+			old := h.cfg.OpenAICompatibility
 			h.cfg.OpenAICompatibility = append(h.cfg.OpenAICompatibility[:targetIndex], h.cfg.OpenAICompatibility[targetIndex+1:]...)
 			h.cfg.SanitizeOpenAICompatibility()
+			if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+				h.cfg.OpenAICompatibility = old
+				c.JSON(400, gin.H{"error": errValidate.Error()})
+				return
+			}
 			h.persistLocked(c)
 			return
 		}
 		entry.BaseURL = trimmed
+	}
+	if body.Value.ProxyURL != nil {
+		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
+	}
+	if body.Value.Auth != nil {
+		if strings.TrimSpace(body.Value.Auth.Command) == "" && len(body.Value.Auth.Args) == 0 && body.Value.Auth.TimeoutMS == 0 && body.Value.Auth.RefreshIntervalMS == 0 {
+			entry.Auth = nil
+		} else {
+			auth := *body.Value.Auth
+			entry.Auth = &auth
+		}
 	}
 	if body.Value.APIKeyEntries != nil {
 		entry.APIKeyEntries = append([]config.OpenAICompatibilityAPIKey(nil), (*body.Value.APIKeyEntries)...)
@@ -538,8 +563,14 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		entry.Headers = config.NormalizeHeaders(*body.Value.Headers)
 	}
 	normalizeOpenAICompatibilityEntry(&entry)
+	old := h.cfg.OpenAICompatibility
 	h.cfg.OpenAICompatibility[targetIndex] = entry
 	h.cfg.SanitizeOpenAICompatibility()
+	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+		h.cfg.OpenAICompatibility = old
+		c.JSON(400, gin.H{"error": errValidate.Error()})
+		return
+	}
 	h.persistLocked(c)
 }
 
@@ -957,19 +988,26 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	old := h.cfg.CodexKey
 	h.cfg.CodexKey = filtered
 	h.cfg.SanitizeCodexKeys()
+	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+		h.cfg.CodexKey = old
+		c.JSON(400, gin.H{"error": errValidate.Error()})
+		return
+	}
 	h.persistLocked(c)
 }
 func (h *Handler) PatchCodexKey(c *gin.Context) {
 	type codexKeyPatch struct {
-		APIKey         *string              `json:"api-key"`
-		Prefix         *string              `json:"prefix"`
-		BaseURL        *string              `json:"base-url"`
-		ProxyURL       *string              `json:"proxy-url"`
-		Models         *[]config.CodexModel `json:"models"`
-		Headers        *map[string]string   `json:"headers"`
-		ExcludedModels *[]string            `json:"excluded-models"`
+		APIKey         *string                   `json:"api-key"`
+		Auth           *config.CommandAuthConfig `json:"auth"`
+		Prefix         *string                   `json:"prefix"`
+		BaseURL        *string                   `json:"base-url"`
+		ProxyURL       *string                   `json:"proxy-url"`
+		Models         *[]config.CodexModel      `json:"models"`
+		Headers        *map[string]string        `json:"headers"`
+		ExcludedModels *[]string                 `json:"excluded-models"`
 	}
 	var body struct {
 		Index *int           `json:"index"`
@@ -1011,12 +1049,26 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 	if body.Value.BaseURL != nil {
 		trimmed := strings.TrimSpace(*body.Value.BaseURL)
 		if trimmed == "" {
+			old := h.cfg.CodexKey
 			h.cfg.CodexKey = append(h.cfg.CodexKey[:targetIndex], h.cfg.CodexKey[targetIndex+1:]...)
 			h.cfg.SanitizeCodexKeys()
+			if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+				h.cfg.CodexKey = old
+				c.JSON(400, gin.H{"error": errValidate.Error()})
+				return
+			}
 			h.persistLocked(c)
 			return
 		}
 		entry.BaseURL = trimmed
+	}
+	if body.Value.Auth != nil {
+		if strings.TrimSpace(body.Value.Auth.Command) == "" && len(body.Value.Auth.Args) == 0 && body.Value.Auth.TimeoutMS == 0 && body.Value.Auth.RefreshIntervalMS == 0 {
+			entry.Auth = nil
+		} else {
+			auth := *body.Value.Auth
+			entry.Auth = &auth
+		}
 	}
 	if body.Value.ProxyURL != nil {
 		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
@@ -1031,8 +1083,14 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 		entry.ExcludedModels = config.NormalizeExcludedModels(*body.Value.ExcludedModels)
 	}
 	normalizeCodexKey(&entry)
+	old := h.cfg.CodexKey
 	h.cfg.CodexKey[targetIndex] = entry
 	h.cfg.SanitizeCodexKeys()
+	if errValidate := h.cfg.ValidateCommandAuthConfig(); errValidate != nil {
+		h.cfg.CodexKey = old
+		c.JSON(400, gin.H{"error": errValidate.Error()})
+		return
+	}
 	h.persistLocked(c)
 }
 
@@ -1095,6 +1153,7 @@ func normalizeOpenAICompatibilityEntry(entry *config.OpenAICompatibility) {
 	}
 	// Trim base-url; empty base-url indicates provider should be removed by sanitization
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	existing := make(map[string]struct{}, len(entry.APIKeyEntries))
 	for i := range entry.APIKeyEntries {

--- a/internal/api/handlers/management/config_lists_command_auth_test.go
+++ b/internal/api/handlers/management/config_lists_command_auth_test.go
@@ -1,0 +1,90 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestPatchOpenAICompatRejectedCommandAuthDoesNotMutateConfig(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{cfg: &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{
+		Name:    "proxy",
+		BaseURL: "https://proxy.example.com/v1",
+		APIKeyEntries: []config.OpenAICompatibilityAPIKey{{
+			APIKey: "static-key",
+		}},
+	}}}}
+	body := map[string]any{
+		"index": 0,
+		"value": map[string]any{
+			"auth": map[string]any{"command": "fetch-token"},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = jsonRequestBody(t, http.MethodPatch, "/v0/management/openai-compatibility", body)
+
+	h.PatchOpenAICompat(c)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	entry := h.cfg.OpenAICompatibility[0]
+	if entry.Auth != nil {
+		t.Fatalf("auth mutated to %#v, want nil", entry.Auth)
+	}
+	if got := entry.APIKeyEntries[0].APIKey; got != "static-key" {
+		t.Fatalf("api-key = %q, want static-key", got)
+	}
+}
+
+func TestPatchCodexRejectedCommandAuthDoesNotMutateConfig(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{cfg: &config.Config{CodexKey: []config.CodexKey{{
+		APIKey:  "static-key",
+		BaseURL: "https://proxy.example.com/v1",
+	}}}}
+	body := map[string]any{
+		"index": 0,
+		"value": map[string]any{
+			"auth": map[string]any{"command": "fetch-token"},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = jsonRequestBody(t, http.MethodPatch, "/v0/management/codex-api-key", body)
+
+	h.PatchCodexKey(c)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	entry := h.cfg.CodexKey[0]
+	if entry.Auth != nil {
+		t.Fatalf("auth mutated to %#v, want nil", entry.Auth)
+	}
+	if got := entry.APIKey; got != "static-key" {
+		t.Fatalf("api-key = %q, want static-key", got)
+	}
+}
+
+func jsonRequestBody(t *testing.T, method, target string, body any) *http.Request {
+	t.Helper()
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request body: %v", err)
+	}
+	req := httptest.NewRequest(method, target, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}

--- a/internal/api/handlers/management/config_lists_command_auth_test.go
+++ b/internal/api/handlers/management/config_lists_command_auth_test.go
@@ -78,6 +78,78 @@ func TestPatchCodexRejectedCommandAuthDoesNotMutateConfig(t *testing.T) {
 	}
 }
 
+func TestPatchCommandAuthRejectedDoesNotMutateConfigProviders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		h      *Handler
+		target string
+		patch  func(*Handler, *gin.Context)
+		check  func(*testing.T, *Handler)
+	}{
+		{
+			name:   "gemini",
+			h:      &Handler{cfg: &config.Config{GeminiKey: []config.GeminiKey{{APIKey: "static-key"}}}},
+			target: "/v0/management/gemini-api-key",
+			patch:  (*Handler).PatchGeminiKey,
+			check: func(t *testing.T, h *Handler) {
+				entry := h.cfg.GeminiKey[0]
+				if entry.Auth != nil || entry.APIKey != "static-key" {
+					t.Fatalf("gemini entry mutated to %#v", entry)
+				}
+			},
+		},
+		{
+			name:   "claude",
+			h:      &Handler{cfg: &config.Config{ClaudeKey: []config.ClaudeKey{{APIKey: "static-key"}}}},
+			target: "/v0/management/claude-api-key",
+			patch:  (*Handler).PatchClaudeKey,
+			check: func(t *testing.T, h *Handler) {
+				entry := h.cfg.ClaudeKey[0]
+				if entry.Auth != nil || entry.APIKey != "static-key" {
+					t.Fatalf("claude entry mutated to %#v", entry)
+				}
+			},
+		},
+		{
+			name:   "vertex",
+			h:      &Handler{cfg: &config.Config{VertexCompatAPIKey: []config.VertexCompatKey{{APIKey: "static-key"}}}},
+			target: "/v0/management/vertex-api-key",
+			patch:  (*Handler).PatchVertexCompatKey,
+			check: func(t *testing.T, h *Handler) {
+				entry := h.cfg.VertexCompatAPIKey[0]
+				if entry.Auth != nil || entry.APIKey != "static-key" {
+					t.Fatalf("vertex entry mutated to %#v", entry)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body := map[string]any{
+				"index": 0,
+				"value": map[string]any{
+					"auth": map[string]any{"command": "fetch-token"},
+				},
+			}
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = jsonRequestBody(t, http.MethodPatch, tt.target, body)
+
+			tt.patch(tt.h, c)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			tt.check(t, tt.h)
+		})
+	}
+}
+
 func jsonRequestBody(t *testing.T, method, target string, body any) *http.Request {
 	t.Helper()
 	data, err := json.Marshal(body)

--- a/internal/config/clone.go
+++ b/internal/config/clone.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"reflect"
+	"unsafe"
 
 	"gopkg.in/yaml.v3"
 )
@@ -44,10 +45,14 @@ func cloneRuntimeValue(v reflect.Value) reflect.Value {
 		out := reflect.New(v.Type()).Elem()
 		for i := 0; i < v.NumField(); i++ {
 			dst := out.Field(i)
+			src := v.Field(i)
 			if !dst.CanSet() {
-				return v
+				if !dst.CanAddr() || !src.Type().AssignableTo(dst.Type()) {
+					return v
+				}
+				dst = reflect.NewAt(dst.Type(), unsafe.Pointer(dst.UnsafeAddr())).Elem()
 			}
-			dst.Set(cloneRuntimeValue(v.Field(i)))
+			dst.Set(cloneRuntimeValue(src))
 		}
 		return out
 	case reflect.Slice:

--- a/internal/config/clone.go
+++ b/internal/config/clone.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"reflect"
-	"unsafe"
 
 	"gopkg.in/yaml.v3"
 )
@@ -47,10 +46,7 @@ func cloneRuntimeValue(v reflect.Value) reflect.Value {
 			dst := out.Field(i)
 			src := v.Field(i)
 			if !dst.CanSet() {
-				if !dst.CanAddr() || !src.Type().AssignableTo(dst.Type()) {
-					return v
-				}
-				dst = reflect.NewAt(dst.Type(), unsafe.Pointer(dst.UnsafeAddr())).Elem()
+				continue
 			}
 			dst.Set(cloneRuntimeValue(src))
 		}

--- a/internal/config/clone_test.go
+++ b/internal/config/clone_test.go
@@ -86,6 +86,32 @@ func TestCloneForRuntimeDoesNotShareReferenceFields(t *testing.T) {
 	assertNoSharedRuntimeReferences(t, reflect.ValueOf(cfg), reflect.ValueOf(clone), "Config")
 }
 
+func TestCloneForRuntimeCommandAuthDoesNotPanic(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte(`
+gemini-api-key:
+  - auth:
+      command: fetch-token
+codex-api-key:
+  - base-url: https://codex.example.com/v1
+    auth:
+      command: fetch-token
+`))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes error: %v", err)
+	}
+
+	clone := cfg.CloneForRuntime()
+	if clone == nil {
+		t.Fatal("CloneForRuntime returned nil")
+	}
+	if clone.GeminiKey[0].Auth == nil || clone.GeminiKey[0].Auth.Command != "fetch-token" {
+		t.Fatalf("gemini command auth clone = %#v", clone.GeminiKey[0].Auth)
+	}
+	if got := CommandAuthIdentity(clone.GeminiKey[0].Auth); got == "" {
+		t.Fatal("cloned gemini command auth identity is empty")
+	}
+}
+
 func sampleCloneRuntimeConfig() *Config {
 	cacheStrict := true
 	bypassStrict := false

--- a/internal/config/command_auth.go
+++ b/internal/config/command_auth.go
@@ -24,6 +24,13 @@ type CommandAuthConfig struct {
 	identity          string
 }
 
+// CommandAuthCapable is implemented by config entries that may use command auth.
+type CommandAuthCapable interface {
+	GetAPIKey() string
+	GetBaseURL() string
+	GetCommandAuth() *CommandAuthConfig
+}
+
 func (c *CommandAuthConfig) UnmarshalYAML(value *yaml.Node) error {
 	if c == nil {
 		return nil
@@ -72,6 +79,132 @@ func (c *CommandAuthConfig) UnmarshalJSON(data []byte) error {
 		out.RefreshIntervalMS = aliases.RefreshIntervalMS
 	}
 	*c = CommandAuthConfig(out)
+	return nil
+}
+
+func (k *GeminiKey) UnmarshalYAML(value *yaml.Node) error {
+	if k == nil {
+		return nil
+	}
+	type raw GeminiKey
+	var out raw
+	if value != nil {
+		if err := value.Decode(&out); err != nil {
+			return err
+		}
+		decodeYAMLStringAlias(value, "api_key", &out.APIKey)
+		decodeYAMLStringAlias(value, "base_url", &out.BaseURL)
+		decodeYAMLStringAlias(value, "proxy_url", &out.ProxyURL)
+		decodeYAMLStringSliceAlias(value, "excluded_models", &out.ExcludedModels)
+		decodeYAMLBoolAlias(value, "disable_cooling", &out.DisableCooling)
+	}
+	*k = GeminiKey(out)
+	return nil
+}
+
+func (k *GeminiKey) UnmarshalJSON(data []byte) error {
+	if k == nil {
+		return nil
+	}
+	type raw GeminiKey
+	var out raw
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	var aliases struct {
+		APIKey         string   `json:"api_key"`
+		BaseURL        string   `json:"base_url"`
+		ProxyURL       string   `json:"proxy_url"`
+		ExcludedModels []string `json:"excluded_models"`
+		DisableCooling bool     `json:"disable_cooling"`
+	}
+	if err := json.Unmarshal(data, &aliases); err != nil {
+		return err
+	}
+	if strings.TrimSpace(out.APIKey) == "" {
+		out.APIKey = aliases.APIKey
+	}
+	if strings.TrimSpace(out.BaseURL) == "" {
+		out.BaseURL = aliases.BaseURL
+	}
+	if strings.TrimSpace(out.ProxyURL) == "" {
+		out.ProxyURL = aliases.ProxyURL
+	}
+	if len(out.ExcludedModels) == 0 {
+		out.ExcludedModels = aliases.ExcludedModels
+	}
+	if !out.DisableCooling {
+		out.DisableCooling = aliases.DisableCooling
+	}
+	*k = GeminiKey(out)
+	return nil
+}
+
+func (k *ClaudeKey) UnmarshalYAML(value *yaml.Node) error {
+	if k == nil {
+		return nil
+	}
+	type raw ClaudeKey
+	var out raw
+	if value != nil {
+		if err := value.Decode(&out); err != nil {
+			return err
+		}
+		decodeYAMLStringAlias(value, "api_key", &out.APIKey)
+		decodeYAMLStringAlias(value, "base_url", &out.BaseURL)
+		decodeYAMLStringAlias(value, "proxy_url", &out.ProxyURL)
+		decodeYAMLStringSliceAlias(value, "excluded_models", &out.ExcludedModels)
+		decodeYAMLBoolAlias(value, "rebuild_mid_system_message", &out.RebuildMidSystemMessage)
+		decodeYAMLBoolAlias(value, "disable_cooling", &out.DisableCooling)
+		decodeYAMLBoolAlias(value, "experimental_cch_signing", &out.ExperimentalCCHSigning)
+	}
+	*k = ClaudeKey(out)
+	return nil
+}
+
+func (k *ClaudeKey) UnmarshalJSON(data []byte) error {
+	if k == nil {
+		return nil
+	}
+	type raw ClaudeKey
+	var out raw
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	var aliases struct {
+		APIKey                  string   `json:"api_key"`
+		BaseURL                 string   `json:"base_url"`
+		ProxyURL                string   `json:"proxy_url"`
+		ExcludedModels          []string `json:"excluded_models"`
+		RebuildMidSystemMessage bool     `json:"rebuild_mid_system_message"`
+		DisableCooling          bool     `json:"disable_cooling"`
+		ExperimentalCCHSigning  bool     `json:"experimental_cch_signing"`
+	}
+	if err := json.Unmarshal(data, &aliases); err != nil {
+		return err
+	}
+	if strings.TrimSpace(out.APIKey) == "" {
+		out.APIKey = aliases.APIKey
+	}
+	if strings.TrimSpace(out.BaseURL) == "" {
+		out.BaseURL = aliases.BaseURL
+	}
+	if strings.TrimSpace(out.ProxyURL) == "" {
+		out.ProxyURL = aliases.ProxyURL
+	}
+	if len(out.ExcludedModels) == 0 {
+		out.ExcludedModels = aliases.ExcludedModels
+	}
+	if !out.RebuildMidSystemMessage {
+		out.RebuildMidSystemMessage = aliases.RebuildMidSystemMessage
+	}
+	if !out.DisableCooling {
+		out.DisableCooling = aliases.DisableCooling
+	}
+	if !out.ExperimentalCCHSigning {
+		out.ExperimentalCCHSigning = aliases.ExperimentalCCHSigning
+	}
+	*k = ClaudeKey(out)
 	return nil
 }
 
@@ -221,6 +354,17 @@ func validateCommandAuth(section string, auth *CommandAuthConfig) error {
 	return nil
 }
 
+func validateCommandAuthEntry[T CommandAuthCapable](section string, entry T) error {
+	auth := entry.GetCommandAuth()
+	if err := validateCommandAuth(section, auth); err != nil {
+		return err
+	}
+	if auth != nil && strings.TrimSpace(entry.GetAPIKey()) != "" {
+		return fmt.Errorf("%s cannot set both api-key and auth", section)
+	}
+	return nil
+}
+
 // CommandAuthIdentity returns a stable non-secret identity for a command auth config.
 func CommandAuthIdentity(auth *CommandAuthConfig) string {
 	if auth == nil || strings.TrimSpace(auth.Command) == "" {
@@ -254,14 +398,24 @@ func (cfg *Config) ValidateCommandAuthConfig() error {
 	if cfg == nil {
 		return nil
 	}
-	for i := range cfg.CodexKey {
-		entry := &cfg.CodexKey[i]
-		section := fmt.Sprintf("codex-api-key[%d]", i)
-		if err := validateCommandAuth(section, entry.Auth); err != nil {
+	for i := range cfg.GeminiKey {
+		if err := validateCommandAuthEntry(fmt.Sprintf("gemini-api-key[%d]", i), cfg.GeminiKey[i]); err != nil {
 			return err
 		}
-		if entry.Auth != nil && strings.TrimSpace(entry.APIKey) != "" {
-			return fmt.Errorf("%s cannot set both api-key and auth", section)
+	}
+	for i := range cfg.ClaudeKey {
+		if err := validateCommandAuthEntry(fmt.Sprintf("claude-api-key[%d]", i), cfg.ClaudeKey[i]); err != nil {
+			return err
+		}
+	}
+	for i := range cfg.CodexKey {
+		if err := validateCommandAuthEntry(fmt.Sprintf("codex-api-key[%d]", i), cfg.CodexKey[i]); err != nil {
+			return err
+		}
+	}
+	for i := range cfg.VertexCompatAPIKey {
+		if err := validateCommandAuthEntry(fmt.Sprintf("vertex-api-key[%d]", i), cfg.VertexCompatAPIKey[i]); err != nil {
+			return err
 		}
 	}
 	for i := range cfg.OpenAICompatibility {

--- a/internal/config/command_auth.go
+++ b/internal/config/command_auth.go
@@ -21,6 +21,7 @@ type CommandAuthConfig struct {
 	Args              []string `yaml:"args,omitempty" json:"args,omitempty"`
 	TimeoutMS         int      `yaml:"timeout-ms,omitempty" json:"timeout-ms,omitempty"`
 	RefreshIntervalMS int      `yaml:"refresh-interval-ms,omitempty" json:"refresh-interval-ms,omitempty"`
+	identity          string
 }
 
 func (c *CommandAuthConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -200,6 +201,8 @@ func normalizeCommandAuth(auth *CommandAuthConfig) {
 	if auth.RefreshIntervalMS == 0 {
 		auth.RefreshIntervalMS = DefaultCommandAuthRefreshIntervalMS
 	}
+	auth.identity = ""
+	auth.identity = CommandAuthIdentity(auth)
 }
 
 func validateCommandAuth(section string, auth *CommandAuthConfig) error {
@@ -223,6 +226,9 @@ func CommandAuthIdentity(auth *CommandAuthConfig) string {
 	if auth == nil || strings.TrimSpace(auth.Command) == "" {
 		return ""
 	}
+	if auth.identity != "" {
+		return auth.identity
+	}
 	argsJSON, _ := json.Marshal(normalizedCommandAuthArgs(auth.Args))
 	sum := sha256.Sum256([]byte(strings.TrimSpace(auth.Command) + "\x00" + string(argsJSON)))
 	return hex.EncodeToString(sum[:])
@@ -240,11 +246,7 @@ func normalizedCommandAuthArgs(args []string) []string {
 	if len(args) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(args))
-	for _, arg := range args {
-		out = append(out, arg)
-	}
-	return out
+	return args
 }
 
 // ValidateCommandAuthConfig validates dynamic provider auth configuration.

--- a/internal/config/command_auth.go
+++ b/internal/config/command_auth.go
@@ -1,0 +1,319 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultCommandAuthTimeoutMS         = 5000
+	DefaultCommandAuthRefreshIntervalMS = 300000
+)
+
+// CommandAuthConfig configures a command that returns a bearer token on stdout.
+type CommandAuthConfig struct {
+	Command           string   `yaml:"command" json:"command"`
+	Args              []string `yaml:"args,omitempty" json:"args,omitempty"`
+	TimeoutMS         int      `yaml:"timeout-ms,omitempty" json:"timeout-ms,omitempty"`
+	RefreshIntervalMS int      `yaml:"refresh-interval-ms,omitempty" json:"refresh-interval-ms,omitempty"`
+}
+
+func (c *CommandAuthConfig) UnmarshalYAML(value *yaml.Node) error {
+	if c == nil {
+		return nil
+	}
+	type raw CommandAuthConfig
+	var out raw
+	if value != nil {
+		if err := value.Decode(&out); err != nil {
+			return err
+		}
+		if node := yamlMappingValue(value, "timeout_ms"); node != nil && out.TimeoutMS == 0 {
+			if err := node.Decode(&out.TimeoutMS); err != nil {
+				return fmt.Errorf("parse timeout_ms: %w", err)
+			}
+		}
+		if node := yamlMappingValue(value, "refresh_interval_ms"); node != nil && out.RefreshIntervalMS == 0 {
+			if err := node.Decode(&out.RefreshIntervalMS); err != nil {
+				return fmt.Errorf("parse refresh_interval_ms: %w", err)
+			}
+		}
+	}
+	*c = CommandAuthConfig(out)
+	return nil
+}
+
+func (c *CommandAuthConfig) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return nil
+	}
+	type raw CommandAuthConfig
+	var out raw
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	var aliases struct {
+		TimeoutMS         int `json:"timeout_ms"`
+		RefreshIntervalMS int `json:"refresh_interval_ms"`
+	}
+	if err := json.Unmarshal(data, &aliases); err != nil {
+		return err
+	}
+	if out.TimeoutMS == 0 && aliases.TimeoutMS != 0 {
+		out.TimeoutMS = aliases.TimeoutMS
+	}
+	if out.RefreshIntervalMS == 0 && aliases.RefreshIntervalMS != 0 {
+		out.RefreshIntervalMS = aliases.RefreshIntervalMS
+	}
+	*c = CommandAuthConfig(out)
+	return nil
+}
+
+func (k *CodexKey) UnmarshalYAML(value *yaml.Node) error {
+	if k == nil {
+		return nil
+	}
+	type raw CodexKey
+	var out raw
+	if value != nil {
+		if err := value.Decode(&out); err != nil {
+			return err
+		}
+		decodeYAMLStringAlias(value, "api_key", &out.APIKey)
+		decodeYAMLStringAlias(value, "base_url", &out.BaseURL)
+		decodeYAMLStringAlias(value, "proxy_url", &out.ProxyURL)
+		decodeYAMLStringSliceAlias(value, "excluded_models", &out.ExcludedModels)
+		decodeYAMLBoolAlias(value, "disable_cooling", &out.DisableCooling)
+	}
+	*k = CodexKey(out)
+	return nil
+}
+
+func (k *CodexKey) UnmarshalJSON(data []byte) error {
+	if k == nil {
+		return nil
+	}
+	type raw CodexKey
+	var out raw
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	var aliases struct {
+		APIKey         string   `json:"api_key"`
+		BaseURL        string   `json:"base_url"`
+		ProxyURL       string   `json:"proxy_url"`
+		ExcludedModels []string `json:"excluded_models"`
+		DisableCooling bool     `json:"disable_cooling"`
+	}
+	if err := json.Unmarshal(data, &aliases); err != nil {
+		return err
+	}
+	if strings.TrimSpace(out.APIKey) == "" {
+		out.APIKey = aliases.APIKey
+	}
+	if strings.TrimSpace(out.BaseURL) == "" {
+		out.BaseURL = aliases.BaseURL
+	}
+	if strings.TrimSpace(out.ProxyURL) == "" {
+		out.ProxyURL = aliases.ProxyURL
+	}
+	if len(out.ExcludedModels) == 0 {
+		out.ExcludedModels = aliases.ExcludedModels
+	}
+	if !out.DisableCooling {
+		out.DisableCooling = aliases.DisableCooling
+	}
+	*k = CodexKey(out)
+	return nil
+}
+
+func (c *OpenAICompatibility) UnmarshalYAML(value *yaml.Node) error {
+	if c == nil {
+		return nil
+	}
+	type raw OpenAICompatibility
+	var out raw
+	if value != nil {
+		if err := value.Decode(&out); err != nil {
+			return err
+		}
+		decodeYAMLStringAlias(value, "base_url", &out.BaseURL)
+		decodeYAMLStringAlias(value, "proxy_url", &out.ProxyURL)
+		decodeYAMLBoolAlias(value, "disable_cooling", &out.DisableCooling)
+		if node := yamlMappingValue(value, "api_key_entries"); node != nil && len(out.APIKeyEntries) == 0 {
+			if err := node.Decode(&out.APIKeyEntries); err != nil {
+				return fmt.Errorf("parse api_key_entries: %w", err)
+			}
+		}
+	}
+	*c = OpenAICompatibility(out)
+	return nil
+}
+
+func (c *OpenAICompatibility) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return nil
+	}
+	type raw OpenAICompatibility
+	var out raw
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	var aliases struct {
+		BaseURL        string                      `json:"base_url"`
+		ProxyURL       string                      `json:"proxy_url"`
+		APIKeyEntries  []OpenAICompatibilityAPIKey `json:"api_key_entries"`
+		DisableCooling bool                        `json:"disable_cooling"`
+	}
+	if err := json.Unmarshal(data, &aliases); err != nil {
+		return err
+	}
+	if strings.TrimSpace(out.BaseURL) == "" {
+		out.BaseURL = aliases.BaseURL
+	}
+	if strings.TrimSpace(out.ProxyURL) == "" {
+		out.ProxyURL = aliases.ProxyURL
+	}
+	if len(out.APIKeyEntries) == 0 {
+		out.APIKeyEntries = aliases.APIKeyEntries
+	}
+	if !out.DisableCooling {
+		out.DisableCooling = aliases.DisableCooling
+	}
+	*c = OpenAICompatibility(out)
+	return nil
+}
+
+func normalizeCommandAuth(auth *CommandAuthConfig) {
+	if auth == nil {
+		return
+	}
+	auth.Command = strings.TrimSpace(auth.Command)
+	if auth.TimeoutMS == 0 {
+		auth.TimeoutMS = DefaultCommandAuthTimeoutMS
+	}
+	if auth.RefreshIntervalMS == 0 {
+		auth.RefreshIntervalMS = DefaultCommandAuthRefreshIntervalMS
+	}
+}
+
+func validateCommandAuth(section string, auth *CommandAuthConfig) error {
+	if auth == nil {
+		return nil
+	}
+	if strings.TrimSpace(auth.Command) == "" {
+		return fmt.Errorf("%s auth.command is required", section)
+	}
+	if auth.TimeoutMS < 0 {
+		return fmt.Errorf("%s auth.timeout-ms must be non-negative", section)
+	}
+	if auth.RefreshIntervalMS < 0 {
+		return fmt.Errorf("%s auth.refresh-interval-ms must be non-negative", section)
+	}
+	return nil
+}
+
+// CommandAuthIdentity returns a stable non-secret identity for a command auth config.
+func CommandAuthIdentity(auth *CommandAuthConfig) string {
+	if auth == nil || strings.TrimSpace(auth.Command) == "" {
+		return ""
+	}
+	argsJSON, _ := json.Marshal(normalizedCommandAuthArgs(auth.Args))
+	sum := sha256.Sum256([]byte(strings.TrimSpace(auth.Command) + "\x00" + string(argsJSON)))
+	return hex.EncodeToString(sum[:])
+}
+
+func CommandAuthArgsJSON(auth *CommandAuthConfig) string {
+	if auth == nil {
+		return "[]"
+	}
+	argsJSON, _ := json.Marshal(normalizedCommandAuthArgs(auth.Args))
+	return string(argsJSON)
+}
+
+func normalizedCommandAuthArgs(args []string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(args))
+	for _, arg := range args {
+		out = append(out, arg)
+	}
+	return out
+}
+
+// ValidateCommandAuthConfig validates dynamic provider auth configuration.
+func (cfg *Config) ValidateCommandAuthConfig() error {
+	if cfg == nil {
+		return nil
+	}
+	for i := range cfg.CodexKey {
+		entry := &cfg.CodexKey[i]
+		section := fmt.Sprintf("codex-api-key[%d]", i)
+		if err := validateCommandAuth(section, entry.Auth); err != nil {
+			return err
+		}
+		if entry.Auth != nil && strings.TrimSpace(entry.APIKey) != "" {
+			return fmt.Errorf("%s cannot set both api-key and auth", section)
+		}
+	}
+	for i := range cfg.OpenAICompatibility {
+		entry := &cfg.OpenAICompatibility[i]
+		section := fmt.Sprintf("openai-compatibility[%d]", i)
+		if err := validateCommandAuth(section, entry.Auth); err != nil {
+			return err
+		}
+		if entry.Auth != nil {
+			for j := range entry.APIKeyEntries {
+				if strings.TrimSpace(entry.APIKeyEntries[j].APIKey) != "" {
+					return fmt.Errorf("%s cannot set both api-key-entries[%d].api-key and auth", section, j)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func yamlMappingValue(value *yaml.Node, key string) *yaml.Node {
+	if value == nil || value.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		if value.Content[i] != nil && value.Content[i].Value == key {
+			return value.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func decodeYAMLStringAlias(value *yaml.Node, key string, target *string) {
+	if target == nil || strings.TrimSpace(*target) != "" {
+		return
+	}
+	if node := yamlMappingValue(value, key); node != nil {
+		_ = node.Decode(target)
+	}
+}
+
+func decodeYAMLBoolAlias(value *yaml.Node, key string, target *bool) {
+	if target == nil || *target {
+		return
+	}
+	if node := yamlMappingValue(value, key); node != nil {
+		_ = node.Decode(target)
+	}
+}
+
+func decodeYAMLStringSliceAlias(value *yaml.Node, key string, target *[]string) {
+	if target == nil || len(*target) > 0 {
+		return
+	}
+	if node := yamlMappingValue(value, key); node != nil {
+		_ = node.Decode(target)
+	}
+}

--- a/internal/config/command_auth_test.go
+++ b/internal/config/command_auth_test.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseConfigBytes_CommandAuthAliasesAndDefaults(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte(`
+codex-api-key:
+  - base_url: https://proxy.example.com/v1
+    auth:
+      command: /usr/local/bin/fetch-token
+      args: ["--audience", " codex "]
+    models:
+      - name: gpt-5-codex
+        alias: gpt-5-codex
+openai-compatibility:
+  - name: proxy
+    base_url: https://proxy.example.com/v1
+    proxy_url: http://proxy.local
+    auth:
+      command: fetch-openai-token
+      timeout_ms: 7000
+      refresh_interval_ms: 9000
+    models:
+      - name: gpt-5
+        alias: gpt-5
+`))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes error: %v", err)
+	}
+	if len(cfg.CodexKey) != 1 {
+		t.Fatalf("codex key count = %d, want 1", len(cfg.CodexKey))
+	}
+	codex := cfg.CodexKey[0]
+	if codex.BaseURL != "https://proxy.example.com/v1" {
+		t.Fatalf("codex base-url = %q", codex.BaseURL)
+	}
+	if codex.Auth == nil {
+		t.Fatal("codex auth is nil")
+	}
+	if codex.Auth.TimeoutMS != DefaultCommandAuthTimeoutMS {
+		t.Fatalf("codex timeout-ms = %d, want default %d", codex.Auth.TimeoutMS, DefaultCommandAuthTimeoutMS)
+	}
+	if codex.Auth.RefreshIntervalMS != DefaultCommandAuthRefreshIntervalMS {
+		t.Fatalf("codex refresh-interval-ms = %d, want default %d", codex.Auth.RefreshIntervalMS, DefaultCommandAuthRefreshIntervalMS)
+	}
+	if len(codex.Auth.Args) != 2 || codex.Auth.Args[1] != " codex " {
+		t.Fatalf("codex auth args = %#v, want second arg with surrounding spaces preserved", codex.Auth.Args)
+	}
+
+	if len(cfg.OpenAICompatibility) != 1 {
+		t.Fatalf("openai compat count = %d, want 1", len(cfg.OpenAICompatibility))
+	}
+	compat := cfg.OpenAICompatibility[0]
+	if compat.BaseURL != "https://proxy.example.com/v1" {
+		t.Fatalf("compat base-url = %q", compat.BaseURL)
+	}
+	if compat.ProxyURL != "http://proxy.local" {
+		t.Fatalf("compat proxy-url = %q", compat.ProxyURL)
+	}
+	if compat.Auth == nil {
+		t.Fatal("compat auth is nil")
+	}
+	if compat.Auth.TimeoutMS != 7000 || compat.Auth.RefreshIntervalMS != 9000 {
+		t.Fatalf("compat auth timings = %d/%d, want 7000/9000", compat.Auth.TimeoutMS, compat.Auth.RefreshIntervalMS)
+	}
+}
+
+func TestParseConfigBytes_CommandAuthAidenExample(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte(`
+openai-compatibility:
+  - name: aiden
+    base_url: https://aiden-aiproxy.bytedance.net/v2
+    auth:
+      command: aiden
+      args: ["auth", "get-sso-token"]
+    models:
+      - name: gpt-5.4
+        alias: aiden-live-test
+`))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes error: %v", err)
+	}
+	if len(cfg.OpenAICompatibility) != 1 {
+		t.Fatalf("openai compat count = %d, want 1", len(cfg.OpenAICompatibility))
+	}
+	compat := cfg.OpenAICompatibility[0]
+	if compat.BaseURL != "https://aiden-aiproxy.bytedance.net/v2" {
+		t.Fatalf("base-url = %q", compat.BaseURL)
+	}
+	if compat.Auth == nil {
+		t.Fatal("auth is nil")
+	}
+	if compat.Auth.Command != "aiden" {
+		t.Fatalf("auth command = %q", compat.Auth.Command)
+	}
+	if len(compat.Auth.Args) != 2 || compat.Auth.Args[0] != "auth" || compat.Auth.Args[1] != "get-sso-token" {
+		t.Fatalf("auth args = %#v", compat.Auth.Args)
+	}
+}
+
+func TestParseConfigBytes_CommandAuthRejectsStaticKeyConflict(t *testing.T) {
+	_, err := ParseConfigBytes([]byte(`
+codex-api-key:
+  - api-key: static-key
+    base-url: https://proxy.example.com/v1
+    auth:
+      command: fetch-token
+`))
+	if err == nil || !strings.Contains(err.Error(), "cannot set both api-key and auth") {
+		t.Fatalf("error = %v, want api-key/auth conflict", err)
+	}
+
+	_, err = ParseConfigBytes([]byte(`
+openai-compatibility:
+  - name: proxy
+    base-url: https://proxy.example.com/v1
+    auth:
+      command: fetch-token
+    api-key-entries:
+      - api-key: static-key
+`))
+	if err == nil || !strings.Contains(err.Error(), "cannot set both api-key-entries") {
+		t.Fatalf("error = %v, want api-key-entries/auth conflict", err)
+	}
+}

--- a/internal/config/command_auth_test.go
+++ b/internal/config/command_auth_test.go
@@ -101,6 +101,31 @@ openai-compatibility:
 	}
 }
 
+func TestCommandAuthIdentityCachedAfterParse(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte(`
+codex-api-key:
+  - base-url: https://proxy.example.com/v1
+    auth:
+      command: fetch-token
+      args: ["--audience", "codex"]
+`))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes error: %v", err)
+	}
+	auth := cfg.CodexKey[0].Auth
+	if auth == nil {
+		t.Fatal("auth is nil")
+	}
+	identity := CommandAuthIdentity(auth)
+	if identity == "" {
+		t.Fatal("identity is empty")
+	}
+	auth.Args = []string{"mutated"}
+	if got := CommandAuthIdentity(auth); got != identity {
+		t.Fatalf("cached identity changed to %q, want %q", got, identity)
+	}
+}
+
 func TestParseConfigBytes_CommandAuthRejectsStaticKeyConflict(t *testing.T) {
 	_, err := ParseConfigBytes([]byte(`
 codex-api-key:

--- a/internal/config/command_auth_test.go
+++ b/internal/config/command_auth_test.go
@@ -7,6 +7,12 @@ import (
 
 func TestParseConfigBytes_CommandAuthAliasesAndDefaults(t *testing.T) {
 	cfg, err := ParseConfigBytes([]byte(`
+gemini-api-key:
+  - auth:
+      command: fetch-gemini-token
+claude-api-key:
+  - auth:
+      command: fetch-claude-token
 codex-api-key:
   - base_url: https://proxy.example.com/v1
     auth:
@@ -29,6 +35,12 @@ openai-compatibility:
 `))
 	if err != nil {
 		t.Fatalf("ParseConfigBytes error: %v", err)
+	}
+	if len(cfg.GeminiKey) != 1 || cfg.GeminiKey[0].Auth == nil || cfg.GeminiKey[0].Auth.Command != "fetch-gemini-token" {
+		t.Fatalf("gemini command auth = %#v", cfg.GeminiKey)
+	}
+	if len(cfg.ClaudeKey) != 1 || cfg.ClaudeKey[0].Auth == nil || cfg.ClaudeKey[0].Auth.Command != "fetch-claude-token" {
+		t.Fatalf("claude command auth = %#v", cfg.ClaudeKey)
 	}
 	if len(cfg.CodexKey) != 1 {
 		t.Fatalf("codex key count = %d, want 1", len(cfg.CodexKey))
@@ -136,6 +148,36 @@ codex-api-key:
 `))
 	if err == nil || !strings.Contains(err.Error(), "cannot set both api-key and auth") {
 		t.Fatalf("error = %v, want api-key/auth conflict", err)
+	}
+
+	_, err = ParseConfigBytes([]byte(`
+gemini-api-key:
+  - api-key: static-key
+    auth:
+      command: fetch-token
+`))
+	if err == nil || !strings.Contains(err.Error(), "cannot set both api-key and auth") {
+		t.Fatalf("error = %v, want gemini api-key/auth conflict", err)
+	}
+
+	_, err = ParseConfigBytes([]byte(`
+claude-api-key:
+  - api-key: static-key
+    auth:
+      command: fetch-token
+`))
+	if err == nil || !strings.Contains(err.Error(), "cannot set both api-key and auth") {
+		t.Fatalf("error = %v, want claude api-key/auth conflict", err)
+	}
+
+	_, err = ParseConfigBytes([]byte(`
+vertex-api-key:
+  - api-key: static-key
+    auth:
+      command: fetch-token
+`))
+	if err == nil || !strings.Contains(err.Error(), "cannot set both api-key and auth") {
+		t.Fatalf("error = %v, want vertex api-key/auth conflict", err)
 	}
 
 	_, err = ParseConfigBytes([]byte(`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -438,6 +438,10 @@ type ClaudeKey struct {
 	// APIKey is the authentication key for accessing Claude API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
+	// Auth executes a command to obtain a token before upstream requests.
+	// Mutually exclusive with APIKey.
+	Auth *CommandAuthConfig `yaml:"auth,omitempty" json:"auth,omitempty"`
+
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
@@ -478,6 +482,9 @@ type ClaudeKey struct {
 
 func (k ClaudeKey) GetAPIKey() string  { return k.APIKey }
 func (k ClaudeKey) GetBaseURL() string { return k.BaseURL }
+func (k ClaudeKey) GetCommandAuth() *CommandAuthConfig {
+	return k.Auth
+}
 
 // ClaudeModel describes a mapping between an alias and the actual upstream model name.
 type ClaudeModel struct {
@@ -537,6 +544,9 @@ type CodexKey struct {
 
 func (k CodexKey) GetAPIKey() string  { return k.APIKey }
 func (k CodexKey) GetBaseURL() string { return k.BaseURL }
+func (k CodexKey) GetCommandAuth() *CommandAuthConfig {
+	return k.Auth
+}
 
 // CodexModel describes a mapping between an alias and the actual upstream model name.
 type CodexModel struct {
@@ -559,6 +569,10 @@ func (m CodexModel) GetForceMapping() bool { return m.ForceMapping }
 type GeminiKey struct {
 	// APIKey is the authentication key for accessing Gemini API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// Auth executes a command to obtain a token before upstream requests.
+	// Mutually exclusive with APIKey.
+	Auth *CommandAuthConfig `yaml:"auth,omitempty" json:"auth,omitempty"`
 
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
@@ -588,6 +602,9 @@ type GeminiKey struct {
 
 func (k GeminiKey) GetAPIKey() string  { return k.APIKey }
 func (k GeminiKey) GetBaseURL() string { return k.BaseURL }
+func (k GeminiKey) GetCommandAuth() *CommandAuthConfig {
+	return k.Auth
+}
 
 // GeminiModel describes a mapping between an alias and the actual upstream model name.
 type GeminiModel struct {
@@ -1024,9 +1041,13 @@ func (cfg *Config) SanitizeClaudeKeys() {
 	}
 	for i := range cfg.ClaudeKey {
 		entry := &cfg.ClaudeKey[i]
+		entry.APIKey = strings.TrimSpace(entry.APIKey)
 		entry.Prefix = normalizeModelPrefix(entry.Prefix)
+		entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
+		normalizeCommandAuth(entry.Auth)
 	}
 }
 
@@ -1042,7 +1063,8 @@ func (cfg *Config) SanitizeGeminiKeys() {
 	for i := range cfg.GeminiKey {
 		entry := cfg.GeminiKey[i]
 		entry.APIKey = strings.TrimSpace(entry.APIKey)
-		if entry.APIKey == "" {
+		normalizeCommandAuth(entry.Auth)
+		if entry.APIKey == "" && (entry.Auth == nil || strings.TrimSpace(entry.Auth.Command) == "") {
 			continue
 		}
 		entry.Prefix = normalizeModelPrefix(entry.Prefix)
@@ -1051,6 +1073,9 @@ func (cfg *Config) SanitizeGeminiKeys() {
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
 		uniqueKey := entry.APIKey + "|" + entry.BaseURL
+		if entry.APIKey == "" {
+			uniqueKey = CommandAuthIdentity(entry.Auth) + "|" + entry.BaseURL
+		}
 		if _, exists := seen[uniqueKey]; exists {
 			continue
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -501,6 +501,10 @@ type CodexKey struct {
 	// APIKey is the authentication key for accessing Codex API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
+	// Auth executes a command to obtain a bearer token before upstream requests.
+	// Mutually exclusive with APIKey.
+	Auth *CommandAuthConfig `yaml:"auth,omitempty" json:"auth,omitempty"`
+
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
@@ -619,6 +623,13 @@ type OpenAICompatibility struct {
 
 	// BaseURL is the base URL for the external OpenAI-compatible API endpoint.
 	BaseURL string `yaml:"base-url" json:"base-url"`
+
+	// ProxyURL overrides the global proxy setting for command-auth providers if provided.
+	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
+
+	// Auth executes a command to obtain a bearer token before upstream requests.
+	// Mutually exclusive with non-empty APIKeyEntries.
+	Auth *CommandAuthConfig `yaml:"auth,omitempty" json:"auth,omitempty"`
 
 	// APIKeyEntries defines API keys with optional per-key proxy configuration.
 	APIKeyEntries []OpenAICompatibilityAPIKey `yaml:"api-key-entries,omitempty" json:"api-key-entries,omitempty"`
@@ -806,6 +817,10 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Validate raw payload rules and drop invalid entries.
 	cfg.SanitizePayloadRules()
 
+	if err = cfg.ValidateCommandAuthConfig(); err != nil {
+		return nil, fmt.Errorf("invalid command auth config: %w", err)
+	}
+
 	// Return the populated configuration struct.
 	return &cfg, nil
 }
@@ -966,7 +981,9 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 		e.Name = strings.TrimSpace(e.Name)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.ProxyURL = strings.TrimSpace(e.ProxyURL)
 		e.Headers = NormalizeHeaders(e.Headers)
+		normalizeCommandAuth(e.Auth)
 		if e.BaseURL == "" {
 			// Skip providers with no base-url; treated as removed
 			continue
@@ -985,10 +1002,13 @@ func (cfg *Config) SanitizeCodexKeys() {
 	out := make([]CodexKey, 0, len(cfg.CodexKey))
 	for i := range cfg.CodexKey {
 		e := cfg.CodexKey[i]
+		e.APIKey = strings.TrimSpace(e.APIKey)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.ProxyURL = strings.TrimSpace(e.ProxyURL)
 		e.Headers = NormalizeHeaders(e.Headers)
 		e.ExcludedModels = NormalizeExcludedModels(e.ExcludedModels)
+		normalizeCommandAuth(e.Auth)
 		if e.BaseURL == "" {
 			continue
 		}

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -87,6 +87,9 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	cfg.OAuthExcludedModels = NormalizeOAuthExcludedModels(cfg.OAuthExcludedModels)
 	cfg.SanitizeOAuthModelAlias()
 	cfg.SanitizePayloadRules()
+	if err := cfg.ValidateCommandAuthConfig(); err != nil {
+		return nil, fmt.Errorf("invalid command auth config: %w", err)
+	}
 
 	return &cfg, nil
 }

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -1,6 +1,12 @@
 package config
 
-import "strings"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
 
 // VertexCompatKey represents the configuration for Vertex AI-compatible API keys.
 // This supports third-party services that use Vertex AI-style endpoint paths
@@ -12,6 +18,10 @@ type VertexCompatKey struct {
 	// APIKey is the authentication key for accessing the Vertex-compatible API.
 	// Maps to the x-goog-api-key header.
 	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// Auth executes a command to obtain a token before upstream requests.
+	// Mutually exclusive with APIKey.
+	Auth *CommandAuthConfig `yaml:"auth,omitempty" json:"auth,omitempty"`
 
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
@@ -39,8 +49,64 @@ type VertexCompatKey struct {
 	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
 }
 
+func (k *VertexCompatKey) UnmarshalYAML(value *yaml.Node) error {
+	if k == nil {
+		return nil
+	}
+	type raw VertexCompatKey
+	var out raw
+	if value != nil {
+		if err := value.Decode(&out); err != nil {
+			return err
+		}
+		decodeYAMLStringAlias(value, "api_key", &out.APIKey)
+		decodeYAMLStringAlias(value, "base_url", &out.BaseURL)
+		decodeYAMLStringAlias(value, "proxy_url", &out.ProxyURL)
+		decodeYAMLStringSliceAlias(value, "excluded_models", &out.ExcludedModels)
+	}
+	*k = VertexCompatKey(out)
+	return nil
+}
+
+func (k *VertexCompatKey) UnmarshalJSON(data []byte) error {
+	if k == nil {
+		return nil
+	}
+	type raw VertexCompatKey
+	var out raw
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	var aliases struct {
+		APIKey         string   `json:"api_key"`
+		BaseURL        string   `json:"base_url"`
+		ProxyURL       string   `json:"proxy_url"`
+		ExcludedModels []string `json:"excluded_models"`
+	}
+	if err := json.Unmarshal(data, &aliases); err != nil {
+		return fmt.Errorf("parse vertex-api-key aliases: %w", err)
+	}
+	if strings.TrimSpace(out.APIKey) == "" {
+		out.APIKey = aliases.APIKey
+	}
+	if strings.TrimSpace(out.BaseURL) == "" {
+		out.BaseURL = aliases.BaseURL
+	}
+	if strings.TrimSpace(out.ProxyURL) == "" {
+		out.ProxyURL = aliases.ProxyURL
+	}
+	if len(out.ExcludedModels) == 0 {
+		out.ExcludedModels = aliases.ExcludedModels
+	}
+	*k = VertexCompatKey(out)
+	return nil
+}
+
 func (k VertexCompatKey) GetAPIKey() string  { return k.APIKey }
 func (k VertexCompatKey) GetBaseURL() string { return k.BaseURL }
+func (k VertexCompatKey) GetCommandAuth() *CommandAuthConfig {
+	return k.Auth
+}
 
 // VertexCompatModel represents a model configuration for Vertex compatibility,
 // including the actual model name and its alias for API routing.
@@ -70,7 +136,8 @@ func (cfg *Config) SanitizeVertexCompatKeys() {
 	for i := range cfg.VertexCompatAPIKey {
 		entry := cfg.VertexCompatAPIKey[i]
 		entry.APIKey = strings.TrimSpace(entry.APIKey)
-		if entry.APIKey == "" {
+		normalizeCommandAuth(entry.Auth)
+		if entry.APIKey == "" && (entry.Auth == nil || strings.TrimSpace(entry.Auth.Command) == "") {
 			continue
 		}
 		entry.Prefix = normalizeModelPrefix(entry.Prefix)
@@ -92,6 +159,9 @@ func (cfg *Config) SanitizeVertexCompatKeys() {
 
 		// Use API key + base URL as uniqueness key
 		uniqueKey := entry.APIKey + "|" + entry.BaseURL
+		if entry.APIKey == "" {
+			uniqueKey = CommandAuthIdentity(entry.Auth) + "|" + entry.BaseURL
+		}
 		if _, exists := seen[uniqueKey]; exists {
 			continue
 		}

--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -53,12 +53,23 @@ func (e *AIStudioExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.
 	if req == nil {
 		return nil
 	}
+	if token := commandAuthMetadataToken(auth); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 	var attrs map[string]string
 	if auth != nil {
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(req, attrs)
 	return nil
+}
+
+func (e *AIStudioExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool {
+	return helps.ShouldPrepareCommandAuth(auth)
+}
+
+func (e *AIStudioExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return helps.PrepareCommandAuth(ctx, auth)
 }
 
 // HttpRequest forwards an arbitrary HTTP request through the websocket relay.
@@ -144,6 +155,9 @@ func (e *AIStudioExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth,
 		Headers: http.Header{"Content-Type": []string{"application/json"}},
 		Body:    body.payload,
 	}
+	if token := commandAuthMetadataToken(auth); token != "" {
+		wsReq.Headers.Set("Authorization", "Bearer "+token)
+	}
 	var attrs map[string]string
 	if auth != nil {
 		attrs = auth.Attributes
@@ -212,6 +226,9 @@ func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth
 		URL:     endpoint,
 		Headers: http.Header{"Content-Type": []string{"application/json"}},
 		Body:    body.payload,
+	}
+	if token := commandAuthMetadataToken(auth); token != "" {
+		wsReq.Headers.Set("Authorization", "Bearer "+token)
 	}
 	var attrs map[string]string
 	if auth != nil {
@@ -392,6 +409,9 @@ func (e *AIStudioExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.A
 		Headers: http.Header{"Content-Type": []string{"application/json"}},
 		Body:    body.payload,
 	}
+	if token := commandAuthMetadataToken(auth); token != "" {
+		wsReq.Headers.Set("Authorization", "Bearer "+token)
+	}
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -432,6 +452,9 @@ func (e *AIStudioExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.A
 
 // Refresh refreshes the authentication credentials (no-op for AI Studio).
 func (e *AIStudioExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	if helps.ShouldPrepareCommandAuth(auth) {
+		return helps.PrepareCommandAuth(ctx, auth)
+	}
 	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
 		return refreshed, err
 	}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1602,6 +1602,9 @@ attemptLoop:
 
 // Refresh refreshes the authentication credentials using the refresh token.
 func (e *AntigravityExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	if helps.ShouldPrepareCommandAuth(auth) {
+		return helps.PrepareCommandAuth(ctx, auth)
+	}
 	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
 		return refreshed, err
 	}
@@ -1616,7 +1619,7 @@ func (e *AntigravityExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Au
 }
 
 func (e *AntigravityExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool {
-	return antigravityProjectIDFromAuth(auth) == ""
+	return helps.ShouldPrepareCommandAuth(auth) || antigravityProjectIDFromAuth(auth) == ""
 }
 
 func (e *AntigravityExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
@@ -1625,6 +1628,20 @@ func (e *AntigravityExecutor) PrepareRequestAuth(ctx context.Context, auth *clip
 	}
 
 	updated := auth.Clone()
+	if helps.ShouldPrepareCommandAuth(updated) {
+		prepared, errPrepare := helps.PrepareCommandAuth(ctx, updated)
+		if errPrepare != nil {
+			return nil, errPrepare
+		}
+		if prepared != nil {
+			updated = prepared
+		}
+	}
+
+	if antigravityProjectIDFromAuth(updated) != "" {
+		return updated, nil
+	}
+
 	token, refreshedAuth, errToken := e.ensureAccessToken(ctx, updated)
 	if errToken != nil {
 		return nil, errToken
@@ -1817,6 +1834,13 @@ func (e *AntigravityExecutor) ensureAccessToken(ctx context.Context, auth *clipr
 		return "", nil, statusErr{code: http.StatusUnauthorized, msg: "missing auth"}
 	}
 	accessToken := metaStringValue(auth.Metadata, "access_token")
+	if cliproxyauth.IsCommandAuth(auth) {
+		if strings.TrimSpace(accessToken) == "" {
+			return "", nil, statusErr{code: http.StatusUnauthorized, msg: "missing command auth access token"}
+		}
+		e.maybeRefreshAntigravityCreditsHint(ctx, auth, accessToken)
+		return accessToken, nil, nil
+	}
 	expiry := tokenExpiry(auth.Metadata)
 	if accessToken != "" && expiry.After(time.Now().Add(refreshSkew)) {
 		e.maybeRefreshAntigravityCreditsHint(ctx, auth, accessToken)

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -798,6 +798,9 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 
 func (e *ClaudeExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
 	log.Debugf("claude executor: refresh called")
+	if helps.ShouldPrepareCommandAuth(auth) {
+		return helps.PrepareCommandAuth(ctx, auth)
+	}
 	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
 		return refreshed, err
 	}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -179,6 +179,14 @@ func (e *ClaudeExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Au
 	return nil
 }
 
+func (e *ClaudeExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool {
+	return helps.ShouldPrepareCommandAuth(auth)
+}
+
+func (e *ClaudeExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return helps.PrepareCommandAuth(ctx, auth)
+}
+
 // HttpRequest injects Claude credentials into the request and executes it.
 func (e *ClaudeExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
 	if req == nil {

--- a/internal/runtime/executor/claude_signing.go
+++ b/internal/runtime/executor/claude_signing.go
@@ -46,6 +46,22 @@ func resolveClaudeKeyConfig(cfg *config.Config, auth *cliproxyauth.Auth) *config
 	}
 
 	apiKey, baseURL := claudeCreds(auth)
+	attrCommandKey := ""
+	if auth.Attributes != nil {
+		attrCommandKey = strings.TrimSpace(auth.Attributes[cliproxyauth.AttrAuthCommandKey])
+	}
+	if attrCommandKey != "" {
+		for i := range cfg.ClaudeKey {
+			entry := &cfg.ClaudeKey[i]
+			cfgCommandKey := config.CommandAuthIdentity(entry.Auth)
+			cfgBase := strings.TrimSpace(entry.BaseURL)
+			if cfgCommandKey != "" && strings.EqualFold(attrCommandKey, cfgCommandKey) {
+				if cfgBase == "" || baseURL == "" || strings.EqualFold(cfgBase, baseURL) {
+					return entry
+				}
+			}
+		}
+	}
 	if apiKey == "" {
 		return nil
 	}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1880,22 +1880,17 @@ func (e *CodexExecutor) resolveCodexConfig(auth *cliproxyauth.Auth) *config.Code
 	if auth == nil || e.cfg == nil {
 		return nil
 	}
-	var attrKey, attrBase, attrCommandKey string
+	var attrKey, attrBase string
 	if auth.Attributes != nil {
 		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
 		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
-		attrCommandKey = strings.TrimSpace(auth.Attributes[cliproxyauth.AttrAuthCommandKey])
 	}
 	for i := range e.cfg.CodexKey {
 		entry := &e.cfg.CodexKey[i]
 		cfgKey := strings.TrimSpace(entry.APIKey)
 		cfgBase := strings.TrimSpace(entry.BaseURL)
-		cfgCommandKey := config.CommandAuthIdentity(entry.Auth)
-		if attrCommandKey != "" && cfgCommandKey != "" && strings.EqualFold(attrCommandKey, cfgCommandKey) {
-			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
-				return entry
-			}
-			continue
+		if commandAuthMatches(entry.Auth, cfgBase, attrBase, auth) {
+			return entry
 		}
 		if attrKey != "" && attrBase != "" {
 			if strings.EqualFold(cfgKey, attrKey) && strings.EqualFold(cfgBase, attrBase) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1371,6 +1371,9 @@ func countCodexInputTokens(enc tokenizer.Codec, body []byte) (int64, error) {
 
 func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
 	log.Debugf("codex executor: refresh called")
+	if helps.ShouldPrepareCommandAuth(auth) {
+		return helps.PrepareCommandAuth(ctx, auth)
+	}
 	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
 		return refreshed, err
 	}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -722,6 +722,14 @@ func (e *CodexExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Aut
 	return nil
 }
 
+func (e *CodexExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool {
+	return helps.ShouldPrepareCommandAuth(auth)
+}
+
+func (e *CodexExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return helps.PrepareCommandAuth(ctx, auth)
+}
+
 // HttpRequest injects Codex credentials into the request and executes it.
 func (e *CodexExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
 	if req == nil {
@@ -1872,15 +1880,23 @@ func (e *CodexExecutor) resolveCodexConfig(auth *cliproxyauth.Auth) *config.Code
 	if auth == nil || e.cfg == nil {
 		return nil
 	}
-	var attrKey, attrBase string
+	var attrKey, attrBase, attrCommandKey string
 	if auth.Attributes != nil {
 		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
 		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+		attrCommandKey = strings.TrimSpace(auth.Attributes[cliproxyauth.AttrAuthCommandKey])
 	}
 	for i := range e.cfg.CodexKey {
 		entry := &e.cfg.CodexKey[i]
 		cfgKey := strings.TrimSpace(entry.APIKey)
 		cfgBase := strings.TrimSpace(entry.BaseURL)
+		cfgCommandKey := config.CommandAuthIdentity(entry.Auth)
+		if attrCommandKey != "" && cfgCommandKey != "" && strings.EqualFold(attrCommandKey, cfgCommandKey) {
+			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
+			continue
+		}
 		if attrKey != "" && attrBase != "" {
 			if strings.EqualFold(cfgKey, attrKey) && strings.EqualFold(cfgBase, attrBase) {
 				return entry

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -1696,6 +1696,20 @@ func (e *CodexAutoExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth
 	return e.httpExec.PrepareRequest(req, auth)
 }
 
+func (e *CodexAutoExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool {
+	if e == nil || e.httpExec == nil {
+		return false
+	}
+	return e.httpExec.ShouldPrepareRequestAuth(auth)
+}
+
+func (e *CodexAutoExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	if e == nil || e.httpExec == nil {
+		return auth, nil
+	}
+	return e.httpExec.PrepareRequestAuth(ctx, auth)
+}
+
 func (e *CodexAutoExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
 	if e == nil || e.httpExec == nil {
 		return nil, fmt.Errorf("codex auto executor: http executor is nil")

--- a/internal/runtime/executor/command_auth_config.go
+++ b/internal/runtime/executor/command_auth_config.go
@@ -1,0 +1,35 @@
+package executor
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func commandAuthMatches(authCfg *config.CommandAuthConfig, cfgBase, attrBase string, auth *cliproxyauth.Auth) bool {
+	if auth == nil || auth.Attributes == nil {
+		return false
+	}
+	attrCommandKey := strings.TrimSpace(auth.Attributes[cliproxyauth.AttrAuthCommandKey])
+	if attrCommandKey == "" {
+		return false
+	}
+	cfgCommandKey := config.CommandAuthIdentity(authCfg)
+	if cfgCommandKey == "" || !strings.EqualFold(attrCommandKey, cfgCommandKey) {
+		return false
+	}
+	if attrBase == "" {
+		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+	}
+	cfgBase = strings.TrimSpace(cfgBase)
+	return cfgBase == "" || strings.EqualFold(cfgBase, attrBase)
+}
+
+func commandAuthMetadataToken(auth *cliproxyauth.Auth) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	token, _ := auth.Metadata["access_token"].(string)
+	return strings.TrimSpace(token)
+}

--- a/internal/runtime/executor/command_auth_test.go
+++ b/internal/runtime/executor/command_auth_test.go
@@ -1,0 +1,158 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestParseCommandAuthBearerToken(t *testing.T) {
+	token, err := helps.ParseCommandAuthBearerToken([]byte("\nBearer test-token\n"))
+	if err != nil {
+		t.Fatalf("ParseCommandAuthBearerToken error: %v", err)
+	}
+	if token != "test-token" {
+		t.Fatalf("token = %q, want test-token", token)
+	}
+}
+
+func TestOpenAICompatPrepareRequestUsesCommandAuthMetadata(t *testing.T) {
+	exec := NewOpenAICompatExecutor("openai-compatibility", nil)
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/v1/models", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"base_url": "https://example.com/v1"},
+		Metadata:   map[string]any{"access_token": "dynamic-token"},
+	}
+	if err := exec.PrepareRequest(req, auth); err != nil {
+		t.Fatalf("PrepareRequest error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer dynamic-token" {
+		t.Fatalf("Authorization = %q, want Bearer dynamic-token", got)
+	}
+}
+
+func TestCommandAuthPrepareExecutesCommandAndCaches(t *testing.T) {
+	script := writeTokenScript(t, "Bearer dynamic-token")
+	auth := &cliproxyauth.Auth{
+		ID:         "command-auth",
+		Provider:   "openai-compatibility",
+		Attributes: commandAuthAttrs(script, 60000),
+	}
+
+	if !helps.ShouldPrepareCommandAuth(auth) {
+		t.Fatal("expected command auth to require preparation")
+	}
+	updated, err := helps.PrepareCommandAuth(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("PrepareCommandAuth error: %v", err)
+	}
+	if got, _ := updated.Metadata["access_token"].(string); got != "dynamic-token" {
+		t.Fatalf("access_token = %q, want dynamic-token", got)
+	}
+	if !updated.NextRefreshAfter.After(time.Now()) {
+		t.Fatalf("NextRefreshAfter = %v, want future", updated.NextRefreshAfter)
+	}
+	if helps.ShouldPrepareCommandAuth(updated) {
+		t.Fatal("expected cached command auth to skip preparation")
+	}
+}
+
+func TestCommandAuthPrepareFindsUserNPMGlobalBin(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".npm-global", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	script := filepath.Join(binDir, "command-auth-token")
+	body := "#!/bin/sh\nprintf '%s\\n' 'Bearer user-bin-token'\n"
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatalf("write token script: %v", err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	auth := &cliproxyauth.Auth{
+		ID:         "command-auth",
+		Provider:   "openai-compatibility",
+		Attributes: commandAuthAttrs("command-auth-token", 60000),
+	}
+	updated, err := helps.PrepareCommandAuth(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("PrepareCommandAuth error: %v", err)
+	}
+	if got, _ := updated.Metadata["access_token"].(string); got != "user-bin-token" {
+		t.Fatalf("access_token = %q, want user-bin-token", got)
+	}
+}
+
+func TestManagerPrepareHttpRequestRunsCommandAuth(t *testing.T) {
+	script := writeTokenScript(t, "manager-token")
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(NewOpenAICompatExecutor("openai-compatibility", nil))
+
+	auth := &cliproxyauth.Auth{
+		ID:         "command-auth",
+		Provider:   "openai-compatibility",
+		Attributes: commandAuthAttrs(script, 60000),
+	}
+	if _, err := manager.Register(cliproxyauth.WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/v1/models", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := manager.PrepareHttpRequest(context.Background(), auth, req); err != nil {
+		t.Fatalf("PrepareHttpRequest error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer manager-token" {
+		t.Fatalf("Authorization = %q, want Bearer manager-token", got)
+	}
+	current, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected auth in manager")
+	}
+	if got, _ := current.Metadata["access_token"].(string); got != "manager-token" {
+		t.Fatalf("manager access_token = %q, want manager-token", got)
+	}
+}
+
+func writeTokenScript(t *testing.T, token string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token.sh")
+	body := "#!/bin/sh\nprintf '%s\\n' " + shellSingleQuote(token) + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write token script: %v", err)
+	}
+	return path
+}
+
+func commandAuthAttrs(command string, refreshMS int) map[string]string {
+	return map[string]string{
+		"base_url":                                "https://example.com/v1",
+		cliproxyauth.AttrAuthKind:                 cliproxyauth.AttrAuthKindAPIKey,
+		cliproxyauth.AttrAuthSource:               cliproxyauth.AttrAuthSourceCommand,
+		cliproxyauth.AttrAuthCommand:              command,
+		cliproxyauth.AttrAuthArgsJSON:             "[]",
+		cliproxyauth.AttrAuthTimeoutMS:            "5000",
+		cliproxyauth.AttrAuthRefreshIntervalMS:    strconv.Itoa(refreshMS),
+		cliproxyauth.AttrAuthInvalidatesOnNext401: "true",
+	}
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}

--- a/internal/runtime/executor/command_auth_test.go
+++ b/internal/runtime/executor/command_auth_test.go
@@ -15,12 +15,25 @@ import (
 )
 
 func TestParseCommandAuthBearerToken(t *testing.T) {
-	token, err := helps.ParseCommandAuthBearerToken([]byte("\nBearer test-token\n"))
-	if err != nil {
-		t.Fatalf("ParseCommandAuthBearerToken error: %v", err)
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{name: "bearer", output: "\nBearer test-token\n", want: "test-token"},
+		{name: "leading noise", output: "warning: cached token stale\nBearer fresh-token\n", want: "fresh-token"},
+		{name: "fallback", output: "plain-token\n", want: "plain-token"},
 	}
-	if token != "test-token" {
-		t.Fatalf("token = %q, want test-token", token)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, err := helps.ParseCommandAuthBearerToken([]byte(tt.output))
+			if err != nil {
+				t.Fatalf("ParseCommandAuthBearerToken error: %v", err)
+			}
+			if token != tt.want {
+				t.Fatalf("token = %q, want %q", token, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/executor/command_auth_test.go
+++ b/internal/runtime/executor/command_auth_test.go
@@ -180,6 +180,55 @@ func TestProviderRequestAuthPreparersRunCommandAuth(t *testing.T) {
 	}
 }
 
+func TestProviderRefreshRunsDueCommandAuth(t *testing.T) {
+	script := writeTokenScript(t, "refreshed-provider-token")
+	tests := []struct {
+		name     string
+		metadata map[string]any
+		exec     interface {
+			Refresh(context.Context, *cliproxyauth.Auth) (*cliproxyauth.Auth, error)
+		}
+	}{
+		{name: "gemini", exec: NewGeminiExecutor(nil)},
+		{name: "claude", exec: NewClaudeExecutor(nil)},
+		{name: "codex", exec: NewCodexExecutor(nil)},
+		{name: "openai-compat", exec: NewOpenAICompatExecutor("openai-compatibility", nil)},
+		{name: "vertex", exec: NewGeminiVertexExecutor(nil)},
+		{name: "kimi", exec: NewKimiExecutor(nil)},
+		{name: "xai", exec: NewXAIExecutor(nil)},
+		{name: "xai-auto", exec: NewXAIAutoExecutor(nil)},
+		{name: "aistudio", exec: NewAIStudioExecutor(nil, "aistudio", nil)},
+		{name: "antigravity", metadata: map[string]any{"project_id": "test-project"}, exec: NewAntigravityExecutor(nil)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth := &cliproxyauth.Auth{
+				ID:         tt.name + "-command-auth",
+				Provider:   tt.name,
+				Attributes: commandAuthAttrs(script, 60000),
+				Metadata:   tt.metadata,
+			}
+			if auth.Metadata == nil {
+				auth.Metadata = make(map[string]any)
+			}
+			auth.Metadata["access_token"] = "stale-provider-token"
+			auth.NextRefreshAfter = time.Now().Add(-time.Second)
+
+			updated, err := tt.exec.Refresh(context.Background(), auth)
+			if err != nil {
+				t.Fatalf("Refresh error: %v", err)
+			}
+			if got, _ := updated.Metadata["access_token"].(string); got != "refreshed-provider-token" {
+				t.Fatalf("access_token = %q, want refreshed-provider-token", got)
+			}
+			if !updated.NextRefreshAfter.After(time.Now()) {
+				t.Fatalf("NextRefreshAfter = %v, want future", updated.NextRefreshAfter)
+			}
+		})
+	}
+}
+
 func TestCommandAuthPrepareExecutesCommandAndCaches(t *testing.T) {
 	script := writeTokenScript(t, "Bearer dynamic-token")
 	auth := &cliproxyauth.Auth{

--- a/internal/runtime/executor/command_auth_test.go
+++ b/internal/runtime/executor/command_auth_test.go
@@ -55,6 +55,131 @@ func TestOpenAICompatPrepareRequestUsesCommandAuthMetadata(t *testing.T) {
 	}
 }
 
+func TestProviderPrepareRequestUsesCommandAuthMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		exec interface {
+			PrepareRequest(*http.Request, *cliproxyauth.Auth) error
+		}
+		url        string
+		wantHeader string
+		wantValue  string
+	}{
+		{
+			name:       "gemini",
+			exec:       NewGeminiExecutor(nil),
+			url:        "https://generativelanguage.googleapis.com/v1beta/models",
+			wantHeader: "x-goog-api-key",
+			wantValue:  "dynamic-token",
+		},
+		{
+			name:       "claude",
+			exec:       NewClaudeExecutor(nil),
+			url:        "https://api.anthropic.com/v1/messages",
+			wantHeader: "Authorization",
+			wantValue:  "Bearer dynamic-token",
+		},
+		{
+			name:       "vertex",
+			exec:       NewGeminiVertexExecutor(nil),
+			url:        "https://aiplatform.googleapis.com/v1/publishers/google/models/gemini:generateContent",
+			wantHeader: "x-goog-api-key",
+			wantValue:  "dynamic-token",
+		},
+		{
+			name:       "kimi",
+			exec:       NewKimiExecutor(nil),
+			url:        "https://api.kimi.com/coding/v1/chat/completions",
+			wantHeader: "Authorization",
+			wantValue:  "Bearer dynamic-token",
+		},
+		{
+			name:       "xai",
+			exec:       NewXAIExecutor(nil),
+			url:        "https://api.x.ai/v1/responses",
+			wantHeader: "Authorization",
+			wantValue:  "Bearer dynamic-token",
+		},
+		{
+			name:       "aistudio",
+			exec:       NewAIStudioExecutor(nil, "aistudio", nil),
+			url:        "https://generativelanguage.googleapis.com/v1beta/models",
+			wantHeader: "Authorization",
+			wantValue:  "Bearer dynamic-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tt.url, nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			auth := &cliproxyauth.Auth{
+				Attributes: map[string]string{
+					"base_url":                  "https://example.com/v1",
+					cliproxyauth.AttrAuthKind:   cliproxyauth.AttrAuthKindAPIKey,
+					cliproxyauth.AttrAuthSource: cliproxyauth.AttrAuthSourceCommand,
+				},
+				Metadata: map[string]any{"access_token": "dynamic-token"},
+			}
+			if err := tt.exec.PrepareRequest(req, auth); err != nil {
+				t.Fatalf("PrepareRequest error: %v", err)
+			}
+			if got := req.Header.Get(tt.wantHeader); got != tt.wantValue {
+				t.Fatalf("%s = %q, want %q", tt.wantHeader, got, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestProviderRequestAuthPreparersRunCommandAuth(t *testing.T) {
+	script := writeTokenScript(t, "prepared-provider-token")
+	tests := []struct {
+		name     string
+		metadata map[string]any
+		exec     interface {
+			ShouldPrepareRequestAuth(*cliproxyauth.Auth) bool
+			PrepareRequestAuth(context.Context, *cliproxyauth.Auth) (*cliproxyauth.Auth, error)
+		}
+	}{
+		{name: "gemini", exec: NewGeminiExecutor(nil)},
+		{name: "claude", exec: NewClaudeExecutor(nil)},
+		{name: "codex", exec: NewCodexExecutor(nil)},
+		{name: "openai-compat", exec: NewOpenAICompatExecutor("openai-compatibility", nil)},
+		{name: "vertex", exec: NewGeminiVertexExecutor(nil)},
+		{name: "kimi", exec: NewKimiExecutor(nil)},
+		{name: "xai", exec: NewXAIExecutor(nil)},
+		{name: "xai-auto", exec: NewXAIAutoExecutor(nil)},
+		{name: "aistudio", exec: NewAIStudioExecutor(nil, "aistudio", nil)},
+		{name: "antigravity", metadata: map[string]any{"project_id": "test-project"}, exec: NewAntigravityExecutor(nil)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth := &cliproxyauth.Auth{
+				ID:         tt.name + "-command-auth",
+				Provider:   tt.name,
+				Attributes: commandAuthAttrs(script, 60000),
+				Metadata:   tt.metadata,
+			}
+			if !tt.exec.ShouldPrepareRequestAuth(auth) {
+				t.Fatal("expected command auth to require preparation")
+			}
+			updated, err := tt.exec.PrepareRequestAuth(context.Background(), auth)
+			if err != nil {
+				t.Fatalf("PrepareRequestAuth error: %v", err)
+			}
+			if got, _ := updated.Metadata["access_token"].(string); got != "prepared-provider-token" {
+				t.Fatalf("access_token = %q, want prepared-provider-token", got)
+			}
+			if tt.exec.ShouldPrepareRequestAuth(updated) {
+				t.Fatal("expected prepared command auth to skip preparation")
+			}
+		})
+	}
+}
+
 func TestCommandAuthPrepareExecutesCommandAndCaches(t *testing.T) {
 	script := writeTokenScript(t, "Bearer dynamic-token")
 	auth := &cliproxyauth.Auth{

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -71,6 +71,14 @@ func (e *GeminiExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Au
 	return nil
 }
 
+func (e *GeminiExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool {
+	return helps.ShouldPrepareCommandAuth(auth)
+}
+
+func (e *GeminiExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return helps.PrepareCommandAuth(ctx, auth)
+}
+
 // HttpRequest injects Gemini credentials into the request and executes it.
 func (e *GeminiExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
 	if req == nil {
@@ -453,6 +461,11 @@ func geminiAPIKey(a *cliproxyauth.Auth) string {
 			return v
 		}
 	}
+	if a.Metadata != nil {
+		if v, ok := a.Metadata["access_token"].(string); ok {
+			return strings.TrimSpace(v)
+		}
+	}
 	return ""
 }
 
@@ -482,6 +495,9 @@ func (e *GeminiExecutor) resolveGeminiConfig(auth *cliproxyauth.Auth) *config.Ge
 		entry := &e.cfg.GeminiKey[i]
 		cfgKey := strings.TrimSpace(entry.APIKey)
 		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if commandAuthMatches(entry.Auth, cfgBase, attrBase, auth) {
+			return entry
+		}
 		if attrKey != "" && attrBase != "" {
 			if strings.EqualFold(cfgKey, attrKey) && strings.EqualFold(cfgBase, attrBase) {
 				return entry

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -446,6 +446,9 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 
 // Refresh refreshes the authentication credentials (no-op for Gemini API key).
 func (e *GeminiExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	if helps.ShouldPrepareCommandAuth(auth) {
+		return helps.PrepareCommandAuth(ctx, auth)
+	}
 	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
 		return refreshed, err
 	}

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -217,6 +217,14 @@ func (e *GeminiVertexExecutor) PrepareRequest(req *http.Request, auth *cliproxya
 	return nil
 }
 
+func (e *GeminiVertexExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool {
+	return helps.ShouldPrepareCommandAuth(auth)
+}
+
+func (e *GeminiVertexExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return helps.PrepareCommandAuth(ctx, auth)
+}
+
 // HttpRequest injects Vertex credentials into the request and executes it.
 func (e *GeminiVertexExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
 	if req == nil {
@@ -1121,6 +1129,9 @@ func (e *GeminiVertexExecutor) resolveVertexConfig(auth *cliproxyauth.Auth) *con
 		entry := &e.cfg.VertexCompatAPIKey[i]
 		cfgKey := strings.TrimSpace(entry.APIKey)
 		cfgBase := strings.TrimSpace(entry.BaseURL)
+		if commandAuthMatches(entry.Auth, cfgBase, attrBase, auth) {
+			return entry
+		}
 		if attrKey != "" && attrBase != "" {
 			if strings.EqualFold(cfgKey, attrKey) && strings.EqualFold(cfgBase, attrBase) {
 				return entry

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -303,6 +303,9 @@ func (e *GeminiVertexExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 
 // Refresh refreshes the authentication credentials (no-op for Vertex).
 func (e *GeminiVertexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	if helps.ShouldPrepareCommandAuth(auth) {
+		return helps.PrepareCommandAuth(ctx, auth)
+	}
 	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
 		return refreshed, err
 	}

--- a/internal/runtime/executor/helps/command_auth.go
+++ b/internal/runtime/executor/helps/command_auth.go
@@ -1,0 +1,223 @@
+package helps
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+const (
+	defaultCommandAuthTimeout         = 5 * time.Second
+	defaultCommandAuthRefreshInterval = 5 * time.Minute
+	commandAuthOutputLimit            = 64 * 1024
+)
+
+// ShouldPrepareCommandAuth reports whether a command-backed auth needs a fresh token.
+func ShouldPrepareCommandAuth(auth *cliproxyauth.Auth) bool {
+	if !cliproxyauth.IsCommandAuth(auth) {
+		return false
+	}
+	if strings.TrimSpace(commandAuthAccessToken(auth)) == "" {
+		return true
+	}
+	if auth.NextRefreshAfter.IsZero() {
+		return true
+	}
+	return !time.Now().Before(auth.NextRefreshAfter)
+}
+
+// PrepareCommandAuth executes the configured command and stores the bearer token in auth metadata.
+func PrepareCommandAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	if !cliproxyauth.IsCommandAuth(auth) {
+		return auth, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	attrs := auth.Attributes
+	command := strings.TrimSpace(attrs[cliproxyauth.AttrAuthCommand])
+	if command == "" {
+		return auth, fmt.Errorf("command auth: command is empty")
+	}
+	args, errArgs := commandAuthArgs(attrs[cliproxyauth.AttrAuthArgsJSON])
+	if errArgs != nil {
+		return auth, errArgs
+	}
+	timeout := commandAuthDuration(attrs[cliproxyauth.AttrAuthTimeoutMS], defaultCommandAuthTimeout)
+	refreshInterval := commandAuthDuration(attrs[cliproxyauth.AttrAuthRefreshIntervalMS], defaultCommandAuthRefreshInterval)
+
+	runCtx := ctx
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	resolvedCommand := resolveCommandAuthExecutable(command)
+	cmd := exec.CommandContext(runCtx, resolvedCommand, args...)
+	var stdout limitedBuffer
+	var stderr limitedBuffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	errRun := cmd.Run()
+	if errRun != nil {
+		if runCtx.Err() == context.DeadlineExceeded {
+			return auth, fmt.Errorf("command auth: command timed out after %s", timeout)
+		}
+		errText := strings.TrimSpace(stderr.String())
+		if errText == "" {
+			return auth, fmt.Errorf("command auth: command failed: %w", errRun)
+		}
+		return auth, fmt.Errorf("command auth: command failed: %w: %s", errRun, errText)
+	}
+
+	token, errToken := ParseCommandAuthBearerToken(stdout.Bytes())
+	if errToken != nil {
+		return auth, errToken
+	}
+
+	updated := auth.Clone()
+	if updated.Metadata == nil {
+		updated.Metadata = make(map[string]any)
+	}
+	now := time.Now().UTC()
+	updated.Metadata["access_token"] = token
+	updated.LastRefreshedAt = now
+	updated.NextRefreshAfter = now.Add(refreshInterval)
+	updated.UpdatedAt = now
+	return updated, nil
+}
+
+func resolveCommandAuthExecutable(command string) string {
+	command = strings.TrimSpace(command)
+	if command == "" || strings.ContainsAny(command, `/\`) {
+		return command
+	}
+	if path, errLookPath := exec.LookPath(command); errLookPath == nil {
+		return path
+	}
+	for _, dir := range commandAuthUserBinDirs() {
+		path := filepath.Join(dir, command)
+		if isExecutableFile(path) {
+			return path
+		}
+		if runtime.GOOS == "windows" {
+			for _, ext := range []string{".exe", ".cmd", ".bat"} {
+				if isExecutableFile(path + ext) {
+					return path + ext
+				}
+			}
+		}
+	}
+	return command
+}
+
+func commandAuthUserBinDirs() []string {
+	home := strings.TrimSpace(os.Getenv("HOME"))
+	if home == "" {
+		if userProfile := strings.TrimSpace(os.Getenv("USERPROFILE")); userProfile != "" {
+			home = userProfile
+		}
+	}
+	if home == "" {
+		return nil
+	}
+	return []string{
+		filepath.Join(home, ".npm-global", "bin"),
+		filepath.Join(home, ".local", "bin"),
+		filepath.Join(home, "bin"),
+	}
+}
+
+func isExecutableFile(path string) bool {
+	info, errStat := os.Stat(path)
+	if errStat != nil || info.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode()&0o111 != 0
+}
+
+// ParseCommandAuthBearerToken extracts a bearer token from command stdout.
+func ParseCommandAuthBearerToken(output []byte) (string, error) {
+	for _, line := range bytes.Split(output, []byte{'\n'}) {
+		token := strings.TrimSpace(string(line))
+		if token == "" {
+			continue
+		}
+		if len(token) >= len("Bearer ") && strings.EqualFold(token[:len("Bearer ")], "Bearer ") {
+			token = strings.TrimSpace(token[len("Bearer "):])
+		}
+		if token != "" {
+			return token, nil
+		}
+	}
+	return "", fmt.Errorf("command auth: command produced empty stdout")
+}
+
+func commandAuthAccessToken(auth *cliproxyauth.Auth) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	if token, ok := auth.Metadata["access_token"].(string); ok {
+		return strings.TrimSpace(token)
+	}
+	return ""
+}
+
+func commandAuthArgs(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var args []string
+	if err := json.Unmarshal([]byte(raw), &args); err != nil {
+		return nil, fmt.Errorf("command auth: parse args: %w", err)
+	}
+	return args, nil
+}
+
+func commandAuthDuration(raw string, fallback time.Duration) time.Duration {
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	return time.Duration(value) * time.Millisecond
+}
+
+type limitedBuffer struct {
+	buf bytes.Buffer
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	accepted := len(p)
+	remaining := commandAuthOutputLimit - b.buf.Len()
+	if remaining > 0 {
+		if len(p) > remaining {
+			_, _ = b.buf.Write(p[:remaining])
+		} else {
+			_, _ = b.buf.Write(p)
+		}
+	}
+	return accepted, nil
+}
+
+func (b *limitedBuffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
+func (b *limitedBuffer) String() string {
+	return b.buf.String()
+}

--- a/internal/runtime/executor/helps/command_auth.go
+++ b/internal/runtime/executor/helps/command_auth.go
@@ -152,17 +152,21 @@ func isExecutableFile(path string) bool {
 
 // ParseCommandAuthBearerToken extracts a bearer token from command stdout.
 func ParseCommandAuthBearerToken(output []byte) (string, error) {
+	var fallbackToken string
 	for _, line := range bytes.Split(output, []byte{'\n'}) {
 		token := strings.TrimSpace(string(line))
 		if token == "" {
 			continue
 		}
 		if len(token) >= len("Bearer ") && strings.EqualFold(token[:len("Bearer ")], "Bearer ") {
-			token = strings.TrimSpace(token[len("Bearer "):])
+			return strings.TrimSpace(token[len("Bearer "):]), nil
 		}
-		if token != "" {
-			return token, nil
+		if fallbackToken == "" {
+			fallbackToken = token
 		}
+	}
+	if fallbackToken != "" {
+		return fallbackToken, nil
 	}
 	return "", fmt.Errorf("command auth: command produced empty stdout")
 }

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -55,6 +55,14 @@ func (e *KimiExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth
 	return nil
 }
 
+func (e *KimiExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool {
+	return helps.ShouldPrepareCommandAuth(auth)
+}
+
+func (e *KimiExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return helps.PrepareCommandAuth(ctx, auth)
+}
+
 // HttpRequest injects Kimi credentials into the request and executes it.
 func (e *KimiExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
 	if req == nil {
@@ -575,6 +583,9 @@ func fallbackAssistantReasoning(msg gjson.Result, hasLatest bool, latest string)
 // Refresh refreshes the Kimi token using the refresh token.
 func (e *KimiExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
 	log.Debugf("kimi executor: refresh called")
+	if helps.ShouldPrepareCommandAuth(auth) {
+		return helps.PrepareCommandAuth(ctx, auth)
+	}
 	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
 		return refreshed, err
 	}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -66,6 +66,14 @@ func (e *OpenAICompatExecutor) PrepareRequest(req *http.Request, auth *cliproxya
 	return nil
 }
 
+func (e *OpenAICompatExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool {
+	return helps.ShouldPrepareCommandAuth(auth)
+}
+
+func (e *OpenAICompatExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return helps.PrepareCommandAuth(ctx, auth)
+}
+
 // HttpRequest injects OpenAI-compatible credentials into the request and executes it.
 func (e *OpenAICompatExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
 	if req == nil {
@@ -739,6 +747,11 @@ func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (base
 	if auth.Attributes != nil {
 		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
 		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
+	}
+	if apiKey == "" && auth.Metadata != nil {
+		if token, ok := auth.Metadata["access_token"].(string); ok {
+			apiKey = strings.TrimSpace(token)
+		}
 	}
 	return
 }

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -616,6 +616,9 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 // Refresh is a no-op for API-key based compatibility providers.
 func (e *OpenAICompatExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
 	log.Debugf("openai compat executor: refresh called")
+	if helps.ShouldPrepareCommandAuth(auth) {
+		return helps.PrepareCommandAuth(ctx, auth)
+	}
 	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
 		return refreshed, err
 	}

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -86,6 +86,14 @@ func (e *XAIExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth)
 	return nil
 }
 
+func (e *XAIExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool {
+	return helps.ShouldPrepareCommandAuth(auth)
+}
+
+func (e *XAIExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return helps.PrepareCommandAuth(ctx, auth)
+}
+
 // HttpRequest injects xAI credentials into the request and executes it.
 func (e *XAIExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
 	if req == nil {
@@ -734,6 +742,9 @@ func (e *XAIExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, 
 // Refresh refreshes xAI OAuth credentials using the stored refresh token.
 func (e *XAIExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
 	log.Debugf("xai executor: refresh called")
+	if helps.ShouldPrepareCommandAuth(auth) {
+		return helps.PrepareCommandAuth(ctx, auth)
+	}
 	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
 		return refreshed, err
 	}

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -1356,6 +1356,20 @@ func (e *XAIAutoExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.A
 	return e.httpExec.PrepareRequest(req, auth)
 }
 
+func (e *XAIAutoExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool {
+	if e == nil || e.httpExec == nil {
+		return false
+	}
+	return e.httpExec.ShouldPrepareRequestAuth(auth)
+}
+
+func (e *XAIAutoExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	if e == nil || e.httpExec == nil {
+		return auth, nil
+	}
+	return e.httpExec.PrepareRequestAuth(ctx, auth)
+}
+
 func (e *XAIAutoExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
 	if e == nil || e.httpExec == nil {
 		return nil, fmt.Errorf("xai auto executor: http executor is nil")

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -382,13 +382,25 @@ func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int) {
 	openAICompatCount := 0
 
 	if len(cfg.GeminiKey) > 0 {
-		geminiAPIKeyCount += len(cfg.GeminiKey)
+		for _, entry := range cfg.GeminiKey {
+			if strings.TrimSpace(entry.APIKey) != "" || entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+				geminiAPIKeyCount++
+			}
+		}
 	}
 	if len(cfg.VertexCompatAPIKey) > 0 {
-		vertexCompatAPIKeyCount += len(cfg.VertexCompatAPIKey)
+		for _, entry := range cfg.VertexCompatAPIKey {
+			if strings.TrimSpace(entry.APIKey) != "" || entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+				vertexCompatAPIKeyCount++
+			}
+		}
 	}
 	if len(cfg.ClaudeKey) > 0 {
-		claudeAPIKeyCount += len(cfg.ClaudeKey)
+		for _, entry := range cfg.ClaudeKey {
+			if strings.TrimSpace(entry.APIKey) != "" || entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+				claudeAPIKeyCount++
+			}
+		}
 	}
 	if len(cfg.CodexKey) > 0 {
 		for _, entry := range cfg.CodexKey {

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -391,11 +391,19 @@ func BuildAPIKeyClients(cfg *config.Config) (int, int, int, int, int) {
 		claudeAPIKeyCount += len(cfg.ClaudeKey)
 	}
 	if len(cfg.CodexKey) > 0 {
-		codexAPIKeyCount += len(cfg.CodexKey)
+		for _, entry := range cfg.CodexKey {
+			if strings.TrimSpace(entry.APIKey) != "" || entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != "" {
+				codexAPIKeyCount++
+			}
+		}
 	}
 	if len(cfg.OpenAICompatibility) > 0 {
 		for _, compatConfig := range cfg.OpenAICompatibility {
 			if compatConfig.Disabled {
+				continue
+			}
+			if compatConfig.Auth != nil && strings.TrimSpace(compatConfig.Auth.Command) != "" {
+				openAICompatCount++
 				continue
 			}
 			openAICompatCount += len(compatConfig.APIKeyEntries)

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -224,6 +224,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 			if strings.TrimSpace(o.APIKey) != strings.TrimSpace(n.APIKey) {
 				changes = append(changes, fmt.Sprintf("codex[%d].api-key: updated", i))
 			}
+			if config.CommandAuthIdentity(o.Auth) != config.CommandAuthIdentity(n.Auth) || commandAuthPresence(o.Auth) != commandAuthPresence(n.Auth) {
+				changes = append(changes, fmt.Sprintf("codex[%d].auth: updated", i))
+			}
 			if !equalStringMap(o.Headers, n.Headers) {
 				changes = append(changes, fmt.Sprintf("codex[%d].headers: updated", i))
 			}

--- a/internal/watcher/diff/openai_compat.go
+++ b/internal/watcher/diff/openai_compat.go
@@ -69,6 +69,12 @@ func describeOpenAICompatibilityUpdate(oldEntry, newEntry config.OpenAICompatibi
 	if oldEntry.Disabled != newEntry.Disabled {
 		details = append(details, fmt.Sprintf("disabled %t -> %t", oldEntry.Disabled, newEntry.Disabled))
 	}
+	if strings.TrimSpace(oldEntry.ProxyURL) != strings.TrimSpace(newEntry.ProxyURL) {
+		details = append(details, "proxy-url updated")
+	}
+	if config.CommandAuthIdentity(oldEntry.Auth) != config.CommandAuthIdentity(newEntry.Auth) || commandAuthPresence(oldEntry.Auth) != commandAuthPresence(newEntry.Auth) {
+		details = append(details, "auth updated")
+	}
 	if oldKeyCount != newKeyCount {
 		details = append(details, fmt.Sprintf("api-keys %d -> %d", oldKeyCount, newKeyCount))
 	}
@@ -85,6 +91,9 @@ func describeOpenAICompatibilityUpdate(oldEntry, newEntry config.OpenAICompatibi
 }
 
 func countAPIKeys(entry config.OpenAICompatibility) int {
+	if commandAuthPresence(entry.Auth) {
+		return 1
+	}
 	count := 0
 	for _, keyEntry := range entry.APIKeyEntries {
 		if strings.TrimSpace(keyEntry.APIKey) != "" {
@@ -145,6 +154,9 @@ func openAICompatSignature(entry config.OpenAICompatibility) string {
 	if v := strings.TrimSpace(entry.BaseURL); v != "" {
 		parts = append(parts, "base="+v)
 	}
+	if v := strings.TrimSpace(entry.ProxyURL); v != "" {
+		parts = append(parts, "proxy="+v)
+	}
 
 	models := make([]string, 0, len(entry.Models))
 	for _, model := range entry.Models {
@@ -177,10 +189,17 @@ func openAICompatSignature(entry config.OpenAICompatibility) string {
 	if count := countAPIKeys(entry); count > 0 {
 		parts = append(parts, fmt.Sprintf("api_keys=%d", count))
 	}
+	if identity := config.CommandAuthIdentity(entry.Auth); identity != "" {
+		parts = append(parts, "auth="+identity)
+	}
 
 	if len(parts) == 0 {
 		return ""
 	}
 	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
 	return hex.EncodeToString(sum[:])
+}
+
+func commandAuthPresence(auth *config.CommandAuthConfig) bool {
+	return auth != nil && strings.TrimSpace(auth.Command) != ""
 }

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -242,7 +242,8 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 	out := make([]*coreauth.Auth, 0)
 	for i := range cfg.OpenAICompatibility {
 		compat := &cfg.OpenAICompatibility[i]
-		if compat.Disabled {
+		hasCommandAuth := compat.Auth != nil && strings.TrimSpace(compat.Auth.Command) != ""
+		if compat.Disabled && !hasCommandAuth {
 			continue
 		}
 		prefix := strings.TrimSpace(compat.Prefix)
@@ -254,7 +255,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 		base := strings.TrimSpace(compat.BaseURL)
 		disableCooling := compat.DisableCooling
 
-		if compat.Auth != nil && strings.TrimSpace(compat.Auth.Command) != "" {
+		if hasCommandAuth {
 			idKind := fmt.Sprintf("openai-compatibility:%s", providerName)
 			idParts := append(CommandAuthIDParts(compat.Auth), base, strings.TrimSpace(compat.ProxyURL))
 			id, token := idGen.Next(idKind, idParts...)
@@ -287,6 +288,10 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				Metadata:   metadata,
 				CreatedAt:  now,
 				UpdatedAt:  now,
+			}
+			if compat.Disabled {
+				a.Disabled = true
+				a.Status = coreauth.StatusDisabled
 			}
 			if len(a.Metadata) == 0 {
 				a.Metadata = nil

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -165,15 +165,25 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 	for i := range cfg.CodexKey {
 		ck := cfg.CodexKey[i]
 		key := strings.TrimSpace(ck.APIKey)
-		if key == "" {
+		hasCommandAuth := ck.Auth != nil && strings.TrimSpace(ck.Auth.Command) != ""
+		if key == "" && !hasCommandAuth {
 			continue
 		}
 		prefix := strings.TrimSpace(ck.Prefix)
-		id, token := idGen.Next("codex:apikey", key, ck.BaseURL)
-		attrs := map[string]string{
-			"source":  fmt.Sprintf("config:codex[%s]", token),
-			"api_key": key,
+		var idParts []string
+		if hasCommandAuth {
+			idParts = append(CommandAuthIDParts(ck.Auth), ck.BaseURL)
+		} else {
+			idParts = []string{key, ck.BaseURL}
 		}
+		id, token := idGen.Next("codex:apikey", idParts...)
+		attrs := map[string]string{
+			"source": fmt.Sprintf("config:codex[%s]", token),
+		}
+		if key != "" {
+			attrs["api_key"] = key
+		}
+		addCommandAuthToAttrs(ck.Auth, attrs)
 		metadata := map[string]any{}
 		if ck.DisableCooling {
 			metadata["disable_cooling"] = true
@@ -192,10 +202,14 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 		}
 		addConfigHeadersToAttrs(ck.Headers, attrs)
 		proxyURL := strings.TrimSpace(ck.ProxyURL)
+		label := "codex-apikey"
+		if hasCommandAuth {
+			label = "codex-auth-command"
+		}
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "codex",
-			Label:      "codex-apikey",
+			Label:      label,
 			Prefix:     prefix,
 			Status:     coreauth.StatusActive,
 			ProxyURL:   proxyURL,
@@ -233,6 +247,47 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 		internalProviderKey := util.OpenAICompatibleProviderKey(providerName)
 		base := strings.TrimSpace(compat.BaseURL)
 		disableCooling := compat.DisableCooling
+
+		if compat.Auth != nil && strings.TrimSpace(compat.Auth.Command) != "" {
+			idKind := fmt.Sprintf("openai-compatibility:%s", providerName)
+			idParts := append(CommandAuthIDParts(compat.Auth), base, strings.TrimSpace(compat.ProxyURL))
+			id, token := idGen.Next(idKind, idParts...)
+			attrs := map[string]string{
+				"source":       fmt.Sprintf("config:%s[%s]", providerName, token),
+				"base_url":     base,
+				"compat_name":  compat.Name,
+				"provider_key": internalProviderKey,
+			}
+			addCommandAuthToAttrs(compat.Auth, attrs)
+			metadata := map[string]any{}
+			if disableCooling {
+				metadata["disable_cooling"] = true
+			}
+			if compat.Priority != 0 {
+				attrs["priority"] = strconv.Itoa(compat.Priority)
+			}
+			if hash := diff.ComputeOpenAICompatModelsHash(compat.Models); hash != "" {
+				attrs["models_hash"] = hash
+			}
+			addConfigHeadersToAttrs(compat.Headers, attrs)
+			a := &coreauth.Auth{
+				ID:         id,
+				Provider:   internalProviderKey,
+				Label:      compat.Name,
+				Prefix:     prefix,
+				Status:     coreauth.StatusActive,
+				ProxyURL:   strings.TrimSpace(compat.ProxyURL),
+				Attributes: attrs,
+				Metadata:   metadata,
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			}
+			if len(a.Metadata) == 0 {
+				a.Metadata = nil
+			}
+			out = append(out, a)
+			continue
+		}
 
 		// Handle new APIKeyEntries format (preferred)
 		createdEntries := 0

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -19,6 +19,14 @@ func NewConfigSynthesizer() *ConfigSynthesizer {
 	return &ConfigSynthesizer{}
 }
 
+func credentialLabel(provider string, commandAuth bool) string {
+	provider = strings.TrimSpace(provider)
+	if commandAuth {
+		return provider + "-auth-command"
+	}
+	return provider + "-apikey"
+}
+
 // Synthesize generates Auth entries from config API keys.
 func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, error) {
 	out := make([]*coreauth.Auth, 0, 32)
@@ -50,17 +58,21 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeys(ctx *SynthesisContext) []*corea
 	for i := range cfg.GeminiKey {
 		entry := cfg.GeminiKey[i]
 		key := strings.TrimSpace(entry.APIKey)
-		if key == "" {
+		hasCommandAuth := entry.Auth != nil && strings.TrimSpace(entry.Auth.Command) != ""
+		if key == "" && !hasCommandAuth {
 			continue
 		}
 		prefix := strings.TrimSpace(entry.Prefix)
 		base := strings.TrimSpace(entry.BaseURL)
 		proxyURL := strings.TrimSpace(entry.ProxyURL)
-		id, token := idGen.Next("gemini:apikey", key, base)
+		id, token := idGen.Next("gemini:apikey", commandAuthIDPartsOrAPIKey(entry.Auth, key, base)...)
 		attrs := map[string]string{
-			"source":  fmt.Sprintf("config:gemini[%s]", token),
-			"api_key": key,
+			"source": fmt.Sprintf("config:gemini[%s]", token),
 		}
+		if key != "" {
+			attrs["api_key"] = key
+		}
+		addCommandAuthToAttrs(entry.Auth, attrs)
 		metadata := map[string]any{}
 		if entry.DisableCooling {
 			metadata["disable_cooling"] = true
@@ -78,7 +90,7 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeys(ctx *SynthesisContext) []*corea
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "gemini",
-			Label:      "gemini-apikey",
+			Label:      credentialLabel("gemini", hasCommandAuth),
 			Prefix:     prefix,
 			Status:     coreauth.StatusActive,
 			ProxyURL:   proxyURL,
@@ -106,16 +118,20 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 	for i := range cfg.ClaudeKey {
 		ck := cfg.ClaudeKey[i]
 		key := strings.TrimSpace(ck.APIKey)
-		if key == "" {
+		hasCommandAuth := ck.Auth != nil && strings.TrimSpace(ck.Auth.Command) != ""
+		if key == "" && !hasCommandAuth {
 			continue
 		}
 		prefix := strings.TrimSpace(ck.Prefix)
 		base := strings.TrimSpace(ck.BaseURL)
-		id, token := idGen.Next("claude:apikey", key, base)
+		id, token := idGen.Next("claude:apikey", commandAuthIDPartsOrAPIKey(ck.Auth, key, base)...)
 		attrs := map[string]string{
-			"source":  fmt.Sprintf("config:claude[%s]", token),
-			"api_key": key,
+			"source": fmt.Sprintf("config:claude[%s]", token),
 		}
+		if key != "" {
+			attrs["api_key"] = key
+		}
+		addCommandAuthToAttrs(ck.Auth, attrs)
 		metadata := map[string]any{}
 		if ck.DisableCooling {
 			metadata["disable_cooling"] = true
@@ -137,7 +153,7 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "claude",
-			Label:      "claude-apikey",
+			Label:      credentialLabel("claude", hasCommandAuth),
 			Prefix:     prefix,
 			Status:     coreauth.StatusActive,
 			ProxyURL:   proxyURL,
@@ -170,13 +186,7 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 			continue
 		}
 		prefix := strings.TrimSpace(ck.Prefix)
-		var idParts []string
-		if hasCommandAuth {
-			idParts = append(CommandAuthIDParts(ck.Auth), ck.BaseURL)
-		} else {
-			idParts = []string{key, ck.BaseURL}
-		}
-		id, token := idGen.Next("codex:apikey", idParts...)
+		id, token := idGen.Next("codex:apikey", commandAuthIDPartsOrAPIKey(ck.Auth, key, ck.BaseURL)...)
 		attrs := map[string]string{
 			"source": fmt.Sprintf("config:codex[%s]", token),
 		}
@@ -202,14 +212,10 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 		}
 		addConfigHeadersToAttrs(ck.Headers, attrs)
 		proxyURL := strings.TrimSpace(ck.ProxyURL)
-		label := "codex-apikey"
-		if hasCommandAuth {
-			label = "codex-auth-command"
-		}
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "codex",
-			Label:      label,
+			Label:      credentialLabel("codex", hasCommandAuth),
 			Prefix:     prefix,
 			Status:     coreauth.StatusActive,
 			ProxyURL:   proxyURL,
@@ -389,15 +395,20 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 		base := strings.TrimSpace(compat.BaseURL)
 
 		key := strings.TrimSpace(compat.APIKey)
+		hasCommandAuth := compat.Auth != nil && strings.TrimSpace(compat.Auth.Command) != ""
+		if key == "" && !hasCommandAuth {
+			continue
+		}
 		prefix := strings.TrimSpace(compat.Prefix)
 		proxyURL := strings.TrimSpace(compat.ProxyURL)
 		idKind := "vertex:apikey"
-		id, token := idGen.Next(idKind, key, base, proxyURL)
+		id, token := idGen.Next(idKind, commandAuthIDPartsOrAPIKey(compat.Auth, key, base, proxyURL)...)
 		attrs := map[string]string{
 			"source":       fmt.Sprintf("config:vertex-apikey[%s]", token),
 			"base_url":     base,
 			"provider_key": providerName,
 		}
+		addCommandAuthToAttrs(compat.Auth, attrs)
 		if compat.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(compat.Priority)
 		}
@@ -411,7 +422,7 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   providerName,
-			Label:      "vertex-apikey",
+			Label:      credentialLabel("vertex", hasCommandAuth),
 			Prefix:     prefix,
 			Status:     coreauth.StatusActive,
 			ProxyURL:   proxyURL,

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -473,6 +473,37 @@ func TestConfigSynthesizer_OpenAICompatCommandAuth(t *testing.T) {
 	}
 }
 
+func TestConfigSynthesizer_OpenAICompatDisabledCommandAuth(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			OpenAICompatibility: []config.OpenAICompatibility{{
+				Name:     "proxy",
+				BaseURL:  "https://proxy.example.com/v1",
+				Disabled: true,
+				Auth: &config.CommandAuthConfig{
+					Command:           "fetch-token",
+					TimeoutMS:         5000,
+					RefreshIntervalMS: 300000,
+				},
+			}},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 disabled command auth, got %d", len(auths))
+	}
+	if !auths[0].Disabled || auths[0].Status != coreauth.StatusDisabled {
+		t.Fatalf("disabled command auth status = %v/%s, want true/%s", auths[0].Disabled, auths[0].Status, coreauth.StatusDisabled)
+	}
+}
+
 func TestConfigSynthesizer_OpenAICompat(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -337,6 +337,72 @@ func TestConfigSynthesizer_CodexCommandAuth(t *testing.T) {
 	}
 }
 
+func TestConfigSynthesizer_CommandAuthProviders(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			GeminiKey: []config.GeminiKey{{
+				BaseURL: "https://gemini.example.com",
+				Auth: &config.CommandAuthConfig{
+					Command:           "fetch-gemini-token",
+					TimeoutMS:         5000,
+					RefreshIntervalMS: 300000,
+				},
+			}},
+			ClaudeKey: []config.ClaudeKey{{
+				BaseURL: "https://claude.example.com",
+				Auth: &config.CommandAuthConfig{
+					Command:           "fetch-claude-token",
+					TimeoutMS:         5000,
+					RefreshIntervalMS: 300000,
+				},
+			}},
+			VertexCompatAPIKey: []config.VertexCompatKey{{
+				BaseURL: "https://vertex.example.com",
+				Auth: &config.CommandAuthConfig{
+					Command:           "fetch-vertex-token",
+					TimeoutMS:         5000,
+					RefreshIntervalMS: 300000,
+				},
+			}},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 3 {
+		t.Fatalf("expected 3 auths, got %d", len(auths))
+	}
+
+	want := map[string]string{
+		"gemini": "fetch-gemini-token",
+		"claude": "fetch-claude-token",
+		"vertex": "fetch-vertex-token",
+	}
+	for _, auth := range auths {
+		command := want[auth.Provider]
+		if command == "" {
+			t.Fatalf("unexpected provider %q", auth.Provider)
+		}
+		if got := auth.Attributes[coreauth.AttrAuthCommand]; got != command {
+			t.Fatalf("%s auth_command = %q, want %q", auth.Provider, got, command)
+		}
+		if got := auth.Attributes[coreauth.AttrAuthSource]; got != coreauth.AttrAuthSourceCommand {
+			t.Fatalf("%s auth_source = %q, want command", auth.Provider, got)
+		}
+		if _, ok := auth.Attributes["api_key"]; ok {
+			t.Fatalf("%s command auth should not set api_key", auth.Provider)
+		}
+		if auth.Label != auth.Provider+"-auth-command" {
+			t.Fatalf("%s label = %q", auth.Provider, auth.Label)
+		}
+	}
+}
+
 func TestConfigSynthesizer_CodexKeys_SkipsEmptyAndHeaders(t *testing.T) {
 	synth := NewConfigSynthesizer()
 	ctx := &SynthesisContext{
@@ -570,8 +636,8 @@ func TestConfigSynthesizer_VertexCompat_SkipsEmptyAndHeaders(t *testing.T) {
 	ctx := &SynthesisContext{
 		Config: &config.Config{
 			VertexCompatAPIKey: []config.VertexCompatKey{
-				{APIKey: "", BaseURL: "https://vertex.api"},   // empty key creates auth without api_key attr
-				{APIKey: "  ", BaseURL: "https://vertex.api"}, // whitespace key creates auth without api_key attr
+				{APIKey: "", BaseURL: "https://vertex.api"},   // empty, should be skipped
+				{APIKey: "  ", BaseURL: "https://vertex.api"}, // whitespace, should be skipped
 				{APIKey: "valid-key", BaseURL: "https://vertex.api", Headers: map[string]string{"X-Vertex": "test"}},
 			},
 		},
@@ -583,20 +649,11 @@ func TestConfigSynthesizer_VertexCompat_SkipsEmptyAndHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Vertex compat doesn't skip empty keys - it creates auths without api_key attribute
-	if len(auths) != 3 {
-		t.Fatalf("expected 3 auths, got %d", len(auths))
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth (empty keys skipped), got %d", len(auths))
 	}
-	// First two should not have api_key attribute
-	if _, ok := auths[0].Attributes["api_key"]; ok {
-		t.Error("expected first auth to not have api_key attribute")
-	}
-	if _, ok := auths[1].Attributes["api_key"]; ok {
-		t.Error("expected second auth to not have api_key attribute")
-	}
-	// Third should have headers
-	if auths[2].Attributes["header:X-Vertex"] != "test" {
-		t.Errorf("expected header:X-Vertex=test, got %s", auths[2].Attributes["header:X-Vertex"])
+	if auths[0].Attributes["header:X-Vertex"] != "test" {
+		t.Errorf("expected header:X-Vertex=test, got %s", auths[0].Attributes["header:X-Vertex"])
 	}
 }
 

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -292,6 +292,51 @@ func TestConfigSynthesizer_CodexKeys(t *testing.T) {
 	}
 }
 
+func TestConfigSynthesizer_CodexCommandAuth(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			CodexKey: []config.CodexKey{
+				{
+					BaseURL: "https://proxy.example.com/v1",
+					Auth: &config.CommandAuthConfig{
+						Command:           "fetch-token",
+						Args:              []string{"--audience", "codex"},
+						TimeoutMS:         5000,
+						RefreshIntervalMS: 300000,
+					},
+				},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth, got %d", len(auths))
+	}
+	auth := auths[0]
+	if auth.Label != "codex-auth-command" {
+		t.Fatalf("label = %q, want codex-auth-command", auth.Label)
+	}
+	if _, ok := auth.Attributes["api_key"]; ok {
+		t.Fatal("command auth should not set static api_key")
+	}
+	if got := auth.Attributes[coreauth.AttrAuthSource]; got != coreauth.AttrAuthSourceCommand {
+		t.Fatalf("auth_source = %q, want command", got)
+	}
+	if got := auth.Attributes[coreauth.AttrAuthCommand]; got != "fetch-token" {
+		t.Fatalf("auth_command = %q, want fetch-token", got)
+	}
+	if got := auth.Attributes[coreauth.AttrAuthKind]; got != coreauth.AttrAuthKindAPIKey {
+		t.Fatalf("auth_kind = %q, want apikey", got)
+	}
+}
+
 func TestConfigSynthesizer_CodexKeys_SkipsEmptyAndHeaders(t *testing.T) {
 	synth := NewConfigSynthesizer()
 	ctx := &SynthesisContext{
@@ -315,6 +360,50 @@ func TestConfigSynthesizer_CodexKeys_SkipsEmptyAndHeaders(t *testing.T) {
 	}
 	if auths[0].Attributes["header:Authorization"] != "Bearer xyz" {
 		t.Errorf("expected header:Authorization=Bearer xyz, got %s", auths[0].Attributes["header:Authorization"])
+	}
+}
+
+func TestConfigSynthesizer_OpenAICompatCommandAuth(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			OpenAICompatibility: []config.OpenAICompatibility{
+				{
+					Name:     "proxy",
+					BaseURL:  "https://proxy.example.com/v1",
+					ProxyURL: "http://proxy.local",
+					Auth: &config.CommandAuthConfig{
+						Command:           "fetch-token",
+						Args:              []string{"--audience", "codex"},
+						TimeoutMS:         5000,
+						RefreshIntervalMS: 300000,
+					},
+				},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth, got %d", len(auths))
+	}
+	auth := auths[0]
+	if auth.ProxyURL != "http://proxy.local" {
+		t.Fatalf("proxy_url = %q, want http://proxy.local", auth.ProxyURL)
+	}
+	if _, ok := auth.Attributes["api_key"]; ok {
+		t.Fatal("command auth should not set static api_key")
+	}
+	if got := auth.Attributes[coreauth.AttrAuthSource]; got != coreauth.AttrAuthSourceCommand {
+		t.Fatalf("auth_source = %q, want command", got)
+	}
+	if got := auth.Attributes["provider_key"]; got == "" {
+		t.Fatal("provider_key should be set")
 	}
 }
 

--- a/internal/watcher/synthesizer/helpers.go
+++ b/internal/watcher/synthesizer/helpers.go
@@ -145,3 +145,13 @@ func addCommandAuthToAttrs(auth *config.CommandAuthConfig, attrs map[string]stri
 	attrs[coreauth.AttrAuthRefreshIntervalMS] = strconv.Itoa(auth.RefreshIntervalMS)
 	attrs[coreauth.AttrAuthInvalidatesOnNext401] = "true"
 }
+
+func commandAuthIDPartsOrAPIKey(auth *config.CommandAuthConfig, apiKey string, extra ...string) []string {
+	if auth != nil && strings.TrimSpace(auth.Command) != "" {
+		return append(CommandAuthIDParts(auth), extra...)
+	}
+	out := make([]string, 0, 1+len(extra))
+	out = append(out, strings.TrimSpace(apiKey))
+	out = append(out, extra...)
+	return out
+}

--- a/internal/watcher/synthesizer/helpers.go
+++ b/internal/watcher/synthesizer/helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -117,4 +118,30 @@ func addConfigHeadersToAttrs(headers map[string]string, attrs map[string]string)
 		}
 		attrs["header:"+key] = val
 	}
+}
+
+func CommandAuthIDParts(auth *config.CommandAuthConfig) []string {
+	if auth == nil || strings.TrimSpace(auth.Command) == "" {
+		return nil
+	}
+	return []string{
+		"auth-command",
+		strings.TrimSpace(auth.Command),
+		config.CommandAuthArgsJSON(auth),
+		config.CommandAuthIdentity(auth),
+	}
+}
+
+func addCommandAuthToAttrs(auth *config.CommandAuthConfig, attrs map[string]string) {
+	if auth == nil || attrs == nil || strings.TrimSpace(auth.Command) == "" {
+		return
+	}
+	attrs[coreauth.AttrAuthKind] = coreauth.AttrAuthKindAPIKey
+	attrs[coreauth.AttrAuthSource] = coreauth.AttrAuthSourceCommand
+	attrs[coreauth.AttrAuthCommand] = strings.TrimSpace(auth.Command)
+	attrs[coreauth.AttrAuthArgsJSON] = config.CommandAuthArgsJSON(auth)
+	attrs[coreauth.AttrAuthCommandKey] = config.CommandAuthIdentity(auth)
+	attrs[coreauth.AttrAuthTimeoutMS] = strconv.Itoa(auth.TimeoutMS)
+	attrs[coreauth.AttrAuthRefreshIntervalMS] = strconv.Itoa(auth.RefreshIntervalMS)
+	attrs[coreauth.AttrAuthInvalidatesOnNext401] = "true"
 }

--- a/sdk/cliproxy/auth/command_auth_test.go
+++ b/sdk/cliproxy/auth/command_auth_test.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestCommandAuthUnauthorizedInvalidatesTokenWithoutCooldown(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "command-auth",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"source":        "config:codex[abc]",
+			AttrAuthKind:    AttrAuthKindAPIKey,
+			AttrAuthSource:  AttrAuthSourceCommand,
+			AttrAuthCommand: "fetch-token",
+		},
+		Metadata: map[string]any{"access_token": "bad-token"},
+		Status:   StatusActive,
+	}
+	auth.NextRefreshAfter = time.Now().Add(time.Hour)
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:  auth.ID,
+		Model:   "gpt-5-codex",
+		Success: false,
+		Error:   &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	current, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("expected auth in manager")
+	}
+	if _, exists := current.Metadata["access_token"]; exists {
+		t.Fatal("expected access_token to be cleared")
+	}
+	if !current.NextRefreshAfter.IsZero() {
+		t.Fatalf("NextRefreshAfter = %v, want zero", current.NextRefreshAfter)
+	}
+	if !current.NextRetryAfter.IsZero() {
+		t.Fatalf("NextRetryAfter = %v, want zero", current.NextRetryAfter)
+	}
+	state := current.ModelStates["gpt-5-codex"]
+	if state == nil {
+		t.Fatal("expected model state")
+	}
+	if !state.NextRetryAfter.IsZero() {
+		t.Fatalf("model NextRetryAfter = %v, want zero", state.NextRetryAfter)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1004,7 +1004,18 @@ func isAPIKeyAuth(auth *Auth) bool {
 	if auth == nil {
 		return false
 	}
-	return auth.AuthKind() == AuthKindAPIKey
+	if auth.AuthKind() == AuthKindAPIKey {
+		return true
+	}
+	kind, _ := auth.AccountInfo()
+	if strings.EqualFold(strings.TrimSpace(kind), "api_key") {
+		return true
+	}
+	if auth.Attributes == nil {
+		return false
+	}
+	authKind := strings.ToLower(strings.TrimSpace(auth.Attributes[AttrAuthKind]))
+	return authKind == AttrAuthKindAPIKey || authKind == AttrAuthKindAPIKeyUnderscore
 }
 
 func isOpenAICompatAPIKeyAuth(auth *Auth) bool {
@@ -1948,7 +1959,7 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *internalconfig.Config) {
 		if strings.TrimSpace(auth.ID) == "" {
 			continue
 		}
-		if auth.AuthKind() != AuthKindAPIKey {
+		if !isAPIKeyAuth(auth) {
 			continue
 		}
 
@@ -3046,7 +3057,7 @@ func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) strin
 		return requestedModel
 	}
 
-	if auth.AuthKind() != AuthKindAPIKey {
+	if !isAPIKeyAuth(auth) {
 		return requestedModel
 	}
 
@@ -3151,6 +3162,22 @@ func resolveClaudeAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internal
 func resolveCodexAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internalconfig.CodexKey {
 	if cfg == nil {
 		return nil
+	}
+	if auth != nil && auth.Attributes != nil {
+		attrCommandKey := strings.TrimSpace(auth.Attributes[AttrAuthCommandKey])
+		attrBase := strings.TrimSpace(auth.Attributes["base_url"])
+		if attrCommandKey != "" {
+			for i := range cfg.CodexKey {
+				entry := &cfg.CodexKey[i]
+				cfgCommandKey := internalconfig.CommandAuthIdentity(entry.Auth)
+				cfgBase := strings.TrimSpace(entry.BaseURL)
+				if cfgCommandKey != "" && strings.EqualFold(attrCommandKey, cfgCommandKey) {
+					if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
+						return entry
+					}
+				}
+			}
+		}
 	}
 	return resolveAPIKeyConfig(cfg.CodexKey, auth)
 }
@@ -3574,7 +3601,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					} else {
 						switch statusCode {
 						case 401:
-							if disableCooling {
+							if IsCommandAuth(auth) {
+								invalidateCommandAuthToken(auth)
+								state.Unavailable = false
+								state.NextRetryAfter = time.Time{}
+							} else if disableCooling {
 								state.NextRetryAfter = time.Time{}
 							} else {
 								next := now.Add(30 * time.Minute)
@@ -4098,6 +4129,14 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	}
 	switch statusCode {
 	case 401:
+		if IsCommandAuth(auth) {
+			invalidateCommandAuthToken(auth)
+			auth.Unavailable = false
+			auth.Status = StatusActive
+			auth.StatusMessage = ""
+			auth.NextRetryAfter = time.Time{}
+			return
+		}
 		auth.StatusMessage = "unauthorized"
 		if disableCooling {
 			auth.NextRetryAfter = time.Time{}
@@ -4148,6 +4187,16 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.StatusMessage = "request failed"
 		}
 	}
+}
+
+func invalidateCommandAuthToken(auth *Auth) {
+	if !IsCommandAuth(auth) {
+		return
+	}
+	if auth.Metadata != nil {
+		delete(auth.Metadata, "access_token")
+	}
+	auth.NextRefreshAfter = time.Time{}
 }
 
 // nextQuotaCooldown returns the next cooldown duration and updated backoff level for repeated quota errors.
@@ -5214,7 +5263,7 @@ func (m *Manager) persist(ctx context.Context, auth *Auth) error {
 	if shouldSkipPersist(ctx) {
 		return nil
 	}
-	if IsConfigAPIKeyAuth(auth) {
+	if IsConfigCredentialAuth(auth) {
 		return nil
 	}
 	if auth.Attributes != nil {
@@ -5767,6 +5816,13 @@ func (m *Manager) PrepareHttpRequest(ctx context.Context, auth *Auth, req *http.
 	if exec == nil {
 		return &Error{Code: "provider_not_found", Message: "executor not registered for provider: " + providerKey}
 	}
+	preparedAuth, errPrepareAuth := m.prepareRequestAuth(ctx, exec, auth)
+	if errPrepareAuth != nil {
+		return errPrepareAuth
+	}
+	if preparedAuth != nil {
+		auth = preparedAuth
+	}
 	preparer, ok := exec.(RequestPreparer)
 	if !ok || preparer == nil {
 		return &Error{Code: "not_supported", Message: "executor does not support http request preparation"}
@@ -5818,6 +5874,13 @@ func (m *Manager) HttpRequest(ctx context.Context, auth *Auth, req *http.Request
 	exec := m.executorFor(providerKey)
 	if exec == nil {
 		return nil, &Error{Code: "provider_not_found", Message: "executor not registered for provider: " + providerKey}
+	}
+	preparedAuth, errPrepareAuth := m.prepareRequestAuth(ctx, exec, auth)
+	if errPrepareAuth != nil {
+		return nil, errPrepareAuth
+	}
+	if preparedAuth != nil {
+		auth = preparedAuth
 	}
 	return exec.HttpRequest(ctx, auth, req)
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3104,16 +3104,30 @@ func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) strin
 type APIKeyConfigEntry interface {
 	GetAPIKey() string
 	GetBaseURL() string
+	GetCommandAuth() *internalconfig.CommandAuthConfig
 }
 
 func resolveAPIKeyConfig[T APIKeyConfigEntry](entries []T, auth *Auth) *T {
 	if auth == nil || len(entries) == 0 {
 		return nil
 	}
-	attrKey, attrBase := "", ""
+	attrKey, attrBase, attrCommandKey := "", "", ""
 	if auth.Attributes != nil {
 		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
 		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+		attrCommandKey = strings.TrimSpace(auth.Attributes[AttrAuthCommandKey])
+	}
+	if attrCommandKey != "" {
+		for i := range entries {
+			entry := &entries[i]
+			cfgCommandKey := internalconfig.CommandAuthIdentity((*entry).GetCommandAuth())
+			cfgBase := strings.TrimSpace((*entry).GetBaseURL())
+			if cfgCommandKey != "" && strings.EqualFold(attrCommandKey, cfgCommandKey) {
+				if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
+					return entry
+				}
+			}
+		}
 	}
 	for i := range entries {
 		entry := &entries[i]
@@ -3162,22 +3176,6 @@ func resolveClaudeAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internal
 func resolveCodexAPIKeyConfig(cfg *internalconfig.Config, auth *Auth) *internalconfig.CodexKey {
 	if cfg == nil {
 		return nil
-	}
-	if auth != nil && auth.Attributes != nil {
-		attrCommandKey := strings.TrimSpace(auth.Attributes[AttrAuthCommandKey])
-		attrBase := strings.TrimSpace(auth.Attributes["base_url"])
-		if attrCommandKey != "" {
-			for i := range cfg.CodexKey {
-				entry := &cfg.CodexKey[i]
-				cfgCommandKey := internalconfig.CommandAuthIdentity(entry.Auth)
-				cfgBase := strings.TrimSpace(entry.BaseURL)
-				if cfgCommandKey != "" && strings.EqualFold(attrCommandKey, cfgCommandKey) {
-					if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
-						return entry
-					}
-				}
-			}
-		}
 	}
 	return resolveAPIKeyConfig(cfg.CodexKey, auth)
 }

--- a/sdk/cliproxy/auth/config_apikey.go
+++ b/sdk/cliproxy/auth/config_apikey.go
@@ -1,5 +1,21 @@
 package auth
 
+import "strings"
+
+const (
+	AttrAuthKind                 = "auth_kind"
+	AttrAuthSource               = "auth_source"
+	AttrAuthSourceCommand        = "command"
+	AttrAuthCommand              = "auth_command"
+	AttrAuthArgsJSON             = "auth_args_json"
+	AttrAuthCommandKey           = "auth_command_key"
+	AttrAuthTimeoutMS            = "auth_timeout_ms"
+	AttrAuthRefreshIntervalMS    = "auth_refresh_interval_ms"
+	AttrAuthInvalidatesOnNext401 = "auth_invalidate_on_401"
+	AttrAuthKindAPIKey           = "apikey"
+	AttrAuthKindAPIKeyUnderscore = "api_key"
+)
+
 // IsConfigAPIKeyAuth reports whether the auth entry is synthesized from config *-api-key lists.
 func IsConfigAPIKeyAuth(auth *Auth) bool {
 	if auth == nil {
@@ -12,4 +28,35 @@ func IsConfigAPIKeyAuth(auth *Auth) bool {
 		return false
 	}
 	return authAttribute(auth, AttributeAPIKey) != ""
+}
+
+// IsConfigCredentialAuth reports whether the auth entry is synthesized from configuration
+// credential sections. This includes static API keys and command-backed API-key-class auths.
+func IsConfigCredentialAuth(auth *Auth) bool {
+	if auth == nil || auth.Attributes == nil {
+		return false
+	}
+	source := strings.ToLower(strings.TrimSpace(auth.Attributes["source"]))
+	if !strings.HasPrefix(source, "config:") {
+		return false
+	}
+	if strings.TrimSpace(auth.Attributes["api_key"]) != "" {
+		return true
+	}
+	authKind := strings.ToLower(strings.TrimSpace(auth.Attributes[AttrAuthKind]))
+	if authKind == AttrAuthKindAPIKey || authKind == AttrAuthKindAPIKeyUnderscore {
+		return true
+	}
+	return IsCommandAuth(auth)
+}
+
+// IsCommandAuth reports whether the auth entry obtains its bearer token from a configured command.
+func IsCommandAuth(auth *Auth) bool {
+	if auth == nil || auth.Attributes == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Attributes[AttrAuthSource]), AttrAuthSourceCommand) {
+		return false
+	}
+	return strings.TrimSpace(auth.Attributes[AttrAuthCommand]) != ""
 }

--- a/sdk/cliproxy/auth/config_apikey_test.go
+++ b/sdk/cliproxy/auth/config_apikey_test.go
@@ -30,4 +30,31 @@ func TestIsConfigAPIKeyAuth(t *testing.T) {
 	}) {
 		t.Fatal("expected config api key auth")
 	}
+	if IsConfigAPIKeyAuth(&Auth{
+		ID:       "codex:apikey:command",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"source":        "config:codex[abc]",
+			AttrAuthKind:    AttrAuthKindAPIKey,
+			AttrAuthSource:  AttrAuthSourceCommand,
+			AttrAuthCommand: "fetch-token",
+		},
+	}) {
+		t.Fatal("expected command auth without static api_key to not be static config api key auth")
+	}
+}
+
+func TestIsConfigCredentialAuth(t *testing.T) {
+	if !IsConfigCredentialAuth(&Auth{
+		ID:       "codex:apikey:command",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"source":        "config:codex[abc]",
+			AttrAuthKind:    AttrAuthKindAPIKey,
+			AttrAuthSource:  AttrAuthSourceCommand,
+			AttrAuthCommand: "fetch-token",
+		},
+	}) {
+		t.Fatal("expected command auth to be config credential auth")
+	}
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2185,15 +2185,23 @@ func (s *Service) resolveConfigClaudeKey(auth *coreauth.Auth) *config.ClaudeKey 
 	if auth == nil || s.cfg == nil {
 		return nil
 	}
-	var attrKey, attrBase string
+	var attrKey, attrBase, attrCommandKey string
 	if auth.Attributes != nil {
 		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
 		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+		attrCommandKey = strings.TrimSpace(auth.Attributes[coreauth.AttrAuthCommandKey])
 	}
 	for i := range s.cfg.ClaudeKey {
 		entry := &s.cfg.ClaudeKey[i]
 		cfgKey := strings.TrimSpace(entry.APIKey)
 		cfgBase := strings.TrimSpace(entry.BaseURL)
+		cfgCommandKey := config.CommandAuthIdentity(entry.Auth)
+		if attrCommandKey != "" && cfgCommandKey != "" && strings.EqualFold(attrCommandKey, cfgCommandKey) {
+			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
+			continue
+		}
 		if attrKey != "" && attrBase != "" {
 			if strings.EqualFold(cfgKey, attrKey) && strings.EqualFold(cfgBase, attrBase) {
 				return entry
@@ -2224,15 +2232,23 @@ func (s *Service) resolveConfigGeminiKey(auth *coreauth.Auth) *config.GeminiKey 
 	if auth == nil || s.cfg == nil {
 		return nil
 	}
-	var attrKey, attrBase string
+	var attrKey, attrBase, attrCommandKey string
 	if auth.Attributes != nil {
 		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
 		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+		attrCommandKey = strings.TrimSpace(auth.Attributes[coreauth.AttrAuthCommandKey])
 	}
 	for i := range s.cfg.GeminiKey {
 		entry := &s.cfg.GeminiKey[i]
 		cfgKey := strings.TrimSpace(entry.APIKey)
 		cfgBase := strings.TrimSpace(entry.BaseURL)
+		cfgCommandKey := config.CommandAuthIdentity(entry.Auth)
+		if attrCommandKey != "" && cfgCommandKey != "" && strings.EqualFold(attrCommandKey, cfgCommandKey) {
+			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
+			continue
+		}
 		if attrKey != "" && strings.EqualFold(cfgKey, attrKey) {
 			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
 				return entry
@@ -2250,15 +2266,23 @@ func (s *Service) resolveConfigVertexCompatKey(auth *coreauth.Auth) *config.Vert
 	if auth == nil || s.cfg == nil {
 		return nil
 	}
-	var attrKey, attrBase string
+	var attrKey, attrBase, attrCommandKey string
 	if auth.Attributes != nil {
 		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
 		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+		attrCommandKey = strings.TrimSpace(auth.Attributes[coreauth.AttrAuthCommandKey])
 	}
 	for i := range s.cfg.VertexCompatAPIKey {
 		entry := &s.cfg.VertexCompatAPIKey[i]
 		cfgKey := strings.TrimSpace(entry.APIKey)
 		cfgBase := strings.TrimSpace(entry.BaseURL)
+		cfgCommandKey := config.CommandAuthIdentity(entry.Auth)
+		if attrCommandKey != "" && cfgCommandKey != "" && strings.EqualFold(attrCommandKey, cfgCommandKey) {
+			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
+			continue
+		}
 		if attrKey != "" && strings.EqualFold(cfgKey, attrKey) {
 			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
 				return entry

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -335,7 +335,7 @@ func (s *Service) runModelRegistrationTaskPhase(ctx context.Context, tasks []mod
 }
 
 func modelRegistrationPhase(auth *coreauth.Auth) int {
-	if coreauth.IsConfigAPIKeyAuth(auth) {
+	if coreauth.IsConfigCredentialAuth(auth) {
 		return modelRegistrationPhaseConfigAPIKey
 	}
 	return modelRegistrationPhaseOther
@@ -1380,7 +1380,7 @@ func (s *Service) registerConfigAPIKeyAuths(ctx context.Context, cfg *config.Con
 	tasks := make([]modelRegistrationTask, 0, len(auths))
 	needsAliasRebuild := false
 	for _, auth := range auths {
-		if !coreauth.IsConfigAPIKeyAuth(auth) {
+		if !coreauth.IsConfigCredentialAuth(auth) {
 			continue
 		}
 		prepared := s.prepareCoreAuthForModelRegistration(registrationCtx, auth)
@@ -2284,15 +2284,23 @@ func (s *Service) resolveConfigCodexKey(auth *coreauth.Auth) *config.CodexKey {
 	if auth == nil || s.cfg == nil {
 		return nil
 	}
-	var attrKey, attrBase string
+	var attrKey, attrBase, attrCommandKey string
 	if auth.Attributes != nil {
 		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
 		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
+		attrCommandKey = strings.TrimSpace(auth.Attributes[coreauth.AttrAuthCommandKey])
 	}
 	for i := range s.cfg.CodexKey {
 		entry := &s.cfg.CodexKey[i]
 		cfgKey := strings.TrimSpace(entry.APIKey)
 		cfgBase := strings.TrimSpace(entry.BaseURL)
+		cfgCommandKey := config.CommandAuthIdentity(entry.Auth)
+		if attrCommandKey != "" && cfgCommandKey != "" && strings.EqualFold(attrCommandKey, cfgCommandKey) {
+			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
+				return entry
+			}
+			continue
+		}
 		if attrKey != "" && strings.EqualFold(cfgKey, attrKey) {
 			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
 				return entry

--- a/sdk/cliproxy/service_command_auth_resolve_test.go
+++ b/sdk/cliproxy/service_command_auth_resolve_test.go
@@ -1,0 +1,43 @@
+package cliproxy
+
+import (
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+// TestResolveConfigKeys_MatchCommandAuth verifies that command-backed credentials
+// without an api-key or base-url are matched by their command identity during model
+// registration, mirroring the Codex resolver.
+func TestResolveConfigKeys_MatchCommandAuth(t *testing.T) {
+	geminiAuth := &config.CommandAuthConfig{Command: "fetch-gemini"}
+	claudeAuth := &config.CommandAuthConfig{Command: "fetch-claude"}
+	vertexAuth := &config.CommandAuthConfig{Command: "fetch-vertex"}
+
+	service := &Service{cfg: &config.Config{
+		GeminiKey:          []config.GeminiKey{{Auth: geminiAuth}},
+		ClaudeKey:          []config.ClaudeKey{{Auth: claudeAuth}},
+		VertexCompatAPIKey: []config.VertexCompatKey{{Auth: vertexAuth}},
+	}}
+
+	mkAuth := func(provider string, auth *config.CommandAuthConfig) *coreauth.Auth {
+		return &coreauth.Auth{
+			Provider: provider,
+			Attributes: map[string]string{
+				"source":                    "config:" + provider + "[abc]",
+				coreauth.AttrAuthCommandKey: config.CommandAuthIdentity(auth),
+			},
+		}
+	}
+
+	if got := service.resolveConfigGeminiKey(mkAuth("gemini", geminiAuth)); got == nil || got.Auth != geminiAuth {
+		t.Fatalf("gemini resolver did not match command-auth entry: %#v", got)
+	}
+	if got := service.resolveConfigClaudeKey(mkAuth("claude", claudeAuth)); got == nil || got.Auth != claudeAuth {
+		t.Fatalf("claude resolver did not match command-auth entry: %#v", got)
+	}
+	if got := service.resolveConfigVertexCompatKey(mkAuth("vertex", vertexAuth)); got == nil || got.Auth != vertexAuth {
+		t.Fatalf("vertex resolver did not match command-auth entry: %#v", got)
+	}
+}

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -27,6 +27,7 @@ type VertexCompatModel = internalconfig.VertexCompatModel
 type OpenAICompatibility = internalconfig.OpenAICompatibility
 type OpenAICompatibilityAPIKey = internalconfig.OpenAICompatibilityAPIKey
 type OpenAICompatibilityModel = internalconfig.OpenAICompatibilityModel
+type CommandAuthConfig = internalconfig.CommandAuthConfig
 
 type TLS = internalconfig.TLSConfig
 
@@ -41,6 +42,10 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 }
 
 func ParseConfigBytes(data []byte) (*Config, error) { return internalconfig.ParseConfigBytes(data) }
+
+func CommandAuthIdentity(auth *CommandAuthConfig) string {
+	return internalconfig.CommandAuthIdentity(auth)
+}
 
 func SaveConfigPreserveComments(configFile string, cfg *Config) error {
 	return internalconfig.SaveConfigPreserveComments(configFile, cfg)


### PR DESCRIPTION
## Summary
- add command-backed credential support for Codex and OpenAI-compatible provider config
- resolve command auth tokens before request execution, refresh due command-auth tokens, and invalidate cached command tokens on 401
- expose command auth metadata in management APIs, including `auth_key` and `auth_source=command`
- match command-auth usage stats by stable non-secret auth identity while preserving OpenAI-compatible `compat_name` provider grouping

## Related PRs
- Management Center UI support: router-for-me/Cli-Proxy-API-Management-Center#327
