### PR TITLE
feat(codex): validate Responses input before upstream

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -790,6 +790,9 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		return resp, errReplay
 	}
 	reporter.SetTranslatedReasoningEffort(body, to.String())
+	if err = validateCodexExecutorUpstreamBody(body); err != nil {
+		return resp, err
+	}
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	var identityState codexIdentityConfuseState
@@ -962,6 +965,9 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body = normalizeCodexParallelToolCallsForTools(body)
 	reporter.SetTranslatedReasoningEffort(body, to.String())
+	if err = validateCodexExecutorUpstreamBody(body); err != nil {
+		return resp, err
+	}
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses/compact"
 	var identityState codexIdentityConfuseState
@@ -1076,6 +1082,9 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		return nil, errReplay
 	}
 	reporter.SetTranslatedReasoningEffort(body, to.String())
+	if err = validateCodexExecutorUpstreamBody(body); err != nil {
+		return nil, err
+	}
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	var identityState codexIdentityConfuseState

--- a/internal/runtime/executor/codex_executor_responses_validate.go
+++ b/internal/runtime/executor/codex_executor_responses_validate.go
@@ -1,0 +1,23 @@
+package executor
+
+import (
+	"net/http"
+
+	codexresponses "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/codex/openai/responses"
+	"github.com/tidwall/sjson"
+)
+
+func validateCodexExecutorUpstreamBody(body []byte) error {
+	verr := codexresponses.ValidateCodexResponsesInput(body)
+	if verr == nil {
+		return nil
+	}
+	payload := []byte("{\"error\":{}}")
+	payload, _ = sjson.SetBytes(payload, "error.message", verr.Message)
+	payload, _ = sjson.SetBytes(payload, "error.type", "invalid_request_error")
+	payload, _ = sjson.SetBytes(payload, "error.code", "invalid_value")
+	if verr.Param != "" {
+		payload, _ = sjson.SetBytes(payload, "error.param", verr.Param)
+	}
+	return newCodexStatusErr(http.StatusBadRequest, payload)
+}

--- a/internal/runtime/executor/codex_executor_responses_validate_test.go
+++ b/internal/runtime/executor/codex_executor_responses_validate_test.go
@@ -1,0 +1,19 @@
+package executor
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestValidateCodexExecutorUpstreamBody_RejectsMixedUserMessage(t *testing.T) {
+	body := []byte("{\"model\":\"gpt-5.5\",\"stream\":true,\"store\":false,\"input\":[{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"output_text\",\"text\":\"a\"},{\"type\":\"input_text\",\"text\":\"b\"}]}]}")
+	err := validateCodexExecutorUpstreamBody(body)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var status statusErr
+	if !errors.As(err, &status) || status.code != http.StatusBadRequest {
+		t.Fatalf("got %#v", err)
+	}
+}

--- a/internal/translator/codex/openai/responses/codex_openai-responses_validate.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_validate.go
@@ -1,0 +1,58 @@
+package responses
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+type ValidationError struct {
+	Message string
+	Param   string
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+var codexResponsesOutputTextRoles = map[string]struct{}{
+	"assistant": {},
+}
+
+func ValidateCodexResponsesInput(rawJSON []byte) *ValidationError {
+	input := gjson.GetBytes(rawJSON, "input")
+	if !input.Exists() || input.Type == gjson.String || !input.IsArray() {
+		return nil
+	}
+	items := input.Array()
+	for i, item := range items {
+		if item.Get("type").String() != "message" {
+			continue
+		}
+		role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
+		if role == "" {
+			role = "user"
+		}
+		if _, ok := codexResponsesOutputTextRoles[role]; ok {
+			continue
+		}
+		content := item.Get("content")
+		if !content.Exists() || content.Type == gjson.String || !content.IsArray() {
+			continue
+		}
+		for j, part := range content.Array() {
+			if part.Get("type").String() != "output_text" {
+				continue
+			}
+			return &ValidationError{
+				Message: "Invalid value: 'output_text'. Supported values are: 'input_text', 'input_image', 'input_file', and 'scoped_content'.",
+				Param:   fmt.Sprintf("input[%d].content[%d]", i, j),
+			}
+		}
+	}
+	return nil
+}

--- a/internal/translator/codex/openai/responses/codex_openai-responses_validate_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_validate_test.go
@@ -1,0 +1,41 @@
+package responses
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestValidateCodexResponsesInput_RejectsOutputTextInUserMessage(t *testing.T) {
+	inputJSON := []byte("{\"input\":[{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"output_text\",\"text\":\"a\"},{\"type\":\"input_text\",\"text\":\"b\"}]}]}")
+	verr := ValidateCodexResponsesInput(inputJSON)
+	if verr == nil || verr.Param != "input[0].content[0]" {
+		t.Fatalf("got %#v", verr)
+	}
+}
+
+func TestValidateCodexResponsesInput_AllowsAssistantOutputText(t *testing.T) {
+	inputJSON := []byte("{\"input\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}]}")
+	if err := ValidateCodexResponsesInput(inputJSON); err != nil {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToCodex_StripsUnsupportedTokenLimits(t *testing.T) {
+	inputJSON := []byte("{\"model\":\"gpt-5.5\",\"max_output_tokens\":32,\"input\":[{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"hi\"}]}]}")
+	output := ConvertOpenAIResponsesRequestToCodex("gpt-5.5", inputJSON, false)
+	if err := ValidateCodexResponsesInput(output); err != nil {
+		t.Fatalf("valid after convert: %v", err)
+	}
+	if gjson.GetBytes(output, "max_output_tokens").Exists() {
+		t.Fatal("max_output_tokens should be stripped")
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToCodex_ValidateRejectsMixedUserMessageAfterConvert(t *testing.T) {
+	inputJSON := []byte("{\"model\":\"gpt-5.5\",\"input\":[{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"output_text\",\"text\":\"a\"},{\"type\":\"input_text\",\"text\":\"b\"}]}]}")
+	output := ConvertOpenAIResponsesRequestToCodex("gpt-5.5", inputJSON, false)
+	if err := ValidateCodexResponsesInput(output); err == nil {
+		t.Fatal("expected validation error")
+	}
+}


### PR DESCRIPTION
Validates OpenAI Responses input[] before Codex executor sends to /responses.

Rules (from live Codex upstream):
- output_text is only allowed on assistant message content
- user/developer with output_text -> CPA 400 invalid_value

Coverage:
- ValidateCodexResponsesInput + translator tests
- validateCodexExecutorUpstreamBody in Execute / ExecuteStream / compact
- Executor unit test for 400 mapping
