### PR TITLE
fix(claude): buffer complete SSE events before forwarding in direct-passthrough stream

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -545,6 +545,12 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if responseFormat == to {
 			scanner := bufio.NewScanner(decodedBody)
 			scanner.Buffer(nil, 52_428_800) // 50MB
+			// Accumulate lines into complete SSE events before sending.
+			// A complete event is delimited by a blank line. Sending whole
+			// events atomically prevents the downstream keep-alive ticker
+			// from inserting heartbeats between the event: and data: lines
+			// of the same SSE frame.
+			var eventBuf []byte
 			for scanner.Scan() {
 				line := scanner.Bytes()
 				helps.AppendAPIResponseChunk(ctx, e.cfg, line)
@@ -552,12 +558,23 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 					reporter.Publish(ctx, detail)
 				}
 				line = restoreClaudeOAuthToolNamesFromStreamLine(line, claudeToolPrefix, auth.ToolPrefixDisabled(), oauthToolNamesReverseMap)
-				// Forward the line as-is to preserve SSE format
-				cloned := make([]byte, len(line)+1)
-				copy(cloned, line)
-				cloned[len(line)] = '\n'
+				eventBuf = append(eventBuf, line...)
+				eventBuf = append(eventBuf, '\n')
+				// Blank line signals end of an SSE event — flush the buffer.
+				if len(line) == 0 {
+					cloned := bytes.Clone(eventBuf)
+					eventBuf = eventBuf[:0]
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Payload: cloned}:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+			// Flush any trailing data that was not terminated by a blank line.
+			if len(eventBuf) > 0 {
 				select {
-				case out <- cliproxyexecutor.StreamChunk{Payload: cloned}:
+				case out <- cliproxyexecutor.StreamChunk{Payload: bytes.Clone(eventBuf)}:
 				case <-ctx.Done():
 					return
 				}


### PR DESCRIPTION
## Summary

Fixes #4121

The Claude executor direct-passthrough path (`responseFormat == to`) sent each upstream SSE line as a separate chunk. The downstream `ForwardStream` keep-alive ticker could fire between the `event:` and `data:` lines of the same SSE frame, injecting `": keep-alive\n\n"` that prematurely terminates the event. Clients then receive an event with empty data and fail with:

```
Error: Could not parse Anthropic SSE event content_block_delta: Unexpected end of JSON input
```

## Fix

Buffer lines in the executor until a blank line is encountered (the SSE event boundary), then send the entire accumulated event as a single atomic chunk. This ensures `ForwardStream` keep-alive heartbeats can only appear between complete events, never mid-frame.

## Scope

Only the Claude executor direct-passthrough branch is modified. All other streaming paths are unaffected because they either:
- Use `JSONPayload()` to extract pure JSON and re-frame downstream (Gemini, Antigravity)
- Output complete SSE frames via `AppendSSEEventBytes(..., trailingNewlines=2)` from translators
- Use downstream framers (`responsesSSEFramer`) or `"data: %s\n\n"` wrapping

## Testing

- `go test ./internal/runtime/executor/ -count=1` — PASS
- `go test ./sdk/api/handlers/... -count=1` — PASS