### PR TITLE
fix(usage): group openai-compatibility api-key-usage by bare provider name

### DIFF
--- a/internal/api/handlers/management/api_key_usage.go
+++ b/internal/api/handlers/management/api_key_usage.go
@@ -40,6 +40,30 @@ func mergeRecentRequestBuckets(dst, src []coreauth.RecentRequestBucket) []coreau
 	return dst
 }
 
+
+// usageProviderKey resolves the provider key used to group usage statistics.
+//
+// For OpenAI-compatible providers, auth.Provider carries the namespaced key
+// introduced by provider-key unification (e.g. "openai-compatible-vast"); that
+// namespace is required for executor routing (see #3600). The usage/statistics
+// surface and the Management Center panel, however, address these providers by
+// their bare config name (e.g. "vast"), which is preserved on the auth as
+// compat_name. Returning the bare name here keeps the usage grouping aligned
+// with what the panel looks up, restoring recent-requests/totals display for
+// OpenAI-compatible providers. Other provider kinds keep strings.ToLower(auth.Provider).
+func usageProviderKey(auth *coreauth.Auth) string {
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	if provider == "" {
+		return "unknown"
+	}
+	if auth.Attributes != nil {
+		if compatName := strings.TrimSpace(auth.Attributes["compat_name"]); compatName != "" {
+			return strings.ToLower(compatName)
+		}
+	}
+	return provider
+}
+
 // GetAPIKeyUsage returns recent request buckets for all in-memory api_key auths,
 // grouped by provider and keyed by "base_url|api_key".
 func (h *Handler) GetAPIKeyUsage(c *gin.Context) {
@@ -78,10 +102,7 @@ func (h *Handler) GetAPIKeyUsage(c *gin.Context) {
 			}
 		}
 		compositeKey := baseURL + "|" + apiKey
-		provider := strings.ToLower(strings.TrimSpace(auth.Provider))
-		if provider == "" {
-			provider = "unknown"
-		}
+		provider := usageProviderKey(auth)
 
 		recent := auth.RecentRequestsSnapshot(now)
 		providerBucket, ok := out[provider]

--- a/internal/api/handlers/management/api_key_usage.go
+++ b/internal/api/handlers/management/api_key_usage.go
@@ -40,7 +40,6 @@ func mergeRecentRequestBuckets(dst, src []coreauth.RecentRequestBucket) []coreau
 	return dst
 }
 
-
 // usageProviderKey resolves the provider key used to group usage statistics.
 //
 // For OpenAI-compatible providers, auth.Provider carries the namespaced key
@@ -51,7 +50,12 @@ func mergeRecentRequestBuckets(dst, src []coreauth.RecentRequestBucket) []coreau
 // compat_name. Returning the bare name here keeps the usage grouping aligned
 // with what the panel looks up, restoring recent-requests/totals display for
 // OpenAI-compatible providers. Other provider kinds keep strings.ToLower(auth.Provider).
+// If compat_name is missing for some reason, the openai-compatible- namespace
+// prefix is stripped as a fallback so the bare name still matches the panel.
 func usageProviderKey(auth *coreauth.Auth) string {
+	if auth == nil {
+		return "unknown"
+	}
 	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
 	if provider == "" {
 		return "unknown"
@@ -61,7 +65,10 @@ func usageProviderKey(auth *coreauth.Auth) string {
 			return strings.ToLower(compatName)
 		}
 	}
-	return provider
+	// Fallback: an OpenAI-compatible auth that reached here without compat_name
+	// still carries the namespaced provider key; strip the namespace so the panel
+	// (which looks up by the bare name) can match its usage.
+	return strings.TrimPrefix(provider, "openai-compatible-")
 }
 
 // GetAPIKeyUsage returns recent request buckets for all in-memory api_key auths,

--- a/internal/api/handlers/management/api_key_usage_test.go
+++ b/internal/api/handlers/management/api_key_usage_test.go
@@ -127,6 +127,52 @@ func TestGetAPIKeyUsage_GroupsByProviderAndAPIKey(t *testing.T) {
 		t.Fatalf("vast totals = %d/%d, want 1/1", vastSuccess, vastFailed)
 	}
 }
