### PR TITLE
feat(claude): add global claude-cloak-mode config (auto/always/never)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -134,11 +134,23 @@ save-cooldown-status: false
 # Set to 0 to keep the legacy 60-second cooldown; set to -1 to disable transient error cooldowns.
 transient-error-cooldown-seconds: 0
 
-# When true, globally disable Claude request cloaking (the Claude Code CLI disguise and
-# system prompt replacement), so the original system prompt is passed through to Claude as-is.
-# Individual credentials can still override this: a claude-api-key entry via its "cloak.mode",
-# or a Claude OAuth/token file via a "cloak_mode" value. Default false keeps the per-client
-# "auto" behavior (cloak only non-Claude-Code clients).
+# Global default Claude cloak mode: "auto" (default), "always", or "never".
+# Cloaking is the Claude Code CLI disguise (device fingerprint + fake user id +
+# system prompt replacement). "auto" cloaks only clients whose User-Agent is not
+# Claude Code; "always" cloaks every request regardless of client; "never" disables
+# it. Set "always" when this proxy only ever fronts non-Claude-Code apps: it stops a
+# stray "claude-cli" User-Agent from disabling cloaking (which makes Anthropic reject
+# premium models with 429 while Haiku still works). Individual credentials can still
+# override this via a claude-api-key "cloak.mode" or a Claude OAuth/token file
+# "cloak_mode" value. Empty keeps "auto".
+claude-cloak-mode: "auto"
+
+# When true, globally disable Claude request cloaking (equivalent to
+# claude-cloak-mode: "never"; kept for backward compatibility and takes precedence
+# over claude-cloak-mode when true), so the original system prompt is passed through
+# to Claude as-is. Individual credentials can still override this: a claude-api-key
+# entry via its "cloak.mode", or a Claude OAuth/token file via a "cloak_mode" value.
+# Default false keeps the per-client "auto" behavior (cloak only non-Claude-Code clients).
 disable-claude-cloak-mode: false
 
 # disable-image-generation supports: false (default), true, "chat", or "passthrough".

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -142,12 +142,23 @@ type Config struct {
 	// These are used as fallbacks when the client does not send its own headers.
 	ClaudeHeaderDefaults ClaudeHeaderDefaults `yaml:"claude-header-defaults" json:"claude-header-defaults"`
 
+	// ClaudeCloakMode sets the global default Claude cloak mode: "auto" (default),
+	// "always", or "never". Cloaking disguises requests as the official Claude Code
+	// CLI and replaces the system prompt. "auto" cloaks only clients whose
+	// User-Agent is not Claude Code; "always" cloaks every request regardless of
+	// client (useful when the proxy only ever fronts non-Claude-Code apps, so a
+	// stray "claude-cli" User-Agent can't disable cloaking and get premium models
+	// rejected); "never" disables it. A specific credential can still override this
+	// via its own cloak settings (the per claude-api-key "cloak" block, or a
+	// "cloak_mode" value in the auth/OAuth token file). Empty preserves "auto".
+	ClaudeCloakMode string `yaml:"claude-cloak-mode" json:"claude-cloak-mode"`
+
 	// DisableClaudeCloakMode globally disables Claude request cloaking when true.
-	// Cloaking disguises requests as the official Claude Code CLI and replaces the
-	// system prompt. When true, every Claude credential defaults to no cloaking
-	// ("never"); a specific credential can still re-enable or override it via its own
-	// cloak settings (the per claude-api-key "cloak" block, or a "cloak_mode" value in
-	// the auth/OAuth token file). Default false preserves the per-client "auto" behavior.
+	// Equivalent to ClaudeCloakMode "never" and kept for backward compatibility;
+	// when true it takes precedence over ClaudeCloakMode. A specific credential can
+	// still re-enable or override it via its own cloak settings (the per
+	// claude-api-key "cloak" block, or a "cloak_mode" value in the auth/OAuth token
+	// file). Default false preserves the per-client "auto" behavior.
 	DisableClaudeCloakMode bool `yaml:"disable-claude-cloak-mode" json:"disable-claude-cloak-mode"`
 
 	// OpenAICompatibility defines OpenAI API compatibility configurations for external providers.

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -2054,12 +2054,18 @@ func applyCloaking(ctx context.Context, cfg *config.Config, auth *cliproxyauth.A
 
 	// Determine cloak settings. Precedence (low -> high):
 	//   built-in "auto" default
+	//   -> global claude-cloak-mode default ("auto"/"always"/"never")
 	//   -> global disable-claude-cloak-mode switch (forces "never")
 	//   -> per-credential settings from auth attributes/metadata
 	//   -> per claude-api-key cloak config
 	cloakMode := "auto"
-	if cfg != nil && cfg.DisableClaudeCloakMode {
-		cloakMode = "never"
+	if cfg != nil {
+		if globalMode := strings.ToLower(strings.TrimSpace(cfg.ClaudeCloakMode)); globalMode != "" {
+			cloakMode = globalMode
+		}
+		if cfg.DisableClaudeCloakMode {
+			cloakMode = "never"
+		}
 	}
 	strictMode := attrStrict
 	sensitiveWords := attrWords

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2712,6 +2712,38 @@ func TestApplyCloaking_PreservesConfiguredStrictModeAndSensitiveWordsWhenModeOmi
 	}
 }
 
+func TestApplyCloaking_GlobalAlwaysModeCloaksClaudeCliClient(t *testing.T) {
+	// A "claude-cli" User-Agent is treated as a genuine Claude Code client, so the
+	// default "auto" mode skips cloaking. claude-cloak-mode: "always" must force
+	// cloaking anyway — the fix for non-Claude-Code apps that send a claude-cli UA
+	// and get premium models rejected (429) because their request went un-cloaked.
+	incoming := http.Header{"User-Agent": []string{"claude-cli/2.1.181 (external, cli)"}}
+	ctx := newClaudeHeaderTestRequest(t, incoming).Context()
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123"}}
+	payload := []byte(`{"system":"orig","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	// Baseline: default "auto" mode leaves a claude-cli client un-cloaked, so the
+	// original system prompt passes through unchanged.
+	baseOut, errBase := applyCloaking(ctx, &config.Config{}, auth, payload, "claude-3-5-sonnet-20241022", "key-123")
+	if errBase != nil {
+		t.Fatalf("applyCloaking() baseline error = %v", errBase)
+	}
+	if got := gjson.GetBytes(baseOut, "system").String(); got != "orig" {
+		t.Fatalf("auto mode should not cloak a claude-cli client; system = %q", got)
+	}
+
+	// With claude-cloak-mode: "always", cloaking is forced even for a claude-cli
+	// client — the system prompt is replaced with the injected Claude Code blocks.
+	cfg := &config.Config{ClaudeCloakMode: "always"}
+	out, errCloaking := applyCloaking(ctx, cfg, auth, payload, "claude-3-5-sonnet-20241022", "key-123")
+	if errCloaking != nil {
+		t.Fatalf("applyCloaking() always error = %v", errCloaking)
+	}
+	if !gjson.GetBytes(out, "system").IsArray() {
+		t.Fatalf("claude-cloak-mode always should cloak (inject Claude Code system blocks); system = %q", gjson.GetBytes(out, "system").Raw)
+	}
+}
+
 func TestNormalizeClaudeSamplingForUpstream_RemovesTemperature(t *testing.T) {
 	payload := []byte(`{"temperature":0,"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`)
 	out := normalizeClaudeSamplingForUpstream(payload)


### PR DESCRIPTION
## Problem

Claude cloaking is decided per-request by `ShouldCloak`. In the default `auto` mode it **skips cloaking for any client whose `User-Agent` starts with `claude-cli`** (assumed to be a genuine Claude Code client). Today the only *global* control is `disable-claude-cloak-mode`, which forces `"never"` — there is **no global way to force `"always"`**.

That's a footgun for the common deployment where the proxy only ever fronts **non-Claude-Code apps**: if such an app sends a `claude-cli` User-Agent (e.g. because it was told that impersonating Claude Code helps), the proxy skips cloaking and forwards a half-formed Claude identity. Anthropic's **premium tier (Sonnet/Opus) then rejects it with `429 rate_limit_error`, while Haiku (cloak-exempt) keeps working** — so the failure is easy to misdiagnose as a rate limit until a strong model is used.

The only current remedy is a **per-credential** `cloak_mode`, which for OAuth lives inside each token JSON and is **regenerated (lost) on re-login** — so it can't be pinned in version-controlled config.

## Change

Add a global **`claude-cloak-mode: "auto" | "always" | "never"`** that sets the default cloak mode for every Claude credential, still overridable per-credential (per `claude-api-key` `cloak.mode` or per-OAuth `cloak_mode`) exactly as before.

- Precedence (low → high): built-in `auto` → **`claude-cloak-mode` global default** → `disable-claude-cloak-mode` (still forces `never`, kept for backward compat and wins if set) → per-credential → per-`claude-api-key`.
- `claude-cloak-mode: "always"` makes cloaking independent of the client User-Agent, closing the footgun in one place, in config that survives re-login.
- Fully backward compatible: default (empty) preserves today's `auto` behavior; `disable-claude-cloak-mode` is unchanged.

## Files
- `internal/config/config.go` — new `ClaudeCloakMode string` field (`yaml:"claude-cloak-mode"`).
- `internal/runtime/executor/claude_executor.go` — apply it as the global default in the cloak-mode precedence block.
- `config.example.yaml` — document the new knob.
- `internal/runtime/executor/claude_executor_test.go` — `TestApplyCloaking_GlobalAlwaysModeCloaksClaudeCliClient`: verifies `always` cloaks a `claude-cli` client that `auto` skips.

## Verification
- `gofmt` clean; `go build ./cmd/server` OK.
- `go test ./internal/runtime/executor/ ./internal/config/` passes (incl. the new test).