### PR TITLE
fix(translator): Codex Responses Lite 工具下发/回放与无 id tool_calls 事件链修复

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -60,7 +60,8 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 		inputItems := input.Array()
 		outputCallIDs := make(map[string]struct{})
 		for _, item := range inputItems {
-			if item.Get("type").String() != "function_call_output" {
+			itemType := item.Get("type").String()
+			if itemType != "function_call_output" && itemType != "custom_tool_call_output" {
 				continue
 			}
 			callID := strings.TrimSpace(item.Get("call_id").String())
@@ -138,7 +139,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			if itemType == "" && item.Get("role").String() != "" {
 				itemType = "message"
 			}
-			if itemType != "function_call" {
+			if itemType != "function_call" && itemType != "custom_tool_call" {
 				flushPendingToolCalls()
 			}
 
@@ -257,6 +258,33 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				if len(awaitingToolOutputs) == 0 && len(deferredMessages) > 0 {
 					flushDeferredMessages()
 				}
+
+			case "custom_tool_call":
+				// Codex freeform tool call replay: wrap the raw input so it
+				// matches the {"input": string} function shape used when
+				// converting custom tool definitions.
+				toolCall := []byte(`{"id":"","type":"function","function":{"name":"","arguments":""}}`)
+				toolCall, _ = sjson.SetBytes(toolCall, "id", item.Get("call_id").String())
+				toolCall, _ = sjson.SetBytes(toolCall, "function.name", item.Get("name").String())
+				wrappedArgs, _ := sjson.SetBytes([]byte(`{"input":""}`), "input", item.Get("input").String())
+				toolCall, _ = sjson.SetBytes(toolCall, "function.arguments", string(wrappedArgs))
+				pendingToolCalls = append(pendingToolCalls, gjson.ParseBytes(toolCall).Value())
+				if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
+					pendingToolCallIDs = append(pendingToolCallIDs, callID)
+				}
+
+			case "custom_tool_call_output":
+				toolMessage := []byte(`{"role":"tool","tool_call_id":"","content":""}`)
+				callID := strings.TrimSpace(item.Get("call_id").String())
+				toolMessage, _ = sjson.SetBytes(toolMessage, "tool_call_id", callID)
+				toolMessage, _ = sjson.SetBytes(toolMessage, "content", responsesToolOutputText(item.Get("output")))
+				out, _ = sjson.SetRawBytes(out, "messages.-1", toolMessage)
+				if callID != "" {
+					delete(awaitingToolOutputs, callID)
+				}
+				if len(awaitingToolOutputs) == 0 && len(deferredMessages) > 0 {
+					flushDeferredMessages()
+				}
 			}
 
 		}
@@ -270,20 +298,33 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 		out, _ = sjson.SetRawBytes(out, "messages.-1", msg)
 	}
 
