### PR TITLE
fix(usage): expose cache write accounting semantics

### DIFF
--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -68,6 +68,7 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		CachedTokens:        record.Detail.CachedTokens,
 		CacheReadTokens:     record.Detail.CacheReadTokens,
 		CacheCreationTokens: record.Detail.CacheCreationTokens,
+		CacheInputMode:      string(record.Detail.CacheInputMode),
 		TotalTokens:         record.Detail.TotalTokens,
 	}
 	if tokens.TotalTokens == 0 {
@@ -141,13 +142,14 @@ type requestDetail struct {
 }
 
 type tokenStats struct {
-	InputTokens         int64 `json:"input_tokens"`
-	OutputTokens        int64 `json:"output_tokens"`
-	ReasoningTokens     int64 `json:"reasoning_tokens"`
-	CachedTokens        int64 `json:"cached_tokens"`
-	CacheReadTokens     int64 `json:"cache_read_tokens"`
-	CacheCreationTokens int64 `json:"cache_creation_tokens"`
-	TotalTokens         int64 `json:"total_tokens"`
+	InputTokens         int64  `json:"input_tokens"`
+	OutputTokens        int64  `json:"output_tokens"`
+	ReasoningTokens     int64  `json:"reasoning_tokens"`
+	CachedTokens        int64  `json:"cached_tokens"`
+	CacheReadTokens     int64  `json:"cache_read_tokens"`
+	CacheCreationTokens int64  `json:"cache_creation_tokens"`
+	CacheInputMode      string `json:"cache_input_mode,omitempty"`
+	TotalTokens         int64  `json:"total_tokens"`
 }
 
 type failDetail struct {

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -38,9 +38,10 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 			RequestedAt:     time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC),
 			Latency:         1500 * time.Millisecond,
 			Detail: coreusage.Detail{
-				InputTokens:  10,
-				OutputTokens: 20,
-				TotalTokens:  30,
+				InputTokens:    10,
+				OutputTokens:   20,
+				CacheInputMode: coreusage.CacheInputModeIncluded,
+				TotalTokens:    30,
 			},
 			ResponseHeaders: responseHeaders.Clone(),
 		})
@@ -57,6 +58,7 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 		requireStringField(t, payload, "request_id", "ctx-request-id")
 		requireStringField(t, payload, "reasoning_effort", "medium")
 		requireStringField(t, payload, "service_tier", "priority")
+		requireNestedStringField(t, payload, "tokens", "cache_input_mode", string(coreusage.CacheInputModeIncluded))
 		requireHeaderField(t, payload, "response_headers", "X-Upstream-Request-Id", []string{"upstream-req-1"})
 		requireHeaderField(t, payload, "response_headers", "Retry-After", []string{"30"})
 		requireBoolField(t, payload, "failed", false)
