### PR TITLE
fix(codex/ws): route compaction requests over HTTP to avoid WS close 1009

### DIFF
--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -401,6 +401,21 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
 	}
+	if codexRequestIsCompaction(ctx) {
+		log.Debugf("codex websockets: routing compaction request over HTTP to avoid WS message size limit (auth ID: %s, model: %s)", auth.ID, req.Model)
+		// The WebSocket request body carries a top-level "type":"response.create"
+		// field (WS v2 semantics). The HTTP /responses endpoint rejects it with
+		// `Unsupported parameter: type`, so strip it before delegating to HTTP.
+		if stripped, errDelete := sjson.DeleteBytes(req.Payload, "type"); errDelete == nil {
+			req.Payload = stripped
+		}
+		if len(opts.OriginalRequest) > 0 {
+			if stripped, errDelete := sjson.DeleteBytes(opts.OriginalRequest, "type"); errDelete == nil {
+				opts.OriginalRequest = stripped
+			}
+		}
+		return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)
+	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	apiKey, baseURL := codexCreds(auth)
@@ -696,6 +711,26 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}()
 
 	return &cliproxyexecutor.StreamResult{Headers: upstreamHeaders, Chunks: out}, nil
+}
+
+// codexRequestIsCompaction reports whether the incoming request is a codex
+// compaction turn. Such turns carry the full transcript and must not be sent as a
+// single WebSocket message, which upstream rejects with close 1009 (message too
+// big); they are routed over HTTP instead. Detection uses the X-Codex-Turn-Metadata
+// request header (request_kind == "compaction").
+func codexRequestIsCompaction(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	ginCtx, ok := ctx.Value("gin").(*gin.Context)
+	if !ok || ginCtx == nil || ginCtx.Request == nil {
+		return false
+	}
+	raw := strings.TrimSpace(ginCtx.Request.Header.Get("X-Codex-Turn-Metadata"))
+	if raw == "" {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(gjson.Get(raw, "request_kind").String()), "compaction")
 }
 
 func (e *CodexWebsocketsExecutor) dialCodexWebsocket(ctx context.Context, auth *cliproxyauth.Auth, wsURL string, headers http.Header) (*websocket.Conn, *http.Response, error) {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -177,6 +177,11 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	if opts.Alt == "responses/compact" {
 		return e.CodexExecutor.executeCompact(ctx, auth, req, opts)
 	}
+	if codexRequestIsCompaction(req.Payload) {
+		log.Debugf("codex websockets: routing compaction request over HTTP to avoid WS message size limit (auth ID: %s, model: %s)", auth.ID, req.Model)
+		stripCodexWebsocketEnvelopeType(&req, &opts)
+		return e.CodexExecutor.Execute(ctx, auth, req, opts)
+	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	apiKey, baseURL := codexCreds(auth)
@@ -401,19 +406,9 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
 	}
-	if codexRequestIsCompaction(ctx) {
+	if codexRequestIsCompaction(req.Payload) {
 		log.Debugf("codex websockets: routing compaction request over HTTP to avoid WS message size limit (auth ID: %s, model: %s)", auth.ID, req.Model)
-		// The WebSocket request body carries a top-level "type":"response.create"
-		// field (WS v2 semantics). The HTTP /responses endpoint rejects it with
-		// `Unsupported parameter: type`, so strip it before delegating to HTTP.
-		if stripped, errDelete := sjson.DeleteBytes(req.Payload, "type"); errDelete == nil {
-			req.Payload = stripped
-		}
-		if len(opts.OriginalRequest) > 0 {
-			if stripped, errDelete := sjson.DeleteBytes(opts.OriginalRequest, "type"); errDelete == nil {
-				opts.OriginalRequest = stripped
-			}
-		}
+		stripCodexWebsocketEnvelopeType(&req, &opts)
 		return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)
 	}
 
@@ -713,24 +708,38 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	return &cliproxyexecutor.StreamResult{Headers: upstreamHeaders, Chunks: out}, nil
 }
 
