### PR TITLE
fix: avoid management IP ban on missing key

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -320,17 +320,20 @@ func (h *Handler) AuthenticateManagementKey(clientIP string, localClient bool, p
 	envSecret := h.envSecret
 
 	now := time.Now()
+	banned := false
+	banMessage := ""
 	h.attemptsMu.Lock()
 	ai := h.failedAttempts[clientIP]
 	if ai != nil && !ai.blockedUntil.IsZero() {
 		if now.Before(ai.blockedUntil) {
 			remaining := ai.blockedUntil.Sub(now).Round(time.Second)
-			h.attemptsMu.Unlock()
-			return false, http.StatusForbidden, fmt.Sprintf("IP banned due to too many failed attempts. Try again in %s", remaining)
+			banned = true
+			banMessage = fmt.Sprintf("IP banned due to too many failed attempts. Try again in %s", remaining)
+		} else {
+			// Ban expired, reset state
+			ai.blockedUntil = time.Time{}
+			ai.count = 0
 		}
-		// Ban expired, reset state
-		ai.blockedUntil = time.Time{}
-		ai.count = 0
 	}
 	h.attemptsMu.Unlock()
 
@@ -368,32 +371,34 @@ func (h *Handler) AuthenticateManagementKey(clientIP string, localClient bool, p
 	}
 
 	if provided == "" {
-		fail()
 		return false, http.StatusUnauthorized, "missing management key"
 	}
 
-	if localClient {
-		if lp := h.localPassword; lp != "" {
-			if subtle.ConstantTimeCompare([]byte(provided), []byte(lp)) == 1 {
-				reset()
-				return true, 0, ""
+	isValid := func() bool {
+		if localClient {
+			if lp := h.localPassword; lp != "" {
+				if subtle.ConstantTimeCompare([]byte(provided), []byte(lp)) == 1 {
+					return true
+				}
 			}
 		}
+		if envSecret != "" && subtle.ConstantTimeCompare([]byte(provided), []byte(envSecret)) == 1 {
+			return true
+		}
+		return secretHash != "" && bcrypt.CompareHashAndPassword([]byte(secretHash), []byte(provided)) == nil
 	}
 
-	if envSecret != "" && subtle.ConstantTimeCompare([]byte(provided), []byte(envSecret)) == 1 {
+	if isValid() {
 		reset()
 		return true, 0, ""
 	}
 
-	if secretHash == "" || bcrypt.CompareHashAndPassword([]byte(secretHash), []byte(provided)) != nil {
-		fail()
-		return false, http.StatusUnauthorized, "invalid management key"
+	if banned {
+		return false, http.StatusForbidden, banMessage
 	}
 
-	reset()
-
-	return true, 0, ""
+	fail()
+	return false, http.StatusUnauthorized, "invalid management key"
 }
 
 // persist saves the current in-memory config to disk.

--- a/internal/api/handlers/management/handler_test.go
+++ b/internal/api/handlers/management/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestAuthenticateManagementKey_MissingKeyDoesNotTriggerIPBan(t *testing.T) {
@@ -88,6 +89,31 @@ func TestAuthenticateManagementKey_CorrectKeyClearsActiveIPBan(t *testing.T) {
 	}
 	if statusCode != http.StatusUnauthorized || errMsg != "invalid management key" {
 		t.Fatalf("expected ban counter to reset after correct key, status=%d msg=%q", statusCode, errMsg)
+	}
+}
+
+func TestAuthenticateManagementKey_ConfigSecretClearsActiveIPBan(t *testing.T) {
+	secretHash, err := bcrypt.GenerateFromPassword([]byte("test-secret"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("GenerateFromPassword() error = %v", err)
+	}
+	h := &Handler{
+		cfg: &config.Config{
+			RemoteManagement: config.RemoteManagement{SecretKey: string(secretHash)},
+		},
+		failedAttempts: make(map[string]*attemptInfo),
+	}
+
+	for i := 0; i < 5; i++ {
+		allowed, _, _ := h.AuthenticateManagementKey("127.0.0.1", true, "wrong-secret")
+		if allowed {
+			t.Fatalf("expected auth to be denied at invalid-key attempt %d", i+1)
+		}
+	}
+
+	allowed, statusCode, errMsg := h.AuthenticateManagementKey("127.0.0.1", true, "test-secret")
+	if !allowed {
+		t.Fatalf("expected bcrypt config secret to clear active ban, status=%d msg=%q", statusCode, errMsg)
 	}
 }
 

--- a/internal/api/handlers/management/handler_test.go
+++ b/internal/api/handlers/management/handler_test.go
@@ -11,7 +11,30 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
 )
 
-func TestAuthenticateManagementKey_LocalhostIPBan_BlocksCorrectKeyDuringBan(t *testing.T) {
+func TestAuthenticateManagementKey_MissingKeyDoesNotTriggerIPBan(t *testing.T) {
+	h := &Handler{
+		cfg:            &config.Config{},
+		failedAttempts: make(map[string]*attemptInfo),
+		envSecret:      "test-secret",
+	}
+
+	for i := 0; i < 5; i++ {
+		allowed, statusCode, errMsg := h.AuthenticateManagementKey("127.0.0.1", true, "")
+		if allowed {
+			t.Fatalf("expected auth to be denied at missing-key attempt %d", i+1)
+		}
+		if statusCode != http.StatusUnauthorized || errMsg != "missing management key" {
+			t.Fatalf("unexpected missing-key failure at attempt %d: status=%d msg=%q", i+1, statusCode, errMsg)
+		}
+	}
+
+	allowed, statusCode, errMsg := h.AuthenticateManagementKey("127.0.0.1", true, "test-secret")
+	if !allowed {
+		t.Fatalf("expected correct key to be allowed after missing-key requests, status=%d msg=%q", statusCode, errMsg)
+	}
+}
+
+func TestAuthenticateManagementKey_InvalidKeyStillTriggersIPBan(t *testing.T) {
 	h := &Handler{
 		cfg:            &config.Config{},
 		failedAttempts: make(map[string]*attemptInfo),
@@ -21,22 +44,50 @@ func TestAuthenticateManagementKey_LocalhostIPBan_BlocksCorrectKeyDuringBan(t *t
 	for i := 0; i < 5; i++ {
 		allowed, statusCode, errMsg := h.AuthenticateManagementKey("127.0.0.1", true, "wrong-secret")
 		if allowed {
-			t.Fatalf("expected auth to be denied at attempt %d", i+1)
+			t.Fatalf("expected auth to be denied at invalid-key attempt %d", i+1)
 		}
 		if statusCode != http.StatusUnauthorized || errMsg != "invalid management key" {
-			t.Fatalf("unexpected auth failure at attempt %d: status=%d msg=%q", i+1, statusCode, errMsg)
+			t.Fatalf("unexpected invalid-key failure at attempt %d: status=%d msg=%q", i+1, statusCode, errMsg)
 		}
 	}
 
-	allowed, statusCode, errMsg := h.AuthenticateManagementKey("127.0.0.1", true, "test-secret")
+	allowed, statusCode, errMsg := h.AuthenticateManagementKey("127.0.0.1", true, "wrong-secret")
 	if allowed {
-		t.Fatalf("expected correct key to be denied while banned")
+		t.Fatalf("expected invalid key to be denied while banned")
 	}
 	if statusCode != http.StatusForbidden {
 		t.Fatalf("expected forbidden status while banned, got %d", statusCode)
 	}
 	if !strings.HasPrefix(errMsg, "IP banned due to too many failed attempts. Try again in") {
 		t.Fatalf("unexpected banned message: %q", errMsg)
+	}
+}
+
+func TestAuthenticateManagementKey_CorrectKeyClearsActiveIPBan(t *testing.T) {
+	h := &Handler{
+		cfg:            &config.Config{},
+		failedAttempts: make(map[string]*attemptInfo),
+		envSecret:      "test-secret",
+	}
+
+	for i := 0; i < 5; i++ {
+		allowed, _, _ := h.AuthenticateManagementKey("127.0.0.1", true, "wrong-secret")
+		if allowed {
+			t.Fatalf("expected auth to be denied at invalid-key attempt %d", i+1)
+		}
+	}
+
+	allowed, statusCode, errMsg := h.AuthenticateManagementKey("127.0.0.1", true, "test-secret")
+	if !allowed {
+		t.Fatalf("expected correct key to clear active ban, status=%d msg=%q", statusCode, errMsg)
+	}
+
+	allowed, statusCode, errMsg = h.AuthenticateManagementKey("127.0.0.1", true, "wrong-secret")
+	if allowed {
+		t.Fatalf("expected wrong key to fail after ban was cleared")
+	}
+	if statusCode != http.StatusUnauthorized || errMsg != "invalid management key" {
+		t.Fatalf("expected ban counter to reset after correct key, status=%d msg=%q", statusCode, errMsg)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #4013.

This changes management authentication so requests with no management key return `401 missing management key` without incrementing the IP ban counter. Invalid non-empty keys still count toward the ban, preserving brute-force protection.

It also allows a correct management key to clear an active ban for that client IP, so a legitimate administrator is not locked out for the full ban window after accidental missing-key probes.

## Why

Behind reverse proxies, unauthenticated probes or UI/API calls can collapse to the same apparent client IP. Counting missing credentials as ban-worthy can lock out management access even when no wrong key was attempted.

## Tests

```bash
go test ./internal/api/handlers/management -run 'TestAuthenticateManagementKey_|TestMiddlewareSetsSupportPluginHeader' -count=1
```

Covered paths include missing-key no-ban behavior, invalid-key ban behavior, valid-key ban recovery via `envSecret`, and valid-key ban recovery via bcrypt-backed `remote-management.secret-key`.

## Deployment Verification

Verified the patch in a reverse-proxy/relay deployment:

- Five requests with no management key returned `401`; a subsequent request with the valid key returned `200`.
- Five requests with wrong management keys returned `401`; the next wrong-key request returned `403`; a subsequent request with the valid key returned `200` and cleared the active ban.
- Confirmed the management page/API can remain available through the relay/reverse-proxy path.

No private hostnames, credentials, or deployment-specific secrets are required to reproduce the behavior.

## Notes

A broader local run including `./internal/api/handlers/management ./internal/api` still hits pre-existing plugin-store test failures unrelated to this change: versioned `.dylib` files are written while some tests expect unversioned names.