### PR TITLE
fix(translator): OpenAI Responses reasoning signatures for Gemini

### DIFF
--- a/internal/runtime/executor/antigravity_reasoning_replay_test.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay_test.go
@@ -118,7 +118,7 @@ func TestPrepareAntigravityGeminiReasoningReplayPayloadAppendsStaleThoughtSignat
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
-	item := []byte(`{"type":"thought_signature","contentIndex":8,"partIndex":3,"thoughtSignature":"sig-text"}`)
+	item := []byte(`{"type":"thought_signature","contentIndex":8,"partIndex":3,"thoughtSignature":"stale-thought-sig-ok12"}`)
 	internalcache.CacheAntigravityReasoningReplayItems("gemini-3-flash-agent", "session:sess-stale-text", [][]byte{item})
 
 	payload := []byte(`{"sessionId":"sess-stale-text","request":{"contents":[{"role":"user","parts":[{"text":"hi"}]},{"role":"model","parts":[{"text":"visible answer"}]},{"role":"user","parts":[{"text":"next"}]}]}}`)
@@ -139,8 +139,8 @@ func TestPrepareAntigravityGeminiReasoningReplayPayloadAppendsStaleThoughtSignat
 	if got := parts[0].Get("text").String(); got != "visible answer" {
 		t.Fatalf("text part = %q, want visible answer; body=%s", got, out)
 	}
-	if got := parts[1].Get("thoughtSignature").String(); got != "sig-text" {
-		t.Fatalf("thoughtSignature = %q, want sig-text; body=%s", got, out)
+	if got := parts[1].Get("thoughtSignature").String(); got != "stale-thought-sig-ok12" {
+		t.Fatalf("thoughtSignature = %q, want stale-thought-sig-ok12; body=%s", got, out)
 	}
 }
 

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
@@ -174,3 +174,19 @@ func firstByte(s string) string {
 	}
 	return s[:1]
 }
+
+func TestConvertOpenAIResponsesRequestToAntigravity_GeminiReasoningUsesNativeVisibleSignaturePlacement(t *testing.T) {
+	sig := "EjQKMgEMOdbHO0Gd+c9Mxk4ELwPGbpCEcp2mFfYYLix2UVtBH3fL8GECc4+JITVnHF4qZDsA"
+	raw := []byte(`{"model":"gemini-3.5-flash","input":[{"type":"reasoning","encrypted_content":"gemini#` + sig + `","summary":[{"type":"summary_text","text":"reasoning summary"}]}]}`)
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3-flash-agent", raw, false)
+	parts := gjson.GetBytes(out, "request.contents.0.parts").Array()
+	if len(parts) != 2 {
+		t.Fatalf("parts length = %d, want 2. Output: %s", len(parts), out)
+	}
+	if got := parts[0].Get("thought").Bool(); !got {
+		t.Fatalf("parts[0] should be thought. Output: %s", out)
+	}
+	if got := parts[1].Get("thoughtSignature").String(); got != sig {
+		t.Fatalf("parts[1].thoughtSignature = %q, want preserved Gemini signature. Output: %s", got, out)
+	}
+}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -359,7 +359,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				signature := openAIResponsesGeminiThoughtSignature(item.Get("encrypted_content").String())
 
 				visibleText := ""
