### PR TITLE
feat(translator): add response_format conversion in Chat Completions …

### DIFF
--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
@@ -75,6 +75,9 @@ func ConvertOpenAIRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 		}
 	}
 
+	// JSON structured output (OpenAI response_format -> Gemini responseMimeType/responseJsonSchema)
+	out = applyOpenAIResponseFormatToGemini(out, rawJSON)
+
 	// Map OpenAI modalities -> Gemini generationConfig.responseModalities
 	// e.g. "modalities": ["image", "text"] -> ["IMAGE", "TEXT"]
 	if mods := gjson.GetBytes(rawJSON, "modalities"); mods.Exists() && mods.IsArray() {
@@ -483,4 +486,30 @@ func openAIInputAudioMimeType(audioFormat string) string {
 	default:
 		return "audio/" + audioFormat
 	}
+}
+
+// applyOpenAIResponseFormatToGemini maps OpenAI Chat Completions response_format to Gemini
+// generationConfig structured-output fields. The schema is passed through raw (not cleaned)
+// to match the Responses-side translator (bc652c7): Gemini response structured output requires
+// additionalProperties:false on strict schemas and supports $defs/$ref, which the tool-calling
+// schema cleaner (util.CleanJSONSchemaForGemini) would strip.
+func applyOpenAIResponseFormatToGemini(out []byte, rawJSON []byte) []byte {
+	rf := gjson.GetBytes(rawJSON, "response_format")
+	if !rf.Exists() {
+		return out
+	}
+
+	formatType := strings.ToLower(strings.TrimSpace(rf.Get("type").String()))
+	switch formatType {
+	case "json_object":
+		out, _ = sjson.SetBytes(out, "generationConfig.responseMimeType", "application/json")
+	case "json_schema":
+		out, _ = sjson.SetBytes(out, "generationConfig.responseMimeType", "application/json")
+		out, _ = sjson.DeleteBytes(out, "generationConfig.responseSchema")
+		if schema := rf.Get("json_schema.schema"); schema.Exists() {
+			out, _ = sjson.SetRawBytes(out, "generationConfig.responseJsonSchema", []byte(schema.Raw))
+		}
+	}
+
+	return out
 }

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_request_test.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_request_test.go
@@ -182,3 +182,208 @@ func TestConvertOpenAIRequestToGeminiCleansToolSchemaRequiredFields(t *testing.T
 		t.Fatalf("required[1] = %q, want industry. Schema: %s", got, schema.Raw)
 	}
 }
