### PR TITLE
fix(codex): preserve configured model metadata identity

### DIFF
--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -27,6 +27,9 @@ const (
 type ModelInfo struct {
 	// ID is the unique identifier for the model
 	ID string `json:"id"`
+	// MetadataModelID identifies the canonical model used to resolve client metadata.
+	// It is internal and must not be exposed in model-list responses.
+	MetadataModelID string `json:"-"`
 	// Object type for the model (typically "model")
 	Object string `json:"object"`
 	// Created timestamp when the model was created

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -54,9 +54,11 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 		if id == "" {
 			continue
 		}
+		metadataID := codexClientMetadataModelID(id)
 
-		if template, ok := templates[id]; ok {
+		if template, ok := templates[metadataID]; ok {
 			entry := cloneCodexClientModelMap(template)
+			entry["slug"] = id
 			applyCodexClientDisplayName(entry, model)
 			sanitizeCodexClientReasoningMetadata(entry)
 			applyCodexClientVisibilityOverride(entry, id)
@@ -65,7 +67,7 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 		}
 
 		entry := cloneCodexClientModelMap(defaultTemplate)
-		applyCodexClientModelMetadata(entry, id, model)
+		applyCodexClientModelMetadata(entry, id, metadataID, model)
 		sanitizeCodexClientReasoningMetadata(entry)
 		applyCodexClientVisibilityOverride(entry, id)
 		result = append(result, entry)
@@ -172,37 +174,59 @@ func loadCodexClientModelTemplatesSnapshot(raw []byte, revision uint64) (map[str
 	return codexClientModelTemplates, codexClientDefaultTemplate, codexClientModelTemplatesErr
 }
 
+func codexClientMetadataModelID(id string) string {
+	if info := registry.LookupModelInfo(id); info != nil {
+		if metadataID := strings.TrimSpace(info.MetadataModelID); metadataID != "" {
+			return metadataID
+		}
+	}
+	return id
+}
+
 func applyCodexClientDisplayName(entry map[string]any, model map[string]any) {
 	if displayName := stringModelValue(model, "display_name"); displayName != "" {
 		entry["display_name"] = displayName
 	}
 }
 
-func applyCodexClientModelMetadata(entry map[string]any, id string, model map[string]any) {
-	info := registry.LookupModelInfo(id)
+func applyCodexClientModelMetadata(entry map[string]any, id, metadataID string, model map[string]any) {
+	clientInfo := registry.LookupModelInfo(id)
+	capabilityInfo := clientInfo
+	if clientInfo != nil && strings.TrimSpace(clientInfo.MetadataModelID) != "" {
+		if staticInfo := registry.LookupStaticModelInfo(metadataID); staticInfo != nil {
+			capabilityInfo = staticInfo
+		} else if metadataID != id {
+			if metadataInfo := registry.LookupModelInfo(metadataID); metadataInfo != nil {
+				capabilityInfo = metadataInfo
+			}
+		}
+	}
 
 	displayName := stringModelValue(model, "display_name")
 	description := stringModelValue(model, "description")
 	contextWindow := intModelValue(model, "context_length")
 
-	if info != nil {
-		if info.DisplayName != "" {
-			displayName = info.DisplayName
+	if clientInfo != nil {
+		if clientInfo.DisplayName != "" {
+			displayName = clientInfo.DisplayName
 		}
-		if info.Description != "" {
-			description = info.Description
+		if clientInfo.Description != "" {
+			description = clientInfo.Description
 		}
-		if info.ContextLength > 0 {
-			contextWindow = info.ContextLength
+	}
+
+	if capabilityInfo != nil {
+		if capabilityInfo.ContextLength > 0 {
+			contextWindow = capabilityInfo.ContextLength
 		}
-		if info.Type == registry.OpenAIImageModelType {
+		if capabilityInfo.Type == registry.OpenAIImageModelType {
 			entry["visibility"] = "hide"
 			delete(entry, "input_modalities")
 			delete(entry, "supports_image_detail_original")
 		} else {
-			applyCodexClientInputModalitiesMetadata(entry, info.SupportedInputModalities)
+			applyCodexClientInputModalitiesMetadata(entry, capabilityInfo.SupportedInputModalities)
 		}
-		applyCodexClientThinkingMetadata(entry, info.Thinking)
+		applyCodexClientThinkingMetadata(entry, capabilityInfo.Thinking)
 	}
 
 	if displayName == "" {

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -49,6 +49,7 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 	}
 
 	result := make([]map[string]any, 0, len(models))
+	templateBackedIndexes := make(map[int]struct{})
 	for _, model := range models {
 		id := strings.TrimSpace(stringModelValue(model, "id"))
 		if id == "" {
@@ -59,6 +60,7 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 		if template, ok := templates[metadataID]; ok {
 			entry := cloneCodexClientModelMap(template)
 			entry["slug"] = id
+			templateBackedIndexes[len(result)] = struct{}{}
 			applyCodexClientDisplayName(entry, model)
 			sanitizeCodexClientReasoningMetadata(entry)
 			applyCodexClientVisibilityOverride(entry, id)
@@ -73,7 +75,7 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 		result = append(result, entry)
 	}
 
-	applyCodexClientNonTemplatePriorities(result, templates)
+	applyCodexClientNonTemplatePriorities(result, templates, templateBackedIndexes)
 
 	sort.SliceStable(result, func(i, j int) bool {
 		return codexClientModelPriority(result[i]) < codexClientModelPriority(result[j])
@@ -93,7 +95,7 @@ func maxCodexClientTemplatePriority(templates map[string]map[string]any) int {
 	return maxPriority
 }
 
-func applyCodexClientNonTemplatePriorities(result []map[string]any, templates map[string]map[string]any) {
+func applyCodexClientNonTemplatePriorities(result []map[string]any, templates map[string]map[string]any, templateBackedIndexes map[int]struct{}) {
 	if len(result) == 0 {
 		return
 	}
@@ -107,10 +109,10 @@ func applyCodexClientNonTemplatePriorities(result []map[string]any, templates ma
 
 	pending := make([]nonTemplateEntry, 0)
 	for index, entry := range result {
-		slug := stringModelValue(entry, "slug")
-		if _, ok := templates[slug]; ok {
+		if _, ok := templateBackedIndexes[index]; ok {
 			continue
 		}
+		slug := stringModelValue(entry, "slug")
 		displayName := stringModelValue(entry, "display_name")
 		if displayName == "" {
 			displayName = slug
@@ -191,13 +193,13 @@ func applyCodexClientDisplayName(entry map[string]any, model map[string]any) {
 
 func applyCodexClientModelMetadata(entry map[string]any, id, metadataID string, model map[string]any) {
 	clientInfo := registry.LookupModelInfo(id)
-	capabilityInfo := clientInfo
+	metadataInfo := clientInfo
 	if clientInfo != nil && strings.TrimSpace(clientInfo.MetadataModelID) != "" {
 		if staticInfo := registry.LookupStaticModelInfo(metadataID); staticInfo != nil {
-			capabilityInfo = staticInfo
+			metadataInfo = staticInfo
 		} else if metadataID != id {
-			if metadataInfo := registry.LookupModelInfo(metadataID); metadataInfo != nil {
-				capabilityInfo = metadataInfo
+			if resolvedInfo := registry.LookupModelInfo(metadataID); resolvedInfo != nil {
+				metadataInfo = resolvedInfo
 			}
 		}
 	}
@@ -215,10 +217,34 @@ func applyCodexClientModelMetadata(entry map[string]any, id, metadataID string, 
 		}
 	}
 
-	if capabilityInfo != nil {
-		if capabilityInfo.ContextLength > 0 {
-			contextWindow = capabilityInfo.ContextLength
+	if contextWindow <= 0 && clientInfo != nil && clientInfo.ContextLength > 0 {
+		contextWindow = clientInfo.ContextLength
+	}
+	if contextWindow <= 0 && metadataInfo != nil && metadataInfo.ContextLength > 0 {
+		contextWindow = metadataInfo.ContextLength
+	}
+
+	// Canonical metadata fills missing capabilities; route-specific configuration remains authoritative.
+	capabilityInfo := metadataInfo
+	if clientInfo != nil {
+		if capabilityInfo == nil {
+			capabilityInfo = clientInfo
+		} else {
+			mergedInfo := *capabilityInfo
+			if clientInfo.Type == registry.OpenAIImageModelType {
+				mergedInfo.Type = clientInfo.Type
+			}
+			if len(clientInfo.SupportedInputModalities) > 0 {
+				mergedInfo.SupportedInputModalities = clientInfo.SupportedInputModalities
+			}
+			if clientInfo.Thinking != nil {
+				mergedInfo.Thinking = clientInfo.Thinking
+			}
+			capabilityInfo = &mergedInfo
 		}
+	}
+
+	if capabilityInfo != nil {
 		if capabilityInfo.Type == registry.OpenAIImageModelType {
 			entry["visibility"] = "hide"
 			delete(entry, "input_modalities")

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -49,7 +49,6 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 	}
 
 	result := make([]map[string]any, 0, len(models))
-	templateBackedIndexes := make(map[int]struct{})
 	for _, model := range models {
 		id := strings.TrimSpace(stringModelValue(model, "id"))
 		if id == "" {
@@ -60,7 +59,9 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 		if template, ok := templates[metadataID]; ok {
 			entry := cloneCodexClientModelMap(template)
 			entry["slug"] = id
-			templateBackedIndexes[len(result)] = struct{}{}
+			if metadataID != id {
+				applyCodexClientModelCapabilities(entry, registry.LookupModelInfo(id))
+			}
 			applyCodexClientDisplayName(entry, model)
 			sanitizeCodexClientReasoningMetadata(entry)
 			applyCodexClientVisibilityOverride(entry, id)
@@ -69,13 +70,13 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 		}
 
 		entry := cloneCodexClientModelMap(defaultTemplate)
-		applyCodexClientModelMetadata(entry, id, metadataID, model)
+		applyCodexClientModelMetadata(entry, id, model)
 		sanitizeCodexClientReasoningMetadata(entry)
 		applyCodexClientVisibilityOverride(entry, id)
 		result = append(result, entry)
 	}
 
-	applyCodexClientNonTemplatePriorities(result, templates, templateBackedIndexes)
+	applyCodexClientNonTemplatePriorities(result, templates)
 
 	sort.SliceStable(result, func(i, j int) bool {
 		return codexClientModelPriority(result[i]) < codexClientModelPriority(result[j])
@@ -95,7 +96,7 @@ func maxCodexClientTemplatePriority(templates map[string]map[string]any) int {
 	return maxPriority
 }
 
-func applyCodexClientNonTemplatePriorities(result []map[string]any, templates map[string]map[string]any, templateBackedIndexes map[int]struct{}) {
+func applyCodexClientNonTemplatePriorities(result []map[string]any, templates map[string]map[string]any) {
 	if len(result) == 0 {
 		return
 	}
@@ -109,10 +110,10 @@ func applyCodexClientNonTemplatePriorities(result []map[string]any, templates ma
 
 	pending := make([]nonTemplateEntry, 0)
 	for index, entry := range result {
-		if _, ok := templateBackedIndexes[index]; ok {
+		slug := stringModelValue(entry, "slug")
+		if _, ok := templates[codexClientMetadataModelID(slug)]; ok {
 			continue
 		}
-		slug := stringModelValue(entry, "slug")
 		displayName := stringModelValue(entry, "display_name")
 		if displayName == "" {
 			displayName = slug
@@ -191,68 +192,38 @@ func applyCodexClientDisplayName(entry map[string]any, model map[string]any) {
 	}
 }
 
-func applyCodexClientModelMetadata(entry map[string]any, id, metadataID string, model map[string]any) {
-	clientInfo := registry.LookupModelInfo(id)
-	metadataInfo := clientInfo
-	if clientInfo != nil && strings.TrimSpace(clientInfo.MetadataModelID) != "" {
-		if staticInfo := registry.LookupStaticModelInfo(metadataID); staticInfo != nil {
-			metadataInfo = staticInfo
-		} else if metadataID != id {
-			if resolvedInfo := registry.LookupModelInfo(metadataID); resolvedInfo != nil {
-				metadataInfo = resolvedInfo
-			}
-		}
+func applyCodexClientModelCapabilities(entry map[string]any, info *registry.ModelInfo) {
+	if info == nil {
+		return
 	}
+	if info.Type == registry.OpenAIImageModelType {
+		entry["visibility"] = "hide"
+		delete(entry, "input_modalities")
+		delete(entry, "supports_image_detail_original")
+	} else {
+		applyCodexClientInputModalitiesMetadata(entry, info.SupportedInputModalities)
+	}
+	applyCodexClientThinkingMetadata(entry, info.Thinking)
+}
+
+func applyCodexClientModelMetadata(entry map[string]any, id string, model map[string]any) {
+	info := registry.LookupModelInfo(id)
 
 	displayName := stringModelValue(model, "display_name")
 	description := stringModelValue(model, "description")
 	contextWindow := intModelValue(model, "context_length")
 
-	if clientInfo != nil {
-		if clientInfo.DisplayName != "" {
-			displayName = clientInfo.DisplayName
+	if info != nil {
+		if info.DisplayName != "" {
+			displayName = info.DisplayName
 		}
-		if clientInfo.Description != "" {
-			description = clientInfo.Description
+		if info.Description != "" {
+			description = info.Description
 		}
-	}
-
-	if contextWindow <= 0 && clientInfo != nil && clientInfo.ContextLength > 0 {
-		contextWindow = clientInfo.ContextLength
-	}
-	if contextWindow <= 0 && metadataInfo != nil && metadataInfo.ContextLength > 0 {
-		contextWindow = metadataInfo.ContextLength
-	}
-
-	// Canonical metadata fills missing capabilities; route-specific configuration remains authoritative.
-	capabilityInfo := metadataInfo
-	if clientInfo != nil {
-		if capabilityInfo == nil {
-			capabilityInfo = clientInfo
-		} else {
-			mergedInfo := *capabilityInfo
-			if clientInfo.Type == registry.OpenAIImageModelType {
-				mergedInfo.Type = clientInfo.Type
-			}
-			if len(clientInfo.SupportedInputModalities) > 0 {
-				mergedInfo.SupportedInputModalities = clientInfo.SupportedInputModalities
-			}
-			if clientInfo.Thinking != nil {
-				mergedInfo.Thinking = clientInfo.Thinking
-			}
-			capabilityInfo = &mergedInfo
+		if info.ContextLength > 0 {
+			contextWindow = info.ContextLength
 		}
-	}
-
-	if capabilityInfo != nil {
-		if capabilityInfo.Type == registry.OpenAIImageModelType {
-			entry["visibility"] = "hide"
-			delete(entry, "input_modalities")
-			delete(entry, "supports_image_detail_original")
-		} else {
-			applyCodexClientInputModalitiesMetadata(entry, capabilityInfo.SupportedInputModalities)
-		}
-		applyCodexClientThinkingMetadata(entry, capabilityInfo.Thinking)
+		applyCodexClientModelCapabilities(entry, info)
 	}
 
 	if displayName == "" {

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -283,6 +283,9 @@ func TestCodexClientModelsResponse_UsesConfiguredMetadataModelID(t *testing.T) {
 		if got := stringModelValue(entry, "comp_hash"); got != "3000" {
 			t.Errorf("%s comp_hash = %q, want 3000", route, got)
 		}
+		if got := intModelValue(entry, "priority"); got != 1 {
+			t.Errorf("%s priority = %d, want 1", route, got)
+		}
 	}
 }
 
@@ -297,6 +300,12 @@ func TestCodexClientModelsResponse_UsesMetadataModelIDForStaticCapabilities(t *t
 		OwnedBy:         "anthropic",
 		Type:            "openai-compatibility",
 		DisplayName:     "Claude Opus Route",
+		SupportedInputModalities: []string{
+			"text",
+		},
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"low", "high"},
+		},
 	}})
 	t.Cleanup(func() {
 		modelRegistry.UnregisterClient(clientID)
@@ -318,6 +327,26 @@ func TestCodexClientModelsResponse_UsesMetadataModelIDForStaticCapabilities(t *t
 	}
 	if got := intModelValue(models[0], "max_context_window"); got != 1000000 {
 		t.Fatalf("max_context_window = %d, want 1000000", got)
+	}
+	modalities, ok := models[0]["input_modalities"].([]any)
+	if !ok || len(modalities) != 1 || modalities[0] != "text" {
+		t.Fatalf("input_modalities = %#v, want [text]", models[0]["input_modalities"])
+	}
+	if _, exists := models[0]["supports_image_detail_original"]; exists {
+		t.Fatalf("text-only model should not expose supports_image_detail_original: %#v", models[0]["supports_image_detail_original"])
+	}
+	levels, ok := models[0]["supported_reasoning_levels"].([]any)
+	if !ok || len(levels) != 2 {
+		t.Fatalf("supported_reasoning_levels = %#v, want low and high", models[0]["supported_reasoning_levels"])
+	}
+	for index, want := range []string{"low", "high"} {
+		level, ok := levels[index].(map[string]any)
+		if !ok {
+			t.Fatalf("supported_reasoning_levels[%d] = %T, want map[string]any", index, levels[index])
+		}
+		if got := stringModelValue(level, "effort"); got != want {
+			t.Fatalf("supported_reasoning_levels[%d] = %q, want %s", index, got, want)
+		}
 	}
 }
 

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -226,3 +226,114 @@ func TestLoadCodexClientModelTemplatesRefreshesOnRevision(t *testing.T) {
 		t.Fatalf("cached display_name = %q, want Second", got)
 	}
 }
+
+func TestCodexClientModelsResponse_UsesConfiguredMetadataModelID(t *testing.T) {
+	routes := []string{
+		"krc-sol",
+		"krc/gpt-5.6-sol",
+		"krc/sol-alt",
+	}
+	registered := make([]*registry.ModelInfo, 0, len(routes))
+	for _, route := range routes {
+		registered = append(registered, &registry.ModelInfo{
+			ID:              route,
+			MetadataModelID: "gpt-5.6-sol",
+			Object:          "model",
+			OwnedBy:         "openai",
+			Type:            "openai",
+			DisplayName:     route,
+		})
+	}
+
+	modelRegistry := registry.GetGlobalRegistry()
+	clientID := "codex-metadata-model-id-test"
+	modelRegistry.RegisterClient(clientID, "codex", registered)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	openaiModels := modelRegistry.GetAvailableModels("openai")
+	for _, model := range openaiModels {
+		if _, exists := model["metadata_model_id"]; exists {
+			t.Fatalf("ordinary OpenAI model metadata exposed internal metadata_model_id: %#v", model)
+		}
+	}
+
+	resp := CodexClientModelsResponse(openaiModels)
+	models, ok := resp["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", resp["models"])
+	}
+
+	entries := make(map[string]map[string]any, len(routes))
+	for _, entry := range models {
+		entries[stringModelValue(entry, "slug")] = entry
+	}
+	for _, route := range routes {
+		entry := entries[route]
+		if entry == nil {
+			t.Fatalf("expected Codex client entry for %q", route)
+		}
+		if got := intModelValue(entry, "context_window"); got != 372000 {
+			t.Errorf("%s context_window = %d, want 372000", route, got)
+		}
+		if got := intModelValue(entry, "max_context_window"); got != 372000 {
+			t.Errorf("%s max_context_window = %d, want 372000", route, got)
+		}
+		if got := stringModelValue(entry, "comp_hash"); got != "3000" {
+			t.Errorf("%s comp_hash = %q, want 3000", route, got)
+		}
+	}
+}
+
+func TestCodexClientModelsResponse_UsesMetadataModelIDForStaticCapabilities(t *testing.T) {
+	const route = "krc/claude-opus"
+	modelRegistry := registry.GetGlobalRegistry()
+	clientID := "codex-static-metadata-model-id-test"
+	modelRegistry.RegisterClient(clientID, "openai-compatibility", []*registry.ModelInfo{{
+		ID:              route,
+		MetadataModelID: "claude-opus-4-6",
+		Object:          "model",
+		OwnedBy:         "anthropic",
+		Type:            "openai-compatibility",
+		DisplayName:     "Claude Opus Route",
+	}})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	resp := CodexClientModelsResponse([]map[string]any{{
+		"id":           route,
+		"display_name": "Claude Opus Route",
+	}})
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+	if got := stringModelValue(models[0], "slug"); got != route {
+		t.Fatalf("slug = %q, want %s", got, route)
+	}
+	if got := intModelValue(models[0], "context_window"); got != 1000000 {
+		t.Fatalf("context_window = %d, want 1000000", got)
+	}
+	if got := intModelValue(models[0], "max_context_window"); got != 1000000 {
+		t.Fatalf("max_context_window = %d, want 1000000", got)
+	}
+}
+
+func TestCodexClientModelsResponse_UsesIDWhenMetadataModelIDIsUnset(t *testing.T) {
+	resp := CodexClientModelsResponse([]map[string]any{{"id": "gpt-5.6-sol"}})
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+	if got := stringModelValue(models[0], "slug"); got != "gpt-5.6-sol" {
+		t.Fatalf("slug = %q, want gpt-5.6-sol", got)
+	}
+	if got := intModelValue(models[0], "context_window"); got != 372000 {
+		t.Fatalf("context_window = %d, want 372000", got)
+	}
+	if got := stringModelValue(models[0], "comp_hash"); got != "3000" {
+		t.Fatalf("comp_hash = %q, want 3000", got)
+	}
+}

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -236,18 +236,22 @@ func TestCodexClientModelsResponse_UsesConfiguredMetadataModelID(t *testing.T) {
 	registered := make([]*registry.ModelInfo, 0, len(routes))
 	for _, route := range routes {
 		registered = append(registered, &registry.ModelInfo{
-			ID:              route,
-			MetadataModelID: "gpt-5.6-sol",
-			Object:          "model",
-			OwnedBy:         "openai",
-			Type:            "openai",
-			DisplayName:     route,
+			ID:                       route,
+			MetadataModelID:          "gpt-5.6-sol",
+			Object:                   "model",
+			OwnedBy:                  "openai",
+			Type:                     "openai-compatibility",
+			DisplayName:              route,
+			SupportedInputModalities: []string{"text"},
+			Thinking: &registry.ThinkingSupport{
+				Levels: []string{"low", "high"},
+			},
 		})
 	}
 
 	modelRegistry := registry.GetGlobalRegistry()
 	clientID := "codex-metadata-model-id-test"
-	modelRegistry.RegisterClient(clientID, "codex", registered)
+	modelRegistry.RegisterClient(clientID, "openai-compatibility", registered)
 	t.Cleanup(func() {
 		modelRegistry.UnregisterClient(clientID)
 	})
@@ -286,66 +290,23 @@ func TestCodexClientModelsResponse_UsesConfiguredMetadataModelID(t *testing.T) {
 		if got := intModelValue(entry, "priority"); got != 1 {
 			t.Errorf("%s priority = %d, want 1", route, got)
 		}
-	}
-}
-
-func TestCodexClientModelsResponse_UsesMetadataModelIDForStaticCapabilities(t *testing.T) {
-	const route = "krc/claude-opus"
-	modelRegistry := registry.GetGlobalRegistry()
-	clientID := "codex-static-metadata-model-id-test"
-	modelRegistry.RegisterClient(clientID, "openai-compatibility", []*registry.ModelInfo{{
-		ID:              route,
-		MetadataModelID: "claude-opus-4-6",
-		Object:          "model",
-		OwnedBy:         "anthropic",
-		Type:            "openai-compatibility",
-		DisplayName:     "Claude Opus Route",
-		SupportedInputModalities: []string{
-			"text",
-		},
-		Thinking: &registry.ThinkingSupport{
-			Levels: []string{"low", "high"},
-		},
-	}})
-	t.Cleanup(func() {
-		modelRegistry.UnregisterClient(clientID)
-	})
-
-	resp := CodexClientModelsResponse([]map[string]any{{
-		"id":           route,
-		"display_name": "Claude Opus Route",
-	}})
-	models, ok := resp["models"].([]map[string]any)
-	if !ok || len(models) != 1 {
-		t.Fatalf("models = %#v, want one model", resp["models"])
-	}
-	if got := stringModelValue(models[0], "slug"); got != route {
-		t.Fatalf("slug = %q, want %s", got, route)
-	}
-	if got := intModelValue(models[0], "context_window"); got != 1000000 {
-		t.Fatalf("context_window = %d, want 1000000", got)
-	}
-	if got := intModelValue(models[0], "max_context_window"); got != 1000000 {
-		t.Fatalf("max_context_window = %d, want 1000000", got)
-	}
-	modalities, ok := models[0]["input_modalities"].([]any)
-	if !ok || len(modalities) != 1 || modalities[0] != "text" {
-		t.Fatalf("input_modalities = %#v, want [text]", models[0]["input_modalities"])
-	}
-	if _, exists := models[0]["supports_image_detail_original"]; exists {
-		t.Fatalf("text-only model should not expose supports_image_detail_original: %#v", models[0]["supports_image_detail_original"])
-	}
-	levels, ok := models[0]["supported_reasoning_levels"].([]any)
-	if !ok || len(levels) != 2 {
-		t.Fatalf("supported_reasoning_levels = %#v, want low and high", models[0]["supported_reasoning_levels"])
-	}
-	for index, want := range []string{"low", "high"} {
-		level, ok := levels[index].(map[string]any)
-		if !ok {
-			t.Fatalf("supported_reasoning_levels[%d] = %T, want map[string]any", index, levels[index])
+		modalities, ok := entry["input_modalities"].([]any)
+		if !ok || len(modalities) != 1 || modalities[0] != "text" {
+			t.Errorf("%s input_modalities = %#v, want [text]", route, entry["input_modalities"])
 		}
-		if got := stringModelValue(level, "effort"); got != want {
-			t.Fatalf("supported_reasoning_levels[%d] = %q, want %s", index, got, want)
+		if _, exists := entry["supports_image_detail_original"]; exists {
+			t.Errorf("%s should not expose supports_image_detail_original", route)
+		}
+		levels, ok := entry["supported_reasoning_levels"].([]any)
+		if !ok || len(levels) != 2 {
+			t.Errorf("%s supported_reasoning_levels = %#v, want low and high", route, entry["supported_reasoning_levels"])
+			continue
+		}
+		for index, want := range []string{"low", "high"} {
+			level, ok := levels[index].(map[string]any)
+			if !ok || stringModelValue(level, "effort") != want {
+				t.Errorf("%s supported_reasoning_levels[%d] = %#v, want %s", route, index, levels[index], want)
+			}
 		}
 	}
 }

--- a/sdk/cliproxy/config_model_display_name_test.go
+++ b/sdk/cliproxy/config_model_display_name_test.go
@@ -95,3 +95,40 @@ func TestBuildConfigModelsDisplayNameFallback(t *testing.T) {
 		t.Fatalf("DisplayName = %q, want upstream model name", model.DisplayName)
 	}
 }
+
+func TestBuildCodexConfigModelsPreservesMetadataModelID(t *testing.T) {
+	models := buildCodexConfigModels(&config.CodexKey{Models: []config.CodexModel{{
+		Name: "gpt-5.6-sol", Alias: "sol-alt",
+	}}})
+
+	var configured *ModelInfo
+	for _, model := range models {
+		if model != nil && model.ID == "sol-alt" {
+			configured = model
+			break
+		}
+	}
+	if configured == nil {
+		t.Fatal("configured model sol-alt was not built")
+	}
+	if configured.MetadataModelID != "gpt-5.6-sol" {
+		t.Fatalf("MetadataModelID = %q, want gpt-5.6-sol", configured.MetadataModelID)
+	}
+}
+
+func TestApplyModelPrefixesPreservesMetadataModelID(t *testing.T) {
+	models := applyModelPrefixes([]*ModelInfo{{
+		ID:              "sol-alt",
+		MetadataModelID: "gpt-5.6-sol",
+	}}, "krc", true)
+
+	if len(models) != 1 {
+		t.Fatalf("models length = %d, want 1", len(models))
+	}
+	if models[0].ID != "krc/sol-alt" {
+		t.Fatalf("ID = %q, want krc/sol-alt", models[0].ID)
+	}
+	if models[0].MetadataModelID != "gpt-5.6-sol" {
+		t.Fatalf("MetadataModelID = %q, want gpt-5.6-sol", models[0].MetadataModelID)
+	}
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2492,13 +2492,14 @@ func buildConfiguredModelInfo(model modelEntry, ownedBy, modelType string, creat
 		displayName = alias
 	}
 	return &ModelInfo{
-		ID:          alias,
-		Object:      "model",
-		Created:     created,
-		OwnedBy:     ownedBy,
-		Type:        modelType,
-		DisplayName: displayName,
-		UserDefined: userDefined,
+		ID:              alias,
+		MetadataModelID: name,
+		Object:          "model",
+		Created:         created,
+		OwnedBy:         ownedBy,
+		Type:            modelType,
+		DisplayName:     displayName,
+		UserDefined:     userDefined,
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve configured `models[].name` as an internal canonical metadata model ID while keeping aliases and prefixes as client-facing route IDs
- resolve Codex client catalog templates and static capabilities through the canonical ID, then restore the client-facing ID as the emitted `slug`
- keep the internal metadata identity out of ordinary OpenAI model-list maps
- cover alias, prefix, prefix + alias, static capability fallback, and legacy ID lookup behavior

This fixes configured routes such as `krc/gpt-5.6-sol` or a custom alias falling back to the `gpt-5.5` Codex client template. They now inherit the full `gpt-5.6-sol` metadata, including the 372000 context window and `comp_hash: "3000"`, without changing routing slugs.

## Related PRs

- #4215 preserves prefixed API-key runtime capabilities; this PR fixes Codex client catalog metadata identity.
- #4242 adjusts combined catalog/code-mode metadata; this PR fixes template selection for configured aliases and prefixes.

## Testing

- `go test -v -run TestCodexClientModelsResponse_ ./sdk/api/handlers/openai`
- `go test -v -run TestBuildConfigModelsDisplayName ./sdk/cliproxy` plus the new metadata/prefix tests
- `go build -o test-output ./cmd/server && rm test-output`
- `go test ./...` passes all packages except the existing `internal/api` assertion in `TestModelsWithClientVersionReturnsCodexCatalog` (`custom priority = 143, want 129`); the same failure reproduces on a clean `upstream/dev` worktree at e0a0b5a4.