### PR TITLE
Add reasoning effort to OAuth model aliases

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -396,6 +396,9 @@ nonstream-keepalive-interval: 0
 #   codex:
 #     - name: "gpt-5"
 #       alias: "g5"
+#     - name: "gpt-5.5"
+#       alias: "gpt-5.5-high"
+#       reasoning-effort: "high" # optional: applies fixed thinking level when alias is used
 #   kimi:
 #     - name: "kimi-k2.5"
 #       alias: "k2.5"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	sdkpluginstore "github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginstore"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
@@ -354,6 +355,9 @@ type OAuthModelAlias struct {
 	Name  string `yaml:"name" json:"name"`
 	Alias string `yaml:"alias" json:"alias"`
 	Fork  bool   `yaml:"fork,omitempty" json:"fork,omitempty"`
+
+	// ReasoningEffort applies a fixed thinking/reasoning level when this alias is used.
+	ReasoningEffort string `yaml:"reasoning-effort,omitempty" json:"reasoning-effort,omitempty"`
 
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 }
@@ -944,7 +948,13 @@ func (cfg *Config) SanitizeOAuthModelAlias() {
 				continue
 			}
 			seenAlias[aliasKey] = struct{}{}
-			clean = append(clean, OAuthModelAlias{Name: name, Alias: alias, Fork: entry.Fork, ForceMapping: entry.ForceMapping})
+			reasoningEffort := strings.ToLower(strings.TrimSpace(entry.ReasoningEffort))
+			if reasoningEffort != "" {
+				if _, ok := thinking.ParseLevelSuffix(reasoningEffort); !ok {
+					continue
+				}
+			}
+			clean = append(clean, OAuthModelAlias{Name: name, Alias: alias, Fork: entry.Fork, ReasoningEffort: reasoningEffort, ForceMapping: entry.ForceMapping})
 		}
 		if len(clean) > 0 {
 			out[channel] = clean

--- a/internal/config/oauth_model_alias_test.go
+++ b/internal/config/oauth_model_alias_test.go
@@ -6,7 +6,7 @@ func TestSanitizeOAuthModelAlias_PreservesForkFlag(t *testing.T) {
 	cfg := &Config{
 		OAuthModelAlias: map[string][]OAuthModelAlias{
 			" CoDeX ": {
-				{Name: " gpt-5 ", Alias: " g5 ", Fork: true},
+				{Name: " gpt-5 ", Alias: " g5 ", Fork: true, ReasoningEffort: " HIGH "},
 				{Name: "gpt-6", Alias: "g6"},
 			},
 		},
@@ -18,8 +18,8 @@ func TestSanitizeOAuthModelAlias_PreservesForkFlag(t *testing.T) {
 	if len(aliases) != 2 {
 		t.Fatalf("expected 2 sanitized aliases, got %d", len(aliases))
 	}
-	if aliases[0].Name != "gpt-5" || aliases[0].Alias != "g5" || !aliases[0].Fork {
-		t.Fatalf("expected first alias to be gpt-5->g5 fork=true, got name=%q alias=%q fork=%v", aliases[0].Name, aliases[0].Alias, aliases[0].Fork)
+	if aliases[0].Name != "gpt-5" || aliases[0].Alias != "g5" || !aliases[0].Fork || aliases[0].ReasoningEffort != "high" {
+		t.Fatalf("expected first alias to be gpt-5->g5 fork=true reasoning-effort=high, got name=%q alias=%q fork=%v reasoning-effort=%q", aliases[0].Name, aliases[0].Alias, aliases[0].Fork, aliases[0].ReasoningEffort)
 	}
 	if aliases[1].Name != "gpt-6" || aliases[1].Alias != "g6" || aliases[1].Fork {
 		t.Fatalf("expected second alias to be gpt-6->g6 fork=false, got name=%q alias=%q fork=%v", aliases[1].Name, aliases[1].Alias, aliases[1].Fork)

--- a/internal/watcher/diff/oauth_model_alias.go
+++ b/internal/watcher/diff/oauth_model_alias.go
@@ -83,6 +83,9 @@ func summarizeOAuthModelAliasList(list []config.OAuthModelAlias) OAuthModelAlias
 		if alias.Fork {
 			key += "|fork"
 		}
+		if alias.ReasoningEffort != "" {
+			key += "|reasoning-effort=" + strings.ToLower(strings.TrimSpace(alias.ReasoningEffort))
+		}
 		if alias.ForceMapping {
 			key += "|force-mapping"
 		}

--- a/sdk/cliproxy/auth/oauth_model_alias.go
+++ b/sdk/cliproxy/auth/oauth_model_alias.go
@@ -18,9 +18,10 @@ type modelAliasEntry interface {
 
 // oauthModelAliasEntry stores the upstream model name and mapping flags for an alias.
 type oauthModelAliasEntry struct {
-	upstreamModel string
-	configAlias   string
-	forceMapping  bool
+	upstreamModel   string
+	configAlias     string
+	reasoningEffort string
+	forceMapping    bool
 }
 
 type oauthModelAliasTable struct {
@@ -62,9 +63,10 @@ func compileOAuthModelAliasTable(aliases map[string][]internalconfig.OAuthModelA
 				continue
 			}
 			rev[aliasKey] = oauthModelAliasEntry{
-				upstreamModel: name,
-				configAlias:   alias,
-				forceMapping:  entry.ForceMapping,
+				upstreamModel:   name,
+				configAlias:     alias,
+				reasoningEffort: strings.ToLower(strings.TrimSpace(entry.ReasoningEffort)),
+				forceMapping:    entry.ForceMapping,
 			}
 		}
 		if len(rev) > 0 {
@@ -120,12 +122,20 @@ func modelAliasLookupCandidates(requestedModel string) (thinking.SuffixResult, [
 }
 
 func preserveResolvedModelSuffix(resolved string, requestResult thinking.SuffixResult) string {
+	return preserveResolvedModelSuffixWithEffort(resolved, requestResult, "")
+}
+
+func preserveResolvedModelSuffixWithEffort(resolved string, requestResult thinking.SuffixResult, reasoningEffort string) string {
 	resolved = strings.TrimSpace(resolved)
 	if resolved == "" {
 		return ""
 	}
 	if thinking.ParseSuffix(resolved).HasSuffix {
 		return resolved
+	}
+	reasoningEffort = strings.ToLower(strings.TrimSpace(reasoningEffort))
+	if reasoningEffort != "" {
+		return resolved + "(" + reasoningEffort + ")"
 	}
 	if requestResult.HasSuffix && requestResult.RawSuffix != "" {
 		return resolved + "(" + requestResult.RawSuffix + ")"
@@ -359,7 +369,7 @@ func resolveUpstreamModelFromAliases(aliases []internalconfig.OAuthModelAlias, r
 					return OAuthModelAliasResult{}
 				}
 				return OAuthModelAliasResult{
-					UpstreamModel: preserveResolvedModelSuffix(original, requestResult),
+					UpstreamModel: preserveResolvedModelSuffixWithEffort(original, requestResult, entry.ReasoningEffort),
 					ForceMapping:  entry.ForceMapping,
 					OriginalAlias: oauthModelAliasForceMappingResponseModel(alias),
 				}
@@ -369,7 +379,7 @@ func resolveUpstreamModelFromAliases(aliases []internalconfig.OAuthModelAlias, r
 				originalAlias = oauthModelAliasForceMappingResponseModel(alias)
 			}
 			return OAuthModelAliasResult{
-				UpstreamModel: preserveResolvedModelSuffix(original, requestResult),
+				UpstreamModel: preserveResolvedModelSuffixWithEffort(original, requestResult, entry.ReasoningEffort),
 				ForceMapping:  entry.ForceMapping,
 				OriginalAlias: originalAlias,
 			}
@@ -432,20 +442,13 @@ func resolveUpstreamModelFromAliasTable(m *Manager, auth *Auth, requestedModel, 
 				return OAuthModelAliasResult{}
 			}
 			return OAuthModelAliasResult{
-				UpstreamModel: preserveResolvedModelSuffix(targetModel, requestResult),
+				UpstreamModel: preserveResolvedModelSuffixWithEffort(targetModel, requestResult, entry.reasoningEffort),
 				ForceMapping:  entry.forceMapping,
 				OriginalAlias: oauthModelAliasForceMappingResponseModel(entry.configAlias),
 			}
 		}
 
-		var upstreamModel string
-		if thinking.ParseSuffix(targetModel).HasSuffix {
-			upstreamModel = targetModel
-		} else if requestResult.HasSuffix && requestResult.RawSuffix != "" {
-			upstreamModel = targetModel + "(" + requestResult.RawSuffix + ")"
-		} else {
-			upstreamModel = targetModel
-		}
+		upstreamModel := preserveResolvedModelSuffixWithEffort(targetModel, requestResult, entry.reasoningEffort)
 
 		originalAlias := requestedModel
 		if entry.forceMapping {

--- a/sdk/cliproxy/auth/oauth_model_alias_reasoning_test.go
+++ b/sdk/cliproxy/auth/oauth_model_alias_reasoning_test.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestApplyOAuthModelAlias_ReasoningEffortAppliesFixedSuffix(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{
+			Name:            "gpt-5.5",
+			Alias:           "gpt-5.5-high",
+			ReasoningEffort: "high",
+			Fork:            true,
+		}},
+	})
+
+	auth := createAuthForChannel("codex")
+	resolvedModel := mgr.applyOAuthModelAlias(auth, "gpt-5.5-high")
+	if resolvedModel != "gpt-5.5(high)" {
+		t.Fatalf("applyOAuthModelAlias() model = %q, want %q", resolvedModel, "gpt-5.5(high)")
+	}
+}
+
+func TestApplyOAuthModelAlias_ReasoningEffortOverridesRequestSuffix(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{
+			Name:            "gpt-5.5",
+			Alias:           "gpt-5.5-high",
+			ReasoningEffort: "high",
+			Fork:            true,
+		}},
+	})
+
+	auth := createAuthForChannel("codex")
+	resolvedModel := mgr.applyOAuthModelAlias(auth, "gpt-5.5-high(low)")
+	if resolvedModel != "gpt-5.5(high)" {
+		t.Fatalf("applyOAuthModelAlias() model = %q, want fixed alias effort %q", resolvedModel, "gpt-5.5(high)")
+	}
+}
+
+func TestApplyOAuthModelAlias_PerAuthReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	auth := &Auth{
+		ID:       "codex-auth-id",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"auth_kind":     "oauth",
+			"model_aliases": `[{"name":"gpt-5.5","alias":"gpt-5.5-medium","reasoning-effort":"medium"}]`,
+		},
+	}
+
+	resolvedModel := mgr.applyOAuthModelAlias(auth, "gpt-5.5-medium")
+	if resolvedModel != "gpt-5.5(medium)" {
+		t.Fatalf("applyOAuthModelAlias() model = %q, want %q", resolvedModel, "gpt-5.5(medium)")
+	}
+}


### PR DESCRIPTION
Adds a first-class `reasoning-effort` field to OAuth model aliases so client-visible aliases can map to an upstream model plus a fixed thinking/reasoning level.\n\nExample:\n\n```yaml\noauth-model-alias:\n  codex:\n    - name: "gpt-5.5"\n      alias: "gpt-5.5-high"\n      reasoning-effort: "high"\n      fork: true\n```\n\nBehavior:\n- `gpt-5.5-high` routes upstream as `gpt-5.5(high)`.\n- A request suffix like `gpt-5.5-high(low)` is overridden by the fixed alias effort.\n- Existing aliases without `reasoning-effort` keep previous suffix behavior.\n- Invalid effort values are dropped during config sanitization.\n\nVerification:\n- `go test ./internal/config ./internal/watcher/diff ./sdk/cliproxy/auth`\n- `go build -o /tmp/cli-proxy-api-test ./cmd/server && rm /tmp/cli-proxy-api-test`\n- `go test ./...`