### PR TITLE
fix(claude-stream): synthesize terminal message_stop on clean upstream EOF

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -545,11 +545,15 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if responseFormat == to {
 			scanner := bufio.NewScanner(decodedBody)
 			scanner.Buffer(nil, 52_428_800) // 50MB
+			sawMessageStop := false
 			for scanner.Scan() {
 				line := scanner.Bytes()
 				helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 				if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 					reporter.Publish(ctx, detail)
+				}
+				if bytes.Contains(line, []byte("message_stop")) {
+					sawMessageStop = true
 				}
 				line = restoreClaudeOAuthToolNamesFromStreamLine(line, claudeToolPrefix, auth.ToolPrefixDisabled(), oauthToolNamesReverseMap)
 				// Forward the line as-is to preserve SSE format
@@ -569,6 +573,19 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
 				case <-ctx.Done():
 				}
+			} else if !sawMessageStop {
+				// The upstream closed the SSE stream cleanly without emitting a
+				// terminal message_stop event. Synthesize one so downstream
+				// clients receive a proper stream terminator instead of
+				// reporting "Connection closed mid-response. The response above
+				// may be incomplete." This mirrors the synthetic terminal-marker
+				// guard in openai_compat_executor.go. The leading blank line
+				// guarantees SSE event separation even if the upstream truncated
+				// mid-event.
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: []byte("\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")}:
+				case <-ctx.Done():
+				}
 			}
 			return
 		}
@@ -577,11 +594,15 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		scanner := bufio.NewScanner(decodedBody)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
+		sawMessageStop := false
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 				reporter.Publish(ctx, detail)
+			}
+			if bytes.Contains(line, []byte("message_stop")) {
+				sawMessageStop = true
 			}
 			line = restoreClaudeOAuthToolNamesFromStreamLine(line, claudeToolPrefix, auth.ToolPrefixDisabled(), oauthToolNamesReverseMap)
 			chunks := sdktranslator.TranslateStream(
@@ -608,6 +629,30 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			select {
 			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
 			case <-ctx.Done():
+			}
+		} else if !sawMessageStop {
+			// The upstream closed the stream cleanly without a terminal
+			// message_stop. Feed a synthetic Claude message_stop event through
+			// the translator so it can finalize the downstream stream (e.g.
+			// emit the terminal chunk / [DONE]) exactly once, instead of the
+			// client seeing a truncated response. Mirrors the synthetic
+			// terminal-marker guard in openai_compat_executor.go.
+			chunks := sdktranslator.TranslateStream(
+				ctx,
+				to,
+				responseFormat,
+				req.Model,
+				opts.OriginalRequest,
+				bodyForTranslation,
+				[]byte("data: {\"type\":\"message_stop\"}"),
+				&param,
+			)
+			for i := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}()

--- a/internal/runtime/executor/claude_executor_streamterminal_test.go
+++ b/internal/runtime/executor/claude_executor_streamterminal_test.go
@@ -1,0 +1,91 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+// Bug #2: a Claude->Claude passthrough stream whose upstream closes cleanly
+// WITHOUT a terminal message_stop event must still deliver a terminal event to
+// the client, instead of silently truncating (which surfaces downstream as
+// "Connection closed mid-response. The response above may be incomplete.").
+func TestClaudeExecutor_ExecuteStreamEmitsMessageStopOnCleanEOFWithoutTerminal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Upstream closes cleanly WITHOUT a terminal message_stop event.
+		_, _ = w.Write([]byte("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude-3-5-sonnet-20241022\"}}\n\n"))
+		_, _ = w.Write([]byte("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var buf []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+		buf = append(buf, chunk.Payload...)
+	}
+	if !strings.Contains(string(buf), `"type":"message_stop"`) {
+		t.Fatalf("expected a synthetic message_stop terminal event on clean EOF, got:\n%s", string(buf))
+	}
+}
+
+// When the upstream already sends message_stop, the executor must NOT add a
+// second one.
+func TestClaudeExecutor_ExecuteStreamDoesNotDuplicateMessageStop(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\"}}\n\n"))
+		_, _ = w.Write([]byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet-20241022",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var buf []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+		buf = append(buf, chunk.Payload...)
+	}
+	if n := strings.Count(string(buf), `"type":"message_stop"`); n != 1 {
+		t.Fatalf("expected exactly one message_stop, got %d:\n%s", n, string(buf))
+	}
+}


### PR DESCRIPTION
## What

Fixes #3996.

`ClaudeExecutor.ExecuteStream` did not emit any terminal event when the Claude
upstream closed an SSE stream **cleanly** (EOF, no error) **without** a
`message_stop`. Downstream clients then report:

```
API Error: Connection closed mid-response. The response above may be incomplete.
```

Every other streaming executor guards against a missing terminal marker on clean
EOF (e.g. `openai_compat_executor.go` feeds a synthetic `data: [DONE]`); the
Claude executor was the only one that did not.

## Change

In both branches of `ClaudeExecutor.ExecuteStream`, track whether a
`message_stop` was seen and, on clean EOF (`scanner.Err() == nil`) when it was
not, synthesize a terminal exactly once:

- **Claude→Claude passthrough:** emit `event: message_stop\ndata: {"type":"message_stop"}\n\n`
  (leading blank line guarantees SSE event separation even if the upstream
  truncated mid-event).
- **Claude→other translation:** feed a synthetic Claude `data: {"type":"message_stop"}`
  line through `sdktranslator.TranslateStream` so the translator finalizes the
  downstream stream once.

The `sawMessageStop` gate ensures an upstream that already sent `message_stop`
is never duplicated.

## Tests

Adds `internal/runtime/executor/claude_executor_streamterminal_test.go`:

- `TestClaudeExecutor_ExecuteStreamEmitsMessageStopOnCleanEOFWithoutTerminal` —
  fails before the change, passes after.
- `TestClaudeExecutor_ExecuteStreamDoesNotDuplicateMessageStop` — guards against
  double emission.

`go build ./cmd/server` and `go test ./internal/runtime/executor/ -run TestClaudeExecutor_ExecuteStream...` pass.

## Notes

- Distinct from #3995 (request *hangs* with no timeout); this PR addresses a
  clean EOF that *ends* the stream without a terminal event.
- Scope is limited to the Claude executor's clean-EOF path; the error path
  (`WriteTerminalError`) and other executors are unchanged.
