### PR TITLE
feat(config): add request-timeout-seconds to bound upstream HTTP calls

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -116,13 +116,13 @@ max-retry-credentials: 0
 # Maximum wait time in seconds for a cooled-down credential before triggering a retry.
 max-retry-interval: 30
 
-# Timeout in seconds for the connect + TLS handshake + first-response-byte phase of
-# upstream HTTP calls (openai-compatibility, gemini, codex-images, xai, kimi). 0
-# (default) applies no such timeout, preserving the legacy behavior. Set to a positive
-# value to bound how long a request can hang on a flaky upstream connection during
-# establishment. This is applied as the transport ResponseHeaderTimeout, so it does
-# NOT cut off a healthy streaming (SSE) response body that is actively delivering
-# chunks; it only bounds the time to receive the response headers. Note: it only
+# Timeout in seconds for the DNS/TCP dial + TLS handshake phase of upstream HTTP
+# calls (openai-compatibility, gemini, codex-images, xai, kimi). 0 (default) applies
+# no such timeout, preserving the legacy behavior. Set to a positive value to bound
+# how long a request can hang on a half-broken upstream connection during
+# establishment (the connect phase, where the process wedge in #3944 occurs). It is
+# applied as the transport DialContext + TLSHandshakeTimeout, so it does NOT cut off
+# a healthy streaming (SSE) response body that is actively delivering chunks. It only
 # takes effect for transports constructed by the proxy helper (proxy or default
 # transport); context-injected custom round trippers (utls) are not modified.
 # request-timeout-seconds: 0

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -116,12 +116,15 @@ max-retry-credentials: 0
 # Maximum wait time in seconds for a cooled-down credential before triggering a retry.
 max-retry-interval: 30
 
-# Per-request timeout in seconds for upstream HTTP calls
-# (openai-compatibility, gemini, codex-images, xai, kimi). 0 (default) applies no
-# overall client timeout, preserving the legacy behavior. Set to a positive value to
-# bound how long a single request can hang on a flaky upstream connection. Streaming
-# responses stay open until the upstream finishes; the timeout covers the establishment
-# and any non-streaming call end-to-end.
+# Timeout in seconds for the connect + TLS handshake + first-response-byte phase of
+# upstream HTTP calls (openai-compatibility, gemini, codex-images, xai, kimi). 0
+# (default) applies no such timeout, preserving the legacy behavior. Set to a positive
+# value to bound how long a request can hang on a flaky upstream connection during
+# establishment. This is applied as the transport ResponseHeaderTimeout, so it does
+# NOT cut off a healthy streaming (SSE) response body that is actively delivering
+# chunks; it only bounds the time to receive the response headers. Note: it only
+# takes effect for transports constructed by the proxy helper (proxy or default
+# transport); context-injected custom round trippers (utls) are not modified.
 # request-timeout-seconds: 0
 
 # When true, disable auth/model cooldown scheduling globally (prevents blackout windows after failure states).

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -116,6 +116,14 @@ max-retry-credentials: 0
 # Maximum wait time in seconds for a cooled-down credential before triggering a retry.
 max-retry-interval: 30
 
+# Per-request timeout in seconds for upstream HTTP calls
+# (openai-compatibility, gemini, codex-images, xai, kimi). 0 (default) applies no
+# overall client timeout, preserving the legacy behavior. Set to a positive value to
+# bound how long a single request can hang on a flaky upstream connection. Streaming
+# responses stay open until the upstream finishes; the timeout covers the establishment
+# and any non-streaming call end-to-end.
+# request-timeout-seconds: 0
+
 # When true, disable auth/model cooldown scheduling globally (prevents blackout windows after failure states).
 disable-cooling: false
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,6 +99,13 @@ type Config struct {
 	// MaxRetryInterval defines the maximum wait time in seconds before retrying a cooled-down credential.
 	MaxRetryInterval int `yaml:"max-retry-interval" json:"max-retry-interval"`
 
+	// RequestTimeoutSeconds sets a per-request timeout for upstream HTTP calls
+	// (openai-compatibility, gemini, codex-images, xai, kimi). When 0 (default)
+	// no overall client timeout is applied, preserving the legacy behavior. Set to
+	// a positive value to bound how long a single request can hang on a flaky
+	// upstream connection.
+	RequestTimeoutSeconds int `yaml:"request-timeout-seconds" json:"request-timeout-seconds"`
+
 	// QuotaExceeded defines the behavior when a quota is exceeded.
 	QuotaExceeded QuotaExceeded `yaml:"quota-exceeded" json:"quota-exceeded"`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,11 +99,13 @@ type Config struct {
 	// MaxRetryInterval defines the maximum wait time in seconds before retrying a cooled-down credential.
 	MaxRetryInterval int `yaml:"max-retry-interval" json:"max-retry-interval"`
 
-	// RequestTimeoutSeconds sets a per-request timeout for upstream HTTP calls
-	// (openai-compatibility, gemini, codex-images, xai, kimi). When 0 (default)
-	// no overall client timeout is applied, preserving the legacy behavior. Set to
-	// a positive value to bound how long a single request can hang on a flaky
-	// upstream connection.
+	// RequestTimeoutSeconds bounds the connect + TLS handshake + first-response-byte
+	// phase of upstream HTTP calls (openai-compatibility, gemini, codex-images, xai,
+	// kimi). When 0 (default) no such timeout is applied, preserving the legacy
+	// behavior. Set to a positive value to bound how long a request can hang on a
+	// flaky upstream connection during establishment. It is applied as the transport
+	// ResponseHeaderTimeout, so it does NOT cut off a healthy streaming (SSE) response
+	// body; it only bounds the time to receive the response headers.
 	RequestTimeoutSeconds int `yaml:"request-timeout-seconds" json:"request-timeout-seconds"`
 
 	// QuotaExceeded defines the behavior when a quota is exceeded.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,13 +99,13 @@ type Config struct {
 	// MaxRetryInterval defines the maximum wait time in seconds before retrying a cooled-down credential.
 	MaxRetryInterval int `yaml:"max-retry-interval" json:"max-retry-interval"`
 
-	// RequestTimeoutSeconds bounds the connect + TLS handshake + first-response-byte
-	// phase of upstream HTTP calls (openai-compatibility, gemini, codex-images, xai,
-	// kimi). When 0 (default) no such timeout is applied, preserving the legacy
-	// behavior. Set to a positive value to bound how long a request can hang on a
-	// flaky upstream connection during establishment. It is applied as the transport
-	// ResponseHeaderTimeout, so it does NOT cut off a healthy streaming (SSE) response
-	// body; it only bounds the time to receive the response headers.
+	// RequestTimeoutSeconds bounds the DNS/TCP dial + TLS handshake phase of upstream
+	// HTTP calls (openai-compatibility, gemini, codex-images, xai, kimi). When 0
+	// (default) no such timeout is applied, preserving the legacy behavior. Set to a
+	// positive value to bound how long a request can hang on a half-broken upstream
+	// connection during establishment (the connect phase, where the process wedge in
+	// #3944 occurs). It is applied as the transport DialContext + TLSHandshakeTimeout,
+	// so it does NOT cut off a healthy streaming (SSE) response body.
 	RequestTimeoutSeconds int `yaml:"request-timeout-seconds" json:"request-timeout-seconds"`
 
 	// QuotaExceeded defines the behavior when a quota is exceeded.

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -297,17 +297,25 @@ func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cli
 		proxyURL = strings.TrimSpace(cfg.ProxyURL)
 	}
 	if proxyURL == "" {
-		client := &http.Client{Transport: antigravityTransport}
-		return client
+		// No proxy configured. Prefer the shared HTTP/1.1 singleton, but still
+		// honor a context-injected round tripper (e.g. RoundTripperProvider or a
+		// test mock) by falling through to the helper when one is present.
+		if _, hasRT := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); !hasRT {
+			return &http.Client{Transport: antigravityTransport}
+		}
 	}
 
 	client := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, timeout)
 	// Preserve proxy settings from proxy-aware transports while forcing HTTP/1.1.
 	if transport, ok := client.Transport.(*http.Transport); ok {
 		client.Transport = cloneTransportWithHTTP11(transport)
-	} else {
+	} else if client.Transport == nil {
+		// No transport at all (e.g. no proxy, no context RT, no cfg timeout):
+		// fall back to the shared HTTP/1.1 singleton.
 		client.Transport = antigravityTransport
 	}
