### PR TITLE
fix(oauth): force-map responses to config alias not request suffix

### DIFF
--- a/sdk/cliproxy/auth/oauth_model_alias.go
+++ b/sdk/cliproxy/auth/oauth_model_alias.go
@@ -18,6 +18,7 @@ type modelAliasEntry interface {
 // oauthModelAliasEntry stores the upstream model name and mapping flags for an alias.
 type oauthModelAliasEntry struct {
 	upstreamModel string
+	configAlias   string
 	forceMapping  bool
 }
 
@@ -61,6 +62,7 @@ func compileOAuthModelAliasTable(aliases map[string][]internalconfig.OAuthModelA
 			}
 			rev[aliasKey] = oauthModelAliasEntry{
 				upstreamModel: name,
+				configAlias:   alias,
 				forceMapping:  entry.ForceMapping,
 			}
 		}
@@ -128,6 +130,10 @@ func preserveResolvedModelSuffix(resolved string, requestResult thinking.SuffixR
 		return resolved + "(" + requestResult.RawSuffix + ")"
 	}
 	return resolved
+}
+
+func oauthModelAliasForceMappingResponseModel(configAlias string) string {
+	return strings.TrimSpace(configAlias)
 }
 
 func resolveModelAliasPoolFromConfigModels(requestedModel string, models []modelAliasEntry) []string {
@@ -306,13 +312,13 @@ func resolveUpstreamModelFromAliases(aliases []internalconfig.OAuthModelAlias, r
 				return OAuthModelAliasResult{
 					UpstreamModel: preserveResolvedModelSuffix(original, requestResult),
 					ForceMapping:  entry.ForceMapping,
-					OriginalAlias: requestedModel,
+					OriginalAlias: oauthModelAliasForceMappingResponseModel(alias),
 				}
 			}
 			return OAuthModelAliasResult{
 				UpstreamModel: preserveResolvedModelSuffix(original, requestResult),
 				ForceMapping:  entry.ForceMapping,
-				OriginalAlias: requestedModel,
+				OriginalAlias: oauthModelAliasForceMappingResponseModel(alias),
 			}
 		}
 	}
@@ -375,7 +381,7 @@ func resolveUpstreamModelFromAliasTable(m *Manager, auth *Auth, requestedModel, 
 			return OAuthModelAliasResult{
 				UpstreamModel: preserveResolvedModelSuffix(targetModel, requestResult),
 				ForceMapping:  entry.forceMapping,
-				OriginalAlias: requestedModel,
+				OriginalAlias: oauthModelAliasForceMappingResponseModel(entry.configAlias),
 			}
 		}
 
@@ -391,7 +397,7 @@ func resolveUpstreamModelFromAliasTable(m *Manager, auth *Auth, requestedModel, 
 		return OAuthModelAliasResult{
 			UpstreamModel: upstreamModel,
 			ForceMapping:  entry.forceMapping,
-			OriginalAlias: requestedModel,
+			OriginalAlias: oauthModelAliasForceMappingResponseModel(entry.configAlias),
 		}
 	}
 

--- a/sdk/cliproxy/auth/oauth_model_alias.go
+++ b/sdk/cliproxy/auth/oauth_model_alias.go
@@ -31,7 +31,7 @@ type oauthModelAliasTable struct {
 type OAuthModelAliasResult struct {
 	UpstreamModel string // resolved upstream model name (empty if no mapping found)
 	ForceMapping  bool   // whether to rewrite model name in responses
-	OriginalAlias string // the original requested alias (for response rewriting)
+	OriginalAlias string // client-visible model for response rewrite; only applied when ForceMapping is true (see rewriteForceMappedResponse / wrapStreamResult)
 }
 
 func compileOAuthModelAliasTable(aliases map[string][]internalconfig.OAuthModelAlias) *oauthModelAliasTable {
@@ -315,10 +315,14 @@ func resolveUpstreamModelFromAliases(aliases []internalconfig.OAuthModelAlias, r
 					OriginalAlias: oauthModelAliasForceMappingResponseModel(alias),
 				}
 			}
+			originalAlias := requestedModel
+			if entry.ForceMapping {
+				originalAlias = oauthModelAliasForceMappingResponseModel(alias)
+			}
 			return OAuthModelAliasResult{
 				UpstreamModel: preserveResolvedModelSuffix(original, requestResult),
 				ForceMapping:  entry.ForceMapping,
-				OriginalAlias: oauthModelAliasForceMappingResponseModel(alias),
+				OriginalAlias: originalAlias,
 			}
 		}
 	}
