### PR TITLE
Unify prefixed model capability lookup

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -240,6 +240,8 @@ nonstream-keepalive-interval: 0
 #     models:
 #       - name: "gemini-2.5-flash" # upstream model name
 #         alias: "native-gemini-flash" # client alias mapped to the upstream model
+#         thinking:                # optional: explicit thinking/reasoning support
+#           levels: ["low", "medium", "high"]
 #     excluded-models:
 #       - "gemini-2.5-pro"
 
@@ -257,6 +259,8 @@ nonstream-keepalive-interval: 0
 #       - name: "gpt-5-codex"   # upstream model name
 #         alias: "codex-latest" # client alias mapped to the upstream model
 #         force-mapping: true    # optional: rewrite response model fields back to the alias
+#         thinking:              # optional: explicit thinking/reasoning support
+#           levels: ["low", "medium", "high"]
 #     excluded-models:
 #       - "gpt-5.1"         # exclude specific models (exact match)
 #       - "gpt-5-*"         # wildcard matching prefix (e.g. gpt-5-medium, gpt-5-codex)
@@ -278,6 +282,8 @@ nonstream-keepalive-interval: 0
 #       - name: "claude-3-5-sonnet-20241022" # upstream model name
 #         alias: "claude-sonnet-latest"      # client alias mapped to the upstream model
 #         force-mapping: true                 # optional: rewrite response model fields back to the alias
+#         thinking:                           # optional: explicit thinking/reasoning support
+#           levels: ["high", "medium", "low", "minimal", "none", "auto"]
 #     excluded-models:
 #       - "claude-opus-4-5-20251101" # exclude specific models (exact match)
 #       - "claude-3-*"               # wildcard matching prefix (e.g. claude-3-7-sonnet-20250219)
@@ -370,6 +376,8 @@ nonstream-keepalive-interval: 0
 #     models:                                     # optional: map aliases to upstream model names
 #       - name: "gemini-2.5-flash"                # upstream model name
 #         alias: "vertex-flash"                   # client-visible alias
+#         thinking:                               # optional: explicit thinking/reasoning support
+#           levels: ["low", "medium", "high"]
 #       - name: "gemini-2.5-pro"
 #         alias: "vertex-pro"
 #     excluded-models:                            # optional: models to exclude from listing

--- a/internal/config/api_key_model_thinking_test.go
+++ b/internal/config/api_key_model_thinking_test.go
@@ -1,0 +1,33 @@
+package config
+
+import "testing"
+
+func TestParseClaudeModelThinking(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte(`
+claude-api-key:
+  - api-key: test-key
+    models:
+      - name: claude-opus-4-6
+        thinking:
+          levels:
+            - high
+            - medium
+            - low
+            - minimal
+            - none
+            - auto
+`))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+	if len(cfg.ClaudeKey) != 1 || len(cfg.ClaudeKey[0].Models) != 1 {
+		t.Fatalf("parsed claude models = %#v", cfg.ClaudeKey)
+	}
+	thinking := cfg.ClaudeKey[0].Models[0].Thinking
+	if thinking == nil {
+		t.Fatal("Thinking = nil, want configured support")
+	}
+	if got, want := len(thinking.Levels), 6; got != want {
+		t.Fatalf("Thinking.Levels count = %d, want %d", got, want)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -492,11 +492,17 @@ type ClaudeModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m ClaudeModel) GetName() string       { return m.Name }
 func (m ClaudeModel) GetAlias() string      { return m.Alias }
 func (m ClaudeModel) GetForceMapping() bool { return m.ForceMapping }
+func (m ClaudeModel) GetThinking() *registry.ThinkingSupport {
+	return m.Thinking
+}
 
 // CodexKey represents the configuration for a Codex API key,
 // including the API key itself and an optional base URL for the API endpoint.
@@ -547,11 +553,17 @@ type CodexModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m CodexModel) GetName() string       { return m.Name }
 func (m CodexModel) GetAlias() string      { return m.Alias }
 func (m CodexModel) GetForceMapping() bool { return m.ForceMapping }
+func (m CodexModel) GetThinking() *registry.ThinkingSupport {
+	return m.Thinking
+}
 
 // GeminiKey represents the configuration for a Gemini API key,
 // including optional overrides for upstream base URL, proxy routing, and headers.
@@ -598,11 +610,17 @@ type GeminiModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m GeminiModel) GetName() string       { return m.Name }
 func (m GeminiModel) GetAlias() string      { return m.Alias }
 func (m GeminiModel) GetForceMapping() bool { return m.ForceMapping }
+func (m GeminiModel) GetThinking() *registry.ThinkingSupport {
+	return m.Thinking
+}
 
 // OpenAICompatibility represents the configuration for OpenAI API compatibility
 // with external providers, allowing model aliases to be routed through OpenAI API format.
@@ -675,6 +693,9 @@ type OpenAICompatibilityModel struct {
 func (m OpenAICompatibilityModel) GetName() string       { return m.Name }
 func (m OpenAICompatibilityModel) GetAlias() string      { return m.Alias }
 func (m OpenAICompatibilityModel) GetForceMapping() bool { return m.ForceMapping }
+func (m OpenAICompatibilityModel) GetThinking() *registry.ThinkingSupport {
+	return m.Thinking
+}
 
 // LoadConfig reads a YAML configuration file from the given path,
 // unmarshals it into a Config struct, applies environment variable overrides,

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -1,6 +1,10 @@
 package config
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
 
 // VertexCompatKey represents the configuration for Vertex AI-compatible API keys.
 // This supports third-party services that use Vertex AI-style endpoint paths
@@ -53,11 +57,17 @@ type VertexCompatModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m VertexCompatModel) GetName() string       { return m.Name }
 func (m VertexCompatModel) GetAlias() string      { return m.Alias }
 func (m VertexCompatModel) GetForceMapping() bool { return m.ForceMapping }
+func (m VertexCompatModel) GetThinking() *registry.ThinkingSupport {
+	return m.Thinking
+}
 
 // SanitizeVertexCompatKeys deduplicates and normalizes Vertex-compatible API key credentials.
 func (cfg *Config) SanitizeVertexCompatKeys() {

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -66,10 +66,15 @@ type ModelInfo struct {
 	// Thinking holds provider-specific reasoning/thinking budget capabilities.
 	// This is optional and currently used for Gemini thinking budget normalization.
 	Thinking *ThinkingSupport `json:"thinking,omitempty"`
+	// ThinkingExplicit indicates Thinking was explicitly provided by user config,
+	// rather than inferred from static upstream metadata.
+	ThinkingExplicit bool `json:"-"`
 
 	// UserDefined indicates this model was defined through config file's models[]
 	// array (e.g., openai-compatibility.*.models[], *-api-key.models[]).
-	// UserDefined models have thinking configuration passed through without validation.
+	// UserDefined models with no Thinking metadata pass thinking configuration
+	// through without validation. When ThinkingExplicit is set, source-format
+	// thinking configuration is validated against the configured capabilities.
 	UserDefined bool `json:"-"`
 }
 

--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -131,7 +131,7 @@ func (e *AIStudioExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth,
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
-	translatedReq, body, err := e.translateRequest(req, opts, false)
+	translatedReq, body, err := e.translateRequest(auth, req, opts, false)
 	if err != nil {
 		return resp, err
 	}
@@ -200,7 +200,7 @@ func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
-	translatedReq, body, err := e.translateRequest(req, opts, true)
+	translatedReq, body, err := e.translateRequest(auth, req, opts, true)
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +376,7 @@ func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth
 // CountTokens counts tokens for the given request using the AI Studio API.
 func (e *AIStudioExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
-	_, body, err := e.translateRequest(req, opts, false)
+	_, body, err := e.translateRequest(auth, req, opts, false)
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
@@ -444,7 +444,7 @@ type translatedPayload struct {
 	toFormat sdktranslator.Format
 }
 
-func (e *AIStudioExecutor) translateRequest(req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) ([]byte, translatedPayload, error) {
+func (e *AIStudioExecutor) translateRequest(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) ([]byte, translatedPayload, error) {
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
 	from := opts.SourceFormat
@@ -456,7 +456,7 @@ func (e *AIStudioExecutor) translateRequest(req cliproxyexecutor.Request, opts c
 	originalPayload := originalPayloadSource
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, stream)
 	payload := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
-	payload, err := thinking.ApplyThinking(payload, req.Model, from.String(), to.String(), e.Identifier())
+	payload, err := helps.ApplyRequestThinkingWithSource(payload, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return nil, translatedPayload{}, err
 	}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -318,6 +318,23 @@ func validateAntigravityRequestSignatures(ctx context.Context, modelName string,
 	return rawJSON, nil
 }
 
+func translateAntigravityRequest(from sdktranslator.Format, to sdktranslator.Format, model string, capabilityModel string, modelInfo *registry.ModelInfo, rawJSON []byte, stream bool) []byte {
+	translateModel := model
+	if from == sdktranslator.FormatClaude &&
+		to == sdktranslator.FormatAntigravity &&
+		modelInfo != nil &&
+		modelInfo.SupportsWebSearch &&
+		strings.TrimSpace(capabilityModel) != "" &&
+		hasAntigravityClaudeTypedWebSearchTool(rawJSON) {
+		translateModel = capabilityModel
+	}
+	out := sdktranslator.TranslateRequest(from, to, translateModel, rawJSON, stream)
+	if translateModel != model {
+		out, _ = sjson.SetBytes(out, "model", model)
+	}
+	return out
+}
+
 func hasAntigravityClaudeTypedWebSearchTool(payload []byte) bool {
 	tools := gjson.GetBytes(payload, "tools")
 	if !tools.IsArray() {
@@ -653,10 +670,11 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	if updatedAuth != nil {
 		auth = updatedAuth
 	}
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
-	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+	modelInfo := helps.RequestModelInfo(auth, e.Identifier(), req.Model, opts)
+	originalTranslated := translateAntigravityRequest(from, to, baseModel, modelInfo.Model, modelInfo.Info, originalPayload, false)
+	translated := translateAntigravityRequest(from, to, baseModel, modelInfo.Model, modelInfo.Info, req.Payload, false)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = thinking.ApplyThinkingWithResolvedModelInfo(translated, originalPayloadSource, modelInfo.Model, from.String(), to.String(), e.Identifier(), modelInfo.Info, modelInfo.Resolved)
 	if err != nil {
 		return resp, err
 	}
@@ -697,7 +715,7 @@ attemptLoop:
 				}
 			}
 
-			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, false, opts.Alt, baseURL)
+			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, false, opts.Alt, baseURL, modelInfo.Info)
 			if errReq != nil {
 				err = errReq
 				return resp, err
@@ -874,10 +892,11 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	if updatedAuth != nil {
 		auth = updatedAuth
 	}
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
-	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
+	modelInfo := helps.RequestModelInfo(auth, e.Identifier(), req.Model, opts)
+	originalTranslated := translateAntigravityRequest(from, to, baseModel, modelInfo.Model, modelInfo.Info, originalPayload, true)
+	translated := translateAntigravityRequest(from, to, baseModel, modelInfo.Model, modelInfo.Info, req.Payload, true)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = thinking.ApplyThinkingWithResolvedModelInfo(translated, originalPayloadSource, modelInfo.Model, from.String(), to.String(), e.Identifier(), modelInfo.Info, modelInfo.Resolved)
 	if err != nil {
 		return resp, err
 	}
@@ -909,7 +928,7 @@ attemptLoop:
 					helps.MarkCreditsUsed(ctx)
 				}
 			}
-			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, true, opts.Alt, baseURL)
+			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, true, opts.Alt, baseURL, modelInfo.Info)
 			if errReq != nil {
 				err = errReq
 				return resp, err
@@ -1344,10 +1363,11 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 		auth = updatedAuth
 	}
 
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
-	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
+	modelInfo := helps.RequestModelInfo(auth, e.Identifier(), req.Model, opts)
+	originalTranslated := translateAntigravityRequest(from, to, baseModel, modelInfo.Model, modelInfo.Info, originalPayload, true)
+	translated := translateAntigravityRequest(from, to, baseModel, modelInfo.Model, modelInfo.Info, req.Payload, true)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = thinking.ApplyThinkingWithResolvedModelInfo(translated, originalPayloadSource, modelInfo.Model, from.String(), to.String(), e.Identifier(), modelInfo.Info, modelInfo.Resolved)
 	if err != nil {
 		return nil, err
 	}
@@ -1389,7 +1409,7 @@ attemptLoop:
 					return nil, err
 				}
 			}
-			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, true, opts.Alt, baseURL)
+			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, true, opts.Alt, baseURL, modelInfo.Info)
 			if errReq != nil {
 				err = errReq
 				return nil, err
@@ -1679,9 +1699,14 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 	}
 
 	// Prepare payload once (doesn't depend on baseURL)
-	payload := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+	sourcePayload := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		sourcePayload = opts.OriginalRequest
+	}
+	modelInfo := helps.RequestModelInfo(auth, e.Identifier(), req.Model, opts)
+	payload := translateAntigravityRequest(from, to, baseModel, modelInfo.Model, modelInfo.Info, req.Payload, false)
 
-	payload, err := thinking.ApplyThinking(payload, req.Model, from.String(), to.String(), e.Identifier())
+	payload, err := thinking.ApplyThinkingWithResolvedModelInfo(payload, sourcePayload, modelInfo.Model, from.String(), to.String(), e.Identifier(), modelInfo.Info, modelInfo.Resolved)
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
@@ -2190,7 +2215,7 @@ func (e *AntigravityExecutor) updateAntigravityCreditsBalance(ctx context.Contex
 	}
 }
 