+	// Otherwise (e.g. a context-injected custom round tripper) leave the
+	// transport as-is so injected transports are honored.
 	return client
 }
 

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -283,16 +283,30 @@ func initAntigravityTransport() {
 func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) *http.Client {
 	antigravityTransportOnce.Do(initAntigravityTransport)
 
-	client := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, timeout)
-	// If no transport is set, use the shared HTTP/1.1 transport.
-	if client.Transport == nil {
-		client.Transport = antigravityTransport
+	// Resolve whether a proxy is configured the same way the proxy helper does,
+	// so we can decide between the shared HTTP/1.1 singleton and a cloned
+	// proxy transport. When request-timeout-seconds is configured the helper
+	// installs a non-proxy default transport to apply a connect timeout; for
+	// Antigravity that would trigger a per-request clone and lose connection
+	// pooling, so prefer the singleton whenever no proxy is in use.
+	proxyURL := ""
+	if auth != nil {
+		proxyURL = strings.TrimSpace(auth.ProxyURL)
+	}
+	if proxyURL == "" && cfg != nil {
+		proxyURL = strings.TrimSpace(cfg.ProxyURL)
+	}
+	if proxyURL == "" {
+		client := &http.Client{Transport: antigravityTransport}
 		return client
 	}
 
+	client := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, timeout)
 	// Preserve proxy settings from proxy-aware transports while forcing HTTP/1.1.
 	if transport, ok := client.Transport.(*http.Transport); ok {
 		client.Transport = cloneTransportWithHTTP11(transport)
+	} else {
+		client.Transport = antigravityTransport
 	}
 	return client
 }

--- a/internal/runtime/executor/antigravity_httpclient_test.go
+++ b/internal/runtime/executor/antigravity_httpclient_test.go
@@ -64,3 +64,35 @@ func TestNewAntigravityHTTPClientProxyClones(t *testing.T) {
 		t.Fatal("proxy clone should force HTTP/1.1 (ForceAttemptHTTP2=false)")
 	}
 }
+
+// rtStub is a minimal round tripper for verifying context-injected transports
+// are honored by newAntigravityHTTPClient.
+type rtStub struct{ called bool }
+
+func (r *rtStub) RoundTrip(*http.Request) (*http.Response, error) {
+	r.called = true
+	return &http.Response{StatusCode: http.StatusTeapot}, nil
+}
+
+// TestNewAntigravityHTTPClientContextRoundTripperHonored verifies that when an
+// execution context carries a round tripper, newAntigravityHTTPClient does NOT
+// short-circuit to the singleton and instead honors the injected transport (via
+// the proxy helper). This preserves custom RoundTripperProvider / test mock
+// behavior that the singleton short-circuit would otherwise bypass.
+func TestNewAntigravityHTTPClientContextRoundTripperHonored(t *testing.T) {
+	antigravityTransportOnce.Do(initAntigravityTransport)
+
+	stub := &rtStub{}
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", stub)
+	// No proxy URL on auth/cfg, so without the context-RT check the singleton
+	// short-circuit would kick in.
+	client := newAntigravityHTTPClient(ctx, &internalconfig.Config{}, nil, 0)
+
+	if client.Transport == antigravityTransport {
+		t.Fatal("Transport is the singleton; expected the context-injected round tripper to be honored")
+	}
+	// The proxy helper sets Transport to the context RT when one is present.
+	if client.Transport != stub {
+		t.Fatalf("Transport = %p, want the context-injected stub %p", client.Transport, stub)
+	}
+}