@@ -394,10 +398,14 @@ func resolveUpstreamModelFromAliasTable(m *Manager, auth *Auth, requestedModel, 
 			upstreamModel = targetModel
 		}
 
+		originalAlias := requestedModel
+		if entry.forceMapping {
+			originalAlias = oauthModelAliasForceMappingResponseModel(entry.configAlias)
+		}
 		return OAuthModelAliasResult{
 			UpstreamModel: upstreamModel,
 			ForceMapping:  entry.forceMapping,
-			OriginalAlias: oauthModelAliasForceMappingResponseModel(entry.configAlias),
+			OriginalAlias: originalAlias,
 		}
 	}
 

--- a/sdk/cliproxy/auth/oauth_model_alias_test.go
+++ b/sdk/cliproxy/auth/oauth_model_alias_test.go
@@ -335,3 +335,21 @@ func TestApplyOAuthModelAlias_PluginProviderSkipsAPIKey(t *testing.T) {
 		t.Errorf("applyOAuthModelAlias() model = %q, want %q", resolvedModel, "sample-latest")
 	}
 }
+func TestApplyOAuthModelAliasWithResult_ForceMappingUsesConfigAliasNotRequestSuffix(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetOAuthModelAlias(map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{
+			Name: "gpt-5.4", Alias: "gpt-5.4-fast", Fork: true, ForceMapping: true,
+		}},
+	})
+	auth := &Auth{ID: "t", Provider: "codex"}
+	res := mgr.applyOAuthModelAliasWithResult(auth, "gpt-5.4-fast(high)")
+	if res.UpstreamModel != "gpt-5.4(high)" {
+		t.Fatalf("upstream = %q want gpt-5.4(high)", res.UpstreamModel)
+	}
+	if res.OriginalAlias != "gpt-5.4-fast" {
+		t.Fatalf("OriginalAlias = %q want gpt-5.4-fast", res.OriginalAlias)
+	}
+}
+

--- a/sdk/cliproxy/auth/oauth_model_alias_test.go
+++ b/sdk/cliproxy/auth/oauth_model_alias_test.go
@@ -369,4 +369,3 @@ func TestApplyOAuthModelAliasWithResult_NoForceMappingPreservesRequestedModelInO
 		t.Fatalf("OriginalAlias = %q want requested model when force-mapping off", res.OriginalAlias)
 	}
 }
-

--- a/sdk/cliproxy/auth/oauth_model_alias_test.go
+++ b/sdk/cliproxy/auth/oauth_model_alias_test.go
@@ -352,4 +352,21 @@ func TestApplyOAuthModelAliasWithResult_ForceMappingUsesConfigAliasNotRequestSuf
 		t.Fatalf("OriginalAlias = %q want gpt-5.4-fast", res.OriginalAlias)
 	}
 }
+func TestApplyOAuthModelAliasWithResult_NoForceMappingPreservesRequestedModelInOriginalAlias(t *testing.T) {
+	t.Parallel()
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetOAuthModelAlias(map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{
+			Name: "gpt-5.4", Alias: "gpt-5.4-fast", Fork: true, ForceMapping: false,
+		}},
+	})
+	auth := &Auth{ID: "t", Provider: "codex"}
+	res := mgr.applyOAuthModelAliasWithResult(auth, "gpt-5.4-fast(high)")
+	if res.ForceMapping {
+		t.Fatal("expected ForceMapping false")
+	}
+	if res.OriginalAlias != "gpt-5.4-fast(high)" {
+		t.Fatalf("OriginalAlias = %q want requested model when force-mapping off", res.OriginalAlias)
+	}
+}
 

