### PR TITLE
fix(openai): start Responses keepalives during stream bootstrap

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	. "github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
@@ -485,7 +486,22 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 	// New core execution path
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
-	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+	type streamExecutionResult struct {
+		data            <-chan []byte
+		upstreamHeaders http.Header
+		errs            <-chan *interfaces.ErrorMessage
+	}
+	// Auth selection validates the upstream stream bootstrap synchronously. Run it separately so
+	// configured downstream keep-alives can start while the first upstream payload is still pending.
+	executionChan := make(chan streamExecutionResult, 1)
+	go func() {
+		data, upstreamHeaders, errs := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+		executionChan <- streamExecutionResult{data: data, upstreamHeaders: upstreamHeaders, errs: errs}
+	}()
+
+	var dataChan <-chan []byte
+	var upstreamHeaders http.Header
+	var errChan <-chan *interfaces.ErrorMessage
 
 	setSSEHeaders := func() {
 		c.Header("Content-Type", "text/event-stream")
@@ -494,21 +510,65 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		c.Header("Access-Control-Allow-Origin", "*")
 	}
 	framer := &responsesSSEFramer{}
+	streamCommitted := false
+	commitStream := func() {
+		if streamCommitted {
+			return
+		}
+		setSSEHeaders()
+		handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+		streamCommitted = true
+	}
+	writeStreamError := func(errMsg *interfaces.ErrorMessage) {
+		if errMsg == nil {
+			return
+		}
+		framer.Flush(c.Writer)
+		status := http.StatusInternalServerError
+		if errMsg.StatusCode > 0 {
+			status = errMsg.StatusCode
+		}
+		errText := http.StatusText(status)
+		if errMsg.Error != nil && errMsg.Error.Error() != "" {
+			errText = errMsg.Error.Error()
+		}
+		chunk := handlers.BuildOpenAIResponsesStreamErrorChunk(status, errText, 0)
+		_, _ = fmt.Fprintf(c.Writer, "\nevent: error\ndata: %s\n\n", string(chunk))
+	}
 
-	// Peek at the first chunk
+	keepAliveInterval := handlers.StreamingKeepAliveInterval(h.Cfg)
+	var keepAlive *time.Ticker
+	var keepAliveC <-chan time.Time
+	if keepAliveInterval > 0 {
+		keepAlive = time.NewTicker(keepAliveInterval)
+		defer keepAlive.Stop()
+		keepAliveC = keepAlive.C
+	}
+
+	// Wait for stream execution and peek at the first chunk.
 	for {
 		select {
 		case <-c.Request.Context().Done():
 			cliCancel(c.Request.Context().Err())
 			return
+		case execution := <-executionChan:
+			dataChan = execution.data
+			upstreamHeaders = execution.upstreamHeaders
+			errChan = execution.errs
+			executionChan = nil
 		case errMsg, ok := <-errChan:
 			if !ok {
 				// Err channel closed cleanly; wait for data channel.
 				errChan = nil
 				continue
 			}
-			// Upstream failed immediately. Return proper error status and JSON.
-			h.WriteErrorResponse(c, errMsg)
+			if streamCommitted {
+				writeStreamError(errMsg)
+				flusher.Flush()
+			} else {
+				// Upstream failed immediately. Return proper error status and JSON.
+				h.WriteErrorResponse(c, errMsg)
+			}
 			if errMsg != nil {
 				cliCancel(errMsg.Error)
 			} else {
@@ -518,8 +578,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		case chunk, ok := <-dataChan:
 			if !ok {
 				// Stream closed without data? Send headers and done.
-				setSSEHeaders()
-				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+				commitStream()
 				_, _ = c.Writer.Write([]byte("\n"))
 				flusher.Flush()
 				cliCancel(nil)
@@ -527,8 +586,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			}
 
 			// Success! Set headers.
-			setSSEHeaders()
-			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+			commitStream()
 
 			// Write first chunk logic (matching forwardResponsesStream)
 			framer.WriteChunk(c.Writer, chunk)
@@ -537,6 +595,10 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			// Continue
 			h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan, framer)
 			return
+		case <-keepAliveC:
+			commitStream()
+			_, _ = c.Writer.Write([]byte(": keep-alive\n\n"))
+			flusher.Flush()
 		}
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -494,8 +494,9 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 	// Auth selection validates the upstream stream bootstrap synchronously. Run it separately so
 	// configured downstream keep-alives can start while the first upstream payload is still pending.
 	executionChan := make(chan streamExecutionResult, 1)
+	bgCtx := context.WithValue(cliCtx, "gin", c.Copy())
 	go func() {
-		data, upstreamHeaders, errs := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+		data, upstreamHeaders, errs := h.ExecuteStreamWithAuthManager(bgCtx, h.HandlerType(), modelName, rawJSON, "")
 		executionChan <- streamExecutionResult{data: data, upstreamHeaders: upstreamHeaders, errs: errs}
 	}()
 
@@ -544,6 +545,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		defer keepAlive.Stop()
 		keepAliveC = keepAlive.C
 	}