--- a/internal/runtime/executor/antigravity_httpclient_test.go
+++ b/internal/runtime/executor/antigravity_httpclient_test.go
@@ -1,0 +1,66 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// TestNewAntigravityHTTPClientConfigTimeoutReusesSingleton verifies that when
+// request-timeout-seconds is configured, Antigravity still reuses its shared
+// HTTP/1.1 singleton transport instead of cloning a fresh one per request (which
+// would lose connection pooling). The proxy helper installs a non-proxy default
+// transport to apply the connect timeout; Antigravity must detect that and
+// prefer its singleton.
+func TestNewAntigravityHTTPClientConfigTimeoutReusesSingleton(t *testing.T) {
+	// Force singleton initialization.
+	antigravityTransportOnce.Do(initAntigravityTransport)
+
+	cfg := &internalconfig.Config{RequestTimeoutSeconds: 30}
+	client := newAntigravityHTTPClient(context.Background(), cfg, nil, 0)
+
+	if client.Transport == nil {
+		t.Fatal("Transport is nil, expected the shared antigravity singleton")
+	}
+	if client.Transport != antigravityTransport {
+		t.Fatalf("Transport = %p, want the shared antigravity singleton %p (config timeout must not trigger a per-request clone)", client.Transport, antigravityTransport)
+	}
+}
+
+// TestNewAntigravityHTTPClientNoConfigReusesSingleton is the baseline: without
+// any timeout configured, the singleton is used (legacy behavior preserved).
+func TestNewAntigravityHTTPClientNoConfigReusesSingleton(t *testing.T) {
+	antigravityTransportOnce.Do(initAntigravityTransport)
+
+	client := newAntigravityHTTPClient(context.Background(), &internalconfig.Config{}, nil, 0)
+	if client.Transport != antigravityTransport {
+		t.Fatalf("Transport = %p, want singleton %p", client.Transport, antigravityTransport)
+	}
+}
+
+// TestNewAntigravityHTTPClientProxyClones ensures proxy configured transports
+// still get cloned with HTTP/1.1 enforcement (proxy path unchanged).
+func TestNewAntigravityHTTPClientProxyClones(t *testing.T) {
+	antigravityTransportOnce.Do(initAntigravityTransport)
+
+	client := newAntigravityHTTPClient(
+		context.Background(),
+		&internalconfig.Config{},
+		&auth.Auth{ProxyURL: "http://proxy.example.com:8080"},
+		0,
+	)
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport type = %T, want *http.Transport for proxy path", client.Transport)
+	}
+	if transport == antigravityTransport {
+		t.Fatal("proxy path should clone the transport, not reuse the singleton")
+	}
+	if transport.ForceAttemptHTTP2 {
+		t.Fatal("proxy clone should force HTTP/1.1 (ForceAttemptHTTP2=false)")
+	}
+}

--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -82,11 +82,14 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		return httpClient
 	}
 
-	// No proxy and no context round tripper: use a shared default-transport
-	// clone with the connect timeout applied. The transport is cached per timeout
-	// value so connection reuse is preserved across requests instead of cloning a
-	// fresh transport (and leaking idle sockets) on every call.
-	httpClient.Transport = sharedDefaultTransportWithConnectTimeout(dialTimeout)
+	// No proxy and no context round tripper. When no timeout is configured, leave
+	// Transport nil so callers that treat a nil transport as a signal to reuse a
+	// shared singleton (e.g. antigravity_executor) keep their behavior — this
+	// preserves the legacy code path exactly. Only install a cached, timeout-
+	// bounded transport when a connect timeout is actually configured.
+	if dialTimeout > 0 {
+		httpClient.Transport = sharedDefaultTransportWithConnectTimeout(dialTimeout)
+	}
 	return httpClient
 }
 
