### PR TITLE
fix: retry Codex refresh on token invalidation

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -39,6 +39,10 @@ const (
 	codexDefaultImageToolModel = "gpt-image-2"
 )
 
+var refreshCodexAuthForTokenInvalidatedRetry = func(ctx context.Context, e *CodexExecutor, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return e.Refresh(ctx, auth)
+}
+
 var dataTag = []byte("data:")
 
 // Streamed Codex responses may emit response.output_item.done events while leaving
@@ -837,9 +841,63 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		if isCodexTokenInvalidatedResponse(httpResp.StatusCode, b) && auth != nil {
+			if refreshedAuth, refreshErr := refreshCodexAuthForTokenInvalidatedRetry(ctx, e, auth); refreshErr == nil && refreshedAuth != nil {
+				auth = refreshedAuth
+				apiKey, baseURL = codexCreds(auth)
+				if baseURL == "" {
+					baseURL = "https://chatgpt.com/backend-api/codex"
+				}
+				url = strings.TrimSuffix(baseURL, "/") + "/responses"
+				retryReq, retryUpstreamBody, retryIdentityState, retryReqErr := e.cacheHelper(ctx, from, url, auth, req, originalPayloadSource, body)
+				if retryReqErr != nil {
+					err = retryReqErr
+					return resp, err
+				}
+				identityState = retryIdentityState
+				applyCodexHeaders(retryReq, auth, apiKey, true, e.cfg)
+				applyCodexIdentityConfuseHeaders(retryReq.Header, &identityState)
+				if auth != nil {
+					authID = auth.ID
+					authLabel = auth.Label
+					authType, authValue = auth.AccountInfo()
+				}
+				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+					URL:       url,
+					Method:    http.MethodPost,
+					Headers:   retryReq.Header.Clone(),
+					Body:      retryUpstreamBody,
+					Provider:  e.Identifier(),
+					AuthID:    authID,
+					AuthLabel: authLabel,
+					AuthType:  authType,
+					AuthValue: authValue,
+				})
+				if errClose := httpResp.Body.Close(); errClose != nil {
+					log.Errorf("codex executor: close response body error: %v", errClose)
+				}
+				httpResp, err = httpClient.Do(retryReq)
+				if err != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, err)
+					return resp, err
+				}
+				helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+				if httpResp.StatusCode >= 200 && httpResp.StatusCode < 300 {
+					goto codexReadExecuteResponse
+				}
+				b, _ = io.ReadAll(httpResp.Body)
+				b = applyCodexIdentityConfuseResponsePayload(b, identityState)
+				helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+				helps.LogWithRequestID(ctx).Debugf("request error after refresh retry, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+			} else if refreshErr != nil {
+				helps.LogWithRequestID(ctx).Debugf("codex token_invalidated refresh retry failed: %v", refreshErr)
+			}
+		}
 		err = newCodexStatusErr(httpResp.StatusCode, b)
 		return resp, err
 	}
+
+codexReadExecuteResponse:
 	data, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
