### PR TITLE
fix(translator): normalize context-limit errors

### DIFF
--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -446,6 +446,7 @@ func claudeErrorDetailFromText(status int, errText string) (string, string) {
 		message = http.StatusText(status)
 	}
 	errType := claudeErrorTypeFromStatus(status)
+	upstreamCode := ""
 
 	var payload map[string]any
 	if json.Valid([]byte(message)) {
@@ -456,8 +457,12 @@ func claudeErrorDetailFromText(status int, errText string) (string, string) {
 				}
 				if m, ok := e["message"].(string); ok && strings.TrimSpace(m) != "" {
 					message = strings.TrimSpace(m)
-				} else if c, ok := e["code"].(string); ok && strings.TrimSpace(c) != "" {
-					message = strings.TrimSpace(c)
+				}
+				if c, ok := e["code"].(string); ok && strings.TrimSpace(c) != "" {
+					upstreamCode = strings.ToLower(strings.TrimSpace(c))
+					if m, ok := e["message"].(string); !ok || strings.TrimSpace(m) == "" {
+						message = strings.TrimSpace(c)
+					}
 				}
 			} else {
 				if t, ok := payload["type"].(string); ok && strings.TrimSpace(t) != "" && strings.TrimSpace(t) != "error" {
@@ -468,6 +473,11 @@ func claudeErrorDetailFromText(status int, errText string) (string, string) {
 				}
 			}
 		}
