### PR TITLE
feat: add localized plugin metadata and resource menus

### DIFF
--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -16,6 +16,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/htmlsanitize"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/plugini18n"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -125,6 +126,7 @@ type sourcedPlugin struct {
 }
 
 func (h *Handler) ListPluginStore(c *gin.Context) {
+	locales := plugini18n.PreferredLocales(c.Request.Header, c.Request.URL.Query())
 	pluginsEnabled, pluginsDir, proxyURL, sourceConfigs, storeAuth, configs, host := h.pluginStoreSnapshot()
 	sources, errSources := h.pluginStoreSources(sourceConfigs)
 	if errSources != nil {
@@ -152,6 +154,7 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 	entries := make([]pluginStoreListEntry, 0, len(plugins))
 	for index, item := range plugins {
 		plugin := item.plugin
+		display := localizedPluginStoreDisplay(plugin, locales...)
 		status := statuses[plugin.ID]
 		installedVersion := status.InstalledVersion
 		// Fall back to the registry version when the latest release is unknown.
@@ -165,9 +168,9 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 			SourceName:       htmlsanitize.String(item.source.Name),
 			SourceURL:        htmlsanitize.String(item.source.URL),
 			ID:               htmlsanitize.String(plugin.ID),
-			Name:             htmlsanitize.String(plugin.Name),
-			Description:      htmlsanitize.String(plugin.Description),
-			Author:           htmlsanitize.String(plugin.Author),
+			Name:             htmlsanitize.String(display.Name),
+			Description:      htmlsanitize.String(display.Description),
+			Author:           htmlsanitize.String(display.Author),
 			Version:          htmlsanitize.String(storeVersion),
 			Repository:       htmlsanitize.String(plugin.Repository),
 			InstallType:      htmlsanitize.String(pluginstore.PluginInstallType(plugin)),
@@ -175,9 +178,9 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 			AuthConfigured:   pluginAuthConfigured(item.source, plugin, storeAuth),
 			Platforms:        sanitizePluginStorePlatforms(pluginstore.PluginPlatforms(plugin)),
 			Logo:             htmlsanitize.String(plugin.Logo),
-			Homepage:         htmlsanitize.String(plugin.Homepage),
-			License:          htmlsanitize.String(plugin.License),
-			Tags:             htmlsanitize.Strings(plugin.Tags),
+			Homepage:         htmlsanitize.String(display.Homepage),
+			License:          htmlsanitize.String(display.License),
+			Tags:             htmlsanitize.Strings(display.Tags),
 			Installed:        status.Installed,
 			InstalledVersion: htmlsanitize.String(installedVersion),
 			Path:             htmlsanitize.String(status.Path),
@@ -196,6 +199,38 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 		SourceErrors:   sanitizePluginStoreSourceErrors(sourceErrors),
 		Plugins:        entries,
 	})
+}
+
+func localizedPluginStoreDisplay(plugin pluginstore.Plugin, locales ...string) pluginstore.PluginLocale {
+	display := pluginstore.PluginLocale{
+		Name:        plugin.Name,
+		Description: plugin.Description,
+		Author:      plugin.Author,
+		Homepage:    plugin.Homepage,
+		License:     plugin.License,
+		Tags:        append([]string(nil), plugin.Tags...),
+	}
+	if localized, ok := plugini18n.Lookup(plugin.Locales, locales...); ok {
+		if strings.TrimSpace(localized.Name) != "" {
+			display.Name = localized.Name
+		}
+		if strings.TrimSpace(localized.Description) != "" {
+			display.Description = localized.Description
+		}
+		if strings.TrimSpace(localized.Author) != "" {
+			display.Author = localized.Author
+		}
+		if strings.TrimSpace(localized.Homepage) != "" {
+			display.Homepage = localized.Homepage
+		}
+		if strings.TrimSpace(localized.License) != "" {
+			display.License = localized.License
+		}
+		if len(localized.Tags) > 0 {
+			display.Tags = append([]string(nil), localized.Tags...)
+		}
+	}
+	return display
 }
 
 func (h *Handler) InstallPluginFromStore(c *gin.Context) {

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -251,6 +251,65 @@ func TestListPluginStoreEscapesRegistryStrings(t *testing.T) {
 	}
 }
 
+func TestListPluginStoreUsesRequestedLocale(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		cfg: &config.Config{
+			Plugins: config.PluginsConfig{
+				Enabled: true,
+				Dir:     t.TempDir(),
+			},
+		},
+		configFilePath:         writeTestConfigFile(t),
+		pluginStoreRegistryURL: "https://registry.example/registry.json",
+		pluginStoreHTTPClient: fakePluginStoreHTTPClient{
+			"https://registry.example/registry.json": []byte(`{
+				"schema_version": 1,
+				"plugins": [{
+					"id": "sample-provider",
+					"name": "Sample Provider",
+					"description": "Adds sample provider support.",
+					"author": "author-name",
+					"repository": "https://github.com/author-name/cliproxy-sample-provider-plugin",
+					"tags": ["provider"],
+					"locales": {
+						"zh": {
+							"name": "示例插件",
+							"description": "增加示例提供商支持。",
+							"author": "作者",
+							"tags": ["工具"]
+						}
+					}
+				}]
+			}`),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/plugin-store", nil)
+	c.Request.Header.Set("Accept-Language", "fr, zh-CN;q=0.9")
+
+	h.ListPluginStore(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body pluginStoreListResponse
+	if errDecode := json.Unmarshal(rec.Body.Bytes(), &body); errDecode != nil {
+		t.Fatalf("Unmarshal() error = %v; body=%s", errDecode, rec.Body.String())
+	}
+	if len(body.Plugins) != 1 {
+		t.Fatalf("plugins len = %d, want 1", len(body.Plugins))
+	}
+	entry := body.Plugins[0]
+	if entry.Name != "示例插件" || entry.Description != "增加示例提供商支持。" || entry.Author != "作者" ||
+		len(entry.Tags) != 1 || entry.Tags[0] != "工具" {
+		t.Fatalf("store entry = %#v, want localized display fields", entry)
+	}
+}
+
 func TestListPluginStoreShowsLatestReleaseVersionAndCaches(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/management/plugins.go
+++ b/internal/api/handlers/management/plugins.go
@@ -14,6 +14,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/htmlsanitize"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/plugini18n"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	"gopkg.in/yaml.v3"
 )
@@ -57,6 +58,7 @@ type pluginConfigFieldInfo struct {
 
 type pluginMenuInfo struct {
 	Path        string `json:"path"`
+	LaunchURL   string `json:"launch_url,omitempty"`
 	Menu        string `json:"menu"`
 	Description string `json:"description"`
 }
@@ -70,6 +72,7 @@ func (h *Handler) ListPlugins(c *gin.Context) {
 		})
 		return
 	}
+	locales := plugini18n.PreferredLocales(c.Request.Header, c.Request.URL.Query())
 
 	h.mu.Lock()
 	pluginsEnabled := h.cfg.Plugins.Enabled
@@ -117,9 +120,9 @@ func (h *Handler) ListPlugins(c *gin.Context) {
 			entry.SupportsOAuth = info.SupportsOAuth
 			entry.OAuthProvider = htmlsanitize.String(info.OAuthProvider)
 			entry.Logo = htmlsanitize.String(info.Metadata.Logo)
-			entry.ConfigFields = pluginConfigFields(info.Metadata.ConfigFields)
-			entry.Menus = pluginMenus(info.Menus)
-			entry.Metadata = pluginMetadata(info.Metadata)
+			entry.ConfigFields = pluginConfigFields(info.Metadata.ConfigFields, locales...)
+			entry.Menus = pluginMenus(info.Menus, locales...)
+			entry.Metadata = pluginMetadata(info.Metadata, locales...)
 			entries[info.ID] = entry
 		}
 	}
@@ -442,39 +445,71 @@ func pluginFilePath(pluginsDir string, id string, desiredVersions ...map[string]
 	return "", nil
 }
 
