### PR TITLE
Add Cline Pass auth-file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,29 @@ PackyCode provides special discounts for our software users: register using <a h
 - Claude Code multi-account load balancing
 - OpenAI Codex multi-account load balancing
 - Grok Build multi-account load balancing
+- Cline Pass support via the Cline provider settings file
 - OpenAI-compatible upstream providers via config (e.g., OpenRouter)
 - Reusable Go SDK for embedding the proxy (see `docs/sdk-usage.md`)
 
 ## Getting Started
 
 CLIProxyAPI Guides: [https://help.router-for.me/](https://help.router-for.me/)
+
+## Cline Pass
+
+CLIProxyAPI can route Cline Pass models through Cline's OpenAI-compatible API
+when Cline is already signed in locally. Put Cline's provider settings JSON in
+the configured `auth-dir` explicitly, for example:
+
+```bash
+ln -s ~/.cline/data/settings/providers.json ~/.cli-proxy-api/cline-providers.json
+```
+
+The proxy reads the current Cline Pass access token from that file at request
+time instead of copying it into CLIProxyAPI auth metadata. Once loaded, models
+such as `cline-pass/glm-5.2`, `cline-pass/kimi-k2.7-code`,
+`cline-pass/deepseek-v4-pro`, and `cline-pass/qwen3.7-max` are available
+through the OpenAI-compatible chat completions endpoint.
 
 ## Management API
 

--- a/internal/auth/cline/settings.go
+++ b/internal/auth/cline/settings.go
@@ -1,20 +1,15 @@
 package cline
 
 import (
-	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -42,9 +37,8 @@ type ProviderSettings struct {
 }
 
 type AuthSettings struct {
-	AccessToken  string `json:"accessToken"`
-	RefreshToken string `json:"refreshToken"`
-	ExpiresAt    any    `json:"expiresAt"`
+	AccessToken string `json:"accessToken"`
+	ExpiresAt   any    `json:"expiresAt"`
 }
 
 type providerAccessTokenCacheEntry struct {
@@ -60,31 +54,8 @@ var providerAccessTokenCache = struct {
 	entries: make(map[string]providerAccessTokenCacheEntry),
 }
 
-var (
-	clineAPIBaseURL                 = APIBaseURL
-	providerAccessTokenRefreshGroup singleflight.Group
-)
-
 type providerMatch struct {
 	provider ProviderSettings
-}
-
-type providerAccessTokenSnapshot struct {
-	providerAccessTokenCacheEntry
-	auth AuthSettings
-}
-
-type refreshResponse struct {
-	Success *bool `json:"success"`
-	Data    struct {
-		AccessToken  string `json:"accessToken"`
-		RefreshToken string `json:"refreshToken"`
-		ExpiresAt    any    `json:"expiresAt"`
-	} `json:"data"`
-	Code      string `json:"code"`
-	ErrorCode string `json:"errorCode"`
-	Error     string `json:"error"`
-	Message   string `json:"message"`
 }
 
 func ParseProviderSettings(data []byte) (*ProviderSettingsFile, error) {
@@ -271,40 +242,25 @@ func ReadProviderAccessToken(path string, providerID string) (string, error) {
 		return cached.token, nil
 	}
 
-	snapshot, err := readProviderAccessTokenSnapshot(path, providerID)
+	entry, err := readProviderAccessTokenCacheEntry(path, providerID, modTime)
 	if err != nil {
 		return "", err
 	}
-	if tokenExpiresSoon(snapshot.expiresAt, time.Now()) && strings.TrimSpace(snapshot.auth.RefreshToken) != "" {
-		value, errRefresh, _ := providerAccessTokenRefreshGroup.Do(cacheKey, func() (any, error) {
-			return refreshProviderAccessToken(path, providerID)
-		})
-		if errRefresh != nil {
-			return "", errRefresh
-		}
-		refreshed, ok := value.(providerAccessTokenCacheEntry)
-		if !ok {
-			return "", fmt.Errorf("cline provider settings: invalid refresh result")
-		}
-		return refreshed.token, nil
+	if tokenExpiresSoon(entry.expiresAt, time.Now()) {
+		return "", fmt.Errorf("cline provider settings: provider %q access token expired", providerID)
 	}
-	cacheProviderAccessToken(cacheKey, snapshot.providerAccessTokenCacheEntry)
-	return snapshot.token, nil
+	cacheProviderAccessToken(cacheKey, entry)
+	return entry.token, nil
 }
 
-func readProviderAccessTokenSnapshot(path string, providerID string) (providerAccessTokenSnapshot, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return providerAccessTokenSnapshot{}, err
-	}
-	modTime := info.ModTime()
+func readProviderAccessTokenCacheEntry(path string, providerID string, modTime time.Time) (providerAccessTokenCacheEntry, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return providerAccessTokenSnapshot{}, err
+		return providerAccessTokenCacheEntry{}, err
 	}
 	settings, err := ParseProviderSettings(data)
 	if err != nil {
-		return providerAccessTokenSnapshot{}, err
+		return providerAccessTokenCacheEntry{}, err
 	}
 	providerIDs := []string{providerID}
 	if providerID == ProviderClinePass {
@@ -312,67 +268,14 @@ func readProviderAccessTokenSnapshot(path string, providerID string) (providerAc
 	}
 	match, ok := findProviderAuth(settings, providerIDs...)
 	if !ok {
-		return providerAccessTokenSnapshot{}, fmt.Errorf("cline provider settings: provider %q missing access token", providerID)
+		return providerAccessTokenCacheEntry{}, fmt.Errorf("cline provider settings: provider %q missing access token", providerID)
 	}
 	token := strings.TrimSpace(match.provider.Auth.AccessToken)
-	return providerAccessTokenSnapshot{
-		providerAccessTokenCacheEntry: providerAccessTokenCacheEntry{
-			token:     token,
-			modTime:   modTime,
-			expiresAt: authExpiryTime(match.provider.Auth, token),
-		},
-		auth: match.provider.Auth,
-	}, nil
-}
-
-func refreshProviderAccessToken(path string, providerID string) (providerAccessTokenCacheEntry, error) {
-	snapshot, err := readProviderAccessTokenSnapshot(path, providerID)
-	if err != nil {
-		return providerAccessTokenCacheEntry{}, err
-	}
-	if !tokenExpiresSoon(snapshot.expiresAt, time.Now()) || strings.TrimSpace(snapshot.auth.RefreshToken) == "" {
-		cacheProviderAccessToken(path+"|"+providerID, snapshot.providerAccessTokenCacheEntry)
-		return snapshot.providerAccessTokenCacheEntry, nil
-	}
-	refreshed, err := refreshProviderAuth(snapshot.auth.RefreshToken)
-	if err != nil {
-		return providerAccessTokenCacheEntry{}, err
-	}
-	if current, changed, err := readCurrentProviderAccessTokenIfRefreshTokenChanged(path, providerID, snapshot); err != nil {
-		return providerAccessTokenCacheEntry{}, err
-	} else if changed {
-		cacheProviderAccessToken(path+"|"+providerID, current)
-		return current, nil
-	}
-	token := strings.TrimSpace(refreshed.AccessToken)
-	result := providerAccessTokenCacheEntry{
+	return providerAccessTokenCacheEntry{
 		token:     token,
-		modTime:   snapshot.modTime,
-		expiresAt: authExpiryTime(refreshed, token),
-	}
-	cacheProviderAccessToken(path+"|"+providerID, result)
-	return result, nil
-}
-
-func readCurrentProviderAccessTokenIfRefreshTokenChanged(path string, providerID string, previous providerAccessTokenSnapshot) (providerAccessTokenCacheEntry, bool, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return providerAccessTokenCacheEntry{}, false, err
-	}
-	if info.ModTime().Equal(previous.modTime) {
-		return providerAccessTokenCacheEntry{}, false, nil
-	}
-	current, err := readProviderAccessTokenSnapshot(path, providerID)
-	if err != nil {
-		return providerAccessTokenCacheEntry{}, false, err
-	}
-	if strings.TrimSpace(current.auth.RefreshToken) == strings.TrimSpace(previous.auth.RefreshToken) {
-		return providerAccessTokenCacheEntry{}, false, nil
-	}
-	if tokenExpiresSoon(current.expiresAt, time.Now()) {
-		return providerAccessTokenCacheEntry{}, false, fmt.Errorf("cline provider settings: provider auth changed during refresh")
-	}
-	return current.providerAccessTokenCacheEntry, true, nil
+		modTime:   modTime,
+		expiresAt: authExpiryTime(match.provider.Auth, token),
+	}, nil
 }
 
 func cacheProviderAccessToken(cacheKey string, entry providerAccessTokenCacheEntry) {
@@ -466,80 +369,4 @@ func stripClineAccountAccessTokenPrefix(token string) string {
 		return token[len("workos:"):]
 	}
 	return token
-}
-
-func formatClineAccountAccessToken(token string) string {
-	token = strings.TrimSpace(token)
-	if token == "" || strings.HasPrefix(strings.ToLower(token), "workos:") {
-		return token
-	}
-	return "workos:" + token
-}
-
-func refreshProviderAuth(refreshToken string) (AuthSettings, error) {
-	refreshToken = strings.TrimSpace(refreshToken)
-	if refreshToken == "" {
-		return AuthSettings{}, fmt.Errorf("cline provider settings: missing refresh token")
-	}
-	body, err := json.Marshal(map[string]string{
-		"grantType":    "refresh_token",
-		"refreshToken": refreshToken,
-	})
-	if err != nil {
-		return AuthSettings{}, err
-	}
-	url := strings.TrimRight(clineAPIBaseURL, "/") + "/auth/refresh"
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return AuthSettings{}, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return AuthSettings{}, fmt.Errorf("cline provider settings: refresh token request failed: %w", err)
-	}
-	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	var payload refreshResponse
-	_ = json.Unmarshal(respBody, &payload)
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 || (payload.Success != nil && !*payload.Success) {
-		return AuthSettings{}, fmt.Errorf("cline provider settings: refresh token request failed: %s", safeRefreshErrorDetail(resp.StatusCode, payload))
-	}
-	accessToken := strings.TrimSpace(payload.Data.AccessToken)
-	if accessToken == "" {
-		return AuthSettings{}, fmt.Errorf("cline provider settings: refresh token response missing access token")
-	}
-	refreshed := AuthSettings{
-		AccessToken:  formatClineAccountAccessToken(accessToken),
-		RefreshToken: strings.TrimSpace(payload.Data.RefreshToken),
-		ExpiresAt:    payload.Data.ExpiresAt,
-	}
-	if refreshed.RefreshToken == "" {
-		refreshed.RefreshToken = refreshToken
-	}
-	return refreshed, nil
-}
-
-func safeRefreshErrorDetail(status int, payload refreshResponse) string {
-	for _, value := range []string{payload.Code, payload.ErrorCode, payload.Error, payload.Message} {
-		value = strings.TrimSpace(value)
-		if isSafeErrorCode(value) {
-			return value
-		}
-	}
-	return fmt.Sprintf("HTTP %d", status)
-}
-
-func isSafeErrorCode(value string) bool {
-	if len(value) == 0 || len(value) > 64 {
-		return false
-	}
-	for _, r := range value {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
-			continue
-		}
-		return false
-	}
-	return true
 }

--- a/internal/auth/cline/settings.go
+++ b/internal/auth/cline/settings.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -26,8 +25,7 @@ const (
 )
 
 type ProviderSettingsFile struct {
-	Providers       map[string]ProviderEntry `json:"providers"`
-	providerRawKeys map[string]string
+	Providers map[string]ProviderEntry `json:"providers"`
 }
 
 type ProviderEntry struct {
@@ -47,7 +45,6 @@ type AuthSettings struct {
 	AccessToken  string `json:"accessToken"`
 	RefreshToken string `json:"refreshToken"`
 	ExpiresAt    any    `json:"expiresAt"`
-	AccountID    string `json:"accountId"`
 }
 
 type providerAccessTokenCacheEntry struct {
@@ -69,15 +66,12 @@ var (
 )
 
 type providerMatch struct {
-	key      string
 	provider ProviderSettings
 }
 
 type providerAccessTokenSnapshot struct {
 	providerAccessTokenCacheEntry
-	resolvedPath string
-	matchKey     string
-	auth         AuthSettings
+	auth AuthSettings
 }
 
 type refreshResponse struct {
@@ -86,11 +80,6 @@ type refreshResponse struct {
 		AccessToken  string `json:"accessToken"`
 		RefreshToken string `json:"refreshToken"`
 		ExpiresAt    any    `json:"expiresAt"`
-		AccountID    string `json:"accountId"`
-		UserInfo     struct {
-			ClineUserID string `json:"clineUserId"`
-			AccountID   string `json:"accountId"`
-		} `json:"userInfo"`
 	} `json:"data"`
 	Code      string `json:"code"`
 	ErrorCode string `json:"errorCode"`
@@ -110,7 +99,6 @@ func ParseProviderSettings(data []byte) (*ProviderSettingsFile, error) {
 		return nil, fmt.Errorf("cline provider settings: no providers")
 	}
 	normalized := make(map[string]ProviderEntry, len(settings.Providers))
-	rawKeys := make(map[string]string, len(settings.Providers))
 	for rawKey, entry := range settings.Providers {
 		key := strings.ToLower(strings.TrimSpace(rawKey))
 		if key == "" {
@@ -120,10 +108,8 @@ func ParseProviderSettings(data []byte) (*ProviderSettingsFile, error) {
 			return nil, fmt.Errorf("cline provider settings: duplicate provider key %q", key)
 		}
 		normalized[key] = entry
-		rawKeys[key] = rawKey
 	}
 	settings.Providers = normalized
-	settings.providerRawKeys = rawKeys
 	return &settings, nil
 }
 
@@ -155,7 +141,7 @@ func findProvider(settings *ProviderSettingsFile, providerIDs ...string) (provid
 		if entry, ok := settings.Providers[expectedProviderID]; ok {
 			provider := providerSettingsForEntry(expectedProviderID, entry)
 			if providerIDForEntry(expectedProviderID, provider) == expectedProviderID {
-				return providerMatch{key: settings.rawProviderKey(expectedProviderID), provider: provider}, true
+				return providerMatch{provider: provider}, true
 			}
 		}
 		for _, key := range sortedProviderKeys(settings.Providers) {
@@ -164,7 +150,7 @@ func findProvider(settings *ProviderSettingsFile, providerIDs ...string) (provid
 			}
 			provider := providerSettingsForEntry(key, settings.Providers[key])
 			if providerIDForEntry(key, provider) == expectedProviderID {
-				return providerMatch{key: settings.rawProviderKey(key), provider: provider}, true
+				return providerMatch{provider: provider}, true
 			}
 		}
 	}
@@ -197,7 +183,7 @@ func providerMatches(settings *ProviderSettingsFile, expectedProviderID string) 
 	if entry, ok := settings.Providers[expectedProviderID]; ok {
 		provider := providerSettingsForEntry(expectedProviderID, entry)
 		if providerIDForEntry(expectedProviderID, provider) == expectedProviderID {
-			matches = append(matches, providerMatch{key: settings.rawProviderKey(expectedProviderID), provider: provider})
+			matches = append(matches, providerMatch{provider: provider})
 		}
 	}
 	for _, key := range sortedProviderKeys(settings.Providers) {
@@ -206,19 +192,10 @@ func providerMatches(settings *ProviderSettingsFile, expectedProviderID string) 
 		}
 		provider := providerSettingsForEntry(key, settings.Providers[key])
 		if providerIDForEntry(key, provider) == expectedProviderID {
-			matches = append(matches, providerMatch{key: settings.rawProviderKey(key), provider: provider})
+			matches = append(matches, providerMatch{provider: provider})
 		}
 	}
 	return matches
-}
-
-func (settings *ProviderSettingsFile) rawProviderKey(normalizedKey string) string {
-	if settings != nil && settings.providerRawKeys != nil {
-		if rawKey := settings.providerRawKeys[normalizedKey]; strings.TrimSpace(rawKey) != "" {
-			return rawKey
-		}
-	}
-	return normalizedKey
 }
 
 func normalizeProviderIDs(providerIDs ...string) []string {
@@ -321,11 +298,7 @@ func readProviderAccessTokenSnapshot(path string, providerID string) (providerAc
 		return providerAccessTokenSnapshot{}, err
 	}
 	modTime := info.ModTime()
-	resolvedPath := path
-	if evaluated, errEval := filepath.EvalSymlinks(path); errEval == nil && strings.TrimSpace(evaluated) != "" {
-		resolvedPath = evaluated
-	}
-	data, err := os.ReadFile(resolvedPath)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return providerAccessTokenSnapshot{}, err
 	}
@@ -341,18 +314,14 @@ func readProviderAccessTokenSnapshot(path string, providerID string) (providerAc
 	if !ok {
 		return providerAccessTokenSnapshot{}, fmt.Errorf("cline provider settings: provider %q missing access token", providerID)
 	}
-	provider := match.provider
-	token := strings.TrimSpace(provider.Auth.AccessToken)
-	expiresAt := authExpiryTime(provider.Auth, token)
+	token := strings.TrimSpace(match.provider.Auth.AccessToken)
 	return providerAccessTokenSnapshot{
 		providerAccessTokenCacheEntry: providerAccessTokenCacheEntry{
 			token:     token,
 			modTime:   modTime,
-			expiresAt: expiresAt,
+			expiresAt: authExpiryTime(match.provider.Auth, token),
 		},
-		resolvedPath: resolvedPath,
-		matchKey:     match.key,
-		auth:         provider.Auth,
+		auth: match.provider.Auth,
 	}, nil
 }
 
@@ -369,30 +338,41 @@ func refreshProviderAccessToken(path string, providerID string) (providerAccessT
 	if err != nil {
 		return providerAccessTokenCacheEntry{}, err
 	}
-	updated, err := updateStoredProviderAuth(snapshot.resolvedPath, snapshot.matchKey, snapshot.auth.RefreshToken, refreshed)
-	if err != nil {
+	if current, changed, err := readCurrentProviderAccessTokenIfRefreshTokenChanged(path, providerID, snapshot); err != nil {
 		return providerAccessTokenCacheEntry{}, err
-	}
-	if !updated {
-		current, errCurrent := readProviderAccessTokenSnapshot(path, providerID)
-		if errCurrent != nil {
-			return providerAccessTokenCacheEntry{}, errCurrent
-		}
-		if tokenExpiresSoon(current.expiresAt, time.Now()) {
-			return providerAccessTokenCacheEntry{}, fmt.Errorf("cline provider settings: provider auth changed during refresh")
-		}
-		cacheProviderAccessToken(path+"|"+providerID, current.providerAccessTokenCacheEntry)
-		return current.providerAccessTokenCacheEntry, nil
+	} else if changed {
+		cacheProviderAccessToken(path+"|"+providerID, current)
+		return current, nil
 	}
 	token := strings.TrimSpace(refreshed.AccessToken)
-	expiresAt := authExpiryTime(refreshed, token)
-	modTime := snapshot.modTime
-	if refreshedInfo, errStat := os.Stat(path); errStat == nil {
-		modTime = refreshedInfo.ModTime()
+	result := providerAccessTokenCacheEntry{
+		token:     token,
+		modTime:   snapshot.modTime,
+		expiresAt: authExpiryTime(refreshed, token),
 	}
-	result := providerAccessTokenCacheEntry{token: token, modTime: modTime, expiresAt: expiresAt}
 	cacheProviderAccessToken(path+"|"+providerID, result)
 	return result, nil
+}
+
+func readCurrentProviderAccessTokenIfRefreshTokenChanged(path string, providerID string, previous providerAccessTokenSnapshot) (providerAccessTokenCacheEntry, bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return providerAccessTokenCacheEntry{}, false, err
+	}
+	if info.ModTime().Equal(previous.modTime) {
+		return providerAccessTokenCacheEntry{}, false, nil
+	}
+	current, err := readProviderAccessTokenSnapshot(path, providerID)
+	if err != nil {
+		return providerAccessTokenCacheEntry{}, false, err
+	}
+	if strings.TrimSpace(current.auth.RefreshToken) == strings.TrimSpace(previous.auth.RefreshToken) {
+		return providerAccessTokenCacheEntry{}, false, nil
+	}
+	if tokenExpiresSoon(current.expiresAt, time.Now()) {
+		return providerAccessTokenCacheEntry{}, false, fmt.Errorf("cline provider settings: provider auth changed during refresh")
+	}
+	return current.providerAccessTokenCacheEntry, true, nil
 }
 
 func cacheProviderAccessToken(cacheKey string, entry providerAccessTokenCacheEntry) {
@@ -530,18 +510,10 @@ func refreshProviderAuth(refreshToken string) (AuthSettings, error) {
 	if accessToken == "" {
 		return AuthSettings{}, fmt.Errorf("cline provider settings: refresh token response missing access token")
 	}
-	accountID := strings.TrimSpace(payload.Data.AccountID)
-	if accountID == "" {
-		accountID = strings.TrimSpace(payload.Data.UserInfo.ClineUserID)
-	}
-	if accountID == "" {
-		accountID = strings.TrimSpace(payload.Data.UserInfo.AccountID)
-	}
 	refreshed := AuthSettings{
 		AccessToken:  formatClineAccountAccessToken(accessToken),
 		RefreshToken: strings.TrimSpace(payload.Data.RefreshToken),
 		ExpiresAt:    payload.Data.ExpiresAt,
-		AccountID:    accountID,
 	}
 	if refreshed.RefreshToken == "" {
 		refreshed.RefreshToken = refreshToken
@@ -570,72 +542,4 @@ func isSafeErrorCode(value string) bool {
 		return false
 	}
 	return true
-}
-
-func updateStoredProviderAuth(path string, providerKey string, expectedRefreshToken string, refreshed AuthSettings) (bool, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return false, err
-	}
-	var root map[string]any
-	if err := json.Unmarshal(data, &root); err != nil {
-		return false, err
-	}
-	providers, ok := root["providers"].(map[string]any)
-	if !ok {
-		return false, fmt.Errorf("cline provider settings: providers object missing")
-	}
-	entry, ok := providers[providerKey].(map[string]any)
-	if !ok {
-		return false, fmt.Errorf("cline provider settings: provider %q missing during refresh", providerKey)
-	}
-	authTarget := providerAuthTarget(entry)
-	if authTarget == nil {
-		settings, _ := entry["settings"].(map[string]any)
-		if settings == nil {
-			settings = map[string]any{}
-			entry["settings"] = settings
-		}
-		authTarget = map[string]any{}
-		settings["auth"] = authTarget
-	}
-	if currentRefresh, _ := authTarget["refreshToken"].(string); strings.TrimSpace(currentRefresh) != "" && strings.TrimSpace(currentRefresh) != expectedRefreshToken {
-		return false, nil
-	}
-	authTarget["accessToken"] = refreshed.AccessToken
-	authTarget["refreshToken"] = refreshed.RefreshToken
-	authTarget["expiresAt"] = refreshed.ExpiresAt
-	if strings.TrimSpace(refreshed.AccountID) != "" {
-		authTarget["accountId"] = refreshed.AccountID
-	}
-	updated, err := json.MarshalIndent(root, "", "  ")
-	if err != nil {
-		return false, err
-	}
-	updated = append(updated, '\n')
-	info, err := os.Stat(path)
-	if err != nil {
-		return false, err
-	}
-	tmpPath := fmt.Sprintf("%s.%d.%d.tmp", path, os.Getpid(), time.Now().UnixNano())
-	if err := os.WriteFile(tmpPath, updated, info.Mode().Perm()); err != nil {
-		return false, err
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
-		return false, err
-	}
-	return true, nil
-}
-
-func providerAuthTarget(entry map[string]any) map[string]any {
-	if settings, _ := entry["settings"].(map[string]any); settings != nil {
-		if auth, _ := settings["auth"].(map[string]any); auth != nil {
-			return auth
-		}
-	}
-	if auth, _ := entry["auth"].(map[string]any); auth != nil {
-		return auth
-	}
-	return nil
 }

--- a/internal/auth/cline/settings.go
+++ b/internal/auth/cline/settings.go
@@ -1,0 +1,138 @@
+package cline
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	ProviderClinePass                = "cline-pass"
+	APIBaseURL                       = "https://api.cline.bot/api/v1"
+	CredentialSourceProviderSettings = "cline-provider-settings"
+)
+
+type ProviderSettingsFile struct {
+	Providers map[string]ProviderEntry `json:"providers"`
+}
+
+type ProviderEntry struct {
+	Settings ProviderSettings `json:"settings"`
+}
+
+type ProviderSettings struct {
+	Provider string       `json:"provider"`
+	Model    string       `json:"model"`
+	Auth     AuthSettings `json:"auth"`
+}
+
+type AuthSettings struct {
+	AccessToken  string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken"`
+	ExpiresAt    any    `json:"expiresAt"`
+	AccountID    string `json:"accountId"`
+}
+
+type providerAccessTokenCacheEntry struct {
+	token   string
+	modTime time.Time
+}
+
+var providerAccessTokenCache = struct {
+	sync.RWMutex
+	entries map[string]providerAccessTokenCacheEntry
+}{
+	entries: make(map[string]providerAccessTokenCacheEntry),
+}
+
+func ParseProviderSettings(data []byte) (*ProviderSettingsFile, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("cline provider settings: empty data")
+	}
+	var settings ProviderSettingsFile
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, err
+	}
+	if len(settings.Providers) == 0 {
+		return nil, fmt.Errorf("cline provider settings: no providers")
+	}
+	normalized := make(map[string]ProviderEntry, len(settings.Providers))
+	for rawKey, entry := range settings.Providers {
+		key := strings.ToLower(strings.TrimSpace(rawKey))
+		if key == "" {
+			return nil, fmt.Errorf("cline provider settings: empty provider key")
+		}
+		if _, exists := normalized[key]; exists {
+			return nil, fmt.Errorf("cline provider settings: duplicate provider key %q", key)
+		}
+		normalized[key] = entry
+	}
+	settings.Providers = normalized
+	return &settings, nil
+}
+
+func ProviderAuth(settings *ProviderSettingsFile, providerID string) (ProviderSettings, bool) {
+	if settings == nil {
+		return ProviderSettings{}, false
+	}
+	providerID = strings.ToLower(strings.TrimSpace(providerID))
+	if providerID == "" {
+		return ProviderSettings{}, false
+	}
+	entry, ok := settings.Providers[providerID]
+	if !ok {
+		return ProviderSettings{}, false
+	}
+	provider := strings.ToLower(strings.TrimSpace(entry.Settings.Provider))
+	if provider != "" && provider != providerID {
+		return ProviderSettings{}, false
+	}
+	if strings.TrimSpace(entry.Settings.Auth.AccessToken) == "" {
+		return ProviderSettings{}, false
+	}
+	return entry.Settings, true
+}
+
+func ReadProviderAccessToken(path string, providerID string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("cline provider settings: missing path")
+	}
+	providerID = strings.ToLower(strings.TrimSpace(providerID))
+	if providerID == "" {
+		return "", fmt.Errorf("cline provider settings: missing provider ID")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	cacheKey := path + "|" + providerID
+	modTime := info.ModTime()
+	providerAccessTokenCache.RLock()
+	cached, ok := providerAccessTokenCache.entries[cacheKey]
+	providerAccessTokenCache.RUnlock()
+	if ok && cached.modTime.Equal(modTime) {
+		return cached.token, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	settings, err := ParseProviderSettings(data)
+	if err != nil {
+		return "", err
+	}
+	provider, ok := ProviderAuth(settings, providerID)
+	if !ok {
+		return "", fmt.Errorf("cline provider settings: provider %q missing access token", providerID)
+	}
+	token := strings.TrimSpace(provider.Auth.AccessToken)
+	providerAccessTokenCache.Lock()
+	providerAccessTokenCache.entries[cacheKey] = providerAccessTokenCacheEntry{token: token, modTime: modTime}
+	providerAccessTokenCache.Unlock()
+	return token, nil
+}

--- a/internal/auth/cline/settings.go
+++ b/internal/auth/cline/settings.go
@@ -26,7 +26,8 @@ const (
 )
 
 type ProviderSettingsFile struct {
-	Providers map[string]ProviderEntry `json:"providers"`
+	Providers       map[string]ProviderEntry `json:"providers"`
+	providerRawKeys map[string]string
 }
 
 type ProviderEntry struct {
@@ -109,6 +110,7 @@ func ParseProviderSettings(data []byte) (*ProviderSettingsFile, error) {
 		return nil, fmt.Errorf("cline provider settings: no providers")
 	}
 	normalized := make(map[string]ProviderEntry, len(settings.Providers))
+	rawKeys := make(map[string]string, len(settings.Providers))
 	for rawKey, entry := range settings.Providers {
 		key := strings.ToLower(strings.TrimSpace(rawKey))
 		if key == "" {
@@ -118,8 +120,10 @@ func ParseProviderSettings(data []byte) (*ProviderSettingsFile, error) {
 			return nil, fmt.Errorf("cline provider settings: duplicate provider key %q", key)
 		}
 		normalized[key] = entry
+		rawKeys[key] = rawKey
 	}
 	settings.Providers = normalized
+	settings.providerRawKeys = rawKeys
 	return &settings, nil
 }
 
@@ -151,7 +155,7 @@ func findProvider(settings *ProviderSettingsFile, providerIDs ...string) (provid
 		if entry, ok := settings.Providers[expectedProviderID]; ok {
 			provider := providerSettingsForEntry(expectedProviderID, entry)
 			if providerIDForEntry(expectedProviderID, provider) == expectedProviderID {
-				return providerMatch{key: expectedProviderID, provider: provider}, true
+				return providerMatch{key: settings.rawProviderKey(expectedProviderID), provider: provider}, true
 			}
 		}
 		for _, key := range sortedProviderKeys(settings.Providers) {
@@ -160,7 +164,7 @@ func findProvider(settings *ProviderSettingsFile, providerIDs ...string) (provid
 			}
 			provider := providerSettingsForEntry(key, settings.Providers[key])
 			if providerIDForEntry(key, provider) == expectedProviderID {
-				return providerMatch{key: key, provider: provider}, true
+				return providerMatch{key: settings.rawProviderKey(key), provider: provider}, true
 			}
 		}
 	}
@@ -193,7 +197,7 @@ func providerMatches(settings *ProviderSettingsFile, expectedProviderID string) 
 	if entry, ok := settings.Providers[expectedProviderID]; ok {
 		provider := providerSettingsForEntry(expectedProviderID, entry)
 		if providerIDForEntry(expectedProviderID, provider) == expectedProviderID {
-			matches = append(matches, providerMatch{key: expectedProviderID, provider: provider})
+			matches = append(matches, providerMatch{key: settings.rawProviderKey(expectedProviderID), provider: provider})
 		}
 	}
 	for _, key := range sortedProviderKeys(settings.Providers) {
@@ -202,10 +206,19 @@ func providerMatches(settings *ProviderSettingsFile, expectedProviderID string) 
 		}
 		provider := providerSettingsForEntry(key, settings.Providers[key])
 		if providerIDForEntry(key, provider) == expectedProviderID {
-			matches = append(matches, providerMatch{key: key, provider: provider})
+			matches = append(matches, providerMatch{key: settings.rawProviderKey(key), provider: provider})
 		}
 	}
 	return matches
+}
+
+func (settings *ProviderSettingsFile) rawProviderKey(normalizedKey string) string {
+	if settings != nil && settings.providerRawKeys != nil {
+		if rawKey := settings.providerRawKeys[normalizedKey]; strings.TrimSpace(rawKey) != "" {
+			return rawKey
+		}
+	}
+	return normalizedKey
 }
 
 func normalizeProviderIDs(providerIDs ...string) []string {

--- a/internal/auth/cline/settings.go
+++ b/internal/auth/cline/settings.go
@@ -19,6 +19,24 @@ const (
 	CredentialSourceProviderSettings = "cline-provider-settings"
 )
 
+func IsProviderSettingsClinePassAttributes(attrs map[string]string) bool {
+	if attrs == nil {
+		return false
+	}
+	if strings.TrimSpace(attrs["credential_source"]) != CredentialSourceProviderSettings {
+		return false
+	}
+	providerID := strings.TrimSpace(attrs["cline_provider"])
+	if providerID == "" {
+		providerID = strings.TrimSpace(attrs["compat_name"])
+	}
+	if !strings.EqualFold(providerID, ProviderClinePass) {
+		return false
+	}
+	baseURL := strings.TrimRight(strings.TrimSpace(attrs["base_url"]), "/")
+	return strings.EqualFold(baseURL, strings.TrimRight(APIBaseURL, "/"))
+}
+
 type ProviderSettingsFile struct {
 	Providers map[string]ProviderEntry `json:"providers"`
 }

--- a/internal/auth/cline/settings.go
+++ b/internal/auth/cline/settings.go
@@ -1,15 +1,25 @@
 package cline
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 const (
+	ProviderCline                    = "cline"
 	ProviderClinePass                = "cline-pass"
 	APIBaseURL                       = "https://api.cline.bot/api/v1"
 	CredentialSourceProviderSettings = "cline-provider-settings"
@@ -21,6 +31,9 @@ type ProviderSettingsFile struct {
 
 type ProviderEntry struct {
 	Settings ProviderSettings `json:"settings"`
+	Auth     AuthSettings     `json:"auth"`
+	Provider string           `json:"provider"`
+	Model    string           `json:"model"`
 }
 
 type ProviderSettings struct {
@@ -37,8 +50,9 @@ type AuthSettings struct {
 }
 
 type providerAccessTokenCacheEntry struct {
-	token   string
-	modTime time.Time
+	token     string
+	modTime   time.Time
+	expiresAt time.Time
 }
 
 var providerAccessTokenCache = struct {
@@ -46,6 +60,41 @@ var providerAccessTokenCache = struct {
 	entries map[string]providerAccessTokenCacheEntry
 }{
 	entries: make(map[string]providerAccessTokenCacheEntry),
+}
+
+var (
+	clineAPIBaseURL                 = APIBaseURL
+	providerAccessTokenRefreshGroup singleflight.Group
+)
+
+type providerMatch struct {
+	key      string
+	provider ProviderSettings
+}
+
+type providerAccessTokenSnapshot struct {
+	providerAccessTokenCacheEntry
+	resolvedPath string
+	matchKey     string
+	auth         AuthSettings
+}
+
+type refreshResponse struct {
+	Success *bool `json:"success"`
+	Data    struct {
+		AccessToken  string `json:"accessToken"`
+		RefreshToken string `json:"refreshToken"`
+		ExpiresAt    any    `json:"expiresAt"`
+		AccountID    string `json:"accountId"`
+		UserInfo     struct {
+			ClineUserID string `json:"clineUserId"`
+			AccountID   string `json:"accountId"`
+		} `json:"userInfo"`
+	} `json:"data"`
+	Code      string `json:"code"`
+	ErrorCode string `json:"errorCode"`
+	Error     string `json:"error"`
+	Message   string `json:"message"`
 }
 
 func ParseProviderSettings(data []byte) (*ProviderSettingsFile, error) {
@@ -74,26 +123,140 @@ func ParseProviderSettings(data []byte) (*ProviderSettingsFile, error) {
 	return &settings, nil
 }
 
-func ProviderAuth(settings *ProviderSettingsFile, providerID string) (ProviderSettings, bool) {
-	if settings == nil {
-		return ProviderSettings{}, false
-	}
-	providerID = strings.ToLower(strings.TrimSpace(providerID))
-	if providerID == "" {
-		return ProviderSettings{}, false
-	}
-	entry, ok := settings.Providers[providerID]
+func ProviderAuth(settings *ProviderSettingsFile, providerIDs ...string) (ProviderSettings, bool) {
+	match, ok := findProviderAuth(settings, providerIDs...)
 	if !ok {
 		return ProviderSettings{}, false
 	}
-	provider := strings.ToLower(strings.TrimSpace(entry.Settings.Provider))
-	if provider != "" && provider != providerID {
+	return match.provider, true
+}
+
+func FindProvider(settings *ProviderSettingsFile, providerIDs ...string) (ProviderSettings, bool) {
+	match, ok := findProvider(settings, providerIDs...)
+	if !ok {
 		return ProviderSettings{}, false
 	}
-	if strings.TrimSpace(entry.Settings.Auth.AccessToken) == "" {
-		return ProviderSettings{}, false
+	return match.provider, true
+}
+
+func findProvider(settings *ProviderSettingsFile, providerIDs ...string) (providerMatch, bool) {
+	if settings == nil {
+		return providerMatch{}, false
 	}
-	return entry.Settings, true
+	normalizedIDs := normalizeProviderIDs(providerIDs...)
+	if len(normalizedIDs) == 0 {
+		return providerMatch{}, false
+	}
+	for _, expectedProviderID := range normalizedIDs {
+		if entry, ok := settings.Providers[expectedProviderID]; ok {
+			provider := providerSettingsForEntry(expectedProviderID, entry)
+			if providerIDForEntry(expectedProviderID, provider) == expectedProviderID {
+				return providerMatch{key: expectedProviderID, provider: provider}, true
+			}
+		}
+		for _, key := range sortedProviderKeys(settings.Providers) {
+			if key == expectedProviderID {
+				continue
+			}
+			provider := providerSettingsForEntry(key, settings.Providers[key])
+			if providerIDForEntry(key, provider) == expectedProviderID {
+				return providerMatch{key: key, provider: provider}, true
+			}
+		}
+	}
+	return providerMatch{}, false
+}
+
+func findProviderAuth(settings *ProviderSettingsFile, providerIDs ...string) (providerMatch, bool) {
+	if settings == nil {
+		return providerMatch{}, false
+	}
+	normalizedIDs := normalizeProviderIDs(providerIDs...)
+	if len(normalizedIDs) == 0 {
+		return providerMatch{}, false
+	}
+	for _, expectedProviderID := range normalizedIDs {
+		for _, match := range providerMatches(settings, expectedProviderID) {
+			if strings.TrimSpace(match.provider.Auth.AccessToken) != "" {
+				return match, true
+			}
+		}
+	}
+	return providerMatch{}, false
+}
+
+func providerMatches(settings *ProviderSettingsFile, expectedProviderID string) []providerMatch {
+	if settings == nil || strings.TrimSpace(expectedProviderID) == "" {
+		return nil
+	}
+	matches := make([]providerMatch, 0, 1)
+	if entry, ok := settings.Providers[expectedProviderID]; ok {
+		provider := providerSettingsForEntry(expectedProviderID, entry)
+		if providerIDForEntry(expectedProviderID, provider) == expectedProviderID {
+			matches = append(matches, providerMatch{key: expectedProviderID, provider: provider})
+		}
+	}
+	for _, key := range sortedProviderKeys(settings.Providers) {
+		if key == expectedProviderID {
+			continue
+		}
+		provider := providerSettingsForEntry(key, settings.Providers[key])
+		if providerIDForEntry(key, provider) == expectedProviderID {
+			matches = append(matches, providerMatch{key: key, provider: provider})
+		}
+	}
+	return matches
+}
+
+func normalizeProviderIDs(providerIDs ...string) []string {
+	normalized := make([]string, 0, len(providerIDs))
+	seen := make(map[string]struct{}, len(providerIDs))
+	for _, providerID := range providerIDs {
+		providerID = strings.ToLower(strings.TrimSpace(providerID))
+		if providerID == "" {
+			continue
+		}
+		if _, exists := seen[providerID]; exists {
+			continue
+		}
+		seen[providerID] = struct{}{}
+		normalized = append(normalized, providerID)
+	}
+	return normalized
+}
+
+func providerSettingsForEntry(key string, entry ProviderEntry) ProviderSettings {
+	provider := entry.Settings
+	if strings.TrimSpace(provider.Provider) == "" && strings.TrimSpace(entry.Provider) != "" {
+		provider.Provider = entry.Provider
+	}
+	if strings.TrimSpace(provider.Model) == "" && strings.TrimSpace(entry.Model) != "" {
+		provider.Model = entry.Model
+	}
+	if strings.TrimSpace(provider.Provider) == "" {
+		provider.Provider = strings.ToLower(strings.TrimSpace(key))
+	}
+	if strings.TrimSpace(provider.Auth.AccessToken) == "" && strings.TrimSpace(entry.Auth.AccessToken) != "" {
+		provider.Auth = entry.Auth
+	}
+	return provider
+}
+
+func providerIDForEntry(key string, provider ProviderSettings) string {
+	providerID := strings.ToLower(strings.TrimSpace(provider.Provider))
+	if providerID == "" {
+		providerID = strings.ToLower(strings.TrimSpace(key))
+	}
+	return providerID
+}
+
+func sortedProviderKeys(providers map[string]ProviderEntry) []string {
+	keys := make([]string, 0, len(providers))
+	for key := range providers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func ReadProviderAccessToken(path string, providerID string) (string, error) {
@@ -114,25 +277,352 @@ func ReadProviderAccessToken(path string, providerID string) (string, error) {
 	providerAccessTokenCache.RLock()
 	cached, ok := providerAccessTokenCache.entries[cacheKey]
 	providerAccessTokenCache.RUnlock()
-	if ok && cached.modTime.Equal(modTime) {
+	if ok && cached.modTime.Equal(modTime) && !tokenExpiresSoon(cached.expiresAt, time.Now()) {
 		return cached.token, nil
 	}
 
-	data, err := os.ReadFile(path)
+	snapshot, err := readProviderAccessTokenSnapshot(path, providerID)
 	if err != nil {
 		return "", err
+	}
+	if tokenExpiresSoon(snapshot.expiresAt, time.Now()) && strings.TrimSpace(snapshot.auth.RefreshToken) != "" {
+		value, errRefresh, _ := providerAccessTokenRefreshGroup.Do(cacheKey, func() (any, error) {
+			return refreshProviderAccessToken(path, providerID)
+		})
+		if errRefresh != nil {
+			return "", errRefresh
+		}
+		refreshed, ok := value.(providerAccessTokenCacheEntry)
+		if !ok {
+			return "", fmt.Errorf("cline provider settings: invalid refresh result")
+		}
+		return refreshed.token, nil
+	}
+	cacheProviderAccessToken(cacheKey, snapshot.providerAccessTokenCacheEntry)
+	return snapshot.token, nil
+}
+
+func readProviderAccessTokenSnapshot(path string, providerID string) (providerAccessTokenSnapshot, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return providerAccessTokenSnapshot{}, err
+	}
+	modTime := info.ModTime()
+	resolvedPath := path
+	if evaluated, errEval := filepath.EvalSymlinks(path); errEval == nil && strings.TrimSpace(evaluated) != "" {
+		resolvedPath = evaluated
+	}
+	data, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		return providerAccessTokenSnapshot{}, err
 	}
 	settings, err := ParseProviderSettings(data)
 	if err != nil {
-		return "", err
+		return providerAccessTokenSnapshot{}, err
 	}
-	provider, ok := ProviderAuth(settings, providerID)
+	providerIDs := []string{providerID}
+	if providerID == ProviderClinePass {
+		providerIDs = []string{ProviderCline, ProviderClinePass}
+	}
+	match, ok := findProviderAuth(settings, providerIDs...)
 	if !ok {
-		return "", fmt.Errorf("cline provider settings: provider %q missing access token", providerID)
+		return providerAccessTokenSnapshot{}, fmt.Errorf("cline provider settings: provider %q missing access token", providerID)
 	}
+	provider := match.provider
 	token := strings.TrimSpace(provider.Auth.AccessToken)
+	expiresAt := authExpiryTime(provider.Auth, token)
+	return providerAccessTokenSnapshot{
+		providerAccessTokenCacheEntry: providerAccessTokenCacheEntry{
+			token:     token,
+			modTime:   modTime,
+			expiresAt: expiresAt,
+		},
+		resolvedPath: resolvedPath,
+		matchKey:     match.key,
+		auth:         provider.Auth,
+	}, nil
+}
+
+func refreshProviderAccessToken(path string, providerID string) (providerAccessTokenCacheEntry, error) {
+	snapshot, err := readProviderAccessTokenSnapshot(path, providerID)
+	if err != nil {
+		return providerAccessTokenCacheEntry{}, err
+	}
+	if !tokenExpiresSoon(snapshot.expiresAt, time.Now()) || strings.TrimSpace(snapshot.auth.RefreshToken) == "" {
+		cacheProviderAccessToken(path+"|"+providerID, snapshot.providerAccessTokenCacheEntry)
+		return snapshot.providerAccessTokenCacheEntry, nil
+	}
+	refreshed, err := refreshProviderAuth(snapshot.auth.RefreshToken)
+	if err != nil {
+		return providerAccessTokenCacheEntry{}, err
+	}
+	updated, err := updateStoredProviderAuth(snapshot.resolvedPath, snapshot.matchKey, snapshot.auth.RefreshToken, refreshed)
+	if err != nil {
+		return providerAccessTokenCacheEntry{}, err
+	}
+	if !updated {
+		current, errCurrent := readProviderAccessTokenSnapshot(path, providerID)
+		if errCurrent != nil {
+			return providerAccessTokenCacheEntry{}, errCurrent
+		}
+		if tokenExpiresSoon(current.expiresAt, time.Now()) {
+			return providerAccessTokenCacheEntry{}, fmt.Errorf("cline provider settings: provider auth changed during refresh")
+		}
+		cacheProviderAccessToken(path+"|"+providerID, current.providerAccessTokenCacheEntry)
+		return current.providerAccessTokenCacheEntry, nil
+	}
+	token := strings.TrimSpace(refreshed.AccessToken)
+	expiresAt := authExpiryTime(refreshed, token)
+	modTime := snapshot.modTime
+	if refreshedInfo, errStat := os.Stat(path); errStat == nil {
+		modTime = refreshedInfo.ModTime()
+	}
+	result := providerAccessTokenCacheEntry{token: token, modTime: modTime, expiresAt: expiresAt}
+	cacheProviderAccessToken(path+"|"+providerID, result)
+	return result, nil
+}
+
+func cacheProviderAccessToken(cacheKey string, entry providerAccessTokenCacheEntry) {
 	providerAccessTokenCache.Lock()
-	providerAccessTokenCache.entries[cacheKey] = providerAccessTokenCacheEntry{token: token, modTime: modTime}
+	providerAccessTokenCache.entries[cacheKey] = entry
 	providerAccessTokenCache.Unlock()
-	return token, nil
+}
+
+func tokenExpiresSoon(expiresAt time.Time, now time.Time) bool {
+	if expiresAt.IsZero() {
+		return false
+	}
+	return !expiresAt.After(now.Add(time.Minute))
+}
+
+func authExpiryTime(auth AuthSettings, token string) time.Time {
+	if expiresAt, ok := parseExpiryTime(auth.ExpiresAt); ok {
+		return expiresAt
+	}
+	if expiresAt, ok := parseJWTExpiry(stripClineAccountAccessTokenPrefix(token)); ok {
+		return expiresAt
+	}
+	return time.Time{}
+}
+
+func parseExpiryTime(value any) (time.Time, bool) {
+	switch v := value.(type) {
+	case nil:
+		return time.Time{}, false
+	case float64:
+		return timeFromNumericExpiry(v)
+	case int64:
+		return timeFromNumericExpiry(float64(v))
+	case int:
+		return timeFromNumericExpiry(float64(v))
+	case json.Number:
+		n, err := v.Float64()
+		if err != nil {
+			return time.Time{}, false
+		}
+		return timeFromNumericExpiry(n)
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return time.Time{}, false
+		}
+		if n, err := strconv.ParseFloat(trimmed, 64); err == nil {
+			return timeFromNumericExpiry(n)
+		}
+		parsed, err := time.Parse(time.RFC3339, trimmed)
+		if err != nil {
+			return time.Time{}, false
+		}
+		return parsed, true
+	default:
+		return time.Time{}, false
+	}
+}
+
+func timeFromNumericExpiry(value float64) (time.Time, bool) {
+	if value <= 0 {
+		return time.Time{}, false
+	}
+	if value > 10000000000 {
+		return time.UnixMilli(int64(value)), true
+	}
+	return time.Unix(int64(value), 0), true
+}
+
+func parseJWTExpiry(token string) (time.Time, bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || strings.TrimSpace(parts[1]) == "" {
+		return time.Time{}, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, false
+	}
+	var claims struct {
+		Exp any `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return time.Time{}, false
+	}
+	return parseExpiryTime(claims.Exp)
+}
+
+func stripClineAccountAccessTokenPrefix(token string) string {
+	token = strings.TrimSpace(token)
+	if strings.HasPrefix(strings.ToLower(token), "workos:") {
+		return token[len("workos:"):]
+	}
+	return token
+}
+
+func formatClineAccountAccessToken(token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" || strings.HasPrefix(strings.ToLower(token), "workos:") {
+		return token
+	}
+	return "workos:" + token
+}
+
+func refreshProviderAuth(refreshToken string) (AuthSettings, error) {
+	refreshToken = strings.TrimSpace(refreshToken)
+	if refreshToken == "" {
+		return AuthSettings{}, fmt.Errorf("cline provider settings: missing refresh token")
+	}
+	body, err := json.Marshal(map[string]string{
+		"grantType":    "refresh_token",
+		"refreshToken": refreshToken,
+	})
+	if err != nil {
+		return AuthSettings{}, err
+	}
+	url := strings.TrimRight(clineAPIBaseURL, "/") + "/auth/refresh"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return AuthSettings{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return AuthSettings{}, fmt.Errorf("cline provider settings: refresh token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	var payload refreshResponse
+	_ = json.Unmarshal(respBody, &payload)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 || (payload.Success != nil && !*payload.Success) {
+		return AuthSettings{}, fmt.Errorf("cline provider settings: refresh token request failed: %s", safeRefreshErrorDetail(resp.StatusCode, payload))
+	}
+	accessToken := strings.TrimSpace(payload.Data.AccessToken)
+	if accessToken == "" {
+		return AuthSettings{}, fmt.Errorf("cline provider settings: refresh token response missing access token")
+	}
+	accountID := strings.TrimSpace(payload.Data.AccountID)
+	if accountID == "" {
+		accountID = strings.TrimSpace(payload.Data.UserInfo.ClineUserID)
+	}
+	if accountID == "" {
+		accountID = strings.TrimSpace(payload.Data.UserInfo.AccountID)
+	}
+	refreshed := AuthSettings{
+		AccessToken:  formatClineAccountAccessToken(accessToken),
+		RefreshToken: strings.TrimSpace(payload.Data.RefreshToken),
+		ExpiresAt:    payload.Data.ExpiresAt,
+		AccountID:    accountID,
+	}
+	if refreshed.RefreshToken == "" {
+		refreshed.RefreshToken = refreshToken
+	}
+	return refreshed, nil
+}
+
+func safeRefreshErrorDetail(status int, payload refreshResponse) string {
+	for _, value := range []string{payload.Code, payload.ErrorCode, payload.Error, payload.Message} {
+		value = strings.TrimSpace(value)
+		if isSafeErrorCode(value) {
+			return value
+		}
+	}
+	return fmt.Sprintf("HTTP %d", status)
+}
+
+func isSafeErrorCode(value string) bool {
+	if len(value) == 0 || len(value) > 64 {
+		return false
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func updateStoredProviderAuth(path string, providerKey string, expectedRefreshToken string, refreshed AuthSettings) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false, err
+	}
+	providers, ok := root["providers"].(map[string]any)
+	if !ok {
+		return false, fmt.Errorf("cline provider settings: providers object missing")
+	}
+	entry, ok := providers[providerKey].(map[string]any)
+	if !ok {
+		return false, fmt.Errorf("cline provider settings: provider %q missing during refresh", providerKey)
+	}
+	authTarget := providerAuthTarget(entry)
+	if authTarget == nil {
+		settings, _ := entry["settings"].(map[string]any)
+		if settings == nil {
+			settings = map[string]any{}
+			entry["settings"] = settings
+		}
+		authTarget = map[string]any{}
+		settings["auth"] = authTarget
+	}
+	if currentRefresh, _ := authTarget["refreshToken"].(string); strings.TrimSpace(currentRefresh) != "" && strings.TrimSpace(currentRefresh) != expectedRefreshToken {
+		return false, nil
+	}
+	authTarget["accessToken"] = refreshed.AccessToken
+	authTarget["refreshToken"] = refreshed.RefreshToken
+	authTarget["expiresAt"] = refreshed.ExpiresAt
+	if strings.TrimSpace(refreshed.AccountID) != "" {
+		authTarget["accountId"] = refreshed.AccountID
+	}
+	updated, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return false, err
+	}
+	updated = append(updated, '\n')
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	tmpPath := fmt.Sprintf("%s.%d.%d.tmp", path, os.Getpid(), time.Now().UnixNano())
+	if err := os.WriteFile(tmpPath, updated, info.Mode().Perm()); err != nil {
+		return false, err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return false, err
+	}
+	return true, nil
+}
+
+func providerAuthTarget(entry map[string]any) map[string]any {
+	if settings, _ := entry["settings"].(map[string]any); settings != nil {
+		if auth, _ := settings["auth"].(map[string]any); auth != nil {
+			return auth
+		}
+	}
+	if auth, _ := entry["auth"].(map[string]any); auth != nil {
+		return auth
+	}
+	return nil
 }

--- a/internal/auth/cline/settings_test.go
+++ b/internal/auth/cline/settings_test.go
@@ -405,6 +405,83 @@ func TestReadProviderAccessTokenRefreshesExpiredClineAccountAndPreservesSymlink(
 	}
 }
 
+func TestReadProviderAccessTokenRefreshUsesRawProviderKey(t *testing.T) {
+	resetProviderAccessTokenCache(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"success": true,
+			"data": {
+				"accessToken": "new-access-token",
+				"refreshToken": "new-refresh-token",
+				"expiresAt": 1782800000000
+			}
+		}`))
+	}))
+	defer server.Close()
+	oldBaseURL := clineAPIBaseURL
+	clineAPIBaseURL = server.URL
+	t.Cleanup(func() {
+		clineAPIBaseURL = oldBaseURL
+	})
+
+	path := filepath.Join(t.TempDir(), "providers.json")
+	raw := []byte(`{
+		"providers": {
+			" CLINE-PASS ": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2"
+				}
+			},
+			" CLINE ": {
+				"settings": {
+					"provider": "cline",
+					"auth": {
+						"accessToken": "workos:old-access-token",
+						"refreshToken": "old-refresh-token",
+						"expiresAt": 1700000000000
+					}
+				}
+			}
+		}
+	}`)
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatalf("failed to write providers.json: %v", err)
+	}
+
+	token, err := ReadProviderAccessToken(path, ProviderClinePass)
+	if err != nil {
+		t.Fatalf("ReadProviderAccessToken error: %v", err)
+	}
+	if token != "workos:new-access-token" {
+		t.Fatalf("token = %q, want refreshed token", token)
+	}
+
+	var updated map[string]any
+	updatedData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read providers.json: %v", err)
+	}
+	if err := json.Unmarshal(updatedData, &updated); err != nil {
+		t.Fatalf("failed to parse updated providers.json: %v", err)
+	}
+	providers := updated["providers"].(map[string]any)
+	if _, ok := providers["cline"]; ok {
+		t.Fatal("refresh write-back created a normalized cline key instead of using the raw key")
+	}
+	clineEntry := providers[" CLINE "].(map[string]any)
+	clineSettings := clineEntry["settings"].(map[string]any)
+	auth := clineSettings["auth"].(map[string]any)
+	if auth["accessToken"] != "workos:new-access-token" {
+		t.Fatalf("stored accessToken = %#v, want refreshed token", auth["accessToken"])
+	}
+	if auth["refreshToken"] != "new-refresh-token" {
+		t.Fatalf("stored refreshToken = %#v, want new-refresh-token", auth["refreshToken"])
+	}
+}
+
 func TestReadProviderAccessTokenUsesCurrentFileWhenRefreshTokenChanged(t *testing.T) {
 	resetProviderAccessTokenCache(t)
 

--- a/internal/auth/cline/settings_test.go
+++ b/internal/auth/cline/settings_test.go
@@ -1,19 +1,12 @@
 package cline
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
-
-	"golang.org/x/sync/singleflight"
 )
 
 func TestParseProviderSettingsNormalizesProviderKeys(t *testing.T) {
@@ -287,42 +280,8 @@ func TestReadProviderAccessTokenFallsBackToClineAccountForClinePass(t *testing.T
 	}
 }
 
-func TestReadProviderAccessTokenRefreshesExpiredClineAccountWithoutWriteBack(t *testing.T) {
+func TestReadProviderAccessTokenRejectsExpiredClineAccountWithoutWriteBack(t *testing.T) {
 	resetProviderAccessTokenCache(t)
-
-	futureExpiry := futureProviderExpiryJSON()
-	var sawRefresh bool
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/auth/refresh" {
-			t.Fatalf("refresh path = %q, want /auth/refresh", r.URL.Path)
-		}
-		var body map[string]string
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode refresh body: %v", err)
-		}
-		if body["grantType"] != "refresh_token" {
-			t.Fatalf("grantType = %q, want refresh_token", body["grantType"])
-		}
-		if body["refreshToken"] != "old-refresh-token" {
-			t.Fatalf("refreshToken = %q, want old-refresh-token", body["refreshToken"])
-		}
-		sawRefresh = true
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"success": true,
-			"data": {
-				"accessToken": "new-access-token",
-				"refreshToken": "new-refresh-token",
-				"expiresAt": ` + futureExpiry + `
-			}
-		}`))
-	}))
-	defer server.Close()
-	oldBaseURL := clineAPIBaseURL
-	clineAPIBaseURL = server.URL
-	t.Cleanup(func() {
-		clineAPIBaseURL = oldBaseURL
-	})
 
 	targetPath := filepath.Join(t.TempDir(), "providers.json")
 	raw := []byte(`{
@@ -359,14 +318,11 @@ func TestReadProviderAccessTokenRefreshesExpiredClineAccountWithoutWriteBack(t *
 	}
 
 	token, err := ReadProviderAccessToken(linkPath, ProviderClinePass)
-	if err != nil {
-		t.Fatalf("ReadProviderAccessToken error: %v", err)
+	if err == nil {
+		t.Fatalf("expected expired token error, got token %q", token)
 	}
-	if !sawRefresh {
-		t.Fatal("expected refresh endpoint to be called")
-	}
-	if token != "workos:new-access-token" {
-		t.Fatalf("token = %q, want refreshed account token", token)
+	if !strings.Contains(err.Error(), "access token expired") {
+		t.Fatalf("error = %v, want expired token error", err)
 	}
 	if info, err := os.Lstat(linkPath); err != nil {
 		t.Fatalf("failed to stat symlink: %v", err)
@@ -378,135 +334,21 @@ func TestReadProviderAccessTokenRefreshesExpiredClineAccountWithoutWriteBack(t *
 		t.Fatalf("failed to read providers.json: %v", err)
 	}
 	if string(updated) != string(raw) {
-		t.Fatalf("providers.json changed during refresh:\n%s", string(updated))
+		t.Fatalf("providers.json changed during read:\n%s", string(updated))
 	}
 }
 
-func TestReadProviderAccessTokenUsesCurrentFileWhenRefreshTokenChanged(t *testing.T) {
-	resetProviderAccessTokenCache(t)
-
-	targetPath := filepath.Join(t.TempDir(), "providers.json")
-	writeProvidersJSON(t, targetPath, "workos:old-access-token", "old-refresh-token", 1700000000000)
-	fixedTime := time.Unix(1700000000, 0)
-	if err := os.Chtimes(targetPath, fixedTime, fixedTime); err != nil {
-		t.Fatalf("failed to set provider settings mtime: %v", err)
-	}
-
-	futureExpiry := futureProviderExpiryMillis()
-	futureExpiryJSON := strconv.FormatInt(futureExpiry, 10)
-	var calls int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&calls, 1)
-		writeProvidersJSON(t, targetPath, "external-access-token", "external-refresh-token", futureExpiry)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"success": true,
-			"data": {
-				"accessToken": "stale-refresh-result",
-				"refreshToken": "stale-refresh-token",
-				"expiresAt": ` + futureExpiryJSON + `
-			}
-		}`))
-	}))
-	defer server.Close()
-	oldBaseURL := clineAPIBaseURL
-	clineAPIBaseURL = server.URL
-	t.Cleanup(func() {
-		clineAPIBaseURL = oldBaseURL
-	})
-
-	token, err := ReadProviderAccessToken(targetPath, ProviderClinePass)
-	if err != nil {
-		t.Fatalf("ReadProviderAccessToken error: %v", err)
-	}
-	if token != "external-access-token" {
-		t.Fatalf("token = %q, want current file token", token)
-	}
-	if got := atomic.LoadInt32(&calls); got != 1 {
-		t.Fatalf("refresh calls = %d, want 1", got)
-	}
-	data, err := os.ReadFile(targetPath)
-	if err != nil {
-		t.Fatalf("failed to read providers.json: %v", err)
-	}
-	if strings.Contains(string(data), "stale-refresh-result") {
-		t.Fatalf("stale refresh result was written to providers.json: %s", string(data))
-	}
-}
-
-func TestReadProviderAccessTokenDeduplicatesConcurrentRefresh(t *testing.T) {
+func TestReadProviderAccessTokenReturnsFutureExpiringToken(t *testing.T) {
 	resetProviderAccessTokenCache(t)
 
 	path := filepath.Join(t.TempDir(), "providers.json")
-	writeProvidersJSON(t, path, "workos:old-access-token", "shared-refresh-token", 1700000000000)
-	original, err := os.ReadFile(path)
+	writeProvidersJSON(t, path, "workos:fresh-access-token", futureProviderExpiryMillis())
+	token, err := ReadProviderAccessToken(path, ProviderClinePass)
 	if err != nil {
-		t.Fatalf("failed to read providers.json: %v", err)
+		t.Fatalf("ReadProviderAccessToken error: %v", err)
 	}
-
-	futureExpiry := futureProviderExpiryJSON()
-	var calls int32
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var once sync.Once
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&calls, 1)
-		once.Do(func() { close(started) })
-		<-release
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"success": true,
-			"data": {
-				"accessToken": "new-access-token",
-				"refreshToken": "new-refresh-token",
-				"expiresAt": ` + futureExpiry + `
-			}
-		}`))
-	}))
-	defer server.Close()
-	oldBaseURL := clineAPIBaseURL
-	clineAPIBaseURL = server.URL
-	t.Cleanup(func() {
-		clineAPIBaseURL = oldBaseURL
-	})
-
-	const workers = 8
-	begin := make(chan struct{})
-	type result struct {
-		token string
-		err   error
-	}
-	results := make(chan result, workers)
-	for i := 0; i < workers; i++ {
-		go func() {
-			<-begin
-			token, err := ReadProviderAccessToken(path, ProviderClinePass)
-			results <- result{token: token, err: err}
-		}()
-	}
-	close(begin)
-	<-started
-	time.Sleep(50 * time.Millisecond)
-	close(release)
-
-	for i := 0; i < workers; i++ {
-		res := <-results
-		if res.err != nil {
-			t.Fatalf("ReadProviderAccessToken error: %v", res.err)
-		}
-		if res.token != "workos:new-access-token" {
-			t.Fatalf("token = %q, want refreshed token", res.token)
-		}
-	}
-	if got := atomic.LoadInt32(&calls); got != 1 {
-		t.Fatalf("refresh calls = %d, want 1", got)
-	}
-	updated, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("failed to read providers.json: %v", err)
-	}
-	if string(updated) != string(original) {
-		t.Fatalf("providers.json changed during refresh:\n%s", string(updated))
+	if token != "workos:fresh-access-token" {
+		t.Fatalf("token = %q, want fresh token", token)
 	}
 }
 