--- a/sdk/cliproxy/auth/response_model_rewriter_test.go
+++ b/sdk/cliproxy/auth/response_model_rewriter_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"strings"
 	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
 func TestStreamRewriter_RewriteChunk_KimiMessagesDataPrefixWithoutSpace(t *testing.T) {
@@ -179,5 +181,26 @@ func TestRewriteSSEPayloadLines_CodexResponsesLiveFrame(t *testing.T) {
 	}
 	if strings.Contains(got, `"model":"gpt-5.4"`) {
 		t.Fatalf("rewritten chunk still contains upstream model: %q", got)
+	}
+}
+
+func TestRewriteForceMappedResponse_NoRewriteWhenForceMappingDisabled(t *testing.T) {
+	upstream := []byte(`{"model":"gpt-5.4","choices":[]}`)
+	got := append([]byte(nil), upstream...)
+	rewriteForceMappedResponse(&cliproxyexecutor.Response{Payload: got}, OAuthModelAliasResult{
+		UpstreamModel: "gpt-5.4",
+		ForceMapping:  false,
+		OriginalAlias: "gpt-5.4-fast",
+	})
+	if string(got) != string(upstream) {
+		t.Fatalf("payload = %s, want unchanged %s", got, upstream)
+	}
+}
+
+func TestRewriteForceMappedStreamChunk_NoRewriteWhenRewriterNil(t *testing.T) {
+	chunk := []byte(`data: {"model":"gpt-5.4"}` + "\n\n")
+	got := rewriteForceMappedStreamChunk(nil, chunk)
+	if string(got) != string(chunk) {
+		t.Fatalf("chunk = %q, want unchanged upstream payload", got)
 	}
 }

--- a/sdk/cliproxy/auth/response_model_rewriter_test.go
+++ b/sdk/cliproxy/auth/response_model_rewriter_test.go
@@ -186,14 +186,14 @@ func TestRewriteSSEPayloadLines_CodexResponsesLiveFrame(t *testing.T) {
 
 func TestRewriteForceMappedResponse_NoRewriteWhenForceMappingDisabled(t *testing.T) {
 	upstream := []byte(`{"model":"gpt-5.4","choices":[]}`)
-	got := append([]byte(nil), upstream...)
-	rewriteForceMappedResponse(&cliproxyexecutor.Response{Payload: got}, OAuthModelAliasResult{
+	resp := &cliproxyexecutor.Response{Payload: append([]byte(nil), upstream...)}
+	rewriteForceMappedResponse(resp, OAuthModelAliasResult{
 		UpstreamModel: "gpt-5.4",
 		ForceMapping:  false,
 		OriginalAlias: "gpt-5.4-fast",
 	})
-	if string(got) != string(upstream) {
-		t.Fatalf("payload = %s, want unchanged %s", got, upstream)
+	if string(resp.Payload) != string(upstream) {
+		t.Fatalf("payload = %s, want unchanged %s", resp.Payload, upstream)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #3981 (merged). When `force-mapping` is enabled, client-visible `model` / `modelVersion` fields should use the **config `alias`** string (e.g. `gpt-5.4-fast`), not mirror the requested model when the client adds thinking suffixes (e.g. `gpt-5.4-fast(high)`).

Upstream routing still preserves thinking suffixes on the resolved upstream model; only the response rewrite target changes.

## Example (your config)

```yaml
alias: gpt-5.4-fast
force-mapping: true
```

| Request `model` | Response `model` |
|------------------|-------------------|
| `gpt-5.4-fast` | `gpt-5.4-fast` |
| `gpt-5.4-fast(high)` | `gpt-5.4-fast` (not `gpt-5.4-fast(high)`) |

Auth `prefix` (e.g. `a/gpt-5.4-fast`) is still stripped for routing; response remains `gpt-5.4-fast` without `a/`.

## Verification

```bash
go test ./sdk/cliproxy/auth/... -count=1
go build -o test-output ./cmd/server && rm test-output
```