### PR TITLE
fix(cliproxy): keep original model ids routable with aliases

### DIFF
--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1951,7 +1951,7 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 				models = buildGeminiConfigModels(entry)
 			}
 			if authKind == "apikey" {
-				excluded = entry.ExcludedModels
+				excluded = expandExcludedModelsForConfigAliases(entry.ExcludedModels, entry.Models)
 			}
 		}
 		models = applyExcludedModels(models, excluded)
@@ -1962,7 +1962,7 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 				models = buildGeminiConfigModels(entry)
 			}
 			if authKind == "apikey" {
-				excluded = entry.ExcludedModels
+				excluded = expandExcludedModelsForConfigAliases(entry.ExcludedModels, entry.Models)
 			}
 		}
 		models = applyExcludedModels(models, excluded)
@@ -1974,7 +1974,7 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 				models = buildVertexCompatConfigModels(entry)
 			}
 			if authKind == "apikey" {
-				excluded = entry.ExcludedModels
+				excluded = expandExcludedModelsForConfigAliases(entry.ExcludedModels, entry.Models)
 			}
 		}
 		models = applyExcludedModels(models, excluded)
@@ -1992,7 +1992,7 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 				models = buildClaudeConfigModels(entry)
 			}
 			if authKind == "apikey" {
-				excluded = entry.ExcludedModels
+				excluded = expandExcludedModelsForConfigAliases(entry.ExcludedModels, entry.Models)
 			}
 		}
 		models = applyExcludedModels(models, excluded)
@@ -2018,7 +2018,7 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 				models = buildCodexConfigModels(entry)
 			}
 			if authKind == "apikey" {
-				excluded = entry.ExcludedModels
+				excluded = expandExcludedModelsForConfigAliases(entry.ExcludedModels, entry.Models)
 			}
 		}
 		models = applyExcludedModels(models, excluded)
@@ -2381,6 +2381,58 @@ func applyExcludedModels(models []*ModelInfo, excluded []string) []*ModelInfo {
 		}
 	}
 	return filtered
+}
+
+func expandExcludedModelsForConfigAliases[T modelEntry](excluded []string, models []T) []string {
+	if len(excluded) == 0 || len(models) == 0 {
+		return excluded
+	}
+	patterns := make([]string, 0, len(excluded))
+	seen := make(map[string]struct{}, len(excluded)+len(models)*2)
+	out := make([]string, 0, len(excluded)+len(models)*2)
+	add := func(model string) {
+		model = strings.ToLower(strings.TrimSpace(model))
+		if model == "" {
+			return
+		}
+		if _, exists := seen[model]; exists {
+			return
+		}
+		seen[model] = struct{}{}
+		out = append(out, model)
+	}
+	for _, item := range excluded {
+		trimmed := strings.ToLower(strings.TrimSpace(item))
+		if trimmed == "" {
+			continue
+		}
+		patterns = append(patterns, trimmed)
+		add(trimmed)
+	}
+	if len(patterns) == 0 {
+		return excluded
+	}
+	for i := range models {
+		name := strings.TrimSpace(models[i].GetName())
+		alias := strings.TrimSpace(models[i].GetAlias())
+		if name == "" || alias == "" || name == alias {
+			continue
+		}
+		nameKey := strings.ToLower(name)
+		aliasKey := strings.ToLower(alias)
+		matched := false
+		for _, pattern := range patterns {
+			if matchWildcard(pattern, nameKey) || matchWildcard(pattern, aliasKey) {
+				matched = true
+				break
+			}
+		}
+		if matched {
+			add(name)
+			add(alias)
+		}
+	}
+	return out
 }
 
 func applyModelPrefixes(models []*ModelInfo, prefix string, forceModelPrefix bool) []*ModelInfo {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2564,16 +2564,7 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		}
 		models = appendModelInfoIfUnique(models, info, seen)
 		if alias != "" && name != "" && alias != name {
-			models = appendModelInfoIfUnique(models, &ModelInfo{
-				ID:          name,
-				Object:      "model",
-				Created:     now,
-				OwnedBy:     compat.Name,
-				Type:        modelType,
-				DisplayName: name,
-				UserDefined: false,
-				Thinking:    thinking,
-			}, seen)
+			models = appendModelInfoIfUnique(models, configOriginalModelInfo(name, compat.Name, modelType, now, false, thinking), seen)
 		}
 	}
 	return models
