### PR TITLE
fix(management): clear quota cooldown when enabling auth files

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1331,6 +1331,12 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update auth: %v", err)})
 		return
 	}
+	if !*req.Disabled {
+		if _, _, errReset := h.authManager.ResetQuota(ctx, targetAuth.ID); errReset != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to reset auth quota: %v", errReset)})
+			return
+		}
+	}
 
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "disabled": *req.Disabled})
 }

--- a/internal/api/handlers/management/quota_test.go
+++ b/internal/api/handlers/management/quota_test.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
@@ -130,5 +133,96 @@ func TestResetQuota_DoesNotAcceptAuthIDOrFileName(t *testing.T) {
 				t.Fatalf("status = %d, want %d with body %s", rec.Code, tt.wantCode, rec.Body.String())
 			}
 		})
+	}
+}
+
+func TestPatchAuthFileStatus_EnableClearsQuotaCooldownAndPersists(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	authDir := t.TempDir()
+	authFile := filepath.Join(authDir, "quota-disabled.json")
+	if errWrite := os.WriteFile(authFile, []byte(`{"type":"claude","email":"quota@example.com","disabled":true}`), 0o600); errWrite != nil {
+		t.Fatalf("write auth file: %v", errWrite)
+	}
+
+	store := sdkAuth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	manager := coreauth.NewManager(store, nil, nil)
+	next := time.Now().Add(time.Hour)
+	auth := &coreauth.Auth{
+		ID:             "quota-disabled.json",
+		FileName:       "quota-disabled.json",
+		Provider:       "claude",
+		Disabled:       true,
+		Status:         coreauth.StatusDisabled,
+		StatusMessage:  "disabled via management API",
+		Unavailable:    true,
+		NextRetryAfter: next,
+		Quota:          coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: next, BackoffLevel: 2},
+		Attributes: map[string]string{
+			"path": authFile,
+		},
+		Metadata: map[string]any{
+			"type":     "claude",
+			"email":    "quota@example.com",
+			"disabled": true,
+		},
+		ModelStates: map[string]*coreauth.ModelState{
+			"claude-quota-model": {
+				Status:         coreauth.StatusError,
+				StatusMessage:  "quota exhausted",
+				Unavailable:    true,
+				NextRetryAfter: next,
+				Quota:          coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: next, BackoffLevel: 2},
+			},
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/status", strings.NewReader(`{"name":"quota-disabled.json","disabled":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileStatus(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("quota-disabled.json")
+	if !ok || updated == nil {
+		t.Fatalf("updated auth missing")
+	}
+	if updated.Disabled || updated.Status != coreauth.StatusActive || updated.StatusMessage != "" || updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("updated auth state = disabled %v status %q message %q unavailable %v next %v", updated.Disabled, updated.Status, updated.StatusMessage, updated.Unavailable, updated.NextRetryAfter)
+	}
+	if updated.Quota.Exceeded || updated.Quota.Reason != "" || !updated.Quota.NextRecoverAt.IsZero() || updated.Quota.BackoffLevel != 0 {
+		t.Fatalf("updated quota = %+v, want cleared", updated.Quota)
+	}
+	state := updated.ModelStates["claude-quota-model"]
+	if state == nil {
+		t.Fatalf("updated model state missing")
+	}
+	if state.Status != coreauth.StatusActive || state.StatusMessage != "" || state.Unavailable || !state.NextRetryAfter.IsZero() {
+		t.Fatalf("updated model state = status %q message %q unavailable %v next %v", state.Status, state.StatusMessage, state.Unavailable, state.NextRetryAfter)
+	}
+	if state.Quota.Exceeded || state.Quota.Reason != "" || !state.Quota.NextRecoverAt.IsZero() || state.Quota.BackoffLevel != 0 {
+		t.Fatalf("updated model quota = %+v, want cleared", state.Quota)
+	}
+
+	raw, errRead := os.ReadFile(authFile)
+	if errRead != nil {
+		t.Fatalf("read auth file: %v", errRead)
+	}
+	var persisted map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &persisted); errUnmarshal != nil {
+		t.Fatalf("unmarshal persisted auth: %v", errUnmarshal)
+	}
+	if disabled, _ := persisted["disabled"].(bool); disabled {
+		t.Fatalf("persisted disabled = true, want false; raw=%s", string(raw))
 	}
 }


### PR DESCRIPTION
## Summary
- clear auth quota/cooldown state when re-enabling an auth file through management status API
- add regression coverage for enabling a disabled auth that still has 429 quota cooldown/model state

## Verification
- gofmt -w internal\\api\\handlers\\management\\auth_files.go internal\\api\\handlers\\management\\quota_test.go
- go test -count=1 -run TestPatchAuthFileStatus_EnableClearsQuotaCooldownAndPersists ./internal/api/handlers/management
- go test -count=1 ./...
- go build -o test-output.exe ./cmd/server