### PR TITLE
fix(codex): drop orphan tool calls in chat-completions translator

### DIFF
--- a/internal/translator/codex/openai/chat-completions/codex_openai_request.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request.go
@@ -93,6 +93,7 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 
 	// Extract system instructions from first system message (string or text object)
 	messages := gjson.GetBytes(rawJSON, "messages")
+	toolCallIDs, toolOutputIDs := openAIToolCallPairing(messages)
 	// if messages.IsArray() {
 	// 	arr := messages.Array()
 	// 	for i := 0; i < len(arr); i++ {
@@ -120,7 +121,10 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 			switch role {
 			case "tool":
 				// Handle tool response messages as top-level function_call_output objects
-				toolCallID := m.Get("tool_call_id").String()
+				toolCallID := strings.TrimSpace(m.Get("tool_call_id").String())
+				if toolCallID == "" || !toolCallIDs[toolCallID] {
+					continue
+				}
 				content := m.Get("content")
 
 				// Create function_call_output object
@@ -226,6 +230,10 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 						for j := 0; j < len(toolCallsArr); j++ {
 							tc := toolCallsArr[j]
 							if tc.Get("type").String() == "function" {
+								callID := strings.TrimSpace(tc.Get("id").String())
+								if callID == "" || !toolOutputIDs[callID] {
+									continue
+								}
 								// Create function_call as top-level object
 								funcCall := []byte(`{}`)
 								funcCall, _ = sjson.SetBytes(funcCall, "type", "function_call")
@@ -371,6 +379,36 @@ func ConvertOpenAIRequestToCodex(modelName string, inputRawJSON []byte, stream b
 
 	out, _ = sjson.SetBytes(out, "store", false)
 	return out
+}
+
+func openAIToolCallPairing(messages gjson.Result) (callIDs map[string]bool, outputIDs map[string]bool) {
+	callIDs = make(map[string]bool)
+	outputIDs = make(map[string]bool)
+	if !messages.IsArray() {
+		return callIDs, outputIDs
+	}
+	for _, m := range messages.Array() {
+		switch strings.TrimSpace(m.Get("role").String()) {
+		case "assistant":
+			toolCalls := m.Get("tool_calls")
+			if !toolCalls.IsArray() {
+				continue
+			}
+			for _, tc := range toolCalls.Array() {
+				if tc.Get("type").String() != "function" {
+					continue
+				}
+				if id := strings.TrimSpace(tc.Get("id").String()); id != "" {
+					callIDs[id] = true
+				}
+			}
+		case "tool":
+			if id := strings.TrimSpace(m.Get("tool_call_id").String()); id != "" {
+				outputIDs[id] = true
+			}
+		}
+	}
+	return callIDs, outputIDs
 }
 
 func setToolCallOutputContent(funcOutput []byte, content gjson.Result) []byte {

--- a/internal/translator/codex/openai/chat-completions/codex_openai_request_test.go
+++ b/internal/translator/codex/openai/chat-completions/codex_openai_request_test.go
@@ -804,6 +804,46 @@ func TestCallIDsMatchBetweenCallAndOutput(t *testing.T) {
 	}
 }
 
+func TestOrphanToolCallDropped(t *testing.T) {
+	input := []byte(`{
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": "Check status"},
+			{
+				"role": "assistant",
+				"content": null,
+				"tool_calls": [
+					{"id": "call_orphan", "type": "function", "function": {"name": "run_shell_command", "arguments": "{}"}},
+					{"id": "call_ok", "type": "function", "function": {"name": "run_shell_command", "arguments": "{}"}}
+				]
+			},
+			{"role": "tool", "tool_call_id": "call_ok", "content": "{\"cancelled\":true}"}
+		],
+		"tools": [
+			{"type": "function", "function": {"name": "run_shell_command", "description": "Run", "parameters": {"type": "object", "properties": {}}}}
+		]
+	}`)
+
+	out := ConvertOpenAIRequestToCodex("gpt-4o", input, true)
+	items := gjson.GetBytes(out, "input").Array()
+
+	for _, item := range items {
+		if item.Get("type").String() == "function_call" && item.Get("call_id").String() == "call_orphan" {
+			t.Fatalf("orphan function_call should be dropped, got input: %s", gjson.GetBytes(out, "input").Raw)
+		}
+	}
+
+	foundOK := false
+	for _, item := range items {
+		if item.Get("type").String() == "function_call" && item.Get("call_id").String() == "call_ok" {
+			foundOK = true
+		}
+	}
+	if !foundOK {
+		t.Fatalf("expected function_call for call_ok, got: %s", gjson.GetBytes(out, "input").Raw)
+	}
+}
+
 // Tools array should carry over to the Responses format output.
 func TestToolsDefinitionTranslated(t *testing.T) {
 	input := []byte(`{


### PR DESCRIPTION
## Summary

Drop unmatched `assistant.tool_calls` / `role: tool` pairs when translating OpenAI Chat Completions requests to Codex Responses in `ConvertOpenAIRequestToCodex`, so upstream no longer returns HTTP 400 for orphan `function_call` items.

## Problem

On `/v1/chat/completions` → Codex, a long thread can fail with:

```
No tool output found for function call call_xxx
invalid_request_error, param: input
```

Request logs show a valid-looking client history where one `tool_calls` entry has no matching `role: tool` message (common when a tool run is cancelled or never completed). The translator still emitted the corresponding `function_call` into Responses `input`, which Codex rejects.

PR #2141 already skips empty assistant messages when only `tool_calls` are present. The Responses WebSocket path also repairs or drops orphan `function_call` / `function_call_output` pairs (`openai_responses_websocket_toolcall_repair.go`). The chat-completions translator did not apply the same pairing guard.

## Fix

- Add `openAIToolCallPairing(messages)` to collect assistant `tool_calls` IDs and `tool` message `tool_call_id` values.
- Emit `function_call` only when a matching tool result exists in the same request.
- Skip `role: tool` rows whose `tool_call_id` has no matching assistant call.

## Tests

```bash
go test ./internal/translator/codex/openai/chat-completions -run TestOrphanToolCallDropped -count=1
go test ./internal/translator/codex/openai/chat-completions -count=1
go build -o test-output ./cmd/server && rm test-output
```

Regression coverage: `TestOrphanToolCallDropped` (one paired call kept, one orphan call dropped).

## Notes

Behavior matches the existing WebSocket orphan-drop policy, scoped to the chat-completions → Codex translation path only. Sanitized request-log excerpts can be provided on request if an issue reference is needed.
