### PR TITLE
feat(config): per-client API key model aliases

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -61,7 +61,7 @@ func shouldStartExampleAPIKeyWarningServer(cfg *config.Config, commandMode, tuiM
 	if tuiMode && !standalone {
 		return false
 	}
-	return safemode.HasExampleAPIKeys(cfg.APIKeys)
+	return safemode.HasExampleAPIKeys(cfg.ClientAPIKeys.APIKeyStrings())
 }
 
 // main is the entry point of the application.
@@ -548,7 +548,7 @@ func main() {
 	cloudConfigMissing := isCloudDeploy && !configFileExists
 	homeMode := configLoadedFromHome || (cfg != nil && cfg.Home.Enabled)
 	if shouldStartExampleAPIKeyWarningServer(cfg, commandMode, tuiMode, standalone, cloudConfigMissing, homeMode) {
-		matches := safemode.ExampleAPIKeys(cfg.APIKeys)
+		matches := safemode.ExampleAPIKeys(cfg.ClientAPIKeys.APIKeyStrings())
 		log.WithField("api_keys", strings.Join(matches, ",")).Error("unsafe example API key configured; starting warning-only server")
 		cmd.StartExampleAPIKeyWarningServer(cfg, configFilePath, matches)
 		return

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -9,12 +9,12 @@ import (
 func TestShouldStartExampleAPIKeyWarningServer(t *testing.T) {
 	cfgWithExampleKey := &config.Config{
 		SDKConfig: config.SDKConfig{
-			APIKeys: []string{"real-key", " your-api-key-1 "},
+			ClientAPIKeys: config.ClientAPIKeys{{Key: "real-key"}, {Key: " your-api-key-1 "}},
 		},
 	}
 	cfgWithRealKey := &config.Config{
 		SDKConfig: config.SDKConfig{
-			APIKeys: []string{"real-key"},
+			ClientAPIKeys: config.ClientAPIKeys{{Key: "real-key"}},
 		},
 	}
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -35,11 +35,16 @@ remote-management:
 # Authentication directory (supports ~ for home directory)
 auth-dir: "~/.cli-proxy-api"
 
-# API keys for authentication
+# API keys for authentication (client credentials for accessing this proxy)
+# Each entry may be a plain string or an object with per-key model aliases (same fields as oauth-model-alias entries).
 api-keys:
   - "your-api-key-1"
   - "your-api-key-2"
-  - "your-api-key-3"
+  - key: "your-api-key-3"
+    model-aliases:
+      - name: "deepseek-v4"
+        alias: "claude-opus-4.7"
+        force-mapping: true
 
 # Enable debug logging
 debug: false

--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -16,7 +16,7 @@ func Register(cfg *sdkconfig.SDKConfig) {
 		return
 	}
 
-	keys := normalizeKeys(cfg.APIKeys)
+	keys := normalizeKeys(cfg.ClientAPIKeys.APIKeyStrings())
 	if len(keys) == 0 {
 		sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeConfigAPIKey)
 		return

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -104,18 +104,159 @@ func (h *Handler) deleteFromStringList(c *gin.Context, target *[]string, after f
 	c.JSON(400, gin.H{"error": "missing index or value"})
 }
 
-// api-keys
-func (h *Handler) GetAPIKeys(c *gin.Context) { c.JSON(200, gin.H{"api-keys": h.cfg.APIKeys}) }
+// api-keys (client credentials for accessing this proxy)
+func (h *Handler) GetAPIKeys(c *gin.Context) {
+	c.JSON(200, gin.H{"api-keys": h.cfg.ClientAPIKeys})
+}
+
 func (h *Handler) PutAPIKeys(c *gin.Context) {
-	h.putStringList(c, func(v []string) {
-		h.cfg.APIKeys = append([]string(nil), v...)
-	}, nil)
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+	var arr []config.ClientAPIKey
+	if err = json.Unmarshal(data, &arr); err != nil {
+		var stringsOnly []string
+		if err2 := json.Unmarshal(data, &stringsOnly); err2 != nil {
+			var obj struct {
+				Items []config.ClientAPIKey `json:"items"`
+			}
+			if err3 := json.Unmarshal(data, &obj); err3 != nil || len(obj.Items) == 0 {
+				var objStrings struct {
+					Items []string `json:"items"`
+				}
+				if err4 := json.Unmarshal(data, &objStrings); err4 != nil || len(objStrings.Items) == 0 {
+					c.JSON(400, gin.H{"error": "invalid body"})
+					return
+				}
+				arr = clientAPIKeysFromStrings(objStrings.Items)
+			} else {
+				arr = obj.Items
+			}
+		} else {
+			arr = clientAPIKeysFromStrings(stringsOnly)
+		}
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.cfg.ClientAPIKeys = append(config.ClientAPIKeys(nil), arr...)
+	h.cfg.SanitizeClientAPIKeys()
+	h.persistLocked(c)
 }
+
+func clientAPIKeysFromStrings(keys []string) []config.ClientAPIKey {
+	out := make([]config.ClientAPIKey, 0, len(keys))
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out = append(out, config.ClientAPIKey{Key: key})
+	}
+	return out
+}
+
 func (h *Handler) PatchAPIKeys(c *gin.Context) {
-	h.patchStringList(c, &h.cfg.APIKeys, func() {})
+	type apiKeyPatch struct {
+		Key          *string                   `json:"key"`
+		ModelAliases *[]config.OAuthModelAlias `json:"model-aliases"`
+	}
+	var body struct {
+		Index *int         `json:"index"`
+		Match *string      `json:"match"`
+		Old   *string      `json:"old"`
+		New   *string      `json:"new"`
+		Value *apiKeyPatch `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if body.Value != nil {
+		targetIndex := -1
+		if body.Index != nil && *body.Index >= 0 && *body.Index < len(h.cfg.ClientAPIKeys) {
+			targetIndex = *body.Index
+		}
+		if targetIndex == -1 && body.Match != nil {
+			match := strings.TrimSpace(*body.Match)
+			for i := range h.cfg.ClientAPIKeys {
+				if h.cfg.ClientAPIKeys[i].Key == match {
+					targetIndex = i
+					break
+				}
+			}
+		}
+		if targetIndex == -1 {
+			c.JSON(404, gin.H{"error": "api key not found"})
+			return
+		}
+		entry := &h.cfg.ClientAPIKeys[targetIndex]
+		if body.Value.Key != nil {
+			entry.Key = strings.TrimSpace(*body.Value.Key)
+		}
+		if body.Value.ModelAliases != nil {
+			entry.ModelAliases = append([]config.OAuthModelAlias(nil), (*body.Value.ModelAliases)...)
+		}
+		h.cfg.SanitizeClientAPIKeys()
+		h.persistLocked(c)
+		return
+	}
+
+	if body.Index != nil && body.New != nil && *body.Index >= 0 && *body.Index < len(h.cfg.ClientAPIKeys) {
+		h.cfg.ClientAPIKeys[*body.Index].Key = strings.TrimSpace(*body.New)
+		h.cfg.SanitizeClientAPIKeys()
+		h.persistLocked(c)
+		return
+	}
+	if body.Old != nil && body.New != nil {
+		oldKey := strings.TrimSpace(*body.Old)
+		newKey := strings.TrimSpace(*body.New)
+		for i := range h.cfg.ClientAPIKeys {
+			if h.cfg.ClientAPIKeys[i].Key == oldKey {
+				h.cfg.ClientAPIKeys[i].Key = newKey
+				h.cfg.SanitizeClientAPIKeys()
+				h.persistLocked(c)
+				return
+			}
+		}
+		if newKey != "" {
+			h.cfg.ClientAPIKeys = append(h.cfg.ClientAPIKeys, config.ClientAPIKey{Key: newKey})
+			h.cfg.SanitizeClientAPIKeys()
+			h.persistLocked(c)
+			return
+		}
+	}
+	c.JSON(400, gin.H{"error": "missing fields"})
 }
+
 func (h *Handler) DeleteAPIKeys(c *gin.Context) {
-	h.deleteFromStringList(c, &h.cfg.APIKeys, func() {})
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if idxStr := c.Query("index"); idxStr != "" {
+		var idx int
+		if _, err := fmt.Sscanf(idxStr, "%d", &idx); err == nil && idx >= 0 && idx < len(h.cfg.ClientAPIKeys) {
+			h.cfg.ClientAPIKeys = append(h.cfg.ClientAPIKeys[:idx], h.cfg.ClientAPIKeys[idx+1:]...)
+			h.persistLocked(c)
+			return
+		}
+	}
+	if val := strings.TrimSpace(c.Query("value")); val != "" {
+		out := make(config.ClientAPIKeys, 0, len(h.cfg.ClientAPIKeys))
+		for _, entry := range h.cfg.ClientAPIKeys {
+			if entry.Key != val {
+				out = append(out, entry)
+			}
+		}
+		h.cfg.ClientAPIKeys = out
+		h.persistLocked(c)
+		return
+	}
+	c.JSON(400, gin.H{"error": "missing index or value"})
 }
 
 // gemini-api-key: []GeminiKey

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -40,7 +40,7 @@ func newTestServerWithOptions(t *testing.T, opts ...ServerOption) *Server {
 
 	cfg := &proxyconfig.Config{
 		SDKConfig: sdkconfig.SDKConfig{
-			APIKeys: []string{"test-key"},
+			ClientAPIKeys: proxyconfig.ClientAPIKeys{{Key: "test-key"}},
 		},
 		Port:                   0,
 		AuthDir:                authDir,

--- a/internal/config/client_api_key.go
+++ b/internal/config/client_api_key.go
@@ -1,0 +1,170 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ClientAPIKey is a client credential used to access this proxy (config api-keys).
+type ClientAPIKey struct {
+	Key          string            `yaml:"key" json:"key"`
+	ModelAliases []OAuthModelAlias `yaml:"model-aliases,omitempty" json:"model-aliases,omitempty"`
+}
+
+// ClientAPIKeys is the api-keys section: each entry may be a plain key string or a ClientAPIKey object.
+type ClientAPIKeys []ClientAPIKey
+
+// UnmarshalYAML accepts a sequence of strings or mapping objects with key and model-aliases.
+func (keys *ClientAPIKeys) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil {
+		*keys = nil
+		return nil
+	}
+	switch value.Kind {
+	case yaml.SequenceNode:
+		out := make(ClientAPIKeys, 0, len(value.Content))
+		for _, item := range value.Content {
+			if item == nil {
+				continue
+			}
+			switch item.Kind {
+			case yaml.ScalarNode:
+				key := strings.TrimSpace(item.Value)
+				if key == "" {
+					continue
+				}
+				out = append(out, ClientAPIKey{Key: key})
+			case yaml.MappingNode:
+				var entry ClientAPIKey
+				if err := item.Decode(&entry); err != nil {
+					return err
+				}
+				entry.Key = strings.TrimSpace(entry.Key)
+				if entry.Key == "" {
+					continue
+				}
+				out = append(out, entry)
+			default:
+				return fmt.Errorf("api-keys: unsupported entry kind %v", item.Kind)
+			}
+		}
+		*keys = out
+		return nil
+	default:
+		return fmt.Errorf("api-keys: expected sequence, got %v", value.Kind)
+	}
+}
+
+// MarshalYAML writes a compact list (plain strings when no aliases).
+func (keys ClientAPIKeys) MarshalYAML() (interface{}, error) {
+	if len(keys) == 0 {
+		return []string{}, nil
+	}
+	out := make([]interface{}, 0, len(keys))
+	for _, entry := range keys {
+		if len(entry.ModelAliases) == 0 {
+			out = append(out, entry.Key)
+			continue
+		}
+		out = append(out, ClientAPIKey{
+			Key:          entry.Key,
+			ModelAliases: entry.ModelAliases,
+		})
+	}
+	return out, nil
+}
+
+// APIKeyStrings returns trimmed client key values for authentication.
+func (keys ClientAPIKeys) APIKeyStrings() []string {
+	if len(keys) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(keys))
+	seen := make(map[string]struct{}, len(keys))
+	for _, entry := range keys {
+		key := strings.TrimSpace(entry.Key)
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// SanitizeClientAPIKeys normalizes client keys and per-key model aliases.
+func (cfg *Config) SanitizeClientAPIKeys() {
+	if cfg == nil {
+		return
+	}
+	if len(cfg.ClientAPIKeys) == 0 {
+		return
+	}
+	seen := make(map[string]struct{}, len(cfg.ClientAPIKeys))
+	clean := make(ClientAPIKeys, 0, len(cfg.ClientAPIKeys))
+	for _, entry := range cfg.ClientAPIKeys {
+		key := strings.TrimSpace(entry.Key)
+		if key == "" {
+			continue
+		}
+		keyLower := strings.ToLower(key)
+		if _, exists := seen[keyLower]; exists {
+			continue
+		}
+		seen[keyLower] = struct{}{}
+		aliases := sanitizeOAuthModelAliasList(entry.ModelAliases)
+		clean = append(clean, ClientAPIKey{Key: key, ModelAliases: aliases})
+	}
+	cfg.ClientAPIKeys = clean
+}
+
+func sanitizeOAuthModelAliasList(aliases []OAuthModelAlias) []OAuthModelAlias {
+	if len(aliases) == 0 {
+		return nil
+	}
+	cfg := Config{
+		OAuthModelAlias: map[string][]OAuthModelAlias{
+			"client": aliases,
+		},
+	}
+	cfg.SanitizeOAuthModelAlias()
+	out := cfg.OAuthModelAlias["client"]
+	if len(out) == 0 {
+		return nil
+	}
+	return append([]OAuthModelAlias(nil), out...)
+}
+
+// ModelAliasesFor returns model aliases configured for the given client API key.
+func (keys ClientAPIKeys) ModelAliasesFor(clientKey string) []OAuthModelAlias {
+	clientKey = strings.TrimSpace(clientKey)
+	if clientKey == "" {
+		return nil
+	}
+	for _, entry := range keys {
+		if entry.Key != clientKey {
+			continue
+		}
+		if len(entry.ModelAliases) == 0 {
+			return nil
+		}
+		return append([]OAuthModelAlias(nil), entry.ModelAliases...)
+	}
+	return nil
+}
+
+// ClientAPIKeyModelAliases returns model aliases for the given client API key (case-sensitive match on stored key).
+func (cfg *Config) ClientAPIKeyModelAliases(clientKey string) []OAuthModelAlias {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.ClientAPIKeys.ModelAliasesFor(clientKey)
+}

--- a/internal/config/client_api_key_test.go
+++ b/internal/config/client_api_key_test.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestClientAPIKeysUnmarshalYAML_mixed(t *testing.T) {
+	raw := `
+api-keys:
+  - plain-key
+  - key: key-with-alias
+    model-aliases:
+      - name: deepseek-v4
+        alias: claude-opus-4.7
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cfg.SanitizeClientAPIKeys()
+	if len(cfg.ClientAPIKeys) != 2 {
+		t.Fatalf("len = %d, want 2", len(cfg.ClientAPIKeys))
+	}
+	if cfg.ClientAPIKeys[0].Key != "plain-key" || len(cfg.ClientAPIKeys[0].ModelAliases) != 0 {
+		t.Fatalf("entry0 = %#v", cfg.ClientAPIKeys[0])
+	}
+	if cfg.ClientAPIKeys[1].Key != "key-with-alias" {
+		t.Fatalf("entry1 key = %q", cfg.ClientAPIKeys[1].Key)
+	}
+	if len(cfg.ClientAPIKeys[1].ModelAliases) != 1 || cfg.ClientAPIKeys[1].ModelAliases[0].Alias != "claude-opus-4.7" {
+		t.Fatalf("entry1 aliases = %#v", cfg.ClientAPIKeys[1].ModelAliases)
+	}
+	keys := cfg.ClientAPIKeys.APIKeyStrings()
+	if len(keys) != 2 || keys[0] != "plain-key" {
+		t.Fatalf("APIKeyStrings = %#v", keys)
+	}
+}

--- a/internal/config/clone_test.go
+++ b/internal/config/clone_test.go
@@ -31,8 +31,8 @@ func TestCloneForRuntimeDeepCopiesConfig(t *testing.T) {
 	if clone.Home.Host != "home.local" {
 		t.Fatalf("clone.Home.Host = %q, want home.local", clone.Home.Host)
 	}
-	if clone.APIKeys[0] != "client-key" {
-		t.Fatalf("clone.APIKeys[0] = %q, want client-key", clone.APIKeys[0])
+	if clone.ClientAPIKeys[0].Key != "client-key" {
+		t.Fatalf("clone.ClientAPIKeys[0].Key = %q, want client-key", clone.ClientAPIKeys[0].Key)
 	}
 	if clone.OAuthExcludedModels["codex"][0] != "hidden-model" {
 		t.Fatalf("clone.OAuthExcludedModels[codex][0] = %q, want hidden-model", clone.OAuthExcludedModels["codex"][0])
@@ -50,7 +50,7 @@ func TestCloneForRuntimeDeepCopiesConfig(t *testing.T) {
 		t.Fatalf("clone payload object key = %#v, want value", got)
 	}
 
-	clone.APIKeys[0] = "clone-client-key"
+	clone.ClientAPIKeys[0].Key = "clone-client-key"
 	clone.OAuthExcludedModels["codex"][0] = "clone-hidden-model"
 	clone.OAuthModelAlias["codex"][0].Alias = "clone-client-model"
 	clone.OpenAICompatibility[0].Models[0].Thinking.Levels[0] = "clone-low"
@@ -59,8 +59,8 @@ func TestCloneForRuntimeDeepCopiesConfig(t *testing.T) {
 	setPluginRawScalar(t, &plugin.Raw, "mode", "third")
 	clone.Plugins.Configs["sample"] = plugin
 
-	if cfg.APIKeys[0] != "mutated-client-key" {
-		t.Fatalf("cfg.APIKeys[0] = %q, want mutated-client-key", cfg.APIKeys[0])
+	if cfg.ClientAPIKeys[0].Key != "mutated-client-key" {
+		t.Fatalf("cfg.ClientAPIKeys[0].Key = %q, want mutated-client-key", cfg.ClientAPIKeys[0].Key)
 	}
 	if cfg.OAuthExcludedModels["codex"][0] != "mutated-hidden-model" {
 		t.Fatalf("cfg.OAuthExcludedModels[codex][0] = %q, want mutated-hidden-model", cfg.OAuthExcludedModels["codex"][0])
@@ -94,7 +94,7 @@ func sampleCloneRuntimeConfig() *Config {
 
 	return &Config{
 		SDKConfig: SDKConfig{
-			APIKeys: []string{"client-key"},
+			ClientAPIKeys: ClientAPIKeys{{Key: "client-key"}},
 			Streaming: StreamingConfig{
 				KeepAliveSeconds: 3,
 				BootstrapRetries: 2,
@@ -194,7 +194,7 @@ func sampleCloneRuntimeConfig() *Config {
 
 func mutateOriginalConfig(cfg *Config) {
 	cfg.Home.Host = "mutated-home.local"
-	cfg.APIKeys[0] = "mutated-client-key"
+	cfg.ClientAPIKeys[0].Key = "mutated-client-key"
 	cfg.OAuthExcludedModels["codex"][0] = "mutated-hidden-model"
 	cfg.OAuthModelAlias["codex"][0].Alias = "mutated-client-model"
 	cfg.OpenAICompatibility[0].Models[0].Thinking.Levels[0] = "mutated-low"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -800,6 +800,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Normalize global OAuth model name aliases.
 	cfg.SanitizeOAuthModelAlias()
 
+	// Normalize client API keys and per-key model aliases.
+	cfg.SanitizeClientAPIKeys()
+
 	// Validate raw payload rules and drop invalid entries.
 	cfg.SanitizePayloadRules()
 

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -42,8 +42,8 @@ type SDKConfig struct {
 	// RequestLog enables or disables detailed request logging functionality.
 	RequestLog bool `yaml:"request-log" json:"request-log"`
 
-	// APIKeys is a list of keys for authenticating clients to this proxy server.
-	APIKeys []string `yaml:"api-keys" json:"api-keys"`
+	// ClientAPIKeys lists client credentials for accessing this proxy (see ClientAPIKey).
+	ClientAPIKeys ClientAPIKeys `yaml:"api-keys" json:"api-keys"`
 
 	// PassthroughHeaders controls whether upstream response headers are forwarded to downstream clients.
 	// Default is false (disabled).

--- a/internal/modelalias/client_api_key_listing.go
+++ b/internal/modelalias/client_api_key_listing.go
@@ -1,0 +1,101 @@
+package modelalias
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+// ApplyClientAPIKeyModelAliasesToOpenAIMaps rewrites OpenAI-style model maps for a client API key.
+func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, clientKey string, models []map[string]any) []map[string]any {
+	aliases := keys.ModelAliasesFor(clientKey)
+	if len(aliases) == 0 || len(models) == 0 {
+		return models
+	}
+	type aliasEntry struct {
+		alias string
+		fork  bool
+	}
+	forward := make(map[string][]aliasEntry, len(aliases))
+	for _, entry := range aliases {
+		name := strings.TrimSpace(entry.Name)
+		alias := strings.TrimSpace(entry.Alias)
+		if name == "" || alias == "" || strings.EqualFold(name, alias) {
+			continue
+		}
+		key := strings.ToLower(name)
+		forward[key] = append(forward[key], aliasEntry{alias: alias, fork: entry.Fork})
+	}
+	if len(forward) == 0 {
+		return models
+	}
+
+	out := make([]map[string]any, 0, len(models))
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		id, _ := model["id"].(string)
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		key := strings.ToLower(id)
+		entries := forward[key]
+		if len(entries) == 0 {
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, model)
+			continue
+		}
+
+		keepOriginal := false
+		for _, entry := range entries {
+			if entry.fork {
+				keepOriginal = true
+				break
+			}
+		}
+		if keepOriginal {
+			if _, exists := seen[key]; !exists {
+				seen[key] = struct{}{}
+				out = append(out, model)
+			}
+		}
+
+		addedAlias := false
+		for _, entry := range entries {
+			mappedID := strings.TrimSpace(entry.alias)
+			if mappedID == "" || strings.EqualFold(mappedID, id) {
+				continue
+			}
+			aliasKey := strings.ToLower(mappedID)
+			if _, exists := seen[aliasKey]; exists {
+				continue
+			}
+			seen[aliasKey] = struct{}{}
+			clone := make(map[string]any, len(model))
+			for k, v := range model {
+				clone[k] = v
+			}
+			clone["id"] = mappedID
+			out = append(out, clone)
+			addedAlias = true
+		}
+
+		if !keepOriginal && !addedAlias {
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, model)
+		}
+	}
+	if len(out) == 0 {
+		return models
+	}
+	return out
+}

--- a/internal/modelalias/client_api_key_listing.go
+++ b/internal/modelalias/client_api_key_listing.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ApplyClientAPIKeyModelAliasesToOpenAIMaps rewrites OpenAI-style model maps for a client API key.
-func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, clientKey string, models []map[string]any) []map[string]any {
+func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, clientKey string, models []map[string]any, compat []config.OpenAICompatibility) []map[string]any {
 	aliases := keys.ModelAliasesFor(clientKey)
 	if len(aliases) == 0 || len(models) == 0 {
 		return models
@@ -30,6 +30,24 @@ func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, client
 		return models
 	}
 
+	compatBridge := make(map[string]string)
+	for i := range compat {
+		if compat[i].Disabled {
+			continue
+		}
+		for _, model := range compat[i].Models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" {
+				continue
+			}
+			if alias == "" {
+				alias = name
+			}
+			compatBridge[strings.ToLower(alias)] = strings.ToLower(name)
+		}
+	}
+
 	out := make([]map[string]any, 0, len(models))
 	seen := make(map[string]struct{}, len(models))
 	for _, model := range models {
@@ -41,13 +59,18 @@ func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, client
 		if id == "" {
 			continue
 		}
-		key := strings.ToLower(id)
-		entries := forward[key]
+		entries := forward[strings.ToLower(id)]
 		if len(entries) == 0 {
-			if _, exists := seen[key]; exists {
+			if upstream, ok := compatBridge[strings.ToLower(id)]; ok {
+				entries = forward[upstream]
+			}
+		}
+		if len(entries) == 0 {
+			idKey := strings.ToLower(id)
+			if _, exists := seen[idKey]; exists {
 				continue
 			}
-			seen[key] = struct{}{}
+			seen[idKey] = struct{}{}
 			out = append(out, model)
 			continue
 		}
@@ -60,8 +83,9 @@ func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, client
 			}
 		}
 		if keepOriginal {
-			if _, exists := seen[key]; !exists {
-				seen[key] = struct{}{}
+			idKey := strings.ToLower(id)
+			if _, exists := seen[idKey]; !exists {
+				seen[idKey] = struct{}{}
 				out = append(out, model)
 			}
 		}
@@ -87,10 +111,11 @@ func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, client
 		}
 
 		if !keepOriginal && !addedAlias {
-			if _, exists := seen[key]; exists {
+			idKey := strings.ToLower(id)
+			if _, exists := seen[idKey]; exists {
 				continue
 			}
-			seen[key] = struct{}{}
+			seen[idKey] = struct{}{}
 			out = append(out, model)
 		}
 	}

--- a/internal/modelalias/client_api_key_listing.go
+++ b/internal/modelalias/client_api_key_listing.go
@@ -13,8 +13,9 @@ func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, client
 		return models
 	}
 	type aliasEntry struct {
-		alias string
-		fork  bool
+		upstream string
+		alias    string
+		fork     bool
 	}
 	forward := make(map[string][]aliasEntry, len(aliases))
 	for _, entry := range aliases {
@@ -24,12 +25,13 @@ func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, client
 			continue
 		}
 		key := strings.ToLower(name)
-		forward[key] = append(forward[key], aliasEntry{alias: alias, fork: entry.Fork})
+		forward[key] = append(forward[key], aliasEntry{upstream: name, alias: alias, fork: entry.Fork})
 	}
 	if len(forward) == 0 {
 		return models
 	}
 
+	// Supplier list ids are often global compat aliases; map them back to upstream names for per-key rules.
 	compatBridge := make(map[string]string)
 	for i := range compat {
 		if compat[i].Disabled {
@@ -48,6 +50,38 @@ func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, client
 		}
 	}
 
+	matchEntries := func(listID string) []aliasEntry {
+		listID = strings.TrimSpace(listID)
+		if listID == "" {
+			return nil
+		}
+		if entries := forward[strings.ToLower(listID)]; len(entries) > 0 {
+			return entries
+		}
+		if upstreamKey, ok := compatBridge[strings.ToLower(listID)]; ok {
+			return forward[upstreamKey]
+		}
+		return nil
+	}
+
+	appendClone := func(out *[]map[string]any, seen map[string]struct{}, base map[string]any, newID string) {
+		newID = strings.TrimSpace(newID)
+		if newID == "" {
+			return
+		}
+		key := strings.ToLower(newID)
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		clone := make(map[string]any, len(base))
+		for k, v := range base {
+			clone[k] = v
+		}
+		clone["id"] = newID
+		*out = append(*out, clone)
+	}
+
 	out := make([]map[string]any, 0, len(models))
 	seen := make(map[string]struct{}, len(models))
 	for _, model := range models {
@@ -59,12 +93,7 @@ func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, client
 		if id == "" {
 			continue
 		}
-		entries := forward[strings.ToLower(id)]
-		if len(entries) == 0 {
-			if upstream, ok := compatBridge[strings.ToLower(id)]; ok {
-				entries = forward[upstream]
-			}
-		}
+		entries := matchEntries(id)
 		if len(entries) == 0 {
 			idKey := strings.ToLower(id)
 			if _, exists := seen[idKey]; exists {
@@ -75,48 +104,11 @@ func ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys config.ClientAPIKeys, client
 			continue
 		}
 
-		keepOriginal := false
 		for _, entry := range entries {
 			if entry.fork {
-				keepOriginal = true
-				break
+				appendClone(&out, seen, model, entry.upstream)
 			}
-		}
-		if keepOriginal {
-			idKey := strings.ToLower(id)
-			if _, exists := seen[idKey]; !exists {
-				seen[idKey] = struct{}{}
-				out = append(out, model)
-			}
-		}
-
-		addedAlias := false
-		for _, entry := range entries {
-			mappedID := strings.TrimSpace(entry.alias)
-			if mappedID == "" || strings.EqualFold(mappedID, id) {
-				continue
-			}
-			aliasKey := strings.ToLower(mappedID)
-			if _, exists := seen[aliasKey]; exists {
-				continue
-			}
-			seen[aliasKey] = struct{}{}
-			clone := make(map[string]any, len(model))
-			for k, v := range model {
-				clone[k] = v
-			}
-			clone["id"] = mappedID
-			out = append(out, clone)
-			addedAlias = true
-		}
-
-		if !keepOriginal && !addedAlias {
-			idKey := strings.ToLower(id)
-			if _, exists := seen[idKey]; exists {
-				continue
-			}
-			seen[idKey] = struct{}{}
-			out = append(out, model)
+			appendClone(&out, seen, model, entry.alias)
 		}
 	}
 	if len(out) == 0 {

--- a/internal/modelalias/client_api_key_listing_test.go
+++ b/internal/modelalias/client_api_key_listing_test.go
@@ -1,0 +1,44 @@
+package modelalias
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestApplyClientAPIKeyModelAliasesToOpenAIMaps_CompatBridge(t *testing.T) {
+	keys := config.ClientAPIKeys{
+		{
+			Key: "sk-test",
+			ModelAliases: []config.OAuthModelAlias{
+				{Name: "mimo-v2.5", Alias: "gpt5.3", Fork: true},
+			},
+		},
+	}
+	models := []map[string]any{
+		{"id": "gpt5.5", "object": "model"},
+	}
+	compat := []config.OpenAICompatibility{
+		{
+			Name: "test",
+			Models: []config.OpenAICompatibilityModel{
+				{Name: "mimo-v2.5", Alias: "gpt5.5"},
+			},
+		},
+	}
+	out := ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys, "sk-test", models, compat)
+	ids := make([]string, 0, len(out))
+	for _, m := range out {
+		ids = append(ids, m["id"].(string))
+	}
+	want := map[string]bool{"gpt5.5": true, "gpt5.3": true}
+	for _, id := range ids {
+		if !want[id] {
+			t.Fatalf("unexpected id %q in %v", id, ids)
+		}
+		delete(want, id)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing ids %v, got %v", want, ids)
+	}
+}

--- a/internal/modelalias/client_api_key_listing_test.go
+++ b/internal/modelalias/client_api_key_listing_test.go
@@ -1,12 +1,13 @@
 package modelalias
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
-func TestApplyClientAPIKeyModelAliasesToOpenAIMaps_CompatBridge(t *testing.T) {
+func TestApplyClientAPIKeyModelAliasesToOpenAIMaps_CompatBridgeFork(t *testing.T) {
 	keys := config.ClientAPIKeys{
 		{
 			Key: "sk-test",
@@ -31,14 +32,54 @@ func TestApplyClientAPIKeyModelAliasesToOpenAIMaps_CompatBridge(t *testing.T) {
 	for _, m := range out {
 		ids = append(ids, m["id"].(string))
 	}
-	want := map[string]bool{"gpt5.5": true, "gpt5.3": true}
-	for _, id := range ids {
-		if !want[id] {
-			t.Fatalf("unexpected id %q in %v", id, ids)
-		}
-		delete(want, id)
+	sort.Strings(ids)
+	want := []string{"gpt5.3", "mimo-v2.5"}
+	if len(ids) != len(want) {
+		t.Fatalf("ids = %v, want %v", ids, want)
 	}
-	if len(want) != 0 {
-		t.Fatalf("missing ids %v, got %v", want, ids)
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("ids = %v, want %v", ids, want)
+		}
+	}
+}
+
+func TestApplyClientAPIKeyModelAliasesToOpenAIMaps_DevLikeFork(t *testing.T) {
+	keys := config.ClientAPIKeys{
+		{
+			Key: "sk-test",
+			ModelAliases: []config.OAuthModelAlias{
+				{Name: "mimo-v2.5", Alias: "gpt5.3", Fork: true},
+				{Name: "mimo-v2.5-pro", Alias: "opus4.8", Fork: true},
+			},
+		},
+	}
+	models := []map[string]any{
+		{"id": "opus4.5", "object": "model"},
+		{"id": "opus4.1", "object": "model"},
+	}
+	compat := []config.OpenAICompatibility{
+		{
+			Name: "test",
+			Models: []config.OpenAICompatibilityModel{
+				{Name: "mimo-v2.5", Alias: "opus4.5"},
+				{Name: "mimo-v2.5-pro", Alias: "opus4.1"},
+			},
+		},
+	}
+	out := ApplyClientAPIKeyModelAliasesToOpenAIMaps(keys, "sk-test", models, compat)
+	ids := make([]string, 0, len(out))
+	for _, m := range out {
+		ids = append(ids, m["id"].(string))
+	}
+	sort.Strings(ids)
+	want := []string{"gpt5.3", "mimo-v2.5", "mimo-v2.5-pro", "opus4.8"}
+	if len(ids) != len(want) {
+		t.Fatalf("ids = %v, want %v", ids, want)
+	}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("ids = %v, want %v", ids, want)
+		}
 	}
 }

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -249,9 +249,23 @@ func (c *Client) GetAPIKeys() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	var result []string
-	if err := json.Unmarshal(raw, &result); err != nil {
+	var mixed []json.RawMessage
+	if err := json.Unmarshal(raw, &mixed); err != nil {
 		return nil, err
+	}
+	result := make([]string, 0, len(mixed))
+	for _, item := range mixed {
+		var key string
+		if err := json.Unmarshal(item, &key); err == nil && strings.TrimSpace(key) != "" {
+			result = append(result, strings.TrimSpace(key))
+			continue
+		}
+		var entry struct {
+			Key string `json:"key"`
+		}
+		if err := json.Unmarshal(item, &entry); err == nil && strings.TrimSpace(entry.Key) != "" {
+			result = append(result, strings.TrimSpace(entry.Key))
+		}
 	}
 	return result, nil
 }
@@ -266,7 +280,7 @@ func (c *Client) AddAPIKey(key string) error {
 
 // EditAPIKey replaces an API key at the given index.
 func (c *Client) EditAPIKey(index int, newValue string) error {
-	body := map[string]any{"index": index, "value": newValue}
+	body := map[string]any{"index": index, "new": newValue}
 	jsonBody, _ := json.Marshal(body)
 	_, err := c.patch("/v0/management/api-keys", strings.NewReader(string(jsonBody)))
 	return err

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -114,9 +114,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	}
 
 	// API keys (redacted) and counts
-	if len(oldCfg.APIKeys) != len(newCfg.APIKeys) {
-		changes = append(changes, fmt.Sprintf("api-keys count: %d -> %d", len(oldCfg.APIKeys), len(newCfg.APIKeys)))
-	} else if !reflect.DeepEqual(trimStrings(oldCfg.APIKeys), trimStrings(newCfg.APIKeys)) {
+	if len(oldCfg.ClientAPIKeys) != len(newCfg.ClientAPIKeys) {
+		changes = append(changes, fmt.Sprintf("api-keys count: %d -> %d", len(oldCfg.ClientAPIKeys), len(newCfg.ClientAPIKeys)))
+	} else if !reflect.DeepEqual(oldCfg.ClientAPIKeys, newCfg.ClientAPIKeys) {
 		changes = append(changes, "api-keys: values updated (count unchanged, redacted)")
 	}
 	if len(oldCfg.GeminiKey) != len(newCfg.GeminiKey) {

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -165,7 +165,7 @@ func TestBuildConfigChangeDetails_NilSafe(t *testing.T) {
 func TestBuildConfigChangeDetails_SecretsAndCounts(t *testing.T) {
 	oldCfg := &config.Config{
 		SDKConfig: sdkconfig.SDKConfig{
-			APIKeys: []string{"a"},
+			ClientAPIKeys: config.ClientAPIKeys{{Key: "a"}},
 		},
 		RemoteManagement: config.RemoteManagement{
 			SecretKey: "",
@@ -173,7 +173,7 @@ func TestBuildConfigChangeDetails_SecretsAndCounts(t *testing.T) {
 	}
 	newCfg := &config.Config{
 		SDKConfig: sdkconfig.SDKConfig{
-			APIKeys: []string{"a", "b", "c"},
+			ClientAPIKeys: config.ClientAPIKeys{{Key: "a"}, {Key: "b"}, {Key: "c"}},
 		},
 		RemoteManagement: config.RemoteManagement{
 			SecretKey: "new-secret",
@@ -206,7 +206,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 		SDKConfig: sdkconfig.SDKConfig{
 			RequestLog:                 false,
 			ProxyURL:                   "http://old-proxy",
-			APIKeys:                    []string{"key-1"},
+			ClientAPIKeys:              config.ClientAPIKeys{{Key: "key-1"}},
 			ForceModelPrefix:           false,
 			NonStreamKeepAliveInterval: 0,
 		},
@@ -242,7 +242,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 		SDKConfig: sdkconfig.SDKConfig{
 			RequestLog:                 true,
 			ProxyURL:                   "http://new-proxy",
-			APIKeys:                    []string{" key-1 ", "key-2"},
+			ClientAPIKeys:              config.ClientAPIKeys{{Key: " key-1 "}, {Key: "key-2"}},
 			ForceModelPrefix:           true,
 			NonStreamKeepAliveInterval: 5,
 			DisableImageGeneration:     config.DisableImageGenerationAll,
@@ -312,9 +312,9 @@ func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 			SecretKey:              "old",
 		},
 		SDKConfig: sdkconfig.SDKConfig{
-			RequestLog: false,
-			ProxyURL:   "http://old-proxy",
-			APIKeys:    []string{" keyA "},
+			RequestLog:    false,
+			ProxyURL:      "http://old-proxy",
+			ClientAPIKeys: config.ClientAPIKeys{{Key: " keyA "}},
 		},
 		OAuthExcludedModels: map[string][]string{"p1": {"a"}},
 		OpenAICompatibility: []config.OpenAICompatibility{
@@ -363,7 +363,7 @@ func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 		SDKConfig: sdkconfig.SDKConfig{
 			RequestLog:             true,
 			ProxyURL:               "http://new-proxy",
-			APIKeys:                []string{"keyB"},
+			ClientAPIKeys:          config.ClientAPIKeys{{Key: "keyB"}},
 			DisableImageGeneration: config.DisableImageGenerationAll,
 		},
 		OAuthExcludedModels: map[string][]string{"p1": {"b", "c"}, "p2": {"d"}},

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -131,7 +131,7 @@ func (h *ClaudeCodeAPIHandler) ClaudeCountTokens(c *gin.Context) {
 // Parameters:
 //   - c: The Gin context for the request.
 func (h *ClaudeCodeAPIHandler) ClaudeModels(c *gin.Context) {
-	models := h.Models()
+	models := handlers.ApplyClientAPIKeyModelAliases(h.BaseAPIHandler, c, h.Models())
 	firstID := ""
 	lastID := ""
 	if len(models) > 0 {

--- a/sdk/api/handlers/client_api_key_execution.go
+++ b/sdk/api/handlers/client_api_key_execution.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"golang.org/x/net/context"
+)
+
+// resolveModelForProviderLookup applies per-client API key model aliases before registry-based
+// provider resolution. The returned model is used only for GetProviderName; execution still
+// receives the client-visible model via RequestedModelMetadataKey and conductor alias resolution.
+func (h *BaseAPIHandler) resolveModelForProviderLookup(ctx context.Context, modelName string) string {
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" || h == nil {
+		return modelName
+	}
+	clientKey := clientAPIKeyFromContext(ctx)
+	if clientKey == "" || h.AuthManager == nil {
+		return modelName
+	}
+	upstream := h.AuthManager.ApplyClientAPIKeyModelAlias(clientKey, modelName)
+	if strings.TrimSpace(upstream) == "" {
+		return modelName
+	}
+	return upstream
+}
+
+func clientAPIKeyFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil {
+		return clientAPIKeyFromGin(ginCtx)
+	}
+	return coreauth.ClientAPIKeyPrincipalFromContext(ctx)
+}
+
+// providersForModelName resolves provider keys for a model after auto-model and per-client alias rewrite.
+func (h *BaseAPIHandler) providersForModelName(ctx context.Context, resolvedModelName string) []string {
+	parsed := thinking.ParseSuffix(resolvedModelName)
+	baseModel := strings.TrimSpace(parsed.ModelName)
+	providers := util.GetProviderName(baseModel)
+	if len(providers) == 0 && baseModel != resolvedModelName {
+		providers = util.GetProviderName(resolvedModelName)
+	}
+	if len(providers) == 0 {
+		var cfg *internalconfig.Config
+		if h != nil && h.AuthManager != nil {
+			cfg = h.AuthManager.RuntimeConfig()
+		}
+		providers = openAICompatProvidersForUpstreamName(cfg, baseModel)
+	}
+	return providers
+}
+
+func openAICompatProvidersForUpstreamName(cfg *internalconfig.Config, upstreamName string) []string {
+	upstreamName = strings.TrimSpace(upstreamName)
+	if upstreamName == "" || cfg == nil {
+		return nil
+	}
+	out := make([]string, 0, 2)
+	seen := make(map[string]struct{})
+	for i := range cfg.OpenAICompatibility {
+		compat := &cfg.OpenAICompatibility[i]
+		if compat.Disabled {
+			continue
+		}
+		for _, model := range compat.Models {
+			if !strings.EqualFold(strings.TrimSpace(model.Name), upstreamName) {
+				continue
+			}
+			key := util.OpenAICompatibleProviderKey(compat.Name)
+			if key == "" {
+				continue
+			}
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, key)
+		}
+	}
+	return out
+}

--- a/sdk/api/handlers/client_api_key_execution_test.go
+++ b/sdk/api/handlers/client_api_key_execution_test.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestGetRequestDetails_ClientAPIKeyAliasOpenAICompat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mgr := coreauth.NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{
+		SDKConfig: internalconfig.SDKConfig{
+			ClientAPIKeys: internalconfig.ClientAPIKeys{
+				{Key: "sk-test", ModelAliases: []internalconfig.OAuthModelAlias{
+					{Name: "mimo-v2.5", Alias: "gpt5.3"},
+				}},
+			},
+		},
+		OpenAICompatibility: []internalconfig.OpenAICompatibility{
+			{
+				Name: "test",
+				Models: []internalconfig.OpenAICompatibilityModel{
+					{Name: "mimo-v2.5", Alias: "gpt5.5"},
+				},
+			},
+		},
+	})
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, mgr)
+
+	c, _ := gin.CreateTestContext(nil)
+	c.Set("userApiKey", "sk-test")
+	ctx := context.WithValue(context.Background(), "gin", c)
+
+	providers, model, errMsg := handler.getRequestDetails(ctx, "gpt5.3")
+	if errMsg != nil {
+		t.Fatalf("getRequestDetails() error = %+v", errMsg)
+	}
+	wantProvider := "openai-compatible-test"
+	if len(providers) != 1 || providers[0] != wantProvider {
+		t.Fatalf("providers = %v, want [%s]", providers, wantProvider)
+	}
+	if model != "gpt5.3" {
+		t.Fatalf("normalized model = %q, want gpt5.3", model)
+	}
+}
+
+func TestProvidersForModelName_OpenAICompatUpstream(t *testing.T) {
+	mgr := coreauth.NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{
+		OpenAICompatibility: []internalconfig.OpenAICompatibility{
+			{Name: "test", Models: []internalconfig.OpenAICompatibilityModel{
+				{Name: "mimo-v2.5", Alias: "gpt5.5"},
+			}},
+		},
+	})
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, mgr)
+	got := handler.providersForModelName(context.Background(), "mimo-v2.5")
+	want := []string{"openai-compatible-test"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("providers = %v, want %v", got, want)
+	}
+}

--- a/sdk/api/handlers/client_model_aliases.go
+++ b/sdk/api/handlers/client_model_aliases.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/modelalias"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
@@ -17,7 +18,13 @@ func ApplyClientAPIKeyModelAliases(h *BaseAPIHandler, c *gin.Context, models []m
 	if clientKey == "" {
 		return models
 	}
-	return modelalias.ApplyClientAPIKeyModelAliasesToOpenAIMaps(h.Cfg.ClientAPIKeys, clientKey, models)
+	var compat []internalconfig.OpenAICompatibility
+	if h.AuthManager != nil {
+		if cfg := h.AuthManager.RuntimeConfig(); cfg != nil {
+			compat = cfg.OpenAICompatibility
+		}
+	}
+	return modelalias.ApplyClientAPIKeyModelAliasesToOpenAIMaps(h.Cfg.ClientAPIKeys, clientKey, models, compat)
 }
 
 func clientAPIKeyFromGin(c *gin.Context) string {

--- a/sdk/api/handlers/client_model_aliases.go
+++ b/sdk/api/handlers/client_model_aliases.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/modelalias"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// ApplyClientAPIKeyModelAliases rewrites model list entries for the authenticated client API key.
+func ApplyClientAPIKeyModelAliases(h *BaseAPIHandler, c *gin.Context, models []map[string]any) []map[string]any {
+	if h == nil || h.Cfg == nil || c == nil {
+		return models
+	}
+	clientKey := clientAPIKeyFromGin(c)
+	if clientKey == "" {
+		return models
+	}
+	return modelalias.ApplyClientAPIKeyModelAliasesToOpenAIMaps(h.Cfg.ClientAPIKeys, clientKey, models)
+}
+
+func clientAPIKeyFromGin(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	if raw, ok := c.Get("userApiKey"); ok {
+		if key, ok := raw.(string); ok {
+			return strings.TrimSpace(key)
+		}
+	}
+	return coreauth.ClientAPIKeyPrincipalFromContext(c)
+}

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -713,7 +713,7 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 	if routeDecision.ExecutorPluginID != "" {
 		return h.executeWithPluginExecutor(ctx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, routeDecision.ExecutorPluginID, execOptions)
 	}
-	providers, normalizedModel, errMsg := h.providersForExecution(modelName, originalRequestedModel, allowImageModel, routeDecision)
+	providers, normalizedModel, errMsg := h.providersForExecution(ctx, modelName, originalRequestedModel, allowImageModel, routeDecision)
 	if errMsg != nil {
 		return nil, nil, errMsg
 	}
@@ -779,7 +779,7 @@ func (h *BaseAPIHandler) executeCountWithAuthManager(ctx context.Context, handle
 	if routeDecision.ExecutorPluginID != "" {
 		return h.countWithPluginExecutor(ctx, handlerType, modelName, originalRequestedModel, rawJSON, alt, routeDecision.ExecutorPluginID, execOptions)
 	}
-	providers, normalizedModel, errMsg := h.providersForExecution(modelName, originalRequestedModel, false, routeDecision)
+	providers, normalizedModel, errMsg := h.providersForExecution(ctx, modelName, originalRequestedModel, false, routeDecision)
 	if errMsg != nil {
 		return nil, nil, errMsg
 	}
@@ -1100,7 +1100,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	if routeDecision.ExecutorPluginID != "" {
 		return h.streamWithPluginExecutor(ctx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, routeDecision.ExecutorPluginID, execOptions)
 	}
-	providers, normalizedModel, errMsg := h.providersForExecution(modelName, originalRequestedModel, allowImageModel, routeDecision)
+	providers, normalizedModel, errMsg := h.providersForExecution(ctx, modelName, originalRequestedModel, allowImageModel, routeDecision)
 	if errMsg != nil {
 		errChan := make(chan *interfaces.ErrorMessage, 1)
 		errChan <- errMsg
@@ -1430,14 +1430,14 @@ func statusFromError(err error) int {
 	return 0
 }
 
-func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
-	return h.getRequestDetailsWithOptions(modelName, false)
+func (h *BaseAPIHandler) getRequestDetails(ctx context.Context, modelName string) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
+	return h.getRequestDetailsWithOptions(ctx, modelName, false)
 }
 
 // providersForExecution resolves the providers and normalized model for a request. When a model
 // router selected a built-in provider, it skips model->provider resolution and uses the router's
 // provider (with an optional target model); otherwise it falls back to the registry-based path.
-func (h *BaseAPIHandler) providersForExecution(modelName, originalRequestedModel string, allowImageModel bool, routeDecision modelRouteDecision) ([]string, string, *interfaces.ErrorMessage) {
+func (h *BaseAPIHandler) providersForExecution(ctx context.Context, modelName, originalRequestedModel string, allowImageModel bool, routeDecision modelRouteDecision) ([]string, string, *interfaces.ErrorMessage) {
 	if routeDecision.Provider != "" {
 		normalizedModel := originalRequestedModel
 		if routeDecision.Model != "" {
@@ -1448,10 +1448,10 @@ func (h *BaseAPIHandler) providersForExecution(modelName, originalRequestedModel
 		}
 		return []string{routeDecision.Provider}, normalizedModel, nil
 	}
-	return h.getRequestDetailsWithOptions(modelName, allowImageModel)
+	return h.getRequestDetailsWithOptions(ctx, modelName, allowImageModel)
 }
 
-func (h *BaseAPIHandler) getRequestDetailsWithOptions(modelName string, allowImageModel bool) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
+func (h *BaseAPIHandler) getRequestDetailsWithOptions(ctx context.Context, modelName string, allowImageModel bool) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
 	resolvedModelName := modelName
 	initialSuffix := thinking.ParseSuffix(modelName)
 	if initialSuffix.ModelName == "auto" {
@@ -1473,7 +1473,9 @@ func (h *BaseAPIHandler) getRequestDetailsWithOptions(modelName string, allowIma
 		}
 	}
 
-	parsed := thinking.ParseSuffix(resolvedModelName)
+	lookupModel := h.resolveModelForProviderLookup(ctx, resolvedModelName)
+
+	parsed := thinking.ParseSuffix(lookupModel)
 	baseModel := strings.TrimSpace(parsed.ModelName)
 
 	if errMsg := h.validateImageOnlyModel(baseModel, allowImageModel); errMsg != nil {
@@ -1484,14 +1486,14 @@ func (h *BaseAPIHandler) getRequestDetailsWithOptions(modelName string, allowIma
 		return []string{"home"}, resolvedModelName, nil
 	}
 
-	providers = util.GetProviderName(baseModel)
-	// Fallback: if baseModel has no provider but differs from resolvedModelName,
+	providers = h.providersForModelName(ctx, lookupModel)
+	// Fallback: if baseModel has no provider but differs from lookupModel,
 	// try using the full model name. This handles edge cases where custom models
 	// may be registered with their full suffixed name (e.g., "my-model(8192)").
 	// Evaluated in Story 11.8: This fallback is intentionally preserved to support
 	// custom model registrations that include thinking suffixes.
-	if len(providers) == 0 && baseModel != resolvedModelName {
-		providers = util.GetProviderName(resolvedModelName)
+	if len(providers) == 0 && baseModel != lookupModel {
+		providers = util.GetProviderName(lookupModel)
 	}
 
 	if len(providers) == 0 {

--- a/sdk/api/handlers/handlers_model_router_test.go
+++ b/sdk/api/handlers/handlers_model_router_test.go
@@ -455,7 +455,7 @@ func TestExecuteModelPropagatesRouterSkipPluginID(t *testing.T) {
 func TestHandlerProvidersForExecutionUsesRouterProvider(t *testing.T) {
 	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
 	decision := modelRouteDecision{Provider: "claude", Model: "claude-sonnet-4"}
-	providers, normalizedModel, errMsg := handler.providersForExecution("ignored-by-router", "original-model", false, decision)
+	providers, normalizedModel, errMsg := handler.providersForExecution(context.Background(), "ignored-by-router", "original-model", false, decision)
 	if errMsg != nil {
 		t.Fatalf("providersForExecution() error = %+v", errMsg)
 	}
@@ -470,7 +470,7 @@ func TestHandlerProvidersForExecutionUsesRouterProvider(t *testing.T) {
 func TestHandlerProvidersForExecutionFallsBackToOriginalModel(t *testing.T) {
 	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
 	decision := modelRouteDecision{Provider: "claude"}
-	providers, normalizedModel, errMsg := handler.providersForExecution("ignored-by-router", "original-model", false, decision)
+	providers, normalizedModel, errMsg := handler.providersForExecution(context.Background(), "ignored-by-router", "original-model", false, decision)
 	if errMsg != nil {
 		t.Fatalf("providersForExecution() error = %+v", errMsg)
 	}
@@ -532,7 +532,7 @@ func TestHandlerProvidersForExecutionRejectsImageOnlyModelOnProviderRoute(t *tes
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, errMsg := handler.providersForExecution("ignored", tc.originalModel, false, tc.decision)
+			_, _, errMsg := handler.providersForExecution(context.Background(), "ignored", tc.originalModel, false, tc.decision)
 			if errMsg == nil || errMsg.StatusCode != http.StatusServiceUnavailable {
 				t.Fatalf("providersForExecution() error = %+v, want image-only service unavailable", errMsg)
 			}

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"reflect"
 	"strings"
@@ -102,7 +103,7 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			providers, model, errMsg := handler.getRequestDetails(tt.inputModel)
+			providers, model, errMsg := handler.getRequestDetails(context.Background(), tt.inputModel)
 			if (errMsg != nil) != tt.wantErr {
 				t.Fatalf("getRequestDetails() error = %v, wantErr %v", errMsg, tt.wantErr)
 			}
@@ -122,7 +123,7 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 func TestGetRequestDetails_ImageModelReturns503(t *testing.T) {
 	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, coreauth.NewManager(nil, nil, nil))
 
-	_, _, errMsg := handler.getRequestDetails("gpt-image-2")
+	_, _, errMsg := handler.getRequestDetails(context.Background(), "gpt-image-2")
 	if errMsg == nil {
 		t.Fatalf("expected error for gpt-image-2, got nil")
 	}

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -66,6 +66,7 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 
 	// Get all available models
 	allModels := h.Models()
+	allModels = handlers.ApplyClientAPIKeyModelAliases(h.BaseAPIHandler, c, allModels)
 
 	// Filter to only include the 4 required fields: id, object, created, owned_by
 	filteredModels := make([]map[string]any, len(allModels))

--- a/sdk/cliproxy/auth/client_api_key_model_alias.go
+++ b/sdk/cliproxy/auth/client_api_key_model_alias.go
@@ -36,7 +36,7 @@ func compileClientAPIKeyModelAliasTable(entries internalconfig.ClientAPIKeys) cl
 			}
 		}
 		if len(rev) > 0 {
-			out[strings.ToLower(key)] = rev
+			out[key] = rev
 		}
 	}
 	if len(out) == 0 {
@@ -93,7 +93,7 @@ func (m *Manager) resolveClientAPIKeyModelAliasWithResult(clientKey, requestedMo
 	if len(table) == 0 {
 		return OAuthModelAliasResult{}
 	}
-	rev := table[strings.ToLower(clientKey)]
+	rev := table[clientKey]
 	if len(rev) == 0 {
 		return OAuthModelAliasResult{}
 	}

--- a/sdk/cliproxy/auth/client_api_key_model_alias.go
+++ b/sdk/cliproxy/auth/client_api_key_model_alias.go
@@ -149,6 +149,20 @@ func (m *Manager) applyClientAPIKeyModelAlias(clientKey, requestedModel string) 
 	return result.UpstreamModel
 }
 
+// ApplyClientAPIKeyModelAlias resolves the upstream model name for a client API key alias.
+func (m *Manager) ApplyClientAPIKeyModelAlias(clientKey, requestedModel string) string {
+	return m.applyClientAPIKeyModelAlias(clientKey, requestedModel)
+}
+
+// RuntimeConfig returns the latest application config snapshot used by the auth manager.
+func (m *Manager) RuntimeConfig() *internalconfig.Config {
+	if m == nil {
+		return nil
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	return cfg
+}
+
 func (m *Manager) resolveExecutionAliasResultForRequestedWithClient(ctx interface {
 	Value(any) any
 }, auth *Auth, requestedModel string) OAuthModelAliasResult {

--- a/sdk/cliproxy/auth/client_api_key_model_alias.go
+++ b/sdk/cliproxy/auth/client_api_key_model_alias.go
@@ -1,0 +1,160 @@
+package auth
+
+import (
+	"strings"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+type clientAPIKeyModelAliasTable map[string]map[string]oauthModelAliasEntry
+
+func compileClientAPIKeyModelAliasTable(entries internalconfig.ClientAPIKeys) clientAPIKeyModelAliasTable {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make(clientAPIKeyModelAliasTable, len(entries))
+	for _, entry := range entries {
+		key := strings.TrimSpace(entry.Key)
+		if key == "" || len(entry.ModelAliases) == 0 {
+			continue
+		}
+		rev := make(map[string]oauthModelAliasEntry, len(entry.ModelAliases))
+		for _, aliasEntry := range entry.ModelAliases {
+			name := strings.TrimSpace(aliasEntry.Name)
+			alias := strings.TrimSpace(aliasEntry.Alias)
+			if name == "" || alias == "" || strings.EqualFold(name, alias) {
+				continue
+			}
+			aliasKey := strings.ToLower(alias)
+			if _, exists := rev[aliasKey]; exists {
+				continue
+			}
+			rev[aliasKey] = oauthModelAliasEntry{
+				upstreamModel: name,
+				configAlias:   alias,
+				forceMapping:  aliasEntry.ForceMapping,
+			}
+		}
+		if len(rev) > 0 {
+			out[strings.ToLower(key)] = rev
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// SetClientAPIKeyModelAliases updates per-client API key model alias mappings.
+func (m *Manager) SetClientAPIKeyModelAliases(entries internalconfig.ClientAPIKeys) {
+	if m == nil {
+		return
+	}
+	table := compileClientAPIKeyModelAliasTable(entries)
+	m.clientAPIKeyModelAlias.Store(table)
+}
+
+func (m *Manager) clientAPIKeyModelAliasTable() clientAPIKeyModelAliasTable {
+	if m == nil {
+		return nil
+	}
+	raw := m.clientAPIKeyModelAlias.Load()
+	table, _ := raw.(clientAPIKeyModelAliasTable)
+	return table
+}
+
+// ClientAPIKeyPrincipalFromContext returns the authenticated client API key from a request context.
+func ClientAPIKeyPrincipalFromContext(ctx interface {
+	Value(any) any
+}) string {
+	if ctx == nil {
+		return ""
+	}
+	ginCtx, ok := ctx.Value("gin").(interface{ Get(string) (any, bool) })
+	if !ok || ginCtx == nil {
+		return ""
+	}
+	raw, ok := ginCtx.Get("userApiKey")
+	if !ok {
+		return ""
+	}
+	return contextStringValue(raw)
+}
+
+func (m *Manager) resolveClientAPIKeyModelAliasWithResult(clientKey, requestedModel string) OAuthModelAliasResult {
+	if m == nil {
+		return OAuthModelAliasResult{}
+	}
+	clientKey = strings.TrimSpace(clientKey)
+	if clientKey == "" {
+		return OAuthModelAliasResult{}
+	}
+	table := m.clientAPIKeyModelAliasTable()
+	if len(table) == 0 {
+		return OAuthModelAliasResult{}
+	}
+	rev := table[strings.ToLower(clientKey)]
+	if len(rev) == 0 {
+		return OAuthModelAliasResult{}
+	}
+	requestResult, candidates := modelAliasLookupCandidates(requestedModel)
+	if len(candidates) == 0 {
+		return OAuthModelAliasResult{}
+	}
+	baseModel := requestResult.ModelName
+	if baseModel == "" {
+		baseModel = strings.TrimSpace(requestedModel)
+	}
+	for _, candidate := range candidates {
+		key := strings.ToLower(strings.TrimSpace(candidate))
+		if key == "" {
+			continue
+		}
+		entry, exists := rev[key]
+		if !exists {
+			continue
+		}
+		targetModel := entry.upstreamModel
+		if targetModel == "" {
+			continue
+		}
+		if strings.EqualFold(targetModel, baseModel) {
+			if !entry.forceMapping {
+				return OAuthModelAliasResult{}
+			}
+			return OAuthModelAliasResult{
+				UpstreamModel: preserveResolvedModelSuffix(targetModel, requestResult),
+				ForceMapping:  entry.forceMapping,
+				OriginalAlias: oauthModelAliasForceMappingResponseModel(entry.configAlias),
+			}
+		}
+		originalAlias := requestedModel
+		if entry.forceMapping {
+			originalAlias = oauthModelAliasForceMappingResponseModel(entry.configAlias)
+		}
+		return OAuthModelAliasResult{
+			UpstreamModel: preserveResolvedModelSuffix(targetModel, requestResult),
+			ForceMapping:  entry.forceMapping,
+			OriginalAlias: originalAlias,
+		}
+	}
+	return OAuthModelAliasResult{}
+}
+
+func (m *Manager) applyClientAPIKeyModelAlias(clientKey, requestedModel string) string {
+	result := m.resolveClientAPIKeyModelAliasWithResult(clientKey, requestedModel)
+	if result.UpstreamModel == "" {
+		return requestedModel
+	}
+	return result.UpstreamModel
+}
+
+func (m *Manager) resolveExecutionAliasResultForRequestedWithClient(ctx interface {
+	Value(any) any
+}, auth *Auth, requestedModel string) OAuthModelAliasResult {
+	clientKey := ClientAPIKeyPrincipalFromContext(ctx)
+	if result := m.resolveClientAPIKeyModelAliasWithResult(clientKey, requestedModel); result.UpstreamModel != "" {
+		return result
+	}
+	return m.resolveExecutionAliasResultForRequested(auth, requestedModel)
+}

--- a/sdk/cliproxy/auth/client_api_key_model_alias_test.go
+++ b/sdk/cliproxy/auth/client_api_key_model_alias_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
 func TestResolveClientAPIKeyModelAliasWithResult(t *testing.T) {
@@ -26,6 +27,45 @@ func TestResolveClientAPIKeyModelAliasWithResult(t *testing.T) {
 	res2 := mgr.resolveClientAPIKeyModelAliasWithResult("key2", "gpt-5.5")
 	if res2.UpstreamModel != "deepseek-v4" {
 		t.Fatalf("key2 upstream = %q, want deepseek-v4", res2.UpstreamModel)
+	}
+}
+
+func TestResolveClientAPIKeyModelAliasWithResult_ForceMapping(t *testing.T) {
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetClientAPIKeyModelAliases(internalconfig.ClientAPIKeys{
+		{Key: "sk-test", ModelAliases: []internalconfig.OAuthModelAlias{
+			{Name: "mimo-v2.5", Alias: "gpt5.3", ForceMapping: true},
+		}},
+	})
+	res := mgr.resolveClientAPIKeyModelAliasWithResult("sk-test", "gpt5.3")
+	if res.UpstreamModel != "mimo-v2.5" || !res.ForceMapping || res.OriginalAlias != "gpt5.3" {
+		t.Fatalf("result = %+v", res)
+	}
+	resp := cliproxyexecutor.Response{Payload: []byte(`{"model":"mimo-v2.5","choices":[]}`)}
+	rewriteForceMappedResponse(&resp, res)
+	if string(resp.Payload) != `{"model":"gpt5.3","choices":[]}` {
+		t.Fatalf("payload = %s", resp.Payload)
+	}
+}
+
+func TestResolveExecutionAliasPerKeyBeforeGlobal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetClientAPIKeyModelAliases(internalconfig.ClientAPIKeys{
+		{Key: "sk-test", ModelAliases: []internalconfig.OAuthModelAlias{
+			{Name: "mimo-v2.5", Alias: "gpt5.3"},
+		}},
+	})
+	mgr.SetOAuthModelAlias(map[string][]internalconfig.OAuthModelAlias{
+		"openai-compatible-test": {{Name: "mimo-v2.5", Alias: "opus4.5"}},
+	})
+	c, _ := gin.CreateTestContext(nil)
+	c.Set("userApiKey", "sk-test")
+	ctx := context.WithValue(context.Background(), "gin", c)
+	auth := &Auth{Provider: "openai-compatibility", Attributes: map[string]string{"compat_name": "test"}}
+	res := mgr.resolveExecutionAliasResultForRequestedWithClient(ctx, auth, "gpt5.3")
+	if res.UpstreamModel != "mimo-v2.5" {
+		t.Fatalf("per-key upstream = %q, want mimo-v2.5 (not global opus4.5)", res.UpstreamModel)
 	}
 }
 

--- a/sdk/cliproxy/auth/client_api_key_model_alias_test.go
+++ b/sdk/cliproxy/auth/client_api_key_model_alias_test.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestResolveClientAPIKeyModelAliasWithResult(t *testing.T) {
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetClientAPIKeyModelAliases(internalconfig.ClientAPIKeys{
+		{Key: "key1", ModelAliases: []internalconfig.OAuthModelAlias{
+			{Name: "deepseek-v4", Alias: "claude-opus-4.7"},
+		}},
+		{Key: "key2", ModelAliases: []internalconfig.OAuthModelAlias{
+			{Name: "deepseek-v4", Alias: "gpt-5.5"},
+		}},
+	})
+
+	res1 := mgr.resolveClientAPIKeyModelAliasWithResult("key1", "claude-opus-4.7")
+	if res1.UpstreamModel != "deepseek-v4" {
+		t.Fatalf("key1 upstream = %q, want deepseek-v4", res1.UpstreamModel)
+	}
+	res2 := mgr.resolveClientAPIKeyModelAliasWithResult("key2", "gpt-5.5")
+	if res2.UpstreamModel != "deepseek-v4" {
+		t.Fatalf("key2 upstream = %q, want deepseek-v4", res2.UpstreamModel)
+	}
+}
+
+func TestClientAPIKeyPrincipalFromContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+	c.Set("userApiKey", "client-secret")
+	ctx := context.WithValue(context.Background(), "gin", c)
+	if got := ClientAPIKeyPrincipalFromContext(ctx); got != "client-secret" {
+		t.Fatalf("principal = %q", got)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1215,7 +1215,7 @@ func (m *Manager) preparedExecutionModelsWithAlias(ctx context.Context, auth *Au
 func (m *Manager) executionModelCandidatesWithAlias(ctx context.Context, auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult) {
 	requestedModel := rewriteModelForAuth(routeModel, auth)
 	aliasResult := m.resolveExecutionAliasResultForRequestedWithClient(ctx, auth, requestedModel)
-	upstreamModel := executionAliasPoolModel(auth, requestedModel, aliasResult)
+	upstreamModel := m.executionAliasPoolModel(ctx, auth, requestedModel, aliasResult)
 
 	var candidates []string
 	if auth != nil && auth.Attributes != nil {
@@ -1255,14 +1255,19 @@ func (m *Manager) resolveExecutionAliasResultForRequested(auth *Auth, requestedM
 	return m.applyOAuthModelAliasWithResult(auth, requestedModel)
 }
 
-func executionAliasPoolModel(auth *Auth, requestedModel string, aliasResult OAuthModelAliasResult) string {
+func (m *Manager) executionAliasPoolModel(ctx context.Context, auth *Auth, requestedModel string, aliasResult OAuthModelAliasResult) string {
+	if m != nil && ClientAPIKeyPrincipalFromContext(ctx) != "" {
+		if upstream := strings.TrimSpace(aliasResult.UpstreamModel); upstream != "" && !strings.EqualFold(upstream, requestedModel) {
+			return upstream
+		}
+	}
 	if auth != nil && auth.AuthKind() == AuthKindAPIKey {
 		if strings.TrimSpace(requestedModel) != "" {
 			return requestedModel
 		}
 	}
-	if strings.TrimSpace(aliasResult.UpstreamModel) != "" {
-		return aliasResult.UpstreamModel
+	if upstream := strings.TrimSpace(aliasResult.UpstreamModel); upstream != "" {
+		return upstream
 	}
 	return requestedModel
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1697,6 +1697,45 @@ func (m *Manager) routeModelKeysForAuthSelection(ctx context.Context, routeModel
 	for _, alt := range m.clientKeyRegistryModelKeysForRoute(ctx, routeModel) {
 		add(alt)
 	}
+	if cfg := m.RuntimeConfig(); cfg != nil {
+		for _, alt := range supplierRegistryKeysForUpstreamModel(cfg, routeModel) {
+			add(alt)
+		}
+	}
+	return out
+}
+
+func supplierRegistryKeysForUpstreamModel(cfg *internalconfig.Config, upstreamName string) []string {
+	upstreamName = strings.TrimSpace(upstreamName)
+	if upstreamName == "" || cfg == nil {
+		return nil
+	}
+	var out []string
+	seen := make(map[string]struct{})
+	for i := range cfg.OpenAICompatibility {
+		if cfg.OpenAICompatibility[i].Disabled {
+			continue
+		}
+		for _, model := range cfg.OpenAICompatibility[i].Models {
+			name := strings.TrimSpace(model.Name)
+			if name == "" || !strings.EqualFold(name, upstreamName) {
+				continue
+			}
+			alias := strings.TrimSpace(model.Alias)
+			if alias == "" {
+				alias = name
+			}
+			key := canonicalModelKey(alias)
+			if key == "" {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, key)
+		}
+	}
 	return out
 }
 
@@ -1805,6 +1844,13 @@ func (m *Manager) authSupportsRouteModel(ctx context.Context, registryRef *regis
 		}
 		if registryRef.ClientSupportsModel(auth.ID, alt) {
 			return true
+		}
+	}
+	if cfg := m.RuntimeConfig(); cfg != nil {
+		for _, alt := range supplierRegistryKeysForUpstreamModel(cfg, routeModel) {
+			if alt != "" && alt != routeKey && registryRef.ClientSupportsModel(auth.ID, alt) {
+				return true
+			}
 		}
 	}
 	selectionKey := m.selectionModelKeyForAuth(auth, routeModel)

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -244,6 +244,9 @@ type Manager struct {
 	// Keyed by auth.ID, value is alias(lower) -> upstream model (including suffix).
 	apiKeyModelAlias atomic.Value
 
+	// clientAPIKeyModelAlias maps client api-key (lower) -> alias(lower) -> upstream entry.
+	clientAPIKeyModelAlias atomic.Value
+
 	// modelPoolOffsets tracks per-auth alias pool rotation state.
 	modelPoolOffsets map[string]int
 
@@ -282,6 +285,7 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(&internalconfig.Config{})
 	manager.apiKeyModelAlias.Store(apiKeyModelAliasTable(nil))
+	manager.clientAPIKeyModelAlias.Store(clientAPIKeyModelAliasTable(nil))
 	manager.scheduler = newAuthScheduler(selector)
 	return manager
 }
@@ -508,6 +512,7 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 		cfg = &internalconfig.Config{}
 	}
 	m.runtimeConfig.Store(cfg)
+	m.SetClientAPIKeyModelAliases(cfg.ClientAPIKeys)
 	clearedCooldowns := m.clearDisabledCooldownStates(cfg)
 	if !cfg.Home.Enabled {
 		m.clearHomeRuntimeAuths()
@@ -1202,14 +1207,14 @@ func (m *Manager) preparedExecutionModels(auth *Auth, routeModel string) ([]stri
 	return m.filterExecutionModels(auth, routeModel, candidates, pooled), pooled
 }
 
-func (m *Manager) preparedExecutionModelsWithAlias(auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult) {
-	candidates, pooled, aliasResult := m.executionModelCandidatesWithAlias(auth, routeModel)
+func (m *Manager) preparedExecutionModelsWithAlias(ctx context.Context, auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult) {
+	candidates, pooled, aliasResult := m.executionModelCandidatesWithAlias(ctx, auth, routeModel)
 	return m.filterExecutionModels(auth, routeModel, candidates, pooled), pooled, aliasResult
 }
 
-func (m *Manager) executionModelCandidatesWithAlias(auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult) {
+func (m *Manager) executionModelCandidatesWithAlias(ctx context.Context, auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult) {
 	requestedModel := rewriteModelForAuth(routeModel, auth)
-	aliasResult := m.resolveExecutionAliasResultForRequested(auth, requestedModel)
+	aliasResult := m.resolveExecutionAliasResultForRequestedWithClient(ctx, auth, requestedModel)
 	upstreamModel := executionAliasPoolModel(auth, requestedModel, aliasResult)
 
 	var candidates []string
@@ -2507,7 +2512,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(ctx, auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
@@ -2609,7 +2614,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(ctx, auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
@@ -2709,7 +2714,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(ctx, auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
@@ -5134,7 +5139,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 		}
 		c.auth = preparedAuth
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth.ID)
-		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(c.auth, routeModel)
+		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(creditsCtx, c.auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
@@ -5185,7 +5190,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		}
 		c.auth = preparedAuth
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth.ID)
-		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(c.auth, routeModel)
+		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(creditsCtx, c.auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1631,7 +1631,44 @@ func (m *Manager) pickViaPluginScheduler(ctx context.Context, scheduler PluginSc
 	return m.pickViaBuiltinScheduler(ctx, strategy, providerKey, providers, model, opts, tried)
 }
 
-func (m *Manager) authSupportsRouteModel(registryRef *registry.ModelRegistry, auth *Auth, routeModel string) bool {
+func (m *Manager) clientKeyRegistryModelKeysForRoute(ctx context.Context, routeModel string) []string {
+	if m == nil {
+		return nil
+	}
+	clientKey := ClientAPIKeyPrincipalFromContext(ctx)
+	if clientKey == "" {
+		return nil
+	}
+	result := m.resolveClientAPIKeyModelAliasWithResult(clientKey, routeModel)
+	upstream := strings.TrimSpace(result.UpstreamModel)
+	if upstream == "" || strings.EqualFold(upstream, routeModel) {
+		return nil
+	}
+	keys := []string{canonicalModelKey(upstream)}
+	cfg := m.RuntimeConfig()
+	if cfg != nil {
+		for i := range cfg.OpenAICompatibility {
+			if cfg.OpenAICompatibility[i].Disabled {
+				continue
+			}
+			for _, model := range cfg.OpenAICompatibility[i].Models {
+				name := strings.TrimSpace(model.Name)
+				alias := strings.TrimSpace(model.Alias)
+				if alias == "" {
+					alias = name
+				}
+				if name != "" && strings.EqualFold(name, upstream) && alias != "" {
+					keys = append(keys, canonicalModelKey(alias))
+					break
+				}
+			}
+		}
+	}
+	keys = append(keys, canonicalModelKey(routeModel))
+	return keys
+}
+
+func (m *Manager) authSupportsRouteModel(ctx context.Context, registryRef *registry.ModelRegistry, auth *Auth, routeModel string) bool {
 	if registryRef == nil || auth == nil {
 		return true
 	}
@@ -1641,6 +1678,14 @@ func (m *Manager) authSupportsRouteModel(registryRef *registry.ModelRegistry, au
 	}
 	if registryRef.ClientSupportsModel(auth.ID, routeKey) {
 		return true
+	}
+	for _, alt := range m.clientKeyRegistryModelKeysForRoute(ctx, routeModel) {
+		if alt == "" || alt == routeKey {
+			continue
+		}
+		if registryRef.ClientSupportsModel(auth.ID, alt) {
+			return true
+		}
 	}
 	selectionKey := m.selectionModelKeyForAuth(auth, routeModel)
 	return selectionKey != "" && selectionKey != routeKey && registryRef.ClientSupportsModel(auth.ID, selectionKey)
@@ -4335,7 +4380,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		if _, used := tried[candidate.ID]; used {
 			continue
 		}
-		if modelKey != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
+		if modelKey != "" && !m.authSupportsRouteModel(ctx, registryRef, candidate, model) {
 			continue
 		}
 		candidates = append(candidates, candidate)
@@ -4495,7 +4540,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		if _, ok := m.executors[providerKey]; !ok {
 			continue
 		}
-		if modelKey != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
+		if modelKey != "" && !m.authSupportsRouteModel(ctx, registryRef, candidate, model) {
 			continue
 		}
 		candidates = append(candidates, candidate)

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1567,16 +1567,16 @@ func (m *Manager) pickViaBuiltinScheduler(ctx context.Context, strategy schedule
 		var selected *Auth
 		var errPick error
 		if providerKey == "mixed" {
-			selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
+			selected, _, errPick = m.schedulerPickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
 			if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
 				m.syncScheduler()
-				selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
+				selected, _, errPick = m.schedulerPickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
 			}
 		} else {
-			selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
+			selected, errPick = m.schedulerPickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
 			if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
 				m.syncScheduler()
-				selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
+				selected, errPick = m.schedulerPickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
 			}
 		}
 		if errPick != nil {
@@ -1666,6 +1666,121 @@ func (m *Manager) clientKeyRegistryModelKeysForRoute(ctx context.Context, routeM
 	}
 	keys = append(keys, canonicalModelKey(routeModel))
 	return keys
+}
+
+// routeModelKeysForAuthSelection returns model shard keys to try when selecting auth for a client route model.
+// Per-client aliases may use ids that are not registered on auths; fall back to supplier/global registry ids.
+func (m *Manager) routeModelKeysForAuthSelection(ctx context.Context, routeModel string) []string {
+	routeModel = strings.TrimSpace(routeModel)
+	if routeModel == "" {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	out := make([]string, 0, 4)
+	add := func(key string) {
+		key = canonicalModelKey(key)
+		if key == "" {
+			return
+		}
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	add(routeModel)
+	for _, alt := range m.clientKeyRegistryModelKeysForRoute(ctx, routeModel) {
+		add(alt)
+	}
+	return out
+}
+
+func (m *Manager) schedulerPickSingle(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, error) {
+	if m == nil || m.scheduler == nil {
+		return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+	}
+	keys := m.routeModelKeysForAuthSelection(ctx, model)
+	if len(keys) == 0 {
+		return m.scheduler.pickSingle(ctx, provider, model, opts, tried)
+	}
+	var lastErr error
+	for _, key := range keys {
+		picked, errPick := m.scheduler.pickSingle(ctx, provider, key, opts, tried)
+		if errPick == nil && picked != nil {
+			return picked, nil
+		}
+		lastErr = errPick
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+}
+
+func (m *Manager) schedulerPickSingleWithStrategy(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}, strategy schedulerStrategy) (*Auth, error) {
+	if m == nil || m.scheduler == nil {
+		return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+	}
+	keys := m.routeModelKeysForAuthSelection(ctx, model)
+	if len(keys) == 0 {
+		return m.scheduler.pickSingleWithStrategy(ctx, provider, model, opts, tried, strategy)
+	}
+	var lastErr error
+	for _, key := range keys {
+		picked, errPick := m.scheduler.pickSingleWithStrategy(ctx, provider, key, opts, tried, strategy)
+		if errPick == nil && picked != nil {
+			return picked, nil
+		}
+		lastErr = errPick
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+}
+
+func (m *Manager) schedulerPickMixed(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, string, error) {
+	if m == nil || m.scheduler == nil {
+		return nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
+	}
+	keys := m.routeModelKeysForAuthSelection(ctx, model)
+	if len(keys) == 0 {
+		return m.scheduler.pickMixed(ctx, providers, model, opts, tried)
+	}
+	var lastErr error
+	for _, key := range keys {
+		picked, providerKey, errPick := m.scheduler.pickMixed(ctx, providers, key, opts, tried)
+		if errPick == nil && picked != nil {
+			return picked, providerKey, nil
+		}
+		lastErr = errPick
+	}
+	if lastErr != nil {
+		return nil, "", lastErr
+	}
+	return nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
+}
+
+func (m *Manager) schedulerPickMixedWithStrategy(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}, strategy schedulerStrategy) (*Auth, string, error) {
+	if m == nil || m.scheduler == nil {
+		return nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
+	}
+	keys := m.routeModelKeysForAuthSelection(ctx, model)
+	if len(keys) == 0 {
+		return m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
+	}
+	var lastErr error
+	for _, key := range keys {
+		picked, providerKey, errPick := m.scheduler.pickMixedWithStrategy(ctx, providers, key, opts, tried, strategy)
+		if errPick == nil && picked != nil {
+			return picked, providerKey, nil
+		}
+		lastErr = errPick
+	}
+	if lastErr != nil {
+		return nil, "", lastErr
+	}
+	return nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 }
 
 func (m *Manager) authSupportsRouteModel(ctx context.Context, registryRef *registry.ModelRegistry, auth *Auth, routeModel string) bool {
@@ -4453,10 +4568,10 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 	}
 	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
 	for {
-		selected, errPick := m.scheduler.pickSingle(ctx, provider, model, opts, tried)
+		selected, errPick := m.schedulerPickSingle(ctx, provider, model, opts, tried)
 		if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
 			m.syncScheduler()
-			selected, errPick = m.scheduler.pickSingle(ctx, provider, model, opts, tried)
+			selected, errPick = m.schedulerPickSingle(ctx, provider, model, opts, tried)
 		}
 		if errPick != nil {
 			return nil, nil, errPick
@@ -4641,10 +4756,10 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 
 	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
 	for {
-		selected, providerKey, errPick := m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
+		selected, providerKey, errPick := m.schedulerPickMixed(ctx, eligibleProviders, model, opts, tried)
 		if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
 			m.syncScheduler()
-			selected, providerKey, errPick = m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
+			selected, providerKey, errPick = m.schedulerPickMixed(ctx, eligibleProviders, model, opts, tried)
 		}
 		if errPick != nil {
 			return nil, nil, "", errPick

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1407,7 +1407,7 @@ func forceHomeRuntimeConfig(cfg *config.Config) {
 	if cfg == nil {
 		return
 	}
-	cfg.APIKeys = nil
+	cfg.ClientAPIKeys = nil
 	cfg.UsageStatisticsEnabled = true
 	cfg.DisableCooling = true
 	cfg.SaveCooldownStatus = false
@@ -2631,6 +2631,11 @@ func oauthModelAliasesForAuth(cfg *config.Config, channel string, attributes map
 	add(perAuthAliases)
 	add(globalAliases)
 	return out
+}
+
+// ApplyOAuthModelAliasEntries rewrites model listings using the same rules as global OAuth aliases.
+func ApplyOAuthModelAliasEntries(aliases []config.OAuthModelAlias, models []*ModelInfo) []*ModelInfo {
+	return applyOAuthModelAliasEntries(aliases, models)
 }
 
 func applyOAuthModelAliasEntries(aliases []config.OAuthModelAlias, models []*ModelInfo) []*ModelInfo {

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -28,6 +28,9 @@ type OpenAICompatibility = internalconfig.OpenAICompatibility
 type OpenAICompatibilityAPIKey = internalconfig.OpenAICompatibilityAPIKey
 type OpenAICompatibilityModel = internalconfig.OpenAICompatibilityModel
 
+type ClientAPIKey = internalconfig.ClientAPIKey
+type ClientAPIKeys = internalconfig.ClientAPIKeys
+
 type TLS = internalconfig.TLSConfig
 
 const (


### PR DESCRIPTION
## Summary

Adds **per-client API key** model aliases so different `api-keys` entries can expose the **same upstream model** under **different client-visible names** (e.g. key A maps `deepseek-v4` → `claude-opus-4.7`, key B maps `deepseek-v4` → `gpt-5.5`).

Rules match global **`oauth-model-alias`** (`name`, `alias`, `fork`, `force-mapping`). When a request is authenticated with a client API key, **per-key aliases take precedence** over global OAuth / supplier model mappings for listing and execution.

## Motivation

Global `oauth-model-alias` is one mapping per OAuth channel for the whole proxy. Multi-tenant or multi-client setups need **different outward model names per client key** without duplicating upstream credentials.

## Config (backward compatible)

`api-keys` still accepts plain strings. Object entries add optional `model-aliases`:

```yaml
api-keys:
  - key: sk-client-a
    model-aliases:
      - name: mimo-v2.5
        alias: gpt5.3
        fork: true
        force-mapping: true
```

## Behavior

- **`/v1/models`**: rewrites the model list for the authenticated client key (`ApplyClientAPIKeyModelAliases`), including **fork** (keep upstream `name` alongside `alias`) and OpenAI-compat supplier alias bridging.
- **Chat / execution**: resolves providers and auth using per-key aliases before registry lookup; OpenAI-compat scheduler/auth selection tries registry shard keys for per-key aliases and fork-listed upstream names.
- **Responses**: `force-mapping` rewrites upstream `model` in responses when configured on the per-key entry (same as OAuth alias force-mapping).

## Management API

`GET` / `PUT` / `PATCH` `/api-keys` support `key` + `model-aliases` (existing string-only payloads remain valid).

## Testing

```bash
gofmt -w .
go test ./internal/config/... ./internal/modelalias/... ./sdk/cliproxy/auth/... ./sdk/api/handlers/...
go build -o test-output ./cmd/server && rm test-output
```

Manually verified on a dev deployment: per-key alias listing, fork upstream ids, force-mapping response `model`, and per-key priority over supplier/global compat aliases.

## Out of scope (separate repos)

UI for editing `model-aliases` lives in community Management Center forks (e.g. `Cli-Proxy-API-Management-Center`); this PR is **server + management API only**.

## Checklist

- [x] No changes under `internal/translator/`
- [x] `config.example.yaml` updated
- [x] Unit tests for config, listing, auth alias resolution, and handler provider lookup