### PR TITLE
Handle Codex websocket compaction triggers

### DIFF
--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -401,6 +401,9 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
 	}
+	if codexWebsocketRequestHasInputItemType(req, opts, "compaction_trigger") {
+		return e.executeCompactionTriggerStream(ctx, auth, req, opts)
+	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	apiKey, baseURL := codexCreds(auth)
@@ -739,6 +742,193 @@ func buildCodexWebsocketRequestBody(body []byte) []byte {
 	fallback := bytes.Clone(body)
 	fallback, _ = sjson.SetBytes(fallback, "type", "response.create")
 	return fallback
+}
+
+func (e *CodexWebsocketsExecutor) executeCompactionTriggerStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	if e == nil || e.CodexExecutor == nil {
+		return nil, fmt.Errorf("codex websockets executor: codex executor is nil")
+	}
+
+	compactReq := req
+	compactReq.Payload = codexWebsocketPrepareCompactionTriggerPayload(compactReq.Payload)
+	compactOpts := opts
+	compactOpts.Stream = false
+	if len(compactOpts.OriginalRequest) > 0 {
+		compactOpts.OriginalRequest = codexWebsocketPrepareCompactionTriggerPayload(compactOpts.OriginalRequest)
+	}
+
+	resp, err := e.CodexExecutor.executeCompact(ctx, auth, compactReq, compactOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := resp.Headers.Clone()
+	if headers == nil {
+		headers = make(http.Header)
+	}
+	headers.Set("Content-Type", "text/event-stream")
+
+	chunks := codexWebsocketBuildCompactionTriggerStreamChunks(resp.Payload)
+	out := make(chan cliproxyexecutor.StreamChunk, len(chunks))
+	for _, chunk := range chunks {
+		out <- cliproxyexecutor.StreamChunk{Payload: chunk}
+	}
+	close(out)
+	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out}, nil
+}
+
+func codexWebsocketRequestHasInputItemType(req cliproxyexecutor.Request, opts cliproxyexecutor.Options, itemType string) bool {
+	return codexWebsocketInputHasItemType(req.Payload, itemType) || codexWebsocketInputHasItemType(opts.OriginalRequest, itemType)
+}
+
+func codexWebsocketInputHasItemType(body []byte, itemType string) bool {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return false
+	}
+	for _, item := range input.Array() {
+		if item.Get("type").String() == itemType {
+			return true
+		}
+	}
+	return false
+}
+
+func codexWebsocketPrepareCompactionTriggerPayload(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	body = codexWebsocketRemoveInputItemsByType(body, "compaction_trigger")
+	body, _ = sjson.DeleteBytes(body, "stream")
+	return body
+}
+
+func codexWebsocketRemoveInputItemsByType(body []byte, itemType string) []byte {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body
+	}
+
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	kept := 0
+	for _, item := range input.Array() {
+		if item.Get("type").String() == itemType {
+			continue
+		}
+		if kept > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(item.Raw)
+		kept++
+	}
+	buf.WriteByte(']')
+
+	updated, err := sjson.SetRawBytes(body, "input", buf.Bytes())
+	if err != nil {
+		return body
+	}
+	return updated
+}
+
+func codexWebsocketBuildCompactionTriggerStreamChunks(compactData []byte) [][]byte {
+	compactData = codexWebsocketCompactionResponseData(compactData)
+	responseID := codexWebsocketCompactionResponseID(compactData)
+	now := time.Now().Unix()
+	createdAt := gjson.GetBytes(compactData, "created_at").Int()
+	if createdAt == 0 {
+		createdAt = now
+	}
+	completedAt := gjson.GetBytes(compactData, "completed_at").Int()
+	if completedAt == 0 {
+		completedAt = now
+	}
+
+	item := codexWebsocketCompactionOutputItem(compactData, responseID)
+	output := make([]byte, 0, len(item)+2)
+	output = append(output, '[')
+	output = append(output, item...)
+	output = append(output, ']')
+
+	createdResponse := codexWebsocketBuildCompactionBaseResponse(compactData, responseID, createdAt, "in_progress")
+	inProgressResponse := codexWebsocketBuildCompactionBaseResponse(compactData, responseID, createdAt, "in_progress")
+	completedResponse := codexWebsocketBuildCompactionBaseResponse(compactData, responseID, createdAt, "completed")
+	completedResponse, _ = sjson.SetBytes(completedResponse, "completed_at", completedAt)
+	completedResponse, _ = sjson.SetRawBytes(completedResponse, "output", output)
+	if usage := gjson.GetBytes(compactData, "usage"); usage.Exists() {
+		completedResponse, _ = sjson.SetRawBytes(completedResponse, "usage", []byte(usage.Raw))
+	}
+
+	createdPayload := []byte(`{"type":"response.created","sequence_number":0}`)
+	createdPayload, _ = sjson.SetRawBytes(createdPayload, "response", createdResponse)
+	inProgressPayload := []byte(`{"type":"response.in_progress","sequence_number":1}`)
+	inProgressPayload, _ = sjson.SetRawBytes(inProgressPayload, "response", inProgressResponse)
+	addedPayload := []byte(`{"type":"response.output_item.added","sequence_number":2,"output_index":0}`)
+	addedPayload, _ = sjson.SetRawBytes(addedPayload, "item", item)
+	keepalivePayload := []byte(`{"type":"keepalive","sequence_number":3}`)
+	donePayload := []byte(`{"type":"response.output_item.done","sequence_number":4,"output_index":0}`)
+	donePayload, _ = sjson.SetRawBytes(donePayload, "item", item)
+	completedPayload := []byte(`{"type":"response.completed","sequence_number":5}`)
+	completedPayload, _ = sjson.SetRawBytes(completedPayload, "response", completedResponse)
+
+	return [][]byte{
+		codexBuildSSEFrame("response.created", createdPayload),
+		codexBuildSSEFrame("response.in_progress", inProgressPayload),
+		codexBuildSSEFrame("response.output_item.added", addedPayload),
+		codexBuildSSEFrame("keepalive", keepalivePayload),
+		codexBuildSSEFrame("response.output_item.done", donePayload),
+		codexBuildSSEFrame("response.completed", completedPayload),
+	}
+}
+
+func codexWebsocketCompactionResponseData(compactData []byte) []byte {
+	if response := gjson.GetBytes(compactData, "response"); response.Exists() && response.IsObject() {
+		return []byte(response.Raw)
+	}
+	return compactData
+}
+
+func codexWebsocketBuildCompactionBaseResponse(compactData []byte, responseID string, createdAt int64, status string) []byte {
+	response := []byte(`{"id":"","object":"response","created_at":0,"status":"","background":false,"error":null,"incomplete_details":null,"output":[]}`)
+	response, _ = sjson.SetBytes(response, "id", responseID)
+	response, _ = sjson.SetBytes(response, "created_at", createdAt)
+	response, _ = sjson.SetBytes(response, "status", status)
+	if model := gjson.GetBytes(compactData, "model").String(); model != "" {
+		response, _ = sjson.SetBytes(response, "model", model)
+	}
+	return response
+}
+
+func codexWebsocketCompactionOutputItem(compactData []byte, responseID string) []byte {
+	itemResult := gjson.GetBytes(compactData, "output.0")
+	item := []byte(`{"type":"compaction"}`)
+	if itemResult.Exists() && itemResult.Type == gjson.JSON {
+		item = []byte(itemResult.Raw)
+	}
+	if !gjson.GetBytes(item, "type").Exists() {
+		item, _ = sjson.SetBytes(item, "type", "compaction")
+	}
+	if !gjson.GetBytes(item, "id").Exists() {
+		item, _ = sjson.SetBytes(item, "id", codexWebsocketCompactionItemID(responseID))
+	}
+	return item
+}
+
+func codexWebsocketCompactionResponseID(compactData []byte) string {
+	if responseID := strings.TrimSpace(gjson.GetBytes(compactData, "id").String()); responseID != "" {
+		if strings.HasPrefix(responseID, "resp_") {
+			return responseID
+		}
+		return "resp_" + strings.TrimPrefix(responseID, "cmp_")
+	}
+	return fmt.Sprintf("resp_codex_compaction_%d", time.Now().UnixNano())
+}
+
+func codexWebsocketCompactionItemID(responseID string) string {
+	if suffix := strings.TrimPrefix(responseID, "resp_"); suffix != "" && suffix != responseID {
+		return "cmp_" + suffix
+	}
+	return "cmp_" + responseID
 }
 
 func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession, conn *websocket.Conn, readCh chan codexWebsocketRead) (int, []byte, error) {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -224,6 +225,101 @@ func TestCodexWebsocketsExecuteStreamPropagatesUpstreamErrorForDownstreamWebsock
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for error stream chunk")
+	}
+}
+
+func TestCodexWebsocketsExecuteStreamCompactionTriggerUsesHTTPCompact(t *testing.T) {
+	capturedCompactPayload := make(chan []byte, 1)
+	websocketHit := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/responses/compact":
+			body, errRead := io.ReadAll(r.Body)
+			if errRead != nil {
+				t.Errorf("read compact body: %v", errRead)
+				http.Error(w, "read compact body", http.StatusInternalServerError)
+				return
+			}
+			capturedCompactPayload <- bytes.Clone(body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp_codex_ws_compact","model":"gpt-5.5","output":[{"type":"compaction","encrypted_content":"opaque-ws"}],"usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18}}`))
+		case "/responses":
+			select {
+			case websocketHit <- struct{}{}:
+			default:
+			}
+			http.Error(w, "unexpected websocket request", http.StatusInternalServerError)
+		default:
+			t.Errorf("path = %q, want /responses/compact", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "sk-test",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"gpt-5.5","stream":true,"previous_response_id":"resp_old_ws","input":[{"type":"compaction_trigger"}]}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: payload,
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FromString("openai-response"),
+		ResponseFormat:  sdktranslator.FromString("openai-response"),
+		OriginalRequest: payload,
+		Stream:          true,
+	}
+	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+
+	result, err := exec.ExecuteStream(ctx, auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream compaction trigger error: %v", err)
+	}
+
+	var streamed bytes.Buffer
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("compact stream chunk error = %v", chunk.Err)
+		}
+		streamed.Write(chunk.Payload)
+	}
+
+	select {
+	case payload := <-capturedCompactPayload:
+		if codexWebsocketInputHasItemType(payload, "compaction_trigger") {
+			t.Fatalf("compaction_trigger reached codex compact body: %s", payload)
+		}
+		if gjson.GetBytes(payload, "stream").Exists() {
+			t.Fatalf("stream exists in compact body: %s", payload)
+		}
+		if got := gjson.GetBytes(payload, "previous_response_id").String(); got != "resp_old_ws" {
+			t.Fatalf("previous_response_id = %q, want resp_old_ws: %s", got, payload)
+		}
+		if input := gjson.GetBytes(payload, "input"); !input.IsArray() || len(input.Array()) != 0 {
+			t.Fatalf("compact input = %s, want empty array after trigger removal: %s", input.Raw, payload)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for compact HTTP payload")
+	}
+
+	select {
+	case <-websocketHit:
+		t.Fatal("compaction trigger unexpectedly hit upstream websocket /responses endpoint")
+	default:
+	}
+
+	output := streamed.String()
+	if !strings.Contains(output, "event: response.completed\n") {
+		t.Fatalf("missing response.completed event in compact stream: %s", output)
+	}
+	if !strings.Contains(output, `"type":"compaction"`) || !strings.Contains(output, `"encrypted_content":"opaque-ws"`) {
+		t.Fatalf("compaction output missing from compact stream: %s", output)
+	}
+	if !strings.Contains(output, `"usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18}`) {
+		t.Fatalf("usage missing from compact stream: %s", output)
 	}
 }
 


### PR DESCRIPTION
# Draft PR: Handle Codex Websocket Compaction Triggers

## Title

Handle Codex websocket compaction triggers

## Body

### Summary

- route Codex websocket stream requests containing `compaction_trigger` through the existing HTTP compact path
- strip websocket/request-chain fields before calling `/responses/compact`
- synthesize an event stream with compact output, usage, and `response.completed`

### Validation

- `go test -count=1 -v -run "TestCodexWebsocketsExecuteStream(CompactionTriggerUsesHTTPCompact|PassesThroughUpstreamWebsocketPayloadForDownstreamWebsocket|PropagatesUpstreamErrorForDownstreamWebsocket)$" ./internal/runtime/executor`
- `go build -o <temp>/cliproxy-upstream-compact-pr-build.exe ./cmd/server`

### Notes

This preserves normal downstream websocket passthrough and upstream websocket error propagation while preventing compact-trigger requests from being forwarded to upstream websocket `/responses`.
