### PR TITLE
fix(management): refresh rejected Codex tokens

### DIFF
--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -203,7 +204,10 @@ func (h *Handler) APICall(c *gin.Context) {
 		refreshedToken, errRefresh := h.refreshCodexOAuthAccessToken(c.Request.Context(), auth)
 		if errRefresh != nil {
 			log.WithError(errRefresh).Debug("management APICall Codex token refresh failed")
-			c.JSON(http.StatusBadRequest, gin.H{"error": "auth token refresh failed"})
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":         "auth token refresh failed",
+				"refresh_error": managementCodexRefreshErrorCode(errRefresh),
+			})
 			return
 		}
 		for key, template := range tokenHeaderTemplates {
@@ -255,7 +259,7 @@ func (h *Handler) refreshCodexOAuthAccessToken(ctx context.Context, auth *coreau
 	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
 		return "", fmt.Errorf("codex auth missing")
 	}
-	refreshToken := stringValue(auth.Metadata, "refresh_token")
+	refreshToken := managementCodexRefreshToken(auth)
 	if refreshToken == "" {
 		return "", fmt.Errorf("codex refresh token missing")
 	}
@@ -295,6 +299,54 @@ func (h *Handler) refreshCodexOAuthAccessToken(ctx context.Context, auth *coreau
 		}
 	}
 	return strings.TrimSpace(tokenData.AccessToken), nil
+}
+
+func managementCodexRefreshToken(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if refreshToken := stringValue(auth.Metadata, "refresh_token"); refreshToken != "" {
+		return refreshToken
+	}
+	for _, attribute := range []string{coreauth.AttributePath, coreauth.AttributeSource} {
+		path := strings.TrimSpace(auth.Attributes[attribute])
+		if path == "" {
+			continue
+		}
+		data, errRead := os.ReadFile(path)
+		if errRead != nil {
+			continue
+		}
+		var stored map[string]any
+		if errUnmarshal := json.Unmarshal(data, &stored); errUnmarshal != nil {
+			continue
+		}
+		if refreshToken := stringValue(stored, "refresh_token"); refreshToken != "" {
+			return refreshToken
+		}
+	}
+	return ""
+}
+
+func managementCodexRefreshErrorCode(err error) string {
+	if err == nil {
+		return "none"
+	}
+	raw := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(raw, "refresh token missing"):
+		return "refresh_token_missing"
+	case strings.Contains(raw, "refresh_token_reused") || strings.Contains(raw, "already used"):
+		return "refresh_token_reused"
+	case strings.Contains(raw, "invalid_grant") || strings.Contains(raw, "sign in again"):
+		return "reauth_required"
+	case strings.Contains(raw, "deadline exceeded") || strings.Contains(raw, "timeout") || strings.Contains(raw, "connection"):
+		return "transient_transport_failure"
+	case strings.Contains(raw, "empty access token"):
+		return "empty_access_token"
+	default:
+		return "unknown"
+	}
 }
 
 func firstNonEmptyString(values ...*string) string {

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	codexauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
@@ -25,6 +26,14 @@ const (
 )
 
 var antigravityOAuthTokenURL = "https://oauth2.googleapis.com/token"
+
+type managementCodexRefreshService interface {
+	RefreshTokensWithRetry(context.Context, string, int) (*codexauth.CodexTokenData, error)
+}
+
+var newManagementCodexRefreshService = func(cfg *config.Config, proxyURL string) managementCodexRefreshService {
+	return codexauth.NewCodexAuthWithProxyURL(cfg, proxyURL)
+}
 
 type apiCallRequest struct {
 	AuthIndexSnake  *string           `json:"auth_index"`
@@ -123,6 +132,12 @@ func (h *Handler) APICall(c *gin.Context) {
 	if reqHeaders == nil {
 		reqHeaders = map[string]string{}
 	}
+	tokenHeaderTemplates := make(map[string]string)
+	for key, value := range reqHeaders {
+		if strings.Contains(value, "$TOKEN$") {
+			tokenHeaderTemplates[key] = value
+		}
+	}
 
 	var hostOverride string
 	var token string
@@ -183,6 +198,40 @@ func (h *Handler) APICall(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "request failed"})
 		return
 	}
+	if resp.StatusCode == http.StatusUnauthorized && len(tokenHeaderTemplates) > 0 && auth != nil && strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		_ = resp.Body.Close()
+		refreshedToken, errRefresh := h.refreshCodexOAuthAccessToken(c.Request.Context(), auth)
+		if errRefresh != nil {
+			log.WithError(errRefresh).Debug("management APICall Codex token refresh failed")
+			c.JSON(http.StatusBadRequest, gin.H{"error": "auth token refresh failed"})
+			return
+		}
+		for key, template := range tokenHeaderTemplates {
+			reqHeaders[key] = strings.ReplaceAll(template, "$TOKEN$", refreshedToken)
+		}
+		requestBody = nil
+		if body.Data != "" {
+			requestBody = strings.NewReader(body.Data)
+		}
+		req, errNewRequest = http.NewRequestWithContext(c.Request.Context(), method, urlStr, requestBody)
+		if errNewRequest != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to build request"})
+			return
+		}
+		for key, value := range reqHeaders {
+			if strings.EqualFold(key, "host") {
+				req.Host = strings.TrimSpace(value)
+				continue
+			}
+			req.Header.Set(key, value)
+		}
+		resp, errDo = httpClient.Do(req)
+		if errDo != nil {
+			log.WithError(errDo).Debug("management APICall retry request failed")
+			c.JSON(http.StatusBadGateway, gin.H{"error": "request failed"})
+			return
+		}
+	}
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
@@ -200,6 +249,52 @@ func (h *Handler) APICall(c *gin.Context) {
 		Header:     resp.Header,
 		Body:       string(respBody),
 	})