@@ -559,18 +401,13 @@ func resetProviderAccessTokenCache(t *testing.T) {
 	providerAccessTokenCache.Lock()
 	providerAccessTokenCache.entries = make(map[string]providerAccessTokenCacheEntry)
 	providerAccessTokenCache.Unlock()
-	providerAccessTokenRefreshGroup = singleflight.Group{}
 }
 
 func futureProviderExpiryMillis() int64 {
 	return time.Now().Add(24 * time.Hour).UnixMilli()
 }
 
-func futureProviderExpiryJSON() string {
-	return strconv.FormatInt(futureProviderExpiryMillis(), 10)
-}
-
-func writeProvidersJSON(t *testing.T, path string, accessToken string, refreshToken string, expiresAt int64) {
+func writeProvidersJSON(t *testing.T, path string, accessToken string, expiresAt int64) {
 	t.Helper()
 	raw := []byte(`{
 		"providers": {
@@ -585,7 +422,6 @@ func writeProvidersJSON(t *testing.T, path string, accessToken string, refreshTo
 					"provider": "cline",
 					"auth": {
 						"accessToken": "` + accessToken + `",
-						"refreshToken": "` + refreshToken + `",
 						"expiresAt": ` + strconv.FormatInt(expiresAt, 10) + `
 					}
 				}

--- a/internal/auth/cline/settings_test.go
+++ b/internal/auth/cline/settings_test.go
@@ -1,0 +1,95 @@
+package cline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseProviderSettingsNormalizesProviderKeys(t *testing.T) {
+	settings, err := ParseProviderSettings([]byte(`{
+		"providers": {
+			" CLINE-PASS ": {
+				"settings": {
+					"provider": "cline-pass",
+					"auth": {"accessToken": "token"}
+				}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("ParseProviderSettings error: %v", err)
+	}
+	if _, ok := ProviderAuth(settings, ProviderClinePass); !ok {
+		t.Fatal("expected normalized cline-pass provider auth")
+	}
+}
+
+func TestParseProviderSettingsRejectsDuplicateNormalizedProviderKeys(t *testing.T) {
+	_, err := ParseProviderSettings([]byte(`{
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"auth": {"accessToken": "token-a"}
+				}
+			},
+			" CLINE-PASS ": {
+				"settings": {
+					"provider": "cline-pass",
+					"auth": {"accessToken": "token-b"}
+				}
+			}
+		}
+	}`))
+	if err == nil {
+		t.Fatal("expected duplicate normalized provider key error")
+	}
+	if !strings.Contains(err.Error(), "duplicate provider key") {
+		t.Fatalf("expected duplicate provider key error, got: %v", err)
+	}
+}
+
+func TestReadProviderAccessTokenCachesUntilModTimeChanges(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "providers.json")
+	fixedTime := time.Unix(1700000000, 0)
+	writeSettings := func(token string, modTime time.Time) {
+		t.Helper()
+		raw := []byte(`{"providers":{"cline-pass":{"settings":{"provider":"cline-pass","auth":{"accessToken":"` + token + `"}}}}}`)
+		if err := os.WriteFile(path, raw, 0600); err != nil {
+			t.Fatalf("failed to write provider settings: %v", err)
+		}
+		if err := os.Chtimes(path, modTime, modTime); err != nil {
+			t.Fatalf("failed to set provider settings mtime: %v", err)
+		}
+	}
+
+	writeSettings("token-a", fixedTime)
+	first, err := ReadProviderAccessToken(path, ProviderClinePass)
+	if err != nil {
+		t.Fatalf("ReadProviderAccessToken first error: %v", err)
+	}
+	if first != "token-a" {
+		t.Fatalf("first token = %q, want token-a", first)
+	}
+
+	writeSettings("token-b", fixedTime)
+	second, err := ReadProviderAccessToken(path, ProviderClinePass)
+	if err != nil {
+		t.Fatalf("ReadProviderAccessToken second error: %v", err)
+	}
+	if second != "token-a" {
+		t.Fatalf("second token = %q, want cached token-a", second)
+	}
+
+	writeSettings("token-b", fixedTime.Add(time.Second))
+	third, err := ReadProviderAccessToken(path, ProviderClinePass)
+	if err != nil {
+		t.Fatalf("ReadProviderAccessToken third error: %v", err)
+	}
+	if third != "token-b" {
+		t.Fatalf("third token = %q, want refreshed token-b", third)
+	}
+}

--- a/internal/auth/cline/settings_test.go
+++ b/internal/auth/cline/settings_test.go
@@ -1,11 +1,19 @@
 package cline
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 func TestParseProviderSettingsNormalizesProviderKeys(t *testing.T) {
@@ -24,6 +32,203 @@ func TestParseProviderSettingsNormalizesProviderKeys(t *testing.T) {
 	}
 	if _, ok := ProviderAuth(settings, ProviderClinePass); !ok {
 		t.Fatal("expected normalized cline-pass provider auth")
+	}
+}
+
+func TestProviderAuthSupportsSiblingAuthShape(t *testing.T) {
+	settings, err := ParseProviderSettings([]byte(`{
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2"
+				},
+				"auth": {"accessToken": "sibling-token"}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("ParseProviderSettings error: %v", err)
+	}
+	provider, ok := ProviderAuth(settings, ProviderClinePass)
+	if !ok {
+		t.Fatal("expected sibling auth to be accepted")
+	}
+	if got := provider.Auth.AccessToken; got != "sibling-token" {
+		t.Fatalf("access token = %q, want sibling-token", got)
+	}
+}
+
+func TestProviderAuthCanUseClineAccountForClinePass(t *testing.T) {
+	settings, err := ParseProviderSettings([]byte(`{
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2"
+				}
+			},
+			"cline": {
+				"settings": {
+					"provider": "cline",
+					"auth": {"accessToken": "account-token"}
+				}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("ParseProviderSettings error: %v", err)
+	}
+	if _, ok := FindProvider(settings, ProviderClinePass); !ok {
+		t.Fatal("expected cline-pass provider to be detected")
+	}
+	provider, ok := ProviderAuth(settings, ProviderCline, ProviderClinePass)
+	if !ok {
+		t.Fatal("expected cline account auth to be accepted for Cline Pass")
+	}
+	if got := provider.Provider; got != ProviderCline {
+		t.Fatalf("provider = %q, want %q", got, ProviderCline)
+	}
+	if got := provider.Auth.AccessToken; got != "account-token" {
+		t.Fatalf("access token = %q, want account-token", got)
+	}
+}
+
+func TestProviderAuthPrefersClineAccountOverLegacyClinePassAuth(t *testing.T) {
+	settings, err := ParseProviderSettings([]byte(`{
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2",
+					"auth": {"accessToken": "legacy-token"}
+				}
+			},
+			"cline": {
+				"settings": {
+					"provider": "cline",
+					"auth": {"accessToken": "account-token"}
+				}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("ParseProviderSettings error: %v", err)
+	}
+	provider, ok := ProviderAuth(settings, ProviderCline, ProviderClinePass)
+	if !ok {
+		t.Fatal("expected provider auth")
+	}
+	if got := provider.Auth.AccessToken; got != "account-token" {
+		t.Fatalf("access token = %q, want account-token", got)
+	}
+}
+
+func TestProviderAuthFallsBackWhenPreferredProviderHasNoToken(t *testing.T) {
+	settings, err := ParseProviderSettings([]byte(`{
+		"providers": {
+			"cline": {
+				"settings": {
+					"provider": "cline"
+				}
+			},
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2",
+					"auth": {"accessToken": "legacy-token"}
+				}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("ParseProviderSettings error: %v", err)
+	}
+	provider, ok := ProviderAuth(settings, ProviderCline, ProviderClinePass)
+	if !ok {
+		t.Fatal("expected provider auth")
+	}
+	if got := provider.Provider; got != ProviderClinePass {
+		t.Fatalf("provider = %q, want %q", got, ProviderClinePass)
+	}
+	if got := provider.Auth.AccessToken; got != "legacy-token" {
+		t.Fatalf("access token = %q, want legacy-token", got)
+	}
+}
+
+func TestFindProviderPrefersExactKeyBeforeAlias(t *testing.T) {
+	settings, err := ParseProviderSettings([]byte(`{
+		"providers": {
+			"alias": {
+				"settings": {
+					"provider": "cline",
+					"auth": {"accessToken": "alias-token"}
+				}
+			},
+			"cline": {
+				"settings": {
+					"provider": "cline",
+					"auth": {"accessToken": "exact-token"}
+				}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("ParseProviderSettings error: %v", err)
+	}
+	provider, ok := ProviderAuth(settings, ProviderCline)
+	if !ok {
+		t.Fatal("expected provider auth")
+	}
+	if got := provider.Auth.AccessToken; got != "exact-token" {
+		t.Fatalf("access token = %q, want exact-token", got)
+	}
+}
+
+func TestFindProviderSupportsFlatAliasEntry(t *testing.T) {
+	settings, err := ParseProviderSettings([]byte(`{
+		"providers": {
+			"account": {
+				"provider": "cline",
+				"model": "some-model",
+				"auth": {"accessToken": "flat-token"}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("ParseProviderSettings error: %v", err)
+	}
+	provider, ok := ProviderAuth(settings, ProviderCline)
+	if !ok {
+		t.Fatal("expected flat provider auth")
+	}
+	if got := provider.Provider; got != ProviderCline {
+		t.Fatalf("provider = %q, want %q", got, ProviderCline)
+	}
+	if got := provider.Model; got != "some-model" {
+		t.Fatalf("model = %q, want some-model", got)
+	}
+	if got := provider.Auth.AccessToken; got != "flat-token" {
+		t.Fatalf("access token = %q, want flat-token", got)
+	}
+}
+
+func TestProviderAuthIgnoresNonClineProviders(t *testing.T) {
+	settings, err := ParseProviderSettings([]byte(`{
+		"providers": {
+			"openai": {
+				"settings": {
+					"provider": "openai",
+					"auth": {"accessToken": "openai-token"}
+				}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("ParseProviderSettings error: %v", err)
+	}
+	if _, ok := ProviderAuth(settings, ProviderCline, ProviderClinePass); ok {
+		t.Fatal("expected non-Cline provider to be ignored")
 	}
 }
 
@@ -52,7 +257,267 @@ func TestParseProviderSettingsRejectsDuplicateNormalizedProviderKeys(t *testing.
 	}
 }
 
+func TestReadProviderAccessTokenFallsBackToClineAccountForClinePass(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "providers.json")
+	raw := []byte(`{
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2"
+				}
+			},
+			"cline": {
+				"settings": {
+					"provider": "cline",
+					"auth": {"accessToken": "account-token"}
+				}
+			}
+		}
+	}`)
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatalf("failed to write provider settings: %v", err)
+	}
+	token, err := ReadProviderAccessToken(path, ProviderClinePass)
+	if err != nil {
+		t.Fatalf("ReadProviderAccessToken error: %v", err)
+	}
+	if token != "account-token" {
+		t.Fatalf("token = %q, want account-token", token)
+	}
+}
+
+func TestReadProviderAccessTokenRefreshesExpiredClineAccountAndPreservesSymlink(t *testing.T) {
+	resetProviderAccessTokenCache(t)
+
+	var sawRefresh bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/auth/refresh" {
+			t.Fatalf("refresh path = %q, want /auth/refresh", r.URL.Path)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode refresh body: %v", err)
+		}
+		if body["grantType"] != "refresh_token" {
+			t.Fatalf("grantType = %q, want refresh_token", body["grantType"])
+		}
+		if body["refreshToken"] != "old-refresh-token" {
+			t.Fatalf("refreshToken = %q, want old-refresh-token", body["refreshToken"])
+		}
+		sawRefresh = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"success": true,
+			"data": {
+				"accessToken": "new-access-token",
+				"refreshToken": "new-refresh-token",
+				"expiresAt": 1782800000000,
+				"userInfo": {"clineUserId": "acct_new"}
+			}
+		}`))
+	}))
+	defer server.Close()
+	oldBaseURL := clineAPIBaseURL
+	clineAPIBaseURL = server.URL
+	t.Cleanup(func() {
+		clineAPIBaseURL = oldBaseURL
+	})
+
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "providers.json")
+	raw := []byte(`{
+		"lastUsedProvider": "cline",
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2"
+				},
+				"tokenSource": "manual"
+			},
+			"cline": {
+				"settings": {
+					"provider": "cline",
+					"model": "some-model",
+					"auth": {
+						"accessToken": "workos:old-access-token",
+						"refreshToken": "old-refresh-token",
+						"expiresAt": 1700000000000,
+						"accountId": "acct_old"
+					}
+				},
+				"tokenSource": "oauth"
+			}
+		}
+	}`)
+	if err := os.WriteFile(targetPath, raw, 0600); err != nil {
+		t.Fatalf("failed to write providers.json: %v", err)
+	}
+	authDir := t.TempDir()
+	linkPath := filepath.Join(authDir, "cline-providers.json")
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Fatalf("failed to create providers symlink: %v", err)
+	}
+
+	token, err := ReadProviderAccessToken(linkPath, ProviderClinePass)
+	if err != nil {
+		t.Fatalf("ReadProviderAccessToken error: %v", err)
+	}
+	if !sawRefresh {
+		t.Fatal("expected refresh endpoint to be called")
+	}
+	if token != "workos:new-access-token" {
+		t.Fatalf("token = %q, want refreshed account token", token)
+	}
+	if info, err := os.Lstat(linkPath); err != nil {
+		t.Fatalf("failed to stat symlink: %v", err)
+	} else if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s was replaced instead of preserving symlink", linkPath)
+	}
+
+	var updated map[string]any
+	updatedData, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("failed to read updated providers.json: %v", err)
+	}
+	if err := json.Unmarshal(updatedData, &updated); err != nil {
+		t.Fatalf("failed to parse updated providers.json: %v", err)
+	}
+	if updated["lastUsedProvider"] != "cline" {
+		t.Fatalf("lastUsedProvider = %#v, want cline", updated["lastUsedProvider"])
+	}
+	providers := updated["providers"].(map[string]any)
+	clineEntry := providers["cline"].(map[string]any)
+	if clineEntry["tokenSource"] != "oauth" {
+		t.Fatalf("cline tokenSource = %#v, want oauth", clineEntry["tokenSource"])
+	}
+	clineSettings := clineEntry["settings"].(map[string]any)
+	auth := clineSettings["auth"].(map[string]any)
+	if auth["accessToken"] != "workos:new-access-token" {
+		t.Fatalf("stored accessToken = %#v, want refreshed token", auth["accessToken"])
+	}
+	if auth["refreshToken"] != "new-refresh-token" {
+		t.Fatalf("stored refreshToken = %#v, want new-refresh-token", auth["refreshToken"])
+	}
+	if auth["accountId"] != "acct_new" {
+		t.Fatalf("stored accountId = %#v, want acct_new", auth["accountId"])
+	}
+}
+
+func TestReadProviderAccessTokenUsesCurrentFileWhenRefreshTokenChanged(t *testing.T) {
+	resetProviderAccessTokenCache(t)
+
+	targetPath := filepath.Join(t.TempDir(), "providers.json")
+	writeProvidersJSON(t, targetPath, "workos:old-access-token", "old-refresh-token", 1700000000000)
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		writeProvidersJSON(t, targetPath, "external-access-token", "external-refresh-token", 1782800000000)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"success": true,
+			"data": {
+				"accessToken": "stale-refresh-result",
+				"refreshToken": "stale-refresh-token",
+				"expiresAt": 1782800000000
+			}
+		}`))
+	}))
+	defer server.Close()
+	oldBaseURL := clineAPIBaseURL
+	clineAPIBaseURL = server.URL
+	t.Cleanup(func() {
+		clineAPIBaseURL = oldBaseURL
+	})
+
+	token, err := ReadProviderAccessToken(targetPath, ProviderClinePass)
+	if err != nil {
+		t.Fatalf("ReadProviderAccessToken error: %v", err)
+	}
+	if token != "external-access-token" {
+		t.Fatalf("token = %q, want current file token", token)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("refresh calls = %d, want 1", got)
+	}
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("failed to read providers.json: %v", err)
+	}
+	if strings.Contains(string(data), "stale-refresh-result") {
+		t.Fatalf("stale refresh result was written to providers.json: %s", string(data))
+	}
+}
+
+func TestReadProviderAccessTokenDeduplicatesConcurrentRefresh(t *testing.T) {
+	resetProviderAccessTokenCache(t)
+
+	path := filepath.Join(t.TempDir(), "providers.json")
+	writeProvidersJSON(t, path, "workos:old-access-token", "shared-refresh-token", 1700000000000)
+
+	var calls int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		once.Do(func() { close(started) })
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"success": true,
+			"data": {
+				"accessToken": "new-access-token",
+				"refreshToken": "new-refresh-token",
+				"expiresAt": 1782800000000
+			}
+		}`))
+	}))
+	defer server.Close()
+	oldBaseURL := clineAPIBaseURL
+	clineAPIBaseURL = server.URL
+	t.Cleanup(func() {
+		clineAPIBaseURL = oldBaseURL
+	})
+
+	const workers = 8
+	begin := make(chan struct{})
+	type result struct {
+		token string
+		err   error
+	}
+	results := make(chan result, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			<-begin
+			token, err := ReadProviderAccessToken(path, ProviderClinePass)
+			results <- result{token: token, err: err}
+		}()
+	}
+	close(begin)
+	<-started
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	for i := 0; i < workers; i++ {
+		res := <-results
+		if res.err != nil {
+			t.Fatalf("ReadProviderAccessToken error: %v", res.err)
+		}
+		if res.token != "workos:new-access-token" {
+			t.Fatalf("token = %q, want refreshed token", res.token)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("refresh calls = %d, want 1", got)
+	}
+}
+
 func TestReadProviderAccessTokenCachesUntilModTimeChanges(t *testing.T) {
+	resetProviderAccessTokenCache(t)
+
 	path := filepath.Join(t.TempDir(), "providers.json")
 	fixedTime := time.Unix(1700000000, 0)
 	writeSettings := func(token string, modTime time.Time) {
@@ -91,5 +556,40 @@ func TestReadProviderAccessTokenCachesUntilModTimeChanges(t *testing.T) {
 	}
 	if third != "token-b" {
 		t.Fatalf("third token = %q, want refreshed token-b", third)
+	}
+}
+
+func resetProviderAccessTokenCache(t *testing.T) {
+	t.Helper()
+	providerAccessTokenCache.Lock()
+	providerAccessTokenCache.entries = make(map[string]providerAccessTokenCacheEntry)
+	providerAccessTokenCache.Unlock()
+	providerAccessTokenRefreshGroup = singleflight.Group{}
+}
+
+func writeProvidersJSON(t *testing.T, path string, accessToken string, refreshToken string, expiresAt int64) {
+	t.Helper()
+	raw := []byte(`{
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2"
+				}
+			},
+			"cline": {
+				"settings": {
+					"provider": "cline",
+					"auth": {
+						"accessToken": "` + accessToken + `",
+						"refreshToken": "` + refreshToken + `",
+						"expiresAt": ` + strconv.FormatInt(expiresAt, 10) + `
+					}
+				}
+			}
+		}
+	}`)
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatalf("failed to write providers.json: %v", err)
 	}
 }

