### PR TITLE
feat(claude): add relaxed cloak system prompt mode / 添加宽松的 Claude 伪装系统提示词模式

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -379,10 +379,13 @@ nonstream-keepalive-interval: 0
 #                                    # "never": never apply cloaking
 #       # This "cloak" block applies to this claude-api-key entry only. For Claude OAuth
 #       # credentials, set the same options in the auth/token JSON file via "cloak_mode" /
-#       # "cloak_strict_mode" / "cloak_sensitive_words" / "cloak_cache_user_id". The top-level
+#       # "cloak_strict_mode" / "cloak_relaxed_system_prompt" / "cloak_sensitive_words" /
+#       # "cloak_cache_user_id". The top-level
 #       # "disable-claude-cloak-mode: true" disables cloaking for all Claude credentials at once.
-#       strict-mode: false           # false (default): prepend Claude Code prompt to user system messages
-#                                    # true: strip all user system messages, keep only Claude Code prompt
+#       strict-mode: false           # false (default): handle client system messages according to relaxed-system-prompt
+#                                    # true: strip all user system messages, keep only Claude Code prompt; overrides relaxed-system-prompt
+#       relaxed-system-prompt: true  # true (default): keep the billing and agent system blocks, then append client system messages as top-level system blocks
+#                                    # false: use the standard Claude Code prompt and forward client system messages
 #       sensitive-words:             # optional: words to obfuscate with zero-width characters
 #         - "API"
 #         - "proxy"

--- a/internal/config/cloak_test.go
+++ b/internal/config/cloak_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCloakConfigRelaxedSystemPromptPreservesPresence(t *testing.T) {
+	tests := []struct {
+		name      string
+		yamlValue string
+		want      *bool
+	}{
+		{name: "omitted", yamlValue: "mode: auto\n", want: nil},
+		{name: "enabled", yamlValue: "relaxed-system-prompt: true\n", want: boolPointer(true)},
+		{name: "disabled", yamlValue: "relaxed-system-prompt: false\n", want: boolPointer(false)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cloak CloakConfig
+			if err := yaml.Unmarshal([]byte(tt.yamlValue), &cloak); err != nil {
+				t.Fatalf("yaml.Unmarshal() error = %v", err)
+			}
+			if tt.want == nil {
+				if cloak.RelaxedSystemPrompt != nil {
+					t.Fatalf("RelaxedSystemPrompt = %v, want nil", *cloak.RelaxedSystemPrompt)
+				}
+				return
+			}
+			if cloak.RelaxedSystemPrompt == nil || *cloak.RelaxedSystemPrompt != *tt.want {
+				t.Fatalf("RelaxedSystemPrompt = %v, want %v", cloak.RelaxedSystemPrompt, *tt.want)
+			}
+		})
+	}
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}

