### PR TITLE
Add codex-oauth-base-url and codex-oauth-headers for routing codex OAuth traffic through a companion proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ go build -o test-output ./cmd/server && rm test-output # Verify compile (REQUIRE
 - Default config: `config.yaml` (template: `config.example.yaml`)
 - `.env` is auto-loaded from the working directory
 - Auth material defaults under `auths/`
+- `codex-oauth-base-url` and `codex-oauth-headers` are startup-only and route Codex subscription OAuth requests over HTTP
 - Storage backends: file-based default; optional Postgres/git/object store (`PGSTORE_*`, `GITSTORE_*`, `OBJECTSTORE_*`)
 
 ## Architecture

--- a/cmd/fetch_codex_models/main.go
+++ b/cmd/fetch_codex_models/main.go
@@ -127,6 +127,16 @@ func main() {
 	}
 
 	fmt.Printf("Using auth: id=%s label=%s\n", chosen.ID, chosen.Label)
+	modelsBaseURL := codexModelsBaseURL
+	var modelsOAuthHeaders map[string]string
+	if cfg.CodexOAuthBaseURL != "" && (chosen.Attributes == nil || strings.TrimSpace(chosen.Attributes["api_key"]) == "") {
+		if authBaseURL := codexAuthBaseURL(chosen); authBaseURL != "" {
+			fmt.Fprintf(os.Stderr, "error: codex-oauth-base-url conflicts with Codex OAuth auth %q base_url %q\n", chosen.ID, authBaseURL)
+			os.Exit(1)
+		}
+		modelsBaseURL = cfg.CodexOAuthBaseURL
+		modelsOAuthHeaders = cfg.CodexOAuthHeaders
+	}
 
 	accessToken, refreshed, err := ensureAccessToken(ctx, fileStore, chosen)
 	if err != nil {
@@ -139,7 +149,7 @@ func main() {
 
 	fmt.Println("Fetching Codex model list from upstream...")
 
-	raw, count, err := fetchModels(ctx, chosen, accessToken, clientVersion)
+	raw, count, err := fetchModels(ctx, chosen, accessToken, modelsBaseURL, clientVersion, modelsOAuthHeaders)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: failed to fetch codex models: %v\n", err)
 		os.Exit(1)
@@ -228,8 +238,8 @@ func ensureAccessToken(ctx context.Context, store *sdkauth.FileTokenStore, auth 
 	return tokenData.AccessToken, true, nil
 }
 
-func fetchModels(ctx context.Context, auth *coreauth.Auth, accessToken, clientVersion string) ([]byte, int, error) {
-	modelsURL, errURL := codexModelsURL(clientVersion)
+func fetchModels(ctx context.Context, auth *coreauth.Auth, accessToken, baseURL, clientVersion string, oauthHeaders map[string]string) ([]byte, int, error) {
+	modelsURL, errURL := codexModelsURL(baseURL, clientVersion)
 	if errURL != nil {
 		return nil, 0, errURL
 	}
@@ -248,6 +258,9 @@ func fetchModels(ctx context.Context, auth *coreauth.Auth, accessToken, clientVe
 	}
 	if auth != nil {
 		util.ApplyCustomHeadersFromAttrs(httpReq, auth.Attributes)
+	}
+	for name, value := range oauthHeaders {
+		httpReq.Header.Set(name, value)
 	}
 
 	httpClient := &http.Client{}
@@ -281,8 +294,8 @@ func fetchModels(ctx context.Context, auth *coreauth.Auth, accessToken, clientVe
 	return bodyBytes, count, nil
 }
 
-func codexModelsURL(clientVersion string) (string, error) {
-	u, err := url.Parse(codexModelsBaseURL + codexModelsPath)
+func codexModelsURL(baseURL, clientVersion string) (string, error) {
+	u, err := url.Parse(strings.TrimSuffix(baseURL, "/") + codexModelsPath)
 	if err != nil {
 		return "", err
 	}
@@ -292,6 +305,18 @@ func codexModelsURL(clientVersion string) (string, error) {
 		u.RawQuery = q.Encode()
 	}
 	return u.String(), nil
+}
+
+func codexAuthBaseURL(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if auth.Attributes != nil {
+		if baseURL := strings.TrimSpace(auth.Attributes["base_url"]); baseURL != "" {
+			return baseURL
+		}
+	}
+	return metaStringValue(auth.Metadata, "base_url")
 }
 
 func countModels(raw []byte) (int, error) {

--- a/cmd/fetch_codex_models/main_test.go
+++ b/cmd/fetch_codex_models/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestFetchModelsUsesConfiguredBaseURL(t *testing.T) {
+	var gotPath string
+	var gotClientVersion string
+	var gotEdgeKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotClientVersion = r.URL.Query().Get("client_version")
+		gotEdgeKey = r.Header.Get("X-Edgee-Api-Key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[]}`))
+	}))
+	defer server.Close()
+
+	_, count, errFetch := fetchModels(
+		context.Background(),
+		&coreauth.Auth{},
+		"oauth-token",
+		server.URL+"/codex/",
+		"test-version",
+		map[string]string{"x-edgee-api-key": "edge-key"},
+	)
+	if errFetch != nil {
+		t.Fatalf("fetchModels() error = %v", errFetch)
+	}
+	if count != 0 {
+		t.Fatalf("model count = %d, want 0", count)
+	}
+	if gotPath != "/codex/models" {
+		t.Fatalf("request path = %q, want /codex/models", gotPath)
+	}
+	if gotClientVersion != "test-version" {
+		t.Fatalf("client_version = %q, want test-version", gotClientVersion)
+	}
+	if gotEdgeKey != "edge-key" {
+		t.Fatalf("X-Edgee-Api-Key = %q, want configured header", gotEdgeKey)
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -41,7 +41,7 @@ import (
 )
 
 var (
-	Version           = "dev"
+	Version           = "7.2.62+edgee.1"
 	Commit            = "none"
 	BuildDate         = "unknown"
 	DefaultConfigPath = ""

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -177,6 +177,20 @@ routing:
   # How long session-to-auth bindings are retained. Default: 1h
   session-affinity-ttl: "1h"
 
+# Optional upstream base URL for ChatGPT-Codex subscription OAuth credentials.
+# Empty preserves stock routing. When set, this must be an absolute http(s) URL without
+# userinfo, query, or fragment. The value is captured at startup; valid hot reload changes
+# do not take effect until restart. Do not combine it with any Codex OAuth auth-file base_url; a
+# base_url that also matches a codex-api-key entry is reported explicitly as a conflict.
+codex-oauth-base-url: ""
+
+# Optional headers sent with every Codex OAuth request routed to codex-oauth-base-url.
+# Like the base URL, these headers are captured at startup; hot reload changes require a restart.
+codex-oauth-headers: {}
+# Example:
+# codex-oauth-headers:
+#   x-edgee-api-key: "your-edgee-api-key"
+
 # Codex provider behavior.
 codex:
   # When true, and routing.strategy is fill-first or routing.session-affinity is true,

--- a/internal/config/codex_oauth_base_url_test.go
+++ b/internal/config/codex_oauth_base_url_test.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfigCodexOAuthBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    string
+		wantErr bool
+	}{
+		{name: "absent"},
+		{name: "empty", value: `""`},
+		{name: "http", value: "http://example.com/", want: "http://example.com"},
+		{name: "uppercase scheme", value: "HTTPS://example.com/codex/", want: "HTTPS://example.com/codex"},
+		{name: "https path", value: "https://example.com/backend/codex///", want: "https://example.com/backend/codex"},
+		{name: "cloud endpoint", value: "https://api.edgee.ai/v1", want: "https://api.edgee.ai/v1"},
+		{name: "relative", value: "/backend/codex", wantErr: true},
+		{name: "unsupported scheme", value: "ftp://example.com/backend/codex", wantErr: true},
+		{name: "empty host", value: "https:///backend/codex", wantErr: true},
+		{name: "empty hostname", value: "http://:8080/backend/codex", wantErr: true},
+		{name: "userinfo", value: "https://user:pass@example.com/backend/codex", wantErr: true},
+		{name: "query", value: "https://example.com/backend/codex?mode=test", wantErr: true},
+		{name: "empty query", value: "https://example.com/backend/codex?", wantErr: true},
+		{name: "fragment", value: "https://example.com/backend/codex#section", wantErr: true},
+		{name: "empty fragment", value: "https://example.com/backend/codex#", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			contents := "host: 127.0.0.1\n"
+			if tt.value != "" {
+				contents += "codex-oauth-base-url: " + tt.value + "\n"
+			}
+			if errWrite := os.WriteFile(configPath, []byte(contents), 0o600); errWrite != nil {
+				t.Fatalf("write config: %v", errWrite)
+			}
+
+			cfg, errLoad := LoadConfig(configPath)
+			if tt.wantErr {
+				if errLoad == nil {
+					t.Fatal("LoadConfig() error = nil, want validation error")
+				}
+				if !strings.Contains(errLoad.Error(), "codex-oauth-base-url") {
+					t.Fatalf("LoadConfig() error = %q, want key name", errLoad)
+				}
+				return
+			}
+			if errLoad != nil {
+				t.Fatalf("LoadConfig() error = %v", errLoad)
+			}
+			if cfg.CodexOAuthBaseURL != tt.want {
+				t.Fatalf("CodexOAuthBaseURL = %q, want %q", cfg.CodexOAuthBaseURL, tt.want)
+			}
+			if len(cfg.CodexOAuthHeaders) != 0 {
+				t.Fatalf("CodexOAuthHeaders = %#v, want empty", cfg.CodexOAuthHeaders)
+			}
+		})
+	}
+}
+
+func TestLoadConfigCodexOAuthHeaders(t *testing.T) {
+	tests := []struct {
+		name      string
+		header    string
+		wantValue string
+		wantErr   bool
+	}{
+		{name: "valid", header: "x-edgee-api-key", wantValue: "edge-key"},
+		{name: "all token punctuation", header: "!#$%&'*+-.^_`|~", wantValue: "edge-key"},
+		{name: "space", header: "x bad", wantErr: true},
+		{name: "colon", header: "x:bad", wantErr: true},
+		{name: "at sign", header: "x@bad", wantErr: true},
+		{name: "empty", header: "", wantErr: true},
+		{name: "authorization", header: "Authorization", wantErr: true},
+		{name: "host", header: "HOST", wantErr: true},
+		{name: "content length", header: "content-length", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			contents := "codex-oauth-base-url: https://api.edgee.ai/v1\n" +
+				"codex-oauth-headers:\n  " + strconv.Quote(tt.header) + ": edge-key\n"
+			if errWrite := os.WriteFile(configPath, []byte(contents), 0o600); errWrite != nil {
+				t.Fatalf("write config: %v", errWrite)
+			}
+
+			cfg, errLoad := LoadConfig(configPath)
+			if tt.wantErr {
+				if errLoad == nil {
+					t.Fatal("LoadConfig() error = nil, want validation error")
+				}
+				if !strings.Contains(errLoad.Error(), "codex-oauth-headers") || !strings.Contains(errLoad.Error(), strconv.Quote(tt.header)) {
+					t.Fatalf("LoadConfig() error = %q, want key and offending header %q", errLoad, tt.header)
+				}
+				return
+			}
+			if errLoad != nil {
+				t.Fatalf("LoadConfig() error = %v", errLoad)
+			}
+			if cfg.CodexOAuthHeaders[tt.header] != tt.wantValue {
+				t.Fatalf("CodexOAuthHeaders[%q] = %q, want %q", tt.header, cfg.CodexOAuthHeaders[tt.header], tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestLoadConfigRejectsCodexOAuthHeadersWithoutBaseURL(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if errWrite := os.WriteFile(configPath, []byte("codex-oauth-headers:\n  x-edgee-api-key: edge-key\n"), 0o600); errWrite != nil {
+		t.Fatalf("write config: %v", errWrite)
+	}
+
+	_, errLoad := LoadConfig(configPath)
+	if errLoad == nil {
+		t.Fatal("LoadConfig() error = nil, want headers-only validation error")
+	}
+	if !strings.Contains(errLoad.Error(), "codex-oauth-headers") || !strings.Contains(errLoad.Error(), "codex-oauth-base-url") {
+		t.Fatalf("LoadConfig() error = %q, want both config keys", errLoad)
+	}
+}
+
+func TestParseConfigBytesValidatesCodexOAuthConfig(t *testing.T) {
+	cfg, errParse := ParseConfigBytes([]byte("codex-oauth-base-url: https://edge.example.com/codex/\ncodex-oauth-headers:\n  x-edgee-api-key: edge-key\n"))
+	if errParse != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", errParse)
+	}
+	if cfg.CodexOAuthBaseURL != "https://edge.example.com/codex" {
+		t.Fatalf("CodexOAuthBaseURL = %q, want trimmed URL", cfg.CodexOAuthBaseURL)
+	}
+	if cfg.CodexOAuthHeaders["x-edgee-api-key"] != "edge-key" {
+		t.Fatalf("CodexOAuthHeaders = %#v, want configured header", cfg.CodexOAuthHeaders)
+	}
+
+	_, errParse = ParseConfigBytes([]byte("codex-oauth-base-url: relative/path\n"))
+	if errParse == nil || !strings.Contains(errParse.Error(), "codex-oauth-base-url") {
+		t.Fatalf("ParseConfigBytes() error = %v, want key-specific validation error", errParse)
+	}
+
+	_, errParse = ParseConfigBytes([]byte("codex-oauth-headers:\n  x-edgee-api-key: edge-key\n"))
+	if errParse == nil || !strings.Contains(errParse.Error(), "codex-oauth-headers") {
+		t.Fatalf("ParseConfigBytes() error = %v, want headers-only validation error", errParse)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"syscall"
@@ -124,6 +125,14 @@ type Config struct {
 
 	// Codex defines a list of Codex API key configurations as specified in the YAML configuration file.
 	CodexKey []CodexKey `yaml:"codex-api-key" json:"codex-api-key"`
+
+	// CodexOAuthBaseURL overrides the upstream base URL for Codex OAuth credentials.
+	// It is captured at startup; configuration hot reloads do not change it.
+	CodexOAuthBaseURL string `yaml:"codex-oauth-base-url" json:"codex-oauth-base-url"`
+
+	// CodexOAuthHeaders defines headers added to requests routed through CodexOAuthBaseURL.
+	// It is captured at startup; configuration hot reloads do not change it.
+	CodexOAuthHeaders map[string]string `yaml:"codex-oauth-headers" json:"codex-oauth-headers"`
 
 	// Codex configures provider-wide Codex request behavior.
 	Codex CodexConfig `yaml:"codex" json:"codex"`
@@ -757,6 +766,12 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		}
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
+	if err = cfg.NormalizeCodexOAuthBaseURL(); err != nil {
+		return nil, err
+	}
+	if err = cfg.ValidateCodexOAuthHeaders(); err != nil {
+		return nil, err
+	}
 
 	// Hash remote management key if plaintext is detected (nested)
 	// We consider a value to be already hashed if it looks like a bcrypt hash ($2a$, $2b$, or $2y$ prefix).
@@ -838,6 +853,77 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	// Return the populated configuration struct.
 	return &cfg, nil
+}
+
+// NormalizeCodexOAuthBaseURL validates and normalizes the optional Codex OAuth upstream URL.
+func (cfg *Config) NormalizeCodexOAuthBaseURL() error {
+	if cfg == nil || cfg.CodexOAuthBaseURL == "" {
+		return nil
+	}
+
+	raw := cfg.CodexOAuthBaseURL
+	parsed, errParse := url.Parse(raw)
+	if errParse != nil {
+		return fmt.Errorf("codex-oauth-base-url: invalid URL: %w", errParse)
+	}
+	if !parsed.IsAbs() || (!strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https")) {
+		return fmt.Errorf("codex-oauth-base-url: must be an absolute http or https URL")
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("codex-oauth-base-url: host must not be empty")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("codex-oauth-base-url: userinfo is not allowed")
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery {
+		return fmt.Errorf("codex-oauth-base-url: query is not allowed")
+	}
+	if parsed.Fragment != "" || strings.Contains(raw, "#") {
+		return fmt.Errorf("codex-oauth-base-url: fragment is not allowed")
+	}
+
+	cfg.CodexOAuthBaseURL = strings.TrimRight(raw, "/")
+	return nil
+}
+
+// ValidateCodexOAuthHeaders validates headers added to requests routed through CodexOAuthBaseURL.
+func (cfg *Config) ValidateCodexOAuthHeaders() error {
+	if cfg == nil || len(cfg.CodexOAuthHeaders) == 0 {
+		return nil
+	}
+	if cfg.CodexOAuthBaseURL == "" {
+		return fmt.Errorf("codex-oauth-headers: codex-oauth-base-url must be set")
+	}
+
+	for name := range cfg.CodexOAuthHeaders {
+		if !isHTTPToken(name) {
+			return fmt.Errorf("codex-oauth-headers: invalid header name %q", name)
+		}
+		switch strings.ToLower(name) {
+		case "authorization", "host", "content-length":
+			return fmt.Errorf("codex-oauth-headers: forbidden header %q", name)
+		}
+	}
+	return nil
+}
+
+func isHTTPToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			continue
+		}
+		switch c {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // NormalizePluginsConfig applies default plugin configuration values.

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -36,6 +36,12 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config payload: %w", err)
 	}
+	if err := cfg.NormalizeCodexOAuthBaseURL(); err != nil {
+		return nil, err
+	}
+	if err := cfg.ValidateCodexOAuthHeaders(); err != nil {
+		return nil, err
+	}
 
 	// Hash remote management key if plaintext is detected (nested), but do NOT persist.
 	if cfg.RemoteManagement.SecretKey != "" && !looksLikeBcrypt(cfg.RemoteManagement.SecretKey) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -8,7 +8,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -35,6 +37,7 @@ import (
 )
 
 const (
+	codexDefaultBaseURL        = "https://chatgpt.com/backend-api/codex"
 	codexUserAgent             = "codex-tui/0.135.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.135.0)"
 	codexOriginator            = "codex-tui"
 	codexDefaultImageToolModel = "gpt-image-2"
@@ -226,10 +229,20 @@ func codexTerminalErrorIsContextLength(body []byte) bool {
 // CodexExecutor is a stateless executor for Codex (OpenAI Responses API entrypoint).
 // If api_key is unavailable on auth, it falls back to legacy via ClientAdapter.
 type CodexExecutor struct {
-	cfg *config.Config
+	cfg               *config.Config
+	codexOAuthBaseURL string
+	codexOAuthHeaders map[string]string
 }
 
-func NewCodexExecutor(cfg *config.Config) *CodexExecutor { return &CodexExecutor{cfg: cfg} }
+func NewCodexExecutor(cfg *config.Config) *CodexExecutor {
+	var codexOAuthBaseURL string
+	var codexOAuthHeaders map[string]string
+	if cfg != nil {
+		codexOAuthBaseURL = cfg.CodexOAuthBaseURL
+		codexOAuthHeaders = maps.Clone(cfg.CodexOAuthHeaders)
+	}
+	return &CodexExecutor{cfg: cfg, codexOAuthBaseURL: codexOAuthBaseURL, codexOAuthHeaders: codexOAuthHeaders}
+}
 
 func (e *CodexExecutor) Identifier() string { return "codex" }
 
@@ -723,6 +736,9 @@ func (e *CodexExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Aut
 	if req == nil {
 		return nil
 	}
+	if errRoute := e.routeCodexOAuthHTTPRequest(req, auth); errRoute != nil {
+		return errRoute
+	}
 	apiKey, _ := codexCreds(auth)
 	if strings.TrimSpace(apiKey) != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
@@ -732,6 +748,7 @@ func (e *CodexExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Aut
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(req, attrs)
+	e.applyCodexOAuthHeaders(req, auth)
 	return nil
 }
 
@@ -760,10 +777,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
-	apiKey, baseURL := codexCreds(auth)
-	if baseURL == "" {
-		baseURL = "https://chatgpt.com/backend-api/codex"
-	}
+	apiKey, baseURL := e.codexCreds(auth)
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -813,6 +827,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyModelHeaderOverrides(httpReq.Header, baseModel)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	e.applyCodexOAuthHeaders(httpReq, auth)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -941,10 +956,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
-	apiKey, baseURL := codexCreds(auth)
-	if baseURL == "" {
-		baseURL = "https://chatgpt.com/backend-api/codex"
-	}
+	apiKey, baseURL := e.codexCreds(auth)
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -983,6 +995,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	applyCodexHeaders(httpReq, auth, apiKey, false, e.cfg)
 	applyModelHeaderOverrides(httpReq.Header, baseModel)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	e.applyCodexOAuthHeaders(httpReq, auth)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -1046,10 +1059,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
-	apiKey, baseURL := codexCreds(auth)
-	if baseURL == "" {
-		baseURL = "https://chatgpt.com/backend-api/codex"
-	}
+	apiKey, baseURL := e.codexCreds(auth)
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -1098,6 +1108,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyModelHeaderOverrides(httpReq.Header, baseModel)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	e.applyCodexOAuthHeaders(httpReq, auth)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -1598,6 +1609,15 @@ func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, s
 	applyCodexHeadersFromSources(r, auth, token, stream, cfg, ginHeaders)
 }
 
+func (e *CodexExecutor) applyCodexOAuthHeaders(r *http.Request, auth *cliproxyauth.Auth) {
+	if r == nil || !e.usesConfiguredOAuthBaseURL(auth) {
+		return
+	}
+	for name, value := range e.codexOAuthHeaders {
+		r.Header.Set(name, value)
+	}
+}
+
 // applyModelHeaderOverrides forces models.json config.override_header onto upstream headers.
 func applyModelHeaderOverrides(headers http.Header, modelName string) {
 	if headers == nil {
@@ -1932,6 +1952,68 @@ func codexCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {
 		}
 	}
 	return
+}
+
+func (e *CodexExecutor) codexCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {
+	apiKey, baseURL = codexCreds(a)
+	if e.usesConfiguredOAuthBaseURL(a) {
+		baseURL = e.codexOAuthBaseURL
+	}
+	if baseURL == "" {
+		baseURL = codexDefaultBaseURL
+	}
+	return apiKey, baseURL
+}
+
+func (e *CodexExecutor) usesConfiguredOAuthBaseURL(a *cliproxyauth.Auth) bool {
+	if e == nil || e.codexOAuthBaseURL == "" || a == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(a.Provider), "codex") {
+		return false
+	}
+	return a.Attributes == nil || strings.TrimSpace(a.Attributes["api_key"]) == ""
+}
+
+func (e *CodexExecutor) routeCodexOAuthHTTPRequest(req *http.Request, auth *cliproxyauth.Auth) error {
+	if !e.usesConfiguredOAuthBaseURL(auth) {
+		return nil
+	}
+	if req == nil || req.URL == nil {
+		return fmt.Errorf("codex executor: request URL is nil")
+	}
+
+	configuredBase, errConfigured := url.Parse(e.codexOAuthBaseURL)
+	if errConfigured != nil {
+		return fmt.Errorf("codex executor: invalid codex-oauth-base-url: %w", errConfigured)
+	}
+	if codexRequestURLUsesBase(req.URL, configuredBase) {
+		return nil
+	}
+
+	defaultBase, errDefault := url.Parse(codexDefaultBaseURL)
+	if errDefault != nil {
+		return fmt.Errorf("codex executor: invalid default Codex base URL: %w", errDefault)
+	}
+	if !codexRequestURLUsesBase(req.URL, defaultBase) {
+		return fmt.Errorf("codex executor: OAuth request URL %q does not use codex-oauth-base-url %q", req.URL.String(), e.codexOAuthBaseURL)
+	}
+
+	defaultPath := strings.TrimSuffix(defaultBase.Path, "/")
+	suffix := strings.TrimPrefix(req.URL.Path, defaultPath)
+	configuredBase.Path = strings.TrimSuffix(configuredBase.Path, "/") + suffix
+	configuredBase.RawQuery = req.URL.RawQuery
+	req.URL = configuredBase
+	req.Host = ""
+	return nil
+}
+
+func codexRequestURLUsesBase(requestURL, baseURL *url.URL) bool {
+	if requestURL == nil || baseURL == nil || !strings.EqualFold(requestURL.Scheme, baseURL.Scheme) || !strings.EqualFold(requestURL.Host, baseURL.Host) {
+		return false
+	}
+	basePath := strings.TrimSuffix(baseURL.Path, "/")
+	return requestURL.Path == basePath || strings.HasPrefix(requestURL.Path, basePath+"/")
 }
 
 func (e *CodexExecutor) resolveCodexConfig(auth *cliproxyauth.Auth) *config.CodexKey {

--- a/internal/runtime/executor/codex_oauth_base_url_test.go
+++ b/internal/runtime/executor/codex_oauth_base_url_test.go
@@ -1,0 +1,190 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestCodexExecutorOAuthBaseURLDefaultsToStock(t *testing.T) {
+	exec := NewCodexExecutor(&config.Config{})
+	_, baseURL := exec.codexCreds(&cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"access_token": "oauth-token"},
+	})
+	if baseURL != codexDefaultBaseURL {
+		t.Fatalf("baseURL = %q, want stock %q", baseURL, codexDefaultBaseURL)
+	}
+}
+
+func TestCodexAutoExecutorConfiguredOAuthBaseUsesHTTPResponsesEndpoint(t *testing.T) {
+	var gotPath string
+	var gotUpgrade string
+	var gotEdgeKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotUpgrade = r.Header.Get("Upgrade")
+		gotEdgeKey = r.Header.Get("X-Edgee-Api-Key")
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":0,\"output_tokens\":0,\"total_tokens\":0}}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewCodexAutoExecutor(&config.Config{
+		CodexOAuthBaseURL: server.URL,
+		CodexOAuthHeaders: map[string]string{"x-edgee-api-key": "edge-key"},
+		SDKConfig:         config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll},
+	})
+	auth := &cliproxyauth.Auth{
+		Provider:   "codex",
+		Attributes: map[string]string{"websockets": "true"},
+		Metadata:   map[string]any{"access_token": "oauth-token"},
+	}
+	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+
+	_, errExecute := exec.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","input":"hello"}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response")})
+	if errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	if gotPath != "/responses" {
+		t.Fatalf("request path = %q, want /responses", gotPath)
+	}
+	if gotUpgrade != "" {
+		t.Fatalf("Upgrade = %q, want plain HTTP request", gotUpgrade)
+	}
+	if gotEdgeKey != "edge-key" {
+		t.Fatalf("X-Edgee-Api-Key = %q, want configured header", gotEdgeKey)
+	}
+}
+
+func TestCodexExecutorOAuthConfigIsStableAcrossTokenRefreshAndConfigMutation(t *testing.T) {
+	cfg := &config.Config{
+		CodexOAuthBaseURL: "https://edge.example.com/codex",
+		CodexOAuthHeaders: map[string]string{"x-edgee-api-key": "startup-key"},
+	}
+	exec := NewCodexExecutor(cfg)
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+
+	refreshedAuth, errRefresh := exec.Refresh(context.Background(), auth)
+	if errRefresh != nil {
+		t.Fatalf("Refresh() error = %v", errRefresh)
+	}
+	oldToken, oldBaseURL := exec.codexCreds(refreshedAuth)
+	auth.Metadata["access_token"] = "refreshed-token"
+	cfg.CodexOAuthBaseURL = "https://reload.example.com/codex"
+	cfg.CodexOAuthHeaders["x-edgee-api-key"] = "reload-key"
+	newToken, newBaseURL := exec.codexCreds(auth)
+
+	if oldToken != "old-token" || newToken != "refreshed-token" {
+		t.Fatalf("tokens = %q, %q; want old and refreshed token", oldToken, newToken)
+	}
+	if oldBaseURL != "https://edge.example.com/codex" || newBaseURL != oldBaseURL {
+		t.Fatalf("base URLs = %q, %q; want immutable startup route", oldBaseURL, newBaseURL)
+	}
+	httpReq, errRequest := http.NewRequest(http.MethodPost, newBaseURL+"/responses", nil)
+	if errRequest != nil {
+		t.Fatalf("NewRequest() error = %v", errRequest)
+	}
+	exec.applyCodexOAuthHeaders(httpReq, auth)
+	if got := httpReq.Header.Get("X-Edgee-Api-Key"); got != "startup-key" {
+		t.Fatalf("X-Edgee-Api-Key = %q, want immutable startup value", got)
+	}
+}
+
+func TestCodexExecutorHttpRequestRewritesStockOAuthURLToConfiguredBase(t *testing.T) {
+	var gotPath string
+	var gotEdgeKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotEdgeKey = r.Header.Get("X-Edgee-Api-Key")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	exec := NewCodexExecutor(&config.Config{
+		CodexOAuthBaseURL: server.URL + "/edge/codex",
+		CodexOAuthHeaders: map[string]string{"x-edgee-api-key": "edge-key"},
+	})
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"access_token": "oauth-token"},
+	}
+	req, errRequest := http.NewRequest(http.MethodPost, codexDefaultBaseURL+"/responses", nil)
+	if errRequest != nil {
+		t.Fatalf("NewRequest() error = %v", errRequest)
+	}
+
+	resp, errHTTP := exec.HttpRequest(context.Background(), auth, req)
+	if errHTTP != nil {
+		t.Fatalf("HttpRequest() error = %v", errHTTP)
+	}
+	if _, errRead := io.Copy(io.Discard, resp.Body); errRead != nil {
+		t.Fatalf("read response body: %v", errRead)
+	}
+	if errClose := resp.Body.Close(); errClose != nil {
+		t.Fatalf("close response body: %v", errClose)
+	}
+	if gotPath != "/edge/codex/responses" {
+		t.Fatalf("request path = %q, want /edge/codex/responses", gotPath)
+	}
+	if gotEdgeKey != "edge-key" {
+		t.Fatalf("X-Edgee-Api-Key = %q, want configured header", gotEdgeKey)
+	}
+}
+
+func TestCodexExecutorOAuthHeadersAreNotAppliedWithoutBaseURL(t *testing.T) {
+	exec := NewCodexExecutor(&config.Config{
+		CodexOAuthHeaders: map[string]string{"x-edgee-api-key": "edge-key"},
+	})
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Metadata: map[string]any{"access_token": "oauth-token"},
+	}
+	req, errRequest := http.NewRequest(http.MethodPost, codexDefaultBaseURL+"/responses", nil)
+	if errRequest != nil {
+		t.Fatalf("NewRequest() error = %v", errRequest)
+	}
+
+	if errPrepare := exec.PrepareRequest(req, auth); errPrepare != nil {
+		t.Fatalf("PrepareRequest() error = %v", errPrepare)
+	}
+	if got := req.Header.Get("X-Edgee-Api-Key"); got != "" {
+		t.Fatalf("X-Edgee-Api-Key = %q, want empty without configured base URL", got)
+	}
+}
+
+func TestCodexExecutorConfiguredOAuthBaseDoesNotOverrideAPIKeyAuth(t *testing.T) {
+	exec := NewCodexExecutor(&config.Config{
+		CodexOAuthBaseURL: "https://edge.example.com/codex",
+		CodexOAuthHeaders: map[string]string{"x-edgee-api-key": "edge-key"},
+	})
+	auth := &cliproxyauth.Auth{Provider: "codex", Attributes: map[string]string{
+		"api_key":  "sk-test",
+		"base_url": "https://api-key.example.com/v1",
+	}}
+	_, baseURL := exec.codexCreds(auth)
+	if baseURL != "https://api-key.example.com/v1" {
+		t.Fatalf("baseURL = %q, want API-key route", baseURL)
+	}
+	req, errRequest := http.NewRequest(http.MethodPost, baseURL+"/responses", nil)
+	if errRequest != nil {
+		t.Fatalf("NewRequest() error = %v", errRequest)
+	}
+	exec.applyCodexOAuthHeaders(req, auth)
+	if got := req.Header.Get("X-Edgee-Api-Key"); got != "" {
+		t.Fatalf("X-Edgee-Api-Key = %q, want empty for API-key auth", got)
+	}
+}

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -91,10 +91,7 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 		return resp, errPrepare
 	}
 
