### PR TITLE
feat: add on-payment-required option to auto-disable key on 402

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -157,6 +157,7 @@ quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
   antigravity-credits: true # Whether to use credits as last-resort fallback when all free-tier auths are exhausted for Claude models
+  on-payment-required: "cooldown" # "cooldown" (default, 30-min cooldown) or "disable" (permanently disable the key)
 
 # Routing strategy for selecting credentials when multiple match.
 routing:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -323,6 +323,10 @@ type QuotaExceeded struct {
 	// When all free-tier auths are exhausted (429/503), the conductor retries with
 	// an auth that has available Google One AI credits.
 	AntigravityCredits bool `yaml:"antigravity-credits" json:"antigravity-credits"`
+
+	// OnPaymentRequired controls behavior when an API key returns 402 (Payment Required).
+	// Supported values: "cooldown" (default, 30-min cooldown) or "disable" (permanently disable the key).
+	OnPaymentRequired string `yaml:"on-payment-required,omitempty" json:"on-payment-required,omitempty"`
 }
 
 // RoutingConfig configures how credentials are selected for requests.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3405,13 +3405,24 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								shouldSuspendModel = true
 							}
 						case 402, 403:
-							if disableCooling {
-								state.NextRetryAfter = time.Time{}
-							} else {
-								next := now.Add(30 * time.Minute)
-								state.NextRetryAfter = next
-								suspendReason = "payment_required"
-								shouldSuspendModel = true
+							{
+								cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+								if cfg != nil && cfg.QuotaExceeded.OnPaymentRequired == "disable" {
+									auth.Disabled = true
+									auth.Status = StatusDisabled
+									auth.StatusMessage = "payment_required_disabled"
+									state.NextRetryAfter = time.Time{}
+									state.Unavailable = true
+									state.Status = StatusDisabled
+									suspendReason = "payment_required_disabled"
+								} else if disableCooling {
+									state.NextRetryAfter = time.Time{}
+								} else {
+									next := now.Add(30 * time.Minute)
+									state.NextRetryAfter = next
+									suspendReason = "payment_required"
+									shouldSuspendModel = true
+								}
 							}
 						case 404:
 							if disableCooling {
@@ -3927,11 +3938,19 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.NextRetryAfter = now.Add(30 * time.Minute)
 		}
 	case 402, 403:
-		auth.StatusMessage = "payment_required"
-		if disableCooling {
+		cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+		if cfg != nil && cfg.QuotaExceeded.OnPaymentRequired == "disable" {
+			auth.Disabled = true
+			auth.Status = StatusDisabled
+			auth.StatusMessage = "payment_required_disabled"
 			auth.NextRetryAfter = time.Time{}
 		} else {
-			auth.NextRetryAfter = now.Add(30 * time.Minute)
+			auth.StatusMessage = "payment_required"
+			if disableCooling {
+				auth.NextRetryAfter = time.Time{}
+			} else {
+				auth.NextRetryAfter = now.Add(30 * time.Minute)
+			}
 		}
 	case 404:
 		auth.StatusMessage = "not_found"


### PR DESCRIPTION
## Summary

Adds a new `on-payment-required` option to `quota-exceeded` config that controls behavior when an API key returns 402 (Payment Required).

- `cooldown` (default) — current behavior, 30-minute cooldown
- `disable` — automatically disable the key until manually re-enabled via management panel

Closes #3977

## Changes

- `internal/config/config.go` — Added `OnPaymentRequired` field to `QuotaExceeded` struct
- `sdk/cliproxy/auth/conductor.go` — Modified 402 handling in both `MarkResult` and `applyAuthFailureState` to disable key when configured
- `config.example.yaml` — Added new option to example config

## Config example

```yaml
quota-exceeded:
  on-payment-required: "disable"  # "cooldown" (default) or "disable"
```

## Behavior

When `on-payment-required: "disable"`:
- 402 response → key is immediately disabled (`auth.Disabled = true`)
- Proxy skips the disabled key and uses remaining keys
- Key can be re-enabled via management panel: `PUT /v0/management/openai-compatibility`

When `on-payment-required: "cooldown"` (default):
- Current behavior preserved, 30-minute cooldown

## Use case

Users with multiple API keys for the same provider (e.g. 3 keys for mimo API). When one key runs out of balance, it should be automatically disabled so the proxy immediately uses the remaining keys without going through cooldown cycles.