@@ -2594,6 +2585,39 @@ func appendModelInfoIfUnique(models []*ModelInfo, info *ModelInfo, seen map[stri
 	seen[key] = struct{}{}
 	info.ID = modelID
 	return append(models, info)
+}
+
+func configOriginalModelInfo(name, ownedBy, modelType string, created int64, userDefined bool, thinking *registry.ThinkingSupport) *ModelInfo {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	if info := registry.LookupStaticModelInfo(name); info != nil {
+		info.ID = name
+		if info.Object == "" {
+			info.Object = "model"
+		}
+		if info.Created == 0 {
+			info.Created = created
+		}
+		info.OwnedBy = ownedBy
+		info.Type = modelType
+		if info.DisplayName == "" {
+			info.DisplayName = name
+		}
+		info.UserDefined = false
+		return info
+	}
+	return &ModelInfo{
+		ID:          name,
+		Object:      "model",
+		Created:     created,
+		OwnedBy:     ownedBy,
+		Type:        modelType,
+		DisplayName: name,
+		UserDefined: userDefined,
+		Thinking:    thinking,
+	}
 }
 
 func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*ModelInfo {
@@ -2633,19 +2657,7 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 		}
 		out = appendModelInfoIfUnique(out, info, seen)
 		if name != "" && alias != name {
-			nameInfo := &ModelInfo{
-				ID:          name,
-				Object:      "model",
-				Created:     now,
-				OwnedBy:     ownedBy,
-				Type:        modelType,
-				DisplayName: name,
-				UserDefined: true,
-			}
-			if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
-				nameInfo.Thinking = upstream.Thinking
-			}
-			out = appendModelInfoIfUnique(out, nameInfo, seen)
+			out = appendModelInfoIfUnique(out, configOriginalModelInfo(name, ownedBy, modelType, now, true, info.Thinking), seen)
 		}
 	}
 	return out

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2540,9 +2540,8 @@ func appendModelInfoIfUnique(models []*ModelInfo, info *ModelInfo, seen map[stri
 		return models
 	}
 	seen[key] = struct{}{}
-	clone := *info
-	clone.ID = modelID
-	return append(models, &clone)
+	info.ID = modelID
+	return append(models, info)
 }
 
 func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*ModelInfo {

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2605,6 +2605,9 @@ func configOriginalModelInfo(name, ownedBy, modelType string, created int64, use
 		if info.DisplayName == "" {
 			info.DisplayName = name
 		}
+		if thinking != nil {
+			info.Thinking = thinking
+		}
 		info.UserDefined = false
 		return info
 	}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2479,12 +2479,15 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		return nil
 	}
 	now := time.Now().Unix()
-	models := make([]*ModelInfo, 0, len(compat.Models))
+	models := make([]*ModelInfo, 0, len(compat.Models)*2)
+	seen := make(map[string]struct{}, len(compat.Models)*2)
 	for i := range compat.Models {
 		model := compat.Models[i]
-		modelID := strings.TrimSpace(model.Alias)
+		alias := strings.TrimSpace(model.Alias)
+		name := strings.TrimSpace(model.Name)
+		modelID := alias
 		if modelID == "" {
-			modelID = strings.TrimSpace(model.Name)
+			modelID = name
 		}
 		if modelID == "" {
 			continue
@@ -2497,7 +2500,7 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		if thinking == nil && !model.Image {
 			thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
 		}
-		models = append(models, &ModelInfo{
+		info := &ModelInfo{
 			ID:          modelID,
 			Object:      "model",
 			Created:     now,
@@ -2506,9 +2509,40 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 			DisplayName: modelID,
 			UserDefined: false,
 			Thinking:    thinking,
-		})
+		}
+		models = appendModelInfoIfUnique(models, info, seen)
+		if alias != "" && name != "" && !strings.EqualFold(alias, name) {
+			models = appendModelInfoIfUnique(models, &ModelInfo{
+				ID:          name,
+				Object:      "model",
+				Created:     now,
+				OwnedBy:     compat.Name,
+				Type:        modelType,
+				DisplayName: name,
+				UserDefined: false,
+				Thinking:    thinking,
+			}, seen)
+		}
 	}
 	return models
+}
+
+func appendModelInfoIfUnique(models []*ModelInfo, info *ModelInfo, seen map[string]struct{}) []*ModelInfo {
+	if info == nil {
+		return models
+	}
+	modelID := strings.TrimSpace(info.ID)
+	if modelID == "" {
+		return models
+	}
+	key := strings.ToLower(modelID)
+	if _, exists := seen[key]; exists {
+		return models
+	}
+	seen[key] = struct{}{}
+	clone := *info
+	clone.ID = modelID
+	return append(models, &clone)
 }
 
 func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*ModelInfo {
@@ -2516,8 +2550,8 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 		return nil
 	}
 	now := time.Now().Unix()
