### PR TITLE
fix: preserve ultra reasoning effort for Codex clients

### DIFF
--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -27,6 +27,7 @@ var codexClientAllowedReasoningLevels = map[string]struct{}{
 	"high":   {},
 	"xhigh":  {},
 	"max":    {},
+	"ultra":  {},
 }
 
 func (h *OpenAIAPIHandler) codexClientModelsResponse() map[string]any {

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -100,3 +100,35 @@ func TestCodexClientModelsResponse_InputModalitiesFromRegistry(t *testing.T) {
 		t.Fatalf("image endpoint model should not expose input_modalities from registry: %#v", imageEntry["input_modalities"])
 	}
 }
+
+func TestCodexClientModelsResponse_PreservesUltraReasoningEffort(t *testing.T) {
+	resp := CodexClientModelsResponse([]map[string]any{{"id": "gpt-5.6-sol"}})
+	models, ok := resp["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", resp["models"])
+	}
+
+	var sol map[string]any
+	for _, entry := range models {
+		if stringModelValue(entry, "slug") == "gpt-5.6-sol" {
+			sol = entry
+			break
+		}
+	}
+	if sol == nil {
+		t.Fatal("expected codex client entry for gpt-5.6-sol")
+	}
+
+	levels, ok := sol["supported_reasoning_levels"].([]any)
+	if !ok {
+		t.Fatalf("supported_reasoning_levels = %T, want []any", sol["supported_reasoning_levels"])
+	}
+	for _, rawLevel := range levels {
+		level, ok := rawLevel.(map[string]any)
+		if ok && stringModelValue(level, "effort") == "ultra" {
+			return
+		}
+	}
+
+	t.Fatalf("supported_reasoning_levels = %#v, want ultra", levels)
+}


### PR DESCRIPTION
## Summary
- allow `ultra` in the Codex client reasoning-level sanitizer
- add a regression test verifying `gpt-5.6-sol` keeps its `ultra` effort in the client model catalog

## Why
The bundled Codex client model catalog already advertises `ultra` for supported models, but `codexClientAllowedReasoningLevels` filters it out of `/v1/models?client_version=...`. This prevents clients with the Ultra feature enabled from discovering the option.

## Tests
- `go test ./sdk/api/handlers/openai -count=1`
- `go test ./...` has an unrelated failure already present on the upstream baseline: `TestModelsWithClientVersionReturnsCodexCatalog` expects custom priority 129, while the current model catalog returns 143.