+	requiresExecutionHeaders := handlers.PassthroughHeadersEnabled(h.Cfg) || h.PluginHost != nil
 
 	// Wait for stream execution and peek at the first chunk.
 	for {
@@ -596,6 +598,10 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan, framer)
 			return
 		case <-keepAliveC:
+			// Once the response is committed, late upstream or interceptor headers cannot be added.
+			if executionChan != nil && requiresExecutionHeaders {
+				continue
+			}
 			commitStream()
 			_, _ = c.Writer.Write([]byte(": keep-alive\n\n"))
 			flusher.Flush()

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -545,7 +545,11 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		defer keepAlive.Stop()
 		keepAliveC = keepAlive.C
 	}
-	requiresExecutionHeaders := handlers.PassthroughHeadersEnabled(h.Cfg) || h.PluginHost != nil
+	streamInterceptorsActive := h.PluginHost != nil
+	if detector, ok := h.PluginHost.(interface{ HasStreamInterceptors() bool }); ok {
+		streamInterceptorsActive = detector.HasStreamInterceptors()
+	}
+	requiresExecutionHeaders := handlers.PassthroughHeadersEnabled(h.Cfg) || streamInterceptorsActive
 
 	// Wait for stream execution and peek at the first chunk.
 	for {

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -599,7 +599,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			return
 		case <-keepAliveC:
 			// Once the response is committed, late upstream or interceptor headers cannot be added.
-			if executionChan != nil && requiresExecutionHeaders {
+			if requiresExecutionHeaders {
 				continue
 			}
 			commitStream()

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -1,17 +1,58 @@
 package openai
 
 import (
+	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"github.com/tidwall/gjson"
 )
+
+type delayedResponsesStreamExecutor struct {
+	release <-chan struct{}
+}
+
+func (e *delayedResponsesStreamExecutor) Identifier() string { return "test-provider" }
+
+func (e *delayedResponsesStreamExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *delayedResponsesStreamExecutor) ExecuteStream(ctx context.Context, _ *coreauth.Auth, _ coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	chunks := make(chan coreexecutor.StreamChunk)
+	go func() {
+		defer close(chunks)
+		select {
+		case <-ctx.Done():
+		case <-e.release:
+		}
+	}()
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *delayedResponsesStreamExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *delayedResponsesStreamExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *delayedResponsesStreamExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
 
 func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *httptest.ResponseRecorder, *gin.Context, http.Flusher) {
 	t.Helper()
@@ -30,6 +71,75 @@ func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *h
 	}
 
 	return h, recorder, c, flusher
+}
+
+func TestResponsesStreamingSendsConfiguredKeepAliveBeforeFirstChunk(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+
+	executor := &delayedResponsesStreamExecutor{release: release}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "responses-keepalive-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	modelID := "test-responses-keepalive-model"
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelID}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	cfg := &sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{KeepAliveSeconds: 1}}
+	base := handlers.NewBaseAPIHandlers(cfg, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/responses", strings.NewReader(`{"model":"`+modelID+`","stream":true,"input":"hello"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := server.Client()
+	client.Timeout = 2500 * time.Millisecond
+
+	started := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("stream did not start before the first upstream chunk: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed >= 2*time.Second {
+		t.Fatalf("stream headers took %s, want less than 2s", elapsed)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+
+	close(release)
+	released = true
+	body, err := io.ReadAll(resp.Body)
+	if errClose := resp.Body.Close(); err == nil && errClose != nil {
+		err = errClose
+	}
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	if !strings.HasPrefix(string(body), ": keep-alive\n\n") {
+		t.Fatalf("body = %q, want pre-first-chunk keep-alive", body)
+	}
 }
 
 func TestForwardResponsesStreamSeparatesDataOnlySSEChunks(t *testing.T) {

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,6 +23,8 @@ import (
 
 type delayedResponsesStreamExecutor struct {
 	release <-chan struct{}
+	headers http.Header
+	payload []byte
 }
 
 func (e *delayedResponsesStreamExecutor) Identifier() string { return "test-provider" }
@@ -37,9 +40,15 @@ func (e *delayedResponsesStreamExecutor) ExecuteStream(ctx context.Context, _ *c
 		select {
 		case <-ctx.Done():
 		case <-e.release:
+			if len(e.payload) > 0 {
+				select {
+				case <-ctx.Done():
+				case chunks <- coreexecutor.StreamChunk{Payload: e.payload}:
+				}
+			}
 		}
 	}()
-	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	return &coreexecutor.StreamResult{Headers: e.headers.Clone(), Chunks: chunks}, nil
 }
 
 func (e *delayedResponsesStreamExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
@@ -52,6 +61,43 @@ func (e *delayedResponsesStreamExecutor) CountTokens(context.Context, *coreauth.
 
 func (e *delayedResponsesStreamExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
 	return nil, errors.New("not implemented")
+}
+
+func newDelayedResponsesStreamServer(t *testing.T, cfg *sdkconfig.SDKConfig, upstreamHeaders http.Header) (*httptest.Server, func(), string) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	releaseChan := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseChan)
+		})
+	}
+	executor := &delayedResponsesStreamExecutor{
+		release: releaseChan,
+		headers: upstreamHeaders,
+		payload: []byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-keepalive\",\"output\":[]}}\n\n"),
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	authID := t.Name() + "-auth"
+	auth := &coreauth.Auth{ID: authID, Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	modelID := t.Name() + "-model"
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelID}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(cfg, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+	return httptest.NewServer(router), release, modelID
 }
 
 func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *httptest.ResponseRecorder, *gin.Context, http.Flusher) {
@@ -74,36 +120,10 @@ func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *h
 }
 
 func TestResponsesStreamingSendsConfiguredKeepAliveBeforeFirstChunk(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	release := make(chan struct{})
-	released := false
-	defer func() {
-		if !released {
-			close(release)
-		}
-	}()
-
-	executor := &delayedResponsesStreamExecutor{release: release}
-	manager := coreauth.NewManager(nil, nil, nil)
-	manager.RegisterExecutor(executor)
-
-	auth := &coreauth.Auth{ID: "responses-keepalive-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
-	if _, err := manager.Register(context.Background(), auth); err != nil {
-		t.Fatalf("Register auth: %v", err)
-	}
-	modelID := "test-responses-keepalive-model"
-	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelID}})
-	t.Cleanup(func() {
-		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
-	})
-
 	cfg := &sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{KeepAliveSeconds: 1}}
