### PR TITLE
fix(usage): collapse OpenAI service tier metadata

### DIFF
--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -56,23 +56,29 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	if reasoningEffort == "" {
 		reasoningEffort = coreusage.ReasoningEffortFromContext(ctx)
 	}
+	serviceTier := strings.TrimSpace(record.ServiceTier)
 	requestServiceTier := strings.TrimSpace(record.RequestServiceTier)
 	if requestServiceTier == "" {
-		requestServiceTier = strings.TrimSpace(record.ServiceTier)
+		if serviceTier != "" {
+			requestServiceTier = serviceTier
+		} else {
+			requestServiceTier = coreusage.RequestServiceTierFromContext(ctx)
+		}
 	}
-	if requestServiceTier == "" {
-		requestServiceTier = coreusage.ServiceTierFromContext(ctx)
+	if serviceTier == "" {
+		serviceTier = coreusage.ServiceTierFromContext(ctx)
 	}
 	responseServiceTier := strings.TrimSpace(record.ResponseServiceTier)
 
 	tokens := tokenStats{
-		InputTokens:         record.Detail.InputTokens,
-		OutputTokens:        record.Detail.OutputTokens,
-		ReasoningTokens:     record.Detail.ReasoningTokens,
-		CachedTokens:        record.Detail.CachedTokens,
-		CacheReadTokens:     record.Detail.CacheReadTokens,
-		CacheCreationTokens: record.Detail.CacheCreationTokens,
-		TotalTokens:         record.Detail.TotalTokens,
+		InputTokens:            record.Detail.InputTokens,
+		OutputTokens:           record.Detail.OutputTokens,
+		ReasoningTokens:        record.Detail.ReasoningTokens,
+		CachedTokens:           record.Detail.CachedTokens,
+		CacheReadTokens:        record.Detail.CacheReadTokens,
+		CacheReadTokensPresent: true,
+		CacheCreationTokens:    record.Detail.CacheCreationTokens,
+		TotalTokens:            record.Detail.TotalTokens,
 	}
 	if tokens.TotalTokens == 0 {
 		tokens.TotalTokens = tokens.InputTokens + tokens.OutputTokens + tokens.ReasoningTokens
@@ -110,7 +116,7 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		APIKey:              apiKey,
 		RequestID:           requestID,
 		ReasoningEffort:     reasoningEffort,
-		ServiceTier:         requestServiceTier,
+		ServiceTier:         serviceTier,
 		RequestServiceTier:  requestServiceTier,
 		ResponseServiceTier: responseServiceTier,
 	})
@@ -149,13 +155,14 @@ type requestDetail struct {
 }
 
 type tokenStats struct {
-	InputTokens         int64 `json:"input_tokens"`
-	OutputTokens        int64 `json:"output_tokens"`
-	ReasoningTokens     int64 `json:"reasoning_tokens"`
-	CachedTokens        int64 `json:"cached_tokens"`
-	CacheReadTokens     int64 `json:"cache_read_tokens"`
-	CacheCreationTokens int64 `json:"cache_creation_tokens"`
-	TotalTokens         int64 `json:"total_tokens"`
+	InputTokens            int64 `json:"input_tokens"`
+	OutputTokens           int64 `json:"output_tokens"`
+	ReasoningTokens        int64 `json:"reasoning_tokens"`
+	CachedTokens           int64 `json:"cached_tokens"`
+	CacheReadTokens        int64 `json:"cache_read_tokens"`
+	CacheReadTokensPresent bool  `json:"cache_read_tokens_present"`
+	CacheCreationTokens    int64 `json:"cache_creation_tokens"`
+	TotalTokens            int64 `json:"total_tokens"`
 }
 
 type failDetail struct {

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -57,13 +57,8 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		reasoningEffort = coreusage.ReasoningEffortFromContext(ctx)
 	}
 	serviceTier := strings.TrimSpace(record.ServiceTier)
-	requestServiceTier := strings.TrimSpace(record.RequestServiceTier)
-	if requestServiceTier == "" {
-		if serviceTier != "" {
-			requestServiceTier = serviceTier
-		} else {
-			requestServiceTier = coreusage.RequestServiceTierFromContext(ctx)
-		}
+	if serviceTier == "" {
+		serviceTier = strings.TrimSpace(record.RequestServiceTier)
 	}
 	if serviceTier == "" {
 		serviceTier = coreusage.ServiceTierFromContext(ctx)
@@ -117,7 +112,6 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		RequestID:           requestID,
 		ReasoningEffort:     reasoningEffort,
 		ServiceTier:         serviceTier,
-		RequestServiceTier:  requestServiceTier,
 		ResponseServiceTier: responseServiceTier,
 	})
 	if err != nil {
@@ -138,7 +132,6 @@ type queuedUsageDetail struct {
 	RequestID           string `json:"request_id"`
 	ReasoningEffort     string `json:"reasoning_effort"`
 	ServiceTier         string `json:"service_tier"`
-	RequestServiceTier  string `json:"request_service_tier"`
 	ResponseServiceTier string `json:"response_service_tier,omitempty"`
 }
 

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -34,8 +34,7 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 			AuthType:            "apikey",
 			Source:              "user@example.com",
 			ReasoningEffort:     "medium",
-			ServiceTier:         "default",
-			RequestServiceTier:  "auto",
+			ServiceTier:         "auto",
 			ResponseServiceTier: "default",
 			RequestedAt:         time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC),
 			Latency:             1500 * time.Millisecond,
@@ -58,8 +57,8 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 		requireMissingField(t, payload, "user_api_key")
 		requireStringField(t, payload, "request_id", "ctx-request-id")
 		requireStringField(t, payload, "reasoning_effort", "medium")
-		requireStringField(t, payload, "service_tier", "default")
-		requireStringField(t, payload, "request_service_tier", "auto")
+		requireStringField(t, payload, "service_tier", "auto")
+		requireMissingField(t, payload, "request_service_tier")
 		requireStringField(t, payload, "response_service_tier", "default")
 		requireTokensBoolField(t, payload, "cache_read_tokens_present", true)
 		requireHeaderField(t, payload, "response_headers", "X-Upstream-Request-Id", []string{"upstream-req-1"})
@@ -96,10 +95,9 @@ func TestUsageQueuePluginMarksCanonicalZeroCacheRead(t *testing.T) {
 	})
 }
 
