### PR TITLE
fix(executor): gate CountTokens system-prompt injection on cloak config

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -2008,31 +2008,17 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 	oauthToken := isClaudeOAuthToken(apiKey)
 	useCCHSigning := oauthToken || experimentalCCHSigningEnabled(cfg, auth)
 
-	// Get cloak config from ClaudeKey configuration
-	cloakCfg := resolveClaudeKeyCloakConfig(cfg, auth)
-	attrMode, attrStrict, attrWords, attrCache := getCloakConfigFromAuth(auth)
+	// Resolve cloak mode via shared helper (same precedence used by shouldCloakForCount).
+	cloakMode := resolveCloakMode(cfg, auth)
 
-	// Determine cloak settings. Precedence (low -> high):
-	//   built-in "auto" default
-	//   -> global disable-claude-cloak-mode switch (forces "never")
-	//   -> per-credential settings from auth attributes/metadata
-	//   -> per claude-api-key cloak config
-	cloakMode := "auto"
-	if cfg != nil && cfg.DisableClaudeCloakMode {
-		cloakMode = "never"
-	}
+	// Resolve remaining per-credential cloak settings (strict, sensitive words, cache).
+	cloakCfg := resolveClaudeKeyCloakConfig(cfg, auth)
+	_, attrStrict, attrWords, attrCache := getCloakConfigFromAuth(auth)
 	strictMode := attrStrict
 	sensitiveWords := attrWords
 	cacheUserID := attrCache
 
-	if attrMode != "" {
-		cloakMode = attrMode
-	}
-
 	if cloakCfg != nil {
-		if mode := strings.TrimSpace(cloakCfg.Mode); mode != "" {
-			cloakMode = mode
-		}
 		if cloakCfg.StrictMode {
 			strictMode = true
 		}
@@ -2073,9 +2059,10 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 	return payload, nil
 }
 
-// shouldCloakForCount mirrors the cloak-mode resolution in applyCloaking so the
-// count_tokens path only injects the system prompt when cloaking is required.
-func shouldCloakForCount(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth) bool {
+// resolveCloakMode resolves the effective cloak mode from global config,
+// per-credential auth attributes, and per claude-api-key cloak config.
+// Precedence (low → high): "auto" → disable-claude-cloak-mode → auth attr → claude-api-key.
+func resolveCloakMode(cfg *config.Config, auth *cliproxyauth.Auth) string {
 	cloakMode := "auto"
 	if cfg != nil && cfg.DisableClaudeCloakMode {
 		cloakMode = "never"
@@ -2088,7 +2075,13 @@ func shouldCloakForCount(ctx context.Context, cfg *config.Config, auth *cliproxy
 			cloakMode = mode
 		}
 	}
-	return helps.ShouldCloak(cloakMode, getClientUserAgent(ctx))
+	return cloakMode
+}
+
+// shouldCloakForCount uses the shared cloak-mode resolution so the count_tokens
+// path only injects the system prompt when cloaking is required.
+func shouldCloakForCount(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth) bool {
+	return helps.ShouldCloak(resolveCloakMode(cfg, auth), getClientUserAgent(ctx))
 }
 
 // ensureCacheControl injects cache_control breakpoints into the payload for optimal prompt caching.

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -691,7 +691,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 		body = rebuildMidSystemMessagesToTopLevel(body)
 	}
 
-	if !strings.HasPrefix(baseModel, "claude-3-5-haiku") {
+	if !strings.HasPrefix(baseModel, "claude-3-5-haiku") && shouldCloakForCount(ctx, e.cfg, auth) {
 		body = checkSystemInstructions(body)
 	}
 
@@ -2071,6 +2071,24 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 	}
 
 	return payload, nil
+}
+
+// shouldCloakForCount mirrors the cloak-mode resolution in applyCloaking so the
+// count_tokens path only injects the system prompt when cloaking is required.
+func shouldCloakForCount(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth) bool {
+	cloakMode := "auto"
+	if cfg != nil && cfg.DisableClaudeCloakMode {
+		cloakMode = "never"
+	}
+	if attrMode, _, _, _ := getCloakConfigFromAuth(auth); attrMode != "" {
+		cloakMode = attrMode
+	}
+	if cloakCfg := resolveClaudeKeyCloakConfig(cfg, auth); cloakCfg != nil {
+		if mode := strings.TrimSpace(cloakCfg.Mode); mode != "" {
+			cloakMode = mode
+		}
+	}
+	return helps.ShouldCloak(cloakMode, getClientUserAgent(ctx))
 }
 
 // ensureCacheControl injects cache_control breakpoints into the payload for optimal prompt caching.

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2887,3 +2887,91 @@ func TestRestoreClaudeOAuthToolNamesFromStreamLine_MixedCaseWithPrefix(t *testin
 		t.Fatalf("Glob should be restored to glob, got: %s", string(out))
 	}
 }
