### PR TITLE
docs: fix misleading Management API link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ CLIProxyAPI Guides: [https://help.router-for.me/](https://help.router-for.me/)
 
 ## Management API
 
-see [MANAGEMENT_API.md](https://help.router-for.me/management/api)
+see the [Management API docs](https://help.router-for.me/management/api)
 
 ## Usage Statistics
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -99,7 +99,7 @@ CLIProxyAPI 用户手册： [https://help.router-for.me/](https://help.router-fo
 
 ## 管理 API 文档
 
-请参见 [MANAGEMENT_API_CN.md](https://help.router-for.me/cn/management/api)
+请参见[管理 API 文档](https://help.router-for.me/cn/management/api)
 
 ## 使用量统计
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -98,7 +98,7 @@ CLIProxyAPIガイド：[https://help.router-for.me/](https://help.router-for.me/
 
 ## 管理API
 
-[MANAGEMENT_API.md](https://help.router-for.me/management/api)を参照
+[管理APIドキュメント](https://help.router-for.me/management/api)を参照
 
 ## 使用量統計
 


### PR DESCRIPTION
The Management API section links to https://help.router-for.me/management/api, but the link text (MANAGEMENT_API.md / MANAGEMENT_API_CN.md) reads like it's a file in this repo. There isn't one, it just points to the hosted docs site. Reworded the link text in all three READMEs so it doesn't look like a local file that's missing.