### PR TITLE
feat(streaming): add timeout for stalled bootstrap

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -190,10 +190,11 @@ ws-auth: true
 
 # When > 0, emit blank lines every N seconds for non-streaming responses to prevent idle timeouts.
 nonstream-keepalive-interval: 0
-# Streaming behavior (SSE keep-alives + safe bootstrap retries).
+# Streaming behavior (SSE keep-alives + safe bootstrap retries/timeouts).
 # streaming:
-#   keepalive-seconds: 15   # Default: 0 (disabled). <= 0 disables keep-alives.
-#   bootstrap-retries: 1    # Default: 0 (disabled). Retries before first byte is sent.
+#   keepalive-seconds: 15          # Default: 0 (disabled). <= 0 disables keep-alives.
+#   bootstrap-retries: 1           # Default: 0 (disabled). Retries before first byte is sent.
+#   bootstrap-timeout-seconds: 20  # Default: 0 (disabled). Max wait for the first upstream payload; capped at 600.
 
 # Signature cache validation for thinking blocks (Antigravity/Claude).
 # When true (default), cached signatures are preferred and validated.

--- a/internal/config/clone_test.go
+++ b/internal/config/clone_test.go
@@ -96,8 +96,9 @@ func sampleCloneRuntimeConfig() *Config {
 		SDKConfig: SDKConfig{
 			APIKeys: []string{"client-key"},
 			Streaming: StreamingConfig{
-				KeepAliveSeconds: 3,
-				BootstrapRetries: 2,
+				KeepAliveSeconds:        3,
+				BootstrapRetries:        2,
+				BootstrapTimeoutSeconds: 20,
 			},
 		},
 		Home: HomeConfig{

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -67,4 +67,9 @@ type StreamingConfig struct {
 	// to allow auth rotation / transient recovery.
 	// <= 0 disables bootstrap retries. Default is 0.
 	BootstrapRetries int `yaml:"bootstrap-retries,omitempty" json:"bootstrap-retries,omitempty"`
+
+	// BootstrapTimeoutSeconds limits how long the server waits for the first upstream stream payload.
+	// A timed-out attempt is canceled and may consume one BootstrapRetries retry.
+	// <= 0 disables the timeout. Values above 600 are capped at 600 seconds.
+	BootstrapTimeoutSeconds int `yaml:"bootstrap-timeout-seconds,omitempty" json:"bootstrap-timeout-seconds,omitempty"`
 }

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -1161,7 +1161,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	}
 	opts.Metadata = reqMeta
 	req, opts = h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, req, opts, execOptions.SkipInterceptorPluginID)
-	streamResult, err := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
+	streamResult, bootstrapRetries, err := h.executeInitialStreamWithBootstrapTimeout(ctx, providers, req, opts)
 	if err != nil {
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
 		errChan := make(chan *interfaces.ErrorMessage, 1)
@@ -1271,7 +1271,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 			return
 		}
 		sentPayload := false
-		bootstrapRetries := 0
+		bootstrapRetriesUsed := bootstrapRetries
 		chunkIndex := 0
 		var historyChunks [][]byte
 		maxBootstrapRetries := StreamingBootstrapRetries(h.Cfg)