-	base := handlers.NewBaseAPIHandlers(cfg, manager)
-	h := NewOpenAIResponsesAPIHandler(base)
-	router := gin.New()
-	router.POST("/v1/responses", h.Responses)
-	server := httptest.NewServer(router)
+	server, release, modelID := newDelayedResponsesStreamServer(t, cfg, nil)
 	defer server.Close()
+	defer release()
 
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/responses", strings.NewReader(`{"model":"`+modelID+`","stream":true,"input":"hello"}`))
 	if err != nil {
@@ -128,8 +148,7 @@ func TestResponsesStreamingSendsConfiguredKeepAliveBeforeFirstChunk(t *testing.T
 		t.Fatalf("Content-Type = %q, want text/event-stream", got)
 	}
 
-	close(release)
-	released = true
+	release()
 	body, err := io.ReadAll(resp.Body)
 	if errClose := resp.Body.Close(); err == nil && errClose != nil {
 		err = errClose
@@ -139,6 +158,48 @@ func TestResponsesStreamingSendsConfiguredKeepAliveBeforeFirstChunk(t *testing.T
 	}
 	if !strings.HasPrefix(string(body), ": keep-alive\n\n") {
 		t.Fatalf("body = %q, want pre-first-chunk keep-alive", body)
+	}
+}
+
+func TestResponsesStreamingPreservesPassthroughHeadersBeforeKeepAlive(t *testing.T) {
+	cfg := &sdkconfig.SDKConfig{
+		PassthroughHeaders: true,
+		Streaming:          sdkconfig.StreamingConfig{KeepAliveSeconds: 1},
+	}
+	server, release, modelID := newDelayedResponsesStreamServer(t, cfg, http.Header{"X-Request-ID": {"req-delayed"}})
+	defer server.Close()
+	defer release()
+	timer := time.AfterFunc(1200*time.Millisecond, release)
+	defer timer.Stop()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/responses", strings.NewReader(`{"model":"`+modelID+`","stream":true,"input":"hello"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := server.Client()
+	client.Timeout = 3 * time.Second
+
+	started := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("stream did not start after upstream headers became available: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed < time.Second {
+		t.Fatalf("stream committed after %s, before delayed upstream headers were available", elapsed)
+	}
+	if got := resp.Header.Get("X-Request-ID"); got != "req-delayed" {
+		t.Fatalf("X-Request-ID = %q, want req-delayed", got)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if errClose := resp.Body.Close(); err == nil && errClose != nil {
+		err = errClose
+	}
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	if strings.HasPrefix(string(body), ": keep-alive\n\n") {
+		t.Fatalf("body = %q, keep-alive committed before passthrough headers", body)
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -151,44 +151,55 @@ func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *h
 }
 
 func TestResponsesStreamingSendsConfiguredKeepAliveBeforeFirstChunk(t *testing.T) {
-	cfg := &sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{KeepAliveSeconds: 1}}
-	server, release, modelID := newDelayedResponsesStreamServer(t, cfg, nil, nil)
-	defer server.Close()
-	defer release()
+	testCases := []struct {
+		name       string
+		pluginHost handlers.PluginInterceptorHost
+	}{
+		{name: "without_plugin_host"},
+		{name: "with_inactive_plugin_host", pluginHost: &responsesStreamInterceptorHost{}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{KeepAliveSeconds: 1}}
+			server, release, modelID := newDelayedResponsesStreamServer(t, cfg, nil, tc.pluginHost)
+			defer server.Close()
+			defer release()
 
-	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/responses", strings.NewReader(`{"model":"`+modelID+`","stream":true,"input":"hello"}`))
-	if err != nil {
-		t.Fatalf("NewRequest: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	client := server.Client()
-	client.Timeout = 2500 * time.Millisecond
+			req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/responses", strings.NewReader(`{"model":"`+modelID+`","stream":true,"input":"hello"}`))
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			client := server.Client()
+			client.Timeout = 2500 * time.Millisecond
 
-	started := time.Now()
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("stream did not start before the first upstream chunk: %v", err)
-	}
-	if elapsed := time.Since(started); elapsed >= 2*time.Second {
-		t.Fatalf("stream headers took %s, want less than 2s", elapsed)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
-	}
-	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
-		t.Fatalf("Content-Type = %q, want text/event-stream", got)
-	}
+			started := time.Now()
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("stream did not start before the first upstream chunk: %v", err)
+			}
+			if elapsed := time.Since(started); elapsed >= 2*time.Second {
+				t.Fatalf("stream headers took %s, want less than 2s", elapsed)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+			}
+			if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+				t.Fatalf("Content-Type = %q, want text/event-stream", got)
+			}
 
-	release()
-	body, err := io.ReadAll(resp.Body)
-	if errClose := resp.Body.Close(); err == nil && errClose != nil {
-		err = errClose
-	}
-	if err != nil {
-		t.Fatalf("read response body: %v", err)
-	}
-	if !strings.HasPrefix(string(body), ": keep-alive\n\n") {
-		t.Fatalf("body = %q, want pre-first-chunk keep-alive", body)
+			release()
+			body, err := io.ReadAll(resp.Body)
+			if errClose := resp.Body.Close(); err == nil && errClose != nil {
+				err = errClose
+			}
+			if err != nil {
+				t.Fatalf("read response body: %v", err)
+			}
+			if !strings.HasPrefix(string(body), ": keep-alive\n\n") {
+				t.Fatalf("body = %q, want pre-first-chunk keep-alive", body)
+			}
+		})
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -18,6 +18,7 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	"github.com/tidwall/gjson"
 )
 
