### PR TITLE
fix(executor/openai-compat): use the last reported token counts across multiple stream usage chunks (#4053)

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/sjson"
@@ -393,11 +394,17 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		var param any
+		var finalDetail usage.Detail
+		// Publish accumulated usage on every exit path. sync.Once inside the
+		// reporter ensures only the first Publish/PublishFailure call wins.
+		defer func() {
+			reporter.Publish(ctx, finalDetail)
+		}()
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			if detail, ok := helps.ParseOpenAIStreamUsage(line); ok {
-				reporter.Publish(ctx, detail)
+				finalDetail = maxUsageDetailOpenAICompat(finalDetail, detail)
 			}
 			trimmedLine := bytes.TrimSpace(line)
 			if len(trimmedLine) == 0 {
@@ -434,7 +441,13 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		}
 		if errScan := scanner.Err(); errScan != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
-			reporter.PublishFailure(ctx, errScan)
+			// Only mark as failure when the upstream itself is at fault.
+			// If the client disconnected (ctx canceled) the tokens were
+			// already consumed upstream, so let the deferred Publish record
+			// the partial usage as a successful request instead.
+			if ctx.Err() == nil {
+				reporter.PublishFailure(ctx, errScan)
+			}
 			select {
 			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
 			case <-ctx.Done():
@@ -452,8 +465,6 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 				}
 			}
 		}
-		// Ensure we record the request if no usage chunk was ever seen
-		reporter.EnsurePublished(ctx)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }
@@ -795,3 +806,15 @@ func (e statusErr) Error() string {
 }
 func (e statusErr) StatusCode() int            { return e.code }
 func (e statusErr) RetryAfter() *time.Duration { return e.retryAfter }
+
+func maxUsageDetailOpenAICompat(a, b usage.Detail) usage.Detail {
+	return usage.Detail{
+		InputTokens:         max(a.InputTokens, b.InputTokens),
+		OutputTokens:        max(a.OutputTokens, b.OutputTokens),
+		ReasoningTokens:     max(a.ReasoningTokens, b.ReasoningTokens),
+		CachedTokens:        max(a.CachedTokens, b.CachedTokens),
+		CacheReadTokens:     max(a.CacheReadTokens, b.CacheReadTokens),
+		CacheCreationTokens: max(a.CacheCreationTokens, b.CacheCreationTokens),
+		TotalTokens:         max(a.TotalTokens, b.TotalTokens),
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -398,7 +398,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		// Publish accumulated usage on every exit path. sync.Once inside the
 		// reporter ensures only the first Publish/PublishFailure call wins.
 		defer func() {
-			reporter.Publish(ctx, finalDetail)
+			reporter.Publish(context.WithoutCancel(ctx), finalDetail)
 		}()
 		for scanner.Scan() {
 			line := scanner.Bytes()


### PR DESCRIPTION
### Summary
Fixes two bugs in the OpenAI-compat streaming executor's usage reporting:
1. **Only the first usage chunk was recorded** — `UsageReporter.Publish` uses `sync.Once`, so calling it inside the scan loop meant only the first usage-bearing SSE chunk was published; later chunks with the real cumulative totals were dropped. This also caused recorded latency to reflect time-to-first-usage-chunk rather than the full stream duration. Note that some providers send an early chunk where `prompt_tokens` is non-zero but `completion_tokens` and `total_tokens` are zero (e.g. `{"prompt_tokens":39320,"completion_tokens":0,"total_tokens":0}`) — since `prompt_tokens` is non-zero, an all-zero guard won't filter it, and `sync.Once` locks the record with zeros for the remaining fields.
2. **Client disconnects were incorrectly marked as upstream failures** — when the client disconnected mid-stream, `scanner.Err()` returned a `context.Canceled` error which was unconditionally passed to `PublishFailure`. This discarded the already-accumulated usage and marked the request as failed, even though upstream tokens had already been consumed.

### Also fixes
- #4053 

### Changes
- Accumulate usage across all stream chunks via `maxUsageDetailOpenAICompat` (field-wise `max` merge), then publish once via a `defer` closure that covers every goroutine exit path
- Replace the explicit `Publish` + `EnsurePublished` at the end of the goroutine with the deferred `Publish` (the deferred call with a zero `Detail` is equivalent to `EnsurePublished`)
- In the `scanner.Err()` branch, check `ctx.Err()` before calling `PublishFailure` — if the context is already canceled (client disconnect), skip it and let the deferred `Publish` record the partial usage as a successful request

### Files Changed
- `internal/runtime/executor/openai_compat_executor.go` 

### Test
- **Unit tests**: All 7 existing `TestOpenAICompat*` tests pass (`go test -v -run TestOpenAICompat ./internal/runtime/executor/...`), covering stream rejection of non-SSE JSON, keep-alive skipping, image generation passthrough, compact mode, and thinking suffix override
- **Manual testing**: Verified via production logs that client-disconnect scenarios now correctly record partial usage (e.g. `input_tokens=252 output_tokens=367 total_tokens=619`) as successful instead of marking them as failures