### PR TITLE
添加同名模型优先级路由

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -168,6 +168,12 @@ quota-exceeded:
 # Routing strategy for selecting credentials when multiple match.
 routing:
   strategy: "round-robin" # round-robin (default), fill-first
+  # Prefer upstream providers whose protocol family matches the inbound request
+  # when the same visible model or alias is registered on multiple providers.
+  # prefer: try matching providers first, then fall back to cross-protocol translation.
+  # strict: never fall back to cross-protocol providers.
+  # off: keep legacy mixed-provider routing.
+  protocol-affinity: "prefer" # default: prefer
   # Enable universal session-sticky routing for all clients.
   # Session IDs are extracted from: metadata.user_id (Claude Code session format),
   # X-Session-ID, Session_id (Codex), X-Client-Request-Id (PI), conversation_id,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -334,6 +334,11 @@ type RoutingConfig struct {
 	// Supported values: "round-robin" (default), "fill-first".
 	Strategy string `yaml:"strategy,omitempty" json:"strategy,omitempty"`
 
+	// ProtocolAffinity controls mixed-provider routing when the same visible
+	// model is available through different upstream protocol families.
+	// Supported values: "prefer" (default), "strict", "off".
+	ProtocolAffinity string `yaml:"protocol-affinity,omitempty" json:"protocol-affinity,omitempty"`
+
 	// SessionAffinity enables universal session-sticky routing for all clients.
 	// Session IDs are extracted from multiple sources:
 	// metadata.user_id (Claude Code session format), X-Session-ID, Session_id (Codex),

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4544,6 +4544,37 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		return m.pickNextViaHome(ctx, model, opts, tried)
 	}
 