--- a/internal/auth/cline/settings_test.go
+++ b/internal/auth/cline/settings_test.go
@@ -287,7 +287,7 @@ func TestReadProviderAccessTokenFallsBackToClineAccountForClinePass(t *testing.T
 	}
 }
 
-func TestReadProviderAccessTokenRefreshesExpiredClineAccountAndPreservesSymlink(t *testing.T) {
+func TestReadProviderAccessTokenRefreshesExpiredClineAccountWithoutWriteBack(t *testing.T) {
 	resetProviderAccessTokenCache(t)
 
 	futureExpiry := futureProviderExpiryJSON()
@@ -313,8 +313,7 @@ func TestReadProviderAccessTokenRefreshesExpiredClineAccountAndPreservesSymlink(
 			"data": {
 				"accessToken": "new-access-token",
 				"refreshToken": "new-refresh-token",
-				"expiresAt": ` + futureExpiry + `,
-				"userInfo": {"clineUserId": "acct_new"}
+				"expiresAt": ` + futureExpiry + `
 			}
 		}`))
 	}))
@@ -325,8 +324,7 @@ func TestReadProviderAccessTokenRefreshesExpiredClineAccountAndPreservesSymlink(
 		clineAPIBaseURL = oldBaseURL
 	})
 
-	targetDir := t.TempDir()
-	targetPath := filepath.Join(targetDir, "providers.json")
+	targetPath := filepath.Join(t.TempDir(), "providers.json")
 	raw := []byte(`{
 		"lastUsedProvider": "cline",
 		"providers": {
@@ -355,8 +353,7 @@ func TestReadProviderAccessTokenRefreshesExpiredClineAccountAndPreservesSymlink(
 	if err := os.WriteFile(targetPath, raw, 0600); err != nil {
 		t.Fatalf("failed to write providers.json: %v", err)
 	}
-	authDir := t.TempDir()
-	linkPath := filepath.Join(authDir, "cline-providers.json")
+	linkPath := filepath.Join(t.TempDir(), "cline-providers.json")
 	if err := os.Symlink(targetPath, linkPath); err != nil {
 		t.Fatalf("failed to create providers symlink: %v", err)
 	}
@@ -376,111 +373,12 @@ func TestReadProviderAccessTokenRefreshesExpiredClineAccountAndPreservesSymlink(
 	} else if info.Mode()&os.ModeSymlink == 0 {
 		t.Fatalf("%s was replaced instead of preserving symlink", linkPath)
 	}
-
-	var updated map[string]any
-	updatedData, err := os.ReadFile(targetPath)
-	if err != nil {
-		t.Fatalf("failed to read updated providers.json: %v", err)
-	}
-	if err := json.Unmarshal(updatedData, &updated); err != nil {
-		t.Fatalf("failed to parse updated providers.json: %v", err)
-	}
-	if updated["lastUsedProvider"] != "cline" {
-		t.Fatalf("lastUsedProvider = %#v, want cline", updated["lastUsedProvider"])
-	}
-	providers := updated["providers"].(map[string]any)
-	clineEntry := providers["cline"].(map[string]any)
-	if clineEntry["tokenSource"] != "oauth" {
-		t.Fatalf("cline tokenSource = %#v, want oauth", clineEntry["tokenSource"])
-	}
-	clineSettings := clineEntry["settings"].(map[string]any)
-	auth := clineSettings["auth"].(map[string]any)
-	if auth["accessToken"] != "workos:new-access-token" {
-		t.Fatalf("stored accessToken = %#v, want refreshed token", auth["accessToken"])
-	}
-	if auth["refreshToken"] != "new-refresh-token" {
-		t.Fatalf("stored refreshToken = %#v, want new-refresh-token", auth["refreshToken"])
-	}
-	if auth["accountId"] != "acct_new" {
-		t.Fatalf("stored accountId = %#v, want acct_new", auth["accountId"])
-	}
-}
-
-func TestReadProviderAccessTokenRefreshUsesRawProviderKey(t *testing.T) {
-	resetProviderAccessTokenCache(t)
-
-	futureExpiry := futureProviderExpiryJSON()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"success": true,
-			"data": {
-				"accessToken": "new-access-token",
-				"refreshToken": "new-refresh-token",
-				"expiresAt": ` + futureExpiry + `
-			}
-		}`))
-	}))
-	defer server.Close()
-	oldBaseURL := clineAPIBaseURL
-	clineAPIBaseURL = server.URL
-	t.Cleanup(func() {
-		clineAPIBaseURL = oldBaseURL
-	})
-
-	path := filepath.Join(t.TempDir(), "providers.json")
-	raw := []byte(`{
-		"providers": {
-			" CLINE-PASS ": {
-				"settings": {
-					"provider": "cline-pass",
-					"model": "cline-pass/glm-5.2"
-				}
-			},
-			" CLINE ": {
-				"settings": {
-					"provider": "cline",
-					"auth": {
-						"accessToken": "workos:old-access-token",
-						"refreshToken": "old-refresh-token",
-						"expiresAt": 1700000000000
-					}
-				}
-			}
-		}
-	}`)
-	if err := os.WriteFile(path, raw, 0600); err != nil {
-		t.Fatalf("failed to write providers.json: %v", err)
-	}
-
-	token, err := ReadProviderAccessToken(path, ProviderClinePass)
-	if err != nil {
-		t.Fatalf("ReadProviderAccessToken error: %v", err)
-	}
-	if token != "workos:new-access-token" {
-		t.Fatalf("token = %q, want refreshed token", token)
-	}
-
-	var updated map[string]any
-	updatedData, err := os.ReadFile(path)
+	updated, err := os.ReadFile(targetPath)
 	if err != nil {
 		t.Fatalf("failed to read providers.json: %v", err)
 	}
-	if err := json.Unmarshal(updatedData, &updated); err != nil {
-		t.Fatalf("failed to parse updated providers.json: %v", err)
-	}
-	providers := updated["providers"].(map[string]any)
-	if _, ok := providers["cline"]; ok {
-		t.Fatal("refresh write-back created a normalized cline key instead of using the raw key")
-	}
-	clineEntry := providers[" CLINE "].(map[string]any)
-	clineSettings := clineEntry["settings"].(map[string]any)
-	auth := clineSettings["auth"].(map[string]any)
-	if auth["accessToken"] != "workos:new-access-token" {
-		t.Fatalf("stored accessToken = %#v, want refreshed token", auth["accessToken"])
-	}
-	if auth["refreshToken"] != "new-refresh-token" {
-		t.Fatalf("stored refreshToken = %#v, want new-refresh-token", auth["refreshToken"])
+	if string(updated) != string(raw) {
+		t.Fatalf("providers.json changed during refresh:\n%s", string(updated))
 	}
 }
 
@@ -489,6 +387,10 @@ func TestReadProviderAccessTokenUsesCurrentFileWhenRefreshTokenChanged(t *testin
 
 	targetPath := filepath.Join(t.TempDir(), "providers.json")
 	writeProvidersJSON(t, targetPath, "workos:old-access-token", "old-refresh-token", 1700000000000)
+	fixedTime := time.Unix(1700000000, 0)
+	if err := os.Chtimes(targetPath, fixedTime, fixedTime); err != nil {
+		t.Fatalf("failed to set provider settings mtime: %v", err)
+	}
 
 	futureExpiry := futureProviderExpiryMillis()
 	futureExpiryJSON := strconv.FormatInt(futureExpiry, 10)
@@ -537,6 +439,10 @@ func TestReadProviderAccessTokenDeduplicatesConcurrentRefresh(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), "providers.json")
 	writeProvidersJSON(t, path, "workos:old-access-token", "shared-refresh-token", 1700000000000)
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read providers.json: %v", err)
+	}
 
 	futureExpiry := futureProviderExpiryJSON()
 	var calls int32
@@ -594,6 +500,13 @@ func TestReadProviderAccessTokenDeduplicatesConcurrentRefresh(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&calls); got != 1 {
 		t.Fatalf("refresh calls = %d, want 1", got)
+	}
+	updated, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read providers.json: %v", err)
+	}
+	if string(updated) != string(original) {
+		t.Fatalf("providers.json changed during refresh:\n%s", string(updated))
 	}
 }
 

--- a/internal/auth/cline/settings_test.go
+++ b/internal/auth/cline/settings_test.go
@@ -290,6 +290,7 @@ func TestReadProviderAccessTokenFallsBackToClineAccountForClinePass(t *testing.T
 func TestReadProviderAccessTokenRefreshesExpiredClineAccountAndPreservesSymlink(t *testing.T) {
 	resetProviderAccessTokenCache(t)
 
+	futureExpiry := futureProviderExpiryJSON()
 	var sawRefresh bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/auth/refresh" {
@@ -312,7 +313,7 @@ func TestReadProviderAccessTokenRefreshesExpiredClineAccountAndPreservesSymlink(
 			"data": {
 				"accessToken": "new-access-token",
 				"refreshToken": "new-refresh-token",
-				"expiresAt": 1782800000000,
+				"expiresAt": ` + futureExpiry + `,
 				"userInfo": {"clineUserId": "acct_new"}
 			}
 		}`))
@@ -408,6 +409,7 @@ func TestReadProviderAccessTokenRefreshesExpiredClineAccountAndPreservesSymlink(
 func TestReadProviderAccessTokenRefreshUsesRawProviderKey(t *testing.T) {
 	resetProviderAccessTokenCache(t)
 
+	futureExpiry := futureProviderExpiryJSON()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -415,7 +417,7 @@ func TestReadProviderAccessTokenRefreshUsesRawProviderKey(t *testing.T) {
 			"data": {
 				"accessToken": "new-access-token",
 				"refreshToken": "new-refresh-token",
-				"expiresAt": 1782800000000
+				"expiresAt": ` + futureExpiry + `
 			}
 		}`))
 	}))
@@ -488,17 +490,19 @@ func TestReadProviderAccessTokenUsesCurrentFileWhenRefreshTokenChanged(t *testin
 	targetPath := filepath.Join(t.TempDir(), "providers.json")
 	writeProvidersJSON(t, targetPath, "workos:old-access-token", "old-refresh-token", 1700000000000)
 
+	futureExpiry := futureProviderExpiryMillis()
+	futureExpiryJSON := strconv.FormatInt(futureExpiry, 10)
 	var calls int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&calls, 1)
-		writeProvidersJSON(t, targetPath, "external-access-token", "external-refresh-token", 1782800000000)
+		writeProvidersJSON(t, targetPath, "external-access-token", "external-refresh-token", futureExpiry)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"success": true,
 			"data": {
 				"accessToken": "stale-refresh-result",
 				"refreshToken": "stale-refresh-token",
-				"expiresAt": 1782800000000
+				"expiresAt": ` + futureExpiryJSON + `
 			}
 		}`))
 	}))