-func TestUsageQueuePluginPreservesLegacyTierAndEmitsCanonicalAutoTier(t *testing.T) {
+func TestUsageQueuePluginEmitsSingleCanonicalAutoTier(t *testing.T) {
 	withEnabledQueue(t, func() {
-		ctx := coreusage.WithServiceTier(context.Background(), "default")
-		ctx = coreusage.WithRequestServiceTier(ctx, "auto")
+		ctx := coreusage.WithServiceTier(context.Background(), coreusage.AutoServiceTier)
 		ctx = internallogging.WithResponseStatusHolder(ctx)
 		internallogging.SetResponseStatus(ctx, http.StatusOK)
 
@@ -113,8 +111,26 @@ func TestUsageQueuePluginPreservesLegacyTierAndEmitsCanonicalAutoTier(t *testing
 		})
 
 		payload := popSinglePayload(t)
-		requireStringField(t, payload, "service_tier", "default")
-		requireStringField(t, payload, "request_service_tier", "auto")
+		requireStringField(t, payload, "service_tier", "auto")
+		requireMissingField(t, payload, "request_service_tier")
+	})
+}
+
+func TestUsageQueuePluginAcceptsDeprecatedRequestTierRecordField(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := internallogging.WithResponseStatusHolder(context.Background())
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		(&usageQueuePlugin{}).HandleUsage(ctx, coreusage.Record{
+			Provider:           "openai",
+			Model:              "gpt-5.4",
+			RequestServiceTier: "priority",
+			Detail:             coreusage.Detail{InputTokens: 1, TotalTokens: 1},
+		})
+
+		payload := popSinglePayload(t)
+		requireStringField(t, payload, "service_tier", "priority")
+		requireMissingField(t, payload, "request_service_tier")
 	})
 }
 

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -34,7 +34,8 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 			AuthType:            "apikey",
 			Source:              "user@example.com",
 			ReasoningEffort:     "medium",
-			ServiceTier:         "priority",
+			ServiceTier:         "default",
+			RequestServiceTier:  "auto",
 			ResponseServiceTier: "default",
 			RequestedAt:         time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC),
 			Latency:             1500 * time.Millisecond,
@@ -57,13 +58,63 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 		requireMissingField(t, payload, "user_api_key")
 		requireStringField(t, payload, "request_id", "ctx-request-id")
 		requireStringField(t, payload, "reasoning_effort", "medium")
-		requireStringField(t, payload, "service_tier", "priority")
-		requireStringField(t, payload, "request_service_tier", "priority")
+		requireStringField(t, payload, "service_tier", "default")
+		requireStringField(t, payload, "request_service_tier", "auto")
 		requireStringField(t, payload, "response_service_tier", "default")
+		requireTokensBoolField(t, payload, "cache_read_tokens_present", true)
 		requireHeaderField(t, payload, "response_headers", "X-Upstream-Request-Id", []string{"upstream-req-1"})
 		requireHeaderField(t, payload, "response_headers", "Retry-After", []string{"30"})
 		requireBoolField(t, payload, "failed", false)
 		requireFailField(t, payload, http.StatusOK, "")
+	})
+}
+
+func TestUsageQueuePluginMarksCanonicalZeroCacheRead(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := internallogging.WithResponseStatusHolder(context.Background())
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		(&usageQueuePlugin{}).HandleUsage(ctx, coreusage.Record{
+			Provider: "openai",
+			Model:    "gpt-5.4",
+			Detail: coreusage.Detail{
+				CachedTokens:    13,
+				CacheReadTokens: 0,
+			},
+		})
+
+		payload := popSinglePayload(t)
+		requireTokensBoolField(t, payload, "cache_read_tokens_present", true)
+		tokens := requireTokensPayload(t, payload)
+		var cacheReadTokens int64
+		if errUnmarshal := json.Unmarshal(tokens["cache_read_tokens"], &cacheReadTokens); errUnmarshal != nil {
+			t.Fatalf("unmarshal cache_read_tokens: %v", errUnmarshal)
+		}
+		if cacheReadTokens != 0 {
+			t.Fatalf("cache_read_tokens = %d, want 0", cacheReadTokens)
+		}
+	})
+}
+
+func TestUsageQueuePluginPreservesLegacyTierAndEmitsCanonicalAutoTier(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := coreusage.WithServiceTier(context.Background(), "default")
+		ctx = coreusage.WithRequestServiceTier(ctx, "auto")
+		ctx = internallogging.WithResponseStatusHolder(ctx)
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		(&usageQueuePlugin{}).HandleUsage(ctx, coreusage.Record{
+			Provider: "openai",
+			Model:    "gpt-5.4",
+			Detail: coreusage.Detail{
+				InputTokens: 1,
+				TotalTokens: 1,
+			},
+		})
+
+		payload := popSinglePayload(t)
+		requireStringField(t, payload, "service_tier", "default")
+		requireStringField(t, payload, "request_service_tier", "auto")
 	})
 }
 
