### PR TITLE
fix(translator): handle input_image.image_url as object or string

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -172,11 +172,27 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 							contentPart, _ = sjson.SetBytes(contentPart, "text", text)
 							message, _ = sjson.SetRawBytes(message, "content.-1", contentPart)
 						case "input_image":
-							imageURL := contentItem.Get("image_url").String()
+							// image_url may be a plain string ("data:image/png;base64,...")
+							// or an object ({"url": "...", "detail": "..."}).
+							imageURLField := contentItem.Get("image_url")
+							var imageURL string
+							var detailResult gjson.Result
+							if imageURLField.Type == gjson.JSON {
+								// Object form: extract nested url and detail
+								imageURL = imageURLField.Get("url").String()
+								detailResult = imageURLField.Get("detail")
+							} else {
+								// Plain string form
+								imageURL = imageURLField.String()
+							}
+							// Also honour a top-level detail field
+							if !detailResult.Exists() {
+								detailResult = contentItem.Get("detail")
+							}
 							contentPart := []byte(`{"type":"image_url","image_url":{"url":""}}`)
 							contentPart, _ = sjson.SetBytes(contentPart, "image_url.url", imageURL)
-							if detail := contentItem.Get("detail"); detail.Exists() {
-								contentPart, _ = sjson.SetBytes(contentPart, "image_url.detail", detail.String())
+							if detailResult.Exists() {
+								contentPart, _ = sjson.SetBytes(contentPart, "image_url.detail", detailResult.String())
 							}
 							message, _ = sjson.SetRawBytes(message, "content.-1", contentPart)
 						}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -327,3 +327,62 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_PreservesInputImag
 		t.Fatalf("messages.0.content.0.image_url.detail = %q, want high; output=%s", got, out)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_InputImageURLObject(t *testing.T) {
+	// image_url as an object {"url": "data:...", "detail": "low"} — the Codex Desktop format.
+	// Before the fix this produced a raw-JSON string as the URL, causing downstream
+	// "first path segment in URL cannot contain colon" errors.
+	raw := []byte(`{
+		"input": [
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "input_image",
+						"image_url": {
+							"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+							"detail": "low"
+						}
+					}
+				]
+			}
+		]
+	}`)
+	t.Logf("input json:\n%s", prettyJSONForTest(raw))
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("gpt-5.4", raw, false)
+	t.Logf("output json:\n%s", prettyJSONForTest(out))
+
+	wantURL := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+	if got := gjson.GetBytes(out, "messages.0.content.0.image_url.url").String(); got != wantURL {
+		t.Fatalf("messages.0.content.0.image_url.url = %q, want data URI; output=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.image_url.detail").String(); got != "low" {
+		t.Fatalf("messages.0.content.0.image_url.detail = %q, want low; output=%s", got, out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_InputImageDataURIString(t *testing.T) {
+	// image_url as a plain data URI string (no wrapping object).
+	raw := []byte(`{
+		"input": [
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "input_image",
+						"image_url": "data:image/jpeg;base64,/9j/4AAQSkZJRgAB"
+					}
+				]
+			}
+		]
+	}`)
+	t.Logf("input json:\n%s", prettyJSONForTest(raw))
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("gpt-5.4", raw, false)
+	t.Logf("output json:\n%s", prettyJSONForTest(out))
+
+	if got := gjson.GetBytes(out, "messages.0.content.0.image_url.url").String(); got != "data:image/jpeg;base64,/9j/4AAQSkZJRgAB" {
+		t.Fatalf("messages.0.content.0.image_url.url = %q, want data URI; output=%s", got, out)
+	}
+}


### PR DESCRIPTION
## Problem

When using `openai-compatibility` providers (e.g. Ark/Volcengine), Codex Desktop sends `input_image` content blocks where `image_url` is an **object**:

```json
{"type": "input_image", "image_url": {"url": "data:image/png;base64,...", "detail": "low"}}
```

The previous translator code called `contentItem.Get("image_url").String()` on this field. When `image_url` is a JSON object, gjson's `.String()` returns the raw JSON text `{"url":"data:...","detail":"low"}` instead of the URL value. Downstream providers then attempt to parse that raw JSON string as an HTTP URL and fail with:

```
first path segment in URL cannot contain colon
```

This affects all `openai-compatibility` providers when the client sends multimodal requests via the Responses API (e.g. Codex Desktop with vision models like minimax-m3, kimi-k2.7-code, glm-5.2).

Closes #3976

## Fix

Detect whether `image_url` is a JSON object (`gjson.JSON` type) and extract the nested `.url` and `.detail` values. Fall back to the existing plain-string path when `image_url` is already a string.

Also correctly propagates `detail` whether it is nested inside the `image_url` object or specified as a top-level sibling field on the content block — both forms now work.

## Test cases added

- `TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_InputImageURLObject` — object form with `data:` URI and nested `detail`
- `TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_InputImageDataURIString` — plain `data:` URI string (regression guard for existing behaviour)