@@ -1006,9 +1064,53 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		b = applyCodexIdentityConfuseResponsePayload(b, identityState)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		if isCodexTokenInvalidatedResponse(httpResp.StatusCode, b) && auth != nil {
+			if refreshedAuth, refreshErr := refreshCodexAuthForTokenInvalidatedRetry(ctx, e, auth); refreshErr == nil && refreshedAuth != nil {
+				auth = refreshedAuth
+				apiKey, baseURL = codexCreds(auth)
+				if baseURL == "" {
+					baseURL = "https://chatgpt.com/backend-api/codex"
+				}
+				url = strings.TrimSuffix(baseURL, "/") + "/responses/compact"
+				retryReq, retryUpstreamBody, retryIdentityState, retryReqErr := e.cacheHelper(ctx, from, url, auth, req, originalPayloadSource, body)
+				if retryReqErr != nil {
+					err = retryReqErr
+					return resp, err
+				}
+				identityState = retryIdentityState
+				applyCodexHeaders(retryReq, auth, apiKey, false, e.cfg)
+				applyCodexIdentityConfuseHeaders(retryReq.Header, &identityState)
+				if auth != nil {
+					authID = auth.ID
+					authLabel = auth.Label
+					authType, authValue = auth.AccountInfo()
+				}
+				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{URL: url, Method: http.MethodPost, Headers: retryReq.Header.Clone(), Body: retryUpstreamBody, Provider: e.Identifier(), AuthID: authID, AuthLabel: authLabel, AuthType: authType, AuthValue: authValue})
+				if errClose := httpResp.Body.Close(); errClose != nil {
+					log.Errorf("codex executor: close response body error: %v", errClose)
+				}
+				httpResp, err = httpClient.Do(retryReq)
+				if err != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, err)
+					return resp, err
+				}
+				helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+				if httpResp.StatusCode >= 200 && httpResp.StatusCode < 300 {
+					goto codexReadCompactResponse
+				}
+				b, _ = io.ReadAll(httpResp.Body)
+				b = applyCodexIdentityConfuseResponsePayload(b, identityState)
+				helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+				helps.LogWithRequestID(ctx).Debugf("request error after refresh retry, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+			} else if refreshErr != nil {
+				helps.LogWithRequestID(ctx).Debugf("codex token_invalidated refresh retry failed: %v", refreshErr)
+			}
+		}
 		err = newCodexStatusErr(httpResp.StatusCode, b)
 		return resp, err
 	}
+
+codexReadCompactResponse:
 	data, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
@@ -1126,9 +1228,56 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
+		if isCodexTokenInvalidatedResponse(httpResp.StatusCode, data) && auth != nil {
+			if refreshedAuth, refreshErr := refreshCodexAuthForTokenInvalidatedRetry(ctx, e, auth); refreshErr == nil && refreshedAuth != nil {
+				auth = refreshedAuth
+				apiKey, baseURL = codexCreds(auth)
+				if baseURL == "" {
+					baseURL = "https://chatgpt.com/backend-api/codex"
+				}
+				url = strings.TrimSuffix(baseURL, "/") + "/responses"
+				retryReq, retryUpstreamBody, retryIdentityState, retryReqErr := e.cacheHelper(ctx, from, url, auth, req, originalPayloadSource, body)
+				if retryReqErr != nil {
+					return nil, retryReqErr
+				}
+				identityState = retryIdentityState
+				applyCodexHeaders(retryReq, auth, apiKey, true, e.cfg)
+				applyCodexIdentityConfuseHeaders(retryReq.Header, &identityState)
+				if auth != nil {
+					authID = auth.ID
+					authLabel = auth.Label
+					authType, authValue = auth.AccountInfo()
+				}
+				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{URL: url, Method: http.MethodPost, Headers: retryReq.Header.Clone(), Body: retryUpstreamBody, Provider: e.Identifier(), AuthID: authID, AuthLabel: authLabel, AuthType: authType, AuthValue: authValue})
+				httpResp, err = httpClient.Do(retryReq)
+				if err != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, err)
+					return nil, err
+				}
+				helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+				if httpResp.StatusCode >= 200 && httpResp.StatusCode < 300 {
+					goto codexBuildStreamResult
+				}
+				data, readErr = io.ReadAll(httpResp.Body)
+				if errClose := httpResp.Body.Close(); errClose != nil {
+					log.Errorf("codex executor: close response body error: %v", errClose)
+				}
+				if readErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, readErr)
+					return nil, readErr
+				}
+				data = applyCodexIdentityConfuseResponsePayload(data, identityState)
+				helps.AppendAPIResponseChunk(ctx, e.cfg, data)
+				helps.LogWithRequestID(ctx).Debugf("request error after refresh retry, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
+			} else if refreshErr != nil {
+				helps.LogWithRequestID(ctx).Debugf("codex token_invalidated refresh retry failed: %v", refreshErr)
+			}
+		}
 		err = newCodexStatusErr(httpResp.StatusCode, data)
 		return nil, err
 	}