+	if batches, ok := m.protocolAffinityProviderBatches(providers, opts); ok {
+		var firstErr error
+		for _, batch := range batches {
+			if len(batch) == 0 {
+				errBatch := &Error{Code: "provider_not_found", Message: "no protocol-compatible provider supplied"}
+				if firstErr == nil {
+					firstErr = errBatch
+				}
+				continue
+			}
+			auth, executor, provider, errPick := m.pickNextMixedWithoutProtocolAffinity(ctx, batch, model, opts, tried)
+			if errPick == nil {
+				return auth, executor, provider, nil
+			}
+			if firstErr == nil {
+				firstErr = errPick
+			}
+			if !shouldFallbackProtocolAffinityPick(errPick) {
+				return nil, nil, "", errPick
+			}
+		}
+		if firstErr != nil {
+			return nil, nil, "", firstErr
+		}
+		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
+	}
+
+	return m.pickNextMixedWithoutProtocolAffinity(ctx, providers, model, opts, tried)
+}
+
+func (m *Manager) pickNextMixedWithoutProtocolAffinity(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, string, error) {
 	if m.hasPluginScheduler() || !m.useSchedulerFastPath() {
 		return m.pickNextMixedLegacy(ctx, providers, model, opts, tried)
 	}

--- a/sdk/cliproxy/auth/protocol_affinity.go
+++ b/sdk/cliproxy/auth/protocol_affinity.go
@@ -15,6 +15,14 @@ const (
 	protocolAffinityOff    = "off"
 )
 
+const (
+	protocolFamilyOpenAIChat      = "openai-chat"
+	protocolFamilyOpenAIResponses = "openai-responses"
+	protocolFamilyClaude          = "claude"
+	protocolFamilyGemini          = "gemini"
+	protocolFamilyAntigravity     = "antigravity"
+)
+
 func (m *Manager) protocolAffinityMode() string {
 	cfg := &internalconfig.Config{}
 	if m != nil {
@@ -39,46 +47,70 @@ func (m *Manager) protocolAffinityProviderBatches(providers []string, opts clipr
 	if mode == protocolAffinityOff {
 		return nil, false
 	}
-	family := sourceProtocolFamily(opts.SourceFormat)
-	if family == "" {
+	preferences := sourceProtocolPreference(opts.SourceFormat)
+	if len(preferences) == 0 {
 		return nil, false
 	}
 	normalized := normalizeProviderKeys(providers)
-	preferred := make([]string, 0, len(normalized))
-	fallback := make([]string, 0, len(normalized))
+	providerFamilies := make(map[string]string, len(normalized))
 	for _, provider := range normalized {
-		if providerProtocolFamily(provider) == family {
-			preferred = append(preferred, provider)
-		} else {
-			fallback = append(fallback, provider)
+		providerFamilies[provider] = providerProtocolFamily(provider)
+	}
+	used := make(map[string]struct{}, len(normalized))
+	batchForFamily := func(family string) []string {
+		batch := make([]string, 0, len(normalized))
+		for _, provider := range normalized {
+			if _, ok := used[provider]; ok {
+				continue
+			}
+			if providerFamilies[provider] != family {
+				continue
+			}
+			used[provider] = struct{}{}
+			batch = append(batch, provider)
 		}
+		return batch
 	}
 	if mode == protocolAffinityStrict {
-		return [][]string{preferred}, true
+		return [][]string{batchForFamily(preferences[0])}, true
 	}
-	if len(preferred) == 0 {
+
+	batches := make([][]string, 0, len(preferences)+1)
+	for _, family := range preferences {
+		if batch := batchForFamily(family); len(batch) > 0 {
+			batches = append(batches, batch)
+		}
+	}
+	fallback := make([]string, 0, len(normalized))
+	for _, provider := range normalized {
+		if _, ok := used[provider]; ok {
+			continue
+		}
+		fallback = append(fallback, provider)
+	}
+	if len(fallback) > 0 {
+		batches = append(batches, fallback)
+	}
+	if len(batches) == 0 {
 		return nil, false
 	}
-	if len(fallback) == 0 {
-		return [][]string{preferred}, true
-	}
-	return [][]string{preferred, fallback}, true
+	return batches, true
 }
 
-func sourceProtocolFamily(format sdktranslator.Format) string {
+func sourceProtocolPreference(format sdktranslator.Format) []string {
 	switch strings.ToLower(strings.TrimSpace(format.String())) {
-	case "openai", "openai-chat", "chat-completions", "openai-response", "openai-responses", "responses", "openai-image", "openai-video":
-		return "openai"
-	case "codex":
-		return "openai"
+	case "openai", "openai-chat", "chat-completions", "completions", "completion", "openai-image", "openai-video":
+		return []string{protocolFamilyOpenAIChat, protocolFamilyOpenAIResponses}
+	case "openai-response", "openai-responses", "responses", "codex":
+		return []string{protocolFamilyOpenAIResponses, protocolFamilyOpenAIChat}
 	case "claude", "anthropic":
-		return "claude"
+		return []string{protocolFamilyClaude}
 	case "gemini", "google", "vertex", "aistudio":
-		return "gemini"
+		return []string{protocolFamilyGemini}
 	case "antigravity":
-		return "antigravity"
+		return []string{protocolFamilyAntigravity}
 	default:
-		return ""
+		return nil
 	}
 }
 
@@ -86,15 +118,17 @@ func providerProtocolFamily(provider string) string {
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	switch {
 	case provider == "openai", provider == "openai-compatibility", strings.HasPrefix(provider, "openai-compatible-"):
-		return "openai"
-	case provider == "codex", provider == "xai", provider == "kimi":
-		return "openai"
+		return protocolFamilyOpenAIChat
+	case provider == "kimi":
+		return protocolFamilyOpenAIChat
+	case provider == "codex", provider == "xai":
+		return protocolFamilyOpenAIResponses
 	case provider == "claude":
-		return "claude"
+		return protocolFamilyClaude
 	case provider == "gemini", provider == "vertex", provider == "aistudio":
-		return "gemini"
+		return protocolFamilyGemini
 	case provider == "antigravity":
-		return "antigravity"
+		return protocolFamilyAntigravity
 	default:
 		return ""
 	}

--- a/sdk/cliproxy/auth/protocol_affinity.go
+++ b/sdk/cliproxy/auth/protocol_affinity.go
@@ -1,0 +1,121 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+const (
+	protocolAffinityPrefer = "prefer"
+	protocolAffinityStrict = "strict"
+	protocolAffinityOff    = "off"
+)
+
+func (m *Manager) protocolAffinityMode() string {
+	cfg := &internalconfig.Config{}
+	if m != nil {
+		if loaded, ok := m.runtimeConfig.Load().(*internalconfig.Config); ok && loaded != nil {
+			cfg = loaded
+		}
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.Routing.ProtocolAffinity)) {
+	case "", protocolAffinityPrefer:
+		return protocolAffinityPrefer
+	case protocolAffinityStrict:
+		return protocolAffinityStrict
+	case protocolAffinityOff, "none", "disabled", "false":
+		return protocolAffinityOff
+	default:
+		return protocolAffinityPrefer
+	}
+}
+
+func (m *Manager) protocolAffinityProviderBatches(providers []string, opts cliproxyexecutor.Options) ([][]string, bool) {
+	mode := m.protocolAffinityMode()
+	if mode == protocolAffinityOff {
+		return nil, false
+	}
+	family := sourceProtocolFamily(opts.SourceFormat)
+	if family == "" {
+		return nil, false
+	}
+	normalized := normalizeProviderKeys(providers)
+	preferred := make([]string, 0, len(normalized))
+	fallback := make([]string, 0, len(normalized))
+	for _, provider := range normalized {
+		if providerProtocolFamily(provider) == family {
+			preferred = append(preferred, provider)
+		} else {
+			fallback = append(fallback, provider)
+		}
+	}
+	if mode == protocolAffinityStrict {
+		return [][]string{preferred}, true
+	}
+	if len(preferred) == 0 {
+		return nil, false
+	}
+	if len(fallback) == 0 {
+		return [][]string{preferred}, true
+	}
+	return [][]string{preferred, fallback}, true
+}
+
+func sourceProtocolFamily(format sdktranslator.Format) string {
+	switch strings.ToLower(strings.TrimSpace(format.String())) {
+	case "openai", "openai-chat", "chat-completions", "openai-response", "openai-responses", "responses", "openai-image", "openai-video":
+		return "openai"
+	case "codex":
+		return "openai"
+	case "claude", "anthropic":
+		return "claude"
+	case "gemini", "google", "vertex", "aistudio":
+		return "gemini"
+	case "antigravity":
+		return "antigravity"
+	default:
+		return ""
+	}
+}
+
+func providerProtocolFamily(provider string) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	switch {
+	case provider == "openai", provider == "openai-compatibility", strings.HasPrefix(provider, "openai-compatible-"):
+		return "openai"
+	case provider == "codex", provider == "xai", provider == "kimi":
+		return "openai"
+	case provider == "claude":
+		return "claude"
+	case provider == "gemini", provider == "vertex", provider == "aistudio":
+		return "gemini"
+	case provider == "antigravity":
+		return "antigravity"
+	default:
+		return ""
+	}
+}
+
+func shouldFallbackProtocolAffinityPick(err error) bool {
+	if err == nil {
+		return false
+	}
+	var modelCooldown *modelCooldownError
+	if errors.As(err, &modelCooldown) {
+		return true
+	}
+	var authErr *Error
+	if !errors.As(err, &authErr) || authErr == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(authErr.Code)) {
+	case "auth_not_found", "auth_unavailable", "provider_not_found":
+		return true
+	default:
+		return false
+	}
+}

--- a/sdk/cliproxy/auth/scheduler_test.go
+++ b/sdk/cliproxy/auth/scheduler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 )
 
 type schedulerTestExecutor struct{}
@@ -354,6 +355,136 @@ func TestManager_PickNextMixed_UsesWeightedProviderRotationBeforeCredentialRotat
 		if got.ID != wantIDs[index] {
 			t.Fatalf("pickNextMixed() #%d auth.ID = %q, want %q", index, got.ID, wantIDs[index])
 		}
+	}
+}
+
+func TestManagerPickNextMixedProtocolAffinityPrefersSourceProviderForSharedAlias(t *testing.T) {
+	t.Parallel()
+
+	modelAlias := "deepseek-v4-flahs"
+	openAIProvider := "openai-compatible-deepseek"
+	registerSchedulerModels(t, "claude", modelAlias, "claude-shared-alias")
+	registerSchedulerModels(t, openAIProvider, modelAlias, "openai-shared-alias")
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.executors["claude"] = schedulerTestExecutor{}
+	manager.executors[openAIProvider] = schedulerTestExecutor{}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "claude-shared-alias", Provider: "claude"}); errRegister != nil {
+		t.Fatalf("Register(claude-shared-alias) error = %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "openai-shared-alias", Provider: openAIProvider}); errRegister != nil {
+		t.Fatalf("Register(openai-shared-alias) error = %v", errRegister)
+	}
+
+	got, _, provider, errPick := manager.pickNextMixed(context.Background(), []string{"claude", openAIProvider}, modelAlias, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixed(openai) error = %v", errPick)
+	}
+	if provider != openAIProvider {
+		t.Fatalf("pickNextMixed(openai) provider = %q, want %q", provider, openAIProvider)
+	}
+	if got == nil || got.ID != "openai-shared-alias" {
+		t.Fatalf("pickNextMixed(openai) auth = %#v, want openai-shared-alias", got)
+	}
+
+	got, _, provider, errPick = manager.pickNextMixed(context.Background(), []string{"claude", openAIProvider}, modelAlias, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixed(claude) error = %v", errPick)
+	}
+	if provider != "claude" {
+		t.Fatalf("pickNextMixed(claude) provider = %q, want claude", provider)
+	}
+	if got == nil || got.ID != "claude-shared-alias" {
+		t.Fatalf("pickNextMixed(claude) auth = %#v, want claude-shared-alias", got)
+	}
+}
+
+func TestManagerPickNextMixedProtocolAffinityFallsBackWhenPreferredUnavailable(t *testing.T) {
+	t.Parallel()
+
+	modelAlias := "shared-fallback-alias"
+	openAIProvider := "openai-compatible-fallback"
+	registerSchedulerModels(t, "claude", modelAlias, "claude-fallback")
+	registerSchedulerModels(t, openAIProvider, modelAlias, "openai-fallback-disabled")
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.executors["claude"] = schedulerTestExecutor{}
+	manager.executors[openAIProvider] = schedulerTestExecutor{}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "claude-fallback", Provider: "claude"}); errRegister != nil {
+		t.Fatalf("Register(claude-fallback) error = %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "openai-fallback-disabled", Provider: openAIProvider, Disabled: true}); errRegister != nil {
+		t.Fatalf("Register(openai-fallback-disabled) error = %v", errRegister)
+	}
+
+	got, _, provider, errPick := manager.pickNextMixed(context.Background(), []string{"claude", openAIProvider}, modelAlias, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixed() error = %v", errPick)
+	}
+	if provider != "claude" {
+		t.Fatalf("pickNextMixed() provider = %q, want claude fallback", provider)
+	}
+	if got == nil || got.ID != "claude-fallback" {
+		t.Fatalf("pickNextMixed() auth = %#v, want claude-fallback", got)
+	}
+}
+
+func TestManagerPickNextMixedProtocolAffinityStrictRejectsCrossProtocolFallback(t *testing.T) {
+	t.Parallel()
+
+	modelAlias := "shared-strict-alias"
+	openAIProvider := "openai-compatible-strict"
+	registerSchedulerModels(t, "claude", modelAlias, "claude-strict")
+	registerSchedulerModels(t, openAIProvider, modelAlias, "openai-strict-disabled")
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{Routing: internalconfig.RoutingConfig{ProtocolAffinity: "strict"}})
+	manager.executors["claude"] = schedulerTestExecutor{}
+	manager.executors[openAIProvider] = schedulerTestExecutor{}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "claude-strict", Provider: "claude"}); errRegister != nil {
+		t.Fatalf("Register(claude-strict) error = %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "openai-strict-disabled", Provider: openAIProvider, Disabled: true}); errRegister != nil {
+		t.Fatalf("Register(openai-strict-disabled) error = %v", errRegister)
+	}
+
+	got, _, provider, errPick := manager.pickNextMixed(context.Background(), []string{"claude", openAIProvider}, modelAlias, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}, nil)
+	if errPick == nil {
+		t.Fatalf("pickNextMixed() auth = %#v provider = %q, want strict protocol affinity error", got, provider)
+	}
+	if provider != "" {
+		t.Fatalf("pickNextMixed() provider = %q, want empty on strict failure", provider)
+	}
+}
+
+func TestManagerPickNextMixedProtocolAffinityOffKeepsLegacyProviderRotation(t *testing.T) {
+	t.Parallel()
+
+	modelAlias := "shared-off-alias"
+	openAIProvider := "openai-compatible-off"
+	registerSchedulerModels(t, "claude", modelAlias, "claude-off")
+	registerSchedulerModels(t, openAIProvider, modelAlias, "openai-off")
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{Routing: internalconfig.RoutingConfig{ProtocolAffinity: "off"}})
+	manager.executors["claude"] = schedulerTestExecutor{}
+	manager.executors[openAIProvider] = schedulerTestExecutor{}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "claude-off", Provider: "claude"}); errRegister != nil {
+		t.Fatalf("Register(claude-off) error = %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "openai-off", Provider: openAIProvider}); errRegister != nil {
+		t.Fatalf("Register(openai-off) error = %v", errRegister)
+	}
+
+	got, _, provider, errPick := manager.pickNextMixed(context.Background(), []string{"claude", openAIProvider}, modelAlias, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixed() error = %v", errPick)
+	}
+	if provider != "claude" {
+		t.Fatalf("pickNextMixed() provider = %q, want legacy first provider claude", provider)
+	}
+	if got == nil || got.ID != "claude-off" {
+		t.Fatalf("pickNextMixed() auth = %#v, want claude-off", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/scheduler_test.go
+++ b/sdk/cliproxy/auth/scheduler_test.go
@@ -399,6 +399,77 @@ func TestManagerPickNextMixedProtocolAffinityPrefersSourceProviderForSharedAlias
 	}
 }
 
+func TestManagerPickNextMixedProtocolAffinitySplitsOpenAIChatAndResponses(t *testing.T) {
+	t.Parallel()
+
+	modelAlias := "split-openai-protocol-alias"
+	openAIProvider := "openai-compatible-split"
+	registerSchedulerModels(t, "codex", modelAlias, "codex-split")
+	registerSchedulerModels(t, openAIProvider, modelAlias, "openai-split")
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.executors["codex"] = schedulerTestExecutor{}
+	manager.executors[openAIProvider] = schedulerTestExecutor{}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "codex-split", Provider: "codex"}); errRegister != nil {
+		t.Fatalf("Register(codex-split) error = %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "openai-split", Provider: openAIProvider}); errRegister != nil {
+		t.Fatalf("Register(openai-split) error = %v", errRegister)
+	}
+
+	got, _, provider, errPick := manager.pickNextMixed(context.Background(), []string{openAIProvider, "codex"}, modelAlias, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixed(openai-response) error = %v", errPick)
+	}
+	if provider != "codex" {
+		t.Fatalf("pickNextMixed(openai-response) provider = %q, want codex", provider)
+	}
+	if got == nil || got.ID != "codex-split" {
+		t.Fatalf("pickNextMixed(openai-response) auth = %#v, want codex-split", got)
+	}
+
+	got, _, provider, errPick = manager.pickNextMixed(context.Background(), []string{"codex", openAIProvider}, modelAlias, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixed(openai-chat) error = %v", errPick)
+	}
+	if provider != openAIProvider {
+		t.Fatalf("pickNextMixed(openai-chat) provider = %q, want %q", provider, openAIProvider)
+	}
+	if got == nil || got.ID != "openai-split" {
+		t.Fatalf("pickNextMixed(openai-chat) auth = %#v, want openai-split", got)
+	}
+}
+
+func TestManagerPickNextMixedProtocolAffinityResponsesFallsBackToOpenAIChatBeforeClaude(t *testing.T) {
+	t.Parallel()
+
+	modelAlias := "responses-chat-fallback-alias"
+	openAIProvider := "openai-compatible-response-fallback"
+	registerSchedulerModels(t, "claude", modelAlias, "claude-response-fallback")
+	registerSchedulerModels(t, openAIProvider, modelAlias, "openai-response-fallback")
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.executors["claude"] = schedulerTestExecutor{}
+	manager.executors[openAIProvider] = schedulerTestExecutor{}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "claude-response-fallback", Provider: "claude"}); errRegister != nil {
+		t.Fatalf("Register(claude-response-fallback) error = %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "openai-response-fallback", Provider: openAIProvider}); errRegister != nil {
+		t.Fatalf("Register(openai-response-fallback) error = %v", errRegister)
+	}
+
+	got, _, provider, errPick := manager.pickNextMixed(context.Background(), []string{"claude", openAIProvider}, modelAlias, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}, nil)
+	if errPick != nil {
+		t.Fatalf("pickNextMixed(openai-response) error = %v", errPick)
+	}
+	if provider != openAIProvider {
+		t.Fatalf("pickNextMixed(openai-response) provider = %q, want %q", provider, openAIProvider)
+	}
+	if got == nil || got.ID != "openai-response-fallback" {
+		t.Fatalf("pickNextMixed(openai-response) auth = %#v, want openai-response-fallback", got)
+	}
+}
+
 func TestManagerPickNextMixedProtocolAffinityFallsBackWhenPreferredUnavailable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
一个模型在存在不同协议上游（例如同时用openai和anthropic接入deepseek-v4-flash），会根据请求类型决定优先使用哪个上游。

请求分为多个协议族
上游 provider key | 协议族
-- | --
openai, openai-compatibility, openai-compatible-* | openai
codex, xai, kimi | codex
claude | claude
gemini, vertex, aistudio | gemini
antigravity | antigravity

对外入口 SourceFormat | 协议族
-- | --
openai, chat-completions, openai-response, responses, openai-image, openai-video | openai
codex | codex
claude, anthropic | claude
gemini, google, vertex, aistudio | gemini
antigravity | antigravity

同协议族优先使用，失败后会走翻译，openai和codex会优先互相翻译，仍然不成功才会去找anthropic。

功能开关：
```
routing:
  protocol-affinity: "prefer"
```
可选值：
- prefer：默认。同协议/同子协议优先，找不到或不可用再 fallback。
- strict：严格同协议/同子协议，不跨协议 fallback。
- off：关闭这个逻辑，回到原来的 provider 轮询/调度行为。
- none、disabled、false 也等同于 off。