### PR TITLE
fix(codex): 仅为有模板的纯 Codex 路由保留 tool search

### DIFF
--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -192,10 +192,12 @@ func applyCodexClientSearchToolSupport(entry map[string]any, id string, template
 		return
 	}
 
+	if !templateModel {
+		entry["supports_search_tool"] = false
+		return
+	}
+
 	if providersForModel == nil {
-		if !templateModel {
-			entry["supports_search_tool"] = false
-		}
 		return
 	}
 

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -13,6 +13,8 @@ type codexClientModelsPayload struct {
 	Models []map[string]any `json:"models"`
 }
 
+type codexClientModelProvidersFunc func(string) []string
+
 var (
 	codexClientModelTemplatesMu       sync.Mutex
 	codexClientModelTemplatesLoaded   bool
@@ -33,16 +35,20 @@ var codexClientAllowedReasoningLevels = map[string]struct{}{
 }
 
 func (h *OpenAIAPIHandler) codexClientModelsResponse() map[string]any {
-	return CodexClientModelsResponse(h.Models())
+	return codexClientModelsResponse(h.Models(), registry.GetGlobalRegistry().GetModelProviders)
 }
 
 func CodexClientModelsResponse(models []map[string]any) map[string]any {
+	return codexClientModelsResponse(models, nil)
+}
+
+func codexClientModelsResponse(models []map[string]any, providersForModel codexClientModelProvidersFunc) map[string]any {
 	return map[string]any{
-		"models": buildCodexClientModels(models),
+		"models": buildCodexClientModels(models, providersForModel),
 	}
 }
 
-func buildCodexClientModels(models []map[string]any) []map[string]any {
+func buildCodexClientModels(models []map[string]any, providersForModel codexClientModelProvidersFunc) []map[string]any {
 	templates, defaultTemplate, err := loadCodexClientModelTemplates()
 	if err != nil || defaultTemplate == nil {
 		return nil
@@ -58,6 +64,7 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 		if template, ok := templates[id]; ok {
 			entry := cloneCodexClientModelMap(template)
 			applyCodexClientDisplayName(entry, model)
+			applyCodexClientSearchToolSupport(entry, id, true, providersForModel)
 			sanitizeCodexClientReasoningMetadata(entry)
 			applyCodexClientVisibilityOverride(entry, id)
 			result = append(result, entry)
@@ -66,6 +73,7 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 
 		entry := cloneCodexClientModelMap(defaultTemplate)
 		applyCodexClientModelMetadata(entry, id, model)
+		applyCodexClientSearchToolSupport(entry, id, false, providersForModel)
 		sanitizeCodexClientReasoningMetadata(entry)
 		applyCodexClientVisibilityOverride(entry, id)
 		result = append(result, entry)
@@ -175,6 +183,32 @@ func loadCodexClientModelTemplatesSnapshot(raw []byte, revision uint64) (map[str
 func applyCodexClientDisplayName(entry map[string]any, model map[string]any) {
 	if displayName := stringModelValue(model, "display_name"); displayName != "" {
 		entry["display_name"] = displayName
+	}
+}
+
+func applyCodexClientSearchToolSupport(entry map[string]any, id string, templateModel bool, providersForModel codexClientModelProvidersFunc) {
+	supportsSearch, _ := entry["supports_search_tool"].(bool)
+	if !supportsSearch {
+		return
+	}
+
+	if providersForModel == nil {
+		if !templateModel {
+			entry["supports_search_tool"] = false
+		}
+		return
+	}
+
+	providers := providersForModel(id)
+	if len(providers) == 0 {
+		entry["supports_search_tool"] = false
+		return
+	}
+	for _, provider := range providers {
+		if !strings.EqualFold(strings.TrimSpace(provider), "codex") {
+			entry["supports_search_tool"] = false
+			return
+		}
 	}
 }
 

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -143,6 +143,75 @@ func TestCodexClientModelsResponse_AppliesDisplayNameToTemplateModel(t *testing.
 	}
 }
 
+func TestCodexClientModelsResponse_DisablesSearchToolForSynthesizedModels(t *testing.T) {
+	resp := CodexClientModelsResponse([]map[string]any{
+		{"id": "custom-openai-compatible-model"},
+		{"id": "gpt-5.5"},
+	})
+	models, ok := resp["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", resp["models"])
+	}
+
+	bySlug := make(map[string]map[string]any, len(models))
+	for _, model := range models {
+		bySlug[stringModelValue(model, "slug")] = model
+	}
+
+	custom := bySlug["custom-openai-compatible-model"]
+	if custom == nil {
+		t.Fatal("expected synthesized custom model entry")
+	}
+	if got, ok := custom["supports_search_tool"].(bool); !ok || got {
+		t.Fatalf("custom supports_search_tool = %#v, want false", custom["supports_search_tool"])
+	}
+
+	official := bySlug["gpt-5.5"]
+	if official == nil {
+		t.Fatal("expected official template model entry")
+	}
+	if got, ok := official["supports_search_tool"].(bool); !ok || !got {
+		t.Fatalf("official supports_search_tool = %#v, want true", official["supports_search_tool"])
+	}
+}
+
+func TestCodexClientModelsResponse_UsesProviderSearchToolSupport(t *testing.T) {
+	providers := map[string][]string{
+		"new-codex-model": {"codex"},
+		"gpt-5.5":         {"openai-compatible-deepseek"},
+		"gpt-5.4":         {"codex", "xai"},
+		"gpt-5.6-sol":     {"codex"},
+	}
+	resp := codexClientModelsResponse([]map[string]any{
+		{"id": "new-codex-model"},
+		{"id": "gpt-5.5"},
+		{"id": "gpt-5.4"},
+		{"id": "gpt-5.6-sol"},
+	}, func(id string) []string {
+		return providers[id]
+	})
+	models, ok := resp["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", resp["models"])
+	}
+
+	bySlug := make(map[string]map[string]any, len(models))
+	for _, model := range models {
+		bySlug[stringModelValue(model, "slug")] = model
+	}
+
+	for _, slug := range []string{"new-codex-model", "gpt-5.6-sol"} {
+		if got, ok := bySlug[slug]["supports_search_tool"].(bool); !ok || !got {
+			t.Errorf("%s supports_search_tool = %#v, want true", slug, bySlug[slug]["supports_search_tool"])
+		}
+	}
+	for _, slug := range []string{"gpt-5.5", "gpt-5.4"} {
+		if got, ok := bySlug[slug]["supports_search_tool"].(bool); !ok || got {
+			t.Errorf("%s supports_search_tool = %#v, want false", slug, bySlug[slug]["supports_search_tool"])
+		}
+	}
+}
+
 func TestCodexClientModelsResponse_PreservesUltraReasoningEffort(t *testing.T) {
 	resp := CodexClientModelsResponse([]map[string]any{{"id": "gpt-5.6-sol"}})
 	models, ok := resp["models"].([]map[string]any)

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -175,7 +175,7 @@ func TestCodexClientModelsResponse_DisablesSearchToolForSynthesizedModels(t *tes
 	}
 }
 
-func TestCodexClientModelsResponse_UsesProviderSearchToolSupport(t *testing.T) {
+func TestCodexClientModelsResponse_RequiresTemplateAndCodexProvidersForSearchTool(t *testing.T) {
 	providers := map[string][]string{
 		"new-codex-model": {"codex"},
 		"gpt-5.5":         {"openai-compatible-deepseek"},
@@ -200,12 +200,10 @@ func TestCodexClientModelsResponse_UsesProviderSearchToolSupport(t *testing.T) {
 		bySlug[stringModelValue(model, "slug")] = model
 	}
 
-	for _, slug := range []string{"new-codex-model", "gpt-5.6-sol"} {
-		if got, ok := bySlug[slug]["supports_search_tool"].(bool); !ok || !got {
-			t.Errorf("%s supports_search_tool = %#v, want true", slug, bySlug[slug]["supports_search_tool"])
-		}
+	if got, ok := bySlug["gpt-5.6-sol"]["supports_search_tool"].(bool); !ok || !got {
+		t.Errorf("gpt-5.6-sol supports_search_tool = %#v, want true", bySlug["gpt-5.6-sol"]["supports_search_tool"])
 	}
-	for _, slug := range []string{"gpt-5.5", "gpt-5.4"} {
+	for _, slug := range []string{"new-codex-model", "gpt-5.5", "gpt-5.4"} {
 		if got, ok := bySlug[slug]["supports_search_tool"].(bool); !ok || got {
 			t.Errorf("%s supports_search_tool = %#v, want false", slug, bySlug[slug]["supports_search_tool"])
 		}


### PR DESCRIPTION
## 问题

Codex 客户端目录中的官方模板会声明 `supports_search_tool: true`。当前实现还会从 `gpt-5.5` 默认模板合成没有正式模板的模型，因此第三方或未知模型也可能继承该能力；非 Codex 提供商使用官方模型 ID 时，也会直接命中对应模板。

但兼容执行路径没有完整实现 Codex 的动态 `tool_search` 往返：例如 xAI 会过滤该工具，Responses → Chat 转换也不会生成对应的 Chat 工具。这会导致 Codex 客户端隐藏具体 MCP 工具，而模型又无法通过 `tool_search` 发现它们。

## 修改

只有同时满足以下条件时才保留模板中的 `supports_search_tool`：

1. 模型命中正式的 Codex 客户端模板。
2. 模型当前的全部可用提供商均为 `codex`。

只要模型是合成条目、存在非 Codex 提供商，或者存在 Codex/第三方混合路由，就将该能力设为 `false`，让客户端直接提供具体工具。上游模板本来显式关闭该能力时不会被重新开启。

对没有提供商上下文的目录构建保持兼容：正式模板保留原值，合成模型保守关闭。

## 测试

- `go test ./sdk/api/handlers/openai -count=1 -timeout 120s`
- `go test ./internal/api -count=1 -timeout 180s`
- `go build ./cmd/server`

测试覆盖：

- 有正式模板且仅由 Codex 提供的模型。
- 仅由 Codex 提供、但没有正式模板的模型。
- 第三方提供商使用官方模型 ID。
- Codex 与第三方提供商共享同一模型 ID。
- 没有提供商上下文时的模板与合成模型行为。