### PR TITLE
feat(pluginstore): support command-backed auth secrets

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -64,13 +64,26 @@ plugins:
   # Additional plugin store registries. The built-in official registry is always included.
   # store-sources:
   #   - "https://example.com/cliproxy-plugins/registry.json"
-  # Optional plugin store auth rules. Values are read from environment variables;
-  # tokens are not written into plugin manifests or node status.
+  # Optional plugin store auth rules. Use an environment variable or command for each
+  # secret, never both. Commands run through /bin/sh -c on Unix or cmd.exe /C on Windows,
+  # have a fixed 5s limit, their trimmed output is not persisted, and configured expressions
+  # remain visible through privileged config APIs. Do not embed literal secrets.
   # store-auth:
   #   - match: "https://example.com/cliproxy-plugins/"
   #     apply-to: ["registry", "artifact"]
   #     type: bearer
   #     token-env: "CLIPROXY_PLUGIN_STORE_TOKEN"
+  #   - match: "https://api.github.com/"
+  #     type: github-token
+  #     token-command: "gh auth token --hostname github.com"
+  #   - match: "https://basic.example.com/"
+  #     type: basic
+  #     username-command: "security find-generic-password -s plugin-user -w"
+  #     password-command: "security find-generic-password -s plugin-password -w"
+  #   - match: "https://headers.example.com/"
+  #     type: header
+  #     header-name: "X-Plugin-Token"
+  #     header-value-command: "security find-generic-password -s plugin-header -w"
   configs:
     example:
       enabled: true

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -137,12 +137,13 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 		return
 	}
 	pluginsDir = resolvedPluginsDir
+	resolver := pluginstore.NewAuthResolver()
 	sources, errSources := h.pluginStoreSources(sourceConfigs)
 	if errSources != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "plugin_store_source_invalid", "message": errSources.Error()})
 		return
 	}
-	plugins, sourceErrors := h.fetchSourcedPlugins(c.Request.Context(), proxyURL, storeAuth, sources)
+	plugins, sourceErrors := h.fetchSourcedPlugins(c.Request.Context(), resolver, proxyURL, storeAuth, sources)
 	if len(plugins) == 0 && len(sourceErrors) > 0 {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "plugin_store_registry_failed", "message": sourceErrors[0].Message})
 		return
@@ -158,7 +159,7 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 		latestInput = append(latestInput, item.plugin)
 	}
 	client := h.newPluginStoreClient(proxyURL, "", storeAuth)
-	latestVersions := h.latestPluginVersions(c.Request.Context(), client, latestInput)
+	latestVersions := h.latestPluginVersions(c.Request.Context(), resolver, client, latestInput)
 	pluginSourceCounts := make(map[string]int, len(plugins))
 	for _, item := range plugins {
 		pluginSourceCounts[item.plugin.ID]++
@@ -193,7 +194,7 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 			Repository:          htmlsanitize.String(plugin.Repository),
 			InstallType:         htmlsanitize.String(pluginstore.PluginInstallType(plugin)),
 			AuthRequired:        plugin.AuthRequired,
-			AuthConfigured:      pluginAuthConfigured(item.source, plugin, storeAuth),
+			AuthConfigured:      pluginAuthConfigured(c.Request.Context(), resolver, item.source, plugin, storeAuth),
 			Platforms:           sanitizePluginStorePlatforms(pluginstore.PluginPlatforms(plugin)),
 			Logo:                htmlsanitize.String(plugin.Logo),
 			Homepage:            htmlsanitize.String(plugin.Homepage),
@@ -236,6 +237,7 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		return
 	}
 	installCtx := c.Request.Context()
+	resolver := pluginstore.NewAuthResolver()
 	pluginsEnabled, pluginsDir, proxyURL, sourceConfigs, storeAuth, configs, host := h.pluginStoreSnapshot()
 	resolvedPluginsDir, errResolvePluginsDir := config.ResolvePluginsDir(pluginsDir)
 	if errResolvePluginsDir != nil {
@@ -248,7 +250,7 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "plugin_store_source_invalid", "message": errSources.Error()})
 		return
 	}
-	source, plugin, client, okPlugin := h.findPluginStoreInstallTarget(installCtx, proxyURL, storeAuth, sources, id, c.Query("source"), c)
+	source, plugin, client, okPlugin := h.findPluginStoreInstallTarget(installCtx, resolver, proxyURL, storeAuth, sources, id, c.Query("source"), c)
 	if !okPlugin {
 		return
 	}
@@ -273,9 +275,9 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 			c.JSON(http.StatusBadGateway, gin.H{"error": "plugin_manifest_invalid", "message": errManifest.Error()})
 			return
 		}
-		result, errInstall = client.InstallManifest(installCtx, manifest, installOptions)
+		result, errInstall = client.InstallManifestWithResolver(installCtx, resolver, manifest, installOptions)
 	case pluginstore.InstallTypeGitHubRelease:
-		result, errInstall = installPluginStoreGitHubRelease(installCtx, client, plugin, requestedVersion, installOptions)
+		result, errInstall = installPluginStoreGitHubRelease(installCtx, resolver, client, plugin, requestedVersion, installOptions)
 	default:
 		c.JSON(http.StatusBadGateway, gin.H{"error": "plugin_manifest_invalid", "message": fmt.Sprintf("unsupported install type %q", plugin.Install.Type)})
 		return
@@ -385,15 +387,15 @@ func pluginStoreDirectManifest(source pluginstore.Source, plugin pluginstore.Plu
 	return pluginstore.Manifest{}, fmt.Errorf("direct plugin version %q not found", version)
 }
 
