### PR TITLE
fix(translator): preserve cache writes in Anthropic usage

### DIFF
--- a/internal/translator/codex/claude/codex_claude_response.go
+++ b/internal/translator/codex/claude/codex_claude_response.go
@@ -141,11 +141,17 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		output = appendPendingCodexFunctionCallsFromTerminal(output, params, originalRequestRawJSON, responseData)
 		template, _ = sjson.SetBytes(template, "delta.stop_reason", mapCodexStopReasonToClaude(codexStopReason(responseData), params.HasEmittedToolUse))
 		template = setClaudeStopSequence(template, "delta.stop_sequence", responseData)
-		inputTokens, outputTokens, cachedTokens := extractResponsesUsage(responseData.Get("usage"))
+		inputTokens, outputTokens, cachedTokens, cacheCreationTokens := extractResponsesUsage(responseData.Get("usage"))
 		template, _ = sjson.SetBytes(template, "usage.input_tokens", inputTokens)
 		template, _ = sjson.SetBytes(template, "usage.output_tokens", outputTokens)
 		if cachedTokens > 0 {
 			template, _ = sjson.SetBytes(template, "usage.cache_read_input_tokens", cachedTokens)
+		}
+		if cacheCreationTokens > 0 {
+			// OpenAI/Codex cache writes are billed at 1.25x, matching Anthropic's 5m write tier.
+			// Upstream does not expose 5m/1h TTL metadata, so attribute all writes to the 5m bucket.
+			template, _ = sjson.SetBytes(template, "usage.cache_creation_input_tokens", cacheCreationTokens)
+			template, _ = sjson.SetBytes(template, "usage.cache_creation.ephemeral_5m_input_tokens", cacheCreationTokens)
 		}
 
 		output = translatorcommon.AppendSSEEventBytes(output, "message_delta", template, 2)
@@ -352,11 +358,17 @@ func ConvertCodexResponseToClaudeNonStream(_ context.Context, _ string, original
 	out := []byte(`{"id":"","type":"message","role":"assistant","model":"","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}`)
 	out, _ = sjson.SetBytes(out, "id", responseData.Get("id").String())
 	out, _ = sjson.SetBytes(out, "model", responseData.Get("model").String())
-	inputTokens, outputTokens, cachedTokens := extractResponsesUsage(responseData.Get("usage"))
+	inputTokens, outputTokens, cachedTokens, cacheCreationTokens := extractResponsesUsage(responseData.Get("usage"))
 	out, _ = sjson.SetBytes(out, "usage.input_tokens", inputTokens)
 	out, _ = sjson.SetBytes(out, "usage.output_tokens", outputTokens)
 	if cachedTokens > 0 {
 		out, _ = sjson.SetBytes(out, "usage.cache_read_input_tokens", cachedTokens)
+	}
+	if cacheCreationTokens > 0 {
+		// OpenAI/Codex cache writes are billed at 1.25x, matching Anthropic's 5m write tier.
+		// Upstream does not expose 5m/1h TTL metadata, so attribute all writes to the 5m bucket.
+		out, _ = sjson.SetBytes(out, "usage.cache_creation_input_tokens", cacheCreationTokens)
+		out, _ = sjson.SetBytes(out, "usage.cache_creation.ephemeral_5m_input_tokens", cacheCreationTokens)
 	}
 
 	hasToolCall := false
@@ -778,14 +790,18 @@ func resolveCodexClaudeToolUseName(originalRequestRawJSON []byte, name string) s
 	return name
 }
 
