### PR TITLE
fix(auth): refresh xai token on bad-credentials instead of cooldown

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3744,6 +3744,18 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							suspendReason = "invalid_grant"
 							shouldSuspendModel = true
 						}
+					} else if isXaiBadCredentialsResultError(auth.Provider, result.Error) {
+						if state.LastError != nil {
+							state.LastError.Code = "unauthorized"
+						}
+						if disableCooling {
+							state.NextRetryAfter = time.Time{}
+						} else {
+							next := now.Add(30 * time.Minute)
+							state.NextRetryAfter = next
+							suspendReason = "unauthorized"
+							shouldSuspendModel = true
+						}
 					} else {
 						switch statusCode {
 						case 401:
@@ -4162,6 +4174,31 @@ func isInvalidGrantResultError(err *Error) bool {
 	return isInvalidGrantErrorMessage(err.Code) || isInvalidGrantErrorMessage(err.Message)
 }
 
+func isXaiBadCredentialsMessage(message string) bool {
+	lower := strings.ToLower(message)
+	return strings.Contains(lower, "bad-credentials") || strings.Contains(lower, "could not be validated")
+}
+
+func isXaiBadCredentialsError(provider string, err error) bool {
+	if err == nil || !strings.EqualFold(strings.TrimSpace(provider), "xai") {
+		return false
+	}
+	if statusCodeFromError(err) != http.StatusForbidden {
+		return false
+	}
+	return isXaiBadCredentialsMessage(err.Error())
+}
+
+func isXaiBadCredentialsResultError(provider string, err *Error) bool {
+	if err == nil || !strings.EqualFold(strings.TrimSpace(provider), "xai") {
+		return false
+	}
+	if statusCodeFromResult(err) != http.StatusForbidden {
+		return false
+	}
+	return isXaiBadCredentialsMessage(err.Code) || isXaiBadCredentialsMessage(err.Message)
+}
+
 func isModelSupportResultError(err *Error) bool {
 	if err == nil {
 		return false
@@ -4296,6 +4333,18 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	}
 	if isInvalidGrantResultError(resultErr) {
 		auth.StatusMessage = "invalid_grant"
+		if disableCooling {
+			auth.NextRetryAfter = time.Time{}
+		} else {
+			auth.NextRetryAfter = now.Add(30 * time.Minute)
+		}
+		return
+	}
+	if isXaiBadCredentialsResultError(auth.Provider, resultErr) {
+		auth.StatusMessage = "unauthorized"
+		if auth.LastError != nil {
+			auth.LastError.Code = "unauthorized"
+		}
 		if disableCooling {
 			auth.NextRetryAfter = time.Time{}
 		} else {
@@ -5795,13 +5844,14 @@ func clearUnauthorizedModelStates(auth *Auth, now time.Time) []string {
 	return resumed
 }
 
-// tryRefreshAfterUnauthorized refreshes OAuth credentials once after a 401 so the
-// current auth can be retried before fallback/suspend.
+// tryRefreshAfterUnauthorized refreshes OAuth credentials once after a 401, or an
+// xAI 403 bad-credentials response, so the current auth can be retried before
+// fallback/suspend.
 func (m *Manager) tryRefreshAfterUnauthorized(ctx context.Context, auth *Auth, execErr error, alreadyTried bool) (*Auth, bool) {
 	if m == nil || auth == nil || alreadyTried || execErr == nil {
 		return auth, false
 	}
-	if !isUnauthorizedError(execErr) || !authHasRefreshCredential(auth) {
+	if !(isUnauthorizedError(execErr) || isXaiBadCredentialsError(auth.Provider, execErr)) || !authHasRefreshCredential(auth) {
 		return auth, false
 	}
 	log.Debugf("unauthorized response for %s (%s), refreshing credentials before fallback", auth.Provider, auth.ID)

--- a/sdk/cliproxy/auth/xai_bad_credentials_refresh_test.go
+++ b/sdk/cliproxy/auth/xai_bad_credentials_refresh_test.go
@@ -1,0 +1,272 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// xaiBadCredentialsRefreshExecutor mirrors unauthorizedRefreshExecutor but returns
+// an xAI 403 bad-credentials response (instead of a 401) for an invalid token.
+type xaiBadCredentialsRefreshExecutor struct {
+	id string
+
+	mu            sync.Mutex
+	executeCalls  []string
+	streamCalls   []string
+	refreshCalls  int
+	tokenInvalid  map[string]struct{}
+	refreshFail   bool
+	refreshTokens map[string]string
+}
+
+func (e *xaiBadCredentialsRefreshExecutor) Identifier() string { return e.id }
+
+func (e *xaiBadCredentialsRefreshExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.executeCalls = append(e.executeCalls, auth.ID)
+	token := authAccessToken(auth)
+	_, invalid := e.tokenInvalid[token]
+	e.mu.Unlock()
+	if invalid {
+		return cliproxyexecutor.Response{}, &Error{
+			HTTPStatus: http.StatusForbidden,
+			Message:    "unauthenticated:bad-credentials",
+		}
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID + ":" + token)}, nil
+}
+
+func (e *xaiBadCredentialsRefreshExecutor) ExecuteStream(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.streamCalls = append(e.streamCalls, auth.ID)
+	token := authAccessToken(auth)
+	_, invalid := e.tokenInvalid[token]
+	e.mu.Unlock()
+	if invalid {
+		return nil, &Error{
+			HTTPStatus: http.StatusForbidden,
+			Message:    "unauthenticated:bad-credentials",
+		}
+	}
+	ch := make(chan cliproxyexecutor.StreamChunk, 1)
+	ch <- cliproxyexecutor.StreamChunk{Payload: []byte(auth.ID + ":" + token)}
+	close(ch)
+	return &cliproxyexecutor.StreamResult{Headers: http.Header{"X-Auth": {auth.ID}}, Chunks: ch}, nil
+}
+
+func (e *xaiBadCredentialsRefreshExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.refreshCalls++
+	if e.refreshFail {
+		return nil, &Error{HTTPStatus: http.StatusUnauthorized, Message: "refresh token invalid"}
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	next := e.refreshTokens[auth.ID]
+	if next == "" {
+		next = "refreshed-access-token"
+	}
+	auth.Metadata["access_token"] = next
+	return auth, nil
+}
+
+func (e *xaiBadCredentialsRefreshExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (e *xaiBadCredentialsRefreshExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (e *xaiBadCredentialsRefreshExecutor) ExecuteCalls() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]string, len(e.executeCalls))
+	copy(out, e.executeCalls)
+	return out
+}
+
+func (e *xaiBadCredentialsRefreshExecutor) RefreshCalls() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.refreshCalls
+}
+
+func newXaiBadCredentialsRefreshFixture(t *testing.T, refreshFail bool) (*Manager, *xaiBadCredentialsRefreshExecutor, *Auth, *Auth, string) {
+	t.Helper()
+
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	model := "grok-4"
+	primary := &Auth{
+		ID:       "aa-primary-xai",
+		Provider: "xai",
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "primary-refresh-token",
+		},
+	}
+	backup := &Auth{
+		ID:       "bb-backup-xai",
+		Provider: "xai",
+		Metadata: map[string]any{
+			"access_token":  "backup-access-token",
+			"refresh_token": "backup-refresh-token",
+		},
+	}
+
+	executor := &xaiBadCredentialsRefreshExecutor{
+		id: "xai",
+		tokenInvalid: map[string]struct{}{
+			"stale-access-token": {},
+		},
+		refreshFail: refreshFail,
+		refreshTokens: map[string]string{
+			primary.ID: "fresh-access-token",
+		},
+	}
+
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(primary.ID, "xai", []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient(backup.ID, "xai", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(primary.ID)
+		reg.UnregisterClient(backup.ID)
+	})
+
+	if _, errRegister := m.Register(context.Background(), primary); errRegister != nil {
+		t.Fatalf("register primary: %v", errRegister)
+	}
+	if _, errRegister := m.Register(context.Background(), backup); errRegister != nil {
+		t.Fatalf("register backup: %v", errRegister)
+	}
+
+	return m, executor, primary, backup, model
+}
+
+func TestManager_Execute_XaiBadCredentialsRefreshesCurrentAuthBeforeFallback(t *testing.T) {
+	m, executor, primary, backup, model := newXaiBadCredentialsRefreshFixture(t, false)
+
+	resp, errExecute := m.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("Execute error = %v, want success on refreshed primary", errExecute)
+	}
+	if got := string(resp.Payload); got != primary.ID+":fresh-access-token" {
+		t.Fatalf("payload = %q, want refreshed primary response", got)
+	}
+
+	if got := executor.RefreshCalls(); got != 1 {
+		t.Fatalf("Refresh calls = %d, want 1", got)
+	}
+	if got := executor.ExecuteCalls(); len(got) != 2 || got[0] != primary.ID || got[1] != primary.ID {
+		t.Fatalf("Execute calls = %v, want [primary, primary]", got)
+	}
+	for _, id := range executor.ExecuteCalls() {
+		if id == backup.ID {
+			t.Fatalf("backup auth should not be used when refresh recovers primary")
+		}
+	}
+
+	updated, ok := m.GetByID(primary.ID)
+	if !ok || updated == nil {
+		t.Fatalf("primary auth missing after refresh")
+	}
+	if got := authAccessToken(updated); got != "fresh-access-token" {
+		t.Fatalf("primary access_token = %q, want fresh-access-token", got)
+	}
+	if state := updated.ModelStates[model]; state != nil && state.Unavailable {
+		t.Fatalf("primary model should not remain suspended after successful refresh retry")
+	}
+}
+
+func TestManager_Execute_XaiBadCredentialsRefreshFailureFallsBackToNextAuth(t *testing.T) {
+	m, executor, primary, backup, model := newXaiBadCredentialsRefreshFixture(t, true)
+
+	resp, errExecute := m.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("Execute error = %v, want success via backup", errExecute)
+	}
+	if got := string(resp.Payload); got != backup.ID+":backup-access-token" {
+		t.Fatalf("payload = %q, want backup response", got)
+	}
+
+	if got := executor.RefreshCalls(); got != 1 {
+		t.Fatalf("Refresh calls = %d, want 1", got)
+	}
+	if got := executor.ExecuteCalls(); len(got) != 2 || got[0] != primary.ID || got[1] != backup.ID {
+		t.Fatalf("Execute calls = %v, want [primary, backup]", got)
+	}
+
+	updated, ok := m.GetByID(primary.ID)
+	if !ok || updated == nil {
+		t.Fatalf("primary auth missing after failed refresh")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || !state.Unavailable {
+		t.Fatalf("expected primary model to be suspended after refresh failure")
+	}
+	// Key assertion: the xAI bad-credentials branch must tag the model LastError as
+	// "unauthorized" even though the underlying status is a 403. This is what lets a
+	// later successful refresh resume the model early (see the resume test below).
+	if state.LastError == nil || state.LastError.Code != "unauthorized" {
+		t.Fatalf("expected suspended model LastError.Code = unauthorized, got %+v", state.LastError)
+	}
+}
+
+func TestManager_Execute_XaiBadCredentialsResumesAfterLaterRefreshSucceeds(t *testing.T) {
+	m, executor, primary, _, model := newXaiBadCredentialsRefreshFixture(t, true)
+
+	// First request: refresh fails, primary gets suspended, request falls back to backup.
+	if _, errExecute := m.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{}); errExecute != nil {
+		t.Fatalf("Execute error = %v, want success via backup", errExecute)
+	}
+
+	reg := registry.GetGlobalRegistry()
+	suspendedCount := reg.GetModelCount(model)
+	if suspended, ok := m.GetByID(primary.ID); !ok || suspended == nil {
+		t.Fatalf("primary auth missing after failed refresh")
+	} else if state := suspended.ModelStates[model]; state == nil || !state.Unavailable {
+		t.Fatalf("expected primary model to be suspended before resume, got %+v", state)
+	}
+
+	// Second refresh succeeds (valid token, refresh no longer failing). The
+	// bad-credentials LastError.Code = "unauthorized" tag is what makes
+	// clearUnauthorizedModelStates recognize and resume the suspended model.
+	executor.mu.Lock()
+	executor.refreshFail = false
+	executor.refreshTokens[primary.ID] = "fresh-access-token"
+	executor.mu.Unlock()
+
+	if _, errRefresh := m.refreshAuthForRequest(context.Background(), primary.ID, ""); errRefresh != nil {
+		t.Fatalf("refreshAuthForRequest error = %v, want success", errRefresh)
+	}
+
+	// (a) registry count restored: the suspended primary client is back in rotation.
+	if got := reg.GetModelCount(model); got <= suspendedCount {
+		t.Fatalf("expected model count to increase after resume (was %d), got %d", suspendedCount, got)
+	}
+	if got := reg.GetModelCount(model); got == 0 {
+		t.Fatalf("expected non-zero model count after resume")
+	}
+
+	// (b) primary's model state no longer marked unavailable.
+	updated, ok := m.GetByID(primary.ID)
+	if !ok || updated == nil {
+		t.Fatalf("primary auth missing after resume refresh")
+	}
+	if state := updated.ModelStates[model]; state != nil && state.Unavailable {
+		t.Fatalf("expected primary model to be resumed (not unavailable) after successful refresh, got %+v", state)
+	}
+}

--- a/sdk/cliproxy/auth/xai_bad_credentials_test.go
+++ b/sdk/cliproxy/auth/xai_bad_credentials_test.go
@@ -1,0 +1,162 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestIsXaiBadCredentialsError(t *testing.T) {
+	badCreds := &Error{HTTPStatus: http.StatusForbidden, Message: "unauthenticated:bad-credentials"}
+	notValidated := &Error{HTTPStatus: http.StatusForbidden, Message: "The OAuth2 access token could not be validated."}
+
+	if !isXaiBadCredentialsError("xai", badCreds) {
+		t.Fatalf("expected true for xai 403 bad-credentials")
+	}
+	if !isXaiBadCredentialsError("XAI", notValidated) {
+		t.Fatalf("expected true for xai 403 could-not-be-validated (case-insensitive provider)")
+	}
+	if !isXaiBadCredentialsError(" xai ", badCreds) {
+		t.Fatalf("expected true for whitespace-padded xai provider")
+	}
+	if isXaiBadCredentialsError("claude", badCreds) {
+		t.Fatalf("expected false for non-xai provider")
+	}
+	if isXaiBadCredentialsError("xai", &Error{HTTPStatus: http.StatusPaymentRequired, Message: "unauthenticated:bad-credentials"}) {
+		t.Fatalf("expected false for xai with non-403 status")
+	}
+	if isXaiBadCredentialsError("xai", &Error{HTTPStatus: http.StatusForbidden, Message: "forbidden"}) {
+		t.Fatalf("expected false for xai 403 with unrelated message")
+	}
+	if isXaiBadCredentialsError("xai", nil) {
+		t.Fatalf("expected false for nil error")
+	}
+}
+
+func TestIsXaiBadCredentialsResultError(t *testing.T) {
+	if !isXaiBadCredentialsResultError("xai", &Error{HTTPStatus: http.StatusForbidden, Message: "unauthenticated:bad-credentials"}) {
+		t.Fatalf("expected true for xai 403 bad-credentials")
+	}
+	if !isXaiBadCredentialsResultError("xai", &Error{HTTPStatus: http.StatusForbidden, Code: "unauthenticated:bad-credentials"}) {
+		t.Fatalf("expected true when the code carries the marker")
+	}
+	if !isXaiBadCredentialsResultError(" xai ", &Error{HTTPStatus: http.StatusForbidden, Message: "unauthenticated:bad-credentials"}) {
+		t.Fatalf("expected true for whitespace-padded xai provider")
+	}
+	if !isXaiBadCredentialsResultError("xai", &Error{HTTPStatus: http.StatusForbidden, Message: "The OAuth2 access token could not be validated."}) {
+		t.Fatalf("expected true for xai 403 could-not-be-validated")
+	}
+	if isXaiBadCredentialsResultError("claude", &Error{HTTPStatus: http.StatusForbidden, Message: "unauthenticated:bad-credentials"}) {
+		t.Fatalf("expected false for non-xai provider")
+	}
+	if isXaiBadCredentialsResultError("xai", &Error{HTTPStatus: http.StatusPaymentRequired, Message: "unauthenticated:bad-credentials"}) {
+		t.Fatalf("expected false for xai with non-403 status")
+	}
+	if isXaiBadCredentialsResultError("xai", &Error{HTTPStatus: http.StatusForbidden, Message: "forbidden"}) {
+		t.Fatalf("expected false for xai 403 with unrelated message")
+	}
+	if isXaiBadCredentialsResultError("xai", nil) {
+		t.Fatalf("expected false for nil error")
+	}
+}
+
+func TestManager_MarkResult_XaiBadCredentials_On403(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:       "auth-xai-403",
+		Provider: "xai",
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "test-model-xai-403"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "xai", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "xai",
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusForbidden, Message: "unauthenticated:bad-credentials"},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected model state to be present")
+	}
+	if !state.Unavailable {
+		t.Fatalf("expected model state to be unavailable")
+	}
+	if state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected NextRetryAfter to be set for xai bad-credentials")
+	}
+	diff := time.Until(state.NextRetryAfter)
+	if diff < 29*time.Minute || diff > 31*time.Minute {
+		t.Fatalf("expected ~30 minute cooldown for xai bad-credentials, got %v", diff)
+	}
+
+	// The unauthorized classification suspends the model in the registry, so no
+	// clients remain available for it (unlike a transient cooldown).
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("expected model to be suspended (count 0), got %d", count)
+	}
+	if state.LastError == nil || state.LastError.Code != "unauthorized" {
+		t.Fatalf("expected model LastError.Code = unauthorized, got %+v", state.LastError)
+	}
+}
+
+func TestManager_MarkResult_XaiBadCredentials_AuthLevelStatusUnauthorized(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:       "auth-xai-403-authlevel",
+		Provider: "xai",
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "xai",
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusForbidden, Message: "The OAuth2 access token could not be validated."},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if updated.StatusMessage != "unauthorized" {
+		t.Fatalf("expected StatusMessage 'unauthorized' (not payment_required), got %q", updated.StatusMessage)
+	}
+	if updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected NextRetryAfter to be set for xai bad-credentials")
+	}
+	diff := time.Until(updated.NextRetryAfter)
+	if diff < 29*time.Minute || diff > 31*time.Minute {
+		t.Fatalf("expected ~30 minute cooldown for xai bad-credentials, got %v", diff)
+	}
+	if updated.LastError == nil || updated.LastError.Code != "unauthorized" {
+		t.Fatalf("expected auth LastError.Code = unauthorized, got %+v", updated.LastError)
+	}
+}


### PR DESCRIPTION
Fixes #4046.

When xAI rejects the access token with a 403 `unauthenticated:bad-credentials`, the conductor was treating it the same as a generic 402/403 and cooling the auth down for 30 minutes without ever trying to refresh. If you only have one xAI credential, that's a full outage until you manually re-login, even though the refresh token is usually still good.

This makes the bad-credentials case go through the same refresh-then-retry-once path that already exists for 401s, and only marks the auth unauthorized (instead of payment_required) if that refresh actually fails.

Added tests in `sdk/cliproxy/auth/xai_bad_credentials_test.go` covering the new detection helpers and both the model-level and auth-level cooldown paths.