### PR TITLE
fix(pluginstore): rehydrate cloud plugins

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -47,12 +47,6 @@ var (
 	DefaultConfigPath = ""
 )
 
-const storagePluginSyncTimeout = time.Minute
-
-func storagePluginSyncContext() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), storagePluginSyncTimeout)
-}
-
 // init initializes the shared logger setup.
 func init() {
 	logging.SetupBaseLogger()
@@ -69,6 +63,10 @@ func shouldEnableExampleAPIKeySafeMode(cfg *config.Config, commandMode, tuiMode,
 		return false
 	}
 	return safemode.HasExampleAPIKeys(cfg.APIKeys)
+}
+
+func shouldSyncStoragePlugins(commandMode, storageEnabled bool) bool {
+	return storageEnabled && !commandMode
 }
 
 // main is the entry point of the application.
@@ -545,13 +543,14 @@ func main() {
 	}
 	managementasset.SetCurrentConfig(cfg)
 
+	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || xaiLogin
+
 	// Create login options to be used in authentication flows.
 	options := &cmd.LoginOptions{
 		NoBrowser:    noBrowser,
 		CallbackPort: oauthCallbackPort,
 	}
 
-	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || xaiLogin
 	cloudConfigMissing := isCloudDeploy && !configFileExists
 	homeMode := configLoadedFromHome || (cfg != nil && cfg.Home.Enabled)
 	exampleAPIKeySafeMode := shouldEnableExampleAPIKeySafeMode(cfg, commandMode, tuiMode, standalone, cloudConfigMissing, homeMode)