@@ -534,6 +538,7 @@ func TestReadProviderAccessTokenDeduplicatesConcurrentRefresh(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "providers.json")
 	writeProvidersJSON(t, path, "workos:old-access-token", "shared-refresh-token", 1700000000000)
 
+	futureExpiry := futureProviderExpiryJSON()
 	var calls int32
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -548,7 +553,7 @@ func TestReadProviderAccessTokenDeduplicatesConcurrentRefresh(t *testing.T) {
 			"data": {
 				"accessToken": "new-access-token",
 				"refreshToken": "new-refresh-token",
-				"expiresAt": 1782800000000
+				"expiresAt": ` + futureExpiry + `
 			}
 		}`))
 	}))
@@ -642,6 +647,14 @@ func resetProviderAccessTokenCache(t *testing.T) {
 	providerAccessTokenCache.entries = make(map[string]providerAccessTokenCacheEntry)
 	providerAccessTokenCache.Unlock()
 	providerAccessTokenRefreshGroup = singleflight.Group{}
+}
+
+func futureProviderExpiryMillis() int64 {
+	return time.Now().Add(24 * time.Hour).UnixMilli()
+}
+
+func futureProviderExpiryJSON() string {
+	return strconv.FormatInt(futureProviderExpiryMillis(), 10)
 }
 
 func writeProvidersJSON(t *testing.T, path string, accessToken string, refreshToken string, expiresAt int64) {

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -30,6 +30,19 @@ type staticModelsJSON struct {
 	XAI         []*ModelInfo `json:"xai"`
 }
 
+var clinePassModels = []*ModelInfo{
+	clinePassModelInfo("cline-pass/glm-5.2", "GLM 5.2"),
+	clinePassModelInfo("cline-pass/kimi-k2.7-code", "Kimi K2.7 Code"),
+	clinePassModelInfo("cline-pass/kimi-k2.6", "Kimi K2.6"),
+	clinePassModelInfo("cline-pass/deepseek-v4-pro", "DeepSeek V4 Pro"),
+	clinePassModelInfo("cline-pass/deepseek-v4-flash", "DeepSeek V4 Flash"),
+	clinePassModelInfo("cline-pass/mimo-v2.5", "MiMo V2.5"),
+	clinePassModelInfo("cline-pass/mimo-v2.5-pro", "MiMo V2.5 Pro"),
+	clinePassModelInfo("cline-pass/minimax-m3", "MiniMax M3"),
+	clinePassModelInfo("cline-pass/qwen3.7-max", "Qwen3.7 Max"),
+	clinePassModelInfo("cline-pass/qwen3.7-plus", "Qwen3.7 Plus"),
+}
+
 // GetClaudeModels returns the standard Claude model definitions.
 func GetClaudeModels() []*ModelInfo {
 	return cloneModelInfos(getModels().Claude)
@@ -108,6 +121,11 @@ func AntigravityWebSearchModelFor(modelID string) string {
 // GetXAIModels returns the standard xAI Grok model definitions.
 func GetXAIModels() []*ModelInfo {
 	return WithXAIBuiltins(cloneModelInfos(getModels().XAI))
+}
+
+// GetClinePassModels returns the Cline Pass subscription model definitions.
+func GetClinePassModels() []*ModelInfo {
+	return cloneModelInfos(clinePassModels)
 }
 
 // WithCodexBuiltins injects hard-coded Codex-only model definitions that should
@@ -207,6 +225,19 @@ func xaiBuiltinVideo15PreviewModelInfo() *ModelInfo {
 	}
 }
 
+func clinePassModelInfo(id string, displayName string) *ModelInfo {
+	return &ModelInfo{
+		ID:          id,
+		Object:      "model",
+		Created:     1780272000, // 2026-06-01
+		OwnedBy:     "cline-pass",
+		Type:        "openai-compatibility",
+		DisplayName: displayName,
+		Name:        id,
+		Thinking:    &ThinkingSupport{Levels: []string{"low", "medium", "high", "xhigh"}},
+	}
+}
+
 func upsertModelInfos(models []*ModelInfo, extras ...*ModelInfo) []*ModelInfo {
 	if len(extras) == 0 {
 		return models
@@ -277,6 +308,7 @@ func cloneModelInfos(models []*ModelInfo) []*ModelInfo {
 //   - kimi
 //   - antigravity
 //   - xai
+//   - cline-pass
 func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	key := strings.ToLower(strings.TrimSpace(channel))
 	switch key {
@@ -296,6 +328,8 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		return GetAntigravityModels()
 	case "xai", "x-ai", "grok":
 		return GetXAIModels()
+	case "cline-pass":
+		return GetClinePassModels()
 	default:
 		return nil
 	}
@@ -318,6 +352,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		data.Kimi,
 		data.Antigravity,
 		data.XAI,
+		clinePassModels,
 	}
 	for _, models := range allModels {
 		for _, m := range models {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -55,7 +55,10 @@ func (e *OpenAICompatExecutor) PrepareRequest(req *http.Request, auth *cliproxya
 	if req == nil {
 		return nil
 	}
-	_, apiKey := e.resolveCredentials(auth)
+	_, apiKey, err := e.resolveCredentials(auth)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(apiKey) != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
@@ -93,7 +96,10 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
-	baseURL, apiKey := e.resolveCredentials(auth)
+	baseURL, apiKey, err := e.resolveCredentials(auth)
+	if err != nil {
+		return resp, err
+	}
 	if baseURL == "" {
 		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
 		return
@@ -278,7 +284,10 @@ func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxy
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
-	baseURL, apiKey := e.resolveCredentials(auth)
+	baseURL, apiKey, err := e.resolveCredentials(auth)
+	if err != nil {
+		return resp, err
+	}
 	if baseURL == "" {
 		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
 		return resp, err
@@ -371,7 +380,10 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
-	baseURL, apiKey := e.resolveCredentials(auth)
+	baseURL, apiKey, err := e.resolveCredentials(auth)
+	if err != nil {
+		return nil, err
+	}
 	if baseURL == "" {
 		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
 		return nil, err
@@ -553,7 +565,10 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
-	baseURL, apiKey := e.resolveCredentials(auth)
+	baseURL, apiKey, err := e.resolveCredentials(auth)
+	if err != nil {
+		return nil, err
+	}
 	if baseURL == "" {
 		err = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
 		return nil, err
@@ -821,34 +836,51 @@ func rewriteOpenAICompatImagesMultipartPayload(payload []byte, model string, bou
 	return body.Bytes(), writer.FormDataContentType(), nil
 }
 
-func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (baseURL, apiKey string) {
+func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (baseURL, apiKey string, err error) {
 	if auth == nil {
-		return "", ""
+		return "", "", nil
 	}
 	if auth.Attributes != nil {
 		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
 		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
 	}
 	if apiKey == "" {
-		apiKey = e.resolveClineProviderSettingsToken(auth)
+		apiKey, err = e.resolveClineProviderSettingsToken(auth)
+		if err != nil {
+			return baseURL, "", err
+		}
 	}
 	return
 }
 
-func (e *OpenAICompatExecutor) resolveClineProviderSettingsToken(auth *cliproxyauth.Auth) string {
+func (e *OpenAICompatExecutor) resolveClineProviderSettingsToken(auth *cliproxyauth.Auth) (string, error) {
 	if !isClineProviderSettingsAuth(auth) {
-		return ""
+		return "", nil
 	}
 	path := strings.TrimSpace(auth.Attributes[cliproxyauth.AttributePath])
 	if path == "" {
 		path = strings.TrimSpace(auth.Attributes[cliproxyauth.AttributeSource])
 	}
+	if path == "" {
+		return "", clineProviderSettingsCredentialError("missing provider settings path")
+	}
 	token, err := clineauth.ReadProviderAccessToken(path, clineauth.ProviderClinePass)
 	if err != nil {
 		log.Warnf("openai compat executor: failed to read Cline provider access token from %q: %v", path, err)
-		return ""
+		return "", clineProviderSettingsCredentialError("access token unavailable")
 	}
-	return token
+	if strings.TrimSpace(token) == "" {
+		return "", clineProviderSettingsCredentialError("access token unavailable")
+	}
+	return token, nil
+}
+
+func clineProviderSettingsCredentialError(reason string) error {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "access token unavailable"
+	}
+	return statusErr{code: http.StatusFailedDependency, msg: "cline provider settings credential error: " + reason}
 }
 
 func isClineProviderSettingsAuth(auth *cliproxyauth.Auth) bool {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -481,9 +481,6 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			if detail, ok := helps.ParseOpenAIStreamUsage(line); ok {
-				reporter.Publish(ctx, detail)
-			}
 			trimmedLine := bytes.TrimSpace(line)
 			if len(trimmedLine) == 0 {
 				continue
@@ -507,8 +504,21 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 				continue
 			}
 
+			streamLine, errUnwrap := e.handleClineProviderSettingsStreamDataLine(auth, trimmedLine)
+			if errUnwrap != nil {
+				helps.RecordAPIResponseError(ctx, e.cfg, errUnwrap)
+				reporter.PublishFailure(ctx, errUnwrap)
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Err: errUnwrap}:
+				case <-ctx.Done():
+				}
+				return
+			}
+			if detail, ok := helps.ParseOpenAIStreamUsage(streamLine); ok {
+				reporter.Publish(ctx, detail)
+			}
 			// OpenAI-compatible streams must use SSE data lines.
-			chunks := sdktranslator.TranslateStream(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, bytes.Clone(trimmedLine), &param)
+			chunks := sdktranslator.TranslateStream(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, bytes.Clone(streamLine), &param)
 			for i := range chunks {
 				select {
 				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
@@ -541,6 +551,30 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		reporter.EnsurePublished(ctx)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+func (e *OpenAICompatExecutor) handleClineProviderSettingsStreamDataLine(auth *cliproxyauth.Auth, line []byte) ([]byte, error) {
+	if !isClineProviderSettingsAuth(auth) || !bytes.HasPrefix(line, []byte("data:")) {
+		return line, nil
+	}
+	payload := bytes.TrimSpace(line[len("data:"):])
+	if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) || !bytes.HasPrefix(payload, []byte("{")) {
+		return line, nil
+	}
+	var envelope struct {
+		Success *bool `json:"success"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil || envelope.Success == nil {
+		return line, nil
+	}
+	unwrapped, err := e.handleClineProviderSettingsEnvelope(auth, payload)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, 0, len("data: ")+len(unwrapped))
+	out = append(out, "data: "...)
+	out = append(out, unwrapped...)
+	return out, nil
 }
 
 func (e *OpenAICompatExecutor) openAICompatNonSSEStreamError(auth *cliproxyauth.Auth, body []byte) error {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -190,6 +190,11 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		return resp, err
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, body)
+	body, err = e.handleClineProviderSettingsEnvelope(auth, body)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
 	reporter.Publish(ctx, helps.ParseOpenAIUsage(body))
 	// Ensure we at least record the request even if upstream doesn't return usage
 	reporter.EnsurePublished(ctx)
