### PR TITLE
fix(xai): preserve supported reasoning fields

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -1237,6 +1237,8 @@ func xaiSupportsReasoningEffort(model string) bool {
 	switch {
 	case strings.HasPrefix(name, "grok-3-mini"):
 		return true
+	case name == "grok-4":
+		return true
 	case strings.HasPrefix(name, "grok-4.20-multi-agent"):
 		return true
 	case strings.HasPrefix(name, "grok-4.3"):

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -385,7 +385,7 @@ func TestXAIExecutorExecuteStreamCompactionTriggerUsesCompactEndpoint(t *testing
 	}
 }
 
-func TestXAIExecutorOmitsUnsupportedReasoningEffort(t *testing.T) {
+func TestXAIExecutorDropsUnsupportedReasoningEffort(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var errRead error
@@ -395,6 +395,48 @@ func TestXAIExecutorOmitsUnsupportedReasoningEffort(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"model\":\"grok-4\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}]}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"base_url":  server.URL,
+			"auth_kind": "oauth",
+		},
+		Metadata: map[string]any{"access_token": "xai-token"},
+	}
+
+	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "grok-build",
+		Payload: []byte(`{"model":"grok-build","input":"hello","reasoning":{"effort":"high","summary":"concise"}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if gjson.GetBytes(gotBody, "reasoning.effort").Exists() {
+		t.Fatalf("unsupported xAI model must omit reasoning.effort: %s", string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "reasoning.summary").String(); got != "concise" {
+		t.Fatalf("reasoning.summary = %q, want concise; body=%s", got, string(gotBody))
+	}
+}
+
+func TestXAIExecutorPreservesGrok4ReasoningEffort(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var errRead error
+		gotBody, errRead = io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read body: %v", errRead)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"model\":\"grok-4.3\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}]}}\n\n"))
 	}))
 	defer server.Close()
 
@@ -419,8 +461,32 @@ func TestXAIExecutorOmitsUnsupportedReasoningEffort(t *testing.T) {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
-	if gjson.GetBytes(gotBody, "reasoning").Exists() {
-		t.Fatalf("unsupported xAI model must omit reasoning key: %s", string(gotBody))
+	if got := gjson.GetBytes(gotBody, "reasoning.effort").String(); got != "high" {
+		t.Fatalf("reasoning.effort = %q, want high; body=%s", got, string(gotBody))
+	}
+}
+
+func TestXAISupportsReasoningEffortModelList(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{model: "grok-build-0.1", want: false},
+		{model: "grok-4", want: true},
+		{model: "grok-4.3", want: true},
+		{model: "grok-4.20-0309-reasoning", want: false},
+		{model: "grok-4.20-0309-non-reasoning", want: false},
+		{model: "grok-4.20-multi-agent-0309", want: true},
+		{model: "grok-3-mini", want: true},
+		{model: "grok-3-mini-fast", want: true},
+		{model: "grok-composer-2.5-fast", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := xaiSupportsReasoningEffort(tt.model); got != tt.want {
+				t.Fatalf("xaiSupportsReasoningEffort(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- strip only unsupported `reasoning.effort` from xAI Responses requests instead of deleting the whole `reasoning` object
- keep other accepted `reasoning` fields, such as `reasoning.summary`, intact
- allow `grok-4` to preserve `reasoning.effort`, since xAI currently resolves it to `grok-4.3`
- add executor coverage for unsupported effort filtering, `grok-4` effort preservation, and the xAI effort allowlist

## Why

Some xAI models reject controllable `reasoning.effort`, but they still accept the `reasoning` object itself. Dropping the whole object can remove supported fields that should survive request sanitization.

Live xAI `/v1/responses` checks with credentials redacted:

- `grok-build`
  - `reasoning: {}` -> `200`
  - `reasoning: {"summary":"concise"}` -> `200`
  - `reasoning: {"effort":"low","summary":"concise"}` -> `400 invalid-argument`
  - error: `Model grok-build does not support parameter reasoningEffort.`

- `grok-composer-2.5-fast`
  - `reasoning: {}` -> stream starts with `200`
  - `reasoning: {"summary":"concise"}` -> stream starts with `200`
  - `reasoning: {"effort":"low","summary":"concise"}` -> `400 invalid-argument`
  - error: `Model grok-composer-2.5-fast does not support parameter reasoningEffort.`

- `grok-4`
  - `reasoning: {"effort":"low"}` -> `200`
  - response reports `model: "grok-4.3"` and preserves `reasoning.effort: "low"`

- `grok-4.20-multi-agent-0309`
  - `reasoning: {"effort":"low"}` -> stream starts with `200`

- `grok-4.20-0309-reasoning` and `grok-4.20-0309-non-reasoning`
  - `reasoning: {"effort":"low"}` -> `400 invalid-argument`

So the incompatible field is specifically `reasoning.effort`, not the entire `reasoning` object.

## Validation

- `git diff --check upstream/dev..HEAD`
- `go test -count=1 ./internal/runtime/executor -run 'TestXAIExecutorDropsUnsupportedReasoningEffort|TestXAIExecutorPreservesGrok4ReasoningEffort|TestXAISupportsReasoningEffortModelList'`
- `go build -o test-output ./cmd/server && rm test-output`