-func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyauth.Auth, token, modelName string, payload []byte, stream bool, alt, baseURL string) (*http.Request, error) {
+func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyauth.Auth, token, modelName string, payload []byte, stream bool, alt, baseURL string, modelInfo *registry.ModelInfo) (*http.Request, error) {
 	if token == "" {
 		return nil, statusErr{code: http.StatusUnauthorized, msg: "missing access token"}
 	}
@@ -2227,10 +2252,20 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 
 	// Cap maxOutputTokens to model's max_completion_tokens from registry
 	if maxOut := gjson.GetBytes(payload, "request.generationConfig.maxOutputTokens"); maxOut.Exists() && maxOut.Type == gjson.Number {
-		if modelInfo := registry.LookupModelInfo(modelName, "antigravity"); modelInfo != nil && modelInfo.MaxCompletionTokens > 0 {
-			if int(maxOut.Int()) > modelInfo.MaxCompletionTokens {
-				payload, _ = sjson.SetBytes(payload, "request.generationConfig.maxOutputTokens", modelInfo.MaxCompletionTokens)
+		if modelInfo == nil {
+			modelInfo = registry.LookupModelInfo(modelName, "antigravity")
+		}
+		limit := 0
+		if modelInfo != nil {
+			limit = modelInfo.MaxCompletionTokens
+		}
+		if limit <= 0 {
+			if info := registry.LookupModelInfo(modelName, "antigravity"); info != nil {
+				limit = info.MaxCompletionTokens
 			}
+		}
+		if limit > 0 && int(maxOut.Int()) > limit {
+			payload, _ = sjson.SetBytes(payload, "request.generationConfig.maxOutputTokens", limit)
 		}
 	}
 

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
 )
 
 func TestAntigravityBuildRequest_SanitizesGeminiToolSchema(t *testing.T) {
@@ -37,6 +39,38 @@ func TestAntigravityBuildRequest_SanitizesAntigravityToolSchema(t *testing.T) {
 		t.Fatalf("parameters missing or invalid type")
 	}
 	assertSchemaSanitizedAndPropertyPreserved(t, params)
+}
+
+func TestTranslateAntigravityRequestUsesPrefixedCapabilityModelForWebSearch(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-antigravity-executor-prefixed-websearch"
+	modelInfo := &registry.ModelInfo{
+		ID:                "free-provider/gemini-3.1-flash-lite",
+		SupportsWebSearch: true,
+	}
+	reg.RegisterClient(clientID, "antigravity", []*registry.ModelInfo{modelInfo})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+	inputJSON := []byte(`{
+		"model": "gemini-3.1-flash-lite",
+		"messages": [{"role": "user", "content": "Search current weather"}],
+		"tools": [{"type": "web_search_20250305", "name": "web_search"}]
+	}`)
+
+	output := translateAntigravityRequest(
+		sdktranslator.FormatClaude,
+		sdktranslator.FormatAntigravity,
+		"gemini-3.1-flash-lite",
+		"free-provider/gemini-3.1-flash-lite",
+		modelInfo,
+		inputJSON,
+		true,
+	)
+	if got := gjson.GetBytes(output, "requestType").String(); got != "web_search" {
+		t.Fatalf("requestType = %q, want web_search: %s", got, output)
+	}
+	if got := gjson.GetBytes(output, "model").String(); got != "gemini-3.1-flash-lite" {
+		t.Fatalf("request model = %q, want unprefixed upstream model: %s", got, output)
+	}
 }
 
 func TestAntigravityBuildRequest_SkipsSchemaSanitizationWithoutToolsField(t *testing.T) {
@@ -237,7 +271,7 @@ func TestAntigravityBuildRequest_RejectsMissingProjectID(t *testing.T) {
 	executor := &AntigravityExecutor{}
 	auth := &cliproxyauth.Auth{Metadata: map[string]any{}}
 
-	_, err := executor.buildRequest(context.Background(), auth, "token", "gemini-3.1-pro", []byte(`{"request":{}}`), false, "", "https://example.com")
+	_, err := executor.buildRequest(context.Background(), auth, "token", "gemini-3.1-pro", []byte(`{"request":{}}`), false, "", "https://example.com", nil)
 	if err == nil {
 		t.Fatalf("buildRequest should fail when auth has no project_id")
 	}
@@ -337,7 +371,7 @@ func buildRequestBodyFromRawPayload(t *testing.T, modelName string, payload []by
 	executor := &AntigravityExecutor{}
 	auth := &cliproxyauth.Auth{Metadata: map[string]any{"project_id": "project-1"}}
 
-	req, err := executor.buildRequest(context.Background(), auth, "token", modelName, payload, false, "", "https://example.com")
+	req, err := executor.buildRequest(context.Background(), auth, "token", modelName, payload, false, "", "https://example.com", nil)
 	if err != nil {
 		t.Fatalf("buildRequest error: %v", err)
 	}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -222,7 +222,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, stream)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return resp, err
 	}
@@ -240,7 +240,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
-	body = ensureModelMaxTokens(body, baseModel)
+	body = ensureModelMaxTokens(body, baseModel, helps.RequestModelInfo(auth, e.Identifier(), req.Model, opts).Info)
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
@@ -415,7 +415,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +433,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
-	body = ensureModelMaxTokens(body, baseModel)
+	body = ensureModelMaxTokens(body, baseModel, helps.RequestModelInfo(auth, e.Identifier(), req.Model, opts).Info)
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
@@ -2631,7 +2631,7 @@ func injectSystemCacheControl(payload []byte) []byte {
 	return payload
 }
 
-func ensureModelMaxTokens(body []byte, modelID string) []byte {
+func ensureModelMaxTokens(body []byte, modelID string, modelInfo *registry.ModelInfo) []byte {
 	if len(body) == 0 || !gjson.ValidBytes(body) {
 		return body
 	}
@@ -2640,11 +2640,27 @@ func ensureModelMaxTokens(body []byte, modelID string) []byte {
 		return body
 	}
 
+	maxTokens := 0
+	if modelInfo != nil {
+		maxTokens = modelInfo.MaxCompletionTokens
+	}
+	if maxTokens <= 0 {
+		if info := registry.LookupModelInfo(strings.TrimSpace(modelID), "claude"); info != nil {
+			maxTokens = info.MaxCompletionTokens
+		}
+	}
+	if modelInfo != nil {
+		if maxTokens <= 0 {
+			maxTokens = defaultModelMaxTokens
+		}
+		body, _ = sjson.SetBytes(body, "max_tokens", maxTokens)
+		return body
+	}
+
 	for _, provider := range registry.GetGlobalRegistry().GetModelProviders(strings.TrimSpace(modelID)) {
 		if strings.EqualFold(provider, "claude") {
-			maxTokens := defaultModelMaxTokens
-			if info := registry.GetGlobalRegistry().GetModelInfo(strings.TrimSpace(modelID), "claude"); info != nil && info.MaxCompletionTokens > 0 {
-				maxTokens = info.MaxCompletionTokens
+			if maxTokens <= 0 {
+				maxTokens = defaultModelMaxTokens
 			}
 			body, _ = sjson.SetBytes(body, "max_tokens", maxTokens)
 			return body

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1940,7 +1940,7 @@ func TestEnsureModelMaxTokens_UsesRegisteredMaxCompletionTokens(t *testing.T) {
 	defer reg.UnregisterClient(clientID)
 
 	input := []byte(`{"model":"test-claude-max-completion-tokens-model","messages":[{"role":"user","content":"hi"}]}`)
-	out := ensureModelMaxTokens(input, modelID)
+	out := ensureModelMaxTokens(input, modelID, nil)
 
 	if got := gjson.GetBytes(out, "max_tokens").Int(); got != 4096 {
 		t.Fatalf("max_tokens = %d, want %d", got, 4096)
@@ -1962,7 +1962,7 @@ func TestEnsureModelMaxTokens_DefaultsMissingValue(t *testing.T) {
 	defer reg.UnregisterClient(clientID)
 
 	input := []byte(`{"model":"test-claude-default-max-tokens-model","messages":[{"role":"user","content":"hi"}]}`)
-	out := ensureModelMaxTokens(input, modelID)
+	out := ensureModelMaxTokens(input, modelID, nil)
 
 	if got := gjson.GetBytes(out, "max_tokens").Int(); got != defaultModelMaxTokens {
 		t.Fatalf("max_tokens = %d, want %d", got, defaultModelMaxTokens)
@@ -1985,7 +1985,7 @@ func TestEnsureModelMaxTokens_PreservesExplicitValue(t *testing.T) {
 	defer reg.UnregisterClient(clientID)
 
 	input := []byte(`{"model":"test-claude-preserve-max-tokens-model","max_tokens":2048,"messages":[{"role":"user","content":"hi"}]}`)
-	out := ensureModelMaxTokens(input, modelID)
+	out := ensureModelMaxTokens(input, modelID, nil)
 
 	if got := gjson.GetBytes(out, "max_tokens").Int(); got != 2048 {
 		t.Fatalf("max_tokens = %d, want %d", got, 2048)
@@ -1994,7 +1994,7 @@ func TestEnsureModelMaxTokens_PreservesExplicitValue(t *testing.T) {
 
 func TestEnsureModelMaxTokens_SkipsUnregisteredModel(t *testing.T) {
 	input := []byte(`{"model":"test-claude-unregistered-model","messages":[{"role":"user","content":"hi"}]}`)
-	out := ensureModelMaxTokens(input, "test-claude-unregistered-model")
+	out := ensureModelMaxTokens(input, "test-claude-unregistered-model", nil)
 
 	if gjson.GetBytes(out, "max_tokens").Exists() {
 		t.Fatalf("max_tokens should remain unset, got %s", gjson.GetBytes(out, "max_tokens").Raw)
@@ -2950,6 +2950,459 @@ func TestEnsureClaudeThinkingDisplay_SetsSummarizedWhenMissing(t *testing.T) {
 	}
 	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
 		t.Fatalf("thinking.type = %q, want adaptive", got)
+	}
+}
+
+func TestClaudeThinkingUsesOriginalOpenAIReasoningEffortWithPrefixedModelInfo(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-prefixed-claude-thinking-client"
+	upstreamModel := "claude-sonnet-4-6"
+	prefixedModel := "sp-anthropic/" + upstreamModel
+	reg.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
+		ID:               prefixedModel,
+		Type:             "claude",
+		OwnedBy:          "anthropic",
+		Object:           "model",
+		Created:          time.Now().Unix(),
+		UserDefined:      true,
+		ThinkingExplicit: true,
+		Thinking: &registry.ThinkingSupport{
+			ZeroAllowed:    true,
+			DynamicAllowed: true,
+			Levels:         []string{"minimal", "low", "medium", "high", "xhigh", "none", "auto"},
+		},
+	}})
+	defer reg.UnregisterClient(clientID)
+
+	source := []byte(`{"model":"sp-anthropic/claude-sonnet-4-6","reasoning_effort":"xhigh","messages":[{"role":"user","content":"hi"}]}`)
+	translated := sdktranslator.TranslateRequest(
+		sdktranslator.FromString("openai"),
+		sdktranslator.FromString("claude"),
+		upstreamModel,
+		source,
+		false,
+	)
+	translated, _ = sjson.SetBytes(translated, "thinking.type", "adaptive")
+	translated, _ = sjson.SetBytes(translated, "output_config.effort", "max")
+
+	auth := &cliproxyauth.Auth{
+		ID:       clientID,
+		Provider: "claude",
+		Prefix:   "sp-anthropic",
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ModelInfoLookupModelMetadataKey: prefixedModel,
+		},
+	}
+	out, err := helps.ApplyRequestThinkingWithSource(
+		translated,
+		source,
+		auth,
+		"claude",
+		upstreamModel,
+		opts,
+		"openai",
+		"claude",
+	)
+	if err != nil {
+		t.Fatalf("ApplyRequestThinkingWithSource() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "xhigh" {
+		t.Fatalf("output_config.effort = %q, want xhigh; body=%s", got, out)
+	}
+}
+
+func TestClaudeThinkingUsesOriginalOpenAIResponsesReasoningWithPrefixedModelInfo(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-prefixed-claude-responses-thinking-client"
+	upstreamModel := "claude-sonnet-4-6"
+	prefixedModel := "sp-responses/" + upstreamModel
+	reg.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
+		ID:               prefixedModel,
+		Type:             "claude",
+		OwnedBy:          "anthropic",
+		Object:           "model",
+		Created:          time.Now().Unix(),
+		UserDefined:      true,
+		ThinkingExplicit: true,
+		Thinking: &registry.ThinkingSupport{
+			ZeroAllowed:    true,
+			DynamicAllowed: true,
+			Levels:         []string{"minimal", "low", "medium", "high", "xhigh", "none", "auto"},
+		},
+	}})
+	defer reg.UnregisterClient(clientID)
+
+	source := []byte(`{"model":"sp-responses/claude-sonnet-4-6","reasoning":{"effort":"xhigh"},"input":"hi"}`)
+	translated := sdktranslator.TranslateRequest(
+		sdktranslator.FromString("openai-response"),
+		sdktranslator.FromString("claude"),
+		upstreamModel,
+		source,
+		false,
+	)
+	translated, _ = sjson.SetBytes(translated, "thinking.type", "adaptive")
+	translated, _ = sjson.SetBytes(translated, "output_config.effort", "max")
+
+	auth := &cliproxyauth.Auth{
+		ID:       clientID,
+		Provider: "claude",
+		Prefix:   "sp-responses",
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ModelInfoLookupModelMetadataKey: prefixedModel,
+		},
+	}
+	out, err := helps.ApplyRequestThinkingWithSource(
+		translated,
+		source,
+		auth,
+		"claude",
+		upstreamModel,
+		opts,
+		"openai-response",
+		"claude",
+	)
+	if err != nil {
+		t.Fatalf("ApplyRequestThinkingWithSource() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "xhigh" {
+		t.Fatalf("output_config.effort = %q, want xhigh; body=%s", got, out)
+	}
+}
+
+func TestClaudeThinkingMapsUnsupportedOpenAIHighIntentWithPrefixedModelInfo(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-prefixed-claude-thinking-reject-client"
+	upstreamModel := "claude-opus-4-6"
+	prefixedModel := "sp-anthropic/" + upstreamModel
+	reg.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
+		ID:               prefixedModel,
+		Type:             "claude",
+		OwnedBy:          "anthropic",
+		Object:           "model",
+		Created:          time.Now().Unix(),
+		UserDefined:      true,
+		ThinkingExplicit: true,
+		Thinking: &registry.ThinkingSupport{
+			ZeroAllowed: true,
+			Levels:      []string{"high", "medium", "low", "minimal", "none", "auto"},
+		},
+	}})
+	defer reg.UnregisterClient(clientID)
+
+	source := []byte(`{"model":"sp-anthropic/claude-opus-4-6","reasoning_effort":"xhigh","messages":[{"role":"user","content":"hi"}]}`)
+	translated := sdktranslator.TranslateRequest(
+		sdktranslator.FromString("openai"),
+		sdktranslator.FromString("claude"),
+		upstreamModel,
+		source,
+		false,
+	)
+	translated, _ = sjson.SetBytes(translated, "thinking.type", "adaptive")
+	translated, _ = sjson.SetBytes(translated, "output_config.effort", "max")
+
+	auth := &cliproxyauth.Auth{
+		ID:       clientID,
+		Provider: "claude",
+		Prefix:   "sp-anthropic",
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ModelInfoLookupModelMetadataKey: prefixedModel,
+		},
+	}
+	out, err := helps.ApplyRequestThinkingWithSource(
+		translated,
+		source,
+		auth,
+		"claude",
+		upstreamModel,
+		opts,
+		"openai",
+		"claude",
+	)
+	if err != nil {
+		t.Fatalf("ApplyRequestThinkingWithSource() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "high" {
+		t.Fatalf("output_config.effort = %q, want high; body=%s", got, out)
+	}
+}
+
+func TestClaudeThinkingClampsExplicitAutoDefaultToSupportedLevel(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-prefixed-claude-thinking-auto-explicit-client"
+	upstreamModel := "claude-sonnet-4-6"
+	prefixedModel := "sp-anthropic/" + upstreamModel
+	reg.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
+		ID:               prefixedModel,
+		Type:             "claude",
+		OwnedBy:          "anthropic",
+		Object:           "model",
+		Created:          time.Now().Unix(),
+		UserDefined:      true,
+		ThinkingExplicit: true,
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"low", "high"},
+		},
+	}})
+	defer reg.UnregisterClient(clientID)
+
+	source := []byte(`{"model":"sp-anthropic/claude-sonnet-4-6","reasoning_effort":"auto","messages":[{"role":"user","content":"hi"}]}`)
+	translated := []byte(`{"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"}}`)
+
+	auth := &cliproxyauth.Auth{
+		ID:       clientID,
+		Provider: "claude",
+		Prefix:   "sp-anthropic",
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ModelInfoLookupModelMetadataKey: prefixedModel,
+		},
+	}
+	out, err := helps.ApplyRequestThinkingWithSource(
+		translated,
+		source,
+		auth,
+		"claude",
+		upstreamModel,
+		opts,
+		"openai",
+		"claude",
+	)
+	if err != nil {
+		t.Fatalf("ApplyRequestThinkingWithSource() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "low" {
+		t.Fatalf("output_config.effort = %q, want low; body=%s", got, out)
+	}
+}
+
+func TestClaudeThinkingKeepsExplicitAutoAdaptiveDefault(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-prefixed-claude-thinking-auto-supported-client"
+	upstreamModel := "claude-sonnet-4-6"
+	prefixedModel := "sp-anthropic/" + upstreamModel
+	reg.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
+		ID:               prefixedModel,
+		Type:             "claude",
+		OwnedBy:          "anthropic",
+		Object:           "model",
+		Created:          time.Now().Unix(),
+		UserDefined:      true,
+		ThinkingExplicit: true,
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"low", "high", "auto"},
+		},
+	}})
+	defer reg.UnregisterClient(clientID)
+
+	source := []byte(`{"model":"sp-anthropic/claude-sonnet-4-6","reasoning_effort":"auto","messages":[{"role":"user","content":"hi"}]}`)
+	translated := []byte(`{"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"}}`)
+
+	auth := &cliproxyauth.Auth{
+		ID:       clientID,
+		Provider: "claude",
+		Prefix:   "sp-anthropic",
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ModelInfoLookupModelMetadataKey: prefixedModel,
+		},
+	}
+	out, err := helps.ApplyRequestThinkingWithSource(
+		translated,
+		source,
+		auth,
+		"claude",
+		upstreamModel,
+		opts,
+		"openai",
+		"claude",
+	)
+	if err != nil {
+		t.Fatalf("ApplyRequestThinkingWithSource() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive; body=%s", got, out)
+	}
+	if gjson.GetBytes(out, "thinking.budget_tokens").Exists() {
+		t.Fatalf("thinking.budget_tokens should remain omitted; body=%s", out)
+	}
+	if gjson.GetBytes(out, "output_config.effort").Exists() {
+		t.Fatalf("output_config.effort should remain omitted; body=%s", out)
+	}
+}
+
+func TestClaudeThinkingPreservesTranslatedEffortForInferredAliasThinking(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-prefixed-claude-inferred-thinking-client"
+	upstreamModel := "claude-sonnet-4-6"
+	prefixedModel := "sp-inferred/" + upstreamModel
+	reg.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
+		ID:          prefixedModel,
+		Type:        "claude",
+		OwnedBy:     "anthropic",
+		Object:      "model",
+		Created:     time.Now().Unix(),
+		UserDefined: true,
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"low", "medium", "high", "max"},
+		},
+	}})
+	defer reg.UnregisterClient(clientID)
+
+	source := []byte(`{"model":"sp-inferred/claude-sonnet-4-6","reasoning_effort":"minimal","messages":[{"role":"user","content":"hi"}]}`)
+	translated := sdktranslator.TranslateRequest(
+		sdktranslator.FromString("openai"),
+		sdktranslator.FromString("claude"),
+		upstreamModel,
+		source,
+		false,
+	)
+	translated, _ = sjson.SetBytes(translated, "thinking.type", "adaptive")
+	translated, _ = sjson.SetBytes(translated, "output_config.effort", "low")
+
+	auth := &cliproxyauth.Auth{
+		ID:       clientID,
+		Provider: "claude",
+		Prefix:   "sp-inferred",
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ModelInfoLookupModelMetadataKey: prefixedModel,
+		},
+	}
+	out, err := helps.ApplyRequestThinkingWithSource(
+		translated,
+		source,
+		auth,
+		"claude",
+		upstreamModel,
+		opts,
+		"openai",
+		"claude",
+	)
+	if err != nil {
+		t.Fatalf("ApplyRequestThinkingWithSource() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "low" {
+		t.Fatalf("output_config.effort = %q, want translated low; body=%s", got, out)
+	}
+}
+
+func TestClaudeThinkingPreservesProviderBudgetForUserDefinedModelWithoutThinkingMetadata(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-prefixed-claude-user-defined-no-thinking-client"
+	upstreamModel := "claude-custom-model"
+	prefixedModel := "sp-unknown/" + upstreamModel
+	reg.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
+		ID:          prefixedModel,
+		Type:        "claude",
+		OwnedBy:     "anthropic",
+		Object:      "model",
+		Created:     time.Now().Unix(),
+		UserDefined: true,
+	}})
+	defer reg.UnregisterClient(clientID)
+
+	source := []byte(`{"model":"sp-unknown/claude-custom-model","reasoning_effort":"xhigh","messages":[{"role":"user","content":"hi"}]}`)
+	translated := []byte(`{"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"enabled","budget_tokens":32768}}`)
+
+	auth := &cliproxyauth.Auth{
+		ID:       clientID,
+		Provider: "claude",
+		Prefix:   "sp-unknown",
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Metadata: map[string]any{
+			cliproxyexecutor.ModelInfoLookupModelMetadataKey: prefixedModel,
+		},
+	}
+	out, err := helps.ApplyRequestThinkingWithSource(
+		translated,
+		source,
+		auth,
+		"claude",
+		upstreamModel,
+		opts,
+		"openai",
+		"claude",
+	)
+	if err != nil {
+		t.Fatalf("ApplyRequestThinkingWithSource() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "enabled" {
+		t.Fatalf("thinking.type = %q, want enabled; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "thinking.budget_tokens").Int(); got != 32768 {
+		t.Fatalf("thinking.budget_tokens = %d, want 32768; body=%s", got, out)
+	}
+	if gjson.GetBytes(out, "output_config.effort").Exists() {
+		t.Fatalf("output_config.effort should remain omitted; body=%s", out)
+	}
+}
+
+func TestClaudeThinkingPreservesTranslatedAutoAdaptiveDefault(t *testing.T) {
+	source := []byte(`{"model":"claude-sonnet-4-6","reasoning_effort":"auto","messages":[{"role":"user","content":"hi"}]}`)
+	translated := sdktranslator.TranslateRequest(
+		sdktranslator.FromString("openai"),
+		sdktranslator.FromString("claude"),
+		"claude-sonnet-4-6",
+		source,
+		false,
+	)
+	translated, _ = sjson.SetBytes(translated, "thinking.type", "adaptive")
+	translated, _ = sjson.DeleteBytes(translated, "thinking.budget_tokens")
+	translated, _ = sjson.DeleteBytes(translated, "output_config.effort")
+
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+	}
+	out, err := helps.ApplyRequestThinkingWithSource(
+		translated,
+		source,
+		nil,
+		"claude",
+		"claude-sonnet-4-6",
+		opts,
+		"openai",
+		"claude",
+	)
+	if err != nil {
+		t.Fatalf("ApplyRequestThinkingWithSource() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive; body=%s", got, out)
+	}
+	if gjson.GetBytes(out, "output_config.effort").Exists() {
+		t.Fatalf("output_config.effort should remain omitted; body=%s", out)
+	}
+	if gjson.GetBytes(out, "thinking.budget_tokens").Exists() {
+		t.Fatalf("thinking.budget_tokens should remain omitted; body=%s", out)
 	}
 }
 

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -765,7 +765,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return resp, err
 	}