@@ -1332,9 +1332,9 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 					// Safe bootstrap recovery: if the upstream fails before any payload bytes are sent,
 					// retry a few times (to allow auth rotation / transient recovery) and then attempt model fallback.
 					if !sentPayload {
-						if bootstrapRetries < maxBootstrapRetries && bootstrapEligible(streamErr) {
-							bootstrapRetries++
-							retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
+						if bootstrapRetriesUsed < maxBootstrapRetries && bootstrapEligible(streamErr) {
+							bootstrapRetriesUsed++
+							retryResult, retryErr := h.executeStreamBootstrapAttempt(ctx, providers, req, opts)
 							if retryErr == nil {
 								rawStreamHeaders = cloneHeader(retryResult.Headers)
 								baseStreamHeaders = cloneHeader(retryResult.Headers)

--- a/sdk/api/handlers/stream_bootstrap_timeout.go
+++ b/sdk/api/handlers/stream_bootstrap_timeout.go
@@ -1,0 +1,203 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"golang.org/x/net/context"
+)
+
+const maxStreamingBootstrapTimeout = 10 * time.Minute
+
+// StreamingBootstrapTimeout returns the configured maximum wait for the first
+// upstream stream payload. Zero disables the timeout.
+func StreamingBootstrapTimeout(cfg *config.SDKConfig) time.Duration {
+	if cfg == nil || cfg.Streaming.BootstrapTimeoutSeconds <= 0 {
+		return 0
+	}
+	seconds := cfg.Streaming.BootstrapTimeoutSeconds
+	if seconds > int(maxStreamingBootstrapTimeout/time.Second) {
+		return maxStreamingBootstrapTimeout
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+type streamBootstrapTimeoutError struct {
+	timeout time.Duration
+}
+
+func (e *streamBootstrapTimeoutError) Error() string {
+	return fmt.Sprintf("upstream stream produced no payload within %s", e.timeout)
+}
+
+func (e *streamBootstrapTimeoutError) Unwrap() error   { return context.DeadlineExceeded }
+func (e *streamBootstrapTimeoutError) StatusCode() int { return http.StatusGatewayTimeout }
+
+// bootstrapAttemptContext applies a deadline only until disarm is called. Once
+// the first upstream payload has been observed, the context keeps following the
+// parent cancellation without imposing a deadline on the remainder of the stream.
+type bootstrapAttemptContext struct {
+	parent   context.Context
+	deadline time.Time
+	done     chan struct{}
+	timer    *time.Timer
+
+	mu       sync.RWMutex
+	err      error
+	disarmed bool
+}
+
+func newBootstrapAttemptContext(parent context.Context, timeout time.Duration) *bootstrapAttemptContext {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx := &bootstrapAttemptContext{
+		parent:   parent,
+		deadline: time.Now().Add(timeout),
+		done:     make(chan struct{}),
+	}
+	ctx.timer = time.AfterFunc(timeout, ctx.expire)
+	go func() {
+		select {
+		case <-parent.Done():
+			ctx.cancel(parent.Err())
+		case <-ctx.done:
+		}
+	}()
+	return ctx
+}
+
+func (c *bootstrapAttemptContext) Deadline() (time.Time, bool) {
+	c.mu.RLock()
+	disarmed := c.disarmed
+	deadline := c.deadline
+	c.mu.RUnlock()
+	if disarmed {
+		return c.parent.Deadline()
+	}
+	if parentDeadline, ok := c.parent.Deadline(); ok && parentDeadline.Before(deadline) {
+		return parentDeadline, true
+	}
+	return deadline, true
+}
+
+func (c *bootstrapAttemptContext) Done() <-chan struct{} { return c.done }
+
+func (c *bootstrapAttemptContext) Err() error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.err
+}
+
+func (c *bootstrapAttemptContext) Value(key any) any { return c.parent.Value(key) }
+
+func (c *bootstrapAttemptContext) expire() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.disarmed || c.err != nil {
+		return
+	}
+	c.err = context.DeadlineExceeded
+	close(c.done)
+}
+
+func (c *bootstrapAttemptContext) cancel(err error) {
+	if err == nil {
+		err = context.Canceled
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err != nil {
+		return
+	}
+	c.err = err
+	if c.timer != nil {
+		c.timer.Stop()
+	}
+	close(c.done)
+}
+
+// disarm removes the bootstrap deadline while preserving parent cancellation.
+// It reports whether the deadline had already fired.
+func (c *bootstrapAttemptContext) disarm() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if errors.Is(c.err, context.DeadlineExceeded) {
+		return true
+	}
+	c.disarmed = true
+	if c.timer != nil {
+		c.timer.Stop()
+	}
+	return false
+}
+
+func (h *BaseAPIHandler) executeStreamBootstrapAttempt(ctx context.Context, providers []string, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	timeout := StreamingBootstrapTimeout(h.Cfg)
+	if timeout <= 0 {
+		return h.AuthManager.ExecuteStream(ctx, providers, req, opts)
+	}
+
+	attemptCtx := newBootstrapAttemptContext(ctx, timeout)
+	result, err := h.AuthManager.ExecuteStream(attemptCtx, providers, req, opts)
+	timedOut := attemptCtx.disarm()
+	if timedOut {
+		return nil, &streamBootstrapTimeoutError{timeout: timeout}
+	}
+	if err != nil {
+		attemptCtx.cancel(context.Canceled)
+		return nil, err
+	}
+	return releaseBootstrapAttemptContext(result, attemptCtx), nil
+}
+
+func releaseBootstrapAttemptContext(result *coreexecutor.StreamResult, attemptCtx *bootstrapAttemptContext) *coreexecutor.StreamResult {
+	if result == nil || result.Chunks == nil {
+		attemptCtx.cancel(context.Canceled)
+		return result
+	}
+	remaining := result.Chunks
+	out := make(chan coreexecutor.StreamChunk)
+	result.Chunks = out
+	go func() {
+		defer close(out)
+		defer attemptCtx.cancel(context.Canceled)
+		for {
+			select {
+			case <-attemptCtx.Done():
+				return
+			case chunk, ok := <-remaining:
+				if !ok {
+					return
+				}
+				select {
+				case <-attemptCtx.Done():
+					return
+				case out <- chunk:
+				}
+			}
+		}
+	}()
+	return result
+}
+
+func (h *BaseAPIHandler) executeInitialStreamWithBootstrapTimeout(ctx context.Context, providers []string, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, int, error) {
+	maxRetries := StreamingBootstrapRetries(h.Cfg)
+	retriesUsed := 0
+	for {
+		result, err := h.executeStreamBootstrapAttempt(ctx, providers, req, opts)
+		if err == nil {
+			return result, retriesUsed, nil
+		}
+		var timeoutErr *streamBootstrapTimeoutError
+		if !errors.As(err, &timeoutErr) || retriesUsed >= maxRetries {
+			return nil, retriesUsed, err
+		}
+		retriesUsed++
+	}
+}

--- a/sdk/api/handlers/stream_bootstrap_timeout_test.go
+++ b/sdk/api/handlers/stream_bootstrap_timeout_test.go
@@ -1,0 +1,206 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+type bootstrapTimeoutExecutor struct {
+	mu             sync.Mutex
+	calls          int
+	authIDs        []string
+	stallFirst     bool
+	firstDelay     time.Duration
+	betweenPayload time.Duration
+	canceled       chan struct{}
+	cancelOnce     sync.Once
+	streamCanceled chan struct{}
+	streamOnce     sync.Once
+}
+
+func (e *bootstrapTimeoutExecutor) Identifier() string { return "codex" }
+
+func (e *bootstrapTimeoutExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, nil
+}
+
+func (e *bootstrapTimeoutExecutor) ExecuteStream(ctx context.Context, auth *coreauth.Auth, _ coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.calls++
+	call := e.calls
+	if auth != nil {
+		e.authIDs = append(e.authIDs, auth.ID)
+	}
+	e.mu.Unlock()
+
+	chunks := make(chan coreexecutor.StreamChunk, 2)
+	if e.stallFirst && call == 1 {
+		go func() {
+			<-ctx.Done()
+			e.cancelOnce.Do(func() {
+				if e.canceled != nil {
+					close(e.canceled)
+				}
+			})
+			close(chunks)
+		}()
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	if e.streamCanceled != nil {
+		go func() {
+			<-ctx.Done()
+			e.streamOnce.Do(func() { close(e.streamCanceled) })
+		}()
+	}
+
+	go func() {
+		defer close(chunks)
+		if e.firstDelay > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(e.firstDelay):
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case chunks <- coreexecutor.StreamChunk{Payload: []byte("first")}:
+		}
+		if e.betweenPayload <= 0 {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(e.betweenPayload):
+		}
+		select {
+		case <-ctx.Done():
+		case chunks <- coreexecutor.StreamChunk{Payload: []byte("second")}:
+		}
+	}()
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *bootstrapTimeoutExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *bootstrapTimeoutExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, nil
+}
+
+func (e *bootstrapTimeoutExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (e *bootstrapTimeoutExecutor) snapshot() (int, []string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.calls, append([]string(nil), e.authIDs...)
+}
+
+func newBootstrapTimeoutHandler(t *testing.T, executor *bootstrapTimeoutExecutor, retries, timeoutSeconds int, authIDs ...string) *BaseAPIHandler {
+	t.Helper()
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	for _, authID := range authIDs {
+		auth := &coreauth.Auth{ID: authID, Provider: "codex", Status: coreauth.StatusActive}
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatal(err)
+		}
+		registry.GetGlobalRegistry().RegisterClient(authID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+		authID := authID
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
+	}
+	return NewBaseAPIHandlers(&sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{
+		BootstrapRetries:        retries,
+		BootstrapTimeoutSeconds: timeoutSeconds,
+	}}, manager)
+}
+
+func collectBootstrapTimeoutResult(handler *BaseAPIHandler) ([]byte, int) {
+	data, _, errs := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "test-model", []byte(`{"model":"test-model"}`), "")
+	var body []byte
+	if data != nil {
+		for chunk := range data {
+			body = append(body, chunk...)
+		}
+	}
+	status := 0
+	for msg := range errs {
+		if msg != nil {
+			status = msg.StatusCode
+		}
+	}
+	return body, status
+}
+
+func TestStreamingBootstrapTimeoutBounds(t *testing.T) {
+	if got := StreamingBootstrapTimeout(nil); got != 0 {
+		t.Fatalf("nil config timeout = %s, want 0", got)
+	}
+	if got := StreamingBootstrapTimeout(&sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{BootstrapTimeoutSeconds: 20}}); got != 20*time.Second {
+		t.Fatalf("timeout = %s, want 20s", got)
+	}
+	if got := StreamingBootstrapTimeout(&sdkconfig.SDKConfig{Streaming: sdkconfig.StreamingConfig{BootstrapTimeoutSeconds: 9999}}); got != 10*time.Minute {
+		t.Fatalf("capped timeout = %s, want 10m", got)
+	}
+}
+
+func TestStreamBootstrapTimeoutCancelsAndRetries(t *testing.T) {
+	executor := &bootstrapTimeoutExecutor{stallFirst: true, canceled: make(chan struct{})}
+	handler := newBootstrapTimeoutHandler(t, executor, 1, 1, "auth1", "auth2")
+	start := time.Now()
+	body, status := collectBootstrapTimeoutResult(handler)
+	if status != 0 || string(body) != "first" {
+		t.Fatalf("status=%d body=%q", status, body)
+	}
+	if time.Since(start) < 900*time.Millisecond {
+		t.Fatalf("request returned before configured timeout")
+	}
+	select {
+	case <-executor.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("timed-out attempt was not canceled")
+	}
+	calls, authIDs := executor.snapshot()
+	if calls != 2 || len(authIDs) != 2 || authIDs[0] == authIDs[1] {
+		t.Fatalf("calls=%d authIDs=%v, want retry on a different auth", calls, authIDs)
+	}
+}
+
+func TestStreamBootstrapTimeoutReturnsGatewayTimeoutWithoutRetry(t *testing.T) {
+	executor := &bootstrapTimeoutExecutor{stallFirst: true, canceled: make(chan struct{})}
+	handler := newBootstrapTimeoutHandler(t, executor, 0, 1, "auth1")
+	body, status := collectBootstrapTimeoutResult(handler)
+	if len(body) != 0 || status != http.StatusGatewayTimeout {
+		t.Fatalf("status=%d body=%q", status, body)
+	}
+}
+
+func TestStreamBootstrapTimeoutDisarmsAfterFirstPayload(t *testing.T) {
+	executor := &bootstrapTimeoutExecutor{firstDelay: 100 * time.Millisecond, betweenPayload: 1100 * time.Millisecond, streamCanceled: make(chan struct{})}
+	handler := newBootstrapTimeoutHandler(t, executor, 0, 1, "auth1")
+	body, status := collectBootstrapTimeoutResult(handler)
+	if status != 0 || string(body) != "firstsecond" {
+		t.Fatalf("status=%d body=%q", status, body)
+	}
+	if calls, _ := executor.snapshot(); calls != 1 {
+		t.Fatalf("calls=%d, want 1", calls)
+	}
+	select {
+	case <-executor.streamCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("bootstrap attempt context was not released after stream completion")
+	}
+}


### PR DESCRIPTION
## Summary

- add an opt-in `streaming.bootstrap-timeout-seconds` setting for the first upstream stream payload
- cancel a stalled upstream attempt and consume the existing `bootstrap-retries` budget before returning a 504
- remove the bootstrap deadline after the first payload so long-running healthy streams are unaffected
- release the attempt context when the stream closes, including SDK callers that use `context.Background()`
- keep the default behavior unchanged when the setting is unset or non-positive; cap configured values at 600 seconds

## Why

An upstream can accept a streaming request but produce no first payload, leaving the proxy blocked until an external reverse-proxy timeout. Downstream keep-alives keep the client connection open, but they do not cancel or rotate a silent upstream attempt.

This adds a bounded, server-side recovery path that composes with the existing safe bootstrap retry mechanism. It is related to #4280 and complements #4295 without including or duplicating that PR's Responses keep-alive changes.

## User impact

Operators can opt in with:

```yaml
streaming:
  bootstrap-retries: 1
  bootstrap-timeout-seconds: 20
```

If the first upstream payload does not arrive within 20 seconds, the attempt is canceled. One retry is allowed by the configuration above; if recovery is exhausted, the request returns HTTP 504. No timeout is applied after the first payload.

## Validation

- `go test -race ./sdk/api/handlers -run 'TestStreamBootstrapTimeout|TestStreamingBootstrapTimeout' -count=1`
- `go test ./...`
- `go build -o /tmp/cliproxyapi-pr-server ./cmd/server`

Tests cover timeout cancellation, retry/auth rotation, HTTP 504 without retry, configuration bounds, deadline disarming after the first payload, and context release after stream completion.