+
+func TestConvertOpenAIRequestToGemini_ResponseFormatJSONSchema(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.1-flash-lite",
+		"temperature": 0.2,
+		"messages": [
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "text",
+						"text": "Return structured JSON."
+					}
+				]
+			}
+		],
+		"response_format": {
+			"type": "json_schema",
+			"json_schema": {
+				"name": "response",
+				"strict": true,
+				"schema": {
+					"type": "object",
+					"properties": {
+						"cleanedContent": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"cleanedContent"
+					],
+					"additionalProperties": false
+				}
+			}
+		}
+	}`
+
+	output := ConvertOpenAIRequestToGemini("gemini-3.1-flash-lite", []byte(inputJSON), false)
+	result := gjson.ParseBytes(output)
+	genConfig := result.Get("generationConfig")
+
+	if got := genConfig.Get("responseMimeType").String(); got != "application/json" {
+		t.Fatalf("responseMimeType = %q, want application/json. Output: %s", got, output)
+	}
+	schema := genConfig.Get("responseJsonSchema")
+	if !schema.Exists() {
+		t.Fatalf("responseJsonSchema missing. Output: %s", output)
+	}
+	if genConfig.Get("responseSchema").Exists() {
+		t.Fatalf("responseSchema should not be set with responseJsonSchema. Output: %s", output)
+	}
+	if got := schema.Get("type").String(); got != "object" {
+		t.Fatalf("schema type = %q, want object. Output: %s", got, output)
+	}
+	if got := schema.Get("properties.cleanedContent.type").String(); got != "string" {
+		t.Fatalf("cleanedContent type = %q, want string. Output: %s", got, output)
+	}
+	if additionalProperties := schema.Get("additionalProperties"); !additionalProperties.Exists() || additionalProperties.Bool() {
+		t.Fatalf("additionalProperties = %s, want false. Output: %s", additionalProperties.Raw, output)
+	}
+	if got := genConfig.Get("temperature").Float(); got != 0.2 {
+		t.Fatalf("temperature = %v, want 0.2. Output: %s", got, output)
+	}
+}
+
+func TestConvertOpenAIRequestToGemini_ResponseFormatJSONObject(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-flash-lite",
+		"messages": [{"role": "user", "content": "Return a JSON object."}],
+		"response_format": {
+			"type": "json_object"
+		}
+	}`
+
+	output := ConvertOpenAIRequestToGemini("gemini-3.1-flash-lite", []byte(inputJSON), false)
+	result := gjson.ParseBytes(output)
+	genConfig := result.Get("generationConfig")
+
+	if got := genConfig.Get("responseMimeType").String(); got != "application/json" {
+		t.Fatalf("responseMimeType = %q, want application/json. Output: %s", got, output)
+	}
+	if genConfig.Get("responseJsonSchema").Exists() {
+		t.Fatalf("responseJsonSchema should not be set for json_object. Output: %s", output)
+	}
+}
+
+func TestConvertOpenAIRequestToGemini_ResponseFormatAbsent(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-flash-lite",
+		"messages": [{"role": "user", "content": "plain text, no response_format"}],
+		"temperature": 0.5
+	}`
+
+	output := ConvertOpenAIRequestToGemini("gemini-3.1-flash-lite", []byte(inputJSON), false)
+	result := gjson.ParseBytes(output)
+
+	if result.Get("generationConfig.responseMimeType").Exists() {
+		t.Fatalf("responseMimeType should not be set when response_format absent. Output: %s", output)
+	}
+	if result.Get("generationConfig.responseJsonSchema").Exists() {
+		t.Fatalf("responseJsonSchema should not be set when response_format absent. Output: %s", output)
+	}
+	if got := result.Get("generationConfig.temperature").Float(); got != 0.5 {
+		t.Fatalf("temperature = %v, want 0.5. Output: %s", got, output)
+	}
+}
+
+func TestConvertOpenAIRequestToGemini_ResponseFormatJSONSchemaNoSchema(t *testing.T) {
+	// json_schema without an inner schema field: responseMimeType is still set,
+	// but responseJsonSchema is not (there is nothing to embed).
+	inputJSON := `{
+		"model": "gemini-flash-lite",
+		"messages": [{"role": "user", "content": "shape only"}],
+		"response_format": {
+			"type": "json_schema",
+			"json_schema": {
+				"name": "response"
+			}
+		}
+	}`
+
+	output := ConvertOpenAIRequestToGemini("gemini-3.1-flash-lite", []byte(inputJSON), false)
+	result := gjson.ParseBytes(output)
+	genConfig := result.Get("generationConfig")
+
+	if got := genConfig.Get("responseMimeType").String(); got != "application/json" {
+		t.Fatalf("responseMimeType = %q, want application/json. Output: %s", got, output)
+	}
+	if genConfig.Get("responseJsonSchema").Exists() {
+		t.Fatalf("responseJsonSchema should not be set when no schema provided. Output: %s", output)
+	}
+}
+
+func TestConvertOpenAIRequestToGemini_ResponseFormatUnknownType(t *testing.T) {
+	// An unrecognized response_format.type is a no-op: no responseMimeType,
+	// no responseJsonSchema, no spurious generationConfig created. Sibling
+	// fields like temperature still pass through.
+	inputJSON := `{
+		"model": "gemini-flash-lite",
+		"messages": [{"role": "user", "content": "plain text"}],
+		"temperature": 0.7,
+		"response_format": {
+			"type": "text"
+		}
+	}`
+
+	output := ConvertOpenAIRequestToGemini("gemini-3.1-flash-lite", []byte(inputJSON), false)
+	result := gjson.ParseBytes(output)
+
+	if result.Get("generationConfig.responseMimeType").Exists() {
+		t.Fatalf("responseMimeType should not be set for unknown type. Output: %s", output)
+	}
+	if result.Get("generationConfig.responseJsonSchema").Exists() {
+		t.Fatalf("responseJsonSchema should not be set for unknown type. Output: %s", output)
+	}
+	if got := result.Get("generationConfig.temperature").Float(); got != 0.7 {
+		t.Fatalf("temperature = %v, want 0.7. Output: %s", got, output)
+	}
+}
+
+func TestConvertOpenAIRequestToGemini_ResponseFormatPreservesUserGenerationConfig(t *testing.T) {
+	// A user-supplied generationConfig must be preserved; response_format only
+	// adds responseMimeType/responseJsonSchema on top rather than replacing it.
+	inputJSON := `{
+		"model": "gemini-flash-lite",
+		"messages": [{"role": "user", "content": "merge check"}],
+		"generationConfig": {
+			"temperature": 0.9,
+			"topP": 0.8
+		},
+		"response_format": {
+			"type": "json_schema",
+			"json_schema": {
+				"schema": {
+					"type": "object",
+					"properties": {"answer": {"type": "string"}},
+					"required": ["answer"],
+					"additionalProperties": false
+				}
+			}
+		}
+	}`
+
+	output := ConvertOpenAIRequestToGemini("gemini-3.1-flash-lite", []byte(inputJSON), false)
+	result := gjson.ParseBytes(output)
+	genConfig := result.Get("generationConfig")
+
+	if got := genConfig.Get("responseMimeType").String(); got != "application/json" {
+		t.Fatalf("responseMimeType = %q, want application/json. Output: %s", got, output)
+	}
+	schema := genConfig.Get("responseJsonSchema")
+	if !schema.Exists() {
+		t.Fatalf("responseJsonSchema missing. Output: %s", output)
+	}
+	if got := schema.Get("type").String(); got != "object" {
+		t.Fatalf("schema type = %q, want object. Output: %s", got, output)
+	}
+	// User-supplied generationConfig fields survive the merge.
+	if got := genConfig.Get("temperature").Float(); got != 0.9 {
+		t.Fatalf("user temperature = %v, want 0.9. Output: %s", got, output)
+	}
+	if got := genConfig.Get("topP").Float(); got != 0.8 {
+		t.Fatalf("user topP = %v, want 0.8. Output: %s", got, output)
+	}
+}


### PR DESCRIPTION
…to Gemini
## Summary

The Chat Completions → Gemini request translator (`internal/translator/gemini/openai/chat-completions/gemini_openai_request.go`) silently dropped OpenAI's `response_format` field. When a Chat Completions client requested JSON structured output, Gemini received no structured-output directive and returned free-form text.

This PR adds `response_format` → Gemini `generationConfig` conversion, mirroring the behavior the Responses → Gemini translator gained in #bc652c7 (`applyOpenAIResponsesTextFormatToGemini`, which handles the Responses API's `text.format` field).

| OpenAI Chat Completions | Gemini `generationConfig` |
|---|---|
| `response_format: {type: "json_object"}` | `responseMimeType = "application/json"` |
| `response_format: {type: "json_schema", json_schema: {schema: {...}}}` | `responseMimeType = "application/json"` + `responseJsonSchema = <schema>` (+ delete stale `responseSchema`) |

## Background: two different OpenAI shapes

OpenAI exposes structured output through **two different request shapes** depending on the API:

- **Responses API**: `text.format` → handled by `bc652c7` (`applyOpenAIResponsesTextFormatToGemini`)
- **Chat Completions API**: `response_format` (with the schema nested under `response_format.json_schema.schema`) → **not handled** (this PR fills the gap)

The Codex translator (`internal/translator/codex/openai/chat-completions/codex_openai_request.go:252`) already bridges chat-completions `response_format` → Responses `text.format`, confirming the structural difference. This PR brings the Gemini chat-completions path to parity with the Responses path.

## Changes

**One file changed + its test file. No new files, no shared helpers, no responses-side changes.**

### `internal/translator/gemini/openai/chat-completions/gemini_openai_request.go`

Added one function, `applyOpenAIResponseFormatToGemini(out, rawJSON []byte) []byte`, called from `ConvertOpenAIRequestToGemini` between the `n`/candidateCount and modalities blocks:

```go
// applyOpenAIResponseFormatToGemini maps OpenAI Chat Completions response_format to Gemini
// generationConfig structured-output fields. The schema is passed through raw (not cleaned)
// to match the Responses-side translator (bc652c7): Gemini response structured output requires
// additionalProperties:false on strict schemas and supports $defs/$ref, which the tool-calling
// schema cleaner (util.CleanJSONSchemaForGemini) would strip.
func applyOpenAIResponseFormatToGemini(out []byte, rawJSON []byte) []byte {
        rf := gjson.GetBytes(rawJSON, "response_format")
        if !rf.Exists() {
                return out
        }

        formatType := strings.ToLower(strings.TrimSpace(rf.Get("type").String()))
        switch formatType {
        case "json_object":
                if !gjson.GetBytes(out, "generationConfig").Exists() {
                        out, _ = sjson.SetRawBytes(out, "generationConfig", []byte(`{}`))
                }
                out, _ = sjson.SetBytes(out, "generationConfig.responseMimeType", "application/json")
        case "json_schema":
                if !gjson.GetBytes(out, "generationConfig").Exists() {
                        out, _ = sjson.SetRawBytes(out, "generationConfig", []byte(`{}`))
                }
                out, _ = sjson.SetBytes(out, "generationConfig.responseMimeType", "application/json")
                out, _ = sjson.DeleteBytes(out, "generationConfig.responseSchema")
                if schema := rf.Get("json_schema.schema"); schema.Exists() {
                        out, _ = sjson.SetRawBytes(out, "generationConfig.responseJsonSchema", []byte(schema.Raw))
                }
        }

        return out
}
```

### Design decision: raw schema passthrough (no `CleanJSONSchemaForGemini`)

The `json_schema.schema` is written to `generationConfig.responseJsonSchema` **raw**, exactly as `bc652c7` does. It is deliberately **not** run through `util.CleanJSONSchemaForGemini`.

Rationale: `CleanJSONSchemaForGemini` (`internal/util/gemini_schema.go`) is tuned for **Gemini tool-calling** schemas (`parametersJsonSchema`), and would actively harm response schemas:

- It deletes `additionalProperties` (`removeUnsupportedKeywords`), but Gemini response structured output **requires** `additionalProperties: false` on strict schemas — `bc652c7`'s own test asserts it must be preserved.
- It strips `$defs`/`$ref`/`definitions`/`title`/`nullable`, which response structured output supports.
- `convertEnumValuesToStrings` forces `type: "string"` on enums, corrupting numeric/boolean enum response schemas.

The same chat-completions file *does* use `CleanJSONSchemaForGemini` for **tool parameter** schemas (line ~382) — that is a different context (tool-calling) and correctly remains as-is. The two schema contexts face different Gemini constraints, so the tool-calling cleaner is the wrong tool for response schemas. Raw passthrough also keeps the two OpenAI→Gemini structured-output paths (Responses and Chat Completions) behaviorally identical.

## Tests

Added 6 tests to `internal/translator/gemini/openai/chat-completions/gemini_openai_request_test.go`, mirroring `bc652c7`'s coverage plus edge cases:

| Test | Verifies |
|---|---|
| `TestConvertOpenAIRequestToGemini_ResponseFormatJSONSchema` | `json_schema` sets `responseMimeType` + `responseJsonSchema` (raw, `additionalProperties:false` preserved), deletes stale `responseSchema`, preserves sibling `temperature` |
| `TestConvertOpenAIRequestToGemini_ResponseFormatJSONObject` | `json_object` sets `responseMimeType`, does not set `responseJsonSchema` |
| `TestConvertOpenAIRequestToGemini_ResponseFormatAbsent` | Absent `response_format` → no `responseMimeType`/`responseJsonSchema` set (regression guard) |
| `TestConvertOpenAIRequestToGemini_ResponseFormatJSONSchemaNoSchema` | `json_schema` without inner `schema` field → still sets `responseMimeType`, no `responseJsonSchema` |
| `TestConvertOpenAIRequestToGemini_ResponseFormatUnknownType` | Unknown `type` (e.g. `"text"`) → no-op, sibling fields unaffected |
| `TestConvertOpenAIRequestToGemini_ResponseFormatPreservesUserGenerationConfig` | User-supplied `generationConfig` is preserved (merged into, not replaced) |

All tests pass; no regressions in the existing package suite.

```
$ go test ./internal/translator/gemini/openai/chat-completions/
ok      github.com/router-for-me/CLIProxyAPI/v7/internal/translator/gemini/openai/chat-completions
```

## Verification (live, on a running container)

The change was rebuilt into the `cli-proxy-api:latest` Docker image (commit `39a2d71f`) and verified live against a running container at `https://cliproxy.savorcare.com/v1/chat/completions` with `gemini-2.5-flash`.

