### PR TITLE
fix(auth): preserve active cooldowns during model reconciliation

### DIFF
--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -694,12 +694,14 @@ func (r *ModelRegistry) SetModelQuotaExceeded(clientID, modelID string) {
 	defer r.mutex.Unlock()
 	r.ensureAvailableModelsCacheLocked()
 
-	if registration, exists := r.models[modelID]; exists {
-		now := time.Now()
-		registration.QuotaExceededClients[clientID] = &now
-		r.invalidateAvailableModelsCacheLocked()
-		log.Debugf("Marked model %s as quota exceeded for client %s", modelID, clientID)
+	registration, exists := r.models[modelID]
+	if !exists || registration == nil || !r.clientSupportsModelLocked(clientID, modelID) {
+		return
 	}
+	now := time.Now()
+	registration.QuotaExceededClients[clientID] = &now
+	r.invalidateAvailableModelsCacheLocked()
+	log.Debugf("Marked model %s as quota exceeded for client %s", modelID, clientID)
 }
 
 // ClearModelQuotaExceeded removes quota exceeded status for a model and client
@@ -732,7 +734,7 @@ func (r *ModelRegistry) SuspendClientModel(clientID, modelID, reason string) {
 	r.ensureAvailableModelsCacheLocked()
 
 	registration, exists := r.models[modelID]
-	if !exists || registration == nil {
+	if !exists || registration == nil || !r.clientSupportsModelLocked(clientID, modelID) {
 		return
 	}
 	if registration.SuspendedClients == nil {
@@ -786,7 +788,10 @@ func (r *ModelRegistry) ClientSupportsModel(clientID, modelID string) bool {
 
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
+	return r.clientSupportsModelLocked(clientID, modelID)
+}
 
+func (r *ModelRegistry) clientSupportsModelLocked(clientID, modelID string) bool {
 	models, exists := r.clientModels[clientID]
 	if !exists || len(models) == 0 {
 		return false

--- a/internal/registry/model_registry_safety_test.go
+++ b/internal/registry/model_registry_safety_test.go
@@ -110,6 +110,32 @@ func TestCleanupExpiredQuotasInvalidatesAvailableModelsCache(t *testing.T) {
 	}
 }
 
+func TestCooldownWritesIgnoreUnregisteredClient(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("removed-client", "openai", []*ModelInfo{{ID: "m1"}})
+	r.RegisterClient("active-client", "openai", []*ModelInfo{{ID: "m1"}})
+	r.UnregisterClient("removed-client")
+
+	r.SetModelQuotaExceeded("removed-client", "m1")
+	r.SuspendClientModel("removed-client", "m1", "quota")
+
+	if count := r.GetModelCount("m1"); count != 1 {
+		t.Fatalf("model count after stale cooldown writes = %d, want 1", count)
+	}
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	registration := r.models["m1"]
+	if registration == nil {
+		t.Fatal("model registration was removed unexpectedly")
+	}
+	if _, ok := registration.QuotaExceededClients["removed-client"]; ok {
+		t.Fatal("quota state was restored for an unregistered client")
+	}
+	if _, ok := registration.SuspendedClients["removed-client"]; ok {
+		t.Fatal("suspension was restored for an unregistered client")
+	}
+}
+
 func TestGetAvailableModelsReturnsClonedSupportedParameters(t *testing.T) {
 	r := newTestModelRegistry()
 	r.RegisterClient("client-1", "openai", []*ModelInfo{{

--- a/sdk/cliproxy/auth/conductor_reconcile_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_reconcile_cooldown_test.go
@@ -1,0 +1,270 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestManager_ReconcileRegistryModelStatesPreservesUnauthorizedCooldown(t *testing.T) {
+	t.Parallel()
+
+	const (
+		authID = "reconcile-unauthorized-auth"
+		model  = "reconcile-unauthorized-model"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: "codex",
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[model] == nil {
+		t.Fatal("unauthorized model cooldown was not recorded")
+	}
+	wantRetryAfter := before.ModelStates[model].NextRetryAfter
+	if !wantRetryAfter.After(time.Now()) {
+		t.Fatalf("NextRetryAfter = %v, want future cooldown", wantRetryAfter)
+	}
+	resetAggregatedAuthStateForReconcileTest(t, manager, before)
+
+	// RegisterClient replaces the registry-side suspension snapshot.
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count after re-registration = %d, want 1", count)
+	}
+
+	manager.ReconcileRegistryModelStates(ctx, authID)
+	after, ok := manager.GetByID(authID)
+	if !ok || after.ModelStates[model] == nil {
+		t.Fatal("unauthorized model cooldown was removed during reconciliation")
+	}
+	state := after.ModelStates[model]
+	if !state.Unavailable || !state.NextRetryAfter.Equal(wantRetryAfter) {
+		t.Fatalf("reconciled model state = %+v, want active cooldown until %v", state, wantRetryAfter)
+	}
+	if after.Status != StatusError || !after.Unavailable || !after.NextRetryAfter.Equal(wantRetryAfter) {
+		t.Fatalf("reconciled auth state = status %q unavailable %v next %v", after.Status, after.Unavailable, after.NextRetryAfter)
+	}
+	if after.LastError == nil || after.LastError.StatusCode() != http.StatusUnauthorized {
+		t.Fatalf("reconciled auth error = %+v, want unauthorized", after.LastError)
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count after reconciliation = %d, want 0", count)
+	}
+}
+
+func TestManager_ReconcileRegistryModelStatesPreservesQuotaCooldown(t *testing.T) {
+	t.Parallel()
+
+	const (
+		authID = "reconcile-quota-auth"
+		model  = "reconcile-quota-model"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	retryAfter := 20 * time.Minute
+	manager.MarkResult(ctx, Result{
+		AuthID:     authID,
+		Provider:   "codex",
+		Model:      model,
+		Success:    false,
+		Error:      &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota"},
+		RetryAfter: &retryAfter,
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[model] == nil {
+		t.Fatal("quota model cooldown was not recorded")
+	}
+	wantRetryAfter := before.ModelStates[model].NextRetryAfter
+	resetAggregatedAuthStateForReconcileTest(t, manager, before)
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count after re-registration = %d, want 1", count)
+	}
+
+	manager.ReconcileRegistryModelStates(ctx, authID)
+	after, ok := manager.GetByID(authID)
+	if !ok || after.ModelStates[model] == nil {
+		t.Fatal("quota model cooldown was removed during reconciliation")
+	}
+	state := after.ModelStates[model]
+	if !state.Unavailable || !state.Quota.Exceeded || !state.NextRetryAfter.Equal(wantRetryAfter) {
+		t.Fatalf("reconciled model state = %+v, want active quota cooldown until %v", state, wantRetryAfter)
+	}
+	if after.Status != StatusError || !after.Unavailable || !after.Quota.Exceeded || !after.NextRetryAfter.Equal(wantRetryAfter) {
+		t.Fatalf("reconciled auth state = status %q unavailable %v quota %+v next %v", after.Status, after.Unavailable, after.Quota, after.NextRetryAfter)
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count after reconciliation = %d, want 0", count)
+	}
+}
+
+func resetAggregatedAuthStateForReconcileTest(t *testing.T, manager *Manager, auth *Auth) {
+	t.Helper()
+	incoming := auth.Clone()
+	incoming.Status = StatusActive
+	incoming.StatusMessage = ""
+	incoming.Unavailable = false
+	incoming.NextRetryAfter = time.Time{}
+	incoming.Quota = QuotaState{}
+	incoming.LastError = nil
+	if _, err := manager.Update(context.Background(), incoming); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+}
+
+func TestManager_ReconcileRegistryModelStatesDoesNotSuspendCloudflareChallenge(t *testing.T) {
+	const (
+		authID = "reconcile-cloudflare-auth"
+		model  = "reconcile-cloudflare-model"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "claude"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: "claude",
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusForbidden, Message: "cf-mitigated: challenge"},
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[model] == nil {
+		t.Fatal("cloudflare challenge cooldown was not recorded")
+	}
+	wantRetryAfter := before.ModelStates[model].NextRetryAfter
+
+	reg.RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+	manager.ReconcileRegistryModelStates(ctx, authID)
+
+	after, ok := manager.GetByID(authID)
+	if !ok || after.ModelStates[model] == nil {
+		t.Fatal("cloudflare challenge cooldown was removed during reconciliation")
+	}
+	state := after.ModelStates[model]
+	if !state.Unavailable || !state.NextRetryAfter.Equal(wantRetryAfter) {
+		t.Fatalf("reconciled model state = %+v, want transient cooldown until %v", state, wantRetryAfter)
+	}
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count after reconciliation = %d, want 1", count)
+	}
+}
+
+func TestManager_RestoreRegistryCooldownRechecksClearedState(t *testing.T) {
+	const (
+		authID = "reconcile-stale-cooldown-auth"
+		model  = "reconcile-stale-cooldown-model"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: "codex",
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	// Simulate a candidate captured before a concurrent successful result.
+	candidate := registryCooldownCandidate{stateKey: model, model: model}
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	manager.MarkResult(ctx, Result{AuthID: authID, Provider: "codex", Model: model, Success: true})
+	manager.restoreRegistryCooldown(authID, candidate)
+
+	after, ok := manager.GetByID(authID)
+	if !ok || !modelStateIsClean(after.ModelStates[model]) {
+		t.Fatalf("model state after success = %+v, want clean", after.ModelStates[model])
+	}
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count after stale restore = %d, want 1", count)
+	}
+}
+
+func TestManager_ReconcileRegistryModelStatesKeepsSuffixedCooldownManagerScoped(t *testing.T) {
+	const (
+		authID        = "reconcile-suffixed-cooldown-auth"
+		baseModel     = "reconcile-suffixed-cooldown-model"
+		suffixedModel = baseModel + "(high)"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: baseModel}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: "codex",
+		Model:    suffixedModel,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[suffixedModel] == nil {
+		t.Fatal("suffixed model cooldown was not recorded")
+	}
+	wantRetryAfter := before.ModelStates[suffixedModel].NextRetryAfter
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: baseModel}})
+	manager.ReconcileRegistryModelStates(ctx, authID)
+
+	after, ok := manager.GetByID(authID)
+	if !ok || after.ModelStates[suffixedModel] == nil {
+		t.Fatal("suffixed model cooldown was removed during reconciliation")
+	}
+	if state := after.ModelStates[suffixedModel]; !state.Unavailable || !state.NextRetryAfter.Equal(wantRetryAfter) {
+		t.Fatalf("reconciled suffixed state = %+v, want cooldown until %v", state, wantRetryAfter)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(after, suffixedModel, time.Now()); !blocked {
+		t.Fatal("suffixed model request is not blocked by its cooldown")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(after, baseModel, time.Now()); blocked {
+		t.Fatal("base model request is blocked by a suffixed-only cooldown")
+	}
+	if count := reg.GetModelCount(baseModel); count != 1 {
+		t.Fatalf("registry base model count after reconciliation = %d, want 1", count)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -109,38 +109,49 @@ func (m *Manager) RefreshSchedulerAll() {
 	}
 }
 
+type registryCooldownCandidate struct {
+	stateKey string
+	model    string
+}
+
 // ReconcileRegistryModelStates aligns per-model runtime state with the current
 // registry snapshot for one auth.
 //
-// Supported models are reset to a clean state because re-registration already
-// cleared the registry-side cooldown/suspension snapshot. ModelStates for
-// models that are no longer present in the registry are pruned entirely so
-// renamed/removed models cannot keep auth-level status stale.
+// Active cooldowns for supported models are preserved across re-registration
+// and restored into the registry when the stored state key matches a registered
+// model. ModelStates for models that are no longer present in the registry are
+// pruned entirely so renamed/removed models cannot keep auth-level status stale.
 func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID string) {
 	if m == nil || authID == "" {
 		return
 	}
 
-	supportedModels := registry.GetGlobalRegistry().GetModelsForClient(authID)
+	reg := registry.GetGlobalRegistry()
+	supportedModels := reg.GetModelsForClient(authID)
 	supported := make(map[string]struct{}, len(supportedModels))
+	registered := make(map[string]string, len(supportedModels))
 	for _, model := range supportedModels {
 		if model == nil {
 			continue
 		}
-		modelKey := canonicalModelKey(model.ID)
+		registeredModel := strings.TrimSpace(model.ID)
+		modelKey := canonicalModelKey(registeredModel)
 		if modelKey == "" {
 			continue
 		}
 		supported[modelKey] = struct{}{}
+		registered[strings.ToLower(registeredModel)] = registeredModel
 	}
 
 	var snapshot *Auth
+	var cooldowns []registryCooldownCandidate
 	now := time.Now()
 
 	m.mu.Lock()
 	auth, ok := m.auths[authID]
 	if ok && auth != nil && len(auth.ModelStates) > 0 {
 		changed := false
+		preserved := false
 		for modelKey, state := range auth.ModelStates {
 			baseModel := canonicalModelKey(modelKey)
 			if baseModel == "" {
@@ -160,30 +171,151 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 			if modelStateIsClean(state) {
 				continue
 			}
+			if state.Unavailable && state.NextRetryAfter.After(now) {
+				preserved = true
+				registeredModel, exactMatch := registered[strings.ToLower(strings.TrimSpace(modelKey))]
+				if exactMatch {
+					if _, _, suspend := registrySuspensionForModelState(state); suspend {
+						cooldowns = append(cooldowns, registryCooldownCandidate{
+							stateKey: modelKey,
+							model:    registeredModel,
+						})
+					}
+				}
+				continue
+			}
 			resetModelState(state, now)
 			changed = true
 		}
 		if len(auth.ModelStates) == 0 {
 			auth.ModelStates = nil
 		}
-		if changed {
+		if changed || preserved {
+			previousUnavailable := auth.Unavailable
+			previousNextRetryAfter := auth.NextRetryAfter
+			previousQuota := auth.Quota
+			previousStatus := auth.Status
+			previousStatusMessage := auth.StatusMessage
+			previousLastError := cloneError(auth.LastError)
+
 			updateAggregatedAvailability(auth, now)
-			if !hasModelError(auth, now) {
-				auth.LastError = nil
-				auth.StatusMessage = ""
-				auth.Status = StatusActive
+			updateAggregatedModelError(auth, now)
+			aggregateChanged := previousUnavailable != auth.Unavailable ||
+				!previousNextRetryAfter.Equal(auth.NextRetryAfter) ||
+				!cooldownQuotaEqual(previousQuota, auth.Quota) ||
+				previousStatus != auth.Status ||
+				previousStatusMessage != auth.StatusMessage ||
+				!cooldownErrorEqual(previousLastError, auth.LastError)
+			if changed || aggregateChanged {
+				auth.UpdatedAt = now
+				if errPersist := m.persist(ctx, auth); errPersist != nil {
+					logEntryWithRequestID(ctx).WithField("auth_id", auth.ID).Warnf("failed to persist auth changes during model state reconciliation: %v", errPersist)
+				}
+				snapshot = auth.Clone()
 			}
-			auth.UpdatedAt = now
-			if errPersist := m.persist(ctx, auth); errPersist != nil {
-				logEntryWithRequestID(ctx).WithField("auth_id", auth.ID).Warnf("failed to persist auth changes during model state reconciliation: %v", errPersist)
-			}
-			snapshot = auth.Clone()
 		}
+	}
+	if m.scheduler != nil && snapshot != nil {
+		m.scheduler.upsertAuth(snapshot)
 	}
 	m.mu.Unlock()
 
-	if m.scheduler != nil && snapshot != nil {
-		m.scheduler.upsertAuth(snapshot)
+	for _, cooldown := range cooldowns {
+		m.restoreRegistryCooldown(authID, cooldown)
+	}
+}
+
+// restoreRegistryCooldown revalidates a reconciliation candidate before
+// changing the registry. Holding m.mu for the registry writes orders them with
+// concurrent MarkResult, ResetQuota, and Remove state changes so a stale
+// snapshot cannot re-suspend a model that has already recovered.
+func (m *Manager) restoreRegistryCooldown(authID string, cooldown registryCooldownCandidate) {
+	if m == nil || authID == "" || cooldown.stateKey == "" || cooldown.model == "" {
+		return
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	auth := m.auths[authID]
+	if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+		return
+	}
+	state := auth.ModelStates[cooldown.stateKey]
+	if state == nil || !state.Unavailable || !state.NextRetryAfter.After(time.Now()) {
+		return
+	}
+	reason, quota, suspend := registrySuspensionForModelState(state)
+	if !suspend {
+		return
+	}
+
+	reg := registry.GetGlobalRegistry()
+	if quota {
+		reg.SetModelQuotaExceeded(authID, cooldown.model)
+	}
+	reg.SuspendClientModel(authID, cooldown.model, reason)
+}
+
+func updateAggregatedModelError(auth *Auth, now time.Time) {
+	if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+		return
+	}
+	var latest *ModelState
+	for _, state := range auth.ModelStates {
+		if state == nil {
+			continue
+		}
+		activeError := state.LastError != nil
+		if !activeError && state.Status == StatusError {
+			activeError = state.Unavailable && state.NextRetryAfter.After(now)
+		}
+		if !activeError {
+			continue
+		}
+		if latest == nil || state.UpdatedAt.After(latest.UpdatedAt) {
+			latest = state
+		}
+	}
+	if latest == nil {
+		auth.LastError = nil
+		auth.StatusMessage = ""
+		auth.Status = StatusActive
+		return
+	}
+	auth.LastError = cloneError(latest.LastError)
+	auth.StatusMessage = latest.StatusMessage
+	if auth.StatusMessage == "" && auth.LastError != nil {
+		auth.StatusMessage = auth.LastError.Message
+	}
+	auth.Status = StatusError
+}
+
+func registrySuspensionForModelState(state *ModelState) (reason string, quota, suspend bool) {
+	if state == nil {
+		return "", false, false
+	}
+	if state.Quota.Exceeded && strings.EqualFold(strings.TrimSpace(state.Quota.Reason), "quota") {
+		return "quota", true, true
+	}
+	if isModelSupportResultError(state.LastError) {
+		return "model_not_supported", false, true
+	}
+	if isInvalidGrantResultError(state.LastError) {
+		return "invalid_grant", false, true
+	}
+	if isCloudflareChallengeResultError(state.LastError) {
+		return "", false, false
+	}
+	switch statusCodeFromResult(state.LastError) {
+	case http.StatusUnauthorized:
+		return "unauthorized", false, true
+	case http.StatusPaymentRequired, http.StatusForbidden:
+		return "payment_required", false, true
+	case http.StatusNotFound:
+		return "not_found", false, true
+	default:
+		return "", false, false
 	}
 }
 


### PR DESCRIPTION
## Summary

Preserve active per-model cooldowns when an auth's models are re-registered and `ReconcileRegistryModelStates` runs.

## Problem

Auth file updates trigger plugin runtime synchronization, which re-registers models for all auths. Model registration replaces the registry-side suspension and quota snapshot, and `ReconcileRegistryModelStates` then unconditionally resets every non-clean `ModelState` for supported models.

As a result, active 401 and 429 cooldowns can be cleared by an unrelated auth file update. The affected credential becomes eligible again before `NextRetryAfter` and may be repeatedly selected.

This behavior was observed with the following sequence:

1. An auth receives a 401 or 429 and records a future `NextRetryAfter`.
2. Another auth file is updated.
3. Plugin synchronization re-registers the full auth model set.
4. Reconciliation resets the first auth's active cooldown.

## Fix

- Preserve supported model states while `Unavailable` is true and `NextRetryAfter` is still in the future.
- Continue pruning states for models that are no longer registered.
- Continue clearing expired or non-cooling stale states.
- Rebuild top-level auth availability and error fields when preserved model cooldowns came from a reloaded auth file.
- Restore registry suspension and quota markers only when the full stored model-state key matches a registered model ID. A suffix-only state such as `gpt-5(high)` remains manager-scoped and does not hide the registered `gpt-5` base model.
- Preserve the existing transient handling for Cloudflare challenge cooldowns instead of converting their 403 status into a registry suspension.
- Revalidate cooldown candidates under the manager lock immediately before registry writes so concurrent success, quota reset, or auth removal cannot apply a stale suspension.
- Ignore registry cooldown writes for clients that were already unregistered or never supported the target model.

## Tests

Added regression coverage for:

- A 401 unauthorized cooldown surviving model re-registration and reconciliation.
- A 429 quota cooldown surviving model re-registration and reconciliation.
- Registry suspension/quota state being restored after `RegisterClient` replaces it.
- Cloudflare challenge cooldowns remaining transient and registry-visible.
- Stale reconciliation candidates being ignored after a successful result.
- A suffixed cooldown continuing to block the suffixed request without blocking or hiding the unsuffixed base model.
- Registry cooldown writes being ignored after client unregistration.

Commands run:

```text
go test ./sdk/cliproxy/auth ./internal/registry -count=1
go build -buildvcs=false -o /tmp/cli-proxy-api-pr-check ./cmd/server
git diff --check
```

All pass on the current `dev` base.

## Related

- #2121 introduced model-state reconciliation after re-registration.
- #3809 addresses capacity metadata changes, but does not change the unconditional reset in `ReconcileRegistryModelStates`.