+func TestUsageProviderKey(t *testing.T) {
+	tests := []struct {
+		name string
+		auth *coreauth.Auth
+		want string
+	}{
+		{
+			name: "nil auth",
+			auth: nil,
+			want: "unknown",
+		},
+		{
+			name: "empty provider",
+			auth: &coreauth.Auth{Provider: ""},
+			want: "unknown",
+		},
+		{
+			name: "non-openai-compat provider passes through",
+			auth: &coreauth.Auth{Provider: "codex"},
+			want: "codex",
+		},
+		{
+			name: "openai-compat uses bare compat_name",
+			auth: &coreauth.Auth{
+				Provider:   "openai-compatible-vast",
+				Attributes: map[string]string{"compat_name": "VAST"},
+			},
+			want: "vast",
+		},
+		{
+			name: "openai-compat without compat_name strips namespace fallback",
+			auth: &coreauth.Auth{
+				Provider:   "openai-compatible-vast",
+				Attributes: map[string]string{},
+			},
+			want: "vast",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := usageProviderKey(tt.auth); got != tt.want {
+				t.Fatalf("usageProviderKey(%+v) = %q, want %q", tt.auth, got, tt.want)
+			}
+		})
+	}
+}
 
 func payloadKeys(m map[string]map[string]apiKeyUsageEntry) []string {
 	keys := make([]string, 0, len(m))

--- a/internal/api/handlers/management/api_key_usage_test.go
+++ b/internal/api/handlers/management/api_key_usage_test.go
@@ -47,9 +47,22 @@ func TestGetAPIKeyUsage_GroupsByProviderAndAPIKey(t *testing.T) {
 		t.Fatalf("register claude auth: %v", err)
 	}
 
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       "vast-auth",
+		Provider: "openai-compatible-vast",
+		Attributes: map[string]string{
+			"api_key":     "vast-key",
+			"base_url":    "https://www.vastnum.com/v1",
+			"compat_name": "VAST",
+		},
+	}); err != nil {
+		t.Fatalf("register vast openai-compat auth: %v", err)
+	}
 	manager.MarkResult(context.Background(), coreauth.Result{AuthID: "codex-auth", Provider: "codex", Model: "gpt-5", Success: true})
 	manager.MarkResult(context.Background(), coreauth.Result{AuthID: "codex-auth", Provider: "codex", Model: "gpt-5", Success: false})
 	manager.MarkResult(context.Background(), coreauth.Result{AuthID: "claude-auth", Provider: "claude", Model: "claude-4", Success: true})
+	manager.MarkResult(context.Background(), coreauth.Result{AuthID: "vast-auth", Provider: "openai-compatible-vast", Model: "deepseek-v3", Success: true})
+	manager.MarkResult(context.Background(), coreauth.Result{AuthID: "vast-auth", Provider: "openai-compatible-vast", Model: "deepseek-v3", Success: false})
 
 	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
 
@@ -91,4 +104,34 @@ func TestGetAPIKeyUsage_GroupsByProviderAndAPIKey(t *testing.T) {
 	if claudeSuccess != 1 || claudeFailed != 0 {
 		t.Fatalf("claude totals = %d/%d, want 1/0", claudeSuccess, claudeFailed)
 	}
+
+	// OpenAI-compatible providers carry a namespaced auth.Provider (e.g.
+	// "openai-compatible-vast") but must be grouped under their bare config name
+	// ("vast") so the Management Center panel, which looks up by provider name,
+	// can match recent-requests and totals. Regression for #3940.
+	if _, ok := payload["openai-compatible-vast"]; ok {
+		t.Fatalf("openai-compat auth should NOT be grouped under namespaced key %q", "openai-compatible-vast")
+	}
+	vastEntry, ok := payload["vast"]["https://www.vastnum.com/v1|vast-key"]
+	if !ok {
+		t.Fatalf("vast entry missing under bare provider key; payload keys = %v", payloadKeys(payload))
+	}
+	if vastEntry.Success != 1 || vastEntry.Failed != 1 {
+		t.Fatalf("vast totals = %d/%d, want 1/1", vastEntry.Success, vastEntry.Failed)
+	}
+	if len(vastEntry.RecentRequests) != 20 {
+		t.Fatalf("vast buckets len = %d, want 20", len(vastEntry.RecentRequests))
+	}
+	vastSuccess, vastFailed := sumRecentRequestBuckets(vastEntry.RecentRequests)
+	if vastSuccess != 1 || vastFailed != 1 {
+		t.Fatalf("vast totals = %d/%d, want 1/1", vastSuccess, vastFailed)
+	}
+}
+
+func payloadKeys(m map[string]map[string]apiKeyUsageEntry) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
## Summary

