### PR TITLE
feat(claude): add cloak.preserve-system-prompt option

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -265,14 +265,19 @@ nonstream-keepalive-interval: 0
 #                                    # "never": never apply cloaking
 #       # This "cloak" block applies to this claude-api-key entry only. For Claude OAuth
 #       # credentials, set the same options in the auth/token JSON file via "cloak_mode" /
-#       # "cloak_strict_mode" / "cloak_sensitive_words" / "cloak_cache_user_id". The top-level
-#       # "disable-claude-cloak-mode: true" disables cloaking for all Claude credentials at once.
+#       # "cloak_strict_mode" / "cloak_sensitive_words" / "cloak_cache_user_id" /
+#       # "cloak_preserve_system_prompt". The top-level "disable-claude-cloak-mode: true"
+#       # disables cloaking for all Claude credentials at once.
 #       strict-mode: false           # false (default): prepend Claude Code prompt to user system messages
 #                                    # true: strip all user system messages, keep only Claude Code prompt
 #       sensitive-words:             # optional: words to obfuscate with zero-width characters
 #         - "API"
 #         - "proxy"
 #       cache-user-id: true          # optional: default is false; set true to reuse cached user_id per API key instead of generating a random one each request
+#       preserve-system-prompt: false # optional: default is false; only applies when strict-mode is false and cloaking is active for OAuth (Claude Code login) credentials
+#                                    # false (default): the forwarded system prompt is reduced to a neutral reminder so the request looks like native Claude Code traffic
+#                                    # true: keep the original system prompt and move it into the first user message instead of replacing it
+#                                    # note: keeping the original prompt makes requests more recognizable as third-party traffic, which may affect Anthropic plan-vs-extra-usage metering
 #     experimental-cch-signing: false # optional: default is false; when true, sign the final /v1/messages body using the current Claude Code cch algorithm
 #                                     # keep this disabled unless you explicitly need the behavior, so upstream seed changes fall back to legacy proxy behavior
 