@@ -198,6 +203,59 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, body, &param)
 	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 	return resp, nil
+}
+
+func (e *OpenAICompatExecutor) handleClineProviderSettingsEnvelope(auth *cliproxyauth.Auth, body []byte) ([]byte, error) {
+	if !isClineProviderSettingsAuth(auth) {
+		return body, nil
+	}
+	var envelope struct {
+		Success *bool           `json:"success"`
+		Data    json.RawMessage `json:"data"`
+		Code    string          `json:"code"`
+		Error   string          `json:"error"`
+		Message string          `json:"message"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return body, nil
+	}
+	if envelope.Success == nil {
+		return body, nil
+	}
+	if !*envelope.Success {
+		return nil, statusErr{code: http.StatusBadGateway, msg: clineProviderSettingsEnvelopeError(envelope.Code, envelope.Error, envelope.Message)}
+	}
+	if len(envelope.Data) == 0 {
+		return nil, statusErr{code: http.StatusBadGateway, msg: "cline provider settings upstream error: missing data"}
+	}
+	data := bytes.TrimSpace(envelope.Data)
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) || !json.Valid(data) {
+		return nil, statusErr{code: http.StatusBadGateway, msg: "cline provider settings upstream error: invalid data"}
+	}
+	return data, nil
+}
+
+func clineProviderSettingsEnvelopeError(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if isSafeClineEnvelopeError(value) {
+			return fmt.Sprintf("cline provider settings upstream error: %s", value)
+		}
+	}
+	return "cline provider settings upstream error"
+}
+
+func isSafeClineEnvelopeError(value string) bool {
+	if len(value) == 0 || len(value) > 128 {
+		return false
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, endpointPath string) (resp cliproxyexecutor.Response, err error) {
@@ -748,34 +806,40 @@ func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (base
 }
 
 func (e *OpenAICompatExecutor) resolveClineProviderSettingsToken(auth *cliproxyauth.Auth) string {
-	if auth == nil || auth.Attributes == nil {
-		return ""
-	}
-	if strings.TrimSpace(auth.Attributes["credential_source"]) != clineauth.CredentialSourceProviderSettings {
-		return ""
-	}
-	providerID := strings.TrimSpace(auth.Attributes["cline_provider"])
-	if providerID == "" {
-		providerID = strings.TrimSpace(auth.Attributes["compat_name"])
-	}
-	if !strings.EqualFold(providerID, clineauth.ProviderClinePass) {
-		return ""
-	}
-	providerID = clineauth.ProviderClinePass
-	baseURL := strings.TrimRight(strings.TrimSpace(auth.Attributes["base_url"]), "/")
-	if !strings.EqualFold(baseURL, strings.TrimRight(clineauth.APIBaseURL, "/")) {
+	if !isClineProviderSettingsAuth(auth) {
 		return ""
 	}
 	path := strings.TrimSpace(auth.Attributes[cliproxyauth.AttributePath])
 	if path == "" {
 		path = strings.TrimSpace(auth.Attributes[cliproxyauth.AttributeSource])
 	}
-	token, err := clineauth.ReadProviderAccessToken(path, providerID)
+	token, err := clineauth.ReadProviderAccessToken(path, clineauth.ProviderClinePass)
 	if err != nil {
 		log.Warnf("openai compat executor: failed to read Cline provider access token from %q: %v", path, err)
 		return ""
 	}
 	return token
+}
+
+func isClineProviderSettingsAuth(auth *cliproxyauth.Auth) bool {
+	if auth == nil || auth.Attributes == nil {
+		return false
+	}
+	if strings.TrimSpace(auth.Attributes["credential_source"]) != clineauth.CredentialSourceProviderSettings {
+		return false
+	}
+	providerID := strings.TrimSpace(auth.Attributes["cline_provider"])
+	if providerID == "" {
+		providerID = strings.TrimSpace(auth.Attributes["compat_name"])
+	}
+	if !strings.EqualFold(providerID, clineauth.ProviderClinePass) {
+		return false
+	}
+	baseURL := strings.TrimRight(strings.TrimSpace(auth.Attributes["base_url"]), "/")
+	if !strings.EqualFold(baseURL, strings.TrimRight(clineauth.APIBaseURL, "/")) {
+		return false
+	}
+	return true
 }
 
 func (e *OpenAICompatExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *config.OpenAICompatibility {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -469,7 +469,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 					continue
 				}
 				if bytes.HasPrefix(trimmedLine, []byte("{")) || bytes.HasPrefix(trimmedLine, []byte("[")) {
-					streamErr := statusErr{code: http.StatusBadGateway, msg: string(trimmedLine)}
+					streamErr := e.openAICompatNonSSEStreamError(auth, trimmedLine)
 					helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
 					reporter.PublishFailure(ctx, streamErr)
 					select {
@@ -515,6 +515,22 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		reporter.EnsurePublished(ctx)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+func (e *OpenAICompatExecutor) openAICompatNonSSEStreamError(auth *cliproxyauth.Auth, body []byte) error {
+	if !isClineProviderSettingsAuth(auth) {
+		return statusErr{code: http.StatusBadGateway, msg: string(body)}
+	}
+	var envelope struct {
+		Success *bool `json:"success"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Success == nil {
+		return statusErr{code: http.StatusBadGateway, msg: string(body)}
+	}
+	if _, err := e.handleClineProviderSettingsEnvelope(auth, body); err != nil {
+		return err
+	}
+	return statusErr{code: http.StatusBadGateway, msg: "cline provider settings upstream returned non-SSE JSON"}
 }
 
 func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, endpointPath string) (_ *cliproxyexecutor.StreamResult, err error) {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -128,6 +128,8 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 			translated = updated
 		}
 		translated = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "openai compat executor", translated)
