### PR TITLE
fix(stream): retry synchronous EOF during bootstrap

### DIFF
--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -955,6 +956,20 @@ func executionErrorMessage(err error) *interfaces.ErrorMessage {
 	return &interfaces.ErrorMessage{StatusCode: status, Error: err, Addon: addon}
 }
 
+func synchronousBootstrapRetryEligible(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
+}
+
+func streamResultWithError(err error) *coreexecutor.StreamResult {
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	chunks <- coreexecutor.StreamChunk{Err: err}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}
+}
+
 // ExecuteStreamWithAuthManager executes a streaming request via the core auth manager.
 // This path is the only supported execution route.
 // The returned http.Header carries upstream response headers captured before streaming begins.
@@ -1161,7 +1176,13 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	}
 	opts.Metadata = reqMeta
 	req, opts = h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
+	maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
 	streamResult, err := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
+	// Route synchronous EOFs through the existing chunk retry path so they share its retry budget.
+	if err != nil && maxBootstrapRetries > 0 && synchronousBootstrapRetryEligible(err) {
+		streamResult = streamResultWithError(err)
+		err = nil
+	}
 	if err != nil {
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
 		errChan := make(chan *interfaces.ErrorMessage, 1)
@@ -1274,7 +1295,6 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		bootstrapRetries := 0
 		chunkIndex := 0
 		var historyChunks [][]byte
-		maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
 
 		sendErr := func(msg *interfaces.ErrorMessage) bool {
 			if ctx == nil {
@@ -1344,6 +1364,12 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 								pendingChunks = nil
 								streamClosedBeforeRead = false
 								chunks = retryResult.Chunks
+								continue outer
+							}
+							if bootstrapRetries < maxBootstrapRetries && synchronousBootstrapRetryEligible(retryErr) {
+								pendingChunks = nil
+								streamClosedBeforeRead = false
+								chunks = streamResultWithError(retryErr).Chunks
 								continue outer
 							}
 							streamErr = enrichAuthSelectionError(retryErr, providers, normalizedModel)

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -3,7 +3,9 @@ package handlers
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -16,8 +18,10 @@ import (
 )
 
 type failOnceStreamExecutor struct {
-	mu    sync.Mutex
-	calls int
+	mu                  sync.Mutex
+	calls               int
+	synchronousFailures int
+	synchronousErr      error
 }
 
 func (e *failOnceStreamExecutor) Identifier() string { return "codex" }
@@ -31,6 +35,17 @@ func (e *failOnceStreamExecutor) ExecuteStream(context.Context, *coreauth.Auth, 
 	e.calls++
 	call := e.calls
 	e.mu.Unlock()
+
+	if call <= e.synchronousFailures {
+		if e.synchronousErr != nil {
+			return nil, e.synchronousErr
+		}
+		return nil, &url.Error{
+			Op:  "Post",
+			URL: "https://upstream.invalid/responses",
+			Err: io.ErrUnexpectedEOF,
+		}
+	}
 
 	ch := make(chan coreexecutor.StreamChunk, 1)
 	if call == 1 {
@@ -80,8 +95,10 @@ func (e *failOnceStreamExecutor) Calls() int {
 }
 
 type payloadThenErrorStreamExecutor struct {
-	mu    sync.Mutex
-	calls int
+	mu          sync.Mutex
+	calls       int
+	payload     []byte
+	terminalErr error
 }
 
 func (e *payloadThenErrorStreamExecutor) Identifier() string { return "codex" }
@@ -95,16 +112,22 @@ func (e *payloadThenErrorStreamExecutor) ExecuteStream(context.Context, *coreaut
 	e.calls++
 	e.mu.Unlock()
 
-	ch := make(chan coreexecutor.StreamChunk, 2)
-	ch <- coreexecutor.StreamChunk{Payload: []byte("partial")}
-	ch <- coreexecutor.StreamChunk{
-		Err: &coreauth.Error{
+	payload := e.payload
+	if len(payload) == 0 {
+		payload = []byte("partial")
+	}
+	terminalErr := e.terminalErr
+	if terminalErr == nil {
+		terminalErr = &coreauth.Error{
 			Code:       "upstream_closed",
 			Message:    "upstream closed",
 			Retryable:  false,
 			HTTPStatus: http.StatusBadGateway,
-		},
+		}
 	}
+	ch := make(chan coreexecutor.StreamChunk, 2)
+	ch <- coreexecutor.StreamChunk{Payload: payload}
+	ch <- coreexecutor.StreamChunk{Err: terminalErr}
 	close(ch)
 	return &coreexecutor.StreamResult{Chunks: ch}, nil
 }
@@ -268,6 +291,121 @@ func (e *authAwareStreamExecutor) AuthIDs() []string {
 	out := make([]string, len(e.authIDs))
 	copy(out, e.authIDs)
 	return out
+}
+
+func newStreamBootstrapTestHandler(t *testing.T, executor coreauth.ProviderExecutor, bootstrapRetries int) *BaseAPIHandler {
+	t.Helper()
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{
+		ID:       "sync-failure-auth",
+		Provider: executor.Identifier(),
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{"email": "sync-failure@example.com"},
+	}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("manager.Register(auth): %v", err)
+	}
+
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	return NewBaseAPIHandlers(&sdkconfig.SDKConfig{
+		PassthroughHeaders: true,
+		Streaming: sdkconfig.StreamingConfig{
+			BootstrapRetries: bootstrapRetries,
+		},
+	}, manager)
+}
+
+func TestExecuteStreamWithAuthManager_RetriesSynchronousUnexpectedEOF(t *testing.T) {
+	executor := &failOnceStreamExecutor{synchronousFailures: 1}
+	handler := newStreamBootstrapTestHandler(t, executor, 1)
+
+	dataChan, upstreamHeaders, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "test-model", []byte(`{"model":"test-model"}`), "")
+	if dataChan == nil || errChan == nil {
+		t.Fatalf("expected non-nil channels")
+	}
+
+	var got []byte
+	for chunk := range dataChan {
+		got = append(got, chunk...)
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected error: %+v", msg)
+		}
+	}
+
+	if string(got) != "ok" {
+		t.Fatalf("payload = %q, want %q", string(got), "ok")
+	}
+	if calls := executor.Calls(); calls != 2 {
+		t.Fatalf("stream attempts = %d, want 2", calls)
+	}
+	if attempt := upstreamHeaders.Get("X-Upstream-Attempt"); attempt != "2" {
+		t.Fatalf("upstream attempt header = %q, want %q", attempt, "2")
+	}
+}
+
+func TestExecuteStreamWithAuthManager_ExhaustsSynchronousUnexpectedEOFRetries(t *testing.T) {
+	executor := &failOnceStreamExecutor{synchronousFailures: 4}
+	handler := newStreamBootstrapTestHandler(t, executor, 3)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "test-model", []byte(`{"model":"test-model"}`), "")
+	if dataChan == nil || errChan == nil {
+		t.Fatalf("expected non-nil channels")
+	}
+
+	for chunk := range dataChan {
+		t.Fatalf("unexpected payload: %q", string(chunk))
+	}
+	var gotErr *interfaces.ErrorMessage
+	for msg := range errChan {
+		if msg != nil {
+			gotErr = msg
+		}
+	}
+
+	if calls := executor.Calls(); calls != 4 {
+		t.Fatalf("stream attempts = %d, want 4", calls)
+	}
+	if gotErr == nil || !errors.Is(gotErr.Error, io.ErrUnexpectedEOF) {
+		t.Fatalf("terminal error = %v, want wrapped io.ErrUnexpectedEOF", gotErr)
+	}
+	if gotErr.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", gotErr.StatusCode, http.StatusInternalServerError)
+	}
+}
+
+func TestExecuteStreamWithAuthManager_DoesNotRetrySynchronousNonEOFError(t *testing.T) {
+	translationErr := errors.New("request translation failed")
+	executor := &failOnceStreamExecutor{
+		synchronousFailures: 1,
+		synchronousErr:      translationErr,
+	}
+	handler := newStreamBootstrapTestHandler(t, executor, 3)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "test-model", []byte(`{"model":"test-model"}`), "")
+	if dataChan != nil {
+		t.Fatalf("expected nil data channel")
+	}
+	var gotErr *interfaces.ErrorMessage
+	for msg := range errChan {
+		if msg != nil {
+			gotErr = msg
+		}
+
+	}
+	if calls := executor.Calls(); calls != 1 {
+		t.Fatalf("stream attempts = %d, want 1", calls)
+	}
+	if gotErr == nil || !errors.Is(gotErr.Error, translationErr) {
+		t.Fatalf("terminal error = %v, want request translation failure", gotErr)
+	}
 }
 
 func TestExecuteStreamWithAuthManager_RetriesBeforeFirstByte(t *testing.T) {
@@ -463,6 +601,40 @@ func TestExecuteStreamWithAuthManager_DoesNotRetryAfterFirstByte(t *testing.T) {
 	}
 	if executor.Calls() != 1 {
 		t.Fatalf("expected 1 stream attempt, got %d", executor.Calls())
+	}
+}
+
+func TestExecuteStreamWithAuthManager_DoesNotRetryAfterToolCallPayload(t *testing.T) {
+	executor := &payloadThenErrorStreamExecutor{
+		payload:     []byte(`data: {"id":"chatcmpl-retry-guard","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_retry_guard_1","type":"function","function":{"name":"lookup","arguments":"{}"}}]}}]}`),
+		terminalErr: io.ErrUnexpectedEOF,
+	}
+	handler := newStreamBootstrapTestHandler(t, executor, 3)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "test-model", []byte(`{"model":"test-model"}`), "")
+	if dataChan == nil || errChan == nil {
+		t.Fatalf("expected non-nil channels")
+	}
+
+	var got []byte
+	for chunk := range dataChan {
+		got = append(got, chunk...)
+	}
+	var gotErr error
+	for msg := range errChan {
+		if msg != nil && msg.Error != nil {
+			gotErr = msg.Error
+		}
+	}
+
+	if strings.Count(string(got), "call_retry_guard_1") != 1 {
+		t.Fatalf("expected one tool call payload, got %q", string(got))
+	}
+	if !errors.Is(gotErr, io.ErrUnexpectedEOF) {
+		t.Fatalf("terminal error = %v, want io.ErrUnexpectedEOF", gotErr)
+	}
+	if calls := executor.Calls(); calls != 1 {
+		t.Fatalf("stream attempts = %d, want 1", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Route synchronous `io.EOF` / `io.ErrUnexpectedEOF` failures into the existing streaming bootstrap retry path.
- Keep cancellation, deadline, and non-EOF synchronous errors terminal.
- Preserve the existing guard that prevents retries after any downstream payload has been emitted.

## Problem

The streaming handler already retries eligible failures delivered through `StreamResult.Chunks` before the first payload. However, `AuthManager.ExecuteStream` can fail synchronously before returning a `StreamResult`, for example when an upstream POST ends with `unexpected EOF` before any response headers arrive.

That synchronous path returned immediately, so a configured `streaming.bootstrap-retries` value was never consumed. In observed failures, CLIProxyAPI made one upstream POST and returned HTTP 500 even though bootstrap retries were enabled.

## Change

When bootstrap retries are enabled and the synchronous error unwraps to `io.EOF` or `io.ErrUnexpectedEOF`, the handler converts it into an internal one-error stream result and passes it through the existing bootstrap state machine.

The same handling applies when a retry attempt itself fails synchronously with EOF, so synchronous and chunk-delivered bootstrap failures share one retry budget. A successful retry still replaces the upstream response headers before the first downstream payload.

This change does not modify request parameters, transport selection, retry counts, credential selection, credential cooldowns, or mid-stream behavior. The default `bootstrap-retries: 0` behavior is unchanged.

## Evidence

Instrumentation of the original failure showed this sequence:

1. TCP and TLS completed successfully.
2. HTTP/2 was negotiated and the request was written.
3. No upstream response headers or SSE event were received.
4. The request ended with `unexpected EOF`.
5. Only one upstream POST was attempted despite `streaming.bootstrap-retries: 3`.

In a controlled live comparison using the same request shape and network path:

- Patched build: 20/20 requests completed. Two requests encountered a real pre-header EOF and both recovered on the second upstream POST.
- Immediate rollback: 18/20 requests completed. The two failures each made one upstream POST and returned HTTP 500 with `unexpected EOF`.

The same EOF class was also observed with the standard Go transport and on fresh connections, so this recovery change is independent of transport selection.

## Safety and trade-off

- Only errors matching `errors.Is(err, io.EOF)` or `errors.Is(err, io.ErrUnexpectedEOF)` enter this path.
- `context.Canceled`, `context.DeadlineExceeded`, translation failures, and other synchronous errors are not retried.
- Once any payload has been sent downstream, the existing `sentPayload` guard prevents another upstream attempt. A regression test emits a Chat Completions tool-call delta and verifies one payload and one upstream attempt.
- The configured budget is preserved: `bootstrap-retries: N` allows at most `1 + N` upstream attempts.

A missing response does not prove that the upstream did no work. Retrying a POST before response headers arrive can therefore duplicate upstream computation or billing. This patch limits that risk to the explicitly configured bootstrap window and prevents duplicate downstream output or tool calls.

## Related work

- #3726 proposed retrying statusless `unexpected EOF` in the shared auth conductor through `request-retry`. This patch does not change conductor or request-retry semantics; it closes the narrower gap in the existing `streaming.bootstrap-retries` path before the first payload.
- #3353 classifies EOF as HTTP 502 so a failed credential can be cooled down and another credential selected. This patch does not reclassify errors or alter credential availability, and it also addresses the single-credential case.
- #4210 changes the transport selected for `chatgpt.com`. This patch does not select or modify a transport and is orthogonal to that proposal.

## Testing

```text
go test ./sdk/api/handlers -run 'TestExecuteStreamWithAuthManager_(RetriesSynchronousUnexpectedEOF|ExhaustsSynchronousUnexpectedEOFRetries|DoesNotRetrySynchronousNonEOFError|DoesNotRetryAfterFirstByte|DoesNotRetryAfterToolCallPayload)$' -count=20
go test ./sdk/api/handlers -count=1
go test ./... -count=1
go build -o test-output ./cmd/server
```

Focused coverage verifies synchronous EOF recovery, retry exhaustion (`bootstrap-retries + 1` total attempts), non-EOF exclusion, preservation of existing post-payload status handling, no duplicate tool-call payload, and replacement of upstream headers with the successful retry response.
