### PR TITLE
fix(util): preserve user-supplied custom header casing

### DIFF
--- a/internal/util/header_helpers.go
+++ b/internal/util/header_helpers.go
@@ -43,6 +43,9 @@ func applyCustomHeaders(r *http.Request, headers map[string]string) {
 	if r == nil || len(headers) == 0 {
 		return
 	}
+	if r.Header == nil {
+		r.Header = make(http.Header)
+	}
 	for k, v := range headers {
 		if k == "" || v == "" {
 			continue
@@ -55,6 +58,11 @@ func applyCustomHeaders(r *http.Request, headers map[string]string) {
 		if http.CanonicalHeaderKey(k) == "Host" {
 			r.Host = v
 		}
-		r.Header.Set(k, v)
+		// Use direct map assignment to preserve the user-supplied header
+		// casing. net/http's Header.Set canonicalizes keys via
+		// textproto.CanonicalMIMEHeaderKey, which mutates headers like
+		// "x-api-key" into "X-Api-Key" and breaks providers that require
+		// an exact-case match.
+		r.Header[k] = []string{v}
 	}
 }

--- a/internal/util/header_helpers_test.go
+++ b/internal/util/header_helpers_test.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestApplyCustomHeadersFromAttrs_PreservesCasing(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	attrs := map[string]string{
+		"header:x-api-key":     "secret123",
+		"header:x-custom-auth": "token",
+	}
+
+	ApplyCustomHeadersFromAttrs(req, attrs)
+
+	// Go's net/http Header.Set canonicalizes keys via
+	// textproto.CanonicalMIMEHeaderKey. We use direct map assignment so that
+	// the user-supplied casing is preserved in the Header map and therefore
+	// in the request actually written to the wire.
+	if _, ok := req.Header["x-api-key"]; !ok {
+		t.Errorf("expected exact-case header %q in Header map; got keys %v", "x-api-key", req.Header)
+	}
+	if _, ok := req.Header["x-custom-auth"]; !ok {
+		t.Errorf("expected exact-case header %q in Header map; got keys %v", "x-custom-auth", req.Header)
+	}
+
+	// Confirm the values are correct via direct map access.
+	if got := req.Header["x-api-key"]; len(got) != 1 || got[0] != "secret123" {
+		t.Errorf("x-api-key = %v, want [secret123]", got)
+	}
+	if got := req.Header["x-custom-auth"]; len(got) != 1 || got[0] != "token" {
+		t.Errorf("x-custom-auth = %v, want [token]", got)
+	}
+}
+
+func TestApplyCustomHeadersFromAttrs_NilHeaderMap(t *testing.T) {
+	// Synthetic requests may be created with a nil Header map. Direct
+	// assignment must not panic and should initialize the map.
+	req := &http.Request{Method: "GET", URL: &url.URL{Scheme: "http", Host: "example.com"}}
+	if req.Header != nil {
+		t.Fatalf("test setup: expected nil Header map")
+	}
+
+	ApplyCustomHeadersFromAttrs(req, map[string]string{
+		"header:x-api-key": "secret123",
+	})
+
+	if req.Header == nil {
+		t.Fatalf("ApplyCustomHeadersFromAttrs did not initialize nil Header map")
+	}
+	if got := req.Header["x-api-key"]; len(got) != 1 || got[0] != "secret123" {
+		t.Errorf("x-api-key = %v, want [secret123]", got)
+	}
+}


### PR DESCRIPTION
Go's net/http Header.Set canonicalizes keys via textproto.CanonicalMIMEHeaderKey, mutating headers like 'x-api-key' into 'X-Api-Key'. Some upstream providers require exact-case header names, so use direct Header map assignment instead.

Also defensively initialize r.Header if nil, and add tests for casing preservation and nil-header safety.