### PR TITLE
fix(upstream): force HTTP/1.1 on fallback transport to eliminate mid-stream RST_STREAM(INTERNAL_ERROR) leak

### DIFF
--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -2,6 +2,7 @@ package helps
 
 import (
 	"context"
+	cryptotls "crypto/tls"
 	"net"
 	"net/http"
 	"strings"
@@ -152,6 +153,31 @@ func (f *fallbackRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 	return f.fallback.RoundTrip(req)
 }
 
+// forceHTTP11Transport returns a clone of base that negotiates HTTP/1.1 only.
+// Round-trippers that are not *http.Transport (e.g. an injected context
+// RoundTripper or a uTLS round-tripper) are returned unchanged. Proxy and dial
+// settings on base are preserved; only ALPN/protocol negotiation is pinned.
+// The base is cloned, never mutated, so the shared http.DefaultTransport global
+// is left intact.
+func forceHTTP11Transport(base http.RoundTripper) http.RoundTripper {
+	tr, ok := base.(*http.Transport)
+	if !ok || tr == nil {
+		return base
+	}
+	clone := tr.Clone()
+	clone.ForceAttemptHTTP2 = false
+	// Wipe TLSNextProto to prevent an implicit HTTP/2 upgrade.
+	clone.TLSNextProto = make(map[string]func(authority string, c *cryptotls.Conn) http.RoundTripper)
+	if clone.TLSClientConfig == nil {
+		clone.TLSClientConfig = &cryptotls.Config{}
+	} else {
+		clone.TLSClientConfig = clone.TLSClientConfig.Clone()
+	}
+	// Actively advertise only HTTP/1.1 in the ALPN handshake.
+	clone.TLSClientConfig.NextProtos = []string{"http/1.1"}
+	return clone
+}
+
 // NewUtlsHTTPClient creates an HTTP client using utls Chrome TLS fingerprint.
 // Use this for provider requests that need a Chrome-like TLS fingerprint.
 // Falls back to standard transport for non-HTTPS requests.
@@ -179,6 +205,16 @@ func NewUtlsHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyau
 		utlsRT = ctxRoundTripper
 		standardTransport = ctxRoundTripper
 	}
+
+	// Force HTTP/1.1 on the fallback path (every non-fingerprinted host, e.g.
+	// reseller/aggregator upstreams). HTTP/2 lets a flaky upstream reset a
+	// stream mid-response with RST_STREAM(INTERNAL_ERROR), which leaks to the
+	// client as a raw "stream error ...; received from peer". Over HTTP/1.1 a
+	// mid-response drop is instead a clean EOF that ClaudeExecutor.ExecuteStream
+	// already terminates gracefully with a synthetic message_stop. The uTLS
+	// (Anthropic/ChatGPT) path is intentionally left on HTTP/2 to preserve its
+	// Chrome fingerprint.
+	standardTransport = forceHTTP11Transport(standardTransport)
 
 	client := &http.Client{
 		Transport: &fallbackRoundTripper{

--- a/internal/runtime/executor/helps/utls_client_test.go
+++ b/internal/runtime/executor/helps/utls_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -41,5 +42,95 @@ func TestNewUtlsHTTPClientUsesContextRoundTripperForProtectedHost(t *testing.T) 
 	}
 	if !called {
 		t.Fatal("expected context RoundTripper to handle protected host request")
+	}
+}
+
+// TestNewUtlsHTTPClientFallbackForcesHTTP11 verifies that requests to
+// non-fingerprinted hosts (everything except the uTLS-protected Anthropic /
+// ChatGPT domains) go through a fallback transport that negotiates HTTP/1.1
+// only. Forcing HTTP/1.1 eliminates the HTTP/2 RST_STREAM(INTERNAL_ERROR)
+// error class that flaky reseller upstreams emit mid-stream; a mid-response
+// drop then surfaces as a clean EOF that the executor already terminates
+// gracefully with a synthetic message_stop.
+func TestNewUtlsHTTPClientFallbackForcesHTTP11(t *testing.T) {
+	t.Parallel()
+
+	client := NewUtlsHTTPClient(context.Background(), nil, nil, 0)
+
+	fb, ok := client.Transport.(*fallbackRoundTripper)
+	if !ok {
+		t.Fatalf("client.Transport type = %T, want *fallbackRoundTripper", client.Transport)
+	}
+
+	tr, ok := fb.fallback.(*http.Transport)
+	if !ok {
+		t.Fatalf("fallback transport type = %T, want *http.Transport", fb.fallback)
+	}
+
+	if tr.ForceAttemptHTTP2 {
+		t.Error("fallback ForceAttemptHTTP2 = true, want false (HTTP/1.1 only)")
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatal("fallback TLSClientConfig = nil, want NextProtos pinned to http/1.1")
+	}
+	if got := tr.TLSClientConfig.NextProtos; len(got) != 1 || got[0] != "http/1.1" {
+		t.Errorf("fallback TLSClientConfig.NextProtos = %v, want [http/1.1]", got)
+	}
+	if len(tr.TLSNextProto) != 0 {
+		t.Errorf("fallback TLSNextProto has %d entries, want 0 (no implicit h2 upgrade)", len(tr.TLSNextProto))
+	}
+
+	// The shared global must not be mutated into HTTP/1.1; the client must own
+	// an isolated clone.
+	if def, ok := http.DefaultTransport.(*http.Transport); ok && !def.ForceAttemptHTTP2 {
+		t.Error("http.DefaultTransport.ForceAttemptHTTP2 was flipped to false; expected an isolated clone, not mutation of the global")
+	}
+}
+
+// TestForceHTTP11TransportNegotiatesHTTP11AgainstH2Server proves the real
+// behavior: against a server that advertises HTTP/2 over ALPN, the forced
+// transport still negotiates HTTP/1.1. The control assertion confirms the test
+// server genuinely offers h2, so the HTTP/1.1 result is meaningful and not an
+// artifact of the server only speaking HTTP/1.1.
+func TestForceHTTP11TransportNegotiatesHTTP11AgainstH2Server(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+
+	// srv.Client()'s transport trusts the test server's self-signed cert.
+	base, ok := srv.Client().Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("test server client transport type = %T, want *http.Transport", srv.Client().Transport)
+	}
+
+	// Control: the unmodified client negotiates HTTP/2 with this server.
+	controlResp, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("control request returned error: %v", err)
+	}
+	controlProto := controlResp.ProtoMajor
+	_ = controlResp.Body.Close()
+	if controlProto != 2 {
+		t.Fatalf("control negotiated HTTP/%d, want HTTP/2 (test server must offer h2 for this test to be meaningful)", controlProto)
+	}
+
+	// Forced: the same transport, pinned to HTTP/1.1, must negotiate HTTP/1.1.
+	forced, ok := forceHTTP11Transport(base.Clone()).(*http.Transport)
+	if !ok {
+		t.Fatalf("forceHTTP11Transport returned %T, want *http.Transport", forceHTTP11Transport(base.Clone()))
+	}
+	client := &http.Client{Transport: forced}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("forced request returned error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.ProtoMajor != 1 {
+		t.Fatalf("forced transport negotiated HTTP/%d, want HTTP/1.1", resp.ProtoMajor)
 	}
 }