+	} else if !opts.Stream {
+		translated = forceClineProviderSettingsNonStreamChatPayload(auth, translated)
 	}
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
 
@@ -233,6 +235,18 @@ func (e *OpenAICompatExecutor) handleClineProviderSettingsEnvelope(auth *cliprox
 		return nil, statusErr{code: http.StatusBadGateway, msg: "cline provider settings upstream error: invalid data"}
 	}
 	return data, nil
+}
+
+func forceClineProviderSettingsNonStreamChatPayload(auth *cliproxyauth.Auth, body []byte) []byte {
+	if !isClineProviderSettingsAuth(auth) {
+		return body
+	}
+	updated, err := sjson.SetBytes(body, "stream", false)
+	if err != nil {
+		log.Warnf("openai compat executor: failed to force Cline provider settings stream=false: %v", err)
+		return body
+	}
+	return updated
 }
 
 func clineProviderSettingsEnvelopeError(values ...string) string {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -918,24 +918,10 @@ func clineProviderSettingsCredentialError(reason string) error {
 }
 
 func isClineProviderSettingsAuth(auth *cliproxyauth.Auth) bool {
-	if auth == nil || auth.Attributes == nil {
+	if auth == nil {
 		return false
 	}
-	if strings.TrimSpace(auth.Attributes["credential_source"]) != clineauth.CredentialSourceProviderSettings {
-		return false
-	}
-	providerID := strings.TrimSpace(auth.Attributes["cline_provider"])
-	if providerID == "" {
-		providerID = strings.TrimSpace(auth.Attributes["compat_name"])
-	}
-	if !strings.EqualFold(providerID, clineauth.ProviderClinePass) {
-		return false
-	}
-	baseURL := strings.TrimRight(strings.TrimSpace(auth.Attributes["base_url"]), "/")
-	if !strings.EqualFold(baseURL, strings.TrimRight(clineauth.APIBaseURL, "/")) {
-		return false
-	}
-	return true
+	return clineauth.IsProviderSettingsClinePassAttributes(auth.Attributes)
 }
 
 func (e *OpenAICompatExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *config.OpenAICompatibility {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	clineauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/cline"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -740,7 +741,41 @@ func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (base
 		baseURL = strings.TrimSpace(auth.Attributes["base_url"])
 		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
 	}
+	if apiKey == "" {
+		apiKey = e.resolveClineProviderSettingsToken(auth)
+	}
 	return
+}
+
+func (e *OpenAICompatExecutor) resolveClineProviderSettingsToken(auth *cliproxyauth.Auth) string {
+	if auth == nil || auth.Attributes == nil {
+		return ""
+	}
+	if strings.TrimSpace(auth.Attributes["credential_source"]) != clineauth.CredentialSourceProviderSettings {
+		return ""
+	}
+	providerID := strings.TrimSpace(auth.Attributes["cline_provider"])
+	if providerID == "" {
+		providerID = strings.TrimSpace(auth.Attributes["compat_name"])
+	}
+	if !strings.EqualFold(providerID, clineauth.ProviderClinePass) {
+		return ""
+	}
+	providerID = clineauth.ProviderClinePass
+	baseURL := strings.TrimRight(strings.TrimSpace(auth.Attributes["base_url"]), "/")
+	if !strings.EqualFold(baseURL, strings.TrimRight(clineauth.APIBaseURL, "/")) {
+		return ""
+	}
+	path := strings.TrimSpace(auth.Attributes[cliproxyauth.AttributePath])
+	if path == "" {
+		path = strings.TrimSpace(auth.Attributes[cliproxyauth.AttributeSource])
+	}
+	token, err := clineauth.ReadProviderAccessToken(path, providerID)
+	if err != nil {
+		log.Warnf("openai compat executor: failed to read Cline provider access token from %q: %v", path, err)
+		return ""
+	}
+	return token
 }
 
 func (e *OpenAICompatExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *config.OpenAICompatibility {

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -162,6 +162,50 @@ func TestOpenAICompatExecutorPrepareRequestErrorsWhenClineTokenUnavailable(t *te
 	}
 }
 
+func TestOpenAICompatExecutorPrepareRequestErrorsWhenClineTokenExpired(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), "providers.json")
+	raw := []byte(`{
+		"providers": {
+			"cline": {
+				"settings": {
+					"provider": "cline",
+					"auth": {"accessToken": "expired-token", "expiresAt": 1700000000000}
+				}
+			},
+			"cline-pass": {
+				"settings": {"provider": "cline-pass", "model": "cline-pass/glm-5.2"}
+			}
+		}
+	}`)
+	if err := os.WriteFile(settingsPath, raw, 0600); err != nil {
+		t.Fatalf("failed to write Cline provider settings: %v", err)
+	}
+
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":                 clineauth.APIBaseURL,
+		"credential_source":        clineauth.CredentialSourceProviderSettings,
+		"cline_provider":           clineauth.ProviderClinePass,
+		cliproxyauth.AttributePath: settingsPath,
+	}}
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	err = executor.PrepareRequest(req, auth)
+	status, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("error = %T(%v), want statusErr", err, err)
+	}
+	if status.code != http.StatusFailedDependency {
+		t.Fatalf("status code = %d, want %d", status.code, http.StatusFailedDependency)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want no header when token is expired", got)
+	}
+}
+
 func TestOpenAICompatExecutorUnwrapsClineProviderSettingsEnvelope(t *testing.T) {
 	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
 	auth := &cliproxyauth.Auth{Attributes: map[string]string{
@@ -883,5 +927,100 @@ func TestOpenAICompatExecutorStreamSkipsKeepAliveUntilDataLine(t *testing.T) {
 	}
 	if gjson.Get(got.String(), "choices.0.delta.content").String() != "hello" {
 		t.Fatalf("stream payload = %s", got.String())
+	}
+}
+
+func TestOpenAICompatExecutorStreamUnwrapsClineProviderSettingsDataEnvelope(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		body := `data: {"success":true,"data":{"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}}` + "\n"
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	}))
+
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":          clineauth.APIBaseURL,
+		"api_key":           "test",
+		"credential_source": clineauth.CredentialSourceProviderSettings,
+		"cline_provider":    clineauth.ProviderClinePass,
+	}}
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "cline-pass/glm-5.2",
+		Payload: []byte(`{"model":"cline-pass/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var got strings.Builder
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected stream error: %v", chunk.Err)
+		}
+		got.Write(chunk.Payload)
+	}
+	if gjson.Get(got.String(), "choices.0.delta.content").String() != "hello" {
+		t.Fatalf("stream payload = %s", got.String())
+	}
+	if strings.Contains(got.String(), `"success"`) {
+		t.Fatalf("stream payload still contains Cline envelope: %s", got.String())
+	}
+}
+
+func TestOpenAICompatExecutorStreamSanitizesClineProviderSettingsDataEnvelopeError(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		body := `data: {"success":false,"code":"invalid_auth","message":"token expired"}` + "\n"
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	}))
+
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":          clineauth.APIBaseURL,
+		"api_key":           "test",
+		"credential_source": clineauth.CredentialSourceProviderSettings,
+		"cline_provider":    clineauth.ProviderClinePass,
+	}}
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "cline-pass/glm-5.2",
+		Payload: []byte(`{"model":"cline-pass/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var gotErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			gotErr = chunk.Err
+			break
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected Cline stream envelope error")
+	}
+	status, ok := gotErr.(statusErr)
+	if !ok {
+		t.Fatalf("error = %T(%v), want statusErr", gotErr, gotErr)
+	}
+	if status.code != http.StatusBadGateway {
+		t.Fatalf("status code = %d, want %d", status.code, http.StatusBadGateway)
+	}
+	if !strings.Contains(status.msg, "invalid_auth") || strings.Contains(status.msg, "token expired") {
+		t.Fatalf("status message = %q, want sanitized Cline code", status.msg)
 	}
 }

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -283,6 +283,87 @@ func TestOpenAICompatExecutorErrorsOnMalformedClineProviderSettingsEnvelope(t *t
 	}
 }
 