-func pluginConfigFields(fields []pluginapi.ConfigField) []pluginConfigFieldInfo {
+func pluginConfigFields(fields []pluginapi.ConfigField, locales ...string) []pluginConfigFieldInfo {
 	out := make([]pluginConfigFieldInfo, 0, len(fields))
 	for _, field := range fields {
+		description := field.Description
+		if localized, ok := plugini18n.Lookup(field.Locales, locales...); ok && strings.TrimSpace(localized.Description) != "" {
+			description = localized.Description
+		}
 		out = append(out, pluginConfigFieldInfo{
 			Name:        htmlsanitize.String(field.Name),
 			Type:        htmlsanitize.String(string(field.Type)),
 			EnumValues:  htmlsanitize.Strings(field.EnumValues),
-			Description: htmlsanitize.String(field.Description),
+			Description: htmlsanitize.String(description),
 		})
 	}
 	return out
 }
 
-func pluginMenus(menus []pluginhost.RegisteredPluginMenu) []pluginMenuInfo {
+func pluginMenus(menus []pluginhost.RegisteredPluginMenu, locales ...string) []pluginMenuInfo {
 	out := make([]pluginMenuInfo, 0, len(menus))
 	for _, menu := range menus {
+		label := menu.Menu
+		description := menu.Description
+		launchLocale := ""
+		if len(locales) > 0 {
+			launchLocale = locales[0]
+		}
+		if localized, matchedLocale, ok := plugini18n.LookupMatch(menu.Locales, locales...); ok {
+			if strings.TrimSpace(matchedLocale) != "" {
+				launchLocale = matchedLocale
+			}
+			if strings.TrimSpace(localized.Menu) != "" {
+				label = localized.Menu
+			}
+			if strings.TrimSpace(localized.Description) != "" {
+				description = localized.Description
+			}
+		}
 		out = append(out, pluginMenuInfo{
 			Path:        htmlsanitize.String(menu.Path),
-			Menu:        htmlsanitize.String(menu.Menu),
-			Description: htmlsanitize.String(menu.Description),
+			LaunchURL:   plugini18n.AppendLocale(menu.Path, launchLocale),
+			Menu:        htmlsanitize.String(label),
+			Description: htmlsanitize.String(description),
 		})
 	}
 	return out
 }
 
-func pluginMetadata(meta pluginapi.Metadata) *pluginMetadataInfo {
+func pluginMetadata(meta pluginapi.Metadata, locales ...string) *pluginMetadataInfo {
+	name := meta.Name
+	author := meta.Author
+	if localized, ok := plugini18n.Lookup(meta.Locales, locales...); ok {
+		if strings.TrimSpace(localized.Name) != "" {
+			name = localized.Name
+		}
+		if strings.TrimSpace(localized.Author) != "" {
+			author = localized.Author
+		}
+	}
 	return &pluginMetadataInfo{
-		Name:             htmlsanitize.String(meta.Name),
+		Name:             htmlsanitize.String(name),
 		Version:          htmlsanitize.String(meta.Version),
-		Author:           htmlsanitize.String(meta.Author),
+		Author:           htmlsanitize.String(author),
 		GitHubRepository: htmlsanitize.String(meta.GitHubRepository),
 		Logo:             htmlsanitize.String(meta.Logo),
-		ConfigFields:     pluginConfigFields(meta.ConfigFields),
+		ConfigFields:     pluginConfigFields(meta.ConfigFields, locales...),
 	}
 }
 

--- a/internal/api/handlers/management/plugins_test.go
+++ b/internal/api/handlers/management/plugins_test.go
@@ -691,7 +691,7 @@ func TestPluginDisplayFieldsEscapeHTML(t *testing.T) {
 		Type:        pluginapi.ConfigFieldTypeEnum,
 		EnumValues:  []string{`<fast>`, `safe & sound`},
 		Description: `"quoted" 'single' <b>mode</b>`,
-	}})
+	}}, "")
 	if len(fields) != 1 {
 		t.Fatalf("fields len = %d, want 1", len(fields))
 	}
@@ -706,17 +706,20 @@ func TestPluginDisplayFieldsEscapeHTML(t *testing.T) {
 	}
 
 	menus := pluginMenus([]pluginhost.RegisteredPluginMenu{{
-		Path:        `/v0/resource/plugins/sample/<status>`,
+		Path:        `/v0/resource/plugins/sample/<status>?bar=1&baz=2`,
 		Menu:        `<b>Status</b>`,
 		Description: `Shows <script>alert(1)</script>.`,
-	}})
+	}}, "")
 	if len(menus) != 1 {
 		t.Fatalf("menus len = %d, want 1", len(menus))
 	}
-	if menus[0].Path != html.EscapeString(`/v0/resource/plugins/sample/<status>`) ||
+	if menus[0].Path != html.EscapeString(`/v0/resource/plugins/sample/<status>?bar=1&baz=2`) ||
 		menus[0].Menu != html.EscapeString(`<b>Status</b>`) ||
 		menus[0].Description != html.EscapeString(`Shows <script>alert(1)</script>.`) {
 		t.Fatalf("menu = %#v, want escaped strings", menus[0])
+	}
+	if menus[0].LaunchURL != `/v0/resource/plugins/sample/<status>?bar=1&baz=2` {
+		t.Fatalf("LaunchURL = %q, want raw navigable URL", menus[0].LaunchURL)
 	}
 
 	meta := pluginMetadata(pluginapi.Metadata{
@@ -725,13 +728,57 @@ func TestPluginDisplayFieldsEscapeHTML(t *testing.T) {
 		Author:           `"attacker"`,
 		GitHubRepository: `https://example.com/repo?x=<script>`,
 		Logo:             `<svg onload=alert(1)>`,
-	})
+	}, "")
 	if meta.Name != html.EscapeString(`<script>alert(1)</script>`) ||
 		meta.Version != html.EscapeString(`1.0.0&evil=true`) ||
 		meta.Author != html.EscapeString(`"attacker"`) ||
 		meta.GitHubRepository != html.EscapeString(`https://example.com/repo?x=<script>`) ||
 		meta.Logo != html.EscapeString(`<svg onload=alert(1)>`) {
 		t.Fatalf("metadata = %#v, want escaped strings", meta)
+	}
+}
+
+func TestPluginDisplayFieldsUseRequestedLocale(t *testing.T) {
+	t.Parallel()
+
+	fields := pluginConfigFields([]pluginapi.ConfigField{{
+		Name:        "mode",
+		Type:        pluginapi.ConfigFieldTypeEnum,
+		EnumValues:  []string{"fast", "safe"},
+		Description: "Execution mode.",
+		Locales: map[string]pluginapi.ConfigFieldLocale{
+			"zh-CN": {Description: "执行模式。"},
+		},
+	}}, "fr", "zh-CN")
+	if fields[0].Description != "执行模式。" || fields[0].EnumValues[0] != "fast" {
+		t.Fatalf("fields = %#v, want localized description and stable enum values", fields)
+	}
+
+	menus := pluginMenus([]pluginhost.RegisteredPluginMenu{{
+		Path:        `/v0/resource/plugins/sample/status?mode=full&tab=<status>`,
+		Menu:        `Status`,
+		Description: `Shows plugin status.`,
+		Locales: map[string]pluginapi.RouteLocale{
+			"zh": {Menu: "状态", Description: "显示插件状态。"},
+		},
+	}}, "fr", "zh-CN")
+	if len(menus) != 1 {
+		t.Fatalf("menus len = %d, want 1", len(menus))
+	}
+	if menus[0].Menu != "状态" || menus[0].Description != "显示插件状态。" ||
+		menus[0].LaunchURL != "/v0/resource/plugins/sample/status?locale=zh-cn&mode=full&tab=%3Cstatus%3E" {
+		t.Fatalf("menu = %#v, want localized menu with locale launch URL", menus[0])
+	}
+
+	meta := pluginMetadata(pluginapi.Metadata{
+		Name:   "Sample Provider",
+		Author: "author-name",
+		Locales: map[string]pluginapi.MetadataLocale{
+			"zh-CN": {Name: "示例插件", Author: "作者"},
+		},
+	}, "fr", "zh-CN")
+	if meta.Name != "示例插件" || meta.Author != "作者" {
+		t.Fatalf("metadata = %#v, want localized name and author", meta)
 	}
 }
 

--- a/internal/pluginhost/management.go
+++ b/internal/pluginhost/management.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/htmlsanitize"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/plugini18n"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	log "github.com/sirupsen/logrus"
 )
@@ -159,21 +160,23 @@ func resourceRouteFromManagementRoute(item pluginapi.ManagementRoute) pluginapi.
 		Path:        item.Path,
 		Menu:        item.Menu,
 		Description: item.Description,