-func installPluginStoreGitHubRelease(ctx context.Context, client pluginstore.Client, plugin pluginstore.Plugin, requestedVersion string, options pluginstore.InstallOptions) (pluginstore.InstallResult, error) {
+func installPluginStoreGitHubRelease(ctx context.Context, resolver *pluginstore.AuthResolver, client pluginstore.Client, plugin pluginstore.Plugin, requestedVersion string, options pluginstore.InstallOptions) (pluginstore.InstallResult, error) {
 	version := normalizePluginStoreRequestedVersion(requestedVersion)
 	if version == "" {
-		return client.Install(ctx, plugin, options)
+		return client.InstallWithResolver(ctx, resolver, plugin, options)
 	}
 	tags := pluginStoreReleaseTagCandidates(requestedVersion)
 	errs := make([]error, 0, len(tags))
 	for _, tag := range tags {
-		result, errInstall := client.InstallVersion(ctx, plugin, tag, version, options)
+		result, errInstall := client.InstallVersionWithResolver(ctx, resolver, plugin, tag, version, options)
 		if errInstall == nil {
 			return result, nil
 		}
@@ -544,12 +546,12 @@ func (h *Handler) newPluginStoreClient(proxyURL string, registryURL string, stor
 	return pluginstore.Client{HTTPClient: client, RegistryURL: registryURL, Auth: storeAuth}
 }
 
-func (h *Handler) fetchSourcedPlugins(ctx context.Context, proxyURL string, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source) ([]sourcedPlugin, []pluginStoreSourceErr) {
+func (h *Handler) fetchSourcedPlugins(ctx context.Context, resolver *pluginstore.AuthResolver, proxyURL string, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source) ([]sourcedPlugin, []pluginStoreSourceErr) {
 	plugins := make([]sourcedPlugin, 0)
 	sourceErrors := make([]pluginStoreSourceErr, 0)
 	for _, source := range sources {
 		client := h.newPluginStoreClient(proxyURL, source.URL, storeAuth)
-		registry, errRegistry := client.FetchRegistry(ctx)
+		registry, errRegistry := client.FetchRegistryWithResolver(ctx, resolver)
 		if errRegistry != nil {
 			sourceErrors = append(sourceErrors, pluginStoreSourceErr{
 				SourceID:   source.ID,
@@ -566,7 +568,7 @@ func (h *Handler) fetchSourcedPlugins(ctx context.Context, proxyURL string, stor
 	return plugins, sourceErrors
 }
 
-func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, proxyURL string, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source, id string, requestedSourceID string, c *gin.Context) (pluginstore.Source, pluginstore.Plugin, pluginstore.Client, bool) {
+func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, resolver *pluginstore.AuthResolver, proxyURL string, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source, id string, requestedSourceID string, c *gin.Context) (pluginstore.Source, pluginstore.Plugin, pluginstore.Client, bool) {
 	requestedSourceID = strings.TrimSpace(requestedSourceID)
 	if requestedSourceID != "" {
 		for _, source := range sources {
@@ -574,7 +576,7 @@ func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, proxyURL str
 				continue
 			}
 			client := h.newPluginStoreClient(proxyURL, source.URL, storeAuth)
-			registry, errRegistry := client.FetchRegistry(ctx)
+			registry, errRegistry := client.FetchRegistryWithResolver(ctx, resolver)
 			if errRegistry != nil {
 				c.JSON(http.StatusBadGateway, gin.H{"error": "plugin_store_registry_failed", "message": errRegistry.Error()})
 				return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
@@ -590,7 +592,7 @@ func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, proxyURL str
 		return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
 	}
 
-	plugins, sourceErrors := h.fetchSourcedPlugins(ctx, proxyURL, storeAuth, sources)
+	plugins, sourceErrors := h.fetchSourcedPlugins(ctx, resolver, proxyURL, storeAuth, sources)
 	matches := make([]sourcedPlugin, 0)
 	for _, item := range plugins {
 		if item.plugin.ID == id {
@@ -667,21 +669,21 @@ func sanitizePluginStorePlatforms(platforms []pluginstore.Platform) []pluginStor
 	return out
 }
 
-func pluginAuthConfigured(source pluginstore.Source, plugin pluginstore.Plugin, storeAuth []pluginstore.AuthConfig) bool {
-	return pluginstore.PluginAuthConfigured(source, plugin, storeAuth)
+func pluginAuthConfigured(ctx context.Context, resolver *pluginstore.AuthResolver, source pluginstore.Source, plugin pluginstore.Plugin, storeAuth []pluginstore.AuthConfig) bool {
+	return pluginstore.PluginAuthConfiguredContext(ctx, resolver, source, plugin, storeAuth)
 }
 
 // latestPluginVersions resolves the latest release version of each registry
 // plugin concurrently, returning results positionally aligned with plugins.
 // Unresolved entries are left empty so callers can fall back gracefully.
-func (h *Handler) latestPluginVersions(ctx context.Context, client pluginstore.Client, plugins []pluginstore.Plugin) []string {
+func (h *Handler) latestPluginVersions(ctx context.Context, resolver *pluginstore.AuthResolver, client pluginstore.Client, plugins []pluginstore.Plugin) []string {
 	versions := make([]string, len(plugins))
 	var wg sync.WaitGroup
 	for index := range plugins {
 		wg.Add(1)
 		go func(index int) {
 			defer wg.Done()
-			versions[index] = h.latestPluginVersion(ctx, client, plugins[index])
+			versions[index] = h.latestPluginVersion(ctx, resolver, client, plugins[index])
 		}(index)
 	}
 	wg.Wait()
@@ -692,7 +694,7 @@ func (h *Handler) latestPluginVersions(ctx context.Context, client pluginstore.C
 // lookups per repository so repeated listings do not exhaust the GitHub API
 // rate limit. Failed lookups are cached for a shorter interval and reported
 // as an empty version.
-func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Client, plugin pluginstore.Plugin) string {
+func (h *Handler) latestPluginVersion(ctx context.Context, resolver *pluginstore.AuthResolver, client pluginstore.Client, plugin pluginstore.Plugin) string {
 	if pluginstore.PluginInstallType(plugin) != pluginstore.InstallTypeGitHubRelease {
 		return ""
 	}
@@ -710,7 +712,7 @@ func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Cl
 
 	version := ""
 	ttl := pluginReleaseFailureCacheTTL
-	release, errRelease := client.FetchLatestRelease(ctx, plugin)
+	release, errRelease := client.FetchLatestReleaseWithResolver(ctx, resolver, plugin)
 	if errRelease != nil {
 		log.WithError(errRelease).WithField("plugin_id", plugin.ID).Warn("pluginstore: failed to fetch latest release")
 	} else if latestVersion, errVersion := pluginstore.ReleaseVersion(release); errVersion != nil {

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -598,6 +598,51 @@ func TestListPluginStoreIncludesDirectMetadataAndAuth(t *testing.T) {
 	}
 }
 
+func TestListPluginStoreReusesCommandAuthResolution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("command expression is POSIX shell syntax")
+	}
+	countPath := filepath.Join(t.TempDir(), "command-count")
+	const resolved = "command-token"
+	command := "printf x >> " + countPath + "; printf " + resolved
+	h := &Handler{
+		cfg: &config.Config{Plugins: config.PluginsConfig{
+			Enabled: true,
+			Dir:     t.TempDir(),
+			StoreAuth: []pluginstore.AuthConfig{{
+				Match:        "https://registry.example/",
+				ApplyTo:      []string{pluginstore.RequestKindRegistry},
+				Type:         pluginstore.AuthTypeBearer,
+				TokenCommand: command,
+			}},
+		}},
+		configFilePath:         writeTestConfigFile(t),
+		pluginStoreRegistryURL: "https://registry.example/registry.json",
+		pluginStoreHTTPClient: fakePluginStoreHTTPClient{
+			"https://registry.example/registry.json": directRegistryJSON("https://downloads.example/sample-provider.zip", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/plugin-store", nil)
+	h.ListPluginStore(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	count, errRead := os.ReadFile(countPath)
+	if errRead != nil {
+		t.Fatalf("ReadFile(command count) error = %v", errRead)
+	}
+	if string(count) != "x" {
+		t.Fatalf("command executions = %q, want one", count)
+	}
+	if strings.Contains(rec.Body.String(), resolved) {
+		t.Fatalf("list response leaked resolved command value: %s", rec.Body.String())
+	}
+}
+
 func TestListPluginStoreReportsVersionArtifactAuth(t *testing.T) {
 	t.Setenv("PLUGIN_STORE_TOKEN", "secret-token")
 
@@ -1383,6 +1428,32 @@ func pluginStorePlatformsContain(platforms []pluginStorePlatform, goos string, g
 		}
 	}
 	return false
+}
+
+func TestGetConfigSerializesPluginStoreAuthExpressionsOnly(t *testing.T) {
+	const command = "printf configured-expression"
+	const resolved = "resolved-secret"
+	h := &Handler{cfg: &config.Config{Plugins: config.PluginsConfig{StoreAuth: []pluginstore.AuthConfig{{
+		Match:        "https://plugins.example/",
+		Type:         pluginstore.AuthTypeBearer,
+		TokenCommand: command,
+	}}}}}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/config", nil)
+	h.GetConfig(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, command) {
+		t.Fatalf("config response missing command expression: %s", body)
+	}
+	if strings.Contains(body, resolved) || strings.Contains(body, "authResolution") || strings.Contains(body, "cache") {
+		t.Fatalf("config response leaked resolved auth state: %s", body)
+	}
 }
 
 func makeManagementPluginStoreZip(t *testing.T, name string, content string) []byte {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -814,6 +814,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	if errResolvePluginsDir := cfg.ResolvePluginsDir(); errResolvePluginsDir != nil && cfg.Plugins.Enabled {
 		return nil, errResolvePluginsDir
 	}
+	if errAuth := cfg.ValidatePluginStoreAuth(); errAuth != nil {
+		return nil, errAuth
+	}
 
 	// Sanitize Gemini API key configuration and migrate legacy entries.
 	cfg.SanitizeGeminiKeys()
@@ -879,6 +882,16 @@ func (cfg *Config) NormalizePluginsConfig() {
 	if cfg.Plugins.Configs == nil {
 		cfg.Plugins.Configs = map[string]PluginInstanceConfig{}
 	}
+}
+
+func (cfg *Config) ValidatePluginStoreAuth() error {
+	if cfg == nil {
+		return nil
+	}
+	if errAuth := sdkpluginstore.ValidateAuthConfigs(cfg.Plugins.StoreAuth); errAuth != nil {
+		return fmt.Errorf("invalid plugin store auth: %w", errAuth)
+	}
+	return nil
 }
 
 // SanitizePayloadRules validates raw JSON payload rule params and drops invalid rules.

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -79,6 +79,9 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	if errResolvePluginsDir := cfg.ResolvePluginsDir(); errResolvePluginsDir != nil && cfg.Plugins.Enabled {
 		return nil, errResolvePluginsDir
 	}
+	if errAuth := cfg.ValidatePluginStoreAuth(); errAuth != nil {
+		return nil, errAuth
+	}
 
 	// Apply the same sanitization pipeline.
 	cfg.SanitizeGeminiKeys()

--- a/internal/config/plugin_config_test.go
+++ b/internal/config/plugin_config_test.go
@@ -244,3 +244,88 @@ plugins:
 		}
 	}
 }
+
+func TestParseConfigBytes_PluginStoreAuthCommandSources(t *testing.T) {
+	cfg, errParse := ParseConfigBytes([]byte(`
+plugins:
+  store-auth:
+    - match: " https://token.example/ "
+      type: bearer
+      token-command: " printf token "
+    - match: "https://basic.example/"
+      type: basic
+      username-command: " printf username "
+      password-command: " printf password "
+    - match: "https://header.example/"
+      type: header
+      header-name: " X-Plugin-Token "
+      header-value-command: " printf header "
+`))
+	if errParse != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", errParse)
+	}
+
+	auth := cfg.Plugins.StoreAuth
+	if len(auth) != 3 || auth[0].TokenCommand != "printf token" || auth[1].UsernameCommand != "printf username" || auth[1].PasswordCommand != "printf password" || auth[2].HeaderValueCommand != "printf header" {
+		t.Fatalf("normalized command auth = %#v", auth)
+	}
+	if auth[2].HeaderName != "X-Plugin-Token" {
+		t.Fatalf("HeaderName = %q, want X-Plugin-Token", auth[2].HeaderName)
+	}
+}
+
+func TestParseConfigBytes_PluginStoreAuthKeepsEnvironmentSource(t *testing.T) {
+	cfg, errParse := ParseConfigBytes([]byte(`
+plugins:
+  store-auth:
+    - match: "https://plugins.example/"
+      type: bearer
+      token-env: " PLUGIN_STORE_TOKEN "
+`))
+	if errParse != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", errParse)
+	}
+	if got := cfg.Plugins.StoreAuth[0].TokenEnv; got != "PLUGIN_STORE_TOKEN" {
+		t.Fatalf("TokenEnv = %q, want PLUGIN_STORE_TOKEN", got)
+	}
+}
+
+func TestLoadConfigOptional_RejectsAmbiguousPluginStoreAuthSource(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	const secret = "not-a-secret-value"
+	if errWrite := os.WriteFile(configPath, []byte(`
+plugins:
+  store-auth:
+    - match: "https://plugins.example/"
+      type: header
+      header-value-env: "PLUGIN_STORE_HEADER"
+      header-value-command: "printf `+secret+`"
+`), 0o600); errWrite != nil {
+		t.Fatalf("WriteFile() error = %v", errWrite)
+	}
+	_, errLoad := LoadConfigOptional(configPath, false)
+	if errLoad == nil {
+		t.Fatal("LoadConfigOptional() error = nil, want ambiguity error")
+	}
+	if !strings.Contains(errLoad.Error(), "header value source is ambiguous") || strings.Contains(errLoad.Error(), secret) {
+		t.Fatalf("LoadConfigOptional() error = %q, want safe header-value ambiguity", errLoad)
+	}
+}
+
+func TestParseConfigBytes_RejectsAmbiguousPluginStoreAuthSource(t *testing.T) {
+	const secret = "not-a-secret-value"
+	_, errParse := ParseConfigBytes([]byte(`
+plugins:
+  store-auth:
+    - match: "https://plugins.example/"
+      type: bearer
+      token-env: "PLUGIN_STORE_TOKEN"
+      token-command: "printf ` + secret + `"
+`))
+	if errParse == nil {
+		t.Fatal("ParseConfigBytes() error = nil, want ambiguity error")
+	}
+	if !strings.Contains(errParse.Error(), "token source is ambiguous") || strings.Contains(errParse.Error(), secret) {
+		t.Fatalf("ParseConfigBytes() error = %q, want safe token ambiguity", errParse)
+	}
+}

--- a/internal/homeplugins/sync.go
+++ b/internal/homeplugins/sync.go
@@ -143,6 +143,7 @@ func SyncPlatformWithReport(ctx context.Context, cfg *config.Config, pluginRunti
 		return report, errPluginsDir
 	}
 	client := newPluginStoreClient(cfg)
+	resolver := sdkpluginstore.NewAuthResolver()
 	var syncErrors []error
 	ids := make([]string, 0, len(cfg.Plugins.Configs))
 	for id := range cfg.Plugins.Configs {
@@ -169,7 +170,7 @@ func SyncPlatformWithReport(ctx context.Context, cfg *config.Config, pluginRunti
 			continue
 		}
 		status := pluginStatusFromManifest(manifest)
-		result, errSync := installManifest(ctx, client, manifest, root, platform, pluginRuntime)
+		result, errSync := installManifest(ctx, resolver, client, manifest, root, platform, pluginRuntime)
 		if errSync != nil {
 			status.InstallStatus = pluginInstallStatusFailed
 			status.Error = errSync.Error()
@@ -192,7 +193,7 @@ func SyncPlatformWithReport(ctx context.Context, cfg *config.Config, pluginRunti
 	return report, errSync
 }
 
-func installManifest(ctx context.Context, client sdkpluginstore.Client, manifest sdkpluginstore.Manifest, root string, platform Platform, pluginRuntime PluginRuntime) (sdkpluginstore.InstallResult, error) {
+func installManifest(ctx context.Context, resolver *sdkpluginstore.AuthResolver, client sdkpluginstore.Client, manifest sdkpluginstore.Manifest, root string, platform Platform, pluginRuntime PluginRuntime) (sdkpluginstore.InstallResult, error) {
 	id := strings.TrimSpace(manifest.ID)
 	if id == "" {
 		return sdkpluginstore.InstallResult{}, fmt.Errorf("home plugins: manifest plugin id is empty")
@@ -200,7 +201,7 @@ func installManifest(ctx context.Context, client sdkpluginstore.Client, manifest
 	pluginIsBusy := func() bool {
 		return pluginRuntime != nil && pluginRuntime.PluginBusy(id)
 	}
-	result, errInstall := client.InstallManifest(ctx, manifest, sdkpluginstore.InstallOptions{
+	result, errInstall := client.InstallManifestWithResolver(ctx, resolver, manifest, sdkpluginstore.InstallOptions{
 		PluginsDir:   root,
 		GOOS:         platform.GOOS,
 		GOARCH:       platform.GOARCH,

--- a/internal/pluginstore/auth.go
+++ b/internal/pluginstore/auth.go
@@ -27,7 +27,10 @@ const (
 	AuthTypeGitHubToken = "github-token"
 )
 
-const authCommandTimeout = 5 * time.Second
+const (
+	authCommandTimeout   = 5 * time.Second
+	authCommandWaitDelay = 100 * time.Millisecond
+)
 
 var errAuthCommandTimedOut = errors.New("auth command timed out")
 
@@ -345,7 +348,10 @@ func authCommandShell(expression string) (string, []string) {
 }
 
 func runAuthCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).Output()
+	command := exec.CommandContext(ctx, name, args...)
+	command.WaitDelay = authCommandWaitDelay
+	configureAuthCommandCancellation(command)
+	return command.Output()
 }
 
 func validatePluginStoreRequestURL(auth []AuthConfig, requestURL string, kind string) error {

--- a/internal/pluginstore/auth.go
+++ b/internal/pluginstore/auth.go
@@ -1,12 +1,18 @@
 package pluginstore
 
 import (
+	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
+	"runtime"
 	"strings"
+	"sync"
+	"time"
 )
 
 const (
@@ -21,16 +27,62 @@ const (
 	AuthTypeGitHubToken = "github-token"
 )
 
+const authCommandTimeout = 5 * time.Second
+
+var errAuthCommandTimedOut = errors.New("auth command timed out")
+
 type AuthConfig struct {
-	Match          string   `yaml:"match,omitempty" json:"match,omitempty"`
-	ApplyTo        []string `yaml:"apply-to,omitempty" json:"apply_to,omitempty"`
-	Type           string   `yaml:"type,omitempty" json:"type,omitempty"`
-	TokenEnv       string   `yaml:"token-env,omitempty" json:"token_env,omitempty"`
-	UsernameEnv    string   `yaml:"username-env,omitempty" json:"username_env,omitempty"`
-	PasswordEnv    string   `yaml:"password-env,omitempty" json:"password_env,omitempty"`
-	HeaderName     string   `yaml:"header-name,omitempty" json:"header_name,omitempty"`
-	HeaderValueEnv string   `yaml:"header-value-env,omitempty" json:"header_value_env,omitempty"`
-	AllowInsecure  bool     `yaml:"allow-insecure,omitempty" json:"allow_insecure,omitempty"`
+	Match              string   `yaml:"match,omitempty" json:"match,omitempty"`
+	ApplyTo            []string `yaml:"apply-to,omitempty" json:"apply_to,omitempty"`
+	Type               string   `yaml:"type,omitempty" json:"type,omitempty"`
+	TokenEnv           string   `yaml:"token-env,omitempty" json:"token_env,omitempty"`
+	TokenCommand       string   `yaml:"token-command,omitempty" json:"token_command,omitempty"`
+	UsernameEnv        string   `yaml:"username-env,omitempty" json:"username_env,omitempty"`
+	UsernameCommand    string   `yaml:"username-command,omitempty" json:"username_command,omitempty"`
+	PasswordEnv        string   `yaml:"password-env,omitempty" json:"password_env,omitempty"`
+	PasswordCommand    string   `yaml:"password-command,omitempty" json:"password_command,omitempty"`
+	HeaderName         string   `yaml:"header-name,omitempty" json:"header_name,omitempty"`
+	HeaderValueEnv     string   `yaml:"header-value-env,omitempty" json:"header_value_env,omitempty"`
+	HeaderValueCommand string   `yaml:"header-value-command,omitempty" json:"header_value_command,omitempty"`
+	AllowInsecure      bool     `yaml:"allow-insecure,omitempty" json:"allow_insecure,omitempty"`
+}
+
+type AuthResolver struct {
+	mu             sync.Mutex
+	cache          map[string]*authResolution
+	commandTimeout time.Duration
+	onWait         func()
+}
+
+type authResolution struct {
+	done  chan struct{}
+	value string
+	err   error
+}
+
+type authCommandRunnerFunc func(context.Context, string, ...string) ([]byte, error)
+
+var authCommandRunner = runAuthCommand
+var authCommandRunnerMu sync.Mutex
+
+func NewAuthResolver() *AuthResolver {
+	return newAuthResolver(authCommandTimeout)
+}
+
+func newAuthResolver(commandTimeout time.Duration) *AuthResolver {
+	return &AuthResolver{cache: make(map[string]*authResolution), commandTimeout: commandTimeout}
+}
+
+func setAuthCommandRunnerForTest(runner authCommandRunnerFunc) func() {
+	authCommandRunnerMu.Lock()
+	previous := authCommandRunner
+	authCommandRunner = runner
+	authCommandRunnerMu.Unlock()
+	return func() {
+		authCommandRunnerMu.Lock()
+		authCommandRunner = previous
+		authCommandRunnerMu.Unlock()
+	}
 }
 
 func NormalizeAuthConfigs(auth []AuthConfig) []AuthConfig {
@@ -42,10 +94,14 @@ func NormalizeAuthConfigs(auth []AuthConfig) []AuthConfig {
 		item.Match = strings.TrimSpace(item.Match)
 		item.Type = strings.ToLower(strings.TrimSpace(item.Type))
 		item.TokenEnv = strings.TrimSpace(item.TokenEnv)
+		item.TokenCommand = strings.TrimSpace(item.TokenCommand)
 		item.UsernameEnv = strings.TrimSpace(item.UsernameEnv)
+		item.UsernameCommand = strings.TrimSpace(item.UsernameCommand)
 		item.PasswordEnv = strings.TrimSpace(item.PasswordEnv)
+		item.PasswordCommand = strings.TrimSpace(item.PasswordCommand)
 		item.HeaderName = strings.TrimSpace(item.HeaderName)
 		item.HeaderValueEnv = strings.TrimSpace(item.HeaderValueEnv)
+		item.HeaderValueCommand = strings.TrimSpace(item.HeaderValueCommand)
 		if item.Type == "" {
 			item.Type = AuthTypeNone
 		}
@@ -73,76 +129,97 @@ func NormalizeAuthConfigs(auth []AuthConfig) []AuthConfig {
 	return out
 }
 
+func ValidateAuthConfigs(auth []AuthConfig) error {
+	for _, item := range auth {
+		for _, source := range []struct {
+			env     string
+			command string
+			name    string
+		}{
+			{item.TokenEnv, item.TokenCommand, "token"},
+			{item.UsernameEnv, item.UsernameCommand, "username"},
+			{item.PasswordEnv, item.PasswordCommand, "password"},
+			{item.HeaderValueEnv, item.HeaderValueCommand, "header value"},
+		} {
+			if strings.TrimSpace(source.env) != "" && strings.TrimSpace(source.command) != "" {
+				return fmt.Errorf("plugin store auth %s source is ambiguous", source.name)
+			}
+		}
+	}
+	return nil
+}
+
 func AuthConfigured(auth []AuthConfig, requestURL string, kind string) bool {
-	item, ok := matchingAuthConfig(auth, requestURL, kind)
-	if !ok {
-		return false
-	}
-	switch strings.ToLower(strings.TrimSpace(item.Type)) {
-	case AuthTypeNone:
-		return false
-	case AuthTypeBearer, AuthTypeGitHubToken:
-		return strings.TrimSpace(os.Getenv(item.TokenEnv)) != ""
-	case AuthTypeBasic:
-		return strings.TrimSpace(os.Getenv(item.UsernameEnv)) != "" && strings.TrimSpace(os.Getenv(item.PasswordEnv)) != ""
-	case AuthTypeHeader:
-		return item.HeaderName != "" && strings.TrimSpace(os.Getenv(item.HeaderValueEnv)) != ""
-	default:
-		return false
-	}
+	return AuthConfiguredContext(context.Background(), NewAuthResolver(), auth, requestURL, kind)
+}
+
+func AuthConfiguredContext(ctx context.Context, resolver *AuthResolver, auth []AuthConfig, requestURL string, kind string) bool {
+	headers := http.Header{}
+	return applyPluginStoreAuthContext(ctx, resolver, headers, auth, requestURL, kind) == nil && len(headers) > 0
 }
 
 func PluginAuthConfigured(source Source, plugin Plugin, auth []AuthConfig) bool {
-	if AuthConfigured(auth, source.URL, RequestKindRegistry) {
+	return PluginAuthConfiguredContext(context.Background(), NewAuthResolver(), source, plugin, auth)
+}
+
+func PluginAuthConfiguredContext(ctx context.Context, resolver *AuthResolver, source Source, plugin Plugin, auth []AuthConfig) bool {
+	if AuthConfiguredContext(ctx, resolver, auth, source.URL, RequestKindRegistry) {
 		return true
 	}
 	switch PluginInstallType(plugin) {
 	case InstallTypeDirect:
 		for _, artifact := range PluginArtifacts(plugin) {
-			if AuthConfigured(auth, artifact.URL, RequestKindArtifact) {
+			if AuthConfiguredContext(ctx, resolver, auth, artifact.URL, RequestKindArtifact) {
 				return true
 			}
 		}
 	case InstallTypeGitHubRelease:
-		return pluginGitHubReleaseAuthConfigured(plugin, auth)
+		return pluginGitHubReleaseAuthConfiguredContext(ctx, resolver, plugin, auth)
 	}
 	return false
 }
 
 func pluginGitHubReleaseAuthConfigured(plugin Plugin, auth []AuthConfig) bool {
+	return pluginGitHubReleaseAuthConfiguredContext(context.Background(), NewAuthResolver(), plugin, auth)
+}
+
+func pluginGitHubReleaseAuthConfiguredContext(ctx context.Context, resolver *AuthResolver, plugin Plugin, auth []AuthConfig) bool {
 	owner, repo, errRepository := GitHubRepositoryParts(plugin.Repository)
 	if errRepository != nil {
 		return false
 	}
-	releasesURL := fmt.Sprintf(
-		"https://api.github.com/repos/%s/%s/releases/",
-		url.PathEscape(owner),
-		url.PathEscape(repo),
-	)
-	return AuthConfigured(auth, releasesURL+"latest", RequestKindMetadata) ||
-		AuthConfigured(auth, releasesURL+"tags/", RequestKindMetadata)
+	releasesURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/", url.PathEscape(owner), url.PathEscape(repo))
+	return AuthConfiguredContext(ctx, resolver, auth, releasesURL+"latest", RequestKindMetadata) ||
+		AuthConfiguredContext(ctx, resolver, auth, releasesURL+"tags/", RequestKindMetadata)
 }
 
 func applyPluginStoreAuth(headers http.Header, auth []AuthConfig, requestURL string, kind string) error {
+	return applyPluginStoreAuthContext(context.Background(), NewAuthResolver(), headers, auth, requestURL, kind)
+}
+
+func applyPluginStoreAuthContext(ctx context.Context, resolver *AuthResolver, headers http.Header, auth []AuthConfig, requestURL string, kind string) error {
 	item, ok := matchingAuthConfig(auth, requestURL, kind)
 	if !ok {
 		return nil
 	}
+	if resolver == nil {
+		resolver = NewAuthResolver()
+	}
 	switch strings.ToLower(strings.TrimSpace(item.Type)) {
 	case "", AuthTypeNone:
 		return nil
-	case AuthTypeBearer:
-		token, errToken := envValueRequired(item.TokenEnv, "token-env")
+	case AuthTypeBearer, AuthTypeGitHubToken:
+		token, errToken := resolver.value(ctx, item.TokenEnv, item.TokenCommand, "token-env", "token-command")
 		if errToken != nil {
 			return errToken
 		}
 		headers.Set("Authorization", "Bearer "+token)
 	case AuthTypeBasic:
-		username, errUsername := envValueRequired(item.UsernameEnv, "username-env")
+		username, errUsername := resolver.value(ctx, item.UsernameEnv, item.UsernameCommand, "username-env", "username-command")
 		if errUsername != nil {
 			return errUsername
 		}
-		password, errPassword := envValueRequired(item.PasswordEnv, "password-env")
+		password, errPassword := resolver.value(ctx, item.PasswordEnv, item.PasswordCommand, "password-env", "password-command")
 		if errPassword != nil {
 			return errPassword
 		}
@@ -152,21 +229,123 @@ func applyPluginStoreAuth(headers http.Header, auth []AuthConfig, requestURL str
 		if strings.TrimSpace(item.HeaderName) == "" {
 			return fmt.Errorf("plugin store auth missing header-name")
 		}
-		value, errValue := envValueRequired(item.HeaderValueEnv, "header-value-env")
+		value, errValue := resolver.value(ctx, item.HeaderValueEnv, item.HeaderValueCommand, "header-value-env", "header-value-command")
 		if errValue != nil {
 			return errValue
 		}
 		headers.Set(item.HeaderName, value)
-	case AuthTypeGitHubToken:
-		token, errToken := envValueRequired(item.TokenEnv, "token-env")
-		if errToken != nil {
-			return errToken
-		}
-		headers.Set("Authorization", "Bearer "+token)
 	default:
 		return fmt.Errorf("unsupported plugin store auth type %q", item.Type)
 	}
 	return nil
+}
+
+func (r *AuthResolver) value(ctx context.Context, envName, command, envField, commandField string) (string, error) {
+	envName = strings.TrimSpace(envName)
+	command = strings.TrimSpace(command)
+	if envName != "" && command != "" {
+		return "", fmt.Errorf("plugin store auth %s source is ambiguous", strings.TrimSuffix(envField, "-env"))
+	}
+	if envName != "" {
+		return r.resolve(ctx, "env", envName, func(context.Context) (string, error) {
+			value := strings.TrimSpace(os.Getenv(envName))
+			if value == "" {
+				return "", fmt.Errorf("plugin store auth env %s is empty", envName)
+			}
+			return value, nil
+		})
+	}
+	if command != "" {
+		return r.resolve(ctx, "command", command, func(ctx context.Context) (string, error) {
+			output, errCommand := executeAuthCommand(ctx, command, r.commandTimeout)
+			if errCommand != nil {
+				switch {
+				case errors.Is(errCommand, errAuthCommandTimedOut):
+					return "", fmt.Errorf("plugin store auth %s timed out", commandField)
+				case errors.Is(errCommand, context.Canceled), errors.Is(errCommand, context.DeadlineExceeded):
+					return "", errCommand
+				default:
+					return "", fmt.Errorf("plugin store auth %s failed", commandField)
+				}
+			}
+			value := strings.TrimSpace(string(output))
+			if value == "" {
+				return "", fmt.Errorf("plugin store auth %s returned empty output", commandField)
+			}
+			return value, nil
+		})
+	}
+	return "", fmt.Errorf("plugin store auth missing %s", envField)
+}
+
+func (r *AuthResolver) resolve(ctx context.Context, kind, source string, resolve func(context.Context) (string, error)) (string, error) {
+	key := kind + "\x00" + source
+	for {
+		r.mu.Lock()
+		entry, ok := r.cache[key]
+		if !ok {
+			entry = &authResolution{done: make(chan struct{})}
+			r.cache[key] = entry
+		}
+		r.mu.Unlock()
+
+		if !ok {
+			entry.value, entry.err = resolve(ctx)
+			if errors.Is(entry.err, context.Canceled) || errors.Is(entry.err, context.DeadlineExceeded) {
+				r.mu.Lock()
+				if r.cache[key] == entry {
+					delete(r.cache, key)
+				}
+				r.mu.Unlock()
+			}
+			close(entry.done)
+			return entry.value, entry.err
+		}
+
+		if r.onWait != nil {
+			r.onWait()
+		}
+		select {
+		case <-entry.done:
+			if ctx.Err() != nil {
+				return "", ctx.Err()
+			}
+			if errors.Is(entry.err, context.Canceled) || errors.Is(entry.err, context.DeadlineExceeded) {
+				continue
+			}
+			return entry.value, entry.err
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+}
+
+func executeAuthCommand(ctx context.Context, expression string, timeout time.Duration) ([]byte, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	authCommandRunnerMu.Lock()
+	runner := authCommandRunner
+	authCommandRunnerMu.Unlock()
+	name, args := authCommandShell(expression)
+	output, errCommand := runner(commandCtx, name, args...)
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if commandCtx.Err() == context.DeadlineExceeded {
+		return nil, errAuthCommandTimedOut
+	}
+	return output, errCommand
+}
+
+func authCommandShell(expression string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd.exe", []string{"/C", expression}
+	}
+	return "/bin/sh", []string{"-c", expression}
+}
+
+func runAuthCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
 }
 
 func validatePluginStoreRequestURL(auth []AuthConfig, requestURL string, kind string) error {
@@ -244,16 +423,4 @@ func authAppliesTo(item AuthConfig, kind string) bool {
 		}
 	}
 	return false
-}
-
-func envValueRequired(envName string, field string) (string, error) {
-	envName = strings.TrimSpace(envName)
-	if envName == "" {
-		return "", fmt.Errorf("plugin store auth missing %s", field)
-	}
-	value := strings.TrimSpace(os.Getenv(envName))
-	if value == "" {
-		return "", fmt.Errorf("plugin store auth env %s is empty", envName)
-	}
-	return value, nil
 }

--- a/internal/pluginstore/auth_command_unix.go
+++ b/internal/pluginstore/auth_command_unix.go
@@ -1,0 +1,21 @@
+//go:build linux || darwin || freebsd
+
+package pluginstore
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureAuthCommandCancellation(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return nil
+		}
+		if errKill := syscall.Kill(-command.Process.Pid, syscall.SIGKILL); errKill == nil {
+			return nil
+		}
+		return command.Process.Kill()
+	}
+}

--- a/internal/pluginstore/auth_command_windows.go
+++ b/internal/pluginstore/auth_command_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package pluginstore
+
+import "os/exec"
+
+func configureAuthCommandCancellation(command *exec.Cmd) {}

--- a/internal/pluginstore/auth_test.go
+++ b/internal/pluginstore/auth_test.go
@@ -4,10 +4,17 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestPluginStoreAuthMatchesURLHostAndPathBoundaries(t *testing.T) {
@@ -186,6 +193,34 @@ func TestPluginStoreAuthHeaderIsReevaluatedAcrossRedirect(t *testing.T) {
 	}
 }
 
+func TestAuthResolverCommandSourceTrimsAndCaches(t *testing.T) {
+	resolver := NewAuthResolver()
+	calls := 0
+	restore := setAuthCommandRunnerForTest(func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		calls++
+		return []byte("  command-secret \n"), nil
+	})
+	t.Cleanup(restore)
+
+	auth := []AuthConfig{{
+		Match:        "https://plugins.example/private/",
+		Type:         AuthTypeBearer,
+		TokenCommand: "  resolve-token  ",
+	}}
+	for range 2 {
+		headers := http.Header{}
+		if errAuth := applyPluginStoreAuthContext(context.Background(), resolver, headers, auth, "https://plugins.example/private/a.zip", RequestKindArtifact); errAuth != nil {
+			t.Fatalf("applyPluginStoreAuthContext() error = %v", errAuth)
+		}
+		if got := headers.Get("Authorization"); got != "Bearer command-secret" {
+			t.Fatalf("Authorization = %q, want trimmed command result", got)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("command calls = %d, want 1", calls)
+	}
+}
+
 func TestPluginStoreAuthHeaderIsAppliedToMatchingRedirect(t *testing.T) {
 	t.Setenv("PLUGIN_STORE_HEADER", "secret-token")
 
@@ -223,5 +258,411 @@ func TestPluginStoreAuthHeaderIsAppliedToMatchingRedirect(t *testing.T) {
 	}
 	if redirectedHeader != "secret-token" {
 		t.Fatalf("redirected auth header = %q, want secret-token", redirectedHeader)
+	}
+}
+
+func TestNormalizeAuthConfigsTrimsCommandSources(t *testing.T) {
+	normalized := NormalizeAuthConfigs([]AuthConfig{{
+		Match:              " https://plugins.example/ ",
+		TokenCommand:       " token ",
+		UsernameCommand:    " username ",
+		PasswordCommand:    " password ",
+		HeaderValueCommand: " header ",
+	}})
+	if len(normalized) != 1 {
+		t.Fatalf("NormalizeAuthConfigs() length = %d, want 1", len(normalized))
+	}
+	item := normalized[0]
+	if item.TokenCommand != "token" || item.UsernameCommand != "username" || item.PasswordCommand != "password" || item.HeaderValueCommand != "header" {
+		t.Fatalf("NormalizeAuthConfigs() command fields = %#v, want trimmed values", item)
+	}
+}
+
+func TestAuthResolverCommandSourcesApplyAllSecretTypes(t *testing.T) {
+	restore := setAuthCommandRunnerForTest(func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		switch args[len(args)-1] {
+		case "token":
+			return []byte(" token-value\n"), nil
+		case "username":
+			return []byte(" user "), nil
+		case "password":
+			return []byte(" password "), nil
+		case "header":
+			return []byte(" header-value "), nil
+		default:
+			t.Fatalf("unexpected command %q", args[len(args)-1])
+			return nil, nil
+		}
+	})
+	t.Cleanup(restore)
+
+	tests := []struct {
+		name string
+		auth AuthConfig
+		want string
+	}{
+		{name: "bearer", auth: AuthConfig{Type: AuthTypeBearer, TokenCommand: "token"}, want: "Bearer token-value"},
+		{name: "github token", auth: AuthConfig{Type: AuthTypeGitHubToken, TokenCommand: "token"}, want: "Bearer token-value"},
+		{name: "basic", auth: AuthConfig{Type: AuthTypeBasic, UsernameCommand: "username", PasswordCommand: "password"}, want: "Basic dXNlcjpwYXNzd29yZA=="},
+		{name: "header", auth: AuthConfig{Type: AuthTypeHeader, HeaderName: "X-Token", HeaderValueCommand: "header"}, want: "header-value"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.auth.Match = "https://plugins.example/"
+			headers := http.Header{}
+			if errAuth := applyPluginStoreAuthContext(context.Background(), NewAuthResolver(), headers, []AuthConfig{tt.auth}, "https://plugins.example/a", RequestKindArtifact); errAuth != nil {
+				t.Fatalf("applyPluginStoreAuthContext() error = %v", errAuth)
+			}
+			got := headers.Get("Authorization")
+			if tt.auth.Type == AuthTypeHeader {
+				got = headers.Get("X-Token")
+			}
+			if got != tt.want {
+				t.Fatalf("auth header = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAuthResolverRejectsAmbiguousAndMissingSourcesWithoutSecrets(t *testing.T) {
+	secret := "do-not-leak"
+	tests := []struct {
+		name string
+		auth AuthConfig
+		want string
+	}{
+		{name: "ambiguous", auth: AuthConfig{Type: AuthTypeBearer, TokenEnv: "TOKEN", TokenCommand: secret}, want: "source is ambiguous"},
+		{name: "missing", auth: AuthConfig{Type: AuthTypeBearer}, want: "missing token-env"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.auth.Match = "https://plugins.example/"
+			errAuth := applyPluginStoreAuthContext(context.Background(), NewAuthResolver(), http.Header{}, []AuthConfig{tt.auth}, "https://plugins.example/a", RequestKindArtifact)
+			if errAuth == nil || !strings.Contains(errAuth.Error(), tt.want) {
+				t.Fatalf("applyPluginStoreAuthContext() error = %v, want %q", errAuth, tt.want)
+			}
+			if strings.Contains(errAuth.Error(), secret) {
+				t.Fatalf("applyPluginStoreAuthContext() leaked secret in %q", errAuth)
+			}
+		})
+	}
+}
+
+func TestAuthResolverCachesFailuresAndCoalescesConcurrentCommands(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	restore := setAuthCommandRunnerForTest(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-unblock
+		return []byte(""), nil
+	})
+	t.Cleanup(restore)
+
+	resolver := NewAuthResolver()
+	auth := []AuthConfig{{Match: "https://plugins.example/", Type: AuthTypeBearer, TokenCommand: "resolve"}}
+	var group sync.WaitGroup
+	for range 8 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			errAuth := applyPluginStoreAuthContext(context.Background(), resolver, http.Header{}, auth, "https://plugins.example/a", RequestKindArtifact)
+			if errAuth == nil || !strings.Contains(errAuth.Error(), "returned empty output") {
+				t.Errorf("applyPluginStoreAuthContext() error = %v", errAuth)
+			}
+		}()
+	}
+	<-started
+	close(unblock)
+	group.Wait()
+	if calls.Load() != 1 {
+		t.Fatalf("command calls = %d, want 1", calls.Load())
+	}
+	if errAuth := applyPluginStoreAuthContext(context.Background(), resolver, http.Header{}, auth, "https://plugins.example/a", RequestKindArtifact); errAuth == nil {
+		t.Fatal("applyPluginStoreAuthContext() error = nil, want cached failure")
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("cached failure command calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestAuthResolverDoesNotShareCacheAcrossResolvers(t *testing.T) {
+	var calls atomic.Int32
+	restore := setAuthCommandRunnerForTest(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		calls.Add(1)
+		return []byte("value"), nil
+	})
+	t.Cleanup(restore)
+	auth := []AuthConfig{{Match: "https://plugins.example/", Type: AuthTypeBearer, TokenCommand: "resolve"}}
+	for range 2 {
+		if errAuth := applyPluginStoreAuthContext(context.Background(), NewAuthResolver(), http.Header{}, auth, "https://plugins.example/a", RequestKindArtifact); errAuth != nil {
+			t.Fatalf("applyPluginStoreAuthContext() error = %v", errAuth)
+		}
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("command calls = %d, want 2", calls.Load())
+	}
+}
+
+func TestAuthConfiguredContextAgreesWithApplication(t *testing.T) {
+	restore := setAuthCommandRunnerForTest(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte("value"), nil
+	})
+	t.Cleanup(restore)
+	resolver := NewAuthResolver()
+	auth := []AuthConfig{{Match: "https://plugins.example/", Type: AuthTypeBearer, TokenCommand: "resolve"}}
+	if !AuthConfiguredContext(context.Background(), resolver, auth, "https://plugins.example/a", RequestKindArtifact) {
+		t.Fatal("AuthConfiguredContext() = false, want true")
+	}
+	headers := http.Header{}
+	if errAuth := applyPluginStoreAuthContext(context.Background(), resolver, headers, auth, "https://plugins.example/a", RequestKindArtifact); errAuth != nil {
+		t.Fatalf("applyPluginStoreAuthContext() error = %v", errAuth)
+	}
+	if headers.Get("Authorization") != "Bearer value" {
+		t.Fatalf("Authorization = %q, want bearer value", headers.Get("Authorization"))
+	}
+}
+
+func TestAuthCommandUsesCallerBoundedTimeout(t *testing.T) {
+	restore := setAuthCommandRunnerForTest(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("command context has no deadline")
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > time.Second {
+			t.Fatalf("command deadline remaining = %v, want within caller timeout", remaining)
+		}
+		return []byte("value"), nil
+	})
+	t.Cleanup(restore)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+	auth := []AuthConfig{{Match: "https://plugins.example/", Type: AuthTypeBearer, TokenCommand: "resolve"}}
+	if errAuth := applyPluginStoreAuthContext(ctx, NewAuthResolver(), http.Header{}, auth, "https://plugins.example/a", RequestKindArtifact); errAuth != nil {
+		t.Fatalf("applyPluginStoreAuthContext() error = %v", errAuth)
+	}
+}
+
+func TestAuthCommandFailuresDoNotLeakCommandOutputOrErrors(t *testing.T) {
+	secret := "do-not-leak"
+	restore := setAuthCommandRunnerForTest(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return nil, fmt.Errorf("failed with %s", secret)
+	})
+	t.Cleanup(restore)
+	auth := []AuthConfig{{Match: "https://plugins.example/", Type: AuthTypeBearer, TokenCommand: "printf " + secret}}
+	errAuth := applyPluginStoreAuthContext(context.Background(), NewAuthResolver(), http.Header{}, auth, "https://plugins.example/a", RequestKindArtifact)
+	if errAuth == nil || !strings.Contains(errAuth.Error(), "token-command failed") {
+		t.Fatalf("applyPluginStoreAuthContext() error = %v, want generic command failure", errAuth)
+	}
+	if strings.Contains(errAuth.Error(), secret) {
+		t.Fatalf("applyPluginStoreAuthContext() leaked secret in %q", errAuth)
+	}
+}
+
+func TestClientRedirectReusesCommandResolution(t *testing.T) {
+	var calls atomic.Int32
+	restore := setAuthCommandRunnerForTest(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		calls.Add(1)
+		return []byte("command-token"), nil
+	})
+	t.Cleanup(restore)
+
+	var headers []string
+	artifactData := []byte("artifact-data")
+	sum := sha256.Sum256(artifactData)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers = append(headers, r.Header.Get("X-Plugin-Token"))
+		if r.URL.Path == "/private/start.zip" {
+			http.Redirect(w, r, "/private/artifact.zip", http.StatusFound)
+			return
+		}
+		_, _ = w.Write(artifactData)
+	}))
+	t.Cleanup(server.Close)
+
+	client := Client{HTTPClient: server.Client(), Auth: []AuthConfig{{
+		Match:              server.URL + "/private/",
+		ApplyTo:            []string{RequestKindArtifact},
+		Type:               AuthTypeHeader,
+		HeaderName:         "X-Plugin-Token",
+		HeaderValueCommand: "resolve",
+		AllowInsecure:      true,
+	}}}
+	if _, errDownload := client.DownloadArtifact(context.Background(), Artifact{
+		GOOS: "linux", GOARCH: "amd64", URL: server.URL + "/private/start.zip", SHA256: hex.EncodeToString(sum[:]),
+	}); errDownload != nil {
+		t.Fatalf("DownloadArtifact() error = %v", errDownload)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("command calls = %d, want 1", calls.Load())
+	}
+	if len(headers) != 2 || headers[0] != "command-token" || headers[1] != "command-token" {
+		t.Fatalf("redirect headers = %q, want command token on both requests", headers)
+	}
+}
+
+func TestAuthCommandShellMatchesPlatform(t *testing.T) {
+	name, args := authCommandShell("secret command")
+	if runtime.GOOS == "windows" {
+		if name != "cmd.exe" || len(args) != 2 || args[0] != "/C" {
+			t.Fatalf("authCommandShell() = %q, %q; want cmd.exe /C", name, args)
+		}
+		return
+	}
+	if name != "/bin/sh" || len(args) != 2 || args[0] != "-c" {
+		t.Fatalf("authCommandShell() = %q, %q; want /bin/sh -c", name, args)
+	}
+}
+
+func TestAuthCommandInternalTimeoutIsStableAndCached(t *testing.T) {
+	var calls atomic.Int32
+	restore := setAuthCommandRunnerForTest(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		calls.Add(1)
+		<-ctx.Done()
+		return nil, errors.New("signal: killed")
+	})
+	t.Cleanup(restore)
+
+	resolver := newAuthResolver(time.Millisecond)
+	auth := []AuthConfig{{Match: "https://plugins.example/", Type: AuthTypeBearer, TokenCommand: "resolve"}}
+	for range 2 {
+		errAuth := applyPluginStoreAuthContext(context.Background(), resolver, http.Header{}, auth, "https://plugins.example/a", RequestKindArtifact)
+		if errAuth == nil || errAuth.Error() != "plugin store auth token-command timed out" {
+			t.Fatalf("applyPluginStoreAuthContext() error = %v, want stable timeout", errAuth)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("command calls = %d, want cached timeout", calls.Load())
+	}
+}
+
+func TestAuthCommandCallerCancellationDoesNotPoisonCache(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	restore := setAuthCommandRunnerForTest(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+			<-ctx.Done()
+		}
+		return []byte("resolved"), nil
+	})
+	t.Cleanup(restore)
+
+	resolver := NewAuthResolver()
+	auth := []AuthConfig{{Match: "https://plugins.example/", Type: AuthTypeBearer, TokenCommand: "resolve"}}
+	ctx, cancel := context.WithCancel(context.Background())
+	leader := make(chan error, 1)
+	go func() {
+		leader <- applyPluginStoreAuthContext(ctx, resolver, http.Header{}, auth, "https://plugins.example/a", RequestKindArtifact)
+	}()
+	<-started
+	cancel()
+	if errAuth := <-leader; !errors.Is(errAuth, context.Canceled) {
+		t.Fatalf("leader error = %v, want context.Canceled", errAuth)
+	}
+
+	headers := http.Header{}
+	if errAuth := applyPluginStoreAuthContext(context.Background(), resolver, headers, auth, "https://plugins.example/a", RequestKindArtifact); errAuth != nil {
+		t.Fatalf("retry error = %v", errAuth)
+	}
+	if got := headers.Get("Authorization"); got != "Bearer resolved" {
+		t.Fatalf("Authorization = %q, want resolved retry", got)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("command calls = %d, want retry after caller cancellation", calls.Load())
+	}
+}
+
+func TestAuthCommandLiveFollowerRetriesAfterLeaderCancellation(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	restore := setAuthCommandRunnerForTest(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return []byte("resolved"), nil
+	})
+	t.Cleanup(restore)
+
+	resolver := NewAuthResolver()
+	auth := []AuthConfig{{Match: "https://plugins.example/", Type: AuthTypeBearer, TokenCommand: "resolve"}}
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	t.Cleanup(cancelLeader)
+	leader := make(chan error, 1)
+	go func() {
+		leader <- applyPluginStoreAuthContext(leaderCtx, resolver, http.Header{}, auth, "https://plugins.example/a", RequestKindArtifact)
+	}()
+	<-started
+
+	followerWaiting := make(chan struct{})
+	resolver.onWait = func() {
+		close(followerWaiting)
+	}
+	follower := make(chan error, 1)
+	headers := http.Header{}
+	go func() {
+		follower <- applyPluginStoreAuthContext(context.Background(), resolver, headers, auth, "https://plugins.example/a", RequestKindArtifact)
+	}()
+	<-followerWaiting
+	cancelLeader()
+
+	if errAuth := <-leader; !errors.Is(errAuth, context.Canceled) {
+		t.Fatalf("leader error = %v, want context.Canceled", errAuth)
+	}
+	if errAuth := <-follower; errAuth != nil {
+		t.Fatalf("live follower error = %v", errAuth)
+	}
+	if got := headers.Get("Authorization"); got != "Bearer resolved" {
+		t.Fatalf("Authorization = %q, want resolved retry", got)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("command calls = %d, want one live follower retry", calls.Load())
+	}
+}
+
+func TestAuthCommandCallerDeadlineDoesNotPoisonCache(t *testing.T) {
+	var calls atomic.Int32
+	restore := setAuthCommandRunnerForTest(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		if calls.Add(1) == 1 {
+			<-ctx.Done()
+		}
+		return []byte("resolved"), nil
+	})
+	t.Cleanup(restore)
+
+	resolver := NewAuthResolver()
+	auth := []AuthConfig{{Match: "https://plugins.example/", Type: AuthTypeBearer, TokenCommand: "resolve"}}
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now())
+	t.Cleanup(cancel)
+	if errAuth := applyPluginStoreAuthContext(ctx, resolver, http.Header{}, auth, "https://plugins.example/a", RequestKindArtifact); !errors.Is(errAuth, context.DeadlineExceeded) {
+		t.Fatalf("leader error = %v, want context.DeadlineExceeded", errAuth)
+	}
+	if errAuth := applyPluginStoreAuthContext(context.Background(), resolver, http.Header{}, auth, "https://plugins.example/a", RequestKindArtifact); errAuth != nil {
+		t.Fatalf("retry error = %v", errAuth)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("command calls = %d, want retry after caller deadline", calls.Load())
+	}
+}
+
+func TestAuthCommandFailureIsStableAndDoesNotLeakSecrets(t *testing.T) {
+	secret := "secret-expression-stdout-stderr"
+	restore := setAuthCommandRunnerForTest(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte(secret), fmt.Errorf("start failed: %s", secret)
+	})
+	t.Cleanup(restore)
+
+	auth := []AuthConfig{{Match: "https://plugins.example/", Type: AuthTypeBearer, TokenCommand: secret}}
+	errAuth := applyPluginStoreAuthContext(context.Background(), NewAuthResolver(), http.Header{}, auth, "https://plugins.example/a", RequestKindArtifact)
+	if errAuth == nil || errAuth.Error() != "plugin store auth token-command failed" {
+		t.Fatalf("applyPluginStoreAuthContext() error = %v, want stable command failure", errAuth)
+	}
+	if strings.Contains(errAuth.Error(), secret) {
+		t.Fatalf("applyPluginStoreAuthContext() leaked secret in %q", errAuth)
 	}
 }

--- a/internal/pluginstore/auth_unix_test.go
+++ b/internal/pluginstore/auth_unix_test.go
@@ -1,0 +1,105 @@
+//go:build linux || darwin || freebsd
+
+package pluginstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestAuthCommandTimeoutKillsShellChildren(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	resolver := newAuthResolver(100 * time.Millisecond)
+	auth := []AuthConfig{{
+		Match:        "https://plugins.example/",
+		Type:         AuthTypeBearer,
+		TokenCommand: authCommandWithChildPID(pidFile),
+	}}
+
+	started := time.Now()
+	errAuth := applyPluginStoreAuthContext(context.Background(), resolver, nil, auth, "https://plugins.example/a", RequestKindArtifact)
+	elapsed := time.Since(started)
+	if errAuth == nil || errAuth.Error() != "plugin store auth token-command timed out" {
+		t.Fatalf("applyPluginStoreAuthContext() error = %v, want token-command timeout", errAuth)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("auth command elapsed = %v, want near timeout plus wait delay", elapsed)
+	}
+	assertAuthCommandChildGone(t, authCommandChildPID(t, pidFile))
+}
+
+func TestAuthCommandCallerCancellationKillsShellChildren(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	resolver := NewAuthResolver()
+	auth := []AuthConfig{{
+		Match:        "https://plugins.example/",
+		Type:         AuthTypeBearer,
+		TokenCommand: authCommandWithChildPID(pidFile),
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	errResult := make(chan error, 1)
+	started := time.Now()
+	go func() {
+		errResult <- applyPluginStoreAuthContext(ctx, resolver, nil, auth, "https://plugins.example/a", RequestKindArtifact)
+	}()
+	childPID := authCommandChildPID(t, pidFile)
+	cancel()
+
+	if errAuth := <-errResult; !errors.Is(errAuth, context.Canceled) {
+		t.Fatalf("applyPluginStoreAuthContext() error = %v, want context.Canceled", errAuth)
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("auth command elapsed = %v, want near cancellation plus wait delay", elapsed)
+	}
+	assertAuthCommandChildGone(t, childPID)
+}
+
+func authCommandWithChildPID(pidFile string) string {
+	return fmt.Sprintf("sleep 2 & child=$!; printf '%%s' \"$child\" > %q; wait", pidFile)
+}
+
+func authCommandChildPID(t *testing.T, pidFile string) int {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		data, errRead := os.ReadFile(pidFile)
+		if errRead == nil {
+			pid, errParse := strconv.Atoi(string(data))
+			if errParse != nil || pid <= 0 {
+				t.Fatalf("child pid = %q, want positive integer", data)
+			}
+			t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+			return pid
+		}
+		if !errors.Is(errRead, os.ErrNotExist) {
+			t.Fatalf("read child pid: %v", errRead)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("child pid was not written")
+	return 0
+}
+
+func assertAuthCommandChildGone(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		errKill := syscall.Kill(pid, 0)
+		if errors.Is(errKill, syscall.ESRCH) {
+			return
+		}
+		if errKill != nil {
+			t.Fatalf("check child process: %v", errKill)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("child process %d is still running", pid)
+}

--- a/internal/pluginstore/direct.go
+++ b/internal/pluginstore/direct.go
@@ -24,6 +24,10 @@ func SelectArtifact(plan InstallPlan, goos string, goarch string) (Artifact, err
 }
 
 func (c Client) DownloadArtifact(ctx context.Context, artifact Artifact) ([]byte, error) {
+	return c.DownloadArtifactWithResolver(ctx, NewAuthResolver(), artifact)
+}
+
+func (c Client) DownloadArtifactWithResolver(ctx context.Context, resolver *AuthResolver, artifact Artifact) ([]byte, error) {
 	artifact = NormalizeInstallPlan(InstallPlan{Type: InstallTypeDirect, Artifacts: []Artifact{artifact}}).Artifacts[0]
 	if errValidate := ValidateArtifact(artifact); errValidate != nil {
 		return nil, errValidate
@@ -32,7 +36,7 @@ func (c Client) DownloadArtifact(ctx context.Context, artifact Artifact) ([]byte
 	if artifact.Size > 0 {
 		maxSize = artifact.Size
 	}
-	data, errDownload := c.get(ctx, artifact.URL, "application/octet-stream", RequestKindArtifact, maxSize)
+	data, errDownload := c.get(ctx, resolver, artifact.URL, "application/octet-stream", RequestKindArtifact, maxSize)
 	if errDownload != nil {
 		return nil, errDownload
 	}

--- a/internal/pluginstore/github.go
+++ b/internal/pluginstore/github.go
@@ -38,11 +38,15 @@ type ReleaseAsset struct {
 }
 
 func (c Client) FetchRegistry(ctx context.Context) (Registry, error) {
+	return c.FetchRegistryWithResolver(ctx, NewAuthResolver())
+}
+
+func (c Client) FetchRegistryWithResolver(ctx context.Context, resolver *AuthResolver) (Registry, error) {
 	registryURL := strings.TrimSpace(c.RegistryURL)
 	if registryURL == "" {
 		registryURL = DefaultRegistryURL
 	}
-	data, errDownload := c.get(ctx, registryURL, "application/json", RequestKindRegistry, 0)
+	data, errDownload := c.get(ctx, resolver, registryURL, "application/json", RequestKindRegistry, 0)
 	if errDownload != nil {
 		return Registry{}, errDownload
 	}
@@ -56,6 +60,10 @@ func (c Client) FetchRegistry(ctx context.Context) (Registry, error) {
 // FetchLatestRelease returns the latest published release of the plugin's
 // GitHub repository, mirroring the WebUI panel update check.
 func (c Client) FetchLatestRelease(ctx context.Context, plugin Plugin) (Release, error) {
+	return c.FetchLatestReleaseWithResolver(ctx, NewAuthResolver(), plugin)
+}
+
+func (c Client) FetchLatestReleaseWithResolver(ctx context.Context, resolver *AuthResolver, plugin Plugin) (Release, error) {
 	owner, repo, errRepository := GitHubRepositoryParts(plugin.Repository)
 	if errRepository != nil {
 		return Release{}, errRepository
@@ -65,7 +73,7 @@ func (c Client) FetchLatestRelease(ctx context.Context, plugin Plugin) (Release,
 		url.PathEscape(owner),
 		url.PathEscape(repo),
 	)
-	data, errDownload := c.get(ctx, releaseURL, "application/vnd.github+json", RequestKindMetadata, 0)
+	data, errDownload := c.get(ctx, resolver, releaseURL, "application/vnd.github+json", RequestKindMetadata, 0)
 	if errDownload != nil {
 		return Release{}, errDownload
 	}
@@ -78,6 +86,10 @@ func (c Client) FetchLatestRelease(ctx context.Context, plugin Plugin) (Release,
 
 // FetchReleaseByTag returns a published release by its exact GitHub tag.
 func (c Client) FetchReleaseByTag(ctx context.Context, plugin Plugin, tag string) (Release, error) {
+	return c.FetchReleaseByTagWithResolver(ctx, NewAuthResolver(), plugin, tag)
+}
+
+func (c Client) FetchReleaseByTagWithResolver(ctx context.Context, resolver *AuthResolver, plugin Plugin, tag string) (Release, error) {
 	owner, repo, errRepository := GitHubRepositoryParts(plugin.Repository)
 	if errRepository != nil {
 		return Release{}, errRepository
@@ -92,7 +104,7 @@ func (c Client) FetchReleaseByTag(ctx context.Context, plugin Plugin, tag string
 		url.PathEscape(repo),
 		url.PathEscape(tag),
 	)
-	data, errDownload := c.get(ctx, releaseURL, "application/vnd.github+json", RequestKindMetadata, 0)
+	data, errDownload := c.get(ctx, resolver, releaseURL, "application/vnd.github+json", RequestKindMetadata, 0)
 	if errDownload != nil {
 		return Release{}, errDownload
 	}
@@ -114,9 +126,13 @@ func ReleaseVersion(release Release) (string, error) {
 }
 
 func (c Client) DownloadAsset(ctx context.Context, asset ReleaseAsset) ([]byte, error) {
+	return c.DownloadAssetWithResolver(ctx, NewAuthResolver(), asset)
+}
+
+func (c Client) DownloadAssetWithResolver(ctx context.Context, resolver *AuthResolver, asset ReleaseAsset) ([]byte, error) {
 	downloadURL := strings.TrimSpace(asset.BrowserDownloadURL)
 	apiURL := strings.TrimSpace(asset.APIURL)
-	if downloadURL == "" || c.releaseAssetAPIAuthenticated(apiURL) {
+	if downloadURL == "" || c.releaseAssetAPIAuthenticatedContext(ctx, resolver, apiURL) {
 		if apiURL != "" {
 			downloadURL = apiURL
 		}
@@ -124,18 +140,22 @@ func (c Client) DownloadAsset(ctx context.Context, asset ReleaseAsset) ([]byte, 
 	if downloadURL == "" {
 		return nil, fmt.Errorf("asset %q missing download url", asset.Name)
 	}
-	return c.get(ctx, downloadURL, "application/octet-stream", RequestKindArtifact, 0)
+	return c.get(ctx, resolver, downloadURL, "application/octet-stream", RequestKindArtifact, 0)
 }
 
 func (c Client) releaseAssetAPIAuthenticated(apiURL string) bool {
+	return c.releaseAssetAPIAuthenticatedContext(context.Background(), NewAuthResolver(), apiURL)
+}
+
+func (c Client) releaseAssetAPIAuthenticatedContext(ctx context.Context, resolver *AuthResolver, apiURL string) bool {
 	apiURL = strings.TrimSpace(apiURL)
 	if apiURL == "" {
 		return false
 	}
-	return AuthConfigured(c.Auth, apiURL, RequestKindArtifact)
+	return AuthConfiguredContext(ctx, resolver, c.Auth, apiURL, RequestKindArtifact)
 }
 
-func (c Client) get(ctx context.Context, requestURL string, accept string, kind string, maxSize int64) ([]byte, error) {
+func (c Client) get(ctx context.Context, resolver *AuthResolver, requestURL string, accept string, kind string, maxSize int64) ([]byte, error) {
 	currentURL := strings.TrimSpace(requestURL)
 	for redirects := 0; ; redirects++ {
 		if errURL := validatePluginStoreRequestURL(c.Auth, currentURL, kind); errURL != nil {
@@ -145,7 +165,7 @@ func (c Client) get(ctx context.Context, requestURL string, accept string, kind 
 			"Accept":     []string{accept},
 			"User-Agent": []string{c.userAgent()},
 		}
-		if errAuth := applyPluginStoreAuth(headers, c.Auth, currentURL, kind); errAuth != nil {
+		if errAuth := applyPluginStoreAuthContext(ctx, resolver, headers, c.Auth, currentURL, kind); errAuth != nil {
 			return nil, errAuth
 		}
 		resp, errDo := pluginStoreGetNoRedirect(ctx, c.httpClient(), currentURL, headers)

--- a/internal/pluginstore/install.go
+++ b/internal/pluginstore/install.go
@@ -45,15 +45,19 @@ type InstallResult struct {
 }
 
 func (c Client) Install(ctx context.Context, plugin Plugin, options InstallOptions) (InstallResult, error) {
+	return c.InstallWithResolver(ctx, NewAuthResolver(), plugin, options)
+}
+
+func (c Client) InstallWithResolver(ctx context.Context, resolver *AuthResolver, plugin Plugin, options InstallOptions) (InstallResult, error) {
 	if errValidate := ValidatePlugin(plugin); errValidate != nil {
 		return InstallResult{}, errValidate
 	}
 	options = normalizeInstallOptions(options)
 	if PluginInstallType(plugin) == InstallTypeDirect {
 		plugin.Version = normalizeVersion(plugin.Version)
-		return c.InstallDirect(ctx, plugin, plugin.Install, options)
+		return c.installDirectWithResolver(ctx, resolver, plugin, plugin.Install, options)
 	}
-	release, errRelease := c.FetchLatestRelease(ctx, plugin)
+	release, errRelease := c.FetchLatestReleaseWithResolver(ctx, resolver, plugin)
 	if errRelease != nil {
 		return InstallResult{}, errRelease
 	}
@@ -62,23 +66,27 @@ func (c Client) Install(ctx context.Context, plugin Plugin, options InstallOptio
 		return InstallResult{}, errVersion
 	}
 	plugin.Version = latestVersion
-	return c.installRelease(ctx, plugin, release, latestVersion, options)
+	return c.installRelease(ctx, resolver, plugin, release, latestVersion, options)
 }
 
 func (c Client) InstallManifest(ctx context.Context, manifest Manifest, options InstallOptions) (InstallResult, error) {
+	return c.InstallManifestWithResolver(ctx, NewAuthResolver(), manifest, options)
+}
+
+func (c Client) InstallManifestWithResolver(ctx context.Context, resolver *AuthResolver, manifest Manifest, options InstallOptions) (InstallResult, error) {
 	if errValidate := manifest.Validate(); errValidate != nil {
 		return InstallResult{}, errValidate
 	}
 	options = normalizeInstallOptions(options)
 	switch manifest.InstallType() {
 	case InstallTypeDirect:
-		plugin, errPlugin := c.directPluginFromManifest(ctx, manifest)
+		plugin, errPlugin := c.directPluginFromManifest(ctx, resolver, manifest)
 		if errPlugin != nil {
 			return InstallResult{}, errPlugin
 		}
-		return c.InstallDirect(ctx, plugin, plugin.Install, options)
+		return c.installDirectWithResolver(ctx, resolver, plugin, plugin.Install, options)
 	case InstallTypeGitHubRelease:
-		return c.InstallVersion(ctx, manifest.Plugin(), manifest.ReleaseTag, manifest.Version, options)
+		return c.InstallVersionWithResolver(ctx, resolver, manifest.Plugin(), manifest.ReleaseTag, manifest.Version, options)
 	default:
 		return InstallResult{}, fmt.Errorf("unsupported install type %q", manifest.Install.Type)
 	}
@@ -86,6 +94,10 @@ func (c Client) InstallManifest(ctx context.Context, manifest Manifest, options 
 
 // InstallVersion installs a plugin artifact from a fixed release tag/version.
 func (c Client) InstallVersion(ctx context.Context, plugin Plugin, releaseTag string, version string, options InstallOptions) (InstallResult, error) {
+	return c.InstallVersionWithResolver(ctx, NewAuthResolver(), plugin, releaseTag, version, options)
+}
+
+func (c Client) InstallVersionWithResolver(ctx context.Context, resolver *AuthResolver, plugin Plugin, releaseTag string, version string, options InstallOptions) (InstallResult, error) {
 	if errValidate := ValidatePlugin(plugin); errValidate != nil {
 		return InstallResult{}, errValidate
 	}
@@ -98,7 +110,7 @@ func (c Client) InstallVersion(ctx context.Context, plugin Plugin, releaseTag st
 	if releaseTag == "" {
 		releaseTag = version
 	}
-	release, errRelease := c.FetchReleaseByTag(ctx, plugin, releaseTag)
+	release, errRelease := c.FetchReleaseByTagWithResolver(ctx, resolver, plugin, releaseTag)
 	if errRelease != nil {
 		return InstallResult{}, errRelease
 	}
@@ -110,19 +122,19 @@ func (c Client) InstallVersion(ctx context.Context, plugin Plugin, releaseTag st
 		return InstallResult{}, fmt.Errorf("release tag %q resolved version %q, want %q", releaseTag, releaseVersion, version)
 	}
 	plugin.Version = version
-	return c.installRelease(ctx, plugin, release, version, options)
+	return c.installRelease(ctx, resolver, plugin, release, version, options)
 }
 
-func (c Client) installRelease(ctx context.Context, plugin Plugin, release Release, version string, options InstallOptions) (InstallResult, error) {
+func (c Client) installRelease(ctx context.Context, resolver *AuthResolver, plugin Plugin, release Release, version string, options InstallOptions) (InstallResult, error) {
 	archiveAsset, checksumAsset, errAssets := SelectReleaseAssets(release, plugin.ID, plugin.Version, options.GOOS, options.GOARCH)
 	if errAssets != nil {
 		return InstallResult{}, errAssets
 	}
-	archiveData, errArchive := c.DownloadAsset(ctx, archiveAsset)
+	archiveData, errArchive := c.DownloadAssetWithResolver(ctx, resolver, archiveAsset)
 	if errArchive != nil {
 		return InstallResult{}, fmt.Errorf("download %s: %w", archiveAsset.Name, errArchive)
 	}
-	checksumData, errChecksum := c.DownloadAsset(ctx, checksumAsset)
+	checksumData, errChecksum := c.DownloadAssetWithResolver(ctx, resolver, checksumAsset)
 	if errChecksum != nil {
 		return InstallResult{}, fmt.Errorf("download checksums.txt: %w", errChecksum)
 	}
@@ -144,6 +156,10 @@ func (c Client) installRelease(ctx context.Context, plugin Plugin, release Relea
 }
 
 func (c Client) InstallDirect(ctx context.Context, plugin Plugin, plan InstallPlan, options InstallOptions) (InstallResult, error) {
+	return c.installDirectWithResolver(ctx, NewAuthResolver(), plugin, plan, options)
+}
+
+func (c Client) installDirectWithResolver(ctx context.Context, resolver *AuthResolver, plugin Plugin, plan InstallPlan, options InstallOptions) (InstallResult, error) {
 	plugin.ID = strings.TrimSpace(plugin.ID)
 	plugin.Version = normalizeVersion(plugin.Version)
 	if !validPluginID(plugin.ID) {
@@ -162,7 +178,7 @@ func (c Client) InstallDirect(ctx context.Context, plugin Plugin, plan InstallPl
 	if errSelect != nil {
 		return InstallResult{}, errSelect
 	}
-	archiveData, errDownload := c.DownloadArtifact(ctx, artifact)
+	archiveData, errDownload := c.DownloadArtifactWithResolver(ctx, resolver, artifact)
 	if errDownload != nil {
 		return InstallResult{}, fmt.Errorf("download artifact: %w", errDownload)
 	}
@@ -177,7 +193,7 @@ func (c Client) InstallDirect(ctx context.Context, plugin Plugin, plan InstallPl
 	return result, nil
 }
 
-func (c Client) directPluginFromManifest(ctx context.Context, manifest Manifest) (Plugin, error) {
+func (c Client) directPluginFromManifest(ctx context.Context, resolver *AuthResolver, manifest Manifest) (Plugin, error) {
 	plugin := manifest.Plugin()
 	plugin.Version = normalizeVersion(manifest.Version)
 	plugin.Install = NormalizeInstallPlan(plugin.Install)
@@ -194,7 +210,7 @@ func (c Client) directPluginFromManifest(ctx context.Context, manifest Manifest)
 	}
 	sourceClient := c
 	sourceClient.RegistryURL = sourceURL
-	registry, errRegistry := sourceClient.FetchRegistry(ctx)
+	registry, errRegistry := sourceClient.FetchRegistryWithResolver(ctx, resolver)
 	if errRegistry != nil {
 		return Plugin{}, fmt.Errorf("fetch direct install source: %w", errRegistry)
 	}

--- a/sdk/pluginstore/pluginstore.go
+++ b/sdk/pluginstore/pluginstore.go
@@ -44,6 +44,7 @@ type Artifact = internalpluginstore.Artifact
 type Platform = internalpluginstore.Platform
 type Manifest = internalpluginstore.Manifest
 type AuthConfig = internalpluginstore.AuthConfig
+type AuthResolver = internalpluginstore.AuthResolver
 
 type HTTPDoer interface {
 	Do(*http.Request) (*http.Response, error)
@@ -102,12 +103,28 @@ func NormalizeAuthConfigs(auth []AuthConfig) []AuthConfig {
 	return internalpluginstore.NormalizeAuthConfigs(auth)
 }
 
+func ValidateAuthConfigs(auth []AuthConfig) error {
+	return internalpluginstore.ValidateAuthConfigs(auth)
+}
+
+func NewAuthResolver() *AuthResolver {
+	return internalpluginstore.NewAuthResolver()
+}
+
 func AuthConfigured(auth []AuthConfig, requestURL string, kind string) bool {
 	return internalpluginstore.AuthConfigured(auth, requestURL, kind)
 }
 
+func AuthConfiguredContext(ctx context.Context, resolver *AuthResolver, auth []AuthConfig, requestURL string, kind string) bool {
+	return internalpluginstore.AuthConfiguredContext(ctx, resolver, auth, requestURL, kind)
+}
+
 func PluginAuthConfigured(source Source, plugin Plugin, auth []AuthConfig) bool {
 	return internalpluginstore.PluginAuthConfigured(source, plugin, auth)
+}
+
+func PluginAuthConfiguredContext(ctx context.Context, resolver *AuthResolver, source Source, plugin Plugin, auth []AuthConfig) bool {
+	return internalpluginstore.PluginAuthConfiguredContext(ctx, resolver, source, plugin, auth)
 }
 
 func UpdateAvailable(installed, latest string) bool {
@@ -130,22 +147,46 @@ func (c Client) FetchRegistry(ctx context.Context) (Registry, error) {
 	return c.inner.FetchRegistry(ctx)
 }
 
+func (c Client) FetchRegistryWithResolver(ctx context.Context, resolver *AuthResolver) (Registry, error) {
+	return c.inner.FetchRegistryWithResolver(ctx, resolver)
+}
+
 func (c Client) FetchLatestRelease(ctx context.Context, plugin Plugin) (Release, error) {
 	return c.inner.FetchLatestRelease(ctx, plugin)
+}
+
+func (c Client) FetchLatestReleaseWithResolver(ctx context.Context, resolver *AuthResolver, plugin Plugin) (Release, error) {
+	return c.inner.FetchLatestReleaseWithResolver(ctx, resolver, plugin)
 }
 
 func (c Client) FetchReleaseByTag(ctx context.Context, plugin Plugin, tag string) (Release, error) {
 	return c.inner.FetchReleaseByTag(ctx, plugin, tag)
 }
 
+func (c Client) FetchReleaseByTagWithResolver(ctx context.Context, resolver *AuthResolver, plugin Plugin, tag string) (Release, error) {
+	return c.inner.FetchReleaseByTagWithResolver(ctx, resolver, plugin, tag)
+}
+
 func (c Client) Install(ctx context.Context, plugin Plugin, options InstallOptions) (InstallResult, error) {
 	return c.inner.Install(ctx, plugin, options)
+}
+
+func (c Client) InstallWithResolver(ctx context.Context, resolver *AuthResolver, plugin Plugin, options InstallOptions) (InstallResult, error) {
+	return c.inner.InstallWithResolver(ctx, resolver, plugin, options)
 }
 
 func (c Client) InstallVersion(ctx context.Context, plugin Plugin, releaseTag string, version string, options InstallOptions) (InstallResult, error) {
 	return c.inner.InstallVersion(ctx, plugin, releaseTag, version, options)
 }
 
+func (c Client) InstallVersionWithResolver(ctx context.Context, resolver *AuthResolver, plugin Plugin, releaseTag string, version string, options InstallOptions) (InstallResult, error) {
+	return c.inner.InstallVersionWithResolver(ctx, resolver, plugin, releaseTag, version, options)
+}
+
 func (c Client) InstallManifest(ctx context.Context, manifest Manifest, options InstallOptions) (InstallResult, error) {
 	return c.inner.InstallManifest(ctx, manifest, options)
+}
+
+func (c Client) InstallManifestWithResolver(ctx context.Context, resolver *AuthResolver, manifest Manifest, options InstallOptions) (InstallResult, error) {
+	return c.inner.InstallManifestWithResolver(ctx, resolver, manifest, options)
 }


### PR DESCRIPTION
## Summary
- add command-backed alternatives for every existing plugin-store authentication secret
- execute expressions through the platform shell with a fixed five-second bound and caller cancellation
- coalesce secret resolution only within each list, install, or Home-sync operation
- preserve existing auth types, environment behavior, SDK APIs, and redirect matching

## Test plan
- `go test ./internal/pluginstore -run '^TestAuthCommand(Timeout|CallerCancellation)KillsShellChildren$' -count=20`
- `go test -race ./internal/pluginstore -count=1`
- `go test ./internal/pluginstore -count=1`
- `go test ./internal/config ./sdk/pluginstore -count=1`
- `go test ./internal/api/handlers/management ./internal/homeplugins ./sdk/cliproxy -count=1`
- `GOOS=windows GOARCH=amd64 go test -c -o "$CLAUDE_JOB_DIR/tmp/pluginstore_windows.test.exe" ./internal/pluginstore`
- `go build -o "$CLAUDE_JOB_DIR/tmp/cliproxyapi-pr4314" ./cmd/server`
- `go test ./...`

Fixes #4314