+func TestOpenAICompatExecutorForcesClineProviderSettingsNonStreamChatPayload(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":          clineauth.APIBaseURL,
+		"credential_source": clineauth.CredentialSourceProviderSettings,
+		"cline_provider":    clineauth.ProviderClinePass,
+	}}
+	body := []byte(`{"model":"cline-pass/glm-5.2","messages":[{"role":"user","content":"hi"}]}`)
+
+	got := forceClineProviderSettingsNonStreamChatPayload(auth, body)
+	stream := gjson.GetBytes(got, "stream")
+	if !stream.Exists() || stream.Bool() {
+		t.Fatalf("stream = %s, want explicit false; body=%s", stream.Raw, string(got))
+	}
+
+	bodyWithStreamTrue := []byte(`{"model":"cline-pass/glm-5.2","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	got = forceClineProviderSettingsNonStreamChatPayload(auth, bodyWithStreamTrue)
+	stream = gjson.GetBytes(got, "stream")
+	if !stream.Exists() || stream.Bool() {
+		t.Fatalf("stream = %s, want forced false; body=%s", stream.Raw, string(got))
+	}
+}
+
+func TestOpenAICompatExecutorDoesNotForceNonClineNonStreamChatPayload(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": "https://example.com/v1",
+		"api_key":  "test",
+	}}
+	body := []byte(`{"model":"custom-openai","messages":[{"role":"user","content":"hi"}]}`)
+
+	got := forceClineProviderSettingsNonStreamChatPayload(auth, body)
+	if !bytes.Equal(got, body) {
+		t.Fatalf("non-Cline body changed: %s", string(got))
+	}
+}
+
+func TestOpenAICompatExecutorExecuteForcesClineProviderSettingsNonStream(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotPath = req.URL.Path
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		gotBody = body
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)),
+			Request:    req,
+		}, nil
+	}))
+
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":          clineauth.APIBaseURL,
+		"api_key":           "test",
+		"credential_source": clineauth.CredentialSourceProviderSettings,
+		"cline_provider":    clineauth.ProviderClinePass,
+	}}
+	payload := []byte(`{"model":"cline-pass/glm-5.2","messages":[{"role":"user","content":"hi"}]}`)
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "cline-pass/glm-5.2",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/api/v1/chat/completions" {
+		t.Fatalf("path = %q, want /api/v1/chat/completions", gotPath)
+	}
+	stream := gjson.GetBytes(gotBody, "stream")
+	if !stream.Exists() || stream.Bool() {
+		t.Fatalf("stream = %s, want explicit false; body=%s", stream.Raw, string(gotBody))
+	}
+}
+
 func TestOpenAICompatExecutorCompactPassthrough(t *testing.T) {
 	var gotPath string
 	var gotBody []byte

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -211,6 +211,53 @@ func TestOpenAICompatExecutorErrorsOnClineProviderSettingsFailureEnvelope(t *tes
 	}
 }
 
+func TestOpenAICompatExecutorSanitizesClineProviderSettingsStreamJSONEnvelope(t *testing.T) {
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":          clineauth.APIBaseURL,
+		"credential_source": clineauth.CredentialSourceProviderSettings,
+		"cline_provider":    clineauth.ProviderClinePass,
+	}}
+	body := []byte(`{"success":false,"code":"invalid_auth","message":"token expired"}`)
+
+	err := executor.openAICompatNonSSEStreamError(auth, body)
+	status, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("error type = %T, want statusErr", err)
+	}
+	if status.code != http.StatusBadGateway {
+		t.Fatalf("status code = %d, want %d", status.code, http.StatusBadGateway)
+	}
+	if !strings.Contains(status.msg, "invalid_auth") {
+		t.Fatalf("status message = %q, want safe upstream code", status.msg)
+	}
+	if strings.Contains(status.msg, "token expired") || strings.Contains(status.msg, `"success"`) {
+		t.Fatalf("status message used unsanitized upstream JSON: %q", status.msg)
+	}
+}
+
+func TestOpenAICompatExecutorKeepsRawClineStreamJSONWithoutEnvelope(t *testing.T) {
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":          clineauth.APIBaseURL,
+		"credential_source": clineauth.CredentialSourceProviderSettings,
+		"cline_provider":    clineauth.ProviderClinePass,
+	}}
+	body := []byte(`{"error":{"message":"plain upstream JSON"}}`)
+
+	err := executor.openAICompatNonSSEStreamError(auth, body)
+	status, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("error type = %T, want statusErr", err)
+	}
+	if status.code != http.StatusBadGateway {
+		t.Fatalf("status code = %d, want %d", status.code, http.StatusBadGateway)
+	}
+	if status.msg != string(body) {
+		t.Fatalf("status message = %q, want raw JSON %q", status.msg, string(body))
+	}
+}
+
 func TestOpenAICompatExecutorErrorsOnMalformedClineProviderSettingsEnvelope(t *testing.T) {
 	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
 	auth := &cliproxyauth.Auth{Attributes: map[string]string{

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -58,6 +58,48 @@ func TestOpenAICompatExecutorPrepareRequestUsesClineProviderSettingsToken(t *tes
 	}
 }
 
+func TestOpenAICompatExecutorPrepareRequestUsesClineAccountTokenForClinePass(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), "providers.json")
+	raw := []byte(`{
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2"
+				}
+			},
+			"cline": {
+				"settings": {
+					"provider": "cline",
+					"auth": {"accessToken": "cline-account-token"}
+				}
+			}
+		}
+	}`)
+	if err := os.WriteFile(settingsPath, raw, 0600); err != nil {
+		t.Fatalf("failed to write Cline provider settings: %v", err)
+	}
+
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":                 clineauth.APIBaseURL,
+		"credential_source":        clineauth.CredentialSourceProviderSettings,
+		"cline_provider":           clineauth.ProviderClinePass,
+		cliproxyauth.AttributePath: settingsPath,
+	}}
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	if err := executor.PrepareRequest(req, auth); err != nil {
+		t.Fatalf("PrepareRequest error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer cline-account-token" {
+		t.Fatalf("Authorization = %q, want bearer token from Cline account settings", got)
+	}
+}
+
 func TestOpenAICompatExecutorPrepareRequestDoesNotUseClineTokenForOtherBaseURL(t *testing.T) {
 	settingsPath := filepath.Join(t.TempDir(), "providers.json")
 	raw := []byte(`{
@@ -91,6 +133,106 @@ func TestOpenAICompatExecutorPrepareRequestDoesNotUseClineTokenForOtherBaseURL(t
 	}
 	if got := req.Header.Get("Authorization"); got != "" {
 		t.Fatalf("Authorization = %q, want empty header for non-Cline base URL", got)
+	}
+}
+
+func TestOpenAICompatExecutorUnwrapsClineProviderSettingsEnvelope(t *testing.T) {
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":          clineauth.APIBaseURL,
+		"credential_source": clineauth.CredentialSourceProviderSettings,
+		"cline_provider":    clineauth.ProviderClinePass,
+	}}
+	body := []byte(`{
+		"success": true,
+		"data": {
+			"id": "chatcmpl_1",
+			"object": "chat.completion",
+			"model": "zai/glm-5.2",
+			"choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+		}
+	}`)
+
+	got, err := executor.handleClineProviderSettingsEnvelope(auth, body)
+	if err != nil {
+		t.Fatalf("handleClineProviderSettingsEnvelope error: %v", err)
+	}
+	if gjson.GetBytes(got, "object").String() != "chat.completion" {
+		t.Fatalf("payload was not unwrapped: %s", string(got))
+	}
+	if gjson.GetBytes(got, "success").Exists() {
+		t.Fatalf("unexpected Cline envelope in payload: %s", string(got))
+	}
+}
+
+func TestOpenAICompatExecutorDoesNotUnwrapNonClineEnvelope(t *testing.T) {
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": "https://example.com/v1",
+		"api_key":  "test",
+	}}
+	body := []byte(`{"success":true,"data":{"object":"chat.completion"}}`)
+
+	got, err := executor.handleClineProviderSettingsEnvelope(auth, body)
+	if err != nil {
+		t.Fatalf("handleClineProviderSettingsEnvelope error: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("non-Cline payload was unwrapped: %s", string(got))
+	}
+}
+
+func TestOpenAICompatExecutorErrorsOnClineProviderSettingsFailureEnvelope(t *testing.T) {
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":          clineauth.APIBaseURL,
+		"credential_source": clineauth.CredentialSourceProviderSettings,
+		"cline_provider":    clineauth.ProviderClinePass,
+	}}
+	body := []byte(`{"success":false,"code":"invalid_auth","message":"token expired"}`)
+
+	got, err := executor.handleClineProviderSettingsEnvelope(auth, body)
+	if err == nil {
+		t.Fatalf("expected failure envelope error, got payload: %s", string(got))
+	}
+	status, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("error type = %T, want statusErr", err)
+	}
+	if status.code != http.StatusBadGateway {
+		t.Fatalf("status code = %d, want %d", status.code, http.StatusBadGateway)
+	}
+	if !strings.Contains(status.msg, "invalid_auth") {
+		t.Fatalf("status message = %q, want safe upstream code", status.msg)
+	}
+	if strings.Contains(status.msg, "token expired") {
+		t.Fatalf("status message leaked free-form upstream message: %q", status.msg)
+	}
+}
+
+func TestOpenAICompatExecutorErrorsOnMalformedClineProviderSettingsEnvelope(t *testing.T) {
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":          clineauth.APIBaseURL,
+		"credential_source": clineauth.CredentialSourceProviderSettings,
+		"cline_provider":    clineauth.ProviderClinePass,
+	}}
+	body := []byte(`{"success":true}`)
+
+	got, err := executor.handleClineProviderSettingsEnvelope(auth, body)
+	if err == nil {
+		t.Fatalf("expected malformed envelope error, got payload: %s", string(got))
+	}
+	status, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("error type = %T, want statusErr", err)
+	}
+	if status.code != http.StatusBadGateway {
+		t.Fatalf("status code = %d, want %d", status.code, http.StatusBadGateway)
+	}
+	if !strings.Contains(status.msg, "missing data") {
+		t.Fatalf("status message = %q, want missing data", status.msg)
 	}
 }
 

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -9,15 +9,90 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/textproto"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	clineauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/cline"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 )
+
+func TestOpenAICompatExecutorPrepareRequestUsesClineProviderSettingsToken(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), "providers.json")
+	raw := []byte(`{
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"auth": {"accessToken": "cline-access-token"}
+				}
+			}
+		}
+	}`)
+	if err := os.WriteFile(settingsPath, raw, 0600); err != nil {
+		t.Fatalf("failed to write Cline provider settings: %v", err)
+	}
+
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":                 clineauth.APIBaseURL,
+		"credential_source":        clineauth.CredentialSourceProviderSettings,
+		"cline_provider":           clineauth.ProviderClinePass,
+		cliproxyauth.AttributePath: settingsPath,
+	}}
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	if err := executor.PrepareRequest(req, auth); err != nil {
+		t.Fatalf("PrepareRequest error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer cline-access-token" {
+		t.Fatalf("Authorization = %q, want bearer token from Cline provider settings", got)
+	}
+}
+
+func TestOpenAICompatExecutorPrepareRequestDoesNotUseClineTokenForOtherBaseURL(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), "providers.json")
+	raw := []byte(`{
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"auth": {"accessToken": "cline-access-token"}
+				}
+			}
+		}
+	}`)
+	if err := os.WriteFile(settingsPath, raw, 0600); err != nil {
+		t.Fatalf("failed to write Cline provider settings: %v", err)
+	}
+
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":                 "https://example.com/v1",
+		"credential_source":        clineauth.CredentialSourceProviderSettings,
+		"cline_provider":           clineauth.ProviderClinePass,
+		cliproxyauth.AttributePath: settingsPath,
+	}}
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	if err := executor.PrepareRequest(req, auth); err != nil {
+		t.Fatalf("PrepareRequest error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty header for non-Cline base URL", got)
+	}
+}
 
 func TestOpenAICompatExecutorCompactPassthrough(t *testing.T) {
 	var gotPath string

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -136,6 +136,32 @@ func TestOpenAICompatExecutorPrepareRequestDoesNotUseClineTokenForOtherBaseURL(t
 	}
 }
 