-func extractResponsesUsage(usage gjson.Result) (int64, int64, int64) {
+func extractResponsesUsage(usage gjson.Result) (int64, int64, int64, int64) {
 	if !usage.Exists() || usage.Type == gjson.Null {
-		return 0, 0, 0
+		return 0, 0, 0, 0
 	}
 
 	inputTokens := usage.Get("input_tokens").Int()
 	outputTokens := usage.Get("output_tokens").Int()
 	cachedTokens := usage.Get("input_tokens_details.cached_tokens").Int()
+	cacheCreationTokens := usage.Get("input_tokens_details.cache_write_tokens").Int()
+	if cacheCreationTokens == 0 {
+		cacheCreationTokens = usage.Get("input_tokens_details.cache_creation_tokens").Int()
+	}
 
 	if cachedTokens > 0 {
 		if inputTokens >= cachedTokens {
@@ -794,8 +810,15 @@ func extractResponsesUsage(usage gjson.Result) (int64, int64, int64) {
 			inputTokens = 0
 		}
 	}
+	if cacheCreationTokens > 0 {
+		if inputTokens >= cacheCreationTokens {
+			inputTokens -= cacheCreationTokens
+		} else {
+			inputTokens = 0
+		}
+	}
 
-	return inputTokens, outputTokens, cachedTokens
+	return inputTokens, outputTokens, cachedTokens, cacheCreationTokens
 }
 
 // buildReverseMapFromClaudeOriginalShortToOriginal builds a map[short]original from original Claude request tools.

--- a/internal/translator/codex/claude/codex_claude_response_test.go
+++ b/internal/translator/codex/claude/codex_claude_response_test.go
@@ -1250,3 +1250,132 @@ func firstClaudeStreamPayloadForEvent(output, event string) (gjson.Result, bool)
 	}
 	return gjson.Result{}, false
 }
