### PR TITLE
fix(translator): preserve Claude system prompts and tool args

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -12,7 +12,6 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
-	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/translator/gemini/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	log "github.com/sirupsen/logrus"
@@ -362,25 +361,44 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 				continue
 			}
 			originalRole := roleResult.String()
-			role := originalRole
-			if role == "assistant" {
-				role = "model"
-			} else if role == "system" {
-				role = "user"
-			}
-			clientContentJSON := []byte(`{"role":"","parts":[]}`)
-			clientContentJSON, _ = sjson.SetBytes(clientContentJSON, "role", role)
 			contentsResult := messageResult.Get("content")
 			if originalRole == "system" {
-				if reminderText, ok := translatorcommon.ClaudeMessageSystemReminderText(contentsResult); ok {
+				var systemText strings.Builder
+				if contentsResult.Type == gjson.String {
+					systemText.WriteString(contentsResult.String())
+				} else if contentsResult.IsArray() {
+					contentsResult.ForEach(func(_, contentResult gjson.Result) bool {
+						if contentResult.Get("type").String() != "text" {
+							return true
+						}
+						text := contentResult.Get("text").String()
+						if text == "" || util.IsClaudeCodeAttributionSystemText(text) {
+							return true
+						}
+						if systemText.Len() > 0 {
+							systemText.WriteString("\n")
+						}
+						systemText.WriteString(text)
+						return true
+					})
+				}
+				if systemText.Len() > 0 && !util.IsClaudeCodeAttributionSystemText(systemText.String()) {
+					if !hasSystemInstruction {
+						systemInstructionJSON = []byte(`{"role":"user","parts":[]}`)
+						hasSystemInstruction = true
+					}
 					partJSON := []byte(`{}`)
-					partJSON, _ = sjson.SetBytes(partJSON, "text", reminderText)
-					clientContentJSON, _ = sjson.SetRawBytes(clientContentJSON, "parts.-1", partJSON)
-					contentsJSON, _ = sjson.SetRawBytes(contentsJSON, "-1", clientContentJSON)
-					hasContents = true
+					partJSON, _ = sjson.SetBytes(partJSON, "text", systemText.String())
+					systemInstructionJSON, _ = sjson.SetRawBytes(systemInstructionJSON, "parts.-1", partJSON)
 				}
 				continue
 			}
+			role := originalRole
+			if role == "assistant" {
+				role = "model"
+			}
+			clientContentJSON := []byte(`{"role":"","parts":[]}`)
+			clientContentJSON, _ = sjson.SetBytes(clientContentJSON, "role", role)
 			if contentsResult.IsArray() {
 				contentResults := contentsResult.Array()
 				numContents := len(contentResults)

--- a/internal/translator/antigravity/claude/antigravity_claude_request_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request_test.go
@@ -134,50 +134,24 @@ func TestConvertClaudeRequestToAntigravity_StripsClaudeCodeAttribution(t *testin
 	}
 }
 
-func TestConvertClaudeRequestToAntigravity_ConvertsMessageSystemRoleToUserContent(t *testing.T) {
+func TestConvertClaudeRequestToAntigravity_MidConversationSystemBecomesSystemInstruction(t *testing.T) {
 	inputJSON := []byte(`{
-		"model": "gemini-3.5-flash",
-		"system": [{"type": "text", "text": "Top-level rules"}],
+		"model": "gemini-3-pro",
 		"messages": [
-			{"role": "user", "content": [{"type": "text", "text": "Hello"}]},
-			{"role": "system", "content": "String mid-conversation rule"},
-			{"role": "system", "content": [{"type": "text", "text": "Array mid-conversation rule"}]}
+			{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+			{"role": "system", "content": "Available tools and instructions"},
+			{"role": "user", "content": [{"type": "text", "text": "continue"}]}
 		]
 	}`)
 
-	output := ConvertClaudeRequestToAntigravity("gemini-3-flash-agent", inputJSON, false)
-	outputStr := string(output)
+	output := ConvertClaudeRequestToAntigravity("gemini-3-pro", inputJSON, false)
 
-	if systemContent := gjson.Get(outputStr, `request.contents.#(role=="system")`); systemContent.Exists() {
-		t.Fatalf("system role should not be emitted in request.contents: %s", systemContent.Raw)
+	if got := gjson.GetBytes(output, "request.systemInstruction.parts.0.text").String(); got != "Available tools and instructions" {
+		t.Fatalf("Expected mid-conversation system in systemInstruction, got %q: %s", got, output)
 	}
-
-	contents := gjson.Get(outputStr, "request.contents").Array()
-	if len(contents) != 3 {
-		t.Fatalf("Expected the user and message-level system turns in request.contents, got %d: %s", len(contents), gjson.Get(outputStr, "request.contents").Raw)
-	}
-	if got := contents[0].Get("role").String(); got != "user" {
-		t.Fatalf("Expected first content role user, got %q", got)
-	}
-	if got := contents[1].Get("role").String(); got != "user" {
-		t.Fatalf("Expected message-level system content to be downgraded to user role, got %q", got)
-	}
-	if got := contents[1].Get("parts.0.text").String(); got != "<system-reminder>\nString mid-conversation rule\n</system-reminder>" {
-		t.Fatalf("Unexpected string message-level system content text: %q", got)
-	}
-	if got := contents[2].Get("role").String(); got != "user" {
-		t.Fatalf("Expected array message-level system content to be downgraded to user role, got %q", got)
-	}
-	if got := contents[2].Get("parts.0.text").String(); got != "<system-reminder>\nArray mid-conversation rule\n</system-reminder>" {
-		t.Fatalf("Unexpected array message-level system content text: %q", got)
-	}
-
-	parts := gjson.Get(outputStr, "request.systemInstruction.parts").Array()
-	if len(parts) != 1 {
-		t.Fatalf("Expected only top-level system parts, got %d: %s", len(parts), gjson.Get(outputStr, "request.systemInstruction.parts").Raw)
-	}
-	if got := parts[0].Get("text").String(); got != "Top-level rules" {
-		t.Fatalf("Unexpected first system part: %q", got)
+	roles := gjson.GetBytes(output, "request.contents.#.role").Array()
+	if len(roles) != 2 || roles[0].String() != "user" || roles[1].String() != "user" {
+		t.Fatalf("Expected only user contents after removing system message, got %s: %s", gjson.GetBytes(output, "request.contents.#.role").Raw, output)
 	}
 }
 

--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -29,6 +29,9 @@ func appendGeminiSystemInstructionText(out []byte, text string) []byte {
 
 func claudeTextContent(content gjson.Result) string {
 	if content.Type == gjson.String {
+		if util.IsClaudeCodeAttributionSystemText(content.String()) {
+			return ""
+		}
 		return content.String()
 	}
 	if !content.IsArray() {
@@ -41,7 +44,7 @@ func claudeTextContent(content gjson.Result) string {
 			return true
 		}
 		text := part.Get("text")
-		if text.Type != gjson.String || text.String() == "" {
+		if text.Type != gjson.String || text.String() == "" || util.IsClaudeCodeAttributionSystemText(text.String()) {
 			return true
 		}
 		if b.Len() > 0 {

--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -10,14 +10,48 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
-	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/translator/gemini/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
-const geminiClaudeThoughtSignature = "skip_thought_signature_validator"
+func appendGeminiSystemInstructionText(out []byte, text string) []byte {
+	if text == "" {
+		return out
+	}
+	out, _ = sjson.SetBytes(out, "system_instruction.role", "user")
+	part := []byte(`{"text":""}`)
+	part, _ = sjson.SetBytes(part, "text", text)
+	out, _ = sjson.SetRawBytes(out, "system_instruction.parts.-1", part)
+	return out
+}
+
+func claudeTextContent(content gjson.Result) string {
+	if content.Type == gjson.String {
+		return content.String()
+	}
+	if !content.IsArray() {
+		return ""
+	}
+
+	var b strings.Builder
+	content.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("type").String() != "text" {
+			return true
+		}
+		text := part.Get("text")
+		if text.Type != gjson.String || text.String() == "" {
+			return true
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(text.String())
+		return true
+	})
+	return b.String()
+}
 
 // ConvertClaudeRequestToGemini parses a Claude API request and returns a complete
 // Gemini request body (as JSON bytes) ready to be sent via SendRawMessageStream.
@@ -38,28 +72,19 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 
 	// system instruction
 	if systemResult := gjson.GetBytes(rawJSON, "system"); systemResult.IsArray() {
-		systemInstruction := []byte(`{"role":"user","parts":[]}`)
-		hasSystemParts := false
 		systemResult.ForEach(func(_, systemPromptResult gjson.Result) bool {
-			if systemPromptResult.Get("type").String() == "text" {
-				textResult := systemPromptResult.Get("text")
-				if textResult.Type == gjson.String {
-					if util.IsClaudeCodeAttributionSystemText(textResult.String()) {
-						return true
-					}
-					part := []byte(`{"text":""}`)
-					part, _ = sjson.SetBytes(part, "text", textResult.String())
-					systemInstruction, _ = sjson.SetRawBytes(systemInstruction, "parts.-1", part)
-					hasSystemParts = true
-				}
+			if systemPromptResult.Get("type").String() != "text" {
+				return true
 			}
+			textResult := systemPromptResult.Get("text")
+			if textResult.Type != gjson.String || util.IsClaudeCodeAttributionSystemText(textResult.String()) {
+				return true
+			}
+			out = appendGeminiSystemInstructionText(out, textResult.String())
 			return true
 		})
-		if hasSystemParts {
-			out, _ = sjson.SetRawBytes(out, "system_instruction", systemInstruction)
-		}
 	} else if systemResult.Type == gjson.String && !util.IsClaudeCodeAttributionSystemText(systemResult.String()) {
-		out, _ = sjson.SetBytes(out, "system_instruction.parts.-1.text", systemResult.String())
+		out = appendGeminiSystemInstructionText(out, systemResult.String())
 	}
 
 	// contents
@@ -70,25 +95,17 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 				return true
 			}
 			role := roleResult.String()
+			contentsResult := messageResult.Get("content")
+			if role == "system" {
+				out = appendGeminiSystemInstructionText(out, claudeTextContent(contentsResult))
+				return true
+			}
 			if role == "assistant" {
 				role = "model"
-			} else if role == "system" {
-				role = "user"
 			}
 
 			contentJSON := []byte(`{"role":"","parts":[]}`)
 			contentJSON, _ = sjson.SetBytes(contentJSON, "role", role)
-
-			contentsResult := messageResult.Get("content")
-			if roleResult.String() == "system" {
-				if reminderText, ok := translatorcommon.ClaudeMessageSystemReminderText(contentsResult); ok {
-					part := []byte(`{"text":""}`)
-					part, _ = sjson.SetBytes(part, "text", reminderText)
-					contentJSON, _ = sjson.SetRawBytes(contentJSON, "parts.-1", part)
-					out, _ = sjson.SetRawBytes(out, "contents.-1", contentJSON)
-				}
-				return true
-			}
 			if contentsResult.IsArray() {
 				contentsResult.ForEach(func(_, contentResult gjson.Result) bool {
 					switch contentResult.Get("type").String() {
@@ -112,8 +129,7 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 						functionArgs := contentResult.Get("input").String()
 						argsResult := gjson.Parse(functionArgs)
 						if argsResult.IsObject() && gjson.Valid(functionArgs) {
-							part := []byte(`{"thoughtSignature":"","functionCall":{"name":"","args":{}}}`)
-							part, _ = sjson.SetBytes(part, "thoughtSignature", geminiClaudeThoughtSignature)
+							part := []byte(`{"functionCall":{"name":"","args":{}}}`)
 							part, _ = sjson.SetBytes(part, "functionCall.name", functionName)
 							part, _ = sjson.SetRawBytes(part, "functionCall.args", []byte(functionArgs))
 							contentJSON, _ = sjson.SetRawBytes(contentJSON, "parts.-1", part)
@@ -162,8 +178,10 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 					}
 					return true
 				})
-				out, _ = sjson.SetRawBytes(out, "contents.-1", contentJSON)
-			} else if contentsResult.Type == gjson.String {
+				if len(gjson.GetBytes(contentJSON, "parts").Array()) > 0 {
+					out, _ = sjson.SetRawBytes(out, "contents.-1", contentJSON)
+				}
+			} else if contentsResult.Type == gjson.String && contentsResult.String() != "" {
 				part := []byte(`{"text":""}`)
 				part, _ = sjson.SetBytes(part, "text", contentsResult.String())
 				contentJSON, _ = sjson.SetRawBytes(contentJSON, "parts.-1", part)

--- a/internal/translator/gemini/claude/gemini_claude_request_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_request_test.go
@@ -128,6 +128,33 @@ func TestConvertClaudeRequestToGemini_MidConversationSystemBecomesSystemInstruct
 	}
 }
 
+func TestConvertClaudeRequestToGemini_MidConversationSystemSkipsAttribution(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "claude-3-5-sonnet",
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+			{"role": "system", "content": "x-anthropic-billing-header: cc_version=2.1.63.abc; cc_entrypoint=cli; cch=12345;"},
+			{"role": "system", "content": [
+				{"type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.63.abc; cc_entrypoint=cli; cch=12345;"},
+				{"type": "text", "text": "Real system instruction"}
+			]}
+		]
+	}`)
+
+	output := ConvertClaudeRequestToGemini("gemini-3-flash-preview", inputJSON, false)
+
+	parts := gjson.GetBytes(output, "system_instruction.parts").Array()
+	if len(parts) != 1 {
+		t.Fatalf("Expected only non-attribution system part, got %d: %s", len(parts), gjson.GetBytes(output, "system_instruction.parts").Raw)
+	}
+	if got := parts[0].Get("text").String(); got != "Real system instruction" {
+		t.Fatalf("Unexpected system instruction text: %q", got)
+	}
+	if gjson.GetBytes(output, `system_instruction.parts.#(text%"x-anthropic-billing-header:*")`).Exists() {
+		t.Fatalf("Claude Code attribution block was forwarded: %s", gjson.GetBytes(output, "system_instruction.parts").Raw)
+	}
+}
+
 func TestConvertClaudeRequestToGemini_SkipsEmptyTextParts(t *testing.T) {
 	inputJSON := []byte(`{
 		"model": "claude-3-5-sonnet",

--- a/internal/translator/gemini/claude/gemini_claude_request_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_request_test.go
@@ -107,49 +107,24 @@ func TestConvertClaudeRequestToGemini_StripsClaudeCodeAttribution(t *testing.T) 
 	}
 }
 
-func TestConvertClaudeRequestToGemini_ConvertsMessageSystemRoleToUserContent(t *testing.T) {
+func TestConvertClaudeRequestToGemini_MidConversationSystemBecomesSystemInstruction(t *testing.T) {
 	inputJSON := []byte(`{
-		"model": "gemini-3-flash-preview",
-		"system": [{"type": "text", "text": "Top-level rules"}],
+		"model": "claude-3-5-sonnet",
 		"messages": [
-			{"role": "user", "content": [{"type": "text", "text": "Hello"}]},
-			{"role": "system", "content": "String mid-conversation rule"},
-			{"role": "system", "content": [{"type": "text", "text": "Array mid-conversation rule"}]}
+			{"role": "user", "content": [{"type": "text", "text": "hi"}]},
+			{"role": "system", "content": "Available tools and instructions"},
+			{"role": "user", "content": [{"type": "text", "text": "continue"}]}
 		]
 	}`)
 
 	output := ConvertClaudeRequestToGemini("gemini-3-flash-preview", inputJSON, false)
 
-	if systemContent := gjson.GetBytes(output, `contents.#(role=="system")`); systemContent.Exists() {
-		t.Fatalf("system role should not be emitted in contents: %s", systemContent.Raw)
+	if got := gjson.GetBytes(output, "system_instruction.parts.0.text").String(); got != "Available tools and instructions" {
+		t.Fatalf("Expected mid-conversation system in system_instruction, got %q: %s", got, output)
 	}
-
-	contents := gjson.GetBytes(output, "contents").Array()
-	if len(contents) != 3 {
-		t.Fatalf("Expected the user and message-level system turns in contents, got %d: %s", len(contents), gjson.GetBytes(output, "contents").Raw)
-	}
-	if got := contents[0].Get("role").String(); got != "user" {
-		t.Fatalf("Expected first content role user, got %q", got)
-	}
-	if got := contents[1].Get("role").String(); got != "user" {
-		t.Fatalf("Expected message-level string system content to be downgraded to user role, got %q", got)
-	}
-	if got := contents[1].Get("parts.0.text").String(); got != "<system-reminder>\nString mid-conversation rule\n</system-reminder>" {
-		t.Fatalf("Unexpected string message-level system content text: %q", got)
-	}
-	if got := contents[2].Get("role").String(); got != "user" {
-		t.Fatalf("Expected message-level array system content to be downgraded to user role, got %q", got)
-	}
-	if got := contents[2].Get("parts.0.text").String(); got != "<system-reminder>\nArray mid-conversation rule\n</system-reminder>" {
-		t.Fatalf("Unexpected array message-level system content text: %q", got)
-	}
-
-	parts := gjson.GetBytes(output, "system_instruction.parts").Array()
-	if len(parts) != 1 {
-		t.Fatalf("Expected only top-level system parts, got %d: %s", len(parts), gjson.GetBytes(output, "system_instruction.parts").Raw)
-	}
-	if got := parts[0].Get("text").String(); got != "Top-level rules" {
-		t.Fatalf("Unexpected first system part: %q", got)
+	roles := gjson.GetBytes(output, "contents.#.role").Array()
+	if len(roles) != 2 || roles[0].String() != "user" || roles[1].String() != "user" {
+		t.Fatalf("Expected only user contents after removing system message, got %s: %s", gjson.GetBytes(output, "contents.#.role").Raw, output)
 	}
 }
 

--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -9,6 +9,7 @@ package claude
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -28,12 +29,107 @@ type Params struct {
 	HasContent       bool // Tracks whether any content (text, thinking, or tool use) has been output
 	ToolNameMap      map[string]string
 	SanitizedNameMap map[string]string
+	ToolInputSchemas map[string]string
+	ActiveToolName   string
 	SawToolCall      bool
 	HasFinalEvents   bool
 }
 
 // toolUseIDCounter provides a process-wide unique counter for tool use identifiers.
 var toolUseIDCounter uint64
+
+// toolInputSchemaMapFromClaudeRequest returns a canonical tool name -> original
+// Anthropic input_schema map. The Gemini request translator strips fields such
+// as strict/additionalProperties for upstream compatibility, so response
+// translation must use the original Claude schema to clean tool arguments before
+// sending them back to Claude Code.
+func toolInputSchemaMapFromClaudeRequest(rawJSON []byte) map[string]string {
+	if len(rawJSON) == 0 || !gjson.ValidBytes(rawJSON) {
+		return nil
+	}
+
+	tools := gjson.GetBytes(rawJSON, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return nil
+	}
+
+	out := make(map[string]string)
+	tools.ForEach(func(_, tool gjson.Result) bool {
+		name := strings.TrimSpace(tool.Get("name").String())
+		if name == "" {
+			return true
+		}
+		schema := tool.Get("input_schema")
+		if !schema.Exists() || !schema.IsObject() {
+			return true
+		}
+
+		rawSchema := schema.Raw
+		out[util.CanonicalToolName(name)] = rawSchema
+		out[util.CanonicalToolName(util.SanitizeFunctionName(name))] = rawSchema
+		return true
+	})
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// sanitizeToolArgsForClaude applies a small but important subset of JSON Schema
+// enforcement required by Claude Code. Gemini can add explanatory fields such as
+// "reason" even when the original Anthropic schema disallows extra properties.
+// Passing those fields through makes Claude Code's local tool executor reject
+// the tool call.
+func sanitizeToolArgsForClaude(schemaMap map[string]string, toolName string, argsRaw string) string {
+	argsRaw = strings.TrimSpace(argsRaw)
+	if argsRaw == "" || !gjson.Valid(argsRaw) {
+		return "{}"
+	}
+
+	args := gjson.Parse(argsRaw)
+	if !args.IsObject() {
+		return argsRaw
+	}
+
+	if schemaMap == nil || toolName == "" {
+		return argsRaw
+	}
+	schemaRaw := schemaMap[util.CanonicalToolName(toolName)]
+	if schemaRaw == "" {
+		return argsRaw
+	}
+
+	schema := gjson.Parse(schemaRaw)
+	props := schema.Get("properties")
+	additionalProps := schema.Get("additionalProperties")
+
+	// Empty object schema with additionalProperties:false means the only valid
+	// tool input is {}. This fixes no-arg tools such as CronList.
+	if props.IsObject() && len(props.Map()) == 0 && additionalProps.Type == gjson.False {
+		return "{}"
+	}
+
+	// If additionalProperties is not explicitly false, preserve upstream args.
+	if additionalProps.Type != gjson.False || !props.IsObject() {
+		return argsRaw
+	}
+
+	allowed := props.Map()
+	cleaned := make(map[string]any)
+	args.ForEach(func(key, value gjson.Result) bool {
+		if _, ok := allowed[key.String()]; ok {
+			cleaned[key.String()] = value.Value()
+		}
+		return true
+	})
+
+	out, err := json.Marshal(cleaned)
+	if err != nil {
+		return argsRaw
+	}
+	return string(out)
+}
 
 // ConvertGeminiResponseToClaude performs sophisticated streaming response format conversion.
 // This function implements a complex state machine that translates backend client responses
@@ -60,6 +156,7 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 			ResponseIndex:    0,
 			ToolNameMap:      util.ToolNameMapFromClaudeRequest(originalRequestRawJSON),
 			SanitizedNameMap: util.SanitizedToolNameMap(originalRequestRawJSON),
+			ToolInputSchemas: toolInputSchemaMapFromClaudeRequest(originalRequestRawJSON),
 			SawToolCall:      false,
 		}
 	}
@@ -200,7 +297,8 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 				// If we are already in tool use mode and name is empty, treat as continuation (delta).
 				if (*param).(*Params).ResponseType == 3 && upstreamToolName == "" {
 					if fcArgsResult := functionCallResult.Get("args"); fcArgsResult.Exists() {
-						data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"input_json_delta","partial_json":""}}`, (*param).(*Params).ResponseIndex)), "delta.partial_json", fcArgsResult.Raw)
+						argsRaw := sanitizeToolArgsForClaude((*param).(*Params).ToolInputSchemas, (*param).(*Params).ActiveToolName, fcArgsResult.Raw)
+						data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"input_json_delta","partial_json":""}}`, (*param).(*Params).ResponseIndex)), "delta.partial_json", argsRaw)
 						appendEvent("content_block_delta", string(data))
 					}
 					// Continue to next part without closing/opening logic
@@ -235,9 +333,11 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 				data, _ = sjson.SetBytes(data, "content_block.id", util.SanitizeClaudeToolID(fmt.Sprintf("%s-%d", upstreamToolName, atomic.AddUint64(&toolUseIDCounter, 1))))
 				data, _ = sjson.SetBytes(data, "content_block.name", clientToolName)
 				appendEvent("content_block_start", string(data))
+				(*param).(*Params).ActiveToolName = clientToolName
 
 				if fcArgsResult := functionCallResult.Get("args"); fcArgsResult.Exists() {
-					data, _ = sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"input_json_delta","partial_json":""}}`, (*param).(*Params).ResponseIndex)), "delta.partial_json", fcArgsResult.Raw)
+					argsRaw := sanitizeToolArgsForClaude((*param).(*Params).ToolInputSchemas, clientToolName, fcArgsResult.Raw)
+					data, _ = sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"input_json_delta","partial_json":""}}`, (*param).(*Params).ResponseIndex)), "delta.partial_json", argsRaw)
 					appendEvent("content_block_delta", string(data))
 				}
 				(*param).(*Params).ResponseType = 3
