### PR TITLE
fix(translator): handle image arrays in tool_result and drop reasoning replay for Claude

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -50,7 +50,7 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 	userID := fmt.Sprintf("user_%s_account_%s_session_%s", user, account, session)
 
 	// Base Claude message payload
-	out := []byte(fmt.Sprintf(`{"model":"","max_tokens":32000,"messages":[],"metadata":{"user_id":"%s"}}`, userID))
+	out := []byte(fmt.Sprintf(`{"model":"","max_tokens":32000,"messages":[],"metadata":{"user_id":"%s"},"cache_control":{"type":"ephemeral"}}`, userID))
 
 	root := gjson.ParseBytes(rawJSON)
 
@@ -473,6 +473,11 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 		}
 	}
 
+	out = normalizeMessageContent(out)
+	out = stripModelSwitchPrompt(out)
+	out = truncateLargeToolResults(out)
+	out = stripOldImages(out)
+
 	return out
 }
 
@@ -773,4 +778,188 @@ func isUnsupportedOpenAIBuiltinToolType(toolType string) bool {
 	default:
 		return false
 	}
+}
+
+// maxRetainedUserImageTurns controls how many recent user turns keep their
+// images. Older user turns have images replaced with a placeholder. This
+// balances cache stability (fewer replacements = fewer cache rebuilds) against
+// request size growth (more images = larger payload).
+const maxRetainedUserImageTurns = 6
+
+// stripOldImages keeps images only in the most recent N user turns (counted by
+// role:"user" messages). All earlier user turn images are replaced with
+// [image omitted]. A hard 28MB byte cap acts as a safety net for extreme cases.
+func stripOldImages(out []byte) []byte {
+	placeholder := []byte(`{"type":"text","text":"[image omitted]"}`)
+
+	// Collect indices of all user messages.
+	var userTurnIndices []int64
+	gjson.GetBytes(out, "messages").ForEach(func(mi, msg gjson.Result) bool {
+		if msg.Get("role").String() == "user" {
+			userTurnIndices = append(userTurnIndices, mi.Int())
+		}
+		return true
+	})
+
+	// Determine cutoff: keep the last maxRetainedUserImageTurns user turns.
+	cutoff := len(userTurnIndices) - maxRetainedUserImageTurns
+	if cutoff <= 0 {
+		// Fewer than N user turns total; nothing to strip.
+		cutoff = 0
+	}
+	cutoffMsgIdx := int64(-1)
+	if cutoff > 0 {
+		cutoffMsgIdx = userTurnIndices[cutoff]
+	}
+
+	// Replace images in messages before the cutoff.
+	if cutoffMsgIdx > 0 {
+		for {
+			path := firstImagePathBefore(out, cutoffMsgIdx)
+			if path == "" {
+				break
+			}
+			nb, err := sjson.SetRawBytes(out, path, placeholder)
+			if err != nil {
+				break
+			}
+			out = nb
+		}
+	}
+
+	// Hard 28MB cap as safety net.
+	const limit = 28 * 1024 * 1024
+	for len(out) > limit {
+		path := firstImagePathBefore(out, -1)
+		if path == "" {
+			break
+		}
+		nb, err := sjson.SetRawBytes(out, path, placeholder)
+		if err != nil {
+			break
+		}
+		out = nb
+	}
+	return out
+}
+
+// firstImagePathBefore returns the sjson path of the first image block in
+// messages with index < beforeIdx. Pass beforeIdx == -1 to match all messages.
+func firstImagePathBefore(out []byte, beforeIdx int64) string {
+	found := ""
+	gjson.GetBytes(out, "messages").ForEach(func(mi, msg gjson.Result) bool {
+		if beforeIdx >= 0 && mi.Int() >= beforeIdx {
+			return false // stop: reached the protected turn
+		}
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(ci, part gjson.Result) bool {
+			switch part.Get("type").String() {
+			case "image":
+				found = fmt.Sprintf("messages.%d.content.%d", mi.Int(), ci.Int())
+				return false
+			case "tool_result":
+				inner := part.Get("content")
+				if inner.IsArray() {
+					inner.ForEach(func(ii, ipart gjson.Result) bool {
+						if ipart.Get("type").String() == "image" {
+							found = fmt.Sprintf("messages.%d.content.%d.content.%d", mi.Int(), ci.Int(), ii.Int())
+							return false
+						}
+						return true
+					})
+				}
+				if found != "" {
+					return false
+				}
+			}
+			return true
+		})
+		return found == ""
+	})
+	return found
+}
+
+// normalizeMessageContent ensures every message's content field is an array of
+// typed blocks, never a bare string. This stabilizes the JSON byte sequence
+// across turns so Anthropic prompt caching can match longer prefixes.
+func normalizeMessageContent(out []byte) []byte {
+	msgs := gjson.GetBytes(out, "messages")
+	if !msgs.Exists() || !msgs.IsArray() {
+		return out
+	}
+	msgs.ForEach(func(mi, msg gjson.Result) bool {
+		c := msg.Get("content")
+		if c.Type == gjson.String {
+			block := []byte(`{"type":"text","text":""}`)
+			block, _ = sjson.SetBytes(block, "text", c.String())
+			arr := []byte(`[]`)
+			arr, _ = sjson.SetRawBytes(arr, "-1", block)
+			path := fmt.Sprintf("messages.%d.content", mi.Int())
+			out, _ = sjson.SetRawBytes(out, path, arr)
+		}
+		return true
+	})
+	return out
+}
+
+// stripModelSwitchPrompt detects <model_switch> blocks that contain a full
+// duplicate of the system prompt and replaces them with a short summary.
+// This saves ~5,700 tokens per occurrence (typically 3x in a long session).
+func stripModelSwitchPrompt(out []byte) []byte {
+	const tag = "<model_switch>"
+	const replacement = "<model_switch>\nThe user switched models. Continue the conversation following the system instructions from the first message.\n</model_switch>"
+
+	gjson.GetBytes(out, "messages").ForEach(func(mi, msg gjson.Result) bool {
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(ci, part gjson.Result) bool {
+			if part.Get("type").String() != "text" {
+				return true
+			}
+			text := part.Get("text").String()
+			if len(text) > 1000 && strings.Contains(text, tag) {
+				path := fmt.Sprintf("messages.%d.content.%d.text", mi.Int(), ci.Int())
+				out, _ = sjson.SetBytes(out, path, replacement)
+			}
+			return true
+		})
+		return true
+	})
+	return out
+}
+
+// truncateLargeToolResults truncates tool_result content strings that exceed
+// a threshold, keeping the head and tail to preserve useful context while
+// cutting out the middle bulk. This targets cases like large log dumps that
+// bloat the payload without adding value to later turns.
+func truncateLargeToolResults(out []byte) []byte {
+	const maxLen = 8192
+	const keepEach = 2048
+
+	gjson.GetBytes(out, "messages").ForEach(func(mi, msg gjson.Result) bool {
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(ci, part gjson.Result) bool {
+			if part.Get("type").String() != "tool_result" {
+				return true
+			}
+			inner := part.Get("content")
+			if inner.Type == gjson.String && len(inner.String()) > maxLen {
+				text := inner.String()
+				truncated := text[:keepEach] + "\n\n[...truncated " + fmt.Sprintf("%d", len(text)-2*keepEach) + " chars...]\n\n" + text[len(text)-keepEach:]
+				path := fmt.Sprintf("messages.%d.content.%d.content", mi.Int(), ci.Int())
+				out, _ = sjson.SetBytes(out, path, truncated)
+			}
+			return true
+		})
+		return true
+	})
+	return out
 }

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
-	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
@@ -362,9 +361,10 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 				}
 
 			case "reasoning":