@@ -575,11 +574,8 @@ func main() {
 
 	// Register built-in access providers before constructing services.
 	configaccess.Register(&cfg.SDKConfig)
-	if usePostgresStore || useObjectStore || useGitStore {
-		ctxPluginSync, cancelPluginSync := storagePluginSyncContext()
-		errSync := homeplugins.Sync(ctxPluginSync, cfg, pluginHost)
-		cancelPluginSync()
-		if errSync != nil {
+	if shouldSyncStoragePlugins(commandMode, usePostgresStore || useObjectStore || useGitStore) {
+		if errSync := homeplugins.Sync(context.Background(), cfg, pluginHost); errSync != nil {
 			log.Errorf("failed to sync plugins from storage-backed config: %v", errSync)
 			return
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -47,6 +47,12 @@ var (
 	DefaultConfigPath = ""
 )
 
+const storagePluginSyncTimeout = time.Minute
+
+func storagePluginSyncContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), storagePluginSyncTimeout)
+}
+
 // init initializes the shared logger setup.
 func init() {
 	logging.SetupBaseLogger()
@@ -570,7 +576,10 @@ func main() {
 	// Register built-in access providers before constructing services.
 	configaccess.Register(&cfg.SDKConfig)
 	if usePostgresStore || useObjectStore || useGitStore {
-		if errSync := homeplugins.Sync(context.Background(), cfg, pluginHost); errSync != nil {
+		ctxPluginSync, cancelPluginSync := storagePluginSyncContext()
+		errSync := homeplugins.Sync(ctxPluginSync, cfg, pluginHost)
+		cancelPluginSync()
+		if errSync != nil {
 			log.Errorf("failed to sync plugins from storage-backed config: %v", errSync)
 			return
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -569,6 +569,12 @@ func main() {
 
 	// Register built-in access providers before constructing services.
 	configaccess.Register(&cfg.SDKConfig)
+	if usePostgresStore || useObjectStore || useGitStore {
+		if errSync := homeplugins.Sync(context.Background(), cfg, pluginHost); errSync != nil {
+			log.Errorf("failed to sync plugins from storage-backed config: %v", errSync)
+			return
+		}
+	}
 	pluginHost.ApplyConfig(context.Background(), cfg)
 	if configLoadedFromHome {
 		errHomePluginLoad := homeplugins.MarkLoadResults(&homePluginSyncReport, pluginHost)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -65,8 +65,8 @@ func shouldEnableExampleAPIKeySafeMode(cfg *config.Config, commandMode, tuiMode,
 	return safemode.HasExampleAPIKeys(cfg.APIKeys)
 }
 
-func shouldSyncStoragePlugins(commandMode, tuiMode, standalone, storageEnabled bool) bool {
-	return storageEnabled && !commandMode && (!tuiMode || standalone)
+func shouldSyncStoragePlugins(commandMode, tuiMode, standalone, cloudConfigMissing, storageEnabled bool) bool {
+	return storageEnabled && !commandMode && (!tuiMode || standalone) && !cloudConfigMissing
 }
 
 // main is the entry point of the application.
@@ -574,7 +574,7 @@ func main() {
 
 	// Register built-in access providers before constructing services.
 	configaccess.Register(&cfg.SDKConfig)
-	if shouldSyncStoragePlugins(commandMode, tuiMode, standalone, usePostgresStore || useObjectStore || useGitStore) {
+	if shouldSyncStoragePlugins(commandMode, tuiMode, standalone, cloudConfigMissing, usePostgresStore || useObjectStore || useGitStore) {
 		if errSync := homeplugins.Sync(context.Background(), cfg, pluginHost); errSync != nil {
 			log.Errorf("failed to sync plugins from storage-backed config: %v", errSync)
 			return

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -65,8 +65,8 @@ func shouldEnableExampleAPIKeySafeMode(cfg *config.Config, commandMode, tuiMode,
 	return safemode.HasExampleAPIKeys(cfg.APIKeys)
 }
 
-func shouldSyncStoragePlugins(commandMode, storageEnabled bool) bool {
-	return storageEnabled && !commandMode
+func shouldSyncStoragePlugins(commandMode, tuiMode, standalone, storageEnabled bool) bool {
+	return storageEnabled && !commandMode && (!tuiMode || standalone)
 }
 
 // main is the entry point of the application.
@@ -574,7 +574,7 @@ func main() {
 
 	// Register built-in access providers before constructing services.
 	configaccess.Register(&cfg.SDKConfig)
-	if shouldSyncStoragePlugins(commandMode, usePostgresStore || useObjectStore || useGitStore) {
+	if shouldSyncStoragePlugins(commandMode, tuiMode, standalone, usePostgresStore || useObjectStore || useGitStore) {
 		if errSync := homeplugins.Sync(context.Background(), cfg, pluginHost); errSync != nil {
 			log.Errorf("failed to sync plugins from storage-backed config: %v", errSync)
 			return

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -2,22 +2,29 @@ package main
 
 import (
 	"testing"
-	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
-func TestStoragePluginSyncContextDeadline(t *testing.T) {
-	ctx, cancel := storagePluginSyncContext()
-	defer cancel()
-
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		t.Fatal("storagePluginSyncContext() has no deadline")
+func TestShouldSyncStoragePlugins(t *testing.T) {
+	tests := []struct {
+		name        string
+		commandMode bool
+		useStore    bool
+		want        bool
+	}{
+		{name: "server with storage backend", useStore: true, want: true},
+		{name: "server without storage backend", want: false},
+		{name: "native command with storage backend", commandMode: true, useStore: true, want: false},
 	}
-	remaining := time.Until(deadline)
-	if remaining > storagePluginSyncTimeout || remaining < storagePluginSyncTimeout-time.Second {
-		t.Fatalf("storagePluginSyncContext() deadline in %s, want about %s", remaining, storagePluginSyncTimeout)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldSyncStoragePlugins(tt.commandMode, tt.useStore)
+			if got != tt.want {
+				t.Fatalf("shouldSyncStoragePlugins(%t, %t) = %t, want %t", tt.commandMode, tt.useStore, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -2,9 +2,24 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
+
+func TestStoragePluginSyncContextDeadline(t *testing.T) {
+	ctx, cancel := storagePluginSyncContext()
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("storagePluginSyncContext() has no deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining > storagePluginSyncTimeout || remaining < storagePluginSyncTimeout-time.Second {
+		t.Fatalf("storagePluginSyncContext() deadline in %s, want about %s", remaining, storagePluginSyncTimeout)
+	}
+}
 
 func TestShouldEnableExampleAPIKeySafeMode(t *testing.T) {
 	cfgWithExampleKey := &config.Config{

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -8,25 +8,27 @@ import (
 
 func TestShouldSyncStoragePlugins(t *testing.T) {
 	tests := []struct {
-		name        string
-		commandMode bool
-		tuiMode     bool
-		standalone  bool
-		useStore    bool
-		want        bool
+		name         string
+		commandMode  bool
+		tuiMode      bool
+		standalone   bool
+		cloudMissing bool
+		useStore     bool
+		want         bool
 	}{
 		{name: "server with storage backend", useStore: true, want: true},
 		{name: "server without storage backend", want: false},
 		{name: "native command with storage backend", commandMode: true, useStore: true, want: false},
 		{name: "pure TUI client with storage backend", tuiMode: true, useStore: true, want: false},
 		{name: "standalone TUI with storage backend", tuiMode: true, standalone: true, useStore: true, want: true},
+		{name: "cloud standby with storage backend", cloudMissing: true, useStore: true, want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shouldSyncStoragePlugins(tt.commandMode, tt.tuiMode, tt.standalone, tt.useStore)
+			got := shouldSyncStoragePlugins(tt.commandMode, tt.tuiMode, tt.standalone, tt.cloudMissing, tt.useStore)
 			if got != tt.want {
-				t.Fatalf("shouldSyncStoragePlugins(%t, %t, %t, %t) = %t, want %t", tt.commandMode, tt.tuiMode, tt.standalone, tt.useStore, got, tt.want)
+				t.Fatalf("shouldSyncStoragePlugins(%t, %t, %t, %t, %t) = %t, want %t", tt.commandMode, tt.tuiMode, tt.standalone, tt.cloudMissing, tt.useStore, got, tt.want)
 			}
 		})
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -10,19 +10,23 @@ func TestShouldSyncStoragePlugins(t *testing.T) {
 	tests := []struct {
 		name        string
 		commandMode bool
+		tuiMode     bool
+		standalone  bool
 		useStore    bool
 		want        bool
 	}{
 		{name: "server with storage backend", useStore: true, want: true},
 		{name: "server without storage backend", want: false},
 		{name: "native command with storage backend", commandMode: true, useStore: true, want: false},
+		{name: "pure TUI client with storage backend", tuiMode: true, useStore: true, want: false},
+		{name: "standalone TUI with storage backend", tuiMode: true, standalone: true, useStore: true, want: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shouldSyncStoragePlugins(tt.commandMode, tt.useStore)
+			got := shouldSyncStoragePlugins(tt.commandMode, tt.tuiMode, tt.standalone, tt.useStore)
 			if got != tt.want {
-				t.Fatalf("shouldSyncStoragePlugins(%t, %t) = %t, want %t", tt.commandMode, tt.useStore, got, tt.want)
+				t.Fatalf("shouldSyncStoragePlugins(%t, %t, %t, %t) = %t, want %t", tt.commandMode, tt.tuiMode, tt.standalone, tt.useStore, got, tt.want)
 			}
 		})
 	}

--- a/internal/homeplugins/sync.go
+++ b/internal/homeplugins/sync.go
@@ -120,7 +120,7 @@ func SyncWithReport(ctx context.Context, cfg *config.Config, pluginRuntime Plugi
 }
 
 func SyncPlatformWithReport(ctx context.Context, cfg *config.Config, pluginRuntime PluginRuntime, platform Platform) (SyncReport, error) {
-	if cfg == nil || !cfg.Home.Enabled || !cfg.Plugins.Enabled {
+	if cfg == nil || !cfg.Plugins.Enabled {
 		return newSyncReport(platform), nil
 	}
 	platform = NormalizePlatform(platform)

--- a/internal/homeplugins/sync_test.go
+++ b/internal/homeplugins/sync_test.go
@@ -72,6 +72,36 @@ func TestSyncPlatformInstallsManifestArtifact(t *testing.T) {
 	}
 }
 
+func TestSyncPlatformInstallsManifestWithoutHome(t *testing.T) {
+	root := t.TempDir()
+	archiveData := makeZip(t, map[string]string{"sample.dll": "library-data"})
+	archiveName := "sample_0.2.0_windows_amd64.zip"
+	checksum := sha256.Sum256(archiveData)
+	httpClient := mapHTTPDoer{
+		"https://api.github.com/repos/owner/sample-plugin/releases/tags/v0.2.0": []byte(`{
+			"tag_name": "v0.2.0",
+			"assets": [
+				{"name": "` + archiveName + `", "browser_download_url": "https://downloads.example/` + archiveName + `"},
+				{"name": "checksums.txt", "browser_download_url": "https://downloads.example/checksums.txt"}
+			]
+		}`),
+		"https://downloads.example/" + archiveName: archiveData,
+		"https://downloads.example/checksums.txt":  []byte(hex.EncodeToString(checksum[:]) + "  " + archiveName + "\n"),
+	}
+	restore := replacePluginStoreClientForTest(httpClient)
+	defer restore()
+
+	cfg := syncTestConfig(t, root)
+	cfg.Home.Enabled = false
+	if errSync := SyncPlatform(context.Background(), cfg, nil, Platform{GOOS: "windows", GOARCH: "amd64"}); errSync != nil {
+		t.Fatalf("SyncPlatform() error = %v", errSync)
+	}
+	target := pluginTestPath(root, "windows", "amd64", "sample", "0.2.0")
+	if _, errStat := os.Stat(target); errStat != nil {
+		t.Fatalf("plugin artifact %s was not installed: %v", target, errStat)
+	}
+}
+
 func TestSyncPlatformWithReportRecordsSuccessfulInstall(t *testing.T) {
 	root := t.TempDir()
 	archiveData := makeZip(t, map[string]string{"sample.dll": "library-data"})


### PR DESCRIPTION
## Description

Rehydrate plugin-store plugins after Git, PostgreSQL, or object-store configuration bootstrap. The existing portable manifest in synced config.yaml is reused, so no platform-specific binaries are persisted.

## Related Issue

Closes #4298

## Potential Risk & Impact

Plugin rehydration runs only for server startup, never native credential or import commands. Per the repository network policy, an unresponsive plugin store can delay server startup.

## How Has This Been Tested?

- go test ./internal/homeplugins -run ^TestSyncPlatformInstallsManifestWithoutHome$ -count=1
- go test ./cmd/server -run ^TestShouldSyncStoragePlugins$ -count=1
- go test ./cmd/server -count=1
- go test ./...
- go build -o test-output ./cmd/server