### PR TITLE
fix(antigravity): discover OAuth model catalog from upstream

### DIFF
--- a/sdk/cliproxy/antigravity_models.go
+++ b/sdk/cliproxy/antigravity_models.go
@@ -42,6 +42,10 @@ type antigravityFetchedModels struct {
 }
 
 func (s *Service) fetchAntigravityModelsForAuth(ctx context.Context, auth *coreauth.Auth) antigravityFetchedModels {
+	return s.fetchAntigravityModelsForAuthFromBaseURLs(ctx, auth, antigravityModelBaseURLs(auth))
+}
+
+func (s *Service) fetchAntigravityModelsForAuthFromBaseURLs(ctx context.Context, auth *coreauth.Auth, baseURLs []string) antigravityFetchedModels {
 	if auth == nil || auth.Metadata == nil {
 		return antigravityFetchedModels{}
 	}
@@ -56,7 +60,8 @@ func (s *Service) fetchAntigravityModelsForAuth(ctx context.Context, auth *corea
 		client.Transport = transport
 	}
 
-	for _, baseURL := range antigravityModelBaseURLs(auth) {
+	var hints antigravityModelCapabilityHints
+	for _, baseURL := range baseURLs {
 		req, errReq := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(baseURL, "/")+antigravityModelsPath, strings.NewReader(antigravityModelFetchPayload(auth)))
 		if errReq != nil {
 			continue
@@ -81,11 +86,13 @@ func (s *Service) fetchAntigravityModelsForAuth(ctx context.Context, auth *corea
 			continue
 		}
 		fetched := parseAntigravityFetchedModels(body)
-		if len(fetched.Models) > 0 || len(fetched.Hints.WebSearchModelIDs) > 0 {
+		hints = mergeAntigravityModelCapabilityHints(hints, fetched.Hints)
+		if len(fetched.Models) > 0 {
+			fetched.Hints = hints
 			return fetched
 		}
 	}
-	return antigravityFetchedModels{}
+	return antigravityFetchedModels{Hints: hints}
 }
 
 func (s *Service) antigravityModelFetchProxyURL(auth *coreauth.Auth) string {
@@ -151,15 +158,24 @@ func parseAntigravityFetchedModels(body []byte) antigravityFetchedModels {
 
 	models := make([]*ModelInfo, 0, len(parsed.Models))
 	modelIDs := make([]string, 0, len(parsed.Models))
-	for modelID := range parsed.Models {
-		modelID = strings.TrimSpace(modelID)
+	trimmedModels := make(map[string]antigravityFetchedModel, len(parsed.Models))
+	for rawModelID, modelData := range parsed.Models {
+		modelID := strings.TrimSpace(rawModelID)
 		if modelID != "" {
+			if isInternalAntigravityFetchedModelID(modelID) {
+				continue
+			}
+			if _, exists := trimmedModels[modelID]; exists {
+				trimmedModels[modelID] = modelData
+				continue
+			}
+			trimmedModels[modelID] = modelData
 			modelIDs = append(modelIDs, modelID)
 		}
 	}
 	sort.Strings(modelIDs)
 	for _, modelID := range modelIDs {
-		modelData := parsed.Models[modelID]
+		modelData := trimmedModels[modelID]
 		displayName := strings.TrimSpace(modelData.DisplayName)
 		if displayName == "" {
 			displayName = modelID
@@ -191,6 +207,20 @@ func parseAntigravityModelCapabilityHintsFromResponse(parsed antigravityFetchAva
 		if modelID != "" {
 			webSearchModels[modelID] = struct{}{}
 		}
+	}
+	return antigravityModelCapabilityHints{WebSearchModelIDs: webSearchModels}
+}
+
+func mergeAntigravityModelCapabilityHints(left, right antigravityModelCapabilityHints) antigravityModelCapabilityHints {
+	if len(left.WebSearchModelIDs) == 0 && len(right.WebSearchModelIDs) == 0 {
+		return antigravityModelCapabilityHints{}
+	}
+	webSearchModels := make(map[string]struct{}, len(left.WebSearchModelIDs)+len(right.WebSearchModelIDs))
+	for modelID := range left.WebSearchModelIDs {
+		webSearchModels[modelID] = struct{}{}
+	}
+	for modelID := range right.WebSearchModelIDs {
+		webSearchModels[modelID] = struct{}{}
 	}
 	return antigravityModelCapabilityHints{WebSearchModelIDs: webSearchModels}
 }
@@ -286,6 +316,9 @@ func mergeAntigravityStaticModelMetadata(model, staticModel *ModelInfo) {
 	if len(model.SupportedParameters) == 0 {
 		model.SupportedParameters = append([]string(nil), staticModel.SupportedParameters...)
 	}
+	if len(model.SupportedGenerationMethods) == 0 {
+		model.SupportedGenerationMethods = append([]string(nil), staticModel.SupportedGenerationMethods...)
+	}
 	if len(model.SupportedInputModalities) == 0 {
 		model.SupportedInputModalities = append([]string(nil), staticModel.SupportedInputModalities...)
 	}
@@ -322,4 +355,13 @@ func normalizeAntigravityDisplayFamily(displayName string) string {
 
 func normalizeAntigravityFetchedModelID(modelID string) string {
 	return strings.ToLower(strings.TrimSpace(modelID))
+}
+
+func isInternalAntigravityFetchedModelID(modelID string) bool {
+	switch normalizeAntigravityFetchedModelID(modelID) {
+	case "chat_20706", "chat_23310", "tab_flash_lite_preview", "tab_jump_flash_lite_preview", "gemini-2.5-flash-thinking", "gemini-2.5-pro":
+		return true
+	default:
+		return false
+	}
 }

--- a/sdk/cliproxy/antigravity_models.go
+++ b/sdk/cliproxy/antigravity_models.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
@@ -20,21 +22,33 @@ const (
 )
 
 type antigravityFetchAvailableModelsResponse struct {
-	WebSearchModelIDs []string `json:"webSearchModelIds"`
+	Models            map[string]antigravityFetchedModel `json:"models"`
+	WebSearchModelIDs []string                           `json:"webSearchModelIds"`
+}
+
+type antigravityFetchedModel struct {
+	DisplayName         string `json:"displayName"`
+	MaxTokens           int    `json:"maxTokens"`
+	MaxCompletionTokens int    `json:"maxOutputTokens"`
 }
 
 type antigravityModelCapabilityHints struct {
 	WebSearchModelIDs map[string]struct{}
 }
 
-func (s *Service) fetchAntigravityModelCapabilityHintsForAuth(ctx context.Context, auth *coreauth.Auth) antigravityModelCapabilityHints {
+type antigravityFetchedModels struct {
+	Models []*ModelInfo
+	Hints  antigravityModelCapabilityHints
+}
+
+func (s *Service) fetchAntigravityModelsForAuth(ctx context.Context, auth *coreauth.Auth) antigravityFetchedModels {
 	if auth == nil || auth.Metadata == nil {
-		return antigravityModelCapabilityHints{}
+		return antigravityFetchedModels{}
 	}
 	accessToken, _ := auth.Metadata["access_token"].(string)
 	accessToken = strings.TrimSpace(accessToken)
 	if accessToken == "" {
-		return antigravityModelCapabilityHints{}
+		return antigravityFetchedModels{}
 	}
 
 	client := &http.Client{}
@@ -43,7 +57,7 @@ func (s *Service) fetchAntigravityModelCapabilityHintsForAuth(ctx context.Contex
 	}
 
 	for _, baseURL := range antigravityModelBaseURLs(auth) {
-		req, errReq := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(baseURL, "/")+antigravityModelsPath, strings.NewReader(`{}`))
+		req, errReq := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(baseURL, "/")+antigravityModelsPath, strings.NewReader(antigravityModelFetchPayload(auth)))
 		if errReq != nil {
 			continue
 		}
@@ -66,12 +80,12 @@ func (s *Service) fetchAntigravityModelCapabilityHintsForAuth(ctx context.Contex
 		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 			continue
 		}
-		hints := parseAntigravityModelCapabilityHints(body)
-		if len(hints.WebSearchModelIDs) > 0 {
-			return hints
+		fetched := parseAntigravityFetchedModels(body)
+		if len(fetched.Models) > 0 || len(fetched.Hints.WebSearchModelIDs) > 0 {
+			return fetched
 		}
 	}
-	return antigravityModelCapabilityHints{}
+	return antigravityFetchedModels{}
 }
 
 func (s *Service) antigravityModelFetchProxyURL(auth *coreauth.Auth) string {
@@ -113,11 +127,64 @@ func resolveAntigravityModelBaseURL(auth *coreauth.Auth) string {
 	return ""
 }
 
-func parseAntigravityModelCapabilityHints(body []byte) antigravityModelCapabilityHints {
+func antigravityModelFetchPayload(auth *coreauth.Auth) string {
+	if auth == nil || auth.Metadata == nil {
+		return `{}`
+	}
+	projectID, _ := auth.Metadata["project_id"].(string)
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return `{}`
+	}
+	body, err := json.Marshal(map[string]string{"project": projectID})
+	if err != nil {
+		return `{}`
+	}
+	return string(body)
+}
+
+func parseAntigravityFetchedModels(body []byte) antigravityFetchedModels {
 	var parsed antigravityFetchAvailableModelsResponse
 	if err := json.Unmarshal(body, &parsed); err != nil {
-		return antigravityModelCapabilityHints{}
+		return antigravityFetchedModels{}
 	}
+
+	models := make([]*ModelInfo, 0, len(parsed.Models))
+	modelIDs := make([]string, 0, len(parsed.Models))
+	for modelID := range parsed.Models {
+		modelID = strings.TrimSpace(modelID)
+		if modelID != "" {
+			modelIDs = append(modelIDs, modelID)
+		}
+	}
+	sort.Strings(modelIDs)
+	for _, modelID := range modelIDs {
+		modelData := parsed.Models[modelID]
+		displayName := strings.TrimSpace(modelData.DisplayName)
+		if displayName == "" {
+			displayName = modelID
+		}
+		model := &ModelInfo{
+			ID:                  modelID,
+			Object:              "model",
+			OwnedBy:             "antigravity",
+			Type:                "antigravity",
+			DisplayName:         displayName,
+			Name:                modelID,
+			Description:         displayName,
+			ContextLength:       modelData.MaxTokens,
+			MaxCompletionTokens: modelData.MaxCompletionTokens,
+		}
+		models = append(models, model)
+	}
+
+	return antigravityFetchedModels{
+		Models: models,
+		Hints:  parseAntigravityModelCapabilityHintsFromResponse(parsed),
+	}
+}
+
+func parseAntigravityModelCapabilityHintsFromResponse(parsed antigravityFetchAvailableModelsResponse) antigravityModelCapabilityHints {
 	webSearchModels := make(map[string]struct{}, len(parsed.WebSearchModelIDs))
 	for _, modelID := range parsed.WebSearchModelIDs {
 		modelID = normalizeAntigravityFetchedModelID(modelID)
@@ -143,6 +210,114 @@ func applyAntigravityFetchedModelCapabilities(models []*ModelInfo, hints antigra
 		}
 	}
 	return models
+}
+
+func applyAntigravityFetchedModels(staticModels []*ModelInfo, fetched antigravityFetchedModels) []*ModelInfo {
+	if len(fetched.Models) == 0 {
+		return applyAntigravityFetchedModelCapabilities(staticModels, fetched.Hints)
+	}
+
+	staticByID := make(map[string]*ModelInfo, len(staticModels))
+	staticByDisplayName := make(map[string]*ModelInfo, len(staticModels))
+	staticByDisplayFamily := make(map[string]*ModelInfo, len(staticModels))
+	for _, model := range staticModels {
+		if model == nil {
+			continue
+		}
+		id := normalizeAntigravityFetchedModelID(model.ID)
+		if id != "" {
+			staticByID[id] = model
+		}
+		if displayName := normalizeAntigravityDisplayName(model.DisplayName); displayName != "" {
+			if _, exists := staticByDisplayName[displayName]; !exists {
+				staticByDisplayName[displayName] = model
+			}
+		}
+		if family := normalizeAntigravityDisplayFamily(model.DisplayName); family != "" {
+			if _, exists := staticByDisplayFamily[family]; !exists {
+				staticByDisplayFamily[family] = model
+			}
+		}
+	}
+
+	models := make([]*ModelInfo, 0, len(fetched.Models))
+	for _, model := range fetched.Models {
+		if model == nil {
+			continue
+		}
+		merged := *model
+		staticModel := staticByID[normalizeAntigravityFetchedModelID(model.ID)]
+		if staticModel == nil {
+			staticModel = staticByDisplayName[normalizeAntigravityDisplayName(model.DisplayName)]
+		}
+		if staticModel == nil {
+			staticModel = staticByDisplayFamily[normalizeAntigravityDisplayFamily(model.DisplayName)]
+		}
+		if staticModel != nil {
+			mergeAntigravityStaticModelMetadata(&merged, staticModel)
+		}
+		models = append(models, &merged)
+	}
+	return applyAntigravityFetchedModelCapabilities(models, fetched.Hints)
+}
+
+func mergeAntigravityStaticModelMetadata(model, staticModel *ModelInfo) {
+	if model == nil || staticModel == nil {
+		return
+	}
+	if model.Object == "" {
+		model.Object = staticModel.Object
+	}
+	if model.OwnedBy == "" {
+		model.OwnedBy = staticModel.OwnedBy
+	}
+	if model.Type == "" {
+		model.Type = staticModel.Type
+	}
+	if model.ContextLength == 0 && staticModel.ContextLength > 0 {
+		model.ContextLength = staticModel.ContextLength
+	}
+	if model.MaxCompletionTokens == 0 && staticModel.MaxCompletionTokens > 0 {
+		model.MaxCompletionTokens = staticModel.MaxCompletionTokens
+	}
+	if model.Thinking == nil {
+		model.Thinking = cloneThinkingSupport(staticModel.Thinking)
+	}
+	if len(model.SupportedParameters) == 0 {
+		model.SupportedParameters = append([]string(nil), staticModel.SupportedParameters...)
+	}
+	if len(model.SupportedInputModalities) == 0 {
+		model.SupportedInputModalities = append([]string(nil), staticModel.SupportedInputModalities...)
+	}
+	if len(model.SupportedOutputModalities) == 0 {
+		model.SupportedOutputModalities = append([]string(nil), staticModel.SupportedOutputModalities...)
+	}
+}
+
+func cloneThinkingSupport(thinking *registry.ThinkingSupport) *registry.ThinkingSupport {
+	if thinking == nil {
+		return nil
+	}
+	cloned := *thinking
+	if len(thinking.Levels) > 0 {
+		cloned.Levels = append([]string(nil), thinking.Levels...)
+	}
+	return &cloned
+}
+
+func normalizeAntigravityDisplayName(displayName string) string {
+	return strings.ToLower(strings.TrimSpace(displayName))
+}
+
+func normalizeAntigravityDisplayFamily(displayName string) string {
+	displayName = normalizeAntigravityDisplayName(displayName)
+	if displayName == "" {
+		return ""
+	}
+	if idx := strings.Index(displayName, "("); idx >= 0 {
+		displayName = strings.TrimSpace(displayName[:idx])
+	}
+	return displayName
 }
 
 func normalizeAntigravityFetchedModelID(modelID string) string {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1850,7 +1850,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		models = applyExcludedModels(models, excluded)
 	case "antigravity":
 		models = registry.GetAntigravityModels()
-		models = applyAntigravityFetchedModelCapabilities(models, s.fetchAntigravityModelCapabilityHintsForAuth(ctx, a))
+		models = applyAntigravityFetchedModels(models, s.fetchAntigravityModelsForAuth(ctx, a))
 		models = applyExcludedModels(models, excluded)
 	case "claude":
 		models = registry.GetClaudeModels()

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -154,6 +154,19 @@ func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.
 						"maxTokens": 1,
 						"maxOutputTokens": 2
 					},
+					"gemini-3.5-flash-extra-low": {
+						"displayName": "Gemini 3.5 Flash (Low)",
+						"maxTokens": 1048576,
+						"maxOutputTokens": 65535
+					},
+					"gemini-3.5-flash-low": {
+						"displayName": "Gemini 3.5 Flash (Medium)",
+						"maxTokens": 1048576,
+						"maxOutputTokens": 65535
+					},
+					"gemini-3.5-flash-family-only": {
+						"displayName": "Gemini 3.5 Flash (Experimental)"
+					},
 					"fetched-only-search-model": {
 						"displayName": "Fetched Only Search Model"
 					}
@@ -196,7 +209,7 @@ func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.
 		}
 	}
 
-	var webSearchModel, agentModel, staticOnlyModel, fetchedOnlyModel *internalregistry.ModelInfo
+	var webSearchModel, extraLowModel, mediumModel, familyOnlyModel, agentModel, staticOnlyModel, fetchedOnlyModel *internalregistry.ModelInfo
 	for _, model := range models {
 		if model == nil {
 			continue
@@ -204,6 +217,12 @@ func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.
 		switch strings.TrimSpace(model.ID) {
 		case "gemini-3.1-flash-lite":
 			webSearchModel = model
+		case "gemini-3.5-flash-extra-low":
+			extraLowModel = model
+		case "gemini-3.5-flash-low":
+			mediumModel = model
+		case "gemini-3.5-flash-family-only":
+			familyOnlyModel = model
 		case "gemini-3-flash-agent":
 			agentModel = model
 		case "gpt-oss-120b-medium":
@@ -222,19 +241,105 @@ func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.
 	if staticWebSearchModel == nil {
 		t.Fatal("expected static gemini-3.1-flash-lite definition")
 	}
-	if webSearchModel.ContextLength != staticWebSearchModel.ContextLength || webSearchModel.MaxCompletionTokens != staticWebSearchModel.MaxCompletionTokens {
-		t.Fatalf("static token limits should be preserved, got=%#v static=%#v", webSearchModel, staticWebSearchModel)
+	if webSearchModel.ContextLength != 1 || webSearchModel.MaxCompletionTokens != 2 {
+		t.Fatalf("fetched token limits should be preserved, got=%#v", webSearchModel)
 	}
-	if agentModel == nil {
-		t.Fatal("expected gemini-3-flash-agent to be registered")
+	if extraLowModel == nil {
+		t.Fatal("expected fetched gemini-3.5-flash-extra-low to be registered")
 	}
-	if agentModel.SupportsWebSearch {
-		t.Fatal("gemini-3-flash-agent should not support web search")
+	if extraLowModel.DisplayName != "Gemini 3.5 Flash (Low)" {
+		t.Fatalf("extra-low display name = %q, want Gemini 3.5 Flash (Low)", extraLowModel.DisplayName)
+	}
+	if extraLowModel.Thinking == nil {
+		t.Fatal("expected fetched extra-low model to inherit static thinking metadata")
+	}
+	if mediumModel == nil {
+		t.Fatal("expected fetched gemini-3.5-flash-low to be registered")
+	}
+	if mediumModel.DisplayName != "Gemini 3.5 Flash (Medium)" {
+		t.Fatalf("low display name = %q, want Gemini 3.5 Flash (Medium)", mediumModel.DisplayName)
+	}
+	if familyOnlyModel == nil {
+		t.Fatal("expected fetched family-only model to be registered")
+	}
+	if familyOnlyModel.Thinking == nil {
+		t.Fatal("expected family-only model to inherit static thinking metadata")
+	}
+	if familyOnlyModel.ContextLength == 0 || familyOnlyModel.MaxCompletionTokens == 0 {
+		t.Fatalf("expected family-only model to inherit static token limits, got=%#v", familyOnlyModel)
+	}
+	if agentModel != nil {
+		t.Fatalf("static-only gemini-3-flash-agent should not be registered when upstream model list is available: %#v", agentModel)
+	}
+	if staticOnlyModel != nil {
+		t.Fatalf("static-only Antigravity model should not be registered when upstream model list is available: %#v", staticOnlyModel)
+	}
+	if fetchedOnlyModel == nil {
+		t.Fatal("expected fetched-only model to be registered")
+	}
+	if !fetchedOnlyModel.SupportsWebSearch {
+		t.Fatal("expected fetched-only model to support web search")
+	}
+}
+
+func TestRegisterModelsForAuth_AntigravityFallsBackToStaticModelsWhenFetchHasNoModels(t *testing.T) {
+	var sawFetch bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != antigravityModelsPath {
+			t.Fatalf("path = %q, want %s", r.URL.Path, antigravityModelsPath)
+		}
+		sawFetch = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+				"webSearchModelIds": ["gemini-3.1-flash-lite"]
+			}`))
+	}))
+	defer server.Close()
+
+	service := &Service{cfg: &config.Config{}}
+	auth := &coreauth.Auth{
+		ID:       "auth-antigravity-fetch-hints-only",
+		Provider: "antigravity",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"base_url": server.URL,
+		},
+		Metadata: map[string]any{
+			"access_token": "token",
+		},
+	}
+
+	registry := internalregistry.GetGlobalRegistry()
+	registry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		registry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+	if !sawFetch {
+		t.Fatal("expected fetchAvailableModels request")
+	}
+
+	models := registry.GetModelsForClient(auth.ID)
+	var webSearchModel, staticOnlyModel *internalregistry.ModelInfo
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		switch strings.TrimSpace(model.ID) {
+		case "gemini-3.1-flash-lite":
+			webSearchModel = model
+		case "gpt-oss-120b-medium":
+			staticOnlyModel = model
+		}
+	}
+	if webSearchModel == nil {
+		t.Fatal("expected static gemini-3.1-flash-lite to be registered")
+	}
+	if !webSearchModel.SupportsWebSearch {
+		t.Fatal("expected static model to receive fetched web search capability")
 	}
 	if staticOnlyModel == nil {
-		t.Fatal("expected static-only Antigravity model to remain registered")
-	}
-	if fetchedOnlyModel != nil {
-		t.Fatalf("fetched-only model should not be registered: %#v", fetchedOnlyModel)
+		t.Fatal("expected static-only Antigravity model to remain registered on hints-only fetch")
 	}
 }

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -148,30 +148,36 @@ func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.
 		sawFetch = true
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
-				"models": {
-					"gemini-3.1-flash-lite": {
-						"displayName": "Gemini 3.1 Flash Lite",
-						"maxTokens": 1,
-						"maxOutputTokens": 2
+					"models": {
+						"gemini-3.1-flash-lite": {
+							"displayName": "Gemini 3.1 Flash Lite",
+							"maxTokens": 1,
+							"maxOutputTokens": 2
+						},
+						" gemini-3.5-flash-extra-low ": {
+							"displayName": "Gemini 3.5 Flash (Low)",
+							"maxTokens": 1048576,
+							"maxOutputTokens": 65535
+						},
+						"gemini-3.5-flash-low": {
+							"displayName": "Gemini 3.5 Flash (Medium)",
+							"maxTokens": 1048576,
+							"maxOutputTokens": 65535
+						},
+						"gemini-3.5-flash-family-only": {
+							"displayName": "Gemini 3.5 Flash (Experimental)"
+						},
+						"fetched-only-search-model": {
+							"displayName": "Fetched Only Search Model"
+						},
+						"chat_20706": {
+							"displayName": "Internal Chat Model"
+						},
+						"tab_flash_lite_preview": {
+							"displayName": "Internal Tab Model"
+						}
 					},
-					"gemini-3.5-flash-extra-low": {
-						"displayName": "Gemini 3.5 Flash (Low)",
-						"maxTokens": 1048576,
-						"maxOutputTokens": 65535
-					},
-					"gemini-3.5-flash-low": {
-						"displayName": "Gemini 3.5 Flash (Medium)",
-						"maxTokens": 1048576,
-						"maxOutputTokens": 65535
-					},
-					"gemini-3.5-flash-family-only": {
-						"displayName": "Gemini 3.5 Flash (Experimental)"
-					},
-					"fetched-only-search-model": {
-						"displayName": "Fetched Only Search Model"
-					}
-				},
-				"webSearchModelIds": ["gemini-3.1-flash-lite", "fetched-only-search-model"]
+					"webSearchModelIds": ["gemini-3.1-flash-lite", "fetched-only-search-model"]
 			}`))
 	}))
 	defer server.Close()
@@ -209,7 +215,7 @@ func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.
 		}
 	}
 
-	var webSearchModel, extraLowModel, mediumModel, familyOnlyModel, agentModel, staticOnlyModel, fetchedOnlyModel *internalregistry.ModelInfo
+	var webSearchModel, extraLowModel, mediumModel, familyOnlyModel, agentModel, staticOnlyModel, fetchedOnlyModel, internalModel *internalregistry.ModelInfo
 	for _, model := range models {
 		if model == nil {
 			continue
@@ -229,6 +235,8 @@ func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.
 			staticOnlyModel = model
 		case "fetched-only-search-model":
 			fetchedOnlyModel = model
+		case "chat_20706", "tab_flash_lite_preview":
+			internalModel = model
 		}
 	}
 	if webSearchModel == nil {
@@ -252,6 +260,9 @@ func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.
 	}
 	if extraLowModel.Thinking == nil {
 		t.Fatal("expected fetched extra-low model to inherit static thinking metadata")
+	}
+	if extraLowModel.ContextLength != 1048576 || extraLowModel.MaxCompletionTokens != 65535 {
+		t.Fatalf("expected extra-low model to keep fetched token limits, got=%#v", extraLowModel)
 	}
 	if mediumModel == nil {
 		t.Fatal("expected fetched gemini-3.5-flash-low to be registered")
@@ -279,6 +290,9 @@ func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.
 	}
 	if !fetchedOnlyModel.SupportsWebSearch {
 		t.Fatal("expected fetched-only model to support web search")
+	}
+	if internalModel != nil {
+		t.Fatalf("internal Antigravity model should not be registered: %#v", internalModel)
 	}
 }
 
@@ -341,5 +355,80 @@ func TestRegisterModelsForAuth_AntigravityFallsBackToStaticModelsWhenFetchHasNoM
 	}
 	if staticOnlyModel == nil {
 		t.Fatal("expected static-only Antigravity model to remain registered on hints-only fetch")
+	}
+}
+
+func TestFetchAntigravityModelsForAuth_KeepsTryingAfterHintsOnlyResponse(t *testing.T) {
+	var sawHintsOnlyFetch, sawModelFetch bool
+	hintsOnlyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawHintsOnlyFetch = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+				"webSearchModelIds": ["fetched-search-model"]
+			}`))
+	}))
+	defer hintsOnlyServer.Close()
+
+	modelServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawModelFetch = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+				"models": {
+					"fetched-search-model": {
+						"displayName": "Fetched Search Model"
+					}
+				}
+			}`))
+	}))
+	defer modelServer.Close()
+
+	service := &Service{cfg: &config.Config{}}
+	auth := &coreauth.Auth{
+		ID:       "auth-antigravity-fetch-fallback",
+		Provider: "antigravity",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{
+			"access_token": "token",
+		},
+	}
+
+	fetched := service.fetchAntigravityModelsForAuthFromBaseURLs(context.Background(), auth, []string{hintsOnlyServer.URL, modelServer.URL})
+	if !sawHintsOnlyFetch || !sawModelFetch {
+		t.Fatalf("expected both fallback endpoints to be fetched, saw hints=%v models=%v", sawHintsOnlyFetch, sawModelFetch)
+	}
+	if len(fetched.Models) != 1 {
+		t.Fatalf("models count = %d, want 1", len(fetched.Models))
+	}
+	if fetched.Models[0].ID != "fetched-search-model" {
+		t.Fatalf("fetched model ID = %q, want fetched-search-model", fetched.Models[0].ID)
+	}
+	if _, ok := fetched.Hints.WebSearchModelIDs["fetched-search-model"]; !ok {
+		t.Fatalf("expected hints-only response to be retained, got=%#v", fetched.Hints.WebSearchModelIDs)
+	}
+}
+
+func TestApplyAntigravityFetchedModels_MergesGenerationMethods(t *testing.T) {
+	staticModels := []*internalregistry.ModelInfo{{
+		ID:                         "dynamic-model",
+		DisplayName:                "Dynamic Model",
+		SupportedGenerationMethods: []string{"generateContent"},
+	}}
+	fetched := antigravityFetchedModels{
+		Models: []*ModelInfo{{
+			ID:          "dynamic-model",
+			DisplayName: "Dynamic Model",
+		}},
+	}
+
+	models := applyAntigravityFetchedModels(staticModels, fetched)
+	if len(models) != 1 {
+		t.Fatalf("models count = %d, want 1", len(models))
+	}
+	if got := models[0].SupportedGenerationMethods; len(got) != 1 || got[0] != "generateContent" {
+		t.Fatalf("supported generation methods = %#v, want generateContent", got)
+	}
+	staticModels[0].SupportedGenerationMethods[0] = "mutated"
+	if got := models[0].SupportedGenerationMethods[0]; got != "generateContent" {
+		t.Fatalf("supported generation methods should be cloned, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Use Antigravity's live `fetchAvailableModels` response as the per-auth OAuth model catalog when the upstream response includes a model list. This keeps the exposed Antigravity OAuth catalog aligned with the tiers currently advertised by Antigravity instead of relying only on the embedded/static catalog.

Related to #3949.

## Changes

- Parse the Antigravity `models` map from `v1internal:fetchAvailableModels`, not only `webSearchModelIds`.
- Register fetched Antigravity models as the authoritative list for that auth when the upstream list is non-empty.
- Merge static metadata by exact model ID, exact display name, then display-name family so fetched models keep known thinking/modalities/parameter metadata without mutating static registry definitions.
- Preserve capability hints across fallback endpoints and keep the existing fallback path when upstream returns no model list.
- Filter internal/experimental fetched model IDs before registering runtime models.
- Add regression coverage for Gemini 3.5 Flash tier discovery, fetched-only models, family metadata fallback, generation-method metadata merge, and hints-only fallback.

## Antigravity tier catalog

Current upstream discovery advertises these relevant Gemini 3 / 3.5 tiers:

| upstream id | upstream display name |
| --- | --- |
| `gemini-3.5-flash-extra-low` | `Gemini 3.5 Flash (Low)` |
| `gemini-3.5-flash-low` | `Gemini 3.5 Flash (Medium)` |
| `gemini-3-flash-agent` | `Gemini 3.5 Flash (High)` |
| `gemini-3-flash` | `Gemini 3 Flash` |

With this change, the runtime OAuth catalog can expose those upstream-discovered tiers without waiting for a static model catalog refresh.

## Verification

- `go test ./sdk/cliproxy -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- Local source-run server on `127.0.0.1:8321` verified:
  - `/v1/models` lists `gemini-3.5-flash-extra-low`
  - chat completions route successfully for `gemini-3.5-flash-extra-low`, `gemini-3.5-flash-low`, `gemini-3-flash-agent`, and `gemini-3-flash`

## Notes

Antigravity currently reports `modelVersion: gemini-3-flash-a` in responses for the Gemini 3.5 Flash tier IDs. This PR keeps response translation semantics unchanged and focuses on using upstream discovery as the runtime catalog source.
