### PR TITLE
feat(antigravity): actionable hint for region-blocked Gemini 400 (User location is not supported)

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -608,7 +608,31 @@ func newAntigravityStatusErr(statusCode int, body []byte) statusErr {
 			err.retryAfter = retryAfter
 		}
 	}
+	if hint := antigravityRegionBlockedHint(statusCode, body); hint != "" {
+		log.Warnf("antigravity executor: %s", hint)
+		err.msg = strings.TrimRight(err.msg, "\n") + "\n\n" + hint
+	}
 	return err
+}
+
+// antigravityRegionBlockedHint returns an actionable hint when the Antigravity
+// (Gemini Code Assist) upstream rejects a request with the opaque
+// "User location is not supported for the API use." 400. That error is keyed on
+// the request's egress region, not on the request body, and frequently affects
+// datacenter/hosting IPs even when they geolocate to an otherwise supported
+// country. Routing the affected credential through an egress in a supported
+// region (per-auth proxy-url) resolves it. Returns "" for any other response so
+// unrelated errors pass through unchanged.
+func antigravityRegionBlockedHint(statusCode int, body []byte) string {
+	if statusCode != http.StatusBadRequest {
+		return ""
+	}
+	if !strings.Contains(strings.ToLower(string(body)), "user location is not supported") {
+		return ""
+	}
+	return "Gemini is region-restricted and this request's egress IP appears to be in an unsupported region " +
+		"(common for datacenter/hosting IPs even when geolocated to a supported country). " +
+		"Route this credential through an egress in a supported region, e.g. set a per-auth proxy-url."
 }
 
 // Execute performs a non-streaming request to the Antigravity API.

--- a/internal/runtime/executor/antigravity_executor_locationhint_test.go
+++ b/internal/runtime/executor/antigravity_executor_locationhint_test.go
@@ -1,0 +1,50 @@
+package executor
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The Antigravity (Gemini Code Assist) upstream returns an opaque
+// "User location is not supported for the API use." 400 when the request's
+// egress IP is in an unsupported region (common for datacenter/hosting IPs even
+// when geolocated to a supported country). CLIProxyAPI should surface an
+// actionable hint pointing at the per-auth proxy-url remedy.
+func TestAntigravityRegionBlockedHint(t *testing.T) {
+	body := []byte(`{"error":{"code":400,"message":"User location is not supported for the API use.","status":"FAILED_PRECONDITION"}}`)
+
+	if h := antigravityRegionBlockedHint(http.StatusBadRequest, body); h == "" {
+		t.Fatal("expected a hint for a region-blocked 400")
+	}
+	if h := antigravityRegionBlockedHint(http.StatusTooManyRequests, body); h != "" {
+		t.Fatalf("expected no hint for non-400 status, got %q", h)
+	}
+	if h := antigravityRegionBlockedHint(http.StatusBadRequest, []byte(`{"error":{"message":"quota exceeded"}}`)); h != "" {
+		t.Fatalf("expected no hint for an unrelated 400, got %q", h)
+	}
+}
+
+func TestNewAntigravityStatusErr_AppendsRegionHint(t *testing.T) {
+	body := []byte(`{"error":{"message":"User location is not supported for the API use.","status":"FAILED_PRECONDITION"}}`)
+	err := newAntigravityStatusErr(http.StatusBadRequest, body)
+
+	if !strings.Contains(err.msg, "User location is not supported") {
+		t.Fatalf("original upstream message must be preserved, got: %s", err.msg)
+	}
+	if !strings.Contains(strings.ToLower(err.msg), "proxy-url") {
+		t.Fatalf("expected an actionable proxy-url hint to be appended, got: %s", err.msg)
+	}
+	if err.code != http.StatusBadRequest {
+		t.Fatalf("status code must be preserved, got %d", err.code)
+	}
+}
+
+// A non-region 400 must pass through unchanged (no hint noise).
+func TestNewAntigravityStatusErr_UnrelatedErrorUnchanged(t *testing.T) {
+	body := []byte(`{"error":{"message":"invalid argument"}}`)
+	err := newAntigravityStatusErr(http.StatusBadRequest, body)
+	if err.msg != string(body) {
+		t.Fatalf("unrelated 400 body must pass through verbatim, got: %s", err.msg)
+	}
+}


### PR DESCRIPTION
## What

Addresses #3999 (optional enhancement).

Antigravity **Gemini** requests from an unsupported egress region fail with an
opaque 400:

```
User location is not supported for the API use.  (FAILED_PRECONDITION)
```

This is keyed on the request's **egress IP/region**, not the request body, and
commonly affects datacenter/hosting IPs even when they geolocate to a supported
country. Antigravity Claude/Codex are unaffected. Users currently get no signal
that egress is the lever.

Decisive isolation (same account, fresh token, `daily-cloudcode-pa` directly):

| Variation | Result |
|---|---|
| body with injected `project` | 400 |
| body without `project` | 400 |
| native datacenter egress | 400 |
| supported-region proxy egress | 200 OK |

So this is **not** a request-shape bug (stripping `project` does not help — verified),
and it is already resolvable today via the existing per-auth `proxy-url`.

## Change

Make the failure actionable without changing routing behavior:

- Add `antigravityRegionBlockedHint(statusCode, body)` — returns a hint only for
  a 400 whose body contains `User location is not supported`, else `""`.
- In `newAntigravityStatusErr`, when the hint applies, `log.Warnf` it and append
  it to the returned error message. The **original upstream message is preserved**
  (prefix unchanged); unrelated errors pass through verbatim.

The hint points users at routing the affected credential through a per-auth
`proxy-url` in a supported region.

## Tests

`internal/runtime/executor/antigravity_executor_locationhint_test.go`:

- `TestAntigravityRegionBlockedHint` — only the region 400 yields a hint (non-400
  and unrelated 400 yield none).
- `TestNewAntigravityStatusErr_AppendsRegionHint` — hint appended, original
  message + status preserved.
- `TestNewAntigravityStatusErr_UnrelatedErrorUnchanged` — unrelated 400 body
  passes through verbatim.

`go build ./cmd/server` and the targeted tests pass.

## Notes / scope

- No routing, request-shape, or retry behavior changes — this only annotates an
  already-terminal error.
- A docs note under Antigravity setup (Gemini region-gating + `proxy-url`) would
  complement this; happy to add if preferred.