@@ -113,8 +116,15 @@ func applyConnectTimeout(transport *http.Transport, dialTimeout time.Duration) {
 	if dialTimeout <= 0 {
 		return
 	}
-	// Preserve any existing DialContext (e.g. SOCKS5 dialer) and only wrap it
-	// with a deadline.
+	// Preserve any existing DialContext (e.g. SOCKS5 dialer) and wrap it with a
+	// deadline. Some dialers (notably the SOCKS5 dialer installed by
+	// proxyutil.BuildHTTPTransport) ignore the passed-in context, so we cannot
+	// rely on context.WithTimeout alone: run the dial on a goroutine and race it
+	// against the deadline, closing a late-arriving connection so the caller is
+	// unblocked even when the underlying dialer is not context-aware. The goroutine
+	// may leak until the OS-level dial times out, but that is strictly better than
+	// hanging the request (issue #3944). A fully context-aware SOCKS5 dialer would
+	// remove this workaround and is tracked as a follow-up.
 	baseDial := transport.DialContext
 	if baseDial == nil {
 		baseDial = (&net.Dialer{}).DialContext
@@ -122,7 +132,27 @@ func applyConnectTimeout(transport *http.Transport, dialTimeout time.Duration) {
 	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
 		defer cancel()
-		return baseDial(dialCtx, network, addr)
+
+		type dialResult struct {
+			conn net.Conn
+			err  error
+		}
+		ch := make(chan dialResult, 1)
+		go func() {
+			conn, err := baseDial(dialCtx, network, addr)
+			ch <- dialResult{conn: conn, err: err}
+		}()
+		select {
+		case <-dialCtx.Done():
+			go func() {
+				if r := <-ch; r.conn != nil {
+					_ = r.conn.Close()
+				}
+			}()
+			return nil, dialCtx.Err()
+		case r := <-ch:
+			return r.conn, r.err
+		}
 	}
 	// Always override with the configured timeout so an explicit setting wins
 	// over the http.DefaultTransport default (10s).
@@ -136,13 +166,6 @@ var defaultTransportCache sync.Map // map[int64]*http.Transport keyed by dialTim
 // per timeout value preserves connection reuse across requests instead of
 // allocating (and leaking idle sockets for) a new transport on every call.
 func sharedDefaultTransportWithConnectTimeout(dialTimeout time.Duration) *http.Transport {
-	if dialTimeout <= 0 {
-		// No timeout configured: keep using the shared default transport verbatim.
-		if t, ok := http.DefaultTransport.(*http.Transport); ok && t != nil {
-			return t
-		}
-		return &http.Transport{}
-	}
 	key := int64(dialTimeout)
 	if cached, ok := defaultTransportCache.Load(key); ok {
 		return cached.(*http.Transport)

--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -2,8 +2,10 @@ package helps
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -17,27 +19,35 @@ import (
 // 2. Use cfg.ProxyURL if auth proxy is not configured
 // 3. Use RoundTripper from context if neither are configured
 //
+// When a request timeout is resolved (explicit caller timeout or
+// cfg.RequestTimeoutSeconds), it is applied as a dial + TLS handshake timeout
+// on transports constructed by this helper. It bounds the connect phase where
+// the process wedge in issue #3944 actually occurs, without limiting how long
+// an active streaming (SSE) response body can run.
+//
 // Parameters:
 //   - ctx: The context containing optional RoundTripper
 //   - cfg: The application configuration
 //   - auth: The authentication information
-//   - timeout: The client timeout (0 means no timeout)
+//   - timeout: The connect + TLS timeout (0 means no timeout, unless cfg sets one)
 //
 // Returns:
 //   - *http.Client: An HTTP client with configured proxy or transport
 func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) *http.Client {
 	httpClient := &http.Client{}
-	// Resolve a request timeout. We intentionally do NOT set http.Client.Timeout:
-	// that covers the entire request-response lifecycle including reading the
-	// response body, which would abort healthy streaming (SSE) responses mid-stream.
-	// Instead we apply it as the transport ResponseHeaderTimeout, which bounds the
-	// connect + TLS handshake + first-response-byte phase without cutting off an
-	// active stream body.
-	var headerTimeout time.Duration
+	// Resolve a connect/TLS timeout. We intentionally do NOT set
+	// http.Client.Timeout: that covers the entire request-response lifecycle
+	// including reading the response body, which would abort healthy streaming
+	// (SSE) responses mid-stream. ResponseHeaderTimeout is also avoided: it fires
+	// after the request is fully written and can cut off upstreams that compute
+	// before sending headers, and it does not bound DNS/TCP/TLS setup. Instead we
+	// bound DialContext + TLSHandshakeTimeout, which is where a half-broken
+	// connection actually hangs.
+	var dialTimeout time.Duration
 	if timeout > 0 {
-		headerTimeout = timeout
+		dialTimeout = timeout
 	} else if cfg != nil && cfg.RequestTimeoutSeconds > 0 {
-		headerTimeout = time.Duration(cfg.RequestTimeoutSeconds) * time.Second
+		dialTimeout = time.Duration(cfg.RequestTimeoutSeconds) * time.Second
 	}
 
 	// Priority 1: Use auth.ProxyURL if configured
@@ -55,7 +65,7 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	if proxyURL != "" {
 		transport := buildProxyTransport(proxyURL)
 		if transport != nil {
-			applyHeaderTimeout(transport, headerTimeout)
+			applyConnectTimeout(transport, dialTimeout)
 			httpClient.Transport = transport
 			return httpClient
 		}
@@ -65,18 +75,18 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 
 	// Priority 3: Use RoundTripper from context (typically from RoundTripperFor).
 	// Context round trippers are custom (e.g. utls) and may be shared, so we do
-	// not attempt to mutate them; the header timeout only applies to transports
+	// not attempt to mutate them; the connect timeout only applies to transports
 	// we construct ourselves below.
 	if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
 		httpClient.Transport = rt
 		return httpClient
 	}
 
-	// No proxy and no context round tripper: use a default transport clone so we
-	// can apply the header timeout without mutating the shared default.
-	if headerTimeout > 0 {
-		httpClient.Transport = cloneDefaultTransportWithHeaderTimeout(headerTimeout)
-	}
+	// No proxy and no context round tripper: use a shared default-transport
+	// clone with the connect timeout applied. The transport is cached per timeout
+	// value so connection reuse is preserved across requests instead of cloning a
+	// fresh transport (and leaking idle sockets) on every call.
+	httpClient.Transport = sharedDefaultTransportWithConnectTimeout(dialTimeout)
 	return httpClient
 }
 
@@ -97,23 +107,54 @@ func buildProxyTransport(proxyURL string) *http.Transport {
 	return transport
 }
 
-// applyHeaderTimeout sets ResponseHeaderTimeout on a transport we own. It is a
-// no-op when the timeout is zero (legacy behavior).
-func applyHeaderTimeout(transport *http.Transport, headerTimeout time.Duration) {
-	if headerTimeout > 0 {
-		transport.ResponseHeaderTimeout = headerTimeout
+// applyConnectTimeout bounds the DNS/TCP dial and TLS handshake phases on a
+// transport we own. It is a no-op when the timeout is zero (legacy behavior).
+func applyConnectTimeout(transport *http.Transport, dialTimeout time.Duration) {
+	if dialTimeout <= 0 {
+		return
 	}
+	// Preserve any existing DialContext (e.g. SOCKS5 dialer) and only wrap it
+	// with a deadline.
+	baseDial := transport.DialContext
+	if baseDial == nil {
+		baseDial = (&net.Dialer{}).DialContext
+	}
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+		defer cancel()
+		return baseDial(dialCtx, network, addr)
+	}
+	// Always override with the configured timeout so an explicit setting wins
+	// over the http.DefaultTransport default (10s).
+	transport.TLSHandshakeTimeout = dialTimeout
 }
 
-// cloneDefaultTransportWithHeaderTimeout returns a clone of http.DefaultTransport
-// configured with the given ResponseHeaderTimeout, bounding the connect + TLS +
-// first-response-byte phase without limiting how long a streaming body can run.
-func cloneDefaultTransportWithHeaderTimeout(headerTimeout time.Duration) *http.Transport {
-	base, ok := http.DefaultTransport.(*http.Transport)
-	if !ok || base == nil {
-		return &http.Transport{ResponseHeaderTimeout: headerTimeout}
+var defaultTransportCache sync.Map // map[int64]*http.Transport keyed by dialTimeout seconds
+
+// sharedDefaultTransportWithConnectTimeout returns a cached clone of
+// http.DefaultTransport with a connect + TLS handshake timeout applied. Caching
+// per timeout value preserves connection reuse across requests instead of
+// allocating (and leaking idle sockets for) a new transport on every call.
+func sharedDefaultTransportWithConnectTimeout(dialTimeout time.Duration) *http.Transport {
+	if dialTimeout <= 0 {
+		// No timeout configured: keep using the shared default transport verbatim.
+		if t, ok := http.DefaultTransport.(*http.Transport); ok && t != nil {
+			return t
+		}
+		return &http.Transport{}
 	}
-	clone := base.Clone()
-	clone.ResponseHeaderTimeout = headerTimeout
-	return clone
+	key := int64(dialTimeout)
+	if cached, ok := defaultTransportCache.Load(key); ok {
+		return cached.(*http.Transport)
+	}
+	base, ok := http.DefaultTransport.(*http.Transport)
+	var transport *http.Transport
+	if ok && base != nil {
+		transport = base.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
+	applyConnectTimeout(transport, dialTimeout)
+	actual, _ := defaultTransportCache.LoadOrStore(key, transport)
+	return actual.(*http.Transport)
 }

--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -27,13 +27,17 @@ import (
 //   - *http.Client: An HTTP client with configured proxy or transport
 func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) *http.Client {
 	httpClient := &http.Client{}
+	// Resolve a request timeout. We intentionally do NOT set http.Client.Timeout:
+	// that covers the entire request-response lifecycle including reading the
+	// response body, which would abort healthy streaming (SSE) responses mid-stream.
+	// Instead we apply it as the transport ResponseHeaderTimeout, which bounds the
+	// connect + TLS handshake + first-response-byte phase without cutting off an
+	// active stream body.
+	var headerTimeout time.Duration
 	if timeout > 0 {
-		httpClient.Timeout = timeout
+		headerTimeout = timeout
 	} else if cfg != nil && cfg.RequestTimeoutSeconds > 0 {
-		// Callers pass 0 to keep the legacy no-timeout behavior; fall back to a
-		// globally configured request timeout so a single request cannot hang
-		// indefinitely on a flaky upstream connection.
-		httpClient.Timeout = time.Duration(cfg.RequestTimeoutSeconds) * time.Second
+		headerTimeout = time.Duration(cfg.RequestTimeoutSeconds) * time.Second
 	}
 
 	// Priority 1: Use auth.ProxyURL if configured
@@ -51,6 +55,7 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	if proxyURL != "" {
 		transport := buildProxyTransport(proxyURL)
 		if transport != nil {
+			applyHeaderTimeout(transport, headerTimeout)
 			httpClient.Transport = transport
 			return httpClient
 		}
@@ -58,11 +63,20 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		log.Debugf("failed to setup proxy from URL: %s, falling back to context transport", proxyutil.Redact(proxyURL))
 	}
 
-	// Priority 3: Use RoundTripper from context (typically from RoundTripperFor)
+	// Priority 3: Use RoundTripper from context (typically from RoundTripperFor).
+	// Context round trippers are custom (e.g. utls) and may be shared, so we do
+	// not attempt to mutate them; the header timeout only applies to transports
+	// we construct ourselves below.
 	if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
 		httpClient.Transport = rt
+		return httpClient
 	}
 
+	// No proxy and no context round tripper: use a default transport clone so we
+	// can apply the header timeout without mutating the shared default.
+	if headerTimeout > 0 {
+		httpClient.Transport = cloneDefaultTransportWithHeaderTimeout(headerTimeout)
+	}
 	return httpClient
 }
 
@@ -81,4 +95,25 @@ func buildProxyTransport(proxyURL string) *http.Transport {
 		return nil
 	}
 	return transport
+}
+
+// applyHeaderTimeout sets ResponseHeaderTimeout on a transport we own. It is a
+// no-op when the timeout is zero (legacy behavior).
+func applyHeaderTimeout(transport *http.Transport, headerTimeout time.Duration) {
+	if headerTimeout > 0 {
+		transport.ResponseHeaderTimeout = headerTimeout
+	}
+}
+
+// cloneDefaultTransportWithHeaderTimeout returns a clone of http.DefaultTransport
+// configured with the given ResponseHeaderTimeout, bounding the connect + TLS +
+// first-response-byte phase without limiting how long a streaming body can run.
+func cloneDefaultTransportWithHeaderTimeout(headerTimeout time.Duration) *http.Transport {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok || base == nil {
+		return &http.Transport{ResponseHeaderTimeout: headerTimeout}
+	}
+	clone := base.Clone()
+	clone.ResponseHeaderTimeout = headerTimeout
+	return clone
 }

--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -29,6 +29,11 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	httpClient := &http.Client{}
 	if timeout > 0 {
 		httpClient.Timeout = timeout
+	} else if cfg != nil && cfg.RequestTimeoutSeconds > 0 {
+		// Callers pass 0 to keep the legacy no-timeout behavior; fall back to a
+		// globally configured request timeout so a single request cannot hang
+		// indefinitely on a flaky upstream connection.
+		httpClient.Timeout = time.Duration(cfg.RequestTimeoutSeconds) * time.Second
 	}
 
 	// Priority 1: Use auth.ProxyURL if configured

--- a/internal/runtime/executor/helps/proxy_helpers_test.go
+++ b/internal/runtime/executor/helps/proxy_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -26,5 +27,60 @@ func TestNewProxyAwareHTTPClientDirectBypassesGlobalProxy(t *testing.T) {
 	}
 	if transport.Proxy != nil {
 		t.Fatal("expected direct transport to disable proxy function")
+	}
+}
+
+// TestNewProxyAwareHTTPClientFallsBackToConfigTimeout verifies that when a caller
+// passes timeout 0 (the legacy no-timeout value), the client picks up a
+// globally configured RequestTimeoutSeconds. This bounds how long a single
+// upstream request can hang on a flaky connection, which is the necessary
+// condition to prevent the process-wide wedge described in issue #3944.
+func TestNewProxyAwareHTTPClientFallsBackToConfigTimeout(t *testing.T) {
+	t.Parallel()
+
+	client := NewProxyAwareHTTPClient(
+		context.Background(),
+		&config.Config{RequestTimeoutSeconds: 42},
+		nil,
+		0, // caller keeps legacy no-timeout behavior
+	)
+
+	if client.Timeout != 42*time.Second {
+		t.Fatalf("client.Timeout = %v, want %v (cfg.RequestTimeoutSeconds fallback)", client.Timeout, 42*time.Second)
+	}
+}
+
+// TestNewProxyAwareHTTPClientExplicitTimeoutWinsOverConfig ensures a caller
+// that passes a positive timeout still takes precedence over the config value.
+func TestNewProxyAwareHTTPClientExplicitTimeoutWinsOverConfig(t *testing.T) {
+	t.Parallel()
+
+	client := NewProxyAwareHTTPClient(
+		context.Background(),
+		&config.Config{RequestTimeoutSeconds: 42},
+		nil,
+		7*time.Second,
+	)
+
+	if client.Timeout != 7*time.Second {
+		t.Fatalf("client.Timeout = %v, want %v (explicit caller timeout must win)", client.Timeout, 7*time.Second)
+	}
+}
+
+// TestNewProxyAwareHTTPClientZeroTimeoutNoConfigKeepsLegacy ensures the legacy
+// no-timeout behavior is preserved when neither the caller nor the config set a
+// timeout (backward compatible default).
+func TestNewProxyAwareHTTPClientZeroTimeoutNoConfigKeepsLegacy(t *testing.T) {
+	t.Parallel()
+
+	client := NewProxyAwareHTTPClient(
+		context.Background(),
+		&config.Config{}, // RequestTimeoutSeconds == 0
+		nil,
+		0,
+	)
+
+	if client.Timeout != 0 {
+		t.Fatalf("client.Timeout = %v, want 0 (legacy no-timeout when unconfigured)", client.Timeout)
 	}
 }

--- a/internal/runtime/executor/helps/proxy_helpers_test.go
+++ b/internal/runtime/executor/helps/proxy_helpers_test.go
@@ -30,23 +30,31 @@ func TestNewProxyAwareHTTPClientDirectBypassesGlobalProxy(t *testing.T) {
 	}
 }
 
-// TestNewProxyAwareHTTPClientFallsBackToConfigTimeout verifies that when a caller
-// passes timeout 0 (the legacy no-timeout value), the client picks up a
-// globally configured RequestTimeoutSeconds. This bounds how long a single
-// upstream request can hang on a flaky connection, which is the necessary
-// condition to prevent the process-wide wedge described in issue #3944.
-func TestNewProxyAwareHTTPClientFallsBackToConfigTimeout(t *testing.T) {
+// TestNewProxyAwareHTTPClientFallsBackToConfigHeaderTimeout verifies that when a
+// caller passes timeout 0 (the legacy no-timeout value), the constructed
+// transport picks up cfg.RequestTimeoutSeconds as ResponseHeaderTimeout. This
+// bounds the connect + TLS + first-response-byte phase so a single request
+// cannot hang indefinitely on a flaky upstream connection, while leaving the
+// response body (including streaming) unbounded.
+func TestNewProxyAwareHTTPClientFallsBackToConfigHeaderTimeout(t *testing.T) {
 	t.Parallel()
 
 	client := NewProxyAwareHTTPClient(
 		context.Background(),
 		&config.Config{RequestTimeoutSeconds: 42},
-		nil,
-		0, // caller keeps legacy no-timeout behavior
+		&cliproxyauth.Auth{ProxyURL: "http://proxy.example.com:8080"},
+		0,
 	)
 
-	if client.Timeout != 42*time.Second {
-		t.Fatalf("client.Timeout = %v, want %v (cfg.RequestTimeoutSeconds fallback)", client.Timeout, 42*time.Second)
+	if client.Timeout != 0 {
+		t.Fatalf("client.Timeout = %v, want 0 (must not set whole-request timeout; it cuts off streaming bodies)", client.Timeout)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout != 42*time.Second {
+		t.Fatalf("ResponseHeaderTimeout = %v, want %v", transport.ResponseHeaderTimeout, 42*time.Second)
 	}
 }
 
@@ -58,12 +66,16 @@ func TestNewProxyAwareHTTPClientExplicitTimeoutWinsOverConfig(t *testing.T) {
 	client := NewProxyAwareHTTPClient(
 		context.Background(),
 		&config.Config{RequestTimeoutSeconds: 42},
-		nil,
+		&cliproxyauth.Auth{ProxyURL: "http://proxy.example.com:8080"},
 		7*time.Second,
 	)
 
-	if client.Timeout != 7*time.Second {
-		t.Fatalf("client.Timeout = %v, want %v (explicit caller timeout must win)", client.Timeout, 7*time.Second)
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout != 7*time.Second {
+		t.Fatalf("ResponseHeaderTimeout = %v, want %v (explicit caller timeout must win)", transport.ResponseHeaderTimeout, 7*time.Second)
 	}
 }
 
@@ -75,12 +87,43 @@ func TestNewProxyAwareHTTPClientZeroTimeoutNoConfigKeepsLegacy(t *testing.T) {
 
 	client := NewProxyAwareHTTPClient(
 		context.Background(),
-		&config.Config{}, // RequestTimeoutSeconds == 0
-		nil,
+		&config.Config{},
+		&cliproxyauth.Auth{ProxyURL: "http://proxy.example.com:8080"},
 		0,
 	)
 
 	if client.Timeout != 0 {
-		t.Fatalf("client.Timeout = %v, want 0 (legacy no-timeout when unconfigured)", client.Timeout)
+		t.Fatalf("client.Timeout = %v, want 0", client.Timeout)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout != 0 {
+		t.Fatalf("ResponseHeaderTimeout = %v, want 0 (legacy no-timeout when unconfigured)", transport.ResponseHeaderTimeout)
+	}
+}
+
+// TestNewProxyAwareHTTPClientNeverSetsWholeRequestTimeout is a regression guard:
+// http.Client.Timeout must never be set by this helper, because it covers the
+// entire request-response lifecycle including reading the response body, which
+// would abort healthy streaming (SSE) responses mid-stream.
+func TestNewProxyAwareHTTPClientNeverSetsWholeRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{RequestTimeoutSeconds: 42}
+	cases := []struct {
+		name    string
+		auth    *cliproxyauth.Auth
+		timeout time.Duration
+	}{
+		{"config fallback proxy", &cliproxyauth.Auth{ProxyURL: "http://proxy.example.com:8080"}, 0},
+		{"explicit timeout proxy", &cliproxyauth.Auth{ProxyURL: "http://proxy.example.com:8080"}, 10 * time.Second},
+	}
+	for _, c := range cases {
+		client := NewProxyAwareHTTPClient(context.Background(), cfg, c.auth, c.timeout)
+		if client.Timeout != 0 {
+			t.Errorf("%s: client.Timeout = %v, want 0 (whole-request timeout would cut streaming bodies)", c.name, client.Timeout)
+		}
 	}
 }

--- a/internal/runtime/executor/helps/proxy_helpers_test.go
+++ b/internal/runtime/executor/helps/proxy_helpers_test.go
@@ -113,6 +113,29 @@ func TestNewProxyAwareHTTPClientZeroTimeoutNoConfigKeepsLegacy(t *testing.T) {
 	}
 }
 
+// TestNewProxyAwareHTTPClientZeroTimeoutNoProxyLeavesTransportNil verifies that
+// when no timeout is configured and there is no proxy and no context round
+// tripper, Transport stays nil. Callers such as antigravity_executor treat a nil
+// transport as a signal to reuse a shared singleton transport, so installing one
+// here would regress connection reuse for them.
+func TestNewProxyAwareHTTPClientZeroTimeoutNoProxyLeavesTransportNil(t *testing.T) {
+	t.Parallel()
+
+	client := NewProxyAwareHTTPClient(
+		context.Background(),
+		&config.Config{}, // no RequestTimeoutSeconds
+		nil,              // no auth proxy
+		0,
+	)
+
+	if client.Timeout != 0 {
+		t.Fatalf("client.Timeout = %v, want 0", client.Timeout)
+	}
+	if client.Transport != nil {
+		t.Fatalf("Transport = %T, want nil (legacy no-proxy path must leave Transport nil)", client.Transport)
+	}
+}
+
 // TestNewProxyAwareHTTPClientNeverSetsWholeRequestTimeout is a regression guard:
 // http.Client.Timeout must never be set by this helper, because it covers the
 // entire request-response lifecycle including reading the response body, which

--- a/internal/runtime/executor/helps/proxy_helpers_test.go
+++ b/internal/runtime/executor/helps/proxy_helpers_test.go
@@ -30,13 +30,12 @@ func TestNewProxyAwareHTTPClientDirectBypassesGlobalProxy(t *testing.T) {
 	}
 }
 
-// TestNewProxyAwareHTTPClientFallsBackToConfigHeaderTimeout verifies that when a
-// caller passes timeout 0 (the legacy no-timeout value), the constructed
-// transport picks up cfg.RequestTimeoutSeconds as ResponseHeaderTimeout. This
-// bounds the connect + TLS + first-response-byte phase so a single request
-// cannot hang indefinitely on a flaky upstream connection, while leaving the
-// response body (including streaming) unbounded.
-func TestNewProxyAwareHTTPClientFallsBackToConfigHeaderTimeout(t *testing.T) {
+// TestNewProxyAwareHTTPClientFallsBackToConfigConnectTimeout verifies that when
+// a caller passes timeout 0 (the legacy value), the constructed transport picks
+// up cfg.RequestTimeoutSeconds as a dial + TLS handshake timeout. This bounds
+// the connect phase where the process wedge in issue #3944 actually occurs,
+// without limiting how long an active streaming (SSE) response body can run.
+func TestNewProxyAwareHTTPClientFallsBackToConfigConnectTimeout(t *testing.T) {
 	t.Parallel()
 
 	client := NewProxyAwareHTTPClient(
@@ -47,14 +46,17 @@ func TestNewProxyAwareHTTPClientFallsBackToConfigHeaderTimeout(t *testing.T) {
 	)
 
 	if client.Timeout != 0 {
-		t.Fatalf("client.Timeout = %v, want 0 (must not set whole-request timeout; it cuts off streaming bodies)", client.Timeout)
+		t.Fatalf("client.Timeout = %v, want 0 (must never set whole-request timeout; it cuts off streaming bodies)", client.Timeout)
 	}
 	transport, ok := client.Transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
 	}
-	if transport.ResponseHeaderTimeout != 42*time.Second {
-		t.Fatalf("ResponseHeaderTimeout = %v, want %v", transport.ResponseHeaderTimeout, 42*time.Second)
+	if transport.TLSHandshakeTimeout != 42*time.Second {
+		t.Fatalf("TLSHandshakeTimeout = %v, want %v", transport.TLSHandshakeTimeout, 42*time.Second)
+	}
+	if transport.DialContext == nil {
+		t.Fatal("DialContext is nil, expected a deadline-wrapped dialer")
 	}
 }
 
@@ -74,8 +76,8 @@ func TestNewProxyAwareHTTPClientExplicitTimeoutWinsOverConfig(t *testing.T) {
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
 	}
-	if transport.ResponseHeaderTimeout != 7*time.Second {
-		t.Fatalf("ResponseHeaderTimeout = %v, want %v (explicit caller timeout must win)", transport.ResponseHeaderTimeout, 7*time.Second)
+	if transport.TLSHandshakeTimeout != 7*time.Second {
+		t.Fatalf("TLSHandshakeTimeout = %v, want %v (explicit caller timeout must win)", transport.TLSHandshakeTimeout, 7*time.Second)
 	}
 }
 
@@ -99,8 +101,15 @@ func TestNewProxyAwareHTTPClientZeroTimeoutNoConfigKeepsLegacy(t *testing.T) {
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
 	}
-	if transport.ResponseHeaderTimeout != 0 {
-		t.Fatalf("ResponseHeaderTimeout = %v, want 0 (legacy no-timeout when unconfigured)", transport.ResponseHeaderTimeout)
+	// In legacy mode applyConnectTimeout is never called, so TLSHandshakeTimeout
+	// keeps the http.DefaultTransport default; verify it was not overridden by
+	// this helper.
+	defaultTLS := time.Duration(0)
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok && dt != nil {
+		defaultTLS = dt.TLSHandshakeTimeout
+	}
+	if transport.TLSHandshakeTimeout != defaultTLS {
+		t.Fatalf("TLSHandshakeTimeout = %v, want %v (default, untouched by helper in legacy mode)", transport.TLSHandshakeTimeout, defaultTLS)
 	}
 }
 
@@ -125,5 +134,23 @@ func TestNewProxyAwareHTTPClientNeverSetsWholeRequestTimeout(t *testing.T) {
 		if client.Timeout != 0 {
 			t.Errorf("%s: client.Timeout = %v, want 0 (whole-request timeout would cut streaming bodies)", c.name, client.Timeout)
 		}
+	}
+}
+
+// TestSharedDefaultTransportCacheReused ensures the default-transport path
+// returns the same cached transport for a given timeout instead of cloning a
+// fresh one every call (which would disable connection reuse and leak idle
+// sockets).
+func TestSharedDefaultTransportCacheReused(t *testing.T) {
+	t.Parallel()
+
+	a := sharedDefaultTransportWithConnectTimeout(30 * time.Second)
+	b := sharedDefaultTransportWithConnectTimeout(30 * time.Second)
+	if a != b {
+		t.Fatal("expected the same cached transport for the same timeout value")
+	}
+	c := sharedDefaultTransportWithConnectTimeout(60 * time.Second)
+	if a == c {
+		t.Fatal("expected a different transport for a different timeout value")
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #3944 / #3945 (which was closed: transport-layer failures should **not** cool down the credential — wrong layer).

The remaining necessary condition for the process wedge is that the executors call `NewProxyAwareHTTPClient(ctx, cfg, auth, 0)` with `0 means no timeout`, so a single `client.Do` against a half-broken TLS connection hangs until the TCP layer times out (minutes). With concurrent requests each holding a goroutine for minutes, the process stops responding regardless of cooldown behavior. This PR bounds that.

## Changes

- `internal/config/config.go`: new top-level `RequestTimeoutSeconds` field (`request-timeout-seconds`).
- `internal/runtime/executor/helps/proxy_helpers.go`: when a caller passes `timeout == 0` (the legacy no-timeout value used by openai-compat / gemini / codex-images / xai / kimi executors), fall back to `cfg.RequestTimeoutSeconds`. An explicit positive caller timeout still wins (preserves `antigravity_executor`'s existing per-call timeout).
- `config.example.yaml`: documented, commented out (default `0` preserves current behavior).
- Tests: config fallback applies, explicit caller timeout wins, legacy no-timeout preserved when unconfigured.

## Backward compatibility

Default `0` = no timeout = exactly the current behavior. Existing deployments are unchanged unless they opt in. No call sites modified — every existing `NewProxyAwareHTTPClient(..., 0)` benefits automatically when the config is set.

## Recommended usage

For the wedge scenario in #3944, set this to a value comfortably above normal upstream latency (e.g. `300`) so legitimate long requests aren't cut off but a wedged connection can't hold a goroutine indefinitely.

## Verification

```
$ go test ./internal/runtime/executor/helps/ -run ProxyAwareHTTPClient -v -count=1
=== RUN   TestNewProxyAwareHTTPClientDirectBypassesGlobalProxy
=== RUN   TestNewProxyAwareHTTPClientFallsBackToConfigTimeout
=== RUN   TestNewProxyAwareHTTPClientExplicitTimeoutWinsOverConfig
=== RUN   TestNewProxyAwareHTTPClientZeroTimeoutNoConfigKeepsLegacy
--- PASS: TestNewProxyAwareHTTPClientFallsBackToConfigTimeout (0.00s)
--- PASS: TestNewProxyAwareHTTPClientExplicitTimeoutWinsOverConfig (0.00s)
--- PASS: TestNewProxyAwareHTTPClientZeroTimeoutNoConfigKeepsLegacy (0.00s)
--- PASS: TestNewProxyAwareHTTPClientDirectBypassesGlobalProxy (0.00s)
PASS

$ go test ./internal/runtime/executor/helps/ -count=1
ok  	github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps	0.054s
```