+
+codexBuildStreamResult:
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
@@ -1643,6 +1792,14 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(r, attrs)
+}
+
+func isCodexTokenInvalidatedResponse(statusCode int, body []byte) bool {
+	if statusCode != http.StatusUnauthorized {
+		return false
+	}
+	lower := strings.ToLower(string(body))
+	return strings.Contains(lower, "token_invalidated") || strings.Contains(lower, "authentication token has been invalidated")
 }
 
 func newCodexStatusErr(statusCode int, body []byte) statusErr {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -876,17 +876,21 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 				if errClose := httpResp.Body.Close(); errClose != nil {
 					log.Errorf("codex executor: close response body error: %v", errClose)
 				}
-				httpResp, err = httpClient.Do(retryReq)
-				if err != nil {
-					helps.RecordAPIResponseError(ctx, e.cfg, err)
-					return resp, err
+				retryResp, retryErr := httpClient.Do(retryReq)
+				if retryErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, retryErr)
+					return resp, retryErr
 				}
+				httpResp = retryResp
 				helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 				if httpResp.StatusCode >= 200 && httpResp.StatusCode < 300 {
 					goto codexReadExecuteResponse
 				}
 				b, _ = io.ReadAll(httpResp.Body)
 				b = applyCodexIdentityConfuseResponsePayload(b, identityState)
+				if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, b); errClearReplay != nil {
+					return resp, errClearReplay
+				}
 				helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 				helps.LogWithRequestID(ctx).Debugf("request error after refresh retry, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
 			} else if refreshErr != nil {
@@ -1089,11 +1093,12 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 				if errClose := httpResp.Body.Close(); errClose != nil {
 					log.Errorf("codex executor: close response body error: %v", errClose)
 				}
-				httpResp, err = httpClient.Do(retryReq)
-				if err != nil {
-					helps.RecordAPIResponseError(ctx, e.cfg, err)
-					return resp, err
+				retryResp, retryErr := httpClient.Do(retryReq)
+				if retryErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, retryErr)
+					return resp, retryErr
 				}
+				httpResp = retryResp
 				helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 				if httpResp.StatusCode >= 200 && httpResp.StatusCode < 300 {
 					goto codexReadCompactResponse
@@ -1249,11 +1254,12 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					authType, authValue = auth.AccountInfo()
 				}
 				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{URL: url, Method: http.MethodPost, Headers: retryReq.Header.Clone(), Body: retryUpstreamBody, Provider: e.Identifier(), AuthID: authID, AuthLabel: authLabel, AuthType: authType, AuthValue: authValue})
-				httpResp, err = httpClient.Do(retryReq)
-				if err != nil {
-					helps.RecordAPIResponseError(ctx, e.cfg, err)
-					return nil, err
+				retryResp, retryErr := httpClient.Do(retryReq)
+				if retryErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, retryErr)
+					return nil, retryErr
 				}
+				httpResp = retryResp
 				helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 				if httpResp.StatusCode >= 200 && httpResp.StatusCode < 300 {
 					goto codexBuildStreamResult
@@ -1267,6 +1273,9 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					return nil, readErr
 				}
 				data = applyCodexIdentityConfuseResponsePayload(data, identityState)