@@ -316,6 +367,24 @@ func requireBoolField(t *testing.T, payload map[string]json.RawMessage, key stri
 	if got != want {
 		t.Fatalf("%s = %t, want %t", key, got, want)
 	}
+}
+
+func requireTokensPayload(t *testing.T, payload map[string]json.RawMessage) map[string]json.RawMessage {
+	t.Helper()
+	raw, ok := payload["tokens"]
+	if !ok {
+		t.Fatal("payload missing tokens")
+	}
+	var tokens map[string]json.RawMessage
+	if errUnmarshal := json.Unmarshal(raw, &tokens); errUnmarshal != nil {
+		t.Fatalf("unmarshal tokens: %v", errUnmarshal)
+	}
+	return tokens
+}
+
+func requireTokensBoolField(t *testing.T, payload map[string]json.RawMessage, key string, want bool) {
+	t.Helper()
+	requireBoolField(t, requireTokensPayload(t, payload), key, want)
 }
 
 func requireFailField(t *testing.T, payload map[string]json.RawMessage, wantStatus int, wantBody string) {

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -22,24 +22,23 @@ import (
 )
 
 type UsageReporter struct {
-	provider           string
-	executorType       string
-	model              string
-	alias              string
-	authID             string
-	authIndex          string
-	authType           string
-	apiKey             string
-	source             string
-	reasoning          string
-	serviceTier        string
-	requestServiceTier string
-	requestedAt        time.Time
-	ttftMu             sync.RWMutex
-	ttft               time.Duration
-	ttftStart          time.Time
-	ttftSet            bool
-	once               sync.Once
+	provider     string
+	executorType string
+	model        string
+	alias        string
+	authID       string
+	authIndex    string
+	authType     string
+	apiKey       string
+	source       string
+	reasoning    string
+	serviceTier  string
+	requestedAt  time.Time
+	ttftMu       sync.RWMutex
+	ttft         time.Duration
+	ttftStart    time.Time
+	ttftSet      bool
+	once         sync.Once
 }
 
 type usageExecutor interface {
@@ -63,16 +62,15 @@ func NewUsageReporter(ctx context.Context, provider, model string, auth *cliprox
 		alias = model
 	}
 	reporter := &UsageReporter{
-		provider:           provider,
-		model:              model,
-		alias:              strings.TrimSpace(alias),
-		requestedAt:        time.Now(),
-		apiKey:             apiKey,
-		source:             resolveUsageSource(auth, apiKey),
-		authType:           resolveUsageAuthType(auth),
-		reasoning:          usage.ReasoningEffortFromContext(ctx),
-		serviceTier:        usage.ServiceTierFromContext(ctx),
-		requestServiceTier: usage.RequestServiceTierFromContext(ctx),
+		provider:    provider,
+		model:       model,
+		alias:       strings.TrimSpace(alias),
+		requestedAt: time.Now(),
+		apiKey:      apiKey,
+		source:      resolveUsageSource(auth, apiKey),
+		authType:    resolveUsageAuthType(auth),
+		reasoning:   usage.ReasoningEffortFromContext(ctx),
+		serviceTier: usage.ServiceTierFromContext(ctx),
 	}
 	if auth != nil {
 		reporter.authID = auth.ID
@@ -272,7 +270,6 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 		AuthType:            r.authType,
 		ReasoningEffort:     r.reasoning,
 		ServiceTier:         r.serviceTier,
-		RequestServiceTier:  r.requestServiceTier,
 		ResponseServiceTier: strings.TrimSpace(detail.ResponseServiceTier),
 		RequestedAt:         r.requestedAt,
 		Latency:             r.latency(),

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -22,23 +22,24 @@ import (
 )
 
 type UsageReporter struct {
-	provider     string
-	executorType string
-	model        string
-	alias        string
-	authID       string
-	authIndex    string
-	authType     string
-	apiKey       string
-	source       string
-	reasoning    string
-	serviceTier  string
-	requestedAt  time.Time
-	ttftMu       sync.RWMutex
-	ttft         time.Duration
-	ttftStart    time.Time
-	ttftSet      bool
-	once         sync.Once
+	provider           string
+	executorType       string
+	model              string
+	alias              string
+	authID             string
+	authIndex          string
+	authType           string
+	apiKey             string
+	source             string
+	reasoning          string
+	serviceTier        string
+	requestServiceTier string
+	requestedAt        time.Time
+	ttftMu             sync.RWMutex
+	ttft               time.Duration
+	ttftStart          time.Time
+	ttftSet            bool
+	once               sync.Once
 }
 
 type usageExecutor interface {
@@ -62,15 +63,16 @@ func NewUsageReporter(ctx context.Context, provider, model string, auth *cliprox
 		alias = model
 	}
 	reporter := &UsageReporter{
-		provider:    provider,
-		model:       model,
-		alias:       strings.TrimSpace(alias),
-		requestedAt: time.Now(),
-		apiKey:      apiKey,
-		source:      resolveUsageSource(auth, apiKey),
-		authType:    resolveUsageAuthType(auth),
-		reasoning:   usage.ReasoningEffortFromContext(ctx),
-		serviceTier: usage.ServiceTierFromContext(ctx),
+		provider:           provider,
+		model:              model,
+		alias:              strings.TrimSpace(alias),
+		requestedAt:        time.Now(),
+		apiKey:             apiKey,
+		source:             resolveUsageSource(auth, apiKey),
+		authType:           resolveUsageAuthType(auth),
+		reasoning:          usage.ReasoningEffortFromContext(ctx),
+		serviceTier:        usage.ServiceTierFromContext(ctx),
+		requestServiceTier: usage.RequestServiceTierFromContext(ctx),
 	}
 	if auth != nil {
 		reporter.authID = auth.ID
@@ -107,7 +109,6 @@ func (r *UsageReporter) SetTranslatedReasoningEffort(payload []byte, format stri
 		return
 	}
 	r.reasoning = thinking.ExtractTranslatedReasoningEffort(payload, format)
-	r.serviceTier = extractServiceTierFromPayload(payload)
 }
 
 func (r *UsageReporter) TrackHTTPClient(client *http.Client) *http.Client {
@@ -271,7 +272,7 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 		AuthType:            r.authType,
 		ReasoningEffort:     r.reasoning,
 		ServiceTier:         r.serviceTier,
-		RequestServiceTier:  r.serviceTier,
+		RequestServiceTier:  r.requestServiceTier,
 		ResponseServiceTier: strings.TrimSpace(detail.ResponseServiceTier),
 		RequestedAt:         r.requestedAt,
 		Latency:             r.latency(),
@@ -280,19 +281,6 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 		Fail:                fail,
 		Detail:              detail,
 	}
-}
-
-func extractServiceTierFromPayload(payload []byte) string {
-	if len(payload) == 0 {
-		return usage.DefaultServiceTier
-	}
-	for _, path := range []string{"service_tier", "request.service_tier", "response.service_tier"} {
-		serviceTier := strings.TrimSpace(gjson.GetBytes(payload, path).String())
-		if serviceTier != "" {
-			return serviceTier
-		}
-	}
-	return usage.DefaultServiceTier
 }
 
 func failFromErrors(errs ...error) usage.Failure {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -464,9 +464,6 @@ func TestUsageReporterBuildRecordIncludesServiceTier(t *testing.T) {
 	if record.ServiceTier != "auto" {
 		t.Fatalf("service tier = %q, want %q", record.ServiceTier, "auto")
 	}
-	if record.RequestServiceTier != "" {
-		t.Fatalf("deprecated request service tier = %q, want empty", record.RequestServiceTier)
-	}
 	if record.ResponseServiceTier != "default" {
 		t.Fatalf("response service tier = %q, want default", record.ResponseServiceTier)
 	}
@@ -481,16 +478,6 @@ func TestUsageReporterSetTranslatedReasoningEffortPreservesClientServiceTier(t *
 	record := reporter.buildRecord(usage.Detail{TotalTokens: 3}, false)
 	if record.ServiceTier != "auto" {
 		t.Fatalf("service tier = %q, want %q", record.ServiceTier, "auto")
-	}
-}
-
-func TestUsageReporterAcceptsDeprecatedRequestServiceTierAlias(t *testing.T) {
-	ctx := usage.WithRequestServiceTier(context.Background(), "default")
-	reporter := NewUsageReporter(ctx, "openai", "gpt-5.4", nil)
-
-	record := reporter.buildRecord(usage.Detail{TotalTokens: 3}, false)
-	if record.ServiceTier != "default" {
-		t.Fatalf("service tier = %q, want default", record.ServiceTier)
 	}
 }
 

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -457,41 +457,51 @@ func TestUsageReporterBuildRecordIncludesReasoningEffort(t *testing.T) {
 }
 
 func TestUsageReporterBuildRecordIncludesServiceTier(t *testing.T) {
-	ctx := usage.WithServiceTier(context.Background(), "priority")
+	ctx := usage.WithServiceTier(context.Background(), "default")
+	ctx = usage.WithRequestServiceTier(ctx, "auto")
 	reporter := NewUsageReporter(ctx, "openai", "gpt-5.4", nil)
 
 	record := reporter.buildRecord(usage.Detail{TotalTokens: 3, ResponseServiceTier: "default"}, false)
-	if record.ServiceTier != "priority" {
-		t.Fatalf("service tier = %q, want %q", record.ServiceTier, "priority")
+	if record.ServiceTier != "default" {
+		t.Fatalf("service tier = %q, want %q", record.ServiceTier, "default")
 	}
-	if record.RequestServiceTier != "priority" {
-		t.Fatalf("request service tier = %q, want priority", record.RequestServiceTier)
+	if record.RequestServiceTier != "auto" {
+		t.Fatalf("request service tier = %q, want auto", record.RequestServiceTier)
 	}
 	if record.ResponseServiceTier != "default" {
 		t.Fatalf("response service tier = %q, want default", record.ResponseServiceTier)
 	}
 }
 
-func TestUsageReporterSetTranslatedReasoningEffortUpdatesServiceTier(t *testing.T) {
-	reporter := NewUsageReporter(context.Background(), "openai", "gpt-5.4", nil)
+func TestUsageReporterSetTranslatedReasoningEffortPreservesRequestServiceTier(t *testing.T) {
+	ctx := usage.WithServiceTier(context.Background(), "default")
+	ctx = usage.WithRequestServiceTier(ctx, "auto")
+	reporter := NewUsageReporter(ctx, "openai", "gpt-5.4", nil)
 
 	reporter.SetTranslatedReasoningEffort([]byte(`{"service_tier":"priority"}`), "openai")
 
 	record := reporter.buildRecord(usage.Detail{TotalTokens: 3}, false)
-	if record.ServiceTier != "priority" {
-		t.Fatalf("service tier = %q, want %q", record.ServiceTier, "priority")
+	if record.ServiceTier != "default" {
+		t.Fatalf("service tier = %q, want %q", record.ServiceTier, "default")
+	}
+	if record.RequestServiceTier != "auto" {
+		t.Fatalf("request service tier = %q, want %q", record.RequestServiceTier, "auto")
 	}
 }
 
-func TestUsageReporterSetTranslatedReasoningEffortDefaultsServiceTierWhenRemoved(t *testing.T) {
-	ctx := usage.WithServiceTier(context.Background(), "priority")
+func TestUsageReporterSetTranslatedReasoningEffortPreservesExplicitDefaultServiceTier(t *testing.T) {
+	ctx := usage.WithServiceTier(context.Background(), "default")
+	ctx = usage.WithRequestServiceTier(ctx, "default")
 	reporter := NewUsageReporter(ctx, "openai", "gpt-5.4", nil)
 
-	reporter.SetTranslatedReasoningEffort([]byte(`{"model":"gpt-5.4"}`), "openai")
+	reporter.SetTranslatedReasoningEffort([]byte(`{"service_tier":"priority"}`), "openai")
 
 	record := reporter.buildRecord(usage.Detail{TotalTokens: 3}, false)
 	if record.ServiceTier != usage.DefaultServiceTier {
 		t.Fatalf("service tier = %q, want %q", record.ServiceTier, usage.DefaultServiceTier)
+	}
+	if record.RequestServiceTier != usage.DefaultServiceTier {
+		t.Fatalf("request service tier = %q, want %q", record.RequestServiceTier, usage.DefaultServiceTier)
 	}
 }
 

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -457,51 +457,40 @@ func TestUsageReporterBuildRecordIncludesReasoningEffort(t *testing.T) {
 }
 
 func TestUsageReporterBuildRecordIncludesServiceTier(t *testing.T) {
-	ctx := usage.WithServiceTier(context.Background(), "default")
-	ctx = usage.WithRequestServiceTier(ctx, "auto")
+	ctx := usage.WithServiceTier(context.Background(), "auto")
 	reporter := NewUsageReporter(ctx, "openai", "gpt-5.4", nil)
 
 	record := reporter.buildRecord(usage.Detail{TotalTokens: 3, ResponseServiceTier: "default"}, false)
-	if record.ServiceTier != "default" {
-		t.Fatalf("service tier = %q, want %q", record.ServiceTier, "default")
+	if record.ServiceTier != "auto" {
+		t.Fatalf("service tier = %q, want %q", record.ServiceTier, "auto")
 	}
-	if record.RequestServiceTier != "auto" {
-		t.Fatalf("request service tier = %q, want auto", record.RequestServiceTier)
+	if record.RequestServiceTier != "" {
+		t.Fatalf("deprecated request service tier = %q, want empty", record.RequestServiceTier)
 	}
 	if record.ResponseServiceTier != "default" {
 		t.Fatalf("response service tier = %q, want default", record.ResponseServiceTier)
 	}
 }
 
-func TestUsageReporterSetTranslatedReasoningEffortPreservesRequestServiceTier(t *testing.T) {
-	ctx := usage.WithServiceTier(context.Background(), "default")
-	ctx = usage.WithRequestServiceTier(ctx, "auto")
+func TestUsageReporterSetTranslatedReasoningEffortPreservesClientServiceTier(t *testing.T) {
+	ctx := usage.WithServiceTier(context.Background(), "auto")
 	reporter := NewUsageReporter(ctx, "openai", "gpt-5.4", nil)
 
 	reporter.SetTranslatedReasoningEffort([]byte(`{"service_tier":"priority"}`), "openai")
 
 	record := reporter.buildRecord(usage.Detail{TotalTokens: 3}, false)
-	if record.ServiceTier != "default" {
-		t.Fatalf("service tier = %q, want %q", record.ServiceTier, "default")
-	}
-	if record.RequestServiceTier != "auto" {
-		t.Fatalf("request service tier = %q, want %q", record.RequestServiceTier, "auto")
+	if record.ServiceTier != "auto" {
+		t.Fatalf("service tier = %q, want %q", record.ServiceTier, "auto")
 	}
 }
 
-func TestUsageReporterSetTranslatedReasoningEffortPreservesExplicitDefaultServiceTier(t *testing.T) {
-	ctx := usage.WithServiceTier(context.Background(), "default")
-	ctx = usage.WithRequestServiceTier(ctx, "default")
+func TestUsageReporterAcceptsDeprecatedRequestServiceTierAlias(t *testing.T) {
+	ctx := usage.WithRequestServiceTier(context.Background(), "default")
 	reporter := NewUsageReporter(ctx, "openai", "gpt-5.4", nil)
 
-	reporter.SetTranslatedReasoningEffort([]byte(`{"service_tier":"priority"}`), "openai")
-
 	record := reporter.buildRecord(usage.Detail{TotalTokens: 3}, false)
-	if record.ServiceTier != usage.DefaultServiceTier {
-		t.Fatalf("service tier = %q, want %q", record.ServiceTier, usage.DefaultServiceTier)
-	}
-	if record.RequestServiceTier != usage.DefaultServiceTier {
-		t.Fatalf("request service tier = %q, want %q", record.RequestServiceTier, usage.DefaultServiceTier)
+	if record.ServiceTier != "default" {
+		t.Fatalf("service tier = %q, want default", record.ServiceTier)
 	}
 }
 

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -318,18 +318,15 @@ func setServiceTierMetadata(meta map[string]any, rawJSON []byte) {
 	if meta == nil {
 		return
 	}
-	legacyServiceTier := coreusage.DefaultServiceTier
-	requestServiceTier := coreusage.AutoServiceTier
+	serviceTier := coreusage.AutoServiceTier
 	node := gjson.GetBytes(rawJSON, "service_tier")
 	if node.Exists() {
 		value := strings.TrimSpace(node.String())
 		if value != "" {
-			legacyServiceTier = value
-			requestServiceTier = value
+			serviceTier = value
 		}
 	}
-	meta[coreexecutor.ServiceTierMetadataKey] = legacyServiceTier
-	meta[coreexecutor.RequestServiceTierMetadataKey] = requestServiceTier
+	meta[coreexecutor.ServiceTierMetadataKey] = serviceTier
 }
 
 // headersFromContext extracts the original HTTP request headers from the gin context

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -318,15 +318,18 @@ func setServiceTierMetadata(meta map[string]any, rawJSON []byte) {
 	if meta == nil {
 		return
 	}
-	serviceTier := coreusage.DefaultServiceTier
+	legacyServiceTier := coreusage.DefaultServiceTier
+	requestServiceTier := coreusage.AutoServiceTier
 	node := gjson.GetBytes(rawJSON, "service_tier")
 	if node.Exists() {
 		value := strings.TrimSpace(node.String())
 		if value != "" {
-			serviceTier = value
+			legacyServiceTier = value
+			requestServiceTier = value
 		}
 	}
-	meta[coreexecutor.ServiceTierMetadataKey] = serviceTier
+	meta[coreexecutor.ServiceTierMetadataKey] = legacyServiceTier
+	meta[coreexecutor.RequestServiceTierMetadataKey] = requestServiceTier
 }
 
 // headersFromContext extracts the original HTTP request headers from the gin context

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -48,8 +48,8 @@ func TestSetServiceTierMetadataExtractsValue(t *testing.T) {
 	if gotServiceTier != "priority" {
 		t.Fatalf("ServiceTierMetadataKey = %v, want %q", gotServiceTier, "priority")
 	}
-	if gotRequestServiceTier := meta[coreexecutor.RequestServiceTierMetadataKey]; gotRequestServiceTier != "priority" {
-		t.Fatalf("RequestServiceTierMetadataKey = %v, want %q", gotRequestServiceTier, "priority")
+	if _, exists := meta[coreexecutor.RequestServiceTierMetadataKey]; exists {
+		t.Fatal("unexpected deprecated request_service_tier metadata")
 	}
 }
 
@@ -59,11 +59,8 @@ func TestSetServiceTierMetadataDefaultsWhenMissing(t *testing.T) {
 	setServiceTierMetadata(meta, []byte(`{"model":"gpt-5.4"}`))
 
 	gotServiceTier := meta[coreexecutor.ServiceTierMetadataKey]
-	if gotServiceTier != "default" {
-		t.Fatalf("ServiceTierMetadataKey = %v, want %q", gotServiceTier, "default")
-	}
-	if gotRequestServiceTier := meta[coreexecutor.RequestServiceTierMetadataKey]; gotRequestServiceTier != "auto" {
-		t.Fatalf("RequestServiceTierMetadataKey = %v, want %q", gotRequestServiceTier, "auto")
+	if gotServiceTier != "auto" {
+		t.Fatalf("ServiceTierMetadataKey = %v, want %q", gotServiceTier, "auto")
 	}
 }
 
@@ -74,8 +71,5 @@ func TestSetServiceTierMetadataPreservesExplicitDefault(t *testing.T) {
 
 	if gotServiceTier := meta[coreexecutor.ServiceTierMetadataKey]; gotServiceTier != "default" {
 		t.Fatalf("ServiceTierMetadataKey = %v, want %q", gotServiceTier, "default")
-	}
-	if gotRequestServiceTier := meta[coreexecutor.RequestServiceTierMetadataKey]; gotRequestServiceTier != "default" {
-		t.Fatalf("RequestServiceTierMetadataKey = %v, want %q", gotRequestServiceTier, "default")
 	}
 }

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -48,6 +48,9 @@ func TestSetServiceTierMetadataExtractsValue(t *testing.T) {
 	if gotServiceTier != "priority" {
 		t.Fatalf("ServiceTierMetadataKey = %v, want %q", gotServiceTier, "priority")
 	}
+	if gotRequestServiceTier := meta[coreexecutor.RequestServiceTierMetadataKey]; gotRequestServiceTier != "priority" {
+		t.Fatalf("RequestServiceTierMetadataKey = %v, want %q", gotRequestServiceTier, "priority")
+	}
 }
 
 func TestSetServiceTierMetadataDefaultsWhenMissing(t *testing.T) {
@@ -58,5 +61,21 @@ func TestSetServiceTierMetadataDefaultsWhenMissing(t *testing.T) {
 	gotServiceTier := meta[coreexecutor.ServiceTierMetadataKey]
 	if gotServiceTier != "default" {
 		t.Fatalf("ServiceTierMetadataKey = %v, want %q", gotServiceTier, "default")
+	}
+	if gotRequestServiceTier := meta[coreexecutor.RequestServiceTierMetadataKey]; gotRequestServiceTier != "auto" {
+		t.Fatalf("RequestServiceTierMetadataKey = %v, want %q", gotRequestServiceTier, "auto")
+	}
+}
+
+func TestSetServiceTierMetadataPreservesExplicitDefault(t *testing.T) {
+	meta := make(map[string]any)
+
+	setServiceTierMetadata(meta, []byte(`{"service_tier":"default"}`))
+
+	if gotServiceTier := meta[coreexecutor.ServiceTierMetadataKey]; gotServiceTier != "default" {
+		t.Fatalf("ServiceTierMetadataKey = %v, want %q", gotServiceTier, "default")
+	}
+	if gotRequestServiceTier := meta[coreexecutor.RequestServiceTierMetadataKey]; gotRequestServiceTier != "default" {
+		t.Fatalf("RequestServiceTierMetadataKey = %v, want %q", gotRequestServiceTier, "default")
 	}
 }

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -48,9 +48,6 @@ func TestSetServiceTierMetadataExtractsValue(t *testing.T) {
 	if gotServiceTier != "priority" {
 		t.Fatalf("ServiceTierMetadataKey = %v, want %q", gotServiceTier, "priority")
 	}
-	if _, exists := meta[coreexecutor.RequestServiceTierMetadataKey]; exists {
-		t.Fatal("unexpected deprecated request_service_tier metadata")
-	}
 }
 
 func TestSetServiceTierMetadataDefaultsWhenMissing(t *testing.T) {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3025,9 +3025,6 @@ func contextWithRequestedModelAlias(ctx context.Context, opts cliproxyexecutor.O
 		ctx = coreusage.WithReasoningEffort(ctx, effort)
 	}
 	serviceTier := serviceTierFromOptions(opts)
-	if serviceTier == "" {
-		serviceTier = requestServiceTierFromOptions(opts)
-	}
 	if serviceTier != "" {
 		ctx = coreusage.WithServiceTier(ctx, serviceTier)
 	}
@@ -3079,10 +3076,6 @@ func reasoningEffortFromOptions(opts cliproxyexecutor.Options) string {
 
 func serviceTierFromOptions(opts cliproxyexecutor.Options) string {
 	return stringMetadataValue(opts.Metadata, cliproxyexecutor.ServiceTierMetadataKey)
-}
-
-func requestServiceTierFromOptions(opts cliproxyexecutor.Options) string {
-	return stringMetadataValue(opts.Metadata, cliproxyexecutor.RequestServiceTierMetadataKey)
 }
 
 func stringMetadataValue(metadata map[string]any, key string) string {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3025,15 +3025,11 @@ func contextWithRequestedModelAlias(ctx context.Context, opts cliproxyexecutor.O
 		ctx = coreusage.WithReasoningEffort(ctx, effort)
 	}
 	serviceTier := serviceTierFromOptions(opts)
+	if serviceTier == "" {
+		serviceTier = requestServiceTierFromOptions(opts)
+	}
 	if serviceTier != "" {
 		ctx = coreusage.WithServiceTier(ctx, serviceTier)
-	}
-	requestServiceTier := requestServiceTierFromOptions(opts)
-	if requestServiceTier == "" {
-		requestServiceTier = serviceTier
-	}
-	if requestServiceTier != "" {
-		ctx = coreusage.WithRequestServiceTier(ctx, requestServiceTier)
 	}
 	return ctx
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -3028,6 +3028,13 @@ func contextWithRequestedModelAlias(ctx context.Context, opts cliproxyexecutor.O
 	if serviceTier != "" {
 		ctx = coreusage.WithServiceTier(ctx, serviceTier)
 	}
+	requestServiceTier := requestServiceTierFromOptions(opts)
+	if requestServiceTier == "" {
+		requestServiceTier = serviceTier
+	}
+	if requestServiceTier != "" {
+		ctx = coreusage.WithRequestServiceTier(ctx, requestServiceTier)
+	}
 	return ctx
 }
 
@@ -3075,10 +3082,18 @@ func reasoningEffortFromOptions(opts cliproxyexecutor.Options) string {
 }
 
 func serviceTierFromOptions(opts cliproxyexecutor.Options) string {
-	if len(opts.Metadata) == 0 {
+	return stringMetadataValue(opts.Metadata, cliproxyexecutor.ServiceTierMetadataKey)
+}
+
+func requestServiceTierFromOptions(opts cliproxyexecutor.Options) string {
+	return stringMetadataValue(opts.Metadata, cliproxyexecutor.RequestServiceTierMetadataKey)
+}
+
+func stringMetadataValue(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
 		return ""
 	}
-	raw, ok := opts.Metadata[cliproxyexecutor.ServiceTierMetadataKey]
+	raw, ok := metadata[key]
 	if !ok || raw == nil {
 		return ""
 	}

--- a/sdk/cliproxy/auth/conductor_usage_test.go
+++ b/sdk/cliproxy/auth/conductor_usage_test.go
@@ -11,10 +11,9 @@ import (
 func TestContextWithRequestedModelAliasIncludesReasoningEffort(t *testing.T) {
 	ctx := contextWithRequestedModelAlias(context.Background(), cliproxyexecutor.Options{
 		Metadata: map[string]any{
-			cliproxyexecutor.RequestedModelMetadataKey:     "client-model",
-			cliproxyexecutor.ReasoningEffortMetadataKey:    "medium",
-			cliproxyexecutor.ServiceTierMetadataKey:        "default",
-			cliproxyexecutor.RequestServiceTierMetadataKey: "auto",
+			cliproxyexecutor.RequestedModelMetadataKey:  "client-model",
+			cliproxyexecutor.ReasoningEffortMetadataKey: "medium",
+			cliproxyexecutor.ServiceTierMetadataKey:     "auto",
 		},
 	}, "fallback-model")
 
@@ -25,18 +24,18 @@ func TestContextWithRequestedModelAliasIncludesReasoningEffort(t *testing.T) {
 		t.Fatalf("reasoning effort = %q, want %q", got, "medium")
 	}
 	gotServiceTier := coreusage.ServiceTierFromContext(ctx)
-	if gotServiceTier != "default" {
-		t.Fatalf("service tier = %q, want %q", gotServiceTier, "default")
+	if gotServiceTier != "auto" {
+		t.Fatalf("service tier = %q, want %q", gotServiceTier, "auto")
 	}
 	if gotRequestServiceTier := coreusage.RequestServiceTierFromContext(ctx); gotRequestServiceTier != "auto" {
-		t.Fatalf("request service tier = %q, want %q", gotRequestServiceTier, "auto")
+		t.Fatalf("deprecated request service tier = %q, want %q", gotRequestServiceTier, "auto")
 	}
 }
 
-func TestContextWithRequestedModelAliasUsesLegacyTierWhenCanonicalTierIsAbsent(t *testing.T) {
+func TestContextWithRequestedModelAliasAcceptsDeprecatedTierMetadata(t *testing.T) {
 	ctx := contextWithRequestedModelAlias(context.Background(), cliproxyexecutor.Options{
 		Metadata: map[string]any{
-			cliproxyexecutor.ServiceTierMetadataKey: "priority",
+			cliproxyexecutor.RequestServiceTierMetadataKey: "priority",
 		},
 	}, "fallback-model")
 

--- a/sdk/cliproxy/auth/conductor_usage_test.go
+++ b/sdk/cliproxy/auth/conductor_usage_test.go
@@ -27,22 +27,4 @@ func TestContextWithRequestedModelAliasIncludesReasoningEffort(t *testing.T) {
 	if gotServiceTier != "auto" {
 		t.Fatalf("service tier = %q, want %q", gotServiceTier, "auto")
 	}
-	if gotRequestServiceTier := coreusage.RequestServiceTierFromContext(ctx); gotRequestServiceTier != "auto" {
-		t.Fatalf("deprecated request service tier = %q, want %q", gotRequestServiceTier, "auto")
-	}
-}
-
-func TestContextWithRequestedModelAliasAcceptsDeprecatedTierMetadata(t *testing.T) {
-	ctx := contextWithRequestedModelAlias(context.Background(), cliproxyexecutor.Options{
-		Metadata: map[string]any{
-			cliproxyexecutor.RequestServiceTierMetadataKey: "priority",
-		},
-	}, "fallback-model")
-
-	if got := coreusage.ServiceTierFromContext(ctx); got != "priority" {
-		t.Fatalf("service tier = %q, want %q", got, "priority")
-	}
-	if got := coreusage.RequestServiceTierFromContext(ctx); got != "priority" {
-		t.Fatalf("request service tier = %q, want %q", got, "priority")
-	}
 }

--- a/sdk/cliproxy/auth/conductor_usage_test.go
+++ b/sdk/cliproxy/auth/conductor_usage_test.go
@@ -11,9 +11,10 @@ import (
 func TestContextWithRequestedModelAliasIncludesReasoningEffort(t *testing.T) {
 	ctx := contextWithRequestedModelAlias(context.Background(), cliproxyexecutor.Options{
 		Metadata: map[string]any{
-			cliproxyexecutor.RequestedModelMetadataKey:  "client-model",
-			cliproxyexecutor.ReasoningEffortMetadataKey: "medium",
-			cliproxyexecutor.ServiceTierMetadataKey:     "priority",
+			cliproxyexecutor.RequestedModelMetadataKey:     "client-model",
+			cliproxyexecutor.ReasoningEffortMetadataKey:    "medium",
+			cliproxyexecutor.ServiceTierMetadataKey:        "default",
+			cliproxyexecutor.RequestServiceTierMetadataKey: "auto",
 		},
 	}, "fallback-model")
 
@@ -24,7 +25,25 @@ func TestContextWithRequestedModelAliasIncludesReasoningEffort(t *testing.T) {
 		t.Fatalf("reasoning effort = %q, want %q", got, "medium")
 	}
 	gotServiceTier := coreusage.ServiceTierFromContext(ctx)
-	if gotServiceTier != "priority" {
-		t.Fatalf("service tier = %q, want %q", gotServiceTier, "priority")
+	if gotServiceTier != "default" {
+		t.Fatalf("service tier = %q, want %q", gotServiceTier, "default")
+	}
+	if gotRequestServiceTier := coreusage.RequestServiceTierFromContext(ctx); gotRequestServiceTier != "auto" {
+		t.Fatalf("request service tier = %q, want %q", gotRequestServiceTier, "auto")
+	}
+}
+
+func TestContextWithRequestedModelAliasUsesLegacyTierWhenCanonicalTierIsAbsent(t *testing.T) {
+	ctx := contextWithRequestedModelAlias(context.Background(), cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.ServiceTierMetadataKey: "priority",
+		},
+	}, "fallback-model")
+
+	if got := coreusage.ServiceTierFromContext(ctx); got != "priority" {
+		t.Fatalf("service tier = %q, want %q", got, "priority")
+	}
+	if got := coreusage.RequestServiceTierFromContext(ctx); got != "priority" {
+		t.Fatalf("request service tier = %q, want %q", got, "priority")
 	}
 }

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -27,10 +27,6 @@ const ReasoningEffortMetadataKey = "reasoning_effort"
 // ServiceTierMetadataKey stores the client-requested service tier for usage logs.
 const ServiceTierMetadataKey = "service_tier"
 
-// RequestServiceTierMetadataKey is the deprecated metadata alias used by older
-// SDK callers. New callers must use ServiceTierMetadataKey.
-const RequestServiceTierMetadataKey = "request_service_tier"
-
 const (
 	// PinnedAuthMetadataKey locks execution to a specific auth ID.
 	PinnedAuthMetadataKey = "pinned_auth_id"

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -24,10 +24,11 @@ const AuthSelectionModelMetadataKey = "auth_selection_model"
 // ReasoningEffortMetadataKey stores the client-requested reasoning effort for usage logs.
 const ReasoningEffortMetadataKey = "reasoning_effort"
 
-// ServiceTierMetadataKey stores the legacy service tier for usage logs.
+// ServiceTierMetadataKey stores the client-requested service tier for usage logs.
 const ServiceTierMetadataKey = "service_tier"
 
-// RequestServiceTierMetadataKey stores the canonical client-requested service tier for usage logs.
+// RequestServiceTierMetadataKey is the deprecated metadata alias used by older
+// SDK callers. New callers must use ServiceTierMetadataKey.
 const RequestServiceTierMetadataKey = "request_service_tier"
 
 const (

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -24,8 +24,11 @@ const AuthSelectionModelMetadataKey = "auth_selection_model"
 // ReasoningEffortMetadataKey stores the client-requested reasoning effort for usage logs.
 const ReasoningEffortMetadataKey = "reasoning_effort"
 
-// ServiceTierMetadataKey stores the client-requested service tier for usage logs.
+// ServiceTierMetadataKey stores the legacy service tier for usage logs.
 const ServiceTierMetadataKey = "service_tier"
+
+// RequestServiceTierMetadataKey stores the canonical client-requested service tier for usage logs.
+const RequestServiceTierMetadataKey = "request_service_tier"
 
 const (
 	// PinnedAuthMetadataKey locks execution to a specific auth ID.

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -34,8 +34,8 @@ type Record struct {
 	ReasoningEffort string
 	// ServiceTier stores the client-requested service tier.
 	ServiceTier string
-	// RequestServiceTier is a deprecated input alias for older SDK callers. New
-	// records must use ServiceTier and are emitted with service_tier only.
+	// RequestServiceTier is a deprecated input-only alias retained for existing
+	// plugin callers. It is normalized into ServiceTier and never emitted.
 	RequestServiceTier string
 	// ResponseServiceTier stores the final tier reported by the upstream response.
 	ResponseServiceTier string
@@ -161,18 +161,6 @@ func ServiceTierFromContext(ctx context.Context) string {
 	default:
 		return DefaultServiceTier
 	}
-}
-
-// WithRequestServiceTier is retained for source compatibility. New callers must
-// use WithServiceTier; both names write the same value.
-func WithRequestServiceTier(ctx context.Context, tier string) context.Context {
-	return WithServiceTier(ctx, tier)
-}
-
-// RequestServiceTierFromContext is retained for source compatibility. New
-// callers must use ServiceTierFromContext.
-func RequestServiceTierFromContext(ctx context.Context) string {
-	return ServiceTierFromContext(ctx)
 }
 
 // Plugin consumes usage records emitted by the proxy runtime.

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -10,12 +10,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// DefaultServiceTier preserves the legacy service_tier value when a request does
-// not specify service_tier.
+// DefaultServiceTier is retained for direct SDK and non-OpenAI usage callers.
 const DefaultServiceTier = "default"
 
-// AutoServiceTier is the canonical request_service_tier value when a request
-// does not specify service_tier.
+// AutoServiceTier is the OpenAI request semantics when service_tier is omitted.
+// OpenAI HTTP handlers set it explicitly, without changing other providers'
+// historical direct-SDK default.
 const AutoServiceTier = "auto"
 
 // Record contains the usage statistics captured for a single provider request.
@@ -32,9 +32,10 @@ type Record struct {
 	Source       string
 	// ReasoningEffort stores the translated upstream thinking level for request event logs.
 	ReasoningEffort string
-	// ServiceTier stores the legacy service_tier value for older usage sinks.
+	// ServiceTier stores the client-requested service tier.
 	ServiceTier string
-	// RequestServiceTier stores the canonical client-requested service tier.
+	// RequestServiceTier is a deprecated input alias for older SDK callers. New
+	// records must use ServiceTier and are emitted with service_tier only.
 	RequestServiceTier string
 	// ResponseServiceTier stores the final tier reported by the upstream response.
 	ResponseServiceTier string
@@ -69,7 +70,6 @@ type Detail struct {
 type requestedModelAliasContextKey struct{}
 type reasoningEffortContextKey struct{}
 type serviceTierContextKey struct{}
-type requestServiceTierContextKey struct{}
 
 // WithRequestedModelAlias stores the client-requested model name for usage sinks.
 func WithRequestedModelAlias(ctx context.Context, alias string) context.Context {
@@ -127,7 +127,7 @@ func ReasoningEffortFromContext(ctx context.Context) string {
 	}
 }
 
-// WithServiceTier stores the legacy service_tier value for usage sinks.
+// WithServiceTier stores the client-requested service tier for usage sinks.
 func WithServiceTier(ctx context.Context, tier string) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
@@ -136,14 +136,10 @@ func WithServiceTier(ctx context.Context, tier string) context.Context {
 	if tier == "" {
 		tier = DefaultServiceTier
 	}
-	ctx = context.WithValue(ctx, serviceTierContextKey{}, tier)
-	if _, exists := requestServiceTierContextValue(ctx); !exists {
-		ctx = context.WithValue(ctx, requestServiceTierContextKey{}, tier)
-	}
-	return ctx
+	return context.WithValue(ctx, serviceTierContextKey{}, tier)
 }
 
-// ServiceTierFromContext returns the legacy service_tier value stored in ctx.
+// ServiceTierFromContext returns the client-requested service tier stored in ctx.
 func ServiceTierFromContext(ctx context.Context) string {
 	if ctx == nil {
 		return DefaultServiceTier
@@ -167,42 +163,16 @@ func ServiceTierFromContext(ctx context.Context) string {
 	}
 }
 
-// WithRequestServiceTier stores the canonical client-requested service tier for
-// usage sinks.
+// WithRequestServiceTier is retained for source compatibility. New callers must
+// use WithServiceTier; both names write the same value.
 func WithRequestServiceTier(ctx context.Context, tier string) context.Context {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	tier = strings.TrimSpace(tier)
-	if tier == "" {
-		tier = AutoServiceTier
-	}
-	return context.WithValue(ctx, requestServiceTierContextKey{}, tier)
+	return WithServiceTier(ctx, tier)
 }
 
-// RequestServiceTierFromContext returns the canonical client-requested service
-// tier stored in ctx.
+// RequestServiceTierFromContext is retained for source compatibility. New
+// callers must use ServiceTierFromContext.
 func RequestServiceTierFromContext(ctx context.Context) string {
-	tier, exists := requestServiceTierContextValue(ctx)
-	if !exists || tier == "" {
-		return AutoServiceTier
-	}
-	return tier
-}
-
-func requestServiceTierContextValue(ctx context.Context) (string, bool) {
-	if ctx == nil {
-		return "", false
-	}
-	raw := ctx.Value(requestServiceTierContextKey{})
-	switch value := raw.(type) {
-	case string:
-		return strings.TrimSpace(value), true
-	case []byte:
-		return strings.TrimSpace(string(value)), true
-	default:
-		return "", false
-	}
+	return ServiceTierFromContext(ctx)
 }
 
 // Plugin consumes usage records emitted by the proxy runtime.

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -10,8 +10,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// DefaultServiceTier is used when a request does not specify service_tier.
+// DefaultServiceTier preserves the legacy service_tier value when a request does
+// not specify service_tier.
 const DefaultServiceTier = "default"
+
+// AutoServiceTier is the canonical request_service_tier value when a request
+// does not specify service_tier.
+const AutoServiceTier = "auto"
 
 // Record contains the usage statistics captured for a single provider request.
 type Record struct {
@@ -27,9 +32,9 @@ type Record struct {
 	Source       string
 	// ReasoningEffort stores the translated upstream thinking level for request event logs.
 	ReasoningEffort string
-	// ServiceTier stores the client-requested service tier for request event logs.
+	// ServiceTier stores the legacy service_tier value for older usage sinks.
 	ServiceTier string
-	// RequestServiceTier explicitly aliases the client-requested service tier.
+	// RequestServiceTier stores the canonical client-requested service tier.
 	RequestServiceTier string
 	// ResponseServiceTier stores the final tier reported by the upstream response.
 	ResponseServiceTier string
@@ -64,6 +69,7 @@ type Detail struct {
 type requestedModelAliasContextKey struct{}
 type reasoningEffortContextKey struct{}
 type serviceTierContextKey struct{}
+type requestServiceTierContextKey struct{}
 
 // WithRequestedModelAlias stores the client-requested model name for usage sinks.
 func WithRequestedModelAlias(ctx context.Context, alias string) context.Context {
@@ -121,7 +127,7 @@ func ReasoningEffortFromContext(ctx context.Context) string {
 	}
 }
 
-// WithServiceTier stores the client-requested service tier for usage sinks.
+// WithServiceTier stores the legacy service_tier value for usage sinks.
 func WithServiceTier(ctx context.Context, tier string) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
@@ -130,10 +136,14 @@ func WithServiceTier(ctx context.Context, tier string) context.Context {
 	if tier == "" {
 		tier = DefaultServiceTier
 	}
-	return context.WithValue(ctx, serviceTierContextKey{}, tier)
+	ctx = context.WithValue(ctx, serviceTierContextKey{}, tier)
+	if _, exists := requestServiceTierContextValue(ctx); !exists {
+		ctx = context.WithValue(ctx, requestServiceTierContextKey{}, tier)
+	}
+	return ctx
 }
 
-// ServiceTierFromContext returns the client-requested service tier stored in ctx.
+// ServiceTierFromContext returns the legacy service_tier value stored in ctx.
 func ServiceTierFromContext(ctx context.Context) string {
 	if ctx == nil {
 		return DefaultServiceTier
@@ -154,6 +164,44 @@ func ServiceTierFromContext(ctx context.Context) string {
 		return tier
 	default:
 		return DefaultServiceTier
+	}
+}
+
+// WithRequestServiceTier stores the canonical client-requested service tier for
+// usage sinks.
+func WithRequestServiceTier(ctx context.Context, tier string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tier = strings.TrimSpace(tier)
+	if tier == "" {
+		tier = AutoServiceTier
+	}
+	return context.WithValue(ctx, requestServiceTierContextKey{}, tier)
+}
+
+// RequestServiceTierFromContext returns the canonical client-requested service
+// tier stored in ctx.
+func RequestServiceTierFromContext(ctx context.Context) string {
+	tier, exists := requestServiceTierContextValue(ctx)
+	if !exists || tier == "" {
+		return AutoServiceTier
+	}
+	return tier
+}
+
+func requestServiceTierContextValue(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	raw := ctx.Value(requestServiceTierContextKey{})
+	switch value := raw.(type) {
+	case string:
+		return strings.TrimSpace(value), true
+	case []byte:
+		return strings.TrimSpace(string(value)), true
+	default:
+		return "", false
 	}
 }
 


### PR DESCRIPTION
## Summary

- Emit usage queue payload fields as `service_tier` (client-requested) and optional `response_service_tier` (upstream actual).
- Do not emit `request_service_tier`. Treat omitted OpenAI request tier as internal `auto`; do not forward literal `auto` as a backend request value.
- Keep `Record.RequestServiceTier` only as a deprecated input alias for older plugin/SDK callers; normalize it into `service_tier` before emit.
- Preserve response-tier capture when upstream returns a processing tier, including cases where requested and returned tiers differ.

## Production evidence

Direct Codex backend: `https://chatgpt.com/backend-api/codex/responses` via `cch.us.xcodecli.com`

| Requested tier | HTTP | Returned tier |
|---|---:|---|
| omitted | 200 | `default` |
| `default` | 200 | `default` |
| `priority` | 200 | `default` |
| `auto` | 400 | unsupported |
| `standard` | 400 | unsupported |
| `flex` | 400 | unsupported |

Implications:

- Preserve requested and actual tiers separately.
- Requested `priority` can be accepted while upstream still returns `default`.
- Literal `auto` / `standard` / `flex` are not valid backend request values on this path.

## Home companion contract

Home defaults billing to request `service_tier`, stores optional `response_service_tier`, and can optionally switch to response-source pricing later.

Companion PR: https://github.com/router-for-me/CLIProxyAPIHome/pull/40

## Validation

- `go test ./sdk/api/handlers ./sdk/cliproxy/auth ./internal/runtime/executor/helps ./internal/redisqueue -count=1`
- `go build -o test-output ./cmd/server && rm test-output`
- `git diff --check`
- rebased onto latest `upstream/dev`