### PR TITLE
feat(pluginhost): structured model errors and fail-closed request interceptors

### DIFF
--- a/internal/pluginhost/adapters.go
+++ b/internal/pluginhost/adapters.go
@@ -519,8 +519,11 @@ func (h *Host) callRequestInterceptor(ctx context.Context, record capabilityReco
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			h.fusePlugin(record.id, method, recovered)
-			out = pluginapi.RequestInterceptResponse{}
-			ok = false
+			out = pluginapi.RequestInterceptResponse{
+				Reject:       true,
+				RejectReason: "request interceptor panic: " + record.id,
+			}
+			ok = true
 		}
 	}()
 	resp, errIntercept := call(ctx, req)
@@ -610,6 +613,11 @@ func (h *Host) interceptRequest(ctx context.Context, req pluginapi.RequestInterc
 			current.Headers = mergeHeaders(current.Headers, resp.Headers, resp.ClearHeaders)
 			if len(resp.Body) > 0 {
 				current.Body = bytes.Clone(resp.Body)
+			}
+			if resp.Reject {
+				current.Reject = true
+				current.RejectReason = resp.RejectReason
+				break
 			}
 		}
 	}

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -3,6 +3,7 @@ package pluginhost
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1562,8 +1563,15 @@ func TestInterceptorsSkipErrorsAndFusePanics(t *testing.T) {
 	)
 
 	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("body")})