-	// Convert tools from responses format to chat completions format
-	if tools := root.Get("tools"); tools.Exists() && tools.IsArray() {
-		var chatCompletionsTools []interface{}
-
+	// Convert tools from responses format to chat completions format.
+	// Codex Desktop (Responses Lite) delivers tool definitions through an
+	// "additional_tools" input item instead of the top-level "tools" field,
+	// so merge both sources.
+	var chatCompletionsTools []interface{}
+	appendChatTools := func(tools gjson.Result) {
+		if !tools.Exists() || !tools.IsArray() {
+			return
+		}
 		tools.ForEach(func(_, tool gjson.Result) bool {
 			for _, chatTool := range convertResponsesToolToOpenAIChatTools(tool) {
 				chatCompletionsTools = append(chatCompletionsTools, gjson.ParseBytes(chatTool).Value())
 			}
 			return true
 		})
-
-		if len(chatCompletionsTools) > 0 {
-			out, _ = sjson.SetBytes(out, "tools", chatCompletionsTools)
-		}
+	}
+	appendChatTools(root.Get("tools"))
+	if input := root.Get("input"); input.Exists() && input.IsArray() {
+		input.ForEach(func(_, item gjson.Result) bool {
+			if item.Get("type").String() == "additional_tools" {
+				appendChatTools(item.Get("tools"))
+			}
+			return true
+		})
+	}
+	if len(chatCompletionsTools) > 0 {
+		out, _ = sjson.SetBytes(out, "tools", chatCompletionsTools)
 	}
 
 	if reasoningEffort := root.Get("reasoning.effort"); reasoningEffort.Exists() {

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -479,7 +479,13 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 						existingCallID := st.FuncCallIDs[key]
 						effectiveCallID := existingCallID
 						shouldEmitItem := false
-						if existingCallID == "" && newCallID != "" {
+						if existingCallID == "" {
+							if newCallID == "" {
+								// Some OpenAI-compatible providers omit tool_call ids in
+								// streaming deltas; synthesize one so the Responses event
+								// chain (output_item.added/done) still fires for Codex.
+								newCallID = fmt.Sprintf("call_%s_%d_%d", st.ResponseID, idx, toolIndex)
+							}
 							effectiveCallID = newCallID
 							st.FuncCallIDs[key] = newCallID
 							st.FuncOutputIx[key] = allocOutputIndex()
@@ -758,8 +764,13 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 
 				// Function/tool calls
 				if tcs := msg.Get("tool_calls"); tcs.Exists() && tcs.IsArray() {
-					tcs.ForEach(func(_, tc gjson.Result) bool {
+					tcs.ForEach(func(tcIndex, tc gjson.Result) bool {
 						callID := tc.Get("id").String()
+						if callID == "" {
+							// Providers may omit tool_call ids; synthesize one so the
+							// function_call item stays usable for Codex round-trips.
+							callID = fmt.Sprintf("call_%s_%d_%d", id, choice.Get("index").Int(), tcIndex.Int())
+						}
 						name := tc.Get("function.name").String()
 						args := tc.Get("function.arguments").String()
 						item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -46,6 +46,9 @@ type oaiToResponsesState struct {
 	// function item done state
 	FuncArgsDone map[string]bool
 	FuncItemDone map[string]bool
+	// names of freeform ("custom") tools from the original request; calls to
+	// these are emitted as custom_tool_call items instead of function_call
+	CustomToolNames map[string]struct{}
 	// usage aggregation
 	PromptTokens     int64
 	CachedTokens     int64
@@ -166,6 +169,15 @@ func buildResponsesCompletedEvent(st *oaiToResponsesState, requestRawJSON []byte
 			}
 			callID := st.FuncCallIDs[key]
 			name := st.FuncNames[key]
+			if _, isCustomTool := st.CustomToolNames[name]; isCustomTool {
+				item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)
+				item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ctc_%s", callID))
+				item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(args))
+				item, _ = sjson.SetBytes(item, "call_id", callID)
+				item, _ = sjson.SetBytes(item, "name", name)
+				outputItems = append(outputItems, completedOutputItem{index: st.FuncOutputIx[key], raw: item})
+				continue
+			}
 			item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
 			item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
 			item, _ = sjson.SetBytes(item, "arguments", args)
@@ -301,6 +313,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 		st.MsgItemDone = make(map[int]bool)
 		st.FuncArgsDone = make(map[string]bool)
 		st.FuncItemDone = make(map[string]bool)
+		st.CustomToolNames = responsesCustomToolNames(requestForNamespace)
 		st.PromptTokens = 0
 		st.CachedTokens = 0
 		st.CompletionTokens = 0
@@ -492,15 +505,27 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 							shouldEmitItem = true
 						}
 
+						_, isCustomTool := st.CustomToolNames[st.FuncNames[key]]
+
 						if shouldEmitItem && effectiveCallID != "" {
 							outputIndex := st.FuncOutputIx[key]
-							o := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
-							o, _ = sjson.SetBytes(o, "sequence_number", nextSeq())
-							o, _ = sjson.SetBytes(o, "output_index", outputIndex)
-							o, _ = sjson.SetBytes(o, "item.id", fmt.Sprintf("fc_%s", effectiveCallID))
-							o, _ = sjson.SetBytes(o, "item.call_id", effectiveCallID)
-							o = applyResponsesFunctionCallNamespaceFields(o, requestForNamespace, st.FuncNames[key], "item")
-							out = append(out, emitRespEvent("response.output_item.added", o))
+							if isCustomTool {
+								o := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"in_progress","input":"","call_id":"","name":""}}`)
+								o, _ = sjson.SetBytes(o, "sequence_number", nextSeq())
+								o, _ = sjson.SetBytes(o, "output_index", outputIndex)
+								o, _ = sjson.SetBytes(o, "item.id", fmt.Sprintf("ctc_%s", effectiveCallID))
+								o, _ = sjson.SetBytes(o, "item.call_id", effectiveCallID)
+								o, _ = sjson.SetBytes(o, "item.name", st.FuncNames[key])
+								out = append(out, emitRespEvent("response.output_item.added", o))
+							} else {
+								o := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
+								o, _ = sjson.SetBytes(o, "sequence_number", nextSeq())
+								o, _ = sjson.SetBytes(o, "output_index", outputIndex)
+								o, _ = sjson.SetBytes(o, "item.id", fmt.Sprintf("fc_%s", effectiveCallID))
+								o, _ = sjson.SetBytes(o, "item.call_id", effectiveCallID)
+								o = applyResponsesFunctionCallNamespaceFields(o, requestForNamespace, st.FuncNames[key], "item")
+								out = append(out, emitRespEvent("response.output_item.added", o))
+							}
 						}
 
 						if st.FuncArgsBuf[key] == nil {
@@ -512,7 +537,10 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 							if refCallID == "" {
 								refCallID = newCallID
 							}
-							if refCallID != "" {
+							// Custom tool calls buffer arguments only: JSON argument
+							// fragments cannot be mapped onto freeform input deltas, so
+							// the full input is delivered with the done events instead.
+							if refCallID != "" && !isCustomTool {
 								outputIndex := st.FuncOutputIx[key]
 								ad := []byte(`{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
 								ad, _ = sjson.SetBytes(ad, "sequence_number", nextSeq())
@@ -599,6 +627,27 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 						args := "{}"
 						if b := st.FuncArgsBuf[key]; b != nil && b.Len() > 0 {
 							args = b.String()
+						}
+						if _, isCustomTool := st.CustomToolNames[st.FuncNames[key]]; isCustomTool {
+							input := unwrapCustomToolInput(args)
+							inputDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
+							inputDone, _ = sjson.SetBytes(inputDone, "sequence_number", nextSeq())
+							inputDone, _ = sjson.SetBytes(inputDone, "item_id", fmt.Sprintf("ctc_%s", callID))
+							inputDone, _ = sjson.SetBytes(inputDone, "output_index", outputIndex)
+							inputDone, _ = sjson.SetBytes(inputDone, "input", input)
+							out = append(out, emitRespEvent("response.custom_tool_call_input.done", inputDone))
+
+							itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}}`)
+							itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+							itemDone, _ = sjson.SetBytes(itemDone, "output_index", outputIndex)
+							itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("ctc_%s", callID))
+							itemDone, _ = sjson.SetBytes(itemDone, "item.input", input)
+							itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", callID)
+							itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[key])
+							out = append(out, emitRespEvent("response.output_item.done", itemDone))
+							st.FuncItemDone[key] = true
+							st.FuncArgsDone[key] = true
+							continue
 						}
 						fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
 						fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
@@ -764,6 +813,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 
 				// Function/tool calls
 				if tcs := msg.Get("tool_calls"); tcs.Exists() && tcs.IsArray() {
+					customToolNames := responsesCustomToolNames(requestForNamespace)
 					tcs.ForEach(func(tcIndex, tc gjson.Result) bool {
 						callID := tc.Get("id").String()
 						if callID == "" {
@@ -773,6 +823,15 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 						}
 						name := tc.Get("function.name").String()
 						args := tc.Get("function.arguments").String()
+						if _, isCustomTool := customToolNames[name]; isCustomTool {
+							item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)
+							item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ctc_%s", callID))
+							item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(args))
+							item, _ = sjson.SetBytes(item, "call_id", callID)
+							item, _ = sjson.SetBytes(item, "name", name)
+							outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
+							return true
+						}
 						item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
 						item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
 						item, _ = sjson.SetBytes(item, "arguments", args)

--- a/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
@@ -120,6 +120,10 @@ func responsesToolOutputText(output gjson.Result) string {
 	if output.IsArray() {
 		var b strings.Builder
 		output.ForEach(func(_, part gjson.Result) bool {
+			if part.Type == gjson.String {
+				b.WriteString(part.String())
+				return true
+			}
 			if text := part.Get("text"); text.Exists() {
 				b.WriteString(text.String())
 			}
@@ -168,8 +172,11 @@ func responsesCustomToolNames(requestRawJSON []byte) map[string]struct{} {
 // function-call arguments produced for a converted custom tool; it falls back
 // to the raw arguments when the wrapper is absent.
 func unwrapCustomToolInput(arguments string) string {
-	if v := gjson.Get(arguments, "input"); v.Exists() && v.Type == gjson.String {
-		return v.String()
+	if v := gjson.Get(arguments, "input"); v.Exists() {
+		if v.Type == gjson.String {
+			return v.String()
+		}
+		return v.Raw
 	}
 	return arguments
 }

--- a/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
@@ -16,10 +16,30 @@ func convertResponsesToolToOpenAIChatTools(tool gjson.Result) [][]byte {
 		}
 	case "namespace":
 		return convertResponsesNamespaceToolToOpenAIChat(tool)
+	case "custom":
+		if tJSON, ok := convertResponsesCustomToolToOpenAIChat(tool); ok {
+			return [][]byte{tJSON}
+		}
 	default:
 		return nil
 	}
 	return nil
+}
+
+// convertResponsesCustomToolToOpenAIChat maps a Responses freeform ("custom")
+// tool onto a Chat Completions function tool with a single freeform "input"
+// string, mirroring the function-based shape Codex uses for apply_patch.
+func convertResponsesCustomToolToOpenAIChat(tool gjson.Result) ([]byte, bool) {
+	name := responsesToolName(tool)
+	if name == "" {
+		return nil, false
+	}
+	chatTool := []byte(`{"type":"function","function":{"name":"","description":"","parameters":{"type":"object","properties":{"input":{"type":"string"}},"required":["input"]}}}`)
+	chatTool, _ = sjson.SetBytes(chatTool, "function.name", name)
+	if description := responsesToolDescription(tool); description != "" {
+		chatTool, _ = sjson.SetBytes(chatTool, "function.description", description)
+	}
+	return chatTool, true
 }
 
 func convertResponsesNamespaceToolToOpenAIChat(tool gjson.Result) [][]byte {
@@ -88,6 +108,70 @@ func responsesToolParameters(tool gjson.Result) gjson.Result {
 		}
 	}
 	return gjson.Result{}
+}
+
+// responsesToolOutputText flattens a tool output value that may be a plain
+// string or an array of content parts ({"type":"input_text","text":...}) into
+// a single text payload for a Chat Completions tool message.
+func responsesToolOutputText(output gjson.Result) string {
+	if output.Type == gjson.String {
+		return output.String()
+	}
+	if output.IsArray() {
+		var b strings.Builder
+		output.ForEach(func(_, part gjson.Result) bool {
+			if text := part.Get("text"); text.Exists() {
+				b.WriteString(text.String())
+			}
+			return true
+		})
+		return b.String()
+	}
+	if output.Exists() {
+		return output.Raw
+	}
+	return ""
+}
+
+// responsesCustomToolNames collects the names of freeform ("custom") tools
+// declared in the original Responses request, both in the top-level "tools"
+// field and in Codex Desktop "additional_tools" input items.
+func responsesCustomToolNames(requestRawJSON []byte) map[string]struct{} {
+	names := make(map[string]struct{})
+	collect := func(tools gjson.Result) {
+		if !tools.Exists() || !tools.IsArray() {
+			return
+		}
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			if strings.TrimSpace(tool.Get("type").String()) == "custom" {
+				if name := responsesToolName(tool); name != "" {
+					names[name] = struct{}{}
+				}
+			}
+			return true
+		})
+	}
+	root := gjson.ParseBytes(requestRawJSON)
+	collect(root.Get("tools"))
+	if input := root.Get("input"); input.Exists() && input.IsArray() {
+		input.ForEach(func(_, item gjson.Result) bool {
+			if item.Get("type").String() == "additional_tools" {
+				collect(item.Get("tools"))
+			}
+			return true
+		})
+	}
+	return names
+}
+
+// unwrapCustomToolInput extracts the freeform input from the {"input": "..."}
+// function-call arguments produced for a converted custom tool; it falls back
+// to the raw arguments when the wrapper is absent.
+func unwrapCustomToolInput(arguments string) string {
+	if v := gjson.Get(arguments, "input"); v.Exists() && v.Type == gjson.String {
+		return v.String()
+	}
+	return arguments
 }
 
 func qualifyResponsesNamespaceToolName(namespaceName, childName string) string {


### PR DESCRIPTION
Closes #4219

## 问题

Codex（经 `/v1/responses` 接入）使用 `openai-compatibility` 提供商时工具完全不可用，模型答复"没有工具可以使用"；同一客户端切换 Codex OAuth 凭证则正常。经 `request-log` 抓取真实流量定位到三个转换层缺陷：

1. **Codex Desktop（Responses Lite）格式不被识别（主因，实测确认）**
   Codex Desktop 0.144.x（请求头 `X-Openai-Internal-Codex-Responses-Lite: true`）顶层 `tools` 为 null：工具定义经 input 中的 `additional_tools` item 下发（实测含 `custom` 类型 `exec`、`function` 类型 `wait`/`request_user_input`、`namespace` 类型 `collaboration`），历史工具调用为 `custom_tool_call` / `custom_tool_call_output` item。原转换全部静默丢弃——实测抓包 281 个 input item 翻译后发往上游为 `tools: null` + 90 条纯 user/assistant 消息，51 对工具调用历史全部丢失。
2. **上游流式 `tool_calls` 缺少 `id` 时事件链被吞**
   `existingCallID == "" && newCallID != ""` 在上游（自建 vLLM/sglang、部分中转网关）不发 id 时永远为 false，`response.output_item.added/done` 等事件全部不发出；非流式路径产出 `call_id:""` 残缺 item。
3. **`type:"custom"`（freeform）工具定义被丢弃**
   工具转换仅认 `function`/`namespace`，Codex 对 gpt-5.x-codex 系列以 custom 形式下发的 `apply_patch` 直接消失。

## 修复

**请求方向**（`openai_openai-responses_request.go` / `..._tools.go`）：
- 工具收集合并顶层 `tools` 与所有 `additional_tools` item；`custom` 工具映射为带 `{"input": string}` 参数的 function 工具（与 Codex function 形态 `apply_patch` 形状一致）
- `custom_tool_call` 回放为 assistant `tool_calls[]`（原始 input 包装为 `{"input": ...}`）；`custom_tool_call_output` 回放为 `tool` 消息（content-parts 数组拍平），并纳入 `outputCallIDs` 预扫描维持工具消息相邻性

**响应方向**（`openai_openai-responses_response.go`）：
- 流式/非流式缺失 id 时合成确定性 `call_<responseID>_<choiceIdx>_<toolIndex>`（chat completions 上游无状态，call_id 仅需单请求内自洽）
- 对原始请求中声明为 custom 的工具（顶层 + additional_tools，流开始时缓存），调用以 `custom_tool_call` item 回放：`output_item.added`(type=custom_tool_call) → `custom_tool_call_input.done` → `output_item.done`；JSON arguments 增量无法映射为 freeform input 增量，故不发 delta，完整 input 随 done 一次性下发；`response.completed` 与非流式同形

## 验证

- 用抓包的真实 Codex Desktop 请求（1.3MB、281 item）过转换：9 个工具全部下发（namespace 扁平化为 `collaboration__*`）、51 对工具历史完整回放
- 经真实 openai-compatibility 上游端到端测试：模型成功调用 `exec` 并以 `custom_tool_call` 事件链回放，Codex Desktop 多轮工具循环恢复正常
- 无 id / 空 id 流式与非流式用例验证合成 id 后事件链完整；带 id 上游行为不变
- `gofmt` / `go build` / `go test ./internal/translator/...` 全绿

三个提交按缺陷原子拆分，可独立 review。
