### PR TITLE
Harden reasoning-replay isolation, selector retirement, and xAI error routing

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1280,6 +1280,9 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 		if entry.ownedBy != "" {
 			model["owned_by"] = entry.ownedBy
 		}
+		if entry.displayName != "" {
+			model["display_name"] = entry.displayName
+		}
 		filtered = append(filtered, model)
 	}
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -919,8 +919,10 @@ func TestModelsWithClientVersionReturnsCodexCatalog(t *testing.T) {
 	if got, _ := custom["display_name"].(string); got != "Custom Codex Model" {
 		t.Fatalf("custom display_name = %q, want Custom Codex Model", got)
 	}
-	if got := int(codexClientTestPriority(custom["priority"])); got != 129 {
-		t.Fatalf("custom priority = %v, want 129", custom["priority"])
+	// Non-template models start after the highest template priority (currently
+	// codex-auto-review=43) with +100 for the first custom model.
+	if got := int(codexClientTestPriority(custom["priority"])); got != 143 {
+		t.Fatalf("custom priority = %v, want 143", custom["priority"])
 	}
 	if got, _ := custom["description"].(string); got != "Custom model from registry" {
 		t.Fatalf("custom description = %q, want Custom model from registry", got)

--- a/internal/cache/antigravity_reasoning_replay_cache.go
+++ b/internal/cache/antigravity_reasoning_replay_cache.go
@@ -64,32 +64,58 @@ func CacheAntigravityReasoningReplayItems(modelName, sessionKey string, items []
 	return CacheAntigravityReasoningReplayItemsBestEffort(context.Background(), modelName, sessionKey, items)
 }
 
+// AntigravityReasoningReplayStoreStatus reports why a completed-turn cache write
+// succeeded or failed so callers can decide whether to keep prior entries.
+type AntigravityReasoningReplayStoreStatus int
+
+const (
+	// AntigravityReasoningReplayStoreInvalidArgs means model/session were empty.
+	AntigravityReasoningReplayStoreInvalidArgs AntigravityReasoningReplayStoreStatus = iota
+	// AntigravityReasoningReplayStored means a valid reasoning batch was written.
+	AntigravityReasoningReplayStored
+	// AntigravityReasoningReplayNoReplayableState means the completed output had no
+	// cacheable reasoning batch (for example reasoning disabled).
+	AntigravityReasoningReplayNoReplayableState
+	// AntigravityReasoningReplayStoreBackendError means normalize succeeded but the
+	// storage backend failed; previous entries should be retained.
+	AntigravityReasoningReplayStoreBackendError
+)
+
 // CacheAntigravityReasoningReplayItemsBestEffort stores replay items for completed response paths.
 func CacheAntigravityReasoningReplayItemsBestEffort(ctx context.Context, modelName, sessionKey string, items [][]byte) bool {
+	return StoreAntigravityReasoningReplayItems(ctx, modelName, sessionKey, items) == AntigravityReasoningReplayStored
+}
+
+// StoreAntigravityReasoningReplayItems stores replay items and distinguishes empty
+// completed state from backend failures.
+func StoreAntigravityReasoningReplayItems(ctx context.Context, modelName, sessionKey string, items [][]byte) AntigravityReasoningReplayStoreStatus {
 	key := antigravityReasoningReplayCacheKey(modelName, sessionKey)
 	if key == "" {
-		return false
+		return AntigravityReasoningReplayStoreInvalidArgs
 	}
 	normalized, ok := normalizeAntigravityReasoningReplayItems(items)
 	if !ok {
-		return false
+		return AntigravityReasoningReplayNoReplayableState
 	}
 	if client, homeMode, errClient := currentAntigravityReasoningReplayKVClient(); homeMode {
 		if errClient != nil {
 			log.Errorf("home kv best-effort antigravity reasoning replay set failed prefix=cpa:antigravity:*: %v", errClient)
-			return false
+			return AntigravityReasoningReplayStoreBackendError
 		}
 		raw, errMarshal := json.Marshal(normalized)
 		if errMarshal != nil {
 			log.Errorf("home kv best-effort antigravity reasoning replay set failed prefix=cpa:antigravity:*: %v", errMarshal)
-			return false
+			return AntigravityReasoningReplayStoreBackendError
 		}
 		written, errSet := client.KVSet(ctx, antigravityReasoningReplayKVKey(modelName, sessionKey), raw, homekv.KVSetOptions{EX: AntigravityReasoningReplayCacheTTL})
 		if errSet != nil {
 			log.Errorf("home kv best-effort antigravity reasoning replay set failed prefix=cpa:antigravity:*: %v", errSet)
-			return false
+			return AntigravityReasoningReplayStoreBackendError
 		}
-		return written
+		if !written {
+			return AntigravityReasoningReplayStoreBackendError
+		}
+		return AntigravityReasoningReplayStored
 	}
 
 	cacheCleanupOnce.Do(startCacheCleanup)
@@ -103,7 +129,7 @@ func CacheAntigravityReasoningReplayItemsBestEffort(ctx context.Context, modelNa
 	if len(antigravityReasoningReplayEntries) > AntigravityReasoningReplayCacheMaxEntries {
 		evictOldestAntigravityReasoningReplayEntries(AntigravityReasoningReplayCacheEvictBatchSize)
 	}
-	return true
+	return AntigravityReasoningReplayStored
 }
 
 // GetAntigravityReasoningReplayItem retrieves a normalized reasoning replay item.
@@ -144,7 +170,7 @@ func GetAntigravityReasoningReplayItemsRequired(ctx context.Context, modelName, 
 			return nil, false, errUnmarshal
 		}
 		if _, errExpire := client.KVExpire(ctx, antigravityReasoningReplayKVKey(modelName, sessionKey), AntigravityReasoningReplayCacheTTL); errExpire != nil {
-			return nil, false, errExpire
+			log.Warnf("home kv antigravity reasoning replay expire failed prefix=cpa:antigravity:*: %v", errExpire)
 		}
 		return cloneAntigravityReasoningReplayItems(homeItems), true, nil
 	}

--- a/internal/cache/antigravity_reasoning_replay_cache_test.go
+++ b/internal/cache/antigravity_reasoning_replay_cache_test.go
@@ -1,0 +1,93 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+)
+
+type fakeAntigravityReasoningReplayKVClient struct {
+	values map[string][]byte
+	setErr error
+	delErr error
+}
+
+func newFakeAntigravityReasoningReplayKVClient() *fakeAntigravityReasoningReplayKVClient {
+	return &fakeAntigravityReasoningReplayKVClient{values: make(map[string][]byte)}
+}
+
+func (c *fakeAntigravityReasoningReplayKVClient) KVGet(_ context.Context, key string) ([]byte, bool, error) {
+	value, ok := c.values[key]
+	if !ok {
+		return nil, false, nil
+	}
+	return append([]byte(nil), value...), true, nil
+}
+
+func (c *fakeAntigravityReasoningReplayKVClient) KVSet(_ context.Context, key string, value []byte, _ homekv.KVSetOptions) (bool, error) {
+	if c.setErr != nil {
+		return false, c.setErr
+	}
+	c.values[key] = append([]byte(nil), value...)
+	return true, nil
+}
+
+func (c *fakeAntigravityReasoningReplayKVClient) KVDel(_ context.Context, keys ...string) (int64, error) {
+	if c.delErr != nil {
+		return 0, c.delErr
+	}
+	var deleted int64
+	for _, key := range keys {
+		if _, ok := c.values[key]; ok {
+			delete(c.values, key)
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+func (c *fakeAntigravityReasoningReplayKVClient) KVExpire(_ context.Context, _ string, _ time.Duration) (bool, error) {
+	return true, nil
+}
+
+func useFakeAntigravityReasoningReplayKVClient(t *testing.T, client *fakeAntigravityReasoningReplayKVClient, homeMode bool, errClient error) {
+	t.Helper()
+	previous := currentAntigravityReasoningReplayKVClient
+	currentAntigravityReasoningReplayKVClient = func() (antigravityReasoningReplayKVClient, bool, error) {
+		return client, homeMode, errClient
+	}
+	t.Cleanup(func() {
+		currentAntigravityReasoningReplayKVClient = previous
+	})
+}
+
+func validAntigravityReasoningReplayItemForTest() []byte {
+	return []byte(`{"type":"thought_signature","thoughtSignature":"VALID_REPLAY_SIGNATURE_XXXXXXXXXX","contentIndex":1,"partIndex":0}`)
+}
+
+func TestStoreAntigravityReasoningReplayItemsStatus(t *testing.T) {
+	ClearAntigravityReasoningReplayCache()
+	t.Cleanup(ClearAntigravityReasoningReplayCache)
+
+	if status := StoreAntigravityReasoningReplayItems(context.Background(), "", "session", [][]byte{validAntigravityReasoningReplayItemForTest()}); status != AntigravityReasoningReplayStoreInvalidArgs {
+		t.Fatalf("empty model status = %v, want InvalidArgs", status)
+	}
+	if status := StoreAntigravityReasoningReplayItems(context.Background(), "gemini-3-flash-agent", "session", [][]byte{[]byte(`{"type":"message"}`)}); status != AntigravityReasoningReplayNoReplayableState {
+		t.Fatalf("non-replayable status = %v, want NoReplayableState", status)
+	}
+
+	client := newFakeAntigravityReasoningReplayKVClient()
+	client.setErr = errors.New("set failed")
+	useFakeAntigravityReasoningReplayKVClient(t, client, true, nil)
+	if status := StoreAntigravityReasoningReplayItems(context.Background(), "gemini-3-flash-agent", "session-home", [][]byte{validAntigravityReasoningReplayItemForTest()}); status != AntigravityReasoningReplayStoreBackendError {
+		t.Fatalf("backend error status = %v, want StoreBackendError", status)
+	}
+
+	useFakeAntigravityReasoningReplayKVClient(t, newFakeAntigravityReasoningReplayKVClient(), false, nil)
+	if status := StoreAntigravityReasoningReplayItems(context.Background(), "gemini-3-flash-agent", "session-local", [][]byte{validAntigravityReasoningReplayItemForTest()}); status != AntigravityReasoningReplayStored {
+		t.Fatalf("local store status = %v, want Stored", status)
+	}
+}

--- a/internal/cache/codex_reasoning_replay_cache.go
+++ b/internal/cache/codex_reasoning_replay_cache.go
@@ -63,32 +63,58 @@ func CacheCodexReasoningReplayItems(modelName, sessionKey string, items [][]byte
 	return CacheCodexReasoningReplayItemsBestEffort(context.Background(), modelName, sessionKey, items)
 }
 
+// CodexReasoningReplayStoreStatus reports why a completed-turn cache write
+// succeeded or failed so callers can decide whether to keep prior entries.
+type CodexReasoningReplayStoreStatus int
+
+const (
+	// CodexReasoningReplayStoreInvalidArgs means model/session were empty.
+	CodexReasoningReplayStoreInvalidArgs CodexReasoningReplayStoreStatus = iota
+	// CodexReasoningReplayStored means a valid reasoning batch was written.
+	CodexReasoningReplayStored
+	// CodexReasoningReplayNoReplayableState means the completed output had no
+	// cacheable reasoning batch (for example reasoning disabled).
+	CodexReasoningReplayNoReplayableState
+	// CodexReasoningReplayStoreBackendError means normalize succeeded but the
+	// storage backend failed; previous entries should be retained.
+	CodexReasoningReplayStoreBackendError
+)
+
 // CacheCodexReasoningReplayItemsBestEffort stores replay items for completed response paths.
 func CacheCodexReasoningReplayItemsBestEffort(ctx context.Context, modelName, sessionKey string, items [][]byte) bool {
+	return StoreCodexReasoningReplayItems(ctx, modelName, sessionKey, items) == CodexReasoningReplayStored
+}
+
+// StoreCodexReasoningReplayItems stores replay items and distinguishes empty
+// completed state from backend failures.
+func StoreCodexReasoningReplayItems(ctx context.Context, modelName, sessionKey string, items [][]byte) CodexReasoningReplayStoreStatus {
 	key := codexReasoningReplayCacheKey(modelName, sessionKey)
 	if key == "" {
-		return false
+		return CodexReasoningReplayStoreInvalidArgs
 	}
 	normalized, ok := normalizeCodexReasoningReplayItems(items)
 	if !ok {
-		return false
+		return CodexReasoningReplayNoReplayableState
 	}
 	if client, homeMode, errClient := currentCodexReasoningReplayKVClient(); homeMode {
 		if errClient != nil {
 			log.Errorf("home kv best-effort codex reasoning replay set failed prefix=cpa:codex:*: %v", errClient)
-			return false
+			return CodexReasoningReplayStoreBackendError
 		}
 		raw, errMarshal := json.Marshal(normalized)
 		if errMarshal != nil {
 			log.Errorf("home kv best-effort codex reasoning replay set failed prefix=cpa:codex:*: %v", errMarshal)
-			return false
+			return CodexReasoningReplayStoreBackendError
 		}
 		written, errSet := client.KVSet(ctx, codexReasoningReplayKVKey(modelName, sessionKey), raw, homekv.KVSetOptions{EX: CodexReasoningReplayCacheTTL})
 		if errSet != nil {
 			log.Errorf("home kv best-effort codex reasoning replay set failed prefix=cpa:codex:*: %v", errSet)
-			return false
+			return CodexReasoningReplayStoreBackendError
 		}
-		return written
+		if !written {
+			return CodexReasoningReplayStoreBackendError
+		}
+		return CodexReasoningReplayStored
 	}
 
 	cacheCleanupOnce.Do(startCacheCleanup)
@@ -102,7 +128,7 @@ func CacheCodexReasoningReplayItemsBestEffort(ctx context.Context, modelName, se
 	if len(codexReasoningReplayEntries) > CodexReasoningReplayCacheMaxEntries {
 		evictOldestCodexReasoningReplayEntries(CodexReasoningReplayCacheEvictBatchSize)
 	}
-	return true
+	return CodexReasoningReplayStored
 }
 
 // GetCodexReasoningReplayItem retrieves a normalized reasoning replay item.
@@ -143,7 +169,7 @@ func GetCodexReasoningReplayItemsRequired(ctx context.Context, modelName, sessio
 			return nil, false, errUnmarshal
 		}
 		if _, errExpire := client.KVExpire(ctx, codexReasoningReplayKVKey(modelName, sessionKey), CodexReasoningReplayCacheTTL); errExpire != nil {
-			return nil, false, errExpire
+			log.Warnf("home kv codex reasoning replay expire failed prefix=cpa:codex:*: %v", errExpire)
 		}
 		return cloneCodexReasoningReplayItems(homeItems), true, nil
 	}

--- a/internal/cache/codex_reasoning_replay_cache_test.go
+++ b/internal/cache/codex_reasoning_replay_cache_test.go
@@ -148,9 +148,6 @@ func TestCodexReasoningReplayRequiredHomeFailures(t *testing.T) {
 		client *fakeCodexReasoningReplayKVClient
 	}{
 		{name: "get", client: &fakeCodexReasoningReplayKVClient{values: make(map[string][]byte), getErr: errors.New("get failed")}},
-		{name: "expire", client: &fakeCodexReasoningReplayKVClient{values: map[string][]byte{
-			codexReasoningReplayKVKey("gpt-5.4", "session-home"): mustCodexReasoningReplayJSON(t, [][]byte{validCodexReasoningReplayItemForTest(4)}),
-		}, expireErr: errors.New("expire failed")}},
 		{name: "delete", client: &fakeCodexReasoningReplayKVClient{values: make(map[string][]byte), delErr: errors.New("delete failed")}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -166,6 +163,52 @@ func TestCodexReasoningReplayRequiredHomeFailures(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCodexReasoningReplayRequiredHomeExpireFailureReturnsItems(t *testing.T) {
+	ClearCodexReasoningReplayCache()
+	t.Cleanup(ClearCodexReasoningReplayCache)
+	client := newFakeCodexReasoningReplayKVClient()
+	client.expireErr = errors.New("expire failed")
+	key := codexReasoningReplayKVKey("gpt-5.4", "session-home")
+	item := validCodexReasoningReplayItemForTest(4)
+	client.values[key] = mustCodexReasoningReplayJSON(t, [][]byte{item})
+	useFakeCodexReasoningReplayKVClient(t, client, true, nil)
+
+	items, found, errGet := GetCodexReasoningReplayItemsRequired(context.Background(), "gpt-5.4", "session-home")
+	if errGet != nil {
+		t.Fatalf("GetCodexReasoningReplayItemsRequired() error = %v", errGet)
+	}
+	if !found || len(items) != 1 || string(items[0]) != string(item) {
+		t.Fatalf("GetCodexReasoningReplayItemsRequired() = %q, %v, want item, true", items, found)
+	}
+	if client.expireCount != 1 || client.lastExpireTTL != CodexReasoningReplayCacheTTL {
+		t.Fatalf("KVExpire count/ttl = %d/%v, want 1/%v", client.expireCount, client.lastExpireTTL, CodexReasoningReplayCacheTTL)
+	}
+}
+
+func TestStoreCodexReasoningReplayItemsStatus(t *testing.T) {
+	ClearCodexReasoningReplayCache()
+	t.Cleanup(ClearCodexReasoningReplayCache)
+
+	if status := StoreCodexReasoningReplayItems(context.Background(), "", "session", [][]byte{validCodexReasoningReplayItemForTest(1)}); status != CodexReasoningReplayStoreInvalidArgs {
+		t.Fatalf("empty model status = %v, want InvalidArgs", status)
+	}
+	if status := StoreCodexReasoningReplayItems(context.Background(), "gpt-5.4", "session", [][]byte{[]byte(`{"type":"message"}`)}); status != CodexReasoningReplayNoReplayableState {
+		t.Fatalf("non-replayable status = %v, want NoReplayableState", status)
+	}
+
+	client := newFakeCodexReasoningReplayKVClient()
+	client.setErr = errors.New("set failed")
+	useFakeCodexReasoningReplayKVClient(t, client, true, nil)
+	if status := StoreCodexReasoningReplayItems(context.Background(), "gpt-5.4", "session-home", [][]byte{validCodexReasoningReplayItemForTest(2)}); status != CodexReasoningReplayStoreBackendError {
+		t.Fatalf("backend error status = %v, want StoreBackendError", status)
+	}
+
+	useFakeCodexReasoningReplayKVClient(t, newFakeCodexReasoningReplayKVClient(), false, nil)
+	if status := StoreCodexReasoningReplayItems(context.Background(), "gpt-5.4", "session-local", [][]byte{validCodexReasoningReplayItemForTest(3)}); status != CodexReasoningReplayStored {
+		t.Fatalf("local store status = %v, want Stored", status)
 	}
 }
 

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -803,10 +803,7 @@ attemptLoop:
 						continue attemptLoop
 					}
 				}
-				if errClear := clearAntigravityReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, bodyBytes); errClear != nil {
-					err = errClear
-					return resp, err
-				}
+				clearAntigravityReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, bodyBytes)
 				err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
 				return resp, err
 			}
@@ -1507,10 +1504,7 @@ attemptLoop:
 						continue attemptLoop
 					}
 				}
-				if errClear := clearAntigravityReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, bodyBytes); errClear != nil {
-					err = errClear
-					return nil, err
-				}
+				clearAntigravityReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, bodyBytes)
 				err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
 				return nil, err
 			}