+func TestOpenAICompatExecutorPrepareRequestErrorsWhenClineTokenUnavailable(t *testing.T) {
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":                 clineauth.APIBaseURL,
+		"credential_source":        clineauth.CredentialSourceProviderSettings,
+		"cline_provider":           clineauth.ProviderClinePass,
+		cliproxyauth.AttributePath: filepath.Join(t.TempDir(), "missing-providers.json"),
+	}}
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	err = executor.PrepareRequest(req, auth)
+	status, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("error = %T(%v), want statusErr", err, err)
+	}
+	if status.code != http.StatusFailedDependency {
+		t.Fatalf("status code = %d, want %d", status.code, http.StatusFailedDependency)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want no header when token is unavailable", got)
+	}
+}
+
 func TestOpenAICompatExecutorUnwrapsClineProviderSettingsEnvelope(t *testing.T) {
 	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
 	auth := &cliproxyauth.Auth{Attributes: map[string]string{
@@ -361,6 +387,78 @@ func TestOpenAICompatExecutorExecuteForcesClineProviderSettingsNonStream(t *test
 	stream := gjson.GetBytes(gotBody, "stream")
 	if !stream.Exists() || stream.Bool() {
 		t.Fatalf("stream = %s, want explicit false; body=%s", stream.Raw, string(gotBody))
+	}
+}
+
+func TestOpenAICompatExecutorExecuteDoesNotCallUpstreamWhenClineTokenUnavailable(t *testing.T) {
+	called := false
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		t.Fatalf("upstream should not be called when Cline provider settings token is unavailable")
+		return nil, nil
+	}))
+
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":                 clineauth.APIBaseURL,
+		"credential_source":        clineauth.CredentialSourceProviderSettings,
+		"cline_provider":           clineauth.ProviderClinePass,
+		cliproxyauth.AttributePath: filepath.Join(t.TempDir(), "missing-providers.json"),
+	}}
+	payload := []byte(`{"model":"cline-pass/glm-5.2","messages":[{"role":"user","content":"hi"}]}`)
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "cline-pass/glm-5.2",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       false,
+	})
+	status, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("error = %T(%v), want statusErr", err, err)
+	}
+	if status.code != http.StatusFailedDependency {
+		t.Fatalf("status code = %d, want %d", status.code, http.StatusFailedDependency)
+	}
+	if called {
+		t.Fatal("upstream was called despite missing Cline provider settings token")
+	}
+}
+
+func TestOpenAICompatExecutorExecuteStreamDoesNotCallUpstreamWhenClineTokenUnavailable(t *testing.T) {
+	called := false
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		t.Fatalf("upstream should not be called when Cline provider settings token is unavailable")
+		return nil, nil
+	}))
+
+	executor := NewOpenAICompatExecutor("openai-compatible-cline-pass", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url":                 clineauth.APIBaseURL,
+		"credential_source":        clineauth.CredentialSourceProviderSettings,
+		"cline_provider":           clineauth.ProviderClinePass,
+		cliproxyauth.AttributePath: filepath.Join(t.TempDir(), "missing-providers.json"),
+	}}
+	payload := []byte(`{"model":"cline-pass/glm-5.2","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+
+	_, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "cline-pass/glm-5.2",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       true,
+	})
+	status, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("error = %T(%v), want statusErr", err, err)
+	}
+	if status.code != http.StatusFailedDependency {
+		t.Fatalf("status code = %d, want %d", status.code, http.StatusFailedDependency)
+	}
+	if called {
+		t.Fatal("upstream was called despite missing Cline provider settings token")
 	}
 }
 

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -217,6 +217,12 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 }
 
 func synthesizeClineProviderSettingsAuths(ctx *SynthesisContext, fullPath string, data []byte) []*coreauth.Auth {
+	var typed struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &typed); err == nil && strings.TrimSpace(typed.Type) != "" {
+		return nil
+	}
 	settings, err := clineauth.ParseProviderSettings(data)
 	if err != nil {
 		return nil

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -9,8 +9,10 @@ import (
 	"strconv"
 	"strings"
 
+	clineauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/cline"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
@@ -116,6 +118,9 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			return auths
 		}
 	}
+	if clineAuths := synthesizeClineProviderSettingsAuths(ctx, fullPath, data); len(clineAuths) > 0 {
+		return clineAuths
+	}
 	if provider == "" || provider == "gemini-cli" {
 		return nil
 	}
@@ -209,6 +214,49 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 		}
 	}
 	return []*coreauth.Auth{a}
+}
+
+func synthesizeClineProviderSettingsAuths(ctx *SynthesisContext, fullPath string, data []byte) []*coreauth.Auth {
+	settings, err := clineauth.ParseProviderSettings(data)
+	if err != nil {
+		return nil
+	}
+	if _, ok := clineauth.ProviderAuth(settings, clineauth.ProviderClinePass); !ok {
+		return nil
+	}
+
+	id := fullPath
+	if strings.TrimSpace(ctx.AuthDir) != "" {
+		if rel, errRel := filepath.Rel(ctx.AuthDir, fullPath); errRel == nil && rel != "" {
+			id = rel
+		}
+	}
+	id = id + "#" + clineauth.ProviderClinePass
+	if runtime.GOOS == "windows" {
+		id = strings.ToLower(id)
+	}
+
+	providerKey := util.OpenAICompatibleProviderKey(clineauth.ProviderClinePass)
+	return []*coreauth.Auth{{
+		ID:       id,
+		Provider: providerKey,
+		Label:    clineauth.ProviderClinePass,
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			coreauth.AttributeAuthIndexSeed: "cline-provider-settings|" + fullPath + "|" + clineauth.ProviderClinePass,
+			coreauth.AttributeAuthKind:      coreauth.AuthKindOAuth,
+			coreauth.AttributeSource:        fullPath,
+			coreauth.AttributePath:          fullPath,
+			coreauth.AttributeSourceBackend: coreauth.AuthSourceFile,
+			"base_url":                      clineauth.APIBaseURL,
+			"compat_name":                   clineauth.ProviderClinePass,
+			"provider_key":                  providerKey,
+			"credential_source":             clineauth.CredentialSourceProviderSettings,
+			"cline_provider":                clineauth.ProviderClinePass,
+		},
+		CreatedAt: ctx.Now,
+		UpdatedAt: ctx.Now,
+	}}
 }
 
 func parsePluginFileAuths(parser PluginAuthParser, req pluginapi.AuthParseRequest) ([]*coreauth.Auth, bool, error) {

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -221,7 +221,10 @@ func synthesizeClineProviderSettingsAuths(ctx *SynthesisContext, fullPath string
 	if err != nil {
 		return nil
 	}
-	if _, ok := clineauth.ProviderAuth(settings, clineauth.ProviderClinePass); !ok {
+	if _, ok := clineauth.FindProvider(settings, clineauth.ProviderClinePass); !ok {
+		return nil
+	}
+	if _, ok := clineauth.ProviderAuth(settings, clineauth.ProviderCline, clineauth.ProviderClinePass); !ok {
 		return nil
 	}
 

--- a/internal/watcher/synthesizer/file_test.go
+++ b/internal/watcher/synthesizer/file_test.go
@@ -289,6 +289,46 @@ func TestFileSynthesizer_Synthesize_ClinePassWithClineAccountAuth(t *testing.T) 
 	}
 }
 
+func TestFileSynthesizer_Synthesize_ClinePassProviderSettingsIgnoresTypedAuthFile(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "claude-auth.json")
+	raw := []byte(`{
+		"type": "claude",
+		"email": "typed@example.com",
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2",
+					"auth": {"accessToken": "access-token"}
+				}
+			}
+		}
+	}`)
+
+	ctx := &SynthesisContext{
+		Config:      &config.Config{},
+		AuthDir:     tempDir,
+		Now:         time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	if clineAuths := synthesizeClineProviderSettingsAuths(ctx, path, raw); len(clineAuths) != 0 {
+		t.Fatalf("expected typed auth file not to synthesize Cline provider settings auths, got %d", len(clineAuths))
+	}
+
+	auths := SynthesizeAuthFile(ctx, path, raw)
+	if len(auths) != 1 {
+		t.Fatalf("expected typed auth file to remain on regular synthesis path, got %d auths", len(auths))
+	}
+	if auths[0].Provider != "claude" {
+		t.Fatalf("provider = %q, want claude", auths[0].Provider)
+	}
+	if auths[0].Provider == "openai-compatible-cline-pass" {
+		t.Fatalf("typed auth file was misclassified as Cline provider settings: %#v", auths[0])
+	}
+}
+
 func TestSynthesizeAuthFileExpandsPluginMultiAuths(t *testing.T) {
 	tempDir := t.TempDir()
 	fullPath := filepath.Join(tempDir, "geminicli.json")

--- a/internal/watcher/synthesizer/file_test.go
+++ b/internal/watcher/synthesizer/file_test.go
@@ -229,6 +229,66 @@ func TestFileSynthesizer_Synthesize_ClinePassProviderSettings(t *testing.T) {
 	}
 }
 
+func TestFileSynthesizer_Synthesize_ClinePassWithClineAccountAuth(t *testing.T) {
+	tempDir := t.TempDir()
+	raw := []byte(`{
+		"version": 1,
+		"lastUsedProvider": "cline",
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2"
+				},
+				"tokenSource": "manual"
+			},
+			"cline": {
+				"settings": {
+					"provider": "cline",
+					"model": "account-default-model",
+					"auth": {
+						"accessToken": "account-token",
+						"refreshToken": "refresh-token",
+						"expiresAt": 1782754552000,
+						"accountId": "acct_123"
+					}
+				},
+				"tokenSource": "oauth"
+			}
+		}
+	}`)
+	path := filepath.Join(tempDir, "providers.json")
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatalf("failed to write providers.json: %v", err)
+	}
+
+	synth := NewFileSynthesizer()
+	ctx := &SynthesisContext{
+		Config:      &config.Config{},
+		AuthDir:     tempDir,
+		Now:         time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth, got %d", len(auths))
+	}
+	auth := auths[0]
+	if auth.Provider != "openai-compatible-cline-pass" {
+		t.Fatalf("provider = %q, want openai-compatible-cline-pass", auth.Provider)
+	}
+	if got := auth.Attributes["credential_source"]; got != "cline-provider-settings" {
+		t.Fatalf("credential_source = %q, want cline-provider-settings", got)
+	}
+	if _, ok := auth.Attributes["api_key"]; ok {
+		t.Fatal("expected synthesized auth not to persist Cline access token as api_key")
+	}
+}
+
 func TestSynthesizeAuthFileExpandsPluginMultiAuths(t *testing.T) {
 	tempDir := t.TempDir()
 	fullPath := filepath.Join(tempDir, "geminicli.json")

--- a/internal/watcher/synthesizer/file_test.go
+++ b/internal/watcher/synthesizer/file_test.go
@@ -162,6 +162,73 @@ func TestFileSynthesizer_Synthesize_IgnoresGeminiProviderFile(t *testing.T) {
 	}
 }
 
+func TestFileSynthesizer_Synthesize_ClinePassProviderSettings(t *testing.T) {
+	tempDir := t.TempDir()
+	raw := []byte(`{
+		"version": 1,
+		"lastUsedProvider": "cline-pass",
+		"providers": {
+			"cline-pass": {
+				"settings": {
+					"provider": "cline-pass",
+					"model": "cline-pass/glm-5.2",
+					"auth": {
+						"accessToken": "access-token",
+						"refreshToken": "refresh-token",
+						"expiresAt": 1782754552000,
+						"accountId": "acct_123"
+					}
+				}
+			}
+		}
+	}`)
+	path := filepath.Join(tempDir, "providers.json")
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatalf("failed to write providers.json: %v", err)
+	}
+
+	synth := NewFileSynthesizer()
+	ctx := &SynthesisContext{
+		Config:      &config.Config{},
+		AuthDir:     tempDir,
+		Now:         time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("expected 1 auth, got %d", len(auths))
+	}
+	auth := auths[0]
+	if auth.ID != "providers.json#cline-pass" {
+		t.Fatalf("auth ID = %q, want providers.json#cline-pass", auth.ID)
+	}
+	if auth.Provider != "openai-compatible-cline-pass" {
+		t.Fatalf("provider = %q, want openai-compatible-cline-pass", auth.Provider)
+	}
+	if auth.Label != "cline-pass" {
+		t.Fatalf("label = %q, want cline-pass", auth.Label)
+	}
+	if got := auth.Attributes["base_url"]; got != "https://api.cline.bot/api/v1" {
+		t.Fatalf("base_url = %q, want Cline API base URL", got)
+	}
+	if got := auth.Attributes["credential_source"]; got != "cline-provider-settings" {
+		t.Fatalf("credential_source = %q, want cline-provider-settings", got)
+	}
+	if got := auth.Attributes["auth_kind"]; got != "oauth" {
+		t.Fatalf("auth_kind = %q, want oauth", got)
+	}
+	if _, ok := auth.Attributes["api_key"]; ok {
+		t.Fatal("expected synthesized auth not to persist Cline access token as api_key")
+	}
+	if auth.Metadata != nil {
+		t.Fatalf("metadata = %#v, want nil so Cline tokens are not copied", auth.Metadata)
+	}
+}
+
 func TestSynthesizeAuthFileExpandsPluginMultiAuths(t *testing.T) {
 	tempDir := t.TempDir()
 	fullPath := filepath.Join(tempDir, "geminicli.json")

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -482,6 +482,145 @@ func TestManagerExecuteStream_ModelSupportBadRequestFallsBackAndSuspendsAuth(t *
 	}
 }
 
+func TestManager_ClineProviderSettingsCredentialErrorFallsBackWithoutCooldown(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	provider := "openai-compatible-cline-pass"
+	model := "cline-pass/glm-5.2"
+	badAuth := &Auth{ID: "aa-missing-token", Provider: provider}
+	goodAuth := &Auth{ID: "bb-good-token", Provider: provider}
+	executor := &authFallbackExecutor{
+		id: provider,
+		executeErrors: map[string]error{
+			badAuth.ID: &Error{
+				HTTPStatus: http.StatusFailedDependency,
+				Message:    "cline provider settings credential error: access token unavailable",
+			},
+		},
+	}
+	m.RegisterExecutor(executor)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(badAuth.ID, provider, []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient(goodAuth.ID, provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(badAuth.ID)
+		reg.UnregisterClient(goodAuth.ID)
+	})
+
+	if _, errRegister := m.Register(context.Background(), badAuth); errRegister != nil {
+		t.Fatalf("register bad auth: %v", errRegister)
+	}
+	if _, errRegister := m.Register(context.Background(), goodAuth); errRegister != nil {
+		t.Fatalf("register good auth: %v", errRegister)
+	}
+
+	resp, errExecute := m.Execute(context.Background(), []string{provider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("execute error = %v, want success", errExecute)
+	}
+	if string(resp.Payload) != goodAuth.ID {
+		t.Fatalf("execute payload = %q, want %q", string(resp.Payload), goodAuth.ID)
+	}
+	got := executor.ExecuteCalls()
+	want := []string{badAuth.ID, goodAuth.ID}
+	if len(got) != len(want) {
+		t.Fatalf("execute calls = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("execute call %d auth = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	updatedBad, ok := m.GetByID(badAuth.ID)
+	if !ok || updatedBad == nil {
+		t.Fatalf("expected bad auth to remain registered")
+	}
+	state := updatedBad.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected model state for %q", model)
+	}
+	if !state.Unavailable {
+		t.Fatalf("expected bad auth model state to record the local credential failure")
+	}
+	if !state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected no cooldown for local credential dependency error, got %v", state.NextRetryAfter)
+	}
+}
+
+func TestManagerExecuteStream_ClineProviderSettingsCredentialErrorFallsBackWithoutCooldown(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	provider := "openai-compatible-cline-pass"
+	model := "cline-pass/glm-5.2"
+	badAuth := &Auth{ID: "aa-missing-token", Provider: provider}
+	goodAuth := &Auth{ID: "bb-good-token", Provider: provider}
+	executor := &authFallbackExecutor{
+		id: provider,
+		streamFirstErrors: map[string]error{
+			badAuth.ID: &Error{
+				HTTPStatus: http.StatusFailedDependency,
+				Message:    "cline provider settings credential error: access token unavailable",
+			},
+		},
+	}
+	m.RegisterExecutor(executor)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(badAuth.ID, provider, []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient(goodAuth.ID, provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(badAuth.ID)
+		reg.UnregisterClient(goodAuth.ID)
+	})
+
+	if _, errRegister := m.Register(context.Background(), badAuth); errRegister != nil {
+		t.Fatalf("register bad auth: %v", errRegister)
+	}
+	if _, errRegister := m.Register(context.Background(), goodAuth); errRegister != nil {
+		t.Fatalf("register good auth: %v", errRegister)
+	}
+
+	streamResult, errExecute := m.ExecuteStream(context.Background(), []string{provider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("execute stream error = %v, want success", errExecute)
+	}
+	var payload []byte
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("execute stream chunk error = %v, want success", chunk.Err)
+		}
+		payload = append(payload, chunk.Payload...)
+	}
+	if string(payload) != goodAuth.ID {
+		t.Fatalf("execute stream payload = %q, want %q", string(payload), goodAuth.ID)
+	}
+	got := executor.StreamCalls()
+	want := []string{badAuth.ID, goodAuth.ID}
+	if len(got) != len(want) {
+		t.Fatalf("stream calls = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("stream call %d auth = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	updatedBad, ok := m.GetByID(badAuth.ID)
+	if !ok || updatedBad == nil {
+		t.Fatalf("expected bad auth to remain registered")
+	}
+	state := updatedBad.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected model state for %q", model)
+	}
+	if !state.Unavailable {
+		t.Fatalf("expected bad auth model state to record the local credential failure")
+	}
+	if !state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected no cooldown for local credential dependency error, got %v", state.NextRetryAfter)
+	}
+}
+
 func TestManager_MarkResult_RespectsAuthDisableCoolingOverride(t *testing.T) {
 	prev := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -825,21 +825,10 @@ func openAICompatInfoFromAuth(a *coreauth.Auth) (providerKey string, compatName 
 }
 
 func isClineProviderSettingsCompatAuth(a *coreauth.Auth) bool {
-	if a == nil || a.Attributes == nil {
+	if a == nil {
 		return false
 	}
-	if strings.TrimSpace(a.Attributes["credential_source"]) != clineauth.CredentialSourceProviderSettings {
-		return false
-	}
-	providerID := strings.TrimSpace(a.Attributes["cline_provider"])
-	if providerID == "" {
-		providerID = strings.TrimSpace(a.Attributes["compat_name"])
-	}
-	if !strings.EqualFold(providerID, clineauth.ProviderClinePass) {
-		return false
-	}
-	baseURL := strings.TrimRight(strings.TrimSpace(a.Attributes["base_url"]), "/")
-	return strings.EqualFold(baseURL, strings.TrimRight(clineauth.APIBaseURL, "/"))
+	return clineauth.IsProviderSettingsClinePassAttributes(a.Attributes)
 }
 
 type openAICompatibilityRegistrationCache struct {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -824,6 +824,24 @@ func openAICompatInfoFromAuth(a *coreauth.Auth) (providerKey string, compatName 
 	return "", "", false
 }
 
+func isClineProviderSettingsCompatAuth(a *coreauth.Auth) bool {
+	if a == nil || a.Attributes == nil {
+		return false
+	}
+	if strings.TrimSpace(a.Attributes["credential_source"]) != clineauth.CredentialSourceProviderSettings {
+		return false
+	}
+	providerID := strings.TrimSpace(a.Attributes["cline_provider"])
+	if providerID == "" {
+		providerID = strings.TrimSpace(a.Attributes["compat_name"])
+	}
+	if !strings.EqualFold(providerID, clineauth.ProviderClinePass) {
+		return false
+	}
+	baseURL := strings.TrimRight(strings.TrimSpace(a.Attributes["base_url"]), "/")
+	return strings.EqualFold(baseURL, strings.TrimRight(clineauth.APIBaseURL, "/"))
+}
+
 type openAICompatibilityRegistrationCache struct {
 	byName map[string]*openAICompatibilityRegistrationEntry
 }
@@ -2015,7 +2033,7 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		models = registry.GetXAIModels()
 		models = applyExcludedModels(models, excluded)
 	default:
-		if compatDetected && strings.EqualFold(compatDisplayName, clineauth.ProviderClinePass) {
+		if compatDetected && strings.EqualFold(compatDisplayName, clineauth.ProviderClinePass) && isClineProviderSettingsCompatAuth(a) {
 			providerKey := compatProviderKey
 			if providerKey == "" {
 				providerKey = util.OpenAICompatibleProviderKey(clineauth.ProviderClinePass)

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/api"
+	clineauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/cline"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/homeplugins"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
@@ -2014,6 +2015,21 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		models = registry.GetXAIModels()
 		models = applyExcludedModels(models, excluded)
 	default:
+		if compatDetected && strings.EqualFold(compatDisplayName, clineauth.ProviderClinePass) {
+			providerKey := compatProviderKey
+			if providerKey == "" {
+				providerKey = util.OpenAICompatibleProviderKey(clineauth.ProviderClinePass)
+			}
+			models = registry.GetClinePassModels()
+			models = applyExcludedModels(models, excluded)
+			models = s.appendPluginModels(providerKey, models)
+			if len(models) > 0 {
+				s.registerResolvedModelsForAuth(a, providerKey, applyModelPrefixes(models, a.Prefix, s.cfg != nil && s.cfg.ForceModelPrefix))
+			} else {
+				GlobalModelRegistry().UnregisterClient(a.ID)
+			}
+			return
+		}
 		// Handle OpenAI-compatibility providers by name using config
 		if s.cfg != nil {
 			providerKey := provider

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2020,8 +2020,15 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 			if providerKey == "" {
 				providerKey = util.OpenAICompatibleProviderKey(clineauth.ProviderClinePass)
 			}
+			clineExcluded := s.oauthExcludedModels(providerKey, authKind)
+			if a.Attributes != nil {
+				if val, ok := a.Attributes["excluded_models"]; ok && strings.TrimSpace(val) != "" {
+					clineExcluded = strings.Split(val, ",")
+				}
+			}
 			models = registry.GetClinePassModels()
-			models = applyExcludedModels(models, excluded)
+			models = applyExcludedModels(models, clineExcluded)
+			models = applyOAuthModelAliasForAuth(s.cfg, providerKey, authKind, a.Attributes, models)
 			models = s.appendPluginModels(providerKey, models)
 			if len(models) > 0 {
 				s.registerResolvedModelsForAuth(a, providerKey, applyModelPrefixes(models, a.Prefix, s.cfg != nil && s.cfg.ForceModelPrefix))

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	clineauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/cline"
 	internalregistry "github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -145,9 +146,12 @@ func TestRegisterModelsForAuth_ClinePassCompatAuth(t *testing.T) {
 		Provider: "openai-compatible-cline-pass",
 		Status:   coreauth.StatusActive,
 		Attributes: map[string]string{
-			"auth_kind":    "oauth",
-			"compat_name":  "cline-pass",
-			"provider_key": "openai-compatible-cline-pass",
+			"auth_kind":         "oauth",
+			"compat_name":       "cline-pass",
+			"provider_key":      "openai-compatible-cline-pass",
+			"credential_source": clineauth.CredentialSourceProviderSettings,
+			"cline_provider":    clineauth.ProviderClinePass,
+			"base_url":          clineauth.APIBaseURL,
 		},
 	}
 
@@ -212,9 +216,12 @@ func TestRegisterModelsForAuth_ClinePassUsesResolvedProviderControls(t *testing.
 		Provider: "openai-compatible-cline-pass",
 		Status:   coreauth.StatusActive,
 		Attributes: map[string]string{
-			"auth_kind":    "oauth",
-			"compat_name":  "cline-pass",
-			"provider_key": "openai-compatible-cline-pass",
+			"auth_kind":         "oauth",
+			"compat_name":       "cline-pass",
+			"provider_key":      "openai-compatible-cline-pass",
+			"credential_source": clineauth.CredentialSourceProviderSettings,
+			"cline_provider":    clineauth.ProviderClinePass,
+			"base_url":          clineauth.APIBaseURL,
 		},
 	}
 
@@ -246,6 +253,118 @@ func TestRegisterModelsForAuth_ClinePassUsesResolvedProviderControls(t *testing.
 	}
 	if !sawAlias {
 		t.Fatal("expected alias model registered through resolved Cline Pass provider key")
+	}
+}
+
+func TestRegisterModelsForAuth_OpenAICompatibilityNamedClinePassUsesConfigModels(t *testing.T) {
+	service := &Service{
+		cfg: &config.Config{
+			OpenAICompatibility: []config.OpenAICompatibility{
+				{
+					Name:    "cline-pass",
+					BaseURL: "https://example.com/v1",
+					Models: []config.OpenAICompatibilityModel{
+						{Name: "custom-upstream-model", Alias: "custom-cline-pass-model"},
+					},
+				},
+			},
+		},
+	}
+	auth := &coreauth.Auth{
+		ID:       "auth-config-cline-pass",
+		Provider: "openai-compatible-cline-pass",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind":    coreauth.AuthKindAPIKey,
+			"compat_name":  "cline-pass",
+			"provider_key": "openai-compatible-cline-pass",
+		},
+	}
+
+	modelRegistry := internalregistry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	models := modelRegistry.GetModelsForClient(auth.ID)
+	if len(models) == 0 {
+		t.Fatal("expected configured OpenAI-compatible models to be registered")
+	}
+	var sawConfigured bool
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		switch model.ID {
+		case "custom-cline-pass-model":
+			sawConfigured = true
+		case "cline-pass/glm-5.2":
+			t.Fatal("ordinary OpenAI-compatible config named cline-pass was replaced by static Cline Pass models")
+		}
+	}
+	if !sawConfigured {
+		t.Fatalf("expected configured model alias, got %#v", models)
+	}
+}
+
+func TestIsClineProviderSettingsCompatAuth(t *testing.T) {
+	tests := []struct {
+		name      string
+		attrs     map[string]string
+		wantCline bool
+	}{
+		{
+			name: "synthesized cline provider settings auth",
+			attrs: map[string]string{
+				"credential_source": clineauth.CredentialSourceProviderSettings,
+				"cline_provider":    clineauth.ProviderClinePass,
+				"base_url":          clineauth.APIBaseURL,
+			},
+			wantCline: true,
+		},
+		{
+			name: "compat name fallback",
+			attrs: map[string]string{
+				"credential_source": clineauth.CredentialSourceProviderSettings,
+				"compat_name":       clineauth.ProviderClinePass,
+				"base_url":          clineauth.APIBaseURL + "/",
+			},
+			wantCline: true,
+		},
+		{
+			name: "ordinary config named cline pass",
+			attrs: map[string]string{
+				"compat_name": clineauth.ProviderClinePass,
+				"base_url":    clineauth.APIBaseURL,
+			},
+		},
+		{
+			name: "different base URL",
+			attrs: map[string]string{
+				"credential_source": clineauth.CredentialSourceProviderSettings,
+				"cline_provider":    clineauth.ProviderClinePass,
+				"base_url":          "https://example.com/v1",
+			},
+		},
+		{
+			name: "different provider",
+			attrs: map[string]string{
+				"credential_source": clineauth.CredentialSourceProviderSettings,
+				"cline_provider":    "cline",
+				"base_url":          clineauth.APIBaseURL,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isClineProviderSettingsCompatAuth(&coreauth.Auth{Attributes: tc.attrs})
+			if got != tc.wantCline {
+				t.Fatalf("isClineProviderSettingsCompatAuth() = %v, want %v", got, tc.wantCline)
+			}
+		})
 	}
 }
 

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -194,6 +194,61 @@ func TestRegisterModelsForAuth_ClinePassCompatAuth(t *testing.T) {
 	}
 }
 
+func TestRegisterModelsForAuth_ClinePassUsesResolvedProviderControls(t *testing.T) {
+	service := &Service{
+		cfg: &config.Config{
+			OAuthExcludedModels: map[string][]string{
+				"openai-compatible-cline-pass": {"cline-pass/glm-5.2"},
+			},
+			OAuthModelAlias: map[string][]config.OAuthModelAlias{
+				"openai-compatible-cline-pass": {
+					{Name: "cline-pass/qwen3.7-max", Alias: "cline-pass/qwen3.7-max-alias"},
+				},
+			},
+		},
+	}
+	auth := &coreauth.Auth{
+		ID:       "auth-cline-pass-controls",
+		Provider: "openai-compatible-cline-pass",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind":    "oauth",
+			"compat_name":  "cline-pass",
+			"provider_key": "openai-compatible-cline-pass",
+		},
+	}
+
+	modelRegistry := internalregistry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	models := modelRegistry.GetModelsForClient(auth.ID)
+	if len(models) == 0 {
+		t.Fatal("expected Cline Pass models to be registered")
+	}
+	var sawAlias bool
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		switch model.ID {
+		case "cline-pass/glm-5.2":
+			t.Fatal("expected cline-pass/glm-5.2 to be excluded by resolved Cline Pass provider key")
+		case "cline-pass/qwen3.7-max":
+			t.Fatal("expected original qwen model to be renamed by resolved Cline Pass alias")
+		case "cline-pass/qwen3.7-max-alias":
+			sawAlias = true
+		}
+	}
+	if !sawAlias {
+		t.Fatal("expected alias model registered through resolved Cline Pass provider key")
+	}
+}
+
 func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.T) {
 	var sawFetch bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -136,6 +136,64 @@ func TestRegisterModelsForAuth_OpenAICompatibilityImageModelType(t *testing.T) {
 	}
 }
 
+func TestRegisterModelsForAuth_ClinePassCompatAuth(t *testing.T) {
+	service := &Service{
+		cfg: &config.Config{},
+	}
+	auth := &coreauth.Auth{
+		ID:       "auth-cline-pass",
+		Provider: "openai-compatible-cline-pass",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind":    "oauth",
+			"compat_name":  "cline-pass",
+			"provider_key": "openai-compatible-cline-pass",
+		},
+	}
+
+	modelRegistry := internalregistry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	models := modelRegistry.GetModelsForClient(auth.ID)
+	if len(models) == 0 {
+		t.Fatal("expected Cline Pass models to be registered")
+	}
+	var glm *internalregistry.ModelInfo
+	for _, model := range models {
+		if model != nil && model.ID == "cline-pass/glm-5.2" {
+			glm = model
+			break
+		}
+	}
+	if glm == nil {
+		t.Fatal("expected cline-pass/glm-5.2 to be registered")
+	}
+	if glm.OwnedBy != "cline-pass" {
+		t.Fatalf("owned_by = %q, want cline-pass", glm.OwnedBy)
+	}
+	if glm.Type != "openai-compatibility" {
+		t.Fatalf("type = %q, want openai-compatibility", glm.Type)
+	}
+	if glm.Thinking == nil {
+		t.Fatal("expected Cline Pass model to include thinking levels")
+	}
+	hasXHigh := false
+	for _, level := range glm.Thinking.Levels {
+		if level == "xhigh" {
+			hasXHigh = true
+			break
+		}
+	}
+	if !hasXHigh {
+		t.Fatalf("thinking levels = %#v, want xhigh support", glm.Thinking.Levels)
+	}
+}
+
 func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.T) {
 	var sawFetch bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Detect Cline `providers.json` files in `auth-dir` and synthesize a Cline Pass auth entry.
- Read the current Cline Pass token at request time instead of copying it into CLIProxyAPI metadata.
- Register Cline Pass models and document the explicit symlink setup.

## Test
- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`
- Verified a proxied `cline-pass/glm-5.2` chat completion locally