Fixes #3940. Restores recent-requests / per-key usage display for `openai-compatibility` providers in the Management Center, broken as a side effect of the provider-key unification in `4c78e40d` (which closed #3600).

## Problem

`4c78e40d` made `synthesizeOpenAICompat` store `auth.Provider = util.OpenAICompatibleProviderKey(name)`, i.e. the namespaced key `openai-compatible-<name>` (e.g. `openai-compatible-vast`) instead of the bare lowercased `name`. That namespace is the correct fix for #3600 at the **executor/routing** layer.

However, `GetAPIKeyUsage` groups usage statistics by `strings.ToLower(auth.Provider)`:

```go
provider := strings.ToLower(strings.TrimSpace(auth.Provider))
// = "openai-compatible-vast"  for openai-compatibility auths
```

The Management Center panel addresses OpenAI-compatible providers by their bare config `name` lowercased (e.g. `vast`), with no `openai-compatible-` prefix. Result: the two sides never match, so the recent-request status bar and totals are empty for **every** `openai-compatibility` provider, even though traffic flows normally.

Before `4c78e40d`, `auth.Provider` was the bare lowercased `name`, which matched the panel — so this is a regression introduced when fixing #3600.

## Fix

Group usage by the **bare `compat_name`** (already stored on the auth attributes by `synthesizeOpenAICompat`) for OpenAI-compatible auths, instead of the namespaced `auth.Provider`. `auth.Provider` is left untouched, so #3600's executor namespacing is fully preserved — only the usage/statistics grouping is realigned.

```go
func usageProviderKey(auth *coreauth.Auth) string {
	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
	if provider == "" {
		return "unknown"
	}
	if auth.Attributes != nil {
		if compatName := strings.TrimSpace(auth.Attributes["compat_name"]); compatName != "" {
			return strings.ToLower(compatName)
		}
	}
	return provider
}
```

A unit test (`TestGetAPIKeyUsage_GroupsByProviderAndAPIKey`) is extended to register an openai-compatibility auth whose `auth.Provider` is the namespaced `openai-compatible-vast` with `compat_name = "VAST"`, and assert it is grouped under `vast` (not under `openai-compatible-vast`). Verified the test fails on `main` without the fix and passes with it.

## Why backend, not panel

The usage API is the source of truth and `compat_name` is already available on the auth, so the backend change is minimal and self-contained. The alternative (have the panel prepend `openai-compatible-` when looking up OpenAI-compatible providers) would couple every consumer of the usage API to the internal namespace.

## Verification

- `go vet ./internal/api/handlers/management/` — clean
- `go test ./internal/api/handlers/management/ -run TestGetAPIKeyUsage` — PASS (with fix), FAIL (without fix, on the new assertion)

A pre-existing unrelated failure (`TestWriteOAuthCallbackFileForPendingSessionCreatesMissingAuthDirForCallbackProviders/gemini`) is present on clean `main` as well and is not affected by this change.

## Risk

Low. The change is confined to the read-only usage-aggregation handler; request routing, executor registration, cooldown, and the #3600 collision fix are all keyed off `auth.Provider` / `provider_key` elsewhere and are untouched.

Fixes #3940
