### PR TITLE
Update Antigravity hub user agent

### DIFF
--- a/internal/auth/antigravity/auth_test.go
+++ b/internal/auth/antigravity/auth_test.go
@@ -84,8 +84,12 @@ func assertLoadCodeAssistHeaders(t *testing.T, req *http.Request) {
 	if got := req.Header.Get("X-Goog-Api-Client"); got != "" {
 		t.Fatalf("X-Goog-Api-Client = %q, want empty", got)
 	}
-	if got := req.Header.Get("User-Agent"); strings.Contains(got, "google-api-nodejs-client/") {
-		t.Fatalf("User-Agent = %q", got)
+	userAgent := req.Header.Get("User-Agent")
+	if !strings.HasPrefix(userAgent, "antigravity/hub/") {
+		t.Fatalf("User-Agent = %q", userAgent)
+	}
+	if strings.Contains(userAgent, "google-api-nodejs-client/") {
+		t.Fatalf("User-Agent = %q", userAgent)
 	}
 }
 
@@ -100,8 +104,12 @@ func assertOnboardUserHeaders(t *testing.T, req *http.Request) {
 	if got := req.Header.Get("X-Goog-Api-Client"); got != "gl-node/22.21.1" {
 		t.Fatalf("X-Goog-Api-Client = %q", got)
 	}
-	if got := req.Header.Get("User-Agent"); !strings.Contains(got, "google-api-nodejs-client/10.3.0") {
-		t.Fatalf("User-Agent = %q", got)
+	userAgent := req.Header.Get("User-Agent")
+	if !strings.HasPrefix(userAgent, "antigravity/hub/") {
+		t.Fatalf("User-Agent = %q", userAgent)
+	}
+	if !strings.Contains(userAgent, "google-api-nodejs-client/10.3.0") {
+		t.Fatalf("User-Agent = %q", userAgent)
 	}
 }
 

--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -3,24 +3,21 @@ package misc
 
 import (
 	"context"
-	"encoding/json"
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 )
 
 const (
-	antigravityFallbackVersion = "1.0.13"
-	antigravityCLIPlatform     = "darwin/arm64"
-	antigravityCLIClientName   = "aidev_client"
+	antigravityFallbackVersion = "2.2.1"
+	antigravityHubPlatform     = "darwin/arm64"
 	antigravityVersionCacheTTL = 6 * time.Hour
 	antigravityFetchTimeout    = 10 * time.Second
 	AntigravityNodeAPIClientUA = "google-api-nodejs-client/10.3.0"
@@ -28,28 +25,11 @@ const (
 )
 
 var (
-	antigravityCLIUpdaterBaseURL = "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests"
-	antigravityCLILatestURL      = "https://storage.googleapis.com/antigravity-public/antigravity-cli/latest"
-	antigravityCLIGCSListURL     = "https://storage.googleapis.com/antigravity-public/?prefix=antigravity-cli/&delimiter=/"
+	antigravityHubLatestManifestURL = "https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/manifest/latest-arm64-mac.yml"
 )
 
-type antigravityCLIUpdaterManifest struct {
-	Version string `json:"version"`
-	URL     string `json:"url"`
-	SHA512  string `json:"sha512"`
-}
-
-type antigravityGCSList struct {
-	CommonPrefixes []antigravityGCSPrefix `xml:"CommonPrefixes"`
-}
-
-type antigravityGCSPrefix struct {
-	Prefix string `xml:"Prefix"`
-}
-
-type antigravitySemVersion struct {
-	raw   string
-	parts [3]int
+type antigravityHubUpdaterManifest struct {
+	Version string `yaml:"version"`
 }
 
 var (
@@ -128,28 +108,13 @@ func AntigravityLatestVersion() string {
 	return antigravityFallbackVersion
 }
 
-// AntigravityUserAgent returns the User-Agent string used by the agy CLI family.
+// AntigravityUserAgent returns the User-Agent string used by the Antigravity Hub family.
 func AntigravityUserAgent() string {
-	return fmt.Sprintf("antigravity/cli/%s %s", AntigravityLatestVersion(), antigravityCLIUserAgentDetails())
-}
-
-func antigravityCLIUserAgentDetails() string {
-	osType, arch := "darwin", "arm64"
-	if platform := strings.TrimSpace(antigravityCLIPlatform); platform != "" {
-		if parts := strings.SplitN(platform, "/", 2); len(parts) == 2 {
-			if trimmedOS := strings.TrimSpace(parts[0]); trimmedOS != "" {
-				osType = trimmedOS
-			}
-			if trimmedArch := strings.TrimSpace(parts[1]); trimmedArch != "" {
-				arch = trimmedArch
-			}
-		}
-	}
-	return fmt.Sprintf("(%s; os_type=%s; arch=%s)", antigravityCLIClientName, osType, arch)
+	return fmt.Sprintf("antigravity/hub/%s %s", AntigravityLatestVersion(), antigravityHubPlatform)
 }
 
 func isAntigravityFamilyUserAgent(lower string) bool {
-	return strings.HasPrefix(lower, "antigravity/cli/") || strings.HasPrefix(lower, "antigravity/")
+	return strings.HasPrefix(lower, "antigravity/hub/") || strings.HasPrefix(lower, "antigravity/")
 }
 
 func antigravityBaseUserAgent(userAgent string) string {
@@ -203,25 +168,23 @@ func AntigravityOnboardUserUserAgent(userAgent string) string {
 func AntigravityVersionFromUserAgent(userAgent string) string {
 	base := antigravityBaseUserAgent(userAgent)
 	lower := strings.ToLower(base)
-	for _, familyPrefix := range []string{"antigravity/cli/", "antigravity/hub/"} {
-		if strings.HasPrefix(lower, familyPrefix) {
-			rest := base[len(familyPrefix):]
-			if idx := strings.IndexAny(rest, " \t"); idx >= 0 {
-				rest = rest[:idx]
-			}
-			rest = strings.TrimSpace(rest)
-			if rest == "" {
-				return AntigravityLatestVersion()
-			}
-			return rest
+	if strings.HasPrefix(lower, "antigravity/hub/") {
+		rest := base[len("antigravity/hub/"):]
+		if idx := strings.IndexAny(rest, " 	"); idx >= 0 {
+			rest = rest[:idx]
 		}
+		rest = strings.TrimSpace(rest)
+		if rest == "" {
+			return AntigravityLatestVersion()
+		}
+		return rest
 	}
 	const legacyPrefix = "antigravity/"
 	if !strings.HasPrefix(lower, legacyPrefix) {
 		return AntigravityLatestVersion()
 	}
 	rest := base[len(legacyPrefix):]
-	if idx := strings.IndexAny(rest, " \t"); idx >= 0 {
+	if idx := strings.IndexAny(rest, " 	"); idx >= 0 {
 		rest = rest[:idx]
 	}
 	rest = strings.TrimSpace(rest)
@@ -231,251 +194,73 @@ func AntigravityVersionFromUserAgent(userAgent string) string {
 	return rest
 }
 
-func antigravityCLIUpdaterManifestName() string {
-	return strings.ReplaceAll(antigravityCLIPlatform, "/", "_")
-}
-
 func fetchAntigravityLatestVersion(ctx context.Context) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
 	client := &http.Client{Timeout: antigravityFetchTimeout}
-
-	version, errManifest := fetchAntigravityCLIUpdaterManifestVersion(ctx, client)
-	if errManifest == nil {
-		return version, nil
-	}
-
-	log.WithError(errManifest).Debug("failed to fetch antigravity CLI updater manifest, trying CLI latest pointer")
-
-	version, errLatest := fetchAntigravityCLILatestVersion(ctx, client)
-	if errLatest == nil {
-		return version, nil
-	}
-
-	log.WithError(errLatest).Debug("failed to fetch antigravity CLI latest version, trying CLI GCS prefix list")
-
-	version, errList := fetchAntigravityCLIGCSLatestVersion(ctx, client)
-	if errList == nil {
-		return version, nil
-	}
-
-	return "", fmt.Errorf("fetch antigravity CLI updater manifest: %v; fetch antigravity CLI latest: %v; fetch antigravity CLI GCS version: %w", errManifest, errLatest, errList)
+	return fetchAntigravityHubLatestManifestVersion(ctx, client)
 }
 
-func fetchAntigravityCLIUpdaterManifestVersion(ctx context.Context, client *http.Client) (string, error) {
-	manifestURL := fmt.Sprintf("%s/%s.json", strings.TrimSuffix(antigravityCLIUpdaterBaseURL, "/"), antigravityCLIUpdaterManifestName())
-	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+func fetchAntigravityHubLatestManifestVersion(ctx context.Context, client *http.Client) (string, error) {
+	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodGet, antigravityHubLatestManifestURL, nil)
 	if errReq != nil {
-		return "", fmt.Errorf("build antigravity CLI updater manifest request: %w", errReq)
+		return "", fmt.Errorf("build antigravity Hub updater manifest request: %w", errReq)
 	}
+	httpReq.Header.Set("User-Agent", "electron-builder")
+	httpReq.Header.Set("Cache-Control", "no-cache")
 
 	resp, errDo := client.Do(httpReq)
 	if errDo != nil {
-		return "", fmt.Errorf("fetch antigravity CLI updater manifest: %w", errDo)
+		return "", fmt.Errorf("fetch antigravity Hub updater manifest: %w", errDo)
 	}
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
-			log.WithError(errClose).Warn("antigravity CLI updater manifest response body close error")
+			log.WithError(errClose).Warn("antigravity Hub updater manifest response body close error")
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("antigravity CLI updater manifest returned status %d", resp.StatusCode)
+		return "", fmt.Errorf("antigravity Hub updater manifest returned status %d", resp.StatusCode)
 	}
 
 	raw, errRead := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if errRead != nil {
-		return "", fmt.Errorf("read antigravity CLI updater manifest: %w", errRead)
+		return "", fmt.Errorf("read antigravity Hub updater manifest: %w", errRead)
 	}
 
-	var manifest antigravityCLIUpdaterManifest
-	if errDecode := json.Unmarshal(raw, &manifest); errDecode != nil {
-		return "", fmt.Errorf("decode antigravity CLI updater manifest: %w", errDecode)
+	var manifest antigravityHubUpdaterManifest
+	if errDecode := yaml.Unmarshal(raw, &manifest); errDecode != nil {
+		return "", fmt.Errorf("decode antigravity Hub updater manifest: %w", errDecode)
 	}
 
 	version := strings.TrimSpace(manifest.Version)
 	if version == "" {
-		return "", errors.New("antigravity CLI updater manifest returned empty version")
+		return "", errors.New("antigravity Hub updater manifest returned empty version")
 	}
-	if _, ok := parseAntigravitySemVersion(version); !ok {
-		return "", fmt.Errorf("antigravity CLI updater manifest returned invalid version %q", version)
+	if !isValidAntigravitySemVersion(version) {
+		return "", fmt.Errorf("antigravity Hub updater manifest returned invalid version %q", version)
 	}
 	return version, nil
 }
 
-func fetchAntigravityCLILatestVersion(ctx context.Context, client *http.Client) (string, error) {
-	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodGet, antigravityCLILatestURL, nil)
-	if errReq != nil {
-		return "", fmt.Errorf("build antigravity CLI latest request: %w", errReq)
-	}
-
-	resp, errDo := client.Do(httpReq)
-	if errDo != nil {
-		return "", fmt.Errorf("fetch antigravity CLI latest: %w", errDo)
-	}
-	defer func() {
-		if errClose := resp.Body.Close(); errClose != nil {
-			log.WithError(errClose).Warn("antigravity CLI latest response body close error")
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("antigravity CLI latest returned status %d", resp.StatusCode)
-	}
-
-	raw, errRead := io.ReadAll(io.LimitReader(resp.Body, 256))
-	if errRead != nil {
-		return "", fmt.Errorf("read antigravity CLI latest: %w", errRead)
-	}
-	version := strings.TrimSpace(string(raw))
-	if version == "" {
-		return "", errors.New("antigravity CLI latest returned empty version")
-	}
-	semVersion, ok := parseAntigravitySemVersion(version)
-	if !ok {
-		return "", fmt.Errorf("antigravity CLI latest returned invalid version %q", version)
-	}
-	return semVersion.raw, nil
-}
-
-func fetchAntigravityCLIGCSLatestVersion(ctx context.Context, client *http.Client) (string, error) {
-	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodGet, antigravityCLIGCSListURL, nil)
-	if errReq != nil {
-		return "", fmt.Errorf("build antigravity CLI GCS request: %w", errReq)
-	}
-
-	resp, errDo := client.Do(httpReq)
-	if errDo != nil {
-		return "", fmt.Errorf("fetch antigravity CLI GCS list: %w", errDo)
-	}
-	defer func() {
-		if errClose := resp.Body.Close(); errClose != nil {
-			log.WithError(errClose).Warn("antigravity CLI GCS response body close error")
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("antigravity CLI GCS list returned status %d", resp.StatusCode)
-	}
-
-	var list antigravityGCSList
-	if errDecode := xml.NewDecoder(resp.Body).Decode(&list); errDecode != nil {
-		return "", fmt.Errorf("decode antigravity CLI GCS list: %w", errDecode)
-	}
-
-	prefixes := make([]string, 0, len(list.CommonPrefixes))
-	for _, commonPrefix := range list.CommonPrefixes {
-		prefixes = append(prefixes, commonPrefix.Prefix)
-	}
-
-	return latestAntigravityCLIVersionFromPrefixes(prefixes)
-}
-
-func latestAntigravityCLIVersionFromPrefixes(prefixes []string) (string, error) {
-	var best antigravitySemVersion
-	found := false
-
-	for _, prefix := range prefixes {
-		version, ok := antigravityCLIVersionFromPrefix(prefix)
-		if !ok {
-			continue
-		}
-		semVersion, ok := parseAntigravitySemVersion(version)
-		if !ok {
-			continue
-		}
-		if !found || compareAntigravitySemVersion(semVersion, best) > 0 {
-			best = semVersion
-			found = true
-		}
-	}
-
-	if !found {
-		return "", errors.New("antigravity-cli GCS list contained no version prefixes")
-	}
-
-	return best.raw, nil
-}
-
-func antigravityCLIVersionFromPrefix(prefix string) (string, bool) {
-	const cliPrefix = "antigravity-cli/"
-	prefix = strings.TrimSpace(prefix)
-	prefix = strings.TrimSuffix(prefix, "/")
-	if !strings.HasPrefix(prefix, cliPrefix) {
-		return "", false
-	}
-
-	name := strings.TrimPrefix(prefix, cliPrefix)
-	if name == "latest" || name == "test" || name == "tools" || strings.HasPrefix(name, "v") {
-		return "", false
-	}
-
-	separator := strings.LastIndex(name, "-")
-	if separator > 0 && separator < len(name)-1 {
-		version := strings.TrimSpace(name[:separator])
-		executionID := name[separator+1:]
-		if version != "" && executionID != "" {
-			allDigits := true
-			for _, ch := range executionID {
-				if ch < '0' || ch > '9' {
-					allDigits = false
-					break
-				}
-			}
-			if allDigits {
-				if _, ok := parseAntigravitySemVersion(version); ok {
-					return version, true
-				}
-			}
-		}
-	}
-
-	version := strings.TrimSpace(name)
-	if version == "" {
-		return "", false
-	}
-	if _, ok := parseAntigravitySemVersion(version); !ok {
-		return "", false
-	}
-	return version, true
-}
-
-func parseAntigravitySemVersion(version string) (antigravitySemVersion, bool) {
+func isValidAntigravitySemVersion(version string) bool {
 	parts := strings.Split(version, ".")
 	if len(parts) != 3 {
-		return antigravitySemVersion{}, false
+		return false
 	}
 
-	semVersion := antigravitySemVersion{raw: version}
-	for i, part := range parts {
+	for _, part := range parts {
 		if part == "" {
-			return antigravitySemVersion{}, false
+			return false
 		}
 		for _, ch := range part {
 			if ch < '0' || ch > '9' {
-				return antigravitySemVersion{}, false
+				return false
 			}
 		}
-		value, errParse := strconv.Atoi(part)
-		if errParse != nil {
-			return antigravitySemVersion{}, false
-		}
-		semVersion.parts[i] = value
 	}
 
-	return semVersion, true
-}
-
-func compareAntigravitySemVersion(left antigravitySemVersion, right antigravitySemVersion) int {
-	for i := range left.parts {
-		if left.parts[i] > right.parts[i] {
-			return 1
-		}
-		if left.parts[i] < right.parts[i] {
-			return -1
-		}
-	}
-	return 0
+	return true
 }

--- a/internal/misc/antigravity_version_test.go
+++ b/internal/misc/antigravity_version_test.go
@@ -4,25 +4,18 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"sync/atomic"
 	"testing"
 	"time"
 )
 
-func overrideAntigravityVersionURLsForTest(t *testing.T, updaterBaseURL string, cliLatestURL string, cliListURL string) func() {
+func overrideAntigravityVersionURLsForTest(t *testing.T, hubManifestURL string) func() {
 	t.Helper()
 
-	oldUpdater := antigravityCLIUpdaterBaseURL
-	oldCLILatest := antigravityCLILatestURL
-	oldCLIList := antigravityCLIGCSListURL
-	antigravityCLIUpdaterBaseURL = updaterBaseURL
-	antigravityCLILatestURL = cliLatestURL
-	antigravityCLIGCSListURL = cliListURL
+	oldHubManifest := antigravityHubLatestManifestURL
+	antigravityHubLatestManifestURL = hubManifestURL
 
 	return func() {
-		antigravityCLIUpdaterBaseURL = oldUpdater
-		antigravityCLILatestURL = oldCLILatest
-		antigravityCLIGCSListURL = oldCLIList
+		antigravityHubLatestManifestURL = oldHubManifest
 	}
 }
 
@@ -44,44 +37,43 @@ func overrideAntigravityVersionCacheForTest(t *testing.T, version string, expiry
 	}
 }
 
-func TestAntigravityLatestVersionUsesCurrentCLIFallback(t *testing.T) {
+func TestAntigravityLatestVersionUsesCurrentHubFallback(t *testing.T) {
 	restore := overrideAntigravityVersionCacheForTest(t, "", time.Time{})
 	defer restore()
 
 	version := AntigravityLatestVersion()
-	if version != "1.0.13" {
-		t.Fatalf("AntigravityLatestVersion() = %q, want %q", version, "1.0.13")
+	if version != "2.2.1" {
+		t.Fatalf("AntigravityLatestVersion() = %q, want %q", version, "2.2.1")
 	}
 }
 
-func TestAntigravityUserAgentUsesCLIFamily(t *testing.T) {
-	restore := overrideAntigravityVersionCacheForTest(t, "1.0.8", time.Now().Add(time.Hour))
+func TestAntigravityUserAgentUsesHubFamily(t *testing.T) {
+	restore := overrideAntigravityVersionCacheForTest(t, "2.2.1", time.Now().Add(time.Hour))
 	defer restore()
 
-	want := "antigravity/cli/1.0.8 (aidev_client; os_type=darwin; arch=arm64)"
+	want := "antigravity/hub/2.2.1 darwin/arm64"
 	if got := AntigravityUserAgent(); got != want {
 		t.Fatalf("AntigravityUserAgent() = %q, want %q", got, want)
 	}
 }
 
-func TestAntigravityVersionFromUserAgentParsesCLIFamily(t *testing.T) {
-	if got := AntigravityVersionFromUserAgent("antigravity/cli/1.0.8 darwin/arm64"); got != "1.0.8" {
-		t.Fatalf("AntigravityVersionFromUserAgent() = %q, want %q", got, "1.0.8")
+func TestAntigravityVersionFromUserAgentParsesHubFamily(t *testing.T) {
+	if got := AntigravityVersionFromUserAgent("antigravity/hub/2.2.1 darwin/arm64"); got != "2.2.1" {
+		t.Fatalf("AntigravityVersionFromUserAgent() = %q, want %q", got, "2.2.1")
 	}
 }
 
-func TestAntigravityVersionFromUserAgentParsesAidevClientSuffix(t *testing.T) {
-	ua := "antigravity/cli/1.0.13 (aidev_client; os_type=darwin; arch=arm64)"
-	if got := AntigravityVersionFromUserAgent(ua); got != "1.0.13" {
-		t.Fatalf("AntigravityVersionFromUserAgent() = %q, want %q", got, "1.0.13")
+func TestAntigravityVersionFromUserAgentParsesLegacyFamily(t *testing.T) {
+	if got := AntigravityVersionFromUserAgent("antigravity/1.23.2 windows/amd64"); got != "1.23.2" {
+		t.Fatalf("AntigravityVersionFromUserAgent() = %q, want %q", got, "1.23.2")
 	}
 }
 
 func TestAntigravityLoadCodeAssistUserAgentUsesShortUA(t *testing.T) {
-	restore := overrideAntigravityVersionCacheForTest(t, "1.0.13", time.Now().Add(time.Hour))
+	restore := overrideAntigravityVersionCacheForTest(t, "2.2.1", time.Now().Add(time.Hour))
 	defer restore()
 
-	want := "antigravity/cli/1.0.13 (aidev_client; os_type=darwin; arch=arm64)"
+	want := "antigravity/hub/2.2.1 darwin/arm64"
 	if got := AntigravityLoadCodeAssistUserAgent(""); got != want {
 		t.Fatalf("AntigravityLoadCodeAssistUserAgent() = %q, want %q", got, want)
 	}
@@ -90,122 +82,57 @@ func TestAntigravityLoadCodeAssistUserAgentUsesShortUA(t *testing.T) {
 	}
 }
 
-func TestAntigravityCLIUpdaterManifestName(t *testing.T) {
-	if got := antigravityCLIUpdaterManifestName(); got != "darwin_arm64" {
-		t.Fatalf("antigravityCLIUpdaterManifestName() = %q, want %q", got, "darwin_arm64")
+func TestAntigravityOnboardUserUserAgentUsesLongUA(t *testing.T) {
+	restore := overrideAntigravityVersionCacheForTest(t, "2.2.1", time.Now().Add(time.Hour))
+	defer restore()
+
+	want := "antigravity/hub/2.2.1 darwin/arm64 google-api-nodejs-client/10.3.0"
+	if got := AntigravityOnboardUserUserAgent(""); got != want {
+		t.Fatalf("AntigravityOnboardUserUserAgent() = %q, want %q", got, want)
 	}
 }
 
-func TestFetchAntigravityLatestVersionPrefersDarwinManifest(t *testing.T) {
-	var cliLatestRequests atomic.Int32
-	var cliListRequests atomic.Int32
-
+func TestFetchAntigravityLatestVersionUsesHubManifest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/manifests/darwin_arm64.json":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"version":"1.0.8","url":"https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.8-5963827121094656/darwin-arm/cli_mac_arm64.tar.gz"}`))
-		case "/cli-latest":
-			cliLatestRequests.Add(1)
-			http.Error(w, "should not be called", http.StatusInternalServerError)
-		case "/cli-list":
-			cliListRequests.Add(1)
-			http.Error(w, "should not be called", http.StatusInternalServerError)
+		case "/hub/latest-arm64-mac.yml":
+			if got := r.Header.Get("User-Agent"); got != "electron-builder" {
+				t.Errorf("hub manifest User-Agent = %q, want %q", got, "electron-builder")
+			}
+			if got := r.Header.Get("Cache-Control"); got != "no-cache" {
+				t.Errorf("hub manifest Cache-Control = %q, want %q", got, "no-cache")
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("version: 2.2.1\npath: Antigravity-arm64-mac.zip\n"))
 		default:
 			http.NotFound(w, r)
 		}
 	}))
 	defer server.Close()
 
-	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/manifests", server.URL+"/cli-latest", server.URL+"/cli-list")
+	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/hub/latest-arm64-mac.yml")
 	defer restore()
 
 	version, errFetch := fetchAntigravityLatestVersion(context.Background())
 	if errFetch != nil {
 		t.Fatalf("fetchAntigravityLatestVersion() error = %v", errFetch)
 	}
-	if version != "1.0.8" {
-		t.Fatalf("fetchAntigravityLatestVersion() = %q, want %q", version, "1.0.8")
-	}
-	if got := cliLatestRequests.Load(); got != 0 {
-		t.Fatalf("CLI latest requests = %d, want 0", got)
-	}
-	if got := cliListRequests.Load(); got != 0 {
-		t.Fatalf("CLI GCS list requests = %d, want 0", got)
+	if version != "2.2.1" {
+		t.Fatalf("fetchAntigravityLatestVersion() = %q, want %q", version, "2.2.1")
 	}
 }
 
-func TestFetchAntigravityLatestVersionFallsBackToCLILatest(t *testing.T) {
+func TestFetchAntigravityLatestVersionReturnsHubManifestError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/manifests/darwin_arm64.json":
-			http.Error(w, "temporary outage", http.StatusInternalServerError)
-		case "/cli-latest":
-			_, _ = w.Write([]byte("1.0.9"))
-		default:
-			http.NotFound(w, r)
-		}
+		http.Error(w, "temporary outage", http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
-	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/manifests", server.URL+"/cli-latest", server.URL+"/cli-list")
+	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/hub/latest-arm64-mac.yml")
 	defer restore()
 
-	version, errFetch := fetchAntigravityLatestVersion(context.Background())
-	if errFetch != nil {
-		t.Fatalf("fetchAntigravityLatestVersion() error = %v", errFetch)
-	}
-	if version != "1.0.9" {
-		t.Fatalf("fetchAntigravityLatestVersion() = %q, want %q", version, "1.0.9")
-	}
-}
-
-func TestFetchAntigravityLatestVersionFallsBackToCLIGCSList(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/manifests/darwin_arm64.json":
-			http.Error(w, "temporary outage", http.StatusInternalServerError)
-		case "/cli-latest":
-			http.Error(w, "temporary outage", http.StatusInternalServerError)
-		case "/cli-list":
-			w.Header().Set("Content-Type", "application/xml")
-			_, _ = w.Write([]byte(`<?xml version='1.0' encoding='UTF-8'?>
-<ListBucketResult xmlns='http://doc.s3.amazonaws.com/2006-03-01'>
-  <CommonPrefixes><Prefix>antigravity-cli/1.0.7/</Prefix></CommonPrefixes>
-  <CommonPrefixes><Prefix>antigravity-cli/1.0.8/</Prefix></CommonPrefixes>
-  <CommonPrefixes><Prefix>antigravity-cli/1.0.8-5963827121094656/</Prefix></CommonPrefixes>
-</ListBucketResult>`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
-	restore := overrideAntigravityVersionURLsForTest(t, server.URL+"/manifests", server.URL+"/cli-latest", server.URL+"/cli-list")
-	defer restore()
-
-	version, errFetch := fetchAntigravityLatestVersion(context.Background())
-	if errFetch != nil {
-		t.Fatalf("fetchAntigravityLatestVersion() error = %v", errFetch)
-	}
-	if version != "1.0.8" {
-		t.Fatalf("fetchAntigravityLatestVersion() = %q, want %q", version, "1.0.8")
-	}
-}
-
-func TestLatestAntigravityCLIVersionFromPrefixesSortsByNumericSemver(t *testing.T) {
-	prefixes := []string{
-		"antigravity-cli/1.0.7/",
-		"antigravity-cli/1.0.8/",
-		"antigravity-cli/1.0.8-5963827121094656/",
-		"antigravity-cli/latest/",
-	}
-
-	version, errParse := latestAntigravityCLIVersionFromPrefixes(prefixes)
-	if errParse != nil {
-		t.Fatalf("latestAntigravityCLIVersionFromPrefixes() error = %v", errParse)
-	}
-	if version != "1.0.8" {
-		t.Fatalf("latestAntigravityCLIVersionFromPrefixes() = %q, want %q", version, "1.0.8")
+	_, errFetch := fetchAntigravityLatestVersion(context.Background())
+	if errFetch == nil {
+		t.Fatal("fetchAntigravityLatestVersion() error = nil, want error")
 	}
 }

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -51,7 +51,6 @@ const (
 	antigravityGeneratePath                = "/v1internal:generateContent"
 	antigravityClientID                    = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
 	antigravityClientSecret                = "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"
-	defaultAntigravityAgent                = "antigravity/cli/1.0.13 (aidev_client; os_type=darwin; arch=arm64)" // fallback only; overridden at runtime by misc.AntigravityUserAgent()
 	antigravityAuthType                    = "antigravity"
 	refreshSkew                            = 3000 * time.Second
 	antigravityCreditsHintRefreshInterval  = 10 * time.Minute

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -675,8 +675,8 @@ func TestUpdateAntigravityCreditsBalance_LoadCodeAssistUserAgent(t *testing.T) {
 	t.Cleanup(resetAntigravityCreditsRetryState)
 
 	exec := NewAntigravityExecutor(&config.Config{})
-	const configuredUserAgent = "antigravity/1.23.2 windows/amd64 google-api-nodejs-client/10.3.0"
-	const loadCodeAssistUserAgent = "antigravity/1.23.2 windows/amd64"
+	const configuredUserAgent = "antigravity/hub/1.23.2 windows/amd64 google-api-nodejs-client/10.3.0"
+	const loadCodeAssistUserAgent = "antigravity/hub/1.23.2 windows/amd64"
 	auth := &cliproxyauth.Auth{
 		ID:         "auth-load-code-assist-ua",
 		Attributes: map[string]string{"user_agent": configuredUserAgent},


### PR DESCRIPTION
## Summary
- switch Antigravity default user agent to the Hub format
- fetch the latest Antigravity version from the Hub updater manifest
- update Antigravity auth/executor tests for the Hub user agent

## Tests
- go build -o test-output ./cmd/server && rm test-output