### PR TITLE
fix(codex): recheck paid usage limits before stale reset deadlines

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -38,8 +38,10 @@ const (
 	codexUserAgent             = "codex-tui/0.135.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.135.0)"
 	codexOriginator            = "codex-tui"
 	codexDefaultImageToolModel = "gpt-image-2"
-	codexResponsesLiteHeader   = "X-OpenAI-Internal-Codex-Responses-Lite"
-	codexResponsesLiteMetadata = "client_metadata.ws_request_header_x_openai_internal_codex_responses_lite"
+	// Paid quotas can be reset before resets_at, so periodically recheck them.
+	codexPaidPlanRecheckInterval = 30 * time.Minute
+	codexResponsesLiteHeader     = "X-OpenAI-Internal-Codex-Responses-Lite"
+	codexResponsesLiteMetadata   = "client_metadata.ws_request_header_x_openai_internal_codex_responses_lite"
 )
 
 var dataTag = []byte("data:")
@@ -1894,18 +1896,24 @@ func parseCodexRetryAfter(statusCode int, errorBody []byte, now time.Time) *time
 	if strings.TrimSpace(gjson.GetBytes(errorBody, "error.type").String()) != "usage_limit_reached" {
 		return nil
 	}
+	var retryAfter time.Duration
 	if resetsAt := gjson.GetBytes(errorBody, "error.resets_at").Int(); resetsAt > 0 {
 		resetAtTime := time.Unix(resetsAt, 0)
 		if resetAtTime.After(now) {
-			retryAfter := resetAtTime.Sub(now)
-			return &retryAfter
+			retryAfter = resetAtTime.Sub(now)
 		}
 	}
-	if resetsInSeconds := gjson.GetBytes(errorBody, "error.resets_in_seconds").Int(); resetsInSeconds > 0 {
-		retryAfter := time.Duration(resetsInSeconds) * time.Second
-		return &retryAfter
+	if retryAfter <= 0 {
+		retryAfter = time.Duration(gjson.GetBytes(errorBody, "error.resets_in_seconds").Int()) * time.Second
 	}
-	return nil
+	if retryAfter <= 0 {
+		return nil
+	}
+	planType := strings.TrimSpace(gjson.GetBytes(errorBody, "error.plan_type").String())
+	if planType != "" && !strings.EqualFold(planType, "free") && retryAfter > codexPaidPlanRecheckInterval {
+		retryAfter = codexPaidPlanRecheckInterval
+	}
+	return &retryAfter
 }
 
 func codexCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -46,6 +46,23 @@ func TestParseCodexRetryAfter(t *testing.T) {
 		}
 	})
 
+	t.Run("caps paid plan reset hint for recheck", func(t *testing.T) {
+		resetAt := now.Add(4 * time.Hour).Unix()
+		body := []byte(`{"error":{"type":"usage_limit_reached","plan_type":"team","resets_at":` + itoa(resetAt) + `}}`)
+		retryAfter := parseCodexRetryAfter(http.StatusTooManyRequests, body, now)
+		if retryAfter == nil || *retryAfter != codexPaidPlanRecheckInterval {
+			t.Fatalf("retryAfter = %v, want %v", retryAfter, codexPaidPlanRecheckInterval)
+		}
+	})
+
+	t.Run("keeps free plan reset hint", func(t *testing.T) {
+		body := []byte(`{"error":{"type":"usage_limit_reached","plan_type":"free","resets_in_seconds":14400}}`)
+		retryAfter := parseCodexRetryAfter(http.StatusTooManyRequests, body, now)
+		if retryAfter == nil || *retryAfter != 4*time.Hour {
+			t.Fatalf("retryAfter = %v, want %v", retryAfter, 4*time.Hour)
+		}
+	})
+
 	t.Run("non-429 status code", func(t *testing.T) {
 		body := []byte(`{"error":{"type":"usage_limit_reached","resets_in_seconds":30}}`)
 		if got := parseCodexRetryAfter(http.StatusBadRequest, body, now); got != nil {


### PR DESCRIPTION
## Summary

- cap long Codex `usage_limit_reached` retry hints for paid plans at 30 minutes
- keep free-plan reset hints unchanged
- cover both a paid `resets_at` deadline and the original free-plan behavior

## Root cause

#1666 intentionally made Codex cooldowns follow `resets_at` / `resets_in_seconds`, preventing repeated requests from exhausted free accounts. Paid quota can also be reset before that advertised deadline. If the reset happens outside CLIProxyAPI's management `reset-quota` endpoint, the cached deadline becomes stale and every model request is rejected locally, so the proxy never observes the restored quota. This is the stale-cooldown behavior reported in #3942; #3866 added the explicit management reset path but does not cover external resets.

This change preserves exact long cooldowns for free plans while periodically rechecking paid plans. The 30-minute ceiling matches the existing maximum inferred quota backoff and avoids returning to a tight retry loop.

## Impact

Paid Codex accounts recover from externally reset quota within at most 30 minutes instead of remaining blocked for the original hours- or days-long reset window. Short reset hints and all free-plan behavior are unchanged.

## Validation

- `go test ./internal/runtime/executor -count=1`
- `go test ./internal/runtime/executor -run TestParseCodexRetryAfter -count=1`
- `go build -o /tmp/cliproxyapi-pr-build ./cmd/server`
- `go test ./... -count=1` (one unrelated baseline failure: `TestModelsWithClientVersionReturnsCodexCatalog`, remote model priority `143`, expected `129`)
- confirmed the same failing test on a clean `origin/dev` worktree