-	out := make([]*ModelInfo, 0, len(models))
-	seen := make(map[string]struct{}, len(models))
+	out := make([]*ModelInfo, 0, len(models)*2)
+	seen := make(map[string]struct{}, len(models)*2)
 	for i := range models {
 		model := models[i]
 		name := strings.TrimSpace(model.GetName())
@@ -2528,11 +2562,6 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 		if alias == "" {
 			continue
 		}
-		key := strings.ToLower(alias)
-		if _, exists := seen[key]; exists {
-			continue
-		}
-		seen[key] = struct{}{}
 		display := name
 		if display == "" {
 			display = alias
@@ -2551,7 +2580,22 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 				info.Thinking = upstream.Thinking
 			}
 		}
-		out = append(out, info)
+		out = appendModelInfoIfUnique(out, info, seen)
+		if name != "" && !strings.EqualFold(alias, name) {
+			nameInfo := &ModelInfo{
+				ID:          name,
+				Object:      "model",
+				Created:     now,
+				OwnedBy:     ownedBy,
+				Type:        modelType,
+				DisplayName: name,
+				UserDefined: true,
+			}
+			if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
+				nameInfo.Thinking = upstream.Thinking
+			}
+			out = appendModelInfoIfUnique(out, nameInfo, seen)
+		}
 	}
 	return out
 }

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2511,7 +2511,7 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 			Thinking:    thinking,
 		}
 		models = appendModelInfoIfUnique(models, info, seen)
