### PR TITLE
feat(store): object store support prefix and virtual-hosted-style access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,4 +31,6 @@
 # OBJECTSTORE_BUCKET=cli-proxy-config
 # OBJECTSTORE_ACCESS_KEY=your_access_key
 # OBJECTSTORE_SECRET_KEY=your_secret_key
+# OBJECTSTORE_VIRTUAL_HOSTED_STYLE=false
+# OBJECTSTORE_PREFIX=/
 # OBJECTSTORE_LOCAL_PATH=/data/cliproxy/objectstore

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -153,26 +154,28 @@ func main() {
 	var homeClient *home.Client
 	var homePluginSyncReport homeplugins.SyncReport
 	var (
-		usePostgresStore     bool
-		pgStoreDSN           string
-		pgStoreSchema        string
-		pgStoreLocalPath     string
-		pgStoreInst          *store.PostgresStore
-		useGitStore          bool
-		gitStoreRemoteURL    string
-		gitStoreUser         string
-		gitStorePassword     string
-		gitStoreBranch       string
-		gitStoreLocalPath    string
-		gitStoreInst         *store.GitTokenStore
-		gitStoreRoot         string
-		useObjectStore       bool
-		objectStoreEndpoint  string
-		objectStoreAccess    string
-		objectStoreSecret    string
-		objectStoreBucket    string
-		objectStoreLocalPath string
-		objectStoreInst      *store.ObjectTokenStore
+		usePostgresStore              bool
+		pgStoreDSN                    string
+		pgStoreSchema                 string
+		pgStoreLocalPath              string
+		pgStoreInst                   *store.PostgresStore
+		useGitStore                   bool
+		gitStoreRemoteURL             string
+		gitStoreUser                  string
+		gitStorePassword              string
+		gitStoreBranch                string
+		gitStoreLocalPath             string
+		gitStoreInst                  *store.GitTokenStore
+		gitStoreRoot                  string
+		useObjectStore                bool
+		objectStoreEndpoint           string
+		objectStoreAccess             string
+		objectStoreSecret             string
+		objectStoreBucket             string
+		objectStoreVirtualHostedStyle bool
+		objectStorePrefix             string
+		objectStoreLocalPath          string
+		objectStoreInst               *store.ObjectTokenStore
 	)
 
 	wd, err := os.Getwd()
@@ -254,6 +257,17 @@ func main() {
 	}
 	if value, ok := lookupEnv("OBJECTSTORE_BUCKET", "objectstore_bucket"); ok {
 		objectStoreBucket = value
+	}
+	if value, ok := lookupEnv("OBJECTSTORE_VIRTUAL_HOSTED_STYLE", "objectstore_virtual_hosted_style"); ok {
+		valueBool, errParse := strconv.ParseBool(value)
+		if errParse != nil {
+			log.Errorf("invalid OBJECTSTORE_VIRTUAL_HOSTED_STYLE value %q: %v", value, err)
+			return
+		}
+		objectStoreVirtualHostedStyle = valueBool
+	}
+	if value, ok := lookupEnv("OBJECTSTORE_PREFIX", "objectstore_prefix"); ok {
+		objectStorePrefix = value
 	}
 	if value, ok := lookupEnv("OBJECTSTORE_LOCAL_PATH", "objectstore_local_path"); ok {
 		objectStoreLocalPath = value
@@ -402,9 +416,10 @@ func main() {
 			Bucket:    objectStoreBucket,
 			AccessKey: objectStoreAccess,
 			SecretKey: objectStoreSecret,
+			Prefix:    objectStorePrefix,
 			LocalRoot: objectStoreRoot,
 			UseSSL:    useSSL,
-			PathStyle: true,
+			PathStyle: !objectStoreVirtualHostedStyle,
 		}
 		objectStoreInst, err = store.NewObjectTokenStore(objCfg)
 		if err != nil {

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -146,7 +146,7 @@ func (s *ObjectTokenStore) Bootstrap(ctx context.Context, exampleConfigPath stri
 		return fmt.Errorf("object store: not initialized")
 	}
 	if err := s.ensureBucket(ctx); err != nil {
-		return err
+		log.WithError(err).Warnf("object store: skip ensure bucket %s", s.cfg.Bucket)
 	}
 	if err := s.syncConfigFromBucket(ctx, exampleConfigPath); err != nil {
 		return err

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -102,6 +102,8 @@ func NewObjectTokenStore(cfg ObjectStoreConfig) (*ObjectTokenStore, error) {
 	}
 	if cfg.PathStyle {
 		options.BucketLookup = minio.BucketLookupPath
+	} else {
+		options.BucketLookup = minio.BucketLookupDNS
 	}
 
 	client, err := minio.New(cfg.Endpoint, options)


### PR DESCRIPTION
## Summary

- Add `OBJECTSTORE_VIRTUAL_HOSTED_STYLE` to support S3-compatible providers that require virtual-hosted-style bucket addressing.
- Add `OBJECTSTORE_PREFIX` so a single object store bucket can isolate CLIProxyAPI data under a fixed prefix.
- Skip the object store bucket existence/create check during bootstrap to avoid requiring bucket-level list/create permissions. Missing or inaccessible buckets will still fail later when reading or writing objects.