--- a/internal/runtime/executor/antigravity_reasoning_replay.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay.go
@@ -11,6 +11,7 @@ import (
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -44,19 +45,33 @@ func antigravityReasoningReplayScopeFromPayload(modelName string, payload []byte
 }
 
 func antigravityReasoningReplayScopeFromRequest(ctx context.Context, modelName string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, payload []byte) antigravityReasoningReplayScope {
+	// Trusted execution sessions take precedence and remain un-namespaced.
+	if value := metadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); value != "" {
+		return antigravityReasoningReplayScope{
+			modelName:  modelName,
+			sessionKey: helps.IsolateClientReasoningReplaySessionKey(ctx, "execution:"+value),
+		}
+	}
+	if value := metadataString(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); value != "" {
+		return antigravityReasoningReplayScope{
+			modelName:  modelName,
+			sessionKey: helps.IsolateClientReasoningReplaySessionKey(ctx, "execution:"+value),
+		}
+	}
 	if scope := antigravityReasoningReplayScopeFromPayload(modelName, payload); scope.valid() {
+		scope.sessionKey = helps.IsolateClientReasoningReplaySessionKey(ctx, scope.sessionKey)
+		if !scope.valid() {
+			return antigravityReasoningReplayScope{}
+		}
 		return scope
 	}
 	if scope := antigravityReasoningReplayScopeFromPayload(modelName, req.Payload); scope.valid() {
+		scope.sessionKey = helps.IsolateClientReasoningReplaySessionKey(ctx, scope.sessionKey)
+		if !scope.valid() {
+			return antigravityReasoningReplayScope{}
+		}
 		return scope
 	}
-	if value := metadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); value != "" {
-		return antigravityReasoningReplayScope{modelName: modelName, sessionKey: "execution:" + value}
-	}
-	if value := metadataString(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); value != "" {
-		return antigravityReasoningReplayScope{modelName: modelName, sessionKey: "execution:" + value}
-	}
-	_ = ctx
 	return antigravityReasoningReplayScope{}
 }
 
@@ -121,18 +136,26 @@ func prepareAntigravityGeminiReasoningReplayPayload(ctx context.Context, modelNa
 	return applyAntigravityReasoningReplayCache(ctx, modelName, req, opts, payload)
 }
 
-func clearAntigravityReasoningReplayOnInvalidSignature(ctx context.Context, scope antigravityReasoningReplayScope, statusCode int, body []byte) error {
+// clearAntigravityReasoningReplayOnInvalidSignature best-effort clears stale
+// replay state when upstream rejects an injected thought signature. Delete
+// failures are logged and never replace the upstream status error.
+func clearAntigravityReasoningReplayOnInvalidSignature(ctx context.Context, scope antigravityReasoningReplayScope, statusCode int, body []byte) {
 	if !scope.valid() {
-		return nil
+		return
 	}
 	if statusCode != http.StatusBadRequest {
-		return nil
+		return
 	}
 	bodyText := strings.ToLower(string(body))
 	if !strings.Contains(bodyText, "thoughtsignature") && !strings.Contains(bodyText, "thought_signature") && !strings.Contains(bodyText, "signature") {
-		return nil
+		return
 	}
-	return internalcache.DeleteAntigravityReasoningReplayItemRequired(ctx, scope.modelName, scope.sessionKey)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errDelete := internalcache.DeleteAntigravityReasoningReplayItemRequired(ctx, scope.modelName, scope.sessionKey); errDelete != nil {
+		log.Warnf("antigravity reasoning replay cache delete failed after invalid signature: %v", errDelete)
+	}
 }
 
 func applyAntigravityReasoningReplayCache(ctx context.Context, modelName string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, payload []byte) ([]byte, antigravityReasoningReplayScope, error) {
@@ -531,6 +554,10 @@ type antigravityReasoningReplayAccumulator struct {
 	seenFC         map[string]bool
 	contentIndex   int
 	nextPartIndex  int
+	// completed is set once a terminal finishReason is observed, distinguishing a
+	// successfully completed turn from an interrupted stream so an empty completed
+	// batch can clear a stale prior entry without a partial stream doing so.
+	completed bool
 }
 
 func newAntigravityReasoningReplayAccumulator(scope antigravityReasoningReplayScope, requestPayload []byte) *antigravityReasoningReplayAccumulator {
@@ -559,6 +586,9 @@ func (a *antigravityReasoningReplayAccumulator) ObserveSSELine(line []byte) {
 }
 
 func (a *antigravityReasoningReplayAccumulator) observeResponsePayload(payload []byte) {
+	if fr := gjson.GetBytes(payload, "response.candidates.0.finishReason"); fr.Exists() && strings.TrimSpace(fr.String()) != "" {
+		a.completed = true
+	}
 	parts := gjson.GetBytes(payload, "response.candidates.0.content.parts")
 	if !parts.IsArray() {
 		return
@@ -624,11 +654,28 @@ func buildAntigravityFunctionCallPartItem(contentIndex, partIndex int, fc gjson.
 }
 
 func (a *antigravityReasoningReplayAccumulator) Flush(ctx context.Context) {
-	if a == nil || !a.scope.valid() || len(a.items) == 0 {
+	if a == nil || !a.scope.valid() {
 		return
 	}
-	if !internalcache.CacheAntigravityReasoningReplayItemsBestEffort(ctx, a.scope.modelName, a.scope.sessionKey, a.items) {
-		_ = internalcache.DeleteAntigravityReasoningReplayItemRequired(ctx, a.scope.modelName, a.scope.sessionKey)
+	// An interrupted stream (no terminal finishReason) with no collected items
+	// must not clear a still-valid prior entry; only a successfully completed turn
+	// with no reasoning parts should clear it, matching codex parity.
+	if len(a.items) == 0 && !a.completed {
+		return
+	}
+	switch internalcache.StoreAntigravityReasoningReplayItems(ctx, a.scope.modelName, a.scope.sessionKey, a.items) {
+	case internalcache.AntigravityReasoningReplayStored:
+		return
+	case internalcache.AntigravityReasoningReplayNoReplayableState:
+		// Successful completed turn without cacheable reasoning must not leave
+		// a previous turn's encrypted state to be injected later.
+		if errDelete := internalcache.DeleteAntigravityReasoningReplayItemRequired(ctx, a.scope.modelName, a.scope.sessionKey); errDelete != nil {
+			log.Warnf("antigravity reasoning replay cache delete failed after non-replayable completed output: %v", errDelete)
+		}
+	case internalcache.AntigravityReasoningReplayStoreBackendError:
+		log.Debug("antigravity reasoning replay cache store backend error; retaining previous entry")
+	default:
+		// Invalid args: nothing to store or clear.
 	}
 }
 
@@ -638,6 +685,9 @@ func cacheAntigravityReasoningReplayFromResponse(ctx context.Context, scope anti
 	}
 	acc := newAntigravityReasoningReplayAccumulator(scope, requestPayload)
 	acc.observeResponsePayload(body)
+	// This path only runs for a fully received successful response, so an empty
+	// batch here is a completed turn without reasoning and may clear stale state.
+	acc.completed = true
 	acc.Flush(ctx)
 }
 

--- a/internal/runtime/executor/antigravity_reasoning_replay_clear_test.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay_clear_test.go
@@ -10,17 +10,59 @@ import (
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 )
+
+func TestAntigravityReasoningReplayFlushClearsOnEmptyCompletion(t *testing.T) {
+	internalcache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
+
+	model := "gemini-3-flash-agent"
+	ctx := context.Background()
+	sessionKey := "execution:empty-completion"
+	scope := antigravityReasoningReplayScope{modelName: model, sessionKey: sessionKey}
+	sig := []byte(`{"type":"thought_signature","thoughtSignature":"OLD_REPLAY_SIGNATURE_XXXXXXXXXX","contentIndex":1,"partIndex":0}`)
+	if !internalcache.CacheAntigravityReasoningReplayItems(model, sessionKey, [][]byte{sig}) {
+		t.Fatal("failed to seed replay cache")
+	}
+
+	// An interrupted stream (no terminal finishReason) with no items must NOT
+	// clear the still-valid prior entry.
+	acc := newAntigravityReasoningReplayAccumulator(scope, []byte(`{}`))
+	acc.Flush(ctx)
+	if _, ok := internalcache.GetAntigravityReasoningReplayItem(model, sessionKey); !ok {
+		t.Fatal("interrupted empty stream must not clear replay entry")
+	}
+
+	// A successfully completed turn with no reasoning parts MUST clear the stale
+	// entry so it is not injected into the next turn.
+	acc2 := newAntigravityReasoningReplayAccumulator(scope, []byte(`{}`))
+	acc2.completed = true
+	acc2.Flush(ctx)
+	if _, ok := internalcache.GetAntigravityReasoningReplayItem(model, sessionKey); ok {
+		t.Fatal("completed empty turn must clear stale replay entry")
+	}
+}
+
+func TestAntigravityReasoningReplayObserveMarksCompletedOnFinishReason(t *testing.T) {
+	scope := antigravityReasoningReplayScope{modelName: "gemini-3-flash-agent", sessionKey: "execution:finish-reason"}
+	acc := newAntigravityReasoningReplayAccumulator(scope, []byte(`{}`))
+	acc.observeResponsePayload([]byte(`{"response":{"candidates":[{"finishReason":"STOP","content":{"parts":[]}}]}}`))
+	if !acc.completed {
+		t.Fatal("finishReason must mark the accumulator completed")
+	}
+}
 
 func TestAntigravityReasoningReplayClearsOnInvalidSignature400(t *testing.T) {
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
 	model := "gemini-3-flash-agent"
-	sessionKey := "session:pr3900-invalid-sig"
+	ctx := testContextWithAPIKey("antigravity-replay-caller")
+	sessionKey := helps.IsolateClientReasoningReplaySessionKey(ctx, "session:pr3900-invalid-sig")
 	bad := []byte(`{"type":"thought_signature","thoughtSignature":"INVALID_REPLAY_SIGNATURE_PR3900_XXXXXXXXX","contentIndex":1,"partIndex":0}`)
 	if !internalcache.CacheAntigravityReasoningReplayItems(model, sessionKey, [][]byte{bad}) {
 		t.Fatal("failed to seed replay cache")
@@ -48,7 +90,7 @@ func TestAntigravityReasoningReplayClearsOnInvalidSignature400(t *testing.T) {
 	}
 
 	payload := []byte(`{"sessionId":"pr3900-invalid-sig","request":{"contents":[{"role":"user","parts":[{"text":"hi"}]},{"role":"user","parts":[{"functionResponse":{"id":"id1","name":"Bash","response":{"result":"ok"}}}]}]}}`)
-	_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err := exec.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model:   model,
 		Payload: payload,
 	}, cliproxyexecutor.Options{

--- a/internal/runtime/executor/antigravity_reasoning_replay_test.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/tidwall/gjson"
 )
@@ -48,15 +49,17 @@ func TestPrepareAntigravityGeminiReasoningReplayPayloadInjectsCachedToolPart(t *
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
+	ctx := testContextWithAPIKey("antigravity-prepare-caller")
+	sessionKey := helps.IsolateClientReasoningReplaySessionKey(ctx, "session:sess-2")
 	item := []byte(`{"type":"function_call_part","contentIndex":1,"partIndex":0,"name":"Read","call_id":"id1","args":{"file_path":"/a"},"thoughtSignature":"sig-first"}`)
-	if !internalcache.CacheAntigravityReasoningReplayItems("gemini-3-flash-agent", "session:sess-2", [][]byte{item}) {
+	if !internalcache.CacheAntigravityReasoningReplayItems("gemini-3-flash-agent", sessionKey, [][]byte{item}) {
 		t.Fatal("cache write failed")
 	}
 
 	req := cliproxyexecutor.Request{}
 	opts := cliproxyexecutor.Options{}
 	payload := []byte(`{"sessionId":"sess-2","request":{"contents":[{"role":"user","parts":[{"text":"hi"}]},{"role":"user","parts":[{"functionResponse":{"id":"id1","name":"Read","response":{"result":"ok"}}}]}]}}`)
-	out, scope, err := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), "gemini-3-flash-agent", req, opts, payload)
+	out, scope, err := prepareAntigravityGeminiReasoningReplayPayload(ctx, "gemini-3-flash-agent", req, opts, payload)
 	if err != nil {
 		t.Fatalf("prepare error: %v", err)
 	}
@@ -81,11 +84,13 @@ func TestPrepareAntigravityGeminiReasoningReplayInsertsBeforeModelFunctionRespon
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
+	ctx := testContextWithAPIKey("antigravity-prepare-caller")
+	sessionKey := helps.IsolateClientReasoningReplaySessionKey(ctx, "session:sess-3")
 	item := []byte(`{"type":"function_call_part","contentIndex":1,"partIndex":0,"name":"Read","call_id":"id1","args":{"file_path":"/a"},"thoughtSignature":"sig-first"}`)
-	internalcache.CacheAntigravityReasoningReplayItems("gemini-3-flash-agent", "session:sess-3", [][]byte{item})
+	internalcache.CacheAntigravityReasoningReplayItems("gemini-3-flash-agent", sessionKey, [][]byte{item})
 
 	payload := []byte(`{"sessionId":"sess-3","request":{"contents":[{"role":"user","parts":[{"text":"hi"}]},{"role":"model","parts":[{"functionResponse":{"id":"id1","name":"Read","response":{"result":"ok"}}}]}]}}`)
-	out, _, err := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), "gemini-3-flash-agent", cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, payload)
+	out, _, err := prepareAntigravityGeminiReasoningReplayPayload(ctx, "gemini-3-flash-agent", cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, payload)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,11 +106,13 @@ func TestMergeAntigravityFunctionCallPartReplayMergesSignatureIntoExistingFuncti
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
+	ctx := testContextWithAPIKey("antigravity-prepare-caller")
+	sessionKey := helps.IsolateClientReasoningReplaySessionKey(ctx, "session:sess-merge")
 	item := []byte(`{"type":"function_call_part","contentIndex":1,"partIndex":0,"name":"Read","call_id":"id1","args":{"file_path":"/a"},"thoughtSignature":"sig-first"}`)
-	internalcache.CacheAntigravityReasoningReplayItems("gemini-3-flash-agent", "session:sess-merge", [][]byte{item})
+	internalcache.CacheAntigravityReasoningReplayItems("gemini-3-flash-agent", sessionKey, [][]byte{item})
 
 	payload := []byte(`{"sessionId":"sess-merge","request":{"contents":[{"role":"user","parts":[{"text":"hi"}]},{"role":"model","parts":[{"functionCall":{"id":"id1","name":"Read","args":{"file_path":"/a"}}}]},{"role":"user","parts":[{"functionResponse":{"id":"id1","name":"Read","response":{"result":"ok"}}}]}]}}`)
-	out, _, err := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), "gemini-3-flash-agent", cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, payload)
+	out, _, err := prepareAntigravityGeminiReasoningReplayPayload(ctx, "gemini-3-flash-agent", cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, payload)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,11 +125,13 @@ func TestPrepareAntigravityGeminiReasoningReplayPayloadAppendsStaleThoughtSignat
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
+	ctx := testContextWithAPIKey("antigravity-prepare-caller")
+	sessionKey := helps.IsolateClientReasoningReplaySessionKey(ctx, "session:sess-stale-text")
 	item := []byte(`{"type":"thought_signature","contentIndex":8,"partIndex":3,"thoughtSignature":"stale-thought-sig-ok12"}`)
-	internalcache.CacheAntigravityReasoningReplayItems("gemini-3-flash-agent", "session:sess-stale-text", [][]byte{item})
+	internalcache.CacheAntigravityReasoningReplayItems("gemini-3-flash-agent", sessionKey, [][]byte{item})
 
 	payload := []byte(`{"sessionId":"sess-stale-text","request":{"contents":[{"role":"user","parts":[{"text":"hi"}]},{"role":"model","parts":[{"text":"visible answer"}]},{"role":"user","parts":[{"text":"next"}]}]}}`)
-	out, _, err := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), "gemini-3-flash-agent", cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, payload)
+	out, _, err := prepareAntigravityGeminiReasoningReplayPayload(ctx, "gemini-3-flash-agent", cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, payload)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,5 +181,38 @@ func TestAntigravityRequestHasMatchingFunctionResponseWhitespaceCallID(t *testin
 	item := gjson.Parse(`{"call_id":" "}`)
 	if !antigravityRequestHasMatchingFunctionResponse(nil, item) {
 		t.Fatal("whitespace-only call_id should be treated as empty => true")
+	}
+}
+
+func TestAntigravityReasoningReplayScopeIsolatesClientSessionByAPIKey(t *testing.T) {
+	payload := []byte(`{"sessionId":"shared-session","request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`)
+	req := cliproxyexecutor.Request{Model: "gemini-3-flash-agent", Payload: payload}
+	opts := cliproxyexecutor.Options{}
+
+	scopeA := antigravityReasoningReplayScopeFromRequest(testContextWithAPIKey("api-key-a"), "gemini-3-flash-agent", req, opts, payload)
+	scopeB := antigravityReasoningReplayScopeFromRequest(testContextWithAPIKey("api-key-b"), "gemini-3-flash-agent", req, opts, payload)
+	if !scopeA.valid() || !scopeB.valid() {
+		t.Fatalf("scopes must be valid with caller api keys: A=%+v B=%+v", scopeA, scopeB)
+	}
+	if scopeA.sessionKey == scopeB.sessionKey {
+		t.Fatalf("session keys must differ across callers, both %q", scopeA.sessionKey)
+	}
+	if !strings.HasPrefix(scopeA.sessionKey, "caller:") || !strings.Contains(scopeA.sessionKey, "session:shared-session") {
+		t.Fatalf("session key A = %q, want caller-isolated session key", scopeA.sessionKey)
+	}
+
+	scopeNoKey := antigravityReasoningReplayScopeFromRequest(context.Background(), "gemini-3-flash-agent", req, opts, payload)
+	if scopeNoKey.valid() {
+		t.Fatalf("without caller API key must disable client-controlled replay: %+v", scopeNoKey)
+	}
+
+	executionScope := antigravityReasoningReplayScopeFromRequest(context.Background(), "gemini-3-flash-agent", cliproxyexecutor.Request{
+		Model: "gemini-3-flash-agent",
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: "trusted-session",
+		},
+	}, cliproxyexecutor.Options{}, []byte(`{}`))
+	if !executionScope.valid() || executionScope.sessionKey != "execution:trusted-session" {
+		t.Fatalf("trusted execution session = %+v, want execution:trusted-session", executionScope)
 	}
 }

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -283,7 +283,7 @@ func codexReasoningReplayScopeFromRequest(ctx context.Context, from sdktranslato
 	}
 	return codexReasoningReplayScope{
 		modelName:  thinking.ParseSuffix(req.Model).ModelName,
-		sessionKey: codexReasoningReplaySessionKey(ctx, from, req, opts, body),
+		sessionKey: helps.IsolateClientReasoningReplaySessionKey(ctx, codexReasoningReplaySessionKey(ctx, from, req, opts, body)),
 	}
 }
 
