### PR TITLE
fix(auth): cool down credentials on transport-level errors

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1601,11 +1601,20 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 		emit := func(chunk cliproxyexecutor.StreamChunk) bool {
 			if chunk.Err != nil && !failed {
 				failed = true
-				rerr := &Error{Message: chunk.Err.Error()}
-				if se, ok := errors.AsType[cliproxyexecutor.StatusError](chunk.Err); ok && se != nil {
-					rerr.HTTPStatus = se.StatusCode()
+				// Client-initiated cancellations (context.Canceled) and
+				// deadline expirations surface as zero-status chunk errors
+				// rather than upstream transport failures; do not cool down
+				// the credential for them.
+				isClientCancel := errors.Is(chunk.Err, context.Canceled) ||
+					errors.Is(chunk.Err, context.DeadlineExceeded) ||
+					ctx.Err() != nil
+				if !isClientCancel {
+					rerr := &Error{Message: chunk.Err.Error()}
+					if se, ok := errors.AsType[cliproxyexecutor.StatusError](chunk.Err); ok && se != nil {
+						rerr.HTTPStatus = se.StatusCode()
+					}
+					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr})
 				}
-				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr})
 			}
 			if !forward {
 				return false
@@ -3970,8 +3979,11 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		if statusCode == 0 && !disableCooling {
 			auth.StatusMessage = "transport error"
 			auth.NextRetryAfter = nextTransientErrorRetryAfter(now)
-		} else if auth.StatusMessage == "" {
-			auth.StatusMessage = "request failed"
+		} else {
+			auth.NextRetryAfter = time.Time{}
+			if auth.StatusMessage == "" {
+				auth.StatusMessage = "request failed"
+			}
 		}
 	}
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -1609,10 +1610,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 					errors.Is(chunk.Err, context.DeadlineExceeded) ||
 					ctx.Err() != nil
 				if !isClientCancel {
-					rerr := &Error{Message: chunk.Err.Error()}
-					if se, ok := errors.AsType[cliproxyexecutor.StatusError](chunk.Err); ok && se != nil {
-						rerr.HTTPStatus = se.StatusCode()
-					}
+					rerr := errorToResultError(chunk.Err)
 					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr})
 				}
 			}
@@ -1667,10 +1665,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			if errCtx := ctx.Err(); errCtx != nil {
 				return nil, errCtx
 			}
-			rerr := &Error{Message: errStream.Error()}
-			if se, ok := errors.AsType[cliproxyexecutor.StatusError](errStream); ok && se != nil {
-				rerr.HTTPStatus = se.StatusCode()
-			}
+			rerr := errorToResultError(errStream)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 			result.RetryAfter = retryAfterFromError(errStream)
 			m.MarkResult(ctx, result)
@@ -1688,10 +1683,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				return nil, errCtx
 			}
 			if isRequestInvalidError(bootstrapErr) {
-				rerr := &Error{Message: bootstrapErr.Error()}
-				if se, ok := errors.AsType[cliproxyexecutor.StatusError](bootstrapErr); ok && se != nil {
-					rerr.HTTPStatus = se.StatusCode()
-				}
+				rerr := errorToResultError(bootstrapErr)
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				m.MarkResult(ctx, result)
@@ -1699,10 +1691,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				return nil, bootstrapErr
 			}
 			if idx < len(execModels)-1 {
-				rerr := &Error{Message: bootstrapErr.Error()}
-				if se, ok := errors.AsType[cliproxyexecutor.StatusError](bootstrapErr); ok && se != nil {
-					rerr.HTTPStatus = se.StatusCode()
-				}
+				rerr := errorToResultError(bootstrapErr)
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				m.MarkResult(ctx, result)
@@ -1710,10 +1699,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				lastErr = bootstrapErr
 				continue
 			}
-			rerr := &Error{Message: bootstrapErr.Error()}
-			if se, ok := errors.AsType[cliproxyexecutor.StatusError](bootstrapErr); ok && se != nil {
-				rerr.HTTPStatus = se.StatusCode()
-			}
+			rerr := errorToResultError(bootstrapErr)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
 			m.MarkResult(ctx, result)
