### PR TITLE
fix(antigravity): align CLI User-Agent with agy 1.0.13 short form

### DIFF
--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -53,7 +53,7 @@ func (o *AntigravityAuth) shortUserAgent() string {
 }
 
 func (o *AntigravityAuth) nodeUserAgent() string {
-	return misc.AntigravityLoadCodeAssistUserAgent("")
+	return misc.AntigravityOnboardUserUserAgent("")
 }
 
 func antigravityLoadCodeAssistMetadata() map[string]string {

--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	antigravityFallbackVersion = "1.0.8"
+	antigravityFallbackVersion = "1.0.13"
 	antigravityCLIPlatform     = "darwin/arm64"
+	antigravityCLIClientName   = "aidev_client"
 	antigravityVersionCacheTTL = 6 * time.Hour
 	antigravityFetchTimeout    = 10 * time.Second
 	AntigravityNodeAPIClientUA = "google-api-nodejs-client/10.3.0"
@@ -129,7 +130,22 @@ func AntigravityLatestVersion() string {
 
 // AntigravityUserAgent returns the User-Agent string used by the agy CLI family.
 func AntigravityUserAgent() string {
-	return fmt.Sprintf("antigravity/cli/%s %s", AntigravityLatestVersion(), antigravityCLIPlatform)
+	return fmt.Sprintf("antigravity/cli/%s %s", AntigravityLatestVersion(), antigravityCLIUserAgentDetails())
+}
+
+func antigravityCLIUserAgentDetails() string {
+	osType, arch := "darwin", "arm64"
+	if platform := strings.TrimSpace(antigravityCLIPlatform); platform != "" {
+		if parts := strings.SplitN(platform, "/", 2); len(parts) == 2 {
+			if trimmedOS := strings.TrimSpace(parts[0]); trimmedOS != "" {
+				osType = trimmedOS
+			}
+			if trimmedArch := strings.TrimSpace(parts[1]); trimmedArch != "" {
+				arch = trimmedArch
+			}
+		}
+	}
+	return fmt.Sprintf("(%s; os_type=%s; arch=%s)", antigravityCLIClientName, osType, arch)
 }
 
 func isAntigravityFamilyUserAgent(lower string) bool {
@@ -159,9 +175,15 @@ func AntigravityRequestUserAgent(userAgent string) string {
 	return antigravityBaseUserAgent(userAgent)
 }
 
-// AntigravityLoadCodeAssistUserAgent returns the long Antigravity control-plane
-// UA used by loadCodeAssist requests.
+// AntigravityLoadCodeAssistUserAgent returns the short Antigravity UA used by
+// loadCodeAssist requests.
 func AntigravityLoadCodeAssistUserAgent(userAgent string) string {
+	return AntigravityRequestUserAgent(userAgent)
+}
+
+// AntigravityOnboardUserUserAgent returns the long Antigravity control-plane UA
+// used by onboardUser requests.
+func AntigravityOnboardUserUserAgent(userAgent string) string {
 	userAgent = strings.TrimSpace(userAgent)
 	if userAgent == "" {
 		return AntigravityUserAgent() + " " + AntigravityNodeAPIClientUA

--- a/internal/misc/antigravity_version_test.go
+++ b/internal/misc/antigravity_version_test.go
@@ -49,8 +49,8 @@ func TestAntigravityLatestVersionUsesCurrentCLIFallback(t *testing.T) {
 	defer restore()
 
 	version := AntigravityLatestVersion()
-	if version != "1.0.8" {
-		t.Fatalf("AntigravityLatestVersion() = %q, want %q", version, "1.0.8")
+	if version != "1.0.13" {
+		t.Fatalf("AntigravityLatestVersion() = %q, want %q", version, "1.0.13")
 	}
 }
 
@@ -58,7 +58,7 @@ func TestAntigravityUserAgentUsesCLIFamily(t *testing.T) {
 	restore := overrideAntigravityVersionCacheForTest(t, "1.0.8", time.Now().Add(time.Hour))
 	defer restore()
 
-	want := "antigravity/cli/1.0.8 darwin/arm64"
+	want := "antigravity/cli/1.0.8 (aidev_client; os_type=darwin; arch=arm64)"
 	if got := AntigravityUserAgent(); got != want {
 		t.Fatalf("AntigravityUserAgent() = %q, want %q", got, want)
 	}
@@ -67,6 +67,26 @@ func TestAntigravityUserAgentUsesCLIFamily(t *testing.T) {
 func TestAntigravityVersionFromUserAgentParsesCLIFamily(t *testing.T) {
 	if got := AntigravityVersionFromUserAgent("antigravity/cli/1.0.8 darwin/arm64"); got != "1.0.8" {
 		t.Fatalf("AntigravityVersionFromUserAgent() = %q, want %q", got, "1.0.8")
+	}
+}
+
+func TestAntigravityVersionFromUserAgentParsesAidevClientSuffix(t *testing.T) {
+	ua := "antigravity/cli/1.0.13 (aidev_client; os_type=darwin; arch=arm64)"
+	if got := AntigravityVersionFromUserAgent(ua); got != "1.0.13" {
+		t.Fatalf("AntigravityVersionFromUserAgent() = %q, want %q", got, "1.0.13")
+	}
+}
+
+func TestAntigravityLoadCodeAssistUserAgentUsesShortUA(t *testing.T) {
+	restore := overrideAntigravityVersionCacheForTest(t, "1.0.13", time.Now().Add(time.Hour))
+	defer restore()
+
+	want := "antigravity/cli/1.0.13 (aidev_client; os_type=darwin; arch=arm64)"
+	if got := AntigravityLoadCodeAssistUserAgent(""); got != want {
+		t.Fatalf("AntigravityLoadCodeAssistUserAgent() = %q, want %q", got, want)
+	}
+	if got := AntigravityLoadCodeAssistUserAgent(want); got != want {
+		t.Fatalf("AntigravityLoadCodeAssistUserAgent(configured) = %q, want %q", got, want)
 	}
 }
 

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -51,7 +51,7 @@ const (
 	antigravityGeneratePath                = "/v1internal:generateContent"
 	antigravityClientID                    = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
 	antigravityClientSecret                = "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"
-	defaultAntigravityAgent                = "antigravity/cli/1.0.8 darwin/arm64" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
+	defaultAntigravityAgent                = "antigravity/cli/1.0.13 (aidev_client; os_type=darwin; arch=arm64)" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
 	antigravityAuthType                    = "antigravity"
 	refreshSkew                            = 3000 * time.Second
 	antigravityCreditsHintRefreshInterval  = 10 * time.Minute


### PR DESCRIPTION
## Summary

Align CPA Antigravity client fingerprint with agy CLI `1.0.13`:

- Default UA suffix becomes `(aidev_client; os_type=darwin; arch=arm64)` instead of `darwin/arm64`
- `loadCodeAssist` uses the short UA (no `google-api-nodejs-client/...` suffix)
- `onboardUser` keeps the long UA via `AntigravityOnboardUserUserAgent`

## Motivation

Real Antigravity CLI `1.0.13` changed User-Agent formatting. CPA upstream proxy traffic should match the short CLI UA for generate/stream and loadCodeAssist.

## Testing

- `go test ./internal/misc/... ./internal/auth/antigravity/... ./internal/runtime/executor/... -run 'Antigravity|LoadCodeAssist|FetchProject'`
- `go build -o test-output ./cmd/server`
- Live CPA request-log check: upstream `generateContent` sends `antigravity/cli/1.0.13 (aidev_client; os_type=darwin; arch=arm64)`

## Notes

CPAMC quota refresh still hardcodes the old UA in its frontend bundle; tracked separately in Cli-Proxy-API-Management-Center#333.