+}
+
+func (h *Handler) refreshCodexOAuthAccessToken(ctx context.Context, auth *coreauth.Auth) (string, error) {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return "", fmt.Errorf("codex auth missing")
+	}
+	refreshToken := stringValue(auth.Metadata, "refresh_token")
+	if refreshToken == "" {
+		return "", fmt.Errorf("codex refresh token missing")
+	}
+	service := newManagementCodexRefreshService(h.cfg, auth.ProxyURL)
+	tokenData, errRefresh := service.RefreshTokensWithRetry(ctx, refreshToken, 3)
+	if errRefresh != nil {
+		return "", errRefresh
+	}
+	if tokenData == nil || strings.TrimSpace(tokenData.AccessToken) == "" {
+		return "", fmt.Errorf("codex token refresh returned empty access token")
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["access_token"] = strings.TrimSpace(tokenData.AccessToken)
+	if value := strings.TrimSpace(tokenData.RefreshToken); value != "" {
+		auth.Metadata["refresh_token"] = value
+	}
+	if value := strings.TrimSpace(tokenData.IDToken); value != "" {
+		auth.Metadata["id_token"] = value
+	}
+	if value := strings.TrimSpace(tokenData.AccountID); value != "" {
+		auth.Metadata["account_id"] = value
+	}
+	if value := strings.TrimSpace(tokenData.Email); value != "" {
+		auth.Metadata["email"] = value
+	}
+	auth.Metadata["expired"] = tokenData.Expire
+	auth.Metadata["type"] = "codex"
+	now := time.Now()
+	auth.Metadata["last_refresh"] = now.Format(time.RFC3339)
+	auth.LastRefreshedAt = now
+	auth.UpdatedAt = now
+	if h != nil && h.authManager != nil {
+		if _, errUpdate := h.authManager.Update(ctx, auth); errUpdate != nil {
+			return "", errUpdate
+		}
+	}
+	return strings.TrimSpace(tokenData.AccessToken), nil
 }
 
 func firstNonEmptyString(values ...*string) string {

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -204,9 +205,10 @@ func (h *Handler) APICall(c *gin.Context) {
 		refreshedToken, errRefresh := h.refreshCodexOAuthAccessToken(c.Request.Context(), auth)
 		if errRefresh != nil {
 			log.WithError(errRefresh).Debug("management APICall Codex token refresh failed")
+			refreshError := managementCodexRefreshErrorCode(errRefresh)
 			c.JSON(http.StatusBadRequest, gin.H{
-				"error":         "auth token refresh failed",
-				"refresh_error": managementCodexRefreshErrorCode(errRefresh),
+				"error":         "auth token refresh failed: " + refreshError,
+				"refresh_error": refreshError,
 			})
 			return
 		}
@@ -259,17 +261,25 @@ func (h *Handler) refreshCodexOAuthAccessToken(ctx context.Context, auth *coreau
 	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
 		return "", fmt.Errorf("codex auth missing")
 	}
-	refreshToken := managementCodexRefreshToken(auth)
-	if refreshToken == "" {
+	refreshTokens := h.managementCodexRefreshTokens(auth)
+	if len(refreshTokens) == 0 {
 		return "", fmt.Errorf("codex refresh token missing")
 	}
 	service := newManagementCodexRefreshService(h.cfg, auth.ProxyURL)
-	tokenData, errRefresh := service.RefreshTokensWithRetry(ctx, refreshToken, 3)
-	if errRefresh != nil {
-		return "", errRefresh
+	var tokenData *codexauth.CodexTokenData
+	var errRefresh error
+	for _, refreshToken := range refreshTokens {
+		tokenData, errRefresh = service.RefreshTokensWithRetry(ctx, refreshToken, 3)
+		if errRefresh == nil && tokenData != nil && strings.TrimSpace(tokenData.AccessToken) != "" {
+			break
+		}
+		if errRefresh == nil {
+			errRefresh = fmt.Errorf("codex token refresh returned empty access token")
+		}
+		tokenData = nil
 	}
-	if tokenData == nil || strings.TrimSpace(tokenData.AccessToken) == "" {
-		return "", fmt.Errorf("codex token refresh returned empty access token")
+	if tokenData == nil {
+		return "", errRefresh
 	}
 	if auth.Metadata == nil {
 		auth.Metadata = make(map[string]any)
@@ -301,18 +311,53 @@ func (h *Handler) refreshCodexOAuthAccessToken(ctx context.Context, auth *coreau
 	return strings.TrimSpace(tokenData.AccessToken), nil
 }
 
-func managementCodexRefreshToken(auth *coreauth.Auth) string {
+func (h *Handler) managementCodexRefreshTokens(auth *coreauth.Auth) []string {
 	if auth == nil {
-		return ""
+		return nil
 	}
-	if refreshToken := stringValue(auth.Metadata, "refresh_token"); refreshToken != "" {
-		return refreshToken
+	refreshTokens := make([]string, 0, 2)
+	seenTokens := make(map[string]struct{}, 2)
+	addToken := func(refreshToken string) {
+		refreshToken = strings.TrimSpace(refreshToken)
+		if refreshToken == "" {
+			return
+		}
+		if _, exists := seenTokens[refreshToken]; exists {
+			return
+		}
+		seenTokens[refreshToken] = struct{}{}
+		refreshTokens = append(refreshTokens, refreshToken)
+	}
+	addToken(stringValue(auth.Metadata, "refresh_token"))
+
+	paths := make([]string, 0, 4)
+	seenPaths := make(map[string]struct{}, 4)
+	addPath := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return
+		}
+		path = filepath.Clean(path)
+		if _, exists := seenPaths[path]; exists {
+			return
+		}
+		seenPaths[path] = struct{}{}
+		paths = append(paths, path)
 	}
 	for _, attribute := range []string{coreauth.AttributePath, coreauth.AttributeSource} {
-		path := strings.TrimSpace(auth.Attributes[attribute])
-		if path == "" {
-			continue
+		addPath(auth.Attributes[attribute])
+	}
+	if h != nil && h.cfg != nil {
+		authDir := strings.TrimSpace(h.cfg.AuthDir)
+		if authDir != "" {
+			for _, name := range []string{auth.FileName, auth.ID} {
+				if name = strings.TrimSpace(name); name != "" {
+					addPath(filepath.Join(authDir, filepath.Base(name)))
+				}
+			}
 		}
+	}
+	for _, path := range paths {
 		data, errRead := os.ReadFile(path)
 		if errRead != nil {
 			continue
@@ -321,11 +366,9 @@ func managementCodexRefreshToken(auth *coreauth.Auth) string {
 		if errUnmarshal := json.Unmarshal(data, &stored); errUnmarshal != nil {
 			continue
 		}
-		if refreshToken := stringValue(stored, "refresh_token"); refreshToken != "" {
-			return refreshToken
-		}
+		addToken(stringValue(stored, "refresh_token"))
 	}
-	return ""
+	return refreshTokens
 }
 
 func managementCodexRefreshErrorCode(err error) string {
@@ -338,10 +381,18 @@ func managementCodexRefreshErrorCode(err error) string {
 		return "refresh_token_missing"
 	case strings.Contains(raw, "refresh_token_reused") || strings.Contains(raw, "already used"):
 		return "refresh_token_reused"
-	case strings.Contains(raw, "invalid_grant") || strings.Contains(raw, "sign in again"):
+	case strings.Contains(raw, "invalid_grant") || strings.Contains(raw, "sign in again") || strings.Contains(raw, "status 400") || strings.Contains(raw, "status 401"):
 		return "reauth_required"
+	case strings.Contains(raw, "status 403"):
+		return "oauth_access_denied"
+	case strings.Contains(raw, "status 429"):
+		return "upstream_rate_limited"
+	case strings.Contains(raw, "status 500") || strings.Contains(raw, "status 502") || strings.Contains(raw, "status 503") || strings.Contains(raw, "status 504"):
+		return "upstream_unavailable"
 	case strings.Contains(raw, "deadline exceeded") || strings.Contains(raw, "timeout") || strings.Contains(raw, "connection"):
 		return "transient_transport_failure"
+	case strings.Contains(raw, "failed to parse refresh response") || strings.Contains(raw, "failed to read refresh response"):
+		return "malformed_upstream_response"
 	case strings.Contains(raw, "empty access token"):
 		return "empty_access_token"
 	default:

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -1,14 +1,112 @@
 package management
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/gin-gonic/gin"
+	codexauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
+
+type fakeManagementCodexRefreshService struct {
+	tokenData *codexauth.CodexTokenData
+}
+
+func (f *fakeManagementCodexRefreshService) RefreshTokensWithRetry(_ context.Context, refreshToken string, retries int) (*codexauth.CodexTokenData, error) {
+	if refreshToken != "refresh-old" {
+		return nil, fmt.Errorf("refresh token = %q, want refresh-old", refreshToken)
+	}
+	if retries != 3 {
+		return nil, fmt.Errorf("retries = %d, want 3", retries)
+	}
+	return f.tokenData, nil
+}
+
+func TestAPICallRefreshesCodexTokenAfterUnauthorized(t *testing.T) {
+	originalFactory := newManagementCodexRefreshService
+	newManagementCodexRefreshService = func(_ *config.Config, _ string) managementCodexRefreshService {
+		return &fakeManagementCodexRefreshService{tokenData: &codexauth.CodexTokenData{
+			AccessToken:  "access-new",
+			RefreshToken: "refresh-new",
+			IDToken:      "id-new",
+			AccountID:    "account-new",
+			Email:        "codex@example.test",
+			Expire:       time.Now().Add(time.Hour).Format(time.RFC3339),
+		}}
+	}
+	defer func() { newManagementCodexRefreshService = originalFactory }()
+
+	requests := 0
+	requestTokens := make([]string, 0, 2)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		requestTokens = append(requestTokens, r.Header.Get("Authorization"))
+		if requestTokens[len(requestTokens)-1] == "Bearer access-old" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"expired"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	auth := &coreauth.Auth{
+		ID:       "codex-example.json",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"access_token":  "access-old",
+			"refresh_token": "refresh-old",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+	router := gin.New()
+	router.POST("/api-call", h.APICall)
+	payload, _ := json.Marshal(map[string]any{
+		"auth_index": auth.EnsureIndex(),
+		"method":     http.MethodGet,
+		"url":        upstream.URL,
+		"header":     map[string]string{"Authorization": "Bearer $TOKEN$"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api-call", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("management status = %d, body=%s", recorder.Code, recorder.Body.String())
+	}
+	responseBody, _ := io.ReadAll(recorder.Body)
+	var response apiCallResponse
+	if errUnmarshal := json.Unmarshal(responseBody, &response); errUnmarshal != nil {
+		t.Fatalf("decode response: %v", errUnmarshal)
+	}
+	if response.StatusCode != http.StatusOK || requests != 2 {
+		t.Fatalf("upstream status=%d requests=%d, want 200/2", response.StatusCode, requests)
+	}
+	if requestTokens[0] != "Bearer access-old" || requestTokens[1] != "Bearer access-new" {
+		t.Fatalf("Authorization sequence = %v, want old/new", requestTokens)
+	}
+	updated := h.authByIndex(auth.Index)
+	if got := tokenValueForAuth(updated); got != "access-new" {
+		t.Fatalf("persisted access token = %q, want access-new", got)
+	}
+}
 
 func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 	t.Parallel()

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -61,14 +63,18 @@ func TestAPICallRefreshesCodexTokenAfterUnauthorized(t *testing.T) {
 	}))
 	defer upstream.Close()
 
+	authFile := filepath.Join(t.TempDir(), "codex-example.json")
+	if errWrite := os.WriteFile(authFile, []byte(`{"refresh_token":"refresh-old"}`), 0o600); errWrite != nil {
+		t.Fatalf("write auth file: %v", errWrite)
+	}
 	manager := coreauth.NewManager(nil, nil, nil)
 	auth := &coreauth.Auth{
 		ID:       "codex-example.json",
 		Provider: "codex",
-		Metadata: map[string]any{
-			"access_token":  "access-old",
-			"refresh_token": "refresh-old",
+		Attributes: map[string]string{
+			coreauth.AttributePath: authFile,
 		},
+		Metadata: map[string]any{"access_token": "access-old"},
 	}
 	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
 		t.Fatalf("register auth: %v", errRegister)

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -21,30 +21,36 @@ import (
 )
 
 type fakeManagementCodexRefreshService struct {
-	tokenData *codexauth.CodexTokenData
+	tokenData     *codexauth.CodexTokenData
+	refreshTokens []string
 }
 
 func (f *fakeManagementCodexRefreshService) RefreshTokensWithRetry(_ context.Context, refreshToken string, retries int) (*codexauth.CodexTokenData, error) {
-	if refreshToken != "refresh-old" {
-		return nil, fmt.Errorf("refresh token = %q, want refresh-old", refreshToken)
-	}
 	if retries != 3 {
 		return nil, fmt.Errorf("retries = %d, want 3", retries)
+	}
+	f.refreshTokens = append(f.refreshTokens, refreshToken)
+	if refreshToken == "refresh-stale" {
+		return nil, fmt.Errorf("token refresh failed: refresh_token_reused")
+	}
+	if refreshToken != "refresh-old" {
+		return nil, fmt.Errorf("refresh token = %q, want refresh-old", refreshToken)
 	}
 	return f.tokenData, nil
 }
 
 func TestAPICallRefreshesCodexTokenAfterUnauthorized(t *testing.T) {
 	originalFactory := newManagementCodexRefreshService
+	fakeRefresh := &fakeManagementCodexRefreshService{tokenData: &codexauth.CodexTokenData{
+		AccessToken:  "access-new",
+		RefreshToken: "refresh-new",
+		IDToken:      "id-new",
+		AccountID:    "account-new",
+		Email:        "codex@example.test",
+		Expire:       time.Now().Add(time.Hour).Format(time.RFC3339),
+	}}
 	newManagementCodexRefreshService = func(_ *config.Config, _ string) managementCodexRefreshService {
-		return &fakeManagementCodexRefreshService{tokenData: &codexauth.CodexTokenData{
-			AccessToken:  "access-new",
-			RefreshToken: "refresh-new",
-			IDToken:      "id-new",
-			AccountID:    "account-new",
-			Email:        "codex@example.test",
-			Expire:       time.Now().Add(time.Hour).Format(time.RFC3339),
-		}}
+		return fakeRefresh
 	}
 	defer func() { newManagementCodexRefreshService = originalFactory }()
 
@@ -74,7 +80,10 @@ func TestAPICallRefreshesCodexTokenAfterUnauthorized(t *testing.T) {
 		Attributes: map[string]string{
 			coreauth.AttributePath: authFile,
 		},
-		Metadata: map[string]any{"access_token": "access-old"},
+		Metadata: map[string]any{
+			"access_token":  "access-old",
+			"refresh_token": "refresh-stale",
+		},
 	}
 	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
 		t.Fatalf("register auth: %v", errRegister)
@@ -107,6 +116,9 @@ func TestAPICallRefreshesCodexTokenAfterUnauthorized(t *testing.T) {
 	}
 	if requestTokens[0] != "Bearer access-old" || requestTokens[1] != "Bearer access-new" {
 		t.Fatalf("Authorization sequence = %v, want old/new", requestTokens)
+	}
+	if got := fmt.Sprint(fakeRefresh.refreshTokens); got != "[refresh-stale refresh-old]" {
+		t.Fatalf("refresh token candidates = %s, want stale/persisted", got)
 	}
 	updated := h.authByIndex(auth.Index)
 	if got := tokenValueForAuth(updated); got != "access-new" {


### PR DESCRIPTION
## Summary

- retry management `api-call` once after a Codex-authenticated upstream 401
- reuse the existing Codex refresh service and proxy settings
- persist rotated access, refresh, ID, account, and expiry metadata through the runtime manager
- cover the 401 -> refresh -> retry path with a regression test

## Root cause

The management quota UI calls `POST /v0/management/api-call`. That path substituted the stored Codex access token but, unlike the Codex executor, never refreshed it after an upstream 401. A complete persisted credential could therefore remain unusable in quota views until another path refreshed it.

## Live evidence

A v7.2.63 deployment returned upstream 401 for the Codex usage endpoint while the stored record contained access, refresh, ID, and account fields. The management handler reached upstream, proving this was not the post-persist runtime metadata gap fixed by #4200.

## Validation

- patch applies cleanly to current `dev` and v7.2.63
- regression test: `TestAPICallRefreshesCodexTokenAfterUnauthorized`
- full Go compile/test delegated to CI and the downstream Kubernetes BuildKit stable-channel build