### PR TITLE
fix(xai): flatten Codex Responses Lite additional tools

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -1434,6 +1434,17 @@ func flattenXAIAdditionalTools(body []byte) []byte {
 	if !input.Exists() || !input.IsArray() {
 		return body
 	}
+	hasAdditionalTools := false
+	input.ForEach(func(_, item gjson.Result) bool {
+		if item.Get("type").String() == "additional_tools" {
+			hasAdditionalTools = true
+			return false
+		}
+		return true
+	})
+	if !hasAdditionalTools {
+		return body
+	}
 
 	topLevelTools := gjson.GetBytes(body, "tools")
 	if topLevelTools.Exists() && !topLevelTools.IsArray() {
@@ -1445,7 +1456,6 @@ func flattenXAIAdditionalTools(body []byte) []byte {
 		tools = append(tools, json.RawMessage(tool.Raw))
 	}
 
-	changed := false
 	inputItems := input.Array()
 	items := make([]json.RawMessage, 0, len(inputItems))
 	for _, item := range inputItems {
@@ -1460,10 +1470,6 @@ func flattenXAIAdditionalTools(body []byte) []byte {
 		for _, tool := range additionalTools.Array() {
 			tools = append(tools, json.RawMessage(tool.Raw))
 		}
-		changed = true
-	}
-	if !changed {
-		return body
 	}
 
 	rawInput, errMarshalInput := json.Marshal(items)

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -894,6 +894,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
+	body = flattenXAIAdditionalTools(body)
 	namespaceTools := collectXAINamespaceToolRefs(body)
 	// Collect before normalizeXAITools flattens namespace wrappers so keys match
 	// the post-restore (namespace, short-name) shape used by the response filter.
@@ -1419,6 +1420,72 @@ func normalizeXAITools(body []byte) []byte {
 		}
 	}
 	return body
+}
+
+// flattenXAIAdditionalTools converts Codex Responses Lite tool declarations
+// into the top-level tools array accepted by xAI Responses. OpenAI's Codex
+// upstream accepts additional_tools as an input item, but xAI rejects that
+// item before generation because it is not a supported ModelInput variant.
+func flattenXAIAdditionalTools(body []byte) []byte {
+	if !gjson.ValidBytes(body) {
+		return body
+	}
+	input := gjson.GetBytes(body, "input")
+	if !input.Exists() || !input.IsArray() {
+		return body
+	}
+
+	topLevelTools := gjson.GetBytes(body, "tools")
+	if topLevelTools.Exists() && !topLevelTools.IsArray() {
+		return body
+	}
+
+	tools := make([]json.RawMessage, 0, len(topLevelTools.Array()))
+	for _, tool := range topLevelTools.Array() {
+		tools = append(tools, json.RawMessage(tool.Raw))
+	}
+
+	changed := false
+	inputItems := input.Array()
+	items := make([]json.RawMessage, 0, len(inputItems))
+	for _, item := range inputItems {
+		if item.Get("type").String() != "additional_tools" {
+			items = append(items, json.RawMessage(item.Raw))
+			continue
+		}
+		additionalTools := item.Get("tools")
+		if additionalTools.Exists() && !additionalTools.IsArray() {
+			return body
+		}
+		for _, tool := range additionalTools.Array() {
+			tools = append(tools, json.RawMessage(tool.Raw))
+		}
+		changed = true
+	}
+	if !changed {
+		return body
+	}
+
+	rawInput, errMarshalInput := json.Marshal(items)
+	if errMarshalInput != nil {
+		return body
+	}
+	updated, errSetInput := sjson.SetRawBytes(body, "input", rawInput)
+	if errSetInput != nil {
+		return body
+	}
+	if len(tools) == 0 {
+		return updated
+	}
+	rawTools, errMarshalTools := json.Marshal(tools)
+	if errMarshalTools != nil {
+		return body
+	}
+	updated, errSetTools := sjson.SetRawBytes(updated, "tools", rawTools)
+	if errSetTools != nil {
+		return body
+	}
+	return updated
 }
 
 func normalizeXAIToolArray(tools gjson.Result) ([]byte, bool, bool) {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -212,13 +212,17 @@ func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 	}
 }
 
