### PR TITLE
docs: add Universal Chat Provider to "Who is with us?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ Windows desktop UI that manages CLIProxyAPI and Perplexity WebUI Scraper from a 
 
 Cross-platform (Tauri) port of Quotio for Windows, macOS and Linux. Manages a pool of AI accounts (Codex, Claude Code, GitHub Copilot, Gemini, Antigravity, Kiro, Cursor, Trae, GLM) through CLIProxyAPI, with per-account 5-hour/weekly quota bars, Codex rate-limit reset credits with one-click reset, smart scheduling, usage statistics, and multi-instance Codex — no API keys needed.
 
+### [Universal Chat Provider](https://github.com/maxdewald/vscode-universal-chat-provider)
+
+VS Code extension that brings your Claude, ChatGPT/Codex, Antigravity, Grok, and Kimi subscriptions into GitHub Copilot Chat as native language models — and can power your Git commit messages, chat titles, and summaries too. Runs CLIProxyAPI in a fully managed background lifecycle (download, verify, supervise) shared across all windows, so it's zero-setup. No API keys needed, just OAuth.
+
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.
 


### PR DESCRIPTION
Adds [Universal Chat Provider](https://github.com/maxdewald/vscode-universal-chat-provider) to the **Who is with us?** list.

It's a VS Code extension built on CLIProxyAPI that brings Claude, ChatGPT/Codex, Antigravity, Grok, and Kimi subscriptions into GitHub Copilot Chat as native language models (no API keys, just OAuth). In managed mode it downloads, verifies, and supervises CLIProxyAPI for you, sharing one server across all VS Code windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)