@@ -945,7 +945,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return resp, err
 	}
@@ -1052,7 +1052,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return nil, err
 	}
@@ -1209,9 +1209,13 @@ func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("codex")
+	sourcePayload := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		sourcePayload = opts.OriginalRequest
+	}
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	body, err := thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err := helps.ApplyRequestThinkingWithSource(body, sourcePayload, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -100,7 +100,7 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 	reporter := helps.NewExecutorUsageReporter(ctx, e, mainModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
-	body, errBuild := e.prepareCodexOpenAIImageBody(prepared.Body, req, opts, mainModel)
+	body, errBuild := e.prepareCodexOpenAIImageBody(prepared.Body, auth, req, opts, mainModel)
 	if errBuild != nil {
 		return resp, errBuild
 	}
@@ -196,7 +196,7 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 	reporter := helps.NewExecutorUsageReporter(ctx, e, mainModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
-	body, errBuild := e.prepareCodexOpenAIImageBody(prepared.Body, req, opts, mainModel)
+	body, errBuild := e.prepareCodexOpenAIImageBody(prepared.Body, auth, req, opts, mainModel)
 	if errBuild != nil {
 		return nil, errBuild
 	}
@@ -641,14 +641,15 @@ func codexIsDirectOpenAIImageModel(model string) bool {
 	}
 }
 
-func (e *CodexExecutor) prepareCodexOpenAIImageBody(body []byte, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, mainModel string) ([]byte, error) {
+func (e *CodexExecutor) prepareCodexOpenAIImageBody(body []byte, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, mainModel string) ([]byte, error) {
 	out := body
 	mainModel = strings.TrimSpace(mainModel)
 	if mainModel == "" {
 		mainModel = codexOpenAIImagesMainModel
 	}
 	var errThinking error
-	out, errThinking = thinking.ApplyThinking(out, mainModel, codexOpenAIImageSourceFormat, "codex", e.Identifier())
+	mainModelOpts := withoutModelInfoLookupModelMetadata(opts)
+	out, errThinking = helps.ApplyRequestThinking(out, auth, e.Identifier(), mainModel, mainModelOpts, codexOpenAIImageSourceFormat, "codex")
 	if errThinking != nil {
 		return nil, errThinking
 	}
@@ -663,6 +664,24 @@ func (e *CodexExecutor) prepareCodexOpenAIImageBody(body []byte, req cliproxyexe
 	out, _ = sjson.DeleteBytes(out, "safety_identifier")
 	out, _ = sjson.DeleteBytes(out, "stream_options")
 	return normalizeCodexInstructions(out), nil
+}
+
+func withoutModelInfoLookupModelMetadata(opts cliproxyexecutor.Options) cliproxyexecutor.Options {
+	if len(opts.Metadata) == 0 {
+		return opts
+	}
+	if _, ok := opts.Metadata[cliproxyexecutor.ModelInfoLookupModelMetadataKey]; !ok {
+		return opts
+	}
+	meta := make(map[string]any, len(opts.Metadata)-1)
+	for key, value := range opts.Metadata {
+		if key == cliproxyexecutor.ModelInfoLookupModelMetadataKey {
+			continue
+		}
+		meta[key] = value
+	}
+	opts.Metadata = meta
+	return opts
 }
 
 func recordCodexOpenAIImageRequest(ctx context.Context, cfg *config.Config, provider string, auth *cliproxyauth.Auth, url string, headers http.Header, body []byte) {

--- a/internal/runtime/executor/codex_openai_images_test.go
+++ b/internal/runtime/executor/codex_openai_images_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -35,6 +36,36 @@ func codexOpenAIImageTestOptions(path string, stream bool) cliproxyexecutor.Opti
 		Metadata: map[string]any{
 			cliproxyexecutor.RequestPathMetadataKey: path,
 		},
+	}
+}
+
+func TestPrepareCodexOpenAIImageBodyDoesNotUseRouteImageModelInfoForMainModelThinking(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-codex-openai-image-route-model-info"
+	reg.RegisterClient(clientID, "codex", []*registry.ModelInfo{{
+		ID: "pref/gpt-image-1.5",
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Provider: "codex", Prefix: "pref"}
+	opts := codexOpenAIImageTestOptions(codexImagesGenerationsPath, false)
+	opts.Metadata[cliproxyexecutor.ModelInfoLookupModelMetadataKey] = "pref/gpt-image-1.5"
+	body := codexBuildImagesResponsesRequest("draw", nil, []byte(`{"type":"image_generation","action":"generate"}`))
+
+	out, err := executor.prepareCodexOpenAIImageBody(body, auth, cliproxyexecutor.Request{
+		Model:   "gpt-image-1.5",
+		Payload: []byte(`{"model":"gpt-image-1.5","prompt":"draw"}`),
+	}, opts, codexOpenAIImagesMainModel)
+	if err != nil {
+		t.Fatalf("prepareCodexOpenAIImageBody() error = %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "model").String(); got != codexOpenAIImagesMainModel {
+		t.Fatalf("model = %q, want %q; body=%s", got, codexOpenAIImagesMainModel, out)
+	}
+	if got := gjson.GetBytes(out, "reasoning.effort").String(); got != "medium" {
+		t.Fatalf("reasoning.effort = %q, want medium; body=%s", got, out)
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -198,7 +198,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return resp, err
 	}
@@ -422,7 +422,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		userPayload = opts.OriginalRequest
 	}
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, userPayload, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -148,7 +148,8 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	modelInfo := helps.RequestModelInfo(auth, e.Identifier(), req.Model, opts)
+	body, err = thinking.ApplyThinkingWithResolvedModelInfo(body, originalPayloadSource, modelInfo.Model, from.String(), to.String(), e.Identifier(), modelInfo.Info, modelInfo.Resolved)
 	if err != nil {
 		return resp, err
 	}
@@ -158,7 +159,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
-	body = capGeminiMaxOutputTokens(body, baseModel)
+	body = capGeminiMaxOutputTokens(body, baseModel, modelInfo.Info)
 
 	action := "generateContent"
 	if req.Metadata != nil {
@@ -261,7 +262,8 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	modelInfo := helps.RequestModelInfo(auth, e.Identifier(), req.Model, opts)
+	body, err = thinking.ApplyThinkingWithResolvedModelInfo(body, originalPayloadSource, modelInfo.Model, from.String(), to.String(), e.Identifier(), modelInfo.Info, modelInfo.Resolved)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +273,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
-	body = capGeminiMaxOutputTokens(body, baseModel)
+	body = capGeminiMaxOutputTokens(body, baseModel, modelInfo.Info)
 
 	baseURL := resolveGeminiBaseURL(auth)
 	url := fmt.Sprintf("%s/%s/models/%s:%s", baseURL, glAPIVersion, baseModel, "streamGenerateContent")
@@ -390,7 +392,7 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 	if gjson.GetBytes(body, "model").Exists() && targetName != "" {
 		body, _ = sjson.SetBytes(body, "model", targetName)
 	}
-	body, err = applyGeminiInteractionsThinking(body, req.Model)
+	body, err = applyGeminiInteractionsThinking(body, auth, req.Model, opts)
 	if err != nil {
 		return resp, err
 	}
@@ -466,7 +468,7 @@ func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cl
 	if gjson.GetBytes(body, "model").Exists() && targetName != "" {
 		body, _ = sjson.SetBytes(body, "model", targetName)
 	}
-	body, err = applyGeminiInteractionsThinking(body, req.Model)
+	body, err = applyGeminiInteractionsThinking(body, auth, req.Model, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -613,9 +615,14 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("gemini")
+	sourcePayload := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		sourcePayload = opts.OriginalRequest
+	}
 	translatedReq := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	translatedReq, err := thinking.ApplyThinking(translatedReq, req.Model, from.String(), to.String(), e.Identifier())
+	modelInfo := helps.RequestModelInfo(auth, e.Identifier(), req.Model, opts)
+	translatedReq, err := thinking.ApplyThinkingWithResolvedModelInfo(translatedReq, sourcePayload, modelInfo.Model, from.String(), to.String(), e.Identifier(), modelInfo.Info, modelInfo.Resolved)
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
@@ -795,8 +802,12 @@ func isNativeInteractionsAuth(auth *cliproxyauth.Auth) bool {
 	return strings.EqualFold(strings.TrimSpace(auth.Provider), "gemini-interactions")
 }
 
-func applyGeminiInteractionsThinking(body []byte, model string) ([]byte, error) {
-	return thinking.ApplyThinking(body, model, sdktranslator.FormatInteractions.String(), sdktranslator.FormatInteractions.String(), "gemini")
+func applyGeminiInteractionsThinking(body []byte, auth *cliproxyauth.Auth, model string, opts cliproxyexecutor.Options) ([]byte, error) {
+	providerKey := "gemini"
+	if auth != nil && strings.TrimSpace(auth.Provider) != "" {
+		providerKey = strings.TrimSpace(auth.Provider)
+	}
+	return helps.ApplyRequestThinking(body, auth, providerKey, model, opts, sdktranslator.FormatInteractions.String(), sdktranslator.FormatInteractions.String())
 }
 
 func applyGeminiInteractionsRevisionHeader(req *http.Request) {
@@ -886,24 +897,36 @@ func applyGeminiHeaders(req *http.Request, auth *cliproxyauth.Auth) {
 	util.ApplyCustomHeadersFromAttrs(req, attrs)
 }
 
-func capGeminiMaxOutputTokens(body []byte, modelName string) []byte {
+func capGeminiMaxOutputTokens(body []byte, modelName string, modelInfo *registry.ModelInfo) []byte {
 	maxOut := gjson.GetBytes(body, "generationConfig.maxOutputTokens")
 	if !maxOut.Exists() || maxOut.Type != gjson.Number {
 		return body
 	}
-	modelInfo := registry.LookupModelInfo(modelName, "gemini")
 	if modelInfo == nil {
+		modelInfo = registry.LookupModelInfo(modelName, "gemini")
+	}
+	limit := geminiOutputTokenLimit(modelInfo)
+	if limit <= 0 {
+		limit = geminiOutputTokenLimit(registry.LookupModelInfo(modelName, "gemini"))
+	}
+	if limit <= 0 {
 		return body
 	}
-	limit := modelInfo.OutputTokenLimit
-	if limit <= 0 {
-		limit = modelInfo.MaxCompletionTokens
-	}
-	if limit <= 0 || maxOut.Int() <= int64(limit) {
+	if maxOut.Int() <= int64(limit) {
 		return body
 	}
 	body, _ = sjson.SetBytes(body, "generationConfig.maxOutputTokens", limit)
 	return body
+}
+
+func geminiOutputTokenLimit(modelInfo *registry.ModelInfo) int {
+	if modelInfo == nil {
+		return 0
+	}
+	if modelInfo.OutputTokenLimit > 0 {
+		return modelInfo.OutputTokenLimit
+	}
+	return modelInfo.MaxCompletionTokens
 }
 
 func fixGeminiImageAspectRatio(modelName string, rawJSON []byte) []byte {

--- a/internal/runtime/executor/gemini_executor_test.go
+++ b/internal/runtime/executor/gemini_executor_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -19,7 +21,7 @@ import (
 func TestCapGeminiMaxOutputTokensUsesOutputTokenLimit(t *testing.T) {
 	body := []byte(`{"generationConfig":{"maxOutputTokens":500000,"temperature":0.2},"contents":[]}`)
 
-	out := capGeminiMaxOutputTokens(body, "gemini-3.1-pro-preview")
+	out := capGeminiMaxOutputTokens(body, "gemini-3.1-pro-preview", nil)
 
 	if got := gjson.GetBytes(out, "generationConfig.maxOutputTokens").Int(); got != 65536 {
 		t.Fatalf("maxOutputTokens = %d, want 65536", got)
@@ -52,11 +54,56 @@ func TestCapGeminiMaxOutputTokensLeavesAllowedOrUnknown(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out := capGeminiMaxOutputTokens(tt.body, tt.model)
+			out := capGeminiMaxOutputTokens(tt.body, tt.model, nil)
 			if got := gjson.GetBytes(out, "generationConfig.maxOutputTokens").Int(); got != tt.want {
 				t.Fatalf("maxOutputTokens = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCapGeminiMaxOutputTokensFallsBackToStaticLimitWhenResolvedInfoHasNoLimit(t *testing.T) {
+	body := []byte(`{"generationConfig":{"maxOutputTokens":500000},"contents":[]}`)
+	modelInfo := &registry.ModelInfo{
+		ID: "free-provider/gemini-3.1-pro-preview",
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"xhigh", "high"},
+		},
+	}
+
+	out := capGeminiMaxOutputTokens(body, "gemini-3.1-pro-preview", modelInfo)
+
+	if got := gjson.GetBytes(out, "generationConfig.maxOutputTokens").Int(); got != 65536 {
+		t.Fatalf("maxOutputTokens = %d, want static fallback 65536", got)
+	}
+}
+
+func TestApplyGeminiInteractionsThinkingUsesAuthProviderForPrefixedModelInfo(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-gemini-interactions-prefixed-thinking"
+	reg.RegisterClient(clientID, "gemini-interactions", []*registry.ModelInfo{{
+		ID: "free-provider/gemini-interactions-model",
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"xhigh", "high"},
+		},
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	body := []byte(`{"model":"gemini-interactions-model","reasoning_effort":"xhigh","messages":[{"role":"user","content":"hi"}]}`)
+	out, err := applyGeminiInteractionsThinking(body, &cliproxyauth.Auth{
+		Provider: "gemini-interactions",
+		Prefix:   "free-provider",
+	}, "gemini-interactions-model", cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.ModelInfoLookupModelMetadataKey: "free-provider/gemini-interactions-model",
+		},
+	})
+	if err != nil {
+		t.Fatalf("applyGeminiInteractionsThinking() error = %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "reasoning_effort").String(); got != string(thinking.LevelXHigh) {
+		t.Fatalf("reasoning_effort = %q, want xhigh; body=%s", got, out)
 	}
 }
 

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -331,7 +331,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
 		body = sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-		body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+		body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 		if err != nil {
 			return resp, err
 		}
@@ -456,7 +456,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return resp, err
 	}
@@ -571,7 +571,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return nil, err
 	}
@@ -716,7 +716,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return nil, err
 	}
@@ -849,10 +849,14 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("gemini")
+	sourcePayload := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		sourcePayload = opts.OriginalRequest
+	}
 
 	translatedReq := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	translatedReq, err := thinking.ApplyThinking(translatedReq, req.Model, from.String(), to.String(), e.Identifier())
+	translatedReq, err := helps.ApplyRequestThinkingWithSource(translatedReq, sourcePayload, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
@@ -940,10 +944,14 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("gemini")
+	sourcePayload := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		sourcePayload = opts.OriginalRequest
+	}
 
 	translatedReq := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	translatedReq, err := thinking.ApplyThinking(translatedReq, req.Model, from.String(), to.String(), e.Identifier())
+	translatedReq, err := helps.ApplyRequestThinkingWithSource(translatedReq, sourcePayload, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/helps/model_info_lookup.go
+++ b/internal/runtime/executor/helps/model_info_lookup.go
@@ -1,0 +1,163 @@
+package helps
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// ModelInfoLookup carries the model id and registry entry that should be used
+// for request-time model capability checks.
+type ModelInfoLookup struct {
+	Model    string
+	Info     *registry.ModelInfo
+	Resolved bool
+}
+
+// RequestModelInfo resolves the ModelInfo for a specific execution attempt.
+//
+// Providers can rewrite a prefixed client model into an unprefixed upstream
+// model before executors run. In that case the registry capability entry may
+// belong to the prefixed model, so prefer a request-scoped lookup candidate
+// only when that exact model is registered for the current provider.
+func RequestModelInfo(auth *cliproxyauth.Auth, providerKey string, upstreamModel string, opts cliproxyexecutor.Options) ModelInfoLookup {
+	providerKey = strings.TrimSpace(providerKey)
+	upstreamModel = strings.TrimSpace(upstreamModel)
+	lookupModel := upstreamModel
+
+	for _, candidate := range modelInfoLookupCandidates(auth, opts, upstreamModel) {
+		if providerHasModel(providerKey, candidate) {
+			lookupModel = candidate
+			break
+		}
+	}
+
+	info := lookupModelInfo(providerKey, lookupModel)
+	if !sameModelBase(lookupModel, upstreamModel) {
+		upstreamInfo := lookupModelInfo(providerKey, upstreamModel)
+		if info == nil {
+			info = upstreamInfo
+		} else if info.Thinking == nil && !info.ThinkingExplicit && upstreamInfo != nil {
+			info.Thinking = upstreamInfo.Thinking
+		}
+	}
+	return ModelInfoLookup{Model: lookupModel, Info: info, Resolved: true}
+}
+
+func modelInfoLookupCandidates(auth *cliproxyauth.Auth, opts cliproxyexecutor.Options, upstreamModel string) []string {
+	candidates := make([]string, 0, 3)
+	if candidate := PayloadModelInfoLookupModel(opts, ""); strings.TrimSpace(candidate) != "" {
+		candidates = append(candidates, candidate)
+	}
+	if auth != nil {
+		prefix := strings.Trim(strings.TrimSpace(auth.Prefix), "/")
+		suffix := thinking.ParseSuffix(upstreamModel)
+		base := strings.TrimSpace(suffix.ModelName)
+		if prefix != "" && base != "" && !hasModelPrefix(base, prefix) {
+			candidate := prefix + "/" + base
+			if suffix.HasSuffix && strings.TrimSpace(suffix.RawSuffix) != "" {
+				candidate += "(" + strings.TrimSpace(suffix.RawSuffix) + ")"
+			}
+			candidates = append(candidates, candidate)
+		}
+	}
+	if strings.TrimSpace(upstreamModel) != "" {
+		candidates = append(candidates, upstreamModel)
+	}
+	return candidates
+}
+
+// ApplyRequestThinking applies thinking using the request-scoped ModelInfo
+// lookup for config API-key providers.
+func ApplyRequestThinking(body []byte, auth *cliproxyauth.Auth, providerKey string, model string, opts cliproxyexecutor.Options, fromFormat string, toFormat string) ([]byte, error) {
+	lookup := RequestModelInfo(auth, providerKey, model, opts)
+	return thinking.ApplyThinkingWithResolvedModelInfo(body, nil, lookup.Model, fromFormat, toFormat, providerKey, lookup.Info, lookup.Resolved)
+}
+
+// ApplyRequestThinkingWithSource applies thinking to a translated request body
+// while preserving source-format thinking parameters for request-scoped model
+// capability checks.
+func ApplyRequestThinkingWithSource(body []byte, sourceBody []byte, auth *cliproxyauth.Auth, providerKey string, model string, opts cliproxyexecutor.Options, fromFormat string, toFormat string) ([]byte, error) {
+	lookup := RequestModelInfo(auth, providerKey, model, opts)
+	return thinking.ApplyThinkingWithResolvedModelInfo(body, sourceBody, lookup.Model, fromFormat, toFormat, providerKey, lookup.Info, lookup.Resolved)
+}
+
+// PayloadModelInfoLookupModel returns the per-attempt model capability lookup
+// model, falling back to fallback when metadata is absent.
+func PayloadModelInfoLookupModel(opts cliproxyexecutor.Options, fallback string) string {
+	if len(opts.Metadata) == 0 {
+		return fallback
+	}
+	raw, ok := opts.Metadata[cliproxyexecutor.ModelInfoLookupModelMetadataKey]
+	if !ok || raw == nil {
+		return fallback
+	}
+	switch value := raw.(type) {
+	case string:
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	case []byte:
+		if trimmed := strings.TrimSpace(string(value)); trimmed != "" {
+			return trimmed
+		}
+	}
+	return fallback
+}
+
+func lookupModelInfo(providerKey string, model string) *registry.ModelInfo {
+	modelID := strings.TrimSpace(thinking.ParseSuffix(model).ModelName)
+	if modelID == "" {
+		return nil
+	}
+	if strings.TrimSpace(providerKey) != "" {
+		providers := registry.GetGlobalRegistry().GetModelProviders(modelID)
+		if len(providers) > 0 && !providerInList(providers, providerKey) {
+			return registry.LookupStaticModelInfo(modelID)
+		}
+	}
+	return registry.LookupModelInfo(modelID, providerKey)
+}
+
+func providerHasModel(providerKey string, model string) bool {
+	providerKey = strings.TrimSpace(providerKey)
+	if providerKey == "" {
+		return false
+	}
+	modelID := strings.TrimSpace(thinking.ParseSuffix(model).ModelName)
+	if modelID == "" {
+		return false
+	}
+	return providerInList(registry.GetGlobalRegistry().GetModelProviders(modelID), providerKey)
+}
+
+func providerInList(providers []string, providerKey string) bool {
+	providerKey = strings.TrimSpace(providerKey)
+	if providerKey == "" {
+		return false
+	}
+	for _, provider := range providers {
+		if strings.EqualFold(provider, providerKey) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameModelBase(a, b string) bool {
+	a = strings.TrimSpace(thinking.ParseSuffix(a).ModelName)
+	b = strings.TrimSpace(thinking.ParseSuffix(b).ModelName)
+	return strings.EqualFold(a, b)
+}
+
+func hasModelPrefix(model string, prefix string) bool {
+	model = strings.TrimSpace(model)
+	prefix = strings.Trim(strings.TrimSpace(prefix), "/")
+	if model == "" || prefix == "" {
+		return false
+	}
+	return strings.HasPrefix(strings.ToLower(model), strings.ToLower(prefix)+"/")
+}

--- a/internal/runtime/executor/helps/model_info_lookup_test.go
+++ b/internal/runtime/executor/helps/model_info_lookup_test.go
@@ -1,0 +1,221 @@
+package helps
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+func TestRequestModelInfoUsesRequestScopedPrefixedModel(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-model-info-lookup-prefixed"
+	provider := "test-prefixed-provider"
+	reg.RegisterClient(clientID, provider, []*registry.ModelInfo{{
+		ID: "free-provider/gpt-test",
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"xhigh", "high"},
+		},
+		MaxCompletionTokens: 12345,
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	lookup := RequestModelInfo(
+		&cliproxyauth.Auth{Prefix: "free-provider"},
+		provider,
+		"gpt-test(xhigh)",
+		cliproxyexecutor.Options{
+			Metadata: map[string]any{
+				cliproxyexecutor.ModelInfoLookupModelMetadataKey: "free-provider/gpt-test(xhigh)",
+			},
+		},
+	)
+
+	if lookup.Model != "free-provider/gpt-test(xhigh)" {
+		t.Fatalf("lookup model = %q, want prefixed request-scoped model", lookup.Model)
+	}
+	if lookup.Info == nil {
+		t.Fatal("expected prefixed ModelInfo")
+	}
+	if got := lookup.Info.MaxCompletionTokens; got != 12345 {
+		t.Fatalf("MaxCompletionTokens = %d, want 12345", got)
+	}
+	if got := lookup.Info.Thinking.Levels[0]; got != "xhigh" {
+		t.Fatalf("first thinking level = %q, want xhigh", got)
+	}
+}
+
+func TestRequestModelInfoDoesNotUseOtherProviderPrefixedModel(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-model-info-lookup-other-provider"
+	reg.RegisterClient(clientID, "provider-a", []*registry.ModelInfo{{
+		ID: "free-provider/provider-specific-model",
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"xhigh"},
+		},
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	lookup := RequestModelInfo(
+		&cliproxyauth.Auth{Prefix: "free-provider"},
+		"provider-b",
+		"provider-specific-model",
+		cliproxyexecutor.Options{
+			Metadata: map[string]any{
+				cliproxyexecutor.ModelInfoLookupModelMetadataKey: "free-provider/provider-specific-model",
+			},
+		},
+	)
+
+	if lookup.Model != "provider-specific-model" {
+		t.Fatalf("lookup model = %q, want upstream model fallback", lookup.Model)
+	}
+	if lookup.Info != nil {
+		t.Fatalf("unexpected ModelInfo from another provider: %+v", lookup.Info)
+	}
+}
+
+func TestRequestModelInfoDoesNotUseOtherProviderUnprefixedFallback(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-model-info-lookup-other-provider-unprefixed"
+	reg.RegisterClient(clientID, "provider-a", []*registry.ModelInfo{{
+		ID: "provider-specific-model",
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"xhigh"},
+		},
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	lookup := RequestModelInfo(
+		nil,
+		"provider-b",
+		"provider-specific-model",
+		cliproxyexecutor.Options{},
+	)
+
+	if lookup.Model != "provider-specific-model" {
+		t.Fatalf("lookup model = %q, want upstream model", lookup.Model)
+	}
+	if lookup.Info != nil {
+		t.Fatalf("unexpected unprefixed ModelInfo from another provider: %+v", lookup.Info)
+	}
+}
+
+func TestRequestModelInfoFallsBackToStaticModelInfo(t *testing.T) {
+	lookup := RequestModelInfo(
+		nil,
+		"antigravity",
+		"gemini-3.5-flash-low",
+		cliproxyexecutor.Options{},
+	)
+
+	if lookup.Info == nil {
+		t.Fatal("expected static ModelInfo fallback")
+	}
+	if lookup.Info.Thinking == nil {
+		t.Fatal("expected static thinking metadata")
+	}
+	if got := lookup.Info.ID; got != "gemini-3.5-flash-low" {
+		t.Fatalf("ModelInfo.ID = %q, want gemini-3.5-flash-low", got)
+	}
+}
+
+func TestRequestModelInfoFillsMissingThinkingFromUpstreamModel(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-model-info-lookup-prefixed-static-thinking"
+	provider := "gemini"
+	reg.RegisterClient(clientID, provider, []*registry.ModelInfo{{
+		ID: "free-provider/gemini-3.1-pro-preview",
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	lookup := RequestModelInfo(
+		&cliproxyauth.Auth{Prefix: "free-provider"},
+		provider,
+		"gemini-3.1-pro-preview",
+		cliproxyexecutor.Options{
+			Metadata: map[string]any{
+				cliproxyexecutor.ModelInfoLookupModelMetadataKey: "free-provider/gemini-3.1-pro-preview",
+			},
+		},
+	)
+
+	if lookup.Model != "free-provider/gemini-3.1-pro-preview" {
+		t.Fatalf("lookup model = %q, want prefixed request-scoped model", lookup.Model)
+	}
+	if lookup.Info == nil {
+		t.Fatal("expected prefixed ModelInfo")
+	}
+	if lookup.Info.ID != "free-provider/gemini-3.1-pro-preview" {
+		t.Fatalf("ModelInfo.ID = %q, want prefixed registration", lookup.Info.ID)
+	}
+	if lookup.Info.Thinking == nil {
+		t.Fatal("expected static upstream thinking fallback")
+	}
+	levels := lookup.Info.Thinking.Levels
+	if len(levels) != 3 || levels[0] != "low" || levels[1] != "medium" || levels[2] != "high" {
+		t.Fatalf("Thinking.Levels = %v, want [low medium high]", levels)
+	}
+}
+
+func TestApplyRequestThinkingDoesNotUseOtherProviderFallback(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-apply-thinking-other-provider-unprefixed"
+	model := "provider-specific-model"
+	reg.RegisterClient(clientID, "provider-a", []*registry.ModelInfo{{
+		ID: model,
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"high"},
+		},
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	source := []byte(`{"model":"provider-specific-model","reasoning_effort":"xhigh","messages":[{"role":"user","content":"hi"}]}`)
+	body := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+
+	out, err := ApplyRequestThinkingWithSource(
+		body,
+		source,
+		nil,
+		"provider-b",
+		model,
+		cliproxyexecutor.Options{},
+		"openai",
+		"claude",
+	)
+	if err != nil {
+		t.Fatalf("ApplyRequestThinkingWithSource() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "xhigh" {
+		t.Fatalf("output_config.effort = %q, want xhigh passthrough without other provider metadata; body=%s", got, out)
+	}
+}
+
+func TestRequestModelInfoDoesNotDoublePrefixCaseInsensitiveModel(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-model-info-lookup-case-prefix"
+	provider := "test-case-prefix-provider"
+	reg.RegisterClient(clientID, provider, []*registry.ModelInfo{{
+		ID: "Free-Provider/gpt-test",
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"high"},
+		},
+	}})
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	lookup := RequestModelInfo(
+		&cliproxyauth.Auth{Prefix: "free-provider"},
+		provider,
+		"Free-Provider/gpt-test(high)",
+		cliproxyexecutor.Options{},
+	)
+
+	if lookup.Model != "Free-Provider/gpt-test(high)" {
+		t.Fatalf("lookup model = %q, want original case-preserved prefixed model", lookup.Model)
+	}
+	if lookup.Info == nil {
+		t.Fatal("expected case-preserved prefixed ModelInfo")
+	}
+}

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -103,7 +103,7 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 		return resp, fmt.Errorf("kimi executor: failed to set model in payload: %w", err)
 	}
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), "kimi", e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), "kimi")
 	if err != nil {
 		return resp, err
 	}
@@ -212,7 +212,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 		return nil, fmt.Errorf("kimi executor: failed to set model in payload: %w", err)
 	}
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), "kimi", e.Identifier())
+	body, err = helps.ApplyRequestThinkingWithSource(body, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), "kimi")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -114,7 +114,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, opts.Stream)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, opts.Stream)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = helps.ApplyRequestThinkingWithSource(translated, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return resp, err
 	}
@@ -315,7 +315,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = helps.ApplyRequestThinkingWithSource(translated, originalPayloadSource, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return nil, err
 	}
@@ -582,11 +582,15 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("openai")
+	sourcePayload := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		sourcePayload = opts.OriginalRequest
+	}
 	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
 	modelForCounting := baseModel
 
-	translated, err := thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err := helps.ApplyRequestThinkingWithSource(translated, sourcePayload, auth, e.Identifier(), req.Model, opts, from.String(), to.String())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -119,7 +119,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		baseURL = xaiauth.DefaultAPIBaseURL
 	}
 
-	prepared, err := e.prepareResponsesRequest(ctx, req, opts, true)
+	prepared, err := e.prepareResponsesRequest(ctx, auth, req, opts, true)
 	if err != nil {
 		return resp, err
 	}
@@ -210,7 +210,7 @@ func (e *XAIExecutor) executeCompactRequest(ctx context.Context, auth *cliproxya
 		baseURL = xaiauth.DefaultAPIBaseURL
 	}
 
-	prepared, err := e.prepareResponsesRequestTo(ctx, req, opts, false, sdktranslator.FormatOpenAIResponse)
+	prepared, err := e.prepareResponsesRequestTo(ctx, auth, req, opts, false, sdktranslator.FormatOpenAIResponse)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -577,7 +577,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 		baseURL = xaiauth.DefaultAPIBaseURL
 	}
 
-	prepared, err := e.prepareResponsesRequest(ctx, req, opts, true)
+	prepared, err := e.prepareResponsesRequest(ctx, auth, req, opts, true)
 	if err != nil {
 		return nil, err
 	}
@@ -715,7 +715,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 
 // CountTokens estimates token count for xAI Responses requests.
 func (e *XAIExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	prepared, err := e.prepareResponsesRequest(ctx, req, opts, false)
+	prepared, err := e.prepareResponsesRequest(ctx, auth, req, opts, false)
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
@@ -806,11 +806,11 @@ type xaiPreparedRequest struct {
 	replayScope     xaiReasoningReplayScope
 }
 
-func (e *XAIExecutor) prepareResponsesRequest(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) (*xaiPreparedRequest, error) {
-	return e.prepareResponsesRequestTo(ctx, req, opts, stream, sdktranslator.FormatCodex)
+func (e *XAIExecutor) prepareResponsesRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) (*xaiPreparedRequest, error) {
+	return e.prepareResponsesRequestTo(ctx, auth, req, opts, stream, sdktranslator.FormatCodex)
 }
 
-func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool, to sdktranslator.Format) (*xaiPreparedRequest, error) {
+func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool, to sdktranslator.Format) (*xaiPreparedRequest, error) {
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -823,7 +823,8 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	body := sdktranslator.TranslateRequest(from, to, baseModel, bytes.Clone(req.Payload), stream)
 
 	var err error
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), e.Identifier(), e.Identifier())
+	modelInfo := helps.RequestModelInfo(auth, e.Identifier(), req.Model, opts)
+	body, err = thinking.ApplyThinkingWithResolvedModelInfo(body, originalPayloadSource, modelInfo.Model, from.String(), e.Identifier(), e.Identifier(), modelInfo.Info, modelInfo.Resolved)
 	if err != nil {
 		return nil, err
 	}
@@ -847,7 +848,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	body = normalizeXAIInputReasoningItems(body)
 	body = sanitizeXAIInputEncryptedContent(body)
 	body = normalizeCodexInstructions(body)
-	body = sanitizeXAIResponsesBody(body, baseModel)
+	body = sanitizeXAIResponsesBody(body, baseModel, modelInfo.Info)
 
 	sessionID, errSession := xaiResolveComposerSessionID(ctx, req, opts, baseModel)
 	if errSession != nil {
@@ -1017,9 +1018,9 @@ func xaiMetadataString(meta map[string]any, key string) string {
 	}
 }
 
-func sanitizeXAIResponsesBody(body []byte, model string) []byte {
+func sanitizeXAIResponsesBody(body []byte, model string, modelInfo *registry.ModelInfo) []byte {
 	body = removeXAIEncryptedReasoningInclude(body)
-	if !xaiSupportsReasoningEffort(model) {
+	if !xaiSupportsReasoningEffort(model, modelInfo) {
 		if gjson.GetBytes(body, "reasoning.effort").Exists() {
 			log.Debugf("xai: stripping reasoning.effort for model %s (no thinking levels in model registry)", model)
 		}
@@ -1349,7 +1350,10 @@ func removeXAIEncryptedReasoningInclude(body []byte) []byte {
 // xaiSupportsReasoningEffort reports whether the model accepts Responses API
 // reasoning.effort. Capability comes from model registry thinking metadata
 // (static models.json and dynamic registrations), not a hard-coded name allowlist.
-func xaiSupportsReasoningEffort(model string) bool {
+func xaiSupportsReasoningEffort(model string, modelInfo *registry.ModelInfo) bool {
+	if modelInfo != nil && modelInfo.Thinking != nil {
+		return len(modelInfo.Thinking.Levels) > 0
+	}
 	name := strings.ToLower(strings.TrimSpace(thinking.ParseSuffix(model).ModelName))
 	if idx := strings.LastIndex(name, "/"); idx >= 0 {
 		name = name[idx+1:]

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -200,7 +201,7 @@ func TestXAIExecutorComposerSessionIsolation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+			prepared, err := exec.prepareResponsesRequest(context.Background(), auth, cliproxyexecutor.Request{
 				Model:   tt.model,
 				Payload: tt.payload,
 			}, cliproxyexecutor.Options{
@@ -453,10 +454,22 @@ func TestXAISupportsReasoningEffortUsesModelRegistry(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := xaiSupportsReasoningEffort(tt.model); got != tt.want {
+			if got := xaiSupportsReasoningEffort(tt.model, nil); got != tt.want {
 				t.Fatalf("xaiSupportsReasoningEffort(%q) = %v, want %v", tt.model, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestXAISupportsReasoningEffortUsesResolvedModelInfo(t *testing.T) {
+	info := &registry.ModelInfo{
+		ID: "free-provider/custom-xai-model",
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"xhigh", "high"},
+		},
+	}
+	if !xaiSupportsReasoningEffort("custom-xai-model", info) {
+		t.Fatal("expected resolved ModelInfo thinking levels to enable xAI reasoning effort")
 	}
 }
 
@@ -1124,11 +1137,11 @@ func TestXAIExecutorComposerReusesClaudeCodeSession(t *testing.T) {
 	req := cliproxyexecutor.Request{Model: "grok-composer-2.5-fast", Payload: payload}
 	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Stream: true}
 
-	first, err := exec.prepareResponsesRequest(context.Background(), req, opts, true)
+	first, err := exec.prepareResponsesRequest(context.Background(), auth, req, opts, true)
 	if err != nil {
 		t.Fatalf("prepareResponsesRequest first error: %v", err)
 	}
-	second, err := exec.prepareResponsesRequest(context.Background(), req, opts, true)
+	second, err := exec.prepareResponsesRequest(context.Background(), auth, req, opts, true)
 	if err != nil {
 		t.Fatalf("prepareResponsesRequest second error: %v", err)
 	}

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -407,7 +407,7 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 		baseURL = xaiauth.DefaultAPIBaseURL
 	}
 
-	prepared, err := e.prepareResponsesWebsocketRequest(ctx, req, opts)
+	prepared, err := e.prepareResponsesWebsocketRequest(ctx, auth, req, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -854,8 +854,8 @@ func xaiBareWebsocketErrorStatus(payload []byte) int {
 	return http.StatusInternalServerError
 }
 
-func (e *XAIWebsocketsExecutor) prepareResponsesWebsocketRequest(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*xaiPreparedRequest, error) {
-	prepared, err := e.prepareResponsesRequest(ctx, req, opts, true)
+func (e *XAIWebsocketsExecutor) prepareResponsesWebsocketRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*xaiPreparedRequest, error) {
+	prepared, err := e.prepareResponsesRequest(ctx, auth, req, opts, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -108,20 +108,30 @@ func normalizedProviderName(provider string) string {
 	return strings.ToLower(strings.TrimSpace(provider))
 }
 
-// IsUserDefinedModel reports whether the model is a user-defined model that should
-// have thinking configuration passed through without validation.
+// IsUserDefinedModel reports whether the model is a user-defined model.
 //
 // User-defined models are configured via config file's models[] array
 // (e.g., openai-compatibility.*.models[], *-api-key.models[]). These models
 // are marked with UserDefined=true at registration time.
 //
-// User-defined models should have their thinking configuration applied directly,
-// letting the upstream service validate the configuration.
+// User-defined models with no Thinking metadata have their thinking configuration
+// applied directly, letting the upstream service validate it. When explicit
+// Thinking support is configured, source-format thinking is validated against it.
+// Inferred static Thinking keeps provider-translated thinking parameters.
 func IsUserDefinedModel(modelInfo *registry.ModelInfo) bool {
 	if modelInfo == nil {
 		return true
 	}
 	return modelInfo.UserDefined
+}
+
+// HasExplicitThinkingSupport reports whether thinking metadata was explicitly
+// configured by the user instead of inferred from static upstream metadata.
+func HasExplicitThinkingSupport(modelInfo *registry.ModelInfo) bool {
+	if modelInfo == nil {
+		return false
+	}
+	return modelInfo.ThinkingExplicit
 }
 
 // ApplyThinking applies thinking configuration to a request body.
@@ -162,6 +172,28 @@ func IsUserDefinedModel(modelInfo *registry.ModelInfo) bool {
 //	// Without suffix - uses body config
 //	result, err := thinking.ApplyThinking(body, "gemini-2.5-pro", "gemini", "gemini", "gemini")
 func ApplyThinking(body []byte, model string, fromFormat string, toFormat string, providerKey string) ([]byte, error) {
+	return ApplyThinkingWithModelInfo(body, model, fromFormat, toFormat, providerKey, nil)
+}
+
+// ApplyThinkingWithModelInfo applies thinking configuration using a pre-resolved
+// model registry entry when provided.
+func ApplyThinkingWithModelInfo(body []byte, model string, fromFormat string, toFormat string, providerKey string, modelInfo *registry.ModelInfo) ([]byte, error) {
+	return ApplyThinkingWithSourceAndModelInfo(body, nil, model, fromFormat, toFormat, providerKey, modelInfo)
+}
+
+// ApplyThinkingWithSourceAndModelInfo applies thinking configuration to body
+// while preferring thinking parameters from sourceBody when the request was
+// translated before provider-specific thinking validation.
+func ApplyThinkingWithSourceAndModelInfo(body []byte, sourceBody []byte, model string, fromFormat string, toFormat string, providerKey string, modelInfo *registry.ModelInfo) ([]byte, error) {
+	return ApplyThinkingWithResolvedModelInfo(body, sourceBody, model, fromFormat, toFormat, providerKey, modelInfo, modelInfo != nil)
+}
+
+// ApplyThinkingWithResolvedModelInfo applies thinking configuration using an
+// optional pre-resolved model registry entry. When modelInfoResolved is true,
+// nil modelInfo means the caller already performed a guarded lookup and found
+// no matching model, so this function must not fall back to a global registry
+// lookup.
+func ApplyThinkingWithResolvedModelInfo(body []byte, sourceBody []byte, model string, fromFormat string, toFormat string, providerKey string, modelInfo *registry.ModelInfo, modelInfoResolved bool) ([]byte, error) {
 	providerFormat := strings.ToLower(strings.TrimSpace(toFormat))
 	providerKey = strings.ToLower(strings.TrimSpace(providerKey))
 	if providerKey == "" {
@@ -185,16 +217,19 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 	suffixResult := ParseSuffix(model)
 	baseModel := suffixResult.ModelName
 	// Use provider-specific lookup to handle capability differences across providers.
-	modelInfo := registry.LookupModelInfo(baseModel, providerKey)
+	if modelInfo == nil && !modelInfoResolved {
+		modelInfo = registry.LookupModelInfo(baseModel, providerKey)
+	}
 
 	// 3. Model capability check
-	// Unknown models are treated as user-defined so thinking config can still be applied.
-	// The upstream service is responsible for validating the configuration.
-	if IsUserDefinedModel(modelInfo) {
-		return applyUserDefinedModel(body, modelInfo, fromFormat, providerFormat, suffixResult)
+	// Unknown models and user-defined models without explicit Thinking metadata
+	// are passed through so the upstream service can validate them. User-defined
+	// models with explicit Thinking metadata use that metadata for validation.
+	if IsUserDefinedModel(modelInfo) && (modelInfo == nil || modelInfo.Thinking == nil) {
+		return applyUserDefinedModel(body, sourceBody, modelInfo, fromFormat, providerFormat, suffixResult)
 	}
 	if modelInfo.Thinking == nil {
-		config := extractThinkingConfig(body, providerFormat)
+		config := extractTranslatedThinkingConfig(body, sourceBody, fromFormat, providerFormat, false)
 		if hasThinkingConfig(config) {
 			log.WithFields(log.Fields{
 				"model":    baseModel,
@@ -221,7 +256,7 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 			"level":    config.Level,
 		}).Debug("thinking: config from model suffix |")
 	} else {
-		config = extractThinkingConfig(body, providerFormat)
+		config = extractTranslatedThinkingConfig(body, sourceBody, fromFormat, providerFormat, HasExplicitThinkingSupport(modelInfo))
 		if hasThinkingConfig(config) {
 			log.WithFields(log.Fields{
 				"provider": providerFormat,
@@ -317,9 +352,9 @@ func parseSuffixToConfig(rawSuffix, provider, model string) ThinkingConfig {
 	return ThinkingConfig{}
 }
 
-// applyUserDefinedModel applies thinking configuration for user-defined models
-// without ThinkingSupport validation.
-func applyUserDefinedModel(body []byte, modelInfo *registry.ModelInfo, fromFormat, toFormat string, suffixResult SuffixResult) ([]byte, error) {
+// applyUserDefinedModel applies thinking configuration for unknown or
+// user-defined models without explicit ThinkingSupport validation.
+func applyUserDefinedModel(body []byte, sourceBody []byte, modelInfo *registry.ModelInfo, fromFormat, toFormat string, suffixResult SuffixResult) ([]byte, error) {
 	// Get model ID for logging
 	modelID := ""
 	if modelInfo != nil {
@@ -340,10 +375,7 @@ func applyUserDefinedModel(body []byte, modelInfo *registry.ModelInfo, fromForma
 			"level":    config.Level,
 		}).Debug("thinking: config from model suffix |")
 	} else {
-		config = extractThinkingConfig(body, fromFormat)
-		if !hasThinkingConfig(config) && fromFormat != toFormat {
-			config = extractThinkingConfig(body, toFormat)
-		}
+		config = extractTranslatedUserDefinedThinkingConfig(body, sourceBody, fromFormat, toFormat)
 		if hasThinkingConfig(config) {
 			log.WithFields(log.Fields{
 				"provider": toFormat,
@@ -383,6 +415,58 @@ func applyUserDefinedModel(body []byte, modelInfo *registry.ModelInfo, fromForma
 	return applier.Apply(body, config, modelInfo)
 }
 
+func extractTranslatedThinkingConfig(body []byte, sourceBody []byte, fromFormat, providerFormat string, preferSource bool) ThinkingConfig {
+	providerConfig := extractThinkingConfig(body, providerFormat)
+	if len(sourceBody) > 0 {
+		sourceConfig := extractThinkingConfig(sourceBody, fromFormat)
+		if hasThinkingConfig(sourceConfig) {
+			if !preferSource && isAutoConfig(sourceConfig) && hasProviderAdaptiveDefault(body, providerFormat) {
+				return ThinkingConfig{}
+			}
+			if preferSource || !hasThinkingConfig(providerConfig) {
+				return sourceConfig
+			}
+		}
+	}
+	return providerConfig
+}
+
+func extractTranslatedUserDefinedThinkingConfig(body []byte, sourceBody []byte, fromFormat, toFormat string) ThinkingConfig {
+	providerConfig := extractThinkingConfig(body, toFormat)
+	if len(sourceBody) > 0 {
+		sourceConfig := extractThinkingConfig(sourceBody, fromFormat)
+		if hasThinkingConfig(sourceConfig) {
+			if isAutoConfig(sourceConfig) && hasProviderAdaptiveDefault(body, toFormat) {
+				return ThinkingConfig{}
+			}
+			if !hasThinkingConfig(providerConfig) {
+				return sourceConfig
+			}
+		}
+	}
+	if hasThinkingConfig(providerConfig) {
+		return providerConfig
+	}
+	config := extractThinkingConfig(body, fromFormat)
+	return config
+}
+
+func hasProviderAdaptiveDefault(body []byte, providerFormat string) bool {
+	if providerFormat != "claude" {
+		return false
+	}
+	thinkingType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "thinking.type").String()))
+	if thinkingType != "adaptive" && thinkingType != "auto" {
+		return false
+	}
+	effort := gjson.GetBytes(body, "output_config.effort")
+	return !effort.Exists() || strings.TrimSpace(effort.String()) == ""
+}
+
+func isAutoConfig(config ThinkingConfig) bool {
+	return config.Mode == ModeAuto || (config.Mode == ModeLevel && config.Level == LevelAuto)
+}
+
 func normalizeUserDefinedConfig(config ThinkingConfig, fromFormat, toFormat string) ThinkingConfig {
 	if config.Mode != ModeLevel {
 		return config
@@ -418,6 +502,8 @@ func extractThinkingConfig(body []byte, provider string) ThinkingConfig {
 		return extractInteractionsConfig(body)
 	case "openai":
 		return extractOpenAIConfig(body)
+	case "openai-response":
+		return extractCodexConfig(body)
 	case "codex", "xai":
 		return extractCodexConfig(body)
 	case "kimi":

--- a/internal/thinking/provider/claude/apply.go
+++ b/internal/thinking/provider/claude/apply.go
@@ -70,7 +70,8 @@ func init() {
 //	  }
 //	}
 func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *registry.ModelInfo) ([]byte, error) {
-	if thinking.IsUserDefinedModel(modelInfo) {
+	if thinking.IsUserDefinedModel(modelInfo) &&
+		(config.Mode != thinking.ModeAuto || !thinking.HasExplicitThinkingSupport(modelInfo)) {
 		return applyCompatibleClaude(body, config)
 	}
 	if modelInfo.Thinking == nil {

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -53,17 +53,9 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		return &config, nil
 	}
 
-	// allowClampUnsupported determines whether to clamp unsupported levels instead of returning an error.
-	// This applies when crossing provider families (e.g., openai→gemini, claude→gemini) and the target
-	// model supports discrete levels. Same-family conversions require strict validation.
-	//
 	// modelFamilyMismatch covers providers that reuse another protocol on the wire
 	// (e.g. Kimi serving Claude-compatible /v1/messages). In that path fromFormat and
-	// toFormat both look like "claude", but the model itself is not Claude-family, so
-	// unsupported levels such as "max" should clamp to the nearest supported level
-	// (typically "high") instead of failing validation.
-	toCapability := detectModelCapability(modelInfo)
-	toHasLevelSupport := toCapability == CapabilityLevelOnly || toCapability == CapabilityHybrid
+	// toFormat both look like "claude", but the model itself is not Claude-family.
 	modelFamilyMismatch := false
 	if modelInfo != nil {
 		modelType := strings.ToLower(strings.TrimSpace(modelInfo.Type))
@@ -74,7 +66,14 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 			}
 		}
 	}
-	allowClampUnsupported := toHasLevelSupport && (!isSameProviderFamily(fromFormat, toFormat) || modelFamilyMismatch)
+
+	// Clamp unsupported levels across effective provider-family boundaries when the
+	// target has discrete levels and no explicit Thinking capability was configured.
+	// Explicit capabilities remain strict except for the high-intent mapping below.
+	toCapability := detectModelCapability(modelInfo)
+	toHasLevelSupport := toCapability == CapabilityLevelOnly || toCapability == CapabilityHybrid
+	crossProviderFamily := !isSameProviderFamily(fromFormat, toFormat) || modelFamilyMismatch
+	allowClampUnsupported := toHasLevelSupport && crossProviderFamily && !HasExplicitThinkingSupport(modelInfo)
 
 	// strictBudget determines whether to enforce strict budget range validation.
 	// This applies when: (1) config comes from request body (not suffix), (2) source format is known,
@@ -129,9 +128,22 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		config.Level = ""
 	}
 
+	if config.Mode == ModeNone && HasExplicitThinkingSupport(modelInfo) && !supportsThinkingDisable(support) {
+		validLevels := normalizeLevels(support.Levels)
+		message := `level "none" not supported`
+		if len(validLevels) > 0 {
+			message += ", valid levels: " + strings.Join(validLevels, ", ")
+		}
+		return nil, NewThinkingError(ErrLevelNotSupported, message)
+	}
+
 	if len(support.Levels) > 0 && config.Mode == ModeLevel {
 		if !isLevelSupported(string(config.Level), support.Levels) {
-			if allowClampUnsupported {
+			highIntent := crossProviderFamily && isHighIntentLevel(config.Level)
+			if mapped, ok := mapHighIntentLevel(config.Level, support.Levels, crossProviderFamily); ok {
+				logLevelMapping(toFormat, model, config.Level, mapped)
+				config.Level = mapped
+			} else if allowClampUnsupported && !highIntent {
 				config.Level = clampLevel(config.Level, modelInfo, toFormat)
 			}
 			if !isLevelSupported(string(config.Level), support.Levels) {
@@ -154,9 +166,10 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		}
 	}
 
-	// Convert ModeAuto to mid-range if dynamic not allowed
-	if config.Mode == ModeAuto && !support.DynamicAllowed {
-		config = convertAutoToMidRange(config, support, toFormat, model)
+	// Convert ModeAuto to mid-range if dynamic not allowed. An explicit "auto"
+	// level also means auto is accepted for level-based model configs.
+	if config.Mode == ModeAuto && !support.DynamicAllowed && !isLevelSupported(string(LevelAuto), support.Levels) {
+		config = convertAutoToMidRange(config, modelInfo, support, toFormat, model)
 	}
 
 	if config.Mode == ModeNone && toFormat == "claude" {
@@ -184,24 +197,25 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 //
 // This function handles the case where a model does not support dynamic/auto thinking.
 // The auto mode is silently converted to a fixed value based on model capability:
-//   - Level-only models: convert to ModeLevel with LevelMedium
+//   - Level-only models: convert to ModeLevel with the supported level closest to LevelMedium
 //   - Budget models: convert to ModeBudget with mid = (Min + Max) / 2
 //
 // Logging:
 //   - Debug level when conversion occurs
 //   - Fields: original_mode, clamped_to, reason
-func convertAutoToMidRange(config ThinkingConfig, support *registry.ThinkingSupport, provider, model string) ThinkingConfig {
-	// For level-only models (has Levels but no Min/Max range), use ModeLevel with medium
+func convertAutoToMidRange(config ThinkingConfig, modelInfo *registry.ModelInfo, support *registry.ThinkingSupport, provider, model string) ThinkingConfig {
+	// For level-only models (has Levels but no Min/Max range), use the supported level closest to medium.
 	if len(support.Levels) > 0 && support.Min == 0 && support.Max == 0 {
+		level := clampLevel(LevelMedium, modelInfo, provider)
 		config.Mode = ModeLevel
-		config.Level = LevelMedium
+		config.Level = level
 		config.Budget = 0
 		log.WithFields(log.Fields{
 			"provider":      provider,
 			"model":         model,
 			"original_mode": "auto",
-			"clamped_to":    string(LevelMedium),
-		}).Debug("thinking: mode converted, dynamic not allowed, using medium level |")
+			"clamped_to":    string(level),
+		}).Debug("thinking: mode converted, dynamic not allowed, using supported midpoint level |")
 		return config
 	}
 
@@ -228,6 +242,48 @@ func convertAutoToMidRange(config ThinkingConfig, support *registry.ThinkingSupp
 
 // standardLevelOrder defines the canonical ordering of thinking levels from lowest to highest.
 var standardLevelOrder = []ThinkingLevel{LevelMinimal, LevelLow, LevelMedium, LevelHigh, LevelXHigh, LevelMax}
+
+func mapHighIntentLevel(level ThinkingLevel, supported []string, crossProvider bool) (ThinkingLevel, bool) {
+	if !crossProvider {
+		return "", false
+	}
+	var candidates []ThinkingLevel
+	switch level {
+	case LevelXHigh:
+		candidates = []ThinkingLevel{LevelXHigh, LevelMax, LevelHigh}
+	case LevelMax:
+		candidates = []ThinkingLevel{LevelMax, LevelXHigh, LevelHigh}
+	default:
+		return "", false
+	}
+	for _, candidate := range candidates {
+		if isLevelSupported(string(candidate), supported) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func isHighIntentLevel(level ThinkingLevel) bool {
+	switch level {
+	case LevelXHigh, LevelMax:
+		return true
+	default:
+		return false
+	}
+}
+
+func logLevelMapping(provider, model string, original, mapped ThinkingLevel) {
+	if original == mapped {
+		return
+	}
+	log.WithFields(log.Fields{
+		"provider":       provider,
+		"model":          model,
+		"original_value": string(original),
+		"mapped_to":      string(mapped),
+	}).Debug("thinking: high-intent level mapped |")
+}
 
 // clampLevel clamps the given level to the nearest supported level.
 // On tie, prefers the lower level.
@@ -349,6 +405,13 @@ func normalizeLevels(levels []string) []string {
 		out[i] = strings.ToLower(strings.TrimSpace(l))
 	}
 	return out
+}
+
+func supportsThinkingDisable(support *registry.ThinkingSupport) bool {
+	if support == nil {
+		return false
+	}
+	return support.ZeroAllowed || isLevelSupported(string(LevelNone), support.Levels)
 }
 
 // isBudgetCapableProvider returns true if the provider supports budget-based thinking.

--- a/internal/thinking/validate_test.go
+++ b/internal/thinking/validate_test.go
@@ -1,0 +1,338 @@
+package thinking
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestValidateConfigMapsCrossProviderHighIntentLevels(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested ThinkingLevel
+		supported []string
+		want      ThinkingLevel
+	}{
+		{
+			name:      "xhigh prefers max before high",
+			requested: LevelXHigh,
+			supported: []string{"max", "high"},
+			want:      LevelMax,
+		},
+		{
+			name:      "xhigh falls back to high",
+			requested: LevelXHigh,
+			supported: []string{"high", "medium", "low"},
+			want:      LevelHigh,
+		},
+		{
+			name:      "max falls back to xhigh",
+			requested: LevelMax,
+			supported: []string{"xhigh", "high"},
+			want:      LevelXHigh,
+		},
+		{
+			name:      "max falls back to high",
+			requested: LevelMax,
+			supported: []string{"high", "medium", "low"},
+			want:      LevelHigh,
+		},
+		{
+			name:      "xhigh remains xhigh when supported",
+			requested: LevelXHigh,
+			supported: []string{"xhigh", "max", "high"},
+			want:      LevelXHigh,
+		},
+		{
+			name:      "max remains max when supported",
+			requested: LevelMax,
+			supported: []string{"max", "xhigh", "high"},
+			want:      LevelMax,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateConfig(
+				ThinkingConfig{Mode: ModeLevel, Level: tt.requested},
+				userDefinedLevelModel(tt.supported),
+				"openai",
+				"claude",
+				false,
+			)
+			if err != nil {
+				t.Fatalf("ValidateConfig() error = %v", err)
+			}
+			if got == nil {
+				t.Fatal("ValidateConfig() = nil, want config")
+			}
+			if got.Mode != ModeLevel || got.Level != tt.want {
+				t.Fatalf("ValidateConfig() = mode %s level %q, want level %q", got.Mode, got.Level, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateConfigDoesNotClampHighIntentBelowHigh(t *testing.T) {
+	for _, requested := range []ThinkingLevel{LevelXHigh, LevelMax} {
+		t.Run(string(requested), func(t *testing.T) {
+			_, err := ValidateConfig(
+				ThinkingConfig{Mode: ModeLevel, Level: requested},
+				userDefinedLevelModel([]string{"medium", "low"}),
+				"openai",
+				"claude",
+				false,
+			)
+			if err == nil {
+				t.Fatal("ValidateConfig() error = nil, want unsupported level")
+			}
+			if !strings.Contains(err.Error(), `not supported`) {
+				t.Fatalf("error = %q, want unsupported level", err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateConfigDoesNotMapHighIntentWithinSameProviderFamily(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested ThinkingLevel
+		supported []string
+		from      string
+		to        string
+	}{
+		{
+			name:      "claude xhigh to claude high",
+			requested: LevelXHigh,
+			supported: []string{"high", "medium", "low"},
+			from:      "claude",
+			to:        "claude",
+		},
+		{
+			name:      "claude max to claude xhigh",
+			requested: LevelMax,
+			supported: []string{"xhigh", "high"},
+			from:      "claude",
+			to:        "claude",
+		},
+		{
+			name:      "openai xhigh to codex high",
+			requested: LevelXHigh,
+			supported: []string{"high"},
+			from:      "openai",
+			to:        "codex",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := userDefinedLevelModel(tt.supported)
+			model.Type = tt.to
+			_, err := ValidateConfig(
+				ThinkingConfig{Mode: ModeLevel, Level: tt.requested},
+				model,
+				tt.from,
+				tt.to,
+				false,
+			)
+			if err == nil {
+				t.Fatal("ValidateConfig() error = nil, want unsupported level")
+			}
+			if !strings.Contains(err.Error(), `not supported`) {
+				t.Fatalf("error = %q, want unsupported level", err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateConfigHandlesModelFamilyMismatch(t *testing.T) {
+	t.Run("maps high intent across model family mismatch", func(t *testing.T) {
+		model := userDefinedLevelModel([]string{"max", "high"})
+		model.Type = "kimi"
+
+		got, err := ValidateConfig(
+			ThinkingConfig{Mode: ModeLevel, Level: LevelXHigh},
+			model,
+			"claude",
+			"claude",
+			false,
+		)
+		if err != nil {
+			t.Fatalf("ValidateConfig() error = %v", err)
+		}
+		if got == nil || got.Mode != ModeLevel || got.Level != LevelMax {
+			t.Fatalf("ValidateConfig() = %+v, want max level", got)
+		}
+	})
+
+	t.Run("keeps ordinary explicit levels strict", func(t *testing.T) {
+		model := userDefinedLevelModel([]string{"low", "high"})
+		model.Type = "kimi"
+
+		_, err := ValidateConfig(
+			ThinkingConfig{Mode: ModeLevel, Level: LevelMinimal},
+			model,
+			"claude",
+			"claude",
+			false,
+		)
+		if err == nil {
+			t.Fatal("ValidateConfig() error = nil, want unsupported level")
+		}
+		if !strings.Contains(err.Error(), `not supported`) {
+			t.Fatalf("error = %q, want unsupported level", err.Error())
+		}
+	})
+}
+
+func TestValidateConfigClampsInferredAliasThinking(t *testing.T) {
+	got, err := ValidateConfig(
+		ThinkingConfig{Mode: ModeLevel, Level: LevelMinimal},
+		inferredAliasLevelModel([]string{"low", "high"}),
+		"openai",
+		"gemini",
+		false,
+	)
+	if err != nil {
+		t.Fatalf("ValidateConfig() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("ValidateConfig() = nil, want config")
+	}
+	if got.Mode != ModeLevel || got.Level != LevelLow {
+		t.Fatalf("ValidateConfig() = mode %s level %q, want low", got.Mode, got.Level)
+	}
+}
+
+func TestValidateConfigRejectsExplicitUnsupportedAliasThinking(t *testing.T) {
+	_, err := ValidateConfig(
+		ThinkingConfig{Mode: ModeLevel, Level: LevelMinimal},
+		userDefinedLevelModel([]string{"low", "high"}),
+		"openai",
+		"gemini",
+		false,
+	)
+	if err == nil {
+		t.Fatal("ValidateConfig() error = nil, want unsupported level")
+	}
+	if !strings.Contains(err.Error(), `not supported`) {
+		t.Fatalf("error = %q, want unsupported level", err.Error())
+	}
+}
+
+func TestValidateConfigConvertsAutoToSupportedMidpointLevel(t *testing.T) {
+	got, err := ValidateConfig(
+		ThinkingConfig{Mode: ModeLevel, Level: LevelAuto},
+		userDefinedLevelModel([]string{"low", "high"}),
+		"openai",
+		"claude",
+		false,
+	)
+	if err != nil {
+		t.Fatalf("ValidateConfig() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("ValidateConfig() = nil, want config")
+	}
+	if got.Mode != ModeLevel || got.Level != LevelLow {
+		t.Fatalf("ValidateConfig() = mode %s level %q, want low", got.Mode, got.Level)
+	}
+}
+
+func TestValidateConfigRejectsExplicitUnsupportedNone(t *testing.T) {
+	model := &registry.ModelInfo{
+		ID:               "test/model",
+		Type:             "codex",
+		UserDefined:      true,
+		ThinkingExplicit: true,
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"low", "medium", "high"},
+		},
+	}
+	for _, config := range []ThinkingConfig{
+		{Mode: ModeLevel, Level: LevelNone},
+		{Mode: ModeBudget, Budget: 0},
+		{Mode: ModeNone},
+	} {
+		_, err := ValidateConfig(
+			config,
+			model,
+			"openai",
+			"codex",
+			false,
+		)
+		if err == nil {
+			t.Fatalf("ValidateConfig(%+v) error = nil, want unsupported none", config)
+		}
+		if !strings.Contains(err.Error(), `level "none" not supported`) {
+			t.Fatalf("error = %q, want unsupported none", err.Error())
+		}
+	}
+}
+
+func TestValidateConfigAllowsExplicitSupportedNone(t *testing.T) {
+	tests := []struct {
+		name  string
+		model *registry.ModelInfo
+	}{
+		{
+			name:  "none level",
+			model: userDefinedLevelModel([]string{"low", "medium", "high", "none"}),
+		},
+		{
+			name: "zero allowed",
+			model: &registry.ModelInfo{
+				ID:               "test/model",
+				Type:             "codex",
+				UserDefined:      true,
+				ThinkingExplicit: true,
+				Thinking: &registry.ThinkingSupport{
+					ZeroAllowed: true,
+					Levels:      []string{"low", "medium", "high"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateConfig(
+				ThinkingConfig{Mode: ModeLevel, Level: LevelNone},
+				tt.model,
+				"openai",
+				"codex",
+				false,
+			)
+			if err != nil {
+				t.Fatalf("ValidateConfig() error = %v", err)
+			}
+			if got == nil || got.Mode != ModeNone {
+				t.Fatalf("ValidateConfig() = %+v, want ModeNone", got)
+			}
+		})
+	}
+}
+
+func userDefinedLevelModel(levels []string) *registry.ModelInfo {
+	return &registry.ModelInfo{
+		ID:               "test/model",
+		Type:             "claude",
+		UserDefined:      true,
+		ThinkingExplicit: true,
+		Thinking: &registry.ThinkingSupport{
+			ZeroAllowed: true,
+			Levels:      levels,
+		},
+	}
+}
+
+func inferredAliasLevelModel(levels []string) *registry.ModelInfo {
+	return &registry.ModelInfo{
+		ID:          "test/model",
+		Type:        "gemini",
+		UserDefined: true,
+		Thinking: &registry.ThinkingSupport{
+			ZeroAllowed: true,
+			Levels:      levels,
+		},
+	}
+}

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 // ComputeOpenAICompatModelsHash returns a stable hash for OpenAI-compat models.
@@ -21,7 +22,7 @@ func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) str
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + fmt.Sprintf("image=%t", model.Image))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + fmt.Sprintf("image=%t", model.Image) + "|" + thinkingHashPart(model.Thinking))
 		}
 	})
 	return hashJoined(keys)
@@ -36,7 +37,7 @@ func ComputeVertexCompatModelsHash(models []config.VertexCompatModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + thinkingHashPart(model.Thinking))
 		}
 	})
 	return hashJoined(keys)
@@ -51,7 +52,7 @@ func ComputeClaudeModelsHash(models []config.ClaudeModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + thinkingHashPart(model.Thinking))
 		}
 	})
 	return hashJoined(keys)
@@ -66,7 +67,7 @@ func ComputeCodexModelsHash(models []config.CodexModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + thinkingHashPart(model.Thinking))
 		}
 	})
 	return hashJoined(keys)
@@ -81,7 +82,7 @@ func ComputeGeminiModelsHash(models []config.GeminiModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + thinkingHashPart(model.Thinking))
 		}
 	})
 	return hashJoined(keys)
@@ -122,6 +123,33 @@ func normalizeModelPairs(collect func(out func(key string))) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func thinkingHashPart(thinking *registry.ThinkingSupport) string {
+	if thinking == nil {
+		return "thinking="
+	}
+	normalizedLevels := make([]string, 0, len(thinking.Levels))
+	for _, level := range thinking.Levels {
+		if trimmed := strings.ToLower(strings.TrimSpace(level)); trimmed != "" {
+			normalizedLevels = append(normalizedLevels, trimmed)
+		}
+	}
+	sort.Strings(normalizedLevels)
+	data, _ := json.Marshal(struct {
+		Min            int      `json:"min"`
+		Max            int      `json:"max"`
+		ZeroAllowed    bool     `json:"zero_allowed"`
+		DynamicAllowed bool     `json:"dynamic_allowed"`
+		Levels         []string `json:"levels"`
+	}{
+		Min:            thinking.Min,
+		Max:            thinking.Max,
+		ZeroAllowed:    thinking.ZeroAllowed,
+		DynamicAllowed: thinking.DynamicAllowed,
+		Levels:         normalizedLevels,
+	})
+	return "thinking=" + string(data)
 }
 
 func hashJoined(keys []string) string {

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 func TestComputeOpenAICompatModelsHash_Deterministic(t *testing.T) {
@@ -33,6 +34,81 @@ func TestComputeOpenAICompatModelsHash_IncludesImageFlag(t *testing.T) {
 	}
 	if textModel == imageModel {
 		t.Fatal("hash should change when image flag changes")
+	}
+}
+
+func TestComputeModelsHash_IncludesThinkingSupport(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+	}{
+		{
+			name: "openai compatibility",
+			a: ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{
+				Name:     "m1",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+			}}),
+			b: ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{
+				Name:     "m1",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"xhigh"}},
+			}}),
+		},
+		{
+			name: "vertex compatibility",
+			a: ComputeVertexCompatModelsHash([]config.VertexCompatModel{{
+				Name:     "m1",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+			}}),
+			b: ComputeVertexCompatModelsHash([]config.VertexCompatModel{{
+				Name:     "m1",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"xhigh"}},
+			}}),
+		},
+		{
+			name: "claude",
+			a: ComputeClaudeModelsHash([]config.ClaudeModel{{
+				Name:     "m1",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+			}}),
+			b: ComputeClaudeModelsHash([]config.ClaudeModel{{
+				Name:     "m1",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"xhigh"}},
+			}}),
+		},
+		{
+			name: "codex",
+			a: ComputeCodexModelsHash([]config.CodexModel{{
+				Name:     "m1",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+			}}),
+			b: ComputeCodexModelsHash([]config.CodexModel{{
+				Name:     "m1",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"xhigh"}},
+			}}),
+		},
+		{
+			name: "gemini",
+			a: ComputeGeminiModelsHash([]config.GeminiModel{{
+				Name:     "m1",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+			}}),
+			b: ComputeGeminiModelsHash([]config.GeminiModel{{
+				Name:     "m1",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"xhigh"}},
+			}}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.a == "" || tt.b == "" {
+				t.Fatalf("hashes should not be empty, got %q / %q", tt.a, tt.b)
+			}
+			if tt.a == tt.b {
+				t.Fatal("hash should change when thinking support changes")
+			}
+		})
 	}
 }
 

--- a/internal/watcher/diff/models_summary.go
+++ b/internal/watcher/diff/models_summary.go
@@ -1,9 +1,6 @@
 package diff
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"sort"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -45,7 +42,7 @@ func SummarizeGeminiModels(models []config.GeminiModel) GeminiModelsSummary {
 		}
 	})
 	return GeminiModelsSummary{
-		hash:  hashJoined(keys),
+		hash:  ComputeGeminiModelsHash(models),
 		count: len(keys),
 	}
 }
@@ -66,7 +63,7 @@ func SummarizeClaudeModels(models []config.ClaudeModel) ClaudeModelsSummary {
 		}
 	})
 	return ClaudeModelsSummary{
-		hash:  hashJoined(keys),
+		hash:  ComputeClaudeModelsHash(models),
 		count: len(keys),
 	}
 }
@@ -87,7 +84,7 @@ func SummarizeCodexModels(models []config.CodexModel) CodexModelsSummary {
 		}
 	})
 	return CodexModelsSummary{
-		hash:  hashJoined(keys),
+		hash:  ComputeCodexModelsHash(models),
 		count: len(keys),
 	}
 }
@@ -97,25 +94,21 @@ func SummarizeVertexModels(models []config.VertexCompatModel) VertexModelsSummar
 	if len(models) == 0 {
 		return VertexModelsSummary{}
 	}
-	names := make([]string, 0, len(models))
-	for _, model := range models {
-		name := strings.TrimSpace(model.Name)
-		alias := strings.TrimSpace(model.Alias)
-		if name == "" && alias == "" {
-			continue
+	keys := normalizeModelPairs(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
 		}
-		if alias != "" {
-			name = alias
-		}
-		names = append(names, name)
-	}
-	if len(names) == 0 {
+	})
+	if len(keys) == 0 {
 		return VertexModelsSummary{}
 	}
-	sort.Strings(names)
-	sum := sha256.Sum256([]byte(strings.Join(names, "|")))
 	return VertexModelsSummary{
-		hash:  hex.EncodeToString(sum[:]),
-		count: len(names),
+		hash:  ComputeVertexCompatModelsHash(models),
+		count: len(keys),
 	}
 }

--- a/internal/watcher/diff/oauth_excluded_test.go
+++ b/internal/watcher/diff/oauth_excluded_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 func TestSummarizeExcludedModels_NormalizesAndDedupes(t *testing.T) {
@@ -75,6 +76,26 @@ func TestSummarizeVertexModels(t *testing.T) {
 	}
 	if blank := SummarizeVertexModels([]config.VertexCompatModel{{Name: " "}}); blank.count != 0 || blank.hash != "" {
 		t.Fatalf("expected blank model ignored, got %+v", blank)
+	}
+}
+
+func TestSummarizeModelsIncludesThinkingSupport(t *testing.T) {
+	oldSummary := SummarizeClaudeModels([]config.ClaudeModel{{
+		Name:     "claude-test",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+	}})
+	newSummary := SummarizeClaudeModels([]config.ClaudeModel{{
+		Name:     "claude-test",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"xhigh"}},
+	}})
+	if oldSummary.hash == "" || newSummary.hash == "" {
+		t.Fatalf("expected non-empty hashes, got %q / %q", oldSummary.hash, newSummary.hash)
+	}
+	if oldSummary.hash == newSummary.hash {
+		t.Fatal("summary hash should change when thinking support changes")
+	}
+	if oldSummary.count != newSummary.count {
+		t.Fatalf("summary count changed with thinking only: %d / %d", oldSummary.count, newSummary.count)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1842,6 +1842,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		}
 		execOpts := opts
 		execReq, execOpts = applyRequestAfterAuthInterceptor(ctx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+		execOpts = withModelInfoLookupModelMetadata(execOpts, modelInfoLookupModelForExecution(routeModel, execReq, executionModel != ""))
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, execOpts)
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
@@ -2586,6 +2587,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			}
 			execOpts := opts
 			execReq, execOpts = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			execOpts = withModelInfoLookupModelMetadata(execOpts, modelInfoLookupModelForExecution(routeModel, execReq, restoreExecutionModel))
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -2705,6 +2707,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			}
 			execOpts := opts
 			execReq, execOpts = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			execOpts = withModelInfoLookupModelMetadata(execOpts, modelInfoLookupModelForExecution(routeModel, execReq, restoreExecutionModel))
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -2865,6 +2868,43 @@ func ensureRequestedModelMetadata(opts cliproxyexecutor.Options, requestedModel 
 	meta[cliproxyexecutor.RequestedModelMetadataKey] = requestedModel
 	opts.Metadata = meta
 	return opts
+}
+
+func withModelInfoLookupModelMetadata(opts cliproxyexecutor.Options, lookupModel string) cliproxyexecutor.Options {
+	lookupModel = strings.TrimSpace(lookupModel)
+	if lookupModel == "" {
+		return opts
+	}
+	meta := make(map[string]any, len(opts.Metadata)+1)
+	for k, v := range opts.Metadata {
+		meta[k] = v
+	}
+	meta[cliproxyexecutor.ModelInfoLookupModelMetadataKey] = lookupModel
+	opts.Metadata = meta
+	return opts
+}
+
+func modelInfoLookupModelForExecution(routeModel string, execReq cliproxyexecutor.Request, useExecutionModel bool) string {
+	routeModel = strings.TrimSpace(routeModel)
+	executionModel := strings.TrimSpace(execReq.Model)
+	if useExecutionModel {
+		if executionModel != "" {
+			return executionModel
+		}
+	}
+	if routeModel == "" {
+		return executionModel
+	}
+	executionResult := thinking.ParseSuffix(executionModel)
+	if executionResult.HasSuffix && strings.TrimSpace(executionResult.RawSuffix) != "" {
+		routeResult := thinking.ParseSuffix(routeModel)
+		routeBase := strings.TrimSpace(routeResult.ModelName)
+		if routeBase == "" {
+			routeBase = routeModel
+		}
+		return routeBase + "(" + strings.TrimSpace(executionResult.RawSuffix) + ")"
+	}
+	return routeModel
 }
 
 func authSelectionModelFromOptions(opts cliproxyexecutor.Options, fallback string) string {
@@ -5364,7 +5404,8 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			resultModel := m.stateModelForExecution(c.auth, routeModel, upstreamModel, pooled)
 			execReq := req
 			execReq.Model = upstreamModel
-			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
+			execOpts := withModelInfoLookupModelMetadata(creditsOpts, modelInfoLookupModelForExecution(routeModel, execReq, false))
+			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, execOpts)
 			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
 				result.Error = &Error{Message: errExec.Error()}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -11,6 +11,9 @@ import (
 // RequestedModelMetadataKey stores the client-requested model name in Options.Metadata.
 const RequestedModelMetadataKey = "requested_model"
 
+// ModelInfoLookupModelMetadataKey stores the request-scoped model name used for registry ModelInfo capability lookup.
+const ModelInfoLookupModelMetadataKey = "model_info_lookup_model"
+
 // RequestPathMetadataKey stores the inbound HTTP request path (e.g. "/v1/images/generations") in Options.Metadata.
 // It is optional and may be absent for non-HTTP executions.
 const RequestPathMetadataKey = "request_path"

--- a/sdk/cliproxy/openai_compat_config_models_test.go
+++ b/sdk/cliproxy/openai_compat_config_models_test.go
@@ -59,6 +59,133 @@ func TestBuildOpenAICompatibilityConfigModels_InputModalities(t *testing.T) {
 	}
 }
 
+func TestBuildOpenAICompatibilityConfigModels_ThinkingExplicit(t *testing.T) {
+	models := buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{
+		Name: "compat",
+		Models: []config.OpenAICompatibilityModel{
+			{
+				Name:     "explicit-thinking",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"xhigh"}},
+			},
+			{
+				Name: "default-thinking",
+			},
+		},
+	})
+	if len(models) != 2 {
+		t.Fatalf("model count = %d, want 2", len(models))
+	}
+	if !models[0].ThinkingExplicit {
+		t.Fatal("explicit model ThinkingExplicit = false, want true")
+	}
+	if models[1].ThinkingExplicit {
+		t.Fatal("default model ThinkingExplicit = true, want false")
+	}
+}
+
+func TestBuildClaudeConfigModels_UsesConfiguredThinking(t *testing.T) {
+	models := buildClaudeConfigModels(&config.ClaudeKey{
+		Models: []config.ClaudeModel{
+			{
+				Name: "claude-opus-4-6",
+				Thinking: &registry.ThinkingSupport{
+					Levels: []string{"high", "medium", "low", "minimal", "none", "auto"},
+				},
+			},
+		},
+	})
+	if len(models) != 1 {
+		t.Fatalf("model count = %d, want 1", len(models))
+	}
+	if models[0].Thinking == nil {
+		t.Fatal("Thinking = nil, want configured support")
+	}
+	if !models[0].ThinkingExplicit {
+		t.Fatal("ThinkingExplicit = false, want true for configured support")
+	}
+	if got := joinModalities(models[0].Thinking.Levels); got != "high,medium,low,minimal,none,auto" {
+		t.Fatalf("Thinking.Levels = %q, want configured levels", got)
+	}
+}
+
+func TestBuildClaudeConfigModels_InferredThinkingIsNotExplicit(t *testing.T) {
+	models := buildClaudeConfigModels(&config.ClaudeKey{
+		Models: []config.ClaudeModel{{Name: "claude-sonnet-4-6"}},
+	})
+	if len(models) != 1 {
+		t.Fatalf("model count = %d, want 1", len(models))
+	}
+	if models[0].Thinking == nil {
+		t.Fatal("Thinking = nil, want static inferred support")
+	}
+	if models[0].ThinkingExplicit {
+		t.Fatal("ThinkingExplicit = true, want false for static inferred support")
+	}
+}
+
+func TestBuildAPIKeyConfigModels_UseConfiguredThinking(t *testing.T) {
+	tests := []struct {
+		name   string
+		models []*ModelInfo
+	}{
+		{
+			name: "gemini",
+			models: buildGeminiConfigModels(&config.GeminiKey{Models: []config.GeminiModel{{
+				Name:     "gemini-test",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"xhigh"}},
+			}}}),
+		},
+		{
+			name: "codex",
+			models: buildCodexConfigModels(&config.CodexKey{Models: []config.CodexModel{{
+				Name:     "codex-test",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"xhigh"}},
+			}}}),
+		},
+		{
+			name: "claude",
+			models: buildClaudeConfigModels(&config.ClaudeKey{Models: []config.ClaudeModel{{
+				Name:     "claude-test",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"xhigh"}},
+			}}}),
+		},
+		{
+			name: "vertex",
+			models: buildVertexCompatConfigModels(&config.VertexCompatKey{Models: []config.VertexCompatModel{{
+				Name:     "vertex-test",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"xhigh"}},
+			}}}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := findModelByPrefix(tt.models, tt.name+"-test")
+			if model == nil {
+				t.Fatalf("configured model %q not found in %+v", tt.name+"-test", tt.models)
+			}
+			if model.Thinking == nil {
+				t.Fatal("Thinking = nil, want configured support")
+			}
+			if !model.ThinkingExplicit {
+				t.Fatal("ThinkingExplicit = false, want true for configured support")
+			}
+			if got := joinModalities(model.Thinking.Levels); got != "xhigh" {
+				t.Fatalf("Thinking.Levels = %q, want xhigh", got)
+			}
+		})
+	}
+}
+
+func findModelByPrefix(models []*ModelInfo, prefix string) *ModelInfo {
+	for _, model := range models {
+		if model != nil && len(model.ID) >= len(prefix) && model.ID[:len(prefix)] == prefix {
+			return model
+		}
+	}
+	return nil
+}
+
 func joinModalities(modalities []string) string {
 	if len(modalities) == 0 {
 		return ""

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2474,6 +2474,10 @@ type modelEntry interface {
 	GetAlias() string
 }
 
+type modelThinkingEntry interface {
+	GetThinking() *registry.ThinkingSupport
+}
+
 func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []*ModelInfo {
 	if compat == nil || len(compat.Models) == 0 {
 		return nil
@@ -2497,6 +2501,7 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		if thinking == nil && !model.Image {
 			thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
 		}
+		thinkingExplicit := model.Thinking != nil
 		inputModalities := normalizeCompatConfigModalities(model.InputModalities)
 		outputModalities := normalizeCompatConfigModalities(model.OutputModalities)
 		models = append(models, &ModelInfo{
@@ -2508,6 +2513,7 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 			DisplayName:               modelID,
 			UserDefined:               false,
 			Thinking:                  thinking,
+			ThinkingExplicit:          thinkingExplicit,
 			SupportedInputModalities:  inputModalities,
 			SupportedOutputModalities: outputModalities,
 		})
@@ -2573,7 +2579,13 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 			DisplayName: display,
 			UserDefined: true,
 		}
-		if name != "" {
+		if thinkingEntry, ok := any(model).(modelThinkingEntry); ok {
+			if thinking := thinkingEntry.GetThinking(); thinking != nil {
+				info.Thinking = thinking
+				info.ThinkingExplicit = true
+			}
+		}
+		if info.Thinking == nil && name != "" {
 			if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
 				info.Thinking = upstream.Thinking
 			}


### PR DESCRIPTION
## Summary

- Carry the client-facing model selected for the current execution attempt in executor metadata, so runtime capability checks can resolve provider-registered model metadata even after routing strips a provider prefix from the upstream model name.
- Centralize request-scoped `ModelInfo` lookup behind a provider-guarded helper, avoiding cross-provider capability leakage.
- Use the resolved `ModelInfo` for runtime capability checks that previously looked up only the upstream model name:
  - thinking / reasoning validation and application
  - Claude, Gemini, and Antigravity max token caps
  - xAI `reasoning.effort` support
  - Antigravity Claude typed web-search routing
- Preserve source-format thinking parameters across translated executor paths when a prefixed/user-defined model entry should override translator static mappings, while keeping translated provider-format defaults for normal static models.
- Honor explicit `models[].thinking` metadata for API-key provider model entries, so cross-provider high-intent levels can map within `xhigh` / `max` / `high` according to the target model capabilities instead of treating configured user-defined models as unconditional passthrough.
- Include `models[].thinking` metadata in hot-reload model hashes, so thinking-only config updates refresh registered model capabilities.
- Keep synthetic Codex image main-model thinking isolated from route image model metadata.

## Failure Examples Without This Change

**The core issue is that prefixed client requests can lose the ability to match their provider-registered model capabilities during execution, which then causes serious field handling mistakes.**

A config provider can expose prefixed client model names while keeping each configured model name as the unprefixed upstream model. For example:

```yaml
force-model-prefix: true
claude-api-key:
  - prefix: sp-anthropic
    base-url: https://example.test
    api-key: sk-example
    models:
      - name: claude-sonnet-4-6
        thinking:
          levels: [xhigh, high, medium, low, minimal, none, auto]
```

The configured `models[].name` remains `claude-sonnet-4-6`. With `force-model-prefix`, CPA exposes the client-facing model as `sp-anthropic/claude-sonnet-4-6`, then routes the request upstream as `claude-sonnet-4-6`. Before this fix, executor-stage checks often looked up only the unprefixed upstream model, so the provider-specific registered metadata for `sp-anthropic/claude-sonnet-4-6` could be missed.

That can cause several incorrect behaviors:

- OpenAI-compatible chat to a Claude API-key provider can send `reasoning_effort: xhigh`, but validation may use the static unprefixed Claude metadata, ignore configured `models[].thinking.levels`, or let the translator's stale static mapping rewrite it to a different level such as `max`. With the configured metadata available, CPA can map high-intent levels within `xhigh` / `max` / `high` based on what the target model supports.
- Gemini, Codex, Kimi, xAI, Vertex-compatible, OpenAI-compatible, and Antigravity config providers can hit the same metadata mismatch when a prefixed/user-defined model overrides thinking support but execution uses an unprefixed upstream model.
- A user-defined prefixed model that only overrides thinking metadata can accidentally bypass the upstream static max-token cap fallback, forwarding an oversized `maxOutputTokens` / `max_tokens` value to the provider.
- xAI-style `reasoning.effort` support can be checked against the wrong unprefixed model entry.
- Antigravity Claude typed web-search routing can miss prefixed model capability metadata and choose the wrong request path.
- Hot-reloading a config change that only edits `models[].thinking` can leave stale registry capabilities active until a restart if that metadata is not included in the model hash.

This PR keeps the provider request model unchanged for upstream calls, but uses the request-scoped client-facing model only for registry capability lookup when that exact model is registered for the current provider.

## Tests

- `go test ./...`