### PR TITLE
fix(translator): strip data URI prefix from OpenAI file_data for Gemini inlineData

### DIFF
--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -209,6 +209,11 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 								ext = sp[len(sp)-1]
 							}
 							if mimeType, ok := misc.MimeTypes[ext]; ok {
+								// fileData is a data URL ("data:<mime>;base64,<payload>"); Gemini
+								// wants the raw base64 payload only, not the whole data URL.
+								if i := strings.Index(fileData, ";base64,"); i >= 0 {
+									fileData = fileData[i+len(";base64,"):]
+								}
 								node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".inlineData.mimeType", mimeType)
 								node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".inlineData.data", fileData)
 								p++

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
@@ -223,6 +223,11 @@ func ConvertOpenAIRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 								ext = sp[len(sp)-1]
 							}
 							if mimeType, ok := misc.MimeTypes[ext]; ok {
+								// fileData is a data URL ("data:<mime>;base64,<payload>"); Gemini
+								// wants the raw base64 payload only, not the whole data URL.
+								if i := strings.Index(fileData, ";base64,"); i >= 0 {
+									fileData = fileData[i+len(";base64,"):]
+								}
 								node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".inlineData.mime_type", mimeType)
 								node, _ = sjson.SetBytes(node, "parts."+itoa(p)+".inlineData.data", fileData)
 								p++


### PR DESCRIPTION
## Problem

When an OpenAI-compatible client sends a file attachment (e.g. a PDF) as a `file` content part, requests to Gemini / Antigravity models fail with:

Invalid value at 'request.contents[0].parts[1].inline_data.data' (TYPE_BYTES), Base64 decoding failed for "data:application/pdf;base64,JVBER..."

Image attachments (`image_url`) work fine — only `file` parts are affected.

## Root cause

In the OpenAI → Gemini/Antigravity request translators, the `image_url` branch strips the `data:<mime>;base64,` prefix before writing the payload to `inlineData.data`, but the `file` branch writes `file.file_data` through verbatim.

OpenAI's `file.file_data` is a data URL (`data:application/pdf;base64,<payload>`), whereas Gemini's `inlineData.data` expects the raw base64 payload only (the media type is carried separately in `mimeType`). Passing the whole data URL makes Gemini try to base64-decode the `data:...;base64,` prefix, which fails.

Affected files:
- `internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go`
- `internal/translator/gemini/openai/chat-completions/gemini_openai_request.go`

## Fix

Strip the `data:<mime>;base64,` prefix in the `file` branch, mirroring the existing `image_url` handling:

```go
if i := strings.Index(fileData, ";base64,"); i >= 0 {
    fileData = fileData[i+len(";base64,"):]
}
```

Locating the marker with strings.Index(";base64,") (rather than fixed offsets) also tolerates data URLs with extra parameters (e.g. ;charset=). If the marker is absent (already-raw base64), the value is passed through unchanged, so there is no behavior change for existing inputs.