+
+func TestExtractResponsesUsage_CacheReadAndWrite(t *testing.T) {
+	tests := []struct {
+		name              string
+		usageJSON         string
+		wantInput         int64
+		wantOutput        int64
+		wantCached        int64
+		wantCacheCreation int64
+	}{
+		{
+			name:              "cache read only",
+			usageJSON:         `{"input_tokens":9818,"output_tokens":20,"input_tokens_details":{"cached_tokens":9472}}`,
+			wantInput:         346,
+			wantOutput:        20,
+			wantCached:        9472,
+			wantCacheCreation: 0,
+		},
+		{
+			name:              "cache write tokens",
+			usageJSON:         `{"input_tokens":2000,"output_tokens":30,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":1500}}`,
+			wantInput:         500,
+			wantOutput:        30,
+			wantCached:        0,
+			wantCacheCreation: 1500,
+		},
+		{
+			name:              "cache creation alias",
+			usageJSON:         `{"input_tokens":2000,"output_tokens":30,"input_tokens_details":{"cache_creation_tokens":400}}`,
+			wantInput:         1600,
+			wantOutput:        30,
+			wantCached:        0,
+			wantCacheCreation: 400,
+		},
+		{
+			name:              "read and write together",
+			usageJSON:         `{"input_tokens":9818,"output_tokens":20,"input_tokens_details":{"cached_tokens":9472,"cache_write_tokens":100}}`,
+			wantInput:         246,
+			wantOutput:        20,
+			wantCached:        9472,
+			wantCacheCreation: 100,
+		},
+		{
+			name:              "malformed cached tokens cannot go negative",
+			usageJSON:         `{"input_tokens":10,"output_tokens":1,"input_tokens_details":{"cached_tokens":50,"cache_write_tokens":3}}`,
+			wantInput:         0,
+			wantOutput:        1,
+			wantCached:        50,
+			wantCacheCreation: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, output, cached, creation := extractResponsesUsage(gjson.Parse(tt.usageJSON))
+			if input != tt.wantInput || output != tt.wantOutput || cached != tt.wantCached || creation != tt.wantCacheCreation {
+				t.Fatalf("got input=%d output=%d cached=%d creation=%d, want %d %d %d %d",
+					input, output, cached, creation, tt.wantInput, tt.wantOutput, tt.wantCached, tt.wantCacheCreation)
+			}
+		})
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamEmitsCacheUsage(t *testing.T) {
+	ctx := context.Background()
+	var param any
+	outputs := ConvertCodexResponseToClaude(
+		ctx,
+		"",
+		[]byte(`{"messages":[]}`),
+		nil,
+		[]byte(`data: {"type":"response.completed","response":{"stop_reason":"stop","usage":{"input_tokens":9818,"output_tokens":20,"input_tokens_details":{"cached_tokens":9472,"cache_write_tokens":111}},"output":[]}}`),
+		&param,
+	)
+
+	messageDelta, ok := findClaudeStreamMessageDelta(outputs)
+	if !ok {
+		t.Fatalf("message_delta not found in outputs: %v", outputs)
+	}
+	if got := messageDelta.Get("usage.input_tokens").Int(); got != 235 {
+		t.Fatalf("input_tokens = %d, want 235", got)
+	}
+	if got := messageDelta.Get("usage.output_tokens").Int(); got != 20 {
+		t.Fatalf("output_tokens = %d, want 20", got)
+	}
+	if got := messageDelta.Get("usage.cache_read_input_tokens").Int(); got != 9472 {
+		t.Fatalf("cache_read_input_tokens = %d, want 9472", got)
+	}
+	if got := messageDelta.Get("usage.cache_creation_input_tokens").Int(); got != 111 {
+		t.Fatalf("cache_creation_input_tokens = %d, want 111", got)
+	}
+	if got := messageDelta.Get("usage.cache_creation.ephemeral_5m_input_tokens").Int(); got != 111 {
+		t.Fatalf("ephemeral_5m_input_tokens = %d, want 111", got)
+	}
+	if messageDelta.Get("usage.cache_creation.ephemeral_1h_input_tokens").Exists() && messageDelta.Get("usage.cache_creation.ephemeral_1h_input_tokens").Int() != 0 {
+		t.Fatalf("ephemeral_1h_input_tokens should be absent or 0, got %d", messageDelta.Get("usage.cache_creation.ephemeral_1h_input_tokens").Int())
+	}
+}
+
+func TestConvertCodexResponseToClaudeNonStream_EmitsCacheUsage(t *testing.T) {
+	ctx := context.Background()
+	out := ConvertCodexResponseToClaudeNonStream(
+		ctx,
+		"",
+		[]byte(`{"messages":[]}`),
+		nil,
+		[]byte(`{"type":"response.completed","response":{"id":"resp_1","model":"gpt-5","stop_reason":"stop","usage":{"input_tokens":9818,"output_tokens":20,"input_tokens_details":{"cached_tokens":9472,"cache_write_tokens":111}},"output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}}`),
+		nil,
+	)
+	parsed := gjson.ParseBytes(out)
+	if got := parsed.Get("usage.input_tokens").Int(); got != 235 {
+		t.Fatalf("input_tokens = %d, want 235. Output: %s", got, string(out))
+	}
+	if got := parsed.Get("usage.output_tokens").Int(); got != 20 {
+		t.Fatalf("output_tokens = %d, want 20. Output: %s", got, string(out))
+	}
+	if got := parsed.Get("usage.cache_read_input_tokens").Int(); got != 9472 {
+		t.Fatalf("cache_read_input_tokens = %d, want 9472. Output: %s", got, string(out))
+	}
+	if got := parsed.Get("usage.cache_creation_input_tokens").Int(); got != 111 {
+		t.Fatalf("cache_creation_input_tokens = %d, want 111. Output: %s", got, string(out))
+	}
+	if got := parsed.Get("usage.cache_creation.ephemeral_5m_input_tokens").Int(); got != 111 {
+		t.Fatalf("ephemeral_5m_input_tokens = %d, want 111. Output: %s", got, string(out))
+	}
+	if parsed.Get("usage.cache_creation.ephemeral_1h_input_tokens").Exists() && parsed.Get("usage.cache_creation.ephemeral_1h_input_tokens").Int() != 0 {
+		t.Fatalf("ephemeral_1h_input_tokens should be absent or 0, got %d. Output: %s", parsed.Get("usage.cache_creation.ephemeral_1h_input_tokens").Int(), string(out))
+	}
+}

--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -338,9 +338,9 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 	// Only process if usage has actual values (not null)
 	if param.FinishReason != "" {
 		usage := root.Get("usage")
-		var inputTokens, outputTokens, cachedTokens int64
+		var inputTokens, outputTokens, cachedTokens, cacheCreationTokens int64
 		if usage.Exists() && usage.Type != gjson.Null {
-			inputTokens, outputTokens, cachedTokens = extractOpenAIUsage(usage)
+			inputTokens, outputTokens, cachedTokens, cacheCreationTokens = extractOpenAIUsage(usage)
 			// Send message_delta with usage
 			messageDeltaJSON := []byte(`{"type":"message_delta","delta":{"stop_reason":"","stop_sequence":null},"usage":{"input_tokens":0,"output_tokens":0}}`)
 			messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "delta.stop_reason", mapOpenAIFinishReasonToAnthropic(effectiveOpenAIFinishReason(param)))
@@ -348,6 +348,9 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 			messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "usage.output_tokens", outputTokens)
 			if cachedTokens > 0 {
 				messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "usage.cache_read_input_tokens", cachedTokens)
+			}
+			if cacheCreationTokens > 0 {
+				messageDeltaJSON, _ = sjson.SetBytes(messageDeltaJSON, "usage.cache_creation_input_tokens", cacheCreationTokens)
 			}
 			results = append(results, translatorcommon.AppendSSEEventBytes(nil, "message_delta", messageDeltaJSON, 2))
 			param.MessageDeltaSent = true