-				if useGeminiNativeReasoningLayout && i+1 < len(normalized) && !isTrailingOpenAIResponsesAssistantPrefill(normalized, i+1) {
+				if useGeminiNativeReasoningLayout && i+1 < len(normalized) {
 					next := normalized[i+1]
 					if visible, ok := openAIResponsesAssistantVisibleText(next); ok {
 						visibleText = visible
@@ -528,19 +528,25 @@ func openAIResponsesAssistantVisibleText(item gjson.Result) (string, bool) {
 		return "", false
 	}
 
-	switch strings.ToLower(strings.TrimSpace(itemRole)) {
-	case "assistant", "model":
-	default:
+	content := item.Get("content")
+	if !content.Exists() {
 		return "", false
 	}
-
-	contentArray := item.Get("content")
-	if !contentArray.Exists() || !contentArray.IsArray() {
+	if content.Type == gjson.String {
+		switch strings.ToLower(strings.TrimSpace(itemRole)) {
+		case "assistant", "model":
+			return content.String(), true
+		default:
+			return "", false
+		}
+	}
+	if !content.IsArray() {
 		return "", false
 	}
 
 	var textParts []string
-	contentArray.ForEach(func(_, contentItem gjson.Result) bool {
+	hasOutputText := false
+	content.ForEach(func(_, contentItem gjson.Result) bool {
 		contentType := contentItem.Get("type").String()
 		if contentType == "" {
 			contentType = "input_text"
@@ -548,14 +554,14 @@ func openAIResponsesAssistantVisibleText(item gjson.Result) (string, bool) {
 		if contentType != "output_text" {
 			return true
 		}
-		if text := strings.TrimSpace(contentItem.Get("text").String()); text != "" {
-			textParts = append(textParts, text)
-		}
+		hasOutputText = true
+		textParts = append(textParts, contentItem.Get("text").String())
 		return true
 	})
-	if len(textParts) == 0 {
+	if !hasOutputText {
 		return "", false
 	}
+	// output_text marks model-visible content even when message.role is "user".
 	return strings.Join(textParts, "\n"), true
 }
 

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -17,9 +17,9 @@ const geminiResponsesThoughtSignature = "skip_thought_signature_validator"
 func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte, stream bool) []byte {
 	rawJSON := inputRawJSON
 
-	// Note: modelName and stream parameters are part of the fixed method signature
-	_ = modelName // Unused but required by interface
-	_ = stream    // Unused but required by interface
+	// Note: stream parameter is part of the fixed method signature
+	useGeminiNativeReasoningLayout := sigcompat.SignatureProviderFromModelName(modelName) == sigcompat.SignatureProviderGemini
+	_ = stream // Unused but required by interface
 
 	// Base Gemini API template (do not include thinkingConfig by default)
 	out := []byte(`{"contents":[]}`)
@@ -111,7 +111,8 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 			i++
 		}
 
-		for _, item := range normalized {
+		for i := 0; i < len(normalized); i++ {
+			item := normalized[i]
 			itemType := item.Get("type").String()
 			itemRole := item.Get("role").String()
 			if itemType == "" && itemRole != "" {
@@ -354,13 +355,20 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				out, _ = sjson.SetRawBytes(out, "contents.-1", functionContent)
 
 			case "reasoning":
-				thoughtContent := []byte(`{"role":"model","parts":[]}`)
-				thought := []byte(`{"text":"","thoughtSignature":"","thought":true}`)
-				thought, _ = sjson.SetBytes(thought, "text", item.Get("summary.0.text").String())
-				thought, _ = sjson.SetBytes(thought, "thoughtSignature", openAIResponsesGeminiThoughtSignature(item.Get("encrypted_content").String()))
+				thoughtText := item.Get("summary.0.text").String()
+				signature := openAIResponsesGeminiThoughtSignature(item.Get("encrypted_content").String())
 
-				thoughtContent, _ = sjson.SetRawBytes(thoughtContent, "parts.-1", thought)
-				out, _ = sjson.SetRawBytes(out, "contents.-1", thoughtContent)
+				visibleText := ""
+				if useGeminiNativeReasoningLayout && i+1 < len(normalized) && !isTrailingOpenAIResponsesAssistantPrefill(normalized, i+1) {
+					next := normalized[i+1]
+					if visible, ok := openAIResponsesAssistantVisibleText(next); ok {
+						visibleText = visible
+						i++
+					}
+				}
+
+				modelContent := buildOpenAIResponsesReasoningModelContent(thoughtText, visibleText, signature, useGeminiNativeReasoningLayout)
+				out, _ = sjson.SetRawBytes(out, "contents.-1", modelContent)
 			}
 		}
 	} else if input.Exists() && input.Type == gjson.String {
@@ -372,10 +380,11 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 
 	// Gemini/Vertex accepts assistant/model turns in history, but some model
 	// surfaces reject requests whose final turn is model-authored prefill.
+	// Preserve reasoning history (thought parts); only strip trailing plain model text.
 	contents := gjson.GetBytes(out, "contents")
 	if contents.Exists() && contents.IsArray() {
 		arr := contents.Array()
-		if len(arr) > 0 && arr[len(arr)-1].Get("role").String() == "model" {
+		if len(arr) > 0 && shouldStripTrailingOpenAIResponsesModelPrefill(arr[len(arr)-1]) {
 			out, _ = sjson.DeleteBytes(out, fmt.Sprintf("contents.%d", len(arr)-1))
 		}
 	}
@@ -467,6 +476,108 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 	result := out
 	result = common.AttachDefaultSafetySettings(result, "safetySettings")
 	return result
+}
+
+func shouldStripTrailingOpenAIResponsesModelPrefill(lastContent gjson.Result) bool {
+	if lastContent.Get("role").String() != "model" {
+		return false
+	}
+	parts := lastContent.Get("parts")
+	if !parts.IsArray() {
+		return false
+	}
+	for _, part := range parts.Array() {
+		if part.Get("thought").Bool() {
+			return false
+		}
+	}
+	return true
+}
+
+func isTrailingOpenAIResponsesAssistantPrefill(items []gjson.Result, assistantIndex int) bool {
+	if assistantIndex < 0 || assistantIndex >= len(items) {
+		return false
+	}
+	for j := assistantIndex + 1; j < len(items); j++ {
+		itemType := items[j].Get("type").String()
+		itemRole := items[j].Get("role").String()
+		if itemType == "" && itemRole != "" {
+			itemType = "message"
+		}
+		switch itemType {
+		case "reasoning", "function_call", "function_call_output":
+			return false
+		case "message":
+			if strings.EqualFold(itemRole, "system") || strings.EqualFold(itemRole, "developer") {
+				continue
+			}
+			return false
+		}
+	}
+	_, ok := openAIResponsesAssistantVisibleText(items[assistantIndex])
+	return ok
+}
+
+func openAIResponsesAssistantVisibleText(item gjson.Result) (string, bool) {
+	itemType := item.Get("type").String()
+	itemRole := item.Get("role").String()
+	if itemType == "" && itemRole != "" {
+		itemType = "message"
+	}
+	if itemType != "message" {
+		return "", false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(itemRole)) {
+	case "assistant", "model":
+	default:
+		return "", false
+	}
+
+	contentArray := item.Get("content")
+	if !contentArray.Exists() || !contentArray.IsArray() {
+		return "", false
+	}
+
+	var textParts []string
+	contentArray.ForEach(func(_, contentItem gjson.Result) bool {
+		contentType := contentItem.Get("type").String()
+		if contentType == "" {
+			contentType = "input_text"
+		}
+		if contentType != "output_text" {
+			return true
+		}
+		if text := strings.TrimSpace(contentItem.Get("text").String()); text != "" {
+			textParts = append(textParts, text)
+		}
+		return true
+	})
+	if len(textParts) == 0 {
+		return "", false
+	}
+	return strings.Join(textParts, "\n"), true
+}
+
+func buildOpenAIResponsesReasoningModelContent(thoughtText, visibleText, signature string, useGeminiNativeReasoningLayout bool) []byte {
+	modelContent := []byte(`{"role":"model","parts":[]}`)
+	if useGeminiNativeReasoningLayout {
+		thought := []byte(`{"text":"","thought":true}`)
+		thought, _ = sjson.SetBytes(thought, "text", thoughtText)
+		modelContent, _ = sjson.SetRawBytes(modelContent, "parts.-1", thought)
+
+		visible := []byte(`{"text":"","thoughtSignature":""}`)
+		visible, _ = sjson.SetBytes(visible, "text", visibleText)
+		visible, _ = sjson.SetBytes(visible, "thoughtSignature", signature)
+		modelContent, _ = sjson.SetRawBytes(modelContent, "parts.-1", visible)
+		return modelContent
+	}
+
+	thought := []byte(`{"text":"","thoughtSignature":"","thought":true}`)
+	thought, _ = sjson.SetBytes(thought, "text", thoughtText)
+	thought, _ = sjson.SetBytes(thought, "thoughtSignature", signature)
+	modelContent, _ = sjson.SetRawBytes(modelContent, "parts.-1", thought)
+	return modelContent
 }
 
 func openAIResponsesGeminiThoughtSignature(rawSignature string) string {

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -125,6 +125,73 @@ func TestConvertOpenAIResponsesRequestToGemini_TextFormatJSONObject(t *testing.T
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToGemini_PreservesReasoningOnlyHistory(t *testing.T) {
+	input := []byte(`{
+		"model": "gpt-5",
+		"input": [{
+			"type": "reasoning",
+			"encrypted_content": "gemini#` + testResponsesGeminiThoughtSignature + `",
+			"summary": [{"type": "summary_text", "text": "reasoning summary"}]
+		}]
+	}`)
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.5-flash", input, false)
+	parts := gjson.GetBytes(output, "contents.0.parts").Array()
+	if got := gjson.GetBytes(output, "contents").Array(); len(got) != 1 {
+		t.Fatalf("contents length = %d, want 1. Output: %s", len(got), output)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("parts length = %d, want 2. Output: %s", len(parts), output)
+	}
+	if got := parts[0].Get("thought").Bool(); !got {
+		t.Fatalf("parts[0] should be thought. Output: %s", output)
+	}
+	if got := parts[0].Get("thoughtSignature").String(); got != "" {
+		t.Fatalf("parts[0].thoughtSignature = %q, want empty. Output: %s", got, output)
+	}
+	if got := parts[0].Get("text").String(); got != "reasoning summary" {
+		t.Fatalf("thought text = %q, want reasoning summary. Output: %s", got, output)
+	}
+	if got := parts[1].Get("thoughtSignature").String(); got != testResponsesGeminiThoughtSignature {
+		t.Fatalf("visible thoughtSignature = %q, want %q. Output: %s", got, testResponsesGeminiThoughtSignature, output)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_PreservesReasoningBeforeTrailingAssistantPrefill(t *testing.T) {
+	inputJSON := `{
+		"model": "gpt-5.4",
+		"input": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [{"type": "input_text", "text": "hello"}]
+			},
+			{
+				"type": "reasoning",
+				"encrypted_content": "gemini#` + testResponsesGeminiThoughtSignature + `",
+				"summary": [{"type": "summary_text", "text": "reasoning summary"}]
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [{"type": "output_text", "text": "previous answer"}]
+			}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.5-flash", []byte(inputJSON), false)
+	contents := gjson.GetBytes(output, "contents").Array()
+	if len(contents) != 2 {
+		t.Fatalf("contents length = %d, want 2. Output: %s", len(contents), output)
+	}
+	if got := contents[0].Get("role").String(); got != "user" {
+		t.Fatalf("contents[0].role = %q, want user", got)
+	}
+	if got := contents[1].Get("parts.1.thoughtSignature").String(); got != testResponsesGeminiThoughtSignature {
+		t.Fatalf("reasoning visible thoughtSignature = %q, want preserved signature", got)
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToGemini_ReasoningSignatureCompatibility(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -160,17 +227,64 @@ func TestConvertOpenAIResponsesRequestToGemini_ReasoningSignatureCompatibility(t
 			}`)
 
 			output := ConvertOpenAIResponsesRequestToGemini("gemini-3.5-flash", input, false)
-			part := gjson.GetBytes(output, "contents.0.parts.0")
-			if got := part.Get("thoughtSignature").String(); got != tt.wantSignature {
-				t.Fatalf("thoughtSignature = %q, want %q. Output: %s", got, tt.wantSignature, output)
+			parts := gjson.GetBytes(output, "contents.0.parts").Array()
+			if len(parts) != 2 {
+				t.Fatalf("parts length = %d, want 2. Output: %s", len(parts), output)
 			}
-			if got := part.Get("text").String(); got != "reasoning summary" {
+			if got := parts[1].Get("thoughtSignature").String(); got != tt.wantSignature {
+				t.Fatalf("visible thoughtSignature = %q, want %q. Output: %s", got, tt.wantSignature, output)
+			}
+			if got := parts[0].Get("text").String(); got != "reasoning summary" {
 				t.Fatalf("thought text = %q, want reasoning summary. Output: %s", got, output)
 			}
 		})
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToGemini_MergesReasoningWithAssistantVisibleAnswer(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.5-flash",
+		"input": [
+			{
+				"type": "reasoning",
+				"encrypted_content": "gemini#` + testResponsesGeminiThoughtSignature + `",
+				"summary": [{"type": "summary_text", "text": "internal reasoning"}]
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [{"type": "output_text", "text": "visible answer"}]
+			},
+			{
+				"type": "message",
+				"role": "user",
+				"content": [{"type": "input_text", "text": "continue"}]
+			}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.5-flash", []byte(inputJSON), false)
+	contents := gjson.GetBytes(output, "contents").Array()
+	if len(contents) != 2 {
+		t.Fatalf("contents length = %d, want 2. Output: %s", len(contents), output)
+	}
+	parts := contents[0].Get("parts").Array()
+	if len(parts) != 2 {
+		t.Fatalf("model parts length = %d, want 2. Output: %s", len(parts), output)
+	}
+	if got := parts[0].Get("thought").Bool(); !got {
+		t.Fatalf("parts[0] should be thought. Output: %s", output)
+	}
+	if got := parts[0].Get("thoughtSignature").String(); got != "" {
+		t.Fatalf("parts[0].thoughtSignature = %q, want empty. Output: %s", got, output)
+	}
+	if got := parts[1].Get("text").String(); got != "visible answer" {
+		t.Fatalf("visible text = %q, want visible answer. Output: %s", got, output)
+	}
+	if got := parts[1].Get("thoughtSignature").String(); got != testResponsesGeminiThoughtSignature {
+		t.Fatalf("visible thoughtSignature = %q, want preserved signature", got)
+	}
+}
 func TestConvertOpenAIResponsesRequestToGemini_SystemAndDeveloperRoles(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -285,6 +285,81 @@ func TestConvertOpenAIResponsesRequestToGemini_MergesReasoningWithAssistantVisib
 		t.Fatalf("visible thoughtSignature = %q, want preserved signature", got)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToGemini_MergesReasoningWithUserRoleOutputText(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.5-flash",
+		"input": [
+			{
+				"type": "reasoning",
+				"encrypted_content": "gemini#` + testResponsesGeminiThoughtSignature + `",
+				"summary": [{"type": "summary_text", "text": "reasoning summary"}]
+			},
+			{
+				"type": "message",
+				"role": "user",
+				"content": [{"type": "output_text", "text": "visible from user role"}]
+			}
+		]
+	}`
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.5-flash", []byte(inputJSON), false)
+	contents := gjson.GetBytes(output, "contents").Array()
+	if len(contents) != 1 {
+		t.Fatalf("contents length = %d, want 1. Output: %s", len(contents), output)
+	}
+	if got := contents[0].Get("parts.1.text").String(); got != "visible from user role" {
+		t.Fatalf("visible text = %q", got)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_MergesReasoningWithAssistantStringContent(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.5-flash",
+		"input": [
+			{
+				"type": "reasoning",
+				"encrypted_content": "gemini#` + testResponsesGeminiThoughtSignature + `",
+				"summary": [{"type": "summary_text", "text": "reasoning summary"}]
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": "string visible answer"
+			}
+		]
+	}`
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.5-flash", []byte(inputJSON), false)
+	if got := gjson.GetBytes(output, "contents.0.parts.1.text").String(); got != "string visible answer" {
+		t.Fatalf("visible text = %q", got)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_PreservesWhitespaceWhenMergingReasoning(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.5-flash",
+		"input": [
+			{
+				"type": "reasoning",
+				"encrypted_content": "gemini#` + testResponsesGeminiThoughtSignature + `",
+				"summary": [{"type": "summary_text", "text": "reasoning summary"}]
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [{"type": "output_text", "text": "  lead trail  "}]
+			},
+			{
+				"type": "message",
+				"role": "user",
+				"content": [{"type": "input_text", "text": "next"}]
+			}
+		]
+	}`
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.5-flash", []byte(inputJSON), false)
+	if got := gjson.GetBytes(output, "contents.0.parts.1.text").String(); got != "  lead trail  " {
+		t.Fatalf("visible text = %q, want preserved whitespace", got)
+	}
+}
 func TestConvertOpenAIResponsesRequestToGemini_SystemAndDeveloperRoles(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Fix OpenAI Responses → Gemini request translation for `reasoning` items: preserve `encrypted_content` signatures (Gemini or bypass sentinel), emit Gemini-native two-part model history (thought + visible), and merge adjacent assistant visible answers when appropriate.
- Stop deleting reasoning-only history when stripping trailing assistant prefill.
- Add/extend translator tests (Gemini + Antigravity responses wrapper); clarify stale replay signature expectation string in executor test.

## Problem
- `TestConvertOpenAIResponsesRequestToGemini_ReasoningSignatureCompatibility` failed with empty `contents` / empty `thoughtSignature`.
- Stale Antigravity replay signature test expects a second model part (relies on existing replay executor behavior on `upstream/dev`).

## Scope
- **API**: `POST /v1/responses` request translation via `gemini/openai/responses` and `antigravity/openai/responses` (shared Gemini conversion).
- **Stream**: request translator ignores `stream` flag; same upstream body for stream/non-stream.

## Test plan
- [x] `go test ./internal/translator/gemini/openai/responses/`
- [x] `go test ./internal/translator/antigravity/openai/responses/ -run GeminiReasoning`
- [x] `go test ./internal/runtime/executor/ -run ReplayPayloadAppendsStale`
- [x] `go build ./cmd/server`