@@ -2360,10 +2346,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if errCtx := execCtx.Err(); errCtx != nil {
 					return cliproxyexecutor.Response{}, errCtx
 				}
-				result.Error = &Error{Message: errExec.Error()}
-				if se, ok := errors.AsType[cliproxyexecutor.StatusError](errExec); ok && se != nil {
-					result.Error.HTTPStatus = se.StatusCode()
-				}
+				result.Error = errorToResultError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
@@ -2461,10 +2444,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				if errCtx := execCtx.Err(); errCtx != nil {
 					return cliproxyexecutor.Response{}, errCtx
 				}
-				result.Error = &Error{Message: errExec.Error()}
-				if se, ok := errors.AsType[cliproxyexecutor.StatusError](errExec); ok && se != nil {
-					result.Error.HTTPStatus = se.StatusCode()
-				}
+				result.Error = errorToResultError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
@@ -3453,15 +3433,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								state.NextRetryAfter = nextTransientErrorRetryAfter(now)
 							}
 						default:
-							// Transport-level errors (TLS failures, connection
-							// resets, DNS) carry no HTTP status code; cool down
-							// briefly so the credential isn't immediately
-							// re-selected against a broken upstream connection.
-							if statusCode == 0 && !disableCooling {
-								state.NextRetryAfter = nextTransientErrorRetryAfter(now)
-							} else {
-								state.NextRetryAfter = time.Time{}
-							}
+							state.NextRetryAfter = time.Time{}
 						}
 					}
 
@@ -3683,6 +3655,31 @@ func errorString(err error) string {
 		return ""
 	}
 	return err.Error()
+}
+
+// errorToResultError converts an executor error into the *Error shape stored
+// on a Result. It preserves an explicit HTTP status when the error implements
+// StatusError. Transport-level failures returned by http.Client.Do are
+// *url.Error with no status code; map them to 502 so the cooldown switch
+// treats them as transient upstream errors instead of falling through the
+// default branch (which would leave the credential immediately re-selectable,
+// or, for genuine local validation errors that also carry status 0, would
+// incorrectly cool down a credential for a bad client request).
+func errorToResultError(err error) *Error {
+	if err == nil {
+		return nil
+	}
+	e := &Error{Message: err.Error()}
+	if se, ok := errors.AsType[cliproxyexecutor.StatusError](err); ok && se != nil {
+		e.HTTPStatus = se.StatusCode()
+		return e
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		e.HTTPStatus = http.StatusBadGateway
+		e.Retryable = true
+	}
+	return e
 }
 
 func statusCodeFromError(err error) int {
@@ -3972,18 +3969,8 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.NextRetryAfter = nextTransientErrorRetryAfter(now)
 		}
 	default:
-		// Transport-level errors (TLS failures, connection resets, DNS)
-		// carry no HTTP status code; cool down briefly so the credential
-		// isn't immediately re-selected against a broken upstream
-		// connection.
-		if statusCode == 0 && !disableCooling {
-			auth.StatusMessage = "transport error"
-			auth.NextRetryAfter = nextTransientErrorRetryAfter(now)
-		} else {
-			auth.NextRetryAfter = time.Time{}
-			if auth.StatusMessage == "" {
-				auth.StatusMessage = "request failed"
-			}
+		if auth.StatusMessage == "" {
+			auth.StatusMessage = "request failed"
 		}
 	}
 }
@@ -4985,10 +4972,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
 			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
-				result.Error = &Error{Message: errExec.Error()}
-				if se, ok := errors.AsType[cliproxyexecutor.StatusError](errExec); ok && se != nil {
-					result.Error.HTTPStatus = se.StatusCode()
-				}
+				result.Error = errorToResultError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4994,6 +4994,11 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
 			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
+				// A client cancellation surfaces as a *url.Error wrapping the
+				// context error; do not cool down the credits credential for it.
+				if errCtx := creditsCtx.Err(); errCtx != nil {
+					return cliproxyexecutor.Response{}, false, nil
+				}
 				result.Error = errorToResultError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3444,7 +3444,15 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								state.NextRetryAfter = nextTransientErrorRetryAfter(now)
 							}
 						default:
-							state.NextRetryAfter = time.Time{}
+							// Transport-level errors (TLS failures, connection
+							// resets, DNS) carry no HTTP status code; cool down
+							// briefly so the credential isn't immediately
+							// re-selected against a broken upstream connection.
+							if statusCode == 0 && !disableCooling {
+								state.NextRetryAfter = nextTransientErrorRetryAfter(now)
+							} else {
+								state.NextRetryAfter = time.Time{}
+							}
 						}
 					}
 
@@ -3955,7 +3963,14 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.NextRetryAfter = nextTransientErrorRetryAfter(now)
 		}
 	default:
-		if auth.StatusMessage == "" {
+		// Transport-level errors (TLS failures, connection resets, DNS)
+		// carry no HTTP status code; cool down briefly so the credential
+		// isn't immediately re-selected against a broken upstream
+		// connection.
+		if statusCode == 0 && !disableCooling {
+			auth.StatusMessage = "transport error"
+			auth.NextRetryAfter = nextTransientErrorRetryAfter(now)
+		} else if auth.StatusMessage == "" {
 			auth.StatusMessage = "request failed"
 		}
 	}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1610,7 +1610,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 					errors.Is(chunk.Err, context.DeadlineExceeded) ||
 					ctx.Err() != nil
 				if !isClientCancel {
-					rerr := errorToResultError(chunk.Err)
+					rerr := errorToStreamResultError(chunk.Err)
 					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr})
 				}
 			}
@@ -3679,6 +3679,28 @@ func errorToResultError(err error) *Error {
 		e.HTTPStatus = http.StatusBadGateway
 		e.Retryable = true
 	}
+	return e
+}
+
+// errorToStreamResultError converts a streaming chunk error into the *Error
+// shape stored on a Result. Unlike the non-streaming path, by the time a
+// stream is producing chunks the request has already been accepted upstream,
+// so there are no local request-validation errors here: any chunk error is
+// either a client-initiated cancellation (filtered by the caller) or an
+// upstream/transport failure. Map bare errors to 502 so mid-stream resets,
+// TLS errors and truncated reads cool down the credential instead of
+// falling through the cooldown switch default branch.
+func errorToStreamResultError(err error) *Error {
+	if err == nil {
+		return nil
+	}
+	e := &Error{Message: err.Error()}
+	if se, ok := errors.AsType[cliproxyexecutor.StatusError](err); ok && se != nil {
+		e.HTTPStatus = se.StatusCode()
+		return e
+	}
+	e.HTTPStatus = http.StatusBadGateway
+	e.Retryable = true
 	return e
 }
 

--- a/sdk/cliproxy/auth/transport_cooldown_test.go
+++ b/sdk/cliproxy/auth/transport_cooldown_test.go
@@ -2,16 +2,48 @@ package auth
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
+// TestErrorToResultError_MapsTransportErrorToBadGateway verifies that a
+// transport-level failure returned by http.Client.Do (a *url.Error) is mapped
+// to HTTP 502 so the cooldown switch treats it as a transient upstream error.
+// A bare local validation error (no status, not a *url.Error) stays at 0.
+func TestErrorToResultError_MapsTransportErrorToBadGateway(t *testing.T) {
+	t.Run("transport error mapped to 502", func(t *testing.T) {
+		err := &url.Error{Op: "Post", URL: "https://example.com/v1/chat/completions", Err: errors.New("remote error: tls: bad record MAC")}
+		got := errorToResultError(err)
+		if got.HTTPStatus != http.StatusBadGateway {
+			t.Fatalf("HTTPStatus = %d, want %d", got.HTTPStatus, http.StatusBadGateway)
+		}
+		if !got.Retryable {
+			t.Fatalf("Retryable = false, want true")
+		}
+		if got.Message == "" {
+			t.Fatalf("Message is empty")
+		}
+	})
+	t.Run("local validation error stays status 0", func(t *testing.T) {
+		got := errorToResultError(errors.New("multipart boundary is missing"))
+		if got.HTTPStatus != 0 {
+			t.Fatalf("HTTPStatus = %d, want 0 (local validation errors carry no HTTP status)", got.HTTPStatus)
+		}
+		if got.Retryable {
+			t.Fatalf("Retryable = true, want false")
+		}
+	})
+}
+
 // TestMarkResult_TransportErrorCooldownsModel verifies that a transport-level