--- a/internal/config/claude_cloak_preserve_system_prompt_test.go
+++ b/internal/config/claude_cloak_preserve_system_prompt_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfigOptional_CloakPreserveSystemPrompt(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	configYAML := []byte(`
+claude-api-key:
+  - api-key: "sk-preserve-true"
+    cloak:
+      preserve-system-prompt: true
+  - api-key: "sk-preserve-false"
+    cloak:
+      preserve-system-prompt: false
+  - api-key: "sk-preserve-unset"
+    cloak:
+      mode: "always"
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+
+	if len(cfg.ClaudeKey) != 3 {
+		t.Fatalf("ClaudeKey count = %d, want 3", len(cfg.ClaudeKey))
+	}
+
+	enabled := cfg.ClaudeKey[0].Cloak
+	if enabled == nil || enabled.PreserveSystemPrompt == nil {
+		t.Fatal("ClaudeKey[0].Cloak.PreserveSystemPrompt = nil, want non-nil")
+	}
+	if got := *enabled.PreserveSystemPrompt; !got {
+		t.Fatalf("ClaudeKey[0].Cloak.PreserveSystemPrompt = %v, want true", got)
+	}
+
+	disabled := cfg.ClaudeKey[1].Cloak
+	if disabled == nil || disabled.PreserveSystemPrompt == nil {
+		t.Fatal("ClaudeKey[1].Cloak.PreserveSystemPrompt = nil, want non-nil")
+	}
+	if got := *disabled.PreserveSystemPrompt; got {
+		t.Fatalf("ClaudeKey[1].Cloak.PreserveSystemPrompt = %v, want false", got)
+	}
+
+	unset := cfg.ClaudeKey[2].Cloak
+	if unset == nil {
+		t.Fatal("ClaudeKey[2].Cloak = nil, want non-nil")
+	}
+	if unset.PreserveSystemPrompt != nil {
+		t.Fatalf("ClaudeKey[2].Cloak.PreserveSystemPrompt = %v, want nil", *unset.PreserveSystemPrompt)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -420,6 +420,17 @@ type CloakConfig struct {
 	// - true: strip all user system messages, keep only Claude Code prompt
 	StrictMode bool `yaml:"strict-mode,omitempty" json:"strict-mode,omitempty"`
 
+	// PreserveSystemPrompt controls how the caller's original system prompt is
+	// forwarded when cloaking OAuth (Claude Code login) requests. It only has an
+	// effect when StrictMode is false.
+	// - false (default): the forwarded system prompt is reduced to a neutral
+	//   reminder so the request looks like native Claude Code traffic.
+	// - true: the caller's original system prompt is kept and moved into the first
+	//   user message instead of being replaced.
+	// Keeping the original prompt makes requests more recognizable as third-party
+	// traffic, which may affect Anthropic plan-vs-extra-usage metering.
+	PreserveSystemPrompt *bool `yaml:"preserve-system-prompt,omitempty" json:"preserve-system-prompt,omitempty"`
+
 	// SensitiveWords is a list of words to obfuscate with zero-width characters.
 	// This can help bypass certain content filters.
 	SensitiveWords []string `yaml:"sensitive-words,omitempty" json:"sensitive-words,omitempty"`

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -1154,7 +1154,7 @@ func claudeCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {
 }
 
 func checkSystemInstructions(payload []byte) []byte {
-	return checkSystemInstructionsWithSigningMode(payload, false, false, false, "2.1.63", "", "")
+	return checkSystemInstructionsWithSigningMode(payload, false, false, false, false, "2.1.63", "", "")
 }
 
 func rebuildMidSystemMessagesToTopLevel(payload []byte) []byte {
@@ -1719,11 +1719,12 @@ func getWorkloadFromContext(ctx context.Context) string {
 
 // getCloakConfigFromAuth extracts cloak configuration from the auth's attributes,
 // falling back to its stored metadata (the raw OAuth/token JSON). Returns
-// (cloakMode, strictMode, sensitiveWords, cacheUserID); an empty cloakMode means
-// the credential did not explicitly configure a mode.
-func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMode bool, sensitiveWords []string, cacheUserID bool) {
+// (cloakMode, strictMode, sensitiveWords, cacheUserID, preserveSystemPrompt); an
+// empty cloakMode means the credential did not explicitly configure a mode, and a
+// nil preserveSystemPrompt means it did not configure that flag.
+func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMode bool, sensitiveWords []string, cacheUserID bool, preserveSystemPrompt *bool) {
 	if auth == nil {
-		return "", false, nil, false
+		return "", false, nil, false, nil
 	}
 
 	// lookupCloakAttr prefers the executor-facing Attributes, then falls back to the
@@ -1758,7 +1759,12 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMo
 
 	cacheUserID = strings.EqualFold(lookupCloakAttr("cloak_cache_user_id"), "true")
 
-	return cloakMode, strictMode, sensitiveWords, cacheUserID
+	if preserveRaw := lookupCloakAttr("cloak_preserve_system_prompt"); preserveRaw != "" {
+		preserve := strings.EqualFold(preserveRaw, "true")
+		preserveSystemPrompt = &preserve
+	}
+
+	return cloakMode, strictMode, sensitiveWords, cacheUserID, preserveSystemPrompt
 }
 
 // injectFakeUserID generates and injects a fake user ID into the request metadata.
@@ -1837,7 +1843,7 @@ func generateBillingHeader(payload []byte, experimentalCCHSigning bool, version,
 }
 
 func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
-	return checkSystemInstructionsWithSigningMode(payload, strictMode, false, false, "2.1.63", "", "")
+	return checkSystemInstructionsWithSigningMode(payload, strictMode, false, false, false, "2.1.63", "", "")
 }
 
 // checkSystemInstructionsWithSigningMode injects Claude Code-style system blocks:
@@ -1848,7 +1854,11 @@ func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
 //	system[3]: system instructions (no cache_control)
 //	system[4]: doing tasks (no cache_control)
 //	system[5]: user system messages moved to first user message
-func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, experimentalCCHSigning bool, oauthMode bool, version, entrypoint, workload string) []byte {
+//
+// When preserveSystemPrompt is true, the caller's original system prompt is kept
+// and moved into the first user message even on OAuth requests, instead of being
+// reduced to the neutral reminder produced by sanitizeForwardedSystemPrompt.
+func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, experimentalCCHSigning bool, oauthMode bool, preserveSystemPrompt bool, version, entrypoint, workload string) []byte {
 	system := gjson.GetBytes(payload, "system")
 
 	// Extract original message text for fingerprint computation (before billing injection).
@@ -1911,7 +1921,7 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 
 		if len(userSystemParts) > 0 {
 			combined := strings.Join(userSystemParts, "\n\n")
-			if oauthMode {
+			if oauthMode && !preserveSystemPrompt {
 				combined = sanitizeForwardedSystemPrompt(combined)
 			}
 			if strings.TrimSpace(combined) != "" {
@@ -2016,7 +2026,7 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 
 	// Get cloak config from ClaudeKey configuration
 	cloakCfg := resolveClaudeKeyCloakConfig(cfg, auth)
-	attrMode, attrStrict, attrWords, attrCache := getCloakConfigFromAuth(auth)
+	attrMode, attrStrict, attrWords, attrCache, attrPreserve := getCloakConfigFromAuth(auth)
 
 	// Determine cloak settings. Precedence (low -> high):
 	//   built-in "auto" default
@@ -2030,6 +2040,10 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 	strictMode := attrStrict
 	sensitiveWords := attrWords
 	cacheUserID := attrCache
+	preserveSystemPrompt := false
+	if attrPreserve != nil {
+		preserveSystemPrompt = *attrPreserve
+	}
 
 	if attrMode != "" {
 		cloakMode = attrMode
@@ -2048,6 +2062,9 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 		if cloakCfg.CacheUserID != nil {
 			cacheUserID = *cloakCfg.CacheUserID
 		}
+		if cloakCfg.PreserveSystemPrompt != nil {
+			preserveSystemPrompt = *cloakCfg.PreserveSystemPrompt
+		}
 	}
 
 	// Determine if cloaking should be applied
@@ -2060,7 +2077,7 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 		billingVersion := helps.DefaultClaudeVersion(cfg)
 		entrypoint := parseEntrypointFromUA(clientUserAgent)
 		workload := getWorkloadFromContext(ctx)
-		payload = checkSystemInstructionsWithSigningMode(payload, strictMode, useCCHSigning, oauthToken, billingVersion, entrypoint, workload)
+		payload = checkSystemInstructionsWithSigningMode(payload, strictMode, useCCHSigning, oauthToken, preserveSystemPrompt, billingVersion, entrypoint, workload)
 	}
 
 	// Inject fake user ID

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2444,6 +2444,43 @@ func TestCheckSystemInstructionsWithMode_StringWithSpecialChars(t *testing.T) {
 	}
 }
 
+// Test case 6: OAuth mode without preserve sanitizes the forwarded system prompt
+func TestCheckSystemInstructionsWithSigningMode_OAuthSanitizesByDefault(t *testing.T) {
+	payload := []byte(`{"system":"You are a helpful assistant.","messages":[{"role":"user","content":"hi"}]}`)
+
+	out := checkSystemInstructionsWithSigningMode(payload, false, false, true, false, "2.1.63", "", "")
+
+	got := gjson.GetBytes(out, "messages.0.content").String()
+	if strings.Contains(got, "You are a helpful assistant.") {
+		t.Fatalf("OAuth default should not forward the original system prompt, got %q", got)
+	}
+	if want := expectedForwardedSystemReminder(sanitizeForwardedSystemPrompt("You are a helpful assistant.")) + "hi"; got != want {
+		t.Fatalf("OAuth default should forward sanitized reminder, got %q want %q", got, want)
+	}
+}
+
+// Test case 7: OAuth mode with preserve keeps the caller's original system prompt
+func TestCheckSystemInstructionsWithSigningMode_OAuthPreserveKeepsOriginal(t *testing.T) {
+	payload := []byte(`{"system":"You are a helpful assistant.","messages":[{"role":"user","content":"hi"}]}`)
+
+	out := checkSystemInstructionsWithSigningMode(payload, false, false, true, true, "2.1.63", "", "")
+
+	if want := expectedForwardedSystemReminder("You are a helpful assistant.") + "hi"; gjson.GetBytes(out, "messages.0.content").String() != want {
+		t.Fatalf("OAuth preserve should forward the original system prompt, got %q want %q", gjson.GetBytes(out, "messages.0.content").String(), want)
+	}
+}
+
+// Test case 8: preserve has no effect in strict mode
+func TestCheckSystemInstructionsWithSigningMode_PreserveIgnoredInStrictMode(t *testing.T) {
+	payload := []byte(`{"system":"You are a helpful assistant.","messages":[{"role":"user","content":"hi"}]}`)
+
+	out := checkSystemInstructionsWithSigningMode(payload, true, false, true, true, "2.1.63", "", "")
+
+	if got := gjson.GetBytes(out, "messages.0.content").String(); got != "hi" {
+		t.Fatalf("strict mode should never forward system prompt regardless of preserve, got %q", got)
+	}
+}
+
 func TestClaudeExecutor_ExperimentalCCHSigningDisabledByDefaultKeepsLegacyHeader(t *testing.T) {
 	var seenBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -198,6 +198,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 				if len(o.Cloak.SensitiveWords) != len(n.Cloak.SensitiveWords) {
 					changes = append(changes, fmt.Sprintf("claude[%d].cloak.sensitive-words: %d -> %d", i, len(o.Cloak.SensitiveWords), len(n.Cloak.SensitiveWords)))
 				}
+				if !boolPtrEqual(o.Cloak.PreserveSystemPrompt, n.Cloak.PreserveSystemPrompt) {
+					changes = append(changes, fmt.Sprintf("claude[%d].cloak.preserve-system-prompt: %s -> %s", i, boolPtrString(o.Cloak.PreserveSystemPrompt), boolPtrString(n.Cloak.PreserveSystemPrompt)))
+				}
 			}
 		}
 	}
@@ -388,4 +391,18 @@ func formatProxyURL(raw string) string {
 		return host
 	}
 	return scheme + "://" + host
+}
+
+func boolPtrEqual(a, b *bool) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func boolPtrString(v *bool) string {
+	if v == nil {
+		return "<unset>"
+	}
+	return fmt.Sprintf("%t", *v)
 }


### PR DESCRIPTION
By default, cloaking OAuth (Claude Code login) requests reduces the caller's forwarded system prompt to a neutral reminder so traffic looks like native Claude Code. This drops user/client system prompts entirely on OAuth credentials, even outside strict mode.

Add an opt-in cloak option that, when strict mode is off, keeps the original system prompt and moves it into the first user message instead of replacing it. Configurable per claude-api-key entry via cloak.preserve-system-prompt, or per OAuth credential via the cloak_preserve_system_prompt auth attribute. Defaults to false, so existing behavior is unchanged.

Keeping the original prompt makes requests more recognizable as third-party traffic, which may affect Anthropic plan-vs-extra-usage metering; this is documented in config.example.yaml.