### PR TITLE
fix(openai): allow xAI image-only models on /v1/images endpoints

### DIFF
--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -1401,7 +1401,7 @@ func (h *OpenAIAPIHandler) collectImagesWithModel(c *gin.Context, imageReq []byt
 	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
 
 	model = strings.TrimSpace(model)
-	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, xaiImagesHandlerType, model, imageReq, "")
+	resp, upstreamHeaders, errMsg := h.ExecuteImageWithAuthManager(cliCtx, xaiImagesHandlerType, model, imageReq, "")
 	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)
@@ -1452,7 +1452,7 @@ func (h *OpenAIAPIHandler) streamImagesWithModel(c *gin.Context, imageReq []byte
 	}
 	resultChan := make(chan imageStreamResult, 1)
 	go func() {
-		resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, xaiImagesHandlerType, model, imageReq, "")
+		resp, upstreamHeaders, errMsg := h.ExecuteImageWithAuthManager(cliCtx, xaiImagesHandlerType, model, imageReq, "")
 		resultChan <- imageStreamResult{resp: resp, upstreamHeaders: upstreamHeaders, errMsg: errMsg}
 	}()
 


### PR DESCRIPTION
## Summary

xAI image generation/editing requests for the image-only models `grok-imagine-image` and `grok-imagine-image-quality` are rejected on `/v1/images/generations` and `/v1/images/edits` with:

```
503 model grok-imagine-image is only supported on /v1/images/generations and /v1/images/edits
```

even though the request is sent to exactly those endpoints.

## Root cause

The non-streaming and pseudo-streaming xAI image collectors call `ExecuteWithAuthManager`, which passes `allowImageModel=false` down to `validateImageOnlyModel`. Since `grok-imagine-image*` are classified as image-only models (`isOpenAIImageOnlyModel`), the gate rejects them with 503 before the request ever reaches the upstream — despite the caller being the images endpoint itself.

The routed Codex image paths (`collectRoutedImages` / `streamRoutedImages`) already use the `ExecuteImage*` variants (`allowImageModel=true`); the xAI collectors were simply left on the wrong helper.

## Fix

Switch both xAI image call sites in `sdk/api/handlers/openai/openai_images_handlers.go` to `ExecuteImageWithAuthManager`, so the images endpoints permit image-only models — consistent with the Codex image paths.

- `collectImagesWithModel`: `ExecuteWithAuthManager` → `ExecuteImageWithAuthManager`
- `streamImagesWithModel`: `ExecuteWithAuthManager` → `ExecuteImageWithAuthManager` (this collector performs a non-streaming upstream call and synthesizes SSE from the full result, so the non-stream `ExecuteImage*` helper is the correct one)

The chat completions path continues to reject image-only models (still returns 503), so the gate is only lifted for the image endpoints.

## Testing

Built a patched image from `v7.2.66` and ran it locally:

- `POST /v1/images/generations` + `grok-imagine-image` — **before:** local 503 `... is only supported on /v1/images/generations and /v1/images/edits`; **after:** the request passes the local gate and reaches xAI upstream (the 503 is gone). In my environment the upstream then returns its own 403 `permission-denied` / `spending-limit` because the available xAI accounts lack image-endpoint entitlement/credits, which confirms the routing gate is fixed and the request is now correctly forwarded. I was unable to complete an end-to-end image render due to account entitlement, not code.
- `GET /v1/models` still lists `grok-imagine-image`, `grok-imagine-image-quality`, `grok-imagine-video`.
- `POST /v1/chat/completions` + `grok-4.5` — still 200 (no regression).
- `POST /v1/chat/completions` + `grok-imagine-image` — still 503 (image-only model correctly rejected on chat).
- `go build ./cmd/server` passes; no gofmt changes.