@@ -283,6 +285,20 @@ func requireStringField(t *testing.T, payload map[string]json.RawMessage, key, w
 	if got != want {
 		t.Fatalf("%s = %q, want %q", key, got, want)
 	}
+}
+
+func requireNestedStringField(t *testing.T, payload map[string]json.RawMessage, parent, key, want string) {
+	t.Helper()
+
+	raw, ok := payload[parent]
+	if !ok {
+		t.Fatalf("payload missing %q", parent)
+	}
+	var nested map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &nested); err != nil {
+		t.Fatalf("unmarshal %q: %v", parent, err)
+	}
+	requireStringField(t, nested, key, want)
 }
 
 func requireMissingField(t *testing.T, payload map[string]json.RawMessage, key string) {

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -514,6 +514,7 @@ func hasOpenAIStyleUsageTokenFields(usageNode gjson.Result) bool {
 		usageNode.Get("total_tokens").Exists() ||
 		usageNode.Get("prompt_tokens_details.cached_tokens").Exists() ||
 		usageNode.Get("input_tokens_details.cached_tokens").Exists() ||
+		usageNode.Get("prompt_tokens_details.cache_write_tokens").Exists() ||
 		usageNode.Get("input_tokens_details.cache_write_tokens").Exists() ||
 		usageNode.Get("completion_tokens_details.reasoning_tokens").Exists() ||
 		usageNode.Get("output_tokens_details.reasoning_tokens").Exists()
@@ -540,7 +541,11 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	if cached.Exists() {
 		detail.CachedTokens = cached.Int()
 	}
-	if cacheWrite := usageNode.Get("input_tokens_details.cache_write_tokens"); cacheWrite.Exists() {
+	cacheWrite := usageNode.Get("prompt_tokens_details.cache_write_tokens")
+	if !cacheWrite.Exists() {
+		cacheWrite = usageNode.Get("input_tokens_details.cache_write_tokens")
+	}
+	if cacheWrite.Exists() {
 		detail.CacheCreationTokens = cacheWrite.Int()
 	}
 	reasoning := usageNode.Get("completion_tokens_details.reasoning_tokens")

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -530,9 +530,10 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 		outputNode = usageNode.Get("output_tokens")
 	}
 	detail := usage.Detail{
-		InputTokens:  inputNode.Int(),
-		OutputTokens: outputNode.Int(),
-		TotalTokens:  usageNode.Get("total_tokens").Int(),
+		InputTokens:    inputNode.Int(),
+		OutputTokens:   outputNode.Int(),
+		CacheInputMode: usage.CacheInputModeIncluded,
+		TotalTokens:    usageNode.Get("total_tokens").Int(),
 	}
 	cached := usageNode.Get("prompt_tokens_details.cached_tokens")
 	if !cached.Exists() {
@@ -599,6 +600,7 @@ func parseClaudeUsageNode(usageNode gjson.Result) usage.Detail {
 		CachedTokens:        cacheReadTokens,
 		CacheReadTokens:     cacheReadTokens,
 		CacheCreationTokens: cacheCreationTokens,
+		CacheInputMode:      usage.CacheInputModeSeparate,
 	}
 	if detail.CachedTokens == 0 {
 		detail.CachedTokens = detail.CacheCreationTokens
@@ -608,12 +610,15 @@ func parseClaudeUsageNode(usageNode gjson.Result) usage.Detail {
 }
 
 func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {
+	cachedTokens := node.Get("cachedContentTokenCount").Int()
 	detail := usage.Detail{
 		InputTokens:     node.Get("promptTokenCount").Int(),
 		OutputTokens:    node.Get("candidatesTokenCount").Int(),
 		ReasoningTokens: node.Get("thoughtsTokenCount").Int(),
 		TotalTokens:     node.Get("totalTokenCount").Int(),
-		CachedTokens:    node.Get("cachedContentTokenCount").Int(),
+		CachedTokens:    cachedTokens,
+		CacheReadTokens: cachedTokens,
+		CacheInputMode:  usage.CacheInputModeIncluded,
 	}
 	if detail.TotalTokens == 0 {
 		detail.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
@@ -622,14 +627,19 @@ func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {
 }
 
 func parseInteractionsUsageDetail(node gjson.Result) usage.Detail {
+	cacheRead := firstExistingUsageNode(node, "cache_read_tokens", "cacheReadTokens")
 	detail := usage.Detail{
 		InputTokens:         firstExistingUsageNode(node, "input_tokens", "prompt_tokens", "total_input_tokens").Int(),
 		OutputTokens:        firstExistingUsageNode(node, "output_tokens", "completion_tokens", "total_output_tokens").Int(),
 		ReasoningTokens:     firstExistingUsageNode(node, "reasoning_tokens", "thoughtsTokenCount", "total_thought_tokens").Int(),
 		TotalTokens:         firstExistingUsageNode(node, "total_tokens", "totalTokenCount").Int(),
 		CachedTokens:        firstExistingUsageNode(node, "cached_tokens", "cachedContentTokenCount", "total_cached_tokens").Int(),
-		CacheReadTokens:     firstExistingUsageNode(node, "cache_read_tokens", "cacheReadTokens").Int(),
-		CacheCreationTokens: firstExistingUsageNode(node, "cache_creation_tokens", "cacheCreationTokens").Int(),
+		CacheReadTokens:     cacheRead.Int(),
+		CacheCreationTokens: firstExistingUsageNode(node, "cache_creation_tokens", "cacheCreationTokens", "cache_write_tokens", "cacheWriteTokens").Int(),
+		CacheInputMode:      usage.CacheInputModeIncluded,
+	}
+	if !cacheRead.Exists() && detail.CachedTokens > 0 {
+		detail.CacheReadTokens = detail.CachedTokens
 	}
 	if detail.TotalTokens == 0 {
 		detail.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens + detail.CacheReadTokens + detail.CacheCreationTokens

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -29,6 +29,9 @@ func TestParseOpenAIUsageChatCompletions(t *testing.T) {
 	if detail.CacheCreationTokens != 6 {
 		t.Fatalf("cache creation tokens = %d, want %d", detail.CacheCreationTokens, 6)
 	}
+	if detail.CacheInputMode != usage.CacheInputModeIncluded {
+		t.Fatalf("cache input mode = %q, want %q", detail.CacheInputMode, usage.CacheInputModeIncluded)
+	}
 	if detail.ReasoningTokens != 5 {
 		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 5)
 	}
@@ -200,6 +203,9 @@ func TestParseClaudeUsageIncludesCacheTokensInTotal(t *testing.T) {
 	if detail.CacheCreationTokens != 19514 {
 		t.Fatalf("cache creation tokens = %d, want %d", detail.CacheCreationTokens, 19514)
 	}
+	if detail.CacheInputMode != usage.CacheInputModeSeparate {
+		t.Fatalf("cache input mode = %q, want %q", detail.CacheInputMode, usage.CacheInputModeSeparate)
+	}
 	if detail.CachedTokens != 7 {
 		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 7)
 	}
@@ -216,6 +222,19 @@ func TestParseClaudeUsageFallsBackCachedTokensToCacheCreation(t *testing.T) {
 	}
 	if detail.TotalTokens != 22852 {
 		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 22852)
+	}
+}
+
+func TestParseGeminiUsageNormalizesCachedContent(t *testing.T) {
+	detail := ParseGeminiUsage([]byte(`{"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":2,"cachedContentTokenCount":4,"totalTokenCount":12}}`))
+	if detail.CachedTokens != 4 {
+		t.Fatalf("cached tokens = %d, want 4", detail.CachedTokens)
+	}
+	if detail.CacheReadTokens != 4 {
+		t.Fatalf("cache read tokens = %d, want 4", detail.CacheReadTokens)
+	}
+	if detail.CacheInputMode != usage.CacheInputModeIncluded {
+		t.Fatalf("cache input mode = %q, want %q", detail.CacheInputMode, usage.CacheInputModeIncluded)
 	}
 }
 

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestParseOpenAIUsageChatCompletions(t *testing.T) {
-	data := []byte(`{"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3,"prompt_tokens_details":{"cached_tokens":4},"completion_tokens_details":{"reasoning_tokens":5}}}`)
+	data := []byte(`{"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3,"prompt_tokens_details":{"cached_tokens":4,"cache_write_tokens":6},"completion_tokens_details":{"reasoning_tokens":5}}}`)
 	detail := ParseOpenAIUsage(data)
 	if detail.InputTokens != 1 {
 		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 1)
@@ -26,8 +26,18 @@ func TestParseOpenAIUsageChatCompletions(t *testing.T) {
 	if detail.CachedTokens != 4 {
 		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 4)
 	}
+	if detail.CacheCreationTokens != 6 {
+		t.Fatalf("cache creation tokens = %d, want %d", detail.CacheCreationTokens, 6)
+	}
 	if detail.ReasoningTokens != 5 {
 		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 5)
+	}
+}
+
+func TestParseOpenAIUsageDetectsPromptCacheWriteOnly(t *testing.T) {
+	detail := ParseOpenAIUsage([]byte(`{"usage":{"prompt_tokens_details":{"cache_write_tokens":6}}}`))
+	if detail.CacheCreationTokens != 6 {
+		t.Fatalf("cache creation tokens = %d, want %d", detail.CacheCreationTokens, 6)
 	}
 }
 
@@ -89,8 +99,8 @@ func TestParseOpenAIStreamUsageIgnoresNullUsage(t *testing.T) {
 	}
 }
 
-func TestParseOpenAIStreamUsageResponsesFields(t *testing.T) {
-	line := []byte(`data: {"id":"chunk_1","object":"chat.completion.chunk","choices":[],"usage":{"input_tokens":8,"output_tokens":5,"total_tokens":13,"input_tokens_details":{"cached_tokens":3},"output_tokens_details":{"reasoning_tokens":2}}}`)
+func TestParseOpenAIStreamUsageChatCompletionsFields(t *testing.T) {
+	line := []byte(`data: {"id":"chunk_1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":8,"completion_tokens":5,"total_tokens":13,"prompt_tokens_details":{"cached_tokens":3,"cache_write_tokens":4},"completion_tokens_details":{"reasoning_tokens":2}}}`)
 	detail, ok := ParseOpenAIStreamUsage(line)
 	if !ok {
 		t.Fatal("ParseOpenAIStreamUsage() ok = false, want true")
@@ -106,6 +116,9 @@ func TestParseOpenAIStreamUsageResponsesFields(t *testing.T) {
 	}
 	if detail.CachedTokens != 3 {
 		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 3)
+	}
+	if detail.CacheCreationTokens != 4 {
+		t.Fatalf("cache creation tokens = %d, want %d", detail.CacheCreationTokens, 4)
 	}
 	if detail.ReasoningTokens != 2 {
 		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 2)

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -99,6 +99,29 @@ func TestParseOpenAIStreamUsageIgnoresNullUsage(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIStreamUsageResponsesFields(t *testing.T) {
+	line := []byte(`data: {"id":"chunk_1","object":"chat.completion.chunk","choices":[],"usage":{"input_tokens":8,"output_tokens":5,"total_tokens":13,"input_tokens_details":{"cached_tokens":3},"output_tokens_details":{"reasoning_tokens":2}}}`)
+	detail, ok := ParseOpenAIStreamUsage(line)
+	if !ok {
+		t.Fatal("ParseOpenAIStreamUsage() ok = false, want true")
+	}
+	if detail.InputTokens != 8 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 8)
+	}
+	if detail.OutputTokens != 5 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 5)
+	}
+	if detail.TotalTokens != 13 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 13)
+	}
+	if detail.CachedTokens != 3 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 3)
+	}
+	if detail.ReasoningTokens != 2 {
+		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 2)
+	}
+}
+
 func TestParseOpenAIStreamUsageChatCompletionsFields(t *testing.T) {
 	line := []byte(`data: {"id":"chunk_1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":8,"completion_tokens":5,"total_tokens":13,"prompt_tokens_details":{"cached_tokens":3,"cache_write_tokens":4},"completion_tokens_details":{"reasoning_tokens":2}}}`)
 	detail, ok := ParseOpenAIStreamUsage(line)

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -13,6 +13,16 @@ import (
 // DefaultServiceTier is used when a request does not specify service_tier.
 const DefaultServiceTier = "default"
 
+// CacheInputMode describes whether fine-grained cache tokens are already
+// included in InputTokens. The zero value is intentionally unknown so older
+// plugins and usage consumers remain backward compatible.
+type CacheInputMode string
+
+const (
+	CacheInputModeIncluded CacheInputMode = "included_in_input"
+	CacheInputModeSeparate CacheInputMode = "separate_from_input"
+)
+
 // Record contains the usage statistics captured for a single provider request.
 type Record struct {
 	Provider string
@@ -53,6 +63,7 @@ type Detail struct {
 	CachedTokens        int64
 	CacheReadTokens     int64
 	CacheCreationTokens int64
+	CacheInputMode      CacheInputMode
 	TotalTokens         int64
 }
 


### PR DESCRIPTION
## Summary

Parse OpenAI Chat Completions cache creation tokens and expose optional cache-input accounting semantics to usage consumers.

The accounting metadata is backward compatible: consumers can use `cache_input_mode` when present and continue inferring provider semantics when older queue producers omit it.

## Changes

- Recognize `prompt_tokens_details.cache_write_tokens` and retain the Responses API fallback.
- Mark OpenAI, Gemini, and Interactions cache tokens as included in input tokens.
- Mark Claude cache read and creation tokens as separate from input tokens.
- Publish the optional `tokens.cache_input_mode` field through the Redis usage queue.
- Preserve existing token fields and the zero-value behavior for SDK consumers.

## Testing

- [x] `go test -race ./internal/runtime/executor/helps ./internal/redisqueue ./sdk/cliproxy/usage`
- [x] `go build -o /tmp/cpa-cache-accounting-server ./cmd/server`
- [ ] `go test ./...` — the unchanged catalog test currently fails `TestModelsWithClientVersionReturnsCodexCatalog` with `custom priority = 143, want 129`; the modified packages pass.

## Compatibility

- The new field is optional and omitted when unknown.
- Existing plugins and queue consumers remain compatible.
- CPA Manager Plus does not require this PR; it supports current released CPA payloads and treats this metadata as an accuracy enhancement.

## Related

Refs #4180.
Refs https://github.com/seakee/CPA-Manager-Plus/pull/338.

This PR does not modify `internal/translator/**`; translator propagation remains maintainer-owned.
Refs #4483.