@@ -702,20 +702,39 @@ func cacheCodexReasoningReplayFromCompleted(scope codexReasoningReplayScope, com
 			continue
 		}
 	}
-	if !internalcache.CacheCodexReasoningReplayItemsBestEffort(context.Background(), scope.modelName, scope.sessionKey, items) {
-		internalcache.DeleteCodexReasoningReplayItem(scope.modelName, scope.sessionKey)
+	switch internalcache.StoreCodexReasoningReplayItems(context.Background(), scope.modelName, scope.sessionKey, items) {
+	case internalcache.CodexReasoningReplayStored:
+		return
+	case internalcache.CodexReasoningReplayNoReplayableState:
+		// Successful completed turn without cacheable reasoning must not leave
+		// a previous turn's encrypted state to be injected later.
+		if errDelete := internalcache.DeleteCodexReasoningReplayItemRequired(context.Background(), scope.modelName, scope.sessionKey); errDelete != nil {
+			log.Warnf("codex reasoning replay cache delete failed after non-replayable completed output: %v", errDelete)
+		}
+	case internalcache.CodexReasoningReplayStoreBackendError:
+		log.Debug("codex reasoning replay cache store backend error; retaining previous entry")
+	default:
+		// Invalid args: nothing to store or clear.
 	}
 }
 
-func clearCodexReasoningReplayOnInvalidSignature(ctx context.Context, scope codexReasoningReplayScope, statusCode int, body []byte) error {
+// clearCodexReasoningReplayOnInvalidSignature best-effort clears stale replay
+// state when upstream rejects encrypted thinking content. Delete failures are
+// logged and never replace the upstream status error.
+func clearCodexReasoningReplayOnInvalidSignature(ctx context.Context, scope codexReasoningReplayScope, statusCode int, body []byte) {
 	if !scope.valid() {
-		return nil
+		return
 	}
 	code, _, ok := codexStatusErrorClassification(statusCode, body)
-	if ok && code == "thinking_signature_invalid" {
-		return internalcache.DeleteCodexReasoningReplayItemRequired(ctx, scope.modelName, scope.sessionKey)
+	if !ok || code != "thinking_signature_invalid" {
+		return
 	}
-	return nil
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errDelete := internalcache.DeleteCodexReasoningReplayItemRequired(ctx, scope.modelName, scope.sessionKey); errDelete != nil {
+		log.Warnf("codex reasoning replay cache delete failed after invalid signature: %v", errDelete)
+	}
 }
 
 // PrepareRequest injects Codex credentials into the outgoing HTTP request.
@@ -846,9 +865,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		b, _ := io.ReadAll(httpResp.Body)
 		b = applyCodexIdentityConfuseResponsePayload(b, identityState)
-		if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, b); errClearReplay != nil {
-			return resp, errClearReplay
-		}
+		clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, b)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
 		err = newCodexStatusErr(httpResp.StatusCode, b)
@@ -874,9 +891,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		eventType := gjson.GetBytes(eventData, "type").String()
 
 		if streamErr, terminalBody, ok := codexTerminalStreamErr(eventData); ok {
-			if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {
-				return resp, errClearReplay
-			}
+			clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody)
 			err = streamErr
 			return resp, err
 		}
@@ -1134,9 +1149,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			return nil, readErr
 		}
 		data = applyCodexIdentityConfuseResponsePayload(data, identityState)
-		if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, data); errClearReplay != nil {
-			return nil, errClearReplay
-		}
+		clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, data)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
 		err = newCodexStatusErr(httpResp.StatusCode, data)
@@ -1163,15 +1176,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			if bytes.HasPrefix(line, dataTag) {
 				data := bytes.TrimSpace(line[5:])
 				if streamErr, terminalBody, ok := codexTerminalStreamErr(data); ok {
-					if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {
-						helps.RecordAPIResponseError(ctx, e.cfg, errClearReplay)
-						reporter.PublishFailure(ctx, errClearReplay)
-						select {
-						case out <- cliproxyexecutor.StreamChunk{Err: errClearReplay}:
-						case <-ctx.Done():
-						}
-						return
-					}
+					clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody)
 					helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
 					reporter.PublishFailure(ctx, streamErr)
 					select {

--- a/internal/runtime/executor/codex_executor_reasoning_replay_cache_test.go
+++ b/internal/runtime/executor/codex_executor_reasoning_replay_cache_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -79,7 +80,8 @@ func TestCodexExecutorReasoningReplayCacheStoresFinalDoneAndInjectsNextClaudeReq
 		Stream:       false,
 	}
 
-	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	ctx := codexReplayCallerContext()
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model:   "gpt-5.4",
 		Payload: []byte(`{"model":"gpt-5.4","metadata":{"user_id":"{\"device_id\":\"device-test\",\"account_uuid\":\"\",\"session_id\":\"session-1\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`),
 	}, opts)
@@ -87,7 +89,7 @@ func TestCodexExecutorReasoningReplayCacheStoresFinalDoneAndInjectsNextClaudeReq
 		t.Fatalf("first Execute error: %v", err)
 	}
 
-	_, err = executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err = executor.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model:   "gpt-5.4",
 		Payload: []byte(`{"model":"gpt-5.4","metadata":{"user_id":"{\"device_id\":\"device-test\",\"account_uuid\":\"\",\"session_id\":\"session-1\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"next"}]}]}`),
 	}, opts)
@@ -110,7 +112,7 @@ func TestCodexExecutorReasoningReplayCacheStoresFinalDoneAndInjectsNextClaudeReq
 	}
 }
 
