### PR TITLE
Fix Codex WebSocket payload model prefix rewrite / 修复 Codex WebSocket 请求体模型前缀改写

### DIFF
--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -428,6 +428,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, body, requestedModel, requestPath, opts.Headers)
+	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body = normalizeCodexInstructions(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -95,6 +95,7 @@ func TestCodexWebsocketsExecutePreservesPreviousResponseIDUpstream(t *testing.T)
 
 func TestCodexWebsocketsExecuteStreamPassesThroughUpstreamWebsocketPayloadForDownstreamWebsocket(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	capturedPayload := make(chan []byte, 1)
 	delta := []byte(`{"type":"response.output_text.delta","delta":"hello"}`)
 	completed := []byte(`{"type":"response.completed","response":{"id":"resp-1","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -105,10 +106,12 @@ func TestCodexWebsocketsExecuteStreamPassesThroughUpstreamWebsocketPayloadForDow
 		}
 		defer func() { _ = conn.Close() }()
 
-		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+		_, payload, errRead := conn.ReadMessage()
+		if errRead != nil {
 			t.Errorf("read upstream websocket message: %v", errRead)
 			return
 		}
+		capturedPayload <- bytes.Clone(payload)
 		if errWrite := conn.WriteMessage(websocket.TextMessage, delta); errWrite != nil {
 			t.Errorf("write delta websocket message: %v", errWrite)
 			return
@@ -124,7 +127,7 @@ func TestCodexWebsocketsExecuteStreamPassesThroughUpstreamWebsocketPayloadForDow
 	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5-codex",
-		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","role":"user","content":"hello"}]}`),
+		Payload: []byte(`{"model":"prolite/gpt-5-codex","input":[{"type":"message","role":"user","content":"hello"}]}`),
 	}
 	opts := cliproxyexecutor.Options{
 		SourceFormat:   sdktranslator.FromString("openai-response"),
@@ -150,6 +153,15 @@ func TestCodexWebsocketsExecuteStreamPassesThroughUpstreamWebsocketPayloadForDow
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for first stream chunk")
+	}
+
+	select {
+	case payload := <-capturedPayload:
+		if got := gjson.GetBytes(payload, "model").String(); got != "gpt-5-codex" {
+			t.Fatalf("upstream model = %s, want gpt-5-codex; payload=%s", got, payload)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upstream websocket payload")
 	}
 }
 


### PR DESCRIPTION
## 中文
### 问题
当下游请求使用 prefix 路由模型名，例如 `prolite/gpt-5.5` 时，auth manager 会选中对应凭据并把执行模型解析为 `gpt-5.5`。但 Codex WebSocket streaming 路径此前没有同步改写上游 payload 中的 `model` 字段，导致上游收到带 prefix 的模型名并返回 unsupported model。

### 修复
- 在 Codex WebSocket streaming executor 中，将上游 payload 的 `model` 设置为已剥 prefix 的 `baseModel`。
- 扩展 WebSocket streaming 回归测试，断言下游 payload 带 prefix 时，上游只收到基础模型名。

## English
### Problem
When a downstream request uses a prefixed routing model such as `prolite/gpt-5.5`, the auth manager selects the matching credential and resolves the execution model to `gpt-5.5`. However, the Codex WebSocket streaming path did not rewrite the upstream payload `model` field, so upstream could receive the prefixed model name and reject it as unsupported.

### Fix
- Set the Codex WebSocket streaming upstream payload `model` to the prefix-stripped `baseModel`.
- Extend the WebSocket streaming regression test to assert that upstream receives only the base model when the downstream payload contains a prefix.