### PR TITLE
feat(openai-compat): Add extra_body config for provider-specific request fields

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -315,6 +315,10 @@ nonstream-keepalive-interval: 0
 #     disable-cooling: false # optional: per-provider override for auth/model cooldown scheduling
 #     headers:
 #       X-Custom-Header: "custom-value"
+#     extra-body: # optional: provider-specific fields merged into the upstream request body after translation
+#       tags: # example: Nous Portal requires a tags array (undocumented)
+#         - "product=hermes-agent"
+#         - "user={{api_key}}" # {{api_key}} is replaced with the resolved API key at runtime
 #     api-key-entries:
 #       - api-key: "sk-or-v1-...b780"
 #         proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -631,6 +631,10 @@ type OpenAICompatibility struct {
 
 	// DisableCooling disables auth/model cooldown scheduling for this provider when true.
 	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
+
+	// ExtraBody is merged into the upstream request body after translation.
+	// Use for provider-specific fields not part of the OpenAI API spec.
+	ExtraBody map[string]any `yaml:"extra-body,omitempty" json:"extra-body,omitempty"`
 }
 
 // OpenAICompatibilityAPIKey represents an API key configuration with optional proxy setting.

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -130,6 +130,8 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	}
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
 
+	translated = e.injectExtraBody(translated, auth)
+
 	url := strings.TrimSuffix(baseURL, "/") + endpoint
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
 	if err != nil {
@@ -328,6 +330,8 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	// are captured even when the upstream is an OpenAI-compatible provider.
 	translated, _ = sjson.SetBytes(translated, "stream_options.include_usage", true)
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
+
+	translated = e.injectExtraBody(translated, auth)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
@@ -741,6 +745,27 @@ func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (base
 		apiKey = strings.TrimSpace(auth.Attributes["api_key"])
 	}
 	return
+}
+
+// injectExtraBody merges provider-specific fields from the extra_body config
+// into the upstream request payload after translation. String values support
+// the {{api_key}} placeholder, replaced with the resolved API key at runtime.
+func (e *OpenAICompatExecutor) injectExtraBody(payload []byte, auth *cliproxyauth.Auth) []byte {
+	if len(payload) == 0 || auth == nil {
+		return payload
+	}
+	compat := e.resolveCompatConfig(auth)
+	if compat == nil || len(compat.ExtraBody) == 0 {
+		return payload
+	}
+	_, apiKey := e.resolveCredentials(auth)
+	for key, value := range compat.ExtraBody {
+		if s, ok := value.(string); ok && strings.Contains(s, "{{api_key}}") {
+			value = strings.ReplaceAll(s, "{{api_key}}", apiKey)
+		}
+		payload, _ = sjson.SetBytes(payload, key, value)
+	}
+	return payload
 }
 
 func (e *OpenAICompatExecutor) resolveCompatConfig(auth *cliproxyauth.Auth) *config.OpenAICompatibility {


### PR DESCRIPTION
Some OpenAI-compatible providers require non-standard fields in the request body that aren't part of the OpenAI API spec. Without a way to inject these from config, such providers need executor code patches.

## What this adds

An `extra_body` map on `openai-compatibility` providers, merged into the translated payload before the upstream request. String values support `{{api_key}}` for dynamic substitution with the resolved API key.

```yaml
openai-compatibility:
  - name: "nous"
    base-url: "https://inference-api.nousresearch.com/v1"
    extra_body:
      tags:
        - "product=hermes-agent"
        - "user={{api_key}}"
    api-key-entries:
      - api-key: "sk-..."
    models:
      - name: "tencent/hy3:free"
        alias: "tencent/hy3:free"
```

## Why

The Nous Portal inference API rejects requests without a `tags` array (HTTP 400, "missing tags"). This requirement is undocumented in their API docs. Other providers may have similar non-standard fields.

Hermes Agent already supports this pattern via `extra_body` on custom providers.

## How it works

- `ExtraBody map[string]any` added to `OpenAICompatibility` config struct
- `injectExtraBody` merges fields into the payload after `TranslateRequest`, before `NewRequestWithContext`
- Called in both `Execute` (non-streaming) and `ExecuteStream` paths
- `{{api_key}}` in string values replaced with the resolved credential at runtime

Closes #4203