### PR TITLE
fix(home): preserve Codex model context metadata

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1219,6 +1219,10 @@ func (s *Server) handleHomeCodexClientModels(c *gin.Context) {
 		return
 	}
 
+	c.JSON(http.StatusOK, formatHomeCodexClientModels(entries))
+}
+
+func formatHomeCodexClientModels(entries []homeModelEntry) map[string]any {
 	models := make([]map[string]any, 0, len(entries))
 	for _, entry := range entries {
 		model := map[string]any{
@@ -1235,10 +1239,13 @@ func (s *Server) handleHomeCodexClientModels(c *gin.Context) {
 			model["display_name"] = entry.displayName
 			model["description"] = entry.displayName
 		}
+		if entry.contextLength > 0 {
+			model["context_length"] = entry.contextLength
+		}
 		models = append(models, model)
 	}
 
-	c.JSON(http.StatusOK, openai.CodexClientModelsResponse(models))
+	return openai.CodexClientModelsResponse(models)
 }
 
 func (s *Server) geminiModelsHandler(geminiHandler *gemini.GeminiAPIHandler) gin.HandlerFunc {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1359,6 +1359,31 @@ func TestDecodeHomeModelsKeepsTokenMetadata(t *testing.T) {
 	}
 }
 
+func TestFormatHomeCodexModelsKeepsContextMetadataForOpaqueAlias(t *testing.T) {
+	resp := formatHomeCodexClientModels([]homeModelEntry{
+		{
+			id:            "model-orchestration",
+			displayName:   "Claude Fable 5",
+			contextLength: 1000000,
+		},
+	})
+
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+	model := models[0]
+	if got, _ := model["slug"].(string); got != "model-orchestration" {
+		t.Fatalf("slug = %q, want model-orchestration", got)
+	}
+	if got, _ := model["context_window"].(int); got != 1000000 {
+		t.Fatalf("context_window = %v, want 1000000", model["context_window"])
+	}
+	if got, _ := model["max_context_window"].(int); got != 1000000 {
+		t.Fatalf("max_context_window = %v, want 1000000", model["max_context_window"])
+	}
+}
+
 func TestHomeModelsAuthStatus(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1045,7 +1045,7 @@ func TestModelsWithClientVersionReturnsCodexCatalog(t *testing.T) {
 		t.Fatalf("custom display_name = %q, want Custom Codex Model", got)
 	}
 	wantCustomPriority := codexClientTestMaxTemplatePriority(t) + 100
-	if got := int(codexClientTestPriority(custom["priority"])); got != wantCustomPriority {
+	if got := codexClientTestInt(custom["priority"]); got != wantCustomPriority {
 		t.Fatalf("custom priority = %v, want %d", custom["priority"], wantCustomPriority)
 	}
 	if got, _ := custom["description"].(string); got != "Custom model from registry" {
@@ -1102,10 +1102,12 @@ func TestModelsWithClientVersionReturnsCodexCatalog(t *testing.T) {
 	}
 }
 
-func codexClientTestPriority(raw any) int {
+func codexClientTestInt(raw any) int {
 	switch value := raw.(type) {
 	case int:
 		return value
+	case int64:
+		return int(value)
 	case float64:
 		return int(value)
 	default:
@@ -1123,7 +1125,7 @@ func codexClientTestMaxTemplatePriority(t *testing.T) int {
 	}
 	maxPriority := 0
 	for _, model := range payload.Models {
-		if priority := codexClientTestPriority(model["priority"]); priority > maxPriority {
+		if priority := codexClientTestInt(model["priority"]); priority > maxPriority {
 			maxPriority = priority
 		}
 	}
@@ -1376,10 +1378,10 @@ func TestFormatHomeCodexModelsKeepsContextMetadataForOpaqueAlias(t *testing.T) {
 	if got, _ := model["slug"].(string); got != "model-orchestration" {
 		t.Fatalf("slug = %q, want model-orchestration", got)
 	}
-	if got, _ := model["context_window"].(int); got != 1000000 {
+	if got := codexClientTestInt(model["context_window"]); got != 1000000 {
 		t.Fatalf("context_window = %v, want 1000000", model["context_window"])
 	}
-	if got, _ := model["max_context_window"].(int); got != 1000000 {
+	if got := codexClientTestInt(model["max_context_window"]); got != 1000000 {
 		t.Fatalf("max_context_window = %v, want 1000000", model["max_context_window"])
 	}
 }

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -64,6 +64,7 @@ func buildCodexClientModels(models []map[string]any, providersForModel codexClie
 		if template, ok := templates[id]; ok {
 			entry := cloneCodexClientModelMap(template)
 			applyCodexClientDisplayName(entry, model)
+			applyCodexClientContextWindow(entry, model)
 			applyCodexClientSearchToolSupport(entry, id, true, providersForModel)
 			sanitizeCodexClientReasoningMetadata(entry)
 			applyCodexClientVisibilityOverride(entry, id)
@@ -184,6 +185,15 @@ func applyCodexClientDisplayName(entry map[string]any, model map[string]any) {
 	if displayName := stringModelValue(model, "display_name"); displayName != "" {
 		entry["display_name"] = displayName
 	}
+}
+
+func applyCodexClientContextWindow(entry map[string]any, model map[string]any) {
+	contextWindow := intModelValue(model, "context_length")
+	if contextWindow <= 0 {
+		return
+	}
+	entry["context_window"] = contextWindow
+	entry["max_context_window"] = contextWindow
 }
 
 func applyCodexClientSearchToolSupport(entry map[string]any, id string, templateModel bool, providersForModel codexClientModelProvidersFunc) {

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -143,6 +143,25 @@ func TestCodexClientModelsResponse_AppliesDisplayNameToTemplateModel(t *testing.
 	}
 }
 
+func TestCodexClientModelsResponse_AppliesContextWindowToTemplateModel(t *testing.T) {
+	resp := CodexClientModelsResponse([]map[string]any{
+		{
+			"id":             "gpt-5.5",
+			"context_length": 1000000,
+		},
+	})
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+	if got := intModelValue(models[0], "context_window"); got != 1000000 {
+		t.Fatalf("context_window = %v, want 1000000", models[0]["context_window"])
+	}
+	if got := intModelValue(models[0], "max_context_window"); got != 1000000 {
+		t.Fatalf("max_context_window = %v, want 1000000", models[0]["max_context_window"])
+	}
+}
+
 func TestCodexClientModelsResponse_DisablesSearchToolForSynthesizedModels(t *testing.T) {
 	resp := CodexClientModelsResponse([]map[string]any{
 		{"id": "custom-openai-compatible-model"},


### PR DESCRIPTION
Summary
- preserve Home context length when building the Codex client model catalog
- ensure opaque router aliases advertise their upstream context and maximum context windows
- add regression coverage for a model-orchestration alias exposing a 1M context window

Verification
- go test ./internal/api -count=1
- go build -o /private/tmp/cli-proxy-api-fable-test ./cmd/server
- go test ./... -count=1