-func TestXAIExecutorExecuteRestoresAdditionalToolsNamespaceCalls(t *testing.T) {
+func TestXAIExecutorExecuteFlattensAdditionalToolsAndRestoresNamespaceCalls(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var errRead error
 		gotBody, errRead = io.ReadAll(r.Body)
 		if errRead != nil {
 			t.Fatalf("read body: %v", errRead)
+		}
+		if gjson.GetBytes(gotBody, `input.#(type=="additional_tools")`).Exists() {
+			http.Error(w, `{"error":"data did not match any variant of untagged enum ModelInput"}`, http.StatusUnprocessableEntity)
+			return
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"name\":\"mcp__exa__web_search_exa\",\"call_id\":\"call_1\",\"arguments\":\"{}\"}}\n\n"))
@@ -250,9 +254,15 @@ func TestXAIExecutorExecuteRestoresAdditionalToolsNamespaceCalls(t *testing.T) {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
-	tool := gjson.GetBytes(gotBody, "input.0.tools.0")
+	if got := gjson.GetBytes(gotBody, "input.0.role").String(); got != "user" {
+		t.Fatalf("input.0.role = %q, want user after flattening; body=%s", got, gotBody)
+	}
+	if gjson.GetBytes(gotBody, "input.1").Exists() {
+		t.Fatalf("additional_tools input item was not removed: %s", gotBody)
+	}
+	tool := gjson.GetBytes(gotBody, "tools.0")
 	if got := tool.Get("name").String(); got != "mcp__exa__web_search_exa" {
-		t.Fatalf("upstream additional tool name = %q, want qualified name; body=%s", got, gotBody)
+		t.Fatalf("upstream tool name = %q, want qualified name; body=%s", got, gotBody)
 	}
 	if got := tool.Get("type").String(); got != "function" {
 		t.Fatalf("upstream additional tool type = %q, want function; body=%s", got, gotBody)
@@ -266,6 +276,13 @@ func TestXAIExecutorExecuteRestoresAdditionalToolsNamespaceCalls(t *testing.T) {
 	}
 	if got := output.Get("namespace").String(); got != "mcp__exa" {
 		t.Fatalf("response output namespace = %q, want mcp__exa; payload=%s", got, resp.Payload)
+	}
+}
+
+func TestFlattenXAIAdditionalToolsLeavesOrdinaryRequestsUnchanged(t *testing.T) {
+	body := []byte(`{"model":"grok-4.3","input":[{"type":"message","role":"user","content":"hello"}],"tools":[{"type":"function","name":"lookup"}]}`)
+	if got := flattenXAIAdditionalTools(body); !bytes.Equal(got, body) {
+		t.Fatalf("ordinary request changed: got=%s want=%s", got, body)
 	}
 }
 

--- a/internal/runtime/executor/xai_websockets_executor_test.go
+++ b/internal/runtime/executor/xai_websockets_executor_test.go
@@ -202,7 +202,13 @@ func TestXAIWebsocketsExecuteStreamRestoresNamespaceToolCalls(t *testing.T) {
 
 	select {
 	case payload := <-capturedPayload:
-		tool := gjson.GetBytes(payload, "input.0.tools.0")
+		if gjson.GetBytes(payload, `input.#(type=="additional_tools")`).Exists() {
+			t.Fatalf("additional_tools input item was not removed: %s", payload)
+		}
+		if got := gjson.GetBytes(payload, "input.0.role").String(); got != "user" {
+			t.Fatalf("input.0.role = %q, want user after flattening; payload=%s", got, payload)
+		}
+		tool := gjson.GetBytes(payload, "tools.0")
 		if got := tool.Get("name").String(); got != "mcp__exa__web_search_exa" {
 			t.Fatalf("upstream tool name = %q, want qualified name; payload=%s", got, payload)
 		}


### PR DESCRIPTION
## Summary

- flatten Codex Responses Lite `input[].type=additional_tools` declarations into the top-level `tools` array before forwarding to xAI
- remove the unsupported `additional_tools` input item while preserving ordinary input items and existing top-level tools
- preserve namespace tool normalization and response-name restoration for both HTTP and WebSocket transports

## Problem

Codex Responses Lite sends dynamic tool declarations as an `additional_tools` input item. xAI Build rejects that item before generation with HTTP 422:

```
Failed to deserialize the JSON body into the target type: data did not match any variant of untagged enum ModelInput
```

The xAI executor already normalizes top-level tools, so converting the Codex-only wrapper at this provider boundary keeps other request formats unchanged.

## Verification

- `go test ./internal/runtime/executor -count=1`
- `go build -o /tmp/cli-proxy-api ./cmd/server`
- GitHub Actions run: https://github.com/FSOTM/CLIProxyAPI/actions/runs/29330698864