+				if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, data); errClearReplay != nil {
+					return nil, errClearReplay
+				}
 				helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 				helps.LogWithRequestID(ctx).Debugf("request error after refresh retry, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
 			} else if refreshErr != nil {

--- a/internal/runtime/executor/codex_executor_auth_retry_test.go
+++ b/internal/runtime/executor/codex_executor_auth_retry_test.go
@@ -1,0 +1,123 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestCodexExecutorExecuteRefreshesAndRetriesTokenInvalidated(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			if got := r.Header.Get("Authorization"); got != "Bearer stale-token" {
+				t.Fatalf("first Authorization = %q, want stale token", got)
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"error":{"message":"Your authentication token has been invalidated. Please try signing in again.","type":"invalid_request_error","code":"token_invalidated"},"status":401}`)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer fresh-token" {
+			t.Fatalf("retry Authorization = %q, want fresh token", got)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"msg\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]}}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"response.completed\",\"response\":{\"output\":[]}}\n\n")
+	}))
+	defer server.Close()
+
+	oldRefresh := refreshCodexAuthForTokenInvalidatedRetry
+	refreshCodexAuthForTokenInvalidatedRetry = func(ctx context.Context, e *CodexExecutor, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+		auth.Metadata["access_token"] = "fresh-token"
+		return auth, nil
+	}
+	defer func() { refreshCodexAuthForTokenInvalidatedRetry = oldRefresh }()
+
+	executor := NewCodexExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{
+		Provider:   "codex",
+		Metadata:   map[string]any{"access_token": "stale-token", "refresh_token": "refresh-token"},
+		Attributes: map[string]string{"base_url": server.URL},
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err != nil {
+		t.Fatalf("Execute returned error after refresh retry: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2", calls)
+	}
+}
+
+func TestCodexExecutorExecuteStreamRefreshesAndRetriesTokenInvalidated(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			if got := r.Header.Get("Authorization"); got != "Bearer stale-token" {
+				t.Fatalf("first Authorization = %q, want stale token", got)
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"error":{"code":"token_invalidated","message":"Your authentication token has been invalidated. Please try signing in again."},"status":401}`)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer fresh-token" {
+			t.Fatalf("retry Authorization = %q, want fresh token", got)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n")
+	}))
+	defer server.Close()
+
+	oldRefresh := refreshCodexAuthForTokenInvalidatedRetry
+	refreshCodexAuthForTokenInvalidatedRetry = func(ctx context.Context, e *CodexExecutor, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+		auth.Metadata["access_token"] = "fresh-token"
+		return auth, nil
+	}
+	defer func() { refreshCodexAuthForTokenInvalidatedRetry = oldRefresh }()
+
+	executor := NewCodexExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{
+		Provider:   "codex",
+		Metadata:   map[string]any{"access_token": "stale-token", "refresh_token": "refresh-token"},
+		Attributes: map[string]string{"base_url": server.URL},
+	}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err != nil {
+		t.Fatalf("ExecuteStream returned error after refresh retry: %v", err)
+	}
+	for range result.Chunks {
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2", calls)
+	}
+}
+
+func TestIsCodexTokenInvalidatedResponse(t *testing.T) {
+	body := []byte(`{"error":{"code":"token_invalidated","message":"Your authentication token has been invalidated. Please try signing in again."},"status":401}`)
+	if !isCodexTokenInvalidatedResponse(http.StatusUnauthorized, body) {
+		t.Fatal("expected token_invalidated response to be detected")
+	}
+	if isCodexTokenInvalidatedResponse(http.StatusTooManyRequests, body) {
+		t.Fatal("429 must not be treated as token_invalidated")
+	}
+	if isCodexTokenInvalidatedResponse(http.StatusUnauthorized, []byte(strings.Repeat("x", 10))) {
+		t.Fatal("generic 401 must not be treated as token_invalidated")
+	}
+}