--- a/internal/config/clone_test.go
+++ b/internal/config/clone_test.go
@@ -91,6 +91,7 @@ func sampleCloneRuntimeConfig() *Config {
 	bypassStrict := false
 	pluginEnabled := false
 	cacheUserID := true
+	relaxedSystemPrompt := true
 
 	return &Config{
 		SDKConfig: SDKConfig{
@@ -145,8 +146,9 @@ func sampleCloneRuntimeConfig() *Config {
 			Headers:        map[string]string{"X-Claude": "one"},
 			ExcludedModels: []string{"claude-hidden"},
 			Cloak: &CloakConfig{
-				SensitiveWords: []string{"secret"},
-				CacheUserID:    &cacheUserID,
+				RelaxedSystemPrompt: &relaxedSystemPrompt,
+				SensitiveWords:      []string{"secret"},
+				CacheUserID:         &cacheUserID,
 			},
 		}},
 		OpenAICompatibility: []OpenAICompatibility{{

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -294,9 +294,15 @@ type CloakConfig struct {
 	Mode string `yaml:"mode,omitempty" json:"mode,omitempty"`
 
 	// StrictMode controls how system prompts are handled when cloaking.
-	// - false (default): prepend Claude Code prompt to user system messages
-	// - true: strip all user system messages, keep only Claude Code prompt
+	// - false (default): handle client system prompts according to RelaxedSystemPrompt
+	// - true: strip all client system messages and keep only the Claude Code prompt
 	StrictMode bool `yaml:"strict-mode,omitempty" json:"strict-mode,omitempty"`
+
+	// RelaxedSystemPrompt preserves client system prompts as top-level Claude system blocks.
+	// - true (default): keep only the billing and agent identifier blocks, then append client system prompts
+	// - false: use the standard Claude Code system prompt and forwarding behavior
+	// StrictMode takes precedence when both settings are enabled.
+	RelaxedSystemPrompt *bool `yaml:"relaxed-system-prompt,omitempty" json:"relaxed-system-prompt,omitempty"`
 
 	// SensitiveWords is a list of words to obfuscate with zero-width characters.
 	// This can help bypass certain content filters.

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -60,11 +60,12 @@ func getWorkloadFromContext(ctx context.Context) string {
 
 // getCloakConfigFromAuth extracts cloak configuration from the auth's attributes,
 // falling back to its stored metadata (the raw OAuth/token JSON). Returns
-// (cloakMode, strictMode, sensitiveWords, cacheUserID); an empty cloakMode means
-// the credential did not explicitly configure a mode.
-func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMode bool, sensitiveWords []string, cacheUserID bool) {
+// (cloakMode, strictMode, relaxedSystemPrompt, sensitiveWords, cacheUserID);
+// an empty cloakMode means the credential did not explicitly configure a mode.
+// A nil relaxedSystemPrompt means the credential did not explicitly configure it.
+func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMode bool, relaxedSystemPrompt *bool, sensitiveWords []string, cacheUserID bool) {
 	if auth == nil {
-		return "", false, nil, false
+		return "", false, nil, nil, false
 	}
 
 	// lookupCloakAttr prefers the executor-facing Attributes, then falls back to the
@@ -80,6 +81,12 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMo
 			if value, ok := auth.Metadata[key].(string); ok {
 				return strings.TrimSpace(value)
 			}
+			if value, ok := auth.Metadata[key].(bool); ok {
+				if value {
+					return "true"
+				}
+				return "false"
+			}
 		}
 		return ""
 	}
@@ -89,6 +96,10 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMo
 	cloakMode = lookupCloakAttr("cloak_mode")
 
 	strictMode = strings.EqualFold(lookupCloakAttr("cloak_strict_mode"), "true")
+	if value := lookupCloakAttr("cloak_relaxed_system_prompt"); value != "" {
+		enabled := strings.EqualFold(value, "true")
+		relaxedSystemPrompt = &enabled
+	}
 
 	if wordsStr := lookupCloakAttr("cloak_sensitive_words"); wordsStr != "" {
 		sensitiveWords = strings.Split(wordsStr, ",")
@@ -99,7 +110,66 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMo
 
 	cacheUserID = strings.EqualFold(lookupCloakAttr("cloak_cache_user_id"), "true")
 
-	return cloakMode, strictMode, sensitiveWords, cacheUserID
+	return cloakMode, strictMode, relaxedSystemPrompt, sensitiveWords, cacheUserID
+}
+
+func resolveClaudeSystemPromptModes(attrStrict bool, attrRelaxedSystemPrompt *bool, cloakCfg *config.CloakConfig) (strictMode bool, relaxedSystemPrompt bool) {
+	strictMode = attrStrict
+	relaxedSystemPrompt = true
+	if attrRelaxedSystemPrompt != nil {
+		relaxedSystemPrompt = *attrRelaxedSystemPrompt
+	}
+	if cloakCfg != nil {
+		if cloakCfg.StrictMode {
+			strictMode = true
+		}
+		if cloakCfg.RelaxedSystemPrompt != nil {
+			relaxedSystemPrompt = *cloakCfg.RelaxedSystemPrompt
+		}
+	}
+	if strictMode {
+		relaxedSystemPrompt = false
+	}
+	return strictMode, relaxedSystemPrompt
+}
+
+type claudeCloakSettings struct {
+	mode                string
+	strictMode          bool
+	relaxedSystemPrompt bool
+	sensitiveWords      []string
+	cacheUserID         bool
+}
+
+func resolveClaudeCloakSettings(cfg *config.Config, auth *cliproxyauth.Auth) claudeCloakSettings {
+	cloakCfg := resolveClaudeKeyCloakConfig(cfg, auth)
+	attrMode, attrStrict, attrRelaxedSystemPrompt, attrWords, attrCache := getCloakConfigFromAuth(auth)
+	strictMode, relaxedSystemPrompt := resolveClaudeSystemPromptModes(attrStrict, attrRelaxedSystemPrompt, cloakCfg)
+	settings := claudeCloakSettings{
+		mode:                "auto",
+		strictMode:          strictMode,
+		relaxedSystemPrompt: relaxedSystemPrompt,
+		sensitiveWords:      attrWords,
+		cacheUserID:         attrCache,
+	}
+	if cfg != nil && cfg.DisableClaudeCloakMode {
+		settings.mode = "never"
+	}
+	if attrMode != "" {
+		settings.mode = attrMode
+	}
+	if cloakCfg != nil {
+		if mode := strings.TrimSpace(cloakCfg.Mode); mode != "" {
+			settings.mode = mode
+		}
+		if len(cloakCfg.SensitiveWords) > 0 {
+			settings.sensitiveWords = cloakCfg.SensitiveWords
+		}
+		if cloakCfg.CacheUserID != nil {
+			settings.cacheUserID = *cloakCfg.CacheUserID
+		}
+	}
+	return settings
 }
 
 // injectFakeUserID generates and injects a fake user ID into the request metadata.
@@ -178,19 +248,21 @@ func generateBillingHeader(payload []byte, experimentalCCHSigning bool, version,
 }
 
 func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
-	return checkSystemInstructionsWithSigningMode(payload, strictMode, false, false, "2.1.63", "", "")
+	return checkSystemInstructionsWithSigningMode(payload, strictMode, false, false, false, "2.1.63", "", "")
 }
 
 // checkSystemInstructionsWithSigningMode injects Claude Code-style system blocks:
 //
 //	system[0]: billing header (no cache_control)
 //	system[1]: agent identifier (cache_control ephemeral, scope=org)
-//	system[2]: core intro prompt (cache_control ephemeral, scope=global)
-//	system[3]: system instructions (no cache_control)
-//	system[4]: doing tasks (no cache_control)
-//	system[5]: user system messages moved to first user message
-func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, experimentalCCHSigning bool, oauthMode bool, version, entrypoint, workload string) []byte {
+//	system[2]: core intro prompt (cache_control ephemeral, scope=global), unless relaxedSystemPrompt is enabled
+//	system[3+]: client system blocks when relaxedSystemPrompt is enabled
+//
+// In standard (non-relaxed) mode, client system messages are moved to the first user message
+// to keep the upstream payload closer to the official Claude Code request shape.
+func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, relaxedSystemPrompt bool, experimentalCCHSigning bool, oauthMode bool, version, entrypoint, workload string) []byte {
 	system := gjson.GetBytes(payload, "system")
+	useRelaxedSystemPrompt := relaxedSystemPrompt && !strictMode
 
 	// Extract original message text for fingerprint computation (before billing injection).
 	// Use the first system text block's content as the fingerprint source.
@@ -231,10 +303,17 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 	staticBlock := buildTextBlock(staticPrompt, nil)
 
 	systemResult := "[" + billingBlock + "," + agentBlock + "," + staticBlock + "]"
+	if useRelaxedSystemPrompt {
+		systemResult = "[" + billingBlock + "," + agentBlock
+		if preservedSystem := buildRelaxedSystemPromptBlocks(system); preservedSystem != "" {
+			systemResult += "," + preservedSystem
+		}
+		systemResult += "]"
+	}
 	payload, _ = sjson.SetRawBytes(payload, "system", []byte(systemResult))
 
 	// Collect user system instructions and prepend to first user message
-	if !strictMode {
+	if !strictMode && !useRelaxedSystemPrompt {
 		var userSystemParts []string
 		if system.IsArray() {
 			system.ForEach(func(_, part gjson.Result) bool {
@@ -262,6 +341,25 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, exp
 	}
 
 	return payload
+}
+
+func buildRelaxedSystemPromptBlocks(system gjson.Result) string {
+	var blocks []string
+	if system.IsArray() {
+		system.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").String() != "text" {
+				return true
+			}
+			if strings.TrimSpace(part.Get("text").String()) == "" {
+				return true
+			}
+			blocks = append(blocks, part.Raw)
+			return true
+		})
+	} else if system.Type == gjson.String && strings.TrimSpace(system.String()) != "" {
+		blocks = append(blocks, buildTextBlock(system.String(), nil))
+	}
+	return strings.Join(blocks, ",")
 }
 
 // sanitizeForwardedSystemPrompt reduces forwarded third-party system context to a
@@ -372,45 +470,9 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 	// Enable cch signing for OAuth tokens by default (not just experimental flag).
 	oauthToken := isClaudeOAuthToken(apiKey)
 	useCCHSigning := oauthToken || experimentalCCHSigningEnabled(cfg, auth)
-
-	// Get cloak config from ClaudeKey configuration
-	cloakCfg := resolveClaudeKeyCloakConfig(cfg, auth)
-	attrMode, attrStrict, attrWords, attrCache := getCloakConfigFromAuth(auth)
-
-	// Determine cloak settings. Precedence (low -> high):
-	//   built-in "auto" default
-	//   -> global disable-claude-cloak-mode switch (forces "never")
-	//   -> per-credential settings from auth attributes/metadata
-	//   -> per claude-api-key cloak config
-	cloakMode := "auto"
-	if cfg != nil && cfg.DisableClaudeCloakMode {
-		cloakMode = "never"
-	}
-	strictMode := attrStrict
-	sensitiveWords := attrWords
-	cacheUserID := attrCache
-
-	if attrMode != "" {
-		cloakMode = attrMode
-	}
-
-	if cloakCfg != nil {
-		if mode := strings.TrimSpace(cloakCfg.Mode); mode != "" {
-			cloakMode = mode
-		}
-		if cloakCfg.StrictMode {
-			strictMode = true
-		}
-		if len(cloakCfg.SensitiveWords) > 0 {
-			sensitiveWords = cloakCfg.SensitiveWords
-		}
-		if cloakCfg.CacheUserID != nil {
-			cacheUserID = *cloakCfg.CacheUserID
-		}
-	}
-
+	cloakSettings := resolveClaudeCloakSettings(cfg, auth)
 	// Determine if cloaking should be applied
-	if !helps.ShouldCloak(cloakMode, clientUserAgent) {
+	if !helps.ShouldCloak(cloakSettings.mode, clientUserAgent) {
 		return payload, nil
 	}
 
@@ -419,19 +481,19 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 		billingVersion := helps.DefaultClaudeVersion(cfg)
 		entrypoint := parseEntrypointFromUA(clientUserAgent)
 		workload := getWorkloadFromContext(ctx)
-		payload = checkSystemInstructionsWithSigningMode(payload, strictMode, useCCHSigning, oauthToken, billingVersion, entrypoint, workload)
+		payload = checkSystemInstructionsWithSigningMode(payload, cloakSettings.strictMode, cloakSettings.relaxedSystemPrompt, useCCHSigning, oauthToken, billingVersion, entrypoint, workload)
 	}
 
 	// Inject fake user ID
 	var errFakeUserID error
-	payload, errFakeUserID = injectFakeUserID(ctx, payload, apiKey, cacheUserID)
+	payload, errFakeUserID = injectFakeUserID(ctx, payload, apiKey, cloakSettings.cacheUserID)
 	if errFakeUserID != nil {
 		return nil, errFakeUserID
 	}
 
 	// Apply sensitive word obfuscation
-	if len(sensitiveWords) > 0 {
-		matcher := helps.BuildSensitiveWordMatcher(sensitiveWords)
+	if len(cloakSettings.sensitiveWords) > 0 {
+		matcher := helps.BuildSensitiveWordMatcher(cloakSettings.sensitiveWords)
 		payload = helps.ObfuscateSensitiveWords(payload, matcher)
 	}
 

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -369,10 +369,6 @@ func claudeCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {
 	return
 }
 
-func checkSystemInstructions(payload []byte) []byte {
-	return checkSystemInstructionsWithSigningMode(payload, false, false, false, "2.1.63", "", "")
-}
-
 func rebuildMidSystemMessagesToTopLevel(payload []byte) []byte {
 	messages := gjson.GetBytes(payload, "messages")
 	if !messages.IsArray() {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1384,6 +1384,45 @@ func TestClaudeExecutor_CountTokensCountsLocallyWithoutUpstreamRequest(t *testin
 	}
 }
 
+func TestClaudeExecutor_CountTokensExcludesGenerationSystemPromptModes(t *testing.T) {
+	relaxedEnabled := true
+	relaxedDisabled := false
+	tests := []struct {
+		name  string
+		cloak *config.CloakConfig
+	}{
+		{name: "relaxed by default"},
+		{name: "relaxed explicitly disabled", cloak: &config.CloakConfig{RelaxedSystemPrompt: &relaxedDisabled}},
+		{name: "strict overrides relaxed", cloak: &config.CloakConfig{StrictMode: true, RelaxedSystemPrompt: &relaxedEnabled}},
+	}
+
+	payload := []byte(`{
+		"system":"client system instructions",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]
+	}`)
+	const expectedCount int64 = 7
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := NewClaudeExecutor(&config.Config{ClaudeKey: []config.ClaudeKey{{
+				APIKey: "key-123",
+				Cloak:  tt.cloak,
+			}}})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123"}}
+			resp, errCount := executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   "claude-sonnet-4-5",
+				Payload: payload,
+			}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+			if errCount != nil {
+				t.Fatalf("CountTokens() error = %v", errCount)
+			}
+			if got := gjson.GetBytes(resp.Payload, "input_tokens").Int(); got != expectedCount {
+				t.Fatalf("input_tokens = %d, want %d; payload = %s", got, expectedCount, resp.Payload)
+			}
+		})
+	}
+}
+
 func TestClaudeExecutor_CountTokensRejectsInvalidRequests(t *testing.T) {
 	testCases := []struct {
 		name    string
@@ -2451,6 +2490,44 @@ func TestCheckSystemInstructionsWithMode_StringSystemStrict(t *testing.T) {
 	}
 }
 
+func TestCheckSystemInstructionsWithSigningMode_RelaxedSystemPromptPreservesTopLevelSystem(t *testing.T) {
+	payload := []byte(`{"system":[{"type":"text","text":"Be concise.","cache_control":{"type":"ephemeral"}},{"type":"text","text":"   "},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"x"}},{"type":"text","text":"Prefer JSON."}],"messages":[{"role":"assistant","content":[{"type":"text","text":"ready"}]},{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	out := checkSystemInstructionsWithSigningMode(payload, false, true, false, false, "2.1.63", "", "")
+
+	blocks := gjson.GetBytes(out, "system").Array()
+	if len(blocks) != 4 {
+		t.Fatalf("relaxed system prompt should produce 2 injected blocks plus 2 client blocks, got %d: %s", len(blocks), gjson.GetBytes(out, "system").Raw)
+	}
+	if !strings.HasPrefix(blocks[0].Get("text").String(), "x-anthropic-billing-header:") {
+		t.Fatalf("blocks[0] should be billing header, got %q", blocks[0].Get("text").String())
+	}
+	if blocks[1].Get("text").String() != "You are Claude Code, Anthropic's official CLI for Claude." {
+		t.Fatalf("blocks[1] should be agent block, got %q", blocks[1].Get("text").String())
+	}
+	if got := blocks[2].Get("text").String(); got != "Be concise." {
+		t.Fatalf("blocks[2].text = %q, want client system prompt", got)
+	}
+	if got := blocks[2].Get("cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("blocks[2].cache_control.type = %q, want ephemeral", got)
+	}
+	if got := blocks[3].Get("text").String(); got != "Prefer JSON." {
+		t.Fatalf("blocks[3].text = %q, want second client system prompt", got)
+	}
+	if strings.Contains(gjson.GetBytes(out, "system").Raw, expectedClaudeCodeStaticPrompt()) {
+		t.Fatalf("relaxed system prompt should not include the static Claude Code prompt")
+	}
+	if strings.Contains(string(out), "<system-reminder>") {
+		t.Fatalf("relaxed system prompt should not prepend client system prompts into user messages: %s", string(out))
+	}
+	if got := gjson.GetBytes(out, "messages.0.role").String(); got != "assistant" {
+		t.Fatalf("messages.0.role = %q, want original assistant first message preserved", got)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.text").String(); got != "hi" {
+		t.Fatalf("messages.1.content.0.text = %q, want original user text", got)
+	}
+}
+
 // Test case 3: Empty string system prompt does not alter the first user message
 func TestCheckSystemInstructionsWithMode_EmptyStringSystemIgnored(t *testing.T) {
 	payload := []byte(`{"system":"","messages":[{"role":"user","content":"hi"}]}`)
@@ -2685,12 +2762,14 @@ func TestClaudeExecutor_RebuildMidSystemMessageOptInMovesSystemMessages(t *testi
 }
 
 func TestApplyCloaking_PreservesConfiguredStrictModeAndSensitiveWordsWhenModeOmitted(t *testing.T) {
+	relaxedSystemPrompt := true
 	cfg := &config.Config{
 		ClaudeKey: []config.ClaudeKey{{
 			APIKey: "key-123",
 			Cloak: &config.CloakConfig{
-				StrictMode:     true,
-				SensitiveWords: []string{"proxy"},
+				StrictMode:          true,
+				RelaxedSystemPrompt: &relaxedSystemPrompt,
+				SensitiveWords:      []string{"proxy"},
 			},
 		}},
 	}
@@ -2706,11 +2785,252 @@ func TestApplyCloaking_PreservesConfiguredStrictModeAndSensitiveWordsWhenModeOmi
 	if len(blocks) != 3 {
 		t.Fatalf("expected strict mode to keep the 3 injected Claude Code system blocks, got %d", len(blocks))
 	}
+	if got := blocks[2].Get("text").String(); got != expectedClaudeCodeStaticPrompt() {
+		t.Fatalf("strict mode should override the relaxed default and keep the static Claude Code prompt, got %q", got)
+	}
 	if got := gjson.GetBytes(out, "messages.0.content.#").Int(); got != 1 {
 		t.Fatalf("strict mode should not prepend a forwarded system reminder block, got %d content blocks", got)
 	}
 	if got := gjson.GetBytes(out, "messages.0.content.0.text").String(); !strings.Contains(got, "\u200B") {
 		t.Fatalf("expected configured sensitive word obfuscation to apply, got %q", got)
+	}
+}
+
+func TestClaudeExecutor_ExecutePathsUseConfiguredSystemPromptMode(t *testing.T) {
+	relaxedEnabled := true
+	relaxedDisabled := false
+	tests := []struct {
+		name             string
+		cloak            *config.CloakConfig
+		wantClientSystem bool
+		wantReminder     bool
+	}{
+		{name: "relaxed by default", wantClientSystem: true},
+		{
+			name:         "relaxed explicitly disabled",
+			cloak:        &config.CloakConfig{RelaxedSystemPrompt: &relaxedDisabled},
+			wantReminder: true,
+		},
+		{
+			name:  "strict overrides relaxed",
+			cloak: &config.CloakConfig{StrictMode: true, RelaxedSystemPrompt: &relaxedEnabled},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestBodies := make(chan []byte, 2)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, errRead := io.ReadAll(r.Body)
+				if errRead != nil {
+					t.Errorf("read request body: %v", errRead)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				requestBodies <- bytes.Clone(body)
+				if gjson.GetBytes(body, "stream").Bool() {
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = w.Write([]byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+			}))
+			defer server.Close()
+
+			executor := NewClaudeExecutor(&config.Config{ClaudeKey: []config.ClaudeKey{{
+				APIKey: "key-123",
+				Cloak:  tt.cloak,
+			}}})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{
+				"api_key":  "key-123",
+				"base_url": server.URL,
+			}}
+			request := cliproxyexecutor.Request{
+				Model:   "claude-sonnet-4-5",
+				Payload: []byte(`{"system":"Client rule","messages":[{"role":"user","content":"hi"}]}`),
+			}
+			options := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
+
+			if _, errExecute := executor.Execute(context.Background(), auth, request, options); errExecute != nil {
+				t.Fatalf("Execute() error = %v", errExecute)
+			}
+			stream, errStream := executor.ExecuteStream(context.Background(), auth, request, options)
+			if errStream != nil {
+				t.Fatalf("ExecuteStream() error = %v", errStream)
+			}
+			for chunk := range stream.Chunks {
+				if chunk.Err != nil {
+					t.Fatalf("ExecuteStream() chunk error = %v", chunk.Err)
+				}
+			}
+
+			for _, path := range []string{"execute", "stream"} {
+				body := <-requestBodies
+				blocks := gjson.GetBytes(body, "system").Array()
+				if len(blocks) != 3 {
+					t.Fatalf("%s system block count = %d, want 3: %s", path, len(blocks), gjson.GetBytes(body, "system").Raw)
+				}
+				if tt.wantClientSystem {
+					if got := blocks[2].Get("text").String(); got != "Client rule" {
+						t.Fatalf("%s system[2].text = %q, want client system prompt", path, got)
+					}
+				} else if got := blocks[2].Get("text").String(); got != expectedClaudeCodeStaticPrompt() {
+					t.Fatalf("%s system[2].text = %q, want static Claude Code prompt", path, got)
+				}
+				reminder := strings.Contains(gjson.GetBytes(body, "messages.0.content").String(), "<system-reminder>")
+				if reminder != tt.wantReminder {
+					t.Fatalf("%s system reminder present = %t, want %t: %s", path, reminder, tt.wantReminder, string(body))
+				}
+			}
+		})
+	}
+}
+
+func TestApplyCloaking_RelaxedSystemPromptEnabledByDefault(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123"}}
+	payload := []byte(`{"system":"Client rule","messages":[{"role":"user","content":"hi"}]}`)
+
+	out, errCloaking := applyCloaking(context.Background(), &config.Config{}, auth, payload, "claude-3-5-sonnet-20241022", "key-123")
+	if errCloaking != nil {
+		t.Fatalf("applyCloaking() error = %v", errCloaking)
+	}
+
+	blocks := gjson.GetBytes(out, "system").Array()
+	if len(blocks) != 3 {
+		t.Fatalf("default relaxed system prompt should keep 2 injected blocks plus the client system block, got %d: %s", len(blocks), gjson.GetBytes(out, "system").Raw)
+	}
+	if got := blocks[2].Get("text").String(); got != "Client rule" {
+		t.Fatalf("blocks[2].text = %q, want client system prompt", got)
+	}
+	if strings.Contains(gjson.GetBytes(out, "system").Raw, expectedClaudeCodeStaticPrompt()) {
+		t.Fatal("default relaxed system prompt should not include the static Claude Code prompt")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content").String(); got != "hi" {
+		t.Fatalf("messages.0.content = %q, want original user content", got)
+	}
+}
+
+func TestApplyCloaking_RelaxedSystemPromptCanBeDisabled(t *testing.T) {
+	disabled := false
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		auth *cliproxyauth.Auth
+	}{
+		{
+			name: "claude key config",
+			cfg: &config.Config{ClaudeKey: []config.ClaudeKey{{
+				APIKey: "key-123",
+				Cloak:  &config.CloakConfig{RelaxedSystemPrompt: &disabled},
+			}}},
+			auth: &cliproxyauth.Auth{
+				Attributes: map[string]string{"api_key": "key-123"},
+				Metadata:   map[string]any{"cloak_relaxed_system_prompt": true},
+			},
+		},
+		{
+			name: "auth metadata boolean",
+			cfg:  &config.Config{},
+			auth: &cliproxyauth.Auth{
+				Attributes: map[string]string{"api_key": "key-123"},
+				Metadata:   map[string]any{"cloak_relaxed_system_prompt": false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := []byte(`{"system":"Client rule","messages":[{"role":"user","content":"hi"}]}`)
+			out, errCloaking := applyCloaking(context.Background(), tt.cfg, tt.auth, payload, "claude-3-5-sonnet-20241022", "key-123")
+			if errCloaking != nil {
+				t.Fatalf("applyCloaking() error = %v", errCloaking)
+			}
+
+			blocks := gjson.GetBytes(out, "system").Array()
+			if len(blocks) != 3 {
+				t.Fatalf("standard system prompt should keep 3 injected blocks, got %d", len(blocks))
+			}
+			if got := blocks[2].Get("text").String(); got != expectedClaudeCodeStaticPrompt() {
+				t.Fatalf("explicit false should restore the static Claude Code prompt, got %q", got)
+			}
+			if got := gjson.GetBytes(out, "messages.0.content").String(); !strings.Contains(got, "<system-reminder>") {
+				t.Fatalf("explicit false should forward the client system prompt, got %q", got)
+			}
+		})
+	}
+}
+
+func TestApplyCloaking_RelaxedSystemPromptFromClaudeKeyConfig(t *testing.T) {
+	relaxedSystemPrompt := true
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "key-123",
+			Cloak: &config.CloakConfig{
+				RelaxedSystemPrompt: &relaxedSystemPrompt,
+			},
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"api_key": "key-123"},
+		Metadata:   map[string]any{"cloak_relaxed_system_prompt": false},
+	}
+	payload := []byte(`{"system":"Client rule","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	out, errCloaking := applyCloaking(context.Background(), cfg, auth, payload, "claude-3-5-sonnet-20241022", "key-123")
+	if errCloaking != nil {
+		t.Fatalf("applyCloaking() error = %v", errCloaking)
+	}
+
+	blocks := gjson.GetBytes(out, "system").Array()
+	if len(blocks) != 3 {
+		t.Fatalf("relaxed system prompt should keep 2 injected blocks plus the client system block, got %d: %s", len(blocks), gjson.GetBytes(out, "system").Raw)
+	}
+	if got := blocks[2].Get("text").String(); got != "Client rule" {
+		t.Fatalf("blocks[2].text = %q, want client system prompt", got)
+	}
+	if strings.Contains(gjson.GetBytes(out, "system").Raw, expectedClaudeCodeStaticPrompt()) {
+		t.Fatalf("relaxed system prompt should not include the static Claude Code prompt")
+	}
+	if strings.Contains(string(out), "<system-reminder>") {
+		t.Fatalf("relaxed system prompt should not forward client system prompt into messages: %s", string(out))
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.text").String(); got != "hi" {
+		t.Fatalf("messages.0.content.0.text = %q, want original user text", got)
+	}
+	if got := gjson.GetBytes(out, "metadata.user_id").String(); got == "" {
+		t.Fatal("expected cloaking to keep injecting metadata.user_id")
+	}
+}
+
+func TestApplyCloaking_RelaxedSystemPromptFromAuthMetadata(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{"api_key": "key-123"},
+		Metadata: map[string]any{
+			"cloak_relaxed_system_prompt": true,
+		},
+	}
+	payload := []byte(`{"system":[{"type":"text","text":"Client rule"}],"messages":[{"role":"user","content":"hi"}]}`)
+
+	_, _, relaxedSystemPrompt, _, _ := getCloakConfigFromAuth(auth)
+	if relaxedSystemPrompt == nil || !*relaxedSystemPrompt {
+		t.Fatalf("getCloakConfigFromAuth() relaxedSystemPrompt = %v, want explicit true", relaxedSystemPrompt)
+	}
+
+	out, errCloaking := applyCloaking(context.Background(), &config.Config{}, auth, payload, "claude-3-5-sonnet-20241022", "key-123")
+	if errCloaking != nil {
+		t.Fatalf("applyCloaking() error = %v", errCloaking)
+	}
+
+	blocks := gjson.GetBytes(out, "system").Array()
+	if len(blocks) != 3 {
+		t.Fatalf("relaxed system prompt from auth metadata should produce 3 system blocks, got %d", len(blocks))
+	}
+	if got := blocks[2].Get("text").String(); got != "Client rule" {
+		t.Fatalf("blocks[2].text = %q, want client system prompt", got)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content").String(); got != "hi" {
+		t.Fatalf("messages.0.content = %q, want original user text", got)
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -118,7 +118,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 	}
 
 	if !strings.HasPrefix(baseModel, "claude-3-5-haiku") {
-		body = checkSystemInstructions(body)
+		body = checkSystemInstructionsWithMode(body, false)
 	}
 
 	// Keep count_tokens requests compatible with Anthropic cache-control constraints too.

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -250,6 +250,11 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 			if o.RebuildMidSystemMessage != n.RebuildMidSystemMessage {
 				changes = append(changes, fmt.Sprintf("claude[%d].rebuild-mid-system-message: %t -> %t", i, o.RebuildMidSystemMessage, n.RebuildMidSystemMessage))
 			}
+			oldRelaxedSystemPrompt := relaxedSystemPromptEnabled(o.Cloak)
+			newRelaxedSystemPrompt := relaxedSystemPromptEnabled(n.Cloak)
+			if oldRelaxedSystemPrompt != newRelaxedSystemPrompt {
+				changes = append(changes, fmt.Sprintf("claude[%d].cloak.relaxed-system-prompt: %t -> %t", i, oldRelaxedSystemPrompt, newRelaxedSystemPrompt))
+			}
 			if o.Cloak != nil && n.Cloak != nil {
 				if strings.TrimSpace(o.Cloak.Mode) != strings.TrimSpace(n.Cloak.Mode) {
 					changes = append(changes, fmt.Sprintf("claude[%d].cloak.mode: %s -> %s", i, o.Cloak.Mode, n.Cloak.Mode))
@@ -423,6 +428,10 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	}
 
 	return changes
+}
+
+func relaxedSystemPromptEnabled(cloak *config.CloakConfig) bool {
+	return cloak == nil || cloak.RelaxedSystemPrompt == nil || *cloak.RelaxedSystemPrompt
 }
 
 func trimStrings(in []string) []string {

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -407,6 +407,8 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 }
 
 func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
+	relaxedSystemPromptDisabled := false
+	relaxedSystemPromptEnabled := true
 	oldCfg := &config.Config{
 		Port:                          1,
 		AuthDir:                       "/a",
@@ -425,7 +427,7 @@ func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 			{APIKey: "g-old", BaseURL: "http://g-old", ProxyURL: "http://gp-old", Headers: map[string]string{"A": "1"}},
 		},
 		ClaudeKey: []config.ClaudeKey{
-			{APIKey: "c-old", BaseURL: "http://c-old", ProxyURL: "http://cp-old", Headers: map[string]string{"H": "1"}, ExcludedModels: []string{"x"}},
+			{APIKey: "c-old", BaseURL: "http://c-old", ProxyURL: "http://cp-old", Headers: map[string]string{"H": "1"}, ExcludedModels: []string{"x"}, Cloak: &config.CloakConfig{Mode: "auto", RelaxedSystemPrompt: &relaxedSystemPromptDisabled, SensitiveWords: []string{"old"}}},
 		},
 		CodexKey: []config.CodexKey{
 			{APIKey: "x-old", BaseURL: "http://x-old", ProxyURL: "http://xp-old", Headers: map[string]string{"H": "1"}, ExcludedModels: []string{"x"}},
@@ -474,7 +476,7 @@ func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 			{APIKey: "g-new", BaseURL: "http://g-new", ProxyURL: "http://gp-new", Headers: map[string]string{"A": "2"}, ExcludedModels: []string{"x", "y"}},
 		},
 		ClaudeKey: []config.ClaudeKey{
-			{APIKey: "c-new", BaseURL: "http://c-new", ProxyURL: "http://cp-new", Headers: map[string]string{"H": "2"}, ExcludedModels: []string{"x", "y"}},
+			{APIKey: "c-new", BaseURL: "http://c-new", ProxyURL: "http://cp-new", Headers: map[string]string{"H": "2"}, ExcludedModels: []string{"x", "y"}, Cloak: &config.CloakConfig{Mode: "always", StrictMode: true, RelaxedSystemPrompt: &relaxedSystemPromptEnabled, SensitiveWords: []string{"new", "secret"}}},
 		},
 		CodexKey: []config.CodexKey{
 			{APIKey: "x-new", BaseURL: "http://x-new", ProxyURL: "http://xp-new", Headers: map[string]string{"H": "2"}, ExcludedModels: []string{"x", "y"}},
@@ -541,6 +543,10 @@ func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 	expectContains(t, changes, "claude[0].api-key: updated")
 	expectContains(t, changes, "claude[0].headers: updated")
 	expectContains(t, changes, "claude[0].excluded-models: updated (1 -> 2 entries)")
+	expectContains(t, changes, "claude[0].cloak.mode: auto -> always")
+	expectContains(t, changes, "claude[0].cloak.strict-mode: false -> true")
+	expectContains(t, changes, "claude[0].cloak.relaxed-system-prompt: false -> true")
+	expectContains(t, changes, "claude[0].cloak.sensitive-words: 1 -> 2")
 	expectContains(t, changes, "codex[0].base-url: http://x-old -> http://x-new")
 	expectContains(t, changes, "codex[0].proxy-url: http://xp-old -> http://xp-new")
 	expectContains(t, changes, "codex[0].api-key: updated")
@@ -581,6 +587,40 @@ func TestFormatProxyURL(t *testing.T) {
 			if got := formatProxyURL(tt.in); got != tt.want {
 				t.Fatalf("expected %q, got %q", tt.want, got)
 			}
+		})
+	}
+}
+
+func TestBuildConfigChangeDetails_RelaxedSystemPromptUsesEffectiveDefault(t *testing.T) {
+	disabled := false
+	enabled := true
+	claudeConfig := func(cloak *config.CloakConfig) *config.Config {
+		return &config.Config{ClaudeKey: []config.ClaudeKey{{APIKey: "key", Cloak: cloak}}}
+	}
+
+	tests := []struct {
+		name string
+		old  *config.CloakConfig
+		new  *config.CloakConfig
+		want string
+	}{
+		{name: "omitted field to disabled", old: &config.CloakConfig{}, new: &config.CloakConfig{RelaxedSystemPrompt: &disabled}, want: "claude[0].cloak.relaxed-system-prompt: true -> false"},
+		{name: "absent block to disabled", old: nil, new: &config.CloakConfig{RelaxedSystemPrompt: &disabled}, want: "claude[0].cloak.relaxed-system-prompt: true -> false"},
+		{name: "disabled to absent block", old: &config.CloakConfig{RelaxedSystemPrompt: &disabled}, new: nil, want: "claude[0].cloak.relaxed-system-prompt: false -> true"},
+		{name: "omitted field to enabled", old: &config.CloakConfig{}, new: &config.CloakConfig{RelaxedSystemPrompt: &enabled}},
+		{name: "absent block to enabled", old: nil, new: &config.CloakConfig{RelaxedSystemPrompt: &enabled}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changes := BuildConfigChangeDetails(claudeConfig(tt.old), claudeConfig(tt.new))
+			if tt.want == "" {
+				if len(changes) != 0 {
+					t.Fatalf("expected no effective change, got %v", changes)
+				}
+				return
+			}
+			expectContains(t, changes, tt.want)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Add `cloak.relaxed-system-prompt` for Claude API-key cloaking and `cloak_relaxed_system_prompt` for auth/token metadata.
- Enable relaxed system-prompt handling by default while preserving an explicit `false` opt-out.
- In relaxed mode, keep the billing header and `You are Claude Code, Anthropic's official CLI for Claude.` system blocks, skip the long static Claude Code prompt, and append client-provided text system blocks at the top level.
- Preserve explicit strict-mode behavior: `strict-mode: true` takes precedence and strips client system prompts.
- Apply the same cloak enablement and resolved system-prompt mode to message execution and `count_tokens` requests.
- Document the setting and include effective-value changes in config change details.

## Rationale

The standard cloak path moves client system prompts into a user-message `<system-reminder>`, changing their role and ordering semantics. Relaxed mode keeps the minimum Claude Code cloak markers while preserving downstream system instructions as actual Claude system blocks.

Because relaxed handling is the preferred behavior for this configuration, omission now means enabled. The configuration uses a presence-aware boolean so users can still select the standard forwarding path with `relaxed-system-prompt: false`. Auth/token metadata accepts both JSON booleans and legacy string boolean values.

Execution and token counting resolve cloak enablement plus strict and relaxed settings through the same precedence path, preventing `count_tokens` from measuring a different system-prompt shape than the corresponding request.

## Behavior

- Default: billing block, Claude Code agent block, then non-empty client text system blocks in their original order.
- `relaxed-system-prompt: false`: standard Claude Code static prompt and client-system forwarding behavior.
- `strict-mode: true`: standard injected Claude Code blocks only; client system prompts are discarded.
- Disabled cloak modes leave client system prompts unchanged in both execution and token counting.
- Client text block fields such as `cache_control` are preserved.
- Empty and non-text system blocks are ignored in relaxed mode.
- Existing cloak enablement, signing, Haiku exclusions, user ID injection, and sensitive-word handling remain unchanged.

## Validation

- `go test ./internal/config ./internal/watcher/diff ./internal/runtime/executor -run 'Test(CloakConfig|CloneForRuntime|BuildConfigChangeDetails|CheckSystemInstructions|ApplyCloaking|ClaudeExecutor_CountTokens|ClaudeExecutor_RebuildMidSystemMessage|ClaudeExecutor_ExperimentalCCHSigning)' -count=1`
- `go test ./... -count=1`
- `go build ./cmd/server`
