### PR TITLE
fix(util): preserve user-supplied custom header casing

### DIFF
--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -258,7 +258,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		if respHS != nil {
 			helps.RecordAPIWebsocketUpgradeRejection(ctx, e.cfg, websocketUpgradeRequestLog(wsReqLog), respHS.StatusCode, respHS.Header.Clone(), bodyErr)
 		}
-		if respHS != nil && respHS.StatusCode == http.StatusUpgradeRequired {
+		if canFallbackToCodexHTTPAfterWebsocketDialFailure(body) {
 			return e.CodexExecutor.Execute(ctx, auth, req, opts)
 		}
 		if respHS != nil && respHS.StatusCode > 0 {
@@ -461,7 +461,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		if respHS != nil {
 			helps.RecordAPIWebsocketUpgradeRejection(ctx, e.cfg, websocketUpgradeRequestLog(wsReqLog), respHS.StatusCode, respHS.Header.Clone(), bodyErr)
 		}
-		if respHS != nil && respHS.StatusCode == http.StatusUpgradeRequired {
+		if canFallbackToCodexHTTPAfterWebsocketDialFailure(body) {
+			if sess != nil {
+				sess.reqMu.Unlock()
+			}
 			return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)
 		}
 		if respHS != nil && respHS.StatusCode > 0 {
@@ -685,6 +688,10 @@ func buildCodexWebsocketRequestBody(body []byte) []byte {
 	fallback := bytes.Clone(body)
 	fallback, _ = sjson.SetBytes(fallback, "type", "response.create")
 	return fallback
+}
+
+func canFallbackToCodexHTTPAfterWebsocketDialFailure(body []byte) bool {
+	return strings.TrimSpace(gjson.GetBytes(body, "previous_response_id").String()) == ""
 }
 
 func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession, conn *websocket.Conn, readCh chan codexWebsocketRead) (int, []byte, error) {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -90,6 +91,95 @@ func TestCodexWebsocketsExecutePreservesPreviousResponseIDUpstream(t *testing.T)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for upstream websocket payload")
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamFallsBackToHTTPOnUpgradeFailureWithoutPreviousResponseID(t *testing.T) {
+	var websocketAttempts int32
+	var httpFallbackCalls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Fatalf("request path = %s, want /responses", r.URL.Path)
+		}
+		if strings.EqualFold(strings.TrimSpace(r.Header.Get("Upgrade")), "websocket") {
+			atomic.AddInt32(&websocketAttempts, 1)
+			http.Error(w, "websocket unavailable", http.StatusBadRequest)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("fallback request method = %s, want POST", r.Method)
+		}
+		atomic.AddInt32(&httpFallbackCalls, 1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-http\",\"output\":[],\"usage\":{\"input_tokens\":0,\"output_tokens\":0,\"total_tokens\":0}}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","input":[{"type":"message","id":"msg-1"}]}`),
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("codex")}
+
+	result, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	foundCompleted := false
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+		if bytes.Contains(chunk.Payload, []byte(`"response.completed"`)) {
+			foundCompleted = true
+		}
+	}
+	if !foundCompleted {
+		t.Fatalf("fallback stream did not produce response.completed chunk")
+	}
+	if got := atomic.LoadInt32(&websocketAttempts); got == 0 {
+		t.Fatalf("websocket attempts = %d, want at least 1", got)
+	}
+	if got := atomic.LoadInt32(&httpFallbackCalls); got != 1 {
+		t.Fatalf("http fallback calls = %d, want 1", got)
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamDoesNotFallbackWhenPreviousResponseIDIsPresent(t *testing.T) {
+	var httpFallbackCalls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.EqualFold(strings.TrimSpace(r.Header.Get("Upgrade")), "websocket") {
+			http.Error(w, "websocket unavailable", http.StatusBadRequest)
+			return
+		}
+		atomic.AddInt32(&httpFallbackCalls, 1)
+		http.Error(w, "unexpected fallback", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","previous_response_id":"resp-1","input":[{"type":"message","id":"msg-2"}]}`),
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("codex")}
+
+	_, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+	if err == nil {
+		t.Fatalf("expected dial failure to be returned when previous_response_id is present")
+	}
+	status, ok := err.(interface{ StatusCode() int })
+	if !ok || status.StatusCode() != http.StatusBadRequest {
+		t.Fatalf("status = %#v, want 400", err)
+	}
+	if got := atomic.LoadInt32(&httpFallbackCalls); got != 0 {
+		t.Fatalf("http fallback calls = %d, want 0", got)
 	}
 }
 