-	apiKey, baseURL := codexCreds(auth)
-	if baseURL == "" {
-		baseURL = "https://chatgpt.com/backend-api/codex"
-	}
+	apiKey, baseURL := e.codexCreds(auth)
 
 	mainModel := e.resolveGPTImage2BaseModel()
 	reporter := helps.NewExecutorUsageReporter(ctx, e, mainModel, auth)
@@ -115,6 +112,7 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyModelHeaderOverrides(httpReq.Header, mainModel)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	e.applyCodexOAuthHeaders(httpReq, auth)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
@@ -188,10 +186,7 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 		return nil, errPrepare
 	}
 
-	apiKey, baseURL := codexCreds(auth)
-	if baseURL == "" {
-		baseURL = "https://chatgpt.com/backend-api/codex"
-	}
+	apiKey, baseURL := e.codexCreds(auth)
 
 	mainModel := e.resolveGPTImage2BaseModel()
 	reporter := helps.NewExecutorUsageReporter(ctx, e, mainModel, auth)
@@ -212,6 +207,7 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyModelHeaderOverrides(httpReq.Header, mainModel)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	e.applyCodexOAuthHeaders(httpReq, auth)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
@@ -321,10 +317,7 @@ func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *clip
 		return resp, errPrepare
 	}
 