-	if string(got.Body) != "body|success" {
-		t.Fatalf("body = %q, want body|success", got.Body)
+	// Plain errors fail open, while panics fail closed and stop the chain.
+	if string(got.Body) != "body" {
+		t.Fatalf("body = %q, want body", got.Body)
+	}
+	if !got.Reject {
+		t.Fatal("panic request interceptor did not set Reject")
+	}
+	if got.RejectReason != "request interceptor panic: panic" {
+		t.Fatalf("RejectReason = %q, want \"request interceptor panic: panic\"", got.RejectReason)
 	}
 	if !host.isPluginFused("panic") {
 		t.Fatal("panic plugin was not fused")
@@ -3392,4 +3400,74 @@ func (failingReadCloser) Read(p []byte) (int, error) {
 
 func (failingReadCloser) Close() error {
 	return nil
+}
+
+func TestInterceptRequestRejectAbortsChain(t *testing.T) {
+	downstreamCalled := false
+	host := newHostWithRecords(
+		capabilityRecord{
+			id:       "reject",
+			priority: 20,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				RequestInterceptor: requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+					return pluginapi.RequestInterceptResponse{Reject: true, RejectReason: "policy denied"}, nil
+				}),
+			}},
+		},
+		capabilityRecord{
+			id:       "downstream",
+			priority: 10,
+			plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+				RequestInterceptor: requestInterceptorFunc(func(ctx context.Context, req pluginapi.RequestInterceptRequest) (pluginapi.RequestInterceptResponse, error) {
+					downstreamCalled = true
+					return pluginapi.RequestInterceptResponse{Body: append(req.Body, []byte("|downstream")...)}, nil
+				}),
+			}},
+		},
+	)
+
+	got := host.InterceptRequestBeforeAuth(context.Background(), pluginapi.RequestInterceptRequest{Body: []byte("body")})
+
+	if !got.Reject {
+		t.Fatal("expected Reject to propagate")
+	}
+	if got.RejectReason != "policy denied" {
+		t.Fatalf("RejectReason = %q, want %q", got.RejectReason, "policy denied")
+	}
+	if downstreamCalled {
+		t.Fatal("downstream interceptor ran after a rejection; chain was not aborted")
+	}
+}
+
+func TestRequestInterceptResponseRejectRoundTrip(t *testing.T) {
+	// The reject signal crosses the RPC boundary as JSON on pluginapi.RequestInterceptResponse.
+	original := pluginapi.RequestInterceptResponse{Reject: true, RejectReason: "policy denied"}
+
+	raw, errMarshal := json.Marshal(original)
+	if errMarshal != nil {
+		t.Fatalf("marshal RequestInterceptResponse: %v", errMarshal)
+	}
+	if !strings.Contains(string(raw), `"reject":true`) {
+		t.Fatalf("marshalled JSON missing reject field: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"reject_reason":"policy denied"`) {
+		t.Fatalf("marshalled JSON missing reject_reason field: %s", raw)
+	}
+
+	var decoded pluginapi.RequestInterceptResponse
+	if errUnmarshal := json.Unmarshal(raw, &decoded); errUnmarshal != nil {
+		t.Fatalf("unmarshal RequestInterceptResponse: %v", errUnmarshal)
+	}
+	if !decoded.Reject || decoded.RejectReason != "policy denied" {
+		t.Fatalf("round-trip lost reject fields: %+v", decoded)
+	}
+
+	// An empty rejection must omit both fields (omitempty) so unrelated responses stay unchanged.
+	empty, errEmpty := json.Marshal(pluginapi.RequestInterceptResponse{})
+	if errEmpty != nil {
+		t.Fatalf("marshal empty RequestInterceptResponse: %v", errEmpty)
+	}
+	if strings.Contains(string(empty), "reject") {
+		t.Fatalf("empty response should omit reject fields: %s", empty)
+	}
 }

--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
@@ -248,7 +249,9 @@ func (h *Host) callHostStreamEmit(ctx context.Context, request []byte) ([]byte, 
 		return nil, fmt.Errorf("decode stream emit request: %w", errUnmarshal)
 	}
 	chunk := pluginapi.ExecutorStreamChunk{Payload: append([]byte(nil), req.Payload...)}
-	if req.Error != "" {
+	if req.ErrorDetails != nil {
+		chunk.Err = newPluginStreamError(req.ErrorDetails, req.Error)
+	} else if req.Error != "" {
 		chunk.Err = fmt.Errorf("%s", req.Error)
 	}
 	if errEmit := h.streams.emit(ctx, req.StreamID, chunk); errEmit != nil {
@@ -262,7 +265,7 @@ func (h *Host) callHostStreamClose(request []byte) ([]byte, error) {
 	if errUnmarshal := json.Unmarshal(request, &req); errUnmarshal != nil {
 		return nil, fmt.Errorf("decode stream close request: %w", errUnmarshal)
 	}
-	h.streams.close(req.StreamID, req.Error)
+	h.streams.close(req.StreamID, req.Error, req.ErrorDetails)
 	return marshalRPCResult(rpcEmptyResponse{})
 }
 
@@ -282,7 +285,7 @@ func (h *Host) callHostModelExecute(ctx context.Context, request []byte) ([]byte
 	ctx = h.resolveCallbackContext(req.HostCallbackID, ctx)
 	resp, errMsg := executor.ExecuteModel(ctx, modelExecutionRequestFromPlugin(req.HostModelExecutionRequest, skipPluginID))
 	if errMsg != nil {
-		return nil, modelExecutionError(errMsg)
+		return marshalRPCResult(hostModelExecutionErrorResponse(errMsg))
 	}
 	return marshalRPCResult(pluginapi.HostModelExecutionResponse{
 		StatusCode: resp.StatusCode,
@@ -306,17 +309,129 @@ func modelExecutionRequestFromPlugin(req pluginapi.HostModelExecutionRequest, sk
 	}
 }
 
-func modelExecutionError(errMsg *interfaces.ErrorMessage) error {
+type pluginStreamError struct {
+	statusCode int
+	headers    httpHeader
+	body       []byte
+	message    string
+}
+
+func newPluginStreamError(details *pluginapi.HostModelError, fallback string) error {
+	if details == nil {
+		return fmt.Errorf("%s", fallback)
+	}
+	message := details.Message
+	if message == "" && len(details.Body) > 0 {
+		message = string(details.Body)
+	}
+	if message == "" {
+		message = fallback
+	}
+	if message == "" && details.StatusCode > 0 {
+		message = fmt.Sprintf("upstream returned status %d", details.StatusCode)
+	}
+	return &pluginStreamError{
+		statusCode: details.StatusCode,
+		headers:    httpHeader(cloneHeader(details.Headers)),
+		body:       append([]byte(nil), details.Body...),
+		message:    message,
+	}
+}
+
+func (e *pluginStreamError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if len(e.body) > 0 {
+		return string(e.body)
+	}
+	return e.message
+}
+
+func (e *pluginStreamError) StatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.statusCode
+}
+
+func (e *pluginStreamError) Headers() http.Header {
+	if e == nil {
+		return nil
+	}
+	return cloneHeader(http.Header(e.headers))
+}
+
+// hostModelExecutionErrorResponse builds a successful RPC result that carries a
+// structured model failure in Error. Callers must inspect Error/StatusCode.
+func hostModelExecutionErrorResponse(errMsg *interfaces.ErrorMessage) pluginapi.HostModelExecutionResponse {
+	details := hostModelErrorFromMessage(errMsg)
+	if details == nil {
+		return pluginapi.HostModelExecutionResponse{}
+	}
+	return pluginapi.HostModelExecutionResponse{
+		StatusCode: details.StatusCode,
+		Headers:    cloneHeader(details.Headers),
+		Body:       append([]byte(nil), details.Body...),
+		Error:      details,
+	}
+}
+
+// hostModelStreamErrorResponse builds a successful RPC result that carries a
+// structured stream-startup failure in Error. StreamID is left empty.
+func hostModelStreamErrorResponse(errMsg *interfaces.ErrorMessage) pluginapi.HostModelStreamResponse {
+	details := hostModelErrorFromMessage(errMsg)
+	if details == nil {
+		return pluginapi.HostModelStreamResponse{}
+	}
+	return pluginapi.HostModelStreamResponse{
+		StatusCode: details.StatusCode,
+		Headers:    cloneHeader(details.Headers),
+		Error:      details,
+	}
+}
+
+// hostModelErrorFromMessage maps interfaces.ErrorMessage into HostModelError.
+// Body is filled from the error string when no raw upstream body is available.
+func hostModelErrorFromMessage(errMsg *interfaces.ErrorMessage) *pluginapi.HostModelError {
 	if errMsg == nil {
 		return nil
 	}
+	message := ""
 	if errMsg.Error != nil {
-		return errMsg.Error
+		message = errMsg.Error.Error()
 	}
-	if errMsg.StatusCode > 0 {
-		return fmt.Errorf("model execution failed with status %d", errMsg.StatusCode)
+	if message == "" && errMsg.StatusCode > 0 {
+		message = fmt.Sprintf("model execution failed with status %d", errMsg.StatusCode)
 	}
-	return fmt.Errorf("model execution failed")
+	return &pluginapi.HostModelError{
+		StatusCode: errMsg.StatusCode,
+		Headers:    cloneHeader(errMsg.Addon),
+		Body:       []byte(message),
+		Message:    message,
+	}
+}
+
+func hostModelErrorFromError(err error) *pluginapi.HostModelError {
+	if err == nil {
+		return nil
+	}
+	message := err.Error()
+	details := &pluginapi.HostModelError{
+		Body:    []byte(message),
+		Message: message,
+	}
+	if statusErr, ok := err.(interface{ StatusCode() int }); ok {
+		details.StatusCode = statusErr.StatusCode()
+	}
+	if headerErr, ok := err.(interface{ Headers() http.Header }); ok {
+		details.Headers = cloneHeader(headerErr.Headers())
+	}
+	if streamErr, ok := err.(*handlers.ModelExecutionStreamError); ok && streamErr != nil {
+		details.StatusCode = streamErr.StatusCode
+		details.Headers = cloneHeader(streamErr.Headers)
+	}
+	return details
 }
 
 func (h *Host) callHostLog(ctx context.Context, request []byte) ([]byte, error) {

--- a/internal/pluginhost/host_callbacks_test.go
+++ b/internal/pluginhost/host_callbacks_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -233,6 +234,49 @@ func TestHostStreamCallbacksEmitAndClose(t *testing.T) {
 	}
 }
 
+func TestHostStreamEmitPreservesStructuredError(t *testing.T) {
+	host := New()
+	streamID, chunks, cleanup := host.streams.open(context.Background())
+	defer cleanup()
+
+	upstreamBody := `{"error":{"message":"quota","code":"rate_limit"}}`
+	emitReq, errMarshal := json.Marshal(rpcStreamEmitRequest{
+		StreamID: streamID,
+		Error:    upstreamBody,
+		ErrorDetails: &pluginapi.HostModelError{
+			StatusCode: http.StatusTooManyRequests,
+			Headers:    http.Header{"Retry-After": []string{"5"}},
+			Body:       []byte(upstreamBody),
+			Message:    upstreamBody,
+		},
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal emit request: %v", errMarshal)
+	}
+	if _, errEmit := host.callFromPlugin(context.Background(), pluginabi.MethodHostStreamEmit, emitReq); errEmit != nil {
+		t.Fatalf("emit callback error = %v", errEmit)
+	}
+
+	chunk, ok := <-chunks
+	if !ok {
+		t.Fatal("stream closed before structured error chunk")
+	}
+	if len(chunk.Payload) != 0 || chunk.Err == nil {
+		t.Fatalf("chunk = %#v, want structured error without payload", chunk)
+	}
+	statusErr, ok := chunk.Err.(interface{ StatusCode() int })
+	if !ok || statusErr.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("chunk error status = %#v, want 429", chunk.Err)
+	}
+	headerErr, ok := chunk.Err.(interface{ Headers() http.Header })
+	if !ok || headerErr.Headers().Get("Retry-After") != "5" {
+		t.Fatalf("chunk error headers = %#v, want retry-after", chunk.Err)
+	}
+	if chunk.Err.Error() != upstreamBody {
+		t.Fatalf("chunk error body = %q, want upstream body", chunk.Err.Error())
+	}
+}
+
 func TestHostModelExecuteCallback(t *testing.T) {
 	host := New()
 	var got handlers.ModelExecutionRequest
@@ -290,6 +334,49 @@ func TestHostModelExecuteCallback(t *testing.T) {
 	}
 	if got.Alt != "raw" {
 		t.Fatalf("alt = %q, want raw", got.Alt)
+	}
+}
+
+func TestHostModelExecuteCallbackReturnsStructuredUpstreamError(t *testing.T) {
+	host := New()
+	upstreamBody := `{"error":{"message":"quota","code":"rate_limit"}}`
+	host.SetModelExecutor(&fakeHostModelExecutor{
+		executeModel: func(ctx context.Context, req handlers.ModelExecutionRequest) (handlers.ModelExecutionResponse, *interfaces.ErrorMessage) {
+			return handlers.ModelExecutionResponse{}, &interfaces.ErrorMessage{
+				StatusCode: http.StatusTooManyRequests,
+				Error:      errors.New(upstreamBody),
+				Addon:      http.Header{"Retry-After": []string{"5"}},
+			}
+		},
+	})
+
+	rawReq, errMarshal := json.Marshal(pluginapi.HostModelExecutionRequest{
+		EntryProtocol: "openai",
+		ExitProtocol:  "openai",
+		Model:         "model-1",
+		Body:          []byte(`{"request":true}`),
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostModelExecute, rawReq)
+	if errCall != nil {
+		t.Fatalf("callFromPlugin() error = %v", errCall)
+	}
+
+	resp, errDecode := decodeRPCEnvelope[pluginapi.HostModelExecutionResponse](rawResp)
+	if errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests ||
+		resp.Headers.Get("Retry-After") != "5" ||
+		string(resp.Body) != upstreamBody ||
+		resp.Error == nil ||
+		resp.Error.StatusCode != http.StatusTooManyRequests ||
+		resp.Error.Headers.Get("Retry-After") != "5" ||
+		string(resp.Error.Body) != upstreamBody ||
+		resp.Error.Message != upstreamBody {
+		t.Fatalf("response = %#v, want structured upstream error", resp)
 	}
 }
 
@@ -456,11 +543,14 @@ func TestHostModelStreamReadAfterCallbackCloseReturnsDone(t *testing.T) {
 func TestHostModelExecuteStreamStartupErrorCleansUp(t *testing.T) {
 	host := New()
 	ctxSeen := make(chan context.Context, 1)
+	upstreamBody := `{"error":{"message":"quota","code":"rate_limit"}}`
 	host.SetModelExecutor(&fakeHostModelExecutor{
 		executeModelStream: func(ctx context.Context, req handlers.ModelExecutionRequest) (handlers.ModelExecutionStream, *interfaces.ErrorMessage) {
 			ctxSeen <- ctx
 			return handlers.ModelExecutionStream{}, &interfaces.ErrorMessage{
-				StatusCode: http.StatusBadGateway,
+				StatusCode: http.StatusTooManyRequests,
+				Error:      errors.New(upstreamBody),
+				Addon:      http.Header{"Retry-After": []string{"5"}},
 			}
 		},
 	})
@@ -476,14 +566,22 @@ func TestHostModelExecuteStreamStartupErrorCleansUp(t *testing.T) {
 		t.Fatalf("marshal request: %v", errMarshal)
 	}
 	rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostModelExecuteStream, rawReq)
-	if errCall == nil {
-		t.Fatalf("execute stream callback error is nil, raw response = %q", rawResp)
+	if errCall != nil {
+		t.Fatalf("execute stream callback error = %v", errCall)
 	}
-	if rawResp != nil {
-		t.Fatalf("raw response = %q, want nil on startup error", rawResp)
+	resp, errDecode := decodeRPCEnvelope[pluginapi.HostModelStreamResponse](rawResp)
+	if errDecode != nil {
+		t.Fatalf("decode stream response: %v", errDecode)
 	}
-	if !strings.Contains(errCall.Error(), "status 502") {
-		t.Fatalf("execute stream callback error = %v, want status 502", errCall)
+	if resp.StreamID != "" ||
+		resp.StatusCode != http.StatusTooManyRequests ||
+		resp.Headers.Get("Retry-After") != "5" ||
+		resp.Error == nil ||
+		resp.Error.StatusCode != http.StatusTooManyRequests ||
+		resp.Error.Headers.Get("Retry-After") != "5" ||
+		string(resp.Error.Body) != upstreamBody ||
+		resp.Error.Message != upstreamBody {
+		t.Fatalf("stream response = %#v, want structured startup error", resp)
 	}
 
 	var streamCtx context.Context
@@ -599,6 +697,7 @@ func TestHostModelStreamReadReturnsPayloadAndTerminalError(t *testing.T) {
 	chunks <- handlers.ModelExecutionChunk{Err: &handlers.ModelExecutionStreamError{
 		StatusCode: http.StatusBadGateway,
 		Message:    "terminal boom",
+		Headers:    http.Header{"Retry-After": []string{"5"}},
 	}}
 	host.SetModelExecutor(&fakeHostModelExecutor{
 		executeModelStream: func(ctx context.Context, req handlers.ModelExecutionRequest) (handlers.ModelExecutionStream, *interfaces.ErrorMessage) {
@@ -635,7 +734,14 @@ func TestHostModelStreamReadReturnsPayloadAndTerminalError(t *testing.T) {
 	if errDecode != nil {
 		t.Fatalf("decode terminal response: %v", errDecode)
 	}
-	if !terminal.Done || terminal.Error != "terminal boom" || len(terminal.Payload) != 0 {
+	if !terminal.Done ||
+		terminal.Error != "terminal boom" ||
+		len(terminal.Payload) != 0 ||
+		terminal.ErrorDetails == nil ||
+		terminal.ErrorDetails.StatusCode != http.StatusBadGateway ||
+		terminal.ErrorDetails.Headers.Get("Retry-After") != "5" ||
+		string(terminal.ErrorDetails.Body) != "terminal boom" ||
+		terminal.ErrorDetails.Message != "terminal boom" {
 		t.Fatalf("terminal read = %#v, want done terminal error", terminal)
 	}
 }

--- a/internal/pluginhost/host_model_stream_callbacks.go
+++ b/internal/pluginhost/host_model_stream_callbacks.go
@@ -30,7 +30,7 @@ func (h *Host) callHostModelExecuteStream(ctx context.Context, request []byte) (
 	stream, errMsg := executor.ExecuteModelStream(streamCtx, modelExecutionRequestFromPlugin(req.HostModelExecutionRequest, skipPluginID))
 	if errMsg != nil {
 		cancel()
-		return nil, modelExecutionError(errMsg)
+		return marshalRPCResult(hostModelStreamErrorResponse(errMsg))
 	}
 	streamID := ""
 	if h.modelStreams != nil {
@@ -70,6 +70,7 @@ func (h *Host) callHostModelStreamRead(ctx context.Context, request []byte) ([]b
 	}
 	if chunk.Err != nil {
 		resp.Error = chunk.Err.Error()
+		resp.ErrorDetails = hostModelErrorFromError(chunk.Err)
 		resp.Done = true
 	}
 	return marshalRPCResult(resp)

--- a/internal/pluginhost/stream_bridge.go
+++ b/internal/pluginhost/stream_bridge.go
@@ -10,25 +10,35 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
 
+// streamPayloadBuffer is how many payload chunks may be queued before emit
+// waits for the consumer. The raw channel capacity is one larger so close can
+// always enqueue a terminal error without timers or dropping it.
+const streamPayloadBuffer = 16
+
 type streamBridge struct {
 	next    atomic.Uint64
 	mu      sync.Mutex
+	space   *sync.Cond
 	streams map[string]chan pluginapi.ExecutorStreamChunk
 }
 
 type rpcStreamEmitRequest struct {
-	StreamID string `json:"stream_id"`
-	Payload  []byte `json:"payload,omitempty"`
-	Error    string `json:"error,omitempty"`
+	StreamID     string                    `json:"stream_id"`
+	Payload      []byte                    `json:"payload,omitempty"`
+	Error        string                    `json:"error,omitempty"`
+	ErrorDetails *pluginapi.HostModelError `json:"error_details,omitempty"`
 }
 
 type rpcStreamCloseRequest struct {
-	StreamID string `json:"stream_id"`
-	Error    string `json:"error,omitempty"`
+	StreamID     string                    `json:"stream_id"`
+	Error        string                    `json:"error,omitempty"`
+	ErrorDetails *pluginapi.HostModelError `json:"error_details,omitempty"`
 }
 
 func newStreamBridge() *streamBridge {
-	return &streamBridge{streams: make(map[string]chan pluginapi.ExecutorStreamChunk)}
+	b := &streamBridge{streams: make(map[string]chan pluginapi.ExecutorStreamChunk)}
+	b.space = sync.NewCond(&b.mu)
+	return b
 }
 
 func (b *streamBridge) open(ctx context.Context) (string, <-chan pluginapi.ExecutorStreamChunk, func()) {
@@ -38,56 +48,118 @@ func (b *streamBridge) open(ctx context.Context) (string, <-chan pluginapi.Execu
 		return "", chunks, func() {}
 	}
 	id := strconv.FormatUint(b.next.Add(1), 10)
-	chunks := make(chan pluginapi.ExecutorStreamChunk, 16)
+	// +1 slot reserved for close's terminal error (emit never fills it).
+	raw := make(chan pluginapi.ExecutorStreamChunk, streamPayloadBuffer+1)
+	out := make(chan pluginapi.ExecutorStreamChunk)
+	abort := make(chan struct{})
+	relayDone := make(chan struct{})
 	b.mu.Lock()
-	b.streams[id] = chunks
+	b.streams[id] = raw
 	b.mu.Unlock()
+
+	// Relay raw -> out and wake emitters after each delivery so emit can use
+	// the payload slots freed by the consumer (without polling or timers).
+	go func() {
+		defer close(relayDone)
+		defer close(out)
+		for {
+			var chunk pluginapi.ExecutorStreamChunk
+			var ok bool
+			select {
+			case <-abort:
+				return
+			case chunk, ok = <-raw:
+				if !ok {
+					return
+				}
+			}
+			select {
+			case <-abort:
+				return
+			case out <- chunk:
+			}
+			b.mu.Lock()
+			b.space.Broadcast()
+			b.mu.Unlock()
+		}
+	}()
+
+	var abortOnce sync.Once
 	cleanup := func() {
-		b.close(id, "")
+		abortOnce.Do(func() { close(abort) })
+		b.close(id, "", nil)
+		<-relayDone
 	}
 	if ctx != nil && ctx.Done() != nil {
 		go func() {
-			<-ctx.Done()
-			b.close(id, ctx.Err().Error())
+			select {
+			case <-ctx.Done():
+				cleanup()
+			case <-abort:
+			}
 		}()
 	}
-	return id, chunks, cleanup
+	return id, out, cleanup
 }
 
 func (b *streamBridge) emit(ctx context.Context, id string, chunk pluginapi.ExecutorStreamChunk) error {
 	if b == nil || id == "" {
 		return fmt.Errorf("stream id is required")
 	}
-	b.mu.Lock()
-	chunks := b.streams[id]
-	b.mu.Unlock()
-	if chunks == nil {
-		return fmt.Errorf("stream %s is not open", id)
-	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case chunks <- chunk:
-		return nil
+
+	// Wake Cond waiters when the request context is canceled (no stream timer).
+	stop := context.AfterFunc(ctx, func() {
+		b.mu.Lock()
+		b.space.Broadcast()
+		b.mu.Unlock()
+	})
+	if stop != nil {
+		defer stop()
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for {
+		raw := b.streams[id]
+		if raw == nil {
+			return fmt.Errorf("stream %s is not open", id)
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// Keep one slot free so close can always deliver a terminal error.
+		if len(raw) < streamPayloadBuffer {
+			raw <- chunk
+			return nil
+		}
+		b.space.Wait()
 	}
 }
 
-func (b *streamBridge) close(id string, errorMessage string) {
+func (b *streamBridge) close(id string, errorMessage string, errorDetails *pluginapi.HostModelError) {
 	if b == nil || id == "" {
 		return
 	}
 	b.mu.Lock()
-	chunks := b.streams[id]
+	raw := b.streams[id]
 	delete(b.streams, id)
+	if raw != nil {
+		// emit never occupies the reserved slot, so this send cannot block and
+		// cannot be overtaken by a concurrent emit (both hold b.mu).
+		if errorDetails != nil || errorMessage != "" {
+			var err error
+			if errorDetails != nil {
+				err = newPluginStreamError(errorDetails, errorMessage)
+			} else {
+				err = fmt.Errorf("%s", errorMessage)
+			}
+			raw <- pluginapi.ExecutorStreamChunk{Err: err}
+		}
+		close(raw)
+	}
+	b.space.Broadcast()
 	b.mu.Unlock()
-	if chunks == nil {
-		return
-	}
-	if errorMessage != "" {
-		chunks <- pluginapi.ExecutorStreamChunk{Err: fmt.Errorf("%s", errorMessage)}
-	}
-	close(chunks)
 }

--- a/internal/pluginhost/stream_bridge_test.go
+++ b/internal/pluginhost/stream_bridge_test.go
@@ -1,0 +1,171 @@
+package pluginhost
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func TestStreamBridgeCloseDeliversTerminalErrorWhenBufferFull(t *testing.T) {
+	bridge := newStreamBridge()
+	id, chunks, cleanup := bridge.open(context.Background())
+	defer cleanup()
+
+	for i := 0; i < streamPayloadBuffer; i++ {
+		if err := bridge.emit(context.Background(), id, pluginapi.ExecutorStreamChunk{Payload: []byte("p")}); err != nil {
+			t.Fatalf("emit %d: %v", i, err)
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		bridge.close(id, "upstream failed", &pluginapi.HostModelError{
+			StatusCode: http.StatusBadGateway,
+			Message:    "upstream failed",
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("close hung with a full payload buffer")
+	}
+
+	var sawTerminal bool
+	var payloads int
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case chunk, ok := <-chunks:
+			if !ok {
+				if !sawTerminal {
+					t.Fatal("stream closed with clean EOF; terminal error was dropped")
+				}
+				if payloads != streamPayloadBuffer {
+					t.Fatalf("payloads = %d, want %d", payloads, streamPayloadBuffer)
+				}
+				return
+			}
+			if chunk.Err != nil {
+				sawTerminal = true
+				if se, ok := chunk.Err.(interface{ StatusCode() int }); !ok || se.StatusCode() != http.StatusBadGateway {
+					t.Fatalf("terminal error = %#v, want status 502", chunk.Err)
+				}
+			} else {
+				payloads++
+			}
+		case <-deadline:
+			t.Fatal("timed out draining stream")
+		}
+	}
+}
+
+func TestStreamBridgeCleanupStopsRelayWithoutConsumer(t *testing.T) {
+	bridge := newStreamBridge()
+	id, chunks, cleanup := bridge.open(context.Background())
+
+	if err := bridge.emit(context.Background(), id, pluginapi.ExecutorStreamChunk{Payload: []byte("pending")}); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	cleanup()
+
+	select {
+	case chunk, ok := <-chunks:
+		if ok {
+			t.Fatalf("chunk after cleanup = %#v, want closed stream", chunk)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("relay did not stop after cleanup")
+	}
+}
+
+func TestStreamBridgeEmitStopsAfterClose(t *testing.T) {
+	bridge := newStreamBridge()
+	id, chunks, _ := bridge.open(context.Background())
+
+	bridge.close(id, "closed", nil)
+	if err := bridge.emit(context.Background(), id, pluginapi.ExecutorStreamChunk{Payload: []byte("late")}); err == nil {
+		t.Fatal("emit after close should fail")
+	}
+
+	var sawErr bool
+	for chunk := range chunks {
+		if chunk.Err != nil {
+			sawErr = true
+		}
+	}
+	if !sawErr {
+		t.Fatal("expected terminal error from close")
+	}
+}
+
+func TestStreamBridgeConcurrentEmitDuringClose(t *testing.T) {
+	bridge := newStreamBridge()
+	id, chunks, _ := bridge.open(context.Background())
+
+	for i := 0; i < streamPayloadBuffer; i++ {
+		if err := bridge.emit(context.Background(), id, pluginapi.ExecutorStreamChunk{Payload: []byte("p")}); err != nil {
+			t.Fatalf("emit %d: %v", i, err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_ = bridge.emit(context.Background(), id, pluginapi.ExecutorStreamChunk{Payload: []byte("extra")})
+	}()
+	go func() {
+		defer wg.Done()
+		bridge.close(id, "boom", &pluginapi.HostModelError{StatusCode: http.StatusBadGateway, Message: "boom"})
+	}()
+	wg.Wait()
+
+	var sawTerminal bool
+	for chunk := range chunks {
+		if chunk.Err != nil {
+			sawTerminal = true
+		}
+	}
+	if !sawTerminal {
+		t.Fatal("expected terminal error to survive concurrent emit")
+	}
+}
+
+func TestStreamBridgeEmitUnblocksWhenConsumerDrains(t *testing.T) {
+	bridge := newStreamBridge()
+	id, chunks, cleanup := bridge.open(context.Background())
+	defer cleanup()
+
+	for i := 0; i < streamPayloadBuffer; i++ {
+		if err := bridge.emit(context.Background(), id, pluginapi.ExecutorStreamChunk{Payload: []byte("p")}); err != nil {
+			t.Fatalf("emit %d: %v", i, err)
+		}
+	}
+
+	emitDone := make(chan error, 1)
+	go func() {
+		emitDone <- bridge.emit(context.Background(), id, pluginapi.ExecutorStreamChunk{Payload: []byte("more")})
+	}()
+
+	// Consumer drains one payload so the blocked emit can use a free slot.
+	select {
+	case <-chunks:
+	case <-time.After(time.Second):
+		t.Fatal("timed out reading first payload")
+	}
+
+	select {
+	case err := <-emitDone:
+		if err != nil {
+			t.Fatalf("emit after drain: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("emit stayed blocked after consumer drained")
+	}
+}

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -759,7 +759,11 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 		RequestAfterAuthInterceptor: h.requestAfterAuthInterceptor(afterAuthCapture, execOptions.SkipInterceptorPluginID),
 	}
 	opts.Metadata = reqMeta
-	req, opts = h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	newReq, newOpts, rejectErr := h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	if rejectErr != nil {
+		return nil, nil, rejectErr
+	}
+	req, opts = newReq, newOpts
 	resp, err := h.AuthManager.Execute(ctx, providers, req, opts)
 	if err != nil {
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
@@ -825,7 +829,11 @@ func (h *BaseAPIHandler) executeCountWithAuthManager(ctx context.Context, handle
 		RequestAfterAuthInterceptor: h.requestAfterAuthInterceptor(afterAuthCapture, execOptions.SkipInterceptorPluginID),
 	}
 	opts.Metadata = reqMeta
-	req, opts = h.applyRequestInterceptorsBeforeAuth(ctx, handlerType, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	newReq, newOpts, rejectErr := h.applyRequestInterceptorsBeforeAuth(ctx, handlerType, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	if rejectErr != nil {
+		return nil, nil, rejectErr
+	}
+	req, opts = newReq, newOpts
 	resp, err := h.AuthManager.ExecuteCount(ctx, providers, req, opts)
 	if err != nil {
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
@@ -856,8 +864,16 @@ func (h *BaseAPIHandler) executeWithPluginExecutor(ctx context.Context, entryPro
 		return nil, nil, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("plugin executor host is unavailable")}
 	}
 	req, opts := h.pluginExecutorRequest(ctx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, false, execOptions)
-	req, opts = h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
-	req, opts = h.applyRequestInterceptorsAfterPluginExecutorRoute(ctx, host, executorPluginID, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	newReq, newOpts, rejectErr := h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	if rejectErr != nil {
+		return nil, nil, rejectErr
+	}
+	req, opts = newReq, newOpts
+	newReq, newOpts, rejectErr = h.applyRequestInterceptorsAfterPluginExecutorRoute(ctx, host, executorPluginID, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	if rejectErr != nil {
+		return nil, nil, rejectErr
+	}
+	req, opts = newReq, newOpts
 	resp, errExecute := host.ExecutePluginExecutor(ctx, executorPluginID, req, opts)
 	if errExecute != nil {
 		return nil, nil, executionErrorMessage(errExecute)
@@ -874,8 +890,16 @@ func (h *BaseAPIHandler) countWithPluginExecutor(ctx context.Context, handlerTyp
 		return nil, nil, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("plugin executor host is unavailable")}
 	}
 	req, opts := h.pluginExecutorRequest(ctx, handlerType, handlerType, modelName, originalRequestedModel, rawJSON, alt, false, execOptions)
-	req, opts = h.applyRequestInterceptorsBeforeAuth(ctx, handlerType, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
-	req, opts = h.applyRequestInterceptorsAfterPluginExecutorRoute(ctx, host, executorPluginID, handlerType, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	newReq, newOpts, rejectErr := h.applyRequestInterceptorsBeforeAuth(ctx, handlerType, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	if rejectErr != nil {
+		return nil, nil, rejectErr
+	}
+	req, opts = newReq, newOpts
+	newReq, newOpts, rejectErr = h.applyRequestInterceptorsAfterPluginExecutorRoute(ctx, host, executorPluginID, handlerType, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	if rejectErr != nil {
+		return nil, nil, rejectErr
+	}
+	req, opts = newReq, newOpts
 	resp, errCount := host.CountPluginExecutor(ctx, executorPluginID, req, opts)
 	if errCount != nil {
 		return nil, nil, executionErrorMessage(errCount)
@@ -911,9 +935,9 @@ func (h *BaseAPIHandler) pluginExecutorRequest(ctx context.Context, entryProtoco
 	return req, opts
 }
 
-func (h *BaseAPIHandler) applyRequestInterceptorsAfterPluginExecutorRoute(ctx context.Context, host PluginExecutorHost, executorPluginID, entryProtocol, originalRequestedModel string, req coreexecutor.Request, opts coreexecutor.Options, skipPluginID string) (coreexecutor.Request, coreexecutor.Options) {
+func (h *BaseAPIHandler) applyRequestInterceptorsAfterPluginExecutorRoute(ctx context.Context, host PluginExecutorHost, executorPluginID, entryProtocol, originalRequestedModel string, req coreexecutor.Request, opts coreexecutor.Options, skipPluginID string) (coreexecutor.Request, coreexecutor.Options, *interfaces.ErrorMessage) {
 	if !requestInterceptorsEnabled(h.interceptorHost()) {
-		return req, opts
+		return req, opts, nil
 	}
 	toFormat := sdktranslator.FromString(entryProtocol)
 	if resolver, ok := host.(pluginExecutorFormatResolver); ok && resolver != nil {
@@ -931,12 +955,19 @@ func (h *BaseAPIHandler) applyRequestInterceptorsAfterPluginExecutorRoute(ctx co
 		Body:           cloneBytes(req.Payload),
 		Metadata:       opts.Metadata,
 	}, skipPluginID)
+	if resp.Reject {
+		// Keep original req/opts so partial interceptor mutations are not applied.
+		return req, opts, &interfaces.ErrorMessage{
+			StatusCode: http.StatusForbidden,
+			Error:      fmt.Errorf("request rejected by plugin: %s", resp.RejectReason),
+		}
+	}
 	opts.Headers = mergeRequestInterceptorHeaders(opts.Headers, resp.Headers, resp.ClearHeaders)
 	if len(resp.Body) > 0 {
 		req.Payload = cloneBytes(resp.Body)
 		opts.OriginalRequest = cloneBytes(resp.Body)
 	}
-	return req, opts
+	return req, opts, nil
 }
 
 func executionErrorMessage(err error) *interfaces.ErrorMessage {
@@ -976,8 +1007,22 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 		return nil, nil, errChan
 	}
 	req, opts := h.pluginExecutorRequest(ctx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, true, execOptions)
-	req, opts = h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
-	req, opts = h.applyRequestInterceptorsAfterPluginExecutorRoute(ctx, host, executorPluginID, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	newReq, newOpts, rejectErr := h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	if rejectErr != nil {
+		errChan := make(chan *interfaces.ErrorMessage, 1)
+		errChan <- rejectErr
+		close(errChan)
+		return nil, nil, errChan
+	}
+	req, opts = newReq, newOpts
+	newReq, newOpts, rejectErr = h.applyRequestInterceptorsAfterPluginExecutorRoute(ctx, host, executorPluginID, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	if rejectErr != nil {
+		errChan := make(chan *interfaces.ErrorMessage, 1)
+		errChan <- rejectErr
+		close(errChan)
+		return nil, nil, errChan
+	}
+	req, opts = newReq, newOpts
 	streamResult, errStream := host.ExecutePluginExecutorStream(ctx, executorPluginID, req, opts)
 	if errStream != nil {
 		errChan := make(chan *interfaces.ErrorMessage, 1)
@@ -1160,7 +1205,14 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		RequestAfterAuthInterceptor: h.requestAfterAuthInterceptor(afterAuthCapture, execOptions.SkipInterceptorPluginID),
 	}
 	opts.Metadata = reqMeta
-	req, opts = h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	newReq, newOpts, rejectErr := h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	if rejectErr != nil {
+		errChan := make(chan *interfaces.ErrorMessage, 1)
+		errChan <- rejectErr
+		close(errChan)
+		return nil, nil, errChan
+	}
+	req, opts = newReq, newOpts
 	streamResult, err := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
 	if err != nil {
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
@@ -2045,10 +2097,10 @@ func interceptStreamChunk(ctx context.Context, host PluginInterceptorHost, req p
 	return host.InterceptStreamChunk(ctx, req)
 }
 
-func (h *BaseAPIHandler) applyRequestInterceptorsBeforeAuth(ctx context.Context, handlerType, requestedModel string, req coreexecutor.Request, opts coreexecutor.Options, skipPluginID string) (coreexecutor.Request, coreexecutor.Options) {
+func (h *BaseAPIHandler) applyRequestInterceptorsBeforeAuth(ctx context.Context, handlerType, requestedModel string, req coreexecutor.Request, opts coreexecutor.Options, skipPluginID string) (coreexecutor.Request, coreexecutor.Options, *interfaces.ErrorMessage) {
 	host := h.interceptorHost()
 	if host == nil {
-		return req, opts
+		return req, opts, nil
 	}
 	resp := interceptRequestBeforeAuth(ctx, host, pluginapi.RequestInterceptRequest{
 		SourceFormat:   handlerType,
@@ -2059,12 +2111,18 @@ func (h *BaseAPIHandler) applyRequestInterceptorsBeforeAuth(ctx context.Context,
 		Body:           cloneBytes(req.Payload),
 		Metadata:       opts.Metadata,
 	}, skipPluginID)
+	if resp.Reject {
+		return req, opts, &interfaces.ErrorMessage{
+			StatusCode: http.StatusForbidden,
+			Error:      fmt.Errorf("request rejected by plugin: %s", resp.RejectReason),
+		}
+	}
 	opts.Headers = finalInterceptorHeaders(opts.Headers, resp.Headers)
 	if len(resp.Body) > 0 {
 		req.Payload = cloneBytes(resp.Body)
 		opts.OriginalRequest = cloneBytes(resp.Body)
 	}
-	return req, opts
+	return req, opts, nil
 }
 
 func (h *BaseAPIHandler) requestAfterAuthInterceptor(capture *requestAfterAuthCapture, skipPluginID string) coreexecutor.RequestAfterAuthInterceptor {
@@ -2099,6 +2157,8 @@ func (h *BaseAPIHandler) applyRequestInterceptorsAfterAuth(ctx context.Context, 
 		Headers:      resp.Headers,
 		Body:         resp.Body,
 		ClearHeaders: resp.ClearHeaders,
+		Reject:       resp.Reject,
+		RejectReason: resp.RejectReason,
 	}
 }
 

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 
@@ -365,6 +366,80 @@ func TestHandlerRequestInterceptorAfterAuthRewritesExecutorRequest(t *testing.T)
 	}
 	if !responseChecked {
 		t.Fatal("response interceptor was not called")
+	}
+}
+
+func TestApplyRequestInterceptorsBeforeAuthRejectReturns403(t *testing.T) {
+	handler := &BaseAPIHandler{}
+	handler.SetPluginHost(&handlerInterceptorTestHost{
+		interceptRequestBeforeAuth: func(context.Context, pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
+			return pluginapi.RequestInterceptResponse{Reject: true, RejectReason: "policy denied"}
+		},
+	})
+
+	req := coreexecutor.Request{Model: "gpt", Payload: []byte("body")}
+	opts := coreexecutor.Options{}
+	outReq, _, rejectErr := handler.applyRequestInterceptorsBeforeAuth(context.Background(), "openai", "gpt", req, opts, "")
+
+	if rejectErr == nil {
+		t.Fatal("expected a rejection ErrorMessage from the before-auth interceptors")
+	}
+	if rejectErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("StatusCode = %d, want %d", rejectErr.StatusCode, http.StatusForbidden)
+	}
+	if rejectErr.Error == nil || !strings.Contains(rejectErr.Error.Error(), "policy denied") {
+		t.Fatalf("Error = %v, want reason substring %q", rejectErr.Error, "policy denied")
+	}
+	if !strings.Contains(rejectErr.Error.Error(), "request rejected by plugin") {
+		t.Fatalf("Error = %v, want prefix %q", rejectErr.Error, "request rejected by plugin")
+	}
+	if string(outReq.Payload) != "body" {
+		t.Fatalf("Payload = %q, want original body on reject", outReq.Payload)
+	}
+}
+
+func TestApplyRequestInterceptorsAfterPluginExecutorRouteRejectReturns403(t *testing.T) {
+	handler := &BaseAPIHandler{}
+	handler.SetPluginHost(&handlerInterceptorTestHost{
+		interceptRequestAfterAuth: func(context.Context, pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
+			return pluginapi.RequestInterceptResponse{
+				Reject:       true,
+				RejectReason: "policy denied",
+				Body:         []byte("should-not-be-applied"),
+			}
+		},
+	})
+
+	req := coreexecutor.Request{Model: "gpt", Payload: []byte("body")}
+	opts := coreexecutor.Options{}
+	outReq, outOpts, rejectErr := handler.applyRequestInterceptorsAfterPluginExecutorRoute(
+		context.Background(),
+		nil,
+		"executor-plugin",
+		"openai",
+		"gpt",
+		req,
+		opts,
+		"",
+	)
+
+	if rejectErr == nil {
+		t.Fatal("expected a rejection ErrorMessage from the plugin-executor after-auth path")
+	}
+	if rejectErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("StatusCode = %d, want %d", rejectErr.StatusCode, http.StatusForbidden)
+	}
+	if rejectErr.Error == nil || !strings.Contains(rejectErr.Error.Error(), "policy denied") {
+		t.Fatalf("Error = %v, want reason substring %q", rejectErr.Error, "policy denied")
+	}
+	if !strings.Contains(rejectErr.Error.Error(), "request rejected by plugin") {
+		t.Fatalf("Error = %v, want prefix %q", rejectErr.Error, "request rejected by plugin")
+	}
+	if string(outReq.Payload) != "body" {
+		t.Fatalf("Payload = %q, want original body (mutations discarded on reject)", outReq.Payload)
+	}
+	if string(outOpts.OriginalRequest) == "should-not-be-applied" {
+		t.Fatalf("OriginalRequest was mutated on reject: %q", outOpts.OriginalRequest)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1841,7 +1841,10 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			execReq.Model = executionModel
 		}
 		execOpts := opts
-		execReq, execOpts = applyRequestAfterAuthInterceptor(ctx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+		execReq, execOpts, errAfterAuth := applyRequestAfterAuthInterceptor(ctx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+		if errAfterAuth != nil {
+			return nil, errAfterAuth
+		}
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, execOpts)
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
@@ -2429,9 +2432,9 @@ type requestToFormatResolver interface {
 	RequestToFormat(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format
 }
 
-func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExecutor, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, requestedModel string) (cliproxyexecutor.Request, cliproxyexecutor.Options) {
+func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExecutor, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, requestedModel string) (cliproxyexecutor.Request, cliproxyexecutor.Options, error) {
 	if opts.RequestAfterAuthInterceptor == nil {
-		return req, opts
+		return req, opts, nil
 	}
 	toFormat := requestToFormat(provider, executor, req, opts)
 	resp := opts.RequestAfterAuthInterceptor(ctx, cliproxyexecutor.RequestAfterAuthInterceptRequest{
@@ -2444,12 +2447,21 @@ func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExec
 		Body:           bytes.Clone(req.Payload),
 		Metadata:       opts.Metadata,
 	})
+	if resp.Reject {
+		// Terminal policy rejection: do not cool credentials or retry other auths.
+		return req, opts, &Error{
+			Code:       "request_rejected_by_plugin",
+			Message:    resp.RejectReason,
+			HTTPStatus: http.StatusForbidden,
+			Retryable:  false,
+		}
+	}
 	opts.Headers = mergeRequestHeaders(opts.Headers, resp.Headers, resp.ClearHeaders)
 	if len(resp.Body) > 0 {
 		req.Payload = bytes.Clone(resp.Body)
 		opts.OriginalRequest = bytes.Clone(resp.Body)
 	}
-	return req, opts
+	return req, opts, nil
 }
 
 func requestToFormat(provider string, executor ProviderExecutor, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format {
@@ -2585,7 +2597,10 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				execReq.Model = executionModel
 			}
 			execOpts := opts
-			execReq, execOpts = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			execReq, execOpts, errAfterAuth := applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			if errAfterAuth != nil {
+				return cliproxyexecutor.Response{}, errAfterAuth
+			}
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -2704,7 +2719,10 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				execReq.Model = executionModel
 			}
 			execOpts := opts
-			execReq, execOpts = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			execReq, execOpts, errAfterAuth := applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			if errAfterAuth != nil {
+				return cliproxyexecutor.Response{}, errAfterAuth
+			}
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -3590,11 +3608,13 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 	if maxWait <= 0 {
 		return 0, false
 	}
-	status := statusCodeFromError(err)
-	if status == http.StatusOK {
+	// Plugin policy rejections are terminal even when some auth is cooling down.
+	// Check before closestCooldownWait so a 403 reject never sleeps/retries.
+	if isRequestRejectedByPluginError(err) || isRequestInvalidError(err) {
 		return 0, false
 	}
-	if isRequestInvalidError(err) {
+	status := statusCodeFromError(err)
+	if status == http.StatusOK {
 		return 0, false
 	}
 	wait, found := m.closestCooldownWait(providers, model, attempt)
@@ -4229,12 +4249,16 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 // isRequestInvalidError returns true if the error represents a client request
 // error that should not be retried. Specifically, it treats 400 responses with
 // "invalid_request_error", request-scoped 404 item misses caused by `store=false`,
-// and all 422 responses as request-shape failures, where switching auths or
-// pooled upstream models will not help. Model-support errors are excluded so
-// routing can fall through to another auth or upstream.
+// all 422 responses, and plugin policy rejections (request_rejected_by_plugin)
+// as request-shape / policy failures, where switching auths or pooled upstream
+// models will not help. Model-support errors are excluded so routing can fall
+// through to another auth or upstream.
 func isRequestInvalidError(err error) bool {
 	if err == nil {
 		return false
+	}
+	if isRequestRejectedByPluginError(err) {
+		return true
 	}
 	if isCloudflareChallengeError(err) {
 		return false
@@ -4263,6 +4287,19 @@ func isRequestInvalidError(err error) bool {
 	default:
 		return false
 	}
+}
+
+// isRequestRejectedByPluginError reports plugin policy rejections that must
+// terminate auth selection and outer cooldown retries immediately.
+func isRequestRejectedByPluginError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var authErr *Error
+	if errors.As(err, &authErr) && authErr != nil {
+		return authErr.Code == "request_rejected_by_plugin"
+	}
+	return false
 }
 
 func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool) {

--- a/sdk/cliproxy/auth/request_after_auth_reject_test.go
+++ b/sdk/cliproxy/auth/request_after_auth_reject_test.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestApplyRequestAfterAuthInterceptorRejectPropagates(t *testing.T) {
+	opts := cliproxyexecutor.Options{
+		RequestAfterAuthInterceptor: func(_ context.Context, _ cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+			return cliproxyexecutor.RequestAfterAuthInterceptResponse{Reject: true, RejectReason: "policy denied"}
+		},
+	}
+	req := cliproxyexecutor.Request{Model: "gpt", Payload: []byte("body")}
+
+	outReq, _, errAfterAuth := applyRequestAfterAuthInterceptor(context.Background(), nil, "openai", req, opts, "gpt")
+
+	if errAfterAuth == nil {
+		t.Fatal("expected a rejection error to propagate from the after-auth interceptor")
+	}
+	if e, ok := errAfterAuth.(*Error); ok {
+		if e.HTTPStatus != http.StatusForbidden {
+			t.Fatalf("HTTPStatus = %d, want %d", e.HTTPStatus, http.StatusForbidden)
+		}
+		if e.Code != "request_rejected_by_plugin" {
+			t.Fatalf("Code = %q, want %q", e.Code, "request_rejected_by_plugin")
+		}
+		if e.Message != "policy denied" {
+			t.Fatalf("Message = %q, want %q", e.Message, "policy denied")
+		}
+		if e.Retryable {
+			t.Fatal("Retryable = true, want false for plugin policy rejection")
+		}
+	} else {
+		t.Fatalf("error type = %T, want *Error", errAfterAuth)
+	}
+	if string(outReq.Payload) != "body" {
+		t.Fatalf("Payload = %q, want original body on reject", outReq.Payload)
+	}
+	if !isRequestInvalidError(errAfterAuth) {
+		t.Fatal("isRequestInvalidError should treat plugin rejection as terminal")
+	}
+	if !isRequestRejectedByPluginError(errAfterAuth) {
+		t.Fatal("isRequestRejectedByPluginError should match request_rejected_by_plugin")
+	}
+	if _, shouldRetry := (&Manager{}).shouldRetryAfterError(errAfterAuth, 0, []string{"openai"}, "gpt", time.Minute); shouldRetry {
+		t.Fatal("shouldRetryAfterError should not retry plugin policy rejections")
+	}
+}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -81,6 +81,10 @@ type RequestAfterAuthInterceptResponse struct {
 	Body []byte
 	// ClearHeaders explicitly removes current request headers before Headers is applied.
 	ClearHeaders []string
+	// Reject, when true, aborts the request after auth selection (fail-closed).
+	Reject bool
+	// RejectReason is an optional human-readable explanation surfaced to the caller.
+	RejectReason string
 }
 
 // Options controls execution behavior for both streaming and non-streaming calls.

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -614,7 +614,27 @@ type HostModelExecutionRequest struct {
 	Alt string `json:"alt"`
 }
 
+// HostModelError preserves upstream model execution error details for plugins.
+//
+// Body is best-effort. When the host only has an error string (not a raw upstream
+// response body), Body may contain that string and match Message.
+type HostModelError struct {
+	// StatusCode is the upstream model execution HTTP status code.
+	StatusCode int `json:"status_code"`
+	// Headers contains upstream error response headers when available.
+	Headers http.Header `json:"headers"`
+	// Body contains the upstream error response body when available.
+	// If the host only has a string error, Body may hold that string.
+	Body []byte `json:"body"`
+	// Message is a human-readable error message.
+	Message string `json:"message"`
+}
+
 // HostModelExecutionResponse describes a non-streaming host model execution response.
+//
+// Error contract: host.model.execute returns a successful RPC envelope even when
+// model execution fails. Callers must inspect Error (or StatusCode) rather than
+// relying only on the RPC-level error channel.
 type HostModelExecutionResponse struct {
 	// StatusCode is the model execution HTTP status code.
 	StatusCode int `json:"status_code"`
@@ -622,16 +642,27 @@ type HostModelExecutionResponse struct {
 	Headers http.Header `json:"headers"`
 	// Body contains the raw response body.
 	Body []byte `json:"body"`
+	// Error is set when model execution fails before a normal response is available.
+	// Prefer checking Error (or StatusCode >= 400) over the RPC error channel alone.
+	Error *HostModelError `json:"error,omitempty"`
 }
 
 // HostModelStreamResponse describes a streaming host model execution response.
+//
+// Error contract: host.model.execute_stream returns a successful RPC envelope
+// even when stream startup fails. Callers must inspect Error (or StatusCode)
+// rather than relying only on the RPC-level error channel.
 type HostModelStreamResponse struct {
 	// StatusCode is the model execution HTTP status code.
 	StatusCode int `json:"status_code"`
 	// Headers contains response headers.
 	Headers http.Header `json:"headers"`
 	// StreamID identifies the host-owned stream for later reads.
+	// Empty when Error is set and no stream was opened.
 	StreamID string `json:"stream_id"`
+	// Error is set when streaming fails before a stream is opened.
+	// Prefer checking Error (or StatusCode >= 400) over the RPC error channel alone.
+	Error *HostModelError `json:"error,omitempty"`
 }
 
 // HostModelStreamReadRequest asks the host to read the next model stream chunk.
@@ -641,11 +672,17 @@ type HostModelStreamReadRequest struct {
 }
 
 // HostModelStreamReadResponse returns one model stream chunk or terminal state.
+//
+// ErrorDetails carries structured stream errors when available. Error remains
+// the plain-string form for older callers.
 type HostModelStreamReadResponse struct {
 	// Payload contains the raw stream chunk bytes.
 	Payload []byte `json:"payload"`
 	// Error reports a stream error associated with this read.
 	Error string `json:"error"`
+	// ErrorDetails preserves structured stream error details when available.
+	// Prefer ErrorDetails when present; Error is the string fallback.
+	ErrorDetails *HostModelError `json:"error_details,omitempty"`
 	// Done reports whether the stream has ended.
 	Done bool `json:"done"`
 }
@@ -1002,6 +1039,12 @@ type RequestInterceptResponse struct {
 	Body []byte
 	// ClearHeaders explicitly removes current request headers before Headers is applied.
 	ClearHeaders []string
+	// Reject, when true, aborts the request before it reaches the upstream.
+	// Interceptors use this to fail closed (for example, when a policy plugin
+	// cannot safely continue) instead of forwarding the original body.
+	Reject bool `json:"reject,omitempty"`
+	// RejectReason is an optional human-readable explanation surfaced to the caller.
+	RejectReason string `json:"reject_reason,omitempty"`
 }
 
 // ResponseInterceptRequest describes a successful non-streaming response.

--- a/sdk/pluginapi/types_test.go
+++ b/sdk/pluginapi/types_test.go
@@ -210,17 +210,24 @@ func TestHostModelTypesPreserveFields(t *testing.T) {
 		t.Fatalf("HostModelExecutionRequest headers = %#v", decodedRequest.Headers)
 	}
 
+	upstreamErrorBody := `{"error":{"message":"quota","code":"rate_limit"}}`
 	response := HostModelExecutionResponse{
-		StatusCode: http.StatusAccepted,
-		Headers:    http.Header{"Content-Type": []string{"application/json"}},
-		Body:       []byte(`{"ok":true}`),
+		StatusCode: http.StatusTooManyRequests,
+		Headers:    http.Header{"Retry-After": []string{"5"}},
+		Body:       []byte(upstreamErrorBody),
+		Error: &HostModelError{
+			StatusCode: http.StatusTooManyRequests,
+			Headers:    http.Header{"Retry-After": []string{"5"}},
+			Body:       []byte(upstreamErrorBody),
+			Message:    upstreamErrorBody,
+		},
 	}
 	rawResponse, errMarshalResponse := json.Marshal(response)
 	if errMarshalResponse != nil {
 		t.Fatalf("marshal HostModelExecutionResponse: %v", errMarshalResponse)
 	}
 	responseJSON := string(rawResponse)
-	for _, field := range []string{"status_code", "headers", "body"} {
+	for _, field := range []string{"status_code", "headers", "body", "error"} {
 		if !strings.Contains(responseJSON, `"`+field+`"`) {
 			t.Fatalf("HostModelExecutionResponse JSON missing field %q: %s", field, responseJSON)
 		}
@@ -230,22 +237,32 @@ func TestHostModelTypesPreserveFields(t *testing.T) {
 		t.Fatalf("unmarshal HostModelExecutionResponse: %v", errUnmarshalResponse)
 	}
 	if decodedResponse.StatusCode != response.StatusCode ||
-		decodedResponse.Headers.Get("Content-Type") != "application/json" ||
-		string(decodedResponse.Body) != string(response.Body) {
+		decodedResponse.Headers.Get("Retry-After") != "5" ||
+		string(decodedResponse.Body) != string(response.Body) ||
+		decodedResponse.Error == nil ||
+		decodedResponse.Error.StatusCode != http.StatusTooManyRequests ||
+		decodedResponse.Error.Headers.Get("Retry-After") != "5" ||
+		string(decodedResponse.Error.Body) != upstreamErrorBody ||
+		decodedResponse.Error.Message != upstreamErrorBody {
 		t.Fatalf("HostModelExecutionResponse round trip = %#v", decodedResponse)
 	}
 
 	streamResponse := HostModelStreamResponse{
-		StatusCode: http.StatusOK,
-		Headers:    http.Header{"Content-Type": []string{"text/event-stream"}},
-		StreamID:   "stream-1",
+		StatusCode: http.StatusTooManyRequests,
+		Headers:    http.Header{"Retry-After": []string{"5"}},
+		Error: &HostModelError{
+			StatusCode: http.StatusTooManyRequests,
+			Headers:    http.Header{"Retry-After": []string{"5"}},
+			Body:       []byte(upstreamErrorBody),
+			Message:    upstreamErrorBody,
+		},
 	}
 	rawStreamResponse, errMarshalStreamResponse := json.Marshal(streamResponse)
 	if errMarshalStreamResponse != nil {
 		t.Fatalf("marshal HostModelStreamResponse: %v", errMarshalStreamResponse)
 	}
 	streamResponseJSON := string(rawStreamResponse)
-	for _, field := range []string{"status_code", "headers", "stream_id"} {
+	for _, field := range []string{"status_code", "headers", "error"} {
 		if !strings.Contains(streamResponseJSON, `"`+field+`"`) {
 			t.Fatalf("HostModelStreamResponse JSON missing field %q: %s", field, streamResponseJSON)
 		}
@@ -255,8 +272,13 @@ func TestHostModelTypesPreserveFields(t *testing.T) {
 		t.Fatalf("unmarshal HostModelStreamResponse: %v", errUnmarshalStreamResponse)
 	}
 	if decodedStreamResponse.StatusCode != streamResponse.StatusCode ||
-		decodedStreamResponse.Headers.Get("Content-Type") != "text/event-stream" ||
-		decodedStreamResponse.StreamID != streamResponse.StreamID {
+		decodedStreamResponse.Headers.Get("Retry-After") != "5" ||
+		decodedStreamResponse.StreamID != "" ||
+		decodedStreamResponse.Error == nil ||
+		decodedStreamResponse.Error.StatusCode != http.StatusTooManyRequests ||
+		decodedStreamResponse.Error.Headers.Get("Retry-After") != "5" ||
+		string(decodedStreamResponse.Error.Body) != upstreamErrorBody ||
+		decodedStreamResponse.Error.Message != upstreamErrorBody {
 		t.Fatalf("HostModelStreamResponse round trip = %#v", decodedStreamResponse)
 	}
 
@@ -280,13 +302,19 @@ func TestHostModelTypesPreserveFields(t *testing.T) {
 		Payload: []byte("data: test\n\n"),
 		Error:   "temporary stream error",
 		Done:    true,
+		ErrorDetails: &HostModelError{
+			StatusCode: http.StatusBadGateway,
+			Headers:    http.Header{"Retry-After": []string{"5"}},
+			Body:       []byte("temporary stream error"),
+			Message:    "temporary stream error",
+		},
 	}
 	rawReadResponse, errMarshalReadResponse := json.Marshal(readResponse)
 	if errMarshalReadResponse != nil {
 		t.Fatalf("marshal HostModelStreamReadResponse: %v", errMarshalReadResponse)
 	}
 	readResponseJSON := string(rawReadResponse)
-	for _, field := range []string{"payload", "error", "done"} {
+	for _, field := range []string{"payload", "error", "done", "error_details"} {
 		if !strings.Contains(readResponseJSON, `"`+field+`"`) {
 			t.Fatalf("HostModelStreamReadResponse JSON missing field %q: %s", field, readResponseJSON)
 		}
@@ -297,7 +325,12 @@ func TestHostModelTypesPreserveFields(t *testing.T) {
 	}
 	if string(decodedReadResponse.Payload) != string(readResponse.Payload) ||
 		decodedReadResponse.Error != readResponse.Error ||
-		decodedReadResponse.Done != readResponse.Done {
+		decodedReadResponse.Done != readResponse.Done ||
+		decodedReadResponse.ErrorDetails == nil ||
+		decodedReadResponse.ErrorDetails.StatusCode != http.StatusBadGateway ||
+		decodedReadResponse.ErrorDetails.Headers.Get("Retry-After") != "5" ||
+		string(decodedReadResponse.ErrorDetails.Body) != "temporary stream error" ||
+		decodedReadResponse.ErrorDetails.Message != "temporary stream error" {
 		t.Fatalf("HostModelStreamReadResponse round trip = %#v", decodedReadResponse)
 	}
 


### PR DESCRIPTION
## Summary

This PR strengthens the plugin host in two related areas:

1. **Structured upstream model errors** so plugins can see full failure details from host model execution.
2. **Fail-closed request interceptors** so plugins can reject a request with HTTP 403 before the original body is sent upstream.

These changes are intentional host API extensions for policy / safety plugins (and any other request interceptor), not a single-plugin special case.

## What changed

### Structured model errors
- Add `HostModelError` (`status_code`, `headers`, `body`, `message`)
- Propagate structured errors on:
  - `host.model.execute`
  - `host.model.execute_stream` (startup failure)
  - stream read (`error_details`)
- Stream bridge errors implement `StatusCode()` / `Headers()` for host callers

**Important contract change:**  
On model execution failure, the host now returns a **successful RPC envelope** with failure details in `Error` / `StatusCode` (instead of only an RPC-level error).  
Plugin authors should inspect:

- `resp.Error != nil`, or
- `resp.StatusCode >= 400`

`Body` is best-effort: when the host only has a string error (no raw upstream body), `Body` may match `Message`.

### Fail-closed request interceptors
- Add `Reject` / `RejectReason` to:
  - `RequestInterceptResponse` (JSON-tagged for plugin RPC)
  - `RequestAfterAuthInterceptResponse` (in-process, no JSON tags)
- Request-interceptor **panic** → fail-closed (`Reject=true`, chain stops, plugin fused)
- Plain interceptor **error** remains fail-open (avoids locking out all traffic on soft failures)
- Before-auth reject → HTTP 403 (`request rejected by plugin: ...`)
- After-auth reject → `request_rejected_by_plugin` with HTTP 403
- Honored on:
  - AuthManager path
  - plugin-executor path (sync / count / stream)
- On reject, partial header/body mutations are discarded

## Why

Without reject support, a request interceptor that cannot safely continue has no way to stop the request, so the original body may still reach upstream.  
Without structured model errors, plugins calling host model APIs lose status/headers/body detail needed for correct fallback and diagnostics.

## Test plan

- [x] `go test ./internal/pluginhost/ -count=1`
- [x] `go test ./sdk/api/handlers/ -count=1`
- [x] `go test ./sdk/cliproxy/auth/ -count=1`
- [x] `go test ./sdk/pluginapi/ -count=1`
- [x] `go build -o test-output ./cmd/server && rm test-output`

Covered behavior:
- interceptor chain abort on `Reject`
- panic → reject + fuse
- `Reject` JSON round-trip
- before-auth 403
- plugin-executor after-auth 403 (mutations discarded)
- after-auth reject propagation (`request_rejected_by_plugin`)
- structured `HostModelError` passthrough

## Notes for reviewers

- Response interceptors remain fail-open by design.
- Public comments/examples use generic policy language (not a specific plugin name).
- Suggested review focus:
  1. all after-auth routes honor `Reject`
  2. mutation discard on reject
  3. model-error envelope contract for existing plugins