### PR TITLE
fix(images): allow grok models on image endpoints

### DIFF
--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -1401,7 +1401,7 @@ func (h *OpenAIAPIHandler) collectImagesWithModel(c *gin.Context, imageReq []byt
 	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
 
 	model = strings.TrimSpace(model)
-	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, xaiImagesHandlerType, model, imageReq, "")
+	resp, upstreamHeaders, errMsg := h.ExecuteImageWithAuthManager(cliCtx, xaiImagesHandlerType, model, imageReq, "")
 	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)
@@ -1452,7 +1452,7 @@ func (h *OpenAIAPIHandler) streamImagesWithModel(c *gin.Context, imageReq []byte
 	}
 	resultChan := make(chan imageStreamResult, 1)
 	go func() {
-		resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, xaiImagesHandlerType, model, imageReq, "")
+		resp, upstreamHeaders, errMsg := h.ExecuteImageWithAuthManager(cliCtx, xaiImagesHandlerType, model, imageReq, "")
 		resultChan <- imageStreamResult{resp: resp, upstreamHeaders: upstreamHeaders, errMsg: errMsg}
 	}()
 


### PR DESCRIPTION
## Summary

- execute Grok image generation and edit requests through the image-aware auth manager path
- allow both standard and locally wrapped streaming image requests to pass image-only model validation
- prevent `/v1/images/generations` and `/v1/images/edits` from returning the misleading image-endpoint-only HTTP 503

## Root cause

The xAI image handlers called `ExecuteWithAuthManager`, which sets `allowImageModel` to `false`. Since Grok image models are classified as image-only, CLIProxyAPI rejected them before provider selection even when the request already used a supported image endpoint.

## Testing

- `go test ./sdk/api/handlers/openai ./sdk/api/handlers -count=1`
- `go test ./internal/runtime/executor/... -count=1`
- `go build -o test-output ./cmd/server && rm test-output`

## Affected version

`v7.2.66`

## Observed error

CLIProxyAPI incorrectly returned HTTP 503 before provider selection or any upstream request:

```json
{"error":{"message":"model grok-imagine-image is only supported on /v1/images/generations and /v1/images/edits","type":"server_error","code":"internal_server_error"}}
```