+	}
+	if status == http.StatusBadRequest &&
+		(upstreamCode == "context_length_exceeded" || upstreamCode == "context_too_large") &&
+		!strings.Contains(strings.ToLower(message), "prompt is too long") {
+		message = "Prompt is too long: " + message
 	}
 
 	return errType, message

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -452,16 +452,26 @@ func claudeErrorDetailFromText(status int, errText string) (string, string) {
 	if json.Valid([]byte(message)) {
 		if err := json.Unmarshal([]byte(message), &payload); err == nil {
 			if e, ok := payload["error"].(map[string]any); ok {
-				if t, ok := e["type"].(string); ok && strings.TrimSpace(t) != "" {
-					errType = strings.TrimSpace(t)
+				if t, ok := e["type"].(string); ok {
+					typeText := strings.TrimSpace(t)
+					if typeText != "" {
+						errType = typeText
+					}
 				}
-				if m, ok := e["message"].(string); ok && strings.TrimSpace(m) != "" {
-					message = strings.TrimSpace(m)
+				messageText := ""
+				if m, ok := e["message"].(string); ok {
+					messageText = strings.TrimSpace(m)
+					if messageText != "" {
+						message = messageText
+					}
 				}
-				if c, ok := e["code"].(string); ok && strings.TrimSpace(c) != "" {
-					upstreamCode = strings.ToLower(strings.TrimSpace(c))
-					if m, ok := e["message"].(string); !ok || strings.TrimSpace(m) == "" {
-						message = strings.TrimSpace(c)
+				if c, ok := e["code"].(string); ok {
+					codeText := strings.TrimSpace(c)
+					if codeText != "" {
+						upstreamCode = strings.ToLower(codeText)
+						if messageText == "" {
+							message = codeText
+						}
 					}
 				}
 			} else {
@@ -474,7 +484,7 @@ func claudeErrorDetailFromText(status int, errText string) (string, string) {
 			}
 		}
 	}
-	if status == http.StatusBadRequest &&
+	if (status == http.StatusBadRequest || status == http.StatusRequestEntityTooLarge) &&
 		(upstreamCode == "context_length_exceeded" || upstreamCode == "context_too_large") &&
 		!strings.Contains(strings.ToLower(message), "prompt is too long") {
 		message = "Prompt is too long: " + message

--- a/sdk/api/handlers/claude/code_handlers_error_test.go
+++ b/sdk/api/handlers/claude/code_handlers_error_test.go
@@ -14,28 +14,39 @@ import (
 func TestClaudeErrorNormalizesContextLimitForClientCompaction(t *testing.T) {
 	tests := []struct {
 		name    string
+		status  int
 		errText string
 		want    string
 	}{
 		{
-			name:    "normalized executor code",
+			name:    "normalized executor code on request entity too large",
+			status:  http.StatusRequestEntityTooLarge,
 			errText: `{"error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again.","type":"invalid_request_error","code":"context_too_large"}}`,
 			want:    "Prompt is too long: Your input exceeds the context window of this model. Please adjust your input and try again.",
 		},
 		{
 			name:    "upstream context code",
+			status:  http.StatusBadRequest,
 			errText: `{"error":{"message":"Maximum context length exceeded.","type":"invalid_request_error","code":"context_length_exceeded"}}`,
 			want:    "Prompt is too long: Maximum context length exceeded.",
 		},
 		{
 			name:    "recognized message remains unchanged",
+			status:  http.StatusRequestEntityTooLarge,
 			errText: `{"error":{"message":"Prompt is too long: Maximum context length exceeded.","type":"invalid_request_error","code":"context_too_large"}}`,
 			want:    "Prompt is too long: Maximum context length exceeded.",
 		},
 		{
 			name:    "unrelated bad request remains unchanged",
+			status:  http.StatusBadRequest,
 			errText: `{"error":{"message":"Invalid request body.","type":"invalid_request_error","code":"invalid_request"}}`,
 			want:    "Invalid request body.",
+		},
+		{
+			name:    "unrelated request entity too large remains unchanged",
+			status:  http.StatusRequestEntityTooLarge,
+			errText: `{"error":{"message":"Upload exceeds the request size limit.","type":"invalid_request_error","code":"request_too_large"}}`,
+			want:    "Upload exceeds the request size limit.",
 		},
 	}
 
@@ -43,7 +54,7 @@ func TestClaudeErrorNormalizesContextLimitForClientCompaction(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := &ClaudeCodeAPIHandler{}
 			msg := &interfaces.ErrorMessage{
-				StatusCode: http.StatusBadRequest,
+				StatusCode: tt.status,
 				Error:      errors.New(tt.errText),
 			}
 

--- a/sdk/api/handlers/claude/code_handlers_error_test.go
+++ b/sdk/api/handlers/claude/code_handlers_error_test.go
@@ -11,23 +11,54 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestClaudeErrorExtractsOpenAIStyleUpstreamJSON(t *testing.T) {
-	handler := &ClaudeCodeAPIHandler{}
-	msg := &interfaces.ErrorMessage{
-		StatusCode: http.StatusBadRequest,
-		Error:      errors.New(`{"error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again.","type":"invalid_request_error","code":"context_too_large"}}`),
+func TestClaudeErrorNormalizesContextLimitForClientCompaction(t *testing.T) {
+	tests := []struct {
+		name    string
+		errText string
+		want    string
+	}{
+		{
+			name:    "normalized executor code",
+			errText: `{"error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again.","type":"invalid_request_error","code":"context_too_large"}}`,
+			want:    "Prompt is too long: Your input exceeds the context window of this model. Please adjust your input and try again.",
+		},
+		{
+			name:    "upstream context code",
+			errText: `{"error":{"message":"Maximum context length exceeded.","type":"invalid_request_error","code":"context_length_exceeded"}}`,
+			want:    "Prompt is too long: Maximum context length exceeded.",
+		},
+		{
+			name:    "recognized message remains unchanged",
+			errText: `{"error":{"message":"Prompt is too long: Maximum context length exceeded.","type":"invalid_request_error","code":"context_too_large"}}`,
+			want:    "Prompt is too long: Maximum context length exceeded.",
+		},
+		{
+			name:    "unrelated bad request remains unchanged",
+			errText: `{"error":{"message":"Invalid request body.","type":"invalid_request_error","code":"invalid_request"}}`,
+			want:    "Invalid request body.",
+		},
 	}
 
-	got := handler.toClaudeError(msg)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &ClaudeCodeAPIHandler{}
+			msg := &interfaces.ErrorMessage{
+				StatusCode: http.StatusBadRequest,
+				Error:      errors.New(tt.errText),
+			}
 
-	if got.Type != "error" {
-		t.Fatalf("type = %q, want error", got.Type)
-	}
-	if got.Error.Type != "invalid_request_error" {
-		t.Fatalf("error.type = %q, want invalid_request_error", got.Error.Type)
-	}
-	if got.Error.Message != "Your input exceeds the context window of this model. Please adjust your input and try again." {
-		t.Fatalf("error.message = %q", got.Error.Message)
+			got := handler.toClaudeError(msg)
+
+			if got.Type != "error" {
+				t.Fatalf("type = %q, want error", got.Type)
+			}
+			if got.Error.Type != "invalid_request_error" {
+				t.Fatalf("error.type = %q, want invalid_request_error", got.Error.Type)
+			}
+			if got.Error.Message != tt.want {
+				t.Fatalf("error.message = %q, want %q", got.Error.Message, tt.want)
+			}
+		})
 	}
 }
 
@@ -70,7 +101,7 @@ func TestWriteClaudeErrorResponseUsesClaudeEnvelope(t *testing.T) {
 	if got := gjson.GetBytes(body, "error.type").String(); got != "invalid_request_error" {
 		t.Fatalf("error.type = %q, want invalid_request_error; body=%s", got, body)
 	}
-	if got := gjson.GetBytes(body, "error.message").String(); got != "Your input exceeds the context window of this model. Please adjust your input and try again." {
+	if got := gjson.GetBytes(body, "error.message").String(); got != "Prompt is too long: Your input exceeds the context window of this model. Please adjust your input and try again." {
 		t.Fatalf("error.message = %q; body=%s", got, body)
 	}
 }


### PR DESCRIPTION
## Summary

- normalize recognized HTTP 400 and 413 context-limit errors with the downstream client's compaction trigger phrase
- preserve the original status, error type, and upstream explanation
- leave unrelated HTTP 400 and 413 errors unchanged and avoid double-prefixing already recognized messages

## Why

The downstream client only starts reactive compaction for a specific error phrase. The current proxy preserves generic context-window messages, including recognized 413 responses, so the client can retry without compacting. This change translates only the two recognized context-limit codes on HTTP 400 or 413 responses and leaves every other error category untouched.

## Test plan

- [x] `go test -count=1 .` from the modified adapter package
- [x] table coverage for both recognized codes, HTTP 400 and 413 handling, idempotence, and unrelated 400 and 413 responses
- [x] `go build -buildvcs=false -o <temp> ./cmd/server`
- [x] `git diff --check`
- [x] required pull-request checks: build and repository policy guards
