### PR TITLE
Improve reasoning content handling in response logic

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -398,7 +398,11 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 				}
 
 				// reasoning_content (OpenAI reasoning incremental text)
-				if rc := delta.Get("reasoning_content"); rc.Exists() && rc.String() != "" {
+				rc := delta.Get("reasoning_content")
+				if !rc.Exists() || rc.String() == "" {
+					rc = delta.Get("reasoning")
+				}
+				if rc.Exists() && rc.String() != "" {
 					// On first appearance, add reasoning item and part
 					if st.ReasoningID == "" {
 						st.ReasoningID = fmt.Sprintf("rs_%s_%d", st.ResponseID, idx)


### PR DESCRIPTION
Enhance reasoning content retrieval by falling back to 'reasoning' if 'reasoning_content' is absent or empty. In some selfhosted openai-like server serving deepseek, the response.delta may contains reasoning rather than reasoning_content. So the client like codex does not recognize the thinking process.
The fork is tested and in codex Ctrl+T, the thinking process shows correctly.