### 1. Upstream payload inspection (direct translator output)

To confirm the conversion is actually uploaded to Gemini (not just that the model happens to return JSON), the registered translator function was invoked directly with a sample request and its output inspected — this is the exact payload cliproxy sends to Gemini:

```json
{
  "contents": [{"role":"user","parts":[{"text":"Describe a person named Bob who is 25."}]}],
  "model": "gemini-2.5-flash",
  "generationConfig": {
    "responseMimeType": "application/json",
    "responseJsonSchema": {
      "type": "object",
      "properties": {"name": {"type":"string"}, "age": {"type":"integer"}},
      "required": ["name","age"],
      "additionalProperties": false
    }
  },
  "safetySettings": [...]
}
```

Both `responseMimeType` and `responseJsonSchema` are present, and `additionalProperties: false` is preserved raw — confirming the conversion reaches Gemini. (This bypasses the model entirely; it inspects the translator's output directly, which is possible because `ConvertOpenAIRequestToGemini` is a pure function registered via `init.go` as the OpenAI→Gemini request translator.)

### 2. Controlled A/B test (same prompt, with vs without `response_format`)

To rule out "the model returns JSON on its own," the same JSON-free prompt was sent twice with only `response_format` varying:

**Prompt:** `Tell me about the planet Mars.` (verified to contain no JSON/object/schema hints)

| | No `response_format` | `response_format: json_object` |
|---|---|---|
| Returned content | Long Markdown prose ("Mars, often called the **"Red Planet"**...") | Structured JSON object (`{"name":"Mars","category":"Planet",...}`) |
| Valid JSON? | ❌ No (free prose) | ✅ Yes |
| Starts with `{`? | ❌ No | ✅ Yes |

The only variable between A and B is `response_format`. Since A returns prose and B returns a JSON object, the structured output can only be driven by `response_format` being correctly translated to `responseMimeType` and uploaded to Gemini.

### 3. `json_schema` live test

```bash
curl -X POST .../v1/chat/completions -d '{
  "model": "gemini-2.5-flash",
  "messages": [{"role":"user","content":"Describe a person named Bob who is 25 years old."}],
  "response_format": {"type":"json_schema","json_schema":{"name":"person","strict":true,"schema":{
    "type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},
    "required":["name","age"],"additionalProperties":false}}}}'
```

Returned `{"name":"Bob","age":25}` — conforms to the schema, with no extra fields (`additionalProperties: false` enforced by Gemini).
