### PR TITLE
fix(browser): avoid opening about:blank when probing browser availabi…

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -84,12 +84,6 @@ func openURLPlatformSpecific(url string) error {
 // Returns:
 //   - true if a browser can be opened, false otherwise.
 func IsAvailable() bool {
-	// First check if open-golang can work
-	testErr := open.Run("about:blank")
-	if testErr == nil {
-		return true
-	}
-
 	// Check platform-specific commands
 	switch runtime.GOOS {
 	case "darwin":


### PR DESCRIPTION
## 概述

`IsAvailable()` 通过真正执行 `open.Run("about:blank")` 来探测浏览器是否可用，
这有可见副作用：它会真的让系统去打开 `about:blank`。
于是每次 `*-login` 都会在打开真正的认证链接之前先弹出一个窗口/弹框。

## 复现

在 Linux（这里是 KDE/KIO）上运行任意 `*-login` 命令，在认证页打开前，
系统会尝试"读取文件 about:blank"并弹出错误框：

<img width="301" height="160" alt="屏幕截图_20260624_153210" src="https://github.com/user-attachments/assets/07c47438-d430-488c-b0b8-fb9fd1321f54" />

## 根因

`internal/browser/browser.go` 的 `IsAvailable()` 用 `open.Run("about:blank")` 做能力检测。
一个纯粹的"是否可用"检查不应有任何副作用，而其下方已有的按平台 `exec.LookPath` 检测已足够。

## 修复

移除 `open.Run("about:blank")` 探测，仅依赖已有的按平台 `exec.LookPath` 检测。
改动最小，且不影响真正打开浏览器的 `OpenURL` 流程。