### PR TITLE
fix(gemini): route 3.1 Flash Lite preview requests to GA

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -436,12 +436,42 @@
       }
     },
     {
+      "id": "gemini-3.1-flash-lite",
+      "object": "model",
+      "created": 1776288000,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.1 Flash Lite",
+      "name": "models/gemini-3.1-flash-lite",
+      "version": "3.1",
+      "description": "Our smallest and most cost effective model, built for at scale usage.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
       "id": "gemini-3.1-flash-lite-preview",
       "object": "model",
       "created": 1776288000,
       "owned_by": "google",
       "type": "gemini",
-      "display_name": "Gemini 3.1 Flash Lite Preview",
+      "display_name": "Gemini 3.1 Flash Lite (legacy preview id)",
       "name": "models/gemini-3.1-flash-lite-preview",
       "version": "3.1",
       "description": "Our smallest and most cost effective model, built for at scale usage.",
@@ -459,6 +489,8 @@
         "dynamic_allowed": true,
         "levels": [
           "minimal",
+          "low",
+          "medium",
           "high"
         ]
       }
@@ -735,12 +767,42 @@
       }
     },
     {
+      "id": "gemini-3.1-flash-lite",
+      "object": "model",
+      "created": 1776288000,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.1 Flash Lite",
+      "name": "models/gemini-3.1-flash-lite",
+      "version": "3.1",
+      "description": "Our smallest and most cost effective model, built for at scale usage.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
       "id": "gemini-3.1-flash-lite-preview",
       "object": "model",
       "created": 1776288000,
       "owned_by": "google",
       "type": "gemini",
-      "display_name": "Gemini 3.1 Flash Lite Preview",
+      "display_name": "Gemini 3.1 Flash Lite (legacy preview id)",
       "name": "models/gemini-3.1-flash-lite-preview",
       "version": "3.1",
       "description": "Our smallest and most cost effective model, built for at scale usage.",
@@ -1054,12 +1116,42 @@
       }
     },
     {
+      "id": "gemini-3.1-flash-lite",
+      "object": "model",
+      "created": 1776288000,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.1 Flash Lite",
+      "name": "models/gemini-3.1-flash-lite",
+      "version": "3.1",
+      "description": "Our smallest and most cost effective model, built for at scale usage.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
       "id": "gemini-3.1-flash-lite-preview",
       "object": "model",
       "created": 1776288000,
       "owned_by": "google",
       "type": "gemini",
-      "display_name": "Gemini 3.1 Flash Lite Preview",
+      "display_name": "Gemini 3.1 Flash Lite (legacy preview id)",
       "name": "models/gemini-3.1-flash-lite-preview",
       "version": "3.1",
       "description": "Our smallest and most cost effective model, built for at scale usage.",
@@ -1230,12 +1322,42 @@
       }
     },
     {
+      "id": "gemini-3.1-flash-lite",
+      "object": "model",
+      "created": 1776288000,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.1 Flash Lite",
+      "name": "models/gemini-3.1-flash-lite",
+      "version": "3.1",
+      "description": "Our smallest and most cost effective model, built for at scale usage.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
       "id": "gemini-3.1-flash-lite-preview",
       "object": "model",
       "created": 1776288000,
       "owned_by": "google",
       "type": "gemini",
-      "display_name": "Gemini 3.1 Flash Lite Preview",
+      "display_name": "Gemini 3.1 Flash Lite (legacy preview id)",
       "name": "models/gemini-3.1-flash-lite-preview",
       "version": "3.1",
       "description": "Our smallest and most cost effective model, built for at scale usage.",

--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -127,7 +127,7 @@ func (e *AIStudioExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth,
 	if opts.Alt == "responses/compact" {
 		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
@@ -196,7 +196,7 @@ func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
@@ -375,7 +375,7 @@ func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth
 
 // CountTokens counts tokens for the given request using the AI Studio API.
 func (e *AIStudioExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 	_, body, err := e.translateRequest(req, opts, false)
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
@@ -445,7 +445,7 @@ type translatedPayload struct {
 }
 
 func (e *AIStudioExecutor) translateRequest(req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) ([]byte, translatedPayload, error) {
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("gemini")

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -129,7 +129,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if shouldExecuteNativeInteractions(auth, opts) {
 		return e.executeInteractions(ctx, auth, req, opts)
 	}
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 
 	apiKey := geminiAPIKey(auth)
 
@@ -243,7 +243,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if shouldExecuteNativeInteractions(auth, opts) {
 		return e.executeInteractionsStream(ctx, auth, req, opts)
 	}
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 
 	apiKey := geminiAPIKey(auth)
 
@@ -381,7 +381,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 }
 
 func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
-	targetName := thinking.ParseSuffix(req.Model).ModelName
+	targetName := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 	apiKey := geminiAPIKey(auth)
 	reporter := helps.NewExecutorUsageReporter(ctx, e, targetName, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -457,7 +457,7 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 }
 
 func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
-	targetName := thinking.ParseSuffix(req.Model).ModelName
+	targetName := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 	apiKey := geminiAPIKey(auth)
 	reporter := helps.NewExecutorUsageReporter(ctx, e, targetName, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -606,7 +606,7 @@ func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cl
 
 // CountTokens counts tokens for the given request using the Gemini API.
 func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 
 	apiKey := geminiAPIKey(auth)
 

--- a/internal/runtime/executor/gemini_executor_test.go
+++ b/internal/runtime/executor/gemini_executor_test.go
@@ -142,6 +142,41 @@ func TestGeminiExecutorInteractionsWithGeminiAPIKeyUsesGeminiEndpoint(t *testing
 	}
 }
 
+func TestGeminiExecutorRewritesFlashLitePreviewToGAInPath(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`))
+	}))
+	defer server.Close()
+
+	exec := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "gemini",
+		Attributes: map[string]string{
+			"api_key":  "test-key",
+			"base_url": server.URL,
+		},
+	}
+	// Client still requests the retired preview id.
+	req := cliproxyexecutor.Request{
+		Model:   "gemini-3.1-flash-lite-preview",
+		Payload: []byte(`{"model":"gemini-3.1-flash-lite-preview","contents":[{"role":"user","parts":[{"text":"hi"}]}]}`),
+	}
+	_, errExecute := exec.Execute(context.Background(), auth, req, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FromString("gemini"),
+		ResponseFormat: sdktranslator.FromString("gemini"),
+	})
+	if errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	want := "/v1beta/models/gemini-3.1-flash-lite:generateContent"
+	if gotPath != want {
+		t.Fatalf("path = %q, want GA resource %q (preview must be rewritten)", gotPath, want)
+	}
+}
+
 func TestGeminiExecutorNativeInteractionsUsesInteractionsEndpoint(t *testing.T) {
 	var gotPath string
 	var gotRevision string

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -304,7 +304,7 @@ func (e *GeminiVertexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.A
 // executeWithServiceAccount handles authentication using service account credentials.
 // This method contains the original service account authentication logic.
 func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, projectID, location string, saJSON []byte) (resp cliproxyexecutor.Response, err error) {
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -439,7 +439,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 
 // executeWithAPIKey handles authentication using API key credentials.
 func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, apiKey, baseURL string) (resp cliproxyexecutor.Response, err error) {
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -554,7 +554,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 
 // executeStreamWithServiceAccount handles streaming authentication using service account credentials.
 func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, projectID, location string, saJSON []byte) (_ *cliproxyexecutor.StreamResult, err error) {
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -699,7 +699,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 
 // executeStreamWithAPIKey handles streaming authentication using API key credentials.
 func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, apiKey, baseURL string) (_ *cliproxyexecutor.StreamResult, err error) {
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
@@ -844,7 +844,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 
 // countTokensWithServiceAccount counts tokens using service account credentials.
 func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, projectID, location string, saJSON []byte) (cliproxyexecutor.Response, error) {
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -935,7 +935,7 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 
 // countTokensWithAPIKey handles token counting using API key credentials.
 func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, apiKey, baseURL string) (cliproxyexecutor.Response, error) {
-	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	baseModel := helps.CanonicalGeminiUpstreamModel(thinking.ParseSuffix(req.Model).ModelName)
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)

--- a/internal/runtime/executor/helps/gemini_model_aliases.go
+++ b/internal/runtime/executor/helps/gemini_model_aliases.go
@@ -1,0 +1,32 @@
+package helps
+
+import "strings"
+
+// geminiUpstreamModelAliases maps retired client-facing model IDs to the
+// upstream ID Google currently serves. Keep this map small and explicit.
+var geminiUpstreamModelAliases = map[string]string{
+	// Gemini 3.1 Flash Lite left preview; Vertex/AI Studio return 404 for the
+	// old preview resource name (see router-for-me/CLIProxyAPI#4220).
+	"gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
+}
+
+// CanonicalGeminiUpstreamModel rewrites known retired Gemini model IDs to the
+// GA resource name used by Google AI / Vertex publishers/google/models/{id}.
+// Unknown IDs are returned unchanged (after trim).
+func CanonicalGeminiUpstreamModel(model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return model
+	}
+	if canonical, ok := geminiUpstreamModelAliases[model]; ok {
+		return canonical
+	}
+	// Also accept "models/<id>" forms that some clients pass through.
+	if strings.HasPrefix(model, "models/") {
+		id := strings.TrimPrefix(model, "models/")
+		if canonical, ok := geminiUpstreamModelAliases[id]; ok {
+			return canonical
+		}
+	}
+	return model
+}

--- a/internal/runtime/executor/helps/gemini_model_aliases.go
+++ b/internal/runtime/executor/helps/gemini_model_aliases.go
@@ -12,21 +12,19 @@ var geminiUpstreamModelAliases = map[string]string{
 
 // CanonicalGeminiUpstreamModel rewrites known retired Gemini model IDs to the
 // GA resource name used by Google AI / Vertex publishers/google/models/{id}.
-// Unknown IDs are returned unchanged (after trim).
+// Accepts bare IDs and optional "models/<id>" forms; always returns a bare ID
+// so executors can safely build /models/{id}:... URLs. Unknown IDs are
+// returned unchanged after trim and prefix strip.
 func CanonicalGeminiUpstreamModel(model string) string {
 	model = strings.TrimSpace(model)
 	if model == "" {
 		return model
 	}
-	if canonical, ok := geminiUpstreamModelAliases[model]; ok {
+	// Strip one leading models/ so clients that pass resource names don't
+	// produce doubled /models/models/... segments in executor URLs.
+	id := strings.TrimPrefix(model, "models/")
+	if canonical, ok := geminiUpstreamModelAliases[id]; ok {
 		return canonical
 	}
-	// Also accept "models/<id>" forms that some clients pass through.
-	if strings.HasPrefix(model, "models/") {
-		id := strings.TrimPrefix(model, "models/")
-		if canonical, ok := geminiUpstreamModelAliases[id]; ok {
-			return canonical
-		}
-	}
-	return model
+	return id
 }

--- a/internal/runtime/executor/helps/gemini_model_aliases_test.go
+++ b/internal/runtime/executor/helps/gemini_model_aliases_test.go
@@ -1,6 +1,9 @@
 package helps
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestCanonicalGeminiUpstreamModel(t *testing.T) {
 	t.Parallel()
@@ -20,5 +23,21 @@ func TestCanonicalGeminiUpstreamModel(t *testing.T) {
 		if got := CanonicalGeminiUpstreamModel(tc.in); got != tc.want {
 			t.Fatalf("CanonicalGeminiUpstreamModel(%q)=%q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestCanonicalGeminiUpstreamModel_usedAsURLSegment(t *testing.T) {
+	t.Parallel()
+	// Mirror Gemini executor path shape: /v1beta/models/{id}:generateContent
+	upstream := CanonicalGeminiUpstreamModel("gemini-3.1-flash-lite-preview")
+	gotPath := fmt.Sprintf("/v1beta/models/%s:generateContent", upstream)
+	wantPath := "/v1beta/models/gemini-3.1-flash-lite:generateContent"
+	if gotPath != wantPath {
+		t.Fatalf("path = %q, want %q", gotPath, wantPath)
+	}
+	// Vertex publishers path shape
+	vertexPath := fmt.Sprintf("/v1/projects/p/locations/us-central1/publishers/google/models/%s:generateContent", upstream)
+	if vertexPath != "/v1/projects/p/locations/us-central1/publishers/google/models/gemini-3.1-flash-lite:generateContent" {
+		t.Fatalf("vertex path = %q", vertexPath)
 	}
 }

--- a/internal/runtime/executor/helps/gemini_model_aliases_test.go
+++ b/internal/runtime/executor/helps/gemini_model_aliases_test.go
@@ -1,0 +1,24 @@
+package helps
+
+import "testing"
+
+func TestCanonicalGeminiUpstreamModel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in, want string
+	}{
+		{"gemini-3.1-flash-lite-preview", "gemini-3.1-flash-lite"},
+		{"  gemini-3.1-flash-lite-preview  ", "gemini-3.1-flash-lite"},
+		{"models/gemini-3.1-flash-lite-preview", "gemini-3.1-flash-lite"},
+		{"gemini-3.1-flash-lite", "gemini-3.1-flash-lite"},
+		{"gemini-2.5-flash", "gemini-2.5-flash"},
+		{"", ""},
+		{"   ", ""},
+	}
+	for _, tc := range cases {
+		if got := CanonicalGeminiUpstreamModel(tc.in); got != tc.want {
+			t.Fatalf("CanonicalGeminiUpstreamModel(%q)=%q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/runtime/executor/helps/gemini_model_aliases_test.go
+++ b/internal/runtime/executor/helps/gemini_model_aliases_test.go
@@ -15,7 +15,9 @@ func TestCanonicalGeminiUpstreamModel(t *testing.T) {
 		{"  gemini-3.1-flash-lite-preview  ", "gemini-3.1-flash-lite"},
 		{"models/gemini-3.1-flash-lite-preview", "gemini-3.1-flash-lite"},
 		{"gemini-3.1-flash-lite", "gemini-3.1-flash-lite"},
+		{"models/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"},
 		{"gemini-2.5-flash", "gemini-2.5-flash"},
+		{"models/gemini-2.5-flash", "gemini-2.5-flash"},
 		{"", ""},
 		{"   ", ""},
 	}


### PR DESCRIPTION
## Summary

- Rewrite `gemini-3.1-flash-lite-preview` → `gemini-3.1-flash-lite` on **Gemini, Vertex AI, and AI Studio** execute/stream/count/interactions **upstream paths** via `helps.CanonicalGeminiUpstreamModel`.
- Keep the preview id registered as a legacy client-facing alias and add the GA catalog entry in the **embedded** `models.json`.
- Tests: helper coverage + `TestGeminiExecutorRewritesFlashLitePreviewToGAInPath` (real `Execute()` path assertion).

## Why

Google retired the preview resource name; clients get `404 NOT_FOUND` for `…/models/gemini-3.1-flash-lite-preview` (#4220).

## Companion (required for durable catalog)

Embedded catalog is overwritten by remote refresh/CI from **[router-for-me/models](https://github.com/router-for-me/models)**.

**Required companion:** https://github.com/router-for-me/models/pull/23  
Without models#23, runtime rewrite still fixes the 404, but catalog GA listing will not persist after remote refresh.

## Out of scope / residuals

- Vertex **region** defaults (separate from model resource-name 404).
- Selection-layer per-model cooldown keys still use the client-facing model string (preview vs GA are dual registrations). Pre-existing dual-ID behavior; not introduced as a new selection API.

## Codex gate (gpt-5.6-sol · xhigh)

| Gate | Result |
|---|---|
| Correctness (A) | **PASS** |
| Policy (B) | **PASS** |
| Completeness (C) initial | REVISE → fixed tests + companion link |
| Correctness re-gate (A2) | **PASS** |
| Completeness re-gate (C2) | residual notes addressed in this body |

## Test plan

- [x] `go test ./internal/runtime/executor/helps -count=1`
- [x] `go test ./internal/runtime/executor -run TestGeminiExecutorRewritesFlashLitePreviewToGAInPath -count=1`
- [x] `go build -o test-output ./cmd/server && rm test-output`
- [x] CI checks green on PR

Fixes #4220