@@ -291,6 +391,7 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 	root := gjson.ParseBytes(rawJSON)
 	toolNameMap := util.ToolNameMapFromClaudeRequest(originalRequestRawJSON)
 	sanitizedNameMap := util.SanitizedToolNameMap(originalRequestRawJSON)
+	toolInputSchemas := toolInputSchemaMapFromClaudeRequest(originalRequestRawJSON)
 
 	out := []byte(`{"id":"","type":"message","role":"assistant","model":"","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}`)
 	out, _ = sjson.SetBytes(out, "id", root.Get("responseId").String())
@@ -354,7 +455,7 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 				toolBlock, _ = sjson.SetBytes(toolBlock, "name", clientToolName)
 				inputRaw := "{}"
 				if args := functionCall.Get("args"); args.Exists() && gjson.Valid(args.Raw) && args.IsObject() {
-					inputRaw = args.Raw
+					inputRaw = sanitizeToolArgsForClaude(toolInputSchemas, clientToolName, args.Raw)
 				}
 				toolBlock, _ = sjson.SetRawBytes(toolBlock, "input", []byte(inputRaw))
 				out, _ = sjson.SetRawBytes(out, "content.-1", toolBlock)

--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -9,7 +9,6 @@ package claude
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -104,31 +103,30 @@ func sanitizeToolArgsForClaude(schemaMap map[string]string, toolName string, arg
 	props := schema.Get("properties")
 	additionalProps := schema.Get("additionalProperties")
 
-	// Empty object schema with additionalProperties:false means the only valid
-	// tool input is {}. This fixes no-arg tools such as CronList.
-	if props.IsObject() && len(props.Map()) == 0 && additionalProps.Type == gjson.False {
-		return "{}"
-	}
-
 	// If additionalProperties is not explicitly false, preserve upstream args.
-	if additionalProps.Type != gjson.False || !props.IsObject() {
+	if additionalProps.Type != gjson.False || (props.Exists() && !props.IsObject()) {
 		return argsRaw
 	}
 
 	allowed := props.Map()
-	cleaned := make(map[string]any)
-	args.ForEach(func(key, value gjson.Result) bool {
-		if _, ok := allowed[key.String()]; ok {
-			cleaned[key.String()] = value.Value()
+	cleanedBytes := []byte(argsRaw)
+	var deleteErr error
+	args.ForEach(func(key, _ gjson.Result) bool {
+		if deleteErr != nil {
+			return false
 		}
-		return true
+		k := key.String()
+		if _, ok := allowed[k]; ok {
+			return true
+		}
+		escapedKey := strings.ReplaceAll(k, ".", `\.`)
+		cleanedBytes, deleteErr = sjson.DeleteBytes(cleanedBytes, escapedKey)
+		return deleteErr == nil
 	})
-
-	out, err := json.Marshal(cleaned)
-	if err != nil {
+	if deleteErr != nil {
 		return argsRaw
 	}
-	return string(out)
+	return string(cleanedBytes)
 }
 
 // ConvertGeminiResponseToClaude performs sophisticated streaming response format conversion.

--- a/internal/translator/gemini/claude/gemini_claude_response_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_response_test.go
@@ -7,6 +7,28 @@ import (
 	"testing"
 )
 
+func TestSanitizeToolArgsForClaude_RemovesAllArgsWhenPropertiesMissingAndAdditionalPropertiesFalse(t *testing.T) {
+	schemaMap := map[string]string{
+		"strict_tool": `{"type":"object","additionalProperties":false}`,
+	}
+
+	got := sanitizeToolArgsForClaude(schemaMap, "strict_tool", `{"extra":"value","id":123}`)
+	if got != "{}" {
+		t.Fatalf("expected all args to be stripped, got %s", got)
+	}
+}
+
+func TestSanitizeToolArgsForClaude_PreservesAllowedLargeIntegerPrecision(t *testing.T) {
+	schemaMap := map[string]string{
+		"strict_tool": `{"type":"object","properties":{"id":{"type":"integer"}},"additionalProperties":false}`,
+	}
+
+	got := sanitizeToolArgsForClaude(schemaMap, "strict_tool", `{"id":9223372036854775807,"extra":"drop"}`)
+	if got != `{"id":9223372036854775807}` {
+		t.Fatalf("expected large integer to be preserved exactly, got %s", got)
+	}
+}
+
 func TestConvertGeminiResponseToClaude_SignatureOnlyPartDoesNotOpenEmptyTextBlock(t *testing.T) {
 	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
 	thinkingChunk := []byte(`{


### PR DESCRIPTION
Move mid-conversation Claude system messages into Gemini/Antigravity system instructions, avoid synthetic Gemini tool thought signatures, and sanitize Gemini tool call args against original Claude schemas.