@@ -476,11 +479,14 @@ func convertOpenAINonStreamingToAnthropic(rawJSON []byte) [][]byte {
 
 	// Set usage information
 	if usage := root.Get("usage"); usage.Exists() {
-		inputTokens, outputTokens, cachedTokens := extractOpenAIUsage(usage)
+		inputTokens, outputTokens, cachedTokens, cacheCreationTokens := extractOpenAIUsage(usage)
 		out, _ = sjson.SetBytes(out, "usage.input_tokens", inputTokens)
 		out, _ = sjson.SetBytes(out, "usage.output_tokens", outputTokens)
 		if cachedTokens > 0 {
 			out, _ = sjson.SetBytes(out, "usage.cache_read_input_tokens", cachedTokens)
+		}
+		if cacheCreationTokens > 0 {
+			out, _ = sjson.SetBytes(out, "usage.cache_creation_input_tokens", cacheCreationTokens)
 		}
 	}
 
@@ -749,11 +755,14 @@ func ConvertOpenAIResponseToClaudeNonStream(_ context.Context, _ string, origina
 	}
 
 	if respUsage := root.Get("usage"); respUsage.Exists() {
-		inputTokens, outputTokens, cachedTokens := extractOpenAIUsage(respUsage)
+		inputTokens, outputTokens, cachedTokens, cacheCreationTokens := extractOpenAIUsage(respUsage)
 		out, _ = sjson.SetBytes(out, "usage.input_tokens", inputTokens)
 		out, _ = sjson.SetBytes(out, "usage.output_tokens", outputTokens)
 		if cachedTokens > 0 {
 			out, _ = sjson.SetBytes(out, "usage.cache_read_input_tokens", cachedTokens)
+		}
+		if cacheCreationTokens > 0 {
+			out, _ = sjson.SetBytes(out, "usage.cache_creation_input_tokens", cacheCreationTokens)
 		}
 	}
 
@@ -772,14 +781,18 @@ func ClaudeTokenCount(ctx context.Context, count int64) []byte {
 	return translatorcommon.ClaudeInputTokensJSON(count)
 }
 
-func extractOpenAIUsage(usage gjson.Result) (int64, int64, int64) {
+func extractOpenAIUsage(usage gjson.Result) (int64, int64, int64, int64) {
 	if !usage.Exists() || usage.Type == gjson.Null {
-		return 0, 0, 0
+		return 0, 0, 0, 0
 	}
 
 	inputTokens := usage.Get("prompt_tokens").Int()
 	outputTokens := usage.Get("completion_tokens").Int()
 	cachedTokens := usage.Get("prompt_tokens_details.cached_tokens").Int()
+	cacheCreationTokens := usage.Get("prompt_tokens_details.cache_write_tokens").Int()
+	if cacheCreationTokens == 0 {
+		cacheCreationTokens = usage.Get("prompt_tokens_details.cache_creation_tokens").Int()
+	}
 
 	if cachedTokens > 0 {
 		if inputTokens >= cachedTokens {
@@ -788,6 +801,13 @@ func extractOpenAIUsage(usage gjson.Result) (int64, int64, int64) {
 			inputTokens = 0
 		}
 	}
+	if cacheCreationTokens > 0 {
+		if inputTokens >= cacheCreationTokens {
+			inputTokens -= cacheCreationTokens
+		} else {
+			inputTokens = 0
+		}
+	}
 
-	return inputTokens, outputTokens, cachedTokens
+	return inputTokens, outputTokens, cachedTokens, cacheCreationTokens
 }

--- a/internal/translator/openai/claude/openai_claude_response_test.go
+++ b/internal/translator/openai/claude/openai_claude_response_test.go
@@ -364,3 +364,138 @@ func TestStreamingTool_StopReasonMixedSuppressedAndValid(t *testing.T) {
 		t.Fatalf("stop_reason = %q, want %q", got, "tool_use")
 	}
 }
+
+func TestExtractOpenAIUsage_CacheReadAndWrite(t *testing.T) {
+	tests := []struct {
+		name              string
+		usageJSON         string
+		wantInput         int64
+		wantOutput        int64
+		wantCached        int64
+		wantCacheCreation int64
+	}{
+		{
+			name:              "cache read only",
+			usageJSON:         `{"prompt_tokens":2006,"completion_tokens":300,"prompt_tokens_details":{"cached_tokens":1920}}`,
+			wantInput:         86,
+			wantOutput:        300,
+			wantCached:        1920,
+			wantCacheCreation: 0,
+		},
+		{
+			name:              "cache write tokens",
+			usageJSON:         `{"prompt_tokens":2006,"completion_tokens":300,"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":1800}}`,
+			wantInput:         206,
+			wantOutput:        300,
+			wantCached:        0,
+			wantCacheCreation: 1800,
+		},
+		{
+			name:              "cache creation alias",
+			usageJSON:         `{"prompt_tokens":2006,"completion_tokens":300,"prompt_tokens_details":{"cache_creation_tokens":400}}`,
+			wantInput:         1606,
+			wantOutput:        300,
+			wantCached:        0,
+			wantCacheCreation: 400,
+		},
+		{
+			name:              "read and write together",
+			usageJSON:         `{"prompt_tokens":2006,"completion_tokens":300,"prompt_tokens_details":{"cached_tokens":1920,"cache_write_tokens":50}}`,
+			wantInput:         36,
+			wantOutput:        300,
+			wantCached:        1920,
+			wantCacheCreation: 50,
+		},
+		{
+			name:              "malformed cached tokens cannot go negative",
+			usageJSON:         `{"prompt_tokens":10,"completion_tokens":1,"prompt_tokens_details":{"cached_tokens":50,"cache_write_tokens":3}}`,
+			wantInput:         0,
+			wantOutput:        1,
+			wantCached:        50,
+			wantCacheCreation: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, output, cached, creation := extractOpenAIUsage(gjson.Parse(tt.usageJSON))
+			if input != tt.wantInput || output != tt.wantOutput || cached != tt.wantCached || creation != tt.wantCacheCreation {
+				t.Fatalf("got input=%d output=%d cached=%d creation=%d, want %d %d %d %d",
+					input, output, cached, creation, tt.wantInput, tt.wantOutput, tt.wantCached, tt.wantCacheCreation)
+			}
+		})
+	}
+}
+
+func TestConvertOpenAIResponseToClaude_StreamEmitsCacheUsage(t *testing.T) {
+	events := runStream(t, streamReq,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"}}]}`,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":2006,"completion_tokens":300,"prompt_tokens_details":{"cached_tokens":1920,"cache_write_tokens":50}}}`,
+	)
+
+	var usagePayload string
+	for _, e := range events {
+		if e.Type == "message_delta" {
+			usagePayload = e.Payload
+		}
+	}
+	if usagePayload == "" {
+		t.Fatalf("message_delta not found in events: %+v", events)
+	}
+	parsed := gjson.Parse(usagePayload)
+	if got := parsed.Get("usage.input_tokens").Int(); got != 36 {
+		t.Fatalf("input_tokens = %d, want 36", got)
+	}
+	if got := parsed.Get("usage.output_tokens").Int(); got != 300 {
+		t.Fatalf("output_tokens = %d, want 300", got)
+	}
+	if got := parsed.Get("usage.cache_read_input_tokens").Int(); got != 1920 {
+		t.Fatalf("cache_read_input_tokens = %d, want 1920", got)
+	}
+	if got := parsed.Get("usage.cache_creation_input_tokens").Int(); got != 50 {
+		t.Fatalf("cache_creation_input_tokens = %d, want 50", got)
+	}
+}
+
+func TestConvertOpenAIResponseToClaudeNonStream_EmitsCacheUsage(t *testing.T) {
+	out := ConvertOpenAIResponseToClaudeNonStream(
+		context.Background(),
+		"",
+		[]byte(`{"messages":[]}`),
+		nil,
+		[]byte(`{"id":"c1","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2006,"completion_tokens":300,"prompt_tokens_details":{"cached_tokens":1920,"cache_write_tokens":50}}}`),
+		nil,
+	)
+	parsed := gjson.ParseBytes(out)
+	if got := parsed.Get("usage.input_tokens").Int(); got != 36 {
+		t.Fatalf("input_tokens = %d, want 36. Output: %s", got, string(out))
+	}
+	if got := parsed.Get("usage.output_tokens").Int(); got != 300 {
+		t.Fatalf("output_tokens = %d, want 300. Output: %s", got, string(out))
+	}
+	if got := parsed.Get("usage.cache_read_input_tokens").Int(); got != 1920 {
+		t.Fatalf("cache_read_input_tokens = %d, want 1920. Output: %s", got, string(out))
+	}
+	if got := parsed.Get("usage.cache_creation_input_tokens").Int(); got != 50 {
+		t.Fatalf("cache_creation_input_tokens = %d, want 50. Output: %s", got, string(out))
+	}
+}
+
+func TestConvertOpenAINonStreamingToAnthropic_EmitsCacheUsage(t *testing.T) {
+	outs := convertOpenAINonStreamingToAnthropic([]byte(
+		`{"id":"c1","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2006,"completion_tokens":300,"prompt_tokens_details":{"cached_tokens":1920,"cache_write_tokens":50}}}`,
+	))
+	if len(outs) != 1 {
+		t.Fatalf("expected 1 output, got %d", len(outs))
+	}
+	parsed := gjson.ParseBytes(outs[0])
+	if got := parsed.Get("usage.input_tokens").Int(); got != 36 {
+		t.Fatalf("input_tokens = %d, want 36. Output: %s", got, string(outs[0]))
+	}
+	if got := parsed.Get("usage.cache_read_input_tokens").Int(); got != 1920 {
+		t.Fatalf("cache_read_input_tokens = %d, want 1920. Output: %s", got, string(outs[0]))
+	}
+	if got := parsed.Get("usage.cache_creation_input_tokens").Int(); got != 50 {
+		t.Fatalf("cache_creation_input_tokens = %d, want 50. Output: %s", got, string(outs[0]))
+	}
+}


### PR DESCRIPTION
## Summary

- translate OpenAI and Codex `cache_write_tokens` and `cache_creation_tokens` into Anthropic `cache_creation_input_tokens`
- normalize Anthropic `input_tokens` by subtracting cache reads and cache writes so all three input buckets remain mutually exclusive
- report Codex Responses cache writes in `cache_creation.ephemeral_5m_input_tokens` to preserve the matching 1.25x billing rate
- cover streaming and non-streaming Responses and Chat Completions paths, aliases, mixed read/write usage, and malformed counts

## Validation

- `go test -count=1 ./internal/translator/codex/claude/ ./internal/translator/openai/claude/`
- `go build -o test-output ./cmd/server && rm -f test-output`
- live `gpt-5.6-terra` cache-read sample confirmed that upstream `cached_tokens` is included in `input_tokens`: `5924 - 5376 = 548`

Upstream currently reports `cache_write_tokens: 0`; preserving and partitioning non-zero writes is covered by focused tests.

Closes #4262