### PR TITLE
docs: update VS Code Universal Chat Provider description

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ Windows desktop UI that manages CLIProxyAPI and Perplexity WebUI Scraper from a 
 
 Cross-platform (Tauri) port of Quotio for Windows, macOS and Linux. Manages a pool of AI accounts (Codex, Claude Code, GitHub Copilot, Gemini, Antigravity, Kiro, Cursor, Trae, GLM) through CLIProxyAPI, with per-account 5-hour/weekly quota bars, Codex rate-limit reset credits with one-click reset, smart scheduling, usage statistics, and multi-instance Codex — no API keys needed.
 
-### [Universal Chat Provider](https://github.com/maxdewald/vscode-universal-chat-provider)
+### [VSCode Universal Chat Provider](https://github.com/maxdewald/vscode-universal-chat-provider)
 
-VS Code extension that brings your Claude, ChatGPT/Codex, Antigravity, Grok, and Kimi subscriptions into GitHub Copilot Chat as native language models — and can power your Git commit messages, chat titles, and summaries too. Runs CLIProxyAPI in a fully managed background lifecycle (download, verify, supervise) shared across all windows, so it's zero-setup. No API keys needed, just OAuth.
+VS Code extension that brings your AI subscriptions into GitHub Copilot Chat and can power your Git commit messages, chat titles, and summaries too. Runs CLIProxyAPI in a fully managed background lifecycle (download, verify, supervise) shared across all windows, so it's zero-setup. No API keys needed, just OAuth.
 
 ### [CPA-Tray-Powershell](https://github.com/IQ-Director/CPA-Tray-Powershell)
 


### PR DESCRIPTION
## Summary

- use the full VS Code Universal Chat Provider name
- simplify the extension description to cover all supported AI subscriptions

## Testing

- Documentation-only change