-	apiKey, baseURL := codexCreds(auth)
-	if baseURL == "" {
-		baseURL = "https://chatgpt.com/backend-api/codex"
-	}
+	apiKey, baseURL := e.codexCreds(auth)
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, model, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -342,6 +335,7 @@ func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *clip
 		httpReq.Header.Set("Content-Type", contentType)
 	}
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	e.applyCodexOAuthHeaders(httpReq, auth)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
@@ -382,10 +376,7 @@ func (e *CodexExecutor) executeDirectOpenAIImageStream(ctx context.Context, auth
 		return nil, errPrepare
 	}
 
-	apiKey, baseURL := codexCreds(auth)
-	if baseURL == "" {
-		baseURL = "https://chatgpt.com/backend-api/codex"
-	}
+	apiKey, baseURL := e.codexCreds(auth)
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, model, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -403,6 +394,7 @@ func (e *CodexExecutor) executeDirectOpenAIImageStream(ctx context.Context, auth
 		httpReq.Header.Set("Content-Type", contentType)
 	}
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	e.applyCodexOAuthHeaders(httpReq, auth)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -175,15 +175,15 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if e.CodexExecutor.usesConfiguredOAuthBaseURL(auth) {
+		return e.CodexExecutor.Execute(ctx, auth, req, opts)
+	}
 	if opts.Alt == "responses/compact" {
 		return e.CodexExecutor.executeCompact(ctx, auth, req, opts)
 	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
-	apiKey, baseURL := codexCreds(auth)
-	if baseURL == "" {
-		baseURL = "https://chatgpt.com/backend-api/codex"
-	}
+	apiKey, baseURL := e.CodexExecutor.codexCreds(auth)
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -401,15 +401,15 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if e.CodexExecutor.usesConfiguredOAuthBaseURL(auth) {
+		return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)
+	}
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
 	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
