### PR TITLE
fix(claude): preserve forwarded system blocks in OAuth cloaking

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1894,7 +1894,7 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 
 	// Collect user system instructions and prepend to first user message.
 	// In OAuth mode, sanitize only the first forwarded system block and preserve
-	// all subsequent blocks unchanged (PR #3335 approach).
+	// all subsequent blocks unchanged.
 	if !strictMode {
 		var userSystemParts []string
 		if system.IsArray() {
@@ -1912,9 +1912,11 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 		}
 
 		if len(userSystemParts) > 0 {
-			combined := strings.Join(userSystemParts, "\n\n")
+			var combined string
 			if oauthMode {
 				combined = sanitizeForwardedSystemPrompt(userSystemParts)
+			} else {
+				combined = strings.Join(userSystemParts, "\n\n")
 			}
 			if strings.TrimSpace(combined) != "" {
 				payload = prependToFirstUserMessage(payload, combined)
@@ -1926,8 +1928,8 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 }
 
 // sanitizeForwardedSystemPrompt sanitizes the first forwarded system block and
-// preserves all subsequent blocks unchanged. This is the PR #3335 approach:
-// sanitize userSystemParts[0], keep userSystemParts[1:].
+// preserves all subsequent blocks unchanged: sanitize userSystemParts[0],
+// keep userSystemParts[1:].
 func sanitizeForwardedSystemPrompt(parts []string) string {
 	if len(parts) == 0 {
 		return ""

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1929,7 +1929,8 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 
 // sanitizeForwardedSystemPrompt sanitizes the first forwarded system block and
 // preserves all subsequent blocks unchanged: sanitize userSystemParts[0],
-// keep userSystemParts[1:].
+// keep userSystemParts[1:]. It also extracts <available_skills> from block[0]
+// before replacing it, since OpenCode typically sends everything in a single block.
 func sanitizeForwardedSystemPrompt(parts []string) string {
 	if len(parts) == 0 {
 		return ""
@@ -1938,9 +1939,28 @@ func sanitizeForwardedSystemPrompt(parts []string) string {
 Keep responses concise and focused on the user's request.
 Prefer acting on the user's task over describing product-specific workflows.`)
 	sanitized := make([]string, 0, len(parts))
-	sanitized = append(sanitized, genericReminder)
+	parts0 := genericReminder
+	if skills := extractAvailableSkillsBlock(parts[0]); skills != "" {
+		parts0 = genericReminder + "\n\n" + skills
+	}
+	sanitized = append(sanitized, parts0)
 	sanitized = append(sanitized, parts[1:]...)
 	return strings.Join(sanitized, "\n\n")
+}
+
+func extractAvailableSkillsBlock(text string) string {
+	const openTag = "<available_skills>"
+	const closeTag = "</available_skills>"
+	start := strings.Index(text, openTag)
+	if start < 0 {
+		return ""
+	}
+	end := strings.Index(text[start:], closeTag)
+	if end < 0 {
+		return ""
+	}
+	end += start + len(closeTag)
+	return strings.TrimSpace(text[start:end])
 }
 
 // buildTextBlock constructs a JSON text block object with proper escaping.

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1892,7 +1892,9 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 	systemResult := "[" + billingBlock + "," + agentBlock + "," + staticBlock + "]"
 	payload, _ = sjson.SetRawBytes(payload, "system", []byte(systemResult))
 
-	// Collect user system instructions and prepend to first user message
+	// Collect user system instructions and prepend to first user message.
+	// In OAuth mode, sanitize only the first forwarded system block and preserve
+	// all subsequent blocks unchanged (PR #3335 approach).
 	if !strictMode {
 		var userSystemParts []string
 		if system.IsArray() {
@@ -1912,7 +1914,7 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 		if len(userSystemParts) > 0 {
 			combined := strings.Join(userSystemParts, "\n\n")
 			if oauthMode {
-				combined = sanitizeForwardedSystemPrompt(combined)
+				combined = sanitizeForwardedSystemPrompt(userSystemParts)
 			}
 			if strings.TrimSpace(combined) != "" {
 				payload = prependToFirstUserMessage(payload, combined)
@@ -1923,17 +1925,20 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 	return payload
 }
 
-// sanitizeForwardedSystemPrompt reduces forwarded third-party system context to a
-// tiny neutral reminder for Claude OAuth cloaking. The goal is to preserve only
-// the minimum tool/task guidance while removing virtually all client-specific
-// prompt structure that Anthropic may classify as third-party agent traffic.
-func sanitizeForwardedSystemPrompt(text string) string {
-	if strings.TrimSpace(text) == "" {
+// sanitizeForwardedSystemPrompt sanitizes the first forwarded system block and
+// preserves all subsequent blocks unchanged. This is the PR #3335 approach:
+// sanitize userSystemParts[0], keep userSystemParts[1:].
+func sanitizeForwardedSystemPrompt(parts []string) string {
+	if len(parts) == 0 {
 		return ""
 	}
-	return strings.TrimSpace(`Use the available tools when needed to help with software engineering tasks.
+	genericReminder := strings.TrimSpace(`Use the available tools when needed to help with software engineering tasks.
 Keep responses concise and focused on the user's request.
 Prefer acting on the user's task over describing product-specific workflows.`)
+	sanitized := make([]string, 0, len(parts))
+	sanitized = append(sanitized, genericReminder)
+	sanitized = append(sanitized, parts[1:]...)
+	return strings.Join(sanitized, "\n\n")
 }
 
 // buildTextBlock constructs a JSON text block object with proper escaping.

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2464,6 +2464,23 @@ func TestCheckSystemInstructionsWithSigningMode_OAuthPassthroughPreserveSanitize
 	}
 }
 
+func TestCheckSystemInstructionsWithSigningMode_OAuthSingleBlockPreservesAvailableSkills(t *testing.T) {
+	payload := []byte(`{"system":[{"type":"text","text":"You are OpenCode.\n<available_skills>\n  <skill><name>browser-automation</name><description>Browser automation.</description></skill>\n</available_skills>\nDo not forward this product-specific text."}],"messages":[{"role":"user","content":"hi"}]}`)
+
+	out := checkSystemInstructionsWithSigningMode(payload, false, false, true, "2.1.63", "cli", "")
+
+	content := gjson.GetBytes(out, "messages.0.content").String()
+	if !strings.Contains(content, "<available_skills>") || !strings.Contains(content, "browser-automation") {
+		t.Fatalf("single-block passthrough should preserve available skills, got %q", content)
+	}
+	if strings.Contains(content, "Do not forward this product-specific text") {
+		t.Fatalf("single-block passthrough forwarded unrelated product-specific text: %q", content)
+	}
+	if strings.Contains(content, "You are OpenCode") {
+		t.Fatalf("single-block passthrough should sanitize identity, got %q", content)
+	}
+}
+
 func TestClaudeExecutor_ExperimentalCCHSigningDisabledByDefaultKeepsLegacyHeader(t *testing.T) {
 	var seenBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2444,6 +2444,26 @@ func TestCheckSystemInstructionsWithMode_StringWithSpecialChars(t *testing.T) {
 	}
 }
 
+func TestCheckSystemInstructionsWithSigningMode_OAuthPassthroughPreserveSanitizesFirstPreservesRest(t *testing.T) {
+	payload := []byte(`{"system":[{"type":"text","text":"You are OpenCode, the best coding agent on the planet.\nOpenCode primary prompt."},{"type":"text","text":"# AGENTS.md\n\n## Rules\n\n- Preserve me verbatim."},{"type":"text","text":"<available_skills><skill><name>custom-skill</name><description>Keep me.</description></skill></available_skills>"}],"messages":[{"role":"user","content":"hi"}]}`)
+
+	out := checkSystemInstructionsWithSigningMode(payload, false, false, true, "2.1.63", "cli", "")
+
+	content := gjson.GetBytes(out, "messages.0.content").String()
+	if !strings.Contains(content, "# AGENTS.md") || !strings.Contains(content, "Preserve me verbatim") {
+		t.Fatalf("passthrough-preserve should preserve second system block verbatim, got %q", content)
+	}
+	if !strings.Contains(content, "custom-skill") || !strings.Contains(content, "Keep me") {
+		t.Fatalf("passthrough-preserve should preserve third system block verbatim, got %q", content)
+	}
+	if strings.Contains(content, "You are OpenCode, the best coding agent on the planet") {
+		t.Fatalf("passthrough-preserve should sanitize first block identity, got %q", content)
+	}
+	if got := gjson.GetBytes(out, "system.#").Int(); got != 3 {
+		t.Fatalf("system blocks = %d, want 3 canonical Claude Code blocks", got)
+	}
+}
+
 func TestClaudeExecutor_ExperimentalCCHSigningDisabledByDefaultKeepsLegacyHeader(t *testing.T) {
 	var seenBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Sanitize only the first forwarded system block during OAuth cloaking and preserve all subsequent blocks unchanged. Extract `<available_skills>` from the first block before sanitizing, since clients like OpenCode typically send everything in a single block.

## Problem

When clients like OpenCode or Amp route requests through Claude OAuth cloaking, all forwarded `system[]` text blocks are collected into one string and passed through `sanitizeForwardedSystemPrompt()`. That function replaces the entire input with a short generic reminder:

```
Use the available tools when needed to help with software engineering tasks.
Keep responses concise and focused on the user's request.
Prefer acting on the user's task over describing product-specific workflows.
```

This drops important context like AGENTS.md guidance and skill descriptions, which can significantly affect tool use and task behavior.

## Fix

1. Collect forwarded `system[]` text blocks as before.
2. In OAuth mode, sanitize only `userSystemParts[0]` with the existing generic reminder.
3. Extract `<available_skills>` from `userSystemParts[0]` before replacing it (OpenCode sends everything in a single block).
4. Preserve `userSystemParts[1:]` unchanged.
5. Join all parts and prepend to the first user message using the existing `<system-reminder>` path.

This keeps the OAuth cloaking safety behavior for the primary third-party agent prompt while preserving additional project guidance and skill descriptions.

## Test Plan

- `TestCheckSystemInstructionsWithSigningMode_OAuthPassthroughPreserveSanitizesFirstPreservesRest` — verifies multi-block case: sanitizes first block, preserves later AGENTS.md and skill blocks
- `TestCheckSystemInstructionsWithSigningMode_OAuthSingleBlockPreservesAvailableSkills` — verifies single-block case: extracts `<available_skills>` before sanitizing
- `go test -run 'TestCheckSystemInstructions' ./internal/runtime/executor`
- `go build -o test-output ./cmd/server && rm test-output`

Refs #3245
Closes #3335
