### PR TITLE
feat(websearch): forward web_search tool requests to a configurable target model

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -113,6 +113,19 @@ force-model-prefix: false
 # Default is false (disabled).
 passthrough-headers: false
 
+# Forward requests that carry an Anthropic web_search server tool (tools[].type starts with
+# "web_search", e.g. "web_search_20250305") to a different model. Useful when the requested
+# model's upstream does not support Anthropic's server-side web search.
+# The request body is forwarded unchanged; the existing pipeline (translation, auth selection,
+# headers, upstream model remapping) handles the target. The response model field is rewritten
+# back to the client's originally requested model so forwarding stays transparent.
+# A request whose model already equals the configured target is NOT forwarded (avoids a self-loop).
+# No target-capability validation is performed: forwarding to a target that cannot handle the
+# request is the user's responsibility.
+# websearch-forward:
+#   enable: false
+#   model: "deepseek" # target model (alias) to forward web_search requests to
+
 # Number of times to retry a request. Retries will occur if the HTTP response code is 403, 408, 500, 502, 503, or 504.
 request-retry: 3
 

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -55,6 +55,20 @@ type SDKConfig struct {
 	// NonStreamKeepAliveInterval controls how often blank lines are emitted for non-streaming responses.
 	// <= 0 disables keep-alives. Value is in seconds.
 	NonStreamKeepAliveInterval int `yaml:"nonstream-keepalive-interval,omitempty" json:"nonstream-keepalive-interval,omitempty"`
+
+	// WebSearchForward reroutes requests carrying an Anthropic web_search server tool
+	// (tools[].type = "web_search_*") to a different model, for upstreams that lack server-side
+	// web search. The request body is forwarded unchanged; the existing pipeline handles the target.
+	// The response model field is rewritten back to the client's originally requested model.
+	WebSearchForward WebSearchForwardConfig `yaml:"websearch-forward,omitempty" json:"websearch-forward,omitempty"`
+}
+
+// WebSearchForwardConfig controls rerouting of web_search tool requests to another model.
+type WebSearchForwardConfig struct {
+	// Enable activates web_search request forwarding.
+	Enable bool `yaml:"enable" json:"enable"`
+	// Model is the target model name (alias) to forward web_search requests to.
+	Model string `yaml:"model,omitempty" json:"model,omitempty"`
 }
 
 // StreamingConfig holds server streaming behavior configuration.

--- a/internal/config/web_search_forward_test.go
+++ b/internal/config/web_search_forward_test.go
@@ -1,0 +1,33 @@
+package config
+
+import "testing"
+
+func TestParseConfigBytes_WebSearchForward(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte(`
+websearch-forward:
+  enable: true
+  model: "deepseek"
+`))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+	if !cfg.WebSearchForward.Enable {
+		t.Fatal("WebSearchForward.Enable = false, want true")
+	}
+	if cfg.WebSearchForward.Model != "deepseek" {
+		t.Fatalf("WebSearchForward.Model = %q, want %q", cfg.WebSearchForward.Model, "deepseek")
+	}
+}
+
+func TestParseConfigBytes_WebSearchForwardDefault(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte(`port: 8317`))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+	if cfg.WebSearchForward.Enable {
+		t.Fatal("WebSearchForward.Enable = true, want false by default")
+	}
+	if cfg.WebSearchForward.Model != "" {
+		t.Fatalf("WebSearchForward.Model = %q, want empty by default", cfg.WebSearchForward.Model)
+	}
+}

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -713,12 +713,21 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 	if routeDecision.ExecutorPluginID != "" {
 		return h.executeWithPluginExecutor(ctx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, routeDecision.ExecutorPluginID, execOptions)
 	}
-	providers, normalizedModel, errMsg := h.providersForExecution(modelName, originalRequestedModel, allowImageModel, routeDecision)
+	routingModel := originalRequestedModel
+	if routeDecision.Provider == "" {
+		if target := h.webSearchForwardTarget(originalRequestedModel, rawJSON); target != "" {
+			routingModel = target
+		}
+	}
+	providers, normalizedModel, errMsg := h.providersForExecution(routingModel, originalRequestedModel, allowImageModel, routeDecision)
 	if errMsg != nil {
 		return nil, nil, errMsg
 	}
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = originalRequestedModel
+	if routingModel != originalRequestedModel {
+		reqMeta[coreexecutor.ForcedResponseModelMetadataKey] = originalRequestedModel
+	}
 	addModelExecutionSourceMetadata(reqMeta, execOptions.InternalSource)
 	setReasoningEffortMetadata(reqMeta, entryProtocol, normalizedModel, rawJSON)
 	setServiceTierMetadata(reqMeta, rawJSON)