--- a/internal/runtime/executor/codex_executor_auth_retry_test.go
+++ b/internal/runtime/executor/codex_executor_auth_retry_test.go
@@ -2,12 +2,14 @@ package executor
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -107,6 +109,110 @@ func TestCodexExecutorExecuteStreamRefreshesAndRetriesTokenInvalidated(t *testin
 	if calls != 2 {
 		t.Fatalf("upstream calls = %d, want 2", calls)
 	}
+}
+
+func TestCodexExecutorExecuteRefreshRetryTransportErrorDoesNotPanic(t *testing.T) {
+	calls := 0
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if got := r.Header.Get("Authorization"); got != "Bearer stale-token" {
+			t.Fatalf("first Authorization = %q, want stale token", got)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, `{"error":{"code":"token_invalidated","message":"Your authentication token has been invalidated. Please try signing in again."},"status":401}`)
+	}))
+	defer server.Close()
+
+	oldRefresh := refreshCodexAuthForTokenInvalidatedRetry
+	refreshCodexAuthForTokenInvalidatedRetry = func(ctx context.Context, e *CodexExecutor, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+		auth.Metadata["access_token"] = "fresh-token"
+		server.Close()
+		return auth, nil
+	}
+	defer func() { refreshCodexAuthForTokenInvalidatedRetry = oldRefresh }()
+
+	executor := NewCodexExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{
+		Provider:   "codex",
+		Metadata:   map[string]any{"access_token": "stale-token", "refresh_token": "refresh-token"},
+		Attributes: map[string]string{"base_url": server.URL},
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")})
+	if err == nil {
+		t.Fatal("expected retry transport error, got nil")
+	}
+	if calls != 1 {
+		t.Fatalf("upstream calls = %d, want 1 before retry transport failure", calls)
+	}
+}
+
+func TestCodexExecutorExecuteRefreshRetryClearsInvalidReasoningReplay(t *testing.T) {
+	internalcache.ClearCodexReasoningReplayCache()
+	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
+
+	const sessionID = "retry-invalid-signature"
+	const sessionKey = "execution:" + sessionID
+	model := "gpt-5.5"
+	if !internalcache.CacheCodexReasoningReplayItem(model, sessionKey, validCodexReasoningReplayItemForAuthRetryTest(7)) {
+		t.Fatal("failed to seed codex reasoning replay cache")
+	}
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"error":{"code":"token_invalidated","message":"Your authentication token has been invalidated. Please try signing in again."},"status":401}`)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"Invalid signature in thinking block","type":"invalid_request_error","code":"invalid_request_error"}}`)
+	}))
+	defer server.Close()
+
+	oldRefresh := refreshCodexAuthForTokenInvalidatedRetry
+	refreshCodexAuthForTokenInvalidatedRetry = func(ctx context.Context, e *CodexExecutor, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+		auth.Metadata["access_token"] = "fresh-token"
+		return auth, nil
+	}
+	defer func() { refreshCodexAuthForTokenInvalidatedRetry = oldRefresh }()
+
+	executor := NewCodexExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{
+		Provider:   "codex",
+		Metadata:   map[string]any{"access_token": "stale-token", "refresh_token": "refresh-token"},
+		Attributes: map[string]string{"base_url": server.URL},
+	}
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:    model,
+		Payload:  []byte(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}],"max_tokens":16}`),
+		Metadata: map[string]any{cliproxyexecutor.ExecutionSessionMetadataKey: sessionID},
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err == nil {
+		t.Fatal("expected retry invalid signature error, got nil")
+	}
+	if _, ok := internalcache.GetCodexReasoningReplayItem(model, sessionKey); ok {
+		t.Fatal("expected invalid reasoning replay cache to be cleared after retry error")
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2", calls)
+	}
+}
+
+func validCodexReasoningReplayItemForAuthRetryTest(seed byte) []byte {
+	payload := make([]byte, 1+8+16+16+32)
+	payload[0] = 0x80
+	for i := 9; i < len(payload); i++ {
+		payload[i] = seed + byte(i)
+	}
+	encryptedContent := base64.RawURLEncoding.EncodeToString(payload)
+	return []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"` + encryptedContent + `"}`)
 }
 
 func TestIsCodexTokenInvalidatedResponse(t *testing.T) {


### PR DESCRIPTION
## Summary

- detect Codex `401 token_invalidated` responses
- call the existing `CodexExecutor.Refresh()` path before suspending/falling back
- retry the same request once with refreshed auth for normal, compact, and streaming Codex responses
- add regression tests for non-stream, stream, and token-invalidated detection

Closes #4087

## Test plan

- `go test ./internal/runtime/executor -run 'TestCodexExecutorExecuteRefreshesAndRetriesTokenInvalidated|TestCodexExecutorExecuteStreamRefreshesAndRetriesTokenInvalidated|TestIsCodexTokenInvalidatedResponse' -count=1`
- `go test ./internal/runtime/executor -count=1`
- `go test ./... -count=1`
- Manual smoke with two Codex auth files on v7.2.49 latest:
  - unpatched latest: primary `token_invalidated` immediately suspended/fell back
  - patched latest: primary `token_invalidated` called refresh first, then fell back only after refresh returned `refresh_token_invalidated`