-func TestCodexExecutorReasoningReplayCacheSharesSameSessionAcrossClientKeys(t *testing.T) {
+func TestCodexExecutorReasoningReplayCacheIsolatesSessionAcrossClientKeys(t *testing.T) {
 	internalcache.ClearCodexReasoningReplayCache()
 	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
 
@@ -127,17 +129,51 @@ func TestCodexExecutorReasoningReplayCacheSharesSameSessionAcrossClientKeys(t *t
 	if !firstScope.valid() {
 		t.Fatalf("first replay scope is invalid: %#v", firstScope)
 	}
+	if !strings.HasPrefix(firstScope.sessionKey, "caller:") || !strings.Contains(firstScope.sessionKey, "claude:session-only") {
+		t.Fatalf("session key = %q, want caller-isolated Claude session key", firstScope.sessionKey)
+	}
 	cacheCodexReasoningReplayFromCompleted(firstScope, []byte(`{"response":{"output":[{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+encryptedContent+`"}]}}`))
 
 	secondBody, secondScope := applyCodexReasoningReplayCache(codexReplaySessionOnlyContext("client-key-b"), from, req, opts, body)
-	if secondScope != firstScope {
-		t.Fatalf("replay scope should ignore client API key for the same session: first=%#v second=%#v", firstScope, secondScope)
+	if secondScope.sessionKey == firstScope.sessionKey {
+		t.Fatalf("replay scopes must differ across client API keys: both %#v", firstScope)
 	}
-	if got := gjson.GetBytes(secondBody, "input.0.type").String(); got != "reasoning" {
-		t.Fatalf("input.0.type = %q, want same-session replay; body=%s", got, string(secondBody))
+	if got := gjson.GetBytes(secondBody, "input.0.type").String(); got == "reasoning" {
+		t.Fatalf("client-key-b must not receive client-key-a replay; body=%s", string(secondBody))
 	}
-	if got := gjson.GetBytes(secondBody, "input.0.encrypted_content").String(); got != encryptedContent {
+
+	// Same caller can still read its own entry.
+	sameBody, sameScope := applyCodexReasoningReplayCache(codexReplaySessionOnlyContext("client-key-a"), from, req, opts, body)
+	if sameScope != firstScope {
+		t.Fatalf("same caller scope = %#v, want %#v", sameScope, firstScope)
+	}
+	if got := gjson.GetBytes(sameBody, "input.0.encrypted_content").String(); got != encryptedContent {
 		t.Fatalf("injected encrypted_content = %q, want cached value", got)
+	}
+
+	noKeyScope := codexReasoningReplayScopeFromRequest(context.Background(), from, req, opts, body)
+	if noKeyScope.valid() {
+		t.Fatalf("Claude without caller API key must disable replay: %#v", noKeyScope)
+	}
+}
+
+func TestCodexExecutorReasoningReplayScopeAllowsTrustedExecutionSessionWithoutAPIKey(t *testing.T) {
+	from := sdktranslator.FromString("claude")
+	payload := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello"}]}`)
+	scope := codexReasoningReplayScopeFromRequest(context.Background(), from, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: from,
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: "trusted-session",
+		},
+	}, payload)
+	if !scope.valid() {
+		t.Fatal("trusted execution session must remain replayable without caller API key")
+	}
+	if scope.sessionKey != "execution:trusted-session" {
+		t.Fatalf("session key = %q, want execution:trusted-session", scope.sessionKey)
 	}
 }
 
@@ -243,8 +279,9 @@ func TestCodexExecutorReasoningReplayCacheSharesSameSessionAcrossCodexAuths(t *t
 		SourceFormat: sdktranslator.FromString("claude"),
 		Stream:       false,
 	}
+	ctx := codexReplayCallerContext()
 
-	_, err := executor.Execute(context.Background(), firstAuth, cliproxyexecutor.Request{
+	_, err := executor.Execute(ctx, firstAuth, cliproxyexecutor.Request{
 		Model:   "gpt-5.4",
 		Payload: []byte(`{"model":"gpt-5.4","metadata":{"user_id":"{\"device_id\":\"device-test\",\"account_uuid\":\"\",\"session_id\":\"session-auth-switch\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`),
 	}, opts)
@@ -252,7 +289,7 @@ func TestCodexExecutorReasoningReplayCacheSharesSameSessionAcrossCodexAuths(t *t
 		t.Fatalf("first Execute error: %v", err)
 	}
 
-	_, err = executor.Execute(context.Background(), secondAuth, cliproxyexecutor.Request{
+	_, err = executor.Execute(ctx, secondAuth, cliproxyexecutor.Request{
 		Model:   "gpt-5.4",
 		Payload: []byte(`{"model":"gpt-5.4","metadata":{"user_id":"{\"device_id\":\"device-test\",\"account_uuid\":\"\",\"session_id\":\"session-auth-switch\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"next"}]}]}`),
 	}, opts)
@@ -272,6 +309,8 @@ func TestCodexExecutorReasoningReplayCacheSharesSameSessionAcrossCodexAuths(t *t
 	}
 }
 
+const codexReplayTestCallerAPIKey = "codex-replay-caller"
+
 func codexReplaySessionOnlyContext(apiKey string) context.Context {
 	recorder := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(recorder)
@@ -279,6 +318,14 @@ func codexReplaySessionOnlyContext(apiKey string) context.Context {
 	ginCtx.Set("accessProvider", "config-inline")
 	ginCtx.Request = httptest.NewRequest("POST", "/v1/messages", nil)
 	return context.WithValue(context.Background(), "gin", ginCtx)
+}
+
+func codexReplayCallerContext() context.Context {
+	return codexReplaySessionOnlyContext(codexReplayTestCallerAPIKey)
+}
+
+func codexIsolatedReplaySessionKey(apiKey, rawSessionKey string) string {
+	return helps.IsolateClientReasoningReplaySessionKey(codexReplaySessionOnlyContext(apiKey), rawSessionKey)
 }
 
 func TestCodexExecutorReasoningReplayCacheDoesNotInjectNativeResponsesRequest(t *testing.T) {
@@ -367,7 +414,8 @@ func TestCodexExecutorReasoningReplayCacheDoesNotDuplicateClaudeClientReasoning(
 
 	cachedEncryptedContent := validCodexReasoningEncryptedContentForTestSeed(5)
 	clientEncryptedContent := validCodexReasoningEncryptedContentForTestSeed(6)
-	internalcache.CacheCodexReasoningReplayItem("gpt-5.4", "claude:session-2", []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+cachedEncryptedContent+`"}`))
+	sessionKey := codexIsolatedReplaySessionKey(codexReplayTestCallerAPIKey, "claude:session-2")
+	internalcache.CacheCodexReasoningReplayItem("gpt-5.4", sessionKey, []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+cachedEncryptedContent+`"}`))
 
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -382,7 +430,7 @@ func TestCodexExecutorReasoningReplayCacheDoesNotDuplicateClaudeClientReasoning(
 	defer server.Close()
 
 	executor := NewCodexExecutor(&config.Config{})
-	_, err := executor.Execute(context.Background(), &cliproxyauth.Auth{
+	_, err := executor.Execute(codexReplayCallerContext(), &cliproxyauth.Auth{
 		ID: "auth-replay-2",
 		Attributes: map[string]string{
 			"base_url": server.URL,
@@ -418,7 +466,8 @@ func TestCodexExecutorReasoningReplayCacheInsertsReasoningBeforeAssistantOutputI
 	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
 
 	cachedEncryptedContent := validCodexReasoningEncryptedContentForTestSeed(7)
-	internalcache.CacheCodexReasoningReplayItem("gpt-5.4", "claude:session-history", []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+cachedEncryptedContent+`"}`))
+	sessionKey := codexIsolatedReplaySessionKey(codexReplayTestCallerAPIKey, "claude:session-history")
+	internalcache.CacheCodexReasoningReplayItem("gpt-5.4", sessionKey, []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+cachedEncryptedContent+`"}`))
 
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -433,7 +482,7 @@ func TestCodexExecutorReasoningReplayCacheInsertsReasoningBeforeAssistantOutputI
 	defer server.Close()
 
 	executor := NewCodexExecutor(&config.Config{})
-	_, err := executor.Execute(context.Background(), &cliproxyauth.Auth{
+	_, err := executor.Execute(codexReplayCallerContext(), &cliproxyauth.Auth{
 		ID: "auth-replay-history",
 		Attributes: map[string]string{
 			"base_url": server.URL,
@@ -505,7 +554,8 @@ func TestCodexExecutorReasoningReplayCacheExecuteStreamStoresFinalDoneForClaude(
 		},
 	}
 
-	streamResult, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+	ctx := codexReplayCallerContext()
+	streamResult, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
 		Model:   "gpt-5.4",
 		Payload: []byte(`{"model":"gpt-5.4","metadata":{"user_id":"{\"device_id\":\"device-test\",\"account_uuid\":\"\",\"session_id\":\"stream-session-1\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`),
 	}, cliproxyexecutor.Options{
@@ -521,7 +571,7 @@ func TestCodexExecutorReasoningReplayCacheExecuteStreamStoresFinalDoneForClaude(
 		}
 	}
 
-	_, err = executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err = executor.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model:   "gpt-5.4",
 		Payload: []byte(`{"model":"gpt-5.4","metadata":{"user_id":"{\"device_id\":\"device-test\",\"account_uuid\":\"\",\"session_id\":\"stream-session-1\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"next"}]}]}`),
 	}, cliproxyexecutor.Options{
@@ -546,7 +596,8 @@ func TestCodexExecutorReasoningReplayCacheClearsOnNonStreamResponseFailedInvalid
 	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
 
 	cachedEncryptedContent := validCodexReasoningEncryptedContentForTestSeed(9)
-	internalcache.CacheCodexReasoningReplayItem("gpt-5.4", "claude:session-invalid-nonstream", []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+cachedEncryptedContent+`"}`))
+	sessionKey := codexIsolatedReplaySessionKey(codexReplayTestCallerAPIKey, "claude:session-invalid-nonstream")
+	internalcache.CacheCodexReasoningReplayItem("gpt-5.4", sessionKey, []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+cachedEncryptedContent+`"}`))
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.ReadAll(r.Body)
@@ -556,7 +607,7 @@ func TestCodexExecutorReasoningReplayCacheClearsOnNonStreamResponseFailedInvalid
 	defer server.Close()
 
 	executor := NewCodexExecutor(&config.Config{})
-	_, err := executor.Execute(context.Background(), &cliproxyauth.Auth{
+	_, err := executor.Execute(codexReplayCallerContext(), &cliproxyauth.Auth{
 		ID: "auth-replay-invalid-nonstream",
 		Attributes: map[string]string{
 			"base_url": server.URL,
@@ -572,7 +623,7 @@ func TestCodexExecutorReasoningReplayCacheClearsOnNonStreamResponseFailedInvalid
 	if err == nil {
 		t.Fatal("expected invalid signature error")
 	}
-	if _, ok := internalcache.GetCodexReasoningReplayItem("gpt-5.4", "claude:session-invalid-nonstream"); ok {
+	if _, ok := internalcache.GetCodexReasoningReplayItem("gpt-5.4", sessionKey); ok {
 		t.Fatal("invalid signature response.failed should clear cached replay item")
 	}
 }
@@ -582,7 +633,8 @@ func TestCodexExecutorReasoningReplayCacheClearsOnStreamResponseFailedInvalidSig
 	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
 
 	cachedEncryptedContent := validCodexReasoningEncryptedContentForTestSeed(10)
-	internalcache.CacheCodexReasoningReplayItem("gpt-5.4", "claude:session-invalid-stream", []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+cachedEncryptedContent+`"}`))
+	sessionKey := codexIsolatedReplaySessionKey(codexReplayTestCallerAPIKey, "claude:session-invalid-stream")
+	internalcache.CacheCodexReasoningReplayItem("gpt-5.4", sessionKey, []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+cachedEncryptedContent+`"}`))
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.ReadAll(r.Body)
@@ -592,7 +644,7 @@ func TestCodexExecutorReasoningReplayCacheClearsOnStreamResponseFailedInvalidSig
 	defer server.Close()
 
 	executor := NewCodexExecutor(&config.Config{})
-	streamResult, err := executor.ExecuteStream(context.Background(), &cliproxyauth.Auth{
+	streamResult, err := executor.ExecuteStream(codexReplayCallerContext(), &cliproxyauth.Auth{
 		ID: "auth-replay-invalid-stream",
 		Attributes: map[string]string{
 			"base_url": server.URL,
@@ -618,7 +670,7 @@ func TestCodexExecutorReasoningReplayCacheClearsOnStreamResponseFailedInvalidSig
 	if !gotChunkErr {
 		t.Fatal("expected stream chunk error for invalid signature response.failed")
 	}
-	if _, ok := internalcache.GetCodexReasoningReplayItem("gpt-5.4", "claude:session-invalid-stream"); ok {
+	if _, ok := internalcache.GetCodexReasoningReplayItem("gpt-5.4", sessionKey); ok {
 		t.Fatal("invalid signature response.failed should clear cached replay item")
 	}
 }
@@ -656,8 +708,9 @@ func TestCodexExecutorReasoningReplayCacheReplaysFunctionCallForClaudeToolResult
 		SourceFormat: sdktranslator.FromString("claude"),
 		Stream:       false,
 	}
+	ctx := codexReplayCallerContext()
 
-	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model: "gpt-5.4",
 		Payload: []byte(`{
 			"model":"gpt-5.4",
@@ -670,7 +723,7 @@ func TestCodexExecutorReasoningReplayCacheReplaysFunctionCallForClaudeToolResult
 		t.Fatalf("first Execute error: %v", err)
 	}
 
-	_, err = executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err = executor.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model: "gpt-5.4",
 		Payload: []byte(`{
 			"model":"gpt-5.4",
@@ -717,7 +770,7 @@ func TestCodexExecutorReasoningReplayCacheDropsFunctionCallWithoutMatchingOutput
 	encryptedContent := validCodexReasoningEncryptedContentForTestSeed(14)
 	scope := codexReasoningReplayScope{
 		modelName:  "gpt-5.4",
-		sessionKey: "claude:session-dropped-tool",
+		sessionKey: codexIsolatedReplaySessionKey(codexReplayTestCallerAPIKey, "claude:session-dropped-tool"),
 	}
 	cacheCodexReasoningReplayFromCompleted(scope, []byte(`{"response":{"output":[`+
 		`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+encryptedContent+`"},`+
@@ -735,7 +788,7 @@ func TestCodexExecutorReasoningReplayCacheDropsFunctionCallWithoutMatchingOutput
 	}
 
 	updated, replayScope := applyCodexReasoningReplayCache(
-		context.Background(),
+		codexReplayCallerContext(),
 		sdktranslator.FromString("claude"),
 		req,
 		cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")},
@@ -796,8 +849,9 @@ func TestCodexExecutorReasoningReplayCacheMatchesShortenedClaudeToolResultCallID
 		SourceFormat: sdktranslator.FromString("claude"),
 		Stream:       false,
 	}
+	ctx := codexReplayCallerContext()
 
-	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model: "gpt-5.4",
 		Payload: []byte(`{
 			"model":"gpt-5.4",
@@ -810,7 +864,7 @@ func TestCodexExecutorReasoningReplayCacheMatchesShortenedClaudeToolResultCallID
 		t.Fatalf("first Execute error: %v", err)
 	}
 
-	_, err = executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err = executor.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model: "gpt-5.4",
 		Payload: []byte(`{
 			"model":"gpt-5.4",

--- a/internal/runtime/executor/helps/reasoning_replay_isolate.go
+++ b/internal/runtime/executor/helps/reasoning_replay_isolate.go
@@ -1,0 +1,62 @@
+package helps
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AccessProviderFromContext returns the frontend access provider name stored by
+// AuthMiddleware (gin key "accessProvider").
+func AccessProviderFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	ginCtx, ok := ctx.Value("gin").(*gin.Context)
+	if !ok || ginCtx == nil {
+		return ""
+	}
+	if v, exists := ginCtx.Get("accessProvider"); exists {
+		switch value := v.(type) {
+		case string:
+			return strings.TrimSpace(value)
+		case fmt.Stringer:
+			return strings.TrimSpace(value.String())
+		default:
+			return strings.TrimSpace(fmt.Sprintf("%v", value))
+		}
+	}
+	return ""
+}
+
+// IsolateClientReasoningReplaySessionKey namespaces client-controlled session
+// keys by the downstream access provider and principal so two callers cannot
+// share encrypted reasoning by reusing prompt_cache_key / window / session
+// headers across auth realms. Trusted execution session keys keep their
+// existing form. Client-controlled sessions without a caller principal are
+// disabled rather than shared globally.
+func IsolateClientReasoningReplaySessionKey(ctx context.Context, sessionKey string) string {
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return ""
+	}
+	if strings.HasPrefix(sessionKey, "execution:") {
+		return sessionKey
+	}
+	// Hash the provider-issued principal as an opaque value: AuthMiddleware stores
+	// principals verbatim, so two distinct principals that differ only in
+	// surrounding whitespace (e.g. "alice" vs " alice ") must not be trimmed into
+	// the same replay namespace. Only a truly empty principal counts as missing.
+	principal := APIKeyFromContext(ctx)
+	if principal == "" {
+		return ""
+	}
+	provider := AccessProviderFromContext(ctx)
+	material := provider + "\x00" + principal
+	sum := sha256.Sum256([]byte(material))
+	return "caller:" + hex.EncodeToString(sum[:8]) + ":" + sessionKey
+}

--- a/internal/runtime/executor/helps/reasoning_replay_isolate_test.go
+++ b/internal/runtime/executor/helps/reasoning_replay_isolate_test.go
@@ -1,0 +1,82 @@
+package helps
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func testGinContextWithCaller(principal, provider string) context.Context {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	if principal != "" {
+		ginCtx.Set("userApiKey", principal)
+	}
+	if provider != "" {
+		ginCtx.Set("accessProvider", provider)
+	}
+	return context.WithValue(context.Background(), "gin", ginCtx)
+}
+
+func TestIsolateClientReasoningReplaySessionKeyIncludesProvider(t *testing.T) {
+	raw := "claude:shared-session"
+	keyA := IsolateClientReasoningReplaySessionKey(testGinContextWithCaller("same-principal", "provider-a"), raw)
+	keyB := IsolateClientReasoningReplaySessionKey(testGinContextWithCaller("same-principal", "provider-b"), raw)
+	if keyA == "" || keyB == "" {
+		t.Fatalf("expected isolated keys, got A=%q B=%q", keyA, keyB)
+	}
+	if keyA == keyB {
+		t.Fatalf("same principal different provider must not share keys: %q", keyA)
+	}
+	if !strings.HasPrefix(keyA, "caller:") || !strings.Contains(keyA, raw) {
+		t.Fatalf("keyA = %q, want caller-isolated form", keyA)
+	}
+
+	keyA2 := IsolateClientReasoningReplaySessionKey(testGinContextWithCaller("same-principal", "provider-a"), raw)
+	if keyA != keyA2 {
+		t.Fatalf("same principal+provider must be stable: %q vs %q", keyA, keyA2)
+	}
+}
+
+func TestIsolateClientReasoningReplaySessionKeyPreservesOpaquePrincipals(t *testing.T) {
+	raw := "prompt-cache:shared"
+	// Principals that differ only in surrounding whitespace are distinct subjects
+	// (AuthMiddleware stores them verbatim) and must not share a replay namespace.
+	keyA := IsolateClientReasoningReplaySessionKey(testGinContextWithCaller("alice", "provider-a"), raw)
+	keyB := IsolateClientReasoningReplaySessionKey(testGinContextWithCaller(" alice ", "provider-a"), raw)
+	if keyA == "" || keyB == "" {
+		t.Fatalf("expected isolated keys, got A=%q B=%q", keyA, keyB)
+	}
+	if keyA == keyB {
+		t.Fatalf("whitespace-distinct principals must not share a replay namespace: %q", keyA)
+	}
+}
+
+func TestIsolateClientReasoningReplaySessionKeyRequiresPrincipal(t *testing.T) {
+	if got := IsolateClientReasoningReplaySessionKey(context.Background(), "claude:session"); got != "" {
+		t.Fatalf("without principal got %q, want empty", got)
+	}
+	if got := IsolateClientReasoningReplaySessionKey(testGinContextWithCaller("", "provider-a"), "claude:session"); got != "" {
+		t.Fatalf("empty principal got %q, want empty", got)
+	}
+}
+
+func TestIsolateClientReasoningReplaySessionKeyAllowsExecutionWithoutPrincipal(t *testing.T) {
+	got := IsolateClientReasoningReplaySessionKey(context.Background(), "execution:trusted")
+	if got != "execution:trusted" {
+		t.Fatalf("execution key = %q, want execution:trusted", got)
+	}
+}
+
+func TestAccessProviderFromContext(t *testing.T) {
+	if got := AccessProviderFromContext(testGinContextWithCaller("p", "config-inline")); got != "config-inline" {
+		t.Fatalf("provider = %q, want config-inline", got)
+	}
+	if got := AccessProviderFromContext(context.Background()); got != "" {
+		t.Fatalf("empty context provider = %q, want empty", got)
+	}
+}

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -169,6 +169,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 			helps.RecordAPIResponseError(ctx, e.cfg, errRead)
 			return resp, errRead
 		}
+		clearXAIReasoningReplayOnInvalidEncryptedContent(ctx, prepared.replayScope, httpResp.StatusCode, data)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
 		return resp, xaiStatusErr(httpResp.StatusCode, data)
@@ -191,6 +192,11 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		switch gjson.GetBytes(eventData, "type").String() {
 		case "response.output_item.done":
 			xaiCollectOutputItemDone(eventData, outputItemsByIndex, &outputItemsFallback)
+		case "error", "response.failed":
+			if status, body, ok := xaiSSETerminalFailure(eventData); ok {
+				clearXAIReasoningReplayOnInvalidEncryptedContent(ctx, prepared.replayScope, status, body)
+				return resp, xaiStatusErr(status, body)
+			}
 		case "response.completed":
 			if detail, ok := helps.ParseCodexUsage(eventData); ok {
 				reporter.Publish(ctx, detail)
@@ -265,6 +271,7 @@ func (e *XAIExecutor) executeCompactRequest(ctx context.Context, auth *cliproxya
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		clearXAIReasoningReplayOnInvalidEncryptedContent(ctx, prepared.replayScope, httpResp.StatusCode, data)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
 		err = xaiStatusErr(httpResp.StatusCode, data)
 		return nil, nil, nil, err
@@ -626,6 +633,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 			helps.RecordAPIResponseError(ctx, e.cfg, errRead)
 			return nil, errRead
 		}
+		clearXAIReasoningReplayOnInvalidEncryptedContent(ctx, prepared.replayScope, httpResp.StatusCode, data)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
 		return nil, xaiStatusErr(httpResp.StatusCode, data)
@@ -676,6 +684,18 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 					switch normalizedEventName {
 					case "response.output_item.done":
 						xaiCollectOutputItemDone(eventData, outputItemsByIndex, &outputItemsFallback)
+					case "error", "response.failed":
+						if status, body, okFail := xaiSSETerminalFailure(eventData); okFail {
+							clearXAIReasoningReplayOnInvalidEncryptedContent(ctx, prepared.replayScope, status, body)
+							streamErr := xaiStatusErr(status, body)
+							helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+							reporter.PublishFailure(ctx, streamErr)
+							select {
+							case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+							case <-ctx.Done():
+							}
+							return
+						}
 					case "response.completed":
 						if detail, ok := helps.ParseCodexUsage(eventData); ok {
 							reporter.Publish(ctx, detail)

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -17,6 +17,7 @@ import (
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -1952,6 +1953,549 @@ func TestXAIReasoningReplayScopeDisablesClaudeWithoutAPIKey(t *testing.T) {
 	}
 	if !strings.HasPrefix(scopeWithKey.sessionKey, "caller:") || !strings.Contains(scopeWithKey.sessionKey, "claude:shared-session") {
 		t.Fatalf("session key = %q, want caller-isolated Claude session key", scopeWithKey.sessionKey)
+	}
+}
+
+func TestXAIReasoningReplayClearsOnInvalidEncryptedContent(t *testing.T) {
+	internalcache.ClearXAIReasoningReplayCache()
+	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)
+
+	encrypted := testValidGrokEncryptedContentForSeed(50)
+	sessionKey := helps.IsolateClientReasoningReplaySessionKey(testContextWithAPIKey("xai-invalid-caller"), "prompt-cache:invalid-session")
+	if sessionKey == "" {
+		t.Fatal("expected isolated session key")
+	}
+	if !internalcache.CacheXAIReasoningReplayItem("grok-4.3", sessionKey, []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+encrypted+`"}`)) {
+		t.Fatal("failed to seed replay cache")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid_encrypted_content","type":"invalid_request_error"}}`))
+	}))
+	defer server.Close()
+
+	executor := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-xai-invalid-encrypted",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+	}
+	ctx := testContextWithAPIKey("xai-invalid-caller")
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "grok-4.3",
+		Payload: []byte(`{"model":"grok-4.3","prompt_cache_key":"invalid-session","input":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Stream: false})
+	if err == nil {
+		t.Fatal("expected upstream 400 error")
+	}
+	if _, ok := internalcache.GetXAIReasoningReplayItem("grok-4.3", sessionKey); ok {
+		t.Fatal("invalid encrypted content response should clear cached replay item")
+	}
+}
+
+func TestXAIReasoningReplayClearsOnInvalidEncryptedContentCompact(t *testing.T) {
+	internalcache.ClearXAIReasoningReplayCache()
+	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)
+
+	encrypted := testValidGrokEncryptedContentForSeed(51)
+	sessionKey := helps.IsolateClientReasoningReplaySessionKey(testContextWithAPIKey("xai-invalid-compact-caller"), "prompt-cache:invalid-compact")
+	if sessionKey == "" {
+		t.Fatal("expected isolated session key")
+	}
+	if !internalcache.CacheXAIReasoningReplayItem("grok-4.3", sessionKey, []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+encrypted+`"}`)) {
+		t.Fatal("failed to seed replay cache")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		if !strings.HasSuffix(r.URL.Path, "/responses/compact") {
+			t.Fatalf("unexpected path %q, want /responses/compact", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid_encrypted_content","type":"invalid_request_error"}}`))
+	}))
+	defer server.Close()
+
+	executor := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-xai-invalid-encrypted-compact",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+	}
+	ctx := testContextWithAPIKey("xai-invalid-compact-caller")
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "grok-4.3",
+		Payload: []byte(`{"model":"grok-4.3","prompt_cache_key":"invalid-compact","input":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+		Alt:          "responses/compact",
+	})
+	if err == nil {
+		t.Fatal("expected upstream compact 400 error")
+	}
+	if _, ok := internalcache.GetXAIReasoningReplayItem("grok-4.3", sessionKey); ok {
+		t.Fatal("invalid encrypted content compact response should clear cached replay item")
+	}
+}
+
+func TestXAIReasoningReplayClearsOnTopLevelSSEError(t *testing.T) {
+	internalcache.ClearXAIReasoningReplayCache()
+	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)
+
+	encrypted := testValidGrokEncryptedContentForSeed(54)
+	sessionKey := helps.IsolateClientReasoningReplaySessionKey(testContextWithAPIKey("xai-top-level-error-caller"), "prompt-cache:top-level-error")
+	if !internalcache.CacheXAIReasoningReplayItem("grok-4.3", sessionKey, []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+encrypted+`"}`)) {
+		t.Fatal("failed to seed replay cache")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Standard Responses SSE shape: top-level code/message, no nested error object.
+		_, _ = w.Write([]byte(`data: {"type":"error","code":"invalid_encrypted_content","message":"encrypted content rejected"}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-xai-top-level-error",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+	}
+	ctx := testContextWithAPIKey("xai-top-level-error-caller")
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "grok-4.3",
+		Payload: []byte(`{"model":"grok-4.3","prompt_cache_key":"top-level-error","input":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Stream: false})
+	if err == nil {
+		t.Fatal("expected top-level SSE error")
+	}
+	if _, ok := internalcache.GetXAIReasoningReplayItem("grok-4.3", sessionKey); ok {
+		t.Fatal("top-level invalid_encrypted_content error should clear cached replay item")
+	}
+}
+
+func TestXAIStatusFromErrorSemantics(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{name: "free usage", body: `{"error":{"code":"subscription:free-usage-exhausted"}}`, want: http.StatusTooManyRequests},
+		{name: "rate limit", body: `{"error":{"type":"rate_limit_exceeded"}}`, want: http.StatusTooManyRequests},
+		{name: "server error", body: `{"error":{"type":"server_error"}}`, want: http.StatusInternalServerError},
+		{name: "overloaded", body: `{"error":{"type":"overloaded"}}`, want: http.StatusServiceUnavailable},
+		{name: "account deactivated is auth", body: `{"error":{"code":"account_deactivated"}}`, want: http.StatusUnauthorized},
+		// Free-form message text must never synthesize a quota/rate cooldown.
+		{name: "message-only quota not classified", body: `{"error":{"message":"you still have included free usage; watch the rate limit"}}`, want: 0},
+		{name: "invalid encrypted", body: `{"error":{"code":"invalid_encrypted_content"}}`, want: http.StatusBadRequest},
+		{name: "invalid api key", body: `{"error":{"code":"invalid_api_key"}}`, want: http.StatusUnauthorized},
+		{name: "authentication error", body: `{"error":{"type":"authentication_error"}}`, want: http.StatusUnauthorized},
+		{name: "insufficient quota", body: `{"error":{"code":"insufficient_quota"}}`, want: http.StatusTooManyRequests},
+		// Structured type must win over a message that echoes "rate limit".
+		{name: "invalid_request type beats message", body: `{"error":{"type":"invalid_request_error","message":"your prompt mentioned rate limit"}}`, want: http.StatusBadRequest},
+		{name: "context length exceeded code", body: `{"error":{"code":"context_length_exceeded"}}`, want: http.StatusBadRequest},
+		{name: "request validation error message", body: `{"error":{"message":"Request validation error: bad field"}}`, want: http.StatusBadRequest},
+		// A specific quota/rate code must win over a generic invalid_request type.
+		{name: "rate_limit code beats invalid_request type", body: `{"error":{"code":"rate_limit_exceeded","type":"invalid_request_error"}}`, want: http.StatusTooManyRequests},
+		{name: "free usage code beats invalid_request type", body: `{"error":{"code":"subscription:free-usage-exhausted","type":"invalid_request_error"}}`, want: http.StatusTooManyRequests},
+		{name: "unknown", body: `{"error":{"message":"something else"}}`, want: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := xaiStatusFromErrorSemantics([]byte(tc.body)); got != tc.want {
+				t.Fatalf("status = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestXAISSETerminalFailureStatus(t *testing.T) {
+	cases := []struct {
+		name  string
+		event string
+		want  int
+	}{
+		{
+			// Model/caller text inside response.output must NOT drive the status:
+			// the error object is generic, so this falls to the 500 default.
+			name:  "content does not leak into status",
+			event: `{"type":"response.failed","response":{"error":{"message":"aborted"},"output":[{"type":"message","content":[{"type":"output_text","text":"explaining rate limit and too many requests"}]}]}}`,
+			want:  http.StatusInternalServerError,
+		},
+		{
+			name:  "statusless unknown defaults to 500",
+			event: `{"type":"error","error":{"message":"connection reset by peer"}}`,
+			want:  http.StatusInternalServerError,
+		},
+		{
+			name:  "bare error event defaults to 500",
+			event: `{"type":"error"}`,
+			want:  http.StatusInternalServerError,
+		},
+		{
+			name:  "top-level invalid_api_key maps to 401",
+			event: `{"type":"error","code":"invalid_api_key","message":"bad key"}`,
+			want:  http.StatusUnauthorized,
+		},
+		{
+			name:  "top-level insufficient_quota maps to 429",
+			event: `{"type":"error","code":"insufficient_quota","message":"no credits"}`,
+			want:  http.StatusTooManyRequests,
+		},
+		{
+			// Type-only nested error object must be preserved and classified.
+			name:  "type-only nested error maps to 429",
+			event: `{"type":"error","error":{"type":"rate_limit_exceeded"}}`,
+			want:  http.StatusTooManyRequests,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, _, ok := xaiSSETerminalFailure([]byte(tc.event))
+			if !ok {
+				t.Fatalf("xaiSSETerminalFailure(%s) not recognized as terminal", tc.event)
+			}
+			if status != tc.want {
+				t.Fatalf("status = %d, want %d", status, tc.want)
+			}
+		})
+	}
+}
+
+func TestXAISSETerminalFailureTagsInvalidRequestType(t *testing.T) {
+	// A code-only client error (no explicit type) must be tagged
+	// invalid_request_error so the conductor treats the 400 as request-scoped.
+	status, body, ok := xaiSSETerminalFailure([]byte(`{"type":"error","code":"context_length_exceeded","message":"too long"}`))
+	if !ok {
+		t.Fatal("expected terminal failure")
+	}
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+	if got := gjson.GetBytes(body, "error.type").String(); got != "invalid_request_error" {
+		t.Fatalf("error.type = %q, want invalid_request_error", got)
+	}
+}
+
+func TestParseXAIWebsocketErrorPreservesFlatCodeInCodexEnvelope(t *testing.T) {
+	// type+status makes parseCodexWebsocketError match; the flat code/message must
+	// still survive and the 400 must be canonicalized so it is not retried.
+	payload := []byte(`{"type":"error","status":400,"code":"invalid_encrypted_content","message":"rejected thinking"}`)
+	err, ok := parseXAIWebsocketError(payload)
+	if !ok {
+		t.Fatal("expected terminal websocket error")
+	}
+	body := err.Error()
+	if !strings.Contains(body, "invalid_encrypted_content") {
+		t.Fatalf("flat code lost from error body: %s", body)
+	}
+	if got := gjson.Get(body, "error.type").String(); got != "invalid_request_error" {
+		t.Fatalf("error.type = %q, want invalid_request_error (canonicalized)", got)
+	}
+}
+
+func TestParseXAIWebsocketBareErrorCanonicalizes400(t *testing.T) {
+	payload := []byte(`{"error":{"code":"invalid_encrypted_content"}}`)
+	err, ok := parseXAIWebsocketError(payload)
+	if !ok {
+		t.Fatal("expected terminal websocket error")
+	}
+	if got := gjson.Get(err.Error(), "error.type").String(); got != "invalid_request_error" {
+		t.Fatalf("bare 400 error.type = %q, want invalid_request_error", got)
+	}
+}
+
+func TestXAISSETerminalFailureRejectsSuccessStatus(t *testing.T) {
+	// A response.failed carrying an SSE transport status of 200 must not become a
+	// 200; it falls through to semantic classification (server_error -> 500).
+	status, _, ok := xaiSSETerminalFailure([]byte(`{"type":"response.failed","status":200,"response":{"error":{"code":"server_error"}}}`))
+	if !ok {
+		t.Fatal("expected terminal failure")
+	}
+	if status != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (200 rejected, classified from server_error)", status)
+	}
+}
+
+func TestXAIBareWebsocketErrorClassifiesInvalidEncrypted(t *testing.T) {
+	// A bare error with no top-level type/status must still be classified 400 from
+	// its structured code, so parseXAIWebsocketError yields a 4xx that clears replay.
+	payload := []byte(`{"error":{"code":"invalid_encrypted_content"}}`)
+	wsErr, ok := parseXAIWebsocketError(payload)
+	if !ok {
+		t.Fatal("expected terminal websocket error")
+	}
+	if got := xaiErrorStatusCode(wsErr, payload); got != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (so replay is cleared)", got)
+	}
+}
+
+func TestXAINestedStatusRejectsNonHTTPCodes(t *testing.T) {
+	// Application error codes (e.g. 1001) and 2xx/3xx values must not be treated as
+	// HTTP statuses.
+	if got := xaiNestedExplicitWebsocketStatus([]byte(`{"response":{"error":{"code":1001}}}`)); got != 0 {
+		t.Fatalf("app code 1001 = %d, want 0 (ignored)", got)
+	}
+	if got := xaiNestedExplicitWebsocketStatus([]byte(`{"error":{"code":200}}`)); got != 0 {
+		t.Fatalf("2xx code = %d, want 0 (ignored)", got)
+	}
+	if got := xaiNestedExplicitWebsocketStatus([]byte(`{"error":{"code":429}}`)); got != 429 {
+		t.Fatalf("valid 429 = %d, want 429", got)
+	}
+}
+
+func TestXAIMixedShapeErrorMergesFlatCode(t *testing.T) {
+	// An event that combines a nested error value with a flat structured code must
+	// be classified from both: the flat code drives status and replay cleanup.
+	event := []byte(`{"type":"error","code":"insufficient_quota","error":"rejected"}`)
+	if got := gjson.GetBytes(xaiWebsocketErrorObject(event), "error.code").String(); got != "insufficient_quota" {
+		t.Fatalf("merged error.code = %q, want insufficient_quota", got)
+	}
+	status, _, ok := xaiSSETerminalFailure(event)
+	if !ok {
+		t.Fatal("expected terminal failure")
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 from flat insufficient_quota code", status)
+	}
+	// Flat invalid-encrypted code alongside a nested error value must still be
+	// visible for the replay-clear gate.
+	obj := xaiWebsocketErrorObject([]byte(`{"type":"error","status":400,"code":"invalid_encrypted_content","error":"rejected"}`))
+	if !xaiBodyIndicatesInvalidEncryptedContent(obj) {
+		t.Fatalf("merged body %q should indicate invalid encrypted content", obj)
+	}
+}
+
+func TestXAISSETerminalFailureCanonicalizesRequestType(t *testing.T) {
+	// A non-canonical request type must be canonicalized to invalid_request_error
+	// (so isRequestInvalidError recognizes it) while preserving the original as code.
+	status, body, ok := xaiSSETerminalFailure([]byte(`{"type":"error","error":{"type":"invalid_prompt","message":"bad prompt"}}`))
+	if !ok || status != http.StatusBadRequest {
+		t.Fatalf("status=%d ok=%v, want 400/true", status, ok)
+	}
+	if got := gjson.GetBytes(body, "error.type").String(); got != "invalid_request_error" {
+		t.Fatalf("error.type = %q, want invalid_request_error", got)
+	}
+	if got := gjson.GetBytes(body, "error.code").String(); got != "invalid_prompt" {
+		t.Fatalf("error.code = %q, want invalid_prompt (original preserved)", got)
+	}
+}
+
+func TestXAIErrorStatusCodeServerErrorNotDowngradedByContent(t *testing.T) {
+	// End-to-end: a server_error code whose message echoes invalid_encrypted_content
+	// must remain 500 through parseXAIWebsocketError + xaiErrorStatusCode, so the
+	// replay clear gate (4xx only) does not evict valid state for a server failure.
+	payload := []byte(`{"type":"error","error":{"code":"server_error","message":"internal failure: invalid_encrypted_content observed"}}`)
+	wsErr, ok := parseXAIWebsocketError(payload)
+	if !ok {
+		t.Fatal("expected terminal websocket error")
+	}
+	if got := xaiErrorStatusCode(wsErr, payload); got != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (not downgraded to 400 by message content)", got)
+	}
+}
+
+func TestXAIErrorStatusCodeHonorsResponseErrorStatus(t *testing.T) {
+	payload := []byte(`{"type":"response.failed","response":{"error":{"message":"invalid_encrypted_content","status":500}}}`)
+	if got := xaiErrorStatusCode(statusErr{code: 500, msg: "x"}, payload); got != 500 {
+		t.Fatalf("status = %d, want 500 from response.error.status", got)
+	}
+	// Explicit 5xx must not clear replay despite invalid-encrypted text.
+	scope := xaiReasoningReplayScope{modelName: "grok-4.3", sessionKey: "execution:nested-5xx"}
+	encrypted := testValidGrokEncryptedContentForSeed(55)
+	if !internalcache.CacheXAIReasoningReplayItem(scope.modelName, scope.sessionKey, []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+encrypted+`"}`)) {
+		t.Fatal("failed to seed cache")
+	}
+	clearXAIReasoningReplayOnInvalidEncryptedContent(context.Background(), scope, 500, payload)
+	if _, ok := internalcache.GetXAIReasoningReplayItem(scope.modelName, scope.sessionKey); !ok {
+		t.Fatal("explicit 5xx must not clear replay cache")
+	}
+	internalcache.DeleteXAIReasoningReplayItem(scope.modelName, scope.sessionKey)
+}
+
+func TestXAIErrorStatusCodeIgnoresContentInvalidEncrypted(t *testing.T) {
+	// A statusless response.failed whose error object is generic but whose
+	// response.output echoes "invalid_encrypted_content" must NOT be classified
+	// 400 (which would evict valid replay); only the structured error object may
+	// drive classification.
+	payload := []byte(`{"type":"response.failed","response":{"error":{"message":"aborted"},"output":[{"type":"message","content":[{"type":"output_text","text":"the phrase invalid_encrypted_content appears here"}]}]}}`)
+	wsErr, ok := parseXAIWebsocketError(payload)
+	if !ok {
+		t.Fatal("expected terminal websocket error")
+	}
+	if got := xaiErrorStatusCode(wsErr, payload); got == http.StatusBadRequest {
+		t.Fatalf("status = 400 driven by response.output content, want non-400 (got %d)", got)
+	}
+
+	// The cleanup path must also leave a valid replay entry in place.
+	scope := xaiReasoningReplayScope{modelName: "grok-4.3", sessionKey: "execution:content-invalid"}
+	encrypted := testValidGrokEncryptedContentForSeed(57)
+	if !internalcache.CacheXAIReasoningReplayItem(scope.modelName, scope.sessionKey, []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+encrypted+`"}`)) {
+		t.Fatal("failed to seed cache")
+	}
+	t.Cleanup(func() { internalcache.DeleteXAIReasoningReplayItem(scope.modelName, scope.sessionKey) })
+	clearXAIReasoningReplayOnInvalidEncryptedContent(context.Background(), scope, xaiErrorStatusCode(wsErr, payload), xaiWebsocketErrorObject(payload))
+	if _, ok := internalcache.GetXAIReasoningReplayItem(scope.modelName, scope.sessionKey); !ok {
+		t.Fatal("model-output content must not clear replay cache")
+	}
+}
+
+func TestXAIReasoningReplayClearsOnSSEResponseFailed(t *testing.T) {
+	internalcache.ClearXAIReasoningReplayCache()
+	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)
+
+	encrypted := testValidGrokEncryptedContentForSeed(52)
+	sessionKey := helps.IsolateClientReasoningReplaySessionKey(testContextWithAPIKey("xai-sse-failed-caller"), "prompt-cache:sse-failed")
+	if sessionKey == "" {
+		t.Fatal("expected isolated session key")
+	}
+	if !internalcache.CacheXAIReasoningReplayItem("grok-4.3", sessionKey, []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+encrypted+`"}`)) {
+		t.Fatal("failed to seed replay cache")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`data: {"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"message":"invalid_encrypted_content","type":"invalid_request_error"}}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-xai-sse-failed",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+	}
+	ctx := testContextWithAPIKey("xai-sse-failed-caller")
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "grok-4.3",
+		Payload: []byte(`{"model":"grok-4.3","prompt_cache_key":"sse-failed","input":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Stream: false})
+	if err == nil {
+		t.Fatal("expected terminal SSE failure error")
+	}
+	if _, ok := internalcache.GetXAIReasoningReplayItem("grok-4.3", sessionKey); ok {
+		t.Fatal("response.failed with invalid encrypted content should clear cached replay item")
+	}
+}
+
+func TestXAIReasoningReplayClearsOnSSEResponseFailedStream(t *testing.T) {
+	internalcache.ClearXAIReasoningReplayCache()
+	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)
+
+	encrypted := testValidGrokEncryptedContentForSeed(53)
+	sessionKey := helps.IsolateClientReasoningReplaySessionKey(testContextWithAPIKey("xai-sse-stream-failed-caller"), "prompt-cache:sse-stream-failed")
+	if !internalcache.CacheXAIReasoningReplayItem("grok-4.3", sessionKey, []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+encrypted+`"}`)) {
+		t.Fatal("failed to seed replay cache")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`data: {"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"message":"invalid_encrypted_content","type":"invalid_request_error"}}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID: "auth-xai-sse-stream-failed",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+	}
+	ctx := testContextWithAPIKey("xai-sse-stream-failed-caller")
+	stream, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "grok-4.3",
+		Payload: []byte(`{"model":"grok-4.3","prompt_cache_key":"sse-stream-failed","input":[{"role":"user","content":"hi"}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream setup error: %v", err)
+	}
+	gotErr := false
+	for chunk := range stream.Chunks {
+		if chunk.Err != nil {
+			gotErr = true
+		}
+	}
+	if !gotErr {
+		t.Fatal("expected stream chunk error for response.failed")
+	}
+	if _, ok := internalcache.GetXAIReasoningReplayItem("grok-4.3", sessionKey); ok {
+		t.Fatal("stream response.failed should clear cached replay item")
+	}
+}
+
+func TestParseXAIWebsocketErrorResponseFailed(t *testing.T) {
+	payload := []byte(`{"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"message":"invalid_encrypted_content","type":"invalid_request_error"}}}`)
+	err, ok := parseXAIWebsocketError(payload)
+	if !ok || err == nil {
+		t.Fatalf("parseXAIWebsocketError() = %v, %v, want error, true", err, ok)
+	}
+	statusCode := xaiErrorStatusCode(err, payload)
+	if statusCode < 400 || statusCode >= 500 {
+		t.Fatalf("status for response.failed cleanup = %d, want 4xx", statusCode)
+	}
+	if !xaiBodyIndicatesInvalidEncryptedContent(payload) {
+		t.Fatal("expected invalid encrypted content marker in payload")
+	}
+}
+
+func TestXAIErrorStatusCodeFallsBackForInvalidEncryptedBody(t *testing.T) {
+	payload := []byte(`{"error":{"message":"invalid_encrypted_content"}}`)
+	// With no classified error status (nil err), a statusless invalid-encrypted
+	// body maps to 400 so the replay-cache clear gate runs.
+	if got := xaiErrorStatusCode(nil, payload); got != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", got)
+	}
+
+	// A classified error status wins over the invalid-content fallback: a server
+	// failure whose message merely echoes invalid_encrypted_content must stay 5xx
+	// and not evict valid replay state. (parseXAIWebsocketError itself classifies a
+	// genuine statusless invalid-encrypted error as 400, so the real caller passes
+	// a 400-status err here — not a 500.)
+	err500 := statusErr{code: http.StatusInternalServerError, msg: "x"}
+	if got := xaiErrorStatusCode(err500, payload); got != http.StatusInternalServerError {
+		t.Fatalf("classified 500 must not be downgraded to 400, got %d", got)
+	}
+
+	// Explicit payload status still wins when present.
+	if got := xaiErrorStatusCode(err500, []byte(`{"status":422,"error":{"message":"invalid_encrypted_content"}}`)); got != 422 {
+		t.Fatalf("status = %d, want 422 from payload", got)
+	}
+
+	// Nested explicit 5xx must win over invalid-encrypted body classification so
+	// cleanup does not delete replay state for server errors.
+	if got := xaiErrorStatusCode(err500, []byte(`{"error":{"message":"invalid_encrypted_content","status":500}}`)); got != 500 {
+		t.Fatalf("nested status = %d, want 500", got)
+	}
+	if got := xaiErrorStatusCode(err500, []byte(`{"error":{"message":"invalid_encrypted_content","code":"503"}}`)); got != 503 {
+		t.Fatalf("nested code = %d, want 503", got)
+	}
+
+	// Non-matching body still uses err StatusCode().
+	if got := xaiErrorStatusCode(err500, []byte(`{"error":{"message":"other"}}`)); got != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 from StatusCode()", got)
+	}
+	if got := xaiErrorStatusCode(statusErr{code: 422, msg: "x"}, []byte(`{}`)); got != 422 {
+		t.Fatalf("status = %d, want 422 from StatusCode()", got)
 	}
 }
 

--- a/internal/runtime/executor/xai_reasoning_replay.go
+++ b/internal/runtime/executor/xai_reasoning_replay.go
@@ -2,8 +2,7 @@ package executor
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
+	"net/http"
 	"strings"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
@@ -13,6 +12,7 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 type xaiReasoningReplayScope struct {
@@ -60,32 +60,11 @@ func xaiReasoningReplayScopeFromRequest(ctx context.Context, from sdktranslator.
 		return xaiReasoningReplayScope{}
 	}
 	sessionKey := codexReasoningReplaySessionKey(ctx, from, req, opts, body)
-	sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
+	sessionKey = helps.IsolateClientReasoningReplaySessionKey(ctx, sessionKey)
 	return xaiReasoningReplayScope{
 		modelName:  thinking.ParseSuffix(req.Model).ModelName,
 		sessionKey: sessionKey,
 	}
-}
-
-// xaiReasoningReplayIsolateSessionKey namespaces client-controlled session keys
-// by the downstream CPA API key so two callers cannot share encrypted reasoning
-// or assistant text by reusing prompt_cache_key / window / session headers.
-// Trusted execution session keys keep their existing form. Client-controlled
-// sessions without a caller API key are disabled rather than shared globally.
-func xaiReasoningReplayIsolateSessionKey(ctx context.Context, sessionKey string) string {
-	sessionKey = strings.TrimSpace(sessionKey)
-	if sessionKey == "" {
-		return ""
-	}
-	if strings.HasPrefix(sessionKey, "execution:") {
-		return sessionKey
-	}
-	apiKey := strings.TrimSpace(helps.APIKeyFromContext(ctx))
-	if apiKey == "" {
-		return ""
-	}
-	sum := sha256.Sum256([]byte(apiKey))
-	return "caller:" + hex.EncodeToString(sum[:8]) + ":" + sessionKey
 }
 
 func xaiReasoningReplayEnabledForSource(from sdktranslator.Format) bool {
@@ -302,5 +281,275 @@ func clearXAIReasoningReplayAfterCompaction(ctx context.Context, scope xaiReason
 	}
 	if errDelete := internalcache.DeleteXAIReasoningReplayItemRequired(ctx, scope.modelName, scope.sessionKey); errDelete != nil {
 		log.Warnf("xai reasoning replay cache delete failed after successful compaction: %v", errDelete)
+	}
+}
+
+// clearXAIReasoningReplayOnInvalidEncryptedContent best-effort clears stale
+// replay state when upstream rejects injected encrypted reasoning content.
+// Delete failures never replace the upstream status error.
+func clearXAIReasoningReplayOnInvalidEncryptedContent(ctx context.Context, scope xaiReasoningReplayScope, statusCode int, body []byte) {
+	if !scope.valid() {
+		return
+	}
+	if statusCode < 400 || statusCode >= 500 {
+		return
+	}
+	if !xaiBodyIndicatesInvalidEncryptedContent(body) {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errDelete := internalcache.DeleteXAIReasoningReplayItemRequired(ctx, scope.modelName, scope.sessionKey); errDelete != nil {
+		log.Warnf("xai reasoning replay cache delete failed after invalid encrypted content: %v", errDelete)
+	}
+}
+
+func xaiBodyIndicatesInvalidEncryptedContent(body []byte) bool {
+	lower := strings.ToLower(strings.TrimSpace(string(body)))
+	if lower == "" {
+		return false
+	}
+	return strings.Contains(lower, "invalid_encrypted_content") ||
+		strings.Contains(lower, "invalid signature in thinking block") ||
+		(strings.Contains(lower, "encrypted_content") && strings.Contains(lower, "invalid"))
+}
+
+// xaiSSETerminalFailure extracts a client-facing status and error body from a
+// terminal SSE event (type "error" or "response.failed") so callers can clear
+// stale replay state even when the HTTP status was 200.
+func xaiSSETerminalFailure(eventData []byte) (status int, body []byte, ok bool) {
+	eventType := strings.TrimSpace(gjson.GetBytes(eventData, "type").String())
+	switch eventType {
+	case "error", "response.failed":
+	default:
+		return 0, nil, false
+	}
+
+	body = xaiExtractTerminalErrorBody(eventData)
+	if len(body) == 0 {
+		// Still treat the event as terminal with a minimal error body so callers
+		// return rather than waiting for response.completed.
+		body = []byte(`{"error":{"message":"upstream response failed","type":"api_error"}}`)
+	}
+
+	// Only valid 4xx/5xx values count: a response.failed can carry an SSE transport
+	// status like 200, which must not become a success/non-HTTP error status.
+	if s := int(gjson.GetBytes(eventData, "status").Int()); xaiIsHTTPErrorStatus(s) {
+		status = s
+	}
+	if status <= 0 {
+		if s := int(gjson.GetBytes(eventData, "status_code").Int()); xaiIsHTTPErrorStatus(s) {
+			status = s
+		}
+	}
+	if status <= 0 {
+		status = xaiNestedExplicitWebsocketStatus(body)
+	}
+	if status <= 0 {
+		status = xaiNestedExplicitWebsocketStatus(eventData)
+	}
+	if status <= 0 {
+		// Classify only from the extracted structured error body, never the full
+		// event: the event can carry response.output / response.instructions text
+		// that would let caller/model content drive the synthesized status.
+		status = xaiStatusFromErrorSemantics(body)
+	}
+	if status <= 0 {
+		// Unknown statusless upstream failure: treat as transient server-side so
+		// retry/failover/cooldown stays eligible (genuine client faults are already
+		// mapped to 400 by the invalid_request / invalid_encrypted_content cases).
+		status = http.StatusInternalServerError
+	}
+	if status == http.StatusBadRequest {
+		// Tag synthesized client errors with the canonical request-error type so
+		// the conductor's isRequestInvalidError recognizes the 400 and returns it
+		// once instead of retrying across every model/credential.
+		body = xaiEnsureInvalidRequestType(body)
+	}
+	return status, body, true
+}
+
+// xaiEnsureInvalidRequestType canonicalizes a classified client-error body so
+// error.type is the canonical "invalid_request_error" that the conductor's
+// isRequestInvalidError recognizes. A non-canonical but meaningful existing type
+// (e.g. "invalid_request", "invalid_prompt", "context_length_exceeded") is
+// preserved as error.code when code is empty, so the specific reason is not lost
+// while routing still treats the 400 as request-scoped (returned once, not
+// retried across every model/credential).
+func xaiEnsureInvalidRequestType(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	existingType := strings.TrimSpace(gjson.GetBytes(body, "error.type").String())
+	if strings.EqualFold(existingType, "invalid_request_error") {
+		return body
+	}
+	if existingType != "" && strings.TrimSpace(gjson.GetBytes(body, "error.code").String()) == "" {
+		if updated, err := sjson.SetBytes(body, "error.code", existingType); err == nil {
+			body = updated
+		}
+	}
+	updated, err := sjson.SetBytes(body, "error.type", "invalid_request_error")
+	if err != nil {
+		return body
+	}
+	return updated
+}
+
+// xaiWebsocketErrorObject extracts the structured error object of a websocket
+// error event, never sibling fields such as response.output or instructions, so
+// caller- or model-supplied content in the event cannot drive status
+// classification or replay-cache cleanup.
+func xaiWebsocketErrorObject(payload []byte) []byte {
+	return xaiExtractTerminalErrorBody(payload)
+}
+
+// xaiExtractTerminalErrorBody builds the canonical {"error":{...}} object for a
+// terminal error event by combining the nested error object (error /
+// response.error / body.error — body.error covers the Codex websocket shape) with
+// flat top-level structured fields (code, message, error_type, param). Merging
+// both shapes ensures an event that mixes a nested error value with flat fields
+// (e.g. {"error":"rejected","code":"invalid_encrypted_content"}) is fully
+// classified. Sibling fields such as response.output are never read.
+func xaiExtractTerminalErrorBody(eventData []byte) []byte {
+	var base []byte
+	for _, path := range []string{"error", "response.error", "body.error"} {
+		if body := xaiTerminalErrorBody(eventData, path); len(body) > 0 {
+			base = body
+			break
+		}
+	}
+	return xaiMergeFlatErrorFields(base, eventData)
+}
+
+// xaiMergeFlatErrorFields overlays flat top-level error fields onto base.error.*
+// without overwriting values already present. base may be empty, in which case a
+// body is built solely from the flat fields. Root "type" is the event name, not
+// an error class, so only "error_type" maps to error.type.
+func xaiMergeFlatErrorFields(base []byte, eventData []byte) []byte {
+	fields := []struct{ src, dst string }{
+		{"message", "error.message"},
+		{"code", "error.code"},
+		{"error_type", "error.type"},
+		{"param", "error.param"},
+	}
+	out := base
+	for _, f := range fields {
+		val := strings.TrimSpace(gjson.GetBytes(eventData, f.src).String())
+		if val == "" {
+			continue
+		}
+		if len(out) == 0 {
+			out = []byte(`{"error":{}}`)
+		}
+		if strings.TrimSpace(gjson.GetBytes(out, f.dst).String()) != "" {
+			continue
+		}
+		if updated, err := sjson.SetBytes(out, f.dst, val); err == nil {
+			out = updated
+		}
+	}
+	return out
+}
+
+func xaiTerminalErrorBody(eventData []byte, path string) []byte {
+	errorResult := gjson.GetBytes(eventData, path)
+	if !errorResult.Exists() {
+		return nil
+	}
+	body := []byte(`{"error":{}}`)
+	if errorResult.Type == gjson.JSON {
+		body, _ = sjson.SetRawBytes(body, "error", []byte(errorResult.Raw))
+	} else if message := strings.TrimSpace(errorResult.String()); message != "" {
+		body, _ = sjson.SetBytes(body, "error.message", message)
+	} else {
+		return nil
+	}
+	if strings.TrimSpace(gjson.GetBytes(body, "error.message").String()) == "" &&
+		strings.TrimSpace(gjson.GetBytes(body, "error.code").String()) == "" &&
+		strings.TrimSpace(gjson.GetBytes(body, "error.type").String()) == "" {
+		// A type-only error object (e.g. {"type":"rate_limit_exceeded"}) is still a
+		// classifiable structured error; only drop it when message, code, and type
+		// are all absent.
+		return nil
+	}
+	return body
+}
+
+// xaiStatusFromErrorSemantics maps statusless semantic error codes/types to an
+// HTTP-like status for cooldown/retry and replay-cache cleanup gates.
+func xaiStatusFromErrorSemantics(payload []byte) int {
+	if len(payload) == 0 {
+		return 0
+	}
+	// codes holds only the structured error identifiers (code/type). These are
+	// safe to match standard auth/quota codes against because they are not
+	// free-form text that can echo caller- or model-supplied content.
+	codes := strings.ToLower(strings.Join([]string{
+		gjson.GetBytes(payload, "error.code").String(),
+		gjson.GetBytes(payload, "error.type").String(),
+		gjson.GetBytes(payload, "code").String(),
+		gjson.GetBytes(payload, "error_type").String(),
+		gjson.GetBytes(payload, "response.error.code").String(),
+		gjson.GetBytes(payload, "response.error.type").String(),
+	}, " "))
+	// messages holds the human-readable text; it can echo caller/model content,
+	// so it is only consulted after the structured code/type identifiers below.
+	messages := strings.ToLower(strings.Join([]string{
+		gjson.GetBytes(payload, "error.message").String(),
+		gjson.GetBytes(payload, "message").String(),
+		gjson.GetBytes(payload, "response.error.message").String(),
+	}, " "))
+
+	// Pass 1 — structured code/type identifiers (high confidence). These win over
+	// message heuristics so a client error (e.g. type invalid_request_error) whose
+	// message merely echoes "rate limit" is not misclassified as retryable.
+	// Specific quota / rate / server codes are checked before the generic
+	// invalid_request bucket, because an event can carry both a specific code and
+	// a generic type (e.g. code=rate_limit_exceeded, type=invalid_request_error)
+	// and the specific code must win.
+	switch {
+	case strings.Contains(codes, "invalid_api_key"),
+		strings.Contains(codes, "authentication_error"),
+		// A deactivated account is an auth/permission failure, not recoverable
+		// quota, so it must leave the quota backoff path.
+		strings.Contains(codes, "account_deactivated"):
+		return http.StatusUnauthorized
+	case strings.Contains(codes, "insufficient_quota"),
+		strings.Contains(codes, "free-usage-exhausted"):
+		return http.StatusTooManyRequests
+	case strings.Contains(codes, "rate_limit"): // rate_limit / rate_limit_exceeded
+		return http.StatusTooManyRequests
+	case strings.Contains(codes, "server_error"),
+		strings.Contains(codes, "internal_error"):
+		return http.StatusInternalServerError
+	case strings.Contains(codes, "overloaded"):
+		return http.StatusServiceUnavailable
+	case strings.Contains(codes, "invalid_encrypted_content"),
+		strings.Contains(codes, "invalid_request"), // invalid_request / invalid_request_error
+		strings.Contains(codes, "invalid_prompt"),
+		strings.Contains(codes, "context_length_exceeded"),
+		strings.Contains(codes, "context_too_large"):
+		return http.StatusBadRequest
+	}
+
+	// Pass 2 — message/body heuristics. Only client-error (400) classifications
+	// are derived from free-form message text; a 400 is returned to the caller
+	// with no credential action. Auth, quota, rate, and server statuses — which
+	// trigger refresh, cooldown, or suspension — come exclusively from explicit
+	// status or the structured codes classified in pass 1, so caller- or
+	// model-echoed text cannot suspend or cool credentials.
+	haystack := codes + " " + messages
+	switch {
+	case strings.Contains(haystack, "invalid_encrypted_content"),
+		strings.Contains(haystack, "invalid signature in thinking"),
+		strings.Contains(haystack, "request validation error"),
+		strings.Contains(haystack, "context length"),
+		strings.Contains(haystack, "maximum context"),
+		strings.Contains(haystack, "too many tokens"):
+		return http.StatusBadRequest
+	default:
+		return 0
 	}
 }

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -625,6 +625,8 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 			helps.AppendAPIWebsocketResponse(ctx, e.cfg, payload)
 
 			if wsErr, ok := parseXAIWebsocketError(payload); ok {
+				statusCode := xaiErrorStatusCode(wsErr, payload)
+				clearXAIReasoningReplayOnInvalidEncryptedContent(ctx, prepared.replayScope, statusCode, xaiWebsocketErrorObject(payload))
 				terminateReason = "upstream_error"
 				terminateErr = wsErr
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
@@ -638,7 +640,10 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 
 			for _, payload := range xaiNormalizeReasoningSummaryDataEvents(payload) {
 				eventType := gjson.GetBytes(payload, "type").String()
-				isTerminalEvent := eventType == "response.completed" || eventType == "response.done" || eventType == "error"
+				isTerminalEvent := eventType == "response.completed" ||
+					eventType == "response.done" ||
+					eventType == "error" ||
+					eventType == "response.failed"
 				warmupCompletedPayload := []byte(nil)
 				switch eventType {
 				case "response.created":
@@ -669,6 +674,8 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 						idMapper.state.recordTranscriptTurn(wsReqBody, payload)
 						recordedTranscript = true
 					}
+				case "response.failed", "error":
+					logXAIWebsocketTerminalResponse(executionSessionID, authID, wsURL, eventType, payload)
 				}
 
 				if cliproxyexecutor.DownstreamWebsocket(ctx) {
@@ -820,46 +827,156 @@ func buildXAIWebsocketWarmupCompletedPayload(createdPayload []byte) []byte {
 	return completed
 }
 
+// xaiErrorStatusCode extracts an HTTP-like status from a websocket error for
+// replay-cache cleanup. Explicit top-level or nested status wins; only
+// statusless invalid encrypted-content bodies map to 400 when
+// parseXAIWebsocketError synthesized a 500, so the clear helper's 4xx gate
+// still runs without deleting on explicit server errors.
+func xaiErrorStatusCode(err error, payload []byte) int {
+	if status := int(gjson.GetBytes(payload, "status").Int()); xaiIsHTTPErrorStatus(status) {
+		return status
+	}
+	if status := int(gjson.GetBytes(payload, "status_code").Int()); xaiIsHTTPErrorStatus(status) {
+		return status
+	}
+	if status := xaiNestedExplicitWebsocketStatus(payload); status > 0 {
+		return status
+	}
+	// Prefer the status already classified by parseXAIWebsocketError (structured
+	// code/type semantics) so a server_error / overloaded / rate_limit failure
+	// whose message merely echoes "invalid_encrypted_content" is not downgraded to
+	// 400 and does not evict valid replay state.
+	if err != nil {
+		if withStatus, ok := err.(interface{ StatusCode() int }); ok {
+			if code := withStatus.StatusCode(); code > 0 {
+				return code
+			}
+		}
+	}
+	// Fallback for a statusless invalid-encrypted-content body (no classifiable
+	// status): map to 400 so the replay-cache clear gate runs. Classify only from
+	// the structured error object, never the whole event, since response.output /
+	// instructions can echo caller or model text.
+	if xaiBodyIndicatesInvalidEncryptedContent(xaiWebsocketErrorObject(payload)) {
+		return http.StatusBadRequest
+	}
+	return 0
+}
+
+// xaiNestedExplicitWebsocketStatus returns a numeric status from nested error
+// fields that parseXAIWebsocketError also understands (including response.failed).
+// Only valid 4xx/5xx values are treated as HTTP statuses: fields like error.code
+// often carry application error codes (e.g. 1001) that must not be propagated as
+// HTTP statuses, and a 2xx/3xx value must not turn a terminal failure into a
+// success-class response.
+func xaiNestedExplicitWebsocketStatus(payload []byte) int {
+	for _, path := range []string{
+		"error.code", "error.status", "code",
+		"response.error.code", "response.error.status",
+	} {
+		num := gjson.GetBytes(payload, path)
+		if num.Type == gjson.Number {
+			if status := int(num.Int()); xaiIsHTTPErrorStatus(status) {
+				return status
+			}
+		}
+		raw := strings.TrimSpace(num.String())
+		if raw == "" {
+			continue
+		}
+		if status, errAtoi := strconv.Atoi(raw); errAtoi == nil && xaiIsHTTPErrorStatus(status) {
+			return status
+		}
+	}
+	return 0
+}
+
+// xaiIsHTTPErrorStatus reports whether status is a valid HTTP client/server error
+// status code.
+func xaiIsHTTPErrorStatus(status int) bool {
+	return status >= 400 && status <= 599
+}
+
 func parseXAIWebsocketError(payload []byte) (error, bool) {
 	if wsErr, ok := parseCodexWebsocketError(payload); ok {
 		if statusError, okStatus := wsErr.(statusErrWithHeaders); okStatus {
-			xaiError := xaiStatusErr(statusError.code, payload)
-			if xaiError.retryAfter != nil {
-				statusError.retryAfter = xaiError.retryAfter
+			// The Codex envelope builder ignores flat top-level code/message fields.
+			// Rebuild the body from the xAI extractor (merged flat + nested) and
+			// canonicalize a 400 so the actual error is preserved and requests are not
+			// retried across credentials; keep the Codex status, headers, and
+			// retry-after.
+			body := xaiExtractTerminalErrorBody(payload)
+			if len(body) == 0 {
+				body = []byte(statusError.msg)
+			} else {
+				if statusError.code == http.StatusBadRequest {
+					body = xaiEnsureInvalidRequestType(body)
+				}
+				body, _ = sjson.SetBytes(body, "type", "error")
+				body, _ = sjson.SetBytes(body, "status", statusError.code)
 			}
+			xaiError := xaiStatusErr(statusError.code, body)
+			if xaiError.retryAfter == nil {
+				xaiError.retryAfter = statusError.retryAfter
+			}
+			statusError.statusErr = xaiError
 			return statusError, true
 		}
 		return wsErr, true
 	}
+	// Responses API terminal failure: error lives under response.error, not top-level error.
+	if status, body, ok := xaiSSETerminalFailure(payload); ok {
+		out := []byte(`{}`)
+		out, _ = sjson.SetBytes(out, "type", "error")
+		out, _ = sjson.SetBytes(out, "status", status)
+		if errNode := gjson.GetBytes(body, "error"); errNode.Exists() {
+			out, _ = sjson.SetRawBytes(out, "error", []byte(errNode.Raw))
+		} else if errNode := gjson.GetBytes(payload, "response.error"); errNode.Exists() {
+			out, _ = sjson.SetRawBytes(out, "error", []byte(errNode.Raw))
+		} else if errNode := gjson.GetBytes(payload, "error"); errNode.Exists() {
+			out, _ = sjson.SetRawBytes(out, "error", []byte(errNode.Raw))
+		}
+		return xaiStatusErr(status, out), true
+	}
 	if len(payload) == 0 || !gjson.GetBytes(payload, "error").Exists() {
 		return nil, false
 	}
-	status := int(gjson.GetBytes(payload, "status").Int())
+	status := 0
+	if s := int(gjson.GetBytes(payload, "status").Int()); xaiIsHTTPErrorStatus(s) {
+		status = s
+	}
 	if status <= 0 {
-		status = int(gjson.GetBytes(payload, "status_code").Int())
+		if s := int(gjson.GetBytes(payload, "status_code").Int()); xaiIsHTTPErrorStatus(s) {
+			status = s
+		}
 	}
 	if status <= 0 {
 		status = xaiBareWebsocketErrorStatus(payload)
 	}
-	out := []byte(`{}`)
+	// Merge flat + nested fields so no structured code is lost, and canonicalize a
+	// classified 400 so the conductor treats it as request-scoped (not retried).
+	out := xaiExtractTerminalErrorBody(payload)
+	if len(out) == 0 {
+		out = []byte(`{"error":{}}`)
+	}
+	if status == http.StatusBadRequest {
+		out = xaiEnsureInvalidRequestType(out)
+	}
 	out, _ = sjson.SetBytes(out, "type", "error")
 	out, _ = sjson.SetBytes(out, "status", status)
-	if errNode := gjson.GetBytes(payload, "error"); errNode.Exists() {
-		out, _ = sjson.SetRawBytes(out, "error", []byte(errNode.Raw))
-	}
 	return xaiStatusErr(status, out), true
 }
 
 func xaiBareWebsocketErrorStatus(payload []byte) int {
-	for _, path := range []string{"error.code", "error.status", "code"} {
-		raw := strings.TrimSpace(gjson.GetBytes(payload, path).String())
-		if raw == "" {
-			continue
-		}
-		status, errAtoi := strconv.Atoi(raw)
-		if errAtoi == nil && status > 0 {
-			return status
-		}
+	if status := xaiNestedExplicitWebsocketStatus(payload); status > 0 {
+		return status
+	}
+	// Classify from the structured error object (code/type) so a bare shape such as
+	// {"error":{"code":"invalid_encrypted_content"}} — which carries no top-level
+	// type or status — is recognized as a 400 client error and its rejected replay
+	// state is cleared, instead of defaulting to a 5xx that leaves it cached.
+	if status := xaiStatusFromErrorSemantics(xaiWebsocketErrorObject(payload)); status > 0 {
+		return status
 	}
 	message := strings.TrimSpace(gjson.GetBytes(payload, "error.message").String())
 	if strings.Contains(message, `"code":"400"`) || strings.Contains(message, "Request validation error") {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -10,6 +10,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -225,6 +226,19 @@ type Manager struct {
 	mu            sync.RWMutex
 	auths         map[string]*Auth
 	scheduler     *authScheduler
+	// selectorUses tracks in-flight legacy picks per Stoppable selector instance,
+	// so a reinstalled or retired selector is stopped only after every pick that
+	// borrowed it (across all installs) returns. Non-stoppable selectors are
+	// never stopped and are not tracked. A slice (not a map) is used because a
+	// Selector may legally be a non-comparable concrete type (named map/slice/
+	// func); the slice structure is mutated only under mu.Lock. Entries are
+	// claimed/retired by pointer identity, so no selector-value comparison is
+	// needed to find them (which would be unreliable for func-typed selectors).
+	selectorUses []*selectorUseEntry
+	// currentUse is the tracking entry for the currently installed selector, or
+	// nil when the current selector is not stoppable. Pick paths increment this
+	// entry directly (under mu.RLock) rather than looking it up by value.
+	currentUse *selectorUseEntry
 	// pluginScheduler runs outside m.mu before falling back to native selection.
 	pluginScheduler PluginScheduler
 	// homeRuntimeAuths caches auths returned by Home so websocket sessions can
@@ -287,6 +301,10 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	manager.runtimeConfig.Store(&internalconfig.Config{})
 	manager.apiKeyModelAlias.Store(apiKeyModelAliasTable(nil))
 	manager.scheduler = newAuthScheduler(selector)
+	// Track the initial selector so the first SetSelector can retire it; without
+	// this a startup SessionAffinitySelector is treated as already retired and
+	// its SessionCache cleanup goroutine leaks for the process lifetime.
+	manager.currentUse = manager.trackSelectorLocked(selector)
 	return manager
 }
 
@@ -462,6 +480,17 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 }
 
+// SetSelector installs selector as the active selector and asynchronously
+// retires the previous one (Stopping it after its in-flight picks drain).
+//
+// Contract: callers must pass a freshly constructed selector on each change and
+// must not reinstall a StoppableSelector instance that was previously replaced.
+// StoppableSelector.Stop (e.g. SessionAffinitySelector) is irreversible — its
+// SessionCache cleanup goroutine cannot be restarted — so reinstalling a
+// retired instance would leave a live-but-dead-cleanup selector. The only
+// production caller (config hot-reload) always builds a new selector, so this is
+// never hit; the same-instance no-op below only exists to make a redundant set
+// of the current instance harmless.
 func (m *Manager) SetSelector(selector Selector) {
 	if m == nil {
 		return
@@ -470,11 +499,199 @@ func (m *Manager) SetSelector(selector Selector) {
 		selector = &RoundRobinSelector{}
 	}
 	m.mu.Lock()
+	previous := m.selector
+	// Re-setting the same instance is a no-op for retirement: keep its in-flight
+	// counter so older picks stay accounted, and never stop a live selector.
+	if selectorSameInstance(previous, selector) {
+		m.mu.Unlock()
+		if m.scheduler != nil {
+			m.scheduler.setSelector(selector)
+			m.syncScheduler()
+		}
+		return
+	}
 	m.selector = selector
+	prevUse := m.currentUse
+	// Ensure the new stoppable instance has a use-tracking entry so pick paths
+	// can account for it. Reuse an existing entry if this exact instance is being
+	// reinstalled (A->B->A) so drain accounting spans installs.
+	m.currentUse = m.trackSelectorLocked(selector)
 	m.mu.Unlock()
+	// Stop the previous affinity/cache selector so config hot-reload does not
+	// leak SessionCache cleanup goroutines, but defer the Stop until every pick
+	// that borrowed that instance finishes so a mid-pick Stop cannot tear down
+	// resources under an in-flight Pick.
+	if prevUse != nil {
+		go m.retireSelector(prevUse)
+	}
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()
+	}
+}
+
+// selectorUseEntry tracks in-flight picks for a single Stoppable selector
+// instance across all installs of that instance. Entries are referenced by
+// pointer identity, so tracking never depends on comparing selector values.
+type selectorUseEntry struct {
+	sel   StoppableSelector
+	inUse atomic.Int64
+}
+
+// selectorUseEntryLocked returns the existing tracking entry whose selector is
+// the same identifiable instance as sel, or nil. Identity uses the panic-safe
+// selectorSameInstance; it is deliberately best-effort (it returns nil for
+// func-typed selectors, which then get a fresh per-install entry). Callers hold
+// mu (read or write).
+func (m *Manager) selectorUseEntryLocked(sel StoppableSelector) *selectorUseEntry {
+	for _, entry := range m.selectorUses {
+		if selectorSameInstance(entry.sel, sel) {
+			return entry
+		}
+	}
+	return nil
+}
+
+// trackSelectorLocked returns the use-tracking entry for a stoppable selector,
+// reusing an existing one when the same identifiable instance is (re)installed
+// (A->B->A) and appending a fresh entry otherwise. Returns nil for non-stoppable
+// selectors. Callers hold mu.Lock.
+func (m *Manager) trackSelectorLocked(selector Selector) *selectorUseEntry {
+	stoppable, ok := selector.(StoppableSelector)
+	if !ok {
+		return nil
+	}
+	if entry := m.selectorUseEntryLocked(stoppable); entry != nil {
+		return entry
+	}
+	entry := &selectorUseEntry{sel: stoppable}
+	m.selectorUses = append(m.selectorUses, entry)
+	return entry
+}
+
+// removeSelectorUseLocked drops a tracking entry and reports whether it was
+// present. Its presence in the slice is the single retirement claim token, so a
+// true return means the caller (and only the caller) owns the subsequent Stop.
+// Callers hold mu.Lock. The vacated last slot is niled before reslicing so the
+// manager's retained backing array does not keep the retired selector (and its
+// SessionCache) alive.
+func (m *Manager) removeSelectorUseLocked(target *selectorUseEntry) bool {
+	for i, entry := range m.selectorUses {
+		if entry == target {
+			copy(m.selectorUses[i:], m.selectorUses[i+1:])
+			last := len(m.selectorUses) - 1
+			m.selectorUses[last] = nil
+			m.selectorUses = m.selectorUses[:last]
+			return true
+		}
+	}
+	return false
+}
+
+// acquireSelectorUse increments the in-flight counter for the current stoppable
+// selector and returns its entry so the caller can release without a second
+// lookup. Returns nil when the current selector is not stoppable. Callers hold
+// mu.RLock.
+func (m *Manager) acquireSelectorUse() *selectorUseEntry {
+	if m == nil {
+		return nil
+	}
+	entry := m.currentUse
+	if entry == nil {
+		return nil
+	}
+	entry.inUse.Add(1)
+	return entry
+}
+
+func (m *Manager) releaseSelectorUse(entry *selectorUseEntry) {
+	if entry != nil {
+		entry.inUse.Add(-1)
+	}
+}
+
+func (m *Manager) waitSelectorEntryIdle(entry *selectorUseEntry) {
+	if m == nil || entry == nil {
+		return
+	}
+	for entry.inUse.Load() > 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// retireSelector stops a replaced Stoppable selector once every pick that
+// borrowed its instance (across all installs sharing this entry) has returned,
+// unless the same instance was reinstalled in the meantime. The reinstall check
+// and the claim (entry removal) run under mu.Lock so exactly one goroutine
+// retires the entry; Stop is then called after unlocking so a re-entrant custom
+// Stop (one that calls back into Manager) cannot deadlock on mu, matching the
+// shutdown path. Reinstalling a claimed instance is a caller-contract violation
+// (see SetSelector) not reachable from the config hot-reload path.
+func (m *Manager) retireSelector(entry *selectorUseEntry) {
+	if m == nil || entry == nil {
+		return
+	}
+	for {
+		m.waitSelectorEntryIdle(entry)
+		m.mu.Lock()
+		if m.currentUse == entry {
+			// Reinstalled while draining (A->B->A reused this entry): keep alive.
+			m.mu.Unlock()
+			return
+		}
+		if entry.inUse.Load() > 0 {
+			// A pick slipped in during a brief reinstall window; drain again.
+			m.mu.Unlock()
+			continue
+		}
+		// Claim under the lock: removeSelectorUseLocked returning true is the
+		// single exactly-once token. If another retire goroutine or StopAutoRefresh
+		// already claimed this entry, we get false and must not Stop. Stop runs
+		// outside the lock so a re-entrant custom Stop cannot deadlock on mu.
+		claimed := m.removeSelectorUseLocked(entry)
+		m.mu.Unlock()
+		if claimed {
+			entry.sel.Stop()
+		}
+		return
+	}
+}
+
+// selectorSameInstance reports whether a and b refer to the same selector
+// instance without panicking on non-comparable concrete types.
+func selectorSameInstance(a, b Selector) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	va := reflect.ValueOf(a)
+	vb := reflect.ValueOf(b)
+	if !va.IsValid() || !vb.IsValid() || va.Type() != vb.Type() {
+		return false
+	}
+	switch va.Kind() {
+	case reflect.Func:
+		// Function values have no reliable identity: distinct closures built from
+		// the same function literal can share a code pointer, so never treat two
+		// func selectors as the same instance (a replacement is always installed).
+		return false
+	case reflect.Ptr, reflect.Map, reflect.Chan, reflect.UnsafePointer:
+		if va.IsNil() || vb.IsNil() {
+			return va.IsNil() && vb.IsNil()
+		}
+		return va.Pointer() == vb.Pointer()
+	case reflect.Slice:
+		if va.IsNil() || vb.IsNil() {
+			return va.IsNil() && vb.IsNil()
+		}
+		// Pointer, length, and capacity together identify a slice header; two
+		// slices over the same array with the same length but different caps
+		// (base[:1:1] vs base[:1:2]) are distinct values a Pick could observe.
+		return va.Pointer() == vb.Pointer() && va.Len() == vb.Len() && va.Cap() == vb.Cap()
+	default:
+		if va.Comparable() {
+			return a == b
+		}
+		return false
 	}
 }
 
@@ -2277,7 +2494,15 @@ func (m *Manager) invalidateSessionAffinity(authID string) {
 	if m == nil || authID == "" {
 		return
 	}
-	if invalidator, ok := m.selector.(interface{ InvalidateAuth(string) }); ok && invalidator != nil {
+	// Borrow the current selector's retirement entry (like a pick) so a concurrent
+	// SetSelector cannot Stop the selector while InvalidateAuth is still using its
+	// resources. A selector may implement both StoppableSelector and InvalidateAuth.
+	m.mu.RLock()
+	selector := m.selector
+	use := m.acquireSelectorUse()
+	m.mu.RUnlock()
+	defer m.releaseSelectorUse(use)
+	if invalidator, ok := selector.(interface{ InvalidateAuth(string) }); ok && invalidator != nil {
 		invalidator.InvalidateAuth(authID)
 	}
 }
@@ -4523,6 +4748,8 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 
 	m.mu.RLock()
 	selector := m.selector
+	selectorUseCounter := m.acquireSelectorUse()
+	defer m.releaseSelectorUse(selectorUseCounter)
 	pluginScheduler := m.pluginScheduler
 	executor, okExecutor := m.executors[provider]
 	if !okExecutor {
@@ -4688,6 +4915,8 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 
 	m.mu.RLock()
 	selector := m.selector
+	selectorUseCounter := m.acquireSelectorUse()
+	defer m.releaseSelectorUse(selectorUseCounter)
 	pluginScheduler := m.pluginScheduler
 	candidates := make([]*Auth, 0, len(m.auths))
 	modelKey := strings.TrimSpace(model)
@@ -5503,13 +5732,25 @@ func (m *Manager) StopAutoRefresh() {
 	cancel := m.refreshCancel
 	m.refreshCancel = nil
 	m.refreshLoop = nil
+	// Claim the current selector's retirement entry under the lock so a later
+	// SetSelector (whose prevUse would otherwise point at this instance) cannot
+	// queue a second Stop. Stop is not required to be idempotent.
+	current := m.selector
+	claimed := false
+	if m.currentUse != nil {
+		claimed = m.removeSelectorUseLocked(m.currentUse)
+		m.currentUse = nil
+	}
 	m.mu.Unlock()
 	if cancel != nil {
 		cancel()
 	}
-	// Stop selector if it implements StoppableSelector (e.g., SessionAffinitySelector)
-	if stoppable, ok := m.selector.(StoppableSelector); ok {
-		stoppable.Stop()
+	// Stop selector if it implements StoppableSelector (e.g., SessionAffinitySelector),
+	// but only when we won the retirement claim so it is stopped exactly once.
+	if claimed {
+		if stoppable, ok := current.(StoppableSelector); ok {
+			stoppable.Stop()
+		}
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_set_selector_test.go
+++ b/sdk/cliproxy/auth/conductor_set_selector_test.go
@@ -1,0 +1,442 @@
+package auth
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type stopCountingSelector struct {
+	RoundRobinSelector
+	stops atomic.Int32
+}
+
+func (s *stopCountingSelector) Stop() {
+	s.stops.Add(1)
+}
+
+// mapSelector is intentionally non-comparable (named map type) to ensure
+// SetSelector does not panic on interface equality.
+type mapSelector map[string]struct{}
+
+func (mapSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	return (&RoundRobinSelector{}).Pick(ctx, provider, model, opts, auths)
+}
+
+// stoppableMapSelector is a non-comparable (named map type) selector that also
+// implements Stop, to ensure use-tracking never indexes a map with an
+// unhashable key ("hash of unhashable type").
+type stoppableMapSelector map[string]struct{}
+
+func (stoppableMapSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	return (&RoundRobinSelector{}).Pick(ctx, provider, model, opts, auths)
+}
+
+func (stoppableMapSelector) Stop() {}
+
+func waitForStopCount(t *testing.T, s *stopCountingSelector, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.stops.Load() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("Stop calls = %d, want %d", s.stops.Load(), want)
+}
+
+func TestManagerSetSelectorStopsPreviousStoppableSelector(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	first := &stopCountingSelector{}
+	second := &stopCountingSelector{}
+
+	manager.SetSelector(first)
+	manager.SetSelector(second)
+	waitForStopCount(t, first, 1)
+
+	if got := second.stops.Load(); got != 0 {
+		t.Fatalf("second selector Stop calls = %d, want 0", got)
+	}
+
+	// Replacing with a non-stoppable selector should still stop the previous one.
+	manager.SetSelector(&RoundRobinSelector{})
+	waitForStopCount(t, second, 1)
+}
+
+func TestManagerSetSelectorDoesNotPanicOnNonComparableSelector(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	first := &stopCountingSelector{}
+	manager.SetSelector(first)
+
+	// Replacing with a non-comparable concrete type must not panic and must stop previous.
+	manager.SetSelector(mapSelector{})
+	waitForStopCount(t, first, 1)
+
+	// Replacing non-comparable with another non-comparable must also not panic.
+	manager.SetSelector(mapSelector{"x": {}})
+	manager.SetSelector(&RoundRobinSelector{})
+}
+
+// funcSelector is a function-typed Selector used to prove selectorSameInstance
+// never conflates distinct closures built from the same function literal (Go
+// gives no reliable identity to function values).
+type funcSelector func(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error)
+
+func (f funcSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	return f(ctx, provider, model, opts, auths)
+}
+
+func TestSelectorSameInstancePointerIdentity(t *testing.T) {
+	s := &RoundRobinSelector{}
+	if !selectorSameInstance(s, s) {
+		t.Fatal("same pointer should be same instance")
+	}
+	if selectorSameInstance(s, &RoundRobinSelector{}) {
+		t.Fatal("different pointers should not be same instance")
+	}
+	if selectorSameInstance(mapSelector{}, mapSelector{}) {
+		t.Fatal("distinct non-comparable values should not report same instance")
+	}
+}
+
+// sliceSelector is a named slice-typed selector used to verify identity
+// accounts for capacity, not just pointer and length.
+type sliceSelector []int
+
+func (sliceSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	return (&RoundRobinSelector{}).Pick(ctx, provider, model, opts, auths)
+}
+
+func TestSelectorSameInstanceSliceCapacity(t *testing.T) {
+	base := make(sliceSelector, 4)
+	a := base[:1:1]
+	b := base[:1:2]
+	// Same backing array and length but different capacity — a Pick can observe
+	// cap, so these must be treated as different instances.
+	if selectorSameInstance(a, b) {
+		t.Fatal("slice selectors with different capacities must not be same instance")
+	}
+	if !selectorSameInstance(a, a) {
+		t.Fatal("identical slice header must be same instance")
+	}
+}
+
+func TestSelectorSameInstanceFuncSelectorsNeverSame(t *testing.T) {
+	build := func() funcSelector {
+		return funcSelector(func(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+			return nil, nil
+		})
+	}
+	// Two closures from the same literal can share a code pointer; they must not
+	// be treated as the same instance, otherwise SetSelector would drop the new
+	// closure and keep stale routing state.
+	if selectorSameInstance(build(), build()) {
+		t.Fatal("distinct func selectors must not report same instance")
+	}
+}
+
+func TestManagerSetSelectorWaitsForInflightSelectorUse(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	first := &stopCountingSelector{}
+	manager.SetSelector(first)
+
+	counter := manager.acquireSelectorUse()
+	if counter == nil {
+		t.Fatal("expected in-flight counter for stoppable selector")
+	}
+
+	manager.SetSelector(&RoundRobinSelector{})
+	// Give the async retire path time to observe a non-zero use count.
+	time.Sleep(30 * time.Millisecond)
+	if got := first.stops.Load(); got != 0 {
+		t.Fatalf("Stop called while selector still in use: stops=%d", got)
+	}
+
+	manager.releaseSelectorUse(counter)
+	waitForStopCount(t, first, 1)
+}
+
+func TestManagerSetSelectorSameInstanceDoesNotStopOrDropTracking(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	first := &stopCountingSelector{}
+	manager.SetSelector(first)
+
+	counter := manager.acquireSelectorUse()
+	if counter == nil {
+		t.Fatal("expected in-flight counter")
+	}
+
+	// Same instance must not stop or reset tracking.
+	manager.SetSelector(first)
+	time.Sleep(20 * time.Millisecond)
+	if got := first.stops.Load(); got != 0 {
+		t.Fatalf("Stop called on same-instance SetSelector: stops=%d", got)
+	}
+
+	// Replacement must wait for the in-flight use still held.
+	manager.SetSelector(&RoundRobinSelector{})
+	time.Sleep(30 * time.Millisecond)
+	if got := first.stops.Load(); got != 0 {
+		t.Fatalf("Stop called while still in use: stops=%d", got)
+	}
+	manager.releaseSelectorUse(counter)
+	waitForStopCount(t, first, 1)
+}
+
+func TestManagerSetSelectorReleaseThenReacquireStillWaits(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	first := &stopCountingSelector{}
+	manager.SetSelector(first)
+
+	counter := manager.acquireSelectorUse()
+	manager.releaseSelectorUse(counter)
+	// Counter may be zero but must remain reachable for a re-acquire.
+	counter = manager.acquireSelectorUse()
+	if counter == nil {
+		t.Fatal("in-flight counter unreachable after release/re-acquire")
+	}
+
+	manager.SetSelector(&RoundRobinSelector{})
+	time.Sleep(30 * time.Millisecond)
+	if got := first.stops.Load(); got != 0 {
+		t.Fatalf("Stop called after release/re-acquire while still held: stops=%d", got)
+	}
+	manager.releaseSelectorUse(counter)
+	waitForStopCount(t, first, 1)
+}
+
+func TestManagerSetSelectorDoesNotStopReinstalledSelector(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	first := &stopCountingSelector{}
+	manager.SetSelector(first)
+
+	counter := manager.acquireSelectorUse()
+
+	// A -> B queues stop of A after its picks drain.
+	manager.SetSelector(&RoundRobinSelector{})
+	// A reinstalled before drain completes.
+	manager.SetSelector(first)
+	manager.releaseSelectorUse(counter)
+
+	// Async retire must skip Stop because A is current again.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if first.stops.Load() != 0 {
+			t.Fatalf("reinstalled selector was Stopped: stops=%d", first.stops.Load())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestManagerSetSelectorStopsAfterMultiGenerationDrain(t *testing.T) {
+	// A -> B -> A -> C: A spans two installs. A must be Stopped only after every
+	// pick that borrowed it (across both installs) returns, and exactly once.
+	manager := NewManager(nil, nil, nil)
+	a := &stopCountingSelector{}
+	manager.SetSelector(a)
+	firstUse := manager.acquireSelectorUse() // borrowed during install #1
+
+	manager.SetSelector(&RoundRobinSelector{}) // A -> B, retire(A) waits
+	manager.SetSelector(a)                     // B -> A, reinstalled
+	secondUse := manager.acquireSelectorUse()  // borrowed during install #2
+
+	manager.SetSelector(&stopCountingSelector{}) // A -> C, retire(A) again
+
+	// Release the first install's borrow; the second is still outstanding, so A
+	// must not be Stopped yet.
+	manager.releaseSelectorUse(firstUse)
+	time.Sleep(30 * time.Millisecond)
+	if got := a.stops.Load(); got != 0 {
+		t.Fatalf("A Stopped while a pick from install #2 was still in flight: stops=%d", got)
+	}
+
+	manager.releaseSelectorUse(secondUse)
+	waitForStopCount(t, a, 1)
+	// Ensure no double-stop from the two retire goroutines.
+	time.Sleep(30 * time.Millisecond)
+	if got := a.stops.Load(); got != 1 {
+		t.Fatalf("A Stop count = %d, want exactly 1", got)
+	}
+}
+
+// countingFuncSelector is a func-typed StoppableSelector: Go gives func values
+// no reliable identity, so tracking must not rely on comparing selector values.
+var countingFuncSelectorStops atomic.Int32
+
+type countingFuncSelector func(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error)
+
+func (countingFuncSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	return nil, nil
+}
+
+func (countingFuncSelector) Stop() { countingFuncSelectorStops.Add(1) }
+
+func TestManagerRetiresFuncTypedStoppableSelector(t *testing.T) {
+	countingFuncSelectorStops.Store(0)
+	manager := NewManager(nil, nil, nil)
+	fn := countingFuncSelector(func(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+		return nil, nil
+	})
+	manager.SetSelector(fn)
+
+	// In-flight picks on a func-typed selector must be tracked (previously the
+	// value-lookup returned nil for funcs, so they were never tracked or stopped).
+	manager.mu.RLock()
+	entry := manager.acquireSelectorUse()
+	manager.mu.RUnlock()
+	if entry == nil {
+		t.Fatal("func-typed stoppable selector must be tracked")
+	}
+
+	manager.SetSelector(&RoundRobinSelector{})
+	time.Sleep(30 * time.Millisecond)
+	if got := countingFuncSelectorStops.Load(); got != 0 {
+		t.Fatalf("Stop called while func selector still in use: stops=%d", got)
+	}
+	manager.releaseSelectorUse(entry)
+
+	// Must be Stopped exactly once after drain, with its tracking entry removed.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && countingFuncSelectorStops.Load() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := countingFuncSelectorStops.Load(); got != 1 {
+		t.Fatalf("func selector Stop count = %d, want 1", got)
+	}
+	manager.mu.RLock()
+	leaked := len(manager.selectorUses)
+	manager.mu.RUnlock()
+	if leaked != 0 {
+		t.Fatalf("selectorUses leaked %d entries after retirement", leaked)
+	}
+}
+
+func TestManagerTracksSelectorInstalledByNewManager(t *testing.T) {
+	// A stoppable selector passed to NewManager (e.g. startup session affinity)
+	// must be retired on the first replacement, not treated as already-retired.
+	initial := &stopCountingSelector{}
+	manager := NewManager(nil, initial, nil)
+
+	manager.SetSelector(&RoundRobinSelector{})
+	waitForStopCount(t, initial, 1)
+}
+
+func TestManagerSetSelectorHandlesNonComparableStoppableSelector(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+
+	// Installing and looking up a non-comparable stoppable selector must not
+	// panic with "hash of unhashable type".
+	first := stoppableMapSelector{}
+	manager.SetSelector(first)
+
+	manager.mu.RLock()
+	entry := manager.acquireSelectorUse()
+	manager.mu.RUnlock()
+	if entry == nil {
+		t.Fatal("expected tracking entry for non-comparable stoppable selector")
+	}
+	manager.releaseSelectorUse(entry)
+
+	// The retire path (which used to index a map keyed by the selector) must
+	// also not panic.
+	manager.SetSelector(&RoundRobinSelector{})
+	manager.SetSelector(stoppableMapSelector{})
+	manager.SetSelector(&RoundRobinSelector{})
+}
+
+func TestManagerRetireClearsVacatedSlot(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	first := &stopCountingSelector{}
+	manager.SetSelector(first)
+	manager.SetSelector(&RoundRobinSelector{})
+	waitForStopCount(t, first, 1)
+
+	manager.mu.RLock()
+	defer manager.mu.RUnlock()
+	if len(manager.selectorUses) != 0 {
+		t.Fatalf("selectorUses len = %d, want 0", len(manager.selectorUses))
+	}
+	// The vacated backing-array slot must be niled so the retired selector (and
+	// its SessionCache) is not retained for the manager's lifetime.
+	backing := manager.selectorUses[:cap(manager.selectorUses)]
+	for i, entry := range backing {
+		if entry != nil {
+			t.Fatalf("backing slot %d retains a stale entry after retirement", i)
+		}
+	}
+}
+
+// invalidatingSelector implements both StoppableSelector and InvalidateAuth; its
+// InvalidateAuth blocks until released to exercise the drain accounting.
+type invalidatingSelector struct {
+	RoundRobinSelector
+	stops   atomic.Int32
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *invalidatingSelector) Stop() { s.stops.Add(1) }
+
+func (s *invalidatingSelector) InvalidateAuth(string) {
+	close(s.started)
+	<-s.release
+}
+
+func TestManagerInvalidateSessionAffinityBlocksRetireStop(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	sel := &invalidatingSelector{started: make(chan struct{}), release: make(chan struct{})}
+	manager.SetSelector(sel)
+
+	go manager.invalidateSessionAffinity("auth-1")
+	<-sel.started // InvalidateAuth is running and holding the borrow
+
+	manager.SetSelector(&RoundRobinSelector{}) // queues retire(sel)
+	time.Sleep(40 * time.Millisecond)
+	if got := sel.stops.Load(); got != 0 {
+		t.Fatalf("selector Stopped while InvalidateAuth was in flight: stops=%d", got)
+	}
+
+	close(sel.release) // InvalidateAuth returns, releasing the borrow
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && sel.stops.Load() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := sel.stops.Load(); got != 1 {
+		t.Fatalf("selector Stop count = %d, want 1 after InvalidateAuth returns", got)
+	}
+}
+
+func TestManagerStopAutoRefreshThenSetSelectorNoDoubleStop(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	first := &stopCountingSelector{}
+	manager.SetSelector(first)
+
+	manager.StopAutoRefresh() // stops first exactly once and claims its entry
+	waitForStopCount(t, first, 1)
+
+	// A later SetSelector must not queue a second Stop on the already-stopped
+	// selector (Stop is not required to be idempotent).
+	manager.SetSelector(&RoundRobinSelector{})
+	time.Sleep(50 * time.Millisecond)
+	if got := first.stops.Load(); got != 1 {
+		t.Fatalf("first Stop count = %d, want exactly 1 (no double-stop)", got)
+	}
+}
+
+func TestSessionCacheStopIdempotentConcurrent(t *testing.T) {
+	c := NewSessionCache(time.Minute)
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.Stop()
+		}()
+	}
+	wg.Wait() // must not panic on double close(stopCh)
+}

--- a/sdk/cliproxy/auth/session_cache.go
+++ b/sdk/cliproxy/auth/session_cache.go
@@ -13,10 +13,11 @@ type sessionEntry struct {
 
 // SessionCache provides TTL-based session to auth mapping with automatic cleanup.
 type SessionCache struct {
-	mu      sync.RWMutex
-	entries map[string]sessionEntry
-	ttl     time.Duration
-	stopCh  chan struct{}
+	mu       sync.RWMutex
+	entries  map[string]sessionEntry
+	ttl      time.Duration
+	stopCh   chan struct{}
+	stopOnce sync.Once
 }
 
 // NewSessionCache creates a cache with the specified TTL.
@@ -118,13 +119,12 @@ func (c *SessionCache) InvalidateAuth(authID string) {
 	c.mu.Unlock()
 }
 
-// Stop terminates the background cleanup goroutine.
+// Stop terminates the background cleanup goroutine. Safe to call multiple times
+// and from multiple goroutines concurrently.
 func (c *SessionCache) Stop() {
-	select {
-	case <-c.stopCh:
-	default:
+	c.stopOnce.Do(func() {
 		close(c.stopCh)
-	}
+	})
 }
 
 func (c *SessionCache) cleanupLoop() {


### PR DESCRIPTION
Fixes #4287.

Hardens three subsystems surfaced during review. Full `go test ./...` passes, including `-race` on `sdk/cliproxy/auth`; `gofmt` clean.

## Reasoning-replay isolation & provider parity
- Namespace client-controlled replay session keys by access provider + **opaque** principal — no whitespace trim, so distinct principals never share a cache namespace. Client sessions without a caller principal are disabled rather than shared globally; trusted `execution:` keys keep their form.
- Bring **Antigravity** to parity with Codex/xAI:
  - `clearAntigravityReasoningReplayOnInvalidSignature` is log-only (a transient KV delete failure no longer replaces the real upstream status).
  - Add store-status semantics that **retain** prior replay state on a backend store error instead of wiping it.
  - Clear stale state on an empty *successful* completion only, gated on an observed `finishReason` (interrupted streams don't clear).

## Selector retirement concurrency (`sdk/cliproxy/auth`)
- Track in-flight picks per **Stoppable selector instance** via pointer-token entries; drain across installs (A→B→A→C) before `Stop`.
- Single exactly-once retirement claim shared by `retireSelector` and `StopAutoRefresh`; `Stop` runs **outside** the manager lock (no re-entrant deadlock).
- Drain `InvalidateAuth` before `Stop`; nil vacated slice slots (no retained `SessionCache`); idempotent `SessionCache.Stop`; capacity-aware selector identity; no panic on non-comparable/func-typed selectors.

## xAI terminal-error classification & routing
- Credential-affecting statuses (401/403/429/5xx) are classified **only** from structured `error.code`/`type`, never free-form message or `response.output`/`instructions` text — closing a shared-credential cooldown/suspension DoS vector. Message heuristics yield only client-error `400`s.
- Correct precedence (specific quota/rate/server codes over generic `invalid_request`), `account_deactivated` → 401, canonical `invalid_request_error` tagging so client errors aren't retried across credentials.
- Merge flat + nested error shapes, preserve flat codes through the Codex envelope, canonicalize bare 400s, reject non-HTTP/2xx numeric codes, and keep classified 5xx/429 from invalid-content downgrades.

## Tests
Added unit tests across all three areas: replay isolation (opaque principals, provider scoping), Antigravity store-status/clear parity, selector retirement (multi-generation drain, func-typed/non-comparable/slice-capacity identity, StopAutoRefresh/invalidate drain, idempotent stop), and xAI status classification (structured-only precedence, canonicalization, mixed-shape parsing, HTTP-status validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EmQGhzKpDAq3e54FUsug6