@@ -779,12 +788,21 @@ func (h *BaseAPIHandler) executeCountWithAuthManager(ctx context.Context, handle
 	if routeDecision.ExecutorPluginID != "" {
 		return h.countWithPluginExecutor(ctx, handlerType, modelName, originalRequestedModel, rawJSON, alt, routeDecision.ExecutorPluginID, execOptions)
 	}
-	providers, normalizedModel, errMsg := h.providersForExecution(modelName, originalRequestedModel, false, routeDecision)
+	routingModel := originalRequestedModel
+	if routeDecision.Provider == "" {
+		if target := h.webSearchForwardTarget(originalRequestedModel, rawJSON); target != "" {
+			routingModel = target
+		}
+	}
+	providers, normalizedModel, errMsg := h.providersForExecution(routingModel, originalRequestedModel, false, routeDecision)
 	if errMsg != nil {
 		return nil, nil, errMsg
 	}
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = originalRequestedModel
+	if routingModel != originalRequestedModel {
+		reqMeta[coreexecutor.ForcedResponseModelMetadataKey] = originalRequestedModel
+	}
 	setReasoningEffortMetadata(reqMeta, handlerType, normalizedModel, rawJSON)
 	setServiceTierMetadata(reqMeta, rawJSON)
 	payload := rawJSON
@@ -1100,7 +1118,13 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	if routeDecision.ExecutorPluginID != "" {
 		return h.streamWithPluginExecutor(ctx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, routeDecision.ExecutorPluginID, execOptions)
 	}
-	providers, normalizedModel, errMsg := h.providersForExecution(modelName, originalRequestedModel, allowImageModel, routeDecision)
+	routingModel := originalRequestedModel
+	if routeDecision.Provider == "" {
+		if target := h.webSearchForwardTarget(originalRequestedModel, rawJSON); target != "" {
+			routingModel = target
+		}
+	}
+	providers, normalizedModel, errMsg := h.providersForExecution(routingModel, originalRequestedModel, allowImageModel, routeDecision)
 	if errMsg != nil {
 		errChan := make(chan *interfaces.ErrorMessage, 1)
 		errChan <- errMsg
@@ -1109,6 +1133,9 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	}
 	reqMeta := requestExecutionMetadata(ctx)
 	reqMeta[coreexecutor.RequestedModelMetadataKey] = originalRequestedModel
+	if routingModel != originalRequestedModel {
+		reqMeta[coreexecutor.ForcedResponseModelMetadataKey] = originalRequestedModel
+	}
 	addModelExecutionSourceMetadata(reqMeta, execOptions.InternalSource)
 	setReasoningEffortMetadata(reqMeta, entryProtocol, normalizedModel, rawJSON)
 	setServiceTierMetadata(reqMeta, rawJSON)

--- a/sdk/api/handlers/web_search_forward.go
+++ b/sdk/api/handlers/web_search_forward.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// webSearchToolTypePrefix is the common prefix of Anthropic's typed web_search server tools.
+// The full type is versioned with a date suffix (e.g. "web_search_20250305",
+// "web_search_20260209"); matching by prefix future-proofs detection against new versions.
+const webSearchToolTypePrefix = "web_search"
+
+// hasWebSearchTool reports whether the request payload declares an Anthropic web_search server
+// tool, i.e. any entry in the top-level "tools" array whose "type" starts with "web_search".
+//
+// Only Anthropic-format requests carry such typed tools, so this is the sole detection gate:
+// OpenAI tools use type "function" and Gemini uses "functionDeclarations", neither of which
+// matches.
+func hasWebSearchTool(rawJSON []byte) bool {
+	tools := gjson.GetBytes(rawJSON, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return false
+	}
+	for _, tool := range tools.Array() {
+		toolType := strings.ToLower(strings.TrimSpace(tool.Get("type").String()))
+		if strings.HasPrefix(toolType, webSearchToolTypePrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// webSearchForwardTarget returns the model that a web_search-bearing request should be
+// rerouted to, or "" when forwarding should not happen.
+//
+// The request body itself is never modified here — only the routing model is overridden by the
+// caller. No target-capability validation is performed; forwarding to a target that cannot
+// handle the request is the user's responsibility.
+//
+// Returns "" (no forwarding) when:
+//   - the feature is disabled,
+//   - no target model is configured,
+//   - the request carries no web_search tool,
+//   - the target equals the client-requested model (avoids a self-forward loop).
+func (h *BaseAPIHandler) webSearchForwardTarget(requestedModel string, rawJSON []byte) string {
+	cfg := h.Cfg
+	if cfg == nil || !cfg.WebSearchForward.Enable {
+		return ""
+	}
+	target := strings.TrimSpace(cfg.WebSearchForward.Model)
+	if target == "" {
+		return ""
+	}
+	if !hasWebSearchTool(rawJSON) {
+		return ""
+	}
+	if strings.EqualFold(target, strings.TrimSpace(requestedModel)) {
+		return ""
+	}
+	return target
+}

--- a/sdk/api/handlers/web_search_forward_test.go
+++ b/sdk/api/handlers/web_search_forward_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestHasWebSearchTool(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"basic 20250305", `{"tools":[{"type":"web_search_20250305","name":"web_search"}]}`, true},
+		{"20260209", `{"tools":[{"type":"web_search_20260209","name":"web_search"}]}`, true},
+		{"future dated version", `{"tools":[{"type":"web_search_20991231","name":"web_search"}]}`, true},
+		{"openai function tool", `{"tools":[{"type":"function","function":{"name":"foo"}}]}`, false},
+		{"empty type", `{"tools":[{"type":"","name":"x"}]}`, false},
+		{"missing tools field", `{"model":"glm"}`, false},
+		{"empty tools array", `{"tools":[]}`, false},
+		{"mixed function and web_search", `{"tools":[{"type":"function","function":{"name":"foo"}},{"type":"web_search_20250305","name":"web_search"}]}`, true},
+		{"tool without type field", `{"tools":[{"name":"web_search"}]}`, false},
+		{"invalid json", `{"tools":[`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasWebSearchTool([]byte(tt.body)); got != tt.want {
+				t.Errorf("hasWebSearchTool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWebSearchForwardTarget(t *testing.T) {
+	wsBody := `{"tools":[{"type":"web_search_20250305","name":"web_search"}]}`
+	noToolBody := `{"tools":[{"type":"function","function":{"name":"foo"}}]}`
+
+	tests := []struct {
+		name      string
+		enable    bool
+		model     string
+		requested string
+		body      string
+		want      string
+	}{
+		{"forwards when enabled with tool", true, "deepseek", "glm", wsBody, "deepseek"},
+		{"disabled returns empty", false, "deepseek", "glm", wsBody, ""},
+		{"empty target model returns empty", true, "  ", "glm", wsBody, ""},
+		{"no web_search tool returns empty", true, "deepseek", "glm", noToolBody, ""},
+		{"self-forward guard same model", true, "glm", "glm", wsBody, ""},
+		{"self-forward guard case-insensitive", true, "DeepSeek", "deepseek", wsBody, ""},
+		{"requested model trimmed before compare", true, "deepseek", " glm ", wsBody, "deepseek"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &BaseAPIHandler{Cfg: &config.SDKConfig{}}
+			h.Cfg.WebSearchForward.Enable = tt.enable
+			h.Cfg.WebSearchForward.Model = tt.model
+			if got := h.webSearchForwardTarget(tt.requested, []byte(tt.body)); got != tt.want {
+				t.Errorf("webSearchForwardTarget() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("nil cfg returns empty", func(t *testing.T) {
+		h := &BaseAPIHandler{}
+		if got := h.webSearchForwardTarget("glm", []byte(wsBody)); got != "" {
+			t.Errorf("webSearchForwardTarget() with nil Cfg = %q, want empty", got)
+		}
+	})
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2510,6 +2510,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
 		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		applyForcedResponseModel(opts, &aliasResult)
 		if len(models) == 0 {
 			continue
 		}
@@ -2612,6 +2613,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
 		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		applyForcedResponseModel(opts, &aliasResult)
 		if len(models) == 0 {
 			continue
 		}
@@ -2712,6 +2714,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
 		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		applyForcedResponseModel(opts, &aliasResult)
 		if len(models) == 0 {
 			continue
 		}
@@ -2924,6 +2927,35 @@ func requestedModelAliasFromOptions(opts cliproxyexecutor.Options, fallback stri
 	default:
 		return fallback
 	}
+}
+
+// applyForcedResponseModel rewrites aliasResult so the response model field is rewritten to the
+// client's originally requested model, when the request was rerouted transparently (e.g. web_search
+// forwarding sets ForcedResponseModelMetadataKey to the client model). It is a no-op when the
+// metadata key is absent, nil, or empty. This layers on top of the existing force-mapping rewrite
+// (rewriteForceMappedResponse / wrapStreamResult) without changing it.
+func applyForcedResponseModel(opts cliproxyexecutor.Options, aliasResult *OAuthModelAliasResult) {
+	if aliasResult == nil || len(opts.Metadata) == 0 {
+		return
+	}
+	raw, ok := opts.Metadata[cliproxyexecutor.ForcedResponseModelMetadataKey]
+	if !ok || raw == nil {
+		return
+	}
+	var model string
+	switch value := raw.(type) {
+	case string:
+		model = value
+	case []byte:
+		model = string(value)
+	default:
+		return
+	}
+	if model = strings.TrimSpace(model); model == "" {
+		return
+	}
+	aliasResult.ForceMapping = true
+	aliasResult.OriginalAlias = model
 }
 
 func reasoningEffortFromOptions(opts cliproxyexecutor.Options) string {
@@ -5137,6 +5169,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 		c.auth = preparedAuth
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth.ID)
 		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(c.auth, routeModel)
+		applyForcedResponseModel(creditsOpts, &aliasResult)
 		if len(models) == 0 {
 			continue
 		}
@@ -5188,6 +5221,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		c.auth = preparedAuth
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth.ID)
 		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(c.auth, routeModel)
+		applyForcedResponseModel(creditsOpts, &aliasResult)
 		if len(models) == 0 {
 			continue
 		}

--- a/sdk/cliproxy/auth/conductor_forced_response_model_test.go
+++ b/sdk/cliproxy/auth/conductor_forced_response_model_test.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestApplyForcedResponseModel(t *testing.T) {
+	base := func() OAuthModelAliasResult {
+		return OAuthModelAliasResult{UpstreamModel: "deepseek-chat", ForceMapping: false, OriginalAlias: ""}
+	}
+
+	t.Run("overrides when metadata present", func(t *testing.T) {
+		opts := cliproxyexecutor.Options{Metadata: map[string]any{
+			cliproxyexecutor.ForcedResponseModelMetadataKey: "glm",
+		}}
+		r := base()
+		applyForcedResponseModel(opts, &r)
+		if !r.ForceMapping {
+			t.Fatal("ForceMapping = false, want true")
+		}
+		if r.OriginalAlias != "glm" {
+			t.Fatalf("OriginalAlias = %q, want %q", r.OriginalAlias, "glm")
+		}
+		if r.UpstreamModel != "deepseek-chat" {
+			t.Fatalf("UpstreamModel = %q, want unchanged", r.UpstreamModel)
+		}
+	})
+
+	t.Run("overrides existing force-mapping", func(t *testing.T) {
+		opts := cliproxyexecutor.Options{Metadata: map[string]any{
+			cliproxyexecutor.ForcedResponseModelMetadataKey: "glm",
+		}}
+		r := OAuthModelAliasResult{ForceMapping: true, OriginalAlias: "deepseek-alias"}
+		applyForcedResponseModel(opts, &r)
+		if !r.ForceMapping || r.OriginalAlias != "glm" {
+			t.Fatalf("expected forced override to glm, got ForceMapping=%v OriginalAlias=%q", r.ForceMapping, r.OriginalAlias)
+		}
+	})
+
+	t.Run("no-op when metadata absent", func(t *testing.T) {
+		r := base()
+		applyForcedResponseModel(cliproxyexecutor.Options{}, &r)
+		if r.ForceMapping || r.OriginalAlias != "" {
+			t.Fatalf("expected no-op, got ForceMapping=%v OriginalAlias=%q", r.ForceMapping, r.OriginalAlias)
+		}
+	})
+
+	t.Run("no-op when value empty", func(t *testing.T) {
+		opts := cliproxyexecutor.Options{Metadata: map[string]any{
+			cliproxyexecutor.ForcedResponseModelMetadataKey: "   ",
+		}}
+		r := base()
+		applyForcedResponseModel(opts, &r)
+		if r.ForceMapping {
+			t.Fatalf("expected no-op for empty model, got ForceMapping=%v", r.ForceMapping)
+		}
+	})
+
+	t.Run("supports []byte value", func(t *testing.T) {
+		opts := cliproxyexecutor.Options{Metadata: map[string]any{
+			cliproxyexecutor.ForcedResponseModelMetadataKey: []byte("glm"),
+		}}
+		r := base()
+		applyForcedResponseModel(opts, &r)
+		if !r.ForceMapping || r.OriginalAlias != "glm" {
+			t.Fatalf("expected []byte to apply, got ForceMapping=%v OriginalAlias=%q", r.ForceMapping, r.OriginalAlias)
+		}
+	})
+
+	t.Run("nil aliasResult does not panic", func(t *testing.T) {
+		opts := cliproxyexecutor.Options{Metadata: map[string]any{
+			cliproxyexecutor.ForcedResponseModelMetadataKey: "glm",
+		}}
+		applyForcedResponseModel(opts, nil)
+	})
+}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -11,6 +11,11 @@ import (
 // RequestedModelMetadataKey stores the client-requested model name in Options.Metadata.
 const RequestedModelMetadataKey = "requested_model"
 
+// ForcedResponseModelMetadataKey, when set in Options.Metadata to a non-empty string, forces the
+// response model field to be rewritten to that value. Used by web_search forwarding to keep a
+// rerouted request transparent (the response reports the client's originally requested model).
+const ForcedResponseModelMetadataKey = "forced_response_model"
+
 // RequestPathMetadataKey stores the inbound HTTP request path (e.g. "/v1/images/generations") in Options.Metadata.
 // It is optional and may be absent for non-HTTP executions.
 const RequestPathMetadataKey = "request_path"


### PR DESCRIPTION
## Summary

Adds a global `websearch-forward` config (`{enable, model}`) that reroutes requests carrying an Anthropic `web_search` server tool (any `tools[].type` starting with `web_search`, e.g. `web_search_20250305`) to a configurable target model. Forwarding is transparent: the request body is forwarded unchanged to the existing pipeline (translation, auth selection, headers, upstream model remapping), and the response `model` field is rewritten back to the client's originally requested model so the client never sees the reroute.

No search shim is added — this is purely a routing override plus one response fix-up.

## Motivation

Many upstreams don't support Anthropic's server-side web search. Today, when Claude Code sends a `/v1/messages` request with a `web_search_*` tool to such an upstream, the tool is silently dropped or the call misbehaves. This lets operators reroute those requests to a model whose upstream can handle them (e.g. a `claude-api-key` whose upstream speaks the Anthropic protocol and can execute the tool), without building a search shim — just a routing decision.

## How it works

1. Handler detects a `web_search_*` tool via `gjson` prefix match on `tools[].type` (future-proofs dated variants).
2. The **routing** model is overridden to the configured target; the client's original model is preserved.
3. The original model is carried via a new executor metadata key (`ForcedResponseModelMetadataKey`).
4. The conductor applies that metadata at its existing `aliasResult` rewrite step, so both non-streaming (`rewriteForceMappedResponse`) and streaming (`wrapStreamResult` / `StreamRewriter`) responses report the client's model.

The existing force-mapping rewrite machinery is reused unchanged — no signature changes to it.

## Configuration

```yaml
websearch-forward:
  enable: true
  model: "deepseek"   # target model (alias), resolved by the existing pipeline
```

Global (`SDKConfig`), hot-reloadable. A request whose model already equals the configured target is **not** forwarded (avoids a self-loop). No target-capability validation is performed — forwarding to a target that cannot handle the request is existing pipeline behavior.

## Changes

- `internal/config/sdk_config.go` — `WebSearchForwardConfig` + field
- `config.example.yaml` — documented block
- `sdk/cliproxy/executor/types.go` — `ForcedResponseModelMetadataKey`
- `sdk/api/handlers/web_search_forward.go` (new) — `hasWebSearchTool`, `webSearchForwardTarget`
- `sdk/api/handlers/handlers.go` — routing override + metadata in the 3 execute paths
- `sdk/cliproxy/auth/conductor.go` — `applyForcedResponseModel` applied at the 5 `aliasResult` produce sites
- 3 test files

No changes to `internal/translator/` (the forwarded request's tool translation is existing behavior).

## Testing

- `gofmt` clean; `go build ./cmd/server` OK
- `go test ./...` — all packages pass; new unit tests cover detection (dated variants, mixed tools, no-op cases), the self-forward guard, config round-trip, and the forced-response-model override (applied / no-op).
