### PR TITLE
fix(auth): cooldown Antigravity credentials on invalid_grant instead of silent retry loop

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3734,7 +3734,18 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								state.NextRetryAfter = nextTransientErrorRetryAfter(now)
 							}
 						default:
-							state.NextRetryAfter = time.Time{}
+							if isOAuthInvalidGrantResultError(result.Error) {
+								if disableCooling {
+									state.NextRetryAfter = time.Time{}
+								} else {
+									next := now.Add(30 * time.Minute)
+									state.NextRetryAfter = next
+									suspendReason = "unauthorized"
+									shouldSuspendModel = true
+								}
+							} else {
+								state.NextRetryAfter = time.Time{}
+							}
 						}
 					}
 
@@ -3983,6 +3994,20 @@ func isUnauthorizedError(err error) bool {
 	return strings.Contains(raw, "status 401") || strings.Contains(raw, "401 unauthorized")
 }
 
+// isOAuthInvalidGrantMessage checks whether an error message indicates an OAuth
+// invalid_grant failure (revoked or expired refresh token). These are credential-level
+// errors that should be cooled down, not treated as invalid request payloads.
+func isOAuthInvalidGrantMessage(msg string) bool {
+	return strings.Contains(msg, "invalid_grant")
+}
+
+func isOAuthInvalidGrantResultError(err *Error) bool {
+	if err == nil {
+		return false
+	}
+	return isOAuthInvalidGrantMessage(err.Message) || isOAuthInvalidGrantMessage(err.Code)
+}
+
 func hasUnauthorizedAuthFailure(auth *Auth) bool {
 	if auth == nil || auth.LastError == nil {
 		return false
@@ -4152,6 +4177,9 @@ func isRequestInvalidError(err error) bool {
 	switch status {
 	case http.StatusBadRequest:
 		msg := err.Error()
+		if isOAuthInvalidGrantMessage(msg) {
+			return false
+		}
 		return strings.Contains(msg, "invalid_request_error") ||
 			strings.Contains(msg, "INVALID_ARGUMENT") ||
 			strings.Contains(msg, "FAILED_PRECONDITION")
@@ -4241,7 +4269,12 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.NextRetryAfter = nextTransientErrorRetryAfter(now)
 		}
 	default:
-		if auth.StatusMessage == "" {
+		if resultErr != nil && isOAuthInvalidGrantMessage(resultErr.Error()) {
+			auth.StatusMessage = "unauthorized"
+			if !disableCooling {
+				auth.NextRetryAfter = now.Add(30 * time.Minute)
+			}
+		} else if auth.StatusMessage == "" {
 			auth.StatusMessage = "request failed"
 		}
 	}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3737,9 +3737,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							if isOAuthInvalidGrantResultError(result.Error) {
 								if disableCooling {
 									state.NextRetryAfter = time.Time{}
+									auth.NextRetryAfter = time.Time{}
 								} else {
 									next := now.Add(30 * time.Minute)
 									state.NextRetryAfter = next
+									auth.NextRetryAfter = next
 									suspendReason = "unauthorized"
 									shouldSuspendModel = true
 								}
@@ -3998,14 +4000,14 @@ func isUnauthorizedError(err error) bool {
 // invalid_grant failure (revoked or expired refresh token). These are credential-level
 // errors that should be cooled down, not treated as invalid request payloads.
 func isOAuthInvalidGrantMessage(msg string) bool {
-	return strings.Contains(msg, "invalid_grant")
+	return strings.Contains(strings.ToLower(msg), "invalid_grant")
 }
 
 func isOAuthInvalidGrantResultError(err *Error) bool {
 	if err == nil {
 		return false
 	}
-	return isOAuthInvalidGrantMessage(err.Message) || isOAuthInvalidGrantMessage(err.Code)
+	return isOAuthInvalidGrantMessage(err.Error())
 }
 
 func hasUnauthorizedAuthFailure(auth *Auth) bool {
@@ -4271,7 +4273,9 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	default:
 		if resultErr != nil && isOAuthInvalidGrantMessage(resultErr.Error()) {
 			auth.StatusMessage = "unauthorized"
-			if !disableCooling {
+			if disableCooling {
+				auth.NextRetryAfter = time.Time{}
+			} else {
 				auth.NextRetryAfter = now.Add(30 * time.Minute)
 			}
 		} else if auth.StatusMessage == "" {

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -152,6 +152,87 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 }
 
+func TestMarkResultInvalidGrantAppliesCooldown(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-invalid-grant",
+		Provider: "antigravity",
+		Metadata: map[string]any{"type": "antigravity"},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register returned error: %v", errRegister)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "antigravity",
+		Model:    "claude-sonnet-4-20250514",
+		Success:  false,
+		Error: &Error{
+			Code:       "invalid_request_error",
+			Message:    `{"error":"invalid_grant","error_description":"Bad Request"}`,
+			HTTPStatus: http.StatusBadRequest,
+		},
+	})
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("expected auth to exist")
+	}
+	state := updated.ModelStates["claude-sonnet-4-20250514"]
+	if state == nil {
+		t.Fatal("expected model state after failure")
+	}
+	if state.NextRetryAfter.IsZero() {
+		t.Fatal("expected cooldown (non-zero NextRetryAfter) for invalid_grant, got zero")
+	}
+	if !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("expected cooldown in the future, got %v", state.NextRetryAfter)
+	}
+}
+
+func TestApplyAuthFailureStateInvalidGrantAppliesCooldown(t *testing.T) {
+	now := time.Now()
+	invalidGrantErr := &Error{
+		Code:       "invalid_request_error",
+		Message:    `{"error":"invalid_grant","error_description":"Bad Request"}`,
+		HTTPStatus: http.StatusBadRequest,
+	}
+	auth := &Auth{ID: "auth-grant-cooldown"}
+
+	applyAuthFailureState(auth, invalidGrantErr, nil, now, false)
+
+	if auth.StatusMessage != "unauthorized" {
+		t.Fatalf("StatusMessage = %q, want %q", auth.StatusMessage, "unauthorized")
+	}
+	if auth.NextRetryAfter.IsZero() {
+		t.Fatal("expected NextRetryAfter to be set for invalid_grant")
+	}
+	if !auth.NextRetryAfter.Equal(now.Add(30 * time.Minute)) {
+		t.Fatalf("NextRetryAfter = %v, want %v", auth.NextRetryAfter, now.Add(30*time.Minute))
+	}
+}
+
+func TestIsRequestInvalidErrorExcludesInvalidGrant(t *testing.T) {
+	grantErr := &Error{
+		Code:       "invalid_request_error",
+		Message:    `{"error":"invalid_grant","error_description":"Bad Request"}`,
+		HTTPStatus: http.StatusBadRequest,
+	}
+	if isRequestInvalidError(grantErr) {
+		t.Fatal("isRequestInvalidError should return false for invalid_grant wrapped in invalid_request_error")
+	}
+
+	normalBadReq := &Error{
+		Code:       "invalid_request_error",
+		Message:    "invalid parameter: temperature must be between 0 and 2",
+		HTTPStatus: http.StatusBadRequest,
+	}
+	if !isRequestInvalidError(normalBadReq) {
+		t.Fatal("isRequestInvalidError should return true for genuine invalid_request_error")
+	}
+}
+
 func TestJitteredCooldownWaitBounds(t *testing.T) {
 	cases := []struct {
 		wait      time.Duration


### PR DESCRIPTION
## Summary

- Antigravity OAuth credentials returning HTTP 400 with `invalid_grant` (banned/revoked accounts) were never cooled down, causing the conductor to repeatedly select the bad credential
- `isRequestInvalidError` now excludes `invalid_grant` errors so the conductor tries other credentials instead of returning immediately
- `MarkResult` and `applyAuthFailureState` now treat `invalid_grant` like 401 unauthorized (30-minute cooldown + model suspension)

## Root cause

Two independent bugs conspire:

**Bug 1 — `isRequestInvalidError` false positive.** The Antigravity API wraps `invalid_grant` inside an `invalid_request_error` envelope. `isRequestInvalidError` matched the outer wrapper, returning `true` — this told the conductor to stop immediately without trying other credentials in the pool.

**Bug 2 — no cooldown in `MarkResult`.** When the error did reach `MarkResult`, the `default` case in the `statusCode` switch applied no cooldown (`NextRetryAfter = time.Time{}`). The bad credential was immediately eligible for reselection on the next request.

Combined effect: with multiple credentials, one valid and one banned, the banned credential kept being selected and blocking requests.

## Changes

| File | Change |
|------|--------|
| `conductor.go` | `isOAuthInvalidGrantMessage` + `isOAuthInvalidGrantResultError` helpers |
| `conductor.go:4155` | `isRequestInvalidError` returns `false` early when message contains `invalid_grant` |
| `conductor.go:3736` | `MarkResult` default case checks for `invalid_grant` and applies 401-like cooldown |
| `conductor.go:4272` | `applyAuthFailureState` default case applies same cooldown for `invalid_grant` |
| `cooldown_backoff_test.go` | 3 new tests: MarkResult cooldown, applyAuthFailureState cooldown, isRequestInvalidError exclusion |

## Tests

- `go test -run "Cooldown\|Backoff\|InvalidGrant\|IsRequestInvalid" ./sdk/cliproxy/auth/` — all 22 tests pass
- `go build -o test-output ./cmd/server` — compiles cleanly

Closes #4120