### PR TITLE
fix(codex): normalize chat completion ids

### DIFF
--- a/internal/translator/codex/openai/chat-completions/codex_openai_response.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_response.go
@@ -26,7 +26,10 @@ var (
 func normalizeChatCompletionID(upstreamID string) string {
 	id := strings.TrimSpace(upstreamID)
 	if strings.HasPrefix(id, "chatcmpl-") {
-		return id
+		if len(id) > len("chatcmpl-") {
+			return id
+		}
+		id = ""
 	}
 
 	switch {
@@ -384,11 +387,7 @@ func ConvertCodexResponseToOpenAINonStream(_ context.Context, _ string, original
 	}
 
 	// Extract and set the response ID.
-	if idResult := responseResult.Get("id"); idResult.Exists() {
-		template, _ = sjson.SetBytes(template, "id", normalizeChatCompletionID(idResult.String()))
-	} else {
-		template, _ = sjson.SetBytes(template, "id", normalizeChatCompletionID(""))
-	}
+	template, _ = sjson.SetBytes(template, "id", normalizeChatCompletionID(responseResult.Get("id").String()))
 
 	// Extract and set usage metadata (token counts).
 	if usageResult := responseResult.Get("usage"); usageResult.Exists() {

--- a/internal/translator/codex/openai/chat-completions/codex_openai_response.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_response.go
@@ -9,7 +9,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/tidwall/gjson"
@@ -17,8 +19,51 @@ import (
 )
 
 var (
-	dataTag = []byte("data:")
+	dataTag                 = []byte("data:")
+	chatCompletionIDCounter uint64
 )
+
+func normalizeChatCompletionID(upstreamID string) string {
+	id := strings.TrimSpace(upstreamID)
+	if strings.HasPrefix(id, "chatcmpl-") {
+		return id
+	}
+
+	switch {
+	case strings.HasPrefix(id, "resp_"):
+		id = strings.TrimPrefix(id, "resp_")
+	case strings.HasPrefix(id, "resp-"):
+		id = strings.TrimPrefix(id, "resp-")
+	}
+
+	id = sanitizeChatCompletionIDSuffix(id)
+	if id == "" {
+		n := atomic.AddUint64(&chatCompletionIDCounter, 1)
+		id = fmt.Sprintf("%x-%d", time.Now().UnixNano(), n)
+	}
+
+	return "chatcmpl-" + id
+}
+
+func sanitizeChatCompletionIDSuffix(id string) string {
+	var b strings.Builder
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+
+	return strings.Trim(b.String(), "-_")
+}
 
 // ConvertCliToOpenAIParams holds parameters for response conversion.
 type ConvertCliToOpenAIParams struct {
@@ -71,7 +116,7 @@ func ConvertCodexResponseToOpenAI(_ context.Context, modelName string, originalR
 	typeResult := rootResult.Get("type")
 	dataType := typeResult.String()
 	if dataType == "response.created" {
-		(*param).(*ConvertCliToOpenAIParams).ResponseID = rootResult.Get("response.id").String()
+		(*param).(*ConvertCliToOpenAIParams).ResponseID = normalizeChatCompletionID(rootResult.Get("response.id").String())
 		(*param).(*ConvertCliToOpenAIParams).CreatedAt = rootResult.Get("response.created_at").Int()
 		(*param).(*ConvertCliToOpenAIParams).Model = rootResult.Get("response.model").String()
 		if (*param).(*ConvertCliToOpenAIParams).LastImageHashByItemID == nil {
@@ -340,7 +385,9 @@ func ConvertCodexResponseToOpenAINonStream(_ context.Context, _ string, original
 
 	// Extract and set the response ID.
 	if idResult := responseResult.Get("id"); idResult.Exists() {
-		template, _ = sjson.SetBytes(template, "id", idResult.String())
+		template, _ = sjson.SetBytes(template, "id", normalizeChatCompletionID(idResult.String()))
+	} else {
+		template, _ = sjson.SetBytes(template, "id", normalizeChatCompletionID(""))
 	}
 
 	// Extract and set usage metadata (token counts).

--- a/internal/translator/codex/openai/chat-completions/codex_openai_response_test.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_response_test.go
@@ -2,6 +2,7 @@ package chat_completions
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -71,11 +72,14 @@ func TestConvertCodexResponseToOpenAI_StreamNormalizesResponseID(t *testing.T) {
 
 func TestNormalizeChatCompletionID(t *testing.T) {
 	tests := []struct {
-		name string
-		in   string
-		want string
+		name       string
+		in         string
+		want       string
+		wantPrefix string
+		wantNot    string
 	}{
 		{name: "already chat completion", in: "chatcmpl-existing", want: "chatcmpl-existing"},
+		{name: "empty chat completion suffix", in: "chatcmpl-", wantPrefix: "chatcmpl-", wantNot: "chatcmpl-"},
 		{name: "responses underscore", in: "resp_abc123", want: "chatcmpl-abc123"},
 		{name: "responses hyphen", in: "resp-abc123", want: "chatcmpl-abc123"},
 		{name: "trims whitespace", in: "  resp_abc123  ", want: "chatcmpl-abc123"},
@@ -85,6 +89,15 @@ func TestNormalizeChatCompletionID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := normalizeChatCompletionID(tt.in)
+			if tt.wantPrefix != "" && !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Fatalf("normalizeChatCompletionID(%q) = %q, want prefix %q", tt.in, got, tt.wantPrefix)
+			}
+			if tt.wantNot != "" && got == tt.wantNot {
+				t.Fatalf("normalizeChatCompletionID(%q) = %q, want a generated id", tt.in, got)
+			}
+			if tt.want == "" {
+				return
+			}
 			if got != tt.want {
 				t.Fatalf("normalizeChatCompletionID(%q) = %q, want %q", tt.in, got, tt.want)
 			}

--- a/internal/translator/codex/openai/chat-completions/codex_openai_response_test.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_response_test.go
@@ -29,6 +29,69 @@ func TestConvertCodexResponseToOpenAI_StreamSetsModelFromResponseCreated(t *test
 	}
 }
 
+func TestConvertCodexResponseToOpenAI_StreamNormalizesResponseID(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	out := ConvertCodexResponseToOpenAI(ctx, "gpt-5.5", nil, nil, []byte(`data: {"type":"response.created","response":{"id":"resp_abc123","created_at":1700000000,"model":"gpt-5.5"}}`), &param)
+	if len(out) != 0 {
+		t.Fatalf("expected no output for response.created, got %d chunks", len(out))
+	}
+
+	out = ConvertCodexResponseToOpenAI(ctx, "gpt-5.5", nil, nil, []byte(`data: {"type":"response.output_text.delta","delta":"ok"}`), &param)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(out))
+	}
+
+	gotID := gjson.GetBytes(out[0], "id").String()
+	if gotID != "chatcmpl-abc123" {
+		t.Fatalf("expected normalized id %q, got %q; chunk=%s", "chatcmpl-abc123", gotID, string(out[0]))
+	}
+
+	out = ConvertCodexResponseToOpenAI(ctx, "gpt-5.5", nil, nil, []byte(`data: {"type":"response.completed","response":{"usage":{"input_tokens":10,"output_tokens":17,"total_tokens":27,"output_tokens_details":{"reasoning_tokens":10}}}}`), &param)
+	if len(out) != 1 {
+		t.Fatalf("expected completion chunk, got %d", len(out))
+	}
+
+	gotID = gjson.GetBytes(out[0], "id").String()
+	if gotID != "chatcmpl-abc123" {
+		t.Fatalf("expected stream chunks to reuse normalized id %q, got %q; chunk=%s", "chatcmpl-abc123", gotID, string(out[0]))
+	}
+
+	gotCompletionTokens := gjson.GetBytes(out[0], "usage.completion_tokens").Int()
+	if gotCompletionTokens != 17 {
+		t.Fatalf("completion_tokens changed: got %d, want 17; chunk=%s", gotCompletionTokens, string(out[0]))
+	}
+
+	gotReasoningTokens := gjson.GetBytes(out[0], "usage.completion_tokens_details.reasoning_tokens").Int()
+	if gotReasoningTokens != 10 {
+		t.Fatalf("reasoning_tokens changed: got %d, want 10; chunk=%s", gotReasoningTokens, string(out[0]))
+	}
+}
+
+func TestNormalizeChatCompletionID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "already chat completion", in: "chatcmpl-existing", want: "chatcmpl-existing"},
+		{name: "responses underscore", in: "resp_abc123", want: "chatcmpl-abc123"},
+		{name: "responses hyphen", in: "resp-abc123", want: "chatcmpl-abc123"},
+		{name: "trims whitespace", in: "  resp_abc123  ", want: "chatcmpl-abc123"},
+		{name: "sanitizes other id", in: "weird/id:123", want: "chatcmpl-weird-id-123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeChatCompletionID(tt.in)
+			if got != tt.want {
+				t.Fatalf("normalizeChatCompletionID(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConvertCodexResponseToOpenAI_FirstChunkUsesRequestModelName(t *testing.T) {
 	ctx := context.Background()
 	var param any
@@ -147,6 +210,28 @@ func TestConvertCodexResponseToOpenAI_NonStreamImageGenerationCallAddsMessageIma
 	gotURL := gjson.GetBytes(out, "choices.0.message.images.0.image_url.url").String()
 	if gotURL != "data:image/png;base64,aGVsbG8=" {
 		t.Fatalf("expected image url %q, got %q; chunk=%s", "data:image/png;base64,aGVsbG8=", gotURL, string(out))
+	}
+}
+
+func TestConvertCodexResponseToOpenAI_NonStreamNormalizesResponseIDAndPreservesUsage(t *testing.T) {
+	ctx := context.Background()
+
+	raw := []byte(`{"type":"response.completed","response":{"id":"resp_abc123","created_at":1700000000,"model":"gpt-5.5","status":"completed","usage":{"input_tokens":10,"output_tokens":17,"total_tokens":27,"output_tokens_details":{"reasoning_tokens":10}},"output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}}`)
+	out := ConvertCodexResponseToOpenAINonStream(ctx, "gpt-5.5", nil, nil, raw, nil)
+
+	gotID := gjson.GetBytes(out, "id").String()
+	if gotID != "chatcmpl-abc123" {
+		t.Fatalf("expected normalized id %q, got %q; response=%s", "chatcmpl-abc123", gotID, string(out))
+	}
+
+	gotCompletionTokens := gjson.GetBytes(out, "usage.completion_tokens").Int()
+	if gotCompletionTokens != 17 {
+		t.Fatalf("completion_tokens changed: got %d, want 17; response=%s", gotCompletionTokens, string(out))
+	}
+
+	gotReasoningTokens := gjson.GetBytes(out, "usage.completion_tokens_details.reasoning_tokens").Int()
+	if gotReasoningTokens != 10 {
+		t.Fatalf("reasoning_tokens changed: got %d, want 10; response=%s", gotReasoningTokens, string(out))
 	}
 }
 


### PR DESCRIPTION
## Summary
- normalize Codex-backed OpenAI Chat Completions public IDs from resp_* / resp-* to chatcmpl-*
- keep already-normalized chatcmpl-* IDs unchanged and sanitize other upstream IDs
- preserve upstream usage semantics, including completion_tokens and reasoning_tokens
- add stream and non-stream regression tests for ID normalization and usage preservation

## Verification
- PASS: go test -v ./internal/translator/codex/openai/chat-completions
- PASS: go build -o test-output ./cmd/server && rm test-output
- FAIL: go test ./... has unrelated existing failures outside this change:
  - internal/pluginhost: TestRegisterModelsRegistersProviderModelsAndClientID, TestRegisterModelsUsesModelProviderStaticModels, TestRegisterModelsPrunesStaleClientAfterSnapshotChange
  - internal/runtime/executor: TestPrepareAntigravityGeminiReasoningReplayPayloadAppendsStaleThoughtSignatureWithoutNullParts
  - internal/translator/gemini/openai/responses: TestConvertOpenAIResponsesRequestToGemini_ReasoningSignatureCompatibility cases
