### PR TITLE
fix(antigravity): deduplicate function declarations before sending to upstream

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -687,8 +687,15 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 			}
 		}
 		if toolDeclCount > 0 {
-			toolsJSON = []byte(`[]`)
-			toolsJSON, _ = sjson.SetRawBytes(toolsJSON, "-1", functionToolNode)
+			if decls := gjson.GetBytes(functionToolNode, "functionDeclarations"); decls.IsArray() {
+				deduped := util.DeduplicateFunctionDeclarations([]byte(decls.Raw))
+				functionToolNode, _ = sjson.SetRawBytes(functionToolNode, "functionDeclarations", deduped)
+				toolDeclCount = int(gjson.GetBytes(deduped, "#").Int())
+			}
+			if toolDeclCount > 0 {
+				toolsJSON = []byte(`[]`)
+				toolsJSON, _ = sjson.SetRawBytes(toolsJSON, "-1", functionToolNode)
+			}
 		}
 	}
 

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -100,6 +100,8 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 						rawJSON = []byte(renamed)
 					}
 				}
+				// Re-read after renames to pick up parametersJsonSchema changes.
+				declsResult = gjson.GetBytes(rawJSON, fmt.Sprintf("request.tools.%d.%s", i, key))
 				deduped := util.DeduplicateFunctionDeclarations([]byte(declsResult.Raw))
 				var errSet error
 				rawJSON, errSet = sjson.SetRawBytes(rawJSON, fmt.Sprintf("request.tools.%d.%s", i, key), deduped)

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -98,6 +98,17 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 				}
 			}
 		}
