### PR TITLE
fix(management): sync Codex OAuth tokens

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -2177,8 +2177,14 @@ func (h *Handler) RequestCodexToken(c *gin.Context) {
 			FileName: fileName,
 			Storage:  tokenStorage,
 			Metadata: map[string]any{
-				"email":      tokenStorage.Email,
-				"account_id": tokenStorage.AccountID,
+				"type":          "codex",
+				"id_token":      tokenStorage.IDToken,
+				"access_token":  tokenStorage.AccessToken,
+				"refresh_token": tokenStorage.RefreshToken,
+				"account_id":    tokenStorage.AccountID,
+				"last_refresh":  tokenStorage.LastRefresh,
+				"email":         tokenStorage.Email,
+				"expired":       tokenStorage.Expire,
 			},
 		}
 		savedPath, errSave := h.saveTokenRecord(ctx, record)

--- a/internal/api/handlers/management/oauth_codex_concurrency_test.go
+++ b/internal/api/handlers/management/oauth_codex_concurrency_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 type fakeCodexOAuthService struct{}
@@ -27,6 +28,7 @@ func (f *fakeCodexOAuthService) ExchangeCodeForTokens(ctx context.Context, code 
 			IDToken:      "invalid-test-id-token",
 			AccessToken:  "access-" + code,
 			RefreshToken: "refresh-" + code,
+			AccountID:    "account-" + code,
 			Email:        "codex-" + code + "@example.test",
 			Expire:       now.Add(time.Hour).Format(time.RFC3339),
 		},
@@ -72,6 +74,63 @@ func TestRequestCodexTokenCompletionKeepsConcurrentSessionPending(t *testing.T) 
 	waitForOAuthSessionDone(t, firstState)
 	if !IsOAuthSessionPending(secondState, "codex") {
 		t.Fatalf("expected concurrent codex session %s to remain pending after %s completed", secondState, firstState)
+	}
+}
+
+func TestRequestCodexTokenRuntimeSyncIncludesTokens(t *testing.T) {
+	originalNewCodexOAuthService := newCodexOAuthService
+	newCodexOAuthService = func(cfg *config.Config) codexOAuthService {
+		return &fakeCodexOAuthService{}
+	}
+	defer func() {
+		newCodexOAuthService = originalNewCodexOAuthService
+	}()
+
+	authDir := filepath.Join(t.TempDir(), "auths")
+	handler := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	persisted := make(chan *coreauth.Auth, 1)
+	handler.SetPostAuthPersistHook(func(_ context.Context, auth *coreauth.Auth) error {
+		persisted <- auth
+		return nil
+	})
+	router := gin.New()
+	router.GET("/codex-auth-url", handler.RequestCodexToken)
+
+	state := requestCodexTokenState(t, router)
+	defer CompleteOAuthSession(state)
+	if _, errWrite := WriteOAuthCallbackFileForPendingSession(authDir, "codex", state, "runtime-sync", ""); errWrite != nil {
+		t.Fatalf("write codex callback file: %v", errWrite)
+	}
+
+	waitForOAuthSessionDone(t, state)
+	var synced *coreauth.Auth
+	select {
+	case synced = <-persisted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for persisted auth sync")
+	}
+
+	wantMetadata := map[string]string{
+		"type":          "codex",
+		"id_token":      "invalid-test-id-token",
+		"access_token":  "access-runtime-sync",
+		"refresh_token": "refresh-runtime-sync",
+		"account_id":    "account-runtime-sync",
+		"email":         "codex-runtime-sync@example.test",
+	}
+	for key, want := range wantMetadata {
+		if got, _ := synced.Metadata[key].(string); got != want {
+			t.Fatalf("expected metadata %s %q, got %q", key, want, got)
+		}
+	}
+	if got, _ := synced.Metadata["expired"].(string); got == "" {
+		t.Fatal("expected runtime auth metadata to include expiry")
+	}
+	if got, _ := synced.Metadata["last_refresh"].(string); got == "" {
+		t.Fatal("expected runtime auth metadata to include last refresh time")
+	}
+	if got := tokenValueForAuth(synced); got != "access-runtime-sync" {
+		t.Fatalf("expected API call token %q, got %q", "access-runtime-sync", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- populate newly completed Codex OAuth runtime metadata from `CodexTokenStorage`
- make management API calls and Codex refresh work before any process restart
- cover the post-persist runtime sync and selected access token with a regression test

## Root cause

`RequestCodexToken` persisted full token storage but sent only `email` and `account_id` through `postAuthPersistHook`. The runtime auth manager therefore had no `access_token` or `refresh_token` until a restart reloaded the stored JSON.

## Validation

- `git diff --check`
- regression test added: `TestRequestCodexTokenRuntimeSyncIncludesTokens`
- full compile and targeted test delegated to CI because the operator host intentionally has no Go toolchain