### PR TITLE
feat(auth): optionally disable credentials on HTTP 402

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -197,6 +197,11 @@ quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
   antigravity-credits: true # Whether to use credits as last-resort fallback when all free-tier auths are exhausted for Claude models
+  # HTTP 402 handling: "cooldown" (default) or "disable".
+  # "disable" removes the exhausted credential from rotation until manually re-enabled.
+  # File-backed auths persist this state; config-listed API keys may be re-created active on reload.
+  # Plugin-expanded virtual auths retain cooldown because their source file controls the whole group.
+  on-payment-required: "cooldown"
 
 # Routing strategy for selecting credentials when multiple match.
 routing:

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -260,6 +260,7 @@ func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *
 		return current, nil
 	}
 
+	maintenanceSource := auth.Clone()
 	refreshToken := stringValue(metadata, "refresh_token")
 	if refreshToken == "" {
 		return "", fmt.Errorf("antigravity refresh token missing")
@@ -335,7 +336,7 @@ func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *
 	if h != nil && h.authManager != nil {
 		auth.LastRefreshedAt = now
 		auth.UpdatedAt = now
-		_, _ = h.authManager.Update(ctx, auth)
+		_, _ = h.authManager.UpdateCredentialMaintenance(ctx, maintenanceSource, auth)
 	}
 
 	return strings.TrimSpace(tokenResp.AccessToken), nil

--- a/internal/api/handlers/management/api_tools_payment_required_test.go
+++ b/internal/api/handlers/management/api_tools_payment_required_test.go
@@ -1,0 +1,102 @@
+package management
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestRefreshAntigravityOAuthAccessTokenPreservesConcurrentPaymentDisable(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"refreshed-access-token","expires_in":3600,"token_type":"Bearer"}`))
+	}))
+	defer server.Close()
+
+	previousTokenURL := antigravityOAuthTokenURL
+	antigravityOAuthTokenURL = server.URL
+	defer func() { antigravityOAuthTokenURL = previousTokenURL }()
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(&config.Config{
+		QuotaExceeded: config.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	auth := &coreauth.Auth{
+		ID:       "antigravity-management-refresh.json",
+		Provider: "antigravity",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{
+			"type":          "antigravity",
+			"access_token":  "expired-access-token",
+			"refresh_token": "refresh-token",
+			"expired":       time.Now().Add(-time.Minute).Format(time.RFC3339),
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register: %v", errRegister)
+	}
+	staleRefreshAuth, okAuth := manager.GetByID(auth.ID)
+	if !okAuth || staleRefreshAuth == nil {
+		t.Fatal("registered auth missing")
+	}
+
+	handler := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, errRefresh := handler.refreshAntigravityOAuthAccessToken(context.Background(), staleRefreshAuth)
+		refreshDone <- errRefresh
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("management token refresh did not start")
+	}
+
+	manager.MarkResult(context.Background(), coreauth.Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "gemini-test",
+		Error: &coreauth.Error{
+			HTTPStatus: http.StatusPaymentRequired,
+			Message:    "insufficient balance",
+		},
+	})
+	current, okCurrent := manager.GetByID(auth.ID)
+	if !okCurrent || current == nil || !current.Disabled || current.Status != coreauth.StatusDisabled {
+		t.Fatalf("402 did not disable auth before refresh completion: %#v", current)
+	}
+
+	close(release)
+	select {
+	case errRefresh := <-refreshDone:
+		if errRefresh != nil {
+			t.Fatalf("refreshAntigravityOAuthAccessToken: %v", errRefresh)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("management token refresh did not finish")
+	}
+
+	current, okCurrent = manager.GetByID(auth.ID)
+	if !okCurrent || current == nil {
+		t.Fatal("auth missing after refresh")
+	}
+	if !current.Disabled || current.Status != coreauth.StatusDisabled {
+		t.Fatalf("stale management refresh re-enabled payment-disabled auth: %#v", current)
+	}
+	if reason, _ := current.Metadata["disabled_reason"].(string); reason != "payment_required" {
+		t.Fatalf("disabled_reason = %q, want payment_required", reason)
+	}
+	if got, _ := current.Metadata["access_token"].(string); got != "refreshed-access-token" {
+		t.Fatalf("refreshed access token = %q, want refreshed-access-token", got)
+	}
+}

--- a/internal/api/handlers/management/auth_files_fields.go
+++ b/internal/api/handlers/management/auth_files_fields.go
@@ -184,6 +184,7 @@ func applyAuthDisabledState(auth *coreauth.Auth, disabled bool) {
 	if auth == nil {
 		return
 	}
+	paymentRequiredDisabled := isPaymentRequiredDisabled(auth)
 	auth.Disabled = disabled
 	if disabled {
 		auth.Status = coreauth.StatusDisabled
@@ -191,6 +192,9 @@ func applyAuthDisabledState(auth *coreauth.Auth, disabled bool) {
 	} else {
 		auth.Status = coreauth.StatusActive
 		auth.StatusMessage = ""
+		if paymentRequiredDisabled {
+			clearPaymentRequiredDisabledReason(auth)
+		}
 	}
 	auth.UpdatedAt = time.Now()
 	if auth.Metadata == nil {
@@ -589,6 +593,7 @@ func syncAuthFileDisabledState(auth *coreauth.Auth) {
 	if !ok {
 		return
 	}
+	paymentRequiredDisabled := isPaymentRequiredDisabled(auth)
 	auth.Disabled = disabled
 	if disabled {
 		auth.Status = coreauth.StatusDisabled
@@ -599,6 +604,23 @@ func syncAuthFileDisabledState(auth *coreauth.Auth) {
 	}
 	auth.Status = coreauth.StatusActive
 	auth.StatusMessage = ""
+	if paymentRequiredDisabled {
+		clearPaymentRequiredDisabledReason(auth)
+	}
+}
+
+func isPaymentRequiredDisabled(auth *coreauth.Auth) bool {
+	if auth == nil || auth.Metadata == nil {
+		return false
+	}
+	reason, _ := auth.Metadata["disabled_reason"].(string)
+	return reason == "payment_required"
+}
+
+func clearPaymentRequiredDisabledReason(auth *coreauth.Auth) {
+	if auth.Metadata != nil {
+		delete(auth.Metadata, "disabled_reason")
+	}
 }
 
 func (h *Handler) removeAuth(ctx context.Context, id string) {

--- a/internal/api/handlers/management/auth_files_payment_required_test.go
+++ b/internal/api/handlers/management/auth_files_payment_required_test.go
@@ -1,0 +1,88 @@
+package management
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestApplyAuthDisabledStateReenablesPaymentDisabledAuth(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(&config.Config{
+		QuotaExceeded: config.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	auth := &coreauth.Auth{
+		ID:       "empty-model-payment-disabled",
+		Provider: "openai-compatibility",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"disabled": false},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	manager.MarkResult(context.Background(), coreauth.Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Error:    &coreauth.Error{HTTPStatus: http.StatusPaymentRequired},
+	})
+	auth, _ = manager.GetByID(auth.ID)
+	if auth == nil || !auth.Disabled || auth.Status != coreauth.StatusDisabled || auth.Unavailable {
+		t.Fatalf("402 did not apply only the disable overlay: %#v", auth)
+	}
+
+	applyAuthDisabledState(auth, false)
+
+	assertPaymentDisabledAuthReenabled(t, auth)
+}
+
+func TestSyncAuthFileDisabledStateReenablesPaymentDisabledAuth(t *testing.T) {
+	auth := paymentDisabledAuthForManagementTest()
+	auth.Metadata["disabled"] = false
+
+	syncAuthFileDisabledState(auth)
+
+	assertPaymentDisabledAuthReenabled(t, auth)
+}
+
+func paymentDisabledAuthForManagementTest() *coreauth.Auth {
+	retryAt := time.Now().Add(time.Hour)
+	return &coreauth.Auth{
+		Disabled: true,
+		Status:   coreauth.StatusDisabled,
+		Metadata: map[string]any{
+			"disabled":        true,
+			"disabled_reason": "payment_required",
+		},
+		ModelStates: map[string]*coreauth.ModelState{
+			"quota-model": {
+				Status:         coreauth.StatusError,
+				Unavailable:    true,
+				NextRetryAfter: retryAt,
+				Quota: coreauth.QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: retryAt,
+				},
+				LastError: &coreauth.Error{HTTPStatus: http.StatusTooManyRequests},
+			},
+		},
+	}
+}
+
+func assertPaymentDisabledAuthReenabled(t *testing.T, auth *coreauth.Auth) {
+	t.Helper()
+	if auth.Disabled || auth.Unavailable || auth.Status != coreauth.StatusActive {
+		t.Fatalf("auth not re-enabled: disabled=%v unavailable=%v status=%s", auth.Disabled, auth.Unavailable, auth.Status)
+	}
+	if _, exists := auth.Metadata["disabled_reason"]; exists {
+		t.Fatalf("payment disabled reason remained: %#v", auth.Metadata["disabled_reason"])
+	}
+	quotaState := auth.ModelStates["quota-model"]
+	if quotaState != nil && (!quotaState.Unavailable || !quotaState.Quota.Exceeded || quotaState.NextRetryAfter.IsZero()) {
+		t.Fatalf("independent quota state was changed: %#v", quotaState)
+	}
+}

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	sdkpluginstore "github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginstore"
@@ -207,6 +208,18 @@ type QuotaExceeded struct {
 	// When all free-tier auths are exhausted (429/503), the conductor retries with
 	// an auth that has available Google One AI credits.
 	AntigravityCredits bool `yaml:"antigravity-credits" json:"antigravity-credits"`
+
+	// OnPaymentRequired controls what happens when an auth receives HTTP 402 Payment Required.
+	// Supported values are "cooldown" (default) and "disable".
+	OnPaymentRequired string `yaml:"on-payment-required,omitempty" json:"on-payment-required,omitempty"`
+}
+
+// PaymentRequiredAction returns the normalized HTTP 402 handling mode.
+func (q QuotaExceeded) PaymentRequiredAction() string {
+	if strings.EqualFold(strings.TrimSpace(q.OnPaymentRequired), "disable") {
+		return "disable"
+	}
+	return "cooldown"
 }
 
 // RoutingConfig configures how credentials are selected for requests.

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -104,6 +104,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.QuotaExceeded.AntigravityCredits != newCfg.QuotaExceeded.AntigravityCredits {
 		changes = append(changes, fmt.Sprintf("quota-exceeded.antigravity-credits: %t -> %t", oldCfg.QuotaExceeded.AntigravityCredits, newCfg.QuotaExceeded.AntigravityCredits))
 	}
+	if oldCfg.QuotaExceeded.PaymentRequiredAction() != newCfg.QuotaExceeded.PaymentRequiredAction() {
+		changes = append(changes, fmt.Sprintf("quota-exceeded.on-payment-required: %s -> %s", oldCfg.QuotaExceeded.PaymentRequiredAction(), newCfg.QuotaExceeded.PaymentRequiredAction()))
+	}
 	if !reflect.DeepEqual(oldCfg.Antigravity.SensitiveWords, newCfg.Antigravity.SensitiveWords) {
 		changes = append(changes, fmt.Sprintf("antigravity.sensitive-words: %d -> %d", len(oldCfg.Antigravity.SensitiveWords), len(newCfg.Antigravity.SensitiveWords)))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -336,7 +336,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 		MaxRetryCredentials:           1,
 		MaxRetryInterval:              1,
 		WebsocketAuth:                 false,
-		QuotaExceeded:                 config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
+		QuotaExceeded:                 config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false, OnPaymentRequired: "cooldown"},
 		Antigravity:                   config.AntigravityConfig{SensitiveWords: []string{"old-word"}},
 		ClaudeKey:                     []config.ClaudeKey{{APIKey: "c1"}},
 		CodexKey:                      []config.CodexKey{{APIKey: "x1"}},
@@ -362,7 +362,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 		MaxRetryCredentials:           3,
 		MaxRetryInterval:              3,
 		WebsocketAuth:                 true,
-		QuotaExceeded:                 config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
+		QuotaExceeded:                 config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true, OnPaymentRequired: "disable"},
 		Antigravity:                   config.AntigravityConfig{SensitiveWords: []string{"new-word-1", "new-word-2"}},
 		XAI:                           config.XAIConfig{InjectXSearch: true},
 		ClaudeKey: []config.ClaudeKey{
@@ -412,6 +412,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 	expectContains(t, details, "quota-exceeded.switch-project: false -> true")
 	expectContains(t, details, "quota-exceeded.switch-preview-model: false -> true")
 	expectContains(t, details, "quota-exceeded.antigravity-credits: false -> true")
+	expectContains(t, details, "quota-exceeded.on-payment-required: cooldown -> disable")
 	expectContains(t, details, "antigravity.sensitive-words: 1 -> 2")
 	expectContains(t, details, "xai.inject-x-search: false -> true")
 	expectContains(t, details, "api-keys count: 1 -> 2")

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -153,6 +153,10 @@ type Manager struct {
 	refreshLoop   *authAutoRefreshLoop
 
 	requestPrepareLocks sync.Map
+	// authMutationLocks serialize each auth's runtime, scheduler, and persistence
+	// side effects so a newer result cannot be overwritten by an older update.
+	authMutationLocks   sync.Map
+	authMutationLocksMu sync.Mutex
 	// refreshLocks serializes credential refresh per auth ID so concurrent
 	// 401 recoveries and auto-refresh workers do not race the same refresh_token.
 	refreshLocks sync.Map

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -692,14 +692,21 @@ func cooldownReason(statusMessage string, quota QuotaState, lastErr *Error) stri
 
 // MarkResult records an execution result and notifies hooks.
 func (m *Manager) MarkResult(ctx context.Context, result Result) {
+	_ = m.markResult(ctx, result)
+}
+
+// markResult records a result and reports whether callers must stop trying
+// additional models on the same auth because the credential was disabled.
+func (m *Manager) markResult(ctx context.Context, result Result) (stopAuth bool) {
 	if result.AuthID == "" {
-		return
+		return false
 	}
+	unlockAuthMutation := m.lockAuthMutation(result.AuthID)
 
 	shouldResumeModel := false
 	shouldSuspendModel := false
+	var modelsToResume []string
 	suspendReason := ""
-	clearModelQuota := false
 	setModelQuota := false
 	var authSnapshot *Auth
 	cooldownStateChanged := false
@@ -713,13 +720,19 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			cooldownRecordsBefore = m.cooldownStateRecordsForAuthLocked(auth, now)
 		}
 		auth.recordRecentRequest(now, result.Success)
+		paymentDisabled := isPaymentRequiredDisabled(auth)
+		if paymentDisabled {
+			stopAuth = true
+		}
 		if result.Success {
 			auth.Success++
 		} else {
 			auth.Failed++
 		}
 
-		if result.Success {
+		if result.Success && paymentDisabled {
+			auth.UpdatedAt = now
+		} else if result.Success {
 			if result.Model != "" {
 				state := ensureModelState(auth, result.Model)
 				resetModelState(state, now)
@@ -731,7 +744,6 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				}
 				auth.UpdatedAt = now
 				shouldResumeModel = true
-				clearModelQuota = true
 			} else {
 				clearAuthStateOnSuccess(auth, now)
 			}
@@ -739,6 +751,18 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			if result.Model != "" {
 				if !isRequestScopedResultError(result.Error) {
 					disableCooling := m.cooldownDisabledForAuth(auth)
+					statusCode := statusCodeFromResult(result.Error)
+					paymentAction := ""
+					var priorState *ModelState
+					if statusCode == http.StatusPaymentRequired {
+						cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+						paymentAction = paymentRequiredActionForAuth(cfg, auth)
+						if paymentAction == "disable" {
+							if clonedAuth := auth.Clone(); clonedAuth != nil {
+								priorState = clonedAuth.ModelStates[result.Model]
+							}
+						}
+					}
 					state := ensureModelState(auth, result.Model)
 					state.Unavailable = true
 					state.Status = StatusError
@@ -750,7 +774,6 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						auth.StatusMessage = result.Error.Message
 					}
 
-					statusCode := statusCodeFromResult(result.Error)
 					if isModelSupportResultError(result.Error) {
 						next := now.Add(12 * time.Hour)
 						state.NextRetryAfter = next
@@ -788,7 +811,22 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								suspendReason = "unauthorized"
 								shouldSuspendModel = true
 							}
-						case 402, 403:
+						case 402:
+							if applyPaymentRequiredModelFailure(auth, state, now, result.Error, disableCooling, paymentAction) {
+								suspendReason = "payment_required"
+								shouldSuspendModel = true
+							} else if paymentAction == "disable" {
+								if priorState == nil {
+									resetModelState(state, now)
+								} else {
+									auth.ModelStates[result.Model] = priorState
+								}
+								modelsToResume = append(modelsToResume, clearPaymentRequiredModelCooldowns(auth, now)...)
+							}
+							if auth.Disabled || auth.Status == StatusDisabled {
+								stopAuth = true
+							}
+						case 403:
 							if disableCooling {
 								state.NextRetryAfter = time.Time{}
 							} else {
@@ -841,13 +879,22 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						state.Unavailable = false
 						state.Quota.Exceeded = false
 					}
-					auth.Status = StatusError
+					if !auth.Disabled && auth.Status != StatusDisabled {
+						auth.Status = StatusError
+					}
 					auth.UpdatedAt = now
 					updateAggregatedAvailability(auth, now)
 				}
 			} else {
 				disableCooling := m.cooldownDisabledForAuth(auth)
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+				if statusCodeFromResult(result.Error) == http.StatusPaymentRequired && paymentRequiredActionForAuth(cfg, auth) == "disable" {
+					disableAuthForPaymentRequired(auth, now, result.Error)
+					modelsToResume = append(modelsToResume, clearPaymentRequiredModelCooldowns(auth, now)...)
+					stopAuth = true
+				} else {
+					applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				}
 			}
 		}
 
@@ -866,28 +913,33 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 		m.persistCooldownStates(context.Background())
 	}
 
-	if clearModelQuota && result.Model != "" {
-		registry.GetGlobalRegistry().ClearModelQuotaExceeded(result.AuthID, result.Model)
-	}
 	if setModelQuota && result.Model != "" {
 		registry.GetGlobalRegistry().SetModelQuotaExceeded(result.AuthID, result.Model)
 	}
-	if shouldResumeModel {
-		registry.GetGlobalRegistry().ResumeClientModel(result.AuthID, result.Model)
+	if shouldResumeModel && result.Model != "" {
+		modelsToResume = append(modelsToResume, result.Model)
+	}
+	if len(modelsToResume) > 0 {
+		for _, model := range dedupeStrings(modelsToResume) {
+			registry.GetGlobalRegistry().ClearModelQuotaExceeded(result.AuthID, model)
+			registry.GetGlobalRegistry().ResumeClientModel(result.AuthID, model)
+		}
 	} else if shouldSuspendModel {
 		registry.GetGlobalRegistry().SuspendClientModel(result.AuthID, result.Model, suspendReason)
 	}
 
+	unlockAuthMutation()
 	m.hook.OnResult(ctx, result)
 	m.publishErrorEvent(result, authSnapshot)
+	return stopAuth
 }
 
-func (m *Manager) recordExecutionResult(ctx context.Context, result Result, auth *Auth, ephemeral bool) {
+func (m *Manager) recordExecutionResult(ctx context.Context, result Result, auth *Auth, ephemeral bool) bool {
 	if !ephemeral {
-		m.MarkResult(ctx, result)
-		return
+		return m.markResult(ctx, result)
 	}
 	m.reportHomeResult(ctx, result, auth)
+	return false
 }
 
 // reportHomeResult only observes a Home dispatch result and never updates local auth state.

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -374,11 +374,14 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
-				m.MarkResult(execCtx, result)
+				stopAuth := m.markResult(execCtx, result)
 				if isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
 				authErr = errExec
+				if stopAuth {
+					break
+				}
 				continue
 			}
 			m.MarkResult(execCtx, result)
@@ -505,15 +508,19 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				// count_tokens route and return a generic endpoint 404. Record
 				// the failure for hooks and metrics without suspending a model
 				// that remains usable through the messages endpoint.
+				stopAuth := false
 				if isCountTokensEndpointNotFoundError(errExec, execReq.Model) {
 					m.recordAvailabilityNeutralResult(execCtx, result)
 				} else {
-					m.MarkResult(execCtx, result)
+					stopAuth = m.markResult(execCtx, result)
 				}
 				if isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
 				authErr = errExec
+				if stopAuth {
+					break
+				}
 				continue
 			}
 			m.MarkResult(execCtx, result)
@@ -907,7 +914,7 @@ func (m *Manager) prepareRequestAuth(ctx context.Context, executor ProviderExecu
 		return target, nil
 	}
 
-	saved, errUpdate := m.Update(ctx, updated)
+	saved, errUpdate := m.Update(withCredentialMaintenanceUpdate(ctx, target), updated)
 	if errUpdate != nil {
 		return updated, errUpdate
 	}

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1089,6 +1089,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 	if errCandidates != nil {
 		return cliproxyexecutor.Response{}, false, errCandidates
 	}
+candidateLoop:
 	for _, c := range candidates {
 		if ctx.Err() != nil {
 			return cliproxyexecutor.Response{}, false, nil
@@ -1121,7 +1122,9 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
-				m.MarkResult(creditsCtx, result)
+				if m.markResult(creditsCtx, result) {
+					continue candidateLoop
+				}
 				continue
 			}
 			m.MarkResult(creditsCtx, result)

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 // SetRetryConfig updates retry attempts, credential retry limit and cooldown wait interval.
@@ -75,6 +76,7 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth.ID == "" {
 		auth.ID = uuid.NewString()
 	}
+	unlockAuthMutation := m.lockAuthMutation(auth.ID)
 	now := time.Now()
 	clearedCooldown := false
 	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
@@ -93,11 +95,20 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	}
 	m.queueRefreshReschedule(auth.ID)
 	_ = m.persist(ctx, auth)
-	m.hook.OnAuthRegistered(ctx, auth.Clone())
 	if clearedCooldown {
 		m.persistCooldownStates(ctx)
 	}
-	return auth.Clone(), nil
+	result := auth.Clone()
+	unlockAuthMutation()
+	m.hook.OnAuthRegistered(ctx, result.Clone())
+	return result, nil
+}
+
+// UpdateCredentialMaintenance applies a credential refresh or preparation update
+// without allowing a stale snapshot to cross an authoritative payment-disable or
+// re-enable transition. source must be the auth snapshot used to start maintenance.
+func (m *Manager) UpdateCredentialMaintenance(ctx context.Context, source, updated *Auth) (*Auth, error) {
+	return m.Update(withCredentialMaintenanceUpdate(ctx, source), updated)
 }
 
 // Update replaces an existing auth entry and notifies hooks.
@@ -108,10 +119,12 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
 		return nil, fmt.Errorf("update auth: %w", errWeight)
 	}
+	unlockAuthMutation := m.lockAuthMutation(auth.ID)
 	m.mu.Lock()
 	existing, ok := m.auths[auth.ID]
 	if !ok || existing == nil {
 		m.mu.Unlock()
+		unlockAuthMutation()
 		return nil, nil
 	}
 	if !auth.indexAssigned && auth.Index == "" {
@@ -121,6 +134,21 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	auth.Success = existing.Success
 	auth.Failed = existing.Failed
 	auth.recentRequests = existing.recentRequests
+	authoritativePaymentReenable := !isCredentialMaintenanceUpdate(ctx) &&
+		isPaymentRequiredDisabled(existing) &&
+		!auth.Disabled &&
+		auth.Status != StatusDisabled
+	preserveRuntimeState := false
+	if isCredentialMaintenanceUpdate(ctx) {
+		preservePaymentRequiredDisableForMaintenance(ctx, existing, auth)
+		preserveRuntimeState = isPaymentRequiredDisabled(existing)
+	}
+	// Updates that keep a credential payment-disabled may change persistent
+	// metadata, but the current quota/cooldown state remains authoritative.
+	if isPaymentRequiredDisabled(existing) && isPaymentRequiredDisabled(auth) {
+		copyAuthoritativeRuntimeState(existing, auth)
+		preserveRuntimeState = true
+	}
 	if !existing.Disabled && existing.Status != StatusDisabled && !auth.Disabled && auth.Status != StatusDisabled {
 		if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
 			auth.ModelStates = existing.ModelStates
@@ -128,8 +156,12 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	}
 	now := time.Now()
 	clearedCooldown := false
-	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
-		clearedCooldown = clearCooldownStateForAuth(auth, now)
+	var paymentModelsToResume []string
+	if authoritativePaymentReenable {
+		paymentModelsToResume, clearedCooldown = clearPaymentRequiredRuntimeState(auth, now)
+	}
+	if !preserveRuntimeState && (m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled) {
+		clearedCooldown = clearCooldownStateForAuth(auth, now) || clearedCooldown
 	}
 	auth.EnsureIndex()
 	authClone := auth.Clone()
@@ -143,11 +175,17 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	}
 	m.queueRefreshReschedule(auth.ID)
 	_ = m.persist(ctx, auth)
-	m.hook.OnAuthUpdated(ctx, auth.Clone())
 	if clearedCooldown {
 		m.persistCooldownStates(ctx)
 	}
-	return auth.Clone(), nil
+	for _, model := range paymentModelsToResume {
+		registry.GetGlobalRegistry().ClearModelQuotaExceeded(auth.ID, model)
+		registry.GetGlobalRegistry().ResumeClientModel(auth.ID, model)
+	}
+	result := auth.Clone()
+	unlockAuthMutation()
+	m.hook.OnAuthUpdated(ctx, result.Clone())
+	return result, nil
 }
 
 // Remove deletes an auth from runtime state without persisting.

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -581,9 +581,13 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	if m.shouldRefresh(updated, now) {
 		updated.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)
 	}
-	saved, errUpdate := m.Update(ctx, updated)
-	for _, model := range modelsToResume {
-		registry.GetGlobalRegistry().ResumeClientModel(id, model)
+	saved, errUpdate := m.Update(withCredentialMaintenanceUpdate(ctx, auth), updated)
+	if saved != nil {
+		for _, model := range modelsToResume {
+			if modelStateIsClean(saved.ModelStates[model]) {
+				registry.GetGlobalRegistry().ResumeClientModel(id, model)
+			}
+		}
 	}
 	if errUpdate != nil {
 		log.Debugf("persist refreshed auth %s (%s) failed: %v", auth.Provider, auth.ID, errUpdate)

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -159,17 +159,18 @@ func (m *Manager) RefreshSchedulerAll() {
 // ReconcileRegistryModelStates aligns per-model runtime state with the current
 // registry snapshot for one auth.
 //
-// Supported models are reset to a clean state because re-registration already
-// cleared the registry-side cooldown/suspension snapshot. ModelStates for
-// models that are no longer present in the registry are pruned entirely so
-// renamed/removed models cannot keep auth-level status stale.
+// Normal catalog refreshes reset supported models because re-registration
+// clears the registry-side cooldown/suspension snapshot. Watcher updates
+// preserve supported runtime state and restore its registry markers. Models
+// no longer present in the registry are always pruned so renamed/removed
+// models cannot keep auth-level status stale.
 func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID string) {
 	if m == nil || authID == "" {
 		return
 	}
 
 	supportedModels := registry.GetGlobalRegistry().GetModelsForClient(authID)
-	supported := make(map[string]struct{}, len(supportedModels))
+	supported := make(map[string]string, len(supportedModels))
 	for _, model := range supportedModels {
 		if model == nil {
 			continue
@@ -178,10 +179,12 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 		if modelKey == "" {
 			continue
 		}
-		supported[modelKey] = struct{}{}
+		supported[modelKey] = model.ID
 	}
 
 	var snapshot *Auth
+	runtimeStatesToRestore := make(map[string]*ModelState)
+	preserveRuntimeState := shouldSkipPersist(ctx)
 	now := time.Now()
 
 	m.mu.Lock()
@@ -193,7 +196,8 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 			if baseModel == "" {
 				baseModel = strings.TrimSpace(modelKey)
 			}
-			if _, supportedModel := supported[baseModel]; !supportedModel {
+			registryModel, supportedModel := supported[baseModel]
+			if !supportedModel {
 				// Drop state for models that disappeared from the current registry
 				// snapshot. Keeping them around leaks stale errors into auth-level
 				// status, management output, and websocket fallback checks.
@@ -205,6 +209,10 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 				continue
 			}
 			if modelStateIsClean(state) {
+				continue
+			}
+			if preserveRuntimeState {
+				runtimeStatesToRestore[registryModel] = state.Clone()
 				continue
 			}
 			resetModelState(state, now)
@@ -231,6 +239,18 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 
 	if m.scheduler != nil && snapshot != nil {
 		m.scheduler.upsertAuth(snapshot)
+	}
+	for model, state := range runtimeStatesToRestore {
+		if state.Quota.Exceeded {
+			registry.GetGlobalRegistry().SetModelQuotaExceeded(authID, model)
+		}
+		if state.Unavailable {
+			reason := state.Quota.Reason
+			if reason == "" {
+				reason = state.StatusMessage
+			}
+			registry.GetGlobalRegistry().SuspendClientModel(authID, model, reason)
+		}
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -268,11 +268,14 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			rerr := resultErrorFromError(errStream)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 			result.RetryAfter = retryAfterFromError(errStream)
-			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
+			stopAuth := m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 			if isRequestInvalidError(errStream) {
 				return nil, errStream
 			}
 			lastErr = errStream
+			if stopAuth {
+				return nil, errStream
+			}
 			continue
 		}
 
@@ -336,9 +339,12 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				rerr := resultErrorFromError(bootstrapErr)
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
-				m.recordExecutionResult(ctx, result, auth, ephemeralResult)
+				stopAuth := m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 				discardStreamChunks(streamResult.Chunks)
 				lastErr = bootstrapErr
+				if stopAuth {
+					return nil, bootstrapErr
+				}
 				continue
 			}
 			rerr := resultErrorFromError(bootstrapErr)

--- a/sdk/cliproxy/auth/openai_compat_pool_test.go
+++ b/sdk/cliproxy/auth/openai_compat_pool_test.go
@@ -835,3 +835,72 @@ func TestManagerExecuteStream_OpenAICompatAliasPoolStopsOnInvalidBootstrap(t *te
 		t.Fatalf("stream calls = %v, want only first upstream model", got)
 	}
 }
+
+func TestManagerOpenAICompatPoolStopsAfterPaymentRequiredDisable(t *testing.T) {
+	alias := "pooled-pay-alias"
+	models := []internalconfig.OpenAICompatibilityModel{
+		{Name: "model-a", Alias: alias},
+		{Name: "model-b", Alias: alias},
+	}
+	payErr := &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"}
+	paymentRequiredConfig := func() *internalconfig.Config {
+		return &internalconfig.Config{
+			QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+			OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+				Name: "pool", Models: models,
+			}},
+		}
+	}
+
+	t.Run("execute", func(t *testing.T) {
+		executor := &openAICompatPoolExecutor{
+			id:            openAICompatPoolProviderKey,
+			executeErrors: map[string]error{"model-a": payErr},
+		}
+		m := newOpenAICompatPoolTestManager(t, alias, models, executor)
+		m.SetConfig(paymentRequiredConfig())
+		_, err := m.Execute(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{})
+		if err == nil {
+			t.Fatal("expected 402 error")
+		}
+		if got := executor.ExecuteModels(); len(got) != 1 || got[0] != "model-a" {
+			t.Fatalf("execute models = %v, want only model-a", got)
+		}
+		auth, ok := m.GetByID("pool-auth-" + t.Name())
+		if !ok || auth == nil || !auth.Disabled || auth.Status != StatusDisabled {
+			t.Fatalf("auth after 402 = %#v, want disabled", auth)
+		}
+	})
+
+	t.Run("count", func(t *testing.T) {
+		executor := &openAICompatPoolExecutor{
+			id:          openAICompatPoolProviderKey,
+			countErrors: map[string]error{"model-a": payErr},
+		}
+		m := newOpenAICompatPoolTestManager(t, alias, models, executor)
+		m.SetConfig(paymentRequiredConfig())
+		_, err := m.ExecuteCount(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{})
+		if err == nil {
+			t.Fatal("expected 402 error")
+		}
+		if got := executor.CountModels(); len(got) != 1 || got[0] != "model-a" {
+			t.Fatalf("count models = %v, want only model-a", got)
+		}
+	})
+
+	t.Run("stream bootstrap", func(t *testing.T) {
+		executor := &openAICompatPoolExecutor{
+			id:                openAICompatPoolProviderKey,
+			streamFirstErrors: map[string]error{"model-a": payErr},
+		}
+		m := newOpenAICompatPoolTestManager(t, alias, models, executor)
+		m.SetConfig(paymentRequiredConfig())
+		_, err := m.ExecuteStream(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{})
+		if err == nil {
+			t.Fatal("expected 402 error")
+		}
+		if got := executor.StreamModels(); len(got) != 1 || got[0] != "model-a" {
+			t.Fatalf("stream models = %v, want only model-a", got)
+		}
+	})
+}

--- a/sdk/cliproxy/auth/payment_required.go
+++ b/sdk/cliproxy/auth/payment_required.go
@@ -1,0 +1,318 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func paymentRequiredAction(cfg *internalconfig.Config) string {
+	if cfg == nil {
+		return "cooldown"
+	}
+	return cfg.QuotaExceeded.PaymentRequiredAction()
+}
+
+func paymentRequiredActionForAuth(cfg *internalconfig.Config, auth *Auth) string {
+	action := paymentRequiredAction(cfg)
+	if action == "disable" && IsPluginVirtualAuth(auth) {
+		// Virtual children cannot be persisted or managed independently from their
+		// plugin-owned source file, so retain the safe cooldown behavior.
+		return "cooldown"
+	}
+	return action
+}
+
+func isPaymentRequiredDisabled(auth *Auth) bool {
+	if auth == nil || (!auth.Disabled && auth.Status != StatusDisabled) || auth.Metadata == nil {
+		return false
+	}
+	reason, _ := auth.Metadata["disabled_reason"].(string)
+	return reason == "payment_required"
+}
+
+// IsPaymentRequiredDisabled reports whether an auth is disabled specifically
+// because a request returned HTTP 402.
+func IsPaymentRequiredDisabled(auth *Auth) bool {
+	return isPaymentRequiredDisabled(auth)
+}
+
+type authMutationLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func (m *Manager) lockAuthMutation(authID string) func() {
+	if m == nil || strings.TrimSpace(authID) == "" {
+		return func() {}
+	}
+	m.authMutationLocksMu.Lock()
+	lockValue, _ := m.authMutationLocks.LoadOrStore(authID, &authMutationLock{})
+	lock := lockValue.(*authMutationLock)
+	lock.refs++
+	m.authMutationLocksMu.Unlock()
+
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+		m.authMutationLocksMu.Lock()
+		lock.refs--
+		if lock.refs == 0 {
+			m.authMutationLocks.CompareAndDelete(authID, lock)
+		}
+		m.authMutationLocksMu.Unlock()
+	}
+}
+
+type credentialMaintenanceUpdateContextKey struct{}
+
+type credentialMaintenanceUpdateState struct {
+	sourcePaymentRequiredDisabled bool
+	sourceRuntime                 *Auth
+}
+
+func withCredentialMaintenanceUpdate(ctx context.Context, source *Auth) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var sourceRuntime *Auth
+	if source != nil {
+		sourceRuntime = source.Clone()
+	}
+	return context.WithValue(ctx, credentialMaintenanceUpdateContextKey{}, credentialMaintenanceUpdateState{
+		sourcePaymentRequiredDisabled: isPaymentRequiredDisabled(source),
+		sourceRuntime:                 sourceRuntime,
+	})
+}
+
+func credentialMaintenanceStateFromContext(ctx context.Context) (credentialMaintenanceUpdateState, bool) {
+	if ctx == nil {
+		return credentialMaintenanceUpdateState{}, false
+	}
+	state, ok := ctx.Value(credentialMaintenanceUpdateContextKey{}).(credentialMaintenanceUpdateState)
+	return state, ok
+}
+
+func isCredentialMaintenanceUpdate(ctx context.Context) bool {
+	_, ok := credentialMaintenanceStateFromContext(ctx)
+	return ok
+}
+
+func credentialMaintenanceModelStatesEqual(a, b map[string]*ModelState) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for model, aState := range a {
+		bState, ok := b[model]
+		if !ok {
+			return false
+		}
+		if aState == nil || bState == nil {
+			if aState != bState {
+				return false
+			}
+			continue
+		}
+		if aState.Status != bState.Status ||
+			aState.StatusMessage != bState.StatusMessage ||
+			aState.Unavailable != bState.Unavailable ||
+			!aState.NextRetryAfter.Equal(bState.NextRetryAfter) ||
+			!aState.UpdatedAt.Equal(bState.UpdatedAt) ||
+			!cooldownQuotaEqual(aState.Quota, bState.Quota) ||
+			!cooldownErrorEqual(aState.LastError, bState.LastError) {
+			return false
+		}
+	}
+	return true
+}
+
+func credentialMaintenanceRuntimeEqual(source, current *Auth) bool {
+	if source == nil || current == nil {
+		return source == current
+	}
+	return source.Disabled == current.Disabled &&
+		source.Unavailable == current.Unavailable &&
+		source.Status == current.Status &&
+		source.StatusMessage == current.StatusMessage &&
+		source.NextRetryAfter.Equal(current.NextRetryAfter) &&
+		cooldownQuotaEqual(source.Quota, current.Quota) &&
+		cooldownErrorEqual(source.LastError, current.LastError) &&
+		credentialMaintenanceModelStatesEqual(source.ModelStates, current.ModelStates)
+}
+
+func copyAuthoritativeRuntimeState(existing, incoming *Auth) {
+	if existing == nil || incoming == nil {
+		return
+	}
+	incoming.Disabled = existing.Disabled
+	incoming.Unavailable = existing.Unavailable
+	incoming.Status = existing.Status
+	incoming.StatusMessage = existing.StatusMessage
+	incoming.NextRetryAfter = existing.NextRetryAfter
+	currentRuntime := existing.Clone()
+	incoming.ModelStates = currentRuntime.ModelStates
+	incoming.Quota = currentRuntime.Quota
+	incoming.LastError = currentRuntime.LastError
+}
+
+func copyAuthoritativeDisabledMetadata(existing, incoming *Auth) {
+	if incoming.Metadata == nil {
+		incoming.Metadata = make(map[string]any)
+	}
+	incoming.Metadata["disabled"] = existing.Disabled
+	if existing.Disabled || existing.Status == StatusDisabled {
+		if existing.Metadata != nil {
+			if reason, ok := existing.Metadata["disabled_reason"]; ok {
+				incoming.Metadata["disabled_reason"] = reason
+				return
+			}
+		}
+	}
+	delete(incoming.Metadata, "disabled_reason")
+}
+
+// preservePaymentRequiredDisableForMaintenance prevents stale credential
+// maintenance from crossing an authoritative disable/re-enable transition.
+// Config reloads and management updates remain authoritative because they do
+// not carry the maintenance-update context marker.
+func preservePaymentRequiredDisableForMaintenance(ctx context.Context, existing, incoming *Auth) {
+	if incoming == nil {
+		return
+	}
+	if isPaymentRequiredDisabled(existing) {
+		copyAuthoritativeRuntimeState(existing, incoming)
+		incoming.Disabled = true
+		incoming.Status = StatusDisabled
+		if incoming.Metadata == nil {
+			incoming.Metadata = make(map[string]any)
+		}
+		incoming.Metadata["disabled"] = true
+		incoming.Metadata["disabled_reason"] = "payment_required"
+		return
+	}
+	state, ok := credentialMaintenanceStateFromContext(ctx)
+	if !ok {
+		return
+	}
+	if !state.sourcePaymentRequiredDisabled && credentialMaintenanceRuntimeEqual(state.sourceRuntime, existing) {
+		return
+	}
+	// Maintenance started before an authoritative lifecycle or runtime-state
+	// change. Preserve the current runtime fields while retaining refreshed
+	// credential metadata from the maintenance result.
+	copyAuthoritativeRuntimeState(existing, incoming)
+	copyAuthoritativeDisabledMetadata(existing, incoming)
+}
+
+func clearPaymentRequiredModelCooldowns(auth *Auth, now time.Time) []string {
+	if auth == nil || len(auth.ModelStates) == 0 {
+		return nil
+	}
+	models := make([]string, 0, len(auth.ModelStates))
+	for model, state := range auth.ModelStates {
+		if state == nil || statusCodeFromResult(state.LastError) != http.StatusPaymentRequired {
+			continue
+		}
+		resetModelState(state, now)
+		models = append(models, model)
+	}
+	return models
+}
+
+func clearPaymentRequiredRuntimeState(auth *Auth, now time.Time) ([]string, bool) {
+	if auth == nil {
+		return nil, false
+	}
+	models := clearPaymentRequiredModelCooldowns(auth, now)
+	changed := len(models) > 0
+	if statusCodeFromResult(auth.LastError) == http.StatusPaymentRequired {
+		auth.Unavailable = false
+		auth.NextRetryAfter = time.Time{}
+		auth.LastError = nil
+		auth.UpdatedAt = now
+		changed = true
+	}
+	if len(models) > 0 {
+		updateAggregatedAvailability(auth, now)
+	}
+	return models, changed
+}
+
+// disableAuthForPaymentRequired marks an auth disabled after HTTP 402.
+// File-backed auths persist the metadata through the auth store. Config-backed
+// API keys remain disabled until re-enabled or recreated by a config reload.
+func disableAuthForPaymentRequired(auth *Auth, now time.Time, resultErr *Error) {
+	if auth == nil {
+		return
+	}
+	auth.Disabled = true
+	auth.Status = StatusDisabled
+	auth.StatusMessage = "payment_required"
+	auth.UpdatedAt = now
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["disabled"] = true
+	auth.Metadata["disabled_reason"] = "payment_required"
+	if resultErr != nil {
+		auth.LastError = cloneError(resultErr)
+		if resultErr.Message != "" {
+			auth.StatusMessage = resultErr.Message
+		}
+	}
+}
+
+// applyPaymentRequiredModelFailure updates model and auth state for HTTP 402.
+// The disable mode is auth-level because payment balance applies to the whole
+// credential. The model state remains soft so management re-enable is enough to
+// restore routing. The return value requests registry suspension for cooldown only.
+func applyPaymentRequiredModelFailure(auth *Auth, state *ModelState, now time.Time, resultErr *Error, disableCooling bool, action string) (shouldSuspendModel bool) {
+	if action == "disable" {
+		// The disable is credential-wide. Keep any existing per-model runtime
+		// state intact so an explicit credential re-enable does not erase an
+		// independent model cooldown or quota state.
+		disableAuthForPaymentRequired(auth, now, resultErr)
+		return false
+	}
+
+	if state != nil {
+		state.Unavailable = true
+		state.Status = StatusError
+		state.UpdatedAt = now
+		if resultErr != nil {
+			state.LastError = cloneError(resultErr)
+			state.StatusMessage = resultErr.Message
+		}
+	}
+
+	statusMessage := "payment_required"
+	if resultErr != nil && resultErr.Message != "" {
+		statusMessage = resultErr.Message
+	}
+	if state != nil {
+		state.StatusMessage = statusMessage
+		if disableCooling {
+			state.NextRetryAfter = time.Time{}
+		} else {
+			state.NextRetryAfter = now.Add(30 * time.Minute)
+		}
+	}
+	if auth != nil {
+		auth.Status = StatusError
+		auth.StatusMessage = statusMessage
+		auth.UpdatedAt = now
+		if resultErr != nil {
+			auth.LastError = cloneError(resultErr)
+		}
+		if disableCooling {
+			auth.NextRetryAfter = time.Time{}
+		} else {
+			auth.NextRetryAfter = now.Add(30 * time.Minute)
+		}
+	}
+	return !disableCooling
+}

--- a/sdk/cliproxy/auth/payment_required_test.go
+++ b/sdk/cliproxy/auth/payment_required_test.go
@@ -1,0 +1,1150 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestAuthMutationLocksEvictedAfterCredentialChurn(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+
+	for i := 0; i < 128; i++ {
+		auth := &Auth{
+			ID:       fmt.Sprintf("churn-auth-%d", i),
+			Provider: "openai-compatibility",
+			Status:   StatusActive,
+		}
+		if _, err := m.Register(WithSkipPersist(context.Background()), auth); err != nil {
+			t.Fatalf("register auth %d: %v", i, err)
+		}
+		m.Remove(context.Background(), auth.ID)
+	}
+
+	lockCount := 0
+	m.authMutationLocks.Range(func(_, _ any) bool {
+		lockCount++
+		return true
+	})
+	if lockCount != 0 {
+		t.Fatalf("auth mutation lock count after credential churn = %d, want 0", lockCount)
+	}
+}
+
+func TestPaymentRequiredAction(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cfg  *internalconfig.Config
+		want string
+	}{
+		{name: "nil config", want: "cooldown"},
+		{name: "empty config", cfg: &internalconfig.Config{}, want: "cooldown"},
+		{name: "disable normalized", cfg: &internalconfig.Config{QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: " Disable "}}, want: "disable"},
+		{name: "cooldown normalized", cfg: &internalconfig.Config{QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "COOLDOWN"}}, want: "cooldown"},
+		{name: "unknown is safe default", cfg: &internalconfig.Config{QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "unknown"}}, want: "cooldown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := paymentRequiredAction(tt.cfg); got != tt.want {
+				t.Fatalf("paymentRequiredAction() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyPaymentRequiredModelFailureDisable(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	auth := &Auth{ID: "k1", Status: StatusActive}
+	state := &ModelState{Status: StatusActive}
+	errResult := &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"}
+
+	suspend := applyPaymentRequiredModelFailure(auth, state, now, errResult, false, "disable")
+	if suspend {
+		t.Fatal("shouldSuspendModel = true, want false for auth-level disable")
+	}
+	if !auth.Disabled || auth.Status != StatusDisabled || auth.Unavailable {
+		t.Fatalf("auth state = disabled:%v unavailable:%v status:%s", auth.Disabled, auth.Unavailable, auth.Status)
+	}
+	if !auth.NextRetryAfter.IsZero() {
+		t.Fatalf("auth NextRetryAfter = %v, want zero", auth.NextRetryAfter)
+	}
+	if state.Status != StatusActive || state.Unavailable || !state.NextRetryAfter.IsZero() {
+		t.Fatalf("model state changed by auth-level disable: status:%s unavailable:%v next:%v", state.Status, state.Unavailable, state.NextRetryAfter)
+	}
+	if got, _ := auth.Metadata["disabled"].(bool); !got {
+		t.Fatalf("metadata disabled = %#v, want true", auth.Metadata["disabled"])
+	}
+	if got, _ := auth.Metadata["disabled_reason"].(string); got != "payment_required" {
+		t.Fatalf("metadata disabled_reason = %q, want payment_required", got)
+	}
+	if auth.StatusMessage != "insufficient balance" {
+		t.Fatalf("auth StatusMessage = %q, want upstream detail", auth.StatusMessage)
+	}
+}
+
+func TestApplyPaymentRequiredModelFailureCooldown(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	auth := &Auth{ID: "k1", Status: StatusActive}
+	state := &ModelState{Status: StatusActive}
+	errResult := &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"}
+
+	suspend := applyPaymentRequiredModelFailure(auth, state, now, errResult, false, "cooldown")
+	if !suspend {
+		t.Fatal("shouldSuspendModel = false, want true for cooldown")
+	}
+	if auth.Disabled || auth.Status != StatusError {
+		t.Fatalf("auth state = disabled:%v status:%s", auth.Disabled, auth.Status)
+	}
+	if state.NextRetryAfter.Before(now.Add(29*time.Minute)) || state.NextRetryAfter.After(now.Add(31*time.Minute)) {
+		t.Fatalf("model cooldown = %v, want about 30m", state.NextRetryAfter.Sub(now))
+	}
+	if auth.StatusMessage != "insufficient balance" {
+		t.Fatalf("auth StatusMessage = %q, want upstream detail", auth.StatusMessage)
+	}
+	if state.StatusMessage != "insufficient balance" {
+		t.Fatalf("model StatusMessage = %q, want upstream detail", state.StatusMessage)
+	}
+}
+
+func TestPaymentRequiredDisableResumesPriorModelSuspension(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "cooldown"},
+	})
+	const model = "payment-required-mode-transition-model"
+	auth := &Auth{ID: "payment-mode-transition-key", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if got := reg.GetModelCount(model); got != 1 {
+		t.Fatalf("initial registry model count = %d, want 1", got)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: model,
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "cooldown payment failure"},
+	})
+	if got := reg.GetModelCount(model); got != 0 {
+		t.Fatalf("registry model count after cooldown 402 = %d, want 0", got)
+	}
+
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: model,
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "disable payment failure"},
+	})
+	if got := reg.GetModelCount(model); got != 1 {
+		t.Fatalf("registry model count after auth-level disable = %d, want stale suspension cleared", got)
+	}
+	current, _ := m.GetByID(auth.ID)
+	if current == nil || !current.Disabled || current.Status != StatusDisabled {
+		t.Fatalf("auth after disable 402 = %#v", current)
+	}
+}
+
+func TestPaymentRequiredDisablePreservesPriorQuotaMarker(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	const model = "payment-required-prior-quota-model"
+	auth := &Auth{ID: "payment-prior-quota-key", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: model,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+	})
+	if got := reg.GetModelCount(model); got != 0 {
+		t.Fatalf("registry model count after 429 = %d, want 0", got)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: model,
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	})
+	if got := reg.GetModelCount(model); got != 0 {
+		t.Fatalf("registry model count after 402 disable = %d, want independent quota marker preserved", got)
+	}
+	current, _ := m.GetByID(auth.ID)
+	state := current.ModelStates[model]
+	if state == nil || !state.Quota.Exceeded || state.LastError == nil || state.LastError.HTTPStatus != http.StatusTooManyRequests {
+		t.Fatalf("independent quota state changed by 402 disable: %#v", state)
+	}
+}
+
+func TestPaymentRequiredDisabledMetadataUpdatePreservesIndependentQuotaCooldown(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	const quotaModel = "payment-disabled-metadata-quota-model"
+	const paymentModel = "payment-disabled-metadata-payment-model"
+	auth := &Auth{
+		ID:       "payment-disabled-metadata-key",
+		Provider: "openai-compatibility",
+		Status:   StatusActive,
+		Metadata: map[string]any{"note": "before"},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: quotaModel}, {ID: paymentModel}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: quotaModel,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+	})
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: paymentModel,
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	})
+
+	disabled, _ := m.GetByID(auth.ID)
+	if disabled == nil || !isPaymentRequiredDisabled(disabled) {
+		t.Fatalf("auth was not payment-disabled: %#v", disabled)
+	}
+	metadataUpdate := disabled.Clone()
+	metadataUpdate.Metadata["note"] = "after"
+	if _, err := m.Update(context.Background(), metadataUpdate); err != nil {
+		t.Fatalf("metadata update: %v", err)
+	}
+
+	afterUpdate, _ := m.GetByID(auth.ID)
+	quotaState := afterUpdate.ModelStates[quotaModel]
+	if quotaState == nil || !quotaState.Quota.Exceeded || quotaState.LastError == nil || quotaState.LastError.HTTPStatus != http.StatusTooManyRequests {
+		t.Fatalf("metadata update cleared independent quota state: %#v", quotaState)
+	}
+	if got := afterUpdate.Metadata["note"]; got != "after" {
+		t.Fatalf("metadata note = %#v, want after", got)
+	}
+
+	reenabled := afterUpdate.Clone()
+	reenabled.Disabled = false
+	reenabled.Status = StatusActive
+	reenabled.StatusMessage = ""
+	reenabled.Metadata["disabled"] = false
+	delete(reenabled.Metadata, "disabled_reason")
+	if _, err := m.Update(context.Background(), reenabled); err != nil {
+		t.Fatalf("re-enable: %v", err)
+	}
+	current, _ := m.GetByID(auth.ID)
+	if blocked, _, _ := isAuthBlockedForModel(current, quotaModel, time.Now()); !blocked {
+		t.Fatal("independent quota cooldown no longer blocks selection after re-enable")
+	}
+	if got := reg.GetModelCount(quotaModel); got != 0 {
+		t.Fatalf("registry model count after re-enable = %d, want 0 for retained quota", got)
+	}
+}
+
+func TestPaymentRequiredDisableClearsPriorSuspensionsAcrossModels(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "cooldown"},
+	})
+	const modelA = "payment-required-model-a"
+	const modelB = "payment-required-model-b"
+	auth := &Auth{ID: "payment-multi-model-key", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelA}, {ID: modelB}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: modelA,
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "model A payment failure"},
+	})
+	if got := reg.GetModelCount(modelA); got != 0 {
+		t.Fatalf("model A count after cooldown 402 = %d, want suspended", got)
+	}
+	if got := reg.GetModelCount(modelB); got != 1 {
+		t.Fatalf("model B count before disable transition = %d, want 1", got)
+	}
+
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: modelB,
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "model B payment failure"},
+	})
+
+	for _, model := range []string{modelA, modelB} {
+		if got := reg.GetModelCount(model); got != 1 {
+			t.Fatalf("model %s count after auth-level disable = %d, want prior payment suspension cleared", model, got)
+		}
+	}
+	current, _ := m.GetByID(auth.ID)
+	if current == nil || !current.Disabled || current.Status != StatusDisabled {
+		t.Fatalf("auth after disable 402 = %#v", current)
+	}
+	stateA := current.ModelStates[modelA]
+	if stateA == nil || !stateA.NextRetryAfter.IsZero() {
+		t.Fatalf("model A payment cooldown remained after auth-level disable: %#v", stateA)
+	}
+}
+
+func TestMarkResultPaymentRequiredDisableStopsAuthAndKeepsModelReenableSafe(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+
+	const paymentModel = "gpt-payment"
+	const quotaModel = "gpt-quota"
+	auth := &Auth{ID: "pay-key", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: paymentModel}, {ID: quotaModel}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	stop := m.markResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    paymentModel,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	})
+	if !stop {
+		t.Fatal("stopAuth = false, want true")
+	}
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("auth missing")
+	}
+	if !updated.Disabled || updated.Status != StatusDisabled {
+		t.Fatalf("auth not disabled: disabled=%v status=%s", updated.Disabled, updated.Status)
+	}
+
+	retryAt := time.Now().Add(time.Hour)
+	updated.ModelStates[paymentModel] = &ModelState{
+		Status:         StatusError,
+		StatusMessage:  "insufficient balance",
+		Unavailable:    true,
+		NextRetryAfter: retryAt,
+		LastError:      &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	}
+	updated.ModelStates[quotaModel] = &ModelState{
+		Status:         StatusError,
+		StatusMessage:  "quota exhausted",
+		Unavailable:    true,
+		NextRetryAfter: retryAt,
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: retryAt,
+		},
+		LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+	}
+	m.mu.Lock()
+	m.auths[auth.ID] = updated.Clone()
+	m.mu.Unlock()
+	reg.SuspendClientModel(auth.ID, paymentModel, "payment_required")
+	reg.SetModelQuotaExceeded(auth.ID, quotaModel)
+	reg.SuspendClientModel(auth.ID, quotaModel, "quota")
+	seeded, _ := m.GetByID(auth.ID)
+	if blocked, _, _ := isAuthBlockedForModel(seeded, paymentModel, time.Now()); !blocked {
+		t.Fatal("stale payment model state did not reproduce the selection block")
+	}
+	if got := reg.GetModelCount(paymentModel); got != 0 {
+		t.Fatalf("payment model count before management re-enable = %d, want 0", got)
+	}
+
+	// File persistence of the payment disable is echoed through the watcher as
+	// an update without runtime-only model state. It must not erase an
+	// independent quota cooldown before management re-enables the credential.
+	watcherEcho := &Auth{
+		ID:       auth.ID,
+		Provider: auth.Provider,
+		Disabled: true,
+		Status:   StatusDisabled,
+		Metadata: map[string]any{
+			"disabled":        true,
+			"disabled_reason": "payment_required",
+		},
+	}
+	if _, err := m.Update(WithSkipPersist(context.Background()), watcherEcho); err != nil {
+		t.Fatalf("watcher echo update: %v", err)
+	}
+	afterEcho, _ := m.GetByID(auth.ID)
+	echoQuotaState := afterEcho.ModelStates[quotaModel]
+	if echoQuotaState == nil || !echoQuotaState.Quota.Exceeded || echoQuotaState.LastError == nil || echoQuotaState.LastError.HTTPStatus != http.StatusTooManyRequests {
+		t.Fatalf("watcher echo replaced independent quota state: %#v", echoQuotaState)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(afterEcho, quotaModel, time.Now()); !blocked {
+		t.Fatal("watcher echo cleared independent quota selection block")
+	}
+
+	// Exercise the same authoritative update used by management re-enable.
+	reenabled := afterEcho.Clone()
+	reenabled.Disabled = false
+	reenabled.Status = StatusActive
+	reenabled.StatusMessage = ""
+	reenabled.Metadata["disabled"] = false
+	delete(reenabled.Metadata, "disabled_reason")
+	if _, err := m.Update(context.Background(), reenabled); err != nil {
+		t.Fatalf("management re-enable update: %v", err)
+	}
+
+	current, _ := m.GetByID(auth.ID)
+	if blocked, _, _ := isAuthBlockedForModel(current, paymentModel, time.Now()); blocked {
+		t.Fatal("stale payment model state blocks auth after management re-enable")
+	}
+	if got := reg.GetModelCount(paymentModel); got != 1 {
+		t.Fatalf("payment model count after management re-enable = %d, want 1", got)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(current, quotaModel, time.Now()); !blocked {
+		t.Fatal("independent quota state was cleared by management re-enable")
+	}
+	if got := reg.GetModelCount(quotaModel); got != 0 {
+		t.Fatalf("quota model count after management re-enable = %d, want 0", got)
+	}
+	quotaState := current.ModelStates[quotaModel]
+	if quotaState == nil || !quotaState.Quota.Exceeded || quotaState.LastError == nil || quotaState.LastError.HTTPStatus != http.StatusTooManyRequests {
+		t.Fatalf("independent quota state changed: %#v", quotaState)
+	}
+}
+
+func TestMarkResultForbiddenRemainsCooldownWhenPaymentRequiredDisableEnabled(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	auth := &Auth{ID: "forbidden-key", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	stop := m.markResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "gpt-test",
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusForbidden, Message: "forbidden"},
+	})
+	if stop {
+		t.Fatal("stopAuth = true for 403, want false")
+	}
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("auth missing")
+	}
+	if updated.Disabled || updated.Status == StatusDisabled {
+		t.Fatalf("403 disabled auth: disabled=%v status=%s", updated.Disabled, updated.Status)
+	}
+	state := updated.ModelStates["gpt-test"]
+	if state == nil || state.NextRetryAfter.Before(time.Now().Add(29*time.Minute)) {
+		t.Fatalf("403 model cooldown missing: %#v", state)
+	}
+}
+
+func TestPaymentRequiredDisableSurvivesCredentialMaintenanceAndAllowsAuthoritativeReenable(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	auth := &Auth{
+		ID:       "maintenance-update-key",
+		Provider: "openai-compatibility",
+		Status:   StatusActive,
+		Metadata: map[string]any{"disabled": false},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	staleMaintenance, _ := m.GetByID(auth.ID)
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "gpt-test",
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	})
+	if _, err := m.Update(withCredentialMaintenanceUpdate(context.Background(), staleMaintenance), staleMaintenance); err != nil {
+		t.Fatalf("maintenance update: %v", err)
+	}
+	current, _ := m.GetByID(auth.ID)
+	if current == nil || !current.Disabled || current.Status != StatusDisabled {
+		t.Fatalf("maintenance update re-enabled auth: %#v", current)
+	}
+
+	// Config reloads and management changes are authoritative and do not carry
+	// the maintenance context marker.
+	authoritative := &Auth{
+		ID:       auth.ID,
+		Provider: auth.Provider,
+		Status:   StatusActive,
+		Metadata: map[string]any{"disabled": false},
+	}
+	if _, err := m.Update(context.Background(), authoritative); err != nil {
+		t.Fatalf("authoritative re-enable: %v", err)
+	}
+	current, _ = m.GetByID(auth.ID)
+	if current == nil || current.Disabled || current.Status != StatusActive {
+		t.Fatalf("authoritative re-enable was not applied: %#v", current)
+	}
+
+	// A maintenance clone started after re-enable but before a later 402 must
+	// still be rejected when that second disable wins the race.
+	secondStaleMaintenance := current.Clone()
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "gpt-test",
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance again"},
+	})
+	if _, err := m.Update(withCredentialMaintenanceUpdate(context.Background(), secondStaleMaintenance), secondStaleMaintenance); err != nil {
+		t.Fatalf("second maintenance update: %v", err)
+	}
+	current, _ = m.GetByID(auth.ID)
+	if current == nil || !current.Disabled || current.Status != StatusDisabled {
+		t.Fatalf("second maintenance update re-enabled auth: %#v", current)
+	}
+}
+
+func TestCredentialMaintenancePreservesRuntimeStateAcrossPaymentDisableReenableCycle(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	auth := &Auth{
+		ID:       "maintenance-disable-reenable-cycle",
+		Provider: "openai-compatibility",
+		Status:   StatusActive,
+		Metadata: map[string]any{"disabled": false, "token": "old"},
+		ModelStates: map[string]*ModelState{
+			"baseline-model": {Status: StatusActive},
+		},
+	}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	staleMaintenance, _ := m.GetByID(auth.ID)
+	staleMaintenance.Metadata["token"] = "refreshed"
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "baseline-model",
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	})
+	reenabled, _ := m.GetByID(auth.ID)
+	reenabled.Disabled = false
+	reenabled.Unavailable = false
+	reenabled.Status = StatusActive
+	reenabled.StatusMessage = ""
+	reenabled.LastError = nil
+	reenabled.NextRetryAfter = time.Time{}
+	reenabled.Metadata["disabled"] = false
+	delete(reenabled.Metadata, "disabled_reason")
+	if _, err := m.Update(context.Background(), reenabled); err != nil {
+		t.Fatalf("authoritative re-enable: %v", err)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "newer-model",
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "newer quota state"},
+	})
+	beforeMaintenance, _ := m.GetByID(auth.ID)
+	newerState := beforeMaintenance.ModelStates["newer-model"]
+	if newerState == nil || newerState.NextRetryAfter.IsZero() {
+		t.Fatalf("newer runtime state missing before maintenance: %#v", beforeMaintenance.ModelStates)
+	}
+
+	if _, err := m.UpdateCredentialMaintenance(context.Background(), staleMaintenance, staleMaintenance); err != nil {
+		t.Fatalf("maintenance update: %v", err)
+	}
+	current, _ := m.GetByID(auth.ID)
+	if current == nil {
+		t.Fatal("auth missing after maintenance")
+	}
+	if current.Metadata["token"] != "refreshed" {
+		t.Fatalf("credential refresh was lost: metadata=%#v", current.Metadata)
+	}
+	state := current.ModelStates["newer-model"]
+	if state == nil || state.NextRetryAfter.IsZero() || state.StatusMessage != "newer quota state" {
+		t.Fatalf("maintenance replaced newer runtime state: %#v", current.ModelStates)
+	}
+}
+
+func TestPaymentRequiredDisableFallsBackToCooldownForPluginVirtualAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	auth := &Auth{ID: "virtual-key", Provider: "plugin-provider", Status: StatusActive}
+	MarkPluginVirtualAuth(auth, "/tmp/plugin-source.json", 0)
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	stop := m.markResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "model-a",
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	})
+	if stop {
+		t.Fatal("stopAuth = true, want cooldown fallback for plugin virtual auth")
+	}
+	current, _ := m.GetByID(auth.ID)
+	if current == nil {
+		t.Fatal("auth missing")
+	}
+	if current.Disabled || current.Status == StatusDisabled {
+		t.Fatalf("plugin virtual auth was disabled: %#v", current)
+	}
+	state := current.ModelStates["model-a"]
+	if state == nil || state.NextRetryAfter.Before(time.Now().Add(29*time.Minute)) {
+		t.Fatalf("plugin virtual cooldown missing: %#v", state)
+	}
+}
+
+func TestAntigravityCreditsStopsModelPoolAfterPaymentDisable(t *testing.T) {
+	const alias = "claude-payment-pool"
+	models := []internalconfig.OpenAICompatibilityModel{
+		{Name: "model-a", Alias: alias},
+		{Name: "model-b", Alias: alias},
+	}
+	payErr := &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"}
+	executor := &openAICompatPoolExecutor{
+		id:            openAICompatPoolProviderKey,
+		executeErrors: map[string]error{"model-a": payErr},
+	}
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{
+			AntigravityCredits: true,
+			OnPaymentRequired:  "disable",
+		},
+		OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+			Name: "pool", Models: models,
+		}},
+	})
+	m.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "antigravity-payment-pool-key",
+		Provider: "antigravity",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"api_key":      "test-key",
+			"compat_name":  "pool",
+			"provider_key": "pool",
+		},
+	}
+	if _, err := m.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	_, ok, err := m.tryAntigravityCreditsExecute(
+		context.Background(),
+		cliproxyexecutor.Request{Model: alias},
+		cliproxyexecutor.Options{},
+	)
+	if err != nil {
+		t.Fatalf("credits execute: %v", err)
+	}
+	if ok {
+		t.Fatal("credits execute ok = true, want false after 402")
+	}
+	if got := executor.ExecuteModels(); len(got) != 1 || got[0] != "model-a" {
+		t.Fatalf("credits models = %v, want only model-a after disable", got)
+	}
+	current, found := m.GetByID(auth.ID)
+	if !found || current == nil || !current.Disabled || current.Status != StatusDisabled {
+		t.Fatalf("auth after credits 402 = %#v, want disabled", current)
+	}
+}
+
+func TestPaymentRequiredDisableSurvivesConcurrentSuccess(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	auth := &Auth{ID: "concurrent-success-key", Provider: "openai-compatibility", Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "model-a",
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	})
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "model-b", Success: true,
+	})
+
+	current, _ := m.GetByID(auth.ID)
+	if current == nil || !current.Disabled || current.Status != StatusDisabled {
+		t.Fatalf("concurrent success cleared payment disable: %#v", current)
+	}
+}
+
+type paymentRequiredBlockingRefreshExecutor struct {
+	schedulerProviderTestExecutor
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (e *paymentRequiredBlockingRefreshExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	e.once.Do(func() { close(e.started) })
+	select {
+	case <-e.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["access_token"] = "refreshed-token"
+	return auth, nil
+}
+
+func TestPaymentRequiredDisabledRefreshPreservesNewerModelCooldown(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	executor := &paymentRequiredBlockingRefreshExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "codex"},
+		started:                       make(chan struct{}),
+		release:                       make(chan struct{}),
+	}
+	m.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "refresh-disable-cooldown-key",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+	if _, err := m.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, err := m.refreshAuthForRequest(context.Background(), auth.ID, "")
+		refreshDone <- err
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+
+	const cooldownModel = "newer-disabled-cooldown-model"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: cooldownModel}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "payment-model",
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	})
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: cooldownModel,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "newer quota failure"},
+	})
+	beforeRefresh, _ := m.GetByID(auth.ID)
+	beforeState := beforeRefresh.ModelStates[cooldownModel]
+	if beforeState == nil || !beforeState.Unavailable || beforeState.NextRetryAfter.IsZero() {
+		t.Fatalf("newer cooldown was not established: %#v", beforeState)
+	}
+
+	close(executor.release)
+	select {
+	case err := <-refreshDone:
+		if err != nil {
+			t.Fatalf("refresh: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not finish")
+	}
+
+	current, _ := m.GetByID(auth.ID)
+	if current == nil || !current.Disabled || current.Status != StatusDisabled {
+		t.Fatalf("refresh changed payment-disabled state: %#v", current)
+	}
+	afterState := current.ModelStates[cooldownModel]
+	if afterState == nil || !afterState.Unavailable || !afterState.NextRetryAfter.Equal(beforeState.NextRetryAfter) {
+		t.Fatalf("newer model cooldown was overwritten: before=%#v after=%#v", beforeState, afterState)
+	}
+	if current.Quota != beforeRefresh.Quota {
+		t.Fatalf("newer auth quota was overwritten: before=%#v after=%#v", beforeRefresh.Quota, current.Quota)
+	}
+	if current.LastError == nil || current.LastError.HTTPStatus != http.StatusTooManyRequests {
+		t.Fatalf("newer auth error was overwritten: %#v", current.LastError)
+	}
+}
+
+func TestPaymentRequiredAuthoritativeReenableWinsInFlightDisabledRefresh(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	executor := &paymentRequiredBlockingRefreshExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "codex"},
+		started:                       make(chan struct{}),
+		release:                       make(chan struct{}),
+	}
+	m.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "refresh-reenable-key",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+	if _, err := m.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "gpt-test",
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	})
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, err := m.refreshAuthForRequest(context.Background(), auth.ID, "")
+		refreshDone <- err
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+
+	current, _ := m.GetByID(auth.ID)
+	if current == nil || !current.Disabled {
+		t.Fatalf("refresh source auth = %#v, want disabled", current)
+	}
+	reenabled := current.Clone()
+	reenabled.Disabled = false
+	reenabled.Unavailable = false
+	reenabled.Status = StatusActive
+	reenabled.StatusMessage = ""
+	reenabled.Metadata["disabled"] = false
+	if _, err := m.Update(context.Background(), reenabled); err != nil {
+		t.Fatalf("authoritative re-enable: %v", err)
+	}
+	close(executor.release)
+
+	select {
+	case err := <-refreshDone:
+		if err != nil {
+			t.Fatalf("refresh: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not finish")
+	}
+	current, _ = m.GetByID(auth.ID)
+	if current == nil || current.Disabled || current.Status != StatusActive {
+		t.Fatalf("in-flight disabled refresh overrode re-enable: %#v", current)
+	}
+	if got, _ := current.Metadata["access_token"].(string); got != "refreshed-token" {
+		t.Fatalf("refreshed token = %q, want refreshed-token", got)
+	}
+	if _, exists := current.Metadata["disabled_reason"]; exists {
+		t.Fatalf("disabled_reason persisted after authoritative re-enable: %#v", current.Metadata["disabled_reason"])
+	}
+}
+
+func TestPaymentRequiredReenabledRefreshPreservesNewerModelCooldown(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	executor := &paymentRequiredBlockingRefreshExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "codex"},
+		started:                       make(chan struct{}),
+		release:                       make(chan struct{}),
+	}
+	m.RegisterExecutor(executor)
+	auth := &Auth{
+		ID:       "refresh-reenable-cooldown-key",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{"access_token": "old-token"},
+	}
+	if _, err := m.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "payment-model",
+		Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	})
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, err := m.refreshAuthForRequest(context.Background(), auth.ID, "")
+		refreshDone <- err
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+
+	current, _ := m.GetByID(auth.ID)
+	reenabled := current.Clone()
+	reenabled.Disabled = false
+	reenabled.Unavailable = false
+	reenabled.Status = StatusActive
+	reenabled.StatusMessage = ""
+	reenabled.Metadata["disabled"] = false
+	if _, err := m.Update(context.Background(), reenabled); err != nil {
+		t.Fatalf("authoritative re-enable: %v", err)
+	}
+
+	const cooldownModel = "newer-cooldown-model"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: cooldownModel}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: cooldownModel,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "newer quota failure"},
+	})
+	beforeRefresh, _ := m.GetByID(auth.ID)
+	beforeState := beforeRefresh.ModelStates[cooldownModel]
+	if beforeState == nil || !beforeState.Unavailable || beforeState.NextRetryAfter.IsZero() {
+		t.Fatalf("newer cooldown was not established: %#v", beforeState)
+	}
+	if got := reg.GetModelCount(cooldownModel); got != 0 {
+		t.Fatalf("registry model count during cooldown = %d, want 0", got)
+	}
+
+	close(executor.release)
+	select {
+	case err := <-refreshDone:
+		if err != nil {
+			t.Fatalf("refresh: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not finish")
+	}
+
+	current, _ = m.GetByID(auth.ID)
+	if current == nil || current.Disabled {
+		t.Fatalf("refresh changed authoritative re-enable state: %#v", current)
+	}
+	if got, _ := current.Metadata["access_token"].(string); got != "refreshed-token" {
+		t.Fatalf("refreshed token = %q, want refreshed-token", got)
+	}
+	afterState := current.ModelStates[cooldownModel]
+	if afterState == nil || !afterState.Unavailable || !afterState.NextRetryAfter.Equal(beforeState.NextRetryAfter) {
+		t.Fatalf("newer model cooldown was overwritten: before=%#v after=%#v", beforeState, afterState)
+	}
+	if got := reg.GetModelCount(cooldownModel); got != 0 {
+		t.Fatalf("registry model count after refresh = %d, want 0", got)
+	}
+	if current.Quota != beforeRefresh.Quota {
+		t.Fatalf("newer auth quota was overwritten: before=%#v after=%#v", beforeRefresh.Quota, current.Quota)
+	}
+	if current.LastError == nil || current.LastError.HTTPStatus != http.StatusTooManyRequests || current.LastError.Message != "newer quota failure" {
+		t.Fatalf("newer auth error was overwritten: %#v", current.LastError)
+	}
+}
+
+type paymentRequiredRaceStore struct {
+	activeSaveStarted chan struct{}
+	releaseActiveSave chan struct{}
+	disabledSaved     chan struct{}
+	activeOnce        sync.Once
+	disabledOnce      sync.Once
+	mu                sync.Mutex
+	saved             []*Auth
+}
+
+func newPaymentRequiredRaceStore() *paymentRequiredRaceStore {
+	return &paymentRequiredRaceStore{
+		activeSaveStarted: make(chan struct{}),
+		releaseActiveSave: make(chan struct{}),
+		disabledSaved:     make(chan struct{}),
+	}
+}
+
+func (s *paymentRequiredRaceStore) List(context.Context) ([]*Auth, error) { return nil, nil }
+
+func (s *paymentRequiredRaceStore) Save(ctx context.Context, auth *Auth) (string, error) {
+	snapshot := auth.Clone()
+	if snapshot != nil && !snapshot.Disabled {
+		s.activeOnce.Do(func() { close(s.activeSaveStarted) })
+		select {
+		case <-s.releaseActiveSave:
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	s.mu.Lock()
+	s.saved = append(s.saved, snapshot)
+	s.mu.Unlock()
+	if snapshot != nil && snapshot.Disabled {
+		s.disabledOnce.Do(func() { close(s.disabledSaved) })
+	}
+	return "", nil
+}
+
+func (s *paymentRequiredRaceStore) Delete(context.Context, string) error { return nil }
+
+func (s *paymentRequiredRaceStore) lastSaved() *Auth {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.saved) == 0 {
+		return nil
+	}
+	return s.saved[len(s.saved)-1].Clone()
+}
+
+func TestPaymentRequiredDisableWinsInFlightRegistrationPersistence(t *testing.T) {
+	store := newPaymentRequiredRaceStore()
+	m := NewManager(store, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	auth := &Auth{
+		ID:       "registration-race-key",
+		Provider: "openai-compatibility",
+		Status:   StatusActive,
+		Metadata: map[string]any{"token": "initial"},
+	}
+
+	registerDone := make(chan error, 1)
+	go func() {
+		_, err := m.Register(context.Background(), auth)
+		registerDone <- err
+	}()
+	select {
+	case <-store.activeSaveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("registration persistence did not start")
+	}
+
+	markDone := make(chan struct{})
+	go func() {
+		m.MarkResult(context.Background(), Result{
+			AuthID: auth.ID, Provider: auth.Provider, Model: "gpt-test",
+			Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+		})
+		close(markDone)
+	}()
+	select {
+	case <-store.disabledSaved:
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(store.releaseActiveSave)
+
+	select {
+	case err := <-registerDone:
+		if err != nil {
+			t.Fatalf("register: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("registration did not finish")
+	}
+	select {
+	case <-markDone:
+	case <-time.After(time.Second):
+		t.Fatal("402 result did not finish")
+	}
+
+	last := store.lastSaved()
+	if last == nil || !last.Disabled || last.Status != StatusDisabled {
+		t.Fatalf("final persisted auth = %#v, want payment-disabled", last)
+	}
+	current, _ := m.GetByID(auth.ID)
+	if current == nil || !current.Disabled || current.Status != StatusDisabled {
+		t.Fatalf("runtime auth = %#v, want payment-disabled", current)
+	}
+}
+
+func TestPaymentRequiredDisableWinsInFlightMaintenancePersistence(t *testing.T) {
+	store := newPaymentRequiredRaceStore()
+	m := NewManager(store, nil, nil)
+	m.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	auth := &Auth{
+		ID:       "persistence-race-key",
+		Provider: "openai-compatibility",
+		Status:   StatusActive,
+		Metadata: map[string]any{"token": "old"},
+	}
+	if _, err := m.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	staleMaintenance, _ := m.GetByID(auth.ID)
+	staleMaintenance.Metadata["token"] = "refreshed"
+
+	updateDone := make(chan error, 1)
+	go func() {
+		_, err := m.Update(withCredentialMaintenanceUpdate(context.Background(), staleMaintenance), staleMaintenance)
+		updateDone <- err
+	}()
+	select {
+	case <-store.activeSaveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("maintenance persistence did not start")
+	}
+
+	markDone := make(chan struct{})
+	go func() {
+		m.MarkResult(context.Background(), Result{
+			AuthID: auth.ID, Provider: auth.Provider, Model: "gpt-test",
+			Error: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+		})
+		close(markDone)
+	}()
+
+	// The old implementation lets the 402 persist while the stale active save is
+	// blocked. A serialized implementation reaches this channel only after release.
+	select {
+	case <-store.disabledSaved:
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(store.releaseActiveSave)
+
+	select {
+	case err := <-updateDone:
+		if err != nil {
+			t.Fatalf("maintenance update: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("maintenance update did not finish")
+	}
+	select {
+	case <-markDone:
+	case <-time.After(time.Second):
+		t.Fatal("402 result did not finish")
+	}
+
+	last := store.lastSaved()
+	if last == nil || !last.Disabled || last.Status != StatusDisabled {
+		t.Fatalf("final persisted auth = %#v, want payment-disabled", last)
+	}
+	current, _ := m.GetByID(auth.ID)
+	if current == nil || !current.Disabled || current.Status != StatusDisabled {
+		t.Fatalf("runtime auth = %#v, want payment-disabled", current)
+	}
+}

--- a/sdk/cliproxy/service_auth.go
+++ b/sdk/cliproxy/service_auth.go
@@ -281,8 +281,11 @@ func (s *Service) prepareCoreAuthForModelRegistration(ctx context.Context, auth 
 	// immediately for API calls, rather than waiting for model registration to complete.
 	op := "register"
 	var err error
+	preservePaymentDisabledRegistration := false
 	if existing, ok := s.coreManager.GetByID(auth.ID); ok {
 		auth.CreatedAt = existing.CreatedAt
+		preservePaymentDisabledRegistration = coreauth.IsPaymentRequiredDisabled(existing) &&
+			coreauth.IsPaymentRequiredDisabled(auth)
 		if !existing.Disabled && existing.Status != coreauth.StatusDisabled && !auth.Disabled && auth.Status != coreauth.StatusDisabled {
 			auth.LastRefreshedAt = existing.LastRefreshedAt
 			auth.NextRefreshAfter = existing.NextRefreshAfter
@@ -303,6 +306,9 @@ func (s *Service) prepareCoreAuthForModelRegistration(ctx context.Context, auth 
 			return nil
 		}
 		auth = current
+	}
+	if preservePaymentDisabledRegistration {
+		return nil
 	}
 	return auth
 }

--- a/sdk/cliproxy/service_payment_required_test.go
+++ b/sdk/cliproxy/service_payment_required_test.go
@@ -1,0 +1,119 @@
+package cliproxy
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestServiceWatcherEchoPreservesIndependentQuotaAcrossPaymentReenable(t *testing.T) {
+	models := registry.GetClaudeModels()
+	if len(models) < 2 {
+		t.Fatalf("claude model catalog has %d models, want at least 2", len(models))
+	}
+	quotaModel := models[0].ID
+	paymentModel := models[1].ID
+	reg := registry.GetGlobalRegistry()
+	quotaBaseline := reg.GetModelCount(quotaModel)
+	paymentBaseline := reg.GetModelCount(paymentModel)
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{OnPaymentRequired: "disable"},
+	})
+	service := &Service{cfg: &config.Config{}, coreManager: manager}
+	auth := &coreauth.Auth{
+		ID:       "payment-watcher-echo-auth",
+		Provider: "claude",
+		Status:   coreauth.StatusActive,
+	}
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	service.handleAuthUpdate(coreauth.WithSkipPersist(context.Background()), watcher.AuthUpdate{
+		Action: watcher.AuthUpdateActionAdd,
+		ID:     auth.ID,
+		Auth:   auth,
+	})
+	manager.MarkResult(context.Background(), coreauth.Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    quotaModel,
+		Error:    &coreauth.Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+	})
+	manager.MarkResult(context.Background(), coreauth.Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    paymentModel,
+		Error:    &coreauth.Error{HTTPStatus: http.StatusPaymentRequired, Message: "insufficient balance"},
+	})
+
+	disabledEcho := &coreauth.Auth{
+		ID:       auth.ID,
+		Provider: auth.Provider,
+		Disabled: true,
+		Status:   coreauth.StatusDisabled,
+		Metadata: map[string]any{
+			"disabled":        true,
+			"disabled_reason": "payment_required",
+		},
+	}
+	service.handleAuthUpdate(coreauth.WithSkipPersist(context.Background()), watcher.AuthUpdate{
+		Action: watcher.AuthUpdateActionModify,
+		ID:     auth.ID,
+		Auth:   disabledEcho,
+	})
+	assertIndependentQuotaState(t, manager, auth.ID, quotaModel)
+	if got := reg.GetModelCount(quotaModel); got != quotaBaseline {
+		t.Fatalf("quota model count after disabled watcher echo = %d, want baseline %d", got, quotaBaseline)
+	}
+
+	reenabled, _ := manager.GetByID(auth.ID)
+	reenabled.Disabled = false
+	reenabled.Status = coreauth.StatusActive
+	reenabled.StatusMessage = ""
+	reenabled.Metadata["disabled"] = false
+	delete(reenabled.Metadata, "disabled_reason")
+	if _, err := manager.Update(context.Background(), reenabled); err != nil {
+		t.Fatalf("management re-enable: %v", err)
+	}
+
+	activeEcho := &coreauth.Auth{
+		ID:       auth.ID,
+		Provider: auth.Provider,
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"disabled": false},
+	}
+	service.handleAuthUpdate(coreauth.WithSkipPersist(context.Background()), watcher.AuthUpdate{
+		Action: watcher.AuthUpdateActionModify,
+		ID:     auth.ID,
+		Auth:   activeEcho,
+	})
+	assertIndependentQuotaState(t, manager, auth.ID, quotaModel)
+	if got := reg.GetModelCount(quotaModel); got != quotaBaseline {
+		t.Fatalf("quota model count after active watcher echo = %d, want baseline %d", got, quotaBaseline)
+	}
+	if got := reg.GetModelCount(paymentModel); got != paymentBaseline+1 {
+		t.Fatalf("payment model count after re-enable = %d, want %d", got, paymentBaseline+1)
+	}
+}
+
+func assertIndependentQuotaState(t *testing.T, manager *coreauth.Manager, authID, model string) {
+	t.Helper()
+	current, ok := manager.GetByID(authID)
+	if !ok || current == nil {
+		t.Fatal("auth missing")
+	}
+	state := current.ModelStates[model]
+	if state == nil || !state.Unavailable || !state.Quota.Exceeded ||
+		state.LastError == nil || state.LastError.HTTPStatus != http.StatusTooManyRequests ||
+		state.NextRetryAfter.Before(time.Now()) {
+		t.Fatalf("independent quota state changed: %#v", state)
+	}
+}


### PR DESCRIPTION
## Summary

- add `quota-exceeded.on-payment-required: cooldown|disable`, with `cooldown` preserving the existing default
- when configured as `disable`, HTTP 402 removes the credential from rotation until an authoritative management or config update re-enables it
- keep HTTP 403 and every non-402 failure path unchanged
- stop pooled execute, count, stream, and Antigravity credits attempts from trying another model on the same exhausted credential
- preserve non-empty upstream 402 diagnostics in cooldown mode, using `payment_required` only as the empty-message fallback
- expose the setting in config hot-reload diffs and `config.example.yaml`

## State and concurrency behavior

- file-backed credentials persist the disabled flag and `payment_required` reason
- config-backed API keys are disabled for the current runtime; an authoritative config reload may recreate them active
- credential refresh and request-preparation updates cloned before a 402 cannot overwrite the newer disable
- a refresh cloned while disabled cannot later undo an authoritative operator re-enable
- registration, update, and result persistence are ordered per auth ID, so an older active save cannot finish after a newer disabled save
- model state remains soft, so management re-enable does not require a separate quota reset
- plugin-expanded virtual children retain cooldown behavior because their source file owns the group and individual child state cannot be persisted safely

## Compatibility

- empty, mixed-case, and unknown config values normalize safely to `cooldown`
- HTTP 403 remains temporary cooldown-only
- the exported `MarkResult` API remains unchanged
- Home dispatch behavior is unchanged
- default cooldown mode keeps provider diagnostics such as `insufficient balance` visible in auth and model status

## Validation

- red/green regression for preserving upstream 402 diagnostics in cooldown mode
- `go test ./sdk/cliproxy/auth ./internal/config ./internal/watcher/diff -count=1`
- focused payment-required race tests, count 10
- `go test ./... -count=1`
- `go vet ./sdk/cliproxy/auth ./internal/config ./internal/watcher/diff`
- `go build -o /tmp/cli-proxy-api-pr4266 ./cmd/server`
- `git diff --check upstream/dev...HEAD`

Closes #3977.