-// codexRequestIsCompaction reports whether the incoming request is a codex
-// compaction turn. Such turns carry the full transcript and must not be sent as a
-// single WebSocket message, which upstream rejects with close 1009 (message too
-// big); they are routed over HTTP instead. Detection uses the X-Codex-Turn-Metadata
-// request header (request_kind == "compaction").
-func codexRequestIsCompaction(ctx context.Context) bool {
-	if ctx == nil {
-		return false
-	}
-	ginCtx, ok := ctx.Value("gin").(*gin.Context)
-	if !ok || ginCtx == nil || ginCtx.Request == nil {
-		return false
-	}
-	raw := strings.TrimSpace(ginCtx.Request.Header.Get("X-Codex-Turn-Metadata"))
+// codexRequestIsCompaction reports whether the request is a codex compaction turn.
+// Such turns carry the full transcript and must not be sent as a single WebSocket
+// message, which upstream rejects with close 1009 (message too big); they are routed
+// over HTTP instead.
+//
+// Detection reads the per-message X-Codex-Turn-Metadata embedded in the request body
+// (client_metadata.x-codex-turn-metadata, request_kind == "compaction"). The body is
+// used rather than the connection-level upgrade header because a single downstream
+// websocket connection can carry many turns sharing one upgrade request, so a
+// connection-scoped header would misclassify every later turn on a connection whose
+// handshake happened to be a compaction.
+func codexRequestIsCompaction(payload []byte) bool {
+	raw := strings.TrimSpace(gjson.GetBytes(payload, "client_metadata.x-codex-turn-metadata").String())
 	if raw == "" {
 		return false
 	}
 	return strings.EqualFold(strings.TrimSpace(gjson.Get(raw, "request_kind").String()), "compaction")
+}
+
+// stripCodexWebsocketEnvelopeType removes the websocket-only top-level
+// "type":"response.create" field before a request is forwarded over the HTTP
+// transport, which the /responses endpoint otherwise rejects with
+// `Unsupported parameter: type`.
+func stripCodexWebsocketEnvelopeType(req *cliproxyexecutor.Request, opts *cliproxyexecutor.Options) {
+	if stripped, err := sjson.DeleteBytes(req.Payload, "type"); err == nil {
+		req.Payload = stripped
+	}
+	if len(opts.OriginalRequest) > 0 {
+		if stripped, err := sjson.DeleteBytes(opts.OriginalRequest, "type"); err == nil {
+			opts.OriginalRequest = stripped
+		}
+	}
 }
 
 func (e *CodexWebsocketsExecutor) dialCodexWebsocket(ctx context.Context, auth *cliproxyauth.Auth, wsURL string, headers http.Header) (*websocket.Conn, *http.Response, error) {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -20,6 +20,41 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func TestCodexRequestIsCompaction(t *testing.T) {
+	const manualMeta = `{"installation_id":"xx","turn_id":"t1","request_kind":"compaction","compaction":{"trigger":"manual","reason":"user_requested"}}`
+	const autoMeta = `{"installation_id":"xx","turn_id":"t2","request_kind":"compaction","compaction":{"trigger":"auto","reason":"context_limit"}}`
+	const normalMeta = `{"installation_id":"xx","turn_id":"t3","request_kind":"turn"}`
+
+	ctxWithHeader := func(value string, set bool) context.Context {
+		req := httptest.NewRequest(http.MethodGet, "/responses", nil)
+		if set {
+			req.Header.Set("X-Codex-Turn-Metadata", value)
+		}
+		return context.WithValue(context.Background(), "gin", &gin.Context{Request: req})
+	}
+
+	cases := []struct {
+		name string
+		ctx  context.Context
+		want bool
+	}{
+		{name: "manual compaction", ctx: ctxWithHeader(manualMeta, true), want: true},
+		{name: "auto compaction", ctx: ctxWithHeader(autoMeta, true), want: true},
+		{name: "normal turn", ctx: ctxWithHeader(normalMeta, true), want: false},
+		{name: "missing header", ctx: ctxWithHeader("", false), want: false},
+		{name: "empty header", ctx: ctxWithHeader("", true), want: false},
+		{name: "no gin context", ctx: context.Background(), want: false},
+		{name: "nil context", ctx: nil, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := codexRequestIsCompaction(tc.ctx); got != tc.want {
+				t.Fatalf("codexRequestIsCompaction = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildCodexWebsocketRequestBodyPreservesPreviousResponseID(t *testing.T) {
 	body := []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-1"}]}`)
 

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -18,6 +18,7 @@ import (
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func TestCodexRequestIsCompaction(t *testing.T) {
@@ -25,30 +26,32 @@ func TestCodexRequestIsCompaction(t *testing.T) {
 	const autoMeta = `{"installation_id":"xx","turn_id":"t2","request_kind":"compaction","compaction":{"trigger":"auto","reason":"context_limit"}}`
 	const normalMeta = `{"installation_id":"xx","turn_id":"t3","request_kind":"turn"}`
 
-	ctxWithHeader := func(value string, set bool) context.Context {
-		req := httptest.NewRequest(http.MethodGet, "/responses", nil)
-		if set {
-			req.Header.Set("X-Codex-Turn-Metadata", value)
+	// payload embeds the per-turn metadata as a JSON string at
+	// client_metadata.x-codex-turn-metadata, matching the real codex websocket body.
+	payloadWithMeta := func(meta string, set bool) []byte {
+		base := []byte(`{"model":"gpt-5.5","input":[]}`)
+		if !set {
+			return base
 		}
-		return context.WithValue(context.Background(), "gin", &gin.Context{Request: req})
+		out, _ := sjson.SetBytes(base, "client_metadata.x-codex-turn-metadata", meta)
+		return out
 	}
 
 	cases := []struct {
-		name string
-		ctx  context.Context
-		want bool
+		name    string
+		payload []byte
+		want    bool
 	}{
-		{name: "manual compaction", ctx: ctxWithHeader(manualMeta, true), want: true},
-		{name: "auto compaction", ctx: ctxWithHeader(autoMeta, true), want: true},
-		{name: "normal turn", ctx: ctxWithHeader(normalMeta, true), want: false},
-		{name: "missing header", ctx: ctxWithHeader("", false), want: false},
-		{name: "empty header", ctx: ctxWithHeader("", true), want: false},
-		{name: "no gin context", ctx: context.Background(), want: false},
-		{name: "nil context", ctx: nil, want: false},
+		{name: "manual compaction", payload: payloadWithMeta(manualMeta, true), want: true},
+		{name: "auto compaction", payload: payloadWithMeta(autoMeta, true), want: true},
+		{name: "normal turn", payload: payloadWithMeta(normalMeta, true), want: false},
+		{name: "missing client_metadata", payload: payloadWithMeta("", false), want: false},
+		{name: "empty metadata", payload: payloadWithMeta("", true), want: false},
+		{name: "empty payload", payload: nil, want: false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := codexRequestIsCompaction(tc.ctx); got != tc.want {
+			if got := codexRequestIsCompaction(tc.payload); got != tc.want {
 				t.Fatalf("codexRequestIsCompaction = %v, want %v", got, tc.want)
 			}
 		})


### PR DESCRIPTION
## Summary

Codex compaction turns over the WebSocket transport replay the **entire conversation transcript** as a single `response.create` WebSocket message. Compaction fires exactly when the context is at its largest, so this frame is the worst-case payload and exceeds chatgpt.com's per-message size limit — upstream closes the socket with `websocket: close 1009 (message too big)` and the downstream client receives a `500`. Fixes #4017.

This routes compaction requests over the HTTP `/responses` transport (which has no per-message frame-size limit) instead of the WebSocket:

- Detect a compaction turn via the `X-Codex-Turn-Metadata` request header (`request_kind == "compaction"`, true for both manual and auto triggers) in `CodexWebsocketsExecutor.ExecuteStream`, and delegate to the embedded HTTP streaming executor `CodexExecutor.ExecuteStream`. Both paths use the same codex request translator and response format, so the emitted chunks are identical and the websocket handler is agnostic to the underlying transport.
- Strip the top-level WebSocket `type:"response.create"` field before delegating, since the HTTP `/responses` endpoint otherwise rejects it with `Unsupported parameter: type`.

## Testing

- `go test ./internal/runtime/executor/ -run TestCodexRequestIsCompaction` — new unit test covering manual/auto compaction detection plus negative cases (normal turn, missing/empty header, no gin context, nil ctx).
- `go build ./cmd/server`