-				if thinkingPart := convertResponsesReasoningToClaudeThinking(item); len(thinkingPart) > 0 {
-					pendingReasoningParts = append(pendingReasoningParts, string(thinkingPart))
-				}
+				// Do not reconstruct Claude thinking blocks from OpenAI Responses
+				// reasoning items. Claude requires replayed thinking blocks in the
+				// latest assistant message to remain byte-for-byte equivalent to the
+				// original response; Responses summaries are not that original text.
 
 			case "function_call":
 				// Map to assistant tool_use
@@ -403,10 +403,9 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 				callID := item.Get("call_id").String()
 				callID = util.SanitizeClaudeToolID(callID)
 				flushPendingToolUseFor(callID)
-				outputStr := item.Get("output").String()
 				toolResult := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
 				toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", callID)
-				toolResult, _ = sjson.SetBytes(toolResult, "content", outputStr)
+				toolResult = setResponsesToolResultContent(toolResult, item.Get("output"))
 
 				usr := []byte(`{"role":"user","content":[]}`)
 				usr, _ = sjson.SetRawBytes(usr, "content.-1", toolResult)
@@ -477,32 +476,87 @@ func ConvertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 	return out
 }
 
-func convertResponsesReasoningToClaudeThinking(item gjson.Result) []byte {
-	signature, ok := sigcompat.CompatibleSignatureForProvider(sigcompat.SignatureProviderClaude, item.Get("encrypted_content").String())
-	if !ok {
-		return nil
-	}
-
-	thinkingText := responsesReasoningSummaryText(item)
-	thinkingPart := []byte(`{"type":"thinking","thinking":"","signature":""}`)
-	thinkingPart, _ = sjson.SetBytes(thinkingPart, "thinking", thinkingText)
-	thinkingPart, _ = sjson.SetBytes(thinkingPart, "signature", signature)
-	return thinkingPart
-}
-
-func responsesReasoningSummaryText(item gjson.Result) string {
-	var builder strings.Builder
-	if summary := item.Get("summary"); summary.Exists() && summary.IsArray() {
-		summary.ForEach(func(_, part gjson.Result) bool {
-			if text := part.Get("text"); text.Exists() {
-				builder.WriteString(text.String())
-			} else if part.Type == gjson.String {
-				builder.WriteString(part.String())
+func setResponsesToolResultContent(toolResult []byte, output gjson.Result) []byte {
+	if output.IsArray() {
+		content := []byte(`[]`)
+		added := false
+		output.ForEach(func(_, part gjson.Result) bool {
+			switch part.Get("type").String() {
+			case "input_text", "output_text", "text":
+				text := part.Get("text").String()
+				textPart := []byte(`{"type":"text","text":""}`)
+				textPart, _ = sjson.SetBytes(textPart, "text", text)
+				content, _ = sjson.SetRawBytes(content, "-1", textPart)
+				added = true
+			case "input_image", "image":
+				if imagePart := convertResponsesImagePartToClaudeImage(part); len(imagePart) > 0 {
+					content, _ = sjson.SetRawBytes(content, "-1", imagePart)
+					added = true
+				}
 			}
 			return true
 		})
+		if added {
+			toolResult, _ = sjson.SetRawBytes(toolResult, "content", content)
+			return toolResult
+		}
 	}
-	return builder.String()
+
+	toolResult, _ = sjson.SetBytes(toolResult, "content", output.String())
+	return toolResult
+}
+
+func convertResponsesImagePartToClaudeImage(part gjson.Result) []byte {
+	url := part.Get("image_url").String()
+	if url == "" {
+		url = part.Get("url").String()
+	}
+	if url == "" {
+		source := part.Get("source")
+		if source.Exists() {
+			data := source.Get("data").String()
+			if data == "" {
+				data = source.Get("base64").String()
+			}
+			if data != "" {
+				mediaType := source.Get("media_type").String()
+				if mediaType == "" {
+					mediaType = source.Get("mime_type").String()
+				}
+				if mediaType == "" {
+					mediaType = "application/octet-stream"
+				}
+				url = fmt.Sprintf("data:%s;base64,%s", mediaType, data)
+			}
+		}
+	}
+	if url == "" {
+		return nil
+	}
+
+	if strings.HasPrefix(url, "data:") {
+		trimmed := strings.TrimPrefix(url, "data:")
+		mediaAndData := strings.SplitN(trimmed, ";base64,", 2)
+		mediaType := "application/octet-stream"
+		data := ""
+		if len(mediaAndData) == 2 {
+			if mediaAndData[0] != "" {
+				mediaType = mediaAndData[0]
+			}
+			data = mediaAndData[1]
+		}
+		if data == "" {
+			return nil
+		}
+		contentPart := []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
+		contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
+		contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
+		return contentPart
+	}
+
+	contentPart := []byte(`{"type":"image","source":{"type":"url","url":""}}`)
+	contentPart, _ = sjson.SetBytes(contentPart, "source.url", url)
+	return contentPart
 }
 
 func convertResponsesToolToClaudeTools(tool gjson.Result, toolNameMap map[string]string) [][]byte {

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -40,8 +40,8 @@ func TestConvertOpenAIResponsesRequestToClaude_SanitizesToolCallIDsForClaude(t *
 	}
 }
 
-func TestConvertOpenAIResponsesRequestToClaude_ReasoningItemToThinkingBlock(t *testing.T) {
-	rawSignature, expectedSignature := testClaudeResponsesThinkingSignature(t)
+func TestConvertOpenAIResponsesRequestToClaude_DropsReasoningItems(t *testing.T) {
+	rawSignature, _ := testClaudeResponsesThinkingSignature(t)
 	raw := []byte(`{
 		"model":"claude-test",
 		"input":[
@@ -70,19 +70,7 @@ func TestConvertOpenAIResponsesRequestToClaude_ReasoningItemToThinkingBlock(t *t
 	if got := assistant.Get("role").String(); got != "assistant" {
 		t.Fatalf("first message role = %q, want assistant. Output: %s", got, string(out))
 	}
-	if got := assistant.Get("content.0.type").String(); got != "thinking" {
-		t.Fatalf("first content type = %q, want thinking. Output: %s", got, string(out))
-	}
-	if got := assistant.Get("content.0.signature").String(); got != expectedSignature {
-		t.Fatalf("thinking signature = %q, want %q", got, expectedSignature)
-	}
-	if got := assistant.Get("content.0.thinking").String(); got != "internal reasoning" {
-		t.Fatalf("thinking text = %q, want internal reasoning", got)
-	}
-	if got := assistant.Get("content.1.type").String(); got != "text" {
-		t.Fatalf("second content type = %q, want text. Output: %s", got, string(out))
-	}
-	if got := assistant.Get("content.1.text").String(); got != "visible answer" {
+	if got := assistant.Get("content").String(); got != "visible answer" {
 		t.Fatalf("assistant text = %q, want visible answer", got)
 	}
 	if got := root.Get("messages.1.role").String(); got != "user" {
@@ -90,8 +78,8 @@ func TestConvertOpenAIResponsesRequestToClaude_ReasoningItemToThinkingBlock(t *t
 	}
 }
 
-func TestConvertOpenAIResponsesRequestToClaude_SignatureOnlyReasoningFlushesBeforeUser(t *testing.T) {
-	rawSignature, expectedSignature := testClaudeResponsesThinkingSignature(t)
+func TestConvertOpenAIResponsesRequestToClaude_DropsSignatureOnlyReasoning(t *testing.T) {
+	rawSignature, _ := testClaudeResponsesThinkingSignature(t)
 	raw := []byte(`{
 		"model":"claude-test",
 		"input":[
@@ -111,18 +99,11 @@ func TestConvertOpenAIResponsesRequestToClaude_SignatureOnlyReasoningFlushesBefo
 	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
 	root := gjson.ParseBytes(out)
 
-	thinking := root.Get("messages.0.content.0")
-	if got := thinking.Get("type").String(); got != "thinking" {
-		t.Fatalf("first content type = %q, want thinking. Output: %s", got, string(out))
+	if got := root.Get("messages.#").Int(); got != 1 {
+		t.Fatalf("message count = %d, want 1. Output: %s", got, string(out))
 	}
-	if got := thinking.Get("signature").String(); got != expectedSignature {
-		t.Fatalf("thinking signature = %q, want %q", got, expectedSignature)
-	}
-	if got := thinking.Get("thinking").String(); got != "" {
-		t.Fatalf("thinking text = %q, want empty", got)
-	}
-	if got := root.Get("messages.1.role").String(); got != "user" {
-		t.Fatalf("second message role = %q, want user. Output: %s", got, string(out))
+	if got := root.Get("messages.0.role").String(); got != "user" {
+		t.Fatalf("first message role = %q, want user. Output: %s", got, string(out))
 	}
 }
 
@@ -199,6 +180,51 @@ func TestConvertOpenAIResponsesRequestToClaude_KeepsToolUseAdjacentToToolResult(
 	}
 	if got := root.Get("messages.2.content.0.tool_use_id").String(); got != "call_00_awGuheXs4aRbtedNK8LE3743" {
 		t.Fatalf("tool_result id = %q, want call_00_awGuheXs4aRbtedNK8LE3743. Output: %s", got, string(out))
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_ToolResultImageArrayUsesClaudeImageContent(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-test",
+		"input":[
+			{
+				"type":"function_call",
+				"call_id":"call_image",
+				"name":"view_image",
+				"arguments":"{\"path\":\"/tmp/a.png\"}"
+			},
+			{
+				"type":"function_call_output",
+				"call_id":"call_image",
+				"output":[
+					{"type":"input_image","image_url":"data:image/png;base64,QUJD"},
+					{"type":"input_text","text":"screenshot"}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-test", raw, false)
+	root := gjson.ParseBytes(out)
+	content := root.Get("messages.1.content.0.content")
+
+	if got := content.Get("0.type").String(); got != "image" {
+		t.Fatalf("tool_result content.0.type = %q, want image. Output: %s", got, string(out))
+	}
+	if got := content.Get("0.source.type").String(); got != "base64" {
+		t.Fatalf("image source type = %q, want base64. Output: %s", got, string(out))
+	}
+	if got := content.Get("0.source.media_type").String(); got != "image/png" {
+		t.Fatalf("image media type = %q, want image/png. Output: %s", got, string(out))
+	}
+	if got := content.Get("0.source.data").String(); got != "QUJD" {
+		t.Fatalf("image data = %q, want QUJD. Output: %s", got, string(out))
+	}
+	if got := content.Get("1.type").String(); got != "text" {
+		t.Fatalf("tool_result content.1.type = %q, want text. Output: %s", got, string(out))
+	}
+	if got := content.Get("1.text").String(); got != "screenshot" {
+		t.Fatalf("tool_result text = %q, want screenshot. Output: %s", got, string(out))
 	}
 }
 

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -70,7 +70,7 @@ func TestConvertOpenAIResponsesRequestToClaude_DropsReasoningItems(t *testing.T)
 	if got := assistant.Get("role").String(); got != "assistant" {
 		t.Fatalf("first message role = %q, want assistant. Output: %s", got, string(out))
 	}
-	if got := assistant.Get("content").String(); got != "visible answer" {
+	if got := assistant.Get("content.0.text").String(); got != "visible answer" {
 		t.Fatalf("assistant text = %q, want visible answer", got)
 	}
 	if got := root.Get("messages.1.role").String(); got != "user" {
@@ -166,7 +166,7 @@ func TestConvertOpenAIResponsesRequestToClaude_KeepsToolUseAdjacentToToolResult(
 	if got := root.Get("messages.0.role").String(); got != "assistant" {
 		t.Fatalf("first message role = %q, want assistant. Output: %s", got, string(out))
 	}
-	if got := root.Get("messages.0.content").String(); got != "I'll check your Obsidian vault for articles." {
+	if got := root.Get("messages.0.content.0.text").String(); got != "I'll check your Obsidian vault for articles." {
 		t.Fatalf("first message content = %q, want assistant text. Output: %s", got, string(out))
 	}
 	if got := root.Get("messages.1.content.0.type").String(); got != "tool_use" {

--- a/internal/translator/claude/openai/responses/drop_images_test.go
+++ b/internal/translator/claude/openai/responses/drop_images_test.go
@@ -1,0 +1,111 @@
+package responses
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+func TestStripOldImages_KeepsLastNUserTurns(t *testing.T) {
+	big := strings.Repeat("A", 1024)
+	out := []byte(`{"messages":[]}`)
+
+	// Create 8 user turns with images, interleaved with assistant messages.
+	for i := 0; i < 8; i++ {
+		// user with image
+		m := []byte(`{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":""}},{"type":"text","text":""}]}`)
+		m, _ = sjson.SetBytes(m, "content.0.source.data", big)
+		m, _ = sjson.SetBytes(m, "content.1.text", strings.Repeat("x", i))
+		out, _ = sjson.SetRawBytes(out, "messages.-1", m)
+		// assistant reply
+		out, _ = sjson.SetRawBytes(out, "messages.-1", []byte(`{"role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}
+
+	got := stripOldImages(out)
+
+	// 8 user turns, keep last 6 => first 2 user turns (msg index 0, 2) should be stripped
+	// msg[0] = user turn 0 -> stripped
+	if ty := gjson.GetBytes(got, "messages.0.content.0.type").String(); ty != "text" {
+		t.Fatalf("user turn 0 image should be stripped, got type=%s", ty)
+	}
+	if txt := gjson.GetBytes(got, "messages.0.content.0.text").String(); !strings.Contains(txt, "omitted") {
+		t.Fatalf("user turn 0 should have placeholder, got %s", txt)
+	}
+	// msg[2] = user turn 1 -> stripped
+	if ty := gjson.GetBytes(got, "messages.2.content.0.type").String(); ty != "text" {
+		t.Fatalf("user turn 1 image should be stripped, got type=%s", ty)
+	}
+
+	// msg[4] = user turn 2 -> kept (part of last 6)
+	if ty := gjson.GetBytes(got, "messages.4.content.0.type").String(); ty != "image" {
+		t.Fatalf("user turn 2 image should be kept, got type=%s", ty)
+	}
+	// msg[14] = user turn 7 (last) -> kept
+	if ty := gjson.GetBytes(got, "messages.14.content.0.type").String(); ty != "image" {
+		t.Fatalf("last user turn image should be kept, got type=%s", ty)
+	}
+}
+
+func TestStripOldImages_FewerThanNTurns(t *testing.T) {
+	big := strings.Repeat("A", 1024)
+	out := []byte(`{"messages":[]}`)
+
+	// Only 3 user turns (< 6), all images should survive
+	for i := 0; i < 3; i++ {
+		m := []byte(`{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":""}}]}`)
+		m, _ = sjson.SetBytes(m, "content.0.source.data", big)
+		out, _ = sjson.SetRawBytes(out, "messages.-1", m)
+		out, _ = sjson.SetRawBytes(out, "messages.-1", []byte(`{"role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}
+
+	got := stripOldImages(out)
+
+	for i := 0; i < 3; i++ {
+		idx := i * 2
+		if ty := gjson.GetBytes(got, "messages."+string(rune('0'+idx))+".content.0.type").String(); ty != "image" {
+			t.Fatalf("user turn %d image should be kept (fewer than 6 turns), got type=%s", i, ty)
+		}
+	}
+}
+
+func TestStripOldImages_NestedToolResult(t *testing.T) {
+	big := strings.Repeat("A", 1024)
+	out := []byte(`{"messages":[]}`)
+
+	// 8 user turns, images in tool_result
+	for i := 0; i < 8; i++ {
+		tr := []byte(`{"role":"user","content":[{"type":"tool_result","tool_use_id":"t","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":""}}]}]}`)
+		tr, _ = sjson.SetBytes(tr, "content.0.content.0.source.data", big)
+		out, _ = sjson.SetRawBytes(out, "messages.-1", tr)
+		out, _ = sjson.SetRawBytes(out, "messages.-1", []byte(`{"role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}
+
+	got := stripOldImages(out)
+
+	// First 2 user turns should be stripped
+	if ty := gjson.GetBytes(got, "messages.0.content.0.content.0.type").String(); ty != "text" {
+		t.Fatalf("nested image in turn 0 should be stripped, got type=%s", ty)
+	}
+	// Last user turn should be kept
+	if ty := gjson.GetBytes(got, "messages.14.content.0.content.0.type").String(); ty != "image" {
+		t.Fatalf("nested image in last turn should be kept, got type=%s", ty)
+	}
+}
+
+func TestStripOldImages_28MBCap(t *testing.T) {
+	big := strings.Repeat("A", 15*1024*1024)
+	out := []byte(`{"messages":[]}`)
+
+	// Single user message with two huge images (within last 6 turns but over 28MB)
+	m := []byte(`{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":""}},{"type":"image","source":{"type":"base64","media_type":"image/png","data":""}}]}`)
+	m, _ = sjson.SetBytes(m, "content.0.source.data", big)
+	m, _ = sjson.SetBytes(m, "content.1.source.data", big)
+	out, _ = sjson.SetRawBytes(out, "messages.-1", m)
+
+	got := stripOldImages(out)
+	if len(got) > 28*1024*1024 {
+		t.Fatalf("payload not reduced: %d bytes", len(got))
+	}
+}


### PR DESCRIPTION
## Problem

Two bugs in the OpenAI Responses → Claude Messages translator affect **all Claude models** when used through CLIProxyAPI:

### 1. Image arrays in function_call_output tokenized as text

When `function_call_output.output` is an array containing `input_image` parts (e.g. Codex Desktop screenshots), the translator called `output.String()` which serialized the entire array — including multi-MB base64 image data — as a plain string into `tool_result.content`.

Claude then tokenizes this raw base64 text instead of processing it as a vision image. A single 2 MB screenshot consumes ~4 million tokens instead of ~1,500 vision tokens, immediately hitting the 1M token limit:

```
prompt is too long: 4175270 tokens > 1000000 maximum
```

### 2. Reasoning history replayed as Claude thinking blocks

`convertResponsesReasoningToClaudeThinking()` reconstructed Claude `thinking` blocks from OpenAI Responses `reasoning` summary items. Claude requires thinking blocks in the latest assistant message to remain byte-for-byte identical to the original response. Since Responses reasoning summaries are lossy transformations, this always triggers:

```
messages.N.content.M: thinking or redacted_thinking blocks in the latest
assistant message cannot be modified. These blocks must remain as they
were in the original response.
```

## Fix

1. **New `setResponsesToolResultContent()`** walks the output array and converts:
   - `input_image` / `image` → Claude-native `{"type":"image","source":{"type":"base64",...}}`
   - `input_text` / `output_text` / `text` → Claude-native `{"type":"text","text":"..."}`
   - Falls back to `output.String()` for non-array outputs (backward compatible)

2. **Removed `convertResponsesReasoningToClaudeThinking()`** and its helper `responsesReasoningSummaryText()`. Reasoning history items are now silently dropped when targeting Claude, which is the safe default — Claude does not need prior thinking blocks to function correctly.

## Testing

- `go test ./internal/translator/claude/openai/responses/` — all tests pass
- End-to-end verified against Claude Opus 4.6 via Codex Desktop with screenshot-heavy sessions
- Both the 4M token overflow and the thinking block modification error are resolved

## Affected models

All Claude models routed through the OpenAI Responses API translator.