@@ -63,7 +64,36 @@ func (e *delayedResponsesStreamExecutor) HttpRequest(context.Context, *coreauth.
 	return nil, errors.New("not implemented")
 }
 
-func newDelayedResponsesStreamServer(t *testing.T, cfg *sdkconfig.SDKConfig, upstreamHeaders http.Header) (*httptest.Server, func(), string) {
+type responsesStreamInterceptorHost struct {
+	interceptStreamChunk func(context.Context, pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse
+}
+
+func (h *responsesStreamInterceptorHost) InterceptRequestBeforeAuth(_ context.Context, req pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
+	return pluginapi.RequestInterceptResponse{Headers: req.Headers.Clone(), Body: append([]byte(nil), req.Body...)}
+}
+
+func (h *responsesStreamInterceptorHost) InterceptRequestAfterAuth(_ context.Context, req pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
+	return pluginapi.RequestInterceptResponse{Headers: req.Headers.Clone(), Body: append([]byte(nil), req.Body...)}
+}
+
+func (h *responsesStreamInterceptorHost) InterceptResponse(_ context.Context, req pluginapi.ResponseInterceptRequest) pluginapi.ResponseInterceptResponse {
+	return pluginapi.ResponseInterceptResponse{Headers: req.ResponseHeaders.Clone(), Body: append([]byte(nil), req.Body...)}
+}
+
+func (h *responsesStreamInterceptorHost) InterceptStreamChunk(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+	if h != nil && h.interceptStreamChunk != nil {
+		return h.interceptStreamChunk(ctx, req)
+	}
+	return pluginapi.StreamChunkInterceptResponse{Headers: req.ResponseHeaders.Clone(), Body: append([]byte(nil), req.Body...)}
+}
+
+func (h *responsesStreamInterceptorHost) HasRequestInterceptors() bool { return false }
+
+func (h *responsesStreamInterceptorHost) HasStreamInterceptors() bool {
+	return h != nil && h.interceptStreamChunk != nil
+}
+
+func newDelayedResponsesStreamServer(t *testing.T, cfg *sdkconfig.SDKConfig, upstreamHeaders http.Header, pluginHost handlers.PluginInterceptorHost) (*httptest.Server, func(), string) {
 	t.Helper()
 
 	gin.SetMode(gin.TestMode)
@@ -95,6 +125,7 @@ func newDelayedResponsesStreamServer(t *testing.T, cfg *sdkconfig.SDKConfig, ups
 
 	base := handlers.NewBaseAPIHandlers(cfg, manager)
 	h := NewOpenAIResponsesAPIHandler(base)
+	h.SetPluginHost(pluginHost)
 	router := gin.New()
 	router.POST("/v1/responses", h.Responses)
 	return httptest.NewServer(router), release, modelID
@@ -121,7 +152,7 @@ func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *h
 
 func TestResponsesStreamingSendsConfiguredKeepAliveBeforeFirstChunk(t *testing.T) {
 	cfg := &sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{KeepAliveSeconds: 1}}
-	server, release, modelID := newDelayedResponsesStreamServer(t, cfg, nil)
+	server, release, modelID := newDelayedResponsesStreamServer(t, cfg, nil, nil)
 	defer server.Close()
 	defer release()
 
@@ -166,7 +197,7 @@ func TestResponsesStreamingPreservesPassthroughHeadersBeforeKeepAlive(t *testing
 		PassthroughHeaders: true,
 		Streaming:          sdkconfig.StreamingConfig{KeepAliveSeconds: 1},
 	}
-	server, release, modelID := newDelayedResponsesStreamServer(t, cfg, http.Header{"X-Request-ID": {"req-delayed"}})
+	server, release, modelID := newDelayedResponsesStreamServer(t, cfg, http.Header{"X-Request-ID": {"req-delayed"}}, nil)
 	defer server.Close()
 	defer release()
 	timer := time.AfterFunc(1200*time.Millisecond, release)
@@ -200,6 +231,52 @@ func TestResponsesStreamingPreservesPassthroughHeadersBeforeKeepAlive(t *testing
 	}
 	if strings.HasPrefix(string(body), ": keep-alive\n\n") {
 		t.Fatalf("body = %q, keep-alive committed before passthrough headers", body)
+	}
+}
+
+func TestResponsesStreamingPreservesInterceptorHeadersBeforeKeepAlive(t *testing.T) {
+	cfg := &sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{KeepAliveSeconds: 1}}
+	pluginHost := &responsesStreamInterceptorHost{
+		interceptStreamChunk: func(_ context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			headers := req.ResponseHeaders.Clone()
+			if headers == nil {
+				headers = make(http.Header)
+			}
+			if req.ChunkIndex == 0 {
+				time.Sleep(1200 * time.Millisecond)
+				headers.Set("X-Plugin-Header", "ready")
+			}
+			return pluginapi.StreamChunkInterceptResponse{Headers: headers, Body: append([]byte(nil), req.Body...)}
+		},
+	}
+	server, release, modelID := newDelayedResponsesStreamServer(t, cfg, nil, pluginHost)
+	defer server.Close()
+	release()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/responses", strings.NewReader(`{"model":"`+modelID+`","stream":true,"input":"hello"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := server.Client()
+	client.Timeout = 3 * time.Second
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("stream did not start after interceptor headers became available: %v", err)
+	}
+	if got := resp.Header.Get("X-Plugin-Header"); got != "ready" {
+		t.Fatalf("X-Plugin-Header = %q, want ready", got)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if errClose := resp.Body.Close(); err == nil && errClose != nil {
+		err = errClose
+	}
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	if strings.HasPrefix(string(body), ": keep-alive\n\n") {
+		t.Fatalf("body = %q, keep-alive committed before interceptor headers", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Start configured OpenAI Responses SSE keep-alives while the core auth manager is still validating the upstream stream bootstrap.
- Run the bootstrap with a copied Gin context so background reads cannot race with response writes or access a recycled request context.
- Preserve existing auth rotation, bootstrap retry, and model fallback behavior.
- Keep immediate pre-commit failures as normal HTTP errors; emit a Responses SSE error event after the stream is committed.
- Delay the first heartbeat when passthrough headers or active stream interceptors require execution-time response headers, preventing those headers from being silently lost.
- Do not add server-side upstream timeouts or change WebSocket behavior.

`ExecuteStreamWithAuthManager` can block synchronously in `readStreamBootstrap` until the first non-empty upstream payload arrives. Previously, the Responses handler called it before starting its keep-alive ticker, so `streaming.keepalive-seconds` could not emit headers or heartbeats during the pre-first-chunk wait.

## Test plan

- [x] End-to-end delayed-bootstrap test proves `text/event-stream` headers and `: keep-alive` arrive before the first upstream chunk.
- [x] Inactive-plugin-host regression test proves the default empty host does not suppress bootstrap heartbeats.
- [x] Passthrough-header regression test proves the handler waits for delayed execution headers rather than committing a heartbeat that drops them.
- [x] Stream-interceptor regression test proves the handler waits for first-chunk interceptor headers before allowing a heartbeat to commit the response.
- [x] `go test -race ./sdk/api/handlers/openai -run 'TestResponsesStreaming|TestForwardResponsesStream' -count=1`
- [x] `go test ./sdk/api/handlers/openai -count=1`
- [x] `go test ./...`
- [x] `go build -o test-output ./cmd/server && rm test-output`

## Related work

Fixes #4280.

Related to #3533 and #3806. This PR is intentionally limited to the OpenAI Responses SSE path and covers the synchronous auth-manager bootstrap wait; it does not include the WebSocket heartbeat changes from #3806.