-// failure (TLS error, connection reset) carrying no HTTP status code still
-// triggers a short cooldown at the model-state level. Previously the default
-// cooldown branch left NextRetryAfter zero, so the broken credential was
+// failure mapped to 502 triggers a short cooldown at the model-state level.
+// Previously such errors carried no HTTP status and fell into the default
+// branch, leaving NextRetryAfter zero so the broken credential was
 // immediately re-selected on every retry.
 func TestMarkResult_TransportErrorCooldownsModel(t *testing.T) {
 	manager := NewManager(nil, nil, nil)
@@ -25,10 +57,11 @@ func TestMarkResult_TransportErrorCooldownsModel(t *testing.T) {
 		Provider: "openai-compatibility",
 		Model:    "gpt-5",
 		Success:  false,
+		// errorToResultError maps *url.Error to 502; simulate that here.
 		Error: &Error{
-			Message:   `Post "https://example.com/v1/chat/completions": remote error: tls: bad record MAC`,
-			Retryable: true,
-			// HTTPStatus intentionally zero: transport errors carry no HTTP status.
+			Message:    `Post "https://example.com/v1/chat/completions": remote error: tls: bad record MAC`,
+			Retryable:  true,
+			HTTPStatus: http.StatusBadGateway,
 		},
 	})
 
@@ -59,8 +92,8 @@ func TestMarkResult_TransportErrorCooldownsAuth(t *testing.T) {
 		Provider: "openai-compatibility",
 		Success:  false,
 		Error: &Error{
-			Message:   `dial tcp: connection reset by peer`,
-			Retryable: true,
+			Message:    `dial tcp: connection reset by peer`,
+			HTTPStatus: http.StatusBadGateway,
 		},
 	})
 
@@ -71,13 +104,10 @@ func TestMarkResult_TransportErrorCooldownsAuth(t *testing.T) {
 	if got.NextRetryAfter.IsZero() {
 		t.Fatalf("transport error did not cool down auth: NextRetryAfter is zero, want non-zero")
 	}
-	if got.StatusMessage != "transport error" {
-		t.Fatalf("StatusMessage = %q, want %q", got.StatusMessage, "transport error")
-	}
 }
 
-// TestMarkResult_TransportErrorNoCooldownWhenDisabled ensures the new
-// cooldown is skipped when cooling is globally disabled.
+// TestMarkResult_TransportErrorNoCooldownWhenDisabled ensures the cooldown
+// is skipped when cooling is globally disabled.
 func TestMarkResult_TransportErrorNoCooldownWhenDisabled(t *testing.T) {
 	SetQuotaCooldownDisabled(true)
 	t.Cleanup(func() { SetQuotaCooldownDisabled(false) })
@@ -93,34 +123,53 @@ func TestMarkResult_TransportErrorNoCooldownWhenDisabled(t *testing.T) {
 		Provider: "openai-compatibility",
 		Model:    "gpt-5",
 		Success:  false,
-		Error:    &Error{Message: `tls: bad record MAC`, Retryable: true},
+		Error: &Error{
+			Message:    `tls: bad record MAC`,
+			HTTPStatus: http.StatusBadGateway,
+		},
 	})
 
 	got := snapshotAuthByID(manager, auth.ID)
 	if got == nil {
 		t.Fatalf("auth %s not found in snapshot", auth.ID)
 	}
-	blocked, _, _ := isAuthBlockedForModel(got, "gpt-5", time.Now())
-	if blocked {
+	if blocked, _, _ := isAuthBlockedForModel(got, "gpt-5", time.Now()); blocked {
 		t.Fatalf("credential was cooled down despite cooling being globally disabled")
 	}
 }
 