+		Locales:     cloneRouteLocales(item.Locales),
 		Handler:     item.Handler,
 	}
 }
 
 func registerResourceRoute(routes map[string]resourceRouteRecord, record capabilityRecord, item pluginapi.ResourceRoute) bool {
-	path, okRoute := normalizeResourceRoute(record.id, item)
+	dispatchPath, launchPath, okRoute := normalizeResourceRoute(record.id, item)
 	if !okRoute {
 		return false
 	}
-	key := managementRouteKey(http.MethodGet, path)
+	key := managementRouteKey(http.MethodGet, dispatchPath)
 	if _, exists := routes[key]; exists {
 		log.Warnf("pluginhost: plugin %s resource route %s conflicts with a higher-priority plugin and was skipped", record.id, key)
 		return true
 	}
-	item.Path = path
+	item.Path = launchPath
+	item.Locales = cloneRouteLocales(item.Locales)
 	routes[key] = resourceRouteRecord{
 		pluginID: record.id,
 		path:     record.path,
@@ -183,21 +186,25 @@ func registerResourceRoute(routes map[string]resourceRouteRecord, record capabil
 	return true
 }
 
-func normalizeResourceRoute(pluginID string, item pluginapi.ResourceRoute) (string, bool) {
+func normalizeResourceRoute(pluginID string, item pluginapi.ResourceRoute) (string, string, bool) {
 	if item.Handler == nil {
-		return "", false
+		return "", "", false
 	}
 	pluginID = strings.TrimSpace(pluginID)
 	if pluginID == "" {
-		return "", false
+		return "", "", false
 	}
 
 	path := strings.TrimSpace(item.Path)
 	if path == "" {
-		return "", false
+		return "", "", false
 	}
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
+	}
+	path, rawQuery, okRoute := splitResourceRoutePath(path)
+	if !okRoute {
+		return "", "", false
 	}
 
 	pluginBasePath := resourcePluginBasePath + "/" + pluginID
@@ -208,17 +215,36 @@ func normalizeResourceRoute(pluginID string, item pluginapi.ResourceRoute) (stri
 	}
 	path = strings.TrimRight(path, "/")
 	if path == "" {
-		return "", false
+		return "", "", false
 	}
 
-	fullPath := pluginBasePath + path
-	if !strings.HasPrefix(fullPath, pluginBasePath+"/") {
-		return "", false
+	dispatchPath := pluginBasePath + path
+	if !strings.HasPrefix(dispatchPath, pluginBasePath+"/") {
+		return "", "", false
 	}
-	if strings.ContainsAny(fullPath, " \t\r\n") || strings.Contains(fullPath, ":") || strings.Contains(fullPath, "*") || strings.Contains(fullPath, "..") {
-		return "", false
+	if strings.ContainsAny(dispatchPath, " \t\r\n") || strings.Contains(dispatchPath, ":") || strings.Contains(dispatchPath, "*") || strings.Contains(dispatchPath, "..") {
+		return "", "", false
 	}
-	return fullPath, true
+	launchPath := dispatchPath
+	if rawQuery != "" {
+		launchPath += "?" + rawQuery
+	}
+	return dispatchPath, launchPath, true
+}
+
+func splitResourceRoutePath(path string) (string, string, bool) {
+	if strings.Contains(path, "#") {
+		return "", "", false
+	}
+	queryIndex := strings.Index(path, "?")
+	if queryIndex < 0 {
+		return path, "", true
+	}
+	rawQuery := path[queryIndex+1:]
+	if strings.ContainsAny(rawQuery, " \t\r\n") {
+		return "", "", false
+	}
+	return path[:queryIndex], rawQuery, true
 }
 
 func managementRouteKey(method, path string) string {
@@ -252,11 +278,14 @@ func (h *Host) ServeManagementHTTP(w http.ResponseWriter, r *http.Request) bool 
 	}
 	r.Body = io.NopCloser(bytes.NewReader(body))
 
+	headers := cloneHeader(r.Header)
+	query := cloneValues(r.URL.Query())
+	headers = normalizePluginRequestLocale(headers, query)
 	resp, errHandle := h.callManagementHandler(r.Context(), record, pluginapi.ManagementRequest{
 		Method:  r.Method,
 		Path:    r.URL.Path,
-		Headers: cloneHeader(r.Header),
-		Query:   cloneValues(r.URL.Query()),
+		Headers: headers,
+		Query:   query,
 		Body:    bytes.Clone(body),
 	})
 	if errHandle != nil {
@@ -298,11 +327,14 @@ func (h *Host) ServeResourceHTTP(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 
+	headers := cloneHeader(r.Header)
+	query := cloneValues(r.URL.Query())
+	headers = normalizePluginRequestLocale(headers, query)
 	resp, errHandle := h.callResourceHandler(r.Context(), record, pluginapi.ManagementRequest{
 		Method:  http.MethodGet,
 		Path:    r.URL.Path,
-		Headers: cloneHeader(r.Header),
-		Query:   cloneValues(r.URL.Query()),
+		Headers: headers,
+		Query:   query,
 	})
 	if errHandle != nil {
 		log.Warnf("pluginhost: resource handler %s failed: %v", record.pluginID, errHandle)
@@ -324,6 +356,18 @@ func (h *Host) ServeResourceHTTP(w http.ResponseWriter, r *http.Request) bool {
 		log.Warnf("pluginhost: failed to write plugin resource response: %v", errWrite)
 	}
 	return true
+}
+
+func normalizePluginRequestLocale(headers http.Header, query map[string][]string) http.Header {
+	if headers == nil {
+		headers = http.Header{}
+	}
+	locale := plugini18n.LocaleFromRequest(headers, query)
+	if locale == "" {
+		return headers
+	}
+	headers.Set(plugini18n.LocaleHeader, locale)
+	return headers
 }
 
 func (h *Host) callManagementHandler(ctx context.Context, record managementRouteRecord, req pluginapi.ManagementRequest) (resp pluginapi.ManagementResponse, err error) {

--- a/internal/pluginhost/management_test.go
+++ b/internal/pluginhost/management_test.go
@@ -6,6 +6,7 @@ import (
 	"html"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
@@ -122,6 +123,110 @@ func TestServeManagementHTMLEscapesJSONResponseStrings(t *testing.T) {
 	}
 }
 
+func TestServeManagementHTTPForwardsResolvedLocale(t *testing.T) {
+	host := newHostWithRecords(capabilityRecord{
+		id: "locale",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			ManagementAPI: &managementPluginDouble{routes: []pluginapi.ManagementRoute{{
+				Method: http.MethodPost,
+				Path:   "/plugins/locale/run",
+				Handler: managementHandlerFunc(func(_ context.Context, req pluginapi.ManagementRequest) (pluginapi.ManagementResponse, error) {
+					if req.Path != "/v0/management/plugins/locale/run" {
+						t.Fatalf("management request path = %q, want normalized path", req.Path)
+					}
+					if locale := req.Headers.Get("X-Locale"); locale != "zh-CN" {
+						t.Fatalf("management request X-Locale = %q, want zh-CN", locale)
+					}
+					if mode := req.Query.Get("mode"); mode != "full" {
+						t.Fatalf("management request mode query = %q, want full", mode)
+					}
+					req.Headers.Set("X-Original", "mutated")
+					req.Query.Set("mutated", "1")
+					return pluginapi.ManagementResponse{StatusCode: http.StatusCreated, Body: []byte("created")}, nil
+				}),
+			}}},
+		}},
+	})
+	host.RegisterManagementRoutes(context.Background(), nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/plugins/locale/run?mode=full", strings.NewReader(`{"ok":true}`))
+	req.Header.Set("Accept-Language", "zh-CN, en;q=0.8")
+	req.Header.Set("X-Original", "source")
+	rec := httptest.NewRecorder()
+	if !host.ServeManagementHTTP(rec, req) {
+		t.Fatal("ServeManagementHTTP() = false, want true")
+	}
+	if rec.Code != http.StatusCreated || rec.Body.String() != "created" {
+		t.Fatalf("response = %d %q, want 201 created", rec.Code, rec.Body.String())
+	}
+	if got := req.Header.Get("X-Locale"); got != "" {
+		t.Fatalf("original request X-Locale = %q, want unchanged empty", got)
+	}
+	if got := req.Header.Get("X-Original"); got != "source" {
+		t.Fatalf("original request X-Original = %q, want source", got)
+	}
+	if got := req.URL.Query().Get("mutated"); got != "" {
+		t.Fatalf("original request mutated query = %q, want unchanged empty", got)
+	}
+}
+
+func TestServeManagementHTTPForwardsQueryLocaleWithoutHeaders(t *testing.T) {
+	host := newHostWithRecords(capabilityRecord{
+		id: "query-locale",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			ManagementAPI: &managementPluginDouble{routes: []pluginapi.ManagementRoute{{
+				Method: http.MethodGet,
+				Path:   "/plugins/query-locale/status",
+				Handler: managementHandlerFunc(func(_ context.Context, req pluginapi.ManagementRequest) (pluginapi.ManagementResponse, error) {
+					if locale := req.Headers.Get("X-Locale"); locale != "zh-CN" {
+						t.Fatalf("management request X-Locale = %q, want zh-CN", locale)
+					}
+					return pluginapi.ManagementResponse{Body: []byte("ok")}, nil
+				}),
+			}}},
+		}},
+	})
+	host.RegisterManagementRoutes(context.Background(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/plugins/query-locale/status?locale=zh-CN", nil)
+	rec := httptest.NewRecorder()
+	if !host.ServeManagementHTTP(rec, req) {
+		t.Fatal("ServeManagementHTTP() = false, want true")
+	}
+	if rec.Code != http.StatusOK || rec.Body.String() != "ok" {
+		t.Fatalf("response = %d %q, want 200 ok", rec.Code, rec.Body.String())
+	}
+}
+
+func TestServeManagementHTTPProvidesWritableHeadersWithoutLocale(t *testing.T) {
+	host := newHostWithRecords(capabilityRecord{
+		id: "empty-headers",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			ManagementAPI: &managementPluginDouble{routes: []pluginapi.ManagementRoute{{
+				Method: http.MethodGet,
+				Path:   "/plugins/empty-headers/status",
+				Handler: managementHandlerFunc(func(_ context.Context, req pluginapi.ManagementRequest) (pluginapi.ManagementResponse, error) {
+					req.Headers.Set("X-Test", "ok")
+					if req.Headers.Get("X-Test") != "ok" {
+						t.Fatalf("management request headers = %#v, want writable header", req.Headers)
+					}
+					return pluginapi.ManagementResponse{Body: []byte("ok")}, nil
+				}),
+			}}},
+		}},
+	})
+	host.RegisterManagementRoutes(context.Background(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/plugins/empty-headers/status", nil)
+	rec := httptest.NewRecorder()
+	if !host.ServeManagementHTTP(rec, req) {
+		t.Fatal("ServeManagementHTTP() = false, want true")
+	}
+	if rec.Code != http.StatusOK || rec.Body.String() != "ok" {
+		t.Fatalf("response = %d %q, want 200 ok", rec.Code, rec.Body.String())
+	}
+}
+
 func TestManagementHandlerPanicFusesPlugin(t *testing.T) {
 	host := newHostWithRecords(capabilityRecord{
 		id: "panic",
@@ -162,6 +267,9 @@ func TestServeResourceHTTPDispatchesPluginResource(t *testing.T) {
 					if req.Path != "/v0/resource/plugins/resource/status" {
 						t.Fatalf("resource request path = %q, want normalized resource path", req.Path)
 					}
+					if locale := req.Headers.Get("X-Locale"); locale != "zh-CN" {
+						t.Fatalf("resource request X-Locale = %q, want zh-CN", locale)
+					}
 					return pluginapi.ManagementResponse{
 						Headers: http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
 						Body:    []byte("<!doctype html><title>resource</title>"),
@@ -172,7 +280,7 @@ func TestServeResourceHTTPDispatchesPluginResource(t *testing.T) {
 	})
 	host.RegisterManagementRoutes(context.Background(), nil)
 
-	req := httptest.NewRequest(http.MethodGet, "/v0/resource/plugins/resource/status", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v0/resource/plugins/resource/status?locale=zh-CN", nil)
 	rec := httptest.NewRecorder()
 	if !host.ServeResourceHTTP(rec, req) {
 		t.Fatal("ServeResourceHTTP() = false, want true")
@@ -182,6 +290,77 @@ func TestServeResourceHTTPDispatchesPluginResource(t *testing.T) {
 	}
 	if got := rec.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
 		t.Fatalf("Content-Type = %q, want text/html; charset=utf-8", got)
+	}
+}
+
+func TestServeResourceHTTPDispatchesPluginResourceWithDefaultQuery(t *testing.T) {
+	host := newHostWithRecords(capabilityRecord{
+		id: "resource-query",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			ManagementAPI: &managementPluginDouble{resources: []pluginapi.ResourceRoute{{
+				Path:        "/status?mode=full",
+				Menu:        "Status",
+				Description: "Shows plugin status.",
+				Handler: managementHandlerFunc(func(_ context.Context, req pluginapi.ManagementRequest) (pluginapi.ManagementResponse, error) {
+					if req.Path != "/v0/resource/plugins/resource-query/status" {
+						t.Fatalf("resource request path = %q, want normalized resource path", req.Path)
+					}
+					if mode := req.Query.Get("mode"); mode != "full" {
+						t.Fatalf("resource request mode query = %q, want full", mode)
+					}
+					if locale := req.Headers.Get("X-Locale"); locale != "zh-CN" {
+						t.Fatalf("resource request X-Locale = %q, want zh-CN", locale)
+					}
+					return pluginapi.ManagementResponse{Body: []byte("ok")}, nil
+				}),
+			}}},
+		}},
+	})
+	host.RegisterManagementRoutes(context.Background(), nil)
+
+	plugins := host.RegisteredPlugins()
+	if len(plugins) != 1 || len(plugins[0].Menus) != 1 {
+		t.Fatalf("RegisteredPlugins() = %#v, want one plugin with one menu", plugins)
+	}
+	if got := plugins[0].Menus[0].Path; got != "/v0/resource/plugins/resource-query/status?mode=full" {
+		t.Fatalf("menu path = %q, want launch path with default query", got)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/resource/plugins/resource-query/status?mode=full&locale=zh-CN", nil)
+	rec := httptest.NewRecorder()
+	if !host.ServeResourceHTTP(rec, req) {
+		t.Fatal("ServeResourceHTTP() = false, want true")
+	}
+	if rec.Code != http.StatusOK || rec.Body.String() != "ok" {
+		t.Fatalf("response = %d %q, want 200 ok", rec.Code, rec.Body.String())
+	}
+}
+
+func TestServeResourceHTTPForwardsAcceptLanguageLocale(t *testing.T) {
+	host := newHostWithRecords(capabilityRecord{
+		id: "resource-accept-language",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			ManagementAPI: &managementPluginDouble{resources: []pluginapi.ResourceRoute{{
+				Path: "/status",
+				Handler: managementHandlerFunc(func(_ context.Context, req pluginapi.ManagementRequest) (pluginapi.ManagementResponse, error) {
+					if locale := req.Headers.Get("X-Locale"); locale != "zh-CN" {
+						t.Fatalf("resource request X-Locale = %q, want zh-CN", locale)
+					}
+					return pluginapi.ManagementResponse{Body: []byte("ok")}, nil
+				}),
+			}}},
+		}},
+	})
+	host.RegisterManagementRoutes(context.Background(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/resource/plugins/resource-accept-language/status", nil)
+	req.Header.Set("Accept-Language", "zh-CN, en;q=0.8")
+	rec := httptest.NewRecorder()
+	if !host.ServeResourceHTTP(rec, req) {
+		t.Fatal("ServeResourceHTTP() = false, want true")
+	}
+	if rec.Code != http.StatusOK || rec.Body.String() != "ok" {
+		t.Fatalf("response = %d %q, want 200 ok", rec.Code, rec.Body.String())
 	}
 }
 
@@ -257,6 +436,160 @@ func TestRegisteredPluginsIncludesResourceMenus(t *testing.T) {
 	menu := plugins[0].Menus[0]
 	if menu.Path != "/v0/resource/plugins/menu/status" || menu.Menu != "Status" || menu.Description != "Shows plugin status." {
 		t.Fatalf("menu = %#v, want normalized status menu", menu)
+	}
+}
+
+func TestRegisteredPluginsClonesLocalizedMetadataAndMenus(t *testing.T) {
+	plugin := &managementPluginDouble{
+		resources: []pluginapi.ResourceRoute{{
+			Path:        "/status",
+			Menu:        "Status",
+			Description: "Shows plugin status.",
+			Locales: map[string]pluginapi.RouteLocale{
+				"zh-CN": {Menu: "状态", Description: "显示插件状态。"},
+			},
+			Handler: managementHandlerFunc(func(context.Context, pluginapi.ManagementRequest) (pluginapi.ManagementResponse, error) {
+				return pluginapi.ManagementResponse{}, nil
+			}),
+		}},
+	}
+	host := newHostWithRecords(capabilityRecord{
+		id: "localized",
+		meta: pluginapi.Metadata{
+			Name:             "localized",
+			Version:          "1.0.0",
+			Author:           "test",
+			GitHubRepository: "https://github.com/router-for-me/CLIProxyAPI",
+			Locales: map[string]pluginapi.MetadataLocale{
+				"zh-CN": {Name: "本地化插件", Author: "作者"},
+			},
+			ConfigFields: []pluginapi.ConfigField{{
+				Name:        "mode",
+				Type:        pluginapi.ConfigFieldTypeEnum,
+				EnumValues:  []string{"safe", "fast"},
+				Description: "Execution mode.",
+				Locales: map[string]pluginapi.ConfigFieldLocale{
+					"zh-CN": {Description: "执行模式。"},
+				},
+			}},
+		},
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{ManagementAPI: plugin}},
+	})
+	host.RegisterManagementRoutes(context.Background(), nil)
+
+	plugins := host.RegisteredPlugins()
+	if len(plugins) != 1 || len(plugins[0].Menus) != 1 {
+		t.Fatalf("RegisteredPlugins() = %#v, want one plugin with one menu", plugins)
+	}
+	plugins[0].Metadata.Locales["zh-cn"] = pluginapi.MetadataLocale{Name: "mutated"}
+	plugins[0].Metadata.ConfigFields[0].EnumValues[0] = "mutated"
+	plugins[0].Metadata.ConfigFields[0].Locales["zh-cn"] = pluginapi.ConfigFieldLocale{Description: "mutated"}
+	plugins[0].Menus[0].Locales["zh-cn"] = pluginapi.RouteLocale{Menu: "mutated"}
+
+	again := host.RegisteredPlugins()
+	field := again[0].Metadata.ConfigFields[0]
+	if again[0].Metadata.Locales["zh-cn"].Name != "本地化插件" ||
+		field.EnumValues[0] != "safe" ||
+		field.Locales["zh-cn"].Description != "执行模式。" ||
+		again[0].Menus[0].Locales["zh-cn"].Menu != "状态" {
+		t.Fatalf("RegisteredPlugins() returned shared nested data: %#v", again[0])
+	}
+}
+
+func TestRegisteredPluginsNormalizesAndClonesLocaleKeys(t *testing.T) {
+	routeLocales := map[string]pluginapi.RouteLocale{
+		" zh_CN ": {Menu: "状态", Description: "显示插件状态。"},
+	}
+	metaLocales := map[string]pluginapi.MetadataLocale{
+		" zh_CN ": {Name: "本地化插件", Author: "作者"},
+	}
+	fieldLocales := map[string]pluginapi.ConfigFieldLocale{
+		" zh_CN ": {Description: "执行模式。"},
+	}
+	host := newHostWithRecords(capabilityRecord{
+		id: "normalized-locales",
+		meta: pluginapi.Metadata{
+			Name:             "normalized-locales",
+			Version:          "1.0.0",
+			Author:           "test",
+			GitHubRepository: "https://github.com/router-for-me/CLIProxyAPI",
+			Locales:          metaLocales,
+			ConfigFields: []pluginapi.ConfigField{{
+				Name:        "mode",
+				Description: "Execution mode.",
+				Locales:     fieldLocales,
+			}},
+		},
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			ManagementAPI: &managementPluginDouble{resources: []pluginapi.ResourceRoute{{
+				Path:    "/status",
+				Menu:    "Status",
+				Locales: routeLocales,
+				Handler: managementHandlerFunc(func(context.Context, pluginapi.ManagementRequest) (pluginapi.ManagementResponse, error) {
+					return pluginapi.ManagementResponse{}, nil
+				}),
+			}}},
+		}},
+	})
+	host.RegisterManagementRoutes(context.Background(), nil)
+	routeLocales[" zh_CN "] = pluginapi.RouteLocale{Menu: "mutated"}
+
+	plugins := host.RegisteredPlugins()
+	if len(plugins) != 1 || len(plugins[0].Menus) != 1 || len(plugins[0].Metadata.ConfigFields) != 1 {
+		t.Fatalf("RegisteredPlugins() = %#v, want one plugin/menu/field", plugins)
+	}
+	if plugins[0].Metadata.Locales["zh-cn"].Name != "本地化插件" ||
+		plugins[0].Metadata.ConfigFields[0].Locales["zh-cn"].Description != "执行模式。" ||
+		plugins[0].Menus[0].Locales["zh-cn"].Menu != "状态" {
+		t.Fatalf("RegisteredPlugins() locale data = %#v, want normalized cloned locale keys", plugins[0])
+	}
+}
+
+func TestRegisteredPluginsPreservesEmptyConfigFields(t *testing.T) {
+	emptyFields := []pluginapi.ConfigField{}
+	host := newHostWithRecords(capabilityRecord{
+		id: "empty-fields",
+		meta: pluginapi.Metadata{
+			Name:             "empty-fields",
+			Version:          "1.0.0",
+			Author:           "test",
+			GitHubRepository: "https://github.com/router-for-me/CLIProxyAPI",
+			ConfigFields:     emptyFields,
+		},
+	})
+
+	plugins := host.RegisteredPlugins()
+	if len(plugins) != 1 {
+		t.Fatalf("RegisteredPlugins() = %#v, want one plugin", plugins)
+	}
+	if plugins[0].Metadata.ConfigFields == nil || len(plugins[0].Metadata.ConfigFields) != 0 {
+		t.Fatalf("ConfigFields = %#v, want preserved empty slice", plugins[0].Metadata.ConfigFields)
+	}
+}
+
+func TestRegisteredPluginsClonesMetadataLocalesWithoutConfigFields(t *testing.T) {
+	host := newHostWithRecords(capabilityRecord{
+		id: "metadata-only",
+		meta: pluginapi.Metadata{
+			Name:             "metadata-only",
+			Version:          "1.0.0",
+			Author:           "test",
+			GitHubRepository: "https://github.com/router-for-me/CLIProxyAPI",
+			Locales: map[string]pluginapi.MetadataLocale{
+				"zh-CN": {Name: "仅元数据", Author: "作者"},
+			},
+		},
+	})
+
+	plugins := host.RegisteredPlugins()
+	if len(plugins) != 1 {
+		t.Fatalf("RegisteredPlugins() = %#v, want one plugin", plugins)
+	}
+	plugins[0].Metadata.Locales["zh-cn"] = pluginapi.MetadataLocale{Name: "mutated"}
+
+	again := host.RegisteredPlugins()
+	if again[0].Metadata.Locales["zh-cn"].Name != "仅元数据" {
+		t.Fatalf("RegisteredPlugins() metadata locales shared map: %#v", again[0].Metadata.Locales)
 	}
 }
 

--- a/internal/pluginhost/snapshot.go
+++ b/internal/pluginhost/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/plugini18n"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
 
@@ -36,6 +37,7 @@ type RegisteredPluginMenu struct {
 	Path        string
 	Menu        string
 	Description string
+	Locales     map[string]pluginapi.RouteLocale
 }
 
 func emptySnapshot() *Snapshot {
@@ -120,6 +122,7 @@ func (h *Host) registeredPluginMenus() map[string][]RegisteredPluginMenu {
 			Path:        strings.TrimSpace(record.route.Path),
 			Menu:        menu,
 			Description: strings.TrimSpace(record.route.Description),
+			Locales:     cloneRouteLocales(record.route.Locales),
 		})
 	}
 	for pluginID := range out {
@@ -140,21 +143,69 @@ func sortRecords(records []capabilityRecord) {
 }
 
 func clonePluginMetadata(meta pluginapi.Metadata) pluginapi.Metadata {
-	if len(meta.ConfigFields) == 0 {
-		return meta
-	}
+	meta.Locales = cloneMetadataLocales(meta.Locales)
 	meta.ConfigFields = cloneConfigFields(meta.ConfigFields)
 	return meta
 }
 
 func cloneConfigFields(fields []pluginapi.ConfigField) []pluginapi.ConfigField {
-	if len(fields) == 0 {
+	if fields == nil {
 		return nil
 	}
 	out := make([]pluginapi.ConfigField, len(fields))
 	copy(out, fields)
 	for index := range out {
 		out[index].EnumValues = append([]string(nil), fields[index].EnumValues...)
+		out[index].Locales = cloneConfigFieldLocales(fields[index].Locales)
 	}
 	return out
+}
+
+func cloneMetadataLocales(locales map[string]pluginapi.MetadataLocale) map[string]pluginapi.MetadataLocale {
+	return cloneLocaleMap(locales)
+}
+
+func cloneConfigFieldLocales(locales map[string]pluginapi.ConfigFieldLocale) map[string]pluginapi.ConfigFieldLocale {
+	return cloneLocaleMap(locales)
+}
+
+func cloneRouteLocales(locales map[string]pluginapi.RouteLocale) map[string]pluginapi.RouteLocale {
+	return cloneLocaleMap(locales)
+}
+
+func cloneLocaleMap[T any](locales map[string]T) map[string]T {
+	if len(locales) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(locales))
+	for locale := range locales {
+		keys = append(keys, locale)
+	}
+	sort.SliceStable(keys, func(i, j int) bool {
+		left := normalizedHostLocaleKey(keys[i])
+		right := normalizedHostLocaleKey(keys[j])
+		if left == right {
+			return keys[i] < keys[j]
+		}
+		return left < right
+	})
+	out := make(map[string]T, len(locales))
+	for _, rawLocale := range keys {
+		locale := normalizedHostLocaleKey(rawLocale)
+		if locale == "" {
+			continue
+		}
+		if _, exists := out[locale]; exists {
+			continue
+		}
+		out[locale] = locales[rawLocale]
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalizedHostLocaleKey(locale string) string {
+	return strings.ToLower(plugini18n.NormalizeLocale(locale))
 }

--- a/internal/plugini18n/locale.go
+++ b/internal/plugini18n/locale.go
@@ -176,8 +176,14 @@ func localeCandidates(locale string) []string {
 		return nil
 	}
 	out := []string{locale}
-	if index := strings.Index(locale, "-"); index > 0 {
-		out = append(out, locale[:index])
+	current := locale
+	for {
+		index := strings.LastIndex(current, "-")
+		if index <= 0 {
+			break
+		}
+		current = current[:index]
+		out = append(out, current)
 	}
 	return out
 }

--- a/internal/plugini18n/locale.go
+++ b/internal/plugini18n/locale.go
@@ -1,0 +1,187 @@
+package plugini18n
+
+import (
+	"math"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	LocaleHeader = "X-Locale"
+	LocaleQuery  = "locale"
+)
+
+type acceptLanguageEntry struct {
+	value string
+	q     float64
+	order int
+}
+
+func LocaleFromRequest(headers http.Header, query url.Values) string {
+	locales := PreferredLocales(headers, query)
+	if len(locales) == 0 {
+		return ""
+	}
+	return locales[0]
+}
+
+func PreferredLocales(headers http.Header, query url.Values) []string {
+	out := make([]string, 0, 4)
+	seen := map[string]struct{}{}
+	add := func(value string) {
+		value = NormalizeLocale(value)
+		if value == "" || value == "*" {
+			return
+		}
+		key := localeKey(value)
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+
+	if query != nil {
+		add(query.Get(LocaleQuery))
+	}
+	if headers != nil {
+		add(headers.Get(LocaleHeader))
+		for _, value := range parseAcceptLanguage(headers.Values("Accept-Language")) {
+			add(value)
+		}
+	}
+	return out
+}
+
+func NormalizeLocale(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = strings.ReplaceAll(value, "_", "-")
+	if strings.ContainsAny(value, " \t\r\n") {
+		return ""
+	}
+	return value
+}
+
+func Lookup[T any](values map[string]T, locales ...string) (T, bool) {
+	value, _, ok := LookupMatch(values, locales...)
+	return value, ok
+}
+
+func LookupMatch[T any](values map[string]T, locales ...string) (T, string, bool) {
+	var zero T
+	if len(values) == 0 {
+		return zero, "", false
+	}
+	normalized := make(map[string]T, len(values))
+	for key, value := range values {
+		key = localeKey(key)
+		if key == "" {
+			continue
+		}
+		normalized[key] = value
+	}
+	for _, locale := range locales {
+		requested := localeKey(locale)
+		for _, candidate := range localeCandidates(locale) {
+			if value, ok := normalized[candidate]; ok {
+				return value, requested, true
+			}
+		}
+	}
+	return zero, "", false
+}
+
+func SelectString(base string, values map[string]string, locales ...string) string {
+	if value, ok := Lookup(values, locales...); ok && strings.TrimSpace(value) != "" {
+		return value
+	}
+	return base
+}
+
+func AppendLocale(rawURL string, locale string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	locale = NormalizeLocale(locale)
+	if rawURL == "" || locale == "" {
+		return rawURL
+	}
+	parsed, errParse := url.Parse(rawURL)
+	if errParse != nil {
+		return rawURL
+	}
+	query := parsed.Query()
+	if strings.TrimSpace(query.Get(LocaleQuery)) == "" {
+		query.Set(LocaleQuery, locale)
+		parsed.RawQuery = query.Encode()
+	}
+	return parsed.String()
+}
+
+func parseAcceptLanguage(values []string) []string {
+	entries := make([]acceptLanguageEntry, 0)
+	order := 0
+	for _, header := range values {
+		for _, part := range strings.Split(header, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			locale, q := parseAcceptLanguagePart(part)
+			if locale == "" || q <= 0 {
+				continue
+			}
+			entries = append(entries, acceptLanguageEntry{value: locale, q: q, order: order})
+			order++
+		}
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].q == entries[j].q {
+			return entries[i].order < entries[j].order
+		}
+		return entries[i].q > entries[j].q
+	})
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, entry.value)
+	}
+	return out
+}
+
+func parseAcceptLanguagePart(value string) (string, float64) {
+	parts := strings.Split(value, ";")
+	locale := NormalizeLocale(parts[0])
+	q := 1.0
+	for _, part := range parts[1:] {
+		keyValue := strings.SplitN(strings.TrimSpace(part), "=", 2)
+		if len(keyValue) != 2 || strings.TrimSpace(keyValue[0]) != "q" {
+			continue
+		}
+		parsed, errParse := strconv.ParseFloat(strings.TrimSpace(keyValue[1]), 64)
+		if errParse != nil || math.IsNaN(parsed) || parsed < 0 || parsed > 1 {
+			return locale, 0
+		}
+		q = parsed
+	}
+	return locale, q
+}
+
+func localeCandidates(locale string) []string {
+	locale = localeKey(locale)
+	if locale == "" {
+		return nil
+	}
+	out := []string{locale}
+	if index := strings.Index(locale, "-"); index > 0 {
+		out = append(out, locale[:index])
+	}
+	return out
+}
+
+func localeKey(value string) string {
+	return strings.ToLower(NormalizeLocale(value))
+}

--- a/internal/plugini18n/locale_test.go
+++ b/internal/plugini18n/locale_test.go
@@ -74,6 +74,20 @@ func TestLookupMatchesExactCaseInsensitiveAndLanguageFallback(t *testing.T) {
 	}
 }
 
+func TestLookupFallsBackThroughIntermediateLocaleSubtags(t *testing.T) {
+	t.Parallel()
+
+	values := map[string]string{
+		"zh":      "Chinese",
+		"zh-Hant": "Traditional Chinese",
+	}
+
+	got, matchedLocale, ok := LookupMatch(values, "zh-Hant-HK")
+	if !ok || got != "Traditional Chinese" || matchedLocale != "zh-hant-hk" {
+		t.Fatalf("LookupMatch(zh-Hant-HK) = %q/%q/%v, want Traditional Chinese/zh-hant-hk/true", got, matchedLocale, ok)
+	}
+}
+
 func TestAppendLocalePreservesExistingQuery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/plugini18n/locale_test.go
+++ b/internal/plugini18n/locale_test.go
@@ -1,0 +1,88 @@
+package plugini18n
+
+import (
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestPreferredLocalesPrioritizesQueryHeaderAndAcceptLanguage(t *testing.T) {
+	t.Parallel()
+
+	headers := http.Header{}
+	headers.Set(LocaleHeader, "en")
+	headers.Set("Accept-Language", "zh-TW;q=0.8, ru;q=0.9")
+	query := url.Values{LocaleQuery: {"zh-CN"}}
+
+	got := PreferredLocales(headers, query)
+	want := []string{"zh-CN", "en", "ru", "zh-TW"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PreferredLocales() = %#v, want %#v", got, want)
+	}
+}
+
+func TestLocaleFromRequestUsesQueryHeaderAcceptLanguagePrecedence(t *testing.T) {
+	t.Parallel()
+
+	headers := http.Header{}
+	headers.Set(LocaleHeader, "ZH_cn")
+	headers.Set("Accept-Language", "en;q=0.9, zh-CN;q=0.8")
+	query := url.Values{LocaleQuery: {"en-US"}}
+
+	if got := LocaleFromRequest(headers, query); got != "en-US" {
+		t.Fatalf("LocaleFromRequest() = %q, want en-US", got)
+	}
+	got := PreferredLocales(headers, query)
+	want := []string{"en-US", "ZH-cn", "en"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PreferredLocales() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPreferredLocalesFiltersInvalidAcceptLanguageEntries(t *testing.T) {
+	t.Parallel()
+
+	headers := http.Header{}
+	headers.Add("Accept-Language", "*, , zh;q=0, en;q=abc, de;q=1.5, ja;q=-0.1, it;q=NaN, es;q=0.5, fr")
+
+	got := PreferredLocales(headers, nil)
+	want := []string{"fr", "es"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PreferredLocales() = %#v, want %#v", got, want)
+	}
+}
+
+func TestLookupMatchesExactCaseInsensitiveAndLanguageFallback(t *testing.T) {
+	t.Parallel()
+
+	values := map[string]string{
+		"en-US": "American English",
+		"zh":    "Chinese",
+	}
+	if got, ok := Lookup(values, "en-us"); !ok || got != "American English" {
+		t.Fatalf("Lookup(en-us) = %q/%v, want exact match", got, ok)
+	}
+	if got, ok := Lookup(values, "zh-CN"); !ok || got != "Chinese" {
+		t.Fatalf("Lookup(zh-CN) = %q/%v, want language fallback", got, ok)
+	}
+	if got, matchedLocale, ok := LookupMatch(values, "fr", "zh-CN"); !ok || got != "Chinese" || matchedLocale != "zh-cn" {
+		t.Fatalf("LookupMatch(fr, zh-CN) = %q/%q/%v, want Chinese/zh-cn/true", got, matchedLocale, ok)
+	}
+	if got, matchedLocale, ok := LookupMatch(values, "ZH_cn"); !ok || got != "Chinese" || matchedLocale != "zh-cn" {
+		t.Fatalf("LookupMatch(ZH_cn) = %q/%q/%v, want Chinese/zh-cn/true", got, matchedLocale, ok)
+	}
+}
+
+func TestAppendLocalePreservesExistingQuery(t *testing.T) {
+	t.Parallel()
+
+	got := AppendLocale("/v0/resource/plugins/demo/page?mode=full", "zh-CN")
+	want := "/v0/resource/plugins/demo/page?locale=zh-CN&mode=full"
+	if got != want {
+		t.Fatalf("AppendLocale() = %q, want %q", got, want)
+	}
+	if gotExisting := AppendLocale("/page?locale=en", "zh-CN"); gotExisting != "/page?locale=en" {
+		t.Fatalf("AppendLocale() existing locale = %q, want unchanged", gotExisting)
+	}
+}

--- a/internal/pluginstore/manifest.go
+++ b/internal/pluginstore/manifest.go
@@ -7,22 +7,23 @@ import (
 )
 
 type Manifest struct {
-	SchemaVersion int         `yaml:"schema-version,omitempty" json:"schema_version,omitempty"`
-	ID            string      `yaml:"id,omitempty" json:"id,omitempty"`
-	Name          string      `yaml:"name,omitempty" json:"name,omitempty"`
-	Description   string      `yaml:"description,omitempty" json:"description,omitempty"`
-	Author        string      `yaml:"author,omitempty" json:"author,omitempty"`
-	Version       string      `yaml:"version,omitempty" json:"version,omitempty"`
-	ReleaseTag    string      `yaml:"release-tag,omitempty" json:"release_tag,omitempty"`
-	Repository    string      `yaml:"repository,omitempty" json:"repository,omitempty"`
-	Logo          string      `yaml:"logo,omitempty" json:"logo,omitempty"`
-	Homepage      string      `yaml:"homepage,omitempty" json:"homepage,omitempty"`
-	License       string      `yaml:"license,omitempty" json:"license,omitempty"`
-	Tags          []string    `yaml:"tags,omitempty" json:"tags,omitempty"`
-	SourceID      string      `yaml:"source-id,omitempty" json:"source_id,omitempty"`
-	SourceName    string      `yaml:"source-name,omitempty" json:"source_name,omitempty"`
-	SourceURL     string      `yaml:"source-url,omitempty" json:"source_url,omitempty"`
-	Install       InstallPlan `yaml:"install,omitempty" json:"install,omitempty"`
+	SchemaVersion int                     `yaml:"schema-version,omitempty" json:"schema_version,omitempty"`
+	ID            string                  `yaml:"id,omitempty" json:"id,omitempty"`
+	Name          string                  `yaml:"name,omitempty" json:"name,omitempty"`
+	Description   string                  `yaml:"description,omitempty" json:"description,omitempty"`
+	Author        string                  `yaml:"author,omitempty" json:"author,omitempty"`
+	Version       string                  `yaml:"version,omitempty" json:"version,omitempty"`
+	ReleaseTag    string                  `yaml:"release-tag,omitempty" json:"release_tag,omitempty"`
+	Repository    string                  `yaml:"repository,omitempty" json:"repository,omitempty"`
+	Logo          string                  `yaml:"logo,omitempty" json:"logo,omitempty"`
+	Homepage      string                  `yaml:"homepage,omitempty" json:"homepage,omitempty"`
+	License       string                  `yaml:"license,omitempty" json:"license,omitempty"`
+	Tags          []string                `yaml:"tags,omitempty" json:"tags,omitempty"`
+	SourceID      string                  `yaml:"source-id,omitempty" json:"source_id,omitempty"`
+	SourceName    string                  `yaml:"source-name,omitempty" json:"source_name,omitempty"`
+	SourceURL     string                  `yaml:"source-url,omitempty" json:"source_url,omitempty"`
+	Install       InstallPlan             `yaml:"install,omitempty" json:"install,omitempty"`
+	Locales       map[string]PluginLocale `yaml:"locales,omitempty" json:"locales,omitempty"`
 }
 
 func ManifestFromRelease(source Source, plugin Plugin, release Release) (Manifest, error) {
@@ -52,6 +53,7 @@ func ManifestFromPlugin(source Source, plugin Plugin) (Manifest, error) {
 			SourceName:    strings.TrimSpace(source.Name),
 			SourceURL:     strings.TrimSpace(source.URL),
 			Install:       InstallPlan{Type: InstallTypeDirect},
+			Locales:       normalizeAndClonePluginLocales(plugin.Locales),
 		}, nil
 	case InstallTypeGitHubRelease:
 		return Manifest{}, fmt.Errorf("github-release manifest requires a resolved release")
@@ -72,6 +74,7 @@ func manifestFromPlugin(source Source, plugin Plugin, base Manifest) Manifest {
 	base.SourceID = strings.TrimSpace(source.ID)
 	base.SourceName = strings.TrimSpace(source.Name)
 	base.SourceURL = strings.TrimSpace(source.URL)
+	base.Locales = normalizeAndClonePluginLocales(plugin.Locales)
 	return base
 }
 
@@ -88,7 +91,12 @@ func (m Manifest) Plugin() Plugin {
 		License:     strings.TrimSpace(m.License),
 		Tags:        append([]string(nil), m.Tags...),
 		Install:     NormalizeInstallPlan(m.Install),
+		Locales:     normalizeAndClonePluginLocales(m.Locales),
 	}
+}
+
+func normalizeAndClonePluginLocales(locales map[string]PluginLocale) map[string]PluginLocale {
+	return normalizePluginLocales(locales)
 }
 
 func (m Manifest) InstallType() string {

--- a/internal/pluginstore/manifest_test.go
+++ b/internal/pluginstore/manifest_test.go
@@ -1,0 +1,42 @@
+package pluginstore
+
+import "testing"
+
+func TestManifestPluginNormalizesPluginLocales(t *testing.T) {
+	t.Parallel()
+
+	manifest := Manifest{
+		ID:          "sample-provider",
+		Name:        "Sample Provider",
+		Description: "Adds sample provider support.",
+		Author:      "author-name",
+		Version:     "0.1.0",
+		Repository:  "https://github.com/author-name/cliproxy-sample-provider-plugin",
+		Locales: map[string]PluginLocale{
+			" zh_CN ": {
+				Name:        " 示例插件 ",
+				Description: " 增加示例提供商支持。 ",
+				Author:      " 作者 ",
+				Homepage:    " https://example.com/zh ",
+				License:     " MIT ",
+				Tags:        []string{" 工具 "},
+			},
+		},
+	}
+
+	plugin := manifest.Plugin()
+	localized, ok := plugin.Locales["zh-cn"]
+	if !ok {
+		t.Fatalf("plugin locales = %#v, want zh-cn", plugin.Locales)
+	}
+	if localized.Name != "示例插件" || localized.Description != "增加示例提供商支持。" ||
+		localized.Author != "作者" || localized.Homepage != "https://example.com/zh" ||
+		localized.License != "MIT" || len(localized.Tags) != 1 || localized.Tags[0] != "工具" {
+		t.Fatalf("localized plugin = %#v, want trimmed locale fields", localized)
+	}
+
+	manifest.Locales[" zh_CN "].Tags[0] = "mutated"
+	if plugin.Locales["zh-cn"].Tags[0] != "工具" {
+		t.Fatalf("plugin locale tags shared backing array: %#v", plugin.Locales["zh-cn"].Tags)
+	}
+}

--- a/internal/pluginstore/registry.go
+++ b/internal/pluginstore/registry.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -37,24 +38,34 @@ type Registry struct {
 }
 
 type Plugin struct {
-	ID           string      `json:"id"`
-	Name         string      `json:"name"`
-	Description  string      `json:"description"`
-	Author       string      `json:"author"`
-	Version      string      `json:"version"`
-	Versions     []Version   `json:"versions,omitempty"`
-	Repository   string      `json:"repository,omitempty"`
-	Logo         string      `json:"logo,omitempty"`
-	Homepage     string      `json:"homepage,omitempty"`
-	License      string      `json:"license,omitempty"`
-	Tags         []string    `json:"tags,omitempty"`
-	Install      InstallPlan `json:"install,omitempty"`
-	AuthRequired bool        `json:"auth_required,omitempty"`
+	ID           string                  `json:"id"`
+	Name         string                  `json:"name"`
+	Description  string                  `json:"description"`
+	Author       string                  `json:"author"`
+	Version      string                  `json:"version"`
+	Versions     []Version               `json:"versions,omitempty"`
+	Repository   string                  `json:"repository,omitempty"`
+	Logo         string                  `json:"logo,omitempty"`
+	Homepage     string                  `json:"homepage,omitempty"`
+	License      string                  `json:"license,omitempty"`
+	Tags         []string                `json:"tags,omitempty"`
+	Install      InstallPlan             `json:"install,omitempty"`
+	AuthRequired bool                    `json:"auth_required,omitempty"`
+	Locales      map[string]PluginLocale `json:"locales,omitempty"`
 }
 
 type Version struct {
 	Version string      `json:"version"`
 	Install InstallPlan `json:"install,omitempty"`
+}
+
+type PluginLocale struct {
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Author      string   `json:"author,omitempty"`
+	Homepage    string   `json:"homepage,omitempty"`
+	License     string   `json:"license,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
 }
 
 type InstallPlan struct {
@@ -152,6 +163,7 @@ func normalizeRegistry(registry *Registry) {
 		plugin.Homepage = strings.TrimSpace(plugin.Homepage)
 		plugin.License = strings.TrimSpace(plugin.License)
 		plugin.Install = NormalizeInstallPlan(plugin.Install)
+		plugin.Locales = normalizePluginLocales(plugin.Locales)
 		for versionIndex := range plugin.Versions {
 			version := &plugin.Versions[versionIndex]
 			version.Version = normalizeVersion(version.Version)
@@ -161,6 +173,121 @@ func normalizeRegistry(registry *Registry) {
 			plugin.Tags[tagIndex] = strings.TrimSpace(plugin.Tags[tagIndex])
 		}
 	}
+}
+
+func normalizePluginLocales(locales map[string]PluginLocale) map[string]PluginLocale {
+	if len(locales) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(locales))
+	for locale := range locales {
+		keys = append(keys, locale)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		left := normalizePluginLocaleKey(keys[i])
+		right := normalizePluginLocaleKey(keys[j])
+		if left == right {
+			leftScore := canonicalPluginLocaleScore(keys[i])
+			rightScore := canonicalPluginLocaleScore(keys[j])
+			if leftScore != rightScore {
+				return leftScore < rightScore
+			}
+			leftRaw := normalizedPluginLocaleRawKey(keys[i])
+			rightRaw := normalizedPluginLocaleRawKey(keys[j])
+			if leftRaw == rightRaw {
+				return keys[i] < keys[j]
+			}
+			return leftRaw < rightRaw
+		}
+		return left < right
+	})
+	out := make(map[string]PluginLocale, len(locales))
+	for _, rawLocale := range keys {
+		locale := normalizePluginLocaleKey(rawLocale)
+		if locale == "" {
+			continue
+		}
+		if _, exists := out[locale]; exists {
+			continue
+		}
+		value := locales[rawLocale]
+		value.Name = strings.TrimSpace(value.Name)
+		value.Description = strings.TrimSpace(value.Description)
+		value.Author = strings.TrimSpace(value.Author)
+		value.Homepage = strings.TrimSpace(value.Homepage)
+		value.License = strings.TrimSpace(value.License)
+		if len(value.Tags) > 0 {
+			tags := make([]string, len(value.Tags))
+			for index, tag := range value.Tags {
+				tags[index] = strings.TrimSpace(tag)
+			}
+			value.Tags = tags
+		}
+		out[locale] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func canonicalPluginLocaleScore(locale string) int {
+	raw := normalizedPluginLocaleRawKey(locale)
+	if raw == "" {
+		return 1 << 30
+	}
+	score := 0
+	for index, part := range strings.Split(raw, "-") {
+		if part == "" {
+			score += 8
+			continue
+		}
+		switch {
+		case index == 0:
+			if part != strings.ToLower(part) {
+				score += 4
+			}
+		case (len(part) == 2 || len(part) == 3) && isASCIIAlpha(part):
+			if part != strings.ToUpper(part) {
+				score += 3
+			}
+		case len(part) == 4 && isASCIIAlpha(part):
+			want := strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
+			if part != want {
+				score += 3
+			}
+		default:
+			if part != strings.ToLower(part) {
+				score++
+			}
+		}
+	}
+	return score
+}
+
+func isASCIIAlpha(value string) bool {
+	for _, ch := range value {
+		if (ch < 'A' || ch > 'Z') && (ch < 'a' || ch > 'z') {
+			return false
+		}
+	}
+	return value != ""
+}
+
+func normalizePluginLocaleKey(locale string) string {
+	return strings.ToLower(normalizedPluginLocaleRawKey(locale))
+}
+
+func normalizedPluginLocaleRawKey(locale string) string {
+	locale = strings.TrimSpace(locale)
+	if locale == "" {
+		return ""
+	}
+	locale = strings.ReplaceAll(locale, "_", "-")
+	if strings.ContainsAny(locale, " \t\r\n") {
+		return ""
+	}
+	return locale
 }
 
 func ValidateRegistry(registry Registry) error {

--- a/internal/pluginstore/registry_test.go
+++ b/internal/pluginstore/registry_test.go
@@ -68,6 +68,149 @@ func TestParseRegistryNormalizesPluginFields(t *testing.T) {
 	}
 }
 
+func TestParseRegistryNormalizesPluginLocales(t *testing.T) {
+	t.Parallel()
+
+	registry, errParse := ParseRegistry([]byte(`{
+		"schema_version": 1,
+		"plugins": [{
+			"id": "sample-provider",
+			"name": "Sample Provider",
+			"description": "Adds sample provider support.",
+			"author": "author-name",
+			"repository": "https://github.com/author-name/cliproxy-sample-provider-plugin",
+			"locales": {
+				" zh-CN ": {
+					"name": " 示例插件 ",
+					"description": " 增加示例提供商支持。 ",
+					"author": " 作者 ",
+					"tags": [" 工具 "]
+				}
+			}
+		}]
+	}`))
+	if errParse != nil {
+		t.Fatalf("ParseRegistry() error = %v", errParse)
+	}
+	plugin, ok := registry.PluginByID("sample-provider")
+	if !ok {
+		t.Fatal("PluginByID(sample-provider) missing")
+	}
+	localized, ok := plugin.Locales["zh-cn"]
+	if !ok {
+		t.Fatalf("plugin locales = %#v, want zh-cn", plugin.Locales)
+	}
+	if localized.Name != "示例插件" || localized.Description != "增加示例提供商支持。" || localized.Author != "作者" || localized.Tags[0] != "工具" {
+		t.Fatalf("localized plugin = %#v, want trimmed locale fields", localized)
+	}
+}
+
+func TestParseRegistryNormalizesDuplicatePluginLocaleKeysDeterministically(t *testing.T) {
+	t.Parallel()
+
+	registry, errParse := ParseRegistry([]byte(`{
+		"schema_version": 1,
+		"plugins": [{
+			"id": "sample-provider",
+			"name": "Sample Provider",
+			"description": "Adds sample provider support.",
+			"author": "author-name",
+			"repository": "https://github.com/author-name/cliproxy-sample-provider-plugin",
+			"locales": {
+				"ZH-cn": {"name": "uppercase"},
+				"zh-cn": {"name": "lower"},
+				"zh-CN": {"name": "canonical"}
+			}
+		}]
+	}`))
+	if errParse != nil {
+		t.Fatalf("ParseRegistry() error = %v", errParse)
+	}
+	plugin, ok := registry.PluginByID("sample-provider")
+	if !ok {
+		t.Fatal("PluginByID(sample-provider) missing")
+	}
+	if len(plugin.Locales) != 1 || plugin.Locales["zh-cn"].Name != "canonical" {
+		t.Fatalf("plugin locales = %#v, want deterministic canonical value", plugin.Locales)
+	}
+}
+
+func TestParseRegistryCanonicalPluginLocaleScoreSubtags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		locales   string
+		localeKey string
+		wantName  string
+	}{
+		{
+			name:      "numeric region",
+			locales:   `"en-419": {"name": "latin america"}, "en_419": {"name": "underscore"}`,
+			localeKey: "en-419",
+			wantName:  "latin america",
+		},
+		{
+			name:      "script subtag",
+			locales:   `"zh-Hant": {"name": "traditional"}, "zh-hant": {"name": "lower script"}`,
+			localeKey: "zh-hant",
+			wantName:  "traditional",
+		},
+		{
+			name:      "alpha three region",
+			locales:   `"en-USA": {"name": "upper region"}, "en-usa": {"name": "lower region"}`,
+			localeKey: "en-usa",
+			wantName:  "upper region",
+		},
+		{
+			name:      "variant subtag",
+			locales:   `"sl-rozaj": {"name": "lower variant"}, "sl-ROZAJ": {"name": "upper variant"}`,
+			localeKey: "sl-rozaj",
+			wantName:  "lower variant",
+		},
+		{
+			name:      "private subtag",
+			locales:   `"en-x-private": {"name": "lower private"}, "en-X-private": {"name": "upper private"}`,
+			localeKey: "en-x-private",
+			wantName:  "lower private",
+		},
+		{
+			name:      "dash beats underscore",
+			locales:   `"zh-CN": {"name": "dash"}, "zh_CN": {"name": "underscore"}`,
+			localeKey: "zh-cn",
+			wantName:  "dash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			registry, errParse := ParseRegistry([]byte(`{
+				"schema_version": 1,
+				"plugins": [{
+					"id": "sample-provider",
+					"name": "Sample Provider",
+					"description": "Adds sample provider support.",
+					"author": "author-name",
+					"repository": "https://github.com/author-name/cliproxy-sample-provider-plugin",
+					"locales": {` + tt.locales + `}
+				}]
+			}`))
+			if errParse != nil {
+				t.Fatalf("ParseRegistry() error = %v", errParse)
+			}
+			plugin, ok := registry.PluginByID("sample-provider")
+			if !ok {
+				t.Fatal("PluginByID(sample-provider) missing")
+			}
+			if len(plugin.Locales) != 1 || plugin.Locales[tt.localeKey].Name != tt.wantName {
+				t.Fatalf("plugin locales = %#v, want %s => %q", plugin.Locales, tt.localeKey, tt.wantName)
+			}
+		})
+	}
+}
+
 func TestValidateRegistryAllowsMissingVersion(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -31,6 +31,16 @@ type Metadata struct {
 	Logo string
 	// ConfigFields describes plugin-owned configuration fields for management clients.
 	ConfigFields []ConfigField
+	// Locales contains optional localized display metadata keyed by locale, for example "zh-CN".
+	Locales map[string]MetadataLocale `json:"locales,omitempty"`
+}
+
+// MetadataLocale contains localized plugin display metadata.
+type MetadataLocale struct {
+	// Name is the localized human-readable plugin name.
+	Name string `json:"name,omitempty"`
+	// Author is the localized plugin author or organization display name.
+	Author string `json:"author,omitempty"`
 }
 
 // ConfigFieldType classifies plugin-owned configuration values for management clients.
@@ -63,6 +73,14 @@ type ConfigField struct {
 	EnumValues []string
 	// Description explains how the plugin uses the field.
 	Description string
+	// Locales contains optional localized field text keyed by locale, for example "zh-CN".
+	Locales map[string]ConfigFieldLocale `json:"locales,omitempty"`
+}
+
+// ConfigFieldLocale contains localized configuration field text.
+type ConfigFieldLocale struct {
+	// Description explains how the plugin uses the field in the selected locale.
+	Description string `json:"description,omitempty"`
 }
 
 // Capabilities groups the optional host integration interfaces exposed by a plugin.
@@ -1207,6 +1225,8 @@ type ManagementRoute struct {
 	Menu string
 	// Description explains the legacy resource menu entry for UI display.
 	Description string
+	// Locales contains optional localized route menu text keyed by locale, for example "zh-CN".
+	Locales map[string]RouteLocale `json:"locales,omitempty"`
 	// Handler processes matching Management API requests.
 	Handler ManagementHandler
 }
@@ -1219,8 +1239,18 @@ type ResourceRoute struct {
 	Menu string
 	// Description explains the resource route for UI display.
 	Description string
+	// Locales contains optional localized resource menu text keyed by locale, for example "zh-CN".
+	Locales map[string]RouteLocale `json:"locales,omitempty"`
 	// Handler processes matching resource requests. Resource requests are not management-authenticated.
 	Handler ManagementHandler
+}
+
+// RouteLocale contains localized management or resource route menu text.
+type RouteLocale struct {
+	// Menu is the localized management UI menu label.
+	Menu string `json:"menu,omitempty"`
+	// Description explains the route in the selected locale.
+	Description string `json:"description,omitempty"`
 }
 
 // ManagementHandler handles one plugin-owned Management API or resource route.

--- a/sdk/pluginapi/types_test.go
+++ b/sdk/pluginapi/types_test.go
@@ -51,6 +51,39 @@ func TestMetadataConfigFieldsExposePluginSchema(t *testing.T) {
 	}
 }
 
+func TestPluginDisplayLocalesEncodeAsOptionalJSON(t *testing.T) {
+	meta := Metadata{
+		Name: "example",
+		Locales: map[string]MetadataLocale{
+			"zh-CN": {Name: "示例"},
+		},
+		ConfigFields: []ConfigField{{
+			Name:        "mode",
+			Description: "Execution mode.",
+			Locales: map[string]ConfigFieldLocale{
+				"zh-CN": {Description: "执行模式。"},
+			},
+		}},
+	}
+
+	raw, errMarshal := json.Marshal(meta)
+	if errMarshal != nil {
+		t.Fatalf("Marshal() error = %v", errMarshal)
+	}
+	if !strings.Contains(string(raw), `"locales"`) {
+		t.Fatalf("metadata JSON = %s, want optional locales field", raw)
+	}
+
+	var decoded Metadata
+	if errUnmarshal := json.Unmarshal(raw, &decoded); errUnmarshal != nil {
+		t.Fatalf("Unmarshal() error = %v", errUnmarshal)
+	}
+	if decoded.Locales["zh-CN"].Name != "示例" ||
+		decoded.ConfigFields[0].Locales["zh-CN"].Description != "执行模式。" {
+		t.Fatalf("decoded metadata = %#v, want localized fields", decoded)
+	}
+}
+
 func TestAuthParseResponseSupportsMultipleAuths(t *testing.T) {
 	resp := AuthParseResponse{
 		Handled: true,

--- a/sdk/pluginstore/pluginstore.go
+++ b/sdk/pluginstore/pluginstore.go
@@ -34,6 +34,7 @@ const (
 type Source = internalpluginstore.Source
 type Registry = internalpluginstore.Registry
 type Plugin = internalpluginstore.Plugin
+type PluginLocale = internalpluginstore.PluginLocale
 type Version = internalpluginstore.Version
 type Release = internalpluginstore.Release
 type ReleaseAsset = internalpluginstore.ReleaseAsset

--- a/sdk/pluginstore/pluginstore_test.go
+++ b/sdk/pluginstore/pluginstore_test.go
@@ -40,6 +40,13 @@ func TestManifestFromReleaseBuildsPinnedManifest(t *testing.T) {
 			Description: "Adds sample provider support.",
 			Author:      "author-name",
 			Repository:  "https://github.com/author-name/sample-provider",
+			Locales: map[string]PluginLocale{
+				"zh-CN": {
+					Name:        "示例插件",
+					Description: "增加示例提供商支持。",
+					Tags:        []string{"工具"},
+				},
+			},
 		},
 		Release{TagName: "v0.2.0"},
 	)
@@ -51,6 +58,9 @@ func TestManifestFromReleaseBuildsPinnedManifest(t *testing.T) {
 	}
 	if manifest.Version != "0.2.0" || manifest.ReleaseTag != "v0.2.0" {
 		t.Fatalf("manifest version fields = %q/%q, want 0.2.0/v0.2.0", manifest.Version, manifest.ReleaseTag)
+	}
+	if manifest.Locales["zh-cn"].Name != "示例插件" || manifest.Plugin().Locales["zh-cn"].Description != "增加示例提供商支持。" {
+		t.Fatalf("manifest locales = %#v, want copied localized metadata", manifest.Locales)
 	}
 }
 


### PR DESCRIPTION
## Summary

This adds localization support for plugin-facing metadata across the plugin store, SDK schemas, and management/resource menu surfaces.

## Background

Plugin display data currently has a single language path for names, authors, descriptions, config field descriptions, and resource menu labels. This makes plugin store listings and management UI menus hard to localize without custom frontend-side mapping.

## Changes

- Add optional locale maps to plugin SDK types:
  - plugin metadata display fields
  - config field descriptions
  - management/resource route menu text
- Add plugin store locale metadata parsing and normalization.
- Preserve localized plugin metadata in generated install manifests.
- Add preferred locale resolution from:
  - `locale` query parameter
  - `X-Locale` header
  - `Accept-Language`
- Forward the resolved locale to plugin management/resource handlers through `X-Locale`.
- Localize plugin store list entries, installed plugin metadata, config fields, and resource menu labels.
- Fix resource menu launch URLs so default query parameters remain navigable while route dispatch still matches path-only resource handlers.
- Harden locale handling:
  - clone and normalize locale maps before exposing host snapshots
  - avoid shared locale map mutation from plugin-owned route definitions
  - keep plugin management request headers writable even when the original request has no headers

## Compatibility

All locale fields are optional and preserve existing behavior when omitted. Existing plugin metadata and resource routes continue to work without changes.

Resource route dispatch remains path-based. Resource menu paths may include query parameters for launch URLs, but handler dispatch uses the path portion and forwards query values in the request object.

## Testing

- `go test ./internal/pluginhost ./internal/plugini18n ./internal/pluginstore ./internal/api/handlers/management ./sdk/pluginapi`
- `go test ./...`
- `go build -o /private/tmp/cpa-cli-proxy-api-test-output ./cmd/server`

## Related

Refs #4485.