### PR DESCRIPTION
Fixes #4011

### Problem

For upstreams that are **not** uTLS-fingerprinted (`api.anthropic.com` / `chatgpt.com`) — resellers, aggregators, self-hosted relays, any OpenAI/Anthropic-compatible HTTPS endpoint — a stream reset from the upstream surfaces to the client as a raw Go error:

```
stream error: stream ID 1; INTERNAL_ERROR; received from peer
```

This is `golang.org/x/net/http2`'s `errFromPeer`: CLIProxyAPI's HTTP/2 client received a `RST_STREAM(INTERNAL_ERROR)`. The uTLS HTTP/2 round-tripper is gated to a hardcoded allow-list, so every other host falls through to `http.DefaultTransport` (`ForceAttemptHTTP2 = true`) and negotiates HTTP/2 when the upstream's ALPN offers `h2`. A **mid-response** reset can't be retried (pre-first-byte resets already are, via `empty_stream`), so the raw framing error leaks out.

### Fix

Pin the **fallback** transport in `NewUtlsHTTPClient` to HTTP/1.1, mirroring the antigravity executor's `cloneTransportWithHTTP11`:

- `ForceAttemptHTTP2 = false`
- `TLSNextProto` wiped (no implicit h2 upgrade)
- `TLSClientConfig.NextProtos = ["http/1.1"]`

Over HTTP/1.1 the `RST_STREAM(INTERNAL_ERROR)` class cannot occur. A mid-response upstream drop becomes a plain connection close (clean EOF), so the failure mode degrades from a hard error into a normal end-of-stream — and composes with terminal-marker synthesis (#3997) for a graceful `message_stop`/`[DONE]`.

### Scope / safety

- Only the **fallback** path changes. The uTLS HTTP/2 path for Anthropic/ChatGPT is untouched, preserving its Chrome fingerprint.
- The base transport is **cloned, never mutated**, so the shared `http.DefaultTransport` global is left intact.
- Non-`*http.Transport` round-trippers (an injected context RoundTripper, proxy transports) pass through unchanged.
- Proxy/dial settings on the base transport are preserved; only ALPN/protocol negotiation is constrained.

### Tests

`internal/runtime/executor/helps/utls_client_test.go` (3 cases, all green):

1. `TestNewUtlsHTTPClientFallbackForcesHTTP11` — the fallback transport has `ForceAttemptHTTP2=false`, `NextProtos=["http/1.1"]`, empty `TLSNextProto`, and the global `http.DefaultTransport` is not mutated.
2. `TestForceHTTP11TransportNegotiatesHTTP11AgainstH2Server` — **real-behavior**: against an `httptest` server with HTTP/2 enabled, a control request negotiates HTTP/2 (proving the server offers h2) while the forced transport negotiates HTTP/1.1.
3. Existing `TestNewUtlsHTTPClientUsesContextRoundTripperForProtectedHost` still passes (protected-host path unchanged).

```
go test ./internal/runtime/executor/helps/   # ok
go build ./...                                 # ok
```

### Verified in production

Built and deployed against a reseller upstream that negotiates ALPN `h2`. Packet capture of a live streaming request now shows the TLS ClientHello to the upstream offering **only `http/1.1`** (no `h2`); the `INTERNAL_ERROR; received from peer` errors are gone.