+		for i := 0; i < len(toolResults); i++ {
+			declsResult := gjson.GetBytes(rawJSON, fmt.Sprintf("request.tools.%d.function_declarations", i))
+			if declsResult.Exists() && declsResult.IsArray() {
+				deduped := util.DeduplicateFunctionDeclarations([]byte(declsResult.Raw))
+				var errSet error
+				rawJSON, errSet = sjson.SetRawBytes(rawJSON, fmt.Sprintf("request.tools.%d.function_declarations", i), deduped)
+				if errSet != nil {
+					log.Warnf("failed to deduplicate function declarations in tool %d: %v", i, errSet)
+				}
+			}
+		}
 	}
 
 	if strings.Contains(strings.ToLower(modelName), "claude") {

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -86,24 +86,23 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 	if toolsResult.Exists() && toolsResult.IsArray() {
 		toolResults := toolsResult.Array()
 		for i := 0; i < len(toolResults); i++ {
-			functionDeclarationsResult := gjson.GetBytes(rawJSON, fmt.Sprintf("request.tools.%d.function_declarations", i))
-			if functionDeclarationsResult.Exists() && functionDeclarationsResult.IsArray() {
-				functionDeclarationsResults := functionDeclarationsResult.Array()
-				for j := 0; j < len(functionDeclarationsResults); j++ {
-					parametersResult := gjson.GetBytes(rawJSON, fmt.Sprintf("request.tools.%d.function_declarations.%d.parameters", i, j))
-					if parametersResult.Exists() {
-						strJson, _ := util.RenameKey(string(rawJSON), fmt.Sprintf("request.tools.%d.function_declarations.%d.parameters", i, j), fmt.Sprintf("request.tools.%d.function_declarations.%d.parametersJsonSchema", i, j))
-						rawJSON = []byte(strJson)
+			for _, key := range []string{"function_declarations", "functionDeclarations"} {
+				declsResult := gjson.GetBytes(rawJSON, fmt.Sprintf("request.tools.%d.%s", i, key))
+				if !declsResult.Exists() || !declsResult.IsArray() {
+					continue
+				}
+				decls := declsResult.Array()
+				for j := 0; j < len(decls); j++ {
+					paramsPath := fmt.Sprintf("request.tools.%d.%s.%d.parameters", i, key, j)
+					if gjson.GetBytes(rawJSON, paramsPath).Exists() {
+						newPath := fmt.Sprintf("request.tools.%d.%s.%d.parametersJsonSchema", i, key, j)
+						renamed, _ := util.RenameKey(string(rawJSON), paramsPath, newPath)
+						rawJSON = []byte(renamed)
 					}
 				}
-			}
-		}
-		for i := 0; i < len(toolResults); i++ {
-			declsResult := gjson.GetBytes(rawJSON, fmt.Sprintf("request.tools.%d.function_declarations", i))
-			if declsResult.Exists() && declsResult.IsArray() {
 				deduped := util.DeduplicateFunctionDeclarations([]byte(declsResult.Raw))
 				var errSet error
-				rawJSON, errSet = sjson.SetRawBytes(rawJSON, fmt.Sprintf("request.tools.%d.function_declarations", i), deduped)
+				rawJSON, errSet = sjson.SetRawBytes(rawJSON, fmt.Sprintf("request.tools.%d.%s", i, key), deduped)
 				if errSet != nil {
 					log.Warnf("failed to deduplicate function declarations in tool %d: %v", i, errSet)
 				}

--- a/internal/translator/antigravity/interactions/interactions_antigravity_request.go
+++ b/internal/translator/antigravity/interactions/interactions_antigravity_request.go
@@ -468,6 +468,13 @@ func copyInteractionsToolsToAntigravity(out []byte, root gjson.Result) []byte {
 		otherTools = append(otherTools, []byte(tool.Raw))
 		return true
 	})
+	if hasFunction {
+		if decls := gjson.GetBytes(functionToolNode, "functionDeclarations"); decls.IsArray() {
+			deduped := util.DeduplicateFunctionDeclarations([]byte(decls.Raw))
+			functionToolNode, _ = sjson.SetRawBytes(functionToolNode, "functionDeclarations", deduped)
+			hasFunction = gjson.GetBytes(deduped, "#").Int() > 0
+		}
+	}
 	toolsNode := []byte(`[]`)
 	if hasFunction {
 		toolsNode, _ = sjson.SetRawBytes(toolsNode, "-1", functionToolNode)

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -433,6 +433,13 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 				urlContextNodes = append(urlContextNodes, urlToolNode)
 			}
 		}
+		if hasFunction {
+			if decls := gjson.GetBytes(functionToolNode, "functionDeclarations"); decls.IsArray() {
+				deduped := util.DeduplicateFunctionDeclarations([]byte(decls.Raw))
+				functionToolNode, _ = sjson.SetRawBytes(functionToolNode, "functionDeclarations", deduped)
+				hasFunction = gjson.GetBytes(deduped, "#").Int() > 0
+			}
+		}
 		if hasFunction || len(googleSearchNodes) > 0 || len(codeExecutionNodes) > 0 || len(urlContextNodes) > 0 {
 			toolsNode := []byte("[]")
 			if hasFunction {

--- a/internal/util/translator.go
+++ b/internal/util/translator.go
@@ -326,3 +326,23 @@ func RestoreSanitizedToolName(toolNameMap map[string]string, sanitizedName strin
 	}
 	return sanitizedName
 }
+
+// DeduplicateFunctionDeclarations removes duplicate function declarations by name,
+// keeping the first occurrence. Input must be a JSON array of declaration objects.
+func DeduplicateFunctionDeclarations(raw []byte) []byte {
+	result := gjson.ParseBytes(raw)
+	if !result.IsArray() {
+		return raw
+	}
+	seen := make(map[string]bool)
+	deduped := []byte(`[]`)
+	for _, decl := range result.Array() {
+		name := decl.Get("name").String()
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		deduped, _ = sjson.SetRawBytes(deduped, "-1", []byte(decl.Raw))
+	}
+	return deduped
+}

--- a/internal/util/translator.go
+++ b/internal/util/translator.go
@@ -335,14 +335,14 @@ func DeduplicateFunctionDeclarations(raw []byte) []byte {
 		return raw
 	}
 	seen := make(map[string]bool)
-	deduped := []byte(`[]`)
+	var parts []string
 	for _, decl := range result.Array() {
 		name := decl.Get("name").String()
 		if name == "" || seen[name] {
 			continue
 		}
 		seen[name] = true
-		deduped, _ = sjson.SetRawBytes(deduped, "-1", []byte(decl.Raw))
+		parts = append(parts, decl.Raw)
 	}
-	return deduped
+	return []byte("[" + strings.Join(parts, ",") + "]")
 }


### PR DESCRIPTION
## Summary

When clients register multiple MCP plugin sub-servers with overlapping tool names (e.g., Cloudflare's builds/bindings/observability/docks sub-servers all exporting `workers_get_worker`), the antigravity upstream rejects the request with:

> 400 Duplicate function declaration found: mcp__plugin_cloudflare_cloudflare-builds__workers_builds_get_bui

This happens because:
1. Multiple MCP sub-servers register identically-named tools (real duplicates)
2. `SanitizeFunctionName` truncates long tool names to 64 chars, causing hash collisions between different tools (e.g., `workers_builds_get_build` vs `workers_builds_get_build_logs` both truncate to `workers_builds_get_bui`)

This PR only addresses case 1.

## Changes

- Add `DeduplicateFunctionDeclarations` to `internal/util/translator.go` — removes duplicate function declarations by name, keeping the first occurrence
- Apply dedup in all four antigravity translator paths before serializing `functionDeclarations` into the request payload:
  - `internal/translator/antigravity/claude/antigravity_claude_request.go`
  - `internal/translator/antigravity/gemini/antigravity_gemini_request.go`
  - `internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go`
  - `internal/translator/antigravity/interactions/interactions_antigravity_request.go`

## Test Plan

- [x] `go build -o /tmp/cli-proxy-api ./cmd/server` passes
- [x] `go test ./internal/util/...` passes (117 tests)
- [x] `go test ./internal/translator/antigravity/...` passes (148 tests)