-		if alias != "" && name != "" && !strings.EqualFold(alias, name) {
+		if alias != "" && name != "" && alias != name {
 			models = appendModelInfoIfUnique(models, &ModelInfo{
 				ID:          name,
 				Object:      "model",
@@ -2535,7 +2535,7 @@ func appendModelInfoIfUnique(models []*ModelInfo, info *ModelInfo, seen map[stri
 	if modelID == "" {
 		return models
 	}
-	key := strings.ToLower(modelID)
+	key := modelID
 	if _, exists := seen[key]; exists {
 		return models
 	}
@@ -2580,7 +2580,7 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 			}
 		}
 		out = appendModelInfoIfUnique(out, info, seen)
-		if name != "" && !strings.EqualFold(alias, name) {
+		if name != "" && alias != name {
 			nameInfo := &ModelInfo{
 				ID:          name,
 				Object:      "model",

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	internalregistry "github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -134,6 +135,98 @@ func TestRegisterModelsForAuth_OpenAICompatibilityImageModelType(t *testing.T) {
 	if chatModel.Thinking == nil {
 		t.Fatal("expected chat model to keep default thinking support")
 	}
+}
+
+func TestRegisterModelsForAuth_ConfigAliasKeepsOriginalModelRoutable(t *testing.T) {
+	testCases := []struct {
+		name          string
+		service       *Service
+		auth          *coreauth.Auth
+		provider      string
+		originalModel string
+		aliasModel    string
+	}{
+		{
+			name: "codex api key",
+			service: &Service{cfg: &config.Config{
+				CodexKey: []internalconfig.CodexKey{{
+					APIKey:  "codex-key",
+					BaseURL: "https://example.com",
+					Models: []internalconfig.CodexModel{{
+						Name:  "gpt-5.4-mini",
+						Alias: "GPT-5.4 Mini",
+					}},
+				}},
+			}},
+			auth: &coreauth.Auth{
+				ID:       "auth-codex-alias-route",
+				Provider: "codex",
+				Status:   coreauth.StatusActive,
+				Attributes: map[string]string{
+					"auth_kind": "api_key",
+					"api_key":   "codex-key",
+					"base_url":  "https://example.com",
+				},
+			},
+			provider:      "codex",
+			originalModel: "gpt-5.4-mini",
+			aliasModel:    "GPT-5.4 Mini",
+		},
+		{
+			name: "openai compatibility",
+			service: &Service{cfg: &config.Config{
+				OpenAICompatibility: []config.OpenAICompatibility{{
+					Name:    "compat",
+					BaseURL: "https://example.com/v1",
+					Models: []config.OpenAICompatibilityModel{{
+						Name:  "gpt-5.4-mini",
+						Alias: "GPT-5.4 Mini",
+					}},
+				}},
+			}},
+			auth: &coreauth.Auth{
+				ID:       "auth-openai-compat-alias-route",
+				Provider: "openai-compatibility",
+				Status:   coreauth.StatusActive,
+				Attributes: map[string]string{
+					"auth_kind":    "api_key",
+					"compat_name":  "compat",
+					"provider_key": "compat",
+				},
+			},
+			provider:      "compat",
+			originalModel: "gpt-5.4-mini",
+			aliasModel:    "GPT-5.4 Mini",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			modelRegistry := internalregistry.GetGlobalRegistry()
+			modelRegistry.UnregisterClient(tt.auth.ID)
+			t.Cleanup(func() {
+				modelRegistry.UnregisterClient(tt.auth.ID)
+			})
+
+			tt.service.registerModelsForAuth(context.Background(), tt.auth)
+
+			if !providersContain(modelRegistry.GetModelProviders(tt.aliasModel), tt.provider) {
+				t.Fatalf("alias model %q providers = %v, want %q", tt.aliasModel, modelRegistry.GetModelProviders(tt.aliasModel), tt.provider)
+			}
+			if !providersContain(modelRegistry.GetModelProviders(tt.originalModel), tt.provider) {
+				t.Fatalf("original model %q providers = %v, want %q", tt.originalModel, modelRegistry.GetModelProviders(tt.originalModel), tt.provider)
+			}
+		})
+	}
+}
+
+func providersContain(providers []string, want string) bool {
+	for _, provider := range providers {
+		if strings.EqualFold(strings.TrimSpace(provider), want) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.T) {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -198,6 +198,58 @@ func TestRegisterModelsForAuth_ConfigAliasKeepsOriginalModelRoutable(t *testing.
 			originalModel: "gpt-5.4-mini",
 			aliasModel:    "GPT-5.4 Mini",
 		},
+		{
+			name: "codex case-distinct alias",
+			service: &Service{cfg: &config.Config{
+				CodexKey: []internalconfig.CodexKey{{
+					APIKey:  "codex-case-key",
+					BaseURL: "https://example.com",
+					Models: []internalconfig.CodexModel{{
+						Name:  "gpt-5",
+						Alias: "GPT-5",
+					}},
+				}},
+			}},
+			auth: &coreauth.Auth{
+				ID:       "auth-codex-case-alias-route",
+				Provider: "codex",
+				Status:   coreauth.StatusActive,
+				Attributes: map[string]string{
+					"auth_kind": "api_key",
+					"api_key":   "codex-case-key",
+					"base_url":  "https://example.com",
+				},
+			},
+			provider:      "codex",
+			originalModel: "gpt-5",
+			aliasModel:    "GPT-5",
+		},
+		{
+			name: "openai compatibility case-distinct alias",
+			service: &Service{cfg: &config.Config{
+				OpenAICompatibility: []config.OpenAICompatibility{{
+					Name:    "compat-case",
+					BaseURL: "https://example.com/v1",
+					Models: []config.OpenAICompatibilityModel{{
+						Name:  "gpt-5",
+						Alias: "GPT-5",
+					}},
+				}},
+			}},
+			auth: &coreauth.Auth{
+				ID:       "auth-openai-compat-case-alias-route",
+				Provider: "openai-compatibility",
+				Status:   coreauth.StatusActive,
+				Attributes: map[string]string{
+					"auth_kind":    "api_key",
+					"compat_name":  "compat-case",
+					"provider_key": "compat-case",
+				},
+			},
+			provider:      "compat-case",
+			originalModel: "gpt-5",
+			aliasModel:    "GPT-5",
+		},
 	}
 
 	for _, tt := range testCases {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -293,6 +293,52 @@ func clientModelByID(models []*internalregistry.ModelInfo, id string) *internalr
 	return nil
 }
 
+func TestRegisterModelsForAuth_OpenAICompatibilityOriginalModelKeepsCompatThinking(t *testing.T) {
+	static := internalregistry.LookupStaticModelInfo("gemini-2.5-pro")
+	if static == nil {
+		t.Fatal("expected static gemini-2.5-pro metadata")
+	}
+	service := &Service{cfg: &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:    "compat-thinking",
+			BaseURL: "https://example.com/v1",
+			Models: []config.OpenAICompatibilityModel{{
+				Name:     "gemini-2.5-pro",
+				Alias:    "gemini-pro",
+				Thinking: &internalregistry.ThinkingSupport{Levels: []string{"low", "high"}},
+			}},
+		}},
+	}}
+	auth := &coreauth.Auth{
+		ID:       "auth-openai-compat-thinking-route",
+		Provider: "openai-compatibility",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind":    "api_key",
+			"compat_name":  "compat-thinking",
+			"provider_key": "compat-thinking",
+		},
+	}
+	modelRegistry := internalregistry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	registered := clientModelByID(modelRegistry.GetModelsForClient(auth.ID), "gemini-2.5-pro")
+	if registered == nil {
+		t.Fatal("expected original model to be registered")
+	}
+	if static.ContextLength > 0 && registered.ContextLength != static.ContextLength {
+		t.Fatalf("context length = %d, want static %d", registered.ContextLength, static.ContextLength)
+	}
+	if registered.Thinking == nil || len(registered.Thinking.Levels) != 2 || registered.Thinking.Levels[0] != "low" || registered.Thinking.Levels[1] != "high" {
+		t.Fatalf("thinking = %+v, want compat levels [low high]", registered.Thinking)
+	}
+}
+
 func providersContain(providers []string, want string) bool {
 	for _, provider := range providers {
 		if strings.EqualFold(strings.TrimSpace(provider), want) {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -281,6 +281,44 @@ func providersContain(providers []string, want string) bool {
 	return false
 }
 
+func TestRegisterModelsForAuth_ConfigAliasExclusionBlocksOriginalModelPair(t *testing.T) {
+	service := &Service{cfg: &config.Config{
+		CodexKey: []internalconfig.CodexKey{{
+			APIKey:         "codex-excluded-key",
+			BaseURL:        "https://example.com",
+			ExcludedModels: []string{"my-gpt"},
+			Models: []internalconfig.CodexModel{{
+				Name:  "gpt-5",
+				Alias: "my-gpt",
+			}},
+		}},
+	}}
+	auth := &coreauth.Auth{
+		ID:       "auth-codex-alias-excluded-route",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "api_key",
+			"api_key":   "codex-excluded-key",
+			"base_url":  "https://example.com",
+		},
+	}
+	modelRegistry := internalregistry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	if providersContain(modelRegistry.GetModelProviders("my-gpt"), "codex") {
+		t.Fatalf("alias model remained routable after exclusion")
+	}
+	if providersContain(modelRegistry.GetModelProviders("gpt-5"), "codex") {
+		t.Fatalf("original model remained routable after alias exclusion")
+	}
+}
+
 func TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability(t *testing.T) {
 	var sawFetch bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -268,8 +268,29 @@ func TestRegisterModelsForAuth_ConfigAliasKeepsOriginalModelRoutable(t *testing.
 			if !providersContain(modelRegistry.GetModelProviders(tt.originalModel), tt.provider) {
 				t.Fatalf("original model %q providers = %v, want %q", tt.originalModel, modelRegistry.GetModelProviders(tt.originalModel), tt.provider)
 			}
+			if static := internalregistry.LookupStaticModelInfo(tt.originalModel); static != nil && static.ContextLength > 0 {
+				registered := clientModelByID(modelRegistry.GetModelsForClient(tt.auth.ID), tt.originalModel)
+				if registered == nil {
+					t.Fatalf("registered original model %q not found", tt.originalModel)
+				}
+				if registered.ContextLength != static.ContextLength {
+					t.Fatalf("original model %q context length = %d, want static %d", tt.originalModel, registered.ContextLength, static.ContextLength)
+				}
+				if registered.UserDefined {
+					t.Fatalf("original model %q should preserve static metadata instead of being marked user-defined", tt.originalModel)
+				}
+			}
 		})
 	}
+}
+
+func clientModelByID(models []*internalregistry.ModelInfo, id string) *internalregistry.ModelInfo {
+	for _, model := range models {
+		if model != nil && model.ID == id {
+			return model
+		}
+	}
+	return nil
 }
 
 func providersContain(providers []string, want string) bool {


### PR DESCRIPTION
## Summary

- Register both configured aliases and their original upstream model IDs for config-backed model entries.
- Keep original model IDs routable for `codex-api-key` and `openai-compatibility` providers when aliases are configured.
- Add regression coverage for provider lookup through both alias and original model names.

## Why

When a config model had an alias, only the alias was registered in the global model registry. Requests using the original upstream model ID failed at provider lookup with `unknown provider for model` before executor-level alias resolution could map `name -> name`.

## Tests

- `go test ./sdk/cliproxy ./sdk/api/handlers -count=1 -timeout 120s`
- `go build -o /tmp/opencode/cli-proxy-api-pr-test ./cmd/server`