### PR TITLE
Fix thinking lookup for prefixed API-key models

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -222,7 +222,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -412,7 +412,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -765,7 +765,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -945,7 +945,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -1052,7 +1052,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -1211,7 +1211,7 @@ func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth
 	to := sdktranslator.FromString("codex")
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	body, err := thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err := thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -198,7 +198,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -422,7 +422,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		userPayload = opts.OriginalRequest
 	}
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -163,6 +164,102 @@ func TestCodexWebsocketsExecuteStreamPassesThroughUpstreamWebsocketPayloadForDow
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for upstream websocket payload")
 	}
+}
+
+func TestCodexWebsocketsUsesPrefixedThinkingLookup(t *testing.T) {
+	const provider = "codex"
+	const requestedModel = "free-provider/gpt-5-codex"
+	const upstreamModel = "gpt-5-codex"
+
+	reg := registry.GetGlobalRegistry()
+	clientID := "codex-websocket-prefixed-thinking-" + strings.ReplaceAll(t.Name(), "/", "-")
+	reg.RegisterClient(clientID, provider, []*registry.ModelInfo{
+		{
+			ID:      requestedModel,
+			Object:  "model",
+			Created: time.Now().Unix(),
+			OwnedBy: provider,
+			Type:    "codex",
+			Thinking: &registry.ThinkingSupport{
+				Levels: []string{"xhigh"},
+			},
+		},
+	})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	run := func(t *testing.T, stream bool) {
+		t.Helper()
+
+		upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+		capturedPayload := make(chan []byte, 1)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				t.Errorf("upgrade websocket: %v", err)
+				return
+			}
+			defer func() { _ = conn.Close() }()
+
+			_, payload, errRead := conn.ReadMessage()
+			if errRead != nil {
+				t.Errorf("read upstream websocket message: %v", errRead)
+				return
+			}
+			capturedPayload <- bytes.Clone(payload)
+			completed := []byte(`{"type":"response.completed","response":{"id":"resp-1","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)
+			if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+				t.Errorf("write completed websocket message: %v", errWrite)
+			}
+		}))
+		defer server.Close()
+
+		exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+		auth := &cliproxyauth.Auth{Attributes: map[string]string{
+			cliproxyauth.AttributeAuthKind: cliproxyauth.AuthKindAPIKey,
+			cliproxyauth.AttributeSource:   "config:codex[test]",
+			"api_key":                      "sk-test",
+			"base_url":                     server.URL,
+		}}
+		req := cliproxyexecutor.Request{
+			Model:   upstreamModel,
+			Payload: []byte(`{"model":"free-provider/gpt-5-codex","input":[{"type":"message","role":"user","content":"hello"}],"reasoning":{"effort":"xhigh"}}`),
+		}
+		opts := cliproxyexecutor.Options{
+			SourceFormat:   sdktranslator.FromString("openai-response"),
+			ResponseFormat: sdktranslator.FromString("openai-response"),
+			Metadata: map[string]any{
+				cliproxyexecutor.ThinkingLookupModelMetadataKey: requestedModel,
+			},
+		}
+
+		if stream {
+			result, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+			if err != nil {
+				t.Fatalf("ExecuteStream() error = %v", err)
+			}
+			for range result.Chunks {
+			}
+		} else {
+			if _, err := exec.Execute(context.Background(), auth, req, opts); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+		}
+
+		select {
+		case payload := <-capturedPayload:
+			if got := gjson.GetBytes(payload, "model").String(); got != upstreamModel {
+				t.Fatalf("upstream model = %s, want %s; payload=%s", got, upstreamModel, payload)
+			}
+			if got := gjson.GetBytes(payload, "reasoning.effort").String(); got != "xhigh" {
+				t.Fatalf("reasoning.effort = %s, want xhigh; payload=%s", got, payload)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for upstream websocket payload")
+		}
+	}
+
+	t.Run("execute", func(t *testing.T) { run(t, false) })
+	t.Run("stream", func(t *testing.T) { run(t, true) })
 }
 
 func TestCodexWebsocketsExecuteStreamPropagatesUpstreamErrorForDownstreamWebsocket(t *testing.T) {

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -148,7 +148,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -261,7 +261,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +390,7 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 	if gjson.GetBytes(body, "model").Exists() && targetName != "" {
 		body, _ = sjson.SetBytes(body, "model", targetName)
 	}
-	body, err = applyGeminiInteractionsThinking(body, req.Model)
+	body, err = applyGeminiInteractionsThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -466,7 +466,7 @@ func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cl
 	if gjson.GetBytes(body, "model").Exists() && targetName != "" {
 		body, _ = sjson.SetBytes(body, "model", targetName)
 	}
-	body, err = applyGeminiInteractionsThinking(body, req.Model)
+	body, err = applyGeminiInteractionsThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -615,7 +615,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	to := sdktranslator.FromString("gemini")
 	translatedReq := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	translatedReq, err := thinking.ApplyThinking(translatedReq, req.Model, from.String(), to.String(), e.Identifier())
+	translatedReq, err := thinking.ApplyThinking(translatedReq, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
@@ -795,8 +795,8 @@ func isNativeInteractionsAuth(auth *cliproxyauth.Auth) bool {
 	return strings.EqualFold(strings.TrimSpace(auth.Provider), "gemini-interactions")
 }
 
-func applyGeminiInteractionsThinking(body []byte, model string) ([]byte, error) {
-	return thinking.ApplyThinking(body, model, sdktranslator.FormatInteractions.String(), sdktranslator.FormatInteractions.String(), "gemini")
+func applyGeminiInteractionsThinking(body []byte, model string, providerKey string) ([]byte, error) {
+	return thinking.ApplyThinking(body, model, sdktranslator.FormatInteractions.String(), sdktranslator.FormatInteractions.String(), providerKey)
 }
 
 func applyGeminiInteractionsRevisionHeader(req *http.Request) {

--- a/internal/runtime/executor/gemini_executor_test.go
+++ b/internal/runtime/executor/gemini_executor_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -673,6 +675,35 @@ func TestGeminiExecutorNativeInteractionsAppliesThinkingSuffix(t *testing.T) {
 	}
 	if got := gjson.GetBytes(upstreamBody, "generation_config.thinking_summaries").String(); got != "auto" {
 		t.Fatalf("thinking_summaries = %q, want auto. Body: %s", got, string(upstreamBody))
+	}
+}
+
+func TestGeminiInteractionsThinkingUsesSelectedProviderKey(t *testing.T) {
+	const model = "shared-alias"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("gemini-shared-alias", "gemini", []*registry.ModelInfo{{
+		ID:       model,
+		Object:   "model",
+		OwnedBy:  "gemini",
+		Type:     "test",
+		Thinking: &registry.ThinkingSupport{Levels: []string{string(thinking.LevelLow)}},
+	}})
+	reg.RegisterClient("gemini-interactions-shared-alias", "gemini-interactions", []*registry.ModelInfo{{
+		ID:       model,
+		Object:   "model",
+		OwnedBy:  "gemini-interactions",
+		Type:     "test",
+		Thinking: &registry.ThinkingSupport{Levels: []string{string(thinking.LevelHigh)}},
+	}})
+	t.Cleanup(func() { reg.UnregisterClient("gemini-shared-alias") })
+	t.Cleanup(func() { reg.UnregisterClient("gemini-interactions-shared-alias") })
+
+	body, err := applyGeminiInteractionsThinking([]byte(`{"input":"hi"}`), model+"(high)", "gemini-interactions")
+	if err != nil {
+		t.Fatalf("applyGeminiInteractionsThinking() error = %v", err)
+	}
+	if got := gjson.GetBytes(body, "generation_config.thinking_level").String(); got != "high" {
+		t.Fatalf("thinking_level = %q, want high. Body: %s", got, string(body))
 	}
 }
 

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -331,7 +331,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
 		body = sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-		body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+		body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 		if err != nil {
 			return resp, err
 		}
@@ -456,7 +456,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -571,7 +571,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -716,7 +716,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = thinking.ApplyThinking(body, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -852,7 +852,7 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 
 	translatedReq := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	translatedReq, err := thinking.ApplyThinking(translatedReq, req.Model, from.String(), to.String(), e.Identifier())
+	translatedReq, err := thinking.ApplyThinking(translatedReq, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
@@ -943,7 +943,7 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 
 	translatedReq := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	translatedReq, err := thinking.ApplyThinking(translatedReq, req.Model, from.String(), to.String(), e.Identifier())
+	translatedReq, err := thinking.ApplyThinking(translatedReq, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/helps/thinking_lookup.go
+++ b/internal/runtime/executor/helps/thinking_lookup.go
@@ -1,0 +1,59 @@
+package helps
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func ThinkingLookupModelForAuth(auth *cliproxyauth.Auth, providerKey string, upstreamModel string, opts cliproxyexecutor.Options) string {
+	if !cliproxyauth.IsConfigProviderAuth(auth) {
+		return upstreamModel
+	}
+	lookupModel := PayloadThinkingLookupModel(opts, upstreamModel)
+	if providerHasLookupModel(providerKey, lookupModel) {
+		return lookupModel
+	}
+	return upstreamModel
+}
+
+func PayloadThinkingLookupModel(opts cliproxyexecutor.Options, fallback string) string {
+	if len(opts.Metadata) == 0 {
+		return fallback
+	}
+	raw, ok := opts.Metadata[cliproxyexecutor.ThinkingLookupModelMetadataKey]
+	if !ok || raw == nil {
+		return fallback
+	}
+	switch value := raw.(type) {
+	case string:
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	case []byte:
+		if trimmed := strings.TrimSpace(string(value)); trimmed != "" {
+			return trimmed
+		}
+	}
+	return fallback
+}
+
+func providerHasLookupModel(providerKey string, model string) bool {
+	providerKey = strings.TrimSpace(providerKey)
+	if providerKey == "" {
+		return false
+	}
+	modelID := strings.TrimSpace(thinking.ParseSuffix(model).ModelName)
+	if modelID == "" {
+		return false
+	}
+	for _, provider := range registry.GetGlobalRegistry().GetModelProviders(modelID) {
+		if strings.EqualFold(provider, providerKey) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/executor/helps/thinking_lookup_test.go
+++ b/internal/runtime/executor/helps/thinking_lookup_test.go
@@ -1,0 +1,128 @@
+package helps
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestThinkingLookupModelForConfigAPIKeyAuth(t *testing.T) {
+	const provider = "claude"
+	const requestedModel = "team-a/claude-sonnet"
+	const upstreamModel = "claude-sonnet"
+
+	reg := registry.GetGlobalRegistry()
+	clientID := fmt.Sprintf("thinking-lookup-config-apikey-%d", time.Now().UnixNano())
+	reg.RegisterClient(clientID, provider, []*registry.ModelInfo{
+		{
+			ID:          requestedModel,
+			Object:      "model",
+			Created:     time.Now().Unix(),
+			OwnedBy:     "anthropic",
+			Type:        "claude",
+			Thinking:    &registry.ThinkingSupport{Levels: []string{"low", "xhigh"}},
+			UserDefined: true,
+		},
+	})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.ThinkingLookupModelMetadataKey: requestedModel,
+		},
+	}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		cliproxyauth.AttributeAuthKind: cliproxyauth.AuthKindAPIKey,
+		cliproxyauth.AttributeAPIKey:   "test-key",
+		cliproxyauth.AttributeSource:   "config:claude[test-key]",
+	}}
+
+	if got := ThinkingLookupModelForAuth(auth, provider, upstreamModel, opts); got != requestedModel {
+		t.Fatalf("ThinkingLookupModelForAuth() = %q, want %q", got, requestedModel)
+	}
+
+	auth.Attributes[cliproxyauth.AttributeAuthKind] = cliproxyauth.AuthKindOAuth
+	if got := ThinkingLookupModelForAuth(auth, provider, upstreamModel, opts); got != upstreamModel {
+		t.Fatalf("oauth auth lookup = %q, want upstream model %q", got, upstreamModel)
+	}
+}
+
+func TestThinkingLookupModelForKeylessConfigAuth(t *testing.T) {
+	const provider = "openai-compatibility"
+	const requestedModel = "team-a/model"
+	const upstreamModel = "model"
+
+	reg := registry.GetGlobalRegistry()
+	clientID := fmt.Sprintf("thinking-lookup-keyless-%d", time.Now().UnixNano())
+	reg.RegisterClient(clientID, provider, []*registry.ModelInfo{{ID: requestedModel, Object: "model", Created: time.Now().Unix(), OwnedBy: "test", Type: "openai"}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		cliproxyauth.AttributeSource: "config:openai-compatibility[test]",
+	}}
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.ThinkingLookupModelMetadataKey: requestedModel,
+		},
+	}
+
+	if got := ThinkingLookupModelForAuth(auth, provider, upstreamModel, opts); got != requestedModel {
+		t.Fatalf("ThinkingLookupModelForAuth() = %q, want keyless config lookup model", got)
+	}
+}
+
+func TestThinkingLookupModelTrimsLookupModelBeforeRegistryLookup(t *testing.T) {
+	const provider = "openai-compatibility"
+	const requestedModel = "team-a/model"
+	const upstreamModel = "model"
+
+	reg := registry.GetGlobalRegistry()
+	clientID := fmt.Sprintf("thinking-lookup-trim-%d", time.Now().UnixNano())
+	reg.RegisterClient(clientID, provider, []*registry.ModelInfo{{ID: requestedModel, Object: "model", Created: time.Now().Unix(), OwnedBy: "test", Type: "openai"}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		cliproxyauth.AttributeAuthKind: cliproxyauth.AuthKindAPIKey,
+		cliproxyauth.AttributeAPIKey:   "test-key",
+		cliproxyauth.AttributeSource:   "config:openai-compatibility[test-key]",
+	}}
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.ThinkingLookupModelMetadataKey: "  " + requestedModel + "  ",
+		},
+	}
+
+	if got := ThinkingLookupModelForAuth(auth, provider, upstreamModel, opts); got != requestedModel {
+		t.Fatalf("ThinkingLookupModelForAuth() = %q, want trimmed lookup model", got)
+	}
+}
+
+func TestThinkingLookupModelIgnoresPreRouterRequestedModel(t *testing.T) {
+	const provider = "openai-compatibility"
+	const originalRequestedModel = "team-a/original-model"
+	const routedUpstreamModel = "routed-model"
+
+	reg := registry.GetGlobalRegistry()
+	clientID := fmt.Sprintf("thinking-lookup-router-%d", time.Now().UnixNano())
+	reg.RegisterClient(clientID, provider, []*registry.ModelInfo{{ID: originalRequestedModel, Object: "model", Created: time.Now().Unix(), OwnedBy: "test", Type: "openai"}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		cliproxyauth.AttributeAuthKind: cliproxyauth.AuthKindAPIKey,
+		cliproxyauth.AttributeAPIKey:   "test-key",
+		cliproxyauth.AttributeSource:   "config:openai-compatibility[test-key]",
+	}}
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.RequestedModelMetadataKey: originalRequestedModel,
+		},
+	}
+
+	if got := ThinkingLookupModelForAuth(auth, provider, routedUpstreamModel, opts); got != routedUpstreamModel {
+		t.Fatalf("ThinkingLookupModelForAuth() = %q, want routed upstream model", got)
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -114,7 +114,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, opts.Stream)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, opts.Stream)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = thinking.ApplyThinking(translated, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -315,7 +315,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = thinking.ApplyThinking(translated, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +586,7 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 
 	modelForCounting := baseModel
 
-	translated, err := thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err := thinking.ApplyThinking(translated, helps.ThinkingLookupModelForAuth(auth, e.Identifier(), req.Model, opts), from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/openai_compat_executor_thinking_test.go
+++ b/internal/runtime/executor/openai_compat_executor_thinking_test.go
@@ -1,0 +1,78 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/openai"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAICompatExecutorUsesPrefixedRequestedModelForThinkingLookup(t *testing.T) {
+	const provider = "free-provider"
+	const requestedModel = "free-provider/gemini-3.1-pro-preview"
+	const upstreamModel = "gemini-3.1-pro-preview"
+
+	reg := registry.GetGlobalRegistry()
+	clientID := fmt.Sprintf("openai-compat-prefixed-thinking-%d", time.Now().UnixNano())
+	reg.RegisterClient(clientID, provider, []*registry.ModelInfo{
+		{
+			ID:      requestedModel,
+			Object:  "model",
+			Created: time.Now().Unix(),
+			OwnedBy: provider,
+			Type:    "openai-compatibility",
+			Thinking: &registry.ThinkingSupport{
+				Levels: []string{"max", "xhigh", "high", "medium", "low", "minimal", "none", "auto"},
+			},
+		},
+	})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor(provider, &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		cliproxyauth.AttributeAuthKind: cliproxyauth.AuthKindAPIKey,
+		cliproxyauth.AttributeSource:   "config:openai-compatibility[test]",
+		"base_url":                     server.URL + "/v1",
+		"api_key":                      "test",
+	}}
+	payload := []byte(`{"model":"free-provider/gemini-3.1-pro-preview","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   upstreamModel,
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       false,
+		Metadata: map[string]any{
+			cliproxyexecutor.ThinkingLookupModelMetadataKey: requestedModel,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if got := gjson.GetBytes(gotBody, "model").String(); got != upstreamModel {
+		t.Fatalf("model = %q, want %q; body=%s", got, upstreamModel, string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "reasoning_effort").String(); got != "xhigh" {
+		t.Fatalf("reasoning_effort = %q, want xhigh; body=%s", got, string(gotBody))
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1838,6 +1838,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		}
 		execOpts := opts
 		execReq, execOpts = applyRequestAfterAuthInterceptor(ctx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+		execOpts = withThinkingLookupModelMetadata(execOpts, thinkingLookupModelForExecution(routeModel, execReq, executionModel != ""))
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, execOpts)
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
@@ -2551,6 +2552,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			}
 			execOpts := opts
 			execReq, execOpts = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			execOpts = withThinkingLookupModelMetadata(execOpts, thinkingLookupModelForExecution(routeModel, execReq, restoreExecutionModel))
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
@@ -2657,6 +2659,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			}
 			execOpts := opts
 			execReq, execOpts = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			execOpts = withThinkingLookupModelMetadata(execOpts, thinkingLookupModelForExecution(routeModel, execReq, restoreExecutionModel))
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
@@ -2805,6 +2808,43 @@ func ensureRequestedModelMetadata(opts cliproxyexecutor.Options, requestedModel 
 	meta[cliproxyexecutor.RequestedModelMetadataKey] = requestedModel
 	opts.Metadata = meta
 	return opts
+}
+
+func withThinkingLookupModelMetadata(opts cliproxyexecutor.Options, lookupModel string) cliproxyexecutor.Options {
+	lookupModel = strings.TrimSpace(lookupModel)
+	if lookupModel == "" {
+		return opts
+	}
+	meta := make(map[string]any, len(opts.Metadata)+1)
+	for k, v := range opts.Metadata {
+		meta[k] = v
+	}
+	meta[cliproxyexecutor.ThinkingLookupModelMetadataKey] = lookupModel
+	opts.Metadata = meta
+	return opts
+}
+
+func thinkingLookupModelForExecution(routeModel string, execReq cliproxyexecutor.Request, useExecutionModel bool) string {
+	routeModel = strings.TrimSpace(routeModel)
+	executionModel := strings.TrimSpace(execReq.Model)
+	if useExecutionModel {
+		if executionModel != "" {
+			return executionModel
+		}
+	}
+	if routeModel == "" {
+		return executionModel
+	}
+	executionResult := thinking.ParseSuffix(executionModel)
+	if executionResult.HasSuffix && strings.TrimSpace(executionResult.RawSuffix) != "" {
+		routeResult := thinking.ParseSuffix(routeModel)
+		routeBase := strings.TrimSpace(routeResult.ModelName)
+		if routeBase == "" {
+			routeBase = routeModel
+		}
+		return routeBase + "(" + strings.TrimSpace(executionResult.RawSuffix) + ")"
+	}
+	return routeModel
 }
 
 func authSelectionModelFromOptions(opts cliproxyexecutor.Options, fallback string) string {

--- a/sdk/cliproxy/auth/conductor_thinking_lookup_test.go
+++ b/sdk/cliproxy/auth/conductor_thinking_lookup_test.go
@@ -1,0 +1,221 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type thinkingLookupMetadataExecutor struct {
+	id string
+
+	mu           sync.Mutex
+	lookupModels []string
+}
+
+func (e *thinkingLookupMetadataExecutor) Identifier() string { return e.id }
+
+func (e *thinkingLookupMetadataExecutor) Execute(_ context.Context, _ *Auth, _ cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.lookupModels = append(e.lookupModels, metadataString(opts.Metadata, cliproxyexecutor.ThinkingLookupModelMetadataKey))
+	e.mu.Unlock()
+	return cliproxyexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
+}
+
+func (e *thinkingLookupMetadataExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "ExecuteStream not implemented"}
+}
+
+func (e *thinkingLookupMetadataExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *thinkingLookupMetadataExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "CountTokens not implemented"}
+}
+
+func (e *thinkingLookupMetadataExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "HttpRequest not implemented"}
+}
+
+func (e *thinkingLookupMetadataExecutor) LookupModels() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]string, len(e.lookupModels))
+	copy(out, e.lookupModels)
+	return out
+}
+
+func TestExecuteSetsThinkingLookupModelFromRouteModel(t *testing.T) {
+	ctx := context.Background()
+	provider := "thinking-lookup-provider"
+	authID := "thinking-lookup-auth"
+	routeModel := "routed-model"
+	originalRequestedModel := "original-model"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, provider, []*registry.ModelInfo{{
+		ID:      routeModel,
+		Object:  "model",
+		Created: time.Now().Unix(),
+		OwnedBy: provider,
+		Type:    "test",
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	mgr := NewManager(nil, nil, nil)
+	exec := &thinkingLookupMetadataExecutor{id: provider}
+	mgr.RegisterExecutor(exec)
+	if _, err := mgr.Register(ctx, &Auth{
+		ID:       authID,
+		Provider: provider,
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAuthKind: AuthKindAPIKey,
+			AttributeAPIKey:   "test-key",
+			AttributeSource:   "config:test[test-key]",
+		},
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	mgr.RefreshSchedulerEntry(authID)
+
+	_, err := mgr.Execute(ctx, []string{provider}, cliproxyexecutor.Request{Model: routeModel}, cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.RequestedModelMetadataKey: originalRequestedModel,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	got := exec.LookupModels()
+	if len(got) != 1 || got[0] != routeModel {
+		t.Fatalf("thinking lookup model metadata = %v, want [%q]", got, routeModel)
+	}
+}
+
+func TestExecuteSetsThinkingLookupModelFromRestoredExecutionModel(t *testing.T) {
+	ctx := context.Background()
+	provider := "thinking-lookup-selection-provider"
+	authID := "thinking-lookup-selection-auth"
+	selectionModel := "gemini-2.5-flash"
+	executionModel := "agents/custom-model"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, provider, []*registry.ModelInfo{{
+		ID:      selectionModel,
+		Object:  "model",
+		Created: time.Now().Unix(),
+		OwnedBy: provider,
+		Type:    "test",
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	mgr := NewManager(nil, nil, nil)
+	exec := &thinkingLookupMetadataExecutor{id: provider}
+	mgr.RegisterExecutor(exec)
+	if _, err := mgr.Register(ctx, &Auth{
+		ID:       authID,
+		Provider: provider,
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAuthKind: AuthKindAPIKey,
+			AttributeAPIKey:   "test-key",
+			AttributeSource:   "config:test[test-key]",
+		},
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	mgr.RefreshSchedulerEntry(authID)
+
+	_, err := mgr.Execute(ctx, []string{provider}, cliproxyexecutor.Request{Model: executionModel}, cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.AuthSelectionModelMetadataKey: selectionModel,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	got := exec.LookupModels()
+	if len(got) != 1 || got[0] != executionModel {
+		t.Fatalf("thinking lookup model metadata = %v, want [%q]", got, executionModel)
+	}
+}
+
+func TestExecutePreservesAliasResolvedThinkingSuffix(t *testing.T) {
+	ctx := context.Background()
+	provider := "gemini"
+	authID := "thinking-lookup-suffix-auth"
+	routeModel := "g25f"
+	clientModel := "g25f(high)"
+	upstreamModel := "gemini-2.5-flash(low)"
+	wantLookup := "g25f(low)"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, provider, []*registry.ModelInfo{{
+		ID:      routeModel,
+		Object:  "model",
+		Created: time.Now().Unix(),
+		OwnedBy: provider,
+		Type:    "test",
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{
+		GeminiKey: []internalconfig.GeminiKey{{
+			APIKey: "test-key",
+			Models: []internalconfig.GeminiModel{{
+				Name:  upstreamModel,
+				Alias: routeModel,
+			}},
+		}},
+	})
+	exec := &thinkingLookupMetadataExecutor{id: provider}
+	mgr.RegisterExecutor(exec)
+	if _, err := mgr.Register(ctx, &Auth{
+		ID:       authID,
+		Provider: provider,
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			AttributeAuthKind: AuthKindAPIKey,
+			AttributeAPIKey:   "test-key",
+			AttributeSource:   "config:gemini[test-key]",
+		},
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	mgr.RefreshSchedulerEntry(authID)
+
+	_, err := mgr.Execute(ctx, []string{provider}, cliproxyexecutor.Request{Model: clientModel}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	got := exec.LookupModels()
+	if len(got) != 1 || got[0] != wantLookup {
+		t.Fatalf("thinking lookup model metadata = %v, want [%q]", got, wantLookup)
+	}
+}
+
+func metadataString(meta map[string]any, key string) string {
+	if len(meta) == 0 {
+		return ""
+	}
+	switch value := meta[key].(type) {
+	case string:
+		return value
+	case []byte:
+		return string(value)
+	default:
+		return ""
+	}
+}

--- a/sdk/cliproxy/auth/config_apikey.go
+++ b/sdk/cliproxy/auth/config_apikey.go
@@ -13,3 +13,14 @@ func IsConfigAPIKeyAuth(auth *Auth) bool {
 	}
 	return authAttribute(auth, AttributeAPIKey) != ""
 }
+
+// IsConfigProviderAuth reports whether the auth entry is synthesized from provider config.
+func IsConfigProviderAuth(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if auth.AuthKind() == AuthKindOAuth {
+		return false
+	}
+	return auth.AuthSourceKind() == AuthSourceConfig
+}

--- a/sdk/cliproxy/auth/config_apikey_test.go
+++ b/sdk/cliproxy/auth/config_apikey_test.go
@@ -31,3 +31,31 @@ func TestIsConfigAPIKeyAuth(t *testing.T) {
 		t.Fatal("expected config api key auth")
 	}
 }
+
+func TestIsConfigProviderAuth(t *testing.T) {
+	if IsConfigProviderAuth(nil) {
+		t.Fatal("expected nil auth to be false")
+	}
+	if !IsConfigProviderAuth(&Auth{Attributes: map[string]string{"source": "config:openai-compatibility[x]"}}) {
+		t.Fatal("expected keyless config provider auth")
+	}
+	if !IsConfigProviderAuth(&Auth{
+		Attributes: map[string]string{
+			"api_key": "k",
+			"source":  "config:openai-compatibility[x]",
+		},
+	}) {
+		t.Fatal("expected keyed config provider auth")
+	}
+	if IsConfigProviderAuth(&Auth{
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+			"source":    "config:codex[x]",
+		},
+	}) {
+		t.Fatal("expected config oauth auth to be false")
+	}
+	if IsConfigProviderAuth(&Auth{Attributes: map[string]string{"source": "/tmp/auth.json"}}) {
+		t.Fatal("expected file auth to be false")
+	}
+}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -11,6 +11,9 @@ import (
 // RequestedModelMetadataKey stores the client-requested model name in Options.Metadata.
 const RequestedModelMetadataKey = "requested_model"
 
+// ThinkingLookupModelMetadataKey stores the routed model name used for thinking capability lookup.
+const ThinkingLookupModelMetadataKey = "thinking_lookup_model"
+
 // RequestPathMetadataKey stores the inbound HTTP request path (e.g. "/v1/images/generations") in Options.Metadata.
 // It is optional and may be absent for non-HTTP executions.
 const RequestPathMetadataKey = "request_path"


### PR DESCRIPTION
## Summary
- use a routed per-attempt thinking lookup model for config-sourced provider auths when the selected upstream model differs from the client-facing model
- set the lookup metadata in the auth conductor immediately before Execute, ExecuteStream, and CountTokens calls, so model-router requests validate against the routed model instead of stale pre-router metadata
- preserve alias-resolved thinking suffix priority by applying the resolved execution suffix to the client-facing lookup model identity
- use the restored execution model when `AuthSelectionModelMetadataKey` is selection-only, so credential selection models do not override the actual model being sent upstream
- apply the shared lookup to OpenAI-compatible, Gemini, Gemini Interactions, Claude API key, Codex API key, and Vertex-compatible config provider executor paths
- pass the selected Gemini Interactions provider key into thinking lookup so shared aliases use the selected auth provider's model capabilities
- keep upstream request translation unchanged, so provider requests still use the resolved upstream model
- place the shared lookup helper under executor helps and trim the lookup model ID before registry lookup
- add regression tests for prefixed config provider model lookup, keyless config provider auths, alias-resolved suffix priority, selection-only metadata, model-router metadata isolation, Gemini Interactions provider-key lookup, and an OpenAI-compatible executor request with extended thinking levels

## Example failure before this change
A config provider can expose a prefixed client model while forwarding an unprefixed upstream model, for example:

```yaml
force-model-prefix: true
openai-compatibility:
  - name: free-provider
    prefix: free-provider
    models:
      - name: gemini-3.1-pro-preview
        thinking:
          levels: [max, xhigh, high, medium, low, minimal, none, auto]
```

A client request to `free-provider/gemini-3.1-pro-preview` with `reasoning_effort: xhigh` is routed to upstream model `gemini-3.1-pro-preview`. Before this fix, `ApplyThinking` looked up `gemini-3.1-pro-preview` instead of the registered client-facing lookup model `free-provider/gemini-3.1-pro-preview`, missed the config-provided thinking levels, and could reject the request with `level "xhigh" not supported, valid levels: low, medium, high`.

The conductor now supplies the thinking lookup model for the current execution attempt. That keeps prefixed config provider aliases working while preventing model-router requests from validating against unrelated pre-router requested-model metadata. If alias resolution applies a config-side thinking suffix such as `g25f -> gemini-2.5-flash(low)`, the lookup model preserves the client-facing identity and inherits the resolved suffix, so suffix priority remains consistent with the alias resolver. When an auth selection model is used only to choose credentials, the conductor uses the restored execution model for thinking lookup instead.

The same alias/prefix shape exists for other config provider auths that register client-facing aliases and then execute an upstream `name`, including keyless base-URL-only config auths, so the lookup helper is shared across those executor paths. Gemini Interactions also passes its selected provider key through the same lookup path, so shared aliases do not accidentally use the plain Gemini provider's capabilities.

## Tests
- gofmt -w sdk/cliproxy/executor/types.go sdk/cliproxy/auth/conductor.go sdk/cliproxy/auth/conductor_thinking_lookup_test.go sdk/cliproxy/auth/config_apikey.go sdk/cliproxy/auth/config_apikey_test.go internal/runtime/executor/helps/thinking_lookup.go internal/runtime/executor/helps/thinking_lookup_test.go internal/runtime/executor/openai_compat_executor_thinking_test.go internal/runtime/executor/gemini_executor.go internal/runtime/executor/gemini_executor_test.go
- go test ./internal/runtime/executor/helps -run TestThinkingLookupModel -count=1
- go test ./sdk/cliproxy/auth -run 'TestIsConfig|TestExecuteSetsThinkingLookupModel|TestExecutePreservesAliasResolvedThinkingSuffix|TestResolveAPIKeyModelAliasWithResult|TestLookupAPIKeyUpstreamModel' -count=1
- go test ./internal/runtime/executor -run 'TestGemini.*Interactions.*Thinking|TestOpenAICompatExecutorUsesPrefixedRequestedModelForThinkingLookup' -count=1
- go test ./sdk/cliproxy/auth ./internal/runtime/executor/helps ./internal/runtime/executor -count=1
- go build -o test-output ./cmd/server && rm test-output
- go test ./...