-	apiKey, baseURL := codexCreds(auth)
-	if baseURL == "" {
-		baseURL = "https://chatgpt.com/backend-api/codex"
-	}
+	apiKey, baseURL := e.CodexExecutor.codexCreds(auth)
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -1723,7 +1723,7 @@ func (e *CodexAutoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth
 	if e == nil || e.httpExec == nil || e.wsExec == nil {
 		return cliproxyexecutor.Response{}, fmt.Errorf("codex auto executor: executor is nil")
 	}
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
+	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) && !e.httpExec.usesConfiguredOAuthBaseURL(auth) {
 		return e.wsExec.Execute(ctx, auth, req, opts)
 	}
 	return e.httpExec.Execute(ctx, auth, req, opts)
@@ -1733,7 +1733,7 @@ func (e *CodexAutoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyaut
 	if e == nil || e.httpExec == nil || e.wsExec == nil {
 		return nil, fmt.Errorf("codex auto executor: executor is nil")
 	}
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
+	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) && !e.httpExec.usesConfiguredOAuthBaseURL(auth) {
 		return e.wsExec.ExecuteStream(ctx, auth, req, opts)
 	}
 	return e.httpExec.ExecuteStream(ctx, auth, req, opts)

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -6,6 +6,7 @@ package cliproxy
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -271,17 +272,19 @@ func (b *Builder) Build() (*Service, error) {
 	}
 
 	service := &Service{
-		cfg:            b.cfg,
-		configPath:     b.configPath,
-		tokenProvider:  tokenProvider,
-		apiKeyProvider: apiKeyProvider,
-		watcherFactory: watcherFactory,
-		hooks:          b.hooks,
-		authManager:    authManager,
-		accessManager:  accessManager,
-		coreManager:    coreManager,
-		pluginHost:     pluginHost,
-		serverOptions:  append([]api.ServerOption(nil), b.serverOptions...),
+		cfg:               b.cfg,
+		codexOAuthBaseURL: b.cfg.CodexOAuthBaseURL,
+		codexOAuthHeaders: maps.Clone(b.cfg.CodexOAuthHeaders),
+		configPath:        b.configPath,
+		tokenProvider:     tokenProvider,
+		apiKeyProvider:    apiKeyProvider,
+		watcherFactory:    watcherFactory,
+		hooks:             b.hooks,
+		authManager:       authManager,
+		accessManager:     accessManager,
+		coreManager:       coreManager,
+		pluginHost:        pluginHost,
+		serverOptions:     append([]api.ServerOption(nil), b.serverOptions...),
 	}
 	if b.postAuthHook != nil {
 		service.serverOptions = append(service.serverOptions, api.WithPostAuthHook(b.postAuthHook))

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"sync"
@@ -41,6 +42,12 @@ import (
 type Service struct {
 	// cfg holds the current application configuration.
 	cfg *config.Config
+
+	// codexOAuthBaseURL is immutable for the lifetime of the service.
+	codexOAuthBaseURL string
+
+	// codexOAuthHeaders is immutable for the lifetime of the service.
+	codexOAuthHeaders map[string]string
 
 	// cfgMu protects concurrent access to the configuration.
 	cfgMu sync.RWMutex
@@ -1275,6 +1282,8 @@ func (s *Service) applyConfigUpdateWithAuthSynthesis(newCfg *config.Config, synt
 	if newCfg == nil {
 		return
 	}
+	newCfg.CodexOAuthBaseURL = s.codexOAuthBaseURL
+	newCfg.CodexOAuthHeaders = maps.Clone(s.codexOAuthHeaders)
 
 	nextStrategy := strings.ToLower(strings.TrimSpace(newCfg.Routing.Strategy))
 	normalizeStrategy := func(strategy string) string {
@@ -1641,7 +1650,13 @@ func (s *Service) Run(ctx context.Context) error {
 	s.registerPluginAuthParser()
 	if s.coreManager != nil && !homeEnabled {
 		if errLoad := s.coreManager.Load(ctx); errLoad != nil {
+			if s.cfg != nil && s.cfg.CodexOAuthBaseURL != "" {
+				return fmt.Errorf("cliproxy: cannot validate codex-oauth-base-url conflicts because the auth store failed to load: %w", errLoad)
+			}
 			log.Warnf("failed to load auth store: %v", errLoad)
+		}
+		if errConflict := validateCodexOAuthBaseURLAuthConflicts(s.cfg, s.coreManager.List()); errConflict != nil {
+			return errConflict
 		}
 		s.registerConfigAPIKeyAuths(coreauth.WithSkipPersist(ctx), s.cfg)
 		if s.cfg.SaveCooldownStatus {
@@ -1778,6 +1793,59 @@ func (s *Service) Run(ctx context.Context) error {
 	case errServer := <-s.serverErr:
 		return errServer
 	}
+}
+
+func validateCodexOAuthBaseURLAuthConflicts(cfg *config.Config, auths []*coreauth.Auth) error {
+	if cfg == nil || cfg.CodexOAuthBaseURL == "" {
+		return nil
+	}
+
+	for _, auth := range auths {
+		if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+			continue
+		}
+		if auth.Attributes != nil && strings.TrimSpace(auth.Attributes["api_key"]) != "" {
+			continue
+		}
+
+		baseURL := ""
+		if auth.Attributes != nil {
+			baseURL = strings.TrimSpace(auth.Attributes["base_url"])
+		}
+		if baseURL == "" && auth.Metadata != nil {
+			if rawBaseURL, exists := auth.Metadata["base_url"]; exists && rawBaseURL != nil {
+				value, okString := rawBaseURL.(string)
+				if !okString {
+					return fmt.Errorf("codex-oauth-base-url conflicts with Codex OAuth auth %q: base_url must be a string", codexAuthConflictName(auth))
+				}
+				baseURL = strings.TrimSpace(value)
+			}
+		}
+		if baseURL == "" {
+			continue
+		}
+
+		for index := range cfg.CodexKey {
+			if strings.EqualFold(strings.TrimSpace(cfg.CodexKey[index].BaseURL), baseURL) {
+				return fmt.Errorf("codex-oauth-base-url conflicts with Codex OAuth auth %q base_url %q, which matches codex-api-key[%d].base-url", codexAuthConflictName(auth), baseURL, index)
+			}
+		}
+		return fmt.Errorf("codex-oauth-base-url conflicts with Codex OAuth auth %q base_url %q", codexAuthConflictName(auth), baseURL)
+	}
+	return nil
+}
+
+func codexAuthConflictName(auth *coreauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	if fileName := strings.TrimSpace(auth.FileName); fileName != "" {
+		return fileName
+	}
+	if id := strings.TrimSpace(auth.ID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(auth.Label)
 }
 
 // Shutdown gracefully stops background workers and the HTTP server.

--- a/sdk/cliproxy/service_codex_oauth_base_url_test.go
+++ b/sdk/cliproxy/service_codex_oauth_base_url_test.go
@@ -1,0 +1,113 @@
+package cliproxy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestValidateCodexOAuthBaseURLAuthConflicts(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        *config.Config
+		auth       *coreauth.Auth
+		wantErr    bool
+		wantDetail string
+	}{
+		{
+			name: "unset preserves stock behavior",
+			cfg:  &config.Config{},
+			auth: &coreauth.Auth{Provider: "codex", Attributes: map[string]string{"base_url": "https://legacy.example.com"}},
+		},
+		{
+			name:       "attribute base URL conflicts",
+			cfg:        &config.Config{CodexOAuthBaseURL: "https://edge.example.com"},
+			auth:       &coreauth.Auth{ID: "oauth-attr", Provider: "codex", Attributes: map[string]string{"base_url": "https://legacy.example.com"}},
+			wantErr:    true,
+			wantDetail: "oauth-attr",
+		},
+		{
+			name:       "auth file metadata base URL conflicts",
+			cfg:        &config.Config{CodexOAuthBaseURL: "https://edge.example.com"},
+			auth:       &coreauth.Auth{ID: "oauth-file", FileName: "auths/codex.json", Provider: "codex", Metadata: map[string]any{"base_url": "https://legacy.example.com"}},
+			wantErr:    true,
+			wantDetail: "auths/codex.json",
+		},
+		{
+			name: "matching codex API key entry is named",
+			cfg: &config.Config{
+				CodexOAuthBaseURL: "https://edge.example.com",
+				CodexKey:          []config.CodexKey{{BaseURL: "https://legacy.example.com"}},
+			},
+			auth:       &coreauth.Auth{ID: "oauth-match", Provider: "codex", Metadata: map[string]any{"base_url": "https://legacy.example.com"}},
+			wantErr:    true,
+			wantDetail: "codex-api-key[0]",
+		},
+		{
+			name: "API key auth keeps its own base URL",
+			cfg:  &config.Config{CodexOAuthBaseURL: "https://edge.example.com"},
+			auth: &coreauth.Auth{Provider: "codex", Attributes: map[string]string{"api_key": "sk-test", "base_url": "https://api-key.example.com"}},
+		},
+		{
+			name: "other provider is ignored",
+			cfg:  &config.Config{CodexOAuthBaseURL: "https://edge.example.com"},
+			auth: &coreauth.Auth{Provider: "claude", Attributes: map[string]string{"base_url": "https://legacy.example.com"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errConflict := validateCodexOAuthBaseURLAuthConflicts(tt.cfg, []*coreauth.Auth{tt.auth})
+			if !tt.wantErr {
+				if errConflict != nil {
+					t.Fatalf("validation error = %v, want nil", errConflict)
+				}
+				return
+			}
+			if errConflict == nil {
+				t.Fatal("validation error = nil, want conflict")
+			}
+			if !strings.Contains(errConflict.Error(), "codex-oauth-base-url") || !strings.Contains(errConflict.Error(), tt.wantDetail) {
+				t.Fatalf("validation error = %q, want key and %q", errConflict, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestApplyConfigUpdateKeepsStartupCodexOAuthConfig(t *testing.T) {
+	startupURL := "https://startup.example.com/codex"
+	startupHeaders := map[string]string{"x-edgee-api-key": "startup-key"}
+	service := &Service{
+		cfg: &config.Config{
+			CodexOAuthBaseURL: startupURL,
+			CodexOAuthHeaders: map[string]string{"x-edgee-api-key": "startup-key"},
+		},
+		codexOAuthBaseURL: startupURL,
+		codexOAuthHeaders: startupHeaders,
+	}
+	reloaded := &config.Config{
+		CodexOAuthBaseURL: "https://reload.example.com/codex",
+		CodexOAuthHeaders: map[string]string{"x-edgee-api-key": "reload-key"},
+	}
+
+	service.applyConfigUpdateWithAuthSynthesis(reloaded, false)
+
+	if reloaded.CodexOAuthBaseURL != startupURL {
+		t.Fatalf("reloaded CodexOAuthBaseURL = %q, want startup %q", reloaded.CodexOAuthBaseURL, startupURL)
+	}
+	if service.cfg.CodexOAuthBaseURL != startupURL {
+		t.Fatalf("service CodexOAuthBaseURL = %q, want startup %q", service.cfg.CodexOAuthBaseURL, startupURL)
+	}
+	if got := reloaded.CodexOAuthHeaders["x-edgee-api-key"]; got != "startup-key" {
+		t.Fatalf("reloaded CodexOAuthHeaders value = %q, want startup value", got)
+	}
+	if got := service.cfg.CodexOAuthHeaders["x-edgee-api-key"]; got != "startup-key" {
+		t.Fatalf("service CodexOAuthHeaders value = %q, want startup value", got)
+	}
+	startupHeaders["x-edgee-api-key"] = "mutated-after-reload"
+	if got := reloaded.CodexOAuthHeaders["x-edgee-api-key"]; got != "startup-key" {
+		t.Fatalf("reloaded CodexOAuthHeaders aliases startup snapshot: got %q", got)
+	}
+}


### PR DESCRIPTION
## Motivation

ChatGPT-Codex subscription (OAuth) traffic currently always egresses to the fixed `https://chatgpt.com/backend-api/codex` upstream. `codex-api-key` entries already support a per-key `base-url` override, but OAuth auth records have no supported equivalent, so there is no way to route subscription traffic through a local or companion proxy (e.g. a compression/caching gateway) without patching the binary.

This PR adds two top-level config keys that close that gap for OAuth credentials only, with strict validation and no behavior change when unset.

## Keys

- `codex-oauth-base-url` (string, default empty = stock behavior): upstream base URL for codex OAuth credentials (auth records without an `api_key` attribute). Validated at config load: absolute `http`/`https` URI, non-empty host, no userinfo/query/fragment; trailing slash trimmed. Startup fails loudly if any auth record or matching `codex-api-key` entry carries a competing `base_url`, so precedence is never silent. The value is captured at startup (hot-reload-inert) to avoid flipping a live process's routing.
- `codex-oauth-headers` (map, default empty): additional outbound headers (e.g. an API key for the companion proxy) applied to every routed codex OAuth request. Header names must be RFC 7230 tokens; `authorization`, `host`, and `content-length` are rejected case-insensitively. Setting headers without the base URL is a startup error.

## Transport

When the override is set, affected OAuth auths are forced onto the plain HTTP executor: companion proxies generally expose only the HTTP `/responses` surface, and forcing HTTP guarantees no request can bypass the configured upstream via the websocket path. Stock behavior (key unset) is untouched, including websockets.

All `backend-api/codex` consumers honor the override (responses, streaming, compact, images, generic HTTP requests, model fetch).

## Tests

`internal/config` (validation matrix incl. userinfo/query/fragment/relative/empty-host rejection, conflict detection, headers-without-base-url), `internal/runtime/executor` (override applied on HTTP path, headers attached, WS unreachable when set), `sdk/cliproxy` (service wiring), `cmd/fetch_codex_models`. `go build ./...` and the affected package tests pass; the one pre-existing failure on untouched HEAD (`internal/api.TestModelsWithClientVersionReturnsCodexCatalog`) is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)