+
+func TestClaudeExecutor_CountTokens_SkipsCloakWhenDisabled(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"input_tokens":8}`))
+	}))
+	defer server.Close()
+
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+
+	tests := []struct {
+		name      string
+		cfg       *config.Config
+		auth      *cliproxyauth.Auth
+		userAgent string
+		wantCloak bool
+	}{
+		{
+			name:      "disable-claude-cloak-mode skips injection",
+			cfg:       &config.Config{DisableClaudeCloakMode: true},
+			auth:      &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123", "base_url": server.URL}},
+			wantCloak: false,
+		},
+		{
+			name:      "claude-cli user-agent auto-skips injection",
+			cfg:       &config.Config{},
+			auth:      &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123", "base_url": server.URL}},
+			userAgent: "claude-cli/2.1.70 (external, cli)",
+			wantCloak: false,
+		},
+		{
+			name: "per-credential cloak_mode=never skips injection",
+			cfg:  &config.Config{},
+			auth: &cliproxyauth.Auth{Attributes: map[string]string{
+				"api_key":    "key-123",
+				"base_url":   server.URL,
+				"cloak_mode": "never",
+			}},
+			wantCloak: false,
+		},
+		{
+			name:      "default config with non-claude UA still injects",
+			cfg:       &config.Config{},
+			auth:      &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123", "base_url": server.URL}},
+			userAgent: "some-other-client/1.0",
+			wantCloak: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seenBody = nil
+			executor := NewClaudeExecutor(tt.cfg)
+
+			ctx := context.Background()
+			if tt.userAgent != "" {
+				gin.SetMode(gin.TestMode)
+				ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+				ginReq := httptest.NewRequest(http.MethodPost, "http://localhost/v1/messages/count_tokens", nil)
+				ginReq.Header.Set("User-Agent", tt.userAgent)
+				ginCtx.Request = ginReq
+				ctx = context.WithValue(ctx, "gin", ginCtx)
+			}
+
+			_, err := executor.CountTokens(ctx, tt.auth, cliproxyexecutor.Request{
+				Model:   "claude-sonnet-4-20250514",
+				Payload: payload,
+			}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+			if err != nil {
+				t.Fatalf("CountTokens() error = %v", err)
+			}
+			if len(seenBody) == 0 {
+				t.Fatal("expected request body to be captured")
+			}
+
+			hasBilling := strings.Contains(string(seenBody), "x-anthropic-billing-header:")
+			if tt.wantCloak && !hasBilling {
+				t.Fatalf("expected system prompt injection but it was absent: %s", string(seenBody))
+			}
+			if !tt.wantCloak && hasBilling {
+				t.Fatalf("system prompt injection should be skipped but was present: %s", string(seenBody))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `CountTokens` unconditionally called `checkSystemInstructions()`, injecting ~2k tokens of Claude Code system prompt into every `count_tokens` upstream request — inflating token counts by a flat ~2k per entry
- The `Execute` path already gates this injection through `applyCloaking` → `ShouldCloak`, respecting `disable-claude-cloak-mode`, per-credential `cloak_mode`, and the client `User-Agent`
- Added `shouldCloakForCount()` that mirrors `applyCloaking`'s cloak-mode resolution chain, and gates the `checkSystemInstructions` call in `CountTokens` behind it

## Root cause

`CountTokens` (line 694) called `checkSystemInstructions(body)` without checking any cloak configuration. This injected the full billing header + agent identifier + static prompt (~1.5–2k tokens) into the payload sent to `/v1/messages/count_tokens`, which upstream counted and returned — making every context entry appear ~2k tokens larger than reality.

By contrast, the generation path (`Execute` → `applyCloaking`) properly checks:
1. Global `disable-claude-cloak-mode` config flag
2. Per-credential `cloak_mode` from auth attributes/metadata
3. Per `claude-api-key` cloak config block
4. Client `User-Agent` (auto mode skips cloaking for `claude-cli/*`)

The `CountTokens` path checked none of these.

## Changes

| File | Change |
|------|--------|
| `claude_executor.go:694` | Gate `checkSystemInstructions` behind `shouldCloakForCount()` |
| `claude_executor.go:2076` | New `shouldCloakForCount()` helper mirroring `applyCloaking`'s cloak-mode resolution |
| `claude_executor_test.go` | Table-driven test covering: global disable, `claude-cli` UA auto-skip, per-credential `cloak_mode=never`, and default cloaking for non-Claude clients |

## Test plan

- [x] `go build -o test-output ./cmd/server` compiles cleanly
- [x] `go test -run CountTokens ./internal/runtime/executor/` — all 5 CountTokens tests pass (3 existing + 1 new with 4 sub-cases)
- [x] `gofmt` clean
- [ ] Verify with a live CLIProxyAPI instance: Claude Code `/context` counts should match direct Anthropic counts (flat ~2k delta gone)

Closes #4103