-// snapshotAuthByID returns a clone of the auth with the given ID from the
-// manager's current snapshot.
-func snapshotAuthByID(m *Manager, id string) *Auth {
-	for _, a := range m.snapshotAuths() {
-		if a.ID == id {
-			return a
-		}
+// TestMarkResult_LocalValidationErrorDoesNotCooldown verifies that a local
+// request-validation error (no HTTP status, not a transport error) does not
+// cool down a credential, since it reflects a malformed client request rather
+// than an upstream outage.
+func TestMarkResult_LocalValidationErrorDoesNotCooldown(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-local-validation", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register() error: %v", err)
 	}
-	return nil
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "openai-compatibility",
+		Model:    "gpt-5",
+		Success:  false,
+		Error:    &Error{Message: "multipart boundary is missing"}, // HTTPStatus 0, not a transport error
+	})
+
+	got := snapshotAuthByID(manager, auth.ID)
+	if got == nil {
+		t.Fatalf("auth %s not found in snapshot", auth.ID)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(got, "gpt-5", time.Now()); blocked {
+		t.Fatalf("local validation error incorrectly cooled down the credential")
+	}
 }
 
 // TestWrapStreamResult_ClientCancellationDoesNotCooldown verifies that a
 // stream chunk error caused by the client cancelling the request
-// (context.Canceled) is filtered out before reaching MarkResult, so a
-// healthy credential is not put into cooldown for an aborted SSE stream.
+// (context.Canceled) is filtered out before reaching MarkResult, so a healthy
+// credential is not put into cooldown for an aborted SSE stream.
 func TestWrapStreamResult_ClientCancellationDoesNotCooldown(t *testing.T) {
 	manager := NewManager(nil, nil, nil)
 	auth := &Auth{ID: "auth-cancel-stream", Provider: "openai-compatibility", Status: StatusActive}
@@ -143,4 +192,15 @@ func TestWrapStreamResult_ClientCancellationDoesNotCooldown(t *testing.T) {
 	if blocked, _, _ := isAuthBlockedForModel(got, "gpt-5", time.Now()); blocked {
 		t.Fatalf("client cancellation of a stream incorrectly cooled down a healthy credential")
 	}
+}
+
+// snapshotAuthByID returns a clone of the auth with the given ID from the
+// manager's current snapshot.
+func snapshotAuthByID(m *Manager, id string) *Auth {
+	for _, a := range m.snapshotAuths() {
+		if a.ID == id {
+			return a
+		}
+	}
+	return nil
 }

--- a/sdk/cliproxy/auth/transport_cooldown_test.go
+++ b/sdk/cliproxy/auth/transport_cooldown_test.go
@@ -181,7 +181,9 @@ func TestWrapStreamResult_ClientCancellationDoesNotCooldown(t *testing.T) {
 	cancel() // simulate a client that disconnected mid-stream
 
 	buffered := []cliproxyexecutor.StreamChunk{{Err: context.Canceled}}
-	sr := manager.wrapStreamResult(ctx, auth, "openai-compatibility", "gpt-5", nil, buffered, nil)
+	remaining := make(chan cliproxyexecutor.StreamChunk)
+	close(remaining)
+	sr := manager.wrapStreamResult(ctx, auth, "openai-compatibility", "gpt-5", nil, buffered, remaining)
 	for range sr.Chunks {
 	}
 
@@ -203,4 +205,49 @@ func snapshotAuthByID(m *Manager, id string) *Auth {
 		}
 	}
 	return nil
+}
+
+// TestWrapStreamResult_MidStreamReadErrorCooldowns verifies that a streaming
+// read failure (e.g. scanner.Err / Body.Read returning a transport error after
+// the upstream accepted the request) is treated as a transient upstream error
+// and cools down the credential. Unlike *url.Error, these errors surface as
+// bare errors carried on a StreamChunk, so errorToStreamResultError maps them
+// to 502.
+func TestWrapStreamResult_MidStreamReadErrorCooldowns(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-stream-read", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register() error: %v", err)
+	}
+
+	ctx := context.Background()
+	// Simulate a mid-stream read error: bare error, no HTTP status, not a
+	// *url.Error, not a client cancellation.
+	buffered := []cliproxyexecutor.StreamChunk{{Err: errors.New("tls: bad record MAC")}}
+	remaining := make(chan cliproxyexecutor.StreamChunk)
+	close(remaining) // no further chunks; the buffered error is terminal
+	sr := manager.wrapStreamResult(ctx, auth, "openai-compatibility", "gpt-5", nil, buffered, remaining)
+	for range sr.Chunks {
+	}
+
+	got := snapshotAuthByID(manager, auth.ID)
+	if got == nil {
+		t.Fatalf("auth %s not found in snapshot", auth.ID)
+	}
+	if blocked, _, next := isAuthBlockedForModel(got, "gpt-5", time.Now()); !blocked || !next.After(time.Now()) {
+		t.Fatalf("mid-stream read error did not cool down credential: blocked=%v next=%v", blocked, next)
+	}
+}
+
+// TestErrorToStreamResultError_MapsBareErrorToBadGateway covers the streaming
+// helper directly: a bare error becomes 502 (coolable), while an explicit
+// StatusError keeps its status.
+func TestErrorToStreamResultError_MapsBareErrorToBadGateway(t *testing.T) {
+	got := errorToStreamResultError(errors.New("unexpected EOF"))
+	if got.HTTPStatus != http.StatusBadGateway {
+		t.Fatalf("HTTPStatus = %d, want %d", got.HTTPStatus, http.StatusBadGateway)
+	}
+	if !got.Retryable {
+		t.Fatalf("Retryable = false, want true")
+	}
 }

--- a/sdk/cliproxy/auth/transport_cooldown_test.go
+++ b/sdk/cliproxy/auth/transport_cooldown_test.go
@@ -1,0 +1,116 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestMarkResult_TransportErrorCooldownsModel verifies that a transport-level
+// failure (TLS error, connection reset) carrying no HTTP status code still
+// triggers a short cooldown at the model-state level. Previously the default
+// cooldown branch left NextRetryAfter zero, so the broken credential was
+// immediately re-selected on every retry.
+func TestMarkResult_TransportErrorCooldownsModel(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-transport-model", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register() error: %v", err)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "openai-compatibility",
+		Model:    "gpt-5",
+		Success:  false,
+		Error: &Error{
+			Message:   `Post "https://example.com/v1/chat/completions": remote error: tls: bad record MAC`,
+			Retryable: true,
+			// HTTPStatus intentionally zero: transport errors carry no HTTP status.
+		},
+	})
+
+	got := snapshotAuthByID(manager, auth.ID)
+	if got == nil {
+		t.Fatalf("auth %s not found in snapshot", auth.ID)
+	}
+	blocked, _, next := isAuthBlockedForModel(got, "gpt-5", time.Now())
+	if !blocked {
+		t.Fatalf("transport error did not cool down model: isAuthBlockedForModel returned blocked=false, want true (credential should be temporarily unavailable)")
+	}
+	if !next.After(time.Now()) {
+		t.Fatalf("NextRetryAfter %v not in the future", next)
+	}
+}
+
+// TestMarkResult_TransportErrorCooldownsAuth exercises the auth-level
+// applyAuthFailureState path (Model == "").
+func TestMarkResult_TransportErrorCooldownsAuth(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-transport-auth", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register() error: %v", err)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "openai-compatibility",
+		Success:  false,
+		Error: &Error{
+			Message:   `dial tcp: connection reset by peer`,
+			Retryable: true,
+		},
+	})
+
+	got := snapshotAuthByID(manager, auth.ID)
+	if got == nil {
+		t.Fatalf("auth %s not found in snapshot", auth.ID)
+	}
+	if got.NextRetryAfter.IsZero() {
+		t.Fatalf("transport error did not cool down auth: NextRetryAfter is zero, want non-zero")
+	}
+	if got.StatusMessage != "transport error" {
+		t.Fatalf("StatusMessage = %q, want %q", got.StatusMessage, "transport error")
+	}
+}
+
+// TestMarkResult_TransportErrorNoCooldownWhenDisabled ensures the new
+// cooldown is skipped when cooling is globally disabled.
+func TestMarkResult_TransportErrorNoCooldownWhenDisabled(t *testing.T) {
+	SetQuotaCooldownDisabled(true)
+	t.Cleanup(func() { SetQuotaCooldownDisabled(false) })
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-transport-disabled", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register() error: %v", err)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "openai-compatibility",
+		Model:    "gpt-5",
+		Success:  false,
+		Error:    &Error{Message: `tls: bad record MAC`, Retryable: true},
+	})
+
+	got := snapshotAuthByID(manager, auth.ID)
+	if got == nil {
+		t.Fatalf("auth %s not found in snapshot", auth.ID)
+	}
+	blocked, _, _ := isAuthBlockedForModel(got, "gpt-5", time.Now())
+	if blocked {
+		t.Fatalf("credential was cooled down despite cooling being globally disabled")
+	}
+}
+
+// snapshotAuthByID returns a clone of the auth with the given ID from the
+// manager's current snapshot.
+func snapshotAuthByID(m *Manager, id string) *Auth {
+	for _, a := range m.snapshotAuths() {
+		if a.ID == id {
+			return a
+		}
+	}
+	return nil
+}

--- a/sdk/cliproxy/auth/transport_cooldown_test.go
+++ b/sdk/cliproxy/auth/transport_cooldown_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
 // TestMarkResult_TransportErrorCooldownsModel verifies that a transport-level
@@ -113,4 +115,32 @@ func snapshotAuthByID(m *Manager, id string) *Auth {
 		}
 	}
 	return nil
+}
+
+// TestWrapStreamResult_ClientCancellationDoesNotCooldown verifies that a
+// stream chunk error caused by the client cancelling the request
+// (context.Canceled) is filtered out before reaching MarkResult, so a
+// healthy credential is not put into cooldown for an aborted SSE stream.
+func TestWrapStreamResult_ClientCancellationDoesNotCooldown(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-cancel-stream", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register() error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate a client that disconnected mid-stream
+
+	buffered := []cliproxyexecutor.StreamChunk{{Err: context.Canceled}}
+	sr := manager.wrapStreamResult(ctx, auth, "openai-compatibility", "gpt-5", nil, buffered, nil)
+	for range sr.Chunks {
+	}
+
+	got := snapshotAuthByID(manager, auth.ID)
+	if got == nil {
+		t.Fatalf("auth %s not found in snapshot", auth.ID)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(got, "gpt-5", time.Now()); blocked {
+		t.Fatalf("client cancellation of a stream incorrectly cooled down a healthy credential")
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #3944.

Transport-level upstream failures (TLS errors, connection resets, DNS failures) returned by `http.Client.Do` carry no HTTP status code, so `statusCodeFromError` returns `0` and the cooldown switch in `MarkResult` / `applyAuthFailureState` fell into the `default` branch — leaving `NextRetryAfter` at the zero value. The broken credential was therefore immediately eligible for re-selection on the next retry, which (combined with the unbounded retry loop and no client timeout — see issue for the full wedge chain) can hang the whole process.

## Changes

- `sdk/cliproxy/auth/conductor.go`: in both the model-state and auth-level cooldown switches, treat `statusCode == 0` the same as the `408/500/502/503/504` branch, applying `nextTransientErrorRetryAfter(now)` so the selector skips the credential for ~1 minute. Still respects `disableCooling` / `disable-cooling`. Other unknown non-zero status codes keep the previous behavior (no cooldown) to avoid changing semantics for unclassified HTTP responses.
- `sdk/cliproxy/auth/transport_cooldown_test.go`: new tests covering the model-state path, the auth-level path (`Model == ""`), and the `disableCooling` opt-out.

## Why this is enough to break the wedge

Once the broken credential is cooled down, `closestCooldownWait` returns the cooldown for `attempt < requestRetry`, retries succeed against other credentials (or fail fast with `auth_unavailable` instead of looping on a dead connection), and `client.Do` is no longer re-invoked against the same half-broken TLS connection on every attempt. The separate no-timeout issue (`NewProxyAwareHTTPClient(..., 0)`) is noted as a follow-up in the issue.

## Verification

```
$ go test ./sdk/cliproxy/auth/ -run TransportError -v -count=1
=== RUN   TestMarkResult_TransportErrorCooldownsModel
--- PASS: TestMarkResult_TransportErrorCooldownsModel (0.00s)
=== RUN   TestMarkResult_TransportErrorCooldownsAuth
--- PASS: TestMarkResult_TransportErrorCooldownsAuth (0.00s)
=== RUN   TestMarkResult_TransportErrorNoCooldownWhenDisabled
--- PASS: TestMarkResult_TransportErrorNoCooldownWhenDisabled (0.00s)
PASS

$ go test ./sdk/cliproxy/auth/ -count=1
ok  	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.279s
```

Full package test suite passes with no regressions.