--- a/internal/util/header_helpers.go
+++ b/internal/util/header_helpers.go
@@ -43,6 +43,9 @@ func applyCustomHeaders(r *http.Request, headers map[string]string) {
 	if r == nil || len(headers) == 0 {
 		return
 	}
+	if r.Header == nil {
+		r.Header = make(http.Header)
+	}
 	for k, v := range headers {
 		if k == "" || v == "" {
 			continue
@@ -55,6 +58,11 @@ func applyCustomHeaders(r *http.Request, headers map[string]string) {
 		if http.CanonicalHeaderKey(k) == "Host" {
 			r.Host = v
 		}
-		r.Header.Set(k, v)
+		// Use direct map assignment to preserve the user-supplied header
+		// casing. net/http's Header.Set canonicalizes keys via
+		// textproto.CanonicalMIMEHeaderKey, which mutates headers like
+		// "x-api-key" into "X-Api-Key" and breaks providers that require
+		// an exact-case match.
+		r.Header[k] = []string{v}
 	}
 }

--- a/internal/util/header_helpers_test.go
+++ b/internal/util/header_helpers_test.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestApplyCustomHeadersFromAttrs_PreservesCasing(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	attrs := map[string]string{
+		"header:x-api-key":     "secret123",
+		"header:x-custom-auth": "token",
+	}
+
+	ApplyCustomHeadersFromAttrs(req, attrs)
+
+	// Go's net/http Header.Set canonicalizes keys via
+	// textproto.CanonicalMIMEHeaderKey. We use direct map assignment so that
+	// the user-supplied casing is preserved in the Header map and therefore
+	// in the request actually written to the wire.
+	if _, ok := req.Header["x-api-key"]; !ok {
+		t.Errorf("expected exact-case header %q in Header map; got keys %v", "x-api-key", req.Header)
+	}
+	if _, ok := req.Header["x-custom-auth"]; !ok {
+		t.Errorf("expected exact-case header %q in Header map; got keys %v", "x-custom-auth", req.Header)
+	}
+
+	// Confirm the values are correct via direct map access.
+	if got := req.Header["x-api-key"]; len(got) != 1 || got[0] != "secret123" {
+		t.Errorf("x-api-key = %v, want [secret123]", got)
+	}
+	if got := req.Header["x-custom-auth"]; len(got) != 1 || got[0] != "token" {
+		t.Errorf("x-custom-auth = %v, want [token]", got)
+	}
+}
+
+func TestApplyCustomHeadersFromAttrs_NilHeaderMap(t *testing.T) {
+	// Synthetic requests may be created with a nil Header map. Direct
+	// assignment must not panic and should initialize the map.
+	req := &http.Request{Method: "GET", URL: &url.URL{Scheme: "http", Host: "example.com"}}
+	if req.Header != nil {
+		t.Fatalf("test setup: expected nil Header map")
+	}
+
+	ApplyCustomHeadersFromAttrs(req, map[string]string{
+		"header:x-api-key": "secret123",
+	})
+
+	if req.Header == nil {
+		t.Fatalf("ApplyCustomHeadersFromAttrs did not initialize nil Header map")
+	}
+	if got := req.Header["x-api-key"]; len(got) != 1 || got[0] != "secret123" {
+		t.Errorf("x-api-key = %v, want [secret123]", got)
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -261,6 +261,12 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			lastResponseOutput = previousLastResponseOutput
 			continue
 		}
+		if shouldReplayResponsesWebsocketTranscript(forwardErrMsg) {
+			forceTranscriptReplayNextRequest = true
+			lastRequest = previousLastRequest
+			lastResponseOutput = previousLastResponseOutput
+			continue
+		}
 		lastResponseOutput = completedOutput
 	}
 }
@@ -973,8 +979,54 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 }
 
 func shouldReleaseResponsesWebsocketPinnedAuth(errMsg *interfaces.ErrorMessage) bool {
-	if errMsg == nil {
+	status := responsesWebsocketErrorStatus(errMsg)
+	switch status {
+	case http.StatusUnauthorized, http.StatusPaymentRequired, http.StatusForbidden, http.StatusTooManyRequests:
+		return true
+	default:
 		return false
+	}
+}
+
+func shouldReplayResponsesWebsocketTranscript(errMsg *interfaces.ErrorMessage) bool {
+	if responsesWebsocketErrorStatus(errMsg) != http.StatusBadRequest || errMsg == nil || errMsg.Error == nil {
+		return false
+	}
+
+	raw := strings.TrimSpace(errMsg.Error.Error())
+	if raw == "" {
+		return false
+	}
+	lower := strings.ToLower(raw)
+	if strings.Contains(lower, "previous_response_not_found") {
+		return true
+	}
+	if strings.Contains(lower, "previous_response_id") && strings.Contains(lower, "not found") {
+		return true
+	}
+	if !json.Valid([]byte(raw)) {
+		return false
+	}
+
+	code := strings.TrimSpace(gjson.Get(raw, "error.code").String())
+	if code == "" {
+		code = strings.TrimSpace(gjson.Get(raw, "code").String())
+	}
+	if strings.EqualFold(code, "previous_response_not_found") {
+		return true
+	}
+
+	message := strings.TrimSpace(gjson.Get(raw, "error.message").String())
+	if message == "" {
+		message = strings.TrimSpace(gjson.Get(raw, "message").String())
+	}
+	lowerMessage := strings.ToLower(message)
+	return strings.Contains(lowerMessage, "previous_response_id") && strings.Contains(lowerMessage, "not found")
+}
+
+func responsesWebsocketErrorStatus(errMsg *interfaces.ErrorMessage) int {
+	if errMsg == nil {
+		return 0
 	}
 	status := errMsg.StatusCode
 	if status <= 0 && errMsg.Error != nil {
@@ -982,12 +1034,7 @@ func shouldReleaseResponsesWebsocketPinnedAuth(errMsg *interfaces.ErrorMessage) 
 			status = se.StatusCode()
 		}
 	}
-	switch status {
-	case http.StatusUnauthorized, http.StatusPaymentRequired, http.StatusForbidden, http.StatusTooManyRequests:
-		return true
-	default:
-		return false
-	}
+	return status
 }
 
 func responseCompletedOutputFromPayload(payload []byte) []byte {

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -76,6 +76,13 @@ type websocketPinnedFailoverExecutor struct {
 	payloads map[string][][]byte
 }
 
+type websocketPreviousResponseReplayExecutor struct {
+	mu       sync.Mutex
+	authIDs  []string
+	calls    map[string]int
+	payloads map[string][][]byte
+}
+
 type websocketPinnedFailoverStatusError struct {
 	status int
 	msg    string
@@ -255,6 +262,76 @@ func (e *websocketPinnedFailoverExecutor) AuthIDs() []string {
 }
 
 func (e *websocketPinnedFailoverExecutor) Payloads(authID string) [][]byte {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	src := e.payloads[authID]
+	out := make([][]byte, len(src))
+	for i := range src {
+		out[i] = bytes.Clone(src[i])
+	}
+	return out
+}
+
+func (e *websocketPreviousResponseReplayExecutor) Identifier() string { return "test-provider" }
+
+func (e *websocketPreviousResponseReplayExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *websocketPreviousResponseReplayExecutor) ExecuteStream(_ context.Context, auth *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	authID := ""
+	if auth != nil {
+		authID = auth.ID
+	}
+
+	e.mu.Lock()
+	if e.calls == nil {
+		e.calls = make(map[string]int)
+	}
+	if e.payloads == nil {
+		e.payloads = make(map[string][][]byte)
+	}
+	e.authIDs = append(e.authIDs, authID)
+	e.calls[authID]++
+	call := e.calls[authID]
+	e.payloads[authID] = append(e.payloads[authID], bytes.Clone(req.Payload))
+	e.mu.Unlock()
+
+	if call == 2 {
+		chunks := make(chan coreexecutor.StreamChunk, 1)
+		chunks <- coreexecutor.StreamChunk{Err: websocketPinnedFailoverStatusError{
+			status: http.StatusBadRequest,
+			msg:    `{"error":{"message":"No response found for previous_response_id resp-auth-a-1","type":"invalid_request_error","code":"previous_response_not_found"}}`,
+		}}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":"resp-%s-%d","output":[{"type":"message","id":"out-%s-%d"}]}}`, authID, call, authID, call))}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *websocketPreviousResponseReplayExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *websocketPreviousResponseReplayExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *websocketPreviousResponseReplayExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *websocketPreviousResponseReplayExecutor) AuthIDs() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.authIDs...)
+}
+
+func (e *websocketPreviousResponseReplayExecutor) Payloads(authID string) [][]byte {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	src := e.payloads[authID]
@@ -1431,6 +1508,89 @@ func TestResponsesWebsocketReleasesPinnedAuthAfterQuotaError(t *testing.T) {
 	authBInput := gjson.GetBytes(authBPayload, "input").Raw
 	if !strings.Contains(authBInput, `"id":"msg-1"`) || !strings.Contains(authBInput, `"id":"msg-3"`) {
 		t.Fatalf("auth-b replay input missing expected transcript items: %s", authBInput)
+	}
+}
+
+func TestResponsesWebsocketReplaysTranscriptAfterPreviousResponseNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketPreviousResponseReplayExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{
+		ID:         "auth-a",
+		Provider:   executor.Identifier(),
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "replay-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", h.ResponsesWebsocket)
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Fatalf("close websocket: %v", errClose)
+		}
+	}()
+
+	requests := []string{
+		`{"type":"response.create","model":"replay-model","input":[{"type":"message","id":"msg-1"}]}`,
+		`{"type":"response.create","previous_response_id":"resp-auth-a-1","input":[{"type":"message","id":"msg-2"}]}`,
+		`{"type":"response.create","previous_response_id":"resp-auth-a-1","input":[{"type":"message","id":"msg-3"}]}`,
+	}
+	wantTypes := []string{wsEventTypeCompleted, wsEventTypeError, wsEventTypeCompleted}
+	for i := range requests {
+		if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(requests[i])); errWrite != nil {
+			t.Fatalf("write websocket message %d: %v", i+1, errWrite)
+		}
+		_, payload, errReadMessage := conn.ReadMessage()
+		if errReadMessage != nil {
+			t.Fatalf("read websocket message %d: %v", i+1, errReadMessage)
+		}
+		if got := gjson.GetBytes(payload, "type").String(); got != wantTypes[i] {
+			t.Fatalf("message %d payload type = %s, want %s: %s", i+1, got, wantTypes[i], payload)
+		}
+		if i == 1 && int(gjson.GetBytes(payload, "status").Int()) != http.StatusBadRequest {
+			t.Fatalf("error payload status = %d, want %d: %s", gjson.GetBytes(payload, "status").Int(), http.StatusBadRequest, payload)
+		}
+	}
+
+	if got := executor.AuthIDs(); len(got) != 3 || got[0] != "auth-a" || got[1] != "auth-a" || got[2] != "auth-a" {
+		t.Fatalf("selected auth IDs = %v, want [auth-a auth-a auth-a]", got)
+	}
+
+	authPayloads := executor.Payloads("auth-a")
+	if len(authPayloads) != 3 {
+		t.Fatalf("auth payload count = %d, want 3", len(authPayloads))
+	}
+	replayPayload := authPayloads[2]
+	if gjson.GetBytes(replayPayload, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id leaked after replay recovery: %s", replayPayload)
+	}
+	replayInput := gjson.GetBytes(replayPayload, "input").Raw
+	if !strings.Contains(replayInput, `"id":"msg-1"`) || !strings.Contains(replayInput, `"id":"msg-3"`) {
+		t.Fatalf("replay input missing expected transcript items: %s", replayInput)
+	}
+	if strings.Contains(replayInput, `"id":"msg-2"`) {
+		t.Fatalf("failed turn input leaked into replay transcript: %s", replayInput)
 	}
 }
 


### PR DESCRIPTION
Go's net/http Header.Set canonicalizes keys via textproto.CanonicalMIMEHeaderKey, mutating headers like 'x-api-key' into 'X-Api-Key'. Some upstream providers require